### PR TITLE
feat(server): HTTP Basic Auth + safe-by-default remote lockdown

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,23 @@ CORS_ORIGINS=http://localhost:5173,http://127.0.0.1:5173
 # IP Allowlist — comma-separated IPs or CIDRs (e.g. 192.168.1.100,10.0.0.0/24)
 # When set, all other IPs are blocked. Loopback (127.0.0.1/::1) is always allowed.
 # IP_ALLOWLIST=
+# Set IP_ALLOWLIST_ENABLED=false to keep the list above but temporarily disable enforcement.
+# IP_ALLOWLIST_ENABLED=true
+
+# HTTP Basic Auth — set both BASIC_AUTH_USER and BASIC_AUTH_PASS to require a
+# username/password on every request from non-loopback, non-allowlisted IPs.
+# Use a strong, random password and pair with HTTPS (SSL_CERT/SSL_KEY) when
+# exposing the server to the internet.
+# BASIC_AUTH_USER=
+# BASIC_AUTH_PASS=
+# BASIC_AUTH_REALM=Marinara Engine
+
+# Safe-by-default lockdown:
+#   When neither BASIC_AUTH_USER nor BASIC_AUTH_PASS is set, the server refuses
+#   remote connections (loopback and IP_ALLOWLIST entries still work). This
+#   protects users who accidentally expose the port to the public internet.
+#   Set this to true to opt back into the legacy "anyone can connect" behaviour.
+# ALLOW_UNAUTHENTICATED_REMOTE=false
 
 # Giphy GIF API — get a free key from https://developers.giphy.com/
 # (optional; GIF search is disabled when unset)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -23,6 +23,11 @@ cp .env.example .env
 | `SSL_CERT`                       | _(empty)_                                                | Path to the TLS certificate. Set both `SSL_CERT` and `SSL_KEY` to enable HTTPS.                                                                                |
 | `SSL_KEY`                        | _(empty)_                                                | Path to the TLS private key.                                                                                                                                   |
 | `IP_ALLOWLIST`                   | _(empty)_                                                | Comma-separated IPs or CIDRs to allow. Loopback is always allowed.                                                                                             |
+| `IP_ALLOWLIST_ENABLED`           | `true`                                                   | Master switch for `IP_ALLOWLIST`. Set to `false`, `0`, `no`, or `off` to keep the list configured but disable enforcement.                                     |
+| `BASIC_AUTH_USER`                | _(empty)_                                                | Username for HTTP Basic Auth. Set both `BASIC_AUTH_USER` and `BASIC_AUTH_PASS` to require a password on every request. Leave either empty to disable auth.     |
+| `BASIC_AUTH_PASS`                | _(empty)_                                                | Password for HTTP Basic Auth. Use a strong, random value.                                                                                                      |
+| `BASIC_AUTH_REALM`               | `Marinara Engine`                                        | Realm string shown in the browser password prompt.                                                                                                             |
+| `ALLOW_UNAUTHENTICATED_REMOTE`   | `false`                                                  | When neither Basic Auth nor an `IP_ALLOWLIST` entry vouches for a remote IP, requests are refused by default. Set to `true` to allow unauthenticated remote access (NOT recommended on internet-facing servers). |
 | `GIPHY_API_KEY`                  | _(empty)_                                                | Optional Giphy API key. GIF search is unavailable when unset.                                                                                                  |
 
 ## Logging Levels
