### PR TITLE
feat: guide generations with chat input + visible indicator

### DIFF
--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -74,7 +74,7 @@ The only **persisted** store (localStorage via Zustand `persist` middleware). Co
 - **Streaming**: `enableStreaming`, `streamingSpeed`
 - **Conversation theme**: gradient colors for message bubbles
 - **Sound**: `convoNotificationSound`, `rpNotificationSound`
-- **Behavior**: `confirmBeforeDelete`, `enterToSendRP`, `enterToSendConvo`, `weatherEffects`
+- **Behavior**: `confirmBeforeDelete`, `enterToSendRP`, `enterToSendConvo`, `weatherEffects`, `guideGenerations`
 - **Navigation**: `rightPanel`, `rightPanelOpen`, `sidebarOpen`, `settingsTab`, all `*DetailId` fields, `modal`
 
 Synced custom themes are **not** stored in `ui.store.ts`; they are fetched from the server via React Query and mirrored across devices connected to the same Marinara instance.
@@ -87,6 +87,7 @@ Non-persisted. Tracks the active chat session:
 - `messages` — current message array
 - `isStreaming`, `streamBuffer` — generation in progress
 - `inputDrafts` — per-chat draft messages
+- `currentInput` — current value of chat input
 - `perChatTyping` — typing indicator state
 - `unreadCounts`, `chatNotifications` — notification badges
 - `abortControllers` — cancel in-flight generations

--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -83,10 +83,12 @@ export function ChatArea() {
   const isStreaming = isStreamingGlobal && streamingChatId === activeChatId;
   const isPageActive = usePageActivity();
   const regenerateMessageId = useChatStore((s) => s.regenerateMessageId);
+  const currentInput = useChatStore((s) => s.currentInput);
   const chatBackground = useUIStore((s) => s.chatBackground);
   const weatherEffects = useUIStore((s) => s.weatherEffects);
   const messagesPerPage = useUIStore((s) => s.messagesPerPage);
   const centerCompact = useUIStore((s) => s.centerCompact);
+  const guideGenerations = useUIStore((s) => s.guideGenerations);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const prevScrollHeightRef = useRef(0);
@@ -652,12 +654,17 @@ export function ChatArea() {
       }
       try {
         // Regenerate as a new swipe on the existing message
-        await generate({ chatId: activeChatId, connectionId: null, regenerateMessageId: messageId });
+        const hasInput = currentInput ? currentInput.trim().length > 0 : false;
+        await generate(
+          guideGenerations && hasInput
+          ? { chatId: activeChatId, connectionId: null, regenerateMessageId: messageId, generationGuide: currentInput?.toString() }
+          : { chatId: activeChatId, connectionId: null, regenerateMessageId: messageId }
+        );
       } catch {
         // Error toast is shown by the generate hook
       }
     },
