### PR TITLE
fix(docs): Fix anchor link for PR section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,7 +129,7 @@ All server-side logging goes through a shared [Pino](https://getpino.io/) logger
 
 ## Pull Request Expectations
 
-- Link the issue or feature request your PR addresses. If there isn't one yet, open one first (see [Before You Open a PR](#before-you-open-a-pr)).
+- Link the issue or feature request your PR addresses. If there isn't one yet, open one first (see [Before You Open a Pull Request](#before-you-open-a-pull-request)).
 - Keep PRs focused. Separate unrelated refactors from user-facing fixes or documentation work.
 - Explain the why clearly in the PR description. Reviewers should understand the user problem, regression, or tradeoff being addressed, not just the implementation summary.
 - Update documentation in the same PR when behavior changes affect installation, updates, release flow, launchers, or platform-specific behavior.


### PR DESCRIPTION
## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- There's an anchor link error
- Test the new workflow

## What changed

<!-- List the key changes in this PR -->

- Fix that error

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- N/A

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- N/A

## Docs and release impact

- [ ] No docs changes needed
- [x] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

<!-- Add before/after screenshots or recordings for UI changes -->

- N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed a navigation link in the contributing guidelines to properly direct contributors to the relevant section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->