### PR TITLE
feat: random-pool tickbox editor in quick connection switcher

### DIFF
--- a/packages/client/src/components/chat/QuickConnectionSwitcher.tsx
+++ b/packages/client/src/components/chat/QuickConnectionSwitcher.tsx
@@ -2,8 +2,8 @@
 // Quick Connection Switcher — inline dropdown
 // ──────────────────────────────────────────────
 import { useState, useRef, useCallback, useEffect } from "react";
-import { Link } from "lucide-react";
-import { useConnections } from "../../hooks/use-connections";
+import { Link, Dices, Check } from "lucide-react";
+import { useConnections, useUpdateConnection } from "../../hooks/use-connections";
 import { useUpdateChat, useChat } from "../../hooks/use-chats";
 import { useChatStore } from "../../stores/chat.store";
 import { cn } from "../../lib/utils";
@@ -16,10 +16,14 @@ export function QuickConnectionSwitcher({ className }: { className?: string }) {
   const { data: connections } = useConnections();
   const { data: chat } = useChat(activeChatId);
   const updateChat = useUpdateChat();
+  const updateConnection = useUpdateConnection();
 
   const activeConnectionId = (chat as unknown as Record<string, unknown>)?.connectionId as string | null;
+  const isRandom = activeConnectionId === "random";
 
-  const sorted = ((connections ?? []) as Array<{ id: string; name: string }>)
+  const sorted = (
+    (connections ?? []) as Array<{ id: string; name: string; useForRandom?: string }>
+  )
     .slice()
     .sort((a, b) => (a.name || "").localeCompare(b.name || ""));
 
@@ -30,6 +34,18 @@ export function QuickConnectionSwitcher({ className }: { className?: string }) {
       setOpen(false);
     },
     [activeChatId, updateChat],
+  );
+
+  const handleToggleRandom = useCallback(() => {
+    if (!activeChatId) return;
+    updateChat.mutate({ id: activeChatId, connectionId: isRandom ? null : "random" });
+  }, [activeChatId, isRandom, updateChat]);
+
+  const handleTogglePool = useCallback(
+    (connId: string, inPool: boolean) => {
+      updateConnection.mutate({ id: connId, useForRandom: !inPool });
+    },
+    [updateConnection],
   );
 
   useEffect(() => {
@@ -88,36 +104,61 @@ export function QuickConnectionSwitcher({ className }: { className?: string }) {
           className="fixed z-[9999] flex min-w-[280px] max-w-[340px] max-h-[360px] flex-col overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--card)] shadow-2xl"
           style={pos ? { left: pos.left, top: pos.top } : { visibility: "hidden" as const }}
         >
-          <div className="flex items-center justify-center border-b border-[var(--border)] px-3 py-2 text-[0.6875rem] font-semibold">
-            Connections
-          </div>
-          <div className="overflow-y-auto p-1">
+          <div className="flex items-center justify-between gap-2 border-b border-[var(--border)] px-3 py-2">
+            <span className="text-[0.6875rem] font-semibold">Connections</span>
             <button
-              onClick={() => handleSwitch("random")}
+              onClick={handleToggleRandom}
+              title={isRandom ? "Random pool active — click to disable" : "Use random connection from pool"}
               className={cn(
-                "flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-xs transition-colors hover:bg-[var(--accent)]",
-                activeConnectionId === "random" && "text-foreground font-semibold",
+                "flex h-6 w-6 items-center justify-center rounded-md transition-all active:scale-90",
+                isRandom
+                  ? "bg-amber-400/20 text-amber-400 ring-1 ring-amber-400/40"
+                  : "text-[var(--muted-foreground)] hover:bg-amber-400/10 hover:text-amber-400",
               )}
             >
-              <span>🎲 Random</span>
-              {activeConnectionId === "random" && <span className="ml-auto text-[0.6875rem]">✓</span>}
+              <Dices size="0.875rem" />
             </button>
-
-            <div className="mx-2 my-1 h-px bg-[var(--border)]" />
-
-            {sorted.map((conn) => (
-              <button
-                key={conn.id}
-                onClick={() => handleSwitch(conn.id)}
-                className={cn(
-                  "flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-xs transition-colors hover:bg-[var(--accent)]",
-                  activeConnectionId === conn.id && "text-foreground font-semibold",
-                )}
-              >
-                <span>{conn.name || conn.id}</span>
-                {activeConnectionId === conn.id && <span className="ml-auto text-[0.6875rem]">✓</span>}
-              </button>
-            ))}
+          </div>
+          <div className="overflow-y-auto p-1">
+            {sorted.map((conn) => {
+              const inPool = conn.useForRandom === "true";
+              const isActive = activeConnectionId === conn.id;
+              if (isRandom) {
+                return (
+                  <button
+                    key={conn.id}
+                    onClick={() => handleTogglePool(conn.id, inPool)}
+                    className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-xs transition-colors hover:bg-[var(--accent)]"
+                    title={inPool ? "In random pool — click to remove" : "Click to add to random pool"}
+                  >
+                    <span className="flex-1 truncate">{conn.name || conn.id}</span>
+                    <span
+                      className={cn(
+                        "flex h-4 w-4 shrink-0 items-center justify-center rounded border transition-colors",
+                        inPool
+                          ? "border-amber-400/60 bg-amber-400/20 text-amber-400"
+                          : "border-[var(--border)] bg-transparent",
+                      )}
+                    >
+                      {inPool && <Check size="0.625rem" strokeWidth={3} />}
+                    </span>
+                  </button>
+                );
+              }
+              return (
+                <button
+                  key={conn.id}
+                  onClick={() => handleSwitch(conn.id)}
+                  className={cn(
+                    "flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-xs transition-colors hover:bg-[var(--accent)]",
+                    isActive && "text-foreground font-semibold",
+                  )}
+                >
+                  <span className="flex-1 truncate">{conn.name || conn.id}</span>
+                  {isActive && <span className="text-[0.6875rem]">✓</span>}
+                </button>
+              );
+            })}
 
             {sorted.length === 0 && (
               <div className="px-3 py-4 text-center text-[0.6875rem] italic text-[var(--muted-foreground)]">

--- a/packages/client/src/components/chat/QuickSwitcherMobile.tsx
+++ b/packages/client/src/components/chat/QuickSwitcherMobile.tsx
@@ -4,8 +4,8 @@
 // (with persona group support)
 // ──────────────────────────────────────────────
 import { useState, useRef, useCallback, useEffect, useMemo } from "react";
-import { ChevronUp, ChevronDown, ChevronRight, Link, CircleUser, FolderOpen, Folder } from "lucide-react";
-import { useConnections } from "../../hooks/use-connections";
+import { ChevronUp, ChevronDown, ChevronRight, Link, CircleUser, FolderOpen, Folder, Check } from "lucide-react";
+import { useConnections, useUpdateConnection } from "../../hooks/use-connections";
 import { usePersonas, usePersonaGroups } from "../../hooks/use-characters";
 import { useUpdateChat, useChat } from "../../hooks/use-chats";
 import { useChatStore } from "../../stores/chat.store";
@@ -44,11 +44,15 @@ export function QuickSwitcherMobile() {
   const { data: rawPersonaGroups } = usePersonaGroups();
   const { data: chat } = useChat(activeChatId);
   const updateChat = useUpdateChat();
+  const updateConnection = useUpdateConnection();
 
   const activeConnectionId = (chat as unknown as Record<string, unknown>)?.connectionId as string | null;
   const activePersonaId = (chat as unknown as Record<string, unknown>)?.personaId as string | null;
+  const isRandom = activeConnectionId === "random";
 
-  const sortedConnections = ((connections ?? []) as Array<{ id: string; name: string }>)
+  const sortedConnections = (
+    (connections ?? []) as Array<{ id: string; name: string; useForRandom?: string }>
+  )
     .slice()
     .sort((a, b) => (a.name || "").localeCompare(b.name || ""));
 
@@ -111,6 +115,18 @@ export function QuickSwitcherMobile() {
       setOpen(false);
     },
     [activeChatId, updateChat],
+  );
+
+  const handleToggleRandom = useCallback(() => {
+    if (!activeChatId) return;
+    updateChat.mutate({ id: activeChatId, connectionId: isRandom ? null : "random" });
+  }, [activeChatId, isRandom, updateChat]);
+
+  const handleTogglePool = useCallback(
+    (connId: string, inPool: boolean) => {
+      updateConnection.mutate({ id: connId, useForRandom: !inPool });
+    },
+    [updateConnection],
   );
 
   const handleSwitchPersona = useCallback(
@@ -256,29 +272,58 @@ export function QuickSwitcherMobile() {
             {tab === "connections" && (
               <>
                 <button
-                  onClick={() => handleSwitchConnection("random")}
+                  onClick={handleToggleRandom}
                   className={cn(
-                    "flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-xs transition-colors hover:bg-[var(--accent)]",
-                    activeConnectionId === "random" && "text-foreground font-semibold",
+                    "flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-xs transition-colors",
+                    isRandom
+                      ? "bg-amber-400/15 text-amber-400 font-semibold ring-1 ring-amber-400/40"
+                      : "hover:bg-[var(--accent)]",
                   )}
+                  title={isRandom ? "Random pool active — click to disable" : "Use random connection from pool"}
                 >
                   <span>🎲 Random</span>
-                  {activeConnectionId === "random" && <span className="ml-auto text-[0.6875rem]">✓</span>}
+                  {isRandom && <span className="ml-auto text-[0.6875rem]">active</span>}
                 </button>
                 <div className="mx-2 my-1 h-px bg-[var(--border)]" />
-                {sortedConnections.map((conn) => (
-                  <button
-                    key={conn.id}
-                    onClick={() => handleSwitchConnection(conn.id)}
-                    className={cn(
-                      "flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-xs transition-colors hover:bg-[var(--accent)]",
-                      activeConnectionId === conn.id && "text-foreground font-semibold",
-                    )}
-                  >
-                    <span>{conn.name || conn.id}</span>
-                    {activeConnectionId === conn.id && <span className="ml-auto text-[0.6875rem]">✓</span>}
-                  </button>
-                ))}
+                {sortedConnections.map((conn) => {
+                  const inPool = conn.useForRandom === "true";
+                  const isActive = activeConnectionId === conn.id;
+                  if (isRandom) {
+                    return (
+                      <button
+                        key={conn.id}
+                        onClick={() => handleTogglePool(conn.id, inPool)}
+                        className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-xs transition-colors hover:bg-[var(--accent)]"
+                        title={inPool ? "In random pool — click to remove" : "Click to add to random pool"}
+                      >
+                        <span className="flex-1 truncate">{conn.name || conn.id}</span>
+                        <span
+                          className={cn(
+                            "flex h-4 w-4 shrink-0 items-center justify-center rounded border transition-colors",
+                            inPool
+                              ? "border-amber-400/60 bg-amber-400/20 text-amber-400"
+                              : "border-[var(--border)] bg-transparent",
+                          )}
+                        >
+                          {inPool && <Check size="0.625rem" strokeWidth={3} />}
+                        </span>
+                      </button>
+                    );
+                  }
+                  return (
+                    <button
+                      key={conn.id}
+                      onClick={() => handleSwitchConnection(conn.id)}
+                      className={cn(
+                        "flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-xs transition-colors hover:bg-[var(--accent)]",
+                        isActive && "text-foreground font-semibold",
+                      )}
+                    >
+                      <span className="flex-1 truncate">{conn.name || conn.id}</span>
+                      {isActive && <span className="text-[0.6875rem]">✓</span>}
+                    </button>
+                  );
+                })}
                 {sortedConnections.length === 0 && (
                   <div className="px-3 py-4 text-center text-[0.6875rem] italic text-[var(--muted-foreground)]">
                     No connections found.


### PR DESCRIPTION
## Summary

Editing the random connection pool used to require opening the Connections panel and toggling the shuffle button on each connection card. This PR moves that editor into the Quick Connection Switcher itself so it can be managed inline from any chat.

### Desktop (`QuickConnectionSwitcher.tsx`)
- Removed the standalone "🎲 Random" entry above the connection list.
- Added a **dice icon** in the dropdown header next to "Connections".
- Clicking the dice toggles the active chat's connection between `"random"` and unset, and highlights the dice in amber while active.
- While the dice is active, every connection row renders as a tickbox showing the connection's `useForRandom` state. Tapping a row toggles pool membership through the same `useUpdateConnection` mutation used by `ConnectionsPanel.tsx`, so the pool stays consistent everywhere.
- When the dice is inactive, rows behave exactly as before (click to switch the chat to that connection).

### Mobile (`QuickSwitcherMobile.tsx`)
- The "🎲 Random" row at the top of the Connections tab is preserved (as requested — that layout has less room for a dedicated header icon).
- When tapped, the row itself becomes the toggle: it switches the chat to random and gets an amber background + ring + "active" label.
- While random is active, the connection rows below render as the same tickbox editor as the desktop version.

Both flows read the existing `useForRandom` flag and call `useUpdateConnection` — no new endpoints or schema changes.

## Test plan

- [x] Manually verify desktop: open Quick Connection Switcher in a chat. Click the dice — chat switches to random, dice highlights amber, rows show tickboxes that match the current pool.
- [x] Tick / untick a connection in dice mode — verify the change persists and is reflected on the Connections panel's shuffle button.
- [x] Click the dice again — chat connection clears, rows revert to plain switcher behavior.
- [x] Click a connection row in normal mode — chat switches to that connection (existing behavior unchanged).
- [x] Manually verify mobile: open Quick Switcher, Connections tab. Tap "🎲 Random" — row highlights amber, rows below become tickboxes.
- [x] Tick / untick a connection on mobile — verify pool updates and matches desktop / Connections panel.
- [x] Tap "🎲 Random" again — random clears, rows revert to switch-to-connection behavior.
- [x] Verify the existing Connections panel shuffle button still works and stays in sync with the Quick Switcher tickboxes.

> No linked issue — one should be opened before this PR is merged if Pasta-Devs requires it for tracking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added random connection pool management—toggle random mode with a dice icon in the connection switcher
* Connection list now adapts based on mode: select active connection directly or manage random pool membership with visual indicators
* Updated UI in both desktop and mobile switchers for improved connection selection workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->