### PR TITLE
Sync custom themes and fix mobile theme save

### DIFF
--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -78,6 +78,8 @@ The only **persisted** store (localStorage via Zustand `persist` middleware). Co
 - **Navigation**: `rightPanel`, `rightPanelOpen`, `sidebarOpen`, `settingsTab`, all `*DetailId` fields, `modal`
 - **Debug**: `debugMode`
 
+Synced custom themes are **not** stored in `ui.store.ts`; they are fetched from the server via React Query and mirrored across devices connected to the same Marinara instance.
+
 #### `chat.store.ts` — Chat Runtime
 
 Non-persisted. Tracks the active chat session:
@@ -403,7 +405,7 @@ The project uses Tailwind CSS v4 with the `@tailwindcss/vite` plugin (no PostCSS
 
 ### Custom Themes
 
-Users can create custom themes via the Settings > Themes panel. Custom theme CSS is injected as `<style>` tags by `CustomThemeInjector.tsx`.
+Users can create custom themes via the Settings > Themes panel. Theme definitions are stored on the Marinara server and sync across connected devices; the active custom theme is also shared. The CSS is injected as a `<style>` tag by `CustomThemeInjector.tsx`.
 
 ---
 

--- a/packages/client/.instructions.md
+++ b/packages/client/.instructions.md
@@ -139,8 +139,8 @@ src/
 
 | What | Where | Persist? |
 |---|---|---|
-| UI preferences (theme, font, sidebar, appearance) | `ui.store.ts` (Zustand) | Yes (localStorage) |
-| Server data (characters, chats, messages, presets) | React Query hooks | No (cache) |
+| UI preferences (theme mode, fonts, sidebar, appearance) | `ui.store.ts` (Zustand) | Yes (localStorage) |
+| Server data (characters, chats, messages, presets, synced themes) | React Query hooks | No (cache) |
 | Chat runtime (active chat, streaming, drafts) | `chat.store.ts` (Zustand) | No |
 | Agent execution (thoughts, debug, echo) | `agent.store.ts` (Zustand) | No |
 | Game state (scene, combat, encounters) | `game-state.store.ts` / `encounter.store.ts` | No |
@@ -262,6 +262,7 @@ for await (const event of api.streamEvents("/generate", body)) {
 - **Do not write inline styles** for things Tailwind can handle.
 - Global styles live in `src/styles/globals.css`, organized into 20 labeled sections.
 - Custom themes are injected via `<style>` tags by `CustomThemeInjector.tsx`.
+- Synced custom themes come from `/api/themes`; only extensions remain browser-local.
 - The app supports dark and light mode via `data-theme` on `<html>`.
 - Two visual themes exist: `"default"` and `"sillytavern"`.
 

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -9,6 +9,7 @@ import { CustomThemeInjector } from "./components/layout/CustomThemeInjector";
 import { Toaster } from "sonner";
 import { useUIStore } from "./stores/ui.store";
 import { api } from "./lib/api-client";
+import { useLegacyThemeMigration } from "./hooks/use-themes";
 
 const VERSION_RECOVERY_KEY = "marinara:pwa-version-recovery";
 const VERSION_CHECK_INTERVAL_MS = 5 * 60_000;
@@ -50,6 +51,7 @@ export function App() {
   const visualTheme = useUIStore((s) => s.visualTheme);
   const fontFamily = useUIStore((s) => s.fontFamily);
   const hasModalOpen = useUIStore((s) => s.modal !== null);
+  useLegacyThemeMigration();
 
   // Apply theme + font size to the document root whenever they change
   useEffect(() => {

--- a/packages/client/src/components/layout/CustomThemeInjector.tsx
+++ b/packages/client/src/components/layout/CustomThemeInjector.tsx
@@ -4,24 +4,19 @@
 // ──────────────────────────────────────────────
 import { useEffect } from "react";
 import { useUIStore } from "../../stores/ui.store";
+import { useThemes } from "../../hooks/use-themes";
 
 export function CustomThemeInjector() {
-  const activeCustomTheme = useUIStore((s) => s.activeCustomTheme);
-  const customThemes = useUIStore((s) => s.customThemes);
   const installedExtensions = useUIStore((s) => s.installedExtensions);
+  const { data: syncedThemes = [] } = useThemes();
+  const activeTheme = syncedThemes.find((theme) => theme.isActive) ?? null;
 
   // Inject active custom theme CSS
   useEffect(() => {
     const id = "marinara-custom-theme";
     let style = document.getElementById(id) as HTMLStyleElement | null;
 
-    if (!activeCustomTheme) {
-      style?.remove();
-      return;
-    }
-
-    const theme = customThemes.find((t) => t.id === activeCustomTheme);
-    if (!theme) {
+    if (!activeTheme) {
       style?.remove();
       return;
     }
@@ -31,12 +26,12 @@ export function CustomThemeInjector() {
       style.id = id;
       document.head.appendChild(style);
     }
-    style.textContent = theme.css;
+    style.textContent = activeTheme.css;
 
     return () => {
       style?.remove();
     };
-  }, [activeCustomTheme, customThemes]);
+  }, [activeTheme]);
 
   // Inject enabled extension CSS
   useEffect(() => {

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -1,13 +1,21 @@
 // ──────────────────────────────────────────────
 // Panel: Settings (polished)
 // ──────────────────────────────────────────────
-import { useUIStore, type CustomTheme, type InstalledExtension, type VisualTheme } from "../../stores/ui.store";
+import { useUIStore, type InstalledExtension, type VisualTheme } from "../../stores/ui.store";
 import { cn, generateClientId } from "../../lib/utils";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "../../lib/api-client";
 import React, { useRef, useState, useCallback, useEffect } from "react";
 import { toast } from "sonner";
-import { APP_VERSION } from "@marinara-engine/shared";
+import { APP_VERSION, type Theme } from "@marinara-engine/shared";
+import {
+  findDuplicateTheme,
+  useCreateTheme,
+  useDeleteTheme,
+  useSetActiveTheme,
+  useThemes,
+  useUpdateTheme,
+} from "../../hooks/use-themes";
 import {
   Upload,
   X,
@@ -960,13 +968,14 @@ function BackgroundPicker({ selected, onSelect }: { selected: string | null; onS
 }
 
 function ThemesSettings() {
-  const customThemes = useUIStore((s) => s.customThemes);
-  const activeCustomTheme = useUIStore((s) => s.activeCustomTheme);
-  const setActiveCustomTheme = useUIStore((s) => s.setActiveCustomTheme);
-  const addCustomTheme = useUIStore((s) => s.addCustomTheme);
-  const updateCustomTheme = useUIStore((s) => s.updateCustomTheme);
-  const removeCustomTheme = useUIStore((s) => s.removeCustomTheme);
+  const { data: syncedThemes = [], isLoading } = useThemes();
+  const createTheme = useCreateTheme();
+  const updateTheme = useUpdateTheme();
+  const deleteTheme = useDeleteTheme();
+  const setActiveTheme = useSetActiveTheme();
   const fileRef = useRef<HTMLInputElement>(null);
+  const activeCustomTheme = syncedThemes.find((theme) => theme.isActive) ?? null;
+  const isSavingTheme = createTheme.isPending || updateTheme.isPending || setActiveTheme.isPending;
 
   // Editor state
   const [editorOpen, setEditorOpen] = useState(false);
@@ -1003,28 +1012,26 @@ function ThemesSettings() {
     setEditorOpen(true);
   }, []);
 
-  const openEditTheme = useCallback((theme: CustomTheme) => {
+  const openEditTheme = useCallback((theme: Theme) => {
     setEditingId(theme.id);
     setThemeName(theme.name);
     setThemeCss(theme.css);
     setEditorOpen(true);
   }, []);
 
-  const handleSave = useCallback(() => {
+  const handleSave = useCallback(async () => {
     try {
       const name = themeName.trim() || "Untitled Theme";
       if (editingId) {
-        updateCustomTheme(editingId, { name, css: themeCss });
+        await updateTheme.mutateAsync({ id: editingId, name, css: themeCss });
         toast.success(`Theme "${name}" updated`);
       } else {
-        const theme: CustomTheme = {
-          id: crypto.randomUUID(),
+        const theme = await createTheme.mutateAsync({
           name,
           css: themeCss,
           installedAt: new Date().toISOString(),
-        };
-        addCustomTheme(theme);
-        setActiveCustomTheme(theme.id);
+        });
+        await setActiveTheme.mutateAsync(theme.id);
         toast.success(`Theme "${name}" saved and activated`);
       }
       setEditorOpen(false);
@@ -1032,36 +1039,38 @@ function ThemesSettings() {
       console.error("[ThemesSettings] Failed to save theme:", err);
       toast.error("Failed to save theme. Check the browser console for details.");
     }
-  }, [editingId, themeName, themeCss, addCustomTheme, updateCustomTheme, setActiveCustomTheme]);
+  }, [createTheme, editingId, setActiveTheme, themeCss, themeName, updateTheme]);
 
   const handleImportTheme = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
     try {
       const text = await file.text();
-      let themeName: string;
+      let importedThemeName: string;
+      let importedThemeCss: string;
 
       if (file.name.endsWith(".json")) {
         const parsed = JSON.parse(text);
-        const theme: CustomTheme = {
-          id: generateClientId(),
-          name: parsed.name ?? file.name.replace(/\.json$/, ""),
-          css: parsed.css ?? "",
-          installedAt: new Date().toISOString(),
-        };
-        themeName = theme.name;
-        addCustomTheme(theme);
+        importedThemeName =
+          typeof parsed.name === "string" && parsed.name.trim() ? parsed.name : file.name.replace(/\.json$/, "");
+        importedThemeCss = typeof parsed.css === "string" ? parsed.css : "";
       } else {
-        const theme: CustomTheme = {
-          id: generateClientId(),
-          name: file.name.replace(/\.css$/, ""),
-          css: text,
-          installedAt: new Date().toISOString(),
-        };
-        themeName = theme.name;
-        addCustomTheme(theme);
+        importedThemeName = file.name.replace(/\.css$/, "");
+        importedThemeCss = text;
       }
-      toast.success(`Theme "${themeName}" imported`);
+
+      const latestThemes = await api.get<Theme[]>("/themes");
+      const duplicate = findDuplicateTheme(latestThemes, importedThemeName, importedThemeCss);
+      if (duplicate) {
+        toast.success(`Theme "${duplicate.name}" is already synced`);
+      } else {
+        await createTheme.mutateAsync({
+          name: importedThemeName,
+          css: importedThemeCss,
+          installedAt: new Date().toISOString(),
+        });
+        toast.success(`Theme "${importedThemeName}" imported`);
+      }
     } catch (err) {
       console.error("[ThemesSettings] Failed to import theme:", err);
       toast.error("Failed to import theme. Ensure it's a valid CSS or JSON file.");
@@ -1100,10 +1109,11 @@ function ThemesSettings() {
             </button>
             <button
               onClick={handleSave}
-              className="flex items-center gap-1 rounded-md bg-[var(--primary)] px-2.5 py-1 text-[0.625rem] font-medium text-[var(--primary-foreground)] transition-opacity hover:opacity-90 active:scale-95"
+              disabled={isSavingTheme}
+              className="flex items-center gap-1 rounded-md bg-[var(--primary)] px-2.5 py-1 text-[0.625rem] font-medium text-[var(--primary-foreground)] transition-opacity hover:opacity-90 active:scale-95 disabled:cursor-not-allowed disabled:opacity-60"
             >
-              <Save size="0.6875rem" />
-              Save
+              {isSavingTheme ? <Loader2 size="0.6875rem" className="animate-spin" /> : <Save size="0.6875rem" />}
+              {isSavingTheme ? "Saving..." : "Save"}
             </button>
           </div>
         </div>
@@ -1171,7 +1181,8 @@ function ThemesSettings() {
     <div className="flex flex-col gap-4">
       <div className="flex items-center gap-1.5 text-xs text-[var(--muted-foreground)]">
         <Palette size="0.75rem" />
-        Create or import custom CSS themes to personalize the look and feel.
+        Create or import custom CSS themes. Themes sync across devices connected to this Marinara server, while
+        extensions stay local to this browser.
       </div>
 
       {/* Action buttons */}
@@ -1195,7 +1206,14 @@ function ThemesSettings() {
       <div className="flex flex-col gap-1.5">
         <span className="text-xs font-medium">Installed Themes</span>
         <button
-          onClick={() => setActiveCustomTheme(null)}
+          onClick={() =>
+            setActiveTheme.mutate(null, {
+              onError: (err) => {
+                console.error("[ThemesSettings] Failed to reset active theme:", err);
+                toast.error("Failed to reset the active theme.");
+              },
+            })
+          }
           className={cn(
             "flex items-center gap-2 rounded-lg px-3 py-2 text-xs transition-all",
             activeCustomTheme === null
@@ -1209,20 +1227,30 @@ function ThemesSettings() {
         </button>
 
         {/* Custom theme list */}
-        {customThemes.map((t) => (
+        {syncedThemes.map((t) => (
           <div
             key={t.id}
             className={cn(
               "flex items-center gap-2 rounded-lg px-3 py-2 text-xs transition-all",
-              activeCustomTheme === t.id
+              activeCustomTheme?.id === t.id
                 ? "bg-[var(--primary)]/15 text-[var(--primary)] ring-1 ring-[var(--primary)]/30"
                 : "bg-[var(--secondary)] text-[var(--secondary-foreground)] hover:bg-[var(--accent)]",
             )}
           >
-            <button onClick={() => setActiveCustomTheme(t.id)} className="flex flex-1 items-center gap-2 min-w-0">
+            <button
+              onClick={() =>
+                setActiveTheme.mutate(t.id, {
+                  onError: (err) => {
+                    console.error("[ThemesSettings] Failed to activate theme:", err);
+                    toast.error("Failed to activate theme.");
+                  },
+                })
+              }
+              className="flex flex-1 items-center gap-2 min-w-0"
+            >
               <FileCode2 size="0.75rem" className="shrink-0" />
               <span className="truncate">{t.name}</span>
-              {activeCustomTheme === t.id && <Check size="0.75rem" className="shrink-0" />}
+              {activeCustomTheme?.id === t.id && <Check size="0.75rem" className="shrink-0" />}
             </button>
             <button
               onClick={() => openEditTheme(t)}
@@ -1249,8 +1277,15 @@ function ThemesSettings() {
             </button>
             <button
               onClick={() => {
-                if (activeCustomTheme === t.id) setActiveCustomTheme(null);
-                removeCustomTheme(t.id);
+                void (async () => {
+                  try {
+                    await deleteTheme.mutateAsync(t.id);
+                    toast.success(`Theme "${t.name}" removed`);
+                  } catch (err) {
+                    console.error("[ThemesSettings] Failed to remove theme:", err);
+                    toast.error("Failed to remove theme.");
+                  }
+                })();
               }}
               className="rounded p-0.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--destructive)]/10 hover:text-[var(--destructive)]"
               title="Remove theme"
@@ -1260,9 +1295,13 @@ function ThemesSettings() {
           </div>
         ))}
 
-        {customThemes.length === 0 && (
+        {isLoading && syncedThemes.length === 0 && (
+          <p className="py-2 text-center text-[0.625rem] text-[var(--muted-foreground)]">Loading synced themes...</p>
+        )}
+
+        {!isLoading && syncedThemes.length === 0 && (
           <p className="py-2 text-center text-[0.625rem] text-[var(--muted-foreground)]">
-            No custom themes installed yet. Create one or import a .css file above.
+            No synced custom themes yet. Create one or import a .css file above.
           </p>
         )}
       </div>
@@ -1273,6 +1312,7 @@ function ThemesSettings() {
         <code className="rounded bg-[var(--secondary)] px-1">--background</code>,{" "}
         <code className="rounded bg-[var(--secondary)] px-1">--primary</code>) or add custom styles. JSON themes should
         have <code className="rounded bg-[var(--secondary)] px-1">{`{ "name": "...", "css": "..." }`}</code> format.
+        Imported theme files sync to this Marinara server but do not auto-activate.
       </div>
     </div>
   );
@@ -1490,7 +1530,7 @@ function ImportSettings() {
         qc.invalidateQueries();
         const s = data.imported;
         toast.success(
-          `Imported: ${s.characters} characters, ${s.personas} personas, ${s.lorebooks} lorebooks, ${s.presets} presets, ${s.agents} agents`,
+          `Imported: ${s.characters} characters, ${s.personas} personas, ${s.lorebooks} lorebooks, ${s.presets} presets, ${s.agents} agents, ${s.themes ?? 0} themes`,
         );
       } else {
         toast.error(`Import failed: ${data.error ?? "Unknown error"}`);
@@ -1504,7 +1544,8 @@ function ImportSettings() {
   return (
     <div className="flex flex-col gap-3">
       <div className="text-xs text-[var(--muted-foreground)]">
-        Import data from Marinara exports, SillyTavern, or other tools.
+        Import data from Marinara exports, SillyTavern, or other tools. Full profile imports also restore synced custom
+        themes.
       </div>
 
       {/* Profile import */}

--- a/packages/client/src/hooks/use-themes.ts
+++ b/packages/client/src/hooks/use-themes.ts
@@ -1,0 +1,131 @@
+// ──────────────────────────────────────────────
+// Hooks: Synced Custom Themes
+// ──────────────────────────────────────────────
+import { useEffect, useRef } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { api } from "../lib/api-client";
+import { useUIStore } from "../stores/ui.store";
+import type { CreateThemeInput, Theme, UpdateThemeInput } from "@marinara-engine/shared";
+
+export const themeKeys = {
+  all: ["themes"] as const,
+  list: () => [...themeKeys.all, "list"] as const,
+};
+
+export function findDuplicateTheme(themes: Theme[], name: string, css: string) {
+  return themes.find((theme) => theme.name === name && theme.css === css) ?? null;
+}
+
+export function useThemes() {
+  return useQuery({
+    queryKey: themeKeys.list(),
+    queryFn: () => api.get<Theme[]>("/themes"),
+    staleTime: 0,
+    refetchOnWindowFocus: true,
+    refetchOnReconnect: true,
+    refetchInterval: () => (document.hidden ? false : 15_000),
+  });
+}
+
+export function useCreateTheme() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: CreateThemeInput) => api.post<Theme>("/themes", data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: themeKeys.all });
+    },
+  });
+}
+
+export function useUpdateTheme() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, ...data }: { id: string } & UpdateThemeInput) => api.patch<Theme>(`/themes/${id}`, data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: themeKeys.all });
+    },
+  });
+}
+
+export function useDeleteTheme() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => api.delete(`/themes/${id}`),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: themeKeys.all });
+    },
+  });
+}
+
+export function useSetActiveTheme() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string | null) => api.put<Theme | null>("/themes/active", { id }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: themeKeys.all });
+    },
+  });
+}
+
+export function useLegacyThemeMigration() {
+  const legacyThemes = useUIStore((s) => s.customThemes);
+  const legacyActiveCustomTheme = useUIStore((s) => s.activeCustomTheme);
+  const hasMigratedCustomThemesToServer = useUIStore((s) => s.hasMigratedCustomThemesToServer);
+  const clearLegacyCustomThemes = useUIStore((s) => s.clearLegacyCustomThemes);
+  const setHasMigratedCustomThemesToServer = useUIStore((s) => s.setHasMigratedCustomThemesToServer);
+  const qc = useQueryClient();
+  const inFlightRef = useRef(false);
+  const { isSuccess } = useThemes();
+
+  useEffect(() => {
+    if (hasMigratedCustomThemesToServer || !isSuccess || inFlightRef.current) {
+      return;
+    }
+
+    inFlightRef.current = true;
+    void (async () => {
+      try {
+        const latestThemes = await api.get<Theme[]>("/themes");
+        const serverAlreadyHasActiveTheme = latestThemes.some((theme) => theme.isActive);
+        let workingThemes = [...latestThemes];
+        let migratedActiveThemeId: string | null = null;
+
+        for (const legacyTheme of legacyThemes) {
+          let syncedTheme = findDuplicateTheme(workingThemes, legacyTheme.name, legacyTheme.css);
+          if (!syncedTheme) {
+            syncedTheme = await api.post<Theme>("/themes", {
+              name: legacyTheme.name,
+              css: legacyTheme.css,
+              installedAt: legacyTheme.installedAt,
+            });
+            workingThemes = [syncedTheme, ...workingThemes];
+          }
+
+          if (!serverAlreadyHasActiveTheme && legacyActiveCustomTheme === legacyTheme.id) {
+            migratedActiveThemeId = syncedTheme.id;
+          }
+        }
+
+        if (migratedActiveThemeId) {
+          await api.put<Theme | null>("/themes/active", { id: migratedActiveThemeId });
+        }
+
+        clearLegacyCustomThemes();
+        setHasMigratedCustomThemesToServer(true);
+        await qc.invalidateQueries({ queryKey: themeKeys.all });
+      } catch {
+        // Leave migration flag untouched so the next app start can retry.
+      } finally {
+        inFlightRef.current = false;
+      }
+    })();
+  }, [
+    clearLegacyCustomThemes,
+    hasMigratedCustomThemesToServer,
+    isSuccess,
+    legacyActiveCustomTheme,
+    legacyThemes,
+    qc,
+    setHasMigratedCustomThemesToServer,
+  ]);
+}

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -20,7 +20,7 @@ export type HudPosition = "top" | "left" | "right";
 export type EchoChamberSide = "top-left" | "top-right" | "bottom-left" | "bottom-right";
 export type UserStatus = "active" | "idle" | "dnd";
 
-/** A user-installed custom theme */
+/** Legacy browser-local custom theme preserved for one-time migration. */
 export interface CustomTheme {
   id: string;
   name: string;
@@ -134,10 +134,13 @@ interface UIState {
   // ── HUD Layout ──
   hudPosition: HudPosition;
 
-  // ── Custom Themes & Extensions ──
-  /** Currently active custom theme id (null = built-in default) */
+  // ── Legacy Custom Themes & Extensions ──
+  /** Legacy active custom theme id (null = built-in default). Migration only. */
   activeCustomTheme: string | null;
+  /** Legacy browser-local custom themes. Migration only. */
   customThemes: CustomTheme[];
+  /** True once legacy browser-local themes have been migrated to the server. */
+  hasMigratedCustomThemesToServer: boolean;
   installedExtensions: InstalledExtension[];
 
   // ── Onboarding ──
@@ -229,6 +232,9 @@ interface UIState {
   setEnterToSendConvo: (v: boolean) => void;
   setWeatherEffects: (v: boolean) => void;
   setHudPosition: (v: HudPosition) => void;
+  /** Legacy migration helpers for browser-local custom themes. */
+  setHasMigratedCustomThemesToServer: (v: boolean) => void;
+  clearLegacyCustomThemes: () => void;
   setActiveCustomTheme: (id: string | null) => void;
   addCustomTheme: (theme: CustomTheme) => void;
   updateCustomTheme: (id: string, patch: Partial<Pick<CustomTheme, "name" | "css">>) => void;
@@ -299,6 +305,7 @@ export const useUIStore = create<UIState>()(
       hudPosition: "top" as HudPosition,
       activeCustomTheme: null,
       customThemes: [],
+      hasMigratedCustomThemesToServer: false,
       installedExtensions: [],
       hasCompletedOnboarding: false,
       linkApiBannerDismissed: false,
@@ -502,6 +509,8 @@ export const useUIStore = create<UIState>()(
       setEnterToSendConvo: (v) => set({ enterToSendConvo: v }),
       setWeatherEffects: (v) => set({ weatherEffects: v }),
       setHudPosition: (v) => set({ hudPosition: v }),
+      setHasMigratedCustomThemesToServer: (v) => set({ hasMigratedCustomThemesToServer: v }),
+      clearLegacyCustomThemes: () => set({ customThemes: [], activeCustomTheme: null }),
       setActiveCustomTheme: (id) => set({ activeCustomTheme: id }),
       addCustomTheme: (theme) => set((s) => ({ customThemes: [...s.customThemes, theme] })),
       updateCustomTheme: (id, patch) =>
@@ -531,7 +540,7 @@ export const useUIStore = create<UIState>()(
     }),
     {
       name: "marinara-engine-ui",
-      version: 6,
+      version: 7,
       // Debounce localStorage writes to avoid sync I/O on every state change
       storage: createJSONStorage(() => {
         let timer: ReturnType<typeof setTimeout> | null = null;
@@ -613,6 +622,12 @@ export const useUIStore = create<UIState>()(
           if (persisted.textStrokeWidth === undefined) persisted.textStrokeWidth = 0.5;
           if (persisted.textStrokeColor === undefined) persisted.textStrokeColor = "#000000";
         }
+        // v6 → v7: add legacy theme migration completion flag
+        if (version <= 6) {
+          if (persisted.hasMigratedCustomThemesToServer === undefined) {
+            persisted.hasMigratedCustomThemesToServer = false;
+          }
+        }
         return persisted;
       },
       partialize: (state) => ({
@@ -647,6 +662,7 @@ export const useUIStore = create<UIState>()(
         enterToSendConvo: state.enterToSendConvo,
         weatherEffects: state.weatherEffects,
         hudPosition: state.hudPosition,
+        hasMigratedCustomThemesToServer: state.hasMigratedCustomThemesToServer,
         activeCustomTheme: state.activeCustomTheme,
         customThemes: state.customThemes,
         installedExtensions: state.installedExtensions,

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -333,6 +333,15 @@ const CREATE_TABLES: string[] = [
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL
   )`,
+  `CREATE TABLE IF NOT EXISTS custom_themes (
+    id TEXT PRIMARY KEY NOT NULL,
+    name TEXT NOT NULL,
+    css TEXT NOT NULL DEFAULT '',
+    installed_at TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    is_active TEXT NOT NULL DEFAULT 'false'
+  )`,
 ];
 
 // ── Column migrations (ALTER TABLE for schema evolution) ──
@@ -488,4 +497,5 @@ export async function runMigrations(db: DB) {
   await db.run(
     sql.raw(`CREATE INDEX IF NOT EXISTS idx_memory_chunks_chat ON memory_chunks(chat_id, last_message_at DESC)`),
   );
+  await db.run(sql.raw(`CREATE INDEX IF NOT EXISTS idx_custom_themes_active ON custom_themes(is_active)`));
 }

--- a/packages/server/src/db/schema/index.ts
+++ b/packages/server/src/db/schema/index.ts
@@ -12,3 +12,4 @@ export * from "./custom-tools.js";
 export * from "./game-state.js";
 export * from "./regex-scripts.js";
 export * from "./gallery.js";
+export * from "./themes.js";

--- a/packages/server/src/db/schema/themes.ts
+++ b/packages/server/src/db/schema/themes.ts
@@ -1,0 +1,14 @@
+// ──────────────────────────────────────────────
+// Schema: Synced Custom Themes
+// ──────────────────────────────────────────────
+import { sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+export const customThemes = sqliteTable("custom_themes", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+  css: text("css").notNull().default(""),
+  installedAt: text("installed_at").notNull(),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull(),
+  isActive: text("is_active").notNull().default("false"),
+});

--- a/packages/server/src/routes/admin.routes.ts
+++ b/packages/server/src/routes/admin.routes.ts
@@ -58,6 +58,7 @@ export async function adminRoutes(app: FastifyInstance) {
       ["agent_runs", schema.agentRuns],
       ["agent_configs", schema.agentConfigs],
       ["game_state_snapshots", schema.gameStateSnapshots],
+      ["custom_themes", schema.customThemes],
       ["assets", schema.assets],
       ["character_groups", schema.characterGroups],
       ["personas", schema.personas],

--- a/packages/server/src/routes/backup.routes.ts
+++ b/packages/server/src/routes/backup.routes.ts
@@ -9,6 +9,7 @@ import { createCharactersStorage } from "../services/storage/characters.storage.
 import { createLorebooksStorage } from "../services/storage/lorebooks.storage.js";
 import { createPromptsStorage } from "../services/storage/prompts.storage.js";
 import { createAgentsStorage } from "../services/storage/agents.storage.js";
+import { createThemesStorage } from "../services/storage/themes.storage.js";
 import type { ExportEnvelope } from "@marinara-engine/shared";
 import { getDataDir } from "../utils/data-dir.js";
 import { getDatabaseFilePath } from "../config/runtime-config.js";
@@ -96,13 +97,13 @@ export async function backupRoutes(app: FastifyInstance) {
 
   // ── Profile Export ──
   // Returns a portable JSON envelope with characters, personas, lorebooks,
-  // presets (+ groups/sections/choices), agent configs, and connections
-  // (API keys are redacted).
+  // presets (+ groups/sections/choices), agent configs, and synced custom themes.
   app.get("/export-profile", async (_req, reply) => {
     const chars = createCharactersStorage(app.db);
     const lbs = createLorebooksStorage(app.db);
     const presets = createPromptsStorage(app.db);
     const agents = createAgentsStorage(app.db);
+    const themes = createThemesStorage(app.db);
 
     // Characters — include avatar as base64 if available
     const allChars = await chars.list();
@@ -154,6 +155,7 @@ export async function backupRoutes(app: FastifyInstance) {
 
     // Agent configs
     const allAgents = await agents.list();
+    const allThemes = await themes.list();
 
     const envelope: ExportEnvelope = {
       type: "marinara_profile",
@@ -165,6 +167,7 @@ export async function backupRoutes(app: FastifyInstance) {
         lorebooks: lorebookExports,
         presets: presetExports,
         agents: allAgents,
+        themes: allThemes,
       },
     };
 
@@ -187,8 +190,9 @@ export async function backupRoutes(app: FastifyInstance) {
     const lbs = createLorebooksStorage(app.db);
     const presets = createPromptsStorage(app.db);
     const agents = createAgentsStorage(app.db);
+    const themes = createThemesStorage(app.db);
 
-    const stats = { characters: 0, personas: 0, lorebooks: 0, presets: 0, agents: 0 };
+    const stats = { characters: 0, personas: 0, lorebooks: 0, presets: 0, agents: 0, themes: 0 };
 
     // Import characters
     if (Array.isArray(data.characters)) {
@@ -401,6 +405,41 @@ export async function backupRoutes(app: FastifyInstance) {
         } catch {
           /* skip */
         }
+      }
+    }
+
+    // Import synced custom themes
+    let importedActiveThemeId: string | null = null;
+    if (Array.isArray(data.themes)) {
+      for (const theme of data.themes) {
+        try {
+          const duplicate = await themes.findDuplicate(theme.name ?? "", theme.css ?? "");
+          const syncedTheme =
+            duplicate ??
+            (await themes.create({
+              name: theme.name ?? "Imported Theme",
+              css: theme.css ?? "",
+              installedAt: theme.installedAt,
+            }));
+
+          if (!duplicate && syncedTheme) {
+            stats.themes++;
+          }
+
+          if (syncedTheme && (theme.isActive === true || theme.isActive === "true")) {
+            importedActiveThemeId = syncedTheme.id;
+          }
+        } catch {
+          /* skip */
+        }
+      }
+    }
+
+    if (importedActiveThemeId) {
+      try {
+        await themes.setActive(importedActiveThemeId);
+      } catch {
+        /* skip */
       }
     }
 

--- a/packages/server/src/routes/index.ts
+++ b/packages/server/src/routes/index.ts
@@ -38,6 +38,7 @@ import { botBrowserPygmalionRoutes } from "./bot-browser-pygmalion.routes.js";
 import { botBrowserWyvernRoutes } from "./bot-browser-wyvern.routes.js";
 import { chatFoldersRoutes } from "./chat-folders.routes.js";
 import { updatesRoutes } from "./updates.routes.js";
+import { themesRoutes } from "./themes.routes.js";
 
 export async function registerRoutes(app: FastifyInstance) {
   await app.register(chatsRoutes, { prefix: "/api/chats" });
@@ -76,4 +77,5 @@ export async function registerRoutes(app: FastifyInstance) {
   await app.register(botBrowserPygmalionRoutes, { prefix: "/api/bot-browser" });
   await app.register(botBrowserWyvernRoutes, { prefix: "/api/bot-browser" });
   await app.register(updatesRoutes, { prefix: "/api/updates" });
+  await app.register(themesRoutes, { prefix: "/api/themes" });
 }

--- a/packages/server/src/routes/themes.routes.ts
+++ b/packages/server/src/routes/themes.routes.ts
@@ -1,0 +1,42 @@
+// ──────────────────────────────────────────────
+// Routes: Synced Custom Themes
+// ──────────────────────────────────────────────
+import type { FastifyInstance } from "fastify";
+import { createThemeSchema, setActiveThemeSchema, updateThemeSchema } from "@marinara-engine/shared";
+import { createThemesStorage } from "../services/storage/themes.storage.js";
+
+export async function themesRoutes(app: FastifyInstance) {
+  const storage = createThemesStorage(app.db);
+
+  app.get("/", async () => {
+    return storage.list();
+  });
+
+  app.post("/", async (req) => {
+    const input = createThemeSchema.parse(req.body);
+    return storage.create(input);
+  });
+
+  app.patch<{ Params: { id: string } }>("/:id", async (req, reply) => {
+    const data = updateThemeSchema.parse(req.body);
+    const existing = await storage.getById(req.params.id);
+    if (!existing) return reply.status(404).send({ error: "Theme not found" });
+    return storage.update(req.params.id, data);
+  });
+
+  app.delete<{ Params: { id: string } }>("/:id", async (req, reply) => {
+    const existing = await storage.getById(req.params.id);
+    if (!existing) return reply.status(404).send({ error: "Theme not found" });
+    await storage.remove(req.params.id);
+    return reply.status(204).send();
+  });
+
+  app.put("/active", async (req, reply) => {
+    const input = setActiveThemeSchema.parse(req.body);
+    if (input.id !== null) {
+      const existing = await storage.getById(input.id);
+      if (!existing) return reply.status(404).send({ error: "Theme not found" });
+    }
+    return storage.setActive(input.id);
+  });
+}

--- a/packages/server/src/services/storage/themes.storage.ts
+++ b/packages/server/src/services/storage/themes.storage.ts
@@ -1,0 +1,88 @@
+// ──────────────────────────────────────────────
+// Storage: Synced Custom Themes
+// ──────────────────────────────────────────────
+import { desc, eq } from "drizzle-orm";
+import type { DB } from "../../db/connection.js";
+import { customThemes } from "../../db/schema/index.js";
+import { newId, now } from "../../utils/id-generator.js";
+import type { CreateThemeInput, Theme, UpdateThemeInput } from "@marinara-engine/shared";
+
+type ThemeRow = typeof customThemes.$inferSelect;
+
+function mapTheme(row: ThemeRow): Theme {
+  return {
+    id: row.id,
+    name: row.name,
+    css: row.css,
+    installedAt: row.installedAt,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+    isActive: row.isActive === "true",
+  };
+}
+
+export function createThemesStorage(db: DB) {
+  return {
+    async list() {
+      const rows = await db.select().from(customThemes).orderBy(desc(customThemes.updatedAt));
+      return rows.map(mapTheme);
+    },
+
+    async getById(id: string) {
+      const rows = await db.select().from(customThemes).where(eq(customThemes.id, id));
+      const row = rows[0];
+      return row ? mapTheme(row) : null;
+    },
+
+    async getActive() {
+      const rows = await db.select().from(customThemes).where(eq(customThemes.isActive, "true"));
+      const row = rows[0];
+      return row ? mapTheme(row) : null;
+    },
+
+    async findDuplicate(name: string, css: string) {
+      const rows = await db.select().from(customThemes);
+      const row = rows.find((candidate) => candidate.name === name && candidate.css === css);
+      return row ? mapTheme(row) : null;
+    },
+
+    async create(input: CreateThemeInput) {
+      const id = newId();
+      const timestamp = now();
+      await db.insert(customThemes).values({
+        id,
+        name: input.name,
+        css: input.css ?? "",
+        installedAt: input.installedAt ?? timestamp,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+        isActive: "false",
+      });
+      return this.getById(id);
+    },
+
+    async update(id: string, data: UpdateThemeInput) {
+      const updateFields: Partial<typeof customThemes.$inferInsert> = {
+        updatedAt: now(),
+      };
+      if (data.name !== undefined) updateFields.name = data.name;
+      if (data.css !== undefined) updateFields.css = data.css;
+      await db.update(customThemes).set(updateFields).where(eq(customThemes.id, id));
+      return this.getById(id);
+    },
+
+    async setActive(id: string | null) {
+      const activeTheme = await this.getActive();
+      if (activeTheme) {
+        await db.update(customThemes).set({ isActive: "false" }).where(eq(customThemes.id, activeTheme.id));
+      }
+      if (!id) return null;
+      await db.update(customThemes).set({ isActive: "true" }).where(eq(customThemes.id, id));
+      return this.getById(id);
+    },
+
+    async remove(id: string) {
+      await db.delete(customThemes).where(eq(customThemes.id, id));
+    },
+  };
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -17,6 +17,7 @@ export * from "./types/persona.js";
 export * from "./types/regex.js";
 export * from "./types/export.js";
 export * from "./types/haptic.js";
+export * from "./types/theme.js";
 
 // Schemas
 export * from "./schemas/chat.schema.js";
@@ -27,6 +28,7 @@ export * from "./schemas/connection.schema.js";
 export * from "./schemas/agent.schema.js";
 export * from "./schemas/custom-tool.schema.js";
 export * from "./schemas/regex.schema.js";
+export * from "./schemas/theme.schema.js";
 
 // Constants
 export * from "./constants/providers.js";

--- a/packages/shared/src/schemas/theme.schema.ts
+++ b/packages/shared/src/schemas/theme.schema.ts
@@ -1,0 +1,27 @@
+// ──────────────────────────────────────────────
+// Theme Zod Schemas
+// ──────────────────────────────────────────────
+import { z } from "zod";
+
+export const createThemeSchema = z.object({
+  name: z.string().min(1).max(200),
+  css: z.string().default(""),
+  installedAt: z.string().datetime().optional(),
+});
+
+export const updateThemeSchema = z
+  .object({
+    name: z.string().min(1).max(200).optional(),
+    css: z.string().optional(),
+  })
+  .refine((value) => value.name !== undefined || value.css !== undefined, {
+    message: "Must update at least one field",
+  });
+
+export const setActiveThemeSchema = z.object({
+  id: z.string().nullable(),
+});
+
+export type CreateThemeInput = z.infer<typeof createThemeSchema>;
+export type UpdateThemeInput = z.infer<typeof updateThemeSchema>;
+export type SetActiveThemeInput = z.infer<typeof setActiveThemeSchema>;

--- a/packages/shared/src/types/theme.ts
+++ b/packages/shared/src/types/theme.ts
@@ -1,0 +1,17 @@
+// ──────────────────────────────────────────────
+// Theme Types
+// ──────────────────────────────────────────────
+
+/** A synced custom theme stored on the Marinara server. */
+export interface Theme {
+  id: string;
+  name: string;
+  /** Raw CSS injected into the document as a <style> tag. */
+  css: string;
+  /** When this theme was first created or imported by the user. */
+  installedAt: string;
+  createdAt: string;
+  updatedAt: string;
+  /** Whether this is the globally active custom theme. */
+  isActive: boolean;
+}


### PR DESCRIPTION
## Summary
- move custom themes from browser-local state to a server-backed synced theme library
- fix mobile theme save on insecure LAN HTTP by removing direct client UUID generation from theme creation
- sync the active custom theme across connected devices and preserve themes in profile export/import

## Testing
- pnpm --filter @marinara-engine/client lint
- pnpm --filter @marinara-engine/server lint
- pnpm build

## Notes
- client lint still reports pre-existing warnings in unrelated files
- manual Android/browser verification was not run from this environment