### PR TITLE
fix: Unbreak client build and server Docker build on main

### DIFF
--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -1027,6 +1027,9 @@ export function ChatArea() {
             onCloseDeleteDialog={() => setDeleteDialogMessageId(null)}
             onBulkDelete={handleBulkDelete}
             onCancelMultiSelect={handleCancelMultiSelect}
+            onUnselectAllMessages={handleUnselectAllMessages}
+            onSelectAllAboveSelection={handleSelectAllAboveSelection}
+            onSelectAllBelowSelection={handleSelectAllBelowSelection}
             lastAssistantMessageId={lastAssistantMessageId}
           />
         </Suspense>

--- a/packages/server/src/services/import/st-prompt.importer.ts
+++ b/packages/server/src/services/import/st-prompt.importer.ts
@@ -106,6 +106,7 @@ export async function importSTPreset(
         strictRoleFormatting: true,
         singleUserMessage: false,
       },
+    },
     options?.timestampOverrides,
   );
 


### PR DESCRIPTION
## Summary
Main is currently broken in two places after PR #85/#86 merged alongside PR #91. This patch restores it.

### 1. Client build (`TS2739` in `ChatArea.tsx`)
PR #91 added three new props to \`ChatConversationSurface\`. PR #85/#86's rewrite of \`ChatArea.tsx\` landed after mine, and git's auto-merge kept the new prop-passes on the **roleplay** surface but dropped them on the **conversation** surface call site. The conversation-surface type still requires them, so \`pnpm check\` and \`pnpm build\` fail with:

\`\`\`
TS2739: Type '{ ... }' is missing the following properties from type 'ConversationSurfaceProps':
  onUnselectAllMessages, onSelectAllAboveSelection, onSelectAllBelowSelection
\`\`\`

**Fix:** Re-add the three prop lines on the conversation call site (handlers already exist, no logic change).

### 2. Server build (`TS1005` / `TS1136` in `st-prompt.importer.ts`)
From PR #86. In \`importSTPreset\`, the inner \`parameters\` object closes but the outer first-arg object literal to \`storage.create(...)\` never does. The parser then reads \`options?.timestampOverrides,\` as a malformed property assignment:

\`\`\`ts
await storage.create(
  {
    name: ...,
    ...
    parameters: { ... },
  },                        // <-- this closing brace was missing
  options?.timestampOverrides,
);
\`\`\`

This breaks both \`pnpm check\` (lint job) and the Docker release build (\`pnpm build\` at image build time).

**Fix:** One-line addition of the missing closing brace.

## Why this shipped broken
Each PR passed CI at open time, but CI never re-ran against the post-merge tip of main after both landed. So the parallel-merge conflicts slipped through.

## Test plan
- [x] \`pnpm check\` passes locally (verified — 0 errors).
- [x] CI lint + build jobs green.
- [x] Docker build-push workflow completes.
- [x] Conversation chat: Delete more → target + all below selected; Unselect all / ↑ / ↓ all work.
- [x] Roleplay unaffected.
- [x] ST preset import (the thing the broken file is for) still imports — confirms the brace fix didn't shift semantics.