### PR TITLE
fix(generate): execute character commands when response has no prose

### DIFF
--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -1164,6 +1164,9 @@ export function useGenerate() {
               } else if (actionData.action === "chat_created") {
                 toast(`Started ${actionData.mode} chat with ${actionData.characterName}`, { icon: "💬" });
                 qc.invalidateQueries({ queryKey: ["chats"] });
+              } else if (actionData.action === "data_fetched") {
+                const fetchType = (actionData.fetchType as string) ?? "data";
+                toast(`Fetched ${fetchType}: ${actionData.name}`, { icon: "📋" });
               } else if (actionData.action === "navigate") {
                 const panel = actionData.panel as string;
                 const tab = actionData.tab as string | null;

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -5512,8 +5512,19 @@ export async function generateRoutes(app: FastifyInstance) {
             reply.raw.write(`data: ${JSON.stringify({ type: "content_replace", data: fullResponse })}\n\n`);
           }
 
-          // Guard: don't save empty responses — the model returned nothing useful
+          // Guard: don't save empty responses — the model returned nothing useful.
+          // Exception: if the model emitted character commands (e.g. [fetch:...]) with
+          // no surrounding prose, treat the commands as the useful output. Skip saving
+          // a blank assistant bubble but still return the commands so they execute.
           if (!fullResponse.trim() && !input.impersonate) {
+            if (parsedCommands.length > 0) {
+              logger.info(
+                "[generate] Model emitted %d command(s) with no visible prose for chat %s; executing commands without saving a message",
+                parsedCommands.length,
+                input.chatId,
+              );
+              return { savedMsg: null, response: "", commands: parsedCommands, oocMessages, characterId: targetCharId };
+            }
             logger.warn(`[generate] Empty response from model for chat ${input.chatId} (char: ${targetCharId})`);
             reply.raw.write(
               `data: ${JSON.stringify({ type: "error", data: "The AI returned an empty response. Try sending your message again." })}\n\n`,


### PR DESCRIPTION
### Summary
When Professor Mari emits a bare character command (e.g. `[fetch:type="character" name="Becky"]`) with no surrounding prose, the empty-response guard short-circuits with `"The AI returned an empty response"` and the parsed command never reaches the executor. The fetch silently drops; the user just sees an error toast.

This was reproducible by asking Mari to fetch a character to copy from — see attached server log:
```
[generate] Parsed 1 character command(s): [ 'fetch' ]
[generate] Empty response from model for chat E869EWqcUBxWYqzUTNA34 (char: professor_mari)
```

### Why
Bare command directives are valid output for Mari — they're tool calls. The "empty response" detector was conflating "model wrote nothing useful" with "model wrote nothing visible." Commands aren't visible but they're useful.

### Changes
- [[packages/server/src/routes/generate.routes.ts](https://claude.ai/epitaxy/packages/server/src/routes/generate.routes.ts)](packages/server/src/routes/generate.routes.ts): if `parsedCommands.length > 0`, skip the error path and return the commands so they execute. Don't save a blank assistant bubble. The truly-empty case (no prose AND no commands) still surfaces the same error.
- [[packages/client/src/hooks/use-generate.ts](https://claude.ai/epitaxy/packages/client/src/hooks/use-generate.ts)](packages/client/src/hooks/use-generate.ts): add a toast for the previously-silent `data_fetched` action (matches the existing toasts for `character_created` / `persona_created` / etc.).

### Test plan
- [x] Manually verify in browser: ask Mari to fetch a character, then ask her to fetch the same one again in a way that triggers a bare command response — the fetch executes and a `Fetched character: <name>` toast appears (instead of the empty-response error).
- [x] Manually verify the toast also appears on a normal fetch where Mari includes prose (regression check).


<img width="380" height="537" alt="image" src="https://github.com/user-attachments/assets/fc429816-21f4-4ab4-809b-800eb2975665" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added user notifications indicating the type of data that has been fetched.

* **Bug Fixes**
  * Enhanced handling of empty responses in conversation mode to allow commands to execute successfully when command data is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->