### PR TITLE
feat(game): lockable draggable HUD panels + layout/drag-lag fixes

### DIFF
--- a/packages/client/src/components/game/DraggablePanel.tsx
+++ b/packages/client/src/components/game/DraggablePanel.tsx
@@ -1,0 +1,104 @@
+// ──────────────────────────────────────────────
+// Game: Lock + drag helpers for HUD panels
+//
+// Each panel (widget cards, map) uses `useDraggablePanel`
+// to persist a lock flag and {x,y} offset under its id.
+// `PanelLockButton` renders the lock toggle in headers.
+// ──────────────────────────────────────────────
+import { useCallback, useEffect, useState } from "react";
+import { useMotionValue } from "framer-motion";
+import { Lock, Unlock } from "lucide-react";
+import { cn } from "../../lib/utils";
+
+const STORAGE_PREFIX = "marinara-game-panel:";
+
+interface PanelState {
+  locked: boolean;
+  x: number;
+  y: number;
+}
+
+function readPanelState(id: string): PanelState {
+  if (typeof window === "undefined") return { locked: true, x: 0, y: 0 };
+  try {
+    const raw = window.localStorage.getItem(STORAGE_PREFIX + id);
+    if (!raw) return { locked: true, x: 0, y: 0 };
+    const parsed = JSON.parse(raw) as Partial<PanelState>;
+    return {
+      locked: parsed.locked !== false,
+      x: Number.isFinite(parsed.x) ? (parsed.x as number) : 0,
+      y: Number.isFinite(parsed.y) ? (parsed.y as number) : 0,
+    };
+  } catch {
+    return { locked: true, x: 0, y: 0 };
+  }
+}
+
+function writePanelState(id: string, state: PanelState) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_PREFIX + id, JSON.stringify(state));
+  } catch {
+    // quota / unavailable — best-effort only
+  }
+}
+
+/** Returns motion values + lock state for a draggable HUD panel, persisted by id. */
+export function useDraggablePanel(id: string) {
+  const [locked, setLocked] = useState(true);
+  const x = useMotionValue(0);
+  const y = useMotionValue(0);
+
+  // Hydrate from localStorage after mount (avoids SSR mismatch).
+  useEffect(() => {
+    const s = readPanelState(id);
+    setLocked(s.locked);
+    x.set(s.x);
+    y.set(s.y);
+  }, [id, x, y]);
+
+  const toggleLocked = useCallback(() => {
+    setLocked((prev) => {
+      const next = !prev;
+      writePanelState(id, { locked: next, x: x.get(), y: y.get() });
+      return next;
+    });
+  }, [id, x, y]);
+
+  const handleDragEnd = useCallback(() => {
+    writePanelState(id, { locked, x: x.get(), y: y.get() });
+  }, [id, locked, x, y]);
+
+  return { locked, toggleLocked, x, y, handleDragEnd };
+}
+
+interface PanelLockButtonProps {
+  locked: boolean;
+  onToggle: () => void;
+  /** Icon size in px. Matches the adjacent collapse indicator. */
+  size?: number;
+  className?: string;
+}
+
+/** Small lock toggle styled to match collapse/chevron buttons in HUD panels. */
+export function PanelLockButton({ locked, onToggle, size = 10, className }: PanelLockButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={(event) => {
+        event.stopPropagation();
+        onToggle();
+      }}
+      onPointerDown={(event) => event.stopPropagation()}
+      title={locked ? "Unlock to move" : "Lock in place"}
+      aria-label={locked ? "Unlock panel" : "Lock panel"}
+      aria-pressed={!locked}
+      className={cn(
+        "flex shrink-0 items-center justify-center text-white/30 transition-colors hover:text-white/70",
+        className,
+      )}
+    >
+      {locked ? <Lock size={size} /> : <Unlock size={size} />}
+    </button>
+  );
+}

--- a/packages/client/src/components/game/GameMap.tsx
+++ b/packages/client/src/components/game/GameMap.tsx
@@ -2,11 +2,13 @@
 // Game: Map Wrapper (switches between grid and node)
 // ──────────────────────────────────────────────
 import { useState, useCallback } from "react";
+import { motion } from "framer-motion";
 import type { GameMap, GameActiveState } from "@marinara-engine/shared";
 import { GameGridMap } from "./GameGridMap";
 import { GameNodeMap } from "./GameNodeMap";
 import { ChevronDown, ChevronUp, Map as MapIcon, Wand2, X, Compass, MessageCircle, Swords, Moon } from "lucide-react";
 import { cn } from "../../lib/utils";
