### PR TITLE
Fix comfyui generation for sprites and fix default workflow

### DIFF
--- a/packages/server/src/routes/sprites.routes.ts
+++ b/packages/server/src/routes/sprites.routes.ts
@@ -428,6 +428,7 @@ export async function spritesRoutes(app: FastifyInstance) {
               height: targetHeight,
               referenceImage: resolvedRefs[0],
               referenceImages: resolvedRefs.length > 1 ? resolvedRefs : undefined,
+              comfyWorkflow: conn.comfyuiWorkflow || undefined,
             });
 
             let spriteBuffer: Buffer = Buffer.from(imageResult.base64, "base64");
@@ -492,6 +493,7 @@ export async function spritesRoutes(app: FastifyInstance) {
         height: sheetHeight,
         referenceImage: resolvedRefs[0],
         referenceImages: resolvedRefs.length > 1 ? resolvedRefs : undefined,
+        comfyWorkflow: conn.comfyuiWorkflow || undefined,
       });
 
       // Decode the generated image

--- a/packages/server/src/services/image/image-generation.ts
+++ b/packages/server/src/services/image/image-generation.ts
@@ -494,7 +494,7 @@ const DEFAULT_COMFYUI_WORKFLOW: Record<string, unknown> = {
   "3": {
     class_type: "KSampler",
     inputs: {
-      seed: 0,
+      seed: "%seed%",
       steps: 20,
       cfg: 7,
       sampler_name: "euler_ancestral",
@@ -512,7 +512,7 @@ const DEFAULT_COMFYUI_WORKFLOW: Record<string, unknown> = {
   },
   "5": {
     class_type: "EmptyLatentImage",
-    inputs: { width: 512, height: 768, batch_size: 1 },
+    inputs: { width: "%width%", height: "%height%", batch_size: 1 },
   },
   "6": {
     class_type: "CLIPTextEncode",

--- a/packages/server/src/services/image/image-generation.ts
+++ b/packages/server/src/services/image/image-generation.ts
@@ -532,6 +532,8 @@ const DEFAULT_COMFYUI_WORKFLOW: Record<string, unknown> = {
   },
 };
 
+const COMFYUI_GEN_TIMEOUT = Number(process.env.COMFYUI_GEN_TIMEOUT ?? 120);
+
 async function generateComfyUI(baseUrl: string, request: ImageGenRequest): Promise<ImageGenResult> {
   const base = baseUrl.replace(/\/+$/, "");
   const seed = Math.floor(Math.random() * 2 ** 32);
@@ -581,8 +583,7 @@ async function generateComfyUI(baseUrl: string, request: ImageGenRequest): Promi
   const { prompt_id } = (await queueResp.json()) as { prompt_id: string };
 
   // Poll for completion (max ~120 seconds)
-  const maxAttempts = 120;
-  for (let i = 0; i < maxAttempts; i++) {
+  for (let i = 0; i < COMFYUI_GEN_TIMEOUT; i++) {
     await new Promise((r) => setTimeout(r, 1000));
 
     const historyResp = await fetch(`${base}/history/${prompt_id}`);


### PR DESCRIPTION
## Why this change

When generating sprites, the comfyui workflow from the connection settings is not passed through. So it will always default to the default comfyui workflow. This is fine for most SDXL setups, but if using models like flux or ernie, they require different text encoders / vae.

Also the default comfyui workflow does not use the generated seed, so if using the same connection, the output would always be the same, regardless of regeneration. So I have updated the workflow to use the generated seed during the generation request. Width / Height were also not used, so I fixed that as well.

## What changed

Update sprite generation to pass comfyui workflow.
Update pose generation to pass comfyui workflow.
Update default comfyui workflow to add in placeholders for seed/width/height.
Added an env variable to allow customisation of the comfyui timeout (120 seconds is not always sufficient for some models)

## Validation

Setup a comfyui connection, and use a custom workflow and attempt to do sprite / pose generation.
Before update, will fail.

Retry a generation without any custom workflow
Before update, the results will be the same on each generation.

### Manual verification notes

I had manually checked with SDXL / Chroma / Flux / Ernie based workflows. With / Without custom workflows added.





First PR here, and a simple one so have not done all the linting / tooling.
