### PR TITLE
Fix Windows installer clone staging

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "start": "node packages/server/dist/index.js",
     "format": "prettier --write \"packages/**/*.{ts,tsx}\"",
     "lint": "pnpm -r run lint",
-    "test": "pnpm -r run test",
+    "test": "node ./scripts/check-windows-installer-layout.mjs && pnpm -r run test",
     "version:sync": "node ./scripts/sync-version.mjs",
     "version:check": "node ./scripts/check-version-drift.mjs",
     "guard:installer-artifacts": "node ./scripts/check-tracked-installers.mjs",

--- a/scripts/check-windows-installer-layout.mjs
+++ b/scripts/check-windows-installer-layout.mjs
@@ -8,19 +8,60 @@ const installerPath = resolve(REPO_ROOT, "win/installer/installer.nsi");
 
 try {
   const content = await readFile(installerPath, "utf8");
+  const lines = content.split(/\r?\n/);
+  const code = lines
+    .map((line) => (/^\s*;/.test(line) ? "" : line))
+    .join("\n");
 
   const unsafePatterns = [
     {
-      pattern: /\bgit clone\b[^\r\n]*"\$INSTDIR\\repo-temp"/i,
+      pattern: /\bgit clone\b[^\r\n]*"?\$INSTDIR\\repo-temp"?/i,
       message: 'Initial clone target must not be under "$INSTDIR".',
     },
     {
-      pattern: /\brobocopy\s+"\$INSTDIR\\repo-temp"\s+"\$INSTDIR"\b/i,
+      pattern: /\brobocopy\s+"?\$INSTDIR\\repo-temp"?\s+"?\$INSTDIR"?\b/i,
       message: 'Do not robocopy from "$INSTDIR\\repo-temp" into its parent "$INSTDIR".',
     },
   ];
 
-  const failures = unsafePatterns.filter(({ pattern }) => pattern.test(content));
+  const failures = unsafePatterns.filter(({ pattern }) => pattern.test(code));
+
+  const unsafeVariableAssignments = [
+    {
+      pattern: /\bStrCpy\s+(\$[A-Za-z0-9_]+)\s+"?\$INSTDIR\\repo-temp"?\b/i,
+      message: (variable) => `Temporary clone variable ${variable} must not point under "$INSTDIR".`,
+    },
+    {
+      pattern: /\b(?:SetEnv|SetEnvironmentVariable)\s+(\$[A-Za-z0-9_]+)\s+"?\$INSTDIR\\repo-temp"?\b/i,
+      message: (variable) => `Environment staging variable ${variable} must not point under "$INSTDIR".`,
+    },
+  ];
+
+  const unsafeVariables = new Map();
+  for (const line of lines) {
+    const codeLine = /^\s*;/.test(line) ? "" : line;
+    for (const { pattern, message } of unsafeVariableAssignments) {
+      const match = pattern.exec(codeLine);
+      if (match) {
+        const variable = match[1].toUpperCase();
+        unsafeVariables.set(variable, message(match[1]));
+      }
+    }
+  }
+
+  for (const message of unsafeVariables.values()) {
+    failures.push({ message });
+  }
+
+  for (const [variable] of unsafeVariables) {
+    const escapedVariable = variable.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const unsafeVariableUse = new RegExp(`\\b(?:git clone|robocopy)\\b[^\\r\\n]*"?${escapedVariable}"?\\b`, "i");
+    if (unsafeVariableUse.test(code)) {
+      failures.push({
+        message: `Do not use ${variable} as a git clone or robocopy source after assigning it under "$INSTDIR".`,
+      });
+    }
+  }
 
   if (failures.length > 0) {
     console.error("Unsafe Windows installer staging layout detected:");

--- a/scripts/check-windows-installer-layout.mjs
+++ b/scripts/check-windows-installer-layout.mjs
@@ -9,9 +9,7 @@ const installerPath = resolve(REPO_ROOT, "win/installer/installer.nsi");
 try {
   const content = await readFile(installerPath, "utf8");
   const lines = content.split(/\r?\n/);
-  const code = lines
-    .map((line) => (/^\s*;/.test(line) ? "" : line))
-    .join("\n");
+  const code = lines.map((line) => (/^\s*;/.test(line) ? "" : line)).join("\n");
 
   const unsafePatterns = [
     {
@@ -21,6 +19,15 @@ try {
     {
       pattern: /\brobocopy\s+"?\$INSTDIR\\repo-temp"?\s+"?\$INSTDIR"?\b/i,
       message: 'Do not robocopy from "$INSTDIR\\repo-temp" into its parent "$INSTDIR".',
+    },
+    {
+      pattern:
+        /\bStrCpy\s+\$[A-Za-z0-9_]+\s+(?:"\$TEMP\\MarinaraEngine-repo-temp"|\$TEMP\\MarinaraEngine-repo-temp)\s*(?:\r?\n|$)/i,
+      message: 'Temporary clone paths must include a per-run suffix, not fixed "$TEMP\\MarinaraEngine-repo-temp".',
+    },
+    {
+      pattern: /\bStrCpy\s+\$[A-Za-z0-9_]+\s+(?:"\$INSTDIR\.__stage"|\$INSTDIR\.__stage)\s*(?:\r?\n|$)/i,
+      message: 'Temporary stage paths must include a per-run suffix, not fixed "$INSTDIR.__stage".',
     },
   ];
 

--- a/scripts/check-windows-installer-layout.mjs
+++ b/scripts/check-windows-installer-layout.mjs
@@ -1,0 +1,38 @@
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "..");
+const installerPath = resolve(REPO_ROOT, "win/installer/installer.nsi");
+
+try {
+  const content = await readFile(installerPath, "utf8");
+
+  const unsafePatterns = [
+    {
+      pattern: /\bgit clone\b[^\r\n]*"\$INSTDIR\\repo-temp"/i,
+      message: 'Initial clone target must not be under "$INSTDIR".',
+    },
+    {
+      pattern: /\brobocopy\s+"\$INSTDIR\\repo-temp"\s+"\$INSTDIR"\b/i,
+      message: 'Do not robocopy from "$INSTDIR\\repo-temp" into its parent "$INSTDIR".',
+    },
+  ];
+
+  const failures = unsafePatterns.filter(({ pattern }) => pattern.test(content));
+
+  if (failures.length > 0) {
+    console.error("Unsafe Windows installer staging layout detected:");
+    for (const failure of failures) {
+      console.error(`- ${failure.message}`);
+    }
+    console.error("Stage repository clones outside the final install directory.");
+    process.exit(1);
+  }
+
+  console.log("Windows installer staging layout is safe.");
+} catch (err) {
+  console.error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+}

--- a/win/installer/installer.nsi
+++ b/win/installer/installer.nsi
@@ -97,6 +97,7 @@ Var NODE_OK
 Var PNPM_OK
 Var PNPM_RUNNER
 Var CLONE_DIR
+Var STAGE_DIR
 
 Function LaunchApp
   ExecShell "" "$INSTDIR\start.bat"
@@ -330,10 +331,12 @@ Please restart your computer and run this installer again."
     DetailPrint "This may take 2-5 minutes depending on your internet speed."
     DetailPrint ""
     ; Stage fresh clones outside $INSTDIR so robocopy never moves a child
-    ; directory into its own parent. This avoids runaway recursive copies on
-    ; Windows when installs are interrupted or files are locked.
+    ; directory into its own parent. Publish through a sibling staging directory
+    ; so failed copies never leave a half-populated checkout in $INSTDIR.
     StrCpy $CLONE_DIR "$TEMP\MarinaraEngine-repo-temp"
+    StrCpy $STAGE_DIR "$INSTDIR.__stage"
     RMDir /r "$CLONE_DIR"
+    RMDir /r "$STAGE_DIR"
     ; Clone with --depth 1 for faster initial download, then unshallow
     nsExec::ExecToLog 'git clone --depth 1 "${REPO_URL}" "$CLONE_DIR"'
     Pop $0
@@ -353,21 +356,40 @@ ${APP_URL}"
         Abort
       ${EndIf}
     ${EndIf}
-    DetailPrint "Moving files into place..."
+    DetailPrint "Staging downloaded files..."
     ; robocopy returns 0-7 for success, 8+ for errors
-    nsExec::ExecToLog 'robocopy "$CLONE_DIR" "$INSTDIR" /E /MOVE /NFL /NDL /NJH /NJS'
+    nsExec::ExecToLog 'robocopy "$CLONE_DIR" "$STAGE_DIR" /E /MOVE /NFL /NDL /NJH /NJS'
     Pop $0
     ${If} $0 == "error"
       RMDir /r "$CLONE_DIR"
+      RMDir /r "$STAGE_DIR"
       MessageBox MB_OK|MB_ICONSTOP "Failed to move downloaded files into the installation directory.$\r$\n$\r$\nPlease choose an empty folder and run the installer again."
       Abort
     ${EndIf}
     ${If} $0 >= 8
       RMDir /r "$CLONE_DIR"
+      RMDir /r "$STAGE_DIR"
       MessageBox MB_OK|MB_ICONSTOP "Failed to move downloaded files into the installation directory.$\r$\n$\r$\nPlease choose an empty folder and run the installer again."
       Abort
     ${EndIf}
     RMDir /r "$CLONE_DIR"
+    DetailPrint "Publishing files into place..."
+    SetOutPath "$TEMP"
+    ClearErrors
+    RMDir "$INSTDIR"
+    ${If} ${Errors}
+      RMDir /r "$STAGE_DIR"
+      MessageBox MB_OK|MB_ICONSTOP "The installation directory is not empty.$\r$\n$\r$\nPlease choose an empty folder and run the installer again."
+      Abort
+    ${EndIf}
+    ClearErrors
+    Rename "$STAGE_DIR" "$INSTDIR"
+    ${If} ${Errors}
+      RMDir /r "$STAGE_DIR"
+      MessageBox MB_OK|MB_ICONSTOP "Failed to move downloaded files into the installation directory.$\r$\n$\r$\nPlease choose an empty folder and run the installer again."
+      Abort
+    ${EndIf}
+    SetOutPath "$INSTDIR"
     ; Unshallow so future git pull works
     nsExec::ExecToLog 'git fetch --unshallow'
     Pop $0

--- a/win/installer/installer.nsi
+++ b/win/installer/installer.nsi
@@ -98,6 +98,16 @@ Var PNPM_OK
 Var PNPM_RUNNER
 Var CLONE_DIR
 Var STAGE_DIR
+Var STAGING_RUN_ID
+Var CREATED_CLONE
+Var CREATED_STAGE
+
+!macro CleanupCreatedDir FLAG DIR
+  ${If} ${FLAG} == "1"
+    RMDir /r "${DIR}"
+    StrCpy ${FLAG} "0"
+  ${EndIf}
+!macroend
 
 Function LaunchApp
   ExecShell "" "$INSTDIR\start.bat"
@@ -331,23 +341,28 @@ Please restart your computer and run this installer again."
     DetailPrint "This may take 2-5 minutes depending on your internet speed."
     DetailPrint ""
     ; Stage fresh clones outside $INSTDIR so robocopy never moves a child
-    ; directory into its own parent. Publish through a sibling staging directory
-    ; so failed copies never leave a half-populated checkout in $INSTDIR.
-    StrCpy $CLONE_DIR "$TEMP\MarinaraEngine-repo-temp"
-    StrCpy $STAGE_DIR "$INSTDIR.__stage"
-    RMDir /r "$CLONE_DIR"
-    RMDir /r "$STAGE_DIR"
+    ; directory into its own parent. Use per-run paths so unrelated sibling
+    ; folders are never purged by installer cleanup.
+    System::Call 'kernel32::GetCurrentProcessId() i .R0'
+    System::Call 'kernel32::GetTickCount() i .R1'
+    StrCpy $STAGING_RUN_ID "$R0-$R1"
+    StrCpy $CLONE_DIR "$TEMP\MarinaraEngine-repo-temp-$STAGING_RUN_ID"
+    StrCpy $STAGE_DIR "$INSTDIR.__stage-$STAGING_RUN_ID"
+    StrCpy $CREATED_CLONE "0"
+    StrCpy $CREATED_STAGE "0"
     ; Clone with --depth 1 for faster initial download, then unshallow
+    StrCpy $CREATED_CLONE "1"
     nsExec::ExecToLog 'git clone --depth 1 "${REPO_URL}" "$CLONE_DIR"'
     Pop $0
     ${If} $0 != 0
       ; Retry without depth limit in case shallow clone failed
       DetailPrint "Shallow clone failed, trying full clone..."
-      RMDir /r "$CLONE_DIR"
+      !insertmacro CleanupCreatedDir $CREATED_CLONE $CLONE_DIR
+      StrCpy $CREATED_CLONE "1"
       nsExec::ExecToLog 'git clone "${REPO_URL}" "$CLONE_DIR"'
       Pop $0
       ${If} $0 != 0
-        RMDir /r "$CLONE_DIR"
+        !insertmacro CleanupCreatedDir $CREATED_CLONE $CLONE_DIR
         MessageBox MB_OK|MB_ICONSTOP "\
 Failed to download ${APP_NAME}.$\r$\n$\r$\n\
 Please check your internet connection and try again.$\r$\n\
@@ -358,37 +373,39 @@ ${APP_URL}"
     ${EndIf}
     DetailPrint "Staging downloaded files..."
     ; robocopy returns 0-7 for success, 8+ for errors
+    StrCpy $CREATED_STAGE "1"
     nsExec::ExecToLog 'robocopy "$CLONE_DIR" "$STAGE_DIR" /E /MOVE /NFL /NDL /NJH /NJS'
     Pop $0
     ${If} $0 == "error"
-      RMDir /r "$CLONE_DIR"
-      RMDir /r "$STAGE_DIR"
+      !insertmacro CleanupCreatedDir $CREATED_CLONE $CLONE_DIR
+      !insertmacro CleanupCreatedDir $CREATED_STAGE $STAGE_DIR
       MessageBox MB_OK|MB_ICONSTOP "Failed to move downloaded files into the installation directory.$\r$\n$\r$\nPlease choose an empty folder and run the installer again."
       Abort
     ${EndIf}
     ${If} $0 >= 8
-      RMDir /r "$CLONE_DIR"
-      RMDir /r "$STAGE_DIR"
+      !insertmacro CleanupCreatedDir $CREATED_CLONE $CLONE_DIR
+      !insertmacro CleanupCreatedDir $CREATED_STAGE $STAGE_DIR
       MessageBox MB_OK|MB_ICONSTOP "Failed to move downloaded files into the installation directory.$\r$\n$\r$\nPlease choose an empty folder and run the installer again."
       Abort
     ${EndIf}
-    RMDir /r "$CLONE_DIR"
+    !insertmacro CleanupCreatedDir $CREATED_CLONE $CLONE_DIR
     DetailPrint "Publishing files into place..."
     SetOutPath "$TEMP"
     ClearErrors
     RMDir "$INSTDIR"
     ${If} ${Errors}
-      RMDir /r "$STAGE_DIR"
+      !insertmacro CleanupCreatedDir $CREATED_STAGE $STAGE_DIR
       MessageBox MB_OK|MB_ICONSTOP "The installation directory is not empty.$\r$\n$\r$\nPlease choose an empty folder and run the installer again."
       Abort
     ${EndIf}
     ClearErrors
     Rename "$STAGE_DIR" "$INSTDIR"
     ${If} ${Errors}
-      RMDir /r "$STAGE_DIR"
+      !insertmacro CleanupCreatedDir $CREATED_STAGE $STAGE_DIR
       MessageBox MB_OK|MB_ICONSTOP "Failed to move downloaded files into the installation directory.$\r$\n$\r$\nPlease choose an empty folder and run the installer again."
       Abort
     ${EndIf}
+    StrCpy $CREATED_STAGE "0"
     SetOutPath "$INSTDIR"
     ; Unshallow so future git pull works
     nsExec::ExecToLog 'git fetch --unshallow'

--- a/win/installer/installer.nsi
+++ b/win/installer/installer.nsi
@@ -96,6 +96,7 @@ Var GIT_OK
 Var NODE_OK
 Var PNPM_OK
 Var PNPM_RUNNER
+Var CLONE_DIR
 
 Function LaunchApp
   ExecShell "" "$INSTDIR\start.bat"
@@ -328,15 +329,22 @@ Please restart your computer and run this installer again."
     DetailPrint "Cloning ${APP_NAME} repository..."
     DetailPrint "This may take 2-5 minutes depending on your internet speed."
     DetailPrint ""
+    ; Stage fresh clones outside $INSTDIR so robocopy never moves a child
+    ; directory into its own parent. This avoids runaway recursive copies on
+    ; Windows when installs are interrupted or files are locked.
+    StrCpy $CLONE_DIR "$TEMP\MarinaraEngine-repo-temp"
+    RMDir /r "$CLONE_DIR"
     ; Clone with --depth 1 for faster initial download, then unshallow
-    nsExec::ExecToLog 'git clone --depth 1 "${REPO_URL}" "$INSTDIR\repo-temp"'
+    nsExec::ExecToLog 'git clone --depth 1 "${REPO_URL}" "$CLONE_DIR"'
     Pop $0
     ${If} $0 != 0
       ; Retry without depth limit in case shallow clone failed
       DetailPrint "Shallow clone failed, trying full clone..."
-      nsExec::ExecToLog 'git clone "${REPO_URL}" "$INSTDIR\repo-temp"'
+      RMDir /r "$CLONE_DIR"
+      nsExec::ExecToLog 'git clone "${REPO_URL}" "$CLONE_DIR"'
       Pop $0
       ${If} $0 != 0
+        RMDir /r "$CLONE_DIR"
         MessageBox MB_OK|MB_ICONSTOP "\
 Failed to download ${APP_NAME}.$\r$\n$\r$\n\
 Please check your internet connection and try again.$\r$\n\
@@ -347,8 +355,19 @@ ${APP_URL}"
     ${EndIf}
     DetailPrint "Moving files into place..."
     ; robocopy returns 0-7 for success, 8+ for errors
-    nsExec::ExecToLog 'robocopy "$INSTDIR\repo-temp" "$INSTDIR" /E /MOVE /NFL /NDL /NJH /NJS'
+    nsExec::ExecToLog 'robocopy "$CLONE_DIR" "$INSTDIR" /E /MOVE /NFL /NDL /NJH /NJS'
     Pop $0
+    ${If} $0 == "error"
+      RMDir /r "$CLONE_DIR"
+      MessageBox MB_OK|MB_ICONSTOP "Failed to move downloaded files into the installation directory.$\r$\n$\r$\nPlease choose an empty folder and run the installer again."
+      Abort
+    ${EndIf}
+    ${If} $0 >= 8
+      RMDir /r "$CLONE_DIR"
+      MessageBox MB_OK|MB_ICONSTOP "Failed to move downloaded files into the installation directory.$\r$\n$\r$\nPlease choose an empty folder and run the installer again."
+      Abort
+    ${EndIf}
+    RMDir /r "$CLONE_DIR"
     ; Unshallow so future git pull works
     nsExec::ExecToLog 'git fetch --unshallow'
     Pop $0


### PR DESCRIPTION
## Summary
- stage fresh Windows installer clones under `%TEMP%` instead of inside `$INSTDIR`
- handle robocopy failure return codes and clean external staging on success/failure
- add a static guard to prevent reintroducing unsafe `$INSTDIR\repo-temp` parent/child copy layouts

## Validation
- `node ./scripts/check-windows-installer-layout.mjs`
- `pnpm test`

Note: `makensis` was not available locally, so full NSIS build validation still needs a Windows machine/VM with NSIS installed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a pre-test validation that detects unsafe installer staging/cloning patterns to prevent accidental in-place operations.

* **Bug Fixes**
  * Installer now performs clones and staging in per-run temporary locations, with retry logic, explicit error detection, reliable cleanup on failure, and clearer failure messaging to avoid partial or corrupted installs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->