### PR TITLE
Allow setting a custom base url for image service connectors by storing the type explicitly

### DIFF
--- a/packages/client/src/components/connections/ConnectionEditor.tsx
+++ b/packages/client/src/components/connections/ConnectionEditor.tsx
@@ -89,6 +89,7 @@ export function ConnectionEditor() {
   const [localEmbeddingConnectionId, setLocalEmbeddingConnectionId] = useState("");
   const [localOpenrouterProvider, setLocalOpenrouterProvider] = useState("");
   const [localComfyuiWorkflow, setLocalComfyuiWorkflow] = useState("");
+  const [localImageService, setLocalImageService] = useState<string | null>(null);
 
   // Test results
   const [testResult, setTestResult] = useState<{ success: boolean; message: string; latencyMs: number } | null>(null);
@@ -165,6 +166,7 @@ export function ConnectionEditor() {
     setLocalEmbeddingConnectionId((c.embeddingConnectionId as string) ?? "");
     setLocalOpenrouterProvider((c.openrouterProvider as string) ?? "");
     setLocalComfyuiWorkflow((c.comfyuiWorkflow as string) ?? "");
+    setLocalImageService((c.imageService as string | null) ?? null);
     setDirty(false);
     setSaveError(null);
     setTestResult(null);
@@ -227,6 +229,7 @@ export function ConnectionEditor() {
       embeddingConnectionId: localEmbeddingConnectionId || null,
       openrouterProvider: localOpenrouterProvider || null,
       comfyuiWorkflow: localComfyuiWorkflow || null,
+      imageService: localImageService || null,
     };
     // Only send API key if user typed a new one
     if (localApiKey.trim()) {
@@ -255,6 +258,7 @@ export function ConnectionEditor() {
     localEmbeddingConnectionId,
     localOpenrouterProvider,
     localComfyuiWorkflow,
+    localImageService,
     updateConnection,
   ]);
 
@@ -635,11 +639,12 @@ export function ConnectionEditor() {
             >
               <div className="grid grid-cols-2 gap-1.5">
                 {IMAGE_GENERATION_SOURCES.map((src) => {
-                  const isActive = localBaseUrl === src.defaultBaseUrl;
+                  const isActive = localImageService ? localImageService === src.id : localBaseUrl === src.defaultBaseUrl;
                   return (
                     <button
                       key={src.id}
                       onClick={() => {
+                        setLocalImageService(src.id);
                         setLocalBaseUrl(src.defaultBaseUrl);
                         markDirty();
                       }}
@@ -906,7 +911,9 @@ export function ConnectionEditor() {
 
           {/* ── ComfyUI Workflow ── */}
           {localProvider === "image_generation" &&
-            (localBaseUrl.includes(":8188") || localBaseUrl.toLowerCase().includes("comfyui")) && (
+            (localImageService === "comfyui" ||
+              (!localImageService &&
+                (localBaseUrl.includes(":8188") || localBaseUrl.toLowerCase().includes("comfyui")))) && (
               <FieldGroup
                 label="ComfyUI Workflow (Optional)"
                 icon={<Zap size="0.875rem" className="text-sky-400" />}

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -483,6 +483,11 @@ const COLUMN_MIGRATIONS: ColumnMigration[] = [
   },
   {
     table: "api_connections",
+    column: "image_service",
+    definition: "TEXT",
+  },
+  {
+    table: "api_connections",
     column: "embedding_base_url",
     definition: "TEXT",
   },

--- a/packages/server/src/db/schema/connections.ts
+++ b/packages/server/src/db/schema/connections.ts
@@ -31,6 +31,8 @@ export const apiConnections = sqliteTable("api_connections", {
   openrouterProvider: text("openrouter_provider"),
   /** ComfyUI: custom workflow JSON with placeholders (%prompt%, %width%, etc.) */
   comfyuiWorkflow: text("comfyui_workflow"),
+  /** Image generation: explicitly selected service ID (e.g. "comfyui", "automatic1111"). Overrides URL inference. */
+  imageService: text("image_service"),
   /** Default generation parameters (stored as JSON) for new chats using this connection */
   defaultParameters: text("default_parameters"),
   createdAt: text("created_at").notNull(),

--- a/packages/server/src/routes/connections.routes.ts
+++ b/packages/server/src/routes/connections.routes.ts
@@ -83,6 +83,7 @@ export async function connectionsRoutes(app: FastifyInstance) {
         headers[provider.apiKeyHeader] = conn.apiKey;
       }
 
+      const imageService  = conn.imageService;
       // image_generation has no standard modelsEndpoint — use provider-specific checks
       let testUrl: string;
       if (conn.provider === "image_generation" && baseUrl.toLowerCase().includes("novelai.net")) {
@@ -90,11 +91,11 @@ export async function connectionsRoutes(app: FastifyInstance) {
         testUrl = "https://api.novelai.net/user/subscription";
       } else if (
         conn.provider === "image_generation" &&
-        (baseUrl.includes(":8188") || baseUrl.toLowerCase().includes("comfyui"))
+        (imageService === "comfyui" || (!imageService && (baseUrl.includes(":8188") || (baseUrl.toLowerCase().includes("comfyui")))))
       ) {
         // ComfyUI: ping the system stats endpoint
         testUrl = `${baseUrl}/system_stats`;
-      } else if (conn.provider === "image_generation" && baseUrl.includes(":7860")) {
+      } else if (conn.provider === "image_generation" && (imageService === "automatic1111" || (!imageService && baseUrl.includes(":7860")))) {
         // AUTOMATIC1111 / SD Web UI: ping the internal ping endpoint
         testUrl = `${baseUrl}/sdapi/v1/options`;
       } else {
@@ -160,9 +161,10 @@ export async function connectionsRoutes(app: FastifyInstance) {
         }
         return body.slice(0, 300);
       };
+      const imageService = conn.imageService;
 
       // ComfyUI: fetch checkpoints from object_info
-      if (conn.provider === "image_generation" && (lowerBase.includes(":8188") || lowerBase.includes("comfyui"))) {
+      if (conn.provider === "image_generation" && (imageService === "comfyui" || lowerBase.includes(":8188") || lowerBase.includes("comfyui"))) {
         const res = await fetch(`${baseUrl}/object_info/CheckpointLoaderSimple`);
         if (!res.ok) {
           return reply.status(502).send({ error: `ComfyUI returned ${res.status}` });
@@ -175,7 +177,7 @@ export async function connectionsRoutes(app: FastifyInstance) {
       }
 
       // AUTOMATIC1111 / SD Web UI: fetch models from /sdapi/v1/sd-models
-      if (conn.provider === "image_generation" && lowerBase.includes(":7860")) {
+      if (conn.provider === "image_generation" && (imageService === "automatic1111" || (!imageService && lowerBase.includes(":7860")))) {
         const res = await fetch(`${baseUrl}/sdapi/v1/sd-models`);
         if (!res.ok) {
           return reply.status(502).send({ error: `SD Web UI returned ${res.status}` });

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -2231,6 +2231,7 @@ export async function gameRoutes(app: FastifyInstance) {
             const imgModel = imgConn.model || "";
             const imgBaseUrl = imgConn.baseUrl || "https://image.pollinations.ai";
             const imgApiKey = imgConn.apiKey || "";
+            const imgServiceHint = imgConn.imageService || "";
 
             const setupCfg = meta.gameSetupConfig as Record<string, unknown> | null;
             const genre = (setupCfg?.genre as string) || "";
@@ -2274,6 +2275,7 @@ export async function gameRoutes(app: FastifyInstance) {
                   imgModel,
                   imgBaseUrl,
                   imgApiKey,
+                  imgService: imgServiceHint,
                 });
 
                 if (generatedTag) {
@@ -2321,6 +2323,7 @@ export async function gameRoutes(app: FastifyInstance) {
                   imgModel,
                   imgBaseUrl,
                   imgApiKey,
+                  imgService: imgServiceHint,
                 });
 
                 if (generatedTag) {
@@ -2457,6 +2460,7 @@ export async function gameRoutes(app: FastifyInstance) {
     const imgModel = imgConn.model || "";
     const imgBaseUrl = imgConn.baseUrl || "https://image.pollinations.ai";
     const imgApiKey = imgConn.apiKey || "";
+    const imgServiceHint = imgConn.imageService || "";
 
     const setupCfg = meta.gameSetupConfig as Record<string, unknown> | null;
     const genre = (setupCfg?.genre as string) || "";
@@ -2486,6 +2490,7 @@ export async function gameRoutes(app: FastifyInstance) {
         imgModel,
         imgBaseUrl,
         imgApiKey,
+        imgService: imgServiceHint,
       });
       generatedBackground = tag;
     }
@@ -2521,6 +2526,7 @@ export async function gameRoutes(app: FastifyInstance) {
           imgModel,
           imgBaseUrl,
           imgApiKey,
+          imgService: imgServiceHint,
         });
         if (avatarUrl) {
           generatedNpcAvatars.push({ name: npc.name, avatarUrl });

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -4866,6 +4866,7 @@ export async function generateRoutes(app: FastifyInstance) {
                       const imgModel = imgConnFull.model || "";
                       const imgBaseUrl = imgConnFull.baseUrl || "https://image.pollinations.ai";
                       const imgApiKey = imgConnFull.apiKey || "";
+                      const imgServiceHint = imgConnFull.imageService || "";
 
                       for (const npc of charsNeedingAvatars) {
                         try {
@@ -4878,7 +4879,7 @@ export async function generateRoutes(app: FastifyInstance) {
                               1000,
                             );
 
-                          const imageResult = await generateImage(imgModel, imgBaseUrl, imgApiKey, {
+                          const imageResult = await generateImage(imgModel, imgBaseUrl, imgApiKey, imgServiceHint, {
                             prompt,
                             model: imgModel,
                             width: 512,
@@ -5363,6 +5364,7 @@ export async function generateRoutes(app: FastifyInstance) {
                     const imgModel = imgConnFull.model || "";
                     const imgBaseUrl = imgConnFull.baseUrl || "https://image.pollinations.ai";
                     const imgApiKey = imgConnFull.apiKey || "";
+                    const imgServiceHint = imgConnFull.imageService || "";
 
                     // Use selfie resolution from chat metadata if set, otherwise fall back to aspect ratio defaults
                     const selfieRes = (chatMeta.selfieResolution as string) ?? "";
@@ -5461,13 +5463,13 @@ export async function generateRoutes(app: FastifyInstance) {
                       }
                     }
 
-                    const imageResult = await generateImage(imgModel, imgBaseUrl, imgApiKey, {
+                    const imageResult = await generateImage(imgModel, imgBaseUrl, imgApiKey, imgServiceHint, {
                       prompt: fullPrompt,
                       negativePrompt: negativePrompt || undefined,
                       model: imgModel,
                       width: imgWidth,
                       height: imgHeight,
-                      comfyWorkflow: (imgConnFull as any).comfyuiWorkflow || undefined,
+                      comfyWorkflow: imgConnFull.comfyuiWorkflow || undefined,
                       referenceImage: illustratorRefImage,
                       referenceImages: illustratorRefImages,
                     });
@@ -5848,12 +5850,13 @@ export async function generateRoutes(app: FastifyInstance) {
                     const selfieRes = (chatMeta.selfieResolution as string) ?? "512x768";
                     const [selfieW, selfieH] = selfieRes.split("x").map(Number) as [number, number];
 
-                    const imageResult = await generateImage(imgModel, imgBaseUrl, imgApiKey, {
+                    const serviceHint = imgConnFull.imageService || "";
+                    const imageResult = await generateImage(imgModel, imgBaseUrl, imgApiKey, serviceHint, {
                       prompt: imagePrompt,
                       model: imgModel,
                       width: selfieW || 512,
                       height: selfieH || 768,
-                      comfyWorkflow: (imgConnFull as any).comfyuiWorkflow || undefined,
+                      comfyWorkflow: imgConnFull.comfyuiWorkflow || undefined,
                       referenceImage: readAvatarBase64(charRow?.avatarPath as string | null),
                     });
 

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -618,6 +618,7 @@ async function applyRetryResultEffects(args: {
               const imgModel = imgConnFull.model || "";
               const imgBaseUrl = imgConnFull.baseUrl || "https://image.pollinations.ai";
               const imgApiKey = imgConnFull.apiKey || "";
+              const imgServiceHint = imgConnFull.imageService || "";
 
               const chatMeta = typeof chat.metadata === "string" ? JSON.parse(chat.metadata) : (chat.metadata ?? {});
               const selfieRes = (chatMeta.selfieResolution as string) ?? "";
@@ -694,7 +695,7 @@ async function applyRetryResultEffects(args: {
                 }
               }
 
-              const imageResult = await generateImage(imgModel, imgBaseUrl, imgApiKey, {
+              const imageResult = await generateImage(imgModel, imgBaseUrl, imgApiKey, imgServiceHint, {
                 prompt: fullPrompt,
                 negativePrompt: negativePrompt || undefined,
                 model: imgModel,

--- a/packages/server/src/routes/sprites.routes.ts
+++ b/packages/server/src/routes/sprites.routes.ts
@@ -369,6 +369,7 @@ export async function spritesRoutes(app: FastifyInstance) {
     const imgModel = conn.model || "";
     const imgBaseUrl = conn.baseUrl || "https://image.pollinations.ai";
     const imgApiKey = conn.apiKey || "";
+    const imgServiceHint = conn.imageService || "";
 
     // Build the prompt for an expression sheet or full-body
     const expressionList = expressions.join(", ");
@@ -419,7 +420,7 @@ export async function spritesRoutes(app: FastifyInstance) {
             const targetWidth = 832;
             const targetHeight = 1216;
 
-            const imageResult = await generateImage(imgModel, imgBaseUrl, imgApiKey, {
+            const imageResult = await generateImage(imgModel, imgBaseUrl, imgApiKey, imgServiceHint, {
               prompt: posePrompt,
               model: imgModel,
               width: targetWidth,
@@ -483,7 +484,7 @@ export async function spritesRoutes(app: FastifyInstance) {
       const sheetWidth = cols * cellSize;
       const sheetHeight = rows * cellSize;
 
-      const imageResult = await generateImage(imgModel, imgBaseUrl, imgApiKey, {
+      const imageResult = await generateImage(imgModel, imgBaseUrl, imgApiKey, imgServiceHint, {
         prompt,
         model: imgModel,
         width: sheetWidth,

--- a/packages/server/src/services/game/game-asset-generation.ts
+++ b/packages/server/src/services/game/game-asset-generation.ts
@@ -35,6 +35,7 @@ export interface NpcPortraitRequest {
   imgModel: string;
   imgBaseUrl: string;
   imgApiKey: string;
+  imgService: string;
 }
 
 /**
@@ -60,7 +61,7 @@ export async function generateNpcPortrait(req: NpcPortraitRequest): Promise<stri
     );
 
   try {
-    const result = await generateImage(req.imgModel, req.imgBaseUrl, req.imgApiKey, {
+    const result = await generateImage(req.imgModel, req.imgBaseUrl, req.imgApiKey, req.imgService, {
       prompt,
       model: req.imgModel,
       width: 512,
@@ -105,6 +106,7 @@ export interface BackgroundGenRequest {
   imgModel: string;
   imgBaseUrl: string;
   imgApiKey: string;
+  imgService: string;
 }
 
 /**
@@ -136,7 +138,7 @@ export async function generateBackground(req: BackgroundGenRequest): Promise<str
     );
 
   try {
-    const result = await generateImage(req.imgModel, req.imgBaseUrl, req.imgApiKey, {
+    const result = await generateImage(req.imgModel, req.imgBaseUrl, req.imgApiKey, req.imgService, {
       prompt,
       model: req.imgModel,
       width: 1024,

--- a/packages/server/src/services/image/image-generation.ts
+++ b/packages/server/src/services/image/image-generation.ts
@@ -54,11 +54,12 @@ export async function generateImage(
   source: string,
   baseUrl: string,
   apiKey: string,
+  serviceHint: string,
   request: ImageGenRequest,
 ): Promise<ImageGenResult> {
   // Infer the source from model name / base URL if the source looks like a legacy service ID
-  // or if the caller passes a model name as source
-  const resolvedSource = inferImageSource(source, baseUrl);
+  // or if the caller passes a model name as source. An explicit serviceHint overrides inference.
+  const resolvedSource = serviceHint || inferImageSource(source, baseUrl);
   switch (resolvedSource) {
     case "openai":
     case "nanogpt":

--- a/packages/server/src/services/storage/connections.storage.ts
+++ b/packages/server/src/services/storage/connections.storage.ts
@@ -84,6 +84,7 @@ export function createConnectionsStorage(db: DB) {
         embeddingConnectionId: input.embeddingConnectionId ?? null,
         openrouterProvider: input.openrouterProvider ?? null,
         comfyuiWorkflow: input.comfyuiWorkflow ?? null,
+        imageService: input.imageService ?? null,
         createdAt: timestamp,
         updatedAt: timestamp,
       });
@@ -150,6 +151,9 @@ export function createConnectionsStorage(db: DB) {
       if (data.comfyuiWorkflow !== undefined) {
         updateFields.comfyuiWorkflow = data.comfyuiWorkflow;
       }
+      if (data.imageService !== undefined) {
+        updateFields.imageService = data.imageService;
+      }
       await db.update(apiConnections).set(updateFields).where(eq(apiConnections.id, id));
       return this.getById(id);
     },
@@ -178,6 +182,7 @@ export function createConnectionsStorage(db: DB) {
         openrouterProvider: source.openrouterProvider,
         embeddingBaseUrl: source.embeddingBaseUrl,
         comfyuiWorkflow: source.comfyuiWorkflow,
+        imageService: source.imageService,
         createdAt: timestamp,
         updatedAt: timestamp,
       });

--- a/packages/shared/src/schemas/connection.schema.ts
+++ b/packages/shared/src/schemas/connection.schema.ts
@@ -31,6 +31,7 @@ export const createConnectionSchema = z.object({
   embeddingConnectionId: z.string().nullable().default(null),
   openrouterProvider: z.string().nullable().default(null),
   comfyuiWorkflow: z.string().nullable().default(null),
+  imageService: z.string().nullable().default(null),
 });
 
 export type CreateConnectionInput = z.infer<typeof createConnectionSchema>;

--- a/packages/shared/src/types/connection.ts
+++ b/packages/shared/src/types/connection.ts
@@ -39,6 +39,8 @@ export interface APIConnection {
   openrouterProvider: string | null;
   /** ComfyUI workflow JSON for image generation */
   comfyuiWorkflow: string | null;
+  /** Explicitly selected image generation service ID (e.g. "comfyui", "automatic1111"). Overrides URL inference when set. */
+  imageService: string | null;
   /** Default generation parameters for new chats using this connection (JSON) */
   defaultParameters: string | null;
   createdAt: string;


### PR DESCRIPTION
This allows working with oddball user setups.

Selecting ComfyUI allows different base urls. Changing service types clears the base URL
<img width="732" height="843" alt="image" src="https://github.com/user-attachments/assets/e1772ed8-c09e-418a-a221-4d3f7ca5a310" />


AI Disclosure: claude to describe and navigate the codebase, some local model for fancy autocomplete to understand react-isms.