### PR TITLE
fix(agents): anchor director cadence to first group reply

### DIFF
--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -6076,6 +6076,7 @@ export async function generateRoutes(app: FastifyInstance) {
       }
 
       // ── Run generation ──
+      let firstSavedMsg: any = null;
       let lastSavedMsg: any = null;
       const collectedCommands: Array<{ command: CharacterCommand; characterId: string | null; messageId: string }> = [];
       const collectedOocMessages: string[] = [];
@@ -6134,6 +6135,7 @@ export async function generateRoutes(app: FastifyInstance) {
 
           const genResult = await generateForCharacter(charId, messagesWithInstruction);
           if (!genResult) break; // aborted
+          firstSavedMsg ??= genResult.savedMsg;
           lastSavedMsg = genResult.savedMsg;
           allResponses.push(genResult.response);
           for (const cmd of genResult.commands) {
@@ -6189,6 +6191,7 @@ export async function generateRoutes(app: FastifyInstance) {
 
         const genResult = await generateForCharacter(targetCharId, sentMessages);
         if (genResult) {
+          firstSavedMsg ??= genResult.savedMsg;
           lastSavedMsg = genResult.savedMsg;
           for (const cmd of genResult.commands) {
             collectedCommands.push({
@@ -6218,9 +6221,12 @@ export async function generateRoutes(app: FastifyInstance) {
       // Persist successful Narrative Director runs.
       // Interval gating uses getLastSuccessfulRunByType("director", …); those rows were
       // never inserted because only post_generation results were saved below. Pre-gen runs
-      // before the assistant message exists — anchor each run to this turn's saved message id.
-      const preGenAnchorMessageId = (lastSavedMsg as any)?.id ?? "";
-      if (preGenAnchorMessageId && !abortController.signal.aborted) {
+      // before the assistant message exists — anchor each run to the first saved
+      // assistant message from this turn so group-chat cadence counts from the
+      // earliest generated response.
+      const preGenAnchorMessageId =
+        (firstSavedMsg as any)?.role === "assistant" ? ((firstSavedMsg as any)?.id ?? "") : "";
+      if (preGenAnchorMessageId && !input.regenerateMessageId && !abortController.signal.aborted) {
         const preGenSuccessful = pipeline.results.filter((r) => {
           if (!r.success || r.agentType !== "director") return false;
           const cfg = pipelineAgents.find((a) => a.type === r.agentType);


### PR DESCRIPTION
## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- Narrative Director run intervals were counted incorrectly in group chats because successful pre-generation Director runs were anchored to the last generated assistant reply in a multi-character turn. That made cadence tracking drift when multiple characters replied in one generation.

## What changed

<!-- List the key changes in this PR -->

- Track the first saved assistant message produced during a generation turn.
- Persist successful Narrative Director pre-generation runs against that first assistant message, so group-chat interval counting starts from the beginning of the generated group response.
- Skip persisting these pre-generation Director cadence rows during regenerations, so retries/swipes do not incorrectly reset the interval.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [X] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [X] Above manual verification completed (describe below)
- [X] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Automated validation run locally by Codex: `pnpm check`
- Automated test suite run locally by Codex: `pnpm test`
- Production build runs normally.

## Docs and release impact

- [X] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Better handling of multi-character/group interactions during generation, reducing cross-character confusion.
  * More consistent regeneration behavior through improved anchoring of pre-generation content.
  * More reliable collection and organization of in-turn commands and out-of-character messages for downstream processing and provenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->