### PR TITLE
fix(client): persist Author's Notes across outside-click dismissal

### DIFF
--- a/packages/client/src/components/chat/ChatRoleplayPanels.tsx
+++ b/packages/client/src/components/chat/ChatRoleplayPanels.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Globe, Loader2, PenLine, X } from "lucide-react";
 import { useUpdateChatMetadata } from "../../hooks/use-chats";
 import { useActiveLorebookEntries } from "../../hooks/use-lorebooks";
@@ -104,10 +104,38 @@ export function AuthorNotesPanel({
   const [depthStr, setDepthStr] = useState(String((chatMeta.authorNotesDepth as number) ?? 4));
   const updateMeta = useUpdateChatMetadata();
 
+  const latestRef = useRef({ notes, depthStr });
+  latestRef.current = { notes, depthStr };
+  const baselineRef = useRef({
+    notes: (chatMeta.authorNotes as string) ?? "",
+    depth: (chatMeta.authorNotesDepth as number) ?? 4,
+  });
+  const mutateRef = useRef(updateMeta.mutate);
+  mutateRef.current = updateMeta.mutate;
+
   useEffect(() => {
     setNotes((chatMeta.authorNotes as string) ?? "");
     setDepthStr(String((chatMeta.authorNotesDepth as number) ?? 4));
+    baselineRef.current = {
+      notes: (chatMeta.authorNotes as string) ?? "",
+      depth: (chatMeta.authorNotesDepth as number) ?? 4,
+    };
   }, [chatMeta.authorNotes, chatMeta.authorNotesDepth]);
+
+  // Outside-click closes the popover via mousedown, which unmounts the
+  // textarea before its onBlur (the only save trigger) can fire. Flush
+  // the pending edit from the unmount cleanup so typed content survives.
+  useEffect(() => {
+    const capturedChatId = chatId;
+    return () => {
+      const { notes: n, depthStr: d } = latestRef.current;
+      const nextDepth = Math.max(0, parseInt(d, 10) || 0);
+      const base = baselineRef.current;
+      if (n !== base.notes || nextDepth !== base.depth) {
+        mutateRef.current({ id: capturedChatId, authorNotes: n, authorNotesDepth: nextDepth });
+      }
+    };
+  }, [chatId]);
 
   const depth = parseInt(depthStr, 10) || 0;
   const handleSave = () => {


### PR DESCRIPTION
## The bug

Open Author's Notes, type something, click outside the popover — typed content is lost some of the time.

## Root cause

The outside-click handler in `AuthorNotesButton` fires on `mousedown` and calls `setOpen(false)`, which unmounts the textarea before its `onBlur` (the only save trigger) can run. `onBlur` is the lone save path, so when it loses the race the edit is dropped.

Big thanks to @Trade-Mottoes for surfacing this in #213 — the diagnosis there is spot on. I'm taking a different fix path here so we can keep the existing CSS/HTML structure and the no-explicit-save UX intact (Marinara prefers consistency with the existing infrastructure, and the popover should just persist what you typed without a Save button).

## Fix

Flush pending edits from a `useEffect` cleanup in `AuthorNotesPanel`.

- Cleanups run synchronously when React unmounts the component, so the save fires even when outside-click destroys the textarea before `onBlur`.
- React Query's `mutate` is fire-and-forget — the network request goes out fine after the component is gone.
- A `baselineRef` snapshot of the incoming `chatMeta` gates the flush, so we only mutate when the user actually changed something (no spurious writes on simple peek-and-close).
- A `latestRef` carries the most recent textarea/depth values into the cleanup closure.
- The existing `onBlur` save path is preserved — it still handles the tab-between-fields case where the popover stays mounted.

## What did NOT change

- No markup, no CSS, no new components, no Modal swap, no Save/Cancel buttons.
- Mobile and desktop render exactly the same as before.
- One file touched: `packages/client/src/components/chat/ChatRoleplayPanels.tsx` (+29 / -1).

## Testing

- `pnpm check` passes.
- Manually verified: rapid type-then-outside-click no longer loses content, on both desktop popover and mobile portal.
- Verified peek-and-close (no edit) does not trigger an unnecessary mutation.

## Test plan

- [x] Open Author's Notes, type a paragraph, click outside — re-open and confirm content is preserved.
- [x] Repeat 10x rapidly to confirm the race is gone.
- [x] Change Injection Depth, click outside — confirm depth persists.
- [x] Open Author's Notes and close without typing — confirm no extraneous network calls.
- [x] Mobile viewport: same scenarios via the portal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved author notes preservation by ensuring edits are reliably saved when navigating between chats, preventing accidental data loss from rapid interactions or panel closures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->