### PR TITLE
fix(game): preserve generated asset image extensions

### DIFF
--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -4,7 +4,7 @@
 import type { FastifyInstance } from "fastify";
 import { randomUUID } from "crypto";
 import { existsSync, readFileSync } from "fs";
-import { join } from "path";
+import { extname, join } from "path";
 import { z } from "zod";
 import { logger } from "../lib/logger.js";
 import { createChatsStorage } from "../services/storage/chats.storage.js";
@@ -138,6 +138,7 @@ function findCharAvatarFuzzy(npcName: string, charAvatarByName: Map<string, stri
 }
 
 const ILLUSTRATION_COOLDOWN_TURNS = 2;
+const GENERATED_ILLUSTRATION_EXTS = ["png", "jpg", "jpeg", "webp", "avif", "gif"] as const;
 
 function currentGameSessionNumber(meta: Record<string, unknown>): number | null {
   return typeof meta.gameSessionNumber === "number" && Number.isFinite(meta.gameSessionNumber)
@@ -290,11 +291,14 @@ async function addGeneratedIllustrationToGallery(opts: {
   const slug = opts.tag.slice(prefix.length);
   if (!/^[a-z0-9-]+$/.test(slug)) return;
 
-  const assetPath = join(GAME_ASSETS_DIR, "backgrounds", "illustrations", `${slug}.png`);
-  if (!existsSync(assetPath)) return;
+  const assetPath = GENERATED_ILLUSTRATION_EXTS.map((ext) =>
+    join(GAME_ASSETS_DIR, "backgrounds", "illustrations", `${slug}.${ext}`),
+  ).find((candidate) => existsSync(candidate));
+  if (!assetPath) return;
 
   try {
-    const filePath = saveImageToDisk(opts.chatId, readFileSync(assetPath).toString("base64"), "png");
+    const ext = extname(assetPath).toLowerCase().replace(/^\./, "") || "png";
+    const filePath = saveImageToDisk(opts.chatId, readFileSync(assetPath).toString("base64"), ext);
     const gallery = createGalleryStorage(opts.app.db);
     const prompt = [opts.illustration.reason, opts.illustration.prompt].filter(Boolean).join("\n\n");
     await gallery.create({

--- a/packages/server/src/services/game/game-asset-generation.ts
+++ b/packages/server/src/services/game/game-asset-generation.ts
@@ -11,7 +11,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { logger } from "../../lib/logger.js";
 import { join } from "path";
 import { DATA_DIR } from "../../utils/data-dir.js";
-import { generateImage, type ImageGenRequest } from "../image/image-generation.js";
+import { generateImage, type ImageGenResult } from "../image/image-generation.js";
 import { buildAssetManifest, GAME_ASSETS_DIR } from "./asset-manifest.service.js";
 import type { PromptOverridesStorage } from "../storage/prompt-overrides.storage.js";
 import { loadPrompt, GAME_NPC_PORTRAIT, GAME_BACKGROUND, GAME_SCENE_ILLUSTRATION } from "../prompt-overrides/index.js";
@@ -19,6 +19,8 @@ import { loadPrompt, GAME_NPC_PORTRAIT, GAME_BACKGROUND, GAME_SCENE_ILLUSTRATION
 const NPC_AVATAR_DIR = join(DATA_DIR, "avatars", "npc");
 const GAME_BACKGROUND_WIDTH = 1024;
 const GAME_BACKGROUND_HEIGHT = 576;
+const GAME_BACKGROUND_EXTS = ["png", "jpg", "jpeg", "webp", "avif", "gif"] as const;
+const GAME_BACKGROUND_EXT_SET = new Set<string>(GAME_BACKGROUND_EXTS);
 
 // sharp is optional in the server package. Generated game backgrounds should be
 // stored at the VN canvas ratio when possible, but generation must still work on
@@ -43,19 +45,75 @@ async function getSharp(): Promise<SharpFn | null> {
   }
 }
 
-async function gameBackgroundBuffer(base64: string): Promise<Buffer> {
-  const input = Buffer.from(base64, "base64");
+type GameBackgroundImage = {
+  buffer: Buffer;
+  ext: string;
+};
+
+function detectImageExt(buffer: Buffer): string | null {
+  if (buffer[0] === 0x89 && buffer[1] === 0x50 && buffer[2] === 0x4e && buffer[3] === 0x47) return "png";
+  if (buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff) return "jpg";
+  if (buffer[0] === 0x47 && buffer[1] === 0x49 && buffer[2] === 0x46) return "gif";
+  if (
+    buffer[0] === 0x52 &&
+    buffer[1] === 0x49 &&
+    buffer[2] === 0x46 &&
+    buffer[3] === 0x46 &&
+    buffer[8] === 0x57 &&
+    buffer[9] === 0x45 &&
+    buffer[10] === 0x42 &&
+    buffer[11] === 0x50
+  ) {
+    return "webp";
+  }
+  if (buffer[4] === 0x66 && buffer[5] === 0x74 && buffer[6] === 0x79 && buffer[7] === 0x70) {
+    const brand = buffer.subarray(8, 12).toString("ascii").toLowerCase();
+    if (brand.startsWith("avif") || brand.startsWith("avis")) return "avif";
+  }
+  return null;
+}
+
+function normalizeGeneratedImageExt(result: Pick<ImageGenResult, "mimeType" | "ext">, buffer: Buffer): string {
+  const detectedExt = detectImageExt(buffer);
+  if (detectedExt) return detectedExt;
+
+  const ext = result.ext.trim().toLowerCase().replace(/^\./, "");
+  if (GAME_BACKGROUND_EXT_SET.has(ext)) return ext === "jpeg" ? "jpg" : ext;
+
+  const mime = result.mimeType.toLowerCase();
+  if (mime.includes("jpeg") || mime.includes("jpg")) return "jpg";
+  if (mime.includes("webp")) return "webp";
+  if (mime.includes("avif")) return "avif";
+  if (mime.includes("gif")) return "gif";
+  return "png";
+}
+
+async function gameBackgroundImage(result: ImageGenResult): Promise<GameBackgroundImage> {
+  const input = Buffer.from(result.base64, "base64");
   const sharp = await getSharp();
-  if (!sharp) return input;
+  if (!sharp) return { buffer: input, ext: normalizeGeneratedImageExt(result, input) };
   try {
-    return await sharp(input)
+    const buffer = await sharp(input)
       .resize(GAME_BACKGROUND_WIDTH, GAME_BACKGROUND_HEIGHT, { fit: "cover", position: "centre" })
       .png()
       .toBuffer();
+    return { buffer, ext: "png" };
   } catch (err) {
     logger.warn(err, "[game-asset-gen] Failed to resize generated game background; saving original image");
-    return input;
+    return { buffer: input, ext: normalizeGeneratedImageExt(result, input) };
   }
+}
+
+function generatedBackgroundPath(targetDir: string, slug: string, ext: string): string {
+  return join(targetDir, `${slug}.${ext}`);
+}
+
+function existingGeneratedBackgroundPath(targetDir: string, slug: string): string | null {
+  for (const ext of GAME_BACKGROUND_EXTS) {
+    const candidate = generatedBackgroundPath(targetDir, slug, ext);
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
 }
 
 export function readAvatarBase64(avatarPath: string | null | undefined): string | undefined {
@@ -262,15 +320,13 @@ export async function generateBackground(req: BackgroundGenRequest): Promise<str
   if (!slug) return null;
 
   const subcategory = genreToFolder(req.genre);
-  const filename = `${slug}.png`;
   const targetDir = join(GAME_ASSETS_DIR, "backgrounds", subcategory);
-  const targetPath = join(targetDir, filename);
 
   // Build asset tag: backgrounds:<category>:<slug>
   const tag = `backgrounds:${subcategory}:${slug}`;
 
   // Skip if already generated
-  if (existsSync(targetPath)) {
+  if (existingGeneratedBackgroundPath(targetDir, slug)) {
     return tag;
   }
 
@@ -309,8 +365,9 @@ export async function generateBackground(req: BackgroundGenRequest): Promise<str
     );
 
     if (!existsSync(targetDir)) mkdirSync(targetDir, { recursive: true });
-    const imageBuffer = await gameBackgroundBuffer(result.base64);
-    writeFileSync(targetPath, imageBuffer);
+    const image = await gameBackgroundImage(result);
+    const targetPath = generatedBackgroundPath(targetDir, slug, image.ext);
+    writeFileSync(targetPath, image.buffer);
 
     // Rebuild manifest so the new tag is available immediately
     buildAssetManifest();
@@ -319,7 +376,7 @@ export async function generateBackground(req: BackgroundGenRequest): Promise<str
     req.debugLog?.(
       "[debug/game/image-generation] background result slug=%s bytes=%d tag=%s",
       slug,
-      imageBuffer.byteLength,
+      image.buffer.byteLength,
       tag,
     );
     return tag;
@@ -332,9 +389,7 @@ export async function generateBackground(req: BackgroundGenRequest): Promise<str
 export async function generateSceneIllustration(req: SceneIllustrationGenRequest): Promise<string | null> {
   const baseSlug = safeName(req.slug || req.reason || req.prompt.slice(0, 80)) || "scene-illustration";
   const slug = `${baseSlug}-${Date.now().toString(36)}`;
-  const filename = `${slug}.png`;
   const targetDir = join(GAME_ASSETS_DIR, "backgrounds", "illustrations");
-  const targetPath = join(targetDir, filename);
   const tag = `backgrounds:illustrations:${slug}`;
 
   const styleHint = [req.artStyle, req.genre, req.setting].filter(Boolean).join(", ");
@@ -382,15 +437,16 @@ export async function generateSceneIllustration(req: SceneIllustrationGenRequest
     );
 
     if (!existsSync(targetDir)) mkdirSync(targetDir, { recursive: true });
-    const imageBuffer = await gameBackgroundBuffer(result.base64);
-    writeFileSync(targetPath, imageBuffer);
+    const image = await gameBackgroundImage(result);
+    const targetPath = generatedBackgroundPath(targetDir, slug, image.ext);
+    writeFileSync(targetPath, image.buffer);
     buildAssetManifest();
 
     logger.info('[game-asset-gen] Generated scene illustration "%s" -> tag: %s', slug, tag);
     req.debugLog?.(
       "[debug/game/image-generation] scene illustration result slug=%s bytes=%d tag=%s",
       slug,
-      imageBuffer.byteLength,
+      image.buffer.byteLength,
       tag,
     );
     return tag;


### PR DESCRIPTION
## Linked issue

Closes #371

## Why this change

- Generated Game Mode backgrounds can be saved as `.png` even when the image provider returns JPEG bytes, especially when `sharp` is unavailable or fails before re-encoding.
- Mismatched file extensions confuse image editors and make generated assets look corrupt or mislabeled.

## What changed

- Preserve the actual image extension when generated game backgrounds cannot be normalized through `sharp`.
- Detect fallback image formats from file signatures before trusting provider metadata.
- Let generated scene illustrations copied to the gallery use the saved asset extension instead of assuming PNG.
- Share the generated background extension allowlist between the generator and route layer.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `pnpm --filter @marinara-engine/server lint`
- `pnpm --filter @marinara-engine/server test`
- `pnpm --filter @marinara-engine/server build`
- No browser/UI manual verification performed; this is a server-side asset persistence fix.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

N/A, server-side generated asset persistence fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Gallery background illustrations now support multiple image formats (PNG, JPEG, GIF, WebP, AVIF) instead of PNG only
  * Original image format is preserved during processing and storage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->