### PR TITLE
[codex] Add Home Assistant HACS integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 - PocketTTS is now available as a local TTS provider.
 - Optional speech-to-text microphone buttons can be enabled for Conversation, Roleplay, and Game input fields.
 - Character imports now ask before extracting embedded character-card lorebooks into standalone Marinara lorebooks.
+- Home Assistant HACS integration that syncs Marinara custom tools and a Home Assistant agent for smart-home control.
 
 ### Security
 

--- a/custom_components/marinara_engine/__init__.py
+++ b/custom_components/marinara_engine/__init__.py
@@ -1,0 +1,148 @@
+"""Marinara Engine Home Assistant Integration."""
+
+from __future__ import annotations
+
+import logging
+
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.helpers import config_validation as cv
+
+from .const import (
+    CONF_ENABLED_CATEGORIES,
+    CONF_HOST,
+    CONF_PORT,
+    CONF_PRIMARY_CHAT_ID,
+    CONF_WEBHOOK_ID,
+    DEFAULT_ENABLED_CATEGORIES,
+    DOMAIN,
+)
+from .coordinator import MarinaraCoordinator
+from .http import MarinaraToolManifestView
+from .webhook import async_register_webhook, async_unregister_webhook
+
+_LOGGER = logging.getLogger(__name__)
+
+PLATFORMS = [Platform.SENSOR, Platform.SWITCH, Platform.SELECT, Platform.BUTTON]
+
+SEND_MESSAGE_SCHEMA = vol.Schema(
+    {
+        vol.Optional("chat_id"): cv.string,
+        vol.Required("message"): cv.string,
+        vol.Optional("role", default="user"): vol.In(
+            ["user", "assistant", "system", "narrator"]
+        ),
+        vol.Optional("trigger_generation", default=False): cv.boolean,
+    }
+)
+
+TRIGGER_GENERATION_SCHEMA = vol.Schema(
+    {
+        vol.Optional("chat_id"): cv.string,
+        vol.Optional("user_message"): cv.string,
+    }
+)
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    coordinator = MarinaraCoordinator(
+        hass, entry.data[CONF_HOST], entry.data[CONF_PORT]
+    )
+    await coordinator.async_verify_connection()
+    await coordinator.async_config_entry_first_refresh()
+
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
+
+    webhook_id: str = entry.data[CONF_WEBHOOK_ID]
+    async_register_webhook(hass, webhook_id)
+    hass.http.register_view(MarinaraToolManifestView(webhook_id, entry.entry_id))
+
+    _async_register_services(hass, entry, coordinator)
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    # Auto-sync HA tools into Marinara on every startup (idempotent — skips existing)
+    enabled_categories = entry.options.get(CONF_ENABLED_CATEGORIES, DEFAULT_ENABLED_CATEGORIES)
+    hass.async_create_task(
+        _async_sync_tools(hass, coordinator, webhook_id, enabled_categories)
+    )
+
+    return True
+
+
+async def _async_sync_tools(
+    hass: HomeAssistant,
+    coordinator: MarinaraCoordinator,
+    webhook_id: str,
+    enabled_categories: list[str],
+) -> None:
+    from homeassistant.helpers.network import NoURLAvailableError, get_url
+
+    try:
+        base_url = get_url(hass, allow_internal=True, prefer_external=False)
+    except NoURLAvailableError:
+        base_url = f"http://{hass.config.api.local_ip}:{hass.config.api.port}"
+
+    webhook_url = f"{base_url}/api/webhook/{webhook_id}"
+    try:
+        created, updated = await coordinator.sync_tools(webhook_url, enabled_categories)
+        _LOGGER.info(
+            "Marinara Engine: tool sync complete — %d created, %d updated",
+            created,
+            updated,
+        )
+        agent_status = await coordinator.sync_agent(enabled_categories)
+        if agent_status != "unchanged":
+            _LOGGER.info("Marinara Engine: Home Assistant agent %s", agent_status)
+    except Exception as err:
+        _LOGGER.warning("Marinara Engine: could not auto-sync tools: %s", err)
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    async_unregister_webhook(hass, entry.data[CONF_WEBHOOK_ID])
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id, None)
+    return unload_ok
+
+
+def _async_register_services(
+    hass: HomeAssistant, entry: ConfigEntry, coordinator: MarinaraCoordinator
+) -> None:
+    if hass.services.has_service(DOMAIN, "send_message"):
+        return
+
+    async def _send_message(call: ServiceCall) -> None:
+        chat_id = call.data.get("chat_id") or entry.options.get(CONF_PRIMARY_CHAT_ID)
+        if not chat_id:
+            _LOGGER.error(
+                "marinara_engine.send_message: no chat_id provided and no primary chat set"
+            )
+            return
+        await coordinator.send_message(
+            chat_id, call.data["message"], call.data.get("role", "user")
+        )
+        if call.data.get("trigger_generation"):
+            await coordinator.trigger_generation(chat_id)
+
+    async def _trigger_generation(call: ServiceCall) -> None:
+        chat_id = call.data.get("chat_id") or entry.options.get(CONF_PRIMARY_CHAT_ID)
+        if not chat_id:
+            _LOGGER.error(
+                "marinara_engine.trigger_generation: no chat_id provided and no primary chat set"
+            )
+            return
+        await coordinator.trigger_generation(chat_id, call.data.get("user_message"))
+
+    hass.services.async_register(
+        DOMAIN, "send_message", _send_message, schema=SEND_MESSAGE_SCHEMA
+    )
+    hass.services.async_register(
+        DOMAIN,
+        "trigger_generation",
+        _trigger_generation,
+        schema=TRIGGER_GENERATION_SCHEMA,
+    )

--- a/custom_components/marinara_engine/__init__.py
+++ b/custom_components/marinara_engine/__init__.py
@@ -84,7 +84,11 @@ async def _async_sync_tools(
     try:
         base_url = get_url(hass, allow_internal=True, prefer_external=False)
     except NoURLAvailableError:
-        base_url = f"http://{hass.config.api.local_ip}:{hass.config.api.port}"
+        api = getattr(hass.config, "api", None)
+        if api is None or not api.local_ip or not api.port:
+            _LOGGER.warning("Cannot determine Home Assistant URL for tool sync")
+            return
+        base_url = f"http://{api.local_ip}:{api.port}"
 
     webhook_url = f"{base_url}/api/webhook/{webhook_id}"
     try:

--- a/custom_components/marinara_engine/button.py
+++ b/custom_components/marinara_engine/button.py
@@ -78,18 +78,24 @@ class MarinaraSyncToolsButton(CoordinatorEntity[MarinaraCoordinator], ButtonEnti
         try:
             base_url = get_url(self.hass, allow_internal=True, prefer_external=False)
         except NoURLAvailableError:
-            base_url = (
-                f"http://{self.hass.config.api.local_ip}"
-                f":{self.hass.config.api.port}"
-            )
+            api = getattr(self.hass.config, "api", None)
+            if api is None or not api.local_ip or not api.port:
+                _LOGGER.error("Cannot determine Home Assistant URL for tool sync")
+                return
+            base_url = f"http://{api.local_ip}:{api.port}"
         webhook_url = f"{base_url}/api/webhook/{webhook_id}"
         enabled_categories = self._entry.options.get(
             CONF_ENABLED_CATEGORIES, DEFAULT_ENABLED_CATEGORIES
         )
-        created, updated = await self.coordinator.sync_tools(webhook_url, enabled_categories)
-        _LOGGER.info(
-            "Marinara tool sync: %d created, %d updated", created, updated
-        )
-        agent_status = await self.coordinator.sync_agent(enabled_categories)
-        if agent_status != "unchanged":
-            _LOGGER.info("Marinara tool sync: Home Assistant agent %s", agent_status)
+        try:
+            created, updated = await self.coordinator.sync_tools(
+                webhook_url, enabled_categories
+            )
+            _LOGGER.info(
+                "Marinara tool sync: %d created, %d updated", created, updated
+            )
+            agent_status = await self.coordinator.sync_agent(enabled_categories)
+            if agent_status != "unchanged":
+                _LOGGER.info("Marinara tool sync: Home Assistant agent %s", agent_status)
+        except Exception:
+            _LOGGER.exception("Marinara tool sync failed")

--- a/custom_components/marinara_engine/button.py
+++ b/custom_components/marinara_engine/button.py
@@ -1,0 +1,95 @@
+"""Button platform for Marinara Engine."""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.network import NoURLAvailableError, get_url
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import CONF_ENABLED_CATEGORIES, CONF_WEBHOOK_ID, DEFAULT_ENABLED_CATEGORIES, DOMAIN
+from .coordinator import MarinaraCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    coordinator: MarinaraCoordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities([
+        MarinaraAbortButton(coordinator, entry),
+        MarinaraSyncToolsButton(coordinator, entry),
+    ])
+
+
+class MarinaraAbortButton(CoordinatorEntity[MarinaraCoordinator], ButtonEntity):
+    """Cancel any in-flight AI generation."""
+
+    _attr_icon = "mdi:stop-circle-outline"
+
+    def __init__(self, coordinator: MarinaraCoordinator, entry: ConfigEntry) -> None:
+        super().__init__(coordinator)
+        self._entry = entry
+        self._attr_unique_id = f"{entry.entry_id}_abort_generation"
+        self._attr_name = "Marinara Abort Generation"
+
+    @property
+    def device_info(self) -> dict:
+        return {
+            "identifiers": {(DOMAIN, self._entry.entry_id)},
+            "name": "Marinara Engine",
+            "manufacturer": "Marinara Engine",
+            "model": "Local AI Engine",
+        }
+
+    async def async_press(self) -> None:
+        await self.coordinator.abort_generation()
+
+
+class MarinaraSyncToolsButton(CoordinatorEntity[MarinaraCoordinator], ButtonEntity):
+    """Push all 21 HA tool definitions into Marinara's Custom Tools."""
+
+    _attr_icon = "mdi:cloud-sync-outline"
+
+    def __init__(self, coordinator: MarinaraCoordinator, entry: ConfigEntry) -> None:
+        super().__init__(coordinator)
+        self._entry = entry
+        self._attr_unique_id = f"{entry.entry_id}_sync_tools"
+        self._attr_name = "Marinara Sync HA Tools"
+
+    @property
+    def device_info(self) -> dict:
+        return {
+            "identifiers": {(DOMAIN, self._entry.entry_id)},
+            "name": "Marinara Engine",
+            "manufacturer": "Marinara Engine",
+            "model": "Local AI Engine",
+        }
+
+    async def async_press(self) -> None:
+        webhook_id: str = self._entry.data[CONF_WEBHOOK_ID]
+        try:
+            base_url = get_url(self.hass, allow_internal=True, prefer_external=False)
+        except NoURLAvailableError:
+            base_url = (
+                f"http://{self.hass.config.api.local_ip}"
+                f":{self.hass.config.api.port}"
+            )
+        webhook_url = f"{base_url}/api/webhook/{webhook_id}"
+        enabled_categories = self._entry.options.get(
+            CONF_ENABLED_CATEGORIES, DEFAULT_ENABLED_CATEGORIES
+        )
+        created, updated = await self.coordinator.sync_tools(webhook_url, enabled_categories)
+        _LOGGER.info(
+            "Marinara tool sync: %d created, %d updated", created, updated
+        )
+        agent_status = await self.coordinator.sync_agent(enabled_categories)
+        if agent_status != "unchanged":
+            _LOGGER.info("Marinara tool sync: Home Assistant agent %s", agent_status)

--- a/custom_components/marinara_engine/config_flow.py
+++ b/custom_components/marinara_engine/config_flow.py
@@ -1,0 +1,157 @@
+"""Config flow for Marinara Engine."""
+
+from __future__ import annotations
+
+import logging
+
+import aiohttp
+import voluptuous as vol
+
+from homeassistant.components.webhook import async_generate_id
+from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
+from homeassistant.core import callback
+from homeassistant.data_entry_flow import FlowResult
+
+from homeassistant.helpers.selector import (
+    SelectOptionDict,
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
+)
+
+from .const import (
+    CONF_ENABLED_CATEGORIES,
+    CONF_HOST,
+    CONF_PORT,
+    CONF_PRIMARY_CHAT_ID,
+    CONF_WEBHOOK_ID,
+    DEFAULT_ENABLED_CATEGORIES,
+    DEFAULT_HOST,
+    DEFAULT_PORT,
+    DOMAIN,
+    TOOL_CATEGORIES,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+_STEP_USER_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_HOST, default=DEFAULT_HOST): str,
+        vol.Required(CONF_PORT, default=DEFAULT_PORT): vol.Coerce(int),
+    }
+)
+
+
+async def _test_connection(host: str, port: int) -> str | None:
+    """Return None on success or an error key string on failure."""
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(
+                f"http://{host}:{port}/api/chats",
+                timeout=aiohttp.ClientTimeout(total=5),
+            ) as resp:
+                if resp.status == 200:
+                    return None
+                return "cannot_connect"
+    except aiohttp.ClientConnectionError:
+        return "cannot_connect"
+    except Exception:
+        return "unknown"
+
+
+class MarinaraConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Marinara Engine."""
+
+    VERSION = 1
+
+    async def async_step_user(
+        self, user_input: dict | None = None
+    ) -> FlowResult:
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            host = user_input[CONF_HOST].strip()
+            port = user_input[CONF_PORT]
+
+            error = await _test_connection(host, port)
+            if error:
+                errors["base"] = error
+            else:
+                await self.async_set_unique_id(f"{host}:{port}")
+                self._abort_if_unique_id_configured()
+
+                return self.async_create_entry(
+                    title=f"Marinara Engine ({host}:{port})",
+                    data={
+                        CONF_HOST: host,
+                        CONF_PORT: port,
+                        CONF_WEBHOOK_ID: async_generate_id(),
+                    },
+                )
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=_STEP_USER_SCHEMA,
+            errors=errors,
+        )
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlow:
+        return MarinaraOptionsFlow(config_entry)
+
+
+class MarinaraOptionsFlow(OptionsFlow):
+    """Options flow: choose which chat is the primary chat for services."""
+
+    def __init__(self, config_entry: ConfigEntry) -> None:
+        self._config_entry = config_entry
+        self._chats: list[dict] = []
+
+    async def async_step_init(
+        self, user_input: dict | None = None
+    ) -> FlowResult:
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        host = self._config_entry.data[CONF_HOST]
+        port = self._config_entry.data[CONF_PORT]
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(
+                    f"http://{host}:{port}/api/chats",
+                    timeout=aiohttp.ClientTimeout(total=5),
+                ) as resp:
+                    self._chats = await resp.json() if resp.status == 200 else []
+        except Exception:
+            self._chats = []
+
+        chat_options = {c["id"]: c["name"] for c in self._chats}
+        current_chat = self._config_entry.options.get(CONF_PRIMARY_CHAT_ID, "")
+        current_cats = self._config_entry.options.get(
+            CONF_ENABLED_CATEGORIES, DEFAULT_ENABLED_CATEGORIES
+        )
+
+        schema = vol.Schema(
+            {
+                vol.Optional(CONF_PRIMARY_CHAT_ID, default=current_chat): vol.In(
+                    chat_options
+                )
+                if chat_options
+                else str,
+                vol.Optional(
+                    CONF_ENABLED_CATEGORIES, default=current_cats
+                ): SelectSelector(
+                    SelectSelectorConfig(
+                        options=[
+                            SelectOptionDict(value=k, label=v)
+                            for k, v in TOOL_CATEGORIES.items()
+                        ],
+                        multiple=True,
+                        mode=SelectSelectorMode.LIST,
+                    )
+                ),
+            }
+        )
+
+        return self.async_show_form(step_id="init", data_schema=schema)

--- a/custom_components/marinara_engine/config_flow.py
+++ b/custom_components/marinara_engine/config_flow.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping
 
 import aiohttp
 import voluptuous as vol
@@ -40,6 +41,26 @@ _STEP_USER_SCHEMA = vol.Schema(
         vol.Required(CONF_PORT, default=DEFAULT_PORT): vol.Coerce(int),
     }
 )
+
+
+def _chat_options_from_payload(chats: list[object]) -> dict[str, str]:
+    """Build safe chat selector options from Marinara's /api/chats payload."""
+    options: dict[str, str] = {}
+    for chat in chats:
+        if not isinstance(chat, Mapping):
+            _LOGGER.debug("Skipping malformed Marinara chat entry: %s", chat)
+            continue
+        chat_id = chat.get("id")
+        name = chat.get("name")
+        if chat_id is None or not name:
+            _LOGGER.debug("Skipping incomplete Marinara chat entry: %s", chat)
+            continue
+        key = str(chat_id)
+        if key in options:
+            _LOGGER.debug("Skipping duplicate Marinara chat id: %s", key)
+            continue
+        options[key] = str(name)
+    return options
 
 
 async def _test_connection(host: str, port: int) -> str | None:
