### PR TITLE
docs(game-mode): clarify HUD widget state crosses Scene Analysis boundary

### DIFF
--- a/docs/GAME_MODE.md
+++ b/docs/GAME_MODE.md
@@ -265,7 +265,9 @@ Post-processes each GM turn through a separate **sidecar connection** that produ
 - Sprite expression updates for NPCs in scene
 - HUD widget state updates, when widgets were defined in the world-gen blueprint
 
-The sidecar prompt is **not** seen by the main GM model, and the main GM does **not** see what the sidecar produces — they run in parallel pipelines. This means a small/fast model on the sidecar connection won't drag down main GM quality, and vice versa.
+The sidecar prompt is **not** seen by the main GM model, and most of what the sidecar produces — background prompts, music cues, sprite expressions — stays in the sidecar pipeline and is consumed by the UI rather than fed back to the GM. They run in parallel pipelines, so a small/fast model on the sidecar connection won't drag down main GM quality, and vice versa.
+
+**One exception: HUD widget values.** Widget updates emitted by Scene Analysis are written to persistent game state, and the per-turn GM prompt re-reads each widget's current value on every turn (listed under "HUD widget state" in [Phase 2 above](#phase-2-gameplay-turn-by-turn)). So if Scene Analysis updates `Kingdom Wealth` from 50 → 47 after turn N, the GM sees 47 when its prompt is assembled for turn N+1. This is true regardless of which side wrote the update — when Scene Analysis is off, the GM emits widget commands itself, and the same state-rehydration loop carries the new values forward.
 
 If you've downloaded Marinara's local sidecar model, you can route Scene Analysis through it (the wizard exposes a "use local" toggle for the scene model), avoiding API costs entirely.
 


### PR DESCRIPTION
## Why this change

- The Scene Analysis section in `docs/GAME_MODE.md` says the main GM "does **not** see what the sidecar produces." That's true for backgrounds, music cues, and sprite expressions — but not for HUD widget values, which are persisted to game state and re-injected into every subsequent GM prompt.
- Users designing widgets like a 0–100 "Kingdom Wealth" gauge can't tell from the docs whether the GM model is aware of widget changes Scene Analysis applied. The current wording suggests it isn't, when in fact it is.

## What changed

- `docs/GAME_MODE.md` — split the "GM doesn't see sidecar output" sentence into the general rule + a HUD-widget exception, with a Kingdom Wealth example showing how Scene Analysis updates flow into the next turn's GM prompt via persistent state.

## Validation

- [x] `pnpm check` passes locally
- [x] Above manual verification completed (describe below)

### Manual verification notes

- Docs-only change; no runtime behavior modified.
- Verify rendered Markdown reads cleanly on GitHub (link to `#phase-2-gameplay-turn-by-turn` anchor resolves, the new paragraph sits naturally between the bullet list and the local-sidecar paragraph).
- Confirm the technical claim against the code: `buildWidgetSummaryLines` in `packages/server/src/services/game/gm-prompts.ts` reads `widget.config` values into the per-turn GM prompt regardless of the `hasSceneModel` flag, and Scene Analysis writes to that same `widget.config` state.


## UI evidence (if applicable)

N/A — docs-only.