### PR TITLE
feat(agents): add per-turn cost readout to agents picker

### DIFF
--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -118,8 +118,12 @@ import {
   DEFAULT_AGENT_CONTEXT_SIZE,
   DEFAULT_AGENT_TOOLS,
   DEFAULT_AGENT_MAX_TOKENS,
+  DEFAULT_AGENT_PROMPTS,
   MAX_AGENT_MAX_TOKENS,
   MIN_AGENT_MAX_TOKENS,
+  estimateAgentLoadCost,
+  AGENT_COST_HIGH_CALLS,
+  AGENT_COST_HIGH_TOKENS,
   getDefaultBuiltInAgentSettings,
 } from "@marinara-engine/shared";
 import type { Chat, CharacterGroup } from "@marinara-engine/shared";
@@ -271,7 +275,7 @@ export function ChatSettingsDrawer({
     metadata.conversationSchedulesEnabled === true ||
     (metadata.conversationSchedulesEnabled == null && hasGeneratedConversationSchedules);
   const activeLorebookIds: string[] = metadata.activeLorebookIds ?? [];
-  const activeAgentIds: string[] = metadata.activeAgentIds ?? [];
+  const activeAgentIds = useMemo<string[]>(() => metadata.activeAgentIds ?? [], [metadata.activeAgentIds]);
   const activeToolIds: string[] = metadata.activeToolIds ?? [];
   const gameLorebookKeeperEnabled = metadata.gameLorebookKeeperEnabled === true;
   const gameLorebookKeeperLorebookId =
@@ -339,6 +343,31 @@ export function ChatSettingsDrawer({
     }
     return agents;
   }, [agentConfigs, agentConfigsByType]);
+
+  // Estimate the per-turn cost of the active agent loadout — feeds the readout
+  // in the agents picker header and the per-row token badges. Approximate; see
+  // `estimateAgentLoadCost` doc comment for what's counted vs not.
+  const agentLoadCost = useMemo(() => {
+    const inputs = activeAgentIds.flatMap((id) => {
+      const meta = availableAgents.find((a) => a.id === id);
+      if (!meta) return [];
+      const cfg = agentConfigsByType.get(id);
+      const promptTemplate = cfg?.promptTemplate ?? DEFAULT_AGENT_PROMPTS[id] ?? "";
+      return [
+        {
+          type: id,
+          phase: meta.phase,
+          connectionId: cfg?.connectionId ?? null,
+          promptTemplate,
+        },
+      ];
+    });
+    const tokensByType = new Map<string, number>(inputs.map((i) => [i.type, Math.ceil(i.promptTemplate.length / 4)]));
+    return {
+      cost: estimateAgentLoadCost(inputs, chat.connectionId ?? null),
+      tokensByType,
+    };
+  }, [activeAgentIds, availableAgents, agentConfigsByType, chat.connectionId]);
 
   const lorebookKeeperConfig = agentConfigsByType.get("lorebook-keeper") ?? null;
   const lorebookKeeperEnabledByDefault = isEnabledFlag(lorebookKeeperConfig?.enabled);
@@ -3288,6 +3317,29 @@ export function ChatSettingsDrawer({
                       </div>
                     ) : (
                       <>
+                        {/* Approximate per-turn cost of the active agent loadout. */}
+                        <div
+                          className={cn(
+                            "flex items-center justify-between gap-2 rounded-lg px-3 py-2 text-[0.6875rem] ring-1",
+                            agentLoadCost.cost.level === "high"
+                              ? "bg-amber-400/10 text-amber-400/90 ring-amber-400/30"
+                              : "bg-[var(--secondary)]/60 text-[var(--muted-foreground)] ring-[var(--border)]",
+                          )}
+                          title={`Approximate. Each call also carries chat context (recent messages, characters, persona, lorebook), so real per-turn token use is higher. Smaller models may slow down or fail past ~${AGENT_COST_HIGH_CALLS} calls or ~${AGENT_COST_HIGH_TOKENS.toLocaleString()} instruction tokens.`}
+                        >
+                          <span className="flex min-w-0 items-center gap-1.5">
+                            {agentLoadCost.cost.level === "high" && (
+                              <AlertTriangle size="0.75rem" className="shrink-0" />
+                            )}
+                            <span className="truncate">
+                              ~{agentLoadCost.cost.instructionTokens.toLocaleString()} tokens of agent instructions
+                              {" · "}~{agentLoadCost.cost.extraCalls} extra call
+                              {agentLoadCost.cost.extraCalls === 1 ? "" : "s"}/turn
+                            </span>
+                          </span>
+                          <span className="shrink-0 cursor-help text-[0.625rem] opacity-70">ⓘ</span>
+                        </div>
+
                         {activeAgentIds.length === 0 && (
                           <p className="text-[0.6875rem] text-[var(--muted-foreground)] px-1">
                             No per-chat agent overrides. Workspace default agents will be used for this chat.
@@ -3335,27 +3387,38 @@ export function ChatSettingsDrawer({
                               {/* Active agents in this category */}
                               {activeInCat.length > 0 && (
                                 <div className="flex flex-col gap-1 mb-1.5">
-                                  {activeInCat.map((agent) => (
-                                    <div
-                                      key={agent.id}
-                                      className="flex items-center gap-2.5 rounded-lg bg-[var(--primary)]/10 px-3 py-2 ring-1 ring-[var(--primary)]/30"
-                                    >
-                                      <Sparkles size="0.875rem" className="text-[var(--primary)]" />
-                                      <div className="flex-1 min-w-0">
-                                        <span className="block truncate text-xs">{agent.name}</span>
-                                        <span className="mt-0.5 block text-[0.625rem] leading-tight text-[var(--muted-foreground)] line-clamp-2">
-                                          {agent.description}
-                                        </span>
-                                      </div>
-                                      <button
-                                        onClick={() => toggleAgent(agent.id)}
-                                        className="flex h-5 w-5 items-center justify-center rounded-md text-[var(--muted-foreground)] transition-colors hover:bg-[var(--destructive)]/15 hover:text-[var(--destructive)]"
-                                        title="Remove from chat"
+                                  {activeInCat.map((agent) => {
+                                    const tokenEst = agentLoadCost.tokensByType.get(agent.id);
+                                    return (
+                                      <div
+                                        key={agent.id}
+                                        className="flex items-center gap-2.5 rounded-lg bg-[var(--primary)]/10 px-3 py-2 ring-1 ring-[var(--primary)]/30"
                                       >
-                                        <Trash2 size="0.6875rem" />
-                                      </button>
-                                    </div>
-                                  ))}
+                                        <Sparkles size="0.875rem" className="text-[var(--primary)]" />
+                                        <div className="flex-1 min-w-0">
+                                          <span className="block truncate text-xs">{agent.name}</span>
+                                          <span className="mt-0.5 block text-[0.625rem] leading-tight text-[var(--muted-foreground)] line-clamp-2">
+                                            {agent.description}
+                                          </span>
+                                        </div>
+                                        {tokenEst ? (
+                                          <span
+                                            className="shrink-0 tabular-nums text-[0.625rem] text-[var(--muted-foreground)]"
+                                            title={`~${tokenEst.toLocaleString()} tokens of agent instructions (estimated)`}
+                                          >
+                                            ~{tokenEst.toLocaleString()}
+                                          </span>
+                                        ) : null}
+                                        <button
+                                          onClick={() => toggleAgent(agent.id)}
+                                          className="flex h-5 w-5 items-center justify-center rounded-md text-[var(--muted-foreground)] transition-colors hover:bg-[var(--destructive)]/15 hover:text-[var(--destructive)]"
+                                          title="Remove from chat"
+                                        >
+                                          <Trash2 size="0.6875rem" />
+                                        </button>
+                                      </div>
+                                    );
+                                  })}
                                 </div>
                               )}
                               {/* Available agents to add */}
@@ -3401,24 +3464,35 @@ export function ChatSettingsDrawer({
                             >
                               {activeCustom.length > 0 && (
                                 <div className="flex flex-col gap-1 mb-1.5">
-                                  {activeCustom.map((agent) => (
-                                    <div
-                                      key={agent.id}
-                                      className="flex items-center gap-2.5 rounded-lg bg-[var(--primary)]/10 px-3 py-2 ring-1 ring-[var(--primary)]/30"
-                                    >
-                                      <Sparkles size="0.875rem" className="text-[var(--primary)]" />
-                                      <div className="flex-1 min-w-0">
-                                        <span className="block truncate text-xs">{agent.name}</span>
-                                      </div>
-                                      <button
-                                        onClick={() => toggleAgent(agent.id)}
-                                        className="flex h-5 w-5 items-center justify-center rounded-md text-[var(--muted-foreground)] transition-colors hover:bg-[var(--destructive)]/15 hover:text-[var(--destructive)]"
-                                        title="Remove from chat"
+                                  {activeCustom.map((agent) => {
+                                    const tokenEst = agentLoadCost.tokensByType.get(agent.id);
+                                    return (
+                                      <div
+                                        key={agent.id}
+                                        className="flex items-center gap-2.5 rounded-lg bg-[var(--primary)]/10 px-3 py-2 ring-1 ring-[var(--primary)]/30"
                                       >
-                                        <Trash2 size="0.6875rem" />
-                                      </button>
-                                    </div>
-                                  ))}
+                                        <Sparkles size="0.875rem" className="text-[var(--primary)]" />
+                                        <div className="flex-1 min-w-0">
+                                          <span className="block truncate text-xs">{agent.name}</span>
+                                        </div>
+                                        {tokenEst ? (
+                                          <span
+                                            className="shrink-0 tabular-nums text-[0.625rem] text-[var(--muted-foreground)]"
+                                            title={`~${tokenEst.toLocaleString()} tokens of agent instructions (estimated)`}
+                                          >
+                                            ~{tokenEst.toLocaleString()}
+                                          </span>
+                                        ) : null}
+                                        <button
+                                          onClick={() => toggleAgent(agent.id)}
+                                          className="flex h-5 w-5 items-center justify-center rounded-md text-[var(--muted-foreground)] transition-colors hover:bg-[var(--destructive)]/15 hover:text-[var(--destructive)]"
+                                          title="Remove from chat"
+                                        >
+                                          <Trash2 size="0.6875rem" />
+                                        </button>
+                                      </div>
+                                    );
+                                  })}
                                 </div>
                               )}
                               {inactiveCustom.length > 0 && (

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -352,7 +352,9 @@ export function ChatSettingsDrawer({
       const meta = availableAgents.find((a) => a.id === id);
       if (!meta) return [];
       const cfg = agentConfigsByType.get(id);
-      const promptTemplate = cfg?.promptTemplate ?? DEFAULT_AGENT_PROMPTS[id] ?? "";
+      // `||` (not `??`) — custom configs often have an empty-string promptTemplate
+      // meaning "no override", and we still want to count the built-in default.
+      const promptTemplate = cfg?.promptTemplate || DEFAULT_AGENT_PROMPTS[id] || "";
       return [
         {
           type: id,

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -3403,7 +3403,7 @@ export function ChatSettingsDrawer({
                                             {agent.description}
                                           </span>
                                         </div>
-                                        {tokenEst ? (
+                                        {tokenEst != null ? (
                                           <span
                                             className="shrink-0 tabular-nums text-[0.625rem] text-[var(--muted-foreground)]"
                                             title={`~${tokenEst.toLocaleString()} tokens of agent instructions (estimated)`}
@@ -3477,7 +3477,7 @@ export function ChatSettingsDrawer({
                                         <div className="flex-1 min-w-0">
                                           <span className="block truncate text-xs">{agent.name}</span>
                                         </div>
-                                        {tokenEst ? (
+                                        {tokenEst != null ? (
                                           <span
                                             className="shrink-0 tabular-nums text-[0.625rem] text-[var(--muted-foreground)]"
                                             title={`~${tokenEst.toLocaleString()} tokens of agent instructions (estimated)`}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -50,3 +50,4 @@ export * from "./constants/security.js";
 export * from "./utils/macro-engine.js";
 export * from "./utils/xml-wrapper.js";
 export * from "./utils/music-score.js";
+export * from "./utils/agent-cost.js";

--- a/packages/shared/src/utils/agent-cost.ts
+++ b/packages/shared/src/utils/agent-cost.ts
@@ -1,0 +1,87 @@
+// ──────────────────────────────────────────────
+// Agent Loadout Cost Estimator
+// ──────────────────────────────────────────────
+// Pure function that estimates the per-turn cost of an enabled agent set,
+// so the UI can show "~N tokens · ~M extra calls" alongside the agent picker.
+//
+// The estimate is intentionally rough. It is meant to help users sense when
+// a loadout is starting to get heavy, not to predict billing.
+//
+// Two axes:
+//   - instructionTokens: sum of agents' prompt-template tokens (chars/4).
+//     Does NOT include the chat context (recent messages, character cards,
+//     persona, lorebook, summary) that each call also carries — real per-turn
+//     usage will be substantially higher. UI copy should make that clear.
+//   - extraCalls: count of distinct (phase × connection) groups. This mirrors
+//     the server-side batching in
+//     `packages/server/src/services/agents/agent-pipeline.ts`: agents that
+//     share a phase AND connection batch into a single LLM call. v1 ignores
+//     the tool-extraction nuance (tool-using agents technically run alone,
+//     adding 1 call each beyond the batch) — fine for a soft signal.
+// ──────────────────────────────────────────────
+
+import type { AgentPhase } from "../types/agent.js";
+import { BUILT_IN_AGENT_IDS } from "../types/agent.js";
+
+/** Minimal shape needed to estimate an agent's contribution. */
+export interface AgentCostInput {
+  /** Agent type identifier, e.g. "world-state". Used to special-case static agents. */
+  type: string;
+  phase: AgentPhase;
+  /** Per-agent connection override; falls back to the chat default when null. */
+  connectionId: string | null;
+  /** Resolved prompt template (custom override OR built-in default). */
+  promptTemplate: string;
+}
+
+export interface AgentLoadCost {
+  instructionTokens: number;
+  extraCalls: number;
+  /** Soft warning level. "high" when the loadout crosses a threshold likely to
+   *  matter on small-context (~8k) local models. */
+  level: "ok" | "high";
+}
+
+// v1 thresholds, tunable via user feedback:
+//   - 4 extra calls roughly doubles a typical 2-call baseline.
+//   - 4000 instruction tokens fills ~50% of an 8k local-model context.
+export const AGENT_COST_HIGH_CALLS = 4;
+export const AGENT_COST_HIGH_TOKENS = 4000;
+
+/**
+ * Agents whose template contributes to the main prompt but do NOT trigger an
+ * extra LLM call. Currently just `html`, which is statically injected.
+ *
+ * `knowledge-retrieval` and `knowledge-router` ARE separate inference calls
+ * (they ask the LLM to pick or summarize lorebook entries), so they are not
+ * in this set.
+ */
+const NO_EXTRA_CALL_AGENT_TYPES = new Set<string>([BUILT_IN_AGENT_IDS.HTML]);
+
+// TODO: replace chars/4 with a real tokenizer when the project picks one up.
+// Matches the existing `estimateTokens` helpers scattered across the client
+// (PeekPromptModal, LorebookFormFields, etc.).
+function approximateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+export function estimateAgentLoadCost(
+  enabled: AgentCostInput[],
+  defaultConnectionId: string | null,
+): AgentLoadCost {
+  let instructionTokens = 0;
+  const callKeys = new Set<string>();
+
+  for (const a of enabled) {
+    instructionTokens += approximateTokens(a.promptTemplate);
+    if (NO_EXTRA_CALL_AGENT_TYPES.has(a.type)) continue;
+    const connection = a.connectionId ?? defaultConnectionId ?? "default";
+    callKeys.add(`${a.phase}::${connection}`);
+  }
+
+  const extraCalls = callKeys.size;
+  const level: "ok" | "high" =
+    extraCalls >= AGENT_COST_HIGH_CALLS || instructionTokens >= AGENT_COST_HIGH_TOKENS ? "high" : "ok";
+
+  return { instructionTokens, extraCalls, level };
+}


### PR DESCRIPTION
## Summary

Adds a small informational readout to the agents picker in the chat settings drawer (roleplay mode) so users can see the rough overhead of their enabled agent loadout before they hit context-window or latency problems.

- Cumulative pill at the top of the agents section: `~N tokens of agent instructions · ~M extra calls/turn`. Flips to amber with a warning icon when the loadout crosses 4 extra calls or 4000 instruction tokens.
- Per-agent `~N` token badge next to each active agent row.
- Pure cost function `estimateAgentLoadCost` lives in `@marinara-engine/shared`.

## Why

Right now there's no in-UI signal for the cumulative cost of an enabled agent set. Users only find out the loadout is too heavy when things fail — context overflows on small local models, latency spikes from too many extra calls, errors in the logs. By that point they're toggling agents off one-by-one to find a working set.

This gives a soft self-correcting signal before any of that happens. Informational only, no toggles are blocked.

## Approach

- **Token estimate** uses the existing `chars/4` heuristic that's already scattered across the client (PeekPromptModal, LorebookFormFields, etc.). Marked clearly as approximate. There's a `TODO` at the heuristic site for swapping in a real tokenizer when one is added.
- **Extra-calls estimate** mirrors the batching in `packages/server/src/services/agents/agent-pipeline.ts` — agents that share `(phase, connection)` batch into one call. v1 ignores the tool-extraction nuance (tool-using agents technically run alone) — fine for a soft signal.
- **Chat context is intentionally not counted.** Each call also carries recent messages, characters, persona, and lorebook entries, so real per-turn token use is higher than `instructionTokens`. The hover tooltip on the readout calls this out explicitly.
- **Thresholds (4 calls, 4000 tokens) are first-principles defaults**, not measured. 4 calls roughly doubles a typical 2-call baseline; 4000 tokens fills ~50% of an 8k local-model context. Tunable if user feedback says otherwise.

## Scope

- **Roleplay mode only.** Conversation mode hides the agents section entirely (its "agents" are mode-specific features like Autonomous Messaging) and game mode shows a curated 2-toggle allowlist. Both are different design problems; the cost function is reusable if a similar readout makes sense there later.
- No new dependencies. No tokenizer added.

## Files changed

- `packages/shared/src/utils/agent-cost.ts` (new) — pure cost function + threshold constants.
- `packages/shared/src/index.ts` — re-export.
- `packages/client/src/components/chat/ChatSettingsDrawer.tsx` — imports, `agentLoadCost` memo, cumulative pill, two per-row badges, `activeAgentIds` wrapped in `useMemo` to keep the new memo stable. Also a small fix: empty-string `promptTemplate` in custom configs now falls through to the built-in default (was `??`, needed `||`).

## Known limitations

- Estimate is approximate by design and labeled `~`. Real per-turn usage will be higher because chat context is not counted.
- Per-agent token count uses prompt-template length only; agent tool definitions are not separately estimated. v1 simplification.
- Threshold values are gut-feel defaults, not empirically measured against specific small models.

## Test plan

- [x] Cumulative readout shows `~N tokens · ~M extra calls/turn` text in standard chat
- [x] Per-agent `~N` badges render with hover tooltip on active agent rows
- [x] Crossing 4000 tokens or 4 calls flips the pill to amber with an `AlertTriangle` icon
- [x] ⓘ tooltip on the cumulative pill explains the estimate is approximate
- [x] Conversation mode does not render the agents section (unchanged)
- [x] Game mode shows the curated agent allowlist with no readout (unchanged)
- [x] Light mode looks right
- [x] Dark mode looks right
- [x] Mobile width (~400px) — cumulative readout truncates cleanly without overflow
- [x] `pnpm --filter @marinara-engine/shared run lint` passes locally
- [x] `pnpm --filter @marinara-engine/client run lint` passes locally

`pnpm check` currently fails on `main` due to a pre-existing `OutputType.HwPositionWithDuration` rename in `packages/server/src/services/haptic/buttplug-service.ts`. Not introduced by this PR.

## Screenshots
<img width="202" height="615" alt="image" src="https://github.com/user-attachments/assets/7cfdb902-fba1-4a5a-8eda-bf704e030d26" />
<img width="221" height="415" alt="image" src="https://github.com/user-attachments/assets/96cc4c36-2c2a-4a9b-80c9-2f6b8a6b0679" />
<img width="413" height="556" alt="image" src="https://github.com/user-attachments/assets/513cd93d-018f-42c7-982c-e13a384677b6" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added per-turn cost estimation and live visualization for active agents in chat settings.
  * Cost readout header dynamically updates styling and icons when cost thresholds are exceeded.
  * Per-agent instruction token usage estimates now displayed as badges in agent categories.
  * Informational tooltips reference specific thresholds to help manage overall agent loadout costs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->