### PR TITLE
Termux "no such table: lorebook_folders" fix

### DIFF
--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -104,6 +104,16 @@ const CREATE_TABLES: string[] = [
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL
   )`,
+  `CREATE TABLE IF NOT EXISTS lorebook_folders (
+    id TEXT PRIMARY KEY NOT NULL,
+    lorebook_id TEXT NOT NULL REFERENCES lorebooks(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    enabled TEXT NOT NULL DEFAULT 'true',
+    parent_folder_id TEXT,
+    "order" INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+  )`,
   `CREATE TABLE IF NOT EXISTS lorebook_entries (
     id TEXT PRIMARY KEY NOT NULL,
     lorebook_id TEXT NOT NULL REFERENCES lorebooks(id) ON DELETE CASCADE,
@@ -558,6 +568,14 @@ const COLUMN_MIGRATIONS: ColumnMigration[] = [
     table: "lorebook_entries",
     column: "description",
     definition: "TEXT NOT NULL DEFAULT ''",
+  },
+  {
+    // Folder grouping. Nullable — entries with a NULL folder_id live at the
+    // lorebook root level. Not enforced as a foreign key in SQLite so folder
+    // deletion can simply set this back to NULL without cascade hassle.
+    table: "lorebook_entries",
+    column: "folder_id",
+    definition: "TEXT",
   },
 ];
 


### PR DESCRIPTION
Termux "no such table: lorebook_folders" fix

## Linked issue

Closes #383 

## Why this change

- Should fix this issue Termux users are receiving upon pulling this fix, rebuilding ME, and restarting.

## What changed

- Modified `packages/server/src/db/migrate.ts`

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

## Docs and release impact

- [x] No docs changes needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database schema migrations to support additional data fields for enhanced system flexibility and data management capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->