### PR TITLE
fix(chat-input): enable send button immediately after branching

### DIFF
--- a/packages/client/src/components/chat/ChatInput.tsx
+++ b/packages/client/src/components/chat/ChatInput.tsx
@@ -136,6 +136,19 @@ export const ChatInput = memo(function ChatInput({
   // Read directly from the cache to avoid creating a useQuery observer that
   // conflicts with the useInfiniteQuery observer in useChatMessages (mixing
   // useQuery and useInfiniteQuery on the same query key corrupts query state).
+  // Subscribe to cache updates for the active chat so the send button enables
+  // as soon as messages land (e.g. right after branching) without needing the
+  // user to type to trigger a re-render.
+  const [, bumpMessagesTick] = useState(0);
+  useEffect(() => {
+    if (!activeChatId) return;
+    const targetKey = JSON.stringify(chatKeys.messages(activeChatId));
+    return qc.getQueryCache().subscribe((event) => {
+      if (JSON.stringify(event.query.queryKey) === targetKey) {
+        bumpMessagesTick((n) => n + 1);
+      }
+    });
+  }, [activeChatId, qc]);
   const messagesData = qc.getQueryData<InfiniteData<Message[]>>(chatKeys.messages(activeChatId ?? ""));
   const lastMessageRole = useMemo(() => {
     const firstPage = messagesData?.pages?.[0];


### PR DESCRIPTION
## Summary

Closes #259.

After creating a new branch, the send button stayed disabled until the user typed at least one character (then deleted it). This was a regression from prior versions where you could branch and immediately click send to prompt the LLM to continue.

### Root cause

`ChatInput.tsx` derives `canRetry` / `canContinue` from `lastMessageRole`, which it reads off the React Query cache via `qc.getQueryData(chatKeys.messages(activeChatId))`. That call reads the cache once per render but does **not** subscribe to it — so when the new branch's messages finished loading, no re-render fired, and the button stayed in its disabled state. Typing produced a re-render, which re-read the cache and finally surfaced the new `lastMessageRole`.

The pre-existing comment explicitly forbids using `useQuery` here because mixing a `useQuery` observer with the `useInfiniteQuery` observer in `useChatMessages` on the same key corrupts query state.

### Fix

Subscribe to the React Query cache for the active chat's messages key and bump a render counter when it updates. This keeps `lastMessageRole` reactive without introducing a conflicting observer.

```tsx
const [, bumpMessagesTick] = useState(0);
useEffect(() => {
  if (!activeChatId) return;
  const targetKey = JSON.stringify(chatKeys.messages(activeChatId));
  return qc.getQueryCache().subscribe((event) => {
    if (JSON.stringify(event.query.queryKey) === targetKey) {
      bumpMessagesTick((n) => n + 1);
    }
  });
}, [activeChatId, qc]);
```

## Test plan

- [ ] Manually verify in browser: create a chat, branch it from an assistant message in roleplay mode, click send without typing — LLM should continue.
- [ ] Manually verify in browser: branch from a user message — send should trigger retry without typing.
- [ ] Manually verify in browser: switch between chats — drafts still restore and send-button state still matches each chat.
- [ ] Manually verify in browser: typing + sending a normal message still works.
- [ ] `pnpm check` passes (TS + ESLint, no new warnings introduced by this change).

## Notes

- No linked feature request beyond issue #259, which is the bug report itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat input responsiveness—the send button and related controls now update immediately when new messages arrive, without requiring user interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->