### PR TITLE
refactor(server): drop duplicate key details from inline conversation summaries

### DIFF
--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -1315,14 +1315,11 @@ export async function generateRoutes(app: FastifyInstance) {
               const wEntry = weekSummaries[weekKey]!;
               const monday = parseDateKey(weekKey);
               const sunday = new Date(monday.getFullYear(), monday.getMonth(), monday.getDate() + 6);
-              let block = wEntry.summary;
-              if (wEntry.keyDetails.length > 0) {
-                block += `\nKey details: ${wEntry.keyDetails.join("; ")}`;
-              }
+              // Key details are surfaced separately via <important_memories> in the system prompt.
               return [
                 {
                   role: "system" as const,
-                  content: `<summary week="${weekKey} – ${fmtDateKey(sunday)}">\n${block}\n</summary>`,
+                  content: `<summary week="${weekKey} – ${fmtDateKey(sunday)}">\n${wEntry.summary}\n</summary>`,
                 },
               ];
             }
@@ -1330,14 +1327,11 @@ export async function generateRoutes(app: FastifyInstance) {
             // Non-consolidated day with a summary
             const entry = daySummaries[bucket.date];
             if (entry) {
-              let block = entry.summary;
-              if (entry.keyDetails.length > 0) {
-                block += `\nKey details: ${entry.keyDetails.join("; ")}`;
-              }
+              // Key details are surfaced separately via <important_memories> in the system prompt.
               return [
                 {
                   role: "system" as const,
-                  content: `<summary date="${bucket.date}">\n${block}\n</summary>`,
+                  content: `<summary date="${bucket.date}">\n${entry.summary}\n</summary>`,
                 },
               ];
             }


### PR DESCRIPTION
## Summary

In conversation mode, every per-day and per-week summary's `keyDetails` were being injected into the prompt twice:

1. Inline, appended to each `<summary date="...">` / `<summary week="...">` block in the chat history.
2. As the canonical `<important_memories>` block at the end of `conversationSystemPrompt`, where they are already labeled by date and chronologically sorted.

This PR keeps `<important_memories>` as the single source of truth for key details. The inline `<summary>` blocks now hold the narrative recap only.

## Test plan

- [x] `pnpm install`
- [x] `pnpm check` (lint + build) passes
- [x] Manual: open a conversation-mode chat that already has at least one daily summary and one consolidated weekly summary; confirm the model still references key details correctly and that summaries no longer carry an inline `Key details: …` line in the request payload

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized the internal processing of conversation summaries to improve the organization and accessibility of key details within the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->