### PR TITLE
fix(game): instruct GM to use plain quotes in [choices:] options

### DIFF
--- a/packages/client/src/components/game/GameChoiceCards.tsx
+++ b/packages/client/src/components/game/GameChoiceCards.tsx
@@ -83,23 +83,3 @@ export function GameChoiceCards({ choices, onSelect, disabled }: GameChoiceCards
     </div>
   );
 }
-
-// ── Tag Parser ──
-
-/** Parse [choices: "A" | "B" | "C"] from narration content. */
-export function parseChoiceTag(content: string): { choices: string[]; cleanContent: string } | null {
-  const regex = /\[choices:\s*(.+?)\]/i;
-  const match = content.match(regex);
-  if (!match) return null;
-
-  const raw = match[1]!;
-  const choices = raw
-    .split("|")
-    .map((c) => c.trim().replace(/^["']|["']$/g, ""))
-    .filter((c) => c.length > 0);
-
-  if (choices.length === 0) return null;
-
-  const cleanContent = content.replace(regex, "").trim();
-  return { choices, cleanContent };
-}

--- a/packages/server/src/services/game/gm-prompts.ts
+++ b/packages/server/src/services/game/gm-prompts.ts
@@ -553,7 +553,7 @@ export function buildGmFormatReminder(
     ``,
     `COMMANDS:`,
     `- Emit commands when canonical game or UI state changes; no command is needed for flavor alone.`,
-    `- [choices: "Option A" | "Option B" | "Option C"] - only for explicit player-facing options that require a selection.`,
+    `- [choices: "Option A" | "Option B" | "Option C"] - only for explicit player-facing options that require a selection. Use plain straight quotes around each option (do not escape inner quotes with backslashes).`,
   );
 
   if (ctx.playerDiceRollSubmitted) {


### PR DESCRIPTION
## Summary

Tighten the `[choices:]` format guidance in the GM prompt so models don't emit
JSON-style escaped quotes inside choice values. Also remove a dead duplicate
of the choice parser that was sitting unused in `GameChoiceCards.tsx`.

## Why

Some models ([reported on GLM](https://discord.com/channels/1417099416812392641/1500526584870866985)) emit `[choices: "\"Suzuki, wait—\"" | ... ]`
with backslash-escaped inner quotes. The live parser in
`packages/client/src/lib/game-tag-parser.ts` strips one outer quote per option
but doesn't unescape `\"`, so the literal backslashes survive into the choice
strings and get rendered on the **CHOOSE YOUR ACTION** card via
`AnimatedText` / `dangerouslySetInnerHTML`. End-state: users see
`\"Suzuki, wait—\"` on screen. Discord mirror happens to look clean because
Discord's markdown swallows `\"`, but the underlying bytes are the same.

The simplest, root-cause fix is the prompt: explicitly tell the GM to use
plain straight quotes around each option and not to escape inner quotes with
backslashes. This solves it for any model that follows instructions, without
adding a defensive-parsing maintenance surface.

The dead `parseChoiceTag` function in `GameChoiceCards.tsx` had zero imports
across the codebase — the real parser is `parseGmTags` in
`lib/game-tag-parser.ts`. Removing it now to prevent drift.

## Changes

- `packages/server/src/services/game/gm-prompts.ts` — append plain-quote /
  no-escape guidance to the `[choices:]` line in the format reminder
  (~10 words added).
- `packages/client/src/components/game/GameChoiceCards.tsx` — delete unused
  `parseChoiceTag` export (and its `// ── Tag Parser ──` divider).

## Known limitations

- Tested for **regression** on Gemini in the dual-install setup — choices
  still emit and render cleanly. Not yet verified end-to-end on GLM (the
  model that exhibited the original bug). Original reporter to confirm
  on their setup post-merge — happy to follow up with parser-side hardening
  if GLM still escapes despite the prompt change.
- The prompt fix only helps models that respect instructions. A future PR
  could add a small unescape pass in the parser as defense-in-depth, but
  that's deferred until we see a second model report this.

## Test plan

Reviewer / merger: please verify rather than checking these blindly.

- [x] Manually verify choice cards render with plain quotes on a flagship
      model in GM mode (Claude / GPT-4 class / Gemini).
- [x] Manually verify choices still emit at all (no regression — model
      isn't confused by the tighter wording).
- [x] `pnpm check` passes.

## Screenshots

<img width="516" height="182" alt="image" src="https://github.com/user-attachments/assets/66c19a57-e3b1-42ef-9816-df35e25ebdf5" />

<img width="391" height="325" alt="image" src="https://github.com/user-attachments/assets/644fd42a-bf2c-4aec-bcaf-72d97f6280bf" />


## Docs touched

None. No user-facing config or behavior change documented anywhere.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an internal utility function from the game component; existing functionality unchanged.

* **Documentation**
  * Updated choice formatting guidance in game master prompts for clearer quote handling instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->