### PR TITLE
fix(chat): hide deleted characters from group trigger response menu

### DIFF
--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -1124,15 +1124,17 @@ export function ChatRoleplaySurface({
                   }
                   chatCharacters={
                     chatCharIds.length > 1
-                      ? chatCharIds.map((id) => {
-                          const info = characterMap.get(id);
-                          return {
-                            id,
-                            name: info?.name ?? "Unknown",
-                            avatarUrl: info?.avatarUrl ?? null,
-                            avatarCrop: info?.avatarCrop ?? null,
-                          };
-                        })
+                      ? chatCharIds
+                          .filter((id) => characterMap.has(id))
+                          .map((id) => {
+                            const info = characterMap.get(id)!;
+                            return {
+                              id,
+                              name: info.name,
+                              avatarUrl: info.avatarUrl ?? null,
+                              avatarCrop: info.avatarCrop ?? null,
+                            };
+                          })
                       : undefined
                   }
                 />

--- a/packages/client/src/components/chat/ConversationView.tsx
+++ b/packages/client/src/components/chat/ConversationView.tsx
@@ -908,17 +908,19 @@ export function ConversationView({
         }
         chatCharacters={
           chatCharIds.length > 1
-            ? chatCharIds.map((id) => {
-                const info = characterMap.get(id);
-                return {
-                  id,
-                  name: info?.name ?? "Unknown",
-                  avatarUrl: info?.avatarUrl ?? null,
-                  avatarCrop: info?.avatarCrop ?? null,
-                  conversationStatus: info?.conversationStatus,
-                  conversationActivity: info?.conversationActivity,
-                };
-              })
+            ? chatCharIds
+                .filter((id) => characterMap.has(id))
+                .map((id) => {
+                  const info = characterMap.get(id)!;
+                  return {
+                    id,
+                    name: info.name,
+                    avatarUrl: info.avatarUrl ?? null,
+                    avatarCrop: info.avatarCrop ?? null,
+                    conversationStatus: info.conversationStatus,
+                    conversationActivity: info.conversationActivity,
+                  };
+                })
             : undefined
         }
       />


### PR DESCRIPTION
## Summary
In group chats with Individual + Manual response mode, deleted character cards appeared as "Unknown" entries in the trigger response picker (the button between emote and send). Users had no way to remove them since the deleted characters no longer existed under Chat Settings → Characters.

This fix filters out IDs whose characters no longer exist before rendering the picker, matching the convention already used by the chat settings drawer.

Reported in: [Discord](https://discord.com/channels/1417099416812392641/1499649588066517133)

## Why
The server's `DELETE /characters/:id` route intentionally does not cascade-clean `chat.characterIds` arrays in existing chats. The client convention is to tolerate dangling IDs by filtering on render — this is what `ChatSettingsDrawer.tsx:1383-1384` already does (`if (!c) return null`).

The trigger response picker was the one render path that didn't follow this convention. Instead of filtering, it mapped every ID and fell back to `name: "Unknown"`, producing visible-but-uninteractable phantom entries.

## What changed
Two files, identical fix pattern:

- `ChatRoleplaySurface.tsx` — `chatCharacters` prop now `.filter()`s by `characterMap.has(id)` before mapping.
- `ConversationView.tsx` — same filter applied to the conversation-mode surface.

No server changes. No schema changes. No new tests (no automated test suite for this surface).

## Edge cases
- If enough characters get deleted that fewer than 2 valid characters remain, the trigger button correctly disappears (the picker visibility gate already checks `chatCharacters.length > 1` after filtering).
- Pre-existing related issue (out of scope for this PR): the "Characters" section count badge in the chat settings drawer reads raw `chatCharIds.length` and can be off-by-one when stale IDs exist. Will file as a separate follow-up.

## Test plan
Manual verification on Windows test install (port 7820), Roleplay mode group chat, Individual + Manual response order:

- [x] Created a group chat with 3 characters, confirmed trigger response menu lists all 3
- [x] Deleted one character from the Characters panel
- [x] Reopened the chat → confirmed the trigger response menu now shows only the 2 remaining characters (no "Unknown" entry)
- [x] Verified at light mode and dark mode
- [x] Verified at ~400px viewport width (mobile)
- [x] Confirmed `pnpm check` passes locally

## Screenshots
**Before** (current bug — two deleted characters appear as "Unknown"):
<img width="764" height="758" alt="image" src="https://github.com/user-attachments/assets/6e4f2b7c-c8bc-4d53-9939-d0f0d2824275" />

**After** (this PR — only valid characters listed):
<img width="225" height="143" alt="image" src="https://github.com/user-attachments/assets/0677c434-d01b-4437-b451-c5b9cd8f7f15" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat character display to only show valid characters that exist in the system, removing placeholder entries for missing characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->