### PR TITLE
Add optional Timezone env for docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
     environment:
       - NODE_ENV=production
       - DATA_DIR=/app/data
+      # Set Timezone for Chat Schedules
+      # - TZ=Etc/UTC
     restart: unless-stopped
 
 volumes:


### PR DESCRIPTION
## Why this change

Makes it clear during docker compose deployment that TZ needs to be set for the schedules to work.

## What changed

- Add Optional TZ field in docker compose

## Validation

- [ ] `pnpm check`
- [x] Manual verification completed (describe below)

### Manual verification notes

- Schedules were not properly being followed without flag
- Once set, reran docker compose and schedules were being followed correctly

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

N/A