### PR TITLE
fix(connections): allow Claude (Subscription) chats past the baseUrl gate

### DIFF
--- a/packages/server/src/routes/conversation.routes.ts
+++ b/packages/server/src/routes/conversation.routes.ts
@@ -32,6 +32,9 @@ import {
 
 function resolveBaseUrl(connection: { baseUrl: string | null; provider: string }): string {
   if (connection.baseUrl) return connection.baseUrl;
+  // Claude (Subscription) routes through the local Claude Agent SDK and has no
+  // HTTP endpoint — return a sentinel so the downstream baseUrl gate passes.
+  if (connection.provider === "claude_subscription") return "claude-agent-sdk://local";
   const providerDef = PROVIDERS[connection.provider as keyof typeof PROVIDERS];
   return providerDef?.defaultBaseUrl ?? "";
 }

--- a/packages/server/src/routes/generate/generate-route-utils.ts
+++ b/packages/server/src/routes/generate/generate-route-utils.ts
@@ -24,6 +24,10 @@ export function parseExtra(extra: unknown): Record<string, unknown> {
 /** Resolve the base URL for a connection, falling back to the provider default. */
 export function resolveBaseUrl(connection: { baseUrl: string | null; provider: string }): string {
   if (connection.baseUrl) return connection.baseUrl.replace(/\/+$/, "");
+  // Claude (Subscription) routes through the local Claude Agent SDK and has no
+  // HTTP endpoint — but downstream callers gate on a non-empty baseUrl. Return
+  // a sentinel so the gate passes; the provider ignores the value.
+  if (connection.provider === "claude_subscription") return "claude-agent-sdk://local";
   const providerDef = PROVIDERS[connection.provider as keyof typeof PROVIDERS];
   return providerDef?.defaultBaseUrl ?? "";
 }


### PR DESCRIPTION
## Summary
- After #243, real chat messages with a Claude (Subscription) connection failed with `No base URL configured for this connection`, even though the connection test and test-message both succeeded.
- Root cause: the provider has no HTTP endpoint (the Agent SDK uses local `claude login` credentials), so its `defaultBaseUrl` is `""`. `resolveBaseUrl()` therefore returned `""`, and the chat paths in `generate.routes.ts` and `conversation.routes.ts` both reject empty baseUrls. The test-message endpoint had an inline exemption; the chat paths did not.
- Fix: centralize the exemption in `resolveBaseUrl()` (both copies) so a sentinel is returned for `claude_subscription`. The `ClaudeSubscriptionProvider` ignores `baseUrl` entirely, so the sentinel is harmless — it just clears the precondition.

## Test plan
- [x] `pnpm check` passes (typecheck + lint + build).
- [x] Test message on a `claude_subscription` connection still works.
- [x] Send a real chat message on a `claude_subscription` connection → no longer errors with "No base URL configured…".
- [x] Autonomous conversation generation on a `claude_subscription` connection no longer errors at the baseUrl gate.

## Notes
A few non-chat features (character-maker, lorebook-maker, encounter, scene, persona-maker, translate, prompt-reviewer, game) build their baseUrl inline with the same gate. They are not affected by user reports yet but would hit the same wall if pointed at a `claude_subscription` connection — worth a follow-up if we want full coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Claude subscription connections without HTTP endpoints to work properly with schedule generation functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->