@@ -106,7 +127,7 @@ class MarinaraOptionsFlow(OptionsFlow):
 
     def __init__(self, config_entry: ConfigEntry) -> None:
         self._config_entry = config_entry
-        self._chats: list[dict] = []
+        self._chats: list[object] = []
 
     async def async_step_init(
         self, user_input: dict | None = None
@@ -126,7 +147,7 @@ class MarinaraOptionsFlow(OptionsFlow):
         except Exception:
             self._chats = []
 
-        chat_options = {c["id"]: c["name"] for c in self._chats}
+        chat_options = _chat_options_from_payload(self._chats)
         current_chat = self._config_entry.options.get(CONF_PRIMARY_CHAT_ID, "")
         current_cats = self._config_entry.options.get(
             CONF_ENABLED_CATEGORIES, DEFAULT_ENABLED_CATEGORIES

--- a/custom_components/marinara_engine/const.py
+++ b/custom_components/marinara_engine/const.py
@@ -1,0 +1,470 @@
+"""Constants for the Marinara Engine integration."""
+
+DOMAIN = "marinara_engine"
+
+DEFAULT_HOST = "localhost"
+DEFAULT_PORT = 3000
+SCAN_INTERVAL = 30  # seconds
+
+CONF_HOST = "host"
+CONF_PORT = "port"
+CONF_WEBHOOK_ID = "webhook_id"
+CONF_PRIMARY_CHAT_ID = "primary_chat_id"
+CONF_ENABLED_CATEGORIES = "enabled_categories"
+
+TOOL_CATEGORIES: dict[str, str] = {
+    "lights": "Lights & Switches",
+    "climate": "Climate",
+    "covers": "Covers (Blinds & Garage)",
+    "locks": "Locks",
+    "media": "Media Players",
+    "scenes_scripts": "Scenes & Scripts",
+    "query": "Query & Generic",
+}
+
+# Locks excluded by default — users can opt in via Options
+DEFAULT_ENABLED_CATEGORIES: list[str] = [
+    "lights",
+    "climate",
+    "covers",
+    "media",
+    "scenes_scripts",
+    "query",
+]
+
+# Each tool carries a "category" key matching TOOL_CATEGORIES above.
+TOOL_DEFINITIONS = [
+    # ------------------------------------------------------------------ lights
+    {
+        "name": "ha_turn_on",
+        "category": "lights",
+        "description": (
+            "Turn on a Home Assistant entity or all entities of a given domain in an area. "
+            "Provide entity_id for a single entity, or area_name (+ optional domain, default 'light') "
+            "to turn on everything in a room at once."
+        ),
+        "parametersSchema": {
+            "type": "object",
+            "properties": {
+                "entity_id": {
+                    "type": "string",
+                    "description": "Entity ID to turn on, e.g. light.living_room",
+                },
+                "area_name": {
+                    "type": "string",
+                    "description": "Area name to target, e.g. Büro. Turns on all entities of the given domain in that area.",
+                },
+                "domain": {
+                    "type": "string",
+                    "description": "Domain to target when using area_name (default: light), e.g. light, switch, fan",
+                },
+            },
+        },
+    },
+    {
+        "name": "ha_turn_off",
+        "category": "lights",
+        "description": (
+            "Turn off a Home Assistant entity or all entities of a given domain in an area. "
+            "Provide entity_id for a single entity, or area_name (+ optional domain, default 'light')."
+        ),
+        "parametersSchema": {
+            "type": "object",
+            "properties": {
+                "entity_id": {
+                    "type": "string",
+                    "description": "Entity ID to turn off",
+                },
+                "area_name": {
+                    "type": "string",
+                    "description": "Area name to target, e.g. Büro",
+                },
+                "domain": {
+                    "type": "string",
+                    "description": "Domain to target when using area_name (default: light)",
+                },
+            },
+        },
+    },
+    {
+        "name": "ha_toggle",
+        "category": "lights",
+        "description": (
+            "Toggle a Home Assistant entity or all entities of a given domain in an area. "
+            "Provide entity_id for a single entity, or area_name (+ optional domain, default 'light')."
+        ),
+        "parametersSchema": {
+            "type": "object",
+            "properties": {
+                "entity_id": {
+                    "type": "string",
+                    "description": "Entity ID to toggle",
+                },
+                "area_name": {
+                    "type": "string",
+                    "description": "Area name to target, e.g. Büro",
+                },
+                "domain": {
+                    "type": "string",
+                    "description": "Domain to target when using area_name (default: light)",
+                },
+            },
+        },
+    },
+    {
+        "name": "ha_set_brightness",
+        "category": "lights",
+        "description": "Set the brightness of a light or all lights in an area",
+        "parametersSchema": {
+            "type": "object",
+            "properties": {
+                "entity_id": {"type": "string", "description": "Light entity ID"},
+                "area_name": {"type": "string", "description": "Area name to target all lights in that room"},
+                "brightness_pct": {
+                    "type": "number",
+                    "description": "Brightness as a percentage from 0 to 100",
+                },
+            },
+            "required": ["brightness_pct"],
+        },
+    },
+    {
+        "name": "ha_set_color",
+        "category": "lights",
+        "description": "Set the RGB color of a light or all lights in an area",
+        "parametersSchema": {
+            "type": "object",
+            "properties": {
+                "entity_id": {"type": "string", "description": "Light entity ID"},
+                "area_name": {"type": "string", "description": "Area name to target all lights in that room"},
+                "r": {"type": "number", "description": "Red component 0-255"},
+                "g": {"type": "number", "description": "Green component 0-255"},
+                "b": {"type": "number", "description": "Blue component 0-255"},
+            },
+            "required": ["r", "g", "b"],
+        },
+    },
+    {
+        "name": "ha_set_color_temp",
+        "category": "lights",
+        "description": "Set the color temperature of a light or all lights in an area",
+        "parametersSchema": {
+            "type": "object",
+            "properties": {
+                "entity_id": {"type": "string", "description": "Light entity ID"},
+                "area_name": {"type": "string", "description": "Area name to target all lights in that room"},
+                "kelvin": {
+                    "type": "number",
+                    "description": "Color temperature in Kelvin, e.g. 2700 for warm white, 6500 for cool daylight",
+                },
+            },
+            "required": ["kelvin"],
+        },
+    },
+    # ----------------------------------------------------------------- climate
+    {
+        "name": "ha_set_temperature",
+        "category": "climate",
+        "description": "Set the target temperature on a climate device or all climate devices in an area",
+        "parametersSchema": {
+            "type": "object",
+            "properties": {
+                "entity_id": {"type": "string", "description": "Climate entity ID"},
+                "area_name": {"type": "string", "description": "Area name to target all climate devices in that room"},
+                "temperature": {
+                    "type": "number",
+                    "description": "Target temperature in the unit configured in Home Assistant",
+                },
+            },
+            "required": ["temperature"],
+        },
+    },
+    {
+        "name": "ha_set_hvac_mode",
+        "category": "climate",
+        "description": "Set the HVAC mode of a climate device or all climate devices in an area",
+        "parametersSchema": {
+            "type": "object",
+            "properties": {
+                "entity_id": {"type": "string", "description": "Climate entity ID"},
+                "area_name": {"type": "string", "description": "Area name to target all climate devices in that room"},
+                "hvac_mode": {
+                    "type": "string",
+                    "description": "HVAC mode: off, heat, cool, heat_cool, auto, dry, fan_only",
+                },
+            },
+            "required": ["hvac_mode"],
+        },
+    },
+    # ------------------------------------------------------------------ covers
+    {
+        "name": "ha_open_cover",
+        "category": "covers",
+        "description": "Open a cover or all covers in an area (blinds, garage door, curtains, etc.)",
+        "parametersSchema": {
+            "type": "object",
+            "properties": {
+                "entity_id": {
+                    "type": "string",
+                    "description": "Cover entity ID, e.g. cover.living_room_blinds",
+                },
+                "area_name": {"type": "string", "description": "Area name to open all covers in that room"},
+            },
+        },
+    },
+    {
+        "name": "ha_close_cover",
+        "category": "covers",
+        "description": "Close a cover or all covers in an area (blinds, garage door, curtains, etc.)",
+        "parametersSchema": {
+            "type": "object",
+            "properties": {
+                "entity_id": {"type": "string", "description": "Cover entity ID"},
+                "area_name": {"type": "string", "description": "Area name to close all covers in that room"},
+            },
+        },
+    },
+    {
+        "name": "ha_set_cover_position",
+        "category": "covers",
+        "description": "Set the position of a cover or all covers in an area",
+        "parametersSchema": {
+            "type": "object",
+            "properties": {
+                "entity_id": {"type": "string", "description": "Cover entity ID"},
+                "area_name": {"type": "string", "description": "Area name to set position for all covers in that room"},
+                "position": {
+                    "type": "number",
+                    "description": "Position from 0 (closed) to 100 (open)",
+                },
+            },
+            "required": ["position"],
+        },
+    },
+    # ------------------------------------------------------------------- locks
+    {
+        "name": "ha_lock",
+        "category": "locks",
+        "description": "Lock a lock entity",
+        "parametersSchema": {
+            "type": "object",
+            "properties": {
+                "entity_id": {
+                    "type": "string",
+                    "description": "Lock entity ID, e.g. lock.front_door",
+                },
+            },
+            "required": ["entity_id"],
+        },
+    },
+    {
+        "name": "ha_unlock",
+        "category": "locks",
+        "description": "Unlock a lock entity",
+        "parametersSchema": {
+            "type": "object",
+            "properties": {
+                "entity_id": {"type": "string", "description": "Lock entity ID"},
+                "code": {"type": "string", "description": "Optional unlock code"},
+            },
+            "required": ["entity_id"],
+        },
+    },
+    # ------------------------------------------------------------------- media
+    {
+        "name": "ha_media_play",
+        "category": "media",
+        "description": "Play media on a media player",
+        "parametersSchema": {
+            "type": "object",
+            "properties": {
+                "entity_id": {"type": "string", "description": "Media player entity ID"},
+                "media_content_id": {
+                    "type": "string",
+                    "description": "URL or identifier of the media to play (optional)",
+                },
+                "media_content_type": {
+                    "type": "string",
+                    "description": "Type of media: music, tvshow, movie, playlist (optional)",
+                },
+            },
+            "required": ["entity_id"],
+        },
+    },
+    {
+        "name": "ha_media_pause",
+        "category": "media",
+        "description": "Pause a media player",
+        "parametersSchema": {
+            "type": "object",
+            "properties": {
+                "entity_id": {"type": "string", "description": "Media player entity ID"},
+            },
+            "required": ["entity_id"],
+        },
+    },
+    {
+        "name": "ha_set_volume",
+        "category": "media",
+        "description": "Set the volume of a media player",
+        "parametersSchema": {
+            "type": "object",
+            "properties": {
+                "entity_id": {"type": "string", "description": "Media player entity ID"},
+                "volume_level": {
+                    "type": "number",
+                    "description": "Volume level from 0.0 to 1.0",
+                },
+            },
+            "required": ["entity_id", "volume_level"],
+        },
+    },
+    # ---------------------------------------------------------- scenes/scripts
+    {
+        "name": "ha_activate_scene",
+        "category": "scenes_scripts",
+        "description": "Activate a Home Assistant scene",
+        "parametersSchema": {
+            "type": "object",
+            "properties": {
+                "entity_id": {
+                    "type": "string",
+                    "description": "Scene entity ID, e.g. scene.movie_night",
+                },
+            },
+            "required": ["entity_id"],
+        },
+    },
+    {
+        "name": "ha_run_script",
+        "category": "scenes_scripts",
+        "description": "Run a Home Assistant script",
+        "parametersSchema": {
+            "type": "object",
+            "properties": {
+                "entity_id": {
+                    "type": "string",
+                    "description": "Script entity ID, e.g. script.welcome_home",
+                },
+            },
+            "required": ["entity_id"],
+        },
+    },
+    # --------------------------------------------------------------- query/generic
+    {
+        "name": "ha_get_state",
+        "category": "query",
+        "description": "Get the current state and attributes of a Home Assistant entity",
+        "parametersSchema": {
+            "type": "object",
+            "properties": {
+                "entity_id": {
+                    "type": "string",
+                    "description": "Entity ID to query, e.g. sensor.temperature",
+                },
+            },
+            "required": ["entity_id"],
+        },
+    },
+    {
+        "name": "ha_list_areas",
+        "category": "query",
+        "description": "List all areas (rooms) configured in Home Assistant with their IDs and names",
+        "parametersSchema": {
+            "type": "object",
+            "properties": {},
+        },
+    },
+    {
+        "name": "ha_list_entities",
+        "category": "query",
+        "description": (
+            "List Home Assistant entities. Each result includes the area/room the entity belongs to. "
+            "Filter by domain and/or area_name to narrow results."
+        ),
+        "parametersSchema": {
+            "type": "object",
+            "properties": {
+                "domain": {
+                    "type": "string",
+                    "description": "Optional domain filter, e.g. light, switch, climate, sensor",
+                },
+                "area_name": {
+                    "type": "string",
+                    "description": "Optional area name filter, e.g. Büro — returns only entities in that room",
+                },
+            },
+        },
+    },
+    {
+        "name": "ha_call_service",
+        "category": "query",
+        "description": "Call any Home Assistant service with full control over domain, service, and data",
+        "parametersSchema": {
+            "type": "object",
+            "properties": {
+                "domain": {
+                    "type": "string",
+                    "description": "Service domain, e.g. light, switch, climate, script",
+                },
+                "service": {
+                    "type": "string",
+                    "description": "Service name, e.g. turn_on, set_temperature, press",
+                },
+                "entity_id": {
+                    "type": "string",
+                    "description": "Target entity ID (optional)",
+                },
+                "data": {
+                    "type": "object",
+                    "description": "Additional service data as key/value pairs (optional)",
+                },
+            },
+            "required": ["domain", "service"],
+        },
+    },
+    {
+        "name": "ha_notify",
+        "category": "query",
+        "description": "Send a notification via Home Assistant",
+        "parametersSchema": {
+            "type": "object",
+            "properties": {
+                "message": {"type": "string", "description": "Notification message"},
+                "title": {"type": "string", "description": "Notification title (optional)"},
+                "target": {
+                    "type": "string",
+                    "description": "Notification service target, e.g. notify.mobile_app_phone (optional)",
+                },
+            },
+            "required": ["message"],
+        },
+    },
+]
+
+
+def tools_for_categories(enabled_categories: list[str]) -> list[dict]:
+    """Return tool definitions whose category is in enabled_categories."""
+    cats = set(enabled_categories)
+    return [t for t in TOOL_DEFINITIONS if t["category"] in cats]
+
+
+HA_AGENT_PROMPT = """\
+You are a Home Assistant controller. \
+When the user asks you to control smart home devices, call the appropriate \
+ha_* tool and confirm the result. Do not add roleplay, narration, or \
+flavour text — just execute the command and report what happened.
+
+Guidelines:
+- Execute commands directly when the user asks. \
+"Turn on the office lights" → call ha_turn_on with area_name="Office".
+- Use area_name instead of individual entity_ids whenever acting on a room. \
+This is faster and more reliable than listing entities first.
+- If you don't know the exact area name, call ha_list_areas first, then act.
+- If you need to find a specific entity_id, call ha_list_entities with \
+domain and/or area_name to narrow the results — every result includes its area.
+- Prefer specific tools (ha_set_brightness, ha_set_color) over ha_call_service \
+unless no dedicated tool fits.
+- Do not invent entity IDs. Query first if unsure.
+- Report errors clearly so the user can correct them.
+"""

--- a/custom_components/marinara_engine/const.py
+++ b/custom_components/marinara_engine/const.py
@@ -19,7 +19,8 @@ TOOL_CATEGORIES: dict[str, str] = {
     "locks": "Locks",
     "media": "Media Players",
     "scenes_scripts": "Scenes & Scripts",
-    "query": "Query & Generic",
+    "query": "Query",
+    "generic_service": "Generic Service Calls (Advanced)",
 }
 
 # Locks excluded by default — users can opt in via Options
@@ -398,7 +399,7 @@ TOOL_DEFINITIONS = [
     },
     {
         "name": "ha_call_service",
-        "category": "query",
+        "category": "generic_service",
         "description": "Call any Home Assistant service with full control over domain, service, and data",
         "parametersSchema": {
             "type": "object",

--- a/custom_components/marinara_engine/coordinator.py
+++ b/custom_components/marinara_engine/coordinator.py
@@ -1,0 +1,225 @@
+"""DataUpdateCoordinator for Marinara Engine."""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import timedelta
+
+import aiohttp
+
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import DOMAIN, SCAN_INTERVAL
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class MarinaraCoordinator(DataUpdateCoordinator[dict]):
+    """Polls Marinara Engine for chats and agents."""
+
+    def __init__(self, hass: HomeAssistant, host: str, port: int) -> None:
+        self.base_url = f"http://{host}:{port}"
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=DOMAIN,
+            update_interval=timedelta(seconds=SCAN_INTERVAL),
+        )
+
+    async def _async_update_data(self) -> dict:
+        try:
+            async with aiohttp.ClientSession() as session:
+                timeout = aiohttp.ClientTimeout(total=10)
+                async with session.get(
+                    f"{self.base_url}/api/chats", timeout=timeout
+                ) as resp:
+                    resp.raise_for_status()
+                    chats = await resp.json()
+
+                async with session.get(
+                    f"{self.base_url}/api/agents", timeout=timeout
+                ) as resp:
+                    resp.raise_for_status()
+                    agents = await resp.json()
+
+            return {"chats": chats, "agents": agents}
+        except aiohttp.ClientConnectionError as err:
+            raise UpdateFailed(f"Cannot reach Marinara Engine: {err}") from err
+        except aiohttp.ClientResponseError as err:
+            raise UpdateFailed(f"Marinara Engine returned error {err.status}") from err
+        except Exception as err:
+            raise UpdateFailed(f"Unexpected error: {err}") from err
+
+    async def async_verify_connection(self) -> None:
+        """Raise ConfigEntryNotReady if the server is unreachable."""
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(
+                    f"{self.base_url}/api/chats",
+                    timeout=aiohttp.ClientTimeout(total=5),
+                ) as resp:
+                    resp.raise_for_status()
+        except Exception as err:
+            raise ConfigEntryNotReady(
+                f"Cannot connect to Marinara Engine at {self.base_url}: {err}"
+            ) from err
+
+    async def send_message(self, chat_id: str, content: str, role: str = "user") -> None:
+        """POST a message to a chat."""
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                f"{self.base_url}/api/chats/{chat_id}/messages",
+                json={"chatId": chat_id, "role": role, "content": content, "characterId": None},
+                timeout=aiohttp.ClientTimeout(total=10),
+            ) as resp:
+                resp.raise_for_status()
+
+    async def trigger_generation(
+        self, chat_id: str, user_message: str | None = None
+    ) -> None:
+        """Start AI generation for a chat (fire-and-forget, non-streaming)."""
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                f"{self.base_url}/api/generate",
+                json={
+                    "chatId": chat_id,
+                    "userMessage": user_message,
+                    "streaming": False,
+                    "userStatus": "active",
+                },
+                timeout=aiohttp.ClientTimeout(total=120),
+            ) as resp:
+                resp.raise_for_status()
+
+    async def abort_generation(self) -> None:
+        """Cancel any in-flight generation."""
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                f"{self.base_url}/api/generate/abort",
+                timeout=aiohttp.ClientTimeout(total=5),
+            ) as resp:
+                resp.raise_for_status()
+
+    async def set_agent_enabled(self, agent_id: str, enabled: bool) -> None:
+        """Toggle global enabled state for an agent."""
+        async with aiohttp.ClientSession() as session:
+            async with session.patch(
+                f"{self.base_url}/api/agents/{agent_id}",
+                json={"enabled": enabled},
+                timeout=aiohttp.ClientTimeout(total=10),
+            ) as resp:
+                resp.raise_for_status()
+
+    async def sync_agent(self, enabled_categories: list[str]) -> str:
+        """Create or update the Home Assistant agent in Marinara.
+
+        Returns "created", "updated", or "unchanged".
+        """
+        from .const import HA_AGENT_PROMPT, tools_for_categories
+
+        tool_names = [t["name"] for t in tools_for_categories(enabled_categories)]
+
+        async with aiohttp.ClientSession() as session:
+            timeout = aiohttp.ClientTimeout(total=10)
+
+            async with session.get(
+                f"{self.base_url}/api/agents", timeout=timeout
+            ) as resp:
+                resp.raise_for_status()
+                agents = await resp.json()
+
+            existing = next(
+                (a for a in agents if a.get("type") == "home_assistant"), None
+            )
+
+            if existing is not None:
+                settings = existing.get("settings") or {}
+                if isinstance(settings, str):
+                    settings = json.loads(settings)
+                current_tools = settings.get("enabledTools", [])
+                if set(current_tools) == set(tool_names):
+                    return "unchanged"
+                async with session.patch(
+                    f"{self.base_url}/api/agents/{existing['id']}",
+                    json={"settings": {"enabledTools": tool_names}},
+                    timeout=timeout,
+                ) as resp:
+                    resp.raise_for_status()
+                return "updated"
+
+            payload = {
+                "type": "home_assistant",
+                "name": "Home Assistant",
+                "description": (
+                    "Controls Home Assistant smart home devices — lights, climate, "
+                    "covers, locks, media players, scenes, and scripts."
+                ),
+                "phase": "parallel",
+                "enabled": True,
+                "connectionId": None,
+                "promptTemplate": HA_AGENT_PROMPT,
+                "settings": {"enabledTools": tool_names},
+            }
+            async with session.post(
+                f"{self.base_url}/api/agents", json=payload, timeout=timeout
+            ) as resp:
+                resp.raise_for_status()
+
+        return "created"
+
+    async def sync_tools(
+        self, webhook_url: str, enabled_categories: list[str]
+    ) -> tuple[int, int]:
+        """Upsert HA tool definitions into Marinara for the given categories.
+
+        Creates missing tools and updates existing ones so schema changes propagate.
+        Returns (created, updated) counts.
+        """
+        from .const import tools_for_categories
+
+        tools = tools_for_categories(enabled_categories)
+
+        async with aiohttp.ClientSession() as session:
+            timeout = aiohttp.ClientTimeout(total=10)
+
+            async with session.get(
+                f"{self.base_url}/api/custom-tools", timeout=timeout
+            ) as resp:
+                resp.raise_for_status()
+                existing = await resp.json()
+
+            existing_by_name = {t["name"]: t for t in existing}
+
+            created = 0
+            updated = 0
+            for tool in tools:
+                payload = {
+                    "name": tool["name"],
+                    "description": tool["description"],
+                    "parametersSchema": tool["parametersSchema"],
+                    "executionType": "webhook",
+                    "webhookUrl": webhook_url,
+                    "enabled": True,
+                }
+                if tool["name"] in existing_by_name:
+                    tool_id = existing_by_name[tool["name"]]["id"]
+                    async with session.patch(
+                        f"{self.base_url}/api/custom-tools/{tool_id}",
+                        json=payload,
+                        timeout=timeout,
+                    ) as resp:
+                        resp.raise_for_status()
+                    updated += 1
+                else:
+                    async with session.post(
+                        f"{self.base_url}/api/custom-tools",
+                        json=payload,
+                        timeout=timeout,
+                    ) as resp:
+                        resp.raise_for_status()
+                    created += 1
+
+        return created, updated

