### PR TITLE
fix(client): Author's Notes edits lost on outside-click

### DIFF
--- a/packages/client/src/components/chat/ChatRoleplayPanels.tsx
+++ b/packages/client/src/components/chat/ChatRoleplayPanels.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Globe, Loader2, PenLine, X } from "lucide-react";
+import { Globe, Loader2, PenLine, Save, X } from "lucide-react";
 import { useUpdateChatMetadata } from "../../hooks/use-chats";
 import { useActiveLorebookEntries } from "../../hooks/use-lorebooks";
 
@@ -92,27 +92,131 @@ export function WorldInfoPanel({
 export function AuthorNotesPanel({
   chatId,
   chatMeta,
-  isMobile,
   onClose,
 }: {
   chatId: string;
   chatMeta: Record<string, any>;
-  isMobile: boolean;
   onClose: () => void;
 }) {
-  const [notes, setNotes] = useState((chatMeta.authorNotes as string) ?? "");
-  const [depthStr, setDepthStr] = useState(String((chatMeta.authorNotesDepth as number) ?? 4));
+  const propsNotes = (chatMeta.authorNotes as string) ?? "";
+  const propsDepth = (chatMeta.authorNotesDepth as number) ?? 4;
+
+  const [notes, setNotes] = useState(propsNotes);
+  const [depthStr, setDepthStr] = useState(String(propsDepth));
   const updateMeta = useUpdateChatMetadata();
 
-  useEffect(() => {
-    setNotes((chatMeta.authorNotes as string) ?? "");
-    setDepthStr(String((chatMeta.authorNotesDepth as number) ?? 4));
-  }, [chatMeta.authorNotes, chatMeta.authorNotesDepth]);
-
   const depth = parseInt(depthStr, 10) || 0;
+
+  const isDirty = notes !== propsNotes || depth !== propsDepth;
+
+  // Sync draft from props only when NOT dirty — lets external edits land on
+  // first view while respecting pending user edits. Use Cancel to discard
+  // local edits and pick up the server value.
+  useEffect(() => {
+    if (isDirty) return;
+    setNotes(propsNotes);
+    setDepthStr(String(propsDepth));
+    // isDirty intentionally excluded — effect runs on external prop changes only.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [propsNotes, propsDepth]);
+
   const handleSave = () => {
-    updateMeta.mutate({ id: chatId, authorNotes: notes, authorNotesDepth: depth });
+    if (!isDirty) return;
+    updateMeta.mutate(
+      { id: chatId, authorNotes: notes, authorNotesDepth: depth },
+      {
+        onSuccess: () => onClose(),
+      },
+    );
   };
+
+  const handleCancel = () => {
+    setNotes(propsNotes);
+    setDepthStr(String(propsDepth));
+    onClose();
+  };
+
+  const saveDisabled = !isDirty || updateMeta.isPending;
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <label htmlFor="author-notes-text" className="text-xs font-medium text-[var(--foreground)]">
+            Notes
+            {isDirty && (
+              <span className="ml-2 text-[0.625rem] font-normal text-[var(--muted-foreground)]">· unsaved changes</span>
+            )}
+          </label>
+        </div>
+        <textarea
+          id="author-notes-text"
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          placeholder="e.g. Keep the tone dark and suspenseful. The villain is secretly an ally."
+          className="w-full resize-y rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-2.5 py-2 text-xs text-[var(--foreground)] outline-none transition-colors placeholder:text-[var(--muted-foreground)] focus:ring-2 focus:ring-[var(--ring)]"
+          rows={6}
+        />
+        <p className="text-[0.625rem] text-[var(--muted-foreground)]/70">
+          Injected into the prompt at the chosen depth every generation.
+        </p>
+        <div className="flex items-center gap-2 pt-1">
+          <span className="shrink-0 text-[0.6875rem] text-[var(--muted-foreground)]">Injection Depth</span>
+          <input
+            type="text"
+            inputMode="numeric"
+            value={depthStr}
+            onChange={(e) => setDepthStr(e.target.value.replace(/[^0-9]/g, ""))}
+            onBlur={() => {
+              const nextDepth = Math.max(0, parseInt(depthStr, 10) || 0);
+              setDepthStr(String(nextDepth));
+            }}
+            className="w-16 rounded-md border border-[var(--border)] bg-[var(--secondary)] px-2 py-1 text-center text-xs text-[var(--foreground)] outline-none transition-colors [appearance:textfield] focus:ring-2 focus:ring-[var(--ring)] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+          />
+          <span className="text-[0.625rem] text-[var(--muted-foreground)]/70">
+            0 = end of conversation, 4 = four messages from the end.
+          </span>
+        </div>
+      </div>
+
+      <div className="flex items-center justify-end gap-1.5 border-t border-[var(--border)]/40 pt-3">
+        <button
+          onClick={handleCancel}
+          className="rounded-lg px-2.5 py-1 text-[0.625rem] font-medium text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+        >
+          Cancel
+        </button>
+        <button
+          onClick={handleSave}
+          disabled={saveDisabled}
+          className="flex items-center gap-1 rounded-lg bg-gradient-to-r from-amber-400 to-orange-500 px-2.5 py-1 text-[0.625rem] font-medium text-white shadow-sm transition-all hover:shadow-md active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-50 disabled:shadow-none disabled:active:scale-100"
+        >
+          {updateMeta.isPending ? (
+            <Loader2 size="0.625rem" className="animate-spin" />
+          ) : (
+            <Save size="0.625rem" />
+          )}
+          Save
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/** Read-only preview of Author's Notes. Hands off to AuthorNotesPanel for edits. */
+export function AuthorNotesPeek({
+  chatMeta,
+  isMobile,
+  onEdit,
+  onClose,
+}: {
+  chatMeta: Record<string, any>;
+  isMobile: boolean;
+  onEdit: () => void;
+  onClose: () => void;
+}) {
+  const notes = String(chatMeta.authorNotes ?? "").trim();
+  const depth = (chatMeta.authorNotesDepth as number) ?? 4;
 
   return (
     <>
@@ -128,35 +232,29 @@ export function AuthorNotesPanel({
           </button>
         )}
       </h3>
-      <p className="mb-2 text-[0.625rem] text-[var(--muted-foreground)]">
-        Text here is injected into the prompt at the chosen depth every generation.
-      </p>
-      <textarea
-        value={notes}
-        onChange={(e) => setNotes(e.target.value)}
-        onBlur={handleSave}
-        placeholder="e.g. Keep the tone dark and suspenseful. The villain is secretly an ally."
-        className="w-full resize-none rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-2.5 py-2 text-xs text-[var(--foreground)] outline-none transition-colors placeholder:text-[var(--muted-foreground)] focus:ring-2 focus:ring-[var(--ring)]"
-        rows={4}
-      />
-      <div className="mt-2 flex items-center gap-2">
-        <span className="shrink-0 text-[0.625rem] text-[var(--muted-foreground)]">Injection Depth</span>
-        <input
-          type="text"
-          inputMode="numeric"
-          value={depthStr}
-          onChange={(e) => setDepthStr(e.target.value.replace(/[^0-9]/g, ""))}
-          onBlur={() => {
-            const nextDepth = Math.max(0, parseInt(depthStr, 10) || 0);
-            setDepthStr(String(nextDepth));
-            updateMeta.mutate({ id: chatId, authorNotes: notes, authorNotesDepth: nextDepth });
-          }}
-          className="w-14 rounded-md border border-[var(--border)] bg-[var(--secondary)] px-2 py-0.5 text-center text-[0.625rem] text-[var(--foreground)] outline-none transition-colors [appearance:textfield] focus:ring-2 focus:ring-[var(--ring)] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
-        />
+      {notes ? (
+        <>
+          <div className="mb-2 max-h-64 overflow-y-auto whitespace-pre-wrap rounded-lg bg-[var(--secondary)] px-2.5 py-2 text-xs leading-relaxed text-[var(--foreground)]/90">
+            {notes}
+          </div>
+          <p className="mb-2 text-[0.625rem] text-[var(--muted-foreground)]">
+            Injected at depth {depth} every generation.
+          </p>
+        </>
+      ) : (
+        <p className="mb-2 rounded-lg bg-[var(--secondary)]/50 py-4 text-center text-xs italic text-[var(--muted-foreground)]">
+          No Author's Notes yet.
+        </p>
+      )}
+      <div className="flex justify-end border-t border-[var(--border)]/40 pt-2">
+        <button
+          onClick={onEdit}
+          className="flex items-center gap-1 rounded-md px-2.5 py-1 text-[0.625rem] font-medium text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+        >
+          <PenLine size="0.625rem" />
+          Edit
+        </button>
       </div>
-      <p className="mt-1 text-[0.5625rem] text-[var(--muted-foreground)]/60">
-        Depth 0 = end of conversation, 4 = four messages from the end.
-      </p>
     </>
   );
 }

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -27,6 +27,7 @@ import {
   FlipHorizontal2,
 } from "lucide-react";
 import { cn } from "../../lib/utils";
+import { Modal } from "../ui/Modal";
 import { useUIStore } from "../../stores/ui.store";
 import { useChatStore } from "../../stores/chat.store";
 import { useGameStateStore } from "../../stores/game-state.store";
@@ -85,6 +86,11 @@ const WorldInfoPanel = lazy(async () => {
 const AuthorNotesPanel = lazy(async () => {
   const module = await import("./ChatRoleplayPanels");
   return { default: module.AuthorNotesPanel };
+});
+
+const AuthorNotesPeek = lazy(async () => {
+  const module = await import("./ChatRoleplayPanels");
+  return { default: module.AuthorNotesPeek };
 });
 
 function WeatherEffectsConnected() {
@@ -438,42 +444,50 @@ function WorldInfoButton({ chatId }: { chatId: string | null }) {
   );
 }
 
+/**
+ * Three-state Author's Notes affordance: closed → peek → edit.
+ * Toolbar icon toggles between closed and peek; peek's Edit button opens the dialog.
+ */
 function AuthorNotesButton({ chatId, chatMeta }: { chatId: string | null; chatMeta: Record<string, any> }) {
-  const [open, setOpen] = useState(false);
+  const [view, setView] = useState<"closed" | "peek" | "edit">("closed");
   const ref = useRef<HTMLDivElement>(null);
   const isMobile = typeof window !== "undefined" && window.innerWidth < 768;
   const compact = useUIStore((s) => s.centerCompact);
 
+// Outside-click closes the peek. Desktop only — mobile uses the backdrop.
   useEffect(() => {
-    if (!open || isMobile) return;
+    if (view !== "peek" || isMobile) return;
     const handle = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+      if (ref.current && !ref.current.contains(e.target as Node)) setView("closed");
     };
-    document.addEventListener("mousedown", handle);
-    return () => document.removeEventListener("mousedown", handle);
-  }, [open, isMobile]);
+    document.addEventListener("click", handle);
+    return () => document.removeEventListener("click", handle);
+  }, [view, isMobile]);
 
   useEffect(() => {
-    if (!open) return;
+    if (view !== "peek") return;
     const handler = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setOpen(false);
+      if (e.key === "Escape") setView("closed");
     };
     document.addEventListener("keydown", handler);
     return () => document.removeEventListener("keydown", handler);
-  }, [open]);
+  }, [view]);
 
   if (!chatId) return null;
 
   const hasNotes = !!String(chatMeta.authorNotes ?? "").trim();
+  const isOpen = view !== "closed";
+  const peekOpen = view === "peek";
+  const editOpen = view === "edit";
 
   return (
-    <div className="relative" ref={ref} onClick={(e) => e.stopPropagation()}>
+    <div className="relative" ref={ref}>
       <button
-        onClick={() => setOpen(!open)}
+        onClick={() => setView((v) => (v === "closed" ? "peek" : "closed"))}
         className={cn(
           "flex items-center justify-center rounded-full border backdrop-blur-md transition-all",
           compact ? "p-1" : "p-1.5",
-          open
+          isOpen
             ? "bg-foreground/15 border-foreground/20 text-foreground/90"
             : hasNotes
               ? "bg-foreground/10 border-foreground/25 text-foreground/80 hover:bg-foreground/15 hover:text-foreground"
@@ -483,7 +497,8 @@ function AuthorNotesButton({ chatId, chatMeta }: { chatId: string | null; chatMe
       >
         <PenLine size="0.875rem" />
       </button>
-      {open &&
+
+      {peekOpen &&
         (isMobile ? (
           createPortal(
             <div
@@ -491,7 +506,7 @@ function AuthorNotesButton({ chatId, chatMeta }: { chatId: string | null; chatMe
               onMouseDown={(e) => e.stopPropagation()}
               onTouchStart={(e) => e.stopPropagation()}
             >
-              <div className="absolute inset-0 bg-black/30" onClick={() => setOpen(false)} />
+              <div className="absolute inset-0 bg-black/30" onClick={() => setView("closed")} />
               <div
                 className="relative max-h-[calc(100dvh-4rem)] w-full max-w-sm overflow-y-auto rounded-xl border border-[var(--border)] bg-[var(--card)] p-3 shadow-2xl shadow-black/40 animate-message-in"
                 onClick={(e) => e.stopPropagation()}
@@ -504,11 +519,11 @@ function AuthorNotesButton({ chatId, chatMeta }: { chatId: string | null; chatMe
                     </div>
                   }
                 >
-                  <AuthorNotesPanel
-                    chatId={chatId}
+                  <AuthorNotesPeek
                     chatMeta={chatMeta}
                     isMobile={isMobile}
-                    onClose={() => setOpen(false)}
+                    onEdit={() => setView("edit")}
+                    onClose={() => setView("closed")}
                   />
                 </Suspense>
               </div>
@@ -525,15 +540,28 @@ function AuthorNotesButton({ chatId, chatMeta }: { chatId: string | null; chatMe
                 </div>
               }
             >
-              <AuthorNotesPanel
-                chatId={chatId}
+              <AuthorNotesPeek
                 chatMeta={chatMeta}
                 isMobile={isMobile}
-                onClose={() => setOpen(false)}
+                onEdit={() => setView("edit")}
+                onClose={() => setView("closed")}
               />
             </Suspense>
           </div>
         ))}
+
+      <Modal open={editOpen} onClose={() => setView("closed")} title="Author's Notes">
+        <Suspense
+          fallback={
+            <div className="flex items-center gap-2 py-4 text-xs text-[var(--muted-foreground)]">
+              <Loader2 size="0.75rem" className="animate-spin" />
+              Loading author's notes...
+            </div>
+          }
+        >
+          <AuthorNotesPanel chatId={chatId} chatMeta={chatMeta} onClose={() => setView("closed")} />
+        </Suspense>
+      </Modal>
     </div>
   );
 }


### PR DESCRIPTION
## The bug

Open Author's Notes, type content, click outside the popover. The typed content is lost — sometimes. Whether the save takes is, in the current implementation, in the lap of the gods. :)

**Repro:** Open Author's Notes on any chat. Type a paragraph. Click anywhere outside the popover. Re-open. Roughly half the time the content is gone.

## Root cause

The outside-click handler fires on `mousedown` and unmounts the textarea before its `onBlur` (which triggered the save) can run. No reliable fix is possible within the popover-plus-blur-save architecture — the container is trying to be both a transient peek surface (dismiss on mousedown) and a live editor (persist on blur), and those contracts race by construction.

## Fix

Split viewing and editing into their proper containers.

- **`AuthorNotesPeek`** — read-only popover. Transient dismissal is safe because no mutation is in flight. Uses `click` rather than `mousedown` for predictable close semantics.
- **`AuthorNotesPanel`** — committed editing in the shared `Modal` primitive (same one used by `EditAgentModal`, `LorebookMakerModal`, etc.) with explicit Save / Cancel. `isDirty` gates prop-sync so external refetches don't clobber pending edits.
- **`AuthorNotesButton`** — three-state machine (closed / peek / edit) owning all transitions; the two child components are unaware of each other.

## Why peek/edit rather than just "use Modal for everything"

Viewing and editing have different optimal containers. Peeking is by far the more common action ("what did I put in here again?") and is cheap, frequent, and safe. Editing wants a committed feel — backdrop, focus trap, Escape. The one-container-fits-both compromise is precisely what caused the save race: the popover was trying to serve both contracts at once.

## User-visible result

All four close paths (X / backdrop / Escape / Cancel) are race-proof by construction. Desktop and mobile now render as a single consistent dialog (previously desktop was a popover, mobile a full-screen portal). Also picks up `role=dialog`, `aria-modal`, Escape handling and focus trap from the shared `Modal`.

## Testing

- `pnpm lint && pnpm build` pass.
- Manually verified all four close paths on desktop and mobile viewport.
- Manually verified the save race is gone: rapid type-then-outside-click no longer loses content.

## Screenshots
Peek with discrete edit button:
<img width="350" height="220" alt="image" src="https://github.com/user-attachments/assets/56e593e7-86b6-4621-b92b-60dbe56fdfa1" />


Edit:
<img width="501" height="399" alt="image" src="https://github.com/user-attachments/assets/3cd58a33-9f81-47fd-a1d6-39d1d0a5d887" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Author's Notes now use explicit Save and Cancel buttons for draft editing instead of auto-save.
  * Preview mode for Author's Notes is now read-only with an Edit button to transition to edit mode.
  * Enhanced mobile UI for Author's Notes with improved preview and edit workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->