### PR TITLE
fix(sidecar): Replace native llama addon rebuilds with downloadable llama-server runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,7 @@
     "db:push": "pnpm --filter @marinara-engine/server db:push",
     "db:generate": "pnpm --filter @marinara-engine/server db:generate",
     "db:migrate": "pnpm --filter @marinara-engine/server db:migrate",
-    "clean": "pnpm -r --if-present run clean && node ./scripts/clean-workspace.mjs",
-    "sidecar:build": "node ./scripts/build-sidecar-runtime.mjs"
+    "clean": "pnpm -r --if-present run clean && node ./scripts/clean-workspace.mjs"
   },
   "devDependencies": {
     "esbuild": "^0.27.3",
@@ -42,7 +41,6 @@
     "onlyBuiltDependencies": [
       "better-sqlite3",
       "esbuild",
-      "node-llama-cpp",
       "sharp"
     ],
     "overrides": {

--- a/packages/client/src/components/game/GameSetupWizard.tsx
+++ b/packages/client/src/components/game/GameSetupWizard.tsx
@@ -87,7 +87,7 @@ export function GameSetupWizard({ onComplete, onCancel, isLoading, characters }:
 
   const sidecarStatus = useSidecarStore((s) => s.status);
   const sidecarConfig = useSidecarStore((s) => s.config);
-  const sidecarAvailable = sidecarStatus === "downloaded" || sidecarStatus === "loading" || sidecarStatus === "ready";
+  const sidecarAvailable = !!sidecarConfig.modelPath && sidecarStatus !== "not_downloaded";
 
   // Fetch sidecar status on mount so the dropdown is populated without visiting Connections first
   useEffect(() => {

--- a/packages/client/src/components/modals/ModelDownloadModal.tsx
+++ b/packages/client/src/components/modals/ModelDownloadModal.tsx
@@ -32,6 +32,7 @@ export function ModelDownloadModal({ open, onClose }: Props) {
   const {
     status,
     config,
+    modelDownloaded,
     runtime,
     inferenceReady,
     logPath,
@@ -54,8 +55,11 @@ export function ModelDownloadModal({ open, onClose }: Props) {
   const [selectedCustomPath, setSelectedCustomPath] = useState("");
 
   const isDownloading = downloadProgress?.status === "downloading";
-  const hasModel = !!config.modelPath;
-  const activeModelName = useMemo(() => config.modelPath?.split("/").pop() ?? null, [config.modelPath]);
+  const hasModel = modelDownloaded;
+  const activeModelName = useMemo(
+    () => (hasModel ? config.modelPath?.split("/").pop() ?? null : null),
+    [config.modelPath, hasModel],
+  );
   const shouldAutoStart = config.useForTrackers || config.useForGameScene;
   const isPreparingServer =
     hasModel &&

--- a/packages/client/src/components/modals/ModelDownloadModal.tsx
+++ b/packages/client/src/components/modals/ModelDownloadModal.tsx
@@ -33,6 +33,7 @@ export function ModelDownloadModal({ open, onClose }: Props) {
     status,
     config,
     runtime,
+    inferenceReady,
     logPath,
     downloadProgress,
     customModels,
@@ -43,6 +44,7 @@ export function ModelDownloadModal({ open, onClose }: Props) {
     listHuggingFaceModels,
     clearCustomModels,
     cancelDownload,
+    unloadModel,
     markPrompted,
     fetchStatus,
   } = useSidecarStore();
@@ -54,6 +56,14 @@ export function ModelDownloadModal({ open, onClose }: Props) {
   const isDownloading = downloadProgress?.status === "downloading";
   const hasModel = !!config.modelPath;
   const activeModelName = useMemo(() => config.modelPath?.split("/").pop() ?? null, [config.modelPath]);
+  const shouldAutoStart = config.useForTrackers || config.useForGameScene;
+  const isPreparingServer =
+    hasModel &&
+    shouldAutoStart &&
+    !inferenceReady &&
+    (status === "starting_server" || status === "downloaded");
+  const isSetupBusy = isDownloading || status === "downloading_runtime" || isPreparingServer;
+  const canFinish = status === "ready" && inferenceReady;
 
   useEffect(() => {
     if (!open) {
@@ -75,10 +85,29 @@ export function ModelDownloadModal({ open, onClose }: Props) {
 
   const progress = downloadProgress;
   const progressPercent = progress && progress.total > 0 ? Math.round((progress.downloaded / progress.total) * 100) : 0;
-  const progressLabel =
+  const setupLabel =
     progress?.phase === "runtime"
       ? `Downloading llama.cpp runtime${progress.label ? ` (${progress.label})` : ""}...`
-      : `Downloading model${progress?.label ? ` (${progress.label})` : ""}...`;
+      : progress?.phase === "model"
+        ? `Downloading model${progress.label ? ` (${progress.label})` : ""}...`
+        : isPreparingServer
+          ? "Starting local runtime..."
+          : "Setting up local runtime...";
+  const setupDescription =
+    progress?.phase === "model"
+      ? "Downloading your selected GGUF and preparing it for local use."
+      : progress?.phase === "runtime"
+        ? "Downloading the official llama.cpp runtime for this device."
+        : "Loading the model and starting the local llama-server. This can take a few seconds.";
+  const runtimeStatusLabel = canFinish
+    ? "Ready"
+    : isSetupBusy
+      ? "Setting up now"
+      : status === "server_error"
+        ? "Setup error"
+        : runtime.installed
+          ? "Installed"
+          : "Not downloaded yet";
 
   const handleSkip = () => {
     markPrompted();
@@ -105,8 +134,17 @@ export function ModelDownloadModal({ open, onClose }: Props) {
     onClose();
   };
 
+  const handleCancelSetup = () => {
+    if (isPreparingServer) {
+      void unloadModel();
+      return;
+    }
+
+    void cancelDownload();
+  };
+
   return (
-    <Modal open={open} onClose={isDownloading ? () => {} : onClose} title="Local AI Model" width="max-w-2xl">
+    <Modal open={open} onClose={isSetupBusy ? () => {} : onClose} title="Local AI Model" width="max-w-2xl">
       <div className="flex flex-col gap-5">
         <div className="flex items-start gap-3">
           <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-purple-500/10">
@@ -148,20 +186,12 @@ export function ModelDownloadModal({ open, onClose }: Props) {
             Runtime
           </div>
           <div className="mt-2 flex flex-col gap-1 text-xs text-[var(--muted-foreground)]">
-            <span>
-              Status:{" "}
-              {status === "ready"
-                ? "Ready"
-                : status === "starting_server"
-                  ? "Starting local server"
-                  : status === "downloading_runtime"
-                    ? "Downloading runtime"
-                    : status === "server_error"
-                      ? "Server error"
-                      : runtime.installed
-                        ? "Installed"
-                        : "Not downloaded yet"}
-            </span>
+            <span>Status: {runtimeStatusLabel}</span>
+            {isSetupBusy && (
+              <span>
+                Setup in progress. Marinara is still downloading the runtime or starting the local llama-server.
+              </span>
+            )}
             {runtime.installed && (
               <span>
                 Runtime build: {runtime.build} • {runtime.variant}
@@ -171,7 +201,47 @@ export function ModelDownloadModal({ open, onClose }: Props) {
           </div>
         </div>
 
-        {!isDownloading && (
+        {isSetupBusy && (
+          <div className="rounded-xl border border-purple-400/25 bg-purple-500/5 p-4">
+            <div className="flex items-start gap-3">
+              <div className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-purple-500/15">
+                <Loader2 size="1rem" className="animate-spin text-purple-300" />
+              </div>
+              <div className="flex-1">
+                <div className="text-sm font-medium text-purple-200">{setupLabel}</div>
+                <div className="mt-1 text-xs text-[var(--muted-foreground)]/80">{setupDescription}</div>
+              </div>
+            </div>
+
+            {progress ? (
+              <div className="mt-4 flex flex-col gap-2">
+                <div className="flex items-center justify-between text-xs text-[var(--muted-foreground)]">
+                  <span>{setupLabel}</span>
+                  <span>
+                    {formatBytes(progress.downloaded)}
+                    {progress.total > 0 && ` / ${formatBytes(progress.total)}`}
+                  </span>
+                </div>
+                <div className="h-2 w-full overflow-hidden rounded-full bg-[var(--border)]">
+                  <div
+                    className="h-full rounded-full bg-purple-400 transition-all duration-300"
+                    style={{ width: `${progressPercent}%` }}
+                  />
+                </div>
+                <div className="flex items-center justify-between text-xs text-[var(--muted-foreground)]/60">
+                  <span>{progressPercent}%</span>
+                  {progress.speed > 0 && <span>{formatSpeed(progress.speed)}</span>}
+                </div>
+              </div>
+            ) : (
+              <div className="mt-4 h-2 w-full overflow-hidden rounded-full bg-[var(--border)]">
+                <div className="h-full w-1/3 animate-pulse rounded-full bg-purple-400/80" />
+              </div>
+            )}
+          </div>
+        )}
+
+        {!isSetupBusy && (
           <>
             <div className="flex flex-col gap-2">
               <span className="text-xs font-medium uppercase tracking-wider text-[var(--muted-foreground)]/60">
@@ -291,28 +361,6 @@ export function ModelDownloadModal({ open, onClose }: Props) {
           </>
         )}
 
-        {isDownloading && progress && (
-          <div className="flex flex-col gap-2">
-            <div className="flex items-center justify-between text-xs text-[var(--muted-foreground)]">
-              <span>{progressLabel}</span>
-              <span>
-                {formatBytes(progress.downloaded)}
-                {progress.total > 0 && ` / ${formatBytes(progress.total)}`}
-              </span>
-            </div>
-            <div className="h-2 w-full overflow-hidden rounded-full bg-[var(--border)]">
-              <div
-                className="h-full rounded-full bg-purple-400 transition-all duration-300"
-                style={{ width: `${progressPercent}%` }}
-              />
-            </div>
-            <div className="flex items-center justify-between text-xs text-[var(--muted-foreground)]/60">
-              <span>{progressPercent}%</span>
-              {progress.speed > 0 && <span>{formatSpeed(progress.speed)}</span>}
-            </div>
-          </div>
-        )}
-
         {progress?.status === "error" && (
           <div className="rounded-lg border border-red-500/20 bg-red-500/5 p-3 text-sm text-red-400">
             {progress.error || "Download failed. Please try again."}
@@ -320,13 +368,13 @@ export function ModelDownloadModal({ open, onClose }: Props) {
         )}
 
         <div className="flex items-center gap-2">
-          {isDownloading ? (
+          {isSetupBusy ? (
             <button
-              onClick={() => void cancelDownload()}
+              onClick={handleCancelSetup}
               className="flex w-full items-center justify-center gap-2 rounded-xl border border-[var(--border)] px-4 py-2.5 text-sm text-[var(--muted-foreground)] transition-colors hover:bg-[var(--secondary)]"
             >
               <X size="0.875rem" />
-              Cancel Download
+              Cancel Setup
             </button>
           ) : (
             <>
@@ -338,7 +386,8 @@ export function ModelDownloadModal({ open, onClose }: Props) {
               </button>
               <button
                 onClick={handleDone}
-                className="flex flex-1 items-center justify-center gap-2 rounded-xl bg-purple-500/15 px-4 py-2.5 text-sm font-medium text-purple-300 transition-colors hover:bg-purple-500/25"
+                disabled={!canFinish}
+                className="flex flex-1 items-center justify-center gap-2 rounded-xl bg-purple-500/15 px-4 py-2.5 text-sm font-medium text-purple-300 transition-colors hover:bg-purple-500/25 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-purple-500/15"
               >
                 Done
               </button>
@@ -346,7 +395,7 @@ export function ModelDownloadModal({ open, onClose }: Props) {
           )}
         </div>
 
-        {!hasModel && !isDownloading && (
+        {!hasModel && !isSetupBusy && (
           <div className="rounded-xl border border-[var(--border)] bg-[var(--card)]/50 p-3">
             <span className="text-xs font-medium uppercase tracking-wider text-[var(--muted-foreground)]/60">
               What the local model handles

--- a/packages/client/src/components/modals/ModelDownloadModal.tsx
+++ b/packages/client/src/components/modals/ModelDownloadModal.tsx
@@ -1,16 +1,16 @@
 // ──────────────────────────────────────────────
 // Model Download Modal
 //
-// Prompts users to download a local Gemma E2B
-// model for offline tracker/scene analysis.
-// Shows on first launch or from settings.
+// Handles curated Gemma downloads plus BYO
+// HuggingFace GGUF selection for the local
+// llama-server sidecar runtime.
 // ──────────────────────────────────────────────
 
-import { useState, useEffect } from "react";
-import { AlertTriangle, BrainCircuit, Check, Download, HardDrive, X, Zap } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { BrainCircuit, Check, Download, HardDrive, Loader2, Search, Server, X, Zap } from "lucide-react";
+import { SIDECAR_MODELS, type SidecarQuantization } from "@marinara-engine/shared";
 import { Modal } from "../ui/Modal.js";
 import { useSidecarStore } from "../../stores/sidecar.store.js";
-import { SIDECAR_MODELS, type SidecarQuantization } from "@marinara-engine/shared";
 
 interface Props {
   open: boolean;
@@ -29,29 +29,75 @@ function formatSpeed(bytesPerSec: number): string {
 }
 
 export function ModelDownloadModal({ open, onClose }: Props) {
-  const { status, config, runtimeInfo, downloadProgress, startDownload, cancelDownload, markPrompted, fetchStatus } =
-    useSidecarStore();
-  const [selectedQuant, setSelectedQuant] = useState<SidecarQuantization>("q8_0");
-  const isDownloading = downloadProgress?.status === "downloading";
-  const isDownloaded = status === "downloaded" || status === "ready";
+  const {
+    status,
+    config,
+    runtime,
+    logPath,
+    downloadProgress,
+    customModels,
+    customModelsLoading,
+    customModelsError,
+    startDownload,
+    startCustomDownload,
+    listHuggingFaceModels,
+    clearCustomModels,
+    cancelDownload,
+    markPrompted,
+    fetchStatus,
+  } = useSidecarStore();
 
-  // Refresh status when modal opens
+  const [selectedQuant, setSelectedQuant] = useState<SidecarQuantization>("q8_0");
+  const [repoInput, setRepoInput] = useState(config.customModelRepo ?? "unsloth/gemma-4-E2B-it-GGUF");
+  const [selectedCustomPath, setSelectedCustomPath] = useState("");
+
+  const isDownloading = downloadProgress?.status === "downloading";
+  const hasModel = !!config.modelPath;
+  const activeModelName = useMemo(() => config.modelPath?.split("/").pop() ?? null, [config.modelPath]);
+
   useEffect(() => {
-    if (open) fetchStatus();
-  }, [open, fetchStatus]);
+    if (!open) {
+      clearCustomModels();
+      return;
+    }
+
+    void fetchStatus();
+    if (config.customModelRepo) {
+      setRepoInput(config.customModelRepo);
+    }
+  }, [open, config.customModelRepo, fetchStatus, clearCustomModels]);
+
+  useEffect(() => {
+    if (customModels.length > 0 && !customModels.some((entry) => entry.path === selectedCustomPath)) {
+      setSelectedCustomPath(customModels[0]!.path);
+    }
+  }, [customModels, selectedCustomPath]);
+
+  const progress = downloadProgress;
+  const progressPercent = progress && progress.total > 0 ? Math.round((progress.downloaded / progress.total) * 100) : 0;
+  const progressLabel =
+    progress?.phase === "runtime"
+      ? `Downloading llama.cpp runtime${progress.label ? ` (${progress.label})` : ""}...`
+      : `Downloading model${progress?.label ? ` (${progress.label})` : ""}...`;
 
   const handleSkip = () => {
     markPrompted();
     onClose();
   };
 
-  const handleDownload = () => {
+  const handleCuratedDownload = () => {
     markPrompted();
-    startDownload(selectedQuant);
+    void startDownload(selectedQuant);
   };
 
-  const handleCancel = () => {
-    cancelDownload();
+  const handleCustomDownload = () => {
+    if (!repoInput.trim() || !selectedCustomPath) return;
+    markPrompted();
+    void startCustomDownload(repoInput.trim(), selectedCustomPath);
+  };
+
+  const handleListModels = async () => {
+    await listHuggingFaceModels(repoInput.trim());
   };
 
   const handleDone = () => {
@@ -59,154 +105,196 @@ export function ModelDownloadModal({ open, onClose }: Props) {
     onClose();
   };
 
-  const progress = downloadProgress;
-  const progressPercent = progress && progress.total > 0 ? Math.round((progress.downloaded / progress.total) * 100) : 0;
-
   return (
-    <Modal open={open} onClose={isDownloading ? () => {} : onClose} title="Local AI Model" width="max-w-lg">
+    <Modal open={open} onClose={isDownloading ? () => {} : onClose} title="Local AI Model" width="max-w-2xl">
       <div className="flex flex-col gap-5">
-        {/* Header explanation */}
         <div className="flex items-start gap-3">
           <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-purple-500/10">
             <BrainCircuit size="1.25rem" className="text-purple-400" />
           </div>
           <div className="text-sm text-[var(--muted-foreground)]">
-            {isDownloaded ? (
-              <p>
-                Local AI model is ready! It will handle game mechanics, trackers, and scene effects without using your
-                main model's tokens. You can manage it in Settings &rarr; Advanced.
-              </p>
-            ) : (
-              <>
-                <p>
-                  Marinara Engine can run a small, local AI model to handle game mechanics, trackers, scene effects, and
-                  widgets without using your main model's tokens.
-                </p>
-                <p className="mt-1.5 text-xs text-[var(--muted-foreground)]/70">
-                  Powered by Google Gemma 4 E2B (2.3B effective parameters). Runs entirely on your device.
-                </p>
-              </>
-            )}
+            <p>
+              Marinara Engine can run a local llama.cpp sidecar for trackers, scene analysis, and game-state helpers
+              without spending main-model tokens.
+            </p>
+            <p className="mt-1.5 text-xs text-[var(--muted-foreground)]/70">
+              Runtime downloads are automatic per platform. You can use the curated Gemma 4 presets or any GGUF hosted
+              on HuggingFace.
+            </p>
           </div>
         </div>
 
-        {runtimeInfo && (runtimeInfo.state !== "ready" || runtimeInfo.reason === "manual_cpu") && (
-          <div
-            className={`rounded-xl border p-3 ${
-              runtimeInfo.state === "failed"
-                ? "border-amber-500/30 bg-amber-500/10"
-                : runtimeInfo.state === "fallback"
-                  ? "border-sky-500/30 bg-sky-500/10"
-                  : "border-[var(--border)] bg-[var(--secondary)]/40"
-            }`}
-          >
-            <div className="flex items-start gap-2.5">
-              <div className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-black/10">
-                <AlertTriangle size="0.875rem" className="text-current" />
-              </div>
-              <div className="flex-1">
-                <div className="text-sm font-medium">
-                  {runtimeInfo.state === "failed"
-                    ? "Local model setup is optional"
-                    : runtimeInfo.state === "fallback"
-                      ? "Local model is running in CPU mode"
-                      : "Local model is using CPU only"}
-                </div>
-                <p className="mt-1 text-xs leading-relaxed text-[var(--muted-foreground)]">{runtimeInfo.message}</p>
-                {runtimeInfo.state === "failed" && (
-                  <p className="mt-1 text-xs leading-relaxed text-[var(--muted-foreground)]">
-                    Marinara itself will still run normally. Only the optional Gemma sidecar is unavailable.
-                  </p>
-                )}
-              </div>
-            </div>
-          </div>
-        )}
-
-        {/* Success state — model already downloaded */}
-        {isDownloaded && !isDownloading && (
-          <div className="flex flex-col gap-3">
-            <div className="flex items-center gap-3 rounded-xl border border-green-500/30 bg-green-500/5 p-3">
+        {hasModel && (
+          <div className="rounded-xl border border-green-500/30 bg-green-500/5 p-3">
+            <div className="flex items-center gap-3">
               <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-green-500/15">
                 <Check size="1rem" className="text-green-400" />
               </div>
               <div className="flex-1">
-                <div className="text-sm font-medium text-green-300">Model Downloaded</div>
+                <div className="text-sm font-medium text-green-300">{activeModelName ?? "Model Installed"}</div>
                 <div className="text-xs text-[var(--muted-foreground)]/70">
-                  {config.quantization?.toUpperCase()} variant installed and ready to use
+                  {config.customModelRepo
+                    ? `Custom model from ${config.customModelRepo}`
+                    : `${config.quantization?.toUpperCase() ?? "Curated"} Gemma 4 preset`}
                 </div>
               </div>
             </div>
-            <button
-              onClick={handleDone}
-              className="flex items-center justify-center gap-2 rounded-xl bg-purple-500/15 px-4 py-2.5 text-sm font-medium text-purple-300 transition-colors hover:bg-purple-500/25"
-            >
-              Done
-            </button>
           </div>
         )}
 
-        {/* Model selection — only when not downloaded and not downloading */}
-        {!isDownloaded && !isDownloading && (
-          <div className="flex flex-col gap-2">
-            <span className="text-xs font-medium uppercase tracking-wider text-[var(--muted-foreground)]/60">
-              Select Model Size
+        <div className="rounded-xl border border-[var(--border)] bg-[var(--card)]/50 p-3">
+          <div className="flex items-center gap-2 text-sm font-medium">
+            <Server size="0.95rem" className="text-purple-300" />
+            Runtime
+          </div>
+          <div className="mt-2 flex flex-col gap-1 text-xs text-[var(--muted-foreground)]">
+            <span>
+              Status:{" "}
+              {status === "ready"
+                ? "Ready"
+                : status === "starting_server"
+                  ? "Starting local server"
+                  : status === "downloading_runtime"
+                    ? "Downloading runtime"
+                    : status === "server_error"
+                      ? "Server error"
+                      : runtime.installed
+                        ? "Installed"
+                        : "Not downloaded yet"}
             </span>
-            {SIDECAR_MODELS.map((model) => (
-              <label
-                key={model.quantization}
-                className={`flex cursor-pointer items-center gap-3 rounded-xl border p-3 transition-colors ${
-                  selectedQuant === model.quantization
-                    ? "border-purple-400/50 bg-purple-500/5"
-                    : "border-[var(--border)] hover:bg-[var(--secondary)]/50"
-                }`}
-              >
-                <input
-                  type="radio"
-                  name="quantization"
-                  value={model.quantization}
-                  checked={selectedQuant === model.quantization}
-                  onChange={() => setSelectedQuant(model.quantization)}
-                  className="sr-only"
-                />
-                <div
-                  className={`h-4 w-4 shrink-0 rounded-full border-2 transition-colors ${
-                    selectedQuant === model.quantization ? "border-purple-400 bg-purple-400" : "border-[var(--border)]"
+            {runtime.installed && (
+              <span>
+                Runtime build: {runtime.build} • {runtime.variant}
+              </span>
+            )}
+            {status === "server_error" && logPath && <span>Log: {logPath}</span>}
+          </div>
+        </div>
+
+        {!isDownloading && (
+          <>
+            <div className="flex flex-col gap-2">
+              <span className="text-xs font-medium uppercase tracking-wider text-[var(--muted-foreground)]/60">
+                Curated Gemma 4 Presets
+              </span>
+              {SIDECAR_MODELS.map((model) => (
+                <label
+                  key={model.quantization}
+                  className={`flex cursor-pointer items-center gap-3 rounded-xl border p-3 transition-colors ${
+                    selectedQuant === model.quantization
+                      ? "border-purple-400/50 bg-purple-500/5"
+                      : "border-[var(--border)] hover:bg-[var(--secondary)]/50"
                   }`}
                 >
-                  {selectedQuant === model.quantization && (
-                    <div className="flex h-full items-center justify-center">
-                      <div className="h-1.5 w-1.5 rounded-full bg-white" />
-                    </div>
-                  )}
-                </div>
-                <div className="flex-1">
-                  <div className="text-sm font-medium">{model.label}</div>
-                  <div className="flex items-center gap-3 text-xs text-[var(--muted-foreground)]/70">
-                    <span className="flex items-center gap-1">
-                      <Download size="0.75rem" />
-                      {formatBytes(model.sizeBytes)}
-                    </span>
-                    <span className="flex items-center gap-1">
-                      <HardDrive size="0.75rem" />~{formatBytes(model.ramBytes)} RAM
-                    </span>
+                  <input
+                    type="radio"
+                    name="quantization"
+                    value={model.quantization}
+                    checked={selectedQuant === model.quantization}
+                    onChange={() => setSelectedQuant(model.quantization)}
+                    className="sr-only"
+                  />
+                  <div
+                    className={`h-4 w-4 shrink-0 rounded-full border-2 transition-colors ${
+                      selectedQuant === model.quantization ? "border-purple-400 bg-purple-400" : "border-[var(--border)]"
+                    }`}
+                  >
+                    {selectedQuant === model.quantization && (
+                      <div className="flex h-full items-center justify-center">
+                        <div className="h-1.5 w-1.5 rounded-full bg-white" />
+                      </div>
+                    )}
                   </div>
+                  <div className="flex-1">
+                    <div className="text-sm font-medium">{model.label}</div>
+                    <div className="flex items-center gap-3 text-xs text-[var(--muted-foreground)]/70">
+                      <span className="flex items-center gap-1">
+                        <Download size="0.75rem" />
+                        {formatBytes(model.sizeBytes)}
+                      </span>
+                      <span className="flex items-center gap-1">
+                        <HardDrive size="0.75rem" />~{formatBytes(model.ramBytes)} RAM
+                      </span>
+                    </div>
+                  </div>
+                  {model.quantization === "q8_0" && (
+                    <span className="rounded-full bg-purple-500/15 px-2 py-0.5 text-[0.625rem] font-medium text-purple-300">
+                      Recommended
+                    </span>
+                  )}
+                </label>
+              ))}
+              <button
+                onClick={handleCuratedDownload}
+                className="mt-1 flex items-center justify-center gap-2 rounded-xl bg-purple-500/15 px-4 py-2.5 text-sm font-medium text-purple-300 transition-colors hover:bg-purple-500/25"
+              >
+                <Zap size="0.875rem" />
+                {hasModel ? "Switch to Curated Model" : "Download Curated Model"}
+              </button>
+            </div>
+
+            <div className="rounded-xl border border-[var(--border)] bg-[var(--card)]/50 p-3">
+              <div className="text-xs font-medium uppercase tracking-wider text-[var(--muted-foreground)]/60">
+                Use Your Own Model From HuggingFace
+              </div>
+              <div className="mt-3 flex flex-col gap-2">
+                <div className="flex gap-2 max-sm:flex-col">
+                  <input
+                    value={repoInput}
+                    onChange={(event) => setRepoInput(event.target.value)}
+                    placeholder="owner/repo"
+                    className="flex-1 rounded-xl border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-sm outline-none transition-colors focus:border-purple-400/50"
+                  />
+                  <button
+                    onClick={() => void handleListModels()}
+                    disabled={!repoInput.trim() || customModelsLoading}
+                    className="flex items-center justify-center gap-2 rounded-xl border border-[var(--border)] px-4 py-2 text-sm text-[var(--foreground)] transition-colors hover:bg-[var(--secondary)] disabled:opacity-50"
+                  >
+                    {customModelsLoading ? <Loader2 size="0.875rem" className="animate-spin" /> : <Search size="0.875rem" />}
+                    List Models
+                  </button>
                 </div>
-                {model.quantization === "q8_0" && (
-                  <span className="rounded-full bg-purple-500/15 px-2 py-0.5 text-[0.625rem] font-medium text-purple-300">
-                    Recommended
-                  </span>
+
+                {customModelsError && (
+                  <div className="rounded-lg border border-red-500/20 bg-red-500/5 p-3 text-sm text-red-400">
+                    {customModelsError}
+                  </div>
                 )}
-              </label>
-            ))}
-          </div>
+
+                {customModels.length > 0 && (
+                  <>
+                    <select
+                      value={selectedCustomPath}
+                      onChange={(event) => setSelectedCustomPath(event.target.value)}
+                      className="rounded-xl border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-sm outline-none transition-colors focus:border-purple-400/50"
+                    >
+                      {customModels.map((entry) => (
+                        <option key={entry.path} value={entry.path}>
+                          {entry.filename}
+                          {entry.quantizationLabel ? ` • ${entry.quantizationLabel}` : ""}
+                          {entry.sizeBytes ? ` • ${formatBytes(entry.sizeBytes)}` : ""}
+                        </option>
+                      ))}
+                    </select>
+                    <button
+                      onClick={handleCustomDownload}
+                      disabled={!selectedCustomPath}
+                      className="flex items-center justify-center gap-2 rounded-xl bg-sky-500/15 px-4 py-2.5 text-sm font-medium text-sky-300 transition-colors hover:bg-sky-500/25 disabled:opacity-50"
+                    >
+                      <Download size="0.875rem" />
+                      {hasModel ? "Switch to Selected GGUF" : "Download Selected GGUF"}
+                    </button>
+                  </>
+                )}
+              </div>
+            </div>
+          </>
         )}
 
-        {/* Download progress */}
         {isDownloading && progress && (
           <div className="flex flex-col gap-2">
             <div className="flex items-center justify-between text-xs text-[var(--muted-foreground)]">
-              <span>Downloading model...</span>
+              <span>{progressLabel}</span>
               <span>
                 {formatBytes(progress.downloaded)}
                 {progress.total > 0 && ` / ${formatBytes(progress.total)}`}
@@ -225,57 +313,49 @@ export function ModelDownloadModal({ open, onClose }: Props) {
           </div>
         )}
 
-        {/* Error state */}
         {progress?.status === "error" && (
           <div className="rounded-lg border border-red-500/20 bg-red-500/5 p-3 text-sm text-red-400">
             {progress.error || "Download failed. Please try again."}
           </div>
         )}
 
-        {/* Actions — only when not downloaded */}
-        {!isDownloaded && (
-          <div className="flex items-center gap-2">
-            {!isDownloading ? (
-              <>
-                <button
-                  onClick={handleSkip}
-                  className="flex-1 rounded-xl border border-[var(--border)] px-4 py-2.5 text-sm text-[var(--muted-foreground)] transition-colors hover:bg-[var(--secondary)]"
-                >
-                  Skip for Now
-                </button>
-                <button
-                  onClick={handleDownload}
-                  className="flex flex-1 items-center justify-center gap-2 rounded-xl bg-purple-500/15 px-4 py-2.5 text-sm font-medium text-purple-300 transition-colors hover:bg-purple-500/25"
-                >
-                  <Zap size="0.875rem" />
-                  Download Model
-                </button>
-              </>
-            ) : (
+        <div className="flex items-center gap-2">
+          {isDownloading ? (
+            <button
+              onClick={() => void cancelDownload()}
+              className="flex w-full items-center justify-center gap-2 rounded-xl border border-[var(--border)] px-4 py-2.5 text-sm text-[var(--muted-foreground)] transition-colors hover:bg-[var(--secondary)]"
+            >
+              <X size="0.875rem" />
+              Cancel Download
+            </button>
+          ) : (
+            <>
               <button
-                onClick={handleCancel}
-                className="flex w-full items-center justify-center gap-2 rounded-xl border border-[var(--border)] px-4 py-2.5 text-sm text-[var(--muted-foreground)] transition-colors hover:bg-[var(--secondary)]"
+                onClick={handleSkip}
+                className="flex-1 rounded-xl border border-[var(--border)] px-4 py-2.5 text-sm text-[var(--muted-foreground)] transition-colors hover:bg-[var(--secondary)]"
               >
-                <X size="0.875rem" />
-                Cancel Download
+                {hasModel ? "Close" : "Skip for Now"}
               </button>
-            )}
-          </div>
-        )}
+              <button
+                onClick={handleDone}
+                className="flex flex-1 items-center justify-center gap-2 rounded-xl bg-purple-500/15 px-4 py-2.5 text-sm font-medium text-purple-300 transition-colors hover:bg-purple-500/25"
+              >
+                Done
+              </button>
+            </>
+          )}
+        </div>
 
-        {/* Features list — only when not yet downloaded */}
-        {!isDownloaded && !isDownloading && (
+        {!hasModel && !isDownloading && (
           <div className="rounded-xl border border-[var(--border)] bg-[var(--card)]/50 p-3">
             <span className="text-xs font-medium uppercase tracking-wider text-[var(--muted-foreground)]/60">
               What the local model handles
             </span>
             <ul className="mt-2 flex flex-col gap-1 text-xs text-[var(--muted-foreground)]/80">
-              <li>Tracker agents in roleplay mode (character state, world state, quests)</li>
+              <li>Tracker agents in roleplay mode</li>
               <li>Scene effects in game mode (backgrounds, music, SFX, ambient)</li>
-              <li>Widget updates (health bars, inventory, counters)</li>
-              <li>Character expression selection for sprites</li>
-              <li>Weather and time-of-day changes</li>
-              <li>NPC reputation tracking</li>
+              <li>Widget updates, weather, and time-of-day changes</li>
+              <li>NPC reputation tracking and expression selection</li>
             </ul>
           </div>
         )}

--- a/packages/client/src/components/panels/ConnectionsPanel.tsx
+++ b/packages/client/src/components/panels/ConnectionsPanel.tsx
@@ -50,10 +50,11 @@ function formatBytes(bytes: number): string {
 }
 
 function SidecarCard() {
-  const { status, config, modelSize, setShowDownloadModal, updateConfig, deleteModel, fetchStatus } = useSidecarStore();
-  const isDownloaded = !!config.modelPath;
+  const { status, config, modelDownloaded, modelSize, setShowDownloadModal, updateConfig, deleteModel, fetchStatus } =
+    useSidecarStore();
+  const isDownloaded = modelDownloaded;
   const [confirmDelete, setConfirmDelete] = useState(false);
-  const activeModelName = config.modelPath?.split("/").pop() ?? null;
+  const activeModelName = isDownloaded ? config.modelPath?.split("/").pop() ?? null : null;
 
   // Fetch status on mount (handles HMR store resets and initial load)
   useEffect(() => {

--- a/packages/client/src/components/panels/ConnectionsPanel.tsx
+++ b/packages/client/src/components/panels/ConnectionsPanel.tsx
@@ -23,7 +23,6 @@ import {
   BrainCircuit,
   Download,
   Trash,
-  AlertTriangle,
 } from "lucide-react";
 import { cn } from "../../lib/utils";
 
@@ -51,12 +50,10 @@ function formatBytes(bytes: number): string {
 }
 
 function SidecarCard() {
-  const { status, config, modelSize, runtimeInfo, setShowDownloadModal, updateConfig, deleteModel, fetchStatus } =
-    useSidecarStore();
-  const isDownloaded = status === "downloaded" || status === "ready" || status === "loading";
+  const { status, config, modelSize, setShowDownloadModal, updateConfig, deleteModel, fetchStatus } = useSidecarStore();
+  const isDownloaded = !!config.modelPath;
   const [confirmDelete, setConfirmDelete] = useState(false);
-  const runtimeNotice =
-    runtimeInfo && (runtimeInfo.state !== "ready" || runtimeInfo.reason === "manual_cpu") ? runtimeInfo : null;
+  const activeModelName = config.modelPath?.split("/").pop() ?? null;
 
   // Fetch status on mount (handles HMR store resets and initial load)
   useEffect(() => {
@@ -73,7 +70,15 @@ function SidecarCard() {
           <div className="text-sm font-medium">Local Model</div>
           <div className="text-[0.6875rem] text-[var(--muted-foreground)]">
             {isDownloaded
-              ? `Gemma 4 E2B • ${config.quantization?.toUpperCase()}${modelSize ? ` • ${formatBytes(modelSize)}` : ""}`
+              ? `${activeModelName ?? "Model"}${modelSize ? ` • ${formatBytes(modelSize)}` : ""}${
+                  status === "starting_server"
+                    ? " • Starting"
+                    : status === "server_error"
+                      ? " • Error"
+                      : status === "ready"
+                        ? " • Ready"
+                        : ""
+                }`
               : "Not downloaded"}
           </div>
         </div>
@@ -118,51 +123,6 @@ function SidecarCard() {
           </button>
         )}
       </div>
-
-      {runtimeNotice && (
-        <div
-          className={cn(
-            "mt-2.5 rounded-xl border p-2.5",
-            runtimeNotice.state === "failed"
-              ? "border-amber-400/25 bg-amber-400/10"
-              : runtimeNotice.state === "fallback"
-                ? "border-sky-400/25 bg-sky-400/10"
-                : "border-[var(--border)] bg-[var(--secondary)]/40",
-          )}
-        >
-          <div className="flex items-start gap-2">
-            <AlertTriangle
-              size="0.875rem"
-              className={cn(
-                "mt-0.5 shrink-0",
-                runtimeNotice.state === "failed"
-                  ? "text-amber-300"
-                  : runtimeNotice.state === "fallback"
-                    ? "text-sky-300"
-                    : "text-[var(--muted-foreground)]",
-              )}
-            />
-            <div className="min-w-0 flex-1">
-              <div className="text-xs font-medium">
-                {runtimeNotice.state === "failed"
-                  ? "Local Gemma is unavailable"
-                  : runtimeNotice.state === "fallback"
-                    ? "Local Gemma fell back to CPU"
-                    : "Local Gemma is using CPU only"}
-              </div>
-              <p className="mt-0.5 text-[0.6875rem] leading-relaxed text-[var(--muted-foreground)]">
-                {runtimeNotice.message}
-              </p>
-              {runtimeNotice.state === "failed" && (
-                <p className="mt-1 text-[0.6875rem] leading-relaxed text-[var(--muted-foreground)]">
-                  Marinara still works without the local model. Only the optional Gemma sidecar is affected.
-                </p>
-              )}
-            </div>
-          </div>
-        </div>
-      )}
-
       {/* Toggles (only when model is downloaded) */}
       {isDownloaded && (
         <div className="mt-2.5 flex flex-col gap-1.5 border-t border-purple-400/10 pt-2.5">

--- a/packages/client/src/stores/sidecar.store.ts
+++ b/packages/client/src/stores/sidecar.store.ts
@@ -19,6 +19,7 @@ import { api } from "../lib/api-client.js";
 interface SidecarState {
   status: SidecarStatus;
   config: SidecarConfig;
+  modelDownloaded: boolean;
   runtime: SidecarRuntimeInfo;
   inferenceReady: boolean;
   modelSize: number | null;
@@ -154,6 +155,7 @@ async function consumeDownloadStream(
 export const useSidecarStore = create<SidecarState>((set, get) => ({
   status: "not_downloaded",
   config: { ...SIDECAR_DEFAULT_CONFIG },
+  modelDownloaded: false,
   runtime: { installed: false, build: null, variant: null },
   inferenceReady: false,
   modelSize: null,
@@ -171,6 +173,7 @@ export const useSidecarStore = create<SidecarState>((set, get) => ({
       const nextState = {
         status: response.status,
         config: response.config,
+        modelDownloaded: response.modelDownloaded,
         runtime: response.runtime,
         inferenceReady: response.inferenceReady,
         modelSize: response.modelSize,
@@ -279,6 +282,7 @@ export const useSidecarStore = create<SidecarState>((set, get) => ({
       set({
         status: "not_downloaded",
         config: { ...SIDECAR_DEFAULT_CONFIG },
+        modelDownloaded: false,
         inferenceReady: false,
         modelSize: null,
       });

--- a/packages/client/src/stores/sidecar.store.ts
+++ b/packages/client/src/stores/sidecar.store.ts
@@ -1,10 +1,12 @@
 // ──────────────────────────────────────────────
-// Sidecar Store — Client state for local model
+// Sidecar Store — Client state for the local
+// llama-server runtime + GGUF model manager
 // ──────────────────────────────────────────────
 
 import { create } from "zustand";
 import type {
   SidecarConfig,
+  SidecarCustomModelEntry,
   SidecarDownloadProgress,
   SidecarRuntimeInfo,
   SidecarStatus,
@@ -17,18 +19,22 @@ import { api } from "../lib/api-client.js";
 interface SidecarState {
   status: SidecarStatus;
   config: SidecarConfig;
+  runtime: SidecarRuntimeInfo;
   inferenceReady: boolean;
   modelSize: number | null;
-  runtimeInfo: SidecarRuntimeInfo | null;
+  logPath: string | null;
   downloadProgress: SidecarDownloadProgress | null;
-  /** Whether the download/setup modal is open. */
+  customModels: SidecarCustomModelEntry[];
+  customModelsLoading: boolean;
+  customModelsError: string | null;
   showDownloadModal: boolean;
-  /** Has the user been prompted at least once (persisted in localStorage). */
   hasBeenPrompted: boolean;
 
-  // Actions
   fetchStatus: () => Promise<void>;
   startDownload: (quantization: SidecarQuantization) => Promise<void>;
+  startCustomDownload: (repo: string, modelPath: string) => Promise<void>;
+  listHuggingFaceModels: (repo: string) => Promise<SidecarCustomModelEntry[]>;
+  clearCustomModels: () => void;
   cancelDownload: () => Promise<void>;
   deleteModel: () => Promise<void>;
   unloadModel: () => Promise<void>;
@@ -40,145 +46,266 @@ interface SidecarState {
 }
 
 const PROMPTED_KEY = "marinara_sidecar_prompted";
+const TRANSITIONAL_STATUSES = new Set<SidecarStatus>(["downloading_runtime", "downloading_model", "starting_server"]);
+let statusPollTimer: number | null = null;
+
+function clearStatusPollTimer() {
+  if (statusPollTimer !== null) {
+    window.clearTimeout(statusPollTimer);
+    statusPollTimer = null;
+  }
+}
+
+function shouldKeepPolling(state: Pick<SidecarState, "status" | "config" | "inferenceReady">): boolean {
+  if (TRANSITIONAL_STATUSES.has(state.status)) {
+    return true;
+  }
+
+  if (state.status === "downloaded" && (state.config.useForTrackers || state.config.useForGameScene) && !state.inferenceReady) {
+    return true;
+  }
+
+  return false;
+}
+
+async function consumeDownloadStream(
+  path: string,
+  body: unknown,
+  set: (partial: Partial<SidecarState>) => void,
+  get: () => SidecarState,
+): Promise<void> {
+  const response = await fetch(path, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+    cache: "no-store",
+  });
+
+  if (!response.ok || !response.body) {
+    throw new Error("Download request failed");
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split("\n");
+    buffer = lines.pop() ?? "";
+
+    for (const line of lines) {
+      if (!line.startsWith("data: ")) continue;
+      try {
+        const data = JSON.parse(line.slice(6)) as Partial<SidecarDownloadProgress> & {
+          done?: boolean;
+          status?: string;
+          error?: string;
+        };
+
+        if (data.done) {
+          set({ downloadProgress: null });
+          await get().fetchStatus();
+          return;
+        }
+
+        if (data.status === "error") {
+          set({
+            downloadProgress: {
+              phase: (data.phase as SidecarDownloadProgress["phase"]) ?? "model",
+              status: "error",
+              downloaded: 0,
+              total: 0,
+              speed: 0,
+              error: data.error ?? "Download failed",
+              label: data.label,
+            },
+          });
+          await get().fetchStatus();
+          return;
+        }
+
+        if (data.status === "downloading") {
+          set({
+            downloadProgress: {
+              phase: (data.phase as SidecarDownloadProgress["phase"]) ?? "model",
+              status: "downloading",
+              downloaded: Number(data.downloaded ?? 0),
+              total: Number(data.total ?? 0),
+              speed: Number(data.speed ?? 0),
+              label: data.label,
+            },
+            status: (data.phase === "runtime" ? "downloading_runtime" : "downloading_model") as SidecarStatus,
+          });
+        }
+      } catch {
+        // Ignore malformed SSE chunks.
+      }
+    }
+  }
+
+  set({ downloadProgress: null });
+  await get().fetchStatus();
+}
 
 export const useSidecarStore = create<SidecarState>((set, get) => ({
   status: "not_downloaded",
   config: { ...SIDECAR_DEFAULT_CONFIG },
+  runtime: { installed: false, build: null, variant: null },
   inferenceReady: false,
   modelSize: null,
-  runtimeInfo: null,
+  logPath: null,
   downloadProgress: null,
+  customModels: [],
+  customModelsLoading: false,
+  customModelsError: null,
   showDownloadModal: false,
   hasBeenPrompted: localStorage.getItem(PROMPTED_KEY) === "true",
 
   fetchStatus: async () => {
     try {
-      const res = await api.get<SidecarStatusResponse & { inferenceReady: boolean }>("/sidecar/status");
-      set({
-        status: res.status,
-        config: res.config,
-        inferenceReady: res.inferenceReady,
-        modelSize: res.modelSize,
-        runtimeInfo: res.runtimeInfo,
-      });
+      const response = await api.get<SidecarStatusResponse & { inferenceReady: boolean }>("/sidecar/status");
+      const nextState = {
+        status: response.status,
+        config: response.config,
+        runtime: response.runtime,
+        inferenceReady: response.inferenceReady,
+        modelSize: response.modelSize,
+        logPath: response.logPath,
+      };
+      set(nextState);
+
+      clearStatusPollTimer();
+      if (shouldKeepPolling(nextState)) {
+        statusPollTimer = window.setTimeout(() => {
+          void get().fetchStatus();
+        }, 1500);
+      }
     } catch {
-      // Server might not support sidecar yet
+      // Best-effort: the server may not support sidecar yet.
     }
   },
 
   startDownload: async (quantization) => {
-    set({ downloadProgress: { status: "downloading", downloaded: 0, total: 0, speed: 0 } });
+    set({
+      status: "downloading_model",
+      downloadProgress: {
+        phase: "model",
+        status: "downloading",
+        downloaded: 0,
+        total: 0,
+        speed: 0,
+      },
+    });
 
     try {
-      const response = await fetch("/api/sidecar/download", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ quantization }),
+      await consumeDownloadStream("/api/sidecar/download", { quantization }, set, get);
+    } catch (error) {
+      set({
+        downloadProgress: {
+          phase: "model",
+          status: "error",
+          downloaded: 0,
+          total: 0,
+          speed: 0,
+          error: error instanceof Error ? error.message : "Download failed",
+        },
       });
-
-      if (!response.ok || !response.body) {
-        throw new Error("Download request failed");
-      }
-
-      const reader = response.body.getReader();
-      const decoder = new TextDecoder();
-      let buffer = "";
-
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-
-        buffer += decoder.decode(value, { stream: true });
-        const lines = buffer.split("\n");
-        buffer = lines.pop() || "";
-
-        for (const line of lines) {
-          if (!line.startsWith("data: ")) continue;
-          try {
-            const data = JSON.parse(line.slice(6)) as SidecarDownloadProgress;
-            set({ downloadProgress: data });
-
-            if (data.status === "complete") {
-              set({ status: "downloaded", downloadProgress: null });
-              get().fetchStatus();
-              return;
-            }
-            if (data.status === "error") {
-              set({ downloadProgress: data });
-              return;
-            }
-          } catch {
-            // Skip malformed events
-          }
-        }
-      }
-
-      // Process any remaining data in the buffer after stream ends
-      if (buffer.trim()) {
-        const remaining = buffer.split("\n");
-        for (const line of remaining) {
-          if (!line.startsWith("data: ")) continue;
-          try {
-            const data = JSON.parse(line.slice(6)) as SidecarDownloadProgress;
-            if (data.status === "complete") {
-              set({ status: "downloaded", downloadProgress: null });
-              get().fetchStatus();
-              return;
-            }
-          } catch {
-            // Skip malformed events
-          }
-        }
-      }
-
-      // Stream ended without explicit complete — fetch status to check
-      set({ downloadProgress: null });
-      await get().fetchStatus();
-    } catch {
-      // Only clear progress if it wasn't already set to error by an SSE event
-      if (get().downloadProgress?.status !== "error") {
-        set({ downloadProgress: null });
-      }
     }
+  },
+
+  startCustomDownload: async (repo, modelPath) => {
+    set({
+      status: "downloading_model",
+      downloadProgress: {
+        phase: "model",
+        status: "downloading",
+        downloaded: 0,
+        total: 0,
+        speed: 0,
+      },
+    });
+
+    try {
+      await consumeDownloadStream("/api/sidecar/download/custom", { repo, modelPath }, set, get);
+    } catch (error) {
+      set({
+        downloadProgress: {
+          phase: "model",
+          status: "error",
+          downloaded: 0,
+          total: 0,
+          speed: 0,
+          error: error instanceof Error ? error.message : "Download failed",
+        },
+      });
+    }
+  },
+
+  listHuggingFaceModels: async (repo) => {
+    set({ customModelsLoading: true, customModelsError: null });
+    try {
+      const response = await api.post<{ models: SidecarCustomModelEntry[] }>("/sidecar/models/list-huggingface", { repo });
+      set({ customModels: response.models, customModelsLoading: false, customModelsError: null });
+      return response.models;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to list HuggingFace models";
+      set({ customModels: [], customModelsLoading: false, customModelsError: message });
+      throw error;
+    }
+  },
+
+  clearCustomModels: () => {
+    set({ customModels: [], customModelsError: null, customModelsLoading: false });
   },
 
   cancelDownload: async () => {
     try {
       await api.post("/sidecar/download/cancel");
     } catch {
-      /* best-effort */
+      // Best-effort cancel.
     }
+
     set({ downloadProgress: null });
+    await get().fetchStatus();
   },
 
   deleteModel: async () => {
     try {
       await api.delete("/sidecar/model");
-      set({ status: "not_downloaded", inferenceReady: false, modelSize: null });
+      set({
+        status: "not_downloaded",
+        config: { ...SIDECAR_DEFAULT_CONFIG },
+        inferenceReady: false,
+        modelSize: null,
+      });
+      await get().fetchStatus();
     } catch {
-      /* best-effort */
+      // Best-effort delete.
     }
   },
 
   unloadModel: async () => {
     try {
       await api.post("/sidecar/unload");
-      set({ status: "downloaded", inferenceReady: false });
+      await get().fetchStatus();
     } catch {
-      /* best-effort */
+      // Best-effort unload.
     }
   },
 
   updateConfig: async (partial) => {
-    // Optimistic update so toggles feel instant
-    const prev = get().config;
-    set({ config: { ...prev, ...partial } });
+    const previous = get().config;
+    set({ config: { ...previous, ...partial } });
     try {
-      const res = await api.patch<{ config: SidecarConfig }>("/sidecar/config", partial);
-      set({ config: res.config });
+      const response = await api.patch<{ config: SidecarConfig }>("/sidecar/config", partial);
+      set({ config: response.config });
+      void get().fetchStatus();
     } catch {
-      // Revert on failure
-      set({ config: prev });
+      set({ config: previous });
     }
   },
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -40,7 +40,6 @@
   },
   "optionalDependencies": {
     "better-sqlite3": "^11.0.0",
-    "node-llama-cpp": "^3.5.0",
     "onnxruntime-node": "^1.24.3",
     "onnxruntime-web": "^1.24.3",
     "sharp": "^0.34.5",

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -24,6 +24,7 @@ import { basename, join, resolve, dirname } from "path";
 import { fileURLToPath } from "url";
 import { getBuildCommit, getBuildLabel } from "./config/build-info.js";
 import { getCorsConfig, getLogLevel, getNodeEnv } from "./config/runtime-config.js";
+import { sidecarProcessService } from "./services/sidecar/sidecar-process.service.js";
 
 const REVALIDATE_FILES = new Set(["index.html"]);
 const NO_STORE_FILES = new Set(["manifest.json", "sw.js", "registerSW.js"]);
@@ -89,6 +90,11 @@ export async function buildApp(https?: { cert: Buffer; key: Buffer }) {
 
   // ── Routes ──
   await registerRoutes(app);
+
+  // ── Sidecar bootstrap (background) ──
+  void sidecarProcessService.syncForCurrentConfig().catch((error) => {
+    app.log.warn({ err: error }, "sidecar bootstrap failed");
+  });
 
   // ── Serve client build in production ──
   const __dirname = dirname(fileURLToPath(import.meta.url));

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -98,6 +98,7 @@ import {
 import { getMoraleTier, formatMoraleContext } from "../services/game/morale.service.js";
 import type { GameNpc } from "@marinara-engine/shared";
 import { sidecarModelService } from "../services/sidecar/sidecar-model.service.js";
+import { isInferenceAvailable as isSidecarInferenceAvailable } from "../services/sidecar/sidecar-inference.service.js";
 import { readFileSync, existsSync, writeFileSync, mkdirSync } from "fs";
 import { join } from "path";
 
@@ -2258,7 +2259,7 @@ export async function generateRoutes(app: FastifyInstance) {
         // Determine if a separate scene model handles bg/music/sfx/widgets
         const sceneConnectionId = (setupConfig?.sceneConnectionId as string) || null;
         const sidecarCfg = sidecarModelService.getConfig();
-        const sidecarHandlesScene = sidecarCfg.useForGameScene && sidecarModelService.isReady();
+        const sidecarHandlesScene = sidecarCfg.useForGameScene && (await isSidecarInferenceAvailable());
         const hasSceneModel = !!sceneConnectionId || sidecarHandlesScene;
 
         // Approximate turn number: count user messages in the chat (each user message ≈ 1 turn)

--- a/packages/server/src/routes/sidecar.routes.ts
+++ b/packages/server/src/routes/sidecar.routes.ts
@@ -1,10 +1,12 @@
 // ──────────────────────────────────────────────
-// Sidecar Routes — Model management & inference
+// Sidecar Routes — Runtime, model management,
+// and localhost llama-server inference
 // ──────────────────────────────────────────────
 
-import type { FastifyPluginAsync } from "fastify";
+import type { FastifyPluginAsync, FastifyReply } from "fastify";
 import { z } from "zod";
 import { sidecarModelService } from "../services/sidecar/sidecar-model.service.js";
+import { sidecarRuntimeService } from "../services/sidecar/sidecar-runtime.service.js";
 import {
   analyzeScene,
   isInferenceAvailable,
@@ -12,50 +14,72 @@ import {
   runTrackerPrompt,
   unloadModel,
 } from "../services/sidecar/sidecar-inference.service.js";
+import { sidecarProcessService } from "../services/sidecar/sidecar-process.service.js";
 import {
   buildSceneAnalyzerSystemPrompt,
   buildSceneAnalyzerUserPrompt,
   type SceneAnalyzerContext,
 } from "../services/sidecar/scene-analyzer.js";
 import { postProcessSceneResult, type PostProcessContext } from "../services/sidecar/scene-postprocess.js";
-import { scoreMusic, scoreAmbient, type GameActiveState } from "@marinara-engine/shared";
-import type { SidecarQuantization } from "@marinara-engine/shared";
+import {
+  scoreAmbient,
+  scoreMusic,
+  type GameActiveState,
+  type SidecarDownloadProgress,
+  type SidecarQuantization,
+} from "@marinara-engine/shared";
+
+const quantizationSchema = z.enum(["q8_0", "q4_k_m"]);
+const hfRepoSchema = z.string().trim().regex(/^[^/\s]+\/[^/\s]+$/, "Repository must be in owner/repo format");
 
 export const sidecarRoutes: FastifyPluginAsync = async (app) => {
-  // ── Status ──
-  app.get("/status", async () => {
-    const status = sidecarModelService.getStatus();
-    const inferenceReady = await isInferenceAvailable();
-    return { ...status, inferenceReady };
+  app.addHook("onClose", async () => {
+    await sidecarProcessService.stop();
   });
 
-  // ── Update Config ──
+  app.get("/status", async () => {
+    void sidecarProcessService.syncForCurrentConfig().catch((error) => {
+      console.error("[sidecar] Background sync from /status failed:", error);
+    });
+
+    const status = sidecarModelService.getStatus();
+    return {
+      ...status,
+      inferenceReady: sidecarProcessService.isReady(),
+    };
+  });
+
   const configSchema = z.object({
     useForTrackers: z.boolean().optional(),
     useForGameScene: z.boolean().optional(),
     contextSize: z.number().int().min(512).max(32768).optional(),
-    gpuLayers: z.number().int().min(-1).max(256).optional(),
+    gpuLayers: z.number().int().min(-1).max(1024).optional(),
   });
 
   app.patch("/config", async (req) => {
     const body = configSchema.parse(req.body);
     const config = sidecarModelService.updateConfig(body);
+    void sidecarProcessService.syncForCurrentConfig().catch((error) => {
+      console.error("[sidecar] Background sync from /config failed:", error);
+    });
     return { config };
   });
 
-  // ── Download Model (SSE progress stream) ──
-  app.post<{
-    Body: { quantization: SidecarQuantization };
-  }>("/download", async (req, reply) => {
-    const { quantization } = req.body;
-    if (!quantization || !["q8_0", "q4_k_m"].includes(quantization)) {
-      return reply.status(400).send({ error: "Invalid quantization. Must be q8_0 or q4_k_m." });
-    }
+  const listCustomModelsSchema = z.object({
+    repo: hfRepoSchema,
+  });
 
-    // Hijack the response so Fastify doesn't try to finalize it
-    await reply.hijack();
+  app.post("/models/list-huggingface", async (req) => {
+    const body = listCustomModelsSchema.parse(req.body);
+    const models = await sidecarModelService.listHuggingFaceModels(body.repo);
+    return { models };
+  });
 
-    // Set up SSE response
+  async function handleDownloadSse(
+    reply: FastifyReply,
+    task: () => Promise<void>,
+  ): Promise<void> {
+    reply.hijack();
     reply.raw.writeHead(200, {
       "Content-Type": "text/event-stream",
       "Cache-Control": "no-cache",
@@ -66,44 +90,80 @@ export const sidecarRoutes: FastifyPluginAsync = async (app) => {
       reply.raw.write(`data: ${JSON.stringify(data)}\n\n`);
     };
 
-    try {
-      await sidecarModelService.download(quantization, (progress) => {
+    let lastProgressPhase: SidecarDownloadProgress["phase"] | undefined;
+    let lastProgressLabel: string | undefined;
+    const listener = (progress: SidecarDownloadProgress) => {
+      lastProgressPhase = progress.phase;
+      lastProgressLabel = progress.label;
+      if (progress.status === "downloading") {
         sendEvent(progress);
-      });
-      sendEvent({ status: "complete" });
-    } catch (err) {
+      }
+    };
+    sidecarModelService.addProgressListener(listener);
+
+    try {
+      await task();
+      sendEvent({ done: true });
+    } catch (error) {
       sendEvent({
         status: "error",
-        error: err instanceof Error ? err.message : "Download failed",
+        phase: lastProgressPhase,
+        label: lastProgressLabel,
+        error: error instanceof Error ? error.message : "Download failed",
       });
     } finally {
+      sidecarModelService.removeProgressListener(listener);
       reply.raw.end();
     }
+  }
+
+  app.post<{
+    Body: { quantization: SidecarQuantization };
+  }>("/download", async (req, reply) => {
+    const { quantization } = z.object({ quantization: quantizationSchema }).parse(req.body);
+    await handleDownloadSse(reply, async () => {
+      await sidecarModelService.download(quantization);
+      await sidecarProcessService.syncForCurrentConfig();
+    });
   });
 
-  // ── Cancel Download ──
+  app.post<{
+    Body: { repo: string; modelPath: string };
+  }>("/download/custom", async (req, reply) => {
+    const body = z
+      .object({
+        repo: hfRepoSchema,
+        modelPath: z.string().min(1),
+      })
+      .parse(req.body);
+
+    await handleDownloadSse(reply, async () => {
+      await sidecarModelService.downloadCustomModel(body.repo, body.modelPath);
+      await sidecarProcessService.syncForCurrentConfig();
+    });
+  });
+
   app.post("/download/cancel", async () => {
     sidecarModelService.cancelDownload();
+    sidecarRuntimeService.cancelInstall();
     return { ok: true };
   });
 
-  // ── Delete Model ──
   app.delete("/model", async (_req, reply) => {
     if (isInferenceBusy()) {
-      return reply.status(409).send({ error: "Cannot delete model while inference is in progress" });
+      return reply.status(409).send({ error: "Cannot delete the sidecar model while inference is in progress" });
     }
-    await unloadModel();
+
+    await sidecarProcessService.stop();
     sidecarModelService.deleteModel();
     return { ok: true };
   });
 
-  // ── Unload Model (free RAM without deleting file) ──
   app.post("/unload", async () => {
     await unloadModel();
     return { ok: true };
   });
 
-  // ── Scene Analysis (game mode) ──
   const sceneBodySchema = z.object({
     narration: z.string().max(16000),
     playerAction: z.string().max(4000).optional(),
@@ -126,82 +186,61 @@ export const sidecarRoutes: FastifyPluginAsync = async (app) => {
     const body = sceneBodySchema.parse(req.body);
     const available = await isInferenceAvailable();
     if (!available) {
-      return reply.status(503).send({ error: "Sidecar model not available" });
+      return reply.status(503).send({ error: "Sidecar model is not available" });
     }
 
     const bgTags = body.context.availableBackgrounds ?? [];
     const sfxTags = body.context.availableSfx ?? [];
-    console.log(`[scene-analysis] Available: ${bgTags.length} bg, ${sfxTags.length} sfx`);
 
     const sceneCtx = body.context as SceneAnalyzerContext;
     const systemPrompt = buildSceneAnalyzerSystemPrompt(sceneCtx);
     const userPrompt = buildSceneAnalyzerUserPrompt(body.narration, body.playerAction, sceneCtx);
 
-    console.log("[scene-analysis] === SYSTEM PROMPT ===");
-    console.log(systemPrompt);
-    console.log("[scene-analysis] === USER PROMPT ===");
-    console.log(userPrompt);
-    console.log("[scene-analysis] === END PROMPTS ===");
-
     try {
       const raw = await analyzeScene(systemPrompt, userPrompt);
 
-      // Post-process: fuzzy-match prose → real tags, normalise expressions,
-      // and filter widget updates to valid IDs.
       const widgets = (body.context.activeWidgets ?? []) as { id?: string }[];
       const ppCtx: PostProcessContext = {
         availableBackgrounds: bgTags,
         availableSfx: sfxTags,
-        validWidgetIds: new Set(widgets.map((w) => w.id).filter(Boolean) as string[]),
+        validWidgetIds: new Set(widgets.map((widget) => widget.id).filter(Boolean) as string[]),
         characterNames: body.context.characterNames ?? [],
       };
       const result = postProcessSceneResult(raw, ppCtx);
 
-      // ── Dynamic music & ambient scoring ──
-      // Read available tags from server-side manifest.
       const { getAssetManifest } = await import("../services/game/asset-manifest.service.js");
-      const assetManifest = getAssetManifest();
-      const allAssetKeys = Object.keys(assetManifest.assets ?? {});
-      const serverMusicTags = allAssetKeys.filter((k: string) => k.startsWith("music:"));
-      const serverAmbientTags = allAssetKeys.filter((k: string) => k.startsWith("ambient:"));
+      const manifest = getAssetManifest();
+      const assetKeys = Object.keys(manifest.assets ?? {});
+      const musicTags = assetKeys.filter((key) => key.startsWith("music:"));
+      const ambientTags = assetKeys.filter((key) => key.startsWith("ambient:"));
 
       const scoredMusic = scoreMusic({
         state: (body.context.currentState as GameActiveState) ?? "exploration",
         weather: result.weather ?? body.context.currentWeather ?? null,
         timeOfDay: result.timeOfDay ?? body.context.currentTimeOfDay ?? null,
         currentMusic: body.context.currentMusic ?? null,
-        availableMusic: serverMusicTags,
+        availableMusic: musicTags,
       });
-      if (scoredMusic) {
-        result.music = scoredMusic;
-      } else if (result.music) {
-        result.music = null;
-      }
+      result.music = scoredMusic ?? null;
 
       const scoredAmbient = scoreAmbient({
         state: (body.context.currentState as GameActiveState) ?? "exploration",
         weather: result.weather ?? body.context.currentWeather ?? null,
         timeOfDay: result.timeOfDay ?? body.context.currentTimeOfDay ?? null,
         currentAmbient: body.context.currentAmbient ?? null,
-        availableAmbient: serverAmbientTags,
+        availableAmbient: ambientTags,
         background: result.background ?? body.context.currentBackground,
       });
-      if (scoredAmbient) {
-        result.ambient = scoredAmbient;
-      } else if (result.ambient) {
-        result.ambient = null;
-      }
+      result.ambient = scoredAmbient ?? null;
 
-      console.log("[scene-analysis] Post-processed result:", JSON.stringify(result, null, 2));
       return { result };
-    } catch (err) {
+    } catch (error) {
       return reply.status(500).send({
-        error: err instanceof Error ? err.message : "Scene analysis failed",
+        error: error instanceof Error ? error.message : "Scene analysis failed",
       });
     }
   });
 
-  // ── Tracker Inference (roleplay mode) ──
   const trackerBodySchema = z.object({
     systemPrompt: z.string().max(16000),
     userPrompt: z.string().max(16000),
@@ -211,15 +250,15 @@ export const sidecarRoutes: FastifyPluginAsync = async (app) => {
     const body = trackerBodySchema.parse(req.body);
     const available = await isInferenceAvailable();
     if (!available) {
-      return reply.status(503).send({ error: "Sidecar model not available" });
+      return reply.status(503).send({ error: "Sidecar model is not available" });
     }
 
     try {
       const result = await runTrackerPrompt(body.systemPrompt, body.userPrompt);
       return { result };
-    } catch (err) {
+    } catch (error) {
       return reply.status(500).send({
-        error: err instanceof Error ? err.message : "Tracker inference failed",
+        error: error instanceof Error ? error.message : "Tracker inference failed",
       });
     }
   });

--- a/packages/server/src/services/sidecar/sidecar-download.ts
+++ b/packages/server/src/services/sidecar/sidecar-download.ts
@@ -1,0 +1,165 @@
+import { createWriteStream, existsSync, mkdirSync, renameSync, unlinkSync } from "fs";
+import { dirname } from "path";
+import { Readable } from "stream";
+import { pipeline as streamPipeline } from "stream/promises";
+import type { SidecarDownloadProgress } from "@marinara-engine/shared";
+import { sanitizeApiError } from "../llm/base-provider.js";
+
+const USER_AGENT = "MarinaraEngine";
+
+export function isAbortError(error: unknown): boolean {
+  if (typeof DOMException !== "undefined" && error instanceof DOMException && error.name === "AbortError") {
+    return true;
+  }
+
+  const message = error instanceof Error ? error.message : String(error);
+  return /abort/i.test(message);
+}
+
+export interface DownloadFileOptions {
+  url: string;
+  destPath: string;
+  signal?: AbortSignal;
+  headers?: Record<string, string>;
+  progress: Omit<SidecarDownloadProgress, "downloaded" | "total" | "speed" | "status">;
+  onProgress?: (progress: SidecarDownloadProgress) => void;
+}
+
+export async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(url, {
+    ...init,
+    headers: {
+      Accept: "application/json",
+      "User-Agent": USER_AGENT,
+      ...(init?.headers ?? {}),
+    },
+  });
+
+  if (!response.ok) {
+    const raw = await response.text().catch(() => "");
+    throw new Error(`HTTP ${response.status}: ${sanitizeApiError(raw || response.statusText)}`);
+  }
+
+  return (await response.json()) as T;
+}
+
+export async function retry<T>(
+  fn: () => Promise<T>,
+  options: {
+    retries: number;
+    baseDelayMs: number;
+    shouldRetry?: (error: unknown) => boolean;
+  },
+): Promise<T> {
+  const shouldRetry = options.shouldRetry ?? (() => true);
+  let attempt = 0;
+  let lastError: unknown;
+
+  while (attempt < options.retries) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+      attempt += 1;
+      if (attempt >= options.retries || !shouldRetry(error)) {
+        throw error;
+      }
+      const delayMs = options.baseDelayMs * 2 ** (attempt - 1);
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+
+  throw lastError instanceof Error ? lastError : new Error("Retry failed");
+}
+
+export async function downloadFileWithProgress(options: DownloadFileOptions): Promise<void> {
+  mkdirSync(dirname(options.destPath), { recursive: true });
+
+  const tempPath = `${options.destPath}.download`;
+  try {
+    if (existsSync(tempPath)) unlinkSync(tempPath);
+  } catch {
+    // Best-effort cleanup for stale temp files.
+  }
+  try {
+    if (existsSync(options.destPath)) unlinkSync(options.destPath);
+  } catch {
+    // Best-effort cleanup for stale destination files.
+  }
+
+  const response = await fetch(options.url, {
+    signal: options.signal,
+    headers: {
+      "User-Agent": USER_AGENT,
+      ...(options.headers ?? {}),
+    },
+  });
+
+  if (!response.ok) {
+    const raw = await response.text().catch(() => "");
+    throw new Error(`HTTP ${response.status}: ${sanitizeApiError(raw || response.statusText)}`);
+  }
+
+  if (!response.body) {
+    throw new Error("Download response had no body");
+  }
+
+  const total = Number.parseInt(response.headers.get("content-length") || "0", 10) || 0;
+  let downloaded = 0;
+  let lastReportTime = Date.now();
+  let lastReportBytes = 0;
+
+  const reader = response.body.getReader();
+  const writable = createWriteStream(tempPath);
+
+  const readable = new Readable({
+    async read() {
+      try {
+        const { done, value } = await reader.read();
+        if (done) {
+          this.push(null);
+          return;
+        }
+
+        downloaded += value.byteLength;
+        const now = Date.now();
+        if (now - lastReportTime >= 250) {
+          const elapsedSeconds = (now - lastReportTime) / 1000;
+          const speed = elapsedSeconds > 0 ? (downloaded - lastReportBytes) / elapsedSeconds : 0;
+          options.onProgress?.({
+            ...options.progress,
+            status: "downloading",
+            downloaded,
+            total,
+            speed,
+          });
+          lastReportTime = now;
+          lastReportBytes = downloaded;
+        }
+
+        this.push(value);
+      } catch (error) {
+        this.destroy(error as Error);
+      }
+    },
+  });
+
+  try {
+    await streamPipeline(readable, writable);
+    renameSync(tempPath, options.destPath);
+    options.onProgress?.({
+      ...options.progress,
+      status: "complete",
+      downloaded: total || downloaded,
+      total: total || downloaded,
+      speed: 0,
+    });
+  } catch (error) {
+    try {
+      if (existsSync(tempPath)) unlinkSync(tempPath);
+    } catch {
+      // Best-effort cleanup on failure.
+    }
+    throw error;
+  }
+}

--- a/packages/server/src/services/sidecar/sidecar-inference.service.ts
+++ b/packages/server/src/services/sidecar/sidecar-inference.service.ts
@@ -1,221 +1,189 @@
 // ──────────────────────────────────────────────
 // Sidecar Local Model — Inference Service
 //
-// Loads the GGUF model via node-llama-cpp and
-// runs inference with JSON schema grammar
-// constraints. Falls back gracefully when the
-// native module isn't available.
+// Talks to a spawned llama-server subprocess via
+// its OpenAI-compatible localhost HTTP API.
 // ──────────────────────────────────────────────
 
 import type { SceneAnalysis } from "@marinara-engine/shared";
+import { sanitizeApiError } from "../llm/base-provider.js";
 import { sidecarModelService } from "./sidecar-model.service.js";
+import { sidecarProcessService } from "./sidecar-process.service.js";
 
-// node-llama-cpp is an optional dependency — all access is via dynamic import.
-// We store runtime references as `unknown` and cast at call sites to avoid
-// needing the types at compile time.
+let activeRequests = 0;
 
-let llamaModuleLoaded = false;
-let llamaModule: Record<string, unknown> | null = null;
-let llamaInstance: unknown | null = null;
-let loadedModel: unknown | null = null;
-let modelContext: unknown | null = null;
-let sceneContext: unknown | null = null;
+function withRequestTracking<T>(fn: () => Promise<T>): Promise<T> {
+  activeRequests += 1;
+  return fn().finally(() => {
+    activeRequests = Math.max(0, activeRequests - 1);
+  });
+}
 
-/** Simple async mutex — only one inference at a time. */
-let inferenceLock: Promise<void> = Promise.resolve();
 export function isInferenceBusy(): boolean {
-  let busy = true;
-  inferenceLock.then(() => {
-    busy = false;
-  });
-  return busy;
-}
-function withInferenceLock<T>(fn: () => Promise<T>): Promise<T> {
-  let release: () => void;
-  const next = new Promise<void>((r) => {
-    release = r;
-  });
-  const prev = inferenceLock;
-  inferenceLock = next;
-  return prev.then(fn).finally(() => release!());
+  return activeRequests > 0;
 }
 
-/** Maximum output tokens for all sidecar generations. */
 const MAX_OUTPUT_TOKENS = 8192;
-
-/** Max output tokens for scene analysis — bounded JSON, typically ~100-300 tokens. */
 const SCENE_ANALYSIS_MAX_TOKENS = 4096;
 
-/** Fixed context size for scene analysis — narration + asset lists + output headroom. */
-const SCENE_ANALYSIS_CONTEXT_SIZE = 16_384;
+type SidecarMessage = {
+  role: "system" | "user" | "assistant";
+  content: string;
+};
 
-function getLoadErrorMessage(err: unknown): string {
-  if (err instanceof Error) return err.message;
-  return String(err);
-}
-
-function isGemma4ArchitectureError(err: unknown): boolean {
-  const message = getLoadErrorMessage(err).toLowerCase();
-  return message.includes("unknown model architecture") && message.includes("gemma4");
-}
-
-function formatModelLoadError(err: unknown): Error {
-  if (isGemma4ArchitectureError(err)) {
-    return new Error(
-      "The local Gemma runtime is too old to load Gemma 4. Restart Marinara Engine so it can rebuild llama.cpp, then try again.",
-    );
+function extractContentText(content: unknown): string {
+  if (typeof content === "string") {
+    return content;
   }
-  return err instanceof Error ? err : new Error(getLoadErrorMessage(err));
-}
 
-async function loadModelWithGpuPreference(
-  llama: { loadModel: (opts: Record<string, unknown>) => Promise<unknown> },
-  modelPath: string,
-  config: ReturnType<typeof sidecarModelService.getConfig>,
-): Promise<unknown> {
-  const baseOptions = {
-    modelPath,
-    // Enable FA at model level so GPU layer auto-fitting accounts for the
-    // reduced memory footprint of flash attention.
-    defaultContextFlashAttention: true,
-  };
-
-  if (config.gpuLayers !== -1) {
-    console.log(`[sidecar] Loading model with user-configured gpuLayers=${config.gpuLayers}`);
-    try {
-      return await llama.loadModel({ ...baseOptions, gpuLayers: config.gpuLayers });
-    } catch (err) {
-      throw formatModelLoadError(err);
+  if (Array.isArray(content)) {
+    let text = "";
+    for (const item of content) {
+      if (typeof item !== "object" || item === null) continue;
+      const part = item as Record<string, unknown>;
+      if (part.type === "text" && typeof part.text === "string") {
+        text += part.text;
+      }
     }
+    return text;
   }
 
+  return "";
+}
+
+function extractJsonPayload<T>(raw: string): T {
   try {
-    console.log("[sidecar] Loading model with gpuLayers=max (prefer full GPU offload)");
-    return await llama.loadModel({ ...baseOptions, gpuLayers: "max" });
-  } catch (err) {
-    if (isGemma4ArchitectureError(err)) {
-      throw formatModelLoadError(err);
-    }
-
-    console.warn(
-      `[sidecar] Full GPU offload failed (${getLoadErrorMessage(err)}). Retrying with fitted auto GPU layers.`,
-    );
-
-    try {
-      return await llama.loadModel({
-        ...baseOptions,
-        gpuLayers: {
-          min: 1,
-          fitContext: { contextSize: Math.max(config.contextSize, SCENE_ANALYSIS_CONTEXT_SIZE) },
-        },
-      });
-    } catch (fallbackErr) {
-      throw formatModelLoadError(fallbackErr);
-    }
-  }
-}
-
-/** Try to import node-llama-cpp. Returns null if not installed. */
-async function getLlamaModule(): Promise<Record<string, unknown> | null> {
-  if (llamaModuleLoaded) return llamaModule;
-  llamaModuleLoaded = true;
-  try {
-    // Use a variable to prevent TypeScript from resolving this at compile time
-    const moduleName = "node-llama-cpp";
-    llamaModule = (await import(/* webpackIgnore: true */ moduleName)) as Record<string, unknown>;
-    return llamaModule;
+    return JSON.parse(raw) as T;
   } catch {
-    return null;
+    const fenced = raw.match(/```(?:json)?\s*([\s\S]*?)```/i)?.[1];
+    if (fenced) {
+      return JSON.parse(fenced) as T;
+    }
+    throw new Error("Sidecar returned invalid JSON");
   }
 }
 
-/** Initialize the llama runtime (once). */
-async function ensureLlama(): Promise<unknown> {
-  if (llamaInstance) return llamaInstance;
-  const mod = await getLlamaModule();
-  if (!mod) throw new Error("node-llama-cpp is not installed. Run: pnpm add node-llama-cpp");
-  const getLlama = mod.getLlama as (opts?: Record<string, unknown>) => Promise<unknown>;
-  llamaInstance = await getLlama({ gpu: "auto" });
-  return llamaInstance;
-}
+async function streamChatCompletion(options: {
+  messages: SidecarMessage[];
+  maxTokens: number;
+  responseFormat?: Record<string, unknown>;
+}): Promise<string> {
+  const baseUrl = await sidecarProcessService.ensureReady();
+  const response = await fetch(`${baseUrl}/v1/chat/completions`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: "local-sidecar",
+      stream: true,
+      messages: options.messages,
+      max_tokens: options.maxTokens,
+      temperature: 1.0,
+      top_p: 0.95,
+      top_k: 64,
+      ...(options.responseFormat ? { response_format: options.responseFormat } : {}),
+    }),
+    signal: AbortSignal.timeout(5 * 60_000),
+  });
 
-/** Load the GGUF model into memory. */
-async function ensureModel(): Promise<unknown> {
-  if (loadedModel) return loadedModel;
-
-  const modelPath = sidecarModelService.getModelFilePath();
-  if (!modelPath) throw new Error("No sidecar model downloaded");
-
-  const config = sidecarModelService.getConfig();
-  sidecarModelService.setStatus("loading");
-
-  try {
-    const llama = (await ensureLlama()) as { loadModel: (opts: Record<string, unknown>) => Promise<unknown> };
-    loadedModel = await loadModelWithGpuPreference(llama, modelPath, config);
-    const resolvedGpuLayers = (loadedModel as { gpuLayers?: number } | null)?.gpuLayers;
-    console.log(
-      `[sidecar] Model loaded (gpuLayers=${resolvedGpuLayers ?? "unknown"}, contextSize=${config.contextSize})`,
-    );
-    sidecarModelService.setStatus("ready");
-    return loadedModel;
-  } catch (err) {
-    sidecarModelService.setStatus("error");
-    throw formatModelLoadError(err);
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => "");
+    throw new Error(`llama-server error ${response.status}: ${sanitizeApiError(errorText || response.statusText)}`);
   }
+
+  if (!response.body) {
+    throw new Error("llama-server returned no response body");
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let content = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split("\n");
+    buffer = lines.pop() ?? "";
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed.startsWith("data: ")) continue;
+
+      const data = trimmed.slice(6);
+      if (data === "[DONE]") {
+        return content;
+      }
+
+      try {
+        const parsed = JSON.parse(data) as {
+          choices?: Array<{
+            delta?: { content?: unknown };
+            message?: { content?: unknown };
+          }>;
+        };
+
+        const choice = parsed.choices?.[0];
+        if (!choice) continue;
+        if (choice.delta?.content !== undefined) {
+          content += extractContentText(choice.delta.content);
+        } else if (choice.message?.content !== undefined) {
+          content += extractContentText(choice.message.content);
+        }
+      } catch {
+        // Ignore malformed chunks and keep streaming.
+      }
+    }
+  }
+
+  if (buffer.trim().startsWith("data: ")) {
+    const trailing = buffer.trim().slice(6);
+    if (trailing !== "[DONE]") {
+      try {
+        const parsed = JSON.parse(trailing) as {
+          choices?: Array<{
+            delta?: { content?: unknown };
+            message?: { content?: unknown };
+          }>;
+        };
+        const choice = parsed.choices?.[0];
+        if (choice?.delta?.content !== undefined) {
+          content += extractContentText(choice.delta.content);
+        } else if (choice?.message?.content !== undefined) {
+          content += extractContentText(choice.message.content);
+        }
+      } catch {
+        // Ignore malformed trailing chunk.
+      }
+    }
+  }
+
+  return content;
 }
 
-/** Create a context for inference. */
-async function ensureContext(): Promise<unknown> {
-  if (modelContext) return modelContext;
-  const model = (await ensureModel()) as { createContext: (opts: Record<string, unknown>) => Promise<unknown> };
-  const config = sidecarModelService.getConfig();
-  modelContext = await model.createContext({
-    contextSize: config.contextSize,
-    flashAttention: true,
-    // Larger batch = faster prompt evaluation (process more tokens per GPU pass).
-    batchSize: config.contextSize,
-    // Use all available CPU math cores for token evaluation.
-    threads: 0,
-  });
-  return modelContext;
-}
-
-/** Create (or reuse) a lightweight context dedicated to scene analysis. */
-async function ensureSceneContext(): Promise<unknown> {
-  if (sceneContext) return sceneContext;
-  const model = (await ensureModel()) as { createContext: (opts: Record<string, unknown>) => Promise<unknown> };
-  sceneContext = await model.createContext({
-    contextSize: SCENE_ANALYSIS_CONTEXT_SIZE,
-    flashAttention: true,
-    batchSize: SCENE_ANALYSIS_CONTEXT_SIZE,
-    threads: 0,
-  });
-  return sceneContext;
-}
-
-/** Unload the model and free memory. */
 export async function unloadModel(): Promise<void> {
-  if (sceneContext && typeof (sceneContext as { dispose?: () => void }).dispose === "function") {
-    (sceneContext as { dispose: () => void }).dispose();
-  }
-  sceneContext = null;
-
-  if (modelContext && typeof (modelContext as { dispose?: () => void }).dispose === "function") {
-    (modelContext as { dispose: () => void }).dispose();
-  }
-  modelContext = null;
-
-  if (loadedModel && typeof (loadedModel as { dispose?: () => void }).dispose === "function") {
-    (loadedModel as { dispose: () => void }).dispose();
-  }
-  loadedModel = null;
-
-  sidecarModelService.setStatus("downloaded");
+  await sidecarProcessService.stop();
 }
 
-// ── JSON Schema Definitions ──
+const SCENE_WIDGET_UPDATE_SCHEMA = {
+  type: "object" as const,
+  properties: {
+    widgetId: { type: "string" as const },
+    value: { type: ["number", "string"] as const },
+    count: { type: "number" as const },
+    add: { type: "string" as const },
+    remove: { type: "string" as const },
+    running: { type: "boolean" as const },
+    seconds: { type: "number" as const },
+    statName: { type: "string" as const },
+  },
+  required: ["widgetId"] as const,
+  additionalProperties: false as const,
+};
 
-/** JSON schema for SceneAnalysis output — used for grammar-constrained generation. */
 const SCENE_ANALYSIS_SCHEMA = {
   type: "object" as const,
   properties: {
@@ -234,7 +202,13 @@ const SCENE_ANALYSIS_SCHEMA = {
           action: { type: "string" as const },
         },
         required: ["npcName", "action"] as const,
+        additionalProperties: false as const,
       },
+    },
+    widgetUpdates: {
+      type: "array" as const,
+      maxItems: 20,
+      items: SCENE_WIDGET_UPDATE_SCHEMA,
     },
     segmentEffects: {
       type: "array" as const,
@@ -243,118 +217,73 @@ const SCENE_ANALYSIS_SCHEMA = {
         type: "object" as const,
         properties: {
           segment: { type: "number" as const },
-          sfx: { type: "array" as const, items: { type: "string" as const }, maxItems: 3 },
-          background: { type: "string" as const },
+          background: { type: ["string", "null"] as const },
+          music: { type: ["string", "null"] as const },
+          ambient: { type: ["string", "null"] as const },
+          sfx: {
+            type: "array" as const,
+            items: { type: "string" as const },
+            maxItems: 3,
+          },
+          expressions: {
+            type: "object" as const,
+            additionalProperties: { type: "string" as const },
+          },
+          widgetUpdates: {
+            type: "array" as const,
+            items: SCENE_WIDGET_UPDATE_SCHEMA,
+            maxItems: 10,
+          },
         },
         required: ["segment"] as const,
+        additionalProperties: false as const,
       },
     },
   },
   additionalProperties: false as const,
-  required: ["background", "music", "ambient", "weather", "timeOfDay", "reputationChanges", "segmentEffects"] as const,
+  required: ["background", "music", "ambient", "weather", "timeOfDay", "reputationChanges", "widgetUpdates", "segmentEffects"] as const,
 };
 
-// ── Public Inference API ──
-
-/**
- * Run scene analysis on a completed narration turn.
- * Returns a structured SceneAnalysis object with grammar-enforced JSON.
- */
 export async function analyzeScene(systemPrompt: string, userPrompt: string): Promise<SceneAnalysis> {
-  return withInferenceLock(async () => {
-    console.log("[sidecar] Starting scene analysis inference...");
-    console.log(
-      `[sidecar] System prompt length: ${systemPrompt.length} chars, User prompt length: ${userPrompt.length} chars`,
-    );
-    const startTime = Date.now();
-    const mod = await getLlamaModule();
-    if (!mod) throw new Error("node-llama-cpp is not installed");
+  return withRequestTracking(async () => {
+    const raw = await streamChatCompletion({
+      messages: [
+        { role: "system", content: systemPrompt },
+        { role: "user", content: userPrompt },
+      ],
+      maxTokens: SCENE_ANALYSIS_MAX_TOKENS,
+      responseFormat: {
+        type: "json_schema",
+        schema: SCENE_ANALYSIS_SCHEMA,
+      },
+    });
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const llama = (await ensureLlama()) as any;
-    // Use a dedicated small context for scene analysis
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const context = (await ensureSceneContext()) as any;
-
-    const grammar = await llama.createGrammarForJsonSchema(SCENE_ANALYSIS_SCHEMA);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const ChatSession = (mod as any).LlamaChatSession;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const InputLookup = (mod as any).InputLookupTokenPredictor;
-    const session = new ChatSession({ contextSequence: context.getSequence() });
-
-    try {
-      const response = await session.prompt(userPrompt, {
-        grammar,
-        maxTokens: SCENE_ANALYSIS_MAX_TOKENS,
-        // HuggingFace recommended sampling for Gemma 4
-        temperature: 1.0,
-        topP: 0.95,
-        topK: 64,
-        systemPrompt,
-        // Speculative decoding: n-gram lookup from input tokens. Scene analysis
-        // output frequently repeats asset tag names from the prompt, so this
-        // predicts multiple tokens per step for free (no draft model needed).
-        tokenPredictor: InputLookup ? new InputLookup() : undefined,
-      });
-
-      console.log(`[sidecar] Scene analysis complete (${Date.now() - startTime}ms)`);
-      console.log(`[sidecar] Raw response length: ${response.length} chars`);
-      console.log("[sidecar] Raw response:\n", response);
-      // Grammar constrains generation; use JSON.parse for validation since
-      // grammar.parse() has bugs with union types like ["array", "null"].
-      const parsed = JSON.parse(response) as SceneAnalysis;
-      console.log("[sidecar] Parsed result:", JSON.stringify(parsed, null, 2));
-      return parsed;
-    } finally {
-      session.dispose?.();
-    }
+    return extractJsonPayload<SceneAnalysis>(raw);
   });
 }
 
-/**
- * Run a tracker agent prompt through the sidecar model.
- * Returns raw text output (tracker agents produce structured text, not JSON).
- */
 export async function runTrackerPrompt(systemPrompt: string, userPrompt: string): Promise<string> {
-  return withInferenceLock(async () => {
-    console.log("[sidecar] Starting tracker inference...");
-    const startTime = Date.now();
-    const mod = await getLlamaModule();
-    if (!mod) throw new Error("node-llama-cpp is not installed");
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const context = (await ensureContext()) as any;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const ChatSession = (mod as any).LlamaChatSession;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const InputLookup = (mod as any).InputLookupTokenPredictor;
-    const session = new ChatSession({ contextSequence: context.getSequence() });
-
-    try {
-      const response = await session.prompt(userPrompt, {
-        maxTokens: MAX_OUTPUT_TOKENS,
-        // HuggingFace recommended sampling for Gemma 4
-        temperature: 1.0,
-        topP: 0.95,
-        topK: 64,
-        systemPrompt,
-        tokenPredictor: InputLookup ? new InputLookup() : undefined,
-      });
-
-      console.log(`[sidecar] Tracker inference complete (${Date.now() - startTime}ms)`);
-      return response;
-    } finally {
-      session.dispose?.();
-    }
+  return withRequestTracking(async () => {
+    return await streamChatCompletion({
+      messages: [
+        { role: "system", content: systemPrompt },
+        { role: "user", content: userPrompt },
+      ],
+      maxTokens: MAX_OUTPUT_TOKENS,
+    });
   });
 }
 
-/**
- * Check if the sidecar inference is available (model downloaded + module installed).
- */
 export async function isInferenceAvailable(): Promise<boolean> {
-  const mod = await getLlamaModule();
-  if (!mod) return false;
-  return sidecarModelService.getModelFilePath() !== null;
+  if (!sidecarModelService.getModelFilePath() || !sidecarModelService.isEnabled()) {
+    return false;
+  }
+
+  try {
+    await sidecarProcessService.syncForCurrentConfig();
+  } catch {
+    return false;
+  }
+
+  return sidecarProcessService.isReady();
 }

--- a/packages/server/src/services/sidecar/sidecar-model.service.ts
+++ b/packages/server/src/services/sidecar/sidecar-model.service.ts
@@ -1,40 +1,77 @@
 // ──────────────────────────────────────────────
 // Sidecar Local Model — Model Lifecycle Service
 //
-// Manages downloading, loading, and unloading the
-// local Gemma GGUF model. Persists config to a
-// JSON file in data/models/.
+// Owns the persisted sidecar config plus GGUF
+// download/list/delete flows for curated and
+// custom HuggingFace models.
 // ──────────────────────────────────────────────
 
-import { existsSync, mkdirSync, statSync, createWriteStream, readFileSync, writeFileSync, unlinkSync } from "fs";
-import { dirname, join, resolve } from "path";
-import { pipeline as streamPipeline } from "stream/promises";
-import { Readable } from "stream";
-import { fileURLToPath } from "url";
+import { basename, join, relative, resolve, sep } from "path";
+import { existsSync, mkdirSync, readFileSync, statSync, unlinkSync, writeFileSync } from "fs";
 import {
   SIDECAR_DEFAULT_CONFIG,
   SIDECAR_MODELS,
   type SidecarConfig,
+  type SidecarCustomModelEntry,
   type SidecarDownloadProgress,
   type SidecarQuantization,
-  type SidecarRuntimeInfo,
   type SidecarStatus,
   type SidecarStatusResponse,
 } from "@marinara-engine/shared";
 import { getDataDir } from "../../utils/data-dir.js";
+import { downloadFileWithProgress, fetchJson, isAbortError } from "./sidecar-download.js";
+import { sidecarRuntimeService } from "./sidecar-runtime.service.js";
 
-/** Directory where model files and config are stored. */
-const MODELS_DIR = join(getDataDir(), "models");
-const CONFIG_PATH = join(MODELS_DIR, "sidecar-config.json");
-const RUNTIME_INFO_PATH = resolve(
-  dirname(fileURLToPath(import.meta.url)),
-  "../../../data/models/sidecar-runtime-info.json",
-);
+export const MODELS_DIR = join(getDataDir(), "models");
+export const CUSTOM_MODELS_DIR = join(MODELS_DIR, "custom");
+export const CONFIG_PATH = join(MODELS_DIR, "sidecar-config.json");
+export const LEGACY_RUNTIME_STAMP_PATH = join(MODELS_DIR, "sidecar-runtime-stamp.txt");
 
-/** Event callbacks for download progress. */
 type ProgressCallback = (progress: SidecarDownloadProgress) => void;
 
-/** Singleton state for the sidecar model lifecycle. */
+interface HuggingFaceTreeEntry {
+  type?: string;
+  path?: string;
+  size?: number;
+  lfs?: { size?: number };
+}
+
+function normalizeRepoPath(repo: string): string {
+  return repo.trim().replace(/^\/+|\/+$/g, "");
+}
+
+function isValidRepoPath(repo: string): boolean {
+  return /^[^/\s]+\/[^/\s]+$/.test(repo);
+}
+
+function buildHuggingFaceDownloadUrl(repo: string, modelPath: string): string {
+  const encodedPath = modelPath
+    .split("/")
+    .filter(Boolean)
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+  return `https://huggingface.co/${repo}/resolve/main/${encodedPath}`;
+}
+
+function slugifyRepo(repo: string): string {
+  return repo.replace(/[^A-Za-z0-9._-]+/g, "__");
+}
+
+function extractQuantizationLabel(filename: string): string | null {
+  const stem = basename(filename, ".gguf");
+  const match = stem.match(/(?:^|[-_.])(IQ\d+(?:_[A-Z0-9]+)*|Q\d+(?:_[A-Z0-9]+)*)(?:$|[-_.])/i);
+  return match?.[1]?.toUpperCase() ?? null;
+}
+
+function ensureWithinModelsDir(targetPath: string): string {
+  const resolvedRoot = resolve(MODELS_DIR);
+  const resolvedTarget = resolve(targetPath);
+  if (resolvedTarget !== resolvedRoot && !resolvedTarget.startsWith(resolvedRoot + sep)) {
+    throw new Error("Resolved model path escaped the sidecar models directory");
+  }
+  return resolvedTarget;
+}
+
 class SidecarModelService {
   private config: SidecarConfig;
   private status: SidecarStatus = "not_downloaded";
@@ -43,51 +80,109 @@ class SidecarModelService {
 
   constructor() {
     mkdirSync(MODELS_DIR, { recursive: true });
+    mkdirSync(CUSTOM_MODELS_DIR, { recursive: true });
     this.config = this.loadConfig();
     this.status = this.detectStatus();
   }
 
-  // ── Config Persistence ──
-
   private loadConfig(): SidecarConfig {
+    let nextConfig: SidecarConfig = { ...SIDECAR_DEFAULT_CONFIG };
+    let shouldRewrite = false;
+
     try {
       if (existsSync(CONFIG_PATH)) {
-        const raw = readFileSync(CONFIG_PATH, "utf-8");
-        return { ...SIDECAR_DEFAULT_CONFIG, ...JSON.parse(raw) };
+        const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8")) as Partial<SidecarConfig>;
+        nextConfig = { ...SIDECAR_DEFAULT_CONFIG, ...raw };
+
+        // v1.5.x configs only tracked the curated quantization. Migrate them to an explicit modelPath.
+        if (!nextConfig.modelPath && nextConfig.quantization) {
+          const curated = SIDECAR_MODELS.find((model) => model.quantization === nextConfig.quantization);
+          nextConfig.modelPath = curated?.filename ?? null;
+          shouldRewrite = true;
+        }
+
+        if (nextConfig.modelPath && !this.isSafeRelativeModelPath(nextConfig.modelPath)) {
+          nextConfig.modelPath = null;
+          nextConfig.quantization = null;
+          nextConfig.customModelRepo = null;
+          shouldRewrite = true;
+        }
       }
     } catch {
-      // Corrupted config → reset
+      shouldRewrite = true;
+      nextConfig = { ...SIDECAR_DEFAULT_CONFIG };
     }
-    return { ...SIDECAR_DEFAULT_CONFIG };
+
+    if (shouldRewrite) {
+      this.writeConfig(nextConfig);
+    }
+
+    return nextConfig;
+  }
+
+  private writeConfig(config: SidecarConfig): void {
+    writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2), "utf-8");
   }
 
   private saveConfig(): void {
-    writeFileSync(CONFIG_PATH, JSON.stringify(this.config, null, 2), "utf-8");
+    this.writeConfig(this.config);
   }
 
   private detectStatus(): SidecarStatus {
-    if (!this.config.quantization) return "not_downloaded";
-    const path = this.getModelPath(this.config.quantization);
-    if (path && existsSync(path)) return "downloaded";
-    return "not_downloaded";
+    return this.getModelFilePath() ? "downloaded" : "not_downloaded";
   }
 
-  // ── Public Getters ──
+  private isSafeRelativeModelPath(modelPath: string): boolean {
+    try {
+      const resolved = this.resolveModelPath(modelPath);
+      const rel = relative(resolve(MODELS_DIR), resolved);
+      return rel !== "" && !rel.startsWith("..") && !rel.split(/[\\/]/).includes("..");
+    } catch {
+      return false;
+    }
+  }
+
+  private resolveModelPath(modelPath: string): string {
+    return ensureWithinModelsDir(join(MODELS_DIR, modelPath));
+  }
+
+  private emitProgress(progress: SidecarDownloadProgress, inline?: ProgressCallback): void {
+    inline?.(progress);
+    for (const listener of this.progressListeners) {
+      listener(progress);
+    }
+  }
+
+  private buildModelErrorProgress(error: unknown): SidecarDownloadProgress {
+    return {
+      phase: "model",
+      status: "error",
+      downloaded: 0,
+      total: 0,
+      speed: 0,
+      error: error instanceof Error ? error.message : "Model download failed",
+    };
+  }
 
   getStatus(): SidecarStatusResponse {
-    const modelPath = this.config.quantization ? this.getModelPath(this.config.quantization) : null;
+    const modelPath = this.getModelFilePath();
     let modelSize: number | null = null;
-    if (modelPath && existsSync(modelPath)) {
+
+    if (modelPath) {
       try {
         modelSize = statSync(modelPath).size;
-      } catch {}
+      } catch {
+        modelSize = null;
+      }
     }
+
     return {
       status: this.status,
       config: { ...this.config },
-      runtimeInfo: this.getRuntimeInfo(),
-      modelDownloaded: modelPath !== null && existsSync(modelPath),
+      modelDownloaded: modelPath !== null,
       modelSize,
+      runtime: sidecarRuntimeService.getStatus(),
+      logPath: sidecarRuntimeService.getLogPath(),
     };
   }
 
@@ -95,218 +190,264 @@ class SidecarModelService {
     return { ...this.config };
   }
 
+  isEnabled(): boolean {
+    return this.config.useForTrackers || this.config.useForGameScene;
+  }
+
   getModelFilePath(): string | null {
-    if (!this.config.quantization) return null;
-    const p = this.getModelPath(this.config.quantization);
-    return p && existsSync(p) ? p : null;
+    if (!this.config.modelPath) return null;
+    const resolved = this.resolveModelPath(this.config.modelPath);
+    return existsSync(resolved) ? resolved : null;
+  }
+
+  getModelRelativePath(): string | null {
+    return this.getModelFilePath() ? this.config.modelPath : null;
   }
 
   isReady(): boolean {
-    return this.status === "ready" || this.status === "downloaded";
+    return this.status === "ready" || this.status === "downloaded" || this.status === "starting_server";
   }
 
-  // ── Config Updates ──
-
   updateConfig(
-    partial: Partial<Pick<SidecarConfig, "useForTrackers" | "useForGameScene" | "contextSize" | "gpuLayers">>,
+    partial: Partial<
+      Pick<SidecarConfig, "useForTrackers" | "useForGameScene" | "contextSize" | "gpuLayers">
+    >,
   ): SidecarConfig {
-    Object.assign(this.config, partial);
+    this.config = { ...this.config, ...partial };
     this.saveConfig();
+    if (this.status === "not_downloaded" && this.getModelFilePath()) {
+      this.status = "downloaded";
+    }
     return { ...this.config };
   }
 
-  // ── Download ──
-
   async download(quantization: SidecarQuantization, onProgress?: ProgressCallback): Promise<void> {
-    const modelInfo = SIDECAR_MODELS.find((m) => m.quantization === quantization);
-    if (!modelInfo) throw new Error(`Unknown quantization: ${quantization}`);
+    const modelInfo = SIDECAR_MODELS.find((model) => model.quantization === quantization);
+    if (!modelInfo) {
+      throw new Error(`Unknown sidecar quantization: ${quantization}`);
+    }
 
-    if (this.status === "downloading") throw new Error("Download already in progress");
-
-    this.status = "downloading";
-    this.downloadAbort = new AbortController();
-
-    const destPath = this.getModelPath(quantization)!;
-    const tempPath = destPath + ".download";
-
-    try {
-      const res = await fetch(modelInfo.downloadUrl, {
-        signal: this.downloadAbort.signal,
-        headers: { "User-Agent": "MarinaraEngine/1.0" },
-      });
-
-      if (!res.ok) throw new Error(`Download failed: HTTP ${res.status}`);
-      if (!res.body) throw new Error("No response body");
-
-      const total = parseInt(res.headers.get("content-length") || "0", 10);
-      let downloaded = 0;
-      let lastReportTime = Date.now();
-      let lastReportBytes = 0;
-
-      const reader = res.body.getReader();
-      const ws = createWriteStream(tempPath);
-
-      const readable = new Readable({
-        async read() {
-          try {
-            const { done, value } = await reader.read();
-            if (done) {
-              this.push(null);
-              return;
-            }
-            downloaded += value.byteLength;
-
-            // Report progress at most 4 times per second
-            const now = Date.now();
-            if (now - lastReportTime >= 250) {
-              const elapsed = (now - lastReportTime) / 1000;
-              const speed = elapsed > 0 ? (downloaded - lastReportBytes) / elapsed : 0;
-              const progress: SidecarDownloadProgress = {
-                status: "downloading",
-                downloaded,
-                total,
-                speed,
-              };
-              this.emit("download-progress", progress);
-              onProgress?.(progress);
-              for (const listener of sidecarModelService.progressListeners) {
-                listener(progress);
-              }
-              lastReportTime = now;
-              lastReportBytes = downloaded;
-            }
-
-            this.push(value);
-          } catch (err) {
-            this.destroy(err as Error);
-          }
-        },
-      });
-
-      await streamPipeline(readable, ws);
-
-      // Rename temp → final
-      const { renameSync } = await import("fs");
-      renameSync(tempPath, destPath);
-
-      // Update config
-      this.config.quantization = quantization;
+    const relativePath = modelInfo.filename;
+    const destination = this.resolveModelPath(relativePath);
+    if (existsSync(destination)) {
+      this.config = {
+        ...this.config,
+        modelPath: relativePath,
+        quantization,
+        customModelRepo: null,
+      };
       this.saveConfig();
       this.status = "downloaded";
+      this.emitProgress(
+        {
+          phase: "model",
+          status: "complete",
+          downloaded: modelInfo.sizeBytes,
+          total: modelInfo.sizeBytes,
+          speed: 0,
+          label: modelInfo.label,
+        },
+        onProgress,
+      );
+      return;
+    }
 
-      const completeProgress: SidecarDownloadProgress = {
-        status: "complete",
-        downloaded: total || downloaded,
-        total: total || downloaded,
-        speed: 0,
-      };
-      onProgress?.(completeProgress);
-      for (const listener of this.progressListeners) {
-        listener(completeProgress);
-      }
-    } catch (err) {
-      // Clean up partial download
+    await this.downloadModelFile(
+      {
+        url: modelInfo.downloadUrl,
+        relativePath,
+        label: modelInfo.label,
+      },
+      onProgress,
+    );
+
+    this.config = {
+      ...this.config,
+      modelPath: relativePath,
+      quantization,
+      customModelRepo: null,
+    };
+    this.saveConfig();
+    this.status = "downloaded";
+  }
+
+  async listHuggingFaceModels(repoInput: string): Promise<SidecarCustomModelEntry[]> {
+    const repo = normalizeRepoPath(repoInput);
+    if (!isValidRepoPath(repo)) {
+      throw new Error("Repository must be in owner/repo format");
+    }
+
+    const entries = await this.fetchRepoTree(repo);
+    const ggufEntries = entries.filter((entry) => entry.type === "file" && entry.path?.toLowerCase().endsWith(".gguf"));
+    if (ggufEntries.length === 0) {
+      return [];
+    }
+
+    return ggufEntries
+      .map((entry) => {
+        const path = entry.path!;
+        return {
+          path,
+          filename: basename(path),
+          sizeBytes: entry.size ?? entry.lfs?.size ?? null,
+          quantizationLabel: extractQuantizationLabel(path),
+          downloadUrl: buildHuggingFaceDownloadUrl(repo, path),
+        } satisfies SidecarCustomModelEntry;
+      })
+      .sort((a, b) => a.filename.localeCompare(b.filename));
+  }
+
+  async downloadCustomModel(
+    repoInput: string,
+    modelPath: string,
+    onProgress?: ProgressCallback,
+  ): Promise<SidecarCustomModelEntry> {
+    const repo = normalizeRepoPath(repoInput);
+    if (!isValidRepoPath(repo)) {
+      throw new Error("Repository must be in owner/repo format");
+    }
+
+    const models = await this.listHuggingFaceModels(repo);
+    const selected = models.find((entry) => entry.path === modelPath || entry.filename === modelPath);
+    if (!selected) {
+      throw new Error("Selected GGUF was not found in that repository");
+    }
+
+    const relativePath = join("custom", `${slugifyRepo(repo)}__${selected.filename}`).replace(/\\/g, "/");
+    const destination = this.resolveModelPath(relativePath);
+    if (!existsSync(destination)) {
+      await this.downloadModelFile(
+        {
+          url: selected.downloadUrl,
+          relativePath,
+          label: selected.filename,
+        },
+        onProgress,
+      );
+    } else {
+      this.emitProgress(
+        {
+          phase: "model",
+          status: "complete",
+          downloaded: selected.sizeBytes ?? 0,
+          total: selected.sizeBytes ?? 0,
+          speed: 0,
+          label: selected.filename,
+        },
+        onProgress,
+      );
+    }
+
+    this.config = {
+      ...this.config,
+      modelPath: relativePath,
+      quantization: null,
+      customModelRepo: repo,
+    };
+    this.saveConfig();
+    this.status = "downloaded";
+    return selected;
+  }
+
+  private async fetchRepoTree(repo: string): Promise<HuggingFaceTreeEntry[]> {
+    const attempts = [
+      `https://huggingface.co/api/models/${repo}/tree/main?recursive=1`,
+      `https://huggingface.co/api/models/${repo}/tree/master?recursive=1`,
+    ];
+
+    let lastError: unknown;
+    for (const url of attempts) {
       try {
-        if (existsSync(tempPath)) unlinkSync(tempPath);
-      } catch {}
+        return await fetchJson<HuggingFaceTreeEntry[]>(url);
+      } catch (error) {
+        lastError = error;
+      }
+    }
 
+    throw lastError instanceof Error ? lastError : new Error("Failed to load HuggingFace repository tree");
+  }
+
+  private async downloadModelFile(
+    input: { url: string; relativePath: string; label: string },
+    onProgress?: ProgressCallback,
+  ): Promise<void> {
+    if (this.downloadAbort) {
+      throw new Error("Another sidecar download is already in progress");
+    }
+
+    this.status = "downloading_model";
+    this.downloadAbort = new AbortController();
+    const destination = this.resolveModelPath(input.relativePath);
+
+    try {
+      await downloadFileWithProgress({
+        url: input.url,
+        destPath: destination,
+        signal: this.downloadAbort.signal,
+        progress: {
+          phase: "model",
+          label: input.label,
+        },
+        onProgress: (progress) => this.emitProgress(progress, onProgress),
+      });
+    } catch (error) {
       this.status = this.detectStatus();
-
-      const error = err instanceof Error ? err.message : "Unknown download error";
-      if (error.includes("abort")) {
+      if (isAbortError(error)) {
         throw new Error("Download cancelled");
       }
 
-      const errorProgress: SidecarDownloadProgress = {
-        status: "error",
-        downloaded: 0,
-        total: 0,
-        speed: 0,
-        error,
-      };
-      onProgress?.(errorProgress);
-      for (const listener of this.progressListeners) {
-        listener(errorProgress);
-      }
-      throw err;
+      const progress = this.buildModelErrorProgress(error);
+      this.emitProgress(progress, onProgress);
+      throw error;
     } finally {
       this.downloadAbort = null;
     }
   }
 
   cancelDownload(): void {
-    if (this.downloadAbort) {
-      this.downloadAbort.abort();
-      this.downloadAbort = null;
-    }
+    this.downloadAbort?.abort();
+    this.downloadAbort = null;
   }
 
-  // ── Delete Model ──
-
   deleteModel(): void {
-    if (this.config.quantization) {
-      const p = this.getModelPath(this.config.quantization);
-      if (p && existsSync(p)) {
-        unlinkSync(p);
-      }
+    const modelPath = this.getModelFilePath();
+    if (modelPath && existsSync(modelPath)) {
+      unlinkSync(modelPath);
     }
-    this.config.quantization = null;
+
+    this.config = {
+      ...this.config,
+      modelPath: null,
+      quantization: null,
+      customModelRepo: null,
+    };
     this.saveConfig();
     this.status = "not_downloaded";
   }
 
-  // ── Progress Listeners (for SSE) ──
-
-  addProgressListener(cb: ProgressCallback): void {
-    this.progressListeners.add(cb);
+  addProgressListener(callback: ProgressCallback): void {
+    this.progressListeners.add(callback);
   }
 
-  removeProgressListener(cb: ProgressCallback): void {
-    this.progressListeners.delete(cb);
+  removeProgressListener(callback: ProgressCallback): void {
+    this.progressListeners.delete(callback);
   }
 
-  // ── Internals ──
-
-  setStatus(s: SidecarStatus): void {
-    this.status = s;
+  setStatus(status: SidecarStatus): void {
+    this.status = status;
   }
 
-  private getModelPath(quant: SidecarQuantization): string | null {
-    const info = SIDECAR_MODELS.find((m) => m.quantization === quant);
-    if (!info) return null;
-    const filename = `gemma-4-E2B-it-${quant.toUpperCase()}.gguf`;
-    return join(MODELS_DIR, filename);
+  emitExternalProgress(progress: SidecarDownloadProgress): void {
+    this.emitProgress(progress);
   }
 
-  private getRuntimeInfo(): SidecarRuntimeInfo | null {
+  clearLegacyRuntimeStamp(): void {
     try {
-      if (!existsSync(RUNTIME_INFO_PATH)) return null;
-
-      const raw = readFileSync(RUNTIME_INFO_PATH, "utf-8");
-      const parsed = JSON.parse(raw) as Partial<SidecarRuntimeInfo>;
-      const validStates = new Set(["ready", "fallback", "failed"]);
-      const validBackends = new Set(["gpu", "cpu", "unknown"]);
-      const validReasons = new Set(["manual_cpu", "missing_gpu_toolchain", "build_failed", "unknown"]);
-
-      if (
-        typeof parsed?.message !== "string" ||
-        typeof parsed?.updatedAt !== "string" ||
-        !validStates.has(String(parsed.state)) ||
-        !validBackends.has(String(parsed.backend)) ||
-        !validReasons.has(String(parsed.reason))
-      ) {
-        return null;
+      if (existsSync(LEGACY_RUNTIME_STAMP_PATH)) {
+        unlinkSync(LEGACY_RUNTIME_STAMP_PATH);
       }
-
-      return {
-        state: parsed.state as SidecarRuntimeInfo["state"],
-        backend: parsed.backend as SidecarRuntimeInfo["backend"],
-        reason: parsed.reason as SidecarRuntimeInfo["reason"],
-        message: parsed.message,
-        updatedAt: parsed.updatedAt,
-      };
     } catch {
-      return null;
+      // Best-effort cleanup for v1.5.x build stamp residue.
     }
   }
 }

--- a/packages/server/src/services/sidecar/sidecar-process.service.ts
+++ b/packages/server/src/services/sidecar/sidecar-process.service.ts
@@ -1,0 +1,313 @@
+import { spawn, type ChildProcess } from "child_process";
+import { createWriteStream, existsSync, writeFileSync, type WriteStream } from "fs";
+import { createServer } from "net";
+import { dirname } from "path";
+import { sidecarModelService } from "./sidecar-model.service.js";
+import { isAbortError } from "./sidecar-download.js";
+import { sidecarRuntimeService, type SidecarRuntimeInstall } from "./sidecar-runtime.service.js";
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function getFreePort(): Promise<number> {
+  return await new Promise<number>((resolve, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close(() => reject(new Error("Failed to allocate a localhost port")));
+        return;
+      }
+      const port = address.port;
+      server.close((error) => {
+        if (error) reject(error);
+        else resolve(port);
+      });
+    });
+  });
+}
+
+class SidecarProcessService {
+  private child: ChildProcess | null = null;
+  private logStream: WriteStream | null = null;
+  private baseUrl: string | null = null;
+  private ready = false;
+  private currentSignature: string | null = null;
+  private intentionalStop = false;
+  private unexpectedCrashCount = 0;
+  private lastReadyAt = 0;
+  private syncLock: Promise<void> = Promise.resolve();
+
+  isReady(): boolean {
+    return this.ready && this.baseUrl !== null;
+  }
+
+  getBaseUrl(): string | null {
+    return this.baseUrl;
+  }
+
+  async ensureReady(): Promise<string> {
+    await this.syncForCurrentConfig();
+    if (!this.ready || !this.baseUrl) {
+      throw new Error("The local llama-server is not ready");
+    }
+    return this.baseUrl;
+  }
+
+  async syncForCurrentConfig(): Promise<void> {
+    return this.withLock(async () => {
+      await this.syncUnlocked();
+    });
+  }
+
+  async restart(): Promise<void> {
+    return this.withLock(async () => {
+      this.currentSignature = null;
+      await this.stopUnlocked();
+      await this.syncUnlocked();
+    });
+  }
+
+  async stop(): Promise<void> {
+    return this.withLock(async () => {
+      await this.stopUnlocked();
+      if (sidecarModelService.getModelFilePath()) {
+        sidecarModelService.setStatus("downloaded");
+      } else {
+        sidecarModelService.setStatus("not_downloaded");
+      }
+    });
+  }
+
+  private async withLock<T>(fn: () => Promise<T>): Promise<T> {
+    let release: () => void = () => {};
+    const next = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const previous = this.syncLock;
+    this.syncLock = next;
+    await previous;
+    try {
+      return await fn();
+    } finally {
+      release();
+    }
+  }
+
+  private async syncUnlocked(): Promise<void> {
+    const modelPath = sidecarModelService.getModelFilePath();
+    const config = sidecarModelService.getConfig();
+
+    if (!modelPath) {
+      await this.stopUnlocked();
+      sidecarModelService.setStatus("not_downloaded");
+      return;
+    }
+
+    if (!sidecarModelService.isEnabled()) {
+      await this.stopUnlocked();
+      sidecarModelService.setStatus("downloaded");
+      return;
+    }
+
+    const runtime = await this.ensureRuntimeInstalled();
+    const nextSignature = JSON.stringify({
+      serverPath: runtime.serverPath,
+      modelPath,
+      contextSize: config.contextSize,
+      gpuLayers: config.gpuLayers,
+    });
+
+    if (this.child && this.ready && this.currentSignature === nextSignature) {
+      sidecarModelService.setStatus("ready");
+      return;
+    }
+
+    sidecarModelService.setStatus("starting_server");
+    await this.stopUnlocked();
+    await this.startUnlocked(runtime, modelPath, nextSignature);
+  }
+
+  private async ensureRuntimeInstalled(): Promise<SidecarRuntimeInstall> {
+    sidecarModelService.setStatus("downloading_runtime");
+    try {
+      return await sidecarRuntimeService.ensureInstalled((progress) => {
+        sidecarModelService.emitExternalProgress(progress);
+      });
+    } catch (error) {
+      if (isAbortError(error)) {
+        sidecarModelService.setStatus(sidecarModelService.getModelFilePath() ? "downloaded" : "not_downloaded");
+      } else {
+        sidecarModelService.setStatus("server_error");
+      }
+      throw error;
+    }
+  }
+
+  private buildArgs(modelPath: string): string[] {
+    const config = sidecarModelService.getConfig();
+    const args = [
+      "-m",
+      modelPath,
+      "--host",
+      "127.0.0.1",
+      "--parallel",
+      "2",
+      "--log-disable",
+      "--ctx-size",
+      String(config.contextSize),
+    ];
+
+    const gpuLayers = config.gpuLayers === -1 ? 999 : config.gpuLayers;
+    args.push("-ngl", String(gpuLayers));
+    return args;
+  }
+
+  private async startUnlocked(runtime: SidecarRuntimeInstall, modelPath: string, signature: string): Promise<void> {
+    if (!existsSync(modelPath)) {
+      throw new Error("The selected sidecar model file is missing. Please download it again.");
+    }
+
+    const port = await getFreePort();
+    const args = this.buildArgs(modelPath);
+    args.push("--port", String(port));
+
+    writeFileSync(sidecarRuntimeService.getLogPath(), "", "utf-8");
+    const logStream = createWriteStream(sidecarRuntimeService.getLogPath(), { flags: "a" });
+
+    const child = spawn(runtime.serverPath, args, {
+      cwd: dirname(runtime.serverPath),
+      windowsHide: true,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    this.child = child;
+    this.logStream = logStream;
+    this.baseUrl = `http://127.0.0.1:${port}`;
+    this.ready = false;
+    this.currentSignature = signature;
+    this.intentionalStop = false;
+
+    child.stdout!.on("data", (chunk) => {
+      logStream.write(chunk);
+    });
+    child.stderr!.on("data", (chunk) => {
+      logStream.write(chunk);
+    });
+    child.on("exit", (code, signal) => {
+      void this.handleChildExit(code, signal);
+    });
+
+    try {
+      await this.waitForHealth(this.baseUrl, child);
+      this.ready = true;
+      this.unexpectedCrashCount = 0;
+      this.lastReadyAt = Date.now();
+      sidecarModelService.setStatus("ready");
+      sidecarModelService.clearLegacyRuntimeStamp();
+    } catch (error) {
+      sidecarModelService.setStatus("server_error");
+      await this.stopUnlocked();
+      throw error;
+    }
+  }
+
+  private async waitForHealth(baseUrl: string, child: ChildProcess): Promise<void> {
+    const timeoutAt = Date.now() + 60_000;
+    let lastError: unknown = null;
+
+    while (Date.now() < timeoutAt) {
+      if (child.exitCode !== null) {
+        throw new Error(`llama-server exited before becoming ready (exit ${child.exitCode})`);
+      }
+
+      try {
+        const response = await fetch(`${baseUrl}/health`, { signal: AbortSignal.timeout(3_000) });
+        if (response.ok) {
+          return;
+        }
+        lastError = new Error(`HTTP ${response.status}`);
+      } catch (error) {
+        lastError = error;
+      }
+
+      await delay(500);
+    }
+
+    throw lastError instanceof Error ? lastError : new Error("Timed out waiting for llama-server health");
+  }
+
+  private async stopUnlocked(): Promise<void> {
+    const child = this.child;
+    if (!child) {
+      this.ready = false;
+      this.baseUrl = null;
+      return;
+    }
+
+    this.intentionalStop = true;
+    const exited = new Promise<void>((resolve) => {
+      child.once("exit", () => resolve());
+    });
+
+    try {
+      child.kill("SIGTERM");
+    } catch {
+      // Best-effort shutdown.
+    }
+
+    const timeout = delay(5_000);
+    await Promise.race([exited, timeout]);
+
+    if (child.exitCode === null) {
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        // Best-effort forced shutdown.
+      }
+    }
+
+    this.cleanupChildState();
+  }
+
+  private cleanupChildState(): void {
+    this.child = null;
+    this.ready = false;
+    this.baseUrl = null;
+    if (this.logStream) {
+      this.logStream.end();
+      this.logStream = null;
+    }
+  }
+
+  private async handleChildExit(code: number | null, signal: NodeJS.Signals | null): Promise<void> {
+    const wasIntentional = this.intentionalStop;
+    this.intentionalStop = false;
+    this.cleanupChildState();
+
+    if (wasIntentional) {
+      return;
+    }
+
+    console.error(`[sidecar] llama-server exited unexpectedly (code=${code ?? "null"}, signal=${signal ?? "null"})`);
+
+    const crashedSoonAfterReady = this.lastReadyAt > 0 && Date.now() - this.lastReadyAt < 30_000;
+    this.unexpectedCrashCount = crashedSoonAfterReady ? this.unexpectedCrashCount + 1 : 1;
+
+    if (this.unexpectedCrashCount > 1) {
+      sidecarModelService.setStatus("server_error");
+      return;
+    }
+
+    try {
+      await this.syncForCurrentConfig();
+    } catch (error) {
+      console.error("[sidecar] Auto-restart failed:", error);
+      sidecarModelService.setStatus("server_error");
+    }
+  }
+}
+
+export const sidecarProcessService = new SidecarProcessService();

--- a/packages/server/src/services/sidecar/sidecar-runtime.service.ts
+++ b/packages/server/src/services/sidecar/sidecar-runtime.service.ts
@@ -1,0 +1,526 @@
+import AdmZip from "adm-zip";
+import { execFile } from "child_process";
+import { promisify } from "util";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "fs";
+import { join, relative, resolve, sep } from "path";
+import type { SidecarDownloadProgress, SidecarRuntimeInfo } from "@marinara-engine/shared";
+import { getDataDir } from "../../utils/data-dir.js";
+import { downloadFileWithProgress, fetchJson, isAbortError, retry } from "./sidecar-download.js";
+
+const execFileAsync = promisify(execFile);
+
+const RUNTIME_DIR = join(getDataDir(), "sidecar-runtime");
+const CURRENT_RUNTIME_PATH = join(RUNTIME_DIR, "current.json");
+const SERVER_LOG_PATH = join(RUNTIME_DIR, "server.log");
+
+interface GitHubReleaseAsset {
+  name: string;
+  browser_download_url: string;
+  size?: number;
+}
+
+interface GitHubReleaseResponse {
+  tag_name: string;
+  assets: GitHubReleaseAsset[];
+}
+
+interface RuntimeRecord {
+  build: string;
+  variant: string;
+  platform: NodeJS.Platform;
+  arch: string;
+  assetName: string;
+  directoryName: string;
+  serverRelativePath: string;
+  installedAt: string;
+}
+
+export interface SidecarRuntimeInstall extends RuntimeRecord {
+  directoryPath: string;
+  serverPath: string;
+}
+
+interface RuntimeMatch {
+  variant: string;
+  asset: GitHubReleaseAsset;
+}
+
+interface RuntimeCapabilities {
+  platform: NodeJS.Platform;
+  arch: string;
+  preferCuda: boolean;
+  preferRocm: boolean;
+  preferVulkan: boolean;
+}
+
+function ensureWithinRuntimeDir(targetPath: string): string {
+  const root = resolve(RUNTIME_DIR);
+  const resolvedTarget = resolve(targetPath);
+  if (resolvedTarget !== root && !resolvedTarget.startsWith(root + sep)) {
+    throw new Error("Resolved runtime path escaped the sidecar runtime directory");
+  }
+  return resolvedTarget;
+}
+
+function compareVersionStrings(a: string, b: string): number {
+  const aParts = a.split(".").map((part) => Number.parseInt(part, 10) || 0);
+  const bParts = b.split(".").map((part) => Number.parseInt(part, 10) || 0);
+  const len = Math.max(aParts.length, bParts.length);
+  for (let i = 0; i < len; i += 1) {
+    const delta = (aParts[i] ?? 0) - (bParts[i] ?? 0);
+    if (delta !== 0) return delta;
+  }
+  return 0;
+}
+
+function extractVersion(assetName: string): string {
+  const match = assetName.match(/(?:cuda|rocm|openvino)-([0-9.]+)/i);
+  return match?.[1] ?? "0";
+}
+
+function isWindowsAsset(assetName: string): boolean {
+  return assetName.endsWith(".zip");
+}
+
+async function commandSucceeds(command: string, args: string[] = []): Promise<boolean> {
+  try {
+    await execFileAsync(command, args, { timeout: 5_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function findExecutableRecursive(dirPath: string, expectedName: string): string | null {
+  const stack = [dirPath];
+  while (stack.length > 0) {
+    const current = stack.pop()!;
+    const stat = statSync(current, { throwIfNoEntry: false });
+    if (!stat) continue;
+    if (stat.isFile()) {
+      if (current.toLowerCase().endsWith(expectedName.toLowerCase())) {
+        return current;
+      }
+      continue;
+    }
+
+    for (const entry of readdirSync(current, { withFileTypes: true })) {
+      stack.push(join(current, entry.name));
+    }
+  }
+  return null;
+}
+
+class SidecarRuntimeService {
+  private installPromise: Promise<SidecarRuntimeInstall> | null = null;
+  private installAbort: AbortController | null = null;
+
+  constructor() {
+    mkdirSync(RUNTIME_DIR, { recursive: true });
+  }
+
+  getLogPath(): string {
+    return SERVER_LOG_PATH;
+  }
+
+  cancelInstall(): void {
+    this.installAbort?.abort();
+    this.installAbort = null;
+  }
+
+  getStatus(): SidecarRuntimeInfo {
+    const current = this.getCurrentInstall();
+    return {
+      installed: current !== null,
+      build: current?.build ?? null,
+      variant: current?.variant ?? null,
+    };
+  }
+
+  getCurrentInstall(): SidecarRuntimeInstall | null {
+    if (!existsSync(CURRENT_RUNTIME_PATH)) {
+      return null;
+    }
+
+    try {
+      const record = JSON.parse(readFileSync(CURRENT_RUNTIME_PATH, "utf-8")) as RuntimeRecord;
+      const directoryPath = ensureWithinRuntimeDir(join(RUNTIME_DIR, record.directoryName));
+      const serverPath = ensureWithinRuntimeDir(join(directoryPath, record.serverRelativePath));
+      if (!existsSync(serverPath)) {
+        return null;
+      }
+
+      return {
+        ...record,
+        directoryPath,
+        serverPath,
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  async ensureInstalled(onProgress?: (progress: SidecarDownloadProgress) => void): Promise<SidecarRuntimeInstall> {
+    const current = this.getCurrentInstall();
+    if (current && this.isInstallUsable(current)) {
+      return current;
+    }
+
+    if (this.installPromise) {
+      return this.installPromise;
+    }
+
+    this.installPromise = this.installLatest(onProgress).finally(() => {
+      this.installPromise = null;
+    });
+    return this.installPromise;
+  }
+
+  private isInstallUsable(install: SidecarRuntimeInstall): boolean {
+    return install.platform === process.platform && install.arch === process.arch && existsSync(install.serverPath);
+  }
+
+  private writeCurrentInstall(install: SidecarRuntimeInstall): void {
+    const record: RuntimeRecord = {
+      build: install.build,
+      variant: install.variant,
+      platform: install.platform,
+      arch: install.arch,
+      assetName: install.assetName,
+      directoryName: install.directoryName,
+      serverRelativePath: install.serverRelativePath,
+      installedAt: install.installedAt,
+    };
+    writeFileSync(CURRENT_RUNTIME_PATH, JSON.stringify(record, null, 2), "utf-8");
+  }
+
+  private async installLatest(onProgress?: (progress: SidecarDownloadProgress) => void): Promise<SidecarRuntimeInstall> {
+    const abortController = new AbortController();
+    this.installAbort = abortController;
+
+    let archivePath: string | null = null;
+    let extractDirectory: string | null = null;
+    let finalDirectory: string | null = null;
+
+    try {
+      const release = await retry(
+        () =>
+          fetchJson<GitHubReleaseResponse>("https://api.github.com/repos/ggml-org/llama.cpp/releases/latest", {
+            signal: abortController.signal,
+            headers: {
+              Accept: "application/vnd.github+json",
+            },
+          }),
+        {
+          retries: 3,
+          baseDelayMs: 500,
+          shouldRetry: (error) => !isAbortError(error),
+        },
+      );
+
+      const match = await this.selectBestAsset(release.assets);
+      if (!match) {
+        throw new Error(`Your platform (${process.platform}/${process.arch}) is not supported for local inference yet.`);
+      }
+
+      const directoryName = `${release.tag_name}-${match.variant}`;
+      finalDirectory = ensureWithinRuntimeDir(join(RUNTIME_DIR, directoryName));
+      archivePath = ensureWithinRuntimeDir(join(RUNTIME_DIR, match.asset.name));
+      extractDirectory = ensureWithinRuntimeDir(join(RUNTIME_DIR, `${directoryName}.extract`));
+
+      if (existsSync(finalDirectory)) {
+        rmSync(finalDirectory, { recursive: true, force: true });
+      }
+
+      await this.downloadAndExtractAsset({
+        asset: match.asset,
+        archivePath,
+        extractDirectory,
+        signal: abortController.signal,
+        onProgress,
+      });
+
+      const executableName = isWindowsAsset(match.asset.name) ? "llama-server.exe" : "llama-server";
+      const executablePath = findExecutableRecursive(extractDirectory, executableName);
+      if (!executablePath) {
+        throw new Error(`Could not find ${executableName} inside ${match.asset.name}`);
+      }
+
+      renameSync(extractDirectory, finalDirectory);
+      const finalExecutable = ensureWithinRuntimeDir(join(finalDirectory, relative(extractDirectory, executablePath)));
+      if (process.platform !== "win32") {
+        try {
+          chmodSync(finalExecutable, 0o755);
+        } catch {
+          // Best-effort on Unix-like systems.
+        }
+      }
+
+      const install: SidecarRuntimeInstall = {
+        build: release.tag_name,
+        variant: match.variant,
+        platform: process.platform,
+        arch: process.arch,
+        assetName: match.asset.name,
+        directoryName,
+        serverRelativePath: relative(finalDirectory, finalExecutable).replace(/\\/g, "/"),
+        installedAt: new Date().toISOString(),
+        directoryPath: finalDirectory,
+        serverPath: finalExecutable,
+      };
+      this.writeCurrentInstall(install);
+      return install;
+    } catch (error) {
+      if (extractDirectory) {
+        rmSync(extractDirectory, { recursive: true, force: true });
+      }
+      if (finalDirectory) {
+        rmSync(finalDirectory, { recursive: true, force: true });
+      }
+      throw error;
+    } finally {
+      if (archivePath) {
+        rmSync(archivePath, { force: true });
+      }
+      if (this.installAbort === abortController) {
+        this.installAbort = null;
+      }
+    }
+  }
+
+  private async downloadAndExtractAsset(options: {
+    asset: GitHubReleaseAsset;
+    archivePath: string;
+    extractDirectory: string;
+    signal: AbortSignal;
+    onProgress?: (progress: SidecarDownloadProgress) => void;
+  }): Promise<void> {
+    let lastError: unknown = null;
+
+    for (let attempt = 1; attempt <= 2; attempt += 1) {
+      rmSync(options.extractDirectory, { recursive: true, force: true });
+      mkdirSync(options.extractDirectory, { recursive: true });
+
+      await retry(
+        async () => {
+          await downloadFileWithProgress({
+            url: options.asset.browser_download_url,
+            destPath: options.archivePath,
+            signal: options.signal,
+            progress: {
+              phase: "runtime",
+              label: options.asset.name,
+            },
+            onProgress: options.onProgress,
+          });
+        },
+        {
+          retries: 3,
+          baseDelayMs: 750,
+          shouldRetry: (error) => !isAbortError(error),
+        },
+      );
+
+      try {
+        await this.extractArchive(options.archivePath, options.extractDirectory);
+        return;
+      } catch (error) {
+        lastError = error;
+        rmSync(options.extractDirectory, { recursive: true, force: true });
+        rmSync(options.archivePath, { force: true });
+        if (attempt >= 2 || isAbortError(error)) {
+          throw error;
+        }
+      }
+    }
+
+    throw lastError instanceof Error ? lastError : new Error(`Failed to extract ${options.asset.name}`);
+  }
+
+  private async extractArchive(archivePath: string, targetDir: string): Promise<void> {
+    if (archivePath.endsWith(".zip")) {
+      const zip = new AdmZip(archivePath);
+      zip.extractAllTo(targetDir, true);
+      return;
+    }
+
+    if (archivePath.endsWith(".tar.gz")) {
+      await execFileAsync("tar", ["-xzf", archivePath, "-C", targetDir], { timeout: 120_000 });
+      return;
+    }
+
+    throw new Error(`Unsupported runtime archive format: ${archivePath}`);
+  }
+
+  private async detectCapabilities(): Promise<RuntimeCapabilities> {
+    const platform = process.platform;
+    const arch = process.arch;
+
+    const preferCuda = arch === "x64" && (await commandSucceeds("nvidia-smi"));
+    const preferRocm =
+      platform === "linux" && arch === "x64" && ((await commandSucceeds("rocm-smi")) || existsSync("/opt/rocm"));
+    const preferVulkan = await this.detectVulkanSupport(platform);
+
+    return {
+      platform,
+      arch,
+      preferCuda,
+      preferRocm,
+      preferVulkan,
+    };
+  }
+
+  private async detectVulkanSupport(platform: NodeJS.Platform): Promise<boolean> {
+    if (platform === "darwin" || platform === "android") {
+      return false;
+    }
+
+    if (await commandSucceeds("vulkaninfo", ["--summary"])) {
+      return true;
+    }
+
+    if (platform === "win32") {
+      return existsSync("C:\\Windows\\System32\\vulkan-1.dll");
+    }
+
+    if (platform === "linux") {
+      return ["/usr/lib/libvulkan.so", "/usr/lib64/libvulkan.so", "/usr/lib/x86_64-linux-gnu/libvulkan.so.1"].some(
+        (path) => existsSync(path),
+      );
+    }
+
+    return false;
+  }
+
+  private pickLatestVersionedAsset(
+    assets: GitHubReleaseAsset[],
+    pattern: RegExp,
+    options?: { preferPrefix?: string },
+  ): GitHubReleaseAsset | null {
+    const matches = assets.filter((asset) => pattern.test(asset.name));
+    if (matches.length === 0) {
+      return null;
+    }
+
+    matches.sort((left, right) => {
+      if (options?.preferPrefix) {
+        const leftPref = left.name.startsWith(options.preferPrefix) ? 1 : 0;
+        const rightPref = right.name.startsWith(options.preferPrefix) ? 1 : 0;
+        if (leftPref !== rightPref) {
+          return rightPref - leftPref;
+        }
+      }
+      return compareVersionStrings(extractVersion(right.name), extractVersion(left.name));
+    });
+
+    return matches[0] ?? null;
+  }
+
+  private findFirstAsset(assets: GitHubReleaseAsset[], pattern: RegExp): GitHubReleaseAsset | null {
+    return assets.find((asset) => pattern.test(asset.name)) ?? null;
+  }
+
+  private async selectBestAsset(assets: GitHubReleaseAsset[]): Promise<RuntimeMatch | null> {
+    const capabilities = await this.detectCapabilities();
+    const candidates: Array<() => RuntimeMatch | null> = [];
+
+    if (capabilities.platform === "android" && capabilities.arch === "arm64") {
+      candidates.push(() => {
+        const asset = this.findFirstAsset(assets, /^llama-.*-bin-android-arm64\.tar\.gz$/i);
+        return asset ? { variant: "android-arm64-cpu", asset } : null;
+      });
+    } else if (capabilities.platform === "darwin" && capabilities.arch === "arm64") {
+      candidates.push(() => {
+        const asset =
+          this.findFirstAsset(assets, /^llama-.*-bin-macos-arm64\.tar\.gz$/i) ??
+          this.findFirstAsset(assets, /^llama-.*-bin-macos-arm64-kleidiai\.tar\.gz$/i);
+        return asset ? { variant: "macos-arm64-metal", asset } : null;
+      });
+    } else if (capabilities.platform === "darwin" && capabilities.arch === "x64") {
+      candidates.push(() => {
+        const asset = this.findFirstAsset(assets, /^llama-.*-bin-macos-x64\.tar\.gz$/i);
+        return asset ? { variant: "macos-x64-cpu", asset } : null;
+      });
+    } else if (capabilities.platform === "win32" && capabilities.arch === "x64") {
+      if (capabilities.preferCuda) {
+        candidates.push(() => {
+          const asset =
+            this.pickLatestVersionedAsset(assets, /^(?:cudart-)?llama-.*-bin-win-cuda-[0-9.]+-x64\.zip$/i, {
+              preferPrefix: "cudart-",
+            }) ?? null;
+          return asset ? { variant: "win-x64-cuda", asset } : null;
+        });
+      }
+      if (capabilities.preferVulkan) {
+        candidates.push(() => {
+          const asset = this.findFirstAsset(assets, /^llama-.*-bin-win-vulkan-x64\.zip$/i);
+          return asset ? { variant: "win-x64-vulkan", asset } : null;
+        });
+      }
+      candidates.push(() => {
+        const asset = this.findFirstAsset(assets, /^llama-.*-bin-win-cpu-x64\.zip$/i);
+        return asset ? { variant: "win-x64-cpu", asset } : null;
+      });
+    } else if (capabilities.platform === "win32" && capabilities.arch === "arm64") {
+      candidates.push(() => {
+        const asset = this.findFirstAsset(assets, /^llama-.*-bin-win-cpu-arm64\.zip$/i);
+        return asset ? { variant: "win-arm64-cpu", asset } : null;
+      });
+    } else if (capabilities.platform === "linux" && capabilities.arch === "x64") {
+      if (capabilities.preferCuda) {
+        candidates.push(() => {
+          const asset = this.pickLatestVersionedAsset(assets, /^llama-.*-bin-ubuntu-cuda-[0-9.]+-x64\.tar\.gz$/i);
+          return asset ? { variant: "linux-x64-cuda", asset } : null;
+        });
+      }
+      if (capabilities.preferRocm) {
+        candidates.push(() => {
+          const asset = this.pickLatestVersionedAsset(assets, /^llama-.*-bin-ubuntu-rocm-[0-9.]+-x64\.tar\.gz$/i);
+          return asset ? { variant: "linux-x64-rocm", asset } : null;
+        });
+      }
+      if (capabilities.preferVulkan) {
+        candidates.push(() => {
+          const asset = this.findFirstAsset(assets, /^llama-.*-bin-ubuntu-vulkan-x64\.tar\.gz$/i);
+          return asset ? { variant: "linux-x64-vulkan", asset } : null;
+        });
+      }
+      candidates.push(() => {
+        const asset = this.findFirstAsset(assets, /^llama-.*-bin-ubuntu-x64\.tar\.gz$/i);
+        return asset ? { variant: "linux-x64-cpu", asset } : null;
+      });
+    } else if (capabilities.platform === "linux" && capabilities.arch === "arm64") {
+      if (capabilities.preferVulkan) {
+        candidates.push(() => {
+          const asset = this.findFirstAsset(assets, /^llama-.*-bin-ubuntu-vulkan-arm64\.tar\.gz$/i);
+          return asset ? { variant: "linux-arm64-vulkan", asset } : null;
+        });
+      }
+      candidates.push(() => {
+        const asset = this.findFirstAsset(assets, /^llama-.*-bin-ubuntu-arm64\.tar\.gz$/i);
+        return asset ? { variant: "linux-arm64-cpu", asset } : null;
+      });
+    }
+
+    for (const pick of candidates) {
+      const match = pick();
+      if (match) {
+        return match;
+      }
+    }
+
+    return null;
+  }
+}
+
+export const sidecarRuntimeService = new SidecarRuntimeService();

--- a/packages/shared/src/types/sidecar.ts
+++ b/packages/shared/src/types/sidecar.ts
@@ -10,28 +10,18 @@
 export type SidecarQuantization = "q8_0" | "q4_k_m";
 
 /** Current lifecycle state of the sidecar model. */
-export type SidecarStatus = "not_downloaded" | "downloading" | "downloaded" | "loading" | "ready" | "error";
+export type SidecarStatus =
+  | "not_downloaded"
+  | "downloading_runtime"
+  | "downloading_model"
+  | "downloaded"
+  | "starting_server"
+  | "ready"
+  | "server_error";
 
-/** Recent native-runtime build state for the sidecar addon. */
-export type SidecarRuntimeState = "ready" | "fallback" | "failed";
-
-/** Effective backend mode for the built sidecar runtime. */
-export type SidecarRuntimeBackend = "gpu" | "cpu" | "unknown";
-
-/** Why the current runtime note exists. */
-export type SidecarRuntimeReason = "manual_cpu" | "missing_gpu_toolchain" | "build_failed" | "unknown";
-
-/** Optional runtime note emitted by the launcher/build wrapper. */
-export interface SidecarRuntimeInfo {
-  state: SidecarRuntimeState;
-  backend: SidecarRuntimeBackend;
-  reason: SidecarRuntimeReason;
-  message: string;
-  updatedAt: string;
-}
-
-/** Progress info while downloading the model GGUF. */
+/** Progress info while downloading the runtime or model assets. */
 export interface SidecarDownloadProgress {
+  phase: "runtime" | "model";
   status: "downloading" | "complete" | "error";
   /** Bytes downloaded so far. */
   downloaded: number;
@@ -39,14 +29,20 @@ export interface SidecarDownloadProgress {
   total: number;
   /** Download speed in bytes/second. */
   speed: number;
+  /** Optional display label for the thing being downloaded. */
+  label?: string;
   /** Error message if status is "error". */
   error?: string;
 }
 
 /** Persisted sidecar configuration stored server-side. */
 export interface SidecarConfig {
-  /** Which quantization variant is downloaded/active. Null if none. */
+  /** Active model file path, relative to data/models. Null if none. */
+  modelPath: string | null;
+  /** Which curated quantization variant is downloaded/active. Null for BYO models. */
   quantization: SidecarQuantization | null;
+  /** HuggingFace repo for BYO models, e.g. "unsloth/gemma-4-E2B-it-GGUF". */
+  customModelRepo: string | null;
   /** Whether to use the sidecar for tracker agents in roleplay mode. */
   useForTrackers: boolean;
   /** Whether to use the sidecar for game scene analysis (backgrounds, music, widgets, etc.). */
@@ -57,6 +53,12 @@ export interface SidecarConfig {
   gpuLayers: number;
 }
 
+export interface SidecarRuntimeInfo {
+  installed: boolean;
+  build: string | null;
+  variant: string | null;
+}
+
 /** Server response for sidecar status endpoint. */
 export interface SidecarStatusResponse {
   status: SidecarStatus;
@@ -65,8 +67,10 @@ export interface SidecarStatusResponse {
   modelDownloaded: boolean;
   /** Model file size in bytes (if downloaded). */
   modelSize: number | null;
-  /** Optional runtime build note for the native llama.cpp addon. */
-  runtimeInfo: SidecarRuntimeInfo | null;
+  /** Installed llama.cpp runtime info. */
+  runtime: SidecarRuntimeInfo;
+  /** Absolute log path for the spawned llama-server process. */
+  logPath: string | null;
 }
 
 // ── Scene Analysis Output ──
@@ -138,6 +142,8 @@ export interface SidecarModelInfo {
   quantization: SidecarQuantization;
   /** Display name, e.g. "Gemma 4 E2B — Q8" */
   label: string;
+  /** Final GGUF filename on disk. */
+  filename: string;
   /** Approximate file size in bytes. */
   sizeBytes: number;
   /** Approximate RAM needed at runtime. */
@@ -148,9 +154,19 @@ export interface SidecarModelInfo {
   sha256?: string;
 }
 
+export interface SidecarCustomModelEntry {
+  path: string;
+  filename: string;
+  sizeBytes: number | null;
+  quantizationLabel: string | null;
+  downloadUrl: string;
+}
+
 /** Default sidecar configuration. */
 export const SIDECAR_DEFAULT_CONFIG: SidecarConfig = {
+  modelPath: null,
   quantization: null,
+  customModelRepo: null,
   useForTrackers: false,
   useForGameScene: true,
   contextSize: 8192,
@@ -162,6 +178,7 @@ export const SIDECAR_MODELS: SidecarModelInfo[] = [
   {
     quantization: "q8_0",
     label: "Gemma 4 E2B — Q8 (Best Quality)",
+    filename: "gemma-4-E2B-it-Q8_0.gguf",
     sizeBytes: 5_400_000_000,
     ramBytes: 5_800_000_000,
     downloadUrl: "https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/main/gemma-4-E2B-it-Q8_0.gguf",
@@ -169,6 +186,7 @@ export const SIDECAR_MODELS: SidecarModelInfo[] = [
   {
     quantization: "q4_k_m",
     label: "Gemma 4 E2B — Q4_K_M (Smaller, Faster)",
+    filename: "gemma-4-E2B-it-Q4_K_M.gguf",
     sizeBytes: 3_200_000_000,
     ramBytes: 3_600_000_000,
     downloadUrl: "https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/main/gemma-4-E2B-it-Q4_K_M.gguf",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,9 +196,6 @@ importers:
       better-sqlite3:
         specifier: ^11.0.0
         version: 11.10.0
-      node-llama-cpp:
-        specifier: ^3.5.0
-        version: 3.18.1(typescript@5.9.3)
       onnxruntime-node:
         specifier: 1.24.3
         version: 1.24.3
@@ -1455,10 +1452,6 @@ packages:
     resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
     engines: {node: '>=18'}
 
-  '@isaacs/fs-minipass@4.0.1':
-    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
-    engines: {node: '>=18.0.0'}
-
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -1477,12 +1470,6 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
-
-  '@kwsites/file-exists@1.1.1':
-    resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
-
-  '@kwsites/promise-deferred@1.1.1':
-    resolution: {integrity: sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==}
 
   '@libsql/client@0.15.15':
     resolution: {integrity: sha512-twC0hQxPNHPKfeOv3sNT6u2pturQjLcI+CnpTM0SjRpocEGgfiZ7DWKXLNnsothjyJmDqEsBQJ5ztq9Wlu470w==}
@@ -1621,90 +1608,6 @@ packages:
   '@neon-rs/load@0.0.4':
     resolution: {integrity: sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw==}
 
-  '@node-llama-cpp/linux-arm64@3.18.1':
-    resolution: {integrity: sha512-rXMgZxUay78FOJV/fJ67apYP9eElH5jd4df5YRKPlLhLHHchuOSyDn+qtyW/L/EnPzpogoLkmULqCkdXU39XsQ==}
-    engines: {node: '>=20.0.0'}
-    cpu: [arm64, x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@node-llama-cpp/linux-armv7l@3.18.1':
-    resolution: {integrity: sha512-BrJL2cGo0pN5xd5nw+CzTn2rFMpz9MJyZZPUY81ptGkF2uIuXT2hdCVh56i9ImQrTwBfq1YcZL/l/Qe/1+HR/Q==}
-    engines: {node: '>=20.0.0'}
-    cpu: [arm, x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@node-llama-cpp/linux-x64-cuda-ext@3.18.1':
-    resolution: {integrity: sha512-VqyKhAVHPCpFzh0f1koCBgpThL+04QOXwv0oDQ8s8YcpfMMOXQlBhTB0plgTh0HrPExoObfTS4ohkrbyGgmztQ==}
-    engines: {node: '>=20.0.0'}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@node-llama-cpp/linux-x64-cuda@3.18.1':
-    resolution: {integrity: sha512-qOaYP4uwsUoBHQ/7xSOvyJIuXapS57Al+Sudgi00f96ldNZLKe1vuSGptAi5LTM2lIj66PKm6h8PlRWctwsZ2g==}
-    engines: {node: '>=20.0.0'}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@node-llama-cpp/linux-x64-vulkan@3.18.1':
-    resolution: {integrity: sha512-SIaNTK5pUPhwJD0gmiQfHa8OrRctVMmnqu+slJrz2Mzgg/XrwFndJlS9hvc+jSjTXCouwf7sYeQaaJWvQgBh/A==}
-    engines: {node: '>=20.0.0'}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@node-llama-cpp/linux-x64@3.18.1':
-    resolution: {integrity: sha512-tRmWcsyvAcqJHQHXHsaOkx6muGbcirA9nRdNgH6n7bjGUw4VuoBD3dChyNF3/Ktt7ohB9kz+XhhyZjbDHpXyMA==}
-    engines: {node: '>=20.0.0'}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@node-llama-cpp/mac-arm64-metal@3.18.1':
-    resolution: {integrity: sha512-cyZTdsUMlvuRlGmkkoBbN3v/DT6NuruEqoQYd9CqIrPyLa1xLNBTSKIZ9SgRnw23iCOj4URfITvRP+2pu63LuQ==}
-    engines: {node: '>=20.0.0'}
-    cpu: [arm64, x64]
-    os: [darwin]
-
-  '@node-llama-cpp/mac-x64@3.18.1':
-    resolution: {integrity: sha512-GfCPgdltaIpBhEnQ7WfsrRXrZO9r9pBtDUAQMXRuJwOPP5q7xKrQZUXI6J6mpc8tAG0//CTIuGn4hTKoD/8V8w==}
-    engines: {node: '>=20.0.0'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@node-llama-cpp/win-arm64@3.18.1':
-    resolution: {integrity: sha512-S05YUzBMVSRS5KNbOS26cDYugeQHqogI3uewtTUBVC0tPbTHRSKjsdicmgWru1eNAry399LWWhzOf/3St/qsAw==}
-    engines: {node: '>=20.0.0'}
-    cpu: [arm64, x64]
-    os: [win32]
-
-  '@node-llama-cpp/win-x64-cuda-ext@3.18.1':
-    resolution: {integrity: sha512-u0FzJBQsJA355ksKERxwPJhlcWl3ZJSNkU2ZUwDEiKNOCbv3ybvSCIEyDvB63wdtkfVUuCRJWijZnpDZxrCGqg==}
-    engines: {node: '>=20.0.0'}
-    cpu: [x64]
-    os: [win32]
-
-  '@node-llama-cpp/win-x64-cuda@3.18.1':
-    resolution: {integrity: sha512-drgJmBhnxGQtB/SLo4sf4PPSuxRv3MdNP0FF6rKPY9TtzEOV293bRQyYEu/JYwvXfVApAIsRaJUTGvCkA9Qobw==}
-    engines: {node: '>=20.0.0'}
-    cpu: [x64]
-    os: [win32]
-
-  '@node-llama-cpp/win-x64-vulkan@3.18.1':
-    resolution: {integrity: sha512-PjmxrnPToi7y0zlP7l+hRIhvOmuEv94P6xZ11vjqICEJu8XdAJpvTfPKgDW4W0p0v4+So8ZiZYLUuwIHcsseyQ==}
-    engines: {node: '>=20.0.0'}
-    cpu: [x64]
-    os: [win32]
-
-  '@node-llama-cpp/win-x64@3.18.1':
-    resolution: {integrity: sha512-QLDVphPl+YDI+x/VYYgIV1N9g0GMXk3PqcoopOUG3cBRUtce7FO+YX903YdRJezs4oKbIp8YaO+xYBgeUSqhpA==}
-    engines: {node: '>=20.0.0'}
-    cpu: [x64]
-    os: [win32]
-
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
 
@@ -1737,62 +1640,6 @@ packages:
 
   '@protobufjs/utf8@1.1.0':
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
-
-  '@reflink/reflink-darwin-arm64@0.1.19':
-    resolution: {integrity: sha512-ruy44Lpepdk1FqDz38vExBY/PVUsjxZA+chd9wozjUH9JjuDT/HEaQYA6wYN9mf041l0yLVar6BCZuWABJvHSA==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@reflink/reflink-darwin-x64@0.1.19':
-    resolution: {integrity: sha512-By85MSWrMZa+c26TcnAy8SDk0sTUkYlNnwknSchkhHpGXOtjNDUOxJE9oByBnGbeuIE1PiQsxDG3Ud+IVV9yuA==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@reflink/reflink-linux-arm64-gnu@0.1.19':
-    resolution: {integrity: sha512-7P+er8+rP9iNeN+bfmccM4hTAaLP6PQJPKWSA4iSk2bNvo6KU6RyPgYeHxXmzNKzPVRcypZQTpFgstHam6maVg==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@reflink/reflink-linux-arm64-musl@0.1.19':
-    resolution: {integrity: sha512-37iO/Dp6m5DDaC2sf3zPtx/hl9FV3Xze4xoYidrxxS9bgP3S8ALroxRK6xBG/1TtfXKTvolvp+IjrUU6ujIGmA==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@reflink/reflink-linux-x64-gnu@0.1.19':
-    resolution: {integrity: sha512-jbI8jvuYCaA3MVUdu8vLoLAFqC+iNMpiSuLbxlAgg7x3K5bsS8nOpTRnkLF7vISJ+rVR8W+7ThXlXlUQ93ulkw==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@reflink/reflink-linux-x64-musl@0.1.19':
-    resolution: {integrity: sha512-e9FBWDe+lv7QKAwtKOt6A2W/fyy/aEEfr0g6j/hWzvQcrzHCsz07BNQYlNOjTfeytrtLU7k449H1PI95jA4OjQ==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@reflink/reflink-win32-arm64-msvc@0.1.19':
-    resolution: {integrity: sha512-09PxnVIQcd+UOn4WAW73WU6PXL7DwGS6wPlkMhMg2zlHHG65F3vHepOw06HFCq+N42qkaNAc8AKIabWvtk6cIQ==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@reflink/reflink-win32-x64-msvc@0.1.19':
-    resolution: {integrity: sha512-E//yT4ni2SyhwP8JRjVGWr3cbnhWDiPLgnQ66qqaanjjnMiu3O/2tjCPQXlcGc/DEYofpDc9fvhv6tALQsMV9w==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [win32]
-
-  '@reflink/reflink@0.1.19':
-    resolution: {integrity: sha512-DmCG8GzysnCZ15bres3N5AHCmwBwYgp0As6xjhQ47rAUTUXxJiK+lLUxaGsX3hd/30qUpVElh05PbGuxRPgJwA==}
-    engines: {node: '>= 10'}
 
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
@@ -1984,12 +1831,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@simple-git/args-pathspec@1.0.2':
-    resolution: {integrity: sha512-nEFVejViHUoL8wU8GTcwqrvqfUG40S5ts6S4fr1u1Ki5CklXlRDYThPVA/qurTmCYFGnaX3XpVUmICLHdvhLaA==}
-
-  '@simple-git/argv-parser@1.0.3':
-    resolution: {integrity: sha512-NMKv9sJcSN2VvnPT9Ja7eKfGy8Q8mMFLwPTCcuZMtv3+mYcLIZflg31S/tp2XCCyiY7YAx6cgBHQ0fwA2fWHpQ==}
-
   '@surma/rollup-plugin-off-main-thread@2.2.3':
     resolution: {integrity: sha512-lR8q/9W7hZpMWweNiAKU7NQerBnzQQLvi8qnTDU/fxItPhtZVMbPV3lbCwjhIlNBe9Bbr5V+KHshvWmVSG9cxQ==}
 
@@ -2118,10 +1959,6 @@ packages:
 
   '@tanstack/store@0.9.1':
     resolution: {integrity: sha512-+qcNkOy0N1qSGsP7omVCW0SDrXtaDcycPqBDE726yryiA5eTDFpjBReaYjghVJwNf1pcPMyzIwTGlYjCSQR0Fg==}
-
-  '@tinyhttp/content-disposition@2.2.4':
-    resolution: {integrity: sha512-5Kc5CM2Ysn3vTTArBs2vESUt0AQiWZA86yc1TI3B+lxXmtEq133C1nxXNOgnzhrivdPZIh3zLj5gDnZjoLL5GA==}
-    engines: {node: '>=12.17.0'}
 
   '@types/adm-zip@0.5.8':
     resolution: {integrity: sha512-RVVH7QvZYbN+ihqZ4kX/dMiowf6o+Jk1fNwiSdx0NahBJLU787zkULhGhJM8mf/obmLGmgdMM0bXsQTmyfbR7Q==}
@@ -2270,25 +2107,9 @@ packages:
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
-  ansi-escapes@6.2.1:
-    resolution: {integrity: sha512-4nJ3yixlEthEJ9Rk4vPcdBRkZvQZlYyu8j4/Mqz5sgIkddmEnH2Yj2ZrnP9S3tQOvSNRUIgVNF/1yPpRAGNRig==}
-    engines: {node: '>=14.16'}
-
-  ansi-regex@5.0.1:
-    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
-    engines: {node: '>=8'}
-
-  ansi-regex@6.2.2:
-    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
-    engines: {node: '>=12'}
-
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
-
-  ansi-styles@6.2.3:
-    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
-    engines: {node: '>=12'}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -2304,9 +2125,6 @@ packages:
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
-
-  async-retry@1.3.3:
-    resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
 
   async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
@@ -2400,10 +2218,6 @@ packages:
   buttplug@4.0.0:
     resolution: {integrity: sha512-9fO055gmZbHp7lI5C95pNbvjHye/n5cKNxv//ObW7Vh8R6UULE5tz8/dpYXJDcjy64DbX1+M5KnUgr40ygafsQ==}
 
-  bytes@3.1.2:
-    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
-    engines: {node: '>= 0.8'}
-
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -2427,51 +2241,15 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
-  chalk@5.6.2:
-    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
-    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
-
-  chmodrp@1.0.2:
-    resolution: {integrity: sha512-TdngOlFV1FLTzU0o1w8MB6/BFywhtLC0SzRTGJU7T9lmdjlCWeMRt1iVo0Ki+ldwNk0BqNiKoc8xpLZEQ8mY1w==}
-
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
-
-  chownr@3.0.0:
-    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
-    engines: {node: '>=18'}
-
-  ci-info@4.4.0:
-    resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
-    engines: {node: '>=8'}
 
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
-  cli-cursor@5.0.0:
-    resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
-    engines: {node: '>=18'}
-
-  cli-spinners@2.9.2:
-    resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
-    engines: {node: '>=6'}
-
-  cli-spinners@3.4.0:
-    resolution: {integrity: sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==}
-    engines: {node: '>=18.20'}
-
-  cliui@8.0.1:
-    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
-    engines: {node: '>=12'}
-
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
-
-  cmake-js@8.0.0:
-    resolution: {integrity: sha512-YbUP88RDwCvoQkZhRtGURYm9RIpWdtvZuhT87fKNoLjk8kIFIFeARpKfuZQGdwfH99GZpUmqSfcDrK62X7lTgg==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-    hasBin: true
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -2482,10 +2260,6 @@ packages:
 
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
-
-  commander@10.0.1:
-    resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
-    engines: {node: '>=14'}
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -2718,22 +2492,12 @@ packages:
   electron-to-chromium@1.5.302:
     resolution: {integrity: sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==}
 
-  emoji-regex@10.6.0:
-    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
-
-  emoji-regex@8.0.0:
-    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
-
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   enhanced-resolve@5.20.0:
     resolution: {integrity: sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==}
     engines: {node: '>=10.13.0'}
-
-  env-var@7.5.0:
-    resolution: {integrity: sha512-mKZOzLRN0ETzau2W2QXefbFjo5EF4yWq28OyKb9ICdeNhHJlOE/pHHnz4hdYJ9cNZXcJHo5xN4OT4pzuSHSNvA==}
-    engines: {node: '>=10'}
 
   es-abstract@1.24.1:
     resolution: {integrity: sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==}
@@ -2917,14 +2681,6 @@ packages:
   filelist@1.0.6:
     resolution: {integrity: sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==}
 
-  filename-reserved-regex@3.0.0:
-    resolution: {integrity: sha512-hn4cQfU6GOT/7cFHXBqeBg2TbrMBgdD0kcjLhvSQYYwm3s4B6cjvBfb7nBALJLAXqmU5xajSa7X2NnUud/VCdw==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
-  filenamify@6.0.0:
-    resolution: {integrity: sha512-vqIlNogKeyD3yzrm0yhRMQg8hOVwYcYRfjEoODd49iCprMn4HL85gK3HcykQE53EPIpX3HcAbGA5ELQv216dAQ==}
-    engines: {node: '>=16'}
-
   find-my-way@9.5.0:
     resolution: {integrity: sha512-VW2RfnmscZO5KgBY5XVyKREMW5nMZcxDy+buTOsL+zIPnBlbKm+00sgzoQzq1EVh4aALZLfKdwv6atBGcjvjrQ==}
     engines: {node: '>=20'}
@@ -2975,10 +2731,6 @@ packages:
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
-  fs-extra@11.3.4:
-    resolution: {integrity: sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==}
-    engines: {node: '>=14.14'}
-
   fs-extra@9.1.0:
     resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
     engines: {node: '>=10'}
@@ -3005,14 +2757,6 @@ packages:
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
-
-  get-caller-file@2.0.5:
-    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
-    engines: {node: 6.* || 8.* || >= 10.*}
-
-  get-east-asian-width@1.5.0:
-    resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
-    engines: {node: '>=18'}
 
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
@@ -3143,11 +2887,6 @@ packages:
     resolution: {integrity: sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==}
     engines: {node: '>= 10'}
 
-  ipull@3.9.5:
-    resolution: {integrity: sha512-5w/yZB5lXmTfsvNawmvkCjYo4SJNuKQz/av8TC1UiOyfOHyaM+DReqbpU2XpWYfmY+NIUbRRH8PUAWsxaS+IfA==}
-    engines: {node: '>=18.0.0'}
-    hasBin: true
-
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
     engines: {node: '>= 0.4'}
@@ -3188,14 +2927,6 @@ packages:
     resolution: {integrity: sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==}
     engines: {node: '>= 0.4'}
 
-  is-fullwidth-code-point@3.0.0:
-    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
-    engines: {node: '>=8'}
-
-  is-fullwidth-code-point@5.1.0:
-    resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
-    engines: {node: '>=18'}
-
   is-generator-function@1.1.2:
     resolution: {integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==}
     engines: {node: '>= 0.4'}
@@ -3203,10 +2934,6 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
-
-  is-interactive@2.0.0:
-    resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
-    engines: {node: '>=12'}
 
   is-map@2.0.3:
     resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
@@ -3259,10 +2986,6 @@ packages:
     resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
     engines: {node: '>= 0.4'}
 
-  is-unicode-supported@2.1.0:
-    resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
-    engines: {node: '>=18'}
-
   is-weakmap@2.0.2:
     resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
     engines: {node: '>= 0.4'}
@@ -3284,10 +3007,6 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
-
-  isexe@4.0.0:
-    resolution: {integrity: sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==}
-    engines: {node: '>=20'}
 
   jackspeak@4.2.3:
     resolution: {integrity: sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==}
@@ -3369,12 +3088,6 @@ packages:
     resolution: {integrity: sha512-NscWthMQt7fpU8lqd7LXMvT9pi+KhhmTHAJWUB/Lj6MWa0MKFv0F2V4C6WKKpjCVZl0VwcDz4nOI3CyaT1DDiA==}
     cpu: [x64, arm64, wasm32, arm]
     os: [darwin, linux, win32]
-
-  lifecycle-utils@2.1.0:
-    resolution: {integrity: sha512-AnrXnE2/OF9PHCyFg0RSqsnQTzV991XaZA/buhFDoc58xU7rhSCDgCz/09Lqpsn4MpoPHt7TRAXV1kWZypFVsA==}
-
-  lifecycle-utils@3.1.1:
-    resolution: {integrity: sha512-gNd3OvhFNjHykJE3uGntz7UuPzWlK9phrIdXxU9Adis0+ExkwnZibfxCJWiWWZ+a6VbKiZrb+9D9hCQWd4vjTg==}
 
   light-my-request@6.6.0:
     resolution: {integrity: sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==}
@@ -3469,16 +3182,8 @@ packages:
   lodash@4.17.23:
     resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
 
-  log-symbols@7.0.1:
-    resolution: {integrity: sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==}
-    engines: {node: '>=18'}
-
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
-
-  lowdb@7.0.1:
-    resolution: {integrity: sha512-neJAj8GwF0e8EpycYIDFqEPcx9Qz4GUho20jWFR7YiFeXzF1YMLdxB36PypcTSPMA+4+LvgyMacYhlr18Zlymw==}
-    engines: {node: '>=18'}
 
   lru-cache@11.2.6:
     resolution: {integrity: sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==}
@@ -3511,10 +3216,6 @@ packages:
     engines: {node: '>=10.0.0'}
     hasBin: true
 
-  mimic-function@5.0.1:
-    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
-    engines: {node: '>=18'}
-
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
@@ -3536,10 +3237,6 @@ packages:
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
-
-  minizlib@3.1.0:
-    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
-    engines: {node: '>= 18'}
 
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
@@ -3573,13 +3270,6 @@ packages:
     resolution: {integrity: sha512-At6b4UqIEVudaqPsXjmUO1r/N5BUr4yhDGs5PkBE8/oG5+TfLPhFechiskFsnT6Ql0VfUXbalUUCbfXxtj7K+w==}
     engines: {node: '>=10'}
 
-  node-addon-api@8.7.0:
-    resolution: {integrity: sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==}
-    engines: {node: ^18 || ^20 || >= 21}
-
-  node-api-headers@1.8.0:
-    resolution: {integrity: sha512-jfnmiKWjRAGbdD1yQS28bknFM1tbHC1oucyuMPjmkEs+kpiu76aRs40WlTmBmyEgzDM76ge1DQ7XJ3R5deiVjQ==}
-
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
@@ -3588,16 +3278,6 @@ packages:
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
-  node-llama-cpp@3.18.1:
-    resolution: {integrity: sha512-w0zfuy/IKS2fhrbed5SylZDXJHTVz4HnkwZ4UrFPgSNwJab3QIPwIl4lyCKHHy9flLrtxsAuV5kXfH3HZ6bb8w==}
-    engines: {node: '>=20.0.0'}
-    hasBin: true
-    peerDependencies:
-      typescript: '>=5.0.0'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
 
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
@@ -3621,10 +3301,6 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
-  onetime@7.0.0:
-    resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
-    engines: {node: '>=18'}
-
   onnxruntime-common@1.24.3:
     resolution: {integrity: sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA==}
 
@@ -3638,10 +3314,6 @@ packages:
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
-
-  ora@9.3.0:
-    resolution: {integrity: sha512-lBX72MWFduWEf7v7uWf5DHp9Jn5BI8bNPGuFgtXMmr2uDz2Gz2749y3am3agSDdkhHPHYmmxEGSKH85ZLGzgXw==}
-    engines: {node: '>=20'}
 
   own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
@@ -3661,14 +3333,6 @@ packages:
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
-
-  parse-ms@3.0.0:
-    resolution: {integrity: sha512-Tpb8Z7r7XbbtBTrM9UhpkzzaMrqA2VXMT3YChzYltwV3P3pM6t8wl7TvpMnSTosz1aQAdVib7kdoys7vYOPerw==}
-    engines: {node: '>=12'}
-
-  parse-ms@4.0.0:
-    resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
-    engines: {node: '>=18'}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -3772,14 +3436,6 @@ packages:
     resolution: {integrity: sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ==}
     engines: {node: ^14.13.1 || >=16.0.0}
 
-  pretty-ms@8.0.0:
-    resolution: {integrity: sha512-ASJqOugUF1bbzI35STMBUpZqdfYKlJugy6JBziGi2EE+AL5JPJGSzvpeVXojxrr0ViUYoToUjb5kjSEGf7Y83Q==}
-    engines: {node: '>=14.16'}
-
-  pretty-ms@9.3.0:
-    resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
-    engines: {node: '>=18'}
-
   process-warning@4.0.1:
     resolution: {integrity: sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==}
 
@@ -3788,9 +3444,6 @@ packages:
 
   promise-limit@2.7.0:
     resolution: {integrity: sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw==}
-
-  proper-lockfile@4.1.2:
-    resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
 
   protobufjs@7.5.4:
     resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
@@ -3860,10 +3513,6 @@ packages:
     resolution: {integrity: sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q==}
     hasBin: true
 
-  require-directory@2.1.1:
-    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
-    engines: {node: '>=0.10.0'}
-
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
@@ -3880,21 +3529,9 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
-  restore-cursor@5.1.0:
-    resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
-    engines: {node: '>=18'}
-
   ret@0.5.0:
     resolution: {integrity: sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==}
     engines: {node: '>=10'}
-
-  retry@0.12.0:
-    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
-    engines: {node: '>= 4'}
-
-  retry@0.13.1:
-    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
-    engines: {node: '>= 4'}
 
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
@@ -4020,9 +3657,6 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
-  signal-exit@3.0.7:
-    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
-
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -4032,20 +3666,6 @@ packages:
 
   simple-get@4.0.1:
     resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
-
-  simple-git@3.35.2:
-    resolution: {integrity: sha512-ZMjl06lzTm1EScxEGuM6+mEX+NQd14h/B3x0vWU+YOXAMF8sicyi1K4cjTfj5is+35ChJEHDl1EjypzYFWH2FA==}
-
-  sleep-promise@9.1.0:
-    resolution: {integrity: sha512-UHYzVpz9Xn8b+jikYSD6bqvf754xL2uBUzDFwiU6NcdZeifPr6UfgU43xpkPu67VMS88+TI2PSI7Eohgqf2fKA==}
-
-  slice-ansi@7.1.2:
-    resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
-    engines: {node: '>=18'}
-
-  slice-ansi@8.0.0:
-    resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
-    engines: {node: '>=20'}
 
   sliced@1.0.1:
     resolution: {integrity: sha512-VZBmZP8WU3sMOZm1bdgTadsQbcscK0UM8oKxKVBs4XAhUo2Xxzm/OFMGBkPusxw9xL3Uy8LrzEqGqJhclsr0yA==}
@@ -4097,36 +3717,12 @@ packages:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
 
-  stdin-discarder@0.3.1:
-    resolution: {integrity: sha512-reExS1kSGoElkextOcPkel4NE99S0BWxjUHQeDFnR8S993JxpPX7KU4MNmO19NXhlJp+8dmdCbKQVNgLJh2teA==}
-    engines: {node: '>=18'}
-
-  stdout-update@4.0.1:
-    resolution: {integrity: sha512-wiS21Jthlvl1to+oorePvcyrIkiG/6M3D3VTmDUlJm7Cy6SbFhKkAvX+YBuHLxck/tO3mrdpC/cNesigQc3+UQ==}
-    engines: {node: '>=16.0.0'}
-
-  steno@4.0.2:
-    resolution: {integrity: sha512-yhPIQXjrlt1xv7dyPQg2P17URmXbuM5pdGkpiMB3RenprfiBlvK415Lctfe0eshk90oA7/tNq7WEiMK8RSP39A==}
-    engines: {node: '>=18'}
-
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
 
   stream-shift@1.0.3:
     resolution: {integrity: sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==}
-
-  string-width@4.2.3:
-    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
-    engines: {node: '>=8'}
-
-  string-width@7.2.0:
-    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
-    engines: {node: '>=18'}
-
-  string-width@8.2.0:
-    resolution: {integrity: sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==}
-    engines: {node: '>=20'}
 
   string.prototype.matchall@4.0.12:
     resolution: {integrity: sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==}
@@ -4150,14 +3746,6 @@ packages:
   stringify-object@3.3.0:
     resolution: {integrity: sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==}
     engines: {node: '>=4'}
-
-  strip-ansi@6.0.1:
-    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
-    engines: {node: '>=8'}
-
-  strip-ansi@7.2.0:
-    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
-    engines: {node: '>=12'}
 
   strip-comments@2.0.1:
     resolution: {integrity: sha512-ZprKx+bBLXv067WTCALv8SSz5l2+XhpYCsVtSqlMnkAXMWDq+/ekVbl1ghqP9rUHTzv6sm/DwCOiYutU/yp1fw==}
@@ -4199,10 +3787,6 @@ packages:
   tar-stream@2.2.0:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
-
-  tar@7.5.12:
-    resolution: {integrity: sha512-9TsuLcdhOn4XztcQqhNyq1KOwOOED/3k58JAvtULiYqbO8B/0IBAAIE1hj0Svmm58k27TmcigyDI0deMlgG3uw==}
-    engines: {node: '>=18'}
 
   temp-dir@2.0.0:
     resolution: {integrity: sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==}
@@ -4350,9 +3934,6 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
-  url-join@4.0.1:
-    resolution: {integrity: sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==}
-
   use-sync-external-store@1.6.0:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
@@ -4360,10 +3941,6 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
-
-  validate-npm-package-name@7.0.2:
-    resolution: {integrity: sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==}
-    engines: {node: ^20.17.0 || >=22.9.0}
 
   vite-plugin-pwa@1.2.0:
     resolution: {integrity: sha512-a2xld+SJshT9Lgcv8Ji4+srFJL4k/1bVbd1x06JIkvecpQkwkvCncD1+gSzcdm3s+owWLpMJerG3aN5jupJEVw==}
@@ -4448,11 +4025,6 @@ packages:
     engines: {node: '>= 8'}
     hasBin: true
 
-  which@6.0.1:
-    resolution: {integrity: sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-    hasBin: true
-
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
@@ -4506,10 +4078,6 @@ packages:
   workbox-window@7.4.0:
     resolution: {integrity: sha512-/bIYdBLAVsNR3v7gYGaV4pQW3M3kEPx5E8vDxGvxo6khTrGtSSCS7QiFKv9ogzBgZiy0OXLP9zO28U/1nF1mfw==}
 
-  wrap-ansi@7.0.0:
-    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
-    engines: {node: '>=10'}
-
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -4525,32 +4093,12 @@ packages:
       utf-8-validate:
         optional: true
 
-  y18n@5.0.8:
-    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
-    engines: {node: '>=10'}
-
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
-
-  yallist@5.0.0:
-    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
-    engines: {node: '>=18'}
-
-  yargs-parser@21.1.1:
-    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
-    engines: {node: '>=12'}
-
-  yargs@17.7.2:
-    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
-    engines: {node: '>=12'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
-
-  yoctocolors@2.1.2:
-    resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
-    engines: {node: '>=18'}
 
   zod-validation-error@4.0.2:
     resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
@@ -5723,11 +5271,6 @@ snapshots:
 
   '@isaacs/cliui@9.0.0': {}
 
-  '@isaacs/fs-minipass@4.0.1':
-    dependencies:
-      minipass: 7.1.3
-    optional: true
-
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -5751,16 +5294,6 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
-
-  '@kwsites/file-exists@1.1.1':
-    dependencies:
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
-  '@kwsites/promise-deferred@1.1.1':
-    optional: true
 
   '@libsql/client@0.15.15':
     dependencies:
@@ -5871,45 +5404,6 @@ snapshots:
 
   '@neon-rs/load@0.0.4': {}
 
-  '@node-llama-cpp/linux-arm64@3.18.1':
-    optional: true
-
-  '@node-llama-cpp/linux-armv7l@3.18.1':
-    optional: true
-
-  '@node-llama-cpp/linux-x64-cuda-ext@3.18.1':
-    optional: true
-
-  '@node-llama-cpp/linux-x64-cuda@3.18.1':
-    optional: true
-
-  '@node-llama-cpp/linux-x64-vulkan@3.18.1':
-    optional: true
-
-  '@node-llama-cpp/linux-x64@3.18.1':
-    optional: true
-
-  '@node-llama-cpp/mac-arm64-metal@3.18.1':
-    optional: true
-
-  '@node-llama-cpp/mac-x64@3.18.1':
-    optional: true
-
-  '@node-llama-cpp/win-arm64@3.18.1':
-    optional: true
-
-  '@node-llama-cpp/win-x64-cuda-ext@3.18.1':
-    optional: true
-
-  '@node-llama-cpp/win-x64-cuda@3.18.1':
-    optional: true
-
-  '@node-llama-cpp/win-x64-vulkan@3.18.1':
-    optional: true
-
-  '@node-llama-cpp/win-x64@3.18.1':
-    optional: true
-
   '@pinojs/redact@0.4.0': {}
 
   '@protobufjs/aspromise@1.1.2': {}
@@ -5934,42 +5428,6 @@ snapshots:
   '@protobufjs/pool@1.1.0': {}
 
   '@protobufjs/utf8@1.1.0': {}
-
-  '@reflink/reflink-darwin-arm64@0.1.19':
-    optional: true
-
-  '@reflink/reflink-darwin-x64@0.1.19':
-    optional: true
-
-  '@reflink/reflink-linux-arm64-gnu@0.1.19':
-    optional: true
-
-  '@reflink/reflink-linux-arm64-musl@0.1.19':
-    optional: true
-
-  '@reflink/reflink-linux-x64-gnu@0.1.19':
-    optional: true
-
-  '@reflink/reflink-linux-x64-musl@0.1.19':
-    optional: true
-
-  '@reflink/reflink-win32-arm64-msvc@0.1.19':
-    optional: true
-
-  '@reflink/reflink-win32-x64-msvc@0.1.19':
-    optional: true
-
-  '@reflink/reflink@0.1.19':
-    optionalDependencies:
-      '@reflink/reflink-darwin-arm64': 0.1.19
-      '@reflink/reflink-darwin-x64': 0.1.19
-      '@reflink/reflink-linux-arm64-gnu': 0.1.19
-      '@reflink/reflink-linux-arm64-musl': 0.1.19
-      '@reflink/reflink-linux-x64-gnu': 0.1.19
-      '@reflink/reflink-linux-x64-musl': 0.1.19
-      '@reflink/reflink-win32-arm64-msvc': 0.1.19
-      '@reflink/reflink-win32-x64-msvc': 0.1.19
-    optional: true
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
@@ -6098,14 +5556,6 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.59.0':
     optional: true
 
-  '@simple-git/args-pathspec@1.0.2':
-    optional: true
-
-  '@simple-git/argv-parser@1.0.3':
-    dependencies:
-      '@simple-git/args-pathspec': 1.0.2
-    optional: true
-
   '@surma/rollup-plugin-off-main-thread@2.2.3':
     dependencies:
       ejs: 3.1.10
@@ -6219,9 +5669,6 @@ snapshots:
       tiny-warning: 1.0.3
 
   '@tanstack/store@0.9.1': {}
-
-  '@tinyhttp/content-disposition@2.2.4':
-    optional: true
 
   '@types/adm-zip@0.5.8':
     dependencies:
@@ -6413,21 +5860,9 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
-  ansi-escapes@6.2.1:
-    optional: true
-
-  ansi-regex@5.0.1:
-    optional: true
-
-  ansi-regex@6.2.2:
-    optional: true
-
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
-
-  ansi-styles@6.2.3:
-    optional: true
 
   argparse@2.0.1: {}
 
@@ -6447,11 +5882,6 @@ snapshots:
       is-array-buffer: 3.0.5
 
   async-function@1.0.0: {}
-
-  async-retry@1.3.3:
-    dependencies:
-      retry: 0.13.1
-    optional: true
 
   async@3.2.6: {}
 
@@ -6567,9 +5997,6 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  bytes@3.1.2:
-    optional: true
-
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -6596,59 +6023,14 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
-  chalk@5.6.2:
-    optional: true
-
-  chmodrp@1.0.2:
-    optional: true
-
   chownr@1.1.4:
-    optional: true
-
-  chownr@3.0.0:
-    optional: true
-
-  ci-info@4.4.0:
     optional: true
 
   class-variance-authority@0.7.1:
     dependencies:
       clsx: 2.1.1
 
-  cli-cursor@5.0.0:
-    dependencies:
-      restore-cursor: 5.1.0
-    optional: true
-
-  cli-spinners@2.9.2:
-    optional: true
-
-  cli-spinners@3.4.0:
-    optional: true
-
-  cliui@8.0.1:
-    dependencies:
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      wrap-ansi: 7.0.0
-    optional: true
-
   clsx@2.1.1: {}
-
-  cmake-js@8.0.0:
-    dependencies:
-      debug: 4.4.3
-      fs-extra: 11.3.4
-      node-api-headers: 1.8.0
-      rc: 1.2.8
-      semver: 7.7.4
-      tar: 7.5.12
-      url-join: 4.0.1
-      which: 6.0.1
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
 
   color-convert@2.0.1:
     dependencies:
@@ -6657,9 +6039,6 @@ snapshots:
   color-name@1.1.4: {}
 
   colorette@2.0.20: {}
-
-  commander@10.0.1:
-    optional: true
 
   commander@2.20.3: {}
 
@@ -6795,12 +6174,6 @@ snapshots:
 
   electron-to-chromium@1.5.302: {}
 
-  emoji-regex@10.6.0:
-    optional: true
-
-  emoji-regex@8.0.0:
-    optional: true
-
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
@@ -6809,9 +6182,6 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.0
-
-  env-var@7.5.0:
-    optional: true
 
   es-abstract@1.24.1:
     dependencies:
@@ -7150,14 +6520,6 @@ snapshots:
     dependencies:
       minimatch: 5.1.9
 
-  filename-reserved-regex@3.0.0:
-    optional: true
-
-  filenamify@6.0.0:
-    dependencies:
-      filename-reserved-regex: 3.0.0
-    optional: true
-
   find-my-way@9.5.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -7205,13 +6567,6 @@ snapshots:
   fs-constants@1.0.0:
     optional: true
 
-  fs-extra@11.3.4:
-    dependencies:
-      graceful-fs: 4.2.11
-      jsonfile: 6.2.0
-      universalify: 2.0.1
-    optional: true
-
   fs-extra@9.1.0:
     dependencies:
       at-least-node: 1.0.0
@@ -7238,12 +6593,6 @@ snapshots:
   generator-function@2.0.1: {}
 
   gensync@1.0.0-beta.2: {}
-
-  get-caller-file@2.0.5:
-    optional: true
-
-  get-east-asian-width@1.5.0:
-    optional: true
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -7380,31 +6729,6 @@ snapshots:
 
   ipaddr.js@2.3.0: {}
 
-  ipull@3.9.5:
-    dependencies:
-      '@tinyhttp/content-disposition': 2.2.4
-      async-retry: 1.3.3
-      chalk: 5.6.2
-      ci-info: 4.4.0
-      cli-spinners: 2.9.2
-      commander: 10.0.1
-      eventemitter3: 5.0.4
-      filenamify: 6.0.0
-      fs-extra: 11.3.4
-      is-unicode-supported: 2.1.0
-      lifecycle-utils: 2.1.0
-      lodash.debounce: 4.0.8
-      lowdb: 7.0.1
-      pretty-bytes: 6.1.1
-      pretty-ms: 8.0.0
-      sleep-promise: 9.1.0
-      slice-ansi: 7.1.2
-      stdout-update: 4.0.1
-      strip-ansi: 7.2.0
-    optionalDependencies:
-      '@reflink/reflink': 0.1.19
-    optional: true
-
   is-array-buffer@3.0.5:
     dependencies:
       call-bind: 1.0.8
@@ -7451,14 +6775,6 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
 
-  is-fullwidth-code-point@3.0.0:
-    optional: true
-
-  is-fullwidth-code-point@5.1.0:
-    dependencies:
-      get-east-asian-width: 1.5.0
-    optional: true
-
   is-generator-function@1.1.2:
     dependencies:
       call-bound: 1.0.4
@@ -7470,9 +6786,6 @@ snapshots:
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
-
-  is-interactive@2.0.0:
-    optional: true
 
   is-map@2.0.3: {}
 
@@ -7519,9 +6832,6 @@ snapshots:
     dependencies:
       which-typed-array: 1.1.20
 
-  is-unicode-supported@2.1.0:
-    optional: true
-
   is-weakmap@2.0.2: {}
 
   is-weakref@1.1.1:
@@ -7538,9 +6848,6 @@ snapshots:
   isbot@5.1.35: {}
 
   isexe@2.0.0: {}
-
-  isexe@4.0.0:
-    optional: true
 
   jackspeak@4.2.3:
     dependencies:
@@ -7618,12 +6925,6 @@ snapshots:
       '@libsql/linux-x64-musl': 0.5.22
       '@libsql/win32-x64-msvc': 0.5.22
 
-  lifecycle-utils@2.1.0:
-    optional: true
-
-  lifecycle-utils@3.1.1:
-    optional: true
-
   light-my-request@6.6.0:
     dependencies:
       cookie: 1.1.1
@@ -7691,18 +6992,7 @@ snapshots:
 
   lodash@4.17.23: {}
 
-  log-symbols@7.0.1:
-    dependencies:
-      is-unicode-supported: 2.1.0
-      yoctocolors: 2.1.2
-    optional: true
-
   long@5.3.2: {}
-
-  lowdb@7.0.1:
-    dependencies:
-      steno: 4.0.2
-    optional: true
 
   lru-cache@11.2.6: {}
 
@@ -7730,9 +7020,6 @@ snapshots:
 
   mime@3.0.0: {}
 
-  mimic-function@5.0.1:
-    optional: true
-
   mimic-response@3.1.0:
     optional: true
 
@@ -7751,11 +7038,6 @@ snapshots:
   minimist@1.2.8: {}
 
   minipass@7.1.3: {}
-
-  minizlib@3.1.0:
-    dependencies:
-      minipass: 7.1.3
-    optional: true
 
   mkdirp-classic@0.5.3:
     optional: true
@@ -7782,12 +7064,6 @@ snapshots:
       semver: 7.7.4
     optional: true
 
-  node-addon-api@8.7.0:
-    optional: true
-
-  node-api-headers@1.8.0:
-    optional: true
-
   node-domexception@1.0.0: {}
 
   node-fetch@3.3.2:
@@ -7795,55 +7071,6 @@ snapshots:
       data-uri-to-buffer: 4.0.1
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
-
-  node-llama-cpp@3.18.1(typescript@5.9.3):
-    dependencies:
-      '@huggingface/jinja': 0.5.6
-      async-retry: 1.3.3
-      bytes: 3.1.2
-      chalk: 5.6.2
-      chmodrp: 1.0.2
-      cmake-js: 8.0.0
-      cross-spawn: 7.0.6
-      env-var: 7.5.0
-      filenamify: 6.0.0
-      fs-extra: 11.3.4
-      ignore: 7.0.5
-      ipull: 3.9.5
-      is-unicode-supported: 2.1.0
-      lifecycle-utils: 3.1.1
-      log-symbols: 7.0.1
-      nanoid: 5.1.6
-      node-addon-api: 8.7.0
-      ora: 9.3.0
-      pretty-ms: 9.3.0
-      proper-lockfile: 4.1.2
-      semver: 7.7.4
-      simple-git: 3.35.2
-      slice-ansi: 8.0.0
-      stdout-update: 4.0.1
-      strip-ansi: 7.2.0
-      validate-npm-package-name: 7.0.2
-      which: 6.0.1
-      yargs: 17.7.2
-    optionalDependencies:
-      '@node-llama-cpp/linux-arm64': 3.18.1
-      '@node-llama-cpp/linux-armv7l': 3.18.1
-      '@node-llama-cpp/linux-x64': 3.18.1
-      '@node-llama-cpp/linux-x64-cuda': 3.18.1
-      '@node-llama-cpp/linux-x64-cuda-ext': 3.18.1
-      '@node-llama-cpp/linux-x64-vulkan': 3.18.1
-      '@node-llama-cpp/mac-arm64-metal': 3.18.1
-      '@node-llama-cpp/mac-x64': 3.18.1
-      '@node-llama-cpp/win-arm64': 3.18.1
-      '@node-llama-cpp/win-x64': 3.18.1
-      '@node-llama-cpp/win-x64-cuda': 3.18.1
-      '@node-llama-cpp/win-x64-cuda-ext': 3.18.1
-      '@node-llama-cpp/win-x64-vulkan': 3.18.1
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
 
   node-releases@2.0.27: {}
 
@@ -7865,11 +7092,6 @@ snapshots:
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
-
-  onetime@7.0.0:
-    dependencies:
-      mimic-function: 5.0.1
-    optional: true
 
   onnxruntime-common@1.24.3: {}
 
@@ -7897,18 +7119,6 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
-  ora@9.3.0:
-    dependencies:
-      chalk: 5.6.2
-      cli-cursor: 5.0.0
-      cli-spinners: 3.4.0
-      is-interactive: 2.0.0
-      is-unicode-supported: 2.1.0
-      log-symbols: 7.0.1
-      stdin-discarder: 0.3.1
-      string-width: 8.2.0
-    optional: true
-
   own-keys@1.0.1:
     dependencies:
       get-intrinsic: 1.3.0
@@ -7928,12 +7138,6 @@ snapshots:
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
-
-  parse-ms@3.0.0:
-    optional: true
-
-  parse-ms@4.0.0:
-    optional: true
 
   path-exists@4.0.0: {}
 
@@ -8062,28 +7266,11 @@ snapshots:
 
   pretty-bytes@6.1.1: {}
 
-  pretty-ms@8.0.0:
-    dependencies:
-      parse-ms: 3.0.0
-    optional: true
-
-  pretty-ms@9.3.0:
-    dependencies:
-      parse-ms: 4.0.0
-    optional: true
-
   process-warning@4.0.1: {}
 
   process-warning@5.0.0: {}
 
   promise-limit@2.7.0: {}
-
-  proper-lockfile@4.1.2:
-    dependencies:
-      graceful-fs: 4.2.11
-      retry: 0.12.0
-      signal-exit: 3.0.7
-    optional: true
 
   protobufjs@7.5.4:
     dependencies:
@@ -8179,9 +7366,6 @@ snapshots:
     dependencies:
       jsesc: 3.1.0
 
-  require-directory@2.1.1:
-    optional: true
-
   require-from-string@2.0.2: {}
 
   resolve-from@4.0.0: {}
@@ -8194,19 +7378,7 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
-  restore-cursor@5.1.0:
-    dependencies:
-      onetime: 7.0.0
-      signal-exit: 4.1.0
-    optional: true
-
   ret@0.5.0: {}
-
-  retry@0.12.0:
-    optional: true
-
-  retry@0.13.1:
-    optional: true
 
   reusify@1.1.0: {}
 
@@ -8398,9 +7570,6 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
-  signal-exit@3.0.7:
-    optional: true
-
   signal-exit@4.1.0: {}
 
   simple-concat@1.0.1:
@@ -8411,32 +7580,6 @@ snapshots:
       decompress-response: 6.0.0
       once: 1.4.0
       simple-concat: 1.0.1
-    optional: true
-
-  simple-git@3.35.2:
-    dependencies:
-      '@kwsites/file-exists': 1.1.1
-      '@kwsites/promise-deferred': 1.1.1
-      '@simple-git/args-pathspec': 1.0.2
-      '@simple-git/argv-parser': 1.0.3
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
-  sleep-promise@9.1.0:
-    optional: true
-
-  slice-ansi@7.1.2:
-    dependencies:
-      ansi-styles: 6.2.3
-      is-fullwidth-code-point: 5.1.0
-    optional: true
-
-  slice-ansi@8.0.0:
-    dependencies:
-      ansi-styles: 6.2.3
-      is-fullwidth-code-point: 5.1.0
     optional: true
 
   sliced@1.0.1: {}
@@ -8476,46 +7619,12 @@ snapshots:
 
   statuses@2.0.2: {}
 
-  stdin-discarder@0.3.1:
-    optional: true
-
-  stdout-update@4.0.1:
-    dependencies:
-      ansi-escapes: 6.2.1
-      ansi-styles: 6.2.3
-      string-width: 7.2.0
-      strip-ansi: 7.2.0
-    optional: true
-
-  steno@4.0.2:
-    optional: true
-
   stop-iteration-iterator@1.1.0:
     dependencies:
       es-errors: 1.3.0
       internal-slot: 1.1.0
 
   stream-shift@1.0.3: {}
-
-  string-width@4.2.3:
-    dependencies:
-      emoji-regex: 8.0.0
-      is-fullwidth-code-point: 3.0.0
-      strip-ansi: 6.0.1
-    optional: true
-
-  string-width@7.2.0:
-    dependencies:
-      emoji-regex: 10.6.0
-      get-east-asian-width: 1.5.0
-      strip-ansi: 7.2.0
-    optional: true
-
-  string-width@8.2.0:
-    dependencies:
-      get-east-asian-width: 1.5.0
-      strip-ansi: 7.2.0
-    optional: true
 
   string.prototype.matchall@4.0.12:
     dependencies:
@@ -8566,16 +7675,6 @@ snapshots:
       is-obj: 1.0.1
       is-regexp: 1.0.0
 
-  strip-ansi@6.0.1:
-    dependencies:
-      ansi-regex: 5.0.1
-    optional: true
-
-  strip-ansi@7.2.0:
-    dependencies:
-      ansi-regex: 6.2.2
-    optional: true
-
   strip-comments@2.0.1: {}
 
   strip-json-comments@2.0.1:
@@ -8612,15 +7711,6 @@ snapshots:
       fs-constants: 1.0.0
       inherits: 2.0.4
       readable-stream: 3.6.2
-    optional: true
-
-  tar@7.5.12:
-    dependencies:
-      '@isaacs/fs-minipass': 4.0.1
-      chownr: 3.0.0
-      minipass: 7.1.3
-      minizlib: 3.1.0
-      yallist: 5.0.0
     optional: true
 
   temp-dir@2.0.0: {}
@@ -8776,17 +7866,11 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  url-join@4.0.1:
-    optional: true
-
   use-sync-external-store@1.6.0(react@19.2.4):
     dependencies:
       react: 19.2.4
 
   util-deprecate@1.0.2: {}
-
-  validate-npm-package-name@7.0.2:
-    optional: true
 
   vite-plugin-pwa@1.2.0(vite@6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0))(workbox-build@7.4.0(@types/babel__core@7.20.5))(workbox-window@7.4.0):
     dependencies:
@@ -8869,11 +7953,6 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
-
-  which@6.0.1:
-    dependencies:
-      isexe: 4.0.0
-    optional: true
 
   word-wrap@1.2.5: {}
 
@@ -8990,43 +8069,13 @@ snapshots:
       '@types/trusted-types': 2.0.7
       workbox-core: 7.4.0
 
-  wrap-ansi@7.0.0:
-    dependencies:
-      ansi-styles: 4.3.0
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-    optional: true
-
   wrappy@1.0.2: {}
 
   ws@8.19.0: {}
 
-  y18n@5.0.8:
-    optional: true
-
   yallist@3.1.1: {}
 
-  yallist@5.0.0:
-    optional: true
-
-  yargs-parser@21.1.1:
-    optional: true
-
-  yargs@17.7.2:
-    dependencies:
-      cliui: 8.0.1
-      escalade: 3.2.0
-      get-caller-file: 2.0.5
-      require-directory: 2.1.1
-      string-width: 4.2.3
-      y18n: 5.0.8
-      yargs-parser: 21.1.1
-    optional: true
-
   yocto-queue@0.1.0: {}
-
-  yoctocolors@2.1.2:
-    optional: true
 
   zod-validation-error@4.0.2(zod@3.25.76):
     dependencies:

--- a/start-termux.sh
+++ b/start-termux.sh
@@ -232,45 +232,6 @@ else
     fi
 fi
 
-# ── Sidecar (local model) — rebuild native addon if missing or stale ──
-SIDECAR_CONFIG="packages/server/data/models/sidecar-config.json"
-SIDECAR_RUNTIME_STAMP="packages/server/data/models/sidecar-runtime-stamp.txt"
-SIDECAR_RUNTIME_FAILURE_STAMP="packages/server/data/models/sidecar-runtime-failed-stamp.txt"
-SIDECAR_RUNTIME_BUILD_ID="gemma4-runtime-v1"
-if [ -f "$SIDECAR_CONFIG" ]; then
-    SIDECAR_MODEL_FILE=$(find packages/server/data/models -maxdepth 1 -name '*.gguf' -type f 2>/dev/null | head -1)
-    if [ -n "$SIDECAR_MODEL_FILE" ]; then
-        NEED_SIDECAR_BUILD=0
-        SKIP_SIDECAR_RETRY=0
-        LLAMA_BUILD_DIR=$(find node_modules/.pnpm -maxdepth 5 -path '*/node-llama-cpp/llama/localBuilds' -type d 2>/dev/null | head -1)
-        CURRENT_SIDECAR_FAILURE_STAMP=$(cat "$SIDECAR_RUNTIME_FAILURE_STAMP" 2>/dev/null || true)
-        if [ -z "$LLAMA_BUILD_DIR" ] || [ -z "$(find "$LLAMA_BUILD_DIR" -name 'llama-addon.node' 2>/dev/null | head -1)" ]; then
-            if [ "$CURRENT_SIDECAR_FAILURE_STAMP" = "$SIDECAR_RUNTIME_BUILD_ID" ]; then
-                SKIP_SIDECAR_RETRY=1
-                echo "  [WARN] Sidecar addon rebuild already failed for this runtime version. Skipping automatic retry."
-                echo "  [WARN] Run pnpm sidecar:build after fixing your local toolchain to try again."
-            else
-                NEED_SIDECAR_BUILD=1
-            fi
-        elif [ ! -f "$SIDECAR_RUNTIME_STAMP" ] || [ "$(cat "$SIDECAR_RUNTIME_STAMP" 2>/dev/null)" != "$SIDECAR_RUNTIME_BUILD_ID" ]; then
-            NEED_SIDECAR_BUILD=1
-        fi
-
-        if [ "$SKIP_SIDECAR_RETRY" != "1" ] && [ "$NEED_SIDECAR_BUILD" = "1" ]; then
-            echo "  [..] Rebuilding sidecar runtime for Gemma 4 support (may take a few minutes)..."
-            if pnpm sidecar:build; then
-                printf '%s\n' "$SIDECAR_RUNTIME_BUILD_ID" > "$SIDECAR_RUNTIME_STAMP"
-                rm -f "$SIDECAR_RUNTIME_FAILURE_STAMP"
-                echo "  [OK] Sidecar addon ready"
-            else
-                printf '%s\n' "$SIDECAR_RUNTIME_BUILD_ID" > "$SIDECAR_RUNTIME_FAILURE_STAMP"
-                echo "  [WARN] Sidecar addon build failed. The local Gemma model may not load until this succeeds."
-                echo "  [WARN] Automatic retries are disabled until the runtime version changes or you rerun pnpm sidecar:build manually."
-            fi
-        fi
-    fi
-fi
-
 # ── Build if needed ──
 if [ ! -d "packages/shared/dist" ]; then
     echo "  [..] Building shared types..."

--- a/start.bat
+++ b/start.bat
@@ -155,50 +155,6 @@ if not exist "packages\client\dist" (
     call pnpm build:client
 )
 
-:: Sidecar (local model) - rebuild native addon if missing or stale
-set "SIDECAR_RUNTIME_STAMP=packages\server\data\models\sidecar-runtime-stamp.txt"
-set "SIDECAR_RUNTIME_FAILURE_STAMP=packages\server\data\models\sidecar-runtime-failed-stamp.txt"
-set "SIDECAR_RUNTIME_BUILD_ID=gemma4-runtime-v1"
-if exist "packages\server\data\models\sidecar-config.json" (
-    set "SIDECAR_MODEL_FOUND="
-    for /f "delims=" %%F in ('dir /b "packages\server\data\models\*.gguf" 2^>nul') do set "SIDECAR_MODEL_FOUND=1"
-    if defined SIDECAR_MODEL_FOUND (
-        set "NEED_SIDECAR_BUILD="
-        set "SKIP_SIDECAR_RETRY="
-        set "LLAMA_ADDON_FOUND="
-        set "CURRENT_SIDECAR_FAILURE_STAMP="
-        for /f "delims=" %%F in ('dir /s /b "node_modules\.pnpm\*llama-addon.node" 2^>nul') do set "LLAMA_ADDON_FOUND=1"
-        if exist "%SIDECAR_RUNTIME_FAILURE_STAMP%" set /p CURRENT_SIDECAR_FAILURE_STAMP=<"%SIDECAR_RUNTIME_FAILURE_STAMP%"
-        if not defined LLAMA_ADDON_FOUND (
-            if /I "!CURRENT_SIDECAR_FAILURE_STAMP!"=="%SIDECAR_RUNTIME_BUILD_ID%" (
-                set "SKIP_SIDECAR_RETRY=1"
-                echo  [WARN] Sidecar addon rebuild already failed for this runtime version. Skipping automatic retry.
-                echo  [WARN] Run pnpm sidecar:build after fixing your local toolchain to try again.
-            ) else (
-                set "NEED_SIDECAR_BUILD=1"
-            )
-        )
-        if not defined NEED_SIDECAR_BUILD if not defined SKIP_SIDECAR_RETRY (
-            set "CURRENT_SIDECAR_STAMP="
-            if exist "%SIDECAR_RUNTIME_STAMP%" set /p CURRENT_SIDECAR_STAMP=<"%SIDECAR_RUNTIME_STAMP%"
-            if /I not "!CURRENT_SIDECAR_STAMP!"=="%SIDECAR_RUNTIME_BUILD_ID%" set "NEED_SIDECAR_BUILD=1"
-        )
-        if defined NEED_SIDECAR_BUILD (
-            echo  [..] Rebuilding sidecar runtime for Gemma 4 support ^(may take a few minutes^)...
-            call pnpm sidecar:build
-            if errorlevel 1 (
-                >"%SIDECAR_RUNTIME_FAILURE_STAMP%" echo %SIDECAR_RUNTIME_BUILD_ID%
-                echo  [WARN] Sidecar addon build failed. The local Gemma model may not load until this succeeds.
-                echo  [WARN] Automatic retries are disabled until the runtime version changes or you rerun pnpm sidecar:build manually.
-            ) else (
-                >"%SIDECAR_RUNTIME_STAMP%" echo %SIDECAR_RUNTIME_BUILD_ID%
-                if exist "%SIDECAR_RUNTIME_FAILURE_STAMP%" del /q "%SIDECAR_RUNTIME_FAILURE_STAMP%" >nul 2>&1
-                echo  [OK] Sidecar addon ready
-            )
-        )
-    )
-)
-
 :: Database migrations are handled automatically at server startup by runMigrations()
 
 :: Load .env if present (respects user overrides)

--- a/start.sh
+++ b/start.sh
@@ -130,45 +130,6 @@ if [ ! -d "packages/client/dist" ]; then
     pnpm build:client
 fi
 
-# ── Sidecar (local model) — rebuild native addon if missing or stale ──
-SIDECAR_CONFIG="packages/server/data/models/sidecar-config.json"
-SIDECAR_RUNTIME_STAMP="packages/server/data/models/sidecar-runtime-stamp.txt"
-SIDECAR_RUNTIME_FAILURE_STAMP="packages/server/data/models/sidecar-runtime-failed-stamp.txt"
-SIDECAR_RUNTIME_BUILD_ID="gemma4-runtime-v1"
-if [ -f "$SIDECAR_CONFIG" ]; then
-    SIDECAR_MODEL_FILE=$(find packages/server/data/models -maxdepth 1 -name '*.gguf' -type f 2>/dev/null | head -1)
-    if [ -n "$SIDECAR_MODEL_FILE" ]; then
-        NEED_SIDECAR_BUILD=0
-        SKIP_SIDECAR_RETRY=0
-        LLAMA_BUILD_DIR=$(find node_modules/.pnpm -maxdepth 5 -path '*/node-llama-cpp/llama/localBuilds' -type d 2>/dev/null | head -1)
-        CURRENT_SIDECAR_FAILURE_STAMP=$(cat "$SIDECAR_RUNTIME_FAILURE_STAMP" 2>/dev/null || true)
-        if [ -z "$LLAMA_BUILD_DIR" ] || [ -z "$(find "$LLAMA_BUILD_DIR" -name 'llama-addon.node' 2>/dev/null | head -1)" ]; then
-            if [ "$CURRENT_SIDECAR_FAILURE_STAMP" = "$SIDECAR_RUNTIME_BUILD_ID" ]; then
-                SKIP_SIDECAR_RETRY=1
-                echo "  [WARN] Sidecar addon rebuild already failed for this runtime version. Skipping automatic retry."
-                echo "  [WARN] Run pnpm sidecar:build after fixing your local toolchain to try again."
-            else
-                NEED_SIDECAR_BUILD=1
-            fi
-        elif [ ! -f "$SIDECAR_RUNTIME_STAMP" ] || [ "$(cat "$SIDECAR_RUNTIME_STAMP" 2>/dev/null)" != "$SIDECAR_RUNTIME_BUILD_ID" ]; then
-            NEED_SIDECAR_BUILD=1
-        fi
-
-        if [ "$SKIP_SIDECAR_RETRY" != "1" ] && [ "$NEED_SIDECAR_BUILD" = "1" ]; then
-            echo "  [..] Rebuilding sidecar runtime for Gemma 4 support (may take a few minutes)..."
-            if pnpm sidecar:build; then
-                printf '%s\n' "$SIDECAR_RUNTIME_BUILD_ID" > "$SIDECAR_RUNTIME_STAMP"
-                rm -f "$SIDECAR_RUNTIME_FAILURE_STAMP"
-                echo "  [OK] Sidecar addon ready"
-            else
-                printf '%s\n' "$SIDECAR_RUNTIME_BUILD_ID" > "$SIDECAR_RUNTIME_FAILURE_STAMP"
-                echo "  [WARN] Sidecar addon build failed. The local Gemma model may not load until this succeeds."
-                echo "  [WARN] Automatic retries are disabled until the runtime version changes or you rerun pnpm sidecar:build manually."
-            fi
-        fi
-    fi
-fi
-
 # Database migrations are handled automatically at server startup by runMigrations()
 
 # ── Start ──


### PR DESCRIPTION
## Summary

This replaces the old `node-llama-cpp` sidecar path with a downloaded `llama-server` runtime and keeps the local-model flow working without native compilation on end-user machines.

It also adds support for using curated Gemma presets or custom GGUFs from HuggingFace, plus a clearer setup flow in the download modal.

## Why

The previous sidecar flow depended on rebuilding native llama bindings locally, which was fragile across user machines and especially painful on Windows and other environments without the right toolchain.

This change moves Marinara to the official upstream `llama.cpp` server binaries instead:
- no local C++ build step
- no `node-llama-cpp` dependency
- cleaner crash isolation via subprocess
- easier support for newer llama.cpp model/runtime updates
- better platform coverage

## What changed

### Server
- Replaced in-process sidecar inference with a spawned `llama-server` subprocess
- Added runtime install management for official `llama.cpp` release assets
- Added runtime detection/status reporting
- Added BYO GGUF listing + download flow from HuggingFace repos
- Migrated sidecar config to explicit `modelPath`
- Preserved sidecar inference API shape for existing callers where possible
- Added restart/unload/health handling for the sidecar process
- Added cleanup for legacy sidecar runtime stamp behavior

### Client
- Updated sidecar store for new runtime/model lifecycle states
- Added runtime-aware modal UI for:
  - curated model downloads
  - custom HuggingFace GGUF selection
  - active setup progress
  - runtime/server error visibility
- Disabled finishing setup until the sidecar is actually ready
- Added a clearer “setup in progress” flow with cancel behavior while runtime/model startup is happening

### Launcher / packaging
- Removed sidecar native rebuild steps from:
  - `start.bat`
  - `start.sh`
  - `start-termux.sh`
- Removed `node-llama-cpp` from package manifests and lockfile
- Kept app versioning unchanged

## Platform/runtime support

This runtime-selection flow now supports official download/install paths for:
- Windows
- macOS
- Linux
- Android/Termux

With runtime matching/fallback for available upstream variants such as:
- CPU
- CUDA
- Vulkan
- ROCm
- ARM64 where upstream assets exist

## User impact

Users should now be able to enable the local sidecar without needing to compile llama.cpp locally.

They can also:
- keep using curated Gemma sidecar presets
- use their own GGUF from a HuggingFace repo
- see clearer setup progress while the runtime is downloading/starting

## Validation

Ran:
- `pnpm --filter @marinara-engine/shared build`
- `pnpm --filter @marinara-engine/server build`
- `pnpm --filter @marinara-engine/client build`

Manual:
- verified the updated sidecar setup modal flow on the cleaned branch
