### PR TITLE
feat(lorebooks): add description field to lorebook entries (Part of Knowledge-Router Agent PRs)

### DIFF
--- a/packages/client/src/components/lorebooks/LorebookEditor.tsx
+++ b/packages/client/src/components/lorebooks/LorebookEditor.tsx
@@ -281,6 +281,7 @@ export function LorebookEditor() {
         entryId: editingEntryId,
         name: entryForm.name,
         content: entryForm.content,
+        description: entryForm.description,
         keys: entryForm.keys,
         secondaryKeys: entryForm.secondaryKeys,
         enabled: entryForm.enabled,
@@ -430,6 +431,21 @@ export function LorebookEditor() {
                 onChange={(e) => updateEntryForm({ name: e.target.value })}
                 className="w-full rounded-xl bg-[var(--secondary)] px-3 py-2.5 text-sm ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
                 placeholder="Entry name"
+              />
+            </FieldGroup>
+
+            {/* Description */}
+            <FieldGroup
+              label="Description"
+              icon={FileText}
+              help="Brief summary of what this entry is about. Used by the Knowledge Router agent to decide whether to inject this entry — not sent to the main AI as content."
+            >
+              <textarea
+                value={entryForm.description ?? ""}
+                onChange={(e) => updateEntryForm({ description: e.target.value })}
+                rows={2}
+                className="w-full resize-y rounded-xl bg-[var(--secondary)] px-3 py-2.5 text-sm ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+                placeholder="Brief summary of what this entry is about (used by Knowledge Router agent)."
               />
             </FieldGroup>
 

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -108,6 +108,7 @@ const CREATE_TABLES: string[] = [
     lorebook_id TEXT NOT NULL REFERENCES lorebooks(id) ON DELETE CASCADE,
     name TEXT NOT NULL,
     content TEXT NOT NULL DEFAULT '',
+    description TEXT NOT NULL DEFAULT '',
     keys TEXT NOT NULL DEFAULT '[]',
     secondary_keys TEXT NOT NULL DEFAULT '[]',
     enabled TEXT NOT NULL DEFAULT 'true',

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -522,6 +522,11 @@ const COLUMN_MIGRATIONS: ColumnMigration[] = [
     column: "max_tokens_override",
     definition: "INTEGER",
   },
+  {
+    table: "lorebook_entries",
+    column: "description",
+    definition: "TEXT NOT NULL DEFAULT ''",
+  },
 ];
 
 export async function runMigrations(db: DB) {

--- a/packages/server/src/db/schema/lorebooks.ts
+++ b/packages/server/src/db/schema/lorebooks.ts
@@ -30,6 +30,8 @@ export const lorebookEntries = sqliteTable("lorebook_entries", {
     .references(() => lorebooks.id, { onDelete: "cascade" }),
   name: text("name").notNull(),
   content: text("content").notNull().default(""),
+  /** Short summary used by the knowledge-router agent to decide if this entry is relevant */
+  description: text("description").notNull().default(""),
   /** JSON array of primary keywords */
   keys: text("keys").notNull().default("[]"),
   /** JSON array of secondary keywords */

--- a/packages/server/src/services/storage/lorebooks.storage.ts
+++ b/packages/server/src/services/storage/lorebooks.storage.ts
@@ -218,6 +218,7 @@ export function createLorebooksStorage(db: DB) {
         lorebookId: input.lorebookId,
         name: input.name,
         content: input.content ?? "",
+        description: input.description ?? "",
         keys: JSON.stringify(input.keys ?? []),
         secondaryKeys: JSON.stringify(input.secondaryKeys ?? []),
         enabled: String(input.enabled ?? true),
@@ -256,6 +257,7 @@ export function createLorebooksStorage(db: DB) {
       const updates: Record<string, unknown> = { updatedAt: now() };
       if (input.name !== undefined) updates.name = input.name;
       if (input.content !== undefined) updates.content = input.content;
+      if (input.description !== undefined) updates.description = input.description;
       if (input.keys !== undefined) updates.keys = JSON.stringify(input.keys);
       if (input.secondaryKeys !== undefined) updates.secondaryKeys = JSON.stringify(input.secondaryKeys);
       if (input.enabled !== undefined) updates.enabled = String(input.enabled);

--- a/packages/server/test/lorebook-processing.test.ts
+++ b/packages/server/test/lorebook-processing.test.ts
@@ -35,6 +35,7 @@ function makeEntry(overrides: Partial<LorebookEntry> = {}): LorebookEntry {
     lorebookId: "book-1",
     name: "Entry",
     content: "Lore entry",
+    description: "",
     keys: ["keyword"],
     secondaryKeys: [],
     enabled: true,

--- a/packages/shared/src/schemas/lorebook.schema.ts
+++ b/packages/shared/src/schemas/lorebook.schema.ts
@@ -55,6 +55,7 @@ export const createLorebookEntrySchema = z.object({
   lorebookId: z.string(),
   name: z.string().min(1).max(200),
   content: z.string().default(""),
+  description: z.string().default(""),
   keys: z.array(z.string()).default([]),
   secondaryKeys: z.array(z.string()).default([]),
   enabled: z.boolean().default(true),
@@ -88,6 +89,7 @@ export const createLorebookEntrySchema = z.object({
 export const updateLorebookEntrySchema = z.object({
   name: z.string().min(1).max(200).optional(),
   content: z.string().optional(),
+  description: z.string().optional(),
   keys: z.array(z.string()).optional(),
   secondaryKeys: z.array(z.string()).optional(),
   enabled: z.boolean().optional(),

--- a/packages/shared/src/types/lorebook.ts
+++ b/packages/shared/src/types/lorebook.ts
@@ -48,6 +48,8 @@ export interface LorebookEntry {
   name: string;
   /** The actual content injected into the prompt */
   content: string;
+  /** Short summary used by the knowledge-router agent to decide if this entry is relevant */
+  description: string;
   /** Primary trigger keywords (supports regex) */
   keys: string[];
   /** Secondary / optional keywords */


### PR DESCRIPTION
Part 1 of #226 — schema groundwork for the upcoming `knowledge-router` agent.

## Summary

Adds a `description` column to `lorebook_entries` and a textarea for it in the entry editor. The field is short AI-facing summary text (one or two sentences) that the future `knowledge-router` agent will use to decide which entries are relevant to the current scene — without paying the cost of summarizing every entry's full content.

This PR is **schema-only**. No agent yet, no behavior change for existing flows. The field defaults to empty and is invisible to all current code paths.

## Why

The existing `knowledge-retrieval` agent summarizes every enabled entry from the configured source lorebooks before generation. For large lorebooks (One Piece, Wheel of Time, etc.) this gets chunked and adds significant latency and token cost — and for `constant: true` entries, it duplicates work the standard activation pipeline already does. The `knowledge-router` agent (coming in the next PR) will instead read short descriptions and pick entry IDs to inject verbatim. This PR gives users a place to write those descriptions.

See [issue #226](https://github.com/Pasta-Devs/Marinara-Engine/issues/226) for the full design and the maintainer's Discord invitation.

## Changes

| File | Change |
|---|---|
| `packages/server/src/db/schema/lorebooks.ts` | New `description` column on `lorebookEntries`, defaults to `""` |
| `packages/server/src/db/migrate.ts` | Idempotent `ALTER TABLE` migration entry |
| `packages/shared/src/schemas/lorebook.schema.ts` | `description` field on create + update Zod schemas |
| `packages/shared/src/types/lorebook.ts` | `description: string` on `LorebookEntry` |
| `packages/server/src/services/storage/lorebooks.storage.ts` | Wired through `createEntry` / `updateEntry` |
| `packages/client/src/components/lorebooks/LorebookEditor.tsx` | Description textarea below Name in the entry editor |

## Known limitations

- **Existing entries have empty descriptions.** That's intentional — the `knowledge-router` agent will fall back to entry name + first 1-2 keys when description is empty, so old lorebooks still work, just less precisely. A future "lorebook description backfill" agent could auto-populate them; out of scope here.
- **No UI surface yet showing descriptions in lists or coverage.** That's part of the agent's settings panel in the third PR in this set.

<img width="990" height="347" alt="image" src="https://github.com/user-attachments/assets/5efa4b43-85f2-4115-ae05-69b0eac32dd7" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can add and edit a new description field for lorebook entries via the editor; descriptions are saved with entries.
  * Descriptions are now used to improve entry relevance and selection, enhancing how related content is surfaced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->