### PR TITLE
feat: Active filter tab for Lorebooks panel

### DIFF
--- a/packages/client/src/components/panels/LorebooksPanel.tsx
+++ b/packages/client/src/components/panels/LorebooksPanel.tsx
@@ -22,8 +22,10 @@ import {
   X,
   Wand2,
   Trash2,
+  Zap,
 } from "lucide-react";
 import { useUIStore } from "../../stores/ui.store";
+import { useChatStore } from "../../stores/chat.store";
 import { useLorebooks, useDeleteLorebook, useUpdateLorebook } from "../../hooks/use-lorebooks";
 import { useCharacters, usePersonas } from "../../hooks/use-characters";
 import type { Lorebook, LorebookCategory } from "@marinara-engine/shared";
@@ -31,8 +33,9 @@ import { showConfirmDialog } from "../../lib/app-dialogs";
 import { cn } from "../../lib/utils";
 import { api } from "../../lib/api-client";
 
-const CATEGORIES: Array<{ id: LorebookCategory | "all"; label: string; icon: typeof Globe }> = [
+const CATEGORIES: Array<{ id: LorebookCategory | "all" | "active"; label: string; icon: typeof Globe }> = [
   { id: "all", label: "All", icon: Layers },
+  { id: "active", label: "Active", icon: Zap },
   { id: "world", label: "World", icon: Globe },
   { id: "character", label: "Character", icon: Users },
   { id: "npc", label: "NPC", icon: UserRound },
@@ -41,6 +44,7 @@ const CATEGORIES: Array<{ id: LorebookCategory | "all"; label: string; icon: typ
 ];
 
 const CATEGORY_COLORS: Record<string, string> = {
+  active: "from-cyan-400 to-sky-500",
   world: "from-emerald-400 to-teal-500",
   character: "from-violet-400 to-purple-500",
   npc: "from-rose-400 to-pink-500",
@@ -50,7 +54,7 @@ const CATEGORY_COLORS: Record<string, string> = {
 };
 
 export function LorebooksPanel() {
-  const [activeCategory, setActiveCategory] = useState<LorebookCategory | "all">("all");
+  const [activeCategory, setActiveCategory] = useState<LorebookCategory | "all" | "active">("all");
   const [searchQuery, setSearchQuery] = useState("");
   const [sort, setSort] = useState<"name-asc" | "name-desc" | "newest" | "oldest" | "tokens">("name-asc");
   const [activeTag, setActiveTag] = useState<string | null>(null);
@@ -59,7 +63,20 @@ export function LorebooksPanel() {
   const [selectedLorebookIds, setSelectedLorebookIds] = useState<Set<string>>(new Set());
   const [exportingSelected, setExportingSelected] = useState(false);
 
-  const { data: lorebooks, isLoading } = useLorebooks(activeCategory === "all" ? undefined : activeCategory);
+  // Active chat context for the "Active" filter
+  const activeChat = useChatStore((s) => s.activeChat);
+  const activeChatMetadata = activeChat?.metadata;
+  const activeLorebookIds: string[] = useMemo(() => {
+    if (!activeChatMetadata) return [];
+    const meta = typeof activeChatMetadata === "string" ? JSON.parse(activeChatMetadata) : activeChatMetadata;
+    return Array.isArray(meta.activeLorebookIds) ? meta.activeLorebookIds : [];
+  }, [activeChatMetadata]);
+  const activeCharacterIds = useMemo(() => activeChat?.characterIds ?? [], [activeChat?.characterIds]);
+  const activePersonaId = activeChat?.personaId ?? null;
+  const activeChatId = activeChat?.id ?? null;
+
+  // When "active" category is selected, fetch all lorebooks (no category filter) — we filter client-side
+  const { data: lorebooks, isLoading } = useLorebooks(activeCategory === "active" || activeCategory === "all" ? undefined : activeCategory);
   const { data: rawCharacters } = useCharacters();
   const { data: rawPersonas } = usePersonas();
   const deleteLorebook = useDeleteLorebook();
@@ -141,6 +158,17 @@ export function LorebooksPanel() {
   const filtered = useMemo(() => {
     if (!lorebooks) return [];
     let list = lorebooks as Lorebook[];
+    // "Active" filter: show lorebooks active in the current chat
+    // Mirrors server-side filterRelevantLorebooks: pinned + character-linked + persona-linked + chat-scoped
+    if (activeCategory === "active") {
+      list = list.filter(
+        (lb) =>
+          activeLorebookIds.includes(lb.id) ||
+          (lb.characterId && activeCharacterIds.includes(lb.characterId)) ||
+          (lb.personaId && lb.personaId === activePersonaId) ||
+          (lb.chatId && lb.chatId === activeChatId),
+      );
+    }
     if (activeTag) {
       list = list.filter((lb) => parseTags(lb).includes(activeTag));
     }
@@ -154,7 +182,7 @@ export function LorebooksPanel() {
         (lb.personaId ? (personaNameById.get(lb.personaId) ?? "").toLowerCase().includes(q) : false) ||
         parseTags(lb).some((t) => t.toLowerCase().includes(q)),
     );
-  }, [lorebooks, searchQuery, activeTag, characterNameById, personaNameById]);
+  }, [lorebooks, activeCategory, activeLorebookIds, activeCharacterIds, activePersonaId, activeChatId, searchQuery, activeTag, characterNameById, personaNameById]);
 
   const sorted = useMemo(() => {
     const list = [...filtered];

--- a/packages/client/src/components/panels/LorebooksPanel.tsx
+++ b/packages/client/src/components/panels/LorebooksPanel.tsx
@@ -68,8 +68,12 @@ export function LorebooksPanel() {
   const activeChatMetadata = activeChat?.metadata;
   const activeLorebookIds: string[] = useMemo(() => {
     if (!activeChatMetadata) return [];
-    const meta = typeof activeChatMetadata === "string" ? JSON.parse(activeChatMetadata) : activeChatMetadata;
-    return Array.isArray(meta.activeLorebookIds) ? meta.activeLorebookIds : [];
+    try {
+      const meta = typeof activeChatMetadata === "string" ? JSON.parse(activeChatMetadata) : activeChatMetadata;
+      return Array.isArray(meta.activeLorebookIds) ? meta.activeLorebookIds : [];
+    } catch {
+      return [];
+    }
   }, [activeChatMetadata]);
   const activeCharacterIds = useMemo(() => activeChat?.characterIds ?? [], [activeChat?.characterIds]);
   const activePersonaId = activeChat?.personaId ?? null;


### PR DESCRIPTION
## Linked issue

Closes #357

## Why this change

Lorebook collections grow quickly, making the panel hard to navigate. Users want to review or edit entries that are actively injecting into their current chat, but there's no way to see which lorebooks are in play without scrolling through the entire list and manually checking each book's attachment point.

## What changed

- Added an **"Active"** category tab to the Lorebooks panel (between "All" and "World", Zap icon) that filters to only lorebooks participating in the active chat's prompt assembly
- Filter mirrors server-side `filterRelevantLorebooks()` — matches on chat-pinned (`activeLorebookIds`), character-linked, persona-linked, and chat-scoped lorebooks
- Single file change: `packages/client/src/components/panels/LorebooksPanel.tsx`

## Validation

- [x] `pnpm check` passes locally (0 errors, 1 pre-existing unrelated warning in GameNarration.tsx)
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Verified Active tab shows lorebooks pinned via chat settings
- Verified Active tab shows lorebooks linked to the active character card
- Verified Active tab shows lorebooks linked to the active persona
- Verified Active tab shows lorebooks scoped to the chat
- Verified switching chats updates the filtered list correctly
- Verified no active chat selected shows empty state with no errors
- Verified light/dark mode renders correctly
- Verified mobile viewport — tab wraps naturally with flex-wrap

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

<img width="726" height="152" alt="image" src="https://github.com/user-attachments/assets/2997ab7b-3bd5-4bf0-b1ff-ca2a57624678" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an "Active" category tab to the lorebooks panel to quickly view lorebooks relevant to your current chat context, including those connected to your active character, persona, and chat.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->