### PR TITLE
Fix spurious abort on normal generation completion

### DIFF
--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -697,7 +697,9 @@ export async function generateRoutes(app: FastifyInstance) {
     // Set up SSE headers
     startSseReply(reply, { "X-Accel-Buffering": "no" });
 
+    let generationComplete = false;
     const onClose = () => {
+      if (generationComplete) return;
       logger.info("[abort] Client disconnected — aborting generation");
       abortController.abort();
       if (activeGenerations) activeGenerations.delete(input.chatId);
@@ -709,7 +711,7 @@ export async function generateRoutes(app: FastifyInstance) {
         }).catch(() => {});
       }
     };
-    req.raw.on("close", onClose);
+    reply.raw.on("close", onClose);
     if (requestChatMode === "conversation" && !input.impersonate) {
       conversationGenerationStartedAt = markGenerationInProgress(input.chatId);
     }
@@ -5322,6 +5324,7 @@ export async function generateRoutes(app: FastifyInstance) {
           images?: string[];
           providerMetadata?: Record<string, unknown>;
         }>,
+        markGenerationCommitted = false,
       ): Promise<{
         savedMsg: Awaited<ReturnType<typeof chats.createMessage>>;
         response: string;
@@ -5900,6 +5903,9 @@ export async function generateRoutes(app: FastifyInstance) {
                 parsedCommands.length,
                 input.chatId,
               );
+              if (markGenerationCommitted) {
+                generationComplete = true;
+              }
               return { savedMsg: null, response: "", commands: parsedCommands, oocMessages, characterId: targetCharId };
             }
             logger.warn(`[generate] Empty response from model for chat ${input.chatId} (char: ${targetCharId})`);
@@ -5921,6 +5927,9 @@ export async function generateRoutes(app: FastifyInstance) {
               characterId: input.impersonate ? null : targetCharId,
               content: fullResponse,
             });
+          }
+          if (markGenerationCommitted && savedMsg?.id) {
+            generationComplete = true;
           }
           if (chatMode === "conversation" && !input.impersonate && !input.regenerateMessageId) {
             recordAssistantActivity(input.chatId, targetCharId ?? undefined);
@@ -6132,7 +6141,11 @@ export async function generateRoutes(app: FastifyInstance) {
           // Add as a system message at the end (just before any trailing user message)
           messagesWithInstruction.push({ role: "system", content: charInstruction });
 
-          const genResult = await generateForCharacter(charId, messagesWithInstruction);
+          const genResult = await generateForCharacter(
+            charId,
+            messagesWithInstruction,
+            ci === respondingCharIds.length - 1,
+          );
           if (!genResult) break; // aborted
           lastSavedMsg = genResult.savedMsg;
           allResponses.push(genResult.response);
@@ -6187,7 +6200,7 @@ export async function generateRoutes(app: FastifyInstance) {
           sentMessages.push({ role: "system", content: charInstruction });
         }
 
-        const genResult = await generateForCharacter(targetCharId, sentMessages);
+        const genResult = await generateForCharacter(targetCharId, sentMessages, true);
         if (genResult) {
           lastSavedMsg = genResult.savedMsg;
           for (const cmd of genResult.commands) {
@@ -8476,7 +8489,7 @@ export async function generateRoutes(app: FastifyInstance) {
       if (conversationGenerationStartedAt != null && !conversationAssistantSaved) {
         clearGenerationInProgress(input.chatId, conversationGenerationStartedAt);
       }
-      req.raw.off("close", onClose);
+      reply.raw.off("close", onClose);
       if (activeGenerations) activeGenerations.delete(input.chatId);
       reply.raw.end();
     }


### PR DESCRIPTION
Listen for close on reply.raw instead of req.raw and skip abort cleanup when generation has already completed successfully.

## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #443 

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- Tracker agents could be aborted after the main model response finished, leaving generation stuck with no character/custom tracker updates. This fixes the SSE disconnect handling so post-processing agents are not cancelled by the wrong stream lifecycle event.

## What changed

<!-- List the key changes in this PR -->

- Moved generation abort-on-disconnect handling from the incoming request stream to the outgoing SSE response stream.
- Added a completion guard so a normally completed generation does not trigger abort cleanup afterward.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [X] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [X] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Codex ran `pnpm check` locally and it passed.
- Honestly fam, I don't know how to repro the issue but Codex seems very confident this will fix it *shrug* Merge if you think it checks out.

## Docs and release impact

- [X] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

<!-- Add before/after screenshots or recordings for UI changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable handling of client disconnects during streaming so in-flight work is aborted, backend-notified, and cleaned up.
  * Safeguards to ensure completed generations aren’t canceled; completion is signaled and finalized before cleanup.
  * Per-character generation now marks commits so disconnect logic respects per-character finalization and avoids premature aborts.

* **Refactor**
  * Stream listener and cleanup flow simplified for more robust disconnect handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->