### PR TITLE
feat: persist user settings server-side across devices

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -10,6 +10,7 @@ import { Toaster } from "sonner";
 import { useUIStore } from "./stores/ui.store";
 import { api } from "./lib/api-client";
 import { useLegacyThemeMigration } from "./hooks/use-themes";
+import { useSettingsSync } from "./hooks/use-settings-sync";
 
 const VERSION_RECOVERY_KEY = "marinara:pwa-version-recovery";
 const VERSION_CHECK_INTERVAL_MS = 5 * 60_000;
@@ -52,6 +53,7 @@ export function App() {
   const fontFamily = useUIStore((s) => s.fontFamily);
   const hasModalOpen = useUIStore((s) => s.modal !== null);
   useLegacyThemeMigration();
+  useSettingsSync();
 
   // Apply theme + font size to the document root whenever they change
   useEffect(() => {

--- a/packages/client/src/hooks/use-settings-sync.ts
+++ b/packages/client/src/hooks/use-settings-sync.ts
@@ -1,0 +1,115 @@
+// ──────────────────────────────────────────────
+// Hook: Cross-device UI settings sync
+// ──────────────────────────────────────────────
+// On mount: fetches the server's saved settings blob and overlays it onto the
+// UI store so every browser/device sees the same preferences. If the server
+// has no blob yet, the current local state is pushed as the initial seed
+// (one-time migration for users upgrading from browser-only storage).
+//
+// While the app runs: subscribes to UI store changes, debounces serialization,
+// and pushes the synced subset to the server. Only user-facing preference
+// edits trigger a push — transient UI state (modal open, detail panels, etc.)
+// is filtered out via `pickSyncedSettings`.
+import { useEffect } from "react";
+import { api } from "../lib/api-client";
+import { pickSyncedSettings, useUIStore } from "../stores/ui.store";
+
+type SettingsResponse = { value: string | null };
+
+const SETTINGS_KEY = "ui";
+const SETTINGS_PATH = `/app-settings/${SETTINGS_KEY}`;
+const DEBOUNCE_MS = 1000;
+
+export function useSettingsSync() {
+  useEffect(() => {
+    let disposed = false;
+    let ready = false;
+    let pushTimer: ReturnType<typeof setTimeout> | null = null;
+    let lastPushed = "";
+
+    const serialize = () => JSON.stringify(pickSyncedSettings(useUIStore.getState()));
+
+    const pushNow = () => {
+      pushTimer = null;
+      if (disposed) return;
+      const payload = serialize();
+      if (payload === lastPushed) return;
+      lastPushed = payload;
+      api.put(SETTINGS_PATH, { value: payload }).catch(() => {
+        // Server unreachable — next change will retry. We keep `lastPushed`
+        // as the failed payload so we only re-send when the user actually
+        // changes something again.
+      });
+    };
+
+    const schedulePush = () => {
+      if (pushTimer) clearTimeout(pushTimer);
+      pushTimer = setTimeout(pushNow, DEBOUNCE_MS);
+    };
+
+    const flushNow = () => {
+      if (pushTimer) {
+        clearTimeout(pushTimer);
+        pushTimer = null;
+        pushNow();
+      }
+    };
+
+    const unsubscribe = useUIStore.subscribe((state, prev) => {
+      if (!ready || disposed) return;
+      const current = JSON.stringify(pickSyncedSettings(state));
+      const previous = JSON.stringify(pickSyncedSettings(prev));
+      if (current !== previous) schedulePush();
+    });
+
+    // Flush any pending edits before the tab closes so they reach the server.
+    const handleBeforeUnload = () => flushNow();
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "hidden") flushNow();
+    };
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    void (async () => {
+      try {
+        const data = await api.get<SettingsResponse>(SETTINGS_PATH);
+        if (disposed) return;
+        if (data.value) {
+          try {
+            const parsed = JSON.parse(data.value);
+            if (parsed && typeof parsed === "object") {
+              useUIStore.setState(parsed);
+              lastPushed = JSON.stringify(pickSyncedSettings(useUIStore.getState()));
+            }
+          } catch {
+            // Corrupt blob on the server — ignore and let the next edit overwrite it.
+            lastPushed = serialize();
+          }
+        } else {
+          // Server has no settings yet — seed it with whatever is in the local
+          // store (either defaults or previously-localStorage-persisted values).
+          const payload = serialize();
+          lastPushed = payload;
+          try {
+            await api.put(SETTINGS_PATH, { value: payload });
+          } catch {
+            // Seed failed; leave `lastPushed` set so the next change triggers a retry.
+          }
+        }
+      } catch {
+        // Server unreachable at startup — run with local state only.
+        lastPushed = serialize();
+      } finally {
+        if (!disposed) ready = true;
+      }
+    })();
+
+    return () => {
+      disposed = true;
+      unsubscribe();
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      flushNow();
+    };
+  }, []);
+}

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -250,6 +250,57 @@ interface UIState {
   setUserStatusManual: (status: UserStatus) => void;
 }
 
+/**
+ * Returns the subset of UI state that is synced to the server so it persists
+ * across devices and browsers. Excludes legacy migration flags, auto-computed
+ * fields (userStatus), and items tracked via their own server resources
+ * (custom themes, extensions).
+ */
+export function pickSyncedSettings(state: UIState) {
+  return {
+    sidebarOpen: state.sidebarOpen,
+    sidebarWidth: state.sidebarWidth,
+    theme: state.theme,
+    chatBackground: state.chatBackground,
+    fontSize: state.fontSize,
+    chatFontSize: state.chatFontSize,
+    fontFamily: state.fontFamily,
+    enableStreaming: state.enableStreaming,
+    streamingSpeed: state.streamingSpeed,
+    debugMode: state.debugMode,
+    messageGrouping: state.messageGrouping,
+    showTimestamps: state.showTimestamps,
+    showModelName: state.showModelName,
+    showTokenUsage: state.showTokenUsage,
+    showMessageNumbers: state.showMessageNumbers,
+    confirmBeforeDelete: state.confirmBeforeDelete,
+    messagesPerPage: state.messagesPerPage,
+    boldDialogue: state.boldDialogue,
+    narrationFontColor: state.narrationFontColor,
+    narrationOpacity: state.narrationOpacity,
+    chatFontColor: state.chatFontColor,
+    chatFontOpacity: state.chatFontOpacity,
+    textStrokeWidth: state.textStrokeWidth,
+    textStrokeColor: state.textStrokeColor,
+    visualTheme: state.visualTheme,
+    convoGradientFrom: state.convoGradientFrom,
+    convoGradientTo: state.convoGradientTo,
+    enterToSendRP: state.enterToSendRP,
+    enterToSendConvo: state.enterToSendConvo,
+    weatherEffects: state.weatherEffects,
+    hudPosition: state.hudPosition,
+    hasCompletedOnboarding: state.hasCompletedOnboarding,
+    linkApiBannerDismissed: state.linkApiBannerDismissed,
+    echoChamberSide: state.echoChamberSide,
+    userStatusManual: state.userStatusManual,
+    convoNotificationSound: state.convoNotificationSound,
+    rpNotificationSound: state.rpNotificationSound,
+    customConversationPrompt: state.customConversationPrompt,
+  };
+}
+
+export type SyncedSettings = ReturnType<typeof pickSyncedSettings>;
+
 export const useUIStore = create<UIState>()(
   persist(
     (set, get) => ({

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -342,6 +342,11 @@ const CREATE_TABLES: string[] = [
     updated_at TEXT NOT NULL,
     is_active TEXT NOT NULL DEFAULT 'false'
   )`,
+  `CREATE TABLE IF NOT EXISTS app_settings (
+    key TEXT PRIMARY KEY NOT NULL,
+    value TEXT NOT NULL DEFAULT '',
+    updated_at TEXT NOT NULL
+  )`,
 ];
 
 // ── Column migrations (ALTER TABLE for schema evolution) ──

--- a/packages/server/src/db/schema/app-settings.ts
+++ b/packages/server/src/db/schema/app-settings.ts
@@ -1,0 +1,10 @@
+// ──────────────────────────────────────────────
+// Schema: Synced App Settings (key/value)
+// ──────────────────────────────────────────────
+import { sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+export const appSettings = sqliteTable("app_settings", {
+  key: text("key").primaryKey(),
+  value: text("value").notNull().default(""),
+  updatedAt: text("updated_at").notNull(),
+});

--- a/packages/server/src/db/schema/index.ts
+++ b/packages/server/src/db/schema/index.ts
@@ -13,3 +13,4 @@ export * from "./game-state.js";
 export * from "./regex-scripts.js";
 export * from "./gallery.js";
 export * from "./themes.js";
+export * from "./app-settings.js";

--- a/packages/server/src/routes/app-settings.routes.ts
+++ b/packages/server/src/routes/app-settings.routes.ts
@@ -1,0 +1,29 @@
+// ──────────────────────────────────────────────
+// Routes: Synced App Settings (key/value)
+// ──────────────────────────────────────────────
+import type { FastifyInstance } from "fastify";
+import { appSettingsUpdateSchema } from "@marinara-engine/shared";
+import { createAppSettingsStorage } from "../services/storage/app-settings.storage.js";
+
+const ALLOWED_KEYS = new Set(["ui"]);
+
+export async function appSettingsRoutes(app: FastifyInstance) {
+  const storage = createAppSettingsStorage(app.db);
+
+  app.get<{ Params: { key: string } }>("/:key", async (req, reply) => {
+    if (!ALLOWED_KEYS.has(req.params.key)) {
+      return reply.status(404).send({ error: "Unknown settings key" });
+    }
+    const value = await storage.get(req.params.key);
+    return { value };
+  });
+
+  app.put<{ Params: { key: string } }>("/:key", async (req, reply) => {
+    if (!ALLOWED_KEYS.has(req.params.key)) {
+      return reply.status(404).send({ error: "Unknown settings key" });
+    }
+    const input = appSettingsUpdateSchema.parse(req.body);
+    await storage.set(req.params.key, input.value);
+    return { value: input.value };
+  });
+}

--- a/packages/server/src/routes/index.ts
+++ b/packages/server/src/routes/index.ts
@@ -39,6 +39,7 @@ import { botBrowserWyvernRoutes } from "./bot-browser-wyvern.routes.js";
 import { chatFoldersRoutes } from "./chat-folders.routes.js";
 import { updatesRoutes } from "./updates.routes.js";
 import { themesRoutes } from "./themes.routes.js";
+import { appSettingsRoutes } from "./app-settings.routes.js";
 
 export async function registerRoutes(app: FastifyInstance) {
   await app.register(chatsRoutes, { prefix: "/api/chats" });
@@ -78,4 +79,5 @@ export async function registerRoutes(app: FastifyInstance) {
   await app.register(botBrowserWyvernRoutes, { prefix: "/api/bot-browser" });
   await app.register(updatesRoutes, { prefix: "/api/updates" });
   await app.register(themesRoutes, { prefix: "/api/themes" });
+  await app.register(appSettingsRoutes, { prefix: "/api/app-settings" });
 }

--- a/packages/server/src/services/storage/app-settings.storage.ts
+++ b/packages/server/src/services/storage/app-settings.storage.ts
@@ -1,0 +1,30 @@
+// ──────────────────────────────────────────────
+// Storage: Synced App Settings (key/value)
+// ──────────────────────────────────────────────
+import { eq } from "drizzle-orm";
+import type { DB } from "../../db/connection.js";
+import { appSettings } from "../../db/schema/index.js";
+import { now } from "../../utils/id-generator.js";
+
+export function createAppSettingsStorage(db: DB) {
+  return {
+    async get(key: string): Promise<string | null> {
+      const rows = await db.select().from(appSettings).where(eq(appSettings.key, key));
+      return rows[0]?.value ?? null;
+    },
+
+    async set(key: string, value: string): Promise<void> {
+      const timestamp = now();
+      const existing = await db.select().from(appSettings).where(eq(appSettings.key, key));
+      if (existing.length > 0) {
+        await db.update(appSettings).set({ value, updatedAt: timestamp }).where(eq(appSettings.key, key));
+      } else {
+        await db.insert(appSettings).values({ key, value, updatedAt: timestamp });
+      }
+    },
+
+    async remove(key: string): Promise<void> {
+      await db.delete(appSettings).where(eq(appSettings.key, key));
+    },
+  };
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -29,6 +29,7 @@ export * from "./schemas/agent.schema.js";
 export * from "./schemas/custom-tool.schema.js";
 export * from "./schemas/regex.schema.js";
 export * from "./schemas/theme.schema.js";
+export * from "./schemas/app-settings.schema.js";
 
 // Constants
 export * from "./constants/providers.js";

--- a/packages/shared/src/schemas/app-settings.schema.ts
+++ b/packages/shared/src/schemas/app-settings.schema.ts
@@ -1,0 +1,17 @@
+// ──────────────────────────────────────────────
+// App Settings Zod Schemas
+// ──────────────────────────────────────────────
+import { z } from "zod";
+
+/** Payload for PUT /api/app-settings/:key — the opaque serialized settings blob. */
+export const appSettingsUpdateSchema = z.object({
+  value: z.string().max(1_000_000),
+});
+
+/** Response shape for GET /api/app-settings/:key. */
+export const appSettingsResponseSchema = z.object({
+  value: z.string().nullable(),
+});
+
+export type AppSettingsUpdateInput = z.infer<typeof appSettingsUpdateSchema>;
+export type AppSettingsResponse = z.infer<typeof appSettingsResponseSchema>;


### PR DESCRIPTION
## Summary

User settings were previously stored only in browser `localStorage`, so every browser and device saw its own independent preferences. This PR moves them to a server-backed key/value table so they follow the user across browsers and devices until explicitly edited.

- New `app_settings (key, value, updated_at)` table with a single `ui` row holding the serialized preference blob
- `GET/PUT /api/app-settings/:key` (allowlisted to `ui`)
- New client hook `useSettingsSync()` (wired in `App.tsx`) that on mount fetches the server blob and overlays it onto the Zustand UI store, then debounces (1s) and pushes any subsequent changes back to the server
- `localStorage` is kept as a fast-boot cache — the server is authoritative on mount
- One-time seed: existing users' `localStorage` settings are pushed to the server the first time the app loads after this change

## What's now persistent across devices/browsers

Defined in `pickSyncedSettings` in `packages/client/src/stores/ui.store.ts`:

**General tab**
- Enable streaming responses, Streaming speed
- Send on Enter (Roleplay), Send on Enter (Conversations)
- Confirm before deleting
- Messages per page
- Bold dialogue in quotes

**Appearance tab**
- Font size, chat font size, font family
- Visual theme (default / sillytavern)
- Chat background
- Narration color + opacity
- Chat font color + opacity
- Text stroke width + color
- Conversation gradient (from/to)
- Weather effects
- HUD position
- Conversation notification sound, RP notification sound

**Advanced tab**
- Debug mode
- Group consecutive messages
- Show message timestamps / model name / token usage / message numbers

**Other preferences**
- Theme (dark / light)
- Custom conversation prompt (system prompt override)
- Sidebar open state + width
- EchoChamber side
- User status (manual)
- "Has completed onboarding" flag
- "Link API banner dismissed" flag

## Explicitly NOT synced (stays device-local)

- **Custom themes** — already server-synced via the existing `custom_themes` table
- **Installed extensions** — different devices may legitimately want different ones
- **`userStatus`** (auto-idle) — computed from inactivity per-device
- **Transient UI state** — open modals, detail panels, which settings tab is open, etc.
- **`hasMigratedCustomThemesToServer`** — per-device migration flag

## Known tradeoffs

- **Last-write-wins**: two tabs/devices editing near-simultaneously → the later PUT overwrites the earlier one. No real-time cross-tab sync.
- **Offline edit + reload**: if the server is unreachable when a setting is changed and the user reloads before it recovers, the stale server value overlays the local edit.
- **Default-flash**: on a brand-new device, defaults render for ~100–300 ms before the server response overlays the real settings.
- **Dual list**: new settings must be added to both `partialize` (localStorage) and `pickSyncedSettings` (server) or they won't sync.

