### PR TITLE
fix(csp): allow 'unsafe-eval' in script-src so JS extensions run

### DIFF
--- a/packages/server/src/middleware/security-headers.ts
+++ b/packages/server/src/middleware/security-headers.ts
@@ -20,13 +20,19 @@ const PERMISSIONS_POLICY = [
   "xr-spatial-tracking=()",
 ].join(", ");
 
+// 'unsafe-eval' is required by the JS extension system: user-installed
+// extensions are executed via `new Function(...)` in CustomThemeInjector
+// so they can access the marinara extension API. Without it, every JS
+// extension fails with an EvalError. All other directives stay strict —
+// in particular, scripts must still be same-origin ('self'), so this does
+// not permit inline script injection or remote script loading.
 const CONTENT_SECURITY_POLICY = [
   "default-src 'self'",
   "base-uri 'self'",
   "form-action 'self'",
   "frame-ancestors 'none'",
   "object-src 'none'",
-  "script-src 'self'",
+  "script-src 'self' 'unsafe-eval'",
   "style-src 'self' 'unsafe-inline'",
   "img-src 'self' data: blob: https:",
   "media-src 'self' blob:",


### PR DESCRIPTION
The extension system in CustomThemeInjector executes user-installed extension JS via `new Function("marinara", ext.js)` so extensions can receive the marinara API. The page CSP set `script-src 'self'` with no 'unsafe-eval', which the browser enforces against `new Function`/`eval`, so every JS extension failed with EvalError and was effectively unusable.

Grant 'unsafe-eval' on script-src only. All other directives remain strict — scripts must still be same-origin ('self'), so this does not permit inline script injection or remote script loading. The trade-off is documented inline next to the directive.

## Linked issue

Closes #419

## Why this change

- Every JS extension currently fails with `EvalError: ... 'unsafe-eval' is not an allowed source of script: script-src 'self'`. The extension system is effectively broken — anyone who installs a JS extension hits this.
- Root cause is internal to the engine: `CustomThemeInjector.tsx` runs user-installed extension JS via `new Function("marinara", ext.js)` so extensions can receive the marinara API, but the server CSP in `security-headers.ts` sets `script-src 'self'` with no `'unsafe-eval'`. The two contradict each other.

## What changed

- `packages/server/src/middleware/security-headers.ts`: add `'unsafe-eval'` to the `script-src` directive only. All other directives are unchanged — scripts must still be same-origin (`'self'`), so this does not permit inline script injection or remote script loading.
- Inline comment next to the directive explains the trade-off and points at `CustomThemeInjector` as the consumer.

### Why not a stricter fix?

The architecturally cleaner alternative — running extension JS inside a sandboxed iframe with a postMessage RPC bridge — would let the main page CSP keep its strict `script-src 'self'`. But it would break every existing extension's API surface (`addStyle`, `addElement`, `observe`, direct DOM access). That's a major rewrite, not a patch. This PR is the minimum coherent fix to restore extensions; tightening the sandbox is a follow-up.

## Validation

- [x] `pnpm check` passes locally
- [x] Container built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Below manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- [x] Install + enable a JS extension in a browser; confirm no `EvalError` and that `marinara` API methods (`addStyle`, `addElement`, `on`, `observe`, etc.) work.
- [x] Sanity-check that no other CSP-blocked errors appear in the console under normal usage.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

N/A — no UI changes.