### PR TITLE
fix(connections): clear API key when switching to Claude (Subscription)

### DIFF
--- a/packages/client/src/components/connections/ConnectionEditor.tsx
+++ b/packages/client/src/components/connections/ConnectionEditor.tsx
@@ -660,6 +660,12 @@ export function ConnectionEditor() {
                     setLocalBaseUrl(info.defaultBaseUrl);
                     // Clear model if switching provider
                     setLocalModel("");
+                    // Claude (Subscription) ignores the API key field and
+                    // disables the input — clear any previously typed value
+                    // so a stale key from another provider doesn't get saved.
+                    if (key === "claude_subscription") {
+                      setLocalApiKey("");
+                    }
                     markDirty();
                   }}
                   className={cn(


### PR DESCRIPTION
## Summary

Reported by **SILCORE** (Discord, v1.5.6, WSL2 Ubuntu 24.04 / Windows 11):

> If any character is present in the API Key field of the connections input before you select "Claude (Subscription)", although the selection locks the API Key field from being edited further, those character(s) cause the connection to fail.

### Reproduction
1. Create a new connection of type **Anthropic**
2. Type any API key (e.g. `abc123`)
3. Change the connection type to **Claude (Subscription)**
4. Click **Send Test Message**
5. Connection fails

### Root cause

In `ConnectionEditor.tsx`, the provider button `onClick` already auto-fills the base URL and clears the model when switching providers, but it never touches `localApiKey`. The `<input>` for API key gets `disabled` for `claude_subscription`, which hides the value visually but the React state still holds whatever was typed. On save, `if (localApiKey) payload.apiKey = localApiKey` ships the leftover string to the server, and Test Message saves first if dirty — so the stale key is what gets used.

### Fix

When the switched-to provider is `claude_subscription`, also call `setLocalApiKey("")`. Matches the reporter's expected behavior: empty the field before locking + hiding it. No server-side changes needed; the existing payload guard skips `apiKey` when it is falsy.

## Files changed
- `packages/client/src/components/connections/ConnectionEditor.tsx` — 6 lines, inside the provider button `onClick`.

## Test plan (manual — please verify)

- [x] Reproduction case: New connection -> Anthropic -> key `abc123` -> switch to Claude (Subscription) -> API Key field shows empty (still locked) -> **Send Test Message** succeeds
- [x] Reverse switch: Claude (Subscription) -> Anthropic -> API Key field is empty and editable again
- [x] Existing-connection regression: Open an Anthropic connection that already has a saved key on the server -> switch to Claude (Subscription) -> Save -> switch back to Anthropic -> original saved key on the server is still intact (we never sent a clear, just suppressed the send)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where previously entered API keys would persist when switching between connection providers, ensuring a clean state for each provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->