### PR TITLE
fix: Avatar overflow when setting zoom

### DIFF
--- a/packages/client/src/components/panels/CharactersPanel.tsx
+++ b/packages/client/src/components/panels/CharactersPanel.tsx
@@ -641,16 +641,18 @@ export function CharactersPanel() {
               {/* Avatar */}
               <div className="relative flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-pink-400 to-rose-500 text-white shadow-sm">
                 {avatarUrl ? (
-                  <img
-                    src={avatarUrl}
-                    alt={charName}
-                    className="h-full w-full rounded-xl object-cover"
-                    style={getAvatarCropStyle(
-                      char.parsed.extensions?.avatarCrop as
-                        | { zoom: number; offsetX: number; offsetY: number }
-                        | undefined,
-                    )}
-                  />
+                  <div className="absolute inset-0 overflow-hidden rounded-xl">
+                    <img
+                      src={avatarUrl}
+                      alt={charName}
+                      className="h-full w-full object-cover"
+                      style={getAvatarCropStyle(
+                        char.parsed.extensions?.avatarCrop as
+                          | { zoom: number; offsetX: number; offsetY: number }
+                          | undefined,
+                      )}
+                    />
+                  </div>
                 ) : (
                   <User size="1rem" />
                 )}


### PR DESCRIPTION
Discord issue: https://discord.com/channels/1417099416812392641/1485683559522894035

There is a bug that makes the Avatar image on the sidebar overflow when there is a zoom set on the character settings.
This fixes it by just wrapping it to prevent the overflow.



**Before**:
<img width="532" height="456" alt="image" src="https://github.com/user-attachments/assets/52ca67f4-9d30-466c-8199-92f48eaa91e1" />





**After**:
<img width="1414" height="910" alt="image" src="https://github.com/user-attachments/assets/bb3bdd9c-d285-43d4-a788-251094ed5cdd" />

<img width="389" height="832" alt="image" src="https://github.com/user-attachments/assets/44deceb6-368a-4373-815d-2a167a6f92e2" />
