### PR TITLE
Fix scene controls after chat preset changes

### DIFF
--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -263,6 +263,7 @@ export function ChatSettingsDrawer({
     () => (typeof chat.metadata === "string" ? JSON.parse(chat.metadata) : (chat.metadata ?? {})),
     [chat.metadata],
   );
+  const isSceneChat = metadata.sceneStatus === "active" || typeof metadata.sceneOriginChatId === "string";
   const hasGeneratedConversationSchedules =
     !!metadata.characterSchedules &&
     typeof metadata.characterSchedules === "object" &&
@@ -1058,8 +1059,8 @@ export function ChatSettingsDrawer({
           </button>
         </div>
 
-        {/* Chat Settings Preset bar — hidden in Game Mode (not designed for it) */}
-        {!isGame && (
+        {/* Chat Settings Preset bar — hidden in Game Mode and scene chats. */}
+        {!isGame && !isSceneChat && (
           <div className="flex flex-col gap-2 border-b border-[var(--border)] px-4 py-3">
             <input
               ref={presetFileInputRef}

--- a/packages/server/src/services/haptic/buttplug-service.ts
+++ b/packages/server/src/services/haptic/buttplug-service.ts
@@ -28,7 +28,7 @@ const CAPABILITY_TYPES: Array<{ type: OutputType; cap: HapticCapability }> = [
   { type: OutputType.Constrict, cap: "constrict" },
   { type: OutputType.Inflate, cap: "inflate" },
   { type: OutputType.Position, cap: "position" },
-  { type: OutputType.HwPositionWithDuration, cap: "position" },
+  { type: OutputType.PositionWithDuration, cap: "position" },
 ];
 
 /** Map our action strings to buttplug OutputType. */
@@ -200,7 +200,7 @@ class ButtplugService {
       try {
         if (action === "position") {
           const durationMs = Math.max(1, duration || 1) * 1000;
-          if (device.hasOutput(OutputType.HwPositionWithDuration)) {
+          if (device.hasOutput(OutputType.PositionWithDuration)) {
             await device.runOutput(DeviceOutput.PositionWithDuration.percent(intensity, durationMs));
             successfulTargets++;
           } else if (device.hasOutput(OutputType.Position)) {

--- a/packages/server/src/services/haptic/buttplug-service.ts
+++ b/packages/server/src/services/haptic/buttplug-service.ts
@@ -20,6 +20,11 @@ import type { HapticDevice, HapticCapability, HapticDeviceCommand, HapticStatus 
 
 const DEFAULT_SERVER_URL = "ws://127.0.0.1:12345";
 
+const POSITION_WITH_DURATION_OUTPUT =
+  ((OutputType as unknown as Record<string, OutputType | undefined>).HwPositionWithDuration ??
+    (OutputType as unknown as Record<string, OutputType | undefined>).PositionWithDuration) ??
+  null;
+
 /** OutputType values we map to capabilities. */
 const CAPABILITY_TYPES: Array<{ type: OutputType; cap: HapticCapability }> = [
   { type: OutputType.Vibrate, cap: "vibrate" },
@@ -28,8 +33,8 @@ const CAPABILITY_TYPES: Array<{ type: OutputType; cap: HapticCapability }> = [
   { type: OutputType.Constrict, cap: "constrict" },
   { type: OutputType.Inflate, cap: "inflate" },
   { type: OutputType.Position, cap: "position" },
-  { type: OutputType.PositionWithDuration, cap: "position" },
 ];
+if (POSITION_WITH_DURATION_OUTPUT) CAPABILITY_TYPES.push({ type: POSITION_WITH_DURATION_OUTPUT, cap: "position" });
 
 /** Map our action strings to buttplug OutputType. */
 const ACTION_TO_OUTPUT: Partial<Record<HapticDeviceCommand["action"], OutputType>> = {
@@ -200,7 +205,7 @@ class ButtplugService {
       try {
         if (action === "position") {
           const durationMs = Math.max(1, duration || 1) * 1000;
-          if (device.hasOutput(OutputType.PositionWithDuration)) {
+          if (POSITION_WITH_DURATION_OUTPUT && device.hasOutput(POSITION_WITH_DURATION_OUTPUT)) {
             await device.runOutput(DeviceOutput.PositionWithDuration.percent(intensity, durationMs));
             successfulTargets++;
           } else if (device.hasOutput(OutputType.Position)) {

--- a/packages/server/src/services/storage/chat-presets.storage.ts
+++ b/packages/server/src/services/storage/chat-presets.storage.ts
@@ -17,6 +17,11 @@ import {
 
 const CHAT_MODES: ChatMode[] = ["conversation", "roleplay", "visual_novel"];
 const EXCLUDED_METADATA_SET = new Set(CHAT_PRESET_EXCLUDED_METADATA_KEYS);
+const SCENE_POINTER_METADATA_KEYS = new Set(["activeSceneChatId", "sceneBusyCharIds"]);
+
+function isPresetExcludedMetadataKey(key: string) {
+  return EXCLUDED_METADATA_SET.has(key) || SCENE_POINTER_METADATA_KEYS.has(key) || key.startsWith("scene");
+}
 
 interface ChatPresetRow {
   id: string;
@@ -53,7 +58,7 @@ export function sanitizePresetMetadata(metadata: Record<string, unknown> | undef
   if (!metadata || typeof metadata !== "object") return {};
   const out: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(metadata)) {
-    if (EXCLUDED_METADATA_SET.has(key)) continue;
+    if (isPresetExcludedMetadataKey(key)) continue;
     out[key] = value;
   }
   return out;
@@ -239,8 +244,8 @@ export function createChatPresetsStorage(db: DB) {
 
       // Preserve only chat-specific (non-preset) metadata keys.
       const preserved: Record<string, unknown> = {};
-      for (const key of CHAT_PRESET_EXCLUDED_METADATA_KEYS) {
-        if (key in currentMetadata) preserved[key] = currentMetadata[key];
+      for (const [key, value] of Object.entries(currentMetadata)) {
+        if (isPresetExcludedMetadataKey(key)) preserved[key] = value;
       }
 
       const baseDefaults: Record<string, unknown> = {

--- a/packages/server/test/chat-presets-storage.test.ts
+++ b/packages/server/test/chat-presets-storage.test.ts
@@ -1,0 +1,21 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { sanitizePresetMetadata } from "../src/services/storage/chat-presets.storage.js";
+
+test("chat preset metadata sanitization strips scene lifecycle state", () => {
+  const sanitized = sanitizePresetMetadata({
+    enableAgents: false,
+    activeAgentIds: ["agent-a"],
+    sceneStatus: "active",
+    sceneOriginChatId: "origin-chat",
+    sceneDescription: "A temporary scene.",
+    sceneFutureKey: "future scene data",
+    activeSceneChatId: "scene-chat",
+    sceneBusyCharIds: ["char-a"],
+  });
+
+  assert.deepEqual(sanitized, {
+    enableAgents: false,
+    activeAgentIds: ["agent-a"],
+  });
+});

--- a/packages/shared/src/types/chat-preset.ts
+++ b/packages/shared/src/types/chat-preset.ts
@@ -11,7 +11,7 @@
 //
 // What presets DO NOT carry: per-chat identity (name, characters,
 // persona, group, sprites, scene prompt, summary, tags, ephemeral
-// lorebook overrides, connected chat link, folder/sort placement).
+// lorebook overrides, scene lifecycle state, connected chat link, folder/sort placement).
 
 import type { ChatMode, ChatMetadata } from "./chat.js";
 
@@ -49,7 +49,18 @@ export const CHAT_PRESET_EXCLUDED_METADATA_KEYS: readonly string[] = [
   "entryStateOverrides",
   "groupScenarioOverride",
   "groupScenarioText",
+  "sceneOriginChatId",
+  "sceneInitiatorCharId",
+  "sceneDescription",
+  "sceneScenario",
   "sceneSystemPrompt",
+  "sceneRating",
+  "sceneStatus",
+  "sceneConversationContext",
+  "sceneRelationshipHistory",
+  "sceneBackground",
+  "activeSceneChatId",
+  "sceneBusyCharIds",
   // Lorebooks are owned by the chat, never by the preset.
   "activeLorebookIds",
 ] as const;


### PR DESCRIPTION
## Linked issue
https://github.com/Pasta-Devs/Marinara-Engine/issues/408

Closes #408 

## Why this change

- Scene chats could lose their scene controls after applying a roleplay chat preset, leaving the scene unable to be concluded, abandoned, or converted.

## What changed

- Preserve scene lifecycle metadata when chat presets are saved or applied.
- Hide chat preset controls while viewing scene chats so roleplay presets cannot be applied to active scenes from the drawer.
- Add a regression test for stripping scene lifecycle state from saved preset metadata.
- Update the haptic `OutputType` name to match the current Buttplug API so validation passes.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- AI validation run only:
  - `pnpm --filter @marinara-engine/server test`
  - `pnpm --filter @marinara-engine/client lint`
  - `pnpm check`
- Manual browser verification still needs to be completed by a human before submitting.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

<!-- Add before/after screenshots or recordings for UI changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat preset metadata handling by excluding scene-related data from being carried over when applying presets.
  * Enhanced scene chat UI behavior to properly hide preset settings when in scene mode.

* **Improvements**
  * Refined haptic feedback command execution with better duration output type compatibility.

* **Tests**
  * Added test coverage for chat preset metadata sanitization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->