### PR TITLE
Optimize frontend shell and audit polish

### DIFF
--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -12,7 +12,7 @@
     <title>Marinara Engine</title>
     <link rel="icon" type="image/png" href="/favicon.png" />
     <link rel="manifest" href="/manifest.json" />
-    <link rel="apple-touch-icon" href="/logo.png" />
+    <link rel="apple-touch-icon" href="/icon-192.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />

--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -13,9 +13,6 @@
     <link rel="icon" type="image/png" href="/favicon.png" />
     <link rel="manifest" href="/manifest.json" />
     <link rel="apple-touch-icon" href="/icon-192.png" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
   </head>
   <body>
     <div id="root"></div>

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -13,7 +13,6 @@
   "dependencies": {
     "@marinara-engine/shared": "workspace:*",
     "@tanstack/react-query": "^5.80.7",
-    "@tanstack/react-router": "^1.121.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "framer-motion": "^12.34.3",

--- a/packages/client/public/manifest.json
+++ b/packages/client/public/manifest.json
@@ -23,12 +23,6 @@
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "any maskable"
-    },
-    {
-      "src": "/logo.png",
-      "sizes": "1655x1322",
-      "type": "image/png",
-      "purpose": "any"
     }
   ]
 }

--- a/packages/client/src/components/agents/AgentEditor.tsx
+++ b/packages/client/src/components/agents/AgentEditor.tsx
@@ -543,7 +543,9 @@ export function AgentEditor() {
       {/* ── Header ── */}
       <div className="flex flex-wrap items-center gap-3 border-b border-[var(--border)] bg-[var(--card)] px-4 py-3 max-md:gap-2 max-md:px-3">
         <button
+          type="button"
           onClick={handleClose}
+          aria-label="Back to agents"
           className="rounded-xl p-2 transition-all hover:bg-[var(--accent)] active:scale-95"
         >
           <ArrowLeft size="1.125rem" />

--- a/packages/client/src/components/agents/RegexScriptEditor.tsx
+++ b/packages/client/src/components/agents/RegexScriptEditor.tsx
@@ -262,7 +262,9 @@ export function RegexScriptEditor() {
       {/* ── Header ── */}
       <div className="flex items-center gap-3 border-b border-[var(--border)] bg-[var(--card)] px-4 py-3">
         <button
+          type="button"
           onClick={handleClose}
+          aria-label="Back to regex scripts"
           className="rounded-xl p-2 transition-all hover:bg-[var(--accent)] active:scale-95"
         >
           <ArrowLeft size="1.125rem" />

--- a/packages/client/src/components/agents/ToolEditor.tsx
+++ b/packages/client/src/components/agents/ToolEditor.tsx
@@ -223,7 +223,9 @@ export function ToolEditor() {
       {/* ── Header ── */}
       <div className="flex items-center gap-3 border-b border-[var(--border)] bg-[var(--card)] px-4 py-3">
         <button
+          type="button"
           onClick={handleClose}
+          aria-label="Back to tools"
           className="rounded-xl p-2 transition-all hover:bg-[var(--accent)] active:scale-95"
         >
           <ArrowLeft size="1.125rem" />

--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -1067,8 +1067,11 @@ export function ChatArea() {
                 )}
               >
                 <img
-                  src={showEmptyStateEffects ? "/logo-splash.gif" : "/logo.png"}
+                  src="/icon-192.png"
                   alt="Marinara Engine"
+                  width={80}
+                  height={80}
+                  decoding="async"
                   className="h-full w-full object-cover"
                 />
               </div>

--- a/packages/client/src/components/chat/ChatFilesDrawer.tsx
+++ b/packages/client/src/components/chat/ChatFilesDrawer.tsx
@@ -98,7 +98,9 @@ export function ChatFilesDrawer({ chat, open, onClose }: ChatFilesDrawerProps) {
           <div className="flex items-center justify-between border-b border-[var(--border)] px-4 py-3">
             <h3 className="text-sm font-bold">Manage Chat Files</h3>
             <button
+              type="button"
               onClick={onClose}
+              aria-label="Close chat files drawer"
               className="rounded-lg p-1.5 text-[var(--muted-foreground)] transition-all hover:bg-[var(--accent)]"
             >
               <X size="1rem" />
@@ -150,7 +152,9 @@ export function ChatFilesDrawer({ chat, open, onClose }: ChatFilesDrawerProps) {
         <div className="flex items-center justify-between border-b border-[var(--border)] px-4 py-3">
           <h3 className="text-sm font-bold">Manage Chat Files</h3>
           <button
+            type="button"
             onClick={onClose}
+            aria-label="Close chat files drawer"
             className="rounded-lg p-1.5 text-[var(--muted-foreground)] transition-all hover:bg-[var(--accent)]"
           >
             <X size="1rem" />

--- a/packages/client/src/components/chat/ChatGallery.tsx
+++ b/packages/client/src/components/chat/ChatGallery.tsx
@@ -91,6 +91,7 @@ export function ChatGallery({ chatId, onIllustrate }: ChatGalleryProps) {
                 src={img.url}
                 alt={img.prompt || "Gallery image"}
                 loading="lazy"
+                decoding="async"
                 className="aspect-square w-full cursor-pointer object-cover transition-transform group-hover:scale-105"
                 onClick={() => setLightbox(img)}
               />
@@ -99,14 +100,18 @@ export function ChatGallery({ chatId, onIllustrate }: ChatGalleryProps) {
                 <div className="flex w-full items-center justify-between p-2">
                   <div className="flex gap-1">
                     <button
+                      type="button"
                       onClick={() => setLightbox(img)}
+                      aria-label="View image fullscreen"
                       className="rounded-md bg-white/20 p-1.5 text-white transition-colors hover:bg-white/30"
                       title="View fullscreen"
                     >
                       <ZoomIn size="0.75rem" />
                     </button>
                     <button
+                      type="button"
                       onClick={() => pinImage(img)}
+                      aria-label="Pin image to chat"
                       className="rounded-md bg-white/20 p-1.5 text-white transition-colors hover:bg-white/30"
                       title="Pin to chat"
                     >
@@ -114,7 +119,9 @@ export function ChatGallery({ chatId, onIllustrate }: ChatGalleryProps) {
                     </button>
                   </div>
                   <button
+                    type="button"
                     onClick={() => setConfirmDeleteId(img.id)}
+                    aria-label="Delete gallery image"
                     className="rounded-md bg-red-500/40 p-1.5 text-white transition-colors hover:bg-red-500/60"
                   >
                     <Trash2 size="0.75rem" />
@@ -159,15 +166,18 @@ export function ChatGallery({ chatId, onIllustrate }: ChatGalleryProps) {
             <img
               src={lightbox.url}
               alt={lightbox.prompt || "Gallery image"}
+              decoding="async"
               className="max-h-[85vh] w-full rounded-lg object-contain shadow-2xl"
             />
             {/* Controls */}
             <div className="absolute right-2 top-2 flex gap-2">
               <button
+                type="button"
                 onClick={() => {
                   pinImage(lightbox);
                   setLightbox(null);
                 }}
+                aria-label="Pin image to chat"
                 className="rounded-lg bg-black/60 p-2 text-white transition-colors hover:bg-black/80"
                 title="Pin to chat"
               >
@@ -176,12 +186,15 @@ export function ChatGallery({ chatId, onIllustrate }: ChatGalleryProps) {
               <a
                 href={lightbox.url}
                 download
+                aria-label="Download image"
                 className="rounded-lg bg-black/60 p-2 text-white transition-colors hover:bg-black/80"
               >
                 <Download size="0.875rem" />
               </a>
               <button
+                type="button"
                 onClick={() => setLightbox(null)}
+                aria-label="Close image"
                 className="rounded-lg bg-black/60 p-2 text-white transition-colors hover:bg-black/80"
               >
                 <X size="0.875rem" />

--- a/packages/client/src/components/chat/ChatGalleryDrawer.tsx
+++ b/packages/client/src/components/chat/ChatGalleryDrawer.tsx
@@ -27,7 +27,9 @@ export function ChatGalleryDrawer({ chat, open, onClose, onIllustrate }: ChatGal
         <div className="flex items-center justify-between border-b border-[var(--border)] px-4 py-3">
           <h3 className="text-sm font-bold">Gallery</h3>
           <button
+            type="button"
             onClick={onClose}
+            aria-label="Close gallery drawer"
             className="rounded-lg p-1.5 text-[var(--muted-foreground)] transition-all hover:bg-[var(--accent)]"
           >
             <X size="1rem" />

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -100,6 +100,7 @@ const EditTextarea = memo(function EditTextarea({
       <div className="flex items-center gap-1.5 justify-end">
         <button
           onClick={onCancel}
+          aria-label="Cancel edit"
           className="rounded-md p-1 text-white/40 hover:bg-white/10 hover:text-white/70"
           title="Cancel (Esc)"
         >
@@ -107,6 +108,7 @@ const EditTextarea = memo(function EditTextarea({
         </button>
         <button
           onClick={handleSave}
+          aria-label="Save edit"
           className="rounded-md p-1 text-emerald-400/70 hover:bg-emerald-400/10 hover:text-emerald-400"
           title="Save (Cmd+Enter)"
         >
@@ -360,7 +362,9 @@ const CHAT_HTML_ALLOWED_ATTR = [
   "color",
   "colspan",
   "data-spk",
+  "decoding",
   "href",
+  "loading",
   "rel",
   "rowspan",
   "src",
@@ -446,7 +450,7 @@ function renderContent(
   // to avoid the dialogue-bolding regex mangling attribute quotes.
   const withImages = withBreaks.replace(
     /!\[([^\]]*)\]\((https?:\/\/[^)]+)\)/g,
-    (_m, alt: string, url: string) => `<img src="${url}" alt="${alt || "image"}">`,
+    (_m, alt: string, url: string) => `<img src="${url}" alt="${alt || "image"}" loading="lazy" decoding="async">`,
   );
 
   const clean = sanitizeChatHtml(withImages);
@@ -1047,6 +1051,8 @@ export const ChatMessage = memo(function ChatMessage({
             src={avatar.url}
             alt=""
             aria-hidden="true"
+            loading="lazy"
+            decoding="async"
             className="rpg-avatar-panel-tail-image absolute inset-0 h-full w-full object-cover object-top transition-opacity duration-700"
             style={{ opacity: i === 0 ? 1 : 0, ...getAvatarCropStyle(avatar.crop) }}
           />
@@ -1058,6 +1064,8 @@ export const ChatMessage = memo(function ChatMessage({
           src={avatarUrl}
           alt=""
           aria-hidden="true"
+          loading="lazy"
+          decoding="async"
           className="rpg-avatar-panel-tail-image absolute inset-0 h-full w-full object-cover object-top"
           style={avatarCropStyle}
         />
@@ -1121,6 +1129,7 @@ export const ChatMessage = memo(function ChatMessage({
                 e.stopPropagation();
                 onDelete(message.id);
               }}
+              aria-label="Delete message"
               className={cn(
                 "absolute -right-1 -top-1 rounded-md p-1 text-white/20 opacity-0 transition-all hover:bg-red-500/20 hover:text-red-400 group-hover:opacity-100",
                 showActions && "opacity-100",
@@ -1177,6 +1186,7 @@ export const ChatMessage = memo(function ChatMessage({
               {!multiSelectMode && onDelete && (
                 <button
                   onClick={() => onDelete(message.id)}
+                  aria-label="Delete message"
                   className={cn(
                     "absolute right-2 top-2 rounded-md p-1 text-white/20 opacity-0 transition-all hover:bg-red-500/20 hover:text-red-400 group-hover:opacity-100",
                     showActions && "opacity-100",
@@ -1236,7 +1246,8 @@ export const ChatMessage = memo(function ChatMessage({
           {!isGrouped && !showRoleplayAvatarPanel && (
             <div className="mari-message-avatar flex flex-col items-center flex-shrink-0 pt-1">
               {isMergedGroup && mergedAvatars.length > 0 ? (
-                <div
+                <button
+                  type="button"
                   className={cn(
                     "rpg-avatar-glow relative cursor-pointer overflow-hidden ring-2 ring-white/10",
                     compactAvatarFrameClass,
@@ -1245,6 +1256,7 @@ export const ChatMessage = memo(function ChatMessage({
                     const visible = mergedAvatars[cycleIndexRef.current];
                     if (visible) setAvatarLightbox(visible.url);
                   }}
+                  aria-label={`Open ${displayName} avatar`}
                 >
                   {mergedAvatars.map((avatar, i) => (
                     <img
@@ -1254,24 +1266,30 @@ export const ChatMessage = memo(function ChatMessage({
                       }}
                       src={avatar.url}
                       alt="Group"
+                      loading="lazy"
+                      decoding="async"
                       className="absolute inset-0 h-full w-full object-cover transition-opacity duration-700"
                       style={{ opacity: i === 0 ? 1 : 0, ...getAvatarCropStyle(avatar.crop) }}
                     />
                   ))}
-                </div>
+                </button>
               ) : avatarUrl ? (
                 <div className={cn(!isUser && "rpg-avatar-glow")}>
-                  <div
+                  <button
+                    type="button"
                     className={cn("cursor-pointer overflow-hidden ring-2 ring-white/10", compactAvatarFrameClass)}
                     onClick={() => setAvatarLightbox(avatarUrl)}
+                    aria-label={`Open ${displayName} avatar`}
                   >
                     <img
                       src={avatarUrl}
                       alt={displayName}
+                      loading="lazy"
+                      decoding="async"
                       className="h-full w-full object-cover"
                       style={avatarCropStyle}
                     />
-                  </div>
+                  </button>
                 </div>
               ) : (
                 <div
@@ -1389,6 +1407,8 @@ export const ChatMessage = memo(function ChatMessage({
                               }}
                               src={avatar.url}
                               alt="Group"
+                              loading="lazy"
+                              decoding="async"
                               className="absolute inset-0 h-full w-full object-cover object-top transition-opacity duration-700"
                               style={{ opacity: i === 0 ? 1 : 0, ...getAvatarCropStyle(avatar.crop) }}
                             />
@@ -1407,6 +1427,8 @@ export const ChatMessage = memo(function ChatMessage({
                           <img
                             src={avatarUrl}
                             alt={displayName}
+                            loading="lazy"
+                            decoding="async"
                             className="h-full w-full object-cover object-top"
                             style={avatarCropStyle}
                           />
@@ -1465,16 +1487,19 @@ export const ChatMessage = memo(function ChatMessage({
                         onClick={() => setAvatarLightbox(att.url || att.data)}
                         className="block"
                         title="Open image"
+                        aria-label={`Open ${att.filename || att.name || "image"}`}
                       >
                         <img
                           src={att.url || att.data}
                           alt={att.filename || att.name || "image"}
                           className="max-h-80 max-w-full rounded-lg"
                           loading="lazy"
+                          decoding="async"
                         />
                       </button>
                       <button
                         onClick={() => handleRemoveAttachment(i)}
+                        aria-label="Remove image from message"
                         title="Remove from message"
                         className="absolute top-1.5 right-1.5 rounded-full bg-black/60 p-1 text-white/80 transition-opacity hover:bg-black/80 hover:text-white sm:opacity-0 sm:group-hover/att:opacity-100"
                       >
@@ -1490,9 +1515,11 @@ export const ChatMessage = memo(function ChatMessage({
             {hasSwipes && (
               <div className="mari-message-swipes flex items-center gap-1.5 px-1 text-[0.75rem] text-white/40">
                 <button
+                  type="button"
                   className="rounded-md p-[0.25em] transition-colors hover:bg-white/10 disabled:opacity-30"
                   onClick={handleSwipePrev}
                   disabled={message.activeSwipeIndex <= 0}
+                  aria-label="Previous swipe"
                 >
                   <ChevronLeft size={MESSAGE_SWIPE_ICON_SIZE} />
                 </button>
@@ -1500,9 +1527,11 @@ export const ChatMessage = memo(function ChatMessage({
                   {message.activeSwipeIndex + 1}/{swipeCount}
                 </span>
                 <button
+                  type="button"
                   className="rounded-md p-[0.25em] transition-colors hover:bg-white/10 disabled:opacity-30"
                   onClick={handleSwipeNext}
                   disabled={message.activeSwipeIndex >= swipeCount - 1}
+                  aria-label="Next swipe"
                 >
                   <ChevronRight size={MESSAGE_SWIPE_ICON_SIZE} />
                 </button>
@@ -1638,10 +1667,12 @@ export const ChatMessage = memo(function ChatMessage({
             <img
               src={avatarLightbox}
               alt={displayName}
+              decoding="async"
               className="max-h-[85vh] max-w-[90vw] rounded-lg object-contain shadow-2xl"
             />
             <button
               onClick={() => setAvatarLightbox(null)}
+              aria-label="Close image"
               className="absolute right-3 top-3 rounded-lg bg-black/60 p-2 text-white transition-colors hover:bg-black/80"
             >
               <X size="1rem" />
@@ -1680,12 +1711,14 @@ export const ChatMessage = memo(function ChatMessage({
             )}
           >
             {isMergedGroup && mergedAvatars.length > 0 ? (
-              <div
+              <button
+                type="button"
                 className="relative h-8 w-8 cursor-pointer overflow-hidden rounded-full"
                 onClick={() => {
                   const visible = mergedAvatars[cycleIndexRef.current];
                   if (visible) setAvatarLightbox(visible.url);
                 }}
+                aria-label={`Open ${displayName} avatar`}
               >
                 {mergedAvatars.map((avatar, i) => (
                   <img
@@ -1695,24 +1728,29 @@ export const ChatMessage = memo(function ChatMessage({
                     }}
                     src={avatar.url}
                     alt="Group"
+                    loading="lazy"
+                    decoding="async"
                     className="absolute inset-0 h-8 w-8 object-cover transition-opacity duration-700"
                     style={{ opacity: i === 0 ? 1 : 0, ...getAvatarCropStyle(avatar.crop) }}
                   />
                 ))}
-              </div>
+              </button>
             ) : avatarUrl ? (
-              <div
+              <button
+                type="button"
                 className="h-8 w-8 cursor-pointer overflow-hidden rounded-full"
                 onClick={() => setAvatarLightbox(avatarUrl)}
+                aria-label={`Open ${displayName} avatar`}
               >
                 <img
                   src={avatarUrl}
                   alt={displayName}
                   loading="lazy"
+                  decoding="async"
                   className="h-full w-full object-cover"
                   style={avatarCropStyle}
                 />
-              </div>
+              </button>
             ) : (
               <div className="flex h-8 w-8 items-center justify-center rounded-full bg-[var(--accent)] text-[0.6875rem] font-bold text-[var(--muted-foreground)]">
                 {displayName[0]}
@@ -1824,16 +1862,19 @@ export const ChatMessage = memo(function ChatMessage({
                       onClick={() => setAvatarLightbox(att.url || att.data)}
                       className="block"
                       title="Open image"
+                      aria-label={`Open ${att.filename || att.name || "image"}`}
                     >
                       <img
                         src={att.url || att.data}
                         alt={att.filename || att.name || "image"}
                         className="max-h-80 max-w-full rounded-lg"
                         loading="lazy"
+                        decoding="async"
                       />
                     </button>
                     <button
                       onClick={() => handleRemoveAttachment(i)}
+                      aria-label="Remove image from message"
                       title="Remove from message"
                       className="absolute top-1.5 right-1.5 rounded-full bg-black/60 p-1 text-white/80 transition-opacity hover:bg-black/80 hover:text-white sm:opacity-0 sm:group-hover/att:opacity-100"
                     >
@@ -1866,9 +1907,11 @@ export const ChatMessage = memo(function ChatMessage({
           {hasSwipes && (
             <div className="mari-message-swipes flex items-center gap-1.5 px-2 text-[0.75rem] text-[var(--muted-foreground)]">
               <button
+                type="button"
                 className="rounded p-[0.25em] transition-colors hover:bg-[var(--accent)] disabled:opacity-30"
                 onClick={handleSwipePrev}
                 disabled={message.activeSwipeIndex <= 0}
+                aria-label="Previous swipe"
               >
                 <ChevronLeft size={MESSAGE_SWIPE_ICON_SIZE} />
               </button>
@@ -1876,9 +1919,11 @@ export const ChatMessage = memo(function ChatMessage({
                 {message.activeSwipeIndex + 1}/{swipeCount}
               </span>
               <button
+                type="button"
                 className="rounded p-[0.25em] transition-colors hover:bg-[var(--accent)] disabled:opacity-30"
                 onClick={handleSwipeNext}
                 disabled={message.activeSwipeIndex >= swipeCount - 1}
+                aria-label="Next swipe"
               >
                 <ChevronRight size={MESSAGE_SWIPE_ICON_SIZE} />
               </button>
@@ -1993,10 +2038,12 @@ export const ChatMessage = memo(function ChatMessage({
           <img
             src={avatarLightbox}
             alt={displayName}
+            decoding="async"
             className="max-h-[85vh] max-w-[90vw] rounded-lg object-contain shadow-2xl"
           />
           <button
             onClick={() => setAvatarLightbox(null)}
+            aria-label="Close image"
             className="absolute right-3 top-3 rounded-lg bg-black/60 p-2 text-white transition-colors hover:bg-black/80"
           >
             <X size="1rem" />
@@ -2025,6 +2072,7 @@ function ThinkingModal({ thinking, onClose }: { thinking: string; onClose: () =>
           </div>
           <button
             onClick={onClose}
+            aria-label="Close thoughts"
             className="rounded-md p-1 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
           >
             <X size="0.875rem" />
@@ -2059,8 +2107,10 @@ function ActionBtn({
 }) {
   return (
     <button
+      type="button"
       onClick={onClick}
       title={title}
+      aria-label={title}
       disabled={disabled}
       className={cn(
         "rounded-md p-[0.35em] text-[0.8125rem] transition-all active:scale-90 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-30",

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -99,6 +99,7 @@ const EditTextarea = memo(function EditTextarea({
       />
       <div className="flex items-center gap-1.5 justify-end">
         <button
+          type="button"
           onClick={onCancel}
           aria-label="Cancel edit"
           className="rounded-md p-1 text-white/40 hover:bg-white/10 hover:text-white/70"
@@ -107,6 +108,7 @@ const EditTextarea = memo(function EditTextarea({
           <X size="0.8125rem" />
         </button>
         <button
+          type="button"
           onClick={handleSave}
           aria-label="Save edit"
           className="rounded-md p-1 text-emerald-400/70 hover:bg-emerald-400/10 hover:text-emerald-400"
@@ -1124,6 +1126,7 @@ export const ChatMessage = memo(function ChatMessage({
         <div className="relative">
           {!multiSelectMode && onDelete && (
             <button
+              type="button"
               onClick={(e) => {
                 e.stopPropagation();
                 onDelete(message.id);
@@ -1184,6 +1187,7 @@ export const ChatMessage = memo(function ChatMessage({
               {/* Delete button */}
               {!multiSelectMode && onDelete && (
                 <button
+                  type="button"
                   onClick={() => onDelete(message.id)}
                   aria-label="Delete message"
                   className={cn(
@@ -1497,6 +1501,7 @@ export const ChatMessage = memo(function ChatMessage({
                         />
                       </button>
                       <button
+                        type="button"
                         onClick={() => handleRemoveAttachment(i)}
                         aria-label="Remove image from message"
                         title="Remove from message"
@@ -1670,6 +1675,7 @@ export const ChatMessage = memo(function ChatMessage({
               className="max-h-[85vh] max-w-[90vw] rounded-lg object-contain shadow-2xl"
             />
             <button
+              type="button"
               onClick={() => setAvatarLightbox(null)}
               aria-label="Close image"
               className="absolute right-3 top-3 rounded-lg bg-black/60 p-2 text-white transition-colors hover:bg-black/80"
@@ -1872,6 +1878,7 @@ export const ChatMessage = memo(function ChatMessage({
                       />
                     </button>
                     <button
+                      type="button"
                       onClick={() => handleRemoveAttachment(i)}
                       aria-label="Remove image from message"
                       title="Remove from message"
@@ -2041,6 +2048,7 @@ export const ChatMessage = memo(function ChatMessage({
             className="max-h-[85vh] max-w-[90vw] rounded-lg object-contain shadow-2xl"
           />
           <button
+            type="button"
             onClick={() => setAvatarLightbox(null)}
             aria-label="Close image"
             className="absolute right-3 top-3 rounded-lg bg-black/60 p-2 text-white transition-colors hover:bg-black/80"
@@ -2070,6 +2078,7 @@ function ThinkingModal({ thinking, onClose }: { thinking: string; onClose: () =>
             Model Thoughts
           </div>
           <button
+            type="button"
             onClick={onClose}
             aria-label="Close thoughts"
             className="rounded-md p-1 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"

--- a/packages/client/src/components/game/GameGridMap.tsx
+++ b/packages/client/src/components/game/GameGridMap.tsx
@@ -99,7 +99,7 @@ export function GameGridMap({
           }}
         >
           <div
-            className="grid gap-0.5 transition-[width] duration-150 ease-out"
+            className="grid gap-0.5"
             style={{
               gridTemplateColumns: `repeat(${width}, minmax(0, 1fr))`,
               width: `${zoom * 100}%`,

--- a/packages/client/src/components/game/GameNodeMap.tsx
+++ b/packages/client/src/components/game/GameNodeMap.tsx
@@ -103,7 +103,7 @@ export function GameNodeMap({
       >
         <svg
           viewBox={`${visibleMinX} ${visibleMinY} ${visibleViewWidth} ${visibleViewHeight}`}
-          className="block rounded border border-[var(--border)] bg-gray-900/30 transition-[width] duration-150 ease-out"
+          className="block rounded border border-[var(--border)] bg-gray-900/30"
           style={{ width: mapContentWidth }}
         >
           {/* Edges */}

--- a/packages/client/src/components/game/GameReadableDisplay.tsx
+++ b/packages/client/src/components/game/GameReadableDisplay.tsx
@@ -57,7 +57,7 @@ const NOTE_STYLES = [
     name: "official",
     wrapper: "bg-[#fefefe] text-[#1a1a2e] shadow-[0_8px_32px_rgba(0,0,0,0.4)]",
     inner: "font-sans leading-relaxed text-sm",
-    border: "border-l-4 border-[#1a1a2e]/80",
+    border: "border border-[#1a1a2e]/30 ring-1 ring-[#1a1a2e]/10",
     accent: "bg-[#1a1a2e]/5",
     heading: "text-[#1a1a2e] font-sans font-bold uppercase tracking-wide",
     closeBtn: "text-[#1a1a2e]/40 hover:text-[#1a1a2e]",

--- a/packages/client/src/components/layout/AppShell.tsx
+++ b/packages/client/src/components/layout/AppShell.tsx
@@ -4,7 +4,13 @@
 import { ChatSidebar } from "./ChatSidebar";
 import { TopBar } from "./TopBar";
 import { ChatNotificationBubbles } from "../chat/ChatNotificationBubbles";
-import { useUIStore } from "../../stores/ui.store";
+import {
+  RIGHT_PANEL_WIDTH_MAX,
+  RIGHT_PANEL_WIDTH_MIN,
+  SIDEBAR_WIDTH_MAX,
+  SIDEBAR_WIDTH_MIN,
+  useUIStore,
+} from "../../stores/ui.store";
 import { useChatStore } from "../../stores/chat.store";
 import { useBackgroundAutonomousPolling } from "../../hooks/use-background-autonomous";
 import { useIdleDetection } from "../../hooks/use-idle-detection";
@@ -42,6 +48,10 @@ const RightPanel = lazy(() => import("./RightPanel").then((module) => ({ default
 const OnboardingTutorial = lazy(() =>
   import("../onboarding/OnboardingTutorial").then((module) => ({ default: module.OnboardingTutorial })),
 );
+
+function clampWidth(width: number, min: number, max: number) {
+  return Math.max(min, Math.min(max, width));
+}
 
 function MainPaneFallback() {
   return (
@@ -85,6 +95,12 @@ export function AppShell() {
   const rightPanelWidth = useUIStore((s) => s.rightPanelWidth);
   const setRightPanelWidth = useUIStore((s) => s.setRightPanelWidth);
   const closeRightPanel = useUIStore((s) => s.closeRightPanel);
+  const [sidebarDragWidth, setSidebarDragWidth] = useState<number | null>(null);
+  const [rightPanelDragWidth, setRightPanelDragWidth] = useState<number | null>(null);
+  const sidebarDragWidthRef = useRef<number | null>(null);
+  const rightPanelDragWidthRef = useRef<number | null>(null);
+  const liveSidebarWidth = sidebarDragWidth ?? sidebarWidth;
+  const liveRightPanelWidth = rightPanelDragWidth ?? rightPanelWidth;
 
   // Track mobile breakpoint for right-panel animation strategy
   const [isMobile, setIsMobile] = useState(() => typeof window !== "undefined" && window.innerWidth < 768);
@@ -193,11 +209,18 @@ export function AppShell() {
       const originalUserSelect = document.body.style.userSelect;
       document.body.style.cursor = "col-resize";
       document.body.style.userSelect = "none";
+      sidebarDragWidthRef.current = sidebarWidth;
+      setSidebarDragWidth(sidebarWidth);
 
       const onMove = (moveEvent: MouseEvent) => {
-        setSidebarWidth(moveEvent.clientX);
+        const nextWidth = clampWidth(moveEvent.clientX, SIDEBAR_WIDTH_MIN, SIDEBAR_WIDTH_MAX);
+        sidebarDragWidthRef.current = nextWidth;
+        setSidebarDragWidth(nextWidth);
       };
       const onUp = () => {
+        setSidebarWidth(sidebarDragWidthRef.current ?? useUIStore.getState().sidebarWidth);
+        sidebarDragWidthRef.current = null;
+        setSidebarDragWidth(null);
         document.body.style.cursor = originalCursor;
         document.body.style.userSelect = originalUserSelect;
         window.removeEventListener("mousemove", onMove);
@@ -207,7 +230,7 @@ export function AppShell() {
       window.addEventListener("mousemove", onMove);
       window.addEventListener("mouseup", onUp);
     },
-    [isMobile, setSidebarWidth],
+    [isMobile, setSidebarWidth, sidebarWidth],
   );
 
   const startRightPanelResize = useCallback(
@@ -218,11 +241,18 @@ export function AppShell() {
       const originalUserSelect = document.body.style.userSelect;
       document.body.style.cursor = "col-resize";
       document.body.style.userSelect = "none";
+      rightPanelDragWidthRef.current = rightPanelWidth;
+      setRightPanelDragWidth(rightPanelWidth);
 
       const onMove = (moveEvent: MouseEvent) => {
-        setRightPanelWidth(window.innerWidth - moveEvent.clientX);
+        const nextWidth = clampWidth(window.innerWidth - moveEvent.clientX, RIGHT_PANEL_WIDTH_MIN, RIGHT_PANEL_WIDTH_MAX);
+        rightPanelDragWidthRef.current = nextWidth;
+        setRightPanelDragWidth(nextWidth);
       };
       const onUp = () => {
+        setRightPanelWidth(rightPanelDragWidthRef.current ?? useUIStore.getState().rightPanelWidth);
+        rightPanelDragWidthRef.current = null;
+        setRightPanelDragWidth(null);
         document.body.style.cursor = originalCursor;
         document.body.style.userSelect = originalUserSelect;
         window.removeEventListener("mousemove", onMove);
@@ -232,7 +262,7 @@ export function AppShell() {
       window.addEventListener("mousemove", onMove);
       window.addEventListener("mouseup", onUp);
     },
-    [isMobile, setRightPanelWidth],
+    [isMobile, rightPanelWidth, setRightPanelWidth],
   );
 
   const detailView = regexDetailId ? (
@@ -290,15 +320,15 @@ export function AppShell() {
         data-component="ChatSidebarPanel"
         aria-label="Chat list"
         className={cn(
-          "mari-sidebar flex-shrink-0 overflow-hidden bg-[var(--background)]/80 backdrop-blur-xl transition-[width] duration-300 ease-[cubic-bezier(0.16,1,0.3,1)]",
+          "mari-sidebar flex-shrink-0 overflow-hidden bg-[var(--background)]/80 backdrop-blur-xl",
           sidebarOpen && "border-r border-[var(--sidebar-border)]/30",
           // Mobile: fixed overlay
           "max-md:fixed max-md:inset-y-0 max-md:left-0 max-md:z-50 max-md:shadow-2xl max-md:pt-[env(safe-area-inset-top)]",
           !sidebarOpen && "max-md:!w-0",
         )}
-        style={{ width: sidebarOpen ? (isMobile ? "100vw" : sidebarWidth) : 0 }}
+        style={{ width: sidebarOpen ? (isMobile ? "100vw" : liveSidebarWidth) : 0 }}
       >
-        <div className="h-full" style={{ width: isMobile ? "100vw" : sidebarWidth }}>
+        <div className="h-full" style={{ width: isMobile ? "100vw" : liveSidebarWidth }}>
           <ChatSidebar />
         </div>
       </aside>
@@ -309,7 +339,7 @@ export function AppShell() {
           aria-label="Resize left sidebar"
           onMouseDown={startSidebarResize}
           className="absolute inset-y-0 z-20 hidden w-1 cursor-col-resize bg-transparent transition-colors hover:bg-[var(--primary)]/30 md:block"
-          style={{ left: sidebarOpen ? sidebarWidth : 0 }}
+          style={{ left: sidebarOpen ? liveSidebarWidth : 0 }}
         />
       )}
 
@@ -361,13 +391,13 @@ export function AppShell() {
           data-component="RightPanelDesktop"
           aria-label="Settings and tools panel"
           className={cn(
-            "mari-right-panel flex-shrink-0 overflow-hidden bg-[var(--background)]/80 backdrop-blur-xl transition-[width] duration-300 ease-[cubic-bezier(0.16,1,0.3,1)]",
+            "mari-right-panel flex-shrink-0 overflow-hidden bg-[var(--background)]/80 backdrop-blur-xl",
             rightPanelOpen && "border-l border-[var(--sidebar-border)]/30",
           )}
-          style={{ width: rightPanelOpen ? rightPanelWidth : 0 }}
+          style={{ width: rightPanelOpen ? liveRightPanelWidth : 0 }}
         >
           {rightPanelOpen && (
-            <div className="h-full" style={{ width: rightPanelWidth }}>
+            <div className="h-full" style={{ width: liveRightPanelWidth }}>
               <Suspense fallback={<SidePanelFallback />}>
                 <RightPanel />
               </Suspense>
@@ -382,7 +412,7 @@ export function AppShell() {
           aria-label="Resize right sidebar"
           onMouseDown={startRightPanelResize}
           className="absolute inset-y-0 hidden w-1 cursor-col-resize bg-transparent transition-colors hover:bg-[var(--primary)]/30 md:block"
-          style={{ right: rightPanelOpen ? rightPanelWidth : 0 }}
+          style={{ right: rightPanelOpen ? liveRightPanelWidth : 0 }}
         />
       )}
 

--- a/packages/client/src/components/layout/AppShell.tsx
+++ b/packages/client/src/components/layout/AppShell.tsx
@@ -229,18 +229,23 @@ export function AppShell() {
         sidebarDragWidthRef.current = nextWidth;
         setSidebarDragWidth(nextWidth);
       };
-      const onUp = () => {
+      let finished = false;
+      const finishResize = () => {
+        if (finished) return;
+        finished = true;
         setSidebarWidth(sidebarDragWidthRef.current ?? useUIStore.getState().sidebarWidth);
         sidebarDragWidthRef.current = null;
         setSidebarDragWidth(null);
         document.body.style.cursor = originalCursor;
         document.body.style.userSelect = originalUserSelect;
         window.removeEventListener("mousemove", onMove);
-        window.removeEventListener("mouseup", onUp);
+        window.removeEventListener("mouseup", finishResize);
+        window.removeEventListener("blur", finishResize);
       };
 
       window.addEventListener("mousemove", onMove);
-      window.addEventListener("mouseup", onUp);
+      window.addEventListener("mouseup", finishResize);
+      window.addEventListener("blur", finishResize);
     },
     [isMobile, setSidebarWidth, sidebarWidth],
   );
@@ -257,22 +262,31 @@ export function AppShell() {
       setRightPanelDragWidth(rightPanelWidth);
 
       const onMove = (moveEvent: MouseEvent) => {
-        const nextWidth = clampWidth(window.innerWidth - moveEvent.clientX, RIGHT_PANEL_WIDTH_MIN, RIGHT_PANEL_WIDTH_MAX);
+        const nextWidth = clampWidth(
+          window.innerWidth - moveEvent.clientX,
+          RIGHT_PANEL_WIDTH_MIN,
+          RIGHT_PANEL_WIDTH_MAX,
+        );
         rightPanelDragWidthRef.current = nextWidth;
         setRightPanelDragWidth(nextWidth);
       };
-      const onUp = () => {
+      let finished = false;
+      const finishResize = () => {
+        if (finished) return;
+        finished = true;
         setRightPanelWidth(rightPanelDragWidthRef.current ?? useUIStore.getState().rightPanelWidth);
         rightPanelDragWidthRef.current = null;
         setRightPanelDragWidth(null);
         document.body.style.cursor = originalCursor;
         document.body.style.userSelect = originalUserSelect;
         window.removeEventListener("mousemove", onMove);
-        window.removeEventListener("mouseup", onUp);
+        window.removeEventListener("mouseup", finishResize);
+        window.removeEventListener("blur", finishResize);
       };
 
       window.addEventListener("mousemove", onMove);
-      window.addEventListener("mouseup", onUp);
+      window.addEventListener("mouseup", finishResize);
+      window.addEventListener("blur", finishResize);
     },
     [isMobile, rightPanelWidth, setRightPanelWidth],
   );

--- a/packages/client/src/components/layout/AppShell.tsx
+++ b/packages/client/src/components/layout/AppShell.tsx
@@ -17,7 +17,16 @@ import { useIdleDetection } from "../../hooks/use-idle-detection";
 import { usePageActivity } from "../../hooks/use-page-activity";
 import { cn } from "../../lib/utils";
 import { motion, AnimatePresence } from "framer-motion";
-import { lazy, Suspense, useState, useEffect, useRef, useCallback, type MouseEvent as ReactMouseEvent } from "react";
+import {
+  lazy,
+  Suspense,
+  useState,
+  useEffect,
+  useRef,
+  useCallback,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type MouseEvent as ReactMouseEvent,
+} from "react";
 
 const ChatArea = lazy(() => import("../chat/ChatArea").then((module) => ({ default: module.ChatArea })));
 const CharacterEditor = lazy(() =>
@@ -52,6 +61,9 @@ const OnboardingTutorial = lazy(() =>
 function clampWidth(width: number, min: number, max: number) {
   return Math.max(min, Math.min(max, width));
 }
+
+const PANEL_RESIZE_STEP = 16;
+const PANEL_RESIZE_LARGE_STEP = 48;
 
 function MainPaneFallback() {
   return (
@@ -265,6 +277,40 @@ export function AppShell() {
     [isMobile, rightPanelWidth, setRightPanelWidth],
   );
 
+  const adjustSidebarWidth = useCallback(
+    (event: ReactKeyboardEvent<HTMLDivElement>) => {
+      const step = event.shiftKey ? PANEL_RESIZE_LARGE_STEP : PANEL_RESIZE_STEP;
+      let nextWidth = sidebarWidth;
+
+      if (event.key === "ArrowLeft") nextWidth = sidebarWidth - step;
+      else if (event.key === "ArrowRight") nextWidth = sidebarWidth + step;
+      else if (event.key === "Home") nextWidth = SIDEBAR_WIDTH_MIN;
+      else if (event.key === "End") nextWidth = SIDEBAR_WIDTH_MAX;
+      else return;
+
+      event.preventDefault();
+      setSidebarWidth(clampWidth(nextWidth, SIDEBAR_WIDTH_MIN, SIDEBAR_WIDTH_MAX));
+    },
+    [setSidebarWidth, sidebarWidth],
+  );
+
+  const adjustRightPanelWidth = useCallback(
+    (event: ReactKeyboardEvent<HTMLDivElement>) => {
+      const step = event.shiftKey ? PANEL_RESIZE_LARGE_STEP : PANEL_RESIZE_STEP;
+      let nextWidth = rightPanelWidth;
+
+      if (event.key === "ArrowLeft") nextWidth = rightPanelWidth + step;
+      else if (event.key === "ArrowRight") nextWidth = rightPanelWidth - step;
+      else if (event.key === "Home") nextWidth = RIGHT_PANEL_WIDTH_MIN;
+      else if (event.key === "End") nextWidth = RIGHT_PANEL_WIDTH_MAX;
+      else return;
+
+      event.preventDefault();
+      setRightPanelWidth(clampWidth(nextWidth, RIGHT_PANEL_WIDTH_MIN, RIGHT_PANEL_WIDTH_MAX));
+    },
+    [rightPanelWidth, setRightPanelWidth],
+  );
+
   const detailView = regexDetailId ? (
     <RegexScriptEditor />
   ) : personaDetailId ? (
@@ -321,6 +367,7 @@ export function AppShell() {
         aria-label="Chat list"
         className={cn(
           "mari-sidebar flex-shrink-0 overflow-hidden bg-[var(--background)]/80 backdrop-blur-xl",
+          sidebarDragWidth == null && "transition-[width] duration-200 ease-[cubic-bezier(0.16,1,0.3,1)]",
           sidebarOpen && "border-r border-[var(--sidebar-border)]/30",
           // Mobile: fixed overlay
           "max-md:fixed max-md:inset-y-0 max-md:left-0 max-md:z-50 max-md:shadow-2xl max-md:pt-[env(safe-area-inset-top)]",
@@ -337,8 +384,13 @@ export function AppShell() {
           role="separator"
           aria-orientation="vertical"
           aria-label="Resize left sidebar"
+          aria-valuemin={SIDEBAR_WIDTH_MIN}
+          aria-valuemax={SIDEBAR_WIDTH_MAX}
+          aria-valuenow={Math.round(liveSidebarWidth)}
+          tabIndex={0}
           onMouseDown={startSidebarResize}
-          className="absolute inset-y-0 z-20 hidden w-1 cursor-col-resize bg-transparent transition-colors hover:bg-[var(--primary)]/30 md:block"
+          onKeyDown={adjustSidebarWidth}
+          className="absolute inset-y-0 z-20 hidden w-1 cursor-col-resize bg-transparent transition-colors hover:bg-[var(--primary)]/30 focus-visible:bg-[var(--primary)]/40 focus-visible:outline-none md:block"
           style={{ left: sidebarOpen ? liveSidebarWidth : 0 }}
         />
       )}
@@ -392,6 +444,7 @@ export function AppShell() {
           aria-label="Settings and tools panel"
           className={cn(
             "mari-right-panel flex-shrink-0 overflow-hidden bg-[var(--background)]/80 backdrop-blur-xl",
+            rightPanelDragWidth == null && "transition-[width] duration-200 ease-[cubic-bezier(0.16,1,0.3,1)]",
             rightPanelOpen && "border-l border-[var(--sidebar-border)]/30",
           )}
           style={{ width: rightPanelOpen ? liveRightPanelWidth : 0 }}
@@ -410,8 +463,13 @@ export function AppShell() {
           role="separator"
           aria-orientation="vertical"
           aria-label="Resize right sidebar"
+          aria-valuemin={RIGHT_PANEL_WIDTH_MIN}
+          aria-valuemax={RIGHT_PANEL_WIDTH_MAX}
+          aria-valuenow={Math.round(liveRightPanelWidth)}
+          tabIndex={0}
           onMouseDown={startRightPanelResize}
-          className="absolute inset-y-0 hidden w-1 cursor-col-resize bg-transparent transition-colors hover:bg-[var(--primary)]/30 md:block"
+          onKeyDown={adjustRightPanelWidth}
+          className="absolute inset-y-0 hidden w-1 cursor-col-resize bg-transparent transition-colors hover:bg-[var(--primary)]/30 focus-visible:bg-[var(--primary)]/40 focus-visible:outline-none md:block"
           style={{ right: rightPanelOpen ? liveRightPanelWidth : 0 }}
         />
       )}

--- a/packages/client/src/components/lorebooks/LorebookEditor.tsx
+++ b/packages/client/src/components/lorebooks/LorebookEditor.tsx
@@ -1171,7 +1171,7 @@ export function LorebookEditor() {
                               />
                               {!isCollapsed && (
                                 <div
-                                  className="ml-4 space-y-1.5 border-l-2 border-[var(--border)] pl-3"
+                                  className="ml-4 space-y-1.5 border-l border-[var(--border)] pl-3"
                                   onDragOver={(e) => handleFolderBodyDragOver(folder.id, e)}
                                   onDrop={(e) => {
                                     e.stopPropagation();

--- a/packages/client/src/components/panels/CharactersPanel.tsx
+++ b/packages/client/src/components/panels/CharactersPanel.tsx
@@ -852,7 +852,7 @@ export function CharactersPanel() {
 
                   {/* Expanded: show members */}
                   {isExpanded && (
-                    <div className="ml-5 flex flex-col gap-0.5 border-l-2 border-[var(--border)]/40 pl-3 pb-2">
+                    <div className="ml-5 flex flex-col gap-0.5 border-l border-[var(--border)]/40 pl-3 pb-2">
                       {group.memberIds.length === 0 && (
                         <div className="py-2 text-[0.625rem] text-[var(--muted-foreground)] italic">
                           No members — click <Users size="0.625rem" className="inline" /> to add characters

--- a/packages/client/src/lib/markdown.tsx
+++ b/packages/client/src/lib/markdown.tsx
@@ -69,6 +69,7 @@ export function applyInlineMarkdown(text: string, keyPrefix: string, _depth = 0)
             alt={match[3] || ""}
             className="my-1 inline-block max-w-full rounded-lg align-bottom sm:max-w-md"
             loading="lazy"
+            decoding="async"
           />,
         );
       } else {
@@ -488,6 +489,7 @@ export function renderMarkdownBlocks(
           alt={imgMatch[1] || ""}
           className="my-1 max-w-full rounded-lg sm:max-w-md"
           loading="lazy"
+          decoding="async"
         />,
       );
       continue;

--- a/packages/client/src/main.tsx
+++ b/packages/client/src/main.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { registerSW } from "virtual:pwa-register";
 import { App } from "./App";
 import { startKeepAlive } from "./lib/keep-alive";
 import { installCsrfFetchShim } from "./lib/csrf-fetch";
@@ -21,21 +20,46 @@ const queryClient = new QueryClient({
   },
 });
 
-const updateSW = registerSW({
-  immediate: true,
-  onNeedRefresh() {
-    void updateSW(true);
-  },
-  onRegisteredSW(_swUrl: string, registration?: ServiceWorkerRegistration) {
-    if (!registration) {
+function scheduleAfterFirstLoad(callback: () => void) {
+  const schedule = () => {
+    const requestIdleCallback = window.requestIdleCallback;
+    if (typeof requestIdleCallback === "function") {
+      requestIdleCallback(callback, { timeout: 3_000 });
       return;
     }
 
-    window.setInterval(() => {
-      void registration.update();
-    }, 60_000);
-  },
-});
+    globalThis.setTimeout(callback, 1_000);
+  };
+
+  if (document.readyState === "complete") {
+    schedule();
+    return;
+  }
+
+  window.addEventListener("load", schedule, { once: true });
+}
+
+function registerServiceWorker() {
+  scheduleAfterFirstLoad(() => {
+    void import("virtual:pwa-register").then(({ registerSW }) => {
+      const updateSW = registerSW({
+        immediate: true,
+        onNeedRefresh() {
+          void updateSW(true);
+        },
+        onRegisteredSW(_swUrl: string, registration?: ServiceWorkerRegistration) {
+          if (!registration) {
+            return;
+          }
+
+          window.setInterval(() => {
+            void registration.update();
+          }, 60_000);
+        },
+      });
+    });
+  });
+}
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
@@ -44,3 +68,5 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
     </QueryClientProvider>
   </React.StrictMode>,
 );
+
+registerServiceWorker();

--- a/packages/client/src/main.tsx
+++ b/packages/client/src/main.tsx
@@ -41,23 +41,27 @@ function scheduleAfterFirstLoad(callback: () => void) {
 
 function registerServiceWorker() {
   scheduleAfterFirstLoad(() => {
-    void import("virtual:pwa-register").then(({ registerSW }) => {
-      const updateSW = registerSW({
-        immediate: true,
-        onNeedRefresh() {
-          void updateSW(true);
-        },
-        onRegisteredSW(_swUrl: string, registration?: ServiceWorkerRegistration) {
-          if (!registration) {
-            return;
-          }
+    void import("virtual:pwa-register")
+      .then(({ registerSW }) => {
+        const updateSW = registerSW({
+          immediate: true,
+          onNeedRefresh() {
+            void updateSW(true);
+          },
+          onRegisteredSW(_swUrl: string, registration?: ServiceWorkerRegistration) {
+            if (!registration) {
+              return;
+            }
 
-          window.setInterval(() => {
-            void registration.update();
-          }, 60_000);
-        },
+            window.setInterval(() => {
+              void registration.update();
+            }, 60_000);
+          },
+        });
+      })
+      .catch(() => {
+        // Service worker registration is a progressive enhancement.
       });
-    });
   });
 }
 

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -31,10 +31,10 @@ export interface GameSetupLearnedOptions {
   goals: string[];
 }
 
-const SIDEBAR_WIDTH_MIN = 240;
-const SIDEBAR_WIDTH_MAX = 480;
-const RIGHT_PANEL_WIDTH_MIN = 280;
-const RIGHT_PANEL_WIDTH_MAX = 520;
+export const SIDEBAR_WIDTH_MIN = 240;
+export const SIDEBAR_WIDTH_MAX = 480;
+export const RIGHT_PANEL_WIDTH_MIN = 280;
+export const RIGHT_PANEL_WIDTH_MAX = 520;
 const IMAGE_DIMENSION_MIN = 64;
 const IMAGE_DIMENSION_MAX = 4096;
 const GAME_SETUP_LEARNED_LIMIT = 60;

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -528,9 +528,11 @@ strong {
 
 /* Blockquotes */
 .mari-message-content .mari-md-blockquote {
-  border-left: 3px solid rgba(255, 255, 255, 0.15);
-  padding: 0.15em 0 0.15em 0.75em;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 0.5rem;
+  padding: 0.5em 0.75em;
   margin: 0.35em 0;
+  background: rgba(255, 255, 255, 0.035);
   color: rgba(255, 255, 255, 0.6);
   font-style: italic;
 }
@@ -1599,10 +1601,8 @@ summary[class*="cursor-pointer"],
 }
 
 .glimmer-name-gradient {
-  background: linear-gradient(135deg, var(--y2k-lavender) 0%, var(--y2k-pink) 50%, var(--y2k-purple) 100%);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  color: var(--y2k-pink);
+  text-shadow: 0 0 12px rgba(var(--y2k-pink-rgb, 255, 143, 171), 0.18);
 }
 
 .glimmer-bubble {
@@ -1840,10 +1840,8 @@ summary[class*="cursor-pointer"],
 }
 
 .rpg-char-name {
-  background: linear-gradient(135deg, #c084fc 0%, #f472b6 50%, #fb923c 100%);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  color: #f0abfc;
+  text-shadow: 0 0 14px rgba(244, 114, 182, 0.18);
 }
 
 .rpg-streaming {

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -528,12 +528,12 @@ strong {
 
 /* Blockquotes */
 .mari-message-content .mari-md-blockquote {
-  border: 1px solid rgba(255, 255, 255, 0.14);
+  border: 1px solid var(--border);
   border-radius: 0.5rem;
   padding: 0.5em 0.75em;
   margin: 0.35em 0;
-  background: rgba(255, 255, 255, 0.035);
-  color: rgba(255, 255, 255, 0.6);
+  background: color-mix(in srgb, var(--card) 94%, var(--accent));
+  color: var(--muted-foreground);
   font-style: italic;
 }
 
@@ -1601,8 +1601,8 @@ summary[class*="cursor-pointer"],
 }
 
 .glimmer-name-gradient {
-  color: var(--y2k-pink);
-  text-shadow: 0 0 12px rgba(var(--y2k-pink-rgb, 255, 143, 171), 0.18);
+  color: var(--y2k-pink, var(--primary));
+  text-shadow: 0 0 12px color-mix(in srgb, var(--y2k-pink, var(--primary)) 18%, transparent);
 }
 
 .glimmer-bubble {
@@ -1840,8 +1840,8 @@ summary[class*="cursor-pointer"],
 }
 
 .rpg-char-name {
-  color: #f0abfc;
-  text-shadow: 0 0 14px rgba(244, 114, 182, 0.18);
+  color: color-mix(in srgb, var(--primary) 72%, var(--foreground));
+  text-shadow: 0 0 14px color-mix(in srgb, var(--primary) 20%, transparent);
 }
 
 .rpg-streaming {

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -91,6 +91,8 @@ export default defineConfig({
           workbox: {
             // Intentionally exclude html so index.html is not precached and does not interfere with the PWA stale-version/update flow.
             globPatterns: ["**/*.{js,css,png,svg,ico,woff2}"],
+            // Keep the offline shell lean. Large decorative sprites and splash art are fetched on demand.
+            globIgnores: ["**/sprites/**", "logo.png", "logo-splash.gif"],
             navigateFallbackAllowlist: [],
             runtimeCaching: [
               {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,9 +31,6 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.80.7
         version: 5.90.21(react@19.2.4)
-      '@tanstack/react-router':
-        specifier: ^1.121.0
-        version: 1.163.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -66,7 +63,7 @@ importers:
         version: 7.4.0
       zustand:
         specifier: ^5.0.5
-        version: 5.0.11(@types/react@19.2.14)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
+        version: 5.0.11(@types/react@19.2.14)(react@19.2.4)
     devDependencies:
       '@eslint/js':
         specifier: ^9.39.4
@@ -1709,10 +1706,6 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
 
-  '@tanstack/history@1.161.4':
-    resolution: {integrity: sha512-Kp/WSt411ZWYvgXy6uiv5RmhHrz9cAml05AQPrtdAp7eUqvIDbMGPnML25OKbzR3RJ1q4wgENxDTvlGPa9+Mww==}
-    engines: {node: '>=20.19'}
-
   '@tanstack/query-core@5.90.20':
     resolution: {integrity: sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==}
 
@@ -1720,26 +1713,6 @@ packages:
     resolution: {integrity: sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg==}
     peerDependencies:
       react: ^18 || ^19
-
-  '@tanstack/react-router@1.163.3':
-    resolution: {integrity: sha512-hheBbFVb+PbxtrWp8iy6+TTRTbhx3Pn6hKo8Tv/sWlG89ZMcD1xpQWzx8ukHN9K8YWbh5rdzt4kv6u8X4kB28Q==}
-    engines: {node: '>=20.19'}
-    peerDependencies:
-      react: '>=18.0.0 || >=19.0.0'
-      react-dom: '>=18.0.0 || >=19.0.0'
-
-  '@tanstack/react-store@0.9.1':
-    resolution: {integrity: sha512-YzJLnRvy5lIEFTLWBAZmcOjK3+2AepnBv/sr6NZmiqJvq7zTQggyK99Gw8fqYdMdHPQWXjz0epFKJXC+9V2xDA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
-  '@tanstack/router-core@1.163.3':
-    resolution: {integrity: sha512-jPptiGq/w3nuPzcMC7RNa79aU+b6OjaDzWJnBcV2UAwL4ThJamRS4h42TdhJE+oF5yH9IEnCOGQdfnbw45LbfA==}
-    engines: {node: '>=20.19'}
-
-  '@tanstack/store@0.9.1':
-    resolution: {integrity: sha512-+qcNkOy0N1qSGsP7omVCW0SDrXtaDcycPqBDE726yryiA5eTDFpjBReaYjghVJwNf1pcPMyzIwTGlYjCSQR0Fg==}
 
   '@types/adm-zip@0.5.8':
     resolution: {integrity: sha512-RVVH7QvZYbN+ihqZ4kX/dMiowf6o+Jk1fNwiSdx0NahBJLU787zkULhGhJM8mf/obmLGmgdMM0bXsQTmyfbR7Q==}
@@ -2039,9 +2012,6 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
-
-  cookie-es@2.0.0:
-    resolution: {integrity: sha512-RAj4E421UYRgqokKUmotqAwuplYw15qtdXfY+hGzgCJ/MBjCVZcSoHK/kH9kocfjRjcDME7IiDWR/1WX1TM2Pg==}
 
   cookie-signature@1.2.2:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
@@ -2792,10 +2762,6 @@ packages:
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
-  isbot@5.1.35:
-    resolution: {integrity: sha512-waFfC72ZNfwLLuJ2iLaoVaqcNo+CAaLR7xCpAn0Y5WfGzkNHv7ZN39Vbi1y+kb+Zs46XHOX3tZNExroFUPX+Kg==}
-    engines: {node: '>=18'}
-
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
@@ -3444,16 +3410,6 @@ packages:
   serialize-javascript@6.0.2:
     resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
 
-  seroval-plugins@1.5.0:
-    resolution: {integrity: sha512-EAHqADIQondwRZIdeW2I636zgsODzoBDwb3PT/+7TLDWyw1Dy/Xv7iGUIEXXav7usHDE9HVhOU61irI3EnyyHA==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      seroval: ^1.0
-
-  seroval@1.5.0:
-    resolution: {integrity: sha512-OE4cvmJ1uSPrKorFIH9/w/Qwuvi/IMcGbv5RKgcJ/zjA/IohDLU6SVaxFN9FwajbP7nsX0dQqMDes1whk3y+yw==}
-    engines: {node: '>=10'}
-
   serve-static@2.2.1:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
     engines: {node: '>= 18'}
@@ -3634,12 +3590,6 @@ packages:
   thread-stream@3.1.0:
     resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
 
-  tiny-invariant@1.3.3:
-    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
-
-  tiny-warning@1.0.3:
-    resolution: {integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==}
-
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
@@ -3771,11 +3721,6 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
-
-  use-sync-external-store@1.6.0:
-    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -5401,44 +5346,12 @@ snapshots:
       tailwindcss: 4.2.4
       vite: 7.3.2(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)
 
-  '@tanstack/history@1.161.4': {}
-
   '@tanstack/query-core@5.90.20': {}
 
   '@tanstack/react-query@5.90.21(react@19.2.4)':
     dependencies:
       '@tanstack/query-core': 5.90.20
       react: 19.2.4
-
-  '@tanstack/react-router@1.163.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
-    dependencies:
-      '@tanstack/history': 1.161.4
-      '@tanstack/react-store': 0.9.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@tanstack/router-core': 1.163.3
-      isbot: 5.1.35
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-      tiny-invariant: 1.3.3
-      tiny-warning: 1.0.3
-
-  '@tanstack/react-store@0.9.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
-    dependencies:
-      '@tanstack/store': 0.9.1
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-      use-sync-external-store: 1.6.0(react@19.2.4)
-
-  '@tanstack/router-core@1.163.3':
-    dependencies:
-      '@tanstack/history': 1.161.4
-      '@tanstack/store': 0.9.1
-      cookie-es: 2.0.0
-      seroval: 1.5.0
-      seroval-plugins: 1.5.0(seroval@1.5.0)
-      tiny-invariant: 1.3.3
-      tiny-warning: 1.0.3
-
-  '@tanstack/store@0.9.1': {}
 
   '@types/adm-zip@0.5.8':
     dependencies:
@@ -5799,8 +5712,6 @@ snapshots:
   content-type@1.0.5: {}
 
   convert-source-map@2.0.0: {}
-
-  cookie-es@2.0.0: {}
 
   cookie-signature@1.2.2: {}
 
@@ -6589,8 +6500,6 @@ snapshots:
 
   isarray@2.0.5: {}
 
-  isbot@5.1.35: {}
-
   isexe@2.0.0: {}
 
   jackspeak@4.2.3:
@@ -7246,12 +7155,6 @@ snapshots:
     dependencies:
       randombytes: 2.1.0
 
-  seroval-plugins@1.5.0(seroval@1.5.0):
-    dependencies:
-      seroval: 1.5.0
-
-  seroval@1.5.0: {}
-
   serve-static@2.2.1:
     dependencies:
       encodeurl: 2.0.0
@@ -7484,10 +7387,6 @@ snapshots:
     dependencies:
       real-require: 0.2.0
 
-  tiny-invariant@1.3.3: {}
-
-  tiny-warning@1.0.3: {}
-
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
@@ -7622,10 +7521,6 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
-
-  use-sync-external-store@1.6.0(react@19.2.4):
-    dependencies:
-      react: 19.2.4
 
   util-deprecate@1.0.2: {}
 
@@ -7847,8 +7742,7 @@ snapshots:
 
   zod@3.25.76: {}
 
-  zustand@5.0.11(@types/react@19.2.14)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4)):
+  zustand@5.0.11(@types/react@19.2.14)(react@19.2.4):
     optionalDependencies:
       '@types/react': 19.2.14
       react: 19.2.4
-      use-sync-external-store: 1.6.0(react@19.2.4)


### PR DESCRIPTION
## Summary
- trim the client PWA/offline footprint by excluding decorative sprites and splash assets from precache, removing an unused router dependency, and avoiding the oversized logo as an install icon
- defer service worker registration until after first load/idle time, and treat SW registration as a progressive enhancement if the virtual module is unavailable
- avoid persisted Zustand writes during live sidebar resizing, while keeping desktop panel open/close transitions smooth and drag movement instant
- apply a deeper `$impeccable audit` pass: remove decorative gradient text and side-stripe accents in touched surfaces, add labels for obvious icon-only controls, and lazy/async decode chat/gallery imagery
- apply `$impeccable optimize`: remove the render-blocking Google Fonts stylesheet from the shell and replace the empty-state 638 KiB GIF / 598 KiB logo path with the existing 34 KiB icon
- apply `$impeccable polish`: add keyboard-adjustable resize separators with focus states and preserve the newer chat HTML color sanitizer allowance from the base branch

## Audit / Optimize / Polish Notes
- Audit health after this pass: **17/20 Good**
- Accessibility: **3/4**, improved obvious unlabeled icon controls and desktop resize separator keyboard access; broader form labeling needs a separate targeted pass because scan output includes many custom-control false positives
- Performance: **4/4**, PWA precache is now 91 entries / ~3.27 MiB, large decorative assets are on-demand, SW work is off the initial path, live resize persistence is delayed until mouseup, and first empty-state view no longer requests the ~600 KiB logo/GIF or Google Fonts CSS
- Responsive: **3/4**, existing responsive shell remains intact; no new fixed-width mobile risks found in the edited surfaces
- Theming: **3/4**, token usage is mostly preserved; some legacy hard-coded game/theme colors remain intentional local flavor
- Anti-patterns: **4/4**, targeted polish removed decorative gradient text and >1px side-stripe accents in edited surfaces; width transitions are limited to panel open/close and disabled while dragging to avoid resize jank

## Stacking
This is stacked on draft PR #387 (`codex/security-hardening-v1.5.7`). Review this PR after or alongside #387.

## Test Plan
- [ ] Manually verify first app load and PWA update behavior in browser
- [ ] Manually verify the empty chat state still looks correct with the static icon and system font stack
- [ ] Manually verify left sidebar and right panel resizing feels smooth, persists after mouseup, and works from the keyboard with Arrow/Home/End on desktop separators
- [ ] Manually verify chat message avatars, attachments, gallery lightbox, and swipe controls remain usable with mouse and keyboard
- [ ] Manually verify roleplay/game map/readable display visuals still look intentional after audit polish

Validation run locally:
- `pnpm check`

No linked issue was provided; one should be opened before this PR is submitted, per `CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced accessibility by adding proper button labels and types throughout the interface.
  * Optimized image loading performance with async decoding and lazy-loading attributes.
  * Improved panel resizing with live-drag feedback for real-time width updates.

* **Style**
  * Updated blockquote styling with full borders and translucent backgrounds.
  * Refined character name and gradient text styling.
  * Adjusted border widths in folder and group displays.

* **Chores**
  * Updated PWA manifest icons, removing legacy logo references.
  * Removed unused dependency.
  * Deferred service worker registration for better performance.
  * Simplified PWA precaching by excluding splash assets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->