### PR TITLE
feat(chat): "Mari is thinking…" / "updating your stuff…" indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This file is the release-notes source of truth for Marinara Engine. Reuse these entries when publishing GitHub Releases for tags in the `vX.Y.Z` format.
 
+## [Unreleased]
+
+### Added
+
+- "Mari is thinking…" indicator appears above the composer while Professor Mari executes her embedded commands (create/update character, fetch, create chat, navigate). Makes it clear her background work is running and not frozen.
+
 ## [1.5.5]
 
 ### Added

--- a/packages/client/src/components/chat/ChatInput.tsx
+++ b/packages/client/src/components/chat/ChatInput.tsx
@@ -25,6 +25,7 @@ import { EmojiPicker } from "../ui/EmojiPicker";
 import { QuickConnectionSwitcher } from "./QuickConnectionSwitcher";
 import { QuickPersonaSwitcher } from "./QuickPersonaSwitcher";
 import { QuickSwitcherMobile } from "./QuickSwitcherMobile";
+import { MariThinkingIndicator } from "./MariThinkingIndicator";
 
 interface Attachment {
   type: string; // MIME type
@@ -614,6 +615,9 @@ export const ChatInput = memo(function ChatInput({
           ))}
         </div>
       )}
+
+      {/* Mari command-execution indicator */}
+      <MariThinkingIndicator />
 
       {/* Main input container */}
       <div

--- a/packages/client/src/components/chat/ConversationInput.tsx
+++ b/packages/client/src/components/chat/ConversationInput.tsx
@@ -24,6 +24,7 @@ import { QuickPersonaSwitcher } from "./QuickPersonaSwitcher";
 import { QuickSwitcherMobile } from "./QuickSwitcherMobile";
 import { EmojiPicker } from "../ui/EmojiPicker";
 import { GifPicker } from "../ui/GifPicker";
+import { MariThinkingIndicator } from "./MariThinkingIndicator";
 
 interface Attachment {
   type: string;
@@ -625,6 +626,9 @@ export function ConversationInput({ characterNames = [] }: ConversationInputProp
           ))}
         </div>
       )}
+
+      {/* Mari command-execution indicator */}
+      <MariThinkingIndicator />
 
       {/* Input bar */}
       <div

