### PR TITLE
Fix ST import grouping and branch label updates

### DIFF
--- a/packages/client/src/components/chat/ChatFilesDrawer.tsx
+++ b/packages/client/src/components/chat/ChatFilesDrawer.tsx
@@ -1,10 +1,11 @@
 // ──────────────────────────────────────────────
-// Chat: Manage Chat Files — export and branch management
+// Chat: Manage Chat Files — switch between branches
+// Like SillyTavern's "Manage chat files" feature
 // ──────────────────────────────────────────────
-import { X, Trash2, FileText, MessageSquare, Download } from "lucide-react";
+import { X, Trash2, FileText, MessageSquare, Download, Pencil } from "lucide-react";
 import { showConfirmDialog } from "../../lib/app-dialogs";
 import { cn } from "../../lib/utils";
-import { useChatGroup, useDeleteChat, useDeleteChatGroup, useExportChat } from "../../hooks/use-chats";
+import { useChatGroup, useDeleteChat, useDeleteChatGroup, useExportChat, useUpdateChatMetadata } from "../../hooks/use-chats";
 import { useChatStore } from "../../stores/chat.store";
 import type { Chat } from "@marinara-engine/shared";
 
@@ -16,7 +17,7 @@ interface ChatFilesDrawerProps {
 
 export function ChatFilesDrawer({ chat, open, onClose }: ChatFilesDrawerProps) {
   const groupId = (chat as any).groupId as string | null;
-  const { data: groupChats } = useChatGroup(groupId);
+  const { data: groupChats, refetch: refetchGroupChats } = useChatGroup(groupId);
   const deleteChat = useDeleteChat();
   const deleteChatGroup = useDeleteChatGroup();
   const exportChat = useExportChat();
@@ -24,6 +25,43 @@ export function ChatFilesDrawer({ chat, open, onClose }: ChatFilesDrawerProps) {
   const activeChatId = useChatStore((s) => s.activeChatId);
 
   const chatFiles = (groupChats ?? []) as Chat[];
+
+  const getBranchName = (cf: Chat) => {
+    const rawMeta = (cf as any).metadata;
+    const meta =
+      typeof rawMeta === "string"
+        ? (() => {
+            try {
+              return JSON.parse(rawMeta);
+            } catch {
+              return {};
+            }
+          })()
+        : (rawMeta ?? {});
+    return meta?.branchName ?? cf.name;
+  };
+
+  const handleSwitch = (chatId: string) => {
+    setActiveChatId(chatId);
+    onClose();
+  };
+
+  const updateMetadata = useUpdateChatMetadata();
+
+  const handleRename = async (cf: Chat) => {
+    const currentName = getBranchName(cf);
+    const nextName = window.prompt("Rename branch:", currentName);
+    if (!nextName) return;
+
+    const trimmed = nextName.trim();
+    if (!trimmed || trimmed === currentName) return;
+
+    await updateMetadata.mutateAsync({
+      id: cf.id,
+      branchName: trimmed,
+    });
+    await refetchGroupChats();
+  };
 
   const handleDelete = async (chatId: string) => {
     if (
@@ -37,6 +75,10 @@ export function ChatFilesDrawer({ chat, open, onClose }: ChatFilesDrawerProps) {
       return;
     }
     deleteChat.mutate(chatId);
+    if (chatId === activeChatId && chatFiles.length > 1) {
+      const next = chatFiles.find((c) => c.id !== chatId);
+      if (next) setActiveChatId(next.id);
+    }
   };
 
   if (!open) return null;
@@ -135,9 +177,6 @@ export function ChatFilesDrawer({ chat, open, onClose }: ChatFilesDrawerProps) {
           <p className="mt-2 text-center text-[0.625rem] text-[var(--muted-foreground)]/60">
             {chatFiles.length} chat file{chatFiles.length !== 1 ? "s" : ""} in this group
           </p>
-          <p className="mt-1 text-center text-[0.625rem] text-[var(--muted-foreground)]/60">
-            Switch branches from the selector at the top of the chat.
-          </p>
         </div>
 
         {/* Chat files list */}
@@ -152,11 +191,10 @@ export function ChatFilesDrawer({ chat, open, onClose }: ChatFilesDrawerProps) {
               return (
                 <div
                   key={cf.id}
+                  onClick={() => handleSwitch(cf.id)}
                   className={cn(
-                    "group flex items-center gap-3 rounded-xl p-2.5 transition-all",
-                    isActive
-                      ? "bg-sky-400/10 ring-1 ring-sky-400/30"
-                      : "bg-[var(--background)]/40 hover:bg-[var(--accent)]",
+                    "group flex cursor-pointer items-center gap-3 rounded-xl p-2.5 transition-all",
+                    isActive ? "bg-sky-400/10 ring-1 ring-sky-400/30" : "hover:bg-[var(--accent)]",
                   )}
                 >
                   <div
@@ -170,7 +208,7 @@ export function ChatFilesDrawer({ chat, open, onClose }: ChatFilesDrawerProps) {
                     <MessageSquare size="0.875rem" />
                   </div>
                   <div className="min-w-0 flex-1">
-                    <div className="truncate text-xs font-medium">{cf.name}</div>
+                    <div className="truncate text-xs font-medium">{getBranchName(cf)}</div>
                     <div className="text-[0.625rem] text-[var(--muted-foreground)]">
                       {dateStr} at {timeStr}
                     </div>
@@ -181,15 +219,28 @@ export function ChatFilesDrawer({ chat, open, onClose }: ChatFilesDrawerProps) {
                     </span>
                   )}
                   {!isActive && (
-                    <button
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        handleDelete(cf.id);
-                      }}
-                      className="shrink-0 rounded-lg p-1.5 opacity-0 transition-all hover:bg-[var(--destructive)]/15 group-hover:opacity-100 max-md:opacity-100"
-                    >
-                      <Trash2 size="0.75rem" className="text-[var(--destructive)]" />
-                    </button>
+                    <div className="flex shrink-0 items-center gap-1 opacity-0 transition-all group-hover:opacity-100 max-md:opacity-100">
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          void handleRename(cf);
+                        }}
+                        className="rounded-lg p-1.5 transition-all hover:bg-[var(--accent)]/80 active:scale-[0.95] ring-1 ring-transparent hover:ring-[var(--border)]"
+                        title="Rename branch"
+                      >
+                        <Pencil size="0.75rem" className="text-[var(--muted-foreground)]" />
+                      </button>
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleDelete(cf.id);
+                        }}
+                        className="rounded-lg p-1.5 transition-all hover:bg-[var(--destructive)]/15"
+                        title="Delete branch"
+                      >
+                        <Trash2 size="0.75rem" className="text-[var(--destructive)]" />
+                      </button>
+                    </div>
                   )}
                 </div>
               );

