### PR TITLE
feat(game): movable lockable HUD panels + layout/drag fixes

### DIFF
--- a/packages/client/src/components/game/DraggablePanel.tsx
+++ b/packages/client/src/components/game/DraggablePanel.tsx
@@ -1,0 +1,115 @@
+// ──────────────────────────────────────────────
+// Game: Lock + drag helpers for HUD panels
+//
+// Each panel (widget cards, map) uses `useDraggablePanel`
+// to persist a lock flag and {x,y} offset. State is scoped
+// by chatId so positions don't bleed across games.
+// `PanelLockButton` renders the lock toggle in headers.
+// ──────────────────────────────────────────────
+import { useCallback, useRef, useState } from "react";
+import { useMotionValue } from "framer-motion";
+import { Lock, Unlock } from "lucide-react";
+import { cn } from "../../lib/utils";
+
+const STORAGE_PREFIX = "marinara-game-panel:";
+
+interface PanelState {
+  locked: boolean;
+  x: number;
+  y: number;
+}
+
+function storageKey(scopeId: string, panelId: string): string {
+  return `${STORAGE_PREFIX}${scopeId}:${panelId}`;
+}
+
+function readPanelState(key: string): PanelState {
+  if (typeof window === "undefined") return { locked: true, x: 0, y: 0 };
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (!raw) return { locked: true, x: 0, y: 0 };
+    const parsed = JSON.parse(raw) as Partial<PanelState>;
+    return {
+      locked: parsed.locked !== false,
+      x: Number.isFinite(parsed.x) ? (parsed.x as number) : 0,
+      y: Number.isFinite(parsed.y) ? (parsed.y as number) : 0,
+    };
+  } catch {
+    return { locked: true, x: 0, y: 0 };
+  }
+}
+
+function writePanelState(key: string, state: PanelState) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(key, JSON.stringify(state));
+  } catch {
+    // quota / unavailable — best-effort only
+  }
+}
+
+/**
+ * Returns motion values + lock state for a draggable HUD panel, persisted per
+ * chat so positions don't bleed across games. Reads from localStorage
+ * synchronously on first render to avoid a hydration-flicker where a moved
+ * panel paints at origin before snapping back.
+ */
+export function useDraggablePanel(scopeId: string, panelId: string) {
+  const key = storageKey(scopeId, panelId);
+
+  // Synchronous first-render hydration via a ref-captured seed.
+  const seedRef = useRef<PanelState | null>(null);
+  if (seedRef.current === null) {
+    seedRef.current = readPanelState(key);
+  }
+  const seed = seedRef.current;
+
+  const [locked, setLocked] = useState(seed.locked);
+  const x = useMotionValue(seed.x);
+  const y = useMotionValue(seed.y);
+
+  const toggleLocked = useCallback(() => {
+    setLocked((prev) => {
+      const next = !prev;
+      writePanelState(key, { locked: next, x: x.get(), y: y.get() });
+      return next;
+    });
+  }, [key, x, y]);
+
+  const handleDragEnd = useCallback(() => {
+    writePanelState(key, { locked, x: x.get(), y: y.get() });
+  }, [key, locked, x, y]);
+
+  return { locked, toggleLocked, x, y, handleDragEnd };
+}
+
+interface PanelLockButtonProps {
+  locked: boolean;
+  onToggle: () => void;
+  /** Icon size in px. Matches the adjacent collapse indicator. */
+  size?: number;
+  className?: string;
+}
+
+/** Small lock toggle styled to match collapse/chevron buttons in HUD panels. */
+export function PanelLockButton({ locked, onToggle, size = 10, className }: PanelLockButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={(event) => {
+        event.stopPropagation();
+        onToggle();
+      }}
+      onPointerDown={(event) => event.stopPropagation()}
+      title={locked ? "Unlock to move" : "Lock in place"}
+      aria-label={locked ? "Unlock panel" : "Lock panel"}
+      aria-pressed={!locked}
+      className={cn(
+        "flex shrink-0 items-center justify-center text-white/30 transition-colors hover:text-white/70",
+        className,
+      )}
+    >
+      {locked ? <Lock size={size} /> : <Unlock size={size} />}
+    </button>
+  );
+}

