### PR TITLE
feat(chat): Chat-settings presets + quick-start context menu

### DIFF
--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -39,6 +39,10 @@ import {
   Feather,
   Activity,
   Puzzle,
+  Save,
+  FilePlus2,
+  Upload,
+  Download,
 } from "lucide-react";
 import { cn } from "../../lib/utils";
 import { HelpTooltip } from "../ui/HelpTooltip";
@@ -59,6 +63,16 @@ import {
 } from "../../hooks/use-chats";
 import { api } from "../../lib/api-client";
 import { useUIStore } from "../../stores/ui.store";
+import {
+  useChatPresets,
+  useSaveChatPresetSettings,
+  useDuplicateChatPreset,
+  useUpdateChatPreset,
+  useDeleteChatPreset,
+  useApplyChatPreset,
+  useImportChatPreset,
+} from "../../hooks/use-chat-presets";
+import type { ChatMode, ChatPreset, ChatPresetSettings } from "@marinara-engine/shared";
 import { useAgentConfigs, type AgentConfigRow } from "../../hooks/use-agents";
 import { BUILT_IN_AGENTS, BUILT_IN_TOOLS } from "@marinara-engine/shared";
 import type { Chat, CharacterGroup } from "@marinara-engine/shared";
@@ -400,6 +414,128 @@ export function ChatSettingsDrawer({
   const [groupScenarioDraft, setGroupScenarioDraft] = useState((metadata.groupScenarioText as string) ?? "");
   const [groupScenarioExpanded, setGroupScenarioExpanded] = useState(false);
 
+  // ── Chat Settings Presets ──
+  const presetMode = (chatMode === "visual_novel" ? "roleplay" : chatMode) as ChatMode;
+  const { data: chatPresets } = useChatPresets(presetMode);
+  const saveChatPreset = useSaveChatPresetSettings();
+  const duplicateChatPreset = useDuplicateChatPreset();
+  const renameChatPreset = useUpdateChatPreset();
+  const deleteChatPreset = useDeleteChatPreset();
+  const applyChatPreset = useApplyChatPreset();
+  const importChatPreset = useImportChatPreset();
+  const presetList = useMemo(() => (chatPresets ?? []) as ChatPreset[], [chatPresets]);
+  const appliedPresetId = (metadata.appliedChatPresetId as string | undefined) ?? null;
+  const selectedChatPreset = useMemo(() => {
+    if (appliedPresetId) {
+      const match = presetList.find((p) => p.id === appliedPresetId);
+      if (match) return match;
+    }
+    return presetList.find((p) => p.isDefault) ?? null;
+  }, [presetList, appliedPresetId]);
+  const [renamingPreset, setRenamingPreset] = useState(false);
+  const [renamePresetVal, setRenamePresetVal] = useState("");
+  const presetFileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const snapshotCurrentPresetSettings = useCallback((): ChatPresetSettings => {
+    return {
+      connectionId: chat.connectionId ?? null,
+      promptPresetId: chat.promptPresetId ?? null,
+      metadata: { ...metadata },
+    };
+  }, [chat.connectionId, chat.promptPresetId, metadata]);
+
+  const handleSelectPreset = (id: string) => {
+    if (!id || id === selectedChatPreset?.id) return;
+    applyChatPreset.mutate({ presetId: id, chatId: chat.id });
+  };
+
+  const handleSaveIntoPreset = () => {
+    if (!selectedChatPreset || selectedChatPreset.isDefault) return;
+    saveChatPreset.mutate({ id: selectedChatPreset.id, settings: snapshotCurrentPresetSettings() });
+  };
+
+  const handleStartRenamePreset = () => {
+    if (!selectedChatPreset || selectedChatPreset.isDefault) return;
+    setRenamePresetVal(selectedChatPreset.name);
+    setRenamingPreset(true);
+  };
+
+  const handleCommitRenamePreset = () => {
+    if (!selectedChatPreset || selectedChatPreset.isDefault) {
+      setRenamingPreset(false);
+      return;
+    }
+    const next = renamePresetVal.trim();
+    if (next && next !== selectedChatPreset.name) {
+      renameChatPreset.mutate({ id: selectedChatPreset.id, name: next });
+    }
+    setRenamingPreset(false);
+  };
+
+  const handleSaveAsPreset = () => {
+    if (!selectedChatPreset) return;
+    const baseName = window.prompt("Name for the new preset:", `${selectedChatPreset.name} Copy`);
+    if (!baseName?.trim()) return;
+    const trimmed = baseName.trim().slice(0, 120);
+    duplicateChatPreset.mutate(
+      { id: selectedChatPreset.id, name: trimmed },
+      {
+        onSuccess: (created) => {
+          if (!created) return;
+          // Save the current chat settings into the new preset, then apply it
+          // (which records appliedChatPresetId on the chat so the dropdown follows).
+          saveChatPreset.mutate(
+            { id: created.id, settings: snapshotCurrentPresetSettings() },
+            {
+              onSuccess: () => applyChatPreset.mutate({ presetId: created.id, chatId: chat.id }),
+            },
+          );
+        },
+      },
+    );
+  };
+
+  const handleDeletePreset = () => {
+    if (!selectedChatPreset || selectedChatPreset.isDefault) return;
+    const ok = window.confirm(`Delete preset "${selectedChatPreset.name}"? This cannot be undone.`);
+    if (!ok) return;
+    const wasApplied = selectedChatPreset.id === appliedPresetId;
+    const defaultPreset = presetList.find((p) => p.isDefault);
+    deleteChatPreset.mutate(selectedChatPreset.id, {
+      onSuccess: () => {
+        // If the chat was using the preset we just deleted, fall back to the
+        // Default preset's settings — without this, the chat would visually
+        // show "Default" but keep the deleted preset's actual values.
+        if (wasApplied && defaultPreset) {
+          applyChatPreset.mutate({ presetId: defaultPreset.id, chatId: chat.id });
+        }
+      },
+    });
+  };
+
+  const handleExportPreset = () => {
+    if (!selectedChatPreset) return;
+    api.download(`/chat-presets/${selectedChatPreset.id}/export`, `${selectedChatPreset.name}.marinara-chat-preset.json`);
+  };
+
+  const handleImportClick = () => {
+    presetFileInputRef.current?.click();
+  };
+
+  const handleImportFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    e.target.value = ""; // allow re-importing the same file
+    if (!file) return;
+    try {
+      const text = await file.text();
+      const envelope = JSON.parse(text);
+      const created = await importChatPreset.mutateAsync(envelope);
+      if (created?.id) applyChatPreset.mutate({ presetId: created.id, chatId: chat.id });
+    } catch (err) {
+      window.alert(`Failed to import preset: ${err instanceof Error ? err.message : "Invalid file"}`);
+    }
+  };
+
   const saveName = () => {
     if (nameVal.trim() && nameVal !== chat.name) {
       updateChat.mutate({ id: chat.id, name: nameVal.trim() });
@@ -425,6 +561,103 @@ export function ChatSettingsDrawer({
           >
             <X size="1rem" />
           </button>
+        </div>
+
+        {/* Chat Settings Preset bar */}
+        <div className="flex flex-col gap-2 border-b border-[var(--border)] px-4 py-3">
+          <input
+            ref={presetFileInputRef}
+            type="file"
+            accept=".json,application/json"
+            className="hidden"
+            onChange={handleImportFile}
+          />
+          {/* Dropdown / rename input + help */}
+          <div className="flex items-center gap-2">
+            {renamingPreset ? (
+              <input
+                value={renamePresetVal}
+                onChange={(e) => setRenamePresetVal(e.target.value)}
+                onBlur={handleCommitRenamePreset}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") handleCommitRenamePreset();
+                  else if (e.key === "Escape") setRenamingPreset(false);
+                }}
+                autoFocus
+                maxLength={120}
+                className="flex-1 min-w-0 rounded-lg bg-[var(--secondary)] px-3 py-2 text-xs outline-none ring-1 ring-[var(--primary)]/40"
+              />
+            ) : (
+              <select
+                value={selectedChatPreset?.id ?? ""}
+                onChange={(e) => handleSelectPreset(e.target.value)}
+                title="Apply a chat-settings preset to this chat"
+                className="flex-1 min-w-0 rounded-lg bg-[var(--secondary)] px-3 py-2 text-xs outline-none ring-1 ring-transparent transition-shadow focus:ring-[var(--primary)]/40"
+              >
+                {presetList.length === 0 && <option value="">Loading…</option>}
+                {presetList.map((p) => (
+                  <option key={p.id} value={p.id}>
+                    {p.isDefault ? "Default" : p.name}
+                  </option>
+                ))}
+              </select>
+            )}
+            <HelpTooltip
+              side="left"
+              text="Presets bundle this chat's connection, prompt preset, agents, tools, translation, memory recall, advanced parameters, and other settings. They never touch your characters, persona, lorebooks, sprites, summary, tags, or scene prompt — those stay tied to the chat."
+            />
+          </div>
+          {/* Single row of all preset actions */}
+          <div className="flex items-center gap-1">
+            <button
+              onClick={handleSaveIntoPreset}
+              disabled={!selectedChatPreset || selectedChatPreset.isDefault}
+              title={selectedChatPreset?.isDefault ? "Cannot save into the Default preset" : "Save current chat settings into this preset"}
+              className="flex-1 flex items-center justify-center rounded-md p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              <Save size="0.875rem" />
+            </button>
+            <button
+              onClick={handleStartRenamePreset}
+              disabled={!selectedChatPreset || selectedChatPreset.isDefault}
+              title={selectedChatPreset?.isDefault ? "Cannot rename the Default preset" : "Rename preset"}
+              className="flex-1 flex items-center justify-center rounded-md p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              <Pencil size="0.875rem" />
+            </button>
+            <button
+              onClick={handleSaveAsPreset}
+              disabled={!selectedChatPreset}
+              title="Save current chat settings as a new preset"
+              className="flex-1 flex items-center justify-center rounded-md p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              <FilePlus2 size="0.875rem" />
+            </button>
+            <span className="mx-1 h-4 w-px shrink-0 bg-[var(--border)]" aria-hidden />
+            <button
+              onClick={handleImportClick}
+              title="Import preset (.json)"
+              className="flex-1 flex items-center justify-center rounded-md p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+            >
+              <Upload size="0.875rem" />
+            </button>
+            <button
+              onClick={handleExportPreset}
+              disabled={!selectedChatPreset}
+              title="Export preset (.json)"
+              className="flex-1 flex items-center justify-center rounded-md p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              <Download size="0.875rem" />
+            </button>
+            <button
+              onClick={handleDeletePreset}
+              disabled={!selectedChatPreset || selectedChatPreset.isDefault}
+              title={selectedChatPreset?.isDefault ? "Cannot delete the Default preset" : "Delete preset"}
+              className="flex-1 flex items-center justify-center rounded-md p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--destructive)]/15 hover:text-[var(--destructive)] disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              <Trash2 size="0.875rem" />
+            </button>
+          </div>
         </div>
 
         <div className="flex-1 overflow-y-auto">

--- a/packages/client/src/components/chat/ChatSetupWizard.tsx
+++ b/packages/client/src/components/chat/ChatSetupWizard.tsx
@@ -16,6 +16,8 @@ import {
   Users,
   Loader2,
   Bot,
+  Wand2,
+  ArrowLeft,
 } from "lucide-react";
 import { cn } from "../../lib/utils";
 import { useConnections } from "../../hooks/use-connections";
@@ -23,10 +25,12 @@ import { usePresets, usePresetFull, useDefaultPreset } from "../../hooks/use-pre
 import { useCharacters, usePersonas } from "../../hooks/use-characters";
 import { useLorebooks } from "../../hooks/use-lorebooks";
 import { useUpdateChat, useUpdateChatMetadata, useCreateMessage, chatKeys } from "../../hooks/use-chats";
+import { useChatPresets, useApplyChatPreset } from "../../hooks/use-chat-presets";
 import { useUIStore } from "../../stores/ui.store";
+import { useChatStore } from "../../stores/chat.store";
 import { api } from "../../lib/api-client";
 import { ChoiceSelectionModal } from "../presets/ChoiceSelectionModal";
-import type { Chat } from "@marinara-engine/shared";
+import type { Chat, ChatMode, ChatPreset } from "@marinara-engine/shared";
 import { useQueryClient } from "@tanstack/react-query";
 
 // ─── Step definitions ─────────────────────────
@@ -543,6 +547,13 @@ function RoleplaySetupWizard({ chat, onFinish }: ChatSetupWizardProps) {
   const currentStep = STEPS[step]!;
   const isLast = step === STEPS.length - 1;
   const [showChoiceModal, setShowChoiceModal] = useState(false);
+  // Open in shortcut mode if the chat store flag was set (e.g. via right-click "Quick Start").
+  const [shortcutMode, setShortcutMode] = useState(() => {
+    const flag = useChatStore.getState().shouldOpenWizardInShortcutMode;
+    if (flag) useChatStore.getState().setShouldOpenWizardInShortcutMode(false);
+    return flag;
+  });
+  const [shortcutPresetId, setShortcutPresetId] = useState<string>("");
 
   const updateChat = useUpdateChat();
   const updateMeta = useUpdateChatMetadata();
@@ -559,6 +570,12 @@ function RoleplaySetupWizard({ chat, onFinish }: ChatSetupWizardProps) {
   const { data: allPersonas } = usePersonas();
   const { data: allCharacters } = useCharacters();
   const { data: lorebooks } = useLorebooks();
+
+  // Chat-settings presets for the shortcut view
+  const chatPresetMode = ((chat as unknown as { mode?: string }).mode === "visual_novel" ? "roleplay" : "roleplay") as ChatMode;
+  const { data: chatPresetsData } = useChatPresets(chatPresetMode);
+  const chatPresetList = useMemo(() => (chatPresetsData ?? []) as ChatPreset[], [chatPresetsData]);
+  const applyChatPreset = useApplyChatPreset();
 
   const personas = (allPersonas ?? []) as Array<{ id: string; name: string; avatarPath: string | null }>;
   const characters = useMemo(
@@ -716,6 +733,31 @@ function RoleplaySetupWizard({ chat, onFinish }: ChatSetupWizardProps) {
     },
     [chat.id, activeLorebookIds, updateMeta],
   );
+
+  // Default the shortcut dropdown to the Default preset once presets load
+  useEffect(() => {
+    if (shortcutPresetId) return;
+    const def = chatPresetList.find((p) => p.isDefault);
+    if (def) setShortcutPresetId(def.id);
+  }, [chatPresetList, shortcutPresetId]);
+
+  const [shortcutApplying, setShortcutApplying] = useState(false);
+
+  const handleShortcutApply = useCallback(async () => {
+    if (!shortcutPresetId) {
+      onFinish();
+      return;
+    }
+    try {
+      setShortcutApplying(true);
+      await applyChatPreset.mutateAsync({ presetId: shortcutPresetId, chatId: chat.id });
+    } catch {
+      /* fall through — still close the wizard */
+    } finally {
+      setShortcutApplying(false);
+      onFinish();
+    }
+  }, [shortcutPresetId, chat.id, applyChatPreset, onFinish]);
 
   // Search state for character & lorebook pickers
   const [charSearch, setCharSearch] = useState("");
@@ -997,71 +1039,289 @@ function RoleplaySetupWizard({ chat, onFinish }: ChatSetupWizardProps) {
         )}
       >
         <AnimatePresence mode="wait">
-          <motion.div
-            key={step}
-            initial={{ opacity: 0, y: 12, scale: 0.97 }}
-            animate={{ opacity: 1, y: 0, scale: 1 }}
-            exit={{ opacity: 0, y: -12, scale: 0.97 }}
-            transition={{ duration: 0.2, ease: "easeOut" }}
-            className="pointer-events-auto w-full max-w-sm rounded-2xl border border-[var(--border)] bg-[var(--card)] p-5 shadow-2xl"
-          >
-            {/* Sprite */}
-            <div className="mb-3 flex justify-center">
-              <img
-                src={currentStep.sprite}
-                alt="Professor Mari"
-                className="h-28 w-auto object-contain drop-shadow-lg"
-                style={currentStep.spriteFlip ? { transform: "scaleX(-1)" } : undefined}
-                draggable={false}
-              />
-            </div>
+          {shortcutMode ? (
+            <motion.div
+              key="shortcut"
+              initial={{ opacity: 0, y: 12, scale: 0.97 }}
+              animate={{ opacity: 1, y: 0, scale: 1 }}
+              exit={{ opacity: 0, y: -12, scale: 0.97 }}
+              transition={{ duration: 0.2, ease: "easeOut" }}
+              className="pointer-events-auto w-full max-w-sm max-h-[90vh] flex flex-col rounded-2xl border border-[var(--border)] bg-[var(--card)] shadow-2xl overflow-hidden"
+            >
+              {/* Header */}
+              <div className="flex items-center justify-between border-b border-[var(--border)] px-4 py-3">
+                <button
+                  onClick={() => setShortcutMode(false)}
+                  className="flex items-center gap-1.5 rounded-md p-1 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--secondary)] hover:text-[var(--foreground)]"
+                  aria-label="Back"
+                >
+                  <ArrowLeft size="0.875rem" />
+                </button>
+                <div className="flex items-center gap-1.5">
+                  <Wand2 size="0.875rem" className="text-[var(--primary)]" />
+                  <h3 className="text-sm font-semibold text-[var(--foreground)]">Quick Setup</h3>
+                </div>
+                <button
+                  onClick={onFinish}
+                  className="rounded-md p-1 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--secondary)] hover:text-[var(--foreground)]"
+                  aria-label="Close"
+                >
+                  <X size="0.875rem" />
+                </button>
+              </div>
 
-            {/* Title */}
-            <h3 className="mb-1 text-center text-sm font-semibold text-[var(--foreground)]">{currentStep.title}</h3>
+              <div className="flex-1 overflow-y-auto p-4 space-y-4 min-h-0">
+                <p className="text-center text-xs leading-relaxed text-[var(--muted-foreground)]">
+                  Pick a preset, your persona, and any characters to instantly configure this roleplay.
+                </p>
 
-            {/* Body */}
-            <p className="mb-4 text-center text-xs leading-relaxed text-[var(--muted-foreground)]">
-              {currentStep.body}
-            </p>
+                {/* Chat Preset */}
+                <div className="space-y-1.5">
+                  <label className="text-[0.6875rem] font-medium text-[var(--muted-foreground)] uppercase tracking-wider">
+                    Chat Preset
+                  </label>
+                  <select
+                    value={shortcutPresetId}
+                    onChange={(e) => setShortcutPresetId(e.target.value)}
+                    className="w-full rounded-lg bg-[var(--secondary)] px-3 py-2 text-xs outline-none ring-1 ring-[var(--border)] transition-shadow focus:ring-[var(--primary)]/40"
+                  >
+                    {chatPresetList.length === 0 && <option value="">Loading…</option>}
+                    {chatPresetList.map((p) => (
+                      <option key={p.id} value={p.id}>
+                        {p.isDefault ? "Default" : p.name}
+                      </option>
+                    ))}
+                  </select>
+                </div>
 
-            {/* Step content */}
-            <div className="mb-4">{stepRenderers[currentStep.key]?.()}</div>
+                {/* Persona */}
+                <div className="space-y-1.5">
+                  <label className="text-[0.6875rem] font-medium text-[var(--muted-foreground)] uppercase tracking-wider">
+                    Persona
+                  </label>
+                  <select
+                    value={chat.personaId ?? ""}
+                    onChange={(e) => setPersona(e.target.value || null)}
+                    className="w-full rounded-lg bg-[var(--secondary)] px-3 py-2 text-xs outline-none ring-1 ring-[var(--border)] transition-shadow focus:ring-[var(--primary)]/40"
+                  >
+                    <option value="">None</option>
+                    {personas.map((p) => (
+                      <option key={p.id} value={p.id}>
+                        {p.name}
+                      </option>
+                    ))}
+                  </select>
+                </div>
 
-            {/* Progress dots */}
-            <div className="mb-3 flex items-center justify-center gap-1.5">
-              {STEPS.map((_, i) => (
-                <div
-                  key={i}
-                  className={cn(
-                    "h-1.5 rounded-full transition-all duration-300",
-                    i === step
-                      ? "w-4 bg-[var(--primary)]"
-                      : i < step
-                        ? "w-1.5 bg-[var(--primary)]/40"
-                        : "w-1.5 bg-[var(--muted-foreground)]/20",
+                {/* Characters */}
+                <div className="space-y-1.5">
+                  <label className="text-[0.6875rem] font-medium text-[var(--muted-foreground)] uppercase tracking-wider">
+                    {chatCharIds.length > 1 ? (
+                      <span className="flex items-center gap-1.5">
+                        <Users size="0.6875rem" />
+                        Characters · {chatCharIds.length}
+                      </span>
+                    ) : (
+                      "Characters"
+                    )}
+                  </label>
+
+                  {chatCharIds.length > 0 && (
+                    <div className="flex flex-wrap gap-1.5 mb-1.5">
+                      {chatCharIds.map((cid) => {
+                        const c = characters.find((ch) => ch.id === cid);
+                        if (!c) return null;
+                        const name = charName(c);
+                        return (
+                          <button
+                            key={cid}
+                            onClick={() => toggleCharacter(cid)}
+                            className="flex items-center gap-1.5 rounded-full bg-[var(--primary)]/15 pl-1 pr-2.5 py-1 text-xs ring-1 ring-[var(--primary)]/30 transition-all hover:bg-[var(--destructive)]/15 hover:ring-[var(--destructive)]/30 group"
+                          >
+                            {c.avatarPath ? (
+                              <img
+                                src={c.avatarPath}
+                                alt={name}
+                                loading="lazy"
+                                className="h-5 w-5 rounded-full object-cover"
+                              />
+                            ) : (
+                              <div className="flex h-5 w-5 items-center justify-center rounded-full bg-[var(--accent)] text-[0.5rem] font-bold">
+                                {name[0]}
+                              </div>
+                            )}
+                            <span className="truncate max-w-[6rem]">{name}</span>
+                            <X
+                              size="0.625rem"
+                              className="text-[var(--muted-foreground)] group-hover:text-[var(--destructive)]"
+                            />
+                          </button>
+                        );
+                      })}
+                    </div>
                   )}
-                />
-              ))}
-            </div>
 
-            {/* Buttons */}
-            <div className="flex items-center justify-between">
-              <button
-                onClick={onFinish}
-                className="rounded-lg px-3 py-1.5 text-xs text-[var(--muted-foreground)] transition-colors hover:bg-[var(--secondary)] hover:text-[var(--foreground)]"
-              >
-                Skip
-              </button>
-              <button
-                onClick={next}
-                disabled={nextDisabled}
-                className="flex items-center gap-1.5 rounded-lg bg-[var(--primary)] px-4 py-1.5 text-xs font-medium text-[var(--primary-foreground)] shadow-sm transition-all hover:opacity-90 active:scale-95 disabled:opacity-50"
-              >
-                {isLast ? "Done" : "Next"}
-                {isLast ? <Check size="0.75rem" /> : <ChevronRight size="0.75rem" />}
-              </button>
-            </div>
-          </motion.div>
+                  <div className="rounded-lg ring-1 ring-[var(--border)] bg-[var(--card)] overflow-hidden">
+                    <div className="flex items-center gap-2 border-b border-[var(--border)] px-3 py-2">
+                      <Search size="0.75rem" className="text-[var(--muted-foreground)]" />
+                      <input
+                        value={charSearch}
+                        onChange={(e) => setCharSearch(e.target.value)}
+                        placeholder="Search characters…"
+                        className="flex-1 bg-transparent text-xs outline-none placeholder:text-[var(--muted-foreground)]"
+                      />
+                    </div>
+                    <div className="max-h-40 overflow-y-auto">
+                      {characters
+                        .filter(
+                          (c) =>
+                            !chatCharIds.includes(c.id) &&
+                            charName(c).toLowerCase().includes(charSearch.toLowerCase()),
+                        )
+                        .map((c) => {
+                          const name = charName(c);
+                          return (
+                            <button
+                              key={c.id}
+                              onClick={() => toggleCharacter(c.id)}
+                              className="flex w-full items-center gap-2.5 px-3 py-2 text-left transition-all hover:bg-[var(--accent)]"
+                            >
+                              {c.avatarPath ? (
+                                <img
+                                  src={c.avatarPath}
+                                  alt={name}
+                                  loading="lazy"
+                                  className="h-6 w-6 rounded-full object-cover"
+                                />
+                              ) : (
+                                <div className="flex h-6 w-6 items-center justify-center rounded-full bg-[var(--accent)] text-[0.5625rem] font-bold">
+                                  {name[0]}
+                                </div>
+                              )}
+                              <span className="flex-1 truncate text-xs">{name}</span>
+                              <Plus size="0.75rem" className="text-[var(--muted-foreground)]" />
+                            </button>
+                          );
+                        })}
+                      {characters.filter(
+                        (c) =>
+                          !chatCharIds.includes(c.id) &&
+                          charName(c).toLowerCase().includes(charSearch.toLowerCase()),
+                      ).length === 0 && (
+                        <p className="px-3 py-3 text-center text-[0.6875rem] text-[var(--muted-foreground)]">
+                          {characters.filter((c) => !chatCharIds.includes(c.id)).length === 0
+                            ? "All characters added."
+                            : "No matches."}
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              {/* Footer */}
+              <div className="border-t border-[var(--border)] px-4 py-3 flex items-center justify-between">
+                <button
+                  onClick={() => setShortcutMode(false)}
+                  className="rounded-lg px-3 py-1.5 text-xs text-[var(--muted-foreground)] transition-colors hover:bg-[var(--secondary)] hover:text-[var(--foreground)]"
+                >
+                  Back
+                </button>
+                <button
+                  onClick={handleShortcutApply}
+                  disabled={shortcutApplying || !shortcutPresetId}
+                  className="flex items-center gap-1.5 rounded-lg bg-[var(--primary)] px-4 py-1.5 text-xs font-medium text-[var(--primary-foreground)] shadow-sm transition-all hover:opacity-90 active:scale-95 disabled:opacity-50"
+                >
+                  {shortcutApplying ? (
+                    <>
+                      <Loader2 size="0.75rem" className="animate-spin" />
+                      Applying…
+                    </>
+                  ) : (
+                    <>
+                      <Wand2 size="0.75rem" />
+                      Apply &amp; Start
+                    </>
+                  )}
+                </button>
+              </div>
+            </motion.div>
+          ) : (
+            <motion.div
+              key={step}
+              initial={{ opacity: 0, y: 12, scale: 0.97 }}
+              animate={{ opacity: 1, y: 0, scale: 1 }}
+              exit={{ opacity: 0, y: -12, scale: 0.97 }}
+              transition={{ duration: 0.2, ease: "easeOut" }}
+              className="pointer-events-auto w-full max-w-sm rounded-2xl border border-[var(--border)] bg-[var(--card)] p-5 shadow-2xl"
+            >
+              {/* Sprite */}
+              <div className="mb-3 flex justify-center">
+                <img
+                  src={currentStep.sprite}
+                  alt="Professor Mari"
+                  className="h-28 w-auto object-contain drop-shadow-lg"
+                  style={currentStep.spriteFlip ? { transform: "scaleX(-1)" } : undefined}
+                  draggable={false}
+                />
+              </div>
+
+              {/* Title */}
+              <h3 className="mb-1 text-center text-sm font-semibold text-[var(--foreground)]">{currentStep.title}</h3>
+
+              {/* Body */}
+              <p className="mb-4 text-center text-xs leading-relaxed text-[var(--muted-foreground)]">
+                {currentStep.body}
+              </p>
+
+              {/* Step content */}
+              <div className="mb-4">{stepRenderers[currentStep.key]?.()}</div>
+
+              {/* Progress dots */}
+              <div className="mb-3 flex items-center justify-center gap-1.5">
+                {STEPS.map((_, i) => (
+                  <div
+                    key={i}
+                    className={cn(
+                      "h-1.5 rounded-full transition-all duration-300",
+                      i === step
+                        ? "w-4 bg-[var(--primary)]"
+                        : i < step
+                          ? "w-1.5 bg-[var(--primary)]/40"
+                          : "w-1.5 bg-[var(--muted-foreground)]/20",
+                    )}
+                  />
+                ))}
+              </div>
+
+              {/* Buttons */}
+              <div className="flex items-center justify-between gap-2">
+                <button
+                  onClick={onFinish}
+                  className="rounded-lg px-3 py-1.5 text-xs text-[var(--muted-foreground)] transition-colors hover:bg-[var(--secondary)] hover:text-[var(--foreground)]"
+                >
+                  Skip
+                </button>
+                <button
+                  onClick={() => setShortcutMode(true)}
+                  title="Apply a saved chat-settings preset and pick a persona + characters in one step"
+                  className="flex items-center gap-1.5 rounded-lg border border-[var(--primary)]/30 bg-[var(--primary)]/10 px-3 py-1.5 text-xs font-medium text-[var(--primary)] transition-all hover:bg-[var(--primary)]/20"
+                >
+                  <Wand2 size="0.75rem" />
+                  <span className="hidden xs:inline sm:inline">Use Settings Presets</span>
+                  <span className="inline xs:hidden sm:hidden">Presets</span>
+                </button>
+                <button
+                  onClick={next}
+                  disabled={nextDisabled}
+                  className="flex items-center gap-1.5 rounded-lg bg-[var(--primary)] px-4 py-1.5 text-xs font-medium text-[var(--primary-foreground)] shadow-sm transition-all hover:opacity-90 active:scale-95 disabled:opacity-50"
+                >
+                  {isLast ? "Done" : "Next"}
+                  {isLast ? <Check size="0.75rem" /> : <ChevronRight size="0.75rem" />}
+                </button>
+              </div>
+            </motion.div>
+          )}
         </AnimatePresence>
       </div>
     </>

--- a/packages/client/src/components/panels/BotBrowserPanel.tsx
+++ b/packages/client/src/components/panels/BotBrowserPanel.tsx
@@ -1,11 +1,14 @@
 // ──────────────────────────────────────────────
 // Panel: Browser (sidebar — shows imported characters)
 // ──────────────────────────────────────────────
-import { useState, useMemo } from "react";
+import { useState, useMemo, useCallback } from "react";
 import { useCharacters } from "../../hooks/use-characters";
+import { useCreateChat } from "../../hooks/use-chats";
 import { useUIStore } from "../../stores/ui.store";
-import { Search, User, Globe } from "lucide-react";
+import { useChatStore } from "../../stores/chat.store";
+import { Search, User, Globe, Wand2, MessageCircle } from "lucide-react";
 import { cn, getAvatarCropStyle } from "../../lib/utils";
+import { ContextMenu, type ContextMenuItem } from "../ui/ContextMenu";
 
 type CharacterRow = { id: string; data: string; avatarPath: string | null; createdAt: string; updatedAt: string };
 
@@ -14,7 +17,11 @@ export function BotBrowserPanel() {
   const openCharacterDetail = useUIStore((s) => s.openCharacterDetail);
   const openBotBrowser = useUIStore((s) => s.openBotBrowser);
   const botBrowserOpen = useUIStore((s) => s.botBrowserOpen);
+  const createChat = useCreateChat();
   const [search, setSearch] = useState("");
+  const [contextMenu, setContextMenu] = useState<{ x: number; y: number; charId: string; charName: string } | null>(
+    null,
+  );
 
   const parsed = useMemo(() => {
     if (!characters) return [];
@@ -34,6 +41,24 @@ export function BotBrowserPanel() {
     const q = search.toLowerCase();
     return parsed.filter((c) => c.name.toLowerCase().includes(q));
   }, [parsed, search]);
+
+  const quickStartFromCharacter = useCallback(
+    (charId: string, charName: string, mode: "roleplay" | "conversation") => {
+      const label = mode === "conversation" ? "Conversation" : "Roleplay";
+      createChat.mutate(
+        { name: charName ? `${charName} — ${label}` : `New ${label}`, mode, characterIds: [charId] },
+        {
+          onSuccess: (chat) => {
+            useChatStore.getState().setActiveChatId(chat.id);
+            useChatStore.getState().setShouldOpenSettings(true);
+            useChatStore.getState().setShouldOpenWizard(true);
+            useChatStore.getState().setShouldOpenWizardInShortcutMode(true);
+          },
+        },
+      );
+    },
+    [createChat],
+  );
 
   return (
     <div className="flex flex-col gap-2 p-3">
@@ -76,6 +101,10 @@ export function BotBrowserPanel() {
             <button
               key={char.id}
               onClick={() => openCharacterDetail(char.id)}
+              onContextMenu={(e) => {
+                e.preventDefault();
+                setContextMenu({ x: e.clientX, y: e.clientY, charId: char.id, charName: char.name });
+              }}
               className="group flex items-center gap-2.5 rounded-xl p-2 text-left transition-all hover:bg-[var(--sidebar-accent)]"
             >
               <div className="relative flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-pink-400 to-rose-500 text-white shadow-sm overflow-hidden">
@@ -96,6 +125,25 @@ export function BotBrowserPanel() {
           ))}
         </div>
       )}
+
+      {contextMenu &&
+        (() => {
+          const items: ContextMenuItem[] = [
+            {
+              label: "Quick Start Roleplay",
+              icon: <Wand2 size="0.75rem" />,
+              onSelect: () => quickStartFromCharacter(contextMenu.charId, contextMenu.charName, "roleplay"),
+            },
+            {
+              label: "Quick Start Conversation",
+              icon: <MessageCircle size="0.75rem" />,
+              onSelect: () => quickStartFromCharacter(contextMenu.charId, contextMenu.charName, "conversation"),
+            },
+          ];
+          return (
+            <ContextMenu x={contextMenu.x} y={contextMenu.y} items={items} onClose={() => setContextMenu(null)} />
+          );
+        })()}
     </div>
   );
 }

--- a/packages/client/src/components/panels/CharactersPanel.tsx
+++ b/packages/client/src/components/panels/CharactersPanel.tsx
@@ -13,9 +13,10 @@ import {
   useUpdateCharacter,
   useDuplicateCharacter,
 } from "../../hooks/use-characters";
-import { useUpdateChat, useCreateMessage, chatKeys } from "../../hooks/use-chats";
+import { useUpdateChat, useCreateMessage, useCreateChat, chatKeys } from "../../hooks/use-chats";
 import { api } from "../../lib/api-client";
 import { useChatStore } from "../../stores/chat.store";
+import { ContextMenu, type ContextMenuItem } from "../ui/ContextMenu";
 import { useQueryClient } from "@tanstack/react-query";
 import {
   Plus,
@@ -39,6 +40,7 @@ import {
   Tag,
   MessageCircle,
   Star,
+  Wand2,
 } from "lucide-react";
 import { useUIStore } from "../../stores/ui.store";
 import { cn, getAvatarCropStyle } from "../../lib/utils";
@@ -88,7 +90,29 @@ export function CharactersPanel() {
   const activeChat = useChatStore((s) => s.activeChat);
   const updateChat = useUpdateChat();
   const createMessage = useCreateMessage(activeChat?.id ?? null);
+  const createChat = useCreateChat();
   const queryClient = useQueryClient();
+  const [contextMenu, setContextMenu] = useState<{ x: number; y: number; charId: string; charName: string } | null>(
+    null,
+  );
+
+  const quickStartFromCharacter = useCallback(
+    (charId: string, charName: string, mode: "roleplay" | "conversation") => {
+      const label = mode === "conversation" ? "Conversation" : "Roleplay";
+      createChat.mutate(
+        { name: charName ? `${charName} — ${label}` : `New ${label}`, mode, characterIds: [charId] },
+        {
+          onSuccess: (chat) => {
+            useChatStore.getState().setActiveChatId(chat.id);
+            useChatStore.getState().setShouldOpenSettings(true);
+            useChatStore.getState().setShouldOpenWizard(true);
+            useChatStore.getState().setShouldOpenWizardInShortcutMode(true);
+          },
+        },
+      );
+    },
+    [createChat],
+  );
 
   const [search, setSearch] = useState("");
   const [sort, setSort] = useState<SortOption>("name-asc");
@@ -722,6 +746,11 @@ export function CharactersPanel() {
                           <div
                             key={memberId}
                             onClick={() => openCharacterDetail(memberId)}
+                            onContextMenu={(e) => {
+                              if (selectionMode || assigningToGroup) return;
+                              e.preventDefault();
+                              setContextMenu({ x: e.clientX, y: e.clientY, charId: memberId, charName: member.name });
+                            }}
                             className="group/member flex cursor-pointer items-center gap-2 rounded-lg p-1.5 transition-all hover:bg-[var(--sidebar-accent)]"
                           >
                             <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg overflow-hidden bg-gradient-to-br from-pink-400 to-rose-500 text-white">
@@ -828,6 +857,11 @@ export function CharactersPanel() {
                 } else {
                   openCharacterDetail(char.id);
                 }
+              }}
+              onContextMenu={(e) => {
+                if (selectionMode || assigningToGroup) return;
+                e.preventDefault();
+                setContextMenu({ x: e.clientX, y: e.clientY, charId: char.id, charName });
               }}
               className={cn(
                 "group flex items-center gap-2.5 rounded-xl p-2 transition-all hover:bg-[var(--sidebar-accent)] cursor-pointer",
@@ -991,6 +1025,25 @@ export function CharactersPanel() {
           Click to edit · Use ✓ to assign/remove from chat
         </p>
       )}
+
+      {contextMenu &&
+        (() => {
+          const items: ContextMenuItem[] = [
+            {
+              label: "Quick Start Roleplay",
+              icon: <Wand2 size="0.75rem" />,
+              onSelect: () => quickStartFromCharacter(contextMenu.charId, contextMenu.charName, "roleplay"),
+            },
+            {
+              label: "Quick Start Conversation",
+              icon: <MessageCircle size="0.75rem" />,
+              onSelect: () => quickStartFromCharacter(contextMenu.charId, contextMenu.charName, "conversation"),
+            },
+          ];
+          return (
+            <ContextMenu x={contextMenu.x} y={contextMenu.y} items={items} onClose={() => setContextMenu(null)} />
+          );
+        })()}
 
       {/* First message confirmation dialog */}
       {firstMesConfirm && (

--- a/packages/client/src/components/ui/ContextMenu.tsx
+++ b/packages/client/src/components/ui/ContextMenu.tsx
@@ -1,0 +1,101 @@
+// ──────────────────────────────────────────────
+// ContextMenu — small portal-rendered right-click menu
+// ──────────────────────────────────────────────
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import { createPortal } from "react-dom";
+import { cn } from "../../lib/utils";
+
+export interface ContextMenuItem {
+  label: string;
+  icon?: ReactNode;
+  onSelect: () => void;
+  disabled?: boolean;
+  destructive?: boolean;
+}
+
+interface ContextMenuProps {
+  /** Page-relative coordinates (e.clientX / e.clientY) where the menu should anchor. */
+  x: number;
+  y: number;
+  items: ContextMenuItem[];
+  onClose: () => void;
+}
+
+/** Right-click menu anchored at (x, y). Auto-flips when it would clip the viewport. */
+export function ContextMenu({ x, y, items, onClose }: ContextMenuProps) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [pos, setPos] = useState({ left: x, top: y });
+
+  // Flip / clamp the menu so it always stays inside the viewport.
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    let left = x;
+    let top = y;
+    if (left + rect.width > window.innerWidth - 4) left = window.innerWidth - rect.width - 4;
+    if (top + rect.height > window.innerHeight - 4) top = window.innerHeight - rect.height - 4;
+    if (left < 4) left = 4;
+    if (top < 4) top = 4;
+    setPos({ left, top });
+  }, [x, y]);
+
+  // Close on outside click, Escape, scroll, or window resize.
+  useEffect(() => {
+    const onDown = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) onClose();
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    const raf = requestAnimationFrame(() => {
+      document.addEventListener("mousedown", onDown);
+      document.addEventListener("keydown", onKey);
+      window.addEventListener("scroll", onClose, true);
+      window.addEventListener("resize", onClose);
+    });
+    return () => {
+      cancelAnimationFrame(raf);
+      document.removeEventListener("mousedown", onDown);
+      document.removeEventListener("keydown", onKey);
+      window.removeEventListener("scroll", onClose, true);
+      window.removeEventListener("resize", onClose);
+    };
+  }, [onClose]);
+
+  return createPortal(
+    <div
+      ref={ref}
+      role="menu"
+      style={{ position: "fixed", left: pos.left, top: pos.top, zIndex: 9999 }}
+      className="min-w-[12rem] rounded-lg border border-[var(--border)] bg-[var(--card)] py-1 shadow-xl animate-fade-in-up"
+      onContextMenu={(e) => e.preventDefault()}
+    >
+      {items.map((item, i) => (
+        <button
+          key={`${item.label}-${i}`}
+          type="button"
+          role="menuitem"
+          disabled={item.disabled}
+          onClick={() => {
+            if (item.disabled) return;
+            item.onSelect();
+            onClose();
+          }}
+          className={cn(
+            "flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs transition-colors",
+            item.disabled
+              ? "cursor-not-allowed text-[var(--muted-foreground)] opacity-50"
+              : item.destructive
+                ? "text-[var(--destructive)] hover:bg-[var(--destructive)]/10"
+                : "text-[var(--foreground)] hover:bg-[var(--accent)]",
+          )}
+        >
+          {item.icon && <span className="shrink-0 text-[var(--muted-foreground)]">{item.icon}</span>}
+          <span className="flex-1 truncate">{item.label}</span>
+        </button>
+      ))}
+    </div>,
+    document.body,
+  );
+}

--- a/packages/client/src/hooks/use-chat-presets.ts
+++ b/packages/client/src/hooks/use-chat-presets.ts
@@ -1,0 +1,104 @@
+// ──────────────────────────────────────────────
+// React Query: Chat Preset hooks
+// ──────────────────────────────────────────────
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "../lib/api-client";
+import { chatKeys } from "./use-chats";
+import type { Chat, ChatMode, ChatPreset, ChatPresetSettings } from "@marinara-engine/shared";
+
+export const chatPresetKeys = {
+  all: ["chat-presets"] as const,
+  list: (mode?: ChatMode | null) => [...chatPresetKeys.all, "list", mode ?? "all"] as const,
+  detail: (id: string) => [...chatPresetKeys.all, "detail", id] as const,
+  active: (mode: ChatMode) => [...chatPresetKeys.all, "active", mode] as const,
+};
+
+export function useChatPresets(mode?: ChatMode | null) {
+  return useQuery({
+    queryKey: chatPresetKeys.list(mode ?? null),
+    queryFn: () => api.get<ChatPreset[]>(mode ? `/chat-presets?mode=${encodeURIComponent(mode)}` : "/chat-presets"),
+    staleTime: 60_000,
+  });
+}
+
+export function useActiveChatPreset(mode: ChatMode | null) {
+  return useQuery({
+    queryKey: mode ? chatPresetKeys.active(mode) : chatPresetKeys.all,
+    queryFn: () => api.get<ChatPreset | null>(`/chat-presets/active/${mode}`),
+    enabled: !!mode,
+    staleTime: 60_000,
+  });
+}
+
+export function useCreateChatPreset() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: { name: string; mode: ChatMode; settings?: ChatPresetSettings }) =>
+      api.post<ChatPreset>("/chat-presets", data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: chatPresetKeys.all }),
+  });
+}
+
+export function useUpdateChatPreset() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, ...data }: { id: string; name?: string; settings?: ChatPresetSettings }) =>
+      api.patch<ChatPreset>(`/chat-presets/${id}`, data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: chatPresetKeys.all }),
+  });
+}
+
+export function useSaveChatPresetSettings() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, settings }: { id: string; settings: ChatPresetSettings }) =>
+      api.put<ChatPreset>(`/chat-presets/${id}/settings`, settings),
+    onSuccess: () => qc.invalidateQueries({ queryKey: chatPresetKeys.all }),
+  });
+}
+
+export function useDuplicateChatPreset() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, name }: { id: string; name?: string }) =>
+      api.post<ChatPreset>(`/chat-presets/${id}/duplicate`, { name }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: chatPresetKeys.all }),
+  });
+}
+
+export function useSetActiveChatPreset() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => api.post<ChatPreset>(`/chat-presets/${id}/set-active`),
+    onSuccess: () => qc.invalidateQueries({ queryKey: chatPresetKeys.all }),
+  });
+}
+
+export function useDeleteChatPreset() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => api.delete<void>(`/chat-presets/${id}`),
+    onSuccess: () => qc.invalidateQueries({ queryKey: chatPresetKeys.all }),
+  });
+}
+
+export function useImportChatPreset() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (envelope: unknown) => api.post<ChatPreset>("/chat-presets/import", envelope),
+    onSuccess: () => qc.invalidateQueries({ queryKey: chatPresetKeys.all }),
+  });
+}
+
+/** Apply a preset's settings to an existing chat. Refetches the chat afterward. */
+export function useApplyChatPreset() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ presetId, chatId }: { presetId: string; chatId: string }) =>
+      api.post<Chat>(`/chat-presets/${presetId}/apply/${chatId}`),
+    onSuccess: (_data, variables) => {
+      qc.invalidateQueries({ queryKey: chatKeys.detail(variables.chatId) });
+      qc.invalidateQueries({ queryKey: chatKeys.list() });
+    },
+  });
+}

