### PR TITLE
feat: Oracle agent — web search with lorebook persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This file is the release-notes source of truth for Marinara Engine. Reuse these entries when publishing GitHub Releases for tags in the `vX.Y.Z` format.
 
+## [Unreleased]
+
+### Added
+
+- New agent: **Oracle** — fetches live web results when the user types `<search>topic</search>` in a chat message, summarises them with anti-hallucination rules, injects the summary into the character's context, and persists the character's takeaway (preferences, choices, opinions) to the lorebook with the `web-research` tag. Tavily is the MVP provider; configure the API key and behaviour from Settings → Connections → Oracle. See `docs/ORACLE.md` for the end-to-end flow.
+
 ## [1.5.5]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Character expression sprites with automatic emotion switching, custom scene back
 
 ### AI Agent System
 
-25+ built-in agents that run alongside your chat — world state tracking, quest management, combat, expression detection, background selection, narrative direction, prose analysis, Spotify DJ, CYOA choices, and more. All disabled by default; enable only what you want, or create custom agents.
+25+ built-in agents that run alongside your chat — world state tracking, quest management, combat, expression detection, background selection, narrative direction, prose analysis, Spotify DJ, CYOA choices, an Oracle that answers `<search>topic</search>` triggers with live web results (via Tavily) and persists character takeaways to the lorebook, and more. All disabled by default; enable only what you want, or create custom agents.
 
 ### Prompt Engineering
 
@@ -167,6 +167,7 @@ Export chats as JSONL or plain text. Fully local SQLite database — all data st
 | [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md) | Common issues and fixes                                         |
 | [docs/FAQ.md](docs/FAQ.md)                         | Frequently asked questions (LAN access, etc.)                   |
 | [docs/FRONTEND.md](docs/FRONTEND.md)               | Frontend architecture, components, hooks, and API reference     |
+| [docs/ORACLE.md](docs/ORACLE.md)                   | Oracle agent — web search trigger, summary, and persistence     |
 | [android/README.md](android/README.md)             | Android WebView wrapper (APK) guide                             |
 | [CONTRIBUTING.md](CONTRIBUTING.md)                 | Contributor workflow, validation, versioning, and release steps |
 | [CHANGELOG.md](CHANGELOG.md)                       | Release notes                                                   |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -57,6 +57,26 @@ LOG_LEVEL=debug pnpm start
 
 > **Note:** Client-side (browser) logging uses the standard `console.*` API and is not controlled by `LOG_LEVEL`. Production client builds automatically strip `console.log` calls; only `console.warn` and `console.error` survive in the browser.
 
+## Agent-Specific Configuration
+
+Some agents have configuration that lives outside `.env` — typically because it includes encrypted credentials managed through the UI rather than environment variables.
+
+### Oracle (Web Search)
+
+The Oracle agent fetches live web results when the user types `<search>topic</search>` inside a chat message, summarises them with anti-hallucination rules, injects the summary into the character's context, and (optionally) persists character takeaways to the lorebook. It is configured from **Settings → Connections → Oracle**, and the encrypted API key is stored alongside other application settings.
+
+| Setting            | Default   | Range / Values    | Description                                                                                                                                              |
+| ------------------ | --------- | ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `enabled`          | `false`   | boolean           | Master switch for the Oracle agent. The agent must also be enabled in the agent panel for it to fire.                                                    |
+| `provider`         | `tavily`  | `tavily`          | Web-search provider. Only Tavily is implemented in the MVP.                                                                                              |
+| `apiKey`           | _(empty)_ | string            | Provider API key. Encrypted at rest using `ENCRYPTION_KEY`. The UI displays a masked placeholder once a key is saved.                                    |
+| `maxResults`       | `3`       | `1`–`10`          | Number of raw search results requested from the provider. The summariser still caps its own output independently.                                        |
+| `summaryTokenCap`  | `400`     | `100`–`2000`      | Hard cap on the summary length handed back to the character. Smaller values are faster and cheaper; larger values keep more facts.                       |
+| `timeoutMs`        | `8000`    | `2000`–`30000`    | Fetch timeout (ms) before Oracle gives up and returns an empty injection.                                                                                |
+| `autoPersist`      | `true`    | boolean           | When the character makes a durable commitment after a search (a choice, a preference, an opinion), persist it as a lorebook entry tagged `web-research`. |
+
+See [`docs/ORACLE.md`](./ORACLE.md) for the end-to-end flow, the trigger syntax, and how summaries are injected and persisted.
+
 ## Notes
 
 - The shell launchers (`start.bat`, `start.sh`, `start-termux.sh`) source `.env` automatically. If you run `pnpm start` directly, make sure the variables are set in your environment or `.env` file.

--- a/docs/ORACLE.md
+++ b/docs/ORACLE.md
@@ -274,6 +274,27 @@ chat-scoped lorebook loses everything when the user opens a fresh chat. So:
 Future Oracle runs with the same character reuse that one lorebook, so entries
 accumulate instead of spawning a new book per turn.
 
+### Why Oracle entries are persisted as `constant: true`
+
+Lorebook entries normally activate by matching keywords against the recent
+chat. That model breaks for conversational recall: when the user asks
+*"which film were we going to see again?"* a week after the search, the
+message contains none of the original entity names (`Wicked`, `Avatar 3`)
+and the entry never fires — the character forgets.
+
+Oracle entries are written with `constant: true`, which makes them
+always-on: whenever the character's lorebook is in scope, every takeaway
+the character has accumulated is injected, no keyword matching required.
+This is safe because the entries are already character-scoped — they only
+ever appear in chats with that specific character, never bleeding into
+other roleplays.
+
+The trade-off is context size: each takeaway is a single short sentence
+(~30-40 tokens), so 30 entries adds roughly 1k tokens of permanent context.
+Acceptable on modern model windows; if it becomes a problem in practice,
+the user can prune entries from the lorebook panel, and a future iteration
+could cap the count to the N most recent automatically.
+
 ### Why Oracle bypasses the chat's `enableAgents` gate
 
 In conversation mode, Marinara's settings drawer hides the "Enable Agents"
@@ -299,6 +320,49 @@ streaming and coupling. Two focused calls with clean system prompts are more
 robust to small quantized models like Gemma-4-26b. Total latency is ~3-8s and
 the takeaway extractor runs **after** the user-visible response, so the user
 never waits on it.
