### PR TITLE
feat(bot-browser): enable DataCat text search

### DIFF
--- a/packages/client/src/components/bot-browser/BotBrowserView.tsx
+++ b/packages/client/src/components/bot-browser/BotBrowserView.tsx
@@ -1067,11 +1067,13 @@ const datacatProvider: ProviderConfig = {
   search: async (p) => {
     await loadDatacatTags();
     const tagIds = p.includeTags.length > 0 ? datacatTagNamesToIds(p.includeTags) : [];
+    const trimmedQuery = p.query.trim();
 
-    // Fresh = trending, Relevance = recent-public (which is the "Characters" tab on
-    // datacat.run — supports tag filtering and shows the full library). DataCat
-    // has no free-text search endpoint, so `p.query` is ignored for this provider.
-    const useFresh = p.sort === "fresh" && tagIds.length === 0;
+    // Fresh = trending (24h window), Relevance = recent-public (the "Characters"
+    // tab on datacat.run — supports tag filtering, free-text search via the
+    // `search` param, and shows the full library). The /fresh endpoint has no
+    // text-search support, so any user query forces the recent-public path.
+    const useFresh = p.sort === "fresh" && tagIds.length === 0 && trimmedQuery.length === 0;
 
     let list: any[] = [];
     let totalCount = 0;
@@ -1098,17 +1100,13 @@ const datacatProvider: ProviderConfig = {
       const offset = Math.max(0, (p.page - 1) * 80);
       const params = new URLSearchParams({ limit: "80", offset: String(offset) });
       if (tagIds.length > 0) params.set("tagIds", tagIds.join(","));
+      if (trimmedQuery) params.set("q", trimmedQuery);
       const res = await fetch(`/api/bot-browser/datacat/recent?${params}`);
       if (!res.ok) throw new Error("Search failed");
       const data = await res.json();
       list = data?.characters || [];
       totalCount = data?.totalCount || list.length;
     }
-
-    // No client-side query filter for DataCat: upstream has no full-text search
-    // endpoint, and filtering only the current 80-row page would be misleading
-    // (a character on page 2 would still show "no results" on page 1). The UI
-    // disables the search input for this provider — see the search input render.
 
     // DataCat is NSFW-only — every character is tagged NSFW upstream, so filtering
     // by nsfw=false would always return an empty list. Skip the filter entirely.
@@ -1902,22 +1900,12 @@ export function BotBrowserView() {
                   />
                   <input
                     type="text"
-                    value={sourceId === "datacat" ? "" : query}
+                    value={query}
                     onChange={(e) => {
                       setQuery(e.target.value);
                       setPage(1);
                     }}
-                    disabled={sourceId === "datacat"}
-                    placeholder={
-                      sourceId === "datacat"
-                        ? "DataCat doesn't support text search — filter by tag instead"
-                        : "Search characters..."
-                    }
-                    title={
-                      sourceId === "datacat"
-                        ? "DataCat has no full-text search endpoint. Use tags to narrow results."
-                        : undefined
-                    }
+                    placeholder="Search characters..."
                     className="w-full rounded-lg border border-[var(--border)] bg-[var(--secondary)] py-2 pl-9 pr-8 text-sm text-[var(--foreground)] placeholder-[var(--muted-foreground)] outline-none transition-colors focus:border-[var(--primary)] disabled:cursor-not-allowed disabled:opacity-60"
                   />
                   {query && (

--- a/packages/server/src/routes/bot-browser-datacat.routes.ts
+++ b/packages/server/src/routes/bot-browser-datacat.routes.ts
@@ -102,16 +102,20 @@ async function dcFetch(path: string): Promise<unknown> {
 }
 
 export async function botBrowserDatacatRoutes(app: FastifyInstance) {
-  // ── Recent public browse / tag-filtered browse ──
+  // ── Recent public browse / tag-filtered browse / text search ──
+  // Upstream `/api/characters/recent-public` accepts an optional `search` query
+  // param that does substring matching across the character library; pass it
+  // through when present so the client can run free-text searches.
   app.get<{
     Querystring: {
       limit?: string;
       offset?: string;
       min_tokens?: string;
       tagIds?: string;
+      q?: string;
     };
   }>("/datacat/recent", async (req) => {
-    const { limit = "80", offset = "0", min_tokens = String(DEFAULT_MIN_TOTAL_TOKENS), tagIds } = req.query;
+    const { limit = "80", offset = "0", min_tokens = String(DEFAULT_MIN_TOTAL_TOKENS), tagIds, q } = req.query;
     const params = new URLSearchParams();
     params.set("limit", limit);
     params.set("offset", offset);
@@ -124,6 +128,8 @@ export async function botBrowserDatacatRoutes(app: FastifyInstance) {
         .filter(Boolean);
       if (ids.length > 0) params.set("tagIds", ids.join(","));
     }
+    const trimmed = q?.trim();
+    if (trimmed) params.set("search", trimmed);
     return dcFetch(`/api/characters/recent-public?${params}`);
   });
 


### PR DESCRIPTION
## Summary

- DataCat's `/api/characters/recent-public` upstream does support free-text filtering via a `search=<text>` query param — the previous integration assumed it didn't and disabled the search input on this provider. Verified directly: `?search=anime` returns 159 results, `?search=elf` returns 472, `?search=samurai` returns 25, all vs. the unfiltered 84,339, and it composes cleanly with `tagIds` + pagination.
- Server `/datacat/recent` now accepts an optional `q` query param and forwards it as `search` to upstream.
- Client `datacatProvider.search` forwards `p.query` to the backend and forces the `recent-public` path whenever a query is present (the `/fresh` endpoint has no search support).
- Removed the `disabled` state, custom placeholder, and tooltip on the toolbar search input for DataCat — it now behaves like every other provider.

## Test plan

- [x] Manually verify in browser: switch to DataCat, type "samurai" in search, confirm result count narrows to ~25 and entries are samurai-themed
- [x] Manually verify combined filtering: type a query and select a tag — both should narrow results together
- [x] Manually verify pagination: search for a common term ("elf"), confirm page 2 returns different characters than page 1
- [x] Manually verify clearing the query restores the full library view
- [x] Manually verify Fresh sort still works when no query is entered (24h trending window)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * DataCat now supports free-text search in the recent section, allowing users to search for characters by entering text queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->