### PR TITLE
feat(chat): Allow edition of the automatic summaries in conversation mode

### DIFF
--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -48,6 +48,7 @@ import { cn } from "../../lib/utils";
 import { HelpTooltip } from "../ui/HelpTooltip";
 import { ExpandedTextarea } from "../ui/ExpandedTextarea";
 import { ChoiceSelectionModal } from "../presets/ChoiceSelectionModal";
+import { SummariesEditorModal } from "./SummariesEditorModal";
 import { useCharacters, useCharacterSprites, usePersonas, useCharacterGroups } from "../../hooks/use-characters";
 import { useLorebooks } from "../../hooks/use-lorebooks";
 import { usePresets } from "../../hooks/use-presets";
@@ -419,6 +420,7 @@ export function ChatSettingsDrawer({
   const [showToolPicker, setShowToolPicker] = useState(false);
   const [showPersonaPicker, setShowPersonaPicker] = useState(false);
   const [showConnectionPicker, setShowConnectionPicker] = useState(false);
+  const [showSummariesModal, setShowSummariesModal] = useState(false);
   const [connectionSearch, setConnectionSearch] = useState("");
   const [personaSearch, setPersonaSearch] = useState("");
   const [pendingToolIds, setPendingToolIds] = useState<string[]>([]);
@@ -2582,6 +2584,37 @@ export function ChatSettingsDrawer({
             </Section>
           )}
 
+          {/* Automatic Summarization — conversation mode only. Opens a modal to edit per-day and per-week summaries. */}
+          {isConversation && (
+            <Section
+              label="Automatic Summarization"
+              icon={<CalendarClock size="0.875rem" />}
+              help="Past-day conversations are auto-summarized and rolled up into weekly summaries. These summaries are injected into future prompts so characters remember what happened. Use this editor to review and correct what gets remembered."
+            >
+              {(() => {
+                const dayCount = Object.keys(metadata.daySummaries ?? {}).length;
+                const weekCount = Object.keys(metadata.weekSummaries ?? {}).length;
+                const totalCount = dayCount + weekCount;
+                return (
+                  <button
+                    onClick={() => setShowSummariesModal(true)}
+                    className="flex w-full items-center justify-between rounded-lg bg-[var(--secondary)] px-3 py-2.5 text-left transition-all hover:bg-[var(--accent)]"
+                  >
+                    <div className="flex-1 min-w-0">
+                      <span className="text-[0.6875rem] font-medium">Edit Summaries</span>
+                      <p className="text-[0.625rem] text-[var(--muted-foreground)]">
+                        {totalCount === 0
+                          ? "No summaries yet — they appear as the conversation spans multiple days."
+                          : `${totalCount} active ${totalCount === 1 ? "entry" : "entries"}. Review and edit what characters remember.`}
+                      </p>
+                    </div>
+                    <Pencil size="0.875rem" className="shrink-0 text-[var(--muted-foreground)]" />
+                  </button>
+                );
+              })()}
+            </Section>
+          )}
+
           {/* Discord Webhook — conversation mode only */}
           {isConversation && (
             <Section
@@ -3085,6 +3118,9 @@ export function ChatSettingsDrawer({
         chatId={chat.id}
         existingChoices={metadata.presetChoices ?? {}}
       />
+
+      {/* Automatic summarization editor */}
+      <SummariesEditorModal chat={chat} open={showSummariesModal} onClose={() => setShowSummariesModal(false)} />
 
       {/* First message confirmation dialog */}
       {firstMesConfirm && (

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -2589,7 +2589,7 @@ export function ChatSettingsDrawer({
             <Section
               label="Automatic Summarization"
               icon={<CalendarClock size="0.875rem" />}
-              help="Past-day conversations are auto-summarized and rolled up into weekly summaries. These summaries are injected into future prompts so characters remember what happened. Use this editor to review and correct what gets remembered."
+              help="To help keep the request context low, the conversation is automatically summarized. Each day is wrapped up into a day summary. Likewise, day summaries are combined into week summaries. Chat messages that have been summarized are not added to context. Only the week summaries, the day summaries of the current week and today's messages are added to the context. This feature currently can't be disabled."
             >
               <button
                 onClick={() => setShowSummariesModal(true)}
@@ -2598,7 +2598,7 @@ export function ChatSettingsDrawer({
                 <div className="flex-1 min-w-0">
                   <span className="text-[0.6875rem] font-medium">Edit Summaries</span>
                   <p className="text-[0.625rem] text-[var(--muted-foreground)]">
-                    Review and edit what characters remember.
+                    Review and edit what characters remember from this chat.
                   </p>
                 </div>
                 <Pencil size="0.875rem" className="shrink-0 text-[var(--muted-foreground)]" />

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -2591,27 +2591,18 @@ export function ChatSettingsDrawer({
               icon={<CalendarClock size="0.875rem" />}
               help="Past-day conversations are auto-summarized and rolled up into weekly summaries. These summaries are injected into future prompts so characters remember what happened. Use this editor to review and correct what gets remembered."
             >
-              {(() => {
-                const dayCount = Object.keys(metadata.daySummaries ?? {}).length;
-                const weekCount = Object.keys(metadata.weekSummaries ?? {}).length;
-                const totalCount = dayCount + weekCount;
-                return (
-                  <button
-                    onClick={() => setShowSummariesModal(true)}
-                    className="flex w-full items-center justify-between rounded-lg bg-[var(--secondary)] px-3 py-2.5 text-left transition-all hover:bg-[var(--accent)]"
-                  >
-                    <div className="flex-1 min-w-0">
-                      <span className="text-[0.6875rem] font-medium">Edit Summaries</span>
-                      <p className="text-[0.625rem] text-[var(--muted-foreground)]">
-                        {totalCount === 0
-                          ? "No summaries yet — they appear as the conversation spans multiple days."
-                          : `${totalCount} active ${totalCount === 1 ? "entry" : "entries"}. Review and edit what characters remember.`}
-                      </p>
-                    </div>
-                    <Pencil size="0.875rem" className="shrink-0 text-[var(--muted-foreground)]" />
-                  </button>
-                );
-              })()}
+              <button
+                onClick={() => setShowSummariesModal(true)}
+                className="flex w-full items-center justify-between rounded-lg bg-[var(--secondary)] px-3 py-2.5 text-left transition-all hover:bg-[var(--accent)]"
+              >
+                <div className="flex-1 min-w-0">
+                  <span className="text-[0.6875rem] font-medium">Edit Summaries</span>
+                  <p className="text-[0.625rem] text-[var(--muted-foreground)]">
+                    Review and edit what characters remember.
+                  </p>
+                </div>
+                <Pencil size="0.875rem" className="shrink-0 text-[var(--muted-foreground)]" />
+              </button>
             </Section>
           )}
 

--- a/packages/client/src/components/chat/SummariesEditorModal.tsx
+++ b/packages/client/src/components/chat/SummariesEditorModal.tsx
@@ -309,7 +309,7 @@ export function SummariesEditorModal({ chat, open, onClose }: SummariesEditorMod
                   <span className="text-[0.75rem] font-semibold">{entry.label}</span>
                   <span
                     className={cn(
-                      "shrink-0 rounded-full px-1.5 py-0.5 text-[0.5625rem] font-medium uppercase tracking-wider",
+                      "shrink-0 rounded-full px-1.5 py-0.5 text-[0.5625rem] font-medium uppercase tracking-wider max-md:hidden",
                       entry.kind === "week"
                         ? "bg-purple-500/20 text-purple-400"
                         : "bg-blue-500/20 text-blue-400",

--- a/packages/client/src/components/chat/SummariesEditorModal.tsx
+++ b/packages/client/src/components/chat/SummariesEditorModal.tsx
@@ -1,0 +1,316 @@
+// ──────────────────────────────────────────────
+// Summaries Editor Modal — edit auto-generated day/week summaries
+// ──────────────────────────────────────────────
+import { useEffect, useMemo, useRef, useState } from "react";
+import { X, Plus, Trash2, CalendarClock } from "lucide-react";
+import { cn } from "../../lib/utils";
+import type { Chat, ChatMetadata, DaySummaryEntry, WeekSummaryEntry } from "@marinara-engine/shared";
+import { useQueryClient } from "@tanstack/react-query";
+import { chatKeys, useUpdateChatSummaries } from "../../hooks/use-chats";
+
+interface SummariesEditorModalProps {
+  chat: Chat;
+  open: boolean;
+  onClose: () => void;
+}
+
+// ── Date helpers (mirror generate.routes.ts week-consolidation logic) ──
+
+function parseDateKey(key: string): Date {
+  const [dd, mm, yyyy] = key.split(".");
+  return new Date(Number(yyyy), Number(mm) - 1, Number(dd));
+}
+
+function fmtDateKey(d: Date): string {
+  return `${String(d.getDate()).padStart(2, "0")}.${String(d.getMonth() + 1).padStart(2, "0")}.${d.getFullYear()}`;
+}
+
+function weekRangeLabel(mondayKey: string): string {
+  const monday = parseDateKey(mondayKey);
+  const sunday = new Date(monday.getFullYear(), monday.getMonth(), monday.getDate() + 6);
+  return `Week of ${mondayKey} – ${fmtDateKey(sunday)}`;
+}
+
+// ── Entry discriminator ──
+
+type EntryKind = "week" | "day";
+
+interface EntryRef {
+  kind: EntryKind;
+  key: string;
+  label: string;
+}
+
+// ── Draft state ──
+
+interface Drafts {
+  daySummaries: Record<string, DaySummaryEntry>;
+  weekSummaries: Record<string, WeekSummaryEntry>;
+}
+
+function cloneDrafts(metadata: ChatMetadata): Drafts {
+  return {
+    daySummaries: JSON.parse(JSON.stringify(metadata.daySummaries ?? {})),
+    weekSummaries: JSON.parse(JSON.stringify(metadata.weekSummaries ?? {})),
+  };
+}
+
+function computeDelta(
+  current: Drafts,
+  snapshot: Drafts,
+): { daySummaries?: Record<string, DaySummaryEntry>; weekSummaries?: Record<string, WeekSummaryEntry> } {
+  const dayDelta: Record<string, DaySummaryEntry> = {};
+  const weekDelta: Record<string, WeekSummaryEntry> = {};
+  for (const [k, v] of Object.entries(current.daySummaries)) {
+    if (JSON.stringify(v) !== JSON.stringify(snapshot.daySummaries[k])) dayDelta[k] = v;
+  }
+  for (const [k, v] of Object.entries(current.weekSummaries)) {
+    if (JSON.stringify(v) !== JSON.stringify(snapshot.weekSummaries[k])) weekDelta[k] = v;
+  }
+  const out: { daySummaries?: Record<string, DaySummaryEntry>; weekSummaries?: Record<string, WeekSummaryEntry> } = {};
+  if (Object.keys(dayDelta).length > 0) out.daySummaries = dayDelta;
+  if (Object.keys(weekDelta).length > 0) out.weekSummaries = weekDelta;
+  return out;
+}
+
+export function SummariesEditorModal({ chat, open, onClose }: SummariesEditorModalProps) {
+  const metadata = useMemo(
+    () => (typeof chat.metadata === "string" ? JSON.parse(chat.metadata) : (chat.metadata ?? {})),
+    [chat.metadata],
+  );
+
+  const [drafts, setDrafts] = useState<Drafts>(() => cloneDrafts(metadata));
+  const snapshotRef = useRef<Drafts>(drafts);
+  const updateSummaries = useUpdateChatSummaries();
+  const qc = useQueryClient();
+
+  // Reinitialize drafts whenever the modal opens, refetching the chat first so
+  // auto-summaries written during a prior generation show up without a page refresh.
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    (async () => {
+      await qc.refetchQueries({ queryKey: chatKeys.detail(chat.id) });
+      if (cancelled) return;
+      const latest = qc.getQueryData<Chat>(chatKeys.detail(chat.id));
+      const latestMeta: ChatMetadata = latest
+        ? typeof latest.metadata === "string"
+          ? JSON.parse(latest.metadata)
+          : (latest.metadata ?? {})
+        : metadata;
+      const fresh = cloneDrafts(latestMeta);
+      setDrafts(fresh);
+      snapshotRef.current = fresh;
+      updateSummaries.reset();
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  // Build the ordered entry list: weeks first (chronological), then non-consolidated days.
+  const entries = useMemo<EntryRef[]>(() => {
+    const list: EntryRef[] = [];
+
+    // 1. Weeks, sorted by Monday key ascending.
+    const weekKeys = Object.keys(drafts.weekSummaries).sort(
+      (a, b) => parseDateKey(a).getTime() - parseDateKey(b).getTime(),
+    );
+    for (const wk of weekKeys) {
+      list.push({ kind: "week", key: wk, label: weekRangeLabel(wk) });
+    }
+
+    // 2. Days that are NOT covered by a consolidated week.
+    const dayToWeek = new Map<string, string>();
+    for (const wk of weekKeys) {
+      const monday = parseDateKey(wk);
+      for (let i = 0; i < 7; i++) {
+        const d = new Date(monday.getFullYear(), monday.getMonth(), monday.getDate() + i);
+        dayToWeek.set(fmtDateKey(d), wk);
+      }
+    }
+    const dayKeys = Object.keys(drafts.daySummaries)
+      .filter((k) => !dayToWeek.has(k))
+      .sort((a, b) => parseDateKey(a).getTime() - parseDateKey(b).getTime());
+    for (const dk of dayKeys) {
+      list.push({ kind: "day", key: dk, label: dk });
+    }
+
+    return list;
+  }, [drafts]);
+
+  const delta = useMemo(() => computeDelta(drafts, snapshotRef.current), [drafts]);
+  const isDirty = !!(delta.daySummaries || delta.weekSummaries);
+
+  const updateEntry = (kind: EntryKind, key: string, next: DaySummaryEntry | WeekSummaryEntry) => {
+    setDrafts((prev) => {
+      if (kind === "week") {
+        return { ...prev, weekSummaries: { ...prev.weekSummaries, [key]: next as WeekSummaryEntry } };
+      }
+      return { ...prev, daySummaries: { ...prev.daySummaries, [key]: next as DaySummaryEntry } };
+    });
+  };
+
+  const handleSave = () => {
+    if (!isDirty) return;
+    updateSummaries.mutate(
+      { id: chat.id, ...delta },
+      {
+        onSuccess: () => {
+          onClose();
+        },
+      },
+    );
+  };
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50 backdrop-blur-sm max-md:pt-[env(safe-area-inset-top)]"
+      onClick={onClose}
+    >
+      <div
+        className="mx-4 flex max-h-[85vh] w-full max-w-3xl flex-col rounded-2xl border border-[var(--border)] bg-[var(--background)] shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="shrink-0 flex items-center justify-between border-b border-[var(--border)] px-5 py-3">
+          <div className="flex items-center gap-2">
+            <CalendarClock size="1rem" className="text-[var(--muted-foreground)]" />
+            <h3 className="text-sm font-bold">Automatic Summarization</h3>
+            <span className="text-[0.625rem] text-[var(--muted-foreground)]">
+              {entries.length} {entries.length === 1 ? "entry" : "entries"}
+            </span>
+          </div>
+          <button
+            onClick={onClose}
+            className="rounded-lg p-1.5 text-[var(--muted-foreground)] transition-all hover:bg-[var(--accent)]"
+          >
+            <X size="1rem" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="min-h-0 flex-1 overflow-y-auto p-4 space-y-3">
+          <div className="rounded-lg border border-[var(--border)] bg-[var(--secondary)]/30 px-3 py-2 text-[0.6875rem] text-[var(--muted-foreground)]">
+            Days from the current week are automatically consolidated into a weekly summary once the week ends. Edits to
+            the current week&apos;s days may be rewritten by that consolidation.
+          </div>
+
+          {entries.length === 0 && (
+            <div className="rounded-lg border border-dashed border-[var(--border)] px-4 py-8 text-center text-[0.75rem] text-[var(--muted-foreground)]">
+              No summaries yet — come back after your first day of chatting has ended.
+            </div>
+          )}
+
+          {entries.map((entry) => {
+            const current =
+              entry.kind === "week" ? drafts.weekSummaries[entry.key]! : drafts.daySummaries[entry.key]!;
+
+            return (
+              <div
+                key={`${entry.kind}:${entry.key}`}
+                className="rounded-lg border border-[var(--border)] bg-[var(--secondary)]/20 p-3 space-y-2"
+              >
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <span className="text-[0.75rem] font-semibold">{entry.label}</span>
+                    <span
+                      className={cn(
+                        "rounded-full px-1.5 py-0.5 text-[0.5625rem] font-medium uppercase tracking-wider",
+                        entry.kind === "week"
+                          ? "bg-purple-500/20 text-purple-400"
+                          : "bg-blue-500/20 text-blue-400",
+                      )}
+                    >
+                      {entry.kind}
+                    </span>
+                  </div>
+                </div>
+
+                {/* Summary textarea */}
+                <div className="space-y-1">
+                  <label className="text-[0.625rem] font-medium text-[var(--muted-foreground)]">Summary</label>
+                  <textarea
+                    value={current.summary}
+                    onChange={(e) => updateEntry(entry.kind, entry.key, { ...current, summary: e.target.value })}
+                    rows={Math.min(10, Math.max(3, current.summary.split("\n").length + 1))}
+                    className="w-full resize-y rounded-md border border-[var(--border)] bg-[var(--background)] px-2 py-1.5 text-[0.75rem] leading-relaxed text-[var(--foreground)] focus:border-[var(--primary)] focus:outline-none"
+                  />
+                </div>
+
+                {/* Key details rows */}
+                <div className="space-y-1">
+                  <label className="text-[0.625rem] font-medium text-[var(--muted-foreground)]">Key Details</label>
+                  {current.keyDetails.length === 0 && (
+                    <p className="text-[0.6875rem] italic text-[var(--muted-foreground)]">No key details.</p>
+                  )}
+                  <div className="space-y-1.5">
+                    {current.keyDetails.map((detail, i) => (
+                      <div key={i} className="flex gap-1.5">
+                        <textarea
+                          value={detail}
+                          onChange={(e) => {
+                            const nextDetails = [...current.keyDetails];
+                            nextDetails[i] = e.target.value;
+                            updateEntry(entry.kind, entry.key, { ...current, keyDetails: nextDetails });
+                          }}
+                          rows={Math.min(6, Math.max(1, detail.split("\n").length))}
+                          className="flex-1 resize-y rounded-md border border-[var(--border)] bg-[var(--background)] px-2 py-1.5 text-[0.75rem] leading-relaxed text-[var(--foreground)] focus:border-[var(--primary)] focus:outline-none"
+                        />
+                        <button
+                          onClick={() => {
+                            const nextDetails = current.keyDetails.filter((_, idx) => idx !== i);
+                            updateEntry(entry.kind, entry.key, { ...current, keyDetails: nextDetails });
+                          }}
+                          className="shrink-0 self-start rounded-md p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--destructive)]/10 hover:text-[var(--destructive)]"
+                          title="Delete key detail"
+                        >
+                          <Trash2 size="0.75rem" />
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                  <button
+                    onClick={() =>
+                      updateEntry(entry.kind, entry.key, { ...current, keyDetails: [...current.keyDetails, ""] })
+                    }
+                    className="mt-1 flex items-center gap-1 rounded-md px-2 py-1 text-[0.6875rem] text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+                  >
+                    <Plus size="0.75rem" />
+                    Add key detail
+                  </button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Footer */}
+        <div className="shrink-0 flex items-center justify-between gap-2 border-t border-[var(--border)] px-5 py-3">
+          <div className="text-[0.6875rem] text-[var(--destructive)]">
+            {updateSummaries.isError ? "Save failed — try again." : ""}
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={onClose}
+              disabled={updateSummaries.isPending}
+              className="rounded-lg px-3 py-1.5 text-[0.75rem] font-medium text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleSave}
+              disabled={!isDirty || updateSummaries.isPending}
+              className="rounded-lg bg-[var(--primary)] px-3 py-1.5 text-[0.75rem] font-medium text-[var(--primary-foreground)] transition-all hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {updateSummaries.isPending ? "Saving…" : "Save"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/client/src/components/chat/SummariesEditorModal.tsx
+++ b/packages/client/src/components/chat/SummariesEditorModal.tsx
@@ -1,12 +1,37 @@
 // ──────────────────────────────────────────────
 // Summaries Editor Modal — edit auto-generated day/week summaries
 // ──────────────────────────────────────────────
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { X, Plus, Trash2, CalendarClock } from "lucide-react";
 import { cn } from "../../lib/utils";
 import type { Chat, ChatMetadata, DaySummaryEntry, WeekSummaryEntry } from "@marinara-engine/shared";
 import { useQueryClient } from "@tanstack/react-query";
 import { chatKeys, useUpdateChatSummaries } from "../../hooks/use-chats";
+
+interface AutoSizingTextareaProps {
+  value: string;
+  onChange: (value: string) => void;
+  className?: string;
+}
+
+function AutoSizingTextarea({ value, onChange, className }: AutoSizingTextareaProps) {
+  const ref = useRef<HTMLTextAreaElement>(null);
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${el.scrollHeight}px`;
+  }, [value]);
+  return (
+    <textarea
+      ref={ref}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      rows={1}
+      className={cn("resize-none overflow-hidden", className)}
+    />
+  );
+}
 
 interface SummariesEditorModalProps {
   chat: Chat;
@@ -233,11 +258,10 @@ export function SummariesEditorModal({ chat, open, onClose }: SummariesEditorMod
                 {/* Summary textarea */}
                 <div className="space-y-1">
                   <label className="text-[0.625rem] font-medium text-[var(--muted-foreground)]">Summary</label>
-                  <textarea
+                  <AutoSizingTextarea
                     value={current.summary}
-                    onChange={(e) => updateEntry(entry.kind, entry.key, { ...current, summary: e.target.value })}
-                    rows={Math.min(10, Math.max(3, current.summary.split("\n").length + 1))}
-                    className="w-full resize-y rounded-md border border-[var(--border)] bg-[var(--background)] px-2 py-1.5 text-[0.75rem] leading-relaxed text-[var(--foreground)] focus:border-[var(--primary)] focus:outline-none"
+                    onChange={(next) => updateEntry(entry.kind, entry.key, { ...current, summary: next })}
+                    className="w-full rounded-md border border-[var(--border)] bg-[var(--background)] px-2 py-1.5 text-[0.75rem] leading-relaxed text-[var(--foreground)] focus:border-[var(--primary)] focus:outline-none"
                   />
                 </div>
 
@@ -250,15 +274,14 @@ export function SummariesEditorModal({ chat, open, onClose }: SummariesEditorMod
                   <div className="space-y-1.5">
                     {current.keyDetails.map((detail, i) => (
                       <div key={i} className="flex gap-1.5">
-                        <textarea
+                        <AutoSizingTextarea
                           value={detail}
-                          onChange={(e) => {
+                          onChange={(next) => {
                             const nextDetails = [...current.keyDetails];
-                            nextDetails[i] = e.target.value;
+                            nextDetails[i] = next;
                             updateEntry(entry.kind, entry.key, { ...current, keyDetails: nextDetails });
                           }}
-                          rows={Math.min(6, Math.max(1, detail.split("\n").length))}
-                          className="flex-1 resize-y rounded-md border border-[var(--border)] bg-[var(--background)] px-2 py-1.5 text-[0.75rem] leading-relaxed text-[var(--foreground)] focus:border-[var(--primary)] focus:outline-none"
+                          className="flex-1 rounded-md border border-[var(--border)] bg-[var(--background)] px-2 py-1.5 text-[0.75rem] leading-relaxed text-[var(--foreground)] focus:border-[var(--primary)] focus:outline-none"
                         />
                         <button
                           onClick={() => {

--- a/packages/client/src/components/chat/SummariesEditorModal.tsx
+++ b/packages/client/src/components/chat/SummariesEditorModal.tsx
@@ -2,7 +2,7 @@
 // Summaries Editor Modal — edit auto-generated day/week summaries
 // ──────────────────────────────────────────────
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { X, Plus, Trash2, CalendarClock } from "lucide-react";
+import { X, Plus, Trash2, CalendarClock, ChevronRight, ChevronsDownUp, ChevronsUpDown } from "lucide-react";
 import { cn } from "../../lib/utils";
 import type { Chat, ChatMetadata, DaySummaryEntry, WeekSummaryEntry } from "@marinara-engine/shared";
 import { useQueryClient } from "@tanstack/react-query";
@@ -108,6 +108,7 @@ export function SummariesEditorModal({ chat, open, onClose }: SummariesEditorMod
   const snapshotRef = useRef<Drafts>(drafts);
   const updateSummaries = useUpdateChatSummaries();
   const qc = useQueryClient();
+  const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
 
   // Reinitialize drafts whenever the modal opens, refetching the chat first so
   // auto-summaries written during a prior generation show up without a page refresh.
@@ -126,6 +127,7 @@ export function SummariesEditorModal({ chat, open, onClose }: SummariesEditorMod
       const fresh = cloneDrafts(latestMeta);
       setDrafts(fresh);
       snapshotRef.current = fresh;
+      setExpanded(new Set());
       updateSummaries.reset();
     })();
     return () => {
@@ -167,6 +169,20 @@ export function SummariesEditorModal({ chat, open, onClose }: SummariesEditorMod
 
   const delta = useMemo(() => computeDelta(drafts, snapshotRef.current), [drafts]);
   const isDirty = !!(delta.daySummaries || delta.weekSummaries);
+
+  const allExpanded = entries.length > 0 && expanded.size === entries.length;
+  const toggleEntry = (id: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+  const toggleAll = () => {
+    if (allExpanded) setExpanded(new Set());
+    else setExpanded(new Set(entries.map((e) => `${e.kind}:${e.key}`)));
+  };
 
   const updateEntry = (kind: EntryKind, key: string, next: DaySummaryEntry | WeekSummaryEntry) => {
     setDrafts((prev) => {
@@ -230,82 +246,116 @@ export function SummariesEditorModal({ chat, open, onClose }: SummariesEditorMod
             </div>
           )}
 
+          {entries.length > 0 && (
+            <div className="flex items-center justify-end">
+              <button
+                onClick={toggleAll}
+                title={allExpanded ? "Collapse all" : "Expand all"}
+                aria-label={allExpanded ? "Collapse all" : "Expand all"}
+                className="flex items-center gap-1 rounded-md px-2 py-1 text-[0.6875rem] font-medium text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+              >
+                {allExpanded ? <ChevronsDownUp size="0.85rem" /> : <ChevronsUpDown size="0.85rem" />}
+                {allExpanded ? "Collapse all" : "Expand all"}
+              </button>
+            </div>
+          )}
+
           {entries.map((entry) => {
             const current =
               entry.kind === "week" ? drafts.weekSummaries[entry.key]! : drafts.daySummaries[entry.key]!;
+            const id = `${entry.kind}:${entry.key}`;
+            const isOpen = expanded.has(id);
 
             return (
               <div
-                key={`${entry.kind}:${entry.key}`}
-                className="rounded-lg border border-[var(--border)] bg-[var(--secondary)]/20 p-3 space-y-2"
+                key={id}
+                className="rounded-lg border border-[var(--border)] bg-[var(--secondary)]/20"
               >
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-2">
-                    <span className="text-[0.75rem] font-semibold">{entry.label}</span>
-                    <span
-                      className={cn(
-                        "rounded-full px-1.5 py-0.5 text-[0.5625rem] font-medium uppercase tracking-wider",
-                        entry.kind === "week"
-                          ? "bg-purple-500/20 text-purple-400"
-                          : "bg-blue-500/20 text-blue-400",
-                      )}
-                    >
-                      {entry.kind}
-                    </span>
-                  </div>
-                </div>
-
-                {/* Summary textarea */}
-                <div className="space-y-1">
-                  <label className="text-[0.625rem] font-medium text-[var(--muted-foreground)]">Summary</label>
-                  <AutoSizingTextarea
-                    value={current.summary}
-                    onChange={(next) => updateEntry(entry.kind, entry.key, { ...current, summary: next })}
-                    className="w-full rounded-md border border-[var(--border)] bg-[var(--background)] px-2 py-1.5 text-[0.75rem] leading-relaxed text-[var(--foreground)] focus:border-[var(--primary)] focus:outline-none"
+                <button
+                  onClick={() => toggleEntry(id)}
+                  aria-expanded={isOpen}
+                  className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left transition-colors hover:bg-[var(--accent)]/50"
+                >
+                  <ChevronRight
+                    size="0.85rem"
+                    className={cn(
+                      "shrink-0 text-[var(--muted-foreground)] transition-transform",
+                      isOpen && "rotate-90",
+                    )}
                   />
-                </div>
-
-                {/* Key details rows */}
-                <div className="space-y-1">
-                  <label className="text-[0.625rem] font-medium text-[var(--muted-foreground)]">Key Details</label>
-                  {current.keyDetails.length === 0 && (
-                    <p className="text-[0.6875rem] italic text-[var(--muted-foreground)]">No key details.</p>
-                  )}
-                  <div className="space-y-1.5">
-                    {current.keyDetails.map((detail, i) => (
-                      <div key={i} className="flex gap-1.5">
-                        <AutoSizingTextarea
-                          value={detail}
-                          onChange={(next) => {
-                            const nextDetails = [...current.keyDetails];
-                            nextDetails[i] = next;
-                            updateEntry(entry.kind, entry.key, { ...current, keyDetails: nextDetails });
-                          }}
-                          className="flex-1 rounded-md border border-[var(--border)] bg-[var(--background)] px-2 py-1.5 text-[0.75rem] leading-relaxed text-[var(--foreground)] focus:border-[var(--primary)] focus:outline-none"
-                        />
-                        <button
-                          onClick={() => {
-                            const nextDetails = current.keyDetails.filter((_, idx) => idx !== i);
-                            updateEntry(entry.kind, entry.key, { ...current, keyDetails: nextDetails });
-                          }}
-                          className="shrink-0 self-start rounded-md p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--destructive)]/10 hover:text-[var(--destructive)]"
-                          title="Delete key detail"
-                        >
-                          <Trash2 size="0.75rem" />
-                        </button>
-                      </div>
-                    ))}
-                  </div>
-                  <button
-                    onClick={() =>
-                      updateEntry(entry.kind, entry.key, { ...current, keyDetails: [...current.keyDetails, ""] })
-                    }
-                    className="mt-1 flex items-center gap-1 rounded-md px-2 py-1 text-[0.6875rem] text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+                  <span className="text-[0.75rem] font-semibold">{entry.label}</span>
+                  <span
+                    className={cn(
+                      "shrink-0 rounded-full px-1.5 py-0.5 text-[0.5625rem] font-medium uppercase tracking-wider",
+                      entry.kind === "week"
+                        ? "bg-purple-500/20 text-purple-400"
+                        : "bg-blue-500/20 text-blue-400",
+                    )}
                   >
-                    <Plus size="0.75rem" />
-                    Add key detail
-                  </button>
-                </div>
+                    {entry.kind}
+                  </span>
+                  {!isOpen && current.summary && (
+                    <span className="min-w-0 flex-1 truncate text-[0.6875rem] italic text-[var(--muted-foreground)]">
+                      {current.summary}
+                    </span>
+                  )}
+                </button>
+
+                {isOpen && (
+                  <div className="space-y-2 border-t border-[var(--border)] px-3 py-2">
+                    {/* Summary textarea */}
+                    <div className="space-y-1">
+                      <label className="text-[0.625rem] font-medium text-[var(--muted-foreground)]">Summary</label>
+                      <AutoSizingTextarea
+                        value={current.summary}
+                        onChange={(next) => updateEntry(entry.kind, entry.key, { ...current, summary: next })}
+                        className="w-full rounded-md border border-[var(--border)] bg-[var(--background)] px-2 py-1.5 text-[0.75rem] leading-relaxed text-[var(--foreground)] focus:border-[var(--primary)] focus:outline-none"
+                      />
+                    </div>
+
+                    {/* Key details rows */}
+                    <div className="space-y-1">
+                      <label className="text-[0.625rem] font-medium text-[var(--muted-foreground)]">Key Details</label>
+                      {current.keyDetails.length === 0 && (
+                        <p className="text-[0.6875rem] italic text-[var(--muted-foreground)]">No key details.</p>
+                      )}
+                      <div className="space-y-1.5">
+                        {current.keyDetails.map((detail, i) => (
+                          <div key={i} className="flex gap-1.5">
+                            <AutoSizingTextarea
+                              value={detail}
+                              onChange={(next) => {
+                                const nextDetails = [...current.keyDetails];
+                                nextDetails[i] = next;
+                                updateEntry(entry.kind, entry.key, { ...current, keyDetails: nextDetails });
+                              }}
+                              className="flex-1 rounded-md border border-[var(--border)] bg-[var(--background)] px-2 py-1.5 text-[0.75rem] leading-relaxed text-[var(--foreground)] focus:border-[var(--primary)] focus:outline-none"
+                            />
+                            <button
+                              onClick={() => {
+                                const nextDetails = current.keyDetails.filter((_, idx) => idx !== i);
+                                updateEntry(entry.kind, entry.key, { ...current, keyDetails: nextDetails });
+                              }}
+                              className="shrink-0 self-start rounded-md p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--destructive)]/10 hover:text-[var(--destructive)]"
+                              title="Delete key detail"
+                            >
+                              <Trash2 size="0.75rem" />
+                            </button>
+                          </div>
+                        ))}
+                      </div>
+                      <button
+                        onClick={() =>
+                          updateEntry(entry.kind, entry.key, { ...current, keyDetails: [...current.keyDetails, ""] })
+                        }
+                        className="mt-1 flex items-center gap-1 rounded-md px-2 py-1 text-[0.6875rem] text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+                      >
+                        <Plus size="0.75rem" />
+                        Add key detail
+                      </button>
+                    </div>
+                  </div>
+                )}
               </div>
             );
           })}

--- a/packages/client/src/components/chat/SummariesEditorModal.tsx
+++ b/packages/client/src/components/chat/SummariesEditorModal.tsx
@@ -8,6 +8,18 @@ import type { Chat, ChatMetadata, DaySummaryEntry, WeekSummaryEntry } from "@mar
 import { useQueryClient } from "@tanstack/react-query";
 import { chatKeys, useUpdateChatSummaries } from "../../hooks/use-chats";
 
+function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+function fmtTokens(n: number): string {
+  return n.toLocaleString();
+}
+
+function entryTokenText(entry: DaySummaryEntry | WeekSummaryEntry): string {
+  return [entry.summary, ...entry.keyDetails].join("\n");
+}
+
 interface AutoSizingTextareaProps {
   value: string;
   onChange: (value: string) => void;
@@ -170,6 +182,15 @@ export function SummariesEditorModal({ chat, open, onClose }: SummariesEditorMod
   const delta = useMemo(() => computeDelta(drafts, snapshotRef.current), [drafts]);
   const isDirty = !!(delta.daySummaries || delta.weekSummaries);
 
+  const totalTokens = useMemo(() => {
+    let text = "";
+    for (const entry of entries) {
+      const e = entry.kind === "week" ? drafts.weekSummaries[entry.key] : drafts.daySummaries[entry.key];
+      if (e) text += entryTokenText(e);
+    }
+    return estimateTokens(text);
+  }, [entries, drafts]);
+
   const allExpanded = entries.length > 0 && expanded.size === entries.length;
   const toggleEntry = (id: string) => {
     setExpanded((prev) => {
@@ -222,7 +243,8 @@ export function SummariesEditorModal({ chat, open, onClose }: SummariesEditorMod
             <CalendarClock size="1rem" className="text-[var(--muted-foreground)]" />
             <h3 className="text-sm font-bold">Automatic Summarization</h3>
             <span className="text-[0.625rem] text-[var(--muted-foreground)]">
-              {entries.length} {entries.length === 1 ? "entry" : "entries"}
+              {entries.length} {entries.length === 1 ? "entry" : "entries"} &middot; ~{fmtTokens(totalTokens)} token
+              {totalTokens !== 1 ? "s" : ""}
             </span>
           </div>
           <button
@@ -265,6 +287,7 @@ export function SummariesEditorModal({ chat, open, onClose }: SummariesEditorMod
               entry.kind === "week" ? drafts.weekSummaries[entry.key]! : drafts.daySummaries[entry.key]!;
             const id = `${entry.kind}:${entry.key}`;
             const isOpen = expanded.has(id);
+            const entryTokens = estimateTokens(entryTokenText(current));
 
             return (
               <div
@@ -294,11 +317,9 @@ export function SummariesEditorModal({ chat, open, onClose }: SummariesEditorMod
                   >
                     {entry.kind}
                   </span>
-                  {!isOpen && current.summary && (
-                    <span className="min-w-0 flex-1 truncate text-[0.6875rem] italic text-[var(--muted-foreground)]">
-                      {current.summary}
-                    </span>
-                  )}
+                  <span className="ml-auto shrink-0 text-[0.625rem] text-[var(--muted-foreground)]">
+                    ~{fmtTokens(entryTokens)} token{entryTokens !== 1 ? "s" : ""}
+                  </span>
                 </button>
 
                 {isOpen && (

--- a/packages/client/src/hooks/use-chats.ts
+++ b/packages/client/src/hooks/use-chats.ts
@@ -9,7 +9,7 @@ import { useGameStateStore } from "../stores/game-state.store";
 import { useEncounterStore } from "../stores/encounter.store";
 import { useUIStore } from "../stores/ui.store";
 import { clearBrowserRuntimeCaches } from "../lib/cache-reset";
-import type { Chat, Message, MessageSwipe } from "@marinara-engine/shared";
+import type { Chat, Message, MessageSwipe, DaySummaryEntry, WeekSummaryEntry } from "@marinara-engine/shared";
 
 export const chatKeys = {
   all: ["chats"] as const,
@@ -175,6 +175,24 @@ export function useUpdateChatMetadata() {
   return useMutation({
     mutationFn: ({ id, ...metadata }: { id: string; [key: string]: unknown }) =>
       api.patch<Chat>(`/chats/${id}/metadata`, metadata),
+    onSuccess: (_data, vars) => {
+      qc.invalidateQueries({ queryKey: chatKeys.detail(vars.id) });
+    },
+  });
+}
+
+/** Patch day/week summaries via entry-level merge (concurrent-edit safe). */
+export function useUpdateChatSummaries() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      id,
+      ...body
+    }: {
+      id: string;
+      daySummaries?: Record<string, DaySummaryEntry>;
+      weekSummaries?: Record<string, WeekSummaryEntry>;
+    }) => api.patch<Chat>(`/chats/${id}/summaries`, body),
     onSuccess: (_data, vars) => {
       qc.invalidateQueries({ queryKey: chatKeys.detail(vars.id) });
     },

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -2,7 +2,13 @@
 // Routes: Chats
 // ──────────────────────────────────────────────
 import type { FastifyInstance } from "fastify";
-import { createChatSchema, createMessageSchema, getDefaultAgentPrompt, nameToXmlTag } from "@marinara-engine/shared";
+import {
+  createChatSchema,
+  createMessageSchema,
+  getDefaultAgentPrompt,
+  nameToXmlTag,
+  summariesPatchSchema,
+} from "@marinara-engine/shared";
 import { createChatsStorage } from "../services/storage/chats.storage.js";
 import { createConnectionsStorage } from "../services/storage/connections.storage.js";
 import { createRegexScriptsStorage } from "../services/storage/regex-scripts.storage.js";
@@ -92,6 +98,26 @@ export async function chatsRoutes(app: FastifyInstance) {
       incoming.discordWebhookUrl = url;
     }
     const merged = { ...existing, ...incoming };
+    return storage.updateMetadata(req.params.id, merged);
+  });
+
+  // Update chat summaries (entry-level merge for day/week summaries).
+  // Dedicated from generic metadata PATCH so concurrent user edits don't overwrite
+  // the entire daySummaries/weekSummaries maps — we re-read fresh metadata here and
+  // merge per-entry so in-flight generation writes can't clobber user edits on other keys.
+  app.patch<{ Params: { id: string } }>("/:id/summaries", async (req, reply) => {
+    const parsed = summariesPatchSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return reply.status(400).send({ error: "Invalid summaries payload", issues: parsed.error.issues });
+    }
+    const fresh = await storage.getById(req.params.id);
+    if (!fresh) return reply.status(404).send({ error: "Chat not found" });
+    const existing = typeof fresh.metadata === "string" ? JSON.parse(fresh.metadata) : (fresh.metadata ?? {});
+    const merged = {
+      ...existing,
+      daySummaries: { ...(existing.daySummaries ?? {}), ...(parsed.data.daySummaries ?? {}) },
+      weekSummaries: { ...(existing.weekSummaries ?? {}), ...(parsed.data.weekSummaries ?? {}) },
+    };
     return storage.updateMetadata(req.params.id, merged);
   });
 

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -874,6 +874,11 @@ export async function generateRoutes(app: FastifyInstance) {
             new Promise<never>((_, reject) => setTimeout(() => reject(new Error("Summary timeout")), ms)),
           ]);
 
+        // Keys newly produced in this generation — persisted via key-level merge so
+        // concurrent user edits to other entries aren't clobbered when we write back.
+        const newlyGeneratedDays: Record<string, DaySummaryEntry> = {};
+        const newlyConsolidatedWeeks: Record<string, { summary: string; keyDetails: string[] }> = {};
+
         if (bucketsToSummarize.length > 0) {
           const summaryProvider = createLLMProvider(conn.provider, baseUrl, conn.apiKey);
           const summaryResults = await Promise.allSettled(
@@ -931,16 +936,28 @@ export async function generateRoutes(app: FastifyInstance) {
           );
           for (const r of summaryResults) {
             if (r.status === "fulfilled" && r.value.summary) {
-              daySummaries[r.value.date] = {
+              const entry = {
                 summary: r.value.summary,
                 keyDetails: r.value.keyDetails,
               };
+              daySummaries[r.value.date] = entry;
+              newlyGeneratedDays[r.value.date] = entry;
               summariesChanged = true;
             }
           }
-          // Persist new summaries to chat metadata
+          // Persist new summaries via key-level merge against fresh metadata, so a
+          // concurrent user edit to a different day is not clobbered.
           if (summariesChanged) {
-            const updatedMeta = { ...chatMeta, daySummaries };
+            const freshChat = await chats.getById(input.chatId);
+            const freshMeta = freshChat
+              ? typeof freshChat.metadata === "string"
+                ? JSON.parse(freshChat.metadata)
+                : (freshChat.metadata ?? {})
+              : chatMeta;
+            const updatedMeta = {
+              ...freshMeta,
+              daySummaries: { ...(freshMeta.daySummaries ?? {}), ...newlyGeneratedDays },
+            };
             await chats.updateMetadata(input.chatId, updatedMeta);
           }
         }
@@ -1050,15 +1067,27 @@ export async function generateRoutes(app: FastifyInstance) {
           );
           for (const r of weekResults) {
             if (r.status === "fulfilled" && r.value.summary) {
-              weekSummaries[r.value.weekKey] = {
+              const entry = {
                 summary: r.value.summary,
                 keyDetails: r.value.keyDetails,
               };
+              weekSummaries[r.value.weekKey] = entry;
+              newlyConsolidatedWeeks[r.value.weekKey] = entry;
               weekSummariesChanged = true;
             }
           }
           if (weekSummariesChanged) {
-            const updatedMeta = { ...chatMeta, daySummaries, weekSummaries };
+            const freshChat = await chats.getById(input.chatId);
+            const freshMeta = freshChat
+              ? typeof freshChat.metadata === "string"
+                ? JSON.parse(freshChat.metadata)
+                : (freshChat.metadata ?? {})
+              : chatMeta;
+            const updatedMeta = {
+              ...freshMeta,
+              daySummaries: { ...(freshMeta.daySummaries ?? {}), ...newlyGeneratedDays },
+              weekSummaries: { ...(freshMeta.weekSummaries ?? {}), ...newlyConsolidatedWeeks },
+            };
             await chats.updateMetadata(input.chatId, updatedMeta);
           }
         }

--- a/packages/shared/src/schemas/chat.schema.ts
+++ b/packages/shared/src/schemas/chat.schema.ts
@@ -46,6 +46,18 @@ export const generateRequestSchema = z.object({
     .default([]),
 });
 
+// Auto-summarization entries — shape-only validation (no length caps).
+export const summaryEntrySchema = z.object({
+  summary: z.string(),
+  keyDetails: z.array(z.string()),
+});
+
+export const summariesPatchSchema = z.object({
+  daySummaries: z.record(z.string(), summaryEntrySchema).optional(),
+  weekSummaries: z.record(z.string(), summaryEntrySchema).optional(),
+});
+
 export type CreateChatInput = z.infer<typeof createChatSchema>;
 export type CreateMessageInput = z.infer<typeof createMessageSchema>;
 export type GenerateRequestInput = z.infer<typeof generateRequestSchema>;
+export type SummariesPatchInput = z.infer<typeof summariesPatchSchema>;

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -59,6 +59,22 @@ export interface ChatFolder {
   updatedAt: string;
 }
 
+/** A single day's auto-generated conversation summary. */
+export interface DaySummaryEntry {
+  /** Narrative recap of the day. */
+  summary: string;
+  /** Short strings the characters must remember going forward. */
+  keyDetails: string[];
+}
+
+/** A single week's consolidated conversation summary (Monday → Sunday). */
+export interface WeekSummaryEntry {
+  /** Narrative recap of the week. */
+  summary: string;
+  /** Consolidated key details the characters must remember going forward. */
+  keyDetails: string[];
+}
+
 /** Extra metadata stored on a chat. */
 export interface ChatMetadata {
   /** Summary text for context injection */
@@ -135,6 +151,12 @@ export interface ChatMetadata {
   gameSetupConfig?: import("./game.js").GameSetupConfig | null;
   /** Tracked NPCs with reputation */
   gameNpcs?: import("./game.js").GameNpc[];
+
+  // ── Conversation-Mode Auto-Summarization ──
+  /** Per-day auto-generated conversation summaries (key: "DD.MM.YYYY"). */
+  daySummaries?: Record<string, DaySummaryEntry>;
+  /** Per-week consolidated conversation summaries (key: Monday "DD.MM.YYYY"). */
+  weekSummaries?: Record<string, WeekSummaryEntry>;
 
   /** Any extra key-value data */
   [key: string]: unknown;


### PR DESCRIPTION
## Summary

As discussed in this thread: https://discord.com/channels/1417099416812392641/1493651356534181959

NOTE: Automatic Summaries is a feature that already exists in ME! This only adds a way to edit the summaries for the user.

- Adds a new Automatic Summarization section to chat settings (conversation mode only) that opens a modal for reviewing and editing the auto-generated day/week summaries stored in `chatMeta.daySummaries` / `chatMeta.weekSummaries`.
- Lets users prune the conversation summary. Useful when the context begins to grow too much, or when the user wants to add or remove things from the character chat memories.

## Notes

- There is no create-from-scratch flow. Users only edit entries the auto-summarizer has already produced.


## UI Screenshots
Modal:
<img width="1007" height="720" alt="image" src="https://github.com/user-attachments/assets/ae798053-fa11-4526-865d-b25fd1fe1edd" />

Modal with an open row:
<img width="985" height="820" alt="image" src="https://github.com/user-attachments/assets/15d72d77-d999-4fe3-9f4e-406a89ad366f" />

How the chat settings sidebar looks with the new option
<img width="397" height="931" alt="image" src="https://github.com/user-attachments/assets/dca6876c-ad88-42b3-918a-d6df20f6959d" />

Mobile:
<img width="385" height="840" alt="image" src="https://github.com/user-attachments/assets/5afc4bab-d62e-439d-842d-4f8c661e9d71" />


## Validation

- Go to conversation mode -> chat settings -> Automatic Summarization -> Edit Summaries. Verify that the modal works as expected
- Go the the modal again on a conversation with a conversation that has already been summarized. Try editing a detail and then validate with a new message that the change is reflected in the message prompt.
- Same as above but try deleting information instead

## AI Disclosure

Built with Claude Code (Claude Opus) for implementation; human-reviewed and manually validated against the scenarios above.
