### PR TITLE
feat: Add Wolfi Lite container image

### DIFF
--- a/.github/workflows/build-container-lite.yml
+++ b/.github/workflows/build-container-lite.yml
@@ -1,0 +1,163 @@
+# ──────────────────────────────────────────────
+# Build & push lite container image to GHCR
+# ──────────────────────────────────────────────
+# Triggers:
+#   • Tag v*  → ghcr.io/pasta-devs/marinara-engine:1.5.4-lite + :lite
+#
+# NOT triggered on push to main — lite images are only published
+# alongside versioned releases.
+# ──────────────────────────────────────────────
+name: Build & Push Lite Container Image
+
+on:
+  push:
+    tags: ["v*"]
+
+concurrency:
+  group: image-lite-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Lowercase image name
+        id: lower
+        run: echo "image=${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ steps.lower.outputs.image }}
+          tags: |
+            type=semver,pattern={{version}},suffix=-lite
+            type=semver,pattern={{major}}.{{minor}},suffix=-lite
+            type=semver,pattern={{major}},suffix=-lite
+            type=raw,value=lite
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.lite
+          platforms: ${{ matrix.platform }}
+          build-args: |
+            BUILD_COMMIT=${{ github.sha }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ steps.lower.outputs.image }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=lite-${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=lite-${{ matrix.platform }}
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-lite-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: build
+
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Lowercase image name
+        id: lower
+        run: echo "image=${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-lite-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ steps.lower.outputs.image }}
+          tags: |
+            type=semver,pattern={{version}},suffix=-lite
+            type=semver,pattern={{major}}.{{minor}},suffix=-lite
+            type=semver,pattern={{major}},suffix=-lite
+            type=raw,value=lite
+
+      - name: Create manifest list and push
+        id: manifest
+        working-directory: /tmp/digests
+        run: |
+          tags=$(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          image="${{ env.REGISTRY }}/${{ steps.lower.outputs.image }}"
+          digests=$(printf "${image}@sha256:%s " *)
+          docker buildx imagetools create $tags $digests
+          digest=$(docker buildx imagetools inspect "$image:${{ steps.meta.outputs.version }}-lite" --raw | sha256sum | cut -d' ' -f1 | sed 's/^/sha256:/')
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ steps.lower.outputs.image }}:${{ steps.meta.outputs.version }}-lite
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ steps.lower.outputs.image }}
+          subject-digest: ${{ steps.manifest.outputs.digest }}
+          push-to-registry: true

