### PR TITLE
Allow setting max_tokens per Connection.

### DIFF
--- a/packages/client/src/components/connections/ConnectionEditor.tsx
+++ b/packages/client/src/components/connections/ConnectionEditor.tsx
@@ -98,6 +98,7 @@ export function ConnectionEditor() {
   const [localImageGenerationSource, setLocalImageGenerationSource] = useState("");
   const [localComfyuiWorkflow, setLocalComfyuiWorkflow] = useState("");
   const [localImageService, setLocalImageService] = useState<string | null>(null);
+  const [localMaxTokensOverride, setLocalMaxTokensOverride] = useState<number | null>(null);
 
   // Test results
   const [testResult, setTestResult] = useState<{ success: boolean; message: string; latencyMs: number } | null>(null);
@@ -182,6 +183,7 @@ export function ConnectionEditor() {
     );
     setLocalComfyuiWorkflow((c.comfyuiWorkflow as string) ?? "");
     setLocalImageService(((c.imageService as string | null) ?? (c.imageGenerationSource as string | null)) || null);
+    setLocalMaxTokensOverride(typeof c.maxTokensOverride === "number" ? (c.maxTokensOverride as number) : null);
     setDirty(false);
     setSaveError(null);
     setTestResult(null);
@@ -258,6 +260,7 @@ export function ConnectionEditor() {
       comfyuiWorkflow: localComfyuiWorkflow || null,
       imageService:
         localProvider === "image_generation" ? localImageGenerationSource || localImageService || null : null,
+      maxTokensOverride: localMaxTokensOverride ?? null,
     };
     // Only send API key if user typed a new one
     if (localApiKey.trim()) {
@@ -288,6 +291,7 @@ export function ConnectionEditor() {
     localImageGenerationSource,
     localComfyuiWorkflow,
     localImageService,
+    localMaxTokensOverride,
     updateConnection,
   ]);
 
@@ -1003,6 +1007,35 @@ export function ConnectionEditor() {
               </div>
               <p className="mt-1 text-[0.625rem] text-[var(--muted-foreground)]">
                 This is auto-set when selecting a model from the list. Override manually if needed.
+              </p>
+            </FieldGroup>
+          )}
+
+          {/* ── Max Tokens Override ── */}
+          {localProvider !== "image_generation" && (
+            <FieldGroup
+              label="Max Tokens Override"
+              icon={<Zap size="0.875rem" className="text-amber-400" />}
+              help="Hard cap on max_tokens for the API response (limiting output size). Use this for providers that enforce a lower limit than what the engine calculates (e.g. DeepSeek caps at 8192). Leave empty to let the engine decide."
+            >
+              <div className="flex items-center gap-3">
+                <DraftNumberInput
+                  value={localMaxTokensOverride ?? 0}
+                  min={0}
+                  selectOnFocus
+                  onCommit={(nextValue) => {
+                    setLocalMaxTokensOverride(nextValue > 0 ? nextValue : null);
+                    markDirty();
+                  }}
+                  className="w-40 rounded-xl bg-[var(--secondary)] px-3 py-2.5 text-sm ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+                />
+                <span className="text-xs text-[var(--muted-foreground)]">
+                  {localMaxTokensOverride ? `${localMaxTokensOverride.toLocaleString()} tokens max` : "No override"}
+                </span>
+              </div>
+              <p className="mt-1 text-[0.625rem] text-[var(--muted-foreground)]">
+                Set to 0 or leave empty to disable. When set, no request to this connection will exceed this token
+                limit — including batched agent calls.
               </p>
             </FieldGroup>
           )}

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -511,6 +511,11 @@ const COLUMN_MIGRATIONS: ColumnMigration[] = [
     column: "default_parameters",
     definition: "TEXT",
   },
