### PR TITLE
feat(game): middle-mouse + click navigation through chat history for game mode

### DIFF
--- a/packages/client/src/components/game/GameMap.tsx
+++ b/packages/client/src/components/game/GameMap.tsx
@@ -300,6 +300,7 @@ export function GameMapPanel({
   return (
     <motion.div
       data-tour="game-map"
+      data-game-skip-bg-nav="true"
       drag={!locked}
       dragMomentum={false}
       dragElastic={0}

--- a/packages/client/src/components/game/GameNarration.tsx
+++ b/packages/client/src/components/game/GameNarration.tsx
@@ -251,6 +251,28 @@ interface GameNarrationProps {
    * modal is open this stays false so the input bar doesn't appear behind the modal.
    */
   interruptCommitted?: boolean;
+  /**
+   * Wheel-nav offset: 0 means show the latest assistant turn (default). >0 picks an
+   * older assistant message for review (1 = previous turn, 2 = the one before, …).
+   * While >0, narration is rendered instantly (no typewriter), auto-play is suppressed,
+   * and the Next button label switches to "Return".
+   */
+  messageOffset?: number;
+  /** Step ONE log entry forward (toward the present). Bound to Next / bg-click during review. */
+  onStepForward?: () => void;
+  /** Jump straight back to the present in one shot. Bound to the Return button during review. */
+  onJumpToLatest?: () => void;
+  /**
+   * Token bumped from the parent (background-click handler) when wheel-nav is enabled
+   * and the player clicks the bare scene background. GameNarration interprets it as
+   * a Next press at offset 0, or as a Return press at offset > 0.
+   */
+  nextActionToken?: number;
+  /**
+   * Reports the wheel-nav clamp to the parent — equal to the number of past log
+   * entries available to step into. When 0, wheel-up has no past to walk into.
+   */
+  onMaxNavOffsetChange?: (max: number) => void;
 }
 
 /** Regex matching explicit {effect:text} tags used by AnimatedText. */
@@ -589,6 +611,11 @@ export function GameNarration({
   onInterruptCancel,
   interruptPending,
   interruptCommitted,
+  messageOffset = 0,
+  onStepForward,
+  onJumpToLatest,
+  nextActionToken,
+  onMaxNavOffsetChange,
 }: GameNarrationProps) {
   const { translations, translating } = useTranslate();
   const [activeIndex, setActiveIndex] = useState(0);
@@ -719,14 +746,74 @@ export function GameNarration({
   );
 
   const latestAssistant = useMemo(() => {
+    // Newest assistant/narrator turn (independent of wheel-nav offset). Used by the
+    // present-mode renderer (offset 0) and by everything keyed off "the GM's most
+    // recent turn" — segment edits, voice resolution, log builders, etc.
     for (let i = messages.length - 1; i >= 0; i--) {
       const msg = messages[i]!;
-      if (msg.role === "assistant" || msg.role === "narrator") {
-        return msg;
-      }
+      if (msg.role === "assistant" || msg.role === "narrator") return msg;
     }
     return null;
   }, [messages]);
+
+  // Wheel-nav builds a flat chronological list of log entries — one per visible
+  // segment (parsed narration segments for assistant turns + a single player-dialogue
+  // line per user turn). Wheel-up steps backward through this list, matching the
+  // order the player sees in the Logs panel.
+  type FlatLogEntry =
+    | { kind: "assistant"; messageId: string; segmentIndex: number; segment: NarrationSegment; role: Message["role"] }
+    | { kind: "user"; messageId: string; segment: NarrationSegment };
+
+  const flatLogEntries = useMemo<FlatLogEntry[]>(() => {
+    const out: FlatLogEntry[] = [];
+    for (const msg of messages) {
+      if (msg.role === "system") continue;
+      if (msg.role === "user") {
+        if (!msg.content?.trim()) continue;
+        const playerName = personaInfo?.name || "You";
+        const color = personaInfo?.dialogueColor || personaInfo?.nameColor || "#a5b4fc";
+        out.push({
+          kind: "user",
+          messageId: msg.id,
+          segment: {
+            id: `${msg.id}-player`,
+            type: "dialogue",
+            speaker: playerName,
+            content: msg.content,
+            color,
+            sourceMessageId: msg.id,
+            sourceSegmentIndex: 0,
+            sourceRole: "user",
+          },
+        });
+        continue;
+      }
+      if (msg.role !== "assistant" && msg.role !== "narrator") continue;
+      const segs = parseNarrationSegments(msg, speakerColors);
+      for (let si = 0; si < segs.length; si++) {
+        const seg = segs[si]!;
+        if (isDeletedSegment(segmentDeletes, msg.id, si)) continue;
+        if (seg.partyType === "side" || seg.partyType === "extra") continue;
+        out.push({ kind: "assistant", messageId: msg.id, segmentIndex: si, segment: seg, role: msg.role });
+      }
+    }
+    return out;
+  }, [messages, personaInfo, speakerColors, segmentDeletes]);
+
+  // Past-review entry the player is currently looking at. Each wheel-up bumps
+  // `messageOffset`; we step back that many entries from the most recent log entry.
+  const pastReviewEntry = useMemo<FlatLogEntry | null>(() => {
+    if (messageOffset <= 0) return null;
+    const idx = flatLogEntries.length - 1 - messageOffset;
+    if (idx < 0) return null;
+    return flatLogEntries[idx] ?? null;
+  }, [flatLogEntries, messageOffset]);
+
+  // Notify parent of the clamp it should enforce on wheel-up. Length-1 because the
+  // newest entry is "present" (offset 0) so it isn't reachable via wheel-up.
+  useEffect(() => {
+    onMaxNavOffsetChange?.(Math.max(0, flatLogEntries.length - 1));
+  }, [flatLogEntries.length, onMaxNavOffsetChange]);
 
   const partyChatInputMessageId = useMemo(() => {
     if (!partyChatMessageId || !partyChatInput) return null;
@@ -793,6 +880,37 @@ export function GameNarration({
     const origIndices: number[] = [];
     const editInfos: Array<{ messageId: string; segmentIndex: number } | null> = [];
     const sourceMessageIds: Array<string | null> = [];
+
+    // Wheel-nav review mode: render exactly the ONE log entry the player is at.
+    // Each wheel-up steps back through the flat log (one per visible segment),
+    // matching the order shown in the Logs panel. Read-only — no edit overlays.
+    if (pastReviewEntry) {
+      if (pastReviewEntry.kind === "user") {
+        result.push(pastReviewEntry.segment);
+        origIndices.push(-1);
+        editInfos.push(null);
+        sourceMessageIds.push(pastReviewEntry.messageId);
+      } else {
+        result.push(
+          withSegmentSource(
+            pastReviewEntry.segment,
+            pastReviewEntry.messageId,
+            pastReviewEntry.segmentIndex,
+            pastReviewEntry.role,
+          ),
+        );
+        origIndices.push(pastReviewEntry.segmentIndex);
+        editInfos.push({ messageId: pastReviewEntry.messageId, segmentIndex: pastReviewEntry.segmentIndex });
+        sourceMessageIds.push(pastReviewEntry.messageId);
+      }
+      segmentOriginalIndices.current = origIndices;
+      segmentEditInfoRef.current = editInfos;
+      segmentSourceMessageIdsRef.current = sourceMessageIds;
+      partySegStartRef.current = -1;
+      partyLogBaseCutoffRef.current = [];
+      partyLogCutoffRef.current = [];
+      return result;
+    }
 
     // Prepend the user's action as a player dialogue segment when we're streaming or just got a response
     if (latestUserMessage?.content && latestAssistant) {
@@ -966,6 +1084,7 @@ export function GameNarration({
     return result;
   }, [
     latestAssistant,
+    pastReviewEntry,
     speakerColors,
     latestUserMessage,
     personaInfo,
@@ -1268,10 +1387,13 @@ export function GameNarration({
   const doneTyping = !!active && visibleChars >= activeDisplayLen;
   const narrationComplete = !isStreaming && segments.length > 0 && activeIndex === segments.length - 1 && doneTyping;
 
-  // Notify parent about narration completion state
+  // Notify parent about narration completion state. While reviewing the past via
+  // wheel-nav, the past message will look "complete" — but it's not the present, so
+  // suppress the notification to keep the parent's narrationDone state honest.
   useEffect(() => {
+    if (messageOffset > 0) return;
     onNarrationComplete?.(narrationComplete);
-  }, [narrationComplete, onNarrationComplete]);
+  }, [messageOffset, narrationComplete, onNarrationComplete]);
 
   // Build log entries from the LAST scene — includes party chat & player action.
   // Entries are stored chronologically (oldest first, newest last).
@@ -1635,11 +1757,14 @@ export function GameNarration({
     setVisibleChars(effectDisplayLength(segments[restoredSegmentIndex]!.content));
   }, [segments.length]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Persist segment index changes (skip until restore has settled or first message processed)
+  // Persist segment index changes (skip until restore has settled or first message processed).
+  // Suppress while reviewing the past via wheel-nav so the saved present-position isn't
+  // clobbered by the activeIndex jumps we make on offset transitions.
   useEffect(() => {
     if (!segmentChangeReady.current) return;
+    if (messageOffset > 0) return;
     onSegmentChange?.(activeIndex);
-  }, [activeIndex, onSegmentChange]);
+  }, [activeIndex, messageOffset, onSegmentChange]);
 
   // Notify parent when the active segment changes so segment-tied effects can fire
   useEffect(() => {
@@ -1981,7 +2106,14 @@ export function GameNarration({
     [editingLogSeg, onEditMessage, onEditSegment],
   );
 
-  const nextSegment = () => {
+  const nextSegment = useCallback(() => {
+    // While reviewing the past, Next / bg-click steps ONE log entry forward —
+    // symmetric with wheel-down. The player walks back to the present a step
+    // at a time instead of jumping all the way home.
+    if (messageOffset > 0) {
+      onStepForward?.();
+      return;
+    }
     if (!active) return;
     if (!doneTyping) {
       twRef.current.pos = activeDisplayLen; // sync so interval stops
@@ -1995,7 +2127,71 @@ export function GameNarration({
       setVisibleChars(getSegmentStartVisibleChars(nextIndex));
       playClickSfx();
     }
-  };
+  }, [
+    active,
+    activeDisplayLen,
+    activeIndex,
+    doneTyping,
+    getSegmentStartVisibleChars,
+    messageOffset,
+    onStepForward,
+    playClickSfx,
+    segments.length,
+  ]);
+
+  // Background-click forwarding: parent bumps `nextActionToken` whenever the
+  // player clicks the bare scene background (with wheel-nav enabled). We treat
+  // it as a programmatic press of the Next button.
+  const lastNextActionTokenRef = useRef(0);
+  useEffect(() => {
+    if (!nextActionToken) return;
+    if (lastNextActionTokenRef.current === nextActionToken) return;
+    lastNextActionTokenRef.current = nextActionToken;
+    nextSegment();
+  }, [nextActionToken, nextSegment]);
+
+  // Wheel-nav offset transitions:
+  //   • 0 → >0: save where the player was reading so Return can land them back there.
+  //              Snap auto-play off and jump activeIndex to the last segment of the
+  //              past turn (the "ending" of that turn) with visibleChars filled in.
+  //   • >0 → >0 (different): re-snap to last segment of the newly-shown past turn.
+  //   • >0 → 0: restore the saved activeIndex/visibleChars in the latest turn.
+  const prevMessageOffsetRef = useRef(0);
+  const savedPresentSegmentRef = useRef<{ index: number; visibleChars: number } | null>(null);
+  useEffect(() => {
+    const prev = prevMessageOffsetRef.current;
+    const next = messageOffset;
+    prevMessageOffsetRef.current = next;
+    if (prev === next) return;
+
+    if (prev === 0 && next > 0) {
+      savedPresentSegmentRef.current = { index: activeIndex, visibleChars };
+      setAutoPlay(false);
+    }
+
+    if (next > 0) {
+      const lastIdx = Math.max(0, segments.length - 1);
+      setActiveIndex(lastIdx);
+      const seg = segments[lastIdx];
+      const dispLen = seg ? effectDisplayLength(seg.content) : 0;
+      setVisibleChars(dispLen);
+      twRef.current.pos = dispLen;
+      return;
+    }
+
+    if (prev > 0 && next === 0) {
+      const saved = savedPresentSegmentRef.current;
+      savedPresentSegmentRef.current = null;
+      if (saved && saved.index < segments.length) {
+        setActiveIndex(saved.index);
+        setVisibleChars(saved.visibleChars);
+        twRef.current.pos = saved.visibleChars;
+      }
+    }
+    // Intentionally only react to messageOffset changes — segments/activeIndex
+    // are read at transition time and we don't want to re-fire on each segment tick.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [messageOffset]);
 
   // Auto-advance to the next segment after a delay when auto-play is on
   useEffect(() => {
@@ -2123,25 +2319,29 @@ export function GameNarration({
   // The red Interrupt button swaps to a yellow Resume button only AFTER the player
   // confirms in the modal (interruptCommitted). While the modal is still open we keep
   // the red button visible so it doesn't look like the interrupt already happened.
-  const showInterruptControls = !narrationComplete && !partyTurnPending && !!onInterruptRequest;
-  const showNav = !narrationComplete && !isStreaming && !interruptPending;
+  // While reviewing the past (messageOffset > 0), interrupt controls are hidden and
+  // the Next button is forced visible so the player can see and press "Return".
+  const reviewingPast = messageOffset > 0;
+  const showInterruptControls = !reviewingPast && !narrationComplete && !partyTurnPending && !!onInterruptRequest;
+  const showNav = reviewingPast || (!narrationComplete && !isStreaming && !interruptPending);
   const navControls =
     !showInterruptControls && !showNav ? null : (
       <div className="flex items-stretch gap-1">
         {showInterruptControls && !interruptCommitted && (
           <button
             onClick={handleInterrupt}
-            className={cn(NARRATION_ICON_META_BTN, "text-red-300 hover:text-red-200 dark:text-red-300")}
+            className="flex items-center gap-1 self-stretch rounded-lg border border-red-500/40 bg-red-500/15 px-2 text-xs font-semibold text-red-200 transition-colors hover:bg-red-500/25 hover:text-red-50 sm:px-2.5 dark:border-red-500/40 dark:bg-red-500/15 dark:text-red-200 dark:hover:bg-red-500/25"
             title="Pause the GM so you can write back. Nothing is committed until you send."
             aria-label="Interrupt"
           >
-            <Square size={11} className="text-white" fill="currentColor" />
+            <Square size={11} fill="currentColor" />
+            <span className="hidden sm:inline">Interrupt!</span>
           </button>
         )}
         {showInterruptControls && interruptCommitted && (
           <button
             onClick={handleResume}
-            className={cn(NARRATION_META_BTN, "font-semibold text-amber-200 hover:text-amber-100 dark:text-amber-200")}
+            className="flex items-center gap-1 self-stretch rounded-lg border border-amber-400/40 bg-amber-400/15 px-2 text-xs font-semibold text-amber-100 transition-colors hover:bg-amber-400/25 hover:text-amber-50 sm:px-2.5 dark:border-amber-400/40 dark:bg-amber-400/15 dark:text-amber-100 dark:hover:bg-amber-400/25"
             title="Resume narration — your interrupt has not been committed."
             aria-label="Resume"
           >
@@ -2151,18 +2351,31 @@ export function GameNarration({
         )}
         {showNav && (
           <>
-            <button
-              onClick={() => setAutoPlay((v) => !v)}
-              className={cn(
-                "flex items-center justify-center self-stretch rounded-lg border px-2 text-xs transition-colors",
-                autoPlay
-                  ? "border-[var(--primary)]/40 bg-[var(--primary)]/20 text-[var(--primary)]"
-                  : "border-[var(--border)] bg-[var(--muted)]/20 text-[var(--foreground)]/70 hover:bg-[var(--muted)]/40 dark:border-white/10 dark:bg-white/5 dark:text-white/70 dark:hover:bg-white/10",
-              )}
-              title={autoPlay ? "Pause auto-play" : "Auto-play segments"}
-            >
-              {autoPlay ? <Pause size={12} /> : <Play size={12} />}
-            </button>
+            {!reviewingPast && (
+              <button
+                onClick={() => setAutoPlay((v) => !v)}
+                className={cn(
+                  "flex items-center justify-center self-stretch rounded-lg border px-2 text-xs transition-colors",
+                  autoPlay
+                    ? "border-[var(--primary)]/40 bg-[var(--primary)]/20 text-[var(--primary)]"
+                    : "border-[var(--border)] bg-[var(--muted)]/20 text-[var(--foreground)]/70 hover:bg-[var(--muted)]/40 dark:border-white/10 dark:bg-white/5 dark:text-white/70 dark:hover:bg-white/10",
+                )}
+                title={autoPlay ? "Pause auto-play" : "Auto-play segments"}
+              >
+                {autoPlay ? <Pause size={12} /> : <Play size={12} />}
+              </button>
+            )}
+            {reviewingPast && onJumpToLatest && (
+              <button
+                onClick={onJumpToLatest}
+                className="flex items-center gap-1 self-stretch rounded-lg border border-amber-400/40 bg-amber-400/15 px-2 text-xs font-semibold text-amber-100 transition-colors hover:bg-amber-400/25 hover:text-amber-50 sm:px-2.5 dark:border-amber-400/40 dark:bg-amber-400/15 dark:text-amber-100 dark:hover:bg-amber-400/25"
+                title="Jump back to the present"
+                aria-label="Return to present"
+              >
+                <span className="hidden sm:inline">Return</span>
+                <span className="sm:hidden">⤴</span>
+              </button>
+            )}
             <button
               onClick={nextSegment}
               className="flex items-center justify-center self-stretch rounded-lg border border-[var(--border)] bg-[var(--muted)]/20 px-3 text-xs font-semibold text-[var(--foreground)]/75 transition-colors hover:bg-[var(--muted)]/40 dark:border-white/10 dark:bg-white/5 dark:text-white/75 dark:hover:bg-white/10"
@@ -2609,8 +2822,11 @@ export function GameNarration({
           {/* Inline input — appears inside the narration box once all segments are read,
               or after the player has CONFIRMED an interrupt (not just opened the modal).
               Gating on `interruptCommitted` (not `interruptPending`) keeps the input bar
-              from showing in the background while the confirmation modal is still open. */}
+              from showing in the background while the confirmation modal is still open.
+              While reviewing the past via wheel-nav, the input is hidden — the player is
+              looking at history, not typing. */}
           {!scenePreparing &&
+            !reviewingPast &&
             (narrationComplete || interruptCommitted) &&
             !isStreaming &&
             !partyTurnPending &&
@@ -2647,6 +2863,9 @@ export function GameNarration({
       {logsOpen && (
         <div
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+          data-game-skip-bg-nav="true"
+          role="dialog"
+          aria-modal="true"
           onClick={() => {
             setLogsOpen(false);
             setEditingLogSeg(null);

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -1198,6 +1198,7 @@ export function GameSurface({
   const gameTutorialDisabled = useUIStore((s) => s.gameTutorialDisabled);
   const setGameTutorialDisabled = useUIStore((s) => s.setGameTutorialDisabled);
   const gameAvatarScale = useUIStore((s) => s.gameAvatarScale);
+  const gameMiddleMouseNav = useUIStore((s) => s.gameMiddleMouseNav);
   const gameSnapshot = useGameStateStore((s) => (s.current?.chatId === activeChatId ? s.current : null));
   const chatCharacterIds = useMemo(() => getChatCharacterIds(chat.characterIds), [chat.characterIds]);
 
@@ -3616,6 +3617,99 @@ export function GameSurface({
   );
 
   const [gameInputFocusToken, setGameInputFocusToken] = useState(0);
+
+  // Wheel-nav state. `messageOffset` is how many assistant turns back the player is
+  // currently reviewing (0 = present). `nextActionToken` is bumped each time a
+  // background click should fire the Next/Return action inside GameNarration.
+  const [messageOffset, setMessageOffset] = useState(0);
+  const [nextActionToken, setNextActionToken] = useState(0);
+  // Reset offset on chat switch so we never review the wrong chat's history.
+  useEffect(() => {
+    setMessageOffset(0);
+    setNextActionToken(0);
+  }, [activeChatId]);
+
+  // The actual wheel-nav clamp comes from GameNarration — it knows how many flat
+  // log entries exist. Until it reports, we conservatively cap at 0 (wheel-up no-op).
+  const [wheelNavMaxOffset, setWheelNavMaxOffset] = useState(0);
+  const handleMaxNavOffsetChange = useCallback((max: number) => setWheelNavMaxOffset(max), []);
+
+  // Click / Next while reviewing past: step ONE entry forward. Symmetric with
+  // wheel-down. The dedicated Return button (rendered separately) jumps home in one shot.
+  const handleStepForward = useCallback(() => {
+    setMessageOffset((curr) => Math.max(0, curr - 1));
+  }, []);
+  const handleReturnToLatest = useCallback(() => {
+    setMessageOffset(0);
+  }, []);
+
+  // Document-level wheel + click listener for game-mode wheel navigation.
+  // Window-level wheel + click listener for game-mode wheel navigation. Capture phase
+  // so nothing can stopPropagation us out of the loop. We skip events that originate
+  // inside any interactive UI element or overlay panel — buttons, links, inputs, ARIA
+  // roles, and any container marked `[data-game-skip-bg-nav="true"]`. Everything else
+  // (the chat card body, sprites, the bg image, empty space) navs.
+  const lastWheelAtRef = useRef(0);
+  useEffect(() => {
+    if (!gameMiddleMouseNav) return;
+    const max = wheelNavMaxOffset;
+
+    const SKIP_SELECTOR = [
+      "button",
+      "a",
+      "input",
+      "textarea",
+      "select",
+      "label",
+      '[role="button"]',
+      '[role="link"]',
+      '[role="dialog"]',
+      '[role="menu"]',
+      '[role="menuitem"]',
+      '[role="tab"]',
+      '[role="tablist"]',
+      '[role="slider"]',
+      '[role="checkbox"]',
+      '[role="switch"]',
+      '[role="combobox"]',
+      '[role="listbox"]',
+      '[role="option"]',
+      '[data-radix-popper-content-wrapper]',
+      '[data-game-skip-bg-nav="true"]',
+    ].join(",");
+    const inSkipUi = (target: EventTarget | null): Element | null => {
+      if (!(target instanceof Element)) return null;
+      return target.closest(SKIP_SELECTOR);
+    };
+
+    const onWheel = (event: WheelEvent) => {
+      if (event.deltaY === 0) return;
+      if (inSkipUi(event.target)) return;
+      const now = Date.now();
+      // Throttle ~60ms so a single physical scroll-tick doesn't fire many times on touchpads.
+      if (now - lastWheelAtRef.current < 60) return;
+      lastWheelAtRef.current = now;
+      if (event.deltaY < 0) {
+        setMessageOffset((curr) => Math.min(curr + 1, max));
+      } else {
+        setMessageOffset((curr) => (curr > 0 ? curr - 1 : 0));
+      }
+    };
+
+    const onClick = (event: MouseEvent) => {
+      if (event.button !== 0) return;
+      if (inSkipUi(event.target)) return;
+      setNextActionToken((t) => t + 1);
+    };
+
+    window.addEventListener("wheel", onWheel, { capture: true, passive: true });
+    window.addEventListener("click", onClick, { capture: true });
+    return () => {
+      window.removeEventListener("wheel", onWheel, { capture: true } as EventListenerOptions);
+      window.removeEventListener("click", onClick, { capture: true } as EventListenerOptions);
+    };
+  }, [gameMiddleMouseNav, wheelNavMaxOffset]);
+
   // Two-stage interrupt:
   //   1. Player clicks Interrupt → narration pauses (modal pre-empts further reading)
   //      and we stash a *candidate* with the truncation we'd apply on commit.
@@ -5988,6 +6082,11 @@ export function GameSurface({
                           onInterruptCancel={handleInterruptCancel}
                           interruptPending={interruptPending}
                           interruptCommitted={interruptCommitted}
+                          messageOffset={messageOffset}
+                          onStepForward={handleStepForward}
+                          onJumpToLatest={handleReturnToLatest}
+                          nextActionToken={nextActionToken}
+                          onMaxNavOffsetChange={handleMaxNavOffsetChange}
                           inputSlot={
                             <GameInput
                               onSend={handleSendGameTurn}
@@ -6052,6 +6151,11 @@ export function GameSurface({
                       onInterruptCancel={handleInterruptCancel}
                       interruptPending={interruptPending}
                       interruptCommitted={interruptCommitted}
+                      messageOffset={messageOffset}
+                      onStepForward={handleStepForward}
+                      onJumpToLatest={handleReturnToLatest}
+                      nextActionToken={nextActionToken}
+                      onMaxNavOffsetChange={handleMaxNavOffsetChange}
                       inputSlot={
                         <GameInput
                           onSend={handleSendGameTurn}

--- a/packages/client/src/components/game/GameWidgetPanel.tsx
+++ b/packages/client/src/components/game/GameWidgetPanel.tsx
@@ -298,6 +298,7 @@ export function MobileWidgetPanel({ widgets, position, chatId }: MobileWidgetPan
                 key={w.id}
                 className="w-40 overflow-hidden rounded-lg border bg-black/70 backdrop-blur-md transition-all"
                 style={{ borderColor: `${accent}30` }}
+                data-game-skip-bg-nav="true"
               >
                 <div className="flex items-center gap-1.5 px-2.5 py-1.5 text-left">
                   {w.icon && <span className="text-xs">{w.icon}</span>}
@@ -377,6 +378,7 @@ function WidgetCard({
       dragConstraints={constraintsRef as RefObject<Element>}
       onDragEnd={handleDragEnd}
       style={{ x, y, borderColor: `${accent}30` }}
+      data-game-skip-bg-nav="true"
       className={cn(
         "w-full overflow-hidden rounded-lg border bg-black/60 backdrop-blur-md transition-colors",
         !locked && "cursor-grab ring-1 ring-white/20 active:cursor-grabbing",

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -216,6 +216,8 @@ function GeneralSettings() {
   const setStreamingSpeed = useUIStore((s) => s.setStreamingSpeed);
   const gameInstantTextReveal = useUIStore((s) => s.gameInstantTextReveal);
   const setGameInstantTextReveal = useUIStore((s) => s.setGameInstantTextReveal);
+  const gameMiddleMouseNav = useUIStore((s) => s.gameMiddleMouseNav);
+  const setGameMiddleMouseNav = useUIStore((s) => s.setGameMiddleMouseNav);
   const gameTextSpeed = useUIStore((s) => s.gameTextSpeed);
   const setGameTextSpeed = useUIStore((s) => s.setGameTextSpeed);
   const gameAutoPlayDelay = useUIStore((s) => s.gameAutoPlayDelay);
@@ -364,6 +366,13 @@ function GeneralSettings() {
         checked={gameInstantTextReveal}
         onChange={setGameInstantTextReveal}
         help="When enabled, Game mode narration segments appear fully as soon as you enter them. This skips the typewriter effect and hides the narration speed control."
+      />
+
+      <ToggleSetting
+        label="Mouse-wheel + click navigation"
+        checked={gameMiddleMouseNav}
+        onChange={setGameMiddleMouseNav}
+        help="In Game mode, scroll the mouse wheel up to step back through past assistant turns and down to step forward. Clicking the scene background acts like the Next button. While reviewing the past, Next becomes Return — clicking the background or pressing Return jumps you back to where you were reading."
       />
 
       {/* Game Narration Text Speed */}

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -98,6 +98,13 @@ interface UIState {
   streamingSpeed: number;
   /** When true, Game mode narration segments are revealed in full as soon as they become active. */
   gameInstantTextReveal: boolean;
+  /**
+   * When true, the mouse wheel skips through past assistant turns in Game mode (up = back,
+   * down = forward) and clicking the scene background acts like the Next button. While
+   * scrolled into the past, the Next button changes to "Return" so the player can jump back
+   * to where they were reading.
+   */
+  gameMiddleMouseNav: boolean;
   /** Game narration text speed: 1 (very slow) to 100 (instant). Controls the typewriter in game mode. */
   gameTextSpeed: number;
   /** Delay in ms between auto-advancing narration segments when auto-play is enabled. */
@@ -243,6 +250,7 @@ interface UIState {
   setDebugMode: (v: boolean) => void;
   setStreamingSpeed: (v: number) => void;
   setGameInstantTextReveal: (v: boolean) => void;
+  setGameMiddleMouseNav: (v: boolean) => void;
   setGameTextSpeed: (v: number) => void;
   setGameAutoPlayDelay: (v: number) => void;
 
@@ -314,6 +322,7 @@ export function pickSyncedSettings(state: UIState) {
     enableStreaming: state.enableStreaming,
     streamingSpeed: state.streamingSpeed,
     gameInstantTextReveal: state.gameInstantTextReveal,
+    gameMiddleMouseNav: state.gameMiddleMouseNav,
     gameTextSpeed: state.gameTextSpeed,
     gameAutoPlayDelay: state.gameAutoPlayDelay,
 
@@ -388,6 +397,7 @@ export const useUIStore = create<UIState>()(
       debugMode: false,
       streamingSpeed: 50,
       gameInstantTextReveal: false,
+      gameMiddleMouseNav: false,
       gameTextSpeed: 50,
       gameAutoPlayDelay: 3000,
 
@@ -633,6 +643,7 @@ export const useUIStore = create<UIState>()(
       setDebugMode: (v) => set({ debugMode: v }),
       setStreamingSpeed: (v) => set({ streamingSpeed: Math.max(1, Math.min(100, v)) }),
       setGameInstantTextReveal: (v) => set({ gameInstantTextReveal: v }),
+      setGameMiddleMouseNav: (v) => set({ gameMiddleMouseNav: v }),
       setGameTextSpeed: (v) => set({ gameTextSpeed: Math.max(1, Math.min(100, v)) }),
       setGameAutoPlayDelay: (v) => set({ gameAutoPlayDelay: Math.max(200, Math.min(10000, Math.round(v))) }),
 
@@ -820,6 +831,7 @@ export const useUIStore = create<UIState>()(
         debugMode: state.debugMode,
         streamingSpeed: state.streamingSpeed,
         gameInstantTextReveal: state.gameInstantTextReveal,
+        gameMiddleMouseNav: state.gameMiddleMouseNav,
         gameTextSpeed: state.gameTextSpeed,
         gameAutoPlayDelay: state.gameAutoPlayDelay,
 


### PR DESCRIPTION
## Summary

Adds an opt-in **"Mouse-wheel + click navigation"** setting under Settings → General (right below "Instantly reveal game text"). When enabled, the player can scroll back through past chat entries with the mouse wheel and step forward with click — without leaving the game scene.

## Behavior

| | wheel up | wheel down | left click / Next | Return button |
|---|---|---|---|---|
| **At present** | back 1 entry | no-op | advance segment in current GM turn | (hidden) |
| **Reviewing past** | back 1 | forward 1 | forward 1 | jump home in one shot |

- Each step = one **log entry** (one parsed narration segment, one dialogue line, or one player input — same granularity as the Logs panel).
- Wheel-up goes through your own messages too — the chronology matches what you'd see scrolling the Logs.
- Reviewing past freezes auto-play, hides the chat input, and reveals a yellow **Return** button next to the **Next** button. Return jumps straight home; Next / wheel-down / bg-click step forward one entry at a time.
- Auto-play state is snapshotted when review starts and restored on Return (if it was off, it stays off).
- Wheel-up clamp comes from the actual flat-log size — no overshoot into "random text" land.

## UI immunity

Events that originate inside any of the following are skipped — the offset doesn't move and native UI behavior is unaffected:
- Native interactive elements: `button, a, input, textarea, select, label`.
- ARIA roles: `button, link, dialog, menu, menuitem, tab, tablist, slider, checkbox, switch, combobox, listbox, option`.
- Radix popovers: `[data-radix-popper-content-wrapper]`.
- Explicit opt-out marker `[data-game-skip-bg-nav="true"]` was added to:
  - The Logs modal (also tagged `role="dialog"`).
  - HUD widget cards (Bonds, Whispers, etc.) — desktop and mobile.
  - The Map widget.

So clicking inside any of those, or wheeling inside the Logs modal, does what you'd expect (scroll, button click, dismiss) without bumping the offset.

## Implementation

- `useUIStore.gameMiddleMouseNav` — new persisted boolean.
- `GameSurface` owns `messageOffset`/`nextActionToken`/`wheelNavMaxOffset` state and a window-level wheel + click listener attached when the toggle is on. Capture phase so nothing can stopPropagation us out of the loop.
- `GameNarration` builds a `flatLogEntries` list (chronological, one entry per visible segment) and resolves the current review entry via `flatLogEntries[length - 1 - offset]`. Reports the clamp upward via `onMaxNavOffsetChange`.
- Step-forward (`onStepForward`) decrements the offset by one; jump-home (`onJumpToLatest`) zeroes it. Both wired through GameSurface.
- `DirectionEngine` is unmodified — no DOM-stacking gymnastics.

## Test plan

- [x] Toggle off (default): wheel + click behave as before — no nav, no console output.
- [x] Toggle on with multiple GM turns + your replies in the chat: wheel up walks back through the log one entry at a time, in reverse chronological order. Includes player messages.
- [x] At review depth N, click on the bare scene area or press Next: offset decreases by 1 each time. After N clicks you land back at the present where you were reading.
- [x] At review depth N, click Return: offset goes to 0 immediately, narration card returns to the segment you were on before scrolling back.
- [x] Wheel down at present (offset 0): no-op.
- [x] Wheel up to the oldest log entry, then keep wheeling: clamp holds, no further back, no overshoot.
- [x] Click a Bonds/Whispers/HUD widget card or a button inside it: nav does NOT bump.
- [x] Click the map widget or a location pin inside it: nav does NOT bump.
- [x] Open Logs modal, scroll inside it, click X to close: nav does NOT bump on any of those.
- [x] Open Settings panel, scroll inside it, toggle other checkboxes: nav does NOT bump.
- [x] Auto-play snapshot/restore: enable auto-play, wheel up to review, click Return → auto-play resumes; same with auto-play off (stays off).
- [x] New GM turn arrives while reviewing past: nothing breaks; clamp updates.
- [x] Switch chats while reviewing past: offset resets to 0.
- [x] `pnpm check` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to review past narration and turns using mouse-wheel and click navigation while in game mode.
  * Added a new "Game Mode Navigation" toggle in Settings to enable/disable this feature.
  * Navigation state syncs across devices via cloud settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->