### PR TITLE
feat: add /goto slash command to jump to a message by number

### DIFF
--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -38,6 +38,7 @@ import { api } from "../../lib/api-client";
 import { parseCharacterDisplayData } from "../../lib/character-display";
 import { showConfirmDialog } from "../../lib/app-dialogs";
 import { useGameStateStore } from "../../stores/game-state.store";
+import { toast } from "sonner";
 import { BookOpen, HelpCircle, MessageSquare, Theater } from "lucide-react";
 import type { SpritePlacement, SpriteSide } from "@marinara-engine/shared";
 import { useUIStore } from "../../stores/ui.store";
@@ -903,6 +904,63 @@ export function ChatArea() {
     isLoadingMoreRef.current = true;
     fetchNextPage();
   }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
+
+  // ── /goto command: paginate older pages until target message is loaded, then scroll to it
+  const gotoRequest = useChatStore((s) => s.gotoRequest);
+  useEffect(() => {
+    if (!gotoRequest || gotoRequest.chatId !== activeChatId) return;
+    if (!messages) return;
+
+    const targetNumber = gotoRequest.messageNumber;
+    if (totalMessageCount > 0 && targetNumber > totalMessageCount) {
+      toast.error(`Message #${targetNumber} doesn't exist — this chat has ${totalMessageCount} messages.`);
+      useChatStore.getState().clearGotoRequest();
+      return;
+    }
+
+    const targetIndex = targetNumber - 1; // 0-based global index
+    if (targetIndex >= messageOffset) {
+      const targetId = messageIdByOrderIndex.get(targetIndex);
+      if (!targetId) {
+        useChatStore.getState().clearGotoRequest();
+        return;
+      }
+      // Wait one frame so newly-loaded messages are painted before scrolling.
+      const raf = requestAnimationFrame(() => {
+        const el = document.querySelector(`[data-message-id="${CSS.escape(targetId)}"]`);
+        if (el instanceof HTMLElement) {
+          el.scrollIntoView({ behavior: "smooth", block: "center" });
+          userScrolledAwayRef.current = true; // suppress auto-scroll-to-bottom hijacking the jump
+        }
+        useChatStore.getState().clearGotoRequest();
+      });
+      return () => cancelAnimationFrame(raf);
+    }
+
+    // Target is older than the loaded window — fetch the next (older) page.
+    if (hasNextPage && !isFetchingNextPage) {
+      // Only engage the roleplay-surface scroll-preservation handshake when that
+      // surface is actually mounted; otherwise the flag would be set forever.
+      if (scrollRef.current) {
+        prevScrollHeightRef.current = scrollRef.current.scrollHeight;
+        isLoadingMoreRef.current = true;
+      }
+      fetchNextPage();
+    } else if (!hasNextPage) {
+      // Nothing more to load but we still didn't reach the target — give up.
+      useChatStore.getState().clearGotoRequest();
+    }
+  }, [
+    gotoRequest,
+    activeChatId,
+    messages,
+    messageOffset,
+    messageIdByOrderIndex,
+    totalMessageCount,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  ]);
 
   // ═══════════════════════════════════════════════
   // Empty state (no active chat)

