### PR TITLE
feat(extensions): load extension JS via same-origin <script src> instead of new Function

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -14,6 +14,7 @@ import { useSidecarStore } from "./stores/sidecar.store";
 import { api } from "./lib/api-client";
 import { forceRefreshSpa } from "./lib/browser-runtime";
 import { useLegacyThemeMigration } from "./hooks/use-themes";
+import { useLegacyExtensionMigration } from "./hooks/use-extensions";
 import { useSettingsSync } from "./hooks/use-settings-sync";
 
 const VERSION_RECOVERY_KEY = "marinara:pwa-version-recovery";
@@ -49,6 +50,7 @@ export function App() {
   const fontFamily = useUIStore((s) => s.fontFamily);
   const hasModalOpen = useUIStore((s) => s.modal !== null);
   useLegacyThemeMigration();
+  useLegacyExtensionMigration();
   useSettingsSync();
   const showDownloadModal = useSidecarStore((s) => s.showDownloadModal);
   const setShowDownloadModal = useSidecarStore((s) => s.setShowDownloadModal);

--- a/packages/client/src/components/layout/CustomThemeInjector.tsx
+++ b/packages/client/src/components/layout/CustomThemeInjector.tsx
@@ -2,14 +2,115 @@
 // CustomThemeInjector: Injects active custom theme
 // CSS and enabled extension CSS/JS into the DOM
 // ──────────────────────────────────────────────
+//
+// Extension JS is loaded via <script src="/api/extensions/:id/script.js"> —
+// a same-origin URL that satisfies `script-src 'self'` without needing
+// 'unsafe-eval' or any 'unsafe-inline' allowance. The server wraps each
+// extension in an IIFE; this component populates `window.__marinaraExt`
+// with the per-extension `marinara` helper API immediately before
+// inserting the <script> tag, and removes the entry on cleanup so a
+// late-loading script just bails silently.
+// ──────────────────────────────────────────────
 import { useEffect } from "react";
-import { useUIStore } from "../../stores/ui.store";
 import { useThemes } from "../../hooks/use-themes";
+import { useExtensions } from "../../hooks/use-extensions";
+import type { InstalledExtension } from "@marinara-engine/shared";
+
+interface MarinaraExtensionAPI {
+  extensionId: string;
+  extensionName: string;
+  addStyle: (css: string) => HTMLStyleElement;
+  addElement: (parent: Element | string, tag: string, attrs?: Record<string, string>) => Element | null;
+  apiFetch: (path: string, options?: RequestInit) => Promise<unknown>;
+  on: (target: EventTarget, event: string, handler: EventListenerOrEventListenerObject) => void;
+  setInterval: (fn: () => void, ms: number) => number;
+  setTimeout: (fn: () => void, ms: number) => number;
+  observe: (target: Element | string, callback: MutationCallback, options?: MutationObserverInit) => MutationObserver | null;
+  onCleanup: (fn: () => void) => void;
+}
+
+declare global {
+  interface Window {
+    __marinaraExt?: Map<string, MarinaraExtensionAPI>;
+  }
+}
+
+function buildExtensionAPI(ext: InstalledExtension, cleanups: Array<() => void>): MarinaraExtensionAPI {
+  const cssIdPrefix = `marinara-ext-js-style-${ext.id}-`;
+
+  return {
+    extensionId: ext.id,
+    extensionName: ext.name,
+
+    addStyle: (css: string) => {
+      const style = document.createElement("style");
+      style.id = `${cssIdPrefix}${Date.now()}`;
+      style.textContent = css;
+      document.head.appendChild(style);
+      cleanups.push(() => style.remove());
+      return style;
+    },
+
+    addElement: (parent, tag, attrs) => {
+      const target = typeof parent === "string" ? document.querySelector(parent) : parent;
+      if (!target) return null;
+      const el = document.createElement(tag);
+      if (attrs) {
+        Object.entries(attrs).forEach(([k, v]) => {
+          if (k === "innerHTML") el.innerHTML = v;
+          else if (k === "textContent") el.textContent = v;
+          else el.setAttribute(k, v);
+        });
+      }
+      target.appendChild(el);
+      cleanups.push(() => el.remove());
+      return el;
+    },
+
+    apiFetch: async (path, options) => {
+      const res = await fetch(`/api${path}`, {
+        headers: { "Content-Type": "application/json" },
+        ...options,
+      });
+      return res.json();
+    },
+
+    on: (target, event, handler) => {
+      target.addEventListener(event, handler);
+      cleanups.push(() => target.removeEventListener(event, handler));
+    },
+
+    setInterval: (fn, ms) => {
+      const id = window.setInterval(fn, ms);
+      cleanups.push(() => window.clearInterval(id));
+      return id;
+    },
+
+    setTimeout: (fn, ms) => {
+      const id = window.setTimeout(fn, ms);
+      cleanups.push(() => window.clearTimeout(id));
+      return id;
+    },
+
+    observe: (target, callback, options) => {
+      const el = typeof target === "string" ? document.querySelector(target) : target;
+      if (!el) return null;
+      const observer = new MutationObserver(callback);
+      observer.observe(el, options || { childList: true, subtree: true });
+      cleanups.push(() => observer.disconnect());
+      return observer;
+    },
+
+    onCleanup: (fn) => {
+      cleanups.push(fn);
+    },
+  };
+}
 
 export function CustomThemeInjector() {
-  const installedExtensions = useUIStore((s) => s.installedExtensions);
   const { data: syncedThemes = [] } = useThemes();
   const activeTheme = syncedThemes.find((theme) => theme.isActive) ?? null;
+  const { data: installedExtensions = [] } = useExtensions();
 
   // Inject active custom theme CSS
   useEffect(() => {
@@ -37,10 +138,8 @@ export function CustomThemeInjector() {
   useEffect(() => {
     const prefix = "marinara-ext-";
 
-    // Remove old extension styles
     document.querySelectorAll(`style[id^="${prefix}"]`).forEach((el) => el.remove());
 
-    // Inject enabled ones
     for (const ext of installedExtensions) {
       if (!ext.enabled || !ext.css) continue;
       const style = document.createElement("style");
@@ -54,113 +153,43 @@ export function CustomThemeInjector() {
     };
   }, [installedExtensions]);
 
-  // Execute enabled extension JS
+  // Load enabled extension JS as same-origin <script src> (CSP-safe).
   useEffect(() => {
     const cleanupFns: Array<() => void> = [];
-    const prefix = "marinara-ext-js-";
+    const tagPrefix = "marinara-ext-js-";
 
-    // Remove old extension scripts
-    document.querySelectorAll(`[id^="${prefix}"]`).forEach((el) => el.remove());
+    document.querySelectorAll(`script[id^="${tagPrefix}"]`).forEach((el) => el.remove());
+
+    const apiMap: Map<string, MarinaraExtensionAPI> = window.__marinaraExt ?? new Map();
+    window.__marinaraExt = apiMap;
 
     for (const ext of installedExtensions) {
       if (!ext.enabled || !ext.js) continue;
 
-      try {
-        const extensionCleanups: Array<() => void> = [];
+      const extensionCleanups: Array<() => void> = [];
+      const extensionAPI = buildExtensionAPI(ext, extensionCleanups);
+      apiMap.set(ext.id, extensionAPI);
 
-        // Extension API passed to JS extensions
-        const extensionAPI = {
-          extensionId: ext.id,
-          extensionName: ext.name,
+      const script = document.createElement("script");
+      script.id = `${tagPrefix}${ext.id}`;
+      script.async = false;
+      // Cache-bust on every update so toggling enabled / editing JS takes
+      // effect immediately. The server already sends Cache-Control: no-store,
+      // but the query param defends against any intermediary caching too.
+      script.src = `/api/extensions/${encodeURIComponent(ext.id)}/script.js?v=${encodeURIComponent(ext.updatedAt)}`;
+      document.head.appendChild(script);
 
-          // Inject CSS with auto-cleanup
-          addStyle: (css: string) => {
-            const style = document.createElement("style");
-            style.id = `${prefix}style-${ext.id}-${Date.now()}`;
-            style.textContent = css;
-            document.head.appendChild(style);
-            extensionCleanups.push(() => style.remove());
-            return style;
-          },
-
-          // Inject DOM element with auto-cleanup
-          addElement: (parent: Element | string, tag: string, attrs?: Record<string, string>) => {
-            const target = typeof parent === "string" ? document.querySelector(parent) : parent;
-            if (!target) return null;
-            const el = document.createElement(tag);
-            if (attrs) {
-              Object.entries(attrs).forEach(([k, v]) => {
-                if (k === "innerHTML") el.innerHTML = v;
-                else if (k === "textContent") el.textContent = v;
-                else el.setAttribute(k, v);
-              });
-            }
-            target.appendChild(el);
-            extensionCleanups.push(() => el.remove());
-            return el;
-          },
-
-          // Fetch from Marinara API
-          apiFetch: async (path: string, options?: RequestInit) => {
-            const res = await fetch(`/api${path}`, {
-              headers: { "Content-Type": "application/json" },
-              ...options,
-            });
-            return res.json();
-          },
-
-          // addEventListener with auto-cleanup
-          on: (target: EventTarget, event: string, handler: EventListenerOrEventListenerObject) => {
-            target.addEventListener(event, handler);
-            extensionCleanups.push(() => target.removeEventListener(event, handler));
-          },
-
-          // setInterval with auto-cleanup
-          setInterval: (fn: () => void, ms: number) => {
-            const id = window.setInterval(fn, ms);
-            extensionCleanups.push(() => window.clearInterval(id));
-            return id;
-          },
-
-          // setTimeout with auto-cleanup
-          setTimeout: (fn: () => void, ms: number) => {
-            const id = window.setTimeout(fn, ms);
-            extensionCleanups.push(() => window.clearTimeout(id));
-            return id;
-          },
-
-          // MutationObserver with auto-cleanup
-          observe: (target: Element | string, callback: MutationCallback, options?: MutationObserverInit) => {
-            const el = typeof target === "string" ? document.querySelector(target) : target;
-            if (!el) return null;
-            const observer = new MutationObserver(callback);
-            observer.observe(el, options || { childList: true, subtree: true });
-            extensionCleanups.push(() => observer.disconnect());
-            return observer;
-          },
-
-          // Register a cleanup function manually
-          onCleanup: (fn: () => void) => {
-            extensionCleanups.push(fn);
-          },
-        };
-
-        // Execute the JS with the marinara API available
-        const fn = new Function("marinara", ext.js);
-        fn(extensionAPI);
-
-        cleanupFns.push(() => {
-          extensionCleanups.forEach((cleanup) => {
-            try {
-              cleanup();
-            } catch (e) {
-              console.warn(`[Extension:${ext.name}] Cleanup error:`, e);
-            }
-          });
+      cleanupFns.push(() => {
+        apiMap.delete(ext.id);
+        script.remove();
+        extensionCleanups.forEach((fn) => {
+          try {
+            fn();
+          } catch (e) {
+            console.warn(`[Extension:${ext.name}] Cleanup error:`, e);
+          }
         });
-      } catch (e) {
-        console.error(`[Extension:${ext.name}] Failed to execute:`, e);
-      }
+      });
     }
 
     return () => {

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -5,11 +5,16 @@ import {
   APP_LANGUAGE_OPTIONS,
   useUIStore,
   type GameDialogueDisplayMode,
-  type InstalledExtension,
   type RoleplayAvatarStyle,
   type VisualTheme,
 } from "../../stores/ui.store";
-import { cn, generateClientId } from "../../lib/utils";
+import { cn } from "../../lib/utils";
+import {
+  useExtensions,
+  useCreateExtension,
+  useDeleteExtension,
+  useUpdateExtension,
+} from "../../hooks/use-extensions";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { ADMIN_SECRET_STORAGE_KEY, api, getAdminSecretHeader } from "../../lib/api-client";
 import { forceRefreshSpa } from "@/lib/browser-runtime";
@@ -2046,10 +2051,10 @@ const CSS_TEMPLATE = `/* ══════════════════�
 `;
 
 function ExtensionsSettings() {
-  const extensions = useUIStore((s) => s.installedExtensions);
-  const addExtension = useUIStore((s) => s.addExtension);
-  const removeExtension = useUIStore((s) => s.removeExtension);
-  const toggleExtension = useUIStore((s) => s.toggleExtension);
+  const { data: extensions = [] } = useExtensions();
+  const createExtension = useCreateExtension();
+  const updateExtension = useUpdateExtension();
+  const deleteExtension = useDeleteExtension();
   const fileRef = useRef<HTMLInputElement>(null);
 
   const handleImportExtension = async (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -2057,41 +2062,39 @@ function ExtensionsSettings() {
     if (!file) return;
     try {
       const text = await file.text();
+      const installedAt = new Date().toISOString();
 
       if (file.name.endsWith(".json")) {
         const parsed = JSON.parse(text);
-        const ext: InstalledExtension = {
-          id: generateClientId(),
-          name: parsed.name ?? file.name.replace(/\.json$/, ""),
+        const name = parsed.name ?? file.name.replace(/\.json$/, "");
+        await createExtension.mutateAsync({
+          name,
           description: parsed.description ?? "",
-          css: parsed.css ?? undefined,
-          js: parsed.js ?? undefined,
+          css: parsed.css ?? null,
+          js: parsed.js ?? null,
           enabled: true,
-          installedAt: new Date().toISOString(),
-        };
-        addExtension(ext);
-        toast.success(`Extension "${ext.name}" installed`);
+          installedAt,
+        });
+        toast.success(`Extension "${name}" installed`);
       } else if (file.name.endsWith(".js")) {
-        const ext: InstalledExtension = {
-          id: generateClientId(),
-          name: file.name.replace(/\.js$/, ""),
+        const name = file.name.replace(/\.js$/, "");
+        await createExtension.mutateAsync({
+          name,
           description: "JS extension imported from file",
           js: text,
           enabled: true,
-          installedAt: new Date().toISOString(),
-        };
-        addExtension(ext);
-        toast.success(`Extension "${ext.name}" installed`);
+          installedAt,
+        });
+        toast.success(`Extension "${name}" installed`);
       } else if (file.name.endsWith(".css")) {
-        const ext: InstalledExtension = {
-          id: generateClientId(),
-          name: file.name.replace(/\.css$/, ""),
+        const name = file.name.replace(/\.css$/, "");
+        await createExtension.mutateAsync({
+          name,
           description: "CSS extension imported from file",
           css: text,
           enabled: true,
-          installedAt: new Date().toISOString(),
-        };
-        addExtension(ext);
+          installedAt,
+        });
       } else {
         toast.error("Only .json and .css extension files are supported.");
       }
@@ -2132,7 +2135,7 @@ function ExtensionsSettings() {
             )}
           >
             <button
-              onClick={() => toggleExtension(ext.id)}
+              onClick={() => updateExtension.mutate({ id: ext.id, enabled: !ext.enabled })}
               className={cn(
                 "rounded p-0.5 transition-colors",
                 ext.enabled
@@ -2150,7 +2153,7 @@ function ExtensionsSettings() {
               )}
             </div>
             <button
-              onClick={() => removeExtension(ext.id)}
+              onClick={() => deleteExtension.mutate(ext.id)}
               className="rounded p-0.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--destructive)]/10 hover:text-[var(--destructive)]"
               title="Remove extension"
             >

--- a/packages/client/src/hooks/use-extensions.ts
+++ b/packages/client/src/hooks/use-extensions.ts
@@ -1,0 +1,120 @@
+// ──────────────────────────────────────────────
+// Hooks: Installed Extensions (server-synced)
+// ──────────────────────────────────────────────
+import { useEffect, useRef } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { api } from "../lib/api-client";
+import { useUIStore } from "../stores/ui.store";
+import type { CreateExtensionInput, InstalledExtension, UpdateExtensionInput } from "@marinara-engine/shared";
+
+export const extensionKeys = {
+  all: ["extensions"] as const,
+  list: () => [...extensionKeys.all, "list"] as const,
+};
+
+function findDuplicateExtension(extensions: InstalledExtension[], name: string, css: string | null, js: string | null) {
+  return (
+    extensions.find(
+      (ext) => ext.name === name && (ext.css ?? null) === (css ?? null) && (ext.js ?? null) === (js ?? null),
+    ) ?? null
+  );
+}
+
+export function useExtensions() {
+  return useQuery({
+    queryKey: extensionKeys.list(),
+    queryFn: () => api.get<InstalledExtension[]>("/extensions"),
+    staleTime: 0,
+  });
+}
+
+export function useCreateExtension() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: CreateExtensionInput) => api.post<InstalledExtension>("/extensions", data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: extensionKeys.all });
+    },
+  });
+}
+
+export function useUpdateExtension() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, ...data }: { id: string } & UpdateExtensionInput) =>
+      api.patch<InstalledExtension>(`/extensions/${id}`, data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: extensionKeys.all });
+    },
+  });
+}
+
+export function useDeleteExtension() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => api.delete(`/extensions/${id}`),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: extensionKeys.all });
+    },
+  });
+}
+
+/**
+ * One-shot migration of pre-server-storage extensions out of localStorage.
+ *
+ * Mirrors `useLegacyThemeMigration`: on first successful list fetch we POST
+ * any local-only extensions that don't already exist on the server, then
+ * clear the legacy array and flip the migration flag so we don't run again.
+ */
+export function useLegacyExtensionMigration() {
+  const legacyExtensions = useUIStore((s) => s.installedExtensions);
+  const hasMigrated = useUIStore((s) => s.hasMigratedExtensionsToServer);
+  const clearLegacy = useUIStore((s) => s.clearLegacyExtensions);
+  const setMigrated = useUIStore((s) => s.setHasMigratedExtensionsToServer);
+  const qc = useQueryClient();
+  const inFlightRef = useRef(false);
+  const { isSuccess } = useExtensions();
+
+  useEffect(() => {
+    if (hasMigrated || !isSuccess || inFlightRef.current) {
+      return;
+    }
+    if (legacyExtensions.length === 0) {
+      setMigrated(true);
+      return;
+    }
+
+    inFlightRef.current = true;
+    void (async () => {
+      try {
+        const serverExtensions = await api.get<InstalledExtension[]>("/extensions");
+        let working = [...serverExtensions];
+
+        for (const legacy of legacyExtensions) {
+          const css = legacy.css ?? null;
+          const js = legacy.js ?? null;
+          const duplicate = findDuplicateExtension(working, legacy.name, css, js);
+          if (duplicate) continue;
+
+          const created = await api.post<InstalledExtension>("/extensions", {
+            name: legacy.name,
+            description: legacy.description ?? "",
+            css,
+            js,
+            enabled: legacy.enabled,
+            installedAt: legacy.installedAt,
+          });
+          working = [created, ...working];
+        }
+
+        clearLegacy();
+        setMigrated(true);
+        await qc.invalidateQueries({ queryKey: extensionKeys.all });
+      } catch {
+        // Leave migration flag untouched so the next app start can retry.
+      } finally {
+        inFlightRef.current = false;
+      }
+    })();
+  }, [clearLegacy, hasMigrated, isSuccess, legacyExtensions, qc, setMigrated]);
+}

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -84,16 +84,20 @@ export interface CustomTheme {
   installedAt: string;
 }
 
