### PR TITLE
feat: add single-tracker refresh controls in roleplay HUD

### DIFF
--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -700,6 +700,16 @@ export function ChatArea() {
     await retryAgents(activeChatId, types);
   }, [activeChatId, isStreaming, agentProcessing, enabledAgentTypes, retryAgents]);
 
+  const handleRerunSingleTracker = useCallback(
+    async (agentType: string) => {
+      if (!activeChatId || isStreaming || agentProcessing) return;
+      const trackerIds = new Set(BUILT_IN_AGENTS.filter((a) => a.category === "tracker").map((a) => a.id));
+      if (!trackerIds.has(agentType) || !enabledAgentTypes.has(agentType)) return;
+      await retryAgents(activeChatId, [agentType]);
+    },
+    [activeChatId, isStreaming, agentProcessing, enabledAgentTypes, retryAgents],
+  );
+
   const handleSetActiveSwipe = useCallback(
     (messageId: string, index: number) => {
       setActiveSwipe.mutate(
@@ -1456,6 +1466,7 @@ export function ChatArea() {
           onToggleSelectMessage={handleToggleSelectMessage}
           onSummaryContextSizeChange={handleSummaryContextSizeChange}
           onRerunTrackers={handleRerunTrackers}
+          onRerunSingleTracker={handleRerunSingleTracker}
           onStartEncounter={() => startEncounter()}
           onConcludeScene={() => concludeScene(activeChatId)}
           onAbandonScene={() => abandonScene(activeChatId)}

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -606,6 +606,7 @@ type RoleplaySurfaceProps = {
   onToggleSelectMessage: (toggle: MessageSelectionToggle) => void;
   onSummaryContextSizeChange: (size: number) => void;
   onRerunTrackers: () => void;
+  onRerunSingleTracker: (agentType: string) => void;
   onRetryFailedAgents?: () => void;
   onStartEncounter: () => void;
   onConcludeScene: () => void;
@@ -701,6 +702,7 @@ export function ChatRoleplaySurface({
   onToggleSelectMessage,
   onSummaryContextSizeChange,
   onRerunTrackers,
+  onRerunSingleTracker,
   onRetryFailedAgents,
   onStartEncounter,
   onConcludeScene,
@@ -777,8 +779,10 @@ export function ChatRoleplaySurface({
                         chatId={chat.id}
                         characterCount={chatCharIds.length}
                         layout="top"
+                        isStreaming={isStreaming}
                         onRetriggerTrackers={onRerunTrackers}
                         onRetryFailedAgents={onRetryFailedAgents}
+                        onRerunSingleTracker={onRerunSingleTracker}
                         enabledAgentTypes={enabledAgentTypes}
                         manualTrackers={!!chatMeta.manualTrackers}
                       />
@@ -853,8 +857,10 @@ export function ChatRoleplaySurface({
                         chatId={chat.id}
                         characterCount={chatCharIds.length}
                         layout="top"
+                        isStreaming={isStreaming}
                         onRetriggerTrackers={onRerunTrackers}
                         onRetryFailedAgents={onRetryFailedAgents}
+                        onRerunSingleTracker={onRerunSingleTracker}
                         enabledAgentTypes={enabledAgentTypes}
                         manualTrackers={!!chatMeta.manualTrackers}
                         mobileCompact

--- a/packages/client/src/components/chat/RoleplayHUD.tsx
+++ b/packages/client/src/components/chat/RoleplayHUD.tsx
@@ -42,7 +42,9 @@ interface RoleplayHUDProps {
   chatId: string;
   characterCount: number;
   layout?: HudPosition;
+  isStreaming: boolean;
   onRetriggerTrackers?: () => void;
+  onRerunSingleTracker?: (agentType: string) => void;
   onRetryFailedAgents?: () => void;
   /** When true, tracker agents are manual — show a trigger button in the widget strip */
   manualTrackers?: boolean;
@@ -77,7 +79,9 @@ export function RoleplayHUD({
   chatId,
   characterCount: _characterCount,
   layout = "top",
+  isStreaming,
   onRetriggerTrackers,
+  onRerunSingleTracker,
   onRetryFailedAgents,
   manualTrackers,
   mobileCompact,
@@ -106,6 +110,8 @@ export function RoleplayHUD({
   const dismissThoughtBubble = useAgentStore((s) => s.dismissThoughtBubble);
   const clearThoughtBubbles = useAgentStore((s) => s.clearThoughtBubbles);
   const resetAgentStore = useAgentStore((s) => s.reset);
+
+  const isTrackerBusy = isAgentProcessing || isStreaming;
 
   useEffect(() => {
     if (!chatId) return;
@@ -316,6 +322,8 @@ export function RoleplayHUD({
             onSaveWeather={(v) => patchField("weather", v)}
             onSaveTemperature={(v) => patchField("temperature", v)}
             layout={layout}
+            onRerunSingleTracker={onRerunSingleTracker}
+            isTrackerRetryBusy={isTrackerBusy}
           />
         )}
 
@@ -346,6 +354,8 @@ export function RoleplayHUD({
             onUpdateQuests={(q) => patchPlayerStats("activeQuests", q)}
             customTrackerFields={customTrackerFields}
             onUpdateCustomTracker={(fields) => patchPlayerStats("customTrackerFields", fields)}
+            onRerunSingleTracker={onRerunSingleTracker}
+            isTrackerRetryBusy={isTrackerBusy}
           />
         )}
 
@@ -356,14 +366,14 @@ export function RoleplayHUD({
               e.preventDefault();
               onRetriggerTrackers();
             }}
-            disabled={isAgentProcessing}
+            disabled={isTrackerBusy}
             className={cn(
               MOBILE_HUD_BTN,
               "justify-center text-[0.5625rem] font-medium",
-              isAgentProcessing ? "text-purple-600 dark:text-purple-300" : "text-[var(--muted-foreground)]",
+              isTrackerBusy ? "text-purple-600 dark:text-purple-300" : "text-[var(--muted-foreground)]",
             )}
           >
-            <RefreshCw size="0.875rem" className={cn("shrink-0 h-4 w-4", isAgentProcessing && "animate-spin")} />
+            <RefreshCw size="0.875rem" className={cn("shrink-0 h-4 w-4", isTrackerBusy && "animate-spin")} />
           </button>
         )}
       </div>
@@ -383,6 +393,8 @@ export function RoleplayHUD({
             onSaveWeather={(v) => patchField("weather", v)}
             onSaveTemperature={(v) => patchField("temperature", v)}
             layout={layout}
+            onRerunSingleTracker={onRerunSingleTracker}
+            isTrackerRetryBusy={isTrackerBusy}
           />
         )}
 
@@ -393,6 +405,8 @@ export function RoleplayHUD({
             status={personaStatus}
             onUpdateStatus={(status) => patchPlayerStats("status", status)}
             layout={layout}
+            onRerunSingleTracker={onRerunSingleTracker}
+            isTrackerRetryBusy={isTrackerBusy}
           />
         )}
 
@@ -407,6 +421,8 @@ export function RoleplayHUD({
             }}
             chatId={chatId}
             layout={layout}
+            onRerunSingleTracker={onRerunSingleTracker}
+            isTrackerRetryBusy={isTrackerBusy}
           />
         )}
 
@@ -419,7 +435,13 @@ export function RoleplayHUD({
         )}
 
         {enabledAgentTypes.has("quest") && (
-          <QuestsWidget quests={activeQuests} onUpdate={(q) => patchPlayerStats("activeQuests", q)} layout={layout} />
+          <QuestsWidget
+            quests={activeQuests}
+            onUpdate={(q) => patchPlayerStats("activeQuests", q)}
+            layout={layout}
+            onRerunSingleTracker={onRerunSingleTracker}
+            isTrackerRetryBusy={isTrackerBusy}
+          />
         )}
 
         {enabledAgentTypes.has("custom-tracker") && (
@@ -427,6 +449,8 @@ export function RoleplayHUD({
             fields={customTrackerFields}
             onUpdate={(fields) => patchPlayerStats("customTrackerFields", fields)}
             layout={layout}
+            onRerunSingleTracker={onRerunSingleTracker}
+            isTrackerRetryBusy={isTrackerBusy}
           />
         )}
 
@@ -437,11 +461,11 @@ export function RoleplayHUD({
               e.preventDefault();
               onRetriggerTrackers();
             }}
-            disabled={isAgentProcessing}
-            className={cn(WIDGET, isAgentProcessing ? "text-purple-300" : "text-[var(--muted-foreground)]")}
-            title={isAgentProcessing ? "Trackers running…" : "Run Trackers"}
+            disabled={isTrackerBusy}
+            className={cn(WIDGET, isTrackerBusy ? "text-purple-300" : "text-[var(--muted-foreground)]")}
+            title={isTrackerBusy ? "Trackers running…" : "Run Trackers"}
           >
-            <RefreshCw size="0.875rem" className={cn(isAgentProcessing && "animate-spin")} />
+            <RefreshCw size="0.875rem" className={cn(isTrackerBusy && "animate-spin")} />
           </button>
         )}
       </div>
@@ -662,6 +686,8 @@ function CombinedPlayerWidget({
   onUpdateQuests,
   customTrackerFields,
   onUpdateCustomTracker,
+  onRerunSingleTracker,
+  isTrackerRetryBusy,
 }: {
   layout?: HudPosition;
   showPersona: boolean;
@@ -680,6 +706,8 @@ function CombinedPlayerWidget({
   onUpdateQuests: (quests: QuestProgress[]) => void;
   customTrackerFields: CustomTrackerField[];
   onUpdateCustomTracker: (fields: CustomTrackerField[]) => void;
+  onRerunSingleTracker?: (agentType: string) => void;
+  isTrackerRetryBusy?: boolean;
 }) {
   const [open, setOpen] = useState(false);
   const buttonRef = useRef<HTMLButtonElement>(null);
@@ -726,6 +754,8 @@ function CombinedPlayerWidget({
             customTrackerFields={customTrackerFields}
             onUpdateCustomTracker={onUpdateCustomTracker}
             onClose={() => setOpen(false)}
+            onRerunSingleTracker={onRerunSingleTracker}
+            isTrackerRetryBusy={isTrackerRetryBusy}
           />
         </Suspense>
       </WidgetPopover>
@@ -843,11 +873,15 @@ function CharactersWidget({
   onUpdate,
   chatId,
   layout = "top",
+  onRerunSingleTracker,
+  isTrackerRetryBusy,
 }: {
   characters: PresentCharacter[];
   onUpdate: (chars: PresentCharacter[]) => void;
   chatId: string;
   layout?: HudPosition;
+  onRerunSingleTracker?: (agentType: string) => void;
+  isTrackerRetryBusy?: boolean;
 }) {
   const [open, setOpen] = useState(false);
   const buttonRef = useRef<HTMLButtonElement>(null);
@@ -886,7 +920,13 @@ function CharactersWidget({
         className="w-72 max-h-80 overflow-y-auto"
       >
         <Suspense fallback={<DeferredHUDPanelFallback label="Loading characters…" />}>
-          <CharactersPanel characters={characters} onUpdate={onUpdate} chatId={chatId} />
+          <CharactersPanel
+            characters={characters}
+            onUpdate={onUpdate}
+            chatId={chatId}
+            onRerunSingleTracker={onRerunSingleTracker}
+            isTrackerRetryBusy={isTrackerRetryBusy}
+          />
         </Suspense>
       </WidgetPopover>
     </div>
@@ -901,12 +941,16 @@ function PersonaStatsWidget({
   status,
   onUpdateStatus,
   layout = "top",
+  onRerunSingleTracker,
+  isTrackerRetryBusy,
 }: {
   bars: CharacterStat[];
   onUpdate: (bars: CharacterStat[]) => void;
   status: string;
   onUpdateStatus: (status: string) => void;
   layout?: HudPosition;
+  onRerunSingleTracker?: (agentType: string) => void;
+  isTrackerRetryBusy?: boolean;
 }) {
   const [open, setOpen] = useState(false);
   const buttonRef = useRef<HTMLButtonElement>(null);
@@ -952,7 +996,14 @@ function PersonaStatsWidget({
         className="w-60 max-h-80 overflow-y-auto"
       >
         <Suspense fallback={<DeferredHUDPanelFallback label="Loading persona stats…" />}>
-          <PersonaStatsPanel bars={bars} onUpdate={onUpdate} status={status} onUpdateStatus={onUpdateStatus} />
+          <PersonaStatsPanel
+            bars={bars}
+            onUpdate={onUpdate}
+            status={status}
+            onUpdateStatus={onUpdateStatus}
+            onRerunSingleTracker={onRerunSingleTracker}
+            isTrackerRetryBusy={isTrackerRetryBusy}
+          />
         </Suspense>
       </WidgetPopover>
     </div>
@@ -965,10 +1016,14 @@ function CustomTrackerWidget({
   fields,
   onUpdate,
   layout = "top",
+  onRerunSingleTracker,
+  isTrackerRetryBusy,
 }: {
   fields: CustomTrackerField[];
   onUpdate: (fields: CustomTrackerField[]) => void;
   layout?: HudPosition;
+  onRerunSingleTracker?: (agentType: string) => void;
+  isTrackerRetryBusy?: boolean;
 }) {
   const [open, setOpen] = useState(false);
   const buttonRef = useRef<HTMLButtonElement>(null);
@@ -1027,7 +1082,12 @@ function CustomTrackerWidget({
         className="w-72 max-h-80 overflow-y-auto"
       >
         <Suspense fallback={<DeferredHUDPanelFallback label="Loading custom tracker…" />}>
-          <CustomTrackerPanel fields={fields} onUpdate={onUpdate} />
+          <CustomTrackerPanel
+            fields={fields}
+            onUpdate={onUpdate}
+            onRerunSingleTracker={onRerunSingleTracker}
+            isTrackerRetryBusy={isTrackerRetryBusy}
+          />
         </Suspense>
       </WidgetPopover>
     </div>
@@ -1114,10 +1174,14 @@ function QuestsWidget({
   quests,
   onUpdate,
   layout = "top",
+  onRerunSingleTracker,
+  isTrackerRetryBusy,
 }: {
   quests: QuestProgress[];
   onUpdate: (quests: QuestProgress[]) => void;
   layout?: HudPosition;
+  onRerunSingleTracker?: (agentType: string) => void;
+  isTrackerRetryBusy?: boolean;
 }) {
   const [open, setOpen] = useState(false);
   const buttonRef = useRef<HTMLButtonElement>(null);
@@ -1157,7 +1221,12 @@ function QuestsWidget({
         className="w-72 max-h-96 overflow-y-auto"
       >
         <Suspense fallback={<DeferredHUDPanelFallback label="Loading quests…" />}>
-          <QuestsPanel quests={quests} onUpdate={onUpdate} />
+          <QuestsPanel
+            quests={quests}
+            onUpdate={onUpdate}
+            onRerunSingleTracker={onRerunSingleTracker}
+            isTrackerRetryBusy={isTrackerRetryBusy}
+          />
         </Suspense>
       </WidgetPopover>
     </div>
@@ -1292,6 +1361,8 @@ function CombinedWorldWidget({
   onSaveWeather,
   onSaveTemperature,
   layout,
+  onRerunSingleTracker,
+  isTrackerRetryBusy,
 }: {
   location: string;
   date: string;
@@ -1304,6 +1375,8 @@ function CombinedWorldWidget({
   onSaveWeather: (v: string) => void;
   onSaveTemperature: (v: string) => void;
   layout: "top" | "left" | "right";
+  onRerunSingleTracker?: (agentType: string) => void;
+  isTrackerRetryBusy?: boolean;
 }) {
   const [open, setOpen] = useState(false);
   const buttonRef = useRef<HTMLButtonElement>(null);
@@ -1508,6 +1581,8 @@ function CombinedWorldWidget({
             pinColor={pinColor}
             tempColor={tempColor}
             onClose={() => setOpen(false)}
+            onRerunSingleTracker={onRerunSingleTracker}
+            isTrackerRetryBusy={isTrackerRetryBusy}
           />
         </Suspense>
       </WidgetPopover>

--- a/packages/client/src/components/chat/RoleplayHUDPanels.tsx
+++ b/packages/client/src/components/chat/RoleplayHUDPanels.tsx
@@ -18,6 +18,7 @@ import {
   Thermometer,
   Users,
   X,
+  RefreshCw,
 } from "lucide-react";
 import { cn } from "../../lib/utils";
 import { api } from "../../lib/api-client";
@@ -48,6 +49,36 @@ interface CombinedPlayerPanelProps {
   customTrackerFields: CustomTrackerField[];
   onUpdateCustomTracker: (fields: CustomTrackerField[]) => void;
   onClose: () => void;
+  onRerunSingleTracker?: (agentType: string) => void;
+  isTrackerRetryBusy?: boolean;
+}
+
+function TrackerSectionRefresh({
+  agentType,
+  onRerunSingleTracker,
+  busy,
+  title,
+}: {
+  agentType: string;
+  onRerunSingleTracker?: (agentType: string) => void;
+  busy?: boolean;
+  title?: string;
+}) {
+  if (!onRerunSingleTracker) return null;
+  return (
+    <button
+      type="button"
+      onClick={(e) => {
+        e.preventDefault();
+        onRerunSingleTracker(agentType);
+      }}
+      disabled={busy}
+      title={title ?? `Re-run ${agentType} only`}
+      className="rounded p-0.5 text-[var(--muted-foreground)]/50 transition-colors hover:bg-[var(--accent)] hover:text-purple-300 disabled:opacity-40"
+    >
+      <RefreshCw size="0.625rem" className={busy ? "animate-spin" : ""} />
+    </button>
+  );
 }
 
 const EMPTY_STATE = "text-[0.625rem] text-[var(--muted-foreground)]/60 text-center py-1";
@@ -70,6 +101,8 @@ export function CombinedPlayerPanel({
   customTrackerFields,
   onUpdateCustomTracker,
   onClose,
+  onRerunSingleTracker,
+  isTrackerRetryBusy,
 }: CombinedPlayerPanelProps) {
   const updateBar = (idx: number, field: "value" | "max" | "name", val: number | string) => {
     const next = [...personaStats];
@@ -156,10 +189,16 @@ export function CombinedPlayerPanel({
         {showPersona && (
           <div className="p-2">
             <PersonaStatusField value={personaStatus} onSave={onUpdatePersonaStatus} />
-            <div className="px-1 pb-1">
+            <div className="flex items-center justify-between px-1 pb-1">
               <span className="text-[0.625rem] font-semibold text-violet-300/70 uppercase tracking-wider">
                 Persona Stats
               </span>
+              <TrackerSectionRefresh
+                agentType="persona-stats"
+                onRerunSingleTracker={onRerunSingleTracker}
+                busy={isTrackerRetryBusy}
+                title="Re-run persona tracker (stats + inventory)"
+              />
             </div>
             <div className="space-y-2">
               {personaStats.length === 0 && <div className={EMPTY_STATE}>No stats tracked</div>}
@@ -182,12 +221,20 @@ export function CombinedPlayerPanel({
               <span className="text-[0.625rem] font-semibold text-purple-300/70 uppercase tracking-wider flex items-center gap-1">
                 <Users size="0.5625rem" /> Characters ({characters.length})
               </span>
-              <button
-                onClick={addCharacter}
-                className="flex items-center gap-0.5 text-[0.625rem] text-purple-400 hover:text-purple-300 transition-colors"
-              >
-                <Plus size="0.625rem" /> Add
-              </button>
+              <span className="flex items-center gap-1">
+                <TrackerSectionRefresh
+                  agentType="character-tracker"
+                  onRerunSingleTracker={onRerunSingleTracker}
+                  busy={isTrackerRetryBusy}
+                  title="Re-run character tracker only"
+                />
+                <button
+                  onClick={addCharacter}
+                  className="flex items-center gap-0.5 text-[0.625rem] text-purple-400 hover:text-purple-300 transition-colors"
+                >
+                  <Plus size="0.625rem" /> Add
+                </button>
+              </span>
             </div>
             <div className="space-y-2">
               {characters.length === 0 && <div className={EMPTY_STATE}>No characters in scene</div>}
@@ -311,12 +358,20 @@ export function CombinedPlayerPanel({
               <span className="text-[0.625rem] font-semibold text-emerald-300/70 uppercase tracking-wider flex items-center gap-1">
                 <Scroll size="0.5625rem" /> Quests ({quests.length})
               </span>
-              <button
-                onClick={addQuest}
-                className="flex items-center gap-0.5 text-[0.625rem] text-emerald-400 hover:text-emerald-300 transition-colors"
-              >
-                <Plus size="0.625rem" /> Add
-              </button>
+              <span className="flex items-center gap-1">
+                <TrackerSectionRefresh
+                  agentType="quest"
+                  onRerunSingleTracker={onRerunSingleTracker}
+                  busy={isTrackerRetryBusy}
+                  title="Re-run quest tracker only"
+                />
+                <button
+                  onClick={addQuest}
+                  className="flex items-center gap-0.5 text-[0.625rem] text-emerald-400 hover:text-emerald-300 transition-colors"
+                >
+                  <Plus size="0.625rem" /> Add
+                </button>
+              </span>
             </div>
             <div className="space-y-2">
               {quests.length === 0 && <div className={EMPTY_STATE}>No active quests</div>}
@@ -338,12 +393,20 @@ export function CombinedPlayerPanel({
               <span className="text-[0.625rem] font-semibold text-cyan-300/70 uppercase tracking-wider flex items-center gap-1">
                 <SlidersHorizontal size="0.5625rem" /> Custom ({customTrackerFields.length})
               </span>
-              <button
-                onClick={addCustomField}
-                className="flex items-center gap-0.5 text-[0.625rem] text-cyan-400 hover:text-cyan-300 transition-colors"
-              >
-                <Plus size="0.625rem" /> Add
-              </button>
+              <span className="flex items-center gap-1">
+                <TrackerSectionRefresh
+                  agentType="custom-tracker"
+                  onRerunSingleTracker={onRerunSingleTracker}
+                  busy={isTrackerRetryBusy}
+                  title="Re-run custom tracker only"
+                />
+                <button
+                  onClick={addCustomField}
+                  className="flex items-center gap-0.5 text-[0.625rem] text-cyan-400 hover:text-cyan-300 transition-colors"
+                >
+                  <Plus size="0.625rem" /> Add
+                </button>
+              </span>
             </div>
             <div className="space-y-1">
               {customTrackerFields.length === 0 && <div className={EMPTY_STATE}>No fields tracked</div>}
@@ -385,9 +448,18 @@ interface PersonaStatsPanelProps {
   onUpdate: (bars: CharacterStat[]) => void;
   status?: string;
   onUpdateStatus?: (status: string) => void;
+  onRerunSingleTracker?: (agentType: string) => void;
+  isTrackerRetryBusy?: boolean;
 }
 
-export function PersonaStatsPanel({ bars, onUpdate, status = "", onUpdateStatus }: PersonaStatsPanelProps) {
+export function PersonaStatsPanel({
+  bars,
+  onUpdate,
+  status = "",
+  onUpdateStatus,
+  onRerunSingleTracker,
+  isTrackerRetryBusy,
+}: PersonaStatsPanelProps) {
   const updateBar = (idx: number, field: "value" | "max" | "name", val: number | string) => {
     const next = [...bars];
     next[idx] = { ...next[idx]!, [field]: val };
@@ -399,10 +471,16 @@ export function PersonaStatsPanel({ bars, onUpdate, status = "", onUpdateStatus 
       <div className="border-b border-[var(--border)] p-2">
         <PersonaStatusField value={status} onSave={onUpdateStatus} />
       </div>
-      <div className="border-b border-[var(--border)] px-3 py-1.5">
+      <div className="flex items-center justify-between border-b border-[var(--border)] px-3 py-1.5">
         <span className="text-[0.625rem] font-semibold text-[var(--muted-foreground)] uppercase tracking-wider">
           Persona Stats
         </span>
+        <TrackerSectionRefresh
+          agentType="persona-stats"
+          onRerunSingleTracker={onRerunSingleTracker}
+          busy={isTrackerRetryBusy}
+          title="Re-run persona tracker (stats + inventory)"
+        />
       </div>
       <div className="p-2 space-y-2">
         {bars.map((bar, idx) => (
@@ -423,9 +501,17 @@ interface CharactersPanelProps {
   characters: PresentCharacter[];
   onUpdate: (chars: PresentCharacter[]) => void;
   chatId?: string;
+  onRerunSingleTracker?: (agentType: string) => void;
+  isTrackerRetryBusy?: boolean;
 }
 
-export function CharactersPanel({ characters, onUpdate, chatId }: CharactersPanelProps) {
+export function CharactersPanel({
+  characters,
+  onUpdate,
+  chatId,
+  onRerunSingleTracker,
+  isTrackerRetryBusy,
+}: CharactersPanelProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [uploadIdx, setUploadIdx] = useState<number | null>(null);
 
@@ -511,6 +597,12 @@ export function CharactersPanel({ characters, onUpdate, chatId }: CharactersPane
           <Users size="0.625rem" /> Present Characters
         </span>
         <div className="flex items-center gap-2">
+          <TrackerSectionRefresh
+            agentType="character-tracker"
+            onRerunSingleTracker={onRerunSingleTracker}
+            busy={isTrackerRetryBusy}
+            title="Re-run character tracker only"
+          />
           {trackerConfig && (
             <button
               onClick={toggleAutoGenerate}
@@ -706,9 +798,11 @@ export function InventoryPanel({ items, onUpdate }: InventoryPanelProps) {
 interface QuestsPanelProps {
   quests: QuestProgress[];
   onUpdate: (quests: QuestProgress[]) => void;
+  onRerunSingleTracker?: (agentType: string) => void;
+  isTrackerRetryBusy?: boolean;
 }
 
-export function QuestsPanel({ quests, onUpdate }: QuestsPanelProps) {
+export function QuestsPanel({ quests, onUpdate, onRerunSingleTracker, isTrackerRetryBusy }: QuestsPanelProps) {
   const addQuest = () => {
     onUpdate([
       ...quests,
@@ -738,12 +832,20 @@ export function QuestsPanel({ quests, onUpdate }: QuestsPanelProps) {
         <span className="text-[0.625rem] font-semibold text-[var(--muted-foreground)] uppercase tracking-wider flex items-center gap-1">
           <Scroll size="0.625rem" /> Quests ({quests.length})
         </span>
-        <button
-          onClick={addQuest}
-          className="flex items-center gap-0.5 text-[0.625rem] text-emerald-400 hover:text-emerald-300 transition-colors"
-        >
-          <Plus size="0.625rem" /> Add
-        </button>
+        <span className="flex items-center gap-1">
+          <TrackerSectionRefresh
+            agentType="quest"
+            onRerunSingleTracker={onRerunSingleTracker}
+            busy={isTrackerRetryBusy}
+            title="Re-run quest tracker only"
+          />
+          <button
+            onClick={addQuest}
+            className="flex items-center gap-0.5 text-[0.625rem] text-emerald-400 hover:text-emerald-300 transition-colors"
+          >
+            <Plus size="0.625rem" /> Add
+          </button>
+        </span>
       </div>
       <div className="p-2 space-y-2">
         {quests.length === 0 && <div className={cn(EMPTY_STATE, "py-2")}>No active quests</div>}
@@ -763,9 +865,16 @@ export function QuestsPanel({ quests, onUpdate }: QuestsPanelProps) {
 interface CustomTrackerPanelProps {
   fields: CustomTrackerField[];
   onUpdate: (fields: CustomTrackerField[]) => void;
+  onRerunSingleTracker?: (agentType: string) => void;
+  isTrackerRetryBusy?: boolean;
 }
 
-export function CustomTrackerPanel({ fields, onUpdate }: CustomTrackerPanelProps) {
+export function CustomTrackerPanel({
+  fields,
+  onUpdate,
+  onRerunSingleTracker,
+  isTrackerRetryBusy,
+}: CustomTrackerPanelProps) {
   const addField = () => {
     onUpdate([...fields, { name: "New Field", value: "" }]);
   };
@@ -786,12 +895,20 @@ export function CustomTrackerPanel({ fields, onUpdate }: CustomTrackerPanelProps
         <span className="text-[0.625rem] font-semibold text-[var(--muted-foreground)] uppercase tracking-wider flex items-center gap-1">
           <SlidersHorizontal size="0.625rem" /> Custom Tracker ({fields.length})
         </span>
-        <button
-          onClick={addField}
-          className="flex items-center gap-0.5 text-[0.625rem] text-cyan-400 hover:text-cyan-300 transition-colors"
-        >
-          <Plus size="0.625rem" /> Add
-        </button>
+        <span className="flex items-center gap-1">
+          <TrackerSectionRefresh
+            agentType="custom-tracker"
+            onRerunSingleTracker={onRerunSingleTracker}
+            busy={isTrackerRetryBusy}
+            title="Re-run custom tracker only"
+          />
+          <button
+            onClick={addField}
+            className="flex items-center gap-0.5 text-[0.625rem] text-cyan-400 hover:text-cyan-300 transition-colors"
+          >
+            <Plus size="0.625rem" /> Add
+          </button>
+        </span>
       </div>
       <div className="p-2 space-y-1">
         {fields.length === 0 && <div className={cn(EMPTY_STATE, "py-2")}>No fields tracked — add one above</div>}
@@ -840,6 +957,8 @@ interface CombinedWorldPanelProps {
   pinColor: string;
   tempColor: string;
   onClose: () => void;
+  onRerunSingleTracker?: (agentType: string) => void;
+  isTrackerRetryBusy?: boolean;
 }
 
 export function CombinedWorldPanel({
@@ -857,6 +976,8 @@ export function CombinedWorldPanel({
   pinColor,
   tempColor,
   onClose,
+  onRerunSingleTracker,
+  isTrackerRetryBusy,
 }: CombinedWorldPanelProps) {
   return (
     <>
@@ -864,12 +985,20 @@ export function CombinedWorldPanel({
         <span className="text-[0.625rem] font-semibold text-[var(--muted-foreground)] uppercase tracking-wider flex items-center gap-1">
           <CloudSun size="0.625rem" /> World State
         </span>
-        <button
-          onClick={onClose}
-          className="text-[var(--muted-foreground)]/50 hover:text-[var(--foreground)] transition-colors"
-        >
-          <X size="0.75rem" />
-        </button>
+        <span className="flex items-center gap-1">
+          <TrackerSectionRefresh
+            agentType="world-state"
+            onRerunSingleTracker={onRerunSingleTracker}
+            busy={isTrackerRetryBusy}
+            title="Re-run world state tracker only"
+          />
+          <button
+            onClick={onClose}
+            className="text-[var(--muted-foreground)]/50 hover:text-[var(--foreground)] transition-colors"
+          >
+            <X size="0.75rem" />
+          </button>
+        </span>
       </div>
       <div className="divide-y divide-[var(--border)]">
         <WorldFieldRow


### PR DESCRIPTION
## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #327

## Why this change

- Add **more granular control** over tracker updates in roleplay/game chats: users can refresh **one** tracker (world state, persona stats, characters, quests, custom) without rerunning the entire tracker set, which can overwrite unrelated manual edits.

## What changed

- Added a `onRerunSingleTracker(agentType)` callback from `ChatArea` → `ChatRoleplaySurface` → `RoleplayHUD`.
- Added small **per-section refresh buttons** in the Roleplay HUD panels (world state, persona stats, character tracker, quests, custom tracker) that trigger rerun of just that tracker when available.
- Reruns are **guarded** when streaming/agents are processing and only allowed for **enabled tracker agents**.

## Validation

- [X] `pnpm check` passes locally
- [X] Container (Docker / Podman) built and ran without issue
- [X] Ran the app, clicked through the changes manually
- [X] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [X] Above manual verification completed (describe below)
- [X] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- [X] Started the app and opened a roleplay chat with trackers enabled.
- [X] Opened each HUD panel section (World State, Persona Stats, Characters, Quests, Custom Tracker) and confirmed the refresh icon/button is present for each panel.
- [X] Clicked each section refresh and confirmed it reruns only that tracker (and does not retrigger the full tracker set).
- [X] Confirmed refresh controls are disabled/no-op while streaming and while agents are processing.
- [X] Checked mobile viewport to ensure buttons don’t overflow and remain tappable.
- [X] Checked light/dark themes for contrast and layout (ow, my eyes).

## Docs and release impact

- [X] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

<img width="402" height="75" alt="Screenshot 2026-04-30 214934" src="https://github.com/user-attachments/assets/696a1dd2-d708-4414-a43b-ff68570bd8ce" />

<img width="393" height="55" alt="Screenshot 2026-04-30 233901" src="https://github.com/user-attachments/assets/351067e1-a75b-4d61-a886-40e18a575de6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-tracker refresh controls to retry individual tracker sections (Quests, Characters, Persona Stats, World, Custom) from the HUD.
  * HUD now disables tracker actions while streaming or agents are busy and shows a spinner state.

* **Bug Fixes**
  * Prevents reruns when there’s no active chat, during streaming, or while agents are processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->