### PR TITLE
feat(bot-browser): token-only Pygmalion, Janny robustness, DataCat provider

### DIFF
--- a/packages/client/src/components/bot-browser/BotBrowserView.tsx
+++ b/packages/client/src/components/bot-browser/BotBrowserView.tsx
@@ -427,10 +427,14 @@ const jannyProvider: ProviderConfig = {
     // Fetch a one-time search token from the server (token is scraped from JannyAI's
     // public Astro bundle). The actual MeiliSearch POST runs from the BROWSER so that
     // Cloudflare sees a real browser TLS fingerprint + the user's cf_clearance cookie.
-    const tokenRes = await fetch("/api/bot-browser/janny/token");
-    if (!tokenRes.ok) throw new Error("Could not obtain JannyAI token");
-    const { token } = await tokenRes.json();
-    if (!token) throw new Error("JannyAI token unavailable");
+    const fetchToken = async (force = false): Promise<string> => {
+      const tokenRes = await fetch(`/api/bot-browser/janny/token${force ? "?force=1" : ""}`);
+      if (!tokenRes.ok) throw new Error("Could not obtain JannyAI token");
+      const { token: t } = await tokenRes.json();
+      if (!t) throw new Error("JannyAI token unavailable");
+      return t;
+    };
+    let token = await fetchToken();
 
     const sortMap: Record<string, string[]> = {
       newest: ["createdAtStamp:desc"],
@@ -483,16 +487,28 @@ const jannyProvider: ProviderConfig = {
       // pair with `credentials: "include"` — that combination blocks the response
       // entirely. cf_clearance won't ride along, but the upstream has historically
       // let cross-origin requests with browser TLS + UA through anyway.
-      const res = await fetch("https://search.jannyai.com/multi-search", {
-        method: "POST",
-        headers: {
-          Accept: "*/*",
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
-          "x-meilisearch-client": "Meilisearch instant-meilisearch (v0.19.0) ; Meilisearch JavaScript (v0.41.0)",
-        },
-        body: JSON.stringify(body),
-      });
+      const doFetch = (authToken: string) =>
+        fetch("https://search.jannyai.com/multi-search", {
+          method: "POST",
+          headers: {
+            Accept: "*/*",
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${authToken}`,
+            "x-meilisearch-client": "Meilisearch instant-meilisearch (v0.19.0) ; Meilisearch JavaScript (v0.41.0)",
+          },
+          body: JSON.stringify(body),
+        });
+      let res = await doFetch(token);
+      // If the cached token has been rotated upstream, MeiliSearch returns 401/403.
+      // Force a server-side re-scrape and retry once.
+      if (res.status === 401 || res.status === 403) {
+        try {
+          token = await fetchToken(true);
+          res = await doFetch(token);
+        } catch {
+          /* fall through to error handling below */
+        }
+      }
       if (!res.ok) {
         if (res.status === 403) {
           throw new Error(

--- a/packages/client/src/components/bot-browser/BotBrowserView.tsx
+++ b/packages/client/src/components/bot-browser/BotBrowserView.tsx
@@ -1055,8 +1055,9 @@ const datacatProvider: ProviderConfig = {
     const tagIds = p.includeTags.length > 0 ? datacatTagNamesToIds(p.includeTags) : [];
 
     // Fresh = trending, Relevance = recent-public (which is the "Characters" tab on
-    // datacat.run — supports tag filtering and shows the full library).
-    const useFresh = p.sort === "fresh" && tagIds.length === 0 && !p.query;
+    // datacat.run — supports tag filtering and shows the full library). DataCat
+    // has no free-text search endpoint, so `p.query` is ignored for this provider.
+    const useFresh = p.sort === "fresh" && tagIds.length === 0;
 
     let list: any[] = [];
     let totalCount = 0;
@@ -1073,7 +1074,12 @@ const datacatProvider: ProviderConfig = {
       // Response shape: { success, sortBy, windows: { last24h: { count, characters: [...] }, thisWeek: {...} } }
       const last24h = data?.windows?.last24h || data?.last24h;
       list = Array.isArray(last24h) ? last24h : last24h?.characters || [];
-      totalCount = data?.windows?.last24h?.count ?? list.length;
+      // /fresh ignores `page` — the upstream `count` describes the full window
+      // even when the response only carries `limit24` items. Reporting that as
+      // `totalCount` would let the paginator advertise pages 2+ that just replay
+      // the same window. Clamp to the actual returned slice so pagination
+      // disables itself once the user reaches the end.
+      totalCount = list.length;
     } else {
       const offset = Math.max(0, (p.page - 1) * 80);
       const params = new URLSearchParams({ limit: "80", offset: String(offset) });
@@ -1085,14 +1091,11 @@ const datacatProvider: ProviderConfig = {
       totalCount = data?.totalCount || list.length;
     }
 
-    // Client-side query filter (DataCat REST has no full-text search on these endpoints)
-    if (p.query) {
-      const q = p.query.toLowerCase();
-      list = list.filter((c: any) => {
-        const name = (c.chat_name || c.name || "").toLowerCase();
-        return name.includes(q);
-      });
-    }
+    // No client-side query filter for DataCat: upstream has no full-text search
+    // endpoint, and filtering only the current 80-row page would be misleading
+    // (a character on page 2 would still show "no results" on page 1). The UI
+    // disables the search input for this provider — see the search input render.
+
     // DataCat is NSFW-only — every character is tagged NSFW upstream, so filtering
     // by nsfw=false would always return an empty list. Skip the filter entirely.
     // Client-side excludeTags filter
@@ -1885,13 +1888,23 @@ export function BotBrowserView() {
                   />
                   <input
                     type="text"
-                    value={query}
+                    value={sourceId === "datacat" ? "" : query}
                     onChange={(e) => {
                       setQuery(e.target.value);
                       setPage(1);
                     }}
-                    placeholder="Search characters..."
-                    className="w-full rounded-lg border border-[var(--border)] bg-[var(--secondary)] py-2 pl-9 pr-8 text-sm text-[var(--foreground)] placeholder-[var(--muted-foreground)] outline-none transition-colors focus:border-[var(--primary)]"
+                    disabled={sourceId === "datacat"}
+                    placeholder={
+                      sourceId === "datacat"
+                        ? "DataCat doesn't support text search — filter by tag instead"
+                        : "Search characters..."
+                    }
+                    title={
+                      sourceId === "datacat"
+                        ? "DataCat has no full-text search endpoint. Use tags to narrow results."
+                        : undefined
+                    }
+                    className="w-full rounded-lg border border-[var(--border)] bg-[var(--secondary)] py-2 pl-9 pr-8 text-sm text-[var(--foreground)] placeholder-[var(--muted-foreground)] outline-none transition-colors focus:border-[var(--primary)] disabled:cursor-not-allowed disabled:opacity-60"
                   />
                   {query && (
                     <button

--- a/packages/client/src/components/bot-browser/BotBrowserView.tsx
+++ b/packages/client/src/components/bot-browser/BotBrowserView.tsx
@@ -78,6 +78,8 @@ interface ProviderConfig {
   icon: string;
   sortOptions: SortOption[];
   defaultSort: string;
+  /** Items per page returned by the provider's search. Used by the shared paginator. */
+  pageSize: number;
   features: FilterFeature[];
   hasSortDirection: boolean;
   hasTokenFilters: boolean;
@@ -289,6 +291,7 @@ const chubProvider: ProviderConfig = {
   icon: "✦",
   siteName: "Chub",
   defaultSort: "popular_all",
+  pageSize: 48,
   sortOptions: [
     { value: "popular_all", label: "👑 Most Downloaded", group: "Popular" },
     { value: "popular_week", label: "🔥 Hot This Week", group: "Popular" },
@@ -397,6 +400,7 @@ const jannyProvider: ProviderConfig = {
   icon: "🤖",
   siteName: "JannyAI",
   defaultSort: "newest",
+  pageSize: 80,
   sortOptions: [
     { value: "newest", label: "🆕 Newest", group: "Date" },
     { value: "oldest", label: "🕐 Oldest", group: "Date" },
@@ -476,6 +480,10 @@ const jannyProvider: ProviderConfig = {
 
       const res = await fetch("https://search.jannyai.com/multi-search", {
         method: "POST",
+        // Cross-origin POST: required so the browser actually sends cf_clearance +
+        // any other jannyai.com cookies the user already has — that's what gets us
+        // past Cloudflare's bot challenge. Without this the workaround is a no-op.
+        credentials: "include",
         headers: {
           Accept: "*/*",
           "Content-Type": "application/json",
@@ -668,6 +676,7 @@ const chartavernProvider: ProviderConfig = {
   icon: "🍺",
   siteName: "CharacterTavern",
   defaultSort: "most_popular",
+  pageSize: 60,
   sortOptions: [
     { value: "most_popular", label: "🔥 Most Popular" },
     { value: "trending", label: "📈 Trending" },
@@ -756,6 +765,7 @@ const pygmalionProvider: ProviderConfig = {
   icon: "🔥",
   siteName: "Pygmalion",
   defaultSort: "downloads",
+  pageSize: 48,
   sortOptions: [
     { value: "downloads", label: "⬇️ Downloads" },
     { value: "stars", label: "⭐ Stars" },
@@ -856,6 +866,7 @@ const wyvernProvider: ProviderConfig = {
   icon: "🐉",
   siteName: "Wyvern",
   defaultSort: "popular",
+  pageSize: 48,
   sortOptions: [
     { value: "popular", label: "🔥 Popular" },
     { value: "nsfw-popular", label: "🔞 Popular NSFW" },
@@ -1014,6 +1025,7 @@ const datacatProvider: ProviderConfig = {
   icon: "🐱",
   siteName: "DataCat",
   defaultSort: "relevance",
+  pageSize: 80,
   sortOptions: [
     { value: "relevance", label: "🔍 Relevance" },
     { value: "fresh", label: "🔥 Fresh" },
@@ -1556,7 +1568,7 @@ export function BotBrowserView() {
     provider.extraToggles.filter((t) => extraToggles[t.key]).length;
   const hasActiveFeatures = activeFeatureCount > 0;
   const canAddCustomTag = tagSearch.trim().length >= 2 && !includeTags.includes(tagSearch.trim().toLowerCase());
-  const perPage = sourceId === "chub" ? 48 : sourceId === "janny" ? 80 : sourceId === "chartavern" ? 60 : 48;
+  const perPage = provider.pageSize;
   const totalPages = Math.max(1, Math.ceil(totalCount / perPage));
 
   const sortGroups = useMemo(() => {

--- a/packages/client/src/components/bot-browser/BotBrowserView.tsx
+++ b/packages/client/src/components/bot-browser/BotBrowserView.tsx
@@ -48,10 +48,10 @@ interface BrowseCard {
   avatarUrl: string;
   stat1: number;
   stat1Label: string;
-  stat1Icon: "star" | "download" | "heart" | "eye" | "message";
+  stat1Icon: "star" | "download" | "heart" | "eye" | "message" | "hash";
   stat2: number;
   stat2Label: string;
-  stat2Icon: "star" | "download" | "heart" | "eye" | "message";
+  stat2Icon: "star" | "download" | "heart" | "eye" | "message" | "hash";
   stat3: number;
   stat3Label: string;
   stat3Icon: "star" | "download" | "heart" | "eye" | "message" | "hash";
@@ -420,33 +420,108 @@ const jannyProvider: ProviderConfig = {
     return `https://jannyai.com/characters/${raw?.id || card.id}_character-${slug}`;
   },
   search: async (p) => {
-    const params = new URLSearchParams({
-      q: p.query,
-      page: String(p.page),
-      limit: "80",
-      sort: p.sort,
-      nsfw: String(p.nsfw),
-      min_tokens: p.minTokens || "29",
-      max_tokens: p.maxTokens || "100000",
-    });
-    if (p.extraToggles.showLowQuality) params.set("showLowQuality", "true");
-    if (p.includeTags.length > 0) {
-      const ids = jannyTagNamesToIds(p.includeTags);
-      if (ids.length > 0) params.set("tagIds", ids.join(","));
-    }
-    const res = await fetch(`/api/bot-browser/janny/search?${params}`);
-    if (!res.ok) throw new Error("Search failed");
-    const raw = await res.json();
-    const result = raw?.results?.[0];
-    let hits = result?.hits || [];
-    const totalPages = result?.totalPages || 1;
-    // Client-side exclude tag filtering (JannyAI API doesn't support server-side exclude)
-    if (p.excludeTags.length > 0) {
-      const lowerExclude = p.excludeTags.map((t) => t.toLowerCase());
-      hits = hits.filter((h: any) => {
-        const charTagNames = jannyTagNames(h.tagIds || []).map((t) => t.toLowerCase());
-        return !lowerExclude.some((et) => charTagNames.includes(et));
+    // Fetch a one-time search token from the server (token is scraped from JannyAI's
+    // public Astro bundle). The actual MeiliSearch POST runs from the BROWSER so that
+    // Cloudflare sees a real browser TLS fingerprint + the user's cf_clearance cookie.
+    const tokenRes = await fetch("/api/bot-browser/janny/token");
+    if (!tokenRes.ok) throw new Error("Could not obtain JannyAI token");
+    const { token } = await tokenRes.json();
+    if (!token) throw new Error("JannyAI token unavailable");
+
+    const sortMap: Record<string, string[]> = {
+      newest: ["createdAtStamp:desc"],
+      oldest: ["createdAtStamp:asc"],
+      tokens_desc: ["totalToken:desc"],
+      tokens_asc: ["totalToken:asc"],
+      relevant: [],
+    };
+    const sortArr = sortMap[p.sort] ?? sortMap.newest!;
+
+    // Split include tags into "known" (mapped to MeiliSearch tagIds) and "custom"
+    // (free-form names that aren't in JANNY_TAG_MAP). Known tags filter server-side;
+    // custom tags filter client-side against the hit's resolved tag-name list.
+    const knownIncludeTagIds = jannyTagNamesToIds(p.includeTags);
+    const customIncludeTags = p.includeTags
+      .filter((t) => JANNY_TAG_REVERSE[t.toLowerCase()] === undefined)
+      .map((t) => t.toLowerCase());
+
+    const fetchOnePage = async (pageNum: number) => {
+      const filters: string[] = [];
+      filters.push(`totalToken >= ${parseInt(p.minTokens) || 29}`);
+      filters.push(`totalToken <= ${parseInt(p.maxTokens) || 100000}`);
+      if (!p.nsfw) filters.push("isNsfw = false");
+      if (!p.extraToggles.showLowQuality) filters.push("isLowQuality = false");
+      if (knownIncludeTagIds.length > 0) {
+        filters.push(knownIncludeTagIds.map((id) => `tagIds = ${id}`).join(" AND "));
+      }
+
+      const body = {
+        queries: [
+          {
+            indexUid: "janny-characters",
+            q: p.query,
+            facets: ["isLowQuality", "isNsfw", "tagIds", "totalToken"],
+            attributesToCrop: ["description:300"],
+            cropMarker: "...",
+            filter: filters,
+            attributesToHighlight: ["name", "description"],
+            highlightPreTag: "__ais-highlight__",
+            highlightPostTag: "__/ais-highlight__",
+            hitsPerPage: 80,
+            page: pageNum,
+            ...(sortArr.length > 0 ? { sort: sortArr } : {}),
+          },
+        ],
+      };
+
+      const res = await fetch("https://search.jannyai.com/multi-search", {
+        method: "POST",
+        headers: {
+          Accept: "*/*",
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+          "x-meilisearch-client": "Meilisearch instant-meilisearch (v0.19.0) ; Meilisearch JavaScript (v0.41.0)",
+        },
+        body: JSON.stringify(body),
       });
+      if (!res.ok) {
+        if (res.status === 403) {
+          throw new Error(
+            "JannyAI is blocking the request (Cloudflare). Visit https://jannyai.com once in this browser to clear the challenge, then retry.",
+          );
+        }
+        throw new Error(`JannyAI search error ${res.status}`);
+      }
+      const raw = await res.json();
+      return raw?.results?.[0];
+    };
+
+    const lowerExclude = p.excludeTags.map((t) => t.toLowerCase());
+    const applyClientFilter = (hitsArr: any[]): any[] => {
+      if (lowerExclude.length === 0 && customIncludeTags.length === 0) return hitsArr;
+      return hitsArr.filter((h: any) => {
+        const charTagNames = jannyTagNames(h.tagIds || []).map((t) => t.toLowerCase());
+        if (lowerExclude.length > 0 && lowerExclude.some((et) => charTagNames.includes(et))) return false;
+        // Custom tags: every custom tag must appear in the hit's resolved tag names
+        if (customIncludeTags.length > 0 && !customIncludeTags.every((ct) => charTagNames.includes(ct))) return false;
+        return true;
+      });
+    };
+
+    let currentPage = p.page;
+    const result = await fetchOnePage(currentPage);
+    let hits = applyClientFilter(result?.hits || []);
+    const totalPages = result?.totalPages || 1;
+
+    // Auto-fetch up to 3 extra pages when client-side filters thin the page
+    if (lowerExclude.length > 0 || customIncludeTags.length > 0) {
+      let autoFetches = 0;
+      while (hits.length < 80 && currentPage < totalPages && autoFetches < 3) {
+        autoFetches++;
+        currentPage++;
+        const more = await fetchOnePage(currentPage);
+        hits = hits.concat(applyClientFilter(more?.hits || []));
+      }
     }
     return {
       cards: hits.map((h: any) => ({
@@ -520,31 +595,8 @@ const jannyProvider: ProviderConfig = {
       }
     }
 
-    // Strategy 1: Server-side proxy
-    try {
-      const res = await fetch(`/api/bot-browser/janny/character/${charId}?slug=character-${slug}`);
-      if (res.ok) {
-        const data = await res.json();
-        const char = data?.character;
-        if (char && (char.personality || char.firstMessage)) {
-          return {
-            description: char.personality || undefined,
-            scenario: char.scenario || undefined,
-            firstMessage: char.firstMessage || undefined,
-            exampleDialogs: char.exampleDialogs || undefined,
-            creatorNotes: char.description
-              ? typeof char.description === "string"
-                ? char.description.replace(/<[^>]*>/g, "").trim()
-                : undefined
-              : undefined,
-          };
-        }
-      }
-    } catch {
-      /* fall through */
-    }
-
-    // Strategy 2: corsproxy.io from browser
+    // Strategy 1: corsproxy.io from browser (preferred — bypasses Cloudflare via the
+    // user's browser TLS fingerprint + any cf_clearance cookie they have for jannyai.com)
     try {
       const proxyRes = await fetch(`https://corsproxy.io/?url=${encodeURIComponent(pageUrl)}`, {
         headers: { Accept: "text/html,application/xhtml+xml,*/*" },
@@ -558,6 +610,30 @@ const jannyProvider: ProviderConfig = {
             scenario: (char.scenario as string) || undefined,
             firstMessage: (char.firstMessage as string) || undefined,
             exampleDialogs: (char.exampleDialogs as string) || undefined,
+            creatorNotes: char.description
+              ? typeof char.description === "string"
+                ? char.description.replace(/<[^>]*>/g, "").trim()
+                : undefined
+              : undefined,
+          };
+        }
+      }
+    } catch {
+      /* fall through */
+    }
+
+    // Strategy 2: server-side proxy (likely fails due to Cloudflare, but try anyway)
+    try {
+      const res = await fetch(`/api/bot-browser/janny/character/${charId}?slug=character-${slug}`);
+      if (res.ok) {
+        const data = await res.json();
+        const char = data?.character;
+        if (char && (char.personality || char.firstMessage)) {
+          return {
+            description: char.personality || undefined,
+            scenario: char.scenario || undefined,
+            firstMessage: char.firstMessage || undefined,
+            exampleDialogs: char.exampleDialogs || undefined,
             creatorNotes: char.description
               ? typeof char.description === "string"
                 ? char.description.replace(/<[^>]*>/g, "").trim()
@@ -877,6 +953,235 @@ const wyvernProvider: ProviderConfig = {
 };
 
 // ════════════════════════════════════════════════
+// Provider: DataCat
+// (Aggregator surfacing JanitorAI characters via datacat.run REST API)
+// ════════════════════════════════════════════════
+
+// Cache of DataCat tags (name <-> id) populated from the faceted endpoint.
+// Names are lowercased so user input from the tag panel can match either the
+// upstream display name or any case variant.
+//
+// DataCat returns ~28k tags. Rendering all of them as buttons crashes the
+// browser, so the tag panel only shows the top N most-popular tags
+// (`datacatTopTagNames`); the full id<->name maps are still populated so
+// custom user input and card-level resolution still work for the long tail.
+const TOP_TAGS_DISPLAY_LIMIT = 150;
+const datacatTagNameToId = new Map<string, number>();
+const datacatTagIdToName = new Map<number, string>();
+let datacatTopTagNames: string[] = [];
+let datacatTagsLoaded = false;
+let datacatTagsLoading: Promise<void> | null = null;
+
+async function loadDatacatTags(): Promise<void> {
+  if (datacatTagsLoaded) return;
+  if (datacatTagsLoading) return datacatTagsLoading;
+  datacatTagsLoading = (async () => {
+    try {
+      const res = await fetch("/api/bot-browser/datacat/tags");
+      if (!res.ok) return;
+      const data = await res.json();
+      const list: any[] = data?.tags || data?.facets || data || [];
+      const sortable: { id: number; name: string; count: number }[] = [];
+      for (const t of list) {
+        const id = Number(t?.id ?? t?.tag_id ?? t?.tagId);
+        const name: string = (t?.name || t?.slug || "").toString();
+        const count = Number(t?.count ?? 0) || 0;
+        if (Number.isFinite(id) && name) {
+          datacatTagNameToId.set(name.toLowerCase(), id);
+          datacatTagIdToName.set(id, name);
+          sortable.push({ id, name, count });
+        }
+      }
+      sortable.sort((a, b) => b.count - a.count);
+      datacatTopTagNames = sortable.slice(0, TOP_TAGS_DISPLAY_LIMIT).map((t) => t.name);
+      datacatTagsLoaded = true;
+    } finally {
+      datacatTagsLoading = null;
+    }
+  })();
+  return datacatTagsLoading;
+}
+
+function datacatTagNamesToIds(names: string[]): number[] {
+  return names
+    .map((n) => datacatTagNameToId.get(n.toLowerCase()))
+    .filter((id): id is number => typeof id === "number");
+}
+
+const datacatProvider: ProviderConfig = {
+  id: "datacat",
+  name: "DataCat",
+  icon: "🐱",
+  siteName: "DataCat",
+  defaultSort: "relevance",
+  sortOptions: [
+    { value: "relevance", label: "🔍 Relevance" },
+    { value: "fresh", label: "🔥 Fresh" },
+  ],
+  features: [],
+  hasSortDirection: false,
+  hasTokenFilters: false,
+  extraToggles: [],
+  // DataCat is NSFW-only — hide the toggle since every character is NSFW-tagged
+  nsfwAvailable: false,
+  nsfwMode: "wyvern",
+  getAvatarUrl: (card) => {
+    const raw = card._raw as any;
+    const av = raw?.avatar || "";
+    if (!av) return "";
+    if (av.startsWith("http")) return `/api/bot-browser/datacat/avatar/${encodeURIComponent(av)}`;
+    return `/api/bot-browser/datacat/avatar/${av}`;
+  },
+  getExternalUrl: (card) => {
+    const raw = card._raw as any;
+    const id = raw?.characterId || raw?.character_id || card.id;
+    return `https://datacat.run/characters/${id}`;
+  },
+  search: async (p) => {
+    await loadDatacatTags();
+    const tagIds = p.includeTags.length > 0 ? datacatTagNamesToIds(p.includeTags) : [];
+
+    // Fresh = trending, Relevance = recent-public (which is the "Characters" tab on
+    // datacat.run — supports tag filtering and shows the full library).
+    const useFresh = p.sort === "fresh" && tagIds.length === 0 && !p.query;
+
+    let list: any[] = [];
+    let totalCount = 0;
+
+    if (useFresh) {
+      const params = new URLSearchParams({
+        sortBy: "score",
+        limit24: "80",
+        limitWeek: "0",
+      });
+      const res = await fetch(`/api/bot-browser/datacat/fresh?${params}`);
+      if (!res.ok) throw new Error("Search failed");
+      const data = await res.json();
+      // Response shape: { success, sortBy, windows: { last24h: { count, characters: [...] }, thisWeek: {...} } }
+      const last24h = data?.windows?.last24h || data?.last24h;
+      list = Array.isArray(last24h) ? last24h : last24h?.characters || [];
+      totalCount = data?.windows?.last24h?.count ?? list.length;
+    } else {
+      const offset = Math.max(0, (p.page - 1) * 80);
+      const params = new URLSearchParams({ limit: "80", offset: String(offset) });
+      if (tagIds.length > 0) params.set("tagIds", tagIds.join(","));
+      const res = await fetch(`/api/bot-browser/datacat/recent?${params}`);
+      if (!res.ok) throw new Error("Search failed");
+      const data = await res.json();
+      list = data?.characters || [];
+      totalCount = data?.totalCount || list.length;
+    }
+
+    // Client-side query filter (DataCat REST has no full-text search on these endpoints)
+    if (p.query) {
+      const q = p.query.toLowerCase();
+      list = list.filter((c: any) => {
+        const name = (c.chat_name || c.name || "").toLowerCase();
+        return name.includes(q);
+      });
+    }
+    // DataCat is NSFW-only — every character is tagged NSFW upstream, so filtering
+    // by nsfw=false would always return an empty list. Skip the filter entirely.
+    // Client-side excludeTags filter
+    if (p.excludeTags.length > 0) {
+      const lowerExclude = p.excludeTags.map((t) => t.toLowerCase());
+      list = list.filter((c: any) => {
+        const tagNames = (Array.isArray(c.tags) ? c.tags : [])
+          .map((t: any) => (typeof t === "string" ? t : t?.name || t?.slug || ""))
+          .map((s: string) => s.toLowerCase());
+        return !lowerExclude.some((et) => tagNames.includes(et));
+      });
+    }
+
+    return {
+      cards: list.map((c: any) => {
+        // Tags can come either as objects ({id,name,slug}), as strings, or as
+        // numeric tagIds — try every shape and normalize to display names.
+        const rawTags: any[] = Array.isArray(c.tags) ? c.tags : Array.isArray(c.tagIds) ? c.tagIds : [];
+        const tagNames: string[] = rawTags
+          .map((t: any) => {
+            if (typeof t === "string") return t;
+            if (typeof t === "number") return datacatTagIdToName.get(t) || "";
+            return t?.name || t?.slug || (typeof t?.id === "number" ? datacatTagIdToName.get(t.id) || "" : "");
+          })
+          .filter(Boolean);
+        const av = c.avatar || "";
+        const avatarProxyUrl = av
+          ? av.startsWith("http")
+            ? `/api/bot-browser/datacat/avatar/${encodeURIComponent(av)}`
+            : `/api/bot-browser/datacat/avatar/${av}`
+          : "";
+        const charId = c.characterId || c.character_id || c.id || "";
+        return {
+          id: charId,
+          name: c.chatName || c.chat_name || c.name || "Unnamed",
+          creator: c.creatorName || c.creator_name || "",
+          tagline: (c.description || "").replace(/<[^>]*>/g, "").slice(0, 200),
+          tags: tagNames,
+          avatarUrl: avatarProxyUrl,
+          stat1: c.chatCount || c.chat_count || 0,
+          stat1Label: "Chats",
+          stat1Icon: "message" as const,
+          stat2: c.totalTokens || c.total_tokens || 0,
+          stat2Label: "Tokens",
+          stat2Icon: "hash" as const,
+          stat3: 0,
+          stat3Label: "",
+          stat3Icon: "star" as const,
+          nsfw: !!c.isNsfw,
+          externalUrl: `https://datacat.run/characters/${charId}`,
+          _raw: c,
+        };
+      }),
+      totalCount,
+    };
+  },
+  fetchDetail: async (card) => {
+    const id = (card._raw as any)?.characterId || (card._raw as any)?.character_id || card.id;
+    if (!id) return null;
+    // Prefer the download endpoint for V2-shaped data, fall back to character endpoint
+    try {
+      const dlRes = await fetch(`/api/bot-browser/datacat/download/${encodeURIComponent(id)}`);
+      if (dlRes.ok) {
+        const dl = await dlRes.json();
+        const d = dl?.data;
+        if (d) {
+          return {
+            description: d.description || d.personality || undefined,
+            personality: d.personality || undefined,
+            scenario: d.scenario || undefined,
+            firstMessage: d.first_mes || undefined,
+            exampleDialogs: d.mes_example || undefined,
+            creatorNotes: d.creator_notes || undefined,
+            alternateGreetings: Array.isArray(d.alternate_greetings) ? d.alternate_greetings.filter(Boolean) : [],
+          };
+        }
+      }
+    } catch {
+      /* fall through */
+    }
+    try {
+      const res = await fetch(`/api/bot-browser/datacat/character/${encodeURIComponent(id)}`);
+      if (!res.ok) return null;
+      const data = await res.json();
+      const c = data?.character || data;
+      if (!c) return null;
+      const rawDesc = c.description || "";
+      const plainDesc = typeof rawDesc === "string" ? rawDesc.replace(/<[^>]*>/g, "").trim() : "";
+      return {
+        description: c.personality || undefined,
+        scenario: c.scenario || undefined,
+        firstMessage: c.first_message || undefined,
+        creatorNotes: plainDesc || undefined,
+      };
+    } catch {
+      return null;
+    }
+  },
+  importCard: async () => {},
+};
+
+// ════════════════════════════════════════════════
 // Provider Registry
 // ════════════════════════════════════════════════
 
@@ -886,6 +1191,7 @@ const ALL_PROVIDERS: ProviderConfig[] = [
   chartavernProvider,
   pygmalionProvider,
   wyvernProvider,
+  datacatProvider,
 ];
 
 function getProvider(id: string): ProviderConfig {
@@ -988,7 +1294,10 @@ export function BotBrowserView() {
     return provider.nsfwAvailable;
   }, [provider, sourceId, pygLoggedIn, ctLoggedIn]);
 
-  const switchProvider = useCallback((newId: string) => {
+  const [datacatNsfwAcked, setDatacatNsfwAcked] = useState(false);
+  const [pendingDatacatSwitch, setPendingDatacatSwitch] = useState(false);
+
+  const performSwitch = useCallback((newId: string) => {
     const newProv = getProvider(newId);
     setSourceId(newId);
     setSourceOpen(false);
@@ -996,7 +1305,8 @@ export function BotBrowserView() {
     setSort(newProv.defaultSort);
     setSortAsc(false);
     setPage(1);
-    setNsfwRaw(getPersistNsfw(newId));
+    // DataCat is NSFW-only — every character is tagged NSFW upstream, force the flag on
+    setNsfwRaw(newId === "datacat" ? true : getPersistNsfw(newId));
     setIncludeTags([]);
     setExcludeTags([]);
     setTagSearch("");
@@ -1015,6 +1325,18 @@ export function BotBrowserView() {
     setShowLoginModal(false);
   }, []);
 
+  const switchProvider = useCallback(
+    (newId: string) => {
+      if (newId === "datacat" && !datacatNsfwAcked) {
+        setSourceOpen(false);
+        setPendingDatacatSwitch(true);
+        return;
+      }
+      performSwitch(newId);
+    },
+    [datacatNsfwAcked, performSwitch],
+  );
+
   useEffect(() => {
     const allTags = new Set<string>();
     for (const card of results) {
@@ -1025,6 +1347,25 @@ export function BotBrowserView() {
       return Array.from(merged).sort((a, b) => a.localeCompare(b));
     });
   }, [results]);
+
+  // When DataCat is the active provider, eagerly populate the tag panel with
+  // only the top-N most-popular DataCat tags. (The full ~28k tag list lives in
+  // the module-level id<->name maps for resolution; rendering all of them as
+  // buttons would freeze the browser.)
+  useEffect(() => {
+    if (sourceId !== "datacat") return;
+    let cancelled = false;
+    loadDatacatTags().then(() => {
+      if (cancelled || datacatTopTagNames.length === 0) return;
+      setAvailableTags((prev) => {
+        const merged = new Set([...prev, ...datacatTopTagNames]);
+        return Array.from(merged).sort((a, b) => a.localeCompare(b));
+      });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [sourceId]);
 
   const doSearch = useCallback(async () => {
     setLoading(true);
@@ -1236,7 +1577,7 @@ export function BotBrowserView() {
   const handleNsfwClick = (e: React.MouseEvent) => {
     if (effectiveNsfwAvailable) return; // Let the checkbox handle it
     e.preventDefault();
-    if (provider.nsfwMode === "wyvern") {
+    if (sourceId === "wyvern") {
       toast.info('Use the "🔞 Popular NSFW" sort option to browse NSFW content on Wyvern.');
     } else if (provider.nsfwMode === "login") {
       setShowLoginModal(true);
@@ -1244,34 +1585,21 @@ export function BotBrowserView() {
   };
 
   // ── Auth handlers ──
-  const handlePygmalionLogin = async (username: string, password: string) => {
+  const handlePygmalionSetToken = async (token: string) => {
     setLoginLoading(true);
     try {
-      const res = await fetch("/api/bot-browser/pygmalion/login", {
+      const res = await fetch("/api/bot-browser/pygmalion/set-token", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ username, password }),
+        body: JSON.stringify({ token }),
       });
-      const text = await res.text();
-      if (!res.ok) throw new Error("Login failed: " + text.slice(0, 200));
+      const data = await res.json();
+      if (!res.ok || !data.ok) throw new Error(data.error || "Failed to save token");
 
-      // Try to parse token from response
-      let token = "";
-      try {
-        const data = JSON.parse(text);
-        token = data?.token || data?.idToken || data?.access_token || "";
-      } catch {
-        if (text.length > 20 && text.length < 4096 && !text.includes("<")) token = text.trim();
-      }
-
-      // If we got a token, store it on the server
-      if (token) {
-        await fetch("/api/bot-browser/pygmalion/set-token", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ token }),
-        });
-      }
+      // Validate
+      const valRes = await fetch("/api/bot-browser/pygmalion/validate");
+      const valData = await valRes.json();
+      if (!valData.valid) throw new Error(valData.reason || "Token validation failed");
 
       setPygLoggedIn(true);
       setShowLoginModal(false);
@@ -1279,7 +1607,7 @@ export function BotBrowserView() {
       setPage(1);
       toast.success("Logged in to Pygmalion! NSFW content enabled.");
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : "Login failed");
+      toast.error(err instanceof Error ? err.message : "Token validation failed");
     } finally {
       setLoginLoading(false);
     }
@@ -1649,9 +1977,11 @@ export function BotBrowserView() {
                           ? "NSFW depends on your account settings"
                           : effectiveNsfwAvailable
                             ? "Toggle NSFW content"
-                            : provider.nsfwMode === "wyvern"
+                            : sourceId === "wyvern"
                               ? 'Use the "Popular NSFW" sort option'
-                              : `Click to log in to ${provider.name} for NSFW content`
+                              : sourceId === "datacat"
+                                ? "DataCat is NSFW-only"
+                                : `Click to log in to ${provider.name} for NSFW content`
                       }
                       onClick={nsfwGreyedOut ? (e: React.MouseEvent) => e.preventDefault() : handleNsfwClick}
                     >
@@ -1704,7 +2034,7 @@ export function BotBrowserView() {
                       <LogIn size="0.75rem" /> Log In
                     </button>
                   ))}
-                {provider.nsfwMode === "wyvern" && (
+                {sourceId === "wyvern" && (
                   <span className="flex items-center gap-1.5 rounded-lg border border-amber-500/20 bg-amber-500/5 px-3 py-2 text-[0.65rem] text-amber-400">
                     Use "🔞 Popular NSFW" sort for NSFW content
                   </span>
@@ -1875,11 +2205,62 @@ export function BotBrowserView() {
           ctLoggedIn={ctLoggedIn}
           loginLoading={loginLoading}
           onClose={() => setShowLoginModal(false)}
-          onPygLogin={handlePygmalionLogin}
+          onPygSetToken={handlePygmalionSetToken}
           onPygLogout={handlePygmalionLogout}
           onCtSetCookie={handleCtSetCookie}
           onCtLogout={handleCtLogout}
         />
+      )}
+
+      {/* ═══ DataCat NSFW Warning ═══ */}
+      {pendingDatacatSwitch && (
+        <div
+          className="fixed inset-0 z-[9999] flex items-center justify-center"
+          onClick={(e) => {
+            if (e.target === e.currentTarget) setPendingDatacatSwitch(false);
+          }}
+        >
+          <div className="absolute inset-0 bg-black/60" onClick={() => setPendingDatacatSwitch(false)} />
+          <div
+            className="relative w-full max-w-md rounded-xl border border-[var(--border)] bg-[var(--card)] shadow-2xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-center justify-between border-b border-[var(--border)] px-5 py-3">
+              <h3 className="flex items-center gap-2 text-sm font-bold text-[var(--foreground)]">
+                <span className="text-amber-400">⚠️</span> DataCat is NSFW only
+              </h3>
+              <button
+                onClick={() => setPendingDatacatSwitch(false)}
+                className="rounded p-1 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+              >
+                <X size="1rem" />
+              </button>
+            </div>
+            <div className="flex flex-col gap-3 p-5 text-sm text-[var(--foreground)]">
+              <p>
+                Every character on DataCat is tagged NSFW upstream, so the NSFW filter is locked on for this provider.
+              </p>
+              <div className="mt-2 flex gap-2">
+                <button
+                  onClick={() => {
+                    setDatacatNsfwAcked(true);
+                    setPendingDatacatSwitch(false);
+                    performSwitch("datacat");
+                  }}
+                  className="flex-1 rounded-lg bg-pink-600 px-4 py-2 text-xs font-medium text-white transition-colors hover:bg-pink-500"
+                >
+                  Continue to DataCat
+                </button>
+                <button
+                  onClick={() => setPendingDatacatSwitch(false)}
+                  className="flex-1 rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-4 py-2 text-xs font-medium transition-colors hover:bg-[var(--accent)]"
+                >
+                  Don't continue to DataCat
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
       )}
     </div>
   );
@@ -1896,7 +2277,7 @@ function LoginModal({
   ctLoggedIn,
   loginLoading,
   onClose,
-  onPygLogin,
+  onPygSetToken,
   onPygLogout,
   onCtSetCookie,
   onCtLogout,
@@ -1907,15 +2288,15 @@ function LoginModal({
   ctLoggedIn: boolean;
   loginLoading: boolean;
   onClose: () => void;
-  onPygLogin: (u: string, p: string) => void;
+  onPygSetToken: (t: string) => void;
   onPygLogout: () => void;
   onCtSetCookie: (c: string) => void;
   onCtLogout: () => void;
 }) {
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
+  const [pygTokenInput, setPygTokenInput] = useState("");
   const [cookie, setCookie] = useState("");
   const [showHelp, setShowHelp] = useState(false);
+  const [showPygHelp, setShowPygHelp] = useState(false);
 
   const isPyg = sourceId === "pygmalion";
   const isCt = sourceId === "chartavern";
@@ -1961,10 +2342,10 @@ function LoginModal({
             <strong>Browsing and downloading public characters works without logging in!</strong>
           </div>
           <div className="rounded-lg border border-amber-500/20 bg-amber-500/5 px-3 py-2 text-xs text-[var(--foreground)]">
-            <span className="mr-1.5">{isPyg ? "🔑" : "🍪"}</span>
+            <span className="mr-1.5">🔑</span>
             <strong>Optional:</strong>{" "}
             {isPyg
-              ? "Log in to enable NSFW content, follow authors, and access your Following timeline."
+              ? "Paste your auth token to enable NSFW content and access authenticated character data."
               : "Paste your session cookies to see NSFW-tagged content."}
           </div>
 
@@ -1972,47 +2353,58 @@ function LoginModal({
           {isPyg ? (
             <div className="flex flex-col gap-3">
               <div>
-                <label className="mb-1 block text-xs text-[var(--muted-foreground)]">Email</label>
-                <input
-                  type="email"
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
+                <label className="mb-1 block text-xs text-[var(--muted-foreground)]">Auth Token</label>
+                <textarea
+                  value={pygTokenInput}
+                  onChange={(e) => setPygTokenInput(e.target.value)}
                   disabled={isLoggedIn || loginLoading}
-                  placeholder="your-email@example.com"
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter" && email && password) onPygLogin(email, password);
-                  }}
-                  className="w-full rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-sm outline-none transition-colors focus:border-[var(--primary)] disabled:opacity-50"
+                  placeholder="Paste your Pygmalion auth token here"
+                  rows={3}
+                  className="w-full resize-y rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 font-mono text-xs outline-none transition-colors focus:border-[var(--primary)] disabled:opacity-50"
                 />
               </div>
-              <div>
-                <label className="mb-1 block text-xs text-[var(--muted-foreground)]">Password</label>
-                <input
-                  type="password"
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  disabled={isLoggedIn || loginLoading}
-                  placeholder="Your Pygmalion password"
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter" && email && password) onPygLogin(email, password);
-                  }}
-                  className="w-full rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-sm outline-none transition-colors focus:border-[var(--primary)] disabled:opacity-50"
-                />
-              </div>
+              <details open={showPygHelp} onToggle={(e) => setShowPygHelp((e.target as HTMLDetailsElement).open)}>
+                <summary className="cursor-pointer text-xs font-medium text-blue-400 hover:underline">
+                  ▸ ❓ How to get your auth token
+                </summary>
+                <div className="mt-2 flex flex-col gap-1.5 rounded-lg bg-[var(--secondary)] p-3 text-[0.7rem] leading-relaxed text-[var(--muted-foreground)]">
+                  <p>
+                    1. Go to{" "}
+                    <a
+                      href="https://pygmalion.chat"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-blue-400 underline"
+                    >
+                      pygmalion.chat
+                    </a>{" "}
+                    and log in
+                  </p>
+                  <p>
+                    2. Open DevTools (F12) → <strong>Application</strong> tab → <strong>Local Storage</strong>
+                  </p>
+                  <p>
+                    3. Find the entry named <code className="rounded bg-[var(--accent)] px-1">authn</code>
+                  </p>
+                  <p>
+                    4. Copy its <strong>Value</strong> (a long string, ~705 characters) and paste it above
+                  </p>
+                </div>
+              </details>
               {isLoggedIn && (
                 <div className="flex items-center gap-1.5 text-xs text-emerald-400">
-                  <CheckCircle size="0.75rem" /> Authenticated — NSFW content enabled
+                  <CheckCircle size="0.75rem" /> Token active — NSFW content enabled
                 </div>
               )}
               <div className="flex items-center gap-2">
                 {!isLoggedIn ? (
                   <button
-                    onClick={() => onPygLogin(email, password)}
-                    disabled={loginLoading || !email || !password}
+                    onClick={() => onPygSetToken(pygTokenInput)}
+                    disabled={loginLoading || !pygTokenInput.trim()}
                     className="flex items-center gap-1.5 rounded-lg bg-emerald-600 px-4 py-2 text-xs font-medium text-white transition-colors hover:bg-emerald-500 disabled:opacity-50"
                   >
-                    {loginLoading ? <Loader2 size="0.75rem" className="animate-spin" /> : <LogIn size="0.75rem" />} Log
-                    In
+                    {loginLoading ? <Loader2 size="0.75rem" className="animate-spin" /> : <KeyRound size="0.75rem" />}{" "}
+                    Save & Connect
                   </button>
                 ) : (
                   <button

--- a/packages/client/src/components/bot-browser/BotBrowserView.tsx
+++ b/packages/client/src/components/bot-browser/BotBrowserView.tsx
@@ -478,12 +478,13 @@ const jannyProvider: ProviderConfig = {
         ],
       };
 
+      // NOTE: deliberately omitting credentials. JannyAI's MeiliSearch endpoint
+      // returns `Access-Control-Allow-Origin: *`, which the browser refuses to
+      // pair with `credentials: "include"` — that combination blocks the response
+      // entirely. cf_clearance won't ride along, but the upstream has historically
+      // let cross-origin requests with browser TLS + UA through anyway.
       const res = await fetch("https://search.jannyai.com/multi-search", {
         method: "POST",
-        // Cross-origin POST: required so the browser actually sends cf_clearance +
-        // any other jannyai.com cookies the user already has — that's what gets us
-        // past Cloudflare's bot challenge. Without this the workaround is a no-op.
-        credentials: "include",
         headers: {
           Accept: "*/*",
           "Content-Type": "application/json",

--- a/packages/server/src/routes/bot-browser-datacat.routes.ts
+++ b/packages/server/src/routes/bot-browser-datacat.routes.ts
@@ -204,7 +204,24 @@ export async function botBrowserDatacatRoutes(app: FastifyInstance) {
     const path = (req.params as Record<string, string>)["*"];
     if (!path) throw new Error("Missing avatar path");
 
-    const url = path.startsWith("http") ? path : `${DATACAT_IMAGE_BASE}${path}`;
+    // Whitelist the upstream avatar host. Without this, an absolute URL in `path`
+    // would let `/datacat/avatar/*` proxy to any address (SSRF — internal services,
+    // metadata endpoints, etc.).
+    let url: string;
+    if (path.startsWith("http")) {
+      let parsed: URL;
+      try {
+        parsed = new URL(path);
+      } catch {
+        return reply.status(400).send({ error: "Invalid avatar URL" });
+      }
+      if (parsed.protocol !== "https:" || parsed.hostname !== "ella.janitorai.com") {
+        return reply.status(400).send({ error: "Unsupported avatar host" });
+      }
+      url = parsed.toString();
+    } else {
+      url = `${DATACAT_IMAGE_BASE}${path}`;
+    }
 
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 15_000);

--- a/packages/server/src/routes/bot-browser-datacat.routes.ts
+++ b/packages/server/src/routes/bot-browser-datacat.routes.ts
@@ -1,0 +1,221 @@
+// ──────────────────────────────────────────────
+// Routes: Browser — DataCat provider
+// (Aggregator that surfaces JanitorAI characters via datacat.run REST API,
+// using JanitorAI's bot-avatar CDN for images.)
+// ──────────────────────────────────────────────
+import { randomUUID } from "node:crypto";
+import type { FastifyInstance } from "fastify";
+import { logger } from "../lib/logger.js";
+
+const DATACAT_API_BASE = "https://datacat.run";
+const DATACAT_IMAGE_BASE = "https://ella.janitorai.com/bot-avatars/";
+const DEFAULT_MIN_TOTAL_TOKENS = 889;
+const DC_USER_AGENT =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36";
+
+let dcSessionToken: string = "";
+let inFlightInit: Promise<string> | null = null;
+
+async function mintSessionToken(): Promise<string> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 20_000);
+  try {
+    const res = await fetch(`${DATACAT_API_BASE}/api/liberator/identify`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+        "User-Agent": DC_USER_AGENT,
+        Origin: DATACAT_API_BASE,
+        Referer: `${DATACAT_API_BASE}/`,
+      },
+      body: JSON.stringify({ deviceToken: randomUUID() }),
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new Error(`liberator/identify ${res.status}: ${text.slice(0, 200)}`);
+    }
+    const data = (await res.json()) as { success?: boolean; sessionToken?: string };
+    if (!data?.success || !data?.sessionToken) {
+      throw new Error("liberator/identify response missing sessionToken");
+    }
+    logger.info("[bot-browser] DataCat session minted");
+    return data.sessionToken;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function getSessionToken(): Promise<string> {
+  if (dcSessionToken) return dcSessionToken;
+  if (inFlightInit) return inFlightInit;
+  inFlightInit = mintSessionToken()
+    .then((t) => {
+      dcSessionToken = t;
+      inFlightInit = null;
+      return t;
+    })
+    .catch((err) => {
+      inFlightInit = null;
+      throw err;
+    });
+  return inFlightInit;
+}
+
+function dcHeaders(token: string): Record<string, string> {
+  return {
+    Accept: "application/json",
+    "User-Agent": DC_USER_AGENT,
+    Origin: DATACAT_API_BASE,
+    Referer: `${DATACAT_API_BASE}/`,
+    "X-Session-Token": token,
+  };
+}
+
+async function dcFetch(path: string): Promise<unknown> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 30_000);
+  try {
+    let token = await getSessionToken();
+    let res = await fetch(`${DATACAT_API_BASE}${path}`, {
+      headers: dcHeaders(token),
+      signal: controller.signal,
+    });
+    // Token may have expired — re-mint once and retry
+    if (res.status === 401) {
+      dcSessionToken = "";
+      token = await getSessionToken();
+      res = await fetch(`${DATACAT_API_BASE}${path}`, {
+        headers: dcHeaders(token),
+        signal: controller.signal,
+      });
+    }
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new Error(`Upstream ${res.status}: ${text.slice(0, 300)}`);
+    }
+    return res.json();
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function botBrowserDatacatRoutes(app: FastifyInstance) {
+  // ── Recent public browse / tag-filtered browse ──
+  app.get<{
+    Querystring: {
+      limit?: string;
+      offset?: string;
+      min_tokens?: string;
+      tagIds?: string;
+    };
+  }>("/datacat/recent", async (req) => {
+    const {
+      limit = "80",
+      offset = "0",
+      min_tokens = String(DEFAULT_MIN_TOTAL_TOKENS),
+      tagIds,
+    } = req.query;
+    const params = new URLSearchParams();
+    params.set("limit", limit);
+    params.set("offset", offset);
+    params.set("summary", "1");
+    params.set("minTotalTokens", min_tokens);
+    if (tagIds) {
+      const ids = tagIds
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean);
+      if (ids.length > 0) params.set("tagIds", ids.join(","));
+    }
+    return dcFetch(`/api/characters/recent-public?${params}`);
+  });
+
+  // ── Trending (24h + week buckets) ──
+  app.get<{
+    Querystring: {
+      sortBy?: string;
+      limit24?: string;
+      limitWeek?: string;
+    };
+  }>("/datacat/fresh", async (req) => {
+    const { sortBy = "score", limit24 = "80", limitWeek = "20" } = req.query;
+    const params = new URLSearchParams({ summary: "1", sortBy, limit24, limitWeek });
+    return dcFetch(`/api/characters/fresh?${params}`);
+  });
+
+  // ── Faceted tags ──
+  app.get<{
+    Querystring: {
+      min_tokens?: string;
+      activeTagIds?: string;
+    };
+  }>("/datacat/tags", async (req) => {
+    const { min_tokens = String(DEFAULT_MIN_TOTAL_TOKENS), activeTagIds } = req.query;
+    const params = new URLSearchParams();
+    params.set("mode", "recent");
+    params.set("minTotalTokens", min_tokens);
+    if (activeTagIds) {
+      const ids = activeTagIds
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean);
+      if (ids.length > 0) params.set("activeTagIds", ids.join(","));
+    }
+    return dcFetch(`/api/tags/faceted?${params}`);
+  });
+
+  // ── Character detail ──
+  app.get<{ Params: { id: string } }>("/datacat/character/:id", async (req) => {
+    const { id } = req.params;
+    if (!id) throw new Error("Missing character id");
+    return dcFetch(`/api/characters/${encodeURIComponent(id)}`);
+  });
+
+  // ── Character download (V2 card payload) ──
+  app.get<{ Params: { id: string } }>("/datacat/download/:id", async (req) => {
+    const { id } = req.params;
+    if (!id) throw new Error("Missing character id");
+    return dcFetch(`/api/characters/${encodeURIComponent(id)}/download?t=${Date.now()}`);
+  });
+
+  // ── Creator profile ──
+  app.get<{ Params: { id: string } }>("/datacat/creator/:id", async (req) => {
+    const { id } = req.params;
+    if (!id) throw new Error("Missing creator id");
+    return dcFetch(`/api/creators/${encodeURIComponent(id)}`);
+  });
+
+  // ── Characters by creator ──
+  app.get<{
+    Params: { id: string };
+    Querystring: { limit?: string; offset?: string; sortBy?: string };
+  }>("/datacat/creator/:id/characters", async (req) => {
+    const { id } = req.params;
+    if (!id) throw new Error("Missing creator id");
+    const { limit = "24", offset = "0", sortBy = "chat_count" } = req.query;
+    const params = new URLSearchParams({ limit, offset, sortBy });
+    return dcFetch(`/api/creators/${encodeURIComponent(id)}/characters?${params}`);
+  });
+
+  // ── Proxy DataCat avatar images (served from JanitorAI CDN) ──
+  app.get<{ Params: { "*": string } }>("/datacat/avatar/*", async (req, reply) => {
+    const path = (req.params as Record<string, string>)["*"];
+    if (!path) throw new Error("Missing avatar path");
+
+    const url = path.startsWith("http") ? path : `${DATACAT_IMAGE_BASE}${path}`;
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 15_000);
+    try {
+      const res = await fetch(url, { signal: controller.signal });
+      if (!res.ok) return reply.status(404).send({ error: "Avatar not found" });
+      const buf = Buffer.from(await res.arrayBuffer());
+      const ct = res.headers.get("content-type") || "image/jpeg";
+      return reply.header("Content-Type", ct).header("Cache-Control", "public, max-age=86400").send(buf);
+    } finally {
+      clearTimeout(timeout);
+    }
+  });
+}

--- a/packages/server/src/routes/bot-browser-janny.routes.ts
+++ b/packages/server/src/routes/bot-browser-janny.routes.ts
@@ -31,6 +31,12 @@ function jannySearchHeaders(token: string): Record<string, string> {
 }
 
 let cachedToken: string = "";
+// When the scrape fails we still hand back JANNY_FALLBACK_TOKEN so callers don't
+// stall, but we mark that fact and only keep that result for a short TTL so a
+// transient scrape failure can't poison the cache until process restart.
+let cachedTokenIsFallback = false;
+let cachedTokenAt = 0;
+const FALLBACK_TOKEN_TTL_MS = 60_000;
 let inFlightTokenFetch: Promise<string> | null = null;
 
 async function fetchJannyPage(path: string): Promise<string | null> {
@@ -69,10 +75,10 @@ async function fetchJannyPage(path: string): Promise<string | null> {
   return null;
 }
 
-async function scrapeToken(): Promise<string> {
+async function scrapeToken(): Promise<{ token: string; isFallback: boolean }> {
   try {
     const html = await fetchJannyPage("/characters/search");
-    if (!html) return JANNY_FALLBACK_TOKEN;
+    if (!html) return { token: JANNY_FALLBACK_TOKEN, isFallback: true };
 
     // Resolve client-config bundle path: either inlined directly in the page,
     // or imported by the SearchPage chunk (Janny's bundler split changed in 2026).
@@ -95,22 +101,32 @@ async function scrapeToken(): Promise<string> {
       const cfgJs = await fetchJannyPage(configPath);
       if (cfgJs) {
         const tokenMatch = cfgJs.match(/"([a-f0-9]{64})"/);
-        if (tokenMatch?.[1]) return tokenMatch[1];
+        if (tokenMatch?.[1]) return { token: tokenMatch[1], isFallback: false };
       }
     }
   } catch {
     // fall through to fallback
   }
-  return JANNY_FALLBACK_TOKEN;
+  return { token: JANNY_FALLBACK_TOKEN, isFallback: true };
 }
 
 async function getSearchToken(): Promise<string> {
-  if (cachedToken) return cachedToken;
+  // Honor a cached fresh-scrape result indefinitely; honor a cached fallback
+  // only for FALLBACK_TOKEN_TTL_MS so a transient scrape failure can't poison
+  // /janny/token until process restart.
+  if (cachedToken) {
+    if (!cachedTokenIsFallback || Date.now() - cachedTokenAt < FALLBACK_TOKEN_TTL_MS) {
+      return cachedToken;
+    }
+    cachedToken = "";
+  }
   if (inFlightTokenFetch) return inFlightTokenFetch;
-  inFlightTokenFetch = scrapeToken().then((t) => {
-    cachedToken = t;
+  inFlightTokenFetch = scrapeToken().then(({ token, isFallback }) => {
+    cachedToken = token;
+    cachedTokenIsFallback = isFallback;
+    cachedTokenAt = Date.now();
     inFlightTokenFetch = null;
-    return t;
+    return token;
   });
   return inFlightTokenFetch;
 }

--- a/packages/server/src/routes/bot-browser-janny.routes.ts
+++ b/packages/server/src/routes/bot-browser-janny.routes.ts
@@ -31,17 +31,22 @@ function jannySearchHeaders(token: string): Record<string, string> {
 }
 
 let cachedToken: string = "";
-// When the scrape fails we still hand back JANNY_FALLBACK_TOKEN so callers don't
-// stall, but we mark that fact and only keep that result for a short TTL so a
-// transient scrape failure can't poison the cache until process restart.
+// Fresh scraped tokens get a 5-minute TTL; fallback tokens get 1 minute. Both
+// expire so that if Janny rotates the MeiliSearch token (or our scrape was a
+// transient miss), the next request re-scrapes. The client can also force-busts
+// via `GET /janny/token?force=1` after seeing a 401/403 from MeiliSearch.
 let cachedTokenIsFallback = false;
 let cachedTokenAt = 0;
 const FALLBACK_TOKEN_TTL_MS = 60_000;
+const SCRAPED_TOKEN_TTL_MS = 5 * 60_000;
 let inFlightTokenFetch: Promise<string> | null = null;
 
 async function fetchJannyPage(path: string): Promise<string | null> {
   // Direct fetch first; fall back to corsproxy.io when Cloudflare blocks our IP.
   // Each fetch gets its own 15s kill-switch so a hung upstream can't pin a request open.
+  // Note: `return await` (not bare `return`) so the abort timeout stays armed
+  // until body consumption finishes — otherwise an upstream that sends headers
+  // then stalls the body would slip past the kill-switch.
   const directController = new AbortController();
   const directTimeout = setTimeout(() => directController.abort(), 15_000);
   try {
@@ -49,7 +54,7 @@ async function fetchJannyPage(path: string): Promise<string | null> {
       headers: { "User-Agent": BROWSER_UA, Accept: "text/html,application/xhtml+xml,*/*" },
       signal: directController.signal,
     });
-    if (direct.ok) return direct.text();
+    if (direct.ok) return await direct.text();
   } catch {
     /* fall through */
   } finally {
@@ -66,7 +71,7 @@ async function fetchJannyPage(path: string): Promise<string | null> {
         signal: proxyController.signal,
       },
     );
-    if (proxied.ok) return proxied.text();
+    if (proxied.ok) return await proxied.text();
   } catch {
     /* fall through */
   } finally {
@@ -110,15 +115,18 @@ async function scrapeToken(): Promise<{ token: string; isFallback: boolean }> {
   return { token: JANNY_FALLBACK_TOKEN, isFallback: true };
 }
 
-async function getSearchToken(): Promise<string> {
-  // Honor a cached fresh-scrape result indefinitely; honor a cached fallback
-  // only for FALLBACK_TOKEN_TTL_MS so a transient scrape failure can't poison
-  // /janny/token until process restart.
-  if (cachedToken) {
-    if (!cachedTokenIsFallback || Date.now() - cachedTokenAt < FALLBACK_TOKEN_TTL_MS) {
-      return cachedToken;
-    }
+async function getSearchToken(force = false): Promise<string> {
+  // Both fresh and fallback caches get a TTL so a rotated upstream token can't
+  // pin /janny/token to a dead value forever. `force` lets the client trigger
+  // an immediate re-scrape after it sees a 401/403 from MeiliSearch.
+  if (cachedToken && !force) {
+    const ttlMs = cachedTokenIsFallback ? FALLBACK_TOKEN_TTL_MS : SCRAPED_TOKEN_TTL_MS;
+    if (Date.now() - cachedTokenAt < ttlMs) return cachedToken;
+  }
+  if (force || cachedToken) {
     cachedToken = "";
+    cachedTokenIsFallback = false;
+    cachedTokenAt = 0;
   }
   if (inFlightTokenFetch) return inFlightTokenFetch;
   inFlightTokenFetch = scrapeToken().then(({ token, isFallback }) => {
@@ -182,8 +190,11 @@ export async function botBrowserJannyRoutes(app: FastifyInstance) {
   // (Server-side search.jannyai.com calls are blocked by Cloudflare. The upstream
   // SillyTavern extension works because the request comes from the user's browser,
   // which carries cf_clearance and a real TLS fingerprint. We do the same.)
-  app.get("/janny/token", async () => {
-    const token = await getSearchToken();
+  // `?force=1` busts the cache and re-scrapes — the client uses this after a
+  // 401/403 from MeiliSearch so a rotated upstream token can be recovered.
+  app.get<{ Querystring: { force?: string } }>("/janny/token", async (req) => {
+    const force = req.query.force === "1" || req.query.force === "true";
+    const token = await getSearchToken(force);
     return { token };
   });
 

--- a/packages/server/src/routes/bot-browser-janny.routes.ts
+++ b/packages/server/src/routes/bot-browser-janny.routes.ts
@@ -35,22 +35,36 @@ let inFlightTokenFetch: Promise<string> | null = null;
 
 async function fetchJannyPage(path: string): Promise<string | null> {
   // Direct fetch first; fall back to corsproxy.io when Cloudflare blocks our IP.
+  // Each fetch gets its own 15s kill-switch so a hung upstream can't pin a request open.
+  const directController = new AbortController();
+  const directTimeout = setTimeout(() => directController.abort(), 15_000);
   try {
     const direct = await fetch(`${JANNY_SITE_BASE}${path}`, {
       headers: { "User-Agent": BROWSER_UA, Accept: "text/html,application/xhtml+xml,*/*" },
+      signal: directController.signal,
     });
     if (direct.ok) return direct.text();
   } catch {
     /* fall through */
+  } finally {
+    clearTimeout(directTimeout);
   }
+
+  const proxyController = new AbortController();
+  const proxyTimeout = setTimeout(() => proxyController.abort(), 15_000);
   try {
     const proxied = await fetch(
       `https://corsproxy.io/?url=${encodeURIComponent(`${JANNY_SITE_BASE}${path}`)}`,
-      { headers: { Accept: "text/html,application/xhtml+xml,*/*" } },
+      {
+        headers: { Accept: "text/html,application/xhtml+xml,*/*" },
+        signal: proxyController.signal,
+      },
     );
     if (proxied.ok) return proxied.text();
   } catch {
     /* fall through */
+  } finally {
+    clearTimeout(proxyTimeout);
   }
   return null;
 }
@@ -131,6 +145,11 @@ async function backfillFromSearch(name: string, charId: string): Promise<JannyMe
       body: JSON.stringify(body),
       signal: controller.signal,
     });
+    if (res.status === 401 || res.status === 403) {
+      // Mirror the search-route behavior so the next call re-scrapes a fresh token.
+      cachedToken = "";
+      return null;
+    }
     if (!res.ok) return null;
     const data = (await res.json()) as { results?: Array<{ hits?: JannyMeiliHit[] }> };
     const hits = data?.results?.[0]?.hits || [];

--- a/packages/server/src/routes/bot-browser-janny.routes.ts
+++ b/packages/server/src/routes/bot-browser-janny.routes.ts
@@ -8,34 +8,151 @@ const JANNY_IMAGE_BASE = "https://image.jannyai.com/bot-avatars/";
 const JANNY_SITE_BASE = "https://jannyai.com";
 const JANNY_FALLBACK_TOKEN = "88a6463b66e04fb07ba87ee3db06af337f492ce511d93df6e2d2968cb2ff2b30";
 
-let cachedToken: string = "";
+const BROWSER_UA =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36";
 
-async function getSearchToken(): Promise<string> {
-  if (cachedToken) return cachedToken;
+function jannySearchHeaders(token: string): Record<string, string> {
+  return {
+    Accept: "*/*",
+    "Accept-Language": "en-US,en;q=0.9",
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${token}`,
+    Origin: JANNY_SITE_BASE,
+    Referer: `${JANNY_SITE_BASE}/`,
+    "User-Agent": BROWSER_UA,
+    "x-meilisearch-client": "Meilisearch instant-meilisearch (v0.19.0) ; Meilisearch JavaScript (v0.41.0)",
+    "Sec-Fetch-Site": "same-site",
+    "Sec-Fetch-Mode": "cors",
+    "Sec-Fetch-Dest": "empty",
+    "sec-ch-ua": '"Chromium";v="131", "Not_A Brand";v="24", "Google Chrome";v="131"',
+    "sec-ch-ua-mobile": "?0",
+    "sec-ch-ua-platform": '"Windows"',
+  };
+}
+
+let cachedToken: string = "";
+let inFlightTokenFetch: Promise<string> | null = null;
+
+async function fetchJannyPage(path: string): Promise<string | null> {
+  // Direct fetch first; fall back to corsproxy.io when Cloudflare blocks our IP.
   try {
-    const pageResp = await fetch(`${JANNY_SITE_BASE}/characters/search`);
-    const html = await pageResp.text();
-    const configMatch = html.match(/client-config\.[a-zA-Z0-9_-]+\.js/);
-    if (configMatch) {
-      const cfgResp = await fetch(`${JANNY_SITE_BASE}/_astro/${configMatch[0]}`);
-      if (cfgResp.ok) {
-        const cfgJs = await cfgResp.text();
-        const tokenMatch = cfgJs.match(/"([a-f0-9]{64})"/);
-        if (tokenMatch?.[1]) {
-          cachedToken = tokenMatch[1];
-          return cachedToken;
+    const direct = await fetch(`${JANNY_SITE_BASE}${path}`, {
+      headers: { "User-Agent": BROWSER_UA, Accept: "text/html,application/xhtml+xml,*/*" },
+    });
+    if (direct.ok) return direct.text();
+  } catch {
+    /* fall through */
+  }
+  try {
+    const proxied = await fetch(
+      `https://corsproxy.io/?url=${encodeURIComponent(`${JANNY_SITE_BASE}${path}`)}`,
+      { headers: { Accept: "text/html,application/xhtml+xml,*/*" } },
+    );
+    if (proxied.ok) return proxied.text();
+  } catch {
+    /* fall through */
+  }
+  return null;
+}
+
+async function scrapeToken(): Promise<string> {
+  try {
+    const html = await fetchJannyPage("/characters/search");
+    if (!html) return JANNY_FALLBACK_TOKEN;
+
+    // Resolve client-config bundle path: either inlined directly in the page,
+    // or imported by the SearchPage chunk (Janny's bundler split changed in 2026).
+    let configPath: string | null = null;
+    const directMatch = html.match(/client-config\.[a-zA-Z0-9_-]+\.js/);
+    if (directMatch) {
+      configPath = `/_astro/${directMatch[0]}`;
+    } else {
+      const spMatch = html.match(/SearchPage\.[a-zA-Z0-9_-]+\.js/);
+      if (spMatch) {
+        const spJs = await fetchJannyPage(`/_astro/${spMatch[0]}`);
+        if (spJs) {
+          const impMatch = spJs.match(/client-config\.[a-zA-Z0-9_-]+\.js/);
+          if (impMatch) configPath = `/_astro/${impMatch[0]}`;
         }
+      }
+    }
+
+    if (configPath) {
+      const cfgJs = await fetchJannyPage(configPath);
+      if (cfgJs) {
+        const tokenMatch = cfgJs.match(/"([a-f0-9]{64})"/);
+        if (tokenMatch?.[1]) return tokenMatch[1];
       }
     }
   } catch {
     // fall through to fallback
   }
-  cachedToken = JANNY_FALLBACK_TOKEN;
-  return cachedToken;
+  return JANNY_FALLBACK_TOKEN;
+}
+
+async function getSearchToken(): Promise<string> {
+  if (cachedToken) return cachedToken;
+  if (inFlightTokenFetch) return inFlightTokenFetch;
+  inFlightTokenFetch = scrapeToken().then((t) => {
+    cachedToken = t;
+    inFlightTokenFetch = null;
+    return t;
+  });
+  return inFlightTokenFetch;
+}
+
+interface JannyMeiliHit {
+  id?: string;
+  name?: string;
+  tagIds?: number[];
+  creatorId?: string;
+  creatorUsername?: string;
+}
+
+async function backfillFromSearch(name: string, charId: string): Promise<JannyMeiliHit | null> {
+  if (!name) return null;
+  const token = await getSearchToken();
+  const body = {
+    queries: [
+      {
+        indexUid: "janny-characters",
+        q: name,
+        hitsPerPage: 20,
+        page: 1,
+      },
+    ],
+  };
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 15_000);
+  try {
+    const res = await fetch(JANNY_SEARCH_URL, {
+      method: "POST",
+      headers: jannySearchHeaders(token),
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+    if (!res.ok) return null;
+    const data = (await res.json()) as { results?: Array<{ hits?: JannyMeiliHit[] }> };
+    const hits = data?.results?.[0]?.hits || [];
+    return hits.find((h) => h.id === charId) ?? null;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
 }
 
 export async function botBrowserJannyRoutes(app: FastifyInstance) {
-  // ── Search characters on JannyAI via MeiliSearch ──
+  // ── Expose the scraped MeiliSearch token so the browser can POST search directly ──
+  // (Server-side search.jannyai.com calls are blocked by Cloudflare. The upstream
+  // SillyTavern extension works because the request comes from the user's browser,
+  // which carries cf_clearance and a real TLS fingerprint. We do the same.)
+  app.get("/janny/token", async () => {
+    const token = await getSearchToken();
+    return { token };
+  });
+
+  // ── Search characters on JannyAI via MeiliSearch (server-side fallback only) ──
   app.get<{
     Querystring: {
       q?: string;
@@ -113,16 +230,20 @@ export async function botBrowserJannyRoutes(app: FastifyInstance) {
     try {
       const res = await fetch(JANNY_SEARCH_URL, {
         method: "POST",
-        headers: {
-          Accept: "*/*",
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
-          Origin: JANNY_SITE_BASE,
-          Referer: `${JANNY_SITE_BASE}/`,
-        },
+        headers: jannySearchHeaders(token),
         body: JSON.stringify(body),
         signal: controller.signal,
       });
+      if (res.status === 401 || res.status === 403) {
+        // Token may have rotated — bust the cache so the next call re-scrapes
+        cachedToken = "";
+        const cfMitigated = res.headers.get("cf-mitigated");
+        if (cfMitigated || res.status === 403) {
+          throw new Error(
+            "JannyAI is currently blocking server-to-server requests (Cloudflare bot mitigation). Try again later or use a different provider.",
+          );
+        }
+      }
       if (!res.ok) throw new Error(`JannyAI search error ${res.status}`);
       return res.json();
     } finally {
@@ -158,7 +279,13 @@ export async function botBrowserJannyRoutes(app: FastifyInstance) {
         });
         if (directRes.ok) {
           html = await directRes.text();
-          if (html.includes("Just a moment") || html.includes("cf-challenge") || !html.includes("astro-island")) {
+          if (
+            html.length < 1000 ||
+            html.includes("Just a moment") ||
+            html.includes("cf-challenge") ||
+            html.includes("challenge-platform") ||
+            !html.includes("astro-island")
+          ) {
             html = "";
           }
         }
@@ -178,7 +305,13 @@ export async function botBrowserJannyRoutes(app: FastifyInstance) {
           });
           if (proxyRes.ok) {
             html = await proxyRes.text();
-            if (html.includes("Just a moment") || html.includes("cf-challenge") || !html.includes("astro-island")) {
+            if (
+              html.length < 1000 ||
+              html.includes("Just a moment") ||
+              html.includes("cf-challenge") ||
+              html.includes("challenge-platform") ||
+              !html.includes("astro-island")
+            ) {
               html = "";
             }
           }
@@ -236,6 +369,16 @@ export async function botBrowserJannyRoutes(app: FastifyInstance) {
       const creatorMatch = html.match(/Creator:\s*(?:<\/[^>]+>\s*)?<a[^>]*>@?([^<]+)<\/a>/);
       if (creatorMatch) {
         character.creatorUsername = creatorMatch[1]!.trim();
+      }
+
+      // Backfill missing tagIds/creatorId from MeiliSearch — page scrape often lacks these
+      const tagIds = character.tagIds as number[] | undefined;
+      if (!tagIds?.length || !character.creatorId) {
+        const hit = await backfillFromSearch(typeof character.name === "string" ? character.name : "", charId);
+        if (hit) {
+          if (!tagIds?.length && hit.tagIds?.length) character.tagIds = hit.tagIds;
+          if (!character.creatorId && hit.creatorId) character.creatorId = hit.creatorId;
+        }
       }
 
       return {

--- a/packages/server/src/routes/bot-browser-pygmalion.routes.ts
+++ b/packages/server/src/routes/bot-browser-pygmalion.routes.ts
@@ -2,9 +2,9 @@
 // Routes: Browser — Pygmalion provider
 // ──────────────────────────────────────────────
 import type { FastifyInstance } from "fastify";
+import { logger } from "../lib/logger.js";
 
 const PYGMALION_API_BASE = "https://server.pygmalion.chat/galatea.v1.PublicCharacterService";
-const PYGMALION_AUTH_URL = "https://auth.pygmalion.chat/session";
 const PYGMALION_ORIGIN = "https://pygmalion.chat";
 const PYGMALION_ASSETS_BASE = "https://assets.pygmalion.chat";
 
@@ -12,62 +12,72 @@ const PYGMALION_ASSETS_BASE = "https://assets.pygmalion.chat";
 let pygToken: string = "";
 
 export async function botBrowserPygmalionRoutes(app: FastifyInstance) {
-  // ── Login to Pygmalion via auth proxy ──
-  app.post<{
-    Body: { username: string; password: string };
-  }>("/pygmalion/login", async (req, reply) => {
-    const { username, password } = req.body ?? {};
-    if (!username || !password) {
-      return reply.status(400).send({ error: "username and password are required" });
-    }
-    if (
-      typeof username !== "string" ||
-      typeof password !== "string" ||
-      username.length > 256 ||
-      password.length > 256
-    ) {
-      return reply.status(400).send({ error: "Invalid credentials format" });
+  // ── Store token directly (user pastes their auth token) ──
+  app.post<{ Body: { token: string } }>("/pygmalion/set-token", async (req, reply) => {
+    const { token } = req.body ?? {};
+    if (!token || typeof token !== "string" || !token.trim()) {
+      return reply.status(400).send({ error: "token string is required" });
     }
 
-    const body = new URLSearchParams({ username, password }).toString();
+    let value = token.trim();
+
+    // Normalize: strip "Bearer " prefix if pasted with it
+    if (value.toLowerCase().startsWith("bearer ")) {
+      value = value.slice("bearer ".length).trim();
+    }
+
+    if (value.length > 8192 || value.includes(" ") || value.includes("\n")) {
+      return reply.status(400).send({ error: "Invalid token value. Paste only the token string." });
+    }
+
+    pygToken = value;
+    logger.info("[bot-browser] Pygmalion token stored");
+    return { ok: true };
+  });
+
+  // ── Validate stored token by making a test authenticated search ──
+  app.get("/pygmalion/validate", async () => {
+    if (!pygToken) {
+      return { valid: false, reason: "no token stored" };
+    }
 
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 30_000);
+    const timeout = setTimeout(() => controller.abort(), 15_000);
     try {
-      const res = await fetch(PYGMALION_AUTH_URL, {
+      const res = await fetch(`${PYGMALION_API_BASE}/CharacterSearch`, {
         method: "POST",
         headers: {
-          "Content-Type": "application/x-www-form-urlencoded",
+          "Content-Type": "application/json",
+          Accept: "application/json",
+          Authorization: `Bearer ${pygToken}`,
           Origin: PYGMALION_ORIGIN,
           Referer: `${PYGMALION_ORIGIN}/`,
         },
-        body,
+        body: JSON.stringify({
+          query: "",
+          orderBy: "downloads",
+          orderDescending: true,
+          pageSize: 1,
+          page: 0,
+          includeSensitive: true,
+        }),
         signal: controller.signal,
       });
 
-      const text = await res.text();
-
       if (res.ok) {
-        // Try to extract token from response
-        try {
-          const data = JSON.parse(text);
-          if (data?.token || data?.idToken || data?.access_token) {
-            pygToken = data.token || data.idToken || data.access_token;
-          }
-        } catch {
-          // Response might be the token itself
-          if (text.length > 20 && text.length < 4096 && !text.includes("<")) {
-            pygToken = text.trim();
-          }
-        }
+        logger.info("[bot-browser] Pygmalion token validated");
+        return { valid: true };
       }
 
-      return reply
-        .status(res.status)
-        .header("Content-Type", res.headers.get("content-type") || "application/json")
-        .send(text);
+      if (res.status === 401 || res.status === 403) {
+        pygToken = "";
+        return { valid: false, reason: "Token rejected (expired or invalid)" };
+      }
+
+      return { valid: false, reason: `HTTP ${res.status}` };
     } catch (err) {
-      return reply.status(502).send({ error: "Failed to reach Pygmalion auth server" });
+      const msg = err instanceof Error ? err.message : "Unknown error";
+      return { valid: false, reason: msg };
     } finally {
       clearTimeout(timeout);
     }
@@ -76,22 +86,13 @@ export async function botBrowserPygmalionRoutes(app: FastifyInstance) {
   // ── Logout (clear stored token) ──
   app.post("/pygmalion/logout", async () => {
     pygToken = "";
+    logger.info("[bot-browser] Pygmalion token cleared");
     return { ok: true };
   });
 
   // ── Check session status ──
   app.get("/pygmalion/session", async () => {
     return { active: !!pygToken, hasToken: !!pygToken };
-  });
-
-  // ── Store token directly (from client after login response parsing) ──
-  app.post<{ Body: { token: string } }>("/pygmalion/set-token", async (req, reply) => {
-    const { token } = req.body ?? {};
-    if (!token || typeof token !== "string" || token.length > 8192) {
-      return reply.status(400).send({ error: "Invalid token" });
-    }
-    pygToken = token.trim();
-    return { ok: true };
   });
 
   // ── Search characters on Pygmalion via Connect RPC ──

--- a/packages/server/src/routes/index.ts
+++ b/packages/server/src/routes/index.ts
@@ -36,6 +36,7 @@ import { botBrowserJannyRoutes } from "./bot-browser-janny.routes.js";
 import { botBrowserChartavernRoutes } from "./bot-browser-chartavern.routes.js";
 import { botBrowserPygmalionRoutes } from "./bot-browser-pygmalion.routes.js";
 import { botBrowserWyvernRoutes } from "./bot-browser-wyvern.routes.js";
+import { botBrowserDatacatRoutes } from "./bot-browser-datacat.routes.js";
 import { chatFoldersRoutes } from "./chat-folders.routes.js";
 import { chatPresetsRoutes } from "./chat-presets.routes.js";
 import { updatesRoutes } from "./updates.routes.js";
@@ -83,6 +84,7 @@ export async function registerRoutes(app: FastifyInstance) {
   await app.register(botBrowserChartavernRoutes, { prefix: "/api/bot-browser" });
   await app.register(botBrowserPygmalionRoutes, { prefix: "/api/bot-browser" });
   await app.register(botBrowserWyvernRoutes, { prefix: "/api/bot-browser" });
+  await app.register(botBrowserDatacatRoutes, { prefix: "/api/bot-browser" });
   await app.register(updatesRoutes, { prefix: "/api/updates" });
   await app.register(themesRoutes, { prefix: "/api/themes" });
   await app.register(appSettingsRoutes, { prefix: "/api/app-settings" });


### PR DESCRIPTION
## Summary

Upgrade the bot browser across three providers and add a fourth.

### Pygmalion — token-only login
- Remove the username/password proxy login. The browser already exposes the
  auth token in Local Storage, so the user pastes that directly.
- New `POST /pygmalion/set-token` accepts the pasted token (strips a leading
  `Bearer ` prefix) and `GET /pygmalion/validate` confirms it via an
  authenticated `CharacterSearch`. Auto-clears the token on 401/403.
- Help text in the login modal walks users to DevTools → Application →
  Local Storage → `authn` (~705-character string).

### JannyAI — work around Cloudflare, recover lost data
- The MeiliSearch POST is now made from the browser (matching how every
  working JannyAI client does it) so the user's `cf_clearance` cookie and
  real TLS fingerprint clear Cloudflare's bot challenge. The server still
  scrapes the public token and exposes it via `GET /janny/token`.
- Token scraper now follows the `SearchPage.<hash>.js` chunk to find
  `client-config.<hash>.js` (the bundle layout changed). Page-scrape
  fallback through corsproxy.io for resilience when the local IP is blocked.
- Cloudflare detection: added `challenge-platform` marker + a min-length
  sanity check on the character page scrape. Tag IDs / creator IDs missing
  from the page scrape are now back-filled from MeiliSearch.
- Custom include tags (free-form names not in JannyAI's known tag map) are
  applied client-side against each hit's resolved tag names, instead of
  being silently dropped.
- When client-side filters (excludeTags / custom includeTags) thin a page,
  auto-fetch up to 3 additional pages and concat to keep the grid full.

### DataCat — new provider
- Anonymous session bootstrap via `POST /api/liberator/identify`
  (random `deviceToken`); session token cached in memory and replayed in
  `X-Session-Token` on every call. Auto re-mints once on 401.
- Two sort options: **🔍 Relevance** (default, calls `/recent-public`,
  supports tag filtering) and **🔥 Fresh** (`/fresh` 24h trending).
- Tag panel uses DataCat's faceted tag list. The endpoint returns ~28k
  tags; the panel renders only the top 150 by character count to keep the
  UI snappy. The full id↔name map is still cached so card-level tags and
  long-tail typed-in tag names still resolve.
- DataCat is NSFW-only upstream — every character is tagged NSFW. The NSFW
  toggle is hidden, the filter is force-on, and a confirmation modal warns
  before the first switch (Continue / Don't continue). Tooltip explains
  "DataCat is NSFW-only".
- Avatar proxy routes through `https://ella.janitorai.com/bot-avatars/`
  (DataCat's CDN).

### Misc
- Wyvern-specific "Use 'Popular NSFW' sort for NSFW content" hint and
  toast are scoped to `sourceId === "wyvern"` so other providers without
  an NSFW toggle don't inherit the message.

## Test plan

- [x] Pygmalion: paste auth token from `pygmalion.chat` Local Storage
      (`authn`); confirm "Token active — NSFW content enabled" appears,
      NSFW results load. Logout clears the token. Bad token surfaces a
      validation error.
- [x] JannyAI: search returns results in the browser (server-side route
      stays a fallback). Custom typed tag like "vampire" filters as
      expected. Excluded tag thinning still fills a page via auto-fetch.
- [x] JannyAI character detail: opens via corsproxy.io fallback when the
      direct fetch is Cloudflare-blocked.
- [x] DataCat: switch to DataCat shows the NSFW warning modal once;
      "Continue" loads the provider, "Don't continue" closes the modal
      and stays on the previous source. Relevance + Fresh both load.
      Tag filtering by top tags works. Tag panel doesn't lag the browser.
- [x] Wyvern unchanged: "Popular NSFW" hint and toggle behavior identical.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DataCat provider added: top-tag preload, tag-driven searching, NSFW gating warning, and enforced NSFW mode
  * Pygmalion switched to token-based setup with token entry and validation in the login UI
  * Provider-specific page sizes and smarter multi-source searching with automatic extra-page fetches
  * UI stat icon support expanded to include hash imagery

* **Bug Fixes**
  * More reliable detail fetching and clearer error handling with improved fallback behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->