--- a/Dockerfile.lite
+++ b/Dockerfile.lite
@@ -1,0 +1,129 @@
+# ──────────────────────────────────────────────
+# Marinara Engine — Wolfi Lite Docker Build
+# ──────────────────────────────────────────────
+# Three-stage build using Chainguard Wolfi images:
+#   1. Builder  — full dev toolchain, compiles TS and bundles client
+#   2. Deps     — production-only node_modules (stripped of heavy native deps)
+#   3. Runtime  — minimal Wolfi base + Node.js 22 binary only
+#
+# Disabled features (MARINARA_LITE):
+#   • Local sidecar model (llama-server / Gemma)
+#   • Local embedding model (onnxruntime + all-MiniLM-L6-v2)
+#   • Memory recall (semantic search)
+# ──────────────────────────────────────────────
+
+# ── Stage 1: Build ──
+# Uses wolfi-base + nodejs-22 + npm so Node ABI matches across all stages.
+FROM cgr.dev/chainguard/wolfi-base AS builder
+ARG BUILD_COMMIT
+WORKDIR /app
+
+RUN apk add --no-cache nodejs-22 npm && \
+    npm install -g pnpm@10.30.3
+
+ENV MARINARA_LITE=true
+ENV VITE_MARINARA_LITE=true
+
+# Copy workspace config first (layer cache for deps)
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY packages/shared/package.json packages/shared/
+COPY packages/server/package.json packages/server/
+COPY packages/client/package.json packages/client/
+
+# Install all dependencies (including dev for building)
+RUN --mount=type=cache,target=/root/.local/share/pnpm/store \
+    pnpm install --frozen-lockfile
+
+# Copy source code
+COPY tsconfig.base.json ./
+COPY packages/shared/ packages/shared/
+COPY packages/server/ packages/server/
+COPY packages/client/ packages/client/
+
+# Build everything: shared → server + client in parallel
+ENV NODE_OPTIONS="--max-old-space-size=4096"
+RUN pnpm build
+
+# Bake the git commit into build-meta.json so the app can display it.
+RUN if [ -n "$BUILD_COMMIT" ]; then \
+      echo "{\"commit\":\"$BUILD_COMMIT\"}" > packages/server/dist/config/build-meta.json; \
+    fi
+
+# ── Stage 2: Production dependencies ──
+# Separate stage keeps builder cache warm while allowing aggressive dep stripping.
+FROM cgr.dev/chainguard/wolfi-base AS deps
+WORKDIR /app
+
+RUN apk add --no-cache nodejs-22 npm && \
+    npm install -g pnpm@10.30.3
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY packages/shared/package.json packages/shared/
+COPY packages/server/package.json packages/server/
+COPY packages/client/package.json packages/client/
+
+# Install production deps only, then strip non-core native modules.
+RUN --mount=type=cache,target=/root/.local/share/pnpm/store \
+    pnpm install --frozen-lockfile --prod && \
+    # ── Remove onnxruntime (native + WASM) ──
+    rm -rf /app/node_modules/.pnpm/onnxruntime-node@* \
+           /app/node_modules/.pnpm/onnxruntime-web@* \
+           /app/node_modules/.pnpm/onnxruntime-common@* \
+           /app/node_modules/onnxruntime-node \
+           /app/node_modules/onnxruntime-web \
+           /app/node_modules/onnxruntime-common && \
+    # ── Remove @huggingface/transformers (embedding model runtime) ──
+    rm -rf /app/node_modules/.pnpm/@huggingface+transformers@* \
+           /app/node_modules/@huggingface && \
+    # ── Remove sharp native binaries ──
+    rm -rf /app/node_modules/.pnpm/sharp@* \
+           /app/node_modules/sharp && \
+    # ── Sweep leftover native addons ──
+    find /app/node_modules/.pnpm -name '*.node' -path '*onnxruntime*' -delete 2>/dev/null; true
+
+# Archive node_modules preserving pnpm symlinks — Docker COPY
+# dereferences them which would break module resolution.
+RUN tar cf /tmp/node_modules.tar \
+    node_modules \
+    packages/shared/node_modules \
+    packages/server/node_modules 2>/dev/null; true
+
+# ── Stage 3: Minimal Wolfi runtime ──
+# Only the Node.js 22 binary — no npm, no build tools, no shell bloat.
+FROM cgr.dev/chainguard/wolfi-base AS production
+WORKDIR /app
+
+RUN apk add --no-cache nodejs-22-minimal && \
+    # Drop the package manager cache to save space
+    rm -rf /var/cache/apk/*
+
+# Extract prod node_modules (preserves pnpm symlinks).
+# Use a bind mount from the deps stage to avoid copying the tar into the image
+RUN --mount=type=bind,from=deps,source=/tmp/node_modules.tar,target=/tmp/node_modules.tar \
+    tar xf /tmp/node_modules.tar -C /app
+
+# Copy workspace manifests (pnpm resolution needs them)
+COPY package.json pnpm-workspace.yaml ./
+COPY packages/shared/package.json packages/shared/
+COPY packages/server/package.json packages/server/
+COPY packages/client/package.json packages/client/
+
+# Copy built artifacts from builder
+COPY --from=builder /app/packages/shared/dist packages/shared/dist
+COPY --from=builder /app/packages/server/dist packages/server/dist
+COPY --from=builder /app/packages/client/dist packages/client/dist
+
+# Ensure data directory exists
+RUN mkdir -p /app/data
+
+# Runtime feature flag
+ENV MARINARA_LITE=true
+ENV DATA_DIR=/app/data
+ENV PORT=7860
+ENV HOST=0.0.0.0
+ENV NODE_ENV=production
+
+VOLUME /app/data
+EXPOSE 7860
+
+CMD ["node", "packages/server/dist/index.js"]

--- a/docs/installation/containers.md
+++ b/docs/installation/containers.md
@@ -1,6 +1,8 @@
 # Run via Container (Docker / Podman)
 
-## Pre-built Image (Docker)
+## Docker
+
+### Pre-built Image
 
 ```bash
 docker compose up -d
@@ -20,7 +22,7 @@ To pull the latest image and restart:
 docker compose down && docker compose pull && docker compose up -d
 ```
 
-## Build from Source (Docker)
+### Build from Source
 
 If you prefer to build the image yourself:
 
@@ -48,6 +50,46 @@ podman run -d -p 7860:7860 -v marinara-data:/app/data ghcr.io/pasta-devs/marinar
 ```
 
 > **Note:** `podman compose` requires the [`podman-compose`](https://github.com/containers/podman-compose/) plugin. On most distributions you can install it with `sudo dnf install podman-compose` (Fedora), `sudo apt install podman-compose` (Debian/Ubuntu), or `pip install podman-compose`.
+
+## Lite Image (Optional)
+
+A **lite** image variant is available that trades some offline features for a significantly smaller footprint (~60 % smaller than the full image). It is built on [Wolfi](https://wolfi.dev/) — a minimal, CVE-focused Linux (un)distribution designed for containers.
+
+### What is removed
+
+| Feature                                    | Why it’s heavy                                                                |
+| ------------------------------------------ | ----------------------------------------------------------------------------- |
+| Local sidecar model (llama-server / Gemma) | Native runtime libs (`libssl`, `libgomp`, `libvulkan`), large model downloads |
+| Local embedding model (all-MiniLM-L6-v2)   | `onnxruntime-node`, `onnxruntime-web`, `@huggingface/transformers`            |
+| Memory recall (semantic search)            | Depends on the local embedding model                                          |
+| `sharp` native image processing            | Platform-specific native binaries                                             |
+
+All core features — chat, roleplay, game mode, agents, lorebooks, characters, connections to remote LLM APIs — work exactly the same. You just need an external API connection (OpenRouter, OpenAI, Ollama, etc.) for all LLM features instead of being able to run a model locally via ME.
+
+
+### Pre-built image
+
+```bash
+docker pull ghcr.io/pasta-devs/marinara-engine:lite
+docker run -d -p 7860:7860 -v marinara-data:/app/data ghcr.io/pasta-devs/marinara-engine:lite
+```
+
+Or with Podman:
+
+```bash
+podman run -d -p 7860:7860 -v marinara-data:/app/data ghcr.io/pasta-devs/marinara-engine:lite
+```
+
+### Build from source
+
+```bash
+git clone https://github.com/Pasta-Devs/Marinara-Engine.git
+cd Marinara-Engine
+docker build -f Dockerfile.lite -t marinara-engine:lite .
+docker run -d -p 7860:7860 -v marinara-data:/app/data marinara-engine:lite
+```
+
+> **Note:** The lite image is published alongside each versioned release (e.g. `ghcr.io/pasta-devs/marinara-engine:1.5.4-lite`). It is **not** published on every push to `main`.
 
 ## Updating
 

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -42,6 +42,7 @@ async function recoverFromVersionSkew(serverVersion: string) {
 
 export function App() {
   const theme = useUIStore((s) => s.theme);
+  const isLite = import.meta.env.VITE_MARINARA_LITE === "true";
   const fontSize = useUIStore((s) => s.fontSize);
   const language = useUIStore((s) => s.language);
   const visualTheme = useUIStore((s) => s.visualTheme);
@@ -55,7 +56,7 @@ export function App() {
 
   // Fetch sidecar status on mount so the Local AI card is populated when opened later.
   useEffect(() => {
-    void fetchSidecarStatus();
+    if (!isLite) void fetchSidecarStatus();
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Apply theme + font size to the document root whenever they change
@@ -187,7 +188,7 @@ export function App() {
     <>
       <CustomThemeInjector />
       <AppShell />
-      <ModelDownloadModal open={showDownloadModal} onClose={() => setShowDownloadModal(false)} />
+      {!isLite && <ModelDownloadModal open={showDownloadModal} onClose={() => setShowDownloadModal(false)} />}
       {hasModalOpen && (
         <Suspense fallback={null}>
           <LazyModalRenderer />

--- a/packages/client/src/components/agents/AgentEditor.tsx
+++ b/packages/client/src/components/agents/AgentEditor.tsx
@@ -564,7 +564,9 @@ export function AgentEditor() {
               <option value="">
                 {defaultAgentConn ? `Agent default (${defaultAgentConn.name})` : "Use chat connection"}
               </option>
-              <option value={LOCAL_SIDECAR_CONNECTION_ID}>Local Model (sidecar)</option>
+              {import.meta.env.VITE_MARINARA_LITE !== "true" && (
+                <option value={LOCAL_SIDECAR_CONNECTION_ID}>Local Model (sidecar)</option>
+              )}
               {llmConnections.map((conn) => (
                 <option key={conn.id} value={conn.id}>
                   {conn.name} ({conn.provider})

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -2405,7 +2405,7 @@ export function ChatSettingsDrawer({
                       }
                       className="w-full rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-2.5 py-1.5 text-xs text-[var(--foreground)]"
                     >
-                      <option value="">Local sidecar (Gemma)</option>
+                      {import.meta.env.VITE_MARINARA_LITE !== "true" && <option value="">Local sidecar (Gemma)</option>}
                       {((connections ?? []) as Array<{ id: string; name: string; model?: string }>)
                         .filter((c) => (c as { provider?: string }).provider !== "image_generation")
                         .map((c) => (
@@ -2862,7 +2862,7 @@ export function ChatSettingsDrawer({
           )}
 
           {/* Memory Recall — conversation mode: show here; roleplay: shown after Function Calling */}
