### PR TITLE
feat(game): Interrupt button with risky/force confirmation flow

### DIFF
--- a/packages/client/src/components/game/GameInput.tsx
+++ b/packages/client/src/components/game/GameInput.tsx
@@ -34,6 +34,14 @@ interface GameInputProps {
   inline?: boolean;
   /** Key for persisting the input draft to sessionStorage (e.g. chatId) */
   draftKey?: string;
+  /** Increment to request focus on the textarea (used by the Interrupt button to jump the player into typing). */
+  focusToken?: number;
+  /**
+   * When set, the input renders in interrupt-commit mode. `risky` paints the bar red,
+   * highlights the dice button with a glow, and shows a "using dice recommended" hint.
+   * `force` keeps the normal styling — the GM won't be told this is an interrupt.
+   */
+  interruptMode?: "risky" | "force" | null;
 }
 
 const QUICK_DICE = ["d20", "d6", "2d6", "d10", "d100", "d4", "d8", "d12"];
@@ -48,6 +56,8 @@ export function GameInput({
   isStreaming,
   inline,
   draftKey,
+  focusToken,
+  interruptMode,
 }: GameInputProps) {
   const enterToSend = useUIStore((s) => s.enterToSendGame);
   const storageKey = draftKey ? `game-input-draft:${draftKey}` : null;
@@ -77,6 +87,18 @@ export function GameInput({
     if (addressMode !== "party" || hasPartyMembers) return;
     setAddressMode("scene");
   }, [addressMode, hasPartyMembers]);
+
+  // Honors focus requests even if the input was disabled at the time the
+  // token bumped (e.g. Interrupt clicked while `isStreaming` is still true) —
+  // we re-attempt the focus once `disabled` flips to false.
+  const lastFocusedTokenRef = useRef(0);
+  useEffect(() => {
+    if (!focusToken) return;
+    if (lastFocusedTokenRef.current === focusToken) return;
+    if (disabled) return;
+    inputRef.current?.focus();
+    lastFocusedTokenRef.current = focusToken;
+  }, [focusToken, disabled]);
 
   useEffect(() => {
     if (!addressMenuOpen) return;
@@ -201,10 +223,28 @@ export function GameInput({
     [updateText],
   );
 
+  const riskyInterrupt = interruptMode === "risky";
+  const forceInterrupt = interruptMode === "force";
+
   return (
     <div
-      className={inline ? "" : "border-t border-[var(--border)] bg-[var(--card)]"}
-      style={inline ? undefined : { minHeight: 61 }}
+      className={cn(
+        inline ? "" : "border-t border-[var(--border)] bg-[var(--card)]",
+        riskyInterrupt && "rounded-xl ring-1 ring-red-500/40 bg-red-500/5 shadow-[0_0_18px_-6px_rgba(248,113,113,0.55)]",
+        forceInterrupt && "rounded-xl ring-1",
+      )}
+      style={
+        forceInterrupt
+          ? {
+              ...(inline ? {} : { minHeight: 61 }),
+              boxShadow: "0 0 18px -6px rgba(32, 194, 14, 0.6)",
+              backgroundColor: "rgba(32, 194, 14, 0.04)",
+              ["--tw-ring-color" as never]: "rgba(32, 194, 14, 0.45)",
+            }
+          : inline
+            ? undefined
+            : { minHeight: 61 }
+      }
     >
       {/* Dice picker */}
       {showDice && (
@@ -415,6 +455,19 @@ export function GameInput({
         )}
 
         {/* Right: Dice, Emoji (desktop), Send */}
+        {riskyInterrupt && !queuedDice && (
+          <span className="hidden text-[0.625rem] font-medium uppercase tracking-wide text-red-300/80 sm:inline">
+            using dice recommended
+          </span>
+        )}
+        {forceInterrupt && (
+          <span
+            className="hidden text-[0.625rem] font-medium uppercase tracking-wide sm:inline"
+            style={{ color: "#20C20E", opacity: 0.9 }}
+          >
+            force interrupting
+          </span>
+        )}
         <button
           onClick={() => setShowDice(!showDice)}
           className={cn(
@@ -422,8 +475,11 @@ export function GameInput({
             showDice
               ? "text-[var(--foreground)]/80 hover:bg-foreground/10"
               : "text-[var(--foreground)]/50 hover:bg-foreground/10 hover:text-[var(--foreground)]/70",
+            riskyInterrupt &&
+              !queuedDice &&
+              "animate-pulse text-red-300 ring-1 ring-red-400/60 shadow-[0_0_12px_-2px_rgba(248,113,113,0.85)] hover:text-red-200",
           )}
-          title="Roll dice"
+          title={riskyInterrupt && !queuedDice ? "Roll dice — recommended for an interrupt attempt" : "Roll dice"}
         >
           <Dices size={18} />
         </button>

--- a/packages/client/src/components/game/GameInput.tsx
+++ b/packages/client/src/components/game/GameInput.tsx
@@ -230,7 +230,8 @@ export function GameInput({
     <div
       className={cn(
         inline ? "" : "border-t border-[var(--border)] bg-[var(--card)]",
-        riskyInterrupt && "rounded-xl ring-1 ring-red-500/40 bg-red-500/5 shadow-[0_0_18px_-6px_rgba(248,113,113,0.55)]",
+        riskyInterrupt &&
+          "rounded-xl ring-1 ring-red-500/40 bg-red-500/5 shadow-[0_0_18px_-6px_rgba(248,113,113,0.55)]",
         forceInterrupt && "rounded-xl ring-1",
       )}
       style={

--- a/packages/client/src/components/game/GameNarration.tsx
+++ b/packages/client/src/components/game/GameNarration.tsx
@@ -23,6 +23,7 @@ import {
   Check,
   Play,
   Pause,
+  Square,
   Trash2,
   Volume2,
   VolumeX,
@@ -214,6 +215,28 @@ interface GameNarrationProps {
   autoPlayBlocked?: boolean;
   /** Effective game-mode TTS playback volume, 0–1. */
   gameVoiceVolume?: number;
+  /**
+   * Player hit the "Interrupt!" button. Soft-pauses narration: the parent
+   * stops generation, records the interrupt anchor, and only truncates the
+   * GM message when the player actually sends their next turn. `messageId`
+   * + `truncatedContent` describe what truncation *would* be applied; the
+   * parent stashes them until commit (send) or cancel (Resume).
+   */
+  onInterruptRequest?: (info: { messageId: string | null; truncatedContent: string | null }) => void;
+  /** Player hit "Resume" — discard the pending interrupt and continue narration. */
+  onInterruptCancel?: () => void;
+  /**
+   * True while the narration is paused for an interrupt — covers both the pre-confirm
+   * modal phase and the post-confirm waiting-to-send phase. Drives auto-play snapshot
+   * and hides Play/Next.
+   */
+  interruptPending?: boolean;
+  /**
+   * True only after the player has confirmed (Yes or Force Interrupt). Drives the
+   * Resume button and the early reveal of the chat input. While the confirmation
+   * modal is open this stays false so the input bar doesn't appear behind the modal.
+   */
+  interruptCommitted?: boolean;
 }
 
 /** Regex matching explicit {effect:text} tags used by AnimatedText. */
@@ -505,6 +528,10 @@ export function GameNarration({
   onNpcPortraitClick,
   autoPlayBlocked,
   gameVoiceVolume = 1,
+  onInterruptRequest,
+  onInterruptCancel,
+  interruptPending,
+  interruptCommitted,
 }: GameNarrationProps) {
   const { translations, translating } = useTranslate();
   const [activeIndex, setActiveIndex] = useState(0);
@@ -1868,29 +1895,114 @@ export function GameNarration({
   const NARRATION_META_BTN =
     "flex items-center gap-1 rounded-lg border border-[var(--border)] bg-[var(--muted)]/20 px-2.5 py-1 text-xs text-[var(--foreground)]/75 transition-colors hover:bg-[var(--muted)]/40 dark:border-white/10 dark:bg-white/5 dark:text-white/75 dark:hover:bg-white/10";
 
-  // Shared Next + auto-play control group used by dialogue, narration, and readable boxes
-  const navControls = (
-    <div className="flex items-stretch gap-1">
-      <button
-        onClick={() => setAutoPlay((v) => !v)}
-        className={cn(
-          "flex items-center justify-center self-stretch rounded-lg border px-2 text-xs transition-colors",
-          autoPlay
-            ? "border-[var(--primary)]/40 bg-[var(--primary)]/20 text-[var(--primary)]"
-            : "border-[var(--border)] bg-[var(--muted)]/20 text-[var(--foreground)]/70 hover:bg-[var(--muted)]/40 dark:border-white/10 dark:bg-white/5 dark:text-white/70 dark:hover:bg-white/10",
+  const handleInterrupt = useCallback(() => {
+    // Request only — the parent opens the confirmation modal. We don't pause
+    // here; the parent flips `interruptPending` once the player has confirmed
+    // (Yes or Force Interrupt), and the effect below handles the pause then.
+    let truncatedContent: string | null = null;
+    let truncatedMessageId: string | null = null;
+    if (latestAssistant) {
+      const editInfo = segmentEditInfoRef.current[activeIndex];
+      if (editInfo && editInfo.messageId === latestAssistant.id) {
+        const allSegs = parseNarrationSegments(latestAssistant, speakerColors);
+        if (editInfo.segmentIndex < allSegs.length - 1) {
+          const next = truncateMessageContentAtSegment(latestAssistant.content || "", editInfo.segmentIndex);
+          if (next && next !== latestAssistant.content) {
+            truncatedContent = next;
+            truncatedMessageId = latestAssistant.id;
+          }
+        }
+      }
+    }
+    onInterruptRequest?.({ messageId: truncatedMessageId, truncatedContent });
+  }, [activeIndex, latestAssistant, onInterruptRequest, speakerColors]);
+
+  const handleResume = useCallback(() => {
+    onInterruptCancel?.();
+  }, [onInterruptCancel]);
+
+  // Auto-play snapshot/restore: when `interruptPending` flips on we save the
+  // current auto-play state and pause; when it flips off (Resume, send, modal
+  // dismissed, new GM turn arrived, chat switched) we restore exactly what it
+  // was. Also snaps the typewriter so the pause anchor lands at a clean
+  // segment boundary.
+  const autoPlayBeforeInterruptRef = useRef(false);
+  const prevInterruptPendingRef = useRef(false);
+  useEffect(() => {
+    const wasPending = prevInterruptPendingRef.current;
+    const isPending = !!interruptPending;
+    prevInterruptPendingRef.current = isPending;
+    if (!wasPending && isPending) {
+      autoPlayBeforeInterruptRef.current = autoPlay;
+      setAutoPlay(false);
+      if (active) {
+        const dispLen = effectDisplayLength(active.content);
+        setVisibleChars(dispLen);
+        twRef.current.pos = dispLen;
+      }
+    } else if (wasPending && !isPending) {
+      if (autoPlayBeforeInterruptRef.current) {
+        setAutoPlay(true);
+      }
+      autoPlayBeforeInterruptRef.current = false;
+    }
+  }, [active, autoPlay, interruptPending]);
+
+  // Shared Next + auto-play control group used by dialogue, narration, and readable boxes.
+  // The red Interrupt button swaps to a yellow Resume button only AFTER the player
+  // confirms in the modal (interruptCommitted). While the modal is still open we keep
+  // the red button visible so it doesn't look like the interrupt already happened.
+  const showInterruptControls = !narrationComplete && !partyTurnPending && !!onInterruptRequest;
+  const showNav = !narrationComplete && !isStreaming && !interruptPending;
+  const navControls =
+    !showInterruptControls && !showNav ? null : (
+      <div className="flex items-stretch gap-1">
+        {showInterruptControls && !interruptCommitted && (
+          <button
+            onClick={handleInterrupt}
+            className="flex items-center gap-1 self-stretch rounded-lg border border-red-500/40 bg-red-500/15 px-2 text-xs font-semibold text-red-200 transition-colors hover:bg-red-500/25 hover:text-red-50 sm:px-2.5 dark:border-red-500/40 dark:bg-red-500/15 dark:text-red-200 dark:hover:bg-red-500/25"
+            title="Pause the GM so you can write back. Nothing is committed until you send."
+            aria-label="Interrupt"
+          >
+            <Square size={11} fill="currentColor" />
+            <span className="hidden sm:inline">Interrupt!</span>
+          </button>
         )}
-        title={autoPlay ? "Pause auto-play" : "Auto-play segments"}
-      >
-        {autoPlay ? <Pause size={12} /> : <Play size={12} />}
-      </button>
-      <button
-        onClick={nextSegment}
-        className="flex items-center justify-center self-stretch rounded-lg border border-[var(--border)] bg-[var(--muted)]/20 px-3 text-xs font-semibold text-[var(--foreground)]/75 transition-colors hover:bg-[var(--muted)]/40 dark:border-white/10 dark:bg-white/5 dark:text-white/75 dark:hover:bg-white/10"
-      >
-        {!doneTyping ? "Reveal" : "Next"}
-      </button>
-    </div>
-  );
+        {showInterruptControls && interruptCommitted && (
+          <button
+            onClick={handleResume}
+            className="flex items-center gap-1 self-stretch rounded-lg border border-amber-400/40 bg-amber-400/15 px-2 text-xs font-semibold text-amber-100 transition-colors hover:bg-amber-400/25 hover:text-amber-50 sm:px-2.5 dark:border-amber-400/40 dark:bg-amber-400/15 dark:text-amber-100 dark:hover:bg-amber-400/25"
+            title="Resume narration — your interrupt has not been committed."
+            aria-label="Resume"
+          >
+            <Play size={11} fill="currentColor" />
+            <span className="hidden sm:inline">Resume</span>
+          </button>
+        )}
+        {showNav && (
+          <>
+            <button
+              onClick={() => setAutoPlay((v) => !v)}
+              className={cn(
+                "flex items-center justify-center self-stretch rounded-lg border px-2 text-xs transition-colors",
+                autoPlay
+                  ? "border-[var(--primary)]/40 bg-[var(--primary)]/20 text-[var(--primary)]"
+                  : "border-[var(--border)] bg-[var(--muted)]/20 text-[var(--foreground)]/70 hover:bg-[var(--muted)]/40 dark:border-white/10 dark:bg-white/5 dark:text-white/70 dark:hover:bg-white/10",
+              )}
+              title={autoPlay ? "Pause auto-play" : "Auto-play segments"}
+            >
+              {autoPlay ? <Pause size={12} /> : <Play size={12} />}
+            </button>
+            <button
+              onClick={nextSegment}
+              className="flex items-center justify-center self-stretch rounded-lg border border-[var(--border)] bg-[var(--muted)]/20 px-3 text-xs font-semibold text-[var(--foreground)]/75 transition-colors hover:bg-[var(--muted)]/40 dark:border-white/10 dark:bg-white/5 dark:text-white/75 dark:hover:bg-white/10"
+            >
+              {!doneTyping ? "Reveal" : "Next"}
+            </button>
+          </>
+        )}
+      </div>
+    );
 
   return (
     <div className="relative flex min-h-0 flex-1 items-end px-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] pt-20 md:pt-24 sm:px-6 md:pb-4">
@@ -2164,12 +2276,12 @@ export function GameNarration({
                     className={cn(NARRATION_META_BTN, "disabled:opacity-40")}
                   >
                     <ScrollText size={12} />
-                    Logs
+                    <span className="hidden sm:inline">Logs</span>
                   </button>
                   {onOpenInventory && (
                     <button onClick={onOpenInventory} className={cn("relative", NARRATION_META_BTN)}>
                       <Package size={12} />
-                      Inventory
+                      <span className="hidden sm:inline">Inventory</span>
                       {(inventoryCount ?? 0) > 0 && (
                         <span className="absolute -right-1.5 -top-1.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-amber-500 px-0.5 text-[0.55rem] font-bold text-black">
                           {inventoryCount}
@@ -2178,7 +2290,7 @@ export function GameNarration({
                     </button>
                   )}
                 </div>
-                {!narrationComplete && !isStreaming && !partyTurnPending && navControls}
+                {navControls}
               </div>
             </>
           )}
@@ -2260,12 +2372,12 @@ export function GameNarration({
                     className={cn(NARRATION_META_BTN, "disabled:opacity-40")}
                   >
                     <ScrollText size={12} />
-                    Logs
+                    <span className="hidden sm:inline">Logs</span>
                   </button>
                   {onOpenInventory && (
                     <button onClick={onOpenInventory} className={cn("relative", NARRATION_META_BTN)}>
                       <Package size={12} />
-                      Inventory
+                      <span className="hidden sm:inline">Inventory</span>
                       {(inventoryCount ?? 0) > 0 && (
                         <span className="absolute -right-1.5 -top-1.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-amber-500 px-0.5 text-[0.55rem] font-bold text-black">
                           {inventoryCount}
@@ -2274,7 +2386,7 @@ export function GameNarration({
                     </button>
                   )}
                 </div>
-                {!narrationComplete && !isStreaming && navControls}
+                {navControls}
               </div>
             </>
           )}
@@ -2316,18 +2428,23 @@ export function GameNarration({
                     className={cn(NARRATION_META_BTN, "disabled:opacity-40")}
                   >
                     <ScrollText size={12} />
-                    Logs
+                    <span className="hidden sm:inline">Logs</span>
                   </button>
                 </div>
-                {!narrationComplete && !isStreaming && navControls}
+                {navControls}
               </div>
             </>
           )}
 
-          {/* Inline input — appears inside the narration box once all segments are read */}
-          {!scenePreparing && narrationComplete && !isStreaming && !partyTurnPending && inputSlot && (
-            <div className="mt-2">{inputSlot}</div>
-          )}
+          {/* Inline input — appears inside the narration box once all segments are read,
+              or after the player has CONFIRMED an interrupt (not just opened the modal).
+              Gating on `interruptCommitted` (not `interruptPending`) keeps the input bar
+              from showing in the background while the confirmation modal is still open. */}
+          {!scenePreparing &&
+            (narrationComplete || interruptCommitted) &&
+            !isStreaming &&
+            !partyTurnPending &&
+            inputSlot && <div className="mt-2">{inputSlot}</div>}
 
           {/* Also show input when no narration at all (start of scene) */}
           {!scenePreparing && !active && !isStreaming && !sceneAnalysisFailed && inputSlot && (
@@ -2339,7 +2456,7 @@ export function GameNarration({
                     className="flex items-center gap-1 rounded-lg border border-white/10 bg-white/5 px-2.5 py-1 text-xs text-white/75 transition-colors hover:bg-white/10"
                   >
                     <ScrollText size={12} />
-                    Logs
+                    <span className="hidden sm:inline">Logs</span>
                   </button>
                 </div>
               )}
@@ -3232,6 +3349,118 @@ function parseNarrationSegments(message: NarrationMessage, speakerColors: Map<st
   }
 
   return parsed;
+}
+
+/**
+ * Truncate an assistant message's raw content so that it ends just after the
+ * Nth segment (inclusive) that `parseNarrationSegments` would emit. Used by
+ * the Interrupt feature so the model on the next turn can't see narration
+ * the player never read.
+ *
+ * Caveats:
+ *   - Walks the same line-based emission logic as `parseNarrationSegments`,
+ *     including the inline-VN-line normalization and Note/Book placeholder
+ *     extraction. GM tags stripped by `stripGmTagsKeepReadables` (Map, Asset,
+ *     etc.) are dropped from the returned content; that's acceptable because
+ *     they describe scene state already consumed by the time the player can
+ *     hit Interrupt.
+ *   - The `splitInlineDialogue` post-processing is line-ambiguous, so when
+ *     the original message is plain prose with inline quotes the truncation
+ *     point may snap to the nearest line boundary rather than the exact
+ *     dialogue segment. Structured GM output is line-clean.
+ */
+function truncateMessageContentAtSegment(rawContent: string, segmentIndexInclusive: number): string {
+  if (segmentIndexInclusive < 0) return "";
+  const withReadables = stripGmTagsKeepReadables(rawContent || "");
+  const readableContents: Array<{ type: "note" | "book"; content: string }> = [];
+  let source = withReadables;
+  for (const tag of ["[Note:", "[Book:"] as const) {
+    const rType = tag === "[Note:" ? "note" : "book";
+    let searchFrom = 0;
+    while (true) {
+      const idx = source.toLowerCase().indexOf(tag.toLowerCase(), searchFrom);
+      if (idx === -1) break;
+      let depth = 0;
+      let end = -1;
+      for (let i = idx; i < source.length; i++) {
+        if (source[i] === "[") depth++;
+        else if (source[i] === "]") {
+          depth--;
+          if (depth === 0) {
+            end = i;
+            break;
+          }
+        }
+      }
+      if (end === -1) {
+        searchFrom = idx + 1;
+        continue;
+      }
+      const inner = source.slice(idx + tag.length, end).trim();
+      const placeholderIdx = readableContents.length;
+      readableContents.push({ type: rType, content: inner });
+      const placeholder = `__READABLE_${placeholderIdx}__`;
+      source = source.slice(0, idx) + placeholder + source.slice(end + 1);
+      searchFrom = idx + placeholder.length;
+    }
+  }
+
+  const lines = normalizeInlineVnDialogueLines(source).split(/\r?\n/);
+  const readablePlaceholderRe = /^__READABLE_(\d+)__$/;
+  const narrationRegex = /^\s*Narration\s*:\s*(.+)$/i;
+  const legacyDialogueRegex = /^\s*Dialogue\s*\[([^\]]+)\]\s*(?:\[([^\]]+)\])?\s*:\s*(.+)$/i;
+  const compactDialogueRegex = /^\s*\[([^\]]+)\]\s*(?:\[([^\]]+)\])?\s*:\s*(.+)$/;
+  const partyLineRegex =
+    /^\s*\[([^\]]+)\]\s*\[(main|side|extra|action|thought|whisper(?::([^\]]+))?)\]\s*(?:\[([^\]]+)\])?\s*:\s*(.+)$/i;
+
+  const target = segmentIndexInclusive + 1;
+  let segmentCount = 0;
+  let pendingFallback = false;
+  let lastIncludedLineIdx = -1;
+
+  for (let i = 0; i < lines.length; i++) {
+    if (segmentCount >= target) break;
+    const line = lines[i]!.trim();
+
+    if (!line) {
+      if (pendingFallback) {
+        segmentCount++;
+        pendingFallback = false;
+      }
+      continue;
+    }
+
+    const isSpecial =
+      readablePlaceholderRe.test(line) ||
+      partyLineRegex.test(line) ||
+      narrationRegex.test(line) ||
+      legacyDialogueRegex.test(line) ||
+      compactDialogueRegex.test(line);
+
+    if (isSpecial) {
+      if (pendingFallback) {
+        segmentCount++;
+        pendingFallback = false;
+        if (segmentCount >= target) break;
+      }
+      segmentCount++;
+      lastIncludedLineIdx = i;
+    } else {
+      pendingFallback = true;
+      lastIncludedLineIdx = i;
+    }
+  }
+
+  if (lastIncludedLineIdx < 0) return rawContent;
+
+  let kept = lines.slice(0, lastIncludedLineIdx + 1).join("\n");
+  kept = kept.replace(/__READABLE_(\d+)__/g, (_, idxStr) => {
+    const r = readableContents[Number.parseInt(idxStr, 10)];
+    if (!r) return "";
+    return `[${r.type === "note" ? "Note" : "Book"}: ${r.content}]`;
+  });
+
+  return kept;
 }
 
 /**

--- a/packages/client/src/components/game/GameNarration.tsx
+++ b/packages/client/src/components/game/GameNarration.tsx
@@ -1906,7 +1906,13 @@ export function GameNarration({
       if (editInfo && editInfo.messageId === latestAssistant.id) {
         const allSegs = parseNarrationSegments(latestAssistant, speakerColors);
         if (editInfo.segmentIndex < allSegs.length - 1) {
-          const next = truncateMessageContentAtSegment(latestAssistant.content || "", editInfo.segmentIndex);
+          let cutIndex = editInfo.segmentIndex;
+          while (cutIndex + 1 < allSegs.length) {
+            const nextSegment = allSegs[cutIndex + 1];
+            if (nextSegment?.partyType !== "side" && nextSegment?.partyType !== "extra") break;
+            cutIndex += 1;
+          }
+          const next = truncateMessageContentAtSegment(latestAssistant.content || "", cutIndex);
           if (next && next !== latestAssistant.content) {
             truncatedContent = next;
             truncatedMessageId = latestAssistant.id;
@@ -3144,6 +3150,125 @@ function normalizeInlineVnDialogueLines(source: string): string {
     );
 }
 
+type TruncationLine = {
+  text: string;
+  originalStart: number;
+  originalEnd: number;
+};
+
+function findReadableBlockEnd(source: string, start: number): number {
+  let depth = 0;
+  for (let i = start; i < source.length; i++) {
+    if (source[i] === "[") depth++;
+    else if (source[i] === "]") {
+      depth--;
+      if (depth === 0) return i;
+    }
+  }
+  return -1;
+}
+
+function splitTextIntoBoundedLines(text: string, originalStart: number): TruncationLine[] {
+  const lines: TruncationLine[] = [];
+  let lineStart = 0;
+
+  for (let i = 0; i <= text.length; i++) {
+    if (i < text.length && text[i] !== "\n") continue;
+    const rawLine = text.slice(lineStart, i);
+    const lineText = rawLine.endsWith("\r") ? rawLine.slice(0, -1) : rawLine;
+    lines.push({
+      text: lineText,
+      originalStart: originalStart + lineStart,
+      originalEnd: originalStart + lineStart + lineText.length,
+    });
+    lineStart = i + 1;
+  }
+
+  return lines;
+}
+
+function splitInlineVnDialogueLineMetadata(line: TruncationLine): TruncationLine[] {
+  const headerRe = /\[[^\]]+\]\s*\[(?:main|side|extra|action|thought|whisper(?::[^\]]+)?)\]\s*(?:\[[^\]]+\])?\s*:/gi;
+  const pieces: TruncationLine[] = [];
+  let chunkStart = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = headerRe.exec(line.text))) {
+    if (match.index > chunkStart && /\s/.test(line.text[match.index - 1] ?? "")) {
+      pieces.push({
+        text: line.text.slice(chunkStart, match.index),
+        originalStart: line.originalStart + chunkStart,
+        originalEnd: line.originalStart + match.index,
+      });
+      chunkStart = match.index;
+    }
+  }
+  pieces.push({
+    text: line.text.slice(chunkStart),
+    originalStart: line.originalStart + chunkStart,
+    originalEnd: line.originalEnd,
+  });
+
+  return pieces.flatMap((piece) => {
+    const splitRe =
+      /^(\s*\[[^\]]+\]\s*\[(?:main|side|extra|whisper(?::[^\]]+)?)\]\s*(?:\[[^\]]+\])?\s*:\s*(?:"[^"]*"|“[^”]*”|«[^»]*»))\s+(?=\S)/i;
+    const split = splitRe.exec(piece.text);
+    if (!split || split[1].length >= piece.text.length) return [piece];
+
+    const splitAt = split[1].length;
+    return [
+      {
+        text: piece.text.slice(0, splitAt),
+        originalStart: piece.originalStart,
+        originalEnd: piece.originalStart + splitAt,
+      },
+      {
+        text: piece.text.slice(splitAt).trimStart(),
+        originalStart: piece.originalStart + splitAt + (piece.text.slice(splitAt).match(/^\s*/)?.[0].length ?? 0),
+        originalEnd: piece.originalEnd,
+      },
+    ];
+  });
+}
+
+function buildTruncationLines(rawContent: string): TruncationLine[] {
+  const chunks: TruncationLine[] = [];
+  const readableTagRe = /\[(?:Note|Book):/gi;
+  let cursor = 0;
+  let placeholderIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = readableTagRe.exec(rawContent))) {
+    const start = match.index;
+    const end = findReadableBlockEnd(rawContent, start);
+    if (end < 0) continue;
+
+    if (start > cursor) {
+      chunks.push(...splitTextIntoBoundedLines(rawContent.slice(cursor, start), cursor));
+    }
+    chunks.push({
+      text: `__READABLE_${placeholderIndex}__`,
+      originalStart: start,
+      originalEnd: end + 1,
+    });
+    placeholderIndex += 1;
+    cursor = end + 1;
+    readableTagRe.lastIndex = cursor;
+  }
+
+  if (cursor < rawContent.length) {
+    chunks.push(...splitTextIntoBoundedLines(rawContent.slice(cursor), cursor));
+  }
+
+  return chunks.flatMap((chunk) => {
+    if (/^__READABLE_\d+__$/.test(chunk.text)) return [chunk];
+    return splitInlineVnDialogueLineMetadata(chunk).map((line) => ({
+      ...line,
+      text: stripGmTagsKeepReadables(line.text),
+    }));
+  });
+}
+
 function parseNarrationSegments(message: NarrationMessage, speakerColors: Map<string, string>): NarrationSegment[] {
   // Use stripGmTagsKeepReadables so [Note:] and [Book:] stay inline for position-aware display.
   // Extract them first as placeholders so multi-line readables don't break line-based parsing.
@@ -3357,55 +3482,13 @@ function parseNarrationSegments(message: NarrationMessage, speakerColors: Map<st
  * the Interrupt feature so the model on the next turn can't see narration
  * the player never read.
  *
- * Caveats:
- *   - Walks the same line-based emission logic as `parseNarrationSegments`,
- *     including the inline-VN-line normalization and Note/Book placeholder
- *     extraction. GM tags stripped by `stripGmTagsKeepReadables` (Map, Asset,
- *     etc.) are dropped from the returned content; that's acceptable because
- *     they describe scene state already consumed by the time the player can
- *     hit Interrupt.
- *   - The `splitInlineDialogue` post-processing is line-ambiguous, so when
- *     the original message is plain prose with inline quotes the truncation
- *     point may snap to the nearest line boundary rather than the exact
- *     dialogue segment. Structured GM output is line-clean.
+ * The parser-facing text is normalized for segment detection, but the returned
+ * string is always a byte-for-byte prefix of the original raw content.
  */
 function truncateMessageContentAtSegment(rawContent: string, segmentIndexInclusive: number): string {
   if (segmentIndexInclusive < 0) return "";
-  const withReadables = stripGmTagsKeepReadables(rawContent || "");
-  const readableContents: Array<{ type: "note" | "book"; content: string }> = [];
-  let source = withReadables;
-  for (const tag of ["[Note:", "[Book:"] as const) {
-    const rType = tag === "[Note:" ? "note" : "book";
-    let searchFrom = 0;
-    while (true) {
-      const idx = source.toLowerCase().indexOf(tag.toLowerCase(), searchFrom);
-      if (idx === -1) break;
-      let depth = 0;
-      let end = -1;
-      for (let i = idx; i < source.length; i++) {
-        if (source[i] === "[") depth++;
-        else if (source[i] === "]") {
-          depth--;
-          if (depth === 0) {
-            end = i;
-            break;
-          }
-        }
-      }
-      if (end === -1) {
-        searchFrom = idx + 1;
-        continue;
-      }
-      const inner = source.slice(idx + tag.length, end).trim();
-      const placeholderIdx = readableContents.length;
-      readableContents.push({ type: rType, content: inner });
-      const placeholder = `__READABLE_${placeholderIdx}__`;
-      source = source.slice(0, idx) + placeholder + source.slice(end + 1);
-      searchFrom = idx + placeholder.length;
-    }
-  }
 
-  const lines = normalizeInlineVnDialogueLines(source).split(/\r?\n/);
+  const lines = buildTruncationLines(rawContent || "");
   const readablePlaceholderRe = /^__READABLE_(\d+)__$/;
   const narrationRegex = /^\s*Narration\s*:\s*(.+)$/i;
   const legacyDialogueRegex = /^\s*Dialogue\s*\[([^\]]+)\]\s*(?:\[([^\]]+)\])?\s*:\s*(.+)$/i;
@@ -3420,7 +3503,7 @@ function truncateMessageContentAtSegment(rawContent: string, segmentIndexInclusi
 
   for (let i = 0; i < lines.length; i++) {
     if (segmentCount >= target) break;
-    const line = lines[i]!.trim();
+    const line = lines[i]!.text.trim();
 
     if (!line) {
       if (pendingFallback) {
@@ -3452,15 +3535,7 @@ function truncateMessageContentAtSegment(rawContent: string, segmentIndexInclusi
   }
 
   if (lastIncludedLineIdx < 0) return rawContent;
-
-  let kept = lines.slice(0, lastIncludedLineIdx + 1).join("\n");
-  kept = kept.replace(/__READABLE_(\d+)__/g, (_, idxStr) => {
-    const r = readableContents[Number.parseInt(idxStr, 10)];
-    if (!r) return "";
-    return `[${r.type === "note" ? "Note" : "Book"}: ${r.content}]`;
-  });
-
-  return kept;
+  return rawContent.slice(0, lines[lastIncludedLineIdx]!.originalEnd);
 }
 
 /**

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -31,7 +31,7 @@ import {
   useRecruitPartyMember,
   useRemovePartyMember,
 } from "../../hooks/use-game";
-import { useDeleteChat, useUpdateChatMetadata, useUpdateMessage } from "../../hooks/use-chats";
+import { useCreateMessage, useDeleteChat, useUpdateChatMetadata, useUpdateMessage } from "../../hooks/use-chats";
 import { useGenerate } from "../../hooks/use-generate";
 import { useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
 import { spriteKeys, type SpriteInfo } from "../../hooks/use-characters";
@@ -3513,6 +3513,100 @@ export function GameSurface({
     [updateMessage],
   );
 
+  const [gameInputFocusToken, setGameInputFocusToken] = useState(0);
+  // Two-stage interrupt:
+  //   1. Player clicks Interrupt → narration pauses (modal pre-empts further reading)
+  //      and we stash a *candidate* with the truncation we'd apply on commit.
+  //   2. Modal confirms via Yes ("risky") or Force Interrupt ("force"). On commit
+  //      we move the candidate into `pendingInterrupt` with a mode tag. Risky mode
+  //      tells the GM (system message) about the interrupt; force mode does not.
+  // Nothing is mutated server-side until the player presses Send.
+  const [interruptCandidate, setInterruptCandidate] = useState<{
+    chatId: string | null;
+    messageId: string | null;
+    truncatedContent: string | null;
+  } | null>(null);
+  const [interruptModalOpen, setInterruptModalOpen] = useState(false);
+  const [pendingInterrupt, setPendingInterrupt] = useState<{
+    chatId: string | null;
+    messageId: string | null;
+    truncatedContent: string | null;
+    mode: "risky" | "force";
+  } | null>(null);
+
+  const createMessage = useCreateMessage(activeChatId);
+
+  const handleInterruptRequest = useCallback(
+    ({ messageId, truncatedContent }: { messageId: string | null; truncatedContent: string | null }) => {
+      // Pause the GM (abort any in-flight stream) so segments don't keep flying past
+      // while the modal is open. We don't truncate or send a system message yet —
+      // those land at commit-time inside `handleSendGameTurn`.
+      useChatStore.getState().stopGeneration();
+      setInterruptCandidate({ chatId: activeChatId, messageId, truncatedContent });
+      setInterruptModalOpen(true);
+    },
+    [activeChatId],
+  );
+
+  const handleInterruptCancel = useCallback(() => {
+    setPendingInterrupt(null);
+    setInterruptCandidate(null);
+    setInterruptModalOpen(false);
+  }, []);
+
+  const closeInterruptModal = useCallback(() => {
+    // Player declined ("No"): clear candidate so narration can resume.
+    setInterruptModalOpen(false);
+    setInterruptCandidate(null);
+  }, []);
+
+  const confirmInterrupt = useCallback(
+    (mode: "risky" | "force") => {
+      if (!interruptCandidate) {
+        setInterruptModalOpen(false);
+        return;
+      }
+      setPendingInterrupt({ ...interruptCandidate, mode });
+      setInterruptModalOpen(false);
+      setInterruptCandidate(null);
+      setGameInputFocusToken((t) => t + 1);
+    },
+    [interruptCandidate],
+  );
+
+  // If the assistant message changes (new GM turn arrived) or the player switches chats,
+  // any pending anchor is stale — drop it.
+  const pendingInterruptMessageId = pendingInterrupt?.messageId ?? null;
+  const pendingInterruptChatId = pendingInterrupt?.chatId ?? null;
+  useEffect(() => {
+    if (!pendingInterrupt) return;
+    if (pendingInterruptChatId !== activeChatId) {
+      setPendingInterrupt(null);
+      return;
+    }
+    if (pendingInterruptMessageId) {
+      const stillExists = messages.some((m) => m.id === pendingInterruptMessageId);
+      if (!stillExists) setPendingInterrupt(null);
+    }
+  }, [activeChatId, messages, pendingInterrupt, pendingInterruptChatId, pendingInterruptMessageId]);
+
+  // Same staleness rules apply to the unconfirmed candidate.
+  useEffect(() => {
+    if (!interruptCandidate) return;
+    if (interruptCandidate.chatId !== activeChatId) {
+      setInterruptCandidate(null);
+      setInterruptModalOpen(false);
+    }
+  }, [activeChatId, interruptCandidate]);
+
+  // The narration pauses while the modal is open (pre-confirm) OR while a
+  // pending interrupt is in flight (post-confirm, awaiting send/Resume).
+  // `interruptCommitted` is the post-confirm subset — it gates the Resume button
+  // and the early input reveal so neither shows behind the confirmation modal.
+  const interruptPending = (interruptModalOpen || !!pendingInterrupt) && (pendingInterrupt?.chatId ?? activeChatId) === activeChatId;
+  const interruptCommitted = !!pendingInterrupt && pendingInterrupt.chatId === activeChatId;
+  const pendingInterruptMode = pendingInterrupt?.mode ?? null;
+
   // Party members from setup config
   const partyMembers = useMemo(() => {
     const config = chatMeta.gameSetupConfig as Record<string, unknown> | undefined;
@@ -4348,12 +4442,49 @@ export function GameSurface({
   );
 
   const handleSendGameTurn = useCallback(
-    (
+    async (
       message: string,
       attachments?: Array<{ type: string; data: string }>,
       options?: { commitPendingMove?: boolean },
     ) => {
       if (!sessionInteractive) return;
+      // Commit a pending interrupt: persist the truncated GM message before generating
+      // so the server-side prompt build doesn't see segments the player never read. We
+      // await so the PATCH (and the optional risky-mode system message) land before
+      // /generate reads from the DB.
+      const activeInterrupt =
+        pendingInterrupt && pendingInterrupt.chatId === activeChatId ? pendingInterrupt : null;
+      if (
+        activeInterrupt &&
+        activeInterrupt.messageId &&
+        activeInterrupt.truncatedContent !== null
+      ) {
+        try {
+          await updateMessage.mutateAsync({
+            messageId: activeInterrupt.messageId,
+            content: activeInterrupt.truncatedContent,
+          });
+        } catch {
+          // If the truncation PATCH fails the optimistic cache rolls back; let the send
+          // proceed anyway — the player still gets to act on what they saw.
+        }
+      }
+      // Risky mode tells the GM about the interrupt via a one-line system message.
+      // Force mode skips this on purpose — the GM only sees a shorter prior turn and
+      // the player's new input, so it has no idea anything was cut.
+      if (activeInterrupt && activeInterrupt.mode === "risky") {
+        try {
+          await createMessage.mutateAsync({
+            role: "system",
+            content:
+              "[Interrupt] The player attempts to interrupt the Game Master mid-action. Their following turn cuts in before the GM's planned events could occur. Treat their interjection as an in-fiction interruption — the situation may resist them, and the attempt can fail depending on context. If the player includes a dice roll, let the result determine whether the interruption succeeds or how it lands.",
+          });
+        } catch {
+          // Best-effort: even if the system message fails to persist we still send the
+          // turn. The truncation alone preserves the soft-pause UX.
+        }
+      }
+      setPendingInterrupt(null);
       if (options?.commitPendingMove && pendingMapMove) {
         moveOnMap.mutate({ chatId: activeChatId, position: pendingMapMove.position, mapId: activeMapId });
       }
@@ -4362,7 +4493,17 @@ export function GameSurface({
         setPendingMapMove(null);
       }
     },
-    [activeChatId, activeMapId, moveOnMap, pendingMapMove, sendMessage, sessionInteractive],
+    [
+      activeChatId,
+      activeMapId,
+      createMessage,
+      moveOnMap,
+      pendingInterrupt,
+      pendingMapMove,
+      sendMessage,
+      sessionInteractive,
+      updateMessage,
+    ],
   );
 
   useEffect(() => {
@@ -5622,6 +5763,10 @@ export function GameSurface({
                           segmentEdits={segmentEdits}
                           segmentDeletes={segmentDeletes}
                           onEditSegment={handleEditSegment}
+                          onInterruptRequest={handleInterruptRequest}
+                          onInterruptCancel={handleInterruptCancel}
+                          interruptPending={interruptPending}
+                          interruptCommitted={interruptCommitted}
                           inputSlot={
                             <GameInput
                               onSend={handleSendGameTurn}
@@ -5633,6 +5778,8 @@ export function GameSurface({
                               isStreaming={isStreaming}
                               inline
                               draftKey={activeChatId}
+                              focusToken={gameInputFocusToken}
+                              interruptMode={pendingInterruptMode}
                             />
                           }
                         />
@@ -5680,6 +5827,10 @@ export function GameSurface({
                       segmentEdits={segmentEdits}
                       segmentDeletes={segmentDeletes}
                       onEditSegment={handleEditSegment}
+                      onInterruptRequest={handleInterruptRequest}
+                      onInterruptCancel={handleInterruptCancel}
+                      interruptPending={interruptPending}
+                      interruptCommitted={interruptCommitted}
                       inputSlot={
                         <GameInput
                           onSend={handleSendGameTurn}
@@ -5691,6 +5842,8 @@ export function GameSurface({
                           isStreaming={isStreaming}
                           inline
                           draftKey={activeChatId}
+                          focusToken={gameInputFocusToken}
+                          interruptMode={pendingInterruptMode}
                         />
                       }
                     />
@@ -5916,6 +6069,55 @@ export function GameSurface({
           }
         />
       )}
+
+      <Modal
+        open={interruptModalOpen}
+        onClose={closeInterruptModal}
+        title="Attempt to Interrupt?"
+        width="max-w-md"
+      >
+        <div className="flex flex-col gap-4">
+          <div className="flex items-start gap-3">
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-red-500/15">
+              <AlertTriangle size="1.125rem" className="text-red-300" />
+            </div>
+            <p className="text-sm text-[var(--muted-foreground)]">
+              Interruption attempts can go badly depending on the situation. Force Interrupt cuts in
+              cleanly without telling the GM it was an interrupt — Yes attempts an in-fiction
+              interruption that the GM may resist.
+            </p>
+          </div>
+
+          <div className="flex flex-wrap items-center justify-end gap-2">
+            <button
+              onClick={closeInterruptModal}
+              className="rounded-lg bg-[var(--secondary)] px-3 py-1.5 text-xs font-medium text-[var(--muted-foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+            >
+              No
+            </button>
+            <button
+              onClick={() => confirmInterrupt("force")}
+              className="rounded-lg px-3 py-1.5 text-xs font-semibold ring-1 transition-colors"
+              style={{
+                color: "#20C20E",
+                backgroundColor: "rgba(32, 194, 14, 0.12)",
+                borderColor: "rgba(32, 194, 14, 0.35)",
+                boxShadow: "0 0 0 1px rgba(32, 194, 14, 0.35) inset",
+              }}
+              title="Cut in without telling the GM it was an interrupt"
+            >
+              Force Interrupt
+            </button>
+            <button
+              onClick={() => confirmInterrupt("risky")}
+              className="rounded-lg bg-red-500/20 px-3 py-1.5 text-xs font-semibold text-red-200 ring-1 ring-red-500/40 transition-colors hover:bg-red-500/30"
+              title="Attempt an in-fiction interruption — outcomes can fail"
+            >
+              Yes
+            </button>
+          </div>
+        </div>
+      </Modal>
 
       <Modal
         open={confirmEndSessionOpen}

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -3538,10 +3538,6 @@ export function GameSurface({
 
   const handleInterruptRequest = useCallback(
     ({ messageId, truncatedContent }: { messageId: string | null; truncatedContent: string | null }) => {
-      // Pause the GM (abort any in-flight stream) so segments don't keep flying past
-      // while the modal is open. We don't truncate or send a system message yet —
-      // those land at commit-time inside `handleSendGameTurn`.
-      useChatStore.getState().stopGeneration();
       setInterruptCandidate({ chatId: activeChatId, messageId, truncatedContent });
       setInterruptModalOpen(true);
     },
@@ -3566,6 +3562,7 @@ export function GameSurface({
         setInterruptModalOpen(false);
         return;
       }
+      useChatStore.getState().stopGeneration();
       setPendingInterrupt({ ...interruptCandidate, mode });
       setInterruptModalOpen(false);
       setInterruptCandidate(null);
@@ -3584,11 +3581,23 @@ export function GameSurface({
       setPendingInterrupt(null);
       return;
     }
+    const latestAssistantId = latestAssistantMsg?.id ?? null;
+    if (pendingInterruptMessageId && latestAssistantId && pendingInterruptMessageId !== latestAssistantId) {
+      setPendingInterrupt(null);
+      return;
+    }
     if (pendingInterruptMessageId) {
       const stillExists = messages.some((m) => m.id === pendingInterruptMessageId);
       if (!stillExists) setPendingInterrupt(null);
     }
-  }, [activeChatId, messages, pendingInterrupt, pendingInterruptChatId, pendingInterruptMessageId]);
+  }, [
+    activeChatId,
+    latestAssistantMsg?.id,
+    messages,
+    pendingInterrupt,
+    pendingInterruptChatId,
+    pendingInterruptMessageId,
+  ]);
 
   // Same staleness rules apply to the unconfirmed candidate.
   useEffect(() => {
@@ -3596,14 +3605,21 @@ export function GameSurface({
     if (interruptCandidate.chatId !== activeChatId) {
       setInterruptCandidate(null);
       setInterruptModalOpen(false);
+      return;
     }
-  }, [activeChatId, interruptCandidate]);
+    const latestAssistantId = latestAssistantMsg?.id ?? null;
+    if (interruptCandidate.messageId && latestAssistantId && interruptCandidate.messageId !== latestAssistantId) {
+      setInterruptCandidate(null);
+      setInterruptModalOpen(false);
+    }
+  }, [activeChatId, interruptCandidate, latestAssistantMsg?.id]);
 
   // The narration pauses while the modal is open (pre-confirm) OR while a
   // pending interrupt is in flight (post-confirm, awaiting send/Resume).
   // `interruptCommitted` is the post-confirm subset — it gates the Resume button
   // and the early input reveal so neither shows behind the confirmation modal.
-  const interruptPending = (interruptModalOpen || !!pendingInterrupt) && (pendingInterrupt?.chatId ?? activeChatId) === activeChatId;
+  const interruptPending =
+    (interruptModalOpen || !!pendingInterrupt) && (pendingInterrupt?.chatId ?? activeChatId) === activeChatId;
   const interruptCommitted = !!pendingInterrupt && pendingInterrupt.chatId === activeChatId;
   const pendingInterruptMode = pendingInterrupt?.mode ?? null;
 
@@ -4452,21 +4468,16 @@ export function GameSurface({
       // so the server-side prompt build doesn't see segments the player never read. We
       // await so the PATCH (and the optional risky-mode system message) land before
       // /generate reads from the DB.
-      const activeInterrupt =
-        pendingInterrupt && pendingInterrupt.chatId === activeChatId ? pendingInterrupt : null;
-      if (
-        activeInterrupt &&
-        activeInterrupt.messageId &&
-        activeInterrupt.truncatedContent !== null
-      ) {
+      const activeInterrupt = pendingInterrupt && pendingInterrupt.chatId === activeChatId ? pendingInterrupt : null;
+      if (activeInterrupt && activeInterrupt.messageId && activeInterrupt.truncatedContent !== null) {
         try {
           await updateMessage.mutateAsync({
             messageId: activeInterrupt.messageId,
             content: activeInterrupt.truncatedContent,
           });
         } catch {
-          // If the truncation PATCH fails the optimistic cache rolls back; let the send
-          // proceed anyway — the player still gets to act on what they saw.
+          toast.error("Failed to commit the interrupt. Please try again.");
+          return;
         }
       }
       // Risky mode tells the GM about the interrupt via a one-line system message.
@@ -4480,8 +4491,8 @@ export function GameSurface({
               "[Interrupt] The player attempts to interrupt the Game Master mid-action. Their following turn cuts in before the GM's planned events could occur. Treat their interjection as an in-fiction interruption — the situation may resist them, and the attempt can fail depending on context. If the player includes a dice roll, let the result determine whether the interruption succeeds or how it lands.",
           });
         } catch {
-          // Best-effort: even if the system message fails to persist we still send the
-          // turn. The truncation alone preserves the soft-pause UX.
+          toast.error("Failed to mark the risky interrupt. Please try again.");
+          return;
         }
       }
       setPendingInterrupt(null);
@@ -6070,21 +6081,15 @@ export function GameSurface({
         />
       )}
 
-      <Modal
-        open={interruptModalOpen}
-        onClose={closeInterruptModal}
-        title="Attempt to Interrupt?"
-        width="max-w-md"
-      >
+      <Modal open={interruptModalOpen} onClose={closeInterruptModal} title="Attempt to Interrupt?" width="max-w-md">
         <div className="flex flex-col gap-4">
           <div className="flex items-start gap-3">
             <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-red-500/15">
               <AlertTriangle size="1.125rem" className="text-red-300" />
             </div>
             <p className="text-sm text-[var(--muted-foreground)]">
-              Interruption attempts can go badly depending on the situation. Force Interrupt cuts in
-              cleanly without telling the GM it was an interrupt — Yes attempts an in-fiction
-              interruption that the GM may resist.
+              Interruption attempts can go badly depending on the situation. Force Interrupt cuts in cleanly without
+              telling the GM it was an interrupt — Yes attempts an in-fiction interruption that the GM may resist.
             </p>
           </div>
 


### PR DESCRIPTION
## Summary

Adds an **Interrupt!** button to game-mode narration so the player can stop the GM mid-action and write back early. Click → confirmation modal → soft-pause → type → send. Nothing is mutated server-side until the player actually sends, so backing out (Resume / No) is a true undo.

The confirmation modal exposes three options:
- **No** — close, narration resumes from where it paused.
- **Yes** (red) — *risky* in-fiction interrupt; the GM is told via a one-line system message and may resist or fail the attempt. The input bar paints red, the dice button glows, and a `using dice recommended` hint appears next to it.
- **Force Interrupt** (`#20C20E` hacker green) — cuts in cleanly. The GM's last message is truncated at the segment the player saw, but no system message is added, so the GM has no idea anything was cut. Input bar gets a matching green ring + `force interrupting` label.

The truncation reuses the same line-based emission logic as `parseNarrationSegments`, so the prior assistant message is shortened to end at the segment the player was reading. On send, the truncation `PATCH` is awaited before `/generate` reads from the DB, so prompt construction sees the cut.

Auto-play state is snapshotted on pause and restored on Resume — if it was off, it stays off. A stale interrupt anchor self-clears on chat switch or when a new GM turn arrives, so it can never be applied to the wrong message.

## Screenshots

### Desktop
<img width="1907" height="861" alt="image" src="https://github.com/user-attachments/assets/5937acc1-e585-45c0-8cbd-c2e223a008ea" />
<img width="1038" height="728" alt="image" src="https://github.com/user-attachments/assets/10e9cd3f-568b-4a17-91b5-90831107f59d" />
<img width="1908" height="863" alt="image" src="https://github.com/user-attachments/assets/b561b235-226d-409b-8b48-6e0e1ee9f63c" />



### Mobile

<img width="945" height="2048" alt="WhatsApp Image 2026-04-28 at 10 46 32 PM" src="https://github.com/user-attachments/assets/e04df026-4ac7-4fba-8f5d-dcd5a333f6af" />
<img width="945" height="2048" alt="WhatsApp Image 2026-04-28 at 10 46 31 PM" src="https://github.com/user-attachments/assets/3ebd21c5-6d2d-41b7-a829-225db52eadfc" />
<img width="945" height="2048" alt="WhatsApp Image 2026-04-28 at 10 46 31 PM (1)" src="https://github.com/user-attachments/assets/8fba3d65-0034-420c-a357-8e1e6b44042b" />

## Test plan

- [x] Click **Interrupt!** mid-narration — modal appears, narration pauses, input bar does NOT appear behind the modal, auto-play stops.
- [x] Click **No** — modal closes, narration resumes, auto-play returns to its prior state.
- [x] Click **Yes** — modal closes, input bar appears with red ring, dice button glows, `using dice recommended` label visible (>=640px).
- [x] Click **Force Interrupt** — modal closes, input bar appears with green ring, `force interrupting` label visible, dice not glowing.
- [x] Click **Resume** in either committed mode — pending interrupt is discarded, narration resumes, auto-play returns to its prior state, no server-side mutation occurred.
- [x] In Yes (risky) mode, send a turn — verify the GM message in chat history was truncated at the segment you saw AND a `[Interrupt] …` system message appears just before your user turn. Next AI response acknowledges the interrupt.
- [x] In Force mode, send a turn — verify the GM message is truncated but NO system message is added. Next AI response continues without knowing it was interrupted.
- [x] Queue a dice roll in Yes mode and send — verify the dice tag is appended to your user message and the GM treats the result as the interrupt's success/failure.
- [x] Switch chats while an interrupt is pending — pending state clears.
- [x] Wait for a new GM turn while an interrupt is pending — pending state clears.
- [x] Test on mobile (<640px): all narration-card controls fit on one row (Logs/Inventory/Interrupt collapse to icons).
- [x] Confirm \`pnpm check\` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interrupt flow: players can request, confirm, force, or resume narration interruptions with a confirmation modal.
  * Two interrupt modes: "risky" (dice-recommended hint + red styling) and "force" (green highlight, no cost).
  * Inline input now appears appropriately during/after interrupts; narration auto-play pauses and restores around interrupt actions.
  * Input focus behavior improved and buttons/tooltips updated to reflect interrupt state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->