### PR TITLE
Feature: Add scene fork roleplay actions

### DIFF
--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -725,10 +725,10 @@ export function ChatArea() {
 
   const handleCloneSceneFromHere = useCallback(
     (messageId: string) => {
-      if (!activeChatId || isForking) return;
+      if (!activeChatId || isForking || isStreaming) return;
       forkScene(activeChatId, "clone", { upToMessageId: messageId });
     },
-    [activeChatId, forkScene, isForking],
+    [activeChatId, forkScene, isForking, isStreaming],
   );
 
   // Peek prompt state
@@ -1361,7 +1361,8 @@ export function ChatArea() {
           onToggleConversationStart={handleToggleConversationStart}
           onPeekPrompt={handlePeekPrompt}
           onBranch={isSceneChat ? undefined : handleBranch}
-          onCloneSceneFromHere={isSceneChat && !isForking ? handleCloneSceneFromHere : undefined}
+          onCloneSceneFromHere={isSceneChat ? handleCloneSceneFromHere : undefined}
+          isCloneSceneFromHereDisabled={isForking || isStreaming}
           onToggleSelectMessage={handleToggleSelectMessage}
           onSummaryContextSizeChange={handleSummaryContextSizeChange}
           onRerunTrackers={handleRerunTrackers}
@@ -1369,7 +1370,7 @@ export function ChatArea() {
           onConcludeScene={() => concludeScene(activeChatId)}
           onAbandonScene={() => abandonScene(activeChatId)}
           onForkScene={forkScene}
-          isForkingScene={isForking}
+          isForkingScene={isForking || isStreaming}
           onOpenSettings={() => setSettingsOpen(true)}
           onOpenFiles={() => setFilesOpen(true)}
           onOpenGallery={() => setGalleryOpen(true)}

--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -290,7 +290,7 @@ export function ChatArea() {
   const chatMode = rawMode ?? lastModeRef.current;
   const isRoleplay = chatMode === "roleplay" || chatMode === "visual_novel";
   const { startEncounter } = useEncounter();
-  const { concludeScene, abandonScene } = useScene();
+  const { concludeScene, abandonScene, forkScene } = useScene();
   const encounterActive = useEncounterStore((s) => s.active || s.showConfigModal);
 
   // Sprite sidebar settings from chat metadata
@@ -721,6 +721,14 @@ export function ChatArea() {
       );
     },
     [activeChatId, branchChat],
+  );
+
+  const handleCloneSceneFromHere = useCallback(
+    (messageId: string) => {
+      if (!activeChatId) return;
+      forkScene(activeChatId, "clone", { upToMessageId: messageId });
+    },
+    [activeChatId, forkScene],
   );
 
   // Peek prompt state
@@ -1353,12 +1361,14 @@ export function ChatArea() {
           onToggleConversationStart={handleToggleConversationStart}
           onPeekPrompt={handlePeekPrompt}
           onBranch={isSceneChat ? undefined : handleBranch}
+          onCloneSceneFromHere={isSceneChat ? handleCloneSceneFromHere : undefined}
           onToggleSelectMessage={handleToggleSelectMessage}
           onSummaryContextSizeChange={handleSummaryContextSizeChange}
           onRerunTrackers={handleRerunTrackers}
           onStartEncounter={() => startEncounter()}
           onConcludeScene={() => concludeScene(activeChatId)}
           onAbandonScene={() => abandonScene(activeChatId)}
+          onForkScene={forkScene}
           onOpenSettings={() => setSettingsOpen(true)}
           onOpenFiles={() => setFilesOpen(true)}
           onOpenGallery={() => setGalleryOpen(true)}

--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -290,7 +290,7 @@ export function ChatArea() {
   const chatMode = rawMode ?? lastModeRef.current;
   const isRoleplay = chatMode === "roleplay" || chatMode === "visual_novel";
   const { startEncounter } = useEncounter();
-  const { concludeScene, abandonScene, forkScene } = useScene();
+  const { concludeScene, abandonScene, forkScene, isForking } = useScene();
   const encounterActive = useEncounterStore((s) => s.active || s.showConfigModal);
 
   // Sprite sidebar settings from chat metadata
@@ -725,10 +725,10 @@ export function ChatArea() {
 
   const handleCloneSceneFromHere = useCallback(
     (messageId: string) => {
-      if (!activeChatId) return;
+      if (!activeChatId || isForking) return;
       forkScene(activeChatId, "clone", { upToMessageId: messageId });
     },
-    [activeChatId, forkScene],
+    [activeChatId, forkScene, isForking],
   );
 
   // Peek prompt state
@@ -1361,7 +1361,7 @@ export function ChatArea() {
           onToggleConversationStart={handleToggleConversationStart}
           onPeekPrompt={handlePeekPrompt}
           onBranch={isSceneChat ? undefined : handleBranch}
-          onCloneSceneFromHere={isSceneChat ? handleCloneSceneFromHere : undefined}
+          onCloneSceneFromHere={isSceneChat && !isForking ? handleCloneSceneFromHere : undefined}
           onToggleSelectMessage={handleToggleSelectMessage}
           onSummaryContextSizeChange={handleSummaryContextSizeChange}
           onRerunTrackers={handleRerunTrackers}
@@ -1369,6 +1369,7 @@ export function ChatArea() {
           onConcludeScene={() => concludeScene(activeChatId)}
           onAbandonScene={() => abandonScene(activeChatId)}
           onForkScene={forkScene}
+          isForkingScene={isForking}
           onOpenSettings={() => setSettingsOpen(true)}
           onOpenFiles={() => setFilesOpen(true)}
           onOpenGallery={() => setGalleryOpen(true)}

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -111,6 +111,7 @@ const EditTextarea = memo(function EditTextarea({
   );
 });
 
+/** Props for a single rendered chat message, including optional scene fork actions. */
 interface ChatMessageProps {
   message: Message & { swipes?: Array<{ id: string; content: string }> };
   isStreaming?: boolean;

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -123,6 +123,7 @@ interface ChatMessageProps {
   onPeekPrompt?: () => void;
   onBranch?: (messageId: string) => void;
   onCloneSceneFromHere?: (messageId: string) => void;
+  isCloneSceneFromHereDisabled?: boolean;
   isLastAssistantMessage?: boolean;
   characterMap?: CharacterMap;
   chatMode?: string;
@@ -433,6 +434,7 @@ export const ChatMessage = memo(function ChatMessage({
   onPeekPrompt,
   onBranch,
   onCloneSceneFromHere,
+  isCloneSceneFromHereDisabled,
   isLastAssistantMessage,
   characterMap,
   chatMode,
@@ -1424,6 +1426,7 @@ export const ChatMessage = memo(function ChatMessage({
                   icon={<GitBranch size="0.6875rem" />}
                   onClick={() => onCloneSceneFromHere(message.id)}
                   title="Clone from here"
+                  disabled={isCloneSceneFromHereDisabled}
                   dark
                 />
               )}
@@ -1760,6 +1763,7 @@ export const ChatMessage = memo(function ChatMessage({
                 icon={<GitBranch size="0.625rem" />}
                 onClick={() => onCloneSceneFromHere(message.id)}
                 title="Clone from here"
+                disabled={isCloneSceneFromHereDisabled}
               />
             )}
             <ActionBtn

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -121,6 +121,7 @@ interface ChatMessageProps {
   onToggleConversationStart?: (messageId: string, current: boolean) => void;
   onPeekPrompt?: () => void;
   onBranch?: (messageId: string) => void;
+  onCloneSceneFromHere?: (messageId: string) => void;
   isLastAssistantMessage?: boolean;
   characterMap?: CharacterMap;
   chatMode?: string;
@@ -430,6 +431,7 @@ export const ChatMessage = memo(function ChatMessage({
   onToggleConversationStart,
   onPeekPrompt,
   onBranch,
+  onCloneSceneFromHere,
   isLastAssistantMessage,
   characterMap,
   chatMode,
@@ -1416,6 +1418,14 @@ export const ChatMessage = memo(function ChatMessage({
                   dark
                 />
               )}
+              {onCloneSceneFromHere && (
+                <ActionBtn
+                  icon={<GitBranch size="0.6875rem" />}
+                  onClick={() => onCloneSceneFromHere(message.id)}
+                  title="Clone from here"
+                  dark
+                />
+              )}
               <ActionBtn
                 icon={<Trash2 size="0.6875rem" />}
                 onClick={() => onDelete?.(message.id)}
@@ -1742,6 +1752,13 @@ export const ChatMessage = memo(function ChatMessage({
                 icon={<GitBranch size="0.625rem" />}
                 onClick={() => onBranch(message.id)}
                 title="Branch from here"
+              />
+            )}
+            {onCloneSceneFromHere && (
+              <ActionBtn
+                icon={<GitBranch size="0.625rem" />}
+                onClick={() => onCloneSceneFromHere(message.id)}
+                title="Clone from here"
               />
             )}
             <ActionBtn

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -213,6 +213,7 @@ function RegeneratingMessageContent({
   return <ChatMessage message={{ ...msg, extra: cleanExtra, content: streamBuffer || "" }} isStreaming {...rest} />;
 }
 
+/** True for stored context messages that should feed generation but not render in the transcript. */
 function isHiddenFromUser(message: MessageWithSwipes) {
   const extra = typeof message.extra === "string" ? JSON.parse(message.extra) : (message.extra ?? {});
   return extra.hiddenFromUser === true;
@@ -543,6 +544,7 @@ function AuthorNotesButton({ chatId, chatMeta }: { chatId: string | null; chatMe
   );
 }
 
+/** Props for the full roleplay surface, including scene lifecycle and fork controls. */
 type RoleplaySurfaceProps = {
   activeChatId: string;
   chat: ChatData | null | undefined;

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -603,6 +603,7 @@ type RoleplaySurfaceProps = {
   onPeekPrompt: () => void;
   onBranch?: (messageId: string) => void;
   onCloneSceneFromHere?: (messageId: string) => void;
+  isCloneSceneFromHereDisabled?: boolean;
   onToggleSelectMessage: (toggle: MessageSelectionToggle) => void;
   onSummaryContextSizeChange: (size: number) => void;
   onRerunTrackers: () => void;
@@ -697,6 +698,7 @@ export function ChatRoleplaySurface({
   onPeekPrompt,
   onBranch,
   onCloneSceneFromHere,
+  isCloneSceneFromHereDisabled,
   onToggleSelectMessage,
   onSummaryContextSizeChange,
   onRerunTrackers,
@@ -1018,6 +1020,7 @@ export function ChatRoleplaySurface({
                           onPeekPrompt={onPeekPrompt}
                           onBranch={onBranch}
                           onCloneSceneFromHere={onCloneSceneFromHere}
+                          isCloneSceneFromHereDisabled={isCloneSceneFromHereDisabled}
                           isLastAssistantMessage={msg.id === lastAssistantMessageId}
                           characterMap={characterMap}
                           personaInfo={personaInfo}
@@ -1044,6 +1047,7 @@ export function ChatRoleplaySurface({
                           onPeekPrompt={onPeekPrompt}
                           onBranch={onBranch}
                           onCloneSceneFromHere={onCloneSceneFromHere}
+                          isCloneSceneFromHereDisabled={isCloneSceneFromHereDisabled}
                           isLastAssistantMessage={msg.id === lastAssistantMessageId}
                           characterMap={characterMap}
                           personaInfo={personaInfo}

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -213,6 +213,11 @@ function RegeneratingMessageContent({
   return <ChatMessage message={{ ...msg, extra: cleanExtra, content: streamBuffer || "" }} isStreaming {...rest} />;
 }
 
+function isHiddenFromUser(message: MessageWithSwipes) {
+  const extra = typeof message.extra === "string" ? JSON.parse(message.extra) : (message.extra ?? {});
+  return extra.hiddenFromUser === true;
+}
+
 function RpToolbarButton({
   icon,
   title,
@@ -988,6 +993,7 @@ export function ChatRoleplaySurface({
                 )}
 
                 {messages?.map((msg, i) => {
+                  if (isHiddenFromUser(msg)) return null;
                   const isRegenerating = isStreaming && regenerateMessageId === msg.id;
                   return (
                     <div

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -10,7 +10,7 @@ import {
   type ReactNode,
   type RefObject,
 } from "react";
-import { type SpritePlacement, type SpriteSide } from "@marinara-engine/shared";
+import { type SceneForkMode, type SpritePlacement, type SpriteSide } from "@marinara-engine/shared";
 import {
   FolderOpen,
   Globe,
@@ -595,6 +595,7 @@ type RoleplaySurfaceProps = {
   onToggleConversationStart: (messageId: string, current: boolean) => void;
   onPeekPrompt: () => void;
   onBranch?: (messageId: string) => void;
+  onCloneSceneFromHere?: (messageId: string) => void;
   onToggleSelectMessage: (toggle: MessageSelectionToggle) => void;
   onSummaryContextSizeChange: (size: number) => void;
   onRerunTrackers: () => void;
@@ -602,6 +603,7 @@ type RoleplaySurfaceProps = {
   onStartEncounter: () => void;
   onConcludeScene: () => void;
   onAbandonScene: () => void;
+  onForkScene: (sceneChatId: string, mode: SceneForkMode) => void;
   onOpenSettings: () => void;
   onOpenFiles: () => void;
   onOpenGallery: () => void;
@@ -686,6 +688,7 @@ export function ChatRoleplaySurface({
   onToggleConversationStart,
   onPeekPrompt,
   onBranch,
+  onCloneSceneFromHere,
   onToggleSelectMessage,
   onSummaryContextSizeChange,
   onRerunTrackers,
@@ -693,6 +696,7 @@ export function ChatRoleplaySurface({
   onStartEncounter,
   onConcludeScene,
   onAbandonScene,
+  onForkScene,
   onOpenSettings,
   onOpenFiles,
   onOpenGallery,
@@ -1003,6 +1007,7 @@ export function ChatRoleplaySurface({
                           onToggleConversationStart={onToggleConversationStart}
                           onPeekPrompt={onPeekPrompt}
                           onBranch={onBranch}
+                          onCloneSceneFromHere={onCloneSceneFromHere}
                           isLastAssistantMessage={msg.id === lastAssistantMessageId}
                           characterMap={characterMap}
                           personaInfo={personaInfo}
@@ -1028,6 +1033,7 @@ export function ChatRoleplaySurface({
                           onToggleConversationStart={onToggleConversationStart}
                           onPeekPrompt={onPeekPrompt}
                           onBranch={onBranch}
+                          onCloneSceneFromHere={onCloneSceneFromHere}
                           isLastAssistantMessage={msg.id === lastAssistantMessageId}
                           characterMap={characterMap}
                           personaInfo={personaInfo}
@@ -1072,6 +1078,7 @@ export function ChatRoleplaySurface({
                     originChatId={chatMeta.sceneOriginChatId}
                     onConclude={onConcludeScene}
                     onAbandon={onAbandonScene}
+                    onFork={onForkScene}
                   />
                 )}
                 {combatAgentEnabled && (

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -604,6 +604,7 @@ type RoleplaySurfaceProps = {
   onConcludeScene: () => void;
   onAbandonScene: () => void;
   onForkScene: (sceneChatId: string, mode: SceneForkMode) => void;
+  isForkingScene?: boolean;
   onOpenSettings: () => void;
   onOpenFiles: () => void;
   onOpenGallery: () => void;
@@ -697,6 +698,7 @@ export function ChatRoleplaySurface({
   onConcludeScene,
   onAbandonScene,
   onForkScene,
+  isForkingScene,
   onOpenSettings,
   onOpenFiles,
   onOpenGallery,
@@ -1079,6 +1081,7 @@ export function ChatRoleplaySurface({
                     onConclude={onConcludeScene}
                     onAbandon={onAbandonScene}
                     onFork={onForkScene}
+                    isForking={isForkingScene}
                   />
                 )}
                 {combatAgentEnabled && (

--- a/packages/client/src/components/chat/SceneBanner.tsx
+++ b/packages/client/src/components/chat/SceneBanner.tsx
@@ -106,12 +106,14 @@ export function EndSceneBar({
   onConclude,
   onAbandon,
   onFork,
+  isForking,
 }: {
   sceneChatId: string;
   originChatId?: string;
   onConclude: (id: string) => void;
   onAbandon?: (id: string) => void;
   onFork?: (id: string, mode: SceneForkMode) => void;
+  isForking?: boolean;
 }) {
   const setActiveChatId = useChatStore((s) => s.setActiveChatId);
   const [confirmDiscard, setConfirmDiscard] = useState(false);
@@ -125,7 +127,7 @@ export function EndSceneBar({
       cancelLabel: "Cancel",
       tone: "destructive",
     });
-    if (confirmed) onFork?.(sceneChatId, "convert");
+    if (confirmed && !isForking) onFork?.(sceneChatId, "convert");
   };
 
   return (
@@ -174,6 +176,7 @@ export function EndSceneBar({
       {onFork && !confirmDiscard && (
         <button
           onClick={handleConvert}
+          disabled={isForking}
           className="flex items-center gap-1.5 rounded-lg px-3 py-1 text-xs font-medium transition-all hover:opacity-80"
           style={{
             color: "var(--muted-foreground)",

--- a/packages/client/src/components/chat/SceneBanner.tsx
+++ b/packages/client/src/components/chat/SceneBanner.tsx
@@ -1,9 +1,11 @@
 // ──────────────────────────────────────────────
 // SceneBanner — inline message-style indicators for active scenes
 // ──────────────────────────────────────────────
-import { Film, ArrowRight, ArrowLeft, Trash2 } from "lucide-react";
+import { Film, ArrowRight, ArrowLeft, Trash2, ArrowRightLeft } from "lucide-react";
 import { useState } from "react";
 import { useChatStore } from "../../stores/chat.store";
+import { showConfirmDialog } from "../../lib/app-dialogs";
+import type { SceneForkMode } from "@marinara-engine/shared";
 
 interface SceneBannerProps {
   /** "origin" = the conversation has an active scene; "scene" = we ARE the scene chat */
@@ -103,17 +105,31 @@ export function EndSceneBar({
   originChatId,
   onConclude,
   onAbandon,
+  onFork,
 }: {
   sceneChatId: string;
   originChatId?: string;
   onConclude: (id: string) => void;
   onAbandon?: (id: string) => void;
+  onFork?: (id: string, mode: SceneForkMode) => void;
 }) {
   const setActiveChatId = useChatStore((s) => s.setActiveChatId);
   const [confirmDiscard, setConfirmDiscard] = useState(false);
 
+  const handleConvert = async () => {
+    const confirmed = await showConfirmDialog({
+      title: "Convert this scene into a standalone roleplay?",
+      message:
+        "This will create a new roleplay chat from the current scene and detach the original scene from its conversation. No scene summary or character memory will be written back to the original conversation.",
+      confirmLabel: "Convert",
+      cancelLabel: "Cancel",
+      tone: "destructive",
+    });
+    if (confirmed) onFork?.(sceneChatId, "convert");
+  };
+
   return (
-    <div className="flex items-center justify-center gap-2 py-1.5">
+    <div className="flex flex-wrap items-center justify-center gap-2 py-1.5">
       {originChatId && (
         <button
           onClick={() => setActiveChatId(originChatId)}
@@ -153,6 +169,19 @@ export function EndSceneBar({
         >
           <Trash2 size={13} />
           Discard
+        </button>
+      )}
+      {onFork && !confirmDiscard && (
+        <button
+          onClick={handleConvert}
+          className="flex items-center gap-1.5 rounded-lg px-3 py-1 text-xs font-medium transition-all hover:opacity-80"
+          style={{
+            color: "var(--muted-foreground)",
+          }}
+          title="Detach this scene into a standalone roleplay"
+        >
+          <ArrowRightLeft size={13} />
+          Convert
         </button>
       )}
       {onAbandon && confirmDiscard && (

--- a/packages/client/src/hooks/use-scene.ts
+++ b/packages/client/src/hooks/use-scene.ts
@@ -20,6 +20,7 @@ import type {
   SceneFullPlan,
 } from "@marinara-engine/shared";
 
+/** Provides scene lifecycle mutations and the scene-to-roleplay fork action. */
 export function useScene() {
   const qc = useQueryClient();
   const setActiveChatId = useChatStore((s) => s.setActiveChatId);
@@ -138,7 +139,12 @@ export function useScene() {
     [qc, setActiveChatId],
   );
 
-  /** Fork a scene into a standalone roleplay chat. */
+  /**
+   * Fork a scene into a standalone roleplay chat.
+   *
+   * The ref guard prevents duplicate clone/convert requests from rapid clicks
+   * while `isForking` lets the UI disable the relevant controls.
+   */
   const forkScene = useCallback(
     async (
       sceneChatId: string,

--- a/packages/client/src/hooks/use-scene.ts
+++ b/packages/client/src/hooks/use-scene.ts
@@ -12,6 +12,9 @@ import type {
   SceneCreateResponse,
   SceneConcludeRequest,
   SceneConcludeResponse,
+  SceneForkMode,
+  SceneForkRequest,
+  SceneForkResponse,
   ScenePlanRequest,
   ScenePlanResponse,
   SceneFullPlan,
@@ -133,5 +136,46 @@ export function useScene() {
     [qc, setActiveChatId],
   );
 
-  return { planScene, createScene, concludeScene, abandonScene };
+  /** Fork a scene into a standalone roleplay chat. */
+  const forkScene = useCallback(
+    async (
+      sceneChatId: string,
+      mode: SceneForkMode,
+      opts?: { upToMessageId?: string },
+    ): Promise<SceneForkResponse | null> => {
+      try {
+        const res = await api.post<SceneForkResponse>("/scene/fork", {
+          sceneChatId,
+          mode,
+          upToMessageId: opts?.upToMessageId,
+          includePreSceneSummary: true,
+          includeParticipationGuide: true,
+        } satisfies SceneForkRequest);
+
+        qc.invalidateQueries({ queryKey: chatKeys.all });
+        qc.invalidateQueries({ queryKey: chatKeys.messages(sceneChatId) });
+        if (res.originChatId) qc.invalidateQueries({ queryKey: chatKeys.detail(res.originChatId) });
+        qc.invalidateQueries({ queryKey: chatKeys.detail(res.chatId) });
+        qc.invalidateQueries({ queryKey: chatKeys.messages(res.chatId) });
+        qc.invalidateQueries({ queryKey: chatKeys.messageCount(res.chatId) });
+
+        if (mode === "convert") {
+          qc.removeQueries({ queryKey: chatKeys.detail(sceneChatId) });
+        }
+
+        setActiveChatId(res.chatId);
+        toast.success(mode === "convert" ? "Scene converted to roleplay" : "Scene cloned as roleplay", {
+          icon: "RP",
+        });
+        return res;
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : "Failed to fork scene";
+        toast.error(msg);
+        return null;
+      }
+    },
+    [qc, setActiveChatId],
+  );
+
+  return { planScene, createScene, concludeScene, abandonScene, forkScene };
 }

--- a/packages/client/src/hooks/use-scene.ts
+++ b/packages/client/src/hooks/use-scene.ts
@@ -1,7 +1,7 @@
 // ──────────────────────────────────────────────
 // Hook: Scene API calls
 // ──────────────────────────────────────────────
-import { useCallback } from "react";
+import { useCallback, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { api } from "../lib/api-client";
@@ -24,6 +24,8 @@ export function useScene() {
   const qc = useQueryClient();
   const setActiveChatId = useChatStore((s) => s.setActiveChatId);
   const activeChatId = useChatStore((s) => s.activeChatId);
+  const isForkingRef = useRef(false);
+  const [isForking, setIsForking] = useState(false);
 
   /** Plan a scene from a user prompt (used by /scene slash command). */
   const planScene = useCallback(
@@ -143,6 +145,9 @@ export function useScene() {
       mode: SceneForkMode,
       opts?: { upToMessageId?: string },
     ): Promise<SceneForkResponse | null> => {
+      if (isForkingRef.current) return null;
+      isForkingRef.current = true;
+      setIsForking(true);
       try {
         const res = await api.post<SceneForkResponse>("/scene/fork", {
           sceneChatId,
@@ -172,10 +177,13 @@ export function useScene() {
         const msg = err instanceof Error ? err.message : "Failed to fork scene";
         toast.error(msg);
         return null;
+      } finally {
+        isForkingRef.current = false;
+        setIsForking(false);
       }
     },
     [qc, setActiveChatId],
   );
 
-  return { planScene, createScene, concludeScene, abandonScene, forkScene };
+  return { planScene, createScene, concludeScene, abandonScene, forkScene, isForking };
 }

--- a/packages/server/src/routes/scene.routes.ts
+++ b/packages/server/src/routes/scene.routes.ts
@@ -556,7 +556,14 @@ export async function sceneRoutes(app: FastifyInstance) {
         characterId: string | null;
         content: string;
         extra?: unknown;
+        activeSwipeIndex?: number;
         swipeExtra?: unknown;
+        swipes?: Array<{
+          index: number;
+          content: string;
+          extra?: unknown;
+          createdAt?: string | null;
+        }>;
         createdAt?: string | null;
       }> = [];
 
@@ -592,20 +599,26 @@ export async function sceneRoutes(app: FastifyInstance) {
         let extra = msg.extra;
         let swipeExtra: unknown = undefined;
         let createdAt = msg.createdAt;
-        if (msg.activeSwipeIndex > 0) {
-          const swipes = await chats.getSwipes(msg.id);
-          const activeSwipe = swipes.find(
-            (s: { index: number; content?: string; extra?: unknown; createdAt?: string }) =>
-              s.index === msg.activeSwipeIndex,
-          );
-          if (activeSwipe) {
-            content = activeSwipe.content ?? content;
-            extra = activeSwipe.extra ?? extra;
-            // Keep swipe metadata independent; createMessagesBatch supplies the
-            // empty default when the selected swipe has no metadata of its own.
-            swipeExtra = activeSwipe.extra;
-            createdAt = activeSwipe.createdAt ?? createdAt;
-          }
+        const swipes = await chats.getSwipes(msg.id);
+        const copiedSwipes = swipes.map(
+          (swipe: { index: number; content: string; extra?: unknown; createdAt?: string | null }) => ({
+            index: swipe.index,
+            content: swipe.content,
+            extra: swipe.extra,
+            createdAt: swipe.createdAt,
+          }),
+        );
+        const activeSwipe = swipes.find(
+          (s: { index: number; content?: string; extra?: unknown; createdAt?: string }) =>
+            s.index === msg.activeSwipeIndex,
+        );
+        if (activeSwipe) {
+          content = activeSwipe.content ?? content;
+          extra = activeSwipe.extra ?? extra;
+          // Keep swipe metadata independent; createMessagesBatch supplies the
+          // empty default when the selected swipe has no metadata of its own.
+          swipeExtra = activeSwipe.extra;
+          createdAt = activeSwipe.createdAt ?? createdAt;
         }
 
         copiedMessages.push({
@@ -613,7 +626,9 @@ export async function sceneRoutes(app: FastifyInstance) {
           characterId: msg.characterId,
           content,
           extra,
+          activeSwipeIndex: msg.activeSwipeIndex,
           swipeExtra,
+          swipes: copiedSwipes,
           createdAt,
         });
 

--- a/packages/server/src/routes/scene.routes.ts
+++ b/packages/server/src/routes/scene.routes.ts
@@ -130,11 +130,13 @@ function listAvailableBackgrounds(): string[] {
   return readdirSync(BG_DIR).filter((f) => ALLOWED_BG_EXTS.has(extname(f).toLowerCase()));
 }
 
+/** Parse chat metadata regardless of whether storage returned JSON text or an object. */
 function parseMetadata(chat: { metadata?: string | Record<string, unknown> | null }): Record<string, unknown> {
   if (!chat.metadata) return {};
   return typeof chat.metadata === "string" ? JSON.parse(chat.metadata) : chat.metadata;
 }
 
+/** Normalize stored character IDs into a string array for copied roleplay chats. */
 function parseCharacterIds(characterIds: unknown): string[] {
   if (Array.isArray(characterIds)) return characterIds.map(String);
   if (typeof characterIds === "string") {
@@ -148,6 +150,7 @@ function parseCharacterIds(characterIds: unknown): string[] {
   return [];
 }
 
+/** Scene lifecycle keys that must not be copied into standalone roleplay metadata. */
 const SCENE_FORK_METADATA_EXCLUDE = new Set([
   "sceneOriginChatId",
   "sceneInitiatorCharId",
@@ -163,6 +166,7 @@ const SCENE_FORK_METADATA_EXCLUDE = new Set([
   "sceneBusyCharIds",
 ]);
 
+/** Copy only safe non-scene metadata when creating a standalone roleplay fork. */
 function buildRoleplayForkMetadata(sceneMeta: Record<string, unknown>) {
   const next: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(sceneMeta)) {
@@ -172,6 +176,7 @@ function buildRoleplayForkMetadata(sceneMeta: Record<string, unknown>) {
   return next;
 }
 
+/** Build hidden continuity context from user-safe scene fields for the forked chat. */
 function buildForkContextMessage(sceneMeta: Record<string, unknown>, includePreSceneSummary: boolean) {
   if (!includePreSceneSummary) return null;
 
@@ -196,6 +201,7 @@ function buildForkContextMessage(sceneMeta: Record<string, unknown>, includePreS
 // Routes
 // ──────────────────────────────────────────────
 
+/** Register routes for planning, creating, ending, and forking scenes. */
 export async function sceneRoutes(app: FastifyInstance) {
   const chats = createChatsStorage(app.db);
   const connections = createConnectionsStorage(app.db);
@@ -480,7 +486,8 @@ export async function sceneRoutes(app: FastifyInstance) {
 
   // Copy an active scene into a standalone roleplay chat. Clone leaves the
   // original scene running; convert detaches and deletes the original scene
-  // without generating summaries or character memory.
+  // without generating summaries or character memory. The new chat preserves
+  // narrative continuity only; scene lifecycle metadata is stripped.
   app.post<{ Body: SceneForkRequest }>("/fork", async (req, reply) => {
     const {
       sceneChatId,
@@ -507,10 +514,14 @@ export async function sceneRoutes(app: FastifyInstance) {
     if (!isActiveScene && !originChatId) {
       return reply.status(400).send({ error: "Not a scene chat" });
     }
+    // Convert needs an origin to clear active scene state; clone can copy an
+    // orphaned scene-like chat without altering its source.
     if (mode === "convert" && !originChatId) {
       return reply.status(400).send({ error: "convert requires originChatId" });
     }
 
+    // Sort explicitly before validating/slicing `upToMessageId` so "clone from
+    // here" always copies a chronological prefix even if storage ordering changes.
     const sceneMessages = (await chats.listMessages(sceneChatId)).sort(
       (a: { createdAt: string }, b: { createdAt: string }) =>
         new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
@@ -548,6 +559,8 @@ export async function sceneRoutes(app: FastifyInstance) {
 
     const continuity = buildForkContextMessage(sceneMeta, includePreSceneSummary);
     if (continuity) {
+      // Hidden narrator context remains available to prompt assembly while
+      // staying out of the standalone roleplay transcript.
       copiedMessages.push({
         role: "narrator",
         characterId: null,
@@ -583,6 +596,8 @@ export async function sceneRoutes(app: FastifyInstance) {
         if (activeSwipe) {
           content = activeSwipe.content ?? content;
           extra = activeSwipe.extra ?? extra;
+          // Keep swipe metadata independent; createMessagesBatch supplies the
+          // empty default when the selected swipe has no metadata of its own.
           swipeExtra = activeSwipe.extra;
           createdAt = activeSwipe.createdAt ?? createdAt;
         }

--- a/packages/server/src/routes/scene.routes.ts
+++ b/packages/server/src/routes/scene.routes.ts
@@ -570,11 +570,10 @@ export async function sceneRoutes(app: FastifyInstance) {
         if (activeSwipe) {
           content = activeSwipe.content ?? content;
           extra = activeSwipe.extra ?? extra;
-          swipeExtra = activeSwipe.extra;
+          swipeExtra = activeSwipe.extra ?? extra;
           createdAt = activeSwipe.createdAt ?? createdAt;
         }
       }
-      swipeExtra ??= extra;
 
       copiedMessages.push({
         role: msg.role as "user" | "assistant" | "system" | "narrator",

--- a/packages/server/src/routes/scene.routes.ts
+++ b/packages/server/src/routes/scene.routes.ts
@@ -179,9 +179,6 @@ function buildForkContextMessage(sceneMeta: Record<string, unknown>, includePreS
   if (typeof sceneMeta.sceneDescription === "string" && sceneMeta.sceneDescription.trim()) {
     parts.push(`Scene premise:\n${sceneMeta.sceneDescription.trim()}`);
   }
-  if (typeof sceneMeta.sceneScenario === "string" && sceneMeta.sceneScenario.trim()) {
-    parts.push(`Scene scenario:\n${sceneMeta.sceneScenario.trim()}`);
-  }
   if (typeof sceneMeta.sceneRelationshipHistory === "string" && sceneMeta.sceneRelationshipHistory.trim()) {
     parts.push(`Relationship continuity:\n${sceneMeta.sceneRelationshipHistory.trim()}`);
   }
@@ -538,6 +535,9 @@ export async function sceneRoutes(app: FastifyInstance) {
       role: "user" | "assistant" | "system" | "narrator";
       characterId: string | null;
       content: string;
+      extra?: unknown;
+      swipeExtra?: unknown;
+      createdAt?: string | null;
     }> = [];
 
     const continuity = buildForkContextMessage(sceneMeta, includePreSceneSummary);
@@ -558,16 +558,31 @@ export async function sceneRoutes(app: FastifyInstance) {
       }
 
       let content = msg.content;
+      let extra = msg.extra;
+      let swipeExtra: unknown = undefined;
+      let createdAt = msg.createdAt;
       if (msg.activeSwipeIndex > 0) {
         const swipes = await chats.getSwipes(msg.id);
-        const activeSwipe = swipes.find((s: { index: number }) => s.index === msg.activeSwipeIndex);
-        if (activeSwipe) content = activeSwipe.content;
+        const activeSwipe = swipes.find(
+          (s: { index: number; content?: string; extra?: unknown; createdAt?: string }) =>
+            s.index === msg.activeSwipeIndex,
+        );
+        if (activeSwipe) {
+          content = activeSwipe.content ?? content;
+          extra = activeSwipe.extra ?? extra;
+          swipeExtra = activeSwipe.extra;
+          createdAt = activeSwipe.createdAt ?? createdAt;
+        }
       }
+      swipeExtra ??= extra;
 
       copiedMessages.push({
         role: msg.role as "user" | "assistant" | "system" | "narrator",
         characterId: msg.characterId,
         content,
+        extra,
+        swipeExtra,
+        createdAt,
       });
 
       if (upToMessageId && msg.id === upToMessageId) break;

--- a/packages/server/src/routes/scene.routes.ts
+++ b/packages/server/src/routes/scene.routes.ts
@@ -583,7 +583,7 @@ export async function sceneRoutes(app: FastifyInstance) {
         if (activeSwipe) {
           content = activeSwipe.content ?? content;
           extra = activeSwipe.extra ?? extra;
-          swipeExtra = activeSwipe.extra ?? extra;
+          swipeExtra = activeSwipe.extra;
           createdAt = activeSwipe.createdAt ?? createdAt;
         }
       }

--- a/packages/server/src/routes/scene.routes.ts
+++ b/packages/server/src/routes/scene.routes.ts
@@ -507,8 +507,14 @@ export async function sceneRoutes(app: FastifyInstance) {
     if (!isActiveScene && !originChatId) {
       return reply.status(400).send({ error: "Not a scene chat" });
     }
+    if (mode === "convert" && !originChatId) {
+      return reply.status(400).send({ error: "convert requires originChatId" });
+    }
 
-    const sceneMessages = await chats.listMessages(sceneChatId);
+    const sceneMessages = (await chats.listMessages(sceneChatId)).sort(
+      (a: { createdAt: string }, b: { createdAt: string }) =>
+        new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
+    );
     if (upToMessageId && !sceneMessages.some((msg) => msg.id === upToMessageId)) {
       return reply.status(400).send({ error: "Message is not part of this scene" });
     }
@@ -546,6 +552,13 @@ export async function sceneRoutes(app: FastifyInstance) {
         role: "narrator",
         characterId: null,
         content: continuity,
+        extra: {
+          displayText: null,
+          isGenerated: true,
+          tokenCount: null,
+          generationInfo: null,
+          hiddenFromUser: true,
+        },
       });
     }
 

--- a/packages/server/src/routes/scene.routes.ts
+++ b/packages/server/src/routes/scene.routes.ts
@@ -511,6 +511,8 @@ export async function sceneRoutes(app: FastifyInstance) {
     const sceneMeta = parseMetadata(sceneChat);
     const originChatId = typeof sceneMeta.sceneOriginChatId === "string" ? sceneMeta.sceneOriginChatId : null;
     const isActiveScene = sceneMeta.sceneStatus === "active";
+    // Clone accepts inactive scene-like chats with an origin so old scene
+    // transcripts can still be recovered into standalone roleplay chats.
     if (!isActiveScene && !originChatId) {
       return reply.status(400).send({ error: "Not a scene chat" });
     }
@@ -531,9 +533,9 @@ export async function sceneRoutes(app: FastifyInstance) {
     }
 
     const newChat = await chats.create({
-      name: sceneChat.name.startsWith("Scene: ")
-        ? sceneChat.name.replace(/^Scene:\s*/, "")
-        : `${sceneChat.name} (roleplay)`,
+      name: `${sceneChat.name.startsWith("Scene: ") ? sceneChat.name.replace(/^Scene:\s*/, "") : sceneChat.name} - ${
+        mode === "clone" ? "clone" : "converted"
+      }`,
       mode: "roleplay",
       characterIds: parseCharacterIds(sceneChat.characterIds),
       groupId: sceneChat.groupId,
@@ -543,91 +545,105 @@ export async function sceneRoutes(app: FastifyInstance) {
     });
     if (!newChat) return reply.status(500).send({ error: "Failed to create roleplay chat" });
 
-    await chats.updateMetadata(newChat.id, {
-      ...parseMetadata(newChat),
-      ...buildRoleplayForkMetadata(sceneMeta),
-    });
-
-    const copiedMessages: Array<{
-      role: "user" | "assistant" | "system" | "narrator";
-      characterId: string | null;
-      content: string;
-      extra?: unknown;
-      swipeExtra?: unknown;
-      createdAt?: string | null;
-    }> = [];
-
-    const continuity = buildForkContextMessage(sceneMeta, includePreSceneSummary);
-    if (continuity) {
-      // Hidden narrator context remains available to prompt assembly while
-      // staying out of the standalone roleplay transcript.
-      copiedMessages.push({
-        role: "narrator",
-        characterId: null,
-        content: continuity,
-        extra: {
-          displayText: null,
-          isGenerated: true,
-          tokenCount: null,
-          generationInfo: null,
-          hiddenFromUser: true,
-        },
+    try {
+      await chats.updateMetadata(newChat.id, {
+        ...parseMetadata(newChat),
+        ...buildRoleplayForkMetadata(sceneMeta),
       });
-    }
 
-    let skippedParticipationGuide = false;
-    for (const msg of sceneMessages) {
-      if (!includeParticipationGuide && !skippedParticipationGuide && msg.role === "narrator") {
-        skippedParticipationGuide = true;
-        if (upToMessageId && msg.id === upToMessageId) break;
-        continue;
+      const copiedMessages: Array<{
+        role: "user" | "assistant" | "system" | "narrator";
+        characterId: string | null;
+        content: string;
+        extra?: unknown;
+        swipeExtra?: unknown;
+        createdAt?: string | null;
+      }> = [];
+
+      const continuity = buildForkContextMessage(sceneMeta, includePreSceneSummary);
+      if (continuity) {
+        // Hidden narrator context remains available to prompt assembly while
+        // staying out of the standalone roleplay transcript.
+        copiedMessages.push({
+          role: "narrator",
+          characterId: null,
+          content: continuity,
+          extra: {
+            displayText: null,
+            isGenerated: true,
+            tokenCount: null,
+            generationInfo: null,
+            hiddenFromUser: true,
+          },
+        });
       }
 
-      let content = msg.content;
-      let extra = msg.extra;
-      let swipeExtra: unknown = undefined;
-      let createdAt = msg.createdAt;
-      if (msg.activeSwipeIndex > 0) {
-        const swipes = await chats.getSwipes(msg.id);
-        const activeSwipe = swipes.find(
-          (s: { index: number; content?: string; extra?: unknown; createdAt?: string }) =>
-            s.index === msg.activeSwipeIndex,
-        );
-        if (activeSwipe) {
-          content = activeSwipe.content ?? content;
-          extra = activeSwipe.extra ?? extra;
-          // Keep swipe metadata independent; createMessagesBatch supplies the
-          // empty default when the selected swipe has no metadata of its own.
-          swipeExtra = activeSwipe.extra;
-          createdAt = activeSwipe.createdAt ?? createdAt;
+      let skippedParticipationGuide = false;
+      for (const msg of sceneMessages) {
+        if (!includeParticipationGuide && !skippedParticipationGuide && msg.role === "narrator") {
+          // /scene/create writes the generated participation guide as the first
+          // narrator message; this option skips only that generated guide.
+          skippedParticipationGuide = true;
+          if (upToMessageId && msg.id === upToMessageId) break;
+          continue;
         }
+
+        let content = msg.content;
+        let extra = msg.extra;
+        let swipeExtra: unknown = undefined;
+        let createdAt = msg.createdAt;
+        if (msg.activeSwipeIndex > 0) {
+          const swipes = await chats.getSwipes(msg.id);
+          const activeSwipe = swipes.find(
+            (s: { index: number; content?: string; extra?: unknown; createdAt?: string }) =>
+              s.index === msg.activeSwipeIndex,
+          );
+          if (activeSwipe) {
+            content = activeSwipe.content ?? content;
+            extra = activeSwipe.extra ?? extra;
+            // Keep swipe metadata independent; createMessagesBatch supplies the
+            // empty default when the selected swipe has no metadata of its own.
+            swipeExtra = activeSwipe.extra;
+            createdAt = activeSwipe.createdAt ?? createdAt;
+          }
+        }
+
+        copiedMessages.push({
+          role: msg.role as "user" | "assistant" | "system" | "narrator",
+          characterId: msg.characterId,
+          content,
+          extra,
+          swipeExtra,
+          createdAt,
+        });
+
+        if (upToMessageId && msg.id === upToMessageId) break;
       }
 
-      copiedMessages.push({
-        role: msg.role as "user" | "assistant" | "system" | "narrator",
-        characterId: msg.characterId,
-        content,
-        extra,
-        swipeExtra,
-        createdAt,
-      });
+      await chats.createMessagesBatch(newChat.id, copiedMessages);
 
-      if (upToMessageId && msg.id === upToMessageId) break;
-    }
+      if (mode === "convert" && originChatId) {
+        const originChat = await chats.getById(originChatId);
+        if (originChat) {
+          const originMeta = parseMetadata(originChat);
+          delete originMeta.activeSceneChatId;
+          delete originMeta.sceneBusyCharIds;
+          await chats.updateMetadata(originChatId, originMeta);
+        } else {
+          logger.info("[scene/fork] Origin chat %s missing during convert of scene %s", originChatId, sceneChatId);
+        }
 
-    await chats.createMessagesBatch(newChat.id, copiedMessages);
-
-    if (mode === "convert" && originChatId) {
-      const originChat = await chats.getById(originChatId);
-      if (originChat) {
-        const originMeta = parseMetadata(originChat);
-        delete originMeta.activeSceneChatId;
-        delete originMeta.sceneBusyCharIds;
-        await chats.updateMetadata(originChatId, originMeta);
+        await chats.disconnectChat(sceneChatId);
+        await chats.remove(sceneChatId);
       }
-
-      await chats.disconnectChat(sceneChatId);
-      await chats.remove(sceneChatId);
+    } catch (err) {
+      try {
+        await chats.remove(newChat.id);
+      } catch (cleanupErr) {
+        logger.warn(cleanupErr, "[scene/fork] Failed to clean up partial fork chat %s", newChat.id);
+      }
+      logger.error(err, "[scene/fork] Failed to create fork chat %s from scene %s", newChat.id, sceneChatId);
+      return reply.status(500).send({ error: "Failed to fork scene" });
     }
 
     return {

--- a/packages/server/src/routes/scene.routes.ts
+++ b/packages/server/src/routes/scene.routes.ts
@@ -22,6 +22,8 @@ import type {
   SceneCreateResponse,
   SceneConcludeRequest,
   SceneConcludeResponse,
+  SceneForkRequest,
+  SceneForkResponse,
   ScenePlanRequest,
   ScenePlanResponse,
   SceneFullPlan,
@@ -126,6 +128,71 @@ async function getCharacterName(chars: ReturnType<typeof createCharactersStorage
 function listAvailableBackgrounds(): string[] {
   if (!existsSync(BG_DIR)) return [];
   return readdirSync(BG_DIR).filter((f) => ALLOWED_BG_EXTS.has(extname(f).toLowerCase()));
+}
+
+function parseMetadata(chat: { metadata?: string | Record<string, unknown> | null }): Record<string, unknown> {
+  if (!chat.metadata) return {};
+  return typeof chat.metadata === "string" ? JSON.parse(chat.metadata) : chat.metadata;
+}
+
+function parseCharacterIds(characterIds: unknown): string[] {
+  if (Array.isArray(characterIds)) return characterIds.map(String);
+  if (typeof characterIds === "string") {
+    try {
+      const parsed = JSON.parse(characterIds);
+      return Array.isArray(parsed) ? parsed.map(String) : [];
+    } catch {
+      return [];
+    }
+  }
+  return [];
+}
+
+const SCENE_FORK_METADATA_EXCLUDE = new Set([
+  "sceneOriginChatId",
+  "sceneInitiatorCharId",
+  "sceneDescription",
+  "sceneScenario",
+  "sceneSystemPrompt",
+  "sceneRating",
+  "sceneStatus",
+  "sceneConversationContext",
+  "sceneRelationshipHistory",
+  "sceneBackground",
+  "activeSceneChatId",
+  "sceneBusyCharIds",
+]);
+
+function buildRoleplayForkMetadata(sceneMeta: Record<string, unknown>) {
+  const next: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(sceneMeta)) {
+    if (SCENE_FORK_METADATA_EXCLUDE.has(key) || key.startsWith("scene")) continue;
+    next[key] = value;
+  }
+  return next;
+}
+
+function buildForkContextMessage(sceneMeta: Record<string, unknown>, includePreSceneSummary: boolean) {
+  if (!includePreSceneSummary) return null;
+
+  const parts: string[] = [];
+  if (typeof sceneMeta.sceneDescription === "string" && sceneMeta.sceneDescription.trim()) {
+    parts.push(`Scene premise:\n${sceneMeta.sceneDescription.trim()}`);
+  }
+  if (typeof sceneMeta.sceneScenario === "string" && sceneMeta.sceneScenario.trim()) {
+    parts.push(`Scene scenario:\n${sceneMeta.sceneScenario.trim()}`);
+  }
+  if (typeof sceneMeta.sceneRelationshipHistory === "string" && sceneMeta.sceneRelationshipHistory.trim()) {
+    parts.push(`Relationship continuity:\n${sceneMeta.sceneRelationshipHistory.trim()}`);
+  }
+  if (typeof sceneMeta.sceneConversationContext === "string" && sceneMeta.sceneConversationContext.trim()) {
+    parts.push(`Pre-scene conversation context:\n${sceneMeta.sceneConversationContext.trim()}`);
+  }
+
+  if (!parts.length) return null;
+  return [`The following continuity was preserved when this scene became a standalone roleplay.`, "", ...parts].join(
+    "\n\n",
+  );
 }
 
 // ──────────────────────────────────────────────
@@ -412,6 +479,120 @@ export async function sceneRoutes(app: FastifyInstance) {
     await chats.remove(sceneChatId);
 
     return { originChatId };
+  });
+
+  // Copy an active scene into a standalone roleplay chat. Clone leaves the
+  // original scene running; convert detaches and deletes the original scene
+  // without generating summaries or character memory.
+  app.post<{ Body: SceneForkRequest }>("/fork", async (req, reply) => {
+    const {
+      sceneChatId,
+      mode,
+      upToMessageId,
+      includePreSceneSummary = true,
+      includeParticipationGuide = true,
+    } = req.body ?? ({} as SceneForkRequest);
+
+    if (!sceneChatId) return reply.status(400).send({ error: "sceneChatId is required" });
+    if (mode !== "clone" && mode !== "convert") {
+      return reply.status(400).send({ error: "mode must be 'clone' or 'convert'" });
+    }
+    if (mode === "convert" && upToMessageId) {
+      return reply.status(400).send({ error: "Convert cannot be limited to a message" });
+    }
+
+    const sceneChat = await chats.getById(sceneChatId);
+    if (!sceneChat) return reply.status(404).send({ error: "Scene chat not found" });
+
+    const sceneMeta = parseMetadata(sceneChat);
+    const originChatId = typeof sceneMeta.sceneOriginChatId === "string" ? sceneMeta.sceneOriginChatId : null;
+    const isActiveScene = sceneMeta.sceneStatus === "active";
+    if (!isActiveScene && !originChatId) {
+      return reply.status(400).send({ error: "Not a scene chat" });
+    }
+
+    const sceneMessages = await chats.listMessages(sceneChatId);
+    if (upToMessageId && !sceneMessages.some((msg) => msg.id === upToMessageId)) {
+      return reply.status(400).send({ error: "Message is not part of this scene" });
+    }
+
+    const newChat = await chats.create({
+      name: sceneChat.name.startsWith("Scene: ")
+        ? sceneChat.name.replace(/^Scene:\s*/, "")
+        : `${sceneChat.name} (roleplay)`,
+      mode: "roleplay",
+      characterIds: parseCharacterIds(sceneChat.characterIds),
+      groupId: sceneChat.groupId,
+      personaId: sceneChat.personaId,
+      promptPresetId: sceneChat.promptPresetId,
+      connectionId: sceneChat.connectionId,
+    });
+    if (!newChat) return reply.status(500).send({ error: "Failed to create roleplay chat" });
+
+    await chats.updateMetadata(newChat.id, {
+      ...parseMetadata(newChat),
+      ...buildRoleplayForkMetadata(sceneMeta),
+    });
+
+    const copiedMessages: Array<{
+      role: "user" | "assistant" | "system" | "narrator";
+      characterId: string | null;
+      content: string;
+    }> = [];
+
+    const continuity = buildForkContextMessage(sceneMeta, includePreSceneSummary);
+    if (continuity) {
+      copiedMessages.push({
+        role: "narrator",
+        characterId: null,
+        content: continuity,
+      });
+    }
+
+    let skippedParticipationGuide = false;
+    for (const msg of sceneMessages) {
+      if (!includeParticipationGuide && !skippedParticipationGuide && msg.role === "narrator") {
+        skippedParticipationGuide = true;
+        if (upToMessageId && msg.id === upToMessageId) break;
+        continue;
+      }
+
+      let content = msg.content;
+      if (msg.activeSwipeIndex > 0) {
+        const swipes = await chats.getSwipes(msg.id);
+        const activeSwipe = swipes.find((s: { index: number }) => s.index === msg.activeSwipeIndex);
+        if (activeSwipe) content = activeSwipe.content;
+      }
+
+      copiedMessages.push({
+        role: msg.role as "user" | "assistant" | "system" | "narrator",
+        characterId: msg.characterId,
+        content,
+      });
+
+      if (upToMessageId && msg.id === upToMessageId) break;
+    }
+
+    await chats.createMessagesBatch(newChat.id, copiedMessages);
+
+    if (mode === "convert" && originChatId) {
+      const originChat = await chats.getById(originChatId);
+      if (originChat) {
+        const originMeta = parseMetadata(originChat);
+        delete originMeta.activeSceneChatId;
+        delete originMeta.sceneBusyCharIds;
+        await chats.updateMetadata(originChatId, originMeta);
+      }
+
+      await chats.disconnectChat(sceneChatId);
+      await chats.remove(sceneChatId);
+    }
+
+    return {
+      chatId: newChat.id,
+      originChatId,
+      mode,
+    } satisfies SceneForkResponse;
   });
 
   // ───────────────────────── PLAN (user-initiated) ─────────────────────────

--- a/packages/server/src/services/storage/chats.storage.ts
+++ b/packages/server/src/services/storage/chats.storage.ts
@@ -34,11 +34,13 @@ function resolveTimestamps(overrides?: TimestampOverrides | null) {
   };
 }
 
+/** Serialize optional JSON columns while preserving already-encoded metadata. */
 function serializeJsonField(value: unknown, fallback: Record<string, unknown>) {
   if (value === undefined || value === null) return JSON.stringify(fallback);
   return typeof value === "string" ? value : JSON.stringify(value);
 }
 
+/** Create the chat storage facade used by routes and importers. */
 export function createChatsStorage(db: DB) {
   return {
     async list() {
@@ -221,6 +223,11 @@ export function createChatsStorage(db: DB) {
     /**
      * Bulk-insert messages in a single transaction. Much faster than one-by-one
      * createMessage calls (especially on Windows/NTFS where each transaction fsync is expensive).
+     *
+     * Callers may pass `createdAt`, message `extra`, and swipe `swipeExtra`
+     * when cloning/importing existing transcripts so attachments, persona
+     * snapshots, hidden context flags, and original timestamps survive the copy.
+     *
      * Does NOT return the created messages or update chat.updatedAt per message —
      * caller should update chat.updatedAt once after the batch.
      */

--- a/packages/server/src/services/storage/chats.storage.ts
+++ b/packages/server/src/services/storage/chats.storage.ts
@@ -224,9 +224,11 @@ export function createChatsStorage(db: DB) {
      * Bulk-insert messages in a single transaction. Much faster than one-by-one
      * createMessage calls (especially on Windows/NTFS where each transaction fsync is expensive).
      *
-     * Callers may pass `createdAt`, message `extra`, and swipe `swipeExtra`
+     * Callers may pass `createdAt`, message `extra`, `activeSwipeIndex`,
+     * and either the first swipe's `swipeExtra` or the full `swipes` list
      * when cloning/importing existing transcripts so attachments, persona
-     * snapshots, hidden context flags, and original timestamps survive the copy.
+     * snapshots, hidden context flags, alternate swipes, and original
+     * timestamps survive the copy.
      *
      * Does NOT return the created messages or update chat.updatedAt per message —
      * caller should update chat.updatedAt once after the batch.
@@ -237,7 +239,14 @@ export function createChatsStorage(db: DB) {
         Omit<CreateMessageInput, "chatId"> & {
           createdAt?: string | null;
           extra?: unknown;
+          activeSwipeIndex?: number;
           swipeExtra?: unknown;
+          swipes?: Array<{
+            index: number;
+            content: string;
+            extra?: unknown;
+            createdAt?: string | null;
+          }>;
         }
       >,
       timestampOverrides?: TimestampOverrides | null,
@@ -265,7 +274,7 @@ export function createChatsStorage(db: DB) {
           role: input.role,
           characterId: input.characterId,
           content: input.content,
-          activeSwipeIndex: 0,
+          activeSwipeIndex: input.activeSwipeIndex ?? 0,
           extra: serializeJsonField(input.extra, {
             displayText: null,
             isGenerated: input.role !== "user",
@@ -274,14 +283,26 @@ export function createChatsStorage(db: DB) {
           }),
           createdAt: timestamp,
         });
-        swipeRows.push({
-          id: newId(),
-          messageId: id,
-          index: 0,
-          content: input.content,
-          extra: serializeJsonField(input.swipeExtra, {}),
-          createdAt: timestamp,
-        });
+        const inputSwipes = input.swipes?.length
+          ? [...input.swipes].sort((a, b) => a.index - b.index)
+          : [
+              {
+                index: 0,
+                content: input.content,
+                extra: input.swipeExtra,
+                createdAt: timestamp,
+              },
+            ];
+        for (const swipe of inputSwipes) {
+          swipeRows.push({
+            id: newId(),
+            messageId: id,
+            index: swipe.index,
+            content: swipe.content,
+            extra: serializeJsonField(swipe.extra, {}),
+            createdAt: normalizeTimestampOverrides({ createdAt: swipe.createdAt })?.createdAt ?? timestamp,
+          });
+        }
       }
 
       const lastTimestamp = latestTrustedTimestamp(createdTimestamps) ?? batchTimestamps.updatedAt;
@@ -293,6 +314,8 @@ export function createChatsStorage(db: DB) {
       const CHUNK = 500;
       for (let i = 0; i < msgRows.length; i += CHUNK) {
         await db.insert(messages).values(msgRows.slice(i, i + CHUNK));
+      }
+      for (let i = 0; i < swipeRows.length; i += CHUNK) {
         await db.insert(messageSwipes).values(swipeRows.slice(i, i + CHUNK));
       }
       await db.update(chats).set({ updatedAt: lastTimestamp }).where(eq(chats.id, chatId));

--- a/packages/server/src/services/storage/chats.storage.ts
+++ b/packages/server/src/services/storage/chats.storage.ts
@@ -34,6 +34,11 @@ function resolveTimestamps(overrides?: TimestampOverrides | null) {
   };
 }
 
+function serializeJsonField(value: unknown, fallback: Record<string, unknown>) {
+  if (value === undefined || value === null) return JSON.stringify(fallback);
+  return typeof value === "string" ? value : JSON.stringify(value);
+}
+
 export function createChatsStorage(db: DB) {
   return {
     async list() {
@@ -221,7 +226,13 @@ export function createChatsStorage(db: DB) {
      */
     async createMessagesBatch(
       chatId: string,
-      inputs: Array<Omit<CreateMessageInput, "chatId"> & { createdAt?: string | null }>,
+      inputs: Array<
+        Omit<CreateMessageInput, "chatId"> & {
+          createdAt?: string | null;
+          extra?: unknown;
+          swipeExtra?: unknown;
+        }
+      >,
       timestampOverrides?: TimestampOverrides | null,
     ) {
       if (inputs.length === 0) return;
@@ -248,7 +259,7 @@ export function createChatsStorage(db: DB) {
           characterId: input.characterId,
           content: input.content,
           activeSwipeIndex: 0,
-          extra: JSON.stringify({
+          extra: serializeJsonField(input.extra, {
             displayText: null,
             isGenerated: input.role !== "user",
             tokenCount: null,
@@ -261,7 +272,7 @@ export function createChatsStorage(db: DB) {
           messageId: id,
           index: 0,
           content: input.content,
-          extra: JSON.stringify({}),
+          extra: serializeJsonField(input.swipeExtra, {}),
           createdAt: timestamp,
         });
       }

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -210,6 +210,8 @@ export interface MessageExtra {
     dialogueColor?: string | null;
     boxColor?: string | null;
   } | null;
+  /** Stored for generation context but hidden from the visible chat transcript */
+  hiddenFromUser?: boolean;
 }
 
 /** Metadata about how a message was generated. */

--- a/packages/shared/src/types/scene.ts
+++ b/packages/shared/src/types/scene.ts
@@ -104,17 +104,23 @@ export interface SceneAbandonResponse {
   originChatId: string;
 }
 
+/** Scene fork behavior: clone preserves the source scene, convert consumes it. */
 export type SceneForkMode = "clone" | "convert";
 
-/** Request body for POST /scene/fork. */
+/**
+ * Request body for POST /scene/fork.
+ *
+ * Forking preserves roleplay continuity, messages, and safe roleplay settings,
+ * but intentionally does not copy scene lifecycle metadata into the new chat.
+ */
 export interface SceneForkRequest {
   /** The scene (roleplay) chat to copy into a standalone roleplay. */
   sceneChatId: string;
   /** Clone keeps the original scene active; convert detaches and discards it. */
   mode: SceneForkMode;
-  /** Clone only: copy scene messages up to and including this message. */
+  /** Clone only: copy scene messages chronologically up to and including this message. */
   upToMessageId?: string;
-  /** Include origin conversation and relationship context as a narrator note. */
+  /** Include origin conversation and relationship context as a hidden narrator note. */
   includePreSceneSummary?: boolean;
   /** Include scene participation guidance messages when copying scene messages. */
   includeParticipationGuide?: boolean;

--- a/packages/shared/src/types/scene.ts
+++ b/packages/shared/src/types/scene.ts
@@ -104,6 +104,31 @@ export interface SceneAbandonResponse {
   originChatId: string;
 }
 
+export type SceneForkMode = "clone" | "convert";
+
+/** Request body for POST /scene/fork. */
+export interface SceneForkRequest {
+  /** The scene (roleplay) chat to copy into a standalone roleplay. */
+  sceneChatId: string;
+  /** Clone keeps the original scene active; convert detaches and discards it. */
+  mode: SceneForkMode;
+  /** Clone only: copy scene messages up to and including this message. */
+  upToMessageId?: string;
+  /** Include origin conversation and relationship context as a narrator note. */
+  includePreSceneSummary?: boolean;
+  /** Include scene participation guidance messages when copying scene messages. */
+  includeParticipationGuide?: boolean;
+}
+
+/** Response from POST /scene/fork. */
+export interface SceneForkResponse {
+  /** The newly created standalone roleplay chat. */
+  chatId: string;
+  /** The origin conversation chat ID, if the scene had one. */
+  originChatId: string | null;
+  mode: SceneForkMode;
+}
+
 /** Request body for POST /scene/plan (user-initiated via /scene command). */
 export interface ScenePlanRequest {
   /** The conversation chat where the user typed /scene. */


### PR DESCRIPTION
## Why this change

Active scenes could be concluded or abandoned, but there was no way to preserve a scene as an independent roleplay thread. This adds a focused fork flow so users can keep narrative continuity without carrying over scene lifecycle behavior.

## What changed

## What changed

- Added `POST /api/scene/fork` with `clone` and `convert` modes.
- Added shared scene fork request/response types.
- Added `Clone from here` to active scene message actions, copying scene continuity and messages up to the selected message into a standalone roleplay chat.
- Added `Convert` beside the scene discard controls, with confirmation, to detach the active scene into a standalone roleplay.
- Added hidden narrator continuity context so forked chats preserve useful pre-scene context without showing scene setup in the transcript.
- Preserved copied message metadata, timestamps, active swipe state, and all message swipes during fork creation.
- Preserved normal roleplay metadata such as characters, persona, group, preset, connection, lorebook metadata, settings, and background where applicable.
- Ensured forked roleplay chats strip scene lifecycle metadata and do not write scene summaries or character memory during convert cleanup.
- Added fork in-flight guards and disabled clone/convert actions while scene generation is streaming.
- Added best-effort cleanup for partially-created fork chats if message copying or convert cleanup fails.
- Updated forked chat names to distinguish cloned and converted chats.

## Validation

- [x] `pnpm check`
- [x] Manual verification completed (describe below)

### Manual verification notes

- Manually tested functionality with Prof. Mari
- Scenes remain disconnected from their clones
- Context is available to the AI, but hidden from the user
- Conversations are not impacted by cloned or converted roleplays
- Lorebooks travel with cloned and converted scenes
- Swipes and Attachments now transfer to cloned and converted roleplays
- Convert and Clone disable during streaming to prevent errors
- Cloning or Converting from the very first message of a scene functions as expected

## Docs and release impact

- [x] No docs changes needed

## UI evidence

Clone Button
<img width="998" height="185" alt="shot1" src="https://github.com/user-attachments/assets/80c4f3f1-0325-41f2-a604-9b5d7e32a7a4" />

Clone Result
<img width="1905" height="894" alt="shot2" src="https://github.com/user-attachments/assets/2e17f3c1-9922-4f8d-9abe-74e7b97fe72e" />

Convert Button
<img width="561" height="151" alt="shot3" src="https://github.com/user-attachments/assets/248913e1-3db5-4ff7-bd16-383682932cb6" />

Confirmation Prompt
<img width="1053" height="643" alt="shot4" src="https://github.com/user-attachments/assets/d9bcf26e-c4b4-4fb1-a07f-e3b822a8913e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Clone from here" to create a new scene starting at a selected message (supports cloning up to a point and including scene context).
  * "Convert" to turn an active scene into a standalone roleplay chat.
  * Messages marked hidden are omitted from the visible chat transcript.

* **UX Improvements**
  * Action buttons show contextually in scene UIs, disable during fork operations, and surface success/error feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->