--- a/custom_components/marinara_engine/coordinator.py
+++ b/custom_components/marinara_engine/coordinator.py
@@ -10,6 +10,7 @@ import aiohttp
 
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DOMAIN, SCAN_INTERVAL
@@ -22,6 +23,7 @@ class MarinaraCoordinator(DataUpdateCoordinator[dict]):
 
     def __init__(self, hass: HomeAssistant, host: str, port: int) -> None:
         self.base_url = f"http://{host}:{port}"
+        self._session = async_get_clientsession(hass)
         super().__init__(
             hass,
             _LOGGER,
@@ -31,19 +33,18 @@ class MarinaraCoordinator(DataUpdateCoordinator[dict]):
 
     async def _async_update_data(self) -> dict:
         try:
-            async with aiohttp.ClientSession() as session:
-                timeout = aiohttp.ClientTimeout(total=10)
-                async with session.get(
-                    f"{self.base_url}/api/chats", timeout=timeout
-                ) as resp:
-                    resp.raise_for_status()
-                    chats = await resp.json()
+            timeout = aiohttp.ClientTimeout(total=10)
+            async with self._session.get(
+                f"{self.base_url}/api/chats", timeout=timeout
+            ) as resp:
+                resp.raise_for_status()
+                chats = await resp.json()
 
-                async with session.get(
-                    f"{self.base_url}/api/agents", timeout=timeout
-                ) as resp:
-                    resp.raise_for_status()
-                    agents = await resp.json()
+            async with self._session.get(
+                f"{self.base_url}/api/agents", timeout=timeout
+            ) as resp:
+                resp.raise_for_status()
+                agents = await resp.json()
 
             return {"chats": chats, "agents": agents}
         except aiohttp.ClientConnectionError as err:
@@ -56,12 +57,11 @@ class MarinaraCoordinator(DataUpdateCoordinator[dict]):
     async def async_verify_connection(self) -> None:
         """Raise ConfigEntryNotReady if the server is unreachable."""
         try:
-            async with aiohttp.ClientSession() as session:
-                async with session.get(
-                    f"{self.base_url}/api/chats",
-                    timeout=aiohttp.ClientTimeout(total=5),
-                ) as resp:
-                    resp.raise_for_status()
+            async with self._session.get(
+                f"{self.base_url}/api/chats",
+                timeout=aiohttp.ClientTimeout(total=5),
+            ) as resp:
+                resp.raise_for_status()
         except Exception as err:
             raise ConfigEntryNotReady(
                 f"Cannot connect to Marinara Engine at {self.base_url}: {err}"
@@ -69,49 +69,45 @@ class MarinaraCoordinator(DataUpdateCoordinator[dict]):
 
     async def send_message(self, chat_id: str, content: str, role: str = "user") -> None:
         """POST a message to a chat."""
-        async with aiohttp.ClientSession() as session:
-            async with session.post(
-                f"{self.base_url}/api/chats/{chat_id}/messages",
-                json={"chatId": chat_id, "role": role, "content": content, "characterId": None},
-                timeout=aiohttp.ClientTimeout(total=10),
-            ) as resp:
-                resp.raise_for_status()
+        async with self._session.post(
+            f"{self.base_url}/api/chats/{chat_id}/messages",
+            json={"chatId": chat_id, "role": role, "content": content, "characterId": None},
+            timeout=aiohttp.ClientTimeout(total=10),
+        ) as resp:
+            resp.raise_for_status()
 
     async def trigger_generation(
         self, chat_id: str, user_message: str | None = None
     ) -> None:
         """Start AI generation for a chat (fire-and-forget, non-streaming)."""
-        async with aiohttp.ClientSession() as session:
-            async with session.post(
-                f"{self.base_url}/api/generate",
-                json={
-                    "chatId": chat_id,
-                    "userMessage": user_message,
-                    "streaming": False,
-                    "userStatus": "active",
-                },
-                timeout=aiohttp.ClientTimeout(total=120),
-            ) as resp:
-                resp.raise_for_status()
+        async with self._session.post(
+            f"{self.base_url}/api/generate",
+            json={
+                "chatId": chat_id,
+                "userMessage": user_message,
+                "streaming": False,
+                "userStatus": "active",
+            },
+            timeout=aiohttp.ClientTimeout(total=120),
+        ) as resp:
+            resp.raise_for_status()
 
     async def abort_generation(self) -> None:
         """Cancel any in-flight generation."""
-        async with aiohttp.ClientSession() as session:
-            async with session.post(
-                f"{self.base_url}/api/generate/abort",
-                timeout=aiohttp.ClientTimeout(total=5),
-            ) as resp:
-                resp.raise_for_status()
+        async with self._session.post(
+            f"{self.base_url}/api/generate/abort",
+            timeout=aiohttp.ClientTimeout(total=5),
+        ) as resp:
+            resp.raise_for_status()
 
     async def set_agent_enabled(self, agent_id: str, enabled: bool) -> None:
         """Toggle global enabled state for an agent."""
-        async with aiohttp.ClientSession() as session:
-            async with session.patch(
-                f"{self.base_url}/api/agents/{agent_id}",
-                json={"enabled": enabled},
-                timeout=aiohttp.ClientTimeout(total=10),
-            ) as resp:
-                resp.raise_for_status()
+        async with self._session.patch(
+            f"{self.base_url}/api/agents/{agent_id}",
+            json={"enabled": enabled},
+            timeout=aiohttp.ClientTimeout(total=10),
+        ) as resp:
+            resp.raise_for_status()
 
     async def sync_agent(self, enabled_categories: list[str]) -> str:
         """Create or update the Home Assistant agent in Marinara.
@@ -122,51 +118,67 @@ class MarinaraCoordinator(DataUpdateCoordinator[dict]):
 
         tool_names = [t["name"] for t in tools_for_categories(enabled_categories)]
 
-        async with aiohttp.ClientSession() as session:
-            timeout = aiohttp.ClientTimeout(total=10)
+        timeout = aiohttp.ClientTimeout(total=10)
 
-            async with session.get(
-                f"{self.base_url}/api/agents", timeout=timeout
-            ) as resp:
-                resp.raise_for_status()
-                agents = await resp.json()
+        async with self._session.get(
+            f"{self.base_url}/api/agents", timeout=timeout
+        ) as resp:
+            resp.raise_for_status()
+            agents = await resp.json()
+        if not isinstance(agents, list):
+            agents = []
 
-            existing = next(
-                (a for a in agents if a.get("type") == "home_assistant"), None
-            )
+        existing = next(
+            (
+                agent
+                for agent in agents
+                if isinstance(agent, dict) and agent.get("type") == "home_assistant"
+            ),
+            None,
+        )
 
-            if existing is not None:
-                settings = existing.get("settings") or {}
-                if isinstance(settings, str):
+        if existing is not None:
+            settings = existing.get("settings") or {}
+            if isinstance(settings, str):
+                try:
                     settings = json.loads(settings)
-                current_tools = settings.get("enabledTools", [])
-                if set(current_tools) == set(tool_names):
-                    return "unchanged"
-                async with session.patch(
-                    f"{self.base_url}/api/agents/{existing['id']}",
-                    json={"settings": {"enabledTools": tool_names}},
-                    timeout=timeout,
-                ) as resp:
-                    resp.raise_for_status()
-                return "updated"
-
-            payload = {
-                "type": "home_assistant",
-                "name": "Home Assistant",
-                "description": (
-                    "Controls Home Assistant smart home devices — lights, climate, "
-                    "covers, locks, media players, scenes, and scripts."
-                ),
-                "phase": "parallel",
-                "enabled": True,
-                "connectionId": None,
-                "promptTemplate": HA_AGENT_PROMPT,
-                "settings": {"enabledTools": tool_names},
-            }
-            async with session.post(
-                f"{self.base_url}/api/agents", json=payload, timeout=timeout
+                except (TypeError, ValueError) as err:
+                    _LOGGER.warning(
+                        "Invalid JSON in Home Assistant agent settings for id=%s: %s",
+                        existing.get("id"),
+                        err,
+                    )
+                    settings = {}
+            if not isinstance(settings, dict):
+                settings = {}
+            current_tools = settings.get("enabledTools") or []
+            if set(current_tools) == set(tool_names):
+                return "unchanged"
+            async with self._session.patch(
+                f"{self.base_url}/api/agents/{existing['id']}",
+                json={"settings": {"enabledTools": tool_names}},
+                timeout=timeout,
             ) as resp:
                 resp.raise_for_status()
+            return "updated"
+
+        payload = {
+            "type": "home_assistant",
+            "name": "Home Assistant",
+            "description": (
+                "Controls Home Assistant smart home devices — lights, climate, "
+                "covers, locks, media players, scenes, and scripts."
+            ),
+            "phase": "parallel",
+            "enabled": True,
+            "connectionId": None,
+            "promptTemplate": HA_AGENT_PROMPT,
+            "settings": {"enabledTools": tool_names},
+        }
+        async with self._session.post(
+            f"{self.base_url}/api/agents", json=payload, timeout=timeout
+        ) as resp:
+            resp.raise_for_status()
 
         return "created"
 
@@ -178,48 +190,70 @@ class MarinaraCoordinator(DataUpdateCoordinator[dict]):
         Creates missing tools and updates existing ones so schema changes propagate.
         Returns (created, updated) counts.
         """
-        from .const import tools_for_categories
+        from .const import TOOL_DEFINITIONS, tools_for_categories
 
         tools = tools_for_categories(enabled_categories)
+        selected_names = {tool["name"] for tool in tools}
+        managed_names = {tool["name"] for tool in TOOL_DEFINITIONS}
 
-        async with aiohttp.ClientSession() as session:
-            timeout = aiohttp.ClientTimeout(total=10)
+        timeout = aiohttp.ClientTimeout(total=10)
 
-            async with session.get(
-                f"{self.base_url}/api/custom-tools", timeout=timeout
-            ) as resp:
-                resp.raise_for_status()
-                existing = await resp.json()
+        async with self._session.get(
+            f"{self.base_url}/api/custom-tools", timeout=timeout
+        ) as resp:
+            resp.raise_for_status()
+            existing = await resp.json()
+        if not isinstance(existing, list):
+            existing = []
 
-            existing_by_name = {t["name"]: t for t in existing}
+        existing_by_name = {
+            t["name"]: t
+            for t in existing
+            if isinstance(t, dict) and isinstance(t.get("name"), str)
+        }
 
-            created = 0
-            updated = 0
-            for tool in tools:
-                payload = {
-                    "name": tool["name"],
-                    "description": tool["description"],
-                    "parametersSchema": tool["parametersSchema"],
-                    "executionType": "webhook",
-                    "webhookUrl": webhook_url,
-                    "enabled": True,
-                }
-                if tool["name"] in existing_by_name:
-                    tool_id = existing_by_name[tool["name"]]["id"]
-                    async with session.patch(
-                        f"{self.base_url}/api/custom-tools/{tool_id}",
-                        json=payload,
-                        timeout=timeout,
-                    ) as resp:
-                        resp.raise_for_status()
-                    updated += 1
-                else:
-                    async with session.post(
-                        f"{self.base_url}/api/custom-tools",
-                        json=payload,
-                        timeout=timeout,
-                    ) as resp:
-                        resp.raise_for_status()
-                    created += 1
+        created = 0
+        updated = 0
+        for tool in tools:
+            payload = {
+                "name": tool["name"],
+                "description": tool["description"],
+                "parametersSchema": tool["parametersSchema"],
+                "executionType": "webhook",
+                "webhookUrl": webhook_url,
+                "enabled": True,
+            }
+            if tool["name"] in existing_by_name:
+                tool_id = existing_by_name[tool["name"]]["id"]
+                async with self._session.patch(
+                    f"{self.base_url}/api/custom-tools/{tool_id}",
+                    json=payload,
+                    timeout=timeout,
+                ) as resp:
+                    resp.raise_for_status()
+                updated += 1
+            else:
+                async with self._session.post(
+                    f"{self.base_url}/api/custom-tools",
+                    json=payload,
+                    timeout=timeout,
+                ) as resp:
+                    resp.raise_for_status()
+                created += 1
+
+        for name, existing_tool in existing_by_name.items():
+            if (
+                name in managed_names
+                and name not in selected_names
+                and existing_tool.get("webhookUrl") == webhook_url
+                and existing_tool.get("enabled") is not False
+            ):
+                async with self._session.patch(
+                    f"{self.base_url}/api/custom-tools/{existing_tool['id']}",
+                    json={"enabled": False},
+                    timeout=timeout,
+                ) as resp:
+                    resp.raise_for_status()
+                updated += 1
 
         return created, updated

--- a/custom_components/marinara_engine/http.py
+++ b/custom_components/marinara_engine/http.py
@@ -1,0 +1,60 @@
+"""HTTP view that serves tool definitions pre-filled with the webhook URL.
+
+Visit GET /api/marinara_engine/tools/<webhook_id> to download a JSON array
+of custom tool objects ready to paste into Marinara Engine's Custom Tools UI.
+The list is filtered to the categories enabled in the integration options.
+"""
+
+from __future__ import annotations
+
+import json
+
+from aiohttp import web
+
+from homeassistant.components.http import HomeAssistantView
+
+from .const import CONF_ENABLED_CATEGORIES, DEFAULT_ENABLED_CATEGORIES, tools_for_categories
+
+
+class MarinaraToolManifestView(HomeAssistantView):
+    """Serve tool definitions pre-filled with the webhook URL."""
+
+    url = "/api/marinara_engine/tools/{webhook_id}"
+    name = "api:marinara_engine:tools"
+    requires_auth = False  # Marinara needs to fetch this without a token
+
+    def __init__(self, webhook_id: str, entry_id: str) -> None:
+        self._webhook_id = webhook_id
+        self._entry_id = entry_id
+
+    async def get(self, request: web.Request, webhook_id: str) -> web.Response:
+        if webhook_id != self._webhook_id:
+            return web.Response(status=404, text="Not found")
+
+        hass = request.app["hass"]
+        entry = hass.config_entries.async_get_entry(self._entry_id)
+        enabled_categories = (
+            entry.options.get(CONF_ENABLED_CATEGORIES, DEFAULT_ENABLED_CATEGORIES)
+            if entry
+            else DEFAULT_ENABLED_CATEGORIES
+        )
+
+        base_url = str(request.url.origin())
+        webhook_url = f"{base_url}/api/webhook/{webhook_id}"
+
+        tools = [
+            {
+                "name": t["name"],
+                "description": t["description"],
+                "parametersSchema": t["parametersSchema"],
+                "executionType": "webhook",
+                "webhookUrl": webhook_url,
+                "enabled": True,
+            }
+            for t in tools_for_categories(enabled_categories)
+        ]
+
+        return web.Response(
+            body=json.dumps(tools, indent=2),
+            content_type="application/json",
+        )

--- a/custom_components/marinara_engine/manifest.json
+++ b/custom_components/marinara_engine/manifest.json
@@ -1,0 +1,12 @@
+{
+  "domain": "marinara_engine",
+  "name": "Marinara Engine",
+  "version": "1.0.0",
+  "config_flow": true,
+  "documentation": "https://github.com/Pasta-Devs/Marinara-Engine/blob/main/docs/integrations/home-assistant.md",
+  "issue_tracker": "https://github.com/Pasta-Devs/Marinara-Engine/issues",
+  "requirements": [],
+  "dependencies": ["webhook"],
+  "iot_class": "local_polling",
+  "codeowners": []
+}

--- a/custom_components/marinara_engine/select.py
+++ b/custom_components/marinara_engine/select.py
@@ -1,0 +1,65 @@
+"""Select platform for Marinara Engine — pick the active/primary chat."""
+
+from __future__ import annotations
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import CONF_PRIMARY_CHAT_ID, DOMAIN
+from .coordinator import MarinaraCoordinator
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    coordinator: MarinaraCoordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities([MarinaraActiveChatSelect(coordinator, entry)])
+
+
+class MarinaraActiveChatSelect(CoordinatorEntity[MarinaraCoordinator], SelectEntity):
+    """Select which chat the services (send_message, trigger_generation) target."""
+
+    _attr_icon = "mdi:chat-processing-outline"
+
+    def __init__(self, coordinator: MarinaraCoordinator, entry: ConfigEntry) -> None:
+        super().__init__(coordinator)
+        self._entry = entry
+        self._attr_unique_id = f"{entry.entry_id}_active_chat"
+        self._attr_name = "Marinara Active Chat"
+
+    @property
+    def device_info(self) -> dict:
+        return {
+            "identifiers": {(DOMAIN, self._entry.entry_id)},
+            "name": "Marinara Engine",
+            "manufacturer": "Marinara Engine",
+            "model": "Local AI Engine",
+        }
+
+    @property
+    def options(self) -> list[str]:
+        return [c["name"] for c in self.coordinator.data.get("chats", [])]
+
+    @property
+    def current_option(self) -> str | None:
+        primary_id = self._entry.options.get(CONF_PRIMARY_CHAT_ID)
+        if not primary_id:
+            return None
+        for chat in self.coordinator.data.get("chats", []):
+            if chat["id"] == primary_id:
+                return chat["name"]
+        return None
+
+    async def async_select_option(self, option: str) -> None:
+        for chat in self.coordinator.data.get("chats", []):
+            if chat["name"] == option:
+                self.hass.config_entries.async_update_entry(
+                    self._entry,
+                    options={**self._entry.options, CONF_PRIMARY_CHAT_ID: chat["id"]},
+                )
+                return

--- a/custom_components/marinara_engine/sensor.py
+++ b/custom_components/marinara_engine/sensor.py
@@ -1,0 +1,96 @@
+"""Sensor platform for Marinara Engine."""
+
+from __future__ import annotations
+
+from homeassistant.components.sensor import SensorEntity, SensorStateClass
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import MarinaraCoordinator
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    coordinator: MarinaraCoordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities(
+        [
+            MarinaraChatCountSensor(coordinator, entry),
+            MarinaraActiveAgentCountSensor(coordinator, entry),
+        ]
+    )
+
+
+class _MarinaraEntity(CoordinatorEntity[MarinaraCoordinator]):
+    def __init__(self, coordinator: MarinaraCoordinator, entry: ConfigEntry) -> None:
+        super().__init__(coordinator)
+        self._entry = entry
+
+    @property
+    def device_info(self) -> dict:
+        return {
+            "identifiers": {(DOMAIN, self._entry.entry_id)},
+            "name": "Marinara Engine",
+            "manufacturer": "Marinara Engine",
+            "model": "Local AI Engine",
+            "configuration_url": self.coordinator.base_url,
+        }
+
+
+class MarinaraChatCountSensor(_MarinaraEntity, SensorEntity):
+    """Total number of chats in Marinara Engine."""
+
+    _attr_icon = "mdi:chat-outline"
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_native_unit_of_measurement = "chats"
+
+    def __init__(self, coordinator: MarinaraCoordinator, entry: ConfigEntry) -> None:
+        super().__init__(coordinator, entry)
+        self._attr_unique_id = f"{entry.entry_id}_chat_count"
+        self._attr_name = "Marinara Chat Count"
+
+    @property
+    def native_value(self) -> int:
+        return len(self.coordinator.data.get("chats", []))
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        chats = self.coordinator.data.get("chats", [])
+        by_mode: dict[str, int] = {}
+        for c in chats:
+            mode = c.get("mode", "unknown")
+            by_mode[mode] = by_mode.get(mode, 0) + 1
+        return {"by_mode": by_mode}
+
+
+class MarinaraActiveAgentCountSensor(_MarinaraEntity, SensorEntity):
+    """Number of globally enabled agents."""
+
+    _attr_icon = "mdi:robot-outline"
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_native_unit_of_measurement = "agents"
+
+    def __init__(self, coordinator: MarinaraCoordinator, entry: ConfigEntry) -> None:
+        super().__init__(coordinator, entry)
+        self._attr_unique_id = f"{entry.entry_id}_active_agent_count"
+        self._attr_name = "Marinara Active Agent Count"
+
+    @property
+    def native_value(self) -> int:
+        agents = self.coordinator.data.get("agents", [])
+        return sum(1 for a in agents if a.get("enabled") == "true")
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        agents = self.coordinator.data.get("agents", [])
+        return {
+            "total_agents": len(agents),
+            "enabled_agents": [
+                a.get("name") for a in agents if a.get("enabled") == "true"
+            ],
+        }

--- a/custom_components/marinara_engine/services.yaml
+++ b/custom_components/marinara_engine/services.yaml
@@ -1,0 +1,65 @@
+send_message:
+  name: Send Message
+  description: >
+    Send a message to a Marinara Engine chat. If no chat_id is provided, the
+    primary chat configured in the integration options is used.
+  fields:
+    chat_id:
+      name: Chat ID
+      description: >
+        ID of the target chat. Leave blank to use the primary chat set in
+        the integration options.
+      required: false
+      selector:
+        text:
+    message:
+      name: Message
+      description: The message content to send.
+      required: true
+      selector:
+        text:
+          multiline: true
+    role:
+      name: Role
+      description: Message role. Defaults to "user".
+      required: false
+      default: user
+      selector:
+        select:
+          options:
+            - user
+            - assistant
+            - system
+            - narrator
+    trigger_generation:
+      name: Trigger Generation
+      description: >
+        After sending the message, immediately trigger AI generation so the
+        character responds.
+      required: false
+      default: false
+      selector:
+        boolean:
+
+trigger_generation:
+  name: Trigger Generation
+  description: >
+    Start an AI generation turn in a Marinara Engine chat. If no chat_id is
+    provided, the primary chat configured in the integration options is used.
+  fields:
+    chat_id:
+      name: Chat ID
+      description: >
+        ID of the target chat. Leave blank to use the primary chat set in
+        the integration options.
+      required: false
+      selector:
+        text:
+    user_message:
+      name: User Message
+      description: >
+        Optional message to send from the user as part of this generation turn.
+      required: false
+      selector:
+        text:
+          multiline: true

--- a/custom_components/marinara_engine/strings.json
+++ b/custom_components/marinara_engine/strings.json
@@ -1,0 +1,36 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Connect to Marinara Engine",
+        "description": "Enter the host and port where Marinara Engine is running.",
+        "data": {
+          "host": "Host",
+          "port": "Port"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Cannot connect to Marinara Engine. Check the host, port, and that the server is running.",
+      "unknown": "An unexpected error occurred."
+    },
+    "abort": {
+      "already_configured": "Marinara Engine at this address is already configured."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Marinara Engine Options",
+        "description": "Choose the primary chat and which tool categories Marinara is allowed to use.",
+        "data": {
+          "primary_chat_id": "Primary Chat",
+          "enabled_categories": "Exposed Tool Categories"
+        },
+        "data_description": {
+          "enabled_categories": "Only the selected categories will be synced as tools into Marinara Engine. Changes take effect after pressing the Sync HA Tools button or restarting Home Assistant."
+        }
+      }
+    }
+  }
+}

