### PR TITLE
fix(connections): support Claude Subscription helper routes

### DIFF
--- a/packages/server/src/routes/character-maker.routes.ts
+++ b/packages/server/src/routes/character-maker.routes.ts
@@ -54,6 +54,8 @@ export async function characterMakerRoutes(app: FastifyInstance) {
       const providerDef = PROVIDERS[conn.provider as keyof typeof PROVIDERS];
       baseUrl = providerDef?.defaultBaseUrl ?? "";
     }
+    // Claude (Subscription) uses the local Claude Agent SDK; no HTTP endpoint.
+    if (!baseUrl && conn.provider === "claude_subscription") baseUrl = "claude-agent-sdk://local";
     if (!baseUrl) {
       return reply.status(400).send({ error: "No base URL configured for this connection" });
     }

--- a/packages/server/src/routes/encounter.routes.ts
+++ b/packages/server/src/routes/encounter.routes.ts
@@ -46,6 +46,9 @@ async function resolveConnection(
     const providerDef = PROVIDERS[conn.provider as keyof typeof PROVIDERS];
     baseUrl = providerDef?.defaultBaseUrl ?? "";
   }
+  // Claude (Subscription) uses the local Claude Agent SDK and has no HTTP
+  // endpoint — return a sentinel so the gate passes. The provider ignores it.
+  if (!baseUrl && conn.provider === "claude_subscription") baseUrl = "claude-agent-sdk://local";
   if (!baseUrl) throw new Error("No base URL configured for this connection");
 
   return { conn, baseUrl };

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -516,6 +516,9 @@ async function resolveConnection(
     const providerDef = PROVIDERS[conn.provider as keyof typeof PROVIDERS];
     baseUrl = providerDef?.defaultBaseUrl ?? "";
   }
+  // Claude (Subscription) uses the local Claude Agent SDK and has no HTTP
+  // endpoint — return a sentinel so the gate passes. The provider ignores it.
+  if (!baseUrl && conn.provider === "claude_subscription") baseUrl = "claude-agent-sdk://local";
   if (!baseUrl) throw new Error("No base URL configured for this connection");
 
   return { conn, baseUrl, defaultGenerationParameters: parseStoredGenerationParameters(conn.defaultParameters) };

--- a/packages/server/src/routes/lorebook-maker.routes.ts
+++ b/packages/server/src/routes/lorebook-maker.routes.ts
@@ -118,6 +118,8 @@ export async function lorebookMakerRoutes(app: FastifyInstance) {
       const providerDef = PROVIDERS[conn.provider as keyof typeof PROVIDERS];
       baseUrl = providerDef?.defaultBaseUrl ?? "";
     }
+    // Claude (Subscription) uses the local Claude Agent SDK; no HTTP endpoint.
+    if (!baseUrl && conn.provider === "claude_subscription") baseUrl = "claude-agent-sdk://local";
     if (!baseUrl) {
       return reply.status(400).send({ error: "No base URL configured for this connection" });
     }

--- a/packages/server/src/routes/persona-maker.routes.ts
+++ b/packages/server/src/routes/persona-maker.routes.ts
@@ -47,6 +47,8 @@ export async function personaMakerRoutes(app: FastifyInstance) {
       const providerDef = PROVIDERS[conn.provider as keyof typeof PROVIDERS];
       baseUrl = providerDef?.defaultBaseUrl ?? "";
     }
+    // Claude (Subscription) uses the local Claude Agent SDK; no HTTP endpoint.
+    if (!baseUrl && conn.provider === "claude_subscription") baseUrl = "claude-agent-sdk://local";
     if (!baseUrl) {
       return reply.status(400).send({ error: "No base URL configured for this connection" });
     }

--- a/packages/server/src/routes/prompt-reviewer.routes.ts
+++ b/packages/server/src/routes/prompt-reviewer.routes.ts
@@ -71,6 +71,8 @@ export async function promptReviewerRoutes(app: FastifyInstance) {
       const providerDef = PROVIDERS[conn.provider as keyof typeof PROVIDERS];
       baseUrl = providerDef?.defaultBaseUrl ?? "";
     }
+    // Claude (Subscription) uses the local Claude Agent SDK; no HTTP endpoint.
+    if (!baseUrl && conn.provider === "claude_subscription") baseUrl = "claude-agent-sdk://local";
     if (!baseUrl) {
       return reply.status(400).send({ error: "No base URL configured for this connection" });
     }

