### PR TITLE
Fix Android intro typewriter blocking touch-scroll in Game Mode

### DIFF
--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -81,7 +81,7 @@ import type { PersonaInfo } from "../chat/chat-area.types";
 /** Typewriter component for the intro screen — reveals text character-by-character. */
 function IntroTypewriter({ text, onComplete }: { text: string; onComplete?: () => void }) {
   const [visible, setVisible] = useState(0);
-  const containerRef = useRef<HTMLDivElement>(null);
+  const endRef = useRef<HTMLSpanElement>(null);
   const firedRef = useRef(false);
   useEffect(() => {
     if (visible >= text.length) {
@@ -94,15 +94,18 @@ function IntroTypewriter({ text, onComplete }: { text: string; onComplete?: () =
     const t = window.setTimeout(() => setVisible((v) => v + 1), 28);
     return () => window.clearTimeout(t);
   }, [visible, text.length, onComplete]);
-  // Auto-scroll to bottom as text is revealed
+  // Keep the reveal edge in view by scrolling the nearest scrollable ancestor.
+  // A nested overflow-y-auto here blocks Android touch-scroll from reaching the
+  // parent scroll container, so we don't create our own overflow on this div.
   useEffect(() => {
-    containerRef.current?.scrollTo({ top: containerRef.current.scrollHeight });
+    endRef.current?.scrollIntoView({ block: "end" });
   }, [visible]);
   return (
-    <div ref={containerRef} className="overflow-y-auto">
+    <div>
       <p className="text-sm leading-relaxed text-white/70 whitespace-pre-line">
         {text.slice(0, visible)}
         {visible < text.length && <span className="animate-pulse text-white/40">▌</span>}
+        <span ref={endRef} />
       </p>
     </div>
   );


### PR DESCRIPTION
## Summary

- In Game Mode, the intro world-overview screen was unscrollable on Android after a new game was started. Desktop mouse-wheel worked fine.
- Root cause: `IntroTypewriter` in [GameSurface.tsx](packages/client/src/components/game/GameSurface.tsx) wrapped its text in a `<div className="overflow-y-auto">` and auto-scrolled that inner div. The inner div had no height constraint so it never actually scrolled — but on Android Chrome the nested overflow container still captured touch events and blocked scroll-chaining up to the parent (`min-h-0 flex-1 overflow-y-auto`). Desktop mouse-wheel chains through nested overflow naturally, which is why Windows was unaffected.
- Fix: drop the inner `overflow-y-auto` and track the reveal edge with a sentinel `<span>` + `scrollIntoView({ block: "end" })`. The outer scroll container now handles touch input unimpeded, and the reveal-follow behavior is preserved.

## Test plan

- [x] TypeScript check passes (`pnpm --filter @marinara-engine/client exec tsc --noEmit`).
- [x] Tested on Android in a live deployment: scroll works during and after typewriter reveal.
- [x] Reveal edge still scrolls into view as characters appear.
- [x] Desktop (Chrome on Windows) still scrolls fine with mouse wheel.