### PR TITLE
perf(client): split translation state from on-demand helpers

### DIFF
--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -44,7 +44,7 @@ import { useScene } from "../../hooks/use-scene";
 import { useEncounterStore } from "../../stores/encounter.store";
 import { APP_VERSION } from "@marinara-engine/shared";
 import { BUILT_IN_AGENTS } from "@marinara-engine/shared";
-import { useTranslationStore } from "../../hooks/use-translate";
+import { useTranslationStore } from "../../stores/translation.store";
 import { mirrorSpritePlacements, normalizeSpritePlacements } from "./sprite-placement";
 import type { CharacterMap, MessageSelectionToggle, MessageWithSwipes, PeekPromptData } from "./chat-area.types";
 import { RecentChats } from "./RecentChats";

--- a/packages/client/src/components/chat/ChatInput.tsx
+++ b/packages/client/src/components/chat/ChatInput.tsx
@@ -320,7 +320,7 @@ export const ChatInput = memo(function ChatInput({
       : {};
     if (chatMeta.translateInput && message.trim()) {
       try {
-        const { translateText } = await import("../../hooks/use-translate");
+        const { translateText } = await import("../../lib/translate-text");
         const translated = await translateText(message);
         if (translated.trim()) message = translated;
       } catch {

--- a/packages/client/src/components/chat/ConversationInput.tsx
+++ b/packages/client/src/components/chat/ConversationInput.tsx
@@ -275,7 +275,7 @@ export function ConversationInput({ characterNames = [] }: ConversationInputProp
         : {};
       if (streamMeta.translateInput && message.trim()) {
         try {
-          const { translateText } = await import("../../hooks/use-translate");
+          const { translateText } = await import("../../lib/translate-text");
           const translated = await translateText(message);
           if (translated.trim()) message = translated;
         } catch {
@@ -331,7 +331,7 @@ export function ConversationInput({ characterNames = [] }: ConversationInputProp
       : {};
     if (chatMeta.translateInput && message.trim()) {
       try {
-        const { translateText } = await import("../../hooks/use-translate");
+        const { translateText } = await import("../../lib/translate-text");
         const translated = await translateText(message);
         if (translated.trim()) message = translated;
       } catch {

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -15,6 +15,7 @@ import { useChatStore } from "../stores/chat.store";
 import { useAgentStore } from "../stores/agent.store";
 import { useGameModeStore } from "../stores/game-mode.store";
 import { useGameStateStore } from "../stores/game-state.store";
+import { useTranslationStore } from "../stores/translation.store";
 import { useUIStore } from "../stores/ui.store";
 import { chatKeys } from "./use-chats";
 import { characterKeys } from "./use-characters";
@@ -1253,7 +1254,6 @@ export function useGenerate() {
                   : chatData.metadata
                 : {};
             if (meta.autoTranslate) {
-              const { useTranslationStore } = await import("./use-translate");
               const store = useTranslationStore.getState();
               for (const [id, msg] of persistedMessages) {
                 if (msg.role === "assistant" && msg.content && !store.translations[id]) {

--- a/packages/client/src/hooks/use-translate.ts
+++ b/packages/client/src/hooks/use-translate.ts
@@ -1,69 +1,10 @@
 // ──────────────────────────────────────────────
 // Hook: Translation — multi-provider message translation
 // ──────────────────────────────────────────────
-import { create } from "zustand";
 import { useCallback } from "react";
 import { toast } from "sonner";
 import { api } from "../lib/api-client";
-
-// ── Translation config (set from chat metadata) ──
-export interface TranslationConfig {
-  provider: "ai" | "deeplx" | "deepl" | "google";
-  targetLanguage: string;
-  connectionId?: string;
-  deeplApiKey?: string;
-  deeplxUrl?: string;
-}
-
-// ── Zustand store for translation cache ──
-interface TranslationStore {
-  /** Config for the currently active chat */
-  config: TranslationConfig;
-  setConfig: (config: TranslationConfig) => void;
-  /** messageId -> translated text */
-  translations: Record<string, string>;
-  /** messageId -> currently translating */
-  translating: Record<string, boolean>;
-  setTranslation: (id: string, text: string) => void;
-  removeTranslation: (id: string) => void;
-  setTranslating: (id: string, val: boolean) => void;
-  /** Clear all translations (e.g. on chat switch) */
-  clearAll: () => void;
-  /** Seed translations from message extras (e.g. on chat load) */
-  seedFromMessages: (messages: Array<{ id: string; extra?: string | Record<string, unknown> | null }>) => void;
-}
-
-export const useTranslationStore = create<TranslationStore>((set) => ({
-  config: { provider: "google", targetLanguage: "en" },
-  setConfig: (config) => set({ config }),
-  translations: {},
-  translating: {},
-  setTranslation: (id, text) => set((s) => ({ translations: { ...s.translations, [id]: text } })),
-  removeTranslation: (id) =>
-    set((s) => {
-      const { [id]: _, ...rest } = s.translations;
-      return { translations: rest };
-    }),
-  setTranslating: (id, val) => set((s) => ({ translating: { ...s.translating, [id]: val } })),
-  clearAll: () => set({ translations: {}, translating: {} }),
-  seedFromMessages: (messages) =>
-    set((s) => {
-      const seeded: Record<string, string> = {};
-      for (const msg of messages) {
-        if (!msg.extra) continue;
-        try {
-          const extra = typeof msg.extra === "string" ? JSON.parse(msg.extra) : msg.extra;
-          if (extra.translation && typeof extra.translation === "string") {
-            seeded[msg.id] = extra.translation;
-          }
-        } catch {
-          // Skip messages with malformed extra JSON
-        }
-      }
-      // Merge with existing (in-flight translations win over seeded)
-      return { translations: { ...seeded, ...s.translations } };
-    }),
-}));
+import { useTranslationStore } from "../stores/translation.store";
 
 // ── Hook ──
 export function useTranslate() {
@@ -114,18 +55,4 @@ export function useTranslate() {
     translating,
     config,
   };
-}
-
-// ── Standalone translate helper (for input translation / auto-translate) ──
-export async function translateText(text: string): Promise<string> {
-  const store = useTranslationStore.getState();
-  const result = await api.post<{ translatedText: string }>("/translate", {
-    text,
-    provider: store.config.provider,
-    targetLanguage: store.config.targetLanguage,
-    connectionId: store.config.connectionId,
-    deeplApiKey: store.config.deeplApiKey,
-    deeplxUrl: store.config.deeplxUrl,
-  });
-  return result.translatedText;
 }

--- a/packages/client/src/lib/translate-text.ts
+++ b/packages/client/src/lib/translate-text.ts
@@ -1,0 +1,16 @@
+import { api } from "./api-client";
+import { useTranslationStore } from "../stores/translation.store";
+
+/** Standalone translate helper for on-demand translation flows. */
+export async function translateText(text: string): Promise<string> {
+  const store = useTranslationStore.getState();
+  const result = await api.post<{ translatedText: string }>("/translate", {
+    text,
+    provider: store.config.provider,
+    targetLanguage: store.config.targetLanguage,
+    connectionId: store.config.connectionId,
+    deeplApiKey: store.config.deeplApiKey,
+    deeplxUrl: store.config.deeplxUrl,
+  });
+  return result.translatedText;
+}

--- a/packages/client/src/stores/translation.store.ts
+++ b/packages/client/src/stores/translation.store.ts
@@ -1,0 +1,60 @@
+import { create } from "zustand";
+
+// ── Translation config (set from chat metadata) ──
+export interface TranslationConfig {
+  provider: "ai" | "deeplx" | "deepl" | "google";
+  targetLanguage: string;
+  connectionId?: string;
+  deeplApiKey?: string;
+  deeplxUrl?: string;
+}
+
+// ── Zustand store for translation cache ──
+interface TranslationStore {
+  /** Config for the currently active chat */
+  config: TranslationConfig;
+  setConfig: (config: TranslationConfig) => void;
+  /** messageId -> translated text */
+  translations: Record<string, string>;
+  /** messageId -> currently translating */
+  translating: Record<string, boolean>;
+  setTranslation: (id: string, text: string) => void;
+  removeTranslation: (id: string) => void;
+  setTranslating: (id: string, val: boolean) => void;
+  /** Clear all translations (e.g. on chat switch) */
+  clearAll: () => void;
+  /** Seed translations from message extras (e.g. on chat load) */
+  seedFromMessages: (messages: Array<{ id: string; extra?: string | Record<string, unknown> | null }>) => void;
+}
+
+export const useTranslationStore = create<TranslationStore>((set) => ({
+  config: { provider: "google", targetLanguage: "en" },
+  setConfig: (config) => set({ config }),
+  translations: {},
+  translating: {},
+  setTranslation: (id, text) => set((s) => ({ translations: { ...s.translations, [id]: text } })),
+  removeTranslation: (id) =>
+    set((s) => {
+      const { [id]: _, ...rest } = s.translations;
+      return { translations: rest };
+    }),
+  setTranslating: (id, val) => set((s) => ({ translating: { ...s.translating, [id]: val } })),
+  clearAll: () => set({ translations: {}, translating: {} }),
+  seedFromMessages: (messages) =>
+    set((s) => {
+      const seeded: Record<string, string> = {};
+      for (const msg of messages) {
+        if (!msg.extra) continue;
+        try {
+          const extra = typeof msg.extra === "string" ? JSON.parse(msg.extra) : msg.extra;
+          if (extra.translation && typeof extra.translation === "string") {
+            seeded[msg.id] = extra.translation;
+          }
+        } catch {
+          // Skip messages with malformed extra JSON
+        }
+      }
+      // Merge with existing (in-flight translations win over seeded)
+      return { translations: { ...seeded, ...s.translations } };
+    }),
+}));


### PR DESCRIPTION
## Why
The client build currently emits a Vite warning because the translation module is imported both statically and dynamically. That prevents Vite from cleanly splitting the imperative input-translation path into its own async chunk and makes the loading boundary around translation behavior harder to reason about.

This PR is intentionally small and low-risk. It is the first slice in a broader optimization pass, and it only changes module boundaries around translation state and helper loading.

## What Changed
- moved translation Zustand state into a dedicated lightweight store module
- kept the interactive message translation hook focused on UI usage
- moved the imperative input-translation helper into its own tiny async module
- updated chat input and conversation input to lazy-load only the imperative helper
- updated generation cleanup and chat area code to import the lightweight store directly

## Why This Shape
- removes the current mixed static/dynamic import warning from the client build
- preserves existing behavior while making the async translation path explicit
- keeps the always-loaded translation state tiny and predictable
- creates a cleaner foundation for later client bundle work without mixing in unrelated changes

## Review Guidance
1. Check that translation behavior is unchanged in message rendering and auto-translate flows.
2. Check that input translation still works in both chat input components.
3. Confirm the build no longer reports the previous mixed-import Vite warning.

## Validation
- pnpm --filter @marinara-engine/client build

## Follow-ups
This is PR 1 of the optimization train. The next slices are planned as:
- trim the large GameSurface chunk by lazy-loading secondary overlays
- decompose the largest UI monoliths like ChatSettingsDrawer and SettingsPanel
- extract the server generation pipeline into smaller route/domain modules
- address bundled server asset weight and Docker/build-context cost separately