### PR TITLE
Fix {{user}} / {{char}} macro substitution in Game Mode

### DIFF
--- a/packages/client/src/components/game/GameNarration.tsx
+++ b/packages/client/src/components/game/GameNarration.tsx
@@ -450,6 +450,23 @@ export function GameNarration({
       }
     }
 
+    // Resolve display macros ({{user}}, {{char}}) on every segment's content so
+    // downstream renderers (formatNarration / animateTextHtml) receive the
+    // already-substituted text. Mirrors ChatMessage.tsx display-time logic.
+    const userName = personaInfo?.name || "You";
+    const fallbackCharName = (() => {
+      if (!characterMap || characterMap.size === 0) return null;
+      const first = characterMap.values().next().value;
+      return first?.name ?? null;
+    })();
+    for (let i = 0; i < result.length; i++) {
+      const seg = result[i]!;
+      const charName = seg.speaker ?? fallbackCharName;
+      let content = seg.content.replaceAll("{{user}}", userName);
+      if (charName) content = content.replaceAll("{{char}}", charName);
+      if (content !== seg.content) result[i] = { ...seg, content };
+    }
+
     segmentOriginalIndices.current = origIndices;
     segmentEditInfoRef.current = editInfos;
     partySegStartRef.current = partyStart;
@@ -464,6 +481,7 @@ export function GameNarration({
     partyChatInput,
     partyChatMessageId,
     segmentEdits,
+    characterMap,
   ]);
 
   // Clamp activeIndex when segments shrink (e.g. new party chat clears old dialogue)
@@ -480,6 +498,13 @@ export function GameNarration({
   const sideLineMap = useMemo(() => {
     const map = new Map<number, PartyDialogueLine[]>();
 
+    const userName = personaInfo?.name || "You";
+    const subMacros = (text: string, charName: string | null): string => {
+      let out = text.replaceAll("{{user}}", userName);
+      if (charName) out = out.replaceAll("{{char}}", charName);
+      return out;
+    };
+
     // 1. Collect inline side/extra from GM narration
     if (latestAssistant) {
       const allSegs = parseNarrationSegments(latestAssistant, speakerColors);
@@ -493,7 +518,7 @@ export function GameNarration({
           arr.push({
             character: seg.speaker ?? "",
             type: seg.partyType,
-            content: seg.content,
+            content: subMacros(seg.content, seg.speaker ?? null),
             expression: seg.sprite,
             target: seg.whisperTarget,
           });
@@ -519,7 +544,7 @@ export function GameNarration({
       for (const line of partyDialogue) {
         if (line.type === "side" || line.type === "extra") {
           const arr = map.get(lastPartySegIdx) ?? [];
-          arr.push(line);
+          arr.push({ ...line, content: subMacros(line.content, line.character) });
           map.set(lastPartySegIdx, arr);
         } else {
           for (let i = partySegCursor; i < segments.length; i++) {
@@ -534,7 +559,7 @@ export function GameNarration({
     }
 
     return map;
-  }, [latestAssistant, speakerColors, partyDialogue, segments]);
+  }, [latestAssistant, speakerColors, partyDialogue, segments, personaInfo]);
 
   const active = segments[activeIndex] ?? null;
 


### PR DESCRIPTION
## Summary

In Game Mode, `{{user}}` and `{{char}}` macros appear literally in the rendered narration instead of resolving to the active persona/character.

## Root cause

`GameNarration.tsx` is the rendering chokepoint for Game Mode narration and player-action segments, but it never runs display-time macro replacement. The chat path handles this in `ChatMessage.tsx` (around line 650, `text.replaceAll(\"{{user}}\", userName)`), and `GameNarration.tsx` does not call into that path. The server-side `resolveMacros` engine doesn't catch it either, since Game Mode replaces the system prompt entirely with `buildGmSystemPrompt(gmCtx)` (in `generate.routes.ts`), whose output never goes through `resolveMacros`. Net effect: `{{user}}` / `{{char}}` survive end-to-end and render verbatim in the UI.

This is a missing feature, not a regression — Game Mode shipped without macro display-substitution from v1.5.0 onward.

## Fix

Apply the substitution at segment-build time inside the `segments` and `sideLineMap` useMemos in `GameNarration.tsx`. Doing it there (rather than inside `formatNarration`) means every downstream render path — `formatNarration`, `animateTextHtml`, side-line overlays — receives already-resolved text without changing the renderer's signature.

- `{{user}}` → `personaInfo.name` (fallback `"You"`), matching `ChatMessage.tsx`.
- `{{char}}` → `seg.speaker` when present, otherwise the first character in `characterMap`. Left literal if neither is available.