### PR TITLE
Use repo-local pnpm store

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 node_modules
 packages/*/node_modules
+.pnpm-store
 .git
 **/*.tsbuildinfo
 packages/*/dist

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,4 @@
 auto-install-peers=false
 package-manager-strict=false
 package-manager-strict-version=false
+store-dir=.pnpm-store

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN corepack enable && corepack install
 
 # Install all dependencies (including dev for building)
 # Use cache mount to avoid storing pnpm store in image
-RUN --mount=type=cache,target=/root/.local/share/pnpm/store \
+RUN --mount=type=cache,target=/app/.pnpm-store \
     pnpm install --frozen-lockfile
 
 # Copy source code
@@ -61,7 +61,7 @@ RUN corepack enable && corepack install
 # Install production deps only
 # Use cache mount to avoid storing pnpm store in image
 # Strip onnxruntime-web WASM blobs, uses onnxruntime-node (native)
-RUN --mount=type=cache,target=/root/.local/share/pnpm/store \
+RUN --mount=type=cache,target=/app/.pnpm-store \
     pnpm install --frozen-lockfile --prod && \
     rm -rf /app/node_modules/.pnpm/onnxruntime-web@*
 

--- a/Dockerfile.lite
+++ b/Dockerfile.lite
@@ -31,7 +31,7 @@ COPY packages/server/package.json packages/server/
 COPY packages/client/package.json packages/client/
 
 # Install all dependencies (including dev for building)
-RUN --mount=type=cache,target=/root/.local/share/pnpm/store \
+RUN --mount=type=cache,target=/app/.pnpm-store \
     pnpm install --frozen-lockfile
 
 # Copy source code
@@ -63,7 +63,7 @@ COPY packages/server/package.json packages/server/
 COPY packages/client/package.json packages/client/
 
 # Install production deps only, then strip non-core native modules.
-RUN --mount=type=cache,target=/root/.local/share/pnpm/store \
+RUN --mount=type=cache,target=/app/.pnpm-store \
     pnpm install --frozen-lockfile --prod && \
     # ── Remove onnxruntime (native + WASM) ──
     rm -rf /app/node_modules/.pnpm/onnxruntime-node@* \


### PR DESCRIPTION
## Summary
- Configure pnpm to keep its store in the repository root at `.pnpm-store`
- Align Docker BuildKit cache mounts with the repo-local store path
- Exclude the repo-local pnpm store from Docker build context uploads

## Why
Marinara Engine has several install and update paths: manual pnpm commands, shell launchers, Windows batch installer, NSIS installer, in-app updater, and Docker builds. They all run pnpm from the project root or copy the root `.npmrc` before installing, so setting the store location in root `.npmrc` makes the behavior consistent instead of patching each path independently.

## Validation
- [x] Ran `pnpm store path` and confirmed it resolves to `D:\AIStuff\Marinara-Engine\.pnpm-store\v10` locally
- [x] Ran `pnpm install --frozen-lockfile --offline` after moving the existing store; completed with `downloaded 0`
- [x] Ran `pnpm check`

Note: validation ran under Node `v22.22.0`, so pnpm printed the repo's expected engine warning for `>=24 <26`, but the commands completed successfully.

## Manual Verification Needed
- [ ] Manually verify a fresh Windows `start.bat` install creates/uses `.pnpm-store` under the install root
- [ ] Manually verify the Windows installer path creates/uses `.pnpm-store` under the install root
- [ ] Manually verify macOS/Linux `start.sh` creates/uses `.pnpm-store` under the clone root
- [ ] Manually verify Termux `start-termux.sh` still applies its `.npmrc` platform additions and uses the root-local store
- [ ] Manually verify Docker and Docker lite builds retain pnpm cache behavior with the updated cache mount path

No linked issue or feature request is attached yet; one should be opened before submission if this needs issue tracking.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker build configuration by consolidating package manager cache settings to improve build efficiency and deployment performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->