### PR TITLE
feat(conversation): add durable note tag for connected roleplays

### DIFF
--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -43,6 +43,7 @@ import {
   FilePlus2,
   Upload,
   Download,
+  StickyNote,
 } from "lucide-react";
 import { cn, getAvatarCropStyle, type AvatarCrop } from "../../lib/utils";
 import { showAlertDialog, showConfirmDialog, showPromptDialog } from "../../lib/app-dialogs";
@@ -73,6 +74,9 @@ import {
   useChatMemories,
   useDeleteChatMemory,
   useClearChatMemories,
+  useChatNotes,
+  useDeleteChatNote,
+  useClearChatNotes,
   chatKeys,
 } from "../../hooks/use-chats";
 import { api } from "../../lib/api-client";
@@ -87,7 +91,14 @@ import {
   useApplyChatPreset,
   useImportChatPreset,
 } from "../../hooks/use-chat-presets";
-import type { AgentPhase, ChatMode, ChatMemoryChunk, ChatPreset, ChatPresetSettings } from "@marinara-engine/shared";
+import type {
+  AgentPhase,
+  ChatMode,
+  ChatMemoryChunk,
+  ChatPreset,
+  ChatPresetSettings,
+  ConversationNote,
+} from "@marinara-engine/shared";
 import { useAgentConfigs, useCreateAgent, useUpdateAgent, type AgentConfigRow } from "../../hooks/use-agents";
 import { useAgentStore } from "../../stores/agent.store";
 import {
@@ -2400,6 +2411,9 @@ export function ChatSettingsDrawer({
               })()}
             </Section>
           )}
