### PR TITLE
feat(conversation): schedule generation preferences (relocated)

### DIFF
--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -218,6 +218,7 @@ export function ChatSettingsDrawer({
   const { retryAgents } = useGenerate();
   const agentProcessing = useAgentStore((s) => s.isProcessing);
   const scheduleGenerationPreferences = useUIStore((s) => s.scheduleGenerationPreferences);
+  const setScheduleGenerationPreferences = useUIStore((s) => s.setScheduleGenerationPreferences);
 
   const { data: allCharacters } = useCharacters();
   const { data: characterGroups } = useCharacterGroups();
@@ -2014,6 +2015,25 @@ export function ChatSettingsDrawer({
                   )}
                 </div>
 
+                {/* Schedule generation preferences — free-form authorial guidance */}
+                <label className="flex flex-col gap-1.5">
+                  <span className="inline-flex items-center gap-1.5 text-xs font-medium">
+                    <Sparkles size="0.75rem" className="text-[var(--primary)]" />
+                    Schedule generation preferences
+                    <HelpTooltip text="Free-form guidance that steers how character schedules are generated. Both directives ('no characters past midnight') and factual constraints ('I work 9-5') work. This setting is global — it applies to every conversation chat." />
+                  </span>
+                  <textarea
+                    value={scheduleGenerationPreferences}
+                    onChange={(e) => setScheduleGenerationPreferences(e.target.value)}
+                    placeholder="e.g. Make everyone go to sleep before midnight. Give characters free time 10am-noon. I work 9-5 on weekdays."
+                    className="min-h-[5rem] resize-y rounded-lg border border-[var(--border)] bg-[var(--secondary)] p-2.5 text-[0.6875rem] text-[var(--foreground)] outline-none transition-colors focus:border-[var(--primary)]/50 placeholder:text-[var(--muted-foreground)]/40"
+                  />
+                  <p className="text-[0.59375rem] text-[var(--muted-foreground)]/70">
+                    Global setting. Applies to every conversation chat&apos;s next schedule regeneration — manual or
+                    weekly auto.
+                  </p>
+                </label>
+
                 {/* Active schedule-generation preference indicator */}
                 {scheduleGenerationPreferences.trim() && (
                   <div
@@ -2029,7 +2049,7 @@ export function ChatSettingsDrawer({
                         “{scheduleGenerationPreferences.trim()}”
                       </p>
                       <p className="mt-1 text-[0.59375rem] text-[var(--muted-foreground)]/70">
-                        Will be applied the next time schedules are regenerated. Edit in Settings → General.
+                        Will be applied the next time schedules are regenerated.
                       </p>
                     </div>
                   </div>

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -639,6 +639,9 @@ export function ChatSettingsDrawer({
   const [agentAddPreview, setAgentAddPreview] = useState<AgentAddPreview | null>(null);
   const [addingAgentToChat, setAddingAgentToChat] = useState(false);
   const [isRegeneratingSchedules, setIsRegeneratingSchedules] = useState(false);
+  // Synchronous lock to close the re-entry gap: React state commits are async, so two
+  // fast clicks can both pass the `isRegeneratingSchedules` check before the state updates.
+  const isRegeneratingSchedulesRef = useRef(false);
   const [scenePromptExpanded, setScenePromptExpanded] = useState(false);
   const [scenePromptDraft, setScenePromptDraft] = useState(metadata.sceneSystemPrompt ?? "");
   const [groupScenarioDraft, setGroupScenarioDraft] = useState((metadata.groupScenarioText as string) ?? "");
@@ -2047,7 +2050,8 @@ export function ChatSettingsDrawer({
                   </div>
                   <button
                     onClick={async () => {
-                      if (isRegeneratingSchedules) return;
+                      if (isRegeneratingSchedulesRef.current) return;
+                      isRegeneratingSchedulesRef.current = true;
                       setIsRegeneratingSchedules(true);
                       try {
                         const scheduleGenerationPreferences =
@@ -2063,6 +2067,7 @@ export function ChatSettingsDrawer({
                       } catch {
                         // non-critical
                       } finally {
+                        isRegeneratingSchedulesRef.current = false;
                         setIsRegeneratingSchedules(false);
                       }
                     }}

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -638,6 +638,7 @@ export function ChatSettingsDrawer({
   const [choiceModalPresetId, setChoiceModalPresetId] = useState<string | null>(null);
   const [agentAddPreview, setAgentAddPreview] = useState<AgentAddPreview | null>(null);
   const [addingAgentToChat, setAddingAgentToChat] = useState(false);
+  const [isRegeneratingSchedules, setIsRegeneratingSchedules] = useState(false);
   const [scenePromptExpanded, setScenePromptExpanded] = useState(false);
   const [scenePromptDraft, setScenePromptDraft] = useState(metadata.sceneSystemPrompt ?? "");
   const [groupScenarioDraft, setGroupScenarioDraft] = useState((metadata.groupScenarioText as string) ?? "");
@@ -2046,6 +2047,8 @@ export function ChatSettingsDrawer({
                   </div>
                   <button
                     onClick={async () => {
+                      if (isRegeneratingSchedules) return;
+                      setIsRegeneratingSchedules(true);
                       try {
                         const scheduleGenerationPreferences =
                           useUIStore.getState().scheduleGenerationPreferences;
@@ -2059,13 +2062,21 @@ export function ChatSettingsDrawer({
                         qc.invalidateQueries({ queryKey: chatKeys.detail(chat.id) });
                       } catch {
                         // non-critical
+                      } finally {
+                        setIsRegeneratingSchedules(false);
                       }
                     }}
-                    className="flex items-center gap-1 rounded-md px-2 py-1 text-[0.625rem] font-medium text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
-                    title="Regenerate schedules"
+                    disabled={isRegeneratingSchedules}
+                    className={cn(
+                      "flex items-center gap-1 rounded-md px-2 py-1 text-[0.625rem] font-medium transition-colors",
+                      isRegeneratingSchedules
+                        ? "cursor-not-allowed text-[var(--muted-foreground)]/60"
+                        : "text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]",
+                    )}
+                    title={isRegeneratingSchedules ? "Regenerating schedules…" : "Regenerate schedules"}
                   >
-                    <RefreshCw size="0.6875rem" />
-                    Regenerate
+                    <RefreshCw size="0.6875rem" className={cn(isRegeneratingSchedules && "animate-spin")} />
+                    {isRegeneratingSchedules ? "Regenerating…" : "Regenerate"}
                   </button>
                 </div>
 

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -217,6 +217,7 @@ export function ChatSettingsDrawer({
   const disconnectChat = useDisconnectChat();
   const { retryAgents } = useGenerate();
   const agentProcessing = useAgentStore((s) => s.isProcessing);
+  const scheduleGenerationPreferences = useUIStore((s) => s.scheduleGenerationPreferences);
 
   const { data: allCharacters } = useCharacters();
   const { data: characterGroups } = useCharacterGroups();
@@ -2009,6 +2010,27 @@ export function ChatSettingsDrawer({
                   )}
                 </div>
 
+                {/* Active schedule-generation preference indicator */}
+                {scheduleGenerationPreferences.trim() && (
+                  <div
+                    className="flex items-start gap-2 rounded-lg border border-[var(--primary)]/30 bg-[var(--primary)]/10 px-3 py-2.5"
+                    title={scheduleGenerationPreferences.trim()}
+                  >
+                    <Sparkles size="0.875rem" className="mt-0.5 shrink-0 text-[var(--primary)]" />
+                    <div className="flex-1 min-w-0">
+                      <span className="block text-[0.6875rem] font-medium leading-snug text-[var(--foreground)]">
+                        Schedule generation preference active
+                      </span>
+                      <p className="mt-0.5 truncate text-[0.625rem] italic text-[var(--muted-foreground)]">
+                        “{scheduleGenerationPreferences.trim()}”
+                      </p>
+                      <p className="mt-1 text-[0.59375rem] text-[var(--muted-foreground)]/70">
+                        Will be applied the next time schedules are regenerated. Edit in Settings → General.
+                      </p>
+                    </div>
+                  </div>
+                )}
+
                 {/* Schedule status */}
                 <div className="flex items-center gap-2 rounded-lg bg-[var(--secondary)] px-3 py-2.5">
                   <CalendarClock size="0.875rem" className="text-[var(--muted-foreground)]" />
@@ -2025,10 +2047,13 @@ export function ChatSettingsDrawer({
                   <button
                     onClick={async () => {
                       try {
+                        const scheduleGenerationPreferences =
+                          useUIStore.getState().scheduleGenerationPreferences;
                         await api.post("/conversation/schedule/generate", {
                           chatId: chat.id,
                           characterIds: chatCharIds,
                           forceRefresh: true,
+                          scheduleGenerationPreferences,
                         });
                         // Refresh chat data to pick up new schedules
                         qc.invalidateQueries({ queryKey: chatKeys.detail(chat.id) });

--- a/packages/client/src/components/chat/ChatSetupWizard.tsx
+++ b/packages/client/src/components/chat/ChatSetupWizard.tsx
@@ -252,7 +252,12 @@ function ConversationQuickSetup({ chat, onFinish }: ChatSetupWizardProps) {
     if (autonomousEnabled && generateSchedule) {
       setScheduleState("generating");
       try {
-        await api.post("/conversation/schedule/generate", { chatId: chat.id, characterIds: chatCharIds });
+        const scheduleGenerationPreferences = useUIStore.getState().scheduleGenerationPreferences;
+        await api.post("/conversation/schedule/generate", {
+          chatId: chat.id,
+          characterIds: chatCharIds,
+          scheduleGenerationPreferences,
+        });
       } catch {
         // Schedule generation is non-critical — continue anyway
       }

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -195,9 +195,6 @@ function GeneralSettings() {
   const setMessagesPerPage = useUIStore((s) => s.setMessagesPerPage);
   const boldDialogue = useUIStore((s) => s.boldDialogue);
   const setBoldDialogue = useUIStore((s) => s.setBoldDialogue);
-  const scheduleGenerationPreferences = useUIStore((s) => s.scheduleGenerationPreferences);
-  const setScheduleGenerationPreferences = useUIStore((s) => s.setScheduleGenerationPreferences);
-
   return (
     <div className="flex flex-col gap-3">
       <div className="text-xs text-[var(--muted-foreground)]">General application settings.</div>
@@ -384,24 +381,6 @@ function GeneralSettings() {
           'When on, text inside dialogue quotation marks ("like this", 「like this」, or 『like this』) is bolded in addition to its dialogue highlight color. Turn it off to keep the color without bold.'
         }
       />
-
-      {/* Schedule Generation Preferences (Conversation mode) */}
-      <label className="flex flex-col gap-1">
-        <span className="inline-flex items-center gap-1 text-xs font-medium">
-          Schedule generation preferences
-          <HelpTooltip text="Free-form guidance that steers how character schedules are generated in Conversation mode. Both directives ('no characters past midnight') and factual constraints ('I work 9-5') work." />
-        </span>
-        <textarea
-          value={scheduleGenerationPreferences}
-          onChange={(e) => setScheduleGenerationPreferences(e.target.value)}
-          placeholder="e.g. Make everyone go to sleep before midnight. Give characters free time 10am-noon. I work 9-5 on weekdays."
-          className="min-h-[6rem] resize-y rounded-lg border border-[var(--border)] bg-[var(--secondary)] p-3 text-xs text-[var(--foreground)] outline-none transition-colors focus:border-[var(--primary)]/50 placeholder:text-white/20"
-        />
-        <p className="text-[0.625rem] text-[var(--muted-foreground)]">
-          Changes apply the next time schedules are regenerated — manually from a chat&apos;s settings, or automatically
-          each week.
-        </p>
-      </label>
 
       {/* Game Assets Folders */}
       <div className="rounded-xl bg-[var(--secondary)]/50 p-4 ring-1 ring-[var(--border)]">

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -195,6 +195,8 @@ function GeneralSettings() {
   const setMessagesPerPage = useUIStore((s) => s.setMessagesPerPage);
   const boldDialogue = useUIStore((s) => s.boldDialogue);
   const setBoldDialogue = useUIStore((s) => s.setBoldDialogue);
+  const scheduleGenerationPreferences = useUIStore((s) => s.scheduleGenerationPreferences);
+  const setScheduleGenerationPreferences = useUIStore((s) => s.setScheduleGenerationPreferences);
 
   return (
     <div className="flex flex-col gap-3">
@@ -382,6 +384,24 @@ function GeneralSettings() {
           'When on, text inside dialogue quotation marks ("like this", 「like this」, or 『like this』) is bolded in addition to its dialogue highlight color. Turn it off to keep the color without bold.'
         }
       />
+
+      {/* Schedule Generation Preferences (Conversation mode) */}
+      <label className="flex flex-col gap-1">
+        <span className="inline-flex items-center gap-1 text-xs font-medium">
+          Schedule generation preferences
+          <HelpTooltip text="Free-form guidance that steers how character schedules are generated in Conversation mode. Both directives ('no characters past midnight') and factual constraints ('I work 9-5') work." />
+        </span>
+        <textarea
+          value={scheduleGenerationPreferences}
+          onChange={(e) => setScheduleGenerationPreferences(e.target.value)}
+          placeholder="e.g. Make everyone go to sleep before midnight. Give characters free time 10am-noon. I work 9-5 on weekdays."
+          className="min-h-[6rem] resize-y rounded-lg border border-[var(--border)] bg-[var(--secondary)] p-3 text-xs text-[var(--foreground)] outline-none transition-colors focus:border-[var(--primary)]/50 placeholder:text-white/20"
+        />
+        <p className="text-[0.625rem] text-[var(--muted-foreground)]">
+          Changes apply the next time schedules are regenerated — manually from a chat&apos;s settings, or automatically
+          each week.
+        </p>
+      </label>
 
       {/* Game Assets Folders */}
       <div className="rounded-xl bg-[var(--secondary)]/50 p-4 ring-1 ring-[var(--border)]">

--- a/packages/client/src/hooks/use-autonomous-messaging.ts
+++ b/packages/client/src/hooks/use-autonomous-messaging.ts
@@ -75,7 +75,12 @@ export function useAutonomousMessaging(
     async (characterIds?: string[]) => {
       if (!chatId) return;
       try {
-        await api.post("/conversation/schedule/generate", { chatId, characterIds });
+        const scheduleGenerationPreferences = useUIStore.getState().scheduleGenerationPreferences;
+        await api.post("/conversation/schedule/generate", {
+          chatId,
+          characterIds,
+          scheduleGenerationPreferences,
+        });
       } catch {
         // non-critical — schedule generation may fail if no connection
       }

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -144,6 +144,10 @@ interface UIState {
   /** User's custom default system prompt for new conversations (null = built-in default). */
   customConversationPrompt: string | null;
 
+  // ── Schedule Generation Preferences ──
+  /** Free-form user guidance injected into the conversation-mode schedule generation prompt (empty = unset). */
+  scheduleGenerationPreferences: string;
+
   // ── Input ──
   enterToSendRP: boolean;
   enterToSendConvo: boolean;
@@ -259,6 +263,7 @@ interface UIState {
   setConvoNotificationSound: (v: boolean) => void;
   setRpNotificationSound: (v: boolean) => void;
   setCustomConversationPrompt: (v: string | null) => void;
+  setScheduleGenerationPreferences: (v: string) => void;
   setEnterToSendRP: (v: boolean) => void;
   setEnterToSendConvo: (v: boolean) => void;
   setEnterToSendGame: (v: boolean) => void;
@@ -335,6 +340,7 @@ export function pickSyncedSettings(state: UIState) {
     convoNotificationSound: state.convoNotificationSound,
     rpNotificationSound: state.rpNotificationSound,
     customConversationPrompt: state.customConversationPrompt,
+    scheduleGenerationPreferences: state.scheduleGenerationPreferences,
   };
 }
 
@@ -396,6 +402,7 @@ export const useUIStore = create<UIState>()(
       convoNotificationSound: true,
       rpNotificationSound: true,
       customConversationPrompt: null,
+      scheduleGenerationPreferences: "",
       enterToSendRP: false,
       enterToSendConvo: true,
       enterToSendGame: true,
@@ -638,6 +645,7 @@ export const useUIStore = create<UIState>()(
       setConvoNotificationSound: (v) => set({ convoNotificationSound: v }),
       setRpNotificationSound: (v) => set({ rpNotificationSound: v }),
       setCustomConversationPrompt: (v) => set({ customConversationPrompt: v }),
+      setScheduleGenerationPreferences: (v) => set({ scheduleGenerationPreferences: v }),
       setEnterToSendRP: (v) => set({ enterToSendRP: v }),
       setEnterToSendConvo: (v) => set({ enterToSendConvo: v }),
       setEnterToSendGame: (v) => set({ enterToSendGame: v }),
@@ -828,6 +836,7 @@ export const useUIStore = create<UIState>()(
         convoNotificationSound: state.convoNotificationSound,
         rpNotificationSound: state.rpNotificationSound,
         customConversationPrompt: state.customConversationPrompt,
+        scheduleGenerationPreferences: state.scheduleGenerationPreferences,
       }),
     },
   ),

--- a/packages/server/src/routes/conversation.routes.ts
+++ b/packages/server/src/routes/conversation.routes.ts
@@ -52,7 +52,13 @@ export async function conversationRoutes(app: FastifyInstance) {
     };
   }>("/schedule/generate", async (req, reply) => {
     const { chatId, forceRefresh } = req.body;
-    const userSchedulePreferences = (req.body.scheduleGenerationPreferences ?? "").trim();
+    // Runtime guard: TypeScript's Body type is compile-time only. If a client sends a non-string,
+    // .trim() would throw and surface as a 500. Reject explicitly with 400 instead.
+    const rawPrefs: unknown = req.body.scheduleGenerationPreferences;
+    if (rawPrefs != null && typeof rawPrefs !== "string") {
+      return reply.status(400).send({ error: "scheduleGenerationPreferences must be a string" });
+    }
+    const userSchedulePreferences = typeof rawPrefs === "string" ? rawPrefs.trim() : "";
 
     const chat = await chats.getById(chatId);
     if (!chat) return reply.status(404).send({ error: "Chat not found" });

--- a/packages/server/src/routes/conversation.routes.ts
+++ b/packages/server/src/routes/conversation.routes.ts
@@ -44,9 +44,15 @@ export async function conversationRoutes(app: FastifyInstance) {
   // POST /schedule/generate — Generate or refresh weekly schedules
   // ─────────────────────────────────────────────
   app.post<{
-    Body: { chatId: string; forceRefresh?: boolean; characterIds?: string[] };
+    Body: {
+      chatId: string;
+      forceRefresh?: boolean;
+      characterIds?: string[];
+      scheduleGenerationPreferences?: string;
+    };
   }>("/schedule/generate", async (req, reply) => {
     const { chatId, forceRefresh } = req.body;
+    const userSchedulePreferences = (req.body.scheduleGenerationPreferences ?? "").trim();
 
     const chat = await chats.getById(chatId);
     if (!chat) return reply.status(404).send({ error: "Chat not found" });
@@ -170,6 +176,7 @@ export async function conversationRoutes(app: FastifyInstance) {
           charData.name,
           charData.description ?? "",
           charData.personality ?? "",
+          userSchedulePreferences,
         );
         console.log(`[schedule] Generated schedule for ${charData.name}, days:`, Object.keys(schedule.days ?? {}));
 

--- a/packages/server/src/services/conversation/schedule.service.ts
+++ b/packages/server/src/services/conversation/schedule.service.ts
@@ -89,6 +89,7 @@ export async function generateCharacterSchedule(
   characterName: string,
   characterDescription: string,
   characterPersonality: string,
+  userSchedulePreferences?: string,
 ): Promise<{ schedule: Omit<WeekSchedule, "weekStart">; raw: string }> {
   const systemPrompt = [
     `You are a schedule generator. Create a realistic weekly schedule for a character based on their personality and description.`,
@@ -97,6 +98,15 @@ export async function generateCharacterSchedule(
     `Description: ${characterDescription}`,
     `Personality: ${characterPersonality}`,
     ``,
+    ...(userSchedulePreferences?.trim()
+      ? [
+          `User preferences:`,
+          `The person using this app has provided the following scheduling guidance.`,
+          `Honor these preferences even when they would override typical patterns for this character:`,
+          userSchedulePreferences.trim(),
+          ``,
+        ]
+      : []),
     `Generate a schedule for each day of the week (Monday through Sunday).`,
     `Each day should have time blocks covering the full 24 hours.`,
     `The schedule should be realistic and consistent with the character's lifestyle.`,


### PR DESCRIPTION
## Why this change

Builds on @JorgeLTE's work in #221. The feature itself — global authorial guidance for character schedule generation, the active-preference indicator card in the chat settings drawer, the regenerate-button loading state, server-side validation, the per-call wiring across `ChatSetupWizard`, `useAutonomousMessaging`, and the manual Regenerate button — all lands as Jorge wrote it. Only the input control's **location** has changed, per the discussion in [#221 (comment)](https://github.com/Pasta-Devs/Marinara-Engine/pull/221#issuecomment-4330004340).

## What moved

The \"Schedule generation preferences\" textarea was originally placed in `Settings → General`. Three reasons that didn't fit:
- **Conversation-mode-only content** — the textarea has no effect in roleplay, game, or visual-novel chats, but General is app-wide.
- **Prompt-shaping content, not an app preference** — it's free-form text injected into the schedule-generation system prompt under a `User preferences:` block. That's the same kind of content as Author's Notes or `customConversationPrompt`, not the same kind as \"messages per page\" or \"send on Enter\".
- **Visual fit** — it was the only long-form free-text field in a panel of toggles/sliders/selects. It dominated the layout.

Marinara called for `Conversations → Chat Settings → Agents → Schedules`. The functional equivalent in the codebase is the **Autonomous Messaging** section of the chat settings drawer, where all the schedule machinery already lives (Autonomous Messages toggle, Character Exchanges toggle, Selfie Connection, Schedule status, Regenerate button, ScheduleEditor).

## Where it is now

`ChatSettingsDrawer.tsx` Autonomous Messaging section, ordered top-to-bottom:

1. Autonomous Messages toggle
2. Character Exchanges toggle (group only)
3. Selfie Connection picker
4. **Schedule generation preferences** textarea ← new home
5. Active schedule-generation preference indicator card (only when textarea has text)
6. Schedule status + Regenerate button
7. ScheduleEditor

The editor → indicator → regenerate → per-character editor flow now reads as one coherent column inside one section.

## Implementation notes

- The textarea is rendered inside the chat settings drawer but the value is still in the global Zustand store (`scheduleGenerationPreferences`), so it's the same global preference Jorge designed — not per-chat. The `HelpTooltip` text explicitly says \"This setting is global — it applies to every conversation chat\" so users don't get confused by the in-chat-settings location into expecting per-chat scope.
- The indicator card's \"Edit in Settings → General\" stale hint was removed; the editor is now directly above it.
- Nothing else changed. The store field, the per-call wiring (`ChatSetupWizard`, `useAutonomousMessaging`, the manual Regenerate handler), the server route's body validation and prompt injection in `schedule.service.ts` — all preserved untouched.

## Validation

- [x] `pnpm check` passes (TS + ESLint + build, all three workspaces)
- [x] Manual: tested in browser. Textarea appears in the Autonomous Messaging section. Edits persist (global store + Zustand persist). Indicator card updates live as you type. Value still flows through to `POST /conversation/schedule/generate` on the manual Regenerate path. Confirmed the textarea is gone from `Settings → General`. Switching between conversation chats keeps the value (global store, not per-chat). Switching to a non-conversation chat hides the section entirely (existing `isConversation` gate still applies).

## Credit

Original feature work is @JorgeLTE's in #221 — those three commits (the feature, the loading state fix, the CodeRabbit follow-up) are preserved on this branch with their authorship intact. This PR only relocates the input control.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added schedule generation preferences input to customize character schedules
  * User preferences are now considered during schedule generation

* **Improvements**
  * Schedule regeneration displays active preferences and shows loading indicator
  * Prevented concurrent regeneration requests with UI state lock

<!-- end of auto-generated comment: release notes by coderabbit.ai -->