### PR TITLE
feat(server): prompt-overrides registry for image prompts

### DIFF
--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -385,6 +385,12 @@ const CREATE_TABLES: string[] = [
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL
   )`,
+  `CREATE TABLE IF NOT EXISTS prompt_overrides (
+    key TEXT PRIMARY KEY NOT NULL,
+    template TEXT NOT NULL,
+    enabled INTEGER NOT NULL DEFAULT 1,
+    updated_at TEXT NOT NULL
+  )`,
 ];
 
 // ── Column migrations (ALTER TABLE for schema evolution) ──

--- a/packages/server/src/db/schema/index.ts
+++ b/packages/server/src/db/schema/index.ts
@@ -16,3 +16,4 @@ export * from "./regex-scripts.js";
 export * from "./gallery.js";
 export * from "./themes.js";
 export * from "./app-settings.js";
+export * from "./prompt-overrides.js";

--- a/packages/server/src/db/schema/prompt-overrides.ts
+++ b/packages/server/src/db/schema/prompt-overrides.ts
@@ -1,0 +1,14 @@
+// ──────────────────────────────────────────────
+// Schema: Prompt Overrides
+//
+// User-supplied templates that replace hardcoded
+// prompt builders. One row per registered key.
+// ──────────────────────────────────────────────
+import { sqliteTable, text, integer } from "drizzle-orm/sqlite-core";
+
+export const promptOverrides = sqliteTable("prompt_overrides", {
+  key: text("key").primaryKey(),
+  template: text("template").notNull(),
+  enabled: integer("enabled").notNull().default(1),
+  updatedAt: text("updated_at").notNull(),
+});

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -95,6 +95,7 @@ import {
   readAvatarBase64,
 } from "../services/game/game-asset-generation.js";
 import { saveImageToDisk } from "../services/image/image-generation.js";
+import { createPromptOverridesStorage } from "../services/storage/prompt-overrides.storage.js";
 
 // ──────────────────────────────────────────────
 // Helpers
@@ -4577,6 +4578,7 @@ export async function gameRoutes(app: FastifyInstance) {
                 imgApiKey,
                 imgService: imgServiceHint,
                 imgComfyWorkflow,
+                promptOverridesStorage: createPromptOverridesStorage(app.db),
               });
               if (generatedTag) {
                 await addGeneratedIllustrationToGallery({
@@ -4643,6 +4645,7 @@ export async function gameRoutes(app: FastifyInstance) {
                   imgBaseUrl,
                   imgApiKey,
                   imgService: imgServiceHint,
+                  promptOverridesStorage: createPromptOverridesStorage(app.db),
                 });
 
                 if (generatedTag) {
@@ -4692,6 +4695,7 @@ export async function gameRoutes(app: FastifyInstance) {
                   imgBaseUrl,
                   imgApiKey,
                   imgService: imgServiceHint,
+                  promptOverridesStorage: createPromptOverridesStorage(app.db),
                 });
 
                 if (generatedTag) {
@@ -4874,6 +4878,7 @@ export async function gameRoutes(app: FastifyInstance) {
         imgApiKey,
         imgService: imgServiceHint,
         imgComfyWorkflow,
+        promptOverridesStorage: createPromptOverridesStorage(app.db),
       });
       generatedBackground = tag;
     }
@@ -4930,6 +4935,7 @@ export async function gameRoutes(app: FastifyInstance) {
           imgApiKey,
           imgService: imgServiceHint,
           imgComfyWorkflow,
+          promptOverridesStorage: createPromptOverridesStorage(app.db),
         });
 
         if (tag) {
@@ -5017,6 +5023,7 @@ export async function gameRoutes(app: FastifyInstance) {
           imgApiKey,
           imgService: imgServiceHint,
           imgComfyWorkflow,
+          promptOverridesStorage: createPromptOverridesStorage(app.db),
         });
         if (avatarUrl) {
           generatedNpcAvatars.push({ name: npc.name, avatarUrl });

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -30,6 +30,8 @@ import { createGameStateStorage } from "../services/storage/game-state.storage.j
 import { createCustomToolsStorage } from "../services/storage/custom-tools.storage.js";
 import { createLorebooksStorage } from "../services/storage/lorebooks.storage.js";
 import { createRegexScriptsStorage } from "../services/storage/regex-scripts.storage.js";
+import { createPromptOverridesStorage } from "../services/storage/prompt-overrides.storage.js";
+import { loadPrompt, CONVERSATION_SELFIE } from "../services/prompt-overrides/index.js";
 import { processLorebooks } from "../services/lorebook/index.js";
 import { injectAtDepth } from "../services/lorebook/prompt-injector.js";
 import { createLLMProvider } from "../services/llm/provider-registry.js";
@@ -6925,28 +6927,23 @@ export async function generateRoutes(app: FastifyInstance) {
                       conn.openrouterProvider,
                       conn.maxTokensOverride,
                     );
+                    const selfieSystemPrompt = await loadPrompt(
+                      createPromptOverridesStorage(app.db),
+                      CONVERSATION_SELFIE,
+                      {
+                        appearance,
+                        charName,
+                        selfieTagsBlock:
+                          selfieTags.length > 0
+                            ? `\n\nAlways include these tags/modifiers in the prompt: ${selfieTags.join(", ")}`
+                            : "",
+                      },
+                    );
                     const promptResult = await promptBuilder.chatComplete(
                       [
                         {
                           role: "system",
-                          content: [
-                            `You are an image prompt generator. Create a concise, detailed image generation prompt for a selfie photo.`,
-                            `The character's appearance: ${appearance}`,
-                            `Character name: ${charName}`,
-                            ``,
-                            `Generate a prompt that describes a selfie photo of this character. Include:`,
-                            `- Physical appearance details (face, hair, eyes, skin)`,
-                            `- What they're wearing`,
-                            `- Expression and pose (selfie angle)`,
-                            `- Setting/background from context`,
-                            `- Lighting and mood`,
-                            ``,
-                            `Infer the appropriate art style from the character. For example, anime/game characters should use anime/illustration style, realistic characters should use photorealistic style. Match the style to the character's origin.`,
-                            ...(selfieTags.length > 0
-                              ? [``, `Always include these tags/modifiers in the prompt: ${selfieTags.join(", ")}`]
-                              : []),
-                            `Output ONLY the prompt text, nothing else.`,
-                          ].join("\n"),
+                          content: selfieSystemPrompt,
                         },
                         {
                           role: "user",

--- a/packages/server/src/routes/index.ts
+++ b/packages/server/src/routes/index.ts
@@ -46,6 +46,7 @@ import { gameRoutes } from "./game.routes.js";
 import { gameAssetsRoutes } from "./game-assets.routes.js";
 import { sidecarRoutes } from "./sidecar.routes.js";
 import { ttsRoutes } from "./tts.routes.js";
+import { promptOverridesRoutes } from "./prompt-overrides.routes.js";
 
 export async function registerRoutes(app: FastifyInstance) {
   await app.register(chatsRoutes, { prefix: "/api/chats" });
@@ -91,6 +92,7 @@ export async function registerRoutes(app: FastifyInstance) {
   await app.register(gameRoutes, { prefix: "/api/game" });
   await app.register(gameAssetsRoutes, { prefix: "/api/game-assets" });
   await app.register(ttsRoutes, { prefix: "/api/tts" });
+  await app.register(promptOverridesRoutes, { prefix: "/api/prompt-overrides" });
   if (process.env.MARINARA_LITE !== "true" && process.env.MARINARA_LITE !== "1") {
     await app.register(sidecarRoutes, { prefix: "/api/sidecar" });
   }

--- a/packages/server/src/routes/prompt-overrides.routes.ts
+++ b/packages/server/src/routes/prompt-overrides.routes.ts
@@ -1,0 +1,115 @@
+// ──────────────────────────────────────────────
+// Routes: Prompt Overrides
+//
+// Lists registered overridable prompts, returns
+// canonical defaults, and accepts user templates
+// validated against each prompt's declared
+// variable schema.
+// ──────────────────────────────────────────────
+import type { FastifyInstance } from "fastify";
+import { z } from "zod";
+import { createPromptOverridesStorage } from "../services/storage/prompt-overrides.storage.js";
+import {
+  PROMPT_OVERRIDE_REGISTRY,
+  getPromptOverrideDef,
+  renderTemplate,
+  validateTemplate,
+} from "../services/prompt-overrides/index.js";
+
+const upsertBodySchema = z.object({
+  template: z.string().min(1, "Template must not be empty"),
+  enabled: z.boolean().optional().default(true),
+});
+
+const previewBodySchema = z.object({
+  template: z.string(),
+  context: z.record(z.union([z.string(), z.number()])).optional(),
+});
+
+export async function promptOverridesRoutes(app: FastifyInstance) {
+  const storage = createPromptOverridesStorage(app.db);
+
+  /** List every registered key with override status. */
+  app.get("/", async () => {
+    const overrides = await storage.list();
+    const overrideByKey = new Map(overrides.map((row) => [row.key, row]));
+    return PROMPT_OVERRIDE_REGISTRY.map((def) => {
+      const row = overrideByKey.get(def.key);
+      return {
+        key: def.key,
+        description: def.description,
+        variables: def.variables,
+        hasOverride: !!row,
+        enabled: row?.enabled ?? false,
+        updatedAt: row?.updatedAt ?? null,
+      };
+    });
+  });
+
+  /** Read the current override (if any) for a single key. */
+  app.get<{ Params: { key: string } }>("/:key", async (req, reply) => {
+    const def = getPromptOverrideDef(req.params.key);
+    if (!def) return reply.status(404).send({ error: "Unknown prompt key" });
+    const row = await storage.get(def.key);
+    return {
+      key: def.key,
+      description: def.description,
+      variables: def.variables,
+      override: row ?? null,
+    };
+  });
+
+  /** Render the canonical default with the registered example context. */
+  app.get<{ Params: { key: string } }>("/:key/default", async (req, reply) => {
+    const def = getPromptOverrideDef(req.params.key);
+    if (!def) return reply.status(404).send({ error: "Unknown prompt key" });
+    return {
+      key: def.key,
+      template: def.defaultBuilder(def.exampleContext),
+      exampleContext: def.exampleContext,
+    };
+  });
+
+  /** Save or replace an override for the given key. */
+  app.put<{ Params: { key: string } }>("/:key", async (req, reply) => {
+    const def = getPromptOverrideDef(req.params.key);
+    if (!def) return reply.status(404).send({ error: "Unknown prompt key" });
+    const input = upsertBodySchema.parse(req.body);
+    const declared = def.variables.map((v) => v.name);
+    const validation = validateTemplate(input.template, declared);
+    if (!validation.valid) {
+      return reply.status(400).send({
+        error: "Template references unknown variables",
+        unknownVariables: validation.unknownVariables,
+        declaredVariables: declared,
+      });
+    }
+    return storage.upsert({ key: def.key, template: input.template, enabled: input.enabled });
+  });
+
+  /** Reset a key by removing its override row. */
+  app.delete<{ Params: { key: string } }>("/:key", async (req, reply) => {
+    const def = getPromptOverrideDef(req.params.key);
+    if (!def) return reply.status(404).send({ error: "Unknown prompt key" });
+    await storage.remove(def.key);
+    return reply.status(204).send();
+  });
+
+  /** Render an arbitrary template with optional caller-supplied context (defaults to example). */
+  app.post<{ Params: { key: string } }>("/:key/preview", async (req, reply) => {
+    const def = getPromptOverrideDef(req.params.key);
+    if (!def) return reply.status(404).send({ error: "Unknown prompt key" });
+    const input = previewBodySchema.parse(req.body);
+    const declared = def.variables.map((v) => v.name);
+    const validation = validateTemplate(input.template, declared);
+    if (!validation.valid) {
+      return reply.status(400).send({
+        error: "Template references unknown variables",
+        unknownVariables: validation.unknownVariables,
+        declaredVariables: declared,
+      });
+    }
+    const ctx = { ...def.exampleContext, ...(input.context ?? {}) };
+    return { rendered: renderTemplate(input.template, ctx, declared) };
+  });
+}

--- a/packages/server/src/routes/sprites.routes.ts
+++ b/packages/server/src/routes/sprites.routes.ts
@@ -56,7 +56,13 @@ async function getSpriteCapabilities() {
 import { generateImage } from "../services/image/image-generation.js";
 import { createConnectionsStorage } from "../services/storage/connections.storage.js";
 import { createPromptOverridesStorage } from "../services/storage/prompt-overrides.storage.js";
-import { loadPrompt, SPRITES_EXPRESSION_SHEET } from "../services/prompt-overrides/index.js";
+import {
+  loadPrompt,
+  SPRITES_EXPRESSION_SHEET,
+  SPRITES_SINGLE_PORTRAIT,
+  SPRITES_SINGLE_FULL_BODY,
+  SPRITES_FULL_BODY_SHEET,
+} from "../services/prompt-overrides/index.js";
 
 const SPRITES_ROOT = join(DATA_DIR, "sprites");
 const ROUTE_DIR = dirname(fileURLToPath(import.meta.url));
@@ -602,50 +608,34 @@ export async function spritesRoutes(app: FastifyInstance) {
     const singleFullBody = body.spriteType === "full-body" && expressions.length === 1 && cols === 1 && rows === 1;
     const generateExpressionsIndividually =
       body.spriteType !== "full-body" && !singlePortrait && isOpenAIGptImageModel(imgModel);
+    const promptOverridesStorage = createPromptOverridesStorage(app.db);
+    const trimmedAppearance = body.appearance?.trim() || "";
     let prompt = "";
     if (singleFullBody) {
-      prompt = [
-        `single full-body character sprite, one character only,`,
-        `entire body visible from head to toe, centered in frame, no cropping,`,
-        `solid white studio background,`,
-        `${body.appearance?.trim() || ""},`,
-        `pose/action: ${expressions[0] ?? "idle"},`,
-        `anime/game sprite style, consistent character design,`,
-        `no grid, no panel borders, no text, no labels, no watermark`,
-      ].join(" ");
+      prompt = await loadPrompt(promptOverridesStorage, SPRITES_SINGLE_FULL_BODY, {
+        appearance: trimmedAppearance,
+        pose: expressions[0] ?? "idle",
+      });
     } else if (body.spriteType === "full-body") {
-      prompt = [
-        `full-body character sprite sheet with EXACTLY ${expressions.length} total pose cells,`,
-        `strict ${cols} columns by ${rows} rows grid, no extra rows, no extra columns, no extra panels,`,
-        `${expressions.length} equally sized tall cells arranged in a perfectly uniform grid,`,
-        `solid white background, thin straight lines separating each cell,`,
-        `same character in every cell, consistent art style and outfit,`,
-        `poses left-to-right top-to-bottom: ${expressionList},`,
-        `${body.appearance?.trim() || ""},`,
-        `each cell shows the entire body from head to toe, centered, no cropping,`,
-        `leave enough whitespace around each full-body pose so feet, hair, weapons, and hands are fully visible,`,
-        `all cells same size, perfectly aligned, no overlapping, no merged cells,`,
-        `the final image must stop after the ${rows} row; do not draw a bonus row or bonus poses,`,
-        `no text, no labels, no numbers`,
-      ].join(" ");
+      prompt = await loadPrompt(promptOverridesStorage, SPRITES_FULL_BODY_SHEET, {
+        cols,
+        rows,
+        poseCount: expressions.length,
+        poseList: expressionList,
+        appearance: trimmedAppearance,
+      });
     } else if (singlePortrait) {
-      prompt = [
-        `single character portrait sprite, one character only,`,
-        `head and shoulders portrait, centered in frame, no cropping,`,
-        `solid white studio background,`,
-        `${body.appearance?.trim() || ""},`,
-        `facial expression: ${expressions[0] ?? "neutral"},`,
-        `anime/game sprite style, consistent character design,`,
-        `no grid, no panel borders, no text, no labels, no watermark`,
-      ].join(" ");
+      prompt = await loadPrompt(promptOverridesStorage, SPRITES_SINGLE_PORTRAIT, {
+        appearance: trimmedAppearance,
+        expression: expressions[0] ?? "neutral",
+      });
     } else {
-      const promptOverridesStorage = createPromptOverridesStorage(app.db);
       prompt = await loadPrompt(promptOverridesStorage, SPRITES_EXPRESSION_SHEET, {
         cols,
         rows,
         expressionCount: expressions.length,
         expressionList,
-        appearance: body.appearance?.trim() || "",
+        appearance: trimmedAppearance,
       });
     }
 
@@ -664,15 +654,10 @@ export async function spritesRoutes(app: FastifyInstance) {
 
         for (const expression of expressions) {
           try {
-            const expressionPrompt = [
-              `single character portrait sprite, one character only,`,
-              `head and shoulders portrait, centered in frame, no cropping,`,
-              `solid white studio background,`,
-              `${body.appearance?.trim() || ""},`,
-              `facial expression: ${expression},`,
-              `anime/game sprite style, consistent character design,`,
-              `no grid, no panel borders, no text, no labels, no watermark`,
-            ].join(" ");
+            const expressionPrompt = await loadPrompt(promptOverridesStorage, SPRITES_SINGLE_PORTRAIT, {
+              appearance: trimmedAppearance,
+              expression,
+            });
 
             const targetSize = 1024;
             const imageResult = await generateImage(imgModel, imgBaseUrl, imgApiKey, imgServiceHint, {

--- a/packages/server/src/routes/sprites.routes.ts
+++ b/packages/server/src/routes/sprites.routes.ts
@@ -55,6 +55,8 @@ async function getSpriteCapabilities() {
 }
 import { generateImage } from "../services/image/image-generation.js";
 import { createConnectionsStorage } from "../services/storage/connections.storage.js";
+import { createPromptOverridesStorage } from "../services/storage/prompt-overrides.storage.js";
+import { loadPrompt, SPRITES_EXPRESSION_SHEET } from "../services/prompt-overrides/index.js";
 
 const SPRITES_ROOT = join(DATA_DIR, "sprites");
 const ROUTE_DIR = dirname(fileURLToPath(import.meta.url));
@@ -637,19 +639,14 @@ export async function spritesRoutes(app: FastifyInstance) {
         `no grid, no panel borders, no text, no labels, no watermark`,
       ].join(" ");
     } else {
-      prompt = [
-        `character expression sheet with EXACTLY ${expressions.length} total portrait cells,`,
-        `strict ${cols} columns by ${rows} rows grid, no extra rows, no extra columns, no extra panels,`,
-        `${expressions.length} equally sized square cells arranged in a perfectly uniform grid,`,
-        `solid white background, thin straight lines separating each cell,`,
-        `same character in every cell, consistent art style,`,
-        `expressions left-to-right top-to-bottom: ${expressionList},`,
-        `${body.appearance?.trim() || ""},`,
-        `each cell shows head and shoulders portrait with a different facial expression,`,
-        `all cells same size, perfectly aligned, no overlapping, no merged cells,`,
-        `the final image must stop after the ${rows} row; do not draw a fourth row or bonus expressions,`,
-        `no text, no labels, no numbers`,
-      ].join(" ");
+      const promptOverridesStorage = createPromptOverridesStorage(app.db);
+      prompt = await loadPrompt(promptOverridesStorage, SPRITES_EXPRESSION_SHEET, {
+        cols,
+        rows,
+        expressionCount: expressions.length,
+        expressionList,
+        appearance: body.appearance?.trim() || "",
+      });
     }
 
     // Parse reference images to raw base64 (supports data URL, raw base64, or local avatar URL)

--- a/packages/server/src/services/game/game-asset-generation.ts
+++ b/packages/server/src/services/game/game-asset-generation.ts
@@ -13,6 +13,13 @@ import { join } from "path";
 import { DATA_DIR } from "../../utils/data-dir.js";
 import { generateImage, type ImageGenRequest } from "../image/image-generation.js";
 import { buildAssetManifest, GAME_ASSETS_DIR } from "./asset-manifest.service.js";
+import type { PromptOverridesStorage } from "../storage/prompt-overrides.storage.js";
+import {
+  loadPrompt,
+  GAME_NPC_PORTRAIT,
+  GAME_BACKGROUND,
+  GAME_SCENE_ILLUSTRATION,
+} from "../prompt-overrides/index.js";
 
 const NPC_AVATAR_DIR = join(DATA_DIR, "avatars", "npc");
 
@@ -57,24 +64,20 @@ function hasExplicitNonHumanCue(value: string): boolean {
   );
 }
 
-function buildNpcPortraitPrompt(req: NpcPortraitRequest): string {
+function npcPortraitVariables(req: NpcPortraitRequest) {
   const context = req.appearance.trim();
   const explicitNonHuman = hasExplicitNonHumanCue(`${req.npcName} ${context}`);
-  return [
-    `NPC portrait for ${req.npcName}.`,
-    context ? `Canonical visual description from the current game: ${context}.` : "",
-    explicitNonHuman
+  return {
+    npcName: req.npcName,
+    appearanceLine: context ? `Canonical visual description from the current game: ${context}.` : "",
+    nonHumanRule: explicitNonHuman
       ? "The description explicitly indicates a non-human subject. Preserve that exact species, body plan, age category, and silhouette; do not turn it into a human or kemonomimi character unless the description says humanoid."
       : "Unless the description explicitly says otherwise, depict this NPC as a human or humanoid person. Do not infer an animal species from the name, mood, speech verbs, or setting.",
-    req.artStyle ? `Art style: ${req.artStyle}.` : "",
-    explicitNonHuman
+    artStyleLine: req.artStyle ? `Art style: ${req.artStyle}.` : "",
+    compositionRule: explicitNonHuman
       ? "Use a centered avatar composition appropriate to the subject, including a creature portrait or full head-and-body crop only when that best preserves the described non-human form."
       : "Use a centered human/humanoid avatar composition: face and shoulders, readable expression, clear outfit cues.",
-    "High quality game avatar, clear readable design, no text, no UI, no watermark.",
-  ]
-    .filter(Boolean)
-    .join(" ")
-    .slice(0, 1400);
+  };
 }
 
 // ── NPC Portrait Generation ──
@@ -92,6 +95,8 @@ export interface NpcPortraitRequest {
   imgApiKey: string;
   imgService?: string | null;
   imgComfyWorkflow?: string | undefined;
+  /** Storage for user-supplied prompt overrides. Optional — falls back to default builder when omitted. */
+  promptOverridesStorage?: PromptOverridesStorage;
 }
 
 /**
@@ -110,7 +115,11 @@ export async function generateNpcPortrait(req: NpcPortraitRequest): Promise<stri
     return `/api/avatars/npc/${req.chatId}/${slug}.png`;
   }
 
-  const prompt = buildNpcPortraitPrompt(req);
+  const vars = npcPortraitVariables(req);
+  const rawPrompt = req.promptOverridesStorage
+    ? await loadPrompt(req.promptOverridesStorage, GAME_NPC_PORTRAIT, vars)
+    : GAME_NPC_PORTRAIT.defaultBuilder(vars);
+  const prompt = rawPrompt.slice(0, 1400);
 
   try {
     const result = await generateImage(
@@ -168,6 +177,8 @@ export interface BackgroundGenRequest {
   imgApiKey: string;
   imgService?: string | null;
   imgComfyWorkflow?: string | undefined;
+  /** Storage for user-supplied prompt overrides. Optional — falls back to default builder when omitted. */
+  promptOverridesStorage?: PromptOverridesStorage;
 }
 
 export interface SceneIllustrationGenRequest {
@@ -187,6 +198,8 @@ export interface SceneIllustrationGenRequest {
   imgApiKey: string;
   imgService?: string | null;
   imgComfyWorkflow?: string | undefined;
+  /** Storage for user-supplied prompt overrides. Optional — falls back to default builder when omitted. */
+  promptOverridesStorage?: PromptOverridesStorage;
 }
 
 /**
@@ -211,11 +224,14 @@ export async function generateBackground(req: BackgroundGenRequest): Promise<str
   }
 
   const styleHint = [req.artStyle, req.genre, req.setting].filter(Boolean).join(", ");
-  const prompt =
-    `${req.sceneDescription}. ${styleHint ? `Style: ${styleHint}.` : ""} Wide-angle landscape, detailed environment, no characters, no text, no UI, game background art, high quality`.slice(
-      0,
-      1000,
-    );
+  const backgroundVars = {
+    sceneDescription: req.sceneDescription,
+    styleLine: styleHint ? `Style: ${styleHint}.` : "",
+  };
+  const rawBackgroundPrompt = req.promptOverridesStorage
+    ? await loadPrompt(req.promptOverridesStorage, GAME_BACKGROUND, backgroundVars)
+    : GAME_BACKGROUND.defaultBuilder(backgroundVars);
+  const prompt = rawBackgroundPrompt.slice(0, 1000);
 
   try {
     const result = await generateImage(
@@ -255,28 +271,22 @@ export async function generateSceneIllustration(req: SceneIllustrationGenRequest
   const tag = `backgrounds:illustrations:${slug}`;
 
   const styleHint = [req.artStyle, req.genre, req.setting].filter(Boolean).join(", ");
-  const characterHint = req.characters?.length ? `Characters: ${req.characters.join(", ")}.` : "";
-  const referenceHint = req.referenceImages?.length
-    ? "Reference handling: attached character reference images are available. Use them to match faces, hair, build, colors, and distinctive features for the referenced characters."
-    : "";
-  const descriptionHint = req.characterDescriptions?.length
-    ? `Appearance notes for visible characters without an attached reference image:\n- ${req.characterDescriptions.join("\n- ")}`
-    : "";
-  const prompt = [
-    "Image type: polished visual novel CG illustration replacing the game background for one important scene.",
-    "Camera / POV: first-person view from the player protagonist's eyes. Do not show the protagonist except hands or arms when the moment explicitly requires them.",
-    `Scene moment: ${req.prompt}`,
-    req.reason ? `Narrative purpose: ${req.reason}.` : "",
-    characterHint,
-    referenceHint,
-    descriptionHint,
-    styleHint ? `Art direction: ${styleHint}.` : "",
-    "Composition: cinematic 16:9 visual novel CG, emotionally specific staging, clear focal point, high-quality finished illustration.",
-    "Avoid: text, UI, captions, speech bubbles, watermarks, and unrelated characters.",
-  ]
-    .filter(Boolean)
-    .join("\n")
-    .slice(0, 2200);
+  const sceneIllustrationVars = {
+    scenePrompt: req.prompt,
+    narrativePurposeLine: req.reason ? `Narrative purpose: ${req.reason}.` : "",
+    charactersLine: req.characters?.length ? `Characters: ${req.characters.join(", ")}.` : "",
+    referenceHandlingLine: req.referenceImages?.length
+      ? "Reference handling: attached character reference images are available. Use them to match faces, hair, build, colors, and distinctive features for the referenced characters."
+      : "",
+    appearanceNotesBlock: req.characterDescriptions?.length
+      ? `Appearance notes for visible characters without an attached reference image:\n- ${req.characterDescriptions.join("\n- ")}`
+      : "",
+    artDirectionLine: styleHint ? `Art direction: ${styleHint}.` : "",
+  };
+  const rawIllustrationPrompt = req.promptOverridesStorage
+    ? await loadPrompt(req.promptOverridesStorage, GAME_SCENE_ILLUSTRATION, sceneIllustrationVars)
+    : GAME_SCENE_ILLUSTRATION.defaultBuilder(sceneIllustrationVars);
+  const prompt = rawIllustrationPrompt.slice(0, 2200);
 
   try {
     const result = await generateImage(

--- a/packages/server/src/services/prompt-overrides/index.ts
+++ b/packages/server/src/services/prompt-overrides/index.ts
@@ -7,7 +7,25 @@ export type { TemplateValidationResult } from "./template.js";
 export {
   PROMPT_OVERRIDE_REGISTRY,
   SPRITES_EXPRESSION_SHEET,
+  SPRITES_SINGLE_PORTRAIT,
+  SPRITES_SINGLE_FULL_BODY,
+  SPRITES_FULL_BODY_SHEET,
+  GAME_NPC_PORTRAIT,
+  GAME_BACKGROUND,
+  GAME_SCENE_ILLUSTRATION,
+  CONVERSATION_SELFIE,
   getPromptOverrideDef,
   listPromptOverrideKeys,
 } from "./registry.js";
-export type { PromptOverrideKeyDef, PromptVariable, SpritesExpressionSheetCtx } from "./registry.js";
+export type {
+  PromptOverrideKeyDef,
+  PromptVariable,
+  SpritesExpressionSheetCtx,
+  SpritesSinglePortraitCtx,
+  SpritesSingleFullBodyCtx,
+  SpritesFullBodySheetCtx,
+  GameNpcPortraitCtx,
+  GameBackgroundCtx,
+  GameSceneIllustrationCtx,
+  ConversationSelfieCtx,
+} from "./registry.js";

--- a/packages/server/src/services/prompt-overrides/index.ts
+++ b/packages/server/src/services/prompt-overrides/index.ts
@@ -1,0 +1,13 @@
+// ──────────────────────────────────────────────
+// Prompt Overrides — Public exports
+// ──────────────────────────────────────────────
+export { loadPrompt } from "./load-prompt.js";
+export { renderTemplate, validateTemplate } from "./template.js";
+export type { TemplateValidationResult } from "./template.js";
+export {
+  PROMPT_OVERRIDE_REGISTRY,
+  SPRITES_EXPRESSION_SHEET,
+  getPromptOverrideDef,
+  listPromptOverrideKeys,
+} from "./registry.js";
+export type { PromptOverrideKeyDef, PromptVariable, SpritesExpressionSheetCtx } from "./registry.js";

--- a/packages/server/src/services/prompt-overrides/load-prompt.ts
+++ b/packages/server/src/services/prompt-overrides/load-prompt.ts
@@ -1,0 +1,31 @@
+// ──────────────────────────────────────────────
+// loadPrompt — registry-aware prompt resolver
+//
+// Looks up a user override; on hit, renders it
+// against the call-site context using the simple
+// ${name} substitution engine. Falls back to the
+// canonical default builder on miss, on disabled,
+// or on any failure (so prompt rendering can
+// never break the surrounding feature).
+// ──────────────────────────────────────────────
+import { logger } from "../../lib/logger.js";
+import type { PromptOverridesStorage } from "../storage/prompt-overrides.storage.js";
+import { renderTemplate } from "./template.js";
+import type { PromptOverrideKeyDef } from "./registry.js";
+
+export async function loadPrompt<TCtx extends Record<string, string | number | undefined>>(
+  storage: PromptOverridesStorage,
+  def: PromptOverrideKeyDef<TCtx>,
+  ctx: TCtx,
+): Promise<string> {
+  try {
+    const row = await storage.get(def.key);
+    if (row && row.enabled) {
+      const declared = def.variables.map((v) => v.name);
+      return renderTemplate(row.template, ctx, declared);
+    }
+  } catch (err) {
+    logger.warn(err, "[prompt-overrides] Failed to load %s, falling back to default", def.key);
+  }
+  return def.defaultBuilder(ctx);
+}

--- a/packages/server/src/services/prompt-overrides/registry.ts
+++ b/packages/server/src/services/prompt-overrides/registry.ts
@@ -1,89 +1,34 @@
 // ──────────────────────────────────────────────
-// Prompt Override Registry
+// Prompt Override Registry — barrel
 //
-// Each entry registers ONE overridable prompt:
-//  - the stable key
-//  - the variables it interpolates (UI hints)
-//  - the canonical default builder
-//  - an example context for previews
-//
-// Adding a key here is half of exposing a prompt;
-// the other half is calling loadPrompt(key, ctx)
-// at the call site.
+// Per-domain entries live in registry/*.ts. This
+// file aggregates them into the lookup table.
 // ──────────────────────────────────────────────
+import type { PromptOverrideKeyDef } from "./types.js";
 
-export interface PromptVariable {
-  name: string;
-  description: string;
-  example?: string;
-}
+import {
+  SPRITES_EXPRESSION_SHEET,
+  SPRITES_SINGLE_PORTRAIT,
+  SPRITES_SINGLE_FULL_BODY,
+  SPRITES_FULL_BODY_SHEET,
+} from "./registry/sprites.js";
+import {
+  GAME_NPC_PORTRAIT,
+  GAME_BACKGROUND,
+  GAME_SCENE_ILLUSTRATION,
+} from "./registry/game-assets.js";
+import { CONVERSATION_SELFIE } from "./registry/conversation.js";
 
-export interface PromptOverrideKeyDef<TCtx extends Record<string, string | number | undefined>> {
-  key: string;
-  description: string;
-  variables: readonly PromptVariable[];
-  /** The hardcoded behavior used when no override exists or when an override fails. */
-  defaultBuilder: (ctx: TCtx) => string;
-  /** Realistic example values used to preview the default text in the UI. */
-  exampleContext: TCtx;
-}
-
-// ── Sprite expression sheet ──
-//
-// The multi-cell ("strict NxM grid") branch of
-// POST /api/sprites/generate-sheet. Other sprite
-// branches (single portrait, full-body sheet,
-// per-expression GPT-Image fallback) remain
-// hardcoded for now and can be registered later.
-
-export interface SpritesExpressionSheetCtx extends Record<string, string | number | undefined> {
-  cols: number;
-  rows: number;
-  expressionCount: number;
-  expressionList: string;
-  appearance: string;
-}
-
-export const SPRITES_EXPRESSION_SHEET: PromptOverrideKeyDef<SpritesExpressionSheetCtx> = {
-  key: "sprites.expressionSheet",
-  description: "Image prompt for the multi-cell character expression sprite sheet.",
-  variables: [
-    { name: "cols", description: "Columns in the grid.", example: "2" },
-    { name: "rows", description: "Rows in the grid.", example: "3" },
-    { name: "expressionCount", description: "Total cells (cols × rows).", example: "6" },
-    {
-      name: "expressionList",
-      description: "Expression labels in left-to-right top-to-bottom order, comma-separated.",
-      example: "neutral, happy, sad, angry, surprised, embarrassed",
-    },
-    { name: "appearance", description: "Character appearance description.", example: "auburn hair, green eyes, leather jacket" },
-  ],
-  defaultBuilder: (ctx) =>
-    [
-      `character expression sheet with EXACTLY ${ctx.expressionCount} total portrait cells,`,
-      `strict ${ctx.cols} columns by ${ctx.rows} rows grid, no extra rows, no extra columns, no extra panels,`,
-      `${ctx.expressionCount} equally sized square cells arranged in a perfectly uniform grid,`,
-      `solid white background, thin straight lines separating each cell,`,
-      `same character in every cell, consistent art style,`,
-      `expressions left-to-right top-to-bottom: ${ctx.expressionList},`,
-      `${ctx.appearance},`,
-      `each cell shows head and shoulders portrait with a different facial expression,`,
-      `all cells same size, perfectly aligned, no overlapping, no merged cells,`,
-      `the final image must stop after the ${ctx.rows} row; do not draw a fourth row or bonus expressions,`,
-      `no text, no labels, no numbers`,
-    ].join(" "),
-  exampleContext: {
-    cols: 2,
-    rows: 3,
-    expressionCount: 6,
-    expressionList: "neutral, happy, sad, angry, surprised, embarrassed",
-    appearance: "auburn hair, green eyes, leather jacket",
-  },
-};
-
-// ── Registry ──
-
-export const PROMPT_OVERRIDE_REGISTRY = [SPRITES_EXPRESSION_SHEET] as const;
+export const PROMPT_OVERRIDE_REGISTRY = [
+  SPRITES_EXPRESSION_SHEET,
+  SPRITES_SINGLE_PORTRAIT,
+  SPRITES_SINGLE_FULL_BODY,
+  SPRITES_FULL_BODY_SHEET,
+  GAME_NPC_PORTRAIT,
+  GAME_BACKGROUND,
+  GAME_SCENE_ILLUSTRATION,
+  CONVERSATION_SELFIE,
+] as const;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyKeyDef = PromptOverrideKeyDef<any>;
@@ -99,3 +44,19 @@ export function getPromptOverrideDef(key: string): AnyKeyDef | undefined {
 export function listPromptOverrideKeys(): string[] {
   return PROMPT_OVERRIDE_REGISTRY.map((def) => def.key);
 }
+
+// Re-export the typed key defs for direct import at call sites.
+export {
+  SPRITES_EXPRESSION_SHEET,
+  SPRITES_SINGLE_PORTRAIT,
+  SPRITES_SINGLE_FULL_BODY,
+  SPRITES_FULL_BODY_SHEET,
+  GAME_NPC_PORTRAIT,
+  GAME_BACKGROUND,
+  GAME_SCENE_ILLUSTRATION,
+  CONVERSATION_SELFIE,
+};
+export type { SpritesExpressionSheetCtx, SpritesSinglePortraitCtx, SpritesSingleFullBodyCtx, SpritesFullBodySheetCtx } from "./registry/sprites.js";
+export type { GameNpcPortraitCtx, GameBackgroundCtx, GameSceneIllustrationCtx } from "./registry/game-assets.js";
+export type { ConversationSelfieCtx } from "./registry/conversation.js";
+export type { PromptOverrideKeyDef, PromptVariable } from "./types.js";

--- a/packages/server/src/services/prompt-overrides/registry.ts
+++ b/packages/server/src/services/prompt-overrides/registry.ts
@@ -1,0 +1,101 @@
+// ──────────────────────────────────────────────
+// Prompt Override Registry
+//
+// Each entry registers ONE overridable prompt:
+//  - the stable key
+//  - the variables it interpolates (UI hints)
+//  - the canonical default builder
+//  - an example context for previews
+//
+// Adding a key here is half of exposing a prompt;
+// the other half is calling loadPrompt(key, ctx)
+// at the call site.
+// ──────────────────────────────────────────────
+
+export interface PromptVariable {
+  name: string;
+  description: string;
+  example?: string;
+}
+
+export interface PromptOverrideKeyDef<TCtx extends Record<string, string | number | undefined>> {
+  key: string;
+  description: string;
+  variables: readonly PromptVariable[];
+  /** The hardcoded behavior used when no override exists or when an override fails. */
+  defaultBuilder: (ctx: TCtx) => string;
+  /** Realistic example values used to preview the default text in the UI. */
+  exampleContext: TCtx;
+}
+
+// ── Sprite expression sheet ──
+//
+// The multi-cell ("strict NxM grid") branch of
+// POST /api/sprites/generate-sheet. Other sprite
+// branches (single portrait, full-body sheet,
+// per-expression GPT-Image fallback) remain
+// hardcoded for now and can be registered later.
+
+export interface SpritesExpressionSheetCtx extends Record<string, string | number | undefined> {
+  cols: number;
+  rows: number;
+  expressionCount: number;
+  expressionList: string;
+  appearance: string;
+}
+
+export const SPRITES_EXPRESSION_SHEET: PromptOverrideKeyDef<SpritesExpressionSheetCtx> = {
+  key: "sprites.expressionSheet",
+  description: "Image prompt for the multi-cell character expression sprite sheet.",
+  variables: [
+    { name: "cols", description: "Columns in the grid.", example: "2" },
+    { name: "rows", description: "Rows in the grid.", example: "3" },
+    { name: "expressionCount", description: "Total cells (cols × rows).", example: "6" },
+    {
+      name: "expressionList",
+      description: "Expression labels in left-to-right top-to-bottom order, comma-separated.",
+      example: "neutral, happy, sad, angry, surprised, embarrassed",
+    },
+    { name: "appearance", description: "Character appearance description.", example: "auburn hair, green eyes, leather jacket" },
+  ],
+  defaultBuilder: (ctx) =>
+    [
+      `character expression sheet with EXACTLY ${ctx.expressionCount} total portrait cells,`,
+      `strict ${ctx.cols} columns by ${ctx.rows} rows grid, no extra rows, no extra columns, no extra panels,`,
+      `${ctx.expressionCount} equally sized square cells arranged in a perfectly uniform grid,`,
+      `solid white background, thin straight lines separating each cell,`,
+      `same character in every cell, consistent art style,`,
+      `expressions left-to-right top-to-bottom: ${ctx.expressionList},`,
+      `${ctx.appearance},`,
+      `each cell shows head and shoulders portrait with a different facial expression,`,
+      `all cells same size, perfectly aligned, no overlapping, no merged cells,`,
+      `the final image must stop after the ${ctx.rows} row; do not draw a fourth row or bonus expressions,`,
+      `no text, no labels, no numbers`,
+    ].join(" "),
+  exampleContext: {
+    cols: 2,
+    rows: 3,
+    expressionCount: 6,
+    expressionList: "neutral, happy, sad, angry, surprised, embarrassed",
+    appearance: "auburn hair, green eyes, leather jacket",
+  },
+};
+
+// ── Registry ──
+
+export const PROMPT_OVERRIDE_REGISTRY = [SPRITES_EXPRESSION_SHEET] as const;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyKeyDef = PromptOverrideKeyDef<any>;
+
+const REGISTRY_BY_KEY: ReadonlyMap<string, AnyKeyDef> = new Map(
+  PROMPT_OVERRIDE_REGISTRY.map((def) => [def.key, def as AnyKeyDef]),
+);
+
+export function getPromptOverrideDef(key: string): AnyKeyDef | undefined {
+  return REGISTRY_BY_KEY.get(key);
+}
+
+export function listPromptOverrideKeys(): string[] {
+  return PROMPT_OVERRIDE_REGISTRY.map((def) => def.key);
+}

--- a/packages/server/src/services/prompt-overrides/registry/conversation.ts
+++ b/packages/server/src/services/prompt-overrides/registry/conversation.ts
@@ -1,0 +1,58 @@
+// ──────────────────────────────────────────────
+// Registered prompt-override keys: conversation-
+// mode features (selfies, etc.)
+// ──────────────────────────────────────────────
+import type { PromptOverrideKeyDef } from "../types.js";
+
+// ── Selfie wrapper ──
+//
+// The text LLM is asked to write the actual image prompt; this is the
+// system prompt that drives that meta-step. The conditional "include
+// these tags" line is pre-computed at the call site.
+
+export interface ConversationSelfieCtx extends Record<string, string | number | undefined> {
+  appearance: string;
+  charName: string;
+  /**
+   * Either an empty string (when the chat has no selfie tags) or
+   * a leading-newline-prefixed line, e.g.
+   * "\nAlways include these tags/modifiers in the prompt: masterpiece, best quality"
+   */
+  selfieTagsBlock: string;
+}
+
+export const CONVERSATION_SELFIE: PromptOverrideKeyDef<ConversationSelfieCtx> = {
+  key: "conversation.selfie",
+  description: "Meta-prompt that asks the chat LLM to write a selfie image prompt for the active character.",
+  variables: [
+    { name: "appearance", description: "Character appearance text.", example: "auburn hair, green eyes, leather jacket, mid-twenties, athletic build" },
+    { name: "charName", description: "Character display name.", example: "Lyra" },
+    {
+      name: "selfieTagsBlock",
+      description:
+        "Pre-formatted block listing chat-level selfie tags. Empty when none, otherwise begins with two newlines to preserve the blank line above.",
+      example: "\n\nAlways include these tags/modifiers in the prompt: masterpiece, best quality, sharp focus",
+    },
+  ],
+  defaultBuilder: (ctx) =>
+    [
+      `You are an image prompt generator. Create a concise, detailed image generation prompt for a selfie photo.`,
+      `The character's appearance: ${ctx.appearance}`,
+      `Character name: ${ctx.charName}`,
+      ``,
+      `Generate a prompt that describes a selfie photo of this character. Include:`,
+      `- Physical appearance details (face, hair, eyes, skin)`,
+      `- What they're wearing`,
+      `- Expression and pose (selfie angle)`,
+      `- Setting/background from context`,
+      `- Lighting and mood`,
+      ``,
+      `Infer the appropriate art style from the character. For example, anime/game characters should use anime/illustration style, realistic characters should use photorealistic style. Match the style to the character's origin.${ctx.selfieTagsBlock}`,
+      `Output ONLY the prompt text, nothing else.`,
+    ].join("\n"),
+  exampleContext: {
+    appearance: "auburn hair, green eyes, leather jacket, mid-twenties, athletic build",
+    charName: "Lyra",
+    selfieTagsBlock: "\n\nAlways include these tags/modifiers in the prompt: masterpiece, best quality, sharp focus",
+  },
+};

--- a/packages/server/src/services/prompt-overrides/registry/game-assets.ts
+++ b/packages/server/src/services/prompt-overrides/registry/game-assets.ts
@@ -1,0 +1,148 @@
+// ──────────────────────────────────────────────
+// Registered prompt-override keys: game-mode
+// asset generation (NPC portraits, location
+// backgrounds, VN scene illustrations).
+// ──────────────────────────────────────────────
+import type { PromptOverrideKeyDef } from "../types.js";
+
+// ── NPC portrait ──
+//
+// The original builder has three small conditionals (whether the
+// description is non-empty, whether the subject is non-human, whether
+// art style is set). Conditional logic stays at the call site, which
+// pre-computes the lines and passes them as variables. The default
+// builder concatenates lines and drops empty ones via filter(Boolean).
+
+export interface GameNpcPortraitCtx extends Record<string, string | number | undefined> {
+  npcName: string;
+  appearanceLine: string;
+  nonHumanRule: string;
+  artStyleLine: string;
+  compositionRule: string;
+}
+
+export const GAME_NPC_PORTRAIT: PromptOverrideKeyDef<GameNpcPortraitCtx> = {
+  key: "game.npcPortrait",
+  description: "NPC portrait image prompt (in-game, when an NPC is introduced or recruited).",
+  variables: [
+    { name: "npcName", description: "Display name of the NPC.", example: "Lyra" },
+    {
+      name: "appearanceLine",
+      description: "Pre-formatted appearance line, or empty string when no description exists.",
+      example: "Canonical visual description from the current game: auburn hair, green eyes, leather jacket.",
+    },
+    {
+      name: "nonHumanRule",
+      description: "Pre-computed line guarding human vs non-human depiction (one of two strings).",
+      example: "Unless the description explicitly says otherwise, depict this NPC as a human or humanoid person. Do not infer an animal species from the name, mood, speech verbs, or setting.",
+    },
+    {
+      name: "artStyleLine",
+      description: "Pre-formatted art style line, or empty string when the game has no art style set.",
+      example: "Art style: Watercolor fantasy illustration, soft edges, warm palette, Ghibli-inspired.",
+    },
+    {
+      name: "compositionRule",
+      description: "Pre-computed composition instruction (humanoid avatar vs creature portrait).",
+      example: "Use a centered human/humanoid avatar composition: face and shoulders, readable expression, clear outfit cues.",
+    },
+  ],
+  defaultBuilder: (ctx) =>
+    [
+      `NPC portrait for ${ctx.npcName}.`,
+      ctx.appearanceLine,
+      ctx.nonHumanRule,
+      ctx.artStyleLine,
+      ctx.compositionRule,
+      `High quality game avatar, clear readable design, no text, no UI, no watermark.`,
+    ]
+      .filter(Boolean)
+      .join(" "),
+  exampleContext: {
+    npcName: "Lyra",
+    appearanceLine: "Canonical visual description from the current game: auburn hair, green eyes, leather jacket.",
+    nonHumanRule:
+      "Unless the description explicitly says otherwise, depict this NPC as a human or humanoid person. Do not infer an animal species from the name, mood, speech verbs, or setting.",
+    artStyleLine: "Art style: Watercolor fantasy illustration, soft edges, warm palette, Ghibli-inspired.",
+    compositionRule:
+      "Use a centered human/humanoid avatar composition: face and shoulders, readable expression, clear outfit cues.",
+  },
+};
+
+// ── Location background ──
+
+export interface GameBackgroundCtx extends Record<string, string | number | undefined> {
+  sceneDescription: string;
+  styleLine: string;
+}
+
+export const GAME_BACKGROUND: PromptOverrideKeyDef<GameBackgroundCtx> = {
+  key: "game.background",
+  description: "Location background image prompt (in-game, on first visit to a new place).",
+  variables: [
+    { name: "sceneDescription", description: "GM/scene-analyzer description of the location.", example: "moonlit graveyard with crumbling tombstones" },
+    {
+      name: "styleLine",
+      description: "Pre-formatted style line (artStyle + genre + setting), or empty string when nothing is set.",
+      example: "Style: Watercolor fantasy illustration, soft edges, warm palette, Ghibli-inspired, fantasy, medieval kingdom.",
+    },
+  ],
+  defaultBuilder: (ctx) =>
+    `${ctx.sceneDescription}. ${ctx.styleLine} Wide-angle landscape, detailed environment, no characters, no text, no UI, game background art, high quality`,
+  exampleContext: {
+    sceneDescription: "moonlit graveyard with crumbling tombstones",
+    styleLine: "Style: Watercolor fantasy illustration, soft edges, warm palette, Ghibli-inspired, fantasy, medieval kingdom.",
+  },
+};
+
+// ── Scene illustration (VN POV CG) ──
+//
+// Most lines are conditional on whether characters/references/art-style
+// were provided. Pre-computed at the call site, joined with newlines,
+// empty lines dropped.
+
+export interface GameSceneIllustrationCtx extends Record<string, string | number | undefined> {
+  scenePrompt: string;
+  narrativePurposeLine: string;
+  charactersLine: string;
+  referenceHandlingLine: string;
+  appearanceNotesBlock: string;
+  artDirectionLine: string;
+}
+
+export const GAME_SCENE_ILLUSTRATION: PromptOverrideKeyDef<GameSceneIllustrationCtx> = {
+  key: "game.sceneIllustration",
+  description: "VN-style first-person POV CG illustration prompt (rare, story-defining moments only).",
+  variables: [
+    { name: "scenePrompt", description: "The exact illustrated moment, written by the scene-analyzer.", example: "the moonlit duel finally ends — Korr falls to one knee, sword in the dirt" },
+    { name: "narrativePurposeLine", description: "Pre-formatted narrative reason line, or empty string.", example: "Narrative purpose: duel climax — major story beat." },
+    { name: "charactersLine", description: "Pre-formatted visible-characters line, or empty string.", example: "Characters: Lyra, Korr." },
+    { name: "referenceHandlingLine", description: "Pre-formatted reference-image instruction, or empty string when no references attached.", example: "Reference handling: attached character reference images are available. Use them to match faces, hair, build, colors, and distinctive features for the referenced characters." },
+    { name: "appearanceNotesBlock", description: "Pre-formatted appearance notes for visible characters without a reference, or empty string.", example: "Appearance notes for visible characters without an attached reference image:\n- Lyra: auburn hair, green eyes, leather jacket" },
+    { name: "artDirectionLine", description: "Pre-formatted art direction line, or empty string.", example: "Art direction: Watercolor fantasy illustration, soft edges, warm palette, Ghibli-inspired, fantasy, medieval kingdom." },
+  ],
+  defaultBuilder: (ctx) =>
+    [
+      "Image type: polished visual novel CG illustration replacing the game background for one important scene.",
+      "Camera / POV: first-person view from the player protagonist's eyes. Do not show the protagonist except hands or arms when the moment explicitly requires them.",
+      `Scene moment: ${ctx.scenePrompt}`,
+      ctx.narrativePurposeLine,
+      ctx.charactersLine,
+      ctx.referenceHandlingLine,
+      ctx.appearanceNotesBlock,
+      ctx.artDirectionLine,
+      "Composition: cinematic 16:9 visual novel CG, emotionally specific staging, clear focal point, high-quality finished illustration.",
+      "Avoid: text, UI, captions, speech bubbles, watermarks, and unrelated characters.",
+    ]
+      .filter(Boolean)
+      .join("\n"),
+  exampleContext: {
+    scenePrompt: "the moonlit duel finally ends — Korr falls to one knee, sword in the dirt",
+    narrativePurposeLine: "Narrative purpose: duel climax — major story beat.",
+    charactersLine: "Characters: Lyra, Korr.",
+    referenceHandlingLine:
+      "Reference handling: attached character reference images are available. Use them to match faces, hair, build, colors, and distinctive features for the referenced characters.",
+    appearanceNotesBlock: "Appearance notes for visible characters without an attached reference image:\n- Lyra: auburn hair, green eyes, leather jacket",
+    artDirectionLine: "Art direction: Watercolor fantasy illustration, soft edges, warm palette, Ghibli-inspired, fantasy, medieval kingdom.",
+  },
+};

--- a/packages/server/src/services/prompt-overrides/registry/sprites.ts
+++ b/packages/server/src/services/prompt-overrides/registry/sprites.ts
@@ -1,0 +1,164 @@
+// ──────────────────────────────────────────────
+// Registered prompt-override keys: sprite generation
+//
+// Sprite-sheet generation is a 4-way switch in
+// sprites.routes.ts. Each branch is its own
+// override key so users can customise them
+// independently.
+// ──────────────────────────────────────────────
+import type { PromptOverrideKeyDef } from "../types.js";
+
+// ── Multi-cell expression sheet ──
+
+export interface SpritesExpressionSheetCtx extends Record<string, string | number | undefined> {
+  cols: number;
+  rows: number;
+  expressionCount: number;
+  expressionList: string;
+  appearance: string;
+}
+
+export const SPRITES_EXPRESSION_SHEET: PromptOverrideKeyDef<SpritesExpressionSheetCtx> = {
+  key: "sprites.expressionSheet",
+  description: "Multi-cell character expression sprite sheet (the default sprite-generation flow).",
+  variables: [
+    { name: "cols", description: "Columns in the grid.", example: "2" },
+    { name: "rows", description: "Rows in the grid.", example: "3" },
+    { name: "expressionCount", description: "Total cells (cols × rows).", example: "6" },
+    {
+      name: "expressionList",
+      description: "Expression labels in left-to-right top-to-bottom order, comma-separated.",
+      example: "neutral, happy, sad, angry, surprised, embarrassed",
+    },
+    { name: "appearance", description: "Character appearance description.", example: "auburn hair, green eyes, leather jacket" },
+  ],
+  defaultBuilder: (ctx) =>
+    [
+      `character expression sheet with EXACTLY ${ctx.expressionCount} total portrait cells,`,
+      `strict ${ctx.cols} columns by ${ctx.rows} rows grid, no extra rows, no extra columns, no extra panels,`,
+      `${ctx.expressionCount} equally sized square cells arranged in a perfectly uniform grid,`,
+      `solid white background, thin straight lines separating each cell,`,
+      `same character in every cell, consistent art style,`,
+      `expressions left-to-right top-to-bottom: ${ctx.expressionList},`,
+      `${ctx.appearance},`,
+      `each cell shows head and shoulders portrait with a different facial expression,`,
+      `all cells same size, perfectly aligned, no overlapping, no merged cells,`,
+      `the final image must stop after the ${ctx.rows} row; do not draw a fourth row or bonus expressions,`,
+      `no text, no labels, no numbers`,
+    ].join(" "),
+  exampleContext: {
+    cols: 2,
+    rows: 3,
+    expressionCount: 6,
+    expressionList: "neutral, happy, sad, angry, surprised, embarrassed",
+    appearance: "auburn hair, green eyes, leather jacket",
+  },
+};
+
+// ── Single portrait (1×1, head & shoulders) ──
+//
+// Used both for explicit 1×1 portrait requests and as the GPT-Image
+// fallback path that generates expressions one at a time. Same prompt
+// shape, same variables — one key serves both call sites.
+
+export interface SpritesSinglePortraitCtx extends Record<string, string | number | undefined> {
+  appearance: string;
+  expression: string;
+}
+
+export const SPRITES_SINGLE_PORTRAIT: PromptOverrideKeyDef<SpritesSinglePortraitCtx> = {
+  key: "sprites.singlePortrait",
+  description: "Single head-and-shoulders portrait sprite (1×1, also used per-expression for GPT-Image models).",
+  variables: [
+    { name: "appearance", description: "Character appearance description.", example: "auburn hair, green eyes, leather jacket" },
+    { name: "expression", description: "Facial expression for this single image.", example: "neutral" },
+  ],
+  defaultBuilder: (ctx) =>
+    [
+      `single character portrait sprite, one character only,`,
+      `head and shoulders portrait, centered in frame, no cropping,`,
+      `solid white studio background,`,
+      `${ctx.appearance},`,
+      `facial expression: ${ctx.expression},`,
+      `anime/game sprite style, consistent character design,`,
+      `no grid, no panel borders, no text, no labels, no watermark`,
+    ].join(" "),
+  exampleContext: {
+    appearance: "auburn hair, green eyes, leather jacket",
+    expression: "neutral",
+  },
+};
+
+// ── Single full-body sprite (1×1) ──
+
+export interface SpritesSingleFullBodyCtx extends Record<string, string | number | undefined> {
+  appearance: string;
+  pose: string;
+}
+
+export const SPRITES_SINGLE_FULL_BODY: PromptOverrideKeyDef<SpritesSingleFullBodyCtx> = {
+  key: "sprites.singleFullBody",
+  description: "Single full-body character sprite, one pose.",
+  variables: [
+    { name: "appearance", description: "Character appearance description.", example: "auburn hair, green eyes, leather jacket" },
+    { name: "pose", description: "Pose or action for this image.", example: "idle" },
+  ],
+  defaultBuilder: (ctx) =>
+    [
+      `single full-body character sprite, one character only,`,
+      `entire body visible from head to toe, centered in frame, no cropping,`,
+      `solid white studio background,`,
+      `${ctx.appearance},`,
+      `pose/action: ${ctx.pose},`,
+      `anime/game sprite style, consistent character design,`,
+      `no grid, no panel borders, no text, no labels, no watermark`,
+    ].join(" "),
+  exampleContext: {
+    appearance: "auburn hair, green eyes, leather jacket",
+    pose: "idle",
+  },
+};
+
+// ── Multi-cell full-body pose sheet ──
+
+export interface SpritesFullBodySheetCtx extends Record<string, string | number | undefined> {
+  cols: number;
+  rows: number;
+  poseCount: number;
+  poseList: string;
+  appearance: string;
+}
+
+export const SPRITES_FULL_BODY_SHEET: PromptOverrideKeyDef<SpritesFullBodySheetCtx> = {
+  key: "sprites.fullBodySheet",
+  description: "Multi-cell full-body pose sprite sheet (e.g. idle, walk, run, attack).",
+  variables: [
+    { name: "cols", description: "Columns in the grid.", example: "2" },
+    { name: "rows", description: "Rows in the grid.", example: "3" },
+    { name: "poseCount", description: "Total cells (cols × rows).", example: "6" },
+    { name: "poseList", description: "Pose labels in left-to-right top-to-bottom order.", example: "idle, walking, running, attacking, defending, casting" },
+    { name: "appearance", description: "Character appearance description.", example: "auburn hair, green eyes, leather jacket" },
+  ],
+  defaultBuilder: (ctx) =>
+    [
+      `full-body character sprite sheet with EXACTLY ${ctx.poseCount} total pose cells,`,
+      `strict ${ctx.cols} columns by ${ctx.rows} rows grid, no extra rows, no extra columns, no extra panels,`,
+      `${ctx.poseCount} equally sized tall cells arranged in a perfectly uniform grid,`,
+      `solid white background, thin straight lines separating each cell,`,
+      `same character in every cell, consistent art style and outfit,`,
+      `poses left-to-right top-to-bottom: ${ctx.poseList},`,
+      `${ctx.appearance},`,
+      `each cell shows the entire body from head to toe, centered, no cropping,`,
+      `leave enough whitespace around each full-body pose so feet, hair, weapons, and hands are fully visible,`,
+      `all cells same size, perfectly aligned, no overlapping, no merged cells,`,
+      `the final image must stop after the ${ctx.rows} row; do not draw a bonus row or bonus poses,`,
+      `no text, no labels, no numbers`,
+    ].join(" "),
+  exampleContext: {
+    cols: 2,
+    rows: 3,
+    poseCount: 6,
+    poseList: "idle, walking, running, attacking, defending, casting",
+    appearance: "auburn hair, green eyes, leather jacket",
+  },
+};

--- a/packages/server/src/services/prompt-overrides/template.ts
+++ b/packages/server/src/services/prompt-overrides/template.ts
@@ -1,0 +1,51 @@
+// ──────────────────────────────────────────────
+// Prompt Override Template Engine
+//
+// Simple ${name} substitution against a strict
+// variable allowlist. Distinct from the chat
+// macro engine ({{user}}, {{char}}, …) — different
+// domain, different surface.
+// ──────────────────────────────────────────────
+
+const VARIABLE_PATTERN = /\$\{([a-zA-Z_][a-zA-Z0-9_]*)\}/g;
+
+export interface TemplateValidationResult {
+  valid: boolean;
+  unknownVariables: string[];
+}
+
+/**
+ * Check that a template only references variables in the declared list.
+ * Returns the unknown variables found (if any).
+ */
+export function validateTemplate(template: string, declared: readonly string[]): TemplateValidationResult {
+  const allowed = new Set(declared);
+  const seen = new Set<string>();
+  const unknown: string[] = [];
+  for (const match of template.matchAll(VARIABLE_PATTERN)) {
+    const name = match[1];
+    if (!name || seen.has(name)) continue;
+    seen.add(name);
+    if (!allowed.has(name)) unknown.push(name);
+  }
+  return { valid: unknown.length === 0, unknownVariables: unknown };
+}
+
+/**
+ * Substitute ${name} occurrences with the matching value from `vars`.
+ * Variables outside the declared allowlist are left intact (safer than
+ * throwing — production rendering should never crash on a stale template).
+ * Validation is the responsibility of the write path (PUT route).
+ */
+export function renderTemplate(
+  template: string,
+  vars: Record<string, string | number | undefined>,
+  declared: readonly string[],
+): string {
+  const allowed = new Set(declared);
+  return template.replace(VARIABLE_PATTERN, (raw, name: string) => {
+    if (!allowed.has(name)) return raw;
+    const value = vars[name];
+    return value === undefined || value === null ? "" : String(value);
+  });
+}

--- a/packages/server/src/services/prompt-overrides/types.ts
+++ b/packages/server/src/services/prompt-overrides/types.ts
@@ -1,0 +1,21 @@
+// ──────────────────────────────────────────────
+// Public types for the prompt-overrides registry.
+// Kept in a small file so per-domain registry
+// modules can import without circular deps.
+// ──────────────────────────────────────────────
+
+export interface PromptVariable {
+  name: string;
+  description: string;
+  example?: string;
+}
+
+export interface PromptOverrideKeyDef<TCtx extends Record<string, string | number | undefined>> {
+  key: string;
+  description: string;
+  variables: readonly PromptVariable[];
+  /** The hardcoded behavior used when no override exists or when an override fails. */
+  defaultBuilder: (ctx: TCtx) => string;
+  /** Realistic example values used to preview the default text in the UI. */
+  exampleContext: TCtx;
+}

--- a/packages/server/src/services/storage/prompt-overrides.storage.ts
+++ b/packages/server/src/services/storage/prompt-overrides.storage.ts
@@ -1,0 +1,66 @@
+// ──────────────────────────────────────────────
+// Storage: Prompt Overrides
+// ──────────────────────────────────────────────
+import { eq } from "drizzle-orm";
+import type { DB } from "../../db/connection.js";
+import { promptOverrides } from "../../db/schema/index.js";
+import { now } from "../../utils/id-generator.js";
+
+export interface PromptOverrideRow {
+  key: string;
+  template: string;
+  enabled: boolean;
+  updatedAt: string;
+}
+
+export function createPromptOverridesStorage(db: DB) {
+  return {
+    async get(key: string): Promise<PromptOverrideRow | null> {
+      const rows = await db.select().from(promptOverrides).where(eq(promptOverrides.key, key));
+      const row = rows[0];
+      if (!row) return null;
+      return {
+        key: row.key,
+        template: row.template,
+        enabled: row.enabled === 1,
+        updatedAt: row.updatedAt,
+      };
+    },
+
+    async list(): Promise<PromptOverrideRow[]> {
+      const rows = await db.select().from(promptOverrides);
+      return rows.map((row) => ({
+        key: row.key,
+        template: row.template,
+        enabled: row.enabled === 1,
+        updatedAt: row.updatedAt,
+      }));
+    },
+
+    async upsert(input: { key: string; template: string; enabled: boolean }): Promise<PromptOverrideRow> {
+      const timestamp = now();
+      const enabledFlag = input.enabled ? 1 : 0;
+      const existing = await db.select().from(promptOverrides).where(eq(promptOverrides.key, input.key));
+      if (existing.length > 0) {
+        await db
+          .update(promptOverrides)
+          .set({ template: input.template, enabled: enabledFlag, updatedAt: timestamp })
+          .where(eq(promptOverrides.key, input.key));
+      } else {
+        await db.insert(promptOverrides).values({
+          key: input.key,
+          template: input.template,
+          enabled: enabledFlag,
+          updatedAt: timestamp,
+        });
+      }
+      return { key: input.key, template: input.template, enabled: input.enabled, updatedAt: timestamp };
+    },
+
+    async remove(key: string): Promise<void> {
+      await db.delete(promptOverrides).where(eq(promptOverrides.key, key));
+    },
+  };
+}
+
+export type PromptOverridesStorage = ReturnType<typeof createPromptOverridesStorage>;


### PR DESCRIPTION
## Linked issue

Closes #329

## Why this change

The image-generation prompts (sprite sheets, NPC portraits, scene CGs, the
selfie meta-prompt, location backgrounds) are currently hardcoded TS strings
inside route handlers and asset-generation services. Users have no way to tune
them without forking the source.

This is observably user-facing. The multi-cell sprite-sheet prompt in
particular dedicates most of its budget to grid bookkeeping (`EXACTLY N
cells`, `strict NxM grid`, `no extra rows`, `no merged cells`) and a
hardcoded "solid white studio background", which on many image models steers
the result toward a flat, low-contrast aesthetic. The prompt has no field
where users can inject style or quality keywords — the character's
`appearance` field is the only lever, and it is already crowded with physical
descriptors. (Sprite generation runs from the character editor outside any
game session, so it deliberately has no concept of a game-level art style —
this is a separate gap from in-game asset coherence.)

This PR introduces a generic registry that lets user-supplied templates
replace each registered prompt builder, with default behavior unchanged at
every call site.

## What changed

**New `prompt_overrides` table.** Idempotent CREATE in `runMigrations()`; no
separate `pnpm db:push` needed.

**New `services/prompt-overrides/` module:**

- Registry: each entry declares its key, the variables it interpolates
  (`${name}` markers), a canonical default builder, and a realistic example
  context used for previews.
- Template engine: simple `${name}` substitution, deliberately limited to
  flat variable expansion (no conditionals — see "Not included" below).
- `loadPrompt(storage, def, ctx)` helper: returns the user's rendered
  template if present and enabled, otherwise the canonical default. Falls
  back to the default on any error so prompt rendering can never break the
  surrounding feature.

**New `/api/prompt-overrides` routes:**

| Method | Path                  | Description                                           |
| ------ | --------------------- | ----------------------------------------------------- |
| GET    | `/`                   | List registered keys + override status + var schemas  |
| GET    | `/:key`               | Current override for a key                            |
| GET    | `/:key/default`       | Canonical default rendered with example context       |
| PUT    | `/:key`               | Save `{ template, enabled }` — validates `${vars}`    |
| DELETE | `/:key`               | Remove override row (revert to default)               |
| POST   | `/:key/preview`       | Render an arbitrary template with the example context |

PUT and `/preview` reject templates that reference variables not declared by
the registered key (HTTP 400 with `unknownVariables` and `declaredVariables`
in the body).

**Eight prompts registered and converted:**

| Key                       | Replaces                                                   |
| ------------------------- | ---------------------------------------------------------- |
| `sprites.expressionSheet` | Multi-cell expression sheet (`sprites.routes.ts`)          |
| `sprites.singlePortrait`  | Single head/shoulders sprite + GPT-Image fallback per-expr |
| `sprites.singleFullBody`  | Single full-body sprite                                    |
| `sprites.fullBodySheet`   | Multi-cell full-body pose sheet                            |
| `game.npcPortrait`        | `buildNpcPortraitPrompt` in `game-asset-generation.ts`     |
| `game.background`         | Background prompt in `generateBackground`                  |
| `game.sceneIllustration`  | VN POV CG prompt in `generateSceneIllustration`            |
| `conversation.selfie`     | Selfie meta-prompt in `generate.routes.ts`                 |

Default behavior at every call site is byte-for-byte identical.

Conditional logic (e.g. "include this line only when X is non-empty", "use
this rule for non-human NPCs", "add the blank line before the tags block")
stays in TypeScript at the call site; the result is exposed as a pre-computed
string variable (`appearanceLine`, `nonHumanRule`, `selfieTagsBlock`, etc.)
that the user can rearrange in their template but cannot re-conditionalize.
This keeps the engine free of conditional constructs.

**Not included by design.**

- Complex prompts with conditional sections (`gm.systemPrompt`,
  `gm.formatReminder`, `scene.analyzerSystem`, party agent, session recap,
  etc.) are deliberately out of scope. The flat `${var}` engine cannot
  represent ~15 conditional blocks per prompt without re-implementing parts
  of Mustache. Either splitting each into sub-prompts or extending the
  engine with a minimal `{{#if name}}…{{/if}}` construct is a separate
  design decision worth its own PR.
- No UI. The API is consumable from any client; a userscript-style
  extension can add an in-app editor without core changes.

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

This PR is server-only — no UI surface yet. A human reviewer should manually
verify:

- **Migration runs cleanly on an existing database.** Boot the server
  against an existing `marinara-engine.db`; confirm the `prompt_overrides`
  table is created without touching other tables (e.g.
  `sqlite3 packages/server/data/marinara-engine.db ".schema prompt_overrides"`).
- **Migration is idempotent.** Restart the server multiple times; confirm
  no errors and table state stays consistent.
- **Default sprite-sheet behavior is unchanged.** With no overrides set,
  generate a 2×3 sprite expression sheet for a character. The image and the
  prompt sent to the image model should be the same as before this PR. With
  `LOG_LEVEL=debug` you can see the prompt in the server log.
- **Default NPC portrait / scene CG / background are unchanged.** Same
  check in Game Mode with image generation enabled.
- **Default selfie is unchanged.** In Conversation mode, trigger a selfie.
  The meta-prompt sent to the chat LLM should look the same as before.
- **Override path actually overrides.**
  ```bash
  curl -X PUT http://localhost:7860/api/prompt-overrides/sprites.expressionSheet \
    -H 'Content-Type: application/json' \
    -d '{"template":"NEW STYLE: ${expressionCount} cells of ${appearance}","enabled":true}'
  ```
  Then generate a sprite sheet — the model should receive the new prompt
  (verify with `LOG_LEVEL=debug`).
- **Validation rejects unknown variables.** Same PUT with `${doesNotExist}`
  should return HTTP 400 with `unknownVariables: ["doesNotExist"]`.
- **DELETE reverts to default.** After overriding, `DELETE /:key` and
  re-generate; behavior matches default again.

## Docs and release impact

- [x] No docs changes needed
- [x] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [x] Version/release files updated (only if this PR includes a version bump)

A `CHANGELOG.md` entry could be added — leaving that to maintainer
preference. The feature is undocumented in `docs/` because it has no in-app
surface in this PR; a follow-up PR (or a community extension) can add
user-facing docs once the API is stable.

## UI evidence (if applicable)

N/A — server-only. Routes are exercisable via curl; sample requests are in
the **Manual verification notes** above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a prompt override system allowing users to customize templates for asset generation (sprites, backgrounds, portraits, and scenes).
  * New API endpoints to manage, preview, and validate custom prompts.
  * Template system with variable substitution and validation to ensure correct template usage.

* **Chores**
  * Updated database schema and internal asset generation services to support custom prompt overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->