### PR TITLE
fix(chat-bg): make Remove background actually stick across switches

### DIFF
--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -374,27 +374,43 @@ export function ChatArea() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [chat?.id, msgPageCount]);
 
-  // Restore per-chat background from metadata when switching chats.
-  // If the new chat has a saved background, apply it; otherwise keep the current
-  // background so newly-created chats don't flash to black.
+  // Sync chat background from metadata when switching chats. Set the UI store
+  // to whatever the chat's metadata says — including null. The previous version
+  // only set on truthy values, leaving the global chatBackground stale when
+  // switching to a chat whose metadata has been cleared, which made a removed
+  // background re-appear after a chat switch round-trip.
   useEffect(() => {
-    const bg = chatMeta.background as string | undefined;
-    if (bg) {
-      useUIStore.getState().setChatBackground(`/api/backgrounds/file/${encodeURIComponent(bg)}`);
-    }
+    if (!chat?.id) return;
+    const bg = chatMeta.background as string | null | undefined;
+    useUIStore
+      .getState()
+      .setChatBackground(bg ? `/api/backgrounds/file/${encodeURIComponent(bg)}` : null);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [chat?.id]);
 
   // Persist background choice to chat metadata so it survives page refresh.
   // Catches all sources: manual picker, background agent, scene commands, slash commands.
-  // Only persist non-null backgrounds — never write null to metadata (avoids wiping
-  // the user's background when opening a new chat that hasn't had one set yet).
+  // When the user clears the background, we must persist null so the removal
+  // sticks across chat switches; otherwise the restore effect re-applies the
+  // stale saved background. We only write null when metadata already had a
+  // background — that way a global UI background carried over from a previous
+  // chat doesn't pollute a fresh chat's metadata on switch.
   const bgPersistTimer = useRef<ReturnType<typeof setTimeout>>(null);
   useEffect(() => {
-    if (!chat?.id || !chatBackground) return;
+    if (!chat?.id) return;
+    const savedFilename = (chatMeta.background as string | null | undefined) ?? null;
+
+    if (!chatBackground) {
+      if (savedFilename === null) return;
+      if (bgPersistTimer.current) clearTimeout(bgPersistTimer.current);
+      bgPersistTimer.current = setTimeout(() => {
+        updateMeta.mutate({ id: chat!.id, background: null });
+      }, 500);
+      return;
+    }
+
     const filename = decodeURIComponent(chatBackground.replace(/^\/api\/backgrounds\/file\//, ""));
-    // Skip if metadata already matches (avoids pointless writes on restore)
-    if (filename === (chatMeta.background ?? null)) return;
+    if (filename === savedFilename) return;
     if (bgPersistTimer.current) clearTimeout(bgPersistTimer.current);
     bgPersistTimer.current = setTimeout(() => {
       updateMeta.mutate({ id: chat!.id, background: filename });

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -50,7 +50,7 @@ import {
   RefreshCw,
   ExternalLink,
 } from "lucide-react";
-import { useClearAllData, useExpungeData, type ExpungeScope } from "../../hooks/use-chats";
+import { useClearAllData, useExpungeData, useUpdateChatMetadata, type ExpungeScope } from "../../hooks/use-chats";
 import { useChatStore } from "../../stores/chat.store";
 import { chatKeys } from "../../hooks/use-chats";
 import { HelpTooltip } from "../ui/HelpTooltip";
@@ -415,7 +415,25 @@ function AppearanceSettings() {
   const visualTheme = useUIStore((s) => s.visualTheme);
   const setVisualTheme = useUIStore((s) => s.setVisualTheme);
   const chatBackground = useUIStore((s) => s.chatBackground);
-  const setChatBackground = useUIStore((s) => s.setChatBackground);
+  const setChatBackgroundRaw = useUIStore((s) => s.setChatBackground);
+  const activeChatId = useChatStore((s) => s.activeChatId);
+  const updateMeta = useUpdateChatMetadata();
+  // Persist background changes to the active chat's metadata immediately so
+  // a clear (or pick) survives chat switches and page reloads. The effect-based
+  // persist in ChatArea covers other sources (agents/scene/slash commands), but
+  // for the Settings UI we wire the mutation directly to the click to remove
+  // any timing ambiguity around clearing.
+  const setChatBackground = useCallback(
+    (url: string | null) => {
+      setChatBackgroundRaw(url);
+      if (!activeChatId) return;
+      const filename = url
+        ? decodeURIComponent(url.replace(/^\/api\/backgrounds\/file\//, ""))
+        : null;
+      updateMeta.mutate({ id: activeChatId, background: filename });
+    },
+    [setChatBackgroundRaw, activeChatId, updateMeta],
+  );
   const fontFamily = useUIStore((s) => s.fontFamily);
   const setFontFamily = useUIStore((s) => s.setFontFamily);
   const convoGradientFrom = useUIStore((s) => s.convoGradientFrom);

--- a/packages/client/src/hooks/use-chats.ts
+++ b/packages/client/src/hooks/use-chats.ts
@@ -214,8 +214,18 @@ export function useUpdateChatMetadata() {
   return useMutation({
     mutationFn: ({ id, ...metadata }: { id: string; [key: string]: unknown }) =>
       api.patch<Chat>(`/chats/${id}/metadata`, metadata),
-    onSuccess: (_data, vars) => {
-      qc.invalidateQueries({ queryKey: chatKeys.detail(vars.id) });
+    onSuccess: (data, vars) => {
+      // Write the server response straight into the detail cache. Plain
+      // invalidation alone leaves stale data in place when no observer is
+      // mounted to trigger a refetch (e.g. user navigated away after firing
+      // the mutation), causing later renders to re-read the pre-mutation
+      // value — which is what made cleared chat backgrounds reappear after
+      // a chat switch round-trip.
+      if (data) {
+        qc.setQueryData(chatKeys.detail(vars.id), data);
+      } else {
+        qc.invalidateQueries({ queryKey: chatKeys.detail(vars.id) });
+      }
       qc.invalidateQueries({ queryKey: chatKeys.list() });
     },
   });


### PR DESCRIPTION
## Summary

Closes #260.

Removing a chat background via the Settings panel did not survive chat switches (and sometimes did not survive a page refresh either). Three compounding issues were responsible:

### 1. Stale React Query cache after metadata writes
`useUpdateChatMetadata` only called `qc.invalidateQueries(...)` on success and never wrote the server response into the cache. React Query invalidation only triggers a refetch when an active observer is mounted; if the user fired the mutation and then navigated away, the cache was marked stale but never refreshed. Coming back to that chat served the pre-mutation snapshot, and the restore effect re-applied the supposedly-removed background.

**Fix:** the hook now `setQueryData(chatKeys.detail(id), data)` directly with the mutation response, so the cache is always fresh regardless of observer state. Falls back to invalidate if the response is null.

### 2. Restore effect was a one-way sync
`ChatArea`'s background-restore effect only set `chatBackground` when the chat's metadata had a value — it never cleared the global UI-store value. Switching to a chat whose metadata was empty (or had been cleared) left whatever URL was last in the store, including from the previous chat.

**Fix:** the effect now mirrors metadata exactly, setting `null` when metadata has no background. Brand-new chats no longer carry over the previous chat's background as a "don't flash to black" preview, but a fresh-empty chat is the more honest behavior.

### 3. Remove button leaned on a fragile debounced effect chain
The Remove handler in `SettingsPanel` only called `setChatBackground(null)`. Persistence relied on a `useEffect` in `ChatArea` to observe that change and (after a 500 ms debounce) fire a metadata patch. That chain had timing/closure ambiguities that occasionally dropped the write.

**Fix:** the handler now calls `useUpdateChatMetadata` directly from the click, alongside the UI-store update — no debounce, no effect dep race.

The `ChatArea` persist effect's null-write branch is left in place because slash commands, scene events, and agent paths still clear the background without going through Settings.

## Files

- `packages/client/src/hooks/use-chats.ts` — `useUpdateChatMetadata.onSuccess` writes response into the detail cache.
- `packages/client/src/components/chat/ChatArea.tsx` — restore effect now syncs to null when metadata is empty.
- `packages/client/src/components/panels/SettingsPanel.tsx` — Remove / pick handler fires the mutation directly.

## Side benefits

Every other consumer of `useUpdateChatMetadata` (sprite settings, branch labels, chat setup wizard, summary popover, game-state sync, etc.) now sees its mutation result reflected in the cache immediately rather than after a refetch round-trip. No behavior changes for those callers; they just get consistent freshness.

Game mode is unaffected by the restore-effect change — `GameSurface` deliberately ignores `chatBackground` (`_chatBackground` underscore-prefixed at line 565, with an accompanying comment) and renders its own scene-derived background from the asset manifest.

## Test plan

- [x] Manually verify in browser: set a background on a chat, click Remove. Background disappears.
- [x] Manually verify in browser: F5 after Remove. Background stays gone.
- [x] Manually verify in browser: set bg on chat A → click Remove → switch to chat B → switch back to chat A. Background stays gone (this was the flaky case).
- [x] Manually verify in browser: set different backgrounds on chats A and B; switch between them; each chat keeps its own bg.
- [x] Manually verify in browser: pick a background, immediately click another chat (while debounce would still be pending). Switch back. Bg should persist.
- [x] Manually verify in browser: switch repeatedly between an RP chat and a Conversation chat — bg state stays correct on both sides.
- [x] Manually verify in game mode: starting / continuing a game session does not trigger a stray bg change in non-game chats.
- [x] `pnpm check` passes (no new TS / ESLint regressions).

## Notes

No linked feature request beyond issue #260, which is the bug report itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Chat background settings now properly persist when switching between different chats
  * Clearing a background now correctly maintains the removed state across chat switches and application reloads

<!-- end of auto-generated comment: release notes by coderabbit.ai -->