### PR TITLE
Refactor Local AI runtime setup and simplify Local Model onboarding

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -54,13 +54,9 @@ export function App() {
   const setShowDownloadModal = useSidecarStore((s) => s.setShowDownloadModal);
   const fetchSidecarStatus = useSidecarStore((s) => s.fetchStatus);
 
-  // Fetch sidecar status on mount and prompt if first visit
+  // Fetch sidecar status on mount so the Local AI card is populated when opened later.
   useEffect(() => {
-    fetchSidecarStatus().then(() => {
-      if (!useSidecarStore.getState().hasBeenPrompted) {
-        setShowDownloadModal(true);
-      }
-    });
+    void fetchSidecarStatus();
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Apply theme + font size to the document root whenever they change

--- a/packages/client/src/components/modals/ModelDownloadModal.tsx
+++ b/packages/client/src/components/modals/ModelDownloadModal.tsx
@@ -7,8 +7,8 @@
 // ──────────────────────────────────────────────
 
 import { useEffect, useState } from "react";
-import { BrainCircuit, Check, Download, HardDrive, Loader2, MessageSquare, Search, Server, X, Zap } from "lucide-react";
-import type { SidecarBackend, SidecarQuantization } from "@marinara-engine/shared";
+import { BrainCircuit, Check, ChevronDown, ChevronUp, Download, HardDrive, Loader2, MessageSquare, Search, Server, Settings2, X, Zap } from "lucide-react";
+import type { SidecarBackend, SidecarQuantization, SidecarRuntimePreference } from "@marinara-engine/shared";
 import { Modal } from "../ui/Modal.js";
 import { useSidecarStore } from "../../stores/sidecar.store.js";
 
@@ -38,6 +38,61 @@ function formatQuantizationLabel(quantization: SidecarQuantization | null, backe
 function formatRuntimeVariantLabel(variant: string | null): string | null {
   if (!variant) return null;
   return variant.replace(/-/g, " ");
+}
+
+function formatRuntimePreferenceLabel(preference: SidecarRuntimePreference): string {
+  switch (preference) {
+    case "auto":
+      return "Auto detect";
+    case "nvidia":
+      return "NVIDIA GPU (CUDA)";
+    case "amd":
+      return "AMD GPU";
+    case "intel":
+      return "Intel GPU";
+    case "vulkan":
+      return "Vulkan GPU";
+    case "cpu":
+      return "CPU only";
+    case "system":
+      return "System llama-server";
+    default:
+      return preference;
+  }
+}
+
+function describeGpuLayers(gpuLayers: number): string {
+  if (gpuLayers === -1) return "Auto offload";
+  if (gpuLayers === 0) return "CPU only";
+  return `${gpuLayers} GPU layers`;
+}
+
+function getRuntimePreferenceOptions(platform: string, arch: string): SidecarRuntimePreference[] {
+  if (platform === "win32" && arch === "x64") {
+    return ["auto", "nvidia", "amd", "intel", "vulkan", "cpu", "system"];
+  }
+
+  if (platform === "linux" && arch === "x64") {
+    return ["auto", "nvidia", "amd", "intel", "vulkan", "cpu", "system"];
+  }
+
+  if (platform === "linux" && arch === "arm64") {
+    return ["auto", "vulkan", "cpu", "system"];
+  }
+
+  if (platform === "win32" && arch === "arm64") {
+    return ["auto", "cpu", "system"];
+  }
+
+  if (platform === "darwin" && arch === "x64") {
+    return ["auto", "cpu", "system"];
+  }
+
+  if (platform === "android") {
+    return ["auto", "cpu"];
+  }
+
+  return ["auto", "cpu", "system"];
 }
 
 function ResponseBlock({ label, value }: { label: string; value: string }) {
@@ -75,6 +130,7 @@ export function ModelDownloadModal({ open, onClose }: Props) {
     cancelDownload,
     unloadModel,
     restartRuntime,
+    installRuntime,
     sendTestMessage,
     testMessagePending,
     testMessageResult,
@@ -89,6 +145,11 @@ export function ModelDownloadModal({ open, onClose }: Props) {
   const [selectedQuant, setSelectedQuant] = useState<SidecarQuantization>("q8_0");
   const [repoInput, setRepoInput] = useState(config.customModelRepo ?? "");
   const [selectedCustomPath, setSelectedCustomPath] = useState("");
+  const [showRuntimeSettings, setShowRuntimeSettings] = useState(false);
+  const [gpuLayersInput, setGpuLayersInput] = useState(config.gpuLayers > 0 ? String(config.gpuLayers) : "");
+  const [gpuLayersModeDraft, setGpuLayersModeDraft] = useState<"auto" | "cpu" | "custom">(
+    config.gpuLayers === -1 ? "auto" : config.gpuLayers === 0 ? "cpu" : "custom",
+  );
 
   const activeBackend = runtime.backend ?? config.backend;
   const isSystemRuntime = runtime.source === "system";
@@ -107,6 +168,12 @@ export function ModelDownloadModal({ open, onClose }: Props) {
     (status === "starting_server" || status === "downloaded");
   const isSetupBusy = isDownloading || status === "downloading_runtime" || isPreparingServer;
   const canFinish = status === "ready" && inferenceReady;
+  const runtimePreferenceOptions = getRuntimePreferenceOptions(platform, arch);
+  const gpuLayersMode = gpuLayersModeDraft;
+  const quickRuntimeSummary =
+    activeBackend === "mlx"
+      ? "MLX runtime"
+      : `${formatRuntimePreferenceLabel(config.runtimePreference)} • ${describeGpuLayers(config.gpuLayers)}`;
 
   useEffect(() => {
     if (!open) {
@@ -133,6 +200,17 @@ export function ModelDownloadModal({ open, onClose }: Props) {
       setSelectedCustomPath(customModels[0]!.path);
     }
   }, [customModels, selectedCustomPath]);
+
+  useEffect(() => {
+    setGpuLayersInput(config.gpuLayers > 0 ? String(config.gpuLayers) : "");
+    setGpuLayersModeDraft(config.gpuLayers === -1 ? "auto" : config.gpuLayers === 0 ? "cpu" : "custom");
+  }, [config.gpuLayers]);
+
+  useEffect(() => {
+    if (status === "server_error" || testMessageResult) {
+      setShowRuntimeSettings(true);
+    }
+  }, [status, testMessageResult]);
 
   const progress = downloadProgress;
   const progressPercent = progress && progress.total > 0 ? Math.round((progress.downloaded / progress.total) * 100) : 0;
@@ -195,6 +273,37 @@ export function ModelDownloadModal({ open, onClose }: Props) {
     onClose();
   };
 
+  const handleRuntimePreferenceChange = (preference: SidecarRuntimePreference) => {
+    void updateConfig({ runtimePreference: preference });
+  };
+
+  const handleGpuLayersModeChange = (mode: "auto" | "cpu" | "custom") => {
+    setGpuLayersModeDraft(mode);
+
+    if (mode === "auto") {
+      void updateConfig({ gpuLayers: -1 });
+      return;
+    }
+
+    if (mode === "cpu") {
+      void updateConfig({ gpuLayers: 0 });
+      return;
+    }
+
+    if (config.gpuLayers <= 0) {
+      setGpuLayersInput("999");
+    }
+  };
+
+  const handleApplyCustomGpuLayers = () => {
+    const parsed = Number.parseInt(gpuLayersInput, 10);
+    if (!Number.isFinite(parsed) || parsed < 1 || parsed > 1024) {
+      return;
+    }
+    setGpuLayersModeDraft("custom");
+    void updateConfig({ gpuLayers: parsed });
+  };
+
   const handleCancelSetup = () => {
     if (isPreparingServer) {
       void unloadModel();
@@ -218,8 +327,8 @@ export function ModelDownloadModal({ open, onClose }: Props) {
             </p>
             <p className="mt-1.5 text-xs text-[var(--muted-foreground)]/70">
               {isAppleSilicon
-                ? "On Apple Silicon Macs, curated Gemma presets use MLX-native models. Marinara downloads its own private uv bootstrap automatically and keeps the MLX runtime inside its sidecar folder. Custom HuggingFace models on this path must also be MLX-native repos."
-                : "Runtime downloads are automatic per platform. You can use the curated Gemma 4 presets or any GGUF hosted on HuggingFace."}
+                ? "Set up the MLX runtime first if you want Marinara to keep it private and isolated, then choose either a curated Gemma preset or an MLX-native HuggingFace repo."
+                : "Set up the runtime first, then choose either a curated Gemma preset or any GGUF from HuggingFace. Runtime device selection lives inside Runtime Settings."}
             </p>
           </div>
         </div>
@@ -245,137 +354,312 @@ export function ModelDownloadModal({ open, onClose }: Props) {
         )}
 
         <div className="rounded-xl border border-[var(--border)] bg-[var(--card)]/50 p-3">
-          <div className="flex items-center gap-2 text-sm font-medium">
-            <Server size="0.95rem" className="text-purple-300" />
-            Runtime
+          <div className="flex items-start justify-between gap-3 max-sm:flex-col">
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2 text-sm font-medium">
+                <Server size="0.95rem" className="text-purple-300" />
+                Runtime
+              </div>
+              <div className="mt-1 text-xs text-[var(--muted-foreground)]">
+                <span>Status: {runtimeStatusLabel}</span>
+                <span> • </span>
+                <span>{quickRuntimeSummary}</span>
+              </div>
+              <div className="mt-1 text-xs text-[var(--muted-foreground)]/75">
+                {runtime.installed
+                  ? isSystemRuntime
+                    ? `Using system llama-server${runtime.systemPath ? `: ${runtime.systemPath}` : ""}`
+                    : runtime.variant
+                      ? `Installed runtime: ${formatRuntimeVariantLabel(runtime.variant)}`
+                      : "Runtime installed and ready to use."
+                  : hasModel
+                    ? "Your model is ready, but the runtime has not been installed yet."
+                    : "Install and configure the runtime here, then choose a model below."}
+              </div>
+              {status === "server_error" && (
+                <div className="mt-2 text-xs text-amber-200">Runtime startup failed. Open Runtime Settings for details.</div>
+              )}
+            </div>
+            <button
+              onClick={() => setShowRuntimeSettings((current) => !current)}
+              className="flex items-center justify-center gap-2 rounded-xl border border-[var(--border)] px-3 py-2 text-sm text-[var(--foreground)] transition-colors hover:bg-[var(--secondary)]"
+            >
+              <Settings2 size="0.875rem" />
+              Runtime Settings
+              {showRuntimeSettings ? <ChevronUp size="0.875rem" /> : <ChevronDown size="0.875rem" />}
+            </button>
           </div>
-          <div className="mt-2 flex flex-col gap-1 text-xs text-[var(--muted-foreground)]">
-            <span>Status: {runtimeStatusLabel}</span>
-            {isSetupBusy && (
-              <span>
-                Setup in progress. Marinara is still preparing the runtime or starting the local sidecar server.
-              </span>
-            )}
-            {runtime.installed && (
-              <span>
-                Runtime build: {runtime.build} • {runtime.variant}
-              </span>
-            )}
-            {isSystemRuntime && runtime.systemPath && <span>Using system llama-server: {runtime.systemPath}</span>}
-            {status === "server_error" && logPath && <span>Log: {logPath}</span>}
-          </div>
+
           {!isSetupBusy && (
             <div className="mt-3 flex flex-wrap gap-2">
+              {!runtime.installed ? (
+                <button
+                  onClick={() => void installRuntime()}
+                  className="flex items-center justify-center gap-2 rounded-xl bg-purple-500/15 px-4 py-2 text-sm font-medium text-purple-300 transition-colors hover:bg-purple-500/25"
+                >
+                  <Download size="0.875rem" />
+                  {activeBackend === "mlx" ? "Install MLX Runtime" : "Install Runtime"}
+                </button>
+              ) : (
+                <>
+                  {hasModel && (
+                    <button
+                      onClick={() => void restartRuntime()}
+                      className="flex items-center justify-center gap-2 rounded-xl bg-purple-500/15 px-4 py-2 text-sm font-medium text-purple-300 transition-colors hover:bg-purple-500/25"
+                    >
+                      <Loader2 size="0.875rem" />
+                      {status === "server_error" ? "Retry Startup" : inferenceReady ? "Restart Runtime" : "Start Runtime"}
+                    </button>
+                  )}
+                  {canReinstallRuntime && (
+                    <button
+                      onClick={() => void reinstallRuntime()}
+                      className="flex items-center justify-center gap-2 rounded-xl border border-[var(--border)] px-4 py-2 text-sm text-[var(--foreground)] transition-colors hover:bg-[var(--secondary)]"
+                    >
+                      <Download size="0.875rem" />
+                      Reinstall Runtime
+                    </button>
+                  )}
+                </>
+              )}
               <button
-                onClick={() => void sendTestMessage()}
-                disabled={!hasModel || testMessagePending}
+                onClick={() => {
+                  setShowRuntimeSettings(true);
+                  void sendTestMessage();
+                }}
+                disabled={!hasModel || !runtime.installed || testMessagePending}
                 className="flex items-center justify-center gap-2 rounded-xl border border-emerald-500/20 bg-emerald-500/10 px-4 py-2 text-sm font-medium text-emerald-300 transition-colors hover:bg-emerald-500/20 disabled:cursor-not-allowed disabled:opacity-50"
               >
                 {testMessagePending ? <Loader2 size="0.875rem" className="animate-spin" /> : <MessageSquare size="0.875rem" />}
                 Send Test Message
               </button>
-              {!hasModel && (
-                <span className="self-center text-xs text-[var(--muted-foreground)]/70">
-                  Download or choose a model first to test the local runtime.
-                </span>
+            </div>
+          )}
+
+          {showRuntimeSettings && (
+            <div className="mt-4 flex flex-col gap-4 rounded-xl border border-[var(--border)]/80 bg-[var(--secondary)]/40 p-4">
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="flex flex-col gap-2">
+                  <div className="text-xs font-medium uppercase tracking-wider text-[var(--muted-foreground)]/60">
+                    Runtime Target
+                  </div>
+                  {activeBackend === "mlx" ? (
+                    <div className="rounded-xl border border-[var(--border)] bg-[var(--card)]/60 px-3 py-2 text-sm text-[var(--muted-foreground)]/75">
+                      MLX chooses the Apple Silicon accelerator path automatically.
+                    </div>
+                  ) : (
+                    <>
+                      <div className="relative">
+                        <select
+                          value={config.runtimePreference}
+                          onChange={(event) => handleRuntimePreferenceChange(event.target.value as SidecarRuntimePreference)}
+                          className="w-full appearance-none rounded-xl border border-[var(--border)] bg-[var(--card)]/80 px-3 py-2 pr-10 text-sm text-[var(--foreground)] outline-none transition-colors focus:border-purple-400/50 focus:ring-1 focus:ring-purple-400/20"
+                        >
+                          {runtimePreferenceOptions.map((option) => (
+                            <option key={option} value={option}>
+                              {formatRuntimePreferenceLabel(option)}
+                            </option>
+                          ))}
+                        </select>
+                        <ChevronDown
+                          size="0.95rem"
+                          className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-[var(--muted-foreground)]/70"
+                        />
+                      </div>
+                      <div className="text-xs text-[var(--muted-foreground)]/70">
+                        Pick the GPU family you actually want Marinara to target so it does not guess the wrong adapter.
+                      </div>
+                    </>
+                  )}
+                </div>
+
+                <div className="flex flex-col gap-2">
+                  <div className="text-xs font-medium uppercase tracking-wider text-[var(--muted-foreground)]/60">
+                    GPU Offload
+                  </div>
+                  {activeBackend === "mlx" ? (
+                    <div className="rounded-xl border border-[var(--border)] bg-[var(--card)]/60 px-3 py-2 text-sm text-[var(--muted-foreground)]/75">
+                      MLX manages GPU offload automatically.
+                    </div>
+                  ) : (
+                    <>
+                      <div className="relative">
+                        <select
+                          value={gpuLayersMode}
+                          onChange={(event) => handleGpuLayersModeChange(event.target.value as "auto" | "cpu" | "custom")}
+                          className="w-full appearance-none rounded-xl border border-[var(--border)] bg-[var(--card)]/80 px-3 py-2 pr-10 text-sm text-[var(--foreground)] outline-none transition-colors focus:border-purple-400/50 focus:ring-1 focus:ring-purple-400/20"
+                        >
+                          <option value="auto">Auto offload</option>
+                          <option value="cpu">CPU only</option>
+                          <option value="custom">Custom GPU layers</option>
+                        </select>
+                        <ChevronDown
+                          size="0.95rem"
+                          className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-[var(--muted-foreground)]/70"
+                        />
+                      </div>
+                      {gpuLayersMode === "custom" && (
+                        <div className="flex items-center justify-end gap-2">
+                          <input
+                            value={gpuLayersInput}
+                            onChange={(event) => setGpuLayersInput(event.target.value.replace(/[^\d]/g, ""))}
+                            onKeyDown={(event) => {
+                              if (event.key === "Enter") {
+                                handleApplyCustomGpuLayers();
+                              }
+                            }}
+                            placeholder="1-1024"
+                            inputMode="numeric"
+                            className="w-24 shrink-0 rounded-xl border border-[var(--border)] bg-[var(--card)]/80 px-3 py-2 text-center text-sm text-[var(--foreground)] outline-none transition-colors focus:border-purple-400/50 focus:ring-1 focus:ring-purple-400/20"
+                          />
+                          <button
+                            onClick={handleApplyCustomGpuLayers}
+                            className="flex shrink-0 items-center justify-center rounded-xl border border-[var(--border)] bg-[var(--card)]/70 px-4 py-2 text-sm text-[var(--foreground)] transition-colors hover:bg-[var(--card)]"
+                          >
+                            Apply
+                          </button>
+                        </div>
+                      )}
+                      <div className="text-xs text-[var(--muted-foreground)]/70">
+                        Auto tries max offload first, CPU only disables GPU use, and custom lets you cap how many layers go to the GPU.
+                      </div>
+                    </>
+                  )}
+                </div>
+              </div>
+
+              {runtime.installed && (
+                <div className="flex flex-col gap-1 rounded-xl border border-[var(--border)] bg-[var(--card)]/50 p-3 text-xs text-[var(--muted-foreground)]/75">
+                  <span>Status: {runtimeStatusLabel}</span>
+                  {runtime.build && runtime.variant && <span>Runtime build: {runtime.build} • {runtime.variant}</span>}
+                  {isSystemRuntime && runtime.systemPath && <span>Using system llama-server: {runtime.systemPath}</span>}
+                </div>
+              )}
+
+              {status === "server_error" && (
+                <div className="rounded-xl border border-amber-500/25 bg-amber-500/5 p-4">
+                  <div className="text-sm font-medium text-amber-200">Local runtime failed to start</div>
+                  <div className="mt-1 text-xs text-[var(--muted-foreground)]/85">
+                    Marinara will keep working without the local model until you retry or change these settings.
+                  </div>
+                  <div className="mt-3 flex flex-col gap-1 text-xs text-[var(--muted-foreground)]/75">
+                    {failedRuntimeVariant && <span>Runtime: {formatRuntimeVariantLabel(failedRuntimeVariant)}</span>}
+                    {startupError && <span>Error: {startupError}</span>}
+                    {logPath && <span>Log: {logPath}</span>}
+                  </div>
+                  <div className="mt-3 flex gap-2 max-sm:flex-col">
+                    <button
+                      onClick={() => void restartRuntime()}
+                      className="flex items-center justify-center gap-2 rounded-xl bg-amber-500/15 px-4 py-2.5 text-sm font-medium text-amber-200 transition-colors hover:bg-amber-500/25"
+                    >
+                      <Loader2 size="0.875rem" />
+                      Retry Startup
+                    </button>
+                    {canReinstallRuntime && (
+                      <button
+                        onClick={() => void reinstallRuntime()}
+                        className="flex items-center justify-center gap-2 rounded-xl border border-amber-500/20 px-4 py-2.5 text-sm text-amber-100 transition-colors hover:bg-amber-500/10"
+                      >
+                        <Download size="0.875rem" />
+                        Reinstall Runtime
+                      </button>
+                    )}
+                    <button
+                      onClick={() => void updateConfig({ useForTrackers: false, useForGameScene: false })}
+                      className="flex items-center justify-center gap-2 rounded-xl border border-[var(--border)] px-4 py-2.5 text-sm text-[var(--muted-foreground)] transition-colors hover:bg-[var(--secondary)]"
+                    >
+                      Continue Without Local AI
+                    </button>
+                  </div>
+                </div>
+              )}
+
+              {testMessageResult && (
+                <div
+                  className={`rounded-xl border p-4 ${
+                    testMessageResult.success
+                      ? "border-emerald-500/25 bg-emerald-500/5"
+                      : "border-red-500/25 bg-red-500/5"
+                  }`}
+                >
+                  <div className={`text-sm font-medium ${testMessageResult.success ? "text-emerald-300" : "text-red-300"}`}>
+                    Local Test Message {testMessageResult.success ? "Succeeded" : "Failed"}
+                  </div>
+                  <div className="mt-1 text-xs text-[var(--muted-foreground)]/75">{testMessageResult.latencyMs}ms</div>
+                  {testMessageResult.success ? (
+                    <div className="mt-3 flex flex-col gap-3">
+                      {testMessageResult.nonce && (
+                        <div className="text-xs text-[var(--muted-foreground)]/75">
+                          Verification token: <span className="font-mono text-[var(--foreground)]">{testMessageResult.nonce}</span>
+                          {testMessageResult.nonceVerified ? " • echoed by model" : " • not echoed"}
+                        </div>
+                      )}
+                      {(testMessageResult.usage || testMessageResult.timings) && (
+                        <div className="text-xs text-[var(--muted-foreground)]/75">
+                          {testMessageResult.usage && (
+                            <span>
+                              Usage: prompt {testMessageResult.usage.promptTokens ?? "?"}, completion{" "}
+                              {testMessageResult.usage.completionTokens ?? "?"}, total {testMessageResult.usage.totalTokens ?? "?"}
+                            </span>
+                          )}
+                          {testMessageResult.usage && testMessageResult.timings && <span> • </span>}
+                          {testMessageResult.timings && (
+                            <span>
+                              Timings: prompt {testMessageResult.timings.promptMs ?? "?"}ms / gen{" "}
+                              {testMessageResult.timings.predictedMs ?? "?"}ms
+                            </span>
+                          )}
+                        </div>
+                      )}
+                      {!!testMessageResult.messageContent && <ResponseBlock label="Message Content" value={testMessageResult.messageContent} />}
+                      {!!testMessageResult.reasoningContent && (
+                        <ResponseBlock label="Reasoning Content" value={testMessageResult.reasoningContent} />
+                      )}
+                      {!testMessageResult.messageContent && !testMessageResult.reasoningContent && (
+                        <ResponseBlock label="Response" value={testMessageResult.response} />
+                      )}
+                    </div>
+                  ) : (
+                    <div className="mt-3 flex flex-col gap-1 text-xs text-red-200/90">
+                      <span>{testMessageResult.error || "No response received from the local runtime."}</span>
+                      {testMessageResult.failedRuntimeVariant && (
+                        <span>Runtime: {formatRuntimeVariantLabel(testMessageResult.failedRuntimeVariant)}</span>
+                      )}
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {runtimeDiagnostics && (
+                <div className="rounded-xl border border-[var(--border)] bg-[var(--card)]/50 p-3">
+                  <div className="text-xs font-medium uppercase tracking-wider text-[var(--muted-foreground)]/60">Diagnostics</div>
+                  <div className="mt-2 flex flex-col gap-1 text-xs text-[var(--muted-foreground)]/75">
+                    {runtimeDiagnostics.gpuVendors.length > 0 && (
+                      <span>Detected GPU vendors: {runtimeDiagnostics.gpuVendors.join(", ")}</span>
+                    )}
+                    <span>
+                      Backend hints:
+                      {runtimeDiagnostics.preferCuda ? " CUDA" : ""}
+                      {runtimeDiagnostics.preferHip ? " HIP" : ""}
+                      {runtimeDiagnostics.preferRocm ? " ROCm" : ""}
+                      {runtimeDiagnostics.preferSycl ? " SYCL" : ""}
+                      {runtimeDiagnostics.preferVulkan ? " Vulkan" : ""}
+                      {!runtimeDiagnostics.preferCuda &&
+                      !runtimeDiagnostics.preferHip &&
+                      !runtimeDiagnostics.preferRocm &&
+                      !runtimeDiagnostics.preferSycl &&
+                      !runtimeDiagnostics.preferVulkan
+                        ? " none"
+                        : ""}
+                    </span>
+                    {runtimeDiagnostics.systemLlamaPath && <span>System llama-server: {runtimeDiagnostics.systemLlamaPath}</span>}
+                    {runtimeDiagnostics.launchCommand && <span>Last launch command: {runtimeDiagnostics.launchCommand}</span>}
+                  </div>
+                </div>
               )}
             </div>
           )}
         </div>
-
-        {testMessageResult && (
-          <div
-            className={`rounded-xl border p-4 ${
-              testMessageResult.success
-                ? "border-emerald-500/25 bg-emerald-500/5"
-                : "border-red-500/25 bg-red-500/5"
-            }`}
-          >
-            <div className={`text-sm font-medium ${testMessageResult.success ? "text-emerald-300" : "text-red-300"}`}>
-              Local Test Message {testMessageResult.success ? "Succeeded" : "Failed"}
-            </div>
-            <div className="mt-1 text-xs text-[var(--muted-foreground)]/75">{testMessageResult.latencyMs}ms</div>
-            {testMessageResult.success ? (
-              <div className="mt-3 flex flex-col gap-3">
-                {testMessageResult.nonce && (
-                  <div className="text-xs text-[var(--muted-foreground)]/75">
-                    Verification token: <span className="font-mono text-[var(--foreground)]">{testMessageResult.nonce}</span>
-                    {testMessageResult.nonceVerified ? " • echoed by model" : " • not echoed"}
-                  </div>
-                )}
-                {(testMessageResult.usage || testMessageResult.timings) && (
-                  <div className="text-xs text-[var(--muted-foreground)]/75">
-                    {testMessageResult.usage && (
-                      <span>
-                        Usage: prompt {testMessageResult.usage.promptTokens ?? "?"}, completion{" "}
-                        {testMessageResult.usage.completionTokens ?? "?"}, total {testMessageResult.usage.totalTokens ?? "?"}
-                      </span>
-                    )}
-                    {testMessageResult.usage && testMessageResult.timings && <span> • </span>}
-                    {testMessageResult.timings && (
-                      <span>
-                        Timings: prompt {testMessageResult.timings.promptMs ?? "?"}ms / gen {testMessageResult.timings.predictedMs ?? "?"}ms
-                      </span>
-                    )}
-                  </div>
-                )}
-                {!!testMessageResult.messageContent && <ResponseBlock label="Message Content" value={testMessageResult.messageContent} />}
-                {!!testMessageResult.reasoningContent && (
-                  <ResponseBlock label="Reasoning Content" value={testMessageResult.reasoningContent} />
-                )}
-                {!testMessageResult.messageContent && !testMessageResult.reasoningContent && (
-                  <ResponseBlock label="Response" value={testMessageResult.response} />
-                )}
-              </div>
-            ) : (
-              <div className="mt-3 flex flex-col gap-1 text-xs text-red-200/90">
-                <span>{testMessageResult.error || "No response received from the local runtime."}</span>
-                {testMessageResult.failedRuntimeVariant && (
-                  <span>Runtime: {formatRuntimeVariantLabel(testMessageResult.failedRuntimeVariant)}</span>
-                )}
-              </div>
-            )}
-          </div>
-        )}
-
-        {status === "server_error" && (
-          <div className="rounded-xl border border-amber-500/25 bg-amber-500/5 p-4">
-            <div className="text-sm font-medium text-amber-200">Local runtime failed to start</div>
-            <div className="mt-1 text-xs text-[var(--muted-foreground)]/85">
-              Marinara will keep working without the local model until you retry or change settings.
-            </div>
-            <div className="mt-3 flex flex-col gap-1 text-xs text-[var(--muted-foreground)]/75">
-              {failedRuntimeVariant && <span>Runtime: {formatRuntimeVariantLabel(failedRuntimeVariant)}</span>}
-              {startupError && <span>Error: {startupError}</span>}
-              <span>Open this panel to retry startup, switch models, or temporarily disable local helpers.</span>
-              {logPath && <span>Log: {logPath}</span>}
-            </div>
-            <div className="mt-3 flex gap-2 max-sm:flex-col">
-              <button
-                onClick={() => void restartRuntime()}
-                className="flex items-center justify-center gap-2 rounded-xl bg-amber-500/15 px-4 py-2.5 text-sm font-medium text-amber-200 transition-colors hover:bg-amber-500/25"
-              >
-                <Loader2 size="0.875rem" />
-                Retry Startup
-              </button>
-              {canReinstallRuntime && (
-                <button
-                  onClick={() => void reinstallRuntime()}
-                  className="flex items-center justify-center gap-2 rounded-xl border border-amber-500/20 px-4 py-2.5 text-sm text-amber-100 transition-colors hover:bg-amber-500/10"
-                >
-                  <Download size="0.875rem" />
-                  Reinstall Runtime
-                </button>
-              )}
-              <button
-                onClick={() => void updateConfig({ useForTrackers: false, useForGameScene: false })}
-                className="flex items-center justify-center gap-2 rounded-xl border border-[var(--border)] px-4 py-2.5 text-sm text-[var(--muted-foreground)] transition-colors hover:bg-[var(--secondary)]"
-              >
-                Continue Without Local AI
-              </button>
-            </div>
-          </div>
-        )}
 
         {isSetupBusy && (
           <div className="rounded-xl border border-purple-400/25 bg-purple-500/5 p-4">
@@ -604,34 +888,6 @@ export function ModelDownloadModal({ open, onClose }: Props) {
             </>
           )}
         </div>
-
-        {runtimeDiagnostics && (
-          <div className="rounded-xl border border-[var(--border)] bg-[var(--card)]/50 p-3">
-            <div className="text-xs font-medium uppercase tracking-wider text-[var(--muted-foreground)]/60">Diagnostics</div>
-            <div className="mt-2 flex flex-col gap-1 text-xs text-[var(--muted-foreground)]/75">
-              {runtimeDiagnostics.gpuVendors.length > 0 && (
-                <span>Detected GPU vendors: {runtimeDiagnostics.gpuVendors.join(", ")}</span>
-              )}
-              <span>
-                Backend hints:
-                {runtimeDiagnostics.preferCuda ? " CUDA" : ""}
-                {runtimeDiagnostics.preferHip ? " HIP" : ""}
-                {runtimeDiagnostics.preferRocm ? " ROCm" : ""}
-                {runtimeDiagnostics.preferSycl ? " SYCL" : ""}
-                {runtimeDiagnostics.preferVulkan ? " Vulkan" : ""}
-                {!runtimeDiagnostics.preferCuda &&
-                !runtimeDiagnostics.preferHip &&
-                !runtimeDiagnostics.preferRocm &&
-                !runtimeDiagnostics.preferSycl &&
-                !runtimeDiagnostics.preferVulkan
-                  ? " none"
-                  : ""}
-              </span>
-              {runtimeDiagnostics.systemLlamaPath && <span>System llama-server: {runtimeDiagnostics.systemLlamaPath}</span>}
-              {runtimeDiagnostics.launchCommand && <span>Last launch command: {runtimeDiagnostics.launchCommand}</span>}
-            </div>
-          </div>
-        )}
 
         {!hasModel && !isSetupBusy && (
           <div className="rounded-xl border border-[var(--border)] bg-[var(--card)]/50 p-3">

--- a/packages/client/src/components/onboarding/OnboardingTutorial.tsx
+++ b/packages/client/src/components/onboarding/OnboardingTutorial.tsx
@@ -4,6 +4,7 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { useUIStore } from "../../stores/ui.store";
 import { useChatStore } from "../../stores/chat.store";
+import { useSidecarStore } from "../../stores/sidecar.store";
 import { useCreateChat } from "../../hooks/use-chats";
 import { motion, AnimatePresence } from "framer-motion";
 import { ChevronRight, ArrowRightLeft } from "lucide-react";
@@ -72,6 +73,14 @@ const STEPS: TourStep[] = [
     title: "Set Up a Connection",
     body: "Before you start chatting, you'll need to connect an AI provider. Click the chain-link icon (🔗) in the top-right tab buttons, then add your API key for OpenAI, Anthropic, or another provider.",
     sprite: { src: "/sprites/mari/Mari_explaining.png" },
+  },
+  {
+    target: null,
+    title: "Optional: Local AI Model",
+    body: "If you want Marinara to run a helper model on your own device, open the Connections panel and use the Local Model card. From there you can open Local AI Model settings, install the runtime for your machine, and then choose a curated Gemma preset or your own local model.",
+    actionLabel: "Open Local Model",
+    actionKey: "local-model",
+    sprite: { src: "/sprites/mari/Mari_thinking.png" },
   },
   {
     target: null,
@@ -341,6 +350,8 @@ function OnboardingTutorialInner() {
   const openRightPanel = useUIStore((s) => s.openRightPanel);
   const setSettingsTab = useUIStore((s) => s.setSettingsTab);
   const setSidebarOpen = useUIStore((s) => s.setSidebarOpen);
+  const setShowDownloadModal = useSidecarStore((s) => s.setShowDownloadModal);
+  const fetchSidecarStatus = useSidecarStore((s) => s.fetchStatus);
 
   const createChat = useCreateChat();
 
@@ -479,9 +490,17 @@ function OnboardingTutorialInner() {
         setSettingsTab("import");
         // Jump to last step instead of finishing
         setStep(STEPS.length - 1);
+        return;
+      }
+
+      if (key === "local-model") {
+        openRightPanel("connections");
+        void fetchSidecarStatus();
+        setShowDownloadModal(true);
+        finish();
       }
     },
-    [openRightPanel, setSettingsTab],
+    [fetchSidecarStatus, finish, openRightPanel, setSettingsTab, setShowDownloadModal],
   );
 
   const next = useCallback(() => {

--- a/packages/client/src/components/panels/ConnectionsPanel.tsx
+++ b/packages/client/src/components/panels/ConnectionsPanel.tsx
@@ -23,8 +23,7 @@ import {
   X,
   Copy,
   BrainCircuit,
-  Download,
-  Trash,
+  Settings2,
 } from "lucide-react";
 import { cn } from "../../lib/utils";
 import { toast } from "sonner";
@@ -71,11 +70,9 @@ function SidecarCard() {
     failedRuntimeVariant,
     setShowDownloadModal,
     updateConfig,
-    deleteModel,
     fetchStatus,
   } = useSidecarStore();
   const isDownloaded = modelDownloaded;
-  const [confirmDelete, setConfirmDelete] = useState(false);
   const [assigningTrackers, setAssigningTrackers] = useState(false);
   const activeModelName = isDownloaded ? modelDisplayName : null;
   const backendLabel = config.backend === "mlx" ? "MLX" : "GGUF";
@@ -133,6 +130,11 @@ function SidecarCard() {
     }
   };
 
+  const openLocalModelSettings = () => {
+    void fetchStatus();
+    setShowDownloadModal(true);
+  };
+
   return (
     <div className="rounded-xl border border-purple-400/20 bg-gradient-to-br from-purple-500/5 to-fuchsia-500/5 p-3">
       <div className="flex items-center gap-2.5">
@@ -155,46 +157,13 @@ function SidecarCard() {
               : "Not downloaded"}
           </div>
         </div>
-        {isDownloaded ? (
-          confirmDelete ? (
-            <div className="flex items-center gap-1">
-              <button
-                onClick={() => setConfirmDelete(false)}
-                className="rounded-lg px-2 py-1 text-[0.625rem] text-[var(--muted-foreground)] transition-all hover:bg-[var(--secondary)]"
-              >
-                Cancel
-              </button>
-              <button
-                onClick={() => {
-                  deleteModel();
-                  setConfirmDelete(false);
-                }}
-                className="rounded-lg px-2 py-1 text-[0.625rem] font-medium text-[var(--destructive)] transition-all hover:bg-[var(--destructive)]/15"
-              >
-                Delete
-              </button>
-            </div>
-          ) : (
-            <button
-              onClick={() => setConfirmDelete(true)}
-              className="rounded-lg p-1.5 text-[var(--muted-foreground)] transition-all hover:bg-[var(--destructive)]/15 active:scale-90"
-              title="Delete model"
-            >
-              <Trash size="0.8125rem" className="text-[var(--destructive)]" />
-            </button>
-          )
-        ) : (
-          <button
-            onClick={() => {
-              fetchStatus();
-              setShowDownloadModal(true);
-            }}
-            className="rounded-lg p-1.5 text-purple-400 transition-all hover:bg-purple-400/15 active:scale-90"
-            title="Download model"
-          >
-            <Download size="0.8125rem" />
-          </button>
-        )}
+        <button
+          onClick={openLocalModelSettings}
+          className="rounded-lg p-1.5 text-purple-400 transition-all hover:bg-purple-400/15 active:scale-90"
+          title="Open local model settings"
+        >
+          <Settings2 size="0.8125rem" />
+        </button>
       </div>
       {/* Local model actions (only when model is downloaded) */}
       {isDownloaded && (
@@ -278,8 +247,7 @@ function SidecarCard() {
           )}
           <button
             onClick={() => {
-              fetchStatus();
-              setShowDownloadModal(true);
+              openLocalModelSettings();
             }}
             className="mt-2 rounded-lg bg-amber-500/15 px-2.5 py-1 text-[0.6875rem] font-medium text-amber-200 transition-colors hover:bg-amber-500/25"
           >

--- a/packages/client/src/stores/sidecar.store.ts
+++ b/packages/client/src/stores/sidecar.store.ts
@@ -74,10 +74,11 @@ interface SidecarState {
   deleteModel: () => Promise<void>;
   unloadModel: () => Promise<void>;
   restartRuntime: () => Promise<void>;
+  installRuntime: (reinstall?: boolean) => Promise<void>;
   sendTestMessage: () => Promise<void>;
   reinstallRuntime: () => Promise<void>;
   updateConfig: (
-    partial: Partial<Pick<SidecarConfig, "useForTrackers" | "useForGameScene" | "contextSize" | "gpuLayers">>,
+    partial: Partial<Pick<SidecarConfig, "useForTrackers" | "useForGameScene" | "contextSize" | "gpuLayers" | "runtimePreference">>,
   ) => Promise<void>;
   setShowDownloadModal: (open: boolean) => void;
   markPrompted: () => void;
@@ -94,12 +95,17 @@ function clearStatusPollTimer() {
   }
 }
 
-function shouldKeepPolling(state: Pick<SidecarState, "status" | "config" | "inferenceReady">): boolean {
+function shouldKeepPolling(state: Pick<SidecarState, "status" | "config" | "inferenceReady" | "runtime">): boolean {
   if (TRANSITIONAL_STATUSES.has(state.status)) {
     return true;
   }
 
-  if (state.status === "downloaded" && state.config.useForGameScene && !state.inferenceReady) {
+  if (
+    state.status === "downloaded" &&
+    state.runtime.installed &&
+    (state.config.useForGameScene || state.config.useForTrackers) &&
+    !state.inferenceReady
+  ) {
     return true;
   }
 
@@ -390,6 +396,39 @@ export const useSidecarStore = create<SidecarState>((set, get) => ({
     await get().fetchStatus();
   },
 
+  installRuntime: async (reinstall = false) => {
+    set({
+      status: "downloading_runtime",
+      startupError: null,
+      failedRuntimeVariant: null,
+      testMessageResult: null,
+      downloadProgress: {
+        phase: "runtime",
+        status: "downloading",
+        downloaded: 0,
+        total: 0,
+        speed: 0,
+        label: reinstall ? "Reinstalling local runtime" : "Installing local runtime",
+      },
+    });
+
+    try {
+      await consumeDownloadStream("/api/sidecar/runtime/install", reinstall ? { reinstall: true } : {}, set, get);
+    } catch (error) {
+      set({
+        downloadProgress: {
+          phase: "runtime",
+          status: "error",
+          downloaded: 0,
+          total: 0,
+          speed: 0,
+          error: error instanceof Error ? error.message : "Failed to install the local runtime",
+          label: reinstall ? "Reinstall local runtime" : "Install local runtime",
+        },
+      });
+    }
+  },
+
   sendTestMessage: async () => {
     set({
       testMessagePending: true,
@@ -421,38 +460,7 @@ export const useSidecarStore = create<SidecarState>((set, get) => ({
   },
 
   reinstallRuntime: async () => {
-    set({
-      status: "downloading_runtime",
-      startupError: null,
-      failedRuntimeVariant: null,
-      testMessageResult: null,
-      downloadProgress: {
-        phase: "runtime",
-        status: "downloading",
-        downloaded: 0,
-        total: 0,
-        speed: 0,
-        label: "Reinstalling local runtime",
-      },
-    });
-
-    try {
-      await api.post("/sidecar/reinstall");
-    } catch (error) {
-      set({
-        downloadProgress: {
-          phase: "runtime",
-          status: "error",
-          downloaded: 0,
-          total: 0,
-          speed: 0,
-          error: error instanceof Error ? error.message : "Failed to reinstall the local runtime",
-          label: "Reinstall local runtime",
-        },
-      });
-    }
-
-    await get().fetchStatus();
+    await get().installRuntime(true);
   },
 
   updateConfig: async (partial) => {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -8,6 +8,7 @@
     "dev": "tsx watch --ignore ./data --ignore ./node_modules --ignore ../../node_modules src/index.ts",
     "build": "tsc && node ./scripts/write-build-meta.mjs && node -e \"require('fs').cpSync('src/db/default-preset.json','dist/db/default-preset.json')\"",
     "start": "node dist/index.js",
+    "test": "tsx --test test/**/*.test.ts",
     "clean": "node -e \"const fs=require('fs');['dist','*.tsbuildinfo'].forEach(p=>{try{fs.rmSync(p,{recursive:true,force:true})}catch{}})\"",
     "lint": "tsc -b ../shared && tsc --noEmit",
     "db:generate": "drizzle-kit generate --config=drizzle.config.cts",

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -92,7 +92,7 @@ export async function buildApp(https?: { cert: Buffer; key: Buffer }) {
   await registerRoutes(app);
 
   // ── Sidecar bootstrap (background) ──
-  void sidecarProcessService.syncForCurrentConfig({ suppressKnownFailure: true }).catch((error) => {
+  void sidecarProcessService.syncForCurrentConfig({ suppressKnownFailure: true, allowRuntimeInstall: false }).catch((error) => {
     app.log.warn({ err: error }, "sidecar bootstrap failed");
   });
 

--- a/packages/server/src/db/seed-mari.ts
+++ b/packages/server/src/db/seed-mari.ts
@@ -170,7 +170,7 @@ Characters automatically know what's happening in their other chats. When the us
 
 ### Built-In Local Gemma Model
 - Marinara Engine also has an optional built-in local model: **Google Gemma 4 E2B**.
-- The user can download it from the **Local Model** card in the Connections panel or when the **Local AI Model** download modal appears.
+- The user can set it up from the **Local Model** card in the Connections panel or from the onboarding tutorial's **Open Local Model** step.
 - It runs locally on the user's device, needs no API key, and is mainly used so Marinara can handle tracker agents and game scene analysis without spending the main chat model's tokens.
 - To use it for tracker agents, tell the user to open the Connections panel and click **Use local model for all tracker agents** on the Local Model card, or open an individual agent and set **Connection Override** to **Local Model (sidecar)**.
 - To use it for game scene analysis, tell them to enable **Use for game scene analysis** on the Local Model card or pick **Local sidecar (Gemma)** in the roleplay chat's Scene Analysis selector / Game Setup Wizard.

--- a/packages/server/src/routes/sidecar.routes.ts
+++ b/packages/server/src/routes/sidecar.routes.ts
@@ -176,6 +176,7 @@ export const sidecarRoutes: FastifyPluginAsync = async (app) => {
   }>("/download", async (req, reply) => {
     const { quantization } = z.object({ quantization: quantizationSchema }).parse(req.body);
     await handleDownloadSse(reply, async () => {
+      await sidecarProcessService.stop();
       await sidecarModelService.download(quantization);
       await sidecarProcessService.syncForCurrentConfig({ allowRuntimeInstall: false });
     });
@@ -192,6 +193,7 @@ export const sidecarRoutes: FastifyPluginAsync = async (app) => {
       .parse(req.body);
 
     await handleDownloadSse(reply, async () => {
+      await sidecarProcessService.stop();
       await sidecarModelService.downloadCustomModel(body.repo, body.modelPath);
       await sidecarProcessService.syncForCurrentConfig({ allowRuntimeInstall: false });
     });

--- a/packages/server/src/routes/sidecar.routes.ts
+++ b/packages/server/src/routes/sidecar.routes.ts
@@ -24,6 +24,7 @@ import {
 } from "../services/sidecar/scene-analyzer.js";
 import { postProcessSceneResult, type PostProcessContext } from "../services/sidecar/scene-postprocess.js";
 import {
+  SIDECAR_RUNTIME_PREFERENCES,
   scoreAmbient,
   scoreMusic,
   type GameActiveState,
@@ -43,7 +44,7 @@ export const sidecarRoutes: FastifyPluginAsync = async (app) => {
   });
 
   app.get("/status", async () => {
-    void sidecarProcessService.syncForCurrentConfig({ suppressKnownFailure: true }).catch((error) => {
+    void sidecarProcessService.syncForCurrentConfig({ suppressKnownFailure: true, allowRuntimeInstall: false }).catch((error) => {
       console.error("[sidecar] Background sync from /status failed:", error);
     });
 
@@ -61,15 +62,28 @@ export const sidecarRoutes: FastifyPluginAsync = async (app) => {
     useForGameScene: z.boolean().optional(),
     contextSize: z.number().int().min(512).max(32768).optional(),
     gpuLayers: z.number().int().min(-1).max(1024).optional(),
+    runtimePreference: z.enum(SIDECAR_RUNTIME_PREFERENCES).optional(),
   });
 
   app.patch("/config", async (req) => {
     const body = configSchema.parse(req.body);
     const config = sidecarModelService.updateConfig(body);
-    void sidecarProcessService.syncForCurrentConfig({ suppressKnownFailure: true }).catch((error) => {
+    void sidecarProcessService.syncForCurrentConfig({ suppressKnownFailure: true, allowRuntimeInstall: false }).catch((error) => {
       console.error("[sidecar] Background sync from /config failed:", error);
     });
     return { config };
+  });
+
+  app.post("/runtime/install", async (req, reply) => {
+    const body = z.object({ reinstall: z.boolean().optional() }).parse(req.body ?? {});
+
+    await handleDownloadSse(reply, async () => {
+      if (body.reinstall) {
+        await sidecarProcessService.reinstallRuntime();
+      } else {
+        await sidecarProcessService.installRuntime();
+      }
+    });
   });
 
   app.post("/restart", async () => {
@@ -163,7 +177,7 @@ export const sidecarRoutes: FastifyPluginAsync = async (app) => {
     const { quantization } = z.object({ quantization: quantizationSchema }).parse(req.body);
     await handleDownloadSse(reply, async () => {
       await sidecarModelService.download(quantization);
-      await sidecarProcessService.syncForCurrentConfig();
+      await sidecarProcessService.syncForCurrentConfig({ allowRuntimeInstall: false });
     });
   });
 
@@ -179,7 +193,7 @@ export const sidecarRoutes: FastifyPluginAsync = async (app) => {
 
     await handleDownloadSse(reply, async () => {
       await sidecarModelService.downloadCustomModel(body.repo, body.modelPath);
-      await sidecarProcessService.syncForCurrentConfig();
+      await sidecarProcessService.syncForCurrentConfig({ allowRuntimeInstall: false });
     });
   });
 

--- a/packages/server/src/services/llm/providers/local-sidecar.provider.ts
+++ b/packages/server/src/services/llm/providers/local-sidecar.provider.ts
@@ -3,6 +3,7 @@ import { BaseLLMProvider } from "../base-provider.js";
 import { OpenAIProvider } from "./openai.provider.js";
 import { sidecarModelService } from "../../sidecar/sidecar-model.service.js";
 import { sidecarProcessService } from "../../sidecar/sidecar-process.service.js";
+import { resolveSidecarRequestModel } from "../../sidecar/sidecar-request-model.js";
 
 export class LocalSidecarProvider extends BaseLLMProvider {
   constructor() {
@@ -15,14 +16,27 @@ export class LocalSidecarProvider extends BaseLLMProvider {
     return new OpenAIProvider(`${baseUrl}/v1`, "local-sidecar", contextSize, null);
   }
 
+  private getRequestModel(): string {
+    return resolveSidecarRequestModel(
+      sidecarModelService.getResolvedBackend(),
+      sidecarModelService.getConfiguredModelRef(),
+    );
+  }
+
   async *chat(messages: ChatMessage[], options: ChatOptions): AsyncGenerator<string, LLMUsage | void, unknown> {
     const delegate = await this.createDelegate();
-    return yield* delegate.chat(messages, options);
+    return yield* delegate.chat(messages, {
+      ...options,
+      model: this.getRequestModel(),
+    });
   }
 
   async chatComplete(messages: ChatMessage[], options: ChatOptions): Promise<ChatCompletionResult> {
     const delegate = await this.createDelegate();
-    return delegate.chatComplete(messages, options);
+    return delegate.chatComplete(messages, {
+      ...options,
+      model: this.getRequestModel(),
+    });
   }
 
   async embed(_texts: string[], _model: string): Promise<number[][]> {

--- a/packages/server/src/services/sidecar/sidecar-inference.service.ts
+++ b/packages/server/src/services/sidecar/sidecar-inference.service.ts
@@ -10,6 +10,7 @@ import type { SceneAnalysis } from "@marinara-engine/shared";
 import { sanitizeApiError } from "../llm/base-provider.js";
 import { sidecarModelService } from "./sidecar-model.service.js";
 import { sidecarProcessService } from "./sidecar-process.service.js";
+import { resolveSidecarRequestModel } from "./sidecar-request-model.js";
 
 let activeRequests = 0;
 
@@ -61,6 +62,13 @@ type SidecarChatCompletionChunk = {
     };
   }>;
 };
+
+function getRequestModel(): string {
+  return resolveSidecarRequestModel(
+    sidecarModelService.getResolvedBackend(),
+    sidecarModelService.getConfiguredModelRef(),
+  );
+}
 
 export type SidecarTestMessageOutput = {
   content: string;
@@ -135,7 +143,7 @@ async function streamChatCompletion(options: {
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      model: "local-sidecar",
+      model: getRequestModel(),
       stream: true,
       messages: options.messages,
       max_tokens: options.maxTokens,
@@ -236,7 +244,7 @@ export async function runTestMessage(): Promise<SidecarTestMessageOutput> {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          model: "local-sidecar",
+          model: getRequestModel(),
           stream: false,
           messages: [
             {

--- a/packages/server/src/services/sidecar/sidecar-inference.service.ts
+++ b/packages/server/src/services/sidecar/sidecar-inference.service.ts
@@ -437,7 +437,7 @@ export async function isInferenceAvailable(): Promise<boolean> {
   }
 
   try {
-    await sidecarProcessService.syncForCurrentConfig({ suppressKnownFailure: true });
+    await sidecarProcessService.syncForCurrentConfig({ suppressKnownFailure: true, allowRuntimeInstall: false });
   } catch {
     return false;
   }

--- a/packages/server/src/services/sidecar/sidecar-launch-plan.ts
+++ b/packages/server/src/services/sidecar/sidecar-launch-plan.ts
@@ -1,0 +1,53 @@
+export type LlamaStartupPlan = {
+  gpuLayers: number;
+  label: string;
+};
+
+export function buildLlamaArgs(options: {
+  modelPath: string;
+  gpuLayers: number;
+  port: number;
+  contextSize: number;
+  runtimeVariant: string;
+}): string[] {
+  const args = [
+    "-m",
+    options.modelPath,
+    "--host",
+    "127.0.0.1",
+    "--parallel",
+    "2",
+    "--log-disable",
+    "--ctx-size",
+    String(options.contextSize),
+    "--port",
+    String(options.port),
+  ];
+
+  // Gemma 4 needs split mode disabled on CUDA multi-GPU launches,
+  // but non-CUDA builds may reject the flag entirely.
+  if (/cuda/i.test(options.runtimeVariant) && options.gpuLayers > 0) {
+    args.push("-sm", "none");
+  }
+
+  args.push("-ngl", String(options.gpuLayers));
+  return args;
+}
+
+export function buildLlamaStartupPlans(options: {
+  configuredGpuLayers: number;
+  usesGpuRuntime: boolean;
+}): LlamaStartupPlan[] {
+  if (options.configuredGpuLayers !== -1) {
+    return [{ gpuLayers: options.configuredGpuLayers, label: `gpuLayers=${options.configuredGpuLayers}` }];
+  }
+
+  if (!options.usesGpuRuntime) {
+    return [{ gpuLayers: 0, label: "CPU runtime" }];
+  }
+
+  return [
+    { gpuLayers: 999, label: "max GPU offload" },
+    { gpuLayers: 0, label: "CPU fallback" },
+  ];
+}

--- a/packages/server/src/services/sidecar/sidecar-model.service.ts
+++ b/packages/server/src/services/sidecar/sidecar-model.service.ts
@@ -222,6 +222,15 @@ class SidecarModelService {
     return existsSync(resolved) ? resolved : null;
   }
 
+  private getConfiguredModelFileTarget(config: SidecarConfig): string | null {
+    if (!config.modelPath) return null;
+    try {
+      return this.resolveModelPath(config.modelPath);
+    } catch {
+      return null;
+    }
+  }
+
   private hasConfiguredModel(config: SidecarConfig = this.config): boolean {
     return this.resolveBackend(config) === "mlx" ? !!config.modelRepo : this.getModelFilePathForConfig(config) !== null;
   }
@@ -258,6 +267,32 @@ class SidecarModelService {
 
     const modelPath = this.getModelFilePathForConfig(config);
     return modelPath && config.modelPath ? basename(config.modelPath) : null;
+  }
+
+  private cleanupPreviousModel(previousConfig: SidecarConfig, nextConfig: SidecarConfig): void {
+    const previousBackend = this.resolveBackend(previousConfig);
+    const nextBackend = this.resolveBackend(nextConfig);
+
+    if (previousBackend === "mlx") {
+      if (previousConfig.modelRepo && previousConfig.modelRepo !== nextConfig.modelRepo) {
+        mlxRuntimeService.clearModelCache();
+      }
+      return;
+    }
+
+    const previousPath = this.getConfiguredModelFileTarget(previousConfig);
+    if (!previousPath || !existsSync(previousPath)) {
+      return;
+    }
+
+    if (nextBackend === "llama_cpp") {
+      const nextPath = this.getConfiguredModelFileTarget(nextConfig);
+      if (nextPath === previousPath) {
+        return;
+      }
+    }
+
+    unlinkSync(previousPath);
   }
 
   private async fetchRepoInfo(repo: string): Promise<HuggingFaceModelApiResponse> {
@@ -430,16 +465,20 @@ class SidecarModelService {
       throw new Error(`Unknown sidecar quantization: ${quantization}`);
     }
 
+    const previousConfig = { ...this.config };
+
     if (modelInfo.backend === "mlx") {
       const repoId = modelInfo.repoId ?? modelInfo.filename;
-      this.config = {
-        ...this.config,
+      const nextConfig: SidecarConfig = {
+        ...previousConfig,
         backend: "mlx",
         modelPath: null,
         modelRepo: repoId,
         quantization,
         customModelRepo: null,
       };
+      this.cleanupPreviousModel(previousConfig, nextConfig);
+      this.config = nextConfig;
       this.saveConfig();
       this.status = "downloaded";
       this.emitProgress(
@@ -458,15 +497,17 @@ class SidecarModelService {
 
     const relativePath = modelInfo.filename;
     const destination = this.resolveModelPath(relativePath);
+    const nextConfig: SidecarConfig = {
+      ...previousConfig,
+      backend: "llama_cpp",
+      modelPath: relativePath,
+      modelRepo: null,
+      quantization,
+      customModelRepo: null,
+    };
     if (existsSync(destination)) {
-      this.config = {
-        ...this.config,
-        backend: "llama_cpp",
-        modelPath: relativePath,
-        modelRepo: null,
-        quantization,
-        customModelRepo: null,
-      };
+      this.cleanupPreviousModel(previousConfig, nextConfig);
+      this.config = nextConfig;
       this.saveConfig();
       this.status = "downloaded";
       this.emitProgress(
@@ -496,14 +537,8 @@ class SidecarModelService {
       onProgress,
     );
 
-    this.config = {
-      ...this.config,
-      backend: "llama_cpp",
-      modelPath: relativePath,
-      modelRepo: null,
-      quantization,
-      customModelRepo: null,
-    };
+    this.cleanupPreviousModel(previousConfig, nextConfig);
+    this.config = nextConfig;
     this.saveConfig();
     this.status = "downloaded";
   }
@@ -548,16 +583,20 @@ class SidecarModelService {
       throw new Error("Repository must be in owner/repo format");
     }
 
+    const previousConfig = { ...this.config };
+
     if (isMacAppleSilicon()) {
       const selected = await this.resolveCustomMlxRepo(repo);
-      this.config = {
-        ...this.config,
+      const nextConfig: SidecarConfig = {
+        ...previousConfig,
         backend: "mlx",
         modelPath: null,
         modelRepo: repo,
         quantization: null,
         customModelRepo: repo,
       };
+      this.cleanupPreviousModel(previousConfig, nextConfig);
+      this.config = nextConfig;
       this.saveConfig();
       this.status = "downloaded";
       this.emitProgress(
@@ -582,6 +621,14 @@ class SidecarModelService {
 
     const relativePath = join("custom", `${slugifyRepo(repo)}__${selected.filename}`).replace(/\\/g, "/");
     const destination = this.resolveModelPath(relativePath);
+    const nextConfig: SidecarConfig = {
+      ...previousConfig,
+      backend: "llama_cpp",
+      modelPath: relativePath,
+      modelRepo: null,
+      quantization: null,
+      customModelRepo: repo,
+    };
     if (!existsSync(destination)) {
       await this.downloadModelFile(
         {
@@ -605,14 +652,8 @@ class SidecarModelService {
       );
     }
 
-    this.config = {
-      ...this.config,
-      backend: "llama_cpp",
-      modelPath: relativePath,
-      modelRepo: null,
-      quantization: null,
-      customModelRepo: repo,
-    };
+    this.cleanupPreviousModel(previousConfig, nextConfig);
+    this.config = nextConfig;
     this.saveConfig();
     this.status = "downloaded";
     return selected;

--- a/packages/server/src/services/sidecar/sidecar-model.service.ts
+++ b/packages/server/src/services/sidecar/sidecar-model.service.ts
@@ -11,6 +11,7 @@ import { basename, join, relative, resolve, sep } from "path";
 import { existsSync, mkdirSync, readFileSync, statSync, unlinkSync, writeFileSync } from "fs";
 import {
   SIDECAR_DEFAULT_CONFIG,
+  SIDECAR_RUNTIME_PREFERENCES,
   SIDECAR_MLX_MODELS,
   SIDECAR_MODELS,
   type SidecarBackend,
@@ -98,6 +99,10 @@ function repoLeaf(repo: string): string {
   return repo.split("/").filter(Boolean).pop() ?? repo;
 }
 
+function isRuntimePreference(value: unknown): value is SidecarConfig["runtimePreference"] {
+  return typeof value === "string" && (SIDECAR_RUNTIME_PREFERENCES as readonly string[]).includes(value);
+}
+
 class SidecarModelService {
   private config: SidecarConfig;
   private status: SidecarStatus = "not_downloaded";
@@ -119,6 +124,11 @@ class SidecarModelService {
       if (existsSync(CONFIG_PATH)) {
         const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8")) as Partial<SidecarConfig>;
         nextConfig = { ...SIDECAR_DEFAULT_CONFIG, ...raw };
+
+        if (!isRuntimePreference(nextConfig.runtimePreference)) {
+          nextConfig.runtimePreference = SIDECAR_DEFAULT_CONFIG.runtimePreference;
+          shouldRewrite = true;
+        }
 
         // v1.5.x configs only tracked the curated quantization. Migrate them to an explicit model ref.
         if (!nextConfig.modelPath && !nextConfig.modelRepo && nextConfig.quantization) {
@@ -356,7 +366,7 @@ class SidecarModelService {
       backend === "mlx"
         ? mlxRuntimeService.getStatus()
         : {
-            ...sidecarRuntimeService.getStatus(),
+            ...sidecarRuntimeService.getStatus(this.config.runtimePreference),
             backend: "llama_cpp" as const,
           };
 
@@ -404,7 +414,7 @@ class SidecarModelService {
   }
 
   updateConfig(
-    partial: Partial<Pick<SidecarConfig, "useForTrackers" | "useForGameScene" | "contextSize" | "gpuLayers">>,
+    partial: Partial<Pick<SidecarConfig, "useForTrackers" | "useForGameScene" | "contextSize" | "gpuLayers" | "runtimePreference">>,
   ): SidecarConfig {
     this.config = { ...this.config, ...partial };
     this.saveConfig();

--- a/packages/server/src/services/sidecar/sidecar-process.service.ts
+++ b/packages/server/src/services/sidecar/sidecar-process.service.ts
@@ -5,6 +5,7 @@ import { dirname, join } from "path";
 import type { SidecarBackend } from "@marinara-engine/shared";
 import { sidecarModelService } from "./sidecar-model.service.js";
 import { isAbortError } from "./sidecar-download.js";
+import { buildLlamaArgs, buildLlamaStartupPlans } from "./sidecar-launch-plan.js";
 import { buildLlamaProcessEnv } from "./sidecar-runtime-env.js";
 import { mlxRuntimeService, type MlxRuntimeInstall } from "./mlx-runtime.service.js";
 import { sidecarRuntimeService, type SidecarRuntimeInstall } from "./sidecar-runtime.service.js";
@@ -256,27 +257,13 @@ class SidecarProcessService {
 
   private buildLlamaArgs(modelPath: string, gpuLayers: number, port: number, runtime: SidecarRuntimeInstall): string[] {
     const config = sidecarModelService.getConfig();
-    const args = [
-      "-m",
+    return buildLlamaArgs({
       modelPath,
-      "--host",
-      "127.0.0.1",
-      "--parallel",
-      "2",
-      "--log-disable",
-      "--ctx-size",
-      String(config.contextSize),
-      "--port",
-      String(port),
-    ];
-
-    // Gemma 4 needs split mode disabled on CUDA multi-GPU launches,
-    // but non-CUDA builds may reject the flag entirely.
-    if (/cuda/i.test(runtime.variant) && gpuLayers > 0) {
-      args.push("-sm", "none");
-    }
-    args.push("-ngl", String(gpuLayers));
-    return args;
+      gpuLayers,
+      port,
+      contextSize: config.contextSize,
+      runtimeVariant: runtime.variant,
+    });
   }
 
   private buildMlxArgs(modelRepo: string, port: number): string[] {
@@ -289,18 +276,10 @@ class SidecarProcessService {
 
   private buildLlamaStartupPlans(runtime: SidecarRuntimeInstall): Array<{ gpuLayers: number; label: string }> {
     const config = sidecarModelService.getConfig();
-    if (config.gpuLayers !== -1) {
-      return [{ gpuLayers: config.gpuLayers, label: `gpuLayers=${config.gpuLayers}` }];
-    }
-
-    if (!this.usesGpuRuntime(runtime)) {
-      return [{ gpuLayers: 0, label: "CPU runtime" }];
-    }
-
-    return [
-      { gpuLayers: 999, label: "max GPU offload" },
-      { gpuLayers: 0, label: "CPU fallback" },
-    ];
+    return buildLlamaStartupPlans({
+      configuredGpuLayers: config.gpuLayers,
+      usesGpuRuntime: this.usesGpuRuntime(runtime),
+    });
   }
 
   private shouldRetryStartup(error: unknown): error is SidecarServerExitError {

--- a/packages/server/src/services/sidecar/sidecar-process.service.ts
+++ b/packages/server/src/services/sidecar/sidecar-process.service.ts
@@ -116,7 +116,14 @@ class SidecarProcessService {
     return this.withLock(async () => {
       this.clearStartupFailure();
       const backend = sidecarModelService.getResolvedBackend();
+      const hadUsableRuntime = this.isRuntimeInstalled(backend);
+      if (!hadUsableRuntime) {
+        await this.stopUnlocked();
+      }
       await this.ensureRuntimeInstalled(backend);
+      if (!hadUsableRuntime) {
+        this.cleanupInactiveRuntimeBackends(backend);
+      }
 
       if (sidecarModelService.getConfiguredModelRef() && sidecarModelService.isEnabled()) {
         await this.syncUnlocked({ allowRuntimeInstall: false });
@@ -147,6 +154,8 @@ class SidecarProcessService {
         await this.ensureRuntimeInstalled(backend);
         sidecarModelService.setStatus(sidecarModelService.getConfiguredModelRef() ? "downloaded" : "not_downloaded");
       }
+
+      this.cleanupInactiveRuntimeBackends(backend);
     });
   }
 
@@ -277,6 +286,15 @@ class SidecarProcessService {
 
   private isMlxRuntime(runtime: ManagedRuntimeInstall): runtime is MlxRuntimeInstall {
     return "pythonPath" in runtime;
+  }
+
+  private cleanupInactiveRuntimeBackends(activeBackend: SidecarBackend): void {
+    if (activeBackend === "mlx") {
+      sidecarRuntimeService.resetRuntime();
+      return;
+    }
+
+    mlxRuntimeService.resetRuntime();
   }
 
   private getLlamaServerPath(runtime: ManagedRuntimeInstall): string {

--- a/packages/server/src/services/sidecar/sidecar-process.service.ts
+++ b/packages/server/src/services/sidecar/sidecar-process.service.ts
@@ -5,6 +5,7 @@ import { dirname, join } from "path";
 import type { SidecarBackend } from "@marinara-engine/shared";
 import { sidecarModelService } from "./sidecar-model.service.js";
 import { isAbortError } from "./sidecar-download.js";
+import { buildLlamaProcessEnv } from "./sidecar-runtime-env.js";
 import { mlxRuntimeService, type MlxRuntimeInstall } from "./mlx-runtime.service.js";
 import { sidecarRuntimeService, type SidecarRuntimeInstall } from "./sidecar-runtime.service.js";
 
@@ -456,6 +457,7 @@ class SidecarProcessService {
 
       const child = spawn(runtime.serverPath, args, {
         cwd: dirname(runtime.serverPath),
+        env: buildLlamaProcessEnv(runtime),
         windowsHide: true,
         stdio: ["ignore", "pipe", "pipe"],
       });

--- a/packages/server/src/services/sidecar/sidecar-process.service.ts
+++ b/packages/server/src/services/sidecar/sidecar-process.service.ts
@@ -37,6 +37,7 @@ type ManagedRuntimeInstall = SidecarRuntimeInstall | MlxRuntimeInstall;
 type SyncOptions = {
   suppressKnownFailure?: boolean;
   forceStart?: boolean;
+  allowRuntimeInstall?: boolean;
 };
 
 class SidecarServerExitError extends Error {
@@ -87,6 +88,7 @@ class SidecarProcessService {
     await this.syncForCurrentConfig({
       suppressKnownFailure: !forceStart,
       forceStart,
+      allowRuntimeInstall: forceStart,
     });
     if (!this.ready || !this.baseUrl) {
       throw new Error(this.startupError ?? "The local sidecar server is not ready");
@@ -106,7 +108,21 @@ class SidecarProcessService {
       this.clearStartupFailure();
       this.currentSignature = null;
       await this.stopUnlocked();
-      await this.syncUnlocked();
+      await this.syncUnlocked({ allowRuntimeInstall: true });
+    });
+  }
+
+  async installRuntime(): Promise<void> {
+    return this.withLock(async () => {
+      this.clearStartupFailure();
+      const backend = sidecarModelService.getResolvedBackend();
+      await this.ensureRuntimeInstalled(backend);
+
+      if (sidecarModelService.getConfiguredModelRef() && sidecarModelService.isEnabled()) {
+        await this.syncUnlocked({ allowRuntimeInstall: false });
+      } else {
+        sidecarModelService.setStatus(sidecarModelService.getConfiguredModelRef() ? "downloaded" : "not_downloaded");
+      }
     });
   }
 
@@ -119,15 +135,16 @@ class SidecarProcessService {
       if (backend === "mlx") {
         mlxRuntimeService.resetRuntime();
       } else {
-        if (sidecarRuntimeService.getStatus().source === "system") {
+        if (sidecarRuntimeService.getStatus(sidecarModelService.getConfig().runtimePreference).source === "system") {
           throw new Error("The local runtime is using a system llama-server from PATH. Reinstall that runtime outside Marinara.");
         }
         sidecarRuntimeService.resetRuntime();
       }
 
       if (sidecarModelService.getConfiguredModelRef() && sidecarModelService.isEnabled()) {
-        await this.syncUnlocked();
+        await this.syncUnlocked({ allowRuntimeInstall: true });
       } else {
+        await this.ensureRuntimeInstalled(backend);
         sidecarModelService.setStatus(sidecarModelService.getConfiguredModelRef() ? "downloaded" : "not_downloaded");
       }
     });
@@ -171,9 +188,17 @@ class SidecarProcessService {
 
   private normalizeSyncOptions(options?: boolean | SyncOptions): SyncOptions {
     if (typeof options === "boolean") {
-      return { forceStart: options };
+      return { forceStart: options, allowRuntimeInstall: options };
     }
     return options ?? {};
+  }
+
+  private isRuntimeInstalled(backend: SidecarBackend): boolean {
+    if (backend === "mlx") {
+      return mlxRuntimeService.getStatus().installed;
+    }
+
+    return sidecarRuntimeService.getStatus(sidecarModelService.getConfig().runtimePreference).installed;
   }
 
   private async syncUnlocked(options: SyncOptions = {}): Promise<void> {
@@ -188,6 +213,13 @@ class SidecarProcessService {
     }
 
     if (!options.forceStart && !sidecarModelService.isEnabled()) {
+      await this.stopUnlocked();
+      this.clearStartupFailure();
+      sidecarModelService.setStatus("downloaded");
+      return;
+    }
+
+    if (!options.allowRuntimeInstall && !this.isRuntimeInstalled(backend)) {
       await this.stopUnlocked();
       this.clearStartupFailure();
       sidecarModelService.setStatus("downloaded");
@@ -224,9 +256,15 @@ class SidecarProcessService {
         });
       }
 
-      return await sidecarRuntimeService.ensureInstalled((progress) => {
-        sidecarModelService.emitExternalProgress(progress);
-      }, options);
+      return await sidecarRuntimeService.ensureInstalled(
+        (progress) => {
+          sidecarModelService.emitExternalProgress(progress);
+        },
+        {
+          ...options,
+          preference: sidecarModelService.getConfig().runtimePreference,
+        },
+      );
     } catch (error) {
       if (isAbortError(error)) {
         sidecarModelService.setStatus(sidecarModelService.getConfiguredModelRef() ? "downloaded" : "not_downloaded");
@@ -631,7 +669,7 @@ class SidecarProcessService {
     }
 
     try {
-      await this.syncForCurrentConfig();
+      await this.syncForCurrentConfig({ allowRuntimeInstall: false });
     } catch (error) {
       console.error("[sidecar] Auto-restart failed:", error);
       sidecarModelService.setStatus("server_error");

--- a/packages/server/src/services/sidecar/sidecar-request-model.ts
+++ b/packages/server/src/services/sidecar/sidecar-request-model.ts
@@ -1,0 +1,14 @@
+import type { SidecarBackend } from "@marinara-engine/shared";
+
+export const LOCAL_SIDECAR_REQUEST_MODEL = "local-sidecar";
+
+export function resolveSidecarRequestModel(
+  backend: SidecarBackend,
+  configuredModelRef: string | null,
+): string {
+  if (backend === "mlx" && configuredModelRef) {
+    return configuredModelRef;
+  }
+
+  return LOCAL_SIDECAR_REQUEST_MODEL;
+}

--- a/packages/server/src/services/sidecar/sidecar-runtime-env.ts
+++ b/packages/server/src/services/sidecar/sidecar-runtime-env.ts
@@ -1,0 +1,37 @@
+import { delimiter, dirname } from "path";
+
+type LlamaRuntimeEnvInput = {
+  serverPath: string;
+  source: string | null | undefined;
+};
+
+function prependPathEntry(currentValue: string | undefined, entry: string): string {
+  const segments = (currentValue ?? "")
+    .split(delimiter)
+    .map((segment) => segment.trim())
+    .filter(Boolean)
+    .filter((segment) => segment !== entry);
+
+  return [entry, ...segments].join(delimiter);
+}
+
+export function buildLlamaProcessEnv(
+  runtime: LlamaRuntimeEnvInput,
+  platform: NodeJS.Platform = process.platform,
+  baseEnv: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+  const env = { ...baseEnv };
+
+  if (runtime.source !== "bundled") {
+    return env;
+  }
+
+  const runtimeDir = dirname(runtime.serverPath);
+  if (platform === "linux" || platform === "android") {
+    env.LD_LIBRARY_PATH = prependPathEntry(env.LD_LIBRARY_PATH, runtimeDir);
+  } else if (platform === "darwin") {
+    env.DYLD_LIBRARY_PATH = prependPathEntry(env.DYLD_LIBRARY_PATH, runtimeDir);
+  }
+
+  return env;
+}

--- a/packages/server/src/services/sidecar/sidecar-runtime.service.ts
+++ b/packages/server/src/services/sidecar/sidecar-runtime.service.ts
@@ -397,13 +397,7 @@ class SidecarRuntimeService {
     writeFileSync(CURRENT_RUNTIME_PATH, JSON.stringify(record, null, 2), "utf-8");
   }
 
-  resetRuntime(): void {
-    this.cancelInstall();
-    const current = this.getCurrentInstall();
-    if (current?.source === "bundled") {
-      rmSync(current.directoryPath, { recursive: true, force: true });
-    }
-
+  private cleanupBundledArtifacts(keepDirectoryName?: string | null): void {
     for (const entry of readdirSync(RUNTIME_DIR, { withFileTypes: true })) {
       if (entry.name === "mlx" || entry.name === "server.log") {
         continue;
@@ -411,7 +405,13 @@ class SidecarRuntimeService {
 
       const fullPath = join(RUNTIME_DIR, entry.name);
       if (entry.name === "current.json") {
-        unlinkSync(fullPath);
+        if (!keepDirectoryName) {
+          unlinkSync(fullPath);
+        }
+        continue;
+      }
+
+      if (keepDirectoryName && entry.name === keepDirectoryName) {
         continue;
       }
 
@@ -423,6 +423,15 @@ class SidecarRuntimeService {
         rmSync(fullPath, { recursive: true, force: true });
       }
     }
+  }
+
+  resetRuntime(): void {
+    this.cancelInstall();
+    const current = this.getCurrentInstall();
+    if (current?.source === "bundled") {
+      rmSync(current.directoryPath, { recursive: true, force: true });
+    }
+    this.cleanupBundledArtifacts();
   }
 
   private async installLatest(
@@ -510,6 +519,7 @@ class SidecarRuntimeService {
         gpuCapable: this.isGpuVariant(match.variant),
       };
       this.writeCurrentInstall(install);
+      this.cleanupBundledArtifacts(directoryName);
       return install;
     } catch (error) {
       if (extractDirectory) {

--- a/packages/server/src/services/sidecar/sidecar-runtime.service.ts
+++ b/packages/server/src/services/sidecar/sidecar-runtime.service.ts
@@ -19,6 +19,7 @@ import type {
   SidecarDownloadProgress,
   SidecarRuntimeDiagnostics,
   SidecarRuntimeInfo,
+  SidecarRuntimePreference,
   SidecarRuntimeSource,
 } from "@marinara-engine/shared";
 import { getDataDir } from "../../utils/data-dir.js";
@@ -143,6 +144,63 @@ function parseBooleanEnv(value: string | undefined): boolean {
   return /^(1|true|yes|on)$/i.test(value.trim());
 }
 
+function formatRuntimePreference(preference: SidecarRuntimePreference): string {
+  switch (preference) {
+    case "auto":
+      return "automatic detection";
+    case "nvidia":
+      return "an NVIDIA GPU runtime";
+    case "amd":
+      return "an AMD GPU runtime";
+    case "intel":
+      return "an Intel GPU runtime";
+    case "vulkan":
+      return "a Vulkan runtime";
+    case "cpu":
+      return "a CPU-only runtime";
+    case "system":
+      return "a system llama-server runtime";
+    default:
+      return preference;
+  }
+}
+
+function isCpuVariant(variant: string): boolean {
+  return /cpu/i.test(variant);
+}
+
+function isVariantCompatibleWithPreference(variant: string, preference: SidecarRuntimePreference): boolean {
+  if (preference === "auto") {
+    return true;
+  }
+
+  if (preference === "system") {
+    return /^system-/i.test(variant);
+  }
+
+  if (preference === "cpu") {
+    return isCpuVariant(variant);
+  }
+
+  if (preference === "nvidia") {
+    return /cuda/i.test(variant);
+  }
+
+  if (preference === "amd") {
+    return /(hip|rocm|vulkan)/i.test(variant);
+  }
+
+  if (preference === "intel") {
+    return /(sycl|vulkan)/i.test(variant);
+  }
+
+  if (preference === "vulkan") {
+    return /vulkan/i.test(variant);
+  }
+
+  return false;
+}
+
 class SidecarRuntimeService {
   private installPromise: Promise<SidecarRuntimeInstall> | null = null;
   private installAbort: AbortController | null = null;
@@ -163,11 +221,11 @@ class SidecarRuntimeService {
     this.installAbort = null;
   }
 
-  getStatus(): SidecarRuntimeInfo {
+  getStatus(preference: SidecarRuntimePreference = "auto"): SidecarRuntimeInfo {
     const diagnostics = this.getDiagnostics();
-    const systemInstall = this.getSystemInstallSync(diagnostics);
+    const systemInstall = this.getSystemInstallSync(diagnostics, preference);
     const current = this.getCurrentInstall();
-    const activeInstall = systemInstall ?? current;
+    const activeInstall = systemInstall ?? (current && this.isInstallUsableForPreference(current, preference) ? current : null);
     return {
       installed: activeInstall !== null,
       build: activeInstall?.build ?? null,
@@ -270,16 +328,20 @@ class SidecarRuntimeService {
 
   async ensureInstalled(
     onProgress?: (progress: SidecarDownloadProgress) => void,
-    options?: { excludeVariants?: string[] },
+    options?: { excludeVariants?: string[]; preference?: SidecarRuntimePreference },
   ): Promise<SidecarRuntimeInstall> {
     const excludedVariants = new Set(options?.excludeVariants ?? []);
-    const systemInstall = await this.getSystemInstall();
+    const preference = options?.preference ?? "auto";
+    const systemInstall = await this.getSystemInstall(preference);
+    if (preference === "system" && !systemInstall) {
+      throw new Error("No system llama-server was found in PATH. Install llama.cpp separately or choose a bundled runtime.");
+    }
     if (systemInstall && !excludedVariants.has(systemInstall.variant)) {
       return systemInstall;
     }
 
     const current = this.getCurrentInstall();
-    if (current && this.isInstallUsable(current) && !excludedVariants.has(current.variant)) {
+    if (current && this.isInstallUsableForPreference(current, preference) && !excludedVariants.has(current.variant)) {
       return current;
     }
 
@@ -287,7 +349,7 @@ class SidecarRuntimeService {
       return this.installPromise;
     }
 
-    this.installPromise = this.installLatest(onProgress, excludedVariants).finally(() => {
+    this.installPromise = this.installLatest(onProgress, excludedVariants, preference).finally(() => {
       this.installPromise = null;
     });
     return this.installPromise;
@@ -298,6 +360,22 @@ class SidecarRuntimeService {
       return !!install.serverPath;
     }
     return install.platform === process.platform && install.arch === process.arch && existsSync(install.serverPath);
+  }
+
+  private isInstallUsableForPreference(install: SidecarRuntimeInstall, preference: SidecarRuntimePreference): boolean {
+    if (!this.isInstallUsable(install)) {
+      return false;
+    }
+
+    if (preference === "auto") {
+      return true;
+    }
+
+    if (install.source === "system") {
+      return preference === "system";
+    }
+
+    return isVariantCompatibleWithPreference(install.variant, preference);
   }
 
   private writeCurrentInstall(install: SidecarRuntimeInstall): void {
@@ -350,6 +428,7 @@ class SidecarRuntimeService {
   private async installLatest(
     onProgress?: (progress: SidecarDownloadProgress) => void,
     excludedVariants: Set<string> = new Set(),
+    preference: SidecarRuntimePreference = "auto",
   ): Promise<SidecarRuntimeInstall> {
     const abortController = new AbortController();
     this.installAbort = abortController;
@@ -374,8 +453,11 @@ class SidecarRuntimeService {
         },
       );
 
-      const match = await this.selectBestAsset(release.assets, excludedVariants);
+      const match = await this.selectBestAsset(release.assets, excludedVariants, preference);
       if (!match) {
+        if (preference !== "auto") {
+          throw new Error(`Marinara could not find ${formatRuntimePreference(preference)} for ${process.platform}/${process.arch}.`);
+        }
         throw new Error(`Your platform (${process.platform}/${process.arch}) is not supported for local inference yet.`);
       }
 
@@ -672,7 +754,15 @@ class SidecarRuntimeService {
     return null;
   }
 
-  private shouldUseSystemRuntime(): boolean {
+  private shouldUseSystemRuntime(preference: SidecarRuntimePreference = "auto"): boolean {
+    if (preference === "system") {
+      return true;
+    }
+
+    if (preference !== "auto") {
+      return false;
+    }
+
     return parseBooleanEnv(process.env.MARINARA_SIDECAR_USE_SYSTEM_LLAMA) ||
       parseBooleanEnv(process.env.MARINARA_SIDECAR_USE_SYSTEM_LLAMA_SERVER);
   }
@@ -699,8 +789,11 @@ class SidecarRuntimeService {
     };
   }
 
-  private getSystemInstallSync(diagnostics: SidecarRuntimeDiagnostics): SidecarRuntimeInstall | null {
-    if (!this.shouldUseSystemRuntime()) {
+  private getSystemInstallSync(
+    diagnostics: SidecarRuntimeDiagnostics,
+    preference: SidecarRuntimePreference = "auto",
+  ): SidecarRuntimeInstall | null {
+    if (!this.shouldUseSystemRuntime(preference)) {
       return null;
     }
 
@@ -727,8 +820,8 @@ class SidecarRuntimeService {
     return this.createSystemInstall(systemPath, capabilities);
   }
 
-  private async getSystemInstall(): Promise<SidecarRuntimeInstall | null> {
-    if (!this.shouldUseSystemRuntime()) {
+  private async getSystemInstall(preference: SidecarRuntimePreference = "auto"): Promise<SidecarRuntimeInstall | null> {
+    if (!this.shouldUseSystemRuntime(preference)) {
       return null;
     }
 
@@ -752,74 +845,111 @@ class SidecarRuntimeService {
     matches.push({ variant, asset });
   }
 
+  private buildPreferredVariants(capabilities: RuntimeCapabilities, preference: SidecarRuntimePreference): string[] {
+    if (capabilities.platform === "android" && capabilities.arch === "arm64") {
+      return preference === "auto" || preference === "cpu" ? ["android-arm64-cpu"] : [];
+    }
+
+    if (capabilities.platform === "darwin" && capabilities.arch === "arm64") {
+      return preference === "auto" ? ["macos-arm64-metal"] : [];
+    }
+
+    if (capabilities.platform === "darwin" && capabilities.arch === "x64") {
+      return preference === "auto" || preference === "cpu" ? ["macos-x64-cpu"] : [];
+    }
+
+    if (capabilities.platform === "win32" && capabilities.arch === "arm64") {
+      return preference === "auto" || preference === "cpu" ? ["win-arm64-cpu"] : [];
+    }
+
+    if (capabilities.platform === "win32" && capabilities.arch === "x64") {
+      if (preference === "nvidia") return ["win-x64-cuda"];
+      if (preference === "amd") return ["win-x64-hip", "win-x64-vulkan"];
+      if (preference === "intel") return ["win-x64-sycl", "win-x64-vulkan"];
+      if (preference === "vulkan") return ["win-x64-vulkan"];
+      if (preference === "cpu") return ["win-x64-cpu"];
+      if (preference !== "auto") return [];
+
+      const variants: string[] = [];
+      if (capabilities.preferCuda) variants.push("win-x64-cuda");
+      if (capabilities.preferHip) variants.push("win-x64-hip");
+      if (capabilities.preferSycl) variants.push("win-x64-sycl");
+      if (capabilities.preferVulkan) variants.push("win-x64-vulkan");
+      variants.push("win-x64-cpu");
+      return variants;
+    }
+
+    if (capabilities.platform === "linux" && capabilities.arch === "x64") {
+      if (preference === "nvidia") return ["linux-x64-cuda"];
+      if (preference === "amd") return ["linux-x64-rocm", "linux-x64-vulkan"];
+      if (preference === "intel") return ["linux-x64-vulkan"];
+      if (preference === "vulkan") return ["linux-x64-vulkan"];
+      if (preference === "cpu") return ["linux-x64-cpu"];
+      if (preference !== "auto") return [];
+
+      const variants: string[] = [];
+      if (capabilities.preferCuda) variants.push("linux-x64-cuda");
+      if (capabilities.preferRocm) variants.push("linux-x64-rocm");
+      if (capabilities.preferVulkan) variants.push("linux-x64-vulkan");
+      variants.push("linux-x64-cpu");
+      return variants;
+    }
+
+    if (capabilities.platform === "linux" && capabilities.arch === "arm64") {
+      if (preference === "vulkan" || preference === "amd" || preference === "intel") {
+        return ["linux-arm64-vulkan"];
+      }
+      if (preference === "cpu") {
+        return ["linux-arm64-cpu"];
+      }
+      if (preference !== "auto") {
+        return [];
+      }
+
+      return capabilities.preferVulkan ? ["linux-arm64-vulkan", "linux-arm64-cpu"] : ["linux-arm64-cpu"];
+    }
+
+    return [];
+  }
+
   private async selectBestAsset(
     assets: GitHubReleaseAsset[],
     excludedVariants: Set<string> = new Set(),
+    preference: SidecarRuntimePreference = "auto",
   ): Promise<RuntimeMatch | null> {
     const capabilities = await this.detectCapabilities();
     const matches: RuntimeMatch[] = [];
 
-    if (capabilities.platform === "android" && capabilities.arch === "arm64") {
-      this.pushCandidate(matches, excludedVariants, "android-arm64-cpu", this.findFirstAsset(assets, /^llama-.*-bin-android-arm64\.tar\.gz$/i));
-    } else if (capabilities.platform === "darwin" && capabilities.arch === "arm64") {
-      this.pushCandidate(
-        matches,
-        excludedVariants,
+    const orderedVariants = this.buildPreferredVariants(capabilities, preference);
+    const assetByVariant = new Map<string, GitHubReleaseAsset | null>([
+      ["android-arm64-cpu", this.findFirstAsset(assets, /^llama-.*-bin-android-arm64\.tar\.gz$/i)],
+      [
         "macos-arm64-metal",
         this.findFirstAsset(assets, /^llama-.*-bin-macos-arm64\.tar\.gz$/i) ??
           this.findFirstAsset(assets, /^llama-.*-bin-macos-arm64-kleidiai\.tar\.gz$/i),
-      );
-    } else if (capabilities.platform === "darwin" && capabilities.arch === "x64") {
-      this.pushCandidate(matches, excludedVariants, "macos-x64-cpu", this.findFirstAsset(assets, /^llama-.*-bin-macos-x64\.tar\.gz$/i));
-    } else if (capabilities.platform === "win32" && capabilities.arch === "x64") {
-      if (capabilities.preferCuda) {
-        this.pushCandidate(
-          matches,
-          excludedVariants,
-          "win-x64-cuda",
-          this.pickLatestVersionedAsset(assets, /^(?:cudart-)?llama-.*-bin-win-cuda-[0-9.]+-x64\.zip$/i, {
-            preferPrefix: "cudart-",
-          }) ?? null,
-        );
-      }
-      if (capabilities.preferHip) {
-        this.pushCandidate(matches, excludedVariants, "win-x64-hip", this.findFirstAsset(assets, /^llama-.*-bin-win-hip-x64\.zip$/i));
-      }
-      if (capabilities.preferSycl) {
-        this.pushCandidate(matches, excludedVariants, "win-x64-sycl", this.findFirstAsset(assets, /^llama-.*-bin-win-sycl-x64\.zip$/i));
-      }
-      if (capabilities.preferVulkan) {
-        this.pushCandidate(matches, excludedVariants, "win-x64-vulkan", this.findFirstAsset(assets, /^llama-.*-bin-win-vulkan-x64\.zip$/i));
-      }
-      this.pushCandidate(matches, excludedVariants, "win-x64-cpu", this.findFirstAsset(assets, /^llama-.*-bin-win-cpu-x64\.zip$/i));
-    } else if (capabilities.platform === "win32" && capabilities.arch === "arm64") {
-      this.pushCandidate(matches, excludedVariants, "win-arm64-cpu", this.findFirstAsset(assets, /^llama-.*-bin-win-cpu-arm64\.zip$/i));
-    } else if (capabilities.platform === "linux" && capabilities.arch === "x64") {
-      if (capabilities.preferCuda) {
-        this.pushCandidate(
-          matches,
-          excludedVariants,
-          "linux-x64-cuda",
-          this.pickLatestVersionedAsset(assets, /^llama-.*-bin-ubuntu-cuda-[0-9.]+-x64\.tar\.gz$/i),
-        );
-      }
-      if (capabilities.preferRocm) {
-        this.pushCandidate(
-          matches,
-          excludedVariants,
-          "linux-x64-rocm",
-          this.pickLatestVersionedAsset(assets, /^llama-.*-bin-ubuntu-rocm-[0-9.]+-x64\.tar\.gz$/i),
-        );
-      }
-      if (capabilities.preferVulkan) {
-        this.pushCandidate(matches, excludedVariants, "linux-x64-vulkan", this.findFirstAsset(assets, /^llama-.*-bin-ubuntu-vulkan-x64\.tar\.gz$/i));
-      }
-      this.pushCandidate(matches, excludedVariants, "linux-x64-cpu", this.findFirstAsset(assets, /^llama-.*-bin-ubuntu-x64\.tar\.gz$/i));
-    } else if (capabilities.platform === "linux" && capabilities.arch === "arm64") {
-      if (capabilities.preferVulkan) {
-        this.pushCandidate(matches, excludedVariants, "linux-arm64-vulkan", this.findFirstAsset(assets, /^llama-.*-bin-ubuntu-vulkan-arm64\.tar\.gz$/i));
-      }
-      this.pushCandidate(matches, excludedVariants, "linux-arm64-cpu", this.findFirstAsset(assets, /^llama-.*-bin-ubuntu-arm64\.tar\.gz$/i));
+      ],
+      ["macos-x64-cpu", this.findFirstAsset(assets, /^llama-.*-bin-macos-x64\.tar\.gz$/i)],
+      [
+        "win-x64-cuda",
+        this.pickLatestVersionedAsset(assets, /^(?:cudart-)?llama-.*-bin-win-cuda-[0-9.]+-x64\.zip$/i, {
+          preferPrefix: "cudart-",
+        }),
+      ],
+      ["win-x64-hip", this.findFirstAsset(assets, /^llama-.*-bin-win-hip-x64\.zip$/i)],
+      ["win-x64-sycl", this.findFirstAsset(assets, /^llama-.*-bin-win-sycl-x64\.zip$/i)],
+      ["win-x64-vulkan", this.findFirstAsset(assets, /^llama-.*-bin-win-vulkan-x64\.zip$/i)],
+      ["win-x64-cpu", this.findFirstAsset(assets, /^llama-.*-bin-win-cpu-x64\.zip$/i)],
+      ["win-arm64-cpu", this.findFirstAsset(assets, /^llama-.*-bin-win-cpu-arm64\.zip$/i)],
+      ["linux-x64-cuda", this.pickLatestVersionedAsset(assets, /^llama-.*-bin-ubuntu-cuda-[0-9.]+-x64\.tar\.gz$/i)],
+      ["linux-x64-rocm", this.pickLatestVersionedAsset(assets, /^llama-.*-bin-ubuntu-rocm-[0-9.]+-x64\.tar\.gz$/i)],
+      ["linux-x64-vulkan", this.findFirstAsset(assets, /^llama-.*-bin-ubuntu-vulkan-x64\.tar\.gz$/i)],
+      ["linux-x64-cpu", this.findFirstAsset(assets, /^llama-.*-bin-ubuntu-x64\.tar\.gz$/i)],
+      ["linux-arm64-vulkan", this.findFirstAsset(assets, /^llama-.*-bin-ubuntu-vulkan-arm64\.tar\.gz$/i)],
+      ["linux-arm64-cpu", this.findFirstAsset(assets, /^llama-.*-bin-ubuntu-arm64\.tar\.gz$/i)],
+    ]);
+
+    for (const variant of orderedVariants) {
+      this.pushCandidate(matches, excludedVariants, variant, assetByVariant.get(variant) ?? null);
     }
 
     return matches[0] ?? null;

--- a/packages/server/test/sidecar-launch-plan.test.ts
+++ b/packages/server/test/sidecar-launch-plan.test.ts
@@ -1,0 +1,105 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { buildLlamaArgs, buildLlamaStartupPlans } from "../src/services/sidecar/sidecar-launch-plan.js";
+
+test("CPU runtimes only attempt CPU startup when gpuLayers is auto", () => {
+  assert.deepEqual(buildLlamaStartupPlans({ configuredGpuLayers: -1, usesGpuRuntime: false }), [
+    { gpuLayers: 0, label: "CPU runtime" },
+  ]);
+});
+
+test("GPU runtimes try max offload first and then CPU fallback when gpuLayers is auto", () => {
+  assert.deepEqual(buildLlamaStartupPlans({ configuredGpuLayers: -1, usesGpuRuntime: true }), [
+    { gpuLayers: 999, label: "max GPU offload" },
+    { gpuLayers: 0, label: "CPU fallback" },
+  ]);
+});
+
+test("explicit gpuLayers disables automatic fallback planning", () => {
+  assert.deepEqual(buildLlamaStartupPlans({ configuredGpuLayers: 12, usesGpuRuntime: true }), [
+    { gpuLayers: 12, label: "gpuLayers=12" },
+  ]);
+});
+
+test("CUDA offload attempts include split-mode disable", () => {
+  assert.deepEqual(
+    buildLlamaArgs({
+      modelPath: "/app/data/models/gemma.gguf",
+      gpuLayers: 999,
+      port: 8080,
+      contextSize: 8192,
+      runtimeVariant: "win-x64-cuda",
+    }),
+    [
+      "-m",
+      "/app/data/models/gemma.gguf",
+      "--host",
+      "127.0.0.1",
+      "--parallel",
+      "2",
+      "--log-disable",
+      "--ctx-size",
+      "8192",
+      "--port",
+      "8080",
+      "-sm",
+      "none",
+      "-ngl",
+      "999",
+    ],
+  );
+});
+
+test("CPU fallback on a CUDA runtime does not keep split-mode disable", () => {
+  assert.deepEqual(
+    buildLlamaArgs({
+      modelPath: "/app/data/models/gemma.gguf",
+      gpuLayers: 0,
+      port: 8080,
+      contextSize: 8192,
+      runtimeVariant: "win-x64-cuda",
+    }),
+    [
+      "-m",
+      "/app/data/models/gemma.gguf",
+      "--host",
+      "127.0.0.1",
+      "--parallel",
+      "2",
+      "--log-disable",
+      "--ctx-size",
+      "8192",
+      "--port",
+      "8080",
+      "-ngl",
+      "0",
+    ],
+  );
+});
+
+test("CPU runtime launches never add split-mode disable", () => {
+  assert.deepEqual(
+    buildLlamaArgs({
+      modelPath: "/app/data/models/gemma.gguf",
+      gpuLayers: 0,
+      port: 8080,
+      contextSize: 8192,
+      runtimeVariant: "win-x64-cpu",
+    }),
+    [
+      "-m",
+      "/app/data/models/gemma.gguf",
+      "--host",
+      "127.0.0.1",
+      "--parallel",
+      "2",
+      "--log-disable",
+      "--ctx-size",
+      "8192",
+      "--port",
+      "8080",
+      "-ngl",
+      "0",
+    ],
+  );
+});

--- a/packages/server/test/sidecar-request-model.test.ts
+++ b/packages/server/test/sidecar-request-model.test.ts
@@ -1,0 +1,21 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { resolveSidecarRequestModel } from "../src/services/sidecar/sidecar-request-model.js";
+
+test("uses the configured Hugging Face repo for MLX requests", () => {
+  assert.equal(
+    resolveSidecarRequestModel("mlx", "mlx-community/gemma-4-e2b-it-4bit"),
+    "mlx-community/gemma-4-e2b-it-4bit",
+  );
+});
+
+test("keeps the synthetic local model name for llama.cpp requests", () => {
+  assert.equal(
+    resolveSidecarRequestModel("llama_cpp", "/app/data/models/gemma-4-E2B-it-Q8_0.gguf"),
+    "local-sidecar",
+  );
+});
+
+test("falls back to the synthetic local model name when no MLX repo is configured", () => {
+  assert.equal(resolveSidecarRequestModel("mlx", null), "local-sidecar");
+});

--- a/packages/server/test/sidecar-runtime-env.test.ts
+++ b/packages/server/test/sidecar-runtime-env.test.ts
@@ -1,0 +1,51 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { delimiter } from "node:path";
+import { buildLlamaProcessEnv } from "../src/services/sidecar/sidecar-runtime-env.js";
+
+test("adds the bundled runtime directory to LD_LIBRARY_PATH on Android", () => {
+  const env = buildLlamaProcessEnv(
+    {
+      source: "bundled",
+      serverPath: "/data/data/com.termux/files/home/Marinara-Engine/packages/server/data/sidecar-runtime/b8851-android-arm64-cpu/llama-b8851/llama-server",
+    },
+    "android",
+    {},
+  );
+
+  assert.equal(
+    env.LD_LIBRARY_PATH,
+    "/data/data/com.termux/files/home/Marinara-Engine/packages/server/data/sidecar-runtime/b8851-android-arm64-cpu/llama-b8851",
+  );
+});
+
+test("prepends the bundled runtime directory only once", () => {
+  const runtimeDir = "/app/data/sidecar-runtime/b8855-linux-x64-cpu/llama-b8855";
+  const env = buildLlamaProcessEnv(
+    {
+      source: "bundled",
+      serverPath: `${runtimeDir}/llama-server`,
+    },
+    "linux",
+    {
+      LD_LIBRARY_PATH: `${runtimeDir}${delimiter}/usr/lib`,
+    },
+  );
+
+  assert.equal(env.LD_LIBRARY_PATH, `${runtimeDir}${delimiter}/usr/lib`);
+});
+
+test("leaves system runtimes unchanged", () => {
+  const env = buildLlamaProcessEnv(
+    {
+      source: "system",
+      serverPath: "/usr/bin/llama-server",
+    },
+    "linux",
+    {
+      LD_LIBRARY_PATH: "/usr/lib",
+    },
+  );
+
+  assert.equal(env.LD_LIBRARY_PATH, "/usr/lib");
+});

--- a/packages/shared/src/types/sidecar.ts
+++ b/packages/shared/src/types/sidecar.ts
@@ -12,6 +12,10 @@ export type SidecarQuantization = "q8_0" | "q4_k_m";
 /** Runtime backend used by the built-in local model. */
 export type SidecarBackend = "llama_cpp" | "mlx";
 
+/** Which runtime target Marinara should prepare for llama.cpp-based local inference. */
+export const SIDECAR_RUNTIME_PREFERENCES = ["auto", "nvidia", "amd", "intel", "vulkan", "cpu", "system"] as const;
+export type SidecarRuntimePreference = (typeof SIDECAR_RUNTIME_PREFERENCES)[number];
+
 /** Where the active runtime comes from. */
 export type SidecarRuntimeSource = "bundled" | "system";
 
@@ -61,6 +65,8 @@ export interface SidecarConfig {
   contextSize: number;
   /** GPU layers to offload (-1 = try max GPU offload first, then fall back if startup fails). */
   gpuLayers: number;
+  /** Which runtime target to install for llama.cpp-based local inference. */
+  runtimePreference: SidecarRuntimePreference;
 }
 
 export interface SidecarRuntimeInfo {
@@ -216,6 +222,7 @@ export const SIDECAR_DEFAULT_CONFIG: SidecarConfig = {
   useForGameScene: true,
   contextSize: 8192,
   gpuLayers: -1,
+  runtimePreference: "auto",
 };
 
 /**


### PR DESCRIPTION
## Summary

This PR cleans up the Local AI setup flow so runtime setup is separate from model download, easier to configure, and less likely to pick the wrong device on mixed-GPU systems.

## What Changed

- Split runtime installation/setup from model download for the Local AI flow
- Added explicit runtime targeting so users can choose the backend/device family instead of relying only on auto-detection
- Moved the advanced Local AI controls into Runtime Settings to keep the main modal cleaner
- Fixed custom GPU layers so custom values persist and apply correctly
- Updated the Local Model card to always open settings instead of switching between download/delete actions
- Removed the automatic Local AI modal prompt on startup
- Added Local Model setup as part of the replay/onboarding tutorial instead
- Cleaned up old local model artifacts when switching to a new model
- Cleaned up old runtime artifacts when installing/reinstalling a new runtime
- Merged the latest `main` into this branch and resolved the sidecar-related conflicts

## Notes

- Apple Silicon continues to use the MLX path, with cleanup handled through the MLX cache/runtime flow
- System `llama-server` installs from PATH are still treated as external and are not deleted by Marinara

## Validation

- `pnpm --filter @marinara-engine/client build`
- `pnpm --filter @marinara-engine/server test`
- `pnpm --filter @marinara-engine/server lint`
