### PR TITLE
Add launcher browser toggle and fix sidebar tab clipping

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,8 @@
 # Server
 PORT=7860
 HOST=0.0.0.0
+# Shell launchers open the local URL by default. Set false to disable.
+AUTO_OPEN_BROWSER=true
 
 # Database
 DATABASE_URL=file:./data/marinara-engine.db

--- a/README.md
+++ b/README.md
@@ -170,14 +170,16 @@ The Termux launcher handles everything automatically — it downloads a prebuilt
 
 > **Tip:** Install the PWA — tap the browser menu and "Add to Home Screen" for a native app feel.
 
-The start script will:
+The shell launchers will:
 
 1. **Auto-update** from Git (if a `.git` folder is detected)
 2. Check that Node.js and pnpm are installed
 3. Install all dependencies (first run only)
 4. Build the application
 5. Initialize the database
-6. Start the server and open `http://localhost:7860` in your browser
+6. Start the server and open `http://localhost:7860` in your browser by default
+
+Set `AUTO_OPEN_BROWSER=false` in `.env` to skip the automatic browser launch. This applies to the shell launchers (`start.bat`, `start.sh`, and `start-termux.sh`) only. The Android wrapper uses its own WebView.
 
 ### Manual Setup
 
@@ -355,6 +357,7 @@ Copy `.env.example` to `.env` to customize:
 | ---------------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `PORT`           | `7860`                           | Server port                                                                                                                                                   |
 | `HOST`           | `0.0.0.0`                        | Bind address                                                                                                                                                  |
+| `AUTO_OPEN_BROWSER` | `true`                        | Whether the shell launchers auto-open the local app URL. Set to `false`, `0`, `no`, or `off` to disable. Does not apply to the Android WebView wrapper. |
 | `DATABASE_URL`   | `file:./data/marinara-engine.db` | SQLite database path                                                                                                                                          |
 | `ENCRYPTION_KEY` | _(empty)_                        | AES key for API key encryption (generate with `openssl rand -hex 32`)                                                                                         |
 | `LOG_LEVEL`      | `info`                           | Logging verbosity                                                                                                                                             |

