### PR TITLE
docs(lorebooks): explain three scoping mechanisms in FAQ + tooltips

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -95,3 +95,29 @@ Connected chats (the link between a conversation and a roleplay or game) are int
 This is by design — pulling raw DM messages into every roleplay turn would inflate the prompt and dilute the story. If you want something from the DM to stick in the roleplay, ask the conversation character to wrap it in a `<note>`.
 
 </details>
+
+---
+
+<a id="how-do-i-use-one-lorebook-with-multiple-characters"></a>
+
+<details>
+<summary><strong>How do I use one lorebook with multiple characters, or scope it to a specific chat?</strong></summary>
+<br>
+
+Marinara has three different ways to scope a lorebook, each at a different level. Pick whichever matches your use case:
+
+**1. Bind a lorebook to one character or persona** (lorebook editor → `Linked Character` / `Linked Persona`).
+
+The lorebook auto-activates in any chat that includes that character or uses that persona. Best when the lore is specifically *about* that character (e.g., their backstory, their world). The two link types are mutually exclusive — pick one or the other, not both. Each link is single-value, so this is the right tool for one lorebook ↔ one character.
+
+**2. Attach lorebooks per-chat via the chat settings drawer** (gear icon → **Lorebooks** section → **+ Add Lorebook**).
+
+Multi-select. Use this when you want one lorebook active across multiple characters, or scoped to just one specific chat, or when you want several lorebooks layered together for a single chat. The lorebook's `Linked Character` / `Linked Persona` fields can be empty for this — chat attachment is independent of those links.
+
+**3. Filter individual entries by character** (lorebook entry editor → `Character Filters`).
+
+Inside a single shared lorebook, you can mark each entry as only firing when specific characters (or character tags) are present in the chat. Best for a "world bible" lorebook shared across many chats where some entries are character-specific.
+
+**Common scenario — "I want this lorebook for Character A *and* Character B":** leave the lorebook's character link empty, and attach the lorebook via the chat settings drawer in any chat that includes either character. The same lorebook can be attached to as many chats as you want.
+
+</details>

--- a/packages/client/src/components/lorebooks/LorebookEditor.tsx
+++ b/packages/client/src/components/lorebooks/LorebookEditor.tsx
@@ -865,7 +865,7 @@ export function LorebookEditor() {
                 <div>
                   <label className="mb-1.5 flex items-center gap-1 text-xs font-medium">
                     Linked Character{" "}
-                    <HelpTooltip text="When linked to a character, this lorebook will only activate in chats that include that character." />
+                    <HelpTooltip text="When linked to a character, this lorebook auto-activates in any chat that includes that character. For multi-character or chat-specific scope, leave this empty and attach the lorebook per-chat via the chat settings drawer's Lorebooks section instead." />
                   </label>
                   <div className="flex items-center gap-2">
                     <select
@@ -904,7 +904,7 @@ export function LorebookEditor() {
                 <div>
                   <label className="mb-1.5 flex items-center gap-1 text-xs font-medium">
                     Linked Persona{" "}
-                    <HelpTooltip text="When linked to a persona, this lorebook will only activate in chats that use that persona." />
+                    <HelpTooltip text="When linked to a persona, this lorebook auto-activates in any chat that uses that persona. For chat-specific scope, leave this empty and attach the lorebook per-chat via the chat settings drawer's Lorebooks section instead." />
                   </label>
                   <div className="flex items-center gap-2">
                     <select


### PR DESCRIPTION
## Summary

Surfaces the existing lorebook multi-character and chat-scoping mechanisms that aren't discoverable from the lorebook editor today. Pure UX/docs, no behavior change.

## Why

Users — especially SillyTavern migrants — see the lorebook editor's `Linked Character` (single-select) and assume that's the only way to scope a lorebook. They miss two existing mechanisms that already cover the multi-character / chat-specific cases:

- **Chat settings drawer → Lorebooks section** (`metadata.activeLorebookIds[]`) — multi-attach, per-chat.
- **Per-entry character filters** (`characterFilterIds[]`, added in d7179e7) — finer-grained scoping inside a shared lorebook.

The schema and runtime already support all three; the gap is only that the lorebook editor's own UI doesn't point users at them.

## What changed

- `packages/client/src/components/lorebooks/LorebookEditor.tsx` — `Linked Character` and `Linked Persona` tooltips now mention the chat-drawer multi-attach for multi-character / chat-specific scope.
- `docs/FAQ.md` — new entry *"How do I use one lorebook with multiple characters, or scope it to a specific chat?"* walking through all three mechanisms.

## Test plan

- [x] Tooltip text renders correctly on `Linked Character` (light + dark mode)
- [x] Tooltip text renders correctly on `Linked Persona` (light + dark mode)
- [x] Tooltip doesn't overflow at mobile width (~400px)
- [x] FAQ markdown renders correctly on the GitHub diff view

## Notes for the reviewer

- **CI failure is pre-existing on `main`.** The current `pnpm check` failure in `packages/server/src/services/haptic/buttplug-service.ts` (`OutputType.HwPositionWithDuration` not found on the upstream library type) is unrelated to this PR — it landed in `e3e96cd` (v1.5.7 hotfix release) before this branch. Client lint + typecheck pass clean for the files this PR touches.

<img width="653" height="271" alt="image" src="https://github.com/user-attachments/assets/ad0ba9da-1165-4e8c-aaf4-d3a895d20253" />

<img width="744" height="179" alt="image" src="https://github.com/user-attachments/assets/aa7bf04f-a229-4620-9102-26f6d2d6f3c1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added FAQ entry covering multiple approaches to scope lorebooks across characters and specific chats
  * Clarified tooltip text for character and persona linking features to explain auto-activation behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->