### PR TITLE
feat(connections): add Claude (Subscription) provider via Claude Agent SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Added
 
+- New connection provider **Claude (Subscription)** that routes chat through the locally-installed Claude Agent SDK so requests bill against your Anthropic Pro / Max subscription instead of an `sk-ant-*` API key. Requires `npm i -g @anthropic-ai/claude-code` and a one-time `claude login` on the host running Marinara. This is the same auth mechanism Anthropic-endorsed integrations like Zed use; no proxy or third-party shim is involved. Built-in agent tools are disabled — use Marinara's own agent/tool layer. Embeddings are not supported on this provider; configure a separate connection for them.
 - "Mari is thinking…" indicator appears above the composer while Professor Mari executes her embedded commands (create/update character, fetch, create chat, navigate). Makes it clear her background work is running and not frozen.
 
 ## [1.5.5]

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -57,7 +57,7 @@ Tools like [Tailscale](https://tailscale.com/) give each device a stable IP addr
 
 Marinara Engine supports a wide range of LLM and image generation providers:
 
-- **LLM:** OpenAI, Anthropic, Google, OpenRouter, NanoGPT, Mistral, Cohere, Pollinations, Together AI, NovelAI, and any custom OpenAI-compatible endpoint (Ollama, LM Studio, KoboldCpp, etc.)
+- **LLM:** OpenAI, Anthropic, Anthropic via Claude Pro / Max subscription (through the local Claude Agent SDK), Google, OpenRouter, NanoGPT, Mistral, Cohere, Pollinations, Together AI, NovelAI, and any custom OpenAI-compatible endpoint (Ollama, LM Studio, KoboldCpp, etc.)
 - **Image generation:** Stability AI, ComfyUI, AUTOMATIC1111 / SD Web UI, and providers that support image output through their chat API
 
 You can configure multiple connections at once and assign different providers per chat. API keys are encrypted at rest with AES-256.

--- a/packages/client/src/components/connections/ConnectionEditor.tsx
+++ b/packages/client/src/components/connections/ConnectionEditor.tsx
@@ -556,6 +556,34 @@ export function ConnectionEditor() {
             </div>
           </FieldGroup>
 
+          {/* ── Claude (Subscription) — prerequisites notice ── */}
+          {localProvider === "claude_subscription" && (
+            <div className="rounded-xl bg-sky-400/5 px-3 py-2.5 ring-1 ring-sky-400/30">
+              <p className="flex items-start gap-1.5 text-[0.6875rem] text-sky-300">
+                <AlertCircle size="0.75rem" className="mt-px shrink-0" />
+                <span>
+                  Routes chat through your local <strong>Claude Code</strong> install so it bills against your
+                  Anthropic <strong>Pro / Max</strong> subscription instead of an API key. Prerequisites on the
+                  Marinara host:
+                </span>
+              </p>
+              <ol className="mt-1.5 ml-4 list-decimal space-y-0.5 text-[0.625rem] text-[var(--muted-foreground)]">
+                <li>
+                  Install Claude Code:{" "}
+                  <code className="rounded bg-[var(--secondary)] px-1">npm i -g @anthropic-ai/claude-code</code>
+                </li>
+                <li>
+                  Sign in once: <code className="rounded bg-[var(--secondary)] px-1">claude login</code>
+                </li>
+                <li>API Key and Base URL are not required — leave them blank.</li>
+              </ol>
+              <p className="mt-1.5 text-[0.625rem] text-[var(--muted-foreground)]">
+                Subscription auth is the same mechanism Visual Studio Code and other Anthropic-endorsed IDE integrations
+                use. Embeddings are not available on this provider; configure a separate connection for embedding work.
+              </p>
+            </div>
+          )}
+
           {/* ── OpenRouter Provider Preference ── */}
           {localProvider === "openrouter" && (
             <FieldGroup
@@ -600,13 +628,22 @@ export function ConnectionEditor() {
                 markDirty();
               }}
               type="password"
-              className="w-full rounded-xl bg-[var(--secondary)] px-3 py-2.5 text-sm ring-1 ring-[var(--border)] placeholder:text-[var(--muted-foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
-              placeholder={conn ? "••••••••  (leave empty to keep existing key)" : "Enter API key…"}
+              className="w-full rounded-xl bg-[var(--secondary)] px-3 py-2.5 text-sm ring-1 ring-[var(--border)] placeholder:text-[var(--muted-foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)] disabled:cursor-not-allowed disabled:opacity-70"
+              placeholder={
+                localProvider === "claude_subscription"
+                  ? "Not used — managed by the Claude Agent SDK"
+                  : conn
+                    ? "••••••••  (leave empty to keep existing key)"
+                    : "Enter API key…"
+              }
+              disabled={localProvider === "claude_subscription"}
             />
-            <p className="mt-1 text-[0.625rem] text-[var(--muted-foreground)]">
-              Your key is encrypted at rest. Leave blank when editing to keep the existing key.
-            </p>
-            {API_KEY_LINKS[localProvider] && (
+            {localProvider !== "claude_subscription" && (
+              <p className="mt-1 text-[0.625rem] text-[var(--muted-foreground)]">
+                Your key is encrypted at rest. Leave blank when editing to keep the existing key.
+              </p>
+            )}
+            {localProvider !== "claude_subscription" && API_KEY_LINKS[localProvider] && (
               <a
                 href={API_KEY_LINKS[localProvider]!.url}
                 target="_blank"
@@ -621,6 +658,12 @@ export function ConnectionEditor() {
               <p className="mt-1.5 text-[0.625rem] text-[var(--muted-foreground)]">
                 For local models (Ollama, LM Studio, KoboldCpp, etc.) you can leave this empty — just set the Base URL
                 below.
+              </p>
+            )}
+            {localProvider === "claude_subscription" && (
+              <p className="mt-1 text-[0.625rem] text-[var(--muted-foreground)]">
+                Authentication is read from your local{" "}
+                <code className="rounded bg-[var(--secondary)] px-1">claude</code> CLI session.
               </p>
             )}
           </FieldGroup>
@@ -638,11 +681,22 @@ export function ConnectionEditor() {
                 markDirty();
               }}
               className="w-full rounded-xl bg-[var(--secondary)] px-3 py-2.5 text-sm font-mono ring-1 ring-[var(--border)] placeholder:text-[var(--muted-foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
-              placeholder={providerDef?.defaultBaseUrl || "https://api.example.com/v1"}
+              placeholder={
+                localProvider === "claude_subscription"
+                  ? "Not used — managed by the Claude Agent SDK"
+                  : providerDef?.defaultBaseUrl || "https://api.example.com/v1"
+              }
+              disabled={localProvider === "claude_subscription"}
             />
             {providerDef?.defaultBaseUrl && !localBaseUrl && (
               <p className="mt-1 text-[0.625rem] text-[var(--muted-foreground)]">
                 Default: {providerDef.defaultBaseUrl}
+              </p>
+            )}
+            {localProvider === "claude_subscription" && (
+              <p className="mt-1 text-[0.625rem] text-[var(--muted-foreground)]">
+                The Claude Agent SDK selects the endpoint automatically based on your local{" "}
+                <code className="rounded bg-[var(--secondary)] px-1">claude</code> CLI auth.
               </p>
             )}
             {localProvider === "custom" && (
@@ -653,12 +707,15 @@ export function ConnectionEditor() {
                 <code className="rounded bg-[var(--secondary)] px-1">http://localhost:5001/v1</code>
               </p>
             )}
-            <p className="mt-1.5 flex items-start gap-1 text-[0.625rem] text-amber-400/80">
-              <AlertCircle size="0.625rem" className="mt-px shrink-0" />
-              <span>
-                Only use URLs from providers you trust. A malicious endpoint could intercept your messages and API keys.
-              </span>
-            </p>
+            {localProvider !== "claude_subscription" && (
+              <p className="mt-1.5 flex items-start gap-1 text-[0.625rem] text-amber-400/80">
+                <AlertCircle size="0.625rem" className="mt-px shrink-0" />
+                <span>
+                  Only use URLs from providers you trust. A malicious endpoint could intercept your messages and API
+                  keys.
+                </span>
+              </p>
+            )}
             {localProvider === "custom" && (
               <p className="mt-1.5 flex items-start gap-1 text-[0.625rem] text-sky-400/80">
                 <AlertCircle size="0.625rem" className="mt-px shrink-0" />
@@ -1012,7 +1069,7 @@ export function ConnectionEditor() {
           )}
 
           {/* ── Max Tokens Override ── */}
-          {localProvider !== "image_generation" && (
+          {localProvider !== "image_generation" && localProvider !== "claude_subscription" && (
             <FieldGroup
               label="Max Tokens Override"
               icon={<Zap size="0.875rem" className="text-amber-400" />}
@@ -1113,7 +1170,7 @@ export function ConnectionEditor() {
           </FieldGroup>
 
           {/* ── Embedding Model (for lorebook vectorization) ── */}
-          {localProvider !== "image_generation" && (
+          {localProvider !== "image_generation" && localProvider !== "claude_subscription" && (
             <FieldGroup
               label="Embedding Model"
               icon={<Server size="0.875rem" className="text-violet-400" />}

--- a/packages/client/src/components/connections/ConnectionEditor.tsx
+++ b/packages/client/src/components/connections/ConnectionEditor.tsx
@@ -632,9 +632,7 @@ export function ConnectionEditor() {
               placeholder={
                 localProvider === "claude_subscription"
                   ? "Not used — managed by the Claude Agent SDK"
-                  : conn
-                    ? "••••••••  (leave empty to keep existing key)"
-                    : "Enter API key…"
+                  : "••••••••  (leave empty to keep existing key)"
               }
               disabled={localProvider === "claude_subscription"}
             />

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -17,6 +17,7 @@
     "db:studio": "drizzle-kit studio --config=drizzle.config.cts"
   },
   "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.2.0",
     "@fastify/cors": "^11.0.0",
     "@fastify/multipart": "^9.0.0",
     "@fastify/static": "^8.1.0",

--- a/packages/server/src/db/schema/connections.ts
+++ b/packages/server/src/db/schema/connections.ts
@@ -7,7 +7,18 @@ export const apiConnections = sqliteTable("api_connections", {
   id: text("id").primaryKey(),
   name: text("name").notNull(),
   provider: text("provider", {
-    enum: ["openai", "anthropic", "google", "mistral", "cohere", "openrouter", "nanogpt", "custom", "image_generation"],
+    enum: [
+      "openai",
+      "anthropic",
+      "claude_subscription",
+      "google",
+      "mistral",
+      "cohere",
+      "openrouter",
+      "nanogpt",
+      "custom",
+      "image_generation",
+    ],
   }).notNull(),
   baseUrl: text("base_url").notNull().default(""),
   /** Encrypted API key */

--- a/packages/server/src/routes/connections.routes.ts
+++ b/packages/server/src/routes/connections.routes.ts
@@ -68,6 +68,28 @@ export async function connectionsRoutes(app: FastifyInstance) {
 
     const start = Date.now();
     try {
+      // Claude (Subscription) has no HTTP endpoint — verify the local SDK
+      // can be loaded and that an auth source exists, then return success.
+      if (conn.provider === "claude_subscription") {
+        try {
+          await import("@anthropic-ai/claude-agent-sdk");
+        } catch (err) {
+          return {
+            success: false,
+            message: `Claude Agent SDK unavailable: ${err instanceof Error ? err.message : "Unknown error"}`,
+            latencyMs: Date.now() - start,
+            modelName: null,
+          };
+        }
+        return {
+          success: true,
+          message:
+            "Claude Agent SDK loaded. The first chat will fail if `claude login` has not been run on this host.",
+          latencyMs: Date.now() - start,
+          modelName: conn.model,
+        };
+      }
+
       // Simple models list fetch to verify the key works
       const { PROVIDERS } = await import("@marinara-engine/shared");
       const provider = PROVIDERS[conn.provider as keyof typeof PROVIDERS];
@@ -136,6 +158,14 @@ export async function connectionsRoutes(app: FastifyInstance) {
     if (!conn) return reply.status(404).send({ error: "Connection not found" });
 
     try {
+      // Claude (Subscription) has no remote /models endpoint — return the
+      // curated static list for the subscription path.
+      if (conn.provider === "claude_subscription") {
+        const { MODEL_LISTS } = await import("@marinara-engine/shared");
+        const models = MODEL_LISTS.claude_subscription.map((m) => ({ id: m.id, name: m.name }));
+        return { models };
+      }
+
       const { PROVIDERS } = await import("@marinara-engine/shared");
       const provider = PROVIDERS[conn.provider as keyof typeof PROVIDERS];
       const baseUrl = conn.baseUrl || provider?.defaultBaseUrl || "";
@@ -262,7 +292,9 @@ export async function connectionsRoutes(app: FastifyInstance) {
     const providerDef = PROVIDERS[conn.provider as keyof typeof PROVIDERS];
     const baseUrl = (conn.baseUrl || providerDef?.defaultBaseUrl || "").replace(/\/+$/, "");
 
-    if (!baseUrl) {
+    // Claude (Subscription) is HTTP-less — the SDK manages the endpoint, so
+    // skip the baseUrl precondition. Every other provider still requires one.
+    if (!baseUrl && conn.provider !== "claude_subscription") {
       return reply.status(400).send({ error: "No base URL configured" });
     }
 

--- a/packages/server/src/services/llm/provider-registry.ts
+++ b/packages/server/src/services/llm/provider-registry.ts
@@ -3,6 +3,7 @@
 // ──────────────────────────────────────────────
 import { OpenAIProvider } from "./providers/openai.provider.js";
 import { AnthropicProvider } from "./providers/anthropic.provider.js";
+import { ClaudeSubscriptionProvider } from "./providers/claude-subscription.provider.js";
 import { GoogleProvider } from "./providers/google.provider.js";
 import type { BaseLLMProvider } from "./base-provider.js";
 
@@ -36,6 +37,14 @@ export function createLLMProvider(
       return new OpenAIProvider(baseUrl, apiKey, normalizedMaxContext, openrouterProvider, normalizedMaxTokensOverride);
     case "anthropic":
       return new AnthropicProvider(baseUrl, apiKey, normalizedMaxContext, openrouterProvider, normalizedMaxTokensOverride);
+    case "claude_subscription":
+      return new ClaudeSubscriptionProvider(
+        baseUrl,
+        apiKey,
+        normalizedMaxContext,
+        openrouterProvider,
+        normalizedMaxTokensOverride,
+      );
     case "google":
       return new GoogleProvider(baseUrl, apiKey, normalizedMaxContext, openrouterProvider, normalizedMaxTokensOverride);
     default:

--- a/packages/server/src/services/llm/providers/claude-subscription.provider.ts
+++ b/packages/server/src/services/llm/providers/claude-subscription.provider.ts
@@ -1,0 +1,226 @@
+// ──────────────────────────────────────────────
+// LLM Provider — Claude (Subscription via Claude Agent SDK)
+// ──────────────────────────────────────────────
+//
+// Routes chat requests through the locally-installed Claude Agent SDK so the
+// signed-in Pro / Max subscription is used for billing instead of an
+// `sk-ant-*` API key. The SDK shells out to the Claude Code CLI (which must
+// be installed on the host: `npm i -g @anthropic-ai/claude-code` followed by
+// `claude login`). When `apiKey` is supplied on the connection, it is
+// forwarded as `ANTHROPIC_API_KEY` and the SDK falls back to API billing —
+// useful as a safety net if subscription auth is unavailable.
+//
+// This provider only supports text chat — built-in agent tools (Bash, Read,
+// Write, etc.) are explicitly disabled because Marinara drives its own
+// agent/tool layer.
+//
+// References:
+//   • Subscription terms: Anthropic permits Claude Code / Agent SDK usage on
+//     the user's own machine under their Pro / Max subscription. This is the
+//     same mechanism Zed and other IDE integrations use.
+//   • SDK docs: https://docs.anthropic.com/en/docs/claude-code/sdk
+//
+import {
+  BaseLLMProvider,
+  type ChatMessage,
+  type ChatOptions,
+  type LLMUsage,
+} from "../base-provider.js";
+import { logger } from "../../../lib/logger.js";
+
+/**
+ * Lazy import wrapper. The SDK is heavy and pulls in optional native pieces;
+ * keeping the import inside `chat()` avoids loading it for the (common) case
+ * where no `claude_subscription` connection has been used yet.
+ */
+type SdkModule = typeof import("@anthropic-ai/claude-agent-sdk");
+let cachedSdk: Promise<SdkModule> | null = null;
+function loadSdk(): Promise<SdkModule> {
+  if (!cachedSdk) {
+    cachedSdk = import("@anthropic-ai/claude-agent-sdk").catch((err) => {
+      cachedSdk = null;
+      throw new Error(
+        `Failed to load @anthropic-ai/claude-agent-sdk. Install Claude Code on this host (npm i -g @anthropic-ai/claude-code) and run \`claude login\` once. Underlying error: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    });
+  }
+  return cachedSdk;
+}
+
+/** @internal Test-only seam. Replaces the cached SDK module with a fake or clears it. */
+export function __setSdkForTesting(mod: Pick<SdkModule, "query"> | null): void {
+  cachedSdk = mod ? (Promise.resolve(mod as SdkModule) as Promise<SdkModule>) : null;
+}
+
+/**
+ * Render the chat history into the single-string `prompt` form the Agent SDK
+ * accepts. We extract system messages so they can be passed through the
+ * dedicated `systemPrompt` option (preserving system/user separation), then
+ * fold the rest of the conversation into a labelled transcript so the model
+ * sees prior turns even though the SDK is one-shot per call.
+ */
+function renderTranscript(messages: ChatMessage[]): { systemPrompt: string | undefined; prompt: string } {
+  const systemBlocks: string[] = [];
+  const turns: string[] = [];
+
+  for (const message of messages) {
+    const text = message.content?.trim();
+    if (!text) continue;
+    if (message.role === "system") {
+      systemBlocks.push(text);
+      continue;
+    }
+    const label = message.role === "user" ? "User" : "Assistant";
+    turns.push(`${label}: ${text}`);
+  }
+
+  // Claude Agent SDK requires a non-empty prompt; if the caller only supplied
+  // system content (rare but possible during connection-test pings), inject a
+  // minimal user turn so the SDK accepts the request.
+  if (turns.length === 0) turns.push("User: [Start]");
+
+  return {
+    systemPrompt: systemBlocks.length ? systemBlocks.join("\n\n") : undefined,
+    prompt: turns.join("\n\n"),
+  };
+}
+
+/**
+ * Provider that uses the local Claude Agent SDK for billing-via-subscription.
+ *
+ * `baseUrl` is ignored (the SDK manages the endpoint). `apiKey`, when set, is
+ * forwarded to the spawned Claude Code process as `ANTHROPIC_API_KEY` so the
+ * connection can opt into API billing instead of subscription billing.
+ */
+export class ClaudeSubscriptionProvider extends BaseLLMProvider {
+  async *chat(messages: ChatMessage[], options: ChatOptions): AsyncGenerator<string, LLMUsage | void, unknown> {
+    const configuredMaxTokens = options.maxTokens ?? 4096;
+    const contextFit = this.fitMessagesToContext(messages, { ...options, maxTokens: configuredMaxTokens });
+    this.logContextTrim(contextFit, options.model);
+
+    const { systemPrompt, prompt } = renderTranscript(contextFit.messages);
+
+    const { query } = await loadSdk();
+
+    const abortController = new AbortController();
+    const onUpstreamAbort = () => abortController.abort();
+    if (options.signal) {
+      if (options.signal.aborted) {
+        abortController.abort();
+      } else {
+        options.signal.addEventListener("abort", onUpstreamAbort, { once: true });
+      }
+    }
+
+    // Opus 4.7+ is adaptive-only (sampling parameters rejected); other models
+    // accept temperature etc. but the Agent SDK doesn't expose those knobs
+    // directly, so we skip them and rely on the SDK defaults.
+    const modelLower = options.model.toLowerCase();
+    const isAdaptiveOnly = /claude-opus-4-(?:[7-9]|\d{2,})/.test(modelLower);
+
+    const sdkOptions: Parameters<SdkModule["query"]>[0]["options"] = {
+      abortController,
+      model: options.model,
+      systemPrompt,
+      includePartialMessages: options.stream ?? true,
+      // Disable agent tooling — Marinara has its own tool/agent pipeline and
+      // we only want plain text completions out of this provider.
+      tools: [],
+      permissionMode: "bypassPermissions",
+      maxTurns: 1,
+    };
+
+    if (options.enableThinking) {
+      sdkOptions.thinking = { type: "adaptive" };
+      // EffortLevel covers low|medium|high|xhigh|max; reasoningEffort matches
+      // four of those, so a runtime cast is safe.
+      sdkOptions.effort = (options.reasoningEffort ?? "high") as "low" | "medium" | "high" | "xhigh";
+    } else if (isAdaptiveOnly) {
+      // Opus 4.7 always thinks; let the SDK pick a default effort.
+      sdkOptions.thinking = { type: "adaptive" };
+    }
+
+    if (this.apiKey) {
+      // Opt-in API fallback — overrides subscription auth when the connection
+      // has an explicit API key set.
+      sdkOptions.env = { ...process.env, ANTHROPIC_API_KEY: this.apiKey };
+    }
+
+    let inputTokens = 0;
+    let outputTokens = 0;
+    let cachedTokens = 0;
+    let cacheWriteTokens = 0;
+
+    try {
+      const queryHandle = query({ prompt, options: sdkOptions });
+
+      for await (const message of queryHandle) {
+        if (message.type === "stream_event") {
+          const event = message.event as {
+            type: string;
+            delta?: { type: string; text?: string; thinking?: string };
+          };
+          if (event.type === "content_block_delta" && event.delta) {
+            if (event.delta.type === "text_delta" && event.delta.text) {
+              yield event.delta.text;
+            } else if (event.delta.type === "thinking_delta" && event.delta.thinking && options.onThinking) {
+              options.onThinking(event.delta.thinking);
+            }
+          }
+        } else if (message.type === "assistant" && !(options.stream ?? true)) {
+          // Non-streaming path: the SDK still yields the full assistant
+          // message at the end; emit the text blocks once.
+          const blocks = (message.message?.content ?? []) as Array<{ type: string; text?: string; thinking?: string }>;
+          for (const block of blocks) {
+            if (block.type === "text" && block.text) {
+              yield block.text;
+            } else if (block.type === "thinking" && block.thinking && options.onThinking) {
+              options.onThinking(block.thinking);
+            }
+          }
+        } else if (message.type === "result") {
+          if (message.subtype === "success") {
+            const usage = message.usage ?? null;
+            if (usage) {
+              inputTokens = usage.input_tokens ?? 0;
+              outputTokens = usage.output_tokens ?? 0;
+              cachedTokens = usage.cache_read_input_tokens ?? 0;
+              cacheWriteTokens = usage.cache_creation_input_tokens ?? 0;
+            }
+          } else {
+            const detail = message.errors?.length ? ` — ${message.errors.join("; ")}` : "";
+            throw new Error(`Claude (Subscription) request failed (${message.subtype})${detail}`);
+          }
+        }
+      }
+    } catch (err) {
+      logger.error(err, "Claude Agent SDK query failed for model %s", options.model);
+      const friendly = err instanceof Error ? err.message : String(err);
+      throw new Error(`Claude (Subscription) request failed: ${friendly}`);
+    } finally {
+      if (options.signal) options.signal.removeEventListener("abort", onUpstreamAbort);
+    }
+
+    if (inputTokens || outputTokens) {
+      return {
+        promptTokens: inputTokens,
+        completionTokens: outputTokens,
+        totalTokens: inputTokens + outputTokens,
+        ...(cachedTokens ? { cachedPromptTokens: cachedTokens } : {}),
+        ...(cacheWriteTokens ? { cacheWritePromptTokens: cacheWriteTokens } : {}),
+      };
+    }
+  }
+
+  /**
+   * Embeddings are not exposed by the Claude Agent SDK. Surface a clear error
+   * so callers can route embedding work to a separate connection.
+   */
+  override async embed(_texts: string[], _model: string): Promise<number[][]> {
+    throw new Error(
+      "The Claude (Subscription) provider does not support embeddings. Configure a separate embedding connection (OpenAI, Google, or local).",
+    );
+  }
+}

--- a/packages/server/test/claude-subscription-provider.test.ts
+++ b/packages/server/test/claude-subscription-provider.test.ts
@@ -1,0 +1,223 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  ClaudeSubscriptionProvider,
+  __setSdkForTesting,
+} from "../src/services/llm/providers/claude-subscription.provider.js";
+import type { ChatMessage, ChatOptions } from "../src/services/llm/base-provider.js";
+
+type CapturedQuery = {
+  prompt: string;
+  options: Record<string, unknown>;
+};
+
+/**
+ * Build a fake `query()` that records the call and yields a scripted set of
+ * SDK messages. Returns both the fake and the recorded calls so each test can
+ * inspect what the provider sent.
+ */
+function makeFakeSdk(scripted: Array<Record<string, unknown>>) {
+  const calls: CapturedQuery[] = [];
+  const fake = {
+    query: (params: { prompt: string; options?: Record<string, unknown> }) => {
+      calls.push({ prompt: params.prompt, options: { ...(params.options ?? {}) } });
+      // Provide an async iterable that yields the scripted messages in order.
+      return (async function* () {
+        for (const msg of scripted) yield msg;
+      })();
+    },
+  };
+  return { fake, calls };
+}
+
+function streamEvent(delta: { type: string; text?: string; thinking?: string }) {
+  return {
+    type: "stream_event",
+    event: { type: "content_block_delta", delta },
+  };
+}
+
+function successResult(usage?: Record<string, number>) {
+  return {
+    type: "result",
+    subtype: "success",
+    usage: usage ?? { input_tokens: 12, output_tokens: 7 },
+  };
+}
+
+function makeProvider(apiKey = "") {
+  return new ClaudeSubscriptionProvider("", apiKey, undefined, undefined, undefined);
+}
+
+async function drain(
+  provider: ClaudeSubscriptionProvider,
+  messages: ChatMessage[],
+  options: ChatOptions,
+): Promise<{ text: string; usage: unknown }> {
+  let text = "";
+  const gen = provider.chat(messages, options);
+  let next = await gen.next();
+  while (!next.done) {
+    text += next.value;
+    next = await gen.next();
+  }
+  return { text, usage: next.value };
+}
+
+test.afterEach(() => {
+  __setSdkForTesting(null);
+});
+
+test("streams text deltas and merges them into the yielded chunks", async () => {
+  const { fake, calls } = makeFakeSdk([
+    streamEvent({ type: "text_delta", text: "Hel" }),
+    streamEvent({ type: "text_delta", text: "lo " }),
+    streamEvent({ type: "text_delta", text: "world" }),
+    successResult({ input_tokens: 5, output_tokens: 2 }),
+  ]);
+  __setSdkForTesting(fake);
+
+  const provider = makeProvider();
+  const { text, usage } = await drain(
+    provider,
+    [{ role: "user", content: "hi" }],
+    { model: "claude-opus-4-5", stream: true },
+  );
+
+  assert.equal(text, "Hello world");
+  assert.deepEqual(usage, { promptTokens: 5, completionTokens: 2, totalTokens: 7 });
+  assert.equal(calls.length, 1);
+  assert.match(calls[0]!.prompt, /User: hi$/);
+  assert.equal(calls[0]!.options.includePartialMessages, true);
+  assert.deepEqual(calls[0]!.options.tools, []);
+  assert.equal(calls[0]!.options.permissionMode, "bypassPermissions");
+  assert.equal(calls[0]!.options.maxTurns, 1);
+  assert.equal(calls[0]!.options.model, "claude-opus-4-5");
+});
+
+test("extracts system messages into systemPrompt and renders the rest as a transcript", async () => {
+  const { fake, calls } = makeFakeSdk([streamEvent({ type: "text_delta", text: "ok" }), successResult()]);
+  __setSdkForTesting(fake);
+
+  const provider = makeProvider();
+  await drain(
+    provider,
+    [
+      { role: "system", content: "You are Aerith." },
+      { role: "system", content: "Stay in character." },
+      { role: "user", content: "Hi Aerith." },
+      { role: "assistant", content: "Hello, traveler." },
+      { role: "user", content: "Where are we?" },
+    ],
+    { model: "claude-sonnet-4-5", stream: true },
+  );
+
+  assert.equal(calls[0]!.options.systemPrompt, "You are Aerith.\n\nStay in character.");
+  assert.equal(
+    calls[0]!.prompt,
+    "User: Hi Aerith.\n\nAssistant: Hello, traveler.\n\nUser: Where are we?",
+  );
+});
+
+test("Opus 4.7 enables adaptive thinking by default even without enableThinking", async () => {
+  const { fake, calls } = makeFakeSdk([streamEvent({ type: "text_delta", text: "." }), successResult()]);
+  __setSdkForTesting(fake);
+
+  await drain(makeProvider(), [{ role: "user", content: "hi" }], {
+    model: "claude-opus-4-7",
+    stream: true,
+  });
+
+  assert.deepEqual(calls[0]!.options.thinking, { type: "adaptive" });
+});
+
+test("enableThinking with reasoningEffort=xhigh forwards both fields", async () => {
+  const { fake, calls } = makeFakeSdk([streamEvent({ type: "text_delta", text: "." }), successResult()]);
+  __setSdkForTesting(fake);
+
+  await drain(makeProvider(), [{ role: "user", content: "hi" }], {
+    model: "claude-opus-4-5",
+    stream: true,
+    enableThinking: true,
+    reasoningEffort: "xhigh",
+  });
+
+  assert.deepEqual(calls[0]!.options.thinking, { type: "adaptive" });
+  assert.equal(calls[0]!.options.effort, "xhigh");
+});
+
+test("thinking_delta is forwarded to onThinking and not yielded as visible text", async () => {
+  const { fake } = makeFakeSdk([
+    streamEvent({ type: "thinking_delta", thinking: "considering options" }),
+    streamEvent({ type: "text_delta", text: "answer" }),
+    successResult(),
+  ]);
+  __setSdkForTesting(fake);
+
+  const thoughts: string[] = [];
+  const { text } = await drain(makeProvider(), [{ role: "user", content: "?" }], {
+    model: "claude-opus-4-7",
+    stream: true,
+    enableThinking: true,
+    onThinking: (chunk) => thoughts.push(chunk),
+  });
+
+  assert.equal(text, "answer");
+  assert.deepEqual(thoughts, ["considering options"]);
+});
+
+test("apiKey on the connection is forwarded as ANTHROPIC_API_KEY env override", async () => {
+  const { fake, calls } = makeFakeSdk([streamEvent({ type: "text_delta", text: "." }), successResult()]);
+  __setSdkForTesting(fake);
+
+  await drain(makeProvider("sk-ant-test"), [{ role: "user", content: "hi" }], {
+    model: "claude-haiku-4-5",
+    stream: true,
+  });
+
+  const env = calls[0]!.options.env as Record<string, string>;
+  assert.equal(env.ANTHROPIC_API_KEY, "sk-ant-test");
+});
+
+test("non-streaming path emits text from the final assistant message", async () => {
+  const { fake } = makeFakeSdk([
+    {
+      type: "assistant",
+      message: { content: [{ type: "text", text: "complete answer" }] },
+    },
+    successResult(),
+  ]);
+  __setSdkForTesting(fake);
+
+  const { text } = await drain(makeProvider(), [{ role: "user", content: "hi" }], {
+    model: "claude-sonnet-4-5",
+    stream: false,
+  });
+
+  assert.equal(text, "complete answer");
+});
+
+test("error result message is surfaced as a thrown error with details", async () => {
+  const { fake } = makeFakeSdk([
+    {
+      type: "result",
+      subtype: "error_during_execution",
+      errors: ["network glitch"],
+    },
+  ]);
+  __setSdkForTesting(fake);
+
+  await assert.rejects(
+    () =>
+      drain(makeProvider(), [{ role: "user", content: "hi" }], {
+        model: "claude-opus-4-5",
+        stream: true,
+      }),
+    /Claude \(Subscription\) request failed.*network glitch/,
+  );
+});
+
+test("embed() throws — embeddings are not supported on the subscription provider", async () => {
+  const provider = makeProvider();
+  await assert.rejects(() => provider.embed(["hello"], "irrelevant-model"), /does not support embeddings/i);
+});

--- a/packages/shared/src/constants/model-lists.ts
+++ b/packages/shared/src/constants/model-lists.ts
@@ -126,6 +126,21 @@ export const ANTHROPIC_MODELS: KnownModel[] = [
   { id: "claude-3-haiku-20240307", name: "claude-3-haiku-20240307", context: 200000, maxOutput: 4096 },
 ];
 
+// ── Claude (Subscription via Claude Agent SDK) ──
+// Models reachable through the local `claude` CLI auth (Pro / Max). Anthropic
+// gates which model IDs are available per plan tier; the SDK surfaces a clear
+// error if the signed-in plan can't run the requested model. We keep this list
+// to the current tool-eligible families to avoid offering retired aliases that
+// the subscription path no longer accepts.
+export const CLAUDE_SUBSCRIPTION_MODELS: KnownModel[] = [
+  { id: "claude-opus-4-7", name: "Claude Opus 4.7", context: 1000000, maxOutput: 128000 },
+  { id: "claude-opus-4-6", name: "Claude Opus 4.6", context: 1000000, maxOutput: 32000 },
+  { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6", context: 1000000, maxOutput: 32000 },
+  { id: "claude-opus-4-5", name: "Claude Opus 4.5", context: 1000000, maxOutput: 32000 },
+  { id: "claude-sonnet-4-5", name: "Claude Sonnet 4.5", context: 1000000, maxOutput: 16000 },
+  { id: "claude-haiku-4-5", name: "Claude Haiku 4.5", context: 200000, maxOutput: 8192 },
+];
+
 // ── Google AI Studio (from #model_google_select) ──
 
 export const GOOGLE_MODELS: KnownModel[] = [
@@ -515,6 +530,7 @@ export function inferImageSource(model: string, baseUrl: string): string {
 export const MODEL_LISTS: Record<APIProvider, KnownModel[]> = {
   openai: OPENAI_MODELS,
   anthropic: ANTHROPIC_MODELS,
+  claude_subscription: CLAUDE_SUBSCRIPTION_MODELS,
   google: GOOGLE_MODELS,
   mistral: MISTRAL_MODELS,
   cohere: COHERE_MODELS,

--- a/packages/shared/src/constants/providers.ts
+++ b/packages/shared/src/constants/providers.ts
@@ -34,6 +34,18 @@ export const PROVIDERS: Record<APIProvider, ProviderDefinition> = {
     usesAuthHeader: false,
     apiKeyHeader: "x-api-key",
   },
+  claude_subscription: {
+    id: "claude_subscription",
+    name: "Claude (Subscription)",
+    // No base URL — the Claude Agent SDK reads credentials stored locally by the
+    // Claude Code CLI (`claude login`) and routes requests through Anthropic's
+    // first-party endpoints on behalf of the signed-in Pro / Max account.
+    defaultBaseUrl: "",
+    modelsEndpoint: "",
+    supportsStreaming: true,
+    usesAuthHeader: false,
+    apiKeyHeader: null,
+  },
   google: {
     id: "google",
     name: "Google Gemini",

--- a/packages/shared/src/schemas/connection.schema.ts
+++ b/packages/shared/src/schemas/connection.schema.ts
@@ -6,6 +6,7 @@ import { z } from "zod";
 export const apiProviderSchema = z.enum([
   "openai",
   "anthropic",
+  "claude_subscription",
   "google",
   "mistral",
   "cohere",

--- a/packages/shared/src/types/connection.ts
+++ b/packages/shared/src/types/connection.ts
@@ -6,6 +6,7 @@
 export type APIProvider =
   | "openai"
   | "anthropic"
+  | "claude_subscription"
   | "google"
   | "mistral"
   | "cohere"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,6 +110,9 @@ importers:
 
   packages/server:
     dependencies:
+      '@anthropic-ai/claude-agent-sdk':
+        specifier: ^0.2.0
+        version: 0.2.119(zod@3.25.76)
       '@fastify/cors':
         specifier: ^11.0.0
         version: 11.2.0
@@ -220,6 +223,65 @@ importers:
         version: 5.9.3
 
 packages:
+
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.119':
+    resolution: {integrity: sha512-kxnG37SZqUata2Jcp/YQ0n9Y7o/sinE/8LdG4ltM1gePh+z+0Mfa4vBUUTEBMBFth9PTovKoesIuVuyFpvO/Cw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.119':
+    resolution: {integrity: sha512-9Aj8g3ELsmZuOFg17TCkikeg/Wt2ucVT8hOOPQUatzLd7BKhydrHLA0RP42nBpWECO1B/n/mPdQ4iS/LS3s2Fg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.119':
+    resolution: {integrity: sha512-IPGWgtz+gGnD7fxKAvSf913EUT/lYBTBE8EZ7lh3+x5ZP2859LWLmrCm053Lf3nMWo/CWikZsVPwkDVwpz6tIQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.119':
+    resolution: {integrity: sha512-v3o464XkiYehp/OKidQQirxdVb+aGSvdJvHF2zH9p33W8M/NC21zwwh4dhwDnKsyrtBIgkt2CcMwzIl30r0OtA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.119':
+    resolution: {integrity: sha512-QYxFNAe4FFridPkKhGlNcNBJ0TaIygWYyvfI9g4kX0i+RVbresUWuZVkWY06ioJ0fXoixFJ+HNQBMB7dLrIp8Q==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.2.119':
+    resolution: {integrity: sha512-9ePt4ZN+hsqDw4AgS4KtcWIGKfL9Oq28kwkrTER/QAcSrVKxiLonp81cCLzg7Ok/IUJu4Cfd71GZbFv/WE54zw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.119':
+    resolution: {integrity: sha512-p/TjcKQvkCYtXGPlR+mdyNwqCmvRcQL34Wtq0yUZ+iqmI/eyCe59IJ3AZrE0EZoqmiAevEYzatPIt9sncC9uxw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.2.119':
+    resolution: {integrity: sha512-k98Ju0wtktm6FhqTE/cXlVr6K4kGqBolVjEGzeKkW6ZILc7124euwNapAvkQCwMAavAxS/ZnO3jdKMtHtwTVTA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@anthropic-ai/claude-agent-sdk@0.2.119':
+    resolution: {integrity: sha512-6AvthpsaOTlkn514brSGOcCSLHDXODnU+ExN1O3CJCjxr5RBcmzR057C9EIM0G7IchnXsRfMZgRO1QKsjTXdbA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      zod: ^4.0.0
+
+  '@anthropic-ai/sdk@0.81.0':
+    resolution: {integrity: sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   '@apideck/better-ajv-errors@0.3.6':
     resolution: {integrity: sha512-P+ZygBLZtkp0qqOAJJVX4oX/sFo5JR3eBWwwuqHHhK0GIgQOKWrAfiAaWX0aArHkRWHMuggFEgAZNxVPwPZYaA==}
@@ -1272,6 +1334,12 @@ packages:
   '@fastify/websocket@11.2.0':
     resolution: {integrity: sha512-3HrDPbAG1CzUCqnslgJxppvzaAZffieOVbLp1DAy1huCSynUWPifSvfdEDUR8HlJLp3sp1A36uOM2tJogADS8w==}
 
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@huggingface/jinja@0.5.6':
     resolution: {integrity: sha512-MyMWyLnjqo+KRJYSH7oWNbsOn5onuIvfXYPcc0WOGxU0eHUV7oAYUoQTl2BMdu7ml+ea/bu11UM+EshbeHwtIA==}
     engines: {node: '>=18'}
@@ -1535,6 +1603,16 @@ packages:
   '@lukeed/ms@2.0.2':
     resolution: {integrity: sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==}
     engines: {node: '>=8'}
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@napi-rs/canvas-android-arm64@0.1.80':
     resolution: {integrity: sha512-sk7xhN/MoXeuExlggf91pNziBxLPVUqF2CAVnB57KLG/pz7+U5TKG8eXdc3pm0d7Od0WreB6ZKLj37sX9muGOQ==}
@@ -2079,6 +2157,10 @@ packages:
   abstract-logging@2.0.1:
     resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -2190,6 +2272,10 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+
   boolean@3.2.0:
     resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
@@ -2217,6 +2303,10 @@ packages:
 
   buttplug@4.0.0:
     resolution: {integrity: sha512-9fO055gmZbHp7lI5C95pNbvjHye/n5cKNxv//ObW7Vh8R6UULE5tz8/dpYXJDcjy64DbX1+M5KnUgr40ygafsQ==}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -2275,11 +2365,27 @@ packages:
     resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
     engines: {node: '>= 0.6'}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cookie-es@2.0.0:
     resolution: {integrity: sha512-RAj4E421UYRgqokKUmotqAwuplYw15qtdXfY+hGzgCJ/MBjCVZcSoHK/kH9kocfjRjcDME7IiDWR/1WX1TM2Pg==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
 
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
@@ -2287,6 +2393,10 @@ packages:
 
   core-js-compat@3.48.0:
     resolution: {integrity: sha512-OM4cAF3D6VtH/WkLtWvyNC56EZVXsZdU3iqaMG2B4WvYrlqU831pc4UtG5yp0sE9z8Y02wVN7PjW5Zf9Gt0f1Q==}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   crc-32@0.3.0:
     resolution: {integrity: sha512-kucVIjOmMc1f0tv53BJ/5WIX+MGLcKuoBhnGqQrgKJNqLByb/sVMWfW/Aw6hw0jgcqjJ2pi9E5y32zOIpaUlsA==}
@@ -2484,6 +2594,9 @@ packages:
   duplexify@4.1.3:
     resolution: {integrity: sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==}
 
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
   ejs@3.1.10:
     resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
     engines: {node: '>=0.10.0'}
@@ -2491,6 +2604,10 @@ packages:
 
   electron-to-chromium@1.5.302:
     resolution: {integrity: sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
@@ -2615,12 +2732,34 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
+  eventsource-parser@3.0.8:
+    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
 
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
+
+  express-rate-limit@8.4.1:
+    resolution: {integrity: sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   fast-copy@4.0.2:
     resolution: {integrity: sha512-ybA6PDXIXOXivLJK/z9e+Otk7ve13I4ckBvGO5I2RRmBU1gMHLVDJYEuJYhGwez7YNlYji2M2DvVU+a9mSFDlw==}
@@ -2681,6 +2820,10 @@ packages:
   filelist@1.0.6:
     resolution: {integrity: sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-my-way@9.5.0:
     resolution: {integrity: sha512-VW2RfnmscZO5KgBY5XVyKREMW5nMZcxDy+buTOsL+zIPnBlbKm+00sgzoQzq1EVh4aALZLfKdwv6atBGcjvjrQ==}
     engines: {node: '>=20'}
@@ -2711,6 +2854,10 @@ packages:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
 
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
 
@@ -2727,6 +2874,10 @@ packages:
         optional: true
       react-dom:
         optional: true
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -2847,9 +2998,17 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
+  hono@4.12.15:
+    resolution: {integrity: sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==}
+    engines: {node: '>=16.9.0'}
+
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
 
   idb@7.1.1:
     resolution: {integrity: sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==}
@@ -2882,6 +3041,14 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  ip-address@10.1.0:
+    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
 
   ipaddr.js@2.3.0:
     resolution: {integrity: sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==}
@@ -2954,6 +3121,9 @@ packages:
     resolution: {integrity: sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg==}
     engines: {node: '>=0.10.0'}
 
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
@@ -3021,6 +3191,9 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  jose@6.2.2:
+    resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
+
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
@@ -3046,11 +3219,18 @@ packages:
   json-schema-ref-resolver@3.0.0:
     resolution: {integrity: sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A==}
 
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
+
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
@@ -3211,6 +3391,22 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
+
   mime@3.0.0:
     resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
     engines: {node: '>=10.0.0'}
@@ -3266,6 +3462,10 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
   node-abi@3.88.0:
     resolution: {integrity: sha512-At6b4UqIEVudaqPsXjmUO1r/N5BUr4yhDGs5PkBE8/oG5+TfLPhFechiskFsnT6Ql0VfUXbalUUCbfXxtj7K+w==}
     engines: {node: '>=10'}
@@ -3282,6 +3482,10 @@ packages:
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
@@ -3297,6 +3501,10 @@ packages:
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -3334,6 +3542,10 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -3348,6 +3560,9 @@ packages:
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   pdf-parse@2.4.5:
     resolution: {integrity: sha512-mHU89HGh7v+4u2ubfnevJ03lmPgQ5WU4CxAVmTSh/sxVTEDYd1er/dKS/A6vg77NX47KTEoihq8jZBLr8Cxuwg==}
@@ -3389,6 +3604,10 @@ packages:
   pino@9.14.0:
     resolution: {integrity: sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==}
     hasBin: true
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   platform@1.3.6:
     resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
@@ -3449,6 +3668,10 @@ packages:
     resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
     engines: {node: '>=12.0.0'}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
@@ -3456,11 +3679,23 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  qs@6.15.1:
+    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+    engines: {node: '>=0.6'}
+
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
 
   randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
@@ -3554,6 +3789,10 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   safe-array-concat@1.1.3:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
     engines: {node: '>=0.4'}
@@ -3576,6 +3815,9 @@ packages:
     resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
     engines: {node: '>=10'}
 
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
@@ -3594,6 +3836,10 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
   serialize-error@7.0.1:
     resolution: {integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==}
     engines: {node: '>=10'}
@@ -3610,6 +3856,10 @@ packages:
   seroval@1.5.0:
     resolution: {integrity: sha512-OE4cvmJ1uSPrKorFIH9/w/Qwuvi/IMcGbv5RKgcJ/zjA/IohDLU6SVaxFN9FwajbP7nsX0dQqMDes1whk3y+yw==}
     engines: {node: '>=10'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
 
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
@@ -3829,6 +4079,9 @@ packages:
   tr46@1.0.1:
     resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
 
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+
   ts-api-utils@2.4.0:
     resolution: {integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==}
     engines: {node: '>=18.12'}
@@ -3857,6 +4110,10 @@ packages:
   type-fest@0.16.0:
     resolution: {integrity: sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==}
     engines: {node: '>=10'}
+
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
 
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
@@ -3921,6 +4178,10 @@ packages:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   upath@1.2.0:
     resolution: {integrity: sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==}
     engines: {node: '>=4'}
@@ -3941,6 +4202,10 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vite-plugin-pwa@1.2.0:
     resolution: {integrity: sha512-a2xld+SJshT9Lgcv8Ji4+srFJL4k/1bVbd1x06JIkvecpQkwkvCncD1+gSzcdm3s+owWLpMJerG3aN5jupJEVw==}
@@ -4100,6 +4365,11 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
   zod-validation-error@4.0.2:
     resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
     engines: {node: '>=18.0.0'}
@@ -4128,6 +4398,54 @@ packages:
         optional: true
 
 snapshots:
+
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.119':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.119':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.119':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.119':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.119':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.2.119':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.119':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.2.119':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk@0.2.119(zod@3.25.76)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.81.0(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
+      zod: 3.25.76
+    optionalDependencies:
+      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.2.119
+      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.2.119
+      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.2.119
+      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.2.119
+      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.2.119
+      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.2.119
+      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.2.119
+      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.2.119
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - supports-color
+
+  '@anthropic-ai/sdk@0.81.0(zod@3.25.76)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 3.25.76
 
   '@apideck/better-ajv-errors@0.3.6(ajv@8.18.0)':
     dependencies:
@@ -5153,6 +5471,10 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  '@hono/node-server@1.19.14(hono@4.12.15)':
+    dependencies:
+      hono: 4.12.15
+
   '@huggingface/jinja@0.5.6': {}
 
   '@huggingface/transformers@3.8.1':
@@ -5358,6 +5680,28 @@ snapshots:
     optional: true
 
   '@lukeed/ms@2.0.2': {}
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.15)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.8
+      express: 5.2.1
+      express-rate-limit: 8.4.1(express@5.2.1)
+      hono: 4.12.15
+      jose: 6.2.2
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
 
   '@napi-rs/canvas-android-arm64@0.1.80':
     optional: true
@@ -5834,6 +6178,11 @@ snapshots:
 
   abstract-logging@2.0.1: {}
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -5958,6 +6307,20 @@ snapshots:
       readable-stream: 3.6.2
     optional: true
 
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.1
+      raw-body: 3.0.2
+      type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   boolean@3.2.0: {}
 
   brace-expansion@1.1.12:
@@ -5996,6 +6359,8 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+
+  bytes@3.1.2: {}
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -6050,15 +6415,28 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
   convert-source-map@2.0.0: {}
 
   cookie-es@2.0.0: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
 
   cookie@1.1.1: {}
 
   core-js-compat@3.48.0:
     dependencies:
       browserslist: 4.28.1
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   crc-32@0.3.0: {}
 
@@ -6168,11 +6546,15 @@ snapshots:
       readable-stream: 3.6.2
       stream-shift: 1.0.3
 
+  ee-first@1.1.1: {}
+
   ejs@3.1.10:
     dependencies:
       jake: 10.9.4
 
   electron-to-chromium@1.5.302: {}
+
+  encodeurl@2.0.0: {}
 
   end-of-stream@1.4.5:
     dependencies:
@@ -6444,10 +6826,56 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  etag@1.8.1: {}
+
   eventemitter3@5.0.4: {}
+
+  eventsource-parser@3.0.8: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.8
 
   expand-template@2.0.3:
     optional: true
+
+  express-rate-limit@8.4.1(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.1.0
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.1
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   fast-copy@4.0.2: {}
 
@@ -6520,6 +6948,17 @@ snapshots:
     dependencies:
       minimatch: 5.1.9
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   find-my-way@9.5.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -6553,6 +6992,8 @@ snapshots:
     dependencies:
       fetch-blob: 3.2.0
 
+  forwarded@0.2.0: {}
+
   fraction.js@5.3.4: {}
 
   framer-motion@12.34.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
@@ -6563,6 +7004,8 @@ snapshots:
     optionalDependencies:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
+
+  fresh@2.0.0: {}
 
   fs-constants@1.0.0:
     optional: true
@@ -6692,6 +7135,8 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
+  hono@4.12.15: {}
+
   http-errors@2.0.1:
     dependencies:
       depd: 2.0.0
@@ -6699,6 +7144,10 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.2
       toidentifier: 1.0.1
+
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
 
   idb@7.1.1: {}
 
@@ -6726,6 +7175,10 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
+
+  ip-address@10.1.0: {}
+
+  ipaddr.js@1.9.1: {}
 
   ipaddr.js@2.3.0: {}
 
@@ -6800,6 +7253,8 @@ snapshots:
 
   is-obj@1.0.1: {}
 
+  is-promise@4.0.0: {}
+
   is-regex@1.2.1:
     dependencies:
       call-bound: 1.0.4
@@ -6861,6 +7316,8 @@ snapshots:
 
   jiti@2.6.1: {}
 
+  jose@6.2.2: {}
+
   joycon@3.1.1: {}
 
   js-base64@3.7.8: {}
@@ -6879,9 +7336,16 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.28.6
+      ts-algebra: 2.0.0
+
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-schema@0.4.0: {}
 
@@ -7018,6 +7482,16 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
+
+  mime-db@1.54.0: {}
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
+
   mime@3.0.0: {}
 
   mimic-response@3.1.0:
@@ -7059,6 +7533,8 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  negotiator@1.0.0: {}
+
   node-abi@3.88.0:
     dependencies:
       semver: 7.7.4
@@ -7074,6 +7550,8 @@ snapshots:
 
   node-releases@2.0.27: {}
 
+  object-assign@4.1.1: {}
+
   object-inspect@1.13.4: {}
 
   object-keys@1.1.1: {}
@@ -7088,6 +7566,10 @@ snapshots:
       object-keys: 1.1.1
 
   on-exit-leak-free@2.1.2: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
 
   once@1.4.0:
     dependencies:
@@ -7139,6 +7621,8 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parseurl@1.3.3: {}
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
@@ -7149,6 +7633,8 @@ snapshots:
     dependencies:
       lru-cache: 11.2.6
       minipass: 7.1.3
+
+  path-to-regexp@8.4.2: {}
 
   pdf-parse@2.4.5:
     dependencies:
@@ -7219,6 +7705,8 @@ snapshots:
       sonic-boom: 4.2.1
       thread-stream: 3.1.0
 
+  pkce-challenge@5.0.1: {}
+
   platform@1.3.6: {}
 
   png-chunk-text@1.0.0: {}
@@ -7287,6 +7775,11 @@ snapshots:
       '@types/node': 22.19.13
       long: 5.3.2
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
@@ -7294,11 +7787,24 @@ snapshots:
 
   punycode@2.3.1: {}
 
+  qs@6.15.1:
+    dependencies:
+      side-channel: 1.1.0
+
   quick-format-unescaped@4.0.4: {}
 
   randombytes@2.1.0:
     dependencies:
       safe-buffer: 5.2.1
+
+  range-parser@1.2.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
 
   rc@1.2.8:
     dependencies:
@@ -7428,6 +7934,16 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.59.0
       fsevents: 2.3.3
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   safe-array-concat@1.1.3:
     dependencies:
       call-bind: 1.0.8
@@ -7455,6 +7971,8 @@ snapshots:
 
   safe-stable-stringify@2.5.0: {}
 
+  safer-buffer@2.1.2: {}
+
   scheduler@0.27.0: {}
 
   secure-json-parse@4.1.0: {}
@@ -7464,6 +7982,22 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.7.4: {}
+
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   serialize-error@7.0.1:
     dependencies:
@@ -7478,6 +8012,15 @@ snapshots:
       seroval: 1.5.0
 
   seroval@1.5.0: {}
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
 
   set-cookie-parser@2.7.2: {}
 
@@ -7754,6 +8297,8 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  ts-algebra@2.0.0: {}
+
   ts-api-utils@2.4.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
@@ -7779,6 +8324,12 @@ snapshots:
   type-fest@0.13.1: {}
 
   type-fest@0.16.0: {}
+
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
 
   typed-array-buffer@1.0.3:
     dependencies:
@@ -7854,6 +8405,8 @@ snapshots:
 
   universalify@2.0.1: {}
 
+  unpipe@1.0.0: {}
+
   upath@1.2.0: {}
 
   update-browserslist-db@1.2.3(browserslist@4.28.1):
@@ -7871,6 +8424,8 @@ snapshots:
       react: 19.2.4
 
   util-deprecate@1.0.2: {}
+
+  vary@1.1.2: {}
 
   vite-plugin-pwa@1.2.0(vite@6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0))(workbox-build@7.4.0(@types/babel__core@7.20.5))(workbox-window@7.4.0):
     dependencies:
@@ -8076,6 +8631,10 @@ snapshots:
   yallist@3.1.1: {}
 
   yocto-queue@0.1.0: {}
+
+  zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
 
   zod-validation-error@4.0.2(zod@3.25.76):
     dependencies:


### PR DESCRIPTION
…t SDK

Routes chat through the locally-installed Claude Agent SDK so requests bill against the user's Anthropic Pro / Max subscription instead of an sk-ant-* API key. Same auth mechanism Anthropic-endorsed integrations like Visual Studio Code, Cursor, and Zed use — no proxy or third-party shim is involved.

Why: Marinara users with paid Claude subscriptions previously had no path to use them inside Marinara without buying additional API credits on top of the subscription they already pay for. The Agent SDK is Anthropic's public, documented mechanism for this exact use case.

Changes:
- New `claude_subscription` provider registered in shared types, providers constant, model lists, Zod schema, and DB schema enum
- New `ClaudeSubscriptionProvider` wrapping `query()` from `@anthropic-ai/claude-agent-sdk` — streams text deltas, forwards thinking content, defaults to adaptive thinking on Opus 4.7+
- Connection routes short-circuit HTTP-only paths (test, /models, test-message) for the SDK provider since there is no remote endpoint
- Connection editor: themed prerequisites notice (Visual Studio Code reference for context), disables Base URL and API Key inputs (managed by the SDK), hides irrelevant fields (Max Tokens Override, embedding model/endpoint/connection, base-URL warning)
- 9 unit tests covering streaming, transcript rendering, thinking, env fallback, error surfacing, embeddings rejection
- CHANGELOG and docs/FAQ updated; pnpm-lock regenerated

Built-in agent tools (Bash, Read, Write, etc.) are explicitly disabled — Marinara has its own agent/tool layer. Embeddings are not supported on this provider; users must configure a separate connection for them.

Prerequisites for the host running Marinara:
1. npm i -g @anthropic-ai/claude-code
2. claude login

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

## What changed

<!-- List the key changes in this PR -->
- 

## Validation

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Claude (Subscription) connection provider to bill against Anthropic Pro/Max subscription instead of API keys
  * Requires locally-installed Claude Code Agent SDK and `claude login` authentication
  * Agent tools managed by Marinara for this provider
  * Embeddings unsupported for Claude subscription

* **Documentation**
  * Updated FAQ and changelog with Claude subscription provider details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Claude Subscription as a new LLM provider, enabling routing through locally-installed Claude Agent SDK to bill against Anthropic Pro/Max subscriptions.
  * Claude Subscription connections authenticate via Claude CLI instead of API keys.
  * Added Claude model catalog with context window specifications.

* **Documentation**
  * Updated FAQ to clarify Anthropic connectivity via Claude Pro/Max subscription option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->