### PR TITLE
feat(env): hot-reload .env changes without restarting the server

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -88,6 +88,8 @@ Marinara Engine ships with layered access-control mechanisms designed for users 
 
 > Looking for a step-by-step walkthrough rather than a reference? See [Remote Access — Setting Up Basic Auth or an IP Allowlist](REMOTE_ACCESS.md).
 
+> **Hot reload:** changes to access-control variables (`BASIC_AUTH_*`, `IP_ALLOWLIST`, `IP_ALLOWLIST_ENABLED`, `ALLOW_UNAUTHENTICATED_*`, `TRUSTED_PRIVATE_NETWORKS`, `ADMIN_SECRET`, `CSRF_TRUSTED_ORIGINS`) take effect within a couple of seconds of saving `.env` — no restart required. The server logs an `[env-watcher]` line for each change. A short list of low-level variables (`PORT`, `HOST`, `SSL_CERT`/`SSL_KEY`, `CORS_ORIGINS`, storage paths, `ENCRYPTION_KEY`, `TZ`) still need a restart; see [Remote Access § When a restart is required](REMOTE_ACCESS.md#when-a-restart-is-required).
+
 ### Safe-by-default lockdown
 
 By default, when no Basic Auth credentials are configured, the server **refuses connections from every non-loopback IP**. Local browser access continues to work without any configuration:

--- a/docs/REMOTE_ACCESS.md
+++ b/docs/REMOTE_ACCESS.md
@@ -26,7 +26,7 @@ All access settings live in your `.env` file in the project root (next to `packa
 cp .env.example .env
 ```
 
-Edit it with any text editor. After saving, **restart Marinara** for changes to take effect. Quick reference for each install method:
+Edit it with any text editor. **Most security settings — Basic Auth credentials, IP allowlist, admin secret, CSRF origins — apply within a couple of seconds without a restart.** A handful of low-level settings (port, host, TLS cert paths, storage paths, encryption key) still need a restart; if a change you made isn't picked up, see [When a restart is required](#when-a-restart-is-required) below. Quick reference for each install method when you do need a restart:
 
 - **Source install (Windows / macOS / Linux)** — close the launcher window, run `start.bat` / `start.sh` again.
 - **Docker Compose** — `docker compose down && docker compose up -d`. You can also pass the variables in `docker-compose.yml` under `environment:` instead of using `.env`.
@@ -114,9 +114,15 @@ Two options when you're exposing Marinara beyond a trusted network:
 
 For sensitive deployments, consider Tailscale or Cloudflare Access — they avoid exposing the port to the open internet entirely.
 
+## When a restart is required
+
+The server watches `.env` for changes and applies most updates within a couple of seconds — no restart needed. That includes `BASIC_AUTH_USER` / `BASIC_AUTH_PASS` / `BASIC_AUTH_REALM`, `IP_ALLOWLIST` / `IP_ALLOWLIST_ENABLED`, `ALLOW_UNAUTHENTICATED_PRIVATE_NETWORK`, `ALLOW_UNAUTHENTICATED_REMOTE`, `TRUSTED_PRIVATE_NETWORKS`, `ADMIN_SECRET`, `CSRF_TRUSTED_ORIGINS`, `LOG_LEVEL`, and the various `*_LOCAL_URLS_ENABLED` / privileged-feature flags.
+
+Changes to these still need a restart because they're bound at startup: `PORT`, `HOST`, `SSL_CERT`, `SSL_KEY`, `CORS_ORIGINS`, `DATA_DIR`, `STORAGE_BACKEND`, `FILE_STORAGE_DIR`, `DATABASE_URL`, `ENCRYPTION_KEY`, `TZ`, `AUTO_OPEN_BROWSER`, `AUTO_CREATE_DEFAULT_CONNECTION`. The server logs a warning when one of these changes so you don't wonder why it didn't take effect.
+
 ## Verifying it works
 
-After restarting, from your remote device:
+After saving `.env` (and restarting if required), from your remote device:
 
 1. Open `http://<host-ip>:7860` (or your container/Tailscale address).
 2. Basic Auth: you should see a browser password prompt. Enter your credentials.
@@ -125,7 +131,7 @@ After restarting, from your remote device:
 
 Still getting a 403? Check:
 
-- Did you restart the server after editing `.env`?
+- Did you save `.env`? The server picks up most security changes within a couple of seconds; the server log will show an `[env-watcher] Updated:` line. If your change is on the [restart-required list](#when-a-restart-is-required), restart Marinara.
 - Is the client IP what you expect? Marinara logs the blocked IP to the server console.
 - For Docker: are you connecting to the published port, or directly to the container IP?
 - For Tailscale: is the connecting device's `100.x.y.z` address in the allowlist (if you're using Option 2)?

--- a/packages/server/src/config/env-watcher.ts
+++ b/packages/server/src/config/env-watcher.ts
@@ -1,0 +1,156 @@
+// ──────────────────────────────────────────────
+// .env hot-reload watcher
+// ──────────────────────────────────────────────
+// Polls the monorepo-root .env file and re-applies changes to process.env
+// without requiring a server restart. Most security middleware (basic-auth,
+// IP allowlist, CSRF, admin secret, etc.) reads via getter functions in
+// runtime-config.ts, so updates take effect on the next request.
+//
+// A small set of variables are bound at boot and CANNOT take effect from a
+// reload — we still propagate them to process.env, but log a warning so the
+// operator knows a restart is required for them.
+
+import { existsSync, statSync, watchFile, unwatchFile } from "node:fs";
+import { logger } from "../lib/logger.js";
+import { getEnvFilePath, reloadRuntimeEnv, type EnvReloadResult } from "./runtime-config.js";
+
+// Keys whose values are bound at process / app startup and won't take effect
+// without a full restart, even though we propagate them to process.env.
+const RESTART_REQUIRED_KEYS = new Set<string>([
+  "PORT",
+  "HOST",
+  "SSL_CERT",
+  "SSL_KEY",
+  "DATA_DIR",
+  "STORAGE_BACKEND",
+  "FILE_STORAGE_DIR",
+  "DATABASE_URL",
+  "DATABASE_DRIVER",
+  "ENCRYPTION_KEY",
+  "TZ",
+  "AUTO_OPEN_BROWSER",
+  "AUTO_CREATE_DEFAULT_CONNECTION",
+  "CORS_ORIGINS",
+  "NODE_ENV",
+]);
+
+// Keys whose values must be masked when logged.
+const SENSITIVE_KEYS = new Set<string>([
+  "BASIC_AUTH_PASS",
+  "ADMIN_SECRET",
+  "ENCRYPTION_KEY",
+  "GIPHY_API_KEY",
+]);
+
+function maskValue(key: string, value: string | undefined): string {
+  if (value === undefined) return "<unset>";
+  if (SENSITIVE_KEYS.has(key)) {
+    if (!value) return "<empty>";
+    return `<set, length=${value.length}>`;
+  }
+  return value === "" ? "<empty>" : value;
+}
+
+function describeKey(key: string): string {
+  return `${key}=${maskValue(key, process.env[key])}`;
+}
+
+function applyLogLevel(diff: EnvReloadResult) {
+  if (!diff.updated.includes("LOG_LEVEL") && !diff.added.includes("LOG_LEVEL") && !diff.removed.includes("LOG_LEVEL")) {
+    return;
+  }
+  const next = (process.env.LOG_LEVEL ?? "warn").trim() || "warn";
+  try {
+    logger.level = next;
+  } catch (err) {
+    logger.warn({ err, requested: next }, "[env-watcher] Could not apply new LOG_LEVEL to logger");
+  }
+}
+
+function logDiff(diff: EnvReloadResult) {
+  const totalChanges = diff.added.length + diff.updated.length + diff.removed.length;
+  if (totalChanges === 0) {
+    logger.debug("[env-watcher] .env modified, no effective changes");
+    return;
+  }
+
+  const restartKeys: string[] = [];
+  for (const key of [...diff.added, ...diff.updated, ...diff.removed]) {
+    if (RESTART_REQUIRED_KEYS.has(key)) restartKeys.push(key);
+  }
+
+  if (diff.added.length > 0) {
+    logger.info(`[env-watcher] Added: ${diff.added.map(describeKey).join(", ")}`);
+  }
+  if (diff.updated.length > 0) {
+    logger.info(`[env-watcher] Updated: ${diff.updated.map(describeKey).join(", ")}`);
+  }
+  if (diff.removed.length > 0) {
+    logger.info(`[env-watcher] Removed: ${diff.removed.join(", ")}`);
+  }
+
+  if (restartKeys.length > 0) {
+    logger.warn(
+      `[env-watcher] These variables changed but require a server restart to take effect: ${restartKeys.join(", ")}`,
+    );
+  }
+}
+
+export interface EnvWatcherHandle {
+  stop(): void;
+  reloadNow(): EnvReloadResult | null;
+}
+
+export function startEnvWatcher(): EnvWatcherHandle {
+  const envPath = getEnvFilePath();
+  let stopped = false;
+
+  if (!existsSync(envPath)) {
+    logger.info(`[env-watcher] No .env file at ${envPath}; watcher will start once the file is created`);
+  } else {
+    logger.info(`[env-watcher] Watching ${envPath} for changes (changes propagate without restart)`);
+  }
+
+  // Track the last seen mtime/size to ignore polling ticks where nothing
+  // actually changed (watchFile can fire on attribute touches too).
+  let lastMtimeMs = existsSync(envPath) ? statSync(envPath).mtimeMs : 0;
+  let lastSize = existsSync(envPath) ? statSync(envPath).size : -1;
+
+  const handler = (curr: { mtimeMs: number; size: number }, prev: { mtimeMs: number }) => {
+    if (stopped) return;
+    if (curr.mtimeMs === 0 && prev.mtimeMs !== 0) {
+      logger.warn(`[env-watcher] .env disappeared at ${envPath}; clearing previously loaded keys`);
+    }
+    if (curr.mtimeMs === lastMtimeMs && curr.size === lastSize) return;
+    lastMtimeMs = curr.mtimeMs;
+    lastSize = curr.size;
+    try {
+      const diff = reloadRuntimeEnv();
+      logDiff(diff);
+      applyLogLevel(diff);
+    } catch (err) {
+      logger.error(err, "[env-watcher] Failed to reload .env");
+    }
+  };
+
+  watchFile(envPath, { interval: 2_000, persistent: false }, handler);
+
+  return {
+    stop() {
+      if (stopped) return;
+      stopped = true;
+      unwatchFile(envPath, handler);
+    },
+    reloadNow() {
+      try {
+        const diff = reloadRuntimeEnv();
+        logDiff(diff);
+        applyLogLevel(diff);
+        return diff;
+      } catch (err) {
+        logger.error(err, "[env-watcher] Manual reload failed");
+        return null;
+      }
+    },
+  };
+}

--- a/packages/server/src/config/runtime-config.ts
+++ b/packages/server/src/config/runtime-config.ts
@@ -18,13 +18,23 @@ const DEFAULT_DATABASE_PATH = resolve(DEFAULT_DATA_DIR, DEFAULT_DATABASE_FILE);
 const REGRESSION_DATABASE_PATH = resolve(REGRESSION_DATA_DIR, DEFAULT_DATABASE_FILE);
 
 let envLoaded = false;
+// Keys that the .env file currently contributes to process.env. Tracked so a
+// reload can remove keys that were deleted from the file.
+let envFileKeys = new Set<string>();
+
+export function getEnvFilePath() {
+  return resolve(MONOREPO_ROOT, ".env");
+}
 
 export function loadRuntimeEnv() {
   if (envLoaded) return;
 
-  const envPath = resolve(MONOREPO_ROOT, ".env");
+  const envPath = getEnvFilePath();
   if (existsSync(envPath)) {
-    dotenv.config({ path: envPath });
+    const result = dotenv.config({ path: envPath });
+    if (result.parsed) {
+      envFileKeys = new Set(Object.keys(result.parsed));
+    }
   } else {
     dotenv.config();
   }
@@ -33,6 +43,67 @@ export function loadRuntimeEnv() {
 }
 
 loadRuntimeEnv();
+
+export interface EnvReloadResult {
+  added: string[];
+  updated: string[];
+  removed: string[];
+  unchanged: string[];
+}
+
+/**
+ * Re-read the .env file and propagate changes to process.env with override
+ * semantics. Keys removed from the file are deleted from process.env so that
+ * unsetting a value (e.g. clearing BASIC_AUTH_PASS) takes effect immediately.
+ *
+ * Returns a diff so callers can log or react to specific changes. Throws when
+ * the .env file is missing or unreadable so the caller can decide how to
+ * surface the failure.
+ */
+export function reloadRuntimeEnv(): EnvReloadResult {
+  const envPath = getEnvFilePath();
+  if (!existsSync(envPath)) {
+    // No .env to read — clear any keys we previously set from a now-missing file.
+    const removed = [...envFileKeys];
+    for (const key of removed) {
+      delete process.env[key];
+    }
+    envFileKeys = new Set();
+    return { added: [], updated: [], removed, unchanged: [] };
+  }
+
+  const fileContent = readFileSync(envPath);
+  const parsed = dotenv.parse(fileContent);
+  const newKeys = new Set(Object.keys(parsed));
+
+  const added: string[] = [];
+  const updated: string[] = [];
+  const unchanged: string[] = [];
+  const removed: string[] = [];
+
+  for (const [key, value] of Object.entries(parsed)) {
+    const previous = process.env[key];
+    if (!envFileKeys.has(key)) {
+      added.push(key);
+      process.env[key] = value;
+    } else if (previous !== value) {
+      updated.push(key);
+      process.env[key] = value;
+    } else {
+      unchanged.push(key);
+    }
+  }
+
+  for (const key of envFileKeys) {
+    if (!newKeys.has(key)) {
+      removed.push(key);
+      delete process.env[key];
+    }
+  }
+
+  envFileKeys = newKeys;
+  return { added, updated, removed, unchanged };
+}
 
 function normalizeEnvValue(value: string | undefined | null) {
   const trimmed = value?.trim();

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from "url";
 import { buildApp } from "./app.js";
 import { logger } from "./lib/logger.js";
 import { getHost, getPort, getServerProtocol, loadTlsOptions, logStorageDiagnostics } from "./config/runtime-config.js";
+import { startEnvWatcher } from "./config/env-watcher.js";
 import { migrateTaskbarShortcuts } from "./services/setup/taskbar-shortcut-migration.js";
 
 function scheduleTaskbarShortcutMigration() {
@@ -22,6 +23,7 @@ async function main() {
   const tls = loadTlsOptions();
   logStorageDiagnostics();
   const app = await buildApp(tls ?? undefined);
+  const envWatcher = startEnvWatcher();
   const protocol = tls ? "https" : getServerProtocol();
   const port = getPort();
   const host = getHost();
@@ -37,6 +39,7 @@ async function main() {
     logger.info("Received %s; shutting down Marinara Engine", signal);
 
     try {
+      envWatcher.stop();
       await app.close();
       logger.info("Shutdown complete");
       process.exit(0);


### PR DESCRIPTION
## Summary

- Watches the monorepo-root `.env` and propagates added / updated / removed keys to `process.env` on save.
- Most security middleware already reads via `runtime-config.ts` getters that re-evaluate `process.env` per request, so changes to `BASIC_AUTH_USER` / `BASIC_AUTH_PASS` / `BASIC_AUTH_REALM`, `IP_ALLOWLIST` / `IP_ALLOWLIST_ENABLED`, `ADMIN_SECRET`, `CSRF_TRUSTED_ORIGINS`, `TRUSTED_PRIVATE_NETWORKS`, and the `ALLOW_UNAUTHENTICATED_*` / `*_LOCAL_URLS_ENABLED` flags now take effect on the next request — no restart required.
- Boot-bound variables (`PORT`, `HOST`, `SSL_CERT`/`SSL_KEY`, `CORS_ORIGINS`, storage paths, `ENCRYPTION_KEY`, `TZ`, `AUTO_OPEN_*`) still need a restart; the watcher logs a warning identifying which one changed so users aren't left wondering why nothing happened.

## Why

Users adding access-control settings (Basic Auth, IP allowlist) hit a recurring papercut: edit `.env`, forget to restart, conclude the feature is broken, file an issue. The middleware was already architected for per-request reads — the only blocker was a one-time `dotenv.config()` guard at module load. This PR adds a polling watcher (2 s `fs.watchFile`) and a `reloadRuntimeEnv()` helper that re-parses the file and applies the diff to `process.env` (including key removal, so unsetting a value works). `LOG_LEVEL` changes also flow through to the live pino logger.

## What changed

- `packages/server/src/config/runtime-config.ts` — `loadRuntimeEnv()` now records the keys it set; new `reloadRuntimeEnv()` returns an `{ added, updated, removed, unchanged }` diff after re-parsing.
- `packages/server/src/config/env-watcher.ts` (new) — polling watcher, debounces by mtime + size, masks sensitive values (`BASIC_AUTH_PASS`, `ADMIN_SECRET`, `ENCRYPTION_KEY`, `GIPHY_API_KEY`) when logging, warns on restart-required keys, applies `LOG_LEVEL` live.
- `packages/server/src/index.ts` — starts the watcher after `buildApp()`, stops it on graceful shutdown.
- `docs/REMOTE_ACCESS.md` + `docs/CONFIGURATION.md` — new "When a restart is required" section + tweaked the "restart Marinara" wording in the access-control walkthrough.

## Notes

- No linked issue. Per `CONTRIBUTING.md`, one should be opened describing the user-facing problem (Basic Auth / IP allowlist feedback loop friction) before this is merged.
- Polling at 2 s on a tiny text file is negligible CPU; chose `fs.watchFile` over `fs.watch` for cross-platform reliability (editors that write via temp-file + atomic rename break `fs.watch` on Windows).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Environment variables now support hot-reload: most configuration changes take effect within seconds without requiring a server restart via a new environment watcher.
  * A subset of low-level environment variables still require a full restart to take effect.

* **Documentation**
  * Updated configuration and remote access guides to clarify which environment variables support hot-reload and which require a restart.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->