### PR TITLE
feat(chat): clickable character status with group chat support

### DIFF
--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -216,6 +216,7 @@ export function ChatArea() {
           avatarCrop: parsed.extensions?.avatarCrop || null,
           conversationStatus: parsed.extensions?.conversationStatus || undefined,
           conversationActivity: parsed.extensions?.conversationActivity || undefined,
+          extensions: parsed.extensions ?? {},
         });
       } catch {
         map.set(char.id, { name: "Unknown", avatarUrl: null });

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -2044,6 +2044,7 @@ export function ChatSettingsDrawer({
           {/* Autonomous Messaging — conversation mode only */}
           {isConversation && (
             <Section
+              id="autonomous-messaging"
               label="Autonomous Messaging"
               icon={<Bot size="0.875rem" />}
               help="Characters can message you unprompted based on their personality and schedule. Chatty characters will reach out sooner when you're inactive."
@@ -4250,18 +4251,20 @@ function Section({
   icon,
   count,
   help,
+  id,
   children,
 }: {
   label: string;
   icon?: React.ReactNode;
   count?: number;
   help?: string;
+  id?: string;
   children: React.ReactNode;
 }) {
   const [open, setOpen] = useState(false);
 
   return (
-    <div className="border-b border-[var(--border)]">
+    <div id={id} className="border-b border-[var(--border)]">
       <button
         onClick={() => setOpen((o) => !o)}
         className="flex w-full items-center gap-2 px-4 py-3 text-left transition-colors hover:bg-[var(--accent)]/50"

--- a/packages/client/src/components/chat/ConversationView.tsx
+++ b/packages/client/src/components/chat/ConversationView.tsx
@@ -3,7 +3,7 @@
 // ──────────────────────────────────────────────
 import { Suspense, lazy, useRef, useEffect, useLayoutEffect, useCallback, useMemo, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import { Loader2, ChevronUp, Settings2, FolderOpen, Image as ImageIcon, ArrowRightLeft } from "lucide-react";
+import { Loader2, ChevronUp, Settings2, FolderOpen, Image as ImageIcon, ArrowRightLeft, Save, CalendarClock, X } from "lucide-react";
 import { ConversationMessage } from "./ConversationMessage";
 import { ConversationInput } from "./ConversationInput";
 import { SceneBanner, EndSceneBar } from "./SceneBanner";
@@ -12,7 +12,8 @@ import { useChatStore } from "../../stores/chat.store";
 import { useUIStore } from "../../stores/ui.store";
 import { playNotificationPing } from "../../lib/notification-sound";
 import { getAvatarCropStyle } from "../../lib/utils";
-import { characterKeys } from "../../hooks/use-characters";
+import { characterKeys, useUpdateCharacter } from "../../hooks/use-characters";
+import { useGenerate } from "../../hooks/use-generate";
 import { api } from "../../lib/api-client";
 import type { CharacterMap, MessageSelectionToggle, PersonaInfo } from "./chat-area.types";
 import type { Message } from "@marinara-engine/shared";
@@ -144,6 +145,14 @@ export function ConversationView({
   onAbandonScene,
 }: ConversationViewProps) {
   const qc = useQueryClient();
+  const updateCharacter = useUpdateCharacter();
+  const { generate } = useGenerate();
+  const [editingCharId, setEditingCharId] = useState<string | null>(null);
+  const [editStatus, setEditStatus] = useState<"online" | "idle" | "dnd" | "offline">("online");
+  const [editActivity, setEditActivity] = useState("");
+  const [isSavingStatus, setIsSavingStatus] = useState(false);
+  const statusPopoverRef = useRef<HTMLDivElement>(null);
+
   const streamingChatId = useChatStore((s) => s.streamingChatId);
   const isStreaming = useChatStore((s) => s.isStreaming) && streamingChatId === chatId;
   const streamBuffer = useChatStore((s) => s.streamBuffer);
@@ -169,6 +178,18 @@ export function ConversationView({
     const timer = setInterval(refreshStatus, 60_000);
     return () => clearInterval(timer);
   }, [chatId, qc]);
+
+  // Close status popover on outside click
+  useEffect(() => {
+    if (!editingCharId) return;
+    const handler = (e: MouseEvent) => {
+      if (statusPopoverRef.current && !statusPopoverRef.current.contains(e.target as Node)) {
+        setEditingCharId(null);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [editingCharId]);
 
   // Global conversation gradient from settings
   const theme = useUIStore((s) => s.theme);
@@ -560,6 +581,7 @@ export function ConversationView({
               avatarCrop?: { zoom: number; offsetX: number; offsetY: number } | null;
               conversationStatus?: "online" | "idle" | "dnd" | "offline";
               conversationActivity?: string;
+              extensions?: Record<string, unknown>;
             }>;
             if (chars.length === 0) return <div />;
 
@@ -574,10 +596,130 @@ export function ConversationView({
                     : "bg-gray-400";
             };
 
+            const statusLabel = (s?: string) => {
+              const st = s ?? "online";
+              return st === "online" ? "Online" : st === "idle" ? "Away" : st === "dnd" ? "Busy" : "Offline";
+            };
+
+            const openStatus = (charId: string, c: (typeof chars)[number]) => {
+              setEditStatus(c.conversationStatus ?? "online");
+              setEditActivity(c.conversationActivity ?? "");
+              setEditingCharId(charId);
+            };
+
+            const renderStatusPopover = (charId: string, c: (typeof chars)[number]) => {
+              if (editingCharId !== charId) return null;
+              const doSave = async () => {
+                setIsSavingStatus(true);
+                try {
+                  await api.post(`/conversation/status-override/${chatId}`, { characterId: charId, status: editStatus, activity: editActivity });
+                  updateCharacter.mutate({ id: charId, data: { extensions: { ...c.extensions, conversationStatus: editStatus, conversationActivity: editActivity } } });
+                  qc.invalidateQueries({ queryKey: characterKeys.list() });
+                  // Trigger an immediate response when unblocking the character:
+                  // - abort a pending delayed generation, or
+                  // - wake a character that was offline
+                  const wasStreaming = useChatStore.getState().isStreaming;
+                  const wasOffline = (c.conversationStatus ?? "online") === "offline";
+                  const isNowAvailable = editStatus !== "offline";
+                  if (wasStreaming) {
+                    useChatStore.getState().stopGeneration();
+                    await new Promise((r) => setTimeout(r, 300));
+                  }
+                  if (wasStreaming || (wasOffline && isNowAvailable)) {
+                    void generate({ chatId, connectionId: null });
+                  }
+                  setEditingCharId(null);
+                } catch {
+                  // Keep popover open so the user knows the save failed
+                } finally {
+                  setIsSavingStatus(false);
+                }
+              };
+              return (
+                <div
+                  ref={statusPopoverRef}
+                  className="absolute left-0 top-full z-50 mt-1.5 w-56 rounded-lg border border-[var(--border)] bg-[var(--card)] p-3 shadow-lg"
+                >
+                  <div className="mb-3 grid grid-cols-2 gap-1.5">
+                    {(
+                      [
+                        { value: "online", label: "Online", color: "bg-green-500" },
+                        { value: "idle", label: "Away", color: "bg-yellow-500" },
+                        { value: "dnd", label: "Busy", color: "bg-red-500" },
+                        { value: "offline", label: "Offline", color: "bg-gray-400" },
+                      ] as const
+                    ).map(({ value, label, color }) => (
+                      <button
+                        key={value}
+                        onClick={() => setEditStatus(value)}
+                        className={`flex items-center gap-1.5 rounded px-2 py-1 text-[0.7rem] transition-colors ${editStatus === value ? "bg-[var(--accent)] font-medium text-[var(--foreground)]" : "text-[var(--foreground)]/60 hover:bg-[var(--accent)]/50 hover:text-[var(--foreground)]"}`}
+                      >
+                        <span className={`h-2.5 w-2.5 flex-shrink-0 rounded-full ${color}`} />
+                        {label}
+                      </button>
+                    ))}
+                  </div>
+                  <input
+                    autoFocus
+                    type="text"
+                    value={editActivity}
+                    onChange={(e) => setEditActivity(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" && !isSavingStatus) void doSave();
+                      else if (e.key === "Escape") setEditingCharId(null);
+                    }}
+                    placeholder="Activity…"
+                    className="mb-2 w-full rounded border border-[var(--border)] bg-[var(--background)] px-2 py-1 text-[0.75rem] text-[var(--foreground)] outline-none focus:ring-1 focus:ring-[var(--ring)]"
+                  />
+                  <div className="mb-2 flex justify-start">
+                    <button
+                      onClick={() => {
+                        setEditingCharId(null);
+                        onOpenSettings();
+                        setTimeout(() => {
+                          const el = document.getElementById("autonomous-messaging");
+                          if (!el) return;
+                          if (el.children.length < 2) {
+                            (el.querySelector("button") as HTMLButtonElement | null)?.click();
+                          }
+                          el.scrollIntoView({ behavior: "smooth", block: "start" });
+                        }, 150);
+                      }}
+                      className="flex items-center gap-1 text-[0.7rem] text-[var(--foreground)]/50 underline hover:text-[var(--foreground)]"
+                    >
+                      <CalendarClock size={11} />
+                      Edit schedule
+                    </button>
+                  </div>
+                  <div className="flex justify-end gap-1.5">
+                    <button
+                      onClick={() => setEditingCharId(null)}
+                      className="flex items-center gap-1 rounded px-2 py-0.5 text-[0.7rem] text-[var(--foreground)]/60 transition-colors hover:text-[var(--foreground)]"
+                    >
+                      <X size={11} />
+                      Cancel
+                    </button>
+                    <button
+                      onClick={() => void doSave()}
+                      disabled={isSavingStatus}
+                      className="flex items-center gap-1 rounded bg-[var(--primary)] px-2 py-0.5 text-[0.7rem] text-[var(--primary-foreground)] transition-colors hover:opacity-90 disabled:opacity-50"
+                    >
+                      {isSavingStatus ? (
+                        <><Loader2 size={11} className="animate-spin" /><span>Saving…</span></>
+                      ) : (
+                        <><Save size={11} /><span>Save</span></>
+                      )}
+                    </button>
+                  </div>
+                </div>
+              );
+            };
+
             if (chars.length === 1) {
               const c = chars[0]!;
+              const charId = chatCharIds[0]!;
               return (
-                <div className="flex items-center gap-2 rounded-lg bg-[var(--card)]/80 px-2.5 py-1.5 backdrop-blur-sm dark:bg-black/30">
+                <div className="relative flex items-center gap-2 rounded-lg bg-[var(--card)]/80 px-2.5 py-1.5 backdrop-blur-sm dark:bg-black/30">
                   <div className="relative flex-shrink-0">
                     {c.avatarUrl ? (
                       <span className="block h-5 w-5 overflow-hidden rounded-full">
@@ -597,12 +739,16 @@ export function ConversationView({
                       className={`absolute -bottom-0.5 -right-0.5 h-2 w-2 rounded-full ring-[1.5px] ring-[var(--border)] ${statusColor(c.conversationStatus)}`}
                     />
                   </div>
-                  <div className="flex flex-col leading-tight">
-                    <span className="text-[0.75rem] font-medium text-foreground/90">{c.name}</span>
-                    {c.conversationActivity && (
-                      <span className="text-[0.5625rem] text-foreground/50">{c.conversationActivity}</span>
-                    )}
-                  </div>
+                  <button
+                    className="group flex flex-col leading-tight text-left"
+                    onClick={() => openStatus(charId, c)}
+                  >
+                    <span className="text-[0.75rem] font-medium text-foreground/90 transition-colors group-hover:text-foreground">{c.name}</span>
+                    <span className="text-[0.5625rem] text-foreground/50 transition-colors group-hover:text-foreground/70">
+                      {c.conversationActivity || statusLabel(c.conversationStatus)}
+                    </span>
+                  </button>
+                  {renderStatusPopover(charId, c)}
                 </div>
               );
             }
@@ -614,31 +760,41 @@ export function ConversationView({
                   className="relative flex-shrink-0"
                   style={{ width: `${Math.min(chars.length, 3) * 12 + 8}px`, height: 20 }}
                 >
-                  {chars.slice(0, 3).map((c, i) => (
-                    <div key={i} className="absolute top-0" style={{ left: i * 12 }}>
-                      <div className="relative">
-                        {c.avatarUrl ? (
-                          <span className="block h-5 w-5 overflow-hidden rounded-full ring-1 ring-[var(--border)]">
-                            <img
-                              src={c.avatarUrl}
-                              alt={c.name}
-                              className="h-full w-full object-cover"
-                              style={getAvatarCropStyle(c.avatarCrop)}
-                            />
-                          </span>
-                        ) : (
-                          <div className="flex h-5 w-5 items-center justify-center rounded-full bg-foreground/20 text-[0.5rem] font-bold text-foreground ring-1 ring-[var(--border)]">
-                            {c.name[0]}
-                          </div>
-                        )}
-                        <span
-                          className={`absolute -bottom-0.5 -right-0.5 h-1.5 w-1.5 rounded-full ring-[1px] ring-[var(--border)] ${statusColor(c.conversationStatus)}`}
-                        />
+                  {chars.slice(0, 3).map((c, i) => {
+                    const charId = chatCharIds[i]!;
+                    return (
+                      <div key={i} className="absolute top-0" style={{ left: i * 12 }}>
+                        <div className="relative">
+                          <button
+                            className="relative block rounded-full focus:outline-none"
+                            onClick={() => openStatus(charId, c)}
+                            title={c.name}
+                          >
+                            {c.avatarUrl ? (
+                              <span className="block h-5 w-5 overflow-hidden rounded-full ring-1 ring-[var(--border)]">
+                                <img
+                                  src={c.avatarUrl}
+                                  alt={c.name}
+                                  className="h-full w-full object-cover"
+                                  style={getAvatarCropStyle(c.avatarCrop)}
+                                />
+                              </span>
+                            ) : (
+                              <div className="flex h-5 w-5 items-center justify-center rounded-full bg-foreground/20 text-[0.5rem] font-bold text-foreground ring-1 ring-[var(--border)]">
+                                {c.name[0]}
+                              </div>
+                            )}
+                          </button>
+                          <span
+                            className={`absolute -bottom-0.5 -right-0.5 h-1.5 w-1.5 rounded-full ring-[1px] ring-[var(--border)] ${statusColor(c.conversationStatus)}`}
+                          />
+                        </div>
+                        {renderStatusPopover(charId, c)}
                       </div>
-                    </div>
-                  ))}
+                    );
+                  })}
                 </div>
-                <span className="text-[0.75rem] font-medium text-[var(--foreground)]/90">
+                <span className="text-[0.75rem] font-medium text-[var(--foreground)]/90" title="Click an avatar to edit status">
                   {chars.length <= 2 ? chars.map((c) => c.name).join(" & ") : `${chars[0]!.name} + ${chars.length - 1}`}
                 </span>
               </div>

--- a/packages/client/src/components/chat/chat-area.types.ts
+++ b/packages/client/src/components/chat/chat-area.types.ts
@@ -17,6 +17,7 @@ export type CharacterMap = Map<
     avatarCrop?: { zoom: number; offsetX: number; offsetY: number } | null;
     conversationStatus?: "online" | "idle" | "dnd" | "offline";
     conversationActivity?: string;
+    extensions?: Record<string, unknown>;
   }
 >;
 

--- a/packages/server/src/routes/conversation.routes.ts
+++ b/packages/server/src/routes/conversation.routes.ts
@@ -289,9 +289,32 @@ export async function conversationRoutes(app: FastifyInstance) {
       typeof chat.characterIds === "string" ? JSON.parse(chat.characterIds) : chat.characterIds;
 
     const now = new Date();
+    const statusOverrides: Record<string, { status: string; activity: string }> = meta.statusOverrides ?? {};
     const statuses: Record<string, { status: string; activity: string; schedule?: WeekSchedule }> = {};
 
     for (const charId of characterIds) {
+      // Manual override takes precedence — sync it to extensions and skip schedule logic
+      const override = statusOverrides[charId];
+      if (override) {
+        const charRow = await chars.getById(charId);
+        if (charRow) {
+          const charData = JSON.parse(charRow.data as string) as CharacterData;
+          if (
+            charData.extensions?.conversationStatus !== override.status ||
+            charData.extensions?.conversationActivity !== override.activity
+          ) {
+            const extensions = {
+              ...(charData.extensions ?? {}),
+              conversationStatus: override.status,
+              conversationActivity: override.activity,
+            };
+            await chars.update(charId, { extensions } as Partial<CharacterData>);
+          }
+        }
+        statuses[charId] = { status: override.status, activity: override.activity };
+        continue;
+      }
+
       const schedule = schedules[charId];
       if (!schedule) {
         const charRow = await chars.getById(charId);
@@ -377,8 +400,11 @@ export async function conversationRoutes(app: FastifyInstance) {
       typeof chat.characterIds === "string" ? JSON.parse(chat.characterIds) : chat.characterIds;
     const isGroup = characterIds.length > 1;
 
-    // Update each character's conversationStatus to match current schedule
+    const statusOverrides: Record<string, { status: string; activity: string }> = meta.statusOverrides ?? {};
+
+    // Update each character's conversationStatus to match current schedule (skip if overridden)
     for (const cid of characterIds) {
+      if (statusOverrides[cid]) continue;
       const schedule = schedules[cid];
       if (!schedule) continue;
       const { status } = getCurrentStatus(schedule);
@@ -411,7 +437,7 @@ export async function conversationRoutes(app: FastifyInstance) {
       return reply.send({ shouldTrigger: false, characterIds: [], reason: "scene_active", inactivityMs: 0 });
     }
 
-    const result = checkAutonomousMessaging(chatId, filteredSchedules, isGroup);
+    const result = checkAutonomousMessaging(chatId, filteredSchedules, isGroup, statusOverrides);
 
     if (result.shouldTrigger) {
       markGenerationInProgress(chatId);
@@ -422,6 +448,7 @@ export async function conversationRoutes(app: FastifyInstance) {
     // This catches the case where user sent messages while character was offline.
     // Now that they're online, trigger a catch-up generation.
     const onlineCharIds = characterIds.filter((cid) => {
+      if (statusOverrides[cid]) return statusOverrides[cid]!.status !== "offline";
       const schedule = schedules[cid];
       if (!schedule) return true; // No schedule = assume online
       const { status } = getCurrentStatus(schedule);
@@ -457,6 +484,15 @@ export async function conversationRoutes(app: FastifyInstance) {
     if (!chat) return reply.status(404).send({ error: "Chat not found" });
 
     const meta = typeof chat.metadata === "string" ? JSON.parse(chat.metadata) : (chat.metadata ?? {});
+    const statusOverrides: Record<string, { status: string; activity: string }> = meta.statusOverrides ?? {};
+    const override = statusOverrides[characterId];
+    if (override) {
+      const schedules: CharacterSchedules = getEnabledConversationSchedules(meta);
+      const schedule = schedules[characterId];
+      const delayMs = schedule ? getBusyDelay(override.status as "online" | "idle" | "dnd" | "offline", schedule) : 0;
+      return reply.send({ delayMs, status: override.status, activity: override.activity });
+    }
+
     const schedules: CharacterSchedules = getEnabledConversationSchedules(meta);
     const schedule = schedules[characterId];
 
@@ -501,10 +537,38 @@ export async function conversationRoutes(app: FastifyInstance) {
       messages as Array<{ role: string; createdAt?: string; characterId?: string | null }>,
     );
 
-    const result = checkCharacterExchange(chatId, lastSpeakerCharId, schedules);
+    const statusOverrides: Record<string, { status: string; activity: string }> = meta.statusOverrides ?? {};
+    const result = checkCharacterExchange(chatId, lastSpeakerCharId, schedules, statusOverrides);
     if (result.shouldTrigger) {
       markGenerationInProgress(chatId);
     }
     return reply.send(result);
+  });
+
+  // ─────────────────────────────────────────────
+  // POST /status-override/:chatId — Set or clear a manual status override for a character
+  // Body: { characterId, status, activity } — pass status: null to clear
+  // ─────────────────────────────────────────────
+  app.post<{
+    Params: { chatId: string };
+    Body: { characterId: string; status: string | null; activity?: string };
+  }>("/status-override/:chatId", async (req, reply) => {
+    const { chatId } = req.params;
+    const { characterId, status, activity = "" } = req.body;
+
+    const chat = await chats.getById(chatId);
+    if (!chat) return reply.status(404).send({ error: "Chat not found" });
+
+    const meta = typeof chat.metadata === "string" ? JSON.parse(chat.metadata) : (chat.metadata ?? {});
+    const overrides: Record<string, { status: string; activity: string }> = meta.statusOverrides ?? {};
+
+    if (status === null) {
+      delete overrides[characterId];
+    } else {
+      overrides[characterId] = { status, activity };
+    }
+
+    await chats.updateMetadata(chatId, { ...meta, statusOverrides: overrides });
+    return reply.send({ ok: true });
   });
 }

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -931,15 +931,22 @@ export async function generateRoutes(app: FastifyInstance) {
             const schedule = schedules[cid];
             if (schedule) {
               const schedSvc = await import("../services/conversation/schedule.service.js");
-              const derived = schedSvc.getCurrentStatus(schedule);
-              status = derived.status;
-              activity = derived.activity;
-              todaySchedule = schedSvc.getTodaySchedule(schedule);
-              // Sync status to character DB so sidebar/header dots stay in sync
-              const prevStatus = d.extensions?.conversationStatus;
-              if (prevStatus !== status) {
-                const extensions = { ...(d.extensions ?? {}), conversationStatus: status };
-                await chars.update(cid, { extensions } as any).catch(() => {});
+              const overrides = (chatMeta.statusOverrides ?? {}) as Record<string, { status: string; activity: string }>;
+              if (overrides[cid]) {
+                status = overrides[cid]!.status;
+                activity = overrides[cid]!.activity;
+                todaySchedule = schedSvc.getTodaySchedule(schedule);
+              } else {
+                const derived = schedSvc.getCurrentStatus(schedule);
+                status = derived.status;
+                activity = derived.activity;
+                todaySchedule = schedSvc.getTodaySchedule(schedule);
+                // Sync status to character DB so sidebar/header dots stay in sync
+                const prevStatus = d.extensions?.conversationStatus;
+                if (prevStatus !== status) {
+                  const extensions = { ...(d.extensions ?? {}), conversationStatus: status };
+                  await chars.update(cid, { extensions } as any).catch(() => {});
+                }
               }
             }
             convoCharInfo.push({ charId: cid, name: d.name ?? "Unknown", status, activity, todaySchedule });

--- a/packages/server/src/services/conversation/autonomous.service.ts
+++ b/packages/server/src/services/conversation/autonomous.service.ts
@@ -127,6 +127,7 @@ export function checkAutonomousMessaging(
   chatId: string,
   characterSchedules: Record<string, WeekSchedule>,
   isGroupChat: boolean,
+  statusOverrides?: Record<string, { status: string; activity: string }>,
 ): AutonomousCheckResult {
   const noTrigger: AutonomousCheckResult = {
     shouldTrigger: false,
@@ -160,7 +161,7 @@ export function checkAutonomousMessaging(
   const MAX_FOLLOWUPS = 3;
 
   for (const [charId, schedule] of Object.entries(characterSchedules)) {
-    const { status } = getCurrentStatus(schedule);
+    const { status } = statusOverrides?.[charId] ?? getCurrentStatus(schedule);
 
     // Can't send if offline or sleeping
     if (status === "offline") continue;
@@ -235,6 +236,7 @@ export function checkCharacterExchange(
   chatId: string,
   lastSpeakerCharId: string,
   characterSchedules: Record<string, WeekSchedule>,
+  statusOverrides?: Record<string, { status: string; activity: string }>,
 ): AutonomousCheckResult {
   const noTrigger: AutonomousCheckResult = {
     shouldTrigger: false,
@@ -262,7 +264,7 @@ export function checkCharacterExchange(
   for (const [charId, schedule] of Object.entries(characterSchedules)) {
     if (charId === lastSpeakerCharId) continue;
 
-    const { status } = getCurrentStatus(schedule);
+    const { status } = statusOverrides?.[charId] ?? getCurrentStatus(schedule);
     if (status === "offline") continue;
     if (status === "dnd") continue; // Busy characters don't join casual exchanges
 


### PR DESCRIPTION
## What & Why

Characters in conversation mode have a schedule-based availability system (online / away / busy / offline), but there was no way to manually override a character's status from the chat view itself — you had to dig through settings. This PR surfaces that control directly in the chat header and extends it to group chats.

## Changes

**Single-character chats**
- Clicking the character name/activity label opens a compact popover
- Popover lets you set status (Online / Away / Busy / Offline) and a custom activity label (e.g. "In a meeting", "Sleeping")
- Unblocking an offline character (setting them back to online) immediately triggers a response if one was pending
- "Edit schedule" link inside the popover jumps straight to the schedule section in settings

**Group chats**
- Each stacked avatar in the header is now individually clickable
- Clicking an avatar opens the same status/activity popover for that specific character
- Only one popover can be open at a time; clicking outside closes it

**Polish**
- Popover buttons use `lucide-react` icons (`Save`, `X`, `CalendarClock`, `Loader2`) consistent with the rest of the UI
- All colors use CSS custom properties (`--foreground`, `--card`, `--border`, `--primary`, etc.) so the popover respects user themes
- No backend changes needed — the existing `/conversation/status-override` and schedule endpoints already support per-character operations for both chat types

## Test Plan

- [ ] Manually verify: open a single-character chat, click the character name, change status and activity, save — confirm dot color and activity label update immediately
- [ ] Manually verify: set a character offline, then set them back to online — confirm a response is triggered
- [ ] Manually verify: open a group chat, click each avatar individually — confirm the correct character's popover opens for each
- [ ] Manually verify: click outside an open popover — confirm it closes without saving
- [ ] Manually verify: press Enter in the activity field to save, press Escape to cancel
- [ ] Manually verify: "Edit schedule" link opens settings and scrolls to the schedule section
- [ ] Manually verify: switch UI theme — confirm popover colors follow the theme

> **Note:** No linked issue exists yet — one should be opened before merging. See `CONTRIBUTING.md § Before You Open a Pull Request`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Character status and activity can now be edited directly from conversation headers via an interactive popover interface. Changes persist and influence character behavior within conversations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->