### PR TITLE
Allow marinara lorebooks to be imported from lorebook import modal

### DIFF
--- a/packages/client/src/components/modals/ImportLorebookModal.tsx
+++ b/packages/client/src/components/modals/ImportLorebookModal.tsx
@@ -20,16 +20,20 @@ export function ImportLorebookModal({ open, onClose }: Props) {
 
   const handleFile = async (file: File) => {
     setStatus("loading");
+    setMessage("");
 
     try {
       const text = await file.text();
-      const json = JSON.parse(text);
+      const json = JSON.parse(text) as Record<string, unknown>;
 
-      // Pass the filename (without extension) as a fallback name
-      const fallbackName = file.name.replace(/\.json$/i, "");
-      json.__filename = fallbackName;
+      const isMarinaraLorebook = json.type === "marinara_lorebook" && json.version === 1;
+      const endpoint = isMarinaraLorebook ? "/api/import/marinara" : "/api/import/st-lorebook";
 
-      const res = await fetch("/api/import/st-lorebook", {
+      if (!isMarinaraLorebook) {
+        json.__filename = file.name.replace(/\.json$/i, "");
+      }
+
+      const res = await fetch(endpoint, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(json),


### PR DESCRIPTION
This change is to support importing marinara-style lorebooks via the lorebook modal import by dynamically selecting the appropriate API endpoint based on the file content.

**Lorebook import improvements:**

* The import logic now detects if the uploaded file is a Marinara lorebook (by checking for `type === "marinara_lorebook"` and `version === 1`) and sends it to the `/api/import/marinara` endpoint; otherwise, it uses the existing `/api/import/st-lorebook` endpoint.
* The fallback filename is only added to non-Marinara lorebooks to avoid unnecessary data for Marinara files.
