### PR TITLE
feat: Add Quick Connection & Persona Switchers to chat input

### DIFF
--- a/packages/client/src/components/chat/ChatInput.tsx
+++ b/packages/client/src/components/chat/ChatInput.tsx
@@ -18,6 +18,11 @@ import {
   type SlashCommandContext,
 } from "../../lib/slash-commands";
 import { cn } from "../../lib/utils";
+import { QuickConnectionSwitcher } from "./QuickConnectionSwitcher";
+import { QuickPersonaSwitcher } from "./QuickPersonaSwitcher";
+import { QuickSwitcherMobile } from "./QuickSwitcherMobile";
+
+
 
 interface Attachment {
   type: string; // MIME type
@@ -431,6 +436,13 @@ export const ChatInput = memo(function ChatInput({ mode = "conversation", charac
           <Paperclip size="1rem" />
         </button>
 
+        {/* Quick Switchers — desktop: inline, mobile: chevron */}
+        <QuickConnectionSwitcher className="hidden sm:flex" />
+        <QuickPersonaSwitcher className="hidden sm:flex" />
+        <div className="sm:hidden">
+          <QuickSwitcherMobile />
+        </div>
+
         {/* Text input */}
         <textarea
           ref={textareaRef}
@@ -445,6 +457,7 @@ export const ChatInput = memo(function ChatInput({ mode = "conversation", charac
         />
 
         {/* Send / Stop button */}
+
         <button
           onClick={isStreaming ? () => useChatStore.getState().stopGeneration() : handleSend}
           disabled={(!hasInput && !attachments.length && !isStreaming && !canRetry && !canContinue) || !activeChatId}

--- a/packages/client/src/components/chat/ConversationInput.tsx
+++ b/packages/client/src/components/chat/ConversationInput.tsx
@@ -17,6 +17,9 @@ import {
   type SlashCommandContext,
 } from "../../lib/slash-commands";
 import { cn } from "../../lib/utils";
+import { QuickConnectionSwitcher } from "./QuickConnectionSwitcher";
+import { QuickPersonaSwitcher } from "./QuickPersonaSwitcher";
+import { QuickSwitcherMobile } from "./QuickSwitcherMobile";
 import { EmojiPicker } from "../ui/EmojiPicker";
 import { GifPicker } from "../ui/GifPicker";
 
@@ -542,7 +545,15 @@ export function ConversationInput({ characterNames = [] }: ConversationInputProp
           <Plus size="1rem" />
         </button>
 
+        {/* Quick Switchers — desktop: inline, mobile: chevron */}
+        <QuickConnectionSwitcher className="hidden sm:flex" />
+        <QuickPersonaSwitcher className="hidden sm:flex" />
+        <div className="sm:hidden">
+          <QuickSwitcherMobile />
+        </div>
+
         {/* Textarea */}
+
         <textarea
           ref={textareaRef}
           placeholder={characterNames.length > 0 ? `Message @${characterNames[0]}` : "Message..."}

--- a/packages/client/src/components/chat/QuickConnectionSwitcher.tsx
+++ b/packages/client/src/components/chat/QuickConnectionSwitcher.tsx
@@ -1,0 +1,132 @@
+// ──────────────────────────────────────────────
+// Quick Connection Switcher — inline dropdown
+// ──────────────────────────────────────────────
+import { useState, useRef, useCallback, useEffect } from "react";
+import { Link } from "lucide-react";
+import { useConnections } from "../../hooks/use-connections";
+import { useUpdateChat, useChat } from "../../hooks/use-chats";
+import { useChatStore } from "../../stores/chat.store";
+import { cn } from "../../lib/utils";
+
+export function QuickConnectionSwitcher({ className }: { className?: string }) {
+  const [open, setOpen] = useState(false);
+  const btnRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const activeChatId = useChatStore((s) => s.activeChatId);
+  const { data: connections } = useConnections();
+  const { data: chat } = useChat(activeChatId);
+  const updateChat = useUpdateChat();
+
+  const activeConnectionId = (chat as unknown as Record<string, unknown>)?.connectionId as string | null;
+
+  const sorted = ((connections ?? []) as Array<{ id: string; name: string }>)
+    .slice()
+    .sort((a, b) => (a.name || "").localeCompare(b.name || ""));
+
+  const handleSwitch = useCallback(
+    (connId: string | null) => {
+      if (!activeChatId) return;
+      updateChat.mutate({ id: activeChatId, connectionId: connId });
+      setOpen(false);
+    },
+    [activeChatId, updateChat],
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (
+        menuRef.current &&
+        !menuRef.current.contains(e.target as Node) &&
+        btnRef.current &&
+        !btnRef.current.contains(e.target as Node)
+      ) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open]);
+
+  const [pos, setPos] = useState<{ left: number; top: number } | null>(null);
+  useEffect(() => {
+    if (!open || !btnRef.current) return;
+    const rect = btnRef.current.getBoundingClientRect();
+    requestAnimationFrame(() => {
+      const menuEl = menuRef.current;
+      const menuHeight = menuEl?.offsetHeight || 360;
+      const menuWidth = menuEl?.offsetWidth || 300;
+      let left = rect.left;
+      if (left + menuWidth > window.innerWidth) left = window.innerWidth - menuWidth - 8;
+      if (left < 8) left = 8;
+      setPos({ left, top: Math.max(8, rect.top - menuHeight - 8) });
+    });
+  }, [open]);
+
+  if (!activeChatId) return null;
+
+  return (
+    <>
+      <button
+        ref={btnRef}
+        onClick={() => setOpen((v) => !v)}
+        title="Quick Connection Switcher"
+        className={cn(
+          "flex h-8 w-8 items-center justify-center rounded-xl transition-all",
+          open
+            ? "text-[var(--primary)]"
+            : "text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]",
+          className,
+        )}
+      >
+        <Link size="1rem" />
+      </button>
+
+      {open && (
+        <div
+          ref={menuRef}
+          className="fixed z-[9999] flex min-w-[280px] max-w-[340px] max-h-[360px] flex-col overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--card)] shadow-2xl"
+          style={pos ? { left: pos.left, top: pos.top } : undefined}
+        >
+          <div className="flex items-center justify-center border-b border-[var(--border)] px-3 py-2 text-[0.6875rem] font-semibold">
+            Connections
+          </div>
+          <div className="overflow-y-auto p-1">
+            <button
+              onClick={() => handleSwitch("random")}
+              className={cn(
+                "flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-xs transition-colors hover:bg-[var(--accent)]",
+                activeConnectionId === "random" && "text-[var(--primary)] font-semibold",
+              )}
+            >
+              <span>🎲 Random</span>
+              {activeConnectionId === "random" && <span className="ml-auto text-[0.6875rem]">✓</span>}
+            </button>
+
+            <div className="mx-2 my-1 h-px bg-[var(--border)]" />
+
+            {sorted.map((conn) => (
+              <button
+                key={conn.id}
+                onClick={() => handleSwitch(conn.id)}
+                className={cn(
+                  "flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-xs transition-colors hover:bg-[var(--accent)]",
+                  activeConnectionId === conn.id && "text-[var(--primary)] font-semibold",
+                )}
+              >
+                <span>{conn.name || conn.id}</span>
+                {activeConnectionId === conn.id && <span className="ml-auto text-[0.6875rem]">✓</span>}
+              </button>
+            ))}
+
+            {sorted.length === 0 && (
+              <div className="px-3 py-4 text-center text-[0.6875rem] italic text-[var(--muted-foreground)]">
+                No connections found.
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/packages/client/src/components/chat/QuickPersonaSwitcher.tsx
+++ b/packages/client/src/components/chat/QuickPersonaSwitcher.tsx
@@ -1,0 +1,178 @@
+// ──────────────────────────────────────────────
+// Quick Persona Switcher — inline avatar dropdown
+// ──────────────────────────────────────────────
+import { useState, useRef, useCallback, useEffect } from "react";
+import { usePersonas } from "../../hooks/use-characters";
+import { useUpdateChat, useChat } from "../../hooks/use-chats";
+import { useChatStore } from "../../stores/chat.store";
+import { cn } from "../../lib/utils";
+
+interface Persona {
+  id: string;
+  name: string;
+  avatarPath?: string | null;
+  comment?: string | null;
+  description?: string | null;
+}
+
+export function QuickPersonaSwitcher({ className }: { className?: string }) {
+  const [open, setOpen] = useState(false);
+  const btnRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const activeChatId = useChatStore((s) => s.activeChatId);
+  const { data: rawPersonas } = usePersonas();
+  const { data: chat } = useChat(activeChatId);
+  const updateChat = useUpdateChat();
+
+  const personas = ((rawPersonas ?? []) as Persona[])
+    .slice()
+    .sort((a, b) => (a.name || "").localeCompare(b.name || ""));
+
+  const activePersonaId = (chat as unknown as Record<string, unknown>)?.personaId as string | null;
+  const activePersona = personas.find((p) => p.id === activePersonaId) ?? null;
+
+  const handleSwitch = useCallback(
+    (personaId: string | null) => {
+      if (!activeChatId) return;
+      updateChat.mutate({ id: activeChatId, personaId });
+      setOpen(false);
+    },
+    [activeChatId, updateChat],
+  );
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (
+        menuRef.current &&
+        !menuRef.current.contains(e.target as Node) &&
+        btnRef.current &&
+        !btnRef.current.contains(e.target as Node)
+      ) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open]);
+
+  // Position menu above button
+  const [pos, setPos] = useState<{ left: number; top: number } | null>(null);
+  useEffect(() => {
+    if (!open || !btnRef.current) return;
+    const rect = btnRef.current.getBoundingClientRect();
+    requestAnimationFrame(() => {
+      const menuEl = menuRef.current;
+      const menuHeight = menuEl?.offsetHeight || 400;
+      let left = rect.left;
+      if (left + 300 > window.innerWidth) left = window.innerWidth - 308;
+      setPos({ left, top: rect.top - menuHeight - 8 });
+    });
+  }, [open]);
+
+  if (!activeChatId) return null;
+
+  return (
+    <>
+      <button
+        ref={btnRef}
+        onClick={() => setOpen((v) => !v)}
+        title={activePersona ? `${activePersona.name}${activePersona.comment ? " — " + activePersona.comment : ""}` : "Quick Persona Switcher"}
+        className={cn(
+          "flex h-8 w-8 items-center justify-center rounded-full overflow-hidden transition-all border-2",
+          open ? "border-[var(--primary)]" : "border-transparent hover:border-[var(--primary)] hover:opacity-90",
+          className,
+        )}
+      >
+        {activePersona?.avatarPath ? (
+          <img
+            src={activePersona.avatarPath}
+            alt={activePersona.name}
+            className="h-full w-full object-cover rounded-full"
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center rounded-full bg-[var(--secondary)] text-[0.75rem] font-semibold text-[var(--muted-foreground)]">
+            {activePersona ? (activePersona.name || "?")[0].toUpperCase() : "?"}
+          </div>
+        )}
+      </button>
+
+      {open && (
+        <div
+          ref={menuRef}
+          className="fixed z-[9999] flex min-w-[280px] max-w-[340px] max-h-[400px] flex-col overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--card)] shadow-2xl"
+          style={pos ? { left: pos.left, top: pos.top } : undefined}
+        >
+          <div className="flex items-center justify-center border-b border-[var(--border)] px-3 py-2 text-[0.6875rem] font-semibold">
+            Personas
+          </div>
+          <div className="overflow-y-auto p-1">
+            {/* None option */}
+            <button
+              onClick={() => handleSwitch(null)}
+              className={cn(
+                "flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left transition-colors hover:bg-[var(--accent)]",
+                !activePersonaId && "text-[var(--primary)]",
+              )}
+            >
+              <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-[var(--border)] bg-[var(--secondary)] text-xs font-semibold text-[var(--muted-foreground)]">
+                ?
+              </div>
+              <div className="flex min-w-0 flex-1 flex-col">
+                <span className={cn("text-xs font-semibold", !activePersonaId && "text-[var(--primary)]")}>None</span>
+                <span className="text-[0.625rem] text-[var(--muted-foreground)]">No persona selected</span>
+              </div>
+              {!activePersonaId && <span className="ml-auto text-[0.6875rem]">✓</span>}
+            </button>
+
+            <div className="mx-2 my-1 h-px bg-[var(--border)]" />
+
+            {personas.map((persona) => {
+              const isActive = persona.id === activePersonaId;
+              return (
+                <button
+                  key={persona.id}
+                  onClick={() => handleSwitch(persona.id)}
+                  className={cn(
+                    "flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left transition-colors hover:bg-[var(--accent)]",
+                    isActive && "text-[var(--primary)]",
+                  )}
+                >
+                  {persona.avatarPath ? (
+                    <img
+                      src={persona.avatarPath}
+                      alt={persona.name}
+                      className="h-9 w-9 shrink-0 rounded-full border border-[var(--border)] object-cover"
+                    />
+                  ) : (
+                    <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-[var(--border)] bg-[var(--secondary)] text-xs font-semibold text-[var(--muted-foreground)]">
+                      {(persona.name || "?")[0].toUpperCase()}
+                    </div>
+                  )}
+                  <div className="flex min-w-0 flex-1 flex-col">
+                    <span className={cn("text-xs font-semibold", isActive && "text-[var(--primary)]")}>
+                      {persona.name || persona.id}
+                    </span>
+                    {persona.comment && (
+                      <span className="truncate text-[0.625rem] leading-tight text-[var(--muted-foreground)]">
+                        {persona.comment.length > 60 ? persona.comment.substring(0, 60) + "…" : persona.comment}
+                      </span>
+                    )}
+                  </div>
+                  {isActive && <span className="ml-auto shrink-0 text-[0.6875rem]">✓</span>}
+                </button>
+              );
+            })}
+
+            {personas.length === 0 && (
+              <div className="px-3 py-4 text-center text-[0.6875rem] italic text-[var(--muted-foreground)]">
+                No personas found.
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/packages/client/src/components/chat/QuickSwitcherMobile.tsx
+++ b/packages/client/src/components/chat/QuickSwitcherMobile.tsx
@@ -1,0 +1,274 @@
+// ──────────────────────────────────────────────
+// Quick Switcher Mobile — single chevron opens
+// a tabbed menu with Connections + Personas
+// ──────────────────────────────────────────────
+import { useState, useRef, useCallback, useEffect } from "react";
+import { ChevronUp, Link, CircleUser } from "lucide-react";
+import { useConnections } from "../../hooks/use-connections";
+import { usePersonas } from "../../hooks/use-characters";
+import { useUpdateChat, useChat } from "../../hooks/use-chats";
+import { useChatStore } from "../../stores/chat.store";
+import { cn } from "../../lib/utils";
+
+interface Persona {
+  id: string;
+  name: string;
+  avatarPath?: string | null;
+  comment?: string | null;
+}
+
+export function QuickSwitcherMobile() {
+  const [open, setOpen] = useState(false);
+  const [tab, setTab] = useState<"connections" | "personas">("connections");
+  const btnRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const activeChatId = useChatStore((s) => s.activeChatId);
+  const { data: connections } = useConnections();
+  const { data: rawPersonas } = usePersonas();
+  const { data: chat } = useChat(activeChatId);
+  const updateChat = useUpdateChat();
+
+  const activeConnectionId = (chat as unknown as Record<string, unknown>)?.connectionId as string | null;
+  const activePersonaId = (chat as unknown as Record<string, unknown>)?.personaId as string | null;
+
+  const sortedConnections = ((connections ?? []) as Array<{ id: string; name: string }>)
+    .slice()
+    .sort((a, b) => (a.name || "").localeCompare(b.name || ""));
+
+  const sortedPersonas = ((rawPersonas ?? []) as Persona[])
+    .slice()
+    .sort((a, b) => (a.name || "").localeCompare(b.name || ""));
+
+  const handleSwitchConnection = useCallback(
+    (connId: string | null) => {
+      if (!activeChatId) return;
+      updateChat.mutate({ id: activeChatId, connectionId: connId });
+      setOpen(false);
+    },
+    [activeChatId, updateChat],
+  );
+
+  const handleSwitchPersona = useCallback(
+    (personaId: string | null) => {
+      if (!activeChatId) return;
+      updateChat.mutate({ id: activeChatId, personaId });
+      setOpen(false);
+    },
+    [activeChatId, updateChat],
+  );
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (
+        menuRef.current &&
+        !menuRef.current.contains(e.target as Node) &&
+        btnRef.current &&
+        !btnRef.current.contains(e.target as Node)
+      ) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open]);
+
+  // Position menu above input box, aligned to its left edge
+  const [pos, setPos] = useState<{ left: number; top: number; width: number } | null>(null);
+  useEffect(() => {
+    if (!open || !btnRef.current) return;
+    const update = () => {
+      // Find the input box container (the rounded border div)
+      const inputBox = btnRef.current!.closest(".rounded-2xl") as HTMLElement | null;
+      const menuEl = menuRef.current;
+      const menuHeight = menuEl?.offsetHeight || 400;
+
+      if (inputBox) {
+        const boxRect = inputBox.getBoundingClientRect();
+        setPos({
+          left: boxRect.left,
+          top: Math.max(8, boxRect.top - menuHeight - 4),
+          width: boxRect.width,
+        });
+      } else {
+        // Fallback to button position
+        const rect = btnRef.current!.getBoundingClientRect();
+        setPos({
+          left: 8,
+          top: Math.max(8, rect.top - menuHeight - 8),
+          width: 300,
+        });
+      }
+    };
+    requestAnimationFrame(update);
+    const timer = setTimeout(update, 50);
+    return () => clearTimeout(timer);
+  }, [open, tab]);
+
+
+  if (!activeChatId) return null;
+
+  return (
+    <>
+      <button
+        ref={btnRef}
+        onClick={() => setOpen((v) => !v)}
+        title="Quick Switcher"
+        className={cn(
+          "flex h-8 w-8 items-center justify-center rounded-xl transition-all",
+          open
+            ? "text-[var(--primary)]"
+            : "text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]",
+        )}
+      >
+        <ChevronUp
+          size="1rem"
+          className={cn("transition-transform", open && "rotate-180")}
+        />
+      </button>
+
+      {open && (
+        <div
+          ref={menuRef}
+          className="fixed z-[9999] flex max-h-[400px] flex-col overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--card)] shadow-2xl"
+          style={pos ? { left: pos.left, top: pos.top, width: pos.width } : undefined}
+        >
+          {/* Tab bar with icons */}
+          <div className="flex border-b border-[var(--border)]">
+            <button
+              onClick={() => setTab("connections")}
+              className={cn(
+                "flex flex-1 items-center justify-center gap-1.5 px-3 py-2.5 text-[0.6875rem] font-semibold transition-colors",
+                tab === "connections"
+                  ? "text-[var(--foreground)] border-b-2 border-[var(--primary)]"
+                  : "text-[var(--muted-foreground)] hover:text-[var(--foreground)]",
+              )}
+            >
+              <Link size="0.75rem" />
+              Connections
+            </button>
+            <button
+              onClick={() => setTab("personas")}
+              className={cn(
+                "flex flex-1 items-center justify-center gap-1.5 px-3 py-2.5 text-[0.6875rem] font-semibold transition-colors",
+                tab === "personas"
+                  ? "text-[var(--foreground)] border-b-2 border-[var(--primary)]"
+                  : "text-[var(--muted-foreground)] hover:text-[var(--foreground)]",
+              )}
+            >
+              <CircleUser size="0.75rem" />
+              Personas
+            </button>
+          </div>
+
+          {/* Content */}
+          <div className="overflow-y-auto p-1">
+            {tab === "connections" && (
+              <>
+                <button
+                  onClick={() => handleSwitchConnection("random")}
+                  className={cn(
+                    "flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-xs transition-colors hover:bg-[var(--accent)]",
+                    activeConnectionId === "random" && "text-[var(--primary)] font-semibold",
+                  )}
+                >
+                  <span>🎲 Random</span>
+                  {activeConnectionId === "random" && <span className="ml-auto text-[0.6875rem]">✓</span>}
+                </button>
+
+                <div className="mx-2 my-1 h-px bg-[var(--border)]" />
+
+                {sortedConnections.map((conn) => (
+                  <button
+                    key={conn.id}
+                    onClick={() => handleSwitchConnection(conn.id)}
+                    className={cn(
+                      "flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-xs transition-colors hover:bg-[var(--accent)]",
+                      activeConnectionId === conn.id && "text-[var(--primary)] font-semibold",
+                    )}
+                  >
+                    <span>{conn.name || conn.id}</span>
+                    {activeConnectionId === conn.id && <span className="ml-auto text-[0.6875rem]">✓</span>}
+                  </button>
+                ))}
+
+                {sortedConnections.length === 0 && (
+                  <div className="px-3 py-4 text-center text-[0.6875rem] italic text-[var(--muted-foreground)]">
+                    No connections found.
+                  </div>
+                )}
+              </>
+            )}
+
+            {tab === "personas" && (
+              <>
+                <button
+                  onClick={() => handleSwitchPersona(null)}
+                  className={cn(
+                    "flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left transition-colors hover:bg-[var(--accent)]",
+                    !activePersonaId && "text-[var(--primary)]",
+                  )}
+                >
+                  <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-[var(--border)] bg-[var(--secondary)] text-xs font-semibold text-[var(--muted-foreground)]">
+                    ?
+                  </div>
+                  <div className="flex min-w-0 flex-1 flex-col">
+                    <span className={cn("text-xs font-semibold", !activePersonaId && "text-[var(--primary)]")}>None</span>
+                    <span className="text-[0.625rem] text-[var(--muted-foreground)]">No persona selected</span>
+                  </div>
+                  {!activePersonaId && <span className="ml-auto text-[0.6875rem]">✓</span>}
+                </button>
+
+                <div className="mx-2 my-1 h-px bg-[var(--border)]" />
+
+                {sortedPersonas.map((persona) => {
+                  const isActive = persona.id === activePersonaId;
+                  return (
+                    <button
+                      key={persona.id}
+                      onClick={() => handleSwitchPersona(persona.id)}
+                      className={cn(
+                        "flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left transition-colors hover:bg-[var(--accent)]",
+                        isActive && "text-[var(--primary)]",
+                      )}
+                    >
+                      {persona.avatarPath ? (
+                        <img
+                          src={persona.avatarPath}
+                          alt={persona.name}
+                          className="h-9 w-9 shrink-0 rounded-full border border-[var(--border)] object-cover"
+                        />
+                      ) : (
+                        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-[var(--border)] bg-[var(--secondary)] text-xs font-semibold text-[var(--muted-foreground)]">
+                          {(persona.name || "?")[0].toUpperCase()}
+                        </div>
+                      )}
+                      <div className="flex min-w-0 flex-1 flex-col">
+                        <span className={cn("text-xs font-semibold", isActive && "text-[var(--primary)]")}>
+                          {persona.name || persona.id}
+                        </span>
+                        {persona.comment && (
+                          <span className="truncate text-[0.625rem] leading-tight text-[var(--muted-foreground)]">
+                            {persona.comment.length > 60 ? persona.comment.substring(0, 60) + "…" : persona.comment}
+                          </span>
+                        )}
+                      </div>
+                      {isActive && <span className="ml-auto shrink-0 text-[0.6875rem]">✓</span>}
+                    </button>
+                  );
+                })}
+
+                {sortedPersonas.length === 0 && (
+                  <div className="px-3 py-4 text-center text-[0.6875rem] italic text-[var(--muted-foreground)]">
+                    No personas found.
+                  </div>
+                )}
+              </>
+            )}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
Adds inline Quick Switcher components to the chat input area for both Roleplay and Conversation modes, allowing users to change the active connection or persona without opening Chat Settings.

## New Files
- **`QuickConnectionSwitcher.tsx`** — Link icon button that opens a dropdown to switch API connections. Includes a "Random" option. Shows ✓ next to the active connection.
- **`QuickPersonaSwitcher.tsx`** — Circular avatar button that opens a dropdown to switch personas. Shows avatar, name, and comment for each persona. Includes a "None" option.
- **`QuickSwitcherMobile.tsx`** — Mobile-only chevron button that opens a single tabbed menu combining both Connections and Personas. Menu aligns to the input box edges for a clean mobile UI.

## Modified Files
- **`ChatInput.tsx`** — Added switchers to the roleplay input bar. Desktop shows both inline; mobile shows the combined chevron.
- **`ConversationInput.tsx`** — Added switchers to the conversation input bar. Same desktop/mobile behavior.

## Desktop vs Mobile
- **Desktop (≥640px):** Connection (🔗) and Persona (avatar) buttons shown inline next to the attach button
- **Mobile (<640px):** Single chevron (▲) button that opens a tabbed dropdown with both Connections and Personas tabs. Menu width matches the input box width and aligns to its edges.

## Technical Details
- Uses existing `useConnections()`, `usePersonas()`, `useUpdateChat()`, and `useChat()` hooks
- Proper React Query cache invalidation — **no page reload needed**
- Menus use `position: fixed` with dynamic positioning above the trigger
- Click outside to close
- Fully typed with TypeScript
- Responsive via Tailwind `hidden sm:flex` / `sm:hidden` breakpoints