--- a/packages/client/src/stores/chat.store.ts
+++ b/packages/client/src/stores/chat.store.ts
@@ -60,6 +60,8 @@ interface ChatState {
   shouldOpenSettings: boolean;
   /** When true, ChatArea should show the setup wizard for the newly created chat. */
   shouldOpenWizard: boolean;
+  /** When true (and the wizard opens), it should land directly on the Quick Setup shortcut view. */
+  shouldOpenWizardInShortcutMode: boolean;
   /** Pending new-chat mode for first-run connection setup gating. */
   pendingNewChatMode: Exclude<ChatMode, "visual_novel"> | null;
   /** Per-chat draft input text so typing isn't lost when navigating away. */
@@ -94,6 +96,7 @@ interface ChatState {
   setSwipeIndex: (messageId: string, index: number) => void;
   setShouldOpenSettings: (v: boolean) => void;
   setShouldOpenWizard: (v: boolean) => void;
+  setShouldOpenWizardInShortcutMode: (v: boolean) => void;
   setPendingNewChatMode: (mode: Exclude<ChatMode, "visual_novel"> | null) => void;
   setInputDraft: (chatId: string, text: string) => void;
   clearInputDraft: (chatId: string) => void;
@@ -129,6 +132,7 @@ export const useChatStore = create<ChatState>()(
     swipeIndex: new Map(),
     shouldOpenSettings: false,
     shouldOpenWizard: false,
+    shouldOpenWizardInShortcutMode: false,
     pendingNewChatMode: null,
     inputDrafts: loadDrafts(),
     unreadCounts: new Map(),
@@ -273,6 +277,8 @@ export const useChatStore = create<ChatState>()(
     setShouldOpenSettings: (v) => set({ shouldOpenSettings: v }),
 
     setShouldOpenWizard: (v) => set({ shouldOpenWizard: v }),
+
+    setShouldOpenWizardInShortcutMode: (v) => set({ shouldOpenWizardInShortcutMode: v }),
 
     setPendingNewChatMode: (mode) => set({ pendingNewChatMode: mode }),
 

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -347,6 +347,16 @@ const CREATE_TABLES: string[] = [
     value TEXT NOT NULL DEFAULT '',
     updated_at TEXT NOT NULL
   )`,
+  `CREATE TABLE IF NOT EXISTS chat_presets (
+    id TEXT PRIMARY KEY NOT NULL,
+    name TEXT NOT NULL,
+    mode TEXT NOT NULL,
+    is_default TEXT NOT NULL DEFAULT 'false',
+    is_active TEXT NOT NULL DEFAULT 'false',
+    settings TEXT NOT NULL DEFAULT '{}',
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+  )`,
 ];
 
 // ── Column migrations (ALTER TABLE for schema evolution) ──
@@ -503,4 +513,5 @@ export async function runMigrations(db: DB) {
     sql.raw(`CREATE INDEX IF NOT EXISTS idx_memory_chunks_chat ON memory_chunks(chat_id, last_message_at DESC)`),
   );
   await db.run(sql.raw(`CREATE INDEX IF NOT EXISTS idx_custom_themes_active ON custom_themes(is_active)`));
+  await db.run(sql.raw(`CREATE INDEX IF NOT EXISTS idx_chat_presets_mode_active ON chat_presets(mode, is_active)`));
 }

--- a/packages/server/src/db/schema/chat-presets.ts
+++ b/packages/server/src/db/schema/chat-presets.ts
@@ -1,0 +1,20 @@
+// ──────────────────────────────────────────────
+// Schema: Chat Presets
+// ──────────────────────────────────────────────
+import { sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+/** Reusable bundles of chat settings used as defaults for new chats. */
+export const chatPresets = sqliteTable("chat_presets", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+  /** Which chat mode this preset applies to. */
+  mode: text("mode", { enum: ["conversation", "roleplay", "visual_novel"] }).notNull(),
+  /** "true" for the built-in default preset (cannot be deleted, renamed, or saved into). */
+  isDefault: text("is_default").notNull().default("false"),
+  /** "true" for the active preset of its mode (used as starting state for new chats). */
+  isActive: text("is_active").notNull().default("false"),
+  /** JSON-serialized ChatPresetSettings. */
+  settings: text("settings").notNull().default("{}"),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull(),
+});

--- a/packages/server/src/db/schema/index.ts
+++ b/packages/server/src/db/schema/index.ts
@@ -2,6 +2,7 @@
 // Database Schema — Barrel Export
 // ──────────────────────────────────────────────
 export * from "./chats.js";
+export * from "./chat-presets.js";
 export * from "./characters.js";
 export * from "./lorebooks.js";
 export * from "./prompts.js";

--- a/packages/server/src/routes/chat-presets.routes.ts
+++ b/packages/server/src/routes/chat-presets.routes.ts
@@ -1,0 +1,159 @@
+// ──────────────────────────────────────────────
+// Routes: Chat Presets
+// ──────────────────────────────────────────────
+import type { FastifyInstance } from "fastify";
+import {
+  chatModeSchema,
+  createChatPresetSchema,
+  updateChatPresetSchema,
+  chatPresetSettingsSchema,
+  type ChatMode,
+  type ChatPreset,
+  type ChatPresetSettings,
+  type ExportEnvelope,
+} from "@marinara-engine/shared";
+import { createChatPresetsStorage, sanitizePresetSettings } from "../services/storage/chat-presets.storage.js";
+
+function toSafeExportName(name: string, fallback: string) {
+  const sanitized = name.replace(/[<>:"/\\|?*\u0000-\u001f]+/g, " ").replace(/\s+/g, " ").trim();
+  return sanitized || fallback;
+}
+
+interface ChatPresetExportPayload {
+  name: string;
+  mode: ChatMode;
+  settings: ChatPresetSettings;
+}
+
+export async function chatPresetsRoutes(app: FastifyInstance) {
+  const storage = createChatPresetsStorage(app.db);
+
+  // Make sure system defaults exist before serving any request.
+  await storage.ensureDefaults();
+
+  // ── List / Get ──
+
+  app.get("/", async (req) => {
+    const query = req.query as { mode?: string };
+    if (query.mode) {
+      const parsed = chatModeSchema.safeParse(query.mode);
+      if (parsed.success) return storage.listByMode(parsed.data);
+    }
+    return storage.list();
+  });
+
+  app.get<{ Params: { mode: string } }>("/active/:mode", async (req, reply) => {
+    const parsed = chatModeSchema.safeParse(req.params.mode);
+    if (!parsed.success) return reply.status(400).send({ error: "Invalid chat mode" });
+    return (await storage.getActive(parsed.data)) ?? (await storage.getDefault(parsed.data));
+  });
+
+  app.get<{ Params: { id: string } }>("/:id", async (req, reply) => {
+    const preset = await storage.getById(req.params.id);
+    if (!preset) return reply.status(404).send({ error: "Chat preset not found" });
+    return preset;
+  });
+
+  // ── Create / Update ──
+
+  app.post("/", async (req) => {
+    const input = createChatPresetSchema.parse(req.body);
+    return storage.create(input);
+  });
+
+  app.patch<{ Params: { id: string } }>("/:id", async (req, reply) => {
+    const input = updateChatPresetSchema.parse(req.body);
+    const updated = await storage.update(req.params.id, input);
+    if (!updated) return reply.status(404).send({ error: "Chat preset not found" });
+    return updated;
+  });
+
+  /** Save a settings snapshot into a preset (the "Save" button). */
+  app.put<{ Params: { id: string } }>("/:id/settings", async (req, reply) => {
+    const input = chatPresetSettingsSchema.parse(req.body ?? {});
+    const updated = await storage.saveSettings(req.params.id, input);
+    if (!updated) return reply.status(404).send({ error: "Chat preset not found" });
+    return updated;
+  });
+
+  /** Duplicate a preset (the "Save As" button). */
+  app.post<{ Params: { id: string } }>("/:id/duplicate", async (req, reply) => {
+    const body = (req.body ?? {}) as { name?: string };
+    const duplicated = await storage.duplicate(req.params.id, body.name);
+    if (!duplicated) return reply.status(404).send({ error: "Chat preset not found" });
+    return duplicated;
+  });
+
+  /** Mark a preset as the active one for its mode. */
+  app.post<{ Params: { id: string } }>("/:id/set-active", async (req, reply) => {
+    const updated = await storage.setActive(req.params.id);
+    if (!updated) return reply.status(404).send({ error: "Chat preset not found" });
+    return updated;
+  });
+
+  /** Apply a preset's settings to an existing chat (replaces preset-controlled settings). */
+  app.post<{ Params: { id: string; chatId: string } }>("/:id/apply/:chatId", async (req, reply) => {
+    const updated = await storage.applyToChat(req.params.id, req.params.chatId);
+    if (!updated) return reply.status(404).send({ error: "Preset or chat not found" });
+    return updated;
+  });
+
+  // ── Delete ──
+
+  app.delete<{ Params: { id: string } }>("/:id", async (req, reply) => {
+    const removed = await storage.remove(req.params.id);
+    if (!removed) {
+      const existing = await storage.getById(req.params.id);
+      if (!existing) return reply.status(404).send({ error: "Chat preset not found" });
+      return reply.status(400).send({ error: "Cannot delete the default preset" });
+    }
+    return reply.status(204).send();
+  });
+
+  // ── Export ──
+
+  app.get<{ Params: { id: string } }>("/:id/export", async (req, reply) => {
+    const preset = await storage.getById(req.params.id);
+    if (!preset) return reply.status(404).send({ error: "Chat preset not found" });
+    const payload: ChatPresetExportPayload = {
+      name: preset.name,
+      mode: preset.mode,
+      settings: preset.settings,
+    };
+    const envelope: ExportEnvelope<ChatPresetExportPayload> = {
+      type: "marinara_chat_preset",
+      version: 1,
+      exportedAt: new Date().toISOString(),
+      data: payload,
+    };
+    return reply
+      .header(
+        "Content-Disposition",
+        `attachment; filename="${encodeURIComponent(toSafeExportName(preset.name, "chat-preset"))}.marinara-chat-preset.json"`,
+      )
+      .header("Content-Type", "application/json")
+      .send(envelope);
+  });
+
+  // ── Import ──
+
+  app.post("/import", async (req, reply) => {
+    const body = req.body as Partial<ExportEnvelope<ChatPresetExportPayload>> | null;
+    if (!body || body.type !== "marinara_chat_preset" || !body.data) {
+      return reply.status(400).send({ error: "Invalid chat preset envelope" });
+    }
+    const data = body.data;
+    const modeParsed = chatModeSchema.safeParse(data.mode);
+    if (!modeParsed.success) return reply.status(400).send({ error: "Invalid chat mode in envelope" });
+    if (typeof data.name !== "string" || !data.name.trim()) {
+      return reply.status(400).send({ error: "Preset name is required" });
+    }
+    const settings = sanitizePresetSettings(data.settings ?? {});
+    const created = (await storage.importPreset({
+      name: data.name.trim().slice(0, 120),
+      mode: modeParsed.data,
+      settings,
+    })) as ChatPreset | null;
+    return created;
+  });
+}

--- a/packages/server/src/routes/index.ts
+++ b/packages/server/src/routes/index.ts
@@ -37,6 +37,7 @@ import { botBrowserChartavernRoutes } from "./bot-browser-chartavern.routes.js";
 import { botBrowserPygmalionRoutes } from "./bot-browser-pygmalion.routes.js";
 import { botBrowserWyvernRoutes } from "./bot-browser-wyvern.routes.js";
 import { chatFoldersRoutes } from "./chat-folders.routes.js";
+import { chatPresetsRoutes } from "./chat-presets.routes.js";
 import { updatesRoutes } from "./updates.routes.js";
 import { themesRoutes } from "./themes.routes.js";
 import { appSettingsRoutes } from "./app-settings.routes.js";
@@ -44,6 +45,7 @@ import { appSettingsRoutes } from "./app-settings.routes.js";
 export async function registerRoutes(app: FastifyInstance) {
   await app.register(chatsRoutes, { prefix: "/api/chats" });
   await app.register(chatFoldersRoutes, { prefix: "/api/chat-folders" });
+  await app.register(chatPresetsRoutes, { prefix: "/api/chat-presets" });
   await app.register(charactersRoutes, { prefix: "/api/characters" });
   await app.register(lorebooksRoutes, { prefix: "/api/lorebooks" });
   await app.register(promptsRoutes, { prefix: "/api/prompts" });

--- a/packages/server/src/services/storage/chat-presets.storage.ts
+++ b/packages/server/src/services/storage/chat-presets.storage.ts
@@ -1,0 +1,306 @@
+// ──────────────────────────────────────────────
+// Storage: Chat Presets
+// ──────────────────────────────────────────────
+// CRUD for the saved chat-settings bundles applied to new chats.
+// One preset per mode is marked active and used as the starting state.
+import { eq, and, ne, asc } from "drizzle-orm";
+import type { DB } from "../../db/connection.js";
+import { chats, chatPresets } from "../../db/schema/index.js";
+import { newId, now } from "../../utils/id-generator.js";
+import {
+  CHAT_PRESET_EXCLUDED_METADATA_KEYS,
+  type ChatMode,
+  type ChatPresetSettings,
+  type CreateChatPresetInput,
+  type UpdateChatPresetInput,
+} from "@marinara-engine/shared";
+
+const CHAT_MODES: ChatMode[] = ["conversation", "roleplay", "visual_novel"];
+const EXCLUDED_METADATA_SET = new Set(CHAT_PRESET_EXCLUDED_METADATA_KEYS);
+
+interface ChatPresetRow {
+  id: string;
+  name: string;
+  mode: string;
+  isDefault: string;
+  isActive: string;
+  settings: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+function rowToPreset(row: ChatPresetRow) {
+  let settings: ChatPresetSettings = {};
+  try {
+    settings = row.settings ? (JSON.parse(row.settings) as ChatPresetSettings) : {};
+  } catch {
+    settings = {};
+  }
+  return {
+    id: row.id,
+    name: row.name,
+    mode: row.mode as ChatMode,
+    isDefault: row.isDefault === "true",
+    isActive: row.isActive === "true",
+    settings,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+/** Strip chat-specific keys from a metadata object before saving into a preset. */
+export function sanitizePresetMetadata(metadata: Record<string, unknown> | undefined | null) {
+  if (!metadata || typeof metadata !== "object") return {};
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(metadata)) {
+    if (EXCLUDED_METADATA_SET.has(key)) continue;
+    out[key] = value;
+  }
+  return out;
+}
+
+/** Strip chat-specific keys from a settings object before saving into a preset. */
+export function sanitizePresetSettings(input: ChatPresetSettings | undefined | null): ChatPresetSettings {
+  if (!input) return {};
+  const out: ChatPresetSettings = {};
+  if ("connectionId" in input) out.connectionId = input.connectionId ?? null;
+  if ("promptPresetId" in input) out.promptPresetId = input.promptPresetId ?? null;
+  if (input.metadata) out.metadata = sanitizePresetMetadata(input.metadata as Record<string, unknown>);
+  return out;
+}
+
+export function createChatPresetsStorage(db: DB) {
+  const storage = {
+    async list() {
+      const rows = (await db.select().from(chatPresets).orderBy(asc(chatPresets.mode), asc(chatPresets.name))) as ChatPresetRow[];
+      return rows.map(rowToPreset);
+    },
+
+    async listByMode(mode: ChatMode) {
+      const rows = (await db
+        .select()
+        .from(chatPresets)
+        .where(eq(chatPresets.mode, mode))
+        .orderBy(asc(chatPresets.name))) as ChatPresetRow[];
+      return rows.map(rowToPreset);
+    },
+
+    async getById(id: string) {
+      const rows = (await db.select().from(chatPresets).where(eq(chatPresets.id, id))) as ChatPresetRow[];
+      return rows[0] ? rowToPreset(rows[0]) : null;
+    },
+
+    async getActive(mode: ChatMode) {
+      const rows = (await db
+        .select()
+        .from(chatPresets)
+        .where(and(eq(chatPresets.mode, mode), eq(chatPresets.isActive, "true")))) as ChatPresetRow[];
+      return rows[0] ? rowToPreset(rows[0]) : null;
+    },
+
+    async getDefault(mode: ChatMode) {
+      const rows = (await db
+        .select()
+        .from(chatPresets)
+        .where(and(eq(chatPresets.mode, mode), eq(chatPresets.isDefault, "true")))) as ChatPresetRow[];
+      return rows[0] ? rowToPreset(rows[0]) : null;
+    },
+
+    async create(input: CreateChatPresetInput) {
+      const id = newId();
+      const ts = now();
+      const cleaned = sanitizePresetSettings(input.settings as ChatPresetSettings);
+      await db.insert(chatPresets).values({
+        id,
+        name: input.name,
+        mode: input.mode,
+        isDefault: "false",
+        isActive: "false",
+        settings: JSON.stringify(cleaned),
+        createdAt: ts,
+        updatedAt: ts,
+      });
+      return storage.getById(id);
+    },
+
+    async update(id: string, data: UpdateChatPresetInput) {
+      const existing = await storage.getById(id);
+      if (!existing) return null;
+      const patch: Record<string, unknown> = { updatedAt: now() };
+      if (data.name !== undefined) patch.name = data.name;
+      if (data.settings !== undefined) {
+        // Default preset must always have empty settings — refuse to write into it.
+        if (existing.isDefault) {
+          patch.settings = JSON.stringify({});
+        } else {
+          patch.settings = JSON.stringify(sanitizePresetSettings(data.settings as ChatPresetSettings));
+        }
+      }
+      await db.update(chatPresets).set(patch).where(eq(chatPresets.id, id));
+      return storage.getById(id);
+    },
+
+    /** Replace the preset's settings with a sanitized snapshot (used by "Save" button). */
+    async saveSettings(id: string, settings: ChatPresetSettings) {
+      const existing = await storage.getById(id);
+      if (!existing) return null;
+      if (existing.isDefault) return existing; // never mutate the default preset's settings
+      const cleaned = sanitizePresetSettings(settings);
+      await db
+        .update(chatPresets)
+        .set({ settings: JSON.stringify(cleaned), updatedAt: now() })
+        .where(eq(chatPresets.id, id));
+      return storage.getById(id);
+    },
+
+    async remove(id: string) {
+      const existing = await storage.getById(id);
+      if (!existing) return false;
+      if (existing.isDefault) return false; // refuse to delete the system default
+      await db.delete(chatPresets).where(eq(chatPresets.id, id));
+      // If we deleted the active preset, fall back to the default for that mode.
+      if (existing.isActive) {
+        const fallback = await storage.getDefault(existing.mode);
+        if (fallback) await storage.setActive(fallback.id);
+      }
+      return true;
+    },
+
+    async setActive(id: string) {
+      const target = await storage.getById(id);
+      if (!target) return null;
+      const ts = now();
+      // Clear any other active flag for this mode, then set this one.
+      await db
+        .update(chatPresets)
+        .set({ isActive: "false", updatedAt: ts })
+        .where(and(eq(chatPresets.mode, target.mode), ne(chatPresets.id, id)));
+      await db
+        .update(chatPresets)
+        .set({ isActive: "true", updatedAt: ts })
+        .where(eq(chatPresets.id, id));
+      return storage.getById(id);
+    },
+
+    async duplicate(id: string, newName?: string) {
+      const source = await storage.getById(id);
+      if (!source) return null;
+      const newPresetId = newId();
+      const ts = now();
+      await db.insert(chatPresets).values({
+        id: newPresetId,
+        name: newName ?? `${source.name} Copy`,
+        mode: source.mode,
+        isDefault: "false",
+        isActive: "false",
+        settings: JSON.stringify(sanitizePresetSettings(source.settings)),
+        createdAt: ts,
+        updatedAt: ts,
+      });
+      return storage.getById(newPresetId);
+    },
+
+    /** Insert a preset from an imported envelope. Always created as inactive, non-default. */
+    async importPreset(payload: { name: string; mode: ChatMode; settings: ChatPresetSettings }) {
+      return storage.create({
+        name: payload.name,
+        mode: payload.mode,
+        settings: sanitizePresetSettings(payload.settings),
+      });
+    },
+
+    /**
+     * Replace a chat's preset-controlled settings with those from a preset.
+     *
+     * Chat-specific keys (sprites, summary, tags, scene prompt, ephemeral
+     * lorebook overrides, group scenario, etc.) are preserved from the
+     * existing chat metadata. Everything else is reset to the preset's
+     * snapshot, with system defaults filled in for keys the preset doesn't
+     * specify. Selecting the Default preset therefore resets the chat's
+     * preset-controlled settings to their system defaults.
+     */
+    async applyToChat(presetId: string, chatId: string) {
+      const preset = await storage.getById(presetId);
+      if (!preset) return null;
+      const rows = await db.select().from(chats).where(eq(chats.id, chatId));
+      const chatRow = rows[0];
+      if (!chatRow) return null;
+
+      const currentMetadata: Record<string, unknown> = (() => {
+        try {
+          return chatRow.metadata ? JSON.parse(chatRow.metadata) : {};
+        } catch {
+          return {};
+        }
+      })();
+
+      // Preserve only chat-specific (non-preset) metadata keys.
+      const preserved: Record<string, unknown> = {};
+      for (const key of CHAT_PRESET_EXCLUDED_METADATA_KEYS) {
+        if (key in currentMetadata) preserved[key] = currentMetadata[key];
+      }
+
+      const baseDefaults: Record<string, unknown> = {
+        summary: null,
+        tags: [],
+        enableAgents: true,
+        agentOverrides: {},
+        activeAgentIds: [],
+        activeToolIds: [],
+      };
+
+      const presetMetadata = (preset.settings.metadata ?? {}) as Record<string, unknown>;
+
+      const newMetadata: Record<string, unknown> = {
+        ...baseDefaults,
+        ...presetMetadata,
+        ...preserved,
+        appliedChatPresetId: preset.id,
+      };
+
+      const ts = now();
+      await db
+        .update(chats)
+        .set({
+          connectionId: preset.settings.connectionId ?? null,
+          promptPresetId: preset.settings.promptPresetId ?? null,
+          metadata: JSON.stringify(newMetadata),
+          updatedAt: ts,
+        })
+        .where(eq(chats.id, chatId));
+
+      const updatedRows = await db.select().from(chats).where(eq(chats.id, chatId));
+      return updatedRows[0] ?? null;
+    },
+
+    /** Ensure a "Default" preset exists for every chat mode and exactly one preset is active per mode. */
+    async ensureDefaults() {
+      for (const mode of CHAT_MODES) {
+        const existing = await storage.getDefault(mode);
+        let defaultId = existing?.id ?? null;
+        if (!defaultId) {
+          const id = newId();
+          const ts = now();
+          await db.insert(chatPresets).values({
+            id,
+            name: "Default",
+            mode,
+            isDefault: "true",
+            isActive: "false",
+            settings: JSON.stringify({}),
+            createdAt: ts,
+            updatedAt: ts,
+          });
+          defaultId = id;
+        }
+        const active = await storage.getActive(mode);
+        if (!active && defaultId) {
+          await storage.setActive(defaultId);
+        }
+      }
+    },
+  };
+  return storage;
+}
+
+export type ChatPresetsStorage = ReturnType<typeof createChatPresetsStorage>;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -18,9 +18,11 @@ export * from "./types/regex.js";
 export * from "./types/export.js";
 export * from "./types/haptic.js";
 export * from "./types/theme.js";
+export * from "./types/chat-preset.js";
 
 // Schemas
 export * from "./schemas/chat.schema.js";
+export * from "./schemas/chat-preset.schema.js";
 export * from "./schemas/character.schema.js";
 export * from "./schemas/lorebook.schema.js";
 export * from "./schemas/prompt.schema.js";

--- a/packages/shared/src/schemas/chat-preset.schema.ts
+++ b/packages/shared/src/schemas/chat-preset.schema.ts
@@ -1,0 +1,30 @@
+// ──────────────────────────────────────────────
+// Chat Preset Zod Schemas
+// ──────────────────────────────────────────────
+import { z } from "zod";
+import { chatModeSchema } from "./chat.schema.js";
+
+export const chatPresetSettingsSchema = z
+  .object({
+    connectionId: z.string().nullable().optional(),
+    promptPresetId: z.string().nullable().optional(),
+    metadata: z.record(z.unknown()).optional(),
+  })
+  .strict();
+
+export const createChatPresetSchema = z.object({
+  name: z.string().min(1).max(120),
+  mode: chatModeSchema,
+  settings: chatPresetSettingsSchema.default({}),
+});
+
+export const updateChatPresetSchema = z
+  .object({
+    name: z.string().min(1).max(120).optional(),
+    settings: chatPresetSettingsSchema.optional(),
+  })
+  .strict();
+
+export type CreateChatPresetInput = z.infer<typeof createChatPresetSchema>;
+export type UpdateChatPresetInput = z.infer<typeof updateChatPresetSchema>;
+export type ChatPresetSettingsInput = z.infer<typeof chatPresetSettingsSchema>;

--- a/packages/shared/src/types/chat-preset.ts
+++ b/packages/shared/src/types/chat-preset.ts
@@ -1,0 +1,61 @@
+// ──────────────────────────────────────────────
+// Chat Preset Types
+// ──────────────────────────────────────────────
+// Reusable bundles of chat settings that the user can apply as defaults
+// when creating new chats. One "active" preset per chat mode determines
+// the starting state for any newly created chat in that mode.
+//
+// What presets DO carry: connection, prompt preset, and most metadata
+// (agents, tools, lorebooks, translation, advanced parameters, context
+// limit, memory recall, discord mirror, etc.).
+//
+// What presets DO NOT carry: per-chat identity (name, characters,
+// persona, group, sprites, scene prompt, summary, tags, ephemeral
+// lorebook overrides, connected chat link, folder/sort placement).
+
+import type { ChatMode, ChatMetadata } from "./chat.js";
+
+/** Settings stored in a chat preset. All fields optional — only set ones override defaults. */
+export interface ChatPresetSettings {
+  /** Top-level chat fields */
+  connectionId?: string | null;
+  promptPresetId?: string | null;
+  /** Subset of ChatMetadata — chat-specific keys (sprites, summary, tags, etc.) are stripped before saving. */
+  metadata?: Partial<ChatMetadata>;
+}
+
+/** A chat preset stored in the database. */
+export interface ChatPreset {
+  id: string;
+  name: string;
+  /** Which chat mode this preset applies to. */
+  mode: ChatMode;
+  /** True for the built-in "Default" preset (cannot be deleted, renamed, or saved into). */
+  isDefault: boolean;
+  /** True for the preset currently used as the starting state for new chats of this mode. */
+  isActive: boolean;
+  /** Bundled chat settings (JSON). */
+  settings: ChatPresetSettings;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** Metadata keys that must NOT be saved into a preset (chat-specific). */
+export const CHAT_PRESET_EXCLUDED_METADATA_KEYS: readonly string[] = [
+  "summary",
+  "tags",
+  "spriteCharacterIds",
+  "spritePlacements",
+  "entryStateOverrides",
+  "groupScenarioOverride",
+  "groupScenarioText",
+  "sceneSystemPrompt",
+  // Lorebooks are owned by the chat, never by the preset.
+  "activeLorebookIds",
+] as const;
+
+/** Top-level chat keys that CAN be saved into a preset. */
+export const CHAT_PRESET_INCLUDED_CHAT_KEYS: readonly string[] = [
+  "connectionId",
+  "promptPresetId",
+] as const;

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -100,6 +100,8 @@ export interface ChatMetadata {
   /** Per-chat ephemeral / enabled overrides for lorebook entries (entryId → state).
    *  Tracked per-chat so ephemeral countdown in one chat doesn't affect others. */
   entryStateOverrides?: Record<string, { ephemeral?: number | null; enabled?: boolean }>;
+  /** ID of the chat preset most recently applied to this chat (drives the preset bar dropdown). */
+  appliedChatPresetId?: string | null;
   /** Any extra key-value data */
   [key: string]: unknown;
 }

--- a/packages/shared/src/types/export.ts
+++ b/packages/shared/src/types/export.ts
@@ -8,6 +8,7 @@ export type ExportType =
   | "marinara_persona"
   | "marinara_lorebook"
   | "marinara_preset"
+  | "marinara_chat_preset"
   | "marinara_profile";
 
 /** Wrapper envelope for exported data. */


### PR DESCRIPTION
## Summary

Adds a per-mode chat-settings preset system so users don't have to reconfigure every new conversation/roleplay from scratch. A preset bundles a chat's connection, prompt preset, agents, tools, translation, memory recall, advanced parameters, autonomous messaging, and similar reusable settings — and explicitly does **not** touch characters, persona, lorebooks, sprites, summary, tags, or scene prompt (those stay tied to the chat).

## What's new

**Preset bar at the top of Chat Settings drawer**
- Dropdown of presets for the current mode (conversation / roleplay).
- Selecting a preset **immediately applies** its settings to the current chat. Selecting Default resets preset-controlled fields back to system defaults; chat-specific fields are preserved across switches.
- One-row of actions: Save, Rename, Save As, Import, Export, Delete.
- Default preset is auto-seeded per mode and cannot be renamed, deleted, or saved into.
- Deleting the currently-applied preset auto-applies Default so the chat doesn't silently keep the deleted preset's values.
- `?` HelpTooltip explains what the preset does and doesn't carry.
- Conversation and roleplay each have their own list of presets (no cross-mode bleed).

**Wizard**
- New "Use Settings Presets" button between Skip and Next opens a Quick Setup view (Preset / Persona / Characters) for one-shot configuration of a new roleplay.

**Right-click context menu on character rows**
- Characters panel, group members, and the Browser panel all support right-click → "Quick Start Roleplay" / "Quick Start Conversation".
- Creates the chat with that character pre-added and lands directly on the Quick Setup view via a new ` shouldOpenWizardInShortcutMode` chat-store flag.
- Suppressed in selection mode and group-assignment mode so it doesn't fight those flows.

## New entities

- `chat_presets` table (`id`, `name`, `mode`, `is_default`, `is_active`, `settings` JSON, timestamps) — created via the existing idempotent runtime migration in `migrate.ts`.
- `/api/chat-presets` routes: list / get / create / update / delete, `PUT /:id/settings` (Save), `POST /:id/duplicate` (Save As), `POST /:id/set-active`, `POST /:id/apply/:chatId`, `GET /:id/export`, `POST /import`.
- `ChatPreset`, `ChatPresetSettings` shared types + Zod schemas.
- `ContextMenu` reusable UI component (portal-rendered, viewport-clamped, closes on outside click / Escape / scroll / resize).

## Test plan

- [x] Open Chat Settings on a roleplay → see preset bar with Default selected, `?` tooltip readable.
- [x] Tweak settings (agents, advanced parameters, etc.) → click Save As → name it → confirm new preset appears in dropdown and is applied.
- [x] Switch back to Default → confirm preset-controlled settings reset, but characters / persona / lorebooks / sprites / summary unchanged.
- [x] Switch to the saved preset → confirm settings restored.
- [x] Save into the preset (overwrite), Rename, Export (downloads `.marinara-chat-preset.json`), Import (re-uploads it), Delete (with currently-applied preset → confirm settings reset to default).
- [x] Repeat for a conversation chat — confirm presets are scoped per-mode.
- [x] Lorebook test: add a lorebook to a chat, switch presets → lorebook stays.
- [x] New roleplay → wizard appears with "Use Settings Presets" button between Skip and Next; clicking opens Quick Setup with three pickers.
- [x] Right-click a character in the Characters panel → "Quick Start Roleplay" / "Quick Start Conversation" → new chat opens with character pre-added, directly on Quick Setup view.
- [x] Right-click a group member → same menu works.
- [x] Right-click an imported character in the Browser panel → same menu works.
- [x] `pnpm check` passes.