### PR TITLE
fix: persist Narrative Director runs so run interval gating works

### DIFF
--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -3533,10 +3533,15 @@ export async function generateRoutes(app: FastifyInstance) {
       // ── Interval gating: Narrative Director only intervenes every N assistant messages ──
       const directorAgent = resolvedAgents.find((a) => a.type === "director");
       if (directorAgent) {
-        const runInterval =
-          (directorAgent.settings.runInterval as number) ??
-          (getDefaultBuiltInAgentSettings("director").runInterval as number) ??
-          5;
+        const rawInterval = (directorAgent.settings as { runInterval?: unknown }).runInterval;
+        const parsed =
+          typeof rawInterval === "number"
+            ? rawInterval
+            : typeof rawInterval === "string"
+              ? Number(rawInterval)
+              : NaN;
+        const fallback = (getDefaultBuiltInAgentSettings("director").runInterval as number) ?? 5;
+        const runInterval = Number.isFinite(parsed) && parsed >= 1 ? Math.min(100, Math.floor(parsed)) : fallback;
         if (runInterval > 1) {
           const lastRun = await agentsStore.getLastSuccessfulRunByType("director", input.chatId);
           if (lastRun) {
@@ -6099,6 +6104,31 @@ export async function generateRoutes(app: FastifyInstance) {
           parallelResults = await parallelPromise;
         } catch {
           // Non-critical — parallel agents may fail independently
+        }
+      }
+
+      // Persist successful Narrative Director runs.
+      // Interval gating uses getLastSuccessfulRunByType("director", …); those rows were
+      // never inserted because only post_generation results were saved below. Pre-gen runs
+      // before the assistant message exists — anchor each run to this turn's saved message id.
+      const preGenAnchorMessageId = (lastSavedMsg as any)?.id ?? "";
+      if (preGenAnchorMessageId && !abortController.signal.aborted) {
+        const preGenSuccessful = pipeline.results.filter((r) => {
+          if (!r.success || r.agentType !== "director") return false;
+          const cfg = pipelineAgents.find((a) => a.type === r.agentType);
+          return cfg?.phase === "pre_generation";
+        });
+        for (const result of preGenSuccessful) {
+          try {
+            await agentsStore.saveRun({
+              agentConfigId: result.agentId,
+              chatId: input.chatId,
+              messageId: preGenAnchorMessageId,
+              result,
+            });
+          } catch (err) {
+            logger.warn(err, "[agents] Failed to persist Narrative Director run");
+          }
         }
       }
 


### PR DESCRIPTION
## Linked issue

https://discord.com/channels/1417099416812392641/1499815860733477016

Closes #

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- Fixes Narrative Director run interval gating so the agent does not keep running every generation after its first successful run.
- The interval check already looked for the director’s last successful `agent_runs` row, but pre-generation director runs were not being persisted, so there was no saved message anchor to count from.

## What changed

<!-- List the key changes in this PR -->

- Parses the Narrative Director `runInterval` setting more defensively before applying interval gating.
- Persists successful Narrative Director pre-generation runs after the assistant message is saved.
- Anchors the saved director run to the generated assistant message ID so future turns can count assistant messages since the last director run.
- Logs a warning if persisting the director run fails, without failing the whole generation.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [X] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [X] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [X] Above manual verification completed (describe below)
- [X] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Ran `pnpm check` locally. It passed, including `impeccable:check`, lint, and build.
- Started new chat with Narrative Director agent activated. 
- Verified successful Narrative Director output.
- Exchanged messages, checking to ensure no farther output.
- Confirmed next Narrative Director output only generated at the correct interval.
- Confirmed Narrative Director runs every turn when interval is set to 1.

## Docs and release impact

- [X] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
- Improved interval setting validation with automatic fallback to defaults when invalid values are provided
- Fixed data persistence issue for pre-execution operations that were previously not being recorded

<!-- end of auto-generated comment: release notes by coderabbit.ai -->