### PR TITLE
feat(client): Add start muted option and persist audio settings

### DIFF
--- a/packages/client/src/components/game/GameSetupWizard.tsx
+++ b/packages/client/src/components/game/GameSetupWizard.tsx
@@ -15,6 +15,8 @@ import {
   Plug,
   Image,
   BookOpen,
+  Volume2,
+  VolumeX,
 } from "lucide-react";
 import type { GameSetupConfig, GameGmMode } from "@marinara-engine/shared";
 import { cn } from "../../lib/utils";
@@ -29,6 +31,7 @@ import { useConnections } from "../../hooks/use-connections";
 import { usePersonas } from "../../hooks/use-characters";
 import { useSidecarStore } from "../../stores/sidecar.store";
 import { useLorebooks } from "../../hooks/use-lorebooks";
+import { useGameAssetStore } from "../../stores/game-asset.store";
 
 interface GameSetupWizardProps {
   onComplete: (
@@ -103,6 +106,7 @@ export function GameSetupWizard({ onComplete, onCancel, isLoading, characters }:
   const [lbSearch, setLbSearch] = useState("");
   const [enableCustomWidgets, setEnableCustomWidgets] = useState(true);
   const [language, setLanguage] = useState("English");
+  const [startMuted, setStartMuted] = useState(false);
 
   const sidecarStatus = useSidecarStore((s) => s.status);
   const sidecarConfig = useSidecarStore((s) => s.config);
@@ -235,6 +239,9 @@ export function GameSetupWizard({ onComplete, onCancel, isLoading, characters }:
 
   const handleComplete = () => {
     if (isLoading || !canStart) return;
+    if (startMuted) {
+      useGameAssetStore.getState().setAudioMuted(true);
+    }
     // Sync the wizard's local-scene toggle to the global sidecar config
     if (sidecarAvailable) {
       useSidecarStore.getState().updateConfig({ useForGameScene: sceneModelValue === "local" });
@@ -1197,6 +1204,41 @@ export function GameSetupWizard({ onComplete, onCancel, isLoading, characters }:
                 </div>
               </div>
             </div>
+
+          {/* Start Muted */}
+          <div className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-3">
+            <button
+              onClick={() => setStartMuted(!startMuted)}
+              className="flex w-full items-center justify-between gap-2 text-left"
+            >
+              <div className="flex items-center gap-2">
+                {startMuted ? (
+                  <VolumeX size={14} className="text-[var(--muted-foreground)]" />
+                ) : (
+                  <Volume2 size={14} className="text-[var(--primary)]" />
+                )}
+                <div>
+                  <p className="text-xs font-medium text-[var(--foreground)]">Start Muted</p>
+                  <p className="text-[0.55rem] text-[var(--muted-foreground)]">
+                    Begin the game with all audio muted
+                  </p>
+                </div>
+              </div>
+              <div
+                className={cn(
+                  "flex h-5 w-8 items-center rounded-full px-0.5 transition-colors",
+                  startMuted ? "bg-[var(--primary)]" : "bg-[var(--secondary)]",
+                )}
+              >
+                <div
+                  className={cn(
+                    "h-4 w-4 rounded-full bg-white transition-transform",
+                    startMuted && "translate-x-3.5",
+                  )}
+                />
+              </div>
+            </button>
+          </div>
           </>
         )}
       </div>

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -418,7 +418,10 @@ export function GameSurface({
   } | null>(null);
   const [assetGenerationFailed, setAssetGenerationFailed] = useState(false);
   const [volumePopoverOpen, setVolumePopoverOpen] = useState(false);
-  const [masterVolume, setMasterVolume] = useState(50);
+  const [masterVolume, setMasterVolume] = useState(() => {
+    const saved = localStorage.getItem("game-master-volume");
+    return saved != null ? Number(saved) : 50;
+  });
   const [tutorialOpen, setTutorialOpen] = useState(false);
   const tutorialAutoTriggeredRef = useRef(false);
   const volumePopoverRef = useRef<HTMLDivElement>(null);
@@ -2242,6 +2245,7 @@ export function GameSurface({
   const handleVolumeChange = useCallback(
     (value: number) => {
       setMasterVolume(value);
+      localStorage.setItem("game-master-volume", String(value));
       const v = value / 100;
       audioManager.setVolumes(v * 0.6, v * 0.8, v * 0.5); // scale: music 60%, sfx 80%, ambient 50% of master
       if (value === 0 && !audioMuted) {
@@ -2252,6 +2256,13 @@ export function GameSurface({
     },
     [audioMuted],
   );
+
+  // Apply saved volume on mount so audioManager matches the persisted level
+  useEffect(() => {
+    const v = masterVolume / 100;
+    audioManager.setVolumes(v * 0.6, v * 0.8, v * 0.5);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Close volume popover on outside click
   useEffect(() => {
@@ -2684,7 +2695,7 @@ export function GameSurface({
                         <div className="relative flex h-32 w-5 items-end justify-center rounded-full bg-white/10">
                           <div
                             className="absolute bottom-0 w-full rounded-full bg-[var(--primary)]/60"
-                            style={{ height: `${masterVolume}%` }}
+                            style={{ height: `${audioMuted ? 0 : masterVolume}%` }}
                           />
                           <input
                             type="range"
@@ -2696,7 +2707,19 @@ export function GameSurface({
                             style={{ writingMode: "vertical-lr", direction: "rtl" }}
                           />
                         </div>
-                        <span className="text-[10px] tabular-nums text-white/50">{masterVolume}</span>
+                        <span className="text-[10px] tabular-nums text-white/50">{audioMuted ? "M" : masterVolume}</span>
+                        <button
+                          onClick={handleToggleMute}
+                          className={cn(
+                            "flex h-6 w-6 items-center justify-center rounded-full transition-colors",
+                            audioMuted
+                              ? "bg-red-500/30 text-red-300 hover:bg-red-500/50"
+                              : "bg-white/10 text-white/60 hover:bg-white/20 hover:text-white",
+                          )}
+                          title={audioMuted ? "Unmute" : "Mute"}
+                        >
+                          {audioMuted ? <VolumeX size={11} /> : <Volume2 size={11} />}
+                        </button>
                       </div>
                     )}
                   </div>

--- a/packages/client/src/stores/game-asset.store.ts
+++ b/packages/client/src/stores/game-asset.store.ts
@@ -55,7 +55,7 @@ export const useGameAssetStore = create<GameAssetStore>((set, get) => ({
   currentMusic: null,
   currentAmbient: null,
   currentBackground: null,
-  audioMuted: false,
+  audioMuted: localStorage.getItem("game-audio-muted") === "true",
 
   fetchManifest: async () => {
     set({ isLoading: true, error: null });
@@ -81,7 +81,10 @@ export const useGameAssetStore = create<GameAssetStore>((set, get) => ({
   setCurrentMusic: (tag) => set({ currentMusic: tag }),
   setCurrentAmbient: (tag) => set({ currentAmbient: tag }),
   setCurrentBackground: (tag) => set({ currentBackground: tag }),
-  setAudioMuted: (muted) => set({ audioMuted: muted }),
+  setAudioMuted: (muted) => {
+    localStorage.setItem("game-audio-muted", JSON.stringify(muted));
+    set({ audioMuted: muted });
+  },
 
   resolveAssetUrl: (tag: string) => {
     const { manifest } = get();


### PR DESCRIPTION
- Add "Start Muted" toggle to GameSetupWizard
- Persist audio mute and master volume to localStorage
- Sync audio state on mount and when changed
- Improve volume UI with mute button and indicator