### PR TITLE
docs: add FAQ entry on agent and preset overlap

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -95,3 +95,28 @@ Connected chats (the link between a conversation and a roleplay or game) are int
 This is by design — pulling raw DM messages into every roleplay turn would inflate the prompt and dilute the story. If you want something from the DM to stick in the roleplay, ask the conversation character to wrap it in a `<note>`.
 
 </details>
+
+---
+
+<a id="what-happens-if-i-enable-an-agent-and-also-have-similar-instructions-in-my-preset"></a>
+
+<details>
+<summary><strong>What happens if I enable an agent and also have similar instructions in my preset?</strong></summary>
+<br>
+
+Both contribute to the prompt, but in different ways: a preset section is static text concatenated every turn, while an agent runs at request time and produces its own output. If both target the same behavior, the model receives both — usually redundant, occasionally conflicting, and always extra tokens.
+
+Common overlaps to watch for:
+
+- Writing-style or anti-repetition directives in the preset and the **Prose Guardian** agent.
+- "Track time / weather / location" instructions and the **World State** agent.
+- "Track character mood / outfit / stats" instructions and the **Character Tracker** agent.
+- Quest-tracking, combat-mechanics, or persona-stat instructions and their respective agents.
+- HTML/CSS visual-styling prompts and the **Immersive HTML** agent.
+- "Summarize past events" instructions and the **Automated Chat Summary** agent.
+
+**The general rule:** pick one place to express each behavior. If you've enabled an agent that covers a behavior, you can usually remove the matching preset directive. If you'd rather keep your preset version (e.g., it's tuned for a particular character), disable the corresponding agent.
+
+**One important exception:** the `agent_data` marker section, and the `{{agent::TYPE}}` macro, are the *intended* way to thread an agent's output into a specific spot in the preset. That's wiring, not overlap — several agents (World State, Quest Tracker, Character Tracker, and others) set this up for you by default. The pattern to avoid is hand-writing preset sections that duplicate an agent's *behavior*, not using the marker section that carries the agent's *output*.
+
+</details>


### PR DESCRIPTION
## Summary
Adds a single FAQ entry to `docs/FAQ.md` explaining what happens when a user enables an
agent **and** keeps matching instructions in their preset. Best community understanding:
overlap is mostly redundant and slightly harmful (extra tokens, occasionally conflicting
instructions to the model).

## Why
This question comes up periodically and there's no canonical place to point people to.
The new entry:

- Explains how agents (runtime) and preset sections (static) differ
- Lists the most common overlap cases (Prose Guardian, World State, Character Tracker,
  Persona Stats, Quest Tracker, Combat, Immersive HTML, Automated Chat Summary)
- Recommends picking one place for each behavior
- Clarifies that the `agent_data` marker / `{{agent::TYPE}}` macro is **intentional
  wiring**, not overlap, so people don't disable the wrong thing

## Scope
Docs-only — single file, no code or schema changes.

## Background — alternatives considered
Initially tried appending an overlap-clarification sentence to each affected agent's
`description` string in `BUILT_IN_AGENTS`. Browser testing surfaced two blockers: the
agent panel uses `line-clamp-2` (note clipped from preview) and the editor's Description
field is a user-editable `<input type="text">` (note clipped, editable, and persisted
per-user — so updates wouldn't reach existing customizers). Reverted that attempt and
went with docs as the smallest delta that actually reaches users.

If overlap questions persist after this lands, a follow-up could add a read-only
`overlapNote` field on `BuiltInAgentMeta` rendered as a separate annotation in the agent
editor — but that's bigger UI scope and worth gating on real signal.

## Test plan
- [x] Render `docs/FAQ.md` on GitHub and confirm the new entry displays correctly with
      the existing `<details>` collapsible pattern
- [x] Confirm the bullet list, code spans (`agent_data`, `{{agent::TYPE}}`), and bold
      emphasis render as expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added FAQ entry clarifying how preset instructions and agents interact, preventing conflicts, and explaining the recommended method for placing agent outputs within presets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->