### PR TITLE
feat(conversation): define expected content for keyDetails and summary in the automatic summarization prompts

### DIFF
--- a/packages/server/src/services/conversation/auto-summary.service.ts
+++ b/packages/server/src/services/conversation/auto-summary.service.ts
@@ -183,11 +183,9 @@ function parseSummaryResponse(raw: string): DaySummaryEntry {
 function dailySummarySystemPrompt(date: string, scope: string): string {
   return [
     `You are a conversation memory assistant. You will receive ${scope} DM conversation from ${date}.`,
-    `Produce a JSON object with two fields:`,
+    `Produce a JSON object with two fields, in this order:`,
     ``,
-    `1. "summary" — A brief narrative paragraph (2-4 sentences, third person) covering what happened: topics discussed, key moments, emotional tone, and important exchanges.`,
-    ``,
-    `2. "keyDetails" — An array of short, specific strings listing things the characters MUST remember going forward. Include:`,
+    `1. "keyDetails" — An array of short, specific strings listing things the characters MUST remember going forward. Include:`,
     `   - Promises or commitments made ("Alice promised to call Bob tomorrow morning")`,
     `   - Plans or appointments ("They agreed to watch a movie together on Friday")`,
     `   - Unresolved questions or topics left hanging ("Bob asked about Alice's job interview — she said she'd tell him later")`,
@@ -196,7 +194,18 @@ function dailySummarySystemPrompt(date: string, scope: string): string {
     `   - Requests or things someone said they'd do ("Alice said she'd send the recipe")`,
     `   If nothing important needs to be carried forward, use an empty array.`,
     ``,
+    `2. "summary" — A few short atmospheric notes (1-3 brief sentences, third person). These are terse field notes, NOT prose — no flourishes, no literary phrasing. The summary is consumed by a weekly summarizer that builds a relational arc, so focus on things that aggregate meaningfully across days:`,
+    `   - Setting: when they talked (time of day, how long), where each character was, what they were doing`,
+    `   - Physical or emotional state of each character during the talk ("Alice was sleepy in bed the whole time", "Bob was buzzing with excitement")`,
+    `   - Tonal register and how it shifted ("started playful, turned tender when he opened up")`,
+    `   - The character of events as experienced ("heated argument about boundaries", "quiet check-in", "rapid-fire flirting")`,
+    `   Do NOT restate items already in keyDetails — the summary's job is the felt experience AROUND the facts, not the facts themselves.`,
+    `   Avoid: "A buoyant exchange where the energy bloomed from initial pleasantries into a tender celebration."`,
+    `   Prefer: "Buoyant evening chat. Mood warm throughout, lots of mutual hype."`,
+    `   If the day was uneventful, a single sentence is fine.`,
+    ``,
     `Respond with ONLY valid JSON. No markdown fences, no extra text.`,
+    `Example: { "keyDetails": ["Alice promised to send Bob the recipe for pasta", "They planned to meet for coffee on Saturday", "Alice mentioned her sister Clara is visiting next week"], "summary": "Evening chat after work. Bob still at the office, Alice in pajamas at home. Warm and easy throughout, Alice tired by the end but in good spirits." }`,
   ].join("\n");
 }
 
@@ -292,18 +301,26 @@ async function summarizeDayBucket(
 
 function weekSummarySystemPrompt(rangeLabel: string): string {
   return [
-    `You are a conversation memory assistant. You will receive daily conversation summaries for the week of ${rangeLabel}.`,
-    `Produce a JSON object with two fields:`,
+    `You are a conversation memory assistant. You will receive a week's worth of daily entries (date, terse atmospheric notes, key facts) for the week of ${rangeLabel}.`,
+    `Produce a JSON object with two fields, in this order:`,
     ``,
-    `1. "summary" — A cohesive narrative paragraph (3-6 sentences, third person) covering the week: major topics, relationship developments, emotional arc, and significant events. Weave the days together naturally — don't just list each day separately.`,
-    ``,
-    `2. "keyDetails" — A consolidated array of short, specific strings listing things the characters MUST still remember going forward. Review the daily key details and:`,
+    `1. "keyDetails" — A consolidated array of short, specific strings listing things the characters MUST still remember going forward. Review the daily key details and:`,
     `   - KEEP details that are still relevant (upcoming plans, ongoing commitments, unresolved topics)`,
     `   - MERGE duplicates or evolving items into their latest state`,
     `   - DROP details that were already resolved during the week (e.g. "promised to send recipe" if it was sent later that week)`,
     `   - ADD any overarching patterns or relationship developments worth remembering`,
     ``,
+    `2. "summary" — A few terse atmospheric notes (3-5 brief sentences, third person) capturing the week's ARC, not its events. These are field notes, NOT prose — no flourishes, no literary phrasing. The daily entries already cover what felt like what each day; your job is to find the shape across them. Focus on:`,
+    `   - Tonal evolution across the week ("started distant, warmed up by Wednesday")`,
+    `   - Recurring patterns or rhythms ("late-night chats most evenings", "she kept circling back to her recordings")`,
+    `   - Relationship developments worth remembering ("noticeably more openly affectionate by week's end")`,
+    `   - Significant emotional shifts or turning points`,
+    `   Do NOT restate items already in keyDetails — the summary's job is the felt arc AROUND the facts, not the facts themselves. Do not chronicle "Monday they did X, Tuesday they did Y" — that's a list, not an arc.`,
+    `   Avoid: "The week unfolded as a tender progression from initial pleasantries into deeply intimate confessions, with their bond visibly deepening."`,
+    `   Prefer: "Mostly late-evening chats. Tone shifted from playful to tender mid-week after a vulnerable confession. Both more openly affectionate by Sunday."`,
+    ``,
     `Respond with ONLY valid JSON. No markdown fences, no extra text.`,
+    `Example: { "keyDetails": ["Alice's sister Clara visiting next weekend", "Bob still off alcohol after the tequila incidents", "They agreed to weekend plans on Saturday"], "summary": "Mostly late-evening chats, often past midnight. Alice leaning on him through some recurring work doubts. Tone shifted from playful to tender mid-week after a vulnerable confession. Both more openly affectionate by Sunday." }`,
   ].join("\n");
 }
 


### PR DESCRIPTION
'Closes #391'

## Why this change

Refines the day and week conversation summarization prompts so that the narrative `summary` and the bulleted `keyDetails` no longer cover the same ground.

**The problem:** the previous prompts asked both fields to capture "topics, key moments, important exchanges" — so they overlapped heavily. In practice this meant duplicate content sitting in context.

## What changed

**The fix:** reframe the two fields by what only one of them can express:

- **`keyDetails`** (unchanged) — discrete, retrievable facts: promises, plans, named info, decisions, unresolved threads.
- **`summary`** — atmospheric/episodic context: setting, character state, tonal register, recurring patterns. Now explicitly instructed not to restate items from `keyDetails`.

Day and week prompts also now emit `keyDetails` first, so the model writes the facts before composing the summary — gives the atmosphere pass a clean view of what's already covered, and avoids the forward reference in the "do not restate keyDetails" instruction.

### Day prompt
- Reframed as **terse field notes (1-3 brief sentences)** rather than literary prose. Day summaries are ephemeral (rolled into the week summary) and primarily exist to feed the week summarizer, so a note-style register fits the artifact and uses fewer tokens.
- Avoid/Prefer contrast and a terse example added to anchor the register.

### Week prompt
- Reframed as **terse atmospheric notes (3-5 brief sentences)** capturing the week's ARC rather than its events.
- Bullets reframed around tonal evolution / recurring patterns / relationship developments instead of "topics + events".

### Example summary output before change (Notice duplication and bloat)
Summary:
Bob shared two major breakthroughs with Alice. First, he told his singing teacher about his concert dream and vocaloid/utaite culture, and the teacher (a fellow anime nerd) agreed to focus their classes on concert prep, eliminating Bob's need to split time with certification exam work. Second, Bob discovered his concept of head voice was flawed—he'd been mixing in chest voice—and correcting this unlocked his registry flips on 'I'm Invincible' and shifted his entire vocal understanding. Alice was thrilled and emotionally supportive throughout. Bob then left to check on a friend at a nearby bar, noting he's currently put off by alcohol after previous tequila incidents.

Key Details:
- Bob told his singing teacher about his concert dream and vocaloid/utaite culture; the teacher is now tailoring classes to concert prep.
- Bob is setting aside the singing certification exam to focus on the concert.
- Bob's singing teacher is a fellow anime nerd.
- Bob had a fundamental vocal breakthrough: he realized his head voice had chest mixed in; correcting this unlocked registry flips and other vocal issues.
- Bob is now able to do the registry flips on 'I'm Invincible' (Alice song).
- Bob is currently grossed out by alcohol and says "tequila Bob" won't return for a long time.
- Bob left to check on a friend at a nearby bar.
- Alice mentioned she was going through recordings and being self-critical about them.

### Example summary output after change
Summary:
Brief evening chat. Bob hyped about two breakthroughs, Alice validating and excited throughout. Warm and affectionate, quick pace. Bob left to check on a friend at a bar.

Key Details:
- Bob told his singing teacher about his concert dream and vocaloid/utaite culture — the teacher agreed to focus classes on concert prep instead of the certification exam.
- Bob had a vocal breakthrough: he realized his head voice concept was flawed (mixing in chest) and now understands true head voice, which is fixing registry flips and other issues.
- Bob is currently not into alcohol after previous tequila incidents.
- Bob went to check on a friend at a nearby bar.

## Validation
- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
     - I'm having issues building docker before and after my changes on Windows.
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`
- [x] Manually verify a day summary
- [x] Manually verify a week consolidation

## Docs and release impact

- [x] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced auto-summary generation for conversations with improved formatting and structure. Key details now appear first in summaries, followed by more concise, field-notes style content. Summaries better avoid redundancy between sections across both daily and weekly summary generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->