### PR TITLE
Fix Game Mode new scene opening mid-scene instead of at segment 0

### DIFF
--- a/packages/client/src/components/game/GameNarration.tsx
+++ b/packages/client/src/components/game/GameNarration.tsx
@@ -815,6 +815,10 @@ export function GameNarration({
     }
     setActiveIndex(playerSegmentOffset);
     setVisibleChars(getSegmentStartVisibleChars(playerSegmentOffset));
+    // Clear the restore flag once we've advanced to a new message so the
+    // "segments grow after restore" effect below no longer snaps back to the
+    // stale saved index when segments rebuild for the new scene.
+    restoredRef.current = false;
     // For non-restore (new message), enable persistence and enter immediately
     segmentChangeReady.current = true;
     segmentEnterReady.current = true;


### PR DESCRIPTION
## Summary

In Game Mode, when a new GM response arrives, the narration opens on a later segment instead of the first line of the new scene — it visually jumps "into the middle" rather than starting at segment 0.

## Root cause

Two `useEffect`s in `GameNarration.tsx` cooperate to produce the jump:

**Effect A — main new-message handler** (around line 789): on `latestAssistant.id` change, the `isRestored` branch (line 799) sets `activeIndex` to the saved segment index and flips `restoredRef.current = true`. On *subsequent* new scenes it correctly falls through to the non-restore branch (line 816) and sets `activeIndex = playerSegmentOffset` — but it never clears `restoredRef.current` back to `false`.

**Effect B — "segments grow after restore" handler** (around line 833):

```tsx
useEffect(() => {
  if (!restoredRef.current || !latestAssistant?.id) return;
  if (restoredSegmentIndex == null || restoredSegmentIndex < 0) return;
  if (restoredSegmentIndex >= segments.length) return;
  if (activeIndex === restoredSegmentIndex) return;
  setActiveIndex(restoredSegmentIndex);
  setVisibleChars(effectDisplayLength(segments[restoredSegmentIndex]!.content));
}, [segments.length]);
```

This exists for the legitimate case where async party dialogue arrives after page reload and grows the segment list — then we want to snap to the exact saved index.

The failure sequence on a new scene:

1. Effect A runs, sets `activeIndex = 0`.
2. Segments array rebuilds for the new message → `segments.length` changes.
3. Effect B fires. `restoredRef.current` is still `true` from the initial restore. `restoredSegmentIndex` is the stale saved index from the previous scene (persisted via `GameSurface.handleSegmentChange` and re-read by the `restoredSegmentIndex` memo).
4. Effect B overwrites `activeIndex` with the stale value — the mid-scene open.

## Fix

Clear `restoredRef.current` at the end of Effect A's non-restore branch. Once we've advanced past the initial restored message, Effect B should no longer apply the saved index.

## Why this preserves the restore path

- **First-load restore + async party dialogue growth** — Effect A's `isRestored` branch still sets `restoredRef.current = true` and returns early; the new clear lives only in the non-restore branch, so Effect B still fires correctly when party segments arrive for the restored message.
- **New scene after restore** — Effect A now takes the non-restore branch, sets `activeIndex = 0`, and drops `restoredRef.current = false`. Effect B short-circuits at its first guard; no mid-scene jump.
- **Brand new chat (no restore at all)** — `restoredRef.current` was already `false`; writing `false` again is a no-op.

React guarantees effect execution order: Effect A is declared before Effect B, so the ref is already cleared by the time Effect B checks it in the same render cycle.
