### PR TITLE
Lorebook folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 - Resizing sprites in game mode.
 - Conversation auto-summarization now has a Day Rollover Hour (so a late-night session doesn't get cut in half when calendar midnight passes) and a Recent Message Tail (keeps the last N messages verbatim across the day boundary so characters wake up remembering the actual flow of last night, not just the gist). Defaults: 4 AM rollover, 10-message tail.
 - Conversation characters can now emit durable `<note>...</note>` tags for connected roleplay and game chats. Notes persist in the target chat's prompt until cleared from Chat Settings.
+- Lorebook entries now use compact rows with inline controls and an expandable inline editor.
+- Lorebook entries can now be grouped into collapsible folders to reduce vertical clutter for stable or AI-managed entries. Folders have their own enable/disable toggle that gates every entry inside (regardless of each entry's own toggle) without modifying the entries' individual settings, so re-enabling a folder restores everything to how it was. Each folder is its own container — sort by Order works inside the folder, and a folder full of high-Order entries can sit above root-level entries with low Order without conflict. Move entries between folders via a per-row folder picker or drag-and-drop. Collapse state is per-browser (localStorage). Folders are flat in this release; nesting may follow.
 
 ### Fixed
 
@@ -61,6 +63,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 - Minor adjustments to some agent widgets.
 - Game mode now supports multiple maps.
 - Debug mode restored.
+- Expression Engine retries now load available sprites, validate returned expressions, and persist the corrected sprite state.
 
 ## [1.5.5]
 

--- a/packages/client/src/components/lorebooks/LorebookEditor.tsx
+++ b/packages/client/src/components/lorebooks/LorebookEditor.tsx
@@ -1,27 +1,25 @@
 // ──────────────────────────────────────────────
 // Lorebook Editor — Full-page detail view
 // Replaces the chat area when editing a lorebook.
-// Tabs: Overview, Entries, Entry Editor
+// Tabs: Overview, Entries
+//
+// Entries use compact inline rows with an expandable drawer (see
+// LorebookEntryRow). The previous "click an entry → navigate to a sub-view"
+// flow has been replaced so users can edit row-level params without leaving
+// the list. Inspired by SillyTavern's World Info layout.
 // ──────────────────────────────────────────────
-import {
-  useState,
-  useEffect,
-  useLayoutEffect,
-  useCallback,
-  useMemo,
-  useRef,
-  type DragEvent as ReactDragEvent,
-  type KeyboardEvent as ReactKeyboardEvent,
-} from "react";
+import { useState, useEffect, useCallback, useMemo, useRef, type DragEvent as ReactDragEvent } from "react";
 import {
   useLorebook,
   useUpdateLorebook,
   useLorebookEntries,
   useCreateLorebookEntry,
-  useUpdateLorebookEntry,
-  useDeleteLorebookEntry,
   useDeleteLorebook,
   useReorderLorebookEntries,
+  useLorebookFolders,
+  useCreateLorebookFolder,
+  useUpdateLorebookEntry,
+  useReorderLorebookFolders,
 } from "../../hooks/use-lorebooks";
 import { useCharacters, usePersonas } from "../../hooks/use-characters";
 import { useConnections } from "../../hooks/use-connections";
@@ -36,30 +34,58 @@ import {
   Trash2,
   Search,
   Settings2,
-  Key,
   ToggleLeft,
   ToggleRight,
   AlertTriangle,
-  ChevronRight,
   Globe,
   Users,
   UserRound,
-  Maximize2,
   X,
   ArrowUpDown,
-  GripVertical,
   Hash,
   Sparkles,
   Loader2,
   Check,
-  Lock,
   Tag,
   Wand2,
+  FolderPlus,
 } from "lucide-react";
 import { cn } from "../../lib/utils";
 import { HelpTooltip } from "../ui/HelpTooltip";
 import { api } from "../../lib/api-client";
-import type { Lorebook, LorebookEntry, LorebookCategory } from "@marinara-engine/shared";
+import type { Lorebook, LorebookEntry, LorebookFolder, LorebookCategory } from "@marinara-engine/shared";
+import { LorebookEntryRow } from "./LorebookEntryRow";
+import { LorebookFolderRow } from "./LorebookFolderRow";
+import { estimateTokens } from "./LorebookFormFields";
+
+// ──────────────────────────────────────────────
+// Folder collapse state lives in localStorage — purely a UI preference, not
+// worth a server round-trip on every toggle. Keyed per-lorebook so collapse
+// state is independent across books.
+// ──────────────────────────────────────────────
+const FOLDER_COLLAPSE_KEY_PREFIX = "lorebook-folder-collapsed:";
+
+function readCollapsedFolderIds(lorebookId: string | null): Set<string> {
+  if (!lorebookId || typeof window === "undefined") return new Set();
+  try {
+    const raw = window.localStorage.getItem(`${FOLDER_COLLAPSE_KEY_PREFIX}${lorebookId}`);
+    if (!raw) return new Set();
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) return new Set(parsed.filter((id): id is string => typeof id === "string"));
+    return new Set();
+  } catch {
+    return new Set();
+  }
+}
+
+function writeCollapsedFolderIds(lorebookId: string, ids: Set<string>) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(`${FOLDER_COLLAPSE_KEY_PREFIX}${lorebookId}`, JSON.stringify(Array.from(ids)));
+  } catch {
+    /* localStorage unavailable / quota exceeded — silently degrade */
+  }
+}
 
 // ── Types ──
 const TABS = [
@@ -75,10 +101,6 @@ const CATEGORY_OPTIONS: Array<{ value: LorebookCategory; label: string; icon: ty
   { value: "spellbook", label: "Spellbook", icon: Wand2 },
   { value: "uncategorized", label: "Uncategorized", icon: BookOpen },
 ];
-
-function estimateTokens(text: string): number {
-  return Math.ceil(text.length / 4);
-}
 
 type EntrySortKey = "order" | "name-asc" | "name-desc" | "tokens" | "keys" | "newest" | "oldest";
 
@@ -97,17 +119,20 @@ export function LorebookEditor() {
   const closeDetail = useUIStore((s) => s.closeLorebookDetail);
   const { data: rawLorebook, isLoading } = useLorebook(lorebookId);
   const { data: rawEntries } = useLorebookEntries(lorebookId);
+  const { data: rawFolders } = useLorebookFolders(lorebookId);
   const { data: rawCharacters } = useCharacters();
   const { data: rawPersonas } = usePersonas();
   const updateLorebook = useUpdateLorebook();
   const deleteLorebook = useDeleteLorebook();
   const createEntry = useCreateLorebookEntry();
   const updateEntry = useUpdateLorebookEntry();
-  const deleteEntry = useDeleteLorebookEntry();
   const reorderEntries = useReorderLorebookEntries();
+  const createFolder = useCreateLorebookFolder();
+  const reorderFolders = useReorderLorebookFolders();
 
   const lorebook = rawLorebook as Lorebook | undefined;
   const entries = useMemo(() => (rawEntries ?? []) as LorebookEntry[], [rawEntries]);
+  const folders = useMemo(() => (rawFolders ?? []) as LorebookFolder[], [rawFolders]);
   const characters = useMemo(() => {
     if (!rawCharacters) return [] as Array<{ id: string; name: string }>;
     return (rawCharacters as Array<{ id: string; data: string | Record<string, unknown> }>).map((c) => {
@@ -129,13 +154,12 @@ export function LorebookEditor() {
   }, [rawPersonas]);
 
   const [activeTab, setActiveTab] = useState<TabId>("overview");
-  const [editingEntryId, setEditingEntryId] = useState<string | null>(null);
+  const [expandedEntryId, setExpandedEntryId] = useState<string | null>(null);
   const [lorebookDirty, setLorebookDirty] = useState(false);
-  const [entryDirty, setEntryDirty] = useState(false);
   const setEditorDirty = useUIStore((s) => s.setEditorDirty);
   useEffect(() => {
-    setEditorDirty(lorebookDirty || entryDirty);
-  }, [lorebookDirty, entryDirty, setEditorDirty]);
+    setEditorDirty(lorebookDirty);
+  }, [lorebookDirty, setEditorDirty]);
   const [saving, setSaving] = useState(false);
   const [showUnsavedWarning, setShowUnsavedWarning] = useState(false);
   const [entrySearch, setEntrySearch] = useState("");
@@ -143,6 +167,40 @@ export function LorebookEditor() {
   const [draggingEntryIdx, setDraggingEntryIdx] = useState<number | null>(null);
   const [entryDragReadyIdx, setEntryDragReadyIdx] = useState<number | null>(null);
   const [entryDropIdx, setEntryDropIdx] = useState<number | null>(null);
+
+  // ── Folder UI state ──
+  // Collapse state: persisted in localStorage, keyed per-lorebook. Loaded
+  // synchronously on mount so the initial render reflects the user's prior
+  // preference instead of a flash-of-everything-expanded.
+  const [collapsedFolderIds, setCollapsedFolderIds] = useState<Set<string>>(() => readCollapsedFolderIds(lorebookId));
+  // When the user opens a different lorebook, reload its collapse state.
+  useEffect(() => {
+    setCollapsedFolderIds(readCollapsedFolderIds(lorebookId));
+  }, [lorebookId]);
+  const toggleFolderCollapsed = useCallback(
+    (folderId: string) => {
+      if (!lorebookId) return;
+      setCollapsedFolderIds((prev) => {
+        const next = new Set<string>(prev);
+        if (next.has(folderId)) next.delete(folderId);
+        else next.add(folderId);
+        writeCollapsedFolderIds(lorebookId, next);
+        return next;
+      });
+    },
+    [lorebookId],
+  );
+
+  // Cross-container drag-and-drop state. The "container" is null for the root
+  // group or a folder.id for entries inside a folder. We track the source
+  // container so a drop can detect a cross-container move and update the
+  // entry's folderId before reordering.
+  const [dragSourceContainer, setDragSourceContainer] = useState<string | null | undefined>(undefined);
+  const [dropTargetContainer, setDropTargetContainer] = useState<string | null | undefined>(undefined);
+  // Folder reorder uses its own pair so it doesn't entangle with entry DnD.
+  const [draggingFolderIdx, setDraggingFolderIdx] = useState<number | null>(null);
+  const [folderDragReadyIdx, setFolderDragReadyIdx] = useState<number | null>(null);
+  const [folderDropIdx, setFolderDropIdx] = useState<number | null>(null);
 
   // ── Form state for lorebook overview ──
   const [formName, setFormName] = useState("");
@@ -158,10 +216,7 @@ export function LorebookEditor() {
   const [formTags, setFormTags] = useState<string[]>([]);
   const [newTag, setNewTag] = useState("");
 
-  // ── Form state for entry editor ──
-  const [entryForm, setEntryForm] = useState<Partial<LorebookEntry> | null>(null);
   const loadedLorebookIdRef = useRef<string | null>(null);
-  const loadedEntryIdRef = useRef<string | null>(null);
 
   // Load lorebook data into form
   useEffect(() => {
@@ -184,26 +239,8 @@ export function LorebookEditor() {
     loadedLorebookIdRef.current = lorebook.id;
   }, [lorebook, lorebookDirty]);
 
-  // Load entry data into form
-  useEffect(() => {
-    if (!editingEntryId) {
-      setEntryForm(null);
-      setEntryDirty(false);
-      loadedEntryIdRef.current = null;
-      return;
-    }
-    const entry = entries.find((e) => e.id === editingEntryId);
-    if (!entry) return;
-
-    const hasSwitchedEntries = loadedEntryIdRef.current !== editingEntryId;
-    if (!hasSwitchedEntries && entryDirty) return;
-
-    setEntryForm({ ...entry });
-    setEntryDirty(false);
-    loadedEntryIdRef.current = editingEntryId;
-  }, [editingEntryId, entries, entryDirty]);
-
-  // Filtered + sorted entries
+  // Filtered + sorted entries (flat list — used when search is active or
+  // a non-Order sort is selected, both of which suppress folder grouping).
   const filteredEntries = useMemo(() => {
     let result = entries;
     if (entrySearch) {
@@ -233,34 +270,55 @@ export function LorebookEditor() {
         return [...result].sort((a, b) => a.order - b.order);
     }
   }, [entries, entrySearch, entrySort]);
+
+  // Folder grouping is only meaningful when the user is sorting by Order with
+  // no search — any other state would put entries out of their containers
+  // (e.g. "Name A→Z" interleaves entries from different folders).
+  const showFolderGrouping = entrySort === "order" && entrySearch.trim().length === 0;
+
+  /** Entries for a given container (null = root, string = folder.id), sorted by Order. */
+  const entriesByContainer = useMemo(() => {
+    const map = new Map<string | null, LorebookEntry[]>();
+    map.set(null, []);
+    for (const f of folders) map.set(f.id, []);
+    for (const e of entries) {
+      const key = e.folderId ?? null;
+      const list = map.get(key);
+      // If an entry's folderId points to a deleted folder, fall back to root.
+      if (list) list.push(e);
+      else map.get(null)!.push(e);
+    }
+    for (const list of map.values()) list.sort((a, b) => a.order - b.order);
+    return map;
+  }, [entries, folders]);
+
   const canReorderEntries =
-    entrySort === "order" && entrySearch.trim().length === 0 && filteredEntries.length > 1 && !reorderEntries.isPending;
+    showFolderGrouping && entries.length > 1 && !reorderEntries.isPending;
+  const canReorderFolders = showFolderGrouping && folders.length > 1 && !reorderFolders.isPending;
 
   // ── Handlers ──
   const markLorebookDirty = useCallback(() => setLorebookDirty(true), []);
-  const updateEntryForm = useCallback((patch: Partial<LorebookEntry>) => {
-    setEntryDirty(true);
-    setEntryForm((current) => (current ? { ...current, ...patch } : current));
+
+  // Toggle the inline drawer for an entry. Single-expand keeps the page
+  // tidy; users can collapse the open one and click another to jump.
+  const toggleEntryExpanded = useCallback((entryId: string) => {
+    setExpandedEntryId((current) => (current === entryId ? null : entryId));
   }, []);
 
-  // Preserve main scroll position across entry editor sub-view so returning
-  // from an entry doesn't reset a long entry list (e.g. 250 entries on mobile).
-  const mainScrollRef = useRef<HTMLDivElement | null>(null);
   const entryListRef = useRef<HTMLDivElement | null>(null);
-  const savedScrollTopRef = useRef(0);
-  const openEntry = useCallback((entryId: string) => {
-    savedScrollTopRef.current = mainScrollRef.current?.scrollTop ?? 0;
-    setEditingEntryId(entryId);
-  }, []);
-  useLayoutEffect(() => {
-    if (editingEntryId || !mainScrollRef.current) return;
-    mainScrollRef.current.scrollTop = savedScrollTopRef.current;
-  }, [editingEntryId, activeTab]);
 
   const resetEntryDragState = useCallback(() => {
     setDraggingEntryIdx(null);
     setEntryDragReadyIdx(null);
     setEntryDropIdx(null);
+    setDragSourceContainer(undefined);
+    setDropTargetContainer(undefined);
+  }, []);
+
+  const resetFolderDragState = useCallback(() => {
+    setDraggingFolderIdx(null);
+    setFolderDragReadyIdx(null);
+    setFolderDropIdx(null);
   }, []);
 
   const calcEntryDropIdx = useCallback((cardIdx: number, e: ReactDragEvent<HTMLDivElement>) => {
@@ -269,38 +327,72 @@ export function LorebookEditor() {
     return e.clientY < midY ? cardIdx : cardIdx + 1;
   }, []);
 
+  // Drag start on an entry inside a specific container. We capture the
+  // source container so commitEntryDrop can detect a cross-container move.
   const handleEntryDragStart = useCallback(
-    (idx: number, e: ReactDragEvent<HTMLDivElement>) => {
+    (containerId: string | null, idxInContainer: number, entryId: string, e: ReactDragEvent<HTMLDivElement>) => {
       if (!canReorderEntries) {
         e.preventDefault();
         return;
       }
-      setDraggingEntryIdx(idx);
+      setDraggingEntryIdx(idxInContainer);
+      setDragSourceContainer(containerId);
       e.dataTransfer.effectAllowed = "move";
-      e.dataTransfer.setData("text/plain", filteredEntries[idx]?.id ?? String(idx));
+      e.dataTransfer.setData("text/plain", entryId);
     },
-    [canReorderEntries, filteredEntries],
+    [canReorderEntries],
   );
 
   const handleEntryDragOver = useCallback(
-    (idx: number, e: ReactDragEvent<HTMLDivElement>) => {
+    (containerId: string | null, idxInContainer: number, e: ReactDragEvent<HTMLDivElement>) => {
       if (!canReorderEntries || draggingEntryIdx === null) return;
       e.preventDefault();
       e.dataTransfer.dropEffect = "move";
-      setEntryDropIdx(calcEntryDropIdx(idx, e));
+      setEntryDropIdx(calcEntryDropIdx(idxInContainer, e));
+      setDropTargetContainer(containerId);
     },
     [calcEntryDropIdx, canReorderEntries, draggingEntryIdx],
   );
 
-  const handleEntryListDragOver = useCallback(
+  // Dropping on a folder header drops the entry at the top of that folder.
+  const handleFolderHeaderDragOver = useCallback(
+    (folderId: string, e: ReactDragEvent<HTMLDivElement>) => {
+      // If we're dragging an entry, this becomes a cross-container drop target.
+      if (draggingEntryIdx !== null) {
+        e.preventDefault();
+        e.dataTransfer.dropEffect = "move";
+        setDropTargetContainer(folderId);
+        setEntryDropIdx(0);
+      }
+    },
+    [draggingEntryIdx],
+  );
+
+  // Empty folder → still need to accept drops to land an entry inside.
+  const handleFolderBodyDragOver = useCallback(
+    (folderId: string, e: ReactDragEvent<HTMLDivElement>) => {
+      if (!canReorderEntries || draggingEntryIdx === null) return;
+      e.preventDefault();
+      e.dataTransfer.dropEffect = "move";
+      setDropTargetContainer(folderId);
+      // If hovering empty folder body, drop at end.
+      const containerEntries = entriesByContainer.get(folderId) ?? [];
+      setEntryDropIdx(containerEntries.length);
+    },
+    [canReorderEntries, draggingEntryIdx, entriesByContainer],
+  );
+
+  const handleRootListDragOver = useCallback(
     (e: ReactDragEvent<HTMLDivElement>) => {
       if (!canReorderEntries || draggingEntryIdx === null) return;
       e.preventDefault();
       e.dataTransfer.dropEffect = "move";
 
       const container = entryListRef.current;
-      if (!container || filteredEntries.length === 0) {
-        setEntryDropIdx(filteredEntries.length);
+      const rootEntries = entriesByContainer.get(null) ?? [];
+      if (!container || rootEntries.length === 0) {
+        setDropTargetContainer(null);
+        setEntryDropIdx(rootEntries.length);
         return;
       }
 
@@ -310,16 +402,18 @@ export function LorebookEditor() {
 
       const firstRect = firstCard.getBoundingClientRect();
       if (e.clientY < firstRect.top) {
+        setDropTargetContainer(null);
         setEntryDropIdx(0);
         return;
       }
 
       const lastRect = lastCard.getBoundingClientRect();
       if (e.clientY > lastRect.bottom) {
-        setEntryDropIdx(filteredEntries.length);
+        setDropTargetContainer(null);
+        setEntryDropIdx(rootEntries.length);
       }
     },
-    [canReorderEntries, draggingEntryIdx, filteredEntries.length],
+    [canReorderEntries, draggingEntryIdx, entriesByContainer],
   );
 
   const commitEntryDrop = useCallback(
@@ -327,29 +421,108 @@ export function LorebookEditor() {
       e.preventDefault();
       const sourceIdx = draggingEntryIdx;
       const targetIdx = entryDropIdx;
+      const sourceContainer = dragSourceContainer;
+      const targetContainer = dropTargetContainer;
       resetEntryDragState();
-      if (!lorebookId || !canReorderEntries || sourceIdx === null || targetIdx === null) return;
+      if (
+        !lorebookId ||
+        !canReorderEntries ||
+        sourceIdx === null ||
+        targetIdx === null ||
+        sourceContainer === undefined ||
+        targetContainer === undefined
+      ) {
+        return;
+      }
 
-      let insertAt = targetIdx;
-      if (sourceIdx < insertAt) insertAt--;
-      if (sourceIdx === insertAt) return;
+      const sourceList = (entriesByContainer.get(sourceContainer) ?? []).slice();
+      const moved = sourceList[sourceIdx];
+      if (!moved) return;
 
-      const entryIds = filteredEntries.map((entry) => entry.id);
-      const [movedEntryId] = entryIds.splice(sourceIdx, 1);
-      if (!movedEntryId) return;
-      entryIds.splice(insertAt, 0, movedEntryId);
-      reorderEntries.mutate({ lorebookId, entryIds });
+      // Same-container reorder — preserves the existing reorder semantic.
+      if (sourceContainer === targetContainer) {
+        let insertAt = targetIdx;
+        if (sourceIdx < insertAt) insertAt--;
+        if (sourceIdx === insertAt) return;
+        const ids = sourceList.map((entry) => entry.id);
+        ids.splice(sourceIdx, 1);
+        ids.splice(insertAt, 0, moved.id);
+        reorderEntries.mutate({ lorebookId, entryIds: ids, folderId: sourceContainer });
+        return;
+      }
+
+      // Cross-container move. Only update folderId — leave the entry's Order
+      // untouched. The entry will slot into its sorted position in the new
+      // container based on its existing Order value, and the user can change
+      // Order explicitly via the inline editor if they want to reposition it.
+      // (Within-container drags renumber Order because the drag *is* how you
+      // change Order in that case; cross-container drags express folder
+      // membership only.)
+      updateEntry.mutate({ lorebookId, entryId: moved.id, folderId: targetContainer });
     },
     [
       canReorderEntries,
       draggingEntryIdx,
+      dragSourceContainer,
+      dropTargetContainer,
+      entriesByContainer,
       entryDropIdx,
-      filteredEntries,
       lorebookId,
       reorderEntries,
       resetEntryDragState,
+      updateEntry,
     ],
   );
+
+  // ── Folder reorder DnD ──
+  const handleFolderDragStart = useCallback(
+    (idx: number, folderId: string, e: ReactDragEvent<HTMLDivElement>) => {
+      if (!canReorderFolders) {
+        e.preventDefault();
+        return;
+      }
+      setDraggingFolderIdx(idx);
+      e.dataTransfer.effectAllowed = "move";
+      e.dataTransfer.setData("text/plain", folderId);
+    },
+    [canReorderFolders],
+  );
+
+  const handleFolderDragOverHeader = useCallback(
+    (idx: number, e: ReactDragEvent<HTMLDivElement>) => {
+      if (!canReorderFolders || draggingFolderIdx === null) return;
+      e.preventDefault();
+      e.dataTransfer.dropEffect = "move";
+      const rect = e.currentTarget.getBoundingClientRect();
+      const midY = rect.top + rect.height / 2;
+      setFolderDropIdx(e.clientY < midY ? idx : idx + 1);
+    },
+    [canReorderFolders, draggingFolderIdx],
+  );
+
+  const commitFolderDrop = useCallback(
+    (e: ReactDragEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      const sourceIdx = draggingFolderIdx;
+      const targetIdx = folderDropIdx;
+      resetFolderDragState();
+      if (!lorebookId || !canReorderFolders || sourceIdx === null || targetIdx === null) return;
+      let insertAt = targetIdx;
+      if (sourceIdx < insertAt) insertAt--;
+      if (sourceIdx === insertAt) return;
+      const ids = folders.map((f) => f.id);
+      const [moved] = ids.splice(sourceIdx, 1);
+      if (!moved) return;
+      ids.splice(insertAt, 0, moved);
+      reorderFolders.mutate({ lorebookId, folderIds: ids });
+    },
+    [canReorderFolders, draggingFolderIdx, folderDropIdx, folders, lorebookId, reorderFolders, resetFolderDragState],
+  );
+
+  const handleAddFolder = useCallback(async () => {
+    if (!lorebookId) return;
+    await createFolder.mutateAsync({ lorebookId, name: "New Folder", enabled: true });
+  }, [lorebookId, createFolder]);
 
   const handleSaveLorebook = useCallback(async () => {
     if (!lorebookId) return;
@@ -389,44 +562,6 @@ export function LorebookEditor() {
     updateLorebook,
   ]);
 
-  const handleSaveEntry = useCallback(async () => {
-    if (!lorebookId || !editingEntryId || !entryForm) return;
-    setSaving(true);
-    try {
-      await updateEntry.mutateAsync({
-        lorebookId,
-        entryId: editingEntryId,
-        name: entryForm.name,
-        content: entryForm.content,
-        description: entryForm.description,
-        keys: entryForm.keys,
-        secondaryKeys: entryForm.secondaryKeys,
-        enabled: entryForm.enabled,
-        constant: entryForm.constant,
-        selective: entryForm.selective,
-        selectiveLogic: entryForm.selectiveLogic,
-        matchWholeWords: entryForm.matchWholeWords,
-        caseSensitive: entryForm.caseSensitive,
-        useRegex: entryForm.useRegex,
-        position: entryForm.position,
-        depth: entryForm.depth,
-        order: entryForm.order,
-        role: entryForm.role,
-        sticky: entryForm.sticky,
-        cooldown: entryForm.cooldown,
-        delay: entryForm.delay,
-        ephemeral: entryForm.ephemeral,
-        group: entryForm.group,
-        tag: entryForm.tag,
-        locked: entryForm.locked,
-        preventRecursion: entryForm.preventRecursion,
-      });
-      setEntryDirty(false);
-    } finally {
-      setSaving(false);
-    }
-  }, [lorebookId, editingEntryId, entryForm, updateEntry]);
-
   const handleAddEntry = useCallback(async () => {
     if (!lorebookId) return;
     const result = await createEntry.mutateAsync({
@@ -436,44 +571,11 @@ export function LorebookEditor() {
       keys: [],
     });
     if (result && typeof result === "object" && "id" in result) {
-      setEditingEntryId((result as LorebookEntry).id);
+      // Auto-expand the new entry's drawer so the user can fill it in.
+      setExpandedEntryId((result as LorebookEntry).id);
+      setActiveTab("entries");
     }
   }, [lorebookId, createEntry]);
-
-  const handleDeleteEntry = useCallback(
-    async (entryId: string) => {
-      if (!lorebookId) return;
-      if (
-        !(await showConfirmDialog({
-          title: "Delete Entry",
-          message: "Delete this lorebook entry?",
-          confirmLabel: "Delete",
-          tone: "destructive",
-        }))
-      ) {
-        return;
-      }
-      if (editingEntryId === entryId) setEditingEntryId(null);
-      await deleteEntry.mutateAsync({ lorebookId, entryId });
-    },
-    [lorebookId, editingEntryId, deleteEntry],
-  );
-
-  const handleExitEntry = useCallback(async () => {
-    if (
-      entryDirty &&
-      !(await showConfirmDialog({
-        title: "Unsaved Changes",
-        message: "You have unsaved changes. Discard them and leave this entry?",
-        confirmLabel: "Discard",
-        tone: "destructive",
-      }))
-    ) {
-      return;
-    }
-    setEntryDirty(false);
-    setEditingEntryId(null);
-  }, [entryDirty]);
 
   const handleClose = useCallback(() => {
     if (lorebookDirty) {
@@ -504,280 +606,6 @@ export function LorebookEditor() {
     return (
       <div className="flex flex-1 items-center justify-center">
         <div className="shimmer h-8 w-48 rounded-xl" />
-      </div>
-    );
-  }
-
-  // ── Entry editor sub-view ──
-  if (editingEntryId && entryForm) {
-    return (
-      <div className="flex flex-1 flex-col overflow-hidden">
-        {/* Entry editor header */}
-        <div className="flex items-center gap-3 border-b border-[var(--border)] px-4 py-3">
-          <button onClick={handleExitEntry} className="rounded-lg p-1.5 transition-colors hover:bg-[var(--accent)]">
-            <ArrowLeft size="1rem" />
-          </button>
-          <div className="min-w-0 flex-1">
-            <input
-              value={entryForm.name ?? ""}
-              onChange={(e) => updateEntryForm({ name: e.target.value })}
-              className="w-full rounded-lg bg-transparent px-1.5 text-base font-semibold outline-none transition-colors hover:bg-[var(--secondary)] focus:bg-[var(--secondary)] focus:ring-1 focus:ring-[var(--ring)]"
-              placeholder="Entry name"
-            />
-          </div>
-          <button
-            onClick={handleSaveEntry}
-            disabled={saving}
-            className="flex items-center gap-1.5 rounded-xl bg-gradient-to-r from-amber-400 to-orange-500 px-4 py-2 text-xs font-medium text-white shadow-md transition-all hover:shadow-lg active:scale-[0.98] disabled:opacity-50"
-          >
-            <Save size="0.8125rem" />
-            {saving ? "Saving…" : "Save Entry"}
-          </button>
-        </div>
-
-        <div className="flex-1 overflow-y-auto p-4">
-          <div className="mx-auto max-w-3xl space-y-6">
-            {/* Name */}
-            <FieldGroup
-              label="Name"
-              icon={FileText}
-              help="A display name for this entry. This is only for your own organization — it's not sent to the AI."
-            >
-              <input
-                value={entryForm.name ?? ""}
-                onChange={(e) => updateEntryForm({ name: e.target.value })}
-                className="w-full rounded-xl bg-[var(--secondary)] px-3 py-2.5 text-sm ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
-                placeholder="Entry name"
-              />
-            </FieldGroup>
-
-            {/* Description */}
-            <FieldGroup
-              label="Description"
-              icon={FileText}
-              help="Brief summary of what this entry is about. Used by the Knowledge Router agent to decide whether to inject this entry — not sent to the main AI as content."
-            >
-              <textarea
-                value={entryForm.description ?? ""}
-                onChange={(e) => updateEntryForm({ description: e.target.value })}
-                rows={2}
-                className="w-full resize-y rounded-xl bg-[var(--secondary)] px-3 py-2.5 text-sm ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
-                placeholder="Brief summary of what this entry is about (used by Knowledge Router agent)."
-              />
-            </FieldGroup>
-
-            {/* Keys */}
-            <FieldGroup
-              label="Primary Keys"
-              icon={Key}
-              help="Keywords that trigger this entry. When any of these words appear in the chat, this entry's content is injected into the AI's context."
-            >
-              <KeysEditor keys={entryForm.keys ?? []} onChange={(keys) => updateEntryForm({ keys })} />
-            </FieldGroup>
-
-            {/* Secondary Keys */}
-            <FieldGroup
-              label="Secondary Keys"
-              icon={Key}
-              help="Additional keywords used with AND/OR/NOT logic. 'AND' means both primary AND secondary must match. 'NOT' means primary must match but secondary must NOT."
-            >
-              <KeysEditor
-                keys={entryForm.secondaryKeys ?? []}
-                onChange={(keys) => updateEntryForm({ secondaryKeys: keys })}
-              />
-              <div className="mt-2 flex items-center gap-3">
-                <label className="text-[0.6875rem] text-[var(--muted-foreground)]">Logic:</label>
-                {(["and", "or", "not"] as const).map((logic) => (
-                  <button
-                    key={logic}
-                    onClick={() => updateEntryForm({ selectiveLogic: logic })}
-                    className={cn(
-                      "rounded-md px-2 py-0.5 text-[0.6875rem] font-medium transition-colors",
-                      entryForm.selectiveLogic === logic
-                        ? "bg-[var(--accent)] text-[var(--accent-foreground)]"
-                        : "text-[var(--muted-foreground)] hover:bg-[var(--secondary)]",
-                    )}
-                  >
-                    {logic.toUpperCase()}
-                  </button>
-                ))}
-              </div>
-            </FieldGroup>
-
-            {/* Content */}
-            <FieldGroup
-              label="Content"
-              icon={FileText}
-              help="The text that gets injected into the AI's context when this entry activates. Write it as you'd want the AI to know it."
-            >
-              <ExpandableTextarea
-                value={entryForm.content ?? ""}
-                onChange={(v) => updateEntryForm({ content: v })}
-                rows={8}
-                placeholder="The content that will be injected into the prompt when this entry activates…"
-                title="Edit Content"
-              />
-              <p className="mt-1 flex items-center gap-1 text-[0.625rem] text-[var(--muted-foreground)]">
-                <Hash size="0.5625rem" />~{estimateTokens(entryForm.content ?? "").toLocaleString()} tokens
-              </p>
-            </FieldGroup>
-
-            {/* Toggles row */}
-            <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-              <ToggleButton
-                label="Enabled"
-                value={entryForm.enabled ?? true}
-                onChange={(v) => updateEntryForm({ enabled: v })}
-              />
-              <ToggleButton
-                label="Constant"
-                value={entryForm.constant ?? false}
-                onChange={(v) => updateEntryForm({ constant: v })}
-              />
-              <ToggleButton
-                label="Selective"
-                value={entryForm.selective ?? false}
-                onChange={(v) => updateEntryForm({ selective: v })}
-              />
-              <ToggleButton
-                label="Regex"
-                value={entryForm.useRegex ?? false}
-                onChange={(v) => updateEntryForm({ useRegex: v })}
-              />
-              <ToggleButton
-                label="Whole Words"
-                value={entryForm.matchWholeWords ?? false}
-                onChange={(v) => updateEntryForm({ matchWholeWords: v })}
-              />
-              <ToggleButton
-                label="Case Sensitive"
-                value={entryForm.caseSensitive ?? false}
-                onChange={(v) => updateEntryForm({ caseSensitive: v })}
-              />
-              <ToggleButton
-                label="Locked"
-                value={entryForm.locked ?? false}
-                onChange={(v) => updateEntryForm({ locked: v })}
-                tooltip="Prevents the Lorebook Keeper agent from modifying this entry."
-              />
-              <ToggleButton
-                label="No Recursion"
-                value={entryForm.preventRecursion ?? false}
-                onChange={(v) => updateEntryForm({ preventRecursion: v })}
-                tooltip="When enabled, this entry's content won't trigger additional entries during recursive scanning."
-              />
-            </div>
-
-            {/* Injection settings */}
-            <FieldGroup
-              label="Injection"
-              icon={Settings2}
-              help="Position controls where in the prompt this entry appears. 'Before Chat' and 'After Chat' place it in the lore section. 'At Depth' injects it into the chat history at the specified depth."
-            >
-              <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-                <div>
-                  <label className="mb-1 block text-[0.6875rem] text-[var(--muted-foreground)]">Position</label>
-                  <select
-                    value={entryForm.position ?? 0}
-                    onChange={(e) => updateEntryForm({ position: Number(e.target.value) })}
-                    className="w-full rounded-lg bg-[var(--secondary)] px-2 py-1.5 text-xs ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
-                  >
-                    <option value={0}>Before Chat</option>
-                    <option value={1}>After Chat</option>
-                    <option value={2}>At Depth</option>
-                  </select>
-                </div>
-                {(entryForm.position ?? 0) >= 2 && (
-                  <NumberField
-                    label="Depth"
-                    value={entryForm.depth ?? 4}
-                    onChange={(v) => updateEntryForm({ depth: v })}
-                    min={0}
-                  />
-                )}
-                <NumberField
-                  label="Order"
-                  value={entryForm.order ?? 100}
-                  onChange={(v) => updateEntryForm({ order: v })}
-                />
-                <div>
-                  <label className="mb-1 block text-[0.6875rem] text-[var(--muted-foreground)]">Role</label>
-                  <select
-                    value={entryForm.role ?? "system"}
-                    onChange={(e) => updateEntryForm({ role: e.target.value as "system" | "user" | "assistant" })}
-                    className="w-full rounded-lg bg-[var(--secondary)] px-2 py-1.5 text-xs ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
-                  >
-                    <option value="system">System</option>
-                    <option value="user">User</option>
-                    <option value="assistant">Assistant</option>
-                  </select>
-                </div>
-              </div>
-            </FieldGroup>
-
-            {/* Timing */}
-            <FieldGroup
-              label="Timing"
-              icon={Settings2}
-              help="Sticky = stays active for N messages after triggering. Cooldown = waits N messages before it can trigger again. Delay = waits N messages before first activation. Ephemeral = auto-disables after N activations (0 = unlimited)."
-            >
-              <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-                <NumberField
-                  label="Sticky"
-                  value={entryForm.sticky ?? 0}
-                  onChange={(v) => updateEntryForm({ sticky: v || null })}
-                  min={0}
-                />
-                <NumberField
-                  label="Cooldown"
-                  value={entryForm.cooldown ?? 0}
-                  onChange={(v) => updateEntryForm({ cooldown: v || null })}
-                  min={0}
-                />
-                <NumberField
-                  label="Delay"
-                  value={entryForm.delay ?? 0}
-                  onChange={(v) => updateEntryForm({ delay: v || null })}
-                  min={0}
-                />
-                <NumberField
-                  label="Ephemeral"
-                  value={entryForm.ephemeral ?? 0}
-                  onChange={(v) => updateEntryForm({ ephemeral: v || null })}
-                  min={0}
-                />
-              </div>
-            </FieldGroup>
-
-            {/* Group & Tag */}
-            <FieldGroup
-              label="Group & Tag"
-              icon={Settings2}
-              help="Group entries together so only one from the group activates at a time. Tags are for your own organization."
-            >
-              <div className="grid grid-cols-2 gap-3">
-                <div>
-                  <label className="mb-1 block text-[0.6875rem] text-[var(--muted-foreground)]">Group</label>
-                  <input
-                    value={entryForm.group ?? ""}
-                    onChange={(e) => updateEntryForm({ group: e.target.value })}
-                    className="w-full rounded-lg bg-[var(--secondary)] px-2 py-1.5 text-xs ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
-                    placeholder="Group name"
-                  />
-                </div>
-                <div>
-                  <label className="mb-1 block text-[0.6875rem] text-[var(--muted-foreground)]">Tag</label>
-                  <input
-                    value={entryForm.tag ?? ""}
-                    onChange={(e) => updateEntryForm({ tag: e.target.value })}
-                    className="w-full rounded-lg bg-[var(--secondary)] px-2 py-1.5 text-xs ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
-                    placeholder="e.g. location, item, lore"
-                  />
-                </div>
-              </div>
-            </FieldGroup>
-          </div>
-        </div>
       </div>
     );
   }
@@ -896,7 +724,7 @@ export function LorebookEditor() {
         </nav>
 
         {/* Tab Content */}
-        <div ref={mainScrollRef} className="flex-1 overflow-y-auto p-6 @max-5xl:p-4">
+        <div className="flex-1 overflow-y-auto p-6 @max-5xl:p-4">
           <div className="mx-auto max-w-3xl">
             {activeTab === "overview" && (
               <div className="space-y-6">
@@ -1226,6 +1054,14 @@ export function LorebookEditor() {
                     </select>
                   </div>
                   <button
+                    onClick={handleAddFolder}
+                    className="flex items-center gap-1.5 rounded-xl bg-[var(--secondary)] px-3 py-2.5 text-xs font-medium ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)]"
+                    title="Create a new folder to group entries"
+                  >
+                    <FolderPlus size="0.8125rem" />
+                    Add Folder
+                  </button>
+                  <button
                     onClick={handleAddEntry}
                     className="flex items-center gap-1.5 rounded-xl bg-gradient-to-r from-amber-400 to-orange-500 px-4 py-2.5 text-xs font-medium text-white shadow-md transition-all hover:shadow-lg active:scale-[0.98]"
                   >
@@ -1235,148 +1071,294 @@ export function LorebookEditor() {
                 </div>
 
                 {/* Total tokens summary */}
-                {filteredEntries.length > 0 && (
+                {entries.length > 0 && (
                   <div className="flex items-center gap-3 text-[0.6875rem] text-[var(--muted-foreground)]">
-                    <span>{filteredEntries.length} entries</span>
+                    <span>
+                      {entries.length} {entries.length === 1 ? "entry" : "entries"}
+                    </span>
+                    {folders.length > 0 && (
+                      <>
+                        <span>•</span>
+                        <span>
+                          {folders.length} {folders.length === 1 ? "folder" : "folders"}
+                        </span>
+                      </>
+                    )}
                     <span>•</span>
                     <span className="flex items-center gap-1">
                       <Hash size="0.625rem" />
-                      {filteredEntries.reduce((sum, e) => sum + estimateTokens(e.content), 0).toLocaleString()} tokens
-                      (est.)
+                      {entries.reduce((sum, e) => sum + estimateTokens(e.content), 0).toLocaleString()} tokens (est.)
                     </span>
+                    {!showFolderGrouping && folders.length > 0 && (
+                      <span className="ml-auto italic">Folder view paused (clear search and sort by Order)</span>
+                    )}
                   </div>
                 )}
 
-                {/* Entry list */}
-                {filteredEntries.length === 0 && (
+                {/* Empty state */}
+                {entries.length === 0 && folders.length === 0 && (
                   <div className="flex flex-col items-center gap-2 py-8 text-center">
                     <FileText size="1.5rem" className="text-[var(--muted-foreground)]" />
                     <p className="text-xs text-[var(--muted-foreground)]">
-                      {entrySearch ? "No entries match your search" : "No entries yet — add one to get started"}
+                      No entries yet — add one to get started
                     </p>
                   </div>
                 )}
 
-                {filteredEntries.length > 0 && (
-                  <div
-                    ref={entryListRef}
-                    className="space-y-2"
-                    onDragOver={handleEntryListDragOver}
-                    onDrop={commitEntryDrop}
-                  >
-                    {filteredEntries.map((entry, idx) => {
-                      const showDropBefore =
-                        entryDropIdx === idx &&
-                        draggingEntryIdx !== null &&
-                        draggingEntryIdx !== idx &&
-                        draggingEntryIdx !== idx - 1;
-                      const showDropAfter =
-                        idx === filteredEntries.length - 1 &&
-                        entryDropIdx === filteredEntries.length &&
-                        draggingEntryIdx !== null &&
-                        draggingEntryIdx !== idx;
-
-                      return (
-                        <div key={entry.id}>
-                          {showDropBefore && <div className="mx-2 mb-1 h-0.5 rounded-full bg-amber-400" />}
-                          <div
-                            draggable={canReorderEntries && entryDragReadyIdx === idx}
-                            onDragStart={(e) => handleEntryDragStart(idx, e)}
-                            onDragOver={(e) => {
-                              e.stopPropagation();
-                              handleEntryDragOver(idx, e);
-                            }}
-                            onDrop={(e) => {
-                              e.stopPropagation();
-                              commitEntryDrop(e);
-                            }}
-                            onDragEnd={resetEntryDragState}
-                            onClick={() => openEntry(entry.id)}
-                            className={cn(
-                              "group flex cursor-pointer items-center gap-3 rounded-xl bg-[var(--secondary)] p-3 ring-1 ring-[var(--border)] transition-all hover:ring-amber-400/30",
-                              draggingEntryIdx === idx && "opacity-40",
-                            )}
-                          >
-                            <div
-                              className={cn(
-                                "shrink-0 rounded p-0.5 text-[var(--muted-foreground)] transition-colors",
-                                canReorderEntries
-                                  ? "cursor-grab hover:bg-[var(--accent)] hover:text-[var(--foreground)] active:cursor-grabbing"
-                                  : "cursor-not-allowed opacity-40",
+                {/* Entries — folder-grouped view (default sort, no search) */}
+                {lorebookId && showFolderGrouping && (entries.length > 0 || folders.length > 0) && (
+                  <div className="space-y-3">
+                    {/* Folder block */}
+                    {folders.length > 0 && (
+                      <div className="space-y-1.5">
+                        {folders.map((folder, fIdx) => {
+                          const folderEntries = entriesByContainer.get(folder.id) ?? [];
+                          const isCollapsed = collapsedFolderIds.has(folder.id);
+                          const showFolderDropBefore =
+                            folderDropIdx === fIdx &&
+                            draggingFolderIdx !== null &&
+                            draggingFolderIdx !== fIdx &&
+                            draggingFolderIdx !== fIdx - 1;
+                          const showFolderDropAfter =
+                            fIdx === folders.length - 1 &&
+                            folderDropIdx === folders.length &&
+                            draggingFolderIdx !== null &&
+                            draggingFolderIdx !== fIdx;
+                          return (
+                            <div key={folder.id} className="space-y-1">
+                              {showFolderDropBefore && (
+                                <div className="mx-2 mb-1 h-0.5 rounded-full bg-amber-400" />
                               )}
-                              title={
-                                canReorderEntries ? "Drag to reorder" : "Use Order sort and clear search to reorder"
-                              }
-                              onClick={(e) => e.stopPropagation()}
-                              onMouseDown={(e) => {
-                                e.stopPropagation();
-                                if (canReorderEntries) setEntryDragReadyIdx(idx);
-                              }}
-                              onMouseUp={(e) => {
-                                e.stopPropagation();
-                                setEntryDragReadyIdx(null);
-                              }}
-                            >
-                              <GripVertical size="0.875rem" />
-                            </div>
-                            <div className="min-w-0 flex-1">
-                              <div className="flex items-center gap-2">
-                                <span
-                                  className={cn(
-                                    "h-2 w-2 rounded-full",
-                                    entry.enabled ? "bg-emerald-400" : "bg-zinc-500",
+                              <LorebookFolderRow
+                                folder={folder}
+                                lorebookId={lorebookId}
+                                entryCount={folderEntries.length}
+                                isCollapsed={isCollapsed}
+                                onToggleCollapse={() => toggleFolderCollapsed(folder.id)}
+                                draggable={canReorderFolders}
+                                isDragging={draggingFolderIdx === fIdx}
+                                isDragReady={folderDragReadyIdx === fIdx}
+                                onDragHandleMouseDown={() => {
+                                  if (canReorderFolders) setFolderDragReadyIdx(fIdx);
+                                }}
+                                onDragHandleMouseUp={() => setFolderDragReadyIdx(null)}
+                                onDragStart={(e) => handleFolderDragStart(fIdx, folder.id, e)}
+                                onDragOver={(e) => {
+                                  e.stopPropagation();
+                                  // Two roles for the same dragOver: if the user is dragging
+                                  // an entry, this header is a cross-container drop target;
+                                  // otherwise it's a sibling for folder reorder.
+                                  if (draggingEntryIdx !== null) handleFolderHeaderDragOver(folder.id, e);
+                                  else handleFolderDragOverHeader(fIdx, e);
+                                }}
+                                onDrop={(e) => {
+                                  e.stopPropagation();
+                                  if (draggingEntryIdx !== null) commitEntryDrop(e);
+                                  else commitFolderDrop(e);
+                                }}
+                                onDragEnd={() => {
+                                  resetFolderDragState();
+                                  resetEntryDragState();
+                                }}
+                              />
+                              {!isCollapsed && (
+                                <div
+                                  className="ml-4 space-y-1.5 border-l-2 border-[var(--border)] pl-3"
+                                  onDragOver={(e) => handleFolderBodyDragOver(folder.id, e)}
+                                  onDrop={(e) => {
+                                    e.stopPropagation();
+                                    commitEntryDrop(e);
+                                  }}
+                                >
+                                  {folderEntries.length === 0 && (
+                                    <p className="py-2 text-[0.625rem] italic text-[var(--muted-foreground)]">
+                                      Empty — drag an entry here or pick this folder from an entry's folder selector.
+                                    </p>
                                   )}
-                                />
-                                <span className="truncate text-sm font-medium">{entry.name}</span>
-                                {entry.constant && (
-                                  <span className="rounded bg-amber-400/15 px-1.5 py-0.5 text-[0.5625rem] font-medium text-amber-400">
-                                    CONST
-                                  </span>
-                                )}
-                                {entry.locked && (
-                                  <span className="rounded bg-sky-400/15 px-1.5 py-0.5 text-[0.5625rem] font-medium text-sky-400">
-                                    <Lock size="0.5rem" className="inline mr-0.5" />
-                                    LOCKED
-                                  </span>
-                                )}
-                                {entry.tag && (
-                                  <span className="rounded bg-[var(--accent)] px-1.5 py-0.5 text-[0.5625rem] text-[var(--muted-foreground)]">
-                                    {entry.tag}
-                                  </span>
-                                )}
-                              </div>
-                              <div className="mt-0.5 flex items-center gap-2 text-[0.6875rem] text-[var(--muted-foreground)]">
-                                <span className="flex items-center gap-1">
-                                  <Key size="0.625rem" />
-                                  {entry.keys.length > 0 ? entry.keys.slice(0, 3).join(", ") : "No keys"}
-                                  {entry.keys.length > 3 && ` +${entry.keys.length - 3}`}
-                                </span>
-                                <span>•</span>
-                                <span>Order {entry.order}</span>
-                                <span>•</span>
-                                <span>Depth {entry.depth}</span>
-                                <span>•</span>
-                                <span className="flex items-center gap-0.5">
-                                  <Hash size="0.5625rem" />
-                                  {estimateTokens(entry.content).toLocaleString()} tk
-                                </span>
-                              </div>
+                                  {folderEntries.map((entry, eIdx) => {
+                                    const isDropTarget =
+                                      dropTargetContainer === folder.id && draggingEntryIdx !== null;
+                                    const sameContainer = dragSourceContainer === folder.id;
+                                    const showDropBefore =
+                                      isDropTarget &&
+                                      entryDropIdx === eIdx &&
+                                      (!sameContainer ||
+                                        (draggingEntryIdx !== eIdx && draggingEntryIdx !== eIdx - 1));
+                                    const showDropAfter =
+                                      isDropTarget &&
+                                      eIdx === folderEntries.length - 1 &&
+                                      entryDropIdx === folderEntries.length &&
+                                      (!sameContainer || draggingEntryIdx !== eIdx);
+                                    return (
+                                      <div key={entry.id}>
+                                        {showDropBefore && (
+                                          <div className="mx-2 mb-1 h-0.5 rounded-full bg-amber-400" />
+                                        )}
+                                        <LorebookEntryRow
+                                          entry={entry}
+                                          lorebookId={lorebookId}
+                                          isExpanded={expandedEntryId === entry.id}
+                                          onToggleExpand={() => toggleEntryExpanded(entry.id)}
+                                          folders={folders}
+                                          draggable={canReorderEntries}
+                                          isDragging={
+                                            sameContainer && draggingEntryIdx === eIdx
+                                          }
+                                          isDragReady={
+                                            sameContainer && entryDragReadyIdx === eIdx
+                                          }
+                                          onDragHandleMouseDown={() => {
+                                            if (canReorderEntries) {
+                                              setEntryDragReadyIdx(eIdx);
+                                              setDragSourceContainer(folder.id);
+                                            }
+                                          }}
+                                          onDragHandleMouseUp={() => setEntryDragReadyIdx(null)}
+                                          onDragStart={(e) =>
+                                            handleEntryDragStart(folder.id, eIdx, entry.id, e)
+                                          }
+                                          onDragOver={(e) => {
+                                            e.stopPropagation();
+                                            handleEntryDragOver(folder.id, eIdx, e);
+                                          }}
+                                          onDrop={(e) => {
+                                            e.stopPropagation();
+                                            commitEntryDrop(e);
+                                          }}
+                                          onDragEnd={resetEntryDragState}
+                                        />
+                                        {showDropAfter && (
+                                          <div className="mx-2 mt-1 h-0.5 rounded-full bg-amber-400" />
+                                        )}
+                                      </div>
+                                    );
+                                  })}
+                                </div>
+                              )}
+                              {showFolderDropAfter && <div className="mx-2 mt-1 h-0.5 rounded-full bg-amber-400" />}
                             </div>
-                            <button
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                handleDeleteEntry(entry.id);
-                              }}
-                              className="rounded-lg p-1.5 opacity-0 transition-all hover:bg-[var(--destructive)]/15 group-hover:opacity-100 max-md:opacity-100"
-                            >
-                              <Trash2 size="0.75rem" className="text-[var(--destructive)]" />
-                            </button>
-                            <ChevronRight size="0.875rem" className="text-[var(--muted-foreground)]" />
-                          </div>
-                          {showDropAfter && <div className="mx-2 mt-1 h-0.5 rounded-full bg-amber-400" />}
-                        </div>
-                      );
-                    })}
+                          );
+                        })}
+                      </div>
+                    )}
+
+                    {/* Root entries (entries with no folder).
+                        Always rendered when grouping is active so it acts as
+                        a permanent drop target — otherwise a user with all
+                        entries inside folders has no place to drop a folder
+                        entry to bring it back to root. */}
+                    <div
+                      ref={entryListRef}
+                      className={cn(
+                        "space-y-1.5",
+                        // Highlight the zone when an entry from another
+                        // container is being dragged toward it.
+                        draggingEntryIdx !== null &&
+                          dragSourceContainer !== null &&
+                          dropTargetContainer === null &&
+                          "rounded-xl ring-1 ring-amber-400/40 bg-amber-400/5 transition-colors",
+                      )}
+                      onDragOver={handleRootListDragOver}
+                      onDrop={commitEntryDrop}
+                    >
+                      {(entriesByContainer.get(null) ?? []).length === 0 && (
+                        <p
+                          className={cn(
+                            "py-3 text-center text-[0.625rem] italic text-[var(--muted-foreground)] transition-opacity",
+                            // Only call out the empty-root zone while the user
+                            // is actively dragging an entry from a folder; in
+                            // the steady state it would just be visual noise.
+                            draggingEntryIdx !== null && dragSourceContainer !== null
+                              ? "opacity-100"
+                              : "opacity-50",
+                          )}
+                        >
+                          {draggingEntryIdx !== null && dragSourceContainer !== null
+                            ? "Drop here to move out of the folder"
+                            : "No entries at the root level"}
+                        </p>
+                      )}
+                      {(entriesByContainer.get(null) ?? []).map((entry, idx) => {
+                          const rootList = entriesByContainer.get(null) ?? [];
+                          const isDropTarget = dropTargetContainer === null && draggingEntryIdx !== null;
+                          const sameContainer = dragSourceContainer === null;
+                          const showDropBefore =
+                            isDropTarget &&
+                            entryDropIdx === idx &&
+                            (!sameContainer || (draggingEntryIdx !== idx && draggingEntryIdx !== idx - 1));
+                          const showDropAfter =
+                            isDropTarget &&
+                            idx === rootList.length - 1 &&
+                            entryDropIdx === rootList.length &&
+                            (!sameContainer || draggingEntryIdx !== idx);
+                          return (
+                            <div key={entry.id}>
+                              {showDropBefore && <div className="mx-2 mb-1 h-0.5 rounded-full bg-amber-400" />}
+                              <LorebookEntryRow
+                                entry={entry}
+                                lorebookId={lorebookId}
+                                isExpanded={expandedEntryId === entry.id}
+                                onToggleExpand={() => toggleEntryExpanded(entry.id)}
+                                folders={folders}
+                                draggable={canReorderEntries}
+                                isDragging={sameContainer && draggingEntryIdx === idx}
+                                isDragReady={sameContainer && entryDragReadyIdx === idx}
+                                onDragHandleMouseDown={() => {
+                                  if (canReorderEntries) {
+                                    setEntryDragReadyIdx(idx);
+                                    setDragSourceContainer(null);
+                                  }
+                                }}
+                                onDragHandleMouseUp={() => setEntryDragReadyIdx(null)}
+                                onDragStart={(e) => handleEntryDragStart(null, idx, entry.id, e)}
+                                onDragOver={(e) => {
+                                  e.stopPropagation();
+                                  handleEntryDragOver(null, idx, e);
+                                }}
+                                onDrop={(e) => {
+                                  e.stopPropagation();
+                                  commitEntryDrop(e);
+                                }}
+                                onDragEnd={resetEntryDragState}
+                              />
+                              {showDropAfter && <div className="mx-2 mt-1 h-0.5 rounded-full bg-amber-400" />}
+                            </div>
+                          );
+                        })}
+                    </div>
+                  </div>
+                )}
+
+                {/* Entries — flat view (search active or non-Order sort) */}
+                {lorebookId && !showFolderGrouping && filteredEntries.length > 0 && (
+                  <div ref={entryListRef} className="space-y-1.5">
+                    {filteredEntries.map((entry) => (
+                      <LorebookEntryRow
+                        key={entry.id}
+                        entry={entry}
+                        lorebookId={lorebookId}
+                        isExpanded={expandedEntryId === entry.id}
+                        onToggleExpand={() => toggleEntryExpanded(entry.id)}
+                        folders={folders}
+                        draggable={false}
+                        isDragging={false}
+                        isDragReady={false}
+                        onDragHandleMouseDown={() => undefined}
+                        onDragHandleMouseUp={() => undefined}
+                        onDragStart={() => undefined}
+                        onDragOver={() => undefined}
+                        onDrop={() => undefined}
+                        onDragEnd={() => undefined}
+                      />
+                    ))}
+                  </div>
+                )}
+
+                {/* Search-with-no-matches */}
+                {lorebookId && !showFolderGrouping && filteredEntries.length === 0 && entries.length > 0 && (
+                  <div className="flex flex-col items-center gap-2 py-8 text-center">
+                    <FileText size="1.5rem" className="text-[var(--muted-foreground)]" />
+                    <p className="text-xs text-[var(--muted-foreground)]">No entries match your search</p>
                   </div>
                 )}
               </div>
@@ -1384,135 +1366,6 @@ export function LorebookEditor() {
           </div>
         </div>
       </div>
-    </div>
-  );
-}
-
-// ── Reusable sub-components ──
-
-function FieldGroup({
-  label,
-  icon: Icon,
-  help,
-  children,
-}: {
-  label: string;
-  icon: typeof FileText;
-  help?: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <div>
-      <div className="mb-2 flex items-center gap-1.5 text-xs font-medium">
-        <Icon size="0.8125rem" className="text-amber-400" />
-        {label}
-        {help && <HelpTooltip text={help} />}
-      </div>
-      {children}
-    </div>
-  );
-}
-
-function KeysEditor({ keys, onChange }: { keys: string[]; onChange: (keys: string[]) => void }) {
-  const [input, setInput] = useState("");
-
-  const addKey = () => {
-    const trimmed = input.trim();
-    if (trimmed && !keys.includes(trimmed)) {
-      onChange([...keys, trimmed]);
-      setInput("");
-    }
-  };
-
-  return (
-    <div>
-      <div className="flex flex-wrap gap-1.5">
-        {keys.map((key, i) => (
-          <span
-            key={i}
-            className="flex items-center gap-1 rounded-lg bg-amber-400/15 px-2 py-1 text-[0.6875rem] text-amber-300"
-          >
-            {key}
-            <button
-              onClick={() => onChange(keys.filter((_, j) => j !== i))}
-              className="ml-0.5 rounded-sm hover:text-[var(--destructive)]"
-            >
-              ×
-            </button>
-          </span>
-        ))}
-      </div>
-      <div className="mt-1.5 flex gap-1.5">
-        <input
-          value={input}
-          onChange={(e) => setInput(e.target.value)}
-          onKeyDown={(e) => e.key === "Enter" && (e.preventDefault(), addKey())}
-          className="flex-1 rounded-lg bg-[var(--secondary)] px-2 py-1.5 text-xs ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
-          placeholder="Type a keyword and press Enter…"
-        />
-        <button
-          onClick={addKey}
-          className="rounded-lg bg-[var(--accent)] px-2 py-1.5 text-[0.6875rem] font-medium transition-colors hover:bg-[var(--accent)]/80"
-        >
-          Add
-        </button>
-      </div>
-    </div>
-  );
-}
-
-function ToggleButton({
-  label,
-  value,
-  onChange,
-  tooltip,
-}: {
-  label: string;
-  value: boolean;
-  onChange: (v: boolean) => void;
-  tooltip?: string;
-}) {
-  return (
-    <button
-      onClick={() => onChange(!value)}
-      title={tooltip}
-      className={cn(
-        "flex items-center justify-between rounded-xl px-3 py-2.5 text-xs font-medium ring-1 transition-all",
-        value
-          ? "bg-amber-400/15 text-amber-400 ring-amber-400/30"
-          : "bg-[var(--secondary)] text-[var(--muted-foreground)] ring-[var(--border)]",
-      )}
-    >
-      {label}
-      {value ? <ToggleRight size="1.125rem" /> : <ToggleLeft size="1.125rem" />}
-    </button>
-  );
-}
-
-function NumberField({
-  label,
-  value,
-  onChange,
-  min,
-  max,
-}: {
-  label: string;
-  value: number;
-  onChange: (v: number) => void;
-  min?: number;
-  max?: number;
-}) {
-  return (
-    <div>
-      <label className="mb-1 block text-[0.6875rem] text-[var(--muted-foreground)]">{label}</label>
-      <input
-        type="number"
-        value={value}
-        onChange={(e) => onChange(parseInt(e.target.value) || 0)}
-        min={min}
-        max={max}
-        className="w-full rounded-lg bg-[var(--secondary)] px-2 py-1.5 text-xs ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
-      />
     </div>
   );
 }
@@ -1599,149 +1452,6 @@ function VectorizeSection({ lorebookId, entryCount }: { lorebookId: string; entr
           )}
         </>
       )}
-    </div>
-  );
-}
-
-function insertTabAtSelection(element: HTMLTextAreaElement, value: string, applyValue: (nextValue: string) => void) {
-  const start = element.selectionStart;
-  const end = element.selectionEnd;
-  const nextValue = `${value.slice(0, start)}\t${value.slice(end)}`;
-  applyValue(nextValue);
-
-  requestAnimationFrame(() => {
-    element.selectionStart = element.selectionEnd = start + 1;
-  });
-}
-
-function handleTextareaTabKeyDown(
-  event: ReactKeyboardEvent<HTMLTextAreaElement>,
-  value: string,
-  applyValue: (nextValue: string) => void,
-) {
-  if (event.key !== "Tab" || event.shiftKey || event.altKey || event.metaKey || event.ctrlKey) return;
-  event.preventDefault();
-  insertTabAtSelection(event.currentTarget, value, applyValue);
-}
-
-/** Textarea with an expand button that opens a fullscreen modal editor. */
-function ExpandableTextarea({
-  value,
-  onChange,
-  rows,
-  placeholder,
-  title,
-}: {
-  value: string;
-  onChange: (v: string) => void;
-  rows?: number;
-  placeholder?: string;
-  title?: string;
-}) {
-  const [expanded, setExpanded] = useState(false);
-
-  return (
-    <>
-      <div className="relative">
-        <textarea
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          onKeyDown={(e) => handleTextareaTabKeyDown(e, value, onChange)}
-          rows={rows ?? 6}
-          className="w-full resize-y rounded-xl bg-[var(--secondary)] p-3 pr-9 text-sm ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
-          placeholder={placeholder}
-        />
-        <button
-          onClick={() => setExpanded(true)}
-          className="absolute right-2 top-2 rounded-md p-1 text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
-          title="Expand editor"
-        >
-          <Maximize2 size="0.8125rem" />
-        </button>
-      </div>
-
-      {expanded && (
-        <ExpandedContentModal
-          title={title ?? "Edit"}
-          value={value}
-          onChange={onChange}
-          onClose={() => setExpanded(false)}
-          placeholder={placeholder}
-        />
-      )}
-    </>
-  );
-}
-
-/** Fullscreen modal editor for lorebook entry fields. */
-function ExpandedContentModal({
-  title,
-  value,
-  onChange,
-  onClose,
-  placeholder,
-}: {
-  title: string;
-  value: string;
-  onChange: (v: string) => void;
-  onClose: () => void;
-  placeholder?: string;
-}) {
-  const [local, setLocal] = useState(value);
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
-
-  useEffect(() => {
-    setTimeout(() => textareaRef.current?.focus(), 100);
-  }, []);
-
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        onChange(local);
-        onClose();
-      }
-    };
-    document.addEventListener("keydown", handler);
-    return () => document.removeEventListener("keydown", handler);
-  }, [onClose, onChange, local]);
-
-  const handleClose = () => {
-    onChange(local);
-    onClose();
-  };
-
-  return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-6 max-md:pt-[max(1.5rem,env(safe-area-inset-top))]">
-      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={handleClose} />
-      <div className="relative flex h-[80vh] w-full max-w-3xl flex-col rounded-2xl border border-[var(--border)] bg-[var(--card)] shadow-2xl shadow-black/50">
-        <div className="flex items-center justify-between border-b border-[var(--border)] px-4 py-3">
-          <h3 className="text-sm font-semibold">{title}</h3>
-          <button onClick={handleClose} className="rounded-lg p-1.5 hover:bg-[var(--accent)]">
-            <X size="1rem" />
-          </button>
-        </div>
-        <div className="flex-1 overflow-hidden p-4">
-          <textarea
-            ref={textareaRef}
-            value={local}
-            onChange={(e) => setLocal(e.target.value)}
-            onKeyDown={(e) => handleTextareaTabKeyDown(e, local, setLocal)}
-            className="h-full w-full resize-none rounded-lg bg-[var(--secondary)] p-4 text-sm text-[var(--foreground)] ring-1 ring-[var(--border)] placeholder:text-[var(--muted-foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
-            placeholder={placeholder}
-          />
-        </div>
-        <div className="flex items-center justify-between border-t border-[var(--border)] px-4 py-2.5">
-          <p className="text-[0.625rem] text-[var(--muted-foreground)]">
-            Changes auto-save on close. Press Escape to close.
-          </p>
-          <button
-            onClick={handleClose}
-            className="rounded-xl bg-gradient-to-r from-amber-400 to-orange-500 px-4 py-1.5 text-xs font-medium text-white shadow-md hover:shadow-lg active:scale-[0.98]"
-          >
-            Done
-          </button>
-        </div>
-      </div>
     </div>
   );
 }

--- a/packages/client/src/components/lorebooks/LorebookEntryRow.tsx
+++ b/packages/client/src/components/lorebooks/LorebookEntryRow.tsx
@@ -1,0 +1,746 @@
+// ──────────────────────────────────────────────
+// Lorebook Entry Row
+// Compact one-line row with inline controls + expandable drawer.
+// Replaces the previous "click to navigate to entry sub-view" pattern.
+// Inspired by SillyTavern's World Info card layout.
+// ──────────────────────────────────────────────
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type DragEvent as ReactDragEvent,
+  type MouseEvent as ReactMouseEvent,
+} from "react";
+import {
+  ChevronDown,
+  FileText,
+  GripVertical,
+  Hash,
+  Key,
+  Lock,
+  Save,
+  Settings2,
+  ToggleLeft,
+  ToggleRight,
+  Trash2,
+} from "lucide-react";
+import { cn } from "../../lib/utils";
+import { showConfirmDialog } from "../../lib/app-dialogs";
+import { useUpdateLorebookEntry, useDeleteLorebookEntry } from "../../hooks/use-lorebooks";
+import type { LorebookEntry, LorebookFolder } from "@marinara-engine/shared";
+import {
+  ExpandableTextarea,
+  FieldGroup,
+  KeysEditor,
+  NumberField,
+  ToggleButton,
+  estimateTokens,
+} from "./LorebookFormFields";
+
+interface Props {
+  entry: LorebookEntry;
+  lorebookId: string;
+  isExpanded: boolean;
+  onToggleExpand: () => void;
+  /**
+   * All folders in the parent lorebook. Used to populate the folder selector
+   * on the row. May be empty — when empty, the selector is hidden because
+   * "(none)" → "(none)" is meaningless.
+   */
+  folders: LorebookFolder[];
+  // Drag-and-drop wiring (lifted in the parent because cross-row state).
+  draggable: boolean;
+  isDragging: boolean;
+  isDragReady: boolean;
+  onDragHandleMouseDown: () => void;
+  onDragHandleMouseUp: () => void;
+  onDragStart: (e: ReactDragEvent<HTMLDivElement>) => void;
+  onDragOver: (e: ReactDragEvent<HTMLDivElement>) => void;
+  onDrop: (e: ReactDragEvent<HTMLDivElement>) => void;
+  onDragEnd: () => void;
+}
+
+/** Maps the (constant, selective) boolean pair into a single status enum for the inline select. */
+type EntryStatus = "constant" | "selective" | "normal";
+
+function deriveStatus(entry: LorebookEntry): EntryStatus {
+  if (entry.constant) return "constant";
+  if (entry.selective) return "selective";
+  return "normal";
+}
+
+function statusToFlags(status: EntryStatus): { constant: boolean; selective: boolean } {
+  switch (status) {
+    case "constant":
+      return { constant: true, selective: false };
+    case "selective":
+      return { constant: false, selective: true };
+    case "normal":
+    default:
+      return { constant: false, selective: false };
+  }
+}
+
+const STATUS_LABEL: Record<EntryStatus, string> = {
+  constant: "Constant",
+  selective: "Selective",
+  normal: "Normal",
+};
+
+const STATUS_DOT_COLOR: Record<EntryStatus, string> = {
+  constant: "bg-amber-400",
+  selective: "bg-violet-400",
+  normal: "bg-emerald-400",
+};
+
+/** A compact lorebook-entry list row with inline-editable status / position / depth / order /
+ *  probability / enable, plus an expandable drawer with the rest of the entry editor.
+ */
+export function LorebookEntryRow({
+  entry,
+  lorebookId,
+  isExpanded,
+  onToggleExpand,
+  folders,
+  draggable,
+  isDragging,
+  isDragReady,
+  onDragHandleMouseDown,
+  onDragHandleMouseUp,
+  onDragStart,
+  onDragOver,
+  onDrop,
+  onDragEnd,
+}: Props) {
+  const updateEntry = useUpdateLorebookEntry();
+  const deleteEntry = useDeleteLorebookEntry();
+
+  // ── Inline-control optimistic state ──
+  // We keep a local mirror of the entry's fields so the inputs feel snappy
+  // while the mutation flushes. React Query invalidation will reconcile.
+  const [localEnabled, setLocalEnabled] = useState(entry.enabled);
+  const [localStatus, setLocalStatus] = useState<EntryStatus>(deriveStatus(entry));
+  const [localPosition, setLocalPosition] = useState(entry.position);
+  const [localDepth, setLocalDepth] = useState(entry.depth);
+  const [localOrder, setLocalOrder] = useState(entry.order);
+  const [localProbability, setLocalProbability] = useState<number>(entry.probability ?? 100);
+  const [localName, setLocalName] = useState(entry.name);
+
+  // Re-sync local state when the upstream entry changes (e.g. after refetch)
+  // so we don't show stale values, but avoid clobbering an in-flight edit.
+  const lastSyncedRef = useRef(entry);
+  useEffect(() => {
+    if (lastSyncedRef.current === entry) return;
+    lastSyncedRef.current = entry;
+    setLocalEnabled(entry.enabled);
+    setLocalStatus(deriveStatus(entry));
+    setLocalPosition(entry.position);
+    setLocalDepth(entry.depth);
+    setLocalOrder(entry.order);
+    setLocalProbability(entry.probability ?? 100);
+    setLocalName(entry.name);
+  }, [entry]);
+
+  const patch = useCallback(
+    (changes: Partial<LorebookEntry>) => {
+      updateEntry.mutate({ lorebookId, entryId: entry.id, ...changes });
+    },
+    [lorebookId, entry.id, updateEntry],
+  );
+
+  const handleStatusChange = useCallback(
+    (next: EntryStatus) => {
+      setLocalStatus(next);
+      patch(statusToFlags(next));
+    },
+    [patch],
+  );
+
+  const handleEnableToggle = useCallback(
+    (e: ReactMouseEvent) => {
+      e.stopPropagation();
+      const next = !localEnabled;
+      setLocalEnabled(next);
+      patch({ enabled: next });
+    },
+    [localEnabled, patch],
+  );
+
+  const handleNameCommit = useCallback(() => {
+    if (localName.trim() && localName !== entry.name) {
+      patch({ name: localName.trim() });
+    } else if (!localName.trim()) {
+      // Don't allow empty names — revert.
+      setLocalName(entry.name);
+    }
+  }, [localName, entry.name, patch]);
+
+  const handleDelete = useCallback(
+    async (e: ReactMouseEvent) => {
+      e.stopPropagation();
+      if (
+        !(await showConfirmDialog({
+          title: "Delete Entry",
+          message: "Delete this lorebook entry?",
+          confirmLabel: "Delete",
+          tone: "destructive",
+        }))
+      ) {
+        return;
+      }
+      deleteEntry.mutate({ lorebookId, entryId: entry.id });
+    },
+    [lorebookId, entry.id, deleteEntry],
+  );
+
+  const showDepthInput = localPosition === 2;
+
+  return (
+    <div
+      className={cn(
+        "rounded-xl bg-[var(--secondary)] ring-1 ring-[var(--border)] transition-all",
+        isExpanded ? "ring-amber-400/40" : "hover:ring-amber-400/30",
+        isDragging && "opacity-40",
+      )}
+      draggable={draggable && isDragReady}
+      onDragStart={onDragStart}
+      onDragOver={onDragOver}
+      onDrop={onDrop}
+      onDragEnd={onDragEnd}
+    >
+      {/* ── Compact row ── */}
+      <div className="group flex cursor-pointer items-center gap-2 px-2 py-1.5" onClick={onToggleExpand}>
+        {/* Drag handle */}
+        <button
+          type="button"
+          className={cn(
+            "shrink-0 rounded p-0.5 text-[var(--muted-foreground)] transition-colors",
+            draggable
+              ? "cursor-grab hover:bg-[var(--accent)] hover:text-[var(--foreground)] active:cursor-grabbing"
+              : "cursor-not-allowed opacity-40",
+          )}
+          title={draggable ? "Drag to reorder" : "Use Order sort and clear search to reorder"}
+          onClick={(e) => e.stopPropagation()}
+          onMouseDown={(e) => {
+            e.stopPropagation();
+            if (draggable) onDragHandleMouseDown();
+          }}
+          onMouseUp={(e) => {
+            e.stopPropagation();
+            onDragHandleMouseUp();
+          }}
+        >
+          <GripVertical size="0.875rem" />
+        </button>
+
+        {/* Expand chevron */}
+        <button
+          type="button"
+          aria-label={isExpanded ? "Collapse entry" : "Expand entry"}
+          className="shrink-0 rounded p-0.5 text-[var(--muted-foreground)] transition-transform hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+          onClick={(e) => {
+            e.stopPropagation();
+            onToggleExpand();
+          }}
+        >
+          <ChevronDown size="0.875rem" className={cn("transition-transform", isExpanded ? "rotate-0" : "-rotate-90")} />
+        </button>
+
+        {/* Enable toggle */}
+        <button
+          type="button"
+          aria-label={localEnabled ? "Disable entry" : "Enable entry"}
+          title={localEnabled ? "Entry enabled" : "Entry disabled"}
+          onClick={handleEnableToggle}
+          className="shrink-0"
+        >
+          {localEnabled ? (
+            <ToggleRight size="1.125rem" className="text-amber-400" />
+          ) : (
+            <ToggleLeft size="1.125rem" className="text-[var(--muted-foreground)]" />
+          )}
+        </button>
+
+        {/* Status dot + name */}
+        <span
+          className={cn("h-2 w-2 shrink-0 rounded-full", STATUS_DOT_COLOR[localStatus])}
+          title={STATUS_LABEL[localStatus]}
+        />
+        <input
+          value={localName}
+          onChange={(e) => setLocalName(e.target.value)}
+          onBlur={handleNameCommit}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              (e.currentTarget as HTMLInputElement).blur();
+            }
+          }}
+          onClick={(e) => e.stopPropagation()}
+          placeholder="Untitled entry"
+          className="min-w-0 flex-1 truncate bg-transparent px-1 text-sm font-medium outline-none transition-colors hover:bg-[var(--accent)]/40 focus:bg-[var(--accent)]/40 focus:ring-1 focus:ring-[var(--ring)] rounded"
+        />
+
+        {/* Lock badge (display-only on the row; toggled inside the drawer) */}
+        {entry.locked && (
+          <span className="hidden shrink-0 items-center rounded bg-sky-400/15 px-1.5 py-0.5 text-[0.5625rem] font-medium text-sky-400 sm:inline-flex">
+            <Lock size="0.5rem" className="mr-0.5" />
+            LOCKED
+          </span>
+        )}
+
+        {/* ── Inline editable controls cluster ── */}
+        {/* Hidden on very narrow viewports to keep the row from overflowing.
+            Users on mobile can expand the drawer to access them. */}
+        <div className="hidden shrink-0 items-center gap-1 md:flex" onClick={(e) => e.stopPropagation()}>
+          <CompactSelect
+            value={localStatus}
+            onChange={(v) => handleStatusChange(v as EntryStatus)}
+            title="Trigger mode: Constant always fires, Selective uses primary+secondary key logic, Normal fires on any primary key match."
+            options={[
+              { value: "normal", label: "Normal" },
+              { value: "constant", label: "Const" },
+              { value: "selective", label: "Selective" },
+            ]}
+          />
+          <CompactSelect
+            value={String(localPosition)}
+            onChange={(v) => {
+              const n = Number(v);
+              setLocalPosition(n);
+              patch({ position: n });
+            }}
+            title="Position in the prompt: Before Chat, After Chat, or @ Depth (injected into chat history)."
+            options={[
+              { value: "0", label: "↑Char" },
+              { value: "1", label: "↓Char" },
+              { value: "2", label: "@Depth" },
+            ]}
+          />
+          {showDepthInput && (
+            <CompactNumber
+              value={localDepth}
+              onCommit={(n) => {
+                setLocalDepth(n);
+                patch({ depth: n });
+              }}
+              title="Depth (messages back from the latest) where this entry is injected."
+              ariaLabel="Depth"
+              prefix="d"
+              min={0}
+              max={9999}
+            />
+          )}
+          <CompactNumber
+            value={localOrder}
+            onCommit={(n) => {
+              setLocalOrder(n);
+              patch({ order: n });
+            }}
+            title="Insertion order when multiple entries activate (lower = earlier in prompt)."
+            ariaLabel="Order"
+            prefix="ord"
+          />
+          <CompactNumber
+            value={localProbability}
+            onCommit={(n) => {
+              const clamped = Math.max(0, Math.min(100, n));
+              setLocalProbability(clamped);
+              // null = always-fire is the schema default. Save 100 as null
+              // for parity with how new entries are created.
+              patch({ probability: clamped === 100 ? null : clamped });
+            }}
+            title="Trigger probability (0–100%). 100% always fires when keys match."
+            ariaLabel="Trigger probability"
+            prefix="p"
+            suffix="%"
+            min={0}
+            max={100}
+          />
+          {folders.length > 0 && (
+            <CompactSelect
+              value={entry.folderId ?? ""}
+              onChange={(v) => patch({ folderId: v === "" ? null : v })}
+              title="Move this entry to a different folder. (none) = root level."
+              options={[
+                { value: "", label: "(none)" },
+                ...folders.map((f) => ({ value: f.id, label: f.name })),
+              ]}
+            />
+          )}
+        </div>
+
+        {/* Token estimate (compact) */}
+        <span
+          className="hidden shrink-0 items-center gap-0.5 rounded px-1 py-0.5 text-[0.625rem] text-[var(--muted-foreground)] lg:inline-flex"
+          title={`~${estimateTokens(entry.content).toLocaleString()} tokens (estimated)`}
+        >
+          <Hash size="0.5625rem" />
+          {estimateTokens(entry.content).toLocaleString()}
+        </span>
+
+        {/* Delete button (visible on hover, always on mobile) */}
+        <button
+          type="button"
+          aria-label="Delete entry"
+          onClick={handleDelete}
+          className="shrink-0 rounded p-1 opacity-0 transition-all hover:bg-[var(--destructive)]/15 group-hover:opacity-100 max-md:opacity-100"
+        >
+          <Trash2 size="0.75rem" className="text-[var(--destructive)]" />
+        </button>
+      </div>
+
+      {/* ── Expanded drawer ── */}
+      {isExpanded && <ExpandedDrawer entry={entry} lorebookId={lorebookId} />}
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────
+// Sub-components
+// ─────────────────────────────────────────────────────
+
+function CompactSelect({
+  value,
+  onChange,
+  options,
+  title,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  options: Array<{ value: string; label: string }>;
+  title?: string;
+}) {
+  return (
+    <select
+      value={value}
+      title={title}
+      onChange={(e) => onChange(e.target.value)}
+      className="h-6 rounded-md bg-[var(--secondary)] px-1.5 text-[0.6875rem] ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)] hover:ring-amber-400/40 transition-colors"
+    >
+      {options.map((opt) => (
+        <option key={opt.value} value={opt.value}>
+          {opt.label}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+function CompactNumber({
+  value,
+  onCommit,
+  title,
+  ariaLabel,
+  prefix,
+  suffix,
+  min,
+  max,
+}: {
+  value: number;
+  onCommit: (v: number) => void;
+  title?: string;
+  ariaLabel: string;
+  prefix?: string;
+  suffix?: string;
+  min?: number;
+  max?: number;
+}) {
+  const [draft, setDraft] = useState(String(value));
+  // Keep draft synced when external value changes
+  useEffect(() => {
+    setDraft(String(value));
+  }, [value]);
+
+  const commit = () => {
+    const parsed = parseInt(draft, 10);
+    if (Number.isNaN(parsed)) {
+      setDraft(String(value));
+      return;
+    }
+    let clamped = parsed;
+    if (min !== undefined && clamped < min) clamped = min;
+    if (max !== undefined && clamped > max) clamped = max;
+    if (clamped !== value) {
+      setDraft(String(clamped));
+      onCommit(clamped);
+    } else if (clamped !== parsed) {
+      setDraft(String(clamped));
+    }
+  };
+
+  return (
+    <label
+      className="flex h-6 items-center gap-0.5 rounded-md bg-[var(--secondary)] px-1.5 text-[0.6875rem] ring-1 ring-[var(--border)] hover:ring-amber-400/40 transition-colors focus-within:ring-2 focus-within:ring-[var(--ring)]"
+      title={title}
+    >
+      {prefix && <span className="text-[var(--muted-foreground)]">{prefix}:</span>}
+      <input
+        type="number"
+        aria-label={ariaLabel}
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            (e.currentTarget as HTMLInputElement).blur();
+          }
+        }}
+        min={min}
+        max={max}
+        className="w-10 bg-transparent text-right tabular-nums outline-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+      />
+      {suffix && <span className="text-[var(--muted-foreground)]">{suffix}</span>}
+    </label>
+  );
+}
+
+// ─────────────────────────────────────────────────────
+// Expanded drawer — keys, content, advanced toggles, timing, group/tag.
+// Manages its own dirty state and Save button so users see explicit commit
+// for the heavier fields (especially the content textarea).
+// ─────────────────────────────────────────────────────
+
+function ExpandedDrawer({ entry, lorebookId }: { entry: LorebookEntry; lorebookId: string }) {
+  const updateEntry = useUpdateLorebookEntry();
+  const [form, setForm] = useState<Partial<LorebookEntry>>(() => ({ ...entry }));
+  const [dirty, setDirty] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const loadedEntryIdRef = useRef(entry.id);
+
+  // If the underlying entry changes (e.g. due to an inline-control patch), refresh
+  // the drawer form unless the user is in the middle of editing.
+  useEffect(() => {
+    const switched = loadedEntryIdRef.current !== entry.id;
+    if (switched || !dirty) {
+      setForm({ ...entry });
+      setDirty(false);
+      loadedEntryIdRef.current = entry.id;
+    }
+  }, [entry, dirty]);
+
+  const update = useCallback((patch: Partial<LorebookEntry>) => {
+    setDirty(true);
+    setForm((curr) => ({ ...curr, ...patch }));
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    setSaving(true);
+    try {
+      await updateEntry.mutateAsync({
+        lorebookId,
+        entryId: entry.id,
+        name: form.name,
+        content: form.content,
+        description: form.description,
+        keys: form.keys,
+        secondaryKeys: form.secondaryKeys,
+        selectiveLogic: form.selectiveLogic,
+        matchWholeWords: form.matchWholeWords,
+        caseSensitive: form.caseSensitive,
+        useRegex: form.useRegex,
+        role: form.role,
+        sticky: form.sticky,
+        cooldown: form.cooldown,
+        delay: form.delay,
+        ephemeral: form.ephemeral,
+        group: form.group,
+        tag: form.tag,
+        locked: form.locked,
+        preventRecursion: form.preventRecursion,
+      });
+      setDirty(false);
+    } finally {
+      setSaving(false);
+    }
+  }, [form, entry.id, lorebookId, updateEntry]);
+
+  return (
+    <div className="space-y-5 border-t border-[var(--border)] px-4 py-4">
+      {/* Description */}
+      <FieldGroup
+        label="Description"
+        icon={FileText}
+        help="Brief summary of what this entry is about. Used by the Knowledge Router agent to decide whether to inject this entry — not sent to the main AI as content."
+      >
+        <textarea
+          value={form.description ?? ""}
+          onChange={(e) => update({ description: e.target.value })}
+          rows={2}
+          className="w-full resize-y rounded-xl bg-[var(--secondary)] px-3 py-2.5 text-sm ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+          placeholder="Brief summary of what this entry is about (used by Knowledge Router agent)."
+        />
+      </FieldGroup>
+
+      {/* Keys */}
+      <FieldGroup
+        label="Primary Keys"
+        icon={Key}
+        help="Keywords that trigger this entry. When any of these words appear in the chat, this entry's content is injected into the AI's context."
+      >
+        <KeysEditor keys={form.keys ?? []} onChange={(keys) => update({ keys })} />
+      </FieldGroup>
+
+      {/* Secondary Keys + Logic */}
+      <FieldGroup
+        label="Secondary Keys"
+        icon={Key}
+        help="Additional keywords used with AND/OR/NOT logic. 'AND' means both primary AND secondary must match. 'NOT' means primary must match but secondary must NOT."
+      >
+        <KeysEditor keys={form.secondaryKeys ?? []} onChange={(keys) => update({ secondaryKeys: keys })} />
+        <div className="mt-2 flex items-center gap-3">
+          <label className="text-[0.6875rem] text-[var(--muted-foreground)]">Logic:</label>
+          {(["and", "or", "not"] as const).map((logic) => (
+            <button
+              key={logic}
+              onClick={() => update({ selectiveLogic: logic })}
+              className={cn(
+                "rounded-md px-2 py-0.5 text-[0.6875rem] font-medium transition-colors",
+                form.selectiveLogic === logic
+                  ? "bg-[var(--accent)] text-[var(--accent-foreground)]"
+                  : "text-[var(--muted-foreground)] hover:bg-[var(--secondary)]",
+              )}
+            >
+              {logic.toUpperCase()}
+            </button>
+          ))}
+        </div>
+      </FieldGroup>
+
+      {/* Content */}
+      <FieldGroup
+        label="Content"
+        icon={FileText}
+        help="The text that gets injected into the AI's context when this entry activates. Write it as you'd want the AI to know it."
+      >
+        <ExpandableTextarea
+          value={form.content ?? ""}
+          onChange={(v) => update({ content: v })}
+          rows={6}
+          placeholder="The content that will be injected into the prompt when this entry activates…"
+          title="Edit Content"
+        />
+        <p className="mt-1 flex items-center gap-1 text-[0.625rem] text-[var(--muted-foreground)]">
+          <Hash size="0.5625rem" />~{estimateTokens(form.content ?? "").toLocaleString()} tokens
+        </p>
+      </FieldGroup>
+
+      {/* Toggles row — note: enable / constant / selective are now on the row header,
+          so they are intentionally omitted from this block to avoid duplication. */}
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+        <ToggleButton label="Regex" value={form.useRegex ?? false} onChange={(v) => update({ useRegex: v })} />
+        <ToggleButton
+          label="Whole Words"
+          value={form.matchWholeWords ?? false}
+          onChange={(v) => update({ matchWholeWords: v })}
+        />
+        <ToggleButton
+          label="Case Sensitive"
+          value={form.caseSensitive ?? false}
+          onChange={(v) => update({ caseSensitive: v })}
+        />
+        <ToggleButton
+          label="Locked"
+          value={form.locked ?? false}
+          onChange={(v) => update({ locked: v })}
+          tooltip="Prevents the Lorebook Keeper agent from modifying this entry."
+        />
+        <ToggleButton
+          label="No Recursion"
+          value={form.preventRecursion ?? false}
+          onChange={(v) => update({ preventRecursion: v })}
+          tooltip="When enabled, this entry's content won't trigger additional entries during recursive scanning."
+        />
+      </div>
+
+      {/* Role (position/depth/order/probability live on the row header). */}
+      <FieldGroup
+        label="Role"
+        icon={Settings2}
+        help="Which role this entry's content is attributed to in the prompt (only meaningful when injected at depth)."
+      >
+        <select
+          value={form.role ?? "system"}
+          onChange={(e) => update({ role: e.target.value as "system" | "user" | "assistant" })}
+          className="w-full max-w-xs rounded-lg bg-[var(--secondary)] px-2 py-1.5 text-xs ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+        >
+          <option value="system">System</option>
+          <option value="user">User</option>
+          <option value="assistant">Assistant</option>
+        </select>
+      </FieldGroup>
+
+      {/* Timing */}
+      <FieldGroup
+        label="Timing"
+        icon={Settings2}
+        help="Sticky = stays active for N messages after triggering. Cooldown = waits N messages before it can trigger again. Delay = waits N messages before first activation. Ephemeral = auto-disables after N activations (0 = unlimited)."
+      >
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          <NumberField
+            label="Sticky"
+            value={form.sticky ?? 0}
+            onChange={(v) => update({ sticky: v || null })}
+            min={0}
+          />
+          <NumberField
+            label="Cooldown"
+            value={form.cooldown ?? 0}
+            onChange={(v) => update({ cooldown: v || null })}
+            min={0}
+          />
+          <NumberField label="Delay" value={form.delay ?? 0} onChange={(v) => update({ delay: v || null })} min={0} />
+          <NumberField
+            label="Ephemeral"
+            value={form.ephemeral ?? 0}
+            onChange={(v) => update({ ephemeral: v || null })}
+            min={0}
+          />
+        </div>
+      </FieldGroup>
+
+      {/* Group & Tag */}
+      <FieldGroup
+        label="Group & Tag"
+        icon={Settings2}
+        help="Group entries together so only one from the group activates at a time. Tags are for your own organization."
+      >
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label className="mb-1 block text-[0.6875rem] text-[var(--muted-foreground)]">Group</label>
+            <input
+              value={form.group ?? ""}
+              onChange={(e) => update({ group: e.target.value })}
+              className="w-full rounded-lg bg-[var(--secondary)] px-2 py-1.5 text-xs ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+              placeholder="Group name"
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-[0.6875rem] text-[var(--muted-foreground)]">Tag</label>
+            <input
+              value={form.tag ?? ""}
+              onChange={(e) => update({ tag: e.target.value })}
+              className="w-full rounded-lg bg-[var(--secondary)] px-2 py-1.5 text-xs ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+              placeholder="e.g. location, item, lore"
+            />
+          </div>
+        </div>
+      </FieldGroup>
+
+      {/* Save bar — only shows when there are unsaved changes in this drawer. */}
+      <div className="flex items-center justify-end gap-2 border-t border-[var(--border)] pt-3">
+        {dirty && <span className="text-[0.6875rem] text-[var(--muted-foreground)]">Unsaved changes</span>}
+        <button
+          onClick={handleSave}
+          disabled={!dirty || saving}
+          className="flex items-center gap-1.5 rounded-xl bg-gradient-to-r from-amber-400 to-orange-500 px-3 py-1.5 text-xs font-medium text-white shadow-sm transition-all hover:shadow-md active:scale-[0.98] disabled:opacity-50"
+        >
+          <Save size="0.75rem" />
+          {saving ? "Saving…" : "Save Entry"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/client/src/components/lorebooks/LorebookFolderRow.tsx
+++ b/packages/client/src/components/lorebooks/LorebookFolderRow.tsx
@@ -1,0 +1,228 @@
+// ──────────────────────────────────────────────
+// Lorebook Folder Row
+// Header for a collapsible folder of lorebook entries. Mirrors the visual
+// language of LorebookEntryRow (compact, drag handle on the left, inline
+// rename, hover-revealed delete) so the two row types feel like one list.
+//
+// Two toggles live on this row:
+//  • Collapse — a UI-only chevron that hides/shows the folder body. Persisted
+//    in localStorage by the parent editor; never sent to the server.
+//  • Enable  — a server-persisted folder.enabled flag. When OFF, every entry
+//    inside the folder is gated out at activation time regardless of the
+//    entry's own enabled flag. Entries' own flags are preserved untouched.
+// ──────────────────────────────────────────────
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type DragEvent as ReactDragEvent,
+  type MouseEvent as ReactMouseEvent,
+} from "react";
+import { ChevronDown, Folder, GripVertical, ToggleLeft, ToggleRight, Trash2 } from "lucide-react";
+import { cn } from "../../lib/utils";
+import { showConfirmDialog } from "../../lib/app-dialogs";
+import { useUpdateLorebookFolder, useDeleteLorebookFolder } from "../../hooks/use-lorebooks";
+import type { LorebookFolder } from "@marinara-engine/shared";
+
+interface Props {
+  folder: LorebookFolder;
+  lorebookId: string;
+  /** Number of entries currently inside this folder (for the count badge). */
+  entryCount: number;
+  /** UI-only collapse state — owned by the parent editor and persisted in localStorage. */
+  isCollapsed: boolean;
+  onToggleCollapse: () => void;
+  // Drag handle wiring — folder rows are draggable to reorder folders, AND
+  // act as drop targets when dragging an entry across containers.
+  draggable: boolean;
+  isDragging: boolean;
+  isDragReady: boolean;
+  onDragHandleMouseDown: () => void;
+  onDragHandleMouseUp: () => void;
+  onDragStart: (e: ReactDragEvent<HTMLDivElement>) => void;
+  onDragOver: (e: ReactDragEvent<HTMLDivElement>) => void;
+  onDrop: (e: ReactDragEvent<HTMLDivElement>) => void;
+  onDragEnd: () => void;
+}
+
+export function LorebookFolderRow({
+  folder,
+  lorebookId,
+  entryCount,
+  isCollapsed,
+  onToggleCollapse,
+  draggable,
+  isDragging,
+  isDragReady,
+  onDragHandleMouseDown,
+  onDragHandleMouseUp,
+  onDragStart,
+  onDragOver,
+  onDrop,
+  onDragEnd,
+}: Props) {
+  const updateFolder = useUpdateLorebookFolder();
+  const deleteFolder = useDeleteLorebookFolder();
+
+  // Optimistic mirrors so toggle/rename feel snappy while the mutation flushes.
+  const [localEnabled, setLocalEnabled] = useState(folder.enabled);
+  const [localName, setLocalName] = useState(folder.name);
+
+  const lastSyncedRef = useRef(folder);
+  useEffect(() => {
+    if (lastSyncedRef.current === folder) return;
+    lastSyncedRef.current = folder;
+    setLocalEnabled(folder.enabled);
+    setLocalName(folder.name);
+  }, [folder]);
+
+  const handleEnableToggle = useCallback(
+    (e: ReactMouseEvent) => {
+      e.stopPropagation();
+      const next = !localEnabled;
+      setLocalEnabled(next);
+      updateFolder.mutate({ lorebookId, folderId: folder.id, enabled: next });
+    },
+    [localEnabled, lorebookId, folder.id, updateFolder],
+  );
+
+  const handleNameCommit = useCallback(() => {
+    const trimmed = localName.trim();
+    if (!trimmed) {
+      setLocalName(folder.name);
+      return;
+    }
+    if (trimmed !== folder.name) {
+      updateFolder.mutate({ lorebookId, folderId: folder.id, name: trimmed });
+    }
+  }, [localName, folder.name, lorebookId, folder.id, updateFolder]);
+
+  const handleDelete = useCallback(
+    async (e: ReactMouseEvent) => {
+      e.stopPropagation();
+      const confirmed = await showConfirmDialog({
+        title: "Delete Folder",
+        message:
+          entryCount > 0
+            ? `Delete this folder? The ${entryCount} entr${entryCount === 1 ? "y" : "ies"} inside will be moved back to the root level.`
+            : "Delete this folder?",
+        confirmLabel: "Delete",
+        tone: "destructive",
+      });
+      if (!confirmed) return;
+      deleteFolder.mutate({ lorebookId, folderId: folder.id });
+    },
+    [entryCount, lorebookId, folder.id, deleteFolder],
+  );
+
+  return (
+    <div
+      className={cn(
+        "rounded-xl bg-[var(--secondary)]/60 ring-1 ring-[var(--border)] transition-all",
+        !isCollapsed && "ring-amber-400/30",
+        isDragging && "opacity-40",
+      )}
+      draggable={draggable && isDragReady}
+      onDragStart={onDragStart}
+      onDragOver={onDragOver}
+      onDrop={onDrop}
+      onDragEnd={onDragEnd}
+    >
+      <div className="group flex cursor-pointer items-center gap-2 px-2 py-1.5" onClick={onToggleCollapse}>
+        {/* Drag handle */}
+        <button
+          type="button"
+          className={cn(
+            "shrink-0 rounded p-0.5 text-[var(--muted-foreground)] transition-colors",
+            draggable
+              ? "cursor-grab hover:bg-[var(--accent)] hover:text-[var(--foreground)] active:cursor-grabbing"
+              : "cursor-not-allowed opacity-40",
+          )}
+          title={draggable ? "Drag to reorder folder" : "Use Order sort and clear search to reorder"}
+          onClick={(e) => e.stopPropagation()}
+          onMouseDown={(e) => {
+            e.stopPropagation();
+            if (draggable) onDragHandleMouseDown();
+          }}
+          onMouseUp={(e) => {
+            e.stopPropagation();
+            onDragHandleMouseUp();
+          }}
+        >
+          <GripVertical size="0.875rem" />
+        </button>
+
+        {/* Collapse chevron */}
+        <button
+          type="button"
+          aria-label={isCollapsed ? "Expand folder" : "Collapse folder"}
+          className="shrink-0 rounded p-0.5 text-[var(--muted-foreground)] transition-transform hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+          onClick={(e) => {
+            e.stopPropagation();
+            onToggleCollapse();
+          }}
+        >
+          <ChevronDown size="0.875rem" className={cn("transition-transform", isCollapsed ? "-rotate-90" : "rotate-0")} />
+        </button>
+
+        {/* Enable toggle */}
+        <button
+          type="button"
+          aria-label={localEnabled ? "Disable folder" : "Enable folder"}
+          title={
+            localEnabled
+              ? "Folder enabled — entries inside activate normally"
+              : "Folder disabled — entries inside will not activate, regardless of their own toggle"
+          }
+          onClick={handleEnableToggle}
+          className="shrink-0"
+        >
+          {localEnabled ? (
+            <ToggleRight size="1.125rem" className="text-amber-400" />
+          ) : (
+            <ToggleLeft size="1.125rem" className="text-[var(--muted-foreground)]" />
+          )}
+        </button>
+
+        {/* Folder icon + name */}
+        <Folder
+          size="0.875rem"
+          className={cn("shrink-0", localEnabled ? "text-amber-400" : "text-[var(--muted-foreground)]")}
+        />
+        <input
+          value={localName}
+          onChange={(e) => setLocalName(e.target.value)}
+          onBlur={handleNameCommit}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              (e.currentTarget as HTMLInputElement).blur();
+            }
+          }}
+          onClick={(e) => e.stopPropagation()}
+          placeholder="Untitled folder"
+          className="min-w-0 flex-1 truncate bg-transparent px-1 text-sm font-semibold outline-none transition-colors hover:bg-[var(--accent)]/40 focus:bg-[var(--accent)]/40 focus:ring-1 focus:ring-[var(--ring)] rounded"
+        />
+
+        {/* Entry count badge */}
+        <span
+          className="shrink-0 rounded-full bg-[var(--secondary)] px-2 py-0.5 text-[0.625rem] font-medium text-[var(--muted-foreground)]"
+          title={`${entryCount} entr${entryCount === 1 ? "y" : "ies"} in this folder`}
+        >
+          {entryCount}
+        </span>
+
+        {/* Delete (hover-revealed on desktop, always visible on mobile per the row-action convention) */}
+        <button
+          type="button"
+          aria-label="Delete folder"
+          onClick={handleDelete}
+          className="shrink-0 rounded p-1 opacity-0 transition-all hover:bg-[var(--destructive)]/15 group-hover:opacity-100 max-md:opacity-100"
+        >
+          <Trash2 size="0.75rem" className="text-[var(--destructive)]" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/client/src/hooks/use-lorebooks.ts
+++ b/packages/client/src/hooks/use-lorebooks.ts
@@ -3,7 +3,7 @@
 // ──────────────────────────────────────────────
 import { useQuery, useQueries, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "../lib/api-client";
-import type { Lorebook, LorebookEntry } from "@marinara-engine/shared";
+import type { Lorebook, LorebookEntry, LorebookFolder } from "@marinara-engine/shared";
 
 export const lorebookKeys = {
   all: ["lorebooks"] as const,
@@ -12,6 +12,7 @@ export const lorebookKeys = {
   detail: (id: string) => [...lorebookKeys.all, "detail", id] as const,
   entries: (lorebookId: string) => [...lorebookKeys.all, "entries", lorebookId] as const,
   entry: (entryId: string) => [...lorebookKeys.all, "entry", entryId] as const,
+  folders: (lorebookId: string) => [...lorebookKeys.all, "folders", lorebookId] as const,
   search: (q: string) => [...lorebookKeys.all, "search", q] as const,
 };
 
@@ -175,12 +176,94 @@ export function useBulkCreateEntries() {
 export function useReorderLorebookEntries() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: ({ lorebookId, entryIds }: { lorebookId: string; entryIds: string[] }) =>
-      api.put<LorebookEntry[]>(`/lorebooks/${lorebookId}/entries/reorder`, { entryIds }),
+    mutationFn: ({
+      lorebookId,
+      entryIds,
+      folderId,
+    }: {
+      lorebookId: string;
+      entryIds: string[];
+      /**
+       * Container scope for the reorder. `undefined` renumbers every entry
+       * (legacy behavior). `null` reorders root-level entries only.
+       * A string ID reorders the entries inside that folder only.
+       */
+      folderId?: string | null;
+    }) =>
+      api.put<LorebookEntry[]>(`/lorebooks/${lorebookId}/entries/reorder`, {
+        entryIds,
+        ...(folderId !== undefined ? { folderId } : {}),
+      }),
     onSuccess: (entries, variables) => {
       qc.setQueryData(lorebookKeys.entries(variables.lorebookId), entries);
       qc.invalidateQueries({ queryKey: lorebookKeys.entries(variables.lorebookId) });
       qc.invalidateQueries({ queryKey: [...lorebookKeys.all, "active"] });
+    },
+  });
+}
+
+// ── Folders ──
+
+export function useLorebookFolders(lorebookId: string | null) {
+  return useQuery({
+    queryKey: lorebookKeys.folders(lorebookId ?? ""),
+    queryFn: () => api.get<LorebookFolder[]>(`/lorebooks/${lorebookId}/folders`),
+    enabled: !!lorebookId,
+  });
+}
+
+export function useCreateLorebookFolder() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ lorebookId, ...data }: { lorebookId: string } & Record<string, unknown>) =>
+      api.post<LorebookFolder>(`/lorebooks/${lorebookId}/folders`, data),
+    onSuccess: (_data, variables) => {
+      qc.invalidateQueries({ queryKey: lorebookKeys.folders(variables.lorebookId) });
+    },
+  });
+}
+
+export function useUpdateLorebookFolder() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      lorebookId,
+      folderId,
+      ...data
+    }: {
+      lorebookId: string;
+      folderId: string;
+    } & Record<string, unknown>) => api.patch<LorebookFolder>(`/lorebooks/${lorebookId}/folders/${folderId}`, data),
+    onSuccess: (_data, variables) => {
+      qc.invalidateQueries({ queryKey: lorebookKeys.folders(variables.lorebookId) });
+      // Toggling folder.enabled changes which entries activate during scan
+      qc.invalidateQueries({ queryKey: [...lorebookKeys.all, "active"] });
+    },
+  });
+}
+
+export function useDeleteLorebookFolder() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ lorebookId, folderId }: { lorebookId: string; folderId: string }) =>
+      api.delete(`/lorebooks/${lorebookId}/folders/${folderId}`),
+    onSuccess: (_data, variables) => {
+      qc.invalidateQueries({ queryKey: lorebookKeys.folders(variables.lorebookId) });
+      // Removing a folder reparents its entries to root, so the entry list shape changes.
+      qc.invalidateQueries({ queryKey: lorebookKeys.entries(variables.lorebookId) });
+      qc.invalidateQueries({ queryKey: [...lorebookKeys.all, "active"] });
+    },
+  });
+}
+
+export function useReorderLorebookFolders() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ lorebookId, folderIds }: { lorebookId: string; folderIds: string[] }) =>
+      api.put<LorebookFolder[]>(`/lorebooks/${lorebookId}/folders/reorder`, { folderIds }),
+    onSuccess: (folders, variables) => {
+      qc.setQueryData(lorebookKeys.folders(variables.lorebookId), folders);
+      qc.invalidateQueries({ queryKey: lorebookKeys.folders(variables.lorebookId) });
     },
   });
 }

