### PR TITLE
Add -sm none to llama-server args

### DIFF
--- a/packages/server/src/services/sidecar/sidecar-process.service.ts
+++ b/packages/server/src/services/sidecar/sidecar-process.service.ts
@@ -158,6 +158,8 @@ class SidecarProcessService {
       "--log-disable",
       "--ctx-size",
       String(config.contextSize),
+      "-sm",
+      "none",
     ];
 
     const gpuLayers = config.gpuLayers === -1 ? 999 : config.gpuLayers;


### PR DESCRIPTION
There is a [known issue with multiple GPUs and Gemma 4 regarding split mode](https://github.com/ggml-org/llama.cpp/issues/21730).  This pull request adds the no split mode flag to prevent the looping crash.