### PR TITLE
Feature: Confirm before ending scene

### DIFF
--- a/packages/client/src/components/chat/SceneBanner.tsx
+++ b/packages/client/src/components/chat/SceneBanner.tsx
@@ -106,11 +106,23 @@ export function EndSceneBar({
 }: {
   sceneChatId: string;
   originChatId?: string;
-  onConclude: (id: string) => void;
+  onConclude: (id: string) => void | Promise<void>;
   onAbandon?: (id: string) => void;
 }) {
   const setActiveChatId = useChatStore((s) => s.setActiveChatId);
+  const [confirmEnd, setConfirmEnd] = useState(false);
   const [confirmDiscard, setConfirmDiscard] = useState(false);
+  const [isEnding, setIsEnding] = useState(false);
+
+  const handleConfirmEnd = async () => {
+    if (isEnding) return;
+    setIsEnding(true);
+    try {
+      await onConclude(sceneChatId);
+    } finally {
+      setIsEnding(false);
+    }
+  };
 
   return (
     <div className="flex items-center justify-center gap-2 py-1.5">
@@ -129,22 +141,56 @@ export function EndSceneBar({
           Back to conversation
         </button>
       )}
-      <button
-        onClick={() => onConclude(sceneChatId)}
-        className="flex items-center gap-1.5 rounded-lg px-3 py-1 text-xs font-medium transition-all hover:opacity-80"
-        style={{
-          background: "var(--card)",
-          color: "var(--card-foreground)",
-          border: "1px solid var(--border)",
-        }}
-        title="End the scene and generate a summary"
-      >
-        <Film size={14} />
-        End Scene
-      </button>
+      {!confirmEnd && (
+        <button
+          onClick={() => {
+            setConfirmDiscard(false);
+            setConfirmEnd(true);
+          }}
+          className="flex items-center gap-1.5 rounded-lg px-3 py-1 text-xs font-medium transition-all hover:opacity-80"
+          style={{
+            background: "var(--card)",
+            color: "var(--card-foreground)",
+            border: "1px solid var(--border)",
+          }}
+          title="End the scene and generate a summary"
+        >
+          <Film size={14} />
+          End Scene
+        </button>
+      )}
+      {confirmEnd && (
+        <div className="flex items-center gap-1.5">
+          <span className="text-[0.6875rem] text-[var(--foreground)]">End and save summary?</span>
+          <button
+            onClick={handleConfirmEnd}
+            disabled={isEnding}
+            className="rounded-lg px-2 py-0.5 text-[0.6875rem] font-medium transition-all hover:opacity-80"
+            style={{ background: "var(--primary)", color: "var(--primary-foreground)" }}
+          >
+            {isEnding ? "Saving..." : "Yes"}
+          </button>
+          <button
+            onClick={() => setConfirmEnd(false)}
+            disabled={isEnding}
+            className="rounded-lg px-2 py-0.5 text-[0.6875rem] font-medium transition-all hover:opacity-80"
+            style={{
+              background: "var(--card)",
+              color: "var(--card-foreground)",
+              border: "1px solid var(--border)",
+            }}
+          >
+            No
+          </button>
+        </div>
+      )}
       {onAbandon && !confirmDiscard && (
         <button
-          onClick={() => setConfirmDiscard(true)}
+          onClick={() => {
+            setConfirmEnd(false);
+            setConfirmDiscard(true);
+          }}
+          disabled={isEnding}
           className="flex items-center gap-1.5 rounded-lg px-3 py-1 text-xs font-medium transition-all hover:opacity-80"
           style={{
             color: "var(--muted-foreground)",


### PR DESCRIPTION
## Why this change

Prevent accidental scene conclusion taps, especially on mobile where the End Scene button can easily be triggered unintentionally.

## What changed

- Added a confirmation prompt before ending an active scene.
- Added an in-flight guard so the end-scene confirmation cannot be submitted multiple times.
- Made End Scene and Discard confirmations mutually exclusive.

## Validation

- [x] `pnpm check`
- [x] Manual verification completed (describe below)

### Manual verification notes

Completed:
  - Tap End Scene once and confirm the scene does not immediately conclude.
  - Tap No and confirm the prompt disappears.
  - Tap End Scene again, then Yes, and confirm the normal conclusion flow runs.
  - Tap Discard while End confirmation is open and confirm the End confirmation closes.
  - Tap End Scene while Discard confirmation is open and confirm the Discard confirmation closes.
  - Confirm repeated taps on Yes do not submit multiple conclusion requests.

## Docs and release impact

- [x] No docs changes needed

## UI evidence (if applicable)

Confirmation Prompt
<img width="565" height="102" alt="shot1a" src="https://github.com/user-attachments/assets/fb81b881-27c4-4f2c-96c9-3cfe781451da" />

Double click prevention
<img width="1152" height="146" alt="shot2a" src="https://github.com/user-attachments/assets/b2b2f48e-a59e-4624-95f8-f0dcb34e7605" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added confirmation step when ending scenes: users now see an "End and save summary?" dialog with Yes/No options before the scene concludes.

* **Improvements**
  * Scene conclusion workflow now prevents accidental or concurrent submissions during processing, ensuring operations complete reliably. Discarding a scene clears any pending confirmations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->