### PR TITLE
feat: add Card Evolution Auditor agent with user-approval modal

### DIFF
--- a/packages/client/src/components/layout/ModalRenderer.tsx
+++ b/packages/client/src/components/layout/ModalRenderer.tsx
@@ -47,6 +47,9 @@ const CreateConnectionModal = lazy(() =>
 const CreatePersonaModal = lazy(() =>
   import("../modals/CreatePersonaModal").then((module) => ({ default: module.CreatePersonaModal })),
 );
+const CharacterCardUpdateModal = lazy(() =>
+  import("../modals/CharacterCardUpdateModal").then((module) => ({ default: module.CharacterCardUpdateModal })),
+);
 
 export function ModalRenderer() {
   const modal = useUIStore((s) => s.modal);
@@ -98,6 +101,9 @@ export function ModalRenderer() {
       break;
     case "st-bulk-import":
       content = <STBulkImportModal open onClose={closeModal} />;
+      break;
+    case "character-card-update":
+      content = <CharacterCardUpdateModal open onClose={closeModal} />;
       break;
     default:
       content = null;

--- a/packages/client/src/components/modals/CharacterCardUpdateModal.tsx
+++ b/packages/client/src/components/modals/CharacterCardUpdateModal.tsx
@@ -1,0 +1,201 @@
+// ──────────────────────────────────────────────
+// Modal: Confirm character_card_update agent result
+// ──────────────────────────────────────────────
+//
+// The Card Evolution Auditor post-processing agent proposes edits to a
+// character card's fields (description, personality, etc.) based on what
+// happened in the roleplay. Unlike the Lorebook Keeper, card edits require
+// the user's explicit approval — this modal shows the old → new diff and
+// asks the user to approve or reject each batch.
+import { useMemo, useState } from "react";
+import { Loader2, UserCog, Check, X, AlertCircle } from "lucide-react";
+import { Modal } from "../ui/Modal";
+import { useAgentStore } from "../../stores/agent.store";
+import { useCharacter, useUpdateCharacter } from "../../hooks/use-characters";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function CharacterCardUpdateModal({ open, onClose }: Props) {
+  const pending = useAgentStore((s) => s.pendingCardUpdates);
+  const dismissPendingCardUpdate = useAgentStore((s) => s.dismissPendingCardUpdate);
+
+  const entry = pending[0] ?? null;
+  const { data: character } = useCharacter(entry?.characterId ?? null);
+  const updateCharacter = useUpdateCharacter();
+  const [error, setError] = useState<string | null>(null);
+
+  // Character rows come back from /characters with `data` serialized as a JSON
+  // string, so parse it once here and reuse below.
+  const parsedData = useMemo((): Record<string, unknown> => {
+    const raw = (character as { data?: unknown } | undefined)?.data;
+    if (typeof raw === "string") {
+      try {
+        return JSON.parse(raw) as Record<string, unknown>;
+      } catch {
+        return {};
+      }
+    }
+    return (raw as Record<string, unknown>) ?? {};
+  }, [character]);
+
+  // Only show updates whose oldText is still present in the current field —
+  // stale suggestions (field already changed since the agent ran) are dropped.
+  // We use substring match, not equality, because oldText is a sentence-level
+  // slice of a field that often contains multiple paragraphs.
+  const applicableUpdates = useMemo(() => {
+    if (!entry || !character) return [];
+    return entry.updates.filter((u) => {
+      const current = parsedData[u.field];
+      return typeof current === "string" && u.oldText.length > 0 && current.includes(u.oldText);
+    });
+  }, [entry, character, parsedData]);
+
+  if (!entry) return null;
+
+  const closeAndAdvance = () => {
+    dismissPendingCardUpdate(entry.id);
+    setError(null);
+    // If another pending update is queued, keep the modal open so the user
+    // can triage them in sequence; otherwise close.
+    if (pending.length <= 1) {
+      onClose();
+    }
+  };
+
+  const handleApprove = async () => {
+    if (!character || applicableUpdates.length === 0) {
+      closeAndAdvance();
+      return;
+    }
+    // Apply each edit as a targeted substring replace inside the field's current
+    // value, NOT by overwriting the field with newText (which would erase
+    // everything around the edited sentence).
+    const patchedFields: Record<string, string> = {};
+    for (const u of applicableUpdates) {
+      const base = typeof patchedFields[u.field] === "string" ? patchedFields[u.field] : parsedData[u.field];
+      if (typeof base !== "string") continue;
+      patchedFields[u.field] = base.replace(u.oldText, u.newText);
+    }
+    try {
+      await updateCharacter.mutateAsync({
+        id: entry.characterId,
+        data: { ...parsedData, ...patchedFields } as Record<string, unknown>,
+      });
+      closeAndAdvance();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to apply character updates");
+    }
+  };
+
+  const handleReject = () => {
+    closeAndAdvance();
+  };
+
+  const queueNote = pending.length > 1 ? ` (${pending.length - 1} more queued)` : "";
+
+  return (
+    <Modal open={open} onClose={onClose} title="Review Character Card Updates" width="max-w-2xl">
+      <div className="flex flex-col gap-3">
+        <div className="flex items-center gap-3">
+          <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-violet-400 to-fuchsia-500 shadow-lg shadow-violet-400/20">
+            <UserCog size="1.375rem" className="text-white" />
+          </div>
+          <div className="flex-1">
+            <p className="text-sm font-medium">
+              {(typeof parsedData.name === "string" && parsedData.name) || entry.characterName}
+            </p>
+            <p className="text-xs text-[var(--muted-foreground)]">
+              {entry.agentName} proposed {entry.updates.length}{" "}
+              {entry.updates.length === 1 ? "change" : "changes"}
+              {queueNote}
+            </p>
+          </div>
+        </div>
+
+        {applicableUpdates.length === 0 && (
+          <div className="flex items-center gap-2 rounded-lg bg-[var(--secondary)] p-2.5 text-xs text-[var(--muted-foreground)]">
+            <AlertCircle size="0.75rem" className="shrink-0" />
+            None of these proposals still match the current card — the field was probably already edited. Reject to dismiss.
+          </div>
+        )}
+
+        <div className="flex max-h-[60vh] flex-col gap-3 overflow-y-auto">
+          {entry.updates.map((u, idx) => {
+            const stale = !applicableUpdates.includes(u);
+            return (
+              <div
+                key={idx}
+                className={`flex flex-col gap-2 rounded-lg bg-[var(--secondary)] p-3 ring-1 ring-[var(--border)] ${
+                  stale ? "opacity-50" : ""
+                }`}
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <span className="text-xs font-semibold uppercase tracking-wide text-[var(--muted-foreground)]">
+                    {u.field}
+                  </span>
+                  {stale && (
+                    <span className="rounded-full bg-[var(--destructive)]/10 px-2 py-0.5 text-[10px] font-medium text-[var(--destructive)]">
+                      stale
+                    </span>
+                  )}
+                </div>
+                {u.reason && <p className="text-xs italic text-[var(--muted-foreground)]">{u.reason}</p>}
+                <div className="flex flex-col gap-1">
+                  <span className="text-[10px] font-medium uppercase tracking-wide text-[var(--muted-foreground)]">
+                    Before
+                  </span>
+                  <p className="whitespace-pre-wrap rounded-md bg-[var(--destructive)]/5 p-2 text-xs leading-relaxed text-[var(--foreground)]">
+                    {u.oldText}
+                  </p>
+                </div>
+                <div className="flex flex-col gap-1">
+                  <span className="text-[10px] font-medium uppercase tracking-wide text-[var(--muted-foreground)]">
+                    After
+                  </span>
+                  <p className="whitespace-pre-wrap rounded-md bg-emerald-500/5 p-2 text-xs leading-relaxed text-[var(--foreground)]">
+                    {u.newText}
+                  </p>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        {error && (
+          <div className="flex items-center gap-2 rounded-lg bg-[var(--destructive)]/10 p-2.5 text-xs text-[var(--destructive)]">
+            <AlertCircle size="0.75rem" className="shrink-0" />
+            {error}
+          </div>
+        )}
+
+        <div className="flex justify-end gap-2 border-t border-[var(--border)] pt-3">
+          <button
+            type="button"
+            onClick={handleReject}
+            disabled={updateCharacter.isPending}
+            className="flex items-center gap-1.5 rounded-lg px-4 py-2 text-xs font-medium text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] disabled:opacity-50"
+          >
+            <X size="0.75rem" />
+            Reject
+          </button>
+          <button
+            type="button"
+            onClick={handleApprove}
+            disabled={updateCharacter.isPending || applicableUpdates.length === 0}
+            className="flex items-center gap-1.5 rounded-lg bg-[var(--primary)] px-4 py-2 text-xs font-medium text-[var(--primary-foreground)] transition-all hover:opacity-90 disabled:opacity-50"
+          >
+            {updateCharacter.isPending ? (
+              <Loader2 size="0.75rem" className="animate-spin" />
+            ) : (
+              <Check size="0.75rem" />
+            )}
+            Approve {applicableUpdates.length > 0 ? `(${applicableUpdates.length})` : ""}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/packages/client/src/components/modals/CharacterCardUpdateModal.tsx
+++ b/packages/client/src/components/modals/CharacterCardUpdateModal.tsx
@@ -12,6 +12,43 @@ import { Loader2, UserCog, Check, X, AlertCircle } from "lucide-react";
 import { Modal } from "../ui/Modal";
 import { useAgentStore } from "../../stores/agent.store";
 import { useCharacter, useUpdateCharacter } from "../../hooks/use-characters";
+import type { EditableCharacterCardField } from "@marinara-engine/shared";
+
+function getCharacterCardFieldValue(data: Record<string, unknown>, field: EditableCharacterCardField): string | null {
+  if (field === "backstory" || field === "appearance") {
+    const extensions = data.extensions;
+    if (!extensions || typeof extensions !== "object") return null;
+    const value = (extensions as Record<string, unknown>)[field];
+    return typeof value === "string" ? value : null;
+  }
+
+  const value = data[field];
+  return typeof value === "string" ? value : null;
+}
+
+function setCharacterCardFieldValue(
+  data: Record<string, unknown>,
+  field: EditableCharacterCardField,
+  value: string,
+): Record<string, unknown> {
+  if (field === "backstory" || field === "appearance") {
+    const extensions =
+      data.extensions && typeof data.extensions === "object" ? (data.extensions as Record<string, unknown>) : {};
+
+    return {
+      ...data,
+      extensions: {
+        ...extensions,
+        [field]: value,
+      },
+    };
+  }
+
+  return {
+    ...data,
+    [field]: value,
+  };
+}
 
 interface Props {
   open: boolean;
@@ -48,7 +85,7 @@ export function CharacterCardUpdateModal({ open, onClose }: Props) {
   const applicableUpdates = useMemo(() => {
     if (!entry || !character) return [];
     return entry.updates.filter((u) => {
-      const current = parsedData[u.field];
+      const current = getCharacterCardFieldValue(parsedData, u.field);
       return typeof current === "string" && u.oldText.length > 0 && current.includes(u.oldText);
     });
   }, [entry, character, parsedData]);
@@ -73,16 +110,16 @@ export function CharacterCardUpdateModal({ open, onClose }: Props) {
     // Apply each edit as a targeted substring replace inside the field's current
     // value, NOT by overwriting the field with newText (which would erase
     // everything around the edited sentence).
-    const patchedFields: Record<string, string> = {};
+    let nextData: Record<string, unknown> = { ...parsedData };
     for (const u of applicableUpdates) {
-      const base = typeof patchedFields[u.field] === "string" ? patchedFields[u.field] : parsedData[u.field];
+      const base = getCharacterCardFieldValue(nextData, u.field);
       if (typeof base !== "string") continue;
-      patchedFields[u.field] = base.replace(u.oldText, u.newText);
+      nextData = setCharacterCardFieldValue(nextData, u.field, base.replace(u.oldText, u.newText));
     }
     try {
       await updateCharacter.mutateAsync({
         id: entry.characterId,
-        data: { ...parsedData, ...patchedFields } as Record<string, unknown>,
+        data: nextData,
       });
       closeAndAdvance();
     } catch (err) {
@@ -97,7 +134,7 @@ export function CharacterCardUpdateModal({ open, onClose }: Props) {
   const queueNote = pending.length > 1 ? ` (${pending.length - 1} more queued)` : "";
 
   return (
-    <Modal open={open} onClose={onClose} title="Review Character Card Updates" width="max-w-2xl">
+    <Modal open={open} onClose={closeAndAdvance} title="Review Character Card Updates" width="max-w-2xl">
       <div className="flex flex-col gap-3">
         <div className="flex items-center gap-3">
           <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-violet-400 to-fuchsia-500 shadow-lg shadow-violet-400/20">

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -5,11 +5,130 @@ import { useCallback } from "react";
 import { useQueryClient, type InfiniteData, type QueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { api } from "../lib/api-client";
+import type { PendingCardUpdate } from "../stores/agent.store";
 
 /** Show a persistent, copyable error toast and log to console */
 function showError(msg: string) {
   console.error("[Generation]", msg);
   toast.error(msg, { duration: 15000 });
+}
+
+/**
+ * Validate one entry in the Card Evolution Auditor's `updates` array and coerce
+ * it to a typed CharacterCardFieldUpdate. LLM output can be messy, so we drop
+ * anything that doesn't parse cleanly.
+ */
+function parseCardFieldUpdate(raw: unknown): CharacterCardFieldUpdate | null {
+  if (!raw || typeof raw !== "object") return null;
+  const u = raw as Record<string, unknown>;
+  if (u.action !== "update") return null;
+  if (typeof u.field !== "string" || u.field.length === 0) return null;
+  if (typeof u.oldText !== "string") return null;
+  if (typeof u.newText !== "string") return null;
+  if (u.oldText === u.newText) return null;
+  return {
+    action: "update",
+    field: u.field,
+    oldText: u.oldText,
+    newText: u.newText,
+    reason: typeof u.reason === "string" ? u.reason : "",
+  };
+}
+
+function parseCharacterRowData(raw: unknown): Record<string, unknown> | null {
+  if (typeof raw === "string") {
+    try {
+      return JSON.parse(raw) as Record<string, unknown>;
+    } catch {
+      return null;
+    }
+  }
+  if (raw && typeof raw === "object") return raw as Record<string, unknown>;
+  return null;
+}
+
+/**
+ * Build a PendingCardUpdate from a character_card_update agent result, or
+ * return null if no target character can be resolved (e.g. chat has no
+ * characters) or no valid updates remain after parsing.
+ *
+ * Chats often contain multiple characters (group chats, built-in assistants).
+ * The agent's JSON doesn't identify which character each edit applies to, so
+ * we pick the first character in the chat whose field actually contains the
+ * proposed oldText. That character "owns" the edit. Fall back to the first
+ * chat character if no match is found — the modal will flag the edit stale.
+ */
+async function buildPendingCardUpdate(
+  qc: QueryClient,
+  chatId: string,
+  agentName: string,
+  rawData: unknown,
+): Promise<PendingCardUpdate | null> {
+  const data = rawData && typeof rawData === "object" ? (rawData as Record<string, unknown>) : null;
+  const rawUpdates = data && Array.isArray(data.updates) ? (data.updates as unknown[]) : [];
+  const updates = rawUpdates.map(parseCardFieldUpdate).filter((u): u is CharacterCardFieldUpdate => u !== null);
+  if (updates.length === 0) return null;
+
+  const chat = qc.getQueryData<Chat>(chatKeys.detail(chatId));
+  // characterIds is sometimes serialized as a JSON string on the wire —
+  // accept either shape to avoid a .map crash on group chats.
+  const rawChatCharIds = (chat as { characterIds?: unknown })?.characterIds;
+  let chatCharacterIds: string[] = [];
+  if (Array.isArray(rawChatCharIds)) {
+    chatCharacterIds = rawChatCharIds.filter((v): v is string => typeof v === "string");
+  } else if (typeof rawChatCharIds === "string") {
+    try {
+      const parsed = JSON.parse(rawChatCharIds);
+      if (Array.isArray(parsed)) chatCharacterIds = parsed.filter((v): v is string => typeof v === "string");
+    } catch {
+      /* leave empty */
+    }
+  }
+  if (chatCharacterIds.length === 0) return null;
+
+  // Prime the characters list cache if empty — needed for both name resolution
+  // and the field-match heuristic below.
+  let characters = qc.getQueryData<Array<{ id: string; data?: unknown; name?: string }>>(characterKeys.list());
+  if (!characters) {
+    try {
+      characters = await qc.fetchQuery({
+        queryKey: characterKeys.list(),
+        queryFn: () => api.get<Array<{ id: string; data?: unknown; name?: string }>>("/characters"),
+      });
+    } catch {
+      characters = undefined;
+    }
+  }
+  const chatCharacters = chatCharacterIds
+    .map((id) => {
+      const row = characters?.find((c) => c.id === id);
+      const parsed = parseCharacterRowData(row?.data);
+      return { id, row, parsed };
+    })
+    .filter((c) => c.row !== undefined);
+
+  // Find the first chat character whose field contains the first edit's oldText.
+  // This is heuristic — all edits in a batch target the same character in practice.
+  const firstEdit = updates[0]!;
+  const owner = chatCharacters.find((c) => {
+    const fieldValue = c.parsed?.[firstEdit.field];
+    return typeof fieldValue === "string" && fieldValue.includes(firstEdit.oldText);
+  });
+
+  const chosen = owner ?? chatCharacters[0] ?? { id: chatCharacterIds[0]!, row: undefined, parsed: null };
+  const characterName =
+    (chosen.parsed && typeof chosen.parsed.name === "string" && chosen.parsed.name) ||
+    chosen.row?.name ||
+    "Character";
+
+  return {
+    id: `card-update-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    characterId: chosen.id,
+    characterName,
+    updates,
+    agentName,
+    timestamp: Date.now(),
+  };
 }
 import { useChatStore } from "../stores/chat.store";
 import { useAgentStore } from "../stores/agent.store";
@@ -21,7 +140,7 @@ import { chatKeys } from "./use-chats";
 import { characterKeys } from "./use-characters";
 import { playNotificationPing } from "../lib/notification-sound";
 import { stripGmTagsKeepReadables } from "../lib/game-tag-parser";
-import type { Chat, GameMap, Message } from "@marinara-engine/shared";
+import type { Chat, CharacterCardFieldUpdate, GameMap, Message } from "@marinara-engine/shared";
 
 function sortMessagesByCreatedAt(messages: Message[]): Message[] {
   return [...messages].sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
@@ -191,6 +310,7 @@ export function useGenerate() {
   const addEchoMessage = useAgentStore((s) => s.addEchoMessage);
   const setCyoaChoices = useAgentStore((s) => s.setCyoaChoices);
   const clearCyoaChoices = useAgentStore((s) => s.clearCyoaChoices);
+  const enqueuePendingCardUpdate = useAgentStore((s) => s.enqueuePendingCardUpdate);
   const setFailedAgentTypes = useAgentStore((s) => s.setFailedAgentTypes);
   const clearFailedAgentTypes = useAgentStore((s) => s.clearFailedAgentTypes);
   const addDebugEntry = useAgentStore((s) => s.addDebugEntry);
@@ -611,6 +731,19 @@ export function useGenerate() {
                     setCyoaChoices(choices);
                   }
                 }
+              }
+
+              // Character card updates are never applied automatically — enqueue
+              // them for the user-approval modal. (Card Evolution Auditor.)
+              if (result.success && result.resultType === "character_card_update") {
+                buildPendingCardUpdate(qc, params.chatId, result.agentName, result.data)
+                  .then((pending) => {
+                    if (pending) {
+                      enqueuePendingCardUpdate(pending);
+                      useUIStore.getState().openModal("character-card-update");
+                    }
+                  })
+                  .catch((err) => console.warn("[Agent] Failed to build card update entry:", err));
               }
 
               // Apply background change — validate filename exists before applying
@@ -1313,6 +1446,7 @@ export function useGenerate() {
       addEchoMessage,
       setCyoaChoices,
       clearCyoaChoices,
+      enqueuePendingCardUpdate,
       clearFailedAgentTypes,
       setFailedAgentTypes,
       addDebugEntry,
@@ -1378,6 +1512,16 @@ export function useGenerate() {
                 success: result.success,
                 error: result.error,
               });
+              if (result.success && result.resultType === "character_card_update") {
+                buildPendingCardUpdate(qc, chatId, result.agentName, result.data)
+                  .then((pending) => {
+                    if (pending) {
+                      enqueuePendingCardUpdate(pending);
+                      useUIStore.getState().openModal("character-card-update");
+                    }
+                  })
+                  .catch((err) => console.warn("[Agent] Failed to build card update entry:", err));
+              }
               if (result.success && result.data) {
                 const bubble = formatAgentBubble(result.agentType, result.agentName, result.data);
                 if (bubble) addThoughtBubble(result.agentType, result.agentName, bubble);
@@ -1538,6 +1682,7 @@ export function useGenerate() {
       addResult,
       addThoughtBubble,
       addEchoMessage,
+      enqueuePendingCardUpdate,
       clearFailedAgentTypes,
       clearDebugLog,
       clearThoughtBubbles,

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -6,12 +6,19 @@ import { useQueryClient, type InfiniteData, type QueryClient } from "@tanstack/r
 import { toast } from "sonner";
 import { api } from "../lib/api-client";
 import type { PendingCardUpdate } from "../stores/agent.store";
+import {
+  EDITABLE_CHARACTER_CARD_FIELDS,
+  type CharacterCardFieldUpdate,
+  type EditableCharacterCardField,
+} from "@marinara-engine/shared";
 
 /** Show a persistent, copyable error toast and log to console */
 function showError(msg: string) {
   console.error("[Generation]", msg);
   toast.error(msg, { duration: 15000 });
 }
+
+const editableCharacterCardFieldSet = new Set<string>(EDITABLE_CHARACTER_CARD_FIELDS);
 
 /**
  * Validate one entry in the Card Evolution Auditor's `updates` array and coerce
@@ -22,13 +29,15 @@ function parseCardFieldUpdate(raw: unknown): CharacterCardFieldUpdate | null {
   if (!raw || typeof raw !== "object") return null;
   const u = raw as Record<string, unknown>;
   if (u.action !== "update") return null;
-  if (typeof u.field !== "string" || u.field.length === 0) return null;
+  if (typeof u.characterId !== "string" || u.characterId.trim().length === 0) return null;
+  if (typeof u.field !== "string" || !editableCharacterCardFieldSet.has(u.field)) return null;
   if (typeof u.oldText !== "string") return null;
   if (typeof u.newText !== "string") return null;
   if (u.oldText === u.newText) return null;
   return {
+    characterId: u.characterId.trim(),
     action: "update",
-    field: u.field,
+    field: u.field as EditableCharacterCardField,
     oldText: u.oldText,
     newText: u.newText,
     reason: typeof u.reason === "string" ? u.reason : "",
@@ -43,31 +52,26 @@ function parseCharacterRowData(raw: unknown): Record<string, unknown> | null {
       return null;
     }
   }
+
   if (raw && typeof raw === "object") return raw as Record<string, unknown>;
   return null;
 }
 
 /**
- * Build a PendingCardUpdate from a character_card_update agent result, or
- * return null if no target character can be resolved (e.g. chat has no
- * characters) or no valid updates remain after parsing.
- *
- * Chats often contain multiple characters (group chats, built-in assistants).
- * The agent's JSON doesn't identify which character each edit applies to, so
- * we pick the first character in the chat whose field actually contains the
- * proposed oldText. That character "owns" the edit. Fall back to the first
- * chat character if no match is found — the modal will flag the edit stale.
+ * Build one or more PendingCardUpdate batches from a character_card_update
+ * agent result. Each batch is scoped to a single characterId so the approval
+ * modal can review and apply updates without ownership heuristics.
  */
-async function buildPendingCardUpdate(
+async function buildPendingCardUpdates(
   qc: QueryClient,
   chatId: string,
   agentName: string,
   rawData: unknown,
-): Promise<PendingCardUpdate | null> {
+): Promise<PendingCardUpdate[]> {
   const data = rawData && typeof rawData === "object" ? (rawData as Record<string, unknown>) : null;
   const rawUpdates = data && Array.isArray(data.updates) ? (data.updates as unknown[]) : [];
   const updates = rawUpdates.map(parseCardFieldUpdate).filter((u): u is CharacterCardFieldUpdate => u !== null);
-  if (updates.length === 0) return null;
+  if (updates.length === 0) return [];
 
   const chat = qc.getQueryData<Chat>(chatKeys.detail(chatId));
   // characterIds is sometimes serialized as a JSON string on the wire —
@@ -84,10 +88,10 @@ async function buildPendingCardUpdate(
       /* leave empty */
     }
   }
-  if (chatCharacterIds.length === 0) return null;
+  if (chatCharacterIds.length === 0) return [];
+  const chatCharacterIdSet = new Set(chatCharacterIds);
 
-  // Prime the characters list cache if empty — needed for both name resolution
-  // and the field-match heuristic below.
+  // Prime the characters list cache if empty so we can resolve names.
   let characters = qc.getQueryData<Array<{ id: string; data?: unknown; name?: string }>>(characterKeys.list());
   if (!characters) {
     try {
@@ -99,36 +103,47 @@ async function buildPendingCardUpdate(
       characters = undefined;
     }
   }
-  const chatCharacters = chatCharacterIds
-    .map((id) => {
-      const row = characters?.find((c) => c.id === id);
+  const chatCharacters = new Map(
+    chatCharacterIds.map((id) => {
+      const row = characters?.find((character) => character.id === id);
       const parsed = parseCharacterRowData(row?.data);
-      return { id, row, parsed };
-    })
-    .filter((c) => c.row !== undefined);
+      return [id, { row, parsed }] as const;
+    }),
+  );
 
-  // Find the first chat character whose field contains the first edit's oldText.
-  // This is heuristic — all edits in a batch target the same character in practice.
-  const firstEdit = updates[0]!;
-  const owner = chatCharacters.find((c) => {
-    const fieldValue = c.parsed?.[firstEdit.field];
-    return typeof fieldValue === "string" && fieldValue.includes(firstEdit.oldText);
+  const groupedUpdates = new Map<string, CharacterCardFieldUpdate[]>();
+  for (const update of updates) {
+    if (!chatCharacterIdSet.has(update.characterId)) continue;
+
+    const existing = groupedUpdates.get(update.characterId) ?? [];
+    existing.push(update);
+    groupedUpdates.set(update.characterId, existing);
+  }
+
+  if (groupedUpdates.size === 0) return [];
+
+  const timestamp = Date.now();
+  return chatCharacterIds.flatMap((characterId, index) => {
+    const grouped = groupedUpdates.get(characterId);
+    if (!grouped || grouped.length === 0) return [];
+
+    const character = chatCharacters.get(characterId);
+    const characterName =
+      (character?.parsed && typeof character.parsed.name === "string" && character.parsed.name) ||
+      character?.row?.name ||
+      "Character";
+
+    return [
+      {
+        id: `card-update-${characterId}-${timestamp}-${index}`,
+        characterId,
+        characterName,
+        updates: grouped,
+        agentName,
+        timestamp: timestamp + index,
+      },
+    ];
   });
-
-  const chosen = owner ?? chatCharacters[0] ?? { id: chatCharacterIds[0]!, row: undefined, parsed: null };
-  const characterName =
-    (chosen.parsed && typeof chosen.parsed.name === "string" && chosen.parsed.name) ||
-    chosen.row?.name ||
-    "Character";
-
-  return {
-    id: `card-update-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-    characterId: chosen.id,
-    characterName,
-    updates,
-    agentName,
-    timestamp: Date.now(),
-  };
 }
 import { useChatStore } from "../stores/chat.store";
 import { useAgentStore } from "../stores/agent.store";
@@ -140,7 +155,7 @@ import { chatKeys } from "./use-chats";
 import { characterKeys } from "./use-characters";
 import { playNotificationPing } from "../lib/notification-sound";
 import { stripGmTagsKeepReadables } from "../lib/game-tag-parser";
-import type { Chat, CharacterCardFieldUpdate, GameMap, Message } from "@marinara-engine/shared";
+import type { Chat, GameMap, Message } from "@marinara-engine/shared";
 
 function sortMessagesByCreatedAt(messages: Message[]): Message[] {
   return [...messages].sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
@@ -736,10 +751,12 @@ export function useGenerate() {
               // Character card updates are never applied automatically — enqueue
               // them for the user-approval modal. (Card Evolution Auditor.)
               if (result.success && result.resultType === "character_card_update") {
-                buildPendingCardUpdate(qc, params.chatId, result.agentName, result.data)
-                  .then((pending) => {
-                    if (pending) {
-                      enqueuePendingCardUpdate(pending);
+                buildPendingCardUpdates(qc, params.chatId, result.agentName, result.data)
+                  .then((pendingEntries) => {
+                    if (pendingEntries.length > 0) {
+                      for (const pending of pendingEntries) {
+                        enqueuePendingCardUpdate(pending);
+                      }
                       useUIStore.getState().openModal("character-card-update");
                     }
                   })
@@ -1513,10 +1530,12 @@ export function useGenerate() {
                 error: result.error,
               });
               if (result.success && result.resultType === "character_card_update") {
-                buildPendingCardUpdate(qc, chatId, result.agentName, result.data)
-                  .then((pending) => {
-                    if (pending) {
-                      enqueuePendingCardUpdate(pending);
+                buildPendingCardUpdates(qc, chatId, result.agentName, result.data)
+                  .then((pendingEntries) => {
+                    if (pendingEntries.length > 0) {
+                      for (const pending of pendingEntries) {
+                        enqueuePendingCardUpdate(pending);
+                      }
                       useUIStore.getState().openModal("character-card-update");
                     }
                   })

--- a/packages/client/src/stores/agent.store.ts
+++ b/packages/client/src/stores/agent.store.ts
@@ -2,7 +2,25 @@
 // Zustand Store: Agent Slice
 // ──────────────────────────────────────────────
 import { create } from "zustand";
-import type { AgentResult } from "@marinara-engine/shared";
+import type { AgentResult, CharacterCardFieldUpdate } from "@marinara-engine/shared";
+
+/**
+ * A character_card_update result awaiting user confirmation.
+ *
+ * Character cards are sensitive (they define the character's identity) so
+ * the Card Evolution Auditor never writes them automatically — each batch
+ * of proposed edits sits here until the user approves or rejects it.
+ */
+export interface PendingCardUpdate {
+  /** Client-generated ID, used as key for dismissal. */
+  id: string;
+  characterId: string;
+  characterName: string;
+  updates: CharacterCardFieldUpdate[];
+  agentName: string;
+  /** ms since epoch — used for stable ordering. */
+  timestamp: number;
+}
 
 interface AgentDebugEntry {
   timestamp: number;
@@ -46,6 +64,7 @@ interface AgentState {
     label: string;
     text: string;
   }>;
+  pendingCardUpdates: PendingCardUpdate[];
   debugLog: AgentDebugEntry[];
 
   // Actions
@@ -65,6 +84,9 @@ interface AgentState {
   setEchoLoadedChatId: (chatId: string | null) => void;
   setCyoaChoices: (choices: Array<{ label: string; text: string }>) => void;
   clearCyoaChoices: () => void;
+  enqueuePendingCardUpdate: (entry: PendingCardUpdate) => void;
+  dismissPendingCardUpdate: (id: string) => void;
+  clearPendingCardUpdates: () => void;
   addDebugEntry: (entry: AgentDebugEntry) => void;
   clearDebugLog: () => void;
   reset: () => void;
@@ -81,6 +103,7 @@ export const useAgentStore = create<AgentState>((set) => ({
   echoBaseline: 0,
   echoLoadedChatId: null,
   cyoaChoices: [],
+  pendingCardUpdates: [],
   debugLog: [],
 
   setActiveAgents: (agents) => set({ activeAgents: agents }),
@@ -129,6 +152,12 @@ export const useAgentStore = create<AgentState>((set) => ({
   setCyoaChoices: (choices) => set({ cyoaChoices: choices }),
   clearCyoaChoices: () => set({ cyoaChoices: [] }),
 
+  enqueuePendingCardUpdate: (entry) =>
+    set((s) => ({ pendingCardUpdates: [...s.pendingCardUpdates, entry].slice(-20) })),
+  dismissPendingCardUpdate: (id) =>
+    set((s) => ({ pendingCardUpdates: s.pendingCardUpdates.filter((e) => e.id !== id) })),
+  clearPendingCardUpdates: () => set({ pendingCardUpdates: [] }),
+
   addDebugEntry: (entry) => set((s) => ({ debugLog: [...s.debugLog, entry].slice(-100) })),
   clearDebugLog: () => set({ debugLog: [] }),
 
@@ -144,6 +173,7 @@ export const useAgentStore = create<AgentState>((set) => ({
       echoBaseline: 0,
       echoLoadedChatId: null,
       cyoaChoices: [],
+      pendingCardUpdates: [],
       debugLog: [],
     }),
 }));

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -2134,6 +2134,7 @@ export async function generateRoutes(app: FastifyInstance) {
         description: string;
         personality: string;
         scenario: string;
+        creatorNotes: string;
         systemPrompt: string;
         backstory: string;
         appearance: string;
@@ -2157,6 +2158,7 @@ export async function generateRoutes(app: FastifyInstance) {
             description: charData.description ?? "",
             personality: charData.personality ?? "",
             scenario,
+            creatorNotes: charData.creator_notes ?? "",
             systemPrompt: charData.system_prompt ?? "",
             backstory: charData.extensions?.backstory ?? "",
             appearance: charData.extensions?.appearance ?? "",

--- a/packages/server/src/services/agents/agent-executor.ts
+++ b/packages/server/src/services/agents/agent-executor.ts
@@ -62,7 +62,7 @@ export async function executeAgent(
     systemParts.push(`Fulfill the requested task here and return the output in the format specified:`);
     systemParts.push(template);
     systemParts.push(`</agents>`);
-    const extras = buildAgentExtras(context);
+    const extras = buildAgentExtras(context, [config.type]);
     if (extras) {
       systemParts.push(``);
       systemParts.push(extras);
@@ -387,7 +387,10 @@ function buildBatchSystemPrompt(configs: AgentExecConfig[], context: AgentContex
   parts.push(`</agents>`);
 
   // ── Agent-specific extras (sprites, backgrounds, etc.) ──
-  const extras = buildAgentExtras(context);
+  const extras = buildAgentExtras(
+    context,
+    configs.map((c) => c.type),
+  );
   if (extras) {
     parts.push(``);
     parts.push(extras);
@@ -674,8 +677,30 @@ function buildLoreBlock(context: AgentContext): string {
  * Build agent-specific context blocks (sprites, backgrounds, source material, etc.)
  * that go into the system message after lore.
  */
-function buildAgentExtras(context: AgentContext): string {
+function buildAgentExtras(context: AgentContext, agentTypes: string[] = []): string {
   const parts: string[] = [];
+
+  // Card Evolution Auditor needs the FULL character card (not just description)
+  // so it can emit exact-match oldText edits. Gated on agent type because
+  // forwarding every field would bloat context for agents that don't need it.
+  if (agentTypes.includes("card-evolution-auditor") && context.characters.length > 0) {
+    parts.push(`<character_cards>`);
+    for (const char of context.characters) {
+      parts.push(`<character id="${char.id}" name="${char.name}">`);
+      if (char.description) parts.push(`<description>${char.description}</description>`);
+      if (char.personality) parts.push(`<personality>${char.personality}</personality>`);
+      if (char.scenario) parts.push(`<scenario>${char.scenario}</scenario>`);
+      if (char.backstory) parts.push(`<backstory>${char.backstory}</backstory>`);
+      if (char.appearance) parts.push(`<appearance>${char.appearance}</appearance>`);
+      if (char.firstMes) parts.push(`<first_mes>${char.firstMes}</first_mes>`);
+      if (char.mesExample) parts.push(`<mes_example>${char.mesExample}</mes_example>`);
+      if (char.systemPrompt) parts.push(`<system_prompt>${char.systemPrompt}</system_prompt>`);
+      if (char.postHistoryInstructions)
+        parts.push(`<post_history_instructions>${char.postHistoryInstructions}</post_history_instructions>`);
+      parts.push(`</character>`);
+    }
+    parts.push(`</character_cards>`);
+  }
 
   if (context.gameState) {
     parts.push(`<current_game_state>`);
@@ -817,6 +842,7 @@ const AGENT_RESULT_TYPE_MAP: Record<string, AgentResultType> = {
   quest: "quest_update",
   illustrator: "image_prompt",
   "lorebook-keeper": "lorebook_update",
+  "card-evolution-auditor": "character_card_update",
   "prompt-reviewer": "prompt_review",
   combat: "game_state_update",
   background: "background_change",
@@ -841,6 +867,7 @@ const JSON_AGENTS = new Set([
   "quest",
   "illustrator",
   "lorebook-keeper",
+  "card-evolution-auditor",
   "prompt-reviewer",
   "combat",
   "background",

--- a/packages/server/src/services/agents/agent-executor.ts
+++ b/packages/server/src/services/agents/agent-executor.ts
@@ -689,23 +689,32 @@ function buildLoreBlock(context: AgentContext): string {
 function buildAgentExtras(context: AgentContext, agentTypes: string[] = []): string {
   const parts: string[] = [];
 
+  const escapeXml = (value: string) =>
+    value
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&apos;");
+
   // Card Evolution Auditor needs the FULL character card (not just description)
   // so it can emit exact-match oldText edits. Gated on agent type because
   // forwarding every field would bloat context for agents that don't need it.
   if (agentTypes.includes("card-evolution-auditor") && context.characters.length > 0) {
     parts.push(`<character_cards>`);
     for (const char of context.characters) {
-      parts.push(`<character id="${char.id}" name="${char.name}">`);
-      if (char.description) parts.push(`<description>${char.description}</description>`);
-      if (char.personality) parts.push(`<personality>${char.personality}</personality>`);
-      if (char.scenario) parts.push(`<scenario>${char.scenario}</scenario>`);
-      if (char.backstory) parts.push(`<backstory>${char.backstory}</backstory>`);
-      if (char.appearance) parts.push(`<appearance>${char.appearance}</appearance>`);
-      if (char.firstMes) parts.push(`<first_mes>${char.firstMes}</first_mes>`);
-      if (char.mesExample) parts.push(`<mes_example>${char.mesExample}</mes_example>`);
-      if (char.systemPrompt) parts.push(`<system_prompt>${char.systemPrompt}</system_prompt>`);
+      parts.push(`<character id="${escapeXml(char.id)}" name="${escapeXml(char.name)}">`);
+      if (char.description) parts.push(`<description>${escapeXml(char.description)}</description>`);
+      if (char.personality) parts.push(`<personality>${escapeXml(char.personality)}</personality>`);
+      if (char.scenario) parts.push(`<scenario>${escapeXml(char.scenario)}</scenario>`);
+      if (char.backstory) parts.push(`<backstory>${escapeXml(char.backstory)}</backstory>`);
+      if (char.appearance) parts.push(`<appearance>${escapeXml(char.appearance)}</appearance>`);
+      if (char.firstMes) parts.push(`<first_mes>${escapeXml(char.firstMes)}</first_mes>`);
+      if (char.mesExample) parts.push(`<mes_example>${escapeXml(char.mesExample)}</mes_example>`);
+      if (char.creatorNotes) parts.push(`<creator_notes>${escapeXml(char.creatorNotes)}</creator_notes>`);
+      if (char.systemPrompt) parts.push(`<system_prompt>${escapeXml(char.systemPrompt)}</system_prompt>`);
       if (char.postHistoryInstructions)
-        parts.push(`<post_history_instructions>${char.postHistoryInstructions}</post_history_instructions>`);
+        parts.push(`<post_history_instructions>${escapeXml(char.postHistoryInstructions)}</post_history_instructions>`);
       parts.push(`</character>`);
     }
     parts.push(`</character_cards>`);

--- a/packages/shared/src/constants/agent-prompts.ts
+++ b/packages/shared/src/constants/agent-prompts.ts
@@ -242,6 +242,34 @@ Output format:
 }`,
 
   /* ────────────────────────────────────────── */
+  "card-evolution-auditor": `Detect when the active character card has drifted from what has been established in the roleplay and propose precise field edits for the user's review.
+
+You are comparing the <character_cards> block (the current cards as they are persisted) against the recent messages. Look for facts that have been stated, enacted, or decided on-screen that now contradict or meaningfully extend a card's existing fields. Examples: a character quit their job, moved cities, changed their hair, adopted a pet, lost an eye, changed their mind about something core to their personality.
+
+Rules:
+1. Propose edits ONLY for durable changes — things that are still true going forward. Ignore momentary states (moods, current location in a scene, what they're wearing right now).
+2. NEVER fabricate. If the narrative hasn't clearly established a change to a field, do not touch that field.
+3. Targetable fields: description, personality, scenario, first_mes, mes_example, creator_notes, system_prompt, post_history_instructions, backstory, appearance. Do NOT edit name.
+4. Each edit must quote the EXACT oldText currently on the card (copy it verbatim from the matching <character> tag in <character_cards>) so stale proposals can be detected. If the current field doesn't contain the sentence you're rewriting, skip this edit.
+5. Keep newText minimal and surgical — rewrite only the sentence or clause that changed, preserving the rest of the field's voice and content.
+6. If nothing durable has changed, return: { "updates": [] }
+
+Output format (strict JSON, no prose outside the object):
+{
+  "updates": [
+    {
+      "action": "update",
+      "field": "description",
+      "oldText": "exact existing text from the card",
+      "newText": "proposed replacement text",
+      "reason": "one sentence — what in the roleplay triggered this"
+    }
+  ]
+}
+
+IMPORTANT: These edits will be shown to the user for manual approval. Be conservative. A false positive (suggesting a change that isn't warranted) is worse than a false negative (missing one).`,
+
+  /* ────────────────────────────────────────── */
   "prompt-reviewer": `Analyze the assembled system prompt BEFORE generation for quality issues.
 1. Redundant or contradictory instructions, two rules demanding opposite behavior.
 2. Unclear or ambiguous directives, anything a model could reasonably misinterpret.

--- a/packages/shared/src/constants/agent-prompts.ts
+++ b/packages/shared/src/constants/agent-prompts.ts
@@ -250,15 +250,17 @@ Rules:
 1. Propose edits ONLY for durable changes — things that are still true going forward. Ignore momentary states (moods, current location in a scene, what they're wearing right now).
 2. NEVER fabricate. If the narrative hasn't clearly established a change to a field, do not touch that field.
 3. Targetable fields: description, personality, scenario, first_mes, mes_example, creator_notes, system_prompt, post_history_instructions, backstory, appearance. Do NOT edit name.
-4. Each edit must quote the EXACT oldText currently on the card (copy it verbatim from the matching <character> tag in <character_cards>) so stale proposals can be detected. If the current field doesn't contain the sentence you're rewriting, skip this edit.
-5. Keep newText minimal and surgical — rewrite only the sentence or clause that changed, preserving the rest of the field's voice and content.
-6. If nothing durable has changed, return: { "updates": [] }
+4. Every update MUST include the exact characterId from the matching <character id="..."> tag in <character_cards>.
+5. Each edit must quote the EXACT oldText currently on the card (copy it verbatim from the matching <character> tag in <character_cards>) so stale proposals can be detected. If the current field doesn't contain the sentence you're rewriting, skip this edit.
+6. Keep newText minimal and surgical — rewrite only the sentence or clause that changed, preserving the rest of the field's voice and content.
+7. If nothing durable has changed, return: { "updates": [] }
 
 Output format (strict JSON, no prose outside the object):
 {
   "updates": [
     {
       "action": "update",
+      "characterId": "exact character id from the matching <character> tag",
       "field": "description",
       "oldText": "exact existing text from the card",
       "newText": "proposed replacement text",

--- a/packages/shared/src/schemas/agent.schema.ts
+++ b/packages/shared/src/schemas/agent.schema.ts
@@ -16,6 +16,7 @@ export const agentResultTypeSchema = z.enum([
   "continuity_check",
   "director_event",
   "lorebook_update",
+  "character_card_update",
   "prompt_review",
   "background_change",
   "character_tracker_update",

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -23,6 +23,7 @@ export type AgentResultType =
   | "continuity_check"
   | "director_event"
   | "lorebook_update"
+  | "character_card_update"
   | "prompt_review"
   | "background_change"
   | "character_tracker_update"
@@ -96,8 +97,25 @@ export interface AgentContext {
   mainResponse: string | null;
   /** Current game state (if any) */
   gameState: import("./game-state.js").GameState | null;
-  /** Active characters in the chat */
-  characters: Array<{ id: string; name: string; description: string }>;
+  /**
+   * Active characters in the chat. The base shape (id/name/description) is
+   * always populated. Richer card fields are optional — they're present in
+   * practice, but agents should not rely on them unless needed. The Card
+   * Evolution Auditor agent uses them to emit exact-match oldText edits.
+   */
+  characters: Array<{
+    id: string;
+    name: string;
+    description: string;
+    personality?: string;
+    scenario?: string;
+    systemPrompt?: string;
+    backstory?: string;
+    appearance?: string;
+    mesExample?: string;
+    firstMes?: string;
+    postHistoryInstructions?: string;
+  }>;
   /** User persona info */
   persona: {
     name: string;
@@ -139,6 +157,7 @@ export const BUILT_IN_AGENT_IDS = {
   QUEST: "quest",
   ILLUSTRATOR: "illustrator",
   LOREBOOK_KEEPER: "lorebook-keeper",
+  CARD_EVOLUTION_AUDITOR: "card-evolution-auditor",
   PROMPT_REVIEWER: "prompt-reviewer",
   COMBAT: "combat",
   BACKGROUND: "background",
@@ -302,6 +321,15 @@ export const BUILT_IN_AGENTS: BuiltInAgentMeta[] = [
     phase: "post_processing",
     enabledByDefault: false,
     category: "misc",
+  },
+  {
+    id: "card-evolution-auditor",
+    name: "Card Evolution Auditor",
+    description:
+      "Detects when character card fields (description, personality, scenario, etc.) have become outdated based on roleplay events and proposes edits for user approval.",
+    phase: "post_processing",
+    enabledByDefault: false,
+    category: "tracker",
   },
   {
     id: "combat",
@@ -469,6 +497,7 @@ export const DEFAULT_AGENT_TOOLS: Record<string, string[]> = {
   quest: ["update_game_state"],
   illustrator: [],
   "lorebook-keeper": ["search_lorebook"],
+  "card-evolution-auditor": [],
   "prompt-reviewer": [],
   combat: ["roll_dice", "update_game_state"],
   background: [],
@@ -511,6 +540,32 @@ export interface LorebookUpdateResult {
     keys: string[];
     tag?: string;
   };
+}
+
+/**
+ * Single proposed edit to a character card field.
+ *
+ * Unlike LorebookUpdateResult, these edits are NEVER applied automatically —
+ * the server emits them as an agent_result SSE event and the client shows
+ * a confirmation modal. Character cards are more sensitive than lorebook
+ * entries because they define the character's identity.
+ */
+export interface CharacterCardFieldUpdate {
+  /** Currently only "update" is supported; reserved for future create/delete. */
+  action: "update";
+  /** Which character card field this edit targets (e.g. "description", "personality"). */
+  field: string;
+  /** The existing field value the agent observed. */
+  oldText: string;
+  /** The proposed replacement text. */
+  newText: string;
+  /** Why the agent thinks this edit is warranted (shown to the user). */
+  reason: string;
+}
+
+/** Data shape for a character_card_update agent result. */
+export interface CharacterCardUpdateResult {
+  updates: CharacterCardFieldUpdate[];
 }
 
 // ──────────────────────────────────────────────

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -109,6 +109,7 @@ export interface AgentContext {
     description: string;
     personality?: string;
     scenario?: string;
+    creatorNotes?: string;
     systemPrompt?: string;
     backstory?: string;
     appearance?: string;
@@ -550,11 +551,28 @@ export interface LorebookUpdateResult {
  * a confirmation modal. Character cards are more sensitive than lorebook
  * entries because they define the character's identity.
  */
+export const EDITABLE_CHARACTER_CARD_FIELDS = [
+  "description",
+  "personality",
+  "scenario",
+  "first_mes",
+  "mes_example",
+  "creator_notes",
+  "system_prompt",
+  "post_history_instructions",
+  "backstory",
+  "appearance",
+] as const;
+
+export type EditableCharacterCardField = (typeof EDITABLE_CHARACTER_CARD_FIELDS)[number];
+
 export interface CharacterCardFieldUpdate {
+  /** Stable target character id from the <character id="..."> context block. */
+  characterId: string;
   /** Currently only "update" is supported; reserved for future create/delete. */
   action: "update";
-  /** Which character card field this edit targets (e.g. "description", "personality"). */
-  field: string;
+  /** Which stored character-card field this edit targets. */
+  field: EditableCharacterCardField;
   /** The existing field value the agent observed. */
   oldText: string;
   /** The proposed replacement text. */


### PR DESCRIPTION
## Summary

Adds a new post-processing agent — **Card Evolution Auditor** — that watches the roleplay for durable changes to a character (dropped out of school, moved cities, changed hair, etc.) and proposes targeted edits to the character card's fields. Unlike the Lorebook Keeper, which writes back automatically, character card edits require the user's explicit approval via a confirmation modal showing the old → new diff per field.

This introduces a new `character_card_update` agent result type in the shared schemas and wires it through the full pipeline: server-side parsing and emission, a client-side pending-approval queue, a confirmation modal, and a surgical field-level apply path that preserves everything around the edited sentence.

<img width="725" height="467" alt="card_evolution_auditor" src="https://github.com/user-attachments/assets/dd712908-c6a4-4e15-adc8-dedf72bc5093" />

## Why

Character cards drift from what's actually true in long roleplays. A character graduates, quits their job, changes their appearance — but the card still describes them the old way, which then contaminates future generations. This agent closes that loop without risking silent card rewrites that the user didn't sign off on.

## Architecture

| Layer | Change |
|---|---|
| `packages/shared` | New `character_card_update` enum value, built-in agent registration, default prompt, `CharacterCardUpdateResult` + `CharacterCardFieldUpdate` types. `AgentContext.characters` widened to optionally carry richer card fields. |
| `packages/server` | Agent executor maps `card-evolution-auditor` to the new result type and marks it JSON-output. `buildAgentExtras` emits a `<character_cards>` block with full fields **only when this agent is in the batch** — no token cost for other agents. No auto-apply: the server only emits the SSE event. |
| `packages/client` | New `pendingCardUpdates` queue in `agent.store`. `use-generate` handles the SSE event, resolves the target character by matching `oldText` against each chat character's fields, and opens the modal. New `CharacterCardUpdateModal` with per-edit diff, stale detection, and `field.replace(oldText, newText)` apply logic. |

## Known limitations

1. **Conversation mode:** `ChatSettingsDrawer.tsx` hides the "Enable Agents" section in Conversation mode, so this agent (like all agents) isn't reachable from Convo chats today. This predates this PR; not a regression. Backend already supports `chatMode=conversation`. Happy to follow up with a one-line change if you want the toggle exposed there.
2. **Target character resolution:** the agent's JSON doesn't identify *which* character an edit applies to. The client heuristic matches `oldText` against each chat character's fields to pick the owner. Works cleanly for single-character chats and for multi-character chats where the edited text is unambiguous. A future prompt change to emit explicit `characterName` per edit would remove the heuristic — left out of this PR to keep scope tight.

## Test plan

- [x] `pnpm check` passes (lint + production build across all packages).
- [x] Manual end-to-end test in Roleplay mode: enabled agent on a chat, sent a message establishing a permanent hair-color change, agent produced a valid `updates` array, modal appeared with correct character name and old→new diff, approval applied the edit surgically (surrounding description preserved), rejection dismissed without changes.
- [x] Verified `buildAgentExtras` emits `<character_cards>` only when `card-evolution-auditor` is in the agent batch — other agents' context is unchanged.
- [x] Stale detection: edits whose `oldText` no longer matches the current field value are flagged and excluded from the approve action.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI-suggested character card edits are queued for user review instead of auto-applying.
  * New review modal previews before/after snippets, flags stale proposals, and lets you approve, reject, or process the queue progressively.
  * Approving applies targeted substring edits and advances the queue; rejecting skips entries.
  * An auditor agent can detect durable character evolutions and surface proposals for review.
  * Characters now surface additional creator notes and richer card fields for agent reasoning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->