### PR TITLE
revert addition of html in workbox glob patterns 

### DIFF
--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -89,7 +89,7 @@ export default defineConfig({
           devOptions: { enabled: false },
           manifest: false, // We use the static manifest.json in public/
           workbox: {
-            globPatterns: ["**/*.{html,js,css,png,svg,ico,woff2}"],
+            globPatterns: ["**/*.{js,css,png,svg,ico,woff2}"],
             navigateFallbackAllowlist: [],
             runtimeCaching: [
               {

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -89,6 +89,7 @@ export default defineConfig({
           devOptions: { enabled: false },
           manifest: false, // We use the static manifest.json in public/
           workbox: {
+            // Intentionally exclude html so index.html is not precached and does not interfere with the PWA stale-version/update flow.
             globPatterns: ["**/*.{js,css,png,svg,ico,woff2}"],
             navigateFallbackAllowlist: [],
             runtimeCaching: [


### PR DESCRIPTION
https://github.com/Pasta-Devs/Marinara-Engine/blame/038d65d36bd0360ec7c14d490304d8c6c0d86913/packages/client/vite.config.ts#L92

In 9964fc5fc37ea406ebafad92f27d9c137c0ff00f, html was added back into the workbox glob patterns letting the pwa precache the index.html; this change caused the pwa update pattern I added in #31 to stop working.

This PR removes html from it.

@TheLonelyDevil9 Was there a specific reason for adding this back in?
