### PR TITLE
Fix unstable message pagination cursor

### DIFF
--- a/packages/client/src/hooks/use-chats.ts
+++ b/packages/client/src/hooks/use-chats.ts
@@ -83,7 +83,11 @@ export function useChatMessages(chatId: string | null, pageSize: number = 0, ena
     initialPageParam: undefined as string | undefined,
     getNextPageParam: (lastPage) => {
       if (pageSize <= 0 || lastPage.length < pageSize) return undefined;
-      return lastPage[0]?.createdAt;
+      const oldestLoaded = lastPage[0];
+      if (!oldestLoaded) return undefined;
+      return typeof oldestLoaded.rowid === "number"
+        ? `${oldestLoaded.createdAt}|${oldestLoaded.rowid}`
+        : oldestLoaded.createdAt;
     },
     enabled: !!chatId && enabled,
   });

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -156,7 +156,11 @@ import { stripGmTagsKeepReadables } from "../lib/game-tag-parser";
 import type { Chat, GameMap, Message } from "@marinara-engine/shared";
 
 function sortMessagesByCreatedAt(messages: Message[]): Message[] {
-  return [...messages].sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+  return [...messages].sort((a, b) => {
+    const createdAtOrder = new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+    if (createdAtOrder !== 0) return createdAtOrder;
+    return 0;
+  });
 }
 
 function upsertPersistedMessages(qc: QueryClient, chatId: string, incoming: Message[]) {
@@ -188,7 +192,7 @@ function upsertPersistedMessages(qc: QueryClient, chatId: string, incoming: Mess
       if (pages.length === 0) {
         pages.push(missing);
       } else {
-        pages[0] = [...pages[0], ...missing];
+        pages[0] = sortMessagesByCreatedAt([...pages[0], ...missing]);
       }
     }
 
@@ -217,7 +221,7 @@ function appendMissingPersistedMessages(qc: QueryClient, chatId: string, incomin
     if (pages.length === 0) {
       pages.push(missing);
     } else {
-      pages[0] = [...pages[0], ...missing];
+      pages[0] = sortMessagesByCreatedAt([...pages[0], ...missing]);
     }
 
     return { ...old, pages };
@@ -475,8 +479,8 @@ export function useGenerate() {
         qc.setQueryData<InfiniteData<Message[]>>(chatKeys.messages(params.chatId), (old) => {
           if (!old?.pages) return old;
           const pages = [...old.pages];
-          // First page holds newest messages — append to it
-          pages[0] = [...(pages[0] ?? []), optimisticMsg];
+          // First page holds newest messages; merge and re-sort to guarantee order.
+          pages[0] = sortMessagesByCreatedAt([...(pages[0] ?? []), optimisticMsg]);
           return { ...old, pages };
         });
       }

--- a/packages/server/src/services/storage/chats.storage.ts
+++ b/packages/server/src/services/storage/chats.storage.ts
@@ -1,7 +1,7 @@
 // ──────────────────────────────────────────────
 // Storage: Chats
 // ──────────────────────────────────────────────
-import { eq, desc, and, lt, gt, sql, count, inArray } from "drizzle-orm";
+import { eq, desc, and, lt, gt, sql, count, inArray, getTableColumns } from "drizzle-orm";
 import type { DB } from "../../db/connection.js";
 import {
   chats,
@@ -38,6 +38,18 @@ function resolveTimestamps(overrides?: TimestampOverrides | null) {
 function serializeJsonField(value: unknown, fallback: Record<string, unknown>) {
   if (value === undefined || value === null) return JSON.stringify(fallback);
   return typeof value === "string" ? value : JSON.stringify(value);
+}
+
+function parseMessageCursor(before?: string): { createdAt: string; rowid: number } | null {
+  if (!before) return null;
+  const separatorIndex = before.indexOf("|");
+  if (separatorIndex <= 0 || separatorIndex === before.length - 1) return null;
+  const rowid = Number(before.slice(separatorIndex + 1));
+  if (!Number.isSafeInteger(rowid) || rowid < 1) return null;
+  return {
+    createdAt: before.slice(0, separatorIndex),
+    rowid,
+  };
 }
 
 /** Create the chat storage facade used by routes and importers. */
@@ -146,7 +158,11 @@ export function createChatsStorage(db: DB) {
     },
 
     async listMessages(chatId: string) {
-      const rows = await db.select().from(messages).where(eq(messages.chatId, chatId)).orderBy(messages.createdAt);
+      const rows = await db
+        .select({ ...getTableColumns(messages), rowid: sql<number>`messages.rowid`.as("rowid") })
+        .from(messages)
+        .where(eq(messages.chatId, chatId))
+        .orderBy(messages.createdAt, sql`messages.rowid`);
       const swipeCounts = await db
         .select({ messageId: messageSwipes.messageId, count: count() })
         .from(messageSwipes)
@@ -159,12 +175,19 @@ export function createChatsStorage(db: DB) {
     /** Paginated: returns the latest `limit` messages (optionally before a cursor). */
     async listMessagesPaginated(chatId: string, limit: number, before?: string) {
       const conditions = [eq(messages.chatId, chatId)];
-      if (before) conditions.push(lt(messages.createdAt, before));
+      const cursor = parseMessageCursor(before);
+      if (cursor) {
+        conditions.push(
+          sql`(${messages.createdAt} < ${cursor.createdAt} OR (${messages.createdAt} = ${cursor.createdAt} AND messages.rowid < ${cursor.rowid}))`,
+        );
+      } else if (before) {
+        conditions.push(lt(messages.createdAt, before));
+      }
       const rows = await db
-        .select()
+        .select({ ...getTableColumns(messages), rowid: sql<number>`messages.rowid`.as("rowid") })
         .from(messages)
         .where(and(...conditions))
-        .orderBy(desc(messages.createdAt))
+        .orderBy(desc(messages.createdAt), sql`messages.rowid desc`)
         .limit(limit);
       const reversed = rows.reverse();
       const ids = reversed.map((m) => m.id);

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -214,6 +214,8 @@ export interface Message {
   activeSwipeIndex: number;
   /** Number of swipes for this message (0 or 1 = no alternatives) */
   swipeCount?: number;
+  /** Server-side SQLite row position used only for stable pagination cursors */
+  rowid?: number;
   createdAt: string;
   /** Extra display data */
   extra: MessageExtra;


### PR DESCRIPTION
When multiple messages share the same `createdAt`, using only the timestamp as a cursor can skip or duplicate messages. Include the message id as a tiebreaker in the cursor and add `rowid`-based ordering to keep pagination deterministic.

## Linked issue

weh

Closes #

## Why this change

- Fixes unstable chat message ordering/pagination when multiple messages share the same `createdAt` timestamp, which could cause branch history pages to skip, duplicate, or misorder messages.

## What changed

- Changed chat message pagination cursors from timestamp-only to `createdAt|id`.
- Added server-side cursor parsing and rowid tie-break ordering for stable message pagination.
- Applied deterministic ordering to full message listing by sorting on `createdAt` plus `rowid`.
- Re-sorted client-side optimistic and persisted generated message merges so newly inserted messages stay in chronological order.

## Validation

- [X] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [X] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [X] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Opened established chat with 47 messages, branched chats from #47, #45 and #15
- All three confirmed to have correct message order and original timestamps from source chat.
- Started fresh chat, exchanged messages until 20+ messages, branched from #23. All messages with correct order and timestamps.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)


## UI evidence (if applicable)

<!-- Add before/after screenshots or recordings for UI changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced pagination stability when loading earlier messages in conversations.
  * Improved message ordering consistency throughout chat history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->