### PR TITLE
fix(launcher): correct installDir resolution and unblock auto-update

### DIFF
--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -86,7 +86,8 @@ export async function buildApp(https?: { cert: Buffer; key: Buffer }) {
   // bundled MarinaraLauncher.exe so pinning to the taskbar groups the
   // running console under the pinned icon. Idempotent and fire-and-forget.
   try {
-    const installDir = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "..");
+    // app.ts compiles to <installDir>/packages/server/dist/app.js — three levels up from dist/.
+    const installDir = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
     migrateTaskbarShortcuts(installDir);
   } catch (err) {
     app.log.warn({ err }, "taskbar shortcut migration skipped");

--- a/start.bat
+++ b/start.bat
@@ -96,6 +96,16 @@ if /I "!OLD_HEAD!"=="!TARGET_HEAD!" (
     echo  [OK] Already up to date
     goto :skip_update
 )
+:: Drop known-safe untracked files that older installer versions placed in
+:: $INSTDIR but are now also tracked in the repo. Without this, git merge
+:: --ff-only refuses to overwrite them and the auto-update silently fails.
+:: The repo copies are byte-identical to what the installer wrote, so this
+:: is non-destructive — git restores them as tracked files after the merge.
+if exist "app-icon.ico" (
+    git ls-files --error-unmatch "app-icon.ico" >nul 2>&1
+    if errorlevel 1 del /q "app-icon.ico" >nul 2>&1
+)
+
 :: Stash any tracked local changes so the fast-forward update doesn't fail
 set "STASHED=0"
 set "STASH_REF="


### PR DESCRIPTION
Two bugs in the taskbar-launcher migration shipped in #277:

1. **installDir off-by-one.** `app.ts` resolved the install root by walking 4 levels up from `dist/`, which lands one directory too high (e.g. `AppData\Local` instead of `AppData\Local\MarinaraEngine`). The migration then couldn't find `MarinaraLauncher.exe` and silently skipped, leaving the Start Menu shortcut still targeting `start.bat`. Three levels up is correct — `<INSTDIR>/packages/server/dist` → 3 → `<INSTDIR>`.

2. **`app-icon.ico` collision blocks `git pull`.** The original installer wrote `app-icon.ico` into `$INSTDIR` as an untracked file. #277 added `app-icon.ico` to the repo at the same path, so `git merge --ff-only` in `start.bat` refuses to overwrite the untracked copy and the auto-update silently fails (user stays at the previous commit forever). `start.bat` now drops the untracked `app-icon.ico` before merging if (and only if) it's not yet tracked locally — the repo copy is byte-identical to what the installer wrote, so this is non-destructive. Once a user has pulled successfully, the file becomes tracked and the cleanup is a permanent no-op.

Currently-stuck users on pre-#277 HEAD need a one-time manual fix before their `start.bat` will pick up the patch:

    cd $env:LOCALAPPDATA\MarinaraEngine
    Remove-Item app-icon.ico
    git pull origin main

## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

-

## What changed

<!-- List the key changes in this PR -->

-

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

-

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

<!-- Add before/after screenshots or recordings for UI changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed taskbar shortcut migration to properly align with runtime installation location.
  * Improved installation merge process by preventing conflicts with leftover files from previous installer versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->