### PR TITLE
fix: auto-migrate lorebook folders on startup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md
+
+This file is a thin maintainer note for contributors using Codex. Canonical workflow, validation, and release guidance lives in `CONTRIBUTING.md`.
+
+## Preferred Workflow
+
+- Start with `pnpm install`.
+- Run `pnpm check` as the baseline validation command.
+- Run `pnpm db:push` when server or database changes need schema verification.
+- Run `pnpm version:check` when you touch release metadata, version-bearing files, or README release references.
+
+## Repo-Specific Cautions
+
+- Keep edits non-destructive. Do not revert unrelated work in the tree.
+- Prefer focused patches that keep code, docs, and release metadata aligned in the same change.
+- When preparing a PR, make the why explicit in the description so reviewers can see the user problem or rationale, not just the file changes.
+- Check `README.md`, `android/README.md`, `CONTRIBUTING.md`, `CHANGELOG.md`, `docs/CONFIGURATION.md`, `docs/TROUBLESHOOTING.md`, and `docs/FAQ.md` together when install, update, or release behavior changes.
+
+## AI-Generated Pull Request
+
+- **Never auto-check validation or test-plan checkboxes in a PR.** Those boxes are a to-do list for the human contributor, not evidence that work is done. If you generate a test plan, leave every box unchecked.
+- When preparing a PR description, list what needs manual verification clearly and explicitly. Write entries like "Manually verify X in browser" rather than "Works correctly."
+- If there is no linked issue or feature request, note that one should be opened before the PR is submitted. See `CONTRIBUTING.md § Before You Open a Pull Request`.
+
+## Version Truth
+
+- Canonical version: root `package.json`
+- Release tag format: `vX.Y.Z`
+- Release-notes source: `CHANGELOG.md`
+- Derived version files that must stay in sync:
+  - `packages/client/package.json`
+  - `packages/server/package.json`
+  - `packages/shared/package.json`
+  - `packages/shared/src/constants/defaults.ts`
+  - `win/installer/installer.nsi`
+  - `win/installer/install.bat`
+  - `android/app/build.gradle`
+
+Android-specific rule:
+
+- `versionName` matches the app version.
+- `versionCode` increments for every shipped APK.
+
+## Safe Multi-File Updates
+
+- When changing version numbers, bump root `package.json` first, then run `pnpm version:sync -- --android-version-code <next-code>`.
+- Run `pnpm version:check` before tagging or publishing.
+- Keep `CONTRIBUTING.md` authoritative. Add Codex-specific notes here only when they are operationally useful and not already covered there.
+
+## Logging
+
+- **Never use `console.log/warn/error` in server code.** Always import the shared Pino logger:
+  ```ts
+  import { logger } from "../lib/logger.js"; // adjust relative path
+  ```
+- Use the correct level: `logger.error` for failures, `logger.warn` for non-fatal issues, `logger.info` for operational milestones, `logger.debug` for verbose traces (prompts, timing, state patches).
+- Use Pino format specifiers for multi-arg calls: `logger.info("Resolved %d agents", count)` — not `logger.info("Resolved agents:", count)`.
+- Log errors with the error object first: `logger.error(err, "Import failed")`.
+- Client code (`packages/client/`) should keep using `console.*` — the browser has no Pino, and production builds strip `console.log` automatically.
+- See `CONTRIBUTING.md § Logging` for full guidelines and `docs/CONFIGURATION.md § Logging Levels` for the user-facing reference.
+
+## Frontend Changes
+
+- **Read `packages/client/.instructions.md` before editing any client code.** It is the authoritative reference for architecture, patterns, conventions, and common-mistake avoidance.
+- Validate with `pnpm check` (TypeScript + ESLint). There is no automated test suite.

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -104,9 +104,20 @@ const CREATE_TABLES: string[] = [
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL
   )`,
+  `CREATE TABLE IF NOT EXISTS lorebook_folders (
+    id TEXT PRIMARY KEY NOT NULL,
+    lorebook_id TEXT NOT NULL REFERENCES lorebooks(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    enabled TEXT NOT NULL DEFAULT 'true',
+    parent_folder_id TEXT,
+    "order" INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+  )`,
   `CREATE TABLE IF NOT EXISTS lorebook_entries (
     id TEXT PRIMARY KEY NOT NULL,
     lorebook_id TEXT NOT NULL REFERENCES lorebooks(id) ON DELETE CASCADE,
+    folder_id TEXT,
     name TEXT NOT NULL,
     content TEXT NOT NULL DEFAULT '',
     description TEXT NOT NULL DEFAULT '',
@@ -558,6 +569,11 @@ const COLUMN_MIGRATIONS: ColumnMigration[] = [
     table: "lorebook_entries",
     column: "description",
     definition: "TEXT NOT NULL DEFAULT ''",
+  },
+  {
+    table: "lorebook_entries",
+    column: "folder_id",
+    definition: "TEXT",
   },
 ];
 

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -577,6 +577,10 @@ const COLUMN_MIGRATIONS: ColumnMigration[] = [
   },
 ];
 
