### PR TITLE
fix(chats): preserve folder categorization across branch create/delete

### DIFF
--- a/packages/server/src/routes/chat-folders.routes.ts
+++ b/packages/server/src/routes/chat-folders.routes.ts
@@ -76,7 +76,9 @@ export async function chatFoldersRoutes(app: FastifyInstance) {
       const folder = await storage.getById(folderId);
       if (!folder) return reply.status(404).send({ error: "Folder not found" });
     }
-    const chat = await chatsStorage.update(chatId, { folderId });
+    // Propagate the folder to every branch in the group so later branch
+    // creation/deletion doesn't drop the tree back into Uncategorized.
+    const chat = await chatsStorage.setFolderForChat(chatId, folderId);
     return reply.send(chat);
   });
 
@@ -87,7 +89,11 @@ export async function chatFoldersRoutes(app: FastifyInstance) {
     const { orderedChatIds, folderId } = req.body;
     if (!Array.isArray(orderedChatIds)) return reply.status(400).send({ error: "orderedChatIds must be an array" });
     for (let i = 0; i < orderedChatIds.length; i++) {
-      await chatsStorage.update(orderedChatIds[i]!, { folderId, sortOrder: i + 1 });
+      const id = orderedChatIds[i]!;
+      // Update sortOrder on the visible representative chat, then propagate
+      // the folder assignment to its sibling branches.
+      await chatsStorage.update(id, { sortOrder: i + 1 });
+      await chatsStorage.setFolderForChat(id, folderId);
     }
     return reply.send({ ok: true });
   });

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -1169,7 +1169,10 @@ export async function chatsRoutes(app: FastifyInstance) {
     // (preserved) timestamp, so after the loop the branched chat's updatedAt is
     // the last source message's original time. Reset it to now so the branch
     // appears at the top of the chat list as a freshly created chat.
-    await storage.update(newChat.id, {});
+    // Also inherit the source chat's folder so the branch stays inside the
+    // same categorization tree (the new branch becomes the most-recently-
+    // updated row in its group, so the sidebar reads its folderId).
+    await storage.update(newChat.id, { folderId: sourceChat.folderId ?? null });
 
     // Copy game-state snapshots from the source chat for every copied message.
     // Each snapshot is keyed by (chatId, messageId, swipeIndex), so we must re-associate

--- a/packages/server/src/services/storage/chats.storage.ts
+++ b/packages/server/src/services/storage/chats.storage.ts
@@ -97,6 +97,29 @@ export function createChatsStorage(db: DB) {
       return this.getById(id);
     },
 
+    /**
+     * Set the folder assignment for a chat, propagating to every branch that
+     * shares its groupId. The sidebar collapses each group to a single visible
+     * row whose folder is read from whichever branch is currently the
+     * representative — so when one branch is created or deleted and the rep
+     * shifts, every branch must already carry the same folderId or the whole
+     * tree falls back to Uncategorized.
+     *
+     * Sibling branches are updated without bumping updatedAt so categorizing
+     * a chat doesn't silently reorder its branch history.
+     */
+    async setFolderForChat(chatId: string, folderId: string | null) {
+      const chat = await this.getById(chatId);
+      if (!chat) return null;
+      if (chat.groupId) {
+        await db.update(chats).set({ folderId }).where(eq(chats.groupId, chat.groupId));
+        await db.update(chats).set({ updatedAt: now() }).where(eq(chats.id, chatId));
+      } else {
+        await db.update(chats).set({ folderId, updatedAt: now() }).where(eq(chats.id, chatId));
+      }
+      return this.getById(chatId);
+    },
+
     /** List all chats belonging to a group. */
     async listByGroup(groupId: string) {
       return db.select().from(chats).where(eq(chats.groupId, groupId)).orderBy(desc(chats.updatedAt));


### PR DESCRIPTION
Closes #340

## Why this change

When a user moves an RP into a folder, only the *currently visible representative* branch gets `folderId` set. The sidebar collapses every chat sharing a `groupId` into a single row and reads `folderId` from whichever branch is currently the most-recently-updated representative (`packages/client/src/components/layout/ChatSidebar.tsx` `displayChats` + `folderChatsMap`).

That coupling produced two failure modes that always dropped the tree back into Uncategorized:

1. **Branch creation.** `POST /:id/branch` calls `storage.create(...)`, which does not accept `folderId`, so the new branch lands with `folderId = null`. The post-create `storage.update(newChat.id, {})` bumps `updatedAt` to now, making the new branch the most-recently-updated row in its group — so the sidebar reads `folderId = null` from it and the whole tree appears uncategorized.
2. **Branch deletion.** Deleting any branch can surface a sibling whose `folderId` was never set (because the move-to-folder mutation only ever wrote the field on one branch). The replacement representative has `folderId = null` → tree falls out of its folder.

## What changed

- `chats.storage.ts` — new `setFolderForChat(chatId, folderId)` helper. When the chat has a `groupId`, it writes `folderId` to every branch in the group without touching siblings' `updatedAt` (so categorizing doesn't silently reorder branch history), then bumps `updatedAt` on just the targeted chat to preserve the existing "moved chat goes to top" behavior. Falls back to a single-chat update when there's no `groupId`.
- `chats.routes.ts` — branch creation passes `folderId: sourceChat.folderId ?? null` into the existing post-create `storage.update` call so the new branch inherits the source's folder. Combined with `setFolderForChat` propagation at move time, every branch in a group now always carries the same `folderId`.
- `chat-folders.routes.ts` — `/move-chat` and `/reorder-chats` route through `setFolderForChat` so any folder change applies to the whole group, not just the visible representative.

## Compatibility

- Existing single-branch chats (no `groupId`) take the unchanged single-row path.
- Existing groups whose branches already have mismatched `folderId` heal on the next move-to-folder action.
- No schema migration required — the fields already exist; only write paths changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved folder assignment handling during chat reorganization to ensure consistency across related chats.
  * Added validation when moving chats to folders; requests to non-existent folders now return appropriate errors.

* **Improvements**
  * Chat branches now automatically inherit the folder assignment from their source chat, maintaining folder organization across the chat tree.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->