### PR TITLE
Keep custom OpenAI-compatible requests conservative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Custom OpenAI-compatible endpoints like Venice no longer receive provider-specific request fields just because a fetched model ID matches an OpenAI, xAI, OpenRouter, or Z.AI naming pattern.
 - Addressed various security concerns.
 - Game mode dark screen error addressed.
 - Removed the persistent SQLite database as the default live storage path, reducing release-to-release migration failures.

--- a/packages/server/src/services/llm/provider-registry.ts
+++ b/packages/server/src/services/llm/provider-registry.ts
@@ -46,7 +46,14 @@ export function createLLMProvider(
     case "xai":
     case "mistral":
     case "custom":
-      return new OpenAIProvider(baseUrl, apiKey, normalizedMaxContext, openrouterProvider, normalizedMaxTokensOverride);
+      return new OpenAIProvider(
+        baseUrl,
+        apiKey,
+        normalizedMaxContext,
+        openrouterProvider,
+        normalizedMaxTokensOverride,
+        provider,
+      );
     case "cohere":
       return new OpenAIProvider(
         normalizeCohereOpenAIBaseUrl(baseUrl),
@@ -54,6 +61,7 @@ export function createLLMProvider(
         normalizedMaxContext,
         openrouterProvider,
         normalizedMaxTokensOverride,
+        "cohere",
       );
     case "anthropic":
       return new AnthropicProvider(
@@ -74,6 +82,13 @@ export function createLLMProvider(
     case "google":
       return new GoogleProvider(baseUrl, apiKey, normalizedMaxContext, openrouterProvider, normalizedMaxTokensOverride);
     default:
-      return new OpenAIProvider(baseUrl, apiKey, normalizedMaxContext, openrouterProvider, normalizedMaxTokensOverride);
+      return new OpenAIProvider(
+        baseUrl,
+        apiKey,
+        normalizedMaxContext,
+        openrouterProvider,
+        normalizedMaxTokensOverride,
+        "custom",
+      );
   }
 }

--- a/packages/server/src/services/llm/providers/local-sidecar.provider.ts
+++ b/packages/server/src/services/llm/providers/local-sidecar.provider.ts
@@ -13,7 +13,7 @@ export class LocalSidecarProvider extends BaseLLMProvider {
   private async createDelegate(): Promise<OpenAIProvider> {
     const baseUrl = await sidecarProcessService.ensureReady({ forceStart: true });
     const contextSize = sidecarModelService.getConfig().contextSize;
-    return new OpenAIProvider(`${baseUrl}/v1`, "local-sidecar", contextSize, null);
+    return new OpenAIProvider(`${baseUrl}/v1`, "local-sidecar", contextSize, null, null, "local-sidecar");
   }
 
   private getRequestModel(): string {

--- a/packages/server/src/services/llm/providers/openai.provider.ts
+++ b/packages/server/src/services/llm/providers/openai.provider.ts
@@ -54,10 +54,31 @@ type ResponsesUsagePayload = {
   };
 };
 
+type OpenAIProviderKind =
+  | "openai"
+  | "openrouter"
+  | "nanogpt"
+  | "xai"
+  | "mistral"
+  | "cohere"
+  | "custom"
+  | "local-sidecar";
+
 /**
  * Handles OpenAI, OpenRouter, Mistral, Cohere, and any OpenAI-compatible endpoint.
  */
 export class OpenAIProvider extends BaseLLMProvider {
+  constructor(
+    baseUrl: string,
+    apiKey: string,
+    defaultMaxContext?: number,
+    defaultOpenrouterProvider?: string | null,
+    maxTokensOverride?: number | null,
+    private readonly providerKind: OpenAIProviderKind = "openai",
+  ) {
+    super(baseUrl, apiKey, defaultMaxContext, defaultOpenrouterProvider, maxTokensOverride);
+  }
+
   private static async parseJsonBody<T>(response: Response, context: string): Promise<T> {
     const raw = await response.text();
     try {
@@ -218,29 +239,40 @@ export class OpenAIProvider extends BaseLLMProvider {
       "Content-Type": "application/json",
       Authorization: `Bearer ${this.apiKey}`,
     };
-    if (this.baseUrl.includes("openrouter.ai")) {
+    if (!this.isGenericCustomProvider() && this.baseUrl.includes("openrouter.ai")) {
       h["HTTP-Referer"] = "https://github.com/Pasta-Devs/Marinara-Engine";
       h["X-Title"] = "Marinara Engine";
     }
     return h;
   }
 
+  private isGenericCustomProvider(): boolean {
+    return this.providerKind === "custom";
+  }
+
   /** Check if a model ID represents an OpenAI reasoning model */
   private isReasoningModel(model: string): boolean {
+    if (this.isGenericCustomProvider()) return false;
     const m = model.toLowerCase();
     return /^(o1|o3|o4)/.test(m) || m.startsWith("gpt-5");
   }
 
   private isXAIEndpoint(): boolean {
+    if (this.isGenericCustomProvider()) return false;
     const baseUrl = this.baseUrl.toLowerCase();
     return baseUrl.includes("api.x.ai") || baseUrl.includes("x.ai/");
   }
 
   private isOpenRouterXAIModel(model: string): boolean {
-    return this.baseUrl.includes("openrouter.ai") && model.toLowerCase().startsWith("x-ai/grok-");
+    return (
+      !this.isGenericCustomProvider() &&
+      this.baseUrl.includes("openrouter.ai") &&
+      model.toLowerCase().startsWith("x-ai/grok-")
+    );
   }
 
   private isXAIMultiAgentModel(model: string): boolean {
+    if (this.isGenericCustomProvider()) return false;
     return model.toLowerCase() === "grok-4.20-multi-agent";
   }
 
@@ -269,6 +301,7 @@ export class OpenAIProvider extends BaseLLMProvider {
    * GPT-5.x models only support temperature when reasoning effort is "none" (the default).
    */
   private isNoTemperatureModel(model: string, reasoningEffort?: string): boolean {
+    if (this.isGenericCustomProvider()) return false;
     const m = model.toLowerCase();
     if (/^(o1|o3|o4)/.test(m)) return true;
     if (m.startsWith("gpt-5") && reasoningEffort && reasoningEffort !== "none") return true;
@@ -277,9 +310,27 @@ export class OpenAIProvider extends BaseLLMProvider {
     return false;
   }
 
-  /** GLM variants use a boolean thinking toggle instead of effort-based reasoning config. */
+  /** GLM variants on Z.AI/BigModel use a boolean thinking toggle instead of effort-based reasoning config. */
   private isGLMModel(model: string): boolean {
     return model.toLowerCase().includes("glm");
+  }
+
+  private isNativeGLMEndpoint(): boolean {
+    try {
+      const hostname = new URL(this.baseUrl).hostname.toLowerCase();
+      return (
+        hostname === "api.z.ai" ||
+        hostname.endsWith(".api.z.ai") ||
+        hostname === "open.bigmodel.cn" ||
+        hostname.endsWith(".open.bigmodel.cn")
+      );
+    } catch {
+      return false;
+    }
+  }
+
+  private shouldSendGLMEnableThinking(model: string): boolean {
+    return !this.isGenericCustomProvider() && this.isGLMModel(model) && this.isNativeGLMEndpoint();
   }
 
   private hasActiveReasoningEffort(reasoningEffort?: string | null): boolean {
@@ -287,7 +338,7 @@ export class OpenAIProvider extends BaseLLMProvider {
   }
 
   private isOpenRouterEndpoint(): boolean {
-    return this.baseUrl.includes("openrouter.ai");
+    return !this.isGenericCustomProvider() && this.baseUrl.includes("openrouter.ai");
   }
 
   private supportsOpenRouterUnifiedReasoning(model: string): boolean {
@@ -305,7 +356,7 @@ export class OpenAIProvider extends BaseLLMProvider {
       return;
     }
 
-    if (this.isGLMModel(options.model)) {
+    if (this.shouldSendGLMEnableThinking(options.model)) {
       body.enable_thinking = this.hasActiveReasoningEffort(options.reasoningEffort);
       return;
     }
@@ -335,7 +386,7 @@ export class OpenAIProvider extends BaseLLMProvider {
       return;
     }
 
-    if (this.isGLMModel(options.model)) {
+    if (this.shouldSendGLMEnableThinking(options.model)) {
       body.enable_thinking = this.hasActiveReasoningEffort(options.reasoningEffort);
       return;
     }
@@ -358,6 +409,7 @@ export class OpenAIProvider extends BaseLLMProvider {
 
   /** Check if a model requires or benefits from the Responses API instead of Chat Completions */
   private useResponsesAPI(model: string, options?: Pick<ChatOptions, "captureReasoning">): boolean {
+    if (this.isGenericCustomProvider()) return false;
     const m = model.toLowerCase();
     return (
       this.isXAIMultiAgentModel(model) ||
@@ -368,11 +420,13 @@ export class OpenAIProvider extends BaseLLMProvider {
   }
 
   private requiresStreamingChatCompletions(model: string): boolean {
+    if (this.isGenericCustomProvider()) return false;
     return model.toLowerCase().startsWith("gpt-5.5");
   }
 
   private shouldUseOpenRouterPromptCaching(options: ChatOptions): boolean {
     return (
+      !this.isGenericCustomProvider() &&
       this.baseUrl.includes("openrouter.ai") &&
       !!options.enableCaching &&
       options.model.toLowerCase().includes("claude")
@@ -383,6 +437,14 @@ export class OpenAIProvider extends BaseLLMProvider {
     if (!this.shouldUseOpenRouterPromptCaching(options)) return;
     body.cache_control = { type: "ephemeral" };
     logger.debug("[OpenAI] Enabling OpenRouter prompt caching for model=%s", options.model);
+  }
+
+  private supportsGpt5Verbosity(model: string): boolean {
+    return !this.isGenericCustomProvider() && model.toLowerCase().startsWith("gpt-5");
+  }
+
+  private shouldApplyOpenRouterProviderOverride(openrouterProvider?: string | null): boolean {
+    return !!openrouterProvider && !this.isGenericCustomProvider() && this.baseUrl.includes("openrouter.ai");
   }
 
   private static extractChatCompletionsUsage(usage: ChatCompletionsUsagePayload | undefined): LLMUsage | undefined {
@@ -405,6 +467,7 @@ export class OpenAIProvider extends BaseLLMProvider {
    * OpenAI GPT-5.x and o-series models use "developer" for system-level instructions.
    */
   private usesDeveloperRole(model: string): boolean {
+    if (this.isGenericCustomProvider()) return false;
     const m = model.toLowerCase();
     return m.startsWith("gpt-5") || m.startsWith("o1") || m.startsWith("o3") || m.startsWith("o4");
   }
@@ -512,7 +575,7 @@ export class OpenAIProvider extends BaseLLMProvider {
       }
     }
 
-    if (options.verbosity && options.model.toLowerCase().startsWith("gpt-5")) {
+    if (options.verbosity && this.supportsGpt5Verbosity(options.model)) {
       body.verbosity = options.verbosity;
     }
 
@@ -520,7 +583,7 @@ export class OpenAIProvider extends BaseLLMProvider {
 
     // OpenRouter provider routing preference
     const openrouterProvider = this.resolveOpenrouterProvider(options.openrouterProvider);
-    if (openrouterProvider && this.baseUrl.includes("openrouter.ai")) {
+    if (this.shouldApplyOpenRouterProviderOverride(openrouterProvider)) {
       body.provider = { order: [openrouterProvider] };
     }
 
@@ -720,7 +783,7 @@ export class OpenAIProvider extends BaseLLMProvider {
       }
     }
 
-    if (options.verbosity && options.model.toLowerCase().startsWith("gpt-5")) {
+    if (options.verbosity && this.supportsGpt5Verbosity(options.model)) {
       body.verbosity = options.verbosity;
     }
 
@@ -728,7 +791,7 @@ export class OpenAIProvider extends BaseLLMProvider {
 
     // OpenRouter provider routing preference
     const openrouterProvider = this.resolveOpenrouterProvider(options.openrouterProvider);
-    if (openrouterProvider && this.baseUrl.includes("openrouter.ai")) {
+    if (this.shouldApplyOpenRouterProviderOverride(openrouterProvider)) {
       body.provider = { order: [openrouterProvider] };
     }
 
@@ -1091,12 +1154,12 @@ export class OpenAIProvider extends BaseLLMProvider {
     this.applyResponsesReasoning(body, options);
 
     // GPT-5+ text verbosity control
-    if (options.verbosity && options.model.toLowerCase().startsWith("gpt-5")) {
+    if (options.verbosity && this.supportsGpt5Verbosity(options.model)) {
       body.text = { verbosity: options.verbosity };
     }
 
     const openrouterProvider = this.resolveOpenrouterProvider(options.openrouterProvider);
-    if (openrouterProvider && this.baseUrl.includes("openrouter.ai")) {
+    if (this.shouldApplyOpenRouterProviderOverride(openrouterProvider)) {
       body.provider = { order: [openrouterProvider] };
     }
 

--- a/packages/server/test/openai-provider-reasoning.test.ts
+++ b/packages/server/test/openai-provider-reasoning.test.ts
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { MODEL_LISTS } from "../../shared/src/constants/model-lists.ts";
+import { createLLMProvider } from "../src/services/llm/provider-registry.js";
 import { OpenAIProvider } from "../src/services/llm/providers/openai.provider.js";
 import type { ChatOptions } from "../src/services/llm/base-provider.js";
 
@@ -8,6 +9,7 @@ async function captureChatRequestBody(
   model: string,
   overrides: Partial<ChatOptions> = {},
   baseUrl = "https://example.com/v1",
+  provider = new OpenAIProvider(baseUrl, "test-key"),
 ) {
   const requests: Array<Record<string, unknown>> = [];
   const originalFetch = globalThis.fetch;
@@ -29,7 +31,6 @@ async function captureChatRequestBody(
 
   try {
     process.env.PROVIDER_LOCAL_URLS_ENABLED = "true";
-    const provider = new OpenAIProvider(baseUrl, "test-key");
     const options: ChatOptions = {
       model,
       stream: false,
@@ -58,6 +59,7 @@ async function captureChatCompleteRequestBody(
   model: string,
   overrides: Partial<ChatOptions> = {},
   baseUrl = "https://example.com/v1",
+  provider = new OpenAIProvider(baseUrl, "test-key"),
 ) {
   const requests: Array<Record<string, unknown>> = [];
   const originalFetch = globalThis.fetch;
@@ -81,7 +83,6 @@ async function captureChatCompleteRequestBody(
 
   try {
     process.env.PROVIDER_LOCAL_URLS_ENABLED = "true";
-    const provider = new OpenAIProvider(baseUrl, "test-key");
     const options: ChatOptions = {
       model,
       stream: false,
@@ -111,11 +112,86 @@ test("non-reasoning models do not receive reasoning payloads", async () => {
   assert.equal("enable_thinking" in body, false);
 });
 
-test("GLM models still use enable_thinking", async () => {
-  const body = await captureChatRequestBody("glm-4.5");
+test("GLM models on native Z.AI endpoints still use enable_thinking for provider routes", async () => {
+  const body = await captureChatRequestBody("glm-4.5", {}, "https://api.z.ai/api/paas/v4");
 
   assert.equal(body.enable_thinking, true);
   assert.equal("reasoning_effort" in body, false);
+});
+
+test("custom compatible endpoints omit enable_thinking even on native Z.AI URLs", async () => {
+  const provider = createLLMProvider("custom", "https://api.z.ai/api/paas/v4", "test-key");
+  const body = await captureChatRequestBody("glm-4.5", {}, "https://api.z.ai/api/paas/v4", provider);
+
+  assert.equal("enable_thinking" in body, false);
+  assert.equal("reasoning_effort" in body, false);
+});
+
+test("GLM native endpoint detection ignores host-like URL path and query strings", async () => {
+  const adversarialUrl = "https://example.com/api.z.ai/v1?next=https://open.bigmodel.cn/api/paas/v4";
+
+  const chatBody = await captureChatRequestBody("glm-4.5", {}, adversarialUrl);
+  const completeBody = await captureChatCompleteRequestBody("glm-4.5", {}, adversarialUrl);
+
+  assert.equal("enable_thinking" in chatBody, false);
+  assert.equal("reasoning_effort" in chatBody, false);
+  assert.equal("enable_thinking" in completeBody, false);
+  assert.equal("reasoning_effort" in completeBody, false);
+});
+
+test("GLM-named models on custom compatible endpoints omit enable_thinking", async () => {
+  const provider = createLLMProvider("custom", "https://api.venice.ai/api/v1", "test-key");
+  const body = await captureChatRequestBody("zai-org-glm-5-1", {}, "https://api.venice.ai/api/v1", provider);
+
+  assert.equal("enable_thinking" in body, false);
+  assert.equal("reasoning_effort" in body, false);
+});
+
+test("GLM-named chatComplete requests on custom compatible endpoints omit enable_thinking", async () => {
+  const provider = createLLMProvider("custom", "https://api.venice.ai/api/v1", "test-key");
+  const body = await captureChatCompleteRequestBody("zai-org-glm-5-1", {}, "https://api.venice.ai/api/v1", provider);
+
+  assert.equal("enable_thinking" in body, false);
+  assert.equal("reasoning_effort" in body, false);
+});
+
+test("custom compatible endpoints keep OpenAI reasoning model names on a standard body", async () => {
+  const provider = createLLMProvider("custom", "https://example.com/v1", "test-key");
+  const body = await captureChatRequestBody("o3-mini", {}, "https://example.com/v1", provider);
+
+  assert.equal(body.max_tokens, 512);
+  assert.equal("max_completion_tokens" in body, false);
+  assert.equal("reasoning_effort" in body, false);
+  assert.equal("enable_thinking" in body, false);
+});
+
+test("custom compatible endpoints do not force GPT-5.5 streaming extras", async () => {
+  const provider = createLLMProvider("custom", "https://example.com/v1", "test-key");
+  const body = await captureChatRequestBody(
+    "gpt-5.5",
+    { reasoningEffort: "xhigh", verbosity: "high" },
+    "https://example.com/v1",
+    provider,
+  );
+
+  assert.equal(body.stream, false);
+  assert.equal(body.max_tokens, 512);
+  assert.equal("stream_options" in body, false);
+  assert.equal("max_completion_tokens" in body, false);
+  assert.equal("reasoning_effort" in body, false);
+  assert.equal("verbosity" in body, false);
+});
+
+test("custom parameters can opt custom endpoints into provider-specific fields", async () => {
+  const provider = createLLMProvider("custom", "https://api.venice.ai/api/v1", "test-key");
+  const body = await captureChatRequestBody(
+    "zai-org-glm-5-1",
+    { customParameters: { enable_thinking: true } },
+    "https://api.venice.ai/api/v1",
+    provider,
+  );
+
+  assert.equal(body.enable_thinking, true);
 });
 
 test("OpenAI reasoning models still receive reasoning_effort", async () => {


### PR DESCRIPTION
## Summary

- Treat `custom` OpenAI-compatible connections as conservative generic endpoints instead of applying provider/model-name heuristics.
- Keep OpenAI, OpenRouter, xAI, Cohere, and local-sidecar provider routes on their existing specialized request behavior.
- Prevent custom endpoints like Venice from receiving provider-specific fields such as `enable_thinking`, `reasoning_effort`, `max_completion_tokens`, GPT-5 verbosity, OpenRouter routing metadata, or forced GPT-5.5 streaming just because a fetched model ID matches a known naming pattern.
- Preserve the escape hatch: Custom Parameters still merge into the outgoing request body for users who need provider-specific fields.
- Tighten native GLM endpoint detection to parse the hostname instead of matching path/query text.
- Add regression coverage for Venice-shaped GLM IDs, native Z.AI provider routes, custom endpoint standard bodies, GPT-5.5 custom bodies, Custom Parameters, and adversarial host-like URL paths.
- Note the broader fix in the changelog.

## Context

A user reported that Venice.ai's OpenAI-compatible API accepts model fetching and connection tests, but test messages fail with `Unrecognized key(s) in object: 'enable_thinking'` when selecting `zai-org-glm-5-1`. The root issue is broader than GLM: generic custom OpenAI-compatible endpoints can be strict, so Marinara should not infer nonstandard provider fields from model names or endpoint-looking substrings unless the user selected a first-class provider route.

No linked issue exists yet. One should be opened before this PR is submitted, per CONTRIBUTING.md.

## Validation

- [ ] Manually verify a Venice.ai custom OpenAI-compatible connection using `https://api.venice.ai/api/v1` and `zai-org-glm-5-1` can send a test message.
- [ ] Manually verify a native Z.AI/BigModel GLM provider route still receives `enable_thinking` when reasoning effort is configured.
- [ ] Manually verify a custom endpoint can opt into provider-specific request fields through Custom Parameters when needed.
- [ ] Manually verify a non-GLM custom OpenAI-compatible endpoint still sends normal test messages.

Automated checks run locally:

- `pnpm --filter @marinara-engine/server test -- openai-provider-reasoning.test.ts`
- `pnpm --filter @marinara-engine/server lint`
- `pnpm check`

Note: local commands emitted the repo engine warning because this shell is on Node v22.22.0 while package.json wants Node >=24 <26.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Custom OpenAI-compatible endpoints no longer receive unintended provider-specific request fields.
  * GLM "enable_thinking" feature now properly scoped to native Z.AI/BigModel endpoints only.

* **Tests**
  * Expanded test coverage for custom endpoint provider handling and endpoint-specific behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->