### PR TITLE
fix(server): inject lorebooks into preset-less roleplay and visual-no…

### DIFF
--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -1948,6 +1948,43 @@ export async function generateRoutes(app: FastifyInstance) {
         }
       }
 
+      // ── Lorebook injection for preset-less roleplay / visual_novel ──
+      // Conversation mode handles this above; game mode handles it below;
+      // preset-driven chats get lorebook content via the preset assembler.
+      if (!presetId && (chatMode === "roleplay" || chatMode === "visual_novel")) {
+        sendProgress("lorebooks");
+        const scanMessages = mappedMessages.map((m) => ({
+          role: m.role as "user" | "assistant" | "system",
+          content: m.content,
+        }));
+        const lorebookResult = await processLorebooks(app.db, scanMessages, null, {
+          chatId: input.chatId,
+          characterIds,
+          activeLorebookIds: chatActiveLorebookIds,
+          chatEmbedding: chatContextEmbedding,
+          entryStateOverrides:
+            (chatMeta.entryStateOverrides as Record<string, { ephemeral?: number | null; enabled?: boolean }>) ??
+            undefined,
+        });
+
+        if (lorebookResult.updatedEntryStateOverrides) {
+          chatMeta.entryStateOverrides = lorebookResult.updatedEntryStateOverrides;
+          await chats.updateMetadata(input.chatId, chatMeta);
+        }
+        const loreContent = [lorebookResult.worldInfoBefore, lorebookResult.worldInfoAfter]
+          .filter(Boolean)
+          .join("\n");
+        if (loreContent) {
+          const loreBlock = `<lore>\n${loreContent}\n</lore>`;
+          const firstUserIdx = finalMessages.findIndex((m) => m.role === "user" || m.role === "assistant");
+          const insertAt = firstUserIdx >= 0 ? firstUserIdx : finalMessages.length;
+          finalMessages.splice(insertAt, 0, { role: "system" as const, content: loreBlock });
+        }
+        if (lorebookResult.depthEntries.length > 0) {
+          finalMessages = injectAtDepth(finalMessages, lorebookResult.depthEntries);
+        }
+      }
+
       // ── Author's Notes injection ──
       const authorNotes = (chatMeta.authorNotes as string | undefined)?.trim();
       if (authorNotes) {


### PR DESCRIPTION
## Why this change

Active lorebook entries are silently dropped from the prompt for roleplay and visual-novel chats that have no preset assigned. The Active World Info panel cheerfully reports "4 active • ~5,341 tokens" while the model never sees a single one of them — it generates as if the lorebook didn't exist.

The activation scanner is fine: it identifies the right entries, totals their tokens, surfaces them to the UI. The break is one layer deeper. The generation pipeline has lorebook-injection blocks for three paths:

- **Preset-driven chats** of any mode → `assemblePrompt()` expands the `lorebook` marker.
- **Preset-less conversation mode** → inline injection at line 1912.
- **Game mode** → inline injection at line 2743.

Preset-less roleplay and visual-novel fall through every gate. `processLorebooks()` is never called, no `<lore>` block is built, and the model gets generated content it has no way to know about. From the user's perspective: lorebooks "don't work" in roleplay/VN unless they happen to assign a preset — which the UI gives them no obvious reason to do.

## What changed

A single 37-line block added between the conversation-mode lorebook block and Author's Notes injection in `generate.routes.ts`:

- Gates on `!presetId && (chatMode === "roleplay" || chatMode === "visual_novel")` — exactly the modes the existing blocks miss.
- Calls `processLorebooks()` with the chat's active lorebook IDs, entry state overrides, and context embedding — the same arguments the conversation and game blocks pass.
- Splices the resulting `<lore>` block as a system message before the first user/assistant message (mirroring the conversation block's placement).
- Routes any depth-targeted entries through `injectAtDepth()`.

The block is a near-duplicate of the conversation and game versions. That duplication is intentional in this PR: the goal is a narrow correctness fix that's trivial to review. A natural follow-up — extracting the three inline copies into a single `injectLorebookContent()` helper — is noted in the commit message but deliberately deferred so this PR doesn't sprawl.

## Validation

- [x] `pnpm check`
- [x] Manual verification completed (describe below)

### Manual verification notes

Built a clean-room test fixture: one preset-less roleplay chat, one character (Test Steward), one lorebook with a CONST entry containing invented vocabulary the model can't possibly know from training data ("World: Dolomar-9", "Currency: glints", "Marshal Brunnig the Eleventh"), `enableAgents: false` so no agent can sneak the lore in via a different path.

Verified the bug and the fix using a prompt-dumping diagnostic that writes the assembled message array to a JSON file before it reaches the LLM:

- **Without this fix**: dump's system messages contain only the wrapped character info. No `<lore>` block. The model says "I do not know" when asked for the local currency.
- **With this fix**: dump contains a `<lore>\n…\n</lore>` system message ahead of the character info, with the activated CONST entry's text in full. The model correctly answers "glints" and cites Marshal Brunnig.

Same chat, same query, same lorebook configuration in both runs. The presence of `<lore>` in the prompt is the deterministic discriminator.

## Docs and release impact

- [x] No docs changes needed

## UI evidence (if applicable)

N/A — server-side prompt-assembly fix. No UI surface touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* **Lorebook and world-info entries** are now automatically integrated into roleplay and visual novel conversations when presets are not configured, enriching contextual information available during interactions
* **Improved depth-scoped entry management** ensures better conversation consistency and provides enhanced contextual awareness

<!-- end of auto-generated comment: release notes by coderabbit.ai -->