### PR TITLE
feat(security): friendly HTML page when remote browsers hit the auth lockdown

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -86,6 +86,8 @@ LOG_LEVEL=debug pnpm start
 
 Marinara Engine ships with layered access-control mechanisms designed for users who expose the server beyond their local machine.
 
+> Looking for a step-by-step walkthrough rather than a reference? See [Remote Access — Setting Up Basic Auth or an IP Allowlist](REMOTE_ACCESS.md).
+
 ### Safe-by-default lockdown
 
 By default, when no Basic Auth credentials are configured, the server **refuses connections from every non-loopback IP**. Local browser access continues to work without any configuration:

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -18,7 +18,7 @@ The shell launchers (`start.sh`, `start.bat`, `start-termux.sh`) already bind to
 
 Loopback (`127.0.0.1`) works without a password, but other devices on your LAN now require authentication by default. Set `BASIC_AUTH_USER` and `BASIC_AUTH_PASS` in `.env`, then restart Marinara. For privileged actions from that browser, also set `ADMIN_SECRET` and save it in **Settings -> Advanced -> Admin Access**.
 
-You can restore the old unauthenticated LAN behavior with `ALLOW_UNAUTHENTICATED_PRIVATE_NETWORK=true`, but only do this on a network you fully trust.
+You can restore the old unauthenticated LAN behavior with `ALLOW_UNAUTHENTICATED_PRIVATE_NETWORK=true`, but only do this on a network you fully trust. For a step-by-step walkthrough covering Basic Auth, IP Allowlist, and the private-network bypass, see [Remote Access — Setting Up Basic Auth or an IP Allowlist](REMOTE_ACCESS.md).
 
 ## 3. Find your host device's local IP address
 

