### PR TITLE
feat: show running build commit in update panel

### DIFF
--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -7,6 +7,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "../../lib/api-client";
 import React, { useRef, useState, useCallback, useEffect } from "react";
 import { toast } from "sonner";
+import { APP_VERSION } from "@marinara-engine/shared";
 import {
   Upload,
   X,
@@ -1686,6 +1687,18 @@ function AdvancedSettings() {
     queryFn: () => api.get("/backup"),
   });
 
+  const health = useQuery<{
+    status: string;
+    timestamp: string;
+    version: string;
+    commit: string | null;
+    build: string;
+  }>({
+    queryKey: ["health"],
+    queryFn: () => api.get("/health"),
+    staleTime: 60_000,
+  });
+
   const deleteBackupMutation = useMutation({
     mutationFn: (name: string) => api.delete(`/backup/${name}`),
     onSuccess: () => {
@@ -1696,6 +1709,8 @@ function AdvancedSettings() {
 
   const updateCheck = useQuery<{
     currentVersion: string;
+    currentCommit: string | null;
+    currentBuild: string;
     latestVersion: string;
     updateAvailable: boolean;
     releaseUrl: string;
@@ -1723,6 +1738,12 @@ function AdvancedSettings() {
       toast.error(message);
     },
   });
+
+  const currentBuildLabel = (() => {
+    const version = health.data?.version ?? updateCheck.data?.currentVersion ?? APP_VERSION;
+    const commit = health.data?.commit ?? updateCheck.data?.currentCommit ?? null;
+    return commit ? `v${version}+${commit}` : `v${version}`;
+  })();
 
   return (
     <div className="flex flex-col gap-3">
@@ -1752,17 +1773,13 @@ function AdvancedSettings() {
               </>
             )}
           </button>
-          {updateCheck.data && (
-            <span className="text-[0.6875rem] text-[var(--muted-foreground)]">
-              Current: v{updateCheck.data.currentVersion}
-            </span>
-          )}
+          <span className="text-[0.6875rem] text-[var(--muted-foreground)]">Running: {currentBuildLabel}</span>
         </div>
 
         {updateCheck.data && !updateCheck.data.updateAvailable && (
           <div className="flex items-center gap-1.5 rounded-lg bg-[var(--secondary)] px-2.5 py-2 ring-1 ring-[var(--border)]">
             <Check size="0.8125rem" className="text-green-500 shrink-0" />
-            <span className="text-xs">You're on the latest version (v{updateCheck.data.currentVersion})</span>
+            <span className="text-xs">You're on the latest version ({currentBuildLabel})</span>
           </div>
         )}
 

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -20,6 +20,7 @@ import { APP_VERSION } from "@marinara-engine/shared";
 import { existsSync } from "fs";
 import { basename, join, resolve, dirname } from "path";
 import { fileURLToPath } from "url";
+import { getBuildCommit, getBuildLabel } from "./config/build-info.js";
 import { getCorsConfig, getLogLevel, getNodeEnv } from "./config/runtime-config.js";
 
 const REVALIDATE_FILES = new Set(["index.html"]);
@@ -129,11 +130,16 @@ export async function buildApp(https?: { cert: Buffer; key: Buffer }) {
   }
 
   // ── Health Check ──
-  app.get("/api/health", async () => ({
-    status: "ok",
-    version: APP_VERSION,
-    timestamp: new Date().toISOString(),
-  }));
+  app.get("/api/health", async () => {
+    const commit = getBuildCommit();
+    return {
+      status: "ok",
+      version: APP_VERSION,
+      commit,
+      build: getBuildLabel(),
+      timestamp: new Date().toISOString(),
+    };
+  });
 
   return app;
 }

--- a/packages/server/src/config/build-info.ts
+++ b/packages/server/src/config/build-info.ts
@@ -1,0 +1,55 @@
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { APP_VERSION } from "@marinara-engine/shared";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const SERVER_ROOT = resolve(__dirname, "../..");
+const MONOREPO_ROOT = resolve(SERVER_ROOT, "../..");
+const COMMIT_LENGTH = 12;
+
+let cachedCommit: string | null | undefined;
+
+function normalizeCommit(value: string | undefined | null) {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+  return trimmed.slice(0, COMMIT_LENGTH);
+}
+
+export function getBuildCommit() {
+  if (cachedCommit !== undefined) return cachedCommit;
+
+  const envCommit = normalizeCommit(process.env.MARINARA_GIT_COMMIT ?? process.env.GITHUB_SHA);
+  if (envCommit) {
+    cachedCommit = envCommit;
+    return cachedCommit;
+  }
+
+  if (!existsSync(resolve(MONOREPO_ROOT, ".git"))) {
+    cachedCommit = null;
+    return cachedCommit;
+  }
+
+  try {
+    const commit = execFileSync("git", ["rev-parse", `--short=${COMMIT_LENGTH}`, "HEAD"], {
+      cwd: MONOREPO_ROOT,
+      encoding: "utf8",
+      shell: process.platform === "win32",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+
+    cachedCommit = commit || null;
+  } catch {
+    cachedCommit = null;
+  }
+
+  return cachedCommit;
+}
+
+export function getBuildLabel() {
+  const commit = getBuildCommit();
+  return commit ? `${APP_VERSION}+${commit}` : APP_VERSION;
+}

--- a/packages/server/src/routes/updates.routes.ts
+++ b/packages/server/src/routes/updates.routes.ts
@@ -8,6 +8,7 @@ import { existsSync } from "fs";
 import { resolve } from "path";
 import { promisify } from "util";
 import { getMonorepoRoot } from "../config/runtime-config.js";
+import { getBuildCommit, getBuildLabel } from "../config/build-info.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -137,11 +138,15 @@ export async function updatesRoutes(app: FastifyInstance) {
   // with matching release metadata when that release exists.
   app.get("/check", async (_req, reply) => {
     const now = Date.now();
+    const currentCommit = getBuildCommit();
+    const currentBuild = getBuildLabel();
 
     // Return cached if fresh
     if (cachedRelease && now - cacheTimestamp < CACHE_TTL_MS) {
       return {
         currentVersion: APP_VERSION,
+        currentCommit,
+        currentBuild,
         ...cachedRelease,
         updateAvailable: isNewerVersion(APP_VERSION, cachedRelease.latestVersion),
         installType: isGitInstall() ? "git" : "standalone",
@@ -160,6 +165,8 @@ export async function updatesRoutes(app: FastifyInstance) {
 
       return {
         currentVersion: APP_VERSION,
+        currentCommit,
+        currentBuild,
         ...cachedRelease,
         updateAvailable: isNewerVersion(APP_VERSION, cachedRelease.latestVersion),
         installType: isGitInstall() ? "git" : "standalone",
@@ -169,6 +176,8 @@ export async function updatesRoutes(app: FastifyInstance) {
       return reply.status(502).send({
         error: `Failed to check for updates: ${message}`,
         currentVersion: APP_VERSION,
+        currentCommit,
+        currentBuild,
         updateAvailable: false,
       });
     }


### PR DESCRIPTION
## Summary
- show the exact running build in Advanced > Check for Updates
- expose build metadata from the server health and update endpoints
- include the current commit hash in the in-app version label when available

## Why
Support and bug triage currently have to infer whether a user is on an old release, a newer commit on top of a release tag, or a local git checkout. That creates ambiguity when diagnosing regressions like the recent disappearing-message reports.

This change makes the running build visible in-app as X.Y.Z+<commit>, so maintainers can immediately tell which code the user is actually running. The core objective is faster, more accurate issue diagnosis without asking users to open a terminal or inspect git manually.

## Testing
- ran pnpm check successfully
- verified the updates panel renders the running build label from /api/health and /api/updates/check
- verified the label falls back to the release version when no commit metadata is available