### PR TITLE
fix(client): Render ordered lists with correct start number

### DIFF
--- a/packages/client/src/components/chat/ConversationView.tsx
+++ b/packages/client/src/components/chat/ConversationView.tsx
@@ -310,19 +310,37 @@ export function ConversationView({
           return true;
         });
         if (lines.length > 1) {
-          lines.forEach((line, li) => {
-            const isLast = li === lines.length - 1;
+          // Group consecutive list items (ordered or unordered) into single
+          // blocks so numbered / bullet lists render correctly instead of
+          // each item becoming its own <ol> / <ul>.
+          const LIST_LINE_RE = /^\s*(?:[-*+]|\d+\.)\s/;
+          const blocks: string[][] = [];
+          for (const line of lines) {
+            const isList = LIST_LINE_RE.test(line);
+            const prev = blocks[blocks.length - 1];
+            if (isList && prev && LIST_LINE_RE.test(prev[0]!)) {
+              // Continue the current list block
+              prev.push(line);
+            } else {
+              // Start a new block
+              blocks.push([line]);
+            }
+          }
+
+          blocks.forEach((block, bi) => {
+            const isLast = bi === blocks.length - 1;
+            const content = block.join("\n");
             items.push({
               type: "message",
-              key: `${msg.id}__line${li}`,
+              key: `${msg.id}__block${bi}`,
               msg: isLast
-                ? { ...msg, content: line }
+                ? { ...msg, content }
                 : {
                     ...msg,
-                    content: line,
+                    content,
                     extra: { displayText: null, isGenerated: false, tokenCount: null, generationInfo: null },
                   },
-              isGrouped: li === 0 ? grouped : true,
+              isGrouped: bi === 0 ? grouped : true,
               index: messageOffset + i,
             });
           });

--- a/packages/client/src/lib/markdown.tsx
+++ b/packages/client/src/lib/markdown.tsx
@@ -156,7 +156,7 @@ const TASK_ITEM_RE = /^(\s*)[-*+] \[([ xX])\]\s+(.+)/;
 const UL_ITEM_RE = /^(\s*)[*+-]\s+(.+)/;
 
 /** Regex to match an ordered list item (1., 2., …). */
-const OL_ITEM_RE = /^(\s*)\d+\.\s+(.+)/;
+const OL_ITEM_RE = /^(\s*)(\d+)\.\s+(.+)/;
 
 /** Regex to match a table row: starts and ends with |. */
 const TABLE_ROW_RE = /^\|(.+)\|$/;
@@ -180,6 +180,8 @@ interface ListItem {
   indent: number;
   /** undefined = regular item, false = unchecked task, true = checked task */
   task?: boolean;
+  /** For ordered lists: the number written in markdown (used for the start attribute) */
+  start?: number;
 }
 
 // ── Table helpers ──
@@ -275,8 +277,11 @@ function renderList(
     className = "mari-md-ul";
   }
 
+  // Use the start number from the first item so "3. foo" renders starting at 3
+  const startAttr = ordered && items[0]?.start != null && items[0].start !== 1 ? items[0].start : undefined;
+
   return (
-    <Tag key={blockKey} className={className}>
+    <Tag key={blockKey} className={className} {...(startAttr != null ? { start: startAttr } : {})}>
       {elements}
     </Tag>
   );
@@ -567,7 +572,7 @@ export function renderMarkdownBlocks(
         flushList();
         listOrdered = true;
       }
-      listItems.push({ content: olMatch[2]!, indent: olMatch[1]!.length });
+      listItems.push({ content: olMatch[3]!, indent: olMatch[1]!.length, start: parseInt(olMatch[2]!, 10) });
       continue;
     }
 


### PR DESCRIPTION
Ensure markdown ordered lists start at the written number, not always 1