+  {
+    table: "api_connections",
+    column: "max_tokens_override",
+    definition: "INTEGER",
+  },
 ];
 
 export async function runMigrations(db: DB) {

--- a/packages/server/src/db/schema/connections.ts
+++ b/packages/server/src/db/schema/connections.ts
@@ -37,6 +37,8 @@ export const apiConnections = sqliteTable("api_connections", {
   imageService: text("image_service"),
   /** Default generation parameters (stored as JSON) for new chats using this connection */
   defaultParameters: text("default_parameters"),
+  /** Optional hard cap on max_tokens for the API response (for providers like DeepSeek that have lower limits). */
+  maxTokensOverride: integer("max_tokens_override"),
   createdAt: text("created_at").notNull(),
   updatedAt: text("updated_at").notNull(),
 });

--- a/packages/server/src/routes/character-maker.routes.ts
+++ b/packages/server/src/routes/character-maker.routes.ts
@@ -67,7 +67,7 @@ export async function characterMakerRoutes(app: FastifyInstance) {
     });
 
     try {
-      const provider = createLLMProvider(conn.provider, baseUrl, conn.apiKey, conn.maxContext, conn.openrouterProvider);
+      const provider = createLLMProvider(conn.provider, baseUrl, conn.apiKey, conn.maxContext, conn.openrouterProvider, conn.maxTokensOverride);
       let fullResponse = "";
 
       for await (const chunk of provider.chat(

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -1145,7 +1145,7 @@ export async function chatsRoutes(app: FastifyInstance) {
       }
       if (!baseUrl) return reply.status(400).send({ error: "No base URL for this connection" });
 
-      provider = createLLMProvider(conn.provider, baseUrl, conn.apiKey, conn.maxContext, conn.openrouterProvider);
+      provider = createLLMProvider(conn.provider, baseUrl, conn.apiKey, conn.maxContext, conn.openrouterProvider, conn.maxTokensOverride);
       model = conn.model;
     }
 

--- a/packages/server/src/routes/connections.routes.ts
+++ b/packages/server/src/routes/connections.routes.ts
@@ -268,7 +268,7 @@ export async function connectionsRoutes(app: FastifyInstance) {
 
     const start = Date.now();
     try {
-      const provider = createLLMProvider(conn.provider, baseUrl, conn.apiKey, conn.maxContext, conn.openrouterProvider);
+      const provider = createLLMProvider(conn.provider, baseUrl, conn.apiKey, conn.maxContext, conn.openrouterProvider, conn.maxTokensOverride);
 
       let fullResponse = "";
       for await (const chunk of provider.chat([{ role: "user", content: "hi" }], {

--- a/packages/server/src/routes/conversation.routes.ts
+++ b/packages/server/src/routes/conversation.routes.ts
@@ -70,7 +70,7 @@ export async function conversationRoutes(app: FastifyInstance) {
           ? JSON.parse(chat.characterIds)
           : chat.characterIds;
 
-    const provider = createLLMProvider(conn.provider, baseUrl, conn.apiKey, conn.maxContext, conn.openrouterProvider);
+    const provider = createLLMProvider(conn.provider, baseUrl, conn.apiKey, conn.maxContext, conn.openrouterProvider, conn.maxTokensOverride);
     const model = conn.model ?? "";
     const mondayStr = getMonday().toISOString();
 

--- a/packages/server/src/routes/encounter.routes.ts
+++ b/packages/server/src/routes/encounter.routes.ts
@@ -411,7 +411,7 @@ export async function encounterRoutes(app: FastifyInstance) {
       if (!chat) return reply.status(404).send({ error: "Chat not found" });
 
       const { conn, baseUrl } = await resolveConnection(connections, connectionId, chat.connectionId);
-      const provider = createLLMProvider(conn.provider, baseUrl, conn.apiKey, conn.maxContext, conn.openrouterProvider);
+      const provider = createLLMProvider(conn.provider, baseUrl, conn.apiKey, conn.maxContext, conn.openrouterProvider, conn.maxTokensOverride);
 
       const characterIds: string[] = JSON.parse(chat.characterIds as string);
       const characterCtx = await buildCharacterContext(chars, characterIds);
@@ -470,7 +470,7 @@ export async function encounterRoutes(app: FastifyInstance) {
       if (!chat) return reply.status(404).send({ error: "Chat not found" });
 
       const { conn, baseUrl } = await resolveConnection(connections, connectionId, chat.connectionId);
-      const provider = createLLMProvider(conn.provider, baseUrl, conn.apiKey, conn.maxContext, conn.openrouterProvider);
+      const provider = createLLMProvider(conn.provider, baseUrl, conn.apiKey, conn.maxContext, conn.openrouterProvider, conn.maxTokensOverride);
 
       const characterIds: string[] = JSON.parse(chat.characterIds as string);
       const characterCtx = await buildCharacterContext(chars, characterIds);
@@ -561,7 +561,7 @@ export async function encounterRoutes(app: FastifyInstance) {
       if (!chat) return reply.status(404).send({ error: "Chat not found" });
 
       const { conn, baseUrl } = await resolveConnection(connections, connectionId, chat.connectionId);
-      const provider = createLLMProvider(conn.provider, baseUrl, conn.apiKey, conn.maxContext, conn.openrouterProvider);
+      const provider = createLLMProvider(conn.provider, baseUrl, conn.apiKey, conn.maxContext, conn.openrouterProvider, conn.maxTokensOverride);
 
       const characterIds: string[] = JSON.parse(chat.characterIds as string);
       const characterCtx = await buildCharacterContext(chars, characterIds);

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -874,7 +874,7 @@ export async function gameRoutes(app: FastifyInstance) {
       connectionId,
       chat.connectionId,
     );
-    const provider = createLLMProvider(conn.provider, baseUrl, conn.apiKey!, conn.maxContext, conn.openrouterProvider);
+    const provider = createLLMProvider(conn.provider, baseUrl, conn.apiKey!, conn.maxContext, conn.openrouterProvider, conn.maxTokensOverride);
     const setupGenerationParameters = resolveStoredGameGenerationParameters(meta, defaultGenerationParameters);
 
     let gmCharacterCard: string | null = null;
@@ -1435,6 +1435,7 @@ export async function gameRoutes(app: FastifyInstance) {
             conn.apiKey!,
             conn.maxContext,
             conn.openrouterProvider,
+            conn.maxTokensOverride,
           );
 
           const recapMessages: ChatMessage[] = [
@@ -1565,7 +1566,7 @@ export async function gameRoutes(app: FastifyInstance) {
     const latestState = await gameStates.getLatest(chatId);
 
     const { conn, baseUrl } = await resolveConnection(connections, connectionId, chat.connectionId);
-    const provider = createLLMProvider(conn.provider, baseUrl, conn.apiKey!, conn.maxContext, conn.openrouterProvider);
+    const provider = createLLMProvider(conn.provider, baseUrl, conn.apiKey!, conn.maxContext, conn.openrouterProvider, conn.maxTokensOverride);
 
     const summaryMessages: ChatMessage[] = [
       { role: "system", content: buildSessionSummaryPrompt() },
@@ -1825,7 +1826,7 @@ export async function gameRoutes(app: FastifyInstance) {
     if (!chat) throw new Error("Chat not found");
 
     const { conn, baseUrl } = await resolveConnection(connections, connectionId, chat.connectionId);
-    const provider = createLLMProvider(conn.provider, baseUrl, conn.apiKey!, conn.maxContext, conn.openrouterProvider);
+    const provider = createLLMProvider(conn.provider, baseUrl, conn.apiKey!, conn.maxContext, conn.openrouterProvider, conn.maxTokensOverride);
 
     const messages: ChatMessage[] = [
       { role: "system", content: buildMapGenerationPrompt(locationType, context) },
@@ -2419,7 +2420,7 @@ export async function gameRoutes(app: FastifyInstance) {
       { role: "user", content: userPrompt },
     ];
 
-    const provider = createLLMProvider(conn.provider, baseUrl, conn.apiKey!, conn.maxContext, conn.openrouterProvider);
+    const provider = createLLMProvider(conn.provider, baseUrl, conn.apiKey!, conn.maxContext, conn.openrouterProvider, conn.maxTokensOverride);
     const result = await provider.chatComplete(
       messages,
       gameGenOptions(
@@ -2526,7 +2527,7 @@ export async function gameRoutes(app: FastifyInstance) {
       { role: "user", content: userPrompt },
     ];
 
-    const provider = createLLMProvider(conn.provider, baseUrl, conn.apiKey!, conn.maxContext, conn.openrouterProvider);
+    const provider = createLLMProvider(conn.provider, baseUrl, conn.apiKey!, conn.maxContext, conn.openrouterProvider, conn.maxTokensOverride);
     console.log(
       "[game/scene-wrap] chatId=%s, model=%s, narration=%d chars",
       input.chatId,

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -628,6 +628,7 @@ export async function generateRoutes(app: FastifyInstance) {
                 embedConn.apiKey as string,
                 embedConn.maxContext as number | null | undefined,
                 embedConn.openrouterProvider as string | null | undefined,
+                embedConn.maxTokensOverride as number | null | undefined,
               );
               const embeddings = await embeddingProvider.embed([recentMsgs], embeddingModel);
               chatContextEmbedding = embeddings[0] ?? null;
@@ -948,6 +949,7 @@ export async function generateRoutes(app: FastifyInstance) {
             conn.apiKey,
             conn.maxContext,
             conn.openrouterProvider,
+            conn.maxTokensOverride,
           );
           const summaryResults = await Promise.allSettled(
             bucketsToSummarize.map(async (bucket) => {
@@ -1077,6 +1079,7 @@ export async function generateRoutes(app: FastifyInstance) {
             conn.apiKey,
             conn.maxContext,
             conn.openrouterProvider,
+            conn.maxTokensOverride,
           );
           const weekResults = await Promise.allSettled(
             weeksToConsolidate.map(async ({ weekKey, days }) => {
@@ -2005,7 +2008,7 @@ export async function generateRoutes(app: FastifyInstance) {
       }
 
       // Create provider
-      const provider = createLLMProvider(conn.provider, baseUrl, conn.apiKey, conn.maxContext, conn.openrouterProvider);
+      const provider = createLLMProvider(conn.provider, baseUrl, conn.apiKey, conn.maxContext, conn.openrouterProvider, conn.maxTokensOverride);
 
       // ────────────────────────────────────────
       // Agent Pipeline: resolve enabled agents
@@ -2038,6 +2041,7 @@ export async function generateRoutes(app: FastifyInstance) {
               defaultAgentConn.apiKey,
               defaultAgentConn.maxContext,
               defaultAgentConn.openrouterProvider,
+              defaultAgentConn.maxTokensOverride,
             ),
             model: defaultAgentConn.model,
           });
@@ -2069,6 +2073,7 @@ export async function generateRoutes(app: FastifyInstance) {
                   agentConn.apiKey,
                   agentConn.maxContext,
                   agentConn.openrouterProvider,
+                  agentConn.maxTokensOverride,
                 );
                 agentModel = agentConn.model;
                 agentProviderCache.set(effectiveConnectionId, { provider: agentProvider, model: agentModel });
@@ -6183,6 +6188,7 @@ export async function generateRoutes(app: FastifyInstance) {
                     conn.apiKey,
                     conn.maxContext,
                     conn.openrouterProvider,
+                    conn.maxTokensOverride,
                   );
                   const promptResult = await promptBuilder.chatComplete(
                     [

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -265,7 +265,7 @@ async function resolveRetryAgents(args: {
     throw new Error("Cannot resolve provider URL");
   }
 
-  const provider = createLLMProvider(conn.provider, baseUrl, conn.apiKey, conn.maxContext, conn.openrouterProvider);
+  const provider = createLLMProvider(conn.provider, baseUrl, conn.apiKey, conn.maxContext, conn.openrouterProvider, conn.maxTokensOverride);
   const resolvedAgents: ResolvedRetryAgent[] = [];
 
   for (const cfg of enabledConfigs) {
@@ -287,6 +287,7 @@ async function resolveRetryAgents(args: {
               agentConn.apiKey,
               agentConn.maxContext,
               agentConn.openrouterProvider,
+              agentConn.maxTokensOverride,
             );
             agentModel = agentConn.model;
           }

--- a/packages/server/src/routes/lorebook-maker.routes.ts
+++ b/packages/server/src/routes/lorebook-maker.routes.ts
@@ -136,7 +136,7 @@ export async function lorebookMakerRoutes(app: FastifyInstance) {
     };
 
     try {
-      const provider = createLLMProvider(conn.provider, baseUrl, conn.apiKey, conn.maxContext, conn.openrouterProvider);
+      const provider = createLLMProvider(conn.provider, baseUrl, conn.apiKey, conn.maxContext, conn.openrouterProvider, conn.maxTokensOverride);
 
       // ── Decide whether to batch ──
       const totalEntries = input.entryCount;

--- a/packages/server/src/routes/lorebooks.routes.ts
+++ b/packages/server/src/routes/lorebooks.routes.ts
@@ -278,6 +278,7 @@ export async function lorebooksRoutes(app: FastifyInstance) {
       conn.apiKey as string,
       conn.maxContext,
       conn.openrouterProvider,
+      conn.maxTokensOverride,
     );
 
     // Build text for each entry: combine name, keys, and content

--- a/packages/server/src/routes/persona-maker.routes.ts
+++ b/packages/server/src/routes/persona-maker.routes.ts
@@ -59,7 +59,7 @@ export async function personaMakerRoutes(app: FastifyInstance) {
     });
 
     try {
-      const provider = createLLMProvider(conn.provider, baseUrl, conn.apiKey, conn.maxContext, conn.openrouterProvider);
+      const provider = createLLMProvider(conn.provider, baseUrl, conn.apiKey, conn.maxContext, conn.openrouterProvider, conn.maxTokensOverride);
       let fullResponse = "";
 
       for await (const chunk of provider.chat(

--- a/packages/server/src/routes/prompt-reviewer.routes.ts
+++ b/packages/server/src/routes/prompt-reviewer.routes.ts
@@ -131,7 +131,7 @@ export async function promptReviewerRoutes(app: FastifyInstance) {
     });
 
     try {
-      const provider = createLLMProvider(conn.provider, baseUrl, conn.apiKey, conn.maxContext, conn.openrouterProvider);
+      const provider = createLLMProvider(conn.provider, baseUrl, conn.apiKey, conn.maxContext, conn.openrouterProvider, conn.maxTokensOverride);
       let fullResponse = "";
 
       const userPrompt = `Review this prompt preset. Focus areas: ${input.focusAreas.join(", ")}

--- a/packages/server/src/routes/scene.routes.ts
+++ b/packages/server/src/routes/scene.routes.ts
@@ -257,7 +257,7 @@ export async function sceneRoutes(app: FastifyInstance) {
 
     // Resolve connection
     const { conn, baseUrl } = await resolveConnection(connections, connectionId, sceneChat.connectionId);
-    const provider = createLLMProvider(conn.provider, baseUrl, conn.apiKey, conn.maxContext, conn.openrouterProvider);
+    const provider = createLLMProvider(conn.provider, baseUrl, conn.apiKey, conn.maxContext, conn.openrouterProvider, conn.maxTokensOverride);
 
     // Build context
     const characterIds: string[] =
@@ -416,7 +416,7 @@ export async function sceneRoutes(app: FastifyInstance) {
     if (!chat) return reply.status(404).send({ error: "Chat not found" });
 
     const { conn, baseUrl } = await resolveConnection(connections, connectionId, chat.connectionId);
-    const provider = createLLMProvider(conn.provider, baseUrl, conn.apiKey, conn.maxContext, conn.openrouterProvider);
+    const provider = createLLMProvider(conn.provider, baseUrl, conn.apiKey, conn.maxContext, conn.openrouterProvider, conn.maxTokensOverride);
 
     const characterIds: string[] =
       typeof chat.characterIds === "string" ? JSON.parse(chat.characterIds) : (chat.characterIds as string[]);

--- a/packages/server/src/routes/translate.routes.ts
+++ b/packages/server/src/routes/translate.routes.ts
@@ -72,7 +72,7 @@ async function translateWithAI(
     throw Object.assign(new Error("No base URL configured for this connection"), { statusCode: 400 });
   }
 
-  const provider = createLLMProvider(conn.provider, baseUrl, conn.apiKey, conn.maxContext, conn.openrouterProvider);
+  const provider = createLLMProvider(conn.provider, baseUrl, conn.apiKey, conn.maxContext, conn.openrouterProvider, conn.maxTokensOverride);
   const result = await provider.chatComplete(
     [
       {

--- a/packages/server/src/services/agents/agent-executor.ts
+++ b/packages/server/src/services/agents/agent-executor.ts
@@ -74,7 +74,11 @@ export async function executeAgent(
 
     // Agents use lower temperature for reliability
     const temperature = (config.settings.temperature as number) ?? 0.3;
-    const maxTokens = Math.max((config.settings.maxTokens as number) ?? 4096, 16384);
+    const rawMaxTokens = Math.max((config.settings.maxTokens as number) ?? 4096, 16384);
+    const maxTokens =
+      provider.maxTokensOverrideValue !== null
+        ? Math.min(rawMaxTokens, provider.maxTokensOverrideValue)
+        : rawMaxTokens;
     const streamResponses = context.streaming !== false;
 
     // If tools are available, use the tool call loop
@@ -269,12 +273,17 @@ export async function executeAgentBatch(
 
     // Each agent needs enough room for its full JSON output.
     // Use a generous floor (16384) so the model never runs out mid-response.
+    // Cap to the connection-level maxTokensOverride when set.
     const maxTokensPerAgent = Math.max(...configs.map((c) => (c.settings.maxTokens as number) ?? 4096));
     const temperature = Math.min(...configs.map((c) => (c.settings.temperature as number) ?? 0.3));
-    const batchMaxTokens = Math.max(maxTokensPerAgent * configs.length, 16384);
+    const rawBatchMaxTokens = Math.max(maxTokensPerAgent * configs.length, 16384);
+    const batchMaxTokens =
+      provider.maxTokensOverrideValue !== null
+        ? Math.min(rawBatchMaxTokens, provider.maxTokensOverrideValue)
+        : rawBatchMaxTokens;
     const streamResponses = context.streaming !== false;
     console.log(
-      `[agent-batch] maxTokens: ${batchMaxTokens} (${maxTokensPerAgent} × ${configs.length} agents, floor 16384)`,
+      `[agent-batch] maxTokens: ${batchMaxTokens} (${maxTokensPerAgent} × ${configs.length} agents, floor 16384${provider.maxTokensOverrideValue !== null ? `, capped at ${provider.maxTokensOverrideValue}` : ""})`,
     );
 
     if (isDebugAgentsEnabled()) {

--- a/packages/server/src/services/llm/base-provider.ts
+++ b/packages/server/src/services/llm/base-provider.ts
@@ -411,7 +411,19 @@ export abstract class BaseLLMProvider {
     protected apiKey: string,
     protected defaultMaxContext?: number,
     protected defaultOpenrouterProvider?: string | null,
+    protected maxTokensOverride?: number | null,
   ) {}
+
+  /** Cap output max_tokens to the connection-level override, if one is set. */
+  protected applyMaxTokensCap(tokens: number): number {
+    if (this.maxTokensOverride && tokens > this.maxTokensOverride) return this.maxTokensOverride;
+    return tokens;
+  }
+
+  /** Returns the connection-level max tokens override, if set. */
+  public get maxTokensOverrideValue(): number | null {
+    return this.maxTokensOverride ?? null;
+  }
 
   protected fitMessagesToContext(messages: ChatMessage[], options: Pick<ChatOptions, "maxContext" | "maxTokens">) {
     return fitMessagesToContext(messages, options, this.defaultMaxContext);

--- a/packages/server/src/services/llm/provider-registry.ts
+++ b/packages/server/src/services/llm/provider-registry.ts
@@ -15,10 +15,15 @@ export function createLLMProvider(
   apiKey: string,
   maxContext?: number | null,
   openrouterProvider?: string | null,
+  maxTokensOverride?: number | null,
 ): BaseLLMProvider {
   const normalizedMaxContext =
     typeof maxContext === "number" && Number.isFinite(maxContext) && maxContext > 0
       ? Math.floor(maxContext)
+      : undefined;
+  const normalizedMaxTokensOverride =
+    typeof maxTokensOverride === "number" && Number.isFinite(maxTokensOverride) && maxTokensOverride > 0
+      ? Math.floor(maxTokensOverride)
       : undefined;
 
   switch (provider) {
@@ -28,12 +33,12 @@ export function createLLMProvider(
     case "mistral":
     case "cohere":
     case "custom":
-      return new OpenAIProvider(baseUrl, apiKey, normalizedMaxContext, openrouterProvider);
+      return new OpenAIProvider(baseUrl, apiKey, normalizedMaxContext, openrouterProvider, normalizedMaxTokensOverride);
     case "anthropic":
-      return new AnthropicProvider(baseUrl, apiKey, normalizedMaxContext, openrouterProvider);
+      return new AnthropicProvider(baseUrl, apiKey, normalizedMaxContext, openrouterProvider, normalizedMaxTokensOverride);
     case "google":
-      return new GoogleProvider(baseUrl, apiKey, normalizedMaxContext, openrouterProvider);
+      return new GoogleProvider(baseUrl, apiKey, normalizedMaxContext, openrouterProvider, normalizedMaxTokensOverride);
     default:
-      return new OpenAIProvider(baseUrl, apiKey, normalizedMaxContext, openrouterProvider);
+      return new OpenAIProvider(baseUrl, apiKey, normalizedMaxContext, openrouterProvider, normalizedMaxTokensOverride);
   }
 }

--- a/packages/server/src/services/llm/providers/openai.provider.ts
+++ b/packages/server/src/services/llm/providers/openai.provider.ts
@@ -211,11 +211,11 @@ export class OpenAIProvider extends BaseLLMProvider {
   }
 
   async *chat(messages: ChatMessage[], options: ChatOptions): AsyncGenerator<string, LLMUsage | void, unknown> {
-    const configuredMaxTokens = options.maxTokens ?? 4096;
+    const configuredMaxTokens = this.applyMaxTokensCap(options.maxTokens ?? 4096);
     const contextFit = this.fitMessagesToContext(messages, { ...options, maxTokens: configuredMaxTokens });
     messages = contextFit.messages;
     this.logContextTrim(contextFit, options.model);
-    const maxTokens = contextFit.maxTokens ?? configuredMaxTokens;
+    const maxTokens = this.applyMaxTokensCap(contextFit.maxTokens ?? configuredMaxTokens);
 
     // Route to Responses API for models that require it
     if (this.useResponsesAPI(options.model)) {
@@ -395,11 +395,11 @@ export class OpenAIProvider extends BaseLLMProvider {
 
   /** Non-streaming completion with tool-call support */
   async chatComplete(messages: ChatMessage[], options: ChatOptions): Promise<ChatCompletionResult> {
-    const configuredMaxTokens = options.maxTokens ?? 4096;
+    const configuredMaxTokens = this.applyMaxTokensCap(options.maxTokens ?? 4096);
     const contextFit = this.fitMessagesToContext(messages, { ...options, maxTokens: configuredMaxTokens });
     messages = contextFit.messages;
     this.logContextTrim(contextFit, options.model);
-    const maxTokens = contextFit.maxTokens ?? configuredMaxTokens;
+    const maxTokens = this.applyMaxTokensCap(contextFit.maxTokens ?? configuredMaxTokens);
 
     // Route to Responses API for models that require it
     if (this.useResponsesAPI(options.model)) {

--- a/packages/server/src/services/storage/connections.storage.ts
+++ b/packages/server/src/services/storage/connections.storage.ts
@@ -86,6 +86,7 @@ export function createConnectionsStorage(db: DB) {
         imageGenerationSource: input.imageGenerationSource ?? null,
         comfyuiWorkflow: input.comfyuiWorkflow ?? null,
         imageService: input.imageService ?? null,
+        maxTokensOverride: input.maxTokensOverride ?? null,
         createdAt: timestamp,
         updatedAt: timestamp,
       });
@@ -158,6 +159,9 @@ export function createConnectionsStorage(db: DB) {
       if (data.imageService !== undefined) {
         updateFields.imageService = data.imageService;
       }
+      if (data.maxTokensOverride !== undefined) {
+        updateFields.maxTokensOverride = data.maxTokensOverride;
+      }
       await db.update(apiConnections).set(updateFields).where(eq(apiConnections.id, id));
       return this.getById(id);
     },
@@ -188,6 +192,7 @@ export function createConnectionsStorage(db: DB) {
         imageGenerationSource: source.imageGenerationSource,
         comfyuiWorkflow: source.comfyuiWorkflow,
         imageService: source.imageService,
+        maxTokensOverride: source.maxTokensOverride,
         createdAt: timestamp,
         updatedAt: timestamp,
       });

--- a/packages/shared/src/schemas/connection.schema.ts
+++ b/packages/shared/src/schemas/connection.schema.ts
@@ -33,6 +33,7 @@ export const createConnectionSchema = z.object({
   imageGenerationSource: z.string().nullable().default(null),
   comfyuiWorkflow: z.string().nullable().default(null),
   imageService: z.string().nullable().default(null),
+  maxTokensOverride: z.number().int().min(1).nullable().default(null),
 });
 
 export type CreateConnectionInput = z.infer<typeof createConnectionSchema>;

--- a/packages/shared/src/types/connection.ts
+++ b/packages/shared/src/types/connection.ts
@@ -45,6 +45,8 @@ export interface APIConnection {
   imageService: string | null;
   /** Default generation parameters for new chats using this connection (JSON) */
   defaultParameters: string | null;
+  /** Hard cap on max_tokens for the API response (for providers with lower limits, e.g. DeepSeek at 8192). */
+  maxTokensOverride: number | null;
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
## Why this change

This lets providers that restrict output tokens to a small limit still work with coalescing agent calls into batches.

## What changed

- Store a max_tokens_override which limits any upstream max_tokens for this connection to the specified value, when it is set.
- Add a field to the ConnectionEditor ui to let the user manage the setting.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [X] `pnpm check`
- [ ] Manual verification completed (describe below)

### Manual verification notes

<!-- Describe what you manually verified -->
- 

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

<!-- Add screenshots or recordings for UI changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-connection token limit override configuration in the connection editor. Users can now set a maximum token cap for API responses on a per-connection basis, which is applied consistently across all language model operations and requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->