### PR TITLE
feat(assistant): warn users that Mari can edit characters and personas

### DIFF
--- a/packages/client/src/components/chat/ChatInput.tsx
+++ b/packages/client/src/components/chat/ChatInput.tsx
@@ -26,6 +26,7 @@ import { QuickConnectionSwitcher } from "./QuickConnectionSwitcher";
 import { QuickPersonaSwitcher } from "./QuickPersonaSwitcher";
 import { QuickSwitcherMobile } from "./QuickSwitcherMobile";
 import { MariThinkingIndicator } from "./MariThinkingIndicator";
+import { MariCapabilityNotice } from "./MariCapabilityNotice";
 import { SlashCommandFeedback } from "./SlashCommandFeedback";
 
 interface Attachment {
@@ -658,7 +659,8 @@ export const ChatInput = memo(function ChatInput({
         </div>
       )}
 
-      {/* Mari command-execution indicator */}
+      {/* Mari capability + thinking indicators */}
+      <MariCapabilityNotice />
       <MariThinkingIndicator />
 
       {/* Main input container */}

--- a/packages/client/src/components/chat/ConversationInput.tsx
+++ b/packages/client/src/components/chat/ConversationInput.tsx
@@ -26,6 +26,7 @@ import { QuickSwitcherMobile } from "./QuickSwitcherMobile";
 import { EmojiPicker } from "../ui/EmojiPicker";
 import { GifPicker } from "../ui/GifPicker";
 import { MariThinkingIndicator } from "./MariThinkingIndicator";
+import { MariCapabilityNotice } from "./MariCapabilityNotice";
 import { SlashCommandFeedback } from "./SlashCommandFeedback";
 
 interface Attachment {
@@ -757,7 +758,8 @@ export function ConversationInput({
         </div>
       )}
 
-      {/* Mari command-execution indicator */}
+      {/* Mari capability + thinking indicators */}
+      <MariCapabilityNotice />
       <MariThinkingIndicator />
 
       {/* Input bar */}

--- a/packages/client/src/components/chat/MariCapabilityNotice.tsx
+++ b/packages/client/src/components/chat/MariCapabilityNotice.tsx
@@ -1,0 +1,89 @@
+// ──────────────────────────────────────────────
+// Chat: Mari Capability Notice
+// ──────────────────────────────────────────────
+// One-time warning shown above the input bar in any chat where Professor
+// Mari is a participant. Tells the user that her [update_character] /
+// [update_persona] commands write straight to the library with no preview
+// and no undo, so they should back up cards before asking her to edit
+// existing ones. Dismissal persists in localStorage so the warning shows
+// at most once across all of the user's Mari chats.
+import { memo, useMemo, useState, useEffect } from "react";
+import { AlertTriangle, X } from "lucide-react";
+import { PROFESSOR_MARI_ID } from "@marinara-engine/shared";
+import { useChatStore } from "../../stores/chat.store";
+import { useChat } from "../../hooks/use-chats";
+
+const STORAGE_KEY = "mari-capability-notice-dismissed-v1";
+
+function isMariParticipant(activeChat: unknown): boolean {
+  const raw = (activeChat as { characterIds?: unknown } | null | undefined)?.characterIds;
+  if (Array.isArray(raw)) return raw.includes(PROFESSOR_MARI_ID);
+  if (typeof raw === "string") {
+    try {
+      const parsed = JSON.parse(raw);
+      return Array.isArray(parsed) && parsed.includes(PROFESSOR_MARI_ID);
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
+
+export const MariCapabilityNotice = memo(function MariCapabilityNotice() {
+  const activeChatId = useChatStore((s) => s.activeChatId);
+  const { data: activeChat } = useChat(activeChatId);
+  const isMariChat = useMemo(() => isMariParticipant(activeChat), [activeChat]);
+
+  const [dismissed, setDismissed] = useState<boolean>(() => {
+    try {
+      return localStorage.getItem(STORAGE_KEY) === "true";
+    } catch {
+      return false;
+    }
+  });
+
+  // Re-check storage when navigating into a Mari chat — covers other tabs
+  // dismissing it while this one was open.
+  useEffect(() => {
+    if (!isMariChat) return;
+    try {
+      if (localStorage.getItem(STORAGE_KEY) === "true") setDismissed(true);
+    } catch {
+      /* private mode / disabled storage — fall back to in-memory state */
+    }
+  }, [isMariChat]);
+
+  if (!isMariChat || dismissed) return null;
+
+  const handleDismiss = () => {
+    setDismissed(true);
+    try {
+      localStorage.setItem(STORAGE_KEY, "true");
+    } catch {
+      /* non-fatal */
+    }
+  };
+
+  return (
+    <div
+      role="note"
+      className="mb-2 flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-[var(--foreground)]"
+    >
+      <AlertTriangle size="0.875rem" className="mt-0.5 shrink-0 text-amber-500" />
+      <p className="flex-1 leading-relaxed">
+        Mari can edit your characters and personas directly when you ask her to update them. Character edits keep a
+        recoverable version snapshot you can roll back to from the character's history.{" "}
+        <strong className="font-semibold">Persona edits overwrite without a snapshot — back up the persona first</strong>{" "}
+        if you want to keep the old version.
+      </p>
+      <button
+        type="button"
+        onClick={handleDismiss}
+        aria-label="Dismiss notice"
+        className="shrink-0 rounded-md p-1 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+      >
+        <X size="0.75rem" />
+      </button>
+    </div>
+  );
+});

--- a/packages/client/src/components/onboarding/OnboardingTutorial.tsx
+++ b/packages/client/src/components/onboarding/OnboardingTutorial.tsx
@@ -65,7 +65,7 @@ const STEPS: TourStep[] = [
   {
     target: null,
     title: "Meet Professor Mari!",
-    body: "That's me! I'm your built-in assistant. I come pre-installed and I'm always here to help. You can message me anytime to ask questions about the app, and I can even **do things for you:** like create characters, personas, start new chats, and navigate the app.\n\nI've set up a chat with me in the Chats sidebar already. Feel free to ask me anything after the tour!",
+    body: "That's me! I'm your built-in assistant. I come pre-installed and I'm always here to help. You can message me anytime to ask questions about the app, and I can even **do things for you:** like create characters, personas, start new chats, and navigate the app.\n\n**Heads up:** when you ask me to update or edit a character or persona, I write directly to your library. Character edits keep a recoverable version snapshot you can roll back to from that character's history, but **persona edits overwrite without a snapshot — back up the persona first** if you want to keep the old version.\n\nI've set up a chat with me in the Chats sidebar already. Feel free to ask me anything after the tour!",
     sprite: { src: "/sprites/mari/Mari_greet.png" },
   },
   {

--- a/packages/server/src/db/seed-mari.ts
+++ b/packages/server/src/db/seed-mari.ts
@@ -52,6 +52,8 @@ When asked about a character or persona, refer to the <available_characters> and
 
 I'm Mari, your built-in assistant. I can help you get set up, show you around, or do things for you. Like creating characters, personas, starting new chats, and more! Or, I can tell you "skill issue" if you mess up, that comes as a free bonus.
 
+⚠️ **One thing to know up front:** when you ask me to *update* or *edit* a character or persona, I write straight to your library. Character edits keep a recoverable version snapshot you can roll back to from that character's history, but **persona edits overwrite without a snapshot — back up the persona first** if you want to keep the old version. Creating new things is always safe; only edits overwrite.
+
 New here? What would you like to do? Here are some ideas:
 - 🎭 **Create a persona** (that's you, or at least, the version you'd wish you could become)
 - ✨ **Create a new character** to chat with (your waifu or husbandu, those who simp for morally questionable scientists aren't too judgmental in that regard).


### PR DESCRIPTION
## Why this change

Professor Mari (the built-in assistant) executes `[update_character]` and `[update_persona]` commands as soon as the user asks her to edit something — no preview, no confirmation prompt. There is asymmetric data-loss risk between the two paths:

- `update_character` calls `chars.update(...)` with `versionSource: \"command\"`, which creates a recoverable version snapshot before overwriting the active card (`packages/server/src/services/storage/characters.storage.ts:128-139`). The user can roll back from the character's version history.
- `updatePersona` (`characters.storage.ts:309-343`) just writes the new fields straight to the personas table. **No snapshot, no rollback path.** This is the case users actually hit when they lose data.

Audited Mari's full command surface (`packages/server/src/services/conversation/character-commands.ts:209-215` + handlers in `packages/server/src/routes/generate.routes.ts:7651-7806`) to confirm the warning copy is accurate. Mari can:
- Create personas / characters / chats (additive, safe)
- Update characters (creates version snapshot — recoverable)
- Update personas (overwrites with no snapshot — irrecoverable)
- Fetch / navigate (read-only)

She cannot update lorebooks, presets, chats, agents, connections, settings, or regex scripts, and there are no delete commands. So the warning scopes correctly to characters + personas with the asymmetry called out.

## What changed

Three places now surface the same callout, sized for the audience that hits each one:

- **`packages/client/src/components/onboarding/OnboardingTutorial.tsx`** — Step 5 (\"Meet Professor Mari!\") body now includes a Heads up paragraph spelling out the character-vs-persona difference. Every new user sees this during the tour.
- **`packages/server/src/db/seed-mari.ts`** — Mari's `first_mes` opens with a one-line ⚠️ explaining the same. `seedProfessorMari` already re-applies the seed when the character data hash changes (line 444-453), so the updated card propagates on app start. The new `first_mes` only affects *new* chats with Mari, not existing ones already populated by the previous greeting — the in-app banner below covers existing users.
- **New `packages/client/src/components/chat/MariCapabilityNotice.tsx`** — dismissible amber banner that renders above the input bar in any chat where `PROFESSOR_MARI_ID` is in `characterIds`. Detection mirrors the existing `MariThinkingIndicator` pattern. Dismissal persists under `localStorage` key `mari-capability-notice-dismissed-v1`, so it shows at most once across all of the user's Mari chats. Re-checks storage on chat-switch to handle cross-tab dismissal.

Wired into both `ConversationInput.tsx` and `ChatInput.tsx` directly above `<MariThinkingIndicator />` so the new notice and the existing thinking pill share one \"Mari status\" area.

## Compatibility

- Existing Mari chats are unchanged at the data layer — the banner is the only thing that changes for them.
- No new server routes, no schema changes, no backend behavior change. The destructive commands themselves are not modified — this PR is purely informational.
- Banner styling matches existing alert patterns in the codebase (rounded-lg, amber accent, inline X dismiss). Tested in both light and dark themes and at mobile widths.

## Closes / refs

User report from Discord (general). No tracking issue yet — happy to file one if reviewers prefer it linked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a one-time capability notice that displays in Professor Mari conversations, informing users about persona editing behavior with a dismissal option.

* **UI/UX Updates**
  * Enhanced the "Meet Professor Mari!" onboarding step with additional guidance about persona editing behavior.
  * Updated Professor Mari's initial greeting message to include important information regarding persona edits versus character edits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->