### PR TITLE
feat(agents): add editable injections and secret plot controls

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -124,6 +124,22 @@ Inside a single shared lorebook, you can mark each entry as only firing when spe
 
 ---
 
+<details>
+<summary><strong>Does retrying agents rerun every agent or just one?</strong></summary>
+<br>
+
+It depends which retry button you use.
+
+**Re-run Trackers** in the Roleplay HUD's Agents menu keeps the original broad behavior: it reruns all active tracker agents for that chat. Use this when the overall HUD state feels stale.
+
+Individual tracker controls are narrower. If you open a specific HUD widget and rerun it from there, Marinara sends only that tracker through the retry pipeline.
+
+Other retry controls are also scoped to what they say on the button: **Retry Failed Agents** retries the failed agents from the last generation, while Injections-tab re-runs only refresh the selected cached prompt injection for the current assistant message.
+
+</details>
+
+---
+
 <a id="what-happens-if-i-enable-an-agent-and-also-have-similar-instructions-in-my-preset"></a>
 
 <details>
@@ -135,6 +151,7 @@ Both contribute to the prompt, but in different ways: a preset section is static
 Common overlaps to watch for:
 
 - Writing-style or anti-repetition directives in the preset and the **Prose Guardian** agent.
+- Plot-steering, twist, pacing, or "what should happen next" directives in the preset and the **Narrative Director** or **Secret Plot Driver** agents.
 - "Track time / weather / location" instructions and the **World State** agent.
 - "Track character mood / outfit / stats" instructions and the **Character Tracker** agent.
 - Quest-tracking, combat-mechanics, or persona-stat instructions and their respective agents.