--- a/packages/client/src/components/chat/MariThinkingIndicator.tsx
+++ b/packages/client/src/components/chat/MariThinkingIndicator.tsx
@@ -55,6 +55,13 @@ export const MariThinkingIndicator = memo(function MariThinkingIndicator() {
 
   const [visible, setVisible] = useState(false);
   const shownAtRef = useRef(0);
+  /**
+   * chatId that owns the currently-visible pill. Used to bypass the
+   * minimum-duration hide when the user switches away to a different chat —
+   * otherwise a lingering timer would briefly show "Mari is thinking…" in a
+   * chat where nothing is executing.
+   */
+  const visibleChatIdRef = useRef<string | null>(null);
   const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
@@ -63,6 +70,7 @@ export const MariThinkingIndicator = memo(function MariThinkingIndicator() {
         clearTimeout(hideTimerRef.current);
         hideTimerRef.current = null;
       }
+      visibleChatIdRef.current = null;
       setVisible(false);
       return;
     }
@@ -75,14 +83,32 @@ export const MariThinkingIndicator = memo(function MariThinkingIndicator() {
           clearTimeout(hideTimerRef.current);
           hideTimerRef.current = null;
         }
-        shownAtRef.current = Date.now();
+        // Reset the minimum-duration start only when the pill first opens
+        // (or re-opens for a different chat) — not on every re-evaluate.
+        if (visibleChatIdRef.current !== currentActive) {
+          shownAtRef.current = Date.now();
+        }
+        visibleChatIdRef.current = currentActive;
         setVisible(true);
       } else {
+        // If the user switched away from the chat that owns the visible
+        // pill, hide immediately — don't let the minimum-duration timer
+        // linger into a chat where nothing is executing.
+        if (visibleChatIdRef.current && currentActive !== visibleChatIdRef.current) {
+          if (hideTimerRef.current) {
+            clearTimeout(hideTimerRef.current);
+            hideTimerRef.current = null;
+          }
+          visibleChatIdRef.current = null;
+          setVisible(false);
+          return;
+        }
         if (hideTimerRef.current) return;
         const elapsed = Date.now() - shownAtRef.current;
         const remaining = Math.max(0, MIN_VISIBLE_MS - elapsed);
         hideTimerRef.current = setTimeout(() => {
           hideTimerRef.current = null;
+          visibleChatIdRef.current = null;
           setVisible(false);
         }, remaining);
       }

--- a/packages/client/src/components/chat/MariThinkingIndicator.tsx
+++ b/packages/client/src/components/chat/MariThinkingIndicator.tsx
@@ -6,132 +6,142 @@ import { PROFESSOR_MARI_ID } from "@marinara-engine/shared";
 import { useChatStore } from "../../stores/chat.store";
 import { useChat } from "../../hooks/use-chats";
 
-/** Minimum visible duration so fast command runs (single DB write) still register. */
+/** Minimum visible duration so fast phases (single DB write) still register. */
 const MIN_VISIBLE_MS = 600;
 
+type MariPhase = "thinking" | "updating" | "idle";
+
+const PHASE_LABEL: Record<Exclude<MariPhase, "idle">, string> = {
+  thinking: "Mari is thinking…",
+  updating: "Mari is updating your stuff…",
+};
+
 /**
- * Visible-while-working signal for the post-stream command window.
+ * Visible-while-working signal for Mari's two work phases:
  *
- * Mari's embedded commands (create_character, update_character, fetch, …)
- * execute in a server-side loop after her reply finishes streaming. During
- * that window the UI is otherwise silent — no tokens, no typing indicator —
- * so a user who asked her to modify their data can't tell whether she's
- * still working or stalled.
+ * 1. `thinking` — Mari is generating her reply (token streaming has begun).
+ * 2. `updating` — Mari is running embedded commands (create_character,
+ *    update_character, fetch, …) in the post-stream loop.
  *
- * The server emits `assistant_commands_start` / `assistant_commands_end`
- * SSE events around the command loop; `commandsExecutingChatId` mirrors
- * that window. We only surface the indicator in chats where Mari is a
- * participant so non-Mari commands (schedule_update, cross_post, etc.)
- * don't mistakenly trigger a "Mari is thinking" pill.
+ * Without this pill the UI is otherwise silent during those phases, so a
+ * user who asked her to do something can't tell whether she's still working
+ * or stalled.
  *
- * The store is observed via Zustand's direct `subscribe` rather than a
- * selector hook: simple DB commands complete in a fraction of a tick, so
- * the start and end state updates land in the same React batch and the
- * component would never render the intermediate active state. The direct
- * subscribe fires once per state change, capturing both transitions.
+ * Transport: window CustomEvents `marinara:mari-phase` dispatched by
+ * use-generate.ts. We previously tried a Zustand subscribeWithSelector
+ * subscription; in this codebase that combination has documented timing
+ * issues with React 19 batching that drop fast transitions (see
+ * GameSurface.tsx for the same workaround). CustomEvents fire synchronously
+ * and outside React's batching, so the indicator reliably observes every
+ * phase change.
  *
- * A minimum visible duration (MIN_VISIBLE_MS) keeps the pill on-screen
- * long enough to perceive even when a command finishes in under a
- * millisecond.
+ * A minimum visible duration keeps each phase on-screen long enough to
+ * perceive even when it finishes in under a millisecond.
  */
+function isMariParticipant(activeChat: unknown): boolean {
+  // characterIds arrives as an array (typed) or a JSON-encoded string
+  // (raw SQLite column) depending on the endpoint that produced it.
+  const raw = (activeChat as { characterIds?: unknown } | null | undefined)?.characterIds;
+  if (Array.isArray(raw)) return raw.includes(PROFESSOR_MARI_ID);
+  if (typeof raw === "string") {
+    try {
+      const parsed = JSON.parse(raw);
+      return Array.isArray(parsed) && parsed.includes(PROFESSOR_MARI_ID);
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
+
 export const MariThinkingIndicator = memo(function MariThinkingIndicator() {
   const activeChatId = useChatStore((s) => s.activeChatId);
   const { data: activeChat } = useChat(activeChatId);
+  const isMariChat = useMemo(() => isMariParticipant(activeChat), [activeChat]);
 
-  const isMariChat = useMemo(() => {
-    // characterIds can arrive as an array or a JSON-encoded string depending on endpoint.
-    const raw = (activeChat as { characterIds?: unknown } | null | undefined)?.characterIds;
-    if (Array.isArray(raw)) return raw.includes(PROFESSOR_MARI_ID);
-    if (typeof raw === "string") {
-      try {
-        const parsed = JSON.parse(raw);
-        return Array.isArray(parsed) && parsed.includes(PROFESSOR_MARI_ID);
-      } catch {
-        return false;
-      }
-    }
-    return false;
-  }, [activeChat]);
-
-  const [visible, setVisible] = useState(false);
-  const shownAtRef = useRef(0);
-  /**
-   * chatId that owns the currently-visible pill. Used to bypass the
-   * minimum-duration hide when the user switches away to a different chat —
-   * otherwise a lingering timer would briefly show "Mari is thinking…" in a
-   * chat where nothing is executing.
-   */
+  const [phase, setPhase] = useState<MariPhase>("idle");
+  const phaseShownAtRef = useRef(0);
   const visibleChatIdRef = useRef<string | null>(null);
   const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const activeChatIdRef = useRef(activeChatId);
+  activeChatIdRef.current = activeChatId;
+  const isMariChatRef = useRef(isMariChat);
+  isMariChatRef.current = isMariChat;
 
+  // Hide immediately when the user leaves a Mari chat — the pill belongs to
+  // the previous chat and shouldn't linger into a chat that doesn't even
+  // qualify for the indicator.
   useEffect(() => {
-    if (!isMariChat) {
+    if (isMariChat) return;
+    if (hideTimerRef.current) {
+      clearTimeout(hideTimerRef.current);
+      hideTimerRef.current = null;
+    }
+    visibleChatIdRef.current = null;
+    setPhase("idle");
+  }, [isMariChat]);
+
+  // If the active chat changes while the pill is showing for a different
+  // chat, hide it immediately — don't let the min-duration timer leak the
+  // pill into an unrelated chat.
+  useEffect(() => {
+    if (visibleChatIdRef.current && visibleChatIdRef.current !== activeChatId) {
       if (hideTimerRef.current) {
         clearTimeout(hideTimerRef.current);
         hideTimerRef.current = null;
       }
       visibleChatIdRef.current = null;
-      setVisible(false);
-      return;
+      setPhase("idle");
     }
+  }, [activeChatId]);
 
-    const evaluate = () => {
-      const { commandsExecutingChatIds, activeChatId: currentActive } = useChatStore.getState();
-      const shouldShow = !!currentActive && commandsExecutingChatIds.has(currentActive);
-      if (shouldShow) {
-        if (hideTimerRef.current) {
-          clearTimeout(hideTimerRef.current);
-          hideTimerRef.current = null;
-        }
-        // Reset the minimum-duration start only when the pill first opens
-        // (or re-opens for a different chat) — not on every re-evaluate.
-        if (visibleChatIdRef.current !== currentActive) {
-          shownAtRef.current = Date.now();
-        }
-        visibleChatIdRef.current = currentActive;
-        setVisible(true);
-      } else {
-        // If the user switched away from the chat that owns the visible
-        // pill, hide immediately — don't let the minimum-duration timer
-        // linger into a chat where nothing is executing.
-        if (visibleChatIdRef.current && currentActive !== visibleChatIdRef.current) {
-          if (hideTimerRef.current) {
-            clearTimeout(hideTimerRef.current);
-            hideTimerRef.current = null;
-          }
-          visibleChatIdRef.current = null;
-          setVisible(false);
-          return;
-        }
+  useEffect(() => {
+    const onPhase = (e: Event) => {
+      const detail = (e as CustomEvent<{ chatId?: string; phase?: MariPhase }>).detail;
+      const chatId = detail?.chatId;
+      const nextPhase = detail?.phase;
+      if (!chatId || !nextPhase) return;
+
+      // Idle event from a chat we don't own — nothing to hide here.
+      if (nextPhase === "idle" && visibleChatIdRef.current !== chatId) return;
+
+      if (nextPhase === "idle") {
         if (hideTimerRef.current) return;
-        // Nothing currently owns the pill, so there's nothing to hide — avoid
-        // scheduling a no-op setTimeout that would later fire setVisible(false)
-        // on already-hidden state.
-        if (!visibleChatIdRef.current) return;
-        const elapsed = Date.now() - shownAtRef.current;
+        const elapsed = Date.now() - phaseShownAtRef.current;
         const remaining = Math.max(0, MIN_VISIBLE_MS - elapsed);
         hideTimerRef.current = setTimeout(() => {
           hideTimerRef.current = null;
           visibleChatIdRef.current = null;
-          setVisible(false);
+          setPhase("idle");
         }, remaining);
+        return;
       }
+
+      // thinking / updating — only show in the chat the user is looking at,
+      // and only if Mari is a participant.
+      if (!isMariChatRef.current) return;
+      if (chatId !== activeChatIdRef.current) return;
+
+      if (hideTimerRef.current) {
+        clearTimeout(hideTimerRef.current);
+        hideTimerRef.current = null;
+      }
+      phaseShownAtRef.current = Date.now();
+      visibleChatIdRef.current = chatId;
+      setPhase(nextPhase);
     };
 
-    evaluate();
-    const unsubChatIds = useChatStore.subscribe((s) => s.commandsExecutingChatIds, evaluate);
-    const unsubActive = useChatStore.subscribe((s) => s.activeChatId, evaluate);
+    window.addEventListener("marinara:mari-phase", onPhase);
     return () => {
-      unsubChatIds();
-      unsubActive();
+      window.removeEventListener("marinara:mari-phase", onPhase);
       if (hideTimerRef.current) {
         clearTimeout(hideTimerRef.current);
         hideTimerRef.current = null;
       }
     };
-  }, [isMariChat]);
+  }, []);
 
-  if (!visible) return null;
+  if (phase === "idle") return null;
 
   return (
     <div
@@ -144,7 +154,7 @@ export const MariThinkingIndicator = memo(function MariThinkingIndicator() {
         <span className="h-1.5 w-1.5 rounded-full bg-blue-400 animate-pulse [animation-delay:200ms]" />
         <span className="h-1.5 w-1.5 rounded-full bg-blue-400 animate-pulse [animation-delay:400ms]" />
       </span>
-      <span>Mari is thinking…</span>
+      <span>{PHASE_LABEL[phase]}</span>
     </div>
   );
 });

--- a/packages/client/src/components/chat/MariThinkingIndicator.tsx
+++ b/packages/client/src/components/chat/MariThinkingIndicator.tsx
@@ -104,6 +104,10 @@ export const MariThinkingIndicator = memo(function MariThinkingIndicator() {
           return;
         }
         if (hideTimerRef.current) return;
+        // Nothing currently owns the pill, so there's nothing to hide — avoid
+        // scheduling a no-op setTimeout that would later fire setVisible(false)
+        // on already-hidden state.
+        if (!visibleChatIdRef.current) return;
         const elapsed = Date.now() - shownAtRef.current;
         const remaining = Math.max(0, MIN_VISIBLE_MS - elapsed);
         hideTimerRef.current = setTimeout(() => {

--- a/packages/client/src/components/chat/MariThinkingIndicator.tsx
+++ b/packages/client/src/components/chat/MariThinkingIndicator.tsx
@@ -1,0 +1,120 @@
+// ──────────────────────────────────────────────
+// Chat: Mari Thinking Indicator
+// ──────────────────────────────────────────────
+import { memo, useEffect, useMemo, useRef, useState } from "react";
+import { PROFESSOR_MARI_ID } from "@marinara-engine/shared";
+import { useChatStore } from "../../stores/chat.store";
+import { useChat } from "../../hooks/use-chats";
+
+/** Minimum visible duration so fast command runs (single DB write) still register. */
+const MIN_VISIBLE_MS = 600;
+
+/**
+ * Visible-while-working signal for the post-stream command window.
+ *
+ * Mari's embedded commands (create_character, update_character, fetch, …)
+ * execute in a server-side loop after her reply finishes streaming. During
+ * that window the UI is otherwise silent — no tokens, no typing indicator —
+ * so a user who asked her to modify their data can't tell whether she's
+ * still working or stalled.
+ *
+ * The server emits `assistant_commands_start` / `assistant_commands_end`
+ * SSE events around the command loop; `commandsExecutingChatId` mirrors
+ * that window. We only surface the indicator in chats where Mari is a
+ * participant so non-Mari commands (schedule_update, cross_post, etc.)
+ * don't mistakenly trigger a "Mari is thinking" pill.
+ *
+ * The store is observed via Zustand's direct `subscribe` rather than a
+ * selector hook: simple DB commands complete in a fraction of a tick, so
+ * the start and end state updates land in the same React batch and the
+ * component would never render the intermediate active state. The direct
+ * subscribe fires once per state change, capturing both transitions.
+ *
+ * A minimum visible duration (MIN_VISIBLE_MS) keeps the pill on-screen
+ * long enough to perceive even when a command finishes in under a
+ * millisecond.
+ */
+export const MariThinkingIndicator = memo(function MariThinkingIndicator() {
+  const activeChatId = useChatStore((s) => s.activeChatId);
+  const { data: activeChat } = useChat(activeChatId);
+
+  const isMariChat = useMemo(() => {
+    // characterIds can arrive as an array or a JSON-encoded string depending on endpoint.
+    const raw = (activeChat as { characterIds?: unknown } | null | undefined)?.characterIds;
+    if (Array.isArray(raw)) return raw.includes(PROFESSOR_MARI_ID);
+    if (typeof raw === "string") {
+      try {
+        const parsed = JSON.parse(raw);
+        return Array.isArray(parsed) && parsed.includes(PROFESSOR_MARI_ID);
+      } catch {
+        return false;
+      }
+    }
+    return false;
+  }, [activeChat]);
+
+  const [visible, setVisible] = useState(false);
+  const shownAtRef = useRef(0);
+  const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (!isMariChat) {
+      if (hideTimerRef.current) {
+        clearTimeout(hideTimerRef.current);
+        hideTimerRef.current = null;
+      }
+      setVisible(false);
+      return;
+    }
+
+    const evaluate = () => {
+      const { commandsExecutingChatId, activeChatId: currentActive } = useChatStore.getState();
+      const shouldShow = !!currentActive && commandsExecutingChatId === currentActive;
+      if (shouldShow) {
+        if (hideTimerRef.current) {
+          clearTimeout(hideTimerRef.current);
+          hideTimerRef.current = null;
+        }
+        shownAtRef.current = Date.now();
+        setVisible(true);
+      } else {
+        if (hideTimerRef.current) return;
+        const elapsed = Date.now() - shownAtRef.current;
+        const remaining = Math.max(0, MIN_VISIBLE_MS - elapsed);
+        hideTimerRef.current = setTimeout(() => {
+          hideTimerRef.current = null;
+          setVisible(false);
+        }, remaining);
+      }
+    };
+
+    evaluate();
+    const unsubChatId = useChatStore.subscribe((s) => s.commandsExecutingChatId, evaluate);
+    const unsubActive = useChatStore.subscribe((s) => s.activeChatId, evaluate);
+    return () => {
+      unsubChatId();
+      unsubActive();
+      if (hideTimerRef.current) {
+        clearTimeout(hideTimerRef.current);
+        hideTimerRef.current = null;
+      }
+    };
+  }, [isMariChat]);
+
+  if (!visible) return null;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="mb-2 flex items-center gap-2 rounded-lg bg-foreground/5 px-3 py-1.5 text-xs text-foreground/60"
+    >
+      <span className="flex items-center gap-1" aria-hidden="true">
+        <span className="h-1.5 w-1.5 rounded-full bg-blue-400 animate-pulse" />
+        <span className="h-1.5 w-1.5 rounded-full bg-blue-400 animate-pulse [animation-delay:200ms]" />
+        <span className="h-1.5 w-1.5 rounded-full bg-blue-400 animate-pulse [animation-delay:400ms]" />
+      </span>
+      <span>Mari is thinking…</span>
+    </div>
+  );
+});

--- a/packages/client/src/components/chat/MariThinkingIndicator.tsx
+++ b/packages/client/src/components/chat/MariThinkingIndicator.tsx
@@ -68,8 +68,8 @@ export const MariThinkingIndicator = memo(function MariThinkingIndicator() {
     }
 
     const evaluate = () => {
-      const { commandsExecutingChatId, activeChatId: currentActive } = useChatStore.getState();
-      const shouldShow = !!currentActive && commandsExecutingChatId === currentActive;
+      const { commandsExecutingChatIds, activeChatId: currentActive } = useChatStore.getState();
+      const shouldShow = !!currentActive && commandsExecutingChatIds.has(currentActive);
       if (shouldShow) {
         if (hideTimerRef.current) {
           clearTimeout(hideTimerRef.current);
@@ -89,10 +89,10 @@ export const MariThinkingIndicator = memo(function MariThinkingIndicator() {
     };
 
     evaluate();
-    const unsubChatId = useChatStore.subscribe((s) => s.commandsExecutingChatId, evaluate);
+    const unsubChatIds = useChatStore.subscribe((s) => s.commandsExecutingChatIds, evaluate);
     const unsubActive = useChatStore.subscribe((s) => s.activeChatId, evaluate);
     return () => {
-      unsubChatId();
+      unsubChatIds();
       unsubActive();
       if (hideTimerRef.current) {
         clearTimeout(hideTimerRef.current);

--- a/packages/client/src/components/chat/MariThinkingIndicator.tsx
+++ b/packages/client/src/components/chat/MariThinkingIndicator.tsx
@@ -27,13 +27,20 @@ const PHASE_LABEL: Record<Exclude<MariPhase, "idle">, string> = {
  * user who asked her to do something can't tell whether she's still working
  * or stalled.
  *
- * Transport: window CustomEvents `marinara:mari-phase` dispatched by
- * use-generate.ts. We previously tried a Zustand subscribeWithSelector
- * subscription; in this codebase that combination has documented timing
- * issues with React 19 batching that drop fast transitions (see
- * GameSurface.tsx for the same workaround). CustomEvents fire synchronously
- * and outside React's batching, so the indicator reliably observes every
- * phase change.
+ * Two transports working together:
+ *
+ * - **Live transitions** inside the active chat are driven by window
+ *   CustomEvents `marinara:mari-phase` dispatched by use-generate.ts. We
+ *   previously tried a Zustand subscribeWithSelector subscription; in this
+ *   codebase that combination has documented timing issues with React 19
+ *   batching that drop fast transitions (see GameSurface.tsx for the same
+ *   workaround). CustomEvents fire synchronously outside React's batching,
+ *   so the indicator reliably observes every phase change in real time.
+ *
+ * - **Chat-switch restoration** is driven by `mariPhaseByChatId` in the
+ *   chat store. When the user leaves a chat mid-stream and comes back, no
+ *   live event re-fires for the same phase — the store carries the truth so
+ *   the indicator can restore the pill from current state on switch.
  *
  * A minimum visible duration keeps each phase on-screen long enough to
  * perceive even when it finishes in under a millisecond.
@@ -68,32 +75,31 @@ export const MariThinkingIndicator = memo(function MariThinkingIndicator() {
   const isMariChatRef = useRef(isMariChat);
   isMariChatRef.current = isMariChat;
 
-  // Hide immediately when the user leaves a Mari chat — the pill belongs to
-  // the previous chat and shouldn't linger into a chat that doesn't even
-  // qualify for the indicator.
+  // On chat switch (or when isMariChat flips), re-derive the pill from store
+  // truth. Reads the store imperatively so within-chat phase changes don't
+  // re-trigger this effect — those are handled by the CustomEvent listener
+  // below, which applies the min-visible-duration on hide. This effect's job
+  // is purely "what should the pill look like for the chat I just opened?".
   useEffect(() => {
-    if (isMariChat) return;
     if (hideTimerRef.current) {
       clearTimeout(hideTimerRef.current);
       hideTimerRef.current = null;
     }
-    visibleChatIdRef.current = null;
-    setPhase("idle");
-  }, [isMariChat]);
-
-  // If the active chat changes while the pill is showing for a different
-  // chat, hide it immediately — don't let the min-duration timer leak the
-  // pill into an unrelated chat.
-  useEffect(() => {
-    if (visibleChatIdRef.current && visibleChatIdRef.current !== activeChatId) {
-      if (hideTimerRef.current) {
-        clearTimeout(hideTimerRef.current);
-        hideTimerRef.current = null;
-      }
+    if (!isMariChat || !activeChatId) {
+      visibleChatIdRef.current = null;
+      setPhase("idle");
+      return;
+    }
+    const storedPhase = useChatStore.getState().mariPhaseByChatId.get(activeChatId) ?? null;
+    if (storedPhase) {
+      phaseShownAtRef.current = Date.now();
+      visibleChatIdRef.current = activeChatId;
+      setPhase(storedPhase);
+    } else {
       visibleChatIdRef.current = null;
       setPhase("idle");
     }
-  }, [activeChatId]);
+  }, [activeChatId, isMariChat]);
 
   useEffect(() => {
     const onPhase = (e: Event) => {

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -540,11 +540,18 @@ export function useGenerate() {
         rafId = requestAnimationFrame(tick);
       };
 
-      // Safety net: guarantees the "Mari is thinking…" indicator clears for
-      // this chat on every termination path (done, error, abort, unexpected
+      // Safety net: guarantees the Mari work-status pill clears for this
+      // chat on every termination path (done, error, abort, unexpected
       // throw). The assistant_commands_end SSE event is still the primary
       // clear; this just keeps state sane when the stream dies mid-window.
-      const clearCommandsExecutingForThisChat = () => setCommandsExecuting(params.chatId, false);
+      const clearCommandsExecutingForThisChat = () => {
+        setCommandsExecuting(params.chatId, false);
+        window.dispatchEvent(
+          new CustomEvent("marinara:mari-phase", {
+            detail: { chatId: params.chatId, phase: "idle" },
+          }),
+        );
+      };
 
       try {
         const userStatus = useUIStore.getState().userStatus;
@@ -560,6 +567,7 @@ export function useGenerate() {
         )) {
           switch (event.type) {
             case "token": {
+              const isFirstToken = !receivedContent;
               receivedContent = true;
               // Always clear per-chat indicators so switching back shows nothing
               useChatStore.getState().setPerChatTyping(params.chatId, null);
@@ -568,6 +576,16 @@ export function useGenerate() {
                 setTypingCharacterName(null); // Clear typing indicator once response starts
                 setDelayedCharacterInfo(null); // Clear delayed indicator too
                 useChatStore.getState().setGenerationPhase(null); // Clear phase indicator
+              }
+              // Fire the "Mari is thinking…" pill on the first token — that's
+              // the same moment "X is typing…" clears, so the two indicators
+              // never overlap.
+              if (isFirstToken) {
+                window.dispatchEvent(
+                  new CustomEvent("marinara:mari-phase", {
+                    detail: { chatId: params.chatId, phase: "thinking" },
+                  }),
+                );
               }
 
               let chunk = event.data as string;
@@ -1068,6 +1086,11 @@ export function useGenerate() {
 
             case "assistant_commands_start": {
               setCommandsExecuting(params.chatId, true);
+              window.dispatchEvent(
+                new CustomEvent("marinara:mari-phase", {
+                  detail: { chatId: params.chatId, phase: "updating" },
+                }),
+              );
               break;
             }
 
@@ -1367,6 +1390,7 @@ export function useGenerate() {
     [
       qc,
       setStreaming,
+      setCommandsExecuting,
       setStreamBuffer,
       clearStreamBuffer,
       setRegenerateMessageId,

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -310,6 +310,7 @@ export function useGenerate() {
   const qc = useQueryClient();
   // Use individual selectors to avoid re-rendering on every store change
   const setStreaming = useChatStore((s) => s.setStreaming);
+  const setCommandsExecutingChatId = useChatStore((s) => s.setCommandsExecutingChatId);
   const setStreamBuffer = useChatStore((s) => s.setStreamBuffer);
   const clearStreamBuffer = useChatStore((s) => s.clearStreamBuffer);
   const setRegenerateMessageId = useChatStore((s) => s.setRegenerateMessageId);
@@ -1059,6 +1060,18 @@ export function useGenerate() {
               break;
             }
 
+            case "assistant_commands_start": {
+              setCommandsExecutingChatId(params.chatId);
+              break;
+            }
+
+            case "assistant_commands_end": {
+              if (useChatStore.getState().commandsExecutingChatId === params.chatId) {
+                setCommandsExecutingChatId(null);
+              }
+              break;
+            }
+
             case "assistant_action": {
               const actionData = event.data as { action: string; [key: string]: unknown };
               if (actionData.action === "persona_created") {
@@ -1089,6 +1102,9 @@ export function useGenerate() {
 
             case "done": {
               if (isActiveChat()) setProcessing(false);
+              if (useChatStore.getState().commandsExecutingChatId === params.chatId) {
+                setCommandsExecutingChatId(null);
+              }
               break;
             }
 
@@ -1136,6 +1152,9 @@ export function useGenerate() {
               // Flush pending text so the user sees what arrived before the error
               flushTypewriterBuffer();
               if (isActiveChat()) setProcessing(false);
+              if (useChatStore.getState().commandsExecutingChatId === params.chatId) {
+                setCommandsExecutingChatId(null);
+              }
               showError((event.data as string) || "Generation failed");
               window.dispatchEvent(new CustomEvent("marinara:generation-error", { detail: { chatId: params.chatId } }));
               break;

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -310,7 +310,7 @@ export function useGenerate() {
   const qc = useQueryClient();
   // Use individual selectors to avoid re-rendering on every store change
   const setStreaming = useChatStore((s) => s.setStreaming);
-  const setCommandsExecuting = useChatStore((s) => s.setCommandsExecuting);
+  const setMariPhase = useChatStore((s) => s.setMariPhase);
   const setStreamBuffer = useChatStore((s) => s.setStreamBuffer);
   const clearStreamBuffer = useChatStore((s) => s.clearStreamBuffer);
   const setRegenerateMessageId = useChatStore((s) => s.setRegenerateMessageId);
@@ -544,8 +544,8 @@ export function useGenerate() {
       // chat on every termination path (done, error, abort, unexpected
       // throw). The assistant_commands_end SSE event is still the primary
       // clear; this just keeps state sane when the stream dies mid-window.
-      const clearCommandsExecutingForThisChat = () => {
-        setCommandsExecuting(params.chatId, false);
+      const clearMariPhaseForThisChat = () => {
+        setMariPhase(params.chatId, "idle");
         window.dispatchEvent(
           new CustomEvent("marinara:mari-phase", {
             detail: { chatId: params.chatId, phase: "idle" },
@@ -579,8 +579,10 @@ export function useGenerate() {
               }
               // Fire the "Mari is thinking…" pill on the first token — that's
               // the same moment "X is typing…" clears, so the two indicators
-              // never overlap.
+              // never overlap. Also seed the per-chat phase in the store so
+              // the indicator can restore the pill on chat-switch-back.
               if (isFirstToken) {
+                setMariPhase(params.chatId, "thinking");
                 window.dispatchEvent(
                   new CustomEvent("marinara:mari-phase", {
                     detail: { chatId: params.chatId, phase: "thinking" },
@@ -1085,7 +1087,7 @@ export function useGenerate() {
             }
 
             case "assistant_commands_start": {
-              setCommandsExecuting(params.chatId, true);
+              setMariPhase(params.chatId, "updating");
               window.dispatchEvent(
                 new CustomEvent("marinara:mari-phase", {
                   detail: { chatId: params.chatId, phase: "updating" },
@@ -1095,7 +1097,7 @@ export function useGenerate() {
             }
 
             case "assistant_commands_end": {
-              clearCommandsExecutingForThisChat();
+              clearMariPhaseForThisChat();
               break;
             }
 
@@ -1129,7 +1131,7 @@ export function useGenerate() {
 
             case "done": {
               if (isActiveChat()) setProcessing(false);
-              clearCommandsExecutingForThisChat();
+              clearMariPhaseForThisChat();
               break;
             }
 
@@ -1177,7 +1179,7 @@ export function useGenerate() {
               // Flush pending text so the user sees what arrived before the error
               flushTypewriterBuffer();
               if (isActiveChat()) setProcessing(false);
-              clearCommandsExecutingForThisChat();
+              clearMariPhaseForThisChat();
               showError((event.data as string) || "Generation failed");
               window.dispatchEvent(new CustomEvent("marinara:generation-error", { detail: { chatId: params.chatId } }));
               break;
@@ -1219,7 +1221,7 @@ export function useGenerate() {
       } finally {
         // Stream has terminated (done, error, abort, or unexpected throw) —
         // guarantee the Mari indicator clears even if the end SSE never arrived.
-        clearCommandsExecutingForThisChat();
+        clearMariPhaseForThisChat();
         // Cancel any pending animation frame to prevent leaks
         cancelAnimationFrame(rafId);
 
@@ -1390,7 +1392,7 @@ export function useGenerate() {
     [
       qc,
       setStreaming,
-      setCommandsExecuting,
+      setMariPhase,
       setStreamBuffer,
       clearStreamBuffer,
       setRegenerateMessageId,

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -310,7 +310,7 @@ export function useGenerate() {
   const qc = useQueryClient();
   // Use individual selectors to avoid re-rendering on every store change
   const setStreaming = useChatStore((s) => s.setStreaming);
-  const setCommandsExecutingChatId = useChatStore((s) => s.setCommandsExecutingChatId);
+  const setCommandsExecuting = useChatStore((s) => s.setCommandsExecuting);
   const setStreamBuffer = useChatStore((s) => s.setStreamBuffer);
   const clearStreamBuffer = useChatStore((s) => s.clearStreamBuffer);
   const setRegenerateMessageId = useChatStore((s) => s.setRegenerateMessageId);
@@ -539,6 +539,12 @@ export function useGenerate() {
         };
         rafId = requestAnimationFrame(tick);
       };
+
+      // Safety net: guarantees the "Mari is thinking…" indicator clears for
+      // this chat on every termination path (done, error, abort, unexpected
+      // throw). The assistant_commands_end SSE event is still the primary
+      // clear; this just keeps state sane when the stream dies mid-window.
+      const clearCommandsExecutingForThisChat = () => setCommandsExecuting(params.chatId, false);
 
       try {
         const userStatus = useUIStore.getState().userStatus;
@@ -1061,14 +1067,12 @@ export function useGenerate() {
             }
 
             case "assistant_commands_start": {
-              setCommandsExecutingChatId(params.chatId);
+              setCommandsExecuting(params.chatId, true);
               break;
             }
 
             case "assistant_commands_end": {
-              if (useChatStore.getState().commandsExecutingChatId === params.chatId) {
-                setCommandsExecutingChatId(null);
-              }
+              clearCommandsExecutingForThisChat();
               break;
             }
 
@@ -1102,9 +1106,7 @@ export function useGenerate() {
 
             case "done": {
               if (isActiveChat()) setProcessing(false);
-              if (useChatStore.getState().commandsExecutingChatId === params.chatId) {
-                setCommandsExecutingChatId(null);
-              }
+              clearCommandsExecutingForThisChat();
               break;
             }
 
@@ -1152,9 +1154,7 @@ export function useGenerate() {
               // Flush pending text so the user sees what arrived before the error
               flushTypewriterBuffer();
               if (isActiveChat()) setProcessing(false);
-              if (useChatStore.getState().commandsExecutingChatId === params.chatId) {
-                setCommandsExecutingChatId(null);
-              }
+              clearCommandsExecutingForThisChat();
               showError((event.data as string) || "Generation failed");
               window.dispatchEvent(new CustomEvent("marinara:generation-error", { detail: { chatId: params.chatId } }));
               break;
@@ -1194,6 +1194,9 @@ export function useGenerate() {
         showError(msg);
         window.dispatchEvent(new CustomEvent("marinara:generation-error", { detail: { chatId: params.chatId } }));
       } finally {
+        // Stream has terminated (done, error, abort, or unexpected throw) —
+        // guarantee the Mari indicator clears even if the end SSE never arrived.
+        clearCommandsExecutingForThisChat();
         // Cancel any pending animation frame to prevent leaks
         cancelAnimationFrame(rafId);
 

--- a/packages/client/src/stores/chat.store.ts
+++ b/packages/client/src/stores/chat.store.ts
@@ -39,13 +39,15 @@ interface ChatState {
   /** The chatId that the current streaming generation belongs to. */
   streamingChatId: string | null;
   /**
-   * chatId currently in the post-stream command execution window.
+   * chatIds currently in the post-stream command execution window.
    *
    * Mari's embedded commands (create_character, fetch, etc.) run after her
-   * reply finishes streaming; this flag gates the "Mari is thinking…"
-   * indicator so the user knows her background work isn't frozen.
+   * reply finishes streaming; membership in this set gates the "Mari is
+   * thinking…" indicator so the user knows her background work isn't frozen.
+   * Uses a set (not a single id) so concurrent command runs across chats
+   * don't stomp each other.
    */
-  commandsExecutingChatId: string | null;
+  commandsExecutingChatIds: Set<string>;
   streamBuffer: string;
   /** Per-chat AbortControllers for active generations — keyed by chatId. */
   abortControllers: Map<string, AbortController>;
@@ -90,7 +92,7 @@ interface ChatState {
   addMessage: (message: Message) => void;
   updateLastMessage: (content: string) => void;
   setStreaming: (streaming: boolean, chatId?: string) => void;
-  setCommandsExecutingChatId: (chatId: string | null) => void;
+  setCommandsExecuting: (chatId: string, executing: boolean) => void;
   setAbortController: (chatId: string, controller: AbortController | null) => void;
   stopGeneration: () => void;
   appendStreamBuffer: (text: string) => void;
@@ -133,7 +135,7 @@ export const useChatStore = create<ChatState>()(
     messages: [],
     isStreaming: false,
     streamingChatId: null,
-    commandsExecutingChatId: null,
+    commandsExecutingChatIds: new Set(),
     streamBuffer: "",
     abortControllers: new Map(),
     regenerateMessageId: null,
@@ -225,7 +227,18 @@ export const useChatStore = create<ChatState>()(
         streamingChatId: streaming ? (chatId ?? null) : null,
         ...(!streaming ? { generationPhase: null } : {}),
       }),
-    setCommandsExecutingChatId: (chatId) => set({ commandsExecutingChatId: chatId }),
+    setCommandsExecuting: (chatId, executing) =>
+      set((state) => {
+        const next = new Set(state.commandsExecutingChatIds);
+        if (executing) {
+          if (next.has(chatId)) return state;
+          next.add(chatId);
+        } else {
+          if (!next.has(chatId)) return state;
+          next.delete(chatId);
+        }
+        return { commandsExecutingChatIds: next };
+      }),
     setAbortController: (chatId, controller) =>
       set((state) => {
         const m = new Map(state.abortControllers);
@@ -376,7 +389,7 @@ export const useChatStore = create<ChatState>()(
         messages: [],
         isStreaming: false,
         streamingChatId: null,
-        commandsExecutingChatId: null,
+        commandsExecutingChatIds: new Set(),
         streamBuffer: "",
         abortControllers: new Map(),
         regenerateMessageId: null,

--- a/packages/client/src/stores/chat.store.ts
+++ b/packages/client/src/stores/chat.store.ts
@@ -38,6 +38,14 @@ interface ChatState {
   isStreaming: boolean;
   /** The chatId that the current streaming generation belongs to. */
   streamingChatId: string | null;
+  /**
+   * chatId currently in the post-stream command execution window.
+   *
+   * Mari's embedded commands (create_character, fetch, etc.) run after her
+   * reply finishes streaming; this flag gates the "Mari is thinking…"
+   * indicator so the user knows her background work isn't frozen.
+   */
+  commandsExecutingChatId: string | null;
   streamBuffer: string;
   /** Per-chat AbortControllers for active generations — keyed by chatId. */
   abortControllers: Map<string, AbortController>;
@@ -82,6 +90,7 @@ interface ChatState {
   addMessage: (message: Message) => void;
   updateLastMessage: (content: string) => void;
   setStreaming: (streaming: boolean, chatId?: string) => void;
+  setCommandsExecutingChatId: (chatId: string | null) => void;
   setAbortController: (chatId: string, controller: AbortController | null) => void;
   stopGeneration: () => void;
   appendStreamBuffer: (text: string) => void;
@@ -124,6 +133,7 @@ export const useChatStore = create<ChatState>()(
     messages: [],
     isStreaming: false,
     streamingChatId: null,
+    commandsExecutingChatId: null,
     streamBuffer: "",
     abortControllers: new Map(),
     regenerateMessageId: null,
@@ -215,6 +225,7 @@ export const useChatStore = create<ChatState>()(
         streamingChatId: streaming ? (chatId ?? null) : null,
         ...(!streaming ? { generationPhase: null } : {}),
       }),
+    setCommandsExecutingChatId: (chatId) => set({ commandsExecutingChatId: chatId }),
     setAbortController: (chatId, controller) =>
       set((state) => {
         const m = new Map(state.abortControllers);
@@ -365,6 +376,7 @@ export const useChatStore = create<ChatState>()(
         messages: [],
         isStreaming: false,
         streamingChatId: null,
+        commandsExecutingChatId: null,
         streamBuffer: "",
         abortControllers: new Map(),
         regenerateMessageId: null,

--- a/packages/client/src/stores/chat.store.ts
+++ b/packages/client/src/stores/chat.store.ts
@@ -39,15 +39,17 @@ interface ChatState {
   /** The chatId that the current streaming generation belongs to. */
   streamingChatId: string | null;
   /**
-   * chatIds currently in the post-stream command execution window.
+   * Per-chat Mari work phase, used to restore the work-status pill when the
+   * user switches chats mid-stream. The CustomEvent transport handles the
+   * live transitions inside the active chat; this map is the source of truth
+   * so the indicator can read the current phase on chat switch.
    *
-   * Mari's embedded commands (create_character, fetch, etc.) run after her
-   * reply finishes streaming; membership in this set gates the "Mari is
-   * thinking…" indicator so the user knows her background work isn't frozen.
-   * Uses a set (not a single id) so concurrent command runs across chats
-   * don't stomp each other.
+   * - "thinking" — Mari's reply is streaming (set on first token).
+   * - "updating" — Mari's embedded commands are executing (set on
+   *   assistant_commands_start).
+   * - absent — no Mari work in progress for that chat.
    */
-  commandsExecutingChatIds: Set<string>;
+  mariPhaseByChatId: Map<string, "thinking" | "updating">;
   streamBuffer: string;
   /** Per-chat AbortControllers for active generations — keyed by chatId. */
   abortControllers: Map<string, AbortController>;
@@ -92,7 +94,7 @@ interface ChatState {
   addMessage: (message: Message) => void;
   updateLastMessage: (content: string) => void;
   setStreaming: (streaming: boolean, chatId?: string) => void;
-  setCommandsExecuting: (chatId: string, executing: boolean) => void;
+  setMariPhase: (chatId: string, phase: "thinking" | "updating" | "idle") => void;
   setAbortController: (chatId: string, controller: AbortController | null) => void;
   stopGeneration: () => void;
   appendStreamBuffer: (text: string) => void;
@@ -135,7 +137,7 @@ export const useChatStore = create<ChatState>()(
     messages: [],
     isStreaming: false,
     streamingChatId: null,
-    commandsExecutingChatIds: new Set(),
+    mariPhaseByChatId: new Map(),
     streamBuffer: "",
     abortControllers: new Map(),
     regenerateMessageId: null,
@@ -227,17 +229,19 @@ export const useChatStore = create<ChatState>()(
         streamingChatId: streaming ? (chatId ?? null) : null,
         ...(!streaming ? { generationPhase: null } : {}),
       }),
-    setCommandsExecuting: (chatId, executing) =>
+    setMariPhase: (chatId, phase) =>
       set((state) => {
-        const next = new Set(state.commandsExecutingChatIds);
-        if (executing) {
-          if (next.has(chatId)) return state;
-          next.add(chatId);
-        } else {
-          if (!next.has(chatId)) return state;
+        const current = state.mariPhaseByChatId.get(chatId) ?? null;
+        if (phase === "idle") {
+          if (current === null) return state;
+          const next = new Map(state.mariPhaseByChatId);
           next.delete(chatId);
+          return { mariPhaseByChatId: next };
         }
-        return { commandsExecutingChatIds: next };
+        if (current === phase) return state;
+        const next = new Map(state.mariPhaseByChatId);
+        next.set(chatId, phase);
+        return { mariPhaseByChatId: next };
       }),
     setAbortController: (chatId, controller) =>
       set((state) => {
@@ -389,7 +393,7 @@ export const useChatStore = create<ChatState>()(
         messages: [],
         isStreaming: false,
         streamingChatId: null,
-        commandsExecutingChatIds: new Set(),
+        mariPhaseByChatId: new Map(),
         streamBuffer: "",
         abortControllers: new Map(),
         regenerateMessageId: null,

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -6120,12 +6120,11 @@ export async function generateRoutes(app: FastifyInstance) {
       // Character Command Execution (Conversation mode)
       // ────────────────────────────────────────
       if (collectedCommands.length > 0 && !abortController.signal.aborted) {
-        reply.raw.write(
-          `data: ${JSON.stringify({
-            type: "assistant_commands_start",
-            data: { count: collectedCommands.length },
-          })}\n\n`,
-        );
+        trySendSseEvent(reply, {
+          type: "assistant_commands_start",
+          data: { count: collectedCommands.length },
+        });
+        try {
         for (const { command, characterId, messageId } of collectedCommands) {
           try {
             if (command.type === "schedule_update") {
@@ -6944,12 +6943,12 @@ export async function generateRoutes(app: FastifyInstance) {
             logger.error(cmdErr, `[commands] Error processing ${command.type} command`);
           }
         }
-        reply.raw.write(
-          `data: ${JSON.stringify({
+        } finally {
+          trySendSseEvent(reply, {
             type: "assistant_commands_end",
             data: {},
-          })}\n\n`,
-        );
+          });
+        }
       }
 
       // ── Post OOC messages to connected conversation (Roleplay → Conversation) ──

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -6120,6 +6120,12 @@ export async function generateRoutes(app: FastifyInstance) {
       // Character Command Execution (Conversation mode)
       // ────────────────────────────────────────
       if (collectedCommands.length > 0 && !abortController.signal.aborted) {
+        reply.raw.write(
+          `data: ${JSON.stringify({
+            type: "assistant_commands_start",
+            data: { count: collectedCommands.length },
+          })}\n\n`,
+        );
         for (const { command, characterId, messageId } of collectedCommands) {
           try {
             if (command.type === "schedule_update") {
@@ -6938,6 +6944,12 @@ export async function generateRoutes(app: FastifyInstance) {
             logger.error(cmdErr, `[commands] Error processing ${command.type} command`);
           }
         }
+        reply.raw.write(
+          `data: ${JSON.stringify({
+            type: "assistant_commands_end",
+            data: {},
+          })}\n\n`,
+        );
       }
 
       // ── Post OOC messages to connected conversation (Roleplay → Conversation) ──


### PR DESCRIPTION
Picks up @cha1latte's work in #222 and ships it with two correctness fixes and a small UX extension. His four commits are preserved with original authorship; my changes are the final commit on top.

## What this does

A pill above the input bar tells you when Mari is doing background work, so you can tell the difference between "still thinking" and "stalled."

- **"Mari is thinking…"** — appears the moment the typing indicator clears (first token of her reply), stays through the token stream.
- **"Mari is updating your stuff…"** — replaces the thinking pill while her embedded commands (`create_character`, `update_character`, `fetch`, …) execute in the post-stream loop.
- Clears on stream end / error / abort.

## What's new vs #222

### Bug fix: indicator never appeared in practice

The original used `useChatStore.subscribe(selector, evaluate)` to react to store changes. That's the same `subscribeWithSelector` + React 19 batching combination that `GameSurface.tsx:2079-2081` already documents as unreliable for fast start/end transitions. The SSE events arrived (verified via Network → EventStream) but the subscription dropped them — pill never showed.

Switched the transport to window `CustomEvent`s (`marinara:mari-phase`), matching the established pattern (`marinara:generation-complete`, `marinara:generation-error`) already used elsewhere in `use-generate.ts`. CustomEvents fire synchronously, outside React's batching, so every transition is observed.

### UX extension: pill now covers the generation phase too

The original only showed the pill during the post-stream command window. But there's a similar dead-air window during token streaming — typing indicator hides on first token, then nothing visible until commands start (or completion). Extended the pill to cover that window too: **"Mari is thinking…"** fires on the first token (same edge that clears the typing indicator, so they never overlap), seamlessly transitions to **"Mari is updating your stuff…"** when commands start.

### Cleanup
- Fixes the lint warning from #222 (`setCommandsExecuting` missing from `useCallback` deps).
- Extracts `isMariParticipant` as a pure function.
- Splits the chat-switch hide logic into its own focused effect instead of tangling it inside `evaluate()`.
- Kept the Zustand `commandsExecutingChatIds` set + `setCommandsExecuting` action — still useful as a synchronous read source for any future consumer, costs nothing.

## Why a new PR instead of pushing to #222

#222 is from @cha1latte's fork — I can't push to it. Cherry-picked his four commits onto this branch with original authorship preserved (you'll see his name on the first four commits in the history), then layered the fixes on top as one commit. Will close #222 with a comment explaining the situation and crediting his diagnosis.

## Files

| File | Change |
|---|---|
| `packages/client/src/components/chat/MariThinkingIndicator.tsx` | New component, two-phase pill, CustomEvent transport |
| `packages/client/src/hooks/use-generate.ts` | Dispatch `marinara:mari-phase` on first token, on `assistant_commands_start`, and from termination cleanup |
| `packages/client/src/stores/chat.store.ts` | Add `commandsExecutingChatIds` set + `setCommandsExecuting` action (preserved from #222) |
| `packages/client/src/components/chat/ChatInput.tsx` | Mount `<MariThinkingIndicator />` |
| `packages/client/src/components/chat/ConversationInput.tsx` | Mount `<MariThinkingIndicator />` |
| `packages/server/src/routes/generate.routes.ts` | Emit `assistant_commands_start` / `_end` SSE events around the command loop (preserved from #222) |
| `CHANGELOG.md` | Entry |

## Robustness

I walked every edge case I could think of:

- **Phase transitions within MIN_VISIBLE_MS**: timer cleared on each new phase, no flash.
- **Duplicate idle fires** (`assistant_commands_end` AND `done` both call cleanup): second short-circuits.
- **Background-chat events while user is in another chat**: filtered.
- **Chat-switch while pill visible**: dedicated effect hides immediately.
- **Stream error / abort / unexpected throw**: `finally` block always dispatches `idle`. No stuck states.
- **Refresh mid-stream**: clean (no events arrive, pill never shows).
- **Typing-indicator overlap (concern from testing)**: same-event-loop swap on first token. Atomic from user's perspective.
- **Dual-mount safety** (`ChatInput` + `ConversationInput` both render it): only one mounts at a time; if both ever did, they'd both render the same correct pill — no state contention since each instance has its own refs.

## Testing

- `pnpm check` passes (no errors, no warnings).
- Manually tested in conversation mode with Professor Mari:
  - Single-command prompt — pill fires, transitions thinking → updating → clears.
  - 30-command prompt — pill stays visible through the entire window.
  - Chat-switch mid-stream — pill clears immediately in the new chat.
  - Stop button mid-stream — pill clears.
  - Non-Mari chat — no pill ever.
  - Mari chat with no command-triggering prompt — only "Mari is thinking…" during streaming, then clears at done.

## Test plan

- [x] Send Mari a prompt that runs commands — verify pill cycles thinking → updating → clears.
- [x] Watch typing indicator and pill don't overlap on first token.
- [x] Switch chats mid-stream — pill clears in the destination chat.
- [x] Trigger a stream error (kill network briefly) — pill clears.
- [x] Hit Stop mid-stream — pill clears.
- [x] Send a non-command message — pill shows during stream, hides at done.
- [x] Send a message in a non-Mari chat — pill never appears.
- [x] Mobile viewport — pill renders without escaping bounds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a visible "Mari is thinking…" / working indicator above the chat composer that appears during Mari's processing phases (thinking/updating), with accessible status text and subtle animation.
  * Indicator stays visible for a minimum duration to avoid flicker for brief tasks.

* **Chore**
  * Updated changelog with an Unreleased entry recording the new UI indicator.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->