### PR TITLE
Update prompt test assertions for language and skill_check

### DIFF
--- a/packages/server/test/game-session-prompts.test.ts
+++ b/packages/server/test/game-session-prompts.test.ts
@@ -145,15 +145,19 @@ test("GM format reminder reinforces native-language output quality near generati
     language: "Polski",
   });
 
-  assert.match(prompt, /Write every player-visible line in native Polish\./);
-  assert.match(prompt, /The English examples below are format-only; do not imitate their wording or syntax\./);
+  assert.match(prompt, /Write prose directly in Polish like a native speaker\./);
+  assert.match(prompt, /Think in it from the start, don't translate from English\./);
   assert.match(
     prompt,
-    /Before finalizing, silently copy-edit for grammar, word order, punctuation, orthography, and language-specific agreement, removing calques, mixed-language scaffolding, and untranslated filler\./,
+    /The English examples below are for formatting only; ignore their wording and syntax\./,
   );
   assert.match(
     prompt,
-    /Only tags, commands, field names, and deliberate proper nouns or code terms may remain in English\./,
+    /After drafting, reread each sentence and fix: inflection and agreement, verb aspect, word order, prepositions, and anything that sounds translated even if grammatical\./,
+  );
+  assert.match(
+    prompt,
+    /Only tags, commands, field names, and intentional proper nouns stay in English\./,
   );
   assert.doesNotMatch(prompt, /native Polski/);
 });
@@ -191,7 +195,10 @@ test("GM format reminder documents the simplified resolved skill_check command",
     /\[skill_check: skill="Skill Name" dc="1-20" rolls="1-20" modifier="0-10" total="roll \+ modifier \| 1 \| 20" result="critical_success \| success \| failure \| critical_failure"\]/,
   );
   assert.match(prompt, /when uncertainty or the player's actions should be resolved mechanically\./);
-  assert.match(prompt, /You choose the roll result fairly, then narrate the consequence in the same turn\./);
+  assert.match(
+    prompt,
+    /Abandon positivity bias: choose DC \(5 trivial, 10 routine under pressure, 15 hard, 20 desperate\), roll honestly, and narrate the consequence in the same turn\./,
+  );
   assert.doesNotMatch(prompt, /Legacy fallback:/);
   assert.doesNotMatch(prompt, /\bused=/);
   assert.doesNotMatch(prompt, /\bmode=/);


### PR DESCRIPTION
Reflects revised GM instructions: clearer native-language output guidance and explicit DC scale with positivity-bias reminder.

## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- Fixes stale server prompt tests that were failing because they expected older native-language and skill-check reminder wording. The current prompt behavior is intentional and higher quality, so the tests needed to assert the updated wording instead of forcing a prompt regression.

## What changed

<!-- List the key changes in this PR -->

- Updated `packages/server/test/game-session-prompts.test.ts` to match the current native-language reminder text.
- Updated the skill-check assertion to match the current “abandon positivity bias / roll honestly” prompt wording.
- No production prompt behavior was changed.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [X] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [X] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Ran `pnpm --filter @marinara-engine/server exec tsx --test test/game-session-prompts.test.ts`; all 8 tests passed.
- Ran `pnpm --filter @marinara-engine/server test`; all 97 server tests passed.
- No browser/manual app verification was performed because this change only updates server test assertions.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)


## UI evidence (if applicable)

<!-- Add before/after screenshots or recordings for UI changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated GM format reminders with improved Polish-language quality guidance and native speaker phrasing.
  * Enhanced skill check command with explicit DC selection guidance (5/10/15/20), honest rolling instructions, and consequence narration clarification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->