--- a/packages/client/src/components/game/GameMap.tsx
+++ b/packages/client/src/components/game/GameMap.tsx
@@ -1,12 +1,14 @@
 // ──────────────────────────────────────────────
 // Game: Map Wrapper (switches between grid and node)
 // ──────────────────────────────────────────────
-import { useState, useCallback } from "react";
+import { useState, useCallback, type RefObject } from "react";
+import { motion } from "framer-motion";
 import type { GameMap, GameActiveState } from "@marinara-engine/shared";
 import { GameGridMap } from "./GameGridMap";
 import { GameNodeMap } from "./GameNodeMap";
 import { ChevronDown, ChevronUp, Map as MapIcon, Wand2, X, Compass, MessageCircle, Swords, Moon } from "lucide-react";
 import { cn } from "../../lib/utils";
+import { PanelLockButton, useDraggablePanel } from "./DraggablePanel";
 
 const STATE_CONFIG: Record<GameActiveState, { icon: typeof Compass; label: string; color: string }> = {
   exploration: { icon: Compass, label: "Exploration", color: "text-emerald-300" },
@@ -25,14 +27,25 @@ interface GameMapProps {
   gameState?: GameActiveState;
 }
 
+interface GameMapPanelProps extends GameMapProps {
+  /** Chat id used to scope persisted lock + position so layouts don't bleed across games. */
+  chatId: string;
+  /** Ref to the game surface element used as a drag boundary. */
+  constraintsRef?: RefObject<HTMLElement | null>;
+}
+
 /** Desktop: inline collapsible panel. */
-export function GameMapPanel({ map, onMove, onGenerateMap, disabled, gameState }: GameMapProps) {
+export function GameMapPanel({ map, onMove, onGenerateMap, disabled, gameState, chatId, constraintsRef }: GameMapPanelProps) {
   const [collapsed, setCollapsed] = useState(false);
   const [stateHovered, setStateHovered] = useState(false);
+  const { locked, toggleLocked, x, y, handleDragEnd } = useDraggablePanel(chatId, "map");
 
   if (!map) {
     return (
-      <div className="flex flex-col items-center justify-center gap-2 p-3 text-[var(--muted-foreground)]">
+      <div
+        data-tour="game-map"
+        className="flex w-52 flex-col items-center justify-center gap-2 rounded-lg border border-[var(--border)] bg-[var(--card)]/92 p-3 text-[var(--muted-foreground)] shadow-lg backdrop-blur-sm"
+      >
         <span className="text-[0.625rem]">No map yet</span>
         {onGenerateMap && (
           <button
@@ -53,10 +66,30 @@ export function GameMapPanel({ map, onMove, onGenerateMap, disabled, gameState }
   const StateIcon = stateCfg?.icon ?? null;
 
   return (
-    <div className="game-map-container flex flex-col gap-1 p-2">
-      <button
+    <motion.div
+      data-tour="game-map"
+      drag={!locked}
+      dragMomentum={false}
+      dragElastic={0}
+      dragConstraints={constraintsRef as RefObject<Element>}
+      onDragEnd={handleDragEnd}
+      style={{ x, y }}
+      className={cn(
+        "game-map-container flex w-52 flex-col gap-1 rounded-lg border border-[var(--border)] bg-[var(--card)]/92 p-2 shadow-lg backdrop-blur-sm",
+        !locked && "cursor-grab ring-1 ring-white/20 active:cursor-grabbing",
+      )}
+    >
+      <div
+        role="button"
+        tabIndex={0}
         onClick={() => setCollapsed(!collapsed)}
-        className="relative flex items-center gap-1.5 text-xs text-[var(--muted-foreground)] transition-colors hover:text-[var(--foreground)]"
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            setCollapsed(!collapsed);
+          }
+        }}
+        className="relative flex cursor-pointer items-center gap-1.5 text-xs text-[var(--muted-foreground)] transition-colors hover:text-[var(--foreground)]"
       >
         {/* State icon */}
         {StateIcon && (
@@ -83,15 +116,16 @@ export function GameMapPanel({ map, onMove, onGenerateMap, disabled, gameState }
             <span className="block truncate">{mapName}</span>
           )}
         </span>
+        <PanelLockButton locked={locked} onToggle={toggleLocked} size={11} />
         <span className="shrink-0">{collapsed ? <ChevronDown size={12} /> : <ChevronUp size={12} />}</span>
-      </button>
+      </div>
       {!collapsed &&
         (map.type === "grid" ? (
           <GameGridMap map={map} onCellClick={(x, y) => onMove({ x, y })} />
         ) : (
           <GameNodeMap map={map} onNodeClick={(nodeId) => onMove(nodeId)} disabled={disabled} />
         ))}
-    </div>
+    </motion.div>
   );
 }
 

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -411,6 +411,7 @@ export function GameSurface({
   const [tutorialOpen, setTutorialOpen] = useState(false);
   const tutorialAutoTriggeredRef = useRef(false);
   const volumePopoverRef = useRef<HTMLDivElement>(null);
+  const hudSurfaceRef = useRef<HTMLDivElement>(null);
   const lastProcessedMsgRef = useRef<string | null>(null);
   const weatherMsgRef = useRef<string | null>(null);
   const sceneAnalysisTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -2655,7 +2656,7 @@ export function GameSurface({
               )}
 
               {/* Main content area */}
-              <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden">
+              <div ref={hudSurfaceRef} className="relative flex min-h-0 flex-1 flex-col overflow-hidden">
                 {/* Top-left: Map + Party portraits side by side */}
                 <div className="pointer-events-auto absolute left-3 top-3 z-20 flex items-start gap-2">
                   {/* Mobile: map icon button that opens modal */}
@@ -2669,16 +2670,15 @@ export function GameSurface({
                     />
                   </div>
                   {/* Desktop: inline minimap */}
-                  <div
-                    data-tour="game-map"
-                    className="hidden md:block w-52 rounded-lg border border-[var(--border)] bg-[var(--card)]/92 shadow-lg backdrop-blur-sm"
-                  >
+                  <div className="hidden md:block">
                     <GameMapPanel
                       map={currentMap}
                       onMove={handleMapMove}
                       onGenerateMap={handleGenerateMap}
                       disabled={isStreaming || !narrationDone}
                       gameState={gameState}
+                      chatId={activeChatId}
+                      constraintsRef={hudSurfaceRef}
                     />
                   </div>
 
@@ -2978,12 +2978,22 @@ export function GameSurface({
               {!combatUiActive && hudWidgets.length > 0 && (
                 <>
                   {/* Desktop: full widget cards */}
-                  <div className="pointer-events-none absolute inset-x-3 bottom-24 z-30 hidden items-start justify-between md:flex">
+                  <div className="pointer-events-none absolute inset-x-3 bottom-24 z-30 hidden items-end justify-between md:flex">
                     <div className="w-44">
-                      <GameWidgetPanel widgets={normalizedWidgets} position="hud_left" />
+                      <GameWidgetPanel
+                        widgets={normalizedWidgets}
+                        position="hud_left"
+                        chatId={activeChatId}
+                        constraintsRef={hudSurfaceRef}
+                      />
                     </div>
                     <div className="w-44">
-                      <GameWidgetPanel widgets={normalizedWidgets} position="hud_right" />
+                      <GameWidgetPanel
+                        widgets={normalizedWidgets}
+                        position="hud_right"
+                        chatId={activeChatId}
+                        constraintsRef={hudSurfaceRef}
+                      />
                     </div>
                   </div>
                 </>

--- a/packages/client/src/components/game/GameWidgetPanel.tsx
+++ b/packages/client/src/components/game/GameWidgetPanel.tsx
@@ -5,36 +5,48 @@
 // The model picks a type + config during setup;
 // the renderer handles all visual presentation.
 // ──────────────────────────────────────────────
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type RefObject } from "react";
+import { motion } from "framer-motion";
 import type { HudWidget } from "@marinara-engine/shared";
 import { cn } from "../../lib/utils";
+import { PanelLockButton, useDraggablePanel } from "./DraggablePanel";
 
 // ── Public API ──
 
 interface GameWidgetPanelProps {
   widgets: HudWidget[];
   position: "hud_left" | "hud_right";
+  /** Chat id used to scope persisted lock + position so layouts don't bleed across games. */
+  chatId: string;
+  /** Ref to the game surface element used as a drag boundary. */
+  constraintsRef?: RefObject<HTMLElement | null>;
 }
 
 /** Maximum number of custom HUD widgets displayed. */
 const MAX_WIDGETS = 4;
 
 /** Renders a panel of model-defined widgets for a given position. */
-export function GameWidgetPanel({ widgets, position }: GameWidgetPanelProps) {
+export function GameWidgetPanel({ widgets, position, chatId, constraintsRef }: GameWidgetPanelProps) {
   const filtered = widgets.filter((w) => w.position === position && w.type !== "inventory_grid").slice(0, MAX_WIDGETS);
   if (filtered.length === 0) return null;
 
   return (
     <div className="pointer-events-auto flex flex-col gap-2">
       {filtered.map((w) => (
-        <WidgetCard key={w.id} widget={w} />
+        <WidgetCard key={`${chatId}:${w.id}`} widget={w} chatId={chatId} constraintsRef={constraintsRef} />
       ))}
     </div>
   );
 }
 
 /** Mobile: collapsed emoji pills that expand into full widget on tap. */
-export function MobileWidgetPanel({ widgets, position }: GameWidgetPanelProps) {
+export function MobileWidgetPanel({
+  widgets,
+  position,
+}: {
+  widgets: HudWidget[];
+  position: "hud_left" | "hud_right";
+}) {
   const filtered = widgets.filter((w) => w.position === position && w.type !== "inventory_grid").slice(0, MAX_WIDGETS);
   const [expandedId, setExpandedId] = useState<string | null>(null);
 
@@ -90,19 +102,44 @@ export function MobileWidgetPanel({ widgets, position }: GameWidgetPanelProps) {
 
 // ── Widget Card Wrapper ──
 
-function WidgetCard({ widget }: { widget: HudWidget }) {
+function WidgetCard({
+  widget,
+  chatId,
+  constraintsRef,
+}: {
+  widget: HudWidget;
+  chatId: string;
+  constraintsRef?: RefObject<HTMLElement | null>;
+}) {
   const [collapsed, setCollapsed] = useState(false);
   const accent = widget.accent ?? "#a78bfa";
+  const { locked, toggleLocked, x, y, handleDragEnd } = useDraggablePanel(chatId, `widget:${widget.id}`);
 
   return (
-    <div
-      className="w-full overflow-hidden rounded-lg border bg-black/60 backdrop-blur-md transition-all"
-      style={{ borderColor: `${accent}30` }}
+    <motion.div
+      drag={!locked}
+      dragMomentum={false}
+      dragElastic={0}
+      dragConstraints={constraintsRef as RefObject<Element>}
+      onDragEnd={handleDragEnd}
+      style={{ x, y, borderColor: `${accent}30` }}
+      className={cn(
+        "w-full overflow-hidden rounded-lg border bg-black/60 backdrop-blur-md transition-colors",
+        !locked && "cursor-grab ring-1 ring-white/20 active:cursor-grabbing",
+      )}
     >
       {/* Header */}
-      <button
+      <div
+        role="button"
+        tabIndex={0}
         onClick={() => setCollapsed((c) => !c)}
-        className="flex w-full items-center gap-1.5 px-2.5 py-1.5 text-left transition-colors hover:bg-white/5"
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            setCollapsed((c) => !c);
+          }
+        }}
+        className="flex w-full cursor-pointer items-center gap-1.5 px-2.5 py-1.5 text-left transition-colors hover:bg-white/5"
       >
         {widget.icon && <span className="text-xs">{widget.icon}</span>}
         <span
@@ -111,8 +148,9 @@ function WidgetCard({ widget }: { widget: HudWidget }) {
         >
           {widget.label}
         </span>
+        <PanelLockButton locked={locked} onToggle={toggleLocked} size={10} />
         <span className="text-[0.5rem] text-white/30">{collapsed ? "+" : "-"}</span>
-      </button>
+      </div>
 
       {/* Body */}
       {!collapsed && (
@@ -120,7 +158,7 @@ function WidgetCard({ widget }: { widget: HudWidget }) {
           <WidgetBody widget={widget} />
         </div>
       )}
-    </div>
+    </motion.div>
   );
 }
 


### PR DESCRIPTION
## Summary

Adds a small lock icon next to the collapse toggle on every Game Mode HUD panel (map, Bonds, Leads, Mana Stability, Exposure Risk). Panels are locked by default; clicking the lock swaps it to an open padlock, draws a faint ring around the card, and makes it free-draggable within the game surface. Lock state and position persist **per chat** so layouts don't leak between games.

## What's in the box

**New:** `packages/client/src/components/game/DraggablePanel.tsx`
- `useDraggablePanel(chatId, panelId)` hook — returns `{ locked, toggleLocked, x, y, handleDragEnd }`. Storage key is `marinara-game-panel:<chatId>:<panelId>`, so every game gets its own HUD layout.
- Reads localStorage synchronously via a `useRef` seed on first render, so moved panels paint at their saved position with no origin-flash flicker.
- `PanelLockButton` — lucide `Lock`/`Unlock` toggle styled to match the existing chevron/collapse indicators (`text-white/30 hover:text-white/70`), with `stopPropagation` so it doesn't fire the header's collapse click.

**Updated:** `GameWidgetPanel.tsx`, `GameMap.tsx`
- Cards render as `motion.div` with `drag={!locked}`, `dragMomentum={false}`, `dragElastic={0}`, and `dragConstraints` pointed at the game surface — **panels can't be dragged off-screen**.
- `WidgetCard` keyed by `${chatId}:${widget.id}` so switching games remounts with fresh motion values.
- Map card styling (`w-52`, border, bg, shadow, blur) moved from the `GameSurface` wrapper onto `GameMapPanel`'s draggable root, so the whole visual card translates together.
- `data-tour="game-map"` moved from the static wrapper onto the draggable map root, so the onboarding tutorial highlight tracks it wherever it's dragged.

**Updated:** `GameSurface.tsx`
- New `hudSurfaceRef` on the main game content `<div>`, passed as `constraintsRef` to both map and widget panels.
- `activeChatId` threaded down as `chatId` to both panels for storage scoping.
- HUD flex container: `items-start` → `items-end` (fix below).

## Pre-existing bugs fixed along the way

- **Column reshuffle on expand/collapse** — the HUD flex container was `items-start` but anchored at `bottom-24` with no fixed height, so growing the left column pushed the container top upward and dragged the top-aligned right column with it. Switched to `items-end` so both columns bottom-anchor and grow independently upward.
- **Drag lag** — `WidgetCard` had `transition-all`, which made the browser tween every transform update framer-motion pushed during drag. Narrowed to `transition-colors` so only color state animates; transform updates are immediate.

## Test plan

- [x] `pnpm check` passes (client build + typecheck clean)
- [x] All five desktop panels show a lock icon and are locked by default
- [x] Clicking lock → open padlock + ring + grab cursor; drag works; re-lock restores normal behavior
- [x] Collapse/expand still toggles whether locked or unlocked
- [x] Lock state and drag position persist across reload
- [x] Switching chats resets layout to that chat's saved positions (doesn't carry over)
- [x] Cannot drag any panel off-screen (clamped to game surface)
- [x] No paint-flicker when reloading a chat with moved panels
- [x] Expanding/collapsing a widget on the left no longer shifts the right column (and vice versa)
- [x] Drag feels smooth — no CSS-transition lag
- [x] Tutorial highlight still targets the map after it's been moved