-    [activeChatId, isStreaming, generate],
+    [activeChatId, isStreaming, generate, currentInput, guideGenerations],
   );
 
   const _handleRetryAgents = useCallback(async () => {

--- a/packages/client/src/components/chat/ChatInput.tsx
+++ b/packages/client/src/components/chat/ChatInput.tsx
@@ -69,6 +69,7 @@ export const ChatInput = memo(function ChatInput({
   const isStreaming = isStreamingGlobal && streamingChatId === activeChatId;
   const setInputDraft = useChatStore((s) => s.setInputDraft);
   const clearInputDraft = useChatStore((s) => s.clearInputDraft);
+  const setCurrentInput = useChatStore((s) => s.setCurrentInput);
   const { generate } = useGenerate();
   const { applyToUserInput } = useApplyRegex();
   const enterToSend = useUIStore((s) => s.enterToSendRP);
@@ -76,6 +77,11 @@ export const ChatInput = memo(function ChatInput({
   const fileInputRef = useRef<HTMLInputElement>(null);
   const resizeRafRef = useRef<number>(0);
   const qc = useQueryClient();
+
+  const syncInputState = useCallback((value: string) => {
+    setHasInput(value.trim().length > 0);
+    setCurrentInput(value);
+  }, [setCurrentInput]);
 
   // Restore draft when mounting or switching chats
   const prevChatIdRef = useRef<string | null>(null);
@@ -96,12 +102,12 @@ export const ChatInput = memo(function ChatInput({
     if (activeChatId && textareaRef.current) {
       const draft = useChatStore.getState().inputDrafts.get(activeChatId) ?? "";
       textareaRef.current.value = draft;
-      setHasInput(draft.trim().length > 0);
+      syncInputState(draft);
       // Resize textarea to fit content
       textareaRef.current.style.height = "auto";
       textareaRef.current.style.height = Math.min(textareaRef.current.scrollHeight, 200) + "px";
     }
-  }, [activeChatId, setInputDraft, clearInputDraft]);
+  }, [activeChatId, setInputDraft, clearInputDraft, syncInputState]);
 
   // Save draft when component unmounts (e.g. navigating to editor)
   useEffect(() => {
@@ -292,7 +298,7 @@ export const ChatInput = memo(function ChatInput({
         textareaRef.current.value = "";
         textareaRef.current.style.height = "auto";
       }
-      setHasInput(false);
+      syncInputState("");
       setCompletions([]);
       setAttachments([]);
       clearInputDraft(activeChatId);
@@ -339,7 +345,7 @@ export const ChatInput = memo(function ChatInput({
       textareaRef.current.value = "";
       textareaRef.current.style.height = "auto";
     }
-    setHasInput(false);
+    syncInputState("");
     setCompletions([]);
     const pendingAttachments = attachments.map((a) => ({ type: a.type, data: a.data }));
     setAttachments([]);
@@ -384,6 +390,7 @@ export const ChatInput = memo(function ChatInput({
     mode,
     groupResponseOrder,
     createMessage,
+    syncInputState
   ]);
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -442,6 +449,7 @@ export const ChatInput = memo(function ChatInput({
       if (draftTimerRef.current) clearTimeout(draftTimerRef.current);
       const chatId = activeChatId;
       const text = fixed;
+      setCurrentInput(text);
       draftTimerRef.current = setTimeout(() => {
         if (text.trim()) {
           setInputDraft(chatId, text);
@@ -486,9 +494,9 @@ export const ChatInput = memo(function ChatInput({
     const value = el.value;
     el.value = value.slice(0, start) + emoji + value.slice(end);
     el.selectionStart = el.selectionEnd = start + emoji.length;
-    setHasInput(el.value.length > 0);
+    syncInputState(el.value);
     el.focus();
-  }, []);
+  }, [syncInputState]);
 
   // Character picker: trigger a response from a specific character (manual mode)
   const handleCharacterResponse = useCallback(

--- a/packages/client/src/components/chat/ChatInput.tsx
+++ b/packages/client/src/components/chat/ChatInput.tsx
@@ -114,13 +114,13 @@ export const ChatInput = memo(function ChatInput({
   // Save draft when component unmounts (e.g. navigating to editor)
   useEffect(() => {
     const textarea = textareaRef.current;
+    const chatId = useChatStore.getState().activeChatId;
     return () => {
       // Cancel pending debounce timers
       if (draftTimerRef.current) clearTimeout(draftTimerRef.current);
       // Cancel pending resize rAF
       if (resizeRafRef.current) cancelAnimationFrame(resizeRafRef.current);
       // Flush draft synchronously
-      const chatId = useChatStore.getState().activeChatId;
       if (chatId && textarea) {
         const text = textarea.value;
         if (text.trim()) {

--- a/packages/client/src/components/chat/ChatInput.tsx
+++ b/packages/client/src/components/chat/ChatInput.tsx
@@ -728,9 +728,11 @@ export const ChatInput = memo(function ChatInput({
             onClick={() => setCharPickerOpen((v) => !v)}
             className={cn(
               "flex h-8 w-8 items-center justify-center rounded-full transition-colors",
-              charPickerOpen
-                ? "text-foreground bg-foreground/10"
-                : "text-foreground/40 hover:bg-foreground/10 hover:text-foreground/70",
+              guideGenerations && hasInput
+                ? "text-[var(--primary)] bg-[var(--primary)]/15 ring-1 ring-[var(--primary)]/30 hover:bg-[var(--primary)]/20"
+                : charPickerOpen
+                  ? "text-foreground bg-foreground/10"
+                  : "text-foreground/40 hover:bg-foreground/10 hover:text-foreground/70",
             )}
             title={(guideGenerations && hasInput) ? "Trigger character response (guided)" : "Trigger character response"}
           >

--- a/packages/client/src/components/chat/ChatInput.tsx
+++ b/packages/client/src/components/chat/ChatInput.tsx
@@ -70,9 +70,11 @@ export const ChatInput = memo(function ChatInput({
   const setInputDraft = useChatStore((s) => s.setInputDraft);
   const clearInputDraft = useChatStore((s) => s.clearInputDraft);
   const setCurrentInput = useChatStore((s) => s.setCurrentInput);
+  const currentInput = useChatStore((s) => s.currentInput);
   const { generate } = useGenerate();
   const { applyToUserInput } = useApplyRegex();
   const enterToSend = useUIStore((s) => s.enterToSendRP);
+  const guideGenerations = useUIStore((s) => s.guideGenerations);
   const createMessage = useCreateMessage(activeChatId);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const resizeRafRef = useRef<number>(0);
@@ -505,17 +507,17 @@ export const ChatInput = memo(function ChatInput({
       setCharPickerOpen(false);
       setCharPickerPos(null);
       try {
-        await generate({
-          chatId: activeChatId,
-          connectionId: null,
-          forCharacterId: characterId,
-        });
+        await generate(
+          guideGenerations && hasInput
+          ? { chatId: activeChatId, connectionId: null, forCharacterId: characterId, generationGuide: currentInput }
+          : { chatId: activeChatId, connectionId: null, forCharacterId: characterId }
+        );
       } catch (error) {
         const msg = error instanceof Error ? error.message : "Generation failed";
         toast.error(msg);
       }
     },
-    [activeChatId, isStreaming, generate],
+    [activeChatId, isStreaming, generate, hasInput, currentInput, guideGenerations],
   );
 
   // Close character picker on outside click
@@ -730,7 +732,7 @@ export const ChatInput = memo(function ChatInput({
                 ? "text-foreground bg-foreground/10"
                 : "text-foreground/40 hover:bg-foreground/10 hover:text-foreground/70",
             )}
-            title="Trigger character response"
+            title={(guideGenerations && hasInput) ? "Trigger character response (guided)" : "Trigger character response"}
           >
             <Users size="1rem" />
           </button>

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -477,7 +477,11 @@ export const ChatMessage = memo(function ChatMessage({
     })),
   );
   const hasInput = useChatStore((s) => s.currentInput.trim().length > 0);
-  const regenerateButtonTitle = (guideGenerations && hasInput) ? "Regenerate (guided)" : "Regenerate";
+  const isGuided = guideGenerations && hasInput;
+  const regenerateButtonTitle = isGuided ? "Regenerate (guided)" : "Regenerate";
+  const regenerateGuidedClass = isGuided
+    ? "text-[var(--primary)] bg-[var(--primary)]/15 ring-1 ring-[var(--primary)]/30 hover:text-[var(--primary)]"
+    : undefined;
 
   // Build reusable text style objects (memoized to avoid unnecessary DOM updates)
   const textStrokeStyle = useMemo<React.CSSProperties>(
@@ -1393,6 +1397,7 @@ export const ChatMessage = memo(function ChatMessage({
                 icon={<RefreshCw size="0.6875rem" />}
                 onClick={() => onRegenerate?.(message.id)}
                 title={regenerateButtonTitle}
+                className={regenerateGuidedClass}
                 dark
               />
               <ActionBtn
@@ -1729,6 +1734,7 @@ export const ChatMessage = memo(function ChatMessage({
               icon={<RefreshCw size="0.625rem" />}
               onClick={() => onRegenerate?.(message.id)}
               title={regenerateButtonTitle}
+              className={regenerateGuidedClass}
             />
             <ActionBtn
               icon={<Flag size="0.625rem" />}

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -32,6 +32,7 @@ import { useShallow } from "zustand/react/shallow";
 import { resolveMessageMacros } from "../../lib/chat-macros";
 import { useApplyRegex } from "../../hooks/use-apply-regex";
 import { useUIStore } from "../../stores/ui.store";
+import { useChatStore } from "../../stores/chat.store";
 import { useTranslate } from "../../hooks/use-translate";
 import { api } from "../../lib/api-client";
 import { ttsService } from "../../lib/tts-service";
@@ -458,6 +459,7 @@ export const ChatMessage = memo(function ChatMessage({
     showModelName,
     showTokenUsage,
     showMessageNumbers,
+    guideGenerations,
     boldDialogue,
   } = useUIStore(
     useShallow((s) => ({
@@ -470,9 +472,12 @@ export const ChatMessage = memo(function ChatMessage({
       showModelName: s.showModelName,
       showTokenUsage: s.showTokenUsage,
       showMessageNumbers: s.showMessageNumbers,
+      guideGenerations: s.guideGenerations,
       boldDialogue: s.boldDialogue ?? true,
     })),
   );
+  const hasInput = useChatStore((s) => s.currentInput.trim().length > 0);
+  const regenerateButtonTitle = (guideGenerations && hasInput) ? "Regenerate (guided)" : "Regenerate";
 
   // Build reusable text style objects (memoized to avoid unnecessary DOM updates)
   const textStrokeStyle = useMemo<React.CSSProperties>(
@@ -1387,7 +1392,7 @@ export const ChatMessage = memo(function ChatMessage({
               <ActionBtn
                 icon={<RefreshCw size="0.6875rem" />}
                 onClick={() => onRegenerate?.(message.id)}
-                title="Regenerate"
+                title={regenerateButtonTitle}
                 dark
               />
               <ActionBtn
@@ -1723,7 +1728,7 @@ export const ChatMessage = memo(function ChatMessage({
             <ActionBtn
               icon={<RefreshCw size="0.625rem" />}
               onClick={() => onRegenerate?.(message.id)}
-              title="Regenerate"
+              title={regenerateButtonTitle}
             />
             <ActionBtn
               icon={<Flag size="0.625rem" />}

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -1087,6 +1087,7 @@ export function ChatRoleplaySurface({
                   </div>
                 )}
                 <ChatInput
+                  key={activeChatId}
                   mode={isRoleplay ? "roleplay" : "conversation"}
                   characterNames={characterNames}
                   groupResponseOrder={

--- a/packages/client/src/components/chat/ConversationInput.tsx
+++ b/packages/client/src/components/chat/ConversationInput.tsx
@@ -109,12 +109,18 @@ export function ConversationInput({ characterNames = [] }: ConversationInputProp
   const isActuallyGenerating = isStreaming && !delayedCharacterInfo;
   const setInputDraft = useChatStore((s) => s.setInputDraft);
   const clearInputDraft = useChatStore((s) => s.clearInputDraft);
+  const setCurrentInput = useChatStore((s) => s.setCurrentInput);
   const { generate } = useGenerate();
   const { applyToUserInput } = useApplyRegex();
   const enterToSend = useUIStore((s) => s.enterToSendConvo);
   const createMessage = useCreateMessage(activeChatId);
   const qc = useQueryClient();
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const syncInputState = useCallback((value: string) => {
+    setHasInput(value.trim().length > 0);
+    setCurrentInput(value);
+  }, [setCurrentInput]);
 
   // Restore draft
   const prevChatIdRef = useRef<string | null>(null);
@@ -127,12 +133,12 @@ export function ConversationInput({ characterNames = [] }: ConversationInputProp
       if (textareaRef.current) {
         const draft = activeChatId ? (useChatStore.getState().inputDrafts.get(activeChatId) ?? "") : "";
         textareaRef.current.value = draft;
-        setHasInput(draft.length > 0);
+        syncInputState(draft);
         textareaRef.current.style.height = "auto";
         textareaRef.current.style.height = `${Math.min(textareaRef.current.scrollHeight, 160)}px`;
       }
     }
-  }, [activeChatId, setInputDraft]);
+  }, [activeChatId, setInputDraft, syncInputState]);
 
   // Save draft on unmount
   useEffect(() => {
@@ -250,12 +256,12 @@ export function ConversationInput({ characterNames = [] }: ConversationInputProp
       el.value = `${before}@${name} ${after}`;
       const cursorPos = before.length + name.length + 2; // +2 for @ and space
       el.selectionStart = el.selectionEnd = cursorPos;
-      setHasInput(el.value.length > 0);
+      syncInputState(el.value);
       setMentionQuery(null);
       setMentionCompletions([]);
       el.focus();
     },
-    [mentionStartPos],
+    [mentionStartPos, syncInputState],
   );
 
   const handleSend = useCallback(async () => {
@@ -292,8 +298,8 @@ export function ConversationInput({ characterNames = [] }: ConversationInputProp
         textareaRef.current.value = "";
         textareaRef.current.style.height = "auto";
       }
-      setHasInput(false);
       clearInputDraft(activeChatId);
+      syncInputState("");
       const currentAttachments = [...attachments];
       setAttachments([]);
       createMessage.mutate({
@@ -316,8 +322,8 @@ export function ConversationInput({ characterNames = [] }: ConversationInputProp
         characterNames,
       };
       if (textareaRef.current) textareaRef.current.value = "";
-      setHasInput(false);
       clearInputDraft(activeChatId);
+      syncInputState("");
       setAttachments([]);
       const result = await matched.command.execute(matched.args, slashCtx);
       if (result.feedback) {
@@ -353,8 +359,8 @@ export function ConversationInput({ characterNames = [] }: ConversationInputProp
       textareaRef.current.value = "";
       textareaRef.current.style.height = "auto";
     }
-    setHasInput(false);
     clearInputDraft(activeChatId);
+    syncInputState("");
 
     const pendingAttachments = attachments.map((a) => ({ type: a.type, data: a.data }));
     setAttachments([]);
@@ -380,6 +386,7 @@ export function ConversationInput({ characterNames = [] }: ConversationInputProp
     createMessage,
     characterNames,
     qc,
+    syncInputState
   ]);
 
   const handleKeyDown = useCallback(
@@ -426,7 +433,7 @@ export function ConversationInput({ characterNames = [] }: ConversationInputProp
           const cmd = completions[selectedCompletion];
           if (cmd && textareaRef.current) {
             textareaRef.current.value = `/${cmd.name} `;
-            setHasInput(true);
+            syncInputState(textareaRef.current.value);
             setCompletions([]);
           }
           return;
@@ -443,7 +450,7 @@ export function ConversationInput({ characterNames = [] }: ConversationInputProp
         handleSend();
       }
     },
-    [completions, selectedCompletion, mentionCompletions, selectedMention, insertMention, enterToSend, handleSend],
+    [completions, selectedCompletion, mentionCompletions, selectedMention, insertMention, enterToSend, handleSend, syncInputState],
   );
 
   const handleInput = useCallback(() => {
@@ -456,7 +463,7 @@ export function ConversationInput({ characterNames = [] }: ConversationInputProp
       el.style.height = "auto";
       el.style.height = `${Math.min(el.scrollHeight, 160)}px`;
     }, 150);
-    setHasInput(el.value.length > 0);
+    syncInputState(el.value);
 
     // Slash completions
     if (el.value.startsWith("/")) {
@@ -489,7 +496,7 @@ export function ConversationInput({ characterNames = [] }: ConversationInputProp
       setMentionQuery(null);
       setMentionCompletions([]);
     }
-  }, [characterNames]);
+  }, [characterNames, syncInputState]);
 
   useEffect(() => {
     if (hasInput && feedback) setFeedback(null);
@@ -503,9 +510,9 @@ export function ConversationInput({ characterNames = [] }: ConversationInputProp
     const value = el.value;
     el.value = value.slice(0, start) + emoji + value.slice(end);
     el.selectionStart = el.selectionEnd = start + emoji.length;
-    setHasInput(el.value.length > 0);
+    syncInputState(el.value);
     el.focus();
-  }, []);
+  }, [syncInputState]);
 
   const handleGifSelect = useCallback(
     async (gifUrl: string) => {
@@ -550,7 +557,7 @@ export function ConversationInput({ characterNames = [] }: ConversationInputProp
                 e.preventDefault();
                 if (textareaRef.current) {
                   textareaRef.current.value = `/${cmd.name} `;
-                  setHasInput(true);
+                  syncInputState(textareaRef.current.value);
                   setCompletions([]);
                   textareaRef.current.focus();
                 }

--- a/packages/client/src/components/chat/ConversationInput.tsx
+++ b/packages/client/src/components/chat/ConversationInput.tsx
@@ -143,10 +143,10 @@ export function ConversationInput({ characterNames = [] }: ConversationInputProp
   // Save draft on unmount
   useEffect(() => {
     const el = textareaRef.current;
+    const chatId = activeChatId;
     return () => {
-      const id = prevChatIdRef.current;
-      if (id && el?.value) {
-        useChatStore.getState().setInputDraft(id, el.value);
+      if (chatId && el?.value) {
+        useChatStore.getState().setInputDraft(chatId, el.value);
       }
     };
   }, []);

--- a/packages/client/src/components/chat/ConversationMessage.tsx
+++ b/packages/client/src/components/chat/ConversationMessage.tsx
@@ -271,7 +271,11 @@ export const ConversationMessage = memo(function ConversationMessage({
   const editRef = useRef<HTMLTextAreaElement>(null);
   const hasInput = useChatStore((s) => s.currentInput.trim().length > 0);
   const guideGenerations = useUIStore((s) => s.guideGenerations);
-  const regenerateButtonTitle = (guideGenerations && hasInput) ? "Regenerate (guided)" : "Regenerate";
+  const isGuided = guideGenerations && hasInput;
+  const regenerateButtonTitle = isGuided ? "Regenerate (guided)" : "Regenerate";
+  const regenerateGuidedClass = isGuided
+    ? "text-[var(--primary)] bg-[var(--primary)]/15 ring-1 ring-[var(--primary)]/30 hover:text-[var(--primary)] hover:bg-[var(--primary)]/20"
+    : undefined;
 
   // Translation
   const { translate, translations, translating } = useTranslate();
@@ -739,6 +743,7 @@ export const ConversationMessage = memo(function ConversationMessage({
             icon={<RefreshCw size="0.75rem" />}
             onClick={() => onRegenerate?.(message.id)}
             title={regenerateButtonTitle}
+            className={regenerateGuidedClass}
           />
           {isLastAssistantMessage && (
             <MsgAction icon={<Eye size="0.75rem" />} onClick={() => onPeekPrompt?.()} title="Peek prompt" />
@@ -1017,6 +1022,7 @@ export const ConversationMessage = memo(function ConversationMessage({
               icon={<RefreshCw size="0.75rem" />}
               onClick={() => onRegenerate?.(message.id)}
               title={regenerateButtonTitle}
+              className={regenerateGuidedClass}
             />
           )}
           {isLastAssistantMessage && !isUser && (

--- a/packages/client/src/components/chat/ConversationMessage.tsx
+++ b/packages/client/src/components/chat/ConversationMessage.tsx
@@ -18,6 +18,8 @@ import {
 } from "lucide-react";
 import { useQueryClient, type InfiniteData } from "@tanstack/react-query";
 import type { Message } from "@marinara-engine/shared";
+import { useUIStore } from "../../stores/ui.store";
+import { useChatStore } from "../../stores/chat.store";
 import { cn, copyToClipboard } from "../../lib/utils";
 import { applyInlineMarkdown, renderMarkdownBlocks } from "../../lib/markdown";
 import { chatKeys } from "../../hooks/use-chats";
@@ -267,6 +269,9 @@ export const ConversationMessage = memo(function ConversationMessage({
   const [copied, setCopied] = useState(false);
   const [showThinking, setShowThinking] = useState(false);
   const editRef = useRef<HTMLTextAreaElement>(null);
+  const hasInput = useChatStore((s) => s.currentInput.trim().length > 0);
+  const guideGenerations = useUIStore((s) => s.guideGenerations);
+  const regenerateButtonTitle = (guideGenerations && hasInput) ? "Regenerate (guided)" : "Regenerate";
 
   // Translation
   const { translate, translations, translating } = useTranslate();
@@ -733,7 +738,7 @@ export const ConversationMessage = memo(function ConversationMessage({
           <MsgAction
             icon={<RefreshCw size="0.75rem" />}
             onClick={() => onRegenerate?.(message.id)}
-            title="Regenerate"
+            title={regenerateButtonTitle}
           />
           {isLastAssistantMessage && (
             <MsgAction icon={<Eye size="0.75rem" />} onClick={() => onPeekPrompt?.()} title="Peek prompt" />
@@ -1011,7 +1016,7 @@ export const ConversationMessage = memo(function ConversationMessage({
             <MsgAction
               icon={<RefreshCw size="0.75rem" />}
               onClick={() => onRegenerate?.(message.id)}
-              title="Regenerate"
+              title={regenerateButtonTitle}
             />
           )}
           {isLastAssistantMessage && !isUser && (

--- a/packages/client/src/components/chat/ConversationView.tsx
+++ b/packages/client/src/components/chat/ConversationView.tsx
@@ -881,7 +881,7 @@ export function ConversationView({
       )}
 
       {/* ── Input area ── */}
-      <ConversationInput characterNames={characterNames} />
+      <ConversationInput key={chatId} characterNames={characterNames} />
     </div>
   );
 }

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -1928,6 +1928,8 @@ function AdvancedSettings() {
   const setShowTokenUsage = useUIStore((s) => s.setShowTokenUsage);
   const showMessageNumbers = useUIStore((s) => s.showMessageNumbers);
   const setShowMessageNumbers = useUIStore((s) => s.setShowMessageNumbers);
+  const guideGenerations = useUIStore((s) => s.guideGenerations);
+  const setGuideGenerations = useUIStore((s) => s.setGuideGenerations);
   const clearAllData = useClearAllData();
   const expungeData = useExpungeData();
   const [selectedScopes, setSelectedScopes] = useState<ExpungeScope[]>(["chats"]);
@@ -2306,6 +2308,12 @@ function AdvancedSettings() {
         checked={showMessageNumbers}
         onChange={setShowMessageNumbers}
         help="Displays a message number below each avatar in roleplay chats."
+      />
+      <ToggleSetting
+        label="Guide generations with chat input"
+        checked={guideGenerations}
+        onChange={setGuideGenerations}
+        help="Uses chat input to guide regenerations and manually triggered responses."
       />
 
       {/* ── Backup ── */}

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -341,6 +341,7 @@ export function useGenerate() {
       attachments?: Array<{ type: string; data: string }>;
       mentionedCharacterNames?: string[];
       forCharacterId?: string;
+      generationGuide?: string;
     }) => {
       // Prevent concurrent generations for the SAME chat — stops race conditions
       // where autonomous messaging + user input both fire generate at once.

--- a/packages/client/src/stores/chat.store.ts
+++ b/packages/client/src/stores/chat.store.ts
@@ -78,6 +78,8 @@ interface ChatState {
   pendingNewChatMode: Exclude<ChatMode, "visual_novel"> | null;
   /** Per-chat draft input text so typing isn't lost when navigating away. */
   inputDrafts: Map<string, string>;
+  /** Current chat input */
+  currentInput: string;
   /** Per-chat unread message count (from autonomous messages). */
   unreadCounts: Map<string, number>;
   /** Floating notification bubbles — tracks character info for each unread chat. */
@@ -115,6 +117,7 @@ interface ChatState {
   setPendingNewChatMode: (mode: Exclude<ChatMode, "visual_novel"> | null) => void;
   setInputDraft: (chatId: string, text: string) => void;
   clearInputDraft: (chatId: string) => void;
+  setCurrentInput: (text: string) => void;
   incrementUnread: (chatId: string) => void;
   clearUnread: (chatId: string) => void;
   addNotification: (chatId: string, characterName: string, avatarUrl: string | null) => void;
@@ -153,6 +156,7 @@ export const useChatStore = create<ChatState>()(
     shouldOpenWizardInShortcutMode: false,
     pendingNewChatMode: null,
     inputDrafts: loadDrafts(),
+    currentInput: "",
     unreadCounts: new Map(),
     chatNotifications: new Map(),
     dismissedNotifications: new Set(),
@@ -332,6 +336,8 @@ export const useChatStore = create<ChatState>()(
         return { inputDrafts: m };
       }),
 
+    setCurrentInput: (text) => set({ currentInput: text }),
+
     incrementUnread: (chatId: string) =>
       set((state) => {
         const m = new Map(state.unreadCounts);
@@ -406,6 +412,7 @@ export const useChatStore = create<ChatState>()(
         swipeIndex: new Map(),
         pendingNewChatMode: null,
         inputDrafts: new Map(),
+        currentInput: "",
         unreadCounts: new Map(),
         chatNotifications: new Map(),
         dismissedNotifications: new Set(),

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -107,6 +107,7 @@ interface UIState {
   showModelName: boolean;
   showTokenUsage: boolean;
   showMessageNumbers: boolean;
+  guideGenerations: boolean;
   confirmBeforeDelete: boolean;
   /** Number of messages to load per page (0 = load all) */
   messagesPerPage: number;
@@ -242,6 +243,7 @@ interface UIState {
   setShowModelName: (v: boolean) => void;
   setShowTokenUsage: (v: boolean) => void;
   setShowMessageNumbers: (v: boolean) => void;
+  setGuideGenerations: (v: boolean) => void;
   setConfirmBeforeDelete: (v: boolean) => void;
   setMessagesPerPage: (n: number) => void;
   setBoldDialogue: (v: boolean) => void;
@@ -310,6 +312,7 @@ export function pickSyncedSettings(state: UIState) {
     showModelName: state.showModelName,
     showTokenUsage: state.showTokenUsage,
     showMessageNumbers: state.showMessageNumbers,
+    guideGenerations: state.guideGenerations,
     confirmBeforeDelete: state.confirmBeforeDelete,
     messagesPerPage: state.messagesPerPage,
     boldDialogue: state.boldDialogue,
@@ -380,6 +383,7 @@ export const useUIStore = create<UIState>()(
       showModelName: false,
       showTokenUsage: false,
       showMessageNumbers: false,
+      guideGenerations: false,
       confirmBeforeDelete: true,
       messagesPerPage: 20,
       boldDialogue: true,
@@ -621,6 +625,7 @@ export const useUIStore = create<UIState>()(
       setShowModelName: (v) => set({ showModelName: v }),
       setShowTokenUsage: (v) => set({ showTokenUsage: v }),
       setShowMessageNumbers: (v) => set({ showMessageNumbers: v }),
+      setGuideGenerations: (v) => set({ guideGenerations: v }),
       setConfirmBeforeDelete: (v) => set({ confirmBeforeDelete: v }),
       setMessagesPerPage: (n) => set({ messagesPerPage: n }),
       setBoldDialogue: (v) => set({ boldDialogue: v }),
@@ -798,6 +803,7 @@ export const useUIStore = create<UIState>()(
         showModelName: state.showModelName,
         showTokenUsage: state.showTokenUsage,
         showMessageNumbers: state.showMessageNumbers,
+        guideGenerations: state.guideGenerations,
         confirmBeforeDelete: state.confirmBeforeDelete,
         messagesPerPage: state.messagesPerPage,
         boldDialogue: state.boldDialogue,

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -4936,10 +4936,17 @@ export async function generateRoutes(app: FastifyInstance) {
       const collectedCommands: Array<{ command: CharacterCommand; characterId: string | null; messageId: string }> = [];
       const collectedOocMessages: string[] = [];
 
+      const normalizedGenerationGuide = typeof input.generationGuide === "string" ? input.generationGuide.trim() : "";
+      const generationGuideInstruction = normalizedGenerationGuide ? `Take the following into special consideration for your next message: ${normalizedGenerationGuide}` : null;
+
       if (useIndividualLoop) {
         // Individual group mode: generate one response per character
         sendProgress("generating");
         let runningMessages = [...finalMessages];
+
+        if (generationGuideInstruction) {
+          runningMessages.push({ role: "system", content: generationGuideInstruction });
+        }
 
         for (let ci = 0; ci < respondingCharIds.length; ci++) {
           if (abortController.signal.aborted) break;
@@ -4974,6 +4981,10 @@ export async function generateRoutes(app: FastifyInstance) {
         sendProgress("generating");
         let targetCharId = characterIds[0] ?? null;
         const sentMessages = [...finalMessages];
+
+        if (generationGuideInstruction) {
+          sentMessages.push({ role: "system", content: generationGuideInstruction });
+        }
 
         if (mentionedConversationCharacters.length > 0 && !regenGroupChatIndividual) {
           const mentionedNames = mentionedConversationCharacters.map((character) => character.name);

--- a/packages/shared/src/schemas/chat.schema.ts
+++ b/packages/shared/src/schemas/chat.schema.ts
@@ -35,6 +35,7 @@ export const generateRequestSchema = z.object({
   userStatus: z.enum(["active", "idle", "dnd"]).optional().default("active"),
   mentionedCharacterNames: z.array(z.string()).optional().default([]),
   forCharacterId: z.string().nullable().optional().default(null),
+  generationGuide: z.string().nullable().optional().default(null),
   attachments: z
     .array(
       z.object({


### PR DESCRIPTION
## Why this change

Builds on @mm14141's work in #216. The original PR introduces a great quality-of-life feature — let unsent chat input nudge a regeneration or character-trigger one-shot, without polluting the chat history. Tested it in the test dir and the underlying flow works exactly as advertised.

The only thing missing was a **visible signal** that the guided state is armed. The original PR ships the indicator via tooltip text (`"Regenerate (guided)"` / `"Trigger character response (guided)"`), which means a user has to hover the button to discover that their typed-but-unsent input is about to be folded into the prompt as a system instruction. For a feature that silently changes generation behavior, that's too easy to miss.

This PR keeps mm14141's four commits intact and adds a single commit on top that turns the affected buttons pink when guided is armed.

## What changed (on top of #216)

When **`guideGenerations` is on AND the chat input has non-empty text**, three buttons now render with a primary-color (`var(--primary)`) tint:

- **Regenerate** in roleplay messages (`ChatMessage.tsx` — both desktop and grouped layouts)
- **Regenerate** in conversation messages (`ConversationMessage.tsx` — full and compact layouts)
- **Trigger Character** in the chat input bar (`ChatInput.tsx` — group RP only)

Styling applied to each:
```
text-[var(--primary)] bg-[var(--primary)]/15 ring-1 ring-[var(--primary)]/30
```

So the icon is pink, the button has a faint pink fill, and a thin pink ring outlines it. Theme-aware via `var(--primary)` which is defined for both `[data-theme=\"dark\"]` (#ffb3d9) and `[data-theme=\"light\"]` (#e0709a).

When `guideGenerations` is off OR the input is empty, the buttons render in their normal muted styling — zero visual change vs. mm14141's PR. The instant the user starts typing with the toggle on, those buttons light up. Clear the input → they go back to muted.

## Implementation notes

- Both message components derive a shared `isGuided = guideGenerations && hasInput` flag plus a `regenerateGuidedClass` string, and pass it through the existing `className` extension prop on `ActionBtn` / `MsgAction`. No new component plumbing required.
- `cn()` uses `tailwind-merge` so the conflict between the base `text-foreground/40` and the guided `text-[var(--primary)]` resolves cleanly — no need for `!important`.
- `ChatInput.tsx` Trigger Character button is a custom inline button (not `ActionBtn`), so I added the guided branch directly to its `cn(...)` ladder, prioritising guided over the existing open/closed states so the pink tint always wins when armed.
- mm14141's race-condition fixes (`key={activeChatId}` on the input components, the unmount cleanup capture fix, the `currentInput` zustand field) are preserved untouched — those are real bugs his PR catches and they should land alongside the feature.

## Validation

- [x] `pnpm check` passes (TypeScript + ESLint + build, all three workspaces)
- [x] Manual: tested in browser on RP and Conversation chats. Toggle on + type → Regenerate icon and (in group RP) Trigger Character icon turn pink. Clear input or toggle off → buttons return to muted styling. Confirmed in both light and dark mode.
- [x] Confirmed mm14141's underlying behavior (the `generationGuide` system message injection, `Take the following into special consideration for your next message: ...`) still works as expected — the indicator changes are purely visual.

## Credit

Original feature work is @mm14141's in #216 — those four commits are preserved on this branch with their authorship intact. This PR only adds a visible indicator on top.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new advanced setting to enable guided generation mode, which incorporates your current chat input to directly influence message regeneration and response generation outcomes throughout conversations.
  * Regenerate and response generation buttons display enhanced visual feedback—updated tooltips and highlight styling—when guided generation mode is active with input text present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->