### PR TITLE
fix: refresh branch selector dropdown after chat rename

### DIFF
--- a/packages/client/src/hooks/use-chats.ts
+++ b/packages/client/src/hooks/use-chats.ts
@@ -163,9 +163,18 @@ export function useUpdateChat() {
       personaId?: string | null;
       characterIds?: string[];
     }) => api.patch<Chat>(`/chats/${id}`, data),
-    onSuccess: (_data, vars) => {
+    onSuccess: (updatedChat, vars) => {
       qc.invalidateQueries({ queryKey: chatKeys.detail(vars.id) });
       qc.invalidateQueries({ queryKey: chatKeys.list() });
+
+      // Patch the group cache so the branch selector dropdown reflects renames
+      // (and any other field changes) without waiting for a chat switch.
+      if (updatedChat?.groupId) {
+        qc.setQueryData<Chat[]>(chatKeys.group(updatedChat.groupId), (existing) =>
+          existing?.map((chat) => (chat.id === vars.id ? updatedChat : chat)),
+        );
+      }
+      qc.invalidateQueries({ queryKey: [...chatKeys.all, "group"] });
     },
   });
 }


### PR DESCRIPTION
## Summary
- `useUpdateChat.onSuccess` only invalidated `chatKeys.detail` and `chatKeys.list`, leaving `chatKeys.group` (read by `ChatBranchSelector` via `useChatGroup`) stale.
- After a rename, "Manage Chat Files" updated correctly but the new branch selector dropdown — both its current label and the list — kept showing the old name until the user switched chats and came back.
- Now we patch the group cache directly with the returned chat (instant UI update, no flicker) and invalidate `chatKeys.group` as a safety net.

Fixes #234.

## Test plan
- [x] Create a chat with 2+ branches.
- [x] Rename the active branch via Chat Settings → name field.
- [x] Dropdown selector label updates immediately to the new name.
- [x] Open the dropdown — the renamed branch shows the new name in the list (no chat switch required).
- [x] Rename a non-active branch from a different surface (e.g. Quick Switcher / Wizard) — dropdown list still reflects the new name.
- [x] `pnpm check` clean (TypeScript + ESLint + build).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Chat updates now sync immediately with the server, ensuring cached chat lists remain consistent and display the latest state without requiring additional refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->