### PR TITLE
feat(chat): Select-below by default on Delete more with range helpers

### DIFF
--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -441,11 +441,18 @@ export function ChatArea() {
 
   const handleDeleteMore = useCallback(() => {
     if (deleteDialogMessageId) {
-      setSelectedMessageIds(new Set([deleteDialogMessageId]));
+      const startIdx = messages?.findIndex((m) => m.id === deleteDialogMessageId) ?? -1;
+      if (messages && startIdx >= 0) {
+        const ids = new Set<string>();
+        for (let i = startIdx; i < messages.length; i++) ids.add(messages[i]!.id);
+        setSelectedMessageIds(ids);
+      } else {
+        setSelectedMessageIds(new Set([deleteDialogMessageId]));
+      }
     }
     setDeleteDialogMessageId(null);
     setMultiSelectMode(true);
-  }, [deleteDialogMessageId]);
+  }, [deleteDialogMessageId, messages]);
 
   const handleToggleSelectMessage = useCallback((messageId: string) => {
     setSelectedMessageIds((prev) => {
@@ -468,6 +475,40 @@ export function ChatArea() {
     setMultiSelectMode(false);
     setSelectedMessageIds(new Set());
   }, []);
+
+  const handleUnselectAllMessages = useCallback(() => {
+    setSelectedMessageIds(new Set());
+  }, []);
+
+  const handleSelectAllAboveSelection = useCallback(() => {
+    if (!messages || messages.length === 0) return;
+    setSelectedMessageIds((prev) => {
+      if (prev.size === 0) return prev;
+      let firstIdx = -1;
+      for (let i = 0; i < messages.length; i++) {
+        if (prev.has(messages[i]!.id)) { firstIdx = i; break; }
+      }
+      if (firstIdx <= 0) return prev;
+      const next = new Set(prev);
+      for (let i = 0; i < firstIdx; i++) next.add(messages[i]!.id);
+      return next;
+    });
+  }, [messages]);
+
+  const handleSelectAllBelowSelection = useCallback(() => {
+    if (!messages || messages.length === 0) return;
+    setSelectedMessageIds((prev) => {
+      if (prev.size === 0) return prev;
+      let lastIdx = -1;
+      for (let i = messages.length - 1; i >= 0; i--) {
+        if (prev.has(messages[i]!.id)) { lastIdx = i; break; }
+      }
+      if (lastIdx < 0 || lastIdx >= messages.length - 1) return prev;
+      const next = new Set(prev);
+      for (let i = lastIdx + 1; i < messages.length; i++) next.add(messages[i]!.id);
+      return next;
+    });
+  }, [messages]);
 
   const handleRegenerate = useCallback(
     async (messageId: string) => {
@@ -926,6 +967,9 @@ export function ChatArea() {
           onCloseDeleteDialog={() => setDeleteDialogMessageId(null)}
           onBulkDelete={handleBulkDelete}
           onCancelMultiSelect={handleCancelMultiSelect}
+          onUnselectAllMessages={handleUnselectAllMessages}
+          onSelectAllAboveSelection={handleSelectAllAboveSelection}
+          onSelectAllBelowSelection={handleSelectAllBelowSelection}
           lastAssistantMessageId={lastAssistantMessageId}
         />
       </Suspense>
@@ -1022,6 +1066,9 @@ export function ChatArea() {
         onCloseDeleteDialog={() => setDeleteDialogMessageId(null)}
         onBulkDelete={handleBulkDelete}
         onCancelMultiSelect={handleCancelMultiSelect}
+        onUnselectAllMessages={handleUnselectAllMessages}
+        onSelectAllAboveSelection={handleSelectAllAboveSelection}
+        onSelectAllBelowSelection={handleSelectAllBelowSelection}
         isGrouped={isGrouped}
       />
     </Suspense>

--- a/packages/client/src/components/chat/ChatCommonOverlays.tsx
+++ b/packages/client/src/components/chat/ChatCommonOverlays.tsx
@@ -1,6 +1,6 @@
 import { Suspense, lazy, type ComponentProps } from "react";
 import type { SpriteSide } from "@marinara-engine/shared";
-import { Trash2 } from "lucide-react";
+import { ChevronUp, ChevronDown, Trash2 } from "lucide-react";
 import { PinnedImageOverlay } from "./PinnedImageOverlay";
 import type { PeekPromptData } from "./chat-area.types";
 
@@ -85,28 +85,68 @@ type MultiSelectBarProps = {
   selectedCount: number;
   onDelete: () => void;
   onCancel: () => void;
+  onUnselectAll: () => void;
+  onSelectAllAbove: () => void;
+  onSelectAllBelow: () => void;
 };
 
-function MultiSelectBar({ open, selectedCount, onDelete, onCancel }: MultiSelectBarProps) {
+function MultiSelectBar({
+  open,
+  selectedCount,
+  onDelete,
+  onCancel,
+  onUnselectAll,
+  onSelectAllAbove,
+  onSelectAllBelow,
+}: MultiSelectBarProps) {
   if (!open) return null;
 
   return (
-    <div className="fixed bottom-6 left-1/2 z-50 flex -translate-x-1/2 items-center gap-3 rounded-xl bg-[var(--card)] px-5 py-3 shadow-2xl ring-1 ring-[var(--border)]">
-      <span className="text-xs font-medium text-[var(--muted-foreground)]">{selectedCount} selected</span>
-      <button
-        onClick={onDelete}
-        disabled={selectedCount === 0}
-        className="flex items-center gap-1.5 rounded-lg bg-[var(--destructive)] px-4 py-2 text-xs font-medium text-white transition-colors hover:bg-[var(--destructive)]/80 disabled:opacity-40"
-      >
-        <Trash2 size="0.75rem" />
-        Delete selected
-      </button>
-      <button
-        onClick={onCancel}
-        className="rounded-lg px-4 py-2 text-xs font-medium text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)]"
-      >
-        Cancel
-      </button>
+    <div className="fixed bottom-6 left-1/2 z-50 flex -translate-x-1/2 flex-col items-stretch gap-2 rounded-xl bg-[var(--card)] px-5 py-3 shadow-2xl ring-1 ring-[var(--border)]">
+      <div className="flex items-center gap-3">
+        <span className="text-xs font-medium text-[var(--muted-foreground)]">{selectedCount} selected</span>
+        <button
+          onClick={onDelete}
+          disabled={selectedCount === 0}
+          className="flex items-center gap-1.5 rounded-lg bg-[var(--destructive)] px-4 py-2 text-xs font-medium text-white transition-colors hover:bg-[var(--destructive)]/80 disabled:opacity-40"
+        >
+          <Trash2 size="0.75rem" />
+          Delete selected
+        </button>
+        <button
+          onClick={onCancel}
+          className="rounded-lg px-4 py-2 text-xs font-medium text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)]"
+        >
+          Cancel
+        </button>
+      </div>
+      <div className="flex items-center justify-center gap-2">
+        <button
+          onClick={onSelectAllAbove}
+          disabled={selectedCount === 0}
+          title="Select all messages above"
+          aria-label="Select all messages above"
+          className="flex h-7 w-7 items-center justify-center rounded-md text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] disabled:opacity-40"
+        >
+          <ChevronUp size="0.85rem" />
+        </button>
+        <button
+          onClick={onUnselectAll}
+          disabled={selectedCount === 0}
+          className="rounded-lg px-3 py-1 text-[11px] font-medium text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] disabled:opacity-40"
+        >
+          Unselect all
+        </button>
+        <button
+          onClick={onSelectAllBelow}
+          disabled={selectedCount === 0}
+          title="Select all messages below"
+          aria-label="Select all messages below"
+          className="flex h-7 w-7 items-center justify-center rounded-md text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] disabled:opacity-40"
+        >
+          <ChevronDown size="0.85rem" />
+        </button>
+      </div>
     </div>
   );
 }
@@ -133,6 +173,9 @@ type ChatCommonOverlaysProps = {
   onCloseDeleteDialog: () => void;
   onBulkDelete: () => void;
   onCancelMultiSelect: () => void;
+  onUnselectAllMessages: () => void;
+  onSelectAllAboveSelection: () => void;
+  onSelectAllBelowSelection: () => void;
 };
 
 export function ChatCommonOverlays({
@@ -157,6 +200,9 @@ export function ChatCommonOverlays({
   onCloseDeleteDialog,
   onBulkDelete,
   onCancelMultiSelect,
+  onUnselectAllMessages,
+  onSelectAllAboveSelection,
+  onSelectAllBelowSelection,
 }: ChatCommonOverlaysProps) {
   return (
     <>
@@ -203,6 +249,9 @@ export function ChatCommonOverlays({
         selectedCount={selectedMessageCount}
         onDelete={onBulkDelete}
         onCancel={onCancelMultiSelect}
+        onUnselectAll={onUnselectAllMessages}
+        onSelectAllAbove={onSelectAllAboveSelection}
+        onSelectAllBelow={onSelectAllBelowSelection}
       />
     </>
   );

--- a/packages/client/src/components/chat/ChatConversationSurface.tsx
+++ b/packages/client/src/components/chat/ChatConversationSurface.tsx
@@ -66,6 +66,9 @@ type ConversationSurfaceProps = {
   onCloseDeleteDialog: () => void;
   onBulkDelete: () => void;
   onCancelMultiSelect: () => void;
+  onUnselectAllMessages: () => void;
+  onSelectAllAboveSelection: () => void;
+  onSelectAllBelowSelection: () => void;
   lastAssistantMessageId: string | null;
 };
 
@@ -119,6 +122,9 @@ export function ChatConversationSurface({
   onCloseDeleteDialog,
   onBulkDelete,
   onCancelMultiSelect,
+  onUnselectAllMessages,
+  onSelectAllAboveSelection,
+  onSelectAllBelowSelection,
   lastAssistantMessageId,
 }: ConversationSurfaceProps) {
   return (
@@ -184,6 +190,9 @@ export function ChatConversationSurface({
         onCloseDeleteDialog={onCloseDeleteDialog}
         onBulkDelete={onBulkDelete}
         onCancelMultiSelect={onCancelMultiSelect}
+        onUnselectAllMessages={onUnselectAllMessages}
+        onSelectAllAboveSelection={onSelectAllAboveSelection}
+        onSelectAllBelowSelection={onSelectAllBelowSelection}
       />
     </div>
   );

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -610,6 +610,9 @@ type RoleplaySurfaceProps = {
   onCloseDeleteDialog: () => void;
   onBulkDelete: () => void;
   onCancelMultiSelect: () => void;
+  onUnselectAllMessages: () => void;
+  onSelectAllAboveSelection: () => void;
+  onSelectAllBelowSelection: () => void;
   isGrouped: (index: number) => boolean;
 };
 
@@ -692,6 +695,9 @@ export function ChatRoleplaySurface({
   onCloseDeleteDialog,
   onBulkDelete,
   onCancelMultiSelect,
+  onUnselectAllMessages,
+  onSelectAllAboveSelection,
+  onSelectAllBelowSelection,
   isGrouped,
 }: RoleplaySurfaceProps) {
   const linkedChatName = chat?.connectedChatId ? allChats?.find((c) => c.id === chat.connectedChatId)?.name : undefined;
@@ -1088,6 +1094,9 @@ export function ChatRoleplaySurface({
         onCloseDeleteDialog={onCloseDeleteDialog}
         onBulkDelete={onBulkDelete}
         onCancelMultiSelect={onCancelMultiSelect}
+        onUnselectAllMessages={onUnselectAllMessages}
+        onSelectAllAboveSelection={onSelectAllAboveSelection}
+        onSelectAllBelowSelection={onSelectAllBelowSelection}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- **Delete more** now selects the target message plus every message below it, so lopping off a tail is one click instead of N. Applies to both roleplay and conversation modes.
- The multi-select bar gains an **Unselect all** button (medium pill), flanked by small ChevronUp / ChevronDown icon buttons with hover tooltips that extend the current selection upward or downward to the start/end of the chat — useful when the default select-below pick is too broad or too narrow.
- All three new controls disable + dim when the selection is empty, matching the existing Delete selected styling.

## Why
Before this change, clicking **Delete more** at message 27 only highlighted 27 and forced the user to tap every subsequent message individually to prune the tail. The new default reflects the common intent (“delete from here on”) while keeping fine-grained adjustment one click away.

## Test plan
- [x] Roleplay mode: open a chat with 20+ messages, click the trash icon on message 10, choose **Delete more** — verify 10 and all messages after it are selected.
- [x] Conversation mode: same flow, same expectation.
- [x] Click **Unselect all** — verify selection clears but multi-select stays open.
- [x] With a partial selection, click the ↑ arrow — verify everything above the earliest-selected is added; click ↓ — verify everything below the latest-selected is added.
- [x] Hover both arrow buttons — verify the "Select all messages above" / "Select all messages below" tooltips appear.
- [x] Click **Delete selected** — verify the selected messages are removed.
- [x] Click **Cancel** — verify multi-select closes without deleting.