### PR TITLE
feat: CYOA reroll + chat-scoped choices

### DIFF
--- a/packages/client/src/components/chat/CyoaChoices.tsx
+++ b/packages/client/src/components/chat/CyoaChoices.tsx
@@ -1,8 +1,8 @@
 // ──────────────────────────────────────────────
 // CYOA Choices — interactive choice buttons after assistant messages
 // ──────────────────────────────────────────────
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { Check, Loader2, Pencil, Sparkles, X } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Check, Dices, Loader2, Pencil, Sparkles, X } from "lucide-react";
 import { useUpdateMessageExtra } from "../../hooks/use-chats";
 import { useAgentStore } from "../../stores/agent.store";
 import { useGenerate } from "../../hooks/use-generate";
@@ -31,12 +31,14 @@ export function CyoaChoices({ messages }: Props) {
   const choices = useAgentStore((s) => s.cyoaChoices);
   const setCyoaChoices = useAgentStore((s) => s.setCyoaChoices);
   const clearCyoaChoices = useAgentStore((s) => s.clearCyoaChoices);
-  const { generate } = useGenerate();
+  const { generate, retryAgents } = useGenerate();
   const activeChatId = useChatStore((s) => s.activeChatId);
   const isStreaming = useChatStore((s) => s.isStreaming);
   const updateMessageExtra = useUpdateMessageExtra(activeChatId);
   const [isEditing, setIsEditing] = useState(false);
+  const [isRerolling, setIsRerolling] = useState(false);
   const [draftChoices, setDraftChoices] = useState<CyoaChoice[]>([]);
+  const hydratedChatIdRef = useRef<string | null>(null);
 
   // Hydrate CYOA choices from the last assistant message's extras on mount / chat switch
   const persistedChoiceState = useMemo(() => {
@@ -54,9 +56,41 @@ export function CyoaChoices({ messages }: Props) {
   }, [messages]);
 
   useEffect(() => {
-    if (choices.length > 0 || isStreaming || !persistedChoiceState?.choices) return;
-    setCyoaChoices(persistedChoiceState.choices);
-  }, [persistedChoiceState, choices.length, isStreaming, setCyoaChoices]);
+    if (!activeChatId) {
+      hydratedChatIdRef.current = null;
+      setIsEditing(false);
+      setDraftChoices([]);
+      clearCyoaChoices();
+      return;
+    }
+
+    if (hydratedChatIdRef.current === activeChatId) return;
+
+    setIsEditing(false);
+    setDraftChoices([]);
+
+    // Wait until the messages query has produced a value for this chat; otherwise
+    // we would mark hydrated too early and skip re-running when extras arrive.
+    if (messages === undefined) {
+      clearCyoaChoices();
+      return;
+    }
+
+    // On chat switch, clear any previous chat's choices and hydrate from the
+    // new chat's last assistant extra (if present).
+    if (isStreaming) {
+      clearCyoaChoices();
+      return;
+    }
+
+    if (persistedChoiceState?.choices?.length) {
+      setCyoaChoices(persistedChoiceState.choices);
+    } else {
+      clearCyoaChoices();
+    }
+
+    hydratedChatIdRef.current = activeChatId;
+  }, [activeChatId, clearCyoaChoices, isStreaming, messages, persistedChoiceState, setCyoaChoices]);
 
   const handleChoice = useCallback(
     async (text: string) => {
@@ -70,6 +104,19 @@ export function CyoaChoices({ messages }: Props) {
     },
     [activeChatId, isStreaming, isEditing, clearCyoaChoices, generate],
   );
+
+  const handleReroll = useCallback(async () => {
+    if (!activeChatId || isStreaming || isEditing || isRerolling) return;
+    setIsRerolling(true);
+    try {
+      // Re-runs ONLY the CYOA agent with fresh context (latest messages + last
+      // assistant's extras). The retry route persists the new choices to the
+      // message's extra and the SSE handler swaps them into the store.
+      await retryAgents(activeChatId, ["cyoa"]);
+    } finally {
+      setIsRerolling(false);
+    }
+  }, [activeChatId, isStreaming, isEditing, retryAgents]);
 
   const handleStartEdit = useCallback(() => {
     setDraftChoices(choices.map((choice) => ({ ...choice })));
@@ -115,12 +162,24 @@ export function CyoaChoices({ messages }: Props) {
         <button
           type="button"
           onClick={isEditing ? handleCancelEdit : handleStartEdit}
-          disabled={isStreaming || updateMessageExtra.isPending}
+          disabled={isStreaming || isRerolling || updateMessageExtra.isPending}
           className="inline-flex items-center gap-1 rounded-full border border-[var(--border)] bg-[var(--muted)]/20 px-2 py-1 text-[0.5625rem] text-[var(--foreground)]/60 transition-all hover:border-[var(--border)] hover:bg-[var(--muted)]/40 hover:text-[var(--foreground)] disabled:cursor-not-allowed disabled:opacity-40 dark:border-white/10 dark:bg-black/35 dark:text-white/50 dark:hover:bg-white/10 dark:hover:text-white/80"
           title={isEditing ? "Cancel editing choices" : "Edit CYOA choices"}
         >
           <Pencil size="0.625rem" />
           <span>{isEditing ? "Cancel" : "Edit"}</span>
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            void handleReroll();
+          }}
+          disabled={isStreaming || isEditing || isRerolling || updateMessageExtra.isPending}
+          className="inline-flex items-center gap-1 rounded-full border border-[var(--border)] bg-[var(--muted)]/20 px-2 py-1 text-[0.5625rem] text-[var(--foreground)]/60 transition-all hover:border-[var(--border)] hover:bg-[var(--muted)]/40 hover:text-[var(--foreground)] disabled:cursor-not-allowed disabled:opacity-40 dark:border-white/10 dark:bg-black/35 dark:text-white/50 dark:hover:bg-white/10 dark:hover:text-white/80"
+          title="Re-roll CYOA choices using the latest chat context"
+        >
+          {isRerolling ? <Loader2 size="0.625rem" className="animate-spin" /> : <Dices size="0.625rem" />}
+          <span>{isRerolling ? "Rolling" : "Re-roll"}</span>
         </button>
       </div>
       {isEditing ? (
@@ -180,7 +239,7 @@ export function CyoaChoices({ messages }: Props) {
               key={i}
               type="button"
               onClick={() => handleChoice(choice.text)}
-              disabled={isStreaming}
+              disabled={isStreaming || isRerolling}
               className="group relative rounded-xl border border-[var(--border)] bg-[var(--card)]/80 px-4 py-2.5 text-left backdrop-blur-md transition-all hover:border-purple-400/40 hover:bg-purple-500/10 hover:shadow-lg hover:shadow-purple-500/5 active:scale-[0.98] disabled:opacity-50 dark:border-white/10 dark:bg-black/50"
             >
               <span className="block text-[0.6875rem] font-semibold text-purple-700 group-hover:text-purple-600 dark:text-purple-300/90 dark:group-hover:text-purple-200">

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -1527,6 +1527,13 @@ export function useGenerate() {
                   const reactions = (d.reactions as Array<{ characterName: string; reaction: string }>) ?? [];
                   for (const r of reactions) addEchoMessage(r.characterName, r.reaction);
                 }
+                // CYOA re-roll: push the freshly generated choices into the store
+                // so the buttons in CyoaChoices.tsx swap in immediately.
+                if (result.agentType === "cyoa") {
+                  const d = result.data as Record<string, unknown>;
+                  const choices = (d.choices as Array<{ label: string; text: string }>) ?? [];
+                  if (choices.length > 0 && isActiveChat()) setCyoaChoices(choices);
+                }
                 if (result.resultType === "background_change") {
                   const bg = result.data as { chosen?: string | null };
                   if (bg.chosen) {
@@ -1682,6 +1689,7 @@ export function useGenerate() {
       enqueuePendingCardUpdate,
       clearFailedAgentTypes,
       clearThoughtBubbles,
+      setCyoaChoices,
       setFailedAgentTypes,
       setProcessing,
       setGameState,

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -109,6 +109,7 @@ async function resolvePersonaContext(
 }
 
 async function buildRetryAgentContext(args: {
+  cyoaAgentWillRun: boolean;
   chatId: string;
   chat: any;
   chatMeta: Record<string, unknown>;
@@ -121,6 +122,7 @@ async function buildRetryAgentContext(args: {
   streaming: boolean;
 }) {
   const {
+    cyoaAgentWillRun,
     chatId,
     chat,
     chatMeta,
@@ -231,6 +233,16 @@ async function buildRetryAgentContext(args: {
   const latestGS = await gameStateStore.getLatestCommitted(chatId);
   if (latestGS) {
     agentContext.gameState = parseGameStateRow(latestGS as Record<string, unknown>);
+  }
+
+  // CYOA re-rolls: inject the previous choices so the agent generates a fresh,
+  // meaningfully different set instead of repeating the last batch. Mirrors
+  // the same injection in the main generate route.
+  if (cyoaAgentWillRun && lastAssistant) {
+    const lastExtra = parseExtra((lastAssistant as any).extra);
+    if (lastExtra.cyoaChoices) {
+      agentContext.memory._lastCyoaChoices = lastExtra.cyoaChoices;
+    }
   }
 
   return agentContext;
@@ -674,6 +686,38 @@ async function applyRetryResultEffects(args: {
       }
     }
 
+    // Persist re-rolled CYOA choices onto the last assistant message + active swipe
+    // so they survive a page refresh, and broadcast them to the client store.
+    if (result.success && result.type === "cyoa_choices" && result.data && typeof result.data === "object") {
+      try {
+        const cyoaData = result.data as { choices?: Array<{ label: string; text: string }> };
+        if (retryMessageId && cyoaData.choices && cyoaData.choices.length > 0) {
+          await chats.updateSwipeExtra(retryMessageId, retrySwipeIndex, { cyoaChoices: cyoaData.choices });
+          const msgRow = await chats.getMessage(retryMessageId);
+          if (msgRow && (msgRow.activeSwipeIndex ?? 0) === retrySwipeIndex) {
+            await chats.updateMessageExtra(retryMessageId, { cyoaChoices: cyoaData.choices });
+            logger.info(
+              "[retry-agents] CYOA choices persisted chatId=%s messageId=%s choiceCount=%d",
+              chatId,
+              retryMessageId,
+              cyoaData.choices.length,
+            );
+          } else {
+            logger.info(
+              "[retry-agents] CYOA choices persisted to swipe only (active swipe changed) chatId=%s messageId=%s retrySwipeIndex=%d activeSwipeIndex=%s choiceCount=%d",
+              chatId,
+              retryMessageId,
+              retrySwipeIndex,
+              msgRow?.activeSwipeIndex ?? "null",
+              cyoaData.choices.length,
+            );
+          }
+        }
+      } catch (err) {
+        logger.warn(err, "[retry-agents] CYOA choices persistence failed chatId=%s messageId=%s", chatId, retryMessageId);
+      }
+    }
+
     if (result.success && result.type === "custom_tracker_update" && result.data && typeof result.data === "object") {
       try {
         const ctData = result.data as Record<string, unknown>;
@@ -936,7 +980,9 @@ export async function registerRetryAgentsRoute(app: FastifyInstance) {
           conns,
           agentsStore,
         });
+        const cyoaAgentWillRun = resolvedAgents.some((e) => e.resolved.type === "cyoa");
         const agentContext = await buildRetryAgentContext({
+          cyoaAgentWillRun,
           chatId,
           chat,
           chatMeta,
@@ -952,6 +998,13 @@ export async function registerRetryAgentsRoute(app: FastifyInstance) {
         sendSseEvent(reply, { type: "agent_start", data: { phase: "retry" } });
         const lorebookKeeperAgent = resolvedAgents.find((entry) => entry.resolved.type === "lorebook-keeper") ?? null;
         const nonLorebookAgents = resolvedAgents.filter((entry) => entry.resolved.type !== "lorebook-keeper");
+        if (cyoaAgentWillRun) {
+          logger.info(
+            "[retry-agents] CYOA re-roll chatId=%s assistantMessageId=%s",
+            chatId,
+            lastAssistant?.id ?? "none",
+          );
+        }
         const results = nonLorebookAgents.length > 0 ? await executeRetryBatches(agentContext, nonLorebookAgents) : [];
         const lorebookKeeperRunEntries = lorebookKeeperAgent
           ? await executeLorebookKeeperRetries({
@@ -982,6 +1035,13 @@ export async function registerRetryAgentsRoute(app: FastifyInstance) {
               durationMs: result.durationMs,
             },
           });
+        }
+
+        if (cyoaAgentWillRun) {
+          const cyoaRetry = results.find((r) => r.agentType === "cyoa");
+          if (cyoaRetry && !cyoaRetry.success) {
+            logger.warn("[retry-agents] CYOA re-roll failed chatId=%s: %s", chatId, cyoaRetry.error ?? "unknown");
+          }
         }
 
         for (const entry of lorebookKeeperRunEntries) {


### PR DESCRIPTION
Add a CYOA reroll action and prevent stale CYOA choices from bleeding across chat switches.

## Linked issue

Closes #338

## Why this change

- Add an explicit “Re-roll” flow for CYOA choices so users can regenerate options using the latest chat context without sending a new message.

## What changed

- Added a “Re-roll” button to the CYOA choices UI that re-runs only the `cyoa` agent and swaps in the new choices.
- Updated the retry-agent SSE handler to apply `cyoa` results to the client CYOA store immediately.
- Updated the server retry-agents route to (a) include previous CYOA choices for anti-repetition and (b) persist re-rolled choices to message/swipe extras for refresh safety.

## Validation

- [X] `pnpm check` passes locally
- [X] Container (Docker / Podman) built and ran without issue
- [X] Ran the app, clicked through the changes manually
- [X] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [X] Above manual verification completed (describe below)
- [X] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Manual testing TODO:
  - [X] Built and ran app locally without issues.
  - [X] Opened a roleplay chat and enabled CYOA agent
  - After choices appeared, click **Re-roll** and confirmed:
    - [X] Spinner shows and choices disable while re-rolling
    - [X] New choices appear based on most recent assistant message context
    - [X] Refreshed the page and confirmed choices persist
    - [X] Regenerated assistant message and confirmed re-rolling choices use new assistant message's context.
    - [X] Checked light/dark mode and mobile viewport layout
    - [X] Swapped to different roleplay chat with CYOA enabled and confirmed choices stay within their respective chat

## Docs and release impact

- [X] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

<img width="377" height="57" alt="Screenshot 2026-05-02 150255" src="https://github.com/user-attachments/assets/164afdaa-2b5d-4879-a5b0-94dc070e22af" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Re-roll CYOA choices to generate alternative options during a conversation.
  * Retries immediately update choice buttons so new options appear without delay.

* **Bug Fixes / UX**
  * Prevents duplicate or stale CYOA choices when switching chats or during streaming.
  * UI disables edit controls, re-roll button, and individual choices while re-rolling or streaming.
  * Re-roll results are properly persisted and applied to the active message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->