### PR TITLE
Fix NanoGPT image references

### DIFF
--- a/packages/client/src/components/ui/SpriteGenerationModal.tsx
+++ b/packages/client/src/components/ui/SpriteGenerationModal.tsx
@@ -277,7 +277,7 @@ export function SpriteGenerationModal({
   useEffect(() => {
     setAppearance(defaultAppearance ?? "");
     setReferenceImages([]);
-    setUseCurrentAvatarReference(false);
+    setUseCurrentAvatarReference(!!defaultAvatarUrl);
     setStep(0);
     setGeneratedSheet(null);
     setCells([]);

--- a/packages/server/src/routes/sprites.routes.ts
+++ b/packages/server/src/routes/sprites.routes.ts
@@ -4,7 +4,8 @@
 import type { FastifyInstance } from "fastify";
 import { existsSync, mkdirSync, createReadStream, readdirSync, unlinkSync, statSync, readFileSync } from "fs";
 import { writeFile, mkdir, readdir, unlink } from "fs/promises";
-import { join, extname } from "path";
+import { dirname, extname, isAbsolute, join, relative, resolve } from "path";
+import { fileURLToPath } from "url";
 import { DATA_DIR } from "../utils/data-dir.js";
 
 // sharp is an optional dependency — native prebuilds don't exist for all platforms
@@ -56,6 +57,9 @@ import { generateImage } from "../services/image/image-generation.js";
 import { createConnectionsStorage } from "../services/storage/connections.storage.js";
 
 const SPRITES_ROOT = join(DATA_DIR, "sprites");
+const ROUTE_DIR = dirname(fileURLToPath(import.meta.url));
+const CLIENT_PUBLIC_DIR = resolve(ROUTE_DIR, "../../../client/public");
+const CLIENT_DIST_DIR = resolve(ROUTE_DIR, "../../../client/dist");
 
 function ensureDir(dir: string) {
   if (!existsSync(dir)) {
@@ -284,7 +288,39 @@ function extractBase64ImageData(input: string): string {
   return trimmed;
 }
 
-/** Accepts data URL, raw base64, or /api/avatars/file/<filename> URL and returns base64 if resolvable. */
+function normalizeLocalImagePath(input: string): string {
+  const value = input.trim();
+  if (!value) return "";
+  if (value.startsWith("/")) return value.split("?")[0] ?? value;
+  try {
+    const url = new URL(value);
+    return url.pathname;
+  } catch {
+    return value.split("?")[0] ?? value;
+  }
+}
+
+function readSafeNestedFile(root: string, pathSegments: string[]): string | undefined {
+  if (pathSegments.length === 0) return undefined;
+  const decoded = pathSegments.map((segment) => decodeURIComponent(segment));
+  if (
+    decoded.some((segment) => !segment || segment.includes("..") || segment.includes("/") || segment.includes("\\"))
+  ) {
+    return undefined;
+  }
+  const diskPath = resolve(root, ...decoded);
+  const normalizedRoot = resolve(root);
+  const relativePath = relative(normalizedRoot, diskPath);
+  if (relativePath.startsWith("..") || relativePath === "" || isAbsolute(relativePath)) return undefined;
+  try {
+    if (!existsSync(diskPath)) return undefined;
+    return readFileSync(diskPath).toString("base64");
+  } catch {
+    return undefined;
+  }
+}
+
+/** Accepts data URL, raw base64, or local avatar/sprite URL and returns base64 if resolvable. */
 function resolveReferenceImageBase64(input?: string): string | undefined {
   if (!input?.trim()) return undefined;
   const value = input.trim();
@@ -296,18 +332,59 @@ function resolveReferenceImageBase64(input?: string): string | undefined {
     return looksLikeBase64(b64) ? b64 : undefined;
   }
 
-  if (value.startsWith("/api/avatars/file/")) {
-    const filenameRaw = value.split("/").pop()?.split("?")[0];
+  const path = normalizeLocalImagePath(value);
+  if (path.startsWith("/api/avatars/file/")) {
+    const filenameRaw = path.split("/").pop();
     if (!filenameRaw) return undefined;
     const filename = decodeURIComponent(filenameRaw);
     if (filename.includes("..") || filename.includes("/") || filename.includes("\\")) return undefined;
-    const diskPath = join(DATA_DIR, "avatars", filename);
     try {
+      const diskPath = join(DATA_DIR, "avatars", filename);
       if (!existsSync(diskPath)) return undefined;
       return readFileSync(diskPath).toString("base64");
     } catch {
       return undefined;
     }
+  }
+
+  if (path.startsWith("/api/avatars/npc/")) {
+    const parts = path.split("/").filter(Boolean);
+    const chatId = parts[3] ? decodeURIComponent(parts[3]) : "";
+    const filename = parts[4] ? decodeURIComponent(parts[4]) : "";
+    if (!chatId || !filename) return undefined;
+    if (
+      chatId.includes("..") ||
+      chatId.includes("/") ||
+      chatId.includes("\\") ||
+      filename.includes("..") ||
+      filename.includes("/") ||
+      filename.includes("\\")
+    ) {
+      return undefined;
+    }
+    try {
+      const diskPath = join(DATA_DIR, "avatars", "npc", chatId, filename);
+      if (!existsSync(diskPath)) return undefined;
+      return readFileSync(diskPath).toString("base64");
+    } catch {
+      return undefined;
+    }
+  }
+
+  if (path.startsWith("/sprites/")) {
+    const segments = path.split("/").filter(Boolean).slice(1);
+    return (
+      readSafeNestedFile(join(CLIENT_PUBLIC_DIR, "sprites"), segments) ??
+      readSafeNestedFile(join(CLIENT_DIST_DIR, "sprites"), segments)
+    );
+  }
+
+  if (path.startsWith("/api/sprites/")) {
+    const parts = path.split("/").filter(Boolean);
+    const characterId = parts[2] ? decodeURIComponent(parts[2]) : "";
+    const filename = parts[4] ? decodeURIComponent(parts[4]) : "";
+    if (!characterId || !filename) return undefined;
+    return readSafeNestedFile(SPRITES_ROOT, [characterId, filename]);
   }
 
   if (looksLikeBase64(value)) return value;

--- a/packages/server/src/services/image/image-generation.ts
+++ b/packages/server/src/services/image/image-generation.ts
@@ -94,8 +94,9 @@ export async function generateImage(
   const resolvedSource = resolveImageBackend(source, baseUrl, serviceHint, request.model);
   switch (resolvedSource) {
     case "openai":
-    case "nanogpt":
       return generateOpenAI(baseUrl, apiKey, request);
+    case "nanogpt":
+      return generateNanoGPT(baseUrl, apiKey, request);
     case "pollinations":
       return generatePollinations(request);
     case "stability":
@@ -138,6 +139,81 @@ function isOpenAIGptImageModel(model?: string): boolean {
   return !!model && /^gpt-image-(?:1|1\.5|2)(?:$|-)/i.test(model.trim());
 }
 
+function imageDataUrlFromReference(reference: string): string {
+  const trimmed = reference.trim();
+  if (trimmed.startsWith("data:")) return trimmed;
+  const base64 = trimmed.replace(/\s+/g, "");
+  return `data:${detectImageMimeType(base64)};base64,${base64}`;
+}
+
+function detectImageMimeType(base64: string): string {
+  const bytes = Buffer.from(base64.slice(0, 64), "base64");
+  if (bytes[0] === 0x89 && bytes[1] === 0x50 && bytes[2] === 0x4e && bytes[3] === 0x47) return "image/png";
+  if (bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) return "image/jpeg";
+  if (
+    bytes[0] === 0x52 &&
+    bytes[1] === 0x49 &&
+    bytes[2] === 0x46 &&
+    bytes[3] === 0x46 &&
+    bytes[8] === 0x57 &&
+    bytes[9] === 0x45 &&
+    bytes[10] === 0x42 &&
+    bytes[11] === 0x50
+  ) {
+    return "image/webp";
+  }
+  if (bytes[0] === 0x47 && bytes[1] === 0x49 && bytes[2] === 0x46) return "image/gif";
+  return "image/png";
+}
+
+function nanoGPTImagesUrl(baseUrl: string): string {
+  const trimmed = baseUrl.replace(/\/+$/, "");
+  try {
+    const parsed = new URL(trimmed);
+    const path = parsed.pathname.replace(/\/+$/, "");
+    if (path.endsWith("/images/generations")) {
+      // Keep user-supplied full endpoint URLs, but normalize the legacy /api/v1 prefix below.
+    } else if (path === "" || path === "/" || path.endsWith("/api")) {
+      parsed.pathname = "/v1/images/generations";
+    } else if (path.endsWith("/api/v1")) {
+      parsed.pathname = `${path.slice(0, -"/api/v1".length)}/v1/images/generations`;
+    } else if (path.endsWith("/v1")) {
+      parsed.pathname = `${path}/images/generations`;
+    } else {
+      parsed.pathname = `${path}/images/generations`;
+    }
+    parsed.pathname = parsed.pathname.replace(/\/api\/v1\/images\/generations$/, "/v1/images/generations");
+    parsed.search = "";
+    parsed.hash = "";
+    return parsed.toString();
+  } catch {
+    return `${trimmed}/images/generations`;
+  }
+}
+
+async function downloadImageUrl(imageUrl: string): Promise<ImageGenResult> {
+  const imgResp = await fetch(imageUrl, { signal: AbortSignal.timeout(IMAGE_GEN_TIMEOUT) });
+  if (!imgResp.ok) {
+    throw new Error(`Failed to download generated image (${imgResp.status})`);
+  }
+
+  const arrayBuffer = await imgResp.arrayBuffer();
+  const base64 = Buffer.from(arrayBuffer).toString("base64");
+
+  const contentType = imgResp.headers.get("content-type") ?? "";
+  let mimeType = "image/png";
+  let ext = "png";
+  if (contentType.includes("jpeg") || contentType.includes("jpg") || imageUrl.match(/\.jpe?g/i)) {
+    mimeType = "image/jpeg";
+    ext = "jpg";
+  } else if (contentType.includes("webp") || imageUrl.match(/\.webp/i)) {
+    mimeType = "image/webp";
+    ext = "webp";
+  }
+
+  return { base64, mimeType, ext };
+}
+
 async function generateOpenAI(baseUrl: string, apiKey: string, request: ImageGenRequest): Promise<ImageGenResult> {
   const url = `${baseUrl.replace(/\/+$/, "")}/images/generations`;
   const usesGptImageApi = isOpenAIGptImageModel(request.model);
@@ -175,6 +251,54 @@ async function generateOpenAI(baseUrl: string, apiKey: string, request: ImageGen
   if (!b64) throw new Error("No image data in OpenAI response");
 
   return { base64: b64, mimeType: "image/png", ext: "png" };
+}
+
+async function generateNanoGPT(baseUrl: string, apiKey: string, request: ImageGenRequest): Promise<ImageGenResult> {
+  const url = nanoGPTImagesUrl(baseUrl);
+  const body: Record<string, unknown> = {
+    prompt: request.prompt,
+    n: 1,
+    size: `${request.width ?? 1024}x${request.height ?? 1024}`,
+    response_format: "b64_json",
+  };
+  if (request.model) body.model = request.model;
+  if (request.negativePrompt) body.negative_prompt = request.negativePrompt;
+
+  const references = request.referenceImages?.length
+    ? request.referenceImages
+    : request.referenceImage
+      ? [request.referenceImage]
+      : [];
+  if (request.model?.toLowerCase().includes("flux-kontext")) {
+    body.kontext_max_mode = true;
+  }
+  if (references.length === 1) {
+    body.imageDataUrl = imageDataUrlFromReference(references[0]!);
+  } else if (references.length > 1) {
+    body.imageDataUrls = references.map(imageDataUrlFromReference);
+  }
+
+  const resp = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(IMAGE_GEN_TIMEOUT),
+  });
+
+  if (!resp.ok) {
+    const errText = await resp.text().catch(() => "Unknown error");
+    throw new Error(`NanoGPT image generation failed (${resp.status}): ${sanitizeErrorText(errText)}`);
+  }
+
+  const data = (await resp.json()) as { data?: Array<{ b64_json?: string; url?: string }> };
+  const result = data.data?.[0];
+  if (result?.b64_json) return { base64: result.b64_json, mimeType: "image/png", ext: "png" };
+  if (result?.url) return downloadImageUrl(result.url);
+
+  throw new Error("No image data in NanoGPT response");
 }
 
 async function generatePollinations(request: ImageGenRequest): Promise<ImageGenResult> {
@@ -506,28 +630,7 @@ async function generateViaChatCompletions(
     throw new Error(`No image URL found in proxy response: ${content.slice(0, 200)}`);
   }
 
-  // Download the image
-  const imgResp = await fetch(imageUrl, { signal: AbortSignal.timeout(IMAGE_GEN_TIMEOUT) });
-  if (!imgResp.ok) {
-    throw new Error(`Failed to download generated image (${imgResp.status})`);
-  }
-
-  const arrayBuffer = await imgResp.arrayBuffer();
-  const base64 = Buffer.from(arrayBuffer).toString("base64");
-
-  // Detect mime type from URL extension or content-type header
-  const contentType = imgResp.headers.get("content-type") ?? "";
-  let mimeType = "image/png";
-  let ext = "png";
-  if (contentType.includes("jpeg") || contentType.includes("jpg") || imageUrl.match(/\.jpe?g/i)) {
-    mimeType = "image/jpeg";
-    ext = "jpg";
-  } else if (contentType.includes("webp") || imageUrl.match(/\.webp/i)) {
-    mimeType = "image/webp";
-    ext = "webp";
-  }
-
-  return { base64, mimeType, ext };
+  return downloadImageUrl(imageUrl);
 }
 
 // ── ComfyUI ──

--- a/packages/shared/src/constants/model-lists.ts
+++ b/packages/shared/src/constants/model-lists.ts
@@ -513,6 +513,7 @@ export function inferImageSource(model: string, baseUrl: string): string {
     return m;
   }
   if (m === "drawthings") return "automatic1111";
+  if (u.includes("nano-gpt.com")) return "nanogpt";
   if (m.startsWith("dall-e") || m.startsWith("gpt-image") || u.includes("openai.com")) return "openai";
   if (m.startsWith("sd3") || u.includes("stability.ai")) return "stability";
   if (m.includes("nai-diffusion") || u.includes("novelai.net")) return "novelai";
@@ -526,7 +527,6 @@ export function inferImageSource(model: string, baseUrl: string): string {
   if (m.includes("gemini") && m.includes("image")) return "gemini_image";
   if (m.includes("imagen")) return "gemini_image";
   // OpenAI-compatible fallback (works for most proxies)
-  if (u.includes("nano-gpt.com")) return "nanogpt";
   return "openai";
 }
 


### PR DESCRIPTION
Fixes the problem with avatars not being used as reference images, and reference images not working at all with nanogpt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for NanoGPT as an image generation provider.
  * Sprite generation modal now automatically enables the reference image option when a default avatar is available.

* **Improvements**
  * Enhanced reference image handling and source detection across multiple reference types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->