### PR TITLE
fix: make start.sh compatible with macOS bash 3.2

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -152,7 +152,8 @@ else
 fi
 
 AUTO_OPEN_BROWSER_VALUE="${AUTO_OPEN_BROWSER:-true}"
-case "${AUTO_OPEN_BROWSER_VALUE,,}" in
+AUTO_OPEN_BROWSER_NORMALIZED=$(printf '%s' "$AUTO_OPEN_BROWSER_VALUE" | tr '[:upper:]' '[:lower:]')
+case "$AUTO_OPEN_BROWSER_NORMALIZED" in
   0|false|no|off) AUTO_OPEN_BROWSER_ENABLED=0 ;;
   *) AUTO_OPEN_BROWSER_ENABLED=1 ;;
 esac


### PR DESCRIPTION
## Summary

Make `start.sh` work on stock macOS, which still ships `/bin/bash` `3.2`, by replacing Bash 4+ lowercase expansion with a portable normalization step.

## Problem

`start.sh` currently uses:

```sh
${AUTO_OPEN_BROWSER_VALUE,,}
```

That syntax requires Bash 4+, but macOS still ships `/bin/bash` `3.2` by default.

On macOS, running:

```sh
./start.sh
```

can fail with:

```text
bad substitution
```

before the launcher finishes starting the app.

## Change

Replace the Bash 4-specific lowercase expansion with `printf` + `tr` before the `case` statement.

This preserves the existing behavior for values like `false`, `FALSE`, `no`, `off`, and `0`, while remaining compatible with macOS's default Bash.

## Validation

- `bash -n start.sh`
- Verified locally on macOS with `/bin/bash` `3.2.57`
- Confirmed `AUTO_OPEN_BROWSER=false ./start.sh` no longer fails with `bad substitution` and the server starts successfully