@@ -56,6 +61,53 @@ LOG_LEVEL=debug pnpm start
 ```
 
 > **Note:** Client-side (browser) logging uses the standard `console.*` API and is not controlled by `LOG_LEVEL`. Production client builds automatically strip `console.log` calls; only `console.warn` and `console.error` survive in the browser.
+
+## Access Control
+
+Marinara Engine ships with layered access-control mechanisms designed for users who expose the server beyond their local machine.
+
+### Safe-by-default lockdown
+
+By default, when no Basic Auth credentials are configured, the server **refuses connections from any remote IP** that is not in `IP_ALLOWLIST`. Loopback (`127.0.0.1`, `::1`) is always allowed, so local use is unaffected. This protects users who accidentally expose port 7860 to the public internet without setting up authentication.
+
+Remote callers in this state receive a `403 Forbidden` with a message describing the three ways out:
+
+1. Set `BASIC_AUTH_USER` and `BASIC_AUTH_PASS` (recommended for internet-facing servers).
+2. Add the remote IP / network to `IP_ALLOWLIST` (recommended for trusted LANs and VPNs like Tailscale).
+3. Set `ALLOW_UNAUTHENTICATED_REMOTE=true` to opt back into the legacy "anyone can connect" behaviour. Only do this if the network itself is already trusted (e.g. an isolated lab subnet).
+
+### IP Allowlist
+
+Restricts access at the network level. Set `IP_ALLOWLIST` to a comma-separated list of IPs or CIDR ranges:
+
+```
+IP_ALLOWLIST=192.168.1.0/24,203.0.113.42
+```
+
+When set, requests from any other address receive a `403 Forbidden`. Loopback addresses (`127.0.0.1`, `::1`) are **always** allowed so you cannot lock yourself out of local access.
+
+Set `IP_ALLOWLIST_ENABLED=false` to keep the list configured while temporarily disabling enforcement (useful when troubleshooting from a new IP).
+
+### HTTP Basic Auth
+
+Requires a username and password on every request. Set both `BASIC_AUTH_USER` and `BASIC_AUTH_PASS`:
+
+```
+BASIC_AUTH_USER=alice
+BASIC_AUTH_PASS=correct-horse-battery-staple
+```
+
+The browser will show a native password prompt the first time you visit the server and remember the credentials for the session. Leaving either variable empty disables auth.
+
+The following requests are **exempt** from Basic Auth so you cannot lock yourself or trusted networks out:
+
+- Loopback (`127.0.0.1`, `::1`) — if you're on the box itself, no password is needed.
+- Any IP listed in `IP_ALLOWLIST` — if you've already vouched for a network at the IP layer, no second factor is required.
+- The `/api/health` endpoint — so external uptime monitors and load balancers can probe the server without credentials.
+
+> **Always pair Basic Auth with HTTPS** when exposing the server to the public internet — Basic Auth credentials are only base64-encoded, not encrypted. Set `SSL_CERT` and `SSL_KEY`, or front Marinara with a TLS-terminating reverse proxy (nginx, Caddy, Traefik, Cloudflare Tunnel).
+
+For sensitive deployments, also consider Tailscale or Cloudflare Access — they avoid exposing the port to the open internet entirely.
 
 ## Notes
 

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -9,6 +9,7 @@ import { getDB, type DB } from "./db/connection.js";
 import { registerRoutes } from "./routes/index.js";
 import { errorHandler } from "./middleware/error-handler.js";
 import { ipAllowlistHook } from "./middleware/ip-allowlist.js";
+import { basicAuthHook } from "./middleware/basic-auth.js";
 import { runMigrations } from "./db/migrate.js";
 import { seedDefaultPreset } from "./db/seed.js";
 import { seedProfessorMari } from "./db/seed-mari.js";
@@ -102,6 +103,9 @@ export async function buildApp(https?: { cert: Buffer; key: Buffer }) {
 
   // ── IP Allowlist ──
   app.addHook("onRequest", ipAllowlistHook);
+
+  // ── HTTP Basic Auth ──
+  app.addHook("onRequest", basicAuthHook);
 
   // ── Prevent caching of API JSON responses ──
   // Without explicit Cache-Control, browsers apply heuristic caching which

--- a/packages/server/src/config/runtime-config.ts
+++ b/packages/server/src/config/runtime-config.ts
@@ -120,7 +120,28 @@ export function getDatabaseFilePath() {
 }
 
 export function getIpAllowlist() {
+  // Explicit off-switch lets users keep their list configured but
+  // temporarily disable enforcement without deleting the entries.
+  if (isDisabledFlag(process.env.IP_ALLOWLIST_ENABLED)) return null;
   return normalizeEnvValue(process.env.IP_ALLOWLIST);
+}
+
+export function getBasicAuthConfig() {
+  return {
+    user: normalizeEnvValue(process.env.BASIC_AUTH_USER),
+    pass: normalizeEnvValue(process.env.BASIC_AUTH_PASS),
+    realm: normalizeEnvValue(process.env.BASIC_AUTH_REALM) ?? "Marinara Engine",
+  };
+}
+
+/**
+ * Opt-in switch that lets the server accept unauthenticated remote
+ * connections (i.e. neither loopback nor IP_ALLOWLIST nor Basic Auth).
+ * Default false — protects users who accidentally expose the port.
+ */
+export function isUnauthenticatedRemoteAllowed() {
+  const value = (process.env.ALLOW_UNAUTHENTICATED_REMOTE ?? "").trim().toLowerCase();
+  return ["1", "true", "yes", "on"].includes(value);
 }
 
 export function isDebugAgentsEnabled() {

--- a/packages/server/src/middleware/basic-auth.ts
+++ b/packages/server/src/middleware/basic-auth.ts
@@ -1,0 +1,145 @@
+// ──────────────────────────────────────────────
+// Middleware: HTTP Basic Auth + safe-by-default remote lockdown
+// ──────────────────────────────────────────────
+// Set BASIC_AUTH_USER and BASIC_AUTH_PASS to enable HTTP Basic Authentication
+// on every request from non-loopback, non-allowlisted IPs.
+//
+// When credentials are NOT configured, this middleware refuses remote
+// connections by default (returns 403). This protects users who accidentally
+// expose the port to the public internet without setting up a password.
+// To opt back into the legacy "anyone can connect" behaviour, set
+// ALLOW_UNAUTHENTICATED_REMOTE=true.
+//
+// Optional:
+//   BASIC_AUTH_REALM            — string shown in the browser password prompt
+//                                 (default: "Marinara Engine")
+//   ALLOW_UNAUTHENTICATED_REMOTE — set to "true" to disable the default lockdown
+//                                  (NOT recommended on internet-facing servers)
+//
+// Notes:
+//   • The `/api/health` endpoint is exempt so external uptime checks /
+//     load balancers can probe the server without needing credentials.
+//   • Loopback (127.0.0.1, ::1) is exempt — if you're already on the box,
+//     you don't need a password.
+//   • Any IP that matches IP_ALLOWLIST is also exempt — if you've already
+//     vouched for a network, requiring a second factor would be noise.
+//   • Use a strong, random password — Basic Auth sends credentials on
+//     every request, only base64-encoded. Always pair with HTTPS in
+//     production (see SSL_CERT / SSL_KEY).
+
+import type { FastifyRequest, FastifyReply } from "fastify";
+import { timingSafeEqual } from "node:crypto";
+import { getBasicAuthConfig, isUnauthenticatedRemoteAllowed } from "../config/runtime-config.js";
+import { logger } from "../lib/logger.js";
+import { isInIpAllowlist, isLoopbackIp } from "./ip-allowlist.js";
+
+interface CachedConfig {
+  user: string;
+  pass: string;
+  realm: string;
+  expectedHeader: Buffer;
+  announced: boolean;
+}
+
+let cached: { raw: { user: string | null; pass: string | null; realm: string }; resolved: CachedConfig | null } | null =
+  null;
+
+function buildExpectedHeader(user: string, pass: string): Buffer {
+  return Buffer.from(`Basic ${Buffer.from(`${user}:${pass}`, "utf8").toString("base64")}`, "utf8");
+}
+
+function loadConfig(): CachedConfig | null {
+  const raw = getBasicAuthConfig();
+  if (!cached || cached.raw.user !== raw.user || cached.raw.pass !== raw.pass || cached.raw.realm !== raw.realm) {
+    if (raw.user && raw.pass) {
+      cached = {
+        raw,
+        resolved: {
+          user: raw.user,
+          pass: raw.pass,
+          realm: raw.realm,
+          expectedHeader: buildExpectedHeader(raw.user, raw.pass),
+          announced: false,
+        },
+      };
+    } else {
+      cached = { raw, resolved: null };
+    }
+  }
+
+  if (cached.resolved && !cached.resolved.announced) {
+    logger.info(`[basic-auth] HTTP Basic Auth enabled (realm="${cached.resolved.realm}", user="${cached.resolved.user}")`);
+    cached.resolved.announced = true;
+  }
+
+  return cached.resolved;
+}
+
+function safeEqual(a: Buffer, b: Buffer): boolean {
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
+function sendChallenge(reply: FastifyReply, realm: string) {
+  // Quote the realm and escape any embedded quotes / backslashes so the
+  // header stays well-formed even if the user picks an exotic realm string.
+  const safeRealm = realm.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  reply.header("WWW-Authenticate", `Basic realm="${safeRealm}", charset="UTF-8"`);
+  reply.status(401).send({ error: "Authentication required" });
+}
+
+let lockdownAnnounced = false;
+
+function sendLockdown(reply: FastifyReply) {
+  reply.status(403).send({
+    error: "Forbidden",
+    message:
+      "Remote access is disabled because no authentication is configured. " +
+      "Set BASIC_AUTH_USER and BASIC_AUTH_PASS, add this IP to IP_ALLOWLIST, " +
+      "or set ALLOW_UNAUTHENTICATED_REMOTE=true to allow unauthenticated remote connections.",
+  });
+}
+
+// ── Fastify onRequest hook ──
+
+export function basicAuthHook(request: FastifyRequest, reply: FastifyReply, done: () => void) {
+  // Exempt the health endpoint so external probes still work
+  if (request.url === "/api/health" || request.url.startsWith("/api/health?")) {
+    return done();
+  }
+
+  // Exempt loopback and any IP already vouched for by IP_ALLOWLIST
+  const ip = request.ip;
+  const trusted = isLoopbackIp(ip) || isInIpAllowlist(ip);
+  if (trusted) return done();
+
+  const config = loadConfig();
+
+  // No credentials configured → safe-by-default lockdown for remote IPs.
+  // Opt out via ALLOW_UNAUTHENTICATED_REMOTE=true for legacy open-access behaviour.
+  if (!config) {
+    if (isUnauthenticatedRemoteAllowed()) return done();
+    if (!lockdownAnnounced) {
+      logger.warn(
+        `[basic-auth] Refused remote connection from ${ip}. No auth configured; set BASIC_AUTH_USER/BASIC_AUTH_PASS, IP_ALLOWLIST, or ALLOW_UNAUTHENTICATED_REMOTE=true.`,
+      );
+      lockdownAnnounced = true;
+    }
+    sendLockdown(reply);
+    return;
+  }
+
+  const header = request.headers.authorization;
+  if (!header || typeof header !== "string") {
+    sendChallenge(reply, config.realm);
+    return;
+  }
+
+  const provided = Buffer.from(header, "utf8");
+  if (!safeEqual(provided, config.expectedHeader)) {
+    sendChallenge(reply, config.realm);
+    return;
+  }
+
+  return done();
+}

--- a/packages/server/src/middleware/ip-allowlist.ts
+++ b/packages/server/src/middleware/ip-allowlist.ts
@@ -172,6 +172,34 @@ function getAllowlist() {
   return cachedAllowlist.entries;
 }
 
+// ── Reusable predicates (shared with basic-auth) ──
+
+/** True if the given IP string is a loopback address. */
+export function isLoopbackIp(ip: string): boolean {
+  const bytes = ipToBytes(ip);
+  if (!bytes) return false;
+  for (const lb of LOOPBACK_CIDRS) {
+    if (matchesCIDR(bytes, lb)) return true;
+  }
+  return false;
+}
+
+/**
+ * True if the given IP is configured in the active IP_ALLOWLIST.
+ * Returns false when no allowlist is configured (so callers can decide
+ * what to do with "no list" vs "list says no").
+ */
+export function isInIpAllowlist(ip: string): boolean {
+  const allowlist = getAllowlist();
+  if (!allowlist) return false;
+  const bytes = ipToBytes(ip);
+  if (!bytes) return false;
+  for (const entry of allowlist) {
+    if (matchesCIDR(bytes, entry)) return true;
+  }
+  return false;
+}
+
 // ── Fastify onRequest hook ──
 
 export function ipAllowlistHook(request: FastifyRequest, reply: FastifyReply, done: () => void) {


### PR DESCRIPTION
## Summary

Adds optional HTTP Basic Auth and an explicit on/off toggle for the existing IP allowlist, plus a safe-by-default lockdown for **public-internet IPs only** so an accidentally exposed port 7860 cannot be hit by random internet traffic — without breaking LAN, Docker, Kubernetes, or Tailscale traffic.

Motivated by [a Discord request](https://discord.com/) from a user hosting Marinara on a Hetzner Cloud server who wanted simple username/password protection for their public deployment, and by the broader concern that any user who flips `HOST=0.0.0.0` (every shell launcher does) and forwards a port becomes immediately reachable from the open internet with no auth at all.

## Why this strengthens an exposed port 7860

Today, `HOST=0.0.0.0` plus an exposed port = anyone on the internet can use the entire app, browse chats, exfiltrate data, and burn API credits. With this change:

- **Public-only lockdown.** With no `BASIC_AUTH_*` configured, the server returns `403 Forbidden` to any IP that is not loopback, RFC 1918 private, CGNAT (Tailscale), link-local, or in `IP_ALLOWLIST`. The error response tells the operator exactly how to unlock it. Local use, LAN access from your phone, container-to-container traffic on Docker bridges, Kubernetes pods, and Tailscale peers all keep working with zero configuration.
- **Cleared path for legitimate remote access.** Operators who want to reach the server from a *public* IP (or from a non-private network) have three documented options:
  1. Set `BASIC_AUTH_USER` + `BASIC_AUTH_PASS` — the browser shows a native password prompt; credentials are checked with `timingSafeEqual`. Pair with HTTPS via the existing `SSL_CERT` / `SSL_KEY`.
  2. Add the public IP / network to `IP_ALLOWLIST`.
  3. Set `ALLOW_UNAUTHENTICATED_REMOTE=true` to opt back into the legacy open-access behaviour for public IPs as well.
- **Layered, not exclusive.** Basic Auth and `IP_ALLOWLIST` compose cleanly: the allowlist runs first (so blocked IPs never even reach the auth path), and any IP it vouches for is exempt from the password prompt — so e.g. a remote office at a fixed public IP can be allowlisted and skip the password.
- **Principle of least surprise.** The private-network auto-exemption applies *only* to the no-auth lockdown. Once you set `BASIC_AUTH_*`, the password is required from every IP except loopback and explicit `IP_ALLOWLIST` matches — including from your LAN. If you set a password, you mean it.
- **Operational endpoints still work.** `/api/health` is exempt so external uptime monitors and load balancers can probe the server without credentials.

## Behaviour matrix

POST UPDATED MATRIX SCREENSHOT HERE

## New configuration

All env vars are documented in `docs/CONFIGURATION.md` and `.env.example`:

| Variable | Default | Purpose |
| --- | --- | --- |
| `BASIC_AUTH_USER` | _(empty)_ | Username for HTTP Basic Auth. |
| `BASIC_AUTH_PASS` | _(empty)_ | Password for HTTP Basic Auth. |
| `BASIC_AUTH_REALM` | `Marinara Engine` | Realm string shown in the browser prompt. |
| `IP_ALLOWLIST_ENABLED` | `true` | Master switch — keep the list configured but disable enforcement. |
| `ALLOW_UNAUTHENTICATED_REMOTE` | `false` | Opt-in escape hatch to allow unauthenticated **public** access. |

There are **no default credentials** baked in anywhere — `BASIC_AUTH_USER` and `BASIC_AUTH_PASS` start unset, and the lockdown rejects all public-internet requests rather than accepting anything until the operator sets real values.

## Files

- `packages/server/src/middleware/basic-auth.ts` — new `onRequest` hook, timing-safe credential comparison, public-only lockdown logic.
- `packages/server/src/middleware/ip-allowlist.ts` — extracted `isLoopbackIp`, `isInIpAllowlist`, and `isPrivateNetworkIp` helpers (no behaviour change to the existing hook).
- `packages/server/src/config/runtime-config.ts` — `getBasicAuthConfig`, `isUnauthenticatedRemoteAllowed`, and `IP_ALLOWLIST_ENABLED` toggle.
- `packages/server/src/app.ts` — registers the new hook after the IP allowlist.
- `.env.example`, `docs/CONFIGURATION.md` — documents the new vars and the new "Access Control" section.