@@ -142,6 +159,8 @@ Common overlaps to watch for:
 - "Summarize past events" instructions and the **Automated Chat Summary** agent.
 
 **The general rule:** pick one place to express each behavior. If you've enabled an agent that covers a behavior, you can usually remove the matching preset directive. If you'd rather keep your preset version (e.g., it's tuned for a particular character), disable the corresponding agent.
+
+For story direction, choose the tool by how persistent you want the guidance to be. Use **Narrative Director** for occasional next-beat steering. Use **Secret Plot Driver** when you want hidden long-term arc memory and scene directions across turns. Use a preset only when the instruction should be static every turn.
 
 **One important exception:** the `agent_data` marker section, and the `{{agent::TYPE}}` macro, are the _intended_ way to thread an agent's output into a specific spot in the preset. That's wiring, not overlap — several agents (World State, Quest Tracker, Character Tracker, and others) set this up for you by default. The pattern to avoid is hand-writing preset sections that duplicate an agent's _behavior_, not using the marker section that carries the agent's _output_.
 

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -484,17 +484,17 @@ The server (`packages/server`) exposes the following REST API at `/api`:
 | `/api/chats`         | GET, POST, PATCH, DELETE      | Chat CRUD, messages, metadata, connect/disconnect    |
 | `/api/prompts`       | GET, POST, PATCH, DELETE      | Preset CRUD, sections, groups, choice blocks, export |
 | `/api/connections`   | GET, POST, PATCH, DELETE      | API connection CRUD, duplicate, test                 |
-| `/api/agents`        | GET, POST, PATCH, DELETE, PUT | Agent CRUD, toggle, echo messages                    |
+| `/api/agents`        | GET, POST, PATCH, DELETE      | Agent CRUD, echo messages, runs; built-in toggles use `PUT /api/agents/toggle/:agentType`; memory uses `/api/agents/memory/:agentType/:chatId` |
 | `/api/lorebooks`     | GET, POST, PATCH, DELETE      | Lorebook CRUD, entries, export                       |
 | `/api/custom-tools`  | GET, POST, PATCH, DELETE      | Custom tool CRUD                                     |
 | `/api/regex-scripts` | GET, POST, PATCH, DELETE      | Regex script CRUD                                    |
 
 ### Generation
 
-| Endpoint                                        | Method | Description                             |
-| ----------------------------------------------- | ------ | --------------------------------------- |
-| `/api/generate`                                 | POST   | Main SSE generation with agent pipeline |
-| `/api/generate/retry-agents/:chatId/:messageId` | POST   | Retry agent phases                      |
+| Endpoint                     | Method | Description                                                                 |
+| ---------------------------- | ------ | --------------------------------------------------------------------------- |
+| `/api/generate`              | POST   | Main SSE generation with agent pipeline                                     |
+| `/api/generate/retry-agents` | POST   | SSE retry for the agent types supplied by the caller                        |
 
 ### Chat Features
 
@@ -575,6 +575,16 @@ The agent system processes AI responses through configurable pipelines. Agents r
 1. **Pre-generation**: Before the main LLM call (e.g., context injection, knowledge retrieval)
 2. **Parallel**: Alongside the main generation (e.g., world-state tracking, expression detection)
 3. **Post-processing**: After the main response (e.g., prose rewriting, lorebook updates)
+
+Retry requests go through `/api/generate/retry-agents` with an explicit `agentTypes` list. Broad UI actions such as **Re-run Trackers** pass all active tracker types; individual widget controls pass only the target tracker.
+
+Agent memory tools, such as the Secret Plot tab, use `/api/agents/memory/:agentType/:chatId`. The route applies to configured agents that store per-chat memory, currently including `secret-plot-driver` for the Secret Plot tab. `agentType` is the agent type string and `chatId` is the target chat id.
+
+| Method | Body | Success | Errors | Use |
+| ------ | ---- | ------- | ------ | --- |
+| GET | none | `200 { agentConfigId, memory }` | `404` when the agent has no config | Read memory |
+| PATCH | `{ "patch": { "key": value } }` | `200 { agentConfigId, memory }` | `400` for invalid patch bodies or Secret Plot memory shapes; `404` when the agent cannot be configured | Update memory keys |
+| DELETE | none | `204` | none for a missing config | Clear that agent's memory for the chat |
 
 ### Built-in Agents (24)
 

--- a/docs/ROLEPLAY.md
+++ b/docs/ROLEPLAY.md
@@ -38,6 +38,7 @@ Roleplay's interface is significantly richer than Conversation's. Visible elemen
 - **Sprite slots** — up to three character sprites rendered in fixed positions (left, center, right) or free-placement mode. Sprites change expression based on the message content.
 - **Roleplay HUD** — heads-up display widgets along the top or side showing current world state.
 - **Weather overlay** — particle effects (rain, snow, fog, etc.) when the world-state agent infers weather from narrative.
+- **Agents menu** — the sparkle / agent activity menu for agent thoughts, retries, troubleshooting tabs, and optional hidden story guidance.
 - **Echo chamber panel** — simulated chat reactions from a fictional audience, like a Twitch-style chat (optional, agent-driven).
 - **Durable info panels** — toolbar buttons opening Summary, World Info (active lorebook entries), and Author's Notes panels.
 
@@ -73,6 +74,40 @@ Open the chat settings drawer's **Impersonate** section to configure the workflo
 - **Agent pipeline** — skip agents during impersonation when you want a fast draft that does not update trackers, lorebook routers, or world state.
 
 You can also set a per-chat prompt with `/impersonate_prompt "your prompt"` and reset it with `/impersonate_prompt reset`.
+
+## The Agents menu
+
+The Agents menu is the small activity menu in the Roleplay HUD. By default it shows **Activity**: agent thought bubbles, custom agent outputs, failed-agent retry actions, tracker re-run actions, and Echo Chamber controls when those features are active.
+
+Some troubleshooting tools are opt-in so they don't clutter the normal roleplay view:
+
+- **Injections tab** — enable it via the toggle switch in Chat Settings -> Agents -> Writer Agents -> Injections tab.
+- **Secret Plot tab** — enable Secret Plot Driver, then turn on the Secret Plot tab via the toggle on that agent's active card in Chat Settings.
+
+The **Injections tab** shows cached prompt injections saved on the latest assistant message. These are snippets that writer-style agents added before the reply was generated, such as Prose Guardian, Narrative Director, knowledge retrieval, knowledge router, or custom prompt-section agents. You can inspect, edit, save, or re-run eligible cached injections.
+
+When Narrative Director is active, the Injections tab also shows its run countdown and a compact interval stepper. That control changes how often the Director runs on future replies; it does not rewrite the cached injection already attached to the current assistant message.
+
+The important part: edits in the Injections tab don't change the already-visible message by themselves, nor do they carry over to the next assistant message. They're used when you regenerate that same assistant message. Re-running a cached injection also targets that same assistant message, using the transcript slice and tracker snapshot from the original generation rather than the newest chat turn. This keeps regeneration reproducible: you're changing the guidance that fed that reply, not asking the current chat state to invent a new unrelated direction.
+
+Knowledge Retrieval and Knowledge Router cached injections can be viewed but not re-run from this tab because they depend on their own retrieval/routing paths. Custom agents with **Add as Prompt Section** enabled appear below the cached injections so you can inspect and edit their latest saved prompt-section output too.
+
+## Secret Plot Driver
+
+Secret Plot Driver is an optional hidden-story agent. It maintains private plot memory for one roleplay chat: a long-term **arc memory** plus short-term **scene directions** that can be injected before replies. This is different from visible summaries or lorebook entries. It's meant to steer pacing, reveals, and long-term tension without printing the plan directly in the chat.
+
+When Secret Plot Driver is active and the Secret Plot tab is shown, you can edit:
+
+- **Scene direction** — short-term guidance for the next turn or near-term scene motion.
+- **Needs momentum shift** — a hint that the current scene has gone stale and should move.
+- **Arc memory** — hidden long-term plot structure, including the overall arc, protagonist arc, and whether the arc is complete.
+
+There are two re-run buttons with different blast radius:
+
+- **Re-run scene direction** keeps the current arc memory and only refreshes the turn-level guidance.
+- **Re-run full secret plot state** always asks for confirmation first, then may replace the hidden arc and scene directions depending on the model output. When it does, it overwrites the chat's arc memory and hidden plot plan.
+
+Saving edits writes directly to the agent memory used during generation. Hiding the Secret Plot tab only hides the editor; it doesn't disable the agent or delete memory. Removing Secret Plot Driver from the chat DOES delete that chat's hidden plot memory for the agent, including the current arc and scene directions.
 
 ## Sprite expressions
 
@@ -223,6 +258,18 @@ Long contexts compress when they hit the model's window. Things to try:
 - Bump to a model with a larger context window.
 - Use the **Summary** panel (toolbar button) to write down major events explicitly — the summary is injected into prompts and survives compression.
 - Author key facts into a lorebook as **constant** entries — they'll always be in scope regardless of where they were established in chat.
+
+### Regenerating a reply keeps using the wrong guidance
+
+If Prose Guardian, Narrative Director, knowledge retrieval, or a custom prompt-section agent pushed the reply in a bad direction or decided to continue the RP inside its guidance, turn on the **Injections tab** in chat settings -> Agents -> Writer Agents. Open the Roleplay HUD's Agents menu, inspect the cached prompt injections, then edit or re-run the specific injection and regenerate the same assistant message.
+
+This works because Marinara stores the prompt injections used for each assistant message. On regeneration, it reuses that message's cached guidance instead of blindly using whatever the newest chat state would produce.
+
+### Secret Plot Driver keeps steering toward the wrong arc
+
+Open chat settings -> Agents, make sure Secret Plot Driver is active, and show its **Secret Plot tab**. In the Roleplay HUD's Agents menu, use the Secret Plot tab to edit or re-run the hidden state.
+
+Use **Re-run scene direction** when the current turn needs a fresher nudge but the long-term arc is still good. Use **Re-run full secret plot state** when the hidden arc itself is wrong. Removing Secret Plot Driver from the chat wipes its hidden plot memory for that chat, so only do that if you want a clean slate.
 
 ---
 

--- a/packages/client/src/components/agents/ContextInjectionPanel.tsx
+++ b/packages/client/src/components/agents/ContextInjectionPanel.tsx
@@ -1,0 +1,474 @@
+// ──────────────────────────────────────────────
+// Editable cached agent prompt injections (message.extra.contextInjections)
+// Shown in the roleplay Agents menu — survives clearing thought bubbles.
+// ──────────────────────────────────────────────
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Check, ChevronDown, Minus, Plus, RefreshCw, Save } from "lucide-react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { BUILT_IN_AGENTS, getDefaultBuiltInAgentSettings } from "@marinara-engine/shared";
+import type { Message } from "@marinara-engine/shared";
+import { cn } from "../../lib/utils";
+import { api } from "../../lib/api-client";
+import { chatKeys, useUpdateMessageExtra } from "../../hooks/use-chats";
+import { useGenerate } from "../../hooks/use-generate";
+import { HelpTooltip } from "../ui/HelpTooltip";
+import { useUpdateAgentByType, type AgentConfigRow } from "../../hooks/use-agents";
+import { getAgentRunIntervalMeta, stepCadenceValue } from "../../lib/agent-cadence";
+
+const CACHED_INJECTIONS_HELP =
+  "Troubleshooting view for text that certain writer agents added before the current reply, usually Prose Guardian, Narrative Director, or custom injected text. Edits and re-runs are only used if you regenerate this same assistant message. Re-runs use the original transcript slice and tracker snapshot, not newer chat.";
+const DIRECTOR_CADENCE_HELP =
+  "Shows when Narrative Director will add guidance again. Interval changes affect future replies, not the cached injection on this message.";
+const NON_REROLLABLE_INJECTION_AGENTS = new Set(["knowledge-retrieval", "knowledge-router"]);
+
+const INJECTION_LABEL: Record<string, string> = Object.fromEntries(BUILT_IN_AGENTS.map((a) => [a.id, a.name]));
+
+function parseExtra(raw: Message["extra"]): Record<string, unknown> {
+  if (typeof raw === "string") {
+    try {
+      return JSON.parse(raw) as Record<string, unknown>;
+    } catch {
+      return {};
+    }
+  }
+  if (raw && typeof raw === "object") return raw as unknown as Record<string, unknown>;
+  return {};
+}
+
+function findLastAssistant(messages: Message[] | undefined): Message | null {
+  if (!messages?.length) return null;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i]!.role === "assistant") return messages[i]!;
+  }
+  return null;
+}
+
+function agentLabel(agentType: string): string {
+  return INJECTION_LABEL[agentType] ?? agentType;
+}
+
+type CachedInjection = { agentType: string; text: string };
+
+type AgentCadenceStatus = {
+  agentType: string;
+  runInterval: number;
+  lastSuccessfulRun: { messageId: string; createdAt: string } | null;
+  assistantMessagesSinceLastRun: number | null;
+  remainingAssistantMessages: number;
+  runsNextAssistantMessage: boolean;
+  lastRunMessageFound: boolean | null;
+};
+
+function normalizeContextInjections(raw: unknown): CachedInjection[] {
+  if (!Array.isArray(raw)) return [];
+  const normalized: CachedInjection[] = [];
+  for (const entry of raw) {
+    if (typeof entry === "string") {
+      normalized.push({ agentType: "prose-guardian", text: entry });
+      continue;
+    }
+    if (!entry || typeof entry !== "object") continue;
+    const candidate = entry as { agentType?: unknown; text?: unknown };
+    if (typeof candidate.agentType !== "string" || typeof candidate.text !== "string") continue;
+    normalized.push({ agentType: candidate.agentType, text: candidate.text });
+  }
+  return normalized;
+}
+
+function parseAgentSettings(value: string | undefined): Record<string, unknown> {
+  if (!value) return {};
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : {};
+  } catch {
+    return {};
+  }
+}
+
+function normalizeDirectorInterval(value: unknown, fallback: number, max: number): number {
+  const parsed = typeof value === "number" ? value : typeof value === "string" ? Number(value) : NaN;
+  return Number.isFinite(parsed) && parsed >= 1 ? Math.min(max, Math.floor(parsed)) : fallback;
+}
+
+export function ContextInjectionPanel({
+  chatId,
+  messages,
+  isAgentProcessing,
+  isGenerationBusy = isAgentProcessing,
+  agentConfigs,
+  enabledAgentTypes,
+}: {
+  chatId: string | null;
+  messages: Message[] | undefined;
+  isAgentProcessing: boolean;
+  isGenerationBusy?: boolean;
+  agentConfigs?: AgentConfigRow[];
+  enabledAgentTypes?: Set<string>;
+}) {
+  const qc = useQueryClient();
+  const { retryAgents } = useGenerate();
+  const updateExtra = useUpdateMessageExtra(chatId);
+  const updateDirectorAgent = useUpdateAgentByType();
+  const [open, setOpen] = useState(true);
+  const [drafts, setDrafts] = useState<Record<string, string>>({});
+  const [rerollingType, setRerollingType] = useState<string | null>(null);
+  const [savingType, setSavingType] = useState<string | null>(null);
+  const [savedType, setSavedType] = useState<string | null>(null);
+  /** When true, the textarea for that agent is visible */
+  const [expandedInjections, setExpandedInjections] = useState<Record<string, boolean>>({});
+
+  const target = useMemo(() => findLastAssistant(messages), [messages]);
+  const parsedExtra = useMemo(() => (target ? parseExtra(target.extra) : {}), [target]);
+  const injections = useMemo(() => {
+    return normalizeContextInjections(parsedExtra.contextInjections).filter(
+      (entry) => entry.agentType !== "secret-plot-driver",
+    );
+  }, [parsedExtra.contextInjections]);
+  const hasDirectorInjection = injections.some((entry) => entry.agentType === "director");
+  const showDirectorCadence = (enabledAgentTypes?.has("director") ?? false) || hasDirectorInjection;
+  const directorConfig = useMemo(
+    () => (agentConfigs ?? []).find((config) => config.type === "director") ?? null,
+    [agentConfigs],
+  );
+  const directorCadenceQueryKey = useMemo(() => ["agent-cadence", "director", chatId ?? ""] as const, [chatId]);
+  const directorCadence = useQuery({
+    queryKey: directorCadenceQueryKey,
+    enabled: !!chatId && showDirectorCadence,
+    queryFn: () => api.get<AgentCadenceStatus>(`/agents/cadence/director/${chatId}`),
+    staleTime: 15_000,
+  });
+  const directorIntervalMeta = getAgentRunIntervalMeta("director");
+  const directorSettings = useMemo(
+    () => ({ ...getDefaultBuiltInAgentSettings("director"), ...parseAgentSettings(directorConfig?.settings) }),
+    [directorConfig?.settings],
+  );
+  const directorInterval = directorIntervalMeta
+    ? normalizeDirectorInterval(
+        directorCadence.data?.runInterval ?? directorSettings.runInterval,
+        directorIntervalMeta.defaultValue,
+        directorIntervalMeta.max,
+      )
+    : 1;
+
+  useEffect(() => {
+    const next: Record<string, string> = {};
+    for (const inj of injections) {
+      next[inj.agentType] = inj.text ?? "";
+    }
+    setDrafts(next);
+  }, [target?.id, injections]);
+
+  useEffect(() => {
+    setExpandedInjections({});
+  }, [target?.id]);
+
+  const handleSaveOne = useCallback(
+    (agentType: string) => {
+      const text = drafts[agentType] ?? "";
+      const list = injections.map((inj) => (inj.agentType === agentType ? { agentType, text } : { ...inj }));
+      if (!target || !chatId) return;
+      setSavingType(agentType);
+      setSavedType(null);
+      updateExtra.mutate(
+        { messageId: target.id, extra: { contextInjections: list } },
+        {
+          onSuccess: () => setSavedType(agentType),
+          onSettled: () => setSavingType(null),
+        },
+      );
+    },
+    [chatId, drafts, injections, target, updateExtra],
+  );
+
+  const handleReroll = useCallback(
+    async (agentType: string) => {
+      if (!chatId || !target || isGenerationBusy || rerollingType) return;
+      setRerollingType(agentType);
+      try {
+        await retryAgents(chatId, [agentType], { forMessageId: target.id });
+        await qc.invalidateQueries({ queryKey: chatKeys.messages(chatId) });
+        if (agentType === "director") {
+          await qc.invalidateQueries({ queryKey: directorCadenceQueryKey });
+        }
+      } finally {
+        setRerollingType(null);
+      }
+    },
+    [chatId, target, isGenerationBusy, qc, rerollingType, retryAgents, directorCadenceQueryKey],
+  );
+
+  const handleDirectorIntervalStep = useCallback(
+    async (delta: number) => {
+      if (!directorIntervalMeta || updateDirectorAgent.isPending) return;
+      const next = stepCadenceValue(directorInterval, delta, directorIntervalMeta.max);
+      if (next === directorInterval) return;
+      await updateDirectorAgent.mutateAsync({
+        agentType: "director",
+        settings: { ...directorSettings, runInterval: next },
+      });
+      await qc.invalidateQueries({ queryKey: directorCadenceQueryKey });
+    },
+    [
+      directorInterval,
+      directorIntervalMeta,
+      directorSettings,
+      directorCadenceQueryKey,
+      qc,
+      updateDirectorAgent,
+    ],
+  );
+
+  if (!chatId) return null;
+
+  return (
+    <div className="bg-[var(--popover)]/35 text-[var(--popover-foreground)]">
+      <div className="flex w-full items-center gap-1.5 px-2 py-1.5 text-[0.625rem]">
+        <button
+          type="button"
+          onClick={() => setOpen((o) => !o)}
+          className="group flex min-h-6 min-w-0 flex-1 items-center gap-1.5 rounded-md px-1.5 py-0.5 text-left transition-colors hover:bg-[var(--accent)]/45 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--ring)] max-md:min-h-7"
+          aria-expanded={open}
+        >
+          <ChevronDown
+            size="0.75rem"
+            className={cn("shrink-0 text-[var(--primary)] transition-transform", open && "rotate-180")}
+          />
+          <span className="min-w-0 truncate font-semibold text-[var(--popover-foreground)]/75 group-hover:text-[var(--popover-foreground)]">
+            Cached prompt injections
+          </span>
+        </button>
+        <span className="flex shrink-0 items-center gap-1.5">
+          <HelpTooltip
+            text={CACHED_INJECTIONS_HELP}
+            wide
+            side="left"
+            size="0.75rem"
+            className="text-[var(--muted-foreground)]"
+          />
+          {injections.length > 0 && (
+            <span className="rounded-full bg-[var(--primary)]/15 px-1.5 py-px text-[0.5rem] font-semibold text-[var(--primary)] ring-1 ring-[var(--primary)]/25">
+              {injections.length}
+            </span>
+          )}
+        </span>
+      </div>
+      {open && (
+        <div className="border-t border-[var(--border)] px-2 pb-2 pt-1.5">
+          {showDirectorCadence && directorIntervalMeta && (
+            <DirectorCadenceCard
+              status={directorCadence.data}
+              loading={directorCadence.isLoading}
+              error={directorCadence.isError}
+              interval={directorInterval}
+              maxInterval={directorIntervalMeta.max}
+              canEdit
+              saving={updateDirectorAgent.isPending}
+              onStep={handleDirectorIntervalStep}
+            />
+          )}
+          {!target && (
+            <p className="py-2 text-center text-[0.625rem] text-[var(--muted-foreground)]">
+              No assistant message loaded yet.
+            </p>
+          )}
+          {target && injections.length === 0 && (
+            <p className="rounded-lg border border-[var(--border)] bg-[var(--secondary)]/35 px-3 py-2 text-center text-[0.625rem] leading-relaxed text-[var(--muted-foreground)]">
+              No cached injections on this assistant message yet.
+            </p>
+          )}
+          {target &&
+            injections.map((inj) => {
+              const expanded = !!expandedInjections[inj.agentType];
+              const canReroll = !NON_REROLLABLE_INJECTION_AGENTS.has(inj.agentType);
+              const dirty = (drafts[inj.agentType] ?? "") !== (inj.text ?? "");
+              const saving = savingType === inj.agentType && updateExtra.isPending;
+              const saved = savedType === inj.agentType && !dirty && !saving;
+              const rerollBusy = isGenerationBusy || rerollingType === inj.agentType;
+              return (
+                <div
+                  key={inj.agentType}
+                  className="mb-1 overflow-hidden rounded-lg border border-[var(--border)] bg-[var(--card)]/55 last:mb-0"
+                >
+                  <div className="flex items-center gap-1.5 px-2 py-1.5">
+                    <button
+                      type="button"
+                      onClick={() => setExpandedInjections((m) => ({ ...m, [inj.agentType]: !m[inj.agentType] }))}
+                      className="flex min-h-7 min-w-0 flex-1 items-center gap-1.5 rounded-md text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--ring)]"
+                      title={expanded ? "Collapse output" : "Expand output"}
+                      aria-expanded={expanded}
+                    >
+                      <ChevronDown
+                        size="0.75rem"
+                        className={cn(
+                          "shrink-0 text-[var(--primary)] transition-transform",
+                          expanded ? "rotate-180" : "-rotate-90",
+                        )}
+                      />
+                      <span className="truncate text-[0.625rem] font-semibold text-[var(--popover-foreground)]">
+                        {agentLabel(inj.agentType)}
+                      </span>
+                      {dirty && (
+                        <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--primary)]" title="Unsaved edit" />
+                      )}
+                    </button>
+                    <div className="flex shrink-0 items-center gap-1">
+                      {canReroll && (
+                        <button
+                          type="button"
+                          disabled={isGenerationBusy || !!rerollingType || updateExtra.isPending}
+                          onClick={() => handleReroll(inj.agentType)}
+                          className="inline-flex h-6 w-6 items-center justify-center rounded-md text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)]/55 hover:text-[var(--accent-foreground)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--ring)] disabled:opacity-40 max-md:h-7 max-md:w-7"
+                          title={`Re-run ${agentLabel(inj.agentType)} injection`}
+                          aria-label={`Re-run ${agentLabel(inj.agentType)} injection`}
+                        >
+                          <RefreshCw size="0.625rem" className={cn(rerollBusy && "animate-spin")} />
+                        </button>
+                      )}
+                      <button
+                        type="button"
+                        disabled={updateExtra.isPending || isAgentProcessing}
+                        onClick={() => handleSaveOne(inj.agentType)}
+                        className="inline-flex h-6 w-6 items-center justify-center rounded-md text-[var(--primary)] transition-colors hover:bg-[var(--primary)]/15 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--ring)] disabled:opacity-40 max-md:h-7 max-md:w-7"
+                        title={
+                          saved
+                            ? `${agentLabel(inj.agentType)} injection saved`
+                            : `Save ${agentLabel(inj.agentType)} injection`
+                        }
+                        aria-label={
+                          saved
+                            ? `${agentLabel(inj.agentType)} injection saved`
+                            : `Save ${agentLabel(inj.agentType)} injection`
+                        }
+                      >
+                        {saved ? (
+                          <Check size="0.625rem" />
+                        ) : (
+                          <Save size="0.625rem" className={saving ? "animate-pulse" : ""} />
+                        )}
+                      </button>
+                    </div>
+                  </div>
+                  {expanded && (
+                    <div className="border-t border-[var(--border)] px-1.5 pb-1.5">
+                      <textarea
+                        value={drafts[inj.agentType] ?? ""}
+                        onChange={(e) =>
+                          setDrafts((d) => ({
+                            ...d,
+                            [inj.agentType]: e.target.value,
+                          }))
+                        }
+                        rows={4}
+                        className="mt-1.5 min-h-24 w-full resize-y rounded-md border border-[var(--input)] bg-[var(--secondary)]/45 px-2 py-1.5 font-mono text-[0.625rem] leading-relaxed text-[var(--foreground)] outline-none transition-colors placeholder:text-[var(--muted-foreground)] focus:border-[var(--ring)] focus:ring-1 focus:ring-[var(--ring)]"
+                        spellCheck={false}
+                      />
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function DirectorCadenceCard({
+  status,
+  loading,
+  error,
+  interval,
+  maxInterval,
+  canEdit,
+  saving,
+  onStep,
+}: {
+  status: AgentCadenceStatus | undefined;
+  loading: boolean;
+  error: boolean;
+  interval: number;
+  maxInterval: number;
+  canEdit: boolean;
+  saving: boolean;
+  onStep: (delta: number) => void;
+}) {
+  const remaining = status?.remainingAssistantMessages ?? 0;
+  const statusLabel =
+    interval <= 1
+      ? "Every reply"
+      : loading
+        ? "Checking"
+        : error
+          ? "Unavailable"
+          : remaining <= 0
+            ? "Ready"
+            : `${remaining} left`;
+  const detail =
+    interval <= 1
+      ? "Narrative Director can run on every eligible assistant reply."
+      : loading
+        ? "Checking the latest saved Director run."
+        : error
+          ? "Could not load the countdown. The interval setting still saves normally."
+          : !status?.lastSuccessfulRun
+            ? "No saved Director run yet. The next eligible reply can run it."
+            : remaining <= 0
+              ? "Ready for the next eligible assistant reply."
+              : `Next run after ${remaining} assistant ${remaining === 1 ? "reply" : "replies"}.`;
+  const intervalLabel = interval <= 1 ? "assistant reply" : `${interval} replies`;
+
+  return (
+    <div className="mb-1 overflow-hidden rounded-lg border border-[var(--border)] bg-[var(--card)]/55">
+      <div className="flex items-center gap-1.5 px-2 py-1.5">
+        <div className="min-w-0 flex-1">
+          <div className="flex min-w-0 items-center gap-1.5">
+            <span className="truncate text-[0.625rem] font-semibold text-[var(--popover-foreground)]">
+              Narrative Director
+            </span>
+            <span className="shrink-0 rounded-full bg-[var(--primary)]/15 px-1.5 py-px text-[0.5rem] font-semibold text-[var(--primary)] ring-1 ring-[var(--primary)]/25">
+              {statusLabel}
+            </span>
+          </div>
+          <p className="mt-0.5 line-clamp-2 text-[0.5625rem] leading-snug text-[var(--muted-foreground)]">{detail}</p>
+        </div>
+        <HelpTooltip
+          text={DIRECTOR_CADENCE_HELP}
+          wide
+          side="left"
+          size="0.75rem"
+          className="shrink-0 text-[var(--muted-foreground)]"
+        />
+      </div>
+      <div className="flex items-center justify-between gap-2 border-t border-[var(--border)] px-2 py-1.5">
+        <span className="min-w-0 text-[0.5625rem] text-[var(--muted-foreground)]">
+          Runs every <span className="font-medium text-[var(--popover-foreground)]">{intervalLabel}</span>
+        </span>
+        <div className="flex shrink-0 items-center rounded-md border border-[var(--border)] bg-[var(--secondary)]/35">
+          <button
+            type="button"
+            onClick={() => onStep(-1)}
+            disabled={!canEdit || saving || interval <= 1}
+            className="inline-flex h-6 w-6 items-center justify-center rounded-l-md text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)]/55 hover:text-[var(--accent-foreground)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--ring)] disabled:opacity-40 max-md:h-7 max-md:w-7"
+            title="Decrease Narrative Director interval"
+            aria-label="Decrease Narrative Director interval"
+          >
+            <Minus size="0.625rem" />
+          </button>
+          <span className="min-w-8 px-1 text-center text-[0.5625rem] font-semibold tabular-nums text-[var(--popover-foreground)]">
+            {interval === 1 ? "Every" : interval}
+          </span>
+          <button
+            type="button"
+            onClick={() => onStep(1)}
+            disabled={!canEdit || saving || interval >= maxInterval}
+            className="inline-flex h-6 w-6 items-center justify-center rounded-r-md text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)]/55 hover:text-[var(--accent-foreground)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--ring)] disabled:opacity-40 max-md:h-7 max-md:w-7"
+            title="Increase Narrative Director interval"
+            aria-label="Increase Narrative Director interval"
+          >
+            <Plus size="0.625rem" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/client/src/components/agents/SecretPlotPanel.tsx
+++ b/packages/client/src/components/agents/SecretPlotPanel.tsx
@@ -1,0 +1,543 @@
+// Secret Plot memory editor: read/write agent memory used for prompt injection.
+// Shown in the roleplay Agents menu on the opt-in Secret plot tab.
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { AlertTriangle, Check, ChevronDown, Plus, RefreshCw, Save } from "lucide-react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import type { Message } from "@marinara-engine/shared";
+import { api } from "../../lib/api-client";
+import { cn } from "../../lib/utils";
+import { useGenerate } from "../../hooks/use-generate";
+import { showConfirmDialog } from "../../lib/app-dialogs";
+import { HelpTooltip } from "../ui/HelpTooltip";
+
+const AGENT_TYPE = "secret-plot-driver";
+const SECRET_PLOT_HELP =
+  "Hidden story memory used before replies. Turn guidance can be re-run without replacing the long-term arc.";
+
+function findLastAssistant(messages: Message[] | undefined): Message | null {
+  if (!messages?.length) return null;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i]!.role === "assistant") return messages[i]!;
+  }
+  return null;
+}
+
+type SceneDir = { direction: string; fulfilled?: boolean };
+
+function normalizeSceneDirections(raw: unknown): SceneDir[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.flatMap((entry) => {
+    if (!entry || typeof entry !== "object") return [];
+    const candidate = entry as { direction?: unknown; fulfilled?: unknown };
+    if (typeof candidate.direction !== "string") return [];
+    return [{ direction: candidate.direction, fulfilled: candidate.fulfilled === true }];
+  });
+}
+
+function normalizeFulfilledDirections(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.filter((entry): entry is string => typeof entry === "string");
+}
+
+function memoryToDraft(mem: Record<string, unknown>) {
+  const arcRaw = mem.overarchingArc as Record<string, unknown> | string | undefined;
+  let arcDescription = "";
+  let arcProtagonist = "";
+  let arcCompleted = false;
+  if (arcRaw != null) {
+    if (typeof arcRaw === "object") {
+      arcDescription = String(arcRaw.description ?? "");
+      arcProtagonist = String(arcRaw.protagonistArc ?? "");
+      arcCompleted = arcRaw.completed === true;
+    } else {
+      arcDescription = String(arcRaw);
+    }
+  }
+  const dirs = normalizeSceneDirections(mem.sceneDirections);
+  const staleDetected = mem.staleDetected === true;
+  const fulfilled = normalizeFulfilledDirections(mem.recentlyFulfilled);
+  return {
+    arcDescription,
+    arcProtagonist,
+    arcCompleted,
+    sceneDirections: dirs.map((d) => ({
+      direction: d.direction ?? "",
+      fulfilled: !!d.fulfilled,
+    })),
+    staleDetected,
+    recentlyFulfilledText: fulfilled.join("\n"),
+  };
+}
+
+type SecretPlotDraft = ReturnType<typeof memoryToDraft>;
+
+function draftFingerprint(draft: SecretPlotDraft): string {
+  return JSON.stringify(draft);
+}
+
+export function SecretPlotPanel({
+  chatId,
+  messages,
+  isAgentProcessing,
+  isGenerationBusy = isAgentProcessing,
+}: {
+  chatId: string | null;
+  messages: Message[] | undefined;
+  isAgentProcessing: boolean;
+  isGenerationBusy?: boolean;
+}) {
+  const qc = useQueryClient();
+  const { retryAgents } = useGenerate();
+  const [open, setOpen] = useState(true);
+  const [rerollingMode, setRerollingMode] = useState<"full" | "turn_only" | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [showTurnState, setShowTurnState] = useState(true);
+  const [showArcState, setShowArcState] = useState(false);
+  const [draft, setDraft] = useState<SecretPlotDraft | null>(null);
+  const [savedFingerprint, setSavedFingerprint] = useState<string | null>(null);
+  const draftRef = useRef<SecretPlotDraft | null>(null);
+  const savedFingerprintRef = useRef<string | null>(null);
+
+  const queryKey = useMemo(() => ["agent-memory", AGENT_TYPE, chatId ?? ""] as const, [chatId]);
+
+  const { data, isLoading, isError, refetch } = useQuery({
+    queryKey,
+    enabled: !!chatId,
+    queryFn: async () => {
+      const res = await api.get<{ agentConfigId: string; memory: Record<string, unknown> }>(
+        `/agents/memory/${AGENT_TYPE}/${chatId}`,
+      );
+      return res;
+    },
+  });
+
+  const target = useMemo(() => findLastAssistant(messages), [messages]);
+  const draftSignature = useMemo(() => (draft ? draftFingerprint(draft) : null), [draft]);
+  const hasUnsavedChanges = !!draft && savedFingerprint !== null && draftSignature !== savedFingerprint;
+  const hasArcMemory = !!draft && !!(draft.arcDescription.trim() || draft.arcProtagonist.trim());
+  const saveLabel =
+    !draft
+      ? "Secret plot state unavailable"
+      : saved && !hasUnsavedChanges
+      ? "Secret plot state saved"
+      : hasUnsavedChanges
+        ? "Save secret plot changes"
+        : "Save secret plot state";
+
+  useEffect(() => {
+    draftRef.current = draft;
+  }, [draft]);
+
+  useEffect(() => {
+    savedFingerprintRef.current = savedFingerprint;
+  }, [savedFingerprint]);
+
+  useEffect(() => {
+    draftRef.current = null;
+    savedFingerprintRef.current = null;
+    setDraft(null);
+    setSavedFingerprint(null);
+    setSaved(false);
+  }, [chatId]);
+
+  useEffect(() => {
+    if (!data?.memory) return;
+    const currentDraft = draftRef.current;
+    const currentSavedFingerprint = savedFingerprintRef.current;
+    const currentIsDirty =
+      currentDraft !== null &&
+      currentSavedFingerprint !== null &&
+      draftFingerprint(currentDraft) !== currentSavedFingerprint;
+    if (currentIsDirty) return;
+
+    const nextDraft = memoryToDraft(data.memory);
+    const nextFingerprint = draftFingerprint(nextDraft);
+    draftRef.current = nextDraft;
+    savedFingerprintRef.current = nextFingerprint;
+    setDraft(nextDraft);
+    setSavedFingerprint(nextFingerprint);
+    setSaved(false);
+  }, [data?.memory, data?.agentConfigId]);
+
+  const patchMemory = useCallback(
+    async (patch: Record<string, unknown>) => {
+      if (!chatId) return;
+      await api.patch<{ memory: Record<string, unknown> }>(`/agents/memory/${AGENT_TYPE}/${chatId}`, { patch });
+      await qc.invalidateQueries({ queryKey });
+    },
+    [chatId, qc, queryKey],
+  );
+
+  const handleSave = useCallback(async () => {
+    if (!chatId || saving || !draft) return;
+    setSaving(true);
+    try {
+      const overarchingArc =
+        draft.arcDescription.trim() || draft.arcProtagonist.trim() || draft.arcCompleted
+          ? {
+              description: draft.arcDescription.trim() || undefined,
+              protagonistArc: draft.arcProtagonist.trim() || undefined,
+              completed: draft.arcCompleted,
+            }
+          : null;
+      const sceneDirections = draft.sceneDirections
+        .filter((d) => d.direction.trim())
+        .map((d) => ({ direction: d.direction.trim(), fulfilled: d.fulfilled }));
+      const recentlyFulfilled = draft.recentlyFulfilledText
+        .split("\n")
+        .map((s) => s.trim())
+        .filter(Boolean);
+
+      await patchMemory({
+        ...(overarchingArc ? { overarchingArc } : { overarchingArc: null }),
+        sceneDirections,
+        staleDetected: draft.staleDetected,
+        recentlyFulfilled,
+      });
+      setSavedFingerprint(draftFingerprint(draft));
+      setSaved(true);
+    } finally {
+      setSaving(false);
+    }
+  }, [chatId, draft, patchMemory, saving]);
+
+  const handleReroll = useCallback(
+    async (mode: "full" | "turn_only") => {
+      if (!chatId || !target || isGenerationBusy || rerollingMode) return;
+      if (mode === "full") {
+        const ok = await showConfirmDialog({
+          title: "Re-run Arc Memory",
+          message:
+            "Replace the current Secret Plot arc and scene directions? This will rewrite the hidden long-term plot structure for this chat.",
+          confirmLabel: "Re-run Arc",
+          cancelLabel: "Keep Current Arc",
+          tone: "destructive",
+        });
+        if (!ok) return;
+      } else {
+        const currentDraft = draftRef.current;
+        const currentSavedFingerprint = savedFingerprintRef.current;
+        const currentIsDirty =
+          currentDraft !== null &&
+          currentSavedFingerprint !== null &&
+          draftFingerprint(currentDraft) !== currentSavedFingerprint;
+        if (currentIsDirty) {
+          toast("Local edits will be preserved", {
+            description: "This reroll only updates the backend Secret Plot state for the turn.",
+          });
+        }
+      }
+      setRerollingMode(mode);
+      try {
+        await retryAgents(chatId, [AGENT_TYPE], { forMessageId: target.id, secretPlotRerollMode: mode });
+        await qc.invalidateQueries({ queryKey });
+        await refetch();
+      } finally {
+        setRerollingMode(null);
+      }
+    },
+    [chatId, target, isGenerationBusy, rerollingMode, retryAgents, qc, queryKey, refetch],
+  );
+
+  if (!chatId) return null;
+  const turnRerollBusy = isGenerationBusy || rerollingMode === "turn_only";
+  const fullRerollBusy = isGenerationBusy || rerollingMode === "full";
+
+  return (
+    <div className="bg-[var(--popover)]/35 text-[var(--popover-foreground)]">
+      <div className="flex w-full items-center gap-1.5 px-2 py-1.5 text-[0.625rem]">
+        <button
+          type="button"
+          onClick={() => setOpen((value) => !value)}
+          className="group flex min-h-6 min-w-0 flex-1 items-center gap-1.5 rounded-md px-1.5 py-0.5 text-left transition-colors hover:bg-[var(--accent)]/45 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--ring)] max-md:min-h-7"
+          aria-expanded={open}
+        >
+          <ChevronDown
+            size="0.75rem"
+            className={cn("shrink-0 text-[var(--primary)] transition-transform", open && "rotate-180")}
+          />
+          <span className="min-w-0 truncate font-semibold text-[var(--popover-foreground)]/75 group-hover:text-[var(--popover-foreground)]">
+            Story guidance
+          </span>
+          {hasUnsavedChanges && (
+            <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--primary)]" title="Unsaved edit" />
+          )}
+        </button>
+        <span className="flex shrink-0 items-center gap-1.5">
+          <HelpTooltip
+            text={SECRET_PLOT_HELP}
+            wide
+            side="left"
+            size="0.75rem"
+            className="text-[var(--muted-foreground)]"
+          />
+          <button
+            type="button"
+            disabled={saving || isAgentProcessing || !draft}
+            onClick={handleSave}
+            className="inline-flex h-6 w-6 items-center justify-center rounded-md text-[var(--primary)] transition-colors hover:bg-[var(--primary)]/15 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--ring)] disabled:opacity-40 max-md:h-7 max-md:w-7"
+            title={saveLabel}
+            aria-label={saveLabel}
+          >
+            {saved && !hasUnsavedChanges ? (
+              <Check size="0.625rem" />
+            ) : (
+              <Save size="0.625rem" className={saving ? "animate-pulse" : ""} />
+            )}
+          </button>
+        </span>
+      </div>
+
+      {open && (
+        <div className="border-t border-[var(--border)] px-2 pb-2 pt-1.5">
+          {isLoading && (
+            <p className="py-3 text-center text-[0.625rem] text-[var(--muted-foreground)]">Loading plot state...</p>
+          )}
+          {isError && (
+            <p className="rounded-lg border border-[var(--destructive)]/25 bg-[var(--destructive)]/10 px-3 py-2 text-center text-[0.625rem] text-[var(--destructive)]">
+              Could not load agent memory.
+            </p>
+          )}
+
+          {!isLoading && draft && (
+            <div className="space-y-1.5 text-[0.625rem]">
+              <div className="overflow-hidden rounded-lg border border-[var(--border)] bg-[var(--card)]/55">
+                <div className="flex items-center gap-1.5 px-2 py-1.5">
+                  <button
+                    type="button"
+                    onClick={() => setShowTurnState((value) => !value)}
+                    className="flex min-h-7 min-w-0 flex-1 items-center gap-1.5 rounded-md text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--ring)]"
+                    title={showTurnState ? "Collapse direction" : "Expand direction"}
+                    aria-expanded={showTurnState}
+                  >
+                    <ChevronDown
+                      size="0.75rem"
+                      className={cn(
+                        "shrink-0 text-[var(--primary)] transition-transform",
+                        showTurnState ? "rotate-180" : "-rotate-90",
+                      )}
+                    />
+                    <span className="truncate text-[0.625rem] font-semibold text-[var(--popover-foreground)]">
+                      Scene direction
+                    </span>
+                    {draft.staleDetected && (
+                      <span className="rounded bg-[var(--secondary)]/55 px-1 py-0.5 text-[0.5rem] text-[var(--muted-foreground)]">
+                        Motion
+                      </span>
+                    )}
+                  </button>
+                  <button
+                    type="button"
+                    disabled={isGenerationBusy || !!rerollingMode || !target}
+                    onClick={() => handleReroll("turn_only")}
+                    title={
+                      target
+                        ? "Re-run scene directions for this turn but keep the current arc"
+                        : "No assistant message yet"
+                    }
+                    aria-label="Re-run scene directions"
+                    className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)]/55 hover:text-[var(--accent-foreground)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--ring)] disabled:opacity-40 max-md:h-7 max-md:w-7"
+                  >
+                    <RefreshCw size="0.625rem" className={cn(turnRerollBusy && "animate-spin")} />
+                  </button>
+                </div>
+
+                {showTurnState && (
+                  <div className="space-y-1.5 border-t border-[var(--border)] px-1.5 py-1.5">
+                    {draft.sceneDirections.length === 0 && (
+                      <div className="space-y-1.5 rounded-md border border-[var(--border)] bg-[var(--secondary)]/35 px-2 py-1.5">
+                        <p className="text-[0.5625rem] text-[var(--muted-foreground)]">
+                          No direction currently set.
+                        </p>
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setSaved(false);
+                            setDraft((current) =>
+                              current
+                                ? {
+                                    ...current,
+                                    sceneDirections: [
+                                      ...current.sceneDirections,
+                                      { direction: "", fulfilled: false },
+                                    ],
+                                  }
+                                : current,
+                            );
+                          }}
+                          className="inline-flex min-h-6 items-center gap-1 rounded-md border border-[var(--border)]/70 bg-[var(--card)] px-2 py-1 text-[0.5625rem] font-medium text-[var(--popover-foreground)] transition-colors hover:bg-[var(--accent)]/45 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--ring)]"
+                        >
+                          <Plus size="0.625rem" />
+                          Add direction
+                        </button>
+                      </div>
+                    )}
+                    {draft.sceneDirections.map((row, idx) => (
+                      <div
+                        key={idx}
+                        className="rounded-md border border-[var(--border)]/60 bg-[var(--secondary)]/30 p-1"
+                      >
+                        {(draft.sceneDirections.length > 1 || row.fulfilled) && (
+                          <div className="mb-1 flex items-center justify-between gap-2 px-1 text-[0.5rem] text-[var(--muted-foreground)]">
+                            <span>Direction {idx + 1}</span>
+                            <label className="flex shrink-0 items-center gap-1">
+                              <input
+                                type="checkbox"
+                                checked={row.fulfilled}
+                                onChange={(e) => {
+                                  const next = [...draft.sceneDirections];
+                                  next[idx] = { ...next[idx]!, fulfilled: e.target.checked };
+                                  setSaved(false);
+                                  setDraft((current) => (current ? { ...current, sceneDirections: next } : current));
+                                }}
+                                className="h-2.5 w-2.5 rounded border-[var(--input)] accent-[var(--primary)]"
+                              />
+                              Fulfilled
+                            </label>
+                          </div>
+                        )}
+                        <textarea
+                          value={row.direction}
+                          onChange={(e) => {
+                            const next = [...draft.sceneDirections];
+                            next[idx] = { ...next[idx]!, direction: e.target.value };
+                            setSaved(false);
+                            setDraft((current) => (current ? { ...current, sceneDirections: next } : current));
+                          }}
+                          placeholder="Direction..."
+                          rows={2}
+                          spellCheck={false}
+                          className="min-h-12 w-full resize-y rounded-md border border-[var(--input)] bg-[var(--secondary)]/45 px-2 py-1.5 font-mono text-[0.625rem] leading-relaxed text-[var(--foreground)] outline-none transition-colors placeholder:text-[var(--muted-foreground)] focus:border-[var(--ring)] focus:ring-1 focus:ring-[var(--ring)]"
+                        />
+                      </div>
+                    ))}
+                    <label className="flex min-h-6 items-center justify-between gap-2 rounded-md border border-[var(--border)]/60 bg-[var(--secondary)]/25 px-2 py-1 text-[0.5625rem] text-[var(--muted-foreground)]">
+                      <span>Needs momentum shift</span>
+                      <input
+                        type="checkbox"
+                        checked={draft.staleDetected}
+                        onChange={(e) => {
+                          setSaved(false);
+                          setDraft((current) =>
+                            current ? { ...current, staleDetected: e.target.checked } : current,
+                          );
+                        }}
+                        className="h-3 w-3 rounded border-[var(--input)] accent-[var(--primary)]"
+                      />
+                    </label>
+                  </div>
+                )}
+              </div>
+
+              <div className="overflow-hidden rounded-lg border border-[var(--border)] bg-[var(--card)]/55">
+                <div className="flex items-center gap-1.5 px-2 py-1.5">
+                  <button
+                    type="button"
+                    onClick={() => setShowArcState((value) => !value)}
+                    className="flex min-h-7 min-w-0 flex-1 items-center gap-1.5 rounded-md text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--ring)]"
+                    title={showArcState ? "Collapse arc memory" : "Expand arc memory"}
+                    aria-expanded={showArcState}
+                  >
+                    <ChevronDown
+                      size="0.75rem"
+                      className={cn(
+                        "shrink-0 text-[var(--primary)] transition-transform",
+                        showArcState ? "rotate-180" : "-rotate-90",
+                      )}
+                    />
+                    <span className="truncate text-[0.625rem] font-semibold text-[var(--popover-foreground)]">
+                      Arc memory
+                    </span>
+                    {draft.arcCompleted && (
+                      <span className="rounded bg-[var(--primary)]/15 px-1 py-0.5 text-[0.5rem] font-medium text-[var(--primary)]">
+                        Complete
+                      </span>
+                    )}
+                    {!draft.arcCompleted && hasArcMemory && (
+                      <span className="rounded bg-[var(--secondary)]/55 px-1 py-0.5 text-[0.5rem] text-[var(--muted-foreground)]">
+                        Active
+                      </span>
+                    )}
+                  </button>
+                  <button
+                    type="button"
+                    disabled={isGenerationBusy || !!rerollingMode || !target}
+                    onClick={() => handleReroll("full")}
+                    title={target ? "Re-run full secret plot state" : "No assistant message yet"}
+                    aria-label="Re-run full secret plot state"
+                    className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)]/55 hover:text-[var(--accent-foreground)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--ring)] disabled:opacity-40 max-md:h-7 max-md:w-7"
+                  >
+                    <RefreshCw size="0.625rem" className={cn(fullRerollBusy && "animate-spin")} />
+                  </button>
+                </div>
+
+                {showArcState && (
+                  <div className="space-y-1.5 border-t border-[var(--border)] px-1.5 py-1.5">
+                    <p className="flex items-start gap-1.5 rounded-md border border-[var(--destructive)]/20 bg-[var(--destructive)]/10 px-2 py-1 text-[0.5625rem] leading-snug text-[var(--destructive)]">
+                      <AlertTriangle size="0.625rem" className="mt-0.5 shrink-0" />
+                      <span>This section exposes hidden long-term plot structure.</span>
+                    </p>
+                    <div>
+                      <div className="mb-0.5 flex min-h-5 items-center justify-between gap-2 text-[0.5625rem] font-medium text-[var(--muted-foreground)]">
+                        <span>Arc description</span>
+                        <label
+                          className="inline-flex shrink-0 items-center gap-1 rounded border border-[var(--border)]/70 bg-[var(--secondary)]/30 px-1.5 py-0.5 text-[0.5rem] font-medium transition-colors hover:bg-[var(--accent)]/45 hover:text-[var(--accent-foreground)]"
+                          title="Mark this long-term arc as complete without deleting the arc notes."
+                          aria-label="Mark this long-term arc as complete"
+                        >
+                          <input
+                            type="checkbox"
+                            checked={draft.arcCompleted}
+                            onChange={(e) => {
+                              setSaved(false);
+                              setDraft((current) =>
+                                current ? { ...current, arcCompleted: e.target.checked } : current,
+                              );
+                            }}
+                            className="h-2.5 w-2.5 rounded border-[var(--input)] accent-[var(--primary)]"
+                          />
+                          Complete
+                        </label>
+                      </div>
+                      <textarea
+                        value={draft.arcDescription}
+                        onChange={(e) => {
+                          setSaved(false);
+                          setDraft((current) =>
+                            current ? { ...current, arcDescription: e.target.value } : current,
+                          );
+                        }}
+                        rows={3}
+                        spellCheck={false}
+                        className="w-full resize-y rounded-md border border-[var(--input)] bg-[var(--secondary)]/45 px-2 py-1.5 font-mono text-[0.625rem] leading-relaxed text-[var(--foreground)] outline-none transition-colors focus:border-[var(--ring)] focus:ring-1 focus:ring-[var(--ring)]"
+                      />
+                    </div>
+                    <div>
+                      <label className="mb-0.5 block text-[0.5625rem] font-medium text-[var(--muted-foreground)]">
+                        Protagonist arc
+                      </label>
+                      <textarea
+                        value={draft.arcProtagonist}
+                        onChange={(e) => {
+                          setSaved(false);
+                          setDraft((current) =>
+                            current ? { ...current, arcProtagonist: e.target.value } : current,
+                          );
+                        }}
+                        rows={2}
+                        spellCheck={false}
+                        className="w-full resize-y rounded-md border border-[var(--input)] bg-[var(--secondary)]/45 px-2 py-1.5 font-mono text-[0.625rem] leading-relaxed text-[var(--foreground)] outline-none transition-colors focus:border-[var(--ring)] focus:ring-1 focus:ring-[var(--ring)]"
+                      />
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -808,6 +808,7 @@ export function ChatRoleplaySurface({
                         onRerunSingleTracker={onRerunSingleTracker}
                         enabledAgentTypes={enabledAgentTypes}
                         manualTrackers={!!chatMeta.manualTrackers}
+                        injectionSourceMessages={messages}
                       />
                     </Suspense>
                   </div>
@@ -887,6 +888,7 @@ export function ChatRoleplaySurface({
                         enabledAgentTypes={enabledAgentTypes}
                         manualTrackers={!!chatMeta.manualTrackers}
                         mobileCompact
+                        injectionSourceMessages={messages}
                       />
                     </Suspense>
                     <div className="flex items-center gap-1.5">

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -227,6 +227,12 @@ function normalizeNonNegativeInteger(value: unknown, fallback: number, max: numb
   return Math.max(0, Math.min(max, Math.trunc(value)));
 }
 
+function getChatActiveAgentIds(chat: Chat): string[] {
+  const metadata = typeof chat.metadata === "string" ? JSON.parse(chat.metadata) : (chat.metadata ?? {});
+  const activeIds = metadata && typeof metadata === "object" ? (metadata as { activeAgentIds?: unknown }).activeAgentIds : [];
+  return Array.isArray(activeIds) ? activeIds.filter((id): id is string => typeof id === "string") : [];
+}
+
 export function ChatSettingsDrawer({
   chat,
   open,
@@ -722,17 +728,97 @@ export function ChatSettingsDrawer({
     updateMeta.mutate({ id: chat.id, activeLorebookIds: current });
   };
 
-  const toggleAgent = (agentId: string) => {
-    const current = [...activeAgentIds];
+  const hasSecretPlotMemory = (memory: Record<string, unknown> | null | undefined) => {
+    if (!memory) return false;
+    const arc = memory.overarchingArc;
+    if (typeof arc === "string" && arc.trim()) return true;
+    if (arc && typeof arc === "object") {
+      const arcRecord = arc as Record<string, unknown>;
+      if (
+        String(arcRecord.description ?? "").trim() ||
+        String(arcRecord.protagonistArc ?? "").trim() ||
+        arcRecord.completed === true
+      ) {
+        return true;
+      }
+    }
+
+    const sceneDirections = memory.sceneDirections;
+    if (
+      Array.isArray(sceneDirections) &&
+      sceneDirections.some(
+        (entry) =>
+          typeof entry === "string"
+            ? entry.trim()
+            : !!(entry && typeof entry === "object" && String((entry as Record<string, unknown>).direction ?? "").trim()),
+      )
+    ) {
+      return true;
+    }
+
+    const pacing = memory.pacing;
+    if (typeof pacing === "string" ? pacing.trim() : pacing != null) return true;
+    const recentlyFulfilled = memory.recentlyFulfilled;
+    return Array.isArray(recentlyFulfilled) && recentlyFulfilled.some((entry) => String(entry ?? "").trim());
+  };
+
+  const toggleAgent = async (agentId: string) => {
+    const readLatestActiveAgentIds = () => {
+      const latestChat = qc.getQueryData<Chat>(chatKeys.detail(chat.id));
+      return latestChat ? getChatActiveAgentIds(latestChat) : [...activeAgentIds];
+    };
+    const wasRemoving = readLatestActiveAgentIds().includes(agentId);
+    if (wasRemoving && agentId === "secret-plot-driver") {
+      let shouldWarn: boolean;
+      try {
+        const res = await api.get<{ memory: Record<string, unknown> }>(`/agents/memory/${agentId}/${chat.id}`);
+        shouldWarn = hasSecretPlotMemory(res.memory);
+      } catch {
+        shouldWarn = true;
+      }
+      if (shouldWarn) {
+        const ok = await showConfirmDialog({
+          title: "Remove Secret Plot Driver",
+          message:
+            "Remove Secret Plot Driver from this chat? This will wipe its hidden plot memory for this chat, including the current arc and scene directions. This cannot be undone.",
+          confirmLabel: "Remove Agent",
+          tone: "destructive",
+        });
+        if (!ok) return;
+      }
+    }
+
+    const current = readLatestActiveAgentIds();
     const idx = current.indexOf(agentId);
     const isRemoving = idx >= 0;
     if (isRemoving) current.splice(idx, 1);
     else current.push(agentId);
-    updateMeta.mutate({ id: chat.id, activeAgentIds: current });
-
-    // When removing an agent that stores persistent memory, clean it up
-    if (isRemoving && agentId === "secret-plot-driver") {
-      api.delete(`/agents/memory/${agentId}/${chat.id}`).catch(() => {});
+    let metadataSaved = false;
+    try {
+      await updateMeta.mutateAsync(
+        { id: chat.id, activeAgentIds: current },
+        {
+          onSuccess: async () => {
+            metadataSaved = true;
+            // When removing an agent that stores persistent memory, clean it up after metadata is saved.
+            if (isRemoving && agentId === "secret-plot-driver") {
+              await api.delete(`/agents/memory/${agentId}/${chat.id}`);
+            }
+          },
+        },
+      );
+    } catch (error) {
+      if (metadataSaved && isRemoving && agentId === "secret-plot-driver") {
+        const rollbackIds = Array.from(new Set([...readLatestActiveAgentIds(), agentId]));
+        await updateMeta.mutateAsync({ id: chat.id, activeAgentIds: rollbackIds }).catch(() => undefined);
+      }
+      await showAlertDialog({
+        title: isRemoving ? "Couldn't Remove Agent" : "Couldn't Add Agent",
+        message:
+          error instanceof Error
+            ? error.message
+            : "The agent list could not be updated. Please try again.",
+      });
     }
   };
 
@@ -931,6 +1017,11 @@ export function ChatSettingsDrawer({
       await updateMeta.mutateAsync({
         id: chat.id,
         activeAgentIds: Array.from(new Set([...activeAgentIds, agent.id])),
+        ...(agent.id === "secret-plot-driver"
+          ? {
+              showSecretPlotPanel: true,
+            }
+          : {}),
       });
       setAgentAddPreview(null);
     } catch (error) {
@@ -3528,38 +3619,121 @@ export function ChatSettingsDrawer({
                               description={cat.description}
                               count={activeInCat.length}
                             >
+                              {cat.key === "writer" && (
+                                <button
+                                  type="button"
+                                  onClick={() =>
+                                    updateMeta.mutate({
+                                      id: chat.id,
+                                      showInjectionsPanel: metadata.showInjectionsPanel !== true,
+                                    })
+                                  }
+                                  aria-pressed={metadata.showInjectionsPanel === true}
+                                  className="ml-auto flex w-fit max-w-full items-center gap-2 rounded-md bg-[var(--background)]/20 px-1.5 py-1 text-left text-[0.5625rem] text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)]/35 hover:text-[var(--foreground)]"
+                                  title={
+                                    metadata.showInjectionsPanel === true
+                                      ? "Hide the Injections tab in the roleplay Agents menu. This is mainly for troubleshooting Prose Guardian, Narrative Director, or custom injected text before regenerating the current reply."
+                                      : "Show the Injections tab in the roleplay Agents menu. This is mainly for troubleshooting Prose Guardian, Narrative Director, or custom injected text before regenerating the current reply."
+                                  }
+                                >
+                                  <span className="flex min-w-0 items-center gap-1.5">
+                                    <FilePlus2 size="0.625rem" className="shrink-0 text-[var(--primary)]" />
+                                    <span className="truncate font-medium">Injections tab</span>
+                                  </span>
+                                  <span
+                                    className={cn(
+                                      "h-3.5 w-6 shrink-0 rounded-full p-0.5 transition-colors",
+                                      metadata.showInjectionsPanel === true
+                                        ? "bg-[var(--primary)]"
+                                        : "bg-[var(--muted-foreground)]/50",
+                                    )}
+                                  >
+                                    <span
+                                      className={cn(
+                                        "block h-2.5 w-2.5 rounded-full bg-white shadow-sm transition-transform",
+                                        metadata.showInjectionsPanel === true && "translate-x-2.5",
+                                      )}
+                                    />
+                                  </span>
+                                </button>
+                              )}
                               {/* Active agents in this category */}
                               {activeInCat.length > 0 && (
                                 <div className="flex flex-col gap-1 mb-1.5">
                                   {activeInCat.map((agent) => {
                                     const tokenEst = agentLoadCost.tokensByType.get(agent.id);
+                                    const isSecretPlotDriver = agent.id === "secret-plot-driver";
                                     return (
                                       <div
                                         key={agent.id}
-                                        className="flex items-center gap-2.5 rounded-lg bg-[var(--primary)]/10 px-3 py-2 ring-1 ring-[var(--primary)]/30"
+                                        className="rounded-lg bg-[var(--primary)]/10 px-3 py-2 ring-1 ring-[var(--primary)]/30"
                                       >
-                                        <Sparkles size="0.875rem" className="text-[var(--primary)]" />
-                                        <div className="flex-1 min-w-0">
-                                          <span className="block truncate text-xs">{agent.name}</span>
-                                          <span className="mt-0.5 block text-[0.625rem] leading-tight text-[var(--muted-foreground)] line-clamp-2">
-                                            {agent.description}
-                                          </span>
-                                        </div>
-                                        {tokenEst != null ? (
-                                          <span
-                                            className="shrink-0 tabular-nums text-[0.625rem] text-[var(--muted-foreground)]"
-                                            title={`~${tokenEst.toLocaleString()} tokens of agent instructions (estimated)`}
+                                        <div className="flex items-start gap-2.5">
+                                          <Sparkles size="0.875rem" className="mt-0.5 shrink-0 text-[var(--primary)]" />
+                                          <div className="min-w-0 flex-1">
+                                            <div className="flex min-w-0 items-center gap-1.5">
+                                              <span className="block min-w-0 truncate text-xs">{agent.name}</span>
+                                              {tokenEst != null ? (
+                                                <span
+                                                  className="shrink-0 tabular-nums text-[0.625rem] text-[var(--muted-foreground)]"
+                                                  title={`~${tokenEst.toLocaleString()} tokens of agent instructions (estimated)`}
+                                                >
+                                                  ~{tokenEst.toLocaleString()}
+                                                </span>
+                                              ) : null}
+                                            </div>
+                                            <span className="mt-0.5 block text-[0.625rem] leading-tight text-[var(--muted-foreground)] line-clamp-2">
+                                              {agent.description}
+                                            </span>
+                                          </div>
+                                          <button
+                                            onClick={() => {
+                                              void toggleAgent(agent.id);
+                                            }}
+                                            className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-[var(--muted-foreground)] transition-colors hover:bg-[var(--destructive)]/15 hover:text-[var(--destructive)]"
+                                            title="Remove from chat"
                                           >
-                                            ~{tokenEst.toLocaleString()}
-                                          </span>
-                                        ) : null}
-                                        <button
-                                          onClick={() => toggleAgent(agent.id)}
-                                          className="flex h-5 w-5 items-center justify-center rounded-md text-[var(--muted-foreground)] transition-colors hover:bg-[var(--destructive)]/15 hover:text-[var(--destructive)]"
-                                          title="Remove from chat"
-                                        >
-                                          <Trash2 size="0.6875rem" />
-                                        </button>
+                                            <Trash2 size="0.6875rem" />
+                                          </button>
+                                        </div>
+                                        {isSecretPlotDriver && (
+                                          <button
+                                            type="button"
+                                            onClick={() =>
+                                              updateMeta.mutate({
+                                                id: chat.id,
+                                                showSecretPlotPanel: metadata.showSecretPlotPanel !== true,
+                                              })
+                                            }
+                                            aria-pressed={metadata.showSecretPlotPanel === true}
+                                            className="ml-auto mt-1.5 flex w-fit max-w-full items-center gap-2 rounded-md bg-[var(--background)]/20 px-1.5 py-1 text-left text-[0.5625rem] text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)]/35 hover:text-[var(--foreground)]"
+                                            title={
+                                              metadata.showSecretPlotPanel === true
+                                                ? "Hide the Secret Plot tab in the roleplay Agents menu. That tab lets you inspect and edit the Secret Plot Driver's hidden arc memory and scene directions for this chat."
+                                                : "Show the Secret Plot tab in the roleplay Agents menu. Use it to inspect and edit the Secret Plot Driver's hidden arc memory and scene directions for this chat."
+                                            }
+                                          >
+                                            <span className="flex min-w-0 items-center gap-1.5">
+                                              <Brain size="0.625rem" className="shrink-0 text-[var(--primary)]" />
+                                              <span className="truncate font-medium">Secret Plot tab</span>
+                                            </span>
+                                            <span
+                                              className={cn(
+                                                "h-3.5 w-6 shrink-0 rounded-full p-0.5 transition-colors",
+                                                metadata.showSecretPlotPanel === true
+                                                  ? "bg-[var(--primary)]"
+                                                  : "bg-[var(--muted-foreground)]/50",
+                                              )}
+                                            >
+                                              <span
+                                                className={cn(
+                                                  "block h-2.5 w-2.5 rounded-full bg-white shadow-sm transition-transform",
+                                                  metadata.showSecretPlotPanel === true && "translate-x-2.5",
+                                                )}
+                                              />
+                                            </span>
+                                          </button>
+                                        )}
                                       </div>
                                     );
                                   })}
@@ -3628,7 +3802,9 @@ export function ChatSettingsDrawer({
                                           </span>
                                         ) : null}
                                         <button
-                                          onClick={() => toggleAgent(agent.id)}
+                                          onClick={() => {
+                                            void toggleAgent(agent.id);
+                                          }}
                                           className="flex h-5 w-5 items-center justify-center rounded-md text-[var(--muted-foreground)] transition-colors hover:bg-[var(--destructive)]/15 hover:text-[var(--destructive)]"
                                           title="Remove from chat"
                                         >

--- a/packages/client/src/components/chat/RoleplayHUD.tsx
+++ b/packages/client/src/components/chat/RoleplayHUD.tsx
@@ -26,7 +26,8 @@ import { cn } from "../../lib/utils";
 import { api } from "../../lib/api-client";
 import { useGameStateStore } from "../../stores/game-state.store";
 import { useAgentStore } from "../../stores/agent.store";
-import { useAgentConfigs, useCustomAgentRuns } from "../../hooks/use-agents";
+import { useAgentConfigs, useCustomAgentRuns, type AgentConfigRow } from "../../hooks/use-agents";
+import { useChat } from "../../hooks/use-chats";
 import { useUIStore } from "../../stores/ui.store";
 import type {
   GameState,
@@ -35,8 +36,11 @@ import type {
   InventoryItem,
   QuestProgress,
   CustomTrackerField,
+  Message,
 } from "@marinara-engine/shared";
 import type { HudPosition } from "../../stores/ui.store";
+
+const ACTIONS_DROPDOWN_WIDTH_PX = 288;
 
 interface RoleplayHUDProps {
   chatId: string;
@@ -44,12 +48,15 @@ interface RoleplayHUDProps {
   layout?: HudPosition;
   isStreaming: boolean;
   onRetriggerTrackers?: () => void;
+  /** Re-run one tracker agent only (same pipeline as full tracker run). */
   onRerunSingleTracker?: (agentType: string) => void;
   onRetryFailedAgents?: () => void;
   /** When true, tracker agents are manual — show a trigger button in the widget strip */
   manualTrackers?: boolean;
   /** When provided, overrides the globally-computed set so that only per-chat agents show widgets. */
   enabledAgentTypes?: Set<string>;
+  /** Chat messages (chronological) — used to resolve cached prompt injections on the latest assistant reply */
+  injectionSourceMessages?: Message[];
 }
 
 const RoleplayHUDActionsMenu = lazy(async () =>
@@ -86,6 +93,7 @@ export function RoleplayHUD({
   manualTrackers,
   mobileCompact,
   enabledAgentTypes: enabledAgentTypesProp,
+  injectionSourceMessages,
 }: RoleplayHUDProps & { mobileCompact?: boolean }) {
   const [agentsOpen, setAgentsOpen] = useState(false);
   const gameState = useGameStateStore((s) => s.current);
@@ -103,6 +111,25 @@ export function RoleplayHUD({
     return set;
   }, [agentConfigs]);
   const enabledAgentTypes = enabledAgentTypesProp ?? globalEnabledAgentTypes;
+
+  const { data: chatForAgentsMenu } = useChat(chatId);
+  const agentsMenuMetadata = useMemo(() => {
+    const raw = chatForAgentsMenu?.metadata;
+    let m: Record<string, unknown> = {};
+    if (typeof raw === "string") {
+      try {
+        m = JSON.parse(raw) as Record<string, unknown>;
+      } catch {
+        m = {};
+      }
+    } else if (raw && typeof raw === "object") {
+      m = raw as Record<string, unknown>;
+    }
+    return m;
+  }, [chatForAgentsMenu?.metadata]);
+  const showInjectionsTab = agentsMenuMetadata.showInjectionsPanel === true;
+  const showSecretPlotTab =
+    agentsMenuMetadata.showSecretPlotPanel === true && enabledAgentTypes.has("secret-plot-driver");
 
   const thoughtBubbles = useAgentStore((s) => s.thoughtBubbles);
   const isAgentProcessing = useAgentStore((s) => s.isProcessing);
@@ -294,10 +321,13 @@ export function RoleplayHUD({
       {/* Actions (Agents + Clear) */}
       <ActionsGroup
         chatId={chatId}
+        injectionSourceMessages={injectionSourceMessages}
+        agentConfigs={agentConfigs}
         isVertical={isVertical}
         agentsOpen={agentsOpen}
         setAgentsOpen={setAgentsOpen}
         isAgentProcessing={isAgentProcessing}
+        isGenerationBusy={isTrackerBusy}
         thoughtBubbles={thoughtBubbles}
         clearThoughtBubbles={clearThoughtBubbles}
         dismissThoughtBubble={dismissThoughtBubble}
@@ -306,6 +336,8 @@ export function RoleplayHUD({
         onRetriggerTrackers={onRetriggerTrackers}
         onRetryFailedAgents={onRetryFailedAgents}
         failedAgentTypes={failedAgentTypes}
+        showInjectionsTab={showInjectionsTab}
+        showSecretPlotTab={showSecretPlotTab}
       />
 
       {/* ── Mobile: combined widgets, centered ── */}
@@ -496,10 +528,13 @@ function DeferredActionsFallback({ isAgentProcessing }: { isAgentProcessing: boo
 
 interface ActionsGroupProps {
   chatId: string;
+  injectionSourceMessages?: Message[];
+  agentConfigs?: AgentConfigRow[];
   isVertical: boolean;
   agentsOpen: boolean;
   setAgentsOpen: (v: boolean) => void;
   isAgentProcessing: boolean;
+  isGenerationBusy: boolean;
   thoughtBubbles: Array<{ agentId: string; agentName: string; content: string; timestamp: number }>;
   clearThoughtBubbles: () => void;
   dismissThoughtBubble: (i: number) => void;
@@ -508,14 +543,19 @@ interface ActionsGroupProps {
   onRetriggerTrackers?: () => void;
   onRetryFailedAgents?: () => void;
   failedAgentTypes: string[];
+  showInjectionsTab?: boolean;
+  showSecretPlotTab?: boolean;
 }
 
 function ActionsGroup({
   chatId,
+  injectionSourceMessages,
+  agentConfigs,
   isVertical: _isVertical,
   agentsOpen,
   setAgentsOpen,
   isAgentProcessing,
+  isGenerationBusy,
   thoughtBubbles,
   clearThoughtBubbles,
   dismissThoughtBubble,
@@ -524,6 +564,8 @@ function ActionsGroup({
   onRetriggerTrackers,
   onRetryFailedAgents,
   failedAgentTypes,
+  showInjectionsTab,
+  showSecretPlotTab,
 }: ActionsGroupProps) {
   const btnRef = useRef<HTMLButtonElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -540,7 +582,7 @@ function ActionsGroup({
     const rect = btnRef.current.getBoundingClientRect();
     const maxH = 320;
     const top = rect.bottom + 4 + maxH > window.innerHeight ? rect.top - maxH - 4 : rect.bottom + 4;
-    const left = Math.min(rect.left, window.innerWidth - 288 - 8);
+    const left = Math.min(rect.left, window.innerWidth - ACTIONS_DROPDOWN_WIDTH_PX - 8);
     setPos({ top, left });
   }, [agentsOpen]);
 
@@ -578,12 +620,17 @@ function ActionsGroup({
       >
         <Suspense fallback={<DeferredActionsFallback isAgentProcessing={isAgentProcessing} />}>
           <RoleplayHUDActionsMenu
+            chatId={chatId}
+            injectionSourceMessages={injectionSourceMessages}
             isAgentProcessing={isAgentProcessing}
+            isGenerationBusy={isGenerationBusy}
             thoughtBubbles={thoughtBubbles}
             clearThoughtBubbles={clearThoughtBubbles}
             dismissThoughtBubble={dismissThoughtBubble}
             customAgentRuns={customAgentRuns}
             customAgentRunsLoading={customAgentRunsLoading}
+            agentConfigs={agentConfigs}
+            enabledAgentTypes={enabledAgentTypes}
             showEcho={showEcho}
             echoChamberOpen={echoChamberOpen}
             toggleEchoChamber={toggleEchoChamber}
@@ -593,6 +640,8 @@ function ActionsGroup({
             onRetryFailedAgents={onRetryFailedAgents}
             failedAgentTypes={failedAgentTypes}
             onClose={() => setAgentsOpen(false)}
+            showInjectionsTab={showInjectionsTab}
+            showSecretPlotTab={showSecretPlotTab}
           />
         </Suspense>
       </div>,

--- a/packages/client/src/components/chat/RoleplayHUDActionsMenu.tsx
+++ b/packages/client/src/components/chat/RoleplayHUDActionsMenu.tsx
@@ -1,6 +1,23 @@
-import { useEffect, useMemo, useState } from "react";
-import { AlertTriangle, Check, Code2, MessageCircle, Pencil, RefreshCw, Sparkles, Trash2, X } from "lucide-react";
-import { useUpdateAgentRunData, type AgentRunRow } from "../../hooks/use-agents";
+import { lazy, Suspense, useEffect, useMemo, useState } from "react";
+import {
+  AlertTriangle,
+  Check,
+  ChevronDown,
+  Code2,
+  MessageCircle,
+  Pencil,
+  RefreshCw,
+  Sparkles,
+  Trash2,
+  X,
+} from "lucide-react";
+import { BUILT_IN_AGENTS, type Message } from "@marinara-engine/shared";
+import { useUpdateAgentRunData, type AgentConfigRow, type AgentRunRow } from "../../hooks/use-agents";
+import { ContextInjectionPanel } from "../agents/ContextInjectionPanel";
+
+const SecretPlotPanel = lazy(async () =>
+  import("../agents/SecretPlotPanel").then((m) => ({ default: m.SecretPlotPanel })),
+);
 
 interface ThoughtBubble {
   agentId: string;
@@ -9,13 +26,20 @@ interface ThoughtBubble {
   timestamp: number;
 }
 
+type AgentsMenuTab = "activity" | "injections" | "secret";
+
 interface RoleplayHUDActionsMenuProps {
+  chatId: string;
+  injectionSourceMessages?: Message[];
   isAgentProcessing: boolean;
+  isGenerationBusy?: boolean;
   thoughtBubbles: ThoughtBubble[];
   clearThoughtBubbles: () => void;
   dismissThoughtBubble: (index: number) => void;
   customAgentRuns: AgentRunRow[];
   customAgentRunsLoading: boolean;
+  agentConfigs?: AgentConfigRow[];
+  enabledAgentTypes?: Set<string>;
   showEcho: boolean;
   echoChamberOpen: boolean;
   toggleEchoChamber: () => void;
@@ -25,15 +49,22 @@ interface RoleplayHUDActionsMenuProps {
   onRetryFailedAgents?: () => void;
   failedAgentTypes?: string[];
   onClose: () => void;
+  showInjectionsTab?: boolean;
+  showSecretPlotTab?: boolean;
 }
 
 export function RoleplayHUDActionsMenu({
+  chatId,
+  injectionSourceMessages,
   isAgentProcessing,
+  isGenerationBusy = isAgentProcessing,
   thoughtBubbles,
   clearThoughtBubbles,
   dismissThoughtBubble,
   customAgentRuns,
   customAgentRunsLoading,
+  agentConfigs,
+  enabledAgentTypes,
   showEcho,
   echoChamberOpen,
   toggleEchoChamber,
@@ -43,220 +74,343 @@ export function RoleplayHUDActionsMenu({
   onRetryFailedAgents,
   failedAgentTypes,
   onClose,
+  showInjectionsTab,
+  showSecretPlotTab,
 }: RoleplayHUDActionsMenuProps) {
+  const [tab, setTab] = useState<AgentsMenuTab>("activity");
   const uniqueAgentCount = new Set(thoughtBubbles.map((bubble) => bubble.agentId)).size;
   const hasCustomRuns = customAgentRuns.length > 0;
+  const injectableCustomRuns = useMemo(
+    () => getLatestInjectableCustomRuns(customAgentRuns, agentConfigs ?? [], enabledAgentTypes),
+    [customAgentRuns, agentConfigs, enabledAgentTypes],
+  );
+  const hasActiveCustomPromptAgent = useMemo(
+    () => hasActiveInjectableCustomAgent(agentConfigs ?? [], enabledAgentTypes),
+    [agentConfigs, enabledAgentTypes],
+  );
   const hasAnyActivity = isAgentProcessing || thoughtBubbles.length > 0 || hasCustomRuns || customAgentRunsLoading;
+  const tabs = [
+    { id: "activity" as const, label: "Activity" },
+    ...(showInjectionsTab ? [{ id: "injections" as const, label: "Injections" }] : []),
+    ...(showSecretPlotTab ? [{ id: "secret" as const, label: "Secret plot" }] : []),
+  ] as const;
+  const currentTabIndex = tabs.findIndex((t) => t.id === tab);
+  const safeTabIndex = currentTabIndex >= 0 ? currentTabIndex : 0;
+  const currentTab = tabs[safeTabIndex] ?? tabs[0];
+  const activeTab = currentTab.id;
+  const showTrackerActions = activeTab === "activity";
+  const showRetryFailedAction = !!(onRetryFailedAgents && failedAgentTypes && failedAgentTypes.length > 0);
+  const showFooterActions = showEcho || showTrackerActions || showRetryFailedAction;
+
+  useEffect(() => {
+    if (!showInjectionsTab && tab === "injections") {
+      setTab("activity");
+      return;
+    }
+    if (!showSecretPlotTab && tab === "secret") {
+      setTab("activity");
+    }
+  }, [showInjectionsTab, showSecretPlotTab, tab]);
 
   return (
     <>
-      {isAgentProcessing && (
-        <div className="flex items-center gap-2 border-b border-white/5 px-3 py-2">
-          <Sparkles size="0.75rem" className="text-purple-400 animate-pulse" />
-          <span className="text-[0.625rem] text-purple-300/80">Agents thinking…</span>
+      {tabs.length > 1 && (
+        <div className="border-b border-[var(--border)] p-1">
+          <div className="flex rounded-lg bg-[var(--secondary)]/40 p-0.5 ring-1 ring-[var(--border)]">
+            {tabs.map((item) => {
+              const active = currentTab.id === item.id;
+              return (
+                <button
+                  key={item.id}
+                  type="button"
+                  onClick={() => setTab(item.id)}
+                  title={
+                    item.id === "secret"
+                      ? "Values here are stored in agent memory - the same source used when injecting arc and directions before each reply."
+                      : undefined
+                  }
+                  className={
+                    active
+                      ? "min-h-6 min-w-0 flex-1 rounded-md bg-[var(--primary)]/15 px-1.5 py-0.5 text-center text-[0.5625rem] font-semibold text-[var(--primary)] ring-1 ring-[var(--primary)]/25 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--ring)] max-md:min-h-7"
+                      : "min-h-6 min-w-0 flex-1 rounded-md px-1.5 py-0.5 text-center text-[0.5625rem] font-medium text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)]/45 hover:text-[var(--accent-foreground)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--ring)] max-md:min-h-7"
+                  }
+                >
+                  <span className="block truncate">{item.label}</span>
+                </button>
+              );
+            })}
+          </div>
         </div>
       )}
-      {!hasAnyActivity && (
-        <div className="px-3 py-4 text-center text-[0.625rem] text-white/30">No agent activity yet</div>
-      )}
-      {thoughtBubbles.length > 0 && (
+
+      {activeTab === "activity" && (
         <>
-          <div className="flex items-center justify-between border-b border-white/5 px-3 py-1.5">
-            <span className="text-[0.625rem] text-white/40">
-              {uniqueAgentCount} agent{uniqueAgentCount !== 1 ? "s" : ""} triggered
-            </span>
-            <button
-              onClick={clearThoughtBubbles}
-              className="text-[0.625rem] text-white/30 hover:text-white/60 transition-colors"
-            >
-              Clear all
-            </button>
-          </div>
-          <div className="flex flex-col gap-1 p-2">
-            {thoughtBubbles.map((bubble, index) => (
-              <div
-                key={`${bubble.agentId}-${bubble.timestamp}`}
-                className="relative rounded-lg bg-white/5 p-2 text-[0.625rem]"
-              >
+          {isAgentProcessing && (
+            <div className="flex items-center gap-2 border-b border-white/5 px-3 py-2">
+              <Sparkles size="0.75rem" className="text-purple-400 animate-pulse" />
+              <span className="text-[0.625rem] text-purple-300/80">Agents thinking...</span>
+            </div>
+          )}
+          {!hasAnyActivity && (
+            <div className="px-3 py-4 text-center text-[0.625rem] text-white/30">No agent activity yet</div>
+          )}
+          {thoughtBubbles.length > 0 && (
+            <>
+              <div className="flex items-center justify-between border-b border-white/5 px-3 py-1.5">
+                <span className="text-[0.625rem] text-white/40">
+                  {uniqueAgentCount} agent{uniqueAgentCount !== 1 ? "s" : ""} triggered
+                </span>
                 <button
-                  onClick={() => dismissThoughtBubble(index)}
-                  className="absolute right-1.5 top-1.5 text-white/20 hover:text-white/60 transition-colors"
+                  onClick={clearThoughtBubbles}
+                  className="text-[0.625rem] text-white/30 transition-colors hover:text-white/60"
                 >
-                  <X size="0.625rem" />
+                  Clear all
                 </button>
-                <div className="pr-4">
-                  <span className="font-semibold text-purple-300">{bubble.agentName}</span>
-                  <p className="mt-0.5 whitespace-pre-wrap text-white/50 leading-relaxed">{bubble.content}</p>
-                </div>
               </div>
-            ))}
-          </div>
+              <div className="flex flex-col gap-1 p-2">
+                {thoughtBubbles.map((bubble, index) => (
+                  <div
+                    key={`${bubble.agentId}-${bubble.timestamp}`}
+                    className="relative rounded-lg bg-white/5 p-2 text-[0.625rem]"
+                  >
+                    <button
+                      onClick={() => dismissThoughtBubble(index)}
+                      className="absolute right-1.5 top-1.5 text-white/20 transition-colors hover:text-white/60"
+                    >
+                      <X size="0.625rem" />
+                    </button>
+                    <div className="pr-4">
+                      <span className="font-semibold text-purple-300">{bubble.agentName}</span>
+                      <p className="mt-0.5 whitespace-pre-wrap text-white/50 leading-relaxed">{bubble.content}</p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </>
+          )}
+
+          {(hasCustomRuns || customAgentRunsLoading) && (
+            <CustomAgentRunsSection
+              runs={customAgentRuns}
+              loading={customAgentRunsLoading}
+              title="Custom outputs"
+              countMode="all"
+            />
+          )}
         </>
       )}
 
-      {(hasCustomRuns || customAgentRunsLoading) && (
+      {activeTab === "injections" && showInjectionsTab && (
         <>
-          <div className="flex items-center justify-between border-t border-white/5 px-3 py-1.5">
-            <span className="flex items-center gap-1 text-[0.625rem] text-white/40">
-              <Code2 size="0.6875rem" className="text-purple-400/60" />
-              Custom outputs
-            </span>
-            <span className="text-[0.5625rem] text-white/25">
-              {customAgentRunsLoading ? "Loading…" : hasCustomRuns ? customAgentRuns.length : ""}
-            </span>
-          </div>
-          <div className="flex flex-col gap-1 p-2 pt-0">
-            {customAgentRuns.map((run) => (
-              <CustomAgentRunItem key={run.id} run={run} />
-            ))}
-          </div>
+          <ContextInjectionPanel
+            chatId={chatId}
+            messages={injectionSourceMessages}
+            isAgentProcessing={isAgentProcessing}
+            isGenerationBusy={isGenerationBusy}
+            agentConfigs={agentConfigs}
+            enabledAgentTypes={enabledAgentTypes}
+          />
+          {hasActiveCustomPromptAgent && (
+            <CustomAgentRunsSection
+              runs={injectableCustomRuns}
+              loading={customAgentRunsLoading}
+              title="Custom prompt sections"
+              emptyText="No saved prompt-section output yet."
+              countMode="latest"
+              collapsible
+            />
+          )}
         </>
       )}
 
-      <div className="border-t border-white/5 divide-y divide-white/5">
-        {showEcho && (
-          <button
-            onClick={toggleEchoChamber}
-            className="flex w-full items-center gap-2 px-3 py-2 text-[0.625rem] transition-colors hover:bg-white/5"
-          >
-            <MessageCircle size="0.75rem" className={echoChamberOpen ? "text-purple-400" : "text-purple-400/60"} />
-            <span className={echoChamberOpen ? "text-purple-300 font-medium" : "text-white/60"}>
-              Echo Chamber {echoChamberOpen ? "On" : "Off"}
-            </span>
-            {echoMessageCount > 0 && (
-              <span className="ml-auto flex h-4 min-w-[1rem] items-center justify-center rounded-full bg-purple-500/80 px-1 text-[0.5rem] font-bold text-white">
-                {echoMessageCount}
-              </span>
-            )}
-          </button>
-        )}
-        <button
-          onClick={() => {
-            clearGameState();
-            onClose();
-          }}
-          className="flex w-full items-center gap-2 px-3 py-2 text-[0.625rem] text-white/60 transition-colors hover:bg-red-500/10 hover:text-red-300"
+      {activeTab === "secret" && showSecretPlotTab && (
+        <Suspense
+          fallback={<div className="px-3 py-4 text-center text-[0.625rem] text-white/35">Loading secret plot...</div>}
         >
-          <Trash2 size="0.75rem" className="text-purple-400/60" />
-          <span>Clear Trackers</span>
-        </button>
-        {onRetriggerTrackers && (
-          <button
-            onClick={() => {
-              onRetriggerTrackers();
-              onClose();
-            }}
-            disabled={isAgentProcessing}
-            className="flex w-full items-center gap-2 px-3 py-2 text-[0.625rem] font-medium text-purple-300 transition-colors hover:bg-purple-500/10 disabled:opacity-50"
-          >
-            <RefreshCw size="0.6875rem" className={isAgentProcessing ? "animate-spin" : ""} />
-            {isAgentProcessing ? "Running…" : "Re-run Trackers"}
-          </button>
-        )}
-        {onRetryFailedAgents && failedAgentTypes && failedAgentTypes.length > 0 && (
-          <button
-            onClick={() => {
-              onRetryFailedAgents();
-              onClose();
-            }}
-            disabled={isAgentProcessing}
-            className="flex w-full items-center gap-2 px-3 py-2 text-[0.625rem] font-medium text-amber-300 transition-colors hover:bg-amber-500/10 disabled:opacity-50"
-          >
-            <AlertTriangle size="0.6875rem" className={isAgentProcessing ? "animate-pulse" : ""} />
-            {isAgentProcessing ? "Retrying…" : `Retry Failed Agents (${failedAgentTypes.length})`}
-          </button>
-        )}
-      </div>
+          <SecretPlotPanel
+            chatId={chatId}
+            messages={injectionSourceMessages}
+            isAgentProcessing={isAgentProcessing}
+            isGenerationBusy={isGenerationBusy}
+          />
+        </Suspense>
+      )}
+
+      {showFooterActions && (
+        <div className="border-t border-white/5 divide-y divide-white/5">
+          {showEcho && (
+            <button
+              onClick={toggleEchoChamber}
+              className="flex w-full items-center gap-2 px-3 py-2 text-[0.625rem] transition-colors hover:bg-white/5"
+            >
+              <MessageCircle size="0.75rem" className={echoChamberOpen ? "text-purple-400" : "text-purple-400/60"} />
+              <span className={echoChamberOpen ? "text-purple-300 font-medium" : "text-white/60"}>
+                Echo Chamber {echoChamberOpen ? "On" : "Off"}
+              </span>
+              {echoMessageCount > 0 && (
+                <span className="ml-auto flex h-4 min-w-[1rem] items-center justify-center rounded-full bg-purple-500/80 px-1 text-[0.5rem] font-bold text-white">
+                  {echoMessageCount}
+                </span>
+              )}
+            </button>
+          )}
+          {showTrackerActions && (
+            <button
+              onClick={() => {
+                clearGameState();
+                onClose();
+              }}
+              className="flex w-full items-center gap-2 px-3 py-2 text-[0.625rem] text-white/60 transition-colors hover:bg-red-500/10 hover:text-red-300"
+            >
+              <Trash2 size="0.75rem" className="text-purple-400/60" />
+              <span>Clear Trackers</span>
+            </button>
+          )}
+          {showTrackerActions && onRetriggerTrackers && (
+            <button
+              onClick={() => {
+                onRetriggerTrackers();
+                onClose();
+              }}
+              disabled={isGenerationBusy}
+              className="flex w-full items-center gap-2 px-3 py-2 text-[0.625rem] font-medium text-purple-300 transition-colors hover:bg-purple-500/10 disabled:opacity-50"
+            >
+              <RefreshCw size="0.6875rem" className={isGenerationBusy ? "animate-spin" : ""} />
+              {isGenerationBusy ? "Running..." : "Re-run Trackers"}
+            </button>
+          )}
+          {showRetryFailedAction && (
+            <button
+              onClick={() => {
+                onRetryFailedAgents();
+                onClose();
+              }}
+              disabled={isAgentProcessing}
+              className="flex w-full items-center gap-2 px-3 py-2 text-[0.625rem] font-medium text-amber-300 transition-colors hover:bg-amber-500/10 disabled:opacity-50"
+            >
+              <AlertTriangle size="0.6875rem" className={isAgentProcessing ? "animate-pulse" : ""} />
+              {isAgentProcessing ? "Retrying..." : `Retry Failed Agents (${failedAgentTypes?.length ?? 0})`}
+            </button>
+          )}
+        </div>
+      )}
     </>
   );
 }
 
-function CustomAgentRunItem({ run }: { run: AgentRunRow }) {
-  const updateRun = useUpdateAgentRunData();
-  const mode = getEditableMode(run.resultData);
-  const initialDraft = useMemo(() => getEditorValue(run.resultData, mode), [run.resultData, mode]);
-  const [editing, setEditing] = useState(false);
-  const [draft, setDraft] = useState(initialDraft);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (!editing) setDraft(initialDraft);
-  }, [editing, initialDraft]);
-
-  const preview = getRunPreview(run.resultData);
-  const timestamp = formatRunTime(run.createdAt);
-
-  const save = async () => {
-    const parsed = parseDraft(run.resultData, mode, draft);
-    if (!parsed.ok) {
-      setError(parsed.error);
-      return;
-    }
-    setError(null);
-    await updateRun.mutateAsync({ id: run.id, chatId: run.chatId, resultData: parsed.value });
-    setEditing(false);
-  };
+function CustomAgentRunsSection({
+  runs,
+  loading,
+  title,
+  emptyText,
+  countMode,
+  collapsible,
+}: {
+  runs: AgentRunRow[];
+  loading: boolean;
+  title: string;
+  emptyText?: string;
+  countMode: "all" | "latest";
+  collapsible?: boolean;
+}) {
+  const [open, setOpen] = useState(!collapsible);
+  const countLabel = loading ? "Loading..." : runs.length > 0 ? String(runs.length) : "";
+  const heading = (
+    <>
+      <span className="flex items-center gap-1 text-[0.625rem] text-[var(--muted-foreground)]">
+        <Code2 size="0.6875rem" className="text-[var(--primary)]" />
+        {title}
+      </span>
+      <span className="ml-auto text-[0.5625rem] text-[var(--muted-foreground)]/70">{countLabel}</span>
+      {collapsible && (
+        <ChevronDown
+          size="0.75rem"
+          className={
+            open
+              ? "text-[var(--muted-foreground)] transition-transform rotate-180"
+              : "text-[var(--muted-foreground)] transition-transform"
+          }
+        />
+      )}
+    </>
+  );
 
   return (
-    <div className="rounded-lg border border-white/5 bg-white/[0.035] p-2 text-[0.625rem]">
-      <div className="flex items-start gap-2">
-        <div className="min-w-0 flex-1">
-          <div className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5">
-            <span className="font-semibold text-purple-300">{run.agentName}</span>
-            <span className="rounded bg-white/5 px-1 py-0.5 text-[0.5rem] uppercase tracking-wide text-white/35">
-              {run.resultType.replace(/_/g, " ")}
-            </span>
-            {timestamp && <span className="text-[0.5rem] text-white/25">{timestamp}</span>}
-          </div>
-          {!editing && (
-            <pre className="mt-1 max-h-24 overflow-auto whitespace-pre-wrap break-words rounded bg-black/10 p-1.5 font-sans text-white/50 leading-relaxed">
-              {preview || "Empty output"}
-            </pre>
-          )}
-        </div>
+    <div className="border-t border-white/5">
+      {collapsible ? (
         <button
           type="button"
-          onClick={() => {
-            setEditing((value) => !value);
-            setError(null);
-          }}
-          className="rounded p-1 text-white/30 transition-colors hover:bg-white/5 hover:text-purple-300"
-          title={editing ? "Close editor" : "Edit output"}
+          onClick={() => setOpen((value) => !value)}
+          className="flex min-h-7 w-full items-center gap-1.5 px-3 py-1.5 text-left transition-colors hover:bg-[var(--accent)]/45 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--ring)]"
+          aria-expanded={open}
         >
-          {editing ? <X size="0.6875rem" /> : <Pencil size="0.6875rem" />}
+          {heading}
         </button>
-      </div>
-
-      {editing && (
-        <div className="mt-2 space-y-1.5">
-          <textarea
-            value={draft}
-            onChange={(event) => {
-              setDraft(event.target.value);
-              setError(null);
-            }}
-            spellCheck={false}
-            className="min-h-24 w-full resize-y rounded-md border border-white/10 bg-black/20 px-2 py-1.5 font-mono text-[0.625rem] leading-relaxed text-white/70 outline-none transition-colors placeholder:text-white/25 focus:border-purple-400/40"
-          />
-          {error && <div className="text-[0.5625rem] text-amber-300">{error}</div>}
-          <div className="flex items-center justify-between">
-            <span className="text-[0.5625rem] uppercase tracking-wide text-white/25">
-              {mode === "json" ? "JSON" : "Text"}
-            </span>
-            <button
-              type="button"
-              onClick={save}
-              disabled={updateRun.isPending}
-              className="inline-flex items-center gap-1 rounded-md border border-purple-400/20 bg-purple-500/10 px-2 py-1 text-[0.5625rem] font-medium text-purple-200 transition-colors hover:bg-purple-500/20 disabled:opacity-50"
-            >
-              <Check size="0.625rem" />
-              {updateRun.isPending ? "Saving…" : "Save"}
-            </button>
-          </div>
+      ) : (
+        <div className="flex items-center gap-1.5 px-3 py-1.5">{heading}</div>
+      )}
+      {open && (
+        <div className="flex flex-col gap-1 p-2 pt-0">
+          {runs.map((run) => (
+            <CustomAgentRunItem key={run.id} run={run} />
+          ))}
+          {!loading && runs.length === 0 && emptyText && (
+            <div className="px-2 py-2 text-center text-[0.625rem] text-[var(--muted-foreground)]">{emptyText}</div>
+          )}
+          {!loading && countMode === "latest" && runs.length > 0 && (
+            <div className="px-1 text-[0.5625rem] text-[var(--muted-foreground)]/70">
+              Showing the latest saved output per custom agent with Add as Prompt Section enabled.
+            </div>
+          )}
         </div>
       )}
     </div>
   );
+}
+
+function hasActiveInjectableCustomAgent(configs: AgentConfigRow[], enabledAgentTypes?: Set<string>): boolean {
+  const builtInTypes = new Set(BUILT_IN_AGENTS.map((agent) => agent.id));
+  return configs.some((config) => {
+    if (builtInTypes.has(config.type)) return false;
+    if (enabledAgentTypes ? !enabledAgentTypes.has(config.type) : config.enabled !== "true") return false;
+    const settings = parseAgentSettings(config.settings);
+    return settings.injectAsSection === true;
+  });
+}
+
+function getLatestInjectableCustomRuns(
+  runs: AgentRunRow[],
+  configs: AgentConfigRow[],
+  enabledAgentTypes?: Set<string>,
+): AgentRunRow[] {
+  const builtInTypes = new Set(BUILT_IN_AGENTS.map((agent) => agent.id));
+  const injectableTypes = new Set(
+    configs
+      .filter((config) => {
+        if (builtInTypes.has(config.type)) return false;
+        if (enabledAgentTypes ? !enabledAgentTypes.has(config.type) : config.enabled !== "true") return false;
+        const settings = parseAgentSettings(config.settings);
+        return settings.injectAsSection === true;
+      })
+      .map((config) => config.type),
+  );
+  const seen = new Set<string>();
+  const latest: AgentRunRow[] = [];
+  for (const run of runs) {
+    if (!injectableTypes.has(run.agentType) || seen.has(run.agentType)) continue;
+    seen.add(run.agentType);
+    latest.push(run);
+  }
+  return latest;
+}
+
+function parseAgentSettings(value: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : {};
+  } catch {
+    return {};
+  }
 }
 
 function getEditableMode(data: unknown): "text" | "json" {
@@ -308,4 +462,92 @@ function formatRunTime(value: string): string {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return "";
   return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+function CustomAgentRunItem({ run }: { run: AgentRunRow }) {
+  const updateRun = useUpdateAgentRunData();
+  const mode = getEditableMode(run.resultData);
+  const initialDraft = useMemo(() => getEditorValue(run.resultData, mode), [run.resultData, mode]);
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(initialDraft);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!editing) setDraft(initialDraft);
+  }, [editing, initialDraft]);
+
+  const preview = getRunPreview(run.resultData);
+  const timestamp = formatRunTime(run.createdAt);
+
+  const save = async () => {
+    const parsed = parseDraft(run.resultData, mode, draft);
+    if (!parsed.ok) {
+      setError(parsed.error);
+      return;
+    }
+    setError(null);
+    await updateRun.mutateAsync({ id: run.id, chatId: run.chatId, resultData: parsed.value });
+    setEditing(false);
+  };
+
+  return (
+    <div className="rounded-lg border border-[var(--border)] bg-[var(--card)]/55 p-2 text-[0.625rem] text-[var(--popover-foreground)]">
+      <div className="flex items-start gap-2">
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5">
+            <span className="font-semibold text-[var(--primary)]">{run.agentName}</span>
+            <span className="rounded bg-[var(--secondary)]/55 px-1 py-0.5 text-[0.5rem] uppercase tracking-wide text-[var(--muted-foreground)]">
+              {run.resultType.replace(/_/g, " ")}
+            </span>
+            {timestamp && <span className="text-[0.5rem] text-[var(--muted-foreground)]/70">{timestamp}</span>}
+          </div>
+          {!editing && (
+            <pre className="mt-1 max-h-24 overflow-auto whitespace-pre-wrap break-words rounded bg-[var(--secondary)]/35 p-1.5 font-sans text-[var(--muted-foreground)] leading-relaxed">
+              {preview || "Empty output"}
+            </pre>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={() => {
+            setEditing((value) => !value);
+            setError(null);
+          }}
+          className="rounded p-1 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)]/45 hover:text-[var(--accent-foreground)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--ring)]"
+          title={editing ? "Close editor" : "Edit output"}
+        >
+          {editing ? <X size="0.6875rem" /> : <Pencil size="0.6875rem" />}
+        </button>
+      </div>
+
+      {editing && (
+        <div className="mt-2 space-y-1.5">
+          <textarea
+            value={draft}
+            onChange={(event) => {
+              setDraft(event.target.value);
+              setError(null);
+            }}
+            spellCheck={false}
+            className="min-h-24 w-full resize-y rounded-md border border-[var(--input)] bg-[var(--secondary)]/45 px-2 py-1.5 font-mono text-[0.625rem] leading-relaxed text-[var(--foreground)] outline-none transition-colors placeholder:text-[var(--muted-foreground)] focus:border-[var(--ring)] focus:ring-1 focus:ring-[var(--ring)]"
+          />
+          {error && <div className="text-[0.5625rem] text-[var(--destructive)]">{error}</div>}
+          <div className="flex items-center justify-between">
+            <span className="text-[0.5625rem] uppercase tracking-wide text-[var(--muted-foreground)]/70">
+              {mode === "json" ? "JSON" : "Text"}
+            </span>
+            <button
+              type="button"
+              onClick={save}
+              disabled={updateRun.isPending}
+              className="inline-flex min-h-7 items-center gap-1 rounded-md border border-[var(--primary)]/25 bg-[var(--primary)]/10 px-2 py-1 text-[0.5625rem] font-medium text-[var(--primary)] transition-colors hover:bg-[var(--primary)]/20 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--ring)] disabled:opacity-50"
+            >
+              <Check size="0.625rem" />
+              {updateRun.isPending ? "Saving..." : "Save"}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
 }

--- a/packages/client/src/components/chat/RoleplayHUDPanels.tsx
+++ b/packages/client/src/components/chat/RoleplayHUDPanels.tsx
@@ -62,6 +62,7 @@ function TrackerSectionRefresh({
   agentType: string;
   onRerunSingleTracker?: (agentType: string) => void;
   busy?: boolean;
+  /** Tooltip when hovering the refresh control */
   title?: string;
 }) {
   if (!onRerunSingleTracker) return null;

--- a/packages/client/src/components/ui/HelpTooltip.tsx
+++ b/packages/client/src/components/ui/HelpTooltip.tsx
@@ -15,9 +15,17 @@ interface HelpTooltipProps {
   side?: "top" | "bottom" | "left" | "right";
   /** Extra class on the icon wrapper */
   className?: string;
+  /** Use a wider tooltip panel (long explanations) */
+  wide?: boolean;
 }
 
-export function HelpTooltip({ text, size = "0.75rem", side = "top", className }: HelpTooltipProps) {
+export function HelpTooltip({
+  text,
+  size = "0.75rem",
+  side = "top",
+  className,
+  wide,
+}: HelpTooltipProps) {
   const [show, setShow] = useState(false);
   const wrapRef = useRef<HTMLSpanElement>(null);
   const tipRef = useRef<HTMLDivElement>(null);
@@ -102,7 +110,12 @@ export function HelpTooltip({ text, size = "0.75rem", side = "top", className }:
         createPortal(
           <div
             ref={tipRef}
-            className="pointer-events-none fixed z-[9999] w-56 rounded-lg bg-[var(--popover)] px-3 py-2 text-[0.6875rem] leading-relaxed text-[var(--popover-foreground)] shadow-xl ring-1 ring-[var(--border)]"
+            className={cn(
+              "pointer-events-none fixed z-[9999] rounded-lg bg-[var(--popover)] px-3 py-2 text-[0.6875rem] leading-relaxed text-[var(--popover-foreground)] shadow-xl ring-1 ring-[var(--border)]",
+              wide
+                ? "w-[min(22rem,calc(100vw-1.5rem))] max-w-[22rem]"
+                : "w-56",
+            )}
             style={{ top: pos.top, left: pos.left, visibility: pos.ready ? "visible" : "hidden" }}
           >
             {text}

--- a/packages/client/src/hooks/use-agents.ts
+++ b/packages/client/src/hooks/use-agents.ts
@@ -76,6 +76,17 @@ export function useUpdateAgent() {
   });
 }
 
+export function useUpdateAgentByType() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ agentType, ...data }: { agentType: string } & Record<string, unknown>) =>
+      api.patch(`/agents/type/${agentType}`, data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: agentKeys.all });
+    },
+  });
+}
+
 export function useCreateAgent() {
   const qc = useQueryClient();
   return useMutation({

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -1553,7 +1553,15 @@ export function useGenerate() {
   );
 
   const retryAgents = useCallback(
-    async (chatId: string, agentTypes: string[], options?: { lorebookKeeperBackfill?: boolean }) => {
+    async (
+      chatId: string,
+      agentTypes: string[],
+      options?: {
+        lorebookKeeperBackfill?: boolean;
+        forMessageId?: string;
+        secretPlotRerollMode?: "full" | "turn_only";
+      },
+    ) => {
       const isActiveChat = () => useChatStore.getState().activeChatId === chatId;
       const abortController = new AbortController();
       useChatStore.getState().setAbortController(chatId, abortController);
@@ -1570,6 +1578,8 @@ export function useGenerate() {
             agentTypes,
             streaming: useUIStore.getState().enableStreaming,
             lorebookKeeperBackfill: options?.lorebookKeeperBackfill === true,
+            ...(options?.forMessageId ? { forMessageId: options.forMessageId } : {}),
+            ...(options?.secretPlotRerollMode ? { secretPlotRerollMode: options.secretPlotRerollMode } : {}),
           },
           abortController.signal,
         )) {

--- a/packages/server/src/db/file-backed-store.ts
+++ b/packages/server/src/db/file-backed-store.ts
@@ -98,6 +98,7 @@ export type FileNativeDB = {
   insert: (table: Table) => InsertBuilder;
   update: (table: Table) => UpdateSetBuilder;
   delete: (table: Table) => DeleteBuilder;
+  transaction: <T>(fn: (tx: FileNativeDB) => Promise<T> | T) => Promise<T>;
   run: () => Promise<void>;
   all: <T = unknown>() => Promise<T[]>;
   _fileStore: FileNativeStoreController;
@@ -736,6 +737,23 @@ class FileTableStore {
     return this.tables.get(getMeta(table).name) ?? [];
   }
 
+  async transaction<T>(fn: (tx: FileNativeDB) => Promise<T> | T, tx: FileNativeDB): Promise<T> {
+    const tableSnapshot = new Map<string, Row[]>(
+      Array.from(this.tables, ([table, rows]) => [table, rows.map((row) => ({ ...row }))]),
+    );
+    const dirtySnapshot = this.dirty;
+    const dirtyTablesSnapshot = new Set(this.dirtyTables);
+
+    try {
+      return await fn(tx);
+    } catch (err) {
+      this.tables = tableSnapshot;
+      this.dirty = dirtySnapshot;
+      this.dirtyTables = dirtyTablesSnapshot;
+      throw err;
+    }
+  }
+
   select(projection?: Projection): SelectFromBuilder {
     return {
       from: (table) => new SelectQuery(this, getMeta(table), projection),
@@ -1198,13 +1216,16 @@ export async function createFileNativeDB(legacyDbPaths: string[] = []): Promise<
     close: () => store.close(),
   };
 
-  return {
+  let db: FileNativeDB;
+  db = {
     select: (projection) => store.select(projection),
     insert: (table) => store.insert(table),
     update: (table) => store.update(table),
     delete: (table) => store.delete(table),
+    transaction: (fn) => store.transaction(fn, db),
     run: () => store.run(),
     all: <T = unknown>() => store.all<T>(),
     _fileStore: controller,
   };
+  return db;
 }

--- a/packages/server/src/routes/agents.routes.ts
+++ b/packages/server/src/routes/agents.routes.ts
@@ -2,16 +2,100 @@
 // Routes: Agents
 // ──────────────────────────────────────────────
 import type { FastifyInstance } from "fastify";
-import { createAgentConfigSchema, updateAgentConfigSchema, BUILT_IN_AGENTS } from "@marinara-engine/shared";
+import {
+  createAgentConfigSchema,
+  updateAgentConfigSchema,
+  BUILT_IN_AGENTS,
+  getDefaultBuiltInAgentSettings,
+} from "@marinara-engine/shared";
 import { createAgentsStorage } from "../services/storage/agents.storage.js";
+import { createChatsStorage } from "../services/storage/chats.storage.js";
 import { z } from "zod";
 
 const updateAgentRunSchema = z.object({
   resultData: z.unknown(),
 });
 
+const secretPlotArcSchema = z
+  .object({
+    description: z.string().optional(),
+    protagonistArc: z.string().optional(),
+    completed: z.boolean().optional(),
+  })
+  .passthrough();
+
+const secretPlotDirectionTextSchema = z.string().trim().min(1);
+
+const secretPlotMemoryPatchSchema = z
+  .object({
+    overarchingArc: z.union([z.string(), secretPlotArcSchema, z.null()]).optional(),
+    sceneDirections: z
+      .union([
+        z.array(
+          z.object({
+            direction: secretPlotDirectionTextSchema,
+            fulfilled: z.boolean().optional(),
+          }),
+        ),
+        z.null(),
+      ])
+      .optional(),
+    recentlyFulfilled: z.union([z.array(z.string()), z.null()]).optional(),
+    staleDetected: z.union([z.boolean(), z.null()]).optional(),
+    pacing: z.union([z.string(), z.null()]).optional(),
+  })
+  .passthrough();
+
+function normalizeSecretPlotMemoryPatch(patch: Record<string, unknown>): Record<string, unknown> {
+  const parsed = secretPlotMemoryPatchSchema.parse(patch);
+  const normalized: Record<string, unknown> = { ...parsed };
+  if ("sceneDirections" in parsed) {
+    normalized.sceneDirections = (parsed.sceneDirections ?? [])
+      .map((entry) => ({ ...entry, direction: entry.direction.trim() }))
+      .filter((entry) => entry.direction.length > 0);
+  }
+  if ("recentlyFulfilled" in parsed) normalized.recentlyFulfilled = parsed.recentlyFulfilled ?? [];
+  if ("staleDetected" in parsed) normalized.staleDetected = parsed.staleDetected === true;
+  return normalized;
+}
+
+function parseAgentSettings(value: unknown): Record<string, unknown> {
+  if (!value) return {};
+  if (typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value);
+      return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : {};
+    } catch {
+      return {};
+    }
+  }
+  return typeof value === "object" ? (value as Record<string, unknown>) : {};
+}
+
+function normalizeRunInterval(value: unknown, fallback: number, max = 100): number {
+  const parsed = typeof value === "number" ? value : typeof value === "string" ? Number(value) : NaN;
+  return Number.isFinite(parsed) && parsed >= 1 ? Math.min(max, Math.floor(parsed)) : fallback;
+}
+
 export async function agentsRoutes(app: FastifyInstance) {
   const storage = createAgentsStorage(app.db);
+  const chats = createChatsStorage(app.db);
+  const getOrCreateConfigByType = async (agentType: string) => {
+    const existing = await storage.getByType(agentType);
+    if (existing) return existing;
+    const builtIn = BUILT_IN_AGENTS.find((a) => a.id === agentType);
+    if (!builtIn) return null;
+    return storage.create({
+      type: builtIn.id,
+      name: builtIn.name,
+      description: builtIn.description,
+      phase: builtIn.phase,
+      enabled: builtIn.enabledByDefault,
+      connectionId: null,
+      promptTemplate: "",
+      settings: getDefaultBuiltInAgentSettings(builtIn.id),
+    });
+  };
 
   app.get("/", async () => {
     return storage.list();
@@ -21,6 +105,46 @@ export async function agentsRoutes(app: FastifyInstance) {
   app.get<{ Params: { chatId: string }; Querystring: { limit?: string } }>("/runs/:chatId/custom", async (req) => {
     const parsedLimit = req.query.limit ? Number.parseInt(req.query.limit, 10) : undefined;
     return storage.listCustomRunsForChat(req.params.chatId, parsedLimit);
+  });
+
+  /** Get run interval status for built-in cadence-gated agents. */
+  app.get<{ Params: { agentType: string; chatId: string } }>("/cadence/:agentType/:chatId", async (req, reply) => {
+    const { agentType, chatId } = req.params;
+    const builtIn = BUILT_IN_AGENTS.find((agent) => agent.id === agentType);
+    if (!builtIn) return reply.status(404).send({ error: "Unknown agent type" });
+
+    const defaults = getDefaultBuiltInAgentSettings(agentType);
+    const fallback = normalizeRunInterval(defaults.runInterval, 1);
+    const config = await storage.getByType(agentType);
+    const settings = { ...defaults, ...parseAgentSettings(config?.settings) };
+    const runInterval = normalizeRunInterval(settings.runInterval, fallback);
+
+    const lastRun = await storage.getLastSuccessfulRunByType(agentType, chatId);
+    const messages = await chats.listMessages(chatId);
+    let assistantMessagesSinceLastRun: number | null = null;
+    let lastRunMessageFound: boolean | null = null;
+
+    if (lastRun) {
+      const lastRunIdx = messages.findIndex((message: any) => message.id === lastRun.messageId);
+      lastRunMessageFound = lastRunIdx >= 0;
+      assistantMessagesSinceLastRun =
+        lastRunIdx >= 0
+          ? messages.slice(lastRunIdx + 1).filter((message: any) => message.role === "assistant").length
+          : runInterval;
+    }
+
+    const remainingAssistantMessages =
+      runInterval <= 1 || !lastRun ? 0 : Math.max(0, runInterval - ((assistantMessagesSinceLastRun ?? 0) + 1));
+
+    return {
+      agentType,
+      runInterval,
+      lastSuccessfulRun: lastRun ? { messageId: lastRun.messageId, createdAt: lastRun.createdAt } : null,
+      assistantMessagesSinceLastRun,
+      remainingAssistantMessages,
+      runsNextAssistantMessage: remainingAssistantMessages === 0,
+      lastRunMessageFound,
+    };
   });
 
   /** Edit the persisted output of a custom agent run. */
@@ -43,6 +167,15 @@ export async function agentsRoutes(app: FastifyInstance) {
   app.post("/", async (req) => {
     const input = createAgentConfigSchema.parse(req.body);
     return storage.create(input);
+  });
+
+  app.patch<{ Params: { agentType: string } }>("/type/:agentType", async (req, reply) => {
+    const config = await getOrCreateConfigByType(req.params.agentType);
+    if (!config) {
+      return reply.status(404).send({ error: "Agent is not configured" });
+    }
+    const data = updateAgentConfigSchema.parse(req.body);
+    return storage.update(config.id, data);
   });
 
   app.patch<{ Params: { id: string } }>("/:id", async (req) => {
@@ -131,6 +264,47 @@ export async function agentsRoutes(app: FastifyInstance) {
     }
 
     return reply.status(204).send();
+  });
+
+  /** Read persistent memory for an agent in a chat (JSON values). */
+  app.get<{ Params: { agentType: string; chatId: string } }>("/memory/:agentType/:chatId", async (req, reply) => {
+    const config = await storage.getByType(req.params.agentType);
+    if (!config) {
+      return reply.status(404).send({ error: "Agent is not configured" });
+    }
+    const memory = await storage.getMemory(config.id, req.params.chatId);
+    return { agentConfigId: config.id, memory };
+  });
+
+  /** Patch memory keys for an agent in a chat. Body: { patch: { key: value, ... } } */
+  app.patch<{
+    Params: { agentType: string; chatId: string };
+    Body: { patch?: Record<string, unknown> };
+  }>("/memory/:agentType/:chatId", async (req, reply) => {
+    const config = await getOrCreateConfigByType(req.params.agentType);
+    if (!config) {
+      return reply.status(404).send({ error: "Agent is not configured" });
+    }
+    const body = (req.body ?? {}) as { patch?: Record<string, unknown> };
+    const patch = body.patch;
+    if (!patch || typeof patch !== "object") {
+      return reply.status(400).send({ error: "Body must be { patch: { key: value, ... } }" });
+    }
+    let normalizedPatch: Record<string, unknown>;
+    try {
+      normalizedPatch = req.params.agentType === "secret-plot-driver" ? normalizeSecretPlotMemoryPatch(patch) : patch;
+    } catch (err) {
+      if (err instanceof z.ZodError) {
+        return reply.status(400).send({
+          error: "Invalid Secret Plot memory patch",
+          issues: err.issues,
+        });
+      }
+      throw err;
+    }
+    await storage.setMemories(config.id, req.params.chatId, normalizedPatch);
+    const memory = await storage.getMemory(config.id, req.params.chatId);
+    return { agentConfigId: config.id, memory };
   });
 
   /** Clear all memory for a specific agent in a specific chat (used when removing an agent from a chat). */

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -145,6 +145,11 @@ import {
   type AgentConnectionWarning,
 } from "./generate/agent-connection-guards.js";
 import {
+  normalizeContextInjections,
+  normalizeSecretPlotSceneDirections,
+  normalizeStringArray,
+} from "./generate/agent-normalizers.js";
+import {
   createJournal,
   addLocationEntry,
   addEventEntry,
@@ -3854,9 +3859,11 @@ export async function generateRoutes(app: FastifyInstance) {
           const mem = await agentsStore.getMemory(secretPlotAgent.id, input.chatId);
           const state: Record<string, unknown> = {};
           if (mem.overarchingArc) state.overarchingArc = mem.overarchingArc;
-          if (mem.sceneDirections) state.sceneDirections = mem.sceneDirections;
+          const sceneDirections = normalizeSecretPlotSceneDirections(mem.sceneDirections);
+          if (sceneDirections.length > 0) state.sceneDirections = sceneDirections;
           if (mem.pacing) state.pacing = mem.pacing;
-          if (mem.recentlyFulfilled) state.recentlyFulfilled = mem.recentlyFulfilled;
+          const recentlyFulfilled = normalizeStringArray(mem.recentlyFulfilled);
+          if (recentlyFulfilled.length > 0) state.recentlyFulfilled = recentlyFulfilled;
           if (mem.staleDetected != null) state.staleDetected = mem.staleDetected;
           if (Object.keys(state).length > 0) {
             agentContext.memory._secretPlotState = state;
@@ -4752,7 +4759,7 @@ export async function generateRoutes(app: FastifyInstance) {
               await agentsStore.setMemory(agentConfigId, input.chatId, "overarchingArc", plotData.overarchingArc);
             }
             if (plotData.sceneDirections) {
-              const allDirections = plotData.sceneDirections as Array<{ direction: string; fulfilled: boolean }>;
+              const allDirections = normalizeSecretPlotSceneDirections(plotData.sceneDirections);
               const active = allDirections.filter((d) => !d.fulfilled);
               const justFulfilled = allDirections.filter((d) => d.fulfilled).map((d) => d.direction);
               await agentsStore.setMemory(agentConfigId, input.chatId, "sceneDirections", active);
@@ -4760,7 +4767,7 @@ export async function generateRoutes(app: FastifyInstance) {
               // Keep a rolling window of recently fulfilled directions so the agent doesn't repeat them
               if (justFulfilled.length > 0) {
                 const mem = await agentsStore.getMemory(agentConfigId, input.chatId);
-                const prev = (mem.recentlyFulfilled as string[] | undefined) ?? [];
+                const prev = normalizeStringArray(mem.recentlyFulfilled);
                 const merged = [...prev, ...justFulfilled].slice(-10); // keep last 10
                 await agentsStore.setMemory(agentConfigId, input.chatId, "recentlyFulfilled", merged);
               }
@@ -4815,18 +4822,15 @@ export async function generateRoutes(app: FastifyInstance) {
         // knowledge-router) — which `hasPreGenAgents` excludes. Without this, a chat whose
         // only pre-gen agent is KR or Router would silently drop the lore on every regen.
         const regenExtra = parseExtra(regenMsg?.extra);
-        const rawCached = regenExtra.contextInjections as AgentInjection[] | string[] | undefined;
+        // Backwards compat: old caches stored plain string[], and some edited
+        // caches may contain a mix of legacy strings and object-shaped entries.
+        const cached = normalizeContextInjections(regenExtra.contextInjections);
+        // Secret plot is applied from agent memory, not from message cache (legacy entries ignored)
+        const cachedSansSecret = cached.filter((i) => i.agentType !== "secret-plot-driver");
 
-        // Backwards compat: old caches stored plain string[], upgrade to AgentInjection[]
-        const cached: AgentInjection[] | undefined = rawCached?.length
-          ? typeof rawCached[0] === "string"
-            ? (rawCached as string[]).map((text) => ({ agentType: "prose-guardian", text }))
-            : (rawCached as AgentInjection[])
-          : undefined;
-
-        if (cached && cached.length > 0) {
-          contextInjections = cached;
-          for (const inj of cached) {
+        if (cachedSansSecret && cachedSansSecret.length > 0) {
+          contextInjections = cachedSansSecret;
+          for (const inj of cachedSansSecret) {
             reply.raw.write(
               `data: ${JSON.stringify({
                 type: "agent_result",
@@ -4910,9 +4914,7 @@ export async function generateRoutes(app: FastifyInstance) {
         try {
           const plotMem = await agentsStore.getMemory(secretPlotAgent.id, input.chatId);
           const arcRaw = plotMem.overarchingArc as Record<string, unknown> | string | undefined;
-          const sceneDirections = plotMem.sceneDirections as
-            | Array<{ direction: string; fulfilled?: boolean }>
-            | undefined;
+          const sceneDirections = normalizeSecretPlotSceneDirections(plotMem.sceneDirections);
 
           // Inject overarching arc into the prompt
           if (arcRaw) {
@@ -4997,8 +4999,8 @@ export async function generateRoutes(app: FastifyInstance) {
           }
 
           // Inject scene directions into the tracker block
-          const activeDirections = sceneDirections?.filter((d) => !d.fulfilled);
-          if (activeDirections && activeDirections.length > 0) {
+          const activeDirections = sceneDirections.filter((d) => !d.fulfilled);
+          if (activeDirections.length > 0) {
             const dirLines = activeDirections.map((d) => `- ${d.direction}`).join("\n");
             const dirBlock = wrapContent(dirLines, "scene_directions", wrapFormat);
 
@@ -6037,10 +6039,9 @@ export async function generateRoutes(app: FastifyInstance) {
             const cachedReasoning = encryptedReasoningCache.get(input.chatId);
             if (cachedReasoning?.length) extraUpdate.encryptedReasoning = cachedReasoning;
             else extraUpdate.encryptedReasoning = null;
-            // Cache context injections (prose-guardian etc.) on the message so regens can reuse them
-            if (!input.regenerateMessageId && contextInjections.length > 0) {
-              extraUpdate.contextInjections = contextInjections;
-            }
+            // Cache the exact prompt injections used for this swipe so future
+            // regenerations and swipe switches replay the same guidance.
+            extraUpdate.contextInjections = contextInjections.length > 0 ? contextInjections : null;
             // Cache the final prompt (what was actually sent to the model) for Peek Prompt
             extraUpdate.cachedPrompt = finalPromptSent.map((m) => ({ role: m.role, content: m.content }));
             await chats.updateMessageExtra(savedMsg.id, extraUpdate);

--- a/packages/server/src/routes/generate/agent-normalizers.ts
+++ b/packages/server/src/routes/generate/agent-normalizers.ts
@@ -1,0 +1,45 @@
+import type { AgentInjection } from "../../services/agents/agent-pipeline.js";
+
+export type SecretPlotDirection = { direction: string; fulfilled?: boolean };
+
+export function normalizeContextInjections(raw: unknown): AgentInjection[] {
+  if (!Array.isArray(raw)) return [];
+  const normalized: AgentInjection[] = [];
+  for (const entry of raw) {
+    if (typeof entry === "string") {
+      const text = entry.trim();
+      if (text) normalized.push({ agentType: "prose-guardian", text });
+      continue;
+    }
+    if (!entry || typeof entry !== "object") continue;
+    const candidate = entry as { agentType?: unknown; text?: unknown };
+    if (typeof candidate.agentType !== "string" || typeof candidate.text !== "string") continue;
+    const text = candidate.text.trim();
+    if (text) normalized.push({ agentType: candidate.agentType, text });
+  }
+  return normalized;
+}
+
+export function normalizeSecretPlotSceneDirections(raw: unknown): SecretPlotDirection[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.flatMap((entry) => {
+    if (typeof entry === "string") {
+      const direction = entry.trim();
+      return direction ? [{ direction, fulfilled: false }] : [];
+    }
+    if (!entry || typeof entry !== "object") return [];
+    const candidate = entry as { direction?: unknown; fulfilled?: unknown };
+    if (typeof candidate.direction !== "string") return [];
+    const direction = candidate.direction.trim();
+    return direction ? [{ direction, fulfilled: candidate.fulfilled === true }] : [];
+  });
+}
+
+export function normalizeStringArray(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.flatMap((entry) => {
+    if (typeof entry !== "string") return [];
+    const text = entry.trim();
+    return text ? [text] : [];
+  });
+}

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -40,6 +40,11 @@ import {
   type AgentConnectionWarning,
 } from "./agent-connection-guards.js";
 import { validateSpriteExpressionEntries } from "./expression-agent-utils.js";
+import {
+  normalizeContextInjections,
+  normalizeSecretPlotSceneDirections,
+  normalizeStringArray,
+} from "./agent-normalizers.js";
 import type { GameMap } from "@marinara-engine/shared";
 
 type PersonaContext = {
@@ -138,6 +143,13 @@ async function buildRetryAgentContext(args: {
   gameStateStore: ReturnType<typeof createGameStateStorage>;
   lorebooksStore: ReturnType<typeof createLorebooksStorage>;
   streaming: boolean;
+  /**
+   * When retrying agents for a specific assistant message (e.g. refreshing cached prompt injections),
+   * use the game-state snapshot committed for that message+swipe — not the latest chat snapshot.
+   */
+  historicalGameStateAnchor?: { messageId: string; swipeIndex: number } | null;
+  /** When false, do not fall back to the current latest snapshot if no historical anchor exists. */
+  useLatestGameStateFallback?: boolean;
 }) {
   const {
     cyoaAgentWillRun,
@@ -152,6 +164,8 @@ async function buildRetryAgentContext(args: {
     gameStateStore,
     lorebooksStore,
     streaming,
+    historicalGameStateAnchor,
+    useLatestGameStateFallback = true,
   } = args;
 
   const characterIds: string[] =
@@ -249,9 +263,22 @@ async function buildRetryAgentContext(args: {
     agentContext.memory._existingLorebookEntries = existingEntries;
   }
 
-  const latestGS = await gameStateStore.getLatestCommitted(chatId);
-  if (latestGS) {
-    agentContext.gameState = parseGameStateRow(latestGS as Record<string, unknown>);
+  if (historicalGameStateAnchor) {
+    const snap = await gameStateStore.getByChatAndMessage(
+      chatId,
+      historicalGameStateAnchor.messageId,
+      historicalGameStateAnchor.swipeIndex,
+    );
+    if (snap) {
+      agentContext.gameState = parseGameStateRow(snap as Record<string, unknown>);
+    } else {
+      agentContext.gameState = null;
+    }
+  } else if (useLatestGameStateFallback) {
+    const latestGS = await gameStateStore.getLatestCommitted(chatId);
+    if (latestGS) {
+      agentContext.gameState = parseGameStateRow(latestGS as Record<string, unknown>);
+    }
   }
 
   // CYOA re-rolls: inject the previous choices so the agent generates a fresh,
@@ -440,13 +467,38 @@ async function resolveRetryAgents(args: {
   return { conn, enabledConfigs, resolvedAgents, warnings };
 }
 
-async function executeRetryBatches(agentContext: AgentContext, resolvedAgents: ResolvedRetryAgent[]) {
-  const providerModelGroups = new Map<string, { agents: ResolvedRetryAgent[]; provider: any; model: string }>();
+const retryProviderIds = new WeakMap<object, number>();
+let nextRetryProviderId = 0;
+
+function retryProviderKey(provider: unknown): string {
+  if ((typeof provider !== "object" && typeof provider !== "function") || provider === null) {
+    return `primitive:${String(provider)}`;
+  }
+  let id = retryProviderIds.get(provider);
+  if (id === undefined) {
+    id = nextRetryProviderId++;
+    retryProviderIds.set(provider, id);
+  }
+  return `provider:${id}`;
+}
+
+async function executeRetryBatches(
+  agentContext: AgentContext,
+  resolvedAgents: ResolvedRetryAgent[],
+  preGenerationContext?: AgentContext | null,
+) {
+  const providerModelGroups = new Map<
+    string,
+    { agents: ResolvedRetryAgent[]; provider: any; model: string; context: AgentContext }
+  >();
 
   for (const entry of resolvedAgents) {
-    const key = `${entry.agentProvider.constructor.name}::${entry.agentModel}`;
+    const context =
+      preGenerationContext && entry.resolved.phase === "pre_generation" ? preGenerationContext : agentContext;
+    const contextKind = context === preGenerationContext ? "pre_generation" : "default";
+    const key = `${retryProviderKey(entry.agentProvider)}::${entry.agentModel}::${contextKind}`;
     if (!providerModelGroups.has(key)) {
-      providerModelGroups.set(key, { agents: [], provider: entry.agentProvider, model: entry.agentModel });
+      providerModelGroups.set(key, { agents: [], provider: entry.agentProvider, model: entry.agentModel, context });
     }
     providerModelGroups.get(key)!.agents.push(entry);
   }
@@ -455,7 +507,7 @@ async function executeRetryBatches(agentContext: AgentContext, resolvedAgents: R
   const groupSettled = await Promise.allSettled(
     [...providerModelGroups.values()].map(async (group) => {
       const configs = group.agents.map((agent) => agent.resolved);
-      return executeAgentBatch(configs, agentContext, group.provider, group.model);
+      return executeAgentBatch(configs, group.context, group.provider, group.model);
     }),
   );
 
@@ -576,6 +628,7 @@ async function applyRetryResultEffects(args: {
   conns: ReturnType<typeof createConnectionsStorage>;
   chars: ReturnType<typeof createCharactersStorage>;
   resolvedAgents: ResolvedRetryAgent[];
+  secretPlotRerollMode?: "full" | "turn_only";
 }) {
   const {
     app,
@@ -591,11 +644,13 @@ async function applyRetryResultEffects(args: {
     conns,
     chars,
     resolvedAgents,
+    secretPlotRerollMode,
   } = args;
   const sortedResults = [...results].sort(
     (a, b) => (a.type === "game_state_update" ? 0 : 1) - (b.type === "game_state_update" ? 0 : 1),
   );
   const chats = createChatsStorage(app.db);
+  const agentsStore = createAgentsStorage(app.db);
   const chatMeta = parseExtra(chat.metadata) as Record<string, unknown>;
 
   for (const result of sortedResults) {
@@ -639,6 +694,39 @@ async function applyRetryResultEffects(args: {
         sendSseEvent(reply, { type: "game_state_patch", data: worldStatePatch });
       } catch {
         // Non-critical patching failure.
+      }
+    }
+
+    // Keep message.extra.contextInjections in sync when retrying agents that emit injectable text,
+    // so regenerate/swipe replays the edited or re-run snippet instead of stale cache.
+    if (retryMessageId && result.success && (result.type === "context_injection" || result.type === "director_event")) {
+      const text =
+        typeof result.data === "string"
+          ? result.data
+          : result.data && typeof result.data === "object"
+            ? String((result.data as { text?: string }).text ?? "")
+            : "";
+      try {
+        const msg = await chats.getMessage(retryMessageId);
+        if (msg) {
+          const extra = parseExtra(msg.extra) as Record<string, unknown>;
+          let list = normalizeContextInjections(extra.contextInjections).filter(
+            (entry) => entry.agentType !== "secret-plot-driver",
+          );
+          const trimmedText = text.trim();
+          if (trimmedText) {
+            const entry = { agentType: result.agentType, text: trimmedText };
+            const idx = list.findIndex((e) => e.agentType === result.agentType);
+            if (idx >= 0) list[idx] = entry;
+            else list.push(entry);
+          } else {
+            list = list.filter((e) => e.agentType !== result.agentType);
+          }
+          await chats.updateMessageExtra(retryMessageId, { contextInjections: list });
+          await chats.updateSwipeExtra(retryMessageId, retrySwipeIndex, { contextInjections: list });
+        }
+      } catch {
+        /* non-critical */
       }
     }
 
@@ -692,6 +780,43 @@ async function applyRetryResultEffects(args: {
           };
         }
         sendSseEvent(reply, { type: "game_state_patch", data: patchData });
+      } catch {
+        // Non-critical patching failure.
+      }
+    }
+
+    if (result.success && result.type === "secret_plot" && result.data && typeof result.data === "object") {
+      try {
+        const plotData = result.data as Record<string, unknown>;
+        const agentConfigId =
+          resolvedAgents.find((entry) => entry.resolved.type === "secret-plot-driver")?.resolved.id ?? null;
+        if (agentConfigId) {
+          // Turn-only re-run should preserve long-running arc memory while refreshing
+          // per-turn guidance (scene directions/pacing/stale flags).
+          if (secretPlotRerollMode !== "turn_only" && plotData.overarchingArc !== undefined) {
+            await agentsStore.setMemory(agentConfigId, chatId, "overarchingArc", plotData.overarchingArc ?? null);
+          }
+          if (plotData.sceneDirections !== undefined) {
+            const allDirections = normalizeSecretPlotSceneDirections(plotData.sceneDirections);
+            const active = allDirections.filter((d) => !d.fulfilled);
+            const justFulfilled = allDirections.filter((d) => d.fulfilled).map((d) => d.direction);
+            await agentsStore.setMemory(agentConfigId, chatId, "sceneDirections", active);
+            if (justFulfilled.length > 0) {
+              const mem = await agentsStore.getMemory(agentConfigId, chatId);
+              const prev = normalizeStringArray(mem.recentlyFulfilled);
+              await agentsStore.setMemory(
+                agentConfigId,
+                chatId,
+                "recentlyFulfilled",
+                [...prev, ...justFulfilled].slice(-10),
+              );
+            }
+          }
+          if (plotData.pacing !== undefined) {
+            await agentsStore.setMemory(agentConfigId, chatId, "pacing", plotData.pacing ?? null);
+          }
+          await agentsStore.setMemory(agentConfigId, chatId, "staleDetected", plotData.staleDetected === true);
+        }
       } catch {
         // Non-critical patching failure.
       }
@@ -911,7 +1036,6 @@ async function applyRetryResultEffects(args: {
                 const refs: string[] = [];
                 const { readFileSync, existsSync } = await import("node:fs");
                 const { join } = await import("node:path");
-                const DATA_DIR = join(process.cwd(), "packages", "server", "data");
                 for (const c of refChars) {
                   const charRow = await chars.getById(c.id);
                   const avatarPath = charRow?.avatarPath as string | null;
@@ -934,7 +1058,6 @@ async function applyRetryResultEffects(args: {
                   if (avatarPath) {
                     const { readFileSync, existsSync } = await import("node:fs");
                     const { join } = await import("node:path");
-                    const DATA_DIR = join(process.cwd(), "packages", "server", "data");
                     const filename = avatarPath.split("?")[0]?.split("/").pop();
                     if (filename) {
                       const diskPath = join(DATA_DIR, "avatars", filename);
@@ -1012,7 +1135,8 @@ async function applyRetryResultEffects(args: {
                 },
               });
               logger.info(
-                `[retry-agents] Illustrator generated: ${(illData.reason as string)?.slice(0, 80) ?? imagePrompt.slice(0, 80)}...`,
+                "[retry-agents] Illustrator generated: %s...",
+                (illData.reason as string | undefined)?.slice(0, 80) ?? imagePrompt.slice(0, 80),
               );
             }
           }
@@ -1056,200 +1180,276 @@ export async function registerRetryAgentsRoute(app: FastifyInstance) {
   const gameStateStore = createGameStateStorage(app.db);
   const lorebooksStore = createLorebooksStorage(app.db);
 
-  app.post<{ Body: { chatId: string; agentTypes: string[]; streaming?: boolean; lorebookKeeperBackfill?: boolean } }>(
-    "/retry-agents",
-    async (request, reply) => {
-      const { chatId, agentTypes, streaming = true, lorebookKeeperBackfill = false } = request.body;
-      if (!chatId || !agentTypes?.length) {
-        return reply.status(400).send({ error: "chatId and agentTypes are required" });
+  app.post<{
+    Body: {
+      chatId: string;
+      agentTypes: string[];
+      streaming?: boolean;
+      lorebookKeeperBackfill?: boolean;
+      /** When set, scope history and game state to this assistant message (as at original generation), not the latest turn. */
+      forMessageId?: string;
+      /** Secret Plot re-run mode: full = refresh arc+turn data, turn_only = preserve arc and refresh only turn guidance. */
+      secretPlotRerollMode?: "full" | "turn_only";
+    };
+  }>("/retry-agents", async (request, reply) => {
+    const {
+      chatId,
+      agentTypes,
+      streaming = true,
+      lorebookKeeperBackfill = false,
+      forMessageId,
+      secretPlotRerollMode = "full",
+    } = request.body;
+    if (!chatId || !agentTypes?.length) {
+      return reply.status(400).send({ error: "chatId and agentTypes are required" });
+    }
+
+    startSseReply(reply);
+
+    try {
+      const chat = await chats.getById(chatId);
+      if (!chat) {
+        throw new Error("Chat not found");
       }
 
-      startSseReply(reply);
-
-      try {
-        const chat = await chats.getById(chatId);
-        if (!chat) {
-          throw new Error("Chat not found");
+      const chatMeta = parseExtra(chat.metadata);
+      const allMessages = await chats.listMessages(chatId);
+      let startIdx = 0;
+      for (let index = allMessages.length - 1; index >= 0; index--) {
+        const extra = parseExtra(allMessages[index]!.extra);
+        if (extra.isConversationStart) {
+          startIdx = index;
+          break;
         }
+      }
+      let recentMessages = startIdx > 0 ? allMessages.slice(startIdx) : allMessages;
+      let lastAssistant = [...recentMessages].reverse().find((message: any) => message.role === "assistant");
+      let historicalGameStateAnchor: { messageId: string; swipeIndex: number } | null = null;
+      let preGenerationRecentMessages: any[] | null = null;
+      let preGenerationGameStateAnchor: { messageId: string; swipeIndex: number } | null = null;
 
-        const chatMeta = parseExtra(chat.metadata);
-        const allMessages = await chats.listMessages(chatId);
-        let startIdx = 0;
-        for (let index = allMessages.length - 1; index >= 0; index--) {
-          const extra = parseExtra(allMessages[index]!.extra);
-          if (extra.isConversationStart) {
-            startIdx = index;
-            break;
-          }
+      if (forMessageId) {
+        const anchor = allMessages.find((m) => m.id === forMessageId);
+        if (!anchor || anchor.role !== "assistant") {
+          throw new Error("forMessageId must refer to an assistant message in this chat");
         }
-        const scopedMessages = startIdx > 0 ? allMessages.slice(startIdx) : allMessages;
-        const supportsHiddenFromAI = chat.mode === "roleplay" || chat.mode === "visual_novel";
-        const recentMessages = supportsHiddenFromAI
-          ? scopedMessages.filter((message: any) => !isMessageHiddenFromAI(message))
-          : scopedMessages;
-        const lastAssistant = [...recentMessages].reverse().find((message: any) => message.role === "assistant");
-        const { enabledConfigs, resolvedAgents, warnings } = await resolveRetryAgents({
-          agentTypes,
-          chat,
-          conns,
-          agentsStore,
-        });
-        const cyoaAgentWillRun = resolvedAgents.some((e) => e.resolved.type === "cyoa");
-        const agentContext = await buildRetryAgentContext({
-          cyoaAgentWillRun,
-          chatId,
-          chat,
-          chatMeta,
-          recentMessages,
-          enabledConfigs,
-          resolvedAgentTypes: new Set(resolvedAgents.map((a) => a.resolved.type)),
-          lastAssistant,
-          chars,
-          gameStateStore,
-          lorebooksStore,
-          streaming,
-        });
+        const anchorIdx = allMessages.findIndex((m) => m.id === forMessageId);
+        if (anchorIdx < startIdx) {
+          throw new Error("Anchor message is before the conversation start marker");
+        }
+        preGenerationRecentMessages = allMessages.slice(startIdx, anchorIdx);
+        recentMessages = allMessages.slice(startIdx, anchorIdx + 1);
+        lastAssistant = anchor;
+        historicalGameStateAnchor = {
+          messageId: anchor.id,
+          swipeIndex: anchor.activeSwipeIndex ?? 0,
+        };
+      }
 
-        sendSseEvent(reply, { type: "agent_start", data: { phase: "retry" } });
-        for (const warning of warnings) {
-          sendSseEvent(reply, { type: "agent_warning", data: warning });
-        }
-        const lorebookKeeperAgent = resolvedAgents.find((entry) => entry.resolved.type === "lorebook-keeper") ?? null;
-        const nonLorebookAgents = resolvedAgents.filter((entry) => entry.resolved.type !== "lorebook-keeper");
-        if (cyoaAgentWillRun) {
-          logger.info(
-            "[retry-agents] CYOA re-roll chatId=%s assistantMessageId=%s",
-            chatId,
-            lastAssistant?.id ?? "none",
+      const supportsHiddenFromAI = chat.mode === "roleplay" || chat.mode === "visual_novel";
+      if (supportsHiddenFromAI) {
+        recentMessages = recentMessages.filter((message: any) => !isMessageHiddenFromAI(message));
+        if (preGenerationRecentMessages) {
+          preGenerationRecentMessages = preGenerationRecentMessages.filter(
+            (message: any) => !isMessageHiddenFromAI(message),
           );
         }
-        const results = nonLorebookAgents.length > 0 ? await executeRetryBatches(agentContext, nonLorebookAgents) : [];
-        const lorebookKeeperRunEntries = lorebookKeeperAgent
-          ? await executeLorebookKeeperRetries({
-              lorebookKeeperAgent,
-              baseContext: agentContext,
-              messages: recentMessages,
-              readBehindMessages: getLorebookKeeperSettings(chatMeta).readBehindMessages,
-              lastProcessedMessageId:
-                (await agentsStore.getLastSuccessfulRunByType("lorebook-keeper", chatId))?.messageId ?? null,
-              backfillUnprocessed: lorebookKeeperBackfill,
-              lorebooksStore,
-              chatId,
-              chatName: (chat as any).name,
-            })
-          : [];
-
-        // ── Pre-validate expression results before sending SSE events ──
-        // Validation must happen before the SSE send, otherwise the client receives
-        // unvalidated expressions that may not have matching sprite files.
-        for (const result of results) {
-          if (result.success && result.type === "sprite_change" && result.data && typeof result.data === "object") {
-            const spriteData = result.data as {
-              expressions?: Array<{
-                characterId: string;
-                characterName?: string;
-                expression: string;
-                transition?: string;
-              }>;
-            };
-            const availableSprites = agentContext.memory._availableSprites as
-              | Array<{ characterId: string; characterName: string; expressions: string[] }>
-              | undefined;
-            if (Array.isArray(spriteData.expressions) && Array.isArray(availableSprites)) {
-              const validation = validateSpriteExpressionEntries(spriteData.expressions, availableSprites);
-              spriteData.expressions = validation.expressions;
-              for (const warning of validation.warnings) {
-                logger.warn("[retry-agents] %s", warning.message);
-              }
-            } else if (!Array.isArray(availableSprites)) {
-              // No sprite catalog loaded — drop expressions entirely so unvalidated data is never forwarded
-              spriteData.expressions = [];
-            }
-          }
+        if (!forMessageId) {
+          lastAssistant = [...recentMessages].reverse().find((message: any) => message.role === "assistant");
         }
-
-        for (const result of results) {
-          const cfg = resolvedAgents.find((entry) => entry.resolved.type === result.agentType)?.cfg;
-          sendSseEvent(reply, {
-            type: "agent_result",
-            data: {
-              agentType: result.agentType,
-              agentName: cfg?.name ?? result.agentType,
-              resultType: result.type,
-              data: result.data,
-              success: result.success,
-              error: result.error,
-              durationMs: result.durationMs,
-            },
-          });
-        }
-
-        if (cyoaAgentWillRun) {
-          const cyoaRetry = results.find((r) => r.agentType === "cyoa");
-          if (cyoaRetry && !cyoaRetry.success) {
-            logger.warn("[retry-agents] CYOA re-roll failed chatId=%s: %s", chatId, cyoaRetry.error ?? "unknown");
-          }
-        }
-
-        for (const entry of lorebookKeeperRunEntries) {
-          const cfg = lorebookKeeperAgent?.cfg;
-          sendSseEvent(reply, {
-            type: "agent_result",
-            data: {
-              agentType: entry.result.agentType,
-              agentName: cfg?.name ?? entry.result.agentType,
-              resultType: entry.result.type,
-              data: entry.result.data,
-              success: entry.result.success,
-              error: entry.result.error,
-              durationMs: entry.result.durationMs,
-            },
-          });
-        }
-
-        const retryMessageId = lastAssistant?.id ?? "";
-        const retrySwipeIndex = lastAssistant?.activeSwipeIndex ?? 0;
-        await persistRetryResults(agentsStore, chatId, retryMessageId, results);
-        for (const entry of lorebookKeeperRunEntries) {
-          try {
-            await agentsStore.saveRun({
-              agentConfigId: entry.result.agentId,
-              chatId,
-              messageId: entry.messageId,
-              result: entry.result,
-            });
-          } catch {
-            // Non-critical write; keep processing remaining results.
-          }
-        }
-        await applyRetryResultEffects({
-          app,
-          reply,
-          chatId,
-          chat,
-          retryMessageId,
-          retrySwipeIndex,
-          results,
-          agentContext,
-          lorebooksStore,
-          gameStateStore,
-          conns,
-          chars,
-          resolvedAgents: nonLorebookAgents,
-        });
-
-        sendSseEvent(reply, { type: "done", data: "" });
-      } catch (err) {
-        const message =
-          err instanceof Error
-            ? (err as { cause?: unknown }).cause instanceof Error
-              ? `${err.message}: ${(err as { cause?: Error }).cause!.message}`
-              : err.message
-            : "Agent retry failed";
-        sendSseEvent(reply, { type: "error", data: message });
-      } finally {
-        reply.raw.end();
       }
-    },
-  );
+      const preGenerationLastAssistant = preGenerationRecentMessages
+        ? [...preGenerationRecentMessages].reverse().find((message: any) => message.role === "assistant")
+        : null;
+      if (preGenerationLastAssistant) {
+        preGenerationGameStateAnchor = {
+          messageId: preGenerationLastAssistant.id,
+          swipeIndex: preGenerationLastAssistant.activeSwipeIndex ?? 0,
+        };
+      }
+
+      const { enabledConfigs, resolvedAgents, warnings } = await resolveRetryAgents({
+        agentTypes,
+        chat,
+        conns,
+        agentsStore,
+      });
+      const cyoaAgentWillRun = resolvedAgents.some((e) => e.resolved.type === "cyoa");
+      const agentContext = await buildRetryAgentContext({
+        cyoaAgentWillRun,
+        chatId,
+        chat,
+        chatMeta,
+        recentMessages,
+        enabledConfigs,
+        resolvedAgentTypes: new Set(resolvedAgents.map((a) => a.resolved.type)),
+        lastAssistant,
+        chars,
+        gameStateStore,
+        lorebooksStore,
+        streaming,
+        historicalGameStateAnchor,
+      });
+      const hasPreGenerationRetries = resolvedAgents.some((entry) => entry.resolved.phase === "pre_generation");
+      const preGenerationAgentContext =
+        hasPreGenerationRetries && preGenerationRecentMessages
+          ? await buildRetryAgentContext({
+              cyoaAgentWillRun: false,
+              chatId,
+              chat,
+              chatMeta,
+              recentMessages: preGenerationRecentMessages,
+              enabledConfigs,
+              resolvedAgentTypes: new Set(resolvedAgents.map((a) => a.resolved.type)),
+              lastAssistant: null,
+              chars,
+              gameStateStore,
+              lorebooksStore,
+              streaming,
+              historicalGameStateAnchor: preGenerationGameStateAnchor,
+              useLatestGameStateFallback: false,
+            })
+          : null;
+
+      sendSseEvent(reply, { type: "agent_start", data: { phase: "retry" } });
+      for (const warning of warnings) {
+        sendSseEvent(reply, { type: "agent_warning", data: warning });
+      }
+      const lorebookKeeperAgent = resolvedAgents.find((entry) => entry.resolved.type === "lorebook-keeper") ?? null;
+      const nonLorebookAgents = resolvedAgents.filter((entry) => entry.resolved.type !== "lorebook-keeper");
+      if (cyoaAgentWillRun) {
+        logger.info("[retry-agents] CYOA re-roll chatId=%s assistantMessageId=%s", chatId, lastAssistant?.id ?? "none");
+      }
+      const results =
+        nonLorebookAgents.length > 0
+          ? await executeRetryBatches(agentContext, nonLorebookAgents, preGenerationAgentContext)
+          : [];
+      const lorebookKeeperRunEntries = lorebookKeeperAgent
+        ? await executeLorebookKeeperRetries({
+            lorebookKeeperAgent,
+            baseContext: agentContext,
+            messages: recentMessages,
+            readBehindMessages: getLorebookKeeperSettings(chatMeta).readBehindMessages,
+            lastProcessedMessageId:
+              (await agentsStore.getLastSuccessfulRunByType("lorebook-keeper", chatId))?.messageId ?? null,
+            backfillUnprocessed: lorebookKeeperBackfill,
+            lorebooksStore,
+            chatId,
+            chatName: (chat as any).name,
+          })
+        : [];
+
+      // ── Pre-validate expression results before sending SSE events ──
+      // Validation must happen before the SSE send, otherwise the client receives
+      // unvalidated expressions that may not have matching sprite files.
+      for (const result of results) {
+        if (result.success && result.type === "sprite_change" && result.data && typeof result.data === "object") {
+          const spriteData = result.data as {
+            expressions?: Array<{
+              characterId: string;
+              characterName?: string;
+              expression: string;
+              transition?: string;
+            }>;
+          };
+          const availableSprites = agentContext.memory._availableSprites as
+            | Array<{ characterId: string; characterName: string; expressions: string[] }>
+            | undefined;
+          if (Array.isArray(spriteData.expressions) && Array.isArray(availableSprites)) {
+            const validation = validateSpriteExpressionEntries(spriteData.expressions, availableSprites);
+            spriteData.expressions = validation.expressions;
+            for (const warning of validation.warnings) {
+              logger.warn("[retry-agents] %s", warning.message);
+            }
+          } else if (!Array.isArray(availableSprites)) {
+            // No sprite catalog loaded — drop expressions entirely so unvalidated data is never forwarded
+            spriteData.expressions = [];
+          }
+        }
+      }
+
+      for (const result of results) {
+        const cfg = resolvedAgents.find((entry) => entry.resolved.type === result.agentType)?.cfg;
+        sendSseEvent(reply, {
+          type: "agent_result",
+          data: {
+            agentType: result.agentType,
+            agentName: cfg?.name ?? result.agentType,
+            resultType: result.type,
+            data: result.data,
+            success: result.success,
+            error: result.error,
+            durationMs: result.durationMs,
+          },
+        });
+      }
+
+      if (cyoaAgentWillRun) {
+        const cyoaRetry = results.find((r) => r.agentType === "cyoa");
+        if (cyoaRetry && !cyoaRetry.success) {
+          logger.warn("[retry-agents] CYOA re-roll failed chatId=%s: %s", chatId, cyoaRetry.error ?? "unknown");
+        }
+      }
+
+      for (const entry of lorebookKeeperRunEntries) {
+        const cfg = lorebookKeeperAgent?.cfg;
+        sendSseEvent(reply, {
+          type: "agent_result",
+          data: {
+            agentType: entry.result.agentType,
+            agentName: cfg?.name ?? entry.result.agentType,
+            resultType: entry.result.type,
+            data: entry.result.data,
+            success: entry.result.success,
+            error: entry.result.error,
+            durationMs: entry.result.durationMs,
+          },
+        });
+      }
+
+      const retryMessageId = lastAssistant?.id ?? "";
+      const retrySwipeIndex = lastAssistant?.activeSwipeIndex ?? 0;
+      await persistRetryResults(agentsStore, chatId, retryMessageId, results);
+      for (const entry of lorebookKeeperRunEntries) {
+        try {
+          await agentsStore.saveRun({
+            agentConfigId: entry.result.agentId,
+            chatId,
+            messageId: entry.messageId,
+            result: entry.result,
+          });
+        } catch {
+          // Non-critical write; keep processing remaining results.
+        }
+      }
+      await applyRetryResultEffects({
+        app,
+        reply,
+        chatId,
+        chat,
+        retryMessageId,
+        retrySwipeIndex,
+        results,
+        agentContext,
+        lorebooksStore,
+        gameStateStore,
+        conns,
+        chars,
+        resolvedAgents: nonLorebookAgents,
+        secretPlotRerollMode,
+      });
+
+      sendSseEvent(reply, { type: "done", data: "" });
+    } catch (err) {
+      const message =
+        err instanceof Error
+          ? (err as { cause?: unknown }).cause instanceof Error
+            ? `${err.message}: ${(err as { cause?: Error }).cause!.message}`
+            : err.message
+          : "Agent retry failed";
+      sendSseEvent(reply, { type: "error", data: message });
+    } finally {
+      reply.raw.end();
+    }
+  });
 }

--- a/packages/server/src/services/storage/agents.storage.ts
+++ b/packages/server/src/services/storage/agents.storage.ts
@@ -375,6 +375,50 @@ export function createAgentsStorage(db: DB) {
       }
     },
 
+    async setMemories(agentConfigId: string, chatId: string, values: Record<string, unknown>) {
+      const resolvedAgentConfigId = await resolveAgentConfigId(agentConfigId);
+      const entries = Object.entries(values)
+        .filter((entry): entry is [string, unknown] => entry[1] !== undefined)
+        .map(([key, value]) => ({
+          key,
+          value: typeof value === "string" ? value : JSON.stringify(value),
+        }));
+      if (entries.length === 0) return;
+
+      await db.transaction(async (tx) => {
+        const existingRows = await tx
+          .select()
+          .from(agentMemory)
+          .where(and(eq(agentMemory.agentConfigId, resolvedAgentConfigId), eq(agentMemory.chatId, chatId)));
+        const existingByKey = new Map(existingRows.map((row) => [row.key, row]));
+        const timestamp = now();
+        const inserts: (typeof agentMemory.$inferInsert)[] = [];
+
+        for (const entry of entries) {
+          const existing = existingByKey.get(entry.key);
+          if (existing) {
+            await tx
+              .update(agentMemory)
+              .set({ value: entry.value, updatedAt: timestamp })
+              .where(eq(agentMemory.id, existing.id));
+          } else {
+            inserts.push({
+              id: newId(),
+              agentConfigId: resolvedAgentConfigId,
+              chatId,
+              key: entry.key,
+              value: entry.value,
+              updatedAt: timestamp,
+            });
+          }
+        }
+
+        if (inserts.length > 0) {
+          await tx.insert(agentMemory).values(inserts);
+        }
+      });
+    },
+
     /** Delete echo chamber message runs for a specific chat. */
     async clearEchoMessages(chatId: string) {
       await db.delete(agentRuns).where(and(eq(agentRuns.chatId, chatId), eq(agentRuns.resultType, "echo_message")));

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -128,6 +128,10 @@ export interface ChatMetadata {
   groupScenarioOverride?: boolean;
   /** The shared scenario text used when groupScenarioOverride is enabled */
   groupScenarioText?: string;
+  /** When true, show the Secret Plot tab in the roleplay Agents menu (edits apply to agent memory, same as generation). */
+  showSecretPlotPanel?: boolean;
+  /** When true, show the Injections tab in the roleplay Agents menu for cached prompt injections. */
+  showInjectionsPanel?: boolean;
   /** When true, tracker agents only run when the user manually triggers them (not after every generation) */
   manualTrackers?: boolean;
   /** Whether to recall memories from this chat during generation. Default: true for conversation/scenes, false for roleplay. */
@@ -286,6 +290,11 @@ export interface MessageExtra {
   hiddenFromUser?: boolean;
   /** When true, the visible message is excluded from future AI prompt context */
   hiddenFromAI?: boolean;
+  /**
+   * Cached pipeline injections (prose-guardian, director, knowledge-retrieval, etc.)
+   * saved with this assistant message — reused when regenerating that swipe unless refreshed.
+   */
+  contextInjections?: Array<{ agentType: string; text: string }> | null;
 }
 
 /** Metadata about how a message was generated. */


### PR DESCRIPTION
## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

No linked issue, but this feature would be useful for users to troubleshoot their writing agents, quickly test output of different models with re-run, and tweaking their prompts.

Closes #

## Why this change

- Writer-agent guidance could affect a reply without giving users a clear way to inspect, edit, or re-run the specific guidance that caused it.
- Secret Plot Driver memory needed a safer, opt-in UI so users can refresh turn guidance without accidentally wiping or replacing the long-running hidden arc.
- Users can use this to troubleshoot issues, such as Narrative Director continuing roleplay instead of generating guidance, or test the output of different models quickly.

## What changed

- Added opt-in Roleplay HUD tabs for cached prompt injections and Secret Plot Driver state.
- Added editable cached context injections on assistant messages, including save controls, scoped re-runs, and Narrative Director cadence status.
- Added a Secret Plot panel for scene directions, arc memory, fulfilled/momentum state, and full vs turn-only re-runs.
- Added agent memory and cadence API routes, plus retry-agent support for explicit agent lists, historical message anchors, and secret plot rerun modes.
- Updated generation/regeneration so cached injections can be reused or refreshed for the same assistant message.
- Updated shared chat metadata/types and docs in `docs/FAQ.md`, `docs/FRONTEND.md`, and `docs/ROLEPLAY.md`.

## Validation

- [X] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [X] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [X] Read and followed `CONTRIBUTING.md`

AI-run notes:
- `CI=true pnpm install --frozen-lockfile` passed.
- `pnpm check` passed.
- Docker/container build was not run.
- Browser screenshots were captured from a temporary seeded demo app, not real user data.

### Manual verification notes

- [X] Confirm `pnpm check` passes locally.
- [X] Build and run the app locally.
- [X] Open a roleplay chat with agents enabled.
- [X] In Chat Settings -> Agents -> Writer Agents, add/enable Prose Guardian, Narrative Director, and Secret Plot Driver.
- [X] Toggle the Injections tab on and confirm it appears in the Roleplay HUD Agents menu.
- [X] Toggle the Secret Plot tab on and confirm it appears in the Roleplay HUD Agents menu when Secret Plot Driver is active.
- [X] Generate a roleplay reply with writer agents enabled.
- [X] Open Roleplay HUD -> Agents -> Injections and confirm cached prompt injections appear for the latest assistant message.
- [x] Edit one cached injection, save it, refresh/reopen the menu, and confirm the edit persists.
- [x] Re-run one eligible cached injection and confirm only that injection is refreshed.
- [x] With Narrative Director active, confirm its cadence/countdown appears and the interval stepper saves.
- [X] Open Roleplay HUD -> Agents -> Secret plot and confirm scene directions and arc memory load.
- [x] Edit a scene direction, save it, refresh/reopen the menu, and confirm the edit persists.
- [x] Try “re-run scene directions” and confirm it refreshes turn guidance without replacing the long-term arc.
- [x] Try “re-run full secret plot state” and confirm it asks before replacing arc memory.
- [x] Remove Secret Plot Driver from the chat and confirm the destructive warning appears before hidden plot memory is cleared.
- [X] Check the new UI in dark mode and light mode.
- [x] Check the new UI in a narrow/mobile viewport.
- [x] Check empty states: no assistant message yet, no cached injections yet, and no Secret Plot memory yet.
- [ ] Check error paths if possible: failed memory load/save or failed agent retry shows a sensible failure state.

## Docs and release impact

- [ ] No docs changes needed
- [X] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

Docs updated in this branch:
- `docs/FAQ.md`
- `docs/FRONTEND.md`
- `docs/ROLEPLAY.md`

No version/release files appear to be changed.

## UI evidence (if applicable)

<img width="282" height="451" alt="Screenshot 2026-05-06 185839" src="https://github.com/user-attachments/assets/3d6b3adc-5b8a-401f-8d8c-ac050af1c2ea" />
<img width="331" height="231" alt="Screenshot 2026-05-06 190714" src="https://github.com/user-attachments/assets/af2dc4eb-6b57-4031-9c74-3d82eb69a853" />
<img width="326" height="360" alt="hud-injections-tab" src="https://github.com/user-attachments/assets/12103f03-0dae-44ae-8486-84672140770e" />
<img width="326" height="360" alt="hud-secret-plot-arc-fields" src="https://github.com/user-attachments/assets/6d603902-a407-4196-85eb-418bf5b5e2fa" />
<img width="390" height="456" alt="mobile-secret-plot-tab" src="https://github.com/user-attachments/assets/8009d757-68ab-40ab-a891-51475cfcecd6" />

WIP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Roleplay Agents menu with Activity / Injections / Secret tabs; editable cached injections panel and Secret Plot memory editor with save, rerun, and reroll (full or turn-only).
  * Message-scoped agent retry that replays cached injections and supports secret-plot reroll modes.
  * HUD and settings: show Secret Plot panel on add; per-chat toggles for Injections/Secret panels; wider help tooltips.

* **Documentation**
  * FAQ, frontend API, and Roleplay docs updated for retry behavior, plot-steering overlaps, new agent endpoints, and memory tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->