### PR TITLE
feat(game): jump back to a segment by clicking it in Session Logs

### DIFF
--- a/packages/client/src/components/game/GameNarration.tsx
+++ b/packages/client/src/components/game/GameNarration.tsx
@@ -1,7 +1,16 @@
 // ──────────────────────────────────────────────
 // Game: Narration Area (VN-style segmented box)
 // ──────────────────────────────────────────────
-import { useEffect, useMemo, useState, useCallback, useRef, type ReactNode, type MouseEvent as ReactMouseEvent } from "react";
+import {
+  useEffect,
+  useMemo,
+  useState,
+  useCallback,
+  useRef,
+  type ReactNode,
+  type MouseEvent as ReactMouseEvent,
+  type KeyboardEvent as ReactKeyboardEvent,
+} from "react";
 import DOMPurify from "dompurify";
 import { MessageCircle, RefreshCw, ScrollText, X, Package, Pencil, Check, Play, Pause, Trash2 } from "lucide-react";
 import { cn } from "../../lib/utils";
@@ -1892,18 +1901,36 @@ export function GameNarration({
                         sourceMessageId === latestAssistant.id &&
                         liveSegmentIndex >= 0 &&
                         liveSegmentIndex !== activeIndex;
-                      const handleSegRowClick = canJumpToSeg
-                        ? (e: ReactMouseEvent<HTMLDivElement>) => {
-                            const target = e.target as HTMLElement;
-                            if (target.closest("button, input, textarea, a")) return;
-                            setActiveIndex(liveSegmentIndex);
-                            setVisibleChars(getSegmentStartVisibleChars(liveSegmentIndex));
-                            setLogsOpen(false);
-                            setEditingLogSeg(null);
-                            logScrolledRef.current = false;
+                      const performJump = () => {
+                        setActiveIndex(liveSegmentIndex);
+                        setVisibleChars(getSegmentStartVisibleChars(liveSegmentIndex));
+                        setLogsOpen(false);
+                        setEditingLogSeg(null);
+                        logScrolledRef.current = false;
+                        playClickSfx();
+                      };
+                      const isInteractiveTarget = (target: EventTarget | null) =>
+                        target instanceof HTMLElement && !!target.closest("button, input, textarea, a");
+                      const jumpRowProps = canJumpToSeg
+                        ? {
+                            role: "button" as const,
+                            tabIndex: 0,
+                            title: "Jump back to this segment",
+                            onClick: (e: ReactMouseEvent<HTMLDivElement>) => {
+                              if (isInteractiveTarget(e.target)) return;
+                              performJump();
+                            },
+                            onKeyDown: (e: ReactKeyboardEvent<HTMLDivElement>) => {
+                              if (e.key !== "Enter" && e.key !== " ") return;
+                              if (isInteractiveTarget(e.target)) return;
+                              e.preventDefault();
+                              performJump();
+                            },
                           }
-                        : undefined;
-                      const jumpRowClasses = canJumpToSeg ? "cursor-pointer hover:ring-1 hover:ring-white/15" : "";
+                        : null;
+                      const jumpRowClasses = canJumpToSeg
+                        ? "cursor-pointer hover:ring-1 hover:ring-white/15 focus:outline-none focus-visible:ring-1 focus-visible:ring-white/30"
+                        : "";
                       const canEditMessage = !!onEditMessage && !!sourceMessageId && sourceRole === "user";
                       const canEditSegment =
                         !!onEditSegment &&
@@ -2045,8 +2072,7 @@ export function GameNarration({
                         return (
                           <div
                             key={seg.id}
-                            onClick={handleSegRowClick}
-                            title={canJumpToSeg ? "Jump back to this segment" : undefined}
+                            {...(jumpRowProps ?? {})}
                             className={cn(
                               "group/logseg relative flex gap-2 rounded-lg border px-3 py-2",
                               seg.partyType === "thought"
@@ -2131,8 +2157,7 @@ export function GameNarration({
                         return (
                           <div
                             key={seg.id}
-                            onClick={handleSegRowClick}
-                            title={canJumpToSeg ? "Jump back to this segment" : undefined}
+                            {...(jumpRowProps ?? {})}
                             className={cn(
                               "group/logseg relative rounded-lg border border-cyan-400/15 bg-cyan-950/15 px-3 py-2",
                               isActiveSeg && "ring-1 ring-[var(--primary)]/40",
@@ -2156,8 +2181,7 @@ export function GameNarration({
                         return (
                           <div
                             key={seg.id}
-                            onClick={handleSegRowClick}
-                            title={canJumpToSeg ? "Jump back to this segment" : undefined}
+                            {...(jumpRowProps ?? {})}
                             className={cn(
                               "group/logseg relative rounded-lg border border-amber-400/15 bg-amber-950/15 px-3 py-2",
                               isActiveSeg && "ring-1 ring-[var(--primary)]/40",
@@ -2187,8 +2211,7 @@ export function GameNarration({
                       return (
                         <div
                           key={seg.id}
-                          onClick={handleSegRowClick}
-                          title={canJumpToSeg ? "Jump back to this segment" : undefined}
+                          {...(jumpRowProps ?? {})}
                           className={cn(
                             "group/logseg relative rounded-lg border border-white/5 bg-black/20 px-3 py-2",
                             isActiveSeg && "ring-1 ring-[var(--primary)]/40",

--- a/packages/client/src/components/game/GameNarration.tsx
+++ b/packages/client/src/components/game/GameNarration.tsx
@@ -1,7 +1,7 @@
 // ──────────────────────────────────────────────
 // Game: Narration Area (VN-style segmented box)
 // ──────────────────────────────────────────────
-import { useEffect, useMemo, useState, useCallback, useRef, type ReactNode } from "react";
+import { useEffect, useMemo, useState, useCallback, useRef, type ReactNode, type MouseEvent as ReactMouseEvent } from "react";
 import DOMPurify from "dompurify";
 import { MessageCircle, RefreshCw, ScrollText, X, Package, Pencil, Check, Play, Pause, Trash2 } from "lucide-react";
 import { cn } from "../../lib/utils";
@@ -1886,6 +1886,24 @@ export function GameNarration({
                         seg.sourceRole ??
                         (sourceMessageId ? (sourceMessagesById.get(sourceMessageId)?.role ?? null) : null);
                       const isActiveSeg = active?.id === seg.id;
+                      const liveSegmentIndex = segments.findIndex((s) => s.id === seg.id);
+                      const canJumpToSeg =
+                        !!latestAssistant &&
+                        sourceMessageId === latestAssistant.id &&
+                        liveSegmentIndex >= 0 &&
+                        liveSegmentIndex !== activeIndex;
+                      const handleSegRowClick = canJumpToSeg
+                        ? (e: ReactMouseEvent<HTMLDivElement>) => {
+                            const target = e.target as HTMLElement;
+                            if (target.closest("button, input, textarea, a")) return;
+                            setActiveIndex(liveSegmentIndex);
+                            setVisibleChars(getSegmentStartVisibleChars(liveSegmentIndex));
+                            setLogsOpen(false);
+                            setEditingLogSeg(null);
+                            logScrolledRef.current = false;
+                          }
+                        : undefined;
+                      const jumpRowClasses = canJumpToSeg ? "cursor-pointer hover:ring-1 hover:ring-white/15" : "";
                       const canEditMessage = !!onEditMessage && !!sourceMessageId && sourceRole === "user";
                       const canEditSegment =
                         !!onEditSegment &&
@@ -2027,6 +2045,8 @@ export function GameNarration({
                         return (
                           <div
                             key={seg.id}
+                            onClick={handleSegRowClick}
+                            title={canJumpToSeg ? "Jump back to this segment" : undefined}
                             className={cn(
                               "group/logseg relative flex gap-2 rounded-lg border px-3 py-2",
                               seg.partyType === "thought"
@@ -2037,6 +2057,7 @@ export function GameNarration({
                                     ? "border-sky-400/10 bg-sky-950/15"
                                     : "border-white/5 bg-black/20",
                               isActiveSeg && "ring-1 ring-[var(--primary)]/40",
+                              jumpRowClasses,
                             )}
                           >
                             {deleteButton}
@@ -2110,9 +2131,12 @@ export function GameNarration({
                         return (
                           <div
                             key={seg.id}
+                            onClick={handleSegRowClick}
+                            title={canJumpToSeg ? "Jump back to this segment" : undefined}
                             className={cn(
                               "group/logseg relative rounded-lg border border-cyan-400/15 bg-cyan-950/15 px-3 py-2",
                               isActiveSeg && "ring-1 ring-[var(--primary)]/40",
+                              jumpRowClasses,
                             )}
                           >
                             {deleteButton}
@@ -2132,9 +2156,12 @@ export function GameNarration({
                         return (
                           <div
                             key={seg.id}
+                            onClick={handleSegRowClick}
+                            title={canJumpToSeg ? "Jump back to this segment" : undefined}
                             className={cn(
                               "group/logseg relative rounded-lg border border-amber-400/15 bg-amber-950/15 px-3 py-2",
                               isActiveSeg && "ring-1 ring-[var(--primary)]/40",
+                              jumpRowClasses,
                             )}
                           >
                             {deleteButton}
@@ -2160,9 +2187,12 @@ export function GameNarration({
                       return (
                         <div
                           key={seg.id}
+                          onClick={handleSegRowClick}
+                          title={canJumpToSeg ? "Jump back to this segment" : undefined}
                           className={cn(
                             "group/logseg relative rounded-lg border border-white/5 bg-black/20 px-3 py-2",
                             isActiveSeg && "ring-1 ring-[var(--primary)]/40",
+                            jumpRowClasses,
                           )}
                         >
                           {deleteButton}

--- a/packages/client/src/components/game/GameNarration.tsx
+++ b/packages/client/src/components/game/GameNarration.tsx
@@ -1910,7 +1910,7 @@ export function GameNarration({
                         playClickSfx();
                       };
                       const isInteractiveTarget = (target: EventTarget | null) =>
-                        target instanceof HTMLElement && !!target.closest("button, input, textarea, a");
+                        target instanceof Element && !!target.closest("button, input, textarea, a");
                       const jumpRowProps = canJumpToSeg
                         ? {
                             role: "button" as const,


### PR DESCRIPTION
## Why this change

In Game Mode, the Session Logs modal is a read-only history. If you scroll past a beat and want to re-experience it (replay the typewriter for that exact narration segment, or reground yourself in a moment of dialogue), there's no way to get back — `setActiveIndex` is internal to `GameNarration` and segments past the active one have no affordance. This adds the natural interaction: click a logged row from the current scene to make it the active narration segment again.

## What changed

- `packages/client/src/components/game/GameNarration.tsx`: each row in the Session Logs modal that belongs to the latest assistant message (the "current scene") now accepts a click. Clicking sets `activeIndex` to that segment's index in the live `segments` list, resets `visibleChars` via `getSegmentStartVisibleChars` (so the typewriter replays — or reveals instantly if `gameInstantTextReveal` is on), closes the modal, and clears any in-progress log edit state.
- Past-scene rows remain non-interactive: `latestAssistant` is the only message the narration stage can play, so older messages would require a destructive "delete everything after" rewind. Out of scope here — this PR is scoped strictly to the cheap, non-destructive case.
- Click handler short-circuits on `target.closest("button, input, textarea, a")` so the existing edit/delete pencil/trash buttons (and inline edit textareas) keep working without bubbling into a jump.
- Hover affordance: jumpable rows get `cursor-pointer` and a faint `hover:ring-1 hover:ring-white/15`. The currently-active segment keeps its existing `ring-1 ring-[var(--primary)]/40` and is excluded from the jump (it would be a no-op).

Wired across all four segment renderers in the modal — dialogue, system, readable (Note/Book), and the default narration row.

## Validation

- [x] `pnpm check`
- [x] Manual verification completed (describe below)

### Manual verification notes

Built and deployed to the author's EasyPanel instance off fork main; verified in-browser:

- Hovering a current-scene row shows the white hover ring and pointer cursor; tooltip reads "Jump back to this segment".
- Clicking a current-scene row closes the modal and rewinds the narration stage to that segment, with the typewriter replaying from the start of that segment.
- The currently-active segment shows the existing primary-color ring and does not pick up the hover affordance.
- Past-scene rows (older AI messages) are not interactive — no hover ring, default cursor, no click effect.
- Edit (pencil) and delete (trash) icons on hover continue to work normally; clicking them does not also trigger a jump.
- Persistence: the rewound `activeIndex` flows through the existing `onSegmentChange` path and is written to both `localStorage` (`narration-idx:<chatId>`) and the server's `gameNarrationIndex`, so a refresh restores the rewound position.

## Docs and release impact

- [x] No docs changes needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Log rows can be focused and clicked (or activated via Enter/Space) to jump back to the corresponding live narration segment when applicable.
  * Jump restores the conversation view to that point, closes the logs modal, clears log-edit state, resets scroll tracking, and plays a click sound.
  * Eligible rows show hover/focus ring styling; in-row controls are ignored so their interactions aren’t interrupted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->