### PR TITLE
Expose agent token budget settings

### DIFF
--- a/packages/client/src/components/agents/AgentEditor.tsx
+++ b/packages/client/src/components/agents/AgentEditor.tsx
@@ -398,7 +398,7 @@ export function AgentEditor() {
       promptTemplate: localPrompt,
       settings: {
         ...(localContextSize !== "" ? { contextSize: Number(localContextSize) } : {}),
-        ...(localMaxTokens !== "" ? { maxTokens: Number(localMaxTokens) } : {}),
+        ...(localMaxTokens !== "" ? { maxTokens: clampAgentMaxTokens(localMaxTokens) } : {}),
         ...(localRunInterval !== "" ? { runInterval: Number(localRunInterval) } : {}),
         ...(localInjectAsSection ? { injectAsSection: true } : {}),
         enabledTools: localEnabledTools,

--- a/packages/client/src/components/agents/AgentEditor.tsx
+++ b/packages/client/src/components/agents/AgentEditor.tsx
@@ -54,8 +54,12 @@ import { HelpTooltip } from "../ui/HelpTooltip";
 import {
   BUILT_IN_AGENTS,
   BUILT_IN_TOOLS,
+  DEFAULT_AGENT_CONTEXT_SIZE,
   DEFAULT_AGENT_TOOLS,
+  DEFAULT_AGENT_MAX_TOKENS,
   LOCAL_SIDECAR_CONNECTION_ID,
+  MAX_AGENT_MAX_TOKENS,
+  MIN_AGENT_MAX_TOKENS,
   getDefaultBuiltInAgentSettings,
   getDefaultAgentPrompt,
   type AgentPhase,
@@ -110,6 +114,17 @@ const PHASE_META: Record<AgentPhase, { label: string; color: string; icon: typeo
   },
 };
 
+function normalizeAgentMaxTokensInput(value: string): number | "" {
+  if (value === "") return "";
+  const parsed = parseInt(value, 10);
+  if (!Number.isFinite(parsed)) return "";
+  return Math.max(1, Math.min(MAX_AGENT_MAX_TOKENS, parsed));
+}
+
+function clampAgentMaxTokens(value: number): number {
+  return Math.max(MIN_AGENT_MAX_TOKENS, Math.min(MAX_AGENT_MAX_TOKENS, Math.trunc(value)));
+}
+
 // ═══════════════════════════════════════════════
 //  Main Editor
 // ═══════════════════════════════════════════════
@@ -151,6 +166,7 @@ export function AgentEditor() {
   const [localConnectionId, setLocalConnectionId] = useState("");
   const [localImageConnectionId, setLocalImageConnectionId] = useState("");
   const [localContextSize, setLocalContextSize] = useState<number | "">("");
+  const [localMaxTokens, setLocalMaxTokens] = useState<number | "">("");
   const [localRunInterval, setLocalRunInterval] = useState<number | "">("");
   const [customCadenceInputFocused, setCustomCadenceInputFocused] = useState(false);
   const [localPrompt, setLocalPrompt] = useState("");
@@ -199,6 +215,7 @@ export function AgentEditor() {
           : dbConfig.settings
         : {};
       setLocalContextSize(settings.contextSize ?? "");
+      setLocalMaxTokens(settings.maxTokens ?? (defaultSettings.maxTokens as number | undefined) ?? "");
       setLocalImageConnectionId((settings.imageConnectionId as string) ?? "");
       setLocalRunInterval(
         (settings.runInterval as number | undefined) ?? (defaultSettings.runInterval as number) ?? "",
@@ -220,6 +237,7 @@ export function AgentEditor() {
       setLocalConnectionId("");
       setLocalImageConnectionId("");
       setLocalContextSize("");
+      setLocalMaxTokens((defaultSettings.maxTokens as number) ?? "");
       setLocalRunInterval((defaultSettings.runInterval as number) ?? "");
       setLocalInjectAsSection(defaultSettings.injectAsSection === true);
       setLocalEnabledTools(DEFAULT_AGENT_TOOLS[builtIn.id] ?? []);
@@ -237,6 +255,7 @@ export function AgentEditor() {
       setLocalConnectionId("");
       setLocalImageConnectionId("");
       setLocalContextSize("");
+      setLocalMaxTokens(DEFAULT_AGENT_MAX_TOKENS);
       setLocalRunInterval(customRunIntervalMeta?.defaultValue ?? "");
       setLocalInjectAsSection(false);
       setLocalEnabledTools([]);
@@ -379,6 +398,7 @@ export function AgentEditor() {
       promptTemplate: localPrompt,
       settings: {
         ...(localContextSize !== "" ? { contextSize: Number(localContextSize) } : {}),
+        ...(localMaxTokens !== "" ? { maxTokens: Number(localMaxTokens) } : {}),
         ...(localRunInterval !== "" ? { runInterval: Number(localRunInterval) } : {}),
         ...(localInjectAsSection ? { injectAsSection: true } : {}),
         enabledTools: localEnabledTools,
@@ -426,6 +446,7 @@ export function AgentEditor() {
     localImageConnectionId,
     localPrompt,
     localContextSize,
+    localMaxTokens,
     localRunInterval,
     localInjectAsSection,
     localEnabledTools,
@@ -770,35 +791,76 @@ export function AgentEditor() {
             </FieldGroup>
           )}
 
-          {/* ── Context Size (hidden for Chat Summary — that uses the popover) ── */}
-          {!isChatSummaryAgent && (
-            <FieldGroup
-              label="Context Size"
-              icon={<Clock size="0.875rem" className="text-[var(--primary)]" />}
-              help="How many recent chat messages this agent receives as context. More messages = more context but higher token usage. Leave blank for the default (5 messages)."
-            >
-              <div className="flex items-center gap-3">
-                <input
-                  type="number"
-                  min={1}
-                  max={200}
-                  value={localContextSize}
-                  onChange={(e) => {
-                    const v = e.target.value;
-                    setLocalContextSize(v === "" ? "" : Math.max(1, Math.min(200, parseInt(v) || 1)));
-                    markDirty();
-                  }}
-                  placeholder="5"
-                  className="w-28 rounded-xl bg-[var(--secondary)] px-3 py-2.5 text-sm tabular-nums ring-1 ring-[var(--border)] placeholder:text-[var(--muted-foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
-                />
-                <span className="text-[0.6875rem] text-[var(--muted-foreground)]">messages</span>
+          <FieldGroup
+            label="Agent Budget"
+            icon={<Clock size="0.875rem" className="text-[var(--primary)]" />}
+            help="Controls how much recent chat context the agent reads and how much output room it reserves. If max output is too high for the model context, prompt context can be trimmed."
+          >
+            <div className="grid gap-3 sm:grid-cols-2">
+              {!isChatSummaryAgent ? (
+                <div>
+                  <label className="mb-1 block text-[0.6875rem] font-medium text-[var(--muted-foreground)]">
+                    Context Size
+                  </label>
+                  <div className="flex items-center gap-3">
+                    <input
+                      type="number"
+                      min={1}
+                      max={200}
+                      value={localContextSize}
+                      onChange={(e) => {
+                        const v = e.target.value;
+                        setLocalContextSize(v === "" ? "" : Math.max(1, Math.min(200, parseInt(v) || 1)));
+                        markDirty();
+                      }}
+                      placeholder={String(DEFAULT_AGENT_CONTEXT_SIZE)}
+                      className="w-28 rounded-xl bg-[var(--secondary)] px-3 py-2.5 text-sm tabular-nums ring-1 ring-[var(--border)] placeholder:text-[var(--muted-foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+                    />
+                    <span className="text-[0.6875rem] text-[var(--muted-foreground)]">messages</span>
+                  </div>
+                </div>
+              ) : (
+                <div className="rounded-xl bg-[var(--accent)]/50 px-3 py-2.5 text-[0.6875rem] text-[var(--muted-foreground)] ring-1 ring-[var(--border)]">
+                  Chat Summary context size is managed in the Chat Summary panel inside each chat.
+                </div>
+              )}
+              <div>
+                <label className="mb-1 block text-[0.6875rem] font-medium text-[var(--muted-foreground)]">
+                  Max Output Tokens
+                </label>
+                <div className="flex items-center gap-3">
+                    <input
+                      type="number"
+                      min={MIN_AGENT_MAX_TOKENS}
+                      max={MAX_AGENT_MAX_TOKENS}
+                      value={localMaxTokens}
+                    onChange={(e) => {
+                        setLocalMaxTokens(normalizeAgentMaxTokensInput(e.target.value));
+                        markDirty();
+                      }}
+                      onBlur={() => {
+                        if (localMaxTokens !== "") {
+                          setLocalMaxTokens(clampAgentMaxTokens(localMaxTokens));
+                        }
+                      }}
+                      placeholder={String(DEFAULT_AGENT_MAX_TOKENS)}
+                      className="w-32 rounded-xl bg-[var(--secondary)] px-3 py-2.5 text-sm tabular-nums ring-1 ring-[var(--border)] placeholder:text-[var(--muted-foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+                    />
+                  <span className="text-[0.6875rem] text-[var(--muted-foreground)]">tokens</span>
+                </div>
               </div>
+            </div>
+            {!isChatSummaryAgent && (
               <p className="mt-1 text-[0.625rem] text-[var(--muted-foreground)]">
                 Each agent only sees its own context size. When agents are batched together (same model), the highest
-                context size in the batch is used.
+                context size in the batch is used and output budgets are combined.
               </p>
-            </FieldGroup>
-          )}
+            )}
+            <p className="mt-1 text-[0.625rem] text-[var(--muted-foreground)]">
+              For 8k local models, try {DEFAULT_AGENT_MAX_TOKENS.toLocaleString()} or lower so the agent prompt keeps
+              enough room.
+            </p>
+          </FieldGroup>
 
           {/* ── Triggers After (Chat Summary agent) ── */}
           {(isCustomAgent || isNewCustomAgent) && customRunIntervalMeta && (

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -759,12 +759,13 @@ export function ChatSettingsDrawer({
     if (!agentAddPreview) return;
 
     const { agent, config, contextSize, maxTokens, runInterval } = agentAddPreview;
+    const normalizedMaxTokens = normalizeAgentMaxTokens(maxTokens);
     const builtInMeta = BUILT_IN_AGENTS.find((entry) => entry.id === agent.id) ?? null;
     const nextSettings: Record<string, unknown> = {
       ...getDefaultBuiltInAgentSettings(agent.id),
       ...parseAgentSettings(config?.settings),
       contextSize,
-      maxTokens,
+      maxTokens: normalizedMaxTokens,
     };
     const intervalMeta = getAgentRunIntervalMeta(agent.id, !!builtInMeta);
     if (intervalMeta && runInterval != null) {

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -115,7 +115,11 @@ import { useAgentStore } from "../../stores/agent.store";
 import {
   BUILT_IN_AGENTS,
   BUILT_IN_TOOLS,
+  DEFAULT_AGENT_CONTEXT_SIZE,
   DEFAULT_AGENT_TOOLS,
+  DEFAULT_AGENT_MAX_TOKENS,
+  MAX_AGENT_MAX_TOKENS,
+  MIN_AGENT_MAX_TOKENS,
   getDefaultBuiltInAgentSettings,
 } from "@marinara-engine/shared";
 import type { Chat, CharacterGroup } from "@marinara-engine/shared";
@@ -154,6 +158,7 @@ type AgentAddPreview = {
   agent: AvailableAgent;
   config: AgentConfigRow | null;
   contextSize: number;
+  maxTokens: number;
   runInterval: number | null;
 };
 
@@ -173,6 +178,16 @@ function parseAgentSettings(raw: unknown): Record<string, unknown> {
 function normalizePositiveInteger(value: unknown, fallback: number, max: number): number {
   if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
   return Math.max(1, Math.min(max, Math.trunc(value)));
+}
+
+function normalizeAgentMaxTokens(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return DEFAULT_AGENT_MAX_TOKENS;
+  return Math.max(MIN_AGENT_MAX_TOKENS, Math.min(MAX_AGENT_MAX_TOKENS, Math.trunc(value)));
+}
+
+function normalizeAgentMaxTokensInputValue(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return 1;
+  return Math.max(1, Math.min(MAX_AGENT_MAX_TOKENS, Math.trunc(value)));
 }
 
 function isEnabledFlag(value: unknown): boolean {
@@ -732,7 +747,8 @@ export function ChatSettingsDrawer({
     setAgentAddPreview({
       agent,
       config,
-      contextSize: normalizePositiveInteger(mergedSettings.contextSize, 5, 200),
+      contextSize: normalizePositiveInteger(mergedSettings.contextSize, DEFAULT_AGENT_CONTEXT_SIZE, 200),
+      maxTokens: normalizeAgentMaxTokens(mergedSettings.maxTokens),
       runInterval: intervalMeta
         ? normalizePositiveInteger(mergedSettings.runInterval, intervalMeta.defaultValue, intervalMeta.max)
         : null,
@@ -742,12 +758,13 @@ export function ChatSettingsDrawer({
   const confirmAddAgent = async () => {
     if (!agentAddPreview) return;
 
-    const { agent, config, contextSize, runInterval } = agentAddPreview;
+    const { agent, config, contextSize, maxTokens, runInterval } = agentAddPreview;
     const builtInMeta = BUILT_IN_AGENTS.find((entry) => entry.id === agent.id) ?? null;
     const nextSettings: Record<string, unknown> = {
       ...getDefaultBuiltInAgentSettings(agent.id),
       ...parseAgentSettings(config?.settings),
       contextSize,
+      maxTokens,
     };
     const intervalMeta = getAgentRunIntervalMeta(agent.id, !!builtInMeta);
     if (intervalMeta && runInterval != null) {
@@ -3927,40 +3944,84 @@ export function ChatSettingsDrawer({
               </div>
             </div>
 
-            {agentAddPreview.agent.id !== "chat-summary" ? (
-              <div className="space-y-1.5">
-                <label className="block text-[0.6875rem] font-semibold text-[var(--foreground)]">Context Size</label>
-                <div className="flex items-center gap-3">
-                  <input
-                    type="number"
-                    min={1}
-                    max={200}
-                    value={agentAddPreview.contextSize}
-                    onChange={(e) => {
-                      const value = parseInt(e.target.value, 10);
-                      setAgentAddPreview((current) =>
-                        current
-                          ? {
-                              ...current,
-                              contextSize: Number.isFinite(value) ? Math.max(1, Math.min(200, value)) : 5,
-                            }
-                          : current,
-                      );
-                    }}
-                    disabled={addingAgentToChat}
-                    className="w-28 rounded-xl bg-[var(--secondary)] px-3 py-2.5 text-sm tabular-nums ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)] disabled:cursor-not-allowed disabled:opacity-60"
-                  />
-                  <span className="text-[0.6875rem] text-[var(--muted-foreground)]">messages</span>
+            <div className="space-y-1.5">
+              <label className="block text-[0.6875rem] font-semibold text-[var(--foreground)]">Agent Budget</label>
+              <div className="grid gap-3 sm:grid-cols-2">
+                {agentAddPreview.agent.id !== "chat-summary" ? (
+                  <div>
+                    <label className="mb-1 block text-[0.625rem] font-medium text-[var(--muted-foreground)]">
+                      Context Size
+                    </label>
+                    <div className="flex items-center gap-3">
+                      <input
+                        type="number"
+                        min={1}
+                        max={200}
+                        value={agentAddPreview.contextSize}
+                        onChange={(e) => {
+                          const value = parseInt(e.target.value, 10);
+                          setAgentAddPreview((current) =>
+                            current
+                              ? {
+                                  ...current,
+                                  contextSize: Number.isFinite(value)
+                                    ? Math.max(1, Math.min(200, value))
+                                    : DEFAULT_AGENT_CONTEXT_SIZE,
+                                }
+                              : current,
+                          );
+                        }}
+                        disabled={addingAgentToChat}
+                        className="w-28 rounded-xl bg-[var(--secondary)] px-3 py-2.5 text-sm tabular-nums ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)] disabled:cursor-not-allowed disabled:opacity-60"
+                      />
+                      <span className="text-[0.6875rem] text-[var(--muted-foreground)]">messages</span>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="rounded-xl bg-[var(--accent)]/50 px-3 py-2.5 text-[0.6875rem] text-[var(--muted-foreground)] ring-1 ring-[var(--border)]">
+                    Chat Summary context size is managed in the Chat Summary panel after you add the agent.
+                  </div>
+                )}
+                <div>
+                  <label className="mb-1 block text-[0.625rem] font-medium text-[var(--muted-foreground)]">
+                    Max Output Tokens
+                  </label>
+                  <div className="flex items-center gap-3">
+                    <input
+                      type="number"
+                      min={MIN_AGENT_MAX_TOKENS}
+                      max={MAX_AGENT_MAX_TOKENS}
+                      value={agentAddPreview.maxTokens}
+                      onChange={(e) => {
+                        const value = parseInt(e.target.value, 10);
+                        setAgentAddPreview((current) =>
+                          current
+                            ? {
+                                ...current,
+                                maxTokens: normalizeAgentMaxTokensInputValue(
+                                  Number.isFinite(value) ? value : undefined,
+                                ),
+                              }
+                            : current,
+                        );
+                      }}
+                      onBlur={() => {
+                        setAgentAddPreview((current) =>
+                          current ? { ...current, maxTokens: normalizeAgentMaxTokens(current.maxTokens) } : current,
+                        );
+                      }}
+                      disabled={addingAgentToChat}
+                      className="w-32 rounded-xl bg-[var(--secondary)] px-3 py-2.5 text-sm tabular-nums ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)] disabled:cursor-not-allowed disabled:opacity-60"
+                    />
+                    <span className="text-[0.6875rem] text-[var(--muted-foreground)]">tokens</span>
+                  </div>
                 </div>
-                <p className="text-[0.625rem] text-[var(--muted-foreground)]">
-                  How many recent chat messages this agent should receive as working context.
-                </p>
               </div>
-            ) : (
-              <div className="rounded-xl bg-[var(--accent)]/50 px-3 py-2.5 text-[0.6875rem] text-[var(--muted-foreground)] ring-1 ring-[var(--border)]">
-                Context size for automated summaries is managed in the Chat Summary panel after you add the agent.
-              </div>
-            )}
+              <p className="text-[0.625rem] text-[var(--muted-foreground)]">
+                Context size controls recent chat messages. Max output reserves completion room; lower it on small local
+                contexts if logs show the prompt budget collapsing.
+              </p>
+            </div>
 
             {agentAddIntervalMeta && agentAddPreview.runInterval != null && (
               <div className="space-y-1.5">

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -3,6 +3,7 @@ import { logger } from "../../lib/logger.js";
 import {
   BUILT_IN_AGENTS,
   LOCAL_SIDECAR_CONNECTION_ID,
+  getDefaultBuiltInAgentSettings,
   type AgentContext,
   type AgentResult,
 } from "@marinara-engine/shared";
@@ -402,7 +403,7 @@ async function resolveRetryAgents(args: {
         phase: builtIn.phase,
         promptTemplate: "",
         connectionId: null,
-        settings: {},
+        settings: getDefaultBuiltInAgentSettings(builtIn.id),
         provider,
         model: conn.model,
       },

--- a/packages/server/src/services/agents/agent-executor.ts
+++ b/packages/server/src/services/agents/agent-executor.ts
@@ -340,13 +340,16 @@ export async function executeAgentBatch(
 
     // Each agent reserves its own configured output budget. The context fitter
     // may still reduce this further if the prompt needs more room.
-    const maxTokensPerAgent = Math.max(...configs.map((c) => normalizeAgentMaxTokens(c.settings.maxTokens)));
+    const perAgentTokens = configs.map((c) => normalizeAgentMaxTokens(c.settings.maxTokens));
     const temperature = Math.min(...configs.map((c) => (c.settings.temperature as number) ?? 0.3));
-    const rawBatchMaxTokens = Math.min(maxTokensPerAgent * configs.length, MAX_AGENT_MAX_TOKENS);
+    const rawBatchMaxTokens = Math.min(
+      perAgentTokens.reduce((sum, tokens) => sum + tokens, 0),
+      MAX_AGENT_MAX_TOKENS,
+    );
     const batchMaxTokens = applyProviderMaxTokensOverride(provider, rawBatchMaxTokens);
     const streamResponses = context.streaming !== false;
     logger.info(
-      `[agent-batch] maxTokens: ${batchMaxTokens} (${maxTokensPerAgent} × ${configs.length} agents${provider.maxTokensOverrideValue !== null ? `, capped at ${provider.maxTokensOverrideValue}` : ""})`,
+      `[agent-batch] maxTokens: ${batchMaxTokens} (sum=${rawBatchMaxTokens} from [${perAgentTokens.join(", ")}]${provider.maxTokensOverrideValue !== null ? `, capped at ${provider.maxTokensOverrideValue}` : ""})`,
     );
 
     logger.debug(`\n[agent-batch] ═══ BATCH PROMPT — [${configs.map((c) => c.type).join(", ")}] — ${model} ═══`);

--- a/packages/server/src/services/agents/agent-executor.ts
+++ b/packages/server/src/services/agents/agent-executor.ts
@@ -3,7 +3,13 @@
 // ──────────────────────────────────────────────
 import type { BaseLLMProvider, ChatMessage, LLMToolDefinition, LLMToolCall } from "../llm/base-provider.js";
 import type { AgentResult, AgentContext, AgentResultType } from "@marinara-engine/shared";
-import { getDefaultAgentPrompt } from "@marinara-engine/shared";
+import {
+  DEFAULT_AGENT_CONTEXT_SIZE,
+  DEFAULT_AGENT_MAX_TOKENS,
+  MAX_AGENT_MAX_TOKENS,
+  MIN_AGENT_MAX_TOKENS,
+  getDefaultAgentPrompt,
+} from "@marinara-engine/shared";
 import { isDebugAgentsEnabled } from "../../config/runtime-config.js";
 import { logger } from "../../lib/logger.js";
 
@@ -73,6 +79,15 @@ function formatToolPayloadForLog(payload: string, maxLength = 400): string {
   }
 }
 
+function normalizeAgentMaxTokens(value: unknown, fallback = DEFAULT_AGENT_MAX_TOKENS): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
+  return Math.max(MIN_AGENT_MAX_TOKENS, Math.min(MAX_AGENT_MAX_TOKENS, Math.trunc(value)));
+}
+
+function applyProviderMaxTokensOverride(provider: BaseLLMProvider, maxTokens: number): number {
+  return provider.maxTokensOverrideValue !== null ? Math.min(maxTokens, provider.maxTokensOverrideValue) : maxTokens;
+}
+
 /**
  * Execute a single agent: build prompt → call LLM → parse response.
  * If toolContext is provided, the agent can make tool calls in a loop.
@@ -111,14 +126,12 @@ export async function executeAgent(
     }
 
     // Build multi-turn message array for this agent (sliced to its own contextSize)
-    const agentContextSize = (config.settings.contextSize as number) || 5;
+    const agentContextSize = (config.settings.contextSize as number) || DEFAULT_AGENT_CONTEXT_SIZE;
     const messages = buildAgentMessages(systemParts.join("\n"), context, config.type, agentContextSize);
 
     // Agents use lower temperature for reliability
     const temperature = (config.settings.temperature as number) ?? 0.3;
-    const rawMaxTokens = Math.max((config.settings.maxTokens as number) ?? 4096, 16384);
-    const maxTokens =
-      provider.maxTokensOverrideValue !== null ? Math.min(rawMaxTokens, provider.maxTokensOverrideValue) : rawMaxTokens;
+    const maxTokens = applyProviderMaxTokensOverride(provider, normalizeAgentMaxTokens(config.settings.maxTokens));
     const streamResponses = context.streaming !== false;
 
     // If tools are available, use the tool call loop
@@ -320,22 +333,20 @@ export async function executeAgentBatch(
     // Build merged system prompt (includes lore + agent extras)
     const systemPrompt = buildBatchSystemPrompt(configs, context);
     // Batch uses the max contextSize among its members
-    const batchContextSize = Math.max(...configs.map((c) => (c.settings.contextSize as number) || 5));
+    const batchContextSize = Math.max(
+      ...configs.map((c) => (c.settings.contextSize as number) || DEFAULT_AGENT_CONTEXT_SIZE),
+    );
     const messages = buildAgentMessages(systemPrompt, context, "__batch__", batchContextSize);
 
-    // Each agent needs enough room for its full JSON output.
-    // Use a generous floor (16384) so the model never runs out mid-response.
-    // Cap to the connection-level maxTokensOverride when set.
-    const maxTokensPerAgent = Math.max(...configs.map((c) => (c.settings.maxTokens as number) ?? 4096));
+    // Each agent reserves its own configured output budget. The context fitter
+    // may still reduce this further if the prompt needs more room.
+    const maxTokensPerAgent = Math.max(...configs.map((c) => normalizeAgentMaxTokens(c.settings.maxTokens)));
     const temperature = Math.min(...configs.map((c) => (c.settings.temperature as number) ?? 0.3));
-    const rawBatchMaxTokens = Math.max(maxTokensPerAgent * configs.length, 16384);
-    const batchMaxTokens =
-      provider.maxTokensOverrideValue !== null
-        ? Math.min(rawBatchMaxTokens, provider.maxTokensOverrideValue)
-        : rawBatchMaxTokens;
+    const rawBatchMaxTokens = Math.min(maxTokensPerAgent * configs.length, MAX_AGENT_MAX_TOKENS);
+    const batchMaxTokens = applyProviderMaxTokensOverride(provider, rawBatchMaxTokens);
     const streamResponses = context.streaming !== false;
     logger.info(
-      `[agent-batch] maxTokens: ${batchMaxTokens} (${maxTokensPerAgent} × ${configs.length} agents, floor 16384${provider.maxTokensOverrideValue !== null ? `, capped at ${provider.maxTokensOverrideValue}` : ""})`,
+      `[agent-batch] maxTokens: ${batchMaxTokens} (${maxTokensPerAgent} × ${configs.length} agents${provider.maxTokensOverrideValue !== null ? `, capped at ${provider.maxTokensOverrideValue}` : ""})`,
     );
 
     logger.debug(`\n[agent-batch] ═══ BATCH PROMPT — [${configs.map((c) => c.type).join(", ")}] — ${model} ═══`);

--- a/packages/server/src/services/llm/base-provider.ts
+++ b/packages/server/src/services/llm/base-provider.ts
@@ -142,6 +142,7 @@ const CONTEXT_SAFETY_MARGIN_TOKENS = 64;
 const CONTEXT_SAFETY_MARGIN_RATIO = 0.02;
 const MIN_INPUT_BUDGET_TOKENS = 128;
 const MIN_OUTPUT_BUDGET_TOKENS = 128;
+const OUTPUT_BUDGET_REDUCTION_HEADROOM_TOKENS = 64;
 const MIN_CONTENT_CHARS = 48;
 const TRUNCATION_MARKER = "\n\n[Truncated to fit context window]";
 
@@ -317,6 +318,17 @@ export function fitMessagesToContext(
       ? undefined
       : Math.max(1, Math.min(requestedMaxTokens, Math.max(1, usableWindow - reservedInputFloor)));
   let inputBudget = Math.max(0, usableWindow - (maxTokens ?? 0));
+
+  if (estimatedTokensBefore > inputBudget && maxTokens !== undefined) {
+    const minimumOutputBudget = Math.min(MIN_OUTPUT_BUDGET_TOKENS, Math.max(1, usableWindow - 1));
+    const headroom = Math.min(OUTPUT_BUDGET_REDUCTION_HEADROOM_TOKENS, Math.max(0, usableWindow - 1));
+    const maxTokensThatFitPrompt = Math.max(1, usableWindow - estimatedTokensBefore - headroom);
+    const reducedMaxTokens = Math.max(minimumOutputBudget, Math.min(maxTokens, maxTokensThatFitPrompt));
+    if (reducedMaxTokens < maxTokens) {
+      maxTokens = reducedMaxTokens;
+      inputBudget = Math.max(0, usableWindow - maxTokens);
+    }
+  }
 
   if (estimatedTokensBefore <= inputBudget) {
     return {

--- a/packages/server/test/context-fit.test.ts
+++ b/packages/server/test/context-fit.test.ts
@@ -43,3 +43,22 @@ test("context fitting reduces completion budget before truncating protected prom
   assert.ok((fit.maxTokens ?? 0) < 500);
   assert.ok((fit.estimatedTokensAfter ?? 0) <= (fit.inputBudget ?? 0));
 });
+
+test("context fitting preserves agent context by reducing oversized local output budget first", () => {
+  const prompt = repeated("agent prompt", 1000);
+  const messages: ChatMessage[] = [
+    { role: "system", content: prompt },
+    { role: "user", content: repeated("agent history user", 4000), contextKind: "history" },
+    { role: "assistant", content: repeated("agent history assistant", 4000), contextKind: "history" },
+    { role: "user", content: repeated("current turn", 2000), contextKind: "history" },
+  ];
+
+  const fit = fitMessagesToContext(messages, { maxContext: 8192, maxTokens: 8192 });
+
+  assert.equal(fit.trimmed, false);
+  assert.equal(fit.messages.length, messages.length);
+  assert.equal(fit.estimatedTokensAfter, fit.estimatedTokensBefore);
+  assert.ok((fit.inputBudget ?? 0) > 128);
+  assert.ok((fit.maxTokens ?? 0) < 8192);
+  assert.ok((fit.estimatedTokensAfter ?? 0) <= (fit.inputBudget ?? 0));
+});

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -481,9 +481,16 @@ export const BUILT_IN_AGENT_RUN_INTERVAL_DEFAULTS: Readonly<Record<string, numbe
   "chat-summary": 5,
 };
 
+export const DEFAULT_AGENT_CONTEXT_SIZE = 5;
+export const DEFAULT_AGENT_MAX_TOKENS = 4096;
+export const MIN_AGENT_MAX_TOKENS = 128;
+export const MAX_AGENT_MAX_TOKENS = 32768;
+
 export function getDefaultBuiltInAgentSettings(agentType: string): Record<string, unknown> {
   const builtIn = BUILT_IN_AGENTS.find((agent) => agent.id === agentType);
-  const settings: Record<string, unknown> = {};
+  const settings: Record<string, unknown> = {
+    maxTokens: DEFAULT_AGENT_MAX_TOKENS,
+  };
 
   if (builtIn?.defaultInjectAsSection) {
     settings.injectAsSection = true;


### PR DESCRIPTION
## Summary
- Adds an Agent Budget section to the Agent Editor and Add Agent modal with a visible Max Output Tokens setting alongside context size.
- Replaces the hidden 16k agent output floor with the configured per-agent budget, while still respecting connection-level max token overrides.
- Updates context fitting to reduce oversized completion budgets before trimming otherwise-fitting agent prompts, preventing logs like `budget ~128, maxContext=8192` from dropping agent context unnecessarily.

## Testing
- `pnpm --filter @marinara-engine/server test`
- `pnpm --filter @marinara-engine/client build`
- `pnpm --filter @marinara-engine/shared build`
- `pnpm --filter @marinara-engine/server build`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-agent "Max Output Tokens" setting and an "Agent Budget" section in the editor and add-agent UI.

* **Improvements**
  * Numeric inputs normalized/clamped to safe bounds; provider overrides applied when computing budgets.
  * Default context sizing applied and batch budget aggregation refined.
  * Built-in agents now initialize with sensible max-token defaults.

* **Tests**
  * Added a test ensuring output budget is reduced before trimming messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->