+/**
+ * Applies idempotent SQLite schema repairs on startup so upgraded installs can
+ * use the current Drizzle schema before any routes or seeders touch the DB.
+ */
 export async function runMigrations(db: DB) {
   // 1. Create all tables if they don't exist
   for (const stmt of CREATE_TABLES) {

--- a/packages/server/test/db-migrations.test.ts
+++ b/packages/server/test/db-migrations.test.ts
@@ -1,0 +1,83 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createClient } from "@libsql/client";
+import { drizzle } from "drizzle-orm/libsql";
+import { sql } from "drizzle-orm";
+import { runMigrations } from "../src/db/migrate.js";
+import type { DB } from "../src/db/connection.js";
+
+test("startup migrations add lorebook folders schema to existing installs", async () => {
+  const client = createClient({ url: "file::memory:" });
+  const db = drizzle(client) as unknown as DB;
+
+  try {
+    await db.run(
+      sql.raw(`CREATE TABLE lorebooks (
+        id TEXT PRIMARY KEY NOT NULL,
+        name TEXT NOT NULL,
+        description TEXT NOT NULL DEFAULT '',
+        category TEXT NOT NULL DEFAULT 'uncategorized',
+        scan_depth INTEGER NOT NULL DEFAULT 2,
+        token_budget INTEGER NOT NULL DEFAULT 2048,
+        recursive_scanning TEXT NOT NULL DEFAULT 'false',
+        character_id TEXT,
+        persona_id TEXT,
+        chat_id TEXT,
+        enabled TEXT NOT NULL DEFAULT 'true',
+        generated_by TEXT,
+        source_agent_id TEXT,
+        tags TEXT NOT NULL DEFAULT '[]',
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      )`),
+    );
+    await db.run(
+      sql.raw(`CREATE TABLE lorebook_entries (
+        id TEXT PRIMARY KEY NOT NULL,
+        lorebook_id TEXT NOT NULL REFERENCES lorebooks(id) ON DELETE CASCADE,
+        name TEXT NOT NULL,
+        content TEXT NOT NULL DEFAULT '',
+        keys TEXT NOT NULL DEFAULT '[]',
+        secondary_keys TEXT NOT NULL DEFAULT '[]',
+        enabled TEXT NOT NULL DEFAULT 'true',
+        constant TEXT NOT NULL DEFAULT 'false',
+        selective TEXT NOT NULL DEFAULT 'false',
+        selective_logic TEXT NOT NULL DEFAULT 'and',
+        probability INTEGER,
+        scan_depth INTEGER,
+        match_whole_words TEXT NOT NULL DEFAULT 'false',
+        case_sensitive TEXT NOT NULL DEFAULT 'false',
+        use_regex TEXT NOT NULL DEFAULT 'false',
+        position INTEGER NOT NULL DEFAULT 0,
+        depth INTEGER NOT NULL DEFAULT 4,
+        "order" INTEGER NOT NULL DEFAULT 100,
+        role TEXT NOT NULL DEFAULT 'system',
+        sticky INTEGER,
+        cooldown INTEGER,
+        delay INTEGER,
+        "group" TEXT NOT NULL DEFAULT '',
+        group_weight INTEGER,
+        tag TEXT NOT NULL DEFAULT '',
+        relationships TEXT NOT NULL DEFAULT '{}',
+        dynamic_state TEXT NOT NULL DEFAULT '{}',
+        activation_conditions TEXT NOT NULL DEFAULT '[]',
+        schedule TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      )`),
+    );
+
+    await runMigrations(db);
+    await runMigrations(db);
+
+    const folderTables = await db.all<{ name: string }>(
+      sql.raw(`SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'lorebook_folders'`),
+    );
+    const entryColumns = await db.all<{ name: string }>(sql.raw("PRAGMA table_info(lorebook_entries)"));
+
+    assert.equal(folderTables.length, 1);
+    assert.ok(entryColumns.some((column) => column.name === "folder_id"));
+  } finally {
+    client.close();
+  }
+});

--- a/packages/server/test/db-migrations.test.ts
+++ b/packages/server/test/db-migrations.test.ts
@@ -66,6 +66,28 @@ test("startup migrations add lorebook folders schema to existing installs", asyn
         updated_at TEXT NOT NULL
       )`),
     );
+    await db.run(
+      sql.raw(`INSERT INTO lorebooks (
+        id, name, description, category, scan_depth, token_budget, recursive_scanning,
+        character_id, persona_id, chat_id, enabled, generated_by, source_agent_id, tags, created_at, updated_at
+      ) VALUES (
+        'legacy-book', 'Legacy Lorebook', '', 'uncategorized', 2, 2048, 'false',
+        NULL, NULL, NULL, 'true', NULL, NULL, '[]', '2026-01-01T00:00:00.000Z', '2026-01-01T00:00:00.000Z'
+      )`),
+    );
+    await db.run(
+      sql.raw(`INSERT INTO lorebook_entries (
+        id, lorebook_id, name, content, keys, secondary_keys, enabled, constant, selective, selective_logic,
+        probability, scan_depth, match_whole_words, case_sensitive, use_regex, position, depth, "order", role,
+        sticky, cooldown, delay, "group", group_weight, tag, relationships, dynamic_state, activation_conditions,
+        schedule, created_at, updated_at
+      ) VALUES (
+        'legacy-entry', 'legacy-book', 'Legacy Entry', 'Survives migration', '[]', '[]', 'true', 'false',
+        'false', 'and', NULL, NULL, 'false', 'false', 'false', 0, 4, 100, 'system',
+        NULL, NULL, NULL, '', NULL, '', '{}', '{}', '[]',
+        NULL, '2026-01-01T00:00:00.000Z', '2026-01-01T00:00:00.000Z'
+      )`),
+    );
 
     await runMigrations(db);
     await runMigrations(db);
@@ -74,9 +96,13 @@ test("startup migrations add lorebook folders schema to existing installs", asyn
       sql.raw(`SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'lorebook_folders'`),
     );
     const entryColumns = await db.all<{ name: string }>(sql.raw("PRAGMA table_info(lorebook_entries)"));
+    const preservedEntries = await db.all<{ id: string; folder_id: string | null }>(
+      sql.raw(`SELECT id, folder_id FROM lorebook_entries WHERE id = 'legacy-entry'`),
+    );
 
     assert.equal(folderTables.length, 1);
     assert.ok(entryColumns.some((column) => column.name === "folder_id"));
+    assert.deepEqual(preservedEntries, [{ id: "legacy-entry", folder_id: null }]);
   } finally {
     client.close();
   }


### PR DESCRIPTION
## Summary
- Add missing startup migration support for the `lorebook_folders` table.
- Add the missing `lorebook_entries.folder_id` startup migration for existing installs.
- Add a regression test that simulates upgrading a pre-folder lorebook database and verifies legacy rows survive both migration runs.
- Include the repo `AGENTS.md` maintainer instructions.

## Why
Existing installs can hit `no such table: lorebook_folders` after updating, which breaks lorebook UI/API flows unless users manually run database commands. This makes the migration seamless during normal app startup.

## Linked Issue
No linked issue exists yet. Per `CONTRIBUTING.md`, one should be opened before this PR is submitted/merged; this PR is based on live user reports of upgraded installs failing with `no such table: lorebook_folders`.

## Test Plan
- [ ] Review the startup migration SQL for parity with the Drizzle schema.
- [ ] Manually verify an existing install with lorebooks starts without `no such table: lorebook_folders`.
- [ ] Manually verify pre-existing lorebook entries remain visible after upgrade.
- [ ] Manually verify creating, toggling, reordering, and deleting lorebook folders in browser.

## Manual Verification Notes
Manual app/browser verification is still needed before merge. Recommended flow: start from an install/database created before lorebook folders existed, update to this branch, launch normally, open the lorebooks panel, confirm existing entries render, then create/toggle/delete a folder and refresh.

## Automated Validation Run Locally
- `pnpm --filter @marinara-engine/server exec tsx --test test/db-migrations.test.ts`
- Disposable DB schema check: `drizzle-kit push --force` against a throwaway SQLite file
- `pnpm check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a migration test ensuring startup migrations create new folder structures and safely run twice on existing databases

* **Chores**
  * Updated database schema to add lorebook folder support and a folder identifier for entries
  * Added contributor guidance documenting workflow, validation steps, PR hygiene, and logging conventions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->