### PR TITLE
chore(client): add mode-specific intros to chat settings drawers

### DIFF
--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -145,6 +145,16 @@ const HIDDEN_ROLEPLAY_AGENTS = new Set([
   "autonomous-messenger",
 ]);
 
+const MODE_INTROS: Record<string, string> = {
+  conversation:
+    "Plain chat — no roleplay or game systems built in; autonomous messaging and other tools are optional below.",
+  roleplay:
+    "Plain roleplay surface — no built-in dice, combat, or GM pipeline; sprites, world-state tracking, and other helpers are available as optional agents below.",
+  visual_novel:
+    "Sprite- and background-driven roleplay — expressions, world state, and CYOA choices are available as optional agents below.",
+  game: "Full Game Master with built-in dice, combat, encounters, world state, and session/map tracking — the Scene Analysis toggle below adds optional cinematic visuals (backgrounds, music, weather).",
+};
+
 type AvailableAgent = {
   id: string;
   name: string;
@@ -1182,6 +1192,16 @@ export function ChatSettingsDrawer({
         )}
 
         <div className="flex-1 overflow-y-auto">
+          {/* Hardcoded — CHAT_MODES.defaultAgents looks like the source of truth but is currently
+              unused, and wouldn't cover non-agent built-ins (GM pipeline, autonomous messaging, etc.) anyway. */}
+          {MODE_INTROS[chatMode] && (
+            <div className="border-b border-[var(--border)] px-4 py-2.5">
+              <p className="text-[0.625rem] leading-relaxed text-[var(--muted-foreground)]">
+                {MODE_INTROS[chatMode]}
+              </p>
+            </div>
+          )}
+
           {/* Chat Name */}
           <Section
             label="Chat Name"

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -145,7 +145,7 @@ const HIDDEN_ROLEPLAY_AGENTS = new Set([
   "autonomous-messenger",
 ]);
 
-const MODE_INTROS: Record<string, string> = {
+const MODE_INTROS: Record<ChatMode, string> = {
   conversation:
     "Plain chat — no roleplay or game systems built in; autonomous messaging and other tools are optional below.",
   roleplay:
@@ -1194,10 +1194,10 @@ export function ChatSettingsDrawer({
         <div className="flex-1 overflow-y-auto">
           {/* Hardcoded — CHAT_MODES.defaultAgents looks like the source of truth but is currently
               unused, and wouldn't cover non-agent built-ins (GM pipeline, autonomous messaging, etc.) anyway. */}
-          {MODE_INTROS[chatMode] && (
+          {MODE_INTROS[chatMode as ChatMode] && (
             <div className="border-b border-[var(--border)] px-4 py-2.5">
               <p className="text-[0.625rem] leading-relaxed text-[var(--muted-foreground)]">
-                {MODE_INTROS[chatMode]}
+                {MODE_INTROS[chatMode as ChatMode]}
               </p>
             </div>
           )}


### PR DESCRIPTION
## Why

Each chat mode wires in a very different baseline of features, but the
settings drawer doesn't say so anywhere. New users opening it on a Game
chat can't tell that dice, combat, encounters, and session/map tracking
are already running — and on a Roleplay chat they can't tell that none
of that is built in and would need to be reconstructed via optional
agents below.

This adds one short line at the top of the drawer per mode so the
distinction is visible before scrolling through 14 sections.

## What

- New `MODE_INTROS` map in `ChatSettingsDrawer.tsx`, keyed by chat mode,
  with one sentence each for `conversation`, `roleplay`, `visual_novel`,
  and `game`.
- Renders as a muted-text block at the top of the scrollable area,
  matching the existing helper-text style used throughout the drawer.
- No new component, no i18n (project has none), no new state.

## Why hardcoded

`CHAT_MODES.defaultAgents` looked like the natural source of truth, but
it currently has no consumers in the repo (per the recent
`chore/remove-game-master-leftovers` cleanup) and wouldn't cover
non-agent built-ins (GM pipeline, segment edits, autonomous messaging,
map updates, etc.) anyway. A short comment in the file flags this so
both can be folded into one source if `defaultAgents` is ever wired up.

## Manual verification

Verified in dev server:
- [x] Conversation chat: intro reads "Plain chat — no roleplay or game
      systems built in…" above Chat Name (dark theme)
- [x] Roleplay chat: intro reads "Plain roleplay surface — no built-in
      dice, combat, or GM pipeline…" (dark theme)
- [x] Game chat: intro reads "Full Game Master with built-in dice,
      combat, encounters…" and the no-preset-bar layout still looks
      clean (dark theme)
- [x] Light theme: muted-text styling renders correctly (verified Game
      mode; all modes share the same `var(--muted-foreground)` /
      `var(--border)` tokens)
- [x] Visual Novel: not separately tested — VN is effectively Game mode
      in the live product per maintainer note

## Notes

- Validated with `pnpm check` (TS + ESLint + build clean).
- 
<img width="228" height="762" alt="image" src="https://github.com/user-attachments/assets/4c7aa042-f61f-4ff5-b67a-2590fef31d98" />
<img width="227" height="622" alt="image" src="https://github.com/user-attachments/assets/24117308-efda-4ead-b87f-3ba56988d682" />
<img width="228" height="606" alt="image" src="https://github.com/user-attachments/assets/67bd5053-22fb-4269-9ea6-f869eb29e0f8" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat mode descriptions are now displayed in the settings drawer. Users will see introductory text for each available chat mode (Conversation, Roleplay, Visual Novel, Game) above the Chat Name field to help guide mode selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->