--- a/docs/REMOTE_ACCESS.md
+++ b/docs/REMOTE_ACCESS.md
@@ -1,0 +1,156 @@
+# Remote Access — Setting Up Basic Auth or an IP Allowlist
+
+If you're seeing **`403 Forbidden`** when you try to open Marinara Engine from a phone, a Docker container, a Tailscale device, or any other machine that isn't the one running the server, this guide is for you.
+
+By default Marinara only answers requests coming from the same machine (`127.0.0.1` / `::1`). Anything else — your phone on the same Wi-Fi, a Tailscale tablet, a browser hitting the Docker port — gets blocked until you tell Marinara who's allowed in. This is intentional: if your server ever ends up reachable from the public internet, an unprotected install would be wide open. The fix is to set up one of the access methods below and restart.
+
+> **TL;DR** — If you just want it to work and you're on a network you trust (home Wi-Fi, Docker on your own machine, your own Tailnet): set `BASIC_AUTH_USER` and `BASIC_AUTH_PASS` in `.env`, restart, and use those credentials when the browser prompts. That covers 95% of cases.
+
+## Which option do I pick?
+
+| Your situation | Pick this | Section |
+| --- | --- | --- |
+| Phone, tablet, or laptop on your home Wi-Fi | **Basic Auth** | [Option 1](#option-1-basic-auth-recommended) |
+| Docker / Podman container, accessing from the host or LAN | **Basic Auth** | [Option 1](#option-1-basic-auth-recommended) |
+| Tailscale, ZeroTier, or another VPN you control | **Basic Auth** *or* IP Allowlist | [Option 1](#option-1-basic-auth-recommended) / [Option 2](#option-2-ip-allowlist) |
+| Public-internet exposure (custom domain, port forwarding) | **Basic Auth + HTTPS** | [Option 1](#option-1-basic-auth-recommended) + [HTTPS](#serving-over-https) |
+| You really, really don't want a password and your network is fully trusted | Private-network bypass | [Option 3](#option-3-private-network-bypass-no-password) |
+
+Basic Auth is the most flexible choice — works from any IP, no per-device setup, and the browser remembers it. The IP Allowlist is handy when your client devices have stable IPs (Tailscale, static LAN leases) and you'd rather not type a password.
+
+## Before you start: where's `.env`?
+
+All access settings live in your `.env` file in the project root (next to `package.json`). If you don't have one yet:
+
+```bash
+cp .env.example .env
+```
+
+Edit it with any text editor. After saving, **restart Marinara** for changes to take effect. Quick reference for each install method:
+
+- **Source install (Windows / macOS / Linux)** — close the launcher window, run `start.bat` / `start.sh` again.
+- **Docker Compose** — `docker compose down && docker compose up -d`. You can also pass the variables in `docker-compose.yml` under `environment:` instead of using `.env`.
+- **Termux (Android)** — Ctrl+C to stop, then `./start-termux.sh` again.
+
+If you're running on a LAN or remote box and other devices still can't reach the server *at all* (different error than 403), make sure the server is binding to all interfaces with `HOST=0.0.0.0`. The shell launchers do this for you; `pnpm start` does not.
+
+## Option 1: Basic Auth (recommended)
+
+Add two lines to `.env`:
+
+```env
+BASIC_AUTH_USER=alice
+BASIC_AUTH_PASS=correct-horse-battery-staple
+```
+
+Pick a strong, unique password — Basic Auth credentials travel with every request, so treat this like any other login. A passphrase or a generated string is better than a short password. Generate one with:
+
+```bash
+# macOS / Linux
+openssl rand -base64 24
+
+# Windows PowerShell
+[Convert]::ToBase64String((1..18 | %{Get-Random -Max 256}))
+```
+
+Restart Marinara, then open it in your browser from the remote device. You'll see your browser's native password prompt — enter the username and password you set, and the browser will remember them for the rest of the session.
+
+**What's exempt from the password:**
+
+- Loopback (`127.0.0.1`, `::1`) — you don't need to type your password on the host machine itself.
+- Anything in `IP_ALLOWLIST` — useful if you want some devices to skip the prompt (see below).
+- `/api/health` — so uptime monitors and load balancers can keep working.
+
+**Optional:** set `BASIC_AUTH_REALM` to customise the text the browser prompt shows (default is `Marinara Engine`).
+
+> **Important:** if you're exposing the server to the public internet, pair Basic Auth with HTTPS. Basic Auth credentials are only base64-encoded, not encrypted — anyone watching the connection in plaintext can read them. See [Serving over HTTPS](#serving-over-https) below.
+
+## Option 2: IP Allowlist
+
+If you'd rather skip the password prompt and your client devices have stable IPs, set `IP_ALLOWLIST` to a comma-separated list of IPs or CIDR ranges:
+
+```env
+# Allow my whole home subnet plus a specific Tailscale address
+IP_ALLOWLIST=192.168.1.0/24,100.64.1.7
+```
+
+Requests from any address that doesn't match (and isn't loopback) get a 403. Loopback is **always** allowed regardless of the list — you cannot lock yourself out of local access by misconfiguring this.
+
+A few common patterns:
+
+- **Home LAN** — `192.168.1.0/24` or `192.168.0.0/24` (check your router; 10.x and 172.16-31.x networks also exist).
+- **Tailscale / Headscale** — your Tailnet's CGNAT range is typically `100.64.0.0/10`, but you can narrow to specific peer IPs from `tailscale status`.
+- **Docker bridge** — usually `172.17.0.0/16`, but check `docker network inspect bridge` if you're routing between containers.
+- **Single static address** — just the bare IP (e.g. `203.0.113.42`).
+
+You can combine this with Basic Auth: anything in `IP_ALLOWLIST` skips the password prompt; everything else still has to authenticate. That's a nice setup for "no password from my house, password from anywhere else."
+
+To temporarily disable enforcement without erasing your list (handy when troubleshooting from a new IP), set `IP_ALLOWLIST_ENABLED=false`.
+
+## Option 3: Private-network bypass (no password)
+
+If you're running on a fully trusted network — Docker on your own laptop, a personal Tailnet, your home LAN with no port forwarding — you can opt out of the lockdown without setting a password:
+
+```env
+ALLOW_UNAUTHENTICATED_PRIVATE_NETWORK=true
+```
+
+This restores the legacy "open on the LAN, blocked from the public internet" behavior. It applies only to clients in standard private-network ranges:
+
+`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `169.254.0.0/16`, `100.64.0.0/10` (Tailscale CGNAT), `fc00::/7`, `fe80::/10`
+
+Anything outside those ranges (i.e. public-internet IPs) still gets a 403. If your network uses a non-standard range or you want to trust a publicly-routable corporate subnet, override the list with `TRUSTED_PRIVATE_NETWORKS` — see [Configuration § Customising the private-network list](CONFIGURATION.md#customising-the-private-network-list).
+
+> **Trade-off:** anyone on the same private network can reach Marinara without authenticating. That's fine on a network you control; it's not fine on shared Wi-Fi (coffee shop, airport, conference, dorm). When in doubt, use Option 1.
+
+There is also `ALLOW_UNAUTHENTICATED_REMOTE=true` for unauthenticated public-internet access. **Do not turn this on.** If you genuinely need public access, use Basic Auth + HTTPS, or front Marinara with a reverse proxy that handles authentication (Cloudflare Access, Authelia, etc.).
+
+## Serving over HTTPS
+
+Two options when you're exposing Marinara beyond a trusted network:
+
+1. **Built-in TLS** — set `SSL_CERT` and `SSL_KEY` to the paths of your certificate and private key. Use Let's Encrypt (`certbot`) or `mkcert` for local development.
+2. **Reverse proxy** — front Marinara with nginx, Caddy, Traefik, or a Cloudflare Tunnel. The proxy handles TLS termination and you keep `BASIC_AUTH_*` on the Marinara side (or replace it with proxy-level auth).
+
+For sensitive deployments, consider Tailscale or Cloudflare Access — they avoid exposing the port to the open internet entirely.
+
+## Verifying it works
+
+After restarting, from your remote device:
+
+1. Open `http://<host-ip>:7860` (or your container/Tailscale address).
+2. Basic Auth: you should see a browser password prompt. Enter your credentials.
+3. IP Allowlist: the page should load directly with no prompt.
+4. Private-network bypass: the page should load directly with no prompt, **only** if your client IP is in a private-network range.
+
+Still getting a 403? Check:
+
+- Did you restart the server after editing `.env`?
+- Is the client IP what you expect? Marinara logs the blocked IP to the server console.
+- For Docker: are you connecting to the published port, or directly to the container IP?
+- For Tailscale: is the connecting device's `100.x.y.z` address in the allowlist (if you're using Option 2)?
+
+Different error than 403?
+
+- **Connection refused / timeout** — the server isn't bound to a reachable interface. Set `HOST=0.0.0.0` in `.env`.
+- **404 / wrong page** — you're hitting the wrong port. Default is `7860`; check `PORT` in `.env`.
+- **CORS error in the browser console** — set `CORS_ORIGINS` to include the URL you're connecting from (e.g. `http://192.168.1.10:7860`).
+
+The full troubleshooting page is at [docs/TROUBLESHOOTING.md](TROUBLESHOOTING.md).
+
+## A note on privileged actions
+
+Some destructive features (admin cleanup, backups, profile import/export, custom-tool creation, sidecar runtime install, etc.) require an additional shared secret called `ADMIN_SECRET`, on top of whatever access method you picked above. From a remote device you'll need to:
+
+1. Set `ADMIN_SECRET=<some-strong-random-string>` in `.env` and restart.
+2. Open Marinara on the remote device.
+3. Go to **Settings → Advanced → Admin Access** and paste the same secret.
+
+This is separate from Basic Auth. You can use both together — Basic Auth gates the app, `ADMIN_SECRET` gates the dangerous features.
+
+## See also
+
+- [Configuration Reference § Access Control](CONFIGURATION.md#access-control) — full env-var reference and edge cases.
+- [FAQ § How do I access Marinara from my phone or another device?](FAQ.md#how-do-i-access-marinara-engine-from-my-phone-or-another-device) — quick walkthrough for the LAN case.
+- [Troubleshooting](TROUBLESHOOTING.md) — connection issues, mobile access, Spotify on remote installs.
+- [Container install guide](installation/containers.md) — Docker/Podman specifics.

--- a/packages/server/src/middleware/basic-auth.ts
+++ b/packages/server/src/middleware/basic-auth.ts
@@ -107,15 +107,200 @@ function sendChallenge(reply: FastifyReply, realm: string) {
 
 let lockdownAnnounced = false;
 
-function sendLockdown(reply: FastifyReply) {
-  reply.status(403).send({
-    error: "Forbidden",
-    message:
-      "Non-loopback access requires authentication because no Basic Auth credentials are configured. " +
-      "Set BASIC_AUTH_USER and BASIC_AUTH_PASS, add this IP to IP_ALLOWLIST, " +
-      "or explicitly opt in with ALLOW_UNAUTHENTICATED_PRIVATE_NETWORK=true for LAN/private clients. " +
-      "Set ALLOW_UNAUTHENTICATED_REMOTE=true only if unauthenticated public access is intentional.",
-  });
+const LOCKDOWN_JSON_MESSAGE =
+  "Non-loopback access requires authentication because no Basic Auth credentials are configured. " +
+  "Set BASIC_AUTH_USER and BASIC_AUTH_PASS, add this IP to IP_ALLOWLIST, " +
+  "or explicitly opt in with ALLOW_UNAUTHENTICATED_PRIVATE_NETWORK=true for LAN/private clients. " +
+  "Set ALLOW_UNAUTHENTICATED_REMOTE=true only if unauthenticated public access is intentional.";
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function wantsHtml(request: FastifyRequest): boolean {
+  if (request.url.startsWith("/api/")) return false;
+  const accept = request.headers.accept;
+  const value = Array.isArray(accept) ? accept[0] : accept;
+  return typeof value === "string" && value.toLowerCase().includes("text/html");
+}
+
+function renderLockdownPage(clientIp: string): string {
+  const safeIp = escapeHtml(clientIp);
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta name="robots" content="noindex" />
+<title>Marinara Engine — Set up access</title>
+<style>
+  :root {
+    color-scheme: dark;
+    --bg: #0e1320;
+    --panel: #161c2c;
+    --panel-2: #1d2438;
+    --border: #2a3350;
+    --text: #e8ecf6;
+    --muted: #9aa3bd;
+    --accent: #f4a35d;
+    --accent-soft: rgba(244, 163, 93, 0.12);
+    --code-bg: #0a0f1c;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    background: radial-gradient(1200px 800px at 80% -10%, #1a223a 0%, var(--bg) 60%) fixed;
+    color: var(--text);
+    font: 15px/1.55 system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    min-height: 100vh;
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    padding: 32px 16px 64px;
+  }
+  main {
+    width: 100%;
+    max-width: 720px;
+  }
+  header { margin-bottom: 24px; }
+  .badge {
+    display: inline-block;
+    padding: 4px 10px;
+    border-radius: 999px;
+    background: var(--accent-soft);
+    color: var(--accent);
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+  h1 {
+    font-size: 26px;
+    line-height: 1.25;
+    margin: 12px 0 8px;
+    font-weight: 600;
+  }
+  p.lede { color: var(--muted); margin: 0; }
+  .panel {
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 20px 22px;
+    margin-top: 16px;
+  }
+  .panel h2 {
+    font-size: 17px;
+    margin: 0 0 6px;
+    font-weight: 600;
+  }
+  .panel .hint { color: var(--muted); font-size: 14px; margin: 0 0 12px; }
+  ol { margin: 0; padding-left: 20px; }
+  ol li { margin: 6px 0; }
+  code, pre {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 13px;
+  }
+  code {
+    background: var(--code-bg);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 1px 6px;
+  }
+  pre {
+    background: var(--code-bg);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 12px 14px;
+    overflow-x: auto;
+    margin: 8px 0 0;
+  }
+  .ip-pill {
+    display: inline-block;
+    background: var(--accent-soft);
+    color: var(--accent);
+    border-radius: 6px;
+    padding: 1px 8px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 13px;
+  }
+  footer {
+    margin-top: 20px;
+    padding: 16px 22px;
+    background: var(--panel-2);
+    border: 1px dashed var(--border);
+    border-radius: 12px;
+    color: var(--muted);
+    font-size: 13px;
+  }
+  footer strong { color: var(--text); }
+  a { color: var(--accent); text-decoration: none; border-bottom: 1px dotted rgba(244,163,93,0.4); }
+  a:hover { border-bottom-color: var(--accent); }
+  .links {
+    margin-top: 18px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 14px;
+    font-size: 14px;
+  }
+</style>
+</head>
+<body>
+  <main>
+    <header>
+      <span class="badge">Access blocked</span>
+      <h1>This Marinara Engine install needs access control before remote devices can connect.</h1>
+      <p class="lede">You're connecting from <span class="ip-pill">${safeIp}</span>, which isn't loopback. To protect your data, the server refuses non-local traffic until you choose how this device should authenticate. Pick one of the options below, restart Marinara, then refresh this page.</p>
+    </header>
+
+    <section class="panel">
+      <h2>Option 1 — Basic Auth (recommended)</h2>
+      <p class="hint">Best for shared networks, Tailscale, or any device you don't fully control. The browser will prompt for the username and password once, then remember it.</p>
+      <ol>
+        <li>Open your <code>.env</code> file in the Marinara Engine folder.</li>
+        <li>Add (or edit) these two lines, picking your own values:
+          <pre>BASIC_AUTH_USER=yourname
+BASIC_AUTH_PASS=a-long-random-password</pre>
+        </li>
+        <li>Restart Marinara Engine. Refresh this page and enter the credentials.</li>
+      </ol>
+    </section>
+
+    <section class="panel">
+      <h2>Option 2 — IP allowlist</h2>
+      <p class="hint">Best when you only need a few known devices to connect — e.g. your phone on a home network, or specific Tailscale peers.</p>
+      <ol>
+        <li>Open your <code>.env</code> file in the Marinara Engine folder.</li>
+        <li>Add this line. Your current IP is already filled in — add more entries (comma-separated, CIDR allowed) for other devices:
+          <pre>IP_ALLOWLIST=${safeIp}</pre>
+        </li>
+        <li>Restart Marinara Engine and refresh this page.</li>
+      </ol>
+    </section>
+
+    <footer>
+      <strong>On a fully trusted private network?</strong> You can restore the legacy passwordless LAN behavior with <code>ALLOW_UNAUTHENTICATED_PRIVATE_NETWORK=true</code> in your <code>.env</code>. Only do this when you trust every device that can reach this server — anyone on the network will have full access without a password.
+      <div class="links">
+        <a href="https://github.com/Pasta-Devs/Marinara-Engine/blob/main/docs/FAQ.md#how-do-i-access-marinara-engine-from-my-phone-or-another-device" target="_blank" rel="noopener noreferrer">FAQ: Access from another device</a>
+        <a href="https://github.com/Pasta-Devs/Marinara-Engine/blob/main/docs/TROUBLESHOOTING.md#app-not-loading-on-mobile--another-device" target="_blank" rel="noopener noreferrer">Troubleshooting</a>
+        <a href="https://github.com/Pasta-Devs/Marinara-Engine/blob/main/docs/CONFIGURATION.md" target="_blank" rel="noopener noreferrer">Full configuration reference</a>
+      </div>
+    </footer>
+  </main>
+</body>
+</html>`;
+}
+
+function sendLockdown(request: FastifyRequest, reply: FastifyReply) {
+  if (wantsHtml(request)) {
+    reply.status(403).header("Content-Type", "text/html; charset=utf-8").send(renderLockdownPage(request.ip));
+    return;
+  }
+  reply.status(403).send({ error: "Forbidden", message: LOCKDOWN_JSON_MESSAGE });
 }
 
 export function hasBasicAuthConfigured(): boolean {
@@ -165,7 +350,7 @@ export function basicAuthHook(request: FastifyRequest, reply: FastifyReply, done
       );
       lockdownAnnounced = true;
     }
-    sendLockdown(reply);
+    sendLockdown(request, reply);
     return;
   }
 

--- a/packages/server/src/middleware/basic-auth.ts
+++ b/packages/server/src/middleware/basic-auth.ts
@@ -199,6 +199,7 @@ function renderLockdownPage(clientIp: string): string {
     font-weight: 600;
   }
   .panel .hint { color: var(--muted); font-size: 14px; margin: 0 0 12px; }
+  .panel .detail { display: inline-block; margin-top: 12px; font-size: 13px; }
   ol { margin: 0; padding-left: 20px; }
   ol li { margin: 6px 0; }
   code, pre {
@@ -268,6 +269,7 @@ BASIC_AUTH_PASS=a-long-random-password</pre>
         </li>
         <li>Restart Marinara Engine. Refresh this page and enter the credentials.</li>
       </ol>
+      <a class="detail" href="https://github.com/Pasta-Devs/Marinara-Engine/blob/main/docs/REMOTE_ACCESS.md#option-1-basic-auth-recommended" target="_blank" rel="noopener noreferrer">Detailed walkthrough →</a>
     </section>
 
     <section class="panel">
@@ -280,14 +282,15 @@ BASIC_AUTH_PASS=a-long-random-password</pre>
         </li>
         <li>Restart Marinara Engine and refresh this page.</li>
       </ol>
+      <a class="detail" href="https://github.com/Pasta-Devs/Marinara-Engine/blob/main/docs/REMOTE_ACCESS.md#option-2-ip-allowlist" target="_blank" rel="noopener noreferrer">Detailed walkthrough →</a>
     </section>
 
     <footer>
-      <strong>On a fully trusted private network?</strong> You can restore the legacy passwordless LAN behavior with <code>ALLOW_UNAUTHENTICATED_PRIVATE_NETWORK=true</code> in your <code>.env</code>. Only do this when you trust every device that can reach this server — anyone on the network will have full access without a password.
+      <strong>On a fully trusted private network?</strong> You can restore the legacy passwordless LAN behavior with <code>ALLOW_UNAUTHENTICATED_PRIVATE_NETWORK=true</code> in your <code>.env</code>. Only do this when you trust every device that can reach this server — anyone on the network will have full access without a password. <a href="https://github.com/Pasta-Devs/Marinara-Engine/blob/main/docs/REMOTE_ACCESS.md#option-3-private-network-bypass-no-password" target="_blank" rel="noopener noreferrer">Read the caveats first →</a>
       <div class="links">
+        <a href="https://github.com/Pasta-Devs/Marinara-Engine/blob/main/docs/REMOTE_ACCESS.md" target="_blank" rel="noopener noreferrer">Full Remote Access walkthrough</a>
         <a href="https://github.com/Pasta-Devs/Marinara-Engine/blob/main/docs/FAQ.md#how-do-i-access-marinara-engine-from-my-phone-or-another-device" target="_blank" rel="noopener noreferrer">FAQ: Access from another device</a>
         <a href="https://github.com/Pasta-Devs/Marinara-Engine/blob/main/docs/TROUBLESHOOTING.md#app-not-loading-on-mobile--another-device" target="_blank" rel="noopener noreferrer">Troubleshooting</a>
-        <a href="https://github.com/Pasta-Devs/Marinara-Engine/blob/main/docs/CONFIGURATION.md" target="_blank" rel="noopener noreferrer">Full configuration reference</a>
       </div>
     </footer>
   </main>

--- a/packages/server/test/security-middleware.test.ts
+++ b/packages/server/test/security-middleware.test.ts
@@ -41,6 +41,7 @@ async function buildHookApp() {
   });
   app.get("/api/headers", async () => ({ ok: true }));
   app.post("/api/haptic/command", async () => ({ ok: true }));
+  app.get("/", async () => "ok");
   await app.ready();
   return app;
 }
@@ -63,6 +64,63 @@ test("non-loopback requests fail closed when Basic Auth is not configured", asyn
           remoteAddress: "192.168.1.50",
         });
         assert.equal(res.statusCode, 403);
+      } finally {
+        await app.close();
+      }
+    },
+  ));
+
+test("browser navigation hitting the lockdown gets the friendly HTML page", async () =>
+  withEnv(
+    {
+      BASIC_AUTH_USER: undefined,
+      BASIC_AUTH_PASS: undefined,
+      ALLOW_UNAUTHENTICATED_PRIVATE_NETWORK: undefined,
+      ALLOW_UNAUTHENTICATED_REMOTE: undefined,
+      IP_ALLOWLIST: undefined,
+    },
+    async () => {
+      const app = await buildHookApp();
+      try {
+        const res = await app.inject({
+          method: "GET",
+          url: "/",
+          remoteAddress: "192.168.1.50",
+          headers: { accept: "text/html,application/xhtml+xml" },
+        });
+        assert.equal(res.statusCode, 403);
+        assert.match(res.headers["content-type"] ?? "", /text\/html/);
+        assert.match(res.body, /<!doctype html>/i);
+        assert.match(res.body, /BASIC_AUTH_USER/);
+        assert.match(res.body, /IP_ALLOWLIST=192\.168\.1\.50/);
+      } finally {
+        await app.close();
+      }
+    },
+  ));
+
+test("non-browser clients still get JSON 403 from the lockdown", async () =>
+  withEnv(
+    {
+      BASIC_AUTH_USER: undefined,
+      BASIC_AUTH_PASS: undefined,
+      ALLOW_UNAUTHENTICATED_PRIVATE_NETWORK: undefined,
+      ALLOW_UNAUTHENTICATED_REMOTE: undefined,
+      IP_ALLOWLIST: undefined,
+    },
+    async () => {
+      const app = await buildHookApp();
+      try {
+        const res = await app.inject({
+          method: "GET",
+          url: "/api/headers",
+          remoteAddress: "192.168.1.50",
+          headers: { accept: "application/json" },
+        });
+        assert.equal(res.statusCode, 403);
+        assert.match(res.headers["content-type"] ?? "", /application\/json/);
+        const body = JSON.parse(res.body) as { error: string };
+        assert.equal(body.error, "Forbidden");
       } finally {
         await app.close();
       }


### PR DESCRIPTION
## Why

A lot of Docker / Tailscale / phone-on-LAN users are getting confused by the no-auth lockdown that ships with the safe-by-default Basic Auth behavior. When they open the server in a browser without setting `BASIC_AUTH_USER`/`BASIC_AUTH_PASS`/`IP_ALLOWLIST`, they get a raw JSON 403 that just says "Forbidden" — no instructions, no link, no obvious next step. Discord has been seeing this report repeatedly.

This PR keeps the security posture identical (still 403, still fails closed) but replaces the JSON body with a styled, self-contained HTML page **only when the request looks like a browser navigation** (Accept: text/html, non-/api/ path). Programmatic clients (curl, fetch, /api/*) still get the original JSON, so nothing scripted breaks.

## What the page shows

- The user's detected IP (so they don't have to figure it out for the IP_ALLOWLIST path)
- **Option 1 — Basic Auth** with the exact two `.env` lines to add
- **Option 2 — IP allowlist** with `IP_ALLOWLIST=<their-ip>` pre-filled
- A "trusted network escape hatch" footnote pointing at `ALLOW_UNAUTHENTICATED_PRIVATE_NETWORK=true`
- A "Detailed walkthrough →" link inside each option panel that deep-links to the matching anchor in `docs/REMOTE_ACCESS.md`, plus link cards at the bottom for the full walkthrough, FAQ, and Troubleshooting

## Bundled with chai's docs PR (#447)

To avoid the day-one broken-link risk chai called out in #447, this PR also picks up chai's `docs/REMOTE_ACCESS.md` walkthrough plus the `CONFIGURATION.md` / `FAQ.md` cross-reference lines. Either #446 or #447 can land first; the other becomes a no-op merge. **Once both have landed, #447 can be closed without merging** since its content is included here.

## Implementation notes

- `sendLockdown(request, reply)` now branches on `wantsHtml(request)`.
- `wantsHtml` returns false for `/api/*` and only true if `Accept` includes `text/html`.
- The IP and other dynamic content go through an `escapeHtml()` helper so we can't be tricked into XSS via a header-spoofed remote address.
- HTML is fully inline (CSS in `<style>`) so it works without any client build artifacts and won't 404 on a misconfigured static server.
- The existing JSON message is preserved as `LOCKDOWN_JSON_MESSAGE`.

## Tests

Added two unit tests in `packages/server/test/security-middleware.test.ts`:
- A browser navigation (Accept: text/html) hitting a non-API path gets a 403 with `Content-Type: text/html`, the doctype, the `BASIC_AUTH_USER` token, and `IP_ALLOWLIST=<their-ip>`.
- A non-browser (Accept: application/json) request to `/api/headers` still gets the original JSON 403.

The pre-existing "non-loopback fails closed" test still passes unchanged. All 18 security-middleware tests pass.

## Manual verification (not yet done — please confirm before merging)

- [ ] Start Marinara Engine without setting `BASIC_AUTH_USER`/`BASIC_AUTH_PASS`/`IP_ALLOWLIST`
- [ ] From another device on the LAN (or via Tailscale), open `http://<server-ip>:7860/` in a browser
- [ ] Confirm the styled HTML page renders, the IP pill matches the device's address, and both options' code blocks are readable
- [ ] On mobile (narrow viewport), confirm nothing is cut off and the `<pre>` blocks scroll horizontally instead of overflowing
- [ ] Click "Detailed walkthrough →" on each option panel and confirm it opens the matching anchor in REMOTE_ACCESS.md on GitHub
- [ ] From the same blocked device, run `curl -i http://<server-ip>:7860/api/headers` and confirm the JSON 403 still comes back with `Content-Type: application/json`
- [ ] Set `BASIC_AUTH_USER`/`BASIC_AUTH_PASS`, restart, and confirm the lockdown page is gone (browser gets the normal 401 challenge instead)
- [ ] Set `ALLOW_UNAUTHENTICATED_PRIVATE_NETWORK=true`, restart, and confirm the LAN browser loads the app normally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lockdown now serves a friendly HTML page to browser-like clients while API clients continue to receive JSON, adapting responses by client characteristics.

* **Tests**
  * Added a navigation-style test verifying unauthenticated browser requests return the HTML lockdown page with environment placeholders.

* **Documentation**
  * Added Remote Access guide and updated Configuration and FAQ with access-control setup and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->