--- a/packages/client/src/components/layout/ChatSidebar.tsx
+++ b/packages/client/src/components/layout/ChatSidebar.tsx
@@ -485,14 +485,14 @@ export function ChatSidebar() {
               key={tab}
               onClick={() => setActiveTab(tab)}
               className={cn(
-                "flex flex-1 items-center justify-center gap-1.5 rounded-lg px-2 py-1.5 text-xs font-medium transition-all",
+                "flex min-h-[1.875rem] flex-1 items-center justify-center gap-1.5 rounded-lg px-2 py-1.5 text-xs leading-[1.2] font-medium transition-all",
                 isActive
                   ? "bg-[var(--sidebar-accent)] text-[var(--sidebar-accent-foreground)] shadow-sm"
                   : "text-[var(--muted-foreground)] hover:bg-[var(--sidebar-accent)]/50 hover:text-[var(--sidebar-foreground)]",
               )}
             >
               {cfg.icon}
-              {cfg.label}s
+              <span className="leading-[1.2]">{cfg.label}s</span>
               {tabUnread > 0 && !isActive && (
                 <span className="ml-0.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-red-500 px-1 text-[0.5625rem] font-bold leading-none text-white">
                   {tabUnread > 99 ? "99+" : tabUnread}

--- a/start-termux.sh
+++ b/start-termux.sh
@@ -219,9 +219,17 @@ export HOST=${HOST:-0.0.0.0}
 # DATABASE_DRIVER was set above during SQLite driver detection
 export DATABASE_DRIVER=${DATABASE_DRIVER:-sql.js}
 
+AUTO_OPEN_BROWSER_VALUE="${AUTO_OPEN_BROWSER:-true}"
+case "${AUTO_OPEN_BROWSER_VALUE,,}" in
+  0|false|no|off) AUTO_OPEN_BROWSER_ENABLED=0 ;;
+  *) AUTO_OPEN_BROWSER_ENABLED=1 ;;
+esac
+
 # Open in Termux browser if available (no-op if not)
-if command -v termux-open-url &> /dev/null; then
+if [ "$AUTO_OPEN_BROWSER_ENABLED" = "1" ] && command -v termux-open-url &> /dev/null; then
     (sleep 3 && termux-open-url "http://localhost:7860") &
+elif [ "$AUTO_OPEN_BROWSER_ENABLED" != "1" ]; then
+    echo "  [OK] Auto-open disabled (AUTO_OPEN_BROWSER=${AUTO_OPEN_BROWSER_VALUE})"
 fi
 
 # Start server

--- a/start.bat
+++ b/start.bat
@@ -97,6 +97,14 @@ if not defined HOST set HOST=0.0.0.0
 set PROTOCOL=http
 if defined SSL_CERT if defined SSL_KEY set PROTOCOL=https
 
+set "AUTO_OPEN_BROWSER_ENABLED=1"
+if defined AUTO_OPEN_BROWSER (
+    if /I "%AUTO_OPEN_BROWSER%"=="0" set "AUTO_OPEN_BROWSER_ENABLED="
+    if /I "%AUTO_OPEN_BROWSER%"=="false" set "AUTO_OPEN_BROWSER_ENABLED="
+    if /I "%AUTO_OPEN_BROWSER%"=="no" set "AUTO_OPEN_BROWSER_ENABLED="
+    if /I "%AUTO_OPEN_BROWSER%"=="off" set "AUTO_OPEN_BROWSER_ENABLED="
+)
+
 echo.
 echo  ==========================================
 echo    Starting Marinara Engine on %PROTOCOL%://localhost:%PORT%
@@ -105,7 +113,11 @@ echo  ==========================================
 echo.
 
 :: Open browser after a short delay (use explorer.exe as fallback)
-start "" cmd /c "timeout /t 4 /nobreak >nul && start %PROTOCOL%://localhost:%PORT% || explorer %PROTOCOL%://localhost:%PORT%"
+if defined AUTO_OPEN_BROWSER_ENABLED (
+    start "" cmd /c "timeout /t 4 /nobreak >nul && start %PROTOCOL%://localhost:%PORT% || explorer %PROTOCOL%://localhost:%PORT%"
+) else (
+    echo  [OK] Auto-open disabled ^(AUTO_OPEN_BROWSER=%AUTO_OPEN_BROWSER%^)
+)
 
 :: Start server
 cd packages\server

--- a/start.sh
+++ b/start.sh
@@ -100,6 +100,12 @@ else
   PROTOCOL=http
 fi
 
+AUTO_OPEN_BROWSER_VALUE="${AUTO_OPEN_BROWSER:-true}"
+case "${AUTO_OPEN_BROWSER_VALUE,,}" in
+  0|false|no|off) AUTO_OPEN_BROWSER_ENABLED=0 ;;
+  *) AUTO_OPEN_BROWSER_ENABLED=1 ;;
+esac
+
 echo ""
 echo "  ══════════════════════════════════════════"
 echo "    Starting Marinara Engine on ${PROTOCOL}://localhost:$PORT"
@@ -108,7 +114,11 @@ echo "  ════════════════════════
 echo ""
 
 # Open browser after a short delay
-(sleep 3 && open "${PROTOCOL}://localhost:$PORT" 2>/dev/null || xdg-open "${PROTOCOL}://localhost:$PORT" 2>/dev/null) &
+if [ "$AUTO_OPEN_BROWSER_ENABLED" = "1" ]; then
+  (sleep 3 && open "${PROTOCOL}://localhost:$PORT" 2>/dev/null || xdg-open "${PROTOCOL}://localhost:$PORT" 2>/dev/null) &
+else
+  echo "  [OK] Auto-open disabled (AUTO_OPEN_BROWSER=${AUTO_OPEN_BROWSER_VALUE})"
+fi
 
 # Start server
 cd packages/server


### PR DESCRIPTION
## Summary
- add an `AUTO_OPEN_BROWSER` env toggle for the shell launchers
- document the new launcher behavior in `.env.example` and `README.md`
- fix clipped descenders in the sidebar mode tabs by making the tab text metrics explicit

## Details
- `start.bat`, `start.sh`, and `start-termux.sh` now keep auto-open enabled by default and treat `0`, `false`, `no`, and `off` as disabled
- docs now clarify that the toggle applies to the shell launchers only, not the Android WebView wrapper
- `Roleplay` / `Roleplays` in the sidebar tabs now render with explicit line-height and a slightly safer vertical box

## Testing
- `pnpm --filter @marinara-engine/client build`
- `bash -n ./start.sh`
- `bash -n ./start-termux.sh`
- inspected the built client at normal scale and a 125% equivalent to verify the sidebar tab text renders cleanly