### PR TITLE
fix(sidecar): preserve Windows PATH key casing to prevent CUDA backend failure

### DIFF
--- a/packages/server/src/services/sidecar/sidecar-runtime-env.ts
+++ b/packages/server/src/services/sidecar/sidecar-runtime-env.ts
@@ -29,8 +29,14 @@ export function buildLlamaProcessEnv(
 
   if (platform === "win32") {
     const runtimeDir = win32.dirname(runtime.serverPath);
-    env.PATH = prependPathEntry(
-      prependPathEntry(env.PATH, runtimeDir, win32.delimiter),
+    // Windows exposes process.env as a case-insensitive Proxy, but spreading
+    // it into a plain object preserves the native key casing (typically "Path").
+    // Writing to env.PATH when the real key is "Path" creates a duplicate,
+    // causing the child process to lose its system PATH and breaking DLL
+    // resolution for CUDA and other GPU backends.
+    const pathKey = Object.keys(env).find((key) => key.toLowerCase() === "path") ?? "PATH";
+    env[pathKey] = prependPathEntry(
+      prependPathEntry(env[pathKey], runtimeDir, win32.delimiter),
       runtime.directoryPath ?? runtimeDir,
       win32.delimiter,
     );

--- a/packages/server/test/sidecar-runtime-env.test.ts
+++ b/packages/server/test/sidecar-runtime-env.test.ts
@@ -66,3 +66,20 @@ test("prepends bundled runtime directories to PATH on Windows", () => {
 
   assert.equal(env.PATH, `C:\\Marinara\\sidecar-runtime\\b8934-win-x64-cuda${win32.delimiter}C:\\Windows\\System32`);
 });
+
+test("modifies existing Path key instead of creating a duplicate PATH key on Windows", () => {
+  const env = buildLlamaProcessEnv(
+    {
+      source: "bundled",
+      directoryPath: "C:\\Marinara\\sidecar-runtime\\b8934-win-x64-cuda",
+      serverPath: "C:\\Marinara\\sidecar-runtime\\b8934-win-x64-cuda\\llama-server.exe",
+    },
+    "win32",
+    {
+      Path: "C:\\Windows\\System32",
+    },
+  );
+
+  assert.ok(!("PATH" in env), "should not create a duplicate PATH key");
+  assert.equal(env.Path, `C:\\Marinara\\sidecar-runtime\\b8934-win-x64-cuda${win32.delimiter}C:\\Windows\\System32`);
+});


### PR DESCRIPTION
Closes #315
## Why this change

On Windows, `buildLlamaProcessEnv` in `sidecar-runtime-env.ts` spreads `process.env` into a plain object. While `process.env` itself is a case-insensitive Proxy, the spread result is a plain object that preserves the native key casing — typically `"Path"` (title-case), not `"PATH"`.

The original code writes to `env.PATH`, which creates a **duplicate key** when the existing key is `"Path"`. The short uppercase `PATH` (containing only the runtime directory) takes precedence, stripping the child process of all system directories — including `C:\Windows\System32` and NVIDIA driver paths.

This prevents `ggml-cuda.dll` from resolving its implicit dependencies (`nvcuda.dll`, `cublas64_*.dll`), causing silent CUDA load failure and automatic CPU fallback on every startup.

### Before fix (old runtime b8851 without bundled CUDA DLLs)

<img width="1445" height="549" alt="image" src="https://github.com/user-attachments/assets/bba0e5d5-52fb-4028-8b89-cceab65de2dd" />


### Controlled A/B test — same machine, same session

```
=== OLD CODE (env.PATH = ...) ===
PATH-like keys in env: [ 'Path', 'PATH' ]   ← duplicate key
CUDA loaded: false

=== NEW CODE (env[pathKey] = ...) ===
PATH-like keys in env: [ 'Path' ]            ← single key
CUDA loaded: true
ggml_cuda_init: found 1 CUDA devices (Total VRAM: 16375 MiB)
```

## What changed

- **`sidecar-runtime-env.ts`**: Use `Object.keys(env).find(k => k.toLowerCase() === "path")` to detect the actual key casing before prepending. Falls back to `"PATH"` if no key exists.
- **`sidecar-runtime-env.test.ts`**: Added regression test verifying that a `"Path"` key is modified in-place without creating a duplicate `"PATH"` key.

## Compatibility

This fix is complementary to #270 (bundling CUDA DLLs). With bundled DLLs, the CUDA symptom is masked because DLLs are found via same-directory resolution. However, the child process still loses its entire system PATH, which could affect other functionality. This fix addresses the root cause.

## Validation

- [x] `pnpm check`
- [x] Controlled test spawning `llama-server --version` with old vs new env construction
- [x] Verified GPU offload works with fix, breaks without it (on runtime b8851)
- [x] Regression test passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved Windows environment handling that could create duplicate PATH entries. Child processes now inherit the correct PATH, preventing issues with system libraries and GPU/DLL detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->