### PR TITLE
Fix sidecar CUDA runtime setup

### DIFF
--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -2158,10 +2158,14 @@ export async function generateRoutes(app: FastifyInstance) {
       const resolvedAgents: ResolvedAgent[] = [];
       // Cache per-connection providers so agents sharing the same connection batch together
       const agentProviderCache = new Map<string, { provider: BaseLLMProvider; model: string }>();
-      agentProviderCache.set(LOCAL_SIDECAR_CONNECTION_ID, {
-        provider: getLocalSidecarProvider(),
-        model: LOCAL_SIDECAR_MODEL,
-      });
+      const localSidecarAvailableForTrackers =
+        sidecarModelService.getConfig().useForTrackers && sidecarModelService.getConfiguredModelRef() !== null;
+      if (localSidecarAvailableForTrackers) {
+        agentProviderCache.set(LOCAL_SIDECAR_CONNECTION_ID, {
+          provider: getLocalSidecarProvider(),
+          model: LOCAL_SIDECAR_MODEL,
+        });
+      }
 
       // Check if there's a connection marked as default for all agents
       const defaultAgentConn = await connections.getDefaultForAgents();
@@ -2190,7 +2194,11 @@ export async function generateRoutes(app: FastifyInstance) {
         let agentModel = conn.model;
 
         // Resolve connection: per-agent override > default-for-agents > chat connection
-        const effectiveConnectionId = cfg.connectionId ?? defaultAgentConn?.id ?? null;
+        let effectiveConnectionId = cfg.connectionId ?? defaultAgentConn?.id ?? null;
+        if (effectiveConnectionId === LOCAL_SIDECAR_CONNECTION_ID && !localSidecarAvailableForTrackers) {
+          effectiveConnectionId =
+            cfg.connectionId === LOCAL_SIDECAR_CONNECTION_ID ? (defaultAgentConn?.id ?? null) : null;
+        }
         if (effectiveConnectionId) {
           const cached = agentProviderCache.get(effectiveConnectionId);
           if (cached) {

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -11,6 +11,7 @@ import type { ResolvedAgent } from "../../services/agents/agent-pipeline.js";
 import { executeAgent, executeAgentBatch } from "../../services/agents/agent-executor.js";
 import { getLocalSidecarProvider, LOCAL_SIDECAR_MODEL } from "../../services/llm/local-sidecar.js";
 import { createLLMProvider } from "../../services/llm/provider-registry.js";
+import { sidecarModelService } from "../../services/sidecar/sidecar-model.service.js";
 import { createAgentsStorage } from "../../services/storage/agents.storage.js";
 import { createCharactersStorage } from "../../services/storage/characters.storage.js";
 import { createChatsStorage } from "../../services/storage/chats.storage.js";
@@ -275,16 +276,18 @@ async function resolveRetryAgents(args: {
     conn.maxTokensOverride,
   );
   const resolvedAgents: ResolvedRetryAgent[] = [];
+  const localSidecarAvailableForTrackers =
+    sidecarModelService.getConfig().useForTrackers && sidecarModelService.getConfiguredModelRef() !== null;
 
   for (const cfg of enabledConfigs) {
     let agentProvider = provider;
     let agentModel = conn.model;
 
     if (cfg.connectionId) {
-      if (cfg.connectionId === LOCAL_SIDECAR_CONNECTION_ID) {
+      if (cfg.connectionId === LOCAL_SIDECAR_CONNECTION_ID && localSidecarAvailableForTrackers) {
         agentProvider = getLocalSidecarProvider();
         agentModel = LOCAL_SIDECAR_MODEL;
-      } else {
+      } else if (cfg.connectionId !== LOCAL_SIDECAR_CONNECTION_ID) {
         const agentConn = await conns.getWithKey(cfg.connectionId as string);
         if (agentConn) {
           const agentBaseUrl = resolveBaseUrl(agentConn);

--- a/packages/server/src/services/sidecar/sidecar-model-files.ts
+++ b/packages/server/src/services/sidecar/sidecar-model-files.ts
@@ -1,0 +1,18 @@
+import { basename } from "path";
+
+export function isLikelyMmprojModelPath(modelPath: string): boolean {
+  const filename = basename(modelPath).toLowerCase();
+  return filename.includes("mmproj") || /(?:^|[-_.])mm-?proj(?:[-_.]|$)/i.test(filename) || filename.includes("projector");
+}
+
+export function isSupportedLlamaCppModelFilename(modelPath: string): boolean {
+  return modelPath.toLowerCase().endsWith(".gguf") && !isLikelyMmprojModelPath(modelPath);
+}
+
+export function assertSupportedLlamaCppModelPath(modelPath: string): void {
+  if (isLikelyMmprojModelPath(modelPath)) {
+    throw new Error(
+      "The selected GGUF is a multimodal projector (mmproj), not a chat model. Select the main model GGUF instead.",
+    );
+  }
+}

--- a/packages/server/src/services/sidecar/sidecar-model.service.ts
+++ b/packages/server/src/services/sidecar/sidecar-model.service.ts
@@ -27,6 +27,7 @@ import { getDataDir } from "../../utils/data-dir.js";
 import { downloadFileWithProgress, fetchJson, isAbortError } from "./sidecar-download.js";
 import { mlxRuntimeService } from "./mlx-runtime.service.js";
 import { sidecarRuntimeService } from "./sidecar-runtime.service.js";
+import { assertSupportedLlamaCppModelPath, isSupportedLlamaCppModelFilename } from "./sidecar-model-files.js";
 
 export const MODELS_DIR = join(getDataDir(), "models");
 export const CUSTOM_MODELS_DIR = join(MODELS_DIR, "custom");
@@ -441,7 +442,7 @@ class SidecarModelService {
   }
 
   isEnabled(): boolean {
-    return this.config.useForGameScene;
+    return this.config.useForGameScene || this.config.useForTrackers;
   }
 
   getResolvedBackend(): SidecarBackend {
@@ -583,7 +584,9 @@ class SidecarModelService {
     }
 
     const entries = await this.fetchRepoTree(repo);
-    const ggufEntries = entries.filter((entry) => entry.type === "file" && entry.path?.toLowerCase().endsWith(".gguf"));
+    const ggufEntries = entries.filter(
+      (entry) => entry.type === "file" && entry.path && isSupportedLlamaCppModelFilename(entry.path),
+    );
     if (ggufEntries.length === 0) {
       return [];
     }
@@ -647,6 +650,7 @@ class SidecarModelService {
     if (!selected) {
       throw new Error("Selected GGUF was not found in that repository");
     }
+    assertSupportedLlamaCppModelPath(selected.path);
 
     const relativePath = join("custom", `${slugifyRepo(repo)}__${selected.filename}`).replace(/\\/g, "/");
     const destination = this.resolveModelPath(relativePath);

--- a/packages/server/src/services/sidecar/sidecar-process.service.ts
+++ b/packages/server/src/services/sidecar/sidecar-process.service.ts
@@ -10,6 +10,7 @@ import { buildLlamaArgs, buildLlamaStartupPlans } from "./sidecar-launch-plan.js
 import { buildLlamaProcessEnv } from "./sidecar-runtime-env.js";
 import { mlxRuntimeService, type MlxRuntimeInstall } from "./mlx-runtime.service.js";
 import { sidecarRuntimeService, type SidecarRuntimeInstall } from "./sidecar-runtime.service.js";
+import { assertSupportedLlamaCppModelPath } from "./sidecar-model-files.js";
 
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -460,6 +461,7 @@ class SidecarProcessService {
     if (!existsSync(modelPath)) {
       throw new Error("The selected sidecar model file is missing. Please download it again.");
     }
+    assertSupportedLlamaCppModelPath(modelPath);
 
     let activeRuntime: SidecarRuntimeInstall | null = runtime;
     const attemptedVariants = new Set<string>();

--- a/packages/server/src/services/sidecar/sidecar-runtime-env.ts
+++ b/packages/server/src/services/sidecar/sidecar-runtime-env.ts
@@ -2,6 +2,7 @@ import { delimiter, dirname } from "path";
 
 type LlamaRuntimeEnvInput = {
   serverPath: string;
+  directoryPath?: string;
   source: string | null | undefined;
 };
 
@@ -31,6 +32,8 @@ export function buildLlamaProcessEnv(
     env.LD_LIBRARY_PATH = prependPathEntry(env.LD_LIBRARY_PATH, runtimeDir);
   } else if (platform === "darwin") {
     env.DYLD_LIBRARY_PATH = prependPathEntry(env.DYLD_LIBRARY_PATH, runtimeDir);
+  } else if (platform === "win32") {
+    env.PATH = prependPathEntry(prependPathEntry(env.PATH, runtimeDir), runtime.directoryPath ?? runtimeDir);
   }
 
   return env;

--- a/packages/server/src/services/sidecar/sidecar-runtime.service.ts
+++ b/packages/server/src/services/sidecar/sidecar-runtime.service.ts
@@ -3,6 +3,7 @@ import { execFile } from "child_process";
 import { promisify } from "util";
 import {
   chmodSync,
+  copyFileSync,
   existsSync,
   mkdirSync,
   readFileSync,
@@ -30,6 +31,11 @@ const execFileAsync = promisify(execFile);
 const RUNTIME_DIR = join(getDataDir(), "sidecar-runtime");
 const CURRENT_RUNTIME_PATH = join(RUNTIME_DIR, "current.json");
 const SERVER_LOG_PATH = join(RUNTIME_DIR, "server.log");
+const WINDOWS_CUDA_DLL_PATTERNS = [
+  { label: "cudart64_*.dll", pattern: /^cudart64_\d+\.dll$/i },
+  { label: "cublas64_*.dll", pattern: /^cublas64_\d+\.dll$/i },
+  { label: "cublasLt64_*.dll", pattern: /^cublasLt64_\d+\.dll$/i },
+];
 
 interface GitHubReleaseAsset {
   name: string;
@@ -65,6 +71,7 @@ export interface SidecarRuntimeInstall extends RuntimeRecord {
 interface RuntimeMatch {
   variant: string;
   asset: GitHubReleaseAsset;
+  dependencyAssets?: GitHubReleaseAsset[];
 }
 
 type GpuVendor = "nvidia" | "amd" | "intel";
@@ -106,6 +113,10 @@ function extractVersion(assetName: string): string {
   return match?.[1] ?? "0";
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 function isWindowsAsset(assetName: string): boolean {
   return assetName.endsWith(".zip");
 }
@@ -137,6 +148,49 @@ function findExecutableRecursive(dirPath: string, expectedName: string): string 
     }
   }
   return null;
+}
+
+function listFilesRecursive(dirPath: string): string[] {
+  const files: string[] = [];
+  const stack = [dirPath];
+  while (stack.length > 0) {
+    const current = stack.pop()!;
+    const stat = statSync(current, { throwIfNoEntry: false });
+    if (!stat) continue;
+    if (stat.isFile()) {
+      files.push(current);
+      continue;
+    }
+
+    for (const entry of readdirSync(current, { withFileTypes: true })) {
+      stack.push(join(current, entry.name));
+    }
+  }
+  return files;
+}
+
+function findMissingWindowsCudaDlls(runtimeDir: string): string[] {
+  const filenames = new Set(listFilesRecursive(runtimeDir).map((file) => basename(file).toLowerCase()));
+  return WINDOWS_CUDA_DLL_PATTERNS.filter(
+    ({ pattern }) => ![...filenames].some((filename) => pattern.test(filename)),
+  ).map(({ label }) => label);
+}
+
+function stageWindowsCudaDlls(runtimeDir: string, executablePath: string): string[] {
+  const executableDir = dirname(executablePath);
+  const files = listFilesRecursive(runtimeDir);
+
+  for (const { pattern } of WINDOWS_CUDA_DLL_PATTERNS) {
+    const matchingFile = files.find((file) => pattern.test(basename(file)));
+    if (!matchingFile) continue;
+
+    const targetPath = join(executableDir, basename(matchingFile));
+    if (!existsSync(targetPath)) {
+      copyFileSync(matchingFile, targetPath);
+    }
+  }
+
+  return findMissingWindowsCudaDlls(executableDir);
 }
 
 function parseBooleanEnv(value: string | undefined): boolean {
@@ -361,7 +415,15 @@ class SidecarRuntimeService {
     if (install.source === "system") {
       return !!install.serverPath;
     }
-    return install.platform === process.platform && install.arch === process.arch && existsSync(install.serverPath);
+    if (install.platform !== process.platform || install.arch !== process.arch || !existsSync(install.serverPath)) {
+      return false;
+    }
+
+    if (process.platform === "win32" && /cuda/i.test(install.variant)) {
+      return findMissingWindowsCudaDlls(install.directoryPath).length === 0;
+    }
+
+    return true;
   }
 
   private isInstallUsableForPreference(install: SidecarRuntimeInstall, preference: SidecarRuntimePreference): boolean {
@@ -485,7 +547,23 @@ class SidecarRuntimeService {
         extractDirectory,
         signal: abortController.signal,
         onProgress,
+        resetExtractDirectory: true,
       });
+      for (const dependencyAsset of match.dependencyAssets ?? []) {
+        const dependencyArchivePath = ensureWithinRuntimeDir(join(RUNTIME_DIR, dependencyAsset.name));
+        try {
+          await this.downloadAndExtractAsset({
+            asset: dependencyAsset,
+            archivePath: dependencyArchivePath,
+            extractDirectory,
+            signal: abortController.signal,
+            onProgress,
+            resetExtractDirectory: false,
+          });
+        } finally {
+          rmSync(dependencyArchivePath, { force: true });
+        }
+      }
       onProgress?.({
         phase: "runtime",
         status: "downloading",
@@ -503,6 +581,16 @@ class SidecarRuntimeService {
 
       renameSync(extractDirectory, finalDirectory);
       const finalExecutable = ensureWithinRuntimeDir(join(finalDirectory, relative(extractDirectory, executablePath)));
+      if (process.platform === "win32" && /cuda/i.test(match.variant)) {
+        const missingDlls = stageWindowsCudaDlls(finalDirectory, finalExecutable);
+        if (missingDlls.length > 0) {
+          throw new Error(
+            `The downloaded CUDA sidecar runtime is missing required CUDA DLLs (${missingDlls.join(
+              ", ",
+            )}). Reinstall the local runtime so Marinara can download the CUDA runtime package with bundled DLLs.`,
+          );
+        }
+      }
       if (process.platform !== "win32") {
         try {
           chmodSync(finalExecutable, 0o755);
@@ -553,11 +641,14 @@ class SidecarRuntimeService {
     extractDirectory: string;
     signal: AbortSignal;
     onProgress?: (progress: SidecarDownloadProgress) => void;
+    resetExtractDirectory?: boolean;
   }): Promise<void> {
     let lastError: unknown = null;
 
     for (let attempt = 1; attempt <= 2; attempt += 1) {
-      rmSync(options.extractDirectory, { recursive: true, force: true });
+      if (options.resetExtractDirectory ?? true) {
+        rmSync(options.extractDirectory, { recursive: true, force: true });
+      }
       mkdirSync(options.extractDirectory, { recursive: true });
 
       await retry(
@@ -722,6 +813,18 @@ class SidecarRuntimeService {
     return assets.find((asset) => pattern.test(asset.name)) ?? null;
   }
 
+  private findWindowsCudaDllAsset(assets: GitHubReleaseAsset[], cudaRuntimeAsset: GitHubReleaseAsset): GitHubReleaseAsset | null {
+    const cudaVersion = extractVersion(cudaRuntimeAsset.name);
+    if (cudaVersion === "0") {
+      return null;
+    }
+
+    return this.findFirstAsset(
+      assets,
+      new RegExp(`^cudart-llama(?:-.*)?-bin-win-cuda-${escapeRegExp(cudaVersion)}-x64\\.zip$`, "i"),
+    );
+  }
+
   private parseGpuVendors(output: string): GpuVendor[] {
     const vendors = new Set<GpuVendor>();
     const normalized = output.toLowerCase();
@@ -869,11 +972,12 @@ class SidecarRuntimeService {
     excludedVariants: Set<string>,
     variant: string,
     asset: GitHubReleaseAsset | null,
+    dependencyAssets: GitHubReleaseAsset[] = [],
   ): void {
     if (!asset || excludedVariants.has(variant) || matches.some((match) => match.variant === variant)) {
       return;
     }
-    matches.push({ variant, asset });
+    matches.push({ variant, asset, dependencyAssets });
   }
 
   private buildPreferredVariants(capabilities: RuntimeCapabilities, preference: SidecarRuntimePreference): string[] {
@@ -960,12 +1064,7 @@ class SidecarRuntimeService {
           this.findFirstAsset(assets, /^llama-.*-bin-macos-arm64-kleidiai\.tar\.gz$/i),
       ],
       ["macos-x64-cpu", this.findFirstAsset(assets, /^llama-.*-bin-macos-x64\.tar\.gz$/i)],
-      [
-        "win-x64-cuda",
-        this.pickLatestVersionedAsset(assets, /^(?:cudart-)?llama-.*-bin-win-cuda-[0-9.]+-x64\.zip$/i, {
-          preferPrefix: "cudart-",
-        }),
-      ],
+      ["win-x64-cuda", this.pickLatestVersionedAsset(assets, /^llama(?:-.*)?-bin-win-cuda-[0-9.]+-x64\.zip$/i)],
       ["win-x64-hip", this.findFirstAsset(assets, /^llama-.*-bin-win-hip-x64\.zip$/i)],
       ["win-x64-sycl", this.findFirstAsset(assets, /^llama-.*-bin-win-sycl-x64\.zip$/i)],
       ["win-x64-vulkan", this.findFirstAsset(assets, /^llama-.*-bin-win-vulkan-x64\.zip$/i)],
@@ -980,7 +1079,14 @@ class SidecarRuntimeService {
     ]);
 
     for (const variant of orderedVariants) {
-      this.pushCandidate(matches, excludedVariants, variant, assetByVariant.get(variant) ?? null);
+      const asset = assetByVariant.get(variant) ?? null;
+      const dependencyAssets =
+        variant === "win-x64-cuda" && asset
+          ? [this.findWindowsCudaDllAsset(assets, asset)].filter(
+              (dependencyAsset): dependencyAsset is GitHubReleaseAsset => dependencyAsset !== null,
+            )
+          : [];
+      this.pushCandidate(matches, excludedVariants, variant, asset, dependencyAssets);
     }
 
     return matches[0] ?? null;

--- a/packages/server/test/sidecar-model-files.test.ts
+++ b/packages/server/test/sidecar-model-files.test.ts
@@ -1,0 +1,12 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { isLikelyMmprojModelPath, isSupportedLlamaCppModelFilename } from "../src/services/sidecar/sidecar-model-files.js";
+
+test("rejects mmproj GGUF files as main llama.cpp models", () => {
+  assert.equal(isLikelyMmprojModelPath("unslothgemma-4-E2B-it-GGUFmmproj-BF16.gguf"), true);
+  assert.equal(isSupportedLlamaCppModelFilename("custom/mmproj-model.gguf"), false);
+});
+
+test("accepts normal GGUF model filenames", () => {
+  assert.equal(isSupportedLlamaCppModelFilename("gemma-4-E2B-it-Q4_K_M.gguf"), true);
+});

--- a/packages/server/test/sidecar-runtime-env.test.ts
+++ b/packages/server/test/sidecar-runtime-env.test.ts
@@ -49,3 +49,22 @@ test("leaves system runtimes unchanged", () => {
 
   assert.equal(env.LD_LIBRARY_PATH, "/usr/lib");
 });
+
+test("prepends bundled runtime directories to PATH on Windows", () => {
+  const env = buildLlamaProcessEnv(
+    {
+      source: "bundled",
+      directoryPath: "C:\\Marinara\\sidecar-runtime\\b8934-win-x64-cuda",
+      serverPath: "C:\\Marinara\\sidecar-runtime\\b8934-win-x64-cuda\\llama-server.exe",
+    },
+    "win32",
+    {
+      PATH: "C:\\Windows\\System32",
+    },
+  );
+
+  assert.equal(
+    env.PATH,
+    `C:\\Marinara\\sidecar-runtime\\b8934-win-x64-cuda${delimiter}C:\\Windows\\System32`,
+  );
+});


### PR DESCRIPTION
Now, we install the dll files for windows to ensure users without cuda setup can still use local sidecar runtimes with GPUs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Windows CUDA dependency handling for improved runtime support

* **Bug Fixes**
  * Refined local sidecar availability logic to prevent using unavailable connections
  * Added model file validation to catch unsupported formats early

* **Tests**
  * Added model file utility tests
  * Added Windows environment configuration tests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->