### PR TITLE
Fix Vulkan and CPU support for local llama.cpp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,13 @@ FROM node:22-slim AS production
 ARG PNPM_VERSION=10.30.3
 WORKDIR /app
 
+# llama-server dynamically links these at runtime
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      libssl3 \
+      libgomp1 \
+      libvulkan1 \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
 
 # Copy workspace config

--- a/packages/server/src/services/sidecar/sidecar-process.service.ts
+++ b/packages/server/src/services/sidecar/sidecar-process.service.ts
@@ -160,7 +160,7 @@ class SidecarProcessService {
     }
   }
 
-  private buildArgs(modelPath: string, gpuLayers: number): string[] {
+  private buildArgs(modelPath: string, gpuLayers: number, runtime: SidecarRuntimeInstall): string[] {
     const config = sidecarModelService.getConfig();
     const args = [
       "-m",
@@ -172,10 +172,13 @@ class SidecarProcessService {
       "--log-disable",
       "--ctx-size",
       String(config.contextSize),
-      "-sm",
-      "none",
     ];
 
+    // Workaround for https://github.com/ggml-org/llama.cpp/issues/21730:
+    // Gemma 4 crashes with split mode on multi-GPU CUDA setups.
+    if (/cuda/i.test(runtime.variant) && gpuLayers > 0) {
+      args.push("-sm", "none");
+    }
     args.push("-ngl", String(gpuLayers));
     return args;
   }
@@ -190,11 +193,13 @@ class SidecarProcessService {
       return [{ gpuLayers: config.gpuLayers, label: `gpuLayers=${config.gpuLayers}` }];
     }
 
-    const plans = [{ gpuLayers: 999, label: "max GPU offload" }];
     if (this.usesGpuRuntime(runtime)) {
-      plans.push({ gpuLayers: 0, label: "CPU fallback" });
+      return [
+        { gpuLayers: 999, label: "max GPU offload" },
+        { gpuLayers: 0, label: "CPU fallback" },
+      ];
     }
-    return plans;
+    return [{ gpuLayers: 0, label: "CPU only" }];
   }
 
   private shouldRetryStartup(error: unknown): error is LlamaServerExitError {
@@ -248,7 +253,7 @@ class SidecarProcessService {
       for (let attempt = 0; attempt < startupPlans.length; attempt += 1) {
         const plan = startupPlans[attempt]!;
         const port = await getFreePort();
-        const args = this.buildArgs(modelPath, plan.gpuLayers);
+        const args = this.buildArgs(modelPath, plan.gpuLayers, runtime);
         args.push("--port", String(port));
 
         const logStream = createWriteStream(sidecarRuntimeService.getLogPath(), { flags: "a" });


### PR DESCRIPTION
This pull request resolves issues in which the sidecar would not come up in the Docker container. Fixes #129 

⚠️ First contribution ⚠️ 
- Tried to make sure I didn't cause any issues or fires. 
- Followed the contributor guidelines. 
- Tried to avoid regressions, even in fixing regressions. 

## Tests Performed

- Ran locally in Vulkan mode.
- Ran containerized in CPU mode.
- Ran containerized in Vulkan mode.

## Tests Not Performed, and Mitigations

- Didn't test CUDA. The SidecarRuntimeService can't get a Linux CUDA build, because there isn't one.
    - The CUDA builds are Windows only.
    - For Linux, you're supposed to build your own. I didn't want to burden this project with that. For Nvidia/Linux users, Vulkan works well enough.
    - I don't have a Windows PC with a CUDA GPU.
    - Tried to ensure that the Gemma fix was scoped to CUDA where it was intended.
    - Left in the code that adds a Linux CUDA build to the list of builds to try, in case it ever comes back.

## Add required dependencies for sidecar to Dockerfile 

I hesitated to add dependencies to your remarkably clean Dockerfile, but CPU and Vulkan support cover a lot of ground. Hopefully you feel it's worthwhile.

1. Missing `libssl3` prevented `llama-server` from launching.
2. `libgomp1` is required to run `llama-server` in CPU mode.
3. `libvulkan1` is the minimum needed to get Vulkan support working in the container.

## Fix crashes in CPU mode

1. In CPU mode, previously only the 999 GPU layers mode was added. Separated the GPU/CPU cases and clarified the labels.
2. The new `-sm none` fix for Gemma 4 on multi-GPUs was forcing GPU detection even in llama.cpp builds that didn't support it, causing the server to exit immediately. Limited to CUDA runtimes.

## Interactions with other PRs

https://github.com/Pasta-Devs/Marinara-Engine/pull/122 is a more comprehensive rework of this area. However, I think the "Windows Gemma fix" it preserves is a CUDA fix (since the llama.cpp CUDA binary is only available for Windows). Therefore I think the `-sm none` fix here needs to be applied there if this request is not merged.

The container dependency fixes would still apply.

If you want to apply both 122 and this, I'd suggest applying this either to `main` first, or rebasing MuniMuni's change on top of this and preserving the `-sm none` change in the result.