+
+          {/* Notes from Conversation — durable notes saved by the connected conversation's character */}
+          {!isConversation && chat.connectedChatId && <ConversationNotesSection chatId={chat.id} />}
 
           {/* Connect to Conversation — game mode without existing link */}
           {chatMode === "game" && !chat.connectedChatId && (
@@ -4863,5 +4877,99 @@ function HapticConnectionPanel() {
         </div>
       )}
     </div>
+  );
+}
+
+function ConversationNotesSection({ chatId }: { chatId: string }) {
+  const notesQuery = useChatNotes(chatId);
+  const deleteNote = useDeleteChatNote(chatId);
+  const clearNotes = useClearChatNotes(chatId);
+  const notes = useMemo<ConversationNote[]>(() => notesQuery.data ?? [], [notesQuery.data]);
+  const totalChars = useMemo(() => notes.reduce((acc, n) => acc + n.content.length, 0), [notes]);
+
+  const handleDelete = async (note: ConversationNote) => {
+    const ok = await showConfirmDialog({
+      title: "Delete Note",
+      message: "Remove this note from the connected roleplay's prompt?",
+      confirmLabel: "Delete",
+      tone: "destructive",
+    });
+    if (ok) deleteNote.mutate(note.id);
+  };
+
+  const handleClear = async () => {
+    if (notes.length === 0) return;
+    const ok = await showConfirmDialog({
+      title: "Clear All Notes",
+      message: "Remove every durable note from this roleplay? This cannot be undone.",
+      confirmLabel: "Clear all",
+      tone: "destructive",
+    });
+    if (ok) clearNotes.mutate();
+  };
+
+  return (
+    <Section
+      label="Conversation Notes"
+      icon={<StickyNote size="0.875rem" />}
+      count={notes.length}
+      help="Durable notes the connected conversation's character has saved using <note>. They persist in this roleplay's prompt every turn until cleared."
+    >
+      <div className="space-y-2">
+        <div className="flex items-center justify-between gap-2 text-[0.625rem] text-[var(--muted-foreground)]">
+          <span>
+            {notes.length === 0
+              ? "No notes saved yet."
+              : `${notes.length} ${notes.length === 1 ? "note" : "notes"} · ${totalChars.toLocaleString()} chars`}
+          </span>
+          {notes.length > 0 && (
+            <button
+              type="button"
+              onClick={handleClear}
+              disabled={clearNotes.isPending}
+              className="rounded-md p-1 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--destructive)]/15 hover:text-[var(--destructive)] disabled:opacity-40"
+              title="Clear all notes"
+            >
+              <Trash2 size="0.75rem" />
+            </button>
+          )}
+        </div>
+
+        {notes.length === 0 ? (
+          <p className="rounded-lg bg-[var(--secondary)]/50 px-3 py-3 text-[0.625rem] leading-relaxed text-[var(--muted-foreground)]">
+            Characters in the connected conversation can save things they want this roleplay to durably remember by
+            wrapping text in <code className="rounded bg-[var(--accent)]/60 px-1">{"<note>...</note>"}</code>. Saved
+            notes will appear here.
+          </p>
+        ) : (
+          <ul className="space-y-1.5">
+            {notes.map((note) => (
+              <li
+                key={note.id}
+                className="flex items-start gap-2 rounded-lg bg-[var(--card)] px-2.5 py-2 ring-1 ring-[var(--border)]"
+              >
+                <div className="flex-1 min-w-0">
+                  <p className="whitespace-pre-wrap break-words text-[0.6875rem] leading-relaxed text-[var(--foreground)]">
+                    {note.content}
+                  </p>
+                  <p className="mt-1 text-[0.5625rem] text-[var(--muted-foreground)]">
+                    {formatMemoryDate(note.createdAt)}
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => void handleDelete(note)}
+                  disabled={deleteNote.isPending}
+                  className="shrink-0 rounded-md p-1 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--destructive)]/15 hover:text-[var(--destructive)] disabled:opacity-40"
+                  title="Delete this note"
+                >
+                  <Trash2 size="0.6875rem" />
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </Section>
   );
 }

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -4918,11 +4918,15 @@ function ConversationNotesSection({ chatId }: { chatId: string }) {
       <div className="space-y-2">
         <div className="flex items-center justify-between gap-2 text-[0.625rem] text-[var(--muted-foreground)]">
           <span>
-            {notes.length === 0
-              ? "No notes saved yet."
-              : `${notes.length} ${notes.length === 1 ? "note" : "notes"} · ${totalChars.toLocaleString()} chars`}
+            {notesQuery.isLoading
+              ? "Loading…"
+              : notesQuery.error
+                ? "Failed to load."
+                : notes.length === 0
+                  ? "No notes saved yet."
+                  : `${notes.length} ${notes.length === 1 ? "note" : "notes"} · ${totalChars.toLocaleString()} chars`}
           </span>
-          {notes.length > 0 && (
+          {notes.length > 0 && !notesQuery.isLoading && !notesQuery.error && (
             <button
               type="button"
               onClick={handleClear}
@@ -4935,7 +4939,15 @@ function ConversationNotesSection({ chatId }: { chatId: string }) {
           )}
         </div>
 
-        {notes.length === 0 ? (
+        {notesQuery.isLoading ? (
+          <p className="rounded-lg bg-[var(--secondary)]/50 px-3 py-3 text-center text-[0.625rem] leading-relaxed text-[var(--muted-foreground)]">
+            Loading notes…
+          </p>
+        ) : notesQuery.error ? (
+          <p className="rounded-lg bg-[var(--destructive)]/10 px-3 py-3 text-[0.625rem] leading-relaxed text-[var(--destructive)] ring-1 ring-[var(--destructive)]/25">
+            Failed to load notes.
+          </p>
+        ) : notes.length === 0 ? (
           <p className="rounded-lg bg-[var(--secondary)]/50 px-3 py-3 text-[0.625rem] leading-relaxed text-[var(--muted-foreground)]">
             Characters in the connected conversation can save things they want this roleplay to durably remember by
             wrapping text in <code className="rounded bg-[var(--accent)]/60 px-1">{"<note>...</note>"}</code>. Saved

--- a/packages/client/src/hooks/use-chats.ts
+++ b/packages/client/src/hooks/use-chats.ts
@@ -12,6 +12,7 @@ import { clearBrowserRuntimeCaches } from "../lib/browser-runtime";
 import type {
   Chat,
   ChatMemoryChunk,
+  ConversationNote,
   Message,
   MessageSwipe,
   DaySummaryEntry,
@@ -25,6 +26,7 @@ export const chatKeys = {
   messages: (chatId: string) => [...chatKeys.all, "messages", chatId] as const,
   messageCount: (chatId: string) => [...chatKeys.all, "messageCount", chatId] as const,
   memories: (chatId: string) => [...chatKeys.all, "memories", chatId] as const,
+  notes: (chatId: string) => [...chatKeys.all, "notes", chatId] as const,
   group: (groupId: string) => [...chatKeys.all, "group", groupId] as const,
 };
 
@@ -123,6 +125,35 @@ export function useClearChatMemories(chatId: string | null) {
     mutationFn: () => api.delete(`/chats/${chatId}/memories`),
     onSuccess: () => {
       if (chatId) qc.invalidateQueries({ queryKey: chatKeys.memories(chatId) });
+    },
+  });
+}
+
+export function useChatNotes(chatId: string | null) {
+  return useQuery({
+    queryKey: chatKeys.notes(chatId ?? ""),
+    queryFn: () => api.get<ConversationNote[]>(`/chats/${chatId}/notes`),
+    enabled: !!chatId,
+    staleTime: 10_000,
+  });
+}
+
+export function useDeleteChatNote(chatId: string | null) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (noteId: string) => api.delete(`/chats/${chatId}/notes/${noteId}`),
+    onSuccess: () => {
+      if (chatId) qc.invalidateQueries({ queryKey: chatKeys.notes(chatId) });
+    },
+  });
+}
+
+export function useClearChatNotes(chatId: string | null) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () => api.delete(`/chats/${chatId}/notes`),
+    onSuccess: () => {
+      if (chatId) qc.invalidateQueries({ queryKey: chatKeys.notes(chatId) });
     },
   });
 }

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -341,6 +341,14 @@ const CREATE_TABLES: string[] = [
     consumed TEXT NOT NULL DEFAULT 'false',
     created_at TEXT NOT NULL
   )`,
+  `CREATE TABLE IF NOT EXISTS conversation_notes (
+    id TEXT PRIMARY KEY NOT NULL,
+    source_chat_id TEXT NOT NULL REFERENCES chats(id) ON DELETE CASCADE,
+    target_chat_id TEXT NOT NULL REFERENCES chats(id) ON DELETE CASCADE,
+    content TEXT NOT NULL,
+    anchor_message_id TEXT,
+    created_at TEXT NOT NULL
+  )`,
   `CREATE TABLE IF NOT EXISTS memory_chunks (
     id TEXT PRIMARY KEY NOT NULL,
     chat_id TEXT NOT NULL REFERENCES chats(id) ON DELETE CASCADE,
@@ -574,6 +582,9 @@ export async function runMigrations(db: DB) {
   );
   await db.run(
     sql.raw(`CREATE INDEX IF NOT EXISTS idx_ooc_influences_target ON ooc_influences(target_chat_id, consumed)`),
+  );
+  await db.run(
+    sql.raw(`CREATE INDEX IF NOT EXISTS idx_conversation_notes_target ON conversation_notes(target_chat_id, created_at)`),
   );
   await db.run(
     sql.raw(`CREATE INDEX IF NOT EXISTS idx_memory_chunks_chat ON memory_chunks(chat_id, last_message_at DESC)`),

--- a/packages/server/src/db/schema/chats.ts
+++ b/packages/server/src/db/schema/chats.ts
@@ -82,6 +82,23 @@ export const oocInfluences = sqliteTable("ooc_influences", {
   createdAt: text("created_at").notNull(),
 });
 
+export const conversationNotes = sqliteTable("conversation_notes", {
+  id: text("id").primaryKey(),
+  /** The conversation chat that emitted this note */
+  sourceChatId: text("source_chat_id")
+    .notNull()
+    .references(() => chats.id, { onDelete: "cascade" }),
+  /** The roleplay chat where this note will be durably injected */
+  targetChatId: text("target_chat_id")
+    .notNull()
+    .references(() => chats.id, { onDelete: "cascade" }),
+  /** The note text to inject on every roleplay turn until cleared */
+  content: text("content").notNull(),
+  /** The conversation message that produced this note (for traceability) */
+  anchorMessageId: text("anchor_message_id"),
+  createdAt: text("created_at").notNull(),
+});
+
 // ── Memory Chunks: embedded conversation fragments for semantic recall ──
 export const memoryChunks = sqliteTable("memory_chunks", {
   id: text("id").primaryKey(),

--- a/packages/server/src/db/seed-mari.ts
+++ b/packages/server/src/db/seed-mari.ts
@@ -136,7 +136,8 @@ Scenes are mini-roleplays that branch off from conversation chats. They let conv
 ### Connected Chats & OOC System
 Conversation and roleplay chats can be linked together bidirectionally via the "connected chat" feature:
 
-- **Influence tags** (conversation → roleplay): When a character in a conversation chat wraps text in \`<influence>text</influence>\`, that text is stored and injected into the connected roleplay's next generation as \`<ooc_influences>\`. This lets conversation characters subtly steer the roleplay.
+- **Influence tags** (conversation → roleplay, one-shot): When a character in a conversation chat wraps text in \`<influence>text</influence>\`, that text is stored and injected into the connected roleplay's next generation as \`<ooc_influences>\`, then consumed. This lets conversation characters subtly steer the roleplay for a single turn.
+- **Note tags** (conversation → roleplay, durable): When a character in a conversation chat wraps text in \`<note>text</note>\`, that text is saved against the connected roleplay and injected as \`<conversation_notes>\` on every generation until the user clears it from the chat settings drawer. Use this for things the roleplay character should durably remember (a fact learned, a promise made, an established trait). Notes are capped to a total character budget per roleplay; oldest are pruned when the cap is reached.
 - **OOC tags** (roleplay → conversation): When a character in a roleplay wraps text in \`<ooc>comment</ooc>\`, that text is stripped from the roleplay message and posted as an assistant message in the connected conversation chat. This lets roleplay characters "break character" to chat casually.
 - **Connected roleplay context**: The conversation prompt includes a summary and recent messages from the connected roleplay, so conversation characters stay aware of what's happening in the story.
 

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -161,12 +161,30 @@ export async function chatsRoutes(app: FastifyInstance) {
     if (!chat) return reply.status(404).send({ error: "Chat not found" });
     await storage.disconnectChat(req.params.id);
     await storage.deleteInfluencesForChat(req.params.id);
+    await storage.deleteNotesForChat(req.params.id);
     return { disconnected: true };
   });
 
   // List pending OOC influences for a chat
   app.get<{ Params: { id: string } }>("/:id/influences", async (req) => {
     return storage.listPendingInfluences(req.params.id);
+  });
+
+  // List durable conversation notes targeting a chat
+  app.get<{ Params: { id: string } }>("/:id/notes", async (req) => {
+    return storage.listNotes(req.params.id);
+  });
+
+  // Delete a single conversation note
+  app.delete<{ Params: { id: string; noteId: string } }>("/:id/notes/:noteId", async (req, reply) => {
+    await storage.deleteNote(req.params.noteId);
+    return reply.status(204).send();
+  });
+
+  // Clear every conversation note targeting a chat
+  app.delete<{ Params: { id: string } }>("/:id/notes", async (req, reply) => {
+    await storage.clearNotes(req.params.id);
+    return reply.status(204).send();
   });
 
   // Delete all chats in a group (all branches)

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -175,9 +175,9 @@ export async function chatsRoutes(app: FastifyInstance) {
     return storage.listNotes(req.params.id);
   });
 
-  // Delete a single conversation note
+  // Delete a single conversation note (scoped to the target chat to prevent cross-chat deletion)
   app.delete<{ Params: { id: string; noteId: string } }>("/:id/notes/:noteId", async (req, reply) => {
-    await storage.deleteNote(req.params.noteId);
+    await storage.deleteNoteForChat(req.params.id, req.params.noteId);
     return reply.status(204).send();
   });
 

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -58,6 +58,7 @@ import {
   type SelfieCommand,
   type MemoryCommand,
   type InfluenceCommand,
+  type NoteCommand,
   type SceneCommand,
   type HapticCommand,
   type CreatePersonaCommand,
@@ -1880,6 +1881,11 @@ export async function generateRoutes(app: FastifyInstance) {
                 ``,
                 `Influences are injected into the roleplay's context before the next generation. Use them sparingly — only when conversation content genuinely should cross over into the roleplay.`,
                 `The influence tag is stripped from your visible message. The rest of your response is shown normally.`,
+                ``,
+                `If something said in this conversation should durably persist in the roleplay's context across many turns (a fact the character should keep remembering, a promise made, a secret revealed, a name learned), create a note tag instead of an influence:`,
+                `<note>fact, decision, or detail the roleplay character should keep remembering</note>`,
+                `Notes are shown to the roleplay character on every future turn until the user clears them. Use influences for one-shot mid-scene steering; use notes for things that should remain true going forward. Use notes sparingly — every saved note costs prompt budget on every roleplay turn.`,
+                `The note tag is stripped from your visible message.`,
                 `</connected_roleplay_instructions>`,
               ].join("\n");
           } else if (connectedChat && connectedChat.mode === "game") {
@@ -1972,6 +1978,11 @@ export async function generateRoutes(app: FastifyInstance) {
                 ``,
                 `Influences are injected into the game's context before the next generation. Use them sparingly — only when conversation content genuinely should cross over into the game.`,
                 `The influence tag is stripped from your visible message. The rest of your response is shown normally.`,
+                ``,
+                `If something said in this conversation should durably persist in the game's context across many turns (an established world fact, an ongoing party dynamic, a recurring NPC trait, a secret the GM should keep remembering), create a note tag instead of an influence:`,
+                `<note>fact, decision, or detail the game should keep remembering</note>`,
+                `Notes are shown to the game on every future turn until the user clears them. Use influences for one-shot mid-scene steering; use notes for things that should remain true going forward. Use notes sparingly — every saved note costs prompt budget on every game turn.`,
+                `The note tag is stripped from your visible message.`,
                 `</connected_game_instructions>`,
               ].join("\n");
           }
@@ -2122,6 +2133,37 @@ export async function generateRoutes(app: FastifyInstance) {
           // Mark influences as consumed
           for (const inf of pendingInfluences) {
             await chats.markInfluenceConsumed(inf.id);
+          }
+        }
+      }
+
+      // ── Roleplay/Game: inject durable conversation notes (persist until cleared) ──
+      // Same scene bypass as influences — scenes are self-contained.
+      if ((chatMode === "roleplay" || chatMode === "game") && chat.connectedChatId && !isSceneChat) {
+        const persistentNotes = await chats.listNotes(input.chatId);
+        if (persistentNotes.length > 0) {
+          const noteLines = persistentNotes
+            .map((n: any) => stripConversationPromptTimestamps(String(n.content ?? "")))
+            .filter((content: string) => content.length > 0)
+            .map((content: string) => `- ${content}`);
+
+          if (noteLines.length > 0) {
+            const noteBlock = [
+              `<conversation_notes>`,
+              chatMode === "game"
+                ? `Durable notes from a connected conversation. These persist across every turn until the user clears them and represent things the players have established as ongoing truth — character knowledge, world facts, recurring dynamics. Use them to inform NPC behavior, world state, and scene framing — don't reference them explicitly as "notes" in the narrative.`
+                : `Durable notes from a connected conversation. These persist across every turn until the user clears them and represent things the character has been told to durably remember about themselves, the user, or the world. Use them to inform behavior, knowledge, and reactions naturally — don't reference them explicitly as "notes" in the narrative.`,
+              ...noteLines,
+              `</conversation_notes>`,
+            ].join("\n");
+
+            // Inject before the last user message (parallel to the influence block)
+            const lastUserIdx = finalMessages.map((m) => m.role).lastIndexOf("user");
+            if (lastUserIdx >= 0) {
+              finalMessages.splice(lastUserIdx, 0, { role: "system" as const, content: noteBlock });
+            } else {
+              finalMessages.push({ role: "system" as const, content: noteBlock });
+            }
           }
         }
       }
@@ -7094,6 +7136,23 @@ export async function generateRoutes(app: FastifyInstance) {
                   );
                 } else {
                   logger.warn("[commands] Influence command used but no connected chat");
+                }
+              }
+
+              if (command.type === "note") {
+                // ── Note: persist a durable note in the connected roleplay's prompt ──
+                const noteCmd = command as NoteCommand;
+                const freshChat = await chats.getById(input.chatId);
+                const connectedId = freshChat?.connectedChatId as string | null;
+                if (connectedId) {
+                  const noteContent = stripConversationPromptTimestamps(noteCmd.content);
+                  if (!noteContent) continue;
+                  await chats.createNote(input.chatId, connectedId, noteContent, messageId);
+                  logger.info(
+                    `[commands] Conversation note saved for connected chat ${connectedId}: "${noteContent.slice(0, 80)}..."`,
+                  );
+                } else {
+                  logger.warn("[commands] Note command used but no connected chat");
                 }
               }
 

--- a/packages/server/src/services/conversation/character-commands.ts
+++ b/packages/server/src/services/conversation/character-commands.ts
@@ -12,7 +12,8 @@
 // - [memory: target="CharName", summary="description of the memory"]
 // - [scene: scenario="...", background="...", plan="..."] (initiate a mini-roleplay scene)
 // - [haptic: action="vibrate", intensity=0.5, duration=3] (haptic device feedback)
-// - <influence>text</influence> (OOC influence for connected roleplay)
+// - <influence>text</influence> (OOC influence for connected roleplay, one-shot)
+// - <note>text</note> (durable note for connected roleplay, persists until cleared)
 //
 // Assistant commands (Professor Mari):
 // - [create_persona: name="...", description="...", personality="...", appearance="..."]
@@ -65,6 +66,12 @@ export interface SceneCommand {
 export interface InfluenceCommand {
   type: "influence";
   /** The OOC influence text to inject into the connected roleplay */
+  content: string;
+}
+
+export interface NoteCommand {
+  type: "note";
+  /** The durable note text to persist in the connected roleplay's prompt until cleared */
   content: string;
 }
 
@@ -184,6 +191,7 @@ export type CharacterCommand =
   | MemoryCommand
   | SceneCommand
   | InfluenceCommand
+  | NoteCommand
   | HapticCommand
   | AssistantCommand;
 
@@ -195,6 +203,7 @@ const MEMORY_RE = /\[memory:\s*target="([^"]+)"\s*,\s*summary="([^"]+)"\]/gi;
 const SCENE_RE = /\[scene:\s*([^\]]+)\]/gi;
 const HAPTIC_RE = /\[haptic:\s*([^\]]+)\]/gi;
 const INFLUENCE_RE = /<influence>([\s\S]*?)<\/influence>/gi;
+const NOTE_RE = /<note>([\s\S]*?)<\/note>/gi;
 
 // Assistant command regexes
 const CREATE_PERSONA_RE = /\[create_persona:\s*([^\]]+)\]/gi;
@@ -362,6 +371,12 @@ export function parseCharacterCommands(content: string): {
     if (text) commands.push({ type: "influence", content: text });
   }
 
+  // Parse note commands (<note>text</note>)
+  for (const match of content.matchAll(NOTE_RE)) {
+    const text = stripConversationPromptTimestamps(match[1]!.trim());
+    if (text) commands.push({ type: "note", content: text });
+  }
+
   // Parse haptic commands
   for (const match of content.matchAll(HAPTIC_RE)) {
     const params = match[1]!;
@@ -483,6 +498,7 @@ export function parseCharacterCommands(content: string): {
     .replace(SCENE_RE, "")
     .replace(HAPTIC_RE, "")
     .replace(INFLUENCE_RE, "")
+    .replace(NOTE_RE, "")
     .replace(CREATE_PERSONA_RE, "")
     .replace(CREATE_CHARACTER_RE, "")
     .replace(UPDATE_CHARACTER_RE, "")

--- a/packages/server/src/services/storage/chats.storage.ts
+++ b/packages/server/src/services/storage/chats.storage.ts
@@ -9,6 +9,7 @@ import {
   messageSwipes,
   chatImages,
   oocInfluences,
+  conversationNotes,
   agentRuns,
   agentMemory,
 } from "../../db/schema/index.js";
@@ -24,6 +25,9 @@ import {
 } from "../import/import-timestamps.js";
 
 const GALLERY_DIR = join(DATA_DIR, "gallery");
+
+/** Total character budget for durable conversation notes per roleplay chat. Oldest pruned on insert. */
+export const CONVERSATION_NOTES_BUDGET_CHARS = 4000;
 
 function resolveTimestamps(overrides?: TimestampOverrides | null) {
   const normalized = normalizeTimestampOverrides(overrides);
@@ -561,6 +565,67 @@ export function createChatsStorage(db: DB) {
     async deleteInfluencesForChat(chatId: string) {
       await db.delete(oocInfluences).where(eq(oocInfluences.sourceChatId, chatId));
       await db.delete(oocInfluences).where(eq(oocInfluences.targetChatId, chatId));
+    },
+
+    // ── Conversation Notes ──
+
+    /** Create a durable note from a conversation → its connected roleplay, then prune oldest past the char budget. */
+    async createNote(sourceChatId: string, targetChatId: string, content: string, anchorMessageId?: string) {
+      const id = newId();
+      await db.insert(conversationNotes).values({
+        id,
+        sourceChatId,
+        targetChatId,
+        content,
+        anchorMessageId: anchorMessageId ?? null,
+        createdAt: now(),
+      });
+
+      const all = await db
+        .select()
+        .from(conversationNotes)
+        .where(eq(conversationNotes.targetChatId, targetChatId))
+        .orderBy(desc(conversationNotes.createdAt));
+
+      const toDelete: string[] = [];
+      let total = 0;
+      for (let i = 0; i < all.length; i++) {
+        total += all[i]!.content.length;
+        // Always keep the newest note even if it alone exceeds the budget.
+        if (i > 0 && total > CONVERSATION_NOTES_BUDGET_CHARS) {
+          toDelete.push(all[i]!.id);
+        }
+      }
+      if (toDelete.length > 0) {
+        await db.delete(conversationNotes).where(inArray(conversationNotes.id, toDelete));
+      }
+
+      return id;
+    },
+
+    /** List all durable notes targeting a chat, oldest first (for stable prompt ordering). */
+    async listNotes(targetChatId: string) {
+      return db
+        .select()
+        .from(conversationNotes)
+        .where(eq(conversationNotes.targetChatId, targetChatId))
+        .orderBy(conversationNotes.createdAt);
+    },
+
+    /** Delete a single note by id. */
+    async deleteNote(id: string) {
+      await db.delete(conversationNotes).where(eq(conversationNotes.id, id));
+    },
+
+    /** Clear every note targeting a chat. */
+    async clearNotes(targetChatId: string) {
+      await db.delete(conversationNotes).where(eq(conversationNotes.targetChatId, targetChatId));
+    },
+
+    /** Delete all notes associated with a chat (as source or target). */
+    async deleteNotesForChat(chatId: string) {
+      await db.delete(conversationNotes).where(eq(conversationNotes.sourceChatId, chatId));
+      await db.delete(conversationNotes).where(eq(conversationNotes.targetChatId, chatId));
     },
   };
 }

--- a/packages/server/src/services/storage/chats.storage.ts
+++ b/packages/server/src/services/storage/chats.storage.ts
@@ -585,7 +585,7 @@ export function createChatsStorage(db: DB) {
         .select()
         .from(conversationNotes)
         .where(eq(conversationNotes.targetChatId, targetChatId))
-        .orderBy(desc(conversationNotes.createdAt));
+        .orderBy(desc(conversationNotes.createdAt), desc(conversationNotes.id));
 
       const toDelete: string[] = [];
       let total = 0;
@@ -603,13 +603,15 @@ export function createChatsStorage(db: DB) {
       return id;
     },
 
-    /** List all durable notes targeting a chat, oldest first (for stable prompt ordering). */
+    /** List all durable notes targeting a chat, oldest first (for stable prompt ordering).
+     *  `id` secondary sort gives deterministic ordering when timestamps tie (e.g. multiple
+     *  `<note>` tags emitted in a single character response within one millisecond). */
     async listNotes(targetChatId: string) {
       return db
         .select()
         .from(conversationNotes)
         .where(eq(conversationNotes.targetChatId, targetChatId))
-        .orderBy(conversationNotes.createdAt);
+        .orderBy(conversationNotes.createdAt, conversationNotes.id);
     },
 
     /** Delete a single note by id, scoped to its target chat. */

--- a/packages/server/src/services/storage/chats.storage.ts
+++ b/packages/server/src/services/storage/chats.storage.ts
@@ -612,9 +612,11 @@ export function createChatsStorage(db: DB) {
         .orderBy(conversationNotes.createdAt);
     },
 
-    /** Delete a single note by id. */
-    async deleteNote(id: string) {
-      await db.delete(conversationNotes).where(eq(conversationNotes.id, id));
+    /** Delete a single note by id, scoped to its target chat. */
+    async deleteNoteForChat(targetChatId: string, id: string) {
+      await db
+        .delete(conversationNotes)
+        .where(and(eq(conversationNotes.targetChatId, targetChatId), eq(conversationNotes.id, id)));
     },
 
     /** Clear every note targeting a chat. */

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -286,3 +286,13 @@ export interface OocInfluence {
   consumed: boolean;
   createdAt: string;
 }
+
+/** A durable note emitted from a conversation chat that persists in the connected roleplay's prompt until cleared. */
+export interface ConversationNote {
+  id: string;
+  sourceChatId: string;
+  targetChatId: string;
+  content: string;
+  anchorMessageId: string;
+  createdAt: string;
+}


### PR DESCRIPTION
## Summary

Adds a new `<note>` tag, sibling to the existing `<influence>` tag, that conversation-mode characters can emit. Where `<influence>` is one-shot (consumed on first read into the connected roleplay), `<note>` is durable — it persists into the connected roleplay's prompt every turn until the user clears it from the chat settings drawer.

## Why

The conversation→roleplay context flow only had `<influence>`, which evaporates after a single read. When something important happens in a DM that the roleplay character should *durably* remember (a fact learned, a promise made, a name introduced), the only options were a single-shot influence (gone after one turn) or asking the user to manually edit the roleplay's summary field. `<note>` fills that gap with a near-mirror of `<influence>` minus the consumption flag.

Greenlit by @SpicyMarinara in the `#🍝-marinara-engine` [Discord post here](https://discord.com/channels/1417099416812392641/1497363827006640199). No GitHub issue was opened in advance — happy to file one retroactively if maintainers prefer.

## Architecture

| Layer | What changed |
|-------|--------------|
| Schema | New `conversation_notes` table mirroring `ooc_influences` minus the `consumed` column. Created automatically by the existing idempotent `runMigrations()` (also added to `migrate.ts`). |
| Shared types | New `ConversationNote` interface alongside `OocInfluence`. |
| Parser | New `NOTE_RE` in `character-commands.ts`, parallel to `INFLUENCE_RE`. Tag is stripped from the visible message via the existing `.replace()` chain. |
| Queue | After conversation generation, parsed notes are saved via `chats.createNote()` with char-budget pruning. |
| Injection | New `<conversation_notes>` block built in `generate.routes.ts`, injected before the last user message in roleplay/game prompts. Same scene-chat bypass as `<ooc_influences>`. **Not consumed** — that's the behavioral difference. |
| Storage | New CRUD methods + a 4000-char total budget per roleplay (oldest pruned at insert). |
| REST | `GET /chats/:id/notes`, `DELETE /chats/:id/notes/:noteId`, `DELETE /chats/:id/notes`. Disconnect flow also deletes the chat's notes alongside influences. |
| Client hooks | `useChatNotes`, `useDeleteChatNote`, `useClearChatNotes` — same shape as the memory hooks pair. |
| UI | New "Conversation Notes" section in `ChatSettingsDrawer.tsx`, only shown for roleplay/game chats with a connection. View list, per-note delete (× button), and clear-all (trash icon at the section header). |
| Docs | Updated `seed-mari.ts` so Professor Mari knows about the new tag, and the in-prompt connected-roleplay-instructions block teaches conversation characters when to use `<note>` vs `<influence>`. |

## Known limitations

- **No edit UI in v1.** Per-note delete ships; per-note edit is deferred. Workaround: delete the stale note, ask the character to re-emit if needed. Adds nontrivial UI (textarea, save/cancel, validation) for what feels like a low-frequency need.
- **Notes are not visible to the conversation character.** They're injected into the *roleplay* prompt only. The conversation that emitted them doesn't see them in its own context. Intentional — preserves the asymmetric information flow the engine already uses for `<influence>`.
- **Hard 4000-char total budget per roleplay**, oldest pruned at insert. No per-note size cap (a single very large note can crowd out everything else). Pragmatic default; can be tuned later.

## Test plan

- [x] Conversation character emits a `<note>` tag → tag is stripped from the visible message
- [x] Note appears in the roleplay's settings drawer "Conversation Notes" section with timestamp + delete button
- [x] Use Peek Prompt on a roleplay turn → confirm `<conversation_notes>` block appears in the assembled prompt with the note as a bulleted line under the framing text
- [x] Generate multiple roleplay turns → note persists in every prompt (durability)
- [x] Per-note × button removes a single note
- [x] Trash icon at section header clears all notes (confirm dialog appears)
- [x] After clear-all, `<conversation_notes>` section is absent from Peek Prompt (correct empty-list behavior)
- [x] `<influence>` regression: emit one, generate next turn (referenced), generate the turn after (no longer referenced) — Peek Prompt confirms `<ooc_influences>` is consumed
- [x] Disconnect the conversation from the roleplay → all notes are deleted (cascade via `deleteNotesForChat`)
- [x] Light mode renders cleanly in the drawer section
- [x] Dark mode renders cleanly in the drawer section
- [x] Mobile viewport (~400px) renders cleanly
- [x] Empty state shows the helper text mentioning `<note>...</note>`

## Screenshots

**Empty state, dark mode:**
<img width="266" height="150" alt="image" src="https://github.com/user-attachments/assets/d763dd87-2315-4d6e-ba88-446355dca168" />


**Populated, dark mode:**
<img width="271" height="125" alt="image" src="https://github.com/user-attachments/assets/901f67cb-6441-4bbd-8419-492c26d36eda" />


**Populated, light mode:**
<img width="265" height="125" alt="image" src="https://github.com/user-attachments/assets/a2b7fca9-a8c6-44ee-8297-541ebf43d8bf" />


**Mobile viewport (~400px), light mode:**
<img width="398" height="849" alt="image" src="https://github.com/user-attachments/assets/a5bbfc54-3d01-4bca-b783-37d5f3ddd10c" />


**Peek Prompt showing the `<conversation_notes>` section:**
<img width="914" height="730" alt="image" src="https://github.com/user-attachments/assets/4791c8e3-8789-4a48-bf32-0fbbf89dfb69" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Conversation notes section added to chat settings, displaying note count and character usage
  * Users can delete individual notes or clear all notes with confirmation dialogs
  * Notes now persist across conversation turns and automatically integrate into future responses
<!-- end of auto-generated comment: release notes by coderabbit.ai -->