--- a/custom_components/marinara_engine/switch.py
+++ b/custom_components/marinara_engine/switch.py
@@ -1,0 +1,79 @@
+"""Switch platform for Marinara Engine — one switch per agent."""
+
+from __future__ import annotations
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import MarinaraCoordinator
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    coordinator: MarinaraCoordinator = hass.data[DOMAIN][entry.entry_id]
+    agents = coordinator.data.get("agents", [])
+    async_add_entities(
+        [MarinaraAgentSwitch(coordinator, entry, agent) for agent in agents],
+        update_before_add=True,
+    )
+
+
+class MarinaraAgentSwitch(CoordinatorEntity[MarinaraCoordinator], SwitchEntity):
+    """Toggle the global enabled state of a Marinara Engine agent."""
+
+    _attr_icon = "mdi:robot"
+
+    def __init__(
+        self,
+        coordinator: MarinaraCoordinator,
+        entry: ConfigEntry,
+        agent: dict,
+    ) -> None:
+        super().__init__(coordinator)
+        self._entry = entry
+        self._agent_id: str = agent["id"]
+        self._attr_unique_id = f"{entry.entry_id}_agent_{agent['id']}"
+        self._attr_name = f"Marinara Agent: {agent.get('name', agent['id'])}"
+
+    @property
+    def device_info(self) -> dict:
+        return {
+            "identifiers": {(DOMAIN, self._entry.entry_id)},
+            "name": "Marinara Engine",
+            "manufacturer": "Marinara Engine",
+            "model": "Local AI Engine",
+        }
+
+    @property
+    def is_on(self) -> bool:
+        for agent in self.coordinator.data.get("agents", []):
+            if agent["id"] == self._agent_id:
+                return agent.get("enabled") == "true"
+        return False
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        for agent in self.coordinator.data.get("agents", []):
+            if agent["id"] == self._agent_id:
+                return {
+                    "agent_id": self._agent_id,
+                    "type": agent.get("type"),
+                    "phase": agent.get("phase"),
+                    "description": agent.get("description"),
+                }
+        return {}
+
+    async def async_turn_on(self, **kwargs) -> None:
+        await self.coordinator.set_agent_enabled(self._agent_id, True)
+        await self.coordinator.async_request_refresh()
+
+    async def async_turn_off(self, **kwargs) -> None:
+        await self.coordinator.set_agent_enabled(self._agent_id, False)
+        await self.coordinator.async_request_refresh()

