### PR TITLE
docs: clarify connected DM/roleplay context-flow asymmetry

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -67,3 +67,24 @@ Marinara Engine supports a wide range of LLM and image generation providers:
 You can configure multiple connections at once and assign different providers per chat. API keys are encrypted at rest with AES-256.
 
 </details>
+
+---
+
+<a id="why-doesnt-my-roleplay-character-remember-the-messages-from-our-connected-conversation"></a>
+
+<details>
+<summary><strong>Why doesn't my roleplay character remember the messages from our connected conversation?</strong></summary>
+<br>
+
+Connected chats (the link between a conversation and a roleplay or game) are intentionally **asymmetric** in how context flows:
+
+**Roleplay → Conversation (automatic):** the roleplay's summary and recent messages are pulled into the conversation's context every turn, so DM characters always know what's happening in the story. Roleplay characters can also break the fourth wall back into the DM by wrapping text in `<ooc>...</ooc>` tags.
+
+**Conversation → Roleplay (manual, via tags):** the conversation's raw messages are *not* injected into the roleplay. To bridge content the other direction, the conversation character uses one of two OOC tags:
+
+- `<influence>...</influence>` — one-shot steer for the *next* roleplay turn, then consumed.
+- `<note>...</note>` — durable; appears on every roleplay turn until you clear it from the chat settings drawer. Use this for facts the roleplay character should keep remembering.
+
+This is by design — pulling raw DM messages into every roleplay turn would inflate the prompt and dilute the story. If you want something from the DM to stick in the roleplay, ask the conversation character to wrap it in a `<note>`.
+
+</details>

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -2391,7 +2391,7 @@ export function ChatSettingsDrawer({
             <Section
               label="Connected Chat"
               icon={<ArrowRightLeft size="0.875rem" />}
-              help="Link this conversation to a roleplay or game chat. OOC context flows between them — conversation characters can influence the linked chat, and linked events can flow back into the conversation."
+              help="Link this conversation to a roleplay or game. Recent messages from the linked chat are pulled into context here automatically. To send something the other direction, the character uses `<influence>` (steers the next linked turn, one-shot) or `<note>` (persists on every future linked turn until cleared)."
             >
               {chat.connectedChatId ? (
                 (() => {
@@ -2463,7 +2463,7 @@ export function ChatSettingsDrawer({
             <Section
               label="Connected Conversation"
               icon={<ArrowRightLeft size="0.875rem" />}
-              help="This chat is linked to a conversation. OOC influences from that chat will be injected into context, and game events or roleplay moments can flow back."
+              help="Linked to a conversation. `<influence>` tags from the conversation steer the next turn here (one-shot, then consumed). `<note>` tags persist on every turn until cleared. Raw conversation messages are not injected — use `<note>` for facts this chat should keep remembering."
             >
               {(() => {
                 const linked = (allChats ?? []).find((c: Chat) => c.id === chat.connectedChatId);
@@ -2495,7 +2495,7 @@ export function ChatSettingsDrawer({
             <Section
               label="Connected Conversation"
               icon={<ArrowRightLeft size="0.875rem" />}
-              help="Link this game to an OOC conversation. Game events can flow to the conversation and player discussions can influence the game."
+              help="Link this game to an OOC conversation. The conversation character uses `<influence>` (one-shot) or `<note>` (durable) to bridge content into the game; raw conversation messages are not injected. Game events and roleplay moments flow back into the conversation automatically."
             >
               {!showConnectionPicker ? (
                 <button


### PR DESCRIPTION
## Summary

Reword the three "Connected Chat" / "Connected Conversation" help tooltips and add a matching FAQ entry that explain the **asymmetric** context flow between linked DM and roleplay/game chats.

## Why

[A user reported](https://discord.com/channels/1417099416812392641/1498122845879009372) that their roleplay character "only sometimes remembered" the messages from a linked DM conversation. Reading the tooltip copy ("OOC context flows between them — conversation characters can influence the linked chat, and linked events can flow back into the conversation"), they reasonably assumed the connection was symmetric.

In practice the link is intentionally asymmetric:

- **Roleplay → DM (automatic):** the roleplay's summary + last 20 messages are pulled into every DM turn (via `<connected_roleplay>`).
- **DM → Roleplay (manual):** the DM's raw messages are *not* injected. Content bridges only via `<influence>` tags (one-shot, then consumed) or `<note>` tags (durable, persists every turn).

Maintainer (Mari) confirmed the asymmetry is deliberate, so the fix is documentation, not code.

## Changes

- `packages/client/src/components/chat/ChatSettingsDrawer.tsx` — reword the three help-tooltip strings on the **Connected Chat** (DM-side), **Connected Conversation** (RP/game-side, already linked), and **Connect to Conversation** (game-side, no link yet) sections to spell out the asymmetry and name the `<influence>` / `<note>` tags.
- `docs/FAQ.md` — new entry: *"Why doesn't my roleplay character remember the messages from our connected conversation?"* explaining the design and the workflow.

## Known limitations

No code change — the asymmetry itself is unchanged. Users who want raw DM messages to flow into a roleplay's context still need to rely on `<note>` tags. (Per maintainer guidance this is by design.)

## Test plan

- [x] Open a conversation/DM chat → settings drawer → hover the `(?)` next to **Connected Chat** → verify the new tooltip text reads correctly in light + dark mode + ~400px mobile width.
- [x] Open a roleplay chat with a connected DM → settings drawer → hover the `(?)` next to **Connected Conversation** → same visual check.
- [x] Open a game chat with no existing link → settings drawer → hover the `(?)` next to **Connected Conversation** → same visual check.
- [x] On the GitHub diff, check `docs/FAQ.md` rendered correctly (collapsible expands, code spans render).

## Docs touched

`docs/FAQ.md` (one new entry).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated help documentation for Connected Chat mode to clarify how context flows between connected chats and how to use `<influence>` and `<note>` tags to manage information exchange between conversation and roleplay modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->