### PR TITLE
fix(game): full-body sprite no longer stuck on first pose in Game Mode

### DIFF
--- a/packages/client/src/components/chat/SpriteOverlay.tsx
+++ b/packages/client/src/components/chat/SpriteOverlay.tsx
@@ -98,6 +98,8 @@ export function SpriteOverlay({
 
   // When agent result arrives, prefer it over keyword detection
   useEffect(() => {
+    // Full-body sprites use poses from spriteExpressions (game mode); the facial-expression agent would overwrite them with values like "happy" that don't match any full_* sprite.
+    if (fullBodyOnly) return;
     if (expressionResult?.success && expressionResult.data && expressionResult !== appliedResultRef.current) {
       const data = expressionResult.data as {
         expressions?: Array<{ characterId: string; expression: string; transition?: string }>;
@@ -127,7 +129,7 @@ export function SpriteOverlay({
         return;
       }
     }
-  }, [expressionResult, onExpressionChange]);
+  }, [expressionResult, onExpressionChange, fullBodyOnly]);
 
   // Apply saved per-swipe expressions whenever the prop changes (e.g. user swipes).
   // This runs independently of the agent store so swiping always updates the sprite.
@@ -150,6 +152,8 @@ export function SpriteOverlay({
 
   // Fallback: keyword-based detection when no agent result.
   useEffect(() => {
+    // Same reason as the agent effect: keyword detection produces facial expressions, not full-body poses.
+    if (fullBodyOnly) return;
     if (!messages?.length) return;
     // Only skip fallback when the current agent result has already been applied
     if (expressionResult?.success && expressionResult === appliedResultRef.current) return;
@@ -180,7 +184,7 @@ export function SpriteOverlay({
     }
 
     setStates(newStates);
-  }, [messages, characterIds, expressionResult, spriteExpressions]);
+  }, [messages, characterIds, expressionResult, spriteExpressions, fullBodyOnly]);
 
   const visibleChars = characterIds.slice(0, 3);
   const resolvedPlacements = useMemo(() => {


### PR DESCRIPTION
## Summary

In Game Mode, the full-body character sprite was stuck on the first
sprite alphabetically and never updated during scenes — the facial
expression sprite worked correctly. This PR restores per-pose updates
for the full-body overlay.

## Why

Reported by a [user on Discord](https://discord.com/channels/1417099416812392641/1499560895154618368) (Windows 11, .exe installer, ME 1.5.6):
> Since the last update, full-body sprites in Game Mode only display
> the first one from the list, and never update during scenes. Facial
> expressions work perfectly.

The full-body `SpriteOverlay` (rendered with `fullBodyOnly`) shares the
same component as the dialogue avatar overlay. Both subscribed to the
expression agent (which emits facial expressions like `"happy"` /
`"angry"`) and the keyword fallback (which derives the same from message
text). For the full-body overlay, those values don't match any `full_*`
sprite — so the resolver fell through to the neutral fallback (`full_idle`
if present, otherwise `spriteList[0]`), leaving the sprite stuck on a
single image regardless of the pose the dialogue/combat resolver
intended.

## Fix

When `fullBodyOnly={true}`, skip the agent-expression effect and the
keyword fallback effect. The explicit pose passed via `spriteExpressions`
(set by `GameSurface` from `resolveDialogueFullBodyPose` /
`resolveCombatFullBodyPose`) becomes the sole source of truth for the
full-body overlay's pose state. The dialogue avatar overlay path is
untouched.

Files touched: `packages/client/src/components/chat/SpriteOverlay.tsx`
(6 lines added, 2 modified — two early-returns and two effect dependency
arrays updated).

## Test plan

- [x]  Open a Game Mode chat with a character that has multiple `full_*.png` sprites (e.g. `full_idle`, `full_attack`, `full_battle_stance`, `full_casting`, `full_defend`, `full_hurt`, `full_victory`).
- [x] Confirm during dialogue scenes the full-body sprite shows the `idle` pose (or `battle_stance` if `idle` is missing) — not stuck on the alphabetically-first sprite.
- [x] Trigger combat with the character as a player party member. Confirm full-body sprite rotates between `attack`, `defend`, `casting`, `hurt`, `victory`, and `battle_stance` as combat phases advance — not stuck on a single image.
- [x] Confirm the dialogue avatar (small portrait next to the dialogue text) still updates with facial expressions per the expression agent — this overlay should be unaffected.
- [x] Light + dark mode look correct in the Game Mode dialogue/combat surface.
- [x] Mobile viewport (~400px wide) — sprite still renders correctly.

## Notes

No related issue was opened for this bug AFAIK; happy to file one if reviewers prefer that workflow before merge.

I tested the fix with Prof Mari as my sparring partner and she bled tomato sauce. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where facial expressions were incorrectly overridden when displaying full-body sprites. The overlay now properly respects full-body-only mode and prevents unwanted expression updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->