+import { PanelLockButton, useDraggablePanel } from "./DraggablePanel";
 
 const STATE_CONFIG: Record<GameActiveState, { icon: typeof Compass; label: string; color: string }> = {
   exploration: { icon: Compass, label: "Exploration", color: "text-emerald-300" },
@@ -29,10 +31,11 @@ interface GameMapProps {
 export function GameMapPanel({ map, onMove, onGenerateMap, disabled, gameState }: GameMapProps) {
   const [collapsed, setCollapsed] = useState(false);
   const [stateHovered, setStateHovered] = useState(false);
+  const { locked, toggleLocked, x, y, handleDragEnd } = useDraggablePanel("map");
 
   if (!map) {
     return (
-      <div className="flex flex-col items-center justify-center gap-2 p-3 text-[var(--muted-foreground)]">
+      <div className="flex w-52 flex-col items-center justify-center gap-2 rounded-lg border border-[var(--border)] bg-[var(--card)]/92 p-3 text-[var(--muted-foreground)] shadow-lg backdrop-blur-sm">
         <span className="text-[0.625rem]">No map yet</span>
         {onGenerateMap && (
           <button
@@ -53,10 +56,28 @@ export function GameMapPanel({ map, onMove, onGenerateMap, disabled, gameState }
   const StateIcon = stateCfg?.icon ?? null;
 
   return (
-    <div className="game-map-container flex flex-col gap-1 p-2">
-      <button
+    <motion.div
+      drag={!locked}
+      dragMomentum={false}
+      dragElastic={0}
+      onDragEnd={handleDragEnd}
+      style={{ x, y }}
+      className={cn(
+        "game-map-container flex w-52 flex-col gap-1 rounded-lg border border-[var(--border)] bg-[var(--card)]/92 p-2 shadow-lg backdrop-blur-sm",
+        !locked && "cursor-grab ring-1 ring-white/20 active:cursor-grabbing",
+      )}
+    >
+      <div
+        role="button"
+        tabIndex={0}
         onClick={() => setCollapsed(!collapsed)}
-        className="relative flex items-center gap-1.5 text-xs text-[var(--muted-foreground)] transition-colors hover:text-[var(--foreground)]"
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            setCollapsed(!collapsed);
+          }
+        }}
+        className="relative flex cursor-pointer items-center gap-1.5 text-xs text-[var(--muted-foreground)] transition-colors hover:text-[var(--foreground)]"
       >
         {/* State icon */}
         {StateIcon && (
@@ -83,15 +104,16 @@ export function GameMapPanel({ map, onMove, onGenerateMap, disabled, gameState }
             <span className="block truncate">{mapName}</span>
           )}
         </span>
+        <PanelLockButton locked={locked} onToggle={toggleLocked} size={11} />
         <span className="shrink-0">{collapsed ? <ChevronDown size={12} /> : <ChevronUp size={12} />}</span>
-      </button>
+      </div>
       {!collapsed &&
         (map.type === "grid" ? (
           <GameGridMap map={map} onCellClick={(x, y) => onMove({ x, y })} />
         ) : (
           <GameNodeMap map={map} onNodeClick={(nodeId) => onMove(nodeId)} disabled={disabled} />
         ))}
-    </div>
+    </motion.div>
   );
 }
 

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -2669,10 +2669,7 @@ export function GameSurface({
                     />
                   </div>
                   {/* Desktop: inline minimap */}
-                  <div
-                    data-tour="game-map"
-                    className="hidden md:block w-52 rounded-lg border border-[var(--border)] bg-[var(--card)]/92 shadow-lg backdrop-blur-sm"
-                  >
+                  <div data-tour="game-map" className="hidden md:block">
                     <GameMapPanel
                       map={currentMap}
                       onMove={handleMapMove}
@@ -2978,7 +2975,7 @@ export function GameSurface({
               {!combatUiActive && hudWidgets.length > 0 && (
                 <>
                   {/* Desktop: full widget cards */}
-                  <div className="pointer-events-none absolute inset-x-3 bottom-24 z-30 hidden items-start justify-between md:flex">
+                  <div className="pointer-events-none absolute inset-x-3 bottom-24 z-30 hidden items-end justify-between md:flex">
                     <div className="w-44">
                       <GameWidgetPanel widgets={normalizedWidgets} position="hud_left" />
                     </div>

--- a/packages/client/src/components/game/GameWidgetPanel.tsx
+++ b/packages/client/src/components/game/GameWidgetPanel.tsx
@@ -6,8 +6,10 @@
 // the renderer handles all visual presentation.
 // ──────────────────────────────────────────────
 import { useEffect, useRef, useState } from "react";
+import { motion } from "framer-motion";
 import type { HudWidget } from "@marinara-engine/shared";
 import { cn } from "../../lib/utils";
+import { PanelLockButton, useDraggablePanel } from "./DraggablePanel";
 
 // ── Public API ──
 
@@ -93,16 +95,32 @@ export function MobileWidgetPanel({ widgets, position }: GameWidgetPanelProps) {
 function WidgetCard({ widget }: { widget: HudWidget }) {
   const [collapsed, setCollapsed] = useState(false);
   const accent = widget.accent ?? "#a78bfa";
+  const { locked, toggleLocked, x, y, handleDragEnd } = useDraggablePanel(`widget:${widget.id}`);
 
   return (
-    <div
-      className="w-full overflow-hidden rounded-lg border bg-black/60 backdrop-blur-md transition-all"
-      style={{ borderColor: `${accent}30` }}
+    <motion.div
+      drag={!locked}
+      dragMomentum={false}
+      dragElastic={0}
+      onDragEnd={handleDragEnd}
+      style={{ x, y, borderColor: `${accent}30` }}
+      className={cn(
+        "w-full overflow-hidden rounded-lg border bg-black/60 backdrop-blur-md transition-colors",
+        !locked && "cursor-grab ring-1 ring-white/20 active:cursor-grabbing",
+      )}
     >
       {/* Header */}
-      <button
+      <div
+        role="button"
+        tabIndex={0}
         onClick={() => setCollapsed((c) => !c)}
-        className="flex w-full items-center gap-1.5 px-2.5 py-1.5 text-left transition-colors hover:bg-white/5"
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            setCollapsed((c) => !c);
+          }
+        }}
+        className="flex w-full cursor-pointer items-center gap-1.5 px-2.5 py-1.5 text-left transition-colors hover:bg-white/5"
       >
         {widget.icon && <span className="text-xs">{widget.icon}</span>}
         <span
@@ -111,8 +129,9 @@ function WidgetCard({ widget }: { widget: HudWidget }) {
         >
           {widget.label}
         </span>
+        <PanelLockButton locked={locked} onToggle={toggleLocked} size={10} />
         <span className="text-[0.5rem] text-white/30">{collapsed ? "+" : "-"}</span>
-      </button>
+      </div>
 
       {/* Body */}
       {!collapsed && (
@@ -120,7 +139,7 @@ function WidgetCard({ widget }: { widget: HudWidget }) {
           <WidgetBody widget={widget} />
         </div>
       )}
-    </div>
+    </motion.div>
   );
 }
 


### PR DESCRIPTION
## Summary

- Adds a small lock icon next to the collapse toggle on every Game Mode HUD panel (map, Bonds, Leads, Mana Stability, Exposure Risk). Panels are locked by default; clicking the lock swaps it to an open padlock, draws a faint ring around the card, and makes it free-draggable via `framer-motion`. Lock state and `{x, y}` position persist per panel in `localStorage` under `marinara-game-panel:*`.
- Fixes a pre-existing layout bug where expanding a widget on one side visibly shifted the panels on the opposite column.
- Fixes drag feeling laggy / non-smooth on widget cards.

## What changed

**New:** `packages/client/src/components/game/DraggablePanel.tsx`
- `useDraggablePanel(id)` hook — returns `{ locked, toggleLocked, x, y, handleDragEnd }` backed by motion values and localStorage.
- `PanelLockButton` — lucide `Lock`/`Unlock` toggle styled to match the existing `text-white/30 hover:text-white/70` chevron/collapse indicators, with `stopPropagation` so it doesn't fire the header's collapse click.

**Updated:** `GameWidgetPanel.tsx`, `GameMap.tsx`
- `WidgetCard` and `GameMapPanel` render as `motion.div` with `drag={!locked}`, `dragMomentum={false}`, `dragElastic={0}`.
- Header `<button>`s became `role="button"` divs so the lock toggle can nest without invalid HTML, while preserving keyboard (Enter/Space) toggle behavior.
- Map card styling (`w-52`, border, bg, shadow, blur) moved from the `GameSurface` wrapper onto `GameMapPanel`'s draggable root, so the whole visual card translates together when dragged.

**Updated:** `GameSurface.tsx`
- HUD flex container: `items-start` → `items-end`. The container is anchored at `bottom-24` with no fixed height, so under `items-start`, growing the left column pushed the container's top upward and carried the top-aligned right column up with it. With `items-end` both columns bottom-align and grow independently upward.
- Removed the now-duplicated map card classes (width/border/bg/shadow) from the desktop minimap wrapper; `GameMapPanel` owns them now.

**Drag lag fix:** `WidgetCard` previously used `transition-all`, which made the browser tween every transform update `framer-motion` pushed during drag. Narrowed to `transition-colors` so only color state animates; transform updates are immediate.

## Test plan

- [x] `pnpm check` passes (client build + typecheck clean)
- [x] Manually tested in dev build at http://localhost:7820
  - [x] All five panels (map, Bonds, Leads, Mana Stability, Exposure Risk) show a lock icon and are locked by default
  - [x] Clicking lock → open padlock + ring outline + grab cursor; panel can be dragged anywhere
  - [x] Clicking lock again → re-locks and disables drag
  - [x] Collapse/expand button still works when locked and unlocked
  - [x] Lock state and drag position persist across reload
  - [x] Expanding/collapsing a widget on the left no longer shifts the right column (and vice versa)
  - [x] Dragging is smooth — no visible lag from CSS transitions
- [x] Map and widgets keep styling consistent with the rest of the HUD