### PR TITLE
feat: Option to guide generations from chat input textarea

### DIFF
--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -74,7 +74,7 @@ The only **persisted** store (localStorage via Zustand `persist` middleware). Co
 - **Streaming**: `enableStreaming`, `streamingSpeed`
 - **Conversation theme**: gradient colors for message bubbles
 - **Sound**: `convoNotificationSound`, `rpNotificationSound`
-- **Behavior**: `confirmBeforeDelete`, `enterToSendRP`, `enterToSendConvo`, `weatherEffects`
+- **Behavior**: `confirmBeforeDelete`, `enterToSendRP`, `enterToSendConvo`, `weatherEffects`, `guideGenerations`
 - **Navigation**: `rightPanel`, `rightPanelOpen`, `sidebarOpen`, `settingsTab`, all `*DetailId` fields, `modal`
 
 Synced custom themes are **not** stored in `ui.store.ts`; they are fetched from the server via React Query and mirrored across devices connected to the same Marinara instance.
@@ -87,6 +87,7 @@ Non-persisted. Tracks the active chat session:
 - `messages` — current message array
 - `isStreaming`, `streamBuffer` — generation in progress
 - `inputDrafts` — per-chat draft messages
+- `currentInput` — current value of chat input
 - `perChatTyping` — typing indicator state
 - `unreadCounts`, `chatNotifications` — notification badges
 - `abortControllers` — cancel in-flight generations

--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -83,10 +83,12 @@ export function ChatArea() {
   const isStreaming = isStreamingGlobal && streamingChatId === activeChatId;
   const isPageActive = usePageActivity();
   const regenerateMessageId = useChatStore((s) => s.regenerateMessageId);
+  const currentInput = useChatStore((s) => s.currentInput);
   const chatBackground = useUIStore((s) => s.chatBackground);
   const weatherEffects = useUIStore((s) => s.weatherEffects);
   const messagesPerPage = useUIStore((s) => s.messagesPerPage);
   const centerCompact = useUIStore((s) => s.centerCompact);
+  const guideGenerations = useUIStore((s) => s.guideGenerations);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const prevScrollHeightRef = useRef(0);
@@ -652,12 +654,17 @@ export function ChatArea() {
       }
       try {
         // Regenerate as a new swipe on the existing message
-        await generate({ chatId: activeChatId, connectionId: null, regenerateMessageId: messageId });
+        const hasInput = currentInput ? currentInput.trim().length > 0 : false;
+        await generate(
+          guideGenerations && hasInput
+          ? { chatId: activeChatId, connectionId: null, regenerateMessageId: messageId, generationGuide: currentInput?.toString() }
+          : { chatId: activeChatId, connectionId: null, regenerateMessageId: messageId }
+        );
       } catch {
         // Error toast is shown by the generate hook
       }
     },
