### PR TITLE
Lorebook folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 - Conversation auto-summarization now has a Day Rollover Hour (so a late-night session doesn't get cut in half when calendar midnight passes) and a Recent Message Tail (keeps the last N messages verbatim across the day boundary so characters wake up remembering the actual flow of last night, not just the gist). Defaults: 4 AM rollover, 10-message tail.
 - Conversation characters can now emit durable `<note>...</note>` tags for connected roleplay and game chats. Notes persist in the target chat's prompt until cleared from Chat Settings.
 - Lorebook entries now use compact rows with inline controls and an expandable inline editor.
+- Lorebook entries can now be grouped into collapsible folders to reduce vertical clutter for stable or AI-managed entries. Folders have their own enable/disable toggle that gates every entry inside (regardless of each entry's own toggle) without modifying the entries' individual settings, so re-enabling a folder restores everything to how it was. Each folder is its own container — sort by Order works inside the folder, and a folder full of high-Order entries can sit above root-level entries with low Order without conflict. Move entries between folders via a per-row folder picker or drag-and-drop. Collapse state is per-browser (localStorage). Folders are flat in this release; nesting may follow.
 
 ### Fixed
 

--- a/packages/client/src/components/lorebooks/LorebookEditor.tsx
+++ b/packages/client/src/components/lorebooks/LorebookEditor.tsx
@@ -16,6 +16,10 @@ import {
   useCreateLorebookEntry,
   useDeleteLorebook,
   useReorderLorebookEntries,
+  useLorebookFolders,
+  useCreateLorebookFolder,
+  useUpdateLorebookEntry,
+  useReorderLorebookFolders,
 } from "../../hooks/use-lorebooks";
 import { useCharacters, usePersonas } from "../../hooks/use-characters";
 import { useConnections } from "../../hooks/use-connections";
@@ -44,13 +48,44 @@ import {
   Check,
   Tag,
   Wand2,
+  FolderPlus,
 } from "lucide-react";
 import { cn } from "../../lib/utils";
 import { HelpTooltip } from "../ui/HelpTooltip";
 import { api } from "../../lib/api-client";
-import type { Lorebook, LorebookEntry, LorebookCategory } from "@marinara-engine/shared";
+import type { Lorebook, LorebookEntry, LorebookFolder, LorebookCategory } from "@marinara-engine/shared";
 import { LorebookEntryRow } from "./LorebookEntryRow";
+import { LorebookFolderRow } from "./LorebookFolderRow";
 import { estimateTokens } from "./LorebookFormFields";
+
+// ──────────────────────────────────────────────
+// Folder collapse state lives in localStorage — purely a UI preference, not
+// worth a server round-trip on every toggle. Keyed per-lorebook so collapse
+// state is independent across books.
+// ──────────────────────────────────────────────
+const FOLDER_COLLAPSE_KEY_PREFIX = "lorebook-folder-collapsed:";
+
+function readCollapsedFolderIds(lorebookId: string | null): Set<string> {
+  if (!lorebookId || typeof window === "undefined") return new Set();
+  try {
+    const raw = window.localStorage.getItem(`${FOLDER_COLLAPSE_KEY_PREFIX}${lorebookId}`);
+    if (!raw) return new Set();
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) return new Set(parsed.filter((id): id is string => typeof id === "string"));
+    return new Set();
+  } catch {
+    return new Set();
+  }
+}
+
+function writeCollapsedFolderIds(lorebookId: string, ids: Set<string>) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(`${FOLDER_COLLAPSE_KEY_PREFIX}${lorebookId}`, JSON.stringify(Array.from(ids)));
+  } catch {
+    /* localStorage unavailable / quota exceeded — silently degrade */
+  }
+}
 
 // ── Types ──
 const TABS = [
@@ -84,15 +119,20 @@ export function LorebookEditor() {
   const closeDetail = useUIStore((s) => s.closeLorebookDetail);
   const { data: rawLorebook, isLoading } = useLorebook(lorebookId);
   const { data: rawEntries } = useLorebookEntries(lorebookId);
+  const { data: rawFolders } = useLorebookFolders(lorebookId);
   const { data: rawCharacters } = useCharacters();
   const { data: rawPersonas } = usePersonas();
   const updateLorebook = useUpdateLorebook();
   const deleteLorebook = useDeleteLorebook();
   const createEntry = useCreateLorebookEntry();
+  const updateEntry = useUpdateLorebookEntry();
   const reorderEntries = useReorderLorebookEntries();
+  const createFolder = useCreateLorebookFolder();
+  const reorderFolders = useReorderLorebookFolders();
 
   const lorebook = rawLorebook as Lorebook | undefined;
   const entries = useMemo(() => (rawEntries ?? []) as LorebookEntry[], [rawEntries]);
+  const folders = useMemo(() => (rawFolders ?? []) as LorebookFolder[], [rawFolders]);
   const characters = useMemo(() => {
     if (!rawCharacters) return [] as Array<{ id: string; name: string }>;
     return (rawCharacters as Array<{ id: string; data: string | Record<string, unknown> }>).map((c) => {
@@ -127,6 +167,40 @@ export function LorebookEditor() {
   const [draggingEntryIdx, setDraggingEntryIdx] = useState<number | null>(null);
   const [entryDragReadyIdx, setEntryDragReadyIdx] = useState<number | null>(null);
   const [entryDropIdx, setEntryDropIdx] = useState<number | null>(null);
+
+  // ── Folder UI state ──
+  // Collapse state: persisted in localStorage, keyed per-lorebook. Loaded
+  // synchronously on mount so the initial render reflects the user's prior
+  // preference instead of a flash-of-everything-expanded.
+  const [collapsedFolderIds, setCollapsedFolderIds] = useState<Set<string>>(() => readCollapsedFolderIds(lorebookId));
+  // When the user opens a different lorebook, reload its collapse state.
+  useEffect(() => {
+    setCollapsedFolderIds(readCollapsedFolderIds(lorebookId));
+  }, [lorebookId]);
+  const toggleFolderCollapsed = useCallback(
+    (folderId: string) => {
+      if (!lorebookId) return;
+      setCollapsedFolderIds((prev) => {
+        const next = new Set<string>(prev);
+        if (next.has(folderId)) next.delete(folderId);
+        else next.add(folderId);
+        writeCollapsedFolderIds(lorebookId, next);
+        return next;
+      });
+    },
+    [lorebookId],
+  );
+
+  // Cross-container drag-and-drop state. The "container" is null for the root
+  // group or a folder.id for entries inside a folder. We track the source
+  // container so a drop can detect a cross-container move and update the
+  // entry's folderId before reordering.
+  const [dragSourceContainer, setDragSourceContainer] = useState<string | null | undefined>(undefined);
+  const [dropTargetContainer, setDropTargetContainer] = useState<string | null | undefined>(undefined);
+  // Folder reorder uses its own pair so it doesn't entangle with entry DnD.
+  const [draggingFolderIdx, setDraggingFolderIdx] = useState<number | null>(null);
+  const [folderDragReadyIdx, setFolderDragReadyIdx] = useState<number | null>(null);
+  const [folderDropIdx, setFolderDropIdx] = useState<number | null>(null);
 
   // ── Form state for lorebook overview ──
   const [formName, setFormName] = useState("");
@@ -165,7 +239,8 @@ export function LorebookEditor() {
     loadedLorebookIdRef.current = lorebook.id;
   }, [lorebook, lorebookDirty]);
 
-  // Filtered + sorted entries
+  // Filtered + sorted entries (flat list — used when search is active or
+  // a non-Order sort is selected, both of which suppress folder grouping).
   const filteredEntries = useMemo(() => {
     let result = entries;
     if (entrySearch) {
@@ -195,8 +270,31 @@ export function LorebookEditor() {
         return [...result].sort((a, b) => a.order - b.order);
     }
   }, [entries, entrySearch, entrySort]);
+
+  // Folder grouping is only meaningful when the user is sorting by Order with
+  // no search — any other state would put entries out of their containers
+  // (e.g. "Name A→Z" interleaves entries from different folders).
+  const showFolderGrouping = entrySort === "order" && entrySearch.trim().length === 0;
+
+  /** Entries for a given container (null = root, string = folder.id), sorted by Order. */
+  const entriesByContainer = useMemo(() => {
+    const map = new Map<string | null, LorebookEntry[]>();
+    map.set(null, []);
+    for (const f of folders) map.set(f.id, []);
+    for (const e of entries) {
+      const key = e.folderId ?? null;
+      const list = map.get(key);
+      // If an entry's folderId points to a deleted folder, fall back to root.
+      if (list) list.push(e);
+      else map.get(null)!.push(e);
+    }
+    for (const list of map.values()) list.sort((a, b) => a.order - b.order);
+    return map;
+  }, [entries, folders]);
+
   const canReorderEntries =
-    entrySort === "order" && entrySearch.trim().length === 0 && filteredEntries.length > 1 && !reorderEntries.isPending;
+    showFolderGrouping && entries.length > 1 && !reorderEntries.isPending;
+  const canReorderFolders = showFolderGrouping && folders.length > 1 && !reorderFolders.isPending;
 
   // ── Handlers ──
   const markLorebookDirty = useCallback(() => setLorebookDirty(true), []);
@@ -213,6 +311,14 @@ export function LorebookEditor() {
     setDraggingEntryIdx(null);
     setEntryDragReadyIdx(null);
     setEntryDropIdx(null);
+    setDragSourceContainer(undefined);
+    setDropTargetContainer(undefined);
+  }, []);
+
+  const resetFolderDragState = useCallback(() => {
+    setDraggingFolderIdx(null);
+    setFolderDragReadyIdx(null);
+    setFolderDropIdx(null);
   }, []);
 
   const calcEntryDropIdx = useCallback((cardIdx: number, e: ReactDragEvent<HTMLDivElement>) => {
@@ -221,38 +327,72 @@ export function LorebookEditor() {
     return e.clientY < midY ? cardIdx : cardIdx + 1;
   }, []);
 
+  // Drag start on an entry inside a specific container. We capture the
+  // source container so commitEntryDrop can detect a cross-container move.
   const handleEntryDragStart = useCallback(
-    (idx: number, e: ReactDragEvent<HTMLDivElement>) => {
+    (containerId: string | null, idxInContainer: number, entryId: string, e: ReactDragEvent<HTMLDivElement>) => {
       if (!canReorderEntries) {
         e.preventDefault();
         return;
       }
-      setDraggingEntryIdx(idx);
+      setDraggingEntryIdx(idxInContainer);
+      setDragSourceContainer(containerId);
       e.dataTransfer.effectAllowed = "move";
-      e.dataTransfer.setData("text/plain", filteredEntries[idx]?.id ?? String(idx));
+      e.dataTransfer.setData("text/plain", entryId);
     },
-    [canReorderEntries, filteredEntries],
+    [canReorderEntries],
   );
 
   const handleEntryDragOver = useCallback(
-    (idx: number, e: ReactDragEvent<HTMLDivElement>) => {
+    (containerId: string | null, idxInContainer: number, e: ReactDragEvent<HTMLDivElement>) => {
       if (!canReorderEntries || draggingEntryIdx === null) return;
       e.preventDefault();
       e.dataTransfer.dropEffect = "move";
-      setEntryDropIdx(calcEntryDropIdx(idx, e));
+      setEntryDropIdx(calcEntryDropIdx(idxInContainer, e));
+      setDropTargetContainer(containerId);
     },
     [calcEntryDropIdx, canReorderEntries, draggingEntryIdx],
   );
 
-  const handleEntryListDragOver = useCallback(
+  // Dropping on a folder header drops the entry at the top of that folder.
+  const handleFolderHeaderDragOver = useCallback(
+    (folderId: string, e: ReactDragEvent<HTMLDivElement>) => {
+      // If we're dragging an entry, this becomes a cross-container drop target.
+      if (draggingEntryIdx !== null) {
+        e.preventDefault();
+        e.dataTransfer.dropEffect = "move";
+        setDropTargetContainer(folderId);
+        setEntryDropIdx(0);
+      }
+    },
+    [draggingEntryIdx],
+  );
+
+  // Empty folder → still need to accept drops to land an entry inside.
+  const handleFolderBodyDragOver = useCallback(
+    (folderId: string, e: ReactDragEvent<HTMLDivElement>) => {
+      if (!canReorderEntries || draggingEntryIdx === null) return;
+      e.preventDefault();
+      e.dataTransfer.dropEffect = "move";
+      setDropTargetContainer(folderId);
+      // If hovering empty folder body, drop at end.
+      const containerEntries = entriesByContainer.get(folderId) ?? [];
+      setEntryDropIdx(containerEntries.length);
+    },
+    [canReorderEntries, draggingEntryIdx, entriesByContainer],
+  );
+
+  const handleRootListDragOver = useCallback(
     (e: ReactDragEvent<HTMLDivElement>) => {
       if (!canReorderEntries || draggingEntryIdx === null) return;
       e.preventDefault();
       e.dataTransfer.dropEffect = "move";
 
       const container = entryListRef.current;
-      if (!container || filteredEntries.length === 0) {
-        setEntryDropIdx(filteredEntries.length);
+      const rootEntries = entriesByContainer.get(null) ?? [];
+      if (!container || rootEntries.length === 0) {
+        setDropTargetContainer(null);
+        setEntryDropIdx(rootEntries.length);
         return;
       }
 
@@ -262,16 +402,18 @@ export function LorebookEditor() {
 
       const firstRect = firstCard.getBoundingClientRect();
       if (e.clientY < firstRect.top) {
+        setDropTargetContainer(null);
         setEntryDropIdx(0);
         return;
       }
 
       const lastRect = lastCard.getBoundingClientRect();
       if (e.clientY > lastRect.bottom) {
-        setEntryDropIdx(filteredEntries.length);
+        setDropTargetContainer(null);
+        setEntryDropIdx(rootEntries.length);
       }
     },
-    [canReorderEntries, draggingEntryIdx, filteredEntries.length],
+    [canReorderEntries, draggingEntryIdx, entriesByContainer],
   );
 
   const commitEntryDrop = useCallback(
@@ -279,29 +421,108 @@ export function LorebookEditor() {
       e.preventDefault();
       const sourceIdx = draggingEntryIdx;
       const targetIdx = entryDropIdx;
+      const sourceContainer = dragSourceContainer;
+      const targetContainer = dropTargetContainer;
       resetEntryDragState();
-      if (!lorebookId || !canReorderEntries || sourceIdx === null || targetIdx === null) return;
+      if (
+        !lorebookId ||
+        !canReorderEntries ||
+        sourceIdx === null ||
+        targetIdx === null ||
+        sourceContainer === undefined ||
+        targetContainer === undefined
+      ) {
+        return;
+      }
 
-      let insertAt = targetIdx;
-      if (sourceIdx < insertAt) insertAt--;
-      if (sourceIdx === insertAt) return;
+      const sourceList = (entriesByContainer.get(sourceContainer) ?? []).slice();
+      const moved = sourceList[sourceIdx];
+      if (!moved) return;
 
-      const entryIds = filteredEntries.map((entry) => entry.id);
-      const [movedEntryId] = entryIds.splice(sourceIdx, 1);
-      if (!movedEntryId) return;
-      entryIds.splice(insertAt, 0, movedEntryId);
-      reorderEntries.mutate({ lorebookId, entryIds });
+      // Same-container reorder — preserves the existing reorder semantic.
+      if (sourceContainer === targetContainer) {
+        let insertAt = targetIdx;
+        if (sourceIdx < insertAt) insertAt--;
+        if (sourceIdx === insertAt) return;
+        const ids = sourceList.map((entry) => entry.id);
+        ids.splice(sourceIdx, 1);
+        ids.splice(insertAt, 0, moved.id);
+        reorderEntries.mutate({ lorebookId, entryIds: ids, folderId: sourceContainer });
+        return;
+      }
+
+      // Cross-container move. Only update folderId — leave the entry's Order
+      // untouched. The entry will slot into its sorted position in the new
+      // container based on its existing Order value, and the user can change
+      // Order explicitly via the inline editor if they want to reposition it.
+      // (Within-container drags renumber Order because the drag *is* how you
+      // change Order in that case; cross-container drags express folder
+      // membership only.)
+      updateEntry.mutate({ lorebookId, entryId: moved.id, folderId: targetContainer });
     },
     [
       canReorderEntries,
       draggingEntryIdx,
+      dragSourceContainer,
+      dropTargetContainer,
+      entriesByContainer,
       entryDropIdx,
-      filteredEntries,
       lorebookId,
       reorderEntries,
       resetEntryDragState,
+      updateEntry,
     ],
   );
+
+  // ── Folder reorder DnD ──
+  const handleFolderDragStart = useCallback(
+    (idx: number, folderId: string, e: ReactDragEvent<HTMLDivElement>) => {
+      if (!canReorderFolders) {
+        e.preventDefault();
+        return;
+      }
+      setDraggingFolderIdx(idx);
+      e.dataTransfer.effectAllowed = "move";
+      e.dataTransfer.setData("text/plain", folderId);
+    },
+    [canReorderFolders],
+  );
+
+  const handleFolderDragOverHeader = useCallback(
+    (idx: number, e: ReactDragEvent<HTMLDivElement>) => {
+      if (!canReorderFolders || draggingFolderIdx === null) return;
+      e.preventDefault();
+      e.dataTransfer.dropEffect = "move";
+      const rect = e.currentTarget.getBoundingClientRect();
+      const midY = rect.top + rect.height / 2;
+      setFolderDropIdx(e.clientY < midY ? idx : idx + 1);
+    },
+    [canReorderFolders, draggingFolderIdx],
+  );
+
+  const commitFolderDrop = useCallback(
+    (e: ReactDragEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      const sourceIdx = draggingFolderIdx;
+      const targetIdx = folderDropIdx;
+      resetFolderDragState();
+      if (!lorebookId || !canReorderFolders || sourceIdx === null || targetIdx === null) return;
+      let insertAt = targetIdx;
+      if (sourceIdx < insertAt) insertAt--;
+      if (sourceIdx === insertAt) return;
+      const ids = folders.map((f) => f.id);
+      const [moved] = ids.splice(sourceIdx, 1);
+      if (!moved) return;
+      ids.splice(insertAt, 0, moved);
+      reorderFolders.mutate({ lorebookId, folderIds: ids });
+    },
+    [canReorderFolders, draggingFolderIdx, folderDropIdx, folders, lorebookId, reorderFolders, resetFolderDragState],
+  );
+
+  const handleAddFolder = useCallback(async () => {
+    if (!lorebookId) return;
+    await createFolder.mutateAsync({ lorebookId, name: "New Folder", enabled: true });
+  }, [lorebookId, createFolder]);
 
   const handleSaveLorebook = useCallback(async () => {
     if (!lorebookId) return;
@@ -800,9 +1021,12 @@ export function LorebookEditor() {
 
             {activeTab === "entries" && (
               <div className="space-y-3">
-                {/* Search + Sort + Add */}
-                <div className="flex gap-2">
-                  <div className="relative flex-1">
+                {/* Search + Sort + Add — flex-wrap so the row collapses
+                    gracefully on narrow viewports. Search keeps a 12rem
+                    (~192px) flex-basis so it stays usable; the buttons tile
+                    onto the next row instead of being clipped at ~400px. */}
+                <div className="flex flex-wrap items-stretch gap-2">
+                  <div className="relative min-w-0 flex-[1_1_12rem]">
                     <Search
                       size="0.8125rem"
                       className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-[var(--muted-foreground)]"
@@ -815,7 +1039,7 @@ export function LorebookEditor() {
                       className="w-full rounded-xl bg-[var(--secondary)] py-2.5 pl-8 pr-3 text-xs ring-1 ring-[var(--border)] placeholder:text-[var(--muted-foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
                     />
                   </div>
-                  <div className="relative">
+                  <div className="relative shrink-0">
                     <ArrowUpDown
                       size="0.8125rem"
                       className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-[var(--muted-foreground)]"
@@ -833,8 +1057,16 @@ export function LorebookEditor() {
                     </select>
                   </div>
                   <button
+                    onClick={handleAddFolder}
+                    className="flex shrink-0 items-center gap-1.5 rounded-xl bg-[var(--secondary)] px-3 py-2.5 text-xs font-medium ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)]"
+                    title="Create a new folder to group entries"
+                  >
+                    <FolderPlus size="0.8125rem" />
+                    Add Folder
+                  </button>
+                  <button
                     onClick={handleAddEntry}
-                    className="flex items-center gap-1.5 rounded-xl bg-gradient-to-r from-amber-400 to-orange-500 px-4 py-2.5 text-xs font-medium text-white shadow-md transition-all hover:shadow-lg active:scale-[0.98]"
+                    className="flex shrink-0 items-center gap-1.5 rounded-xl bg-gradient-to-r from-amber-400 to-orange-500 px-4 py-2.5 text-xs font-medium text-white shadow-md transition-all hover:shadow-lg active:scale-[0.98]"
                   >
                     <Plus size="0.8125rem" />
                     Add Entry
@@ -842,77 +1074,318 @@ export function LorebookEditor() {
                 </div>
 
                 {/* Total tokens summary */}
-                {filteredEntries.length > 0 && (
+                {entries.length > 0 && (
                   <div className="flex items-center gap-3 text-[0.6875rem] text-[var(--muted-foreground)]">
-                    <span>{filteredEntries.length} entries</span>
+                    <span>
+                      {entries.length} {entries.length === 1 ? "entry" : "entries"}
+                    </span>
+                    {folders.length > 0 && (
+                      <>
+                        <span>•</span>
+                        <span>
+                          {folders.length} {folders.length === 1 ? "folder" : "folders"}
+                        </span>
+                      </>
+                    )}
                     <span>•</span>
                     <span className="flex items-center gap-1">
                       <Hash size="0.625rem" />
-                      {filteredEntries.reduce((sum, e) => sum + estimateTokens(e.content), 0).toLocaleString()} tokens
-                      (est.)
+                      {entries.reduce((sum, e) => sum + estimateTokens(e.content), 0).toLocaleString()} tokens (est.)
                     </span>
+                    {!showFolderGrouping && folders.length > 0 && (
+                      <span className="ml-auto italic">Folder view paused (clear search and sort by Order)</span>
+                    )}
                   </div>
                 )}
 
-                {/* Entry list */}
-                {filteredEntries.length === 0 && (
+                {/* Empty state */}
+                {entries.length === 0 && folders.length === 0 && (
                   <div className="flex flex-col items-center gap-2 py-8 text-center">
                     <FileText size="1.5rem" className="text-[var(--muted-foreground)]" />
                     <p className="text-xs text-[var(--muted-foreground)]">
-                      {entrySearch ? "No entries match your search" : "No entries yet — add one to get started"}
+                      No entries yet — add one to get started
                     </p>
                   </div>
                 )}
 
-                {filteredEntries.length > 0 && lorebookId && (
-                  <div
-                    ref={entryListRef}
-                    className="space-y-1.5"
-                    onDragOver={handleEntryListDragOver}
-                    onDrop={commitEntryDrop}
-                  >
-                    {filteredEntries.map((entry, idx) => {
-                      const showDropBefore =
-                        entryDropIdx === idx &&
-                        draggingEntryIdx !== null &&
-                        draggingEntryIdx !== idx &&
-                        draggingEntryIdx !== idx - 1;
-                      const showDropAfter =
-                        idx === filteredEntries.length - 1 &&
-                        entryDropIdx === filteredEntries.length &&
-                        draggingEntryIdx !== null &&
-                        draggingEntryIdx !== idx;
+                {/* Entries — folder-grouped view (default sort, no search) */}
+                {lorebookId && showFolderGrouping && (entries.length > 0 || folders.length > 0) && (
+                  <div className="space-y-3">
+                    {/* Folder block */}
+                    {folders.length > 0 && (
+                      <div className="space-y-1.5">
+                        {folders.map((folder, fIdx) => {
+                          const folderEntries = entriesByContainer.get(folder.id) ?? [];
+                          const isCollapsed = collapsedFolderIds.has(folder.id);
+                          const showFolderDropBefore =
+                            folderDropIdx === fIdx &&
+                            draggingFolderIdx !== null &&
+                            draggingFolderIdx !== fIdx &&
+                            draggingFolderIdx !== fIdx - 1;
+                          const showFolderDropAfter =
+                            fIdx === folders.length - 1 &&
+                            folderDropIdx === folders.length &&
+                            draggingFolderIdx !== null &&
+                            draggingFolderIdx !== fIdx;
+                          return (
+                            <div key={folder.id} className="space-y-1">
+                              {showFolderDropBefore && (
+                                <div className="mx-2 mb-1 h-0.5 rounded-full bg-amber-400" />
+                              )}
+                              {/*
+                                When an entry from a different container is being
+                                dragged toward this folder, paint a faint amber ring
+                                around the header to mirror the root drop-zone hint.
+                                The ring goes ON the wrapper div above the folder row
+                                because LorebookFolderRow already manages its own ring
+                                state for collapse/dragging visuals.
+                              */}
+                              <LorebookFolderRow
+                                folder={folder}
+                                lorebookId={lorebookId}
+                                entryCount={folderEntries.length}
+                                isCollapsed={isCollapsed}
+                                onToggleCollapse={() => toggleFolderCollapsed(folder.id)}
+                                draggable={canReorderFolders}
+                                isDragging={draggingFolderIdx === fIdx}
+                                isDragReady={folderDragReadyIdx === fIdx}
+                                onDragHandleMouseDown={() => {
+                                  if (canReorderFolders) setFolderDragReadyIdx(fIdx);
+                                }}
+                                onDragHandleMouseUp={() => setFolderDragReadyIdx(null)}
+                                onDragStart={(e) => handleFolderDragStart(fIdx, folder.id, e)}
+                                onDragOver={(e) => {
+                                  e.stopPropagation();
+                                  // Two roles for the same dragOver: if the user is dragging
+                                  // an entry, this header is a cross-container drop target;
+                                  // otherwise it's a sibling for folder reorder.
+                                  if (draggingEntryIdx !== null) handleFolderHeaderDragOver(folder.id, e);
+                                  else handleFolderDragOverHeader(fIdx, e);
+                                }}
+                                onDrop={(e) => {
+                                  e.stopPropagation();
+                                  if (draggingEntryIdx !== null) commitEntryDrop(e);
+                                  else commitFolderDrop(e);
+                                }}
+                                onDragEnd={() => {
+                                  resetFolderDragState();
+                                  resetEntryDragState();
+                                }}
+                              />
+                              {!isCollapsed && (
+                                <div
+                                  className="ml-4 space-y-1.5 border-l-2 border-[var(--border)] pl-3"
+                                  onDragOver={(e) => handleFolderBodyDragOver(folder.id, e)}
+                                  onDrop={(e) => {
+                                    e.stopPropagation();
+                                    commitEntryDrop(e);
+                                  }}
+                                >
+                                  {folderEntries.length === 0 && (
+                                    <p className="py-2 text-[0.625rem] italic text-[var(--muted-foreground)]">
+                                      Empty — drag an entry here or pick this folder from an entry's folder selector.
+                                    </p>
+                                  )}
+                                  {folderEntries.map((entry, eIdx) => {
+                                    const isDropTarget =
+                                      dropTargetContainer === folder.id && draggingEntryIdx !== null;
+                                    const sameContainer = dragSourceContainer === folder.id;
+                                    // Position bars only render for SAME-container drops because
+                                    // cross-container moves deliberately preserve the entry's
+                                    // existing Order (per the user's spec). Showing a bar
+                                    // between two entries during a cross-container drag would
+                                    // promise a position the move won't honor — the folder
+                                    // header's amber ring carries the "drop into this folder"
+                                    // affordance instead.
+                                    const showDropBefore =
+                                      isDropTarget &&
+                                      sameContainer &&
+                                      entryDropIdx === eIdx &&
+                                      draggingEntryIdx !== eIdx &&
+                                      draggingEntryIdx !== eIdx - 1;
+                                    const showDropAfter =
+                                      isDropTarget &&
+                                      sameContainer &&
+                                      eIdx === folderEntries.length - 1 &&
+                                      entryDropIdx === folderEntries.length &&
+                                      draggingEntryIdx !== eIdx;
+                                    return (
+                                      <div key={entry.id}>
+                                        {showDropBefore && (
+                                          <div className="mx-2 mb-1 h-0.5 rounded-full bg-amber-400" />
+                                        )}
+                                        <LorebookEntryRow
+                                          entry={entry}
+                                          lorebookId={lorebookId}
+                                          isExpanded={expandedEntryId === entry.id}
+                                          onToggleExpand={() => toggleEntryExpanded(entry.id)}
+                                          folders={folders}
+                                          draggable={canReorderEntries}
+                                          isDragging={
+                                            sameContainer && draggingEntryIdx === eIdx
+                                          }
+                                          isDragReady={
+                                            sameContainer && entryDragReadyIdx === eIdx
+                                          }
+                                          onDragHandleMouseDown={() => {
+                                            if (canReorderEntries) {
+                                              setEntryDragReadyIdx(eIdx);
+                                              setDragSourceContainer(folder.id);
+                                            }
+                                          }}
+                                          onDragHandleMouseUp={() => setEntryDragReadyIdx(null)}
+                                          onDragStart={(e) =>
+                                            handleEntryDragStart(folder.id, eIdx, entry.id, e)
+                                          }
+                                          onDragOver={(e) => {
+                                            e.stopPropagation();
+                                            handleEntryDragOver(folder.id, eIdx, e);
+                                          }}
+                                          onDrop={(e) => {
+                                            e.stopPropagation();
+                                            commitEntryDrop(e);
+                                          }}
+                                          onDragEnd={resetEntryDragState}
+                                        />
+                                        {showDropAfter && (
+                                          <div className="mx-2 mt-1 h-0.5 rounded-full bg-amber-400" />
+                                        )}
+                                      </div>
+                                    );
+                                  })}
+                                </div>
+                              )}
+                              {showFolderDropAfter && <div className="mx-2 mt-1 h-0.5 rounded-full bg-amber-400" />}
+                            </div>
+                          );
+                        })}
+                      </div>
+                    )}
 
-                      return (
-                        <div key={entry.id}>
-                          {showDropBefore && <div className="mx-2 mb-1 h-0.5 rounded-full bg-amber-400" />}
-                          <LorebookEntryRow
-                            entry={entry}
-                            lorebookId={lorebookId}
-                            isExpanded={expandedEntryId === entry.id}
-                            onToggleExpand={() => toggleEntryExpanded(entry.id)}
-                            draggable={canReorderEntries}
-                            isDragging={draggingEntryIdx === idx}
-                            isDragReady={entryDragReadyIdx === idx}
-                            onDragHandleMouseDown={() => {
-                              if (canReorderEntries) setEntryDragReadyIdx(idx);
-                            }}
-                            onDragHandleMouseUp={() => setEntryDragReadyIdx(null)}
-                            onDragStart={(e) => handleEntryDragStart(idx, e)}
-                            onDragOver={(e) => {
-                              e.stopPropagation();
-                              handleEntryDragOver(idx, e);
-                            }}
-                            onDrop={(e) => {
-                              e.stopPropagation();
-                              commitEntryDrop(e);
-                            }}
-                            onDragEnd={resetEntryDragState}
-                          />
-                          {showDropAfter && <div className="mx-2 mt-1 h-0.5 rounded-full bg-amber-400" />}
-                        </div>
-                      );
-                    })}
+                    {/* Root entries (entries with no folder).
+                        Always rendered when grouping is active so it acts as
+                        a permanent drop target — otherwise a user with all
+                        entries inside folders has no place to drop a folder
+                        entry to bring it back to root. */}
+                    <div
+                      ref={entryListRef}
+                      className={cn(
+                        "space-y-1.5",
+                        // Highlight the zone when an entry from another
+                        // container is being dragged toward it.
+                        draggingEntryIdx !== null &&
+                          dragSourceContainer !== null &&
+                          dropTargetContainer === null &&
+                          "rounded-xl ring-1 ring-amber-400/40 bg-amber-400/5 transition-colors",
+                      )}
+                      onDragOver={handleRootListDragOver}
+                      onDrop={commitEntryDrop}
+                    >
+                      {(entriesByContainer.get(null) ?? []).length === 0 && (
+                        <p
+                          className={cn(
+                            "py-3 text-center text-[0.625rem] italic text-[var(--muted-foreground)] transition-opacity",
+                            // Only call out the empty-root zone while the user
+                            // is actively dragging an entry from a folder; in
+                            // the steady state it would just be visual noise.
+                            draggingEntryIdx !== null && dragSourceContainer !== null
+                              ? "opacity-100"
+                              : "opacity-50",
+                          )}
+                        >
+                          {draggingEntryIdx !== null && dragSourceContainer !== null
+                            ? "Drop here to move out of the folder"
+                            : "No entries at the root level"}
+                        </p>
+                      )}
+                      {(entriesByContainer.get(null) ?? []).map((entry, idx) => {
+                          const rootList = entriesByContainer.get(null) ?? [];
+                          const isDropTarget = dropTargetContainer === null && draggingEntryIdx !== null;
+                          const sameContainer = dragSourceContainer === null;
+                          // Same rule as inside folders: only show the position bar for
+                          // same-container drops because cross-container moves preserve
+                          // Order. The amber ring on the root drop zone (added for Issue
+                          // 2) handles the cross-container affordance.
+                          const showDropBefore =
+                            isDropTarget &&
+                            sameContainer &&
+                            entryDropIdx === idx &&
+                            draggingEntryIdx !== idx &&
+                            draggingEntryIdx !== idx - 1;
+                          const showDropAfter =
+                            isDropTarget &&
+                            sameContainer &&
+                            idx === rootList.length - 1 &&
+                            entryDropIdx === rootList.length &&
+                            draggingEntryIdx !== idx;
+                          return (
+                            <div key={entry.id}>
+                              {showDropBefore && <div className="mx-2 mb-1 h-0.5 rounded-full bg-amber-400" />}
+                              <LorebookEntryRow
+                                entry={entry}
+                                lorebookId={lorebookId}
+                                isExpanded={expandedEntryId === entry.id}
+                                onToggleExpand={() => toggleEntryExpanded(entry.id)}
+                                folders={folders}
+                                draggable={canReorderEntries}
+                                isDragging={sameContainer && draggingEntryIdx === idx}
+                                isDragReady={sameContainer && entryDragReadyIdx === idx}
+                                onDragHandleMouseDown={() => {
+                                  if (canReorderEntries) {
+                                    setEntryDragReadyIdx(idx);
+                                    setDragSourceContainer(null);
+                                  }
+                                }}
+                                onDragHandleMouseUp={() => setEntryDragReadyIdx(null)}
+                                onDragStart={(e) => handleEntryDragStart(null, idx, entry.id, e)}
+                                onDragOver={(e) => {
+                                  e.stopPropagation();
+                                  handleEntryDragOver(null, idx, e);
+                                }}
+                                onDrop={(e) => {
+                                  e.stopPropagation();
+                                  commitEntryDrop(e);
+                                }}
+                                onDragEnd={resetEntryDragState}
+                              />
+                              {showDropAfter && <div className="mx-2 mt-1 h-0.5 rounded-full bg-amber-400" />}
+                            </div>
+                          );
+                        })}
+                    </div>
+                  </div>
+                )}
+
+                {/* Entries — flat view (search active or non-Order sort) */}
+                {lorebookId && !showFolderGrouping && filteredEntries.length > 0 && (
+                  <div ref={entryListRef} className="space-y-1.5">
+                    {filteredEntries.map((entry) => (
+                      <LorebookEntryRow
+                        key={entry.id}
+                        entry={entry}
+                        lorebookId={lorebookId}
+                        isExpanded={expandedEntryId === entry.id}
+                        onToggleExpand={() => toggleEntryExpanded(entry.id)}
+                        folders={folders}
+                        draggable={false}
+                        isDragging={false}
+                        isDragReady={false}
+                        onDragHandleMouseDown={() => undefined}
+                        onDragHandleMouseUp={() => undefined}
+                        onDragStart={() => undefined}
+                        onDragOver={() => undefined}
+                        onDrop={() => undefined}
+                        onDragEnd={() => undefined}
+                      />
+                    ))}
+                  </div>
+                )}
+
+                {/* Search-with-no-matches */}
+                {lorebookId && !showFolderGrouping && filteredEntries.length === 0 && entries.length > 0 && (
+                  <div className="flex flex-col items-center gap-2 py-8 text-center">
+                    <FileText size="1.5rem" className="text-[var(--muted-foreground)]" />
+                    <p className="text-xs text-[var(--muted-foreground)]">No entries match your search</p>
                   </div>
                 )}
               </div>

--- a/packages/client/src/components/lorebooks/LorebookEntryRow.tsx
+++ b/packages/client/src/components/lorebooks/LorebookEntryRow.tsx
@@ -28,7 +28,7 @@ import {
 import { cn } from "../../lib/utils";
 import { showConfirmDialog } from "../../lib/app-dialogs";
 import { useUpdateLorebookEntry, useDeleteLorebookEntry } from "../../hooks/use-lorebooks";
-import type { LorebookEntry } from "@marinara-engine/shared";
+import type { LorebookEntry, LorebookFolder } from "@marinara-engine/shared";
 import {
   ExpandableTextarea,
   FieldGroup,
@@ -43,6 +43,12 @@ interface Props {
   lorebookId: string;
   isExpanded: boolean;
   onToggleExpand: () => void;
+  /**
+   * All folders in the parent lorebook. Used to populate the folder selector
+   * on the row. May be empty — when empty, the selector is hidden because
+   * "(none)" → "(none)" is meaningless.
+   */
+  folders: LorebookFolder[];
   // Drag-and-drop wiring (lifted in the parent because cross-row state).
   draggable: boolean;
   isDragging: boolean;
@@ -96,6 +102,7 @@ export function LorebookEntryRow({
   lorebookId,
   isExpanded,
   onToggleExpand,
+  folders,
   draggable,
   isDragging,
   isDragReady,
@@ -351,6 +358,17 @@ export function LorebookEntryRow({
             min={0}
             max={100}
           />
+          {folders.length > 0 && (
+            <CompactSelect
+              value={entry.folderId ?? ""}
+              onChange={(v) => patch({ folderId: v === "" ? null : v })}
+              title="Move this entry to a different folder. (none) = root level."
+              options={[
+                { value: "", label: "(none)" },
+                ...folders.map((f) => ({ value: f.id, label: f.name })),
+              ]}
+            />
+          )}
         </div>
 
         {/* Token estimate (compact) */}

--- a/packages/client/src/components/lorebooks/LorebookFolderRow.tsx
+++ b/packages/client/src/components/lorebooks/LorebookFolderRow.tsx
@@ -1,0 +1,252 @@
+// ──────────────────────────────────────────────
+// Lorebook Folder Row
+// Header for a collapsible folder of lorebook entries. Mirrors the visual
+// language of LorebookEntryRow (compact, drag handle on the left, inline
+// rename, hover-revealed delete) so the two row types feel like one list.
+//
+// Two toggles live on this row:
+//  • Collapse — a UI-only chevron that hides/shows the folder body. Persisted
+//    in localStorage by the parent editor; never sent to the server.
+//  • Enable  — a server-persisted folder.enabled flag. When OFF, every entry
+//    inside the folder is gated out at activation time regardless of the
+//    entry's own enabled flag. Entries' own flags are preserved untouched.
+// ──────────────────────────────────────────────
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type DragEvent as ReactDragEvent,
+  type MouseEvent as ReactMouseEvent,
+} from "react";
+import { ChevronDown, Folder, GripVertical, ToggleLeft, ToggleRight, Trash2 } from "lucide-react";
+import { cn } from "../../lib/utils";
+import { showConfirmDialog } from "../../lib/app-dialogs";
+import { useUpdateLorebookFolder, useDeleteLorebookFolder } from "../../hooks/use-lorebooks";
+import type { LorebookFolder } from "@marinara-engine/shared";
+
+interface Props {
+  folder: LorebookFolder;
+  lorebookId: string;
+  /** Number of entries currently inside this folder (for the count badge). */
+  entryCount: number;
+  /** UI-only collapse state — owned by the parent editor and persisted in localStorage. */
+  isCollapsed: boolean;
+  onToggleCollapse: () => void;
+  // Drag handle wiring — folder rows are draggable to reorder folders, AND
+  // act as drop targets when dragging an entry across containers.
+  draggable: boolean;
+  isDragging: boolean;
+  isDragReady: boolean;
+  onDragHandleMouseDown: () => void;
+  onDragHandleMouseUp: () => void;
+  onDragStart: (e: ReactDragEvent<HTMLDivElement>) => void;
+  onDragOver: (e: ReactDragEvent<HTMLDivElement>) => void;
+  onDrop: (e: ReactDragEvent<HTMLDivElement>) => void;
+  onDragEnd: () => void;
+}
+
+export function LorebookFolderRow({
+  folder,
+  lorebookId,
+  entryCount,
+  isCollapsed,
+  onToggleCollapse,
+  draggable,
+  isDragging,
+  isDragReady,
+  onDragHandleMouseDown,
+  onDragHandleMouseUp,
+  onDragStart,
+  onDragOver,
+  onDrop,
+  onDragEnd,
+}: Props) {
+  const updateFolder = useUpdateLorebookFolder();
+  const deleteFolder = useDeleteLorebookFolder();
+
+  // Optimistic mirrors so toggle/rename feel snappy while the mutation flushes.
+  const [localEnabled, setLocalEnabled] = useState(folder.enabled);
+  const [localName, setLocalName] = useState(folder.name);
+
+  const lastSyncedRef = useRef(folder);
+  useEffect(() => {
+    if (lastSyncedRef.current === folder) return;
+    lastSyncedRef.current = folder;
+    setLocalEnabled(folder.enabled);
+    setLocalName(folder.name);
+  }, [folder]);
+
+  const handleEnableToggle = useCallback(
+    (e: ReactMouseEvent) => {
+      e.stopPropagation();
+      const previous = localEnabled;
+      const next = !previous;
+      // Optimistic flip — but if the PATCH fails, restore the previous value
+      // so the row doesn't lie about the server state. This matters most for
+      // `enabled`: the activation gate runs server-side, so a failed flip
+      // would mean the row says "off" while entries still activate (or vice
+      // versa).
+      setLocalEnabled(next);
+      updateFolder.mutate(
+        { lorebookId, folderId: folder.id, enabled: next },
+        {
+          onError: () => {
+            setLocalEnabled(previous);
+          },
+        },
+      );
+    },
+    [localEnabled, lorebookId, folder.id, updateFolder],
+  );
+
+  const handleNameCommit = useCallback(() => {
+    const trimmed = localName.trim();
+    if (!trimmed) {
+      setLocalName(folder.name);
+      return;
+    }
+    if (trimmed !== folder.name) {
+      const previous = folder.name;
+      updateFolder.mutate(
+        { lorebookId, folderId: folder.id, name: trimmed },
+        {
+          onError: () => {
+            // Roll the displayed name back to whatever the server still has
+            // so the row doesn't continue showing a renamed folder that the
+            // server never accepted.
+            setLocalName(previous);
+          },
+        },
+      );
+    }
+  }, [localName, folder.name, lorebookId, folder.id, updateFolder]);
+
+  const handleDelete = useCallback(
+    async (e: ReactMouseEvent) => {
+      e.stopPropagation();
+      const confirmed = await showConfirmDialog({
+        title: "Delete Folder",
+        message:
+          entryCount > 0
+            ? `Delete this folder? The ${entryCount} entr${entryCount === 1 ? "y" : "ies"} inside will be moved back to the root level.`
+            : "Delete this folder?",
+        confirmLabel: "Delete",
+        tone: "destructive",
+      });
+      if (!confirmed) return;
+      deleteFolder.mutate({ lorebookId, folderId: folder.id });
+    },
+    [entryCount, lorebookId, folder.id, deleteFolder],
+  );
+
+  return (
+    <div
+      className={cn(
+        "rounded-xl bg-[var(--secondary)]/60 ring-1 ring-[var(--border)] transition-all",
+        !isCollapsed && "ring-amber-400/30",
+        isDragging && "opacity-40",
+      )}
+      draggable={draggable && isDragReady}
+      onDragStart={onDragStart}
+      onDragOver={onDragOver}
+      onDrop={onDrop}
+      onDragEnd={onDragEnd}
+    >
+      <div className="group flex cursor-pointer items-center gap-2 px-2 py-1.5" onClick={onToggleCollapse}>
+        {/* Drag handle */}
+        <button
+          type="button"
+          className={cn(
+            "shrink-0 rounded p-0.5 text-[var(--muted-foreground)] transition-colors",
+            draggable
+              ? "cursor-grab hover:bg-[var(--accent)] hover:text-[var(--foreground)] active:cursor-grabbing"
+              : "cursor-not-allowed opacity-40",
+          )}
+          title={draggable ? "Drag to reorder folder" : "Use Order sort and clear search to reorder"}
+          onClick={(e) => e.stopPropagation()}
+          onMouseDown={(e) => {
+            e.stopPropagation();
+            if (draggable) onDragHandleMouseDown();
+          }}
+          onMouseUp={(e) => {
+            e.stopPropagation();
+            onDragHandleMouseUp();
+          }}
+        >
+          <GripVertical size="0.875rem" />
+        </button>
+
+        {/* Collapse chevron */}
+        <button
+          type="button"
+          aria-label={isCollapsed ? "Expand folder" : "Collapse folder"}
+          className="shrink-0 rounded p-0.5 text-[var(--muted-foreground)] transition-transform hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+          onClick={(e) => {
+            e.stopPropagation();
+            onToggleCollapse();
+          }}
+        >
+          <ChevronDown size="0.875rem" className={cn("transition-transform", isCollapsed ? "-rotate-90" : "rotate-0")} />
+        </button>
+
+        {/* Enable toggle */}
+        <button
+          type="button"
+          aria-label={localEnabled ? "Disable folder" : "Enable folder"}
+          title={
+            localEnabled
+              ? "Folder enabled — entries inside activate normally"
+              : "Folder disabled — entries inside will not activate, regardless of their own toggle"
+          }
+          onClick={handleEnableToggle}
+          className="shrink-0"
+        >
+          {localEnabled ? (
+            <ToggleRight size="1.125rem" className="text-amber-400" />
+          ) : (
+            <ToggleLeft size="1.125rem" className="text-[var(--muted-foreground)]" />
+          )}
+        </button>
+
+        {/* Folder icon + name */}
+        <Folder
+          size="0.875rem"
+          className={cn("shrink-0", localEnabled ? "text-amber-400" : "text-[var(--muted-foreground)]")}
+        />
+        <input
+          value={localName}
+          onChange={(e) => setLocalName(e.target.value)}
+          onBlur={handleNameCommit}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              (e.currentTarget as HTMLInputElement).blur();
+            }
+          }}
+          onClick={(e) => e.stopPropagation()}
+          placeholder="Untitled folder"
+          className="min-w-0 flex-1 truncate bg-transparent px-1 text-sm font-semibold outline-none transition-colors hover:bg-[var(--accent)]/40 focus:bg-[var(--accent)]/40 focus:ring-1 focus:ring-[var(--ring)] rounded"
+        />
+
+        {/* Entry count badge */}
+        <span
+          className="shrink-0 rounded-full bg-[var(--secondary)] px-2 py-0.5 text-[0.625rem] font-medium text-[var(--muted-foreground)]"
+          title={`${entryCount} entr${entryCount === 1 ? "y" : "ies"} in this folder`}
+        >
+          {entryCount}
+        </span>
+
+        {/* Delete (hover-revealed on desktop, always visible on mobile per the row-action convention) */}
+        <button
+          type="button"
+          aria-label="Delete folder"
+          onClick={handleDelete}
+          className="shrink-0 rounded p-1 opacity-0 transition-all hover:bg-[var(--destructive)]/15 group-hover:opacity-100 max-md:opacity-100"
+        >
+          <Trash2 size="0.75rem" className="text-[var(--destructive)]" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/client/src/hooks/use-lorebooks.ts
+++ b/packages/client/src/hooks/use-lorebooks.ts
@@ -3,7 +3,7 @@
 // ──────────────────────────────────────────────
 import { useQuery, useQueries, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "../lib/api-client";
-import type { Lorebook, LorebookEntry } from "@marinara-engine/shared";
+import type { Lorebook, LorebookEntry, LorebookFolder } from "@marinara-engine/shared";
 
 export const lorebookKeys = {
   all: ["lorebooks"] as const,
@@ -12,6 +12,7 @@ export const lorebookKeys = {
   detail: (id: string) => [...lorebookKeys.all, "detail", id] as const,
   entries: (lorebookId: string) => [...lorebookKeys.all, "entries", lorebookId] as const,
   entry: (entryId: string) => [...lorebookKeys.all, "entry", entryId] as const,
+  folders: (lorebookId: string) => [...lorebookKeys.all, "folders", lorebookId] as const,
   search: (q: string) => [...lorebookKeys.all, "search", q] as const,
 };
 
@@ -175,12 +176,94 @@ export function useBulkCreateEntries() {
 export function useReorderLorebookEntries() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: ({ lorebookId, entryIds }: { lorebookId: string; entryIds: string[] }) =>
-      api.put<LorebookEntry[]>(`/lorebooks/${lorebookId}/entries/reorder`, { entryIds }),
+    mutationFn: ({
+      lorebookId,
+      entryIds,
+      folderId,
+    }: {
+      lorebookId: string;
+      entryIds: string[];
+      /**
+       * Container scope for the reorder. `undefined` renumbers every entry
+       * (legacy behavior). `null` reorders root-level entries only.
+       * A string ID reorders the entries inside that folder only.
+       */
+      folderId?: string | null;
+    }) =>
+      api.put<LorebookEntry[]>(`/lorebooks/${lorebookId}/entries/reorder`, {
+        entryIds,
+        ...(folderId !== undefined ? { folderId } : {}),
+      }),
     onSuccess: (entries, variables) => {
       qc.setQueryData(lorebookKeys.entries(variables.lorebookId), entries);
       qc.invalidateQueries({ queryKey: lorebookKeys.entries(variables.lorebookId) });
       qc.invalidateQueries({ queryKey: [...lorebookKeys.all, "active"] });
+    },
+  });
+}
+
+// ── Folders ──
+
+export function useLorebookFolders(lorebookId: string | null) {
+  return useQuery({
+    queryKey: lorebookKeys.folders(lorebookId ?? ""),
+    queryFn: () => api.get<LorebookFolder[]>(`/lorebooks/${lorebookId}/folders`),
+    enabled: !!lorebookId,
+  });
+}
+
+export function useCreateLorebookFolder() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ lorebookId, ...data }: { lorebookId: string } & Record<string, unknown>) =>
+      api.post<LorebookFolder>(`/lorebooks/${lorebookId}/folders`, data),
+    onSuccess: (_data, variables) => {
+      qc.invalidateQueries({ queryKey: lorebookKeys.folders(variables.lorebookId) });
+    },
+  });
+}
+
+export function useUpdateLorebookFolder() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      lorebookId,
+      folderId,
+      ...data
+    }: {
+      lorebookId: string;
+      folderId: string;
+    } & Record<string, unknown>) => api.patch<LorebookFolder>(`/lorebooks/${lorebookId}/folders/${folderId}`, data),
+    onSuccess: (_data, variables) => {
+      qc.invalidateQueries({ queryKey: lorebookKeys.folders(variables.lorebookId) });
+      // Toggling folder.enabled changes which entries activate during scan
+      qc.invalidateQueries({ queryKey: [...lorebookKeys.all, "active"] });
+    },
+  });
+}
+
+export function useDeleteLorebookFolder() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ lorebookId, folderId }: { lorebookId: string; folderId: string }) =>
+      api.delete(`/lorebooks/${lorebookId}/folders/${folderId}`),
+    onSuccess: (_data, variables) => {
+      qc.invalidateQueries({ queryKey: lorebookKeys.folders(variables.lorebookId) });
+      // Removing a folder reparents its entries to root, so the entry list shape changes.
+      qc.invalidateQueries({ queryKey: lorebookKeys.entries(variables.lorebookId) });
+      qc.invalidateQueries({ queryKey: [...lorebookKeys.all, "active"] });
+    },
+  });
+}
+
+export function useReorderLorebookFolders() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ lorebookId, folderIds }: { lorebookId: string; folderIds: string[] }) =>
+      api.put<LorebookFolder[]>(`/lorebooks/${lorebookId}/folders/reorder`, { folderIds }),
+    onSuccess: (folders, variables) => {
+      qc.setQueryData(lorebookKeys.folders(variables.lorebookId), folders);
+      qc.invalidateQueries({ queryKey: lorebookKeys.folders(variables.lorebookId) });
     },
   });
 }

--- a/packages/server/src/db/schema/lorebooks.ts
+++ b/packages/server/src/db/schema/lorebooks.ts
@@ -1,5 +1,5 @@
 // ──────────────────────────────────────────────
-// Schema: Lorebooks & Entries
+// Schema: Lorebooks, Folders & Entries
 // ──────────────────────────────────────────────
 import { sqliteTable, text, integer } from "drizzle-orm/sqlite-core";
 
@@ -24,11 +24,42 @@ export const lorebooks = sqliteTable("lorebooks", {
   updatedAt: text("updated_at").notNull(),
 });
 
+/**
+ * Lorebook folders — collapsible containers that group entries to reduce
+ * visual clutter in the editor. Folders are flat in v1; `parentFolderId` is
+ * reserved (always null) for a future nested-folder PR. When a folder's
+ * `enabled` flag is "false", every entry whose `folderId` matches is
+ * excluded from activation regardless of the entry's own enabled flag —
+ * gating happens at `listActiveEntries` time, not by mutating entry rows.
+ */
+export const lorebookFolders = sqliteTable("lorebook_folders", {
+  id: text("id").primaryKey(),
+  lorebookId: text("lorebook_id")
+    .notNull()
+    .references(() => lorebooks.id, { onDelete: "cascade" }),
+  name: text("name").notNull(),
+  /** SQLite-style "true"/"false" string, matches the rest of this schema. */
+  enabled: text("enabled").notNull().default("true"),
+  /** Reserved for future nesting; always NULL in v1. */
+  parentFolderId: text("parent_folder_id"),
+  /** Display order among sibling folders (lower = higher in the list). */
+  order: integer("order").notNull().default(0),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull(),
+});
+
 export const lorebookEntries = sqliteTable("lorebook_entries", {
   id: text("id").primaryKey(),
   lorebookId: text("lorebook_id")
     .notNull()
     .references(() => lorebooks.id, { onDelete: "cascade" }),
+  /**
+   * Folder this entry belongs to, or NULL for root-level. Not enforced as a
+   * foreign key in SQLite to keep folder deletion cheap (the storage layer
+   * sets entries' folderId back to null when a folder is removed instead of
+   * cascading the entries themselves).
+   */
+  folderId: text("folder_id"),
   name: text("name").notNull(),
   content: text("content").notNull().default(""),
   /** Short summary used by the knowledge-router agent to decide if this entry is relevant */

--- a/packages/server/src/routes/lorebooks.routes.ts
+++ b/packages/server/src/routes/lorebooks.routes.ts
@@ -7,6 +7,8 @@ import {
   updateLorebookSchema,
   createLorebookEntrySchema,
   updateLorebookEntrySchema,
+  createLorebookFolderSchema,
+  updateLorebookFolderSchema,
 } from "@marinara-engine/shared";
 import type { ExportEnvelope } from "@marinara-engine/shared";
 import { createLorebooksStorage } from "../services/storage/lorebooks.storage.js";
@@ -77,11 +79,12 @@ export async function lorebooksRoutes(app: FastifyInstance) {
     const lb = (await storage.getById(req.params.id)) as Record<string, unknown> | null;
     if (!lb) return reply.status(404).send({ error: "Lorebook not found" });
     const entries = await storage.listEntries(req.params.id);
+    const folders = await storage.listFolders(req.params.id);
     const envelope: ExportEnvelope = {
       type: "marinara_lorebook",
       version: 1,
       exportedAt: new Date().toISOString(),
-      data: { lorebook: lb, entries },
+      data: { lorebook: lb, entries, folders },
     };
     return reply
       .header(
@@ -103,11 +106,12 @@ export async function lorebooksRoutes(app: FastifyInstance) {
       const lb = (await storage.getById(id)) as Record<string, unknown> | null;
       if (!lb) continue;
       const entries = await storage.listEntries(id);
+      const folders = await storage.listFolders(id);
       const envelope: ExportEnvelope = {
         type: "marinara_lorebook",
         version: 1,
         exportedAt: new Date().toISOString(),
-        data: { lorebook: lb, entries },
+        data: { lorebook: lb, entries, folders },
       };
       zip.addFile(
         `${toSafeExportName(String(lb.name || "lorebook"), `lorebook-${exportedCount + 1}`)}.marinara.json`,
@@ -138,19 +142,33 @@ export async function lorebooksRoutes(app: FastifyInstance) {
     return entry;
   });
 
-  app.post<{ Params: { id: string } }>("/:id/entries", async (req) => {
+  app.post<{ Params: { id: string } }>("/:id/entries", async (req, reply) => {
     const input = createLorebookEntrySchema.parse({
       ...(req.body as Record<string, unknown>),
       lorebookId: req.params.id,
     });
-    return storage.createEntry(input);
+    try {
+      return await storage.createEntry(input);
+    } catch (err) {
+      if (err instanceof Error && err.message === "folderId does not belong to this lorebook") {
+        return reply.status(400).send({ error: err.message });
+      }
+      throw err;
+    }
   });
 
   app.patch<{ Params: { id: string; entryId: string } }>("/:id/entries/:entryId", async (req, reply) => {
     const input = updateLorebookEntrySchema.parse(req.body);
-    const updated = await storage.updateEntry(req.params.entryId, input);
-    if (!updated) return reply.status(404).send({ error: "Entry not found" });
-    return updated;
+    try {
+      const updated = await storage.updateEntry(req.params.entryId, input);
+      if (!updated) return reply.status(404).send({ error: "Entry not found" });
+      return updated;
+    } catch (err) {
+      if (err instanceof Error && err.message === "folderId does not belong to this lorebook") {
+        return reply.status(400).send({ error: err.message });
+      }
+      throw err;
+    }
   });
 
   app.delete<{ Params: { lorebookId: string; entryId: string } }>(
@@ -176,14 +194,68 @@ export async function lorebooksRoutes(app: FastifyInstance) {
   });
 
   app.put<{ Params: { id: string } }>("/:id/entries/reorder", async (req, reply) => {
-    const body = req.body as { entryIds?: unknown };
+    const body = req.body as { entryIds?: unknown; folderId?: unknown };
     const entryIds = Array.isArray(body.entryIds)
       ? body.entryIds.filter((id): id is string => typeof id === "string")
       : [];
     if (entryIds.length === 0) {
       return reply.status(400).send({ error: "entryIds array is required" });
     }
-    return storage.reorderEntries(req.params.id, entryIds);
+    // folderId scopes the reorder to a single container:
+    //   undefined → legacy behaviour (renumber every entry in the lorebook)
+    //   null      → root-level entries only
+    //   string    → entries inside that folder only
+    let folderId: string | null | undefined;
+    if (body.folderId === null) folderId = null;
+    else if (typeof body.folderId === "string") folderId = body.folderId;
+    else folderId = undefined;
+    return storage.reorderEntries(req.params.id, entryIds, folderId);
+  });
+
+  // ── Folders ──
+
+  app.get<{ Params: { id: string } }>("/:id/folders", async (req) => {
+    return storage.listFolders(req.params.id);
+  });
+
+  app.post<{ Params: { id: string } }>("/:id/folders", async (req, reply) => {
+    const input = createLorebookFolderSchema.parse(req.body);
+    if (input.parentFolderId !== null) {
+      // v1 reserves nesting for a follow-up PR. Accept the field shape but
+      // refuse to persist non-null values rather than silently dropping them.
+      return reply.status(400).send({ error: "Nested folders are not supported in this version" });
+    }
+    return storage.createFolder(req.params.id, input);
+  });
+
+  app.patch<{ Params: { id: string; folderId: string } }>("/:id/folders/:folderId", async (req, reply) => {
+    const input = updateLorebookFolderSchema.parse(req.body);
+    if (input.parentFolderId !== undefined && input.parentFolderId !== null) {
+      return reply.status(400).send({ error: "Nested folders are not supported in this version" });
+    }
+    // Scope by lorebookId so /lorebooks/A/folders/B can't update folder B if
+    // it actually belongs to lorebook X.
+    const updated = await storage.updateFolder(req.params.folderId, input, req.params.id);
+    if (!updated) return reply.status(404).send({ error: "Folder not found" });
+    return updated;
+  });
+
+  app.delete<{ Params: { id: string; folderId: string } }>("/:id/folders/:folderId", async (req, reply) => {
+    // Scope by lorebookId so a request to /lorebooks/A/folders/B cannot
+    // reach a folder belonging to lorebook X and reparent its entries.
+    await storage.removeFolder(req.params.folderId, req.params.id);
+    return reply.status(204).send();
+  });
+
+  app.put<{ Params: { id: string } }>("/:id/folders/reorder", async (req, reply) => {
+    const body = req.body as { folderIds?: unknown };
+    const folderIds = Array.isArray(body.folderIds)
+      ? body.folderIds.filter((id): id is string => typeof id === "string")
+      : [];
+    if (folderIds.length === 0) {
+      return reply.status(400).send({ error: "folderIds array is required" });
+    }
+    return storage.reorderFolders(req.params.id, folderIds);
   });
 
   // ── Search ──

--- a/packages/server/src/services/import/marinara.importer.ts
+++ b/packages/server/src/services/import/marinara.importer.ts
@@ -136,7 +136,11 @@ async function importPersona(data: unknown, db: DB) {
 
 async function importLorebook(data: unknown, db: DB) {
   const storage = createLorebooksStorage(db);
-  const d = data as { lorebook?: Record<string, unknown>; entries?: Record<string, unknown>[] };
+  const d = data as {
+    lorebook?: Record<string, unknown>;
+    entries?: Record<string, unknown>[];
+    folders?: Record<string, unknown>[];
+  };
   if (!d?.lorebook) {
     return { success: false, type: "marinara_lorebook" as const, error: "Invalid lorebook data" };
   }
@@ -155,36 +159,68 @@ async function importLorebook(data: unknown, db: DB) {
     readTimestampOverrides(lb),
   )) as Record<string, unknown> | null;
 
+  // Re-create folders first so we can remap old folder IDs → new folder IDs
+  // before mapping entries. Older exports without `folders` simply skip this
+  // step and every entry lands at root.
+  const folderIdRemap = new Map<string, string>();
+  if (newLb && Array.isArray(d.folders) && d.folders.length > 0) {
+    for (const f of d.folders) {
+      const oldId = typeof f.id === "string" ? f.id : null;
+      const created = (await storage.createFolder(newLb.id as string, {
+        name: String(f.name ?? "Folder"),
+        enabled: f.enabled !== false,
+        parentFolderId: null, // v1 ignores nesting on import
+        order: Number(f.order ?? 0),
+      })) as Record<string, unknown> | null;
+      if (oldId && created?.id) folderIdRemap.set(oldId, created.id as string);
+    }
+  }
+
   if (newLb && Array.isArray(d.entries) && d.entries.length > 0) {
-    const entries = d.entries.map((e) => ({
-      name: String(e.name ?? ""),
-      content: String(e.content ?? ""),
-      keys: Array.isArray(e.keys) ? e.keys.map(String) : [],
-      secondaryKeys: Array.isArray(e.secondaryKeys) ? e.secondaryKeys.map(String) : [],
-      enabled: e.enabled !== false,
-      constant: Boolean(e.constant),
-      selective: Boolean(e.selective),
-      selectiveLogic: (e.selectiveLogic as any) ?? "and",
-      probability: e.probability != null ? Number(e.probability) : null,
-      scanDepth: e.scanDepth != null ? Number(e.scanDepth) : null,
-      matchWholeWords: Boolean(e.matchWholeWords),
-      caseSensitive: Boolean(e.caseSensitive),
-      useRegex: Boolean(e.useRegex),
-      position: Number(e.position ?? 0),
-      depth: Number(e.depth ?? 4),
-      order: Number(e.order ?? 100),
-      role: (e.role as any) ?? "system",
-      sticky: e.sticky != null ? Number(e.sticky) : null,
-      cooldown: e.cooldown != null ? Number(e.cooldown) : null,
-      delay: e.delay != null ? Number(e.delay) : null,
-      group: String(e.group ?? ""),
-      groupWeight: e.groupWeight != null ? Number(e.groupWeight) : null,
-      tag: String(e.tag ?? ""),
-      relationships: (e.relationships as any) ?? {},
-      dynamicState: (e.dynamicState as any) ?? {},
-      activationConditions: (e.activationConditions as any) ?? [],
-      schedule: (e.schedule as any) ?? null,
-    }));
+    const entries = d.entries.map((e) => {
+      const oldFolderId = typeof e.folderId === "string" ? e.folderId : null;
+      const newFolderId = oldFolderId ? (folderIdRemap.get(oldFolderId) ?? null) : null;
+      return {
+        name: String(e.name ?? ""),
+        content: String(e.content ?? ""),
+        // CodeRabbit-flagged: description, ephemeral, locked, and preventRecursion
+        // were absent from the previous map, so an exported lorebook would lose
+        // these fields on re-import. Knowledge-router matching uses description,
+        // ephemeral controls auto-disable countdown, locked protects entries
+        // from the Lorebook Keeper agent, and preventRecursion gates recursive
+        // scanning — all behaviors that should round-trip.
+        description: String(e.description ?? ""),
+        keys: Array.isArray(e.keys) ? e.keys.map(String) : [],
+        secondaryKeys: Array.isArray(e.secondaryKeys) ? e.secondaryKeys.map(String) : [],
+        enabled: e.enabled !== false,
+        constant: Boolean(e.constant),
+        selective: Boolean(e.selective),
+        selectiveLogic: (e.selectiveLogic as any) ?? "and",
+        probability: e.probability != null ? Number(e.probability) : null,
+        scanDepth: e.scanDepth != null ? Number(e.scanDepth) : null,
+        matchWholeWords: Boolean(e.matchWholeWords),
+        caseSensitive: Boolean(e.caseSensitive),
+        useRegex: Boolean(e.useRegex),
+        position: Number(e.position ?? 0),
+        depth: Number(e.depth ?? 4),
+        order: Number(e.order ?? 100),
+        role: (e.role as any) ?? "system",
+        sticky: e.sticky != null ? Number(e.sticky) : null,
+        cooldown: e.cooldown != null ? Number(e.cooldown) : null,
+        delay: e.delay != null ? Number(e.delay) : null,
+        ephemeral: e.ephemeral != null ? Number(e.ephemeral) : null,
+        group: String(e.group ?? ""),
+        groupWeight: e.groupWeight != null ? Number(e.groupWeight) : null,
+        folderId: newFolderId,
+        locked: Boolean(e.locked),
+        preventRecursion: Boolean(e.preventRecursion),
+        tag: String(e.tag ?? ""),
+        relationships: (e.relationships as any) ?? {},
+        dynamicState: (e.dynamicState as any) ?? {},
+        activationConditions: (e.activationConditions as any) ?? [],
+        schedule: (e.schedule as any) ?? null,
+      };
+    });
     await storage.bulkCreateEntries(newLb.id as string, entries);
   }
 

--- a/packages/server/src/services/storage/lorebooks.storage.ts
+++ b/packages/server/src/services/storage/lorebooks.storage.ts
@@ -1,15 +1,17 @@
 // ──────────────────────────────────────────────
 // Storage: Lorebooks
 // ──────────────────────────────────────────────
-import { eq, desc, and, like, inArray } from "drizzle-orm";
+import { eq, desc, and, like, inArray, asc } from "drizzle-orm";
 import type { DB } from "../../db/connection.js";
-import { lorebooks, lorebookEntries } from "../../db/schema/index.js";
+import { lorebooks, lorebookEntries, lorebookFolders } from "../../db/schema/index.js";
 import { newId, now } from "../../utils/id-generator.js";
 import type {
   CreateLorebookInput,
   UpdateLorebookInput,
   CreateLorebookEntryInput,
   UpdateLorebookEntryInput,
+  CreateLorebookFolderInput,
+  UpdateLorebookFolderInput,
 } from "@marinara-engine/shared";
 import { normalizeTimestampOverrides, type TimestampOverrides } from "../import/import-timestamps.js";
 
@@ -49,6 +51,7 @@ function parseEntryRow(row: Record<string, unknown>) {
     useRegex: row.useRegex === "true",
     locked: row.locked === "true",
     preventRecursion: row.preventRecursion === "true",
+    folderId: (row.folderId as string | null | undefined) ?? null,
     keys: JSON.parse((row.keys as string) || "[]"),
     secondaryKeys: JSON.parse((row.secondaryKeys as string) || "[]"),
     relationships: JSON.parse((row.relationships as string) || "{}"),
@@ -56,6 +59,14 @@ function parseEntryRow(row: Record<string, unknown>) {
     activationConditions: JSON.parse((row.activationConditions as string) || "[]"),
     schedule: row.schedule ? JSON.parse(row.schedule as string) : null,
     embedding: row.embedding ? JSON.parse(row.embedding as string) : null,
+  };
+}
+
+function parseFolderRow(row: Record<string, unknown>) {
+  return {
+    ...row,
+    enabled: row.enabled === "true",
+    parentFolderId: (row.parentFolderId as string | null | undefined) ?? null,
   };
 }
 
@@ -190,6 +201,12 @@ export function createLorebooksStorage(db: DB) {
      *  - Its `personaId` matches the chat's active persona
      *  - Its `chatId` matches the current chat
      * When no filters are provided, returns entries from ALL enabled lorebooks (legacy behavior).
+     *
+     * Folder gate: an entry whose `folderId` points at a disabled folder is
+     * excluded here, regardless of the entry's own `enabled` flag. The entry's
+     * own flag is preserved in the database — re-enabling the folder restores
+     * each entry's previous individual setting. Entries with a NULL `folderId`
+     * (root-level entries) are unaffected.
      */
     async listActiveEntries(filters?: {
       activeLorebookIds?: string[];
@@ -216,12 +233,24 @@ export function createLorebooksStorage(db: DB) {
 
       const bookIds = relevantBooks.map((b) => b.id);
       if (bookIds.length === 0) return [];
+
+      // Build the disabled-folder ID set for the relevant lorebooks. Done as
+      // an in-memory filter (rather than a SQL anti-join) because folder
+      // counts per book are small and this keeps the existing query shape.
+      const disabledFolderRows = await db
+        .select({ id: lorebookFolders.id })
+        .from(lorebookFolders)
+        .where(and(inArray(lorebookFolders.lorebookId, bookIds), eq(lorebookFolders.enabled, "false")));
+      const disabledFolderIds = new Set(disabledFolderRows.map((r) => r.id));
+
       const rows = await db
         .select()
         .from(lorebookEntries)
         .where(and(inArray(lorebookEntries.lorebookId, bookIds), eq(lorebookEntries.enabled, "true")))
         .orderBy(lorebookEntries.order);
-      return rows.map((r) => parseEntryRow(r as Record<string, unknown>));
+      const parsed = rows.map((r) => parseEntryRow(r as Record<string, unknown>));
+      if (disabledFolderIds.size === 0) return parsed;
+      return parsed.filter((e) => !e.folderId || !disabledFolderIds.has(e.folderId as string));
     },
 
     async getEntry(id: string) {
@@ -233,9 +262,25 @@ export function createLorebooksStorage(db: DB) {
     async createEntry(input: CreateLorebookEntryInput) {
       const id = newId();
       const timestamp = now();
+      // If a folderId is supplied, the folder must exist AND live in the same
+      // lorebook. Without this check, the route layer accepts any string and
+      // we'd silently create orphaned entries that disappear from the editor's
+      // grouped view and bypass the disabled-folder activation gate.
+      const requestedFolderId = input.folderId ?? null;
+      if (requestedFolderId !== null) {
+        const folderRows = await db
+          .select({ lorebookId: lorebookFolders.lorebookId })
+          .from(lorebookFolders)
+          .where(eq(lorebookFolders.id, requestedFolderId));
+        const folderRow = folderRows[0];
+        if (!folderRow || folderRow.lorebookId !== input.lorebookId) {
+          throw new Error("folderId does not belong to this lorebook");
+        }
+      }
       await db.insert(lorebookEntries).values({
         id,
         lorebookId: input.lorebookId,
+        folderId: requestedFolderId,
         name: input.name,
         content: input.content ?? "",
         description: input.description ?? "",
@@ -278,6 +323,30 @@ export function createLorebooksStorage(db: DB) {
       if (input.name !== undefined) updates.name = input.name;
       if (input.content !== undefined) updates.content = input.content;
       if (input.description !== undefined) updates.description = input.description;
+      if (input.folderId !== undefined) {
+        if (input.folderId !== null) {
+          // Resolve the entry's lorebook so we can check the folder belongs to
+          // the same lorebook. The route layer doesn't carry the lorebookId
+          // through the update payload, so we look it up here.
+          const entryRows = await db
+            .select({ lorebookId: lorebookEntries.lorebookId })
+            .from(lorebookEntries)
+            .where(eq(lorebookEntries.id, id));
+          const entryRow = entryRows[0];
+          if (!entryRow) {
+            throw new Error("entry not found");
+          }
+          const folderRows = await db
+            .select({ lorebookId: lorebookFolders.lorebookId })
+            .from(lorebookFolders)
+            .where(eq(lorebookFolders.id, input.folderId));
+          const folderRow = folderRows[0];
+          if (!folderRow || folderRow.lorebookId !== entryRow.lorebookId) {
+            throw new Error("folderId does not belong to this lorebook");
+          }
+        }
+        updates.folderId = input.folderId;
+      }
       if (input.keys !== undefined) updates.keys = JSON.stringify(input.keys);
       if (input.secondaryKeys !== undefined) updates.secondaryKeys = JSON.stringify(input.secondaryKeys);
       if (input.enabled !== undefined) updates.enabled = String(input.enabled);
@@ -330,18 +399,39 @@ export function createLorebooksStorage(db: DB) {
       return results;
     },
 
-    async reorderEntries(lorebookId: string, entryIds: string[]) {
-      const existingEntries = (await this.listEntries(lorebookId)).map((entry) => {
-        const row = entry as unknown as Record<string, unknown>;
-        return {
-          id: String(row.id),
-          order: typeof row.order === "number" ? row.order : Number(row.order ?? 0),
-        };
-      });
-      const orderById = new Map(existingEntries.map((entry) => [entry.id, entry.order]));
-      const existingIds = new Set(existingEntries.map((entry) => entry.id));
-      const orderedIds = entryIds.filter((id, index, ids) => existingIds.has(id) && ids.indexOf(id) === index);
-      const missingIds = existingEntries
+    /**
+     * Reorder entries inside a single container.
+     *
+     * `folderId` (undefined = legacy, null = root, string = inside that
+     * folder) scopes the reorder so that dragging within one container does
+     * not renumber entries in another. When `folderId` is undefined we keep
+     * the legacy behavior of renumbering every entry in the lorebook.
+     *
+     * Renumbering uses (index + 1) * 10 within the container, so each
+     * container's order space starts back at 10 — that's intentional and
+     * matches the user-facing "each folder is its own container" semantic
+     * (a folder at the top can hold high-Order entries without affecting
+     * root entries below it).
+     */
+    async reorderEntries(lorebookId: string, entryIds: string[], folderId?: string | null) {
+      const allEntries = (await this.listEntries(lorebookId)) as unknown as Array<Record<string, unknown>>;
+
+      const inScope =
+        folderId === undefined
+          ? allEntries
+          : allEntries.filter((row) => {
+              const rowFolder = (row.folderId as string | null | undefined) ?? null;
+              return rowFolder === folderId;
+            });
+
+      const scopeEntries = inScope.map((row) => ({
+        id: String(row.id),
+        order: typeof row.order === "number" ? row.order : Number(row.order ?? 0),
+      }));
+      const orderById = new Map(scopeEntries.map((entry) => [entry.id, entry.order]));
+      const scopeIds = new Set(scopeEntries.map((entry) => entry.id));
+      const orderedIds = entryIds.filter((id, index, ids) => scopeIds.has(id) && ids.indexOf(id) === index);
+      const missingIds = scopeEntries
         .map((entry) => entry.id)
         .filter((id) => !orderedIds.includes(id))
         .sort((leftId, rightId) => (orderById.get(leftId) ?? 0) - (orderById.get(rightId) ?? 0));
@@ -361,6 +451,127 @@ export function createLorebooksStorage(db: DB) {
     async removeEntry(id: string) {
       await db.delete(lorebookEntries).where(eq(lorebookEntries.id, id));
     },
+
+    // ── Folders ──
+
+    async listFolders(lorebookId: string) {
+      const rows = await db
+        .select()
+        .from(lorebookFolders)
+        .where(eq(lorebookFolders.lorebookId, lorebookId))
+        .orderBy(asc(lorebookFolders.order));
+      return rows.map((r) => parseFolderRow(r as Record<string, unknown>));
+    },
+
+    /**
+     * Look up a folder. When `lorebookId` is provided, the lookup is also
+     * scoped to that lorebook — needed because the route layer accepts both
+     * `:id` (lorebook) and `:folderId` and the two should always agree.
+     * Without this scope, `/lorebooks/A/folders/B` would happily return a
+     * folder belonging to lorebook `X`.
+     */
+    async getFolder(folderId: string, lorebookId?: string) {
+      const conditions = lorebookId
+        ? and(eq(lorebookFolders.id, folderId), eq(lorebookFolders.lorebookId, lorebookId))
+        : eq(lorebookFolders.id, folderId);
+      const rows = await db.select().from(lorebookFolders).where(conditions);
+      const row = rows[0];
+      return row ? parseFolderRow(row as Record<string, unknown>) : null;
+    },
+
+    async createFolder(lorebookId: string, input: CreateLorebookFolderInput) {
+      const id = newId();
+      const timestamp = now();
+      // If the caller didn't pass an explicit order, append after existing folders
+      // so the new one shows up at the bottom of the folder block by default.
+      let order = input.order ?? 0;
+      if (input.order === undefined || input.order === 0) {
+        const existing = await db
+          .select({ order: lorebookFolders.order })
+          .from(lorebookFolders)
+          .where(eq(lorebookFolders.lorebookId, lorebookId));
+        if (existing.length > 0) {
+          order = Math.max(...existing.map((r) => r.order ?? 0)) + 10;
+        } else {
+          order = 10;
+        }
+      }
+      await db.insert(lorebookFolders).values({
+        id,
+        lorebookId,
+        name: input.name,
+        enabled: String(input.enabled ?? true),
+        // v1 ignores any non-null parentFolderId — caller is the route layer.
+        parentFolderId: input.parentFolderId ?? null,
+        order,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      });
+      return this.getFolder(id, lorebookId);
+    },
+
+    /**
+     * Update a folder. `lorebookId` is required so a malicious or buggy
+     * caller can't reach folders in a different lorebook by guessing the
+     * folder ID; the WHERE clause requires both to match.
+     */
+    async updateFolder(folderId: string, input: UpdateLorebookFolderInput, lorebookId?: string) {
+      const updates: Record<string, unknown> = { updatedAt: now() };
+      if (input.name !== undefined) updates.name = input.name;
+      if (input.enabled !== undefined) updates.enabled = String(input.enabled);
+      if (input.parentFolderId !== undefined) updates.parentFolderId = input.parentFolderId;
+      if (input.order !== undefined) updates.order = input.order;
+      const whereClause = lorebookId
+        ? and(eq(lorebookFolders.id, folderId), eq(lorebookFolders.lorebookId, lorebookId))
+        : eq(lorebookFolders.id, folderId);
+      await db.update(lorebookFolders).set(updates).where(whereClause);
+      return this.getFolder(folderId, lorebookId);
+    },
+
+    /**
+     * Remove a folder. Entries inside the folder are NOT deleted — their
+     * `folderId` is reset to NULL (root level) so the user doesn't lose
+     * data when they remove a folder by accident.
+     *
+     * `lorebookId` scopes the lookup so a request to
+     * `/lorebooks/A/folders/B` cannot reach a folder belonging to lorebook
+     * `X` and accidentally reparent that other lorebook's entries.
+     */
+    async removeFolder(folderId: string, lorebookId?: string) {
+      const folder = (await this.getFolder(folderId, lorebookId)) as Record<string, unknown> | null;
+      if (!folder) return;
+      const ownerLorebookId = folder.lorebookId as string;
+      await db
+        .update(lorebookEntries)
+        .set({ folderId: null, updatedAt: now() })
+        .where(and(eq(lorebookEntries.lorebookId, ownerLorebookId), eq(lorebookEntries.folderId, folderId)));
+      await db
+        .delete(lorebookFolders)
+        .where(and(eq(lorebookFolders.id, folderId), eq(lorebookFolders.lorebookId, ownerLorebookId)));
+    },
+
+    /** Renumber folders within a lorebook to match `folderIds` left-to-right. */
+    async reorderFolders(lorebookId: string, folderIds: string[]) {
+      const existing = (await this.listFolders(lorebookId)) as unknown as Array<{ id: string; order: number }>;
+      const orderById = new Map(existing.map((f) => [f.id, f.order]));
+      const existingIds = new Set(existing.map((f) => f.id));
+      const orderedIds = folderIds.filter((id, index, ids) => existingIds.has(id) && ids.indexOf(id) === index);
+      const missingIds = existing
+        .map((f) => f.id)
+        .filter((id) => !orderedIds.includes(id))
+        .sort((a, b) => (orderById.get(a) ?? 0) - (orderById.get(b) ?? 0));
+      const nextIds = [...orderedIds, ...missingIds];
+      const timestamp = now();
+      for (const [index, id] of nextIds.entries()) {
+        await db
+          .update(lorebookFolders)
+          .set({ order: (index + 1) * 10, updatedAt: timestamp })
+          .where(and(eq(lorebookFolders.id, id), eq(lorebookFolders.lorebookId, lorebookId)));
+      }
+      return this.listFolders(lorebookId);
+    },
+
+    // ── Search ──
 
     /** Search entries by keyword match in name/content/keys. */
     async searchEntries(query: string) {

--- a/packages/shared/src/schemas/lorebook.schema.ts
+++ b/packages/shared/src/schemas/lorebook.schema.ts
@@ -19,6 +19,26 @@ export const lorebookScheduleSchema = z.object({
   activeLocations: z.array(z.string()).default([]),
 });
 
+// ──────────────────────────────────────────────
+// Folders — collapsible containers for entries
+// `parentFolderId` is reserved for a future nested-folder PR; v1 enforces
+// `null` at the route layer so the schema accepts the field but the server
+// rejects non-null values.
+// ──────────────────────────────────────────────
+export const createLorebookFolderSchema = z.object({
+  name: z.string().min(1).max(200),
+  enabled: z.boolean().default(true),
+  parentFolderId: z.string().nullable().default(null),
+  order: z.number().int().default(0),
+});
+
+export const updateLorebookFolderSchema = z.object({
+  name: z.string().min(1).max(200).optional(),
+  enabled: z.boolean().optional(),
+  parentFolderId: z.string().nullable().optional(),
+  order: z.number().int().optional(),
+});
+
 export const createLorebookSchema = z.object({
   name: z.string().min(1).max(200),
   description: z.string().default(""),
@@ -79,6 +99,8 @@ export const createLorebookEntrySchema = z.object({
   ephemeral: z.number().int().min(0).nullable().default(null),
   group: z.string().default(""),
   groupWeight: z.number().nullable().default(null),
+  /** Optional folder this entry belongs to. Null/omitted = root level. */
+  folderId: z.string().nullable().default(null),
   preventRecursion: z.boolean().default(false),
   locked: z.boolean().default(false),
   tag: z.string().default(""),
@@ -113,6 +135,7 @@ export const updateLorebookEntrySchema = z.object({
   ephemeral: z.number().int().min(0).nullable().optional(),
   group: z.string().optional(),
   groupWeight: z.number().nullable().optional(),
+  folderId: z.string().nullable().optional(),
   preventRecursion: z.boolean().optional(),
   locked: z.boolean().optional(),
   tag: z.string().optional(),
@@ -126,3 +149,5 @@ export type CreateLorebookInput = z.input<typeof createLorebookSchema>;
 export type UpdateLorebookInput = z.infer<typeof updateLorebookSchema>;
 export type CreateLorebookEntryInput = z.input<typeof createLorebookEntrySchema>;
 export type UpdateLorebookEntryInput = z.infer<typeof updateLorebookEntrySchema>;
+export type CreateLorebookFolderInput = z.input<typeof createLorebookFolderSchema>;
+export type UpdateLorebookFolderInput = z.infer<typeof updateLorebookFolderSchema>;

--- a/packages/shared/src/types/lorebook.ts
+++ b/packages/shared/src/types/lorebook.ts
@@ -42,6 +42,42 @@ export interface Lorebook {
   updatedAt: string;
 }
 
+/**
+ * A collapsible container that groups lorebook entries to reduce visual
+ * clutter in the editor. Folders are flat in v1 — `parentFolderId` is reserved
+ * for future nested-folder support and must currently be null.
+ *
+ * Folder enable/disable acts as a gate: when `enabled` is false, every entry
+ * inside the folder is treated as inactive at activation time, regardless of
+ * the entry's own `enabled` flag. The entry's own flag is preserved (the
+ * folder toggle does NOT mutate it), so re-enabling the folder restores the
+ * entries' previous individual settings.
+ *
+ * Folders sit above root-level entries in the editor display. Folder display
+ * order among siblings is controlled by `order`. Entry `order` continues to
+ * control prompt-injection priority and per-container display sort.
+ */
+export interface LorebookFolder {
+  id: string;
+  lorebookId: string;
+  /** Display name shown on the folder header row. */
+  name: string;
+  /**
+   * When false, every entry whose `folderId` matches this folder is skipped
+   * during activation, regardless of the entry's own `enabled` flag.
+   */
+  enabled: boolean;
+  /**
+   * Reserved for future nested-folder support. Always null in v1; the server
+   * rejects non-null values.
+   */
+  parentFolderId: string | null;
+  /** Display order among sibling folders (lower = higher in the list). */
+  order: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
 /** A single lorebook entry. */
 export interface LorebookEntry {
   id: string;
@@ -92,6 +128,14 @@ export interface LorebookEntry {
   // ── Grouping ──
   group: string;
   groupWeight: number | null;
+  /**
+   * ID of the folder this entry belongs to, or null if it lives at the
+   * lorebook root level. Display sort by `order` is per-container — entries
+   * inside a folder sort independently from root entries and from entries in
+   * other folders. When a folder is disabled, every entry whose `folderId`
+   * matches is excluded from activation regardless of `enabled`.
+   */
+  folderId: string | null;
 
   // ── Engine extensions (beyond ST) ──
   /** When true, the Lorebook Keeper agent cannot modify or overwrite this entry */


### PR DESCRIPTION
## Linked issue

Closes #380

## Why this change

- Large lorebooks can become difficult to navigate when long-lived or agent-managed entries sit in one vertical list.
- Users need a way to organize entries into named groups, collapse stable entries out of view, and disable a whole group without losing each entry's own enabled state.
- The feature should preserve existing inline lorebook editing while adding folder organization on top of it.

## What changed

- Added flat lorebook folders with persisted enable state, UI-only collapse state, ordering, rename, delete, and folder-level entry gating.
- Added folder CRUD, reorder, export/import support, schema/types, and route handling for `folderId` on lorebook entries.
- Updated the Lorebook editor to render folders plus root entries when sorting by Order with no active search, while falling back to the existing flat list for search and non-Order sorts.
- Added entry folder pickers and drag-and-drop movement between root and folders, including empty-folder and empty-root drop zones.
- Added folder-aware active-entry filtering so disabled folders exclude their contained entries without mutating the entries' individual enabled flags.

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Ran `pnpm check` against the PR merged onto latest `main`; lint and production build completed successfully.
- CI `container-build-test` passed on the PR.
- Contributor verified opening an existing lorebook, adding/renaming/collapsing/enabling/disabling/deleting folders, and preserving entry state while gating disabled folders.
- Contributor verified moving entries with folder dropdowns and drag-and-drop: root to folder, folder to folder, and folder back to root.
- Contributor verified search and non-Order sorts fall back to a flat entry list with the folder-view-paused hint.
- Contributor verified light mode, dark mode, mobile viewport behavior, empty folders, empty lorebooks, and export/import of lorebooks with folders.
- AI lorebook maker/keeper was not manually exercised; entries default to root through the shared `folderId: null` behavior.

## Docs and release impact

- [ ] No docs changes needed
- [x] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

Dark mode:

<img width="2549" height="1259" alt="Lorebook folders in dark mode" src="https://github.com/user-attachments/assets/8e0ba438-5c6b-4887-8d1e-b91ab6e7ffc6" />

Light mode:

<img width="2533" height="1201" alt="Lorebook folders in light mode" src="https://github.com/user-attachments/assets/ee1d7570-d436-4970-a394-fe68107c9187" />

Mobile:

<img width="1262" height="1425" alt="Lorebook folders on mobile" src="https://github.com/user-attachments/assets/1154aa53-d59e-425b-9747-df277bfb781f" />

## Known limitations

- Folder nesting is intentionally not implemented in this PR. `parentFolderId` is reserved as `null` so a follow-up can add nesting without another migration; the route layer rejects non-null values for now.
- Drag-and-drop is disabled while search or non-Order sorting is active, matching previous ordering behavior. Folder dropdown movement remains available.
- Entry order values can accumulate gaps across containers over time; this is harmless and gets renumbered within a container on the next drag reorder.
