### PR TITLE
fix(#438): persist selfies to active swipe, fix group notification identity

### DIFF
--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -56,6 +56,59 @@ function parseCharacterRowData(raw: unknown): Record<string, unknown> | null {
   return null;
 }
 
+type CachedCharacterRow = {
+  id?: string;
+  data?: unknown;
+  avatarPath?: string | null;
+  name?: string;
+};
+
+function resolveCachedCharacterIdentity(
+  qc: QueryClient,
+  characterId: string | null | undefined,
+  fallbackName = "Character",
+): {
+  name: string;
+  avatarUrl: string | null;
+  avatarCrop?: { zoom: number; offsetX: number; offsetY: number } | null;
+} {
+  if (!characterId) return { name: fallbackName, avatarUrl: null };
+
+  const detail = qc.getQueryData<CachedCharacterRow>(characterKeys.detail(characterId));
+  const list = qc.getQueryData<CachedCharacterRow[]>(characterKeys.list());
+  const row = detail ?? list?.find((character) => character.id === characterId);
+  const parsed = parseCharacterRowData(row?.data);
+  const name =
+    (parsed && typeof parsed.name === "string" && parsed.name.trim()) ||
+    (typeof row?.name === "string" && row.name.trim()) ||
+    fallbackName;
+  const avatarCrop =
+    parsed &&
+    typeof parsed.extensions === "object" &&
+    parsed.extensions &&
+    "avatarCrop" in parsed.extensions
+      ? ((parsed.extensions as { avatarCrop?: { zoom: number; offsetX: number; offsetY: number } | null }).avatarCrop ??
+        null)
+      : null;
+
+  return {
+    name,
+    avatarUrl: row?.avatarPath ?? null,
+    avatarCrop,
+  };
+}
+
+function latestAssistantMessage(messages: Iterable<Message>): Message | null {
+  let latest: Message | null = null;
+  for (const message of messages) {
+    if (message.role !== "assistant") continue;
+    if (!latest || new Date(message.createdAt).getTime() >= new Date(latest.createdAt).getTime()) {
+      latest = message;
+    }
+  }
+  return latest;
+}
+
 /**
  * Build one or more PendingCardUpdate batches from a character_card_update
  * agent result. Each batch is scoped to a single characterId so the approval
@@ -885,25 +938,22 @@ export function useGenerate() {
                     startTypewriter();
                   });
                 }
+                const previousGroupMessage = latestAssistantMessage(persistedMessages.values());
+
                 // Pick up the just-saved message from the previous character
                 await refreshMessagesAuthoritatively(qc, params.chatId, persistedMessages.values());
                 // Increment unread if user navigated away during group generation
                 const activeNow = useChatStore.getState().activeChatId;
                 if (activeNow !== params.chatId) {
                   useChatStore.getState().incrementUnread(params.chatId);
-                  // Show floating avatar notification bubble
-                  const charDetail = qc.getQueryData<{ avatarPath?: string | null }>(
-                    characterKeys.detail(turn.characterId),
+                  const identity = resolveCachedCharacterIdentity(
+                    qc,
+                    previousGroupMessage?.characterId ?? null,
+                    turn.characterName,
                   );
-                  // Detail cache may be empty — fall back to list cache
-                  let avatarPath = charDetail?.avatarPath ?? null;
-                  if (!avatarPath) {
-                    const charList = qc.getQueryData<Array<{ id: string; avatarPath?: string | null }>>(
-                      characterKeys.list(),
-                    );
-                    avatarPath = charList?.find((c) => c.id === turn.characterId)?.avatarPath ?? null;
-                  }
-                  useChatStore.getState().addNotification(params.chatId, turn.characterName, avatarPath);
+                  useChatStore
+                    .getState()
+                    .addNotification(params.chatId, identity.name, identity.avatarUrl, identity.avatarCrop);
                   const chatList = qc.getQueryData<Chat[]>(chatKeys.list());
                   const thisChat = chatList?.find((c) => c.id === params.chatId);
                   const isRpMode = thisChat?.mode === "roleplay" || thisChat?.mode === "visual_novel";
@@ -1321,32 +1371,13 @@ export function useGenerate() {
               : Array.isArray(rawIds)
                 ? rawIds
                 : [];
-          const firstCharId = parsedIds[0];
-          if (firstCharId) {
-            const charDetail = qc.getQueryData<{ data?: { name?: string } | string; avatarPath?: string | null }>(
-              characterKeys.detail(firstCharId),
-            );
-            // Detail cache may be empty — fall back to the always-populated list cache
-            let charAvatar = charDetail?.avatarPath ?? null;
-            let charName = "Character";
-            if (charDetail) {
-              const parsed = typeof charDetail.data === "string" ? JSON.parse(charDetail.data) : charDetail.data;
-              charName = parsed?.name ?? "Character";
-            }
-            if (!charAvatar || charName === "Character") {
-              const charList = qc.getQueryData<
-                Array<{ id: string; data?: string | { name?: string }; avatarPath?: string | null }>
-              >(characterKeys.list());
-              const fromList = charList?.find((c) => c.id === firstCharId);
-              if (fromList) {
-                if (!charAvatar) charAvatar = fromList.avatarPath ?? null;
-                if (charName === "Character") {
-                  const p = typeof fromList.data === "string" ? JSON.parse(fromList.data) : fromList.data;
-                  charName = p?.name ?? "Character";
-                }
-              }
-            }
-            useChatStore.getState().addNotification(params.chatId, charName, charAvatar);
+          const notifiedMessage = latestAssistantMessage(persistedMessages.values());
+          const notifiedCharacterId = notifiedMessage?.characterId ?? parsedIds[0] ?? null;
+          if (notifiedCharacterId) {
+            const identity = resolveCachedCharacterIdentity(qc, notifiedCharacterId);
+            useChatStore
+              .getState()
+              .addNotification(params.chatId, identity.name, identity.avatarUrl, identity.avatarCrop);
           }
           const isRp = chat?.mode === "roleplay" || chat?.mode === "visual_novel";
           const soundEnabled = isRp

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -66,9 +66,9 @@ type CachedCharacterRow = {
 function resolveCachedCharacterIdentity(
   qc: QueryClient,
   characterId: string | null | undefined,
-  fallbackName = "Character",
+  fallbackName: string | null | undefined = "Character",
 ): {
-  name: string;
+  name: string | null;
   avatarUrl: string | null;
   avatarCrop?: { zoom: number; offsetX: number; offsetY: number } | null;
 } {
@@ -81,7 +81,8 @@ function resolveCachedCharacterIdentity(
   const name =
     (parsed && typeof parsed.name === "string" && parsed.name.trim()) ||
     (typeof row?.name === "string" && row.name.trim()) ||
-    fallbackName;
+    fallbackName ||
+    "Character";
   const avatarCrop =
     parsed &&
     typeof parsed.extensions === "object" &&
@@ -949,11 +950,12 @@ export function useGenerate() {
                   const identity = resolveCachedCharacterIdentity(
                     qc,
                     previousGroupMessage?.characterId ?? null,
-                    turn.characterName,
+                    (previousGroupMessage as (Message & { characterName?: string | null }) | null)?.characterName ??
+                      null,
                   );
                   useChatStore
                     .getState()
-                    .addNotification(params.chatId, identity.name, identity.avatarUrl, identity.avatarCrop);
+                    .addNotification(params.chatId, identity.name ?? "Character", identity.avatarUrl, identity.avatarCrop);
                   const chatList = qc.getQueryData<Chat[]>(chatKeys.list());
                   const thisChat = chatList?.find((c) => c.id === params.chatId);
                   const isRpMode = thisChat?.mode === "roleplay" || thisChat?.mode === "visual_novel";
@@ -1377,7 +1379,7 @@ export function useGenerate() {
             const identity = resolveCachedCharacterIdentity(qc, notifiedCharacterId);
             useChatStore
               .getState()
-              .addNotification(params.chatId, identity.name, identity.avatarUrl, identity.avatarCrop);
+              .addNotification(params.chatId, identity.name ?? "Character", identity.avatarUrl, identity.avatarCrop);
           }
           const isRp = chat?.mode === "roleplay" || chat?.mode === "visual_novel";
           const soundEnabled = isRp

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -7135,29 +7135,13 @@ export async function generateRoutes(app: FastifyInstance) {
 
                       // Always persist to the swipe row so the attachment survives
                       // swipe switches even if the user has already navigated away.
-                      const swipeRow = (await chats.getSwipes(messageId)).find(
-                        (s: any) => s.index === targetSwipeIndex,
-                      );
-                      if (swipeRow) {
-                        const swipeExtra =
-                          typeof swipeRow.extra === "string" ? JSON.parse(swipeRow.extra) : (swipeRow.extra ?? {});
-                        const swipeAtts = (swipeExtra.attachments as any[]) ?? [];
-                        swipeAtts.push(attachment);
-                        await chats.updateSwipeExtra(messageId, targetSwipeIndex, { attachments: swipeAtts });
-                      }
+                      await chats.appendSwipeAttachment(messageId, targetSwipeIndex, attachment);
 
                       // Also update the live message row if this swipe is still active,
                       // so the SSE illustration event is immediately visible.
                       const msgRow = await chats.getMessage(messageId);
                       if (msgRow && (msgRow.activeSwipeIndex ?? 0) === targetSwipeIndex) {
-                        const msgExtra = msgRow.extra
-                          ? typeof msgRow.extra === "string"
-                            ? JSON.parse(msgRow.extra)
-                            : msgRow.extra
-                          : {};
-                        const existingAttachments = (msgExtra.attachments as any[]) ?? [];
-                        existingAttachments.push(attachment);
-                        await chats.updateMessageExtra(messageId, { attachments: existingAttachments });
+                        await chats.appendMessageAttachment(messageId, attachment);
                       }
                     }
 
@@ -7555,28 +7539,8 @@ export async function generateRoutes(app: FastifyInstance) {
                           url: imageUrl,
                           filename: `selfie_${charName.toLowerCase().replace(/\s+/g, "_")}.${imageResult.ext}`,
                         };
-                        const swipeRow = (await chats.getSwipes(messageId)).find(
-                          (swipe: any) => swipe.index === activeSwipeIndex,
-                        );
-                        if (swipeRow) {
-                          const swipeExtra = swipeRow.extra
-                            ? typeof swipeRow.extra === "string"
-                              ? JSON.parse(swipeRow.extra)
-                              : swipeRow.extra
-                            : {};
-                          const swipeAttachments = (swipeExtra.attachments as any[]) ?? [];
-                          swipeAttachments.push(attachment);
-                          await chats.updateSwipeExtra(messageId, activeSwipeIndex, { attachments: swipeAttachments });
-                        }
-
-                        const msgExtra = msgRow?.extra
-                          ? typeof msgRow.extra === "string"
-                            ? JSON.parse(msgRow.extra)
-                            : msgRow.extra
-                          : {};
-                        const existingAttachments = (msgExtra.attachments as any[]) ?? [];
-                        existingAttachments.push(attachment);
-                        await chats.updateMessageExtra(messageId, { attachments: existingAttachments });
+                        await chats.appendSwipeAttachment(messageId, activeSwipeIndex, attachment);
+                        await chats.appendMessageAttachment(messageId, attachment);
                       }
 
                       // Send selfie event to client

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -7548,17 +7548,34 @@ export async function generateRoutes(app: FastifyInstance) {
                       const imageUrl = `/api/gallery/file/${input.chatId}/${encodeURIComponent(filename)}`;
                       if (messageId) {
                         const msgRow = await chats.getMessage(messageId);
+                        const activeSwipeIndex =
+                          typeof msgRow?.activeSwipeIndex === "number" ? msgRow.activeSwipeIndex : 0;
+                        const attachment = {
+                          type: "image",
+                          url: imageUrl,
+                          filename: `selfie_${charName.toLowerCase().replace(/\s+/g, "_")}.${imageResult.ext}`,
+                        };
+                        const swipeRow = (await chats.getSwipes(messageId)).find(
+                          (swipe: any) => swipe.index === activeSwipeIndex,
+                        );
+                        if (swipeRow) {
+                          const swipeExtra = swipeRow.extra
+                            ? typeof swipeRow.extra === "string"
+                              ? JSON.parse(swipeRow.extra)
+                              : swipeRow.extra
+                            : {};
+                          const swipeAttachments = (swipeExtra.attachments as any[]) ?? [];
+                          swipeAttachments.push(attachment);
+                          await chats.updateSwipeExtra(messageId, activeSwipeIndex, { attachments: swipeAttachments });
+                        }
+
                         const msgExtra = msgRow?.extra
                           ? typeof msgRow.extra === "string"
                             ? JSON.parse(msgRow.extra)
                             : msgRow.extra
                           : {};
                         const existingAttachments = (msgExtra.attachments as any[]) ?? [];
-                        existingAttachments.push({
-                          type: "image",
-                          url: imageUrl,
-                          filename: `selfie_${charName.toLowerCase().replace(/\s+/g, "_")}.${imageResult.ext}`,
-                        });
+                        existingAttachments.push(attachment);
                         await chats.updateMessageExtra(messageId, { attachments: existingAttachments });
                       }
 

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -7532,15 +7532,19 @@ export async function generateRoutes(app: FastifyInstance) {
                       const imageUrl = `/api/gallery/file/${input.chatId}/${encodeURIComponent(filename)}`;
                       if (messageId) {
                         const msgRow = await chats.getMessage(messageId);
-                        const activeSwipeIndex =
+                        const generationSwipeIndex =
                           typeof msgRow?.activeSwipeIndex === "number" ? msgRow.activeSwipeIndex : 0;
                         const attachment = {
                           type: "image",
                           url: imageUrl,
                           filename: `selfie_${charName.toLowerCase().replace(/\s+/g, "_")}.${imageResult.ext}`,
                         };
-                        await chats.appendSwipeAttachment(messageId, activeSwipeIndex, attachment);
-                        await chats.appendMessageAttachment(messageId, attachment);
+                        await chats.appendSwipeAttachment(messageId, generationSwipeIndex, attachment);
+
+                        const currentMsgRow = await chats.getMessage(messageId);
+                        if (currentMsgRow && (currentMsgRow.activeSwipeIndex ?? 0) === generationSwipeIndex) {
+                          await chats.appendMessageAttachment(messageId, attachment);
+                        }
                       }
 
                       // Send selfie event to client

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -5964,7 +5964,12 @@ export async function generateRoutes(app: FastifyInstance) {
 
       // ── Run generation ──
       let lastSavedMsg: any = null;
-      const collectedCommands: Array<{ command: CharacterCommand; characterId: string | null; messageId: string }> = [];
+      const collectedCommands: Array<{
+        command: CharacterCommand;
+        characterId: string | null;
+        messageId: string;
+        swipeIndex: number;
+      }> = [];
       const collectedOocMessages: string[] = [];
 
       const normalizedGenerationGuide = typeof input.generationGuide === "string" ? input.generationGuide.trim() : "";
@@ -6024,7 +6029,12 @@ export async function generateRoutes(app: FastifyInstance) {
           lastSavedMsg = genResult.savedMsg;
           allResponses.push(genResult.response);
           for (const cmd of genResult.commands) {
-            collectedCommands.push({ command: cmd, characterId: charId, messageId: genResult.savedMsg?.id ?? "" });
+            collectedCommands.push({
+              command: cmd,
+              characterId: charId,
+              messageId: genResult.savedMsg?.id ?? "",
+              swipeIndex: genResult.savedMsg?.activeSwipeIndex ?? 0,
+            });
           }
           collectedOocMessages.push(...genResult.oocMessages);
 
@@ -6082,6 +6092,7 @@ export async function generateRoutes(app: FastifyInstance) {
               command: cmd,
               characterId: genResult.characterId,
               messageId: genResult.savedMsg?.id ?? "",
+              swipeIndex: genResult.savedMsg?.activeSwipeIndex ?? 0,
             });
           }
           collectedOocMessages.push(...genResult.oocMessages);
@@ -7275,7 +7286,7 @@ export async function generateRoutes(app: FastifyInstance) {
           data: { count: collectedCommands.length, professorMariCommandCount },
         });
         try {
-          for (const { command, characterId, messageId } of collectedCommands) {
+          for (const { command, characterId, messageId, swipeIndex } of collectedCommands) {
             try {
               if (command.type === "schedule_update") {
                 // ── Schedule Update: modify the character's current schedule block ──
@@ -7531,9 +7542,7 @@ export async function generateRoutes(app: FastifyInstance) {
                       const filename = filePath.split("/").pop()!;
                       const imageUrl = `/api/gallery/file/${input.chatId}/${encodeURIComponent(filename)}`;
                       if (messageId) {
-                        const msgRow = await chats.getMessage(messageId);
-                        const generationSwipeIndex =
-                          typeof msgRow?.activeSwipeIndex === "number" ? msgRow.activeSwipeIndex : 0;
+                        const generationSwipeIndex = Number.isInteger(swipeIndex) ? swipeIndex : 0;
                         const attachment = {
                           type: "image",
                           url: imageUrl,

--- a/packages/server/src/services/storage/chats.storage.ts
+++ b/packages/server/src/services/storage/chats.storage.ts
@@ -33,23 +33,33 @@ export type MetadataPatch = Record<string, unknown>;
 export type MetadataUpdater = (current: MetadataPatch) => MetadataPatch | Promise<MetadataPatch>;
 
 const metadataPatchQueues = new Map<string, Promise<void>>();
+const messageExtraPatchQueues = new Map<string, Promise<void>>();
+const swipeExtraPatchQueues = new Map<string, Promise<void>>();
 
-async function withMetadataPatchQueue<T>(chatId: string, operation: () => Promise<T>): Promise<T> {
-  const previous = metadataPatchQueues.get(chatId) ?? Promise.resolve();
+async function withPatchQueue<T>(
+  queues: Map<string, Promise<void>>,
+  key: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const previous = queues.get(key) ?? Promise.resolve();
   const queued = previous.catch(() => undefined).then(operation);
   const queuedVoid = queued.then(
     () => undefined,
     () => undefined,
   );
-  metadataPatchQueues.set(chatId, queuedVoid);
+  queues.set(key, queuedVoid);
 
   try {
     return await queued;
   } finally {
-    if (metadataPatchQueues.get(chatId) === queuedVoid) {
-      metadataPatchQueues.delete(chatId);
+    if (queues.get(key) === queuedVoid) {
+      queues.delete(key);
     }
   }
+}
+
+async function withMetadataPatchQueue<T>(chatId: string, operation: () => Promise<T>): Promise<T> {
+  return withPatchQueue(metadataPatchQueues, chatId, operation);
 }
 
 function parseMetadata(raw: unknown): MetadataPatch {
@@ -442,15 +452,33 @@ export function createChatsStorage(db: DB) {
 
     /** Merge partial data into a message's extra JSON field. */
     async updateMessageExtra(id: string, partial: Record<string, unknown>) {
-      const msg = await this.getMessage(id);
-      if (!msg) return null;
-      const existing = typeof msg.extra === "string" ? JSON.parse(msg.extra) : (msg.extra ?? {});
-      const merged = { ...existing, ...partial };
-      await db
-        .update(messages)
-        .set({ extra: JSON.stringify(merged) })
-        .where(eq(messages.id, id));
-      return this.getMessage(id);
+      return withPatchQueue(messageExtraPatchQueues, id, async () => {
+        const msg = await this.getMessage(id);
+        if (!msg) return null;
+        const existing = typeof msg.extra === "string" ? JSON.parse(msg.extra) : (msg.extra ?? {});
+        const merged = { ...existing, ...partial };
+        await db
+          .update(messages)
+          .set({ extra: JSON.stringify(merged) })
+          .where(eq(messages.id, id));
+        return this.getMessage(id);
+      });
+    },
+
+    /** Atomically append an attachment to a message's extra JSON field. */
+    async appendMessageAttachment(id: string, attachment: Record<string, unknown>) {
+      return withPatchQueue(messageExtraPatchQueues, id, async () => {
+        const msg = await this.getMessage(id);
+        if (!msg) return null;
+        const existing = typeof msg.extra === "string" ? JSON.parse(msg.extra) : (msg.extra ?? {});
+        const attachments = Array.isArray(existing.attachments) ? existing.attachments : [];
+        const merged = { ...existing, attachments: [...attachments, attachment] };
+        await db
+          .update(messages)
+          .set({ extra: JSON.stringify(merged) })
+          .where(eq(messages.id, id));
+        return this.getMessage(id);
+      });
     },
 
     async removeMessage(id: string) {
@@ -605,15 +633,33 @@ export function createChatsStorage(db: DB) {
 
     /** Merge partial data into a swipe's extra JSON field. */
     async updateSwipeExtra(messageId: string, swipeIndex: number, partial: Record<string, unknown>) {
-      const swipes = await this.getSwipes(messageId);
-      const target = swipes.find((s: any) => s.index === swipeIndex);
-      if (!target) return;
-      const existing = typeof target.extra === "string" ? JSON.parse(target.extra) : (target.extra ?? {});
-      const merged = { ...existing, ...partial };
-      await db
-        .update(messageSwipes)
-        .set({ extra: JSON.stringify(merged) })
-        .where(eq(messageSwipes.id, target.id));
+      return withPatchQueue(swipeExtraPatchQueues, `${messageId}:${swipeIndex}`, async () => {
+        const swipes = await this.getSwipes(messageId);
+        const target = swipes.find((s: any) => s.index === swipeIndex);
+        if (!target) return;
+        const existing = typeof target.extra === "string" ? JSON.parse(target.extra) : (target.extra ?? {});
+        const merged = { ...existing, ...partial };
+        await db
+          .update(messageSwipes)
+          .set({ extra: JSON.stringify(merged) })
+          .where(eq(messageSwipes.id, target.id));
+      });
+    },
+
+    /** Atomically append an attachment to a swipe's extra JSON field. */
+    async appendSwipeAttachment(messageId: string, swipeIndex: number, attachment: Record<string, unknown>) {
+      return withPatchQueue(swipeExtraPatchQueues, `${messageId}:${swipeIndex}`, async () => {
+        const swipes = await this.getSwipes(messageId);
+        const target = swipes.find((s: any) => s.index === swipeIndex);
+        if (!target) return;
+        const existing = typeof target.extra === "string" ? JSON.parse(target.extra) : (target.extra ?? {});
+        const attachments = Array.isArray(existing.attachments) ? existing.attachments : [];
+        const merged = { ...existing, attachments: [...attachments, attachment] };
+        await db
+          .update(messageSwipes)
+          .set({ extra: JSON.stringify(merged) })
+          .where(eq(messageSwipes.id, target.id));
+      });
     },
 
     // ── Chat Connections ──


### PR DESCRIPTION
## Linked issue

Closes #438

## Why this change

Convo/RP chats could show stale or mismatched character identity in notification bubbles, especially during multi-character generation. Generated selfies were saved to the gallery but disappeared from normal chat rendering because they were not persisted to the active swipe metadata used by the message view.

## What changed

- Persist generated selfie attachments to both the message extra and the active swipe extra so they remain visible in normal chat rendering, after edit mode closes, and after swipe/chat refreshes.
- Resolve off-chat notification identity from the saved assistant message's actual `characterId` instead of assuming the first chat character or the next group turn.
- Preserve avatar crop data when building floating notification bubbles from cached character data.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

This is my first Codex-assisted fix, and I want to be transparent about the verification gaps:

- `node scratch/issue-438-repro.mjs` confirmed the storage bug before the patch and the fixed behavior after: `beforePatchVisibleAttachments 0`, `afterPatchVisibleAttachments 1`.
- `pnpm --filter @marinara-engine/client exec tsc --noEmit` passed.
- `pnpm --filter @marinara-engine/client lint` passed.
- `pnpm --filter @marinara-engine/shared lint` passed.
- `pnpm check` did not complete because `impeccable:check` is currently crashing in `scripts/check-impeccable-context.mjs` (unrelated, pre-existing).
- Server type-check is still blocked by existing unrelated errors in `packages/server/src/services/haptic/buttplug-service.ts` for `OutputType.HwPositionWithDuration` (also pre-existing).
- **Manual app-shell verification still needed:** generate a selfie in a Convo/RP chat and confirm it stays visible after closing edit mode, switching swipes, and switching chats.
- **Manual app-shell verification still needed:** off-chat group notifications show the character who actually sent the saved message, not the next character in the group turn.

Happy to take guidance on any of this.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

Manual app-shell verification still needed with a configured image-generation provider.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed character avatars and names displaying incorrectly in group generation notifications, ensuring accurate identity information is shown
  * Corrected image attachment handling to properly associate selfies and images with specific message versions
  * Improved concurrency and state tracking during multi-character generation for better reliability and data consistency
<!-- end of auto-generated comment: release notes by coderabbit.ai -->