### PR TITLE
fix(chat): Inject character first message on Quick Start Roleplay

### DIFF
--- a/packages/client/src/components/panels/BotBrowserPanel.tsx
+++ b/packages/client/src/components/panels/BotBrowserPanel.tsx
@@ -2,10 +2,12 @@
 // Panel: Browser (sidebar — shows imported characters)
 // ──────────────────────────────────────────────
 import { useState, useMemo, useCallback } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { useCharacters } from "../../hooks/use-characters";
-import { useCreateChat } from "../../hooks/use-chats";
+import { useCreateChat, chatKeys } from "../../hooks/use-chats";
 import { useUIStore } from "../../stores/ui.store";
 import { useChatStore } from "../../stores/chat.store";
+import { api } from "../../lib/api-client";
 import { Search, User, Globe, Wand2, MessageCircle } from "lucide-react";
 import { cn, getAvatarCropStyle } from "../../lib/utils";
 import { ContextMenu, type ContextMenuItem } from "../ui/ContextMenu";
@@ -18,10 +20,16 @@ export function BotBrowserPanel() {
   const openBotBrowser = useUIStore((s) => s.openBotBrowser);
   const botBrowserOpen = useUIStore((s) => s.botBrowserOpen);
   const createChat = useCreateChat();
+  const queryClient = useQueryClient();
   const [search, setSearch] = useState("");
-  const [contextMenu, setContextMenu] = useState<{ x: number; y: number; charId: string; charName: string } | null>(
-    null,
-  );
+  const [contextMenu, setContextMenu] = useState<{
+    x: number;
+    y: number;
+    charId: string;
+    charName: string;
+    firstMes?: string;
+    altGreetings?: string[];
+  } | null>(null);
 
   const parsed = useMemo(() => {
     if (!characters) return [];
@@ -42,14 +50,58 @@ export function BotBrowserPanel() {
     return parsed.filter((c) => c.name.toLowerCase().includes(q));
   }, [parsed, search]);
 
+  const getCharacterGreeting = useCallback(
+    (charId: string): { firstMes?: string; altGreetings: string[] } => {
+      const raw = (characters as CharacterRow[] | undefined)?.find((c) => c.id === charId);
+      if (!raw) return { altGreetings: [] };
+      try {
+        const d = JSON.parse(raw.data) as { first_mes?: string; alternate_greetings?: string[] };
+        return { firstMes: d.first_mes, altGreetings: d.alternate_greetings ?? [] };
+      } catch {
+        return { altGreetings: [] };
+      }
+    },
+    [characters],
+  );
+
   const quickStartFromCharacter = useCallback(
-    (charId: string, charName: string, mode: "roleplay" | "conversation") => {
+    (
+      charId: string,
+      charName: string,
+      mode: "roleplay" | "conversation",
+      firstMes?: string,
+      altGreetings?: string[],
+    ) => {
       const label = mode === "conversation" ? "Conversation" : "Roleplay";
       createChat.mutate(
         { name: charName ? `${charName} — ${label}` : `New ${label}`, mode, characterIds: [charId] },
         {
-          onSuccess: (chat) => {
+          onSuccess: async (chat) => {
             useChatStore.getState().setActiveChatId(chat.id);
+            // Mirror the wizard's roleplay first-message behavior so the
+            // character actually greets the user in the new chat.
+            if (mode === "roleplay" && firstMes?.trim()) {
+              try {
+                const msg = await api.post<{ id: string }>(`/chats/${chat.id}/messages`, {
+                  role: "assistant",
+                  content: firstMes,
+                  characterId: charId,
+                });
+                if (msg?.id && altGreetings?.length) {
+                  for (const greeting of altGreetings) {
+                    if (greeting.trim()) {
+                      await api.post(`/chats/${chat.id}/messages/${msg.id}/swipes`, {
+                        content: greeting,
+                        silent: true,
+                      });
+                    }
+                  }
+                }
+                queryClient.invalidateQueries({ queryKey: chatKeys.messages(chat.id) });
+              } catch {
+                /* swallow — don't block the chat from opening if greeting injection fails */
+              }
+            }
             useChatStore.getState().setShouldOpenSettings(true);
             useChatStore.getState().setShouldOpenWizard(true);
             useChatStore.getState().setShouldOpenWizardInShortcutMode(true);
@@ -57,7 +109,7 @@ export function BotBrowserPanel() {
         },
       );
     },
-    [createChat],
+    [createChat, queryClient],
   );
 
   return (
@@ -103,7 +155,15 @@ export function BotBrowserPanel() {
               onClick={() => openCharacterDetail(char.id)}
               onContextMenu={(e) => {
                 e.preventDefault();
-                setContextMenu({ x: e.clientX, y: e.clientY, charId: char.id, charName: char.name });
+                const greeting = getCharacterGreeting(char.id);
+                setContextMenu({
+                  x: e.clientX,
+                  y: e.clientY,
+                  charId: char.id,
+                  charName: char.name,
+                  firstMes: greeting.firstMes,
+                  altGreetings: greeting.altGreetings,
+                });
               }}
               className="group flex items-center gap-2.5 rounded-xl p-2 text-left transition-all hover:bg-[var(--sidebar-accent)]"
             >
@@ -132,7 +192,14 @@ export function BotBrowserPanel() {
             {
               label: "Quick Start Roleplay",
               icon: <Wand2 size="0.75rem" />,
-              onSelect: () => quickStartFromCharacter(contextMenu.charId, contextMenu.charName, "roleplay"),
+              onSelect: () =>
+                quickStartFromCharacter(
+                  contextMenu.charId,
+                  contextMenu.charName,
+                  "roleplay",
+                  contextMenu.firstMes,
+                  contextMenu.altGreetings,
+                ),
             },
             {
               label: "Quick Start Conversation",

--- a/packages/client/src/components/panels/CharactersPanel.tsx
+++ b/packages/client/src/components/panels/CharactersPanel.tsx
@@ -92,18 +92,53 @@ export function CharactersPanel() {
   const createMessage = useCreateMessage(activeChat?.id ?? null);
   const createChat = useCreateChat();
   const queryClient = useQueryClient();
-  const [contextMenu, setContextMenu] = useState<{ x: number; y: number; charId: string; charName: string } | null>(
-    null,
-  );
+  const [contextMenu, setContextMenu] = useState<{
+    x: number;
+    y: number;
+    charId: string;
+    charName: string;
+    firstMes?: string;
+    altGreetings?: string[];
+  } | null>(null);
 
   const quickStartFromCharacter = useCallback(
-    (charId: string, charName: string, mode: "roleplay" | "conversation") => {
+    (
+      charId: string,
+      charName: string,
+      mode: "roleplay" | "conversation",
+      firstMes?: string,
+      altGreetings?: string[],
+    ) => {
       const label = mode === "conversation" ? "Conversation" : "Roleplay";
       createChat.mutate(
         { name: charName ? `${charName} — ${label}` : `New ${label}`, mode, characterIds: [charId] },
         {
-          onSuccess: (chat) => {
+          onSuccess: async (chat) => {
             useChatStore.getState().setActiveChatId(chat.id);
+            // Mirror the wizard's roleplay first-message behavior — without this,
+            // a quick-started roleplay would open with no greeting from the character.
+            if (mode === "roleplay" && firstMes?.trim()) {
+              try {
+                const msg = await api.post<{ id: string }>(`/chats/${chat.id}/messages`, {
+                  role: "assistant",
+                  content: firstMes,
+                  characterId: charId,
+                });
+                if (msg?.id && altGreetings?.length) {
+                  for (const greeting of altGreetings) {
+                    if (greeting.trim()) {
+                      await api.post(`/chats/${chat.id}/messages/${msg.id}/swipes`, {
+                        content: greeting,
+                        silent: true,
+                      });
+                    }
+                  }
+                }
+                queryClient.invalidateQueries({ queryKey: chatKeys.messages(chat.id) });
+              } catch {
+                /* swallow — don't block the chat from opening if greeting injection fails */
+              }
+            }
             useChatStore.getState().setShouldOpenSettings(true);
             useChatStore.getState().setShouldOpenWizard(true);
             useChatStore.getState().setShouldOpenWizardInShortcutMode(true);
@@ -111,7 +146,7 @@ export function CharactersPanel() {
         },
       );
     },
-    [createChat],
+    [createChat, queryClient],
   );
 
   const [search, setSearch] = useState("");
@@ -749,7 +784,15 @@ export function CharactersPanel() {
                             onContextMenu={(e) => {
                               if (selectionMode || assigningToGroup) return;
                               e.preventDefault();
-                              setContextMenu({ x: e.clientX, y: e.clientY, charId: memberId, charName: member.name });
+                              const fullMember = parsedCharacters.find((c) => c.id === memberId);
+                              setContextMenu({
+                                x: e.clientX,
+                                y: e.clientY,
+                                charId: memberId,
+                                charName: member.name,
+                                firstMes: fullMember?.parsed?.first_mes as string | undefined,
+                                altGreetings: (fullMember?.parsed?.alternate_greetings ?? []) as string[],
+                              });
                             }}
                             className="group/member flex cursor-pointer items-center gap-2 rounded-lg p-1.5 transition-all hover:bg-[var(--sidebar-accent)]"
                           >
@@ -861,7 +904,14 @@ export function CharactersPanel() {
               onContextMenu={(e) => {
                 if (selectionMode || assigningToGroup) return;
                 e.preventDefault();
-                setContextMenu({ x: e.clientX, y: e.clientY, charId: char.id, charName });
+                setContextMenu({
+                  x: e.clientX,
+                  y: e.clientY,
+                  charId: char.id,
+                  charName,
+                  firstMes: char.parsed?.first_mes as string | undefined,
+                  altGreetings: (char.parsed?.alternate_greetings ?? []) as string[],
+                });
               }}
               className={cn(
                 "group flex items-center gap-2.5 rounded-xl p-2 transition-all hover:bg-[var(--sidebar-accent)] cursor-pointer",
@@ -1032,7 +1082,14 @@ export function CharactersPanel() {
             {
               label: "Quick Start Roleplay",
               icon: <Wand2 size="0.75rem" />,
-              onSelect: () => quickStartFromCharacter(contextMenu.charId, contextMenu.charName, "roleplay"),
+              onSelect: () =>
+                quickStartFromCharacter(
+                  contextMenu.charId,
+                  contextMenu.charName,
+                  "roleplay",
+                  contextMenu.firstMes,
+                  contextMenu.altGreetings,
+                ),
             },
             {
               label: "Quick Start Conversation",


### PR DESCRIPTION
## Summary

Right-clicking a character and choosing **Quick Start Roleplay** was creating the chat with the character attached but never seeding the character's `first_mes` greeting, so the new chat opened empty. The wizard's `toggleCharacter` flow handles this for the normal "add a character" path; the right-click shortcut bypassed it.

## Fix

- Capture `first_mes` + `alternate_greetings` at right-click time (alongside `charId` / `charName`).
- In `quickStartFromCharacter`'s `createChat.onSuccess`, when `mode === "roleplay"` and a `first_mes` exists:
  - Post it as the first assistant message on the new chat.
  - Post any alternate greetings as silent swipes on that message.
  - Invalidate `chatKeys.messages(chat.id)` so the chat surface picks them up.
- Conversation mode is intentionally skipped — matches the existing wizard behavior (no auto-greeting for conversations).
- Greeting injection failures are swallowed so they never block the chat from opening.

Applies to all three right-click surfaces:
- Characters panel rows
- Group member rows (inside an expanded group)
- Browser panel imported-character rows
