### PR TITLE
feat(chat): add "Mari is thinking…" indicator for command execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This file is the release-notes source of truth for Marinara Engine. Reuse these entries when publishing GitHub Releases for tags in the `vX.Y.Z` format.
 
+## [Unreleased]
+
+### Added
+
+- "Mari is thinking…" indicator appears above the composer while Professor Mari executes her embedded commands (create/update character, fetch, create chat, navigate). Makes it clear her background work is running and not frozen.
+
 ## [1.5.5]
 
 ### Added

--- a/packages/client/src/components/chat/ChatInput.tsx
+++ b/packages/client/src/components/chat/ChatInput.tsx
@@ -25,6 +25,7 @@ import { EmojiPicker } from "../ui/EmojiPicker";
 import { QuickConnectionSwitcher } from "./QuickConnectionSwitcher";
 import { QuickPersonaSwitcher } from "./QuickPersonaSwitcher";
 import { QuickSwitcherMobile } from "./QuickSwitcherMobile";
+import { MariThinkingIndicator } from "./MariThinkingIndicator";
 
 interface Attachment {
   type: string; // MIME type
@@ -614,6 +615,9 @@ export const ChatInput = memo(function ChatInput({
           ))}
         </div>
       )}
+
+      {/* Mari command-execution indicator */}
+      <MariThinkingIndicator />
 
       {/* Main input container */}
       <div

--- a/packages/client/src/components/chat/ConversationInput.tsx
+++ b/packages/client/src/components/chat/ConversationInput.tsx
@@ -24,6 +24,7 @@ import { QuickPersonaSwitcher } from "./QuickPersonaSwitcher";
 import { QuickSwitcherMobile } from "./QuickSwitcherMobile";
 import { EmojiPicker } from "../ui/EmojiPicker";
 import { GifPicker } from "../ui/GifPicker";
+import { MariThinkingIndicator } from "./MariThinkingIndicator";
 
 interface Attachment {
   type: string;
@@ -625,6 +626,9 @@ export function ConversationInput({ characterNames = [] }: ConversationInputProp
           ))}
         </div>
       )}
+
+      {/* Mari command-execution indicator */}
+      <MariThinkingIndicator />
 
       {/* Input bar */}
       <div

