### PR TITLE
feat(security): trust Tailscale and Docker traffic by default (with opt-out)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,6 +73,27 @@ ALLOW_UNAUTHENTICATED_REMOTE=false
 #             100.64.0.0/10, fc00::/7, fe80::/10
 TRUSTED_PRIVATE_NETWORKS=
 
+# Trusted-interface bypass — set to "true" to let traffic from these ranges
+# skip BOTH the IP allowlist AND Basic Auth, the same way loopback does.
+# Useful for "expose Marinara only over my Tailnet" or "only my Docker
+# containers can reach this" setups, without having to maintain an explicit
+# IP_ALLOWLIST.
+#
+#   BYPASS_AUTH_TAILSCALE — trusts 100.64.0.0/10 (Tailscale CGNAT range).
+#   BYPASS_AUTH_DOCKER    — trusts 172.16.0.0/12 (Docker bridge networks).
+#
+# Cautions:
+#   • If your server's PUBLIC connection is itself behind a CGNAT'd ISP that
+#     uses 100.64.0.0/10, an internet client could appear with a source IP in
+#     this range. Do not enable BYPASS_AUTH_TAILSCALE on a CGNAT'd uplink
+#     unless you've also bound HOST to your tailscale0 IP, or filtered at the
+#     OS firewall.
+#   • 172.16.0.0/12 also covers some private LAN deployments. Only enable
+#     BYPASS_AUTH_DOCKER when the only callers in that range are containers
+#     on a Docker bridge you control.
+BYPASS_AUTH_TAILSCALE=false
+BYPASS_AUTH_DOCKER=false
+
 # CSRF / Origin protection for browser-origin unsafe API requests.
 # The client sends X-Marinara-CSRF automatically. Add extra origins only for
 # trusted alternate frontends/dev hosts. Use the browser-visible origin when

--- a/.env.example
+++ b/.env.example
@@ -73,26 +73,29 @@ ALLOW_UNAUTHENTICATED_REMOTE=false
 #             100.64.0.0/10, fc00::/7, fe80::/10
 TRUSTED_PRIVATE_NETWORKS=
 
-# Trusted-interface bypass — set to "true" to let traffic from these ranges
-# skip BOTH the IP allowlist AND Basic Auth, the same way loopback does.
-# Useful for "expose Marinara only over my Tailnet" or "only my Docker
-# containers can reach this" setups, without having to maintain an explicit
-# IP_ALLOWLIST.
+# Trusted-interface bypass — when true, traffic from these ranges skips
+# BOTH the IP allowlist AND Basic Auth, the same way loopback does. Both
+# default to TRUE so a fresh install works out of the box for the two most
+# common "secure remote access" setups (Tailscale, Docker).
 #
 #   BYPASS_AUTH_TAILSCALE — trusts 100.64.0.0/10 (Tailscale CGNAT range).
+#                           Joining your tailnet already requires your
+#                           Tailscale account, so this is safe by default.
 #   BYPASS_AUTH_DOCKER    — trusts 172.16.0.0/12 (Docker bridge networks).
+#                           Bridge IPs aren't reachable from outside the
+#                           host — packets that actually arrive with this
+#                           source IP came from a container on this host.
 #
-# Cautions:
-#   • If your server's PUBLIC connection is itself behind a CGNAT'd ISP that
-#     uses 100.64.0.0/10, an internet client could appear with a source IP in
-#     this range. Do not enable BYPASS_AUTH_TAILSCALE on a CGNAT'd uplink
-#     unless you've also bound HOST to your tailscale0 IP, or filtered at the
-#     OS firewall.
-#   • 172.16.0.0/12 also covers some private LAN deployments. Only enable
-#     BYPASS_AUTH_DOCKER when the only callers in that range are containers
-#     on a Docker bridge you control.
-BYPASS_AUTH_TAILSCALE=false
-BYPASS_AUTH_DOCKER=false
+# Set either flag to false if your situation matches one of these caveats:
+#   • You run a CGNAT'd public uplink (your ISP uses 100.64.0.0/10 itself)
+#     AND you can't bind HOST to your tailscale0 IP. In that case an
+#     internet client could appear with a Tailscale-shaped source IP. Set
+#     BYPASS_AUTH_TAILSCALE=false (or fix the binding) to stay safe.
+#   • Your non-Docker LAN uses 172.16.x.x / 172.20.x.x addresses. The
+#     bypass would also trust those hosts. Set BYPASS_AUTH_DOCKER=false.
+#   • You want a password from your Tailnet / containers too.
+BYPASS_AUTH_TAILSCALE=true
+BYPASS_AUTH_DOCKER=true
 
 # CSRF / Origin protection for browser-origin unsafe API requests.
 # The client sends X-Marinara-CSRF automatically. Add extra origins only for

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -92,21 +92,22 @@ Marinara Engine ships with layered access-control mechanisms designed for users 
 
 ### Safe-by-default lockdown
 
-By default, when no Basic Auth credentials are configured, the server **refuses connections from every non-loopback IP**. Local browser access continues to work without any configuration:
+By default, when no Basic Auth credentials are configured, the server only accepts connections from a small set of trusted sources:
 
 - Loopback (`127.0.0.1`, `::1`) — always allowed.
 - Anything in `IP_ALLOWLIST` — allowed.
