### PR TITLE
feat: Enable Custom Chat Memory Agents

### DIFF
--- a/packages/client/src/components/agents/AgentEditor.tsx
+++ b/packages/client/src/components/agents/AgentEditor.tsx
@@ -28,6 +28,8 @@ import {
   Trash2,
   Layers,
   Music,
+  ChevronDown,
+  ChevronUp,
   ExternalLink,
   BookOpen,
   Upload,
@@ -42,6 +44,12 @@ import {
   useDeleteKnowledgeSource,
 } from "../../hooks/use-knowledge-sources";
 import { cn } from "../../lib/utils";
+import {
+  getAgentRunIntervalMeta,
+  getCadenceInputValue,
+  parseOptionalCadenceInputValue,
+  stepCadenceValue,
+} from "../../lib/agent-cadence";
 import { HelpTooltip } from "../ui/HelpTooltip";
 import {
   BUILT_IN_AGENTS,
@@ -116,6 +124,11 @@ export function AgentEditor() {
 
   // Custom agent = DB entry with no matching built-in
   const isCustomAgent = !builtIn && !!dbConfig;
+  const isNewCustomAgent = agentDetailId === "__new__";
+  const customRunIntervalMeta =
+    isCustomAgent || isNewCustomAgent
+      ? getAgentRunIntervalMeta(isNewCustomAgent ? "__new__" : (dbConfig?.type ?? agentDetailId ?? ""), false)
+    : null;
 
   // Default prompt for this agent type
   const defaultPrompt = useMemo(() => (agentDetailId ? getDefaultAgentPrompt(agentDetailId) : ""), [agentDetailId]);
@@ -128,6 +141,7 @@ export function AgentEditor() {
   const [localImageConnectionId, setLocalImageConnectionId] = useState("");
   const [localContextSize, setLocalContextSize] = useState<number | "">("");
   const [localRunInterval, setLocalRunInterval] = useState<number | "">("");
+  const [customCadenceInputFocused, setCustomCadenceInputFocused] = useState(false);
   const [localPrompt, setLocalPrompt] = useState("");
   const [localInjectAsSection, setLocalInjectAsSection] = useState(false);
   const [localEnabledTools, setLocalEnabledTools] = useState<string[]>([]);
@@ -721,6 +735,66 @@ export function AgentEditor() {
           )}
 
           {/* ── Triggers After (Chat Summary agent) ── */}
+          {(isCustomAgent || isNewCustomAgent) && customRunIntervalMeta && (
+            <FieldGroup
+              label={customRunIntervalMeta.label}
+              icon={<Clock size="0.875rem" className="text-[var(--primary)]" />}
+              help={customRunIntervalMeta.help}
+            >
+              <div className="flex items-center gap-3">
+                <div className="relative w-28">
+                  <input
+                    type="text"
+                    inputMode="numeric"
+                    value={customCadenceInputFocused ? String(localRunInterval) : getCadenceInputValue(localRunInterval)}
+                    onFocus={(e) => {
+                      setCustomCadenceInputFocused(true);
+                      e.target.select();
+                    }}
+                    onBlur={() => setCustomCadenceInputFocused(false)}
+                    onKeyDown={(e) => {
+                      if (e.key !== "ArrowUp" && e.key !== "ArrowDown") return;
+                      e.preventDefault();
+                      const delta = e.key === "ArrowUp" ? 1 : -1;
+                      setLocalRunInterval(stepCadenceValue(localRunInterval, delta, customRunIntervalMeta.max));
+                      markDirty();
+                    }}
+                    onChange={(e) => {
+                      setLocalRunInterval(parseOptionalCadenceInputValue(e.target.value, customRunIntervalMeta.max));
+                      markDirty();
+                    }}
+                    className="w-full rounded-xl bg-[var(--secondary)] px-3 py-2.5 pr-8 text-sm tabular-nums ring-1 ring-[var(--border)] placeholder:text-[var(--muted-foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+                  />
+                  <div className="absolute right-1 top-1/2 flex -translate-y-1/2 flex-col overflow-hidden rounded-md">
+                    <button
+                      type="button"
+                      aria-label="Increase trigger cadence"
+                      onClick={() => {
+                        setLocalRunInterval(stepCadenceValue(localRunInterval, 1, customRunIntervalMeta.max));
+                        markDirty();
+                      }}
+                      className="flex h-4 w-5 items-center justify-center text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+                    >
+                      <ChevronUp size="0.6875rem" />
+                    </button>
+                    <button
+                      type="button"
+                      aria-label="Decrease trigger cadence"
+                      onClick={() => {
+                        setLocalRunInterval(stepCadenceValue(localRunInterval, -1, customRunIntervalMeta.max));
+                        markDirty();
+                      }}
+                      className="flex h-4 w-5 items-center justify-center text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+                    >
+                      <ChevronDown size="0.6875rem" />
+                    </button>
+                  </div>
+                </div>
+                <span className="text-[0.6875rem] text-[var(--muted-foreground)]">{customRunIntervalMeta.unit}</span>
+              </div>
+            </FieldGroup>
+          )}
+
           {isChatSummaryAgent && (
             <FieldGroup
               label="Triggers After"

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -12,6 +12,7 @@ import {
   Plug,
   ChevronDown,
   ChevronRight,
+  ChevronUp,
   Check,
   Plus,
   Trash2,
@@ -76,6 +77,12 @@ import {
   chatKeys,
 } from "../../hooks/use-chats";
 import { api } from "../../lib/api-client";
+import {
+  getAgentRunIntervalMeta,
+  getCadenceInputValue,
+  parseCadenceInputValue,
+  stepCadenceValue,
+} from "../../lib/agent-cadence";
 import { getCharacterTitle, parseCharacterDisplayData } from "../../lib/character-display";
 import { useUIStore } from "../../stores/ui.store";
 import {
@@ -135,14 +142,6 @@ type AgentAddPreview = {
   runInterval: number | null;
 };
 
-type AgentRunIntervalMeta = {
-  label: string;
-  unit: string;
-  help: string;
-  defaultValue: number;
-  max: number;
-};
-
 function parseAgentSettings(raw: unknown): Record<string, unknown> {
   if (!raw) return {};
   if (typeof raw === "string") {
@@ -168,37 +167,6 @@ function isEnabledFlag(value: unknown): boolean {
 function normalizeNonNegativeInteger(value: unknown, fallback: number, max: number): number {
   if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
   return Math.max(0, Math.min(max, Math.trunc(value)));
-}
-
-function getAgentRunIntervalMeta(agentType: string): AgentRunIntervalMeta | null {
-  switch (agentType) {
-    case "director":
-      return {
-        label: "Run Interval",
-        unit: "assistant messages",
-        help: "How many assistant messages should pass before the Narrative Director jumps in again. Higher values make it less aggressive.",
-        defaultValue: 5,
-        max: 100,
-      };
-    case "lorebook-keeper":
-      return {
-        label: "Run Interval",
-        unit: "assistant messages",
-        help: "How many assistant messages should pass between Lorebook Keeper updates.",
-        defaultValue: 8,
-        max: 100,
-      };
-    case "chat-summary":
-      return {
-        label: "Triggers After",
-        unit: "user messages",
-        help: "How many user messages should pass before the Automated Chat Summary updates again.",
-        defaultValue: 5,
-        max: 200,
-      };
-    default:
-      return null;
-  }
 }
 
 export function ChatSettingsDrawer({
@@ -663,6 +631,7 @@ export function ChatSettingsDrawer({
   const [toolSearch, setToolSearch] = useState("");
   const [choiceModalPresetId, setChoiceModalPresetId] = useState<string | null>(null);
   const [agentAddPreview, setAgentAddPreview] = useState<AgentAddPreview | null>(null);
+  const [agentAddCadenceInputFocused, setAgentAddCadenceInputFocused] = useState(false);
   const [addingAgentToChat, setAddingAgentToChat] = useState(false);
   const [isRegeneratingSchedules, setIsRegeneratingSchedules] = useState(false);
   // Synchronous lock to close the re-entry gap: React state commits are async, so two
@@ -729,12 +698,13 @@ export function ChatSettingsDrawer({
   }, [open]);
 
   const openAgentAddModal = (agent: AvailableAgent) => {
+    setAgentAddCadenceInputFocused(false);
     const config = agentConfigsByType.get(agent.id) ?? null;
     const mergedSettings = {
       ...getDefaultBuiltInAgentSettings(agent.id),
       ...parseAgentSettings(config?.settings),
     };
-    const intervalMeta = getAgentRunIntervalMeta(agent.id);
+    const intervalMeta = getAgentRunIntervalMeta(agent.id, agent.builtIn);
     setAgentAddPreview({
       agent,
       config,
@@ -755,7 +725,7 @@ export function ChatSettingsDrawer({
       ...parseAgentSettings(config?.settings),
       contextSize,
     };
-    const intervalMeta = getAgentRunIntervalMeta(agent.id);
+    const intervalMeta = getAgentRunIntervalMeta(agent.id, !!builtInMeta);
     if (intervalMeta && runInterval != null) {
       nextSettings.runInterval = runInterval;
     }
@@ -795,7 +765,9 @@ export function ChatSettingsDrawer({
     }
   };
 
-  const agentAddIntervalMeta = agentAddPreview ? getAgentRunIntervalMeta(agentAddPreview.agent.id) : null;
+  const agentAddIntervalMeta = agentAddPreview
+    ? getAgentRunIntervalMeta(agentAddPreview.agent.id, agentAddPreview.agent.builtIn)
+    : null;
 
   const snapshotCurrentPresetSettings = useCallback((): ChatPresetSettings => {
     return {
@@ -3862,27 +3834,126 @@ export function ChatSettingsDrawer({
                   {agentAddIntervalMeta.label}
                 </label>
                 <div className="flex items-center gap-3">
-                  <input
-                    type="number"
-                    min={1}
-                    max={agentAddIntervalMeta.max}
-                    value={agentAddPreview.runInterval}
-                    onChange={(e) => {
-                      const value = parseInt(e.target.value, 10);
-                      setAgentAddPreview((current) =>
-                        current
-                          ? {
-                              ...current,
-                              runInterval: Number.isFinite(value)
-                                ? Math.max(1, Math.min(agentAddIntervalMeta.max, value))
-                                : agentAddIntervalMeta.defaultValue,
-                            }
-                          : current,
-                      );
-                    }}
-                    disabled={addingAgentToChat}
-                    className="w-28 rounded-xl bg-[var(--secondary)] px-3 py-2.5 text-sm tabular-nums ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)] disabled:cursor-not-allowed disabled:opacity-60"
-                  />
+                  {agentAddPreview.agent.builtIn ? (
+                    <input
+                      type="number"
+                      min={1}
+                      max={agentAddIntervalMeta.max}
+                      value={agentAddPreview.runInterval}
+                      onChange={(e) => {
+                        setAgentAddPreview((current) =>
+                          current
+                            ? {
+                                ...current,
+                                runInterval: parseCadenceInputValue(
+                                  e.target.value,
+                                  agentAddIntervalMeta.defaultValue,
+                                  agentAddIntervalMeta.max,
+                                ),
+                              }
+                            : current,
+                        );
+                      }}
+                      disabled={addingAgentToChat}
+                      className="w-28 rounded-xl bg-[var(--secondary)] px-3 py-2.5 text-sm tabular-nums ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)] disabled:cursor-not-allowed disabled:opacity-60"
+                    />
+                  ) : (
+                    <div className="relative w-28">
+                      <input
+                        type="text"
+                        inputMode="numeric"
+                        value={
+                          agentAddCadenceInputFocused
+                            ? String(agentAddPreview.runInterval)
+                            : getCadenceInputValue(agentAddPreview.runInterval)
+                        }
+                        onFocus={(e) => {
+                          setAgentAddCadenceInputFocused(true);
+                          e.target.select();
+                        }}
+                        onBlur={() => setAgentAddCadenceInputFocused(false)}
+                        onKeyDown={(e) => {
+                          if (e.key !== "ArrowUp" && e.key !== "ArrowDown") return;
+                          e.preventDefault();
+                          const delta = e.key === "ArrowUp" ? 1 : -1;
+                          setAgentAddPreview((current) =>
+                            current
+                              ? {
+                                  ...current,
+                                  runInterval: stepCadenceValue(
+                                    current.runInterval ?? 1,
+                                    delta,
+                                    agentAddIntervalMeta.max,
+                                  ),
+                                }
+                              : current,
+                          );
+                        }}
+                        onChange={(e) => {
+                          setAgentAddPreview((current) =>
+                            current
+                              ? {
+                                  ...current,
+                                  runInterval: parseCadenceInputValue(
+                                    e.target.value,
+                                    current.runInterval ?? 1,
+                                    agentAddIntervalMeta.max,
+                                  ),
+                                }
+                              : current,
+                          );
+                        }}
+                        disabled={addingAgentToChat}
+                        className="w-full rounded-xl bg-[var(--secondary)] px-3 py-2.5 pr-8 text-sm tabular-nums ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)] disabled:cursor-not-allowed disabled:opacity-60"
+                      />
+                      <div className="absolute right-1 top-1/2 flex -translate-y-1/2 flex-col overflow-hidden rounded-md">
+                        <button
+                          type="button"
+                          aria-label="Increase trigger cadence"
+                          disabled={addingAgentToChat}
+                          onClick={() => {
+                            setAgentAddPreview((current) =>
+                              current
+                                ? {
+                                    ...current,
+                                    runInterval: stepCadenceValue(
+                                      current.runInterval ?? 1,
+                                      1,
+                                      agentAddIntervalMeta.max,
+                                    ),
+                                  }
+                                : current,
+                            );
+                          }}
+                          className="flex h-4 w-5 items-center justify-center text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] disabled:cursor-not-allowed disabled:opacity-50"
+                        >
+                          <ChevronUp size="0.6875rem" />
+                        </button>
+                        <button
+                          type="button"
+                          aria-label="Decrease trigger cadence"
+                          disabled={addingAgentToChat}
+                          onClick={() => {
+                            setAgentAddPreview((current) =>
+                              current
+                                ? {
+                                    ...current,
+                                    runInterval: stepCadenceValue(
+                                      current.runInterval ?? 1,
+                                      -1,
+                                      agentAddIntervalMeta.max,
+                                    ),
+                                  }
+                                : current,
+                            );
+                          }}
+                          className="flex h-4 w-5 items-center justify-center text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] disabled:cursor-not-allowed disabled:opacity-50"
+                        >
+                          <ChevronDown size="0.6875rem" />
+                        </button>
+                      </div>
+                    </div>
+                  )}
                   <span className="text-[0.6875rem] text-[var(--muted-foreground)]">{agentAddIntervalMeta.unit}</span>
                 </div>
                 <p className="text-[0.625rem] text-[var(--muted-foreground)]">{agentAddIntervalMeta.help}</p>

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -964,6 +964,11 @@ export function useGenerate() {
               break;
             }
 
+            case "metadata_patch": {
+              qc.invalidateQueries({ queryKey: chatKeys.detail(params.chatId) });
+              break;
+            }
+
             case "text_rewrite": {
               // Consistency Editor replaced the message — update displayed text
               const rw = event.data as { editedText?: string; changes?: Array<{ description: string }> };

--- a/packages/client/src/lib/agent-cadence.ts
+++ b/packages/client/src/lib/agent-cadence.ts
@@ -1,0 +1,72 @@
+export type AgentRunIntervalMeta = {
+  label: string;
+  unit: string;
+  help: string;
+  defaultValue: number;
+  max: number;
+};
+
+export const EVERY_RUN_LABEL = "Every run";
+
+export function getAgentRunIntervalMeta(agentType: string, isBuiltIn = true): AgentRunIntervalMeta | null {
+  switch (agentType) {
+    case "director":
+      return {
+        label: "Run Interval",
+        unit: "assistant messages",
+        help: "How many assistant messages should pass before the Narrative Director jumps in again. Higher values make it less aggressive.",
+        defaultValue: 5,
+        max: 100,
+      };
+    case "lorebook-keeper":
+      return {
+        label: "Run Interval",
+        unit: "assistant messages",
+        help: "How many assistant messages should pass between Lorebook Keeper updates.",
+        defaultValue: 8,
+        max: 100,
+      };
+    case "chat-summary":
+      return {
+        label: "Triggers After",
+        unit: "user messages",
+        help: "How many user messages should pass before the Automated Chat Summary updates again.",
+        defaultValue: 5,
+        max: 200,
+      };
+    default:
+      if (!isBuiltIn) {
+        return {
+          label: "Trigger Cadence",
+          unit: "user messages",
+          help: "How many user messages should pass since this custom agent last ran before it triggers again. Set to 1 to run whenever its phase runs.",
+          defaultValue: 1,
+          max: 200,
+        };
+      }
+      return null;
+  }
+}
+
+export function getCadenceInputValue(value: number | ""): string {
+  return value === 1 ? EVERY_RUN_LABEL : String(value);
+}
+
+export function parseOptionalCadenceInputValue(value: string, max: number): number | "" {
+  const trimmed = value.trim();
+  if (trimmed === "") return "";
+  if (EVERY_RUN_LABEL.toLowerCase().startsWith(trimmed.toLowerCase())) return 1;
+
+  const parsed = parseInt(trimmed, 10);
+  return Number.isFinite(parsed) ? Math.max(1, Math.min(max, parsed)) : 1;
+}
+
+export function parseCadenceInputValue(value: string, fallback: number, max: number): number {
+  const parsed = parseOptionalCadenceInputValue(value, max);
+  return parsed === "" ? fallback : parsed;
+}
+
+export function stepCadenceValue(value: number | "", delta: number, max: number): number {
+  const current = value === "" ? 1 : value;
+  return Math.max(1, Math.min(max, current + delta));
+}

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -44,7 +44,7 @@ import {
   type ChatMessage,
   type LLMUsage,
 } from "../services/llm/base-provider.js";
-import { executeToolCalls } from "../services/tools/tool-executor.js";
+import { executeToolCalls, type MetadataPatchInput } from "../services/tools/tool-executor.js";
 import { createAgentPipeline, type ResolvedAgent, type AgentInjection } from "../services/agents/agent-pipeline.js";
 import { DATA_DIR } from "../utils/data-dir.js";
 import { executeAgent } from "../services/agents/agent-executor.js";
@@ -2409,6 +2409,36 @@ export async function generateRoutes(app: FastifyInstance) {
         resolvedAgents.map((a) => `${a.type}(${a.phase})`).join(", "),
       );
 
+      const builtInAgentTypes = new Set(BUILT_IN_AGENTS.map((agent) => agent.id));
+      const userMessagesSinceLastAgentRun = async (agentType: string) => {
+        const lastRun = await agentsStore.getLastRunByType(agentType, input.chatId);
+        if (!lastRun) return Number.POSITIVE_INFINITY;
+
+        const lastRunIdx = allChatMessages.findIndex((message: any) => message.id === lastRun.messageId);
+        if (lastRunIdx < 0) return Number.POSITIVE_INFINITY;
+
+        return allChatMessages.slice(lastRunIdx + 1).filter((message: any) => message.role === "user").length;
+      };
+
+      for (let index = resolvedAgents.length - 1; index >= 0; index--) {
+        const agent = resolvedAgents[index]!;
+        if (builtInAgentTypes.has(agent.type)) continue;
+
+        const runInterval = Number(agent.settings.runInterval ?? 0);
+        if (!Number.isFinite(runInterval) || runInterval <= 1) continue;
+
+        const userMessageCount = await userMessagesSinceLastAgentRun(agent.type);
+        if (userMessageCount < runInterval) {
+          logger.debug(
+            "[agents] Skipping custom agent %s until cadence threshold: %d/%d user messages",
+            agent.type,
+            userMessageCount,
+            runInterval,
+          );
+          resolvedAgents.splice(index, 1);
+        }
+      }
+
       // Resolve character info (used for agent context AND prompt fallback)
       const charInfo: Array<{
         id: string;
@@ -3826,8 +3856,14 @@ export async function generateRoutes(app: FastifyInstance) {
       // Tool Resolution (Main Generation + Agent Pipeline)
       // ────────────────────────────────────────
       const inputBody = req.body as Record<string, unknown>;
-      const enableTools = inputBody.enableTools === true || chatMeta.enableTools === true;
+      const enableChatTools = inputBody.enableTools === true || chatMeta.enableTools === true;
+      const enableAgentTools = resolvedAgents.some((agent) => {
+        const agentSettings = typeof agent.settings === "string" ? JSON.parse(agent.settings) : agent.settings || {};
+        return Array.isArray(agentSettings.enabledTools) && agentSettings.enabledTools.length > 0;
+      });
+      const resolveTools = enableChatTools || enableAgentTools;
       let toolDefs: LLMToolDefinition[] | undefined;
+      const allToolDefs: LLMToolDefinition[] = [];
       const customToolDefs: Array<{
         name: string;
         executionType: string;
@@ -3836,7 +3872,7 @@ export async function generateRoutes(app: FastifyInstance) {
         scriptBody: string | null;
       }> = [];
 
-      if (enableTools) {
+      if (resolveTools) {
         // Per-chat tool selection (empty = all tools)
         const chatActiveToolIds: string[] = Array.isArray(chatMeta.activeToolIds)
           ? (chatMeta.activeToolIds as string[])
@@ -3845,11 +3881,7 @@ export async function generateRoutes(app: FastifyInstance) {
         const registeredToolSources = new Map<string, "built-in" | "custom">();
 
         // Built-in tools
-        const builtInFiltered = hasToolFilter
-          ? BUILT_IN_TOOLS.filter((t) => chatActiveToolIds.includes(t.name))
-          : BUILT_IN_TOOLS;
-        toolDefs = [];
-        for (const t of builtInFiltered) {
+        for (const t of BUILT_IN_TOOLS) {
           const existingSource = registeredToolSources.get(t.name);
           if (existingSource) {
             throw new Error(
@@ -3857,7 +3889,7 @@ export async function generateRoutes(app: FastifyInstance) {
             );
           }
           registeredToolSources.set(t.name, "built-in");
-          toolDefs.push({
+          allToolDefs.push({
             type: "function" as const,
             function: {
               name: t.name,
@@ -3869,10 +3901,7 @@ export async function generateRoutes(app: FastifyInstance) {
 
         // Custom tools from DB
         const enabledCustomTools = await customToolsStore.listEnabled();
-        const customFiltered = hasToolFilter
-          ? enabledCustomTools.filter((ct: any) => chatActiveToolIds.includes(ct.name))
-          : enabledCustomTools;
-        for (const ct of customFiltered) {
+        for (const ct of enabledCustomTools) {
           const existingSource = registeredToolSources.get(ct.name);
           if (existingSource) {
             logger.warn(
@@ -3925,7 +3954,7 @@ export async function generateRoutes(app: FastifyInstance) {
               scriptBody: ct.scriptBody,
             });
 
-            toolDefs.push({
+            allToolDefs.push({
               type: "function" as const,
               function: {
                 name: ct.name,
@@ -3943,12 +3972,19 @@ export async function generateRoutes(app: FastifyInstance) {
             );
           }
         }
+
+        if (enableChatTools) {
+          toolDefs = hasToolFilter
+            ? allToolDefs.filter((td) => chatActiveToolIds.includes(td.function.name))
+            : allToolDefs;
+        }
       }
 
       // ── Spotify Token Refresh (Early) ──
-      const resolvedToolNames = new Set((toolDefs ?? []).map((td) => td.function.name));
+      const resolvedToolNames = new Set(allToolDefs.map((td) => td.function.name));
+      const chatResolvedToolNames = new Set((toolDefs ?? []).map((td) => td.function.name));
       const spotifyToolNames = new Set(DEFAULT_AGENT_TOOLS.spotify ?? []);
-      const chatAllowsSpotify = Array.from(resolvedToolNames).some((name) => spotifyToolNames.has(name));
+      const chatAllowsSpotify = Array.from(chatResolvedToolNames).some((name) => spotifyToolNames.has(name));
       const anyAgentAllowsSpotify = resolvedAgents.some((agent) => {
         const agentSettings = typeof agent.settings === "string" ? JSON.parse(agent.settings) : agent.settings || {};
         const agentEnabledNames = Array.isArray(agentSettings.enabledTools)
@@ -3957,7 +3993,7 @@ export async function generateRoutes(app: FastifyInstance) {
         const agentResolvedNames = agentEnabledNames.filter((name) => resolvedToolNames.has(name));
         return agentResolvedNames.some((name) => spotifyToolNames.has(name));
       });
-      const needsSpotify = enableTools && (chatAllowsSpotify || anyAgentAllowsSpotify);
+      const needsSpotify = (enableChatTools && chatAllowsSpotify) || anyAgentAllowsSpotify;
       // Look beyond resolved agents only to reuse stored Spotify credentials when Spotify tools are allowed.
       const spotifyAgent = needsSpotify
         ? (resolvedAgents.find((a) => a.type === "spotify") ??
@@ -4041,6 +4077,34 @@ export async function generateRoutes(app: FastifyInstance) {
           .slice(0, 20)
           .map((e: any) => ({ name: e.name, content: e.content, tag: e.tag, keys: e.keys as string[] }));
       };
+      const updateChatMetadataForTools = async (patchOrUpdater: MetadataPatchInput) => {
+        let emittedPatch: Record<string, unknown> = {};
+        const updatedChat = await chats.patchMetadata(input.chatId, async (currentMeta) => {
+          const patch =
+            typeof patchOrUpdater === "function" ? await patchOrUpdater({ ...currentMeta }) : patchOrUpdater;
+          emittedPatch = patch;
+          return patch;
+        });
+        const updatedMeta = updatedChat ? parseExtra(updatedChat.metadata) : { ...chatMeta, ...emittedPatch };
+        for (const key of Object.keys(chatMeta)) {
+          if (!(key in updatedMeta)) {
+            delete chatMeta[key];
+          }
+        }
+        Object.assign(chatMeta, updatedMeta);
+        agentContext.chatSummary =
+          typeof chatMeta.summary === "string" && chatMeta.summary.trim() ? chatMeta.summary.trim() : null;
+        trySendSseEvent(reply, { type: "metadata_patch", data: emittedPatch });
+        return updatedMeta;
+      };
+      const baseToolExecutionContext = {
+        gameState: gameState ? (gameState as unknown as Record<string, unknown>) : undefined,
+        customTools: customToolDefs,
+        spotify: spotifyCreds,
+        searchLorebook: searchLorebookForTools,
+        chatMeta,
+        onUpdateMetadata: updateChatMetadataForTools,
+      };
 
       // ── Resolve tool context for all agents ──
       // This enables built-in and custom tools for any agent in the pipeline.
@@ -4053,7 +4117,7 @@ export async function generateRoutes(app: FastifyInstance) {
           : [];
         if (agentEnabledNames.length === 0) continue;
 
-        const agentTools = (toolDefs ?? []).filter((td) => agentEnabledNames.includes(td.function.name));
+        const agentTools = allToolDefs.filter((td) => agentEnabledNames.includes(td.function.name));
         if (agentTools.length === 0) continue;
         const allowedToolNames = new Set(agentTools.map((td) => td.function.name));
 
@@ -4067,9 +4131,7 @@ export async function generateRoutes(app: FastifyInstance) {
               });
             }
             const results = await executeToolCalls([call], {
-              customTools: customToolDefs,
-              spotify: spotifyCreds,
-              searchLorebook: searchLorebookForTools,
+              ...baseToolExecutionContext,
             });
             return results[0]?.result ?? "Tool execution failed";
           },
@@ -4866,7 +4928,7 @@ export async function generateRoutes(app: FastifyInstance) {
             }
           }
 
-          if (enableTools && provider.chatComplete) {
+          if (enableChatTools && provider.chatComplete) {
             const MAX_TOOL_ROUNDS = 5;
             let loopMessages: ChatMessage[] = initialProviderMessages;
             // ── Seed encrypted reasoning cache from DB ──
@@ -4992,23 +5054,23 @@ export async function generateRoutes(app: FastifyInstance) {
                 ...(result.providerMetadata ? { providerMetadata: result.providerMetadata } : {}),
               });
 
-              const permittedToolCalls = result.toolCalls.filter((call) => resolvedToolNames.has(call.function.name));
+              const permittedToolCalls = result.toolCalls.filter((call) =>
+                chatResolvedToolNames.has(call.function.name),
+              );
               const deniedToolResults = result.toolCalls
-                .filter((call) => !resolvedToolNames.has(call.function.name))
+                .filter((call) => !chatResolvedToolNames.has(call.function.name))
                 .map((call) => ({
                   toolCallId: call.id,
                   name: call.function.name,
                   result: JSON.stringify({
                     error: `Tool not allowed in this context: ${call.function.name}`,
-                    allowed: Array.from(resolvedToolNames),
+                    allowed: Array.from(chatResolvedToolNames),
                   }),
                   success: false,
                 }));
 
               const executedToolResults = await executeToolCalls(permittedToolCalls, {
-                customTools: customToolDefs,
-                spotify: spotifyCreds,
-                searchLorebook: searchLorebookForTools,
+                ...baseToolExecutionContext,
               });
               const toolResultsById = new Map(
                 [...executedToolResults, ...deniedToolResults].map((result) => [result.toolCallId, result]),
@@ -6384,11 +6446,11 @@ export async function generateRoutes(app: FastifyInstance) {
               const csData = result.data as Record<string, unknown>;
               const newText = ((csData.summary as string) ?? "").trim();
               if (newText) {
-                const existingMeta = parseExtra(chat.metadata);
-                const existing = ((existingMeta.summary as string) ?? "").trim();
-                const combined = existing ? `${existing}\n\n${newText}` : newText;
-                const merged = { ...existingMeta, summary: combined };
-                await chats.updateMetadata(input.chatId, merged);
+                const updatedMeta = await updateChatMetadataForTools((currentMeta) => {
+                  const existing = ((currentMeta.summary as string) ?? "").trim();
+                  return { summary: existing ? `${existing}\n\n${newText}` : newText };
+                });
+                const combined = typeof updatedMeta.summary === "string" ? updatedMeta.summary : newText;
                 reply.raw.write(`data: ${JSON.stringify({ type: "chat_summary", data: { summary: combined } })}\n\n`);
               }
             } catch {

--- a/packages/server/src/services/agents/agent-executor.ts
+++ b/packages/server/src/services/agents/agent-executor.ts
@@ -4,6 +4,7 @@
 import type { BaseLLMProvider, ChatMessage, LLMToolDefinition, LLMToolCall } from "../llm/base-provider.js";
 import type { AgentResult, AgentContext, AgentResultType } from "@marinara-engine/shared";
 import { getDefaultAgentPrompt } from "@marinara-engine/shared";
+import { isDebugAgentsEnabled } from "../../config/runtime-config.js";
 import { logger } from "../../lib/logger.js";
 
 /** Strip HTML/XML-style tags (e.g. <div style="..."> <br> <speaker>) from text to save tokens. */
@@ -201,7 +202,7 @@ async function executeAgentWithTools(
   const MAX_TOOL_ROUNDS = 5;
   const loopMessages = [...initialMessages];
   let totalTokens = 0;
-  const debugAgentsEnabled = logger.isLevelEnabled("debug");
+  const debugAgentsEnabled = isDebugAgentsEnabled() && logger.isLevelEnabled("debug");
 
   for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
     const result = await provider.chatComplete(loopMessages, {

--- a/packages/server/src/services/storage/agents.storage.ts
+++ b/packages/server/src/services/storage/agents.storage.ts
@@ -209,6 +209,18 @@ export function createAgentsStorage(db: DB) {
       return rows[0]?.agent_runs ?? null;
     },
 
+    /** Get the most recent run of an agent type in a given chat, regardless of success. */
+    async getLastRunByType(agentType: string, chatId: string) {
+      const rows = await db
+        .select()
+        .from(agentRuns)
+        .innerJoin(agentConfigs, eq(agentRuns.agentConfigId, agentConfigs.id))
+        .where(and(eq(agentConfigs.type, agentType), eq(agentRuns.chatId, chatId)))
+        .orderBy(desc(agentRuns.createdAt))
+        .limit(1);
+      return rows[0]?.agent_runs ?? null;
+    },
+
     /** Get all echo chamber messages for a chat, ordered by creation time. */
     async getEchoMessages(chatId: string) {
       const rows = await db

--- a/packages/server/src/services/storage/chats.storage.ts
+++ b/packages/server/src/services/storage/chats.storage.ts
@@ -25,6 +25,42 @@ import {
 
 const GALLERY_DIR = join(DATA_DIR, "gallery");
 
+export type MetadataPatch = Record<string, unknown>;
+export type MetadataUpdater = (current: MetadataPatch) => MetadataPatch | Promise<MetadataPatch>;
+
+const metadataPatchQueues = new Map<string, Promise<void>>();
+
+async function withMetadataPatchQueue<T>(chatId: string, operation: () => Promise<T>): Promise<T> {
+  const previous = metadataPatchQueues.get(chatId) ?? Promise.resolve();
+  const queued = previous.catch(() => undefined).then(operation);
+  const queuedVoid = queued.then(
+    () => undefined,
+    () => undefined,
+  );
+  metadataPatchQueues.set(chatId, queuedVoid);
+
+  try {
+    return await queued;
+  } finally {
+    if (metadataPatchQueues.get(chatId) === queuedVoid) {
+      metadataPatchQueues.delete(chatId);
+    }
+  }
+}
+
+function parseMetadata(raw: unknown): MetadataPatch {
+  if (!raw) return {};
+  if (typeof raw === "string") {
+    try {
+      const parsed = JSON.parse(raw);
+      return parsed && typeof parsed === "object" ? (parsed as MetadataPatch) : {};
+    } catch {
+      return {};
+    }
+  }
+  return typeof raw === "object" ? (raw as MetadataPatch) : {};
+}
+
 function resolveTimestamps(overrides?: TimestampOverrides | null) {
   const normalized = normalizeTimestampOverrides(overrides);
   const createdAt = normalized?.createdAt ?? now();
@@ -108,6 +144,23 @@ export function createChatsStorage(db: DB) {
         .set({ metadata: JSON.stringify(metadata), updatedAt: now() })
         .where(eq(chats.id, id));
       return this.getById(id);
+    },
+
+    async patchMetadata(id: string, patchOrUpdater: MetadataPatch | MetadataUpdater) {
+      return withMetadataPatchQueue(id, async () => {
+        const existing = await this.getById(id);
+        if (!existing) return null;
+
+        const current = parseMetadata(existing.metadata);
+        const patch = typeof patchOrUpdater === "function" ? await patchOrUpdater({ ...current }) : patchOrUpdater;
+        const merged = { ...current, ...patch };
+
+        await db
+          .update(chats)
+          .set({ metadata: JSON.stringify(merged), updatedAt: now() })
+          .where(eq(chats.id, id));
+        return this.getById(id);
+      });
     },
 
     async remove(id: string) {

--- a/packages/server/src/services/tools/tool-executor.ts
+++ b/packages/server/src/services/tools/tool-executor.ts
@@ -31,8 +31,17 @@ export interface SpotifyCredentials {
   accessToken: string;
 }
 
+export type MetadataPatch = Record<string, unknown>;
+export type MetadataUpdater = (current: MetadataPatch) => MetadataPatch | Promise<MetadataPatch>;
+export type MetadataPatchInput = MetadataPatch | MetadataUpdater;
+
+const MAX_APPEND_BYTES = 16 * 1024;
+const MAX_TOTAL_SUMMARY_BYTES = 64 * 1024;
+
 export interface ToolExecutionContext {
   gameState?: Record<string, unknown>;
+  chatMeta?: Record<string, unknown>;
+  onUpdateMetadata?: (patch: MetadataPatchInput) => Promise<MetadataPatch>;
   customTools?: CustomToolDef[];
   searchLorebook?: LorebookSearchFn;
   spotify?: SpotifyCredentials;
@@ -93,6 +102,10 @@ async function executeSingleTool(
       return triggerEvent(args);
     case "search_lorebook":
       return searchLorebook(args, context?.searchLorebook);
+    case "read_chat_summary":
+      return readChatSummary(context?.chatMeta);
+    case "append_chat_summary":
+      return appendChatSummary(args, context);
     case "spotify_get_playlists":
       return spotifyGetPlaylists(args, context?.spotify);
     case "spotify_get_playlist_tracks":
@@ -109,7 +122,20 @@ async function executeSingleTool(
       if (custom) return executeCustomTool(custom, args);
       return {
         error: `Unknown tool: ${name}`,
-        available: ["roll_dice", "update_game_state", "set_expression", "trigger_event", "search_lorebook"],
+        available: [
+          "roll_dice",
+          "update_game_state",
+          "set_expression",
+          "trigger_event",
+          "search_lorebook",
+          "read_chat_summary",
+          "append_chat_summary",
+          "spotify_get_playlists",
+          "spotify_get_playlist_tracks",
+          "spotify_search",
+          "spotify_play",
+          "spotify_set_volume",
+        ],
       };
     }
   }
@@ -236,6 +262,82 @@ function setExpression(args: Record<string, unknown>): Record<string, unknown> {
     expression: args.expression,
     display: `🎭 ${args.characterName}: expression → ${args.expression}`,
   };
+}
+
+function readChatSummary(chatMeta?: Record<string, unknown>): Record<string, unknown> {
+  const summary = typeof chatMeta?.summary === "string" ? chatMeta.summary : "";
+  return { summary };
+}
+
+function sanitizePersistedSummaryText(text: string): string {
+  return text
+    .replace(/&(amp|lt|gt);/g, (_match, entity: string) => {
+      switch (entity) {
+        case "amp":
+          return "&";
+        case "lt":
+          return "<";
+        case "gt":
+          return ">";
+        default:
+          return _match;
+      }
+    })
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function utf8ByteLength(text: string): number {
+  return Buffer.byteLength(text, "utf8");
+}
+
+function trimToUtf8Bytes(text: string, maxBytes: number, fromStart = false): string {
+  if (maxBytes <= 0) return "";
+  if (utf8ByteLength(text) <= maxBytes) return text;
+
+  let low = 0;
+  let high = text.length;
+  while (low < high) {
+    const mid = Math.ceil((low + high) / 2);
+    const candidate = fromStart ? text.slice(text.length - mid) : text.slice(0, mid);
+    if (utf8ByteLength(candidate) <= maxBytes) {
+      low = mid;
+    } else {
+      high = mid - 1;
+    }
+  }
+
+  const trimmed = fromStart ? text.slice(text.length - low) : text.slice(0, low);
+  return fromStart ? trimmed.replace(/^[\uDC00-\uDFFF]/, "") : trimmed.replace(/[\uD800-\uDBFF]$/, "");
+}
+
+async function appendChatSummary(
+  args: Record<string, unknown>,
+  context?: ToolExecutionContext,
+): Promise<Record<string, unknown>> {
+  if (typeof args.text !== "string") {
+    return { error: "append_chat_summary requires non-empty text" };
+  }
+  const text = args.text.trim();
+  if (!text) {
+    return { error: "append_chat_summary requires non-empty text" };
+  }
+  const sanitizedText = trimToUtf8Bytes(sanitizePersistedSummaryText(text), MAX_APPEND_BYTES).trim();
+  if (!sanitizedText) {
+    return { error: "append_chat_summary exceeds per-append size limit" };
+  }
+  if (!context?.onUpdateMetadata) {
+    return { error: "Chat metadata updates are not available in this context" };
+  }
+
+  const updated = await context.onUpdateMetadata((currentMeta) => {
+    const existing =
+      typeof currentMeta.summary === "string" ? sanitizePersistedSummaryText(currentMeta.summary.trim()) : "";
+    const summary = existing ? `${existing}\n\n${sanitizedText}` : sanitizedText;
+    return { summary: trimToUtf8Bytes(summary, MAX_TOTAL_SUMMARY_BYTES, true).trim() };
+  });
+  return { summary: typeof updated.summary === "string" ? updated.summary : sanitizedText };
 }
 
 function triggerEvent(args: Record<string, unknown>): Record<string, unknown> {

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -762,6 +762,29 @@ export const BUILT_IN_TOOLS: ToolDefinition[] = [
     },
   },
   {
+    name: "read_chat_summary",
+    description: "Read the current persisted chat summary for this chat.",
+    parameters: {
+      type: "object",
+      properties: {},
+    },
+  },
+  {
+    name: "append_chat_summary",
+    description: "Append durable memory text to the persisted chat summary for this chat.",
+    parameters: {
+      type: "object",
+      properties: {
+        text: {
+          type: "string",
+          description:
+            "Concise summary text to append. Include only durable facts, plans, preferences, or story developments.",
+        },
+      },
+      required: ["text"],
+    },
+  },
+  {
     name: "spotify_get_playlists",
     description:
       "Get the user's Spotify playlists and saved library. Returns playlist names and URIs. Use this FIRST to see what the user already has before searching.",


### PR DESCRIPTION
## Linked issue

Closes #331

## Why this change

Custom agents can participate in generation, but they did not have a clean way to maintain durable chat memory. This change lets users build their own memory agents that can read the current chat summary, append durable updates, and run on a configurable cadence without replacing the built-in summary agent. This change also add a general capability of a configurable execution cadence for custom agents and the ability for custom agents to return content by patching the chat meta data, both required to manage custom chat memory operations.

## What changed

- Added `read_chat_summary` and `append_chat_summary` built-in tool definitions and execution support.
- Added route-owned chat metadata patching so summary tool updates persist and stream a `metadata_patch` event back to the client.
- Passed summary-capable tool context through eligible custom agent execution.
- Refreshed chat detail state on metadata patch events so summary UI can reflect background memory updates.
- Added custom-agent cadence settings so agents can run every N eligible chat messages instead of on every generation. This setting coexists with the "Context Size" setting which is applied on top of cadence setting.
- Preserved existing upstream Knowledge Router behavior and stripped local-only workflow artifacts from the PR branch.

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Create a custom agent with the documented memory-keeper prompt, allow it to use summary tools, generate a chat response, and verify the persisted summary updates.
- Configure the custom agent to run every N eligible chat messages and verify it does not run before the cadence threshold is met.
- Verify summary UI refreshes when the custom agent updates metadata.
- Verify tools still execute for normal agents and do not regress existing custom-tool behavior.
- Verify the existing built-in chat summary agent still works or remains unaffected.
- Verify disabled custom memory-agent configuration has no side effects.
- Verify generation still works when the custom memory agent is disabled.
- Verify a summary update persists to chat metadata.
- Verify unrelated tools and custom tools still execute.

## Docs and release impact

- [x] No docs changes needed. Not applicable: this PR does not change install, update, release, or user-facing documentation behavior.
- [n/a] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [n/a] Version/release files updated. Not applicable: this PR does not include a version bump or release metadata change.

## UI evidence (if applicable)

New Trigger Cadence field added to: pop-up screen when adding a new custom agent to the chat, custom agent configuration. Built-in agent configuration is not affected.

<img width="335" height="105" alt="image" src="https://github.com/user-attachments/assets/e68be7e3-5686-4072-b2bc-c4fd443eb11b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cadence-aware run-interval inputs for custom agents with keyboard/step controls and improved add-agent/edit UIs.
  * Two built-in agent tools to read and append per-chat summaries; agents can persist and update durable chat summaries.
  * Server now enforces agent cadences so custom agents only trigger when their interval is met.
  * Reliable queued chat-metadata patching and propagation ensures summary updates persist and broadcast.

* **Bug Fixes**
  * Metadata updates now trigger UI refreshes so summaries and metadata-dependent views stay current.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->