### PR TITLE
fix(chat): keep branch selector open while scrolling its list

### DIFF
--- a/packages/client/src/components/chat/ChatBranchSelector.tsx
+++ b/packages/client/src/components/chat/ChatBranchSelector.tsx
@@ -64,18 +64,23 @@ export function ChatBranchSelector({
       if (event.key === "Escape") setOpen(false);
     };
 
-    const handleViewportChange = () => setOpen(false);
+    const handleResize = () => setOpen(false);
+
+    const handleScroll = (event: Event) => {
+      if (popoverRef.current?.contains(event.target as Node)) return;
+      setOpen(false);
+    };
 
     document.addEventListener("mousedown", handlePointerDown);
     document.addEventListener("keydown", handleEscape);
-    window.addEventListener("resize", handleViewportChange);
-    window.addEventListener("scroll", handleViewportChange, true);
+    window.addEventListener("resize", handleResize);
+    window.addEventListener("scroll", handleScroll, true);
 
     return () => {
       document.removeEventListener("mousedown", handlePointerDown);
       document.removeEventListener("keydown", handleEscape);
-      window.removeEventListener("resize", handleViewportChange);
-      window.removeEventListener("scroll", handleViewportChange, true);
+      window.removeEventListener("resize", handleResize);
+      window.removeEventListener("scroll", handleScroll, true);
     };
   }, [open]);
 


### PR DESCRIPTION
## Summary
- Fixes a bug reported by @DarkPulse #208 where the chat branch selector closes the moment you try to mousewheel or drag its scrollbar when there are enough branches (~7+) to overflow the list.
- Root cause: the open-popover effect installed a capture-phase `scroll` listener on `window` that called `setOpen(false)` on any scroll event — including scrolls inside the popover's own `overflow-y-auto` list. The "popover shifts for a frame then closes" symptom the reporter saw was the list scrolling before the close fired.
- Fix: split the single handler into `handleResize` (unchanged behavior) and `handleScroll`, which ignores scroll events whose `target` is inside `popoverRef`. Outside scrolls (page, sidebar, etc.) still close the popover as intended.

## Test plan
- [x] Open an RP with 10+ branches and drop down the chat branch selector.
- [x] Mousewheel down inside the list — popover stays open and list scrolls.
- [x] Drag the popover scrollbar — popover stays open during the drag.
- [x] Click a branch — popover closes and switches branch as before.
- [x] Scroll the page/sidebar outside the popover — popover still closes (existing behavior preserved).
- [x] Resize the window — popover still closes (existing behavior preserved).
- [x] Press Escape / click outside — popover still closes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat branch selector popover behavior: the popover now correctly remains open when scrolling within its boundaries, while properly responding to resize events and external scroll actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->