+- Tailscale (`100.64.0.0/10`) and Docker bridge (`172.16.0.0/12`) — allowed by default; see [Trusted-interface bypass](#trusted-interface-bypass-tailscale--docker) to disable.
 
-LAN, Docker bridge, Kubernetes pod, and Tailscale-style private-network callers now require Basic Auth unless you set `ALLOW_UNAUTHENTICATED_PRIVATE_NETWORK=true`. This is the compatibility escape hatch for trusted private networks.
+Everything else — your home LAN's regular `192.168.x.x` / `10.x.x.x` addresses, public-internet callers, Kubernetes pod networks, ULA — requires Basic Auth or `ALLOW_UNAUTHENTICATED_PRIVATE_NETWORK=true`.
 
-Non-loopback callers in the locked-down state receive a `403 Forbidden` with a message describing the ways out:
+Locked-out callers receive a `403 Forbidden` with a message describing the ways out:
 
 1. Set `BASIC_AUTH_USER` and `BASIC_AUTH_PASS` (recommended for internet-facing servers).
 2. Add the public IP / network to `IP_ALLOWLIST`.
 3. Set `ALLOW_UNAUTHENTICATED_PRIVATE_NETWORK=true` to opt back into legacy unauthenticated private-network access.
 4. Set `ALLOW_UNAUTHENTICATED_REMOTE=true` only when unauthenticated public access is intentional.
 
-> Note: the private-network exemption applies only to the lockdown. Once you set Basic Auth credentials, the password is required from every IP except loopback and explicit `IP_ALLOWLIST` matches — including from your LAN. This matches the principle of least surprise: if you set a password, you mean it.
+> Note: even with Basic Auth credentials configured, traffic from the loopback, `IP_ALLOWLIST`, Tailscale, and Docker bridge sources above is still exempt — they're all treated as "already trusted." Set `BYPASS_AUTH_TAILSCALE=false` and/or `BYPASS_AUTH_DOCKER=false` if you want the password from those clients too. Public-internet and ordinary LAN callers always have to authenticate.
 
 #### Customising the private-network list
 
@@ -158,21 +159,27 @@ For sensitive deployments, also consider Tailscale or Cloudflare Access — they
 
 ### Trusted-interface bypass (Tailscale / Docker)
 
-Two opt-in flags let traffic from a specific virtual interface skip both the IP allowlist and Basic Auth, the same way loopback does:
+Two flags trust traffic from a specific virtual interface, skipping both the IP allowlist and Basic Auth the same way loopback does. **Both default to `true`** — a fresh install with no `.env` file is reachable over Tailscale and from Docker containers on the same host without any setup.
 
 ```
 BYPASS_AUTH_TAILSCALE=true   # trusts 100.64.0.0/10 (Tailscale CGNAT range)
 BYPASS_AUTH_DOCKER=true      # trusts 172.16.0.0/12 (Docker bridge networks)
 ```
 
-Use these when you've decided the only way you'll ever reach Marinara remotely is over Tailscale (or only from your Docker containers), and you want zero-friction access from those clients without dropping the password requirement for everyone else. Combines cleanly with `BASIC_AUTH_*`: bypassed clients skip the prompt, everyone else still has to authenticate. The server logs an `[auth-bypass]` line the first time a request actually exercises one of these flags.
+These are safe defaults because:
 
-**Caveats:**
+- A peer in your tailnet already authenticated via your Tailscale account to be there. That's a stronger trust signal than "this packet came from your LAN."
+- Docker bridge IPs are unreachable from outside the host. External traffic NATs through the bridge gateway and arrives with a different source, so a request with `172.16.x.x` / `172.17.x.x` actually came from a container on this host.
 
-- `100.64.0.0/10` is also used by some carrier-grade-NAT ISPs. If your server's public uplink is itself behind CGNAT, an internet client could appear with a Tailscale-shaped source IP and the bypass would let them in. On a CGNAT'd uplink, either leave `BYPASS_AUTH_TAILSCALE` off or bind `HOST` to your `tailscale0` IP so the public NIC never sees the connection.
-- `172.16.0.0/12` also covers some private LAN deployments. Only enable `BYPASS_AUTH_DOCKER` when the only thing in that range is a Docker bridge you control.
+Combines cleanly with `BASIC_AUTH_*`: Tailscale and Docker traffic skips the prompt, everything else (LAN, public internet) still has to authenticate. The server logs an `[auth-bypass]` line the first time a request actually exercises one of these flags.
 
-For the broader "trust every private network" toggle (RFC 1918 + CGNAT + ULA + link-local), see `ALLOW_UNAUTHENTICATED_PRIVATE_NETWORK` under [Safe-by-default lockdown](#safe-by-default-lockdown). The interface-scoped flags above are usually what you actually want, because they trust *only* the interface you set up — not your entire LAN.
+**Set to `false` if:**
+
+- Your server's public uplink is itself behind a CGNAT'd ISP that uses `100.64.0.0/10`. An internet client could appear with a Tailscale-shaped source IP and the bypass would let them in. Set `BYPASS_AUTH_TAILSCALE=false`, or bind `HOST` to your `tailscale0` IP so the public NIC never sees the connection.
+- Your non-Docker LAN uses `172.16.x.x` / `172.20.x.x` addresses. Set `BYPASS_AUTH_DOCKER=false` so non-Docker hosts in that range still hit the auth gate.
+- You want a password from your Tailnet / Docker containers too.
+
+For the broader "trust every private network" toggle (RFC 1918 + CGNAT + ULA + link-local), see `ALLOW_UNAUTHENTICATED_PRIVATE_NETWORK` under [Safe-by-default lockdown](#safe-by-default-lockdown). That one is *off* by default and stays off — it's much broader than these interface-scoped flags.
 
 ### Privileged APIs
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -149,11 +149,30 @@ The following requests are **exempt** from Basic Auth so you cannot lock yoursel
 
 - Loopback (`127.0.0.1`, `::1`) — if you're on the box itself, no password is needed.
 - Any IP listed in `IP_ALLOWLIST` — if you've already vouched for a network at the IP layer, no second factor is required.
+- Tailscale or Docker traffic when their bypass flag is on — see [Trusted-interface bypass](#trusted-interface-bypass-tailscale--docker) below.
 - The `/api/health` endpoint — so external uptime monitors and load balancers can probe the server without credentials.
 
 > **Always pair Basic Auth with HTTPS** when exposing the server to the public internet — Basic Auth credentials are only base64-encoded, not encrypted. Set `SSL_CERT` and `SSL_KEY`, or front Marinara with a TLS-terminating reverse proxy (nginx, Caddy, Traefik, Cloudflare Tunnel).
 
 For sensitive deployments, also consider Tailscale or Cloudflare Access — they avoid exposing the port to the open internet entirely.
+
+### Trusted-interface bypass (Tailscale / Docker)
+
+Two opt-in flags let traffic from a specific virtual interface skip both the IP allowlist and Basic Auth, the same way loopback does:
+
+```
+BYPASS_AUTH_TAILSCALE=true   # trusts 100.64.0.0/10 (Tailscale CGNAT range)
+BYPASS_AUTH_DOCKER=true      # trusts 172.16.0.0/12 (Docker bridge networks)
+```
+
+Use these when you've decided the only way you'll ever reach Marinara remotely is over Tailscale (or only from your Docker containers), and you want zero-friction access from those clients without dropping the password requirement for everyone else. Combines cleanly with `BASIC_AUTH_*`: bypassed clients skip the prompt, everyone else still has to authenticate. The server logs an `[auth-bypass]` line the first time a request actually exercises one of these flags.
+
+**Caveats:**
+
+- `100.64.0.0/10` is also used by some carrier-grade-NAT ISPs. If your server's public uplink is itself behind CGNAT, an internet client could appear with a Tailscale-shaped source IP and the bypass would let them in. On a CGNAT'd uplink, either leave `BYPASS_AUTH_TAILSCALE` off or bind `HOST` to your `tailscale0` IP so the public NIC never sees the connection.
+- `172.16.0.0/12` also covers some private LAN deployments. Only enable `BYPASS_AUTH_DOCKER` when the only thing in that range is a Docker bridge you control.
+
+For the broader "trust every private network" toggle (RFC 1918 + CGNAT + ULA + link-local), see `ALLOW_UNAUTHENTICATED_PRIVATE_NETWORK` under [Safe-by-default lockdown](#safe-by-default-lockdown). The interface-scoped flags above are usually what you actually want, because they trust *only* the interface you set up — not your entire LAN.
 
 ### Privileged APIs
 

--- a/docs/REMOTE_ACCESS.md
+++ b/docs/REMOTE_ACCESS.md
@@ -12,8 +12,9 @@ By default Marinara only answers requests coming from the same machine (`127.0.0
 | --- | --- | --- |
 | Phone, tablet, or laptop on your home Wi-Fi | **Basic Auth** | [Option 1](#option-1-basic-auth-recommended) |
 | Docker / Podman container, accessing from the host or LAN | **Basic Auth** | [Option 1](#option-1-basic-auth-recommended) |
-| Tailscale, ZeroTier, or another VPN you control | **Basic Auth** *or* IP Allowlist | [Option 1](#option-1-basic-auth-recommended) / [Option 2](#option-2-ip-allowlist) |
+| Tailscale, ZeroTier, or another VPN you control | **Basic Auth** *or* IP Allowlist *or* Tailscale bypass | [Option 1](#option-1-basic-auth-recommended) / [Option 2](#option-2-ip-allowlist) / [Option 4](#option-4-tailscale-or-docker-bypass-interface-scoped) |
 | Public-internet exposure (custom domain, port forwarding) | **Basic Auth + HTTPS** | [Option 1](#option-1-basic-auth-recommended) + [HTTPS](#serving-over-https) |
+| Containers / Tailnet should auto-bypass while LAN still needs the password | Interface bypass | [Option 4](#option-4-tailscale-or-docker-bypass-interface-scoped) |
 | You really, really don't want a password and your network is fully trusted | Private-network bypass | [Option 3](#option-3-private-network-bypass-no-password) |
 
 Basic Auth is the most flexible choice — works from any IP, no per-device setup, and the browser remembers it. The IP Allowlist is handy when your client devices have stable IPs (Tailscale, static LAN leases) and you'd rather not type a password.
@@ -59,6 +60,7 @@ Restart Marinara, then open it in your browser from the remote device. You'll se
 
 - Loopback (`127.0.0.1`, `::1`) — you don't need to type your password on the host machine itself.
 - Anything in `IP_ALLOWLIST` — useful if you want some devices to skip the prompt (see below).
+- Tailscale or Docker traffic when their bypass flag is enabled — see [Option 4](#option-4-tailscale-or-docker-bypass-interface-scoped).
 - `/api/health` — so uptime monitors and load balancers can keep working.
 
 **Optional:** set `BASIC_AUTH_REALM` to customise the text the browser prompt shows (default is `Marinara Engine`).
@@ -104,6 +106,32 @@ Anything outside those ranges (i.e. public-internet IPs) still gets a 403. If yo
 > **Trade-off:** anyone on the same private network can reach Marinara without authenticating. That's fine on a network you control; it's not fine on shared Wi-Fi (coffee shop, airport, conference, dorm). When in doubt, use Option 1.
 
 There is also `ALLOW_UNAUTHENTICATED_REMOTE=true` for unauthenticated public-internet access. **Do not turn this on.** If you genuinely need public access, use Basic Auth + HTTPS, or front Marinara with a reverse proxy that handles authentication (Cloudflare Access, Authelia, etc.).
+
+## Option 4: Tailscale or Docker bypass (interface-scoped)
+
+If your only goal is "let my Tailnet peers (or my Docker containers) reach Marinara without typing a password, but block everyone else," there's a more targeted switch than Option 3:
+
+```env
+# Trust traffic from my Tailnet (100.64.0.0/10)
+BYPASS_AUTH_TAILSCALE=true
+
+# Trust traffic from my Docker bridge (172.16.0.0/12)
+BYPASS_AUTH_DOCKER=true
+```
+
+When either flag is on, traffic from the matching range is treated like loopback — it skips both the IP allowlist *and* Basic Auth, even if you have Basic Auth credentials configured for everyone else. The difference vs Option 3 is that this *only* trusts the Tailscale or Docker range, not the entire RFC-1918/CGNAT/ULA private-network list. So you can safely combine it with `BASIC_AUTH_USER` / `BASIC_AUTH_PASS`: your Tailnet skips the prompt, the rest of your LAN still has to type the password.
+
+**When to use this:**
+
+- You set up Tailscale specifically to access Marinara remotely, and want zero-friction access from your Tailnet without a password.
+- Marinara runs in Docker and you have other containers (a reverse proxy, a sidecar) that need to call it without juggling credentials.
+
+**When NOT to use this:**
+
+- **Your server's public connection is on a CGNAT'd ISP that uses `100.64.0.0/10`.** Some carrier-grade NAT setups use the same range Tailscale does. If that applies, an internet client could appear with a source IP that matches the bypass — and `BYPASS_AUTH_TAILSCALE` would let them in. The fix is either to leave the flag off and use Basic Auth, or to bind `HOST` to your `tailscale0` IP so the public NIC never receives the connection. To check, run `tailscale ip -4` and compare with the IP your ISP assigns to your WAN interface.
+- **You have a LAN that uses 172.16.x.x or 172.20.x.x addresses for non-Docker hosts.** `BYPASS_AUTH_DOCKER` trusts the entire `172.16.0.0/12` block; non-Docker callers in that range would also bypass auth. Only flip this on when the only thing in `172.16.0.0/12` is your Docker bridge.
+
+The server logs a `[auth-bypass]` warning the first time a request actually exercises one of these flags, so you have a paper trail of the bypass being live.
 
 ## Serving over HTTPS
 

--- a/docs/REMOTE_ACCESS.md
+++ b/docs/REMOTE_ACCESS.md
@@ -2,20 +2,27 @@
 
 If you're seeing **`403 Forbidden`** when you try to open Marinara Engine from a phone, a Docker container, a Tailscale device, or any other machine that isn't the one running the server, this guide is for you.
 
-By default Marinara only answers requests coming from the same machine (`127.0.0.1` / `::1`). Anything else — your phone on the same Wi-Fi, a Tailscale tablet, a browser hitting the Docker port — gets blocked until you tell Marinara who's allowed in. This is intentional: if your server ever ends up reachable from the public internet, an unprotected install would be wide open. The fix is to set up one of the access methods below and restart.
+By default Marinara only answers requests from three trusted sources:
 
-> **TL;DR** — If you just want it to work and you're on a network you trust (home Wi-Fi, Docker on your own machine, your own Tailnet): set `BASIC_AUTH_USER` and `BASIC_AUTH_PASS` in `.env`, restart, and use those credentials when the browser prompts. That covers 95% of cases.
+1. **Loopback** (`127.0.0.1` / `::1`) — the machine running the server itself.
+2. **Your Tailnet** (`100.64.0.0/10`) — Tailscale peers, since joining your tailnet already required your Tailscale account.
+3. **Docker containers on the same host** (`172.16.0.0/12`) — bridge IPs aren't reachable from outside the host.
+
+Anything else — your phone on the same Wi-Fi, a public-internet client, a coffee-shop laptop — gets blocked until you tell Marinara who's allowed in. If those defaults are too permissive for your setup (rare; see [Option 4](#option-4-tailscale-or-docker-bypass-interface-scoped-on-by-default)), set `BYPASS_AUTH_TAILSCALE=false` / `BYPASS_AUTH_DOCKER=false`.
+
+> **TL;DR** — If you only ever access Marinara over Tailscale, or only from Docker containers on the same host, **you don't need to do anything** — it already works. If you also want to reach it from a phone on your home Wi-Fi or another LAN device: set `BASIC_AUTH_USER` and `BASIC_AUTH_PASS` in `.env`, restart, and use those credentials when the browser prompts. That covers 95% of cases.
 
 ## Which option do I pick?
 
 | Your situation | Pick this | Section |
 | --- | --- | --- |
+| Tailscale, ZeroTier-on-100.64/10, or another VPN you control | **Already works** — no setup needed | [Option 4](#option-4-tailscale-or-docker-bypass-interface-scoped-on-by-default) |
+| Docker / Podman container, accessing from the same host | **Already works** — no setup needed | [Option 4](#option-4-tailscale-or-docker-bypass-interface-scoped-on-by-default) |
 | Phone, tablet, or laptop on your home Wi-Fi | **Basic Auth** | [Option 1](#option-1-basic-auth-recommended) |
-| Docker / Podman container, accessing from the host or LAN | **Basic Auth** | [Option 1](#option-1-basic-auth-recommended) |
-| Tailscale, ZeroTier, or another VPN you control | **Basic Auth** *or* IP Allowlist *or* Tailscale bypass | [Option 1](#option-1-basic-auth-recommended) / [Option 2](#option-2-ip-allowlist) / [Option 4](#option-4-tailscale-or-docker-bypass-interface-scoped) |
 | Public-internet exposure (custom domain, port forwarding) | **Basic Auth + HTTPS** | [Option 1](#option-1-basic-auth-recommended) + [HTTPS](#serving-over-https) |
-| Containers / Tailnet should auto-bypass while LAN still needs the password | Interface bypass | [Option 4](#option-4-tailscale-or-docker-bypass-interface-scoped) |
-| You really, really don't want a password and your network is fully trusted | Private-network bypass | [Option 3](#option-3-private-network-bypass-no-password) |
+| Stable LAN IPs and you'd rather not type a password | IP Allowlist | [Option 2](#option-2-ip-allowlist) |
+| You want a password from your Tailnet / containers TOO | Disable Option 4 + use Option 1 | [Option 4](#option-4-tailscale-or-docker-bypass-interface-scoped-on-by-default) + [Option 1](#option-1-basic-auth-recommended) |
+| You really, really don't want a password and your whole LAN is trusted | Private-network bypass | [Option 3](#option-3-private-network-bypass-no-password) |
 
 Basic Auth is the most flexible choice — works from any IP, no per-device setup, and the browser remembers it. The IP Allowlist is handy when your client devices have stable IPs (Tailscale, static LAN leases) and you'd rather not type a password.
 
@@ -60,7 +67,7 @@ Restart Marinara, then open it in your browser from the remote device. You'll se
 
 - Loopback (`127.0.0.1`, `::1`) — you don't need to type your password on the host machine itself.
 - Anything in `IP_ALLOWLIST` — useful if you want some devices to skip the prompt (see below).
-- Tailscale or Docker traffic when their bypass flag is enabled — see [Option 4](#option-4-tailscale-or-docker-bypass-interface-scoped).
+- Tailscale (`100.64.0.0/10`) and Docker bridge (`172.16.0.0/12`) traffic — bypassed by default; see [Option 4](#option-4-tailscale-or-docker-bypass-interface-scoped-on-by-default) to disable.
 - `/api/health` — so uptime monitors and load balancers can keep working.
 
 **Optional:** set `BASIC_AUTH_REALM` to customise the text the browser prompt shows (default is `Marinara Engine`).
@@ -107,31 +114,30 @@ Anything outside those ranges (i.e. public-internet IPs) still gets a 403. If yo
 
 There is also `ALLOW_UNAUTHENTICATED_REMOTE=true` for unauthenticated public-internet access. **Do not turn this on.** If you genuinely need public access, use Basic Auth + HTTPS, or front Marinara with a reverse proxy that handles authentication (Cloudflare Access, Authelia, etc.).
 
-## Option 4: Tailscale or Docker bypass (interface-scoped)
+## Option 4: Tailscale or Docker bypass (interface-scoped, on by default)
 
-If your only goal is "let my Tailnet peers (or my Docker containers) reach Marinara without typing a password, but block everyone else," there's a more targeted switch than Option 3:
+Two interface-scoped flags let traffic from a Tailnet or a Docker bridge skip both the IP allowlist *and* Basic Auth, the same way loopback does. **Both flags default to `true`**, so a fresh Marinara install reachable over Tailscale or from your Docker containers Just Works without any `.env` setup.
 
 ```env
-# Trust traffic from my Tailnet (100.64.0.0/10)
-BYPASS_AUTH_TAILSCALE=true
-
-# Trust traffic from my Docker bridge (172.16.0.0/12)
-BYPASS_AUTH_DOCKER=true
+# These are the defaults — listed here so you can see how to override them.
+BYPASS_AUTH_TAILSCALE=true   # trusts 100.64.0.0/10 (Tailnet CGNAT)
+BYPASS_AUTH_DOCKER=true      # trusts 172.16.0.0/12 (Docker bridge)
 ```
 
-When either flag is on, traffic from the matching range is treated like loopback — it skips both the IP allowlist *and* Basic Auth, even if you have Basic Auth credentials configured for everyone else. The difference vs Option 3 is that this *only* trusts the Tailscale or Docker range, not the entire RFC-1918/CGNAT/ULA private-network list. So you can safely combine it with `BASIC_AUTH_USER` / `BASIC_AUTH_PASS`: your Tailnet skips the prompt, the rest of your LAN still has to type the password.
+**Why these are safe by default:**
 
-**When to use this:**
+- A peer in your Tailnet already had to authenticate to your Tailscale account to be there. That's a stronger trust signal than "this packet came from your LAN" — anyone in the coffee shop is on your LAN. Almost no one in the coffee shop is on your tailnet.
+- Docker bridge IPs are unreachable from outside the host. External traffic NATs through the bridge gateway and arrives with a different source IP, so a request that actually shows up with `172.17.x.x` or `172.18.x.x` genuinely came from a container on the same host as Marinara.
 
-- You set up Tailscale specifically to access Marinara remotely, and want zero-friction access from your Tailnet without a password.
-- Marinara runs in Docker and you have other containers (a reverse proxy, a sidecar) that need to call it without juggling credentials.
+**Combines cleanly with Basic Auth:** if you set `BASIC_AUTH_USER` / `BASIC_AUTH_PASS`, your Tailnet and Docker containers still skip the prompt while the rest of your LAN and any internet traffic still has to authenticate. That's the typical "no friction from my devices, password from anyone else" setup.
 
-**When NOT to use this:**
+**When to set these to `false`:**
 
-- **Your server's public connection is on a CGNAT'd ISP that uses `100.64.0.0/10`.** Some carrier-grade NAT setups use the same range Tailscale does. If that applies, an internet client could appear with a source IP that matches the bypass — and `BYPASS_AUTH_TAILSCALE` would let them in. The fix is either to leave the flag off and use Basic Auth, or to bind `HOST` to your `tailscale0` IP so the public NIC never receives the connection. To check, run `tailscale ip -4` and compare with the IP your ISP assigns to your WAN interface.
-- **You have a LAN that uses 172.16.x.x or 172.20.x.x addresses for non-Docker hosts.** `BYPASS_AUTH_DOCKER` trusts the entire `172.16.0.0/12` block; non-Docker callers in that range would also bypass auth. Only flip this on when the only thing in `172.16.0.0/12` is your Docker bridge.
+- **Your server's public connection is on a CGNAT'd ISP that uses `100.64.0.0/10`.** Some carrier-grade NAT setups use the same range Tailscale does. If that applies, an internet client could appear with a source IP that matches the bypass — and `BYPASS_AUTH_TAILSCALE=true` would let them in. To check, run `tailscale ip -4` and compare with the IP your ISP assigns to your WAN interface; if both are in `100.64.0.0/10`, either set `BYPASS_AUTH_TAILSCALE=false` or bind `HOST` to your `tailscale0` IP so the public NIC never sees the connection.
+- **Your non-Docker LAN uses `172.16.x.x` / `172.20.x.x` addresses.** `BYPASS_AUTH_DOCKER=true` trusts the entire `172.16.0.0/12` block; non-Docker callers in that range would also bypass auth. Set `BYPASS_AUTH_DOCKER=false` and add the specific containers to `IP_ALLOWLIST` instead.
+- **You genuinely want a password from your Tailnet / containers too** — set the corresponding flag to `false`.
 
-The server logs a `[auth-bypass]` warning the first time a request actually exercises one of these flags, so you have a paper trail of the bypass being live.
+The server logs an `[auth-bypass]` warning the first time a request actually exercises one of these flags, so you can confirm in the log when the bypass goes live.
 
 ## Serving over HTTPS
 

--- a/packages/server/src/config/runtime-config.ts
+++ b/packages/server/src/config/runtime-config.ts
@@ -269,6 +269,32 @@ export function getTrustedPrivateNetworksOverride() {
   return normalizeEnvValue(process.env.TRUSTED_PRIVATE_NETWORKS);
 }
 
+/**
+ * Trust traffic from the Tailscale CGNAT range (100.64.0.0/10) unconditionally.
+ * When enabled, those clients skip both the IP allowlist and Basic Auth, the
+ * same way loopback does. Useful for "expose Marinara only to my Tailnet" setups.
+ *
+ * Caveat: if your server's public connection is itself behind a CGNAT'd ISP that
+ * uses 100.64.0.0/10, an internet client can appear with a source IP in this
+ * range. Bind HOST to your tailscale0 IP (or use a host firewall) for hard
+ * isolation when that risk applies.
+ */
+export function isTailscaleBypassEnabled() {
+  return isEnabledFlag(process.env.BYPASS_AUTH_TAILSCALE);
+}
+
+/**
+ * Trust traffic from the Docker bridge range (172.16.0.0/12) unconditionally.
+ * When enabled, those clients skip both the IP allowlist and Basic Auth.
+ *
+ * Caveat: 172.16.0.0/12 also covers some private LAN deployments. Only enable
+ * this when you're sure the only callers in that range are containers on a
+ * Docker bridge you control.
+ */
+export function isDockerBypassEnabled() {
+  return isEnabledFlag(process.env.BYPASS_AUTH_DOCKER);
+}
+
 export function isDebugAgentsEnabled() {
   const value = normalizeEnvValue(process.env.DEBUG_AGENTS);
   return value === "1" || value?.toLowerCase() === "true";

--- a/packages/server/src/config/runtime-config.ts
+++ b/packages/server/src/config/runtime-config.ts
@@ -272,27 +272,39 @@ export function getTrustedPrivateNetworksOverride() {
 /**
  * Trust traffic from the Tailscale CGNAT range (100.64.0.0/10) unconditionally.
  * When enabled, those clients skip both the IP allowlist and Basic Auth, the
- * same way loopback does. Useful for "expose Marinara only to my Tailnet" setups.
+ * same way loopback does.
  *
- * Caveat: if your server's public connection is itself behind a CGNAT'd ISP that
- * uses 100.64.0.0/10, an internet client can appear with a source IP in this
- * range. Bind HOST to your tailscale0 IP (or use a host firewall) for hard
- * isolation when that risk applies.
+ * Default: ON. Joining a tailnet already requires authentication via the
+ * operator's Tailscale account, which is a stronger trust signal than "any
+ * LAN." Set BYPASS_AUTH_TAILSCALE=false to require Basic Auth from your
+ * Tailnet too.
+ *
+ * Caveat: if your server's public connection is itself behind a CGNAT'd ISP
+ * that uses 100.64.0.0/10, an internet client can appear with a source IP in
+ * this range. Bind HOST to your tailscale0 IP (or use a host firewall) for
+ * hard isolation when that risk applies, or set the flag to false.
  */
 export function isTailscaleBypassEnabled() {
-  return isEnabledFlag(process.env.BYPASS_AUTH_TAILSCALE);
+  // Default-on: only an explicit disable flag turns it off.
+  return !isDisabledFlag(process.env.BYPASS_AUTH_TAILSCALE);
 }
 
 /**
  * Trust traffic from the Docker bridge range (172.16.0.0/12) unconditionally.
  * When enabled, those clients skip both the IP allowlist and Basic Auth.
  *
- * Caveat: 172.16.0.0/12 also covers some private LAN deployments. Only enable
- * this when you're sure the only callers in that range are containers on a
- * Docker bridge you control.
+ * Default: ON. Docker bridge IPs are unreachable from outside the host —
+ * external traffic is NAT'd through the bridge gateway, so a request that
+ * actually arrives with a 172.16.0.0/12 source IP genuinely came from a
+ * container on this host. Set BYPASS_AUTH_DOCKER=false to require auth from
+ * containers as well.
+ *
+ * Caveat: 172.16.0.0/12 also covers some private LAN deployments. If your
+ * non-Docker LAN uses 172.16.x.x or 172.20.x.x addresses, set the flag to
+ * false.
  */
 export function isDockerBypassEnabled() {
-  return isEnabledFlag(process.env.BYPASS_AUTH_DOCKER);
+  return !isDisabledFlag(process.env.BYPASS_AUTH_DOCKER);
 }
 
 export function isDebugAgentsEnabled() {

--- a/packages/server/src/middleware/basic-auth.ts
+++ b/packages/server/src/middleware/basic-auth.ts
@@ -46,7 +46,7 @@ import {
   isUnauthenticatedRemoteAllowed,
 } from "../config/runtime-config.js";
 import { logger } from "../lib/logger.js";
-import { isInIpAllowlist, isLoopbackIp, isPrivateNetworkIp } from "./ip-allowlist.js";
+import { isInIpAllowlist, isLoopbackIp, isPrivateNetworkIp, isTrustedInterfaceIp } from "./ip-allowlist.js";
 
 interface CachedConfig {
   user: string;
@@ -314,7 +314,7 @@ export function isBasicAuthSatisfied(request: FastifyRequest): boolean {
   if (request.url === "/api/health" || request.url.startsWith("/api/health?")) return true;
 
   const ip = request.ip;
-  if (isLoopbackIp(ip) || isInIpAllowlist(ip)) return true;
+  if (isLoopbackIp(ip) || isInIpAllowlist(ip) || isTrustedInterfaceIp(ip)) return true;
 
   const config = loadConfig();
   if (!config) {
@@ -335,9 +335,11 @@ export function basicAuthHook(request: FastifyRequest, reply: FastifyReply, done
     return done();
   }
 
-  // Exempt loopback and any IP already vouched for by IP_ALLOWLIST
+  // Exempt loopback, IPs already vouched for by IP_ALLOWLIST, and traffic
+  // arriving from a trusted Tailscale / Docker interface (when its bypass
+  // flag is on).
   const ip = request.ip;
-  const trusted = isLoopbackIp(ip) || isInIpAllowlist(ip);
+  const trusted = isLoopbackIp(ip) || isInIpAllowlist(ip) || isTrustedInterfaceIp(ip);
   if (trusted) return done();
 
   const config = loadConfig();

--- a/packages/server/src/middleware/ip-allowlist.ts
+++ b/packages/server/src/middleware/ip-allowlist.ts
@@ -12,7 +12,12 @@
 // so you can never lock yourself out of local access.
 
 import type { FastifyRequest, FastifyReply } from "fastify";
-import { getIpAllowlist, getTrustedPrivateNetworksOverride } from "../config/runtime-config.js";
+import {
+  getIpAllowlist,
+  getTrustedPrivateNetworksOverride,
+  isDockerBypassEnabled,
+  isTailscaleBypassEnabled,
+} from "../config/runtime-config.js";
 import { logger } from "../lib/logger.js";
 
 // ── CIDR helpers ──
@@ -126,6 +131,12 @@ function matchesCIDR(ipBytes: number[], cidr: CIDREntry): boolean {
 
 // ── Loopback CIDRs (always allowed) ──
 const LOOPBACK_CIDRS: CIDREntry[] = [parseCIDR("127.0.0.1")!, parseCIDR("::1")!];
+
+// ── Specific interface CIDRs used by the Tailscale / Docker bypass ──
+// Tailscale assigns Tailnet peer IPs from the CGNAT block 100.64.0.0/10.
+// Docker's default bridge networks live within 172.16.0.0/12.
+const TAILSCALE_CIDR = parseCIDR("100.64.0.0/10")!;
+const DOCKER_CIDR = parseCIDR("172.16.0.0/12")!;
 
 // ── Private / non-routable network CIDRs ──
 // Used by the safe-by-default Basic Auth lockdown to avoid breaking
@@ -266,6 +277,55 @@ export function isInIpAllowlist(ip: string): boolean {
   return false;
 }
 
+/** True if the given IP is in the Tailscale CGNAT range (100.64.0.0/10). */
+export function isTailscaleIp(ip: string): boolean {
+  const bytes = ipToBytes(ip);
+  if (!bytes) return false;
+  return matchesCIDR(bytes, TAILSCALE_CIDR);
+}
+
+/** True if the given IP is in the Docker bridge range (172.16.0.0/12). */
+export function isDockerIp(ip: string): boolean {
+  const bytes = ipToBytes(ip);
+  if (!bytes) return false;
+  return matchesCIDR(bytes, DOCKER_CIDR);
+}
+
+let bypassAnnounced = { tailscale: false, docker: false };
+
+/**
+ * True if the given IP belongs to a Tailscale or Docker interface AND the
+ * matching BYPASS_AUTH_* flag is enabled. These clients skip both the IP
+ * allowlist and Basic Auth, the same way loopback does.
+ */
+export function isTrustedInterfaceIp(ip: string): boolean {
+  const tailscaleOn = isTailscaleBypassEnabled();
+  const dockerOn = isDockerBypassEnabled();
+  if (!tailscaleOn && !dockerOn) return false;
+
+  if (tailscaleOn && isTailscaleIp(ip)) {
+    if (!bypassAnnounced.tailscale) {
+      logger.warn(
+        "[auth-bypass] BYPASS_AUTH_TAILSCALE=true — clients in 100.64.0.0/10 will skip Basic Auth and IP allowlist",
+      );
+      bypassAnnounced.tailscale = true;
+    }
+    return true;
+  }
+
+  if (dockerOn && isDockerIp(ip)) {
+    if (!bypassAnnounced.docker) {
+      logger.warn(
+        "[auth-bypass] BYPASS_AUTH_DOCKER=true — clients in 172.16.0.0/12 will skip Basic Auth and IP allowlist",
+      );
+      bypassAnnounced.docker = true;
+    }
+    return true;
+  }
+
+  return false;
+}
+
 // ── Fastify onRequest hook ──
 
 export function ipAllowlistHook(request: FastifyRequest, reply: FastifyReply, done: () => void) {
@@ -287,6 +347,10 @@ export function ipAllowlistHook(request: FastifyRequest, reply: FastifyReply, do
   for (const lb of LOOPBACK_CIDRS) {
     if (matchesCIDR(bytes, lb)) return done();
   }
+
+  // Trusted Tailscale / Docker interfaces (when their bypass flag is on)
+  // are treated like loopback — skip the allowlist check entirely.
+  if (isTrustedInterfaceIp(ip)) return done();
 
   // Check the allowlist
   for (const entry of allowlist) {


### PR DESCRIPTION
## Summary

- Two new flags, `BYPASS_AUTH_TAILSCALE` and `BYPASS_AUTH_DOCKER`, treat traffic from `100.64.0.0/10` (Tailnet CGNAT) and `172.16.0.0/12` (Docker bridge networks) as trusted — those clients skip both the IP allowlist *and* Basic Auth, the same way loopback already does.
- **Both flags default to `true`** so a fresh install with no `.env` works over Tailscale or from same-host Docker containers without any setup.
- Combines cleanly with `BASIC_AUTH_*`: bypassed clients skip the prompt, ordinary LAN / public-internet clients still authenticate. The first request that exercises a bypass logs an `[auth-bypass]` warning so the operator has a paper trail.

## Why

Two recurring user-friction patterns:

1. **"I just installed Marinara and want to reach it from my phone over Tailscale."** Today the lockdown page blocks them; they have to read the docs, generate a password, restart the server. For tailnet access — where joining the tailnet already required the operator's Tailscale account — that's needless friction. Tailnet membership is a stronger trust signal than "any LAN," so trusting `100.64.0.0/10` by default doesn't violate the safe-by-default ethos the way trusting `192.168.0.0/16` would.
2. **"My Marinara container is being called by another container on the same Docker bridge."** Bridge IPs (`172.16.0.0/12`) are unreachable from outside the host — external traffic NATs through the bridge gateway and arrives with a different source — so a request that actually shows up with a `172.x.x.x` source genuinely came from a container on the same host. Trusting that range is also safe by default.

## What changed

- `packages/server/src/config/runtime-config.ts` — added `isTailscaleBypassEnabled()` / `isDockerBypassEnabled()` getters using `!isDisabledFlag(...)` so unset / "true" / "yes" / "1" all enable, only "false" / "no" / "0" / "off" disable.
- `packages/server/src/middleware/ip-allowlist.ts` — extracted the Tailscale and Docker CIDRs as named constants, added `isTailscaleIp()` / `isDockerIp()` predicates and `isTrustedInterfaceIp()` (which checks the bypass flag and logs a one-shot `[auth-bypass]` warning the first time each range is exercised). Wired into `ipAllowlistHook` after the loopback short-circuit.
- `packages/server/src/middleware/basic-auth.ts` — `isBasicAuthSatisfied()` and `basicAuthHook()` treat `isTrustedInterfaceIp(ip)` exactly like loopback or `IP_ALLOWLIST` matches.
- `.env.example` — both flags listed with `=true`, with inline caveats so users see when to disable.
- `docs/REMOTE_ACCESS.md` — rewrote the intro / TL;DR / decision table; new "Option 4: Tailscale or Docker bypass (interface-scoped, on by default)" section; updated Option 1's exemption list.
- `docs/CONFIGURATION.md` — new "Trusted-interface bypass" subsection under Access Control; updated the "Safe-by-default lockdown" so its exempt-list is accurate.

## Caveats (documented)

- `100.64.0.0/10` is also used by some carrier-grade-NAT ISPs. If your server's public uplink is itself behind CGNAT, an internet client could appear with a Tailscale-shaped source IP — set `BYPASS_AUTH_TAILSCALE=false` or bind `HOST` to your `tailscale0` IP.
- `172.16.0.0/12` also covers some private LAN deployments that aren't Docker. If your non-Docker LAN uses `172.16.x.x` / `172.20.x.x`, set `BYPASS_AUTH_DOCKER=false`.
- The broader `ALLOW_UNAUTHENTICATED_PRIVATE_NETWORK` (which trusts the entire RFC 1918 + CGNAT + ULA + link-local set) **stays default-off**. This PR only narrows the auto-trust to two interfaces where the access path itself is authenticated.

## Notes

- No linked issue. Per `CONTRIBUTING.md`, one should be opened describing the user-facing problem (Tailscale users hitting the lockdown page on a fresh install) before this is merged.
- Rebased on top of `main` after #463 (env hot-reload) merged, so the runtime-config and docs edits coexist cleanly.

## Test plan

- [ ] Manually verify a fresh install with **no `.env` file** is reachable from a Tailscale device. Server log shows `[auth-bypass] BYPASS_AUTH_TAILSCALE=true …` once on first request.
- [ ] Manually verify the same fresh-install scenario from a regular LAN phone (non-Tailscale, non-Docker) still hits the lockdown HTML page — confirms we narrowed the trust to just Tailscale/Docker, not the whole LAN.
- [ ] Manually verify loopback (`http://127.0.0.1:7860`) on the host still works regardless of these flags' values.
- [ ] Manually verify the bypass coexists with Basic Auth: set `BASIC_AUTH_USER` / `BASIC_AUTH_PASS`, refresh from Tailscale → loads with no prompt; refresh from a regular LAN phone → password prompt.
- [ ] Manually verify explicit opt-out works: set `BYPASS_AUTH_TAILSCALE=false`, restart, refresh from Tailscale → lockdown page (or password prompt if Basic Auth is configured).
- [ ] Manually verify the bypass beats the IP allowlist: set `IP_ALLOWLIST=192.168.1.0/24` (LAN only, NOT including Tailscale), keep defaults, hit from Tailscale → loads; hit from a non-allowlisted, non-Tailscale device → 403.
- [ ] Manually verify the `[auth-bypass]` warning fires only **once per range per process**, not on every subsequent request.
- [ ] Manually verify Docker bypass from inside a container on the default bridge: `curl http://<host-bridge-ip>:7860/api/health` from a sidecar container → 200, server logs `[auth-bypass] BYPASS_AUTH_DOCKER=true …` once.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic trust for Tailscale and Docker network traffic by default
  * Introduced configuration options to disable Tailscale and Docker interface bypasses if needed

* **Documentation**
  * Updated configuration guides to document new trusted interface bypass options and their default behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->