--- a/packages/client/src/components/chat/MariThinkingIndicator.tsx
+++ b/packages/client/src/components/chat/MariThinkingIndicator.tsx
@@ -55,6 +55,13 @@ export const MariThinkingIndicator = memo(function MariThinkingIndicator() {
 
   const [visible, setVisible] = useState(false);
   const shownAtRef = useRef(0);
+  /**
+   * chatId that owns the currently-visible pill. Used to bypass the
+   * minimum-duration hide when the user switches away to a different chat —
+   * otherwise a lingering timer would briefly show "Mari is thinking…" in a
+   * chat where nothing is executing.
+   */
+  const visibleChatIdRef = useRef<string | null>(null);
   const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
@@ -63,6 +70,7 @@ export const MariThinkingIndicator = memo(function MariThinkingIndicator() {
         clearTimeout(hideTimerRef.current);
         hideTimerRef.current = null;
       }
+      visibleChatIdRef.current = null;
       setVisible(false);
       return;
     }
@@ -75,14 +83,32 @@ export const MariThinkingIndicator = memo(function MariThinkingIndicator() {
           clearTimeout(hideTimerRef.current);
           hideTimerRef.current = null;
         }
-        shownAtRef.current = Date.now();
+        // Reset the minimum-duration start only when the pill first opens
+        // (or re-opens for a different chat) — not on every re-evaluate.
+        if (visibleChatIdRef.current !== currentActive) {
+          shownAtRef.current = Date.now();
+        }
+        visibleChatIdRef.current = currentActive;
         setVisible(true);
       } else {
+        // If the user switched away from the chat that owns the visible
+        // pill, hide immediately — don't let the minimum-duration timer
+        // linger into a chat where nothing is executing.
+        if (visibleChatIdRef.current && currentActive !== visibleChatIdRef.current) {
+          if (hideTimerRef.current) {
+            clearTimeout(hideTimerRef.current);
+            hideTimerRef.current = null;
+          }
+          visibleChatIdRef.current = null;
+          setVisible(false);
+          return;
+        }
         if (hideTimerRef.current) return;
         const elapsed = Date.now() - shownAtRef.current;
         const remaining = Math.max(0, MIN_VISIBLE_MS - elapsed);
         hideTimerRef.current = setTimeout(() => {
           hideTimerRef.current = null;
+          visibleChatIdRef.current = null;
           setVisible(false);
         }, remaining);
       }

--- a/packages/client/src/components/chat/MariThinkingIndicator.tsx
+++ b/packages/client/src/components/chat/MariThinkingIndicator.tsx
@@ -104,6 +104,10 @@ export const MariThinkingIndicator = memo(function MariThinkingIndicator() {
           return;
         }
         if (hideTimerRef.current) return;
+        // Nothing currently owns the pill, so there's nothing to hide — avoid
+        // scheduling a no-op setTimeout that would later fire setVisible(false)
+        // on already-hidden state.
+        if (!visibleChatIdRef.current) return;
         const elapsed = Date.now() - shownAtRef.current;
         const remaining = Math.max(0, MIN_VISIBLE_MS - elapsed);
         hideTimerRef.current = setTimeout(() => {

--- a/packages/client/src/components/chat/MariThinkingIndicator.tsx
+++ b/packages/client/src/components/chat/MariThinkingIndicator.tsx
@@ -1,0 +1,120 @@
+// ──────────────────────────────────────────────
+// Chat: Mari Thinking Indicator
+// ──────────────────────────────────────────────
+import { memo, useEffect, useMemo, useRef, useState } from "react";
+import { PROFESSOR_MARI_ID } from "@marinara-engine/shared";
+import { useChatStore } from "../../stores/chat.store";
+import { useChat } from "../../hooks/use-chats";
+
+/** Minimum visible duration so fast command runs (single DB write) still register. */
+const MIN_VISIBLE_MS = 600;
+
+/**
+ * Visible-while-working signal for the post-stream command window.
+ *
+ * Mari's embedded commands (create_character, update_character, fetch, …)
+ * execute in a server-side loop after her reply finishes streaming. During
+ * that window the UI is otherwise silent — no tokens, no typing indicator —
+ * so a user who asked her to modify their data can't tell whether she's
+ * still working or stalled.
+ *
+ * The server emits `assistant_commands_start` / `assistant_commands_end`
+ * SSE events around the command loop; `commandsExecutingChatId` mirrors
+ * that window. We only surface the indicator in chats where Mari is a
+ * participant so non-Mari commands (schedule_update, cross_post, etc.)
+ * don't mistakenly trigger a "Mari is thinking" pill.
+ *
+ * The store is observed via Zustand's direct `subscribe` rather than a
+ * selector hook: simple DB commands complete in a fraction of a tick, so
+ * the start and end state updates land in the same React batch and the
+ * component would never render the intermediate active state. The direct
+ * subscribe fires once per state change, capturing both transitions.
+ *
+ * A minimum visible duration (MIN_VISIBLE_MS) keeps the pill on-screen
+ * long enough to perceive even when a command finishes in under a
+ * millisecond.
+ */
+export const MariThinkingIndicator = memo(function MariThinkingIndicator() {
+  const activeChatId = useChatStore((s) => s.activeChatId);
+  const { data: activeChat } = useChat(activeChatId);
+
+  const isMariChat = useMemo(() => {
+    // characterIds can arrive as an array or a JSON-encoded string depending on endpoint.
+    const raw = (activeChat as { characterIds?: unknown } | null | undefined)?.characterIds;
+    if (Array.isArray(raw)) return raw.includes(PROFESSOR_MARI_ID);
+    if (typeof raw === "string") {
+      try {
+        const parsed = JSON.parse(raw);
+        return Array.isArray(parsed) && parsed.includes(PROFESSOR_MARI_ID);
+      } catch {
+        return false;
+      }
+    }
+    return false;
+  }, [activeChat]);
+
+  const [visible, setVisible] = useState(false);
+  const shownAtRef = useRef(0);
+  const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (!isMariChat) {
+      if (hideTimerRef.current) {
+        clearTimeout(hideTimerRef.current);
+        hideTimerRef.current = null;
+      }
+      setVisible(false);
+      return;
+    }
+
+    const evaluate = () => {
+      const { commandsExecutingChatId, activeChatId: currentActive } = useChatStore.getState();
+      const shouldShow = !!currentActive && commandsExecutingChatId === currentActive;
+      if (shouldShow) {
+        if (hideTimerRef.current) {
+          clearTimeout(hideTimerRef.current);
+          hideTimerRef.current = null;
+        }
+        shownAtRef.current = Date.now();
+        setVisible(true);
+      } else {
+        if (hideTimerRef.current) return;
+        const elapsed = Date.now() - shownAtRef.current;
+        const remaining = Math.max(0, MIN_VISIBLE_MS - elapsed);
+        hideTimerRef.current = setTimeout(() => {
+          hideTimerRef.current = null;
+          setVisible(false);
+        }, remaining);
+      }
+    };
+
+    evaluate();
+    const unsubChatId = useChatStore.subscribe((s) => s.commandsExecutingChatId, evaluate);
+    const unsubActive = useChatStore.subscribe((s) => s.activeChatId, evaluate);
+    return () => {
+      unsubChatId();
+      unsubActive();
+      if (hideTimerRef.current) {
+        clearTimeout(hideTimerRef.current);
+        hideTimerRef.current = null;
+      }
+    };
+  }, [isMariChat]);
+
+  if (!visible) return null;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="mb-2 flex items-center gap-2 rounded-lg bg-foreground/5 px-3 py-1.5 text-xs text-foreground/60"
+    >
+      <span className="flex items-center gap-1" aria-hidden="true">
+        <span className="h-1.5 w-1.5 rounded-full bg-blue-400 animate-pulse" />
+        <span className="h-1.5 w-1.5 rounded-full bg-blue-400 animate-pulse [animation-delay:200ms]" />
+        <span className="h-1.5 w-1.5 rounded-full bg-blue-400 animate-pulse [animation-delay:400ms]" />
+      </span>
+      <span>Mari is thinking…</span>
+    </div>
+  );
+});

--- a/packages/client/src/components/chat/MariThinkingIndicator.tsx
+++ b/packages/client/src/components/chat/MariThinkingIndicator.tsx
@@ -68,8 +68,8 @@ export const MariThinkingIndicator = memo(function MariThinkingIndicator() {
     }
 
     const evaluate = () => {
-      const { commandsExecutingChatId, activeChatId: currentActive } = useChatStore.getState();
-      const shouldShow = !!currentActive && commandsExecutingChatId === currentActive;
+      const { commandsExecutingChatIds, activeChatId: currentActive } = useChatStore.getState();
+      const shouldShow = !!currentActive && commandsExecutingChatIds.has(currentActive);
       if (shouldShow) {
         if (hideTimerRef.current) {
           clearTimeout(hideTimerRef.current);
@@ -89,10 +89,10 @@ export const MariThinkingIndicator = memo(function MariThinkingIndicator() {
     };
 
     evaluate();
-    const unsubChatId = useChatStore.subscribe((s) => s.commandsExecutingChatId, evaluate);
+    const unsubChatIds = useChatStore.subscribe((s) => s.commandsExecutingChatIds, evaluate);
     const unsubActive = useChatStore.subscribe((s) => s.activeChatId, evaluate);
     return () => {
-      unsubChatId();
+      unsubChatIds();
       unsubActive();
       if (hideTimerRef.current) {
         clearTimeout(hideTimerRef.current);

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -310,7 +310,7 @@ export function useGenerate() {
   const qc = useQueryClient();
   // Use individual selectors to avoid re-rendering on every store change
   const setStreaming = useChatStore((s) => s.setStreaming);
-  const setCommandsExecutingChatId = useChatStore((s) => s.setCommandsExecutingChatId);
+  const setCommandsExecuting = useChatStore((s) => s.setCommandsExecuting);
   const setStreamBuffer = useChatStore((s) => s.setStreamBuffer);
   const clearStreamBuffer = useChatStore((s) => s.clearStreamBuffer);
   const setRegenerateMessageId = useChatStore((s) => s.setRegenerateMessageId);
@@ -542,6 +542,12 @@ export function useGenerate() {
         };
         rafId = requestAnimationFrame(tick);
       };
+
+      // Safety net: guarantees the "Mari is thinking…" indicator clears for
+      // this chat on every termination path (done, error, abort, unexpected
+      // throw). The assistant_commands_end SSE event is still the primary
+      // clear; this just keeps state sane when the stream dies mid-window.
+      const clearCommandsExecutingForThisChat = () => setCommandsExecuting(params.chatId, false);
 
       try {
         const debugMode = useUIStore.getState().debugMode;
@@ -1174,14 +1180,12 @@ export function useGenerate() {
             }
 
             case "assistant_commands_start": {
-              setCommandsExecutingChatId(params.chatId);
+              setCommandsExecuting(params.chatId, true);
               break;
             }
 
             case "assistant_commands_end": {
-              if (useChatStore.getState().commandsExecutingChatId === params.chatId) {
-                setCommandsExecutingChatId(null);
-              }
+              clearCommandsExecutingForThisChat();
               break;
             }
 
@@ -1215,9 +1219,7 @@ export function useGenerate() {
 
             case "done": {
               if (isActiveChat()) setProcessing(false);
-              if (useChatStore.getState().commandsExecutingChatId === params.chatId) {
-                setCommandsExecutingChatId(null);
-              }
+              clearCommandsExecutingForThisChat();
               break;
             }
 
@@ -1265,9 +1267,7 @@ export function useGenerate() {
               // Flush pending text so the user sees what arrived before the error
               flushTypewriterBuffer();
               if (isActiveChat()) setProcessing(false);
-              if (useChatStore.getState().commandsExecutingChatId === params.chatId) {
-                setCommandsExecutingChatId(null);
-              }
+              clearCommandsExecutingForThisChat();
               showError((event.data as string) || "Generation failed");
               window.dispatchEvent(new CustomEvent("marinara:generation-error", { detail: { chatId: params.chatId } }));
               break;
@@ -1307,6 +1307,9 @@ export function useGenerate() {
         showError(msg);
         window.dispatchEvent(new CustomEvent("marinara:generation-error", { detail: { chatId: params.chatId } }));
       } finally {
+        // Stream has terminated (done, error, abort, or unexpected throw) —
+        // guarantee the Mari indicator clears even if the end SSE never arrived.
+        clearCommandsExecutingForThisChat();
         // Cancel any pending animation frame to prevent leaks
         cancelAnimationFrame(rafId);
 

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -310,6 +310,7 @@ export function useGenerate() {
   const qc = useQueryClient();
   // Use individual selectors to avoid re-rendering on every store change
   const setStreaming = useChatStore((s) => s.setStreaming);
+  const setCommandsExecutingChatId = useChatStore((s) => s.setCommandsExecutingChatId);
   const setStreamBuffer = useChatStore((s) => s.setStreamBuffer);
   const clearStreamBuffer = useChatStore((s) => s.clearStreamBuffer);
   const setRegenerateMessageId = useChatStore((s) => s.setRegenerateMessageId);
@@ -1172,6 +1173,18 @@ export function useGenerate() {
               break;
             }
 
+            case "assistant_commands_start": {
+              setCommandsExecutingChatId(params.chatId);
+              break;
+            }
+
+            case "assistant_commands_end": {
+              if (useChatStore.getState().commandsExecutingChatId === params.chatId) {
+                setCommandsExecutingChatId(null);
+              }
+              break;
+            }
+
             case "assistant_action": {
               const actionData = event.data as { action: string; [key: string]: unknown };
               if (actionData.action === "persona_created") {
@@ -1202,6 +1215,9 @@ export function useGenerate() {
 
             case "done": {
               if (isActiveChat()) setProcessing(false);
+              if (useChatStore.getState().commandsExecutingChatId === params.chatId) {
+                setCommandsExecutingChatId(null);
+              }
               break;
             }
 
@@ -1249,6 +1265,9 @@ export function useGenerate() {
               // Flush pending text so the user sees what arrived before the error
               flushTypewriterBuffer();
               if (isActiveChat()) setProcessing(false);
+              if (useChatStore.getState().commandsExecutingChatId === params.chatId) {
+                setCommandsExecutingChatId(null);
+              }
               showError((event.data as string) || "Generation failed");
               window.dispatchEvent(new CustomEvent("marinara:generation-error", { detail: { chatId: params.chatId } }));
               break;

--- a/packages/client/src/stores/chat.store.ts
+++ b/packages/client/src/stores/chat.store.ts
@@ -39,13 +39,15 @@ interface ChatState {
   /** The chatId that the current streaming generation belongs to. */
   streamingChatId: string | null;
   /**
-   * chatId currently in the post-stream command execution window.
+   * chatIds currently in the post-stream command execution window.
    *
    * Mari's embedded commands (create_character, fetch, etc.) run after her
-   * reply finishes streaming; this flag gates the "Mari is thinking…"
-   * indicator so the user knows her background work isn't frozen.
+   * reply finishes streaming; membership in this set gates the "Mari is
+   * thinking…" indicator so the user knows her background work isn't frozen.
+   * Uses a set (not a single id) so concurrent command runs across chats
+   * don't stomp each other.
    */
-  commandsExecutingChatId: string | null;
+  commandsExecutingChatIds: Set<string>;
   streamBuffer: string;
   /** Per-chat AbortControllers for active generations — keyed by chatId. */
   abortControllers: Map<string, AbortController>;
@@ -88,7 +90,7 @@ interface ChatState {
   addMessage: (message: Message) => void;
   updateLastMessage: (content: string) => void;
   setStreaming: (streaming: boolean, chatId?: string) => void;
-  setCommandsExecutingChatId: (chatId: string | null) => void;
+  setCommandsExecuting: (chatId: string, executing: boolean) => void;
   setAbortController: (chatId: string, controller: AbortController | null) => void;
   stopGeneration: () => void;
   appendStreamBuffer: (text: string) => void;
@@ -129,7 +131,7 @@ export const useChatStore = create<ChatState>()(
     messages: [],
     isStreaming: false,
     streamingChatId: null,
-    commandsExecutingChatId: null,
+    commandsExecutingChatIds: new Set(),
     streamBuffer: "",
     abortControllers: new Map(),
     regenerateMessageId: null,
@@ -220,7 +222,18 @@ export const useChatStore = create<ChatState>()(
         streamingChatId: streaming ? (chatId ?? null) : null,
         ...(!streaming ? { generationPhase: null } : {}),
       }),
-    setCommandsExecutingChatId: (chatId) => set({ commandsExecutingChatId: chatId }),
+    setCommandsExecuting: (chatId, executing) =>
+      set((state) => {
+        const next = new Set(state.commandsExecutingChatIds);
+        if (executing) {
+          if (next.has(chatId)) return state;
+          next.add(chatId);
+        } else {
+          if (!next.has(chatId)) return state;
+          next.delete(chatId);
+        }
+        return { commandsExecutingChatIds: next };
+      }),
     setAbortController: (chatId, controller) =>
       set((state) => {
         const m = new Map(state.abortControllers);
@@ -361,7 +374,7 @@ export const useChatStore = create<ChatState>()(
         messages: [],
         isStreaming: false,
         streamingChatId: null,
-        commandsExecutingChatId: null,
+        commandsExecutingChatIds: new Set(),
         streamBuffer: "",
         abortControllers: new Map(),
         regenerateMessageId: null,

--- a/packages/client/src/stores/chat.store.ts
+++ b/packages/client/src/stores/chat.store.ts
@@ -38,6 +38,14 @@ interface ChatState {
   isStreaming: boolean;
   /** The chatId that the current streaming generation belongs to. */
   streamingChatId: string | null;
+  /**
+   * chatId currently in the post-stream command execution window.
+   *
+   * Mari's embedded commands (create_character, fetch, etc.) run after her
+   * reply finishes streaming; this flag gates the "Mari is thinking…"
+   * indicator so the user knows her background work isn't frozen.
+   */
+  commandsExecutingChatId: string | null;
   streamBuffer: string;
   /** Per-chat AbortControllers for active generations — keyed by chatId. */
   abortControllers: Map<string, AbortController>;
@@ -80,6 +88,7 @@ interface ChatState {
   addMessage: (message: Message) => void;
   updateLastMessage: (content: string) => void;
   setStreaming: (streaming: boolean, chatId?: string) => void;
+  setCommandsExecutingChatId: (chatId: string | null) => void;
   setAbortController: (chatId: string, controller: AbortController | null) => void;
   stopGeneration: () => void;
   appendStreamBuffer: (text: string) => void;
@@ -120,6 +129,7 @@ export const useChatStore = create<ChatState>()(
     messages: [],
     isStreaming: false,
     streamingChatId: null,
+    commandsExecutingChatId: null,
     streamBuffer: "",
     abortControllers: new Map(),
     regenerateMessageId: null,
@@ -210,6 +220,7 @@ export const useChatStore = create<ChatState>()(
         streamingChatId: streaming ? (chatId ?? null) : null,
         ...(!streaming ? { generationPhase: null } : {}),
       }),
+    setCommandsExecutingChatId: (chatId) => set({ commandsExecutingChatId: chatId }),
     setAbortController: (chatId, controller) =>
       set((state) => {
         const m = new Map(state.abortControllers);
@@ -350,6 +361,7 @@ export const useChatStore = create<ChatState>()(
         messages: [],
         isStreaming: false,
         streamingChatId: null,
+        commandsExecutingChatId: null,
         streamBuffer: "",
         abortControllers: new Map(),
         regenerateMessageId: null,

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -6161,12 +6161,11 @@ export async function generateRoutes(app: FastifyInstance) {
       // Character Command Execution (Conversation mode)
       // ────────────────────────────────────────
       if (collectedCommands.length > 0 && !abortController.signal.aborted) {
-        reply.raw.write(
-          `data: ${JSON.stringify({
-            type: "assistant_commands_start",
-            data: { count: collectedCommands.length },
-          })}\n\n`,
-        );
+        trySendSseEvent(reply, {
+          type: "assistant_commands_start",
+          data: { count: collectedCommands.length },
+        });
+        try {
         for (const { command, characterId, messageId } of collectedCommands) {
           try {
             if (command.type === "schedule_update") {
@@ -6985,12 +6984,12 @@ export async function generateRoutes(app: FastifyInstance) {
             console.error(`[commands] Error processing ${command.type} command:`, cmdErr);
           }
         }
-        reply.raw.write(
-          `data: ${JSON.stringify({
+        } finally {
+          trySendSseEvent(reply, {
             type: "assistant_commands_end",
             data: {},
-          })}\n\n`,
-        );
+          });
+        }
       }
 
       // ── Post OOC messages to connected conversation (Roleplay → Conversation) ──

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -6161,6 +6161,12 @@ export async function generateRoutes(app: FastifyInstance) {
       // Character Command Execution (Conversation mode)
       // ────────────────────────────────────────
       if (collectedCommands.length > 0 && !abortController.signal.aborted) {
+        reply.raw.write(
+          `data: ${JSON.stringify({
+            type: "assistant_commands_start",
+            data: { count: collectedCommands.length },
+          })}\n\n`,
+        );
         for (const { command, characterId, messageId } of collectedCommands) {
           try {
             if (command.type === "schedule_update") {
@@ -6979,6 +6985,12 @@ export async function generateRoutes(app: FastifyInstance) {
             console.error(`[commands] Error processing ${command.type} command:`, cmdErr);
           }
         }
+        reply.raw.write(
+          `data: ${JSON.stringify({
+            type: "assistant_commands_end",
+            data: {},
+          })}\n\n`,
+        );
       }
 
       // ── Post OOC messages to connected conversation (Roleplay → Conversation) ──


### PR DESCRIPTION
## Summary

Adds a small "Mari is thinking…" pill with pulsing dots above the composer whenever Professor Mari is executing one of her embedded commands (create/update character, fetch, create chat, navigate). Shows only in chats where Mari is a participant.

## Why

From [the Discord feature-request thread](https://discord.com/) — users can't tell whether Mari is still working on a task or stalled, because her commands run *after* her reply finishes streaming and there's no visible signal during that window. Quote: *"I don't know if asking the assistant to work on my cards is happening, or if it's frozen, or what."*

Toasts fire only after each command completes, so they're confirmation after-the-fact, not reassurance during-the-wait.

## How it works

| Layer | Change |
|---|---|
| Server (`generate.routes.ts`) | Emits new SSE events `assistant_commands_start` (before the command loop) and `assistant_commands_end` (after), with no filtering — any conversation-mode character's commands emit them. |
| Client store (`chat.store.ts`) | New `commandsExecutingChatId: string \| null` mirroring the server-side window, set by SSE handlers in `use-generate.ts`. |
| Client hook (`use-generate.ts`) | Handles the two new events; also clears on `done` / `error` as a safety net. |
| Component (`MariThinkingIndicator.tsx`) | Self-computes `isMariChat` from the active chat's `characterIds` (so the pill is Mari-scoped on the client, keeping the server event neutral). Mounted in both `ChatInput` (roleplay) and `ConversationInput` (conversation). |

Two notable implementation details:

- **Direct Zustand subscribe, not a selector hook.** Simple commands (single DB write) finish faster than a React tick — the start/end state updates would land in the same render batch and the component would never observe the active state. Subscribing to the store directly catches both transitions regardless of batching.
- **600ms minimum display duration.** Without it, fast commands would mount+unmount the pill below perceptual threshold. This way even a 1ms command gives a visible "blip."

## Known limitations

- The event is **not** Mari-specific on the server. It emits for any conversation-mode character that runs commands (e.g. `schedule_update`, `cross_post`). The Mari gate lives on the client, so those cases don't show a pill — but if a future feature wants a generic "assistant is working" indicator for non-Mari commands, the plumbing is already there.
- The pill is not customizable yet. Keeping this PR focused on the core signal; a user-swappable visual (e.g. the Mari-themed GIF referenced in the Discord thread) can layer on top later with no changes to the event plumbing.
- If the stream aborts mid-command-loop, the safety clears on `done`/`error` handle cleanup, but the `assistant_commands_end` event won't be received. Behavior: pill disappears when the stream errors, which is correct but means the user doesn't see a natural "finished" signal if the server crashes mid-loop. Acceptable.

## Test plan

Manually verified in dev against a Mari conversation chat:

- [x] Mari chat + action request (create/update/fetch character) → pill appears after stream, disappears after toast
- [x] Mari chat + pure conversation (no commands) → no pill
- [x] Non-Mari chat → no pill ever, including when that character's own commands run
- [x] Multiple commands in one reply → pill stays for the whole window
- [x] Abort mid-stream → no pill
- [x] Page reload while pill is showing → no stuck state after reload
- [x] Chat switch during command execution → pill disappears with the chat context
- [x] `pnpm check` clean (lint + production build, no new warnings)
- [x] `pnpm version:check` passes
- [x] `pnpm guard:installer-artifacts` passes

Screenshot of the pill mid-execution attached.

<img width="1046" height="117" alt="image" src="https://github.com/user-attachments/assets/8b4cfa69-c96f-4369-8b1a-ba06348cf15d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Mari is thinking…" indicator above the chat/composer input that appears while embedded background commands run (character/chat actions and navigation). It provides ARIA-live feedback, enforces a minimum visible duration to avoid flicker, hides immediately when switching chats, and reliably shows/hides during rapid or batched command sequences so the UI no longer appears frozen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->