--- a/custom_components/marinara_engine/translations/en.json
+++ b/custom_components/marinara_engine/translations/en.json
@@ -1,0 +1,36 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Connect to Marinara Engine",
+        "description": "Enter the host and port where Marinara Engine is running (default: localhost:3000).",
+        "data": {
+          "host": "Host",
+          "port": "Port"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Cannot connect to Marinara Engine. Verify the host and port and that the server is running.",
+      "unknown": "An unexpected error occurred."
+    },
+    "abort": {
+      "already_configured": "Marinara Engine at this address is already configured."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Marinara Engine Options",
+        "description": "Choose the primary chat and which tool categories Marinara is allowed to use.",
+        "data": {
+          "primary_chat_id": "Primary Chat",
+          "enabled_categories": "Exposed Tool Categories"
+        },
+        "data_description": {
+          "enabled_categories": "Only the selected categories will be synced as tools into Marinara Engine. Changes take effect after pressing the Sync HA Tools button or restarting Home Assistant."
+        }
+      }
+    }
+  }
+}

--- a/custom_components/marinara_engine/webhook.py
+++ b/custom_components/marinara_engine/webhook.py
@@ -1,0 +1,401 @@
+"""Webhook handler: receives tool calls from Marinara Engine and executes HA actions."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from aiohttp import web
+
+from homeassistant.components.webhook import (
+    async_register,
+    async_unregister,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import area_registry as ar_helper
+from homeassistant.helpers import entity_registry as er_helper
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def async_register_webhook(hass: HomeAssistant, webhook_id: str) -> None:
+    async_register(
+        hass,
+        DOMAIN,
+        "Marinara Engine",
+        webhook_id,
+        _handle_webhook,
+        allowed_methods=["POST"],
+    )
+
+
+def async_unregister_webhook(hass: HomeAssistant, webhook_id: str) -> None:
+    async_unregister(hass, webhook_id)
+
+
+async def _handle_webhook(
+    hass: HomeAssistant, webhook_id: str, request: web.Request
+) -> web.Response:
+    """Dispatch an incoming tool call to the appropriate HA action."""
+    try:
+        body = await request.json()
+    except Exception:
+        return web.Response(status=400, text="Invalid JSON body")
+
+    tool: str = body.get("tool", "")
+    args: dict[str, Any] = body.get("arguments", {})
+
+    _LOGGER.debug("Marinara webhook: tool=%s args=%s", tool, args)
+
+    handler = _DISPATCH.get(tool)
+    if handler is None:
+        _LOGGER.warning("Marinara webhook: unknown tool '%s'", tool)
+        return web.json_response({"error": f"Unknown tool: {tool}"}, status=400)
+
+    try:
+        result = await handler(hass, args)
+    except Exception as err:
+        _LOGGER.error("Marinara webhook: tool '%s' failed: %s", tool, err)
+        return web.json_response({"error": str(err)}, status=500)
+
+    return web.json_response(result)
+
+
+# ---------------------------------------------------------------------------
+# Area helpers
+# ---------------------------------------------------------------------------
+
+def _get_area(hass: HomeAssistant, area_name: str):
+    ar = ar_helper.async_get(hass)
+    area = ar.async_get_area_by_name(area_name)
+    if area is None:
+        raise ValueError(
+            f"Area '{area_name}' not found. Call ha_list_areas to see available areas."
+        )
+    return area
+
+
+def _resolve_entity_and_target(
+    hass: HomeAssistant, args: dict
+) -> tuple[str | None, dict | None]:
+    """Return (entity_id, target) — exactly one will be non-None."""
+    entity_id = args.get("entity_id")
+    area_name = args.get("area_name")
+    if entity_id:
+        return entity_id, None
+    if area_name:
+        area = _get_area(hass, area_name)
+        return None, {"area_id": area.id}
+    raise ValueError("Provide entity_id or area_name")
+
+
+# ---------------------------------------------------------------------------
+# Handlers
+# ---------------------------------------------------------------------------
+
+async def _turn_on(hass: HomeAssistant, args: dict) -> dict:
+    entity_id, target = _resolve_entity_and_target(hass, args)
+    if entity_id:
+        await hass.services.async_call(
+            "homeassistant", "turn_on", {"entity_id": entity_id}, blocking=True
+        )
+        return {"result": f"Turned on {entity_id}"}
+    domain = args.get("domain", "light")
+    await hass.services.async_call(domain, "turn_on", {}, target=target, blocking=True)
+    return {"result": f"Turned on all {domain} in area"}
+
+
+async def _turn_off(hass: HomeAssistant, args: dict) -> dict:
+    entity_id, target = _resolve_entity_and_target(hass, args)
+    if entity_id:
+        await hass.services.async_call(
+            "homeassistant", "turn_off", {"entity_id": entity_id}, blocking=True
+        )
+        return {"result": f"Turned off {entity_id}"}
+    domain = args.get("domain", "light")
+    await hass.services.async_call(domain, "turn_off", {}, target=target, blocking=True)
+    return {"result": f"Turned off all {domain} in area"}
+
+
+async def _toggle(hass: HomeAssistant, args: dict) -> dict:
+    entity_id, target = _resolve_entity_and_target(hass, args)
+    if entity_id:
+        await hass.services.async_call(
+            "homeassistant", "toggle", {"entity_id": entity_id}, blocking=True
+        )
+        return {"result": f"Toggled {entity_id}"}
+    domain = args.get("domain", "light")
+    await hass.services.async_call(domain, "toggle", {}, target=target, blocking=True)
+    return {"result": f"Toggled all {domain} in area"}
+
+
+async def _get_state(hass: HomeAssistant, args: dict) -> dict:
+    entity_id = _require(args, "entity_id")
+    state = hass.states.get(entity_id)
+    if state is None:
+        return {"error": f"Entity '{entity_id}' not found"}
+    return {
+        "entity_id": entity_id,
+        "state": state.state,
+        "attributes": dict(state.attributes),
+        "last_updated": state.last_updated.isoformat(),
+    }
+
+
+async def _list_areas(hass: HomeAssistant, args: dict) -> dict:
+    ar = ar_helper.async_get(hass)
+    return {
+        "areas": [
+            {"id": area.id, "name": area.name}
+            for area in ar.areas.values()
+        ]
+    }
+
+
+async def _list_entities(hass: HomeAssistant, args: dict) -> dict:
+    domain_filter: str | None = args.get("domain")
+    area_name: str | None = args.get("area_name")
+
+    er = er_helper.async_get(hass)
+    ar = ar_helper.async_get(hass)
+
+    area_names: dict[str, str] = {a.id: a.name for a in ar.areas.values()}
+    entity_areas: dict[str, str | None] = {
+        e.entity_id: e.area_id for e in er.entities.values()
+    }
+
+    area_entity_ids: set[str] | None = None
+    if area_name:
+        area = _get_area(hass, area_name)
+        area_entity_ids = {
+            eid for eid, aid in entity_areas.items() if aid == area.id
+        }
+
+    entities = []
+    for s in hass.states.async_all(domain_filter):
+        if area_entity_ids is not None and s.entity_id not in area_entity_ids:
+            continue
+        area_id = entity_areas.get(s.entity_id)
+        entities.append({
+            "entity_id": s.entity_id,
+            "state": s.state,
+            "friendly_name": s.attributes.get("friendly_name"),
+            "area": area_names.get(area_id) if area_id else None,
+        })
+
+    return {"entities": entities}
+
+
+async def _call_service(hass: HomeAssistant, args: dict) -> dict:
+    domain = _require(args, "domain")
+    service = _require(args, "service")
+    data: dict = dict(args.get("data") or {})
+    entity_id = args.get("entity_id")
+    if entity_id:
+        data["entity_id"] = entity_id
+    await hass.services.async_call(domain, service, data, blocking=True)
+    return {"result": f"Called {domain}.{service}"}
+
+
+async def _set_brightness(hass: HomeAssistant, args: dict) -> dict:
+    entity_id, target = _resolve_entity_and_target(hass, args)
+    brightness_pct = float(_require(args, "brightness_pct"))
+    data: dict = {"brightness_pct": brightness_pct}
+    if entity_id:
+        data["entity_id"] = entity_id
+    await hass.services.async_call("light", "turn_on", data, target=target, blocking=True)
+    return {"result": f"Set brightness to {brightness_pct}%"}
+
+
+async def _set_color(hass: HomeAssistant, args: dict) -> dict:
+    entity_id, target = _resolve_entity_and_target(hass, args)
+    r = int(_require(args, "r"))
+    g = int(_require(args, "g"))
+    b = int(_require(args, "b"))
+    data: dict = {"rgb_color": [r, g, b]}
+    if entity_id:
+        data["entity_id"] = entity_id
+    await hass.services.async_call("light", "turn_on", data, target=target, blocking=True)
+    return {"result": f"Set color to rgb({r},{g},{b})"}
+
+
+async def _set_color_temp(hass: HomeAssistant, args: dict) -> dict:
+    entity_id, target = _resolve_entity_and_target(hass, args)
+    kelvin = int(_require(args, "kelvin"))
+    data: dict = {"kelvin": kelvin}
+    if entity_id:
+        data["entity_id"] = entity_id
+    await hass.services.async_call("light", "turn_on", data, target=target, blocking=True)
+    return {"result": f"Set color temperature to {kelvin}K"}
+
+
+async def _set_temperature(hass: HomeAssistant, args: dict) -> dict:
+    entity_id, target = _resolve_entity_and_target(hass, args)
+    temperature = float(_require(args, "temperature"))
+    data: dict = {"temperature": temperature}
+    if entity_id:
+        data["entity_id"] = entity_id
+    await hass.services.async_call(
+        "climate", "set_temperature", data, target=target, blocking=True
+    )
+    return {"result": f"Set temperature to {temperature}"}
+
+
+async def _set_hvac_mode(hass: HomeAssistant, args: dict) -> dict:
+    entity_id, target = _resolve_entity_and_target(hass, args)
+    hvac_mode = _require(args, "hvac_mode")
+    data: dict = {"hvac_mode": hvac_mode}
+    if entity_id:
+        data["entity_id"] = entity_id
+    await hass.services.async_call(
+        "climate", "set_hvac_mode", data, target=target, blocking=True
+    )
+    return {"result": f"Set HVAC mode to {hvac_mode}"}
+
+
+async def _activate_scene(hass: HomeAssistant, args: dict) -> dict:
+    entity_id = _require(args, "entity_id")
+    await hass.services.async_call(
+        "scene", "turn_on", {"entity_id": entity_id}, blocking=True
+    )
+    return {"result": f"Activated scene {entity_id}"}
+
+
+async def _run_script(hass: HomeAssistant, args: dict) -> dict:
+    entity_id = _require(args, "entity_id")
+    await hass.services.async_call(
+        "script", "turn_on", {"entity_id": entity_id}, blocking=True
+    )
+    return {"result": f"Ran script {entity_id}"}
+
+
+async def _media_play(hass: HomeAssistant, args: dict) -> dict:
+    entity_id = _require(args, "entity_id")
+    data: dict = {"entity_id": entity_id}
+    if args.get("media_content_id"):
+        data["media_content_id"] = args["media_content_id"]
+        data["media_content_type"] = args.get("media_content_type", "music")
+        await hass.services.async_call(
+            "media_player", "play_media", data, blocking=True
+        )
+    else:
+        await hass.services.async_call(
+            "media_player", "media_play", {"entity_id": entity_id}, blocking=True
+        )
+    return {"result": f"Playing on {entity_id}"}
+
+
+async def _media_pause(hass: HomeAssistant, args: dict) -> dict:
+    entity_id = _require(args, "entity_id")
+    await hass.services.async_call(
+        "media_player", "media_pause", {"entity_id": entity_id}, blocking=True
+    )
+    return {"result": f"Paused {entity_id}"}
+
+
+async def _set_volume(hass: HomeAssistant, args: dict) -> dict:
+    entity_id = _require(args, "entity_id")
+    volume_level = float(_require(args, "volume_level"))
+    await hass.services.async_call(
+        "media_player",
+        "volume_set",
+        {"entity_id": entity_id, "volume_level": volume_level},
+        blocking=True,
+    )
+    return {"result": f"Set volume to {volume_level}"}
+
+
+async def _lock(hass: HomeAssistant, args: dict) -> dict:
+    entity_id = _require(args, "entity_id")
+    await hass.services.async_call(
+        "lock", "lock", {"entity_id": entity_id}, blocking=True
+    )
+    return {"result": f"Locked {entity_id}"}
+
+
+async def _unlock(hass: HomeAssistant, args: dict) -> dict:
+    entity_id = _require(args, "entity_id")
+    data: dict = {"entity_id": entity_id}
+    if args.get("code"):
+        data["code"] = args["code"]
+    await hass.services.async_call("lock", "unlock", data, blocking=True)
+    return {"result": f"Unlocked {entity_id}"}
+
+
+async def _open_cover(hass: HomeAssistant, args: dict) -> dict:
+    entity_id, target = _resolve_entity_and_target(hass, args)
+    data: dict = {}
+    if entity_id:
+        data["entity_id"] = entity_id
+    await hass.services.async_call("cover", "open_cover", data, target=target, blocking=True)
+    return {"result": "Opened cover(s)"}
+
+
+async def _close_cover(hass: HomeAssistant, args: dict) -> dict:
+    entity_id, target = _resolve_entity_and_target(hass, args)
+    data: dict = {}
+    if entity_id:
+        data["entity_id"] = entity_id
+    await hass.services.async_call("cover", "close_cover", data, target=target, blocking=True)
+    return {"result": "Closed cover(s)"}
+
+
+async def _set_cover_position(hass: HomeAssistant, args: dict) -> dict:
+    entity_id, target = _resolve_entity_and_target(hass, args)
+    position = int(_require(args, "position"))
+    data: dict = {"position": position}
+    if entity_id:
+        data["entity_id"] = entity_id
+    await hass.services.async_call(
+        "cover", "set_cover_position", data, target=target, blocking=True
+    )
+    return {"result": f"Set cover position to {position}%"}
+
+
+async def _notify(hass: HomeAssistant, args: dict) -> dict:
+    message = _require(args, "message")
+    target = args.get("target", "notify.notify")
+    parts = target.split(".", 1)
+    domain = parts[0] if len(parts) == 2 else "notify"
+    service = parts[1] if len(parts) == 2 else "notify"
+    data: dict = {"message": message}
+    if args.get("title"):
+        data["title"] = args["title"]
+    await hass.services.async_call(domain, service, data, blocking=True)
+    return {"result": "Notification sent"}
+
+
+_DISPATCH = {
+    "ha_turn_on": _turn_on,
+    "ha_turn_off": _turn_off,
+    "ha_toggle": _toggle,
+    "ha_get_state": _get_state,
+    "ha_list_areas": _list_areas,
+    "ha_list_entities": _list_entities,
+    "ha_call_service": _call_service,
+    "ha_set_brightness": _set_brightness,
+    "ha_set_color": _set_color,
+    "ha_set_color_temp": _set_color_temp,
+    "ha_set_temperature": _set_temperature,
+    "ha_set_hvac_mode": _set_hvac_mode,
+    "ha_activate_scene": _activate_scene,
+    "ha_run_script": _run_script,
+    "ha_media_play": _media_play,
+    "ha_media_pause": _media_pause,
+    "ha_set_volume": _set_volume,
+    "ha_lock": _lock,
+    "ha_unlock": _unlock,
+    "ha_open_cover": _open_cover,
+    "ha_close_cover": _close_cover,
+    "ha_set_cover_position": _set_cover_position,
+    "ha_notify": _notify,
+}
+
+
+def _require(args: dict, key: str) -> Any:
+    value = args.get(key)
+    if value is None:
+        raise ValueError(f"Missing required argument: {key}")
+    return value

--- a/custom_components/marinara_engine/webhook.py
+++ b/custom_components/marinara_engine/webhook.py
@@ -18,6 +18,16 @@ from homeassistant.helpers import entity_registry as er_helper
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
+_SENSITIVE_ARG_KEYS = {
+    "access_token",
+    "api_key",
+    "code",
+    "password",
+    "pin",
+    "refresh_token",
+    "secret",
+    "token",
+}
 
 
 def async_register_webhook(hass: HomeAssistant, webhook_id: str) -> None:
@@ -47,7 +57,7 @@ async def _handle_webhook(
     tool: str = body.get("tool", "")
     args: dict[str, Any] = body.get("arguments", {})
 
-    _LOGGER.debug("Marinara webhook: tool=%s args=%s", tool, args)
+    _LOGGER.debug("Marinara webhook: tool=%s args=%s", tool, _redact_args(args))
 
     handler = _DISPATCH.get(tool)
     if handler is None:
@@ -75,6 +85,18 @@ def _get_area(hass: HomeAssistant, area_name: str):
             f"Area '{area_name}' not found. Call ha_list_areas to see available areas."
         )
     return area
+
+
+def _redact_args(value: Any) -> Any:
+    """Redact sensitive fields, including lock codes accepted by _unlock."""
+    if isinstance(value, dict):
+        return {
+            key: "<REDACTED>" if str(key).lower() in _SENSITIVE_ARG_KEYS else _redact_args(val)
+            for key, val in value.items()
+        }
+    if isinstance(value, list):
+        return [_redact_args(item) for item in value]
+    return value
 
 
 def _resolve_entity_and_target(

--- a/docs/integrations/home-assistant.md
+++ b/docs/integrations/home-assistant.md
@@ -84,7 +84,8 @@ You can choose which categories to expose in the integration's **Configure** men
 | Locks                    | `ha_lock`, `ha_unlock`                                                                             |
 | Media Players            | `ha_media_play`, `ha_media_pause`, `ha_set_volume`                                                 |
 | Scenes & Scripts         | `ha_activate_scene`, `ha_run_script`                                                               |
-| Query & Generic          | `ha_get_state`, `ha_list_entities`, `ha_call_service`, `ha_notify`                                 |
+| Query                    | `ha_get_state`, `ha_list_areas`, `ha_list_entities`, `ha_notify`                                   |
+| Generic Service Calls    | `ha_call_service`                                                                                  |
 
 ## The Home Assistant agent
 

--- a/docs/integrations/home-assistant.md
+++ b/docs/integrations/home-assistant.md
@@ -1,0 +1,166 @@
+# Marinara Engine — Home Assistant Integration
+
+[![HACS](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://hacs.xyz)
+
+Connects [Marinara Engine](https://github.com/Pasta-Devs/Marinara-Engine) to Home Assistant so your AI characters can control real-world devices — lights, climate, locks, covers, media players, and more — directly from chat, roleplay, and game sessions.
+
+## How it works
+
+Marinara Engine supports **custom webhook tools**: when the AI decides to call a tool during generation, it POSTs to a webhook URL and feeds the result back to the language model. This integration:
+
+1. Registers a private webhook endpoint inside Home Assistant
+2. Creates all selected tool definitions in Marinara, pre-filled with that webhook URL
+3. Creates a **Home Assistant agent** in Marinara that lists every HA tool in its enabled tools — making them appear in the chat's Function Calling picker automatically
+
+```
+Marinara AI  →  calls tool ha_turn_on  →  POST /api/webhook/<id>  →  HA turns on light
+Marinara AI  ←  {"result": "Turned on light.living_room"}          ←  HA responds
+```
+
+Everything happens on first startup. You never copy URLs or configure tools manually.
+
+## Requirements
+
+- Home Assistant 2024.1 or newer
+- [HACS](https://hacs.xyz) installed
+- [Marinara Engine](https://github.com/Pasta-Devs/Marinara-Engine) running locally (default: `localhost:3000`)
+
+## Installation
+
+### 1. Add to HACS
+
+1. Open HACS → three-dot menu → **Custom repositories**
+2. URL: `https://github.com/Pasta-Devs/Marinara-Engine`
+3. Category: **Integration**
+4. Click **Add**, then search for **Marinara Engine** and install it
+5. Restart Home Assistant
+
+### 2. Add the integration
+
+1. Go to **Settings → Devices & Services → Add Integration**
+2. Search for **Marinara Engine**
+3. Enter the host and port where Marinara Engine is running (default: `localhost` / `3000`)
+4. Click **Submit**
+
+On startup, the integration automatically:
+
+- Registers a webhook inside Home Assistant
+- Creates all tool definitions in Marinara → **Settings → Custom Tools**
+- Creates a **Home Assistant** agent in Marinara → **Agents** with every HA tool already enabled
+
+### 3. Done
+
+Open any chat in Marinara. Your AI characters can now turn on lights, adjust the thermostat, play music, and more — they'll do it naturally as the narrative calls for it, without you having to prompt for it explicitly.
+
+## Configuration
+
+After setup, open the integration's **Configure** menu to:
+
+- Set a **Primary Chat** — the default target for `send_message` and `trigger_generation` HA services
+- Choose **Exposed Tool Categories** — select which categories of HA tools Marinara can use (locks are off by default)
+
+Changes to the category selection take effect after pressing **Marinara Sync HA Tools** or restarting Home Assistant.
+
+## Entities
+
+| Entity                      | Type   | Description                                        |
+| --------------------------- | ------ | -------------------------------------------------- |
+| Marinara Chat Count         | Sensor | Total number of chats                              |
+| Marinara Active Agent Count | Sensor | Number of globally enabled agents                  |
+| Marinara Active Chat        | Select | Choose which chat HA services target               |
+| Marinara Agent: _name_      | Switch | Enable / disable each AI agent globally            |
+| Marinara Abort Generation   | Button | Cancel any in-flight AI generation                 |
+| Marinara Sync HA Tools      | Button | Re-sync all tool definitions and agent to Marinara |
+
+## Tool categories
+
+You can choose which categories to expose in the integration's **Configure** menu. Locks are off by default.
+
+| Category                 | Tools                                                                                              |
+| ------------------------ | -------------------------------------------------------------------------------------------------- |
+| Lights & Switches        | `ha_turn_on`, `ha_turn_off`, `ha_toggle`, `ha_set_brightness`, `ha_set_color`, `ha_set_color_temp` |
+| Climate                  | `ha_set_temperature`, `ha_set_hvac_mode`                                                           |
+| Covers (Blinds & Garage) | `ha_open_cover`, `ha_close_cover`, `ha_set_cover_position`                                         |
+| Locks                    | `ha_lock`, `ha_unlock`                                                                             |
+| Media Players            | `ha_media_play`, `ha_media_pause`, `ha_set_volume`                                                 |
+| Scenes & Scripts         | `ha_activate_scene`, `ha_run_script`                                                               |
+| Query & Generic          | `ha_get_state`, `ha_list_entities`, `ha_call_service`, `ha_notify`                                 |
+
+## The Home Assistant agent
+
+On first sync the integration creates a **Home Assistant** agent in Marinara (visible under **Agents**). This agent:
+
+- Runs in **parallel** during every generation turn
+- Has all enabled HA tools listed in its Function Calling settings
+- Carries a prompt that instructs the AI to act on smart home cues naturally — dimming lights when a character reaches for the switch, adjusting the thermostat when the temperature comes up in conversation, and so on
+
+The agent is kept in sync automatically — pressing **Sync HA Tools** after changing the enabled categories will update the agent's tool list in place. No manual deletion needed.
+
+## HA Services
+
+Use these in automations to interact with Marinara from Home Assistant's side.
+
+### `marinara_engine.send_message`
+
+Send a message to a Marinara chat.
+
+| Field                | Required | Description                                  |
+| -------------------- | -------- | -------------------------------------------- |
+| `message`            | Yes      | Message content                              |
+| `chat_id`            | No       | Target chat ID (defaults to primary chat)    |
+| `role`               | No       | `user` / `assistant` / `system` / `narrator` |
+| `trigger_generation` | No       | Also trigger an AI response (default: false) |
+
+**Example — notify the AI when someone arrives:**
+
+```yaml
+automation:
+  trigger:
+    platform: state
+    entity_id: binary_sensor.front_door
+    to: "on"
+  action:
+    service: marinara_engine.send_message
+    data:
+      message: "Someone just arrived at the front door."
+      trigger_generation: true
+```
+
+### `marinara_engine.trigger_generation`
+
+Start an AI generation turn in a chat.
+
+| Field          | Required | Description                               |
+| -------------- | -------- | ----------------------------------------- |
+| `chat_id`      | No       | Target chat ID (defaults to primary chat) |
+| `user_message` | No       | Optional user message to include          |
+
+## Re-syncing tools
+
+Press **Marinara Sync HA Tools** on the integration's device page to push any missing tools and recreate the agent if it was deleted. Tools that already exist are skipped — it's safe to press at any time.
+
+## Troubleshooting
+
+**Tools not appearing in Marinara's Custom Tools**
+Press **Marinara Sync HA Tools**, or restart Home Assistant. Verify under **Settings → Custom Tools** in Marinara.
+
+**Home Assistant agent not showing up in Marinara**
+Press **Marinara Sync HA Tools**. If it's already in the Agents list but not visible in a chat, it may be disabled — enable it there.
+
+**Tools not available in a chat's Function Calling picker**
+The **Home Assistant** agent must be enabled in Marinara (Agents list). If it's there but disabled, enable it. If it's missing entirely, press **Sync HA Tools** to recreate it.
+
+**Webhook calls failing**
+Check that Home Assistant is reachable from the machine running Marinara Engine. If they run on the same machine, the internal URL (`http://localhost:8123`) is used automatically. If Marinara runs on a different device, make sure HA's local network URL is accessible from that device.
+
+**Cannot connect on setup**
+Make sure Marinara Engine is running (`pnpm dev` or the packaged app) and the host/port you entered match where it's actually listening (default: `localhost:3000`).
+
+**Finding the webhook URL manually**
+Go to **Settings → Devices & Services → Marinara Engine** in HA. The webhook ID is stored in the config entry. The full URL follows the pattern:
+
+```
+http://<homeassistant-ip>:8123/api/webhook/<webhook-id>
+```
+
+Each tool in Marinara's Custom Tools list already has this URL set.

--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,6 @@
+{
+  "name": "Marinara Engine",
+  "content_in_root": false,
+  "render_readme": false,
+  "homeassistant": "2024.1.0"
+}


### PR DESCRIPTION
## Summary

Adds the Home Assistant / HACS integration from https://github.com/Gunterlie/marinara-engine-hacs so CI and review tooling can scan it in the Marinara Engine repository.

This PR includes:
- `custom_components/marinara_engine` Home Assistant integration files
- root `hacs.json` metadata
- Home Assistant integration docs under `docs/integrations/home-assistant.md`
- a changelog entry

I also adjusted the copied metadata/docs links to point at `Pasta-Devs/Marinara-Engine`.

## Validation

- [ ] Python syntax check: `python3 -m compileall -q custom_components/marinara_engine`
- [ ] Prettier check for changelog, docs, HACS metadata, and HA JSON/YAML files
- [ ] Let PR CI scan the imported feature

## Notes

Opened as draft intentionally so checks can run before we decide whether this should live inside the main Marinara Engine repo or remain as a separate HACS repository.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Home Assistant integration via HACS with automatic syncing of Marinara custom tools and a Home Assistant agent for device control
  * Webhook endpoint and public tool manifest for tool discovery
  * New entities: active-chat select, per-agent switches, chat/agent sensors, abort and sync buttons
  * Services to send messages and trigger generations; options UI for primary chat and enabled tool categories

* **Documentation**
  * Complete Home Assistant integration setup and troubleshooting guide

* **Chores**
  * Changelog and HACS metadata added
<!-- end of auto-generated comment: release notes by coderabbit.ai -->