-    [activeChatId, isStreaming, generate],
+    [activeChatId, isStreaming, generate, currentInput, guideGenerations],
   );
 
   const _handleRetryAgents = useCallback(async () => {

--- a/packages/client/src/components/chat/ChatInput.tsx
+++ b/packages/client/src/components/chat/ChatInput.tsx
@@ -69,6 +69,7 @@ export const ChatInput = memo(function ChatInput({
   const isStreaming = isStreamingGlobal && streamingChatId === activeChatId;
   const setInputDraft = useChatStore((s) => s.setInputDraft);
   const clearInputDraft = useChatStore((s) => s.clearInputDraft);
+  const setCurrentInput = useChatStore((s) => s.setCurrentInput);
   const { generate } = useGenerate();
   const { applyToUserInput } = useApplyRegex();
   const enterToSend = useUIStore((s) => s.enterToSendRP);
@@ -76,6 +77,11 @@ export const ChatInput = memo(function ChatInput({
   const fileInputRef = useRef<HTMLInputElement>(null);
   const resizeRafRef = useRef<number>(0);
   const qc = useQueryClient();
+
+  const syncInputState = useCallback((value: string) => {
+    setHasInput(value.trim().length > 0);
+    setCurrentInput(value);
+  }, [setCurrentInput]);
 
   // Restore draft when mounting or switching chats
   const prevChatIdRef = useRef<string | null>(null);
@@ -96,12 +102,12 @@ export const ChatInput = memo(function ChatInput({
     if (activeChatId && textareaRef.current) {
       const draft = useChatStore.getState().inputDrafts.get(activeChatId) ?? "";
       textareaRef.current.value = draft;
-      setHasInput(draft.trim().length > 0);
+      syncInputState(draft);
       // Resize textarea to fit content
       textareaRef.current.style.height = "auto";
       textareaRef.current.style.height = Math.min(textareaRef.current.scrollHeight, 200) + "px";
     }
-  }, [activeChatId, setInputDraft, clearInputDraft]);
+  }, [activeChatId, setInputDraft, clearInputDraft, syncInputState]);
 
   // Save draft when component unmounts (e.g. navigating to editor)
   useEffect(() => {
@@ -292,7 +298,7 @@ export const ChatInput = memo(function ChatInput({
         textareaRef.current.value = "";
         textareaRef.current.style.height = "auto";
       }
-      setHasInput(false);
+      syncInputState("");
       setCompletions([]);
       setAttachments([]);
       clearInputDraft(activeChatId);
@@ -339,7 +345,7 @@ export const ChatInput = memo(function ChatInput({
       textareaRef.current.value = "";
       textareaRef.current.style.height = "auto";
     }
-    setHasInput(false);
+    syncInputState("");
     setCompletions([]);
     const pendingAttachments = attachments.map((a) => ({ type: a.type, data: a.data }));
     setAttachments([]);
@@ -384,6 +390,7 @@ export const ChatInput = memo(function ChatInput({
     mode,
     groupResponseOrder,
     createMessage,
+    syncInputState
   ]);
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -442,6 +449,7 @@ export const ChatInput = memo(function ChatInput({
       if (draftTimerRef.current) clearTimeout(draftTimerRef.current);
       const chatId = activeChatId;
       const text = fixed;
+      setCurrentInput(text);
       draftTimerRef.current = setTimeout(() => {
         if (text.trim()) {
           setInputDraft(chatId, text);
@@ -486,9 +494,9 @@ export const ChatInput = memo(function ChatInput({
     const value = el.value;
     el.value = value.slice(0, start) + emoji + value.slice(end);
     el.selectionStart = el.selectionEnd = start + emoji.length;
-    setHasInput(el.value.length > 0);
+    syncInputState(el.value);
     el.focus();
-  }, []);
+  }, [syncInputState]);
 
   // Character picker: trigger a response from a specific character (manual mode)
   const handleCharacterResponse = useCallback(

--- a/packages/client/src/components/chat/ChatInput.tsx
+++ b/packages/client/src/components/chat/ChatInput.tsx
@@ -114,13 +114,13 @@ export const ChatInput = memo(function ChatInput({
   // Save draft when component unmounts (e.g. navigating to editor)
   useEffect(() => {
     const textarea = textareaRef.current;
+    const chatId = useChatStore.getState().activeChatId;
     return () => {
       // Cancel pending debounce timers
       if (draftTimerRef.current) clearTimeout(draftTimerRef.current);
       // Cancel pending resize rAF
       if (resizeRafRef.current) cancelAnimationFrame(resizeRafRef.current);
       // Flush draft synchronously
-      const chatId = useChatStore.getState().activeChatId;
       if (chatId && textarea) {
         const text = textarea.value;
         if (text.trim()) {

--- a/packages/client/src/components/chat/ChatInput.tsx
+++ b/packages/client/src/components/chat/ChatInput.tsx
@@ -70,9 +70,11 @@ export const ChatInput = memo(function ChatInput({
   const setInputDraft = useChatStore((s) => s.setInputDraft);
   const clearInputDraft = useChatStore((s) => s.clearInputDraft);
   const setCurrentInput = useChatStore((s) => s.setCurrentInput);
+  const currentInput = useChatStore((s) => s.currentInput);
   const { generate } = useGenerate();
   const { applyToUserInput } = useApplyRegex();
   const enterToSend = useUIStore((s) => s.enterToSendRP);
+  const guideGenerations = useUIStore((s) => s.guideGenerations);
   const createMessage = useCreateMessage(activeChatId);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const resizeRafRef = useRef<number>(0);
@@ -505,17 +507,17 @@ export const ChatInput = memo(function ChatInput({
       setCharPickerOpen(false);
       setCharPickerPos(null);
       try {
-        await generate({
-          chatId: activeChatId,
-          connectionId: null,
-          forCharacterId: characterId,
-        });
+        await generate(
+          guideGenerations && hasInput
+          ? { chatId: activeChatId, connectionId: null, forCharacterId: characterId, generationGuide: currentInput }
+          : { chatId: activeChatId, connectionId: null, forCharacterId: characterId }
+        );
       } catch (error) {
         const msg = error instanceof Error ? error.message : "Generation failed";
         toast.error(msg);
       }
     },
-    [activeChatId, isStreaming, generate],
+    [activeChatId, isStreaming, generate, hasInput, currentInput, guideGenerations],
   );
 
   // Close character picker on outside click
@@ -730,7 +732,7 @@ export const ChatInput = memo(function ChatInput({
                 ? "text-foreground bg-foreground/10"
                 : "text-foreground/40 hover:bg-foreground/10 hover:text-foreground/70",
             )}
-            title="Trigger character response"
+            title={(guideGenerations && hasInput) ? "Trigger character response (guided)" : "Trigger character response"}
           >
             <Users size="1rem" />
           </button>

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -32,6 +32,7 @@ import { useShallow } from "zustand/react/shallow";
 import { resolveMessageMacros } from "../../lib/chat-macros";
 import { useApplyRegex } from "../../hooks/use-apply-regex";
 import { useUIStore } from "../../stores/ui.store";
+import { useChatStore } from "../../stores/chat.store";
 import { useTranslate } from "../../hooks/use-translate";
 import { api } from "../../lib/api-client";
 import { ttsService } from "../../lib/tts-service";
@@ -458,6 +459,7 @@ export const ChatMessage = memo(function ChatMessage({
     showModelName,
     showTokenUsage,
     showMessageNumbers,
+    guideGenerations,
     boldDialogue,
   } = useUIStore(
     useShallow((s) => ({
@@ -470,9 +472,12 @@ export const ChatMessage = memo(function ChatMessage({
       showModelName: s.showModelName,
       showTokenUsage: s.showTokenUsage,
       showMessageNumbers: s.showMessageNumbers,
+      guideGenerations: s.guideGenerations,
       boldDialogue: s.boldDialogue ?? true,
     })),
   );
+  const hasInput = useChatStore((s) => s.currentInput.trim().length > 0);
+  const regenerateButtonTitle = (guideGenerations && hasInput) ? "Regenerate (guided)" : "Regenerate";
 
   // Build reusable text style objects (memoized to avoid unnecessary DOM updates)
   const textStrokeStyle = useMemo<React.CSSProperties>(
@@ -1387,7 +1392,7 @@ export const ChatMessage = memo(function ChatMessage({
               <ActionBtn
                 icon={<RefreshCw size="0.6875rem" />}
                 onClick={() => onRegenerate?.(message.id)}
-                title="Regenerate"
+                title={regenerateButtonTitle}
                 dark
               />
               <ActionBtn
@@ -1723,7 +1728,7 @@ export const ChatMessage = memo(function ChatMessage({
             <ActionBtn
               icon={<RefreshCw size="0.625rem" />}
               onClick={() => onRegenerate?.(message.id)}
-              title="Regenerate"
+              title={regenerateButtonTitle}
             />
             <ActionBtn
               icon={<Flag size="0.625rem" />}

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -1087,6 +1087,7 @@ export function ChatRoleplaySurface({
                   </div>
                 )}
                 <ChatInput
+                  key={activeChatId}
                   mode={isRoleplay ? "roleplay" : "conversation"}
                   characterNames={characterNames}
                   groupResponseOrder={

--- a/packages/client/src/components/chat/ConversationInput.tsx
+++ b/packages/client/src/components/chat/ConversationInput.tsx
@@ -109,12 +109,18 @@ export function ConversationInput({ characterNames = [] }: ConversationInputProp
   const isActuallyGenerating = isStreaming && !delayedCharacterInfo;
   const setInputDraft = useChatStore((s) => s.setInputDraft);
   const clearInputDraft = useChatStore((s) => s.clearInputDraft);
+  const setCurrentInput = useChatStore((s) => s.setCurrentInput);
   const { generate } = useGenerate();
   const { applyToUserInput } = useApplyRegex();
   const enterToSend = useUIStore((s) => s.enterToSendConvo);
   const createMessage = useCreateMessage(activeChatId);
   const qc = useQueryClient();
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const syncInputState = useCallback((value: string) => {
+    setHasInput(value.trim().length > 0);
+    setCurrentInput(value);
+  }, [setCurrentInput]);
 
   // Restore draft
   const prevChatIdRef = useRef<string | null>(null);
@@ -127,12 +133,12 @@ export function ConversationInput({ characterNames = [] }: ConversationInputProp
       if (textareaRef.current) {
         const draft = activeChatId ? (useChatStore.getState().inputDrafts.get(activeChatId) ?? "") : "";
         textareaRef.current.value = draft;
-        setHasInput(draft.length > 0);
+        syncInputState(draft);
         textareaRef.current.style.height = "auto";
         textareaRef.current.style.height = `${Math.min(textareaRef.current.scrollHeight, 160)}px`;
       }
     }
-  }, [activeChatId, setInputDraft]);
+  }, [activeChatId, setInputDraft, syncInputState]);
 
   // Save draft on unmount
   useEffect(() => {
@@ -250,12 +256,12 @@ export function ConversationInput({ characterNames = [] }: ConversationInputProp
       el.value = `${before}@${name} ${after}`;
       const cursorPos = before.length + name.length + 2; // +2 for @ and space
       el.selectionStart = el.selectionEnd = cursorPos;
-      setHasInput(el.value.length > 0);
+      syncInputState(el.value);
       setMentionQuery(null);
       setMentionCompletions([]);
       el.focus();
     },
-    [mentionStartPos],
+    [mentionStartPos, syncInputState],
   );
 
   const handleSend = useCallback(async () => {
@@ -292,8 +298,8 @@ export function ConversationInput({ characterNames = [] }: ConversationInputProp
         textareaRef.current.value = "";
         textareaRef.current.style.height = "auto";
       }
-      setHasInput(false);
       clearInputDraft(activeChatId);
+      syncInputState("");
       const currentAttachments = [...attachments];
       setAttachments([]);
       createMessage.mutate({
@@ -316,8 +322,8 @@ export function ConversationInput({ characterNames = [] }: ConversationInputProp
         characterNames,
       };
       if (textareaRef.current) textareaRef.current.value = "";
-      setHasInput(false);
       clearInputDraft(activeChatId);
+      syncInputState("");
       setAttachments([]);
       const result = await matched.command.execute(matched.args, slashCtx);
       if (result.feedback) {
@@ -353,8 +359,8 @@ export function ConversationInput({ characterNames = [] }: ConversationInputProp
       textareaRef.current.value = "";
       textareaRef.current.style.height = "auto";
     }
-    setHasInput(false);
     clearInputDraft(activeChatId);
+    syncInputState("");
 
     const pendingAttachments = attachments.map((a) => ({ type: a.type, data: a.data }));
     setAttachments([]);
@@ -380,6 +386,7 @@ export function ConversationInput({ characterNames = [] }: ConversationInputProp
     createMessage,
     characterNames,
     qc,
+    syncInputState
   ]);
 
   const handleKeyDown = useCallback(
@@ -426,7 +433,7 @@ export function ConversationInput({ characterNames = [] }: ConversationInputProp
           const cmd = completions[selectedCompletion];
           if (cmd && textareaRef.current) {
             textareaRef.current.value = `/${cmd.name} `;
-            setHasInput(true);
+            syncInputState(textareaRef.current.value);
             setCompletions([]);
           }
           return;
@@ -443,7 +450,7 @@ export function ConversationInput({ characterNames = [] }: ConversationInputProp
         handleSend();
       }
     },
-    [completions, selectedCompletion, mentionCompletions, selectedMention, insertMention, enterToSend, handleSend],
+    [completions, selectedCompletion, mentionCompletions, selectedMention, insertMention, enterToSend, handleSend, syncInputState],
   );
 
   const handleInput = useCallback(() => {
@@ -456,7 +463,7 @@ export function ConversationInput({ characterNames = [] }: ConversationInputProp
       el.style.height = "auto";
       el.style.height = `${Math.min(el.scrollHeight, 160)}px`;
     }, 150);
-    setHasInput(el.value.length > 0);
+    syncInputState(el.value);
 
     // Slash completions
     if (el.value.startsWith("/")) {
@@ -489,7 +496,7 @@ export function ConversationInput({ characterNames = [] }: ConversationInputProp
       setMentionQuery(null);
       setMentionCompletions([]);
     }
-  }, [characterNames]);
+  }, [characterNames, syncInputState]);
 
   useEffect(() => {
     if (hasInput && feedback) setFeedback(null);
@@ -503,9 +510,9 @@ export function ConversationInput({ characterNames = [] }: ConversationInputProp
     const value = el.value;
     el.value = value.slice(0, start) + emoji + value.slice(end);
     el.selectionStart = el.selectionEnd = start + emoji.length;
-    setHasInput(el.value.length > 0);
+    syncInputState(el.value);
     el.focus();
-  }, []);
+  }, [syncInputState]);
 
   const handleGifSelect = useCallback(
     async (gifUrl: string) => {
@@ -550,7 +557,7 @@ export function ConversationInput({ characterNames = [] }: ConversationInputProp
                 e.preventDefault();
                 if (textareaRef.current) {
                   textareaRef.current.value = `/${cmd.name} `;
-                  setHasInput(true);
+                  syncInputState(textareaRef.current.value);
                   setCompletions([]);
                   textareaRef.current.focus();
                 }

--- a/packages/client/src/components/chat/ConversationInput.tsx
+++ b/packages/client/src/components/chat/ConversationInput.tsx
@@ -143,10 +143,10 @@ export function ConversationInput({ characterNames = [] }: ConversationInputProp
   // Save draft on unmount
   useEffect(() => {
     const el = textareaRef.current;
+    const chatId = activeChatId;
     return () => {
-      const id = prevChatIdRef.current;
-      if (id && el?.value) {
-        useChatStore.getState().setInputDraft(id, el.value);
+      if (chatId && el?.value) {
+        useChatStore.getState().setInputDraft(chatId, el.value);
       }
     };
   }, []);

--- a/packages/client/src/components/chat/ConversationMessage.tsx
+++ b/packages/client/src/components/chat/ConversationMessage.tsx
@@ -18,6 +18,8 @@ import {
 } from "lucide-react";
 import { useQueryClient, type InfiniteData } from "@tanstack/react-query";
 import type { Message } from "@marinara-engine/shared";
+import { useUIStore } from "../../stores/ui.store";
+import { useChatStore } from "../../stores/chat.store";
 import { cn, copyToClipboard } from "../../lib/utils";
 import { applyInlineMarkdown, renderMarkdownBlocks } from "../../lib/markdown";
 import { chatKeys } from "../../hooks/use-chats";
@@ -267,6 +269,9 @@ export const ConversationMessage = memo(function ConversationMessage({
   const [copied, setCopied] = useState(false);
   const [showThinking, setShowThinking] = useState(false);
   const editRef = useRef<HTMLTextAreaElement>(null);
+  const hasInput = useChatStore((s) => s.currentInput.trim().length > 0);
+  const guideGenerations = useUIStore((s) => s.guideGenerations);
+  const regenerateButtonTitle = (guideGenerations && hasInput) ? "Regenerate (guided)" : "Regenerate";
 
   // Translation
   const { translate, translations, translating } = useTranslate();
@@ -733,7 +738,7 @@ export const ConversationMessage = memo(function ConversationMessage({
           <MsgAction
             icon={<RefreshCw size="0.75rem" />}
             onClick={() => onRegenerate?.(message.id)}
-            title="Regenerate"
+            title={regenerateButtonTitle}
           />
           {isLastAssistantMessage && (
             <MsgAction icon={<Eye size="0.75rem" />} onClick={() => onPeekPrompt?.()} title="Peek prompt" />
@@ -1011,7 +1016,7 @@ export const ConversationMessage = memo(function ConversationMessage({
             <MsgAction
               icon={<RefreshCw size="0.75rem" />}
               onClick={() => onRegenerate?.(message.id)}
-              title="Regenerate"
+              title={regenerateButtonTitle}
             />
           )}
           {isLastAssistantMessage && !isUser && (

--- a/packages/client/src/components/chat/ConversationView.tsx
+++ b/packages/client/src/components/chat/ConversationView.tsx
@@ -881,7 +881,7 @@ export function ConversationView({
       )}
 
       {/* ── Input area ── */}
-      <ConversationInput characterNames={characterNames} />
+      <ConversationInput key={chatId} characterNames={characterNames} />
     </div>
   );
 }

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -1928,6 +1928,8 @@ function AdvancedSettings() {
   const setShowTokenUsage = useUIStore((s) => s.setShowTokenUsage);
   const showMessageNumbers = useUIStore((s) => s.showMessageNumbers);
   const setShowMessageNumbers = useUIStore((s) => s.setShowMessageNumbers);
+  const guideGenerations = useUIStore((s) => s.guideGenerations);
+  const setGuideGenerations = useUIStore((s) => s.setGuideGenerations);
   const clearAllData = useClearAllData();
   const expungeData = useExpungeData();
   const [selectedScopes, setSelectedScopes] = useState<ExpungeScope[]>(["chats"]);
@@ -2306,6 +2308,12 @@ function AdvancedSettings() {
         checked={showMessageNumbers}
         onChange={setShowMessageNumbers}
         help="Displays a message number below each avatar in roleplay chats."
+      />
+      <ToggleSetting
+        label="Guide generations with chat input"
+        checked={guideGenerations}
+        onChange={setGuideGenerations}
+        help="Uses chat input to guide regenerations and manually triggered responses."
       />
 
       {/* ── Backup ── */}

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -341,6 +341,7 @@ export function useGenerate() {
       attachments?: Array<{ type: string; data: string }>;
       mentionedCharacterNames?: string[];
       forCharacterId?: string;
+      generationGuide?: string;
     }) => {
       // Prevent concurrent generations for the SAME chat — stops race conditions
       // where autonomous messaging + user input both fire generate at once.

--- a/packages/client/src/stores/chat.store.ts
+++ b/packages/client/src/stores/chat.store.ts
@@ -78,6 +78,8 @@ interface ChatState {
   pendingNewChatMode: Exclude<ChatMode, "visual_novel"> | null;
   /** Per-chat draft input text so typing isn't lost when navigating away. */
   inputDrafts: Map<string, string>;
+  /** Current chat input */
+  currentInput: string;
   /** Per-chat unread message count (from autonomous messages). */
   unreadCounts: Map<string, number>;
   /** Floating notification bubbles — tracks character info for each unread chat. */
@@ -115,6 +117,7 @@ interface ChatState {
   setPendingNewChatMode: (mode: Exclude<ChatMode, "visual_novel"> | null) => void;
   setInputDraft: (chatId: string, text: string) => void;
   clearInputDraft: (chatId: string) => void;
+  setCurrentInput: (text: string) => void;
   incrementUnread: (chatId: string) => void;
   clearUnread: (chatId: string) => void;
   addNotification: (chatId: string, characterName: string, avatarUrl: string | null) => void;
@@ -153,6 +156,7 @@ export const useChatStore = create<ChatState>()(
     shouldOpenWizardInShortcutMode: false,
     pendingNewChatMode: null,
     inputDrafts: loadDrafts(),
+    currentInput: "",
     unreadCounts: new Map(),
     chatNotifications: new Map(),
     dismissedNotifications: new Set(),
@@ -332,6 +336,8 @@ export const useChatStore = create<ChatState>()(
         return { inputDrafts: m };
       }),
 
+    setCurrentInput: (text) => set({ currentInput: text }),
+
     incrementUnread: (chatId: string) =>
       set((state) => {
         const m = new Map(state.unreadCounts);
@@ -406,6 +412,7 @@ export const useChatStore = create<ChatState>()(
         swipeIndex: new Map(),
         pendingNewChatMode: null,
         inputDrafts: new Map(),
+        currentInput: "",
         unreadCounts: new Map(),
         chatNotifications: new Map(),
         dismissedNotifications: new Set(),

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -107,6 +107,7 @@ interface UIState {
   showModelName: boolean;
   showTokenUsage: boolean;
   showMessageNumbers: boolean;
+  guideGenerations: boolean;
   confirmBeforeDelete: boolean;
   /** Number of messages to load per page (0 = load all) */
   messagesPerPage: number;
@@ -242,6 +243,7 @@ interface UIState {
   setShowModelName: (v: boolean) => void;
   setShowTokenUsage: (v: boolean) => void;
   setShowMessageNumbers: (v: boolean) => void;
+  setGuideGenerations: (v: boolean) => void;
   setConfirmBeforeDelete: (v: boolean) => void;
   setMessagesPerPage: (n: number) => void;
   setBoldDialogue: (v: boolean) => void;
@@ -310,6 +312,7 @@ export function pickSyncedSettings(state: UIState) {
     showModelName: state.showModelName,
     showTokenUsage: state.showTokenUsage,
     showMessageNumbers: state.showMessageNumbers,
+    guideGenerations: state.guideGenerations,
     confirmBeforeDelete: state.confirmBeforeDelete,
     messagesPerPage: state.messagesPerPage,
     boldDialogue: state.boldDialogue,
@@ -380,6 +383,7 @@ export const useUIStore = create<UIState>()(
       showModelName: false,
       showTokenUsage: false,
       showMessageNumbers: false,
+      guideGenerations: false,
       confirmBeforeDelete: true,
       messagesPerPage: 20,
       boldDialogue: true,
@@ -621,6 +625,7 @@ export const useUIStore = create<UIState>()(
       setShowModelName: (v) => set({ showModelName: v }),
       setShowTokenUsage: (v) => set({ showTokenUsage: v }),
       setShowMessageNumbers: (v) => set({ showMessageNumbers: v }),
+      setGuideGenerations: (v) => set({ guideGenerations: v }),
       setConfirmBeforeDelete: (v) => set({ confirmBeforeDelete: v }),
       setMessagesPerPage: (n) => set({ messagesPerPage: n }),
       setBoldDialogue: (v) => set({ boldDialogue: v }),
@@ -798,6 +803,7 @@ export const useUIStore = create<UIState>()(
         showModelName: state.showModelName,
         showTokenUsage: state.showTokenUsage,
         showMessageNumbers: state.showMessageNumbers,
+        guideGenerations: state.guideGenerations,
         confirmBeforeDelete: state.confirmBeforeDelete,
         messagesPerPage: state.messagesPerPage,
         boldDialogue: state.boldDialogue,

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -4936,10 +4936,17 @@ export async function generateRoutes(app: FastifyInstance) {
       const collectedCommands: Array<{ command: CharacterCommand; characterId: string | null; messageId: string }> = [];
       const collectedOocMessages: string[] = [];
 
+      const normalizedGenerationGuide = typeof input.generationGuide === "string" ? input.generationGuide.trim() : "";
+      const generationGuideInstruction = normalizedGenerationGuide ? `Take the following into special consideration for your next message: ${normalizedGenerationGuide}` : null;
+
       if (useIndividualLoop) {
         // Individual group mode: generate one response per character
         sendProgress("generating");
         let runningMessages = [...finalMessages];
+
+        if (generationGuideInstruction) {
+          runningMessages.push({ role: "system", content: generationGuideInstruction });
+        }
 
         for (let ci = 0; ci < respondingCharIds.length; ci++) {
           if (abortController.signal.aborted) break;
@@ -4974,6 +4981,10 @@ export async function generateRoutes(app: FastifyInstance) {
         sendProgress("generating");
         let targetCharId = characterIds[0] ?? null;
         const sentMessages = [...finalMessages];
+
+        if (generationGuideInstruction) {
+          sentMessages.push({ role: "system", content: generationGuideInstruction });
+        }
 
         if (mentionedConversationCharacters.length > 0 && !regenGroupChatIndividual) {
           const mentionedNames = mentionedConversationCharacters.map((character) => character.name);

--- a/packages/shared/src/schemas/chat.schema.ts
+++ b/packages/shared/src/schemas/chat.schema.ts
@@ -35,6 +35,7 @@ export const generateRequestSchema = z.object({
   userStatus: z.enum(["active", "idle", "dnd"]).optional().default("active"),
   mentionedCharacterNames: z.array(z.string()).optional().default([]),
   forCharacterId: z.string().nullable().optional().default(null),
+  generationGuide: z.string().nullable().optional().default(null),
   attachments: z
     .array(
       z.object({


### PR DESCRIPTION
## Why this change

This feature provides a more seamless way to guide the AI's responses, allowing users to quickly direct it through the chat input textarea, without needing to send an OOC message or edit the Author's Notes.

## What changed

 - There is now an option under Advanced Settings to enable "Guide generations using chat input" which sets in the persisted UI store.
- This option allows regenerations and "Trigger Character" responses to be guided directly from the chat input, similar to the Guided Generations extension on SillyTavern.
- When activated, `generate.routes.ts` will inject this instruction: "Take the following into special consideration for your next message: [chat input content]"
- Also fixed race conditions related to chat input drafts that were causing issues with this feature.

## Validation

- [x] `pnpm check`
- [x] Manual verification completed (describe below)

### Manual verification notes

- Verified that the guide instruction is applied when and only when the option is enabled and there is text in the chat input.
- Verified that input drafts stay in their respective chats

## Docs and release impact

- [ ] No docs changes needed
- [x] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

<img width="789" height="1317" alt="AdvancedSettingsScreenshot" src="https://github.com/user-attachments/assets/240fdf6e-c836-45b5-a508-27f6525a0c83" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Guide Generations" toggle in Advanced Settings to let current chat input guide regenerations and manual generation.
  * Typed chat input is tracked globally so it can be included when generating or regenerating messages.
  * Switching chats now fully resets/remounts the input so each chat has a fresh input state.
  * Regenerate tooltips and trigger behavior now indicate guided vs non-guided actions.

* **Documentation**
  * Frontend docs updated to document the new UI setting and the tracked current chat input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->