-/** A user-installed extension (JS/CSS) */
-export interface InstalledExtension {
+/**
+ * Pre-migration shape of a browser-local extension. Only used to read
+ * existing localStorage state and replay it against the server
+ * (`/api/extensions`) on first load — see `useLegacyExtensionMigration`.
+ * New extensions go directly through the server-synced hooks in
+ * `use-extensions.ts` and use the canonical `InstalledExtension` type
+ * exported from `@marinara-engine/shared`.
+ */
+export interface LegacyInstalledExtension {
   id: string;
   name: string;
   description: string;
-  /** CSS to inject */
   css?: string;
-  /** JavaScript to execute */
   js?: string;
-  /** Whether the extension is enabled */
   enabled: boolean;
   installedAt: string;
 }
@@ -241,7 +245,10 @@ interface UIState {
   customThemes: CustomTheme[];
   /** True once legacy browser-local themes have been migrated to the server. */
   hasMigratedCustomThemesToServer: boolean;
-  installedExtensions: InstalledExtension[];
+  /** Legacy browser-local extensions. Migration only — see useLegacyExtensionMigration. */
+  installedExtensions: LegacyInstalledExtension[];
+  /** True once legacy browser-local extensions have been migrated to the server. */
+  hasMigratedExtensionsToServer: boolean;
 
   // ── Onboarding ──
   hasCompletedOnboarding: boolean;
@@ -364,9 +371,9 @@ interface UIState {
   addCustomTheme: (theme: CustomTheme) => void;
   updateCustomTheme: (id: string, patch: Partial<Pick<CustomTheme, "name" | "css">>) => void;
   removeCustomTheme: (id: string) => void;
-  addExtension: (ext: InstalledExtension) => void;
-  removeExtension: (id: string) => void;
-  toggleExtension: (id: string) => void;
+  /** Legacy migration helpers for browser-local extensions. */
+  setHasMigratedExtensionsToServer: (v: boolean) => void;
+  clearLegacyExtensions: () => void;
   setHasCompletedOnboarding: (v: boolean) => void;
   setGameTutorialDisabled: (v: boolean) => void;
   dismissLinkApiBanner: () => void;
@@ -532,6 +539,7 @@ export const useUIStore = create<UIState>()(
       customThemes: [],
       hasMigratedCustomThemesToServer: false,
       installedExtensions: [],
+      hasMigratedExtensionsToServer: false,
       hasCompletedOnboarding: false,
       gameTutorialDisabled: false,
       linkApiBannerDismissed: false,
@@ -825,15 +833,8 @@ export const useUIStore = create<UIState>()(
           customThemes: s.customThemes.filter((t) => t.id !== id),
           activeCustomTheme: s.activeCustomTheme === id ? null : s.activeCustomTheme,
         })),
-      addExtension: (ext) => set((s) => ({ installedExtensions: [...s.installedExtensions, ext] })),
-      removeExtension: (id) =>
-        set((s) => ({
-          installedExtensions: s.installedExtensions.filter((e) => e.id !== id),
-        })),
-      toggleExtension: (id) =>
-        set((s) => ({
-          installedExtensions: s.installedExtensions.map((e) => (e.id === id ? { ...e, enabled: !e.enabled } : e)),
-        })),
+      setHasMigratedExtensionsToServer: (v) => set({ hasMigratedExtensionsToServer: v }),
+      clearLegacyExtensions: () => set({ installedExtensions: [] }),
       setHasCompletedOnboarding: (v) => set({ hasCompletedOnboarding: v }),
       setGameTutorialDisabled: (v) => set({ gameTutorialDisabled: v }),
       dismissLinkApiBanner: () => set({ linkApiBannerDismissed: true }),
@@ -845,7 +846,7 @@ export const useUIStore = create<UIState>()(
     }),
     {
       name: "marinara-engine-ui",
-      version: 16,
+      version: 17,
       // Debounce localStorage writes to avoid sync I/O on every state change
       storage: createJSONStorage(() => {
         let timer: ReturnType<typeof setTimeout> | null = null;
@@ -1000,6 +1001,12 @@ export const useUIStore = create<UIState>()(
             persisted.trimIncompleteModelOutput = false;
           }
         }
+        // v16 -> v17: add legacy extension migration completion flag.
+        if (version <= 16) {
+          if (persisted.hasMigratedExtensionsToServer === undefined) {
+            persisted.hasMigratedExtensionsToServer = false;
+          }
+        }
         return persisted;
       },
       partialize: (state) => ({
@@ -1058,6 +1065,7 @@ export const useUIStore = create<UIState>()(
         activeCustomTheme: state.activeCustomTheme,
         customThemes: state.customThemes,
         installedExtensions: state.installedExtensions,
+        hasMigratedExtensionsToServer: state.hasMigratedExtensionsToServer,
         hasCompletedOnboarding: state.hasCompletedOnboarding,
         linkApiBannerDismissed: state.linkApiBannerDismissed,
         echoChamberSide: state.echoChamberSide,

--- a/packages/server/drizzle.config.cts
+++ b/packages/server/drizzle.config.cts
@@ -70,6 +70,7 @@ export default defineConfig({
     "./src/db/schema/regex-scripts.ts",
     "./src/db/schema/gallery.ts",
     "./src/db/schema/themes.ts",
+    "./src/db/schema/extensions.ts",
     "./src/db/schema/app-settings.ts",
   ],
   out: "./src/db/migrations",

--- a/packages/server/src/db/file-backed-store.ts
+++ b/packages/server/src/db/file-backed-store.ts
@@ -181,6 +181,7 @@ export const FILE_BACKED_TABLES = [
   "app_settings",
   "chat_presets",
   "prompt_overrides",
+  "installed_extensions",
 ] as const;
 
 type FileBackedTable = (typeof FILE_BACKED_TABLES)[number];

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -412,6 +412,17 @@ const CREATE_TABLES: string[] = [
     value TEXT NOT NULL DEFAULT '',
     updated_at TEXT NOT NULL
   )`,
+  `CREATE TABLE IF NOT EXISTS installed_extensions (
+    id TEXT PRIMARY KEY NOT NULL,
+    name TEXT NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    css TEXT,
+    js TEXT,
+    enabled TEXT NOT NULL DEFAULT 'true',
+    installed_at TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+  )`,
   `CREATE TABLE IF NOT EXISTS chat_presets (
     id TEXT PRIMARY KEY NOT NULL,
     name TEXT NOT NULL,

--- a/packages/server/src/db/schema/extensions.ts
+++ b/packages/server/src/db/schema/extensions.ts
@@ -1,0 +1,16 @@
+// ──────────────────────────────────────────────
+// Schema: Installed Extensions
+// ──────────────────────────────────────────────
+import { sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+export const installedExtensions = sqliteTable("installed_extensions", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+  description: text("description").notNull().default(""),
+  css: text("css"),
+  js: text("js"),
+  enabled: text("enabled").notNull().default("true"),
+  installedAt: text("installed_at").notNull(),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull(),
+});

--- a/packages/server/src/db/schema/index.ts
+++ b/packages/server/src/db/schema/index.ts
@@ -15,5 +15,6 @@ export * from "./checkpoints.js";
 export * from "./regex-scripts.js";
 export * from "./gallery.js";
 export * from "./themes.js";
+export * from "./extensions.js";
 export * from "./app-settings.js";
 export * from "./prompt-overrides.js";

--- a/packages/server/src/routes/extensions.routes.ts
+++ b/packages/server/src/routes/extensions.routes.ts
@@ -1,0 +1,94 @@
+// ──────────────────────────────────────────────
+// Routes: Installed Extensions
+// ──────────────────────────────────────────────
+//
+// Extensions are stored server-side so they can be served back at
+// /api/extensions/:id/script.js — a same-origin URL that satisfies the
+// strict `script-src 'self'` CSP without needing 'unsafe-eval'. The script
+// payload is wrapped server-side in an IIFE that pulls the per-extension
+// `marinara` API helper out of a window-scoped registry the client
+// populated immediately before injecting the <script> tag.
+// ──────────────────────────────────────────────
+import type { FastifyInstance } from "fastify";
+import { createExtensionSchema, updateExtensionSchema } from "@marinara-engine/shared";
+import { createExtensionsStorage } from "../services/storage/extensions.storage.js";
+
+const ID_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
+
+function escapeJsString(value: string): string {
+  // Safe to drop into a JSON.parse-able literal in the wrapper.
+  return JSON.stringify(value);
+}
+
+export async function extensionsRoutes(app: FastifyInstance) {
+  const storage = createExtensionsStorage(app.db);
+
+  app.get("/", async () => {
+    return storage.list();
+  });
+
+  app.post("/", async (req) => {
+    const input = createExtensionSchema.parse(req.body);
+    return storage.create(input);
+  });
+
+  app.patch<{ Params: { id: string } }>("/:id", async (req, reply) => {
+    if (!ID_PATTERN.test(req.params.id)) {
+      return reply.status(404).send({ error: "Extension not found" });
+    }
+    const data = updateExtensionSchema.parse(req.body);
+    const existing = await storage.getById(req.params.id);
+    if (!existing) return reply.status(404).send({ error: "Extension not found" });
+    return storage.update(req.params.id, data);
+  });
+
+  app.delete<{ Params: { id: string } }>("/:id", async (req, reply) => {
+    if (!ID_PATTERN.test(req.params.id)) {
+      return reply.status(404).send({ error: "Extension not found" });
+    }
+    const existing = await storage.getById(req.params.id);
+    if (!existing) return reply.status(404).send({ error: "Extension not found" });
+    await storage.remove(req.params.id);
+    return reply.status(204).send();
+  });
+
+  // Serve an enabled extension's JS as same-origin executable script.
+  // Disabled or missing extensions return 404 so cached <script> tags become
+  // inert as soon as the user disables/uninstalls.
+  app.get<{ Params: { id: string } }>("/:id/script.js", async (req, reply) => {
+    if (!ID_PATTERN.test(req.params.id)) {
+      return reply.status(404).send("// Extension not found\n");
+    }
+    const ext = await storage.getById(req.params.id);
+    if (!ext || !ext.enabled || !ext.js) {
+      reply.header("Content-Type", "application/javascript; charset=utf-8");
+      reply.header("Cache-Control", "no-store");
+      return reply.status(404).send("// Extension not found or disabled\n");
+    }
+
+    const idLiteral = escapeJsString(ext.id);
+    const nameLiteral = escapeJsString(ext.name);
+
+    // Wrap the user's JS in an IIFE that:
+    //   1. Pulls the per-extension API helper out of window.__marinaraExt.
+    //   2. Bails silently if the loader cleaned up (e.g. extension was
+    //      disabled while the <script> was still in flight).
+    //   3. Catches and logs runtime errors so one extension can't break
+    //      others on the page.
+    // The user's JS is appended verbatim — it never goes through eval/Function.
+    const wrapped =
+      `(function(){\n` +
+      `  var __id=${idLiteral};\n` +
+      `  var __name=${nameLiteral};\n` +
+      `  var marinara=(typeof window!=="undefined"&&window.__marinaraExt&&window.__marinaraExt.get)?window.__marinaraExt.get(__id):null;\n` +
+      `  if(!marinara){console.warn("[Extension:"+__name+"] no API bound; loader may have cleaned up before script loaded");return;}\n` +
+      `  try{\n` +
+      ext.js +
+      `\n  }catch(e){console.error("[Extension:"+__name+"] error",e);}\n` +
+      `})();\n`;
+
+    reply.header("Content-Type", "application/javascript; charset=utf-8");
+    reply.header("Cache-Control", "no-store");
+    return reply.send(wrapped);
+  });
+}

--- a/packages/server/src/routes/index.ts
+++ b/packages/server/src/routes/index.ts
@@ -41,6 +41,7 @@ import { chatFoldersRoutes } from "./chat-folders.routes.js";
 import { chatPresetsRoutes } from "./chat-presets.routes.js";
 import { updatesRoutes } from "./updates.routes.js";
 import { themesRoutes } from "./themes.routes.js";
+import { extensionsRoutes } from "./extensions.routes.js";
 import { appSettingsRoutes } from "./app-settings.routes.js";
 import { gameRoutes } from "./game.routes.js";
 import { gameAssetsRoutes } from "./game-assets.routes.js";
@@ -88,6 +89,7 @@ export async function registerRoutes(app: FastifyInstance) {
   await app.register(botBrowserDatacatRoutes, { prefix: "/api/bot-browser" });
   await app.register(updatesRoutes, { prefix: "/api/updates" });
   await app.register(themesRoutes, { prefix: "/api/themes" });
+  await app.register(extensionsRoutes, { prefix: "/api/extensions" });
   await app.register(appSettingsRoutes, { prefix: "/api/app-settings" });
   await app.register(gameRoutes, { prefix: "/api/game" });
   await app.register(gameAssetsRoutes, { prefix: "/api/game-assets" });

--- a/packages/server/src/services/storage/extensions.storage.ts
+++ b/packages/server/src/services/storage/extensions.storage.ts
@@ -1,0 +1,73 @@
+// ──────────────────────────────────────────────
+// Storage: Installed Extensions
+// ──────────────────────────────────────────────
+import { desc, eq } from "drizzle-orm";
+import type { DB } from "../../db/connection.js";
+import { installedExtensions } from "../../db/schema/index.js";
+import { newId, now } from "../../utils/id-generator.js";
+import type { CreateExtensionInput, InstalledExtension, UpdateExtensionInput } from "@marinara-engine/shared";
+
+type ExtensionRow = typeof installedExtensions.$inferSelect;
+
+function mapExtension(row: ExtensionRow): InstalledExtension {
+  return {
+    id: row.id,
+    name: row.name,
+    description: row.description,
+    css: row.css ?? null,
+    js: row.js ?? null,
+    enabled: row.enabled === "true",
+    installedAt: row.installedAt,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+export function createExtensionsStorage(db: DB) {
+  return {
+    async list() {
+      const rows = await db.select().from(installedExtensions).orderBy(desc(installedExtensions.installedAt));
+      return rows.map(mapExtension);
+    },
+
+    async getById(id: string) {
+      const rows = await db.select().from(installedExtensions).where(eq(installedExtensions.id, id));
+      const row = rows[0];
+      return row ? mapExtension(row) : null;
+    },
+
+    async create(input: CreateExtensionInput) {
+      const id = newId();
+      const timestamp = now();
+      await db.insert(installedExtensions).values({
+        id,
+        name: input.name,
+        description: input.description ?? "",
+        css: input.css ?? null,
+        js: input.js ?? null,
+        enabled: input.enabled === false ? "false" : "true",
+        installedAt: input.installedAt ?? timestamp,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      });
+      return this.getById(id);
+    },
+
+    async update(id: string, data: UpdateExtensionInput) {
+      const updateFields: Partial<typeof installedExtensions.$inferInsert> = {
+        updatedAt: now(),
+      };
+      if (data.name !== undefined) updateFields.name = data.name;
+      if (data.description !== undefined) updateFields.description = data.description;
+      if (data.css !== undefined) updateFields.css = data.css;
+      if (data.js !== undefined) updateFields.js = data.js;
+      if (data.enabled !== undefined) updateFields.enabled = data.enabled ? "true" : "false";
+      await db.update(installedExtensions).set(updateFields).where(eq(installedExtensions.id, id));
+      return this.getById(id);
+    },
+
+    async remove(id: string) {
+      await db.delete(installedExtensions).where(eq(installedExtensions.id, id));
+    },
+  };
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -19,6 +19,7 @@ export * from "./types/regex.js";
 export * from "./types/export.js";
 export * from "./types/haptic.js";
 export * from "./types/theme.js";
+export * from "./types/extension.js";
 export * from "./types/chat-preset.js";
 export * from "./types/game.js";
 export * from "./types/sidecar.js";
@@ -35,6 +36,7 @@ export * from "./schemas/agent.schema.js";
 export * from "./schemas/custom-tool.schema.js";
 export * from "./schemas/regex.schema.js";
 export * from "./schemas/theme.schema.js";
+export * from "./schemas/extension.schema.js";
 export * from "./schemas/app-settings.schema.js";
 
 // Constants

--- a/packages/shared/src/schemas/extension.schema.ts
+++ b/packages/shared/src/schemas/extension.schema.ts
@@ -1,0 +1,28 @@
+// ──────────────────────────────────────────────
+// Extension Zod Schemas
+// ──────────────────────────────────────────────
+import { z } from "zod";
+
+export const createExtensionSchema = z.object({
+  name: z.string().min(1).max(200),
+  description: z.string().max(2000).default(""),
+  css: z.string().nullable().optional(),
+  js: z.string().nullable().optional(),
+  enabled: z.boolean().optional(),
+  installedAt: z.string().datetime().optional(),
+});
+
+export const updateExtensionSchema = z
+  .object({
+    name: z.string().min(1).max(200).optional(),
+    description: z.string().max(2000).optional(),
+    css: z.string().nullable().optional(),
+    js: z.string().nullable().optional(),
+    enabled: z.boolean().optional(),
+  })
+  .refine((value) => Object.keys(value).length > 0, {
+    message: "Must update at least one field",
+  });
+
+export type CreateExtensionInput = z.infer<typeof createExtensionSchema>;
+export type UpdateExtensionInput = z.infer<typeof updateExtensionSchema>;

--- a/packages/shared/src/types/extension.ts
+++ b/packages/shared/src/types/extension.ts
@@ -1,0 +1,26 @@
+// ──────────────────────────────────────────────
+// Extension Types
+// ──────────────────────────────────────────────
+
+/**
+ * A user-installed extension stored on the Marinara server.
+ *
+ * Extension JS is executed in the page via a same-origin <script src> tag
+ * pointing at /api/extensions/:id/script.js so the strict CSP (`script-src 'self'`)
+ * can stay in place — there is no `new Function(...)` or `eval` involved.
+ */
+export interface InstalledExtension {
+  id: string;
+  name: string;
+  description: string;
+  /** Optional CSS injected as a <style> tag while enabled. */
+  css?: string | null;
+  /** Optional JavaScript served at /api/extensions/:id/script.js while enabled. */
+  js?: string | null;
+  /** Whether the extension is currently active. */
+  enabled: boolean;
+  /** When the user originally imported it. */
+  installedAt: string;
+  createdAt: string;
+  updatedAt: string;
+}


### PR DESCRIPTION
## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #419 

## Why this change

Marinara's extension loader currently executes user JS via `new Function("marinara", ext.js)`, which requires `'unsafe-eval'` in `script-src`. The shipped CSP at [`security-headers.ts`](packages/server/src/middleware/security-headers.ts) is `script-src 'self'` — no eval — so on a stock build no JS extension runs. Currently, published Marinara JS extension currently require users to manually add `'unsafe-eval'` to `security-headers.ts` to make extensions work, which defeats the strict policy the project chose to ship.

This PR makes JS extensions work under the existing strict CSP without any policy relaxation. The loader stops using `new Function` and instead loads each enabled extension's JS via a same-origin `<script src>` tag pointing at a new endpoint, `GET /api/extensions/:id/script.js`. `<script src>` from the same origin is allowed by `script-src 'self'` and needs no `'unsafe-eval'`.

## Approach

Mirrors the existing browser-local → server-storage migration that shipped for `customThemes`. Same hook shape, same migration mechanics, same storage/route layout — just for `installed_extensions` instead.

## What changed

**Loader ([`CustomThemeInjector.tsx`](packages/client/src/components/layout/CustomThemeInjector.tsx)):**
- Builds the per-extension `marinara` helper API. Surface is unchanged from today: `addStyle`, `addElement`, `apiFetch`, `on`, `setInterval`, `setTimeout`, `observe`, `onCleanup`, `extensionId`, `extensionName`. Existing extensions need no source changes.
- Registers the API on a `Map` at `window.__marinaraExt` keyed by extension id, immediately before injecting `<script src="/api/extensions/<id>/script.js?v=<updatedAt>">`.
- On cleanup (extension toggled, uninstalled, or list refetched), removes the script tag and the registry entry, then runs the auto-cleanups the API helper tracked (event listeners, intervals, observers, etc.).
- If a script is mid-flight when cleanup runs, the IIFE finds `null` in the registry and returns silently — no orphaned execution.

**Endpoint ([`extensions.routes.ts`](packages/server/src/routes/extensions.routes.ts)):**
- Returns the user's stored JS verbatim, wrapped server-side in a static IIFE that pulls the `marinara` API back out of the window registry and bails if cleanup ran first. The user's JS is appended to the wrapper as a substring; nothing in the wrapper interprets it. No `eval`, `Function`, or `node:vm` usage.
- `Content-Type: application/javascript; charset=utf-8`, `Cache-Control: no-store`. `X-Content-Type-Options: nosniff` is already set globally.
- Strict id validation (`^[A-Za-z0-9_-]{1,64}$`). 404 if disabled, missing, or has no JS. Toggle/uninstall propagates to subsequent loads immediately because nothing is cacheable.
- The `?v=<updatedAt>` cache-buster on the loader side defends against any intermediary caching as a belt-and-braces.

**Storage:**
- New `installed_extensions` table created via the existing idempotent startup migration in [`migrate.ts`](packages/server/src/db/migrate.ts).
- Registered with the file-native store at [`file-backed-store.ts`](packages/server/src/db/file-backed-store.ts) so the runtime JSON-snapshot persistence layer recognizes it (this was the missing piece that needed a follow-up commit during testing).
- Drizzle schema, Zod schemas, shared types — all follow the `customThemes` template.

**Migration:**
- `useLegacyExtensionMigration` reads pre-existing `installedExtensions` out of localStorage on first load, POSTs each one that isn't already on the server, then clears the legacy array and flips a one-shot flag (mirrors `useLegacyThemeMigration`).
- Persist version bumped to v17 with the new flag.

## Compatibility for extension authors

The `marinara` helper API surface is unchanged. Existing `.json` / `.js` / `.css` extension imports work without modification. Tested end-to-end with [kolache's AIO extension](https://github.com/kolacheee/Marinara-kolaches-aio-extension) — installs, runs, edits, saves, and uninstalls cleanly under stock CSP with no `'unsafe-eval'` patch.

## Files

**New:**
- `packages/shared/src/types/extension.ts`
- `packages/shared/src/schemas/extension.schema.ts`
- `packages/server/src/db/schema/extensions.ts`
- `packages/server/src/services/storage/extensions.storage.ts`
- `packages/server/src/routes/extensions.routes.ts`
- `packages/client/src/hooks/use-extensions.ts`

**Modified:**
- `packages/shared/src/index.ts` — export new type/schema
- `packages/server/drizzle.config.cts` — register new schema file
- `packages/server/src/db/migrate.ts` — add `CREATE TABLE installed_extensions`
- `packages/server/src/db/schema/index.ts` — re-export new schema
- `packages/server/src/db/file-backed-store.ts` — add `installed_extensions` to `FILE_BACKED_TABLES`
- `packages/server/src/routes/index.ts` — register `/api/extensions`
- `packages/client/src/App.tsx` — call legacy migration hook
- `packages/client/src/components/layout/CustomThemeInjector.tsx` — switch loader from `new Function` to `<script src>`
- `packages/client/src/components/panels/SettingsPanel.tsx` — switch import/list/toggle/delete to server hooks
- `packages/client/src/stores/ui.store.ts` — add migration flag, persist v17

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

## Manual verification still needed

- [x] Install a JS extension on a stock build (no `'unsafe-eval'` patch in `security-headers.ts`) and confirm it loads and runs
- [ ] Existing localStorage extensions migrate server-side on first load after upgrade — install on old build → upgrade → confirm extensions appear in `/api/extensions` and the legacy localStorage array is cleared
- [x] Toggling enabled / uninstalling stops execution immediately on next page mount
- [ ] CSS-only extensions still inject as `<style>` (they don't go through the script endpoint at all)
- [ ] Multiple enabled extensions get independent `marinara` API instances and independent cleanups — uninstalling one doesn't break the others
- [ ] Disabling an extension while its `<script>` is mid-load doesn't throw — the IIFE bail path should log a warn and return
- [x] Extension imports from `.json`, `.js`, `.css` files all flow through the new server-backed install correctly

Unchecked ones I am unsure how/unable to test and verify.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)