--- a/packages/client/src/components/modals/STBulkImportModal.tsx
+++ b/packages/client/src/components/modals/STBulkImportModal.tsx
@@ -476,12 +476,12 @@ export function STBulkImportModal({ open, onClose }: Props) {
                   )
                 }
                 onSelectNone={() => updateCategorySelection("chats", [])}
-                getItemLabel={(item) => item.characterName || item.name}
+                getItemLabel={(item) => item.name || item.characterName}
                 renderDetails={(item) => {
                   const modified = formatModifiedAt(item.modifiedAt);
                   return (
                     <span>
-                      Folder: {item.folderName}
+                      Folder: {item.folderName} · fileName: {item.name} · characterName: {item.characterName}
                       {modified ? ` · modified ${modified}` : ""}
                     </span>
                   );

--- a/packages/client/src/hooks/use-chats.ts
+++ b/packages/client/src/hooks/use-chats.ts
@@ -110,7 +110,9 @@ export function useCreateChat() {
       personaId?: string | null;
       promptPresetId?: string | null;
     }) => api.post<Chat>("/chats", data),
-    onSuccess: () => qc.invalidateQueries({ queryKey: chatKeys.list() }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: chatKeys.list() });
+    },
   });
 }
 
@@ -121,13 +123,30 @@ export function useDeleteChat() {
     onMutate: async (id) => {
       await qc.cancelQueries({ queryKey: chatKeys.list() });
       const previous = qc.getQueryData<Chat[]>(chatKeys.list());
+      const deletedChat = previous?.find((c) => c.id === id) ?? null;
+
       qc.setQueryData<Chat[]>(chatKeys.list(), (old) => old?.filter((c) => c.id !== id));
-      return { previous };
+
+      if (deletedChat?.groupId) {
+        qc.setQueryData<Chat[]>(chatKeys.group(deletedChat.groupId), (old) =>
+          old?.filter((c) => c.id !== id),
+        );
+      }
+
+      return { previous, deletedChat };
     },
     onError: (_err, _id, context) => {
       if (context?.previous) qc.setQueryData(chatKeys.list(), context.previous);
+      if (context?.deletedChat?.groupId) {
+        qc.invalidateQueries({ queryKey: chatKeys.group(context.deletedChat.groupId) });
+      }
     },
-    onSettled: () => qc.invalidateQueries({ queryKey: chatKeys.list() }),
+    onSettled: (_data, _err, _id, context) => {
+      qc.invalidateQueries({ queryKey: chatKeys.list() });
+      if (context?.deletedChat?.groupId) {
+        qc.invalidateQueries({ queryKey: chatKeys.group(context.deletedChat.groupId) });
+      }
+    },
   });
 }
 