-          {isConversation && (
+          {isConversation && import.meta.env.VITE_MARINARA_LITE !== "true" && (
             <Section
               label="Memory Recall"
               icon={<Brain size="0.875rem" />}
@@ -3132,7 +3132,7 @@ export function ChatSettingsDrawer({
           )}
 
           {/* Memory Recall — roleplay mode: show after Function Calling */}
-          {!isConversation && (
+          {!isConversation && import.meta.env.VITE_MARINARA_LITE !== "true" && (
             <Section
               label="Memory Recall"
               icon={<Brain size="0.875rem" />}

--- a/packages/client/src/components/panels/ConnectionsPanel.tsx
+++ b/packages/client/src/components/panels/ConnectionsPanel.tsx
@@ -276,7 +276,7 @@ export function ConnectionsPanel() {
   return (
     <div className="flex flex-col gap-2 p-3">
       {/* ── Local Model (Sidecar) ── */}
-      <SidecarCard />
+      {import.meta.env.VITE_MARINARA_LITE !== "true" && <SidecarCard />}
 
       <button
         onClick={() => openModal("create-connection")}

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -31,6 +31,7 @@ import {
 } from "./config/runtime-config.js";
 import { sidecarProcessService } from "./services/sidecar/sidecar-process.service.js";
 
+const isLite = process.env.MARINARA_LITE === "true" || process.env.MARINARA_LITE === "1";
 const REVALIDATE_FILES = new Set(["index.html"]);
 const NO_STORE_FILES = new Set(["manifest.json", "sw.js", "registerSW.js"]);
 
@@ -100,10 +101,12 @@ export async function buildApp(https?: { cert: Buffer; key: Buffer }) {
   // ── Routes ──
   await registerRoutes(app);
 
-  // ── Sidecar bootstrap (background) ──
-  void sidecarProcessService.syncForCurrentConfig({ suppressKnownFailure: true, allowRuntimeInstall: false }).catch((error) => {
-    app.log.warn({ err: error }, "sidecar bootstrap failed");
-  });
+  // ── Sidecar bootstrap (background, skipped in lite mode) ──
+  if (!isLite) {
+    void sidecarProcessService.syncForCurrentConfig({ suppressKnownFailure: true, allowRuntimeInstall: false }).catch((error) => {
+      app.log.warn({ err: error }, "sidecar bootstrap failed");
+    });
+  }
 
   // ── Serve client build in production ──
   const __dirname = dirname(fileURLToPath(import.meta.url));

--- a/packages/server/src/routes/index.ts
+++ b/packages/server/src/routes/index.ts
@@ -87,5 +87,7 @@ export async function registerRoutes(app: FastifyInstance) {
   await app.register(appSettingsRoutes, { prefix: "/api/app-settings" });
   await app.register(gameRoutes, { prefix: "/api/game" });
   await app.register(gameAssetsRoutes, { prefix: "/api/game-assets" });
-  await app.register(sidecarRoutes, { prefix: "/api/sidecar" });
+  if (process.env.MARINARA_LITE !== "true" && process.env.MARINARA_LITE !== "1") {
+    await app.register(sidecarRoutes, { prefix: "/api/sidecar" });
+  }
 }

--- a/packages/server/src/services/local-embedder.ts
+++ b/packages/server/src/services/local-embedder.ts
@@ -15,6 +15,7 @@ import { DATA_DIR } from "../utils/data-dir.js";
 
 const MODEL_ID = "Xenova/all-MiniLM-L6-v2";
 const CACHE_DIR = join(DATA_DIR, "models");
+const isLite = process.env.MARINARA_LITE === "true" || process.env.MARINARA_LITE === "1";
 
 // Singleton state
 let pipeline: any = null;
@@ -27,6 +28,7 @@ let loadFailed = false;
  */
 async function getPipeline(): Promise<any> {
   if (pipeline) return pipeline;
+  if (isLite) return null;
   if (loadFailed) return null;
   if (loadingPromise) return loadingPromise;
 
@@ -95,5 +97,6 @@ export async function localEmbed(texts: string[]): Promise<number[][] | null> {
  * Check if the local embedder is available (model loaded or loadable).
  */
 export function isLocalEmbedderAvailable(): boolean {
+  if (isLite) return false;
   return !loadFailed;
 }

--- a/packages/server/src/services/memory-recall.ts
+++ b/packages/server/src/services/memory-recall.ts
@@ -9,6 +9,7 @@ import type { DB } from "../db/connection.js";
 import { messages, memoryChunks } from "../db/schema/index.js";
 import { newId, now } from "../utils/id-generator.js";
 import { localEmbed } from "./local-embedder.js";
+const isLite = process.env.MARINARA_LITE === "true" || process.env.MARINARA_LITE === "1";
 
 /** How many messages per chunk. */
 const CHUNK_SIZE = 5;
@@ -55,6 +56,7 @@ export async function chunkAndEmbedMessages(
   /** Map from role → display name. Used to format "Name: content" lines. */
   nameMap: { userName: string; characterNames: Record<string, string> },
 ): Promise<void> {
+  if (isLite) return;
   // Find the last chunk for this chat to know where to start
   const lastChunk = await db
     .select({ lastMessageAt: memoryChunks.lastMessageAt })
@@ -148,6 +150,7 @@ export async function recallMemories(
   chatIds: string[],
   topK: number = DEFAULT_TOP_K,
 ): Promise<RecalledMemory[]> {
+  if (isLite) return [];
   if (chatIds.length === 0) return [];
 
   // Embed the query using local model


### PR DESCRIPTION
This pull request introduces a new "lite" container image variant for Marinara Engine, focused on reducing image size and attack surface by removing heavy native dependencies and features that require them. It includes a new `Dockerfile.lite` and a dedicated GitHub Actions workflow for building and publishing the lite image. The application code (both server and client) is updated to detect and gracefully disable features not available in the lite build, such as local model hosting, local embedding, and memory recall. Documentation is also updated to describe the lite image, its trade-offs, and usage instructions.

**Containerization & Build System:**
* Added a new GitHub Actions workflow (`.github/workflows/build-container-lite.yml`) to build and publish a multi-arch "lite" container image on versioned release tags, using a minimal Wolfi Linux base and aggressively stripping heavy native dependencies.
* Introduced `Dockerfile.lite`, a three-stage build that omits local model hosting, embedding models, and certain native modules, resulting in a significantly smaller image.

**Documentation:**
* Updated `docs/installation/containers.md` to document the lite image, its differences, and how to use or build it, including a feature comparison table and usage notes. [[1]](diffhunk://#diff-507b48ca8b05fb1099599fec6971fa984ed1a3e8aa2d7665ee1233ccb6d64322L3-R5) [[2]](diffhunk://#diff-507b48ca8b05fb1099599fec6971fa984ed1a3e8aa2d7665ee1233ccb6d64322L23-R25) [[3]](diffhunk://#diff-507b48ca8b05fb1099599fec6971fa984ed1a3e8aa2d7665ee1233ccb6d64322R54-R93)

**Server-Side Feature Gating:**
* Added detection of the lite mode via the `MARINARA_LITE` environment variable in server code. Sidecar model routes, local embedding, and memory recall features are disabled or bypassed in lite mode. [[1]](diffhunk://#diff-b4bf798ca8820447b50fa3dd7cb2ab33ba486b016686ce4f98d28cb3df65b0aeR34) [[2]](diffhunk://#diff-b4bf798ca8820447b50fa3dd7cb2ab33ba486b016686ce4f98d28cb3df65b0aeL103-R109) [[3]](diffhunk://#diff-1dca9465f61595dd08b9d1f48ffb2cff431c9e55a4516ddc6275e9628d595b0eR90-R93) [[4]](diffhunk://#diff-b97cff79b69bf0696e1ff8ba2942a197948cefe9d3a9c81a4b86558f1953e155R18) [[5]](diffhunk://#diff-b97cff79b69bf0696e1ff8ba2942a197948cefe9d3a9c81a4b86558f1953e155R31) [[6]](diffhunk://#diff-b97cff79b69bf0696e1ff8ba2942a197948cefe9d3a9c81a4b86558f1953e155R100) [[7]](diffhunk://#diff-180993a383c2b5769da9370fafc6f79f3459116cd568b07e14b957679598ff7cR12)

**Client-Side Feature Gating:**
* The client now checks the `VITE_MARINARA_LITE` build-time variable and hides or disables UI elements related to local models, local embedding, and memory recall when running in lite mode. [[1]](diffhunk://#diff-ec2dc392bcf26c2a7c1a34631db8a5f5d220596d2e986f8959acaa22494fcb78R45) [[2]](diffhunk://#diff-ec2dc392bcf26c2a7c1a34631db8a5f5d220596d2e986f8959acaa22494fcb78L58-R59) [[3]](diffhunk://#diff-ec2dc392bcf26c2a7c1a34631db8a5f5d220596d2e986f8959acaa22494fcb78L190-R191) [[4]](diffhunk://#diff-0bba2d0e2b9e3d9b5da905af1aef4486a5ab9589e254e013882899ace458ddf9R567-R569) [[5]](diffhunk://#diff-686dcec1921d20b6e91eef19d163dd39c6c6ba34f24c7ae753f3e0430823eeb8L2408-R2408) [[6]](diffhunk://#diff-686dcec1921d20b6e91eef19d163dd39c6c6ba34f24c7ae753f3e0430823eeb8L2865-R2865) [[7]](diffhunk://#diff-686dcec1921d20b6e91eef19d163dd39c6c6ba34f24c7ae753f3e0430823eeb8L3135-R3135) [[8]](diffhunk://#diff-264a3bb94168d1e2dda2790e996da2e830cde1b4f37e7004c22a18c91d1bbb2dL279-R279)
