### PR TITLE
fix(server): scan endpoint shouldn't skip empty chats — CONST entries activate regardless

### DIFF
--- a/packages/server/src/routes/lorebooks.routes.ts
+++ b/packages/server/src/routes/lorebooks.routes.ts
@@ -193,7 +193,8 @@ export async function lorebooksRoutes(app: FastifyInstance) {
     const { chatId } = req.params;
     const chatsStorage = createChatsStorage(app.db);
     const chatMessages = await chatsStorage.listMessages(chatId);
-    if (!chatMessages.length) return reply.send({ entries: [], totalTokens: 0, totalEntries: 0 });
+    // CONST entries activate regardless of message content, so the scan
+    // must run even when the chat has no messages.
 
     // Load chat to get characterIds and activeLorebookIds from metadata
     const chat = await chatsStorage.getById(chatId);


### PR DESCRIPTION
## The bug

Open a fresh chat that has a lorebook with CONST entries attached.
Open the Active World Info panel. It says "No active entries for
this chat" — but CONST entries activate unconditionally by definition,
they should be there. Send any message at all and they appear.

**Repro:**
1. Create a lorebook with one entry, mark it `Constant: true`.
2. Attach the lorebook to a character.
3. Start a fresh chat with that character.
4. Before sending anything, open the World Info panel — empty.
5. Send any message — entries appear.

## Root cause

`/lorebooks/scan/:chatId` had an early return that bailed out with
an empty result when `chatMessages.length === 0`. The intent was
probably "no messages → nothing can have triggered" — but that
ignores CONST, which doesn't need a trigger.

## Fix

Drop the early return. `processLorebooks()` already handles the
empty-message case correctly: keyword-triggered entries don't fire
(nothing to match), and CONST entries activate as expected.

## User-visible result

CONST entries appear in the Active World Info panel from the moment
a chat is created, matching their "always on" semantic.

## Testing

- `pnpm lint && pnpm build` pass.
- Manual: fresh chat with a CONST-entry lorebook attached now shows
  the entry on first panel open, before any message is sent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The scan endpoint now properly processes empty chats by applying consistent processing instead of returning a default response for chats with no messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->