@@ -138,13 +157,24 @@ export function useDeleteChatGroup() {
     onMutate: async (groupId) => {
       await qc.cancelQueries({ queryKey: chatKeys.list() });
       const previous = qc.getQueryData<Chat[]>(chatKeys.list());
+
       qc.setQueryData<Chat[]>(chatKeys.list(), (old) => old?.filter((c) => c.groupId !== groupId));
-      return { previous };
+      qc.setQueryData<Chat[]>(chatKeys.group(groupId), []);
+
+      return { previous, groupId };
     },
     onError: (_err, _groupId, context) => {
       if (context?.previous) qc.setQueryData(chatKeys.list(), context.previous);
+      if (context?.groupId) {
+        qc.invalidateQueries({ queryKey: chatKeys.group(context.groupId) });
+      }
     },
-    onSettled: () => qc.invalidateQueries({ queryKey: chatKeys.list() }),
+    onSettled: (_data, _err, _groupId, context) => {
+      qc.invalidateQueries({ queryKey: chatKeys.list() });
+      if (context?.groupId) {
+        qc.invalidateQueries({ queryKey: chatKeys.group(context.groupId) });
+      }
+    },
   });
 }
 
@@ -175,17 +205,7 @@ export function useUpdateChatMetadata() {
   return useMutation({
     mutationFn: ({ id, ...metadata }: { id: string; [key: string]: unknown }) =>
       api.patch<Chat>(`/chats/${id}/metadata`, metadata),
-    onSuccess: (updatedChat, vars) => {
-      qc.setQueryData(chatKeys.detail(vars.id), updatedChat);
-      qc.setQueryData<Chat[]>(chatKeys.list(), (existing) =>
-        existing?.map((chat) => (chat.id === vars.id ? updatedChat : chat)),
-      );
-
-      const chatStore = useChatStore.getState();
-      if (chatStore.activeChatId === vars.id) {
-        chatStore.setActiveChat(updatedChat);
-      }
-
+    onSuccess: (_data, vars) => {
       qc.invalidateQueries({ queryKey: chatKeys.detail(vars.id) });
       qc.invalidateQueries({ queryKey: chatKeys.list() });
     },
@@ -361,7 +381,11 @@ export function useBranchChat() {
     onSuccess: (newChat, { chatId }) => {
       qc.invalidateQueries({ queryKey: chatKeys.list() });
       qc.invalidateQueries({ queryKey: chatKeys.detail(chatId) });
-      // Pre-populate the new branch's cache so settings are immediately available
+
+      if (newChat?.groupId) {
+        qc.invalidateQueries({ queryKey: chatKeys.group(newChat.groupId) });
+      }
+
       if (newChat) {
         qc.setQueryData(chatKeys.detail(newChat.id), newChat);
       }

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -1032,10 +1032,10 @@ export async function chatsRoutes(app: FastifyInstance) {
       await storage.update(req.params.id, { groupId });
     }
 
-    // Create a new chat as a branch
-    const branchName = `${sourceChat.name} (branch)`;
+    // Create a new chat as a branch. Keep the main thread/chat name stable and
+    // store the per-branch display label in metadata instead.
     const newChat = await storage.create({
-      name: branchName,
+      name: sourceChat.name,
       mode: sourceChat.mode as "conversation" | "roleplay" | "visual_novel",
       characterIds: (() => {
         try {
@@ -1053,11 +1053,12 @@ export async function chatsRoutes(app: FastifyInstance) {
     if (!newChat) return reply.status(500).send({ error: "Failed to create branch" });
 
     // Copy metadata (preset, lorebooks, agents, persona settings, etc.) from source chat
-    if (sourceChat.metadata) {
-      // Preserve all settings but clear transient state like summaries
-      const { summary, daySummaries, weekSummaries, ...settingsToKeep } = sourceMeta;
-      await storage.updateMetadata(newChat.id, settingsToKeep);
-    }
+    // but keep branch labels separate from the stable thread name.
+    const { summary, daySummaries, weekSummaries, ...settingsToKeep } = sourceMeta;
+    await storage.updateMetadata(newChat.id, {
+      ...settingsToKeep,
+      branchName: "New Branch",
+    });
 
     // Copy messages from source chat, using the active swipe's content
     const msgs = await storage.listMessages(req.params.id);

--- a/packages/server/src/services/import/st-bulk.importer.ts
+++ b/packages/server/src/services/import/st-bulk.importer.ts
@@ -138,6 +138,12 @@ function makeScanItemId(category: string, dataDir: string, filePath: string) {
   return `${category}:${relative(dataDir, filePath).replace(/\\/g, "/")}`;
 }
 
+function isPlaceholderChatName(value: unknown) {
+  if (typeof value !== "string") return true;
+  const name = value.trim().toLowerCase();
+  return !name || name === "unused" || name === "new chat";
+}
+
 function isConfidentBuiltinPreset(filePath: string) {
   const name = basename(filePath, extname(filePath)).trim().toLowerCase();
   return new Set([
@@ -164,7 +170,7 @@ export interface STBulkScanResult {
   error?: string;
   dataDir?: string;
   characters: Array<STBulkScanItemBase & { format: string }>;
-  chats: Array<STBulkScanItemBase & { characterName: string; folderName: string }>;
+  chats: Array<STBulkScanItemBase & { characterName: string; folderName: string; chatName: string }>;
   groupChats: Array<STBulkScanItemBase & { groupName: string; members: string[] }>;
   presets: Array<STBulkScanItemBase & { isBuiltin?: boolean }>;
   lorebooks: STBulkScanItemBase[];
@@ -269,13 +275,15 @@ export async function scanSTFolder(rootPath: string): Promise<STBulkScanResult> 
         const firstLine = content.split("\n")[0];
         if (firstLine) {
           const header = JSON.parse(firstLine);
+          const fileBaseName = basename(f, ".jsonl");
           const folderName = basename(join(f, ".."));
-          const charName = header.character_name ?? folderName;
+          const charName = isPlaceholderChatName(header.character_name) ? folderName : String(header.character_name);
           const fileInfo = await stat(f);
           chats.push({
             id: makeScanItemId("chats", dataDir, f),
             path: f,
-            name: String(charName),
+            name: fileBaseName,
+            chatName: fileBaseName,
             characterName: String(charName),
             folderName,
             modifiedAt: parseTrustedTimestamp(fileInfo.mtime),
@@ -586,68 +594,93 @@ export async function runSTBulkImport(
     }
   }
 
-  // Build a name → characterId map for linking chats to characters
-  // We look at ALL characters in DB (including ones just imported)
-  const charNameToId = new Map<string, string>();
-  try {
-    const allChars = await db.select().from(charactersTable);
-    for (const ch of allChars) {
-      try {
-        const data = JSON.parse(ch.data);
-        const name = (data?.name ?? "").toLowerCase().trim();
-        if (name) charNameToId.set(name, ch.id);
-      } catch {
-        // skip
-      }
-    }
-  } catch {
-    // DB read failed, continue without linking
-  }
+	 // Build a name → characterId map for linking chats to characters
+	// We look at ALL characters in DB (including ones just imported)
+	const charNameToId = new Map<string, string>();
+	try {
+	  const allChars = await db.select().from(charactersTable);
+	  for (const ch of allChars) {
+		try {
+		  const data = JSON.parse(ch.data);
+		  const name = (data?.name ?? "").toLowerCase().trim();
+		  if (name) charNameToId.set(name, ch.id);
+		} catch {
+		  // skip
+		}
+	  }
+	} catch {
+	  // DB read failed, continue without linking
+	}
 
-  // Also index by character card filename (ST organises chat folders by filename)
-  for (const ch of selectedCharacters) {
-    const filenameKey = basename(ch.path, extname(ch.path)).toLowerCase().trim();
-    if (filenameKey && !charNameToId.has(filenameKey)) {
-      const charId = charNameToId.get(ch.name.toLowerCase().trim());
-      if (charId) charNameToId.set(filenameKey, charId);
-    }
-  }
+	// Also index by character card filename.
+	// Use ALL scanned characters, not just selectedCharacters, so chats can still
+	// link to already-existing characters even when they were not re-imported now.
+	for (const ch of scanResult.characters) {
+	  const displayNameKey = ch.name.toLowerCase().trim();
+	  const filenameKey = basename(ch.path, extname(ch.path)).toLowerCase().trim();
 
-  // Import chats (with character linking)
-  // Generate one groupId per character name so all chats for the same character
-  // are grouped together (like ST "chat files" / branches).
-  if (selectedChats.length > 0) {
+	  const charId =
+		charNameToId.get(displayNameKey) ??
+		charNameToId.get(filenameKey) ??
+		null;
+
+	  if (charId) {
+		if (displayNameKey && !charNameToId.has(displayNameKey)) {
+		  charNameToId.set(displayNameKey, charId);
+		}
+		if (filenameKey && !charNameToId.has(filenameKey)) {
+		  charNameToId.set(filenameKey, charId);
+		}
+	  }
+	}
+
+	  // Import chats (with character linking)
+  // Group chats by character, but preserve each imported file's name as a branch label.
+    if (selectedChats.length > 0) {
     const charGroupIds = new Map<string, string>();
     const total = selectedChats.length;
     let idx = 0;
+
     for (const ct of selectedChats) {
       idx++;
       onProgress?.({ category: "Chats", item: ct.characterName, current: idx, total, imported });
+
       try {
         const content = await readFile(ct.path, "utf-8");
         const fileInfo = await stat(ct.path);
-        // Try matching by header character_name first, then by folder name (ST uses filenames for folders)
+
+        const normalizedCharacterName = ct.characterName.toLowerCase().trim();
+        const normalizedFolderName = ct.folderName.toLowerCase().trim();
+
+        // Prefer folder name first because ST chat folders usually track the
+        // character card filename more reliably than character_name headers.
         const charId =
-          charNameToId.get(ct.characterName.toLowerCase().trim()) ??
-          charNameToId.get(ct.folderName.toLowerCase().trim()) ??
+          charNameToId.get(normalizedFolderName) ??
+          charNameToId.get(normalizedCharacterName) ??
           null;
-        const groupKey = ct.characterName.toLowerCase().trim();
-        if (!charGroupIds.has(groupKey)) {
-          charGroupIds.set(groupKey, randomUUID());
+
+        const groupKey = normalizedFolderName || normalizedCharacterName;
+        let groupId = charGroupIds.get(groupKey);
+        if (!groupId) {
+          groupId = randomUUID();
+          charGroupIds.set(groupKey, groupId);
         }
+
         await importSTChat(content, db, {
           characterId: charId,
           chatName: ct.characterName,
-          groupId: charGroupIds.get(groupKey)!,
+          branchName: ct.chatName ?? basename(ct.path, ".jsonl"),
+          groupId,
           timestampOverrides: getFileTimestampOverrides(fileInfo),
         });
+
         imported.chats++;
       } catch (err) {
         errors.push(`Chat "${ct.characterName}": ${(err as Error).message}`);
       }
     }
   }
-
+	
   // Import group chats
   if (selectedGroupChats.length > 0) {
     const gcGroupIds = new Map<string, string>();

--- a/packages/server/src/services/import/st-chat.importer.ts
+++ b/packages/server/src/services/import/st-chat.importer.ts
@@ -36,6 +36,8 @@ export interface ImportSTChatOptions {
   mode?: ChatMode;
   /** Explicitly set the chat name instead of deriving from header */
   chatName?: string;
+  /** Optional imported branch/file label for branch UIs */
+  branchName?: string;
   /** For group chats: map of speaker name → characterId */
   speakerMap?: Record<string, string>;
   /** Group ID to associate this chat with (for grouping branches) */
@@ -81,6 +83,7 @@ export async function importSTChat(jsonlContent: string, db: DB, opts?: ImportST
     content: string;
     createdAt?: string;
   }[] = [];
+
   for (let i = 1; i < lines.length; i++) {
     try {
       const stMsg = JSON.parse(lines[i]!) as STChatMessage;
@@ -105,7 +108,12 @@ export async function importSTChat(jsonlContent: string, db: DB, opts?: ImportST
       const createdAt = parseTrustedTimestamp(stMsg.send_date);
       if (createdAt) messageTimestamps.push(createdAt);
 
-      msgInputs.push({ role, characterId: messageCharacterId, content, ...(createdAt ? { createdAt } : {}) });
+      msgInputs.push({
+        role,
+        characterId: messageCharacterId,
+        content,
+        ...(createdAt ? { createdAt } : {}),
+      });
     } catch {
       // Skip malformed lines
     }
@@ -132,6 +140,16 @@ export async function importSTChat(jsonlContent: string, db: DB, opts?: ImportST
   );
 
   if (!chat) return { error: "Failed to create chat" };
+
+  // Preserve an imported branch/file label separately from the main thread/chat name.
+  if (opts?.branchName) {
+    const existingMetadata =
+      typeof chat.metadata === "string" ? JSON.parse(chat.metadata) : (chat.metadata ?? {});
+    await storage.updateMetadata(chat.id, {
+      ...existingMetadata,
+      branchName: opts.branchName,
+    });
+  }
 
   await storage.createMessagesBatch(chat.id, msgInputs, chatTimestamps);
 


### PR DESCRIPTION
Fixes SillyTavern import grouping and branch labeling.

Why:
Imported ST chats could be grouped incorrectly or shown under unused/unknown, and branch rows reused the main chat name instead of a per-branch label. Branch create/delete/rename also did not always refresh the visible branch list until reload.

Changes:
- improve ST chat character matching/grouping
- keep the stable chat/thread name separate from branch labels
- store imported file/checkpoint names as branch metadata
- add branch rename support in the chat files drawer
- invalidate relevant React Query group/list/detail caches after branch create/delete/rename

Manual validation:
- pnpm check
- pnpm db:push
- pnpm version:check
- imported ST chat and character data and verified chats grouped under the correct character
- verified branch labels display correctly
- verified branch rename/create/delete update without page reload

Before:
<img width="774" height="294" alt="image" src="https://github.com/user-attachments/assets/5fb03d12-b58f-4361-9a9f-21524efc6a43" />

<img width="465" height="60" alt="image" src="https://github.com/user-attachments/assets/aeeeb536-c9b5-415a-a700-9f1900dff8f1" />

<img width="339" height="494" alt="image" src="https://github.com/user-attachments/assets/3f44a11a-2ef3-4647-a13c-2b4ef6cc6ada" />

After:
<img width="784" height="609" alt="image" src="https://github.com/user-attachments/assets/755bad9d-1f9e-49ba-97ac-835a99c7b175" />

<img width="231" height="130" alt="image" src="https://github.com/user-attachments/assets/506e0ee6-d0c8-4928-829e-2c8dca2e654e" />

<img width="329" height="165" alt="image" src="https://github.com/user-attachments/assets/57ee5510-fbff-4317-adc6-341a0fe1c00b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat files are now directly clickable to switch between branches
  * Added chat renaming capability
  * Improved branch display naming with metadata support

* **Improvements**
  * Enhanced bulk import modal to show more detailed chat information
  * Smarter character name detection in bulk imports, ignoring placeholder values
  * Better automatic naming for branched chats
  * Improved chat selection and active chat management during deletions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->