### PR TITLE
feat(chat-presets): star icon to mark default preset for new chats

### DIFF
--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -43,6 +43,7 @@ import {
   FilePlus2,
   Upload,
   Download,
+  Star,
 } from "lucide-react";
 import { cn, getAvatarCropStyle, type AvatarCrop } from "../../lib/utils";
 import { showAlertDialog, showConfirmDialog, showPromptDialog } from "../../lib/app-dialogs";
@@ -86,6 +87,7 @@ import {
   useDeleteChatPreset,
   useApplyChatPreset,
   useImportChatPreset,
+  useSetActiveChatPreset,
 } from "../../hooks/use-chat-presets";
 import type { AgentPhase, ChatMode, ChatMemoryChunk, ChatPreset, ChatPresetSettings } from "@marinara-engine/shared";
 import { useAgentConfigs, useCreateAgent, useUpdateAgent, type AgentConfigRow } from "../../hooks/use-agents";
@@ -708,6 +710,7 @@ export function ChatSettingsDrawer({
   const deleteChatPreset = useDeleteChatPreset();
   const applyChatPreset = useApplyChatPreset();
   const importChatPreset = useImportChatPreset();
+  const setActiveChatPreset = useSetActiveChatPreset();
   const presetList = useMemo(() => (chatPresets ?? []) as ChatPreset[], [chatPresets]);
   const appliedPresetId = (metadata.appliedChatPresetId as string | undefined) ?? null;
   const selectedChatPreset = useMemo(() => {
@@ -808,6 +811,11 @@ export function ChatSettingsDrawer({
   const handleSelectPreset = (id: string) => {
     if (!id || id === selectedChatPreset?.id) return;
     applyChatPreset.mutate({ presetId: id, chatId: chat.id });
+  };
+
+  const handleToggleDefaultPreset = () => {
+    if (!selectedChatPreset || selectedChatPreset.isActive) return;
+    setActiveChatPreset.mutate(selectedChatPreset.id);
   };
 
   const handleSaveIntoPreset = () => {
@@ -1028,12 +1036,37 @@ export function ChatSettingsDrawer({
                   ))}
                 </select>
               )}
+              <button
+                onClick={handleToggleDefaultPreset}
+                disabled={!selectedChatPreset || selectedChatPreset.isActive || setActiveChatPreset.isPending}
+                title={
+                  !selectedChatPreset
+                    ? "Select a preset to mark it as default"
+                    : selectedChatPreset.isActive
+                      ? "This preset is the default for new chats in this mode"
+                      : "Mark this preset as default for new chats in this mode"
+                }
+                aria-pressed={!!selectedChatPreset?.isActive}
+                aria-label={selectedChatPreset?.isActive ? "Default preset" : "Mark as default preset"}
+                className={cn(
+                  "shrink-0 flex items-center justify-center rounded-md p-1.5 transition-colors disabled:cursor-not-allowed",
+                  selectedChatPreset?.isActive
+                    ? "text-yellow-400 disabled:opacity-100"
+                    : "text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-yellow-400 disabled:opacity-40",
+                )}
+              >
+                <Star
+                  size="0.875rem"
+                  fill={selectedChatPreset?.isActive ? "currentColor" : "none"}
+                  strokeWidth={selectedChatPreset?.isActive ? 1.5 : 2}
+                />
+              </button>
               <HelpTooltip
                 side="left"
                 text={
                   isConversation
-                    ? "Presets bundle this chat's connection, tools, translation, memory recall, advanced parameters, and other settings. Prompt presets are not applied in conversation mode. Characters, persona, lorebooks, sprites, summary, tags, and scene prompt stay tied to the chat."
-                    : "Presets bundle this chat's connection, prompt preset, agents, tools, translation, memory recall, advanced parameters, and other settings. They never touch your characters, persona, lorebooks, sprites, summary, tags, or scene prompt — those stay tied to the chat."
+                    ? "Presets bundle this chat's connection, tools, translation, memory recall, advanced parameters, and other settings. Prompt presets are not applied in conversation mode. Characters, persona, lorebooks, sprites, summary, tags, and scene prompt stay tied to the chat. Star a preset to use it as the default for new chats in this mode."
+                    : "Presets bundle this chat's connection, prompt preset, agents, tools, translation, memory recall, advanced parameters, and other settings. They never touch your characters, persona, lorebooks, sprites, summary, tags, or scene prompt — those stay tied to the chat. Star a preset to use it as the default for new chats in this mode."
                 }
               />
             </div>

--- a/packages/client/src/components/chat/ChatSetupWizard.tsx
+++ b/packages/client/src/components/chat/ChatSetupWizard.tsx
@@ -1035,12 +1035,20 @@ function RoleplaySetupWizard({ chat, onFinish }: ChatSetupWizardProps) {
     [chat.id, activeLorebookIds, updateMeta],
   );
 
-  // Default the shortcut dropdown to the Default preset once presets load
+  // Default the shortcut dropdown once presets load. Prefer (in order):
+  //  1) the preset already applied to this chat,
+  //  2) the user's starred / active preset for the mode,
+  //  3) the built-in Default preset.
   useEffect(() => {
     if (shortcutPresetId) return;
-    const def = chatPresetList.find((p) => p.isDefault);
-    if (def) setShortcutPresetId(def.id);
-  }, [chatPresetList, shortcutPresetId]);
+    if (chatPresetList.length === 0) return;
+    const appliedId = (metadata.appliedChatPresetId as string | undefined) ?? null;
+    const applied = appliedId ? chatPresetList.find((p) => p.id === appliedId) : null;
+    const starred = chatPresetList.find((p) => p.isActive);
+    const fallback = chatPresetList.find((p) => p.isDefault);
+    const pick = applied ?? starred ?? fallback;
+    if (pick) setShortcutPresetId(pick.id);
+  }, [chatPresetList, shortcutPresetId, metadata.appliedChatPresetId]);
 
   const [shortcutApplying, setShortcutApplying] = useState(false);
 

--- a/packages/client/src/components/chat/NewChatConnectionGate.tsx
+++ b/packages/client/src/components/chat/NewChatConnectionGate.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Loader2, MessageCircle, Plug, X, BookOpen } from "lucide-react";
 import { useConnections } from "../../hooks/use-connections";
 import { useCreateChat } from "../../hooks/use-chats";
+import { useChatPresets, useApplyChatPreset } from "../../hooks/use-chat-presets";
 import { useChatStore } from "../../stores/chat.store";
 import { useUIStore } from "../../stores/ui.store";
 import { cn } from "../../lib/utils";
@@ -22,6 +23,8 @@ interface NewChatConnectionGateProps {
 export function NewChatConnectionGate({ mode, onClose }: NewChatConnectionGateProps) {
   const { data: connections, isLoading } = useConnections();
   const createChat = useCreateChat();
+  const { data: chatPresetsData } = useChatPresets();
+  const applyChatPreset = useApplyChatPreset();
   const openRightPanel = useUIStore((s) => s.openRightPanel);
   const [connectionId, setConnectionId] = useState<string>("");
 
@@ -38,6 +41,11 @@ export function NewChatConnectionGate({ mode, onClose }: NewChatConnectionGatePr
   const handleCreate = () => {
     if (!connectionId) return;
     const label = MODE_META[mode].label;
+    const presets = chatPresetsData ?? [];
+    const presetMode = mode === "conversation" || mode === "roleplay" ? mode : null;
+    const starred = presetMode
+      ? (presets.find((p) => p.mode === presetMode && p.isActive && !p.isDefault) ?? null)
+      : null;
     createChat.mutate(
       {
         name: `New ${label}`,
@@ -46,10 +54,17 @@ export function NewChatConnectionGate({ mode, onClose }: NewChatConnectionGatePr
         connectionId,
       },
       {
-        onSuccess: (chat) => {
+        onSuccess: async (chat) => {
           const store = useChatStore.getState();
           store.setPendingNewChatMode(null);
           store.setActiveChatId(chat.id);
+          if (starred) {
+            try {
+              await applyChatPreset.mutateAsync({ presetId: starred.id, chatId: chat.id });
+            } catch {
+              /* non-fatal — chat still opens with system defaults */
+            }
+          }
           store.setShouldOpenSettings(true);
           store.setShouldOpenWizard(true);
         },

--- a/packages/client/src/components/layout/ChatSidebar.tsx
+++ b/packages/client/src/components/layout/ChatSidebar.tsx
@@ -27,6 +27,7 @@ import {
   Pencil,
 } from "lucide-react";
 import { useChats, useCreateChat, useDeleteChat, useDeleteChatGroup } from "../../hooks/use-chats";
+import { useChatPresets, useApplyChatPreset } from "../../hooks/use-chat-presets";
 import { useConnections } from "../../hooks/use-connections";
 import {
   useChatFolders,
@@ -112,6 +113,8 @@ export function ChatSidebar() {
   const { data: chats, isLoading } = useChats();
   const { data: connections } = useConnections();
   const createChat = useCreateChat();
+  const { data: chatPresetsData } = useChatPresets();
+  const applyChatPreset = useApplyChatPreset();
   const deleteChat = useDeleteChat();
   const deleteChatGroup = useDeleteChatGroup();
   const activeChatId = useChatStore((s) => s.activeChatId);
@@ -420,18 +423,40 @@ export function ChatSidebar() {
       if (hasAnyDetailOpen()) {
         closeAllDetails();
       }
+      // Resolve the user's starred default preset for this mode (only modes with presets).
+      const presets = chatPresetsData ?? [];
+      const presetMode: ChatMode | null = mode === "conversation" || mode === "roleplay" ? mode : null;
+      const starred = presetMode
+        ? (presets.find((p) => p.mode === presetMode && p.isActive && !p.isDefault) ?? null)
+        : null;
       createChat.mutate(
         { name: `New ${MODE_CONFIG[mode]?.label ?? mode}`, mode, characterIds: [] },
         {
-          onSuccess: (chat) => {
+          onSuccess: async (chat) => {
             setActiveChatId(chat.id);
+            if (starred) {
+              try {
+                await applyChatPreset.mutateAsync({ presetId: starred.id, chatId: chat.id });
+              } catch {
+                /* non-fatal — chat still opens with system defaults */
+              }
+            }
             useChatStore.getState().setShouldOpenSettings(true);
             useChatStore.getState().setShouldOpenWizard(true);
           },
         },
       );
     },
-    [connections, createChat, setActiveChatId, setPendingNewChatMode, hasAnyDetailOpen, closeAllDetails],
+    [
+      connections,
+      createChat,
+      setActiveChatId,
+      setPendingNewChatMode,
+      hasAnyDetailOpen,
+      closeAllDetails,
+      chatPresetsData,
+      applyChatPreset,
+    ],
   );
 
   const handleNewChatFromTab = useCallback(() => {

--- a/packages/client/src/components/panels/BotBrowserPanel.tsx
+++ b/packages/client/src/components/panels/BotBrowserPanel.tsx
@@ -5,6 +5,7 @@ import { useState, useMemo, useCallback } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCharacters } from "../../hooks/use-characters";
 import { useCreateChat, chatKeys } from "../../hooks/use-chats";
+import { useChatPresets, useApplyChatPreset } from "../../hooks/use-chat-presets";
 import { useUIStore } from "../../stores/ui.store";
 import { useChatStore } from "../../stores/chat.store";
 import { api } from "../../lib/api-client";
@@ -21,6 +22,8 @@ export function BotBrowserPanel() {
   const botBrowserOpen = useUIStore((s) => s.botBrowserOpen);
   const createChat = useCreateChat();
   const queryClient = useQueryClient();
+  const { data: chatPresetsData } = useChatPresets();
+  const applyChatPreset = useApplyChatPreset();
   const [search, setSearch] = useState("");
   const [contextMenu, setContextMenu] = useState<{
     x: number;
@@ -73,11 +76,24 @@ export function BotBrowserPanel() {
       altGreetings?: string[],
     ) => {
       const label = mode === "conversation" ? "Conversation" : "Roleplay";
+      // Resolve the user's starred default preset for this mode (if any other than the built-in Default).
+      const presets = chatPresetsData ?? [];
+      const presetMode = mode === "conversation" ? "conversation" : "roleplay";
+      const starred = presets.find((p) => p.mode === presetMode && p.isActive && !p.isDefault);
       createChat.mutate(
         { name: charName ? `${charName} — ${label}` : `New ${label}`, mode, characterIds: [charId] },
         {
           onSuccess: async (chat) => {
             useChatStore.getState().setActiveChatId(chat.id);
+            // Apply the user's starred default preset to the brand-new chat so its
+            // settings start where the user wants them.
+            if (starred) {
+              try {
+                await applyChatPreset.mutateAsync({ presetId: starred.id, chatId: chat.id });
+              } catch {
+                /* non-fatal — the chat still opens with system defaults */
+              }
+            }
             // Mirror the wizard's roleplay first-message behavior so the
             // character actually greets the user in the new chat.
             if (mode === "roleplay" && firstMes?.trim()) {
@@ -109,7 +125,7 @@ export function BotBrowserPanel() {
         },
       );
     },
-    [createChat, queryClient],
+    [createChat, queryClient, chatPresetsData, applyChatPreset],
   );
 
   return (

--- a/packages/client/src/components/panels/CharactersPanel.tsx
+++ b/packages/client/src/components/panels/CharactersPanel.tsx
@@ -14,6 +14,7 @@ import {
   useDuplicateCharacter,
 } from "../../hooks/use-characters";
 import { useUpdateChat, useCreateMessage, useCreateChat, chatKeys } from "../../hooks/use-chats";
+import { useChatPresets, useApplyChatPreset } from "../../hooks/use-chat-presets";
 import { api } from "../../lib/api-client";
 import { showConfirmDialog } from "../../lib/app-dialogs";
 import { useChatStore } from "../../stores/chat.store";
@@ -102,6 +103,8 @@ export function CharactersPanel() {
   const createMessage = useCreateMessage(activeChat?.id ?? null);
   const createChat = useCreateChat();
   const queryClient = useQueryClient();
+  const { data: chatPresetsData } = useChatPresets();
+  const applyChatPreset = useApplyChatPreset();
   const [contextMenu, setContextMenu] = useState<{
     x: number;
     y: number;
@@ -120,11 +123,24 @@ export function CharactersPanel() {
       altGreetings?: string[],
     ) => {
       const label = mode === "conversation" ? "Conversation" : "Roleplay";
+      // Resolve the user's starred default preset for this mode (skip the built-in Default — it's a no-op).
+      const presets = chatPresetsData ?? [];
+      const presetMode = mode === "conversation" ? "conversation" : "roleplay";
+      const starred = presets.find((p) => p.mode === presetMode && p.isActive && !p.isDefault);
       createChat.mutate(
         { name: charName ? `${charName} — ${label}` : `New ${label}`, mode, characterIds: [charId] },
         {
           onSuccess: async (chat) => {
             useChatStore.getState().setActiveChatId(chat.id);
+            // Apply the user's starred default preset to the new chat so its
+            // settings start where they want them.
+            if (starred) {
+              try {
+                await applyChatPreset.mutateAsync({ presetId: starred.id, chatId: chat.id });
+              } catch {
+                /* non-fatal — chat still opens with system defaults */
+              }
+            }
             // Mirror the wizard's roleplay first-message behavior — without this,
             // a quick-started roleplay would open with no greeting from the character.
             if (mode === "roleplay" && firstMes?.trim()) {
@@ -156,7 +172,7 @@ export function CharactersPanel() {
         },
       );
     },
-    [createChat, queryClient],
+    [createChat, queryClient, chatPresetsData, applyChatPreset],
   );
 
   const [search, setSearch] = useState("");


### PR DESCRIPTION
## Summary
- Adds a yellow star toggle in the Chat Settings drawer (between the preset dropdown and the help icon) that marks the selected chat-settings preset as the default for new chats of its mode. Filled when active, outline when not, disabled when already active.
- New chats created via the sidebar `+` button, the right-click "Quick Start Roleplay/Conversation" menus in both the Characters panel and the Bot Browser, and the new-chat connection gate now auto-apply the user's starred preset on creation.
- The roleplay wizard's "Use Settings Presets" shortcut now pre-selects the chat's already-applied preset → starred preset → built-in Default (instead of always defaulting to the built-in Default).

## Why
Users with a customized chat-settings preset previously had to manually open Chat Settings and pick it for every new chat. Marking one preset as the per-mode default makes new chats start where the user actually wants them.

## Notes
- No DB / shared schema / server changes. The `isActive` flag on `ChatPreset`, the `setActive` storage method, the `useSetActiveChatPreset` hook, and the `POST /chat-presets/:id/set-active` route already existed but had no UI affordance — this wires them up.
- Built-in Default presets are skipped when applying on creation (applying them is a no-op), saving a round-trip in the common case.
- No issue is currently linked; one should be opened before merging.

## Manual verification
- [x] Open Chat Settings on a roleplay chat: star button appears next to the dropdown and toggles correctly between filled/outline state.
- [x] Star a non-default preset, then open Chat Settings on a different chat in the same mode: the star is on the same preset.
- [x] Right-click a character in the Characters panel → Quick Start Roleplay: new chat opens with the starred preset's settings applied.
- [x] Same via the Bot Browser panel for both Quick Start Roleplay and Quick Start Conversation.
- [x] Click `+` in the chat sidebar for both roleplay and conversation modes: new chat opens with the starred preset applied.
- [x] In the roleplay setup wizard, click "Use Settings Presets": the dropdown is pre-selected to the starred preset.
- [x] Mobile view: star button doesn't break the dropdown row layout or escape any boundaries.
- [x] Visual novel mode shares roleplay presets — verify the star/auto-apply still behaves correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to mark chat presets as default for new chats in your current mode.
  * New chats now automatically apply your starred preset settings when created in conversation or roleplay mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->