--- a/packages/server/src/db/schema/lorebooks.ts
+++ b/packages/server/src/db/schema/lorebooks.ts
@@ -1,5 +1,5 @@
 // ──────────────────────────────────────────────
-// Schema: Lorebooks & Entries
+// Schema: Lorebooks, Folders & Entries
 // ──────────────────────────────────────────────
 import { sqliteTable, text, integer } from "drizzle-orm/sqlite-core";
 
@@ -24,11 +24,42 @@ export const lorebooks = sqliteTable("lorebooks", {
   updatedAt: text("updated_at").notNull(),
 });
 
+/**
+ * Lorebook folders — collapsible containers that group entries to reduce
+ * visual clutter in the editor. Folders are flat in v1; `parentFolderId` is
+ * reserved (always null) for a future nested-folder PR. When a folder's
+ * `enabled` flag is "false", every entry whose `folderId` matches is
+ * excluded from activation regardless of the entry's own enabled flag —
+ * gating happens at `listActiveEntries` time, not by mutating entry rows.
+ */
+export const lorebookFolders = sqliteTable("lorebook_folders", {
+  id: text("id").primaryKey(),
+  lorebookId: text("lorebook_id")
+    .notNull()
+    .references(() => lorebooks.id, { onDelete: "cascade" }),
+  name: text("name").notNull(),
+  /** SQLite-style "true"/"false" string, matches the rest of this schema. */
+  enabled: text("enabled").notNull().default("true"),
+  /** Reserved for future nesting; always NULL in v1. */
+  parentFolderId: text("parent_folder_id"),
+  /** Display order among sibling folders (lower = higher in the list). */
+  order: integer("order").notNull().default(0),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull(),
+});
+
 export const lorebookEntries = sqliteTable("lorebook_entries", {
   id: text("id").primaryKey(),
   lorebookId: text("lorebook_id")
     .notNull()
     .references(() => lorebooks.id, { onDelete: "cascade" }),
+  /**
+   * Folder this entry belongs to, or NULL for root-level. Not enforced as a
+   * foreign key in SQLite to keep folder deletion cheap (the storage layer
+   * sets entries' folderId back to null when a folder is removed instead of
+   * cascading the entries themselves).
+   */
+  folderId: text("folder_id"),
   name: text("name").notNull(),
   content: text("content").notNull().default(""),
   /** Short summary used by the knowledge-router agent to decide if this entry is relevant */

--- a/packages/server/src/routes/lorebooks.routes.ts
+++ b/packages/server/src/routes/lorebooks.routes.ts
@@ -7,6 +7,8 @@ import {
   updateLorebookSchema,
   createLorebookEntrySchema,
   updateLorebookEntrySchema,
+  createLorebookFolderSchema,
+  updateLorebookFolderSchema,
 } from "@marinara-engine/shared";
 import type { ExportEnvelope } from "@marinara-engine/shared";
 import { createLorebooksStorage } from "../services/storage/lorebooks.storage.js";
@@ -77,11 +79,12 @@ export async function lorebooksRoutes(app: FastifyInstance) {
     const lb = (await storage.getById(req.params.id)) as Record<string, unknown> | null;
     if (!lb) return reply.status(404).send({ error: "Lorebook not found" });
     const entries = await storage.listEntries(req.params.id);
+    const folders = await storage.listFolders(req.params.id);
     const envelope: ExportEnvelope = {
       type: "marinara_lorebook",
       version: 1,
       exportedAt: new Date().toISOString(),
-      data: { lorebook: lb, entries },
+      data: { lorebook: lb, entries, folders },
     };
     return reply
       .header(
@@ -103,11 +106,12 @@ export async function lorebooksRoutes(app: FastifyInstance) {
       const lb = (await storage.getById(id)) as Record<string, unknown> | null;
       if (!lb) continue;
       const entries = await storage.listEntries(id);
+      const folders = await storage.listFolders(id);
       const envelope: ExportEnvelope = {
         type: "marinara_lorebook",
         version: 1,
         exportedAt: new Date().toISOString(),
-        data: { lorebook: lb, entries },
+        data: { lorebook: lb, entries, folders },
       };
       zip.addFile(
         `${toSafeExportName(String(lb.name || "lorebook"), `lorebook-${exportedCount + 1}`)}.marinara.json`,
@@ -176,14 +180,64 @@ export async function lorebooksRoutes(app: FastifyInstance) {
   });
 
   app.put<{ Params: { id: string } }>("/:id/entries/reorder", async (req, reply) => {
-    const body = req.body as { entryIds?: unknown };
+    const body = req.body as { entryIds?: unknown; folderId?: unknown };
     const entryIds = Array.isArray(body.entryIds)
       ? body.entryIds.filter((id): id is string => typeof id === "string")
       : [];
     if (entryIds.length === 0) {
       return reply.status(400).send({ error: "entryIds array is required" });
     }
-    return storage.reorderEntries(req.params.id, entryIds);
+    // folderId scopes the reorder to a single container:
+    //   undefined → legacy behaviour (renumber every entry in the lorebook)
+    //   null      → root-level entries only
+    //   string    → entries inside that folder only
+    let folderId: string | null | undefined;
+    if (body.folderId === null) folderId = null;
+    else if (typeof body.folderId === "string") folderId = body.folderId;
+    else folderId = undefined;
+    return storage.reorderEntries(req.params.id, entryIds, folderId);
+  });
+
+  // ── Folders ──
+
+  app.get<{ Params: { id: string } }>("/:id/folders", async (req) => {
+    return storage.listFolders(req.params.id);
+  });
+
+  app.post<{ Params: { id: string } }>("/:id/folders", async (req, reply) => {
+    const input = createLorebookFolderSchema.parse(req.body);
+    if (input.parentFolderId !== null) {
+      // v1 reserves nesting for a follow-up PR. Accept the field shape but
+      // refuse to persist non-null values rather than silently dropping them.
+      return reply.status(400).send({ error: "Nested folders are not supported in this version" });
+    }
+    return storage.createFolder(req.params.id, input);
+  });
+
+  app.patch<{ Params: { id: string; folderId: string } }>("/:id/folders/:folderId", async (req, reply) => {
+    const input = updateLorebookFolderSchema.parse(req.body);
+    if (input.parentFolderId !== undefined && input.parentFolderId !== null) {
+      return reply.status(400).send({ error: "Nested folders are not supported in this version" });
+    }
+    const updated = await storage.updateFolder(req.params.folderId, input);
+    if (!updated) return reply.status(404).send({ error: "Folder not found" });
+    return updated;
+  });
+
+  app.delete<{ Params: { id: string; folderId: string } }>("/:id/folders/:folderId", async (req, reply) => {
+    await storage.removeFolder(req.params.folderId);
+    return reply.status(204).send();
+  });
+
+  app.put<{ Params: { id: string } }>("/:id/folders/reorder", async (req, reply) => {
+    const body = req.body as { folderIds?: unknown };
+    const folderIds = Array.isArray(body.folderIds)
+      ? body.folderIds.filter((id): id is string => typeof id === "string")
+      : [];
+    if (folderIds.length === 0) {
+      return reply.status(400).send({ error: "folderIds array is required" });
+    }
+    return storage.reorderFolders(req.params.id, folderIds);
   });
 
   // ── Search ──

--- a/packages/server/src/services/import/marinara.importer.ts
+++ b/packages/server/src/services/import/marinara.importer.ts
@@ -136,7 +136,11 @@ async function importPersona(data: unknown, db: DB) {
 
 async function importLorebook(data: unknown, db: DB) {
   const storage = createLorebooksStorage(db);
-  const d = data as { lorebook?: Record<string, unknown>; entries?: Record<string, unknown>[] };
+  const d = data as {
+    lorebook?: Record<string, unknown>;
+    entries?: Record<string, unknown>[];
+    folders?: Record<string, unknown>[];
+  };
   if (!d?.lorebook) {
     return { success: false, type: "marinara_lorebook" as const, error: "Invalid lorebook data" };
   }
@@ -155,36 +159,58 @@ async function importLorebook(data: unknown, db: DB) {
     readTimestampOverrides(lb),
   )) as Record<string, unknown> | null;
 
+  // Re-create folders first so we can remap old folder IDs → new folder IDs
+  // before mapping entries. Older exports without `folders` simply skip this
+  // step and every entry lands at root.
+  const folderIdRemap = new Map<string, string>();
+  if (newLb && Array.isArray(d.folders) && d.folders.length > 0) {
+    for (const f of d.folders) {
+      const oldId = typeof f.id === "string" ? f.id : null;
+      const created = (await storage.createFolder(newLb.id as string, {
+        name: String(f.name ?? "Folder"),
+        enabled: f.enabled !== false,
+        parentFolderId: null, // v1 ignores nesting on import
+        order: Number(f.order ?? 0),
+      })) as Record<string, unknown> | null;
+      if (oldId && created?.id) folderIdRemap.set(oldId, created.id as string);
+    }
+  }
+
   if (newLb && Array.isArray(d.entries) && d.entries.length > 0) {
-    const entries = d.entries.map((e) => ({
-      name: String(e.name ?? ""),
-      content: String(e.content ?? ""),
-      keys: Array.isArray(e.keys) ? e.keys.map(String) : [],
-      secondaryKeys: Array.isArray(e.secondaryKeys) ? e.secondaryKeys.map(String) : [],
-      enabled: e.enabled !== false,
-      constant: Boolean(e.constant),
-      selective: Boolean(e.selective),
-      selectiveLogic: (e.selectiveLogic as any) ?? "and",
-      probability: e.probability != null ? Number(e.probability) : null,
-      scanDepth: e.scanDepth != null ? Number(e.scanDepth) : null,
-      matchWholeWords: Boolean(e.matchWholeWords),
-      caseSensitive: Boolean(e.caseSensitive),
-      useRegex: Boolean(e.useRegex),
-      position: Number(e.position ?? 0),
-      depth: Number(e.depth ?? 4),
-      order: Number(e.order ?? 100),
-      role: (e.role as any) ?? "system",
-      sticky: e.sticky != null ? Number(e.sticky) : null,
-      cooldown: e.cooldown != null ? Number(e.cooldown) : null,
-      delay: e.delay != null ? Number(e.delay) : null,
-      group: String(e.group ?? ""),
-      groupWeight: e.groupWeight != null ? Number(e.groupWeight) : null,
-      tag: String(e.tag ?? ""),
-      relationships: (e.relationships as any) ?? {},
-      dynamicState: (e.dynamicState as any) ?? {},
-      activationConditions: (e.activationConditions as any) ?? [],
-      schedule: (e.schedule as any) ?? null,
-    }));
+    const entries = d.entries.map((e) => {
+      const oldFolderId = typeof e.folderId === "string" ? e.folderId : null;
+      const newFolderId = oldFolderId ? (folderIdRemap.get(oldFolderId) ?? null) : null;
+      return {
+        name: String(e.name ?? ""),
+        content: String(e.content ?? ""),
+        keys: Array.isArray(e.keys) ? e.keys.map(String) : [],
+        secondaryKeys: Array.isArray(e.secondaryKeys) ? e.secondaryKeys.map(String) : [],
+        enabled: e.enabled !== false,
+        constant: Boolean(e.constant),
+        selective: Boolean(e.selective),
+        selectiveLogic: (e.selectiveLogic as any) ?? "and",
+        probability: e.probability != null ? Number(e.probability) : null,
+        scanDepth: e.scanDepth != null ? Number(e.scanDepth) : null,
+        matchWholeWords: Boolean(e.matchWholeWords),
+        caseSensitive: Boolean(e.caseSensitive),
+        useRegex: Boolean(e.useRegex),
+        position: Number(e.position ?? 0),
+        depth: Number(e.depth ?? 4),
+        order: Number(e.order ?? 100),
+        role: (e.role as any) ?? "system",
+        sticky: e.sticky != null ? Number(e.sticky) : null,
+        cooldown: e.cooldown != null ? Number(e.cooldown) : null,
+        delay: e.delay != null ? Number(e.delay) : null,
+        group: String(e.group ?? ""),
+        groupWeight: e.groupWeight != null ? Number(e.groupWeight) : null,
+        folderId: newFolderId,
+        tag: String(e.tag ?? ""),
+        relationships: (e.relationships as any) ?? {},
+        dynamicState: (e.dynamicState as any) ?? {},
+        activationConditions: (e.activationConditions as any) ?? [],
+        schedule: (e.schedule as any) ?? null,
+      };
+    });
     await storage.bulkCreateEntries(newLb.id as string, entries);
   }
 

--- a/packages/server/src/services/storage/lorebooks.storage.ts
+++ b/packages/server/src/services/storage/lorebooks.storage.ts
@@ -1,15 +1,17 @@
 // ──────────────────────────────────────────────
 // Storage: Lorebooks
 // ──────────────────────────────────────────────
-import { eq, desc, and, like, inArray } from "drizzle-orm";
+import { eq, desc, and, like, inArray, asc } from "drizzle-orm";
 import type { DB } from "../../db/connection.js";
-import { lorebooks, lorebookEntries } from "../../db/schema/index.js";
+import { lorebooks, lorebookEntries, lorebookFolders } from "../../db/schema/index.js";
 import { newId, now } from "../../utils/id-generator.js";
 import type {
   CreateLorebookInput,
   UpdateLorebookInput,
   CreateLorebookEntryInput,
   UpdateLorebookEntryInput,
+  CreateLorebookFolderInput,
+  UpdateLorebookFolderInput,
 } from "@marinara-engine/shared";
 import { normalizeTimestampOverrides, type TimestampOverrides } from "../import/import-timestamps.js";
 
@@ -49,6 +51,7 @@ function parseEntryRow(row: Record<string, unknown>) {
     useRegex: row.useRegex === "true",
     locked: row.locked === "true",
     preventRecursion: row.preventRecursion === "true",
+    folderId: (row.folderId as string | null | undefined) ?? null,
     keys: JSON.parse((row.keys as string) || "[]"),
     secondaryKeys: JSON.parse((row.secondaryKeys as string) || "[]"),
     relationships: JSON.parse((row.relationships as string) || "{}"),
@@ -56,6 +59,14 @@ function parseEntryRow(row: Record<string, unknown>) {
     activationConditions: JSON.parse((row.activationConditions as string) || "[]"),
     schedule: row.schedule ? JSON.parse(row.schedule as string) : null,
     embedding: row.embedding ? JSON.parse(row.embedding as string) : null,
+  };
+}
+
+function parseFolderRow(row: Record<string, unknown>) {
+  return {
+    ...row,
+    enabled: row.enabled === "true",
+    parentFolderId: (row.parentFolderId as string | null | undefined) ?? null,
   };
 }
 
@@ -190,6 +201,12 @@ export function createLorebooksStorage(db: DB) {
      *  - Its `personaId` matches the chat's active persona
      *  - Its `chatId` matches the current chat
      * When no filters are provided, returns entries from ALL enabled lorebooks (legacy behavior).
+     *
+     * Folder gate: an entry whose `folderId` points at a disabled folder is
+     * excluded here, regardless of the entry's own `enabled` flag. The entry's
+     * own flag is preserved in the database — re-enabling the folder restores
+     * each entry's previous individual setting. Entries with a NULL `folderId`
+     * (root-level entries) are unaffected.
      */
     async listActiveEntries(filters?: {
       activeLorebookIds?: string[];
@@ -216,12 +233,24 @@ export function createLorebooksStorage(db: DB) {
 
       const bookIds = relevantBooks.map((b) => b.id);
       if (bookIds.length === 0) return [];
+
+      // Build the disabled-folder ID set for the relevant lorebooks. Done as
+      // an in-memory filter (rather than a SQL anti-join) because folder
+      // counts per book are small and this keeps the existing query shape.
+      const disabledFolderRows = await db
+        .select({ id: lorebookFolders.id })
+        .from(lorebookFolders)
+        .where(and(inArray(lorebookFolders.lorebookId, bookIds), eq(lorebookFolders.enabled, "false")));
+      const disabledFolderIds = new Set(disabledFolderRows.map((r) => r.id));
+
       const rows = await db
         .select()
         .from(lorebookEntries)
         .where(and(inArray(lorebookEntries.lorebookId, bookIds), eq(lorebookEntries.enabled, "true")))
         .orderBy(lorebookEntries.order);
-      return rows.map((r) => parseEntryRow(r as Record<string, unknown>));
+      const parsed = rows.map((r) => parseEntryRow(r as Record<string, unknown>));
+      if (disabledFolderIds.size === 0) return parsed;
+      return parsed.filter((e) => !e.folderId || !disabledFolderIds.has(e.folderId as string));
     },
 
     async getEntry(id: string) {
@@ -236,6 +265,7 @@ export function createLorebooksStorage(db: DB) {
       await db.insert(lorebookEntries).values({
         id,
         lorebookId: input.lorebookId,
+        folderId: input.folderId ?? null,
         name: input.name,
         content: input.content ?? "",
         description: input.description ?? "",
@@ -278,6 +308,7 @@ export function createLorebooksStorage(db: DB) {
       if (input.name !== undefined) updates.name = input.name;
       if (input.content !== undefined) updates.content = input.content;
       if (input.description !== undefined) updates.description = input.description;
+      if (input.folderId !== undefined) updates.folderId = input.folderId;
       if (input.keys !== undefined) updates.keys = JSON.stringify(input.keys);
       if (input.secondaryKeys !== undefined) updates.secondaryKeys = JSON.stringify(input.secondaryKeys);
       if (input.enabled !== undefined) updates.enabled = String(input.enabled);
@@ -330,18 +361,39 @@ export function createLorebooksStorage(db: DB) {
       return results;
     },
 
-    async reorderEntries(lorebookId: string, entryIds: string[]) {
-      const existingEntries = (await this.listEntries(lorebookId)).map((entry) => {
-        const row = entry as unknown as Record<string, unknown>;
-        return {
-          id: String(row.id),
-          order: typeof row.order === "number" ? row.order : Number(row.order ?? 0),
-        };
-      });
-      const orderById = new Map(existingEntries.map((entry) => [entry.id, entry.order]));
-      const existingIds = new Set(existingEntries.map((entry) => entry.id));
-      const orderedIds = entryIds.filter((id, index, ids) => existingIds.has(id) && ids.indexOf(id) === index);
-      const missingIds = existingEntries
+    /**
+     * Reorder entries inside a single container.
+     *
+     * `folderId` (undefined = legacy, null = root, string = inside that
+     * folder) scopes the reorder so that dragging within one container does
+     * not renumber entries in another. When `folderId` is undefined we keep
+     * the legacy behavior of renumbering every entry in the lorebook.
+     *
+     * Renumbering uses (index + 1) * 10 within the container, so each
+     * container's order space starts back at 10 — that's intentional and
+     * matches the user-facing "each folder is its own container" semantic
+     * (a folder at the top can hold high-Order entries without affecting
+     * root entries below it).
+     */
+    async reorderEntries(lorebookId: string, entryIds: string[], folderId?: string | null) {
+      const allEntries = (await this.listEntries(lorebookId)) as unknown as Array<Record<string, unknown>>;
+
+      const inScope =
+        folderId === undefined
+          ? allEntries
+          : allEntries.filter((row) => {
+              const rowFolder = (row.folderId as string | null | undefined) ?? null;
+              return rowFolder === folderId;
+            });
+
+      const scopeEntries = inScope.map((row) => ({
+        id: String(row.id),
+        order: typeof row.order === "number" ? row.order : Number(row.order ?? 0),
+      }));
+      const orderById = new Map(scopeEntries.map((entry) => [entry.id, entry.order]));
+      const scopeIds = new Set(scopeEntries.map((entry) => entry.id));
+      const orderedIds = entryIds.filter((id, index, ids) => scopeIds.has(id) && ids.indexOf(id) === index);
+      const missingIds = scopeEntries
         .map((entry) => entry.id)
         .filter((id) => !orderedIds.includes(id))
         .sort((leftId, rightId) => (orderById.get(leftId) ?? 0) - (orderById.get(rightId) ?? 0));
@@ -361,6 +413,103 @@ export function createLorebooksStorage(db: DB) {
     async removeEntry(id: string) {
       await db.delete(lorebookEntries).where(eq(lorebookEntries.id, id));
     },
+
+    // ── Folders ──
+
+    async listFolders(lorebookId: string) {
+      const rows = await db
+        .select()
+        .from(lorebookFolders)
+        .where(eq(lorebookFolders.lorebookId, lorebookId))
+        .orderBy(asc(lorebookFolders.order));
+      return rows.map((r) => parseFolderRow(r as Record<string, unknown>));
+    },
+
+    async getFolder(folderId: string) {
+      const rows = await db.select().from(lorebookFolders).where(eq(lorebookFolders.id, folderId));
+      const row = rows[0];
+      return row ? parseFolderRow(row as Record<string, unknown>) : null;
+    },
+
+    async createFolder(lorebookId: string, input: CreateLorebookFolderInput) {
+      const id = newId();
+      const timestamp = now();
+      // If the caller didn't pass an explicit order, append after existing folders
+      // so the new one shows up at the bottom of the folder block by default.
+      let order = input.order ?? 0;
+      if (input.order === undefined || input.order === 0) {
+        const existing = await db
+          .select({ order: lorebookFolders.order })
+          .from(lorebookFolders)
+          .where(eq(lorebookFolders.lorebookId, lorebookId));
+        if (existing.length > 0) {
+          order = Math.max(...existing.map((r) => r.order ?? 0)) + 10;
+        } else {
+          order = 10;
+        }
+      }
+      await db.insert(lorebookFolders).values({
+        id,
+        lorebookId,
+        name: input.name,
+        enabled: String(input.enabled ?? true),
+        // v1 ignores any non-null parentFolderId — caller is the route layer.
+        parentFolderId: input.parentFolderId ?? null,
+        order,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      });
+      return this.getFolder(id);
+    },
+
+    async updateFolder(folderId: string, input: UpdateLorebookFolderInput) {
+      const updates: Record<string, unknown> = { updatedAt: now() };
+      if (input.name !== undefined) updates.name = input.name;
+      if (input.enabled !== undefined) updates.enabled = String(input.enabled);
+      if (input.parentFolderId !== undefined) updates.parentFolderId = input.parentFolderId;
+      if (input.order !== undefined) updates.order = input.order;
+      await db.update(lorebookFolders).set(updates).where(eq(lorebookFolders.id, folderId));
+      return this.getFolder(folderId);
+    },
+
+    /**
+     * Remove a folder. Entries inside the folder are NOT deleted — their
+     * `folderId` is reset to NULL (root level) so the user doesn't lose
+     * data when they remove a folder by accident.
+     */
+    async removeFolder(folderId: string) {
+      const folder = (await this.getFolder(folderId)) as Record<string, unknown> | null;
+      if (!folder) return;
+      const lorebookId = folder.lorebookId as string;
+      await db
+        .update(lorebookEntries)
+        .set({ folderId: null, updatedAt: now() })
+        .where(and(eq(lorebookEntries.lorebookId, lorebookId), eq(lorebookEntries.folderId, folderId)));
+      await db.delete(lorebookFolders).where(eq(lorebookFolders.id, folderId));
+    },
+
+    /** Renumber folders within a lorebook to match `folderIds` left-to-right. */
+    async reorderFolders(lorebookId: string, folderIds: string[]) {
+      const existing = (await this.listFolders(lorebookId)) as unknown as Array<{ id: string; order: number }>;
+      const orderById = new Map(existing.map((f) => [f.id, f.order]));
+      const existingIds = new Set(existing.map((f) => f.id));
+      const orderedIds = folderIds.filter((id, index, ids) => existingIds.has(id) && ids.indexOf(id) === index);
+      const missingIds = existing
+        .map((f) => f.id)
+        .filter((id) => !orderedIds.includes(id))
+        .sort((a, b) => (orderById.get(a) ?? 0) - (orderById.get(b) ?? 0));
+      const nextIds = [...orderedIds, ...missingIds];
+      const timestamp = now();
+      for (const [index, id] of nextIds.entries()) {
+        await db
+          .update(lorebookFolders)
+          .set({ order: (index + 1) * 10, updatedAt: timestamp })
+          .where(and(eq(lorebookFolders.id, id), eq(lorebookFolders.lorebookId, lorebookId)));
+      }
+      return this.listFolders(lorebookId);
+    },
+
+    // ── Search ──
 
     /** Search entries by keyword match in name/content/keys. */
     async searchEntries(query: string) {

--- a/packages/shared/src/schemas/lorebook.schema.ts
+++ b/packages/shared/src/schemas/lorebook.schema.ts
@@ -19,6 +19,26 @@ export const lorebookScheduleSchema = z.object({
   activeLocations: z.array(z.string()).default([]),
 });
 
+// ──────────────────────────────────────────────
+// Folders — collapsible containers for entries
+// `parentFolderId` is reserved for a future nested-folder PR; v1 enforces
+// `null` at the route layer so the schema accepts the field but the server
+// rejects non-null values.
+// ──────────────────────────────────────────────
+export const createLorebookFolderSchema = z.object({
+  name: z.string().min(1).max(200),
+  enabled: z.boolean().default(true),
+  parentFolderId: z.string().nullable().default(null),
+  order: z.number().int().default(0),
+});
+
+export const updateLorebookFolderSchema = z.object({
+  name: z.string().min(1).max(200).optional(),
+  enabled: z.boolean().optional(),
+  parentFolderId: z.string().nullable().optional(),
+  order: z.number().int().optional(),
+});
+
 export const createLorebookSchema = z.object({
   name: z.string().min(1).max(200),
   description: z.string().default(""),
@@ -79,6 +99,8 @@ export const createLorebookEntrySchema = z.object({
   ephemeral: z.number().int().min(0).nullable().default(null),
   group: z.string().default(""),
   groupWeight: z.number().nullable().default(null),
+  /** Optional folder this entry belongs to. Null/omitted = root level. */
+  folderId: z.string().nullable().default(null),
   preventRecursion: z.boolean().default(false),
   locked: z.boolean().default(false),
   tag: z.string().default(""),
@@ -113,6 +135,7 @@ export const updateLorebookEntrySchema = z.object({
   ephemeral: z.number().int().min(0).nullable().optional(),
   group: z.string().optional(),
   groupWeight: z.number().nullable().optional(),
+  folderId: z.string().nullable().optional(),
   preventRecursion: z.boolean().optional(),
   locked: z.boolean().optional(),
   tag: z.string().optional(),
@@ -126,3 +149,5 @@ export type CreateLorebookInput = z.input<typeof createLorebookSchema>;
 export type UpdateLorebookInput = z.infer<typeof updateLorebookSchema>;
 export type CreateLorebookEntryInput = z.input<typeof createLorebookEntrySchema>;
 export type UpdateLorebookEntryInput = z.infer<typeof updateLorebookEntrySchema>;
+export type CreateLorebookFolderInput = z.input<typeof createLorebookFolderSchema>;
+export type UpdateLorebookFolderInput = z.infer<typeof updateLorebookFolderSchema>;

--- a/packages/shared/src/types/lorebook.ts
+++ b/packages/shared/src/types/lorebook.ts
@@ -42,6 +42,42 @@ export interface Lorebook {
   updatedAt: string;
 }
 
+/**
+ * A collapsible container that groups lorebook entries to reduce visual
+ * clutter in the editor. Folders are flat in v1 — `parentFolderId` is reserved
+ * for future nested-folder support and must currently be null.
+ *
+ * Folder enable/disable acts as a gate: when `enabled` is false, every entry
+ * inside the folder is treated as inactive at activation time, regardless of
+ * the entry's own `enabled` flag. The entry's own flag is preserved (the
+ * folder toggle does NOT mutate it), so re-enabling the folder restores the
+ * entries' previous individual settings.
+ *
+ * Folders sit above root-level entries in the editor display. Folder display
+ * order among siblings is controlled by `order`. Entry `order` continues to
+ * control prompt-injection priority and per-container display sort.
+ */
+export interface LorebookFolder {
+  id: string;
+  lorebookId: string;
+  /** Display name shown on the folder header row. */
+  name: string;
+  /**
+   * When false, every entry whose `folderId` matches this folder is skipped
+   * during activation, regardless of the entry's own `enabled` flag.
+   */
+  enabled: boolean;
+  /**
+   * Reserved for future nested-folder support. Always null in v1; the server
+   * rejects non-null values.
+   */
+  parentFolderId: string | null;
+  /** Display order among sibling folders (lower = higher in the list). */
+  order: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
 /** A single lorebook entry. */
 export interface LorebookEntry {
   id: string;
@@ -92,6 +128,14 @@ export interface LorebookEntry {
   // ── Grouping ──
   group: string;
   groupWeight: number | null;
+  /**
+   * ID of the folder this entry belongs to, or null if it lives at the
+   * lorebook root level. Display sort by `order` is per-container — entries
+   * inside a folder sort independently from root entries and from entries in
+   * other folders. When a folder is disabled, every entry whose `folderId`
+   * matches is excluded from activation regardless of `enabled`.
+   */
+  folderId: string | null;
 
   // ── Engine extensions (beyond ST) ──
   /** When true, the Lorebook Keeper agent cannot modify or overwrite this entry */


### PR DESCRIPTION
<html>
<body>
<h2>Summary</h2>
<p>Adds a flat collapsible folder system to the Lorebook editor so large lorebooks (especially ones with many entries that exist mainly for AI agents to manage) can be organized into named groups instead of one long vertical list.</p>
<p>Builds on the previously-merged inline-edit row work — folders are a parallel structure that sit above the existing entry rows.</p>
<h2>Why</h2>
<p>Large lorebooks become hard to navigate quickly: stable / agent-managed entries dominate vertical space, drowning out the entries the user is actively editing. A collapsible folder lets the user park "set-and-forget" entries out of view without disabling them, and gives a single toggle to gate a whole bucket on/off.</p>
<h2>Behavior</h2>
<ul>
<li><strong>Folders are flat</strong> in this PR. The schema includes a <code>parentFolderId</code> field reserved as <code>null</code> so a follow-up PR can add nesting without another migration. The route layer rejects non-null values for now.</li>
<li><strong>Two toggles per folder.</strong> A <em>collapse</em> chevron (UI-only, persisted in <code>localStorage</code> per-lorebook) and an <em>enable</em> toggle (server-persisted). When the enable toggle is OFF, every entry inside the folder is excluded from activation regardless of the entry's own <code>enabled</code> flag — and the entry's own flag is preserved untouched, so re-enabling the folder restores each entry's previous individual setting.</li>
<li><strong>Each folder is its own container.</strong> Sort by Order works inside the folder independently from root entries and from other folders. A folder full of high-Order entries can sit at the top of the list above root-level entries with low Order without conflict — that was an explicit ask in the issue framing.</li>
<li><strong>Move UX:</strong> dropdown picker on each entry row (always available) and drag-and-drop across containers (when sort=Order with empty search). Drop on a folder header → entry moves to the top of that folder. Drop in the empty body of a folder → entry lands at the end. Drop in the root list → moves to root.</li>
<li><strong>Folder reorder via DnD</strong> between folder headers, mirroring the existing entry DnD pattern.</li>
<li><strong>When folder grouping doesn't make sense</strong> (search active, or sort is non-Order), the entries tab falls back to the existing flat list. A small "folder view paused" hint appears in the summary line. Folders aren't deleted — they reappear when the user clears search and re-selects Order.</li>
<li><strong>Deleting a folder reparents entries to root</strong> (sets their <code>folderId</code> back to <code>null</code>) instead of cascading. The confirmation dialog says so explicitly.</li>
</ul>
<h2>Architecture</h2>

Layer | What changed
-- | --
packages/shared | New LorebookFolder type. New createLorebookFolderSchema / updateLorebookFolderSchema. New folderId field on LorebookEntry (defaults to null).
packages/server/src/db/schema/lorebooks.ts | New lorebook_folders table (id, lorebook_id FK, name, enabled, parent_folder_id, order, timestamps). New folder_id nullable column on lorebook_entries.
packages/server/src/services/storage/lorebooks.storage.ts | Folder CRUD + reorder. Activation gate update in listActiveEntries — disabled-folder ID set excludes contained entries. reorderEntries now takes optional folderId so dragging within one container doesn't renumber another.
packages/server/src/routes/lorebooks.routes.ts | New GET / POST / PATCH / DELETE / PUT-reorder endpoints under /lorebooks/:id/folders. Export envelopes now include a folders array. Entry-reorder route accepts an optional folderId body field. Non-null parentFolderId rejected with 400.
packages/server/src/services/import/marinara.importer.ts | Re-imports folders from the export envelope and remaps old folder IDs → new folder IDs before creating entries, so a round-tripped lorebook keeps its folder structure.
packages/client/src/hooks/use-lorebooks.ts | New folder hooks: useLorebookFolders, useCreateLorebookFolder, useUpdateLorebookFolder, useDeleteLorebookFolder, useReorderLorebookFolders. useReorderLorebookEntries now accepts a folderId arg.
packages/client/src/components/lorebooks/LorebookFolderRow.tsx (new) | Collapsible folder header with enable toggle, inline rename, entry-count badge, drag handle, hover-revealed delete.
packages/client/src/components/lorebooks/LorebookEntryRow.tsx | Adds a folder picker (CompactSelect of folders + "(none)") shown only when at least one folder exists.
packages/client/src/components/lorebooks/LorebookEditor.tsx | Restructures the Entries tab to render a folder block + a root block when sort=Order with empty search. Cross-container DnD with source/target container tracking. New "Add Folder" button. localStorage helpers for collapse state.
CHANGELOG.md | Entry under 1.5.6.


<h2>Known limitations</h2>
<ul>
<li>Nesting is intentionally not implemented. The schema reserves <code>parentFolderId</code> so a follow-up PR can add it without another migration; the route currently rejects non-null values.</li>
<li>DnD ignores the search/non-Order sort modes (drag handles disabled, matching previous behavior). The folder picker dropdown still works in those modes, so cross-folder moves are always available.</li>
<li>Folder view doesn't display badges on entries when grouping is suppressed (search/non-Order sort). The "folder view paused" hint in the summary is the only signal that folders exist in those modes — fine for now but could be richer later.</li>
<li>Entry <code>order</code> numbering across containers will accumulate gaps over time as entries move between folders. This is harmless (it doesn't affect activation; lower-Order = earlier) and gets renumbered to (i+1)*10 within a container the next time a drag-reorder happens inside it.</li>
</ul>
<h2>Test plan</h2>
<p>A subset of these were exercised live in the running engine. The rest still need eyes-on verification before merging — they're called out below.</p>
<ul>
<li>[x] <strong><code>pnpm install</code> &amp;&amp; <code>pnpm db:push</code></strong> — confirmed locally; schema changes applied without errors.</li>
<li>[x] <strong><code>pnpm check</code></strong> passes locally with no new errors.</li>
<li>[x] <strong>Open an existing lorebook</strong> with several entries — opened a 6-entry lorebook; entries rendered correctly. No regression vs the inline-edit experience.</li>
<li>[x] <strong>Click "Add Folder"</strong> — confirmed a new folder appears in the folders block, named "New Folder", expanded, enabled. (Append-at-bottom rather than at-the-top, by design — places it after existing folders without disrupting them.)</li>
<li>[x] <strong>Rename the folder</strong> by clicking the name and editing — confirmed change persists after blur and propagates to entry-row folder dropdowns.</li>
<li>[x] <strong>Pick a root entry's folder dropdown → choose the new folder</strong> — entry moved into the folder, count badge incremented, <strong>and the entry's <code>order</code> was preserved</strong> (the cross-container fix).</li>
<li>[x] <strong>Collapse the folder</strong> by clicking the header — entries inside hid, chevron rotated. Reloaded the page → folder stayed collapsed via the <code>lorebook-folder-collapsed:&lt;lorebookId&gt;</code> localStorage key.</li>
<li>[x] <strong>Disable the folder</strong> with the enable toggle — verified via the <code>/api/lorebooks/active/entries</code> endpoint that entries inside the disabled folder are correctly gated out (4 of 6 entries returned), while each entry's own <code>enabled</code> flag in <code>/api/lorebooks/:id/entries</code> remained <code>true</code>. Did <strong>not</strong> run a live chat-generation pass — the activation-gate is verified at the API layer rather than through end-to-end model output. <em>Eyes-on chat-generation pass still recommended before merge.</em></li>
<li>[x] <strong>Re-enable the folder</strong> — <code>/api/lorebooks/active/entries</code> returned all 6 entries, individual flags still untouched.</li>
<li>[x] <strong>Drag a root entry onto a folder header</strong> — manually verified by the contributor; Order is now preserved on cross-container drops.</li>
<li>[x] <strong>Drag an entry from one folder to another folder</strong> — manually verified by the contributor; both containers stay sorted by Order.</li>
<li>[x] <strong>Drag an entry from a folder back to root</strong> — manually verified by the contributor after the empty-root drop-zone fix; the amber drop zone appears with "Drop here to move out of the folder" hint when root is empty.</li>
<li>[x] <strong>Drag a folder up/down</strong> to reorder folders among siblings.</li>
<li>[x] <strong>Delete a folder</strong> that contains entries — confirmation dialog showed "The 1 entry inside will be moved back to the root level." Entry was reparented (<code>folderId: null</code>), no data loss.</li>
<li>[x] <strong>Search for an entry</strong> — folders disappeared, flat list rendered, "Folder view paused (clear search and sort by Order)" hint visible.</li>
<li>[x] <strong>Sort by "Name A→Z"</strong> — folders disappeared, entries listed alphabetically across containers; switching back to Order with empty search restored the folder block.</li>
<li>[x] <strong>Light mode AND dark mode</strong> — folder header, indentation lines, dropdowns and amber accents readable in both themes.</li>
<li>[x] <strong>Mobile viewport (~400px)</strong> — CSS class parity confirmed (folder row uses the same <code>group flex … gap-2</code> and <code>max-md:opacity-100</code> pattern as the entry row that already passes mobile review), but could have a cleaner look. Made a change so that it would wrap on overflow, instead of pushing Add Entry off to the side.</li>
<li>[x] <strong>Empty folder</strong> — body shows the "Empty — drag an entry here or pick this folder from an entry's folder selector." hint.</li>
<li>[x] <strong>Empty lorebook</strong> (no entries, no folders) — existing "No entries yet — add one to get started" empty state appears unchanged.</li>
<li>[x] <strong>Export a lorebook with folders → import the exported file</strong> — Was able to export and import a lorebook with folders without issue.</li>
<li>[x] <strong>Imported a SillyTavern World Info file without issue.</strong></li>
<li>[ ] <strong>AI lorebook keeper / lorebook maker</strong> still creates entries successfully (they default to root). <em>Not yet verified, as I do not have an agent that automates lorebook entries and cannot test this.</em> The shared schema's <code>folderId</code> defaults to null and the storage layer accepts the field, so default behavior should be unchanged.</li>
</ul>
<h2>Screenshots</h2>
Dark Mode
<img width="2549" height="1259" alt="image" src="https://github.com/user-attachments/assets/8e0ba438-5c6b-4887-8d1e-b91ab6e7ffc6" />

Light Mode
<img width="2533" height="1201" alt="image" src="https://github.com/user-attachments/assets/ee1d7570-d436-4970-a394-fe68107c9187" />

Mobile
<img width="1262" height="1425" alt="image" src="https://github.com/user-attachments/assets/1154aa53-d59e-425b-9747-df277bfb781f" />
</body>
</html>