+
+### Why the summariser produces lorebook keys, not a server-side regex
+
+Lorebook entries activate by matching keywords against the chat. The shape of
+those keywords decides whether the entry helps or pollutes:
+
+- A key too generic (`The`, `She`, `Five`) fires on almost every future
+  message and drowns the character's context in stale web findings.
+- A key too long or too specific (the raw search query, or a fully qualified
+  proper noun like `Ichika Nakano`) almost never matches a natural chat
+  message and the entry effectively never activates.
+
+A previous iteration extracted keys with a regex over capitalised words. It
+produced both failure modes — sentence-start artefacts (`The`, `While`,
+`Five`, broken fragments like `Man Band` from hyphenated compounds) on the
+generic side, the verbatim search query on the over-specific side. The regex
+was also English-biased, which clashes with Marinara's multilingual posture.
+
+The summariser now emits a `Keys:` line right before its `Sources:` footer,
+constrained by the prompt to produce **canonical short forms** — given names
+alone when unambiguous in the work (`Ichika`, not `Ichika Nakano`), short
+canonical titles for works/places/organisations (`The Quintessential
+Quintuplets`, not `The Quintessential Quintuplets manga series`), and 3 to 6
+entities total:
+
+    [factual paragraphs]
+
+    Keys: Ichika, Nino, Miku, Yotsuba, Itsuki, The Quintessential Quintuplets
+
+    Sources:
+    - https://…
+
+The server parses that line into the persisted key list, then strips the
+`Keys:` line out before the summary is injected into the character's prompt —
+so the character sees the facts and the sources, never the internal metadata.
+The model picks the keys with full semantic context (it knows what's a name
+and what's just a sentence-start capital), which is robust across languages
+without any server-side stop list.
+
+If the model omits or mangles the `Keys:` block (small quantized models
+sometimes do), the server falls back to the raw search query as the sole key.
+That key rarely matches naturally, but at least the entry exists and the
+user can edit its keys from the lorebook panel — degraded, not broken.
 
 ## Configuration reference
 

--- a/docs/ORACLE.md
+++ b/docs/ORACLE.md
@@ -1,0 +1,376 @@
+# Oracle Agent — Web Search + Character Memory
+
+Oracle lets a user trigger a live web search from inside a chat message,
+injects the findings into the character's context so the character can reply
+with fresh information, then distils the **character's takeaway** (preferences,
+choices, opinions voiced) and stores that as a minimalist lorebook entry for
+future chats.
+
+It is not a factual encyclopedia feature. It is a roleplay-memory feature that
+uses web search as raw material.
+
+## At a glance
+
+- **Trigger**: user writes `<search>topic</search>` anywhere in their message.
+- **Provider**: Tavily (free tier, 1000 searches/month, no credit card).
+- **Model used**: the chat's current LLM (no extra connection required).
+- **Cost per search**: 1 Tavily call + 2 LLM calls (summariser + takeaway extractor). Total latency ~3-8s, non-blocking for the user response.
+- **Persistence**: one short memory sentence per search **only when the character committed to something**. Nothing stored otherwise.
+
+## Quick setup
+
+1. Create a free Tavily key at [tavily.com](https://tavily.com).
+2. In Marinara, open the **Connections** panel → expand the **Oracle (Web Search)** card.
+3. Paste the key, toggle **On**, click **Test connection** to verify.
+4. Open the **Agents** panel → enable the **Oracle** agent.
+5. In a chat, send a message containing `<search>your topic</search>`. The tag is stripped before the character sees it.
+
+Conversation-mode chats work out of the box — Oracle bypasses the chat's
+`enableAgents` gate because it's user-triggered (see design notes below).
+
+## End-to-end flow
+
+```
+┌────────────────────────────────────────────────────────────────────────┐
+│   USER: "…<search>topic</search>…"                                     │
+└───────────────────────────────┬────────────────────────────────────────┘
+                                ▼
+          ┌───────────────────────────────────────────┐
+          │  extractSearchQueries()                    │
+          │  - parses <search> tags                    │
+          │  - strips tags from userMessage            │
+          │  - synthesises a hook if message is empty  │
+          └────────────────────┬──────────────────────┘
+                               ▼
+          ┌───────────────────────────────────────────┐
+          │  Oracle resolution                         │
+          │  1. resolvedAgents.find("oracle")          │
+          │  2. FALLBACK: agentsStore.getByType(...)   │
+          │     — bypass when chat.enableAgents=false  │
+          └────────────────────┬──────────────────────┘
+                               │ (agent ready + OracleConfig loaded)
+                               ▼
+          ┌───────────────────────────────────────────┐
+          │  Tavily search                             │
+          │  - search_depth: "advanced"                │
+          │  - AbortSignal timeout (8s default)        │
+          └────────────────────┬──────────────────────┘
+                               │ (answer + up to maxResults passages)
+                               ▼
+          ┌───────────────────────────────────────────┐
+          │  Summariser (executeAgent with STERILE ctx)│
+          │  - recentMessages=[], persona=null,        │
+          │    characters=[], mainResponse=null        │
+          │  - strict anti-hallucination system prompt │
+          │  - <source_material>, <search_query>,      │
+          │    <source_urls>, <summary_token_cap>      │
+          └────────────────────┬──────────────────────┘
+                               │ (factual summary + Sources footer)
+                               ▼
+          ┌───────────────────────────────────────────┐
+          │  Inject <web_search>…</web_search>         │
+          │  onto the last user message in the prompt  │
+          └────────────────────┬──────────────────────┘
+                               ▼
+          ╔═══════════════════════════════════════════╗
+          ║          MAIN CHARACTER GENERATION         ║
+          ║   (streams to user, uses <web_search>)    ║
+          ╚════════════════════╤══════════════════════╝
+                               │ (combinedResponse saved)
+                               ▼
+          ┌───────────────────────────────────────────┐
+          │  Takeaway extractor                        │
+          │  Inputs: findings (no footer), response,   │
+          │          query, character name             │
+          │  Output: one sentence OR "NO_MEMORY"       │
+          └────────────────────┬──────────────────────┘
+                               │
+               ┌───────────────┴───────────────┐
+               │                                │
+           NO_MEMORY                    sentence produced
+               │                                │
+               ▼                                ▼
+            (skip)           ┌──────────────────────────────────┐
+                             │ Lorebook target resolution        │
+                             │ 1. LK-configured target            │
+                             │ 2. existing character-scoped book  │
+                             │ 3. new character-scoped book       │
+                             │ 4. fallback chat-scoped (create)   │
+                             └───────────────┬──────────────────┘
+                                             ▼
+                             ┌──────────────────────────────────┐
+                             │ persistLorebookKeeperUpdates()   │
+                             │ content = takeaway sentence       │
+                             │ keys    = proper-nouns + query    │
+                             │ tag     = "web-research"          │
+                             └──────────────────────────────────┘
+```
+
+## File map
+
+| Path | Role |
+| --- | --- |
+| `packages/shared/src/types/oracle.ts` | `OracleConfig` Zod schema, shared constants (`ORACLE_SETTINGS_KEY`, `ORACLE_LOREBOOK_TAG`, providers list) |
+| `packages/shared/src/constants/agent-prompts.ts` | Default system prompt for the summariser |
+| `packages/shared/src/types/agent.ts` | `BUILT_IN_AGENTS` entry + `web_search` tool definition |
+| `packages/server/src/services/agents/oracle.ts` | `executeOracle()` + `extractCharacterTakeaway()` + summary splitting + key extraction |
+| `packages/server/src/services/agents/web-search/tavily-provider.ts` | Tavily HTTP wrapper |
+| `packages/server/src/services/agents/web-search/web-search-provider.ts` | Provider interface (pluggable) |
+| `packages/server/src/services/agents/web-search/web-search-provider-factory.ts` | Provider factory with exhaustiveness check |
+| `packages/server/src/services/agents/web-search/config.ts` | Load/save `OracleConfig` with AES-256-GCM-encrypted key |
+| `packages/server/src/routes/oracle.routes.ts` | `GET/PUT /api/oracle/config`, `POST /api/oracle/test` |
+| `packages/server/src/services/conversation/character-commands.ts` | `extractSearchQueries()` helper |
+| `packages/server/src/routes/generate.routes.ts` | Oracle integration (trigger extraction, bypass resolution, parallel execution, injection, post-gen persistence) |
+| `packages/server/src/services/agents/agent-executor.ts` | Rendering of `<source_material>`, `<search_query>`, `<source_urls>`, `<summary_token_cap>` blocks |
+| `packages/server/src/routes/generate/lorebook-keeper-utils.ts` | Extended `persistLorebookKeeperUpdates()` with optional `source` override |
+| `packages/client/src/hooks/use-oracle.ts` | React Query hooks for config/test |
+| `packages/client/src/components/panels/settings/OracleConfigCard.tsx` | Settings UI, mounted in `ConnectionsPanel.tsx` |
+
+## Design decisions
+
+### Why Oracle is a built-in agent, not a Custom Agent
+
+Marinara already exposes two extension surfaces: **Custom Agents**
+(user-defined entries in `agent_configs` with a free-form prompt template,
+configurable phase, and optional tools) and **Custom Tools** (webhook /
+static / script execution via `custom-tools.routes.ts`). On paper, Oracle
+could be modeled as a Custom Agent calling a Custom Tool over a Tavily
+webhook.
+
+In practice, Oracle relies on hooks the current Custom Agent system
+doesn't expose:
+
+1. **Message preprocessing** — extracting `<search>` tags from the user
+   message *before* it is saved or sent to the main LLM. Custom Agents
+   only see the message after it lands.
+2. **User-triggered bypass of `enableAgents`** — Oracle must run in
+   conversation mode where `enableAgents` is hidden and defaults to
+   `false`. Custom Agents are bound by that flag.
+3. **Encrypted global config with masking** — Oracle stores a provider
+   API key in `app_settings` with the same AES helper used for
+   connection keys, and the UI shows a mask. Custom Tool webhooks store
+   credentials too, but without the encryption + masking pattern.
+4. **Post-generation lorebook persistence with takeaway extraction** —
+   the second LLM call distils the *character's commitment*, not the
+   raw findings. There's no generic post-gen hook agents can register.
+5. **Sterile execution context** — Oracle's summariser deliberately drops
+   `recentMessages`, `persona`, `characters`. Custom Agents inherit the
+   chat context wholesale.
+
+Abstracting those hooks into the Custom Agent surface is a worthwhile
+refactor for the future (a second built-in agent that shares 2+ of these
+hooks would justify it), but doing it inside this PR would multiply the
+diff and the review surface. Oracle ships as a built-in for the MVP.
+
+### Why pre_generation phase
+
+The flow is search → inject → character replies. The character must see the
+findings **before** producing output, so Oracle cannot run post-gen or parallel.
+`pre_generation` is the correct phase and matches the existing
+`knowledge-retrieval` agent's pattern.
+
+### Why explicit `<search>` trigger instead of auto-detection
+
+An auto-detect classifier (small LLM scanning each user message for
+"information gaps") would:
+- Cost an extra LLM call on every turn
+- Trigger false positives on fantasy/fiction topics
+- Burn user trust when it fires unexpectedly
+
+Explicit `<search>` is deterministic, free, and user-controlled. Auto-detection
+is deferred to a future phase behind an opt-in toggle.
+
+### Why `<search>` tags instead of a `/web_search` slash command
+
+Marinara already has a slash-command system (`packages/client/src/lib/slash-commands.ts`)
+with `/roll`, `/sys`, `/narrator`, `/scene`, etc. A `/web_search query --save`
+command would be a coherent fit and would offer:
+
+- Discoverability via `/help` and autocomplete.
+- Clean per-call flag overrides (`--no-save`, `--max=5`).
+- Loud failure on typos (`/web_serch` errors immediately).
+
+The reason we picked the inline tag is that Oracle is not a one-shot
+utility ("give me info"); it is a **turn augmenter** ("let the
+character reply to *this* message *with* this info in hand"). With a
+slash command the natural flow becomes:
+
+    User:  /web_search films this week
+    System: [results displayed]
+    User:  Which one do you want to see?
+    Char:  ???  ← where do the findings live in the character's context?
+
+Either you re-inject the findings retroactively into the next user
+message (which is what `<search>` already does, in two steps instead of
+one), or you generate a filler reply, or you ask the user to copy-paste.
+None is as clean as fusing the search into the message that *prompts*
+the character to use it:
+
+    User:  Which one do you want to see? <search>films this week</search>
+           ↓ server strip + inline injection + main LLM call
+    Char:  The new Dune looks solid, want to try the 8pm showing?
+
+Both surfaces can coexist: a `/web_search` command calling the same
+`executeOracle()` backend would be a small follow-up for users who only
+want the lookup utility outside an in-character message.
+
+### Why Tavily as the default provider
+
+Tavily is designed for LLM agents: it returns pre-cleaned text extracts plus a
+synthesized `answer` field, dramatically reducing token bloat compared to raw
+HTML scraping. Its free tier (1000/month, no credit card) is generous for
+roleplay usage. The code is abstracted behind `WebSearchProvider` so Serper,
+Brave, or a local SearXNG can be added without touching the caller.
+
+### Why the summariser uses a STERILE context
+
+The summariser call inherits the chat's LLM — usually a roleplay-tuned model
+like Gemma. When we passed the full chat context (recent messages, persona,
+characters), the model kept continuing the roleplay instead of extracting
+facts. First run produced: *"ok ok je vais aller voir ça direct ! 🏃‍♀️💨 je veux
+trop savoir qui est la plus stylée lol"* — roleplay, not a summary.
+
+Fix: the summariser receives a context with `recentMessages=[]`,
+`persona=null`, `characters=[]`, `mainResponse=null`, `chatSummary=null`. Only
+the source material and the strict anti-hallucination prompt. Result: neutral
+factual prose.
+
+### Why the summary is split into body + Sources footer
+
+The same summary serves two lifecycles:
+
+- **In-turn injection** (ephemeral) — keeps the `Sources:` footer so you can
+  trace provenance while debugging the current response.
+- **Lorebook persistence** (long-term) — strips the footer. URLs in a memory
+  entry pollute the character's context when the entry re-activates later.
+
+### Why the takeaway extractor instead of persisting raw facts
+
+A memory is not an encyclopedia clip. If the user searches for "quintuplets"
+and Mari replies *"I really like Nino, tsundere energy"*, the useful memory is
+*"Mari picked Nino as her favorite."* — not the full list of sisters with
+Wikipedia URLs.
+
+The takeaway extractor runs **after** the character generates its reply. It
+reads: the character's response, the factual findings, the original query. It
+outputs one short sentence in third-person past tense describing what the
+character personally committed to — or `NO_MEMORY` when the character only
+acknowledged the information without voicing a preference. Only genuine
+commitments end up in the lorebook.
+
+This is the core design intent: maximise roleplay continuity, not
+factual recall.
+
+### Why the lorebook is character-scoped (not chat-scoped)
+
+Memories should persist across conversations with the same character. A
+chat-scoped lorebook loses everything when the user opens a fresh chat. So:
+
+- Single-character chat → create/reuse a character-scoped lorebook named
+  `Oracle knowledge (<character name>)` with `sourceAgentId: "oracle"`.
+- Multi-character or zero-character chats → fall back to chat-scoped
+  auto-creation (conservative, avoids cross-contamination).
+
+Future Oracle runs with the same character reuse that one lorebook, so entries
+accumulate instead of spawning a new book per turn.
+
+### Why Oracle bypasses the chat's `enableAgents` gate
+
+In conversation mode, Marinara's settings drawer hides the "Enable Agents"
+toggle entirely. That toggle is per-chat and defaults to `false`, meaning no
+agent — including Oracle — runs in conversation chats. The toggle is hidden
+because traditional agents (world-state, character-tracker, VN expressions) are
+irrelevant in conversation mode.
+
+Oracle is different: it's user-triggered via an explicit tag that can only
+come from the user's own message. Letting it run without an enable toggle
+preserves the "no silent magic" principle — the user literally has to type
+`<search>` to get a search.
+
+Implementation: `generate.routes.ts` falls back to
+`agentsStore.getByType("oracle")` when `resolvedAgents` doesn't contain it,
+and reuses the same connection-resolution priority chain the normal pipeline
+uses.
+
+### Why two LLM calls per search (summariser + takeaway)
+
+Folding both steps into a single structured-output call would complicate
+streaming and coupling. Two focused calls with clean system prompts are more
+robust to small quantized models like Gemma-4-26b. Total latency is ~3-8s and
+the takeaway extractor runs **after** the user-visible response, so the user
+never waits on it.
+
+## Configuration reference
+
+| Field | Default | Range | Purpose |
+| --- | --- | --- | --- |
+| `enabled` | `false` | bool | Master toggle for the Oracle feature |
+| `provider` | `tavily` | enum | Web search provider (only `tavily` in MVP) |
+| `apiKey` | `""` | string | Provider API key, encrypted at rest (AES-256-GCM) |
+| `maxResults` | `3` | 1–10 | How many search results Tavily returns per query |
+| `summaryTokenCap` | `400` | 100–2000 | Upper bound on the summariser's output length |
+| `timeoutMs` | `8000` | 2000–30000 | Fetch timeout; on expiry, generation proceeds with an empty injection |
+| `autoPersist` | `true` | bool | Run the takeaway extractor and persist commitments to the lorebook |
+
+Configuration is stored as JSON under the `oracle` key of the `appSettings`
+table. The API key is encrypted at rest by the same project-wide helper used
+for TTS and connection keys.
+
+## Trigger syntax
+
+| Message text | Behaviour |
+| --- | --- |
+| `Hi! <search>tallest building in Tokyo</search> What do you think?` | Tag is stripped; user message becomes `"Hi! What do you think?"`; Tavily runs; findings appended as `<web_search>…</web_search>` onto that user message |
+| `<search>tallest building in Tokyo</search>` (tag alone) | Stripped user content is empty → no user bubble saved to chat history. The LLM prompt gets a synthetic ephemeral user message carrying the query as `<user_intent query="…">` plus the `<web_search>` block, so the character still has an anchor. Nothing about this synthetic message leaks back into the DB |
+| `Multiple <search>A</search> queries <search>B</search> in one message` | Only the first query runs in MVP (both are detected; additional queries are logged but skipped to bound latency and token cost) |
+| No `<search>` tag | Oracle does nothing |
+
+## Failure modes & what happens
+
+| Scenario | Behaviour |
+| --- | --- |
+| Oracle agent not created in `Agents` panel | Search silently skipped, no log noise |
+| `enabled=false` or no API key | Log: *"Agent enabled but config missing — skipping"*, generation proceeds normally |
+| Tavily returns 0 results | Empty injection, character replies without web context |
+| Tavily timeout | Log warning, empty injection, generation proceeds |
+| Summariser returns `"No relevant information found."` | Injection empty, persistence skipped |
+| Summariser returns empty text | Persistence skipped (not informative) |
+| Character made no durable commitment | Takeaway returns `NO_MEMORY`, persistence skipped |
+| Lorebook creation fails | Log: *"Persist FAILED — targetLorebookId returned null"*, generation unaffected |
+
+## SSE events seen by the client
+
+During the search, the server emits:
+
+- `agent_start` with `agentType: "oracle"` — UI can show a "searching the web..." indicator.
+- `agent_result` with `agentType: "oracle"`, `resultType: "context_injection"`, `data: { text: <summary with Sources footer> }` — UI can render sources attribution alongside the response.
+
+The current client renders these via the generic `use-generate.ts` handler.
+
+## Extending with a new provider
+
+1. Add the provider identifier to `ORACLE_PROVIDERS` in `packages/shared/src/types/oracle.ts`.
+2. Create `packages/server/src/services/agents/web-search/<name>-provider.ts` implementing `WebSearchProvider`.
+3. Add a branch in `getWebSearchProvider()` (the exhaustiveness check will fail to compile until you do).
+4. Add the provider to the dropdown in `OracleConfigCard.tsx`.
+
+No changes needed to the call site in `generate.routes.ts`.
+
+## Known limitations
+
+- **Single query per turn** — the MVP processes only the first `<search>` tag per user message. Multi-query support would multiply Tavily calls and is deferred.
+- **Context stripping in the summariser is a hard override** — if you ever want Oracle to know the roleplay context (e.g. to filter web results by relevance to the character's personality), you'll need to reintroduce a curated subset. Right now it's all-or-nothing neutral.
+- **Multi-character chats fall back to chat-scope** — no heuristic picks one character when several are involved. A user-selectable "primary character for Oracle memories" setting would solve this.
+- **No deduplication across turns** — if the user re-runs the same `<search>`, Oracle re-fetches Tavily and re-runs the summariser. A 24h cache keyed by `(chatId, query)` would cut cost; not implemented because roleplay is low-volume.
+- **The takeaway extractor uses the same LLM as the main response** — on a quantized 26B model it's fine; on a tiny 3B model the takeaway quality degrades. Users can override Oracle's connection to a more capable model via the Agents panel.
+
+## Future work
+
+Candidate improvements, roughly ordered by user value:
+
+1. **Auto-detection mode** behind a toggle — small-model classifier that decides when a search is warranted, plus a "confirm before searching" UI prompt.
+2. **SearXNG adapter** — zero-cost self-hosted provider for users who don't want commercial API dependencies.
+3. **DuckDuckGo Instant Answer adapter** — free, no key; limited to encyclopedic queries but useful as a fallback.
+4. **Multi-query support** — fan out concurrently, merge summaries, produce a single takeaway.
+5. **Vector memory integration** — push takeaways into `memory-recall.ts` for semantic recall instead of keyword matching.
+6. **Search-history panel** — UI listing of past Oracle runs per character, with the ability to pin / edit / delete individual takeaways.

--- a/packages/client/src/components/panels/ConnectionsPanel.tsx
+++ b/packages/client/src/components/panels/ConnectionsPanel.tsx
@@ -18,6 +18,7 @@ import { Plus, Trash2, Link, Check, Shuffle, ExternalLink, X, Copy, BrainCircuit
 import { cn } from "../../lib/utils";
 import { toast } from "sonner";
 import { TTSConfigCard } from "./settings/TTSConfigCard";
+import { OracleConfigCard } from "./settings/OracleConfigCard";
 
 /** Provider → gradient color pair for connection icons. */
 const PROVIDER_COLORS: Record<string, { from: string; to: string; ring: string; badge: string }> = {
@@ -270,6 +271,9 @@ export function ConnectionsPanel() {
 
       {/* ── Text to Speech ── */}
       <TTSConfigCard />
+
+      {/* ── Oracle (Web Search) ── */}
+      <OracleConfigCard />
 
       <button
         onClick={() => openModal("create-connection")}

--- a/packages/client/src/components/panels/settings/OracleConfigCard.tsx
+++ b/packages/client/src/components/panels/settings/OracleConfigCard.tsx
@@ -1,0 +1,390 @@
+// ──────────────────────────────────────────────
+// Oracle Configuration Card (Connections Panel)
+// ──────────────────────────────────────────────
+// Exposes the Oracle agent's web-search config: provider, API key, result
+// count, summary token cap, and auto-persist toggle. Mirrors the TTSConfigCard
+// layout — debounced auto-save, masked key, expand/collapse.
+// ──────────────────────────────────────────────
+import { useState, useEffect, useRef } from "react";
+import {
+  Globe2,
+  Key,
+  Check,
+  Loader2,
+  ChevronDown,
+  ChevronUp,
+  FlaskConical,
+} from "lucide-react";
+import { cn } from "../../../lib/utils";
+import { toast } from "sonner";
+import {
+  useOracleConfig,
+  useUpdateOracleConfig,
+  useTestOracleConnection,
+  ORACLE_API_KEY_MASK,
+} from "../../../hooks/use-oracle";
+import type { OracleConfig } from "@marinara-engine/shared";
+import { ORACLE_PROVIDERS } from "@marinara-engine/shared";
+import { HelpTooltip } from "../../ui/HelpTooltip";
+
+// ── Sub-components ───────────────────────────────
+
+function FieldRow({
+  label,
+  help,
+  children,
+}: {
+  label: string;
+  help?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center gap-1">
+        <span className="text-xs font-medium text-[var(--foreground)]">{label}</span>
+        {help && <HelpTooltip text={help} />}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+const INPUT_CLS =
+  "w-full rounded-xl bg-[var(--secondary)] px-3 py-2.5 text-sm ring-1 ring-[var(--border)] placeholder:text-[var(--muted-foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]";
+
+function ToggleRow({
+  label,
+  checked,
+  onChange,
+  help,
+}: {
+  label: string;
+  checked: boolean;
+  onChange: (v: boolean) => void;
+  help?: string;
+}) {
+  return (
+    <label className="flex cursor-pointer items-center justify-between rounded-lg p-1.5 transition-colors hover:bg-[var(--secondary)]/50">
+      <div className="flex items-center gap-1.5">
+        <span className="text-xs">{label}</span>
+        {help && <HelpTooltip text={help} />}
+      </div>
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+        className="h-3.5 w-3.5 rounded border-[var(--border)] accent-sky-400"
+      />
+    </label>
+  );
+}
+
+// ── Main card ─────────────────────────────────────
+
+export function OracleConfigCard() {
+  const { data: savedConfig, isLoading } = useOracleConfig();
+  const updateConfig = useUpdateOracleConfig();
+  const testConnection = useTestOracleConnection();
+
+  // Local draft state
+  const [enabled, setEnabled] = useState(false);
+  const [provider, setProvider] = useState<OracleConfig["provider"]>("tavily");
+  const [apiKey, setApiKey] = useState("");
+  const [maxResults, setMaxResults] = useState(3);
+  const [summaryTokenCap, setSummaryTokenCap] = useState(400);
+  const [timeoutMs, setTimeoutMs] = useState(8000);
+  const [autoPersist, setAutoPersist] = useState(true);
+
+  const [expanded, setExpanded] = useState(false);
+  const [saveStatus, setSaveStatus] = useState<"idle" | "saving" | "saved" | "error">("idle");
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Populate draft from server on load
+  useEffect(() => {
+    if (!savedConfig) return;
+    setEnabled(savedConfig.enabled);
+    setProvider(savedConfig.provider);
+    setApiKey(savedConfig.apiKey); // masked value from server
+    setMaxResults(savedConfig.maxResults);
+    setSummaryTokenCap(savedConfig.summaryTokenCap);
+    setTimeoutMs(savedConfig.timeoutMs);
+    setAutoPersist(savedConfig.autoPersist);
+    setSaveStatus("idle");
+  }, [savedConfig]);
+
+  // Clear debounce timer on unmount
+  useEffect(() => () => { if (saveTimerRef.current) clearTimeout(saveTimerRef.current); }, []);
+
+  const mark = (overrides?: Partial<OracleConfig>) => {
+    if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+    setSaveStatus("idle");
+    const payload: OracleConfig = {
+      enabled,
+      provider,
+      apiKey: apiKey === ORACLE_API_KEY_MASK ? ORACLE_API_KEY_MASK : apiKey,
+      maxResults,
+      summaryTokenCap,
+      timeoutMs,
+      autoPersist,
+      ...overrides,
+    };
+    saveTimerRef.current = setTimeout(async () => {
+      setSaveStatus("saving");
+      try {
+        await updateConfig.mutateAsync(payload);
+        setSaveStatus("saved");
+        setTimeout(() => setSaveStatus((s) => (s === "saved" ? "idle" : s)), 2000);
+      } catch {
+        setSaveStatus("error");
+        toast.error("Failed to save Oracle settings.");
+      }
+    }, 600);
+  };
+
+  const handleTest = async () => {
+    try {
+      const result = await testConnection.mutateAsync();
+      if (result.ok) {
+        toast.success(`Connection OK — got ${result.resultCount} result${result.resultCount === 1 ? "" : "s"}.`);
+      } else {
+        toast.error(`Test failed: ${result.error ?? "Unknown error"}`);
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Test request failed";
+      toast.error(msg);
+    }
+  };
+
+  if (isLoading) return null;
+
+  return (
+    <div
+      className={cn(
+        "rounded-xl border border-sky-400/20 bg-gradient-to-br from-sky-500/5 to-indigo-500/5 p-3 transition-all",
+        expanded && "border-sky-400/30",
+      )}
+    >
+      {/* ── Header ── */}
+      <div className="flex items-center gap-2.5">
+        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-sky-400 to-indigo-500 text-white shadow-sm">
+          <Globe2 size="1rem" />
+        </div>
+
+        <div className="min-w-0 flex-1">
+          <div className="text-sm font-medium">Oracle (Web Search)</div>
+          <div className="text-[0.6875rem] text-[var(--muted-foreground)]">
+            {enabled
+              ? `${provider} · ${maxResults} result${maxResults === 1 ? "" : "s"} · summary ≤ ${summaryTokenCap} tok`
+              : "Type <search>topic</search> in a message to trigger"}
+          </div>
+        </div>
+
+        <div className="flex items-center gap-1.5">
+          {/* Enable toggle */}
+          <label className="flex cursor-pointer items-center gap-1.5" title={enabled ? "Disable Oracle" : "Enable Oracle"}>
+            <span className="text-[0.6875rem] text-[var(--muted-foreground)]">{enabled ? "On" : "Off"}</span>
+            <div className="relative">
+              <input
+                type="checkbox"
+                checked={enabled}
+                onChange={(e) => {
+                  setEnabled(e.target.checked);
+                  mark({ enabled: e.target.checked });
+                }}
+                className="peer sr-only"
+              />
+              <div className="h-5 w-9 rounded-full bg-[var(--border)] transition-colors peer-checked:bg-sky-400/70" />
+              <div className="absolute left-0.5 top-0.5 h-4 w-4 rounded-full bg-white shadow transition-transform peer-checked:translate-x-4" />
+            </div>
+          </label>
+
+          <button
+            onClick={() => setExpanded((v) => !v)}
+            className="rounded-lg p-1 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--secondary)] hover:text-[var(--foreground)]"
+            title={expanded ? "Collapse" : "Expand"}
+          >
+            {expanded ? <ChevronUp size="0.875rem" /> : <ChevronDown size="0.875rem" />}
+          </button>
+        </div>
+      </div>
+
+      {/* ── Expanded body ── */}
+      {expanded && (
+        <div className="mt-4 space-y-4">
+          {/* Provider */}
+          <FieldRow
+            label="Provider"
+            help="Which web-search API to call. Tavily is designed for LLM agents and returns pre-summarized content, reducing token bloat."
+          >
+            <select
+              value={provider}
+              onChange={(e) => {
+                const next = e.target.value as OracleConfig["provider"];
+                setProvider(next);
+                mark({ provider: next });
+              }}
+              className={cn(INPUT_CLS, "cursor-pointer appearance-none")}
+            >
+              {ORACLE_PROVIDERS.map((p) => (
+                <option key={p} value={p}>
+                  {p}
+                </option>
+              ))}
+            </select>
+          </FieldRow>
+
+          {/* API Key */}
+          <FieldRow
+            label="API Key"
+            help="Your Tavily API key (free tier: 1000 searches/month at tavily.com). Encrypted at rest. Keep the masked value to preserve the current key, or clear the field to remove it."
+          >
+            <div className="relative">
+              <Key size="0.875rem" className="absolute left-3 top-1/2 -translate-y-1/2 text-sky-400" />
+              <input
+                value={apiKey}
+                onChange={(e) => {
+                  setApiKey(e.target.value);
+                  mark({ apiKey: e.target.value === ORACLE_API_KEY_MASK ? ORACLE_API_KEY_MASK : e.target.value });
+                }}
+                type="password"
+                className={cn(INPUT_CLS, "pl-8")}
+                placeholder="Enter API key or clear to remove"
+              />
+            </div>
+            <p className="text-[0.625rem] text-[var(--muted-foreground)]">
+              Encrypted at rest · Keep the masked value to preserve the current key
+            </p>
+          </FieldRow>
+
+          {/* Max results */}
+          <FieldRow
+            label={`Max results — ${maxResults}`}
+            help="Number of raw search results fetched per query. More results = richer summary but higher token cost."
+          >
+            <input
+              type="range"
+              min={1}
+              max={10}
+              step={1}
+              value={maxResults}
+              onChange={(e) => {
+                const next = parseInt(e.target.value, 10);
+                setMaxResults(next);
+                mark({ maxResults: next });
+              }}
+              className="w-full accent-sky-400"
+            />
+            <div className="flex justify-between text-[0.6rem] text-[var(--muted-foreground)]">
+              <span>1</span>
+              <span>5</span>
+              <span>10</span>
+            </div>
+          </FieldRow>
+
+          {/* Summary token cap */}
+          <FieldRow
+            label={`Summary token cap — ${summaryTokenCap}`}
+            help="Hard cap on the summary length injected into the character's prompt. Keeps context budget under control."
+          >
+            <input
+              type="range"
+              min={100}
+              max={2000}
+              step={50}
+              value={summaryTokenCap}
+              onChange={(e) => {
+                const next = parseInt(e.target.value, 10);
+                setSummaryTokenCap(next);
+                mark({ summaryTokenCap: next });
+              }}
+              className="w-full accent-sky-400"
+            />
+            <div className="flex justify-between text-[0.6rem] text-[var(--muted-foreground)]">
+              <span>100</span>
+              <span>1000</span>
+              <span>2000</span>
+            </div>
+          </FieldRow>
+
+          {/* Timeout */}
+          <FieldRow
+            label={`Timeout — ${(timeoutMs / 1000).toFixed(1)}s`}
+            help="Max time to wait for the web-search API before giving up. If exceeded, generation proceeds without web results."
+          >
+            <input
+              type="range"
+              min={2000}
+              max={30_000}
+              step={500}
+              value={timeoutMs}
+              onChange={(e) => {
+                const next = parseInt(e.target.value, 10);
+                setTimeoutMs(next);
+                mark({ timeoutMs: next });
+              }}
+              className="w-full accent-sky-400"
+            />
+            <div className="flex justify-between text-[0.6rem] text-[var(--muted-foreground)]">
+              <span>2s</span>
+              <span>15s</span>
+              <span>30s</span>
+            </div>
+          </FieldRow>
+
+          {/* Auto-persist */}
+          <div className="space-y-1">
+            <span className="text-xs font-medium">Persistence</span>
+            <ToggleRow
+              label="Save summaries to lorebook"
+              help="Each web-search summary is automatically stored as a lorebook entry tagged 'web-research', making it available to the character on later turns without re-searching."
+              checked={autoPersist}
+              onChange={(v) => {
+                setAutoPersist(v);
+                mark({ autoPersist: v });
+              }}
+            />
+          </div>
+
+          {/* Actions */}
+          <div className="flex items-center gap-2 pt-1">
+            <button
+              onClick={handleTest}
+              disabled={!savedConfig?.enabled || testConnection.isPending}
+              className={cn(
+                "flex items-center gap-1.5 rounded-xl px-3 py-2 text-xs ring-1 transition-all",
+                "bg-[var(--secondary)] text-[var(--muted-foreground)] ring-[var(--border)] hover:text-[var(--foreground)] hover:ring-sky-400/60",
+                (!savedConfig?.enabled || testConnection.isPending) && "cursor-not-allowed opacity-50",
+              )}
+              title="Run a quick 1-result search to verify the API key"
+            >
+              {testConnection.isPending ? (
+                <Loader2 size="0.75rem" className="animate-spin" />
+              ) : (
+                <FlaskConical size="0.75rem" />
+              )}
+              {testConnection.isPending ? "Testing…" : "Test connection"}
+            </button>
+
+            <div className="flex-1" />
+
+            {saveStatus === "saving" && (
+              <span className="flex items-center gap-1 text-[0.6875rem] text-[var(--muted-foreground)]">
+                <Loader2 size="0.625rem" className="animate-spin" />
+                Saving…
+              </span>
+            )}
+            {saveStatus === "saved" && (
+              <span className="flex items-center gap-1 text-[0.6875rem] text-emerald-400">
+                <Check size="0.625rem" />
+                Saved
+              </span>
+            )}
+            {saveStatus === "error" && (
+              <span className="text-[0.6875rem] text-rose-400">Save failed</span>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/client/src/hooks/use-oracle.ts
+++ b/packages/client/src/hooks/use-oracle.ts
@@ -1,0 +1,37 @@
+// ──────────────────────────────────────────────
+// Hook: Oracle Config & Test
+// ──────────────────────────────────────────────
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "../lib/api-client";
+import type { OracleConfig, OracleTestResponse } from "@marinara-engine/shared";
+import { ORACLE_API_KEY_MASK } from "@marinara-engine/shared";
+
+const KEYS = {
+  config: ["oracle", "config"] as const,
+};
+
+export function useOracleConfig() {
+  return useQuery({
+    queryKey: KEYS.config,
+    queryFn: () => api.get<OracleConfig>("/oracle/config"),
+    staleTime: 60_000,
+  });
+}
+
+export function useUpdateOracleConfig() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (config: OracleConfig) => api.put<void>("/oracle/config", config),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: KEYS.config });
+    },
+  });
+}
+
+export function useTestOracleConnection() {
+  return useMutation({
+    mutationFn: () => api.post<OracleTestResponse>("/oracle/test", {}),
+  });
+}
+
+export { ORACLE_API_KEY_MASK };

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -6356,6 +6356,13 @@ export async function generateRoutes(app: FastifyInstance) {
               content: takeaway,
               keys: payload.keys,
               tag: ORACLE_LOREBOOK_TAG,
+              // Always-on injection: Oracle entries are character-scoped, so they
+              // are only ever in scope when the user is talking to that character —
+              // and when in scope, the character should always have access to its
+              // accumulated takeaways without depending on the user echoing exact
+              // entity names ("which film were we going to see again?" should still
+              // recall a film picked last week).
+              constant: true,
             }));
 
             // Resolve the preferred target lorebook. Priority:

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -52,6 +52,7 @@ import { getLocalSidecarProvider, LOCAL_SIDECAR_MODEL } from "../services/llm/lo
 import {
   parseCharacterCommands,
   parseDuration,
+  extractSearchQueries,
   type CharacterCommand,
   type ScheduleUpdateCommand,
   type CrossPostCommand,
@@ -70,6 +71,10 @@ import {
 } from "../services/conversation/character-commands.js";
 import { MARI_ASSISTANT_PROMPT } from "../db/seed-mari.js";
 import { executeKnowledgeRetrieval } from "../services/agents/knowledge-retrieval.js";
+import { executeOracle, extractCharacterTakeaway, type OraclePersistPayload } from "../services/agents/oracle.js";
+import { loadOracleConfig } from "../services/agents/web-search/config.js";
+import { createAppSettingsStorage } from "../services/storage/app-settings.storage.js";
+import { ORACLE_LOREBOOK_TAG, type OracleConfig } from "@marinara-engine/shared";
 import { extractFileText, getSourceFilePath } from "./knowledge-sources.routes.js";
 import { gameStateSnapshots as gameStateSnapshotsTable } from "../db/schema/index.js";
 import { chats as chatsTable } from "../db/schema/index.js";
@@ -309,6 +314,21 @@ export async function generateRoutes(app: FastifyInstance) {
    */
   app.post("/", async (req, reply) => {
     const input = generateRequestSchema.parse(req.body);
+
+    // ── Oracle trigger extraction ──
+    // Pull any <search>...</search> tags out of the user message BEFORE it reaches
+    // the main LLM. Storing both lists here keeps the rest of the pipeline agnostic:
+    // the character never sees the raw tags, and the Oracle block downstream picks
+    // up the queries only if the agent is enabled and configured.
+    let oracleSearchQueries: string[] = [];
+    if (input.userMessage) {
+      const extracted = extractSearchQueries(input.userMessage);
+      if (extracted.queries.length > 0) {
+        oracleSearchQueries = extracted.queries;
+        input.userMessage = extracted.cleanContent;
+        logger.info("[oracle] Detected %d <search> trigger(s): %j", extracted.queries.length, extracted.queries);
+      }
+    }
 
     // Resolve the chat
     const chat = await chats.getById(input.chatId);
@@ -3352,6 +3372,85 @@ export async function generateRoutes(app: FastifyInstance) {
       }
 
       // ────────────────────────────────────────
+      // Oracle — load config when the user triggered <search> and the agent is on
+      // ────────────────────────────────────────
+      // Oracle is user-triggered (via <search> tags), so it bypasses the chat-level
+      // enableAgents gate — otherwise it would be unreachable in Conversation mode,
+      // where the Agents section of the chat settings drawer is hidden.
+      let oracleAgent: ResolvedAgent | undefined = resolvedAgents.find((a) => a.type === "oracle");
+      if (!oracleAgent && oracleSearchQueries.length > 0) {
+        const oracleRow = await agentsStore.getByType("oracle");
+        if (oracleRow && oracleRow.enabled === "true") {
+          // Resolve provider: per-agent override → default-for-agents → chat connection
+          let bypassProvider = provider;
+          let bypassModel = conn.model;
+          const bypassConnId = (oracleRow.connectionId as string | null) ?? defaultAgentConn?.id ?? null;
+          if (bypassConnId) {
+            const cached = agentProviderCache.get(bypassConnId);
+            if (cached) {
+              bypassProvider = cached.provider;
+              bypassModel = cached.model;
+            } else {
+              const bypassConn = await connections.getWithKey(bypassConnId);
+              if (bypassConn) {
+                const bypassBaseUrl = resolveBaseUrl(bypassConn);
+                if (bypassBaseUrl) {
+                  bypassProvider = createLLMProvider(
+                    bypassConn.provider,
+                    bypassBaseUrl,
+                    bypassConn.apiKey,
+                    bypassConn.maxContext,
+                    bypassConn.openrouterProvider,
+                    bypassConn.maxTokensOverride,
+                  );
+                  bypassModel = bypassConn.model;
+                }
+              }
+            }
+          }
+          oracleAgent = {
+            id: oracleRow.id,
+            type: oracleRow.type,
+            name: oracleRow.name,
+            phase: oracleRow.phase as string,
+            promptTemplate: oracleRow.promptTemplate as string,
+            connectionId: oracleRow.connectionId as string | null,
+            settings: oracleRow.settings ? JSON.parse(oracleRow.settings as string) : {},
+            provider: bypassProvider,
+            model: bypassModel,
+          };
+          logger.info("[oracle] Resolved via enableAgents bypass (user-triggered by <search>)");
+        }
+      }
+
+      let oracleConfig: OracleConfig | null = null;
+      logger.debug(
+        "[oracle] gate — agentInResolved=%s queries=%d resolvedAgentTypes=[%s]",
+        !!oracleAgent,
+        oracleSearchQueries.length,
+        resolvedAgents.map((a) => a.type).join(", "),
+      );
+      if (oracleAgent && oracleSearchQueries.length > 0) {
+        try {
+          const appSettings = createAppSettingsStorage(app.db);
+          const cfg = await loadOracleConfig(appSettings);
+          logger.debug(
+            "[oracle] config loaded — enabled=%s hasKey=%s provider=%s",
+            cfg.enabled,
+            Boolean(cfg.apiKey),
+            cfg.provider,
+          );
+          if (cfg.enabled && cfg.apiKey) {
+            oracleConfig = cfg;
+          } else {
+            logger.info("[oracle] Agent enabled but config missing (disabled or no API key) — skipping");
+          }
+        } catch (err) {
+          logger.warn(err, "[oracle] Failed to load config");
+        }
+      }
+
+      // ────────────────────────────────────────
       // Automated Chat Summary — interval gating
       // ────────────────────────────────────────
       // Only run if the Automated Chat Summary agent is in the pipeline.
@@ -3600,8 +3699,8 @@ export async function generateRoutes(app: FastifyInstance) {
       let contextInjections: AgentInjection[] = [];
       // Static-injection agents don't need LLM calls — they inject prompt text directly
       const STATIC_INJECTION_AGENTS = new Set(["html"]);
-      const SEPARATE_INJECTION_AGENTS = new Set(["knowledge-retrieval"]);
-      const EXCLUDED_FROM_PIPELINE = new Set(["html", "knowledge-retrieval"]);
+      const SEPARATE_INJECTION_AGENTS = new Set(["knowledge-retrieval", "oracle"]);
+      const EXCLUDED_FROM_PIPELINE = new Set(["html", "knowledge-retrieval", "oracle"]);
       const hasPreGenAgents = resolvedAgents.some(
         (a) => a.phase === "pre_generation" && !EXCLUDED_FROM_PIPELINE.has(a.type),
       );
@@ -3613,8 +3712,16 @@ export async function generateRoutes(app: FastifyInstance) {
         !input.regenerateMessageId
       );
       const shouldRunPreGen = hasPreGenAgents && !input.regenerateMessageId;
+      const shouldRunOracle = !!(
+        oracleAgent &&
+        oracleConfig &&
+        oracleSearchQueries.length > 0 &&
+        !input.regenerateMessageId
+      );
+      // Collected across Oracle runs so the post-gen step can persist summaries to the lorebook.
+      const oraclePersistPayloads: OraclePersistPayload[] = [];
 
-      if (shouldRunPreGen || shouldRunKR) {
+      if (shouldRunPreGen || shouldRunKR || shouldRunOracle) {
         sendProgress("agents");
 
         // Build the pre-gen promise
@@ -3670,14 +3777,51 @@ export async function generateRoutes(app: FastifyInstance) {
             })()
           : Promise.resolve(null);
 
-        // Run both in parallel
-        const [preGenResult, krResult] = await Promise.all([preGenPromise, krPromise]);
+        // Build the Oracle promise — MVP processes only the first query per turn
+        // to keep latency and token cost bounded. Multi-query support ships in Phase 2.
+        const oraclePromise = shouldRunOracle
+          ? (async () => {
+              reply.raw.write(
+                `data: ${JSON.stringify({ type: "agent_start", data: { phase: "pre_generation", agentType: "oracle" } })}\n\n`,
+              );
+              const query = oracleSearchQueries[0]!;
+              const oracleExecConfig = {
+                id: oracleAgent!.id,
+                type: oracleAgent!.type,
+                name: oracleAgent!.name,
+                phase: oracleAgent!.phase,
+                promptTemplate: oracleAgent!.promptTemplate,
+                connectionId: oracleAgent!.connectionId,
+                settings: oracleAgent!.settings,
+              };
+              const _tOracle = Date.now();
+              const { result, persist } = await executeOracle({
+                agentConfig: oracleExecConfig,
+                oracleConfig: oracleConfig!,
+                baseContext: agentContext,
+                provider: oracleAgent!.provider,
+                model: oracleAgent!.model,
+                query,
+              });
+              sendAgentEvent(result);
+              if (persist && oracleConfig!.autoPersist) {
+                oraclePersistPayloads.push(persist);
+              }
+              logger.info("[timing] Oracle: %dms", Date.now() - _tOracle);
+              return result;
+            })()
+          : Promise.resolve(null);
+
+        // Run all three in parallel
+        const [preGenResult, krResult, oracleResult] = await Promise.all([preGenPromise, krPromise, oraclePromise]);
         contextInjections = preGenResult;
 
         // ── Failure gate: only block generation if a critical pre-gen agent failed ──
         // The secret-plot-driver shapes narrative direction — generating without
         // it would produce incoherent output. Other agents are enhancement-only.
-        const preGenResults = pipeline.results.filter((r) => r.agentType !== "knowledge-retrieval");
+        const preGenResults = pipeline.results.filter(
+          (r) => r.agentType !== "knowledge-retrieval" && r.agentType !== "oracle",
+        );
         const criticalFailed = preGenResults.filter((r) => !r.success && r.type === "secret_plot");
         const nonCriticalFailed = preGenResults.filter((r) => !r.success && r.type !== "secret_plot");
         if (criticalFailed.length > 0) {
@@ -3760,6 +3904,42 @@ export async function generateRoutes(app: FastifyInstance) {
               finalMessages[finalMessages.length - 1] = { ...last, content: last.content + krWrapped };
             }
             contextInjections.push({ agentType: "knowledge-retrieval", text: krText });
+          }
+        }
+
+        // Inject Oracle output into the prompt (same pattern as KR, distinct wrapper tag)
+        if (oracleResult?.success && oracleResult.data) {
+          const oracleText =
+            typeof oracleResult.data === "string"
+              ? oracleResult.data
+              : ((oracleResult.data as { text?: string })?.text ?? "");
+          if (oracleText) {
+            const oracleQuery = oracleSearchQueries[0] ?? "";
+            const oracleWrapped =
+              wrapFormat === "markdown"
+                ? `\n\n## Web Search\n${oracleText}`
+                : `\n\n<web_search>\n${oracleText}\n</web_search>`;
+            const lastUserIdx = findLastIndex(finalMessages, "user");
+            if (lastUserIdx >= 0) {
+              // The user typed a message alongside the tag — append findings to it.
+              const target = finalMessages[lastUserIdx]!;
+              finalMessages[lastUserIdx] = { ...target, content: target.content + oracleWrapped };
+            } else {
+              // The user typed ONLY <search> tags — no visible user bubble exists.
+              // Create a synthetic last user message so the main LLM has an anchor,
+              // without polluting the chat history (this message is ephemeral, only
+              // used for this turn's prompt assembly).
+              const anchorPrefix = oracleQuery
+                ? wrapFormat === "markdown"
+                  ? `The user searched for: "${oracleQuery}". Respond using the information below.`
+                  : `<user_intent query="${oracleQuery.replace(/"/g, "&quot;")}">The user triggered a web search for the topic above. Use the information inside &lt;web_search&gt; to answer.</user_intent>`
+                : "";
+              finalMessages.push({
+                role: "user",
+                content: `${anchorPrefix}${oracleWrapped}`.trim(),
+              });
+            }
+            contextInjections.push({ agentType: "oracle", text: oracleText });
           }
         }
       } else if (hasPreGenAgents && input.regenerateMessageId) {
@@ -6113,6 +6293,158 @@ export async function generateRoutes(app: FastifyInstance) {
           } catch {
             // Non-critical — don't fail generation if editor errors
           }
+        }
+      }
+
+      // ────────────────────────────────────────
+      // Oracle: persist web-research summaries to the lorebook
+      // ────────────────────────────────────────
+      // Runs unconditionally (not gated by hasPostWork) so it works in
+      // conversation mode where no post-processing agents are active.
+      //
+      // Scoping strategy:
+      //  - Single-character chat → attach to a character-scoped Oracle lorebook
+      //    (reused across future chats with the same character)
+      //  - Multi-character or zero characters → fall back to chat-scoped
+      //    auto-created lorebook (conservative, avoids cross-contamination)
+      if (oraclePersistPayloads.length > 0 && !abortController.signal.aborted && oracleAgent) {
+        try {
+          // Run the character-takeaway extractor per payload. We persist ONLY the
+          // character's commitments (preferences, choices) — not the raw facts —
+          // so future re-injections from the lorebook push roleplay-relevant
+          // memory instead of an encyclopedia dump.
+          const characterName = charInfo[0]?.name ?? "The character";
+          const extractorAgentConfig = {
+            id: oracleAgent.id,
+            type: oracleAgent.type,
+            name: oracleAgent.name,
+            phase: oracleAgent.phase,
+            promptTemplate: oracleAgent.promptTemplate,
+            connectionId: oracleAgent.connectionId,
+            settings: oracleAgent.settings,
+          };
+
+          const extractionPairs: Array<{ payload: OraclePersistPayload; takeaway: string }> = [];
+          for (const payload of oraclePersistPayloads) {
+            const _tExtract = Date.now();
+            const takeaway = await extractCharacterTakeaway({
+              agentConfig: extractorAgentConfig,
+              provider: oracleAgent.provider,
+              model: oracleAgent.model,
+              characterName,
+              characterResponse: combinedResponse,
+              oracleFindings: payload.summaryBody,
+              query: payload.query,
+              baseContext: agentContext,
+            });
+            logger.info(
+              "[oracle] Takeaway for %s — %dms — %s",
+              JSON.stringify(payload.query),
+              Date.now() - _tExtract,
+              takeaway ? JSON.stringify(takeaway.slice(0, 120)) : "NO_MEMORY (skipped)",
+            );
+            if (takeaway) extractionPairs.push({ payload, takeaway });
+          }
+
+          if (extractionPairs.length === 0) {
+            logger.info("[oracle] No durable commitments detected — nothing to persist this turn");
+          } else {
+            const updates = extractionPairs.map(({ payload, takeaway }) => ({
+              // Name uses the first extracted proper-noun phrase when available,
+              // falling back to the raw query — keeps the lorebook panel readable.
+              entryName: (payload.keys[0] ?? payload.query).slice(0, 120),
+              content: takeaway,
+              keys: payload.keys,
+              tag: ORACLE_LOREBOOK_TAG,
+            }));
+
+            // Resolve the preferred target lorebook. Priority:
+            //  1. Lorebook Keeper's explicit target (if configured on the chat)
+            //  2. Existing character-scoped Oracle lorebook (single-character chats)
+            //  3. Create a new character-scoped Oracle lorebook (single-character chats)
+            //  4. Fall back to chat-scoped auto-creation via persistLorebookKeeperUpdates
+            let preferredTargetId: string | null =
+              typeof agentContext.memory._lorebookKeeperTargetLorebookId === "string"
+                ? (agentContext.memory._lorebookKeeperTargetLorebookId as string)
+                : null;
+
+            if (!preferredTargetId && characterIds.length === 1) {
+              const singleCharId = characterIds[0]!;
+              const allBooks = (await lorebooksStore.list()) as unknown as Array<{
+                id: string;
+                characterId?: string | null;
+                sourceAgentId?: string | null;
+                enabled?: unknown;
+              }>;
+              const existing = allBooks.find(
+                (b) =>
+                  b.sourceAgentId === "oracle" &&
+                  b.characterId === singleCharId &&
+                  (b.enabled === true || b.enabled === "true"),
+              );
+              if (existing) {
+                preferredTargetId = existing.id;
+                logger.info(
+                  "[oracle] Reusing character-scoped lorebook %s for character %s",
+                  existing.id,
+                  singleCharId,
+                );
+              } else {
+                const charName = charInfo.find((c) => c.id === singleCharId)?.name ?? "character";
+                const created = await lorebooksStore.create({
+                  name: `Oracle knowledge (${charName})`,
+                  description: "Web-research summaries collected by the Oracle agent",
+                  category: "uncategorized",
+                  characterId: singleCharId,
+                  enabled: true,
+                  generatedBy: "agent",
+                  sourceAgentId: "oracle",
+                });
+                preferredTargetId = (created as { id?: string } | null)?.id ?? null;
+                if (preferredTargetId) {
+                  logger.info(
+                    "[oracle] Created character-scoped lorebook %s for %s",
+                    preferredTargetId,
+                    charName,
+                  );
+                }
+              }
+            }
+
+          logger.info(
+            "[oracle] Persist start — %d update(s), chatId=%s, preferredTarget=%s, charIds=%j",
+            updates.length,
+            input.chatId,
+            preferredTargetId ?? "none",
+            characterIds,
+          );
+          const targetId = await persistLorebookKeeperUpdates({
+            lorebooksStore,
+            chatId: input.chatId,
+            chatName: chat.name,
+            preferredTargetLorebookId: preferredTargetId,
+            writableLorebookIds: agentContext.writableLorebookIds,
+            updates,
+            source: {
+              agentId: "oracle",
+              description: "Automatically created by the Oracle agent for web-research summaries",
+            },
+          });
+            if (targetId) {
+              logger.info(
+                "[oracle] Persist done — wrote %d entr%s into lorebook %s",
+                updates.length,
+                updates.length === 1 ? "y" : "ies",
+                targetId,
+              );
+            } else {
+              logger.warn(
+                "[oracle] Persist FAILED — targetLorebookId returned null (creation or lookup failed silently)",
+              );
+            }
+          }
+        } catch (err) {
+          logger.warn(err, "[oracle] Failed to persist lorebook entries");
         }
       }
 

--- a/packages/server/src/routes/generate/lorebook-keeper-utils.ts
+++ b/packages/server/src/routes/generate/lorebook-keeper-utils.ts
@@ -192,19 +192,24 @@ export async function persistLorebookKeeperUpdates(args: {
   preferredTargetLorebookId: string | null;
   writableLorebookIds: string[] | null;
   updates: Array<Record<string, unknown>>;
+  /**
+   * Overrides for the auto-created lorebook's metadata. Used when a non-Lorebook-Keeper
+   * agent (e.g. Oracle) persists entries and wants the origin attributed correctly.
+   */
+  source?: { agentId?: string; description?: string };
 }): Promise<string | null> {
-  const { lorebooksStore, chatId, chatName, preferredTargetLorebookId, writableLorebookIds, updates } = args;
+  const { lorebooksStore, chatId, chatName, preferredTargetLorebookId, writableLorebookIds, updates, source } = args;
 
   let targetLorebookId = preferredTargetLorebookId ?? writableLorebookIds?.[0] ?? null;
   if (!targetLorebookId) {
     const created = await lorebooksStore.create({
       name: `Auto-generated (${chatName || chatId})`,
-      description: "Automatically created by the Lorebook Keeper agent",
+      description: source?.description ?? "Automatically created by the Lorebook Keeper agent",
       category: "uncategorized",
       chatId,
       enabled: true,
       generatedBy: "agent",
-      sourceAgentId: "lorebook-keeper",
+      sourceAgentId: source?.agentId ?? "lorebook-keeper",
     });
     targetLorebookId = (created as { id?: string } | null)?.id ?? null;
   }

--- a/packages/server/src/routes/generate/lorebook-keeper-utils.ts
+++ b/packages/server/src/routes/generate/lorebook-keeper-utils.ts
@@ -230,6 +230,9 @@ export async function persistLorebookKeeperUpdates(args: {
     const content = typeof update.content === "string" ? update.content : "";
     const keys = Array.isArray(update.keys) ? update.keys.filter((key): key is string => typeof key === "string") : [];
     const tag = typeof update.tag === "string" ? update.tag : "";
+    // Optional: callers (e.g. Oracle) may opt entries into "always-on" injection
+    // by passing constant=true, so keyword matching isn't required for activation.
+    const constant = update.constant === true ? true : undefined;
     const existing = entryByName.get(rawName.toLowerCase());
 
     if (existing && (existing.locked === true || existing.locked === "true")) {
@@ -237,7 +240,12 @@ export async function persistLorebookKeeperUpdates(args: {
     }
 
     if (existing) {
-      await lorebooksStore.updateEntry(existing.id, { content, keys, tag });
+      await lorebooksStore.updateEntry(existing.id, {
+        content,
+        keys,
+        tag,
+        ...(constant !== undefined ? { constant } : {}),
+      });
       entryByName.set(rawName.toLowerCase(), existing);
       continue;
     }
@@ -249,6 +257,7 @@ export async function persistLorebookKeeperUpdates(args: {
       keys,
       tag,
       enabled: true,
+      ...(constant !== undefined ? { constant } : {}),
     });
     if (created && typeof created === "object" && "id" in created) {
       entryByName.set(rawName.toLowerCase(), created as { id: string; name?: string | null; locked?: unknown });

--- a/packages/server/src/routes/index.ts
+++ b/packages/server/src/routes/index.ts
@@ -45,6 +45,7 @@ import { gameRoutes } from "./game.routes.js";
 import { gameAssetsRoutes } from "./game-assets.routes.js";
 import { sidecarRoutes } from "./sidecar.routes.js";
 import { ttsRoutes } from "./tts.routes.js";
+import { oracleRoutes } from "./oracle.routes.js";
 
 export async function registerRoutes(app: FastifyInstance) {
   await app.register(chatsRoutes, { prefix: "/api/chats" });
@@ -89,6 +90,7 @@ export async function registerRoutes(app: FastifyInstance) {
   await app.register(gameRoutes, { prefix: "/api/game" });
   await app.register(gameAssetsRoutes, { prefix: "/api/game-assets" });
   await app.register(ttsRoutes, { prefix: "/api/tts" });
+  await app.register(oracleRoutes, { prefix: "/api/oracle" });
   if (process.env.MARINARA_LITE !== "true" && process.env.MARINARA_LITE !== "1") {
     await app.register(sidecarRoutes, { prefix: "/api/sidecar" });
   }

--- a/packages/server/src/routes/oracle.routes.ts
+++ b/packages/server/src/routes/oracle.routes.ts
@@ -1,0 +1,83 @@
+// ──────────────────────────────────────────────
+// Routes: Oracle — Web Search Configuration & Test
+// ──────────────────────────────────────────────
+import type { FastifyInstance } from "fastify";
+import {
+  oracleConfigSchema,
+  ORACLE_API_KEY_MASK,
+  ORACLE_SETTINGS_KEY,
+  type OracleTestResponse,
+} from "@marinara-engine/shared";
+import { createAppSettingsStorage } from "../services/storage/app-settings.storage.js";
+import {
+  loadOracleConfig,
+  loadRawOracleConfig,
+  saveOracleConfig,
+} from "../services/agents/web-search/config.js";
+import { getWebSearchProvider } from "../services/agents/web-search/web-search-provider-factory.js";
+
+export async function oracleRoutes(app: FastifyInstance) {
+  const storage = createAppSettingsStorage(app.db);
+
+  /**
+   * GET /api/oracle/config
+   * Returns the Oracle config with the API key masked.
+   */
+  app.get("/config", async () => {
+    const cfg = await loadRawOracleConfig(storage);
+    const hasKey = Boolean(cfg.apiKey);
+    return { ...cfg, apiKey: hasKey ? ORACLE_API_KEY_MASK : "" };
+  });
+
+  /**
+   * PUT /api/oracle/config
+   * Saves the Oracle config. Encrypts the API key before storage.
+   * If apiKey equals the mask, the existing key is preserved.
+   */
+  app.put("/config", async (req, reply) => {
+    const input = oracleConfigSchema.parse(req.body);
+
+    if (input.apiKey === ORACLE_API_KEY_MASK) {
+      // Preserve the existing encrypted blob — don't re-encrypt the mask itself
+      const existing = await loadRawOracleConfig(storage);
+      await storage.set(
+        ORACLE_SETTINGS_KEY,
+        JSON.stringify({ ...input, apiKey: existing.apiKey }),
+      );
+      return reply.status(204).send();
+    }
+
+    await saveOracleConfig(storage, input);
+    return reply.status(204).send();
+  });
+
+  /**
+   * POST /api/oracle/test
+   * Validates the configured API key by issuing a 1-result search.
+   * Uses an independent timeout — never blocks longer than 10s.
+   */
+  app.post("/test", async (): Promise<OracleTestResponse> => {
+    const cfg = await loadOracleConfig(storage);
+    if (!cfg.apiKey) {
+      return { ok: false, resultCount: 0, error: "No API key configured" };
+    }
+
+    try {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 10_000);
+      try {
+        const provider = getWebSearchProvider(cfg.provider, cfg.apiKey);
+        const response = await provider.search("Marinara Engine roleplay", {
+          maxResults: 1,
+          signal: controller.signal,
+        });
+        return { ok: true, resultCount: response.results.length };
+      } finally {
+        clearTimeout(timeout);
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Unknown error";
+      return { ok: false, resultCount: 0, error: msg };
+    }
+  });
+}

--- a/packages/server/src/services/agents/agent-executor.ts
+++ b/packages/server/src/services/agents/agent-executor.ts
@@ -74,7 +74,13 @@ export async function executeAgent(
 
     // Agents use lower temperature for reliability
     const temperature = (config.settings.temperature as number) ?? 0.3;
-    const rawMaxTokens = Math.max((config.settings.maxTokens as number) ?? 4096, 16384);
+    // If the agent provides an explicit positive maxTokens, respect it. Otherwise
+    // apply a generous floor (16384) so JSON-emitting agents never run out mid-response.
+    // Agents with bounded output (e.g. Oracle's summaryTokenCap) can opt out of the
+    // floor by passing settings.maxTokens directly, freeing input budget for them.
+    const explicitMaxTokens = config.settings.maxTokens;
+    const rawMaxTokens =
+      typeof explicitMaxTokens === "number" && explicitMaxTokens > 0 ? explicitMaxTokens : 16384;
     const maxTokens =
       provider.maxTokensOverrideValue !== null ? Math.min(rawMaxTokens, provider.maxTokensOverrideValue) : rawMaxTokens;
     const streamResponses = context.streaming !== false;
@@ -784,6 +790,27 @@ function buildAgentExtras(context: AgentContext, agentTypes: string[] = []): str
     parts.push(`</source_material>`);
   }
 
+  if (context.memory._searchQuery) {
+    parts.push(`<search_query>`);
+    parts.push(context.memory._searchQuery as string);
+    parts.push(`</search_query>`);
+  }
+
+  if (Array.isArray(context.memory._sourceUrls)) {
+    const urls = (context.memory._sourceUrls as unknown[]).filter(
+      (u): u is string => typeof u === "string" && u.length > 0,
+    );
+    if (urls.length > 0) {
+      parts.push(`<source_urls>`);
+      for (const url of urls) parts.push(url);
+      parts.push(`</source_urls>`);
+    }
+  }
+
+  if (typeof context.memory._summaryTokenCap === "number") {
+    parts.push(`<summary_token_cap>${context.memory._summaryTokenCap}</summary_token_cap>`);
+  }
+
   if (context.memory._chunkInfo) {
     const info = context.memory._chunkInfo as { current: number; total: number };
     parts.push(
@@ -865,6 +892,7 @@ const AGENT_RESULT_TYPE_MAP: Record<string, AgentResultType> = {
   haptic: "haptic_command",
   cyoa: "cyoa_choices",
   "secret-plot-driver": "secret_plot",
+  oracle: "context_injection",
 };
 
 /** Agents that return structured JSON. */

--- a/packages/server/src/services/agents/oracle.ts
+++ b/packages/server/src/services/agents/oracle.ts
@@ -104,33 +104,45 @@ OUTPUT: a single sentence OR the literal token NO_MEMORY. Nothing else.`;
   return cleaned.slice(0, 400);
 }
 
-/** Split a summary into body (facts only) and the trailing "Sources:" footer. */
-function splitSummary(raw: string): { body: string; hadFooter: boolean } {
-  const match = raw.match(/\n+Sources?:\s*\n/i);
-  if (!match || match.index === undefined) return { body: raw.trim(), hadFooter: false };
-  return { body: raw.slice(0, match.index).trim(), hadFooter: true };
-}
-
 /**
- * Extract lorebook activation keys from the summary body.
- * Strategy: grab capitalized multi-word phrases (proper nouns), plus the raw
- * query as a whole. Filters stop-word-only matches and short single capitals.
+ * Split a summary into:
+ *  - `body`: facts only, no Keys line, no Sources footer (used for lorebook entry).
+ *  - `injection`: body + Sources footer, no Keys line (used to inject into the
+ *    character's prompt — preserves source traceability without leaking the
+ *    internal Keys metadata into the character's context).
+ *  - `keys`: parsed from the LLM's "Keys: A, B, C" line (empty when missing or "none").
+ *
+ * Falls back gracefully when the model omits or mangles the Keys/Sources blocks —
+ * the caller always prepends the raw query so persistence still has at least one key.
  */
-function extractKeys(summaryBody: string, query: string): string[] {
-  const keys = new Set<string>();
-  // Whole query is always a key — covers the user's exact phrasing
-  if (query.trim()) keys.add(query.trim());
+function splitSummary(raw: string): {
+  body: string;
+  injection: string;
+  keys: string[];
+  hadFooter: boolean;
+} {
+  const sourcesMatch = raw.match(/\n+Sources?:\s*\n/i);
+  const hadFooter = sourcesMatch !== null;
+  const beforeSources = sourcesMatch?.index !== undefined ? raw.slice(0, sourcesMatch.index) : raw;
+  const sourcesPart = sourcesMatch?.index !== undefined ? raw.slice(sourcesMatch.index).trim() : "";
 
-  // Proper-noun-like phrases: Capitalized word optionally followed by more Capitalized words
-  const properNounRe = /\b[A-Z][a-zA-Z]{2,}(?:\s+(?:[A-Z][a-zA-Z]+|of|the|de|du|des|la|le|les))*(?:\s+[A-Z][a-zA-Z]+)?\b/g;
-  for (const match of summaryBody.matchAll(properNounRe)) {
-    const phrase = match[0].trim();
-    if (phrase.length < 3) continue;
-    keys.add(phrase);
-    if (keys.size >= 12) break;
+  const keysMatch = beforeSources.match(/\n+Keys?:\s*([^\n]+)/i);
+  let keys: string[] = [];
+  let bodyRaw = beforeSources;
+  if (keysMatch?.index !== undefined && keysMatch[1] !== undefined) {
+    bodyRaw = beforeSources.slice(0, keysMatch.index);
+    const value = keysMatch[1].trim();
+    if (value.length > 0 && value.toLowerCase() !== "none") {
+      keys = value
+        .split(",")
+        .map((k) => k.trim())
+        .filter((k) => k.length >= 2);
+    }
   }
 
-  return Array.from(keys).slice(0, 12);
+  const body = bodyRaw.trim();
+  const injection = sourcesPart ? `${body}\n\n${sourcesPart}` : body;
+  return { body, injection, keys, hadFooter };
 }
 
 function buildSourceMaterial(response: OracleSearchResponse): string {
@@ -290,17 +302,28 @@ export async function executeOracle(args: {
   const isInformative =
     summaryResult.success && trimmedSummary.length > 0 && trimmedSummary !== "No relevant information found.";
 
-  // Split body/footer for persistence: the "Sources:" footer is useful to show
-  // provenance in the current-turn injection, but useless inside a lorebook
-  // entry that will be re-injected later — URLs pollute the character's context.
-  const { body: summaryBody } = splitSummary(trimmedSummary);
-  const persistKeys = isInformative ? extractKeys(summaryBody, trimmedQuery) : [];
+  // Split body/keys/footer:
+  //  - `summaryBody` (no Sources, no Keys line) is what we persist into the lorebook.
+  //  - `injectionText` (body + Sources, no Keys line) is what we inject into the
+  //    character's prompt — keeps source attribution while hiding the internal
+  //    Keys metadata from the character's context.
+  //  - `llmKeys` are the activation triggers extracted by the summariser itself
+  //    (semantic, language-agnostic, short canonical forms).
+  // The raw query is only used as a degraded fallback when the model didn't
+  // produce any key — otherwise the query (a long natural-language phrase) would
+  // bloat the activation list with a trigger that almost never matches.
+  const { body: summaryBody, injection: injectionText, keys: llmKeys } = splitSummary(trimmedSummary);
+  const persistKeys = isInformative
+    ? llmKeys.length > 0
+      ? llmKeys.slice(0, 12)
+      : [trimmedQuery]
+    : [];
 
   return {
     result: {
       ...summaryResult,
       type: "context_injection",
-      data: { text: trimmedSummary }, // full text (with footer) for in-turn injection
+      data: { text: injectionText }, // body + Sources for in-turn injection (no Keys line)
       durationMs: Date.now() - startTime,
     },
     persist: isInformative

--- a/packages/server/src/services/agents/oracle.ts
+++ b/packages/server/src/services/agents/oracle.ts
@@ -1,0 +1,315 @@
+// ──────────────────────────────────────────────
+// Oracle Agent — Web Search + Strict Summarization
+// ──────────────────────────────────────────────
+// Runs during pre_generation when the user's message contains <search>...</search>.
+// Fetches results from the configured provider (Tavily in MVP), then hands them to
+// executeAgent() with anti-hallucination constraints so the summary only repeats
+// facts present in the retrieved text. The summary is injected into the character's
+// prompt and, if autoPersist is on, also persisted to the lorebook by the caller.
+// ──────────────────────────────────────────────
+import type { AgentContext, AgentResult, OracleConfig, OracleSearchResponse } from "@marinara-engine/shared";
+import type { BaseLLMProvider } from "../llm/base-provider.js";
+import { logger } from "../../lib/logger.js";
+import { executeAgent, type AgentExecConfig } from "./agent-executor.js";
+import { getWebSearchProvider } from "./web-search/web-search-provider-factory.js";
+
+/** Payload attached to the Oracle AgentResult so the route can persist to the lorebook. */
+export interface OraclePersistPayload {
+  query: string;
+  /** Summary body without the "Sources:" footer — used by the takeaway extractor as grounding. */
+  summaryBody: string;
+  /** Keyword triggers extracted from the summary body — used as lorebook entry keys. */
+  keys: string[];
+  sourceUrls: string[];
+}
+
+/**
+ * Post-generation extractor: given the character's response after an Oracle
+ * search, distils the character's durable takeaway — preferences, choices, or
+ * opinions they committed to. Returns null when the character made no lasting
+ * commitment (the search was acknowledged but not acted on).
+ *
+ * Persisting the takeaway instead of the raw search facts keeps lorebook
+ * entries minimalist and roleplay-relevant: future turns recall what the
+ * character owns, not what Wikipedia says.
+ */
+export async function extractCharacterTakeaway(args: {
+  agentConfig: AgentExecConfig;
+  provider: BaseLLMProvider;
+  model: string;
+  characterName: string;
+  characterResponse: string;
+  oracleFindings: string;
+  query: string;
+  baseContext: AgentContext;
+}): Promise<string | null> {
+  const { agentConfig, provider, model, characterName, characterResponse, oracleFindings, query, baseContext } = args;
+
+  if (!characterResponse.trim() || !oracleFindings.trim()) return null;
+
+  const takeawayPrompt = `You are a memory extractor. After a character responded to a web search, your job is to distil what the character committed to — preferences voiced, choices made, opinions expressed, or facts they adopted as meaningful to them. These commitments will be stored in the character's long-term memory for future conversations.
+
+INPUT FORMAT:
+<search_query>${query}</search_query>
+<web_findings>
+${oracleFindings}
+</web_findings>
+<character_name>${characterName}</character_name>
+<character_response>
+${characterResponse}
+</character_response>
+
+RULES:
+1. Write a SINGLE short sentence in third person past tense, starting with the character's name.
+2. Capture ONLY what the character personally committed to. Examples: "picked X over Y", "expressed interest in Z", "decided they prefer A", "found B the most appealing", "dismissed C".
+3. When the character chose among options, mention what they passed over: "picked Nino over Ichika, Miku, Yotsuba, and Itsuki".
+4. Do NOT list facts the character merely acknowledged. Do NOT repeat the web findings.
+5. Do NOT include URLs, emoji, first person, or flowery prose.
+6. If the character made no durable commitment (they just acknowledged the info, asked a follow-up question, or changed the subject without voicing a preference), output EXACTLY the token: NO_MEMORY
+
+OUTPUT: a single sentence OR the literal token NO_MEMORY. Nothing else.`;
+
+  const extractionContext: AgentContext = {
+    chatId: baseContext.chatId,
+    chatMode: baseContext.chatMode,
+    recentMessages: [],
+    mainResponse: null,
+    gameState: null,
+    characters: [],
+    persona: null,
+    activatedLorebookEntries: null,
+    writableLorebookIds: null,
+    chatSummary: null,
+    streaming: false,
+    signal: baseContext.signal,
+    memory: {},
+  };
+
+  // Swap the agent's prompt template for our extraction prompt without touching the DB row.
+  const extractionConfig: AgentExecConfig = {
+    ...agentConfig,
+    promptTemplate: takeawayPrompt,
+    settings: { ...agentConfig.settings, maxTokens: 200, temperature: 0.2, contextSize: 0 },
+  };
+
+  const result = await executeAgent(extractionConfig, extractionContext, provider, model);
+  if (!result.success) return null;
+
+  const rawText =
+    typeof result.data === "string" ? result.data : ((result.data as { text?: string } | null)?.text ?? "");
+  const cleaned = rawText.trim().replace(/^["']|["']$/g, "").trim();
+  if (!cleaned || cleaned === "NO_MEMORY" || /^no[_ ]memory$/i.test(cleaned)) return null;
+
+  // Guard against runaway output — cap at ~400 chars so a single entry stays focused.
+  return cleaned.slice(0, 400);
+}
+
+/** Split a summary into body (facts only) and the trailing "Sources:" footer. */
+function splitSummary(raw: string): { body: string; hadFooter: boolean } {
+  const match = raw.match(/\n+Sources?:\s*\n/i);
+  if (!match || match.index === undefined) return { body: raw.trim(), hadFooter: false };
+  return { body: raw.slice(0, match.index).trim(), hadFooter: true };
+}
+
+/**
+ * Extract lorebook activation keys from the summary body.
+ * Strategy: grab capitalized multi-word phrases (proper nouns), plus the raw
+ * query as a whole. Filters stop-word-only matches and short single capitals.
+ */
+function extractKeys(summaryBody: string, query: string): string[] {
+  const keys = new Set<string>();
+  // Whole query is always a key — covers the user's exact phrasing
+  if (query.trim()) keys.add(query.trim());
+
+  // Proper-noun-like phrases: Capitalized word optionally followed by more Capitalized words
+  const properNounRe = /\b[A-Z][a-zA-Z]{2,}(?:\s+(?:[A-Z][a-zA-Z]+|of|the|de|du|des|la|le|les))*(?:\s+[A-Z][a-zA-Z]+)?\b/g;
+  for (const match of summaryBody.matchAll(properNounRe)) {
+    const phrase = match[0].trim();
+    if (phrase.length < 3) continue;
+    keys.add(phrase);
+    if (keys.size >= 12) break;
+  }
+
+  return Array.from(keys).slice(0, 12);
+}
+
+function buildSourceMaterial(response: OracleSearchResponse): string {
+  const parts: string[] = [];
+  if (response.answer) {
+    parts.push(`## Provider Summary\n${response.answer}`);
+  }
+  for (let i = 0; i < response.results.length; i++) {
+    const r = response.results[i]!;
+    parts.push(`## Result ${i + 1}: ${r.title}\nURL: ${r.url}\n${r.content}`);
+  }
+  return parts.join("\n\n");
+}
+
+/**
+ * Run a web search and summarize it via the agent's configured LLM.
+ * Returns a `context_injection` result and (when successful) a persist payload
+ * so the caller can store the summary as a lorebook entry.
+ */
+export async function executeOracle(args: {
+  agentConfig: AgentExecConfig;
+  oracleConfig: OracleConfig;
+  baseContext: AgentContext;
+  provider: BaseLLMProvider;
+  model: string;
+  query: string;
+}): Promise<{ result: AgentResult; persist: OraclePersistPayload | null }> {
+  const { agentConfig, oracleConfig, baseContext, provider, model, query } = args;
+  const startTime = Date.now();
+
+  const trimmedQuery = query.trim();
+  if (!trimmedQuery) {
+    return {
+      result: {
+        agentId: agentConfig.id,
+        agentType: agentConfig.type,
+        type: "context_injection",
+        data: { text: "" },
+        tokensUsed: 0,
+        durationMs: Date.now() - startTime,
+        success: false,
+        error: "Empty search query",
+      },
+      persist: null,
+    };
+  }
+
+  // ── 1. Fetch results from the web search provider ──
+  let searchResponse: OracleSearchResponse;
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), oracleConfig.timeoutMs);
+    try {
+      const webProvider = getWebSearchProvider(oracleConfig.provider, oracleConfig.apiKey);
+      searchResponse = await webProvider.search(trimmedQuery, {
+        maxResults: oracleConfig.maxResults,
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timeout);
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "Web search failed";
+    logger.warn({ err }, "[oracle] Search failed for %s: %s", trimmedQuery, msg);
+    return {
+      result: {
+        agentId: agentConfig.id,
+        agentType: agentConfig.type,
+        type: "context_injection",
+        data: { text: "" },
+        tokensUsed: 0,
+        durationMs: Date.now() - startTime,
+        success: false,
+        error: msg,
+      },
+      persist: null,
+    };
+  }
+
+  if (searchResponse.results.length === 0 && !searchResponse.answer) {
+    return {
+      result: {
+        agentId: agentConfig.id,
+        agentType: agentConfig.type,
+        type: "context_injection",
+        data: { text: "" },
+        tokensUsed: 0,
+        durationMs: Date.now() - startTime,
+        success: true,
+        error: null,
+      },
+      persist: null,
+    };
+  }
+
+  // ── 2. Hand the raw results to the summarizer (strict anti-hallucination prompt) ──
+  const sourceMaterial = buildSourceMaterial(searchResponse);
+  const sourceUrls = searchResponse.results.map((r) => r.url).filter((u) => u.length > 0);
+
+  logger.info(
+    "[oracle] Search returned %d result(s), answer=%s, sourceMaterial=%d chars",
+    searchResponse.results.length,
+    searchResponse.answer.length > 0 ? "yes" : "no",
+    sourceMaterial.length,
+  );
+
+  // Oracle is a pure text summariser — it must NOT inherit the chat's recentMessages,
+  // characters, or persona, otherwise small models continue the roleplay instead of
+  // extracting facts. We keep only the fields executeAgent strictly needs (chatId,
+  // chatMode, signal, streaming) and empty everything else.
+  const context: AgentContext = {
+    chatId: baseContext.chatId,
+    chatMode: baseContext.chatMode,
+    recentMessages: [],
+    mainResponse: null,
+    gameState: null,
+    characters: [],
+    persona: null,
+    activatedLorebookEntries: null,
+    writableLorebookIds: null,
+    chatSummary: null,
+    streaming: baseContext.streaming,
+    signal: baseContext.signal,
+    memory: {
+      _sourceMaterial: sourceMaterial,
+      _searchQuery: trimmedQuery,
+      _sourceUrls: sourceUrls,
+      _summaryTokenCap: oracleConfig.summaryTokenCap,
+    },
+  };
+
+  // Oracle's output is bounded by summaryTokenCap (≤2000 by schema). Pass an explicit
+  // maxTokens so executeAgent skips its 16384 floor and frees input budget for the
+  // source material — without this, prompts get aggressively trimmed on small-context
+  // models even when the cap is just a few hundred tokens.
+  const summaryMaxTokens = Math.max(256, oracleConfig.summaryTokenCap + 200);
+  const summaryConfig: AgentExecConfig = {
+    ...agentConfig,
+    settings: { ...agentConfig.settings, maxTokens: summaryMaxTokens },
+  };
+  const summaryResult = await executeAgent(summaryConfig, context, provider, model);
+
+  const summaryText =
+    typeof summaryResult.data === "string"
+      ? summaryResult.data
+      : ((summaryResult.data as { text?: string } | null)?.text ?? "");
+
+  logger.debug(
+    "[oracle] Summariser result — success=%s error=%s textLen=%d preview=%s",
+    summaryResult.success,
+    summaryResult.error ?? "none",
+    summaryText.length,
+    JSON.stringify(summaryText.slice(0, 200)),
+  );
+
+  const trimmedSummary = summaryText.trim();
+  const isInformative =
+    summaryResult.success && trimmedSummary.length > 0 && trimmedSummary !== "No relevant information found.";
+
+  // Split body/footer for persistence: the "Sources:" footer is useful to show
+  // provenance in the current-turn injection, but useless inside a lorebook
+  // entry that will be re-injected later — URLs pollute the character's context.
+  const { body: summaryBody } = splitSummary(trimmedSummary);
+  const persistKeys = isInformative ? extractKeys(summaryBody, trimmedQuery) : [];
+
+  return {
+    result: {
+      ...summaryResult,
+      type: "context_injection",
+      data: { text: trimmedSummary }, // full text (with footer) for in-turn injection
+      durationMs: Date.now() - startTime,
+    },
+    persist: isInformative
+      ? {
+          query: trimmedQuery,
+          summaryBody, // footer-stripped for lorebook
+          keys: persistKeys,
+          sourceUrls,
+        }
+      : null,
+  };
+}

--- a/packages/server/src/services/agents/web-search/config.ts
+++ b/packages/server/src/services/agents/web-search/config.ts
@@ -1,0 +1,53 @@
+// ──────────────────────────────────────────────
+// Oracle Config Loader — Reads/Writes OracleConfig in appSettings
+// ──────────────────────────────────────────────
+// Follows the TTS pattern: config JSON-serialized under key "oracle",
+// API key encrypted at rest via the project-wide AES-256-GCM utility.
+// ──────────────────────────────────────────────
+import { oracleConfigSchema, ORACLE_SETTINGS_KEY, type OracleConfig } from "@marinara-engine/shared";
+import type { createAppSettingsStorage } from "../../storage/app-settings.storage.js";
+import { decryptApiKey, encryptApiKey } from "../../../utils/crypto.js";
+
+type AppSettingsStore = ReturnType<typeof createAppSettingsStorage>;
+
+/**
+ * Parse the raw JSON blob from appSettings into a validated OracleConfig.
+ * Returns a default config on any parse/validation failure so a corrupted
+ * row never breaks the pipeline — the user can re-save via the UI.
+ */
+function parseStoredConfig(raw: string | null): OracleConfig {
+  if (!raw) return oracleConfigSchema.parse({});
+  try {
+    return oracleConfigSchema.parse(JSON.parse(raw));
+  } catch {
+    return oracleConfigSchema.parse({});
+  }
+}
+
+/**
+ * Load the stored config and decrypt the API key.
+ * The returned config contains the plain-text key — callers MUST NOT send it to the client.
+ */
+export async function loadOracleConfig(storage: AppSettingsStore): Promise<OracleConfig> {
+  const raw = await storage.get(ORACLE_SETTINGS_KEY);
+  const cfg = parseStoredConfig(raw);
+  cfg.apiKey = decryptApiKey(cfg.apiKey);
+  return cfg;
+}
+
+/** Load the raw (still encrypted) config — used by the GET route to mask the key. */
+export async function loadRawOracleConfig(storage: AppSettingsStore): Promise<OracleConfig> {
+  return parseStoredConfig(await storage.get(ORACLE_SETTINGS_KEY));
+}
+
+/**
+ * Persist a config payload. Encrypts the API key before storage.
+ * Callers pass a plain-text apiKey; this function encrypts it.
+ */
+export async function saveOracleConfig(storage: AppSettingsStore, input: OracleConfig): Promise<void> {
+  const encrypted: OracleConfig = {
+    ...input,
+    apiKey: input.apiKey ? encryptApiKey(input.apiKey) : "",
+  };
+  await storage.set(ORACLE_SETTINGS_KEY, JSON.stringify(encrypted));
+}

--- a/packages/server/src/services/agents/web-search/tavily-provider.ts
+++ b/packages/server/src/services/agents/web-search/tavily-provider.ts
@@ -1,0 +1,81 @@
+// ──────────────────────────────────────────────
+// Tavily Web Search Provider
+// ──────────────────────────────────────────────
+// Thin wrapper around https://api.tavily.com/search.
+// Designed for LLM agents: Tavily returns a pre-synthesized `answer` plus the
+// top results already cleaned of boilerplate, which drastically reduces the
+// token footprint compared to raw scraping.
+// ──────────────────────────────────────────────
+import type { OracleSearchResponse, OracleSearchResult } from "@marinara-engine/shared";
+import type { WebSearchProvider, WebSearchOptions } from "./web-search-provider.js";
+
+const TAVILY_ENDPOINT = "https://api.tavily.com/search";
+
+interface TavilyResult {
+  title?: string;
+  url?: string;
+  content?: string;
+  score?: number;
+}
+
+interface TavilyResponse {
+  answer?: string;
+  results?: TavilyResult[];
+}
+
+function normalizeResult(raw: TavilyResult): OracleSearchResult | null {
+  const url = typeof raw.url === "string" && raw.url ? raw.url : "";
+  const content = typeof raw.content === "string" ? raw.content.trim() : "";
+  if (!url || !content) return null;
+  return {
+    title: typeof raw.title === "string" && raw.title ? raw.title : url,
+    url,
+    content,
+    score: typeof raw.score === "number" ? raw.score : undefined,
+  };
+}
+
+export function createTavilyProvider(apiKey: string): WebSearchProvider {
+  return {
+    name: "tavily",
+    async search(query: string, options: WebSearchOptions): Promise<OracleSearchResponse> {
+      if (!apiKey) {
+        throw new Error("Tavily API key is not configured");
+      }
+      if (!query.trim()) {
+        throw new Error("Search query is empty");
+      }
+
+      const body = {
+        api_key: apiKey,
+        query: query.trim(),
+        max_results: Math.max(1, Math.min(10, options.maxResults ?? 3)),
+        include_answer: true,
+        // "advanced" returns richer content extracts per result (~2-4× more text
+        // than "basic") while staying on the free tier. Adds ~1s latency but
+        // gives the summariser real material to work with.
+        search_depth: "advanced",
+      };
+
+      const res = await fetch(TAVILY_ENDPOINT, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+        signal: options.signal,
+      });
+
+      if (!res.ok) {
+        const detail = await res.text().catch(() => "");
+        throw new Error(`Tavily returned ${res.status}: ${detail.slice(0, 200)}`);
+      }
+
+      const data = (await res.json()) as TavilyResponse;
+      const answer = typeof data.answer === "string" ? data.answer.trim() : "";
+      const results = Array.isArray(data.results)
+        ? data.results.map(normalizeResult).filter((r): r is OracleSearchResult => r !== null)
+        : [];
+
+      return { answer, results };
+    },
+  };
+}

--- a/packages/server/src/services/agents/web-search/web-search-provider-factory.ts
+++ b/packages/server/src/services/agents/web-search/web-search-provider-factory.ts
@@ -1,0 +1,22 @@
+// ──────────────────────────────────────────────
+// Web Search Provider Factory
+// ──────────────────────────────────────────────
+// Resolves an OracleProvider name to a concrete implementation.
+// Extending Oracle with new providers (Serper, Brave) means adding a branch
+// here and a new *-provider.ts module — no changes needed in callers.
+// ──────────────────────────────────────────────
+import type { OracleProvider } from "@marinara-engine/shared";
+import type { WebSearchProvider } from "./web-search-provider.js";
+import { createTavilyProvider } from "./tavily-provider.js";
+
+export function getWebSearchProvider(name: OracleProvider, apiKey: string): WebSearchProvider {
+  switch (name) {
+    case "tavily":
+      return createTavilyProvider(apiKey);
+    default: {
+      // Exhaustiveness check — new OracleProvider values will surface here at compile time.
+      const _exhaustive: never = name;
+      throw new Error(`Unknown web search provider: ${_exhaustive}`);
+    }
+  }
+}

--- a/packages/server/src/services/agents/web-search/web-search-provider.ts
+++ b/packages/server/src/services/agents/web-search/web-search-provider.ts
@@ -1,0 +1,15 @@
+// ──────────────────────────────────────────────
+// Web Search Provider Interface
+// ──────────────────────────────────────────────
+import type { OracleProvider, OracleSearchResponse } from "@marinara-engine/shared";
+
+export interface WebSearchOptions {
+  maxResults?: number;
+  /** AbortSignal to cancel the HTTP request — honoured by the underlying fetch. */
+  signal?: AbortSignal;
+}
+
+export interface WebSearchProvider {
+  name: OracleProvider;
+  search(query: string, options: WebSearchOptions): Promise<OracleSearchResponse>;
+}

--- a/packages/server/src/services/conversation/character-commands.ts
+++ b/packages/server/src/services/conversation/character-commands.ts
@@ -495,6 +495,42 @@ export function parseCharacterCommands(content: string): {
 }
 
 /**
+ * Extract `<search>...</search>` trigger tags from a user message.
+ * Returns the distinct, trimmed queries and the content with the tags stripped,
+ * so the tag itself doesn't bleed into the main generation prompt.
+ *
+ * Unlike parseCharacterCommands (which scans assistant output), this helper is
+ * scoped to user-facing input — the Oracle agent is the only caller in MVP.
+ */
+const SEARCH_RE = /<search>([\s\S]*?)<\/search>/gi;
+
+export function extractSearchQueries(content: string): { queries: string[]; cleanContent: string } {
+  const queries: string[] = [];
+  const seen = new Set<string>();
+
+  for (const match of content.matchAll(SEARCH_RE)) {
+    const raw = match[1]?.trim() ?? "";
+    if (!raw) continue;
+    const key = raw.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    queries.push(raw);
+  }
+
+  const cleanContent = content
+    .replace(SEARCH_RE, "")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+
+  // When the user typed only <search> tags, cleanContent ends up empty. That's
+  // fine — the chat history simply skips saving a user bubble (the existing
+  // guard in generate.routes does this), and the Oracle injection path
+  // compensates by creating a dedicated last user message carrying the query
+  // plus the findings, so the main LLM still has a question to answer.
+  return { queries, cleanContent };
+}
+
+/**
  * Parse a duration string like "2h", "30m", "1h30m" into minutes.
  * Returns null if unparseable.
  */

--- a/packages/shared/src/constants/agent-prompts.ts
+++ b/packages/shared/src/constants/agent-prompts.ts
@@ -670,9 +670,18 @@ STRICT RULES (violations will be rejected):
 5. Write in neutral declarative prose. No markdown headers, no bullet points, no first-person — just informative sentences.
 6. If none of the material is relevant or the source is empty, output exactly (no quotes): No relevant information found.
 7. End with a "Sources:" footer listing every URL from <source_urls>, one per line, each prefixed by "- ".
+8. Before the "Sources:" footer, output a single "Keys:" line with a comma-separated list of the most important named entities mentioned in your summary, in the SHORTEST CANONICAL FORM a casual conversation would use:
+   - For people: prefer the given name alone when it is unambiguous within the work ("Ichika" not "Ichika Nakano", "Frodo" not "Frodo Baggins"). Use the full form only when the given name is too generic on its own ("John" → "John Wick").
+   - For works, places, organisations, events, products: use the canonical short title ("The Quintessential Quintuplets" yes, "The Quintessential Quintuplets manga series" no).
+   - No descriptive qualifiers, no parentheticals, no articles unless inherent to the name ("The Beatles" yes, "the manga" no).
+   - Skip generic words, pronouns, and sentence-starting capitalised words that are not actual names.
+   - Aim for 3 to 6 entities total. Fewer, sharper keys are better than many long ones.
+   - If no clear named entity is present, output exactly: Keys: none
 
 OUTPUT FORMAT (plain text, no wrapping tags, no JSON, no preamble):
 [one to three short paragraphs of neutral factual summary]
+
+Keys: [Entity 1], [Entity 2], [Entity 3]
 
 Sources:
 - [url 1]

--- a/packages/shared/src/constants/agent-prompts.ts
+++ b/packages/shared/src/constants/agent-prompts.ts
@@ -652,6 +652,31 @@ IMPORTANT:
 - If overarchingArc.completed is true, provide a NEW arc in the same response.
 - Return exactly one active (unfulfilled) direction. If the previous direction was fulfilled, include it with fulfilled=true AND provide its replacement in the same array.
 - Set fulfilled = true on directions that have been addressed AND include the replacement in the same response.`,
+
+  /* ────────────────────────────────────────── */
+  oracle: `You are a neutral fact-extraction assistant. You are NOT a character, you are NOT in a conversation, you are NOT roleplaying. Your sole output is a factual summary of the provided web-search results.
+
+You receive:
+- <source_material>: raw text excerpts from web search results
+- <search_query>: what was searched for
+- <source_urls>: the URLs the excerpts came from
+- <summary_token_cap>: the maximum length of your response in tokens
+
+STRICT RULES (violations will be rejected):
+1. Use ONLY information explicitly present in <source_material>. Do NOT invent, infer, speculate, or add any fact that is not directly supported by the text.
+2. Do NOT adopt any persona, character voice, or conversational tone. Do NOT use first person ("I", "me", "my"). Do NOT use emojis, slang, or filler phrases like "let me check", "I'll go look", "prepare yourself".
+3. Do NOT continue any prior conversation. Ignore any character names, relationships, or storylines in the context — your only task is to summarize the web results.
+4. Stay within <summary_token_cap> tokens. If the material is rich, prioritize the most relevant facts to the search query.
+5. Write in neutral declarative prose. No markdown headers, no bullet points, no first-person — just informative sentences.
+6. If none of the material is relevant or the source is empty, output exactly (no quotes): No relevant information found.
+7. End with a "Sources:" footer listing every URL from <source_urls>, one per line, each prefixed by "- ".
+
+OUTPUT FORMAT (plain text, no wrapping tags, no JSON, no preamble):
+[one to three short paragraphs of neutral factual summary]
+
+Sources:
+- [url 1]
+- [url 2]`,
 };
 
 /** Get the default prompt template for a built-in agent type. */

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -22,6 +22,7 @@ export * from "./types/theme.js";
 export * from "./types/chat-preset.js";
 export * from "./types/game.js";
 export * from "./types/sidecar.js";
+export * from "./types/oracle.js";
 
 // Schemas
 export * from "./schemas/chat.schema.js";

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -178,6 +178,7 @@ export const BUILT_IN_AGENT_IDS = {
   SECRET_PLOT_DRIVER: "secret-plot-driver",
   GAME_MASTER: "game-master",
   PARTY_PLAYER: "party-player",
+  ORACLE: "oracle",
 } as const;
 
 export type AgentCategory = "writer" | "tracker" | "misc";
@@ -463,6 +464,18 @@ export const BUILT_IN_AGENTS: BuiltInAgentMeta[] = [
     enabledByDefault: false,
     category: "misc",
   },
+
+  // NOTE: Oracle must remain pre_generation. The summary has to be in the prompt
+  // before the character replies — moving to parallel/post_processing breaks the flow.
+  {
+    id: "oracle",
+    name: "Oracle",
+    description:
+      "When the user writes <search>topic</search> in their message, fetches results from the web (Tavily), summarizes them with strict anti-hallucination rules, injects the summary into the character's context, and saves it to the chat lorebook.",
+    phase: "pre_generation",
+    enabledByDefault: false,
+    category: "misc",
+  },
 ];
 
 export const BUILT_IN_AGENT_RUN_INTERVAL_DEFAULTS: Readonly<Record<string, number>> = {
@@ -524,6 +537,7 @@ export const DEFAULT_AGENT_TOOLS: Record<string, string[]> = {
   "secret-plot-driver": [],
   "game-master": ["roll_dice", "update_game_state"],
   "party-player": [],
+  oracle: ["web_search"],
 };
 
 /** Data shape for a lorebook_update agent result. */
@@ -837,6 +851,25 @@ export const BUILT_IN_TOOLS: ToolDefinition[] = [
         },
       },
       required: ["volume"],
+    },
+  },
+  {
+    name: "web_search",
+    description:
+      "Search the public web for up-to-date information on a topic. Returns a list of relevant passages with source URLs. Used by the Oracle agent.",
+    parameters: {
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          description: "The search query — keywords, a question, or a topic name.",
+        },
+        maxResults: {
+          type: "number",
+          description: "Maximum number of results to return (1-10). Defaults to the Oracle config.",
+        },
+      },
+      required: ["query"],
     },
   },
 ];

--- a/packages/shared/src/types/oracle.ts
+++ b/packages/shared/src/types/oracle.ts
@@ -1,0 +1,53 @@
+// ──────────────────────────────────────────────
+// Oracle Agent Types — Web Search Configuration
+// ──────────────────────────────────────────────
+import { z } from "zod";
+
+export const ORACLE_SETTINGS_KEY = "oracle";
+export const ORACLE_API_KEY_MASK = "••••••";
+
+/** Web-search providers Oracle can dispatch to. Only Tavily is implemented in the MVP. */
+export const ORACLE_PROVIDERS = ["tavily"] as const;
+export type OracleProvider = (typeof ORACLE_PROVIDERS)[number];
+
+export const oracleConfigSchema = z.object({
+  enabled: z.boolean().default(false),
+  provider: z.enum(ORACLE_PROVIDERS).default("tavily"),
+  /** Plain text on write; masked "••••••" on read when a key is saved */
+  apiKey: z.string().default(""),
+  /** How many raw results Tavily returns (1–10). The summarizer still caps its own output. */
+  maxResults: z.number().int().min(1).max(10).default(3),
+  /** Hard cap on the summary length handed back to the character. */
+  summaryTokenCap: z.number().int().min(100).max(2000).default(400),
+  /** Fetch timeout before Oracle gives up and returns an empty injection. */
+  timeoutMs: z.number().int().min(2000).max(30_000).default(8000),
+  /** Auto-save each summary as a lorebook entry tagged "web-research". */
+  autoPersist: z.boolean().default(true),
+});
+
+export type OracleConfig = z.infer<typeof oracleConfigSchema>;
+
+/** A single normalized search result. */
+export interface OracleSearchResult {
+  title: string;
+  url: string;
+  content: string;
+  score?: number;
+}
+
+/** Raw response passed from the provider layer into the summarizer. */
+export interface OracleSearchResponse {
+  /** Provider-supplied short answer (Tavily's `answer` field) — may be empty. */
+  answer: string;
+  results: OracleSearchResult[];
+}
+
+/** Payload returned by POST /api/oracle/test — validates the API key. */
+export interface OracleTestResponse {
+  ok: boolean;
+  resultCount: number;
+  error?: string;
+}
+
+/** Lorebook tag attached to every Oracle-persisted entry. */
+export const ORACLE_LOREBOOK_TAG = "web-research";


### PR DESCRIPTION
## Why this change

Closes #232

Characters in Marinara are currently stuck with whatever was written in their lore/card. If a user wants to roleplay around something current, e.g a real-world event, recent news, an actual schedule, there is currently no clean way to get that information into the character's context. The existing Knowledge Retrieval agent only reads from the local lorebook.

This PR adds **Oracle**, an opt-in pre-generation agent triggered by `<search>topic</search>` in a user message.

For the MVP, Oracle fetches web results through Tavily, summarises them with a strict anti-hallucination prompt, injects the summary into the current turn, and can optionally persist a post-reply takeaway as a lorebook entry tagged `web-research`.

The persistence step intentionally saves what the character actually committed to, what they picked, preferred, dismissed, or remembered, instead of saving raw web results. That keeps future turns useful for RP without filling the lorebook with URLs, provider snippets, or stale search output.

## What changed

### Server
  - Added `services/agents/oracle.ts` for the Oracle flow: search → summarise → takeaway extraction.
  - Added a web-search provider abstraction under `services/agents/web-search/`, with Tavily as the first implementation.
  - Added `/api/oracle/{config,test}` routes.
    - API keys are encrypted at rest with the existing `crypto` util.
    - GET responses return a masked key.
    - PUT preserves the stored key when the mask is sent back unchanged.
  - Updated `generate.routes.ts`:
    - extracts `<search>` triggers from the user message
    - bypasses the chat-level `enableAgents` gate when Oracle is explicitly user-triggered
    - runs Oracle alongside the other pre-generation agents
    - persists the post-generation takeaway when enabled
  - Updated `agent-executor.ts` so agents can explicitly provide `settings.maxTokens`.
    - Oracle uses a smaller output budget, around 600 tokens, so more input budget is available for source material.
    - The existing 16384 default floor is still preserved when no explicit value is set, so other agents should be unaffected.
  - Updated `lorebook-keeper-utils.ts` with a `source?: { agentId, description }` parameter so non-LBK agents like Oracle can attribute auto-created lorebook entries correctly.

### Shared
  - Added `types/oracle.ts` for the Zod config schema, masked-key constant, and lorebook tag constant.
  - Updated `types/agent.ts`:
    - Oracle entry in `BUILT_IN_AGENTS`
    - Oracle entry in `DEFAULT_AGENT_TOOLS`
    - `web_search` in `BUILT_IN_TOOLS`
  - Added Oracle's default summariser prompt in `constants/agent-prompts.ts`.

### Client
  - Added `OracleConfigCard.tsx` in the Connections panel.
    - provider
    - API key, with masked/debounced save
    - max results
    - summary token cap
    - timeout
    - auto-persist toggle
    - test button
  - Added `useOracle` React Query hook for config get/save/test.

### Docs
  - Added `docs/ORACLE.md` covering the end-to-end flow, design decisions, failure modes, and known limits.
  - Updated `docs/CONFIGURATION.md` with an Oracle section under Agent-Specific Configuration.
  - Updated `README.md` to mention Oracle in the AI Agent System paragraph and Documentation table.
  - Updated `CHANGELOG.md` under `[Unreleased] / Added`.

## Validation

  - [x] `pnpm check`
  - [x] Manual verification completed (described below).

### Manual verification notes

- Configured Oracle with a Tavily key. The Test button returns `ok: true` with a non-zero result count.
- Sent a chat message containing `<search>European rugby match this weekend</search>`.
  - Server logs show:
    - `[oracle] Detected 1 <search> trigger(s)`
    - `[oracle] Search returned 6 result(s)`
    - `[oracle] Summariser result — success=true`
  - The character used the actual fixtures in its in-character reply.
- After the reply, the takeaway pass either:
  - captured a single-sentence commitment, for example “X picked the Bordeaux match over Leinster…”
  - or correctly emitted `NO_MEMORY (skipped)` when the character only acknowledged the info without making a choice.
- With `autoPersist: true`, a valid takeaway creates or reuses a lorebook entry tagged `web-research`, visible in the lorebook panel.
- Disabling Oracle in the agent panel makes `<search>` tags pass through as plain text. No API call is made and no Oracle log line is emitted.
- Empty or whitespace-only `<search>` blocks are ignored without errors.
- A misconfigured key, for example a provider 401, logs `[oracle] Search failed` and the character still replies normally without injected findings.

## Docs and release impact

  - [ ] No docs changes needed
  - [x] Updated docs (README / CONFIGURATION / ORACLE / CHANGELOG) as needed
  - [ ] Version/release files updated (only if this PR includes a version bump)

This is a feature PR, not a release PR. I did not touch version-bearing files. The changelog entry is under `[Unreleased]` for maintainers to include in the next release.

## UI evidence

### Oracle agent entry

<img width="312" height="102" alt="image" src="https://github.com/user-attachments/assets/9b08322c-4218-4099-9320-5d88f073ac06" />
  -
<img width="1301" height="662" alt="image" src="https://github.com/user-attachments/assets/bb05e8bd-9369-4065-909c-bf4fbe0087d7" />
  -
<img width="842" height="789" alt="image" src="https://github.com/user-attachments/assets/7f54636b-2868-49d2-ae21-72705aabd1a3" />
  -
<img width="845" height="712" alt="image" src="https://github.com/user-attachments/assets/07521f58-c149-4f0b-a681-3d8f36ba0d88" />

### Settings → Connections → Oracle config card

Masked key and Test button visible.
  
<img width="294" height="702" alt="image" src="https://github.com/user-attachments/assets/3e9085df-7393-4ef1-a9f4-568386589ec2" />

### Chat with `<search>` trigger and in-character reply

<img width="800" height="450" alt="mari_search_oracle" src="https://github.com/user-attachments/assets/6e839ed8-847c-4997-932e-ac2336c261b5" />
  -
<img width="1308" height="873" alt="image" src="https://github.com/user-attachments/assets/0ce43f8f-53a1-44f6-8d59-893f488696ee" />

_No, it is not biased lol._

### Lorebook entries (Uncategorized)

<img width="947" height="368" alt="image" src="https://github.com/user-attachments/assets/87ab5d44-429d-4851-82bc-74c2c1bcdf78" />
  -
<img width="874" height="347" alt="image" src="https://github.com/user-attachments/assets/40985351-d68a-44a0-81fc-16a524448d7d" />

### Lorebook entry details

Different test run from the previous screenshot.

<img width="867" height="927" alt="image" src="https://github.com/user-attachments/assets/e61c3891-333b-4213-9e1b-b980d2dcec8b" />

### Retrieval

<img width="902" height="262" alt="image" src="https://github.com/user-attachments/assets/f1bda82a-4709-4b64-9a30-83d7573a7455" />
 
## Status

This PR is intended as a concrete proposal for Oracle rather than a final “this is the only shape” implementation.

The code is ready for review and manual testing passes, but I am open to changing the trigger syntax, persistence behavior, config surface, or cutting scope if maintainers prefer a smaller first version.

The issue and this PR description were written with LLM assistance. The feature itself comes from my own use case, and the implementation was manually tested in CONVO.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Oracle agent for live web search functionality
  * Trigger searches via `<search>topic</search>` tags in messages
  * Automatic summarization and injection into character context
  * Optional persistence of character insights to lorebook
  * Configure in Settings → Connections → Oracle

* **Documentation**
  * Added Oracle agent setup and usage documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->