### PR TITLE
feat(server): auto-trust private networks in basic-auth lockdown

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,6 +55,13 @@ CORS_ORIGINS=http://localhost:5173,http://127.0.0.1:5173
 #   ports while keeping LAN/phone/container access transparent.
 #   Set this to true to allow unauthenticated PUBLIC connections too.
 # ALLOW_UNAUTHENTICATED_REMOTE=false
+#
+# Override the private-network list used by the lockdown above. Comma-separated
+# IPs / CIDRs. When set, REPLACES the defaults entirely (so include any of the
+# defaults you still want).
+#   Defaults: 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 169.254.0.0/16,
+#             100.64.0.0/10, fc00::/7, fe80::/10
+# TRUSTED_PRIVATE_NETWORKS=192.168.0.0/16,10.0.0.0/8
 
 # Giphy GIF API — get a free key from https://developers.giphy.com/
 # (optional; GIF search is disabled when unset)

--- a/.env.example
+++ b/.env.example
@@ -49,9 +49,11 @@ CORS_ORIGINS=http://localhost:5173,http://127.0.0.1:5173
 
 # Safe-by-default lockdown:
 #   When neither BASIC_AUTH_USER nor BASIC_AUTH_PASS is set, the server refuses
-#   remote connections (loopback and IP_ALLOWLIST entries still work). This
-#   protects users who accidentally expose the port to the public internet.
-#   Set this to true to opt back into the legacy "anyone can connect" behaviour.
+#   connections from PUBLIC-INTERNET IPs only. Loopback, RFC 1918 LANs, Docker
+#   bridges, Kubernetes pods, Tailscale CGNAT, and IP_ALLOWLIST entries all
+#   continue to work without a password. This protects accidentally-exposed
+#   ports while keeping LAN/phone/container access transparent.
+#   Set this to true to allow unauthenticated PUBLIC connections too.
 # ALLOW_UNAUTHENTICATED_REMOTE=false
 
 # Giphy GIF API — get a free key from https://developers.giphy.com/

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -28,6 +28,7 @@ cp .env.example .env
 | `BASIC_AUTH_PASS`                | _(empty)_                                                | Password for HTTP Basic Auth. Use a strong, random value.                                                                                                      |
 | `BASIC_AUTH_REALM`               | `Marinara Engine`                                        | Realm string shown in the browser password prompt.                                                                                                             |
 | `ALLOW_UNAUTHENTICATED_REMOTE`   | `false`                                                  | When neither Basic Auth nor an `IP_ALLOWLIST` entry vouches for a public-internet IP, requests are refused by default. Private-network IPs (RFC 1918, CGNAT, IPv6 ULA / link-local) are always allowed. Set to `true` to allow unauthenticated **public** access (NOT recommended on internet-facing servers). |
+| `TRUSTED_PRIVATE_NETWORKS`       | _(built-in defaults)_                                    | Comma-separated IPs / CIDRs that bypass the no-auth lockdown. When set, **replaces** the defaults (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `169.254.0.0/16`, `100.64.0.0/10`, `fc00::/7`, `fe80::/10`) — include any of the defaults you still want. Useful if you want to drop a range you consider untrusted (e.g. a publicly-routable corporate /16) or substitute your own list. |
 | `GIPHY_API_KEY`                  | _(empty)_                                                | Optional Giphy API key. GIF search is unavailable when unset.                                                                                                  |
 
 ## Logging Levels
@@ -85,6 +86,20 @@ Public callers in the locked-down state receive a `403 Forbidden` with a message
 3. Set `ALLOW_UNAUTHENTICATED_REMOTE=true` to opt back into the legacy "anyone can connect" behaviour for public IPs as well. Only do this if the network itself is already trusted.
 
 > Note: the private-network exemption applies only to the lockdown. Once you set Basic Auth credentials, the password is required from every IP except loopback and explicit `IP_ALLOWLIST` matches — including from your LAN. This matches the principle of least surprise: if you set a password, you mean it.