--- a/packages/client/src/lib/slash-commands.ts
+++ b/packages/client/src/lib/slash-commands.ts
@@ -335,6 +335,22 @@ const COMMANDS: SlashCommand[] = [
     },
   },
   {
+    name: "goto",
+    aliases: ["jump", "scroll"],
+    description: "Scroll to a specific message number (e.g. /goto 27)",
+    usage: "/goto <number>",
+    local: true,
+    async execute(args, ctx) {
+      const raw = args.trim();
+      const n = Number.parseInt(raw, 10);
+      if (!raw || !Number.isFinite(n) || n < 1 || String(n) !== raw) {
+        return { handled: true, feedback: "Usage: /goto <positive message number> (e.g. /goto 27)" };
+      }
+      useChatStore.getState().requestGotoMessage(ctx.chatId, n);
+      return { handled: true };
+    },
+  },
+  {
     name: "help",
     description: "Show available slash commands",
     usage: "/help",

--- a/packages/client/src/stores/chat.store.ts
+++ b/packages/client/src/stores/chat.store.ts
@@ -72,6 +72,8 @@ interface ChatState {
   chatNotifications: Map<string, { chatId: string; characterName: string; avatarUrl: string | null; count: number }>;
   /** Manually dismissed notification chatIds (won't re-appear until next message). */
   dismissedNotifications: Set<string>;
+  /** Pending /goto request — ChatArea fulfils by paginating + scrolling to the target message. Token forces re-fire on identical N. */
+  gotoRequest: { chatId: string; messageNumber: number; token: number } | null;
 
   // Actions
   setActiveChat: (chat: Chat | null) => void;
@@ -104,6 +106,8 @@ interface ChatState {
   clearUnread: (chatId: string) => void;
   addNotification: (chatId: string, characterName: string, avatarUrl: string | null) => void;
   dismissNotification: (chatId: string) => void;
+  requestGotoMessage: (chatId: string, messageNumber: number) => void;
+  clearGotoRequest: () => void;
   reset: () => void;
 }
 
@@ -138,6 +142,7 @@ export const useChatStore = create<ChatState>()(
     unreadCounts: new Map(),
     chatNotifications: new Map(),
     dismissedNotifications: new Set(),
+    gotoRequest: null,
 
     setActiveChat: (chat) => set({ activeChat: chat }),
     setActiveChatId: (id) => {
@@ -336,6 +341,16 @@ export const useChatStore = create<ChatState>()(
         return { chatNotifications: m, dismissedNotifications: d };
       }),
 
+    requestGotoMessage: (chatId, messageNumber) =>
+      set((state) => ({
+        gotoRequest: {
+          chatId,
+          messageNumber,
+          token: (state.gotoRequest?.token ?? 0) + 1,
+        },
+      })),
+    clearGotoRequest: () => set({ gotoRequest: null }),
+
     setSwipeIndex: (messageId: string, index: number) =>
       set((state) => {
         const m = new Map(state.swipeIndex);
@@ -365,6 +380,7 @@ export const useChatStore = create<ChatState>()(
         unreadCounts: new Map(),
         chatNotifications: new Map(),
         dismissedNotifications: new Set(),
+        gotoRequest: null,
       });
       try {
         localStorage.removeItem(STORAGE_KEY);


### PR DESCRIPTION
## Summary
- Adds `/goto N` (aliases `/jump`, `/scroll`) — scrolls the chat to message #N using the same 1-based numbering already exposed by the existing "Show message numbers" setting.
- If the target message lives in an older paginated page, the handler auto-fetches older pages one at a time (mirroring the existing "load more" path) until the message is in the DOM, then smooth-scrolls to it (`block: "center"`).
- Out-of-range numbers show a sonner toast (`Message #N doesn't exist — this chat has X messages.`); bad input (non-integer, ≤ 0) returns the usage hint via the normal slash-command feedback bubble.

## Why
Long chats are a pain to navigate — scrolling back hundreds of messages to revisit a specific moment is tedious and breaks flow. `/goto 27` jumps you straight there, including across paginated history.

## Implementation
- `stores/chat.store.ts` — new `gotoRequest` state + `requestGotoMessage` / `clearGotoRequest` actions. A `token` field forces re-fire when the same number is requested twice.
- `lib/slash-commands.ts` — new local `/goto` command; validates input and dispatches via the store so the command stays decoupled from React.
- `components/chat/ChatArea.tsx` — effect fulfils the request: paginate older pages until the target index is in the loaded window, then `scrollIntoView` via `data-message-id`. Sets `userScrolledAwayRef` so the streaming auto-scroll-to-bottom doesn't immediately yank the user back.

## Test plan
- [x] `/goto 27` in a chat with the target already loaded → scrolls smoothly to message #27, centered.
- [x] `/goto 27` in a long chat where #27 is on an older page → auto-fetches older pages then scrolls.
- [x] `/goto 9999` (out of range) → toast: `Message #9999 doesn't exist — this chat has X messages.`
- [x] `/goto abc`, `/goto 0`, `/goto -3`, `/goto` → usage hint shown in feedback bubble.
- [x] Works in both Conversation and Roleplay surfaces.
- [x] `pnpm check` (TypeScript + ESLint + build) is clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/goto` slash command for message navigation. Users can jump to specific messages by entering `/goto <message_number>`. The feature includes input validation, error feedback, and automatic pagination for older messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->