--- a/packages/server/src/routes/scene.routes.ts
+++ b/packages/server/src/routes/scene.routes.ts
@@ -67,6 +67,9 @@ async function resolveConnection(
     const providerDef = PROVIDERS[conn.provider as keyof typeof PROVIDERS];
     baseUrl = providerDef?.defaultBaseUrl ?? "";
   }
+  // Claude (Subscription) uses the local Claude Agent SDK and has no HTTP
+  // endpoint — return a sentinel so the gate passes. The provider ignores it.
+  if (!baseUrl && conn.provider === "claude_subscription") baseUrl = "claude-agent-sdk://local";
   if (!baseUrl) throw new Error("No base URL configured for this connection");
 
   return { conn, baseUrl };

--- a/packages/server/src/routes/translate.routes.ts
+++ b/packages/server/src/routes/translate.routes.ts
@@ -68,6 +68,8 @@ async function translateWithAI(
     const providerDef = PROVIDERS[conn.provider as keyof typeof PROVIDERS];
     baseUrl = providerDef?.defaultBaseUrl ?? "";
   }
+  // Claude (Subscription) uses the local Claude Agent SDK; no HTTP endpoint.
+  if (!baseUrl && conn.provider === "claude_subscription") baseUrl = "claude-agent-sdk://local";
   if (!baseUrl) {
     throw Object.assign(new Error("No base URL configured for this connection"), { statusCode: 400 });
   }

--- a/packages/server/src/services/llm/providers/claude-subscription.provider.ts
+++ b/packages/server/src/services/llm/providers/claude-subscription.provider.ts
@@ -126,10 +126,13 @@ export class ClaudeSubscriptionProvider extends BaseLLMProvider {
       systemPrompt,
       includePartialMessages: options.stream ?? true,
       // Disable agent tooling — Marinara has its own tool/agent pipeline and
-      // we only want plain text completions out of this provider.
+      // we only want plain text completions out of this provider. With tools
+      // empty, no agentic loop runs, so we leave maxTurns unset; setting it
+      // to 1 caused the SDK to bail with `error_max_turns` because thinking
+      // and other internal steps consume turn budget alongside the assistant
+      // response.
       tools: [],
       permissionMode: "bypassPermissions",
-      maxTurns: 1,
     };
 
     if (options.enableThinking) {

--- a/packages/server/test/claude-subscription-provider.test.ts
+++ b/packages/server/test/claude-subscription-provider.test.ts
@@ -91,7 +91,7 @@ test("streams text deltas and merges them into the yielded chunks", async () => 
   assert.equal(calls[0]!.options.includePartialMessages, true);
   assert.deepEqual(calls[0]!.options.tools, []);
   assert.equal(calls[0]!.options.permissionMode, "bypassPermissions");
-  assert.equal(calls[0]!.options.maxTurns, 1);
+  assert.equal("maxTurns" in calls[0]!.options, false);
   assert.equal(calls[0]!.options.model, "claude-opus-4-5");
 });
 


### PR DESCRIPTION
## Linked issue

Closes #292

## Why this change

- `/scene` from a DM fails when Claude Subscription is selected as the connection.
- The helper route connection resolver expects a normal HTTP base URL, but Claude Subscription is backed by the local Claude Agent SDK.
- Claude Subscription requests can also fail with `error_max_turns` because the provider forces `maxTurns: 1`.

## What changed

- Treats Claude Subscription as a local SDK-backed connection in helper routes by assigning a local sentinel base URL.
- Updates the Claude Subscription provider so it does not force `maxTurns: 1`.
- Updates the Claude Subscription provider test to assert that `maxTurns` is omitted.

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Manually tested with Claude Subscription selected as the connection.
- The original failure was encountered by calling `/scene` from a DM.
- Observed local failures included:
  - `No base URL configured for this connection`
  - `[commands] Scene creation failed`
  - `Claude (Subscription) request failed (error_max_turns) — Reached maximum number of turns (1)`
- With this change, the Claude Subscription route path uses the local SDK connection path and does not force a one-turn limit.
- Also ran `pnpm --dir packages/server exec tsx --test test/claude-subscription-provider.test.ts` successfully.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

No screenshot attached. Relevant runtime errors are included in the linked issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed turn limit constraint from Claude Subscription connections that was prematurely interrupting conversations and causing failures.

* **Chores**
  * Enhanced Claude Subscription provider support across API routes to enable local SDK endpoint handling, eliminating configuration errors when external HTTP endpoints are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->