### PR TITLE
fix: infinite re-render loop in Game Mode (React error #185)

### DIFF
--- a/packages/client/src/components/game/GameNarration.tsx
+++ b/packages/client/src/components/game/GameNarration.tsx
@@ -1391,18 +1391,26 @@ export function GameNarration({
   ]);
 
   // Report active speaker to parent for sprite viewport
+  // Guard against infinite re-render: skip callback if the resolved speaker hasn't changed,
+  // even when dependency refs churn (e.g. unstable speakerAvatarInfos from store).
+  const lastReportedSpeakerRef = useRef<string | null>(undefined);
   useEffect(() => {
     if (!onActiveSpeakerChange) return;
-    if (!active || active.type !== "dialogue" || !active.speaker) {
-      onActiveSpeakerChange(null);
-      return;
-    }
-    const avatar = findNamedMapValue(speakerAvatarInfos, active.speaker);
-    if (avatar) {
-      onActiveSpeakerChange({ name: active.speaker, avatarUrl: avatar.url, expression: active.sprite });
-    } else {
-      onActiveSpeakerChange(null);
-    }
+
+    const next =
+      !active || active.type !== "dialogue" || !active.speaker
+        ? null
+        : (() => {
+            const avatar = findNamedMapValue(speakerAvatarInfos, active.speaker);
+            return avatar
+              ? { name: active.speaker, avatarUrl: avatar.url, expression: active.sprite }
+              : null;
+          })();
+
+    const nextKey = next?.name ?? null;
+    if (nextKey === lastReportedSpeakerRef.current) return;
+    lastReportedSpeakerRef.current = nextKey;
+    onActiveSpeakerChange(next);
   }, [active, speakerAvatarInfos, onActiveSpeakerChange]);
 
   // How many segments are prepended before the actual GM narration segments

--- a/packages/client/src/components/game/GameNarration.tsx
+++ b/packages/client/src/components/game/GameNarration.tsx
@@ -1420,7 +1420,7 @@ export function GameNarration({
   // Report active speaker to parent for sprite viewport
   // Guard against infinite re-render: skip callback if the resolved speaker hasn't changed,
   // even when dependency refs churn (e.g. unstable speakerAvatarInfos from store).
-  const lastReportedSpeakerRef = useRef<string | null>(undefined);
+  const lastReportedSpeakerRef = useRef<string | null>(null);
   useEffect(() => {
     if (!onActiveSpeakerChange) return;
 
@@ -1434,7 +1434,10 @@ export function GameNarration({
               : null;
           })();
 
-    const nextKey = next?.name ?? null;
+    // Composite key catches legitimate expression/avatar changes, not just name
+    const nextKey = next
+      ? `${next.name}|${next.expression ?? ""}|${next.avatarUrl ?? ""}`
+      : null;
     if (nextKey === lastReportedSpeakerRef.current) return;
     lastReportedSpeakerRef.current = nextKey;
     onActiveSpeakerChange(next);

--- a/packages/client/src/stores/game-mode.store.ts
+++ b/packages/client/src/stores/game-mode.store.ts
@@ -273,18 +273,29 @@ export const useGameModeStore = create<GameModeStore>((set) => ({
     }),
   patchNpcAvatars: (avatars) =>
     set((s) => {
+      let modified = false;
       const nextNpcs = s.npcs.map((npc) => {
         const match = avatars.find((a) => a.name.toLowerCase() === npc.name.toLowerCase());
-        return match && !npc.avatarUrl ? { ...npc, avatarUrl: match.avatarUrl } : npc;
+        if (match && !npc.avatarUrl) {
+          modified = true;
+          return { ...npc, avatarUrl: match.avatarUrl };
+        }
+        return npc; // preserve reference — no churn
       });
 
       for (const avatar of avatars) {
         const exists = nextNpcs.some((npc) => npc.name.toLowerCase() === avatar.name.toLowerCase());
         if (!exists) {
           nextNpcs.push(buildTrackedNpcStub(avatar.name, avatar.avatarUrl));
+          modified = true;
         }
       }
 
+      // Return the SAME state reference when nothing actually changed.
+      // Zustand skips subscriber notification on reference equality, which
+      // prevents infinite render loops caused by useEffect → store update →
+      // useSyncExternalStore synchronous re-subscription → repeat.
+      if (!modified) return s;
       return { npcs: nextNpcs };
     }),
   setSetupActive: (active) => set({ isSetupActive: active }),


### PR DESCRIPTION
## Linked issue

Closes #305

## Why this change

Opening any Game Mode chat session immediately crashes the UI with React error #185 (`Maximum update depth exceeded`). The bug prevents all Game Mode gameplay — users cannot use GM chats at all.

**Root cause:** `patchNpcAvatars` in the Zustand store uses `.map()` on the `npcs` array every time it's called, even when nothing was actually modified. `.map()` always returns a **new array reference**, so Zustand sees "state changed" and notifies all subscribers. A `useEffect` in `GameSurface` calls `patchNpcAvatars` during React's commit phase, which triggers a synchronous re-render via `useSyncExternalStore`, re-fires the effect, calls `patchNpcAvatars` again — and the loop continues until React hits its 50-render depth limit.

GM chats are specifically affected because they load additional state (NPCs, character library data via TanStack Query) that feeds into the `useEffect` dependencies, guaranteeing the loop on first mount.

## What changed

- **`packages/client/src/stores/game-mode.store.ts`** — `patchNpcAvatars` now tracks whether any NPC was actually modified. If nothing changed, it returns the **same state reference** (`return s`) instead of a new object. Zustand performs reference equality checking — when the reference is identical, it skips subscriber notification entirely, breaking the infinite loop.
- **`packages/client/src/components/game/GameNarration.tsx`** — Added a `useRef` guard to the `onActiveSpeakerChange` `useEffect`. The effect now tracks the last reported speaker name and bails out if it hasn't changed. This prevents the same class of bug (redundant `setActiveSpeaker` calls) from a different code path where dependency references churn.

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

1. Built the client with `pnpm --filter @marinara-engine/client build` — clean build, no TypeScript errors
2. Rebuilt and restarted the production server on port 7860
3. Opened the app in Chrome, hard-refreshed (Ctrl+Shift+R) to bust service worker cache
4. Navigated to the GM chat (the specific chat that triggered the original crash with `backgrounds:generated:korriban-valley`)
5. Game Mode loaded successfully — no React error #185, no infinite loop, UI fully interactive
6. Also verified CONVO and RP chats still work normally (no regressions)

## Docs and release impact

- [x] No docs changes needed

## UI evidence (if applicable)

Before: Opening any GM chat immediately shows the red React error overlay (error #185) and the tab becomes unresponsive.

After: GM chats load normally with full Game Mode UI rendering. No console errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reduced repeated narration updates so dialogue speaker changes are reported only when the visible speaker actually changes, leading to steadier narration behavior.
  * Prevented unnecessary NPC avatar refreshes by keeping existing avatar data when unchanged, reducing visual flicker and improving game responsiveness and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->