+
+#### Customising the private-network list
+
+The seven default ranges above cover the vast majority of LAN / Docker / Kubernetes / Tailscale setups. If they don't match your network — for example, you have a publicly-routable corporate `/16` that is technically outside RFC 1918 but you trust it, or you want to *drop* a range you consider hostile — set `TRUSTED_PRIVATE_NETWORKS` to a comma-separated list of IPs / CIDRs. This **replaces** the defaults entirely, so include any of them you still want:
+
+```
+# Trust only my office subnet and a single specific home IP
+TRUSTED_PRIVATE_NETWORKS=10.42.0.0/16,203.0.113.7
+
+# Strip 10.0.0.0/8 from the defaults but keep the rest
+TRUSTED_PRIVATE_NETWORKS=172.16.0.0/12,192.168.0.0/16,169.254.0.0/16,100.64.0.0/10,fc00::/7,fe80::/10
+```
+
+When unset, the built-in defaults are used.
 
 ### IP Allowlist
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -27,7 +27,7 @@ cp .env.example .env
 | `BASIC_AUTH_USER`                | _(empty)_                                                | Username for HTTP Basic Auth. Set both `BASIC_AUTH_USER` and `BASIC_AUTH_PASS` to require a password on every request. Leave either empty to disable auth.     |
 | `BASIC_AUTH_PASS`                | _(empty)_                                                | Password for HTTP Basic Auth. Use a strong, random value.                                                                                                      |
 | `BASIC_AUTH_REALM`               | `Marinara Engine`                                        | Realm string shown in the browser password prompt.                                                                                                             |
-| `ALLOW_UNAUTHENTICATED_REMOTE`   | `false`                                                  | When neither Basic Auth nor an `IP_ALLOWLIST` entry vouches for a remote IP, requests are refused by default. Set to `true` to allow unauthenticated remote access (NOT recommended on internet-facing servers). |
+| `ALLOW_UNAUTHENTICATED_REMOTE`   | `false`                                                  | When neither Basic Auth nor an `IP_ALLOWLIST` entry vouches for a public-internet IP, requests are refused by default. Private-network IPs (RFC 1918, CGNAT, IPv6 ULA / link-local) are always allowed. Set to `true` to allow unauthenticated **public** access (NOT recommended on internet-facing servers). |
 | `GIPHY_API_KEY`                  | _(empty)_                                                | Optional Giphy API key. GIF search is unavailable when unset.                                                                                                  |
 
 ## Logging Levels
@@ -68,13 +68,23 @@ Marinara Engine ships with layered access-control mechanisms designed for users 
 
 ### Safe-by-default lockdown
 
-By default, when no Basic Auth credentials are configured, the server **refuses connections from any remote IP** that is not in `IP_ALLOWLIST`. Loopback (`127.0.0.1`, `::1`) is always allowed, so local use is unaffected. This protects users who accidentally expose port 7860 to the public internet without setting up authentication.
+By default, when no Basic Auth credentials are configured, the server **refuses connections from public-internet IPs**. Local and private-network traffic continues to work without any configuration:
 
-Remote callers in this state receive a `403 Forbidden` with a message describing the three ways out:
+- Loopback (`127.0.0.1`, `::1`) — always allowed.
+- RFC 1918 private networks: `10.0.0.0/8`, `172.16.0.0/12` (covers Docker default bridge `172.17.0.0/16`), `192.168.0.0/16` — allowed automatically.
+- Link-local (`169.254.0.0/16`) and IPv6 ULA / link-local (`fc00::/7`, `fe80::/10`) — allowed automatically.
+- CGNAT range `100.64.0.0/10` (Tailscale, carrier NAT) — allowed automatically.
+- Anything in `IP_ALLOWLIST` — allowed.
+
+This means Docker containers, Kubernetes pods, your phone on the LAN, and Tailscale peers all "just work" without any extra config. Only requests from genuinely public IPs are blocked, which is the case that needs protecting when a port gets accidentally exposed.
+
+Public callers in the locked-down state receive a `403 Forbidden` with a message describing the three ways out:
 
 1. Set `BASIC_AUTH_USER` and `BASIC_AUTH_PASS` (recommended for internet-facing servers).
-2. Add the remote IP / network to `IP_ALLOWLIST` (recommended for trusted LANs and VPNs like Tailscale).
-3. Set `ALLOW_UNAUTHENTICATED_REMOTE=true` to opt back into the legacy "anyone can connect" behaviour. Only do this if the network itself is already trusted (e.g. an isolated lab subnet).
+2. Add the public IP / network to `IP_ALLOWLIST`.
+3. Set `ALLOW_UNAUTHENTICATED_REMOTE=true` to opt back into the legacy "anyone can connect" behaviour for public IPs as well. Only do this if the network itself is already trusted.
+
+> Note: the private-network exemption applies only to the lockdown. Once you set Basic Auth credentials, the password is required from every IP except loopback and explicit `IP_ALLOWLIST` matches — including from your LAN. This matches the principle of least surprise: if you set a password, you mean it.
 
 ### IP Allowlist
 

--- a/packages/server/src/config/runtime-config.ts
+++ b/packages/server/src/config/runtime-config.ts
@@ -144,6 +144,15 @@ export function isUnauthenticatedRemoteAllowed() {
   return ["1", "true", "yes", "on"].includes(value);
 }
 
+/**
+ * Optional override for the no-auth-lockdown private-network exemption list.
+ * Comma-separated IPs / CIDRs. When set, REPLACES the built-in defaults
+ * (RFC 1918, CGNAT, link-local, IPv6 ULA). When unset, defaults are used.
+ */
+export function getTrustedPrivateNetworksOverride() {
+  return normalizeEnvValue(process.env.TRUSTED_PRIVATE_NETWORKS);
+}
+
 export function isDebugAgentsEnabled() {
   const value = normalizeEnvValue(process.env.DEBUG_AGENTS);
   return value === "1" || value?.toLowerCase() === "true";

--- a/packages/server/src/middleware/basic-auth.ts
+++ b/packages/server/src/middleware/basic-auth.ts
@@ -4,11 +4,20 @@
 // Set BASIC_AUTH_USER and BASIC_AUTH_PASS to enable HTTP Basic Authentication
 // on every request from non-loopback, non-allowlisted IPs.
 //
-// When credentials are NOT configured, this middleware refuses remote
-// connections by default (returns 403). This protects users who accidentally
-// expose the port to the public internet without setting up a password.
-// To opt back into the legacy "anyone can connect" behaviour, set
-// ALLOW_UNAUTHENTICATED_REMOTE=true.
+// When credentials are NOT configured, this middleware refuses connections
+// from PUBLIC internet IPs (returns 403). Loopback, private networks
+// (RFC 1918 LANs, Docker bridges, Kubernetes pod ranges, Tailscale CGNAT,
+// IPv6 ULA / link-local), and explicit IP_ALLOWLIST entries continue to
+// work without a password. This protects accidentally-exposed ports while
+// keeping LAN / phone / container access "just works" by default.
+//
+// Note: the private-network exemption applies ONLY when no Basic Auth is
+// configured. If you set BASIC_AUTH_USER/PASS, the password is required
+// from every IP except loopback and explicit IP_ALLOWLIST matches —
+// because if you went out of your way to set a password, you mean it.
+//
+// To opt back into the legacy "anyone can connect" behaviour from public
+// IPs too, set ALLOW_UNAUTHENTICATED_REMOTE=true.
 //
 // Optional:
 //   BASIC_AUTH_REALM            — string shown in the browser password prompt
@@ -31,7 +40,7 @@ import type { FastifyRequest, FastifyReply } from "fastify";
 import { timingSafeEqual } from "node:crypto";
 import { getBasicAuthConfig, isUnauthenticatedRemoteAllowed } from "../config/runtime-config.js";
 import { logger } from "../lib/logger.js";
-import { isInIpAllowlist, isLoopbackIp } from "./ip-allowlist.js";
+import { isInIpAllowlist, isLoopbackIp, isPrivateNetworkIp } from "./ip-allowlist.js";
 
 interface CachedConfig {
   user: string;
@@ -94,9 +103,10 @@ function sendLockdown(reply: FastifyReply) {
   reply.status(403).send({
     error: "Forbidden",
     message:
-      "Remote access is disabled because no authentication is configured. " +
+      "Public-internet access is disabled because no authentication is configured. " +
       "Set BASIC_AUTH_USER and BASIC_AUTH_PASS, add this IP to IP_ALLOWLIST, " +
-      "or set ALLOW_UNAUTHENTICATED_REMOTE=true to allow unauthenticated remote connections.",
+      "or set ALLOW_UNAUTHENTICATED_REMOTE=true to allow unauthenticated public access. " +
+      "(Loopback, LAN, Docker, Kubernetes, and Tailscale traffic is allowed automatically.)",
   });
 }
 
@@ -115,13 +125,17 @@ export function basicAuthHook(request: FastifyRequest, reply: FastifyReply, done
 
   const config = loadConfig();
 
-  // No credentials configured → safe-by-default lockdown for remote IPs.
-  // Opt out via ALLOW_UNAUTHENTICATED_REMOTE=true for legacy open-access behaviour.
+  // No credentials configured → safe-by-default lockdown for PUBLIC IPs only.
+  // Private networks (LAN, Docker bridge, Kubernetes pod, Tailscale CGNAT) pass
+  // through so the common "phone on Wi-Fi" / "container-to-container" cases
+  // keep working. Opt out via ALLOW_UNAUTHENTICATED_REMOTE=true to allow
+  // unauthenticated PUBLIC IPs too (legacy open-access behaviour).
   if (!config) {
+    if (isPrivateNetworkIp(ip)) return done();
     if (isUnauthenticatedRemoteAllowed()) return done();
     if (!lockdownAnnounced) {
       logger.warn(
-        `[basic-auth] Refused remote connection from ${ip}. No auth configured; set BASIC_AUTH_USER/BASIC_AUTH_PASS, IP_ALLOWLIST, or ALLOW_UNAUTHENTICATED_REMOTE=true.`,
+        `[basic-auth] Refused public-internet connection from ${ip}. No auth configured; set BASIC_AUTH_USER/BASIC_AUTH_PASS, add the IP to IP_ALLOWLIST, or set ALLOW_UNAUTHENTICATED_REMOTE=true.`,
       );
       lockdownAnnounced = true;
     }

--- a/packages/server/src/middleware/ip-allowlist.ts
+++ b/packages/server/src/middleware/ip-allowlist.ts
@@ -12,7 +12,7 @@
 // so you can never lock yourself out of local access.
 
 import type { FastifyRequest, FastifyReply } from "fastify";
-import { getIpAllowlist } from "../config/runtime-config.js";
+import { getIpAllowlist, getTrustedPrivateNetworksOverride } from "../config/runtime-config.js";
 import { logger } from "../lib/logger.js";
 
 // ── CIDR helpers ──
@@ -131,7 +131,12 @@ const LOOPBACK_CIDRS: CIDREntry[] = [parseCIDR("127.0.0.1")!, parseCIDR("::1")!]
 // Used by the safe-by-default Basic Auth lockdown to avoid breaking
 // LAN, Docker bridge, Kubernetes pod, and Tailscale traffic when no
 // auth is configured. Public IPs are NOT in this list.
-const PRIVATE_NETWORK_CIDRS: CIDREntry[] = [
+//
+// These are *defaults* — operators can override the entire list via the
+// TRUSTED_PRIVATE_NETWORKS env var (comma-separated IPs / CIDRs) to
+// strip ranges they consider untrusted (e.g. a publicly-routable
+// corporate /16) or to substitute their own list entirely.
+const DEFAULT_PRIVATE_NETWORK_CIDRS: CIDREntry[] = [
   parseCIDR("10.0.0.0/8")!, // RFC 1918
   parseCIDR("172.16.0.0/12")!, // RFC 1918 (covers Docker default bridge 172.17.0.0/16)
   parseCIDR("192.168.0.0/16")!, // RFC 1918
@@ -140,6 +145,39 @@ const PRIVATE_NETWORK_CIDRS: CIDREntry[] = [
   parseCIDR("fc00::/7")!, // RFC 4193 unique local (IPv6 ULA)
   parseCIDR("fe80::/10")!, // RFC 4291 IPv6 link-local
 ];
+
+let cachedPrivateNetworks: { raw: string | null; entries: CIDREntry[]; announced: boolean } | null = null;
+
+function getPrivateNetworkCidrs(): CIDREntry[] {
+  const raw = getTrustedPrivateNetworksOverride();
+  if (!cachedPrivateNetworks || cachedPrivateNetworks.raw !== raw) {
+    if (!raw) {
+      cachedPrivateNetworks = { raw: null, entries: DEFAULT_PRIVATE_NETWORK_CIDRS, announced: true };
+    } else {
+      const entries: CIDREntry[] = [];
+      for (const part of raw.split(",")) {
+        const trimmed = part.trim();
+        if (!trimmed) continue;
+        const cidr = parseCIDR(trimmed);
+        if (!cidr) {
+          logger.warn(`[trusted-private-networks] Ignoring invalid entry: "${trimmed}"`);
+          continue;
+        }
+        entries.push(cidr);
+      }
+      cachedPrivateNetworks = { raw, entries, announced: false };
+    }
+  }
+
+  if (cachedPrivateNetworks.raw && !cachedPrivateNetworks.announced) {
+    logger.info(
+      `[trusted-private-networks] Overriding default private-network list with: ${cachedPrivateNetworks.raw}`,
+    );
+    cachedPrivateNetworks.announced = true;
+  }
+
+  return cachedPrivateNetworks.entries;
+}
 
 // ── Build allowlist on startup ──
 
@@ -199,13 +237,14 @@ export function isLoopbackIp(ip: string): boolean {
 }
 
 /**
- * True if the given IP belongs to a private / non-routable range
- * (RFC 1918, CGNAT, IPv6 ULA, link-local). Public internet IPs return false.
+ * True if the given IP belongs to a trusted private / non-routable range.
+ * Defaults to RFC 1918, CGNAT, link-local, and IPv6 ULA — but the operator
+ * can override the entire list via the TRUSTED_PRIVATE_NETWORKS env var.
  */
 export function isPrivateNetworkIp(ip: string): boolean {
   const bytes = ipToBytes(ip);
   if (!bytes) return false;
-  for (const cidr of PRIVATE_NETWORK_CIDRS) {
+  for (const cidr of getPrivateNetworkCidrs()) {
     if (matchesCIDR(bytes, cidr)) return true;
   }
   return false;

--- a/packages/server/src/middleware/ip-allowlist.ts
+++ b/packages/server/src/middleware/ip-allowlist.ts
@@ -127,6 +127,20 @@ function matchesCIDR(ipBytes: number[], cidr: CIDREntry): boolean {
 // ── Loopback CIDRs (always allowed) ──
 const LOOPBACK_CIDRS: CIDREntry[] = [parseCIDR("127.0.0.1")!, parseCIDR("::1")!];
 
+// ── Private / non-routable network CIDRs ──
+// Used by the safe-by-default Basic Auth lockdown to avoid breaking
+// LAN, Docker bridge, Kubernetes pod, and Tailscale traffic when no
+// auth is configured. Public IPs are NOT in this list.
+const PRIVATE_NETWORK_CIDRS: CIDREntry[] = [
+  parseCIDR("10.0.0.0/8")!, // RFC 1918
+  parseCIDR("172.16.0.0/12")!, // RFC 1918 (covers Docker default bridge 172.17.0.0/16)
+  parseCIDR("192.168.0.0/16")!, // RFC 1918
+  parseCIDR("169.254.0.0/16")!, // RFC 3927 link-local
+  parseCIDR("100.64.0.0/10")!, // RFC 6598 CGNAT (Tailscale, carrier NAT)
+  parseCIDR("fc00::/7")!, // RFC 4193 unique local (IPv6 ULA)
+  parseCIDR("fe80::/10")!, // RFC 4291 IPv6 link-local
+];
+
 // ── Build allowlist on startup ──
 
 function buildAllowlist(raw: string | null): CIDREntry[] | null {
@@ -180,6 +194,19 @@ export function isLoopbackIp(ip: string): boolean {
   if (!bytes) return false;
   for (const lb of LOOPBACK_CIDRS) {
     if (matchesCIDR(bytes, lb)) return true;
+  }
+  return false;
+}
+
+/**
+ * True if the given IP belongs to a private / non-routable range
+ * (RFC 1918, CGNAT, IPv6 ULA, link-local). Public internet IPs return false.
+ */
+export function isPrivateNetworkIp(ip: string): boolean {
+  const bytes = ipToBytes(ip);
+  if (!bytes) return false;
+  for (const cidr of PRIVATE_NETWORK_CIDRS) {
+    if (matchesCIDR(bytes, cidr)) return true;
   }
   return false;
 }


### PR DESCRIPTION
## Summary

Follow-up to #343. The safe-by-default lockdown shipped in that PR blocks **all** non-loopback / non-allowlisted IPs when no Basic Auth is configured — which protects accidentally-exposed public ports, but also breaks legitimate LAN, Docker, Kubernetes, and Tailscale users who were never the target of the lockdown.

This PR narrows the lockdown so it blocks **only public-internet IPs**. Private networks pass through automatically when no auth is configured:

- Loopback (`127.0.0.1`, `::1`) — already allowed.
- RFC 1918: `10.0.0.0/8`, `172.16.0.0/12` (covers Docker default bridge `172.17.0.0/16`), `192.168.0.0/16`.
- Link-local: `169.254.0.0/16`, `fe80::/10`.
- IPv6 ULA: `fc00::/7`.
- CGNAT: `100.64.0.0/10` (Tailscale, carrier NAT).
- Explicit `IP_ALLOWLIST` entries — already allowed.

These seven ranges are **defaults, not hardcoded** — operators can override the entire list via `TRUSTED_PRIVATE_NETWORKS` (see below).

## Why

Discord feedback after #343 merged: a Docker user reported a 403 from a container on the same bridge network, and reasonably called it a breaking change. Same problem applies to anyone reaching Marinara from their phone on the LAN, from a Kubernetes pod, from a reverse proxy in another container, or from a Tailscale peer. None of those callers were the threat model of the lockdown — the threat model is "port 7860 got NAT'd onto the public internet by accident."

By restricting the lockdown to public IPs, the safety win is preserved (public exposure is still safe) without breaking any of the "I just want to use it from my phone" workflows that have always worked.

## Principle of least surprise

The private-network exemption applies **only** to the no-auth lockdown. If the operator sets `BASIC_AUTH_USER`/`BASIC_AUTH_PASS`, the password is required from every IP except loopback and explicit `IP_ALLOWLIST` matches — including from the LAN. Reasoning: if you went out of your way to set a password, you meant it; the LAN-bypass would be a surprising security regression for someone trying to lock out a roommate on the same Wi-Fi.

## New env var: `TRUSTED_PRIVATE_NETWORKS`

The seven default ranges cover the vast majority of LAN / Docker / Kubernetes / Tailscale setups. For operators whose network doesn't match — e.g. a publicly-routable corporate `/16` they trust, or a shared `10/8` in a hostile datacenter they don't — `TRUSTED_PRIVATE_NETWORKS` accepts a comma-separated list of IPs / CIDRs that **replaces** the defaults entirely (matches `IP_ALLOWLIST` semantics — what you type is what you get):

```
# Strip 10.0.0.0/8 from the defaults but keep the rest
TRUSTED_PRIVATE_NETWORKS=172.16.0.0/12,192.168.0.0/16,169.254.0.0/16,100.64.0.0/10,fc00::/7,fe80::/10

# Trust only my office subnet
TRUSTED_PRIVATE_NETWORKS=10.42.0.0/16
```

When unset, the defaults are used. Invalid entries are logged with a warn and skipped.

## Behaviour matrix
<img width="1090" height="834" alt="image" src="https://github.com/user-attachments/assets/93221fe9-0214-4964-88fd-ddf2b2526a3a" />

## Files

- `packages/server/src/middleware/ip-allowlist.ts` — adds `DEFAULT_PRIVATE_NETWORK_CIDRS`, a cached resolver that respects the override, and an exported `isPrivateNetworkIp(ip)` helper. Existing IP allowlist hook is unchanged.
- `packages/server/src/middleware/basic-auth.ts` — lockdown branch now calls `isPrivateNetworkIp(ip)` before refusing. Updated docblock, lockdown 403 message, and warn-once log to reflect "public-only" semantics.
- `packages/server/src/config/runtime-config.ts` — adds `getTrustedPrivateNetworksOverride()`.
- `docs/CONFIGURATION.md` — rewrites the "Safe-by-default lockdown" section to list the auto-allowed ranges, clarifies that the exemption only applies in no-auth mode, and documents `TRUSTED_PRIVATE_NETWORKS`.
- `.env.example` — adds `TRUSTED_PRIVATE_NETWORKS` example.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TRUSTED_PRIVATE_NETWORKS env var to override the built-in private-network allowlist.
  * Safe-by-default lockdown now treats only public-internet IPs as blocked when no Basic Auth is configured; private-network contexts remain allowed.

* **Documentation**
  * Expanded docs and example env comments clarifying automatic exemptions (loopback, RFC1918, link-local, CGNAT, container/k8s/tailscale), the scope of ALLOW_UNAUTHENTICATED_REMOTE, and how TRUSTED_PRIVATE_NETWORKS replaces defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->