### PR TITLE
Core safety and UX hardening

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -9,6 +9,7 @@ import { CustomThemeInjector } from "./components/layout/CustomThemeInjector";
 import { Toaster } from "sonner";
 import { useUIStore } from "./stores/ui.store";
 import { api } from "./lib/api-client";
+import { clearBrowserRuntimeCaches } from "./lib/cache-reset";
 import { useLegacyThemeMigration } from "./hooks/use-themes";
 
 const VERSION_RECOVERY_KEY = "marinara:pwa-version-recovery";
@@ -30,15 +31,7 @@ async function recoverFromVersionSkew(serverVersion: string) {
 
   sessionStorage.setItem(VERSION_RECOVERY_KEY, serverVersion);
 
-  if ("serviceWorker" in navigator) {
-    const registrations = await navigator.serviceWorker.getRegistrations();
-    await Promise.all(registrations.map((registration) => registration.unregister()));
-  }
-
-  if ("caches" in window) {
-    const cacheKeys = await caches.keys();
-    await Promise.all(cacheKeys.map((cacheKey) => caches.delete(cacheKey)));
-  }
+  await clearBrowserRuntimeCaches();
 
   const nextUrl = new URL(window.location.href);
   nextUrl.searchParams.set("v", serverVersion);

--- a/packages/client/src/components/characters/CharacterEditor.tsx
+++ b/packages/client/src/components/characters/CharacterEditor.tsx
@@ -6,6 +6,7 @@
 // ──────────────────────────────────────────────
 import { useState, useEffect, useRef, useCallback } from "react";
 import { toast } from "sonner";
+import { useQueryClient } from "@tanstack/react-query";
 import {
   useCharacter,
   useUpdateCharacter,
@@ -17,6 +18,7 @@ import {
   type SpriteInfo,
 } from "../../hooks/use-characters";
 import { useUIStore } from "../../stores/ui.store";
+import { lorebookKeys } from "../../hooks/use-lorebooks";
 import {
   ArrowLeft,
   Save,
@@ -443,7 +445,7 @@ export function CharacterEditor() {
               <ColorsTab formData={formData} updateExtension={updateExtension} avatarUrl={avatarPreview} />
             )}
             {activeTab === "stats" && <StatsTab formData={formData} updateExtension={updateExtension} />}
-            {activeTab === "lorebook" && <LorebookTab formData={formData} />}
+            {activeTab === "lorebook" && <LorebookTab characterId={characterId} formData={formData} />}
           </div>
         </div>
       </div>
@@ -1729,9 +1731,55 @@ function ColorsTab({
   );
 }
 
-function LorebookTab({ formData }: { formData: CharacterData }) {
+function LorebookTab({
+  characterId,
+  formData,
+}: {
+  characterId: string | null;
+  formData: CharacterData;
+}) {
   const book = formData.character_book;
   const entries = book?.entries ?? [];
+  const qc = useQueryClient();
+  const openLorebookDetail = useUIStore((s) => s.openLorebookDetail);
+  const [importing, setImporting] = useState(false);
+  const importMetadata =
+    formData.extensions.importMetadata && typeof formData.extensions.importMetadata === "object"
+      ? (formData.extensions.importMetadata as Record<string, unknown>)
+      : {};
+  const embeddedLorebookMetadata =
+    importMetadata.embeddedLorebook && typeof importMetadata.embeddedLorebook === "object"
+      ? (importMetadata.embeddedLorebook as Record<string, unknown>)
+      : {};
+  const linkedLorebookId =
+    typeof embeddedLorebookMetadata.lorebookId === "string" ? embeddedLorebookMetadata.lorebookId : null;
+  const hasEmbeddedLorebook = entries.length > 0 || embeddedLorebookMetadata.hasEmbeddedLorebook === true;
+
+  const handleImportEmbeddedLorebook = async () => {
+    if (!characterId) return;
+    setImporting(true);
+    try {
+      const result = await api.post<{
+        success: boolean;
+        lorebookId: string;
+        entriesImported: number;
+        reimported?: boolean;
+      }>(`/characters/${characterId}/embedded-lorebook/import`);
+      qc.invalidateQueries({ queryKey: lorebookKeys.all });
+      if (result.lorebookId) {
+        qc.invalidateQueries({ queryKey: ["characters", "detail", characterId] });
+      }
+      toast.success(
+        result.reimported
+          ? `Reimported ${result.entriesImported} embedded lorebook entr${result.entriesImported === 1 ? "y" : "ies"}`
+          : `Imported ${result.entriesImported} embedded lorebook entr${result.entriesImported === 1 ? "y" : "ies"}`,
+      );
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to import embedded lorebook");
+    } finally {
+      setImporting(false);
+    }
+  };
 
   return (
     <div className="space-y-4">
@@ -1739,6 +1787,39 @@ function LorebookTab({ formData }: { formData: CharacterData }) {
         title="Character Lorebook"
         subtitle="World-building entries embedded in this character. Triggered by keywords in conversation."
       />
+
+      {hasEmbeddedLorebook && (
+        <div className="flex flex-wrap items-center gap-2 rounded-xl border border-[var(--border)] bg-[var(--secondary)] px-3 py-2.5">
+          <button
+            type="button"
+            onClick={handleImportEmbeddedLorebook}
+            disabled={!characterId || importing}
+            className={cn(
+              "inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium transition-all",
+              importing || !characterId
+                ? "cursor-not-allowed bg-[var(--accent)] text-[var(--muted-foreground)]"
+                : "bg-[var(--primary)]/15 text-[var(--primary)] hover:bg-[var(--primary)]/25",
+            )}
+          >
+            {importing ? <Loader2 size="0.75rem" className="animate-spin" /> : <Library size="0.75rem" />}
+            {linkedLorebookId ? "Reimport Embedded Lorebook" : "Import Embedded Lorebook"}
+          </button>
+          {linkedLorebookId && (
+            <button
+              type="button"
+              onClick={() => openLorebookDetail(linkedLorebookId)}
+              className="rounded-lg px-3 py-1.5 text-xs font-medium text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+            >
+              Open Linked Lorebook
+            </button>
+          )}
+          <span className="text-[0.6875rem] text-[var(--muted-foreground)]">
+            {linkedLorebookId
+              ? "Refreshes the linked lorebook in place so duplicates are not created."
+              : "Imports this embedded lorebook into Marinara as a linked lorebook."}
+          </span>
+        </div>
+      )}
 
       {entries.length === 0 ? (
         <div className="flex flex-col items-center gap-3 rounded-xl border-2 border-dashed border-[var(--border)] py-12 text-center">

--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -31,6 +31,7 @@ import {
 import { useChatStore } from "../../stores/chat.store";
 import { useGenerate } from "../../hooks/use-generate";
 import { useCharacters, usePersonas } from "../../hooks/use-characters";
+import { useConnections } from "../../hooks/use-connections";
 import { api } from "../../lib/api-client";
 import { useGameStateStore } from "../../stores/game-state.store";
 import { BookOpen, HelpCircle, MessageSquare, Theater } from "lucide-react";
@@ -45,8 +46,9 @@ import { APP_VERSION } from "@marinara-engine/shared";
 import { BUILT_IN_AGENTS } from "@marinara-engine/shared";
 import { useTranslationStore } from "../../hooks/use-translate";
 import { mirrorSpritePlacements, normalizeSpritePlacements } from "./sprite-placement";
-import type { CharacterMap, MessageWithSwipes, PeekPromptData } from "./chat-area.types";
+import type { CharacterMap, MessageSelectionToggle, MessageWithSwipes, PeekPromptData } from "./chat-area.types";
 import { RecentChats } from "./RecentChats";
+import { NewChatConnectionGate } from "./NewChatConnectionGate";
 
 export type { CharacterMap };
 
@@ -88,6 +90,7 @@ export function ChatArea() {
   const [deleteDialogMessageId, setDeleteDialogMessageId] = useState<string | null>(null);
   const [multiSelectMode, setMultiSelectMode] = useState(false);
   const [selectedMessageIds, setSelectedMessageIds] = useState<Set<string>>(new Set());
+  const [selectionAnchorIndex, setSelectionAnchorIndex] = useState<number | null>(null);
 
   const { data: chat } = useChat(activeChatId);
   const { data: allChats } = useChats();
@@ -104,8 +107,26 @@ export function ChatArea() {
   );
   const { data: messageCountData } = useChatMessageCount(activeChatId);
   const totalMessageCount = messageCountData?.count ?? messages?.length ?? 0;
+  const messageOffset = messages ? totalMessageCount - messages.length : 0;
+  const messageIdByOrderIndex = useMemo(() => {
+    const map = new Map<number, string>();
+    if (!messages) return map;
+    messages.forEach((message, index) => {
+      map.set(messageOffset + index, message.id);
+    });
+    return map;
+  }, [messageOffset, messages]);
+  const messageOrderIndexById = useMemo(() => {
+    const map = new Map<string, number>();
+    if (!messages) return map;
+    messages.forEach((message, index) => {
+      map.set(message.id, messageOffset + index);
+    });
+    return map;
+  }, [messageOffset, messages]);
   const { data: allCharacters } = useCharacters();
   const { data: allPersonas } = usePersonas();
+  const { data: connections } = useConnections();
   const deleteMessage = useDeleteMessage(activeChatId);
   const deleteMessages = useDeleteMessages(activeChatId);
   const updateMessage = useUpdateMessage(activeChatId);
@@ -116,11 +137,18 @@ export function ChatArea() {
   const { generate, retryAgents } = useGenerate();
   const setActiveSwipe = useSetActiveSwipe(activeChatId);
   const setActiveChatId = useChatStore((s) => s.setActiveChatId);
+  const pendingNewChatMode = useChatStore((s) => s.pendingNewChatMode);
   const failedAgentTypes = useAgentStore((s) => s.failedAgentTypes);
   const agentProcessing = useAgentStore((s) => s.isProcessing);
 
   const handleQuickStart = useCallback(
     (mode: "conversation" | "roleplay") => {
+      const connectionRows = ((connections ?? []) as Array<{ id: string }>).filter((connection) => !!connection.id);
+      if (connectionRows.length === 0) {
+        useChatStore.getState().setPendingNewChatMode(mode);
+        return;
+      }
+
       const label = mode === "conversation" ? "Conversation" : "Roleplay";
       createChat.mutate(
         { name: `New ${label}`, mode, characterIds: [] },
@@ -133,7 +161,7 @@ export function ChatArea() {
         },
       );
     },
-    [createChat],
+    [connections, createChat],
   );
 
   // Build character lookup map
@@ -258,7 +286,7 @@ export function ChatArea() {
 
   // Sync translation config from chat metadata to the translation store
   useEffect(() => {
-    if (!chat) return;
+    if (!chat?.id) return;
     useTranslationStore.getState().setConfig({
       provider: chatMeta.translationProvider ?? "google",
       targetLanguage: chatMeta.translationTargetLang ?? "en",
@@ -442,19 +470,35 @@ export function ChatArea() {
   const handleDeleteMore = useCallback(() => {
     if (deleteDialogMessageId) {
       setSelectedMessageIds(new Set([deleteDialogMessageId]));
+      setSelectionAnchorIndex(messageOrderIndexById.get(deleteDialogMessageId) ?? null);
     }
     setDeleteDialogMessageId(null);
     setMultiSelectMode(true);
-  }, [deleteDialogMessageId]);
+  }, [deleteDialogMessageId, messageOrderIndexById]);
 
-  const handleToggleSelectMessage = useCallback((messageId: string) => {
+  const handleToggleSelectMessage = useCallback((toggle: MessageSelectionToggle) => {
+    const { messageId, orderIndex, checked, shiftKey } = toggle;
     setSelectedMessageIds((prev) => {
       const next = new Set(prev);
-      if (next.has(messageId)) next.delete(messageId);
-      else next.add(messageId);
+      if (shiftKey && selectionAnchorIndex != null) {
+        const start = Math.min(selectionAnchorIndex, orderIndex);
+        const end = Math.max(selectionAnchorIndex, orderIndex);
+        for (let current = start; current <= end; current++) {
+          const rangeMessageId = messageIdByOrderIndex.get(current);
+          if (!rangeMessageId) continue;
+          if (checked) next.add(rangeMessageId);
+          else next.delete(rangeMessageId);
+        }
+      } else {
+        if (checked) next.add(messageId);
+        else next.delete(messageId);
+      }
       return next;
     });
-  }, []);
+    if (!shiftKey || selectionAnchorIndex == null) {
+      setSelectionAnchorIndex(orderIndex);
+    }
+  }, [messageIdByOrderIndex, selectionAnchorIndex]);
 
   const handleBulkDelete = useCallback(() => {
     if (selectedMessageIds.size > 0) {
@@ -462,12 +506,20 @@ export function ChatArea() {
     }
     setMultiSelectMode(false);
     setSelectedMessageIds(new Set());
+    setSelectionAnchorIndex(null);
   }, [selectedMessageIds, deleteMessages]);
 
   const handleCancelMultiSelect = useCallback(() => {
     setMultiSelectMode(false);
     setSelectedMessageIds(new Set());
+    setSelectionAnchorIndex(null);
   }, []);
+
+  useEffect(() => {
+    setMultiSelectMode(false);
+    setSelectedMessageIds(new Set());
+    setSelectionAnchorIndex(null);
+  }, [activeChatId]);
 
   const handleRegenerate = useCallback(
     async (messageId: string) => {
@@ -694,11 +746,12 @@ export function ChatArea() {
   // ═══════════════════════════════════════════════
   if (!activeChatId) {
     return (
-      <div
-        data-component="ChatArea.EmptyState"
-        className="flex flex-1 flex-col items-center overflow-y-auto p-4 sm:p-8"
-      >
-        <div className="flex w-full max-w-md flex-col items-center gap-6 my-auto py-4">
+      <>
+        <div
+          data-component="ChatArea.EmptyState"
+          className="flex flex-1 flex-col items-center overflow-y-auto p-4 sm:p-8"
+        >
+          <div className="flex w-full max-w-md flex-col items-center gap-6 my-auto py-4">
           {/* Central hero */}
           <div className="relative">
             <div className="animate-pulse-ring bunny-glow flex h-20 w-20 items-center justify-center rounded-2xl shadow-xl shadow-orange-500/20 overflow-hidden">
@@ -824,8 +877,15 @@ export function ChatArea() {
 
             <p className="mt-2 text-[0.625rem] tracking-wide text-[var(--muted-foreground)]/30">v{APP_VERSION}</p>
           </div>
+          </div>
         </div>
-      </div>
+        {pendingNewChatMode && (
+          <NewChatConnectionGate
+            mode={pendingNewChatMode}
+            onClose={() => useChatStore.getState().setPendingNewChatMode(null)}
+          />
+        )}
+      </>
     );
   }
 
@@ -872,24 +932,118 @@ export function ChatArea() {
   // ═══════════════════════════════════════════════
   if (chatMode === "conversation") {
     return (
+      <>
+        <Suspense fallback={surfaceFallback}>
+          <ChatConversationSurface
+            activeChatId={activeChatId}
+            chat={chat}
+            messages={messages}
+            isLoading={isLoading}
+            hasNextPage={!!hasNextPage}
+            isFetchingNextPage={isFetchingNextPage}
+            fetchNextPage={fetchNextPage}
+            pageCount={pageCount}
+            totalMessageCount={totalMessageCount}
+            characterMap={characterMap}
+            characterNames={characterNames}
+            personaInfo={personaInfo}
+            chatMeta={chatMeta}
+            chatCharIds={chatCharIds}
+            connectedChatName={connectedChatName}
+            sceneInfo={conversationSceneInfo}
+            settingsOpen={settingsOpen}
+            filesOpen={filesOpen}
+            galleryOpen={galleryOpen}
+            wizardOpen={wizardOpen}
+            peekPromptData={peekPromptData}
+            deleteDialogMessageId={deleteDialogMessageId}
+            multiSelectMode={multiSelectMode}
+            selectedMessageIds={selectedMessageIds}
+            spriteArrangeMode={spriteArrangeMode}
+            onDelete={handleDelete}
+            onRegenerate={handleRegenerate}
+            onEdit={handleEdit}
+            onPeekPrompt={handlePeekPrompt}
+            onToggleSelectMessage={handleToggleSelectMessage}
+            onSwitchChat={chat?.connectedChatId ? () => setActiveChatId(chat.connectedChatId!) : undefined}
+            onConcludeScene={chatMeta.sceneStatus === "active" ? () => concludeScene(activeChatId) : undefined}
+            onAbandonScene={chatMeta.sceneStatus === "active" ? () => abandonScene(activeChatId) : undefined}
+            onOpenSettings={() => setSettingsOpen(true)}
+            onOpenFiles={() => setFilesOpen(true)}
+            onOpenGallery={() => setGalleryOpen(true)}
+            onCloseSettings={() => setSettingsOpen(false)}
+            onCloseFiles={() => setFilesOpen(false)}
+            onCloseGallery={() => setGalleryOpen(false)}
+            onWizardFinish={() => {
+              setWizardOpen(false);
+              setSettingsOpen(true);
+            }}
+            onClosePeekPrompt={() => setPeekPromptData(null)}
+            onResetSpritePlacements={handleResetSpritePlacements}
+            onSpriteSideChange={handleSetSpritePosition}
+            onToggleSpriteArrange={() => setSpriteArrangeMode((prev) => !prev)}
+            onDeleteConfirm={handleDeleteConfirm}
+            onDeleteMore={handleDeleteMore}
+            onCloseDeleteDialog={() => setDeleteDialogMessageId(null)}
+            onBulkDelete={handleBulkDelete}
+            onCancelMultiSelect={handleCancelMultiSelect}
+            lastAssistantMessageId={lastAssistantMessageId}
+          />
+        </Suspense>
+        {pendingNewChatMode && (
+          <NewChatConnectionGate
+            mode={pendingNewChatMode}
+            onClose={() => useChatStore.getState().setPendingNewChatMode(null)}
+          />
+        )}
+      </>
+    );
+  }
+
+  // ═══════════════════════════════════════════════
+  // Roleplay / Visual Novel mode — existing layout
+  // ═══════════════════════════════════════════════
+  const shouldAnimateMessages = !hasAnimatedRef.current;
+  if (messages?.length) hasAnimatedRef.current = true;
+
+  return (
+    <>
       <Suspense fallback={surfaceFallback}>
-        <ChatConversationSurface
+        <ChatRoleplaySurface
           activeChatId={activeChatId}
           chat={chat}
-          messages={messages}
-          isLoading={isLoading}
-          hasNextPage={!!hasNextPage}
-          isFetchingNextPage={isFetchingNextPage}
-          fetchNextPage={fetchNextPage}
-          pageCount={pageCount}
-          totalMessageCount={totalMessageCount}
+          allChats={chatList}
+          chatMeta={chatMeta}
+          chatMode={chatMode}
+          isRoleplay={isRoleplay}
+          centerCompact={centerCompact}
+          chatBackground={chatBackground}
+          weatherEffects={weatherEffects}
+          expressionAgentEnabled={expressionAgentEnabled}
+          combatAgentEnabled={combatAgentEnabled}
+          encounterActive={encounterActive}
+          spritePosition={spritePosition}
+          spriteCharacterIds={spriteCharacterIds}
+          spriteExpressions={spriteExpressions}
+          spritePlacements={spritePlacements}
+          hasCustomSpritePlacements={hasCustomSpritePlacements}
+          spriteArrangeMode={spriteArrangeMode}
+          enabledAgentTypes={enabledAgentTypes}
+          chatCharIds={chatCharIds}
           characterMap={characterMap}
           characterNames={characterNames}
           personaInfo={personaInfo}
-          chatMeta={chatMeta}
-          chatCharIds={chatCharIds}
-          connectedChatName={connectedChatName}
-          sceneInfo={conversationSceneInfo}
+          messages={messages}
+          msgPayload={msgPayload}
+          isLoading={isLoading}
+          hasNextPage={!!hasNextPage}
+          isFetchingNextPage={isFetchingNextPage}
+          isStreaming={isStreaming}
+          regenerateMessageId={regenerateMessageId}
+          shouldAnimateMessages={shouldAnimateMessages}
+          summaryContextSize={summaryContextSize}
+          totalMessageCount={totalMessageCount}
+          lastAssistantMessageId={lastAssistantMessageId}
           settingsOpen={settingsOpen}
           filesOpen={filesOpen}
           galleryOpen={galleryOpen}
@@ -898,15 +1052,23 @@ export function ChatArea() {
           deleteDialogMessageId={deleteDialogMessageId}
           multiSelectMode={multiSelectMode}
           selectedMessageIds={selectedMessageIds}
-          spriteArrangeMode={spriteArrangeMode}
+          groupChatMode={groupChatMode}
+          scrollRef={scrollRef}
+          messagesEndRef={messagesEndRef}
+          onLoadMore={handleLoadMore}
           onDelete={handleDelete}
           onRegenerate={handleRegenerate}
           onEdit={handleEdit}
+          onSetActiveSwipe={handleSetActiveSwipe}
+          onToggleConversationStart={handleToggleConversationStart}
           onPeekPrompt={handlePeekPrompt}
+          onBranch={handleBranch}
           onToggleSelectMessage={handleToggleSelectMessage}
-          onSwitchChat={chat?.connectedChatId ? () => setActiveChatId(chat.connectedChatId!) : undefined}
-          onConcludeScene={chatMeta.sceneStatus === "active" ? () => concludeScene(activeChatId) : undefined}
-          onAbandonScene={chatMeta.sceneStatus === "active" ? () => abandonScene(activeChatId) : undefined}
+          onSummaryContextSizeChange={handleSummaryContextSizeChange}
+          onRerunTrackers={handleRerunTrackers}
+          onStartEncounter={() => startEncounter()}
+          onConcludeScene={() => concludeScene(activeChatId)}
+          onAbandonScene={() => abandonScene(activeChatId)}
           onOpenSettings={() => setSettingsOpen(true)}
           onOpenFiles={() => setFilesOpen(true)}
           onOpenGallery={() => setGalleryOpen(true)}
@@ -921,110 +1083,24 @@ export function ChatArea() {
           onResetSpritePlacements={handleResetSpritePlacements}
           onSpriteSideChange={handleSetSpritePosition}
           onToggleSpriteArrange={() => setSpriteArrangeMode((prev) => !prev)}
+          onToggleSpritePosition={handleToggleSpritePosition}
+          onExpressionChange={handleExpressionChange}
+          onSpritePlacementChange={handleSpritePlacementChange}
           onDeleteConfirm={handleDeleteConfirm}
           onDeleteMore={handleDeleteMore}
           onCloseDeleteDialog={() => setDeleteDialogMessageId(null)}
           onBulkDelete={handleBulkDelete}
           onCancelMultiSelect={handleCancelMultiSelect}
-          lastAssistantMessageId={lastAssistantMessageId}
+          isGrouped={isGrouped}
         />
       </Suspense>
-    );
-  }
-
-  // ═══════════════════════════════════════════════
-  // Roleplay / Visual Novel mode — existing layout
-  // ═══════════════════════════════════════════════
-  const shouldAnimateMessages = !hasAnimatedRef.current;
-  if (messages?.length) hasAnimatedRef.current = true;
-
-  return (
-    <Suspense fallback={surfaceFallback}>
-      <ChatRoleplaySurface
-        activeChatId={activeChatId}
-        chat={chat}
-        allChats={chatList}
-        chatMeta={chatMeta}
-        chatMode={chatMode}
-        isRoleplay={isRoleplay}
-        centerCompact={centerCompact}
-        chatBackground={chatBackground}
-        weatherEffects={weatherEffects}
-        expressionAgentEnabled={expressionAgentEnabled}
-        combatAgentEnabled={combatAgentEnabled}
-        encounterActive={encounterActive}
-        spritePosition={spritePosition}
-        spriteCharacterIds={spriteCharacterIds}
-        spriteExpressions={spriteExpressions}
-        spritePlacements={spritePlacements}
-        hasCustomSpritePlacements={hasCustomSpritePlacements}
-        spriteArrangeMode={spriteArrangeMode}
-        enabledAgentTypes={enabledAgentTypes}
-        chatCharIds={chatCharIds}
-        characterMap={characterMap}
-        characterNames={characterNames}
-        personaInfo={personaInfo}
-        messages={messages}
-        msgPayload={msgPayload}
-        isLoading={isLoading}
-        hasNextPage={!!hasNextPage}
-        isFetchingNextPage={isFetchingNextPage}
-        isStreaming={isStreaming}
-        regenerateMessageId={regenerateMessageId}
-        shouldAnimateMessages={shouldAnimateMessages}
-        summaryContextSize={summaryContextSize}
-        totalMessageCount={totalMessageCount}
-        lastAssistantMessageId={lastAssistantMessageId}
-        settingsOpen={settingsOpen}
-        filesOpen={filesOpen}
-        galleryOpen={galleryOpen}
-        wizardOpen={wizardOpen}
-        peekPromptData={peekPromptData}
-        deleteDialogMessageId={deleteDialogMessageId}
-        multiSelectMode={multiSelectMode}
-        selectedMessageIds={selectedMessageIds}
-        groupChatMode={groupChatMode}
-        scrollRef={scrollRef}
-        messagesEndRef={messagesEndRef}
-        onLoadMore={handleLoadMore}
-        onDelete={handleDelete}
-        onRegenerate={handleRegenerate}
-        onEdit={handleEdit}
-        onSetActiveSwipe={handleSetActiveSwipe}
-        onToggleConversationStart={handleToggleConversationStart}
-        onPeekPrompt={handlePeekPrompt}
-        onBranch={handleBranch}
-        onToggleSelectMessage={handleToggleSelectMessage}
-        onSummaryContextSizeChange={handleSummaryContextSizeChange}
-        onRerunTrackers={handleRerunTrackers}
-        onStartEncounter={() => startEncounter()}
-        onConcludeScene={() => concludeScene(activeChatId)}
-        onAbandonScene={() => abandonScene(activeChatId)}
-        onOpenSettings={() => setSettingsOpen(true)}
-        onOpenFiles={() => setFilesOpen(true)}
-        onOpenGallery={() => setGalleryOpen(true)}
-        onCloseSettings={() => setSettingsOpen(false)}
-        onCloseFiles={() => setFilesOpen(false)}
-        onCloseGallery={() => setGalleryOpen(false)}
-        onWizardFinish={() => {
-          setWizardOpen(false);
-          setSettingsOpen(true);
-        }}
-        onClosePeekPrompt={() => setPeekPromptData(null)}
-        onResetSpritePlacements={handleResetSpritePlacements}
-        onSpriteSideChange={handleSetSpritePosition}
-        onToggleSpriteArrange={() => setSpriteArrangeMode((prev) => !prev)}
-        onToggleSpritePosition={handleToggleSpritePosition}
-        onExpressionChange={handleExpressionChange}
-        onSpritePlacementChange={handleSpritePlacementChange}
-        onDeleteConfirm={handleDeleteConfirm}
-        onDeleteMore={handleDeleteMore}
-        onCloseDeleteDialog={() => setDeleteDialogMessageId(null)}
-        onBulkDelete={handleBulkDelete}
-        onCancelMultiSelect={handleCancelMultiSelect}
-        isGrouped={isGrouped}
-      />
-    </Suspense>
+      {pendingNewChatMode && (
+        <NewChatConnectionGate
+          mode={pendingNewChatMode}
+          onClose={() => useChatStore.getState().setPendingNewChatMode(null)}
+        />
+      )}
+    </>
   );
 }
 

--- a/packages/client/src/components/chat/ChatConversationSurface.tsx
+++ b/packages/client/src/components/chat/ChatConversationSurface.tsx
@@ -2,7 +2,7 @@ import type { ComponentProps } from "react";
 import type { Message, SpriteSide } from "@marinara-engine/shared";
 import { ConversationView } from "./ConversationView";
 import { ChatCommonOverlays } from "./ChatCommonOverlays";
-import type { CharacterMap, PeekPromptData, PersonaInfo } from "./chat-area.types";
+import type { CharacterMap, MessageSelectionToggle, PeekPromptData, PersonaInfo } from "./chat-area.types";
 
 type SceneInfo =
   | {
@@ -46,7 +46,7 @@ type ConversationSurfaceProps = {
   onRegenerate: (messageId: string) => void;
   onEdit: (messageId: string, content: string) => void;
   onPeekPrompt: () => void;
-  onToggleSelectMessage: (messageId: string) => void;
+  onToggleSelectMessage: (toggle: MessageSelectionToggle) => void;
   onSwitchChat?: () => void;
   onConcludeScene?: () => void;
   onAbandonScene?: () => void;

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -32,6 +32,7 @@ import { useUIStore } from "../../stores/ui.store";
 import { useTranslate } from "../../hooks/use-translate";
 import { api } from "../../lib/api-client";
 import DOMPurify from "dompurify";
+import type { MessageSelectionToggle } from "./chat-area.types";
 
 /** Isolated edit textarea — uncontrolled to avoid React re-renders on every keystroke. */
 const EditTextarea = memo(function EditTextarea({
@@ -133,9 +134,10 @@ interface ChatMessageProps {
   messageDepth?: number;
   /** 1-based ordinal position in the message list. Shown under avatar when actions visible. */
   messageIndex?: number;
+  messageOrderIndex?: number;
   multiSelectMode?: boolean;
   isSelected?: boolean;
-  onToggleSelect?: (messageId: string) => void;
+  onToggleSelect?: (toggle: MessageSelectionToggle) => void;
 }
 
 /** Regex to match a plain image URL as the entire content. */
@@ -433,6 +435,7 @@ export const ChatMessage = memo(function ChatMessage({
   chatCharacterIds,
   messageDepth,
   messageIndex,
+  messageOrderIndex,
   multiSelectMode,
   isSelected,
   onToggleSelect,
@@ -522,7 +525,12 @@ export const ChatMessage = memo(function ChatMessage({
     (e: React.MouseEvent) => {
       // In multi-select mode, clicking toggles selection on any device
       if (multiSelectMode) {
-        onToggleSelect?.(message.id);
+        onToggleSelect?.({
+          messageId: message.id,
+          orderIndex: messageOrderIndex ?? 0,
+          checked: !isSelected,
+          shiftKey: e.shiftKey,
+        });
         return;
       }
       // Only toggle on touch devices
@@ -532,7 +540,7 @@ export const ChatMessage = memo(function ChatMessage({
       if (target.closest("button, a, textarea")) return;
       setShowActions((v) => !v);
     },
-    [multiSelectMode, onToggleSelect, message.id],
+    [isSelected, message.id, messageOrderIndex, multiSelectMode, onToggleSelect],
   );
 
   // Parse message extra for conversation start flag
@@ -805,12 +813,34 @@ export const ChatMessage = memo(function ChatMessage({
       return (
         <div
           ref={msgRef}
-          className="mari-message mari-message-narrator rpg-narrator-msg group mb-4 px-2"
+          className={cn(
+            "mari-message mari-message-narrator rpg-narrator-msg group mb-4 px-2",
+            multiSelectMode && isSelected && "rounded-lg bg-[var(--destructive)]/5 ring-2 ring-[var(--destructive)]/50",
+          )}
           onClick={handleMobileTap}
         >
-          <div className="mari-message-bubble relative rounded-xl border border-amber-500/10 bg-black/40 px-5 py-4">
+          <div className="flex gap-3">
+            {multiSelectMode && (
+              <div className="flex flex-shrink-0 items-start pt-2">
+                <button
+                  type="button"
+                  role="checkbox"
+                  aria-checked={isSelected}
+                  aria-label={isSelected ? "Deselect message" : "Select message"}
+                  className={cn(
+                    "flex h-5 w-5 items-center justify-center rounded border-2 transition-colors",
+                    isSelected
+                      ? "border-[var(--destructive)] bg-[var(--destructive)]"
+                      : "border-[var(--muted-foreground)]/40 bg-[var(--secondary)]",
+                  )}
+                >
+                  {isSelected && <span className="text-xs font-bold text-white">✓</span>}
+                </button>
+              </div>
+            )}
+            <div className="mari-message-bubble relative flex-1 rounded-xl border border-amber-500/10 bg-black/40 px-5 py-4">
             {/* Delete button */}
-            {onDelete && (
+            {!multiSelectMode && onDelete && (
               <button
                 onClick={() => onDelete(message.id)}
                 className={cn(
@@ -829,6 +859,7 @@ export const ChatMessage = memo(function ChatMessage({
             </div>
             <div className="mari-message-content whitespace-pre-wrap break-words italic" style={messageTextStyle}>
               {displayContent}
+            </div>
             </div>
           </div>
         </div>

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -36,7 +36,7 @@ import { ChatInput } from "./ChatInput";
 import { CyoaChoices } from "./CyoaChoices";
 import { EndSceneBar } from "./SceneBanner";
 import { ChatCommonOverlays } from "./ChatCommonOverlays";
-import type { CharacterMap, MessageWithSwipes, PeekPromptData, PersonaInfo } from "./chat-area.types";
+import type { CharacterMap, MessageSelectionToggle, MessageWithSwipes, PeekPromptData, PersonaInfo } from "./chat-area.types";
 
 type ChatData = ComponentProps<typeof ChatCommonOverlays>["chat"];
 
@@ -585,7 +585,7 @@ type RoleplaySurfaceProps = {
   onToggleConversationStart: (messageId: string, current: boolean) => void;
   onPeekPrompt: () => void;
   onBranch: (messageId: string) => void;
-  onToggleSelectMessage: (messageId: string) => void;
+  onToggleSelectMessage: (toggle: MessageSelectionToggle) => void;
   onSummaryContextSizeChange: (size: number) => void;
   onRerunTrackers: () => void;
   onStartEncounter: () => void;
@@ -958,6 +958,7 @@ export function ChatRoleplaySurface({
                           chatMode={chatMode}
                           messageDepth={messages.length - 1 - i}
                           messageIndex={totalMessageCount - messages.length + i + 1}
+                          messageOrderIndex={totalMessageCount - messages.length + i}
                           isGrouped={isGrouped(i)}
                           groupChatMode={groupChatMode}
                           chatCharacterIds={chatCharIds}
@@ -982,6 +983,7 @@ export function ChatRoleplaySurface({
                           chatMode={chatMode}
                           messageDepth={messages.length - 1 - i}
                           messageIndex={totalMessageCount - messages.length + i + 1}
+                          messageOrderIndex={totalMessageCount - messages.length + i}
                           isGrouped={isGrouped(i)}
                           groupChatMode={groupChatMode}
                           chatCharacterIds={chatCharIds}

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -2471,8 +2471,8 @@ const CHAT_PARAM_DEFAULTS: Required<ChatParameters> = {
   topK: 0,
   frequencyPenalty: 0,
   presencePenalty: 0,
-  reasoningEffort: "low",
-  verbosity: "low",
+  reasoningEffort: null,
+  verbosity: null,
 };
 
 const ROLEPLAY_PARAM_DEFAULTS: Required<ChatParameters> = {
@@ -2482,8 +2482,8 @@ const ROLEPLAY_PARAM_DEFAULTS: Required<ChatParameters> = {
   topK: 0,
   frequencyPenalty: 0,
   presencePenalty: 0,
-  reasoningEffort: "maximum",
-  verbosity: "high",
+  reasoningEffort: null,
+  verbosity: null,
 };
 
 const DEFAULT_CONVERSATION_PROMPT = `<role>
@@ -2637,7 +2637,7 @@ function AdvancedParametersSection({
               <div className="mt-1 flex gap-1.5">
                 {([null, "low", "medium", "high", "maximum"] as const).map((level) => (
                   <button
-                    key={level ?? "none"}
+                    key={level ?? "auto"}
                     onClick={() => set("reasoningEffort", level)}
                     className={cn(
                       "rounded-lg px-2 py-1 text-[0.625rem] font-medium transition-all",
@@ -2646,7 +2646,7 @@ function AdvancedParametersSection({
                         : "bg-[var(--secondary)] text-[var(--muted-foreground)] ring-1 ring-[var(--border)] hover:bg-[var(--accent)]",
                     )}
                   >
-                    {level ? level.charAt(0).toUpperCase() + level.slice(1) : "None"}
+                    {level ? level.charAt(0).toUpperCase() + level.slice(1) : "Auto"}
                   </button>
                 ))}
               </div>
@@ -2662,7 +2662,7 @@ function AdvancedParametersSection({
               <div className="mt-1 flex gap-1.5">
                 {([null, "low", "medium", "high"] as const).map((level) => (
                   <button
-                    key={level ?? "none"}
+                    key={level ?? "auto"}
                     onClick={() => set("verbosity", level)}
                     className={cn(
                       "rounded-lg px-2 py-1 text-[0.625rem] font-medium transition-all",
@@ -2671,7 +2671,7 @@ function AdvancedParametersSection({
                         : "bg-[var(--secondary)] text-[var(--muted-foreground)] ring-1 ring-[var(--border)] hover:bg-[var(--accent)]",
                     )}
                   >
-                    {level ? level.charAt(0).toUpperCase() + level.slice(1) : "None"}
+                    {level ? level.charAt(0).toUpperCase() + level.slice(1) : "Auto"}
                   </button>
                 ))}
               </div>

--- a/packages/client/src/components/chat/ConversationMessage.tsx
+++ b/packages/client/src/components/chat/ConversationMessage.tsx
@@ -12,6 +12,7 @@ import { chatKeys } from "../../hooks/use-chats";
 import type { CharacterMap } from "./ChatArea";
 import { useTranslate } from "../../hooks/use-translate";
 import { api } from "../../lib/api-client";
+import type { MessageSelectionToggle } from "./chat-area.types";
 
 /** Build style object for name color (supports gradients). */
 function nameColorStyle(color?: string): React.CSSProperties | undefined {
@@ -221,9 +222,10 @@ interface ConversationMessageProps {
   onEditClick?: () => void;
   /** 1-based ordinal position in the message list. Shown under avatar when actions visible. */
   messageIndex?: number;
+  messageOrderIndex?: number;
   multiSelectMode?: boolean;
   isSelected?: boolean;
-  onToggleSelect?: (messageId: string) => void;
+  onToggleSelect?: (toggle: MessageSelectionToggle) => void;
 }
 
 export const ConversationMessage = memo(function ConversationMessage({
@@ -242,6 +244,7 @@ export const ConversationMessage = memo(function ConversationMessage({
   personaInfo,
   onEditClick,
   messageIndex,
+  messageOrderIndex,
   multiSelectMode,
   isSelected,
   onToggleSelect,
@@ -438,9 +441,14 @@ export const ConversationMessage = memo(function ConversationMessage({
           isStreaming && "bg-[var(--secondary)]/20",
           multiSelectMode && isSelected && "bg-[var(--destructive)]/10",
         )}
-        onClick={() => {
+        onClick={(e) => {
           if (multiSelectMode) {
-            onToggleSelect?.(message.id);
+            onToggleSelect?.({
+              messageId: message.id,
+              orderIndex: messageOrderIndex ?? 0,
+              checked: !isSelected,
+              shiftKey: e.shiftKey,
+            });
           } else {
             setShowActions((v) => !v);
           }
@@ -655,9 +663,14 @@ export const ConversationMessage = memo(function ConversationMessage({
       )}
       data-message-id={message.id}
       data-message-role={message.role}
-      onClick={() => {
+      onClick={(e) => {
         if (multiSelectMode) {
-          onToggleSelect?.(message.id);
+          onToggleSelect?.({
+            messageId: message.id,
+            orderIndex: messageOrderIndex ?? 0,
+            checked: !isSelected,
+            shiftKey: e.shiftKey,
+          });
         } else {
           setShowActions((v) => !v);
         }

--- a/packages/client/src/components/chat/ConversationView.tsx
+++ b/packages/client/src/components/chat/ConversationView.tsx
@@ -12,7 +12,7 @@ import { useUIStore } from "../../stores/ui.store";
 import { playNotificationPing } from "../../lib/notification-sound";
 import { characterKeys } from "../../hooks/use-characters";
 import { api } from "../../lib/api-client";
-import type { CharacterMap, PersonaInfo } from "./chat-area.types";
+import type { CharacterMap, MessageSelectionToggle, PersonaInfo } from "./chat-area.types";
 import type { Message } from "@marinara-engine/shared";
 
 const ConversationAutonomousEffects = lazy(async () => {
@@ -44,7 +44,7 @@ interface ConversationViewProps {
   onOpenGallery: () => void;
   multiSelectMode?: boolean;
   selectedMessageIds?: Set<string>;
-  onToggleSelectMessage?: (messageId: string) => void;
+  onToggleSelectMessage?: (toggle: MessageSelectionToggle) => void;
   connectedChatName?: string;
   onSwitchChat?: () => void;
   sceneInfo?: {
@@ -728,6 +728,7 @@ export function ConversationView({
                 characterMap={characterMap}
                 personaInfo={personaInfo as any}
                 messageIndex={item.index + 1}
+                messageOrderIndex={item.index}
                 multiSelectMode={multiSelectMode}
                 isSelected={selectedMessageIds?.has(msg.id)}
                 onToggleSelect={onToggleSelectMessage}

--- a/packages/client/src/components/chat/NewChatConnectionGate.tsx
+++ b/packages/client/src/components/chat/NewChatConnectionGate.tsx
@@ -1,0 +1,150 @@
+import { useEffect, useMemo, useState } from "react";
+import { Loader2, MessageCircle, Plug, X, BookOpen } from "lucide-react";
+import { useConnections } from "../../hooks/use-connections";
+import { useCreateChat } from "../../hooks/use-chats";
+import { useChatStore } from "../../stores/chat.store";
+import { useUIStore } from "../../stores/ui.store";
+import { cn } from "../../lib/utils";
+
+type Mode = "conversation" | "roleplay";
+
+const MODE_META: Record<Mode, { label: string; icon: React.ReactNode }> = {
+  conversation: { label: "Conversation", icon: <MessageCircle size="0.875rem" /> },
+  roleplay: { label: "Roleplay", icon: <BookOpen size="0.875rem" /> },
+};
+
+interface NewChatConnectionGateProps {
+  mode: Mode;
+  onClose: () => void;
+}
+
+export function NewChatConnectionGate({ mode, onClose }: NewChatConnectionGateProps) {
+  const { data: connections, isLoading } = useConnections();
+  const createChat = useCreateChat();
+  const openRightPanel = useUIStore((s) => s.openRightPanel);
+  const [connectionId, setConnectionId] = useState<string>("");
+
+  const connectionRows = useMemo(
+    () => ((connections ?? []) as Array<{ id: string; name: string }>),
+    [connections],
+  );
+
+  useEffect(() => {
+    if (connectionRows.length === 0) {
+      setConnectionId("");
+      return;
+    }
+    setConnectionId((current) => current || connectionRows[0]!.id);
+  }, [connectionRows]);
+
+  const handleCreate = () => {
+    if (!connectionId) return;
+    const label = MODE_META[mode].label;
+    createChat.mutate(
+      {
+        name: `New ${label}`,
+        mode,
+        characterIds: [],
+        connectionId,
+      },
+      {
+        onSuccess: (chat) => {
+          const store = useChatStore.getState();
+          store.setPendingNewChatMode(null);
+          store.setActiveChatId(chat.id);
+          store.setShouldOpenSettings(true);
+          store.setShouldOpenWizard(true);
+        },
+      },
+    );
+  };
+
+  const showEmptyState = !isLoading && connectionRows.length === 0;
+
+  return (
+    <>
+      <div className="fixed inset-0 z-40 bg-black/40 backdrop-blur-[3px]" onClick={onClose} />
+      <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+        <div className="w-full max-w-sm overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--card)] shadow-2xl">
+          <div className="flex items-center justify-between border-b border-[var(--border)] px-4 py-3">
+            <div className="flex items-center gap-2">
+              <span className="text-[var(--primary)]">{MODE_META[mode].icon}</span>
+              <div>
+                <h3 className="text-sm font-semibold">Set Up {MODE_META[mode].label}</h3>
+                <p className="text-[0.6875rem] text-[var(--muted-foreground)]">Choose a connection before we create the chat.</p>
+              </div>
+            </div>
+            <button
+              onClick={onClose}
+              className="rounded-md p-1 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--secondary)] hover:text-[var(--foreground)]"
+            >
+              <X size="0.875rem" />
+            </button>
+          </div>
+
+          <div className="space-y-4 px-4 py-4">
+            {showEmptyState ? (
+              <div className="rounded-xl border border-[var(--primary)]/20 bg-[var(--primary)]/8 p-4">
+                <div className="mb-2 flex items-center gap-2 text-sm font-medium text-[var(--foreground)]">
+                  <Plug size="0.875rem" className="text-[var(--primary)]" />
+                  No connections found
+                </div>
+                <p className="text-xs text-[var(--muted-foreground)]">
+                  Create a connection first, then come back here and we&apos;ll continue without creating a ghost chat.
+                </p>
+                <button
+                  onClick={() => openRightPanel("connections")}
+                  className="mt-3 flex w-full items-center justify-center gap-1.5 rounded-lg border border-[var(--primary)]/30 bg-[var(--primary)]/10 px-3 py-2 text-xs font-medium text-[var(--primary)] transition-all hover:bg-[var(--primary)]/20"
+                >
+                  <Plug size="0.75rem" />
+                  Open Connections
+                </button>
+              </div>
+            ) : (
+              <div className="space-y-1.5">
+                <label className="text-[0.6875rem] font-medium uppercase tracking-wider text-[var(--muted-foreground)]">
+                  Connection
+                </label>
+                <select
+                  value={connectionId}
+                  onChange={(e) => setConnectionId(e.target.value)}
+                  disabled={createChat.isPending}
+                  className="w-full rounded-lg bg-[var(--secondary)] px-3 py-2.5 text-xs outline-none ring-1 ring-[var(--border)] transition-shadow focus:ring-[var(--primary)]/40"
+                >
+                  <option value="">Select a connection…</option>
+                  {connectionRows.map((connection) => (
+                    <option key={connection.id} value={connection.id}>
+                      {connection.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
+          </div>
+
+          <div className="flex items-center justify-between border-t border-[var(--border)] px-4 py-3">
+            <button
+              onClick={onClose}
+              className="rounded-lg px-3 py-1.5 text-xs text-[var(--muted-foreground)] transition-colors hover:bg-[var(--secondary)] hover:text-[var(--foreground)]"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleCreate}
+              disabled={showEmptyState || !connectionId || createChat.isPending}
+              className={cn(
+                "flex items-center gap-1.5 rounded-lg px-4 py-1.5 text-xs font-medium shadow-sm transition-all active:scale-95",
+                showEmptyState || !connectionId || createChat.isPending
+                  ? "cursor-not-allowed bg-[var(--secondary)] text-[var(--muted-foreground)] opacity-60"
+                  : "bg-[var(--primary)] text-[var(--primary-foreground)] hover:opacity-90",
+              )}
+            >
+              {createChat.isPending ? <Loader2 size="0.75rem" className="animate-spin" /> : MODE_META[mode].icon}
+              Create Chat
+            </button>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/packages/client/src/components/chat/chat-area.types.ts
+++ b/packages/client/src/components/chat/chat-area.types.ts
@@ -44,3 +44,10 @@ export type PeekPromptData = {
 export type MessageWithSwipes = Message & {
   swipes?: Array<{ id: string; content: string }>;
 };
+
+export type MessageSelectionToggle = {
+  messageId: string;
+  orderIndex: number;
+  checked: boolean;
+  shiftKey: boolean;
+};

--- a/packages/client/src/components/connections/ConnectionEditor.tsx
+++ b/packages/client/src/components/connections/ConnectionEditor.tsx
@@ -35,6 +35,7 @@ import {
   ExternalLink,
 } from "lucide-react";
 import { cn } from "../../lib/utils";
+import { DraftNumberInput } from "../ui/DraftNumberInput";
 import { HelpTooltip } from "../ui/HelpTooltip";
 import { PROVIDERS, MODEL_LISTS, IMAGE_GENERATION_SOURCES, type APIProvider } from "@marinara-engine/shared";
 
@@ -923,11 +924,12 @@ export function ConnectionEditor() {
               help="The maximum number of tokens this model can process at once (your messages + its reply). This is auto-set when you pick a model from the list."
             >
               <div className="flex items-center gap-3">
-                <input
-                  type="number"
+                <DraftNumberInput
                   value={localMaxContext}
-                  onChange={(e) => {
-                    setLocalMaxContext(Number(e.target.value) || 128000);
+                  min={0}
+                  selectOnFocus
+                  onCommit={(nextValue) => {
+                    setLocalMaxContext(nextValue);
                     markDirty();
                   }}
                   className="w-40 rounded-xl bg-[var(--secondary)] px-3 py-2.5 text-sm ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"

--- a/packages/client/src/components/layout/AppShell.tsx
+++ b/packages/client/src/components/layout/AppShell.tsx
@@ -9,7 +9,7 @@ import { useBackgroundAutonomousPolling } from "../../hooks/use-background-auton
 import { useIdleDetection } from "../../hooks/use-idle-detection";
 import { cn } from "../../lib/utils";
 import { motion, AnimatePresence } from "framer-motion";
-import { lazy, Suspense, useState, useEffect, useRef, useCallback } from "react";
+import { lazy, Suspense, useState, useEffect, useRef, useCallback, type MouseEvent as ReactMouseEvent } from "react";
 
 const ChatArea = lazy(() => import("../chat/ChatArea").then((module) => ({ default: module.ChatArea })));
 const CharacterEditor = lazy(() =>
@@ -74,7 +74,11 @@ export function AppShell() {
 
   const sidebarOpen = useUIStore((s) => s.sidebarOpen);
   const setSidebarOpen = useUIStore((s) => s.setSidebarOpen);
+  const sidebarWidth = useUIStore((s) => s.sidebarWidth);
+  const setSidebarWidth = useUIStore((s) => s.setSidebarWidth);
   const rightPanelOpen = useUIStore((s) => s.rightPanelOpen);
+  const rightPanelWidth = useUIStore((s) => s.rightPanelWidth);
+  const setRightPanelWidth = useUIStore((s) => s.setRightPanelWidth);
   const closeRightPanel = useUIStore((s) => s.closeRightPanel);
 
   // Track mobile breakpoint for right-panel animation strategy
@@ -95,7 +99,7 @@ export function AppShell() {
       rafId = requestAnimationFrame(() => {
         const { rightPanelOpen: rp, sidebarOpen: sb, sidebarWidth: sw, closeRightPanel: close } = useUIStore.getState();
         if (!rp) return;
-        const panelWidth = 320; // 20rem
+        const panelWidth = useUIStore.getState().rightPanelWidth;
         const reserved = (sb ? sw : 0) + panelWidth;
         if (window.innerWidth - reserved < 400) close();
       });
@@ -154,8 +158,6 @@ export function AppShell() {
     ro.observe(el);
     return () => ro.disconnect();
   }, [checkOverflow]);
-
-  const sidebarWidth = useUIStore((s) => s.sidebarWidth);
   const characterDetailId = useUIStore((s) => s.characterDetailId);
   const lorebookDetailId = useUIStore((s) => s.lorebookDetailId);
   const presetDetailId = useUIStore((s) => s.presetDetailId);
@@ -166,6 +168,56 @@ export function AppShell() {
   const regexDetailId = useUIStore((s) => s.regexDetailId);
   const botBrowserOpen = useUIStore((s) => s.botBrowserOpen);
   const hasCompletedOnboarding = useUIStore((s) => s.hasCompletedOnboarding);
+
+  const startSidebarResize = useCallback(
+    (event: ReactMouseEvent<HTMLDivElement>) => {
+      if (isMobile) return;
+      event.preventDefault();
+      const originalCursor = document.body.style.cursor;
+      const originalUserSelect = document.body.style.userSelect;
+      document.body.style.cursor = "col-resize";
+      document.body.style.userSelect = "none";
+
+      const onMove = (moveEvent: MouseEvent) => {
+        setSidebarWidth(moveEvent.clientX);
+      };
+      const onUp = () => {
+        document.body.style.cursor = originalCursor;
+        document.body.style.userSelect = originalUserSelect;
+        window.removeEventListener("mousemove", onMove);
+        window.removeEventListener("mouseup", onUp);
+      };
+
+      window.addEventListener("mousemove", onMove);
+      window.addEventListener("mouseup", onUp);
+    },
+    [isMobile, setSidebarWidth],
+  );
+
+  const startRightPanelResize = useCallback(
+    (event: ReactMouseEvent<HTMLDivElement>) => {
+      if (isMobile) return;
+      event.preventDefault();
+      const originalCursor = document.body.style.cursor;
+      const originalUserSelect = document.body.style.userSelect;
+      document.body.style.cursor = "col-resize";
+      document.body.style.userSelect = "none";
+
+      const onMove = (moveEvent: MouseEvent) => {
+        setRightPanelWidth(window.innerWidth - moveEvent.clientX);
+      };
+      const onUp = () => {
+        document.body.style.cursor = originalCursor;
+        document.body.style.userSelect = originalUserSelect;
+        window.removeEventListener("mousemove", onMove);
+        window.removeEventListener("mouseup", onUp);
+      };
+
+      window.addEventListener("mousemove", onMove);
+      window.addEventListener("mouseup", onUp);
+    },
+    [isMobile, setRightPanelWidth],
+  );
 
   const detailView = regexDetailId ? (
     <RegexScriptEditor />
@@ -223,6 +275,15 @@ export function AppShell() {
           <ChatSidebar />
         </div>
       </aside>
+      {!isMobile && sidebarOpen && (
+        <div
+          role="separator"
+          aria-orientation="vertical"
+          aria-label="Resize left sidebar"
+          onMouseDown={startSidebarResize}
+          className="relative z-20 hidden w-1 shrink-0 cursor-col-resize bg-transparent transition-colors hover:bg-[var(--primary)]/30 md:block"
+        />
+      )}
 
       {/* Center content */}
       <main
@@ -275,16 +336,26 @@ export function AppShell() {
             "mari-right-panel flex-shrink-0 overflow-hidden bg-[var(--background)]/80 backdrop-blur-xl transition-[width] duration-300 ease-[cubic-bezier(0.16,1,0.3,1)]",
             rightPanelOpen && "border-l border-[var(--sidebar-border)]/30",
           )}
-          style={{ width: rightPanelOpen ? "20rem" : 0 }}
+          style={{ width: rightPanelOpen ? rightPanelWidth : 0 }}
         >
           {rightPanelOpen && (
-            <div className="h-full" style={{ width: "20rem" }}>
+            <div className="h-full" style={{ width: rightPanelWidth }}>
               <Suspense fallback={<SidePanelFallback />}>
                 <RightPanel />
               </Suspense>
             </div>
           )}
         </aside>
+      )}
+      {!isMobile && rightPanelOpen && (
+        <div
+          role="separator"
+          aria-orientation="vertical"
+          aria-label="Resize right sidebar"
+          onMouseDown={startRightPanelResize}
+          className="absolute inset-y-0 hidden w-1 cursor-col-resize bg-transparent transition-colors hover:bg-[var(--primary)]/30 md:block"
+          style={{ right: rightPanelOpen ? rightPanelWidth : 0 }}
+        />
       )}
 
       {/* First-time onboarding tutorial */}

--- a/packages/client/src/components/layout/ChatSidebar.tsx
+++ b/packages/client/src/components/layout/ChatSidebar.tsx
@@ -20,6 +20,7 @@ import {
   GripVertical,
 } from "lucide-react";
 import { useChats, useCreateChat, useDeleteChat, useDeleteChatGroup } from "../../hooks/use-chats";
+import { useConnections } from "../../hooks/use-connections";
 import {
   useChatFolders,
   useCreateFolder,
@@ -67,6 +68,7 @@ const MODE_CONFIG: Record<
 
 export function ChatSidebar() {
   const { data: chats, isLoading } = useChats();
+  const { data: connections } = useConnections();
   const createChat = useCreateChat();
   const deleteChat = useDeleteChat();
   const deleteChatGroup = useDeleteChatGroup();
@@ -78,6 +80,7 @@ export function ChatSidebar() {
   const editorDirty = useUIStore((s) => s.editorDirty);
   const closeAllDetails = useUIStore((s) => s.closeAllDetails);
   const setSidebarOpen = useUIStore((s) => s.setSidebarOpen);
+  const setPendingNewChatMode = useChatStore((s) => s.setPendingNewChatMode);
 
   // Folder hooks
   const { data: folders } = useChatFolders();
@@ -267,6 +270,14 @@ export function ChatSidebar() {
 
   const handleNewChat = useCallback(
     (mode: ChatMode) => {
+      const connectionRows = ((connections ?? []) as Array<{ id: string }>).filter((connection) => !!connection.id);
+      if (connectionRows.length === 0) {
+        if (mode === "conversation" || mode === "roleplay") {
+          setPendingNewChatMode(mode);
+        }
+        return;
+      }
+
       createChat.mutate(
         { name: `New ${MODE_CONFIG[mode]?.label ?? mode}`, mode, characterIds: [] },
         {
@@ -278,7 +289,7 @@ export function ChatSidebar() {
         },
       );
     },
-    [createChat, setActiveChatId],
+    [connections, createChat, setActiveChatId, setPendingNewChatMode],
   );
 
   const handleNewChatFromTab = useCallback(() => {

--- a/packages/client/src/components/modals/ImportCharacterModal.tsx
+++ b/packages/client/src/components/modals/ImportCharacterModal.tsx
@@ -7,111 +7,153 @@ import { Download, FileJson, Image, CheckCircle, XCircle, Loader2 } from "lucide
 import { useQueryClient } from "@tanstack/react-query";
 import { characterKeys } from "../../hooks/use-characters";
 import { lorebookKeys } from "../../hooks/use-lorebooks";
-import { parsePngCharacterCard } from "../../lib/png-parser";
+import { api } from "../../lib/api-client";
 
 interface Props {
   open: boolean;
   onClose: () => void;
 }
 
+type ImportResultRow = {
+  filename: string;
+  success: boolean;
+  message: string;
+};
+
 export function ImportCharacterModal({ open, onClose }: Props) {
   const fileRef = useRef<HTMLInputElement>(null);
-  const [status, setStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
-  const [message, setMessage] = useState("");
+  const [status, setStatus] = useState<"idle" | "loading" | "done">("idle");
+  const [results, setResults] = useState<ImportResultRow[]>([]);
   const [dragOver, setDragOver] = useState(false);
   const qc = useQueryClient();
 
-  const handleFile = async (file: File) => {
+  const handleFiles = async (files: File[]) => {
+    if (files.length === 0) return;
     setStatus("loading");
-    setMessage("");
+    setResults([]);
 
     try {
-      const isPng = file.name.toLowerCase().endsWith(".png") || file.type === "image/png";
-      const isCharX = file.name.toLowerCase().endsWith(".charx");
+      const stCharacterFiles: File[] = [];
+      const marinaraPayloads: Array<{ file: File; payload: Record<string, unknown> }> = [];
 
-      // CharX files are zip archives — upload as multipart
-      if (isCharX) {
-        const form = new FormData();
-        form.append("file", file);
-        const res = await fetch("/api/import/st-character", {
-          method: "POST",
-          body: form,
-        });
-        const data = await res.json();
-        if (data.success) {
-          setStatus("success");
-          setMessage(`Imported "${data.name ?? file.name}" successfully!`);
-          qc.invalidateQueries({ queryKey: characterKeys.list() });
-          if (data.lorebook) {
-            qc.invalidateQueries({ queryKey: lorebookKeys.all });
-          }
-        } else {
-          setStatus("error");
-          setMessage(data.error ?? "Import failed");
+      for (const file of files) {
+        const lower = file.name.toLowerCase();
+        if (lower.endsWith(".png") || lower.endsWith(".charx")) {
+          stCharacterFiles.push(file);
+          continue;
         }
-        return;
-      }
 
-      let json: Record<string, unknown>;
-      let avatarDataUrl: string | null = null;
-
-      if (isPng) {
-        // Extract character JSON and image from PNG tEXt chunk
-        const result = await parsePngCharacterCard(file);
-        json = result.json;
-        avatarDataUrl = result.imageDataUrl;
-      } else {
-        // Plain JSON file
         const text = await file.text();
-        json = JSON.parse(text);
-      }
+        const json = JSON.parse(text) as Record<string, unknown>;
+        const isMarinaraEnvelope =
+          json.version === 1 && typeof json.type === "string" && (json.type as string).startsWith("marinara_");
 
-      // Detect Marinara envelope format and route to the native importer
-      const isMarinaraEnvelope =
-        json.version === 1 && typeof json.type === "string" && (json.type as string).startsWith("marinara_");
-
-      let res: Response;
-      if (isMarinaraEnvelope) {
-        res = await fetch("/api/import/marinara", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(json),
-        });
-      } else {
-        res = await fetch("/api/import/st-character", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ ...json, _avatarDataUrl: avatarDataUrl }),
-        });
-      }
-      const data = await res.json();
-      if (data.success) {
-        setStatus("success");
-        setMessage(`Imported "${data.name ?? file.name}" successfully!`);
-        qc.invalidateQueries({ queryKey: characterKeys.list() });
-        if (data.lorebook) {
-          qc.invalidateQueries({ queryKey: lorebookKeys.all });
+        if (isMarinaraEnvelope) {
+          marinaraPayloads.push({ file, payload: json });
+        } else {
+          stCharacterFiles.push(file);
         }
-      } else {
-        setStatus("error");
-        setMessage(data.error ?? "Import failed");
+      }
+
+      const nextResults: ImportResultRow[] = [];
+      let importedLorebook = false;
+
+      if (stCharacterFiles.length > 0) {
+        const form = new FormData();
+        for (const file of stCharacterFiles) {
+          form.append("files", file);
+        }
+        form.append(
+          "fileTimestamps",
+          JSON.stringify(
+            stCharacterFiles.map((file) => ({
+              name: file.name,
+              lastModified: file.lastModified,
+            })),
+          ),
+        );
+
+        const batchResult = await api.upload<{
+          success: boolean;
+          results: Array<{
+            filename: string;
+            success: boolean;
+            name?: string;
+            error?: string;
+            lorebook?: { lorebookId?: string };
+          }>;
+        }>("/import/st-character/batch", form);
+
+        for (const result of batchResult.results) {
+          if (result.lorebook?.lorebookId) importedLorebook = true;
+          nextResults.push({
+            filename: result.filename,
+            success: result.success,
+            message: result.success ? `Imported "${result.name ?? result.filename}"` : (result.error ?? "Import failed"),
+          });
+        }
+      }
+
+      for (const item of marinaraPayloads) {
+        try {
+          const result = await api.post<{
+            success: boolean;
+            name?: string;
+            error?: string;
+          }>("/import/marinara", {
+            ...item.payload,
+            timestampOverrides: {
+              createdAt: item.file.lastModified,
+              updatedAt: item.file.lastModified,
+            },
+          });
+
+          nextResults.push({
+            filename: item.file.name,
+            success: result.success,
+            message: result.success
+              ? `Imported "${result.name ?? item.file.name}"`
+              : (result.error ?? "Import failed"),
+          });
+        } catch (error) {
+          nextResults.push({
+            filename: item.file.name,
+            success: false,
+            message: error instanceof Error ? error.message : "Import failed",
+          });
+        }
+      }
+
+      setResults(nextResults);
+      setStatus("done");
+
+      if (nextResults.some((result) => result.success)) {
+        qc.invalidateQueries({ queryKey: characterKeys.list() });
+      }
+      if (importedLorebook) {
+        qc.invalidateQueries({ queryKey: lorebookKeys.all });
       }
     } catch (err) {
-      setStatus("error");
-      setMessage(err instanceof Error ? err.message : "Failed to parse file");
+      setResults([
+        {
+          filename: files.length === 1 ? files[0]!.name : `${files.length} files`,
+          success: false,
+          message: err instanceof Error ? err.message : "Failed to parse import files",
+        },
+      ]);
+      setStatus("done");
     }
   };
 
   const handleDrop = (e: React.DragEvent) => {
     e.preventDefault();
     setDragOver(false);
-    const file = e.dataTransfer.files[0];
-    if (file) handleFile(file);
+    handleFiles(Array.from(e.dataTransfer.files));
   };
 
   const reset = () => {
     setStatus("idle");
-    setMessage("");
+    setResults([]);
   };
 
   return (
@@ -144,9 +186,9 @@ export function ImportCharacterModal({ open, onClose }: Props) {
             className={`transition-colors ${dragOver ? "text-[var(--primary)]" : "text-[var(--muted-foreground)]"}`}
           />
           <div className="text-center">
-            <p className="text-sm font-medium">Drop a file here or click to browse</p>
+            <p className="text-sm font-medium">Drop one or more files here or click to browse</p>
             <p className="mt-1 text-xs text-[var(--muted-foreground)]">
-              Supports JSON, PNG (with embedded data), CharX, and Marinara exports
+              Supports JSON, PNG character cards, CharX, and Marinara exports
             </p>
           </div>
           <div className="flex gap-2">
@@ -169,10 +211,10 @@ export function ImportCharacterModal({ open, onClose }: Props) {
           ref={fileRef}
           type="file"
           accept=".json,.png,.marinara,.charx"
+          multiple
           className="hidden"
           onChange={(e) => {
-            const file = e.target.files?.[0];
-            if (file) handleFile(file);
+            handleFiles(Array.from(e.target.files ?? []));
             e.target.value = "";
           }}
         />
@@ -181,19 +223,41 @@ export function ImportCharacterModal({ open, onClose }: Props) {
         {status === "loading" && (
           <div className="flex items-center gap-2 rounded-lg bg-[var(--secondary)] p-3 text-xs">
             <Loader2 size="0.875rem" className="animate-spin text-[var(--primary)]" />
-            Importing...
+            Importing files...
           </div>
         )}
-        {status === "success" && (
-          <div className="flex items-center gap-2 rounded-lg bg-emerald-500/10 p-3 text-xs text-emerald-400">
-            <CheckCircle size="0.875rem" />
-            {message}
-          </div>
-        )}
-        {status === "error" && (
-          <div className="flex items-center gap-2 rounded-lg bg-[var(--destructive)]/10 p-3 text-xs text-[var(--destructive)]">
-            <XCircle size="0.875rem" />
-            {message}
+        {status === "done" && results.length > 0 && (
+          <div className="flex flex-col gap-2">
+            <div
+              className={`flex items-center gap-2 rounded-lg p-3 text-xs ${
+                results.some((result) => result.success)
+                  ? "bg-emerald-500/10 text-emerald-400"
+                  : "bg-[var(--destructive)]/10 text-[var(--destructive)]"
+              }`}
+            >
+              {results.some((result) => result.success) ? <CheckCircle size="0.875rem" /> : <XCircle size="0.875rem" />}
+              {results.filter((result) => result.success).length} succeeded,{" "}
+              {results.filter((result) => !result.success).length} failed
+            </div>
+
+            <div className="max-h-52 overflow-y-auto rounded-lg border border-[var(--border)]">
+              {results.map((result) => (
+                <div
+                  key={`${result.filename}-${result.message}`}
+                  className="flex items-start gap-2 border-b border-[var(--border)] px-3 py-2 text-xs last:border-b-0"
+                >
+                  {result.success ? (
+                    <CheckCircle size="0.8125rem" className="mt-0.5 shrink-0 text-emerald-400" />
+                  ) : (
+                    <XCircle size="0.8125rem" className="mt-0.5 shrink-0 text-[var(--destructive)]" />
+                  )}
+                  <div className="min-w-0">
+                    <div className="truncate font-medium">{result.filename}</div>
+                    <div className="text-[var(--muted-foreground)]">{result.message}</div>
+                  </div>
+                </div>
+              ))}
+            </div>
           </div>
         )}
 

--- a/packages/client/src/components/modals/ImportLorebookModal.tsx
+++ b/packages/client/src/components/modals/ImportLorebookModal.tsx
@@ -5,6 +5,7 @@ import { useState, useRef } from "react";
 import { Modal } from "../ui/Modal";
 import { Download, FileJson, CheckCircle, XCircle, Loader2 } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
+import { api } from "../../lib/api-client";
 
 interface Props {
   open: boolean;
@@ -13,56 +14,72 @@ interface Props {
 
 export function ImportLorebookModal({ open, onClose }: Props) {
   const fileRef = useRef<HTMLInputElement>(null);
-  const [status, setStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
-  const [message, setMessage] = useState("");
+  const [status, setStatus] = useState<"idle" | "loading" | "done">("idle");
+  const [results, setResults] = useState<Array<{ filename: string; success: boolean; message: string }>>([]);
   const [dragOver, setDragOver] = useState(false);
   const qc = useQueryClient();
 
-  const handleFile = async (file: File) => {
+  const handleFiles = async (files: File[]) => {
+    if (files.length === 0) return;
     setStatus("loading");
-    setMessage("");
+    setResults([]);
 
-    try {
-      const text = await file.text();
-      const json = JSON.parse(text) as Record<string, unknown>;
+    const nextResults: Array<{ filename: string; success: boolean; message: string }> = [];
+    for (const file of files) {
+      try {
+        const text = await file.text();
+        const json = JSON.parse(text) as Record<string, unknown>;
 
-      const isMarinaraLorebook = json.type === "marinara_lorebook" && json.version === 1;
-      const endpoint = isMarinaraLorebook ? "/api/import/marinara" : "/api/import/st-lorebook";
+        const isMarinaraLorebook = json.type === "marinara_lorebook" && json.version === 1;
+        const endpoint = isMarinaraLorebook ? "/import/marinara" : "/import/st-lorebook";
+        const payload = isMarinaraLorebook
+          ? {
+              ...json,
+              timestampOverrides: {
+                createdAt: file.lastModified,
+                updatedAt: file.lastModified,
+              },
+            }
+          : {
+              ...json,
+              __filename: file.name.replace(/\.json$/i, ""),
+              timestampOverrides: {
+                createdAt: file.lastModified,
+                updatedAt: file.lastModified,
+              },
+            };
 
-      if (!isMarinaraLorebook) {
-        json.__filename = file.name.replace(/\.json$/i, "");
+        const data = await api.post<{ success: boolean; error?: string }>(endpoint, payload);
+        nextResults.push({
+          filename: file.name,
+          success: data.success,
+          message: data.success ? "Imported lorebook" : (data.error ?? "Import failed"),
+        });
+      } catch (error) {
+        nextResults.push({
+          filename: file.name,
+          success: false,
+          message: error instanceof Error ? error.message : "Failed to parse file",
+        });
       }
+    }
 
-      const res = await fetch(endpoint, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(json),
-      });
-      const data = await res.json();
-      if (data.success) {
-        setStatus("success");
-        setMessage(`Imported lorebook successfully!`);
-        qc.invalidateQueries({ queryKey: ["lorebooks"] });
-      } else {
-        setStatus("error");
-        setMessage(data.error ?? "Import failed");
-      }
-    } catch {
-      setStatus("error");
-      setMessage("Failed to parse file — must be valid JSON");
+    setResults(nextResults);
+    setStatus("done");
+    if (nextResults.some((result) => result.success)) {
+      qc.invalidateQueries({ queryKey: ["lorebooks"] });
     }
   };
 
   const handleDrop = (e: React.DragEvent) => {
     e.preventDefault();
     setDragOver(false);
-    const file = e.dataTransfer.files[0];
-    if (file) handleFile(file);
+    handleFiles(Array.from(e.dataTransfer.files));
   };
 
   const reset = () => {
     setStatus("idle");
-    setMessage("");
+    setResults([]);
   };
 
   return (
@@ -90,7 +107,7 @@ export function ImportLorebookModal({ open, onClose }: Props) {
           }`}
         >
           <Download size="2rem" className={dragOver ? "text-[var(--primary)]" : "text-[var(--muted-foreground)]"} />
-          <p className="text-sm font-medium">Drop lorebook JSON here or click to browse</p>
+          <p className="text-sm font-medium">Drop one or more lorebook files here or click to browse</p>
           <span className="flex items-center gap-1 rounded-full bg-[var(--secondary)] px-2.5 py-1 text-xs text-[var(--muted-foreground)]">
             <FileJson size="0.75rem" /> .json
           </span>
@@ -100,10 +117,10 @@ export function ImportLorebookModal({ open, onClose }: Props) {
           ref={fileRef}
           type="file"
           accept=".json"
+          multiple
           className="hidden"
           onChange={(e) => {
-            const f = e.target.files?.[0];
-            if (f) handleFile(f);
+            handleFiles(Array.from(e.target.files ?? []));
             e.target.value = "";
           }}
         />
@@ -113,14 +130,37 @@ export function ImportLorebookModal({ open, onClose }: Props) {
             <Loader2 size="0.875rem" className="animate-spin text-[var(--primary)]" /> Importing...
           </div>
         )}
-        {status === "success" && (
-          <div className="flex items-center gap-2 rounded-lg bg-emerald-500/10 p-3 text-xs text-emerald-400">
-            <CheckCircle size="0.875rem" /> {message}
-          </div>
-        )}
-        {status === "error" && (
-          <div className="flex items-center gap-2 rounded-lg bg-[var(--destructive)]/10 p-3 text-xs text-[var(--destructive)]">
-            <XCircle size="0.875rem" /> {message}
+        {status === "done" && results.length > 0 && (
+          <div className="flex flex-col gap-2">
+            <div
+              className={`flex items-center gap-2 rounded-lg p-3 text-xs ${
+                results.some((result) => result.success)
+                  ? "bg-emerald-500/10 text-emerald-400"
+                  : "bg-[var(--destructive)]/10 text-[var(--destructive)]"
+              }`}
+            >
+              {results.some((result) => result.success) ? <CheckCircle size="0.875rem" /> : <XCircle size="0.875rem" />}
+              {results.filter((result) => result.success).length} succeeded,{" "}
+              {results.filter((result) => !result.success).length} failed
+            </div>
+            <div className="max-h-52 overflow-y-auto rounded-lg border border-[var(--border)]">
+              {results.map((result) => (
+                <div
+                  key={`${result.filename}-${result.message}`}
+                  className="flex items-start gap-2 border-b border-[var(--border)] px-3 py-2 text-xs last:border-b-0"
+                >
+                  {result.success ? (
+                    <CheckCircle size="0.8125rem" className="mt-0.5 shrink-0 text-emerald-400" />
+                  ) : (
+                    <XCircle size="0.8125rem" className="mt-0.5 shrink-0 text-[var(--destructive)]" />
+                  )}
+                  <div className="min-w-0">
+                    <div className="truncate font-medium">{result.filename}</div>
+                    <div className="text-[var(--muted-foreground)]">{result.message}</div>
+                  </div>
+                </div>
+              ))}
+            </div>
           </div>
         )}
 

--- a/packages/client/src/components/modals/ImportPersonaModal.tsx
+++ b/packages/client/src/components/modals/ImportPersonaModal.tsx
@@ -6,6 +6,7 @@ import { Modal } from "../ui/Modal";
 import { Download, FileJson, CheckCircle, XCircle, Loader2 } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { characterKeys } from "../../hooks/use-characters";
+import { api } from "../../lib/api-client";
 
 interface Props {
   open: boolean;
@@ -14,47 +15,43 @@ interface Props {
 
 export function ImportPersonaModal({ open, onClose }: Props) {
   const fileRef = useRef<HTMLInputElement>(null);
-  const [status, setStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
-  const [message, setMessage] = useState("");
+  const [status, setStatus] = useState<"idle" | "loading" | "done">("idle");
+  const [results, setResults] = useState<Array<{ filename: string; success: boolean; message: string }>>([]);
   const [dragOver, setDragOver] = useState(false);
   const qc = useQueryClient();
 
-  const handleFile = async (file: File) => {
+  const handleFiles = async (files: File[]) => {
+    if (files.length === 0) return;
     setStatus("loading");
-    setMessage("");
+    setResults([]);
 
-    try {
-      const text = await file.text();
-      const json = JSON.parse(text) as Record<string, unknown>;
+    const nextResults: Array<{ filename: string; success: boolean; message: string }> = [];
+    for (const file of files) {
+      try {
+        const text = await file.text();
+        const json = JSON.parse(text) as Record<string, unknown>;
 
-      // Marinara envelope format — route to the native importer
-      const isMarinaraEnvelope =
-        json.version === 1 && typeof json.type === "string" && (json.type as string).startsWith("marinara_");
+        const isMarinaraEnvelope =
+          json.version === 1 && typeof json.type === "string" && (json.type as string).startsWith("marinara_");
 
-      if (isMarinaraEnvelope) {
-        const res = await fetch("/api/import/marinara", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(json),
-        });
-        const data = await res.json();
-        if (data.success) {
-          setStatus("success");
-          setMessage(`Imported "${data.name ?? file.name}" successfully!`);
-          qc.invalidateQueries({ queryKey: characterKeys.personas });
-        } else {
-          setStatus("error");
-          setMessage(data.error ?? "Import failed");
+        if (isMarinaraEnvelope) {
+          const data = await api.post<{ success: boolean; name?: string; error?: string }>("/import/marinara", {
+            ...json,
+            timestampOverrides: {
+              createdAt: file.lastModified,
+              updatedAt: file.lastModified,
+            },
+          });
+          nextResults.push({
+            filename: file.name,
+            success: data.success,
+            message: data.success ? `Imported "${data.name ?? file.name}"` : (data.error ?? "Import failed"),
+          });
+          continue;
         }
-        return;
-      }
 
-      // Plain persona JSON — create directly via the personas API
-      const name = typeof json.name === "string" ? json.name : "Imported Persona";
-      const res = await fetch("/api/personas", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
+        const name = typeof json.name === "string" ? json.name : "Imported Persona";
+        const data = await api.post<{ id?: string; error?: string }>("/characters/personas", {
           name,
           description: json.description ?? "",
           personality: json.personality ?? "",
@@ -62,33 +59,40 @@ export function ImportPersonaModal({ open, onClose }: Props) {
           backstory: json.backstory ?? "",
           appearance: json.appearance ?? "",
           comment: json.comment ?? "",
-        }),
-      });
-      const data = await res.json();
-      if (data.id) {
-        setStatus("success");
-        setMessage(`Imported "${name}" successfully!`);
-        qc.invalidateQueries({ queryKey: characterKeys.personas });
-      } else {
-        setStatus("error");
-        setMessage(data.error ?? "Import failed");
+          tags: json.tags ?? undefined,
+          createdAt: file.lastModified,
+          updatedAt: file.lastModified,
+        });
+        nextResults.push({
+          filename: file.name,
+          success: !!data.id,
+          message: data.id ? `Imported "${name}"` : (data.error ?? "Import failed"),
+        });
+      } catch (err) {
+        nextResults.push({
+          filename: file.name,
+          success: false,
+          message: err instanceof Error ? err.message : "Failed to parse file",
+        });
       }
-    } catch (err) {
-      setStatus("error");
-      setMessage(err instanceof Error ? err.message : "Failed to parse file");
+    }
+
+    setResults(nextResults);
+    setStatus("done");
+    if (nextResults.some((result) => result.success)) {
+      qc.invalidateQueries({ queryKey: characterKeys.personas });
     }
   };
 
   const handleDrop = (e: React.DragEvent) => {
     e.preventDefault();
     setDragOver(false);
-    const file = e.dataTransfer.files[0];
-    if (file) handleFile(file);
+    handleFiles(Array.from(e.dataTransfer.files));
   };
 
   const reset = () => {
     setStatus("idle");
-    setMessage("");
+    setResults([]);
   };
 
   return (
@@ -121,7 +125,7 @@ export function ImportPersonaModal({ open, onClose }: Props) {
             className={`transition-colors ${dragOver ? "text-[var(--primary)]" : "text-[var(--muted-foreground)]"}`}
           />
           <div className="text-center">
-            <p className="text-sm font-medium">Drop a file here or click to browse</p>
+            <p className="text-sm font-medium">Drop one or more files here or click to browse</p>
             <p className="mt-1 text-xs text-[var(--muted-foreground)]">Supports JSON and Marinara persona exports</p>
           </div>
           <div className="flex gap-2">
@@ -138,10 +142,10 @@ export function ImportPersonaModal({ open, onClose }: Props) {
           ref={fileRef}
           type="file"
           accept=".json,.marinara"
+          multiple
           className="hidden"
           onChange={(e) => {
-            const file = e.target.files?.[0];
-            if (file) handleFile(file);
+            handleFiles(Array.from(e.target.files ?? []));
             e.target.value = "";
           }}
         />
@@ -153,16 +157,37 @@ export function ImportPersonaModal({ open, onClose }: Props) {
             Importing...
           </div>
         )}
-        {status === "success" && (
-          <div className="flex items-center gap-2 rounded-lg bg-emerald-500/10 p-3 text-xs text-emerald-400">
-            <CheckCircle size="0.875rem" />
-            {message}
-          </div>
-        )}
-        {status === "error" && (
-          <div className="flex items-center gap-2 rounded-lg bg-[var(--destructive)]/10 p-3 text-xs text-[var(--destructive)]">
-            <XCircle size="0.875rem" />
-            {message}
+        {status === "done" && results.length > 0 && (
+          <div className="flex flex-col gap-2">
+            <div
+              className={`flex items-center gap-2 rounded-lg p-3 text-xs ${
+                results.some((result) => result.success)
+                  ? "bg-emerald-500/10 text-emerald-400"
+                  : "bg-[var(--destructive)]/10 text-[var(--destructive)]"
+              }`}
+            >
+              {results.some((result) => result.success) ? <CheckCircle size="0.875rem" /> : <XCircle size="0.875rem" />}
+              {results.filter((result) => result.success).length} succeeded,{" "}
+              {results.filter((result) => !result.success).length} failed
+            </div>
+            <div className="max-h-52 overflow-y-auto rounded-lg border border-[var(--border)]">
+              {results.map((result) => (
+                <div
+                  key={`${result.filename}-${result.message}`}
+                  className="flex items-start gap-2 border-b border-[var(--border)] px-3 py-2 text-xs last:border-b-0"
+                >
+                  {result.success ? (
+                    <CheckCircle size="0.8125rem" className="mt-0.5 shrink-0 text-emerald-400" />
+                  ) : (
+                    <XCircle size="0.8125rem" className="mt-0.5 shrink-0 text-[var(--destructive)]" />
+                  )}
+                  <div className="min-w-0">
+                    <div className="truncate font-medium">{result.filename}</div>
+                    <div className="text-[var(--muted-foreground)]">{result.message}</div>
+                  </div>
+                </div>
+              ))}
+            </div>
           </div>
         )}
 

--- a/packages/client/src/components/modals/ImportPresetModal.tsx
+++ b/packages/client/src/components/modals/ImportPresetModal.tsx
@@ -5,6 +5,7 @@ import { useState, useRef } from "react";
 import { Modal } from "../ui/Modal";
 import { Download, FileJson, CheckCircle, XCircle, Loader2 } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
+import { api } from "../../lib/api-client";
 
 interface Props {
   open: boolean;
@@ -13,56 +14,74 @@ interface Props {
 
 export function ImportPresetModal({ open, onClose }: Props) {
   const fileRef = useRef<HTMLInputElement>(null);
-  const [status, setStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
-  const [message, setMessage] = useState("");
+  const [status, setStatus] = useState<"idle" | "loading" | "done">("idle");
+  const [results, setResults] = useState<Array<{ filename: string; success: boolean; message: string }>>([]);
   const [dragOver, setDragOver] = useState(false);
   const qc = useQueryClient();
 
-  const handleFile = async (file: File) => {
+  const handleFiles = async (files: File[]) => {
+    if (files.length === 0) return;
     setStatus("loading");
+    setResults([]);
 
-    try {
-      const text = await file.text();
-      const json = JSON.parse(text);
+    const nextResults: Array<{ filename: string; success: boolean; message: string }> = [];
 
-      // Detect Marinara native export format vs SillyTavern format
-      const isMarinara = json.type === "marinara_preset" && json.version === 1;
-      const endpoint = isMarinara ? "/api/import/marinara" : "/api/import/st-preset";
+    for (const file of files) {
+      try {
+        const text = await file.text();
+        const json = JSON.parse(text);
 
-      if (!isMarinara) {
-        json.__filename = file.name.replace(/\.json$/i, "");
+        // Detect Marinara native export format vs SillyTavern format
+        const isMarinara = json.type === "marinara_preset" && json.version === 1;
+        const endpoint = isMarinara ? "/import/marinara" : "/import/st-preset";
+        const payload = isMarinara
+          ? {
+              ...json,
+              timestampOverrides: {
+                createdAt: file.lastModified,
+                updatedAt: file.lastModified,
+              },
+            }
+          : {
+              ...json,
+              __filename: file.name.replace(/\.json$/i, ""),
+              timestampOverrides: {
+                createdAt: file.lastModified,
+                updatedAt: file.lastModified,
+              },
+            };
+
+        const data = await api.post<{ success: boolean; error?: string }> (endpoint, payload);
+        nextResults.push({
+          filename: file.name,
+          success: data.success,
+          message: data.success ? "Imported preset" : (data.error ?? "Import failed"),
+        });
+      } catch (error) {
+        nextResults.push({
+          filename: file.name,
+          success: false,
+          message: error instanceof Error ? error.message : "Failed to parse file",
+        });
       }
+    }
 
-      const res = await fetch(endpoint, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(json),
-      });
-      const data = await res.json();
-      if (data.success) {
-        setStatus("success");
-        setMessage(`Imported preset successfully!`);
-        qc.invalidateQueries();
-      } else {
-        setStatus("error");
-        setMessage(data.error ?? "Import failed");
-      }
-    } catch {
-      setStatus("error");
-      setMessage("Failed to parse file — must be valid JSON");
+    setResults(nextResults);
+    setStatus("done");
+    if (nextResults.some((result) => result.success)) {
+      qc.invalidateQueries();
     }
   };
 
   const handleDrop = (e: React.DragEvent) => {
     e.preventDefault();
     setDragOver(false);
-    const file = e.dataTransfer.files[0];
-    if (file) handleFile(file);
+    handleFiles(Array.from(e.dataTransfer.files));
   };
 
   const reset = () => {
     setStatus("idle");
-    setMessage("");
+    setResults([]);
   };
 
   return (
@@ -90,7 +109,7 @@ export function ImportPresetModal({ open, onClose }: Props) {
           }`}
         >
           <Download size="2rem" className={dragOver ? "text-[var(--primary)]" : "text-[var(--muted-foreground)]"} />
-          <p className="text-sm font-medium">Drop preset JSON here or click to browse</p>
+          <p className="text-sm font-medium">Drop one or more preset files here or click to browse</p>
           <span className="flex items-center gap-1 rounded-full bg-[var(--secondary)] px-2.5 py-1 text-xs text-[var(--muted-foreground)]">
             <FileJson size="0.75rem" /> .json
           </span>
@@ -100,10 +119,10 @@ export function ImportPresetModal({ open, onClose }: Props) {
           ref={fileRef}
           type="file"
           accept=".json"
+          multiple
           className="hidden"
           onChange={(e) => {
-            const f = e.target.files?.[0];
-            if (f) handleFile(f);
+            handleFiles(Array.from(e.target.files ?? []));
             e.target.value = "";
           }}
         />
@@ -113,14 +132,37 @@ export function ImportPresetModal({ open, onClose }: Props) {
             <Loader2 size="0.875rem" className="animate-spin text-[var(--primary)]" /> Importing...
           </div>
         )}
-        {status === "success" && (
-          <div className="flex items-center gap-2 rounded-lg bg-emerald-500/10 p-3 text-xs text-emerald-400">
-            <CheckCircle size="0.875rem" /> {message}
-          </div>
-        )}
-        {status === "error" && (
-          <div className="flex items-center gap-2 rounded-lg bg-[var(--destructive)]/10 p-3 text-xs text-[var(--destructive)]">
-            <XCircle size="0.875rem" /> {message}
+        {status === "done" && results.length > 0 && (
+          <div className="flex flex-col gap-2">
+            <div
+              className={`flex items-center gap-2 rounded-lg p-3 text-xs ${
+                results.some((result) => result.success)
+                  ? "bg-emerald-500/10 text-emerald-400"
+                  : "bg-[var(--destructive)]/10 text-[var(--destructive)]"
+              }`}
+            >
+              {results.some((result) => result.success) ? <CheckCircle size="0.875rem" /> : <XCircle size="0.875rem" />}
+              {results.filter((result) => result.success).length} succeeded,{" "}
+              {results.filter((result) => !result.success).length} failed
+            </div>
+            <div className="max-h-52 overflow-y-auto rounded-lg border border-[var(--border)]">
+              {results.map((result) => (
+                <div
+                  key={`${result.filename}-${result.message}`}
+                  className="flex items-start gap-2 border-b border-[var(--border)] px-3 py-2 text-xs last:border-b-0"
+                >
+                  {result.success ? (
+                    <CheckCircle size="0.8125rem" className="mt-0.5 shrink-0 text-emerald-400" />
+                  ) : (
+                    <XCircle size="0.8125rem" className="mt-0.5 shrink-0 text-[var(--destructive)]" />
+                  )}
+                  <div className="min-w-0">
+                    <div className="truncate font-medium">{result.filename}</div>
+                    <div className="text-[var(--muted-foreground)]">{result.message}</div>
+                  </div>
+                </div>
+              ))}
+            </div>
           </div>
         )}
 

--- a/packages/client/src/components/modals/STBulkImportModal.tsx
+++ b/packages/client/src/components/modals/STBulkImportModal.tsx
@@ -20,6 +20,7 @@ import {
   ChevronRight,
   ArrowLeft,
   Folder,
+  Check,
 } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { cn } from "../../lib/utils";
@@ -29,17 +30,24 @@ interface Props {
   onClose: () => void;
 }
 
+interface ScanItemBase {
+  id: string;
+  path: string;
+  name: string;
+  modifiedAt: string | null;
+}
+
 interface ScanResult {
   success: boolean;
   error?: string;
   dataDir?: string;
-  characters: { path: string; name: string; format: string }[];
-  chats: { path: string; characterName: string; folderName: string }[];
-  groupChats: { path: string; groupName: string; members: string[] }[];
-  presets: { path: string; name: string }[];
-  lorebooks: { path: string; name: string }[];
-  backgrounds: { path: string; name: string }[];
-  personas: { path: string; name: string }[];
+  characters: Array<ScanItemBase & { format: string }>;
+  chats: Array<ScanItemBase & { characterName: string; folderName: string }>;
+  groupChats: Array<ScanItemBase & { groupName: string; members: string[] }>;
+  presets: Array<ScanItemBase & { isBuiltin?: boolean }>;
+  lorebooks: ScanItemBase[];
+  backgrounds: ScanItemBase[];
+  personas: Array<ScanItemBase & { description: string }>;
 }
 
 interface ImportResult {
@@ -66,28 +74,62 @@ interface ImportProgress {
 }
 
 type Phase = "input" | "scanning" | "preview" | "importing" | "done";
+type CategoryKey = "characters" | "chats" | "groupChats" | "presets" | "lorebooks" | "backgrounds" | "personas";
+type SelectionState = Record<CategoryKey, string[]>;
+
+function buildInitialSelection(scan: ScanResult): SelectionState {
+  return {
+    characters: scan.characters.map((item) => item.id),
+    chats: scan.chats.map((item) => item.id),
+    groupChats: scan.groupChats.map((item) => item.id),
+    presets: scan.presets.filter((item) => !item.isBuiltin).map((item) => item.id),
+    lorebooks: scan.lorebooks.map((item) => item.id),
+    backgrounds: scan.backgrounds.map((item) => item.id),
+    personas: scan.personas.map((item) => item.id),
+  };
+}
+
+function formatModifiedAt(value: string | null) {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toLocaleString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
 
 export function STBulkImportModal({ open, onClose }: Props) {
   const [folderPath, setFolderPath] = useState("");
   const [phase, setPhase] = useState<Phase>("input");
   const [scanResult, setScanResult] = useState<ScanResult | null>(null);
+  const [selection, setSelection] = useState<SelectionState>({
+    characters: [],
+    chats: [],
+    groupChats: [],
+    presets: [],
+    lorebooks: [],
+    backgrounds: [],
+    personas: [],
+  });
   const [importResult, setImportResult] = useState<ImportResult | null>(null);
   const [progress, setProgress] = useState<ImportProgress | null>(null);
   const [error, setError] = useState("");
-  const [options, setOptions] = useState({
-    characters: true,
-    chats: true,
-    groupChats: true,
-    presets: true,
-    lorebooks: true,
-    backgrounds: true,
-    personas: true,
-  });
   const qc = useQueryClient();
 
   const reset = useCallback(() => {
     setPhase("input");
     setScanResult(null);
+    setSelection({
+      characters: [],
+      chats: [],
+      groupChats: [],
+      presets: [],
+      lorebooks: [],
+      backgrounds: [],
+      personas: [],
+    });
     setImportResult(null);
     setProgress(null);
     setError("");
@@ -112,6 +154,7 @@ export function STBulkImportModal({ open, onClose }: Props) {
       const data = (await res.json()) as ScanResult;
       if (data.success) {
         setScanResult(data);
+        setSelection(buildInitialSelection(data));
         setPhase("preview");
       } else {
         setError(data.error ?? "Scan failed");
@@ -143,7 +186,7 @@ export function STBulkImportModal({ open, onClose }: Props) {
         setBrowserFolders(data.folders ?? []);
       }
     } catch {
-      // silent
+      // Silent fallback
     }
     setBrowserLoading(false);
   }, []);
@@ -160,24 +203,37 @@ export function STBulkImportModal({ open, onClose }: Props) {
         return;
       }
     } catch {
-      // native picker failed
+      // Native picker failed — fall back to browser below
     }
     setPicking(false);
-    // Native picker didn't return a path — fall back to directory browser
     setShowFolderBrowser(true);
     loadDirectory(folderPath || undefined);
   }, [folderPath, loadDirectory]);
+
+  const updateCategorySelection = useCallback((category: CategoryKey, nextIds: string[]) => {
+    setSelection((prev) => ({ ...prev, [category]: nextIds }));
+  }, []);
+
+  const toggleCategoryItem = useCallback((category: CategoryKey, itemId: string, checked: boolean) => {
+    setSelection((prev) => {
+      const existing = new Set(prev[category]);
+      if (checked) existing.add(itemId);
+      else existing.delete(itemId);
+      return { ...prev, [category]: [...existing] };
+    });
+  }, []);
 
   const handleImport = useCallback(async () => {
     if (!folderPath.trim()) return;
     setPhase("importing");
     setProgress(null);
+    setError("");
 
     try {
       const res = await fetch("/api/import/st-bulk/run", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ folderPath: folderPath.trim(), options }),
+        body: JSON.stringify({ folderPath: folderPath.trim(), options: selection }),
       });
 
       if (!res.ok || !res.body) {
@@ -195,7 +251,6 @@ export function STBulkImportModal({ open, onClose }: Props) {
         if (done) break;
         buffer += decoder.decode(value, { stream: true });
 
-        // Parse SSE events from the buffer
         const parts = buffer.split("\n\n");
         buffer = parts.pop() ?? "";
 
@@ -205,7 +260,7 @@ export function STBulkImportModal({ open, onClose }: Props) {
           let dataStr = "";
           for (const line of lines) {
             if (line.startsWith("event: ")) eventType = line.slice(7);
-            else if (line.startsWith("data: ")) dataStr = line.slice(6);
+            if (line.startsWith("data: ")) dataStr = line.slice(6);
           }
           if (!dataStr) continue;
           try {
@@ -218,33 +273,32 @@ export function STBulkImportModal({ open, onClose }: Props) {
               qc.invalidateQueries();
             }
           } catch {
-            // skip malformed events
+            // Ignore malformed SSE chunks
           }
         }
       }
-
-      // If we exited the loop without a "done" event, the phase may still be "importing"
-      // — this is fine, the SSE stream just ended cleanly after the done event was processed
     } catch {
       setError("Import failed — server error");
       setPhase("preview");
     }
-  }, [folderPath, options, qc]);
+  }, [folderPath, qc, selection]);
+
+  const hasAnySelected = Object.values(selection).some((ids) => ids.length > 0);
+  const builtinPresetCount = scanResult?.presets.filter((item) => item.isBuiltin).length ?? 0;
 
   return (
-    <Modal open={open} onClose={handleClose} title="Import from SillyTavern" width="max-w-lg">
+    <Modal open={open} onClose={handleClose} title="Import from SillyTavern" width="max-w-3xl">
       <div className="flex flex-col gap-4">
-        {/* ── Phase: Input ── */}
         {(phase === "input" || phase === "scanning") && (
           <>
             <p className="text-xs text-[var(--muted-foreground)]">
-              Select or enter the path to your SillyTavern installation folder. We'll scan for characters, chats,
-              presets, lorebooks, and backgrounds to import.
+              Select or enter the path to your SillyTavern installation folder. We&apos;ll scan for characters, chats,
+              presets, lorebooks, backgrounds, and personas before you choose exactly what to import.
             </p>
 
             <div className="flex flex-col gap-1.5">
               <label className="text-xs font-medium">SillyTavern Folder Path</label>
-              <div className="flex gap-2">
+              <div className="flex gap-2 max-sm:flex-col">
                 <input
                   type="text"
                   value={folderPath}
@@ -259,7 +313,7 @@ export function STBulkImportModal({ open, onClose }: Props) {
                 <button
                   onClick={handleBrowse}
                   disabled={phase === "scanning" || picking}
-                  className="flex items-center gap-1 rounded-lg border border-[var(--border)] px-3 py-2 text-xs font-medium transition-all hover:bg-[var(--secondary)] active:scale-95 disabled:opacity-50"
+                  className="flex items-center justify-center gap-1 rounded-lg border border-[var(--border)] px-3 py-2 text-xs font-medium transition-all hover:bg-[var(--secondary)] active:scale-95 disabled:opacity-50"
                   title="Browse for folder"
                 >
                   {picking ? <Loader2 size="0.875rem" className="animate-spin" /> : <FolderOpen size="0.875rem" />}
@@ -268,13 +322,14 @@ export function STBulkImportModal({ open, onClose }: Props) {
               </div>
             </div>
 
-            {/* ── Inline Folder Browser ── */}
             {showFolderBrowser && (
               <div className="rounded-lg border border-[var(--border)] bg-[var(--secondary)]/50">
                 <div className="flex items-center gap-2 border-b border-[var(--border)] px-3 py-2">
                   <button
                     onClick={() => {
-                      const parent = browserPath.replace(/\/[^/]+$/, "") || "/";
+                      const parent = browserPath.includes("\\")
+                        ? browserPath.replace(/\\[^\\]+$/, "")
+                        : browserPath.replace(/\/[^/]+$/, "") || "/";
                       if (parent !== browserPath) loadDirectory(parent);
                     }}
                     disabled={browserLoading || browserPath === "/"}
@@ -283,7 +338,7 @@ export function STBulkImportModal({ open, onClose }: Props) {
                   >
                     <ArrowLeft size="0.75rem" />
                   </button>
-                  <span className="flex-1 truncate text-[0.625rem] font-mono text-[var(--muted-foreground)]">
+                  <span className="flex-1 truncate font-mono text-[0.625rem] text-[var(--muted-foreground)]">
                     {browserPath || "/"}
                   </span>
                   <button
@@ -307,7 +362,7 @@ export function STBulkImportModal({ open, onClose }: Props) {
                     browserFolders.map((name) => (
                       <button
                         key={name}
-                        onClick={() => loadDirectory(`${browserPath}/${name}`)}
+                        onClick={() => loadDirectory(browserPath ? `${browserPath}\\${name}` : name)}
                         className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs transition-colors hover:bg-[var(--accent)]"
                       >
                         <Folder size="0.8125rem" className="shrink-0 text-sky-400" />
@@ -327,7 +382,7 @@ export function STBulkImportModal({ open, onClose }: Props) {
                 "flex items-center justify-center gap-1.5 rounded-lg px-4 py-2.5 text-xs font-medium transition-all",
                 folderPath.trim() && phase !== "scanning"
                   ? "bg-[var(--primary)] text-[var(--primary-foreground)] hover:opacity-90 active:scale-95"
-                  : "bg-[var(--secondary)] text-[var(--muted-foreground)] opacity-50 cursor-not-allowed",
+                  : "cursor-not-allowed bg-[var(--secondary)] text-[var(--muted-foreground)] opacity-50",
               )}
             >
               {phase === "scanning" ? (
@@ -335,104 +390,196 @@ export function STBulkImportModal({ open, onClose }: Props) {
               ) : (
                 <FolderSearch size="0.875rem" />
               )}
-              {phase === "scanning" ? "Scanning…" : "Scan Folder"}
+              {phase === "scanning" ? "Scanning..." : "Scan Folder"}
             </button>
 
             {error && (
               <div className="flex items-start gap-2 rounded-lg bg-[var(--destructive)]/10 p-3 text-xs text-[var(--destructive)]">
-                <XCircle size="0.875rem" className="mt-0.5 flex-shrink-0" />
+                <XCircle size="0.875rem" className="mt-0.5 shrink-0" />
                 <span>{error}</span>
               </div>
             )}
 
             <div className="rounded-lg bg-[var(--secondary)]/50 p-2.5 text-[0.625rem] text-[var(--muted-foreground)] ring-1 ring-[var(--border)]">
-              <strong>Tip:</strong> This is the main SillyTavern folder (the one containing{" "}
+              <strong>Tip:</strong> This is the main SillyTavern folder, usually the one containing{" "}
               <code className="rounded bg-[var(--secondary)] px-1">data/</code> or{" "}
-              <code className="rounded bg-[var(--secondary)] px-1">public/</code>). On most setups it's named{" "}
-              <code className="rounded bg-[var(--secondary)] px-1">SillyTavern</code>.
+              <code className="rounded bg-[var(--secondary)] px-1">public/</code>.
             </div>
           </>
         )}
 
-        {/* ── Phase: Preview ── */}
         {phase === "preview" && scanResult && (
           <>
-            <div className="flex items-center gap-2 rounded-lg bg-emerald-500/10 p-2.5 text-xs text-emerald-400">
-              <CheckCircle size="0.875rem" />
+            <div className="flex items-start gap-2 rounded-lg bg-emerald-500/10 p-2.5 text-xs text-emerald-400">
+              <CheckCircle size="0.875rem" className="mt-0.5 shrink-0" />
               <span>
-                Found ST data in{" "}
+                Found SillyTavern data in{" "}
                 <code className="rounded bg-[var(--secondary)] px-1 text-[0.625rem]">{scanResult.dataDir}</code>
               </span>
             </div>
 
-            <div className="flex flex-col gap-2">
-              <span className="text-xs font-medium">Select what to import:</span>
+            {builtinPresetCount > 0 && (
+              <div className="flex items-start gap-2 rounded-lg bg-amber-500/10 p-2.5 text-xs text-amber-400">
+                <AlertTriangle size="0.875rem" className="mt-0.5 shrink-0" />
+                <span>
+                  {builtinPresetCount} built-in preset{builtinPresetCount !== 1 ? "s were" : " was"} detected and left
+                  unchecked by default so only likely custom presets come across unless you opt in.
+                </span>
+              </div>
+            )}
 
-              <ImportCategory
+            <div className="space-y-3">
+              <div className="flex items-center justify-between gap-2">
+                <span className="text-xs font-medium">Choose exactly what to import</span>
+                <span className="text-[0.6875rem] text-[var(--muted-foreground)]">
+                  {Object.values(selection).reduce((sum, ids) => sum + ids.length, 0)} selected
+                </span>
+              </div>
+
+              <SelectableImportCategory
                 icon={<Users size="0.875rem" />}
                 label="Characters"
-                count={scanResult.characters.length}
-                items={scanResult.characters.map((c) => c.name)}
-                checked={options.characters}
-                onChange={(v) => setOptions((o) => ({ ...o, characters: v }))}
+                items={scanResult.characters}
+                selectedIds={selection.characters}
+                onToggleItem={(itemId, checked) => toggleCategoryItem("characters", itemId, checked)}
+                onSelectAll={() => updateCategorySelection("characters", scanResult.characters.map((item) => item.id))}
+                onSelectNone={() => updateCategorySelection("characters", [])}
+                renderDetails={(item) => {
+                  const modified = formatModifiedAt(item.modifiedAt);
+                  return (
+                    <span>
+                      {item.format.toUpperCase()}
+                      {modified ? ` · modified ${modified}` : ""}
+                    </span>
+                  );
+                }}
               />
 
-              <ImportCategory
+              <SelectableImportCategory
                 icon={<MessageSquare size="0.875rem" />}
                 label="Chats"
-                count={scanResult.chats.length}
-                items={scanResult.chats.map((c) => c.characterName)}
-                checked={options.chats}
-                onChange={(v) => setOptions((o) => ({ ...o, chats: v }))}
+                items={scanResult.chats}
+                selectedIds={selection.chats}
+                onToggleItem={(itemId, checked) => toggleCategoryItem("chats", itemId, checked)}
+                onSelectAll={() => updateCategorySelection("chats", scanResult.chats.map((item) => item.id))}
+                onSelectNone={() => updateCategorySelection("chats", [])}
+                getItemLabel={(item) => item.characterName || item.name}
+                renderDetails={(item) => {
+                  const modified = formatModifiedAt(item.modifiedAt);
+                  return (
+                    <span>
+                      Folder: {item.folderName}
+                      {modified ? ` · modified ${modified}` : ""}
+                    </span>
+                  );
+                }}
               />
 
-              <ImportCategory
+              <SelectableImportCategory
                 icon={<Users size="0.875rem" />}
                 label="Group Chats"
-                count={scanResult.groupChats?.length ?? 0}
-                items={(scanResult.groupChats ?? []).map((g) => `${g.groupName} (${g.members.join(", ")})`)}
-                checked={options.groupChats}
-                onChange={(v) => setOptions((o) => ({ ...o, groupChats: v }))}
+                items={scanResult.groupChats}
+                selectedIds={selection.groupChats}
+                onToggleItem={(itemId, checked) => toggleCategoryItem("groupChats", itemId, checked)}
+                onSelectAll={() => updateCategorySelection("groupChats", scanResult.groupChats.map((item) => item.id))}
+                onSelectNone={() => updateCategorySelection("groupChats", [])}
+                getItemLabel={(item) => item.groupName || item.name}
+                renderDetails={(item) => {
+                  const modified = formatModifiedAt(item.modifiedAt);
+                  return (
+                    <span>
+                      {item.members.length > 0 ? item.members.join(", ") : "No linked members"}
+                      {modified ? ` · modified ${modified}` : ""}
+                    </span>
+                  );
+                }}
               />
 
-              <ImportCategory
+              <SelectableImportCategory
                 icon={<FileText size="0.875rem" />}
                 label="Presets"
-                count={scanResult.presets.length}
-                items={scanResult.presets.map((p) => p.name)}
-                checked={options.presets}
-                onChange={(v) => setOptions((o) => ({ ...o, presets: v }))}
+                items={scanResult.presets}
+                selectedIds={selection.presets}
+                onToggleItem={(itemId, checked) => toggleCategoryItem("presets", itemId, checked)}
+                onSelectAll={() => updateCategorySelection("presets", scanResult.presets.map((item) => item.id))}
+                onSelectNone={() => updateCategorySelection("presets", [])}
+                renderDetails={(item) => {
+                  const modified = formatModifiedAt(item.modifiedAt);
+                  return (
+                    <span>
+                      {item.isBuiltin ? "Detected built-in preset" : "Custom or user preset"}
+                      {modified ? ` · modified ${modified}` : ""}
+                    </span>
+                  );
+                }}
+                renderBadge={(item) =>
+                  item.isBuiltin ? (
+                    <span className="rounded-full bg-amber-500/15 px-2 py-0.5 text-[0.5625rem] font-medium text-amber-400">
+                      Built-in
+                    </span>
+                  ) : null
+                }
               />
 
-              <ImportCategory
+              <SelectableImportCategory
                 icon={<BookOpen size="0.875rem" />}
                 label="Lorebooks"
-                count={scanResult.lorebooks.length}
-                items={scanResult.lorebooks.map((l) => l.name)}
-                checked={options.lorebooks}
-                onChange={(v) => setOptions((o) => ({ ...o, lorebooks: v }))}
+                items={scanResult.lorebooks}
+                selectedIds={selection.lorebooks}
+                onToggleItem={(itemId, checked) => toggleCategoryItem("lorebooks", itemId, checked)}
+                onSelectAll={() => updateCategorySelection("lorebooks", scanResult.lorebooks.map((item) => item.id))}
+                onSelectNone={() => updateCategorySelection("lorebooks", [])}
+                renderDetails={(item) => {
+                  const modified = formatModifiedAt(item.modifiedAt);
+                  return modified ? <span>Modified {modified}</span> : null;
+                }}
               />
 
-              <ImportCategory
+              <SelectableImportCategory
                 icon={<Image size="0.875rem" />}
                 label="Backgrounds"
-                count={scanResult.backgrounds.length}
-                items={scanResult.backgrounds.map((b) => b.name)}
-                checked={options.backgrounds}
-                onChange={(v) => setOptions((o) => ({ ...o, backgrounds: v }))}
+                items={scanResult.backgrounds}
+                selectedIds={selection.backgrounds}
+                onToggleItem={(itemId, checked) => toggleCategoryItem("backgrounds", itemId, checked)}
+                onSelectAll={() =>
+                  updateCategorySelection("backgrounds", scanResult.backgrounds.map((item) => item.id))
+                }
+                onSelectNone={() => updateCategorySelection("backgrounds", [])}
+                renderDetails={(item) => {
+                  const modified = formatModifiedAt(item.modifiedAt);
+                  return modified ? <span>Modified {modified}</span> : null;
+                }}
               />
 
-              <ImportCategory
+              <SelectableImportCategory
                 icon={<UserCircle size="0.875rem" />}
                 label="Personas"
-                count={scanResult.personas?.length ?? 0}
-                items={(scanResult.personas ?? []).map((p) => p.name)}
-                checked={options.personas}
-                onChange={(v) => setOptions((o) => ({ ...o, personas: v }))}
+                items={scanResult.personas}
+                selectedIds={selection.personas}
+                onToggleItem={(itemId, checked) => toggleCategoryItem("personas", itemId, checked)}
+                onSelectAll={() => updateCategorySelection("personas", scanResult.personas.map((item) => item.id))}
+                onSelectNone={() => updateCategorySelection("personas", [])}
+                renderDetails={(item) => {
+                  const modified = formatModifiedAt(item.modifiedAt);
+                  const description = item.description?.trim();
+                  return (
+                    <span>
+                      {description || "No description"}
+                      {modified ? ` · modified ${modified}` : ""}
+                    </span>
+                  );
+                }}
               />
             </div>
 
-            <div className="flex items-center gap-2">
+            {error && (
+              <div className="flex items-start gap-2 rounded-lg bg-[var(--destructive)]/10 p-3 text-xs text-[var(--destructive)]">
+                <XCircle size="0.875rem" className="mt-0.5 shrink-0" />
+                <span>{error}</span>
+              </div>
+            )}
+
+            <div className="flex items-center gap-2 max-sm:flex-col">
               <button
                 onClick={reset}
                 className="flex-1 rounded-lg border border-[var(--border)] px-3 py-2 text-xs font-medium transition-all hover:bg-[var(--secondary)] active:scale-95"
@@ -441,18 +588,12 @@ export function STBulkImportModal({ open, onClose }: Props) {
               </button>
               <button
                 onClick={handleImport}
-                disabled={
-                  !options.characters &&
-                  !options.chats &&
-                  !options.groupChats &&
-                  !options.presets &&
-                  !options.lorebooks &&
-                  !options.backgrounds &&
-                  !options.personas
-                }
+                disabled={!hasAnySelected}
                 className={cn(
                   "flex flex-1 items-center justify-center gap-1.5 rounded-lg px-3 py-2 text-xs font-medium transition-all active:scale-95",
-                  "bg-[var(--primary)] text-[var(--primary-foreground)] hover:opacity-90",
+                  hasAnySelected
+                    ? "bg-[var(--primary)] text-[var(--primary-foreground)] hover:opacity-90"
+                    : "cursor-not-allowed bg-[var(--secondary)] text-[var(--muted-foreground)] opacity-60",
                 )}
               >
                 <Import size="0.875rem" />
@@ -462,11 +603,10 @@ export function STBulkImportModal({ open, onClose }: Props) {
           </>
         )}
 
-        {/* ── Phase: Importing ── */}
         {phase === "importing" && (
           <div className="flex flex-col items-center gap-4 py-6">
             <Loader2 size="2rem" className="animate-spin text-[var(--primary)]" />
-            <p className="text-sm font-medium">Importing your data…</p>
+            <p className="text-sm font-medium">Importing your data...</p>
             {progress ? (
               <div className="flex w-full flex-col gap-2">
                 <div className="flex items-center justify-between text-xs">
@@ -478,12 +618,11 @@ export function STBulkImportModal({ open, onClose }: Props) {
                 <div className="h-1.5 w-full overflow-hidden rounded-full bg-[var(--secondary)]">
                   <div
                     className="h-full rounded-full bg-[var(--primary)] transition-all duration-200"
-                    style={{ width: `${Math.round((progress.current / progress.total) * 100)}%` }}
+                    style={{ width: `${Math.round((progress.current / Math.max(progress.total, 1)) * 100)}%` }}
                   />
                 </div>
                 <p className="truncate text-[0.6875rem] text-[var(--muted-foreground)]">{progress.item}</p>
 
-                {/* Running totals */}
                 <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-[0.625rem] text-[var(--muted-foreground)]">
                   {progress.imported.characters > 0 && <span>{progress.imported.characters} characters</span>}
                   {progress.imported.chats > 0 && <span>{progress.imported.chats} chats</span>}
@@ -495,12 +634,11 @@ export function STBulkImportModal({ open, onClose }: Props) {
                 </div>
               </div>
             ) : (
-              <p className="text-xs text-[var(--muted-foreground)]">Preparing…</p>
+              <p className="text-xs text-[var(--muted-foreground)]">Preparing...</p>
             )}
           </div>
         )}
 
-        {/* ── Phase: Done ── */}
         {phase === "done" && importResult && (
           <>
             <div
@@ -528,7 +666,7 @@ export function STBulkImportModal({ open, onClose }: Props) {
                 <StatCard
                   icon={<Users size="0.875rem" />}
                   label="Group Chats"
-                  count={importResult.imported.groupChats ?? 0}
+                  count={importResult.imported.groupChats}
                 />
                 <StatCard icon={<FileText size="0.875rem" />} label="Presets" count={importResult.imported.presets} />
                 <StatCard
@@ -544,7 +682,7 @@ export function STBulkImportModal({ open, onClose }: Props) {
                 <StatCard
                   icon={<UserCircle size="0.875rem" />}
                   label="Personas"
-                  count={importResult.imported.personas ?? 0}
+                  count={importResult.imported.personas}
                 />
               </div>
             )}
@@ -556,9 +694,9 @@ export function STBulkImportModal({ open, onClose }: Props) {
                   {importResult.errors.length} warning{importResult.errors.length !== 1 ? "s" : ""}
                 </div>
                 <div className="max-h-24 overflow-y-auto text-[0.625rem] text-[var(--muted-foreground)]">
-                  {importResult.errors.map((err, i) => (
-                    <div key={i} className="py-0.5">
-                      {err}
+                  {importResult.errors.map((warning, index) => (
+                    <div key={`${warning}-${index}`} className="py-0.5">
+                      {warning}
                     </div>
                   ))}
                 </div>
@@ -578,66 +716,111 @@ export function STBulkImportModal({ open, onClose }: Props) {
   );
 }
 
-// ─── Sub-components ───
-
-function ImportCategory({
+function SelectableImportCategory<T extends ScanItemBase>({
   icon,
   label,
-  count,
   items,
-  checked,
-  onChange,
+  selectedIds,
+  onToggleItem,
+  onSelectAll,
+  onSelectNone,
+  getItemLabel,
+  renderDetails,
+  renderBadge,
 }: {
   icon: React.ReactNode;
   label: string;
-  count: number;
-  items: string[];
-  checked: boolean;
-  onChange: (v: boolean) => void;
+  items: T[];
+  selectedIds: string[];
+  onToggleItem: (itemId: string, checked: boolean) => void;
+  onSelectAll: () => void;
+  onSelectNone: () => void;
+  getItemLabel?: (item: T) => string;
+  renderDetails?: (item: T) => React.ReactNode;
+  renderBadge?: (item: T) => React.ReactNode;
 }) {
-  const [expanded, setExpanded] = useState(false);
-  const displayItems = items.slice(0, 20);
-  const remaining = items.length - displayItems.length;
+  const [expanded, setExpanded] = useState(items.length <= 8 && items.length > 0);
+  const selectedSet = new Set(selectedIds);
 
   return (
-    <div className="rounded-lg border border-[var(--border)] transition-colors">
-      <label className="flex cursor-pointer items-center gap-2.5 p-2.5">
-        <input
-          type="checkbox"
-          checked={checked && count > 0}
-          disabled={count === 0}
-          onChange={(e) => onChange(e.target.checked)}
-          className="h-3.5 w-3.5 rounded border-[var(--border)] accent-[var(--primary)]"
-        />
-        <span className={cn("text-[var(--muted-foreground)]", count === 0 && "opacity-40")}>{icon}</span>
-        <span className="flex-1 text-xs font-medium">
-          {label} <span className={cn("text-[var(--muted-foreground)]", count === 0 && "opacity-40")}>({count})</span>
-        </span>
-        {count > 0 && (
-          <button
-            type="button"
-            onClick={(e) => {
-              e.preventDefault();
-              setExpanded(!expanded);
-            }}
-            className="text-[0.625rem] text-[var(--primary)] hover:underline"
-          >
-            {expanded ? "Hide" : "Show"}
-          </button>
+    <div className="rounded-lg border border-[var(--border)]">
+      <div className="flex items-center gap-2.5 p-2.5">
+        <span className={cn("shrink-0 text-[var(--muted-foreground)]", items.length === 0 && "opacity-40")}>{icon}</span>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="text-xs font-medium">
+              {label}{" "}
+              <span className={cn("text-[var(--muted-foreground)]", items.length === 0 && "opacity-40")}>
+                ({selectedIds.length}/{items.length})
+              </span>
+            </span>
+          </div>
+        </div>
+        {items.length > 0 && (
+          <>
+            <button
+              type="button"
+              onClick={onSelectAll}
+              className="rounded-md px-2 py-1 text-[0.625rem] font-medium text-[var(--primary)] transition-colors hover:bg-[var(--accent)]"
+            >
+              All
+            </button>
+            <button
+              type="button"
+              onClick={onSelectNone}
+              className="rounded-md px-2 py-1 text-[0.625rem] font-medium text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+            >
+              None
+            </button>
+            <button
+              type="button"
+              onClick={() => setExpanded((prev) => !prev)}
+              className="rounded-md px-2 py-1 text-[0.625rem] font-medium text-[var(--primary)] transition-colors hover:bg-[var(--accent)]"
+            >
+              {expanded ? "Hide" : "Show"}
+            </button>
+          </>
         )}
-      </label>
-      {expanded && count > 0 && (
-        <div className="border-t border-[var(--border)] px-2.5 py-2 max-h-28 overflow-y-auto">
-          {displayItems.map((name, i) => (
-            <div key={i} className="truncate py-0.5 text-[0.625rem] text-[var(--muted-foreground)]">
-              {name}
-            </div>
-          ))}
-          {remaining > 0 && (
-            <div className="py-0.5 text-[0.625rem] font-medium text-[var(--muted-foreground)]">
-              … and {remaining} more
-            </div>
-          )}
+      </div>
+
+      {expanded && items.length > 0 && (
+        <div className="max-h-60 space-y-1 overflow-y-auto border-t border-[var(--border)] px-2.5 py-2">
+          {items.map((item) => {
+            const checked = selectedSet.has(item.id);
+            return (
+              <label
+                key={item.id}
+                className={cn(
+                  "flex cursor-pointer items-start gap-2 rounded-lg px-2 py-2 transition-colors hover:bg-[var(--secondary)]/70",
+                  checked && "bg-[var(--primary)]/6",
+                )}
+              >
+                <input
+                  type="checkbox"
+                  checked={checked}
+                  onChange={(e) => onToggleItem(item.id, e.target.checked)}
+                  className="mt-0.5 h-3.5 w-3.5 rounded border-[var(--border)] accent-[var(--primary)]"
+                />
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <span className="truncate text-xs font-medium">{getItemLabel ? getItemLabel(item) : item.name}</span>
+                    {renderBadge?.(item)}
+                    {checked && (
+                      <span className="shrink-0 rounded-full bg-[var(--primary)]/15 px-1.5 py-0.5 text-[0.5625rem] font-medium text-[var(--primary)]">
+                        <span className="inline-flex items-center gap-1">
+                          <Check size="0.5625rem" />
+                          Selected
+                        </span>
+                      </span>
+                    )}
+                  </div>
+                  {renderDetails && (
+                    <div className="truncate text-[0.625rem] text-[var(--muted-foreground)]">{renderDetails(item)}</div>
+                  )}
+                </div>
+              </label>
+            );
+          })}
         </div>
       )}
     </div>

--- a/packages/client/src/components/panels/AgentsPanel.tsx
+++ b/packages/client/src/components/panels/AgentsPanel.tsx
@@ -28,6 +28,7 @@ export function AgentsPanel() {
   const createRegexScript = useCreateRegexScript();
   const [importError, setImportError] = useState<string | null>(null);
   const [importSuccess, setImportSuccess] = useState<string | null>(null);
+  const [viewMode, setViewMode] = useState<"category" | "status">("category");
 
   // Handler for importing regex scripts from JSON (supports ST format and native)
   const handleImportRegex = async (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -95,6 +96,31 @@ export function AgentsPanel() {
   const customAgents = ((agentConfigs ?? []) as AgentConfigRow[]).filter(
     (c) => !BUILT_IN_AGENTS.some((b) => b.id === c.type),
   );
+  const configByType = new Map(((agentConfigs ?? []) as AgentConfigRow[]).map((config) => [config.type, config]));
+
+  const statusAgents = [
+    ...BUILT_IN_AGENTS.map((agent) => ({
+      id: agent.id,
+      type: agent.id,
+      name: agent.name,
+      description: agent.description,
+      category: agent.category,
+      enabled: configByType.get(agent.id)?.enabled !== "false",
+      custom: false,
+    })),
+    ...customAgents.map((agent) => ({
+      id: agent.id,
+      type: agent.type,
+      name: agent.name,
+      description: agent.description,
+      category: "custom" as const,
+      enabled: agent.enabled !== "false",
+      custom: true,
+    })),
+  ];
+
+  const activeAgents = statusAgents.filter((agent) => agent.enabled);
+  const inactiveAgents = statusAgents.filter((agent) => !agent.enabled);
 
   const handleCreateAgent = () => {
     // Create a new custom agent immediately in DB then open editor
@@ -112,6 +138,31 @@ export function AgentsPanel() {
   return (
     <div className="flex flex-col gap-1 p-3">
       {isLoading && <div className="py-4 text-center text-xs text-[var(--muted-foreground)]">Loading...</div>}
+
+      <div className="mb-1 flex items-center gap-1 rounded-lg bg-[var(--secondary)] p-1 ring-1 ring-[var(--border)]">
+        <button
+          onClick={() => setViewMode("category")}
+          className={cn(
+            "flex-1 rounded-md px-2 py-1 text-[0.625rem] font-medium transition-all",
+            viewMode === "category"
+              ? "bg-[var(--primary)]/15 text-[var(--primary)] ring-1 ring-[var(--primary)]/25"
+              : "text-[var(--muted-foreground)] hover:bg-[var(--accent)]",
+          )}
+        >
+          By Category
+        </button>
+        <button
+          onClick={() => setViewMode("status")}
+          className={cn(
+            "flex-1 rounded-md px-2 py-1 text-[0.625rem] font-medium transition-all",
+            viewMode === "status"
+              ? "bg-[var(--primary)]/15 text-[var(--primary)] ring-1 ring-[var(--primary)]/25"
+              : "text-[var(--muted-foreground)] hover:bg-[var(--accent)]",
+          )}
+        >
+          By Status
+        </button>
+      </div>
 
       {/* ── Regex Scripts (moved to top) ── */}
       <PanelSection
@@ -215,116 +266,140 @@ export function AgentsPanel() {
         )}
       </PanelSection>
 
-      {/* ── Built-in Agents ── */}
-      {[
-        {
-          category: "writer" as AgentCategory,
-          title: "Writer Agents",
-          icon: <PenLine size="0.8125rem" />,
-          desc: "Prose quality, continuity, directions, and narrative flow.",
-        },
-        {
-          category: "tracker" as AgentCategory,
-          title: "Tracker Agents",
-          icon: <Radar size="0.8125rem" />,
-          desc: "Track world state, expressions, quests, backgrounds, and characters.",
-        },
-        {
-          category: "misc" as AgentCategory,
-          title: "Misc Agents",
-          icon: <Puzzle size="0.8125rem" />,
-          desc: "Utilities, combat, illustrations, and other helpers.",
-        },
-      ].map(({ category, title, icon, desc }) => {
-        const agents = BUILT_IN_AGENTS.filter((a) => a.category === category);
-        return (
-          <PanelSection key={category} title={title} icon={icon}>
-            <div className="text-[0.625rem] text-[var(--muted-foreground)] mb-1.5">{desc}</div>
-            {!agents.length ? (
-              <p className="text-[0.625rem] text-[var(--muted-foreground)] px-1 py-2">No agents in this category.</p>
+      {viewMode === "category" ? (
+        <>
+          {/* ── Built-in Agents ── */}
+          {[
+            {
+              category: "writer" as AgentCategory,
+              title: "Writer Agents",
+              icon: <PenLine size="0.8125rem" />,
+              desc: "Prose quality, continuity, directions, and narrative flow.",
+            },
+            {
+              category: "tracker" as AgentCategory,
+              title: "Tracker Agents",
+              icon: <Radar size="0.8125rem" />,
+              desc: "Track world state, expressions, quests, backgrounds, and characters.",
+            },
+            {
+              category: "misc" as AgentCategory,
+              title: "Misc Agents",
+              icon: <Puzzle size="0.8125rem" />,
+              desc: "Utilities, combat, illustrations, and other helpers.",
+            },
+          ].map(({ category, title, icon, desc }) => {
+            const agents = BUILT_IN_AGENTS.filter((a) => a.category === category);
+            return (
+              <PanelSection key={category} title={title} icon={icon}>
+                <div className="mb-1.5 text-[0.625rem] text-[var(--muted-foreground)]">{desc}</div>
+                {!agents.length ? (
+                  <p className="px-1 py-2 text-[0.625rem] text-[var(--muted-foreground)]">No agents in this category.</p>
+                ) : (
+                  agents.map((agent) =>
+                    renderAgentCard({
+                      id: agent.id,
+                      type: agent.id,
+                      name: agent.name,
+                      description: agent.description,
+                      category: agent.category,
+                      enabled: configByType.get(agent.id)?.enabled !== "false",
+                      custom: false,
+                      openAgentDetail,
+                    }),
+                  )
+                )}
+              </PanelSection>
+            );
+          })}
+        </>
+      ) : (
+        <>
+          <PanelSection title="Active Agents" icon={<Sparkles size="0.8125rem" />}>
+            <div className="mb-1.5 text-[0.625rem] text-[var(--muted-foreground)]">
+              Built-ins default to active unless explicitly disabled in their config.
+            </div>
+            {!activeAgents.length ? (
+              <p className="px-1 py-2 text-[0.625rem] text-[var(--muted-foreground)]">No active agents.</p>
             ) : (
-              agents.map((agent) => {
-                return (
-                  <div
-                    key={agent.id}
-                    className="flex items-start gap-2.5 rounded-lg p-2 transition-colors hover:bg-[var(--sidebar-accent)]"
-                  >
-                    <Sparkles size="0.875rem" className="mt-0.5 shrink-0 text-[var(--primary)]" />
-                    <button className="min-w-0 flex-1 text-left" onClick={() => openAgentDetail(agent.id)}>
-                      <div className="text-xs font-medium font-mono">{agent.name}</div>
-                      <div className="text-[0.625rem] text-[var(--muted-foreground)] line-clamp-2">
-                        {agent.description || "No description"}
-                      </div>
-                    </button>
-                    <button
-                      className="mt-0.5 shrink-0 text-[var(--muted-foreground)] transition-colors hover:text-[var(--primary)]"
-                      title="Edit agent"
-                      onClick={() => openAgentDetail(agent.id)}
-                    >
-                      <Pencil size="0.8125rem" />
-                    </button>
-                  </div>
-                );
-              })
+              activeAgents.map((agent) => renderAgentCard({ ...agent, openAgentDetail }))
             )}
           </PanelSection>
-        );
-      })}
+          <PanelSection title="Inactive Agents" icon={<Sparkles size="0.8125rem" />}>
+            {!inactiveAgents.length ? (
+              <p className="px-1 py-2 text-[0.625rem] text-[var(--muted-foreground)]">No inactive agents.</p>
+            ) : (
+              inactiveAgents.map((agent) => renderAgentCard({ ...agent, openAgentDetail }))
+            )}
+          </PanelSection>
+        </>
+      )}
 
-      {/* ── Custom Agents ── */}
-      <PanelSection
-        title="Custom Agents"
-        icon={<Sparkles size="0.8125rem" />}
-        action={
-          <button
-            onClick={handleCreateAgent}
-            className="rounded-md p-1 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--primary)]"
-            title="Create custom agent"
-          >
-            <Plus size="0.8125rem" />
-          </button>
-        }
-      >
-        <div className="text-[0.625rem] text-[var(--muted-foreground)] mb-1.5">
-          Create your own AI agents with custom instructions and settings.
-        </div>
-        {!customAgents.length ? (
-          <p className="text-[0.625rem] text-[var(--muted-foreground)] px-1 py-2">No custom agents yet.</p>
-        ) : (
-          customAgents.map((agent) => {
-            return (
-              <div
-                key={agent.id}
-                className="flex items-start gap-2.5 rounded-lg p-2 transition-colors hover:bg-[var(--sidebar-accent)]"
-              >
-                <Sparkles size="0.875rem" className="mt-0.5 shrink-0 text-[var(--primary)]" />
-                <button className="min-w-0 flex-1 text-left" onClick={() => openAgentDetail(agent.id)}>
-                  <div className="text-xs font-medium font-mono">{agent.name}</div>
-                  <div className="text-[0.625rem] text-[var(--muted-foreground)] line-clamp-2">
-                    {agent.description || "No description"}
-                  </div>
-                </button>
-                <button
-                  className="mt-0.5 shrink-0 text-[var(--muted-foreground)] transition-colors hover:text-[var(--primary)]"
-                  title="Edit agent"
-                  onClick={() => openAgentDetail(agent.id)}
+      {viewMode === "category" && (
+        <PanelSection
+          title="Custom Agents"
+          icon={<Sparkles size="0.8125rem" />}
+          action={
+            <button
+              onClick={handleCreateAgent}
+              className="rounded-md p-1 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--primary)]"
+              title="Create custom agent"
+            >
+              <Plus size="0.8125rem" />
+            </button>
+          }
+        >
+          <div className="text-[0.625rem] text-[var(--muted-foreground)] mb-1.5">
+            Create your own AI agents with custom instructions and settings.
+          </div>
+          {!customAgents.length ? (
+            <p className="text-[0.625rem] text-[var(--muted-foreground)] px-1 py-2">No custom agents yet.</p>
+          ) : (
+            customAgents.map((agent) => {
+              return (
+                <div
+                  key={agent.id}
+                  className="flex items-start gap-2.5 rounded-lg p-2 transition-colors hover:bg-[var(--sidebar-accent)]"
                 >
-                  <Pencil size="0.8125rem" />
-                </button>
-                <button
-                  className="mt-0.5 shrink-0 text-[var(--muted-foreground)] transition-colors hover:text-[var(--destructive)]"
-                  title="Delete agent"
-                  onClick={() => {
-                    if (confirm(`Delete "${agent.name}"?`)) deleteAgent.mutate(agent.id);
-                  }}
-                >
-                  <Trash2 size="0.8125rem" />
-                </button>
-              </div>
-            );
-          })
-        )}
-      </PanelSection>
+                  <Sparkles size="0.875rem" className="mt-0.5 shrink-0 text-[var(--primary)]" />
+                  <button className="min-w-0 flex-1 text-left" onClick={() => openAgentDetail(agent.id)}>
+                    <div className="text-xs font-medium font-mono">{agent.name}</div>
+                    <div className="text-[0.625rem] text-[var(--muted-foreground)] line-clamp-2">
+                      {agent.description || "No description"}
+                    </div>
+                  </button>
+                  <span
+                    className={cn(
+                      "mt-0.5 rounded px-1.5 py-0.5 text-[0.5625rem]",
+                      agent.enabled === "false"
+                        ? "bg-[var(--secondary)] text-[var(--muted-foreground)]"
+                        : "bg-emerald-500/10 text-emerald-400",
+                    )}
+                  >
+                    {agent.enabled === "false" ? "inactive" : "active"}
+                  </span>
+                  <button
+                    className="mt-0.5 shrink-0 text-[var(--muted-foreground)] transition-colors hover:text-[var(--primary)]"
+                    title="Edit agent"
+                    onClick={() => openAgentDetail(agent.id)}
+                  >
+                    <Pencil size="0.8125rem" />
+                  </button>
+                  <button
+                    className="mt-0.5 shrink-0 text-[var(--muted-foreground)] transition-colors hover:text-[var(--destructive)]"
+                    title="Delete agent"
+                    onClick={() => {
+                      if (confirm(`Delete "${agent.name}"?`)) deleteAgent.mutate(agent.id);
+                    }}
+                  >
+                    <Trash2 size="0.8125rem" />
+                  </button>
+                </div>
+              );
+            })
+          )}
+        </PanelSection>
+      )}
 
       {/* ── Custom Function Tools ── */}
       <PanelSection
@@ -381,6 +456,58 @@ export function AgentsPanel() {
           ))
         )}
       </PanelSection>
+    </div>
+  );
+}
+
+function renderAgentCard({
+  id,
+  type,
+  name,
+  description,
+  category,
+  enabled,
+  custom,
+  openAgentDetail,
+}: {
+  id: string;
+  type: string;
+  name: string;
+  description: string;
+  category: AgentCategory | "custom";
+  enabled: boolean;
+  custom: boolean;
+  openAgentDetail: (id: string) => void;
+}) {
+  return (
+    <div key={id} className={cn("flex items-start gap-2.5 rounded-lg p-2 transition-colors hover:bg-[var(--sidebar-accent)]", !enabled && "opacity-55")}>
+      <Sparkles size="0.875rem" className="mt-0.5 shrink-0 text-[var(--primary)]" />
+      <button className="min-w-0 flex-1 text-left" onClick={() => openAgentDetail(custom ? id : type)}>
+        <div className="flex items-center gap-1.5">
+          <span className="truncate text-xs font-medium font-mono">{name}</span>
+          <span
+            className={cn(
+              "rounded px-1.5 py-0.5 text-[0.5rem] uppercase tracking-wide",
+              enabled ? "bg-emerald-500/10 text-emerald-400" : "bg-[var(--secondary)] text-[var(--muted-foreground)]",
+            )}
+          >
+            {enabled ? "active" : "inactive"}
+          </span>
+        </div>
+        <div className="mt-0.5 text-[0.625rem] text-[var(--muted-foreground)] line-clamp-2">
+          {description || "No description"}
+        </div>
+        <div className="mt-1 text-[0.5625rem] uppercase tracking-wide text-[var(--muted-foreground)]/80">
+          {custom ? "custom" : category}
+        </div>
+      </button>
+      <button
+        className="mt-0.5 shrink-0 text-[var(--muted-foreground)] transition-colors hover:text-[var(--primary)]"
+        title="Edit agent"
+        onClick={() => openAgentDetail(custom ? id : type)}
+      >
+        <Pencil size="0.8125rem" />
+      </button>
     </div>
   );
 }

--- a/packages/client/src/components/panels/CharactersPanel.tsx
+++ b/packages/client/src/components/panels/CharactersPanel.tsx
@@ -43,8 +43,34 @@ import { cn, getAvatarCropStyle } from "../../lib/utils";
 
 type CharacterRow = { id: string; data: string; avatarPath: string | null; createdAt: string; updatedAt: string };
 type GroupRow = { id: string; name: string; description: string; characterIds: string; avatarPath: string | null };
+type ParsedCharacterRow = CharacterRow & { parsed: Record<string, any> };
 
 type SortOption = "name-asc" | "name-desc" | "newest" | "oldest" | "favorites";
+
+function getCharacterPreviewMetadata(char: ParsedCharacterRow) {
+  const parts: string[] = [];
+  const creator = typeof char.parsed.creator === "string" ? char.parsed.creator.trim() : "";
+  const version = typeof char.parsed.character_version === "string" ? char.parsed.character_version.trim() : "";
+  const importMetadata =
+    char.parsed.extensions?.importMetadata && typeof char.parsed.extensions.importMetadata === "object"
+      ? (char.parsed.extensions.importMetadata as Record<string, unknown>)
+      : {};
+  const cardMetadata =
+    importMetadata.card && typeof importMetadata.card === "object"
+      ? (importMetadata.card as Record<string, unknown>)
+      : {};
+  const spec = typeof cardMetadata.spec === "string" ? cardMetadata.spec.trim() : "";
+  const specVersion = typeof cardMetadata.specVersion === "string" ? cardMetadata.specVersion.trim() : "";
+  const tags = Array.isArray(char.parsed.tags) ? (char.parsed.tags as string[]).filter(Boolean) : [];
+
+  if (creator) parts.push(`by ${creator}`);
+  if (version) parts.push(`v${version}`);
+  if (spec) parts.push(spec);
+  if (specVersion) parts.push(`spec ${specVersion}`);
+  if (parts.length > 0) return parts.join(" · ");
+  if (tags.length > 0) return tags.slice(0, 3).join(" · ");
+  return "No creator or card metadata";
+}
 
 export function CharactersPanel() {
   const { data: characters, isLoading } = useCharacters();
@@ -80,6 +106,9 @@ export function CharactersPanel() {
   const [activeTag, setActiveTag] = useState<string | null>(null);
   const [tagsExpanded, setTagsExpanded] = useState(false);
   const [favFilter, setFavFilter] = useState<"all" | "favorites" | "non-favorites">("all");
+  const [selectionMode, setSelectionMode] = useState(false);
+  const [selectedCharacterIds, setSelectedCharacterIds] = useState<Set<string>>(new Set());
+  const [exportingSelected, setExportingSelected] = useState(false);
 
   const chatCharacterIds: string[] = activeChat
     ? ((typeof activeChat.characterIds === "string" ? JSON.parse(activeChat.characterIds) : activeChat.characterIds) ??
@@ -99,7 +128,7 @@ export function CharactersPanel() {
         return { ...char, parsed: { name: "Unknown", description: "" } };
       }
     });
-  }, [characters]);
+  }, [characters]) as ParsedCharacterRow[];
 
   const charMap = useMemo(() => {
     const map = new Map<string, { name: string; avatarPath: string | null }>();
@@ -290,6 +319,41 @@ export function CharactersPanel() {
     [updateGroup],
   );
 
+  const exitSelectionMode = useCallback(() => {
+    setSelectionMode(false);
+    setSelectedCharacterIds(new Set());
+  }, []);
+
+  const toggleSelection = useCallback((characterId: string) => {
+    setSelectedCharacterIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(characterId)) next.delete(characterId);
+      else next.add(characterId);
+      return next;
+    });
+  }, []);
+
+  const selectAllVisible = useCallback(() => {
+    setSelectedCharacterIds(new Set(sortedCharacters.map((char) => char.id)));
+  }, [sortedCharacters]);
+
+  const handleExportSelected = useCallback(async () => {
+    if (selectedCharacterIds.size === 0) return;
+    setExportingSelected(true);
+    try {
+      await api.downloadPost(
+        "/characters/export-bulk",
+        { ids: [...selectedCharacterIds] },
+        "marinara-characters.zip",
+      );
+      toast.success(`Exported ${selectedCharacterIds.size} character${selectedCharacterIds.size === 1 ? "" : "s"}`);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to export characters");
+    } finally {
+      setExportingSelected(false);
+    }
+  }, [selectedCharacterIds]);
+
   return (
     <div className="flex flex-col gap-2 p-3">
       {/* Search + Sort */}
@@ -431,7 +495,62 @@ export function CharactersPanel() {
         >
           <Sparkles size="0.75rem" />
         </button>
+        <button
+          onClick={() => {
+            if (selectionMode) {
+              exitSelectionMode();
+            } else {
+              setAssigningToGroup(null);
+              setSelectionMode(true);
+            }
+          }}
+          className={cn(
+            "flex items-center justify-center gap-1 rounded-xl px-3 py-2 text-xs font-medium transition-all",
+            selectionMode
+              ? "bg-[var(--primary)]/15 text-[var(--primary)] ring-1 ring-[var(--primary)]/30"
+              : "bg-[var(--secondary)] text-[var(--secondary-foreground)] ring-1 ring-[var(--border)] hover:bg-[var(--accent)]",
+          )}
+        >
+          <Check size="0.75rem" />
+          Select
+        </button>
       </div>
+
+      {selectionMode && (
+        <div className="flex flex-wrap items-center gap-2 rounded-xl border border-[var(--border)] bg-[var(--secondary)]/60 px-3 py-2">
+          <span className="text-[0.6875rem] font-medium text-[var(--muted-foreground)]">
+            {selectedCharacterIds.size} selected
+          </span>
+          <button
+            onClick={selectAllVisible}
+            disabled={sortedCharacters.length === 0}
+            className="rounded-lg px-2.5 py-1 text-[0.625rem] font-medium text-[var(--primary)] transition-colors hover:bg-[var(--accent)] disabled:opacity-40"
+          >
+            Select visible
+          </button>
+          <button
+            onClick={() => setSelectedCharacterIds(new Set())}
+            disabled={selectedCharacterIds.size === 0}
+            className="rounded-lg px-2.5 py-1 text-[0.625rem] font-medium text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] disabled:opacity-40"
+          >
+            Clear
+          </button>
+          <button
+            onClick={handleExportSelected}
+            disabled={selectedCharacterIds.size === 0 || exportingSelected}
+            className="inline-flex items-center gap-1 rounded-lg bg-[var(--primary)] px-2.5 py-1 text-[0.625rem] font-medium text-[var(--primary-foreground)] transition-all hover:opacity-90 disabled:opacity-40"
+          >
+            <Download size="0.6875rem" />
+            {exportingSelected ? "Exporting..." : "Export ZIP"}
+          </button>
+          <button
+            onClick={exitSelectionMode}
+            className="rounded-lg px-2.5 py-1 text-[0.625rem] font-medium text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+          >
+            Done
+          </button>
+        </div>
+      )}
 
       {/* ── Groups Section ── */}
       <div className="mt-1">
@@ -548,6 +667,9 @@ export function CharactersPanel() {
                       <button
                         onClick={(e) => {
                           e.stopPropagation();
+                          if (!isAssigning) {
+                            exitSelectionMode();
+                          }
                           setAssigningToGroup(isAssigning ? null : group.id);
                         }}
                         className={cn(
@@ -658,6 +780,7 @@ export function CharactersPanel() {
       <div className="flex items-center gap-1.5 px-1 pt-1 text-[0.6875rem] font-semibold uppercase tracking-wider text-[var(--muted-foreground)]">
         <User size="0.6875rem" />
         Characters ({filteredCharacters.length})
+        {selectionMode && <span className="text-[0.625rem] font-normal normal-case">· {selectedCharacterIds.size} selected</span>}
       </div>
 
       {/* Character list */}
@@ -681,20 +804,23 @@ export function CharactersPanel() {
       <div className="stagger-children flex flex-col gap-1">
         {sortedCharacters.map((char) => {
           const charName = char.parsed.name ?? "Unnamed";
-          const charDesc = char.parsed.description ?? "";
           const charTags = (char.parsed.tags ?? []) as string[];
           const charNameColor = (char.parsed.extensions?.nameColor as string) || undefined;
           const isSelected = chatCharacterIds.includes(char.id);
+          const isBulkSelected = selectedCharacterIds.has(char.id);
           const avatarUrl = char.avatarPath;
           // If assigning to a group, highlight members of that group
           const targetGroup = assigningToGroup ? parsedGroups.find((g) => g.id === assigningToGroup) : null;
           const isInTargetGroup = targetGroup?.memberIds.includes(char.id) ?? false;
+          const previewMetadata = getCharacterPreviewMetadata(char);
 
           return (
             <div
               key={char.id}
               onClick={() => {
-                if (assigningToGroup && targetGroup) {
+                if (selectionMode) {
+                  toggleSelection(char.id);
+                } else if (assigningToGroup && targetGroup) {
                   toggleGroupMember(assigningToGroup, char.id, targetGroup.memberIds);
                 } else {
                   openCharacterDetail(char.id);
@@ -702,11 +828,30 @@ export function CharactersPanel() {
               }}
               className={cn(
                 "group flex items-center gap-2.5 rounded-xl p-2 transition-all hover:bg-[var(--sidebar-accent)] cursor-pointer",
+                selectionMode && isBulkSelected && "ring-1 ring-[var(--primary)]/40 bg-[var(--primary)]/8",
                 isSelected && !assigningToGroup && "ring-1 ring-[var(--primary)]/40 bg-[var(--primary)]/5",
                 assigningToGroup && isInTargetGroup && "ring-1 ring-violet-500/50 bg-violet-500/10",
                 assigningToGroup && !isInTargetGroup && "opacity-60 hover:opacity-100",
               )}
             >
+              {selectionMode && (
+                <button
+                  type="button"
+                  aria-label={isBulkSelected ? "Deselect character" : "Select character"}
+                  className={cn(
+                    "flex h-5 w-5 shrink-0 items-center justify-center rounded border-2 transition-colors",
+                    isBulkSelected
+                      ? "border-[var(--primary)] bg-[var(--primary)] text-white"
+                      : "border-[var(--muted-foreground)]/40 bg-[var(--secondary)] text-transparent",
+                  )}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    toggleSelection(char.id);
+                  }}
+                >
+                  <Check size="0.75rem" />
+                </button>
+              )}
               {/* Avatar */}
               <div className="relative flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-pink-400 to-rose-500 text-white shadow-sm">
                 {avatarUrl ? (
@@ -761,7 +906,7 @@ export function CharactersPanel() {
                     ? isInTargetGroup
                       ? "In group — click to remove"
                       : "Click to add to group"
-                    : charDesc.slice(0, 60) || "No description"}
+                    : previewMetadata}
                 </div>
                 {!assigningToGroup && charTags.length > 0 && (
                   <div className="mt-0.5 flex flex-wrap gap-0.5">
@@ -787,7 +932,7 @@ export function CharactersPanel() {
               </div>
 
               {/* Actions (hidden during group assign mode) */}
-              {!assigningToGroup && (
+              {!assigningToGroup && !selectionMode && (
                 <div className="flex shrink-0 items-center gap-0.5 opacity-0 transition-all group-hover:opacity-100 max-md:opacity-100">
                   {activeChat && (
                     <button
@@ -824,7 +969,7 @@ export function CharactersPanel() {
         })}
       </div>
 
-      {activeChat && !assigningToGroup && (
+      {activeChat && !assigningToGroup && !selectionMode && (
         <p className="px-1 text-[0.625rem] text-[var(--muted-foreground)]/60">
           Click to edit · Use ✓ to assign/remove from chat
         </p>

--- a/packages/client/src/components/panels/LorebooksPanel.tsx
+++ b/packages/client/src/components/panels/LorebooksPanel.tsx
@@ -24,6 +24,7 @@ import { useUIStore } from "../../stores/ui.store";
 import { useLorebooks, useDeleteLorebook, useUpdateLorebook } from "../../hooks/use-lorebooks";
 import type { Lorebook, LorebookCategory } from "@marinara-engine/shared";
 import { cn } from "../../lib/utils";
+import { api } from "../../lib/api-client";
 
 const CATEGORIES: Array<{ id: LorebookCategory | "all"; label: string; icon: typeof Globe }> = [
   { id: "all", label: "All", icon: Layers },
@@ -47,6 +48,9 @@ export function LorebooksPanel() {
   const [sort, setSort] = useState<"name-asc" | "name-desc" | "newest" | "oldest" | "tokens">("name-asc");
   const [activeTag, setActiveTag] = useState<string | null>(null);
   const [tagsExpanded, setTagsExpanded] = useState(false);
+  const [selectionMode, setSelectionMode] = useState(false);
+  const [selectedLorebookIds, setSelectedLorebookIds] = useState<Set<string>>(new Set());
+  const [exportingSelected, setExportingSelected] = useState(false);
 
   const { data: lorebooks, isLoading } = useLorebooks(activeCategory === "all" ? undefined : activeCategory);
   const deleteLorebook = useDeleteLorebook();
@@ -141,6 +145,33 @@ export function LorebooksPanel() {
     return map;
   }, [sorted, activeCategory]);
 
+  const exitSelectionMode = useCallback(() => {
+    setSelectionMode(false);
+    setSelectedLorebookIds(new Set());
+  }, []);
+
+  const toggleSelection = useCallback((lorebookId: string) => {
+    setSelectedLorebookIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(lorebookId)) next.delete(lorebookId);
+      else next.add(lorebookId);
+      return next;
+    });
+  }, []);
+
+  const handleExportSelected = useCallback(async () => {
+    if (selectedLorebookIds.size === 0) return;
+    setExportingSelected(true);
+    try {
+      await api.downloadPost("/lorebooks/export-bulk", { ids: [...selectedLorebookIds] }, "marinara-lorebooks.zip");
+      toast.success(`Exported ${selectedLorebookIds.size} lorebook${selectedLorebookIds.size === 1 ? "" : "s"}`);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to export lorebooks");
+    } finally {
+      setExportingSelected(false);
+    }
+  }, [selectedLorebookIds]);
+
   return (
     <div className="flex flex-col gap-2 p-3">
       {/* Action buttons */}
@@ -164,7 +195,57 @@ export function LorebooksPanel() {
         >
           <Sparkles size="0.8125rem" />
         </button>
+        <button
+          onClick={() => {
+            if (selectionMode) exitSelectionMode();
+            else setSelectionMode(true);
+          }}
+          className={cn(
+            "flex items-center justify-center gap-1.5 rounded-xl px-3 py-2.5 text-xs font-medium transition-all",
+            selectionMode
+              ? "bg-amber-400/15 text-amber-400 ring-1 ring-amber-400/30"
+              : "bg-[var(--secondary)] text-[var(--secondary-foreground)] ring-1 ring-[var(--border)] hover:bg-[var(--accent)]",
+          )}
+        >
+          <Download size="0.8125rem" /> Select
+        </button>
       </div>
+
+      {selectionMode && (
+        <div className="flex flex-wrap items-center gap-2 rounded-xl border border-[var(--border)] bg-[var(--secondary)]/60 px-3 py-2">
+          <span className="text-[0.6875rem] font-medium text-[var(--muted-foreground)]">
+            {selectedLorebookIds.size} selected
+          </span>
+          <button
+            onClick={() => setSelectedLorebookIds(new Set(sorted.map((lb) => lb.id)))}
+            disabled={sorted.length === 0}
+            className="rounded-lg px-2.5 py-1 text-[0.625rem] font-medium text-amber-400 transition-colors hover:bg-[var(--accent)] disabled:opacity-40"
+          >
+            Select visible
+          </button>
+          <button
+            onClick={() => setSelectedLorebookIds(new Set())}
+            disabled={selectedLorebookIds.size === 0}
+            className="rounded-lg px-2.5 py-1 text-[0.625rem] font-medium text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] disabled:opacity-40"
+          >
+            Clear
+          </button>
+          <button
+            onClick={handleExportSelected}
+            disabled={selectedLorebookIds.size === 0 || exportingSelected}
+            className="inline-flex items-center gap-1 rounded-lg bg-amber-500 px-2.5 py-1 text-[0.625rem] font-medium text-white transition-all hover:opacity-90 disabled:opacity-40"
+          >
+            <Download size="0.6875rem" />
+            {exportingSelected ? "Exporting..." : "Export ZIP"}
+          </button>
+          <button
+            onClick={exitSelectionMode}
+            className="rounded-lg px-2.5 py-1 text-[0.625rem] font-medium text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+          >
+            Done
+          </button>
+        </div>
+      )}
 
       {/* Search + Sort */}
       <div className="flex gap-1.5">
@@ -319,10 +400,16 @@ export function LorebooksPanel() {
                       <LorebookRow
                         key={lb.id}
                         lorebook={lb}
-                        onClick={() => openLorebookDetail(lb.id)}
+                        onClick={() => {
+                          if (selectionMode) toggleSelection(lb.id);
+                          else openLorebookDetail(lb.id);
+                        }}
                         onDelete={() => {
                           if (confirm(`Delete "${lb.name}"? All entries will be lost.`)) deleteLorebook.mutate(lb.id);
                         }}
+                        selectionMode={selectionMode}
+                        isSelected={selectedLorebookIds.has(lb.id)}
+                        onToggleSelect={() => toggleSelection(lb.id)}
                       />
                     ))}
                   </div>
@@ -333,10 +420,16 @@ export function LorebooksPanel() {
                 <LorebookRow
                   key={lb.id}
                   lorebook={lb}
-                  onClick={() => openLorebookDetail(lb.id)}
+                  onClick={() => {
+                    if (selectionMode) toggleSelection(lb.id);
+                    else openLorebookDetail(lb.id);
+                  }}
                   onDelete={() => {
                     if (confirm(`Delete "${lb.name}"? All entries will be lost.`)) deleteLorebook.mutate(lb.id);
                   }}
+                  selectionMode={selectionMode}
+                  isSelected={selectedLorebookIds.has(lb.id)}
+                  onToggleSelect={() => toggleSelection(lb.id)}
                 />
               ))}
         </div>
@@ -349,19 +442,46 @@ function LorebookRow({
   lorebook,
   onClick,
   onDelete,
+  selectionMode,
+  isSelected,
+  onToggleSelect,
 }: {
   lorebook: Lorebook;
   onClick: () => void;
   onDelete: () => void;
+  selectionMode?: boolean;
+  isSelected?: boolean;
+  onToggleSelect?: () => void;
 }) {
   const gradient = CATEGORY_COLORS[lorebook.category] ?? CATEGORY_COLORS.uncategorized;
   const CatIcon = CATEGORIES.find((c) => c.id === lorebook.category)?.icon ?? BookOpen;
 
   return (
     <div
-      className="group flex cursor-pointer items-center gap-3 rounded-xl p-2.5 transition-all hover:bg-[var(--sidebar-accent)]"
+      className={cn(
+        "group flex cursor-pointer items-center gap-3 rounded-xl p-2.5 transition-all hover:bg-[var(--sidebar-accent)]",
+        selectionMode && isSelected && "ring-1 ring-amber-400/40 bg-amber-400/10",
+      )}
       onClick={onClick}
     >
+      {selectionMode && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onToggleSelect?.();
+          }}
+          className={cn(
+            "flex h-5 w-5 shrink-0 items-center justify-center rounded border-2 transition-colors",
+            isSelected
+              ? "border-amber-400 bg-amber-400 text-white"
+              : "border-[var(--muted-foreground)]/40 bg-[var(--secondary)] text-transparent",
+          )}
+          aria-label={isSelected ? "Deselect lorebook" : "Select lorebook"}
+        >
+          <span className="text-[0.75rem]">✓</span>
+        </button>
+      )}
       <div
         className={cn(
           "flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-to-br text-white shadow-sm",
@@ -383,29 +503,31 @@ function LorebookRow({
           {lorebook.description || "No description"}
         </div>
       </div>
-      <button
-        onClick={(e) => {
-          e.stopPropagation();
-          onDelete();
-        }}
-        className="rounded-lg p-1.5 opacity-0 transition-all hover:bg-[var(--destructive)]/15 group-hover:opacity-100 max-md:opacity-100 active:scale-90"
-      >
-        <svg
-          width="13"
-          height="13"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          className="text-[var(--destructive)]"
+      {!selectionMode && (
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onDelete();
+          }}
+          className="rounded-lg p-1.5 opacity-0 transition-all hover:bg-[var(--destructive)]/15 group-hover:opacity-100 max-md:opacity-100 active:scale-90"
         >
-          <path d="M3 6h18" />
-          <path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6" />
-          <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2" />
-        </svg>
-      </button>
+          <svg
+            width="13"
+            height="13"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="text-[var(--destructive)]"
+          >
+            <path d="M3 6h18" />
+            <path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6" />
+            <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2" />
+          </svg>
+        </button>
+      )}
     </div>
   );
 }

--- a/packages/client/src/components/panels/PersonasPanel.tsx
+++ b/packages/client/src/components/panels/PersonasPanel.tsx
@@ -34,12 +34,14 @@ import {
   ChevronRight,
   Users,
   X,
+  Check,
   UserPlus,
   UserMinus,
   Tag,
 } from "lucide-react";
 import { cn } from "../../lib/utils";
 import { HelpTooltip } from "../ui/HelpTooltip";
+import { api } from "../../lib/api-client";
 
 type PersonaRow = {
   id: string;
@@ -86,6 +88,9 @@ export function PersonasPanel() {
   const [favFilter, setFavFilter] = useState<"all" | "active" | "inactive">("all");
   const [activeTag, setActiveTag] = useState<string | null>(null);
   const [tagsExpanded, setTagsExpanded] = useState(false);
+  const [selectionMode, setSelectionMode] = useState(false);
+  const [selectedPersonaIds, setSelectedPersonaIds] = useState<Set<string>>(new Set());
+  const [exportingSelected, setExportingSelected] = useState(false);
 
   // Groups state
   const [groupsExpanded, setGroupsExpanded] = useState(true);
@@ -254,6 +259,37 @@ export function PersonasPanel() {
     }
   }, [filteredList, sort]);
 
+  const exitSelectionMode = useCallback(() => {
+    setSelectionMode(false);
+    setSelectedPersonaIds(new Set());
+  }, []);
+
+  const toggleSelection = useCallback((personaId: string) => {
+    setSelectedPersonaIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(personaId)) next.delete(personaId);
+      else next.add(personaId);
+      return next;
+    });
+  }, []);
+
+  const handleExportSelected = useCallback(async () => {
+    if (selectedPersonaIds.size === 0) return;
+    setExportingSelected(true);
+    try {
+      await api.downloadPost(
+        "/characters/personas/export-bulk",
+        { ids: [...selectedPersonaIds] },
+        "marinara-personas.zip",
+      );
+      toast.success(`Exported ${selectedPersonaIds.size} persona${selectedPersonaIds.size === 1 ? "" : "s"}`);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to export personas");
+    } finally {
+      setExportingSelected(false);
+    }
+  }, [selectedPersonaIds]);
+
   return (
     <div className="flex flex-col gap-2 p-3">
       {/* Header help */}
@@ -403,7 +439,61 @@ export function PersonasPanel() {
         >
           <Sparkles size="0.75rem" />
         </button>
+        <button
+          onClick={() => {
+            if (selectionMode) exitSelectionMode();
+            else {
+              setAssigningToGroup(null);
+              setSelectionMode(true);
+            }
+          }}
+          className={cn(
+            "flex items-center justify-center gap-1 rounded-xl px-3 py-2 text-xs font-medium transition-all",
+            selectionMode
+              ? "bg-emerald-400/15 text-emerald-400 ring-1 ring-emerald-400/30"
+              : "bg-[var(--secondary)] text-[var(--secondary-foreground)] ring-1 ring-[var(--border)] hover:bg-[var(--accent)]",
+          )}
+        >
+          <Download size="0.75rem" />
+          Select
+        </button>
       </div>
+
+      {selectionMode && (
+        <div className="flex flex-wrap items-center gap-2 rounded-xl border border-[var(--border)] bg-[var(--secondary)]/60 px-3 py-2">
+          <span className="text-[0.6875rem] font-medium text-[var(--muted-foreground)]">
+            {selectedPersonaIds.size} selected
+          </span>
+          <button
+            onClick={() => setSelectedPersonaIds(new Set(list.map((persona) => persona.id)))}
+            disabled={list.length === 0}
+            className="rounded-lg px-2.5 py-1 text-[0.625rem] font-medium text-emerald-400 transition-colors hover:bg-[var(--accent)] disabled:opacity-40"
+          >
+            Select visible
+          </button>
+          <button
+            onClick={() => setSelectedPersonaIds(new Set())}
+            disabled={selectedPersonaIds.size === 0}
+            className="rounded-lg px-2.5 py-1 text-[0.625rem] font-medium text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] disabled:opacity-40"
+          >
+            Clear
+          </button>
+          <button
+            onClick={handleExportSelected}
+            disabled={selectedPersonaIds.size === 0 || exportingSelected}
+            className="inline-flex items-center gap-1 rounded-lg bg-emerald-500 px-2.5 py-1 text-[0.625rem] font-medium text-white transition-all hover:opacity-90 disabled:opacity-40"
+          >
+            <Download size="0.6875rem" />
+            {exportingSelected ? "Exporting..." : "Export ZIP"}
+          </button>
+          <button
+            onClick={exitSelectionMode}
+            className="rounded-lg px-2.5 py-1 text-[0.625rem] font-medium text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+          >
+            Done
+          </button>
+        </div>
+      )}
 
       {/* Hidden file input for avatar uploads */}
       <input ref={fileRef} type="file" accept="image/*" className="hidden" onChange={handleAvatarUpload} />
@@ -505,6 +595,7 @@ export function PersonasPanel() {
                     <div className="flex items-center gap-0.5">
                       <button
                         onClick={() => {
+                          if (assigningToGroup !== group.id) exitSelectionMode();
                           setAssigningToGroup(assigningToGroup === group.id ? null : group.id);
                         }}
                         className={cn(
@@ -623,6 +714,7 @@ export function PersonasPanel() {
       <div className="stagger-children flex flex-col gap-1">
         {list.map((persona) => {
           const active = isActive(persona);
+          const isBulkSelected = selectedPersonaIds.has(persona.id);
           const targetGroup = assigningToGroup ? parsedGroups.find((g) => g.id === assigningToGroup) : null;
           const isInTargetGroup = targetGroup ? targetGroup.memberIds.includes(persona.id) : false;
 
@@ -631,18 +723,39 @@ export function PersonasPanel() {
               key={persona.id}
               className={cn(
                 "group flex items-center gap-3 rounded-xl p-2.5 transition-all hover:bg-[var(--sidebar-accent)] cursor-pointer",
+                selectionMode && isBulkSelected && "ring-1 ring-emerald-400/40 bg-emerald-400/8",
                 active && "ring-1 ring-emerald-400/40 bg-emerald-400/5",
                 assigningToGroup && isInTargetGroup && "ring-1 ring-violet-500/50 bg-violet-500/10",
                 assigningToGroup && !isInTargetGroup && "opacity-60 hover:opacity-100",
               )}
               onClick={() => {
-                if (assigningToGroup && targetGroup) {
+                if (selectionMode) {
+                  toggleSelection(persona.id);
+                } else if (assigningToGroup && targetGroup) {
                   toggleGroupMember(assigningToGroup, persona.id, targetGroup.memberIds);
                 } else {
                   openPersonaDetail(persona.id);
                 }
               }}
             >
+              {selectionMode && (
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    toggleSelection(persona.id);
+                  }}
+                  className={cn(
+                    "flex h-5 w-5 shrink-0 items-center justify-center rounded border-2 transition-colors",
+                    isBulkSelected
+                      ? "border-emerald-400 bg-emerald-400 text-white"
+                      : "border-[var(--muted-foreground)]/40 bg-[var(--secondary)] text-transparent",
+                  )}
+                  aria-label={isBulkSelected ? "Deselect persona" : "Select persona"}
+                >
+                  <Check size="0.75rem" />
+                </button>
+              )}
               {/* Avatar */}
               <button
                 onClick={(e) => handleAvatarClick(e, persona.id)}
@@ -687,7 +800,8 @@ export function PersonasPanel() {
               </div>
 
               {/* Actions */}
-              <div className="flex items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100 max-md:opacity-100">
+              {!selectionMode && (
+                <div className="flex items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100 max-md:opacity-100">
                 {!active && (
                   <button
                     onClick={(e) => {
@@ -722,6 +836,7 @@ export function PersonasPanel() {
                   <Trash2 size="0.8125rem" />
                 </button>
               </div>
+              )}
             </div>
           );
         })}

--- a/packages/client/src/components/panels/PresetsPanel.tsx
+++ b/packages/client/src/components/panels/PresetsPanel.tsx
@@ -2,10 +2,12 @@
 // Panel: Presets (overhauled — search, assign, edit, duplicate)
 // ──────────────────────────────────────────────
 import { useState, useMemo } from "react";
+import { toast } from "sonner";
 import { usePresets, useDeletePreset, useDuplicatePreset, useSetDefaultPreset } from "../../hooks/use-presets";
 import { useUpdateChat, useUpdateChatMetadata } from "../../hooks/use-chats";
 import { useChatStore } from "../../stores/chat.store";
 import { useUIStore } from "../../stores/ui.store";
+import { api } from "../../lib/api-client";
 import { ChoiceSelectionModal } from "../presets/ChoiceSelectionModal";
 import { Plus, Download, FileText, Trash2, Check, Copy, Search, Code2, Hash, Star } from "lucide-react";
 import { cn } from "../../lib/utils";
@@ -32,6 +34,9 @@ export function PresetsPanel() {
   const updateMetadata = useUpdateChatMetadata();
   const [search, setSearch] = useState("");
   const [choiceModalPresetId, setChoiceModalPresetId] = useState<string | null>(null);
+  const [selectionMode, setSelectionMode] = useState(false);
+  const [selectedPresetIds, setSelectedPresetIds] = useState<Set<string>>(new Set());
+  const [exportingSelected, setExportingSelected] = useState(false);
 
   const activePresetId = activeChat?.promptPresetId ?? null;
 
@@ -73,6 +78,33 @@ export function PresetsPanel() {
     }
   };
 
+  const exitSelectionMode = () => {
+    setSelectionMode(false);
+    setSelectedPresetIds(new Set());
+  };
+
+  const toggleSelection = (presetId: string) => {
+    setSelectedPresetIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(presetId)) next.delete(presetId);
+      else next.add(presetId);
+      return next;
+    });
+  };
+
+  const handleExportSelected = async () => {
+    if (selectedPresetIds.size === 0) return;
+    setExportingSelected(true);
+    try {
+      await api.downloadPost("/prompts/export-bulk", { ids: [...selectedPresetIds] }, "marinara-presets.zip");
+      toast.success(`Exported ${selectedPresetIds.size} preset${selectedPresetIds.size === 1 ? "" : "s"}`);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to export presets");
+    } finally {
+      setExportingSelected(false);
+    }
+  };
+
   return (
     <div className="flex flex-col gap-2 p-3">
       {/* Action buttons */}
@@ -89,7 +121,57 @@ export function PresetsPanel() {
         >
           <Download size="0.8125rem" /> Import
         </button>
+        <button
+          onClick={() => {
+            if (selectionMode) exitSelectionMode();
+            else setSelectionMode(true);
+          }}
+          className={cn(
+            "flex items-center justify-center gap-1.5 rounded-xl px-3 py-2.5 text-xs font-medium transition-all",
+            selectionMode
+              ? "bg-purple-400/15 text-purple-400 ring-1 ring-purple-400/30"
+              : "bg-[var(--secondary)] text-[var(--secondary-foreground)] ring-1 ring-[var(--border)] hover:bg-[var(--accent)]",
+          )}
+        >
+          <Check size="0.8125rem" /> Select
+        </button>
       </div>
+
+      {selectionMode && (
+        <div className="flex flex-wrap items-center gap-2 rounded-xl border border-[var(--border)] bg-[var(--secondary)]/60 px-3 py-2">
+          <span className="text-[0.6875rem] font-medium text-[var(--muted-foreground)]">
+            {selectedPresetIds.size} selected
+          </span>
+          <button
+            onClick={() => setSelectedPresetIds(new Set(filteredPresets.map((preset) => preset.id)))}
+            disabled={filteredPresets.length === 0}
+            className="rounded-lg px-2.5 py-1 text-[0.625rem] font-medium text-purple-400 transition-colors hover:bg-[var(--accent)] disabled:opacity-40"
+          >
+            Select visible
+          </button>
+          <button
+            onClick={() => setSelectedPresetIds(new Set())}
+            disabled={selectedPresetIds.size === 0}
+            className="rounded-lg px-2.5 py-1 text-[0.625rem] font-medium text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] disabled:opacity-40"
+          >
+            Clear
+          </button>
+          <button
+            onClick={handleExportSelected}
+            disabled={selectedPresetIds.size === 0 || exportingSelected}
+            className="inline-flex items-center gap-1 rounded-lg bg-purple-500 px-2.5 py-1 text-[0.625rem] font-medium text-white transition-all hover:opacity-90 disabled:opacity-40"
+          >
+            <Download size="0.6875rem" />
+            {exportingSelected ? "Exporting..." : "Export ZIP"}
+          </button>
+          <button
+            onClick={exitSelectionMode}
+            className="rounded-lg px-2.5 py-1 text-[0.625rem] font-medium text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+          >
+            Done
+          </button>
+        </div>
+      )}
 
       {/* Search */}
       <div className="relative">
@@ -129,6 +211,7 @@ export function PresetsPanel() {
       <div className="stagger-children flex flex-col gap-1">
         {filteredPresets.map((preset) => {
           const isSelected = activePresetId === preset.id;
+          const isBulkSelected = selectedPresetIds.has(preset.id);
           const sectionCount = getSectionCount(preset);
           const wrapFormat = (preset.wrapFormat ?? "xml") as string;
           const isDefault = preset.isDefault === "true";
@@ -138,11 +221,30 @@ export function PresetsPanel() {
               key={preset.id}
               className={cn(
                 "group relative flex cursor-pointer items-center gap-3 rounded-xl p-2.5 transition-all hover:bg-[var(--sidebar-accent)]",
+                selectionMode && isBulkSelected && "ring-1 ring-purple-400/40 bg-purple-400/10",
                 isSelected && "ring-1 ring-purple-400/40 bg-purple-400/5",
               )}
             >
               {/* Click to open editor */}
-              <div className="flex min-w-0 flex-1 items-center gap-3" onClick={() => openPresetDetail(preset.id)}>
+              <div
+                className="flex min-w-0 flex-1 items-center gap-3"
+                onClick={() => {
+                  if (selectionMode) toggleSelection(preset.id);
+                  else openPresetDetail(preset.id);
+                }}
+              >
+                {selectionMode && (
+                  <div
+                    className={cn(
+                      "flex h-5 w-5 shrink-0 items-center justify-center rounded border-2 transition-colors",
+                      isBulkSelected
+                        ? "border-purple-400 bg-purple-400 text-white"
+                        : "border-[var(--muted-foreground)]/40 bg-[var(--secondary)] text-transparent",
+                    )}
+                  >
+                    <Check size="0.75rem" />
+                  </div>
+                )}
                 <div className="relative flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-purple-400 to-violet-500 text-white shadow-sm">
                   <FileText size="1rem" />
                   {isSelected && (
@@ -172,7 +274,8 @@ export function PresetsPanel() {
               </div>
 
               {/* Action buttons */}
-              <div className="absolute right-2 top-1/2 -translate-y-1/2 flex shrink-0 items-center gap-0.5 rounded-lg bg-[var(--sidebar)] px-1 py-0.5 opacity-0 shadow-sm ring-1 ring-[var(--border)] transition-opacity group-hover:opacity-100 max-md:opacity-100">
+              {!selectionMode && (
+                <div className="absolute right-2 top-1/2 -translate-y-1/2 flex shrink-0 items-center gap-0.5 rounded-lg bg-[var(--sidebar)] px-1 py-0.5 opacity-0 shadow-sm ring-1 ring-[var(--border)] transition-opacity group-hover:opacity-100 max-md:opacity-100">
                 {activeChat && (
                   <button
                     onClick={(e) => {
@@ -224,16 +327,17 @@ export function PresetsPanel() {
                   }}
                   className="rounded-lg p-1.5 transition-all hover:bg-[var(--destructive)]/15 active:scale-90"
                   title="Delete"
-                >
-                  <Trash2 size="0.75rem" className="text-[var(--destructive)]" />
-                </button>
-              </div>
+                  >
+                    <Trash2 size="0.75rem" className="text-[var(--destructive)]" />
+                  </button>
+                </div>
+              )}
             </div>
           );
         })}
       </div>
 
-      {activeChat && (
+      {activeChat && !selectionMode && (
         <p className="px-1 text-[0.625rem] text-[var(--muted-foreground)]/60">
           Click a preset to edit · hover → "Use" to assign to chat
         </p>

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -43,11 +43,12 @@ import {
   RefreshCw,
   ExternalLink,
 } from "lucide-react";
-import { useClearAllData } from "../../hooks/use-chats";
+import { useClearAllData, useExpungeData, type ExpungeScope } from "../../hooks/use-chats";
 import { useChatStore } from "../../stores/chat.store";
 import { chatKeys } from "../../hooks/use-chats";
 import { HelpTooltip } from "../ui/HelpTooltip";
 import { ConversationSoundSetting, ToggleSetting } from "./settings/SettingControls";
+import { DraftNumberInput } from "../ui/DraftNumberInput";
 
 const TABS = [
   { id: "general", label: "General" },
@@ -66,6 +67,17 @@ const SETTINGS_COMPONENTS: Record<(typeof TABS)[number]["id"], React.FC> = {
   import: ImportSettings,
   advanced: AdvancedSettings,
 };
+
+const EXPUNGE_SCOPE_OPTIONS: Array<{ id: ExpungeScope; label: string; description: string }> = [
+  { id: "chats", label: "Chats & Messages", description: "Chats, folders, messages, scene/OOC data, and chat runtime state." },
+  { id: "characters", label: "Characters", description: "Characters and character groups. Professor Mari is always preserved." },
+  { id: "personas", label: "Personas", description: "Personas and persona groups." },
+  { id: "lorebooks", label: "Lorebooks", description: "Lorebooks and lorebook entries." },
+  { id: "presets", label: "Presets", description: "Prompt presets, groups, sections, and variables." },
+  { id: "connections", label: "Connections", description: "API connections and model endpoints." },
+  { id: "automation", label: "Automation & Themes", description: "Agents, tools, regex scripts, synced themes, and automation state." },
+  { id: "media", label: "Media & Assets", description: "Backgrounds, avatars, sprites, gallery items, fonts, and knowledge-source files." },
+];
 
 // Module-level set survives component remounts (e.g. mobile AnimatePresence unmount/remount)
 const mountedSettingsTabs = new Set<string>();
@@ -213,12 +225,11 @@ function GeneralSettings() {
       {/* Messages per page */}
       <label className="flex items-center gap-2.5 rounded-lg p-1 transition-colors hover:bg-[var(--secondary)]/50">
         <span className="text-xs">Messages per page</span>
-        <input
-          type="number"
+        <DraftNumberInput
+          value={messagesPerPage}
           min={0}
           max={500}
-          value={messagesPerPage}
-          onChange={(e) => setMessagesPerPage(Math.max(0, Math.min(500, parseInt(e.target.value, 10) || 0)))}
+          onCommit={(nextValue) => setMessagesPerPage(Math.max(0, Math.min(500, nextValue)))}
           className="w-16 rounded-md border border-[var(--border)] bg-[var(--secondary)] px-2 py-1 text-xs"
         />
         <HelpTooltip text="How many messages to load at a time. Click 'Load More' in the chat to see older messages. Set to 0 to load all messages at once." />
@@ -1694,7 +1705,9 @@ function AdvancedSettings() {
   const showMessageNumbers = useUIStore((s) => s.showMessageNumbers);
   const setShowMessageNumbers = useUIStore((s) => s.setShowMessageNumbers);
   const clearAllData = useClearAllData();
-  const [confirmStep, setConfirmStep] = useState(0); // 0=idle, 1=first click, 2=confirmed
+  const expungeData = useExpungeData();
+  const [selectedScopes, setSelectedScopes] = useState<ExpungeScope[]>(["chats"]);
+  const [confirmAction, setConfirmAction] = useState<"selected" | "all" | null>(null);
   const [exportingProfile, setExportingProfile] = useState(false);
 
   const handleExportProfile = async () => {
@@ -1789,6 +1802,31 @@ function AdvancedSettings() {
   const currentReleaseLabel = `v${health.data?.version ?? updateCheck.data?.currentVersion ?? APP_VERSION}`;
   const currentCommit = health.data?.commit ?? updateCheck.data?.currentCommit ?? null;
   const currentBuildLabel = currentCommit ? `Build: ${currentCommit.slice(0, 7)}` : "Build: unavailable";
+  const isClearing = clearAllData.isPending || expungeData.isPending;
+  const isAllScopesSelected = selectedScopes.length === EXPUNGE_SCOPE_OPTIONS.length;
+
+  const toggleScope = (scope: ExpungeScope) => {
+    setSelectedScopes((current) =>
+      current.includes(scope) ? current.filter((entry) => entry !== scope) : [...current, scope],
+    );
+  };
+
+  const runExpunge = (mode: "selected" | "all") => {
+    if (mode === "all") {
+      clearAllData.mutate(undefined, {
+        onSuccess: () => toast.success("All selected data was cleared. Runtime caches were reset immediately."),
+        onError: () => toast.error("Failed to clear all data."),
+        onSettled: () => setConfirmAction(null),
+      });
+      return;
+    }
+
+    expungeData.mutate(selectedScopes, {
+      onSuccess: () => toast.success("Selected data was cleared. Runtime caches were reset immediately."),
+      onError: () => toast.error("Failed to clear selected data."),
+      onSettled: () => setConfirmAction(null),
+    });
+  };
 
   return (
     <div className="flex flex-col gap-3">
@@ -2020,50 +2058,91 @@ function AdvancedSettings() {
           Danger Zone
         </div>
         <p className="text-[0.625rem] text-[var(--muted-foreground)]">
-          This will permanently delete <strong>all</strong> characters, chats, messages, presets, lorebooks,
-          backgrounds, sprites, personas, and connections. This action cannot be undone.
+          Permanently clear selected categories of local data. Professor Mari is always preserved, and Marinara resets
+          live caches immediately after a successful expunge so stale data does not linger on screen.
         </p>
-        {confirmStep === 0 && (
+        <div className="grid gap-2">
+          {EXPUNGE_SCOPE_OPTIONS.map((scope) => {
+            const checked = selectedScopes.includes(scope.id);
+            return (
+              <label
+                key={scope.id}
+                className={cn(
+                  "flex cursor-pointer items-start gap-2 rounded-lg px-2.5 py-2 ring-1 transition-colors",
+                  checked
+                    ? "bg-[var(--destructive)]/10 ring-[var(--destructive)]/25"
+                    : "bg-[var(--background)]/40 ring-[var(--border)] hover:bg-[var(--secondary)]/70",
+                )}
+              >
+                <input
+                  type="checkbox"
+                  checked={checked}
+                  disabled={isClearing}
+                  onChange={() => toggleScope(scope.id)}
+                  className="mt-0.5 h-3.5 w-3.5 rounded border-[var(--border)] accent-[var(--destructive)]"
+                />
+                <span className="min-w-0">
+                  <span className="block text-xs font-medium text-[var(--foreground)]">{scope.label}</span>
+                  <span className="block text-[0.625rem] text-[var(--muted-foreground)]">{scope.description}</span>
+                </span>
+              </label>
+            );
+          })}
+        </div>
+        <div className="flex flex-wrap gap-2">
           <button
-            onClick={() => setConfirmStep(1)}
-            className="flex items-center justify-center gap-1.5 rounded-lg bg-[var(--destructive)] px-3 py-2 text-xs font-medium text-white transition-all hover:opacity-90 active:scale-95"
+            onClick={() =>
+              setSelectedScopes(
+                isAllScopesSelected ? [] : EXPUNGE_SCOPE_OPTIONS.map((scope) => scope.id),
+              )
+            }
+            disabled={isClearing}
+            className="rounded-lg border border-[var(--border)] px-3 py-2 text-xs font-medium transition-all hover:bg-[var(--secondary)] active:scale-95 disabled:opacity-50"
+          >
+            {isAllScopesSelected ? "Clear Selection" : "Select All"}
+          </button>
+          <button
+            onClick={() => setConfirmAction("selected")}
+            disabled={selectedScopes.length === 0 || isClearing}
+            className="flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-[var(--destructive)]/85 px-3 py-2 text-xs font-medium text-white transition-all hover:opacity-90 active:scale-95 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <Trash2 size="0.8125rem" />
+            Clear Selected Data
+          </button>
+          <button
+            onClick={() => setConfirmAction("all")}
+            disabled={isClearing}
+            className="flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-[var(--destructive)] px-3 py-2 text-xs font-medium text-white transition-all hover:opacity-90 active:scale-95 disabled:opacity-50"
           >
             <Trash2 size="0.8125rem" />
             Clear All Data
           </button>
-        )}
-        {confirmStep === 1 && (
-          <div className="flex flex-col gap-2">
-            <div className="flex items-start gap-2 rounded-lg bg-[var(--destructive)]/15 p-2.5 text-[0.6875rem] text-[var(--destructive)] font-medium">
+        </div>
+        {confirmAction && (
+          <div className="flex flex-col gap-2 rounded-lg bg-[var(--destructive)]/12 p-2.5">
+            <div className="flex items-start gap-2 text-[0.6875rem] font-medium text-[var(--destructive)]">
               <AlertTriangle size="0.875rem" className="mt-0.5 shrink-0" />
-              Are you sure? This will erase everything. There is no undo.
+              {confirmAction === "all"
+                ? "Delete all supported data categories except Professor Mari? There is no undo."
+                : `Delete ${selectedScopes.length} selected data categor${selectedScopes.length === 1 ? "y" : "ies"}? There is no undo.`}
             </div>
             <div className="flex gap-2">
               <button
-                onClick={() => setConfirmStep(0)}
-                className="flex-1 rounded-lg border border-[var(--border)] px-3 py-2 text-xs font-medium transition-all hover:bg-[var(--secondary)] active:scale-95"
+                onClick={() => setConfirmAction(null)}
+                disabled={isClearing}
+                className="flex-1 rounded-lg border border-[var(--border)] px-3 py-2 text-xs font-medium transition-all hover:bg-[var(--secondary)] active:scale-95 disabled:opacity-50"
               >
                 Cancel
               </button>
               <button
-                onClick={() => {
-                  setConfirmStep(2);
-                  clearAllData.mutate(undefined, {
-                    onSettled: () => setConfirmStep(0),
-                  });
-                }}
-                className="flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-[var(--destructive)] px-3 py-2 text-xs font-medium text-white transition-all hover:opacity-90 active:scale-95"
+                onClick={() => runExpunge(confirmAction)}
+                disabled={isClearing}
+                className="flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-[var(--destructive)] px-3 py-2 text-xs font-medium text-white transition-all hover:opacity-90 active:scale-95 disabled:opacity-50"
               >
-                <Trash2 size="0.75rem" />
-                Yes, Delete Everything
+                {isClearing ? <Loader2 size="0.75rem" className="animate-spin" /> : <Trash2 size="0.75rem" />}
+                Confirm Delete
               </button>
             </div>
-          </div>
-        )}
-        {confirmStep === 2 && (
-          <div className="flex items-center justify-center gap-2 py-2 text-xs text-[var(--muted-foreground)]">
-            <Loader2 size="0.875rem" className="animate-spin" />
-            Clearing all data…
           </div>
         )}
       </div>

--- a/packages/client/src/components/presets/PresetEditor.tsx
+++ b/packages/client/src/components/presets/PresetEditor.tsx
@@ -50,6 +50,7 @@ import {
 } from "lucide-react";
 import { cn } from "../../lib/utils";
 import { HelpTooltip } from "../ui/HelpTooltip";
+import { DraftNumberInput } from "../ui/DraftNumberInput";
 import { api } from "../../lib/api-client";
 import { useAgentConfigs, type AgentConfigRow } from "../../hooks/use-agents";
 import type { WrapFormat, MarkerType } from "@marinara-engine/shared";
@@ -261,7 +262,7 @@ export function PresetEditor() {
             setLocalName(e.target.value);
             markDirty();
           }}
-          className="flex-1 bg-transparent text-lg font-semibold outline-none placeholder:text-[var(--muted-foreground)] max-md:text-base"
+          className="h-10 min-w-0 flex-1 self-stretch bg-transparent text-lg font-semibold outline-none placeholder:text-[var(--muted-foreground)] max-md:text-base"
           placeholder="Preset name…"
         />
         <div className="flex items-center gap-1.5">
@@ -1081,15 +1082,15 @@ function SectionsTab({
                         {section.injectionPosition === "depth" && (
                           <>
                             <label className="text-[var(--muted-foreground)]">Depth:</label>
-                            <input
-                              type="number"
+                            <DraftNumberInput
                               value={section.injectionDepth ?? 0}
-                              onFocus={(e) => e.target.select()}
-                              onChange={(e) =>
+                              min={0}
+                              selectOnFocus
+                              onCommit={(nextValue) =>
                                 onUpdateSection.mutate({
                                   presetId,
                                   sectionId: section.id,
-                                  injectionDepth: parseInt(e.target.value) || 0,
+                                  injectionDepth: nextValue,
                                 })
                               }
                               className="w-16 rounded-lg bg-[var(--secondary)] px-2 py-1 text-xs ring-1 ring-[var(--border)]"

--- a/packages/client/src/components/ui/DraftNumberInput.tsx
+++ b/packages/client/src/components/ui/DraftNumberInput.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useState } from "react";
+
+interface DraftNumberInputProps {
+  value: number;
+  onCommit: (value: number) => void;
+  className?: string;
+  min?: number;
+  max?: number;
+  integer?: boolean;
+  selectOnFocus?: boolean;
+}
+
+export function DraftNumberInput({
+  value,
+  onCommit,
+  className,
+  min,
+  max,
+  integer = true,
+  selectOnFocus = false,
+}: DraftNumberInputProps) {
+  const [draft, setDraft] = useState(String(value));
+
+  useEffect(() => {
+    setDraft(String(value));
+  }, [value]);
+
+  const commit = () => {
+    const parsed = integer ? parseInt(draft, 10) : parseFloat(draft);
+    const inRange = !Number.isNaN(parsed) && (min === undefined || parsed >= min) && (max === undefined || parsed <= max);
+
+    if (inRange) {
+      onCommit(parsed);
+      setDraft(String(parsed));
+      return;
+    }
+
+    setDraft(String(value));
+  };
+
+  return (
+    <input
+      type="text"
+      inputMode={integer ? "numeric" : "decimal"}
+      value={draft}
+      onFocus={(e) => {
+        if (selectOnFocus) e.target.select();
+      }}
+      onChange={(e) => setDraft(e.target.value)}
+      onBlur={commit}
+      onKeyDown={(e) => {
+        if (e.key === "Enter") {
+          e.currentTarget.blur();
+        }
+      }}
+      className={className}
+    />
+  );
+}

--- a/packages/client/src/hooks/use-chats.ts
+++ b/packages/client/src/hooks/use-chats.ts
@@ -4,6 +4,11 @@
 import { useQuery, useInfiniteQuery, useMutation, useQueryClient, type InfiniteData } from "@tanstack/react-query";
 import { api } from "../lib/api-client";
 import { useChatStore } from "../stores/chat.store";
+import { useAgentStore } from "../stores/agent.store";
+import { useGameStateStore } from "../stores/game-state.store";
+import { useEncounterStore } from "../stores/encounter.store";
+import { useUIStore } from "../stores/ui.store";
+import { clearBrowserRuntimeCaches } from "../lib/cache-reset";
 import type { Chat, Message, MessageSwipe } from "@marinara-engine/shared";
 
 export const chatKeys = {
@@ -14,6 +19,31 @@ export const chatKeys = {
   messageCount: (chatId: string) => [...chatKeys.all, "messageCount", chatId] as const,
   group: (groupId: string) => [...chatKeys.all, "group", groupId] as const,
 };
+
+export type ExpungeScope =
+  | "chats"
+  | "characters"
+  | "personas"
+  | "lorebooks"
+  | "presets"
+  | "connections"
+  | "automation"
+  | "media";
+
+async function resetClientAfterExpunge(qc: ReturnType<typeof useQueryClient>) {
+  await clearBrowserRuntimeCaches();
+  useChatStore.getState().reset();
+  useAgentStore.getState().reset();
+  useGameStateStore.getState().reset();
+  useEncounterStore.getState().reset();
+  const ui = useUIStore.getState();
+  ui.closeModal();
+  ui.closeAllDetails();
+  ui.closeRightPanel();
+  ui.closeBotBrowser();
+  ui.setChatBackground(null);
+  qc.clear();
+}
 
 export function useChats() {
   return useQuery({
@@ -321,11 +351,24 @@ export function useGenerateSummary() {
 }
 
 /** Clear all user data */
+export function useExpungeData() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (scopes: ExpungeScope[]) => api.post<{ success: boolean }>("/admin/expunge", { confirm: true, scopes }),
+    onSuccess: async () => {
+      await resetClientAfterExpunge(qc);
+    },
+  });
+}
+
+/** Clear all user data */
 export function useClearAllData() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: () => api.post<{ success: boolean }>("/admin/clear-all", { confirm: true }),
-    onSuccess: () => qc.invalidateQueries(),
+    onSuccess: async () => {
+      await resetClientAfterExpunge(qc);
+    },
   });
 }
 

--- a/packages/client/src/lib/api-client.ts
+++ b/packages/client/src/lib/api-client.ts
@@ -81,6 +81,34 @@ export const api = {
     URL.revokeObjectURL(url);
   },
 
+  /** Download a POST endpoint as a file (useful for bulk exports). */
+  downloadPost: async (path: string, body: unknown, fallbackFilename = "export.bin") => {
+    const res = await fetch(`${BASE}${path}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const payload = await res.json().catch(() => ({ error: res.statusText }));
+      throw new ApiError(res.status, payload.error ?? "Download failed");
+    }
+    const disposition = res.headers.get("Content-Disposition");
+    let filename = fallbackFilename;
+    if (disposition) {
+      const match = disposition.match(/filename="?([^";\n]+)"?/);
+      if (match?.[1]) filename = decodeURIComponent(match[1]);
+    }
+    const blob = await res.blob();
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+  },
+
   /**
    * Stream an SSE endpoint. Returns an async iterable of parsed events.
    */

--- a/packages/client/src/lib/cache-reset.ts
+++ b/packages/client/src/lib/cache-reset.ts
@@ -1,0 +1,13 @@
+export async function clearBrowserRuntimeCaches() {
+  if (typeof window === "undefined") return;
+
+  if ("serviceWorker" in navigator) {
+    const registrations = await navigator.serviceWorker.getRegistrations();
+    await Promise.all(registrations.map((registration) => registration.unregister()));
+  }
+
+  if ("caches" in window) {
+    const cacheKeys = await caches.keys();
+    await Promise.all(cacheKeys.map((cacheKey) => caches.delete(cacheKey)));
+  }
+}

--- a/packages/client/src/stores/chat.store.ts
+++ b/packages/client/src/stores/chat.store.ts
@@ -3,7 +3,7 @@
 // ──────────────────────────────────────────────
 import { create } from "zustand";
 import { subscribeWithSelector } from "zustand/middleware";
-import type { Chat, Message } from "@marinara-engine/shared";
+import type { Chat, ChatMode, Message } from "@marinara-engine/shared";
 import { useAgentStore } from "./agent.store";
 import { useGameStateStore } from "./game-state.store";
 
@@ -60,6 +60,8 @@ interface ChatState {
   shouldOpenSettings: boolean;
   /** When true, ChatArea should show the setup wizard for the newly created chat. */
   shouldOpenWizard: boolean;
+  /** Pending new-chat mode for first-run connection setup gating. */
+  pendingNewChatMode: Exclude<ChatMode, "visual_novel"> | null;
   /** Per-chat draft input text so typing isn't lost when navigating away. */
   inputDrafts: Map<string, string>;
   /** Per-chat unread message count (from autonomous messages). */
@@ -92,6 +94,7 @@ interface ChatState {
   setSwipeIndex: (messageId: string, index: number) => void;
   setShouldOpenSettings: (v: boolean) => void;
   setShouldOpenWizard: (v: boolean) => void;
+  setPendingNewChatMode: (mode: Exclude<ChatMode, "visual_novel"> | null) => void;
   setInputDraft: (chatId: string, text: string) => void;
   clearInputDraft: (chatId: string) => void;
   incrementUnread: (chatId: string) => void;
@@ -126,6 +129,7 @@ export const useChatStore = create<ChatState>()(
     swipeIndex: new Map(),
     shouldOpenSettings: false,
     shouldOpenWizard: false,
+    pendingNewChatMode: null,
     inputDrafts: loadDrafts(),
     unreadCounts: new Map(),
     chatNotifications: new Map(),
@@ -270,6 +274,8 @@ export const useChatStore = create<ChatState>()(
 
     setShouldOpenWizard: (v) => set({ shouldOpenWizard: v }),
 
+    setPendingNewChatMode: (mode) => set({ pendingNewChatMode: mode }),
+
     setInputDraft: (chatId: string, text: string) =>
       set((state) => {
         const m = new Map(state.inputDrafts);
@@ -348,6 +354,7 @@ export const useChatStore = create<ChatState>()(
         perChatTyping: new Map(),
         perChatDelayed: new Map(),
         swipeIndex: new Map(),
+        pendingNewChatMode: null,
         inputDrafts: new Map(),
         unreadCounts: new Map(),
         chatNotifications: new Map(),

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -20,6 +20,11 @@ export type HudPosition = "top" | "left" | "right";
 export type EchoChamberSide = "top-left" | "top-right" | "bottom-left" | "bottom-right";
 export type UserStatus = "active" | "idle" | "dnd";
 
+const SIDEBAR_WIDTH_MIN = 240;
+const SIDEBAR_WIDTH_MAX = 480;
+const RIGHT_PANEL_WIDTH_MIN = 280;
+const RIGHT_PANEL_WIDTH_MAX = 520;
+
 /** Legacy browser-local custom theme preserved for one-time migration. */
 export interface CustomTheme {
   id: string;
@@ -48,6 +53,7 @@ interface UIState {
   sidebarOpen: boolean;
   sidebarWidth: number;
   rightPanelOpen: boolean;
+  rightPanelWidth: number;
   rightPanel: Panel;
   settingsTab: string;
   modal: { type: string; props?: Record<string, unknown> } | null;
@@ -166,6 +172,7 @@ interface UIState {
   toggleSidebar: () => void;
   setSidebarOpen: (open: boolean) => void;
   setSidebarWidth: (width: number) => void;
+  setRightPanelWidth: (width: number) => void;
   openRightPanel: (panel: Panel) => void;
   closeRightPanel: () => void;
   toggleRightPanel: (panel: Panel) => void;
@@ -256,6 +263,7 @@ export const useUIStore = create<UIState>()(
       sidebarOpen: true,
       sidebarWidth: 280,
       rightPanelOpen: false,
+      rightPanelWidth: 320,
       rightPanel: "chat" as Panel,
       settingsTab: "general",
       modal: null,
@@ -317,7 +325,9 @@ export const useUIStore = create<UIState>()(
 
       toggleSidebar: () => set((s) => ({ sidebarOpen: !s.sidebarOpen })),
       setSidebarOpen: (open) => set({ sidebarOpen: open }),
-      setSidebarWidth: (width) => set({ sidebarWidth: width }),
+      setSidebarWidth: (width) => set({ sidebarWidth: Math.max(SIDEBAR_WIDTH_MIN, Math.min(SIDEBAR_WIDTH_MAX, width)) }),
+      setRightPanelWidth: (width) =>
+        set({ rightPanelWidth: Math.max(RIGHT_PANEL_WIDTH_MIN, Math.min(RIGHT_PANEL_WIDTH_MAX, width)) }),
 
       openRightPanel: (panel) => set({ rightPanelOpen: true, rightPanel: panel }),
       closeRightPanel: () => set({ rightPanelOpen: false }),
@@ -540,7 +550,7 @@ export const useUIStore = create<UIState>()(
     }),
     {
       name: "marinara-engine-ui",
-      version: 7,
+      version: 8,
       // Debounce localStorage writes to avoid sync I/O on every state change
       storage: createJSONStorage(() => {
         let timer: ReturnType<typeof setTimeout> | null = null;
@@ -628,11 +638,18 @@ export const useUIStore = create<UIState>()(
             persisted.hasMigratedCustomThemesToServer = false;
           }
         }
+        // v7 → v8: persist right panel width
+        if (version <= 7) {
+          if (persisted.rightPanelWidth === undefined) {
+            persisted.rightPanelWidth = 320;
+          }
+        }
         return persisted;
       },
       partialize: (state) => ({
         sidebarOpen: state.sidebarOpen,
         sidebarWidth: state.sidebarWidth,
+        rightPanelWidth: state.rightPanelWidth,
         theme: state.theme,
         chatBackground: state.chatBackground,
         fontSize: state.fontSize,

--- a/packages/server/src/routes/admin.routes.ts
+++ b/packages/server/src/routes/admin.routes.ts
@@ -1,12 +1,35 @@
 // ──────────────────────────────────────────────
 // Routes: Admin (clear data, maintenance)
 // ──────────────────────────────────────────────
-import type { FastifyInstance } from "fastify";
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import { ne } from "drizzle-orm";
 import { existsSync, readdirSync, rmSync } from "fs";
 import { join } from "path";
+import { PROFESSOR_MARI_ID } from "@marinara-engine/shared";
 import { DATA_DIR } from "../utils/data-dir.js";
 import * as schema from "../db/schema/index.js";
 import { getAdminSecret } from "../config/runtime-config.js";
+
+type ExpungeScope =
+  | "chats"
+  | "characters"
+  | "personas"
+  | "lorebooks"
+  | "presets"
+  | "connections"
+  | "automation"
+  | "media";
+
+const ALL_EXPUNGE_SCOPES: ExpungeScope[] = [
+  "chats",
+  "characters",
+  "personas",
+  "lorebooks",
+  "presets",
+  "connections",
+  "automation",
+  "media",
+];
 
 function clearDirectory(dirPath: string) {
   if (!existsSync(dirPath)) return 0;
@@ -24,70 +47,128 @@ function clearDirectory(dirPath: string) {
   return count;
 }
 
+function isValidScope(scope: unknown): scope is ExpungeScope {
+  return typeof scope === "string" && ALL_EXPUNGE_SCOPES.includes(scope as ExpungeScope);
+}
+
+function requireAdminSecret(req: FastifyRequest, reply: FastifyReply) {
+  const adminSecret = getAdminSecret();
+  if (!adminSecret) return true;
+  const provided = (req.headers["x-admin-secret"] as string) ?? "";
+  if (provided === adminSecret) return true;
+  reply.status(403).send({ error: "Invalid or missing X-Admin-Secret header" });
+  return false;
+}
+
 export async function adminRoutes(app: FastifyInstance) {
-  // Clear all data — nuclear option
+  const runExpunge = async (requestedScopes: ExpungeScope[], reply: FastifyReply) => {
+    if (requestedScopes.length === 0) {
+      return reply.status(400).send({ error: "At least one valid scope is required" });
+    }
+
+    const db = app.db;
+    const tablesCleared: Record<string, number> = {};
+    const filesDeleted: Record<string, number> = {};
+
+    const runDelete = async (name: string, task: () => Promise<unknown>) => {
+      try {
+        const result = await task();
+        tablesCleared[name] = (tablesCleared[name] ?? 0) + ((result as { changes?: number } | undefined)?.changes ?? 0);
+      } catch {
+        tablesCleared[name] = tablesCleared[name] ?? 0;
+      }
+    };
+
+    if (requestedScopes.includes("chats")) {
+      await runDelete("message_swipes", () => db.delete(schema.messageSwipes).run());
+      await runDelete("ooc_influences", () => db.delete(schema.oocInfluences).run());
+      await runDelete("memory_chunks", () => db.delete(schema.memoryChunks).run());
+      await runDelete("messages", () => db.delete(schema.messages).run());
+      await runDelete("agent_runs", () => db.delete(schema.agentRuns).run());
+      await runDelete("agent_memory", () => db.delete(schema.agentMemory).run());
+      await runDelete("game_state_snapshots", () => db.delete(schema.gameStateSnapshots).run());
+      await runDelete("chat_images", () => db.delete(schema.chatImages).run());
+      await runDelete("chat_folders", () => db.delete(schema.chatFolders).run());
+      await runDelete("chats", () => db.delete(schema.chats).run());
+      filesDeleted.gallery = clearDirectory(join(DATA_DIR, "gallery"));
+    }
+
+    if (requestedScopes.includes("characters")) {
+      await runDelete("character_groups", () => db.delete(schema.characterGroups).run());
+      await runDelete("characters", () => db.delete(schema.characters).where(ne(schema.characters.id, PROFESSOR_MARI_ID)).run());
+    }
+
+    if (requestedScopes.includes("personas")) {
+      await runDelete("persona_groups", () => db.delete(schema.personaGroups).run());
+      await runDelete("personas", () => db.delete(schema.personas).run());
+    }
+
+    if (requestedScopes.includes("lorebooks")) {
+      await runDelete("lorebook_entries", () => db.delete(schema.lorebookEntries).run());
+      await runDelete("lorebooks", () => db.delete(schema.lorebooks).run());
+    }
+
+    if (requestedScopes.includes("presets")) {
+      await runDelete("prompt_sections", () => db.delete(schema.promptSections).run());
+      await runDelete("prompt_groups", () => db.delete(schema.promptGroups).run());
+      await runDelete("choice_blocks", () => db.delete(schema.choiceBlocks).run());
+      await runDelete("prompt_presets", () => db.delete(schema.promptPresets).run());
+    }
+
+    if (requestedScopes.includes("connections")) {
+      await runDelete("api_connections", () => db.delete(schema.apiConnections).run());
+    }
+
+    if (requestedScopes.includes("automation")) {
+      await runDelete("agent_runs", () => db.delete(schema.agentRuns).run());
+      await runDelete("agent_memory", () => db.delete(schema.agentMemory).run());
+      await runDelete("agent_configs", () => db.delete(schema.agentConfigs).run());
+      await runDelete("custom_tools", () => db.delete(schema.customTools).run());
+      await runDelete("regex_scripts", () => db.delete(schema.regexScripts).run());
+      await runDelete("custom_themes", () => db.delete(schema.customThemes).run());
+      await runDelete("game_state_snapshots", () => db.delete(schema.gameStateSnapshots).run());
+    }
+
+    if (requestedScopes.includes("media")) {
+      await runDelete("assets", () => db.delete(schema.assets).run());
+      await runDelete("chat_images", () => db.delete(schema.chatImages).run());
+      filesDeleted.backgrounds = clearDirectory(join(DATA_DIR, "backgrounds"));
+      filesDeleted.avatars = clearDirectory(join(DATA_DIR, "avatars"));
+      filesDeleted.sprites = clearDirectory(join(DATA_DIR, "sprites"));
+      filesDeleted.gallery = clearDirectory(join(DATA_DIR, "gallery"));
+      filesDeleted.fonts = clearDirectory(join(DATA_DIR, "fonts"));
+      filesDeleted.knowledgeSources = clearDirectory(join(DATA_DIR, "knowledge-sources"));
+    }
+
+    return {
+      success: true,
+      scopesCleared: requestedScopes,
+      tablesCleared,
+      filesDeleted,
+      preserved: {
+        characters: [PROFESSOR_MARI_ID],
+      },
+    };
+  };
+
+  app.post<{ Body: { confirm: boolean; scopes?: ExpungeScope[] } }>("/expunge", async (req, reply) => {
+    const { confirm, scopes } = req.body as { confirm?: boolean; scopes?: unknown[] };
+    if (!confirm) {
+      return reply.status(400).send({ error: "Must send { confirm: true } to proceed" });
+    }
+    if (!requireAdminSecret(req, reply)) return;
+
+    const requestedScopes = Array.isArray(scopes) ? scopes.filter(isValidScope) : [];
+    return runExpunge(requestedScopes, reply);
+  });
+
+  // Clear all data — compatibility wrapper around scoped expunge.
   app.post<{ Body: { confirm: boolean } }>("/clear-all", async (req, reply) => {
+    if (!requireAdminSecret(req, reply)) return;
     const { confirm } = req.body as { confirm?: boolean };
     if (!confirm) {
       return reply.status(400).send({ error: "Must send { confirm: true } to proceed" });
     }
-
-    // Require ADMIN_SECRET if configured (strongly recommended)
-    const adminSecret = getAdminSecret();
-    if (adminSecret) {
-      const provided = (req.headers["x-admin-secret"] as string) ?? "";
-      if (provided !== adminSecret) {
-        return reply.status(403).send({ error: "Invalid or missing X-Admin-Secret header" });
-      }
-    }
-
-    const db = app.db;
-
-    // Delete from all tables in dependency order using Drizzle schema objects
-    const tablesToClear = [
-      ["message_swipes", schema.messageSwipes],
-      ["messages", schema.messages],
-      ["chats", schema.chats],
-      ["lorebook_entries", schema.lorebookEntries],
-      ["lorebooks", schema.lorebooks],
-      ["prompt_sections", schema.promptSections],
-      ["prompt_groups", schema.promptGroups],
-      ["choice_blocks", schema.choiceBlocks],
-      ["prompt_presets", schema.promptPresets],
-      ["agent_memory", schema.agentMemory],
-      ["agent_runs", schema.agentRuns],
-      ["agent_configs", schema.agentConfigs],
-      ["game_state_snapshots", schema.gameStateSnapshots],
-      ["custom_themes", schema.customThemes],
-      ["assets", schema.assets],
-      ["character_groups", schema.characterGroups],
-      ["personas", schema.personas],
-      ["characters", schema.characters],
-      ["api_connections", schema.apiConnections],
-    ] as const;
-
-    const deleted: Record<string, number> = {};
-    for (const [name, table] of tablesToClear) {
-      try {
-        const result = await db.delete(table).run();
-        deleted[name] = (result as any)?.changes ?? 0;
-      } catch {
-        // Table might not exist, skip
-        deleted[name] = 0;
-      }
-    }
-
-    // Clear file-based data
-    const filesDeleted = {
-      backgrounds: clearDirectory(join(DATA_DIR, "backgrounds")),
-      avatars: clearDirectory(join(DATA_DIR, "avatars")),
-      sprites: clearDirectory(join(DATA_DIR, "sprites")),
-    };
-
-    return {
-      success: true,
-      tablesCleared: deleted,
-      filesDeleted,
-    };
+    return runExpunge(ALL_EXPUNGE_SCOPES, reply);
   });
 }

--- a/packages/server/src/routes/backup.routes.ts
+++ b/packages/server/src/routes/backup.routes.ts
@@ -13,9 +13,17 @@ import { createThemesStorage } from "../services/storage/themes.storage.js";
 import type { ExportEnvelope } from "@marinara-engine/shared";
 import { getDataDir } from "../utils/data-dir.js";
 import { getDatabaseFilePath } from "../config/runtime-config.js";
+import { normalizeTimestampOverrides } from "../services/import/import-timestamps.js";
 
 /** Directories inside DATA_DIR that should be included in every backup. */
 const BACKUP_DIRS = ["avatars", "sprites", "backgrounds", "gallery", "fonts", "knowledge-sources"];
+
+function resolveAvatarWritePath(dataDir: string, avatarPath: unknown) {
+  if (typeof avatarPath !== "string" || !avatarPath.trim()) return null;
+  const filename = avatarPath.split("/").filter(Boolean).pop();
+  if (!filename) return null;
+  return join(dataDir, "avatars", filename);
+}
 
 export async function backupRoutes(app: FastifyInstance) {
   // Create a full backup folder
@@ -199,14 +207,21 @@ export async function backupRoutes(app: FastifyInstance) {
       for (const c of data.characters) {
         try {
           const charData = typeof c.data === "string" ? JSON.parse(c.data) : c.data;
-          const result = await chars.create(charData, c.avatarPath ?? undefined);
+          const result = await chars.create(
+            charData,
+            c.avatarPath ?? undefined,
+            normalizeTimestampOverrides({ createdAt: c.createdAt, updatedAt: c.updatedAt }),
+          );
           // Restore avatar from base64 if provided
           if (c.avatarBase64 && result?.avatarPath) {
             const dataDir = getDataDir();
             const avatarDir = join(dataDir, "avatars");
             await mkdir(avatarDir, { recursive: true });
             const { writeFile } = await import("fs/promises");
-            await writeFile(join(dataDir, result.avatarPath), Buffer.from(c.avatarBase64, "base64"));
+            const avatarFile = resolveAvatarWritePath(dataDir, result.avatarPath);
+            if (avatarFile) {
+              await writeFile(avatarFile, Buffer.from(c.avatarBase64, "base64"));
+            }
           }
           stats.characters++;
         } catch {
@@ -243,7 +258,7 @@ export async function backupRoutes(app: FastifyInstance) {
             personaStats: p.personaStats,
             altDescriptions:
               typeof p.altDescriptions === "string" ? p.altDescriptions : JSON.stringify(p.altDescriptions ?? []),
-          });
+          }, normalizeTimestampOverrides({ createdAt: p.createdAt, updatedAt: p.updatedAt }));
           stats.personas++;
         } catch {
           /* skip */
@@ -255,16 +270,19 @@ export async function backupRoutes(app: FastifyInstance) {
     if (Array.isArray(data.lorebooks)) {
       for (const lb of data.lorebooks) {
         try {
-          const created = await lbs.create({
-            name: lb.name,
-            description: lb.description ?? "",
-            category: lb.category ?? "uncategorized",
-            scanDepth: lb.scanDepth,
-            tokenBudget: lb.tokenBudget,
-            recursiveScanning: lb.recursiveScanning,
-            maxRecursionDepth: lb.maxRecursionDepth,
-            enabled: lb.enabled ?? true,
-          });
+          const created = await lbs.create(
+            {
+              name: lb.name,
+              description: lb.description ?? "",
+              category: lb.category ?? "uncategorized",
+              scanDepth: lb.scanDepth,
+              tokenBudget: lb.tokenBudget,
+              recursiveScanning: lb.recursiveScanning,
+              maxRecursionDepth: lb.maxRecursionDepth,
+              enabled: lb.enabled ?? true,
+            },
+            normalizeTimestampOverrides({ createdAt: lb.createdAt, updatedAt: lb.updatedAt }),
+          );
           if (created && Array.isArray(lb.entries)) {
             for (const entry of lb.entries) {
               await lbs.createEntry({ ...entry, lorebookId: (created as any).id });
@@ -283,16 +301,19 @@ export async function backupRoutes(app: FastifyInstance) {
         try {
           const existing = await presets.getById(p.id);
           if (!existing) {
-            const created = await presets.create({
-              name: `${p.name} (imported)`,
-              description: p.description ?? "",
-              parameters:
-                typeof p.parameters === "string" ? JSON.parse(p.parameters) : (p.parameters ?? p.generationParams),
-              variableGroups:
-                typeof p.variableGroups === "string" ? JSON.parse(p.variableGroups) : (p.variableGroups ?? []),
-              variableValues:
-                typeof p.variableValues === "string" ? JSON.parse(p.variableValues) : (p.variableValues ?? {}),
-            });
+            const created = await presets.create(
+              {
+                name: `${p.name} (imported)`,
+                description: p.description ?? "",
+                parameters:
+                  typeof p.parameters === "string" ? JSON.parse(p.parameters) : (p.parameters ?? p.generationParams),
+                variableGroups:
+                  typeof p.variableGroups === "string" ? JSON.parse(p.variableGroups) : (p.variableGroups ?? []),
+                variableValues:
+                  typeof p.variableValues === "string" ? JSON.parse(p.variableValues) : (p.variableValues ?? {}),
+              },
+              normalizeTimestampOverrides({ createdAt: p.createdAt, updatedAt: p.updatedAt }),
+            );
             if (created) {
               const newPresetId = (created as any).id;
               // Map old group IDs → new group IDs for section groupId references

--- a/packages/server/src/routes/characters.routes.ts
+++ b/packages/server/src/routes/characters.routes.ts
@@ -17,6 +17,14 @@ import { writeFile, mkdir, readFile } from "fs/promises";
 import { join } from "path";
 import { DATA_DIR } from "../utils/data-dir.js";
 import { existsSync } from "fs";
+import { normalizeTimestampOverrides } from "../services/import/import-timestamps.js";
+import { importSTLorebook } from "../services/import/st-lorebook.importer.js";
+import AdmZip from "adm-zip";
+
+function toSafeExportName(name: string, fallback: string) {
+  const sanitized = name.replace(/[<>:"/\\|?*\u0000-\u001f]+/g, " ").replace(/\s+/g, " ").trim();
+  return sanitized || fallback;
+}
 
 export async function charactersRoutes(app: FastifyInstance) {
   const storage = createCharactersStorage(app.db);
@@ -37,7 +45,14 @@ export async function charactersRoutes(app: FastifyInstance) {
     const input = createCharacterSchema.parse(req.body);
     const body = req.body as Record<string, unknown>;
     const avatarPath = typeof body.avatarPath === "string" ? body.avatarPath : undefined;
-    return storage.create(input.data, avatarPath);
+    return storage.create(
+      input.data,
+      avatarPath,
+      normalizeTimestampOverrides({
+        createdAt: body.createdAt,
+        updatedAt: body.updatedAt,
+      }),
+    );
   });
 
   app.patch<{ Params: { id: string } }>("/:id", async (req) => {
@@ -65,7 +80,15 @@ export async function charactersRoutes(app: FastifyInstance) {
       type: "marinara_character",
       version: 1,
       exportedAt: new Date().toISOString(),
-      data: { spec: "chara_card_v2", spec_version: "2.0", data: charData },
+      data: {
+        spec: "chara_card_v2",
+        spec_version: "2.0",
+        data: charData,
+        metadata: {
+          createdAt: char.createdAt,
+          updatedAt: char.updatedAt,
+        },
+      },
     };
     return reply
       .header(
@@ -73,6 +96,113 @@ export async function charactersRoutes(app: FastifyInstance) {
         `attachment; filename="${encodeURIComponent(charData.name || "character")}.marinara.json"`,
       )
       .send(envelope);
+  });
+
+  app.post("/export-bulk", async (req, reply) => {
+    const { ids } = req.body as { ids?: string[] };
+    if (!Array.isArray(ids) || ids.length === 0) {
+      return reply.status(400).send({ error: "ids array is required" });
+    }
+
+    const zip = new AdmZip();
+    let exportedCount = 0;
+    for (const id of ids) {
+      const char = await storage.getById(id);
+      if (!char) continue;
+      const charData = JSON.parse(char.data);
+      const envelope: ExportEnvelope = {
+        type: "marinara_character",
+        version: 1,
+        exportedAt: new Date().toISOString(),
+        data: {
+          spec: "chara_card_v2",
+          spec_version: "2.0",
+          data: charData,
+          metadata: {
+            createdAt: char.createdAt,
+            updatedAt: char.updatedAt,
+          },
+        },
+      };
+      zip.addFile(
+        `${toSafeExportName(String(charData.name ?? "character"), `character-${exportedCount + 1}`)}.marinara.json`,
+        Buffer.from(JSON.stringify(envelope, null, 2), "utf-8"),
+      );
+      exportedCount++;
+    }
+
+    if (exportedCount === 0) {
+      return reply.status(404).send({ error: "No characters found for the provided ids" });
+    }
+
+    return reply
+      .header("Content-Type", "application/zip")
+      .header("Content-Disposition", 'attachment; filename="marinara-characters.zip"')
+      .send(zip.toBuffer());
+  });
+
+  app.post<{ Params: { id: string } }>("/:id/embedded-lorebook/import", async (req, reply) => {
+    const char = await storage.getById(req.params.id);
+    if (!char) return reply.status(404).send({ error: "Character not found" });
+
+    const charData = JSON.parse(char.data) as Record<string, unknown>;
+    const book = charData.character_book as { entries?: unknown[] } | null | undefined;
+    const entries = Array.isArray(book?.entries) ? book.entries : [];
+    if (entries.length === 0) {
+      return reply.status(400).send({ error: "Character does not have an embedded lorebook" });
+    }
+
+    const extensions =
+      charData.extensions && typeof charData.extensions === "object"
+        ? ({ ...(charData.extensions as Record<string, unknown>) } as Record<string, unknown>)
+        : {};
+    const importMetadata =
+      extensions.importMetadata && typeof extensions.importMetadata === "object"
+        ? ({ ...(extensions.importMetadata as Record<string, unknown>) } as Record<string, unknown>)
+        : {};
+    const embeddedLorebookMetadata =
+      importMetadata.embeddedLorebook && typeof importMetadata.embeddedLorebook === "object"
+        ? ({ ...(importMetadata.embeddedLorebook as Record<string, unknown>) } as Record<string, unknown>)
+        : {};
+
+    const result = await importSTLorebook(
+      {
+        name: String(charData.name ?? "Character Lorebook"),
+        entries: book?.entries ?? [],
+        extensions: (book as Record<string, unknown> | null | undefined)?.extensions ?? {},
+      },
+      app.db,
+      {
+        characterId: req.params.id,
+        namePrefix: String(charData.name ?? "Character"),
+        existingLorebookId:
+          typeof embeddedLorebookMetadata.lorebookId === "string" ? embeddedLorebookMetadata.lorebookId : null,
+      },
+    );
+
+    if (!result || "error" in result) {
+      return reply.status(500).send({ error: result?.error ?? "Failed to import embedded lorebook" });
+    }
+
+    extensions.importMetadata = {
+      ...importMetadata,
+      embeddedLorebook: {
+        ...embeddedLorebookMetadata,
+        hasEmbeddedLorebook: true,
+        lorebookId: result.lorebookId,
+      },
+    };
+
+    await storage.update(req.params.id, {
+      extensions: extensions as any,
+    });
+
+    return {
+      success: true,
+      lorebookId: result.lorebookId,
+      entriesImported: result.entriesImported,
+      reimported: result.reimported ?? false,
+    };
   });
 
   // ── Export as PNG ──
@@ -156,7 +286,7 @@ export async function charactersRoutes(app: FastifyInstance) {
   });
 
   app.post("/personas", async (req) => {
-    const { name, description, ...extra } = req.body as {
+    const { name, description, createdAt, updatedAt, ...extra } = req.body as {
       name: string;
       description?: string;
       personality?: string;
@@ -166,8 +296,16 @@ export async function charactersRoutes(app: FastifyInstance) {
       nameColor?: string;
       dialogueColor?: string;
       boxColor?: string;
+      createdAt?: string;
+      updatedAt?: string;
     };
-    return storage.createPersona(name, description ?? "", undefined, extra);
+    return storage.createPersona(
+      name,
+      description ?? "",
+      undefined,
+      extra,
+      normalizeTimestampOverrides({ createdAt, updatedAt }),
+    );
   });
 
   app.patch<{ Params: { id: string } }>("/personas/:id", async (req) => {
@@ -216,7 +354,13 @@ export async function charactersRoutes(app: FastifyInstance) {
       type: "marinara_persona",
       version: 1,
       exportedAt: new Date().toISOString(),
-      data: personaData,
+      data: {
+        ...personaData,
+        metadata: {
+          createdAt: persona.createdAt,
+          updatedAt: persona.updatedAt,
+        },
+      },
     };
     return reply
       .header(
@@ -224,6 +368,54 @@ export async function charactersRoutes(app: FastifyInstance) {
         `attachment; filename="${encodeURIComponent(String(persona.name || "persona"))}.marinara.json"`,
       )
       .send(envelope);
+  });
+
+  app.post("/personas/export-bulk", async (req, reply) => {
+    const { ids } = req.body as { ids?: string[] };
+    if (!Array.isArray(ids) || ids.length === 0) {
+      return reply.status(400).send({ error: "ids array is required" });
+    }
+
+    const zip = new AdmZip();
+    let exportedCount = 0;
+    for (const id of ids) {
+      const persona = await storage.getPersona(id);
+      if (!persona) continue;
+      const {
+        id: _id,
+        createdAt: _createdAt,
+        updatedAt: _updatedAt,
+        avatarPath: _avatarPath,
+        isActive: _isActive,
+        ...personaData
+      } = persona as Record<string, unknown>;
+      const envelope: ExportEnvelope = {
+        type: "marinara_persona",
+        version: 1,
+        exportedAt: new Date().toISOString(),
+        data: {
+          ...personaData,
+          metadata: {
+            createdAt: persona.createdAt,
+            updatedAt: persona.updatedAt,
+          },
+        },
+      };
+      zip.addFile(
+        `${toSafeExportName(String(persona.name ?? "persona"), `persona-${exportedCount + 1}`)}.marinara.json`,
+        Buffer.from(JSON.stringify(envelope, null, 2), "utf-8"),
+      );
+      exportedCount++;
+    }
+
+    if (exportedCount === 0) {
+      return reply.status(404).send({ error: "No personas found for the provided ids" });
+    }
+
+    return reply
+      .header("Content-Type", "application/zip")
+      .header("Content-Disposition", 'attachment; filename="marinara-personas.zip"')
+      .send(zip.toBuffer());
   });
 
   // ── Character Groups ──

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -13,6 +13,7 @@ import { eq, inArray } from "drizzle-orm";
 import { existsSync } from "fs";
 import { join } from "path";
 import { DATA_DIR } from "../utils/data-dir.js";
+import { normalizeTimestampOverrides } from "../services/import/import-timestamps.js";
 
 export async function chatsRoutes(app: FastifyInstance) {
   const storage = createChatsStorage(app.db);
@@ -37,7 +38,14 @@ export async function chatsRoutes(app: FastifyInstance) {
   // Create chat
   app.post("/", async (req) => {
     const input = createChatSchema.parse(req.body);
-    return storage.create(input);
+    const body = req.body as Record<string, unknown>;
+    return storage.create(
+      input,
+      normalizeTimestampOverrides({
+        createdAt: body.createdAt,
+        updatedAt: body.updatedAt,
+      }),
+    );
   });
 
   // Update chat
@@ -150,7 +158,14 @@ export async function chatsRoutes(app: FastifyInstance) {
   // Create message
   app.post<{ Params: { id: string } }>("/:id/messages", async (req) => {
     const input = createMessageSchema.parse({ ...(req.body as Record<string, unknown>), chatId: req.params.id });
-    return storage.createMessage(input);
+    const body = req.body as Record<string, unknown>;
+    return storage.createMessage(
+      input,
+      normalizeTimestampOverrides({
+        createdAt: body.createdAt,
+        updatedAt: body.updatedAt,
+      }),
+    );
   });
 
   // Delete message

--- a/packages/server/src/routes/import.routes.ts
+++ b/packages/server/src/routes/import.routes.ts
@@ -13,6 +13,7 @@ import { importSTLorebook } from "../services/import/st-lorebook.importer.js";
 import { importMarinara } from "../services/import/marinara.importer.js";
 import { scanSTFolder, runSTBulkImport, type STBulkImportOptions } from "../services/import/st-bulk.importer.js";
 import { characters as charactersTable } from "../db/schema/index.js";
+import { normalizeTimestampOverrides } from "../services/import/import-timestamps.js";
 
 const PICK_FOLDER_TIMEOUT_MS = 60_000; // 60s — prevents infinite hang on headless servers
 
@@ -168,6 +169,71 @@ function extractCharaFromPng(buf: Buffer): Record<string, unknown> | null {
   return found.get("ccv3") ?? found.get("chara") ?? null;
 }
 
+function readTimestampOverridesValue(value: unknown) {
+  if (typeof value === "string") {
+    try {
+      return normalizeTimestampOverrides(JSON.parse(value));
+    } catch {
+      return normalizeTimestampOverrides({ createdAt: value, updatedAt: value });
+    }
+  }
+  if (value && typeof value === "object") {
+    return normalizeTimestampOverrides(value as Record<string, unknown>);
+  }
+  return undefined;
+}
+
+function readTimestampOverridesFromBody(body: Record<string, unknown>) {
+  return (
+    readTimestampOverridesValue(body.timestampOverrides ?? body.__timestampOverrides) ??
+    normalizeTimestampOverrides({
+      createdAt: body.createdAt,
+      updatedAt: body.updatedAt,
+    })
+  );
+}
+
+function readTimestampOverridesFromMultipart(file: { fields?: Record<string, any> } | null | undefined) {
+  const field = file?.fields?.timestampOverrides ?? file?.fields?.__timestampOverrides;
+  const rawValue = Array.isArray(field) ? field.at(-1)?.value : field?.value;
+  return readTimestampOverridesValue(rawValue);
+}
+
+async function importCharacterBuffer(
+  fileName: string,
+  buffer: Buffer,
+  db: FastifyInstance["db"],
+  timestampOverrides?: ReturnType<typeof normalizeTimestampOverrides>,
+) {
+  if (fileName.toLowerCase().endsWith(".png")) {
+    const charData = extractCharaFromPng(buffer);
+    if (!charData) {
+      return {
+        success: false,
+        error: "No character data found in PNG. Make sure this is a valid character card with embedded metadata.",
+      };
+    }
+
+    const avatarB64 = buffer.toString("base64");
+    charData._avatarDataUrl = `data:image/png;base64,${avatarB64}`;
+    return importSTCharacter(charData, db, { timestampOverrides });
+  }
+
+  if (fileName.toLowerCase().endsWith(".charx")) {
+    return importCharX(buffer, db, { timestampOverrides });
+  }
+
+  try {
+    const json = JSON.parse(buffer.toString("utf-8"));
+    return importSTCharacter(json, db, { timestampOverrides });
+  } catch {
+    return {
+      success: false,
+      error: "Invalid file format. Expected a JSON character card, a PNG with embedded character data, or a .charx file.",
+    };
+  }
+}
+
 export async function importRoutes(app: FastifyInstance) {
   /** Import a SillyTavern JSONL chat file. */
   app.post("/st-chat", async (req) => {
@@ -175,6 +241,7 @@ export async function importRoutes(app: FastifyInstance) {
     if (!data) return { error: "No file uploaded" };
     const content = await data.toBuffer();
     const text = content.toString("utf-8");
+    const timestampOverrides = readTimestampOverridesFromMultipart(data as any);
 
     // Use the uploaded filename (minus extension) as chat name if available
     const rawName = data.filename ?? "";
@@ -213,12 +280,31 @@ export async function importRoutes(app: FastifyInstance) {
     return importSTChat(text, app.db, {
       ...(chatName ? { chatName } : {}),
       ...(characterId ? { characterId } : {}),
+      ...(timestampOverrides ? { timestampOverrides } : {}),
     });
   });
 
   /** Import a Marinara Engine export (.marinara.json). */
   app.post("/marinara", async (req) => {
-    return importMarinara(req.body as any, app.db);
+    const body = req.body as Record<string, unknown>;
+    const timestampOverrides = readTimestampOverridesFromBody(body);
+    const payload =
+      timestampOverrides && body.data && typeof body.data === "object"
+        ? {
+            ...body,
+            data: {
+              ...(body.data as Record<string, unknown>),
+              metadata: {
+                ...(((body.data as Record<string, unknown>).metadata &&
+                typeof (body.data as Record<string, unknown>).metadata === "object"
+                  ? ((body.data as Record<string, unknown>).metadata as Record<string, unknown>)
+                  : {}) as Record<string, unknown>),
+                timestamps: timestampOverrides,
+              },
+            },
+          }
+        : body;
+    return importMarinara(payload as any, app.db);
   });
 
   /** Import a SillyTavern character (JSON body or PNG file upload). */
@@ -229,60 +315,94 @@ export async function importRoutes(app: FastifyInstance) {
     if (contentType.includes("multipart/form-data")) {
       const file = await req.file();
       if (!file) return { success: false, error: "No file uploaded" };
-
-      const buf = await file.toBuffer();
-      const filename = file.filename ?? "";
-
-      if (filename.toLowerCase().endsWith(".png")) {
-        // Extract character data from PNG tEXt chunk
-        const charData = extractCharaFromPng(buf);
-        if (!charData) {
-          return {
-            success: false,
-            error: "No character data found in PNG. Make sure this is a valid character card with embedded metadata.",
-          };
-        }
-
-        // Attach the PNG itself as avatar data URL
-        const avatarB64 = buf.toString("base64");
-        charData._avatarDataUrl = `data:image/png;base64,${avatarB64}`;
-
-        return importSTCharacter(charData, app.db);
-      }
-
-      if (filename.toLowerCase().endsWith(".charx")) {
-        return importCharX(buf, app.db);
-      }
-
-      // Non-PNG file upload — try parsing as JSON
-      try {
-        const json = JSON.parse(buf.toString("utf-8"));
-        return importSTCharacter(json, app.db);
-      } catch {
-        return {
-          success: false,
-          error:
-            "Invalid file format. Expected a JSON character card, a PNG with embedded character data, or a .charx file.",
-        };
-      }
+      const timestampOverrides = readTimestampOverridesFromMultipart(file as any);
+      return importCharacterBuffer(file.filename ?? "", await file.toBuffer(), app.db, timestampOverrides);
     }
 
     // Standard JSON body
-    return importSTCharacter(req.body as Record<string, unknown>, app.db);
+    const body = req.body as Record<string, unknown>;
+    return importSTCharacter(body, app.db, { timestampOverrides: readTimestampOverridesFromBody(body) });
+  });
+
+  /** Import multiple character cards in one multipart request. */
+  app.post("/st-character/batch", async (req) => {
+    const parts = req.parts();
+    const files: Array<{ filename: string; buffer: Buffer }> = [];
+    const timestampEntries: Array<{ name?: string; lastModified?: number | string }> = [];
+
+    for await (const part of parts) {
+      if (part.type === "file") {
+        files.push({
+          filename: part.filename ?? "character",
+          buffer: await part.toBuffer(),
+        });
+        continue;
+      }
+
+      if (part.fieldname === "fileTimestamps") {
+        try {
+          const parsed = JSON.parse(String(part.value ?? "[]"));
+          if (Array.isArray(parsed)) {
+            timestampEntries.push(...parsed);
+          }
+        } catch {
+          // ignore malformed metadata and continue importing
+        }
+      }
+    }
+
+    if (files.length === 0) {
+      return { success: false, error: "No files uploaded", results: [] };
+    }
+
+    const timestampsByName = new Map<string, Array<{ lastModified?: number | string }>>();
+    for (const entry of timestampEntries) {
+      if (!entry.name) continue;
+      const queue = timestampsByName.get(entry.name) ?? [];
+      queue.push(entry);
+      timestampsByName.set(entry.name, queue);
+    }
+
+    const results = [];
+    for (const file of files) {
+      const timestampEntry = timestampsByName.get(file.filename)?.shift();
+      const timestampOverrides = normalizeTimestampOverrides({
+        createdAt: timestampEntry?.lastModified,
+        updatedAt: timestampEntry?.lastModified,
+      });
+      try {
+        const result = await importCharacterBuffer(file.filename, file.buffer, app.db, timestampOverrides);
+        results.push({ filename: file.filename, ...result });
+      } catch (error) {
+        results.push({
+          filename: file.filename,
+          success: false,
+          error: error instanceof Error ? error.message : "Import failed",
+        });
+      }
+    }
+
+    return {
+      success: results.some((result) => result.success),
+      results,
+    };
   });
 
   /** Import a SillyTavern prompt preset (JSON body). */
   app.post("/st-preset", async (req) => {
     const body = req.body as Record<string, unknown>;
     const fileName = typeof body.__filename === "string" ? body.__filename : undefined;
-    return importSTPreset(body, app.db, fileName);
+    return importSTPreset(body, app.db, fileName, { timestampOverrides: readTimestampOverridesFromBody(body) });
   });
 
   /** Import a SillyTavern World Info / lorebook (JSON body). */
   app.post("/st-lorebook", async (req) => {
     const body = req.body as Record<string, unknown>;
     const fallbackName = typeof body.__filename === "string" ? body.__filename : undefined;
-    return importSTLorebook(body, app.db, fallbackName ? { fallbackName } : undefined);
+    return importSTLorebook(body, app.db, {
+      ...(fallbackName ? { fallbackName } : {}),
+      timestampOverrides: readTimestampOverridesFromBody(body),
+    });
   });
 
   // ═══════════════════════════════════════════════

--- a/packages/server/src/routes/lorebooks.routes.ts
+++ b/packages/server/src/routes/lorebooks.routes.ts
@@ -15,6 +15,13 @@ import { createConnectionsStorage } from "../services/storage/connections.storag
 import { processLorebooks } from "../services/lorebook/index.js";
 import { createLLMProvider } from "../services/llm/provider-registry.js";
 import type { APIProvider } from "@marinara-engine/shared";
+import { normalizeTimestampOverrides } from "../services/import/import-timestamps.js";
+import AdmZip from "adm-zip";
+
+function toSafeExportName(name: string, fallback: string) {
+  const sanitized = name.replace(/[<>:"/\\|?*\u0000-\u001f]+/g, " ").replace(/\s+/g, " ").trim();
+  return sanitized || fallback;
+}
 
 export async function lorebooksRoutes(app: FastifyInstance) {
   const storage = createLorebooksStorage(app.db);
@@ -37,7 +44,14 @@ export async function lorebooksRoutes(app: FastifyInstance) {
 
   app.post("/", async (req) => {
     const input = createLorebookSchema.parse(req.body);
-    return storage.create(input);
+    const body = req.body as Record<string, unknown>;
+    return storage.create(
+      input,
+      normalizeTimestampOverrides({
+        createdAt: body.createdAt,
+        updatedAt: body.updatedAt,
+      }),
+    );
   });
 
   app.patch<{ Params: { id: string } }>("/:id", async (req, reply) => {
@@ -70,6 +84,41 @@ export async function lorebooksRoutes(app: FastifyInstance) {
         `attachment; filename="${encodeURIComponent(String(lb.name || "lorebook"))}.marinara.json"`,
       )
       .send(envelope);
+  });
+
+  app.post("/export-bulk", async (req, reply) => {
+    const { ids } = req.body as { ids?: string[] };
+    if (!Array.isArray(ids) || ids.length === 0) {
+      return reply.status(400).send({ error: "ids array is required" });
+    }
+
+    const zip = new AdmZip();
+    let exportedCount = 0;
+    for (const id of ids) {
+      const lb = (await storage.getById(id)) as Record<string, unknown> | null;
+      if (!lb) continue;
+      const entries = await storage.listEntries(id);
+      const envelope: ExportEnvelope = {
+        type: "marinara_lorebook",
+        version: 1,
+        exportedAt: new Date().toISOString(),
+        data: { lorebook: lb, entries },
+      };
+      zip.addFile(
+        `${toSafeExportName(String(lb.name || "lorebook"), `lorebook-${exportedCount + 1}`)}.marinara.json`,
+        Buffer.from(JSON.stringify(envelope, null, 2), "utf-8"),
+      );
+      exportedCount++;
+    }
+
+    if (exportedCount === 0) {
+      return reply.status(404).send({ error: "No lorebooks found for the provided ids" });
+    }
+
+    return reply
+      .header("Content-Type", "application/zip")
+      .header("Content-Disposition", 'attachment; filename="marinara-lorebooks.zip"')
+      .send(zip.toBuffer());
   });
 
   // ── Entries CRUD ──

--- a/packages/server/src/routes/prompts.routes.ts
+++ b/packages/server/src/routes/prompts.routes.ts
@@ -17,6 +17,13 @@ import { createPromptsStorage } from "../services/storage/prompts.storage.js";
 import { assemblePrompt, type AssemblerInput } from "../services/prompt/index.js";
 import { createChatsStorage } from "../services/storage/chats.storage.js";
 import { createCharactersStorage } from "../services/storage/characters.storage.js";
+import { normalizeTimestampOverrides } from "../services/import/import-timestamps.js";
+import AdmZip from "adm-zip";
+
+function toSafeExportName(name: string, fallback: string) {
+  const sanitized = name.replace(/[<>:"/\\|?*\u0000-\u001f]+/g, " ").replace(/\s+/g, " ").trim();
+  return sanitized || fallback;
+}
 
 export async function promptsRoutes(app: FastifyInstance) {
   const storage = createPromptsStorage(app.db);
@@ -53,7 +60,14 @@ export async function promptsRoutes(app: FastifyInstance) {
 
   app.post("/", async (req) => {
     const input = createPromptPresetSchema.parse(req.body);
-    return storage.create(input);
+    const body = req.body as Record<string, unknown>;
+    return storage.create(
+      input,
+      normalizeTimestampOverrides({
+        createdAt: body.createdAt,
+        updatedAt: body.updatedAt,
+      }),
+    );
   });
 
   app.patch<{ Params: { id: string } }>("/:id", async (req) => {
@@ -101,6 +115,45 @@ export async function promptsRoutes(app: FastifyInstance) {
         `attachment; filename="${encodeURIComponent(preset.name || "preset")}.marinara.json"`,
       )
       .send(envelope);
+  });
+
+  app.post("/export-bulk", async (req, reply) => {
+    const { ids } = req.body as { ids?: string[] };
+    if (!Array.isArray(ids) || ids.length === 0) {
+      return reply.status(400).send({ error: "ids array is required" });
+    }
+
+    const zip = new AdmZip();
+    let exportedCount = 0;
+    for (const id of ids) {
+      const preset = await storage.getById(id);
+      if (!preset) continue;
+      const [sections, groups, choiceBlocks] = await Promise.all([
+        storage.listSections(id),
+        storage.listGroups(id),
+        storage.listChoiceBlocksForPreset(id),
+      ]);
+      const envelope: ExportEnvelope = {
+        type: "marinara_preset",
+        version: 1,
+        exportedAt: new Date().toISOString(),
+        data: { preset, sections, groups, choiceBlocks },
+      };
+      zip.addFile(
+        `${toSafeExportName(preset.name || "preset", `preset-${exportedCount + 1}`)}.marinara.json`,
+        Buffer.from(JSON.stringify(envelope, null, 2), "utf-8"),
+      );
+      exportedCount++;
+    }
+
+    if (exportedCount === 0) {
+      return reply.status(404).send({ error: "No presets found for the provided ids" });
+    }
+
+    return reply
+      .header("Content-Type", "application/zip")
+      .header("Content-Disposition", 'attachment; filename="marinara-presets.zip"')
+      .send(zip.toBuffer());
   });
 
   // ═══════════════════════════════════════════

--- a/packages/server/src/services/import/import-timestamps.ts
+++ b/packages/server/src/services/import/import-timestamps.ts
@@ -1,0 +1,90 @@
+import type { Stats } from "fs";
+
+export interface TimestampOverrides {
+  createdAt?: unknown;
+  updatedAt?: unknown;
+}
+
+export interface NormalizedTimestampOverrides {
+  createdAt?: string | null;
+  updatedAt?: string | null;
+}
+
+export function parseTrustedTimestamp(value: unknown): string | null {
+  if (value instanceof Date && !Number.isNaN(value.getTime())) {
+    return value.toISOString();
+  }
+
+  if (typeof value === "number" && Number.isFinite(value)) {
+    const normalized = value < 1e12 ? value * 1000 : value;
+    const parsed = new Date(normalized);
+    return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+  }
+
+  if (typeof value !== "string") return null;
+  const raw = value.trim();
+  if (!raw) return null;
+
+  if (/^\d{10,}$/.test(raw)) {
+    const numeric = Number(raw);
+    if (Number.isFinite(numeric)) {
+      const normalized = raw.length <= 10 ? numeric * 1000 : numeric;
+      const parsed = new Date(normalized);
+      return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+    }
+  }
+
+  const parsed = new Date(raw);
+  if (!Number.isNaN(parsed.getTime())) {
+    return parsed.toISOString();
+  }
+
+  const legacy = raw.match(
+    /^(\d{1,4})[-/](\d{1,2})[-/](\d{1,2})(?:\s*@?\s*|\s+)(\d{1,2})h?\s*(\d{1,2})m?\s*(\d{1,2})s?(?:\s*(\d{1,3})ms?)?$/i,
+  );
+  if (!legacy) return null;
+
+  const [, year, month, day, hour, minute, second, ms] = legacy;
+  const legacyDate = new Date(
+    Number(year),
+    Number(month) - 1,
+    Number(day),
+    Number(hour),
+    Number(minute),
+    Number(second),
+    Number(ms ?? 0),
+  );
+
+  return Number.isNaN(legacyDate.getTime()) ? null : legacyDate.toISOString();
+}
+
+export function normalizeTimestampOverrides(
+  overrides?: TimestampOverrides | null,
+): NormalizedTimestampOverrides | undefined {
+  if (!overrides) return undefined;
+
+  const createdAt = parseTrustedTimestamp(overrides.createdAt);
+  const updatedAt = parseTrustedTimestamp(overrides.updatedAt);
+
+  if (!createdAt && !updatedAt) return undefined;
+
+  return {
+    createdAt: createdAt ?? updatedAt ?? null,
+    updatedAt: updatedAt ?? createdAt ?? null,
+  };
+}
+
+export function getFileTimestampOverrides(fileStat: Stats): TimestampOverrides | undefined {
+  const modifiedAt = parseTrustedTimestamp(fileStat.mtime);
+  if (!modifiedAt) return undefined;
+  return { createdAt: modifiedAt, updatedAt: modifiedAt };
+}
+
+export function latestTrustedTimestamp(values: Array<unknown>): string | null {
+  const normalized = values
+    .map((value) => parseTrustedTimestamp(value))
+    .filter((value): value is string => !!value)
+    .sort((a, b) => a.localeCompare(b));
+
+  return normalized.at(-1) ?? null;
+}

--- a/packages/server/src/services/import/marinara.importer.ts
+++ b/packages/server/src/services/import/marinara.importer.ts
@@ -6,6 +6,25 @@ import type { ExportEnvelope, ExportType } from "@marinara-engine/shared";
 import { createCharactersStorage } from "../storage/characters.storage.js";
 import { createLorebooksStorage } from "../storage/lorebooks.storage.js";
 import { createPromptsStorage } from "../storage/prompts.storage.js";
+import { normalizeTimestampOverrides, type TimestampOverrides } from "./import-timestamps.js";
+
+function readTimestampOverrides(value: unknown): TimestampOverrides | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const record = value as Record<string, unknown>;
+  const metadata =
+    record.metadata && typeof record.metadata === "object" ? (record.metadata as Record<string, unknown>) : undefined;
+  const timestamps =
+    record.timestamps && typeof record.timestamps === "object"
+      ? (record.timestamps as Record<string, unknown>)
+      : metadata?.timestamps && typeof metadata.timestamps === "object"
+        ? (metadata.timestamps as Record<string, unknown>)
+        : undefined;
+
+  return normalizeTimestampOverrides({
+    createdAt: timestamps?.createdAt ?? metadata?.createdAt ?? record.createdAt,
+    updatedAt: timestamps?.updatedAt ?? metadata?.updatedAt ?? record.updatedAt,
+  });
+}
 
 /**
  * Import a Marinara `.marinara.json` export envelope.
@@ -37,12 +56,41 @@ export async function importMarinara(
 
 async function importCharacter(data: unknown, db: DB) {
   const storage = createCharactersStorage(db);
-  const d = data as { data?: Record<string, unknown>; spec?: string };
-  const charData = d?.data;
+  const d = data as { data?: Record<string, unknown>; spec?: string; spec_version?: string; metadata?: unknown };
+  const charData = d?.data ? { ...(d.data as Record<string, unknown>) } : undefined;
   if (!charData || typeof charData !== "object") {
     return { success: false, type: "marinara_character" as const, error: "Invalid character data" };
   }
-  const result = await storage.create(charData as any);
+  const extensions =
+    charData.extensions && typeof charData.extensions === "object"
+      ? ({ ...(charData.extensions as Record<string, unknown>) } as Record<string, unknown>)
+      : {};
+  const existingImportMetadata =
+    extensions.importMetadata && typeof extensions.importMetadata === "object"
+      ? (extensions.importMetadata as Record<string, unknown>)
+      : {};
+  const cardSpecMetadata =
+    typeof d?.spec === "string" || typeof d?.spec_version === "string"
+      ? {
+          ...(typeof d.spec === "string" ? { spec: d.spec } : {}),
+          ...(typeof d.spec_version === "string" ? { specVersion: d.spec_version } : {}),
+        }
+      : null;
+
+  if (cardSpecMetadata) {
+    extensions.importMetadata = {
+      ...existingImportMetadata,
+      card: {
+        ...(existingImportMetadata.card && typeof existingImportMetadata.card === "object"
+          ? (existingImportMetadata.card as Record<string, unknown>)
+          : {}),
+        ...cardSpecMetadata,
+      },
+    };
+    charData.extensions = extensions;
+  }
+
+  const result = await storage.create(charData as any, undefined, readTimestampOverrides(d));
   return {
     success: true,
     type: "marinara_character" as const,
@@ -72,6 +120,7 @@ async function importPersona(data: unknown, db: DB) {
       dialogueColor: String(d.dialogueColor ?? ""),
       boxColor: String(d.boxColor ?? ""),
     },
+    readTimestampOverrides(d),
   );
   return {
     success: true,
@@ -90,16 +139,19 @@ async function importLorebook(data: unknown, db: DB) {
     return { success: false, type: "marinara_lorebook" as const, error: "Invalid lorebook data" };
   }
   const lb = d.lorebook;
-  const newLb = (await storage.create({
-    name: String(lb.name ?? "Imported Lorebook"),
-    description: String(lb.description ?? ""),
-    category: (lb.category as any) ?? "uncategorized",
-    scanDepth: Number(lb.scanDepth ?? 2),
-    tokenBudget: Number(lb.tokenBudget ?? 2048),
-    recursiveScanning: Boolean(lb.recursiveScanning),
-    enabled: lb.enabled !== false,
-    generatedBy: "import",
-  })) as Record<string, unknown> | null;
+  const newLb = (await storage.create(
+    {
+      name: String(lb.name ?? "Imported Lorebook"),
+      description: String(lb.description ?? ""),
+      category: (lb.category as any) ?? "uncategorized",
+      scanDepth: Number(lb.scanDepth ?? 2),
+      tokenBudget: Number(lb.tokenBudget ?? 2048),
+      recursiveScanning: Boolean(lb.recursiveScanning),
+      enabled: lb.enabled !== false,
+      generatedBy: "import",
+    },
+    readTimestampOverrides(lb),
+  )) as Record<string, unknown> | null;
 
   if (newLb && Array.isArray(d.entries) && d.entries.length > 0) {
     const entries = d.entries.map((e) => ({
@@ -158,15 +210,18 @@ async function importPreset(data: unknown, db: DB) {
   const p = d.preset;
 
   // Create the base preset
-  const newPreset = await storage.create({
-    name: String(p.name ?? "Imported Preset"),
-    description: String(p.description ?? ""),
-    variableGroups: safeParseJson(p.variableGroups, []),
-    variableValues: safeParseJson(p.variableValues, {}),
-    parameters: safeParseJson(p.parameters, {}),
-    wrapFormat: (p.wrapFormat as any) ?? "xml",
-    author: String(p.author ?? ""),
-  });
+  const newPreset = await storage.create(
+    {
+      name: String(p.name ?? "Imported Preset"),
+      description: String(p.description ?? ""),
+      variableGroups: safeParseJson(p.variableGroups, []),
+      variableValues: safeParseJson(p.variableValues, {}),
+      parameters: safeParseJson(p.parameters, {}),
+      wrapFormat: (p.wrapFormat as any) ?? "xml",
+      author: String(p.author ?? ""),
+    },
+    readTimestampOverrides(p),
+  );
   if (!newPreset) {
     return { success: false, type: "marinara_preset" as const, error: "Failed to create preset" };
   }

--- a/packages/server/src/services/import/st-bulk.importer.ts
+++ b/packages/server/src/services/import/st-bulk.importer.ts
@@ -2,7 +2,7 @@
 // Importer: SillyTavern Bulk Import (folder scan)
 // ──────────────────────────────────────────────
 import { readdir, readFile, stat, copyFile, mkdir } from "fs/promises";
-import { join, extname, basename } from "path";
+import { join, extname, basename, relative } from "path";
 import { existsSync, readdirSync } from "fs";
 import { randomUUID } from "crypto";
 import type { DB } from "../../db/connection.js";
@@ -13,6 +13,7 @@ import { importSTLorebook } from "./st-lorebook.importer.js";
 import { characters as charactersTable, personas as personasTable } from "../../db/schema/index.js";
 import { createCharactersStorage } from "../storage/characters.storage.js";
 import { DATA_DIR } from "../../utils/data-dir.js";
+import { getFileTimestampOverrides, parseTrustedTimestamp } from "./import-timestamps.js";
 
 const BG_DIR = join(DATA_DIR, "backgrounds");
 const BG_EXTS = new Set([".jpg", ".jpeg", ".png", ".gif", ".webp", ".avif"]);
@@ -133,19 +134,42 @@ async function listFilesRecursive(dir: string, ext?: string): Promise<string[]> 
   return results;
 }
 
+function makeScanItemId(category: string, dataDir: string, filePath: string) {
+  return `${category}:${relative(dataDir, filePath).replace(/\\/g, "/")}`;
+}
+
+function isConfidentBuiltinPreset(filePath: string) {
+  const name = basename(filePath, extname(filePath)).trim().toLowerCase();
+  return new Set([
+    "default",
+    "deterministic",
+    "neutral",
+    "universal-creative",
+    "universal-light",
+    "universal-super-creative",
+  ]).has(name);
+}
+
 // ─── Scan ───
+
+interface STBulkScanItemBase {
+  id: string;
+  path: string;
+  name: string;
+  modifiedAt: string | null;
+}
 
 export interface STBulkScanResult {
   success: boolean;
   error?: string;
   dataDir?: string;
-  characters: { path: string; name: string; format: string }[];
-  chats: { path: string; characterName: string; folderName: string }[];
-  groupChats: { path: string; groupName: string; members: string[] }[];
-  presets: { path: string; name: string }[];
-  lorebooks: { path: string; name: string }[];
-  backgrounds: { path: string; name: string }[];
-  personas: { path: string; name: string; description: string }[];
+  characters: Array<STBulkScanItemBase & { format: string }>;
+  chats: Array<STBulkScanItemBase & { characterName: string; folderName: string }>;
+  groupChats: Array<STBulkScanItemBase & { groupName: string; members: string[] }>;
+  presets: Array<STBulkScanItemBase & { isBuiltin?: boolean }>;
+  lorebooks: STBulkScanItemBase[];
+  backgrounds: STBulkScanItemBase[];
+  personas: Array<STBulkScanItemBase & { description: string }>;
 }
 
 export async function scanSTFolder(rootPath: string): Promise<STBulkScanResult> {
@@ -201,7 +225,14 @@ export async function scanSTFolder(rootPath: string): Promise<STBulkScanResult> 
         try {
           const raw = JSON.parse(await readFile(fullPath, "utf-8"));
           const name = raw?.data?.name ?? raw?.char_name ?? raw?.name ?? basename(e.name, ".json");
-          characters.push({ path: fullPath, name: String(name), format: "json" });
+          const fileInfo = await stat(fullPath);
+          characters.push({
+            id: makeScanItemId("characters", dataDir, fullPath),
+            path: fullPath,
+            name: String(name),
+            format: "json",
+            modifiedAt: parseTrustedTimestamp(fileInfo.mtime),
+          });
         } catch {
           // skip
         }
@@ -212,7 +243,14 @@ export async function scanSTFolder(rootPath: string): Promise<STBulkScanResult> 
           if (card) {
             const d = card.data as Record<string, unknown> | undefined;
             const name = d?.name ?? card.char_name ?? card.name ?? basename(e.name, ".png");
-            characters.push({ path: fullPath, name: String(name), format: "png" });
+            const fileInfo = await stat(fullPath);
+            characters.push({
+              id: makeScanItemId("characters", dataDir, fullPath),
+              path: fullPath,
+              name: String(name),
+              format: "png",
+              modifiedAt: parseTrustedTimestamp(fileInfo.mtime),
+            });
           }
         } catch {
           // skip
@@ -233,7 +271,15 @@ export async function scanSTFolder(rootPath: string): Promise<STBulkScanResult> 
           const header = JSON.parse(firstLine);
           const folderName = basename(join(f, ".."));
           const charName = header.character_name ?? folderName;
-          chats.push({ path: f, characterName: String(charName), folderName });
+          const fileInfo = await stat(f);
+          chats.push({
+            id: makeScanItemId("chats", dataDir, f),
+            path: f,
+            name: String(charName),
+            characterName: String(charName),
+            folderName,
+            modifiedAt: parseTrustedTimestamp(fileInfo.mtime),
+          });
         }
       } catch {
         // skip
@@ -249,7 +295,14 @@ export async function scanSTFolder(rootPath: string): Promise<STBulkScanResult> 
       try {
         const raw = JSON.parse(await readFile(f, "utf-8"));
         const name = raw.name ?? basename(f, ".json");
-        presets.push({ path: f, name: String(name) });
+        const fileInfo = await stat(f);
+        presets.push({
+          id: makeScanItemId("presets", dataDir, f),
+          path: f,
+          name: String(name),
+          modifiedAt: parseTrustedTimestamp(fileInfo.mtime),
+          ...(isConfidentBuiltinPreset(f) ? { isBuiltin: true } : {}),
+        });
       } catch {
         // skip
       }
@@ -264,7 +317,13 @@ export async function scanSTFolder(rootPath: string): Promise<STBulkScanResult> 
       try {
         const raw = JSON.parse(await readFile(f, "utf-8"));
         const name = raw.name ?? basename(f, ".json");
-        lorebooks.push({ path: f, name: String(name) });
+        const fileInfo = await stat(f);
+        lorebooks.push({
+          id: makeScanItemId("lorebooks", dataDir, f),
+          path: f,
+          name: String(name),
+          modifiedAt: parseTrustedTimestamp(fileInfo.mtime),
+        });
       } catch {
         // skip
       }
@@ -280,7 +339,14 @@ export async function scanSTFolder(rootPath: string): Promise<STBulkScanResult> 
       if (!e.isFile()) continue;
       const ext = extname(e.name).toLowerCase();
       if (BG_EXTS.has(ext)) {
-        backgrounds.push({ path: join(bgDir, e.name), name: e.name });
+        const fullPath = join(bgDir, e.name);
+        const fileInfo = await stat(fullPath);
+        backgrounds.push({
+          id: makeScanItemId("backgrounds", dataDir, fullPath),
+          path: fullPath,
+          name: e.name,
+          modifiedAt: parseTrustedTimestamp(fileInfo.mtime),
+        });
       }
     }
     break; // only use the first matching folder
@@ -321,7 +387,15 @@ export async function scanSTFolder(rootPath: string): Promise<STBulkScanResult> 
         const gcFolder = join(groupChatsDir, groupId);
         const jsonlFiles = await listFiles(gcFolder, ".jsonl");
         for (const f of jsonlFiles) {
-          groupChats.push({ path: f, groupName: meta.name, members: meta.members });
+          const fileInfo = await stat(f);
+          groupChats.push({
+            id: makeScanItemId("groupChats", dataDir, f),
+            path: f,
+            name: meta.name,
+            groupName: meta.name,
+            members: meta.members,
+            modifiedAt: parseTrustedTimestamp(fileInfo.mtime),
+          });
         }
       }
     }
@@ -339,7 +413,15 @@ export async function scanSTFolder(rootPath: string): Promise<STBulkScanResult> 
             const meta = chatId ? groupMetaMap.get(String(chatId)) : null;
             const gName = meta?.name ?? "Group Chat";
             const members = meta?.members ?? [];
-            groupChats.push({ path: f, groupName: gName, members });
+            const fileInfo = await stat(f);
+            groupChats.push({
+              id: makeScanItemId("groupChats", dataDir, f),
+              path: f,
+              name: gName,
+              groupName: gName,
+              members,
+              modifiedAt: parseTrustedTimestamp(fileInfo.mtime),
+            });
           }
         } catch {
           // skip
@@ -379,7 +461,15 @@ export async function scanSTFolder(rootPath: string): Promise<STBulkScanResult> 
         // Get description from settings
         const descEntry = stPersonaDescs[e.name];
         const description = typeof descEntry === "string" ? descEntry : (descEntry?.description ?? "");
-        personas.push({ path: join(avatarDir, e.name), name: displayName, description });
+        const fullPath = join(avatarDir, e.name);
+        const fileInfo = await stat(fullPath);
+        personas.push({
+          id: makeScanItemId("personas", dataDir, fullPath),
+          path: fullPath,
+          name: displayName,
+          description,
+          modifiedAt: parseTrustedTimestamp(fileInfo.mtime),
+        });
       }
     }
     break;
@@ -390,14 +480,16 @@ export async function scanSTFolder(rootPath: string): Promise<STBulkScanResult> 
 
 // ─── Bulk Import ───
 
+export type STBulkImportSelection = boolean | string[];
+
 export interface STBulkImportOptions {
-  characters: boolean;
-  chats: boolean;
-  groupChats: boolean;
-  presets: boolean;
-  lorebooks: boolean;
-  backgrounds: boolean;
-  personas: boolean;
+  characters: STBulkImportSelection;
+  chats: STBulkImportSelection;
+  groupChats: STBulkImportSelection;
+  presets: STBulkImportSelection;
+  lorebooks: STBulkImportSelection;
+  backgrounds: STBulkImportSelection;
+  personas: STBulkImportSelection;
 }
 
 export interface STBulkImportResult {
@@ -429,6 +521,13 @@ export interface ImportProgress {
   imported: STBulkImportResult["imported"];
 }
 
+function resolveSelectedItems<T extends { id: string }>(items: T[], selection: STBulkImportSelection | undefined) {
+  if (selection === true) return items;
+  if (selection === false || !Array.isArray(selection) || selection.length === 0) return [];
+  const selectedIds = new Set(selection);
+  return items.filter((item) => selectedIds.has(item.id));
+}
+
 export async function runSTBulkImport(
   rootPath: string,
   options: STBulkImportOptions,
@@ -447,15 +546,24 @@ export async function runSTBulkImport(
 
   const imported = { characters: 0, chats: 0, groupChats: 0, presets: 0, lorebooks: 0, backgrounds: 0, personas: 0 };
   const errors: string[] = [];
+  const selectedCharacters = resolveSelectedItems(scanResult.characters, options.characters);
+  const selectedChats = resolveSelectedItems(scanResult.chats, options.chats);
+  const selectedGroupChats = resolveSelectedItems(scanResult.groupChats, options.groupChats);
+  const selectedPresets = resolveSelectedItems(scanResult.presets, options.presets);
+  const selectedLorebooks = resolveSelectedItems(scanResult.lorebooks, options.lorebooks);
+  const selectedBackgrounds = resolveSelectedItems(scanResult.backgrounds, options.backgrounds);
+  const selectedPersonas = resolveSelectedItems(scanResult.personas, options.personas);
 
   // Import characters
-  if (options.characters) {
-    const total = scanResult.characters.length;
+  if (selectedCharacters.length > 0) {
+    const total = selectedCharacters.length;
     let idx = 0;
-    for (const ch of scanResult.characters) {
+    for (const ch of selectedCharacters) {
       idx++;
       onProgress?.({ category: "Characters", item: ch.name, current: idx, total, imported });
       try {
+        const fileInfo = await stat(ch.path);
+        const timestampOverrides = getFileTimestampOverrides(fileInfo);
         if (ch.format === "png") {
           const buf = await readFile(ch.path);
           const card = extractCharaFromPng(buf);
@@ -464,12 +572,12 @@ export async function runSTBulkImport(
             const b64 = buf.toString("base64");
             const dataUrl = `data:image/png;base64,${b64}`;
             (card as Record<string, unknown>)._avatarDataUrl = dataUrl;
-            await importSTCharacter(card as Record<string, unknown>, db);
+            await importSTCharacter(card as Record<string, unknown>, db, { timestampOverrides });
             imported.characters++;
           }
         } else {
           const raw = JSON.parse(await readFile(ch.path, "utf-8"));
-          await importSTCharacter(raw, db);
+          await importSTCharacter(raw, db, { timestampOverrides });
           imported.characters++;
         }
       } catch (err) {
@@ -497,7 +605,7 @@ export async function runSTBulkImport(
   }
 
   // Also index by character card filename (ST organises chat folders by filename)
-  for (const ch of scanResult.characters) {
+  for (const ch of selectedCharacters) {
     const filenameKey = basename(ch.path, extname(ch.path)).toLowerCase().trim();
     if (filenameKey && !charNameToId.has(filenameKey)) {
       const charId = charNameToId.get(ch.name.toLowerCase().trim());
@@ -508,15 +616,16 @@ export async function runSTBulkImport(
   // Import chats (with character linking)
   // Generate one groupId per character name so all chats for the same character
   // are grouped together (like ST "chat files" / branches).
-  if (options.chats) {
+  if (selectedChats.length > 0) {
     const charGroupIds = new Map<string, string>();
-    const total = scanResult.chats.length;
+    const total = selectedChats.length;
     let idx = 0;
-    for (const ct of scanResult.chats) {
+    for (const ct of selectedChats) {
       idx++;
       onProgress?.({ category: "Chats", item: ct.characterName, current: idx, total, imported });
       try {
         const content = await readFile(ct.path, "utf-8");
+        const fileInfo = await stat(ct.path);
         // Try matching by header character_name first, then by folder name (ST uses filenames for folders)
         const charId =
           charNameToId.get(ct.characterName.toLowerCase().trim()) ??
@@ -530,6 +639,7 @@ export async function runSTBulkImport(
           characterId: charId,
           chatName: ct.characterName,
           groupId: charGroupIds.get(groupKey)!,
+          timestampOverrides: getFileTimestampOverrides(fileInfo),
         });
         imported.chats++;
       } catch (err) {
@@ -539,15 +649,16 @@ export async function runSTBulkImport(
   }
 
   // Import group chats
-  if (options.groupChats) {
+  if (selectedGroupChats.length > 0) {
     const gcGroupIds = new Map<string, string>();
-    const total = scanResult.groupChats.length;
+    const total = selectedGroupChats.length;
     let idx = 0;
-    for (const gc of scanResult.groupChats) {
+    for (const gc of selectedGroupChats) {
       idx++;
       onProgress?.({ category: "Group Chats", item: gc.groupName, current: idx, total, imported });
       try {
         const content = await readFile(gc.path, "utf-8");
+        const fileInfo = await stat(gc.path);
         // Build speaker→characterId map from member names
         const speakerMap: Record<string, string> = {};
         for (const memberName of gc.members) {
@@ -563,6 +674,7 @@ export async function runSTBulkImport(
           speakerMap,
           mode: "roleplay",
           groupId: gcGroupIds.get(groupKey)!,
+          timestampOverrides: getFileTimestampOverrides(fileInfo),
         });
         imported.groupChats++;
       } catch (err) {
@@ -572,15 +684,16 @@ export async function runSTBulkImport(
   }
 
   // Import presets
-  if (options.presets) {
-    const total = scanResult.presets.length;
+  if (selectedPresets.length > 0) {
+    const total = selectedPresets.length;
     let idx = 0;
-    for (const pr of scanResult.presets) {
+    for (const pr of selectedPresets) {
       idx++;
       onProgress?.({ category: "Presets", item: pr.name, current: idx, total, imported });
       try {
         const raw = JSON.parse(await readFile(pr.path, "utf-8"));
-        await importSTPreset(raw, db, pr.name);
+        const fileInfo = await stat(pr.path);
+        await importSTPreset(raw, db, pr.name, { timestampOverrides: getFileTimestampOverrides(fileInfo) });
         imported.presets++;
       } catch (err) {
         errors.push(`Preset "${pr.name}": ${(err as Error).message}`);
@@ -589,15 +702,19 @@ export async function runSTBulkImport(
   }
 
   // Import lorebooks
-  if (options.lorebooks) {
-    const total = scanResult.lorebooks.length;
+  if (selectedLorebooks.length > 0) {
+    const total = selectedLorebooks.length;
     let idx = 0;
-    for (const lb of scanResult.lorebooks) {
+    for (const lb of selectedLorebooks) {
       idx++;
       onProgress?.({ category: "Lorebooks", item: lb.name, current: idx, total, imported });
       try {
         const raw = JSON.parse(await readFile(lb.path, "utf-8"));
-        await importSTLorebook(raw, db, { fallbackName: lb.name });
+        const fileInfo = await stat(lb.path);
+        await importSTLorebook(raw, db, {
+          fallbackName: lb.name,
+          timestampOverrides: getFileTimestampOverrides(fileInfo),
+        });
         imported.lorebooks++;
       } catch (err) {
         errors.push(`Lorebook "${lb.name}": ${(err as Error).message}`);
@@ -606,14 +723,14 @@ export async function runSTBulkImport(
   }
 
   // Import backgrounds
-  if (options.backgrounds) {
+  if (selectedBackgrounds.length > 0) {
     // Ensure our backgrounds directory exists
     if (!existsSync(BG_DIR)) {
       await mkdir(BG_DIR, { recursive: true });
     }
-    const total = scanResult.backgrounds.length;
+    const total = selectedBackgrounds.length;
     let idx = 0;
-    for (const bg of scanResult.backgrounds) {
+    for (const bg of selectedBackgrounds) {
       idx++;
       onProgress?.({ category: "Backgrounds", item: bg.name, current: idx, total, imported });
       try {
@@ -628,15 +745,15 @@ export async function runSTBulkImport(
   }
 
   // Import personas
-  if (options.personas) {
+  if (selectedPersonas.length > 0) {
     const storage = createCharactersStorage(db);
     const AVATAR_DIR = join(DATA_DIR, "avatars");
     if (!existsSync(AVATAR_DIR)) {
       await mkdir(AVATAR_DIR, { recursive: true });
     }
-    const total = scanResult.personas.length;
+    const total = selectedPersonas.length;
     let idx = 0;
-    for (const p of scanResult.personas) {
+    for (const p of selectedPersonas) {
       idx++;
       onProgress?.({ category: "Personas", item: p.name, current: idx, total, imported });
       try {
@@ -645,7 +762,8 @@ export async function runSTBulkImport(
         const destName = `${randomUUID()}${ext}`;
         await copyFile(p.path, join(AVATAR_DIR, destName));
         const avatarPath = `/api/avatars/file/${destName}`;
-        await storage.createPersona(p.name, p.description, avatarPath);
+        const fileInfo = await stat(p.path);
+        await storage.createPersona(p.name, p.description, avatarPath, undefined, getFileTimestampOverrides(fileInfo));
         imported.personas++;
       } catch (err) {
         errors.push(`Persona "${p.name}": ${(err as Error).message}`);

--- a/packages/server/src/services/import/st-character.importer.ts
+++ b/packages/server/src/services/import/st-character.importer.ts
@@ -11,8 +11,10 @@ import { join } from "path";
 import { randomUUID } from "crypto";
 import { DATA_DIR } from "../../utils/data-dir.js";
 import AdmZip from "adm-zip";
+import { normalizeTimestampOverrides, type TimestampOverrides } from "./import-timestamps.js";
 
 const AVATAR_DIR = join(DATA_DIR, "avatars");
+const IMPORT_METADATA_KEY = "importMetadata";
 
 function ensureAvatarDir() {
   if (!existsSync(AVATAR_DIR)) {
@@ -25,8 +27,13 @@ function ensureAvatarDir() {
  * Handles V1, V2, Pygmalion, and RisuAI formats.
  * If _avatarDataUrl is present, saves the avatar image.
  */
-export async function importSTCharacter(raw: Record<string, unknown>, db: DB) {
+export async function importSTCharacter(
+  raw: Record<string, unknown>,
+  db: DB,
+  options?: { timestampOverrides?: TimestampOverrides | null },
+) {
   const storage = createCharactersStorage(db);
+  const normalizedTimestamps = normalizeTimestampOverrides(options?.timestampOverrides);
 
   // Extract avatar data URL if present (from PNG import)
   const avatarDataUrl = raw._avatarDataUrl as string | null;
@@ -58,6 +65,23 @@ export async function importSTCharacter(raw: Record<string, unknown>, db: DB) {
     data.extensions.botBrowserSource = botBrowserSource;
   }
 
+  const existingImportMetadata =
+    data.extensions[IMPORT_METADATA_KEY] && typeof data.extensions[IMPORT_METADATA_KEY] === "object"
+      ? (data.extensions[IMPORT_METADATA_KEY] as Record<string, unknown>)
+      : {};
+  const cardSpecMetadata = buildCardSpecMetadata(raw);
+  const hasEmbeddedLorebook = !!data.character_book?.entries?.length;
+  data.extensions[IMPORT_METADATA_KEY] = {
+    ...existingImportMetadata,
+    ...(cardSpecMetadata ? { card: cardSpecMetadata } : {}),
+    embeddedLorebook: {
+      ...(typeof existingImportMetadata.embeddedLorebook === "object" && existingImportMetadata.embeddedLorebook
+        ? (existingImportMetadata.embeddedLorebook as Record<string, unknown>)
+        : {}),
+      hasEmbeddedLorebook,
+    },
+  };
+
   // Save avatar image if provided
   let avatarPath: string | undefined;
   if (avatarDataUrl && avatarDataUrl.startsWith("data:image/")) {
@@ -74,7 +98,7 @@ export async function importSTCharacter(raw: Record<string, unknown>, db: DB) {
     }
   }
 
-  const character = await storage.create(data, avatarPath);
+  const character = await storage.create(data, avatarPath, normalizedTimestamps);
   const charId = (character as { id?: string } | null)?.id;
 
   // Extract character_book into a standalone lorebook linked to this character
@@ -92,12 +116,33 @@ export async function importSTCharacter(raw: Record<string, unknown>, db: DB) {
       const result = await importSTLorebook(wiData, db, {
         characterId: charId,
         namePrefix: data.name,
+        timestampOverrides: options?.timestampOverrides,
       });
       if (result && "lorebookId" in result) {
         lorebookResult = {
           lorebookId: result.lorebookId as string,
           entriesImported: result.entriesImported as number,
         };
+
+        const updatedImportMetadata = {
+          ...(data.extensions[IMPORT_METADATA_KEY] as Record<string, unknown>),
+          embeddedLorebook: {
+            ...(((data.extensions[IMPORT_METADATA_KEY] as Record<string, unknown>)?.embeddedLorebook as
+              | Record<string, unknown>
+              | undefined) ?? {}),
+            hasEmbeddedLorebook: true,
+            lorebookId: result.lorebookId as string,
+          },
+        };
+        data.extensions[IMPORT_METADATA_KEY] = updatedImportMetadata;
+        await storage.update(
+          charId,
+          { extensions: { ...data.extensions } },
+          undefined,
+          {
+            updatedAt: normalizedTimestamps?.updatedAt ?? normalizedTimestamps?.createdAt ?? null,
+          },
+        );
       }
     } catch {
       // Non-fatal — character was imported, just lorebook extraction failed
@@ -116,7 +161,7 @@ export async function importSTCharacter(raw: Record<string, unknown>, db: DB) {
  * Import a CharX (.charx) file — RisuAI Character Card V3 zip format.
  * Extracts card.json and the main icon asset from the zip.
  */
-export async function importCharX(buf: Buffer, db: DB) {
+export async function importCharX(buf: Buffer, db: DB, options?: { timestampOverrides?: TimestampOverrides | null }) {
   const zip = new AdmZip(buf);
 
   // Extract card.json from root of the zip
@@ -166,7 +211,18 @@ export async function importCharX(buf: Buffer, db: DB) {
     cardJson._avatarDataUrl = avatarDataUrl;
   }
 
-  return importSTCharacter(cardJson as Record<string, unknown>, db);
+  return importSTCharacter(cardJson as Record<string, unknown>, db, options);
+}
+
+function buildCardSpecMetadata(raw: Record<string, unknown>) {
+  const spec = typeof raw.spec === "string" ? raw.spec : null;
+  const specVersion = typeof raw.spec_version === "string" ? raw.spec_version : null;
+  if (!spec && !specVersion) return null;
+
+  return {
+    ...(spec ? { spec } : {}),
+    ...(specVersion ? { specVersion } : {}),
+  };
 }
 
 /** Resolve an asset URI from a CharX zip to a data URL. */

--- a/packages/server/src/services/import/st-chat.importer.ts
+++ b/packages/server/src/services/import/st-chat.importer.ts
@@ -4,6 +4,7 @@
 import type { DB } from "../../db/connection.js";
 import { createChatsStorage } from "../storage/chats.storage.js";
 import type { ChatMode } from "@marinara-engine/shared";
+import { latestTrustedTimestamp, normalizeTimestampOverrides, parseTrustedTimestamp, type TimestampOverrides } from "./import-timestamps.js";
 
 interface STChatHeader {
   user_name?: string;
@@ -34,6 +35,8 @@ export interface ImportSTChatOptions {
   speakerMap?: Record<string, string>;
   /** Group ID to associate this chat with (for grouping branches) */
   groupId?: string | null;
+  /** Source file timestamps to preserve when trustworthy */
+  timestampOverrides?: TimestampOverrides | null;
 }
 
 /**
@@ -66,24 +69,12 @@ export async function importSTChat(jsonlContent: string, db: DB, opts?: ImportST
     }
   }
 
-  // Create the chat
-  const chat = await storage.create({
-    name: opts?.chatName ?? `${characterName} (imported)`,
-    mode: (opts?.mode ?? "roleplay") as ChatMode,
-    characterIds,
-    groupId: opts?.groupId ?? null,
-    personaId: null,
-    promptPresetId: null,
-    connectionId: null,
-  });
-
-  if (!chat) return { error: "Failed to create chat" };
-
-  // Import messages in batch
+  const messageTimestamps: string[] = [];
   const msgInputs: {
     role: "system" | "user" | "assistant" | "narrator";
     characterId: string | null;
     content: string;
+    createdAt?: string;
   }[] = [];
   for (let i = 1; i < lines.length; i++) {
     try {
@@ -106,13 +97,38 @@ export async function importSTChat(jsonlContent: string, db: DB, opts?: ImportST
         }
       }
 
-      msgInputs.push({ role, characterId: messageCharacterId, content });
+      const createdAt = parseTrustedTimestamp(stMsg.send_date);
+      if (createdAt) messageTimestamps.push(createdAt);
+
+      msgInputs.push({ role, characterId: messageCharacterId, content, ...(createdAt ? { createdAt } : {}) });
     } catch {
       // Skip malformed lines
     }
   }
 
-  await storage.createMessagesBatch(chat.id, msgInputs);
+  const latestMessageTimestamp = latestTrustedTimestamp(messageTimestamps);
+  const chatTimestamps = normalizeTimestampOverrides({
+    createdAt: opts?.timestampOverrides?.createdAt ?? latestMessageTimestamp ?? null,
+    updatedAt:
+      latestMessageTimestamp ?? opts?.timestampOverrides?.updatedAt ?? opts?.timestampOverrides?.createdAt ?? null,
+  });
+
+  const chat = await storage.create(
+    {
+      name: opts?.chatName ?? `${characterName} (imported)`,
+      mode: (opts?.mode ?? "roleplay") as ChatMode,
+      characterIds,
+      groupId: opts?.groupId ?? null,
+      personaId: null,
+      promptPresetId: null,
+      connectionId: null,
+    },
+    chatTimestamps,
+  );
+
+  if (!chat) return { error: "Failed to create chat" };
+
+  await storage.createMessagesBatch(chat.id, msgInputs, chatTimestamps);
 
   return {
     success: true,

--- a/packages/server/src/services/import/st-lorebook.importer.ts
+++ b/packages/server/src/services/import/st-lorebook.importer.ts
@@ -4,6 +4,7 @@
 import type { DB } from "../../db/connection.js";
 import { createLorebooksStorage } from "../storage/lorebooks.storage.js";
 import type { CreateLorebookEntryInput, LorebookCategory } from "@marinara-engine/shared";
+import type { TimestampOverrides } from "./import-timestamps.js";
 
 interface STWorldInfoEntry {
   uid?: number;
@@ -208,7 +209,13 @@ function detectEntryTag(entry: STWorldInfoEntry): string {
 export async function importSTLorebook(
   raw: Record<string, unknown>,
   db: DB,
-  options?: { characterId?: string; namePrefix?: string; fallbackName?: string },
+  options?: {
+    characterId?: string;
+    namePrefix?: string;
+    fallbackName?: string;
+    timestampOverrides?: TimestampOverrides | null;
+    existingLorebookId?: string | null;
+  },
 ) {
   const storage = createLorebooksStorage(db);
   const wi = raw as unknown as STWorldInfo;
@@ -220,17 +227,33 @@ export async function importSTLorebook(
     ? `${options.namePrefix} — ${wi.name ?? "Lorebook"}`
     : (wi.name ?? options?.fallbackName ?? "Imported Lorebook");
 
-  // Create the lorebook
-  const lorebook = (await storage.create({
+  const lorebookInput = {
     name: lbName,
     description: "Imported from SillyTavern",
     category: detectedCategory,
     scanDepth: 2,
     tokenBudget: 2048,
     recursiveScanning: false,
-    generatedBy: "import",
+    generatedBy: "import" as const,
     characterId: options?.characterId ?? null,
-  })) as Record<string, unknown> | null;
+  };
+
+  let lorebook: Record<string, unknown> | null = null;
+  const existingLorebookId = options?.existingLorebookId ?? null;
+  if (existingLorebookId) {
+    const existing = (await storage.getById(existingLorebookId)) as Record<string, unknown> | null;
+    if (existing) {
+      lorebook = (await storage.update(existingLorebookId, lorebookInput)) as Record<string, unknown> | null;
+      const existingEntries = (await storage.listEntries(existingLorebookId)) as unknown as Array<{ id: string }>;
+      for (const entry of existingEntries) {
+        await storage.removeEntry(entry.id);
+      }
+    }
+  }
+
+  if (!lorebook) {
+    lorebook = (await storage.create(lorebookInput, options?.timestampOverrides)) as Record<string, unknown> | null;
+  }
 
   if (!lorebook) return { error: "Failed to create lorebook" };
 
@@ -321,5 +344,6 @@ export async function importSTLorebook(
     name: lorebookName,
     category: detectedCategory,
     entriesImported: imported,
+    reimported: !!existingLorebookId,
   };
 }

--- a/packages/server/src/services/import/st-prompt.importer.ts
+++ b/packages/server/src/services/import/st-prompt.importer.ts
@@ -5,6 +5,7 @@ import type { DB } from "../../db/connection.js";
 import type { MarkerConfig } from "@marinara-engine/shared";
 import { createPromptsStorage } from "../storage/prompts.storage.js";
 import type { PromptVariableGroup } from "@marinara-engine/shared";
+import type { TimestampOverrides } from "./import-timestamps.js";
 
 const VALID_REASONING = new Set(["low", "medium", "high", "maximum"]);
 
@@ -64,7 +65,12 @@ interface STPreset {
  * Import a SillyTavern prompt preset JSON.
  * Parses the prompt array, variable toggle groups, and generation parameters.
  */
-export async function importSTPreset(raw: Record<string, unknown>, db: DB, fileName?: string) {
+export async function importSTPreset(
+  raw: Record<string, unknown>,
+  db: DB,
+  fileName?: string,
+  options?: { timestampOverrides?: TimestampOverrides | null },
+) {
   const storage = createPromptsStorage(db);
   const preset = raw as unknown as STPreset;
 
@@ -72,30 +78,33 @@ export async function importSTPreset(raw: Record<string, unknown>, db: DB, fileN
   const variableGroups = detectVariableGroups(preset.prompts ?? []);
 
   // Create the preset
-  const created = await storage.create({
-    name: `Imported: ${guessPresetName(raw, fileName)}`,
-    description: "Imported from SillyTavern",
-    variableGroups,
-    variableValues: {},
-    parameters: {
-      temperature: clamp(preset.temperature ?? 1, 0, 2),
-      topP: clamp(preset.top_p ?? 1, 0, 1),
-      topK: Math.max(0, Math.round(preset.top_k ?? 0)),
-      minP: clamp(preset.min_p ?? 0, 0, 1),
-      maxTokens: Math.max(1, Math.round(preset.openai_max_tokens ?? 4096)),
-      maxContext: Math.max(1, Math.round(preset.openai_max_context ?? 128000)),
-      frequencyPenalty: clamp(preset.frequency_penalty ?? 0, -2, 2),
-      presencePenalty: clamp(preset.presence_penalty ?? 0, -2, 2),
-      reasoningEffort: toReasoningEffort(preset.reasoning_effort),
-      verbosity: null,
-      squashSystemMessages: preset.squash_system_messages ?? true,
-      showThoughts: preset.show_thoughts ?? true,
-      useMaxContext: false,
-      stopSequences: [],
-      strictRoleFormatting: true,
-      singleUserMessage: false,
+  const created = await storage.create(
+    {
+      name: `Imported: ${guessPresetName(raw, fileName)}`,
+      description: "Imported from SillyTavern",
+      variableGroups,
+      variableValues: {},
+      parameters: {
+        temperature: clamp(preset.temperature ?? 1, 0, 2),
+        topP: clamp(preset.top_p ?? 1, 0, 1),
+        topK: Math.max(0, Math.round(preset.top_k ?? 0)),
+        minP: clamp(preset.min_p ?? 0, 0, 1),
+        maxTokens: Math.max(1, Math.round(preset.openai_max_tokens ?? 4096)),
+        maxContext: Math.max(1, Math.round(preset.openai_max_context ?? 128000)),
+        frequencyPenalty: clamp(preset.frequency_penalty ?? 0, -2, 2),
+        presencePenalty: clamp(preset.presence_penalty ?? 0, -2, 2),
+        reasoningEffort: toReasoningEffort(preset.reasoning_effort),
+        verbosity: null,
+        squashSystemMessages: preset.squash_system_messages ?? true,
+        showThoughts: preset.show_thoughts ?? true,
+        useMaxContext: false,
+        stopSequences: [],
+        strictRoleFormatting: true,
+        singleUserMessage: false,
+      },
     },
-  });
+    options?.timestampOverrides,
+  );
 
   if (!created) return { error: "Failed to create preset" };
 

--- a/packages/server/src/services/storage/characters.storage.ts
+++ b/packages/server/src/services/storage/characters.storage.ts
@@ -6,6 +6,16 @@ import type { DB } from "../../db/connection.js";
 import { characters, personas, characterGroups, personaGroups } from "../../db/schema/index.js";
 import { newId, now } from "../../utils/id-generator.js";
 import type { CharacterData } from "@marinara-engine/shared";
+import { normalizeTimestampOverrides, type TimestampOverrides } from "../import/import-timestamps.js";
+
+function resolveTimestamps(overrides?: TimestampOverrides | null) {
+  const normalized = normalizeTimestampOverrides(overrides);
+  const createdAt = normalized?.createdAt ?? now();
+  return {
+    createdAt,
+    updatedAt: normalized?.updatedAt ?? createdAt,
+  };
+}
 
 export function createCharactersStorage(db: DB) {
   return {
@@ -20,31 +30,40 @@ export function createCharactersStorage(db: DB) {
       return rows[0] ?? null;
     },
 
-    async create(data: CharacterData, avatarPath?: string) {
+    async create(data: CharacterData, avatarPath?: string, timestampOverrides?: TimestampOverrides | null) {
       const id = newId();
-      const timestamp = now();
+      const timestamp = resolveTimestamps(timestampOverrides);
       await db.insert(characters).values({
         id,
         data: JSON.stringify(data),
         avatarPath: avatarPath ?? null,
         spriteFolderPath: null,
-        createdAt: timestamp,
-        updatedAt: timestamp,
+        createdAt: timestamp.createdAt,
+        updatedAt: timestamp.updatedAt,
       });
       return this.getById(id);
     },
 
-    async update(id: string, data: Partial<CharacterData>, avatarPath?: string) {
+    async update(
+      id: string,
+      data: Partial<CharacterData>,
+      avatarPath?: string,
+      options?: { updatedAt?: string | null },
+    ) {
       const existing = await this.getById(id);
       if (!existing) return null;
       const currentData = JSON.parse(existing.data) as CharacterData;
       const merged = { ...currentData, ...data };
+      const updatedAt = normalizeTimestampOverrides({
+        createdAt: options?.updatedAt,
+        updatedAt: options?.updatedAt,
+      })?.updatedAt;
       await db
         .update(characters)
         .set({
           data: JSON.stringify(merged),
           ...(avatarPath !== undefined && { avatarPath }),
-          updatedAt: now(),
+          updatedAt: updatedAt ?? now(),
         })
         .where(eq(characters.id, id));
       return this.getById(id);
@@ -87,9 +106,10 @@ export function createCharactersStorage(db: DB) {
         altDescriptions?: string;
         tags?: string;
       },
+      timestampOverrides?: TimestampOverrides | null,
     ) {
       const id = newId();
-      const timestamp = now();
+      const timestamp = resolveTimestamps(timestampOverrides);
       await db.insert(personas).values({
         id,
         name,
@@ -107,8 +127,8 @@ export function createCharactersStorage(db: DB) {
         personaStats: extra?.personaStats ?? "",
         altDescriptions: extra?.altDescriptions ?? "[]",
         tags: extra?.tags ?? "[]",
-        createdAt: timestamp,
-        updatedAt: timestamp,
+        createdAt: timestamp.createdAt,
+        updatedAt: timestamp.updatedAt,
       });
       return this.getPersona(id);
     },

--- a/packages/server/src/services/storage/chats.storage.ts
+++ b/packages/server/src/services/storage/chats.storage.ts
@@ -17,8 +17,18 @@ import { existsSync, rmSync } from "fs";
 import { join } from "path";
 import { DATA_DIR } from "../../utils/data-dir.js";
 import type { CreateChatInput, CreateMessageInput } from "@marinara-engine/shared";
+import { latestTrustedTimestamp, normalizeTimestampOverrides, type TimestampOverrides } from "../import/import-timestamps.js";
 
 const GALLERY_DIR = join(DATA_DIR, "gallery");
+
+function resolveTimestamps(overrides?: TimestampOverrides | null) {
+  const normalized = normalizeTimestampOverrides(overrides);
+  const createdAt = normalized?.createdAt ?? now();
+  return {
+    createdAt,
+    updatedAt: normalized?.updatedAt ?? createdAt,
+  };
+}
 
 export function createChatsStorage(db: DB) {
   return {
@@ -31,9 +41,9 @@ export function createChatsStorage(db: DB) {
       return rows[0] ?? null;
     },
 
-    async create(input: CreateChatInput) {
+    async create(input: CreateChatInput, timestampOverrides?: TimestampOverrides | null) {
       const id = newId();
-      const timestamp = now();
+      const timestamp = resolveTimestamps(timestampOverrides);
       await db.insert(chats).values({
         id,
         name: input.name,
@@ -51,8 +61,8 @@ export function createChatsStorage(db: DB) {
           activeAgentIds: [],
           activeToolIds: [],
         }),
-        createdAt: timestamp,
-        updatedAt: timestamp,
+        createdAt: timestamp.createdAt,
+        updatedAt: timestamp.updatedAt,
       });
       return this.getById(id);
     },
@@ -167,9 +177,9 @@ export function createChatsStorage(db: DB) {
       return rows[0] ?? null;
     },
 
-    async createMessage(input: CreateMessageInput) {
+    async createMessage(input: CreateMessageInput, timestampOverrides?: TimestampOverrides | null) {
       const id = newId();
-      const timestamp = now();
+      const timestamp = resolveTimestamps(timestampOverrides).createdAt;
       await db.insert(messages).values({
         id,
         chatId: input.chatId,
@@ -205,16 +215,28 @@ export function createChatsStorage(db: DB) {
      * Does NOT return the created messages or update chat.updatedAt per message —
      * caller should update chat.updatedAt once after the batch.
      */
-    async createMessagesBatch(chatId: string, inputs: Omit<CreateMessageInput, "chatId">[]) {
+    async createMessagesBatch(
+      chatId: string,
+      inputs: Array<Omit<CreateMessageInput, "chatId"> & { createdAt?: string | null }>,
+      timestampOverrides?: TimestampOverrides | null,
+    ) {
       if (inputs.length === 0) return;
       const msgRows: (typeof messages.$inferInsert)[] = [];
       const swipeRows: (typeof messageSwipes.$inferInsert)[] = [];
-      const baseTime = Date.now();
+      const batchTimestamps = resolveTimestamps(timestampOverrides);
+      const baseTime = Date.parse(batchTimestamps.createdAt);
+      const safeBaseTime = Number.isNaN(baseTime) ? Date.now() : baseTime;
+      const createdTimestamps: string[] = [];
 
       for (let idx = 0; idx < inputs.length; idx++) {
         const input = inputs[idx]!;
         const id = newId();
-        const timestamp = new Date(baseTime + idx).toISOString();
+        const explicitTimestamp = normalizeTimestampOverrides({
+          createdAt: input.createdAt,
+          updatedAt: input.createdAt,
+        })?.createdAt;
+        const timestamp = explicitTimestamp ?? new Date(safeBaseTime + idx).toISOString();
+        createdTimestamps.push(timestamp);
         msgRows.push({
           id,
           chatId,
@@ -240,7 +262,7 @@ export function createChatsStorage(db: DB) {
         });
       }
 
-      const lastTimestamp = new Date(baseTime + inputs.length - 1).toISOString();
+      const lastTimestamp = latestTrustedTimestamp(createdTimestamps) ?? batchTimestamps.updatedAt;
 
       // Batch in chunks of 500 to stay within SQLite variable limits
       const CHUNK = 500;

--- a/packages/server/src/services/storage/lorebooks.storage.ts
+++ b/packages/server/src/services/storage/lorebooks.storage.ts
@@ -11,6 +11,16 @@ import type {
   CreateLorebookEntryInput,
   UpdateLorebookEntryInput,
 } from "@marinara-engine/shared";
+import { normalizeTimestampOverrides, type TimestampOverrides } from "../import/import-timestamps.js";
+
+function resolveTimestamps(overrides?: TimestampOverrides | null) {
+  const normalized = normalizeTimestampOverrides(overrides);
+  const createdAt = normalized?.createdAt ?? now();
+  return {
+    createdAt,
+    updatedAt: normalized?.updatedAt ?? createdAt,
+  };
+}
 
 /** Parse DB row booleans ("true"/"false") → real booleans and JSON strings → objects. */
 function parseLorebookRow(row: Record<string, unknown>) {
@@ -90,9 +100,9 @@ export function createLorebooksStorage(db: DB) {
       return row ? parseLorebookRow(row as Record<string, unknown>) : null;
     },
 
-    async create(input: CreateLorebookInput) {
+    async create(input: CreateLorebookInput, timestampOverrides?: TimestampOverrides | null) {
       const id = newId();
-      const timestamp = now();
+      const timestamp = resolveTimestamps(timestampOverrides);
       await db.insert(lorebooks).values({
         id,
         name: input.name,
@@ -108,8 +118,8 @@ export function createLorebooksStorage(db: DB) {
         tags: input.tags ? JSON.stringify(input.tags) : "[]",
         generatedBy: input.generatedBy ?? null,
         sourceAgentId: input.sourceAgentId ?? null,
-        createdAt: timestamp,
-        updatedAt: timestamp,
+        createdAt: timestamp.createdAt,
+        updatedAt: timestamp.updatedAt,
       });
       return this.getById(id);
     },

--- a/packages/server/src/services/storage/prompts.storage.ts
+++ b/packages/server/src/services/storage/prompts.storage.ts
@@ -16,6 +16,16 @@ import type {
   UpdateChoiceBlockInput,
 } from "@marinara-engine/shared";
 import { DEFAULT_GENERATION_PARAMS } from "@marinara-engine/shared";
+import { normalizeTimestampOverrides, type TimestampOverrides } from "../import/import-timestamps.js";
+
+function resolveTimestamps(overrides?: TimestampOverrides | null) {
+  const normalized = normalizeTimestampOverrides(overrides);
+  const createdAt = normalized?.createdAt ?? now();
+  return {
+    createdAt,
+    updatedAt: normalized?.updatedAt ?? createdAt,
+  };
+}
 
 export function createPromptsStorage(db: DB) {
   return {
@@ -37,9 +47,9 @@ export function createPromptsStorage(db: DB) {
       return rows[0] ?? null;
     },
 
-    async create(input: CreatePromptPresetInput) {
+    async create(input: CreatePromptPresetInput, timestampOverrides?: TimestampOverrides | null) {
       const id = newId();
-      const timestamp = now();
+      const timestamp = resolveTimestamps(timestampOverrides);
       await db.insert(promptPresets).values({
         id,
         name: input.name,
@@ -52,8 +62,8 @@ export function createPromptsStorage(db: DB) {
         wrapFormat: input.wrapFormat ?? "xml",
         isDefault: String(input.isDefault ?? false),
         author: input.author ?? "",
-        createdAt: timestamp,
-        updatedAt: timestamp,
+        createdAt: timestamp.createdAt,
+        updatedAt: timestamp.updatedAt,
       });
       return this.getById(id);
     },


### PR DESCRIPTION
## Summary
This PR combines the simpler, lower-risk safety and UX fixes into one reviewable slice.

### What this fixes
- gates first-run chat creation behind a connection picker so cancelled setup no longer creates orphan chats
- adds scoped expunge with Mari protection and immediate cache/runtime reset after destructive clears
- introduces `Auto` reasoning effort/verbosity handling as null/omitted values instead of forced explicit defaults
- adds draft-based numeric inputs so fields can be blank while editing and restore on blur if left invalid
- adds agent grouping by active/inactive and desktop-resizable left/right sidebars with persisted widths
- fixes preset header alignment and related low-risk UI polish
- adds shift-click range selection for multi-message deletion

### Why this is being submitted
- these changes are tightly related safety and UX hardening with minimal data-model risk
- they remove blocked flows and destructive surprises first, then bundle the simplest interface improvements behind the same verified client/server plumbing
- shipping them together keeps the first PR high-value while still easy to review and validate in isolation

## Verification
- `pnpm -C packages/client exec tsc --noEmit`
- `pnpm -C packages/server exec tsc --noEmit`
- `pnpm -C packages/client run lint`
- `pnpm -C packages/server run lint`

Client lint still reports 5 pre-existing warnings outside this PR's touched scope in `BotBrowserView.tsx`, `ChatSetupWizard.tsx`, and `QuickPersonaSwitcher.tsx`.
