### PR TITLE
fix: lock lorebook entries and normalize invalid top-p

### DIFF
--- a/packages/client/src/components/lorebooks/LorebookEditor.tsx
+++ b/packages/client/src/components/lorebooks/LorebookEditor.tsx
@@ -446,6 +446,12 @@ export function LorebookEditor() {
                 onChange={(v) => setEntryForm((f) => (f ? { ...f, caseSensitive: v } : f))}
               />
               <ToggleButton
+                label="Locked"
+                value={entryForm.locked ?? false}
+                onChange={(v) => setEntryForm((f) => (f ? { ...f, locked: v } : f))}
+                tooltip="Prevents the Lorebook Keeper agent from modifying this entry."
+              />
+              <ToggleButton
                 label="No Recursion"
                 value={entryForm.preventRecursion ?? false}
                 onChange={(v) => setEntryForm((f) => (f ? { ...f, preventRecursion: v } : f))}

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -123,6 +123,12 @@ function formatAgentInjections(injections: AgentInjection[], wrapFormat: string)
   return parts.join("\n\n");
 }
 
+function normalizeChatTopP(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  if (value <= 0) return 1;
+  return Math.min(value, 1);
+}
+
 export async function generateRoutes(app: FastifyInstance) {
   const chats = createChatsStorage(app.db);
   const connections = createConnectionsStorage(app.db);
@@ -1675,7 +1681,7 @@ export async function generateRoutes(app: FastifyInstance) {
       if (chatParams) {
         if (typeof chatParams.temperature === "number") temperature = chatParams.temperature;
         if (typeof chatParams.maxTokens === "number") maxTokens = chatParams.maxTokens;
-        if (typeof chatParams.topP === "number") topP = chatParams.topP;
+        topP = normalizeChatTopP(chatParams.topP) ?? topP;
         if (typeof chatParams.topK === "number") topK = chatParams.topK;
         if (typeof chatParams.frequencyPenalty === "number") frequencyPenalty = chatParams.frequencyPenalty;
         if (typeof chatParams.presencePenalty === "number") presencePenalty = chatParams.presencePenalty;

--- a/packages/server/src/services/import/st-prompt.importer.ts
+++ b/packages/server/src/services/import/st-prompt.importer.ts
@@ -21,6 +21,10 @@ const MARKER_DISPLAY_NAMES: Partial<Record<string, string>> = {
 function clamp(v: number, min: number, max: number) {
   return Math.min(max, Math.max(min, v));
 }
+function normalizeTopP(v: number | null | undefined) {
+  const clamped = clamp(v ?? 1, 0, 1);
+  return clamped <= 0 ? 1 : clamped;
+}
 function toReasoningEffort(v: unknown): "low" | "medium" | "high" | "maximum" | null {
   if (typeof v === "string" && VALID_REASONING.has(v)) return v as "low" | "medium" | "high" | "maximum";
   return null;
@@ -79,7 +83,7 @@ export async function importSTPreset(raw: Record<string, unknown>, db: DB, fileN
     variableValues: {},
     parameters: {
       temperature: clamp(preset.temperature ?? 1, 0, 2),
-      topP: clamp(preset.top_p ?? 1, 0, 1),
+      topP: normalizeTopP(preset.top_p),
       topK: Math.max(0, Math.round(preset.top_k ?? 0)),
       minP: clamp(preset.min_p ?? 0, 0, 1),
       maxTokens: Math.max(1, Math.round(preset.openai_max_tokens ?? 4096)),

--- a/packages/server/src/services/llm/providers/openai.provider.ts
+++ b/packages/server/src/services/llm/providers/openai.provider.ts
@@ -25,6 +25,12 @@ const RESPONSES_ONLY_SUFFIXES = ["-codex", "-codex-max", "-codex-mini"];
  * Handles OpenAI, OpenRouter, Mistral, Cohere, and any OpenAI-compatible endpoint.
  */
 export class OpenAIProvider extends BaseLLMProvider {
+  private static normalizeTopP(topP: number | null | undefined): number | undefined {
+    if (topP == null || !Number.isFinite(topP)) return undefined;
+    if (topP <= 0) return 1;
+    return Math.min(topP, 1);
+  }
+
   /**
    * Extract text and thinking from an OpenRouter/Anthropic-style content block array.
    * OpenRouter may return `content` as an array of typed blocks instead of a plain string:
@@ -182,7 +188,8 @@ export class OpenAIProvider extends BaseLLMProvider {
     // o-series models never support temperature/topP; GPT-5.x only with effort=none
     if (!this.isNoTemperatureModel(options.model, options.reasoningEffort)) {
       body.temperature = options.temperature ?? 1;
-      if (options.topP != null) body.top_p = options.topP;
+      const topP = OpenAIProvider.normalizeTopP(options.topP);
+      if (topP != null) body.top_p = topP;
       if (options.frequencyPenalty) body.frequency_penalty = options.frequencyPenalty;
       if (options.presencePenalty) body.presence_penalty = options.presencePenalty;
     }
@@ -363,7 +370,8 @@ export class OpenAIProvider extends BaseLLMProvider {
     // o-series models never support temperature/topP; GPT-5.x only with effort=none
     if (!this.isNoTemperatureModel(options.model, options.reasoningEffort)) {
       body.temperature = options.temperature ?? 1;
-      if (options.topP != null) body.top_p = options.topP;
+      const topP = OpenAIProvider.normalizeTopP(options.topP);
+      if (topP != null) body.top_p = topP;
       if (options.frequencyPenalty) body.frequency_penalty = options.frequencyPenalty;
       if (options.presencePenalty) body.presence_penalty = options.presencePenalty;
     }
@@ -719,7 +727,8 @@ export class OpenAIProvider extends BaseLLMProvider {
     // o-series models never support temperature/topP; GPT-5.x only with effort=none
     if (!this.isNoTemperatureModel(options.model, options.reasoningEffort)) {
       if (options.temperature != null) body.temperature = options.temperature;
-      if (options.topP != null) body.top_p = options.topP;
+      const topP = OpenAIProvider.normalizeTopP(options.topP);
+      if (topP != null) body.top_p = topP;
       if (options.frequencyPenalty) body.frequency_penalty = options.frequencyPenalty;
       if (options.presencePenalty) body.presence_penalty = options.presencePenalty;
     }

--- a/packages/shared/src/schemas/prompt.schema.ts
+++ b/packages/shared/src/schemas/prompt.schema.ts
@@ -36,7 +36,7 @@ export const markerConfigSchema = z.object({
 
 export const generationParametersSchema = z.object({
   temperature: z.number().min(0).max(2).default(1),
-  topP: z.number().min(0).max(1).default(1),
+  topP: z.number().gt(0).max(1).default(1),
   topK: z.number().int().min(0).default(0),
   minP: z.number().min(0).max(1).default(0),
   maxTokens: z.number().int().min(1).default(4096),


### PR DESCRIPTION
## Summary
- add a visible lorebook entry lock toggle so users can protect entries from Lorebook Keeper edits
- normalize invalid top_p values