### PR TITLE
feat(extensions): server-side storage for cross-device sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 - Guides for all modes.
 - QoL improvements to Lorebooks handling.
 - Optional intuitive swipe navigation lets Conversation and Roleplay users move through rerolls with arrow keys or touch swipes, with an opt-in reroll-at-the-end shortcut.
+- Installed extensions now sync to the Marinara server instead of per-browser localStorage, so installs, toggles, and removals carry across devices on the same instance; existing local extensions migrate automatically on first load.
 - Roleplay chats can now optionally let characters create direct-message Conversation chats with hidden `[dm: ...]` commands.
 - Lorebook entries can now be selected in bulk and copied or moved to another lorebook.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 - Guides for all modes.
 - QoL improvements to Lorebooks handling.
 - Optional intuitive swipe navigation lets Conversation and Roleplay users move through rerolls with arrow keys or touch swipes, with an opt-in reroll-at-the-end shortcut.
-- Installed extensions now sync to the Marinara server instead of per-browser localStorage, so installs, toggles, and removals carry across devices on the same instance; existing local extensions migrate automatically on first load.
 - Roleplay chats can now optionally let characters create direct-message Conversation chats with hidden `[dm: ...]` commands.
 - Lorebook entries can now be selected in bulk and copied or moved to another lorebook.
 

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -14,6 +14,7 @@ import { useSidecarStore } from "./stores/sidecar.store";
 import { api } from "./lib/api-client";
 import { forceRefreshSpa } from "./lib/browser-runtime";
 import { useLegacyThemeMigration } from "./hooks/use-themes";
+import { useLegacyExtensionMigration } from "./hooks/use-extensions";
 import { useSettingsSync } from "./hooks/use-settings-sync";
 
 const VERSION_RECOVERY_KEY = "marinara:pwa-version-recovery";
@@ -49,6 +50,7 @@ export function App() {
   const fontFamily = useUIStore((s) => s.fontFamily);
   const hasModalOpen = useUIStore((s) => s.modal !== null);
   useLegacyThemeMigration();
+  useLegacyExtensionMigration();
   useSettingsSync();
   const showDownloadModal = useSidecarStore((s) => s.showDownloadModal);
   const setShowDownloadModal = useSidecarStore((s) => s.setShowDownloadModal);

--- a/packages/client/src/components/layout/CustomThemeInjector.tsx
+++ b/packages/client/src/components/layout/CustomThemeInjector.tsx
@@ -3,8 +3,8 @@
 // CSS and enabled extension CSS/JS into the DOM
 // ──────────────────────────────────────────────
 import { useEffect } from "react";
-import { useUIStore } from "../../stores/ui.store";
 import { useThemes } from "../../hooks/use-themes";
+import { useExtensions } from "../../hooks/use-extensions";
 
 type ExtensionGlobal = typeof globalThis & {
   __marinaraExtensionApis?: Map<string, unknown>;
@@ -41,7 +41,7 @@ function buildExtensionModuleSource(apiKey: string, extensionName: string, js: s
 }
 
 export function CustomThemeInjector() {
-  const installedExtensions = useUIStore((s) => s.installedExtensions);
+  const { data: installedExtensions = [] } = useExtensions();
   const { data: syncedThemes = [] } = useThemes();
   const activeTheme = syncedThemes.find((theme) => theme.isActive) ?? null;
 
@@ -163,8 +163,18 @@ export function CustomThemeInjector() {
           },
 
           // Fetch from Marinara API
+          // Deny extensions from calling sensitive endpoints. Without this,
+          // a malicious extension could `apiFetch("/extensions", { method: "POST", ... })`
+          // to re-install itself after the user deletes it, or hit `/admin/*`
+          // privileged routes.
           apiFetch: async (path: string, options?: RequestInit) => {
-            const res = await fetch(`/api${path}`, {
+            const normalized = path.startsWith("/") ? path : `/${path}`;
+            if (normalized.startsWith("/extensions") || normalized.startsWith("/admin")) {
+              const message = `apiFetch denied: extensions cannot reach ${normalized}`;
+              console.warn(`[Extension:${ext.name}] ${message}`);
+              return Promise.reject(new Error(message));
+            }
+            const res = await fetch(`/api${normalized}`, {
               headers: { "Content-Type": "application/json" },
               ...options,
             });

--- a/packages/client/src/components/layout/CustomThemeInjector.tsx
+++ b/packages/client/src/components/layout/CustomThemeInjector.tsx
@@ -2,9 +2,10 @@
 // CustomThemeInjector: Injects active custom theme
 // CSS and enabled extension CSS/JS into the DOM
 // ──────────────────────────────────────────────
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import { useThemes } from "../../hooks/use-themes";
 import { useExtensions } from "../../hooks/use-extensions";
+import { useUIStore } from "../../stores/ui.store";
 
 type ExtensionGlobal = typeof globalThis & {
   __marinaraExtensionApis?: Map<string, unknown>;
@@ -41,7 +42,16 @@ function buildExtensionModuleSource(apiKey: string, extensionName: string, js: s
 }
 
 export function CustomThemeInjector() {
-  const { data: installedExtensions = [] } = useExtensions();
+  const { data: serverExtensions = [] } = useExtensions();
+  const legacyExtensions = useUIStore((s) => s.installedExtensions);
+  const hasMigrated = useUIStore((s) => s.hasMigratedExtensionsToServer);
+  // Until the legacy localStorage list has been migrated, fall back to it so
+  // users with pre-PR extensions don't see them vanish during the brief window
+  // between app boot and `useLegacyExtensionMigration` finishing.
+  const installedExtensions = useMemo(
+    () => (hasMigrated ? serverExtensions : legacyExtensions),
+    [hasMigrated, serverExtensions, legacyExtensions],
+  );
   const { data: syncedThemes = [] } = useThemes();
   const activeTheme = syncedThemes.find((theme) => theme.isActive) ?? null;
 
@@ -166,15 +176,24 @@ export function CustomThemeInjector() {
           // Deny extensions from calling sensitive endpoints. Without this,
           // a malicious extension could `apiFetch("/extensions", { method: "POST", ... })`
           // to re-install itself after the user deletes it, or hit `/admin/*`
-          // privileged routes.
+          // privileged routes. The denylist runs on the *canonical* pathname
+          // produced by the WHATWG URL parser, so `%2e%2e/admin` and other
+          // dot-segment / encoded-traversal payloads can't sneak past.
           apiFetch: async (path: string, options?: RequestInit) => {
             const normalized = path.startsWith("/") ? path : `/${path}`;
-            if (normalized.startsWith("/extensions") || normalized.startsWith("/admin")) {
-              const message = `apiFetch denied: extensions cannot reach ${normalized}`;
+            const url = new URL(`/api${normalized}`, window.location.origin);
+            const apiPath = url.pathname.replace(/^\/api(?=\/|$)/, "");
+            const denied =
+              apiPath === "/extensions" ||
+              apiPath.startsWith("/extensions/") ||
+              apiPath === "/admin" ||
+              apiPath.startsWith("/admin/");
+            if (denied) {
+              const message = `apiFetch denied: extensions cannot reach ${apiPath}`;
               console.warn(`[Extension:${ext.name}] ${message}`);
               return Promise.reject(new Error(message));
             }
-            const res = await fetch(`/api${normalized}`, {
+            const res = await fetch(`${url.pathname}${url.search}`, {
               headers: { "Content-Type": "application/json" },
               ...options,
             });

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -5,11 +5,16 @@ import {
   APP_LANGUAGE_OPTIONS,
   useUIStore,
   type GameDialogueDisplayMode,
-  type InstalledExtension,
   type RoleplayAvatarStyle,
   type VisualTheme,
 } from "../../stores/ui.store";
-import { cn, generateClientId } from "../../lib/utils";
+import { cn } from "../../lib/utils";
+import {
+  useExtensions,
+  useCreateExtension,
+  useDeleteExtension,
+  useUpdateExtension,
+} from "../../hooks/use-extensions";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { ADMIN_SECRET_STORAGE_KEY, api, getAdminSecretHeader } from "../../lib/api-client";
 import { forceRefreshSpa } from "@/lib/browser-runtime";
@@ -326,10 +331,6 @@ function GeneralSettings() {
   const setTrimIncompleteModelOutput = useUIStore((s) => s.setTrimIncompleteModelOutput);
   const speechToTextEnabled = useUIStore((s) => s.speechToTextEnabled);
   const setSpeechToTextEnabled = useUIStore((s) => s.setSpeechToTextEnabled);
-  const intuitiveSwipeNavigation = useUIStore((s) => s.intuitiveSwipeNavigation);
-  const setIntuitiveSwipeNavigation = useUIStore((s) => s.setIntuitiveSwipeNavigation);
-  const intuitiveSwipeRerollLatest = useUIStore((s) => s.intuitiveSwipeRerollLatest);
-  const setIntuitiveSwipeRerollLatest = useUIStore((s) => s.setIntuitiveSwipeRerollLatest);
   const rescanGameAssets = useGameAssetStore((s) => s.rescanAssets);
   const assetFileRef = useRef<HTMLInputElement>(null);
   const [assetCategory, setAssetCategory] = useState<GameAssetCategoryId>("backgrounds");
@@ -604,22 +605,6 @@ function GeneralSettings() {
         onChange={setSpeechToTextEnabled}
         help="When on, chat input bars show a microphone button for browser dictation. Handy still works independently by pasting into the focused input field."
       />
-
-      <ToggleSetting
-        label="Intuitive swipe navigation"
-        checked={intuitiveSwipeNavigation}
-        onChange={setIntuitiveSwipeNavigation}
-        help="In Conversation and Roleplay modes, use Left/Right Arrow on desktop or horizontal touch swipes on mobile to move between alternate generations on the latest assistant message."
-      />
-
-      <div className={cn("pl-5 transition-opacity", intuitiveSwipeNavigation ? "" : "pointer-events-none opacity-45")}>
-        <ToggleSetting
-          label="Reroll past the newest swipe"
-          checked={intuitiveSwipeRerollLatest}
-          onChange={setIntuitiveSwipeRerollLatest}
-          help="When intuitive swipes are enabled, pressing Right Arrow or swiping left on the newest swipe of the latest assistant message creates a new reroll."
-        />
-      </div>
 
       <div className="rounded-xl bg-[var(--secondary)]/50 p-4 ring-1 ring-[var(--border)]">
         <div className="mb-3 flex flex-col gap-1">
@@ -2066,10 +2051,10 @@ const CSS_TEMPLATE = `/* ══════════════════�
 `;
 
 function ExtensionsSettings() {
-  const extensions = useUIStore((s) => s.installedExtensions);
-  const addExtension = useUIStore((s) => s.addExtension);
-  const removeExtension = useUIStore((s) => s.removeExtension);
-  const toggleExtension = useUIStore((s) => s.toggleExtension);
+  const { data: extensions = [] } = useExtensions();
+  const createExtension = useCreateExtension();
+  const updateExtension = useUpdateExtension();
+  const deleteExtension = useDeleteExtension();
   const fileRef = useRef<HTMLInputElement>(null);
 
   const handleImportExtension = async (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -2077,41 +2062,39 @@ function ExtensionsSettings() {
     if (!file) return;
     try {
       const text = await file.text();
+      const installedAt = new Date().toISOString();
 
       if (file.name.endsWith(".json")) {
         const parsed = JSON.parse(text);
-        const ext: InstalledExtension = {
-          id: generateClientId(),
-          name: parsed.name ?? file.name.replace(/\.json$/, ""),
+        const name = parsed.name ?? file.name.replace(/\.json$/, "");
+        await createExtension.mutateAsync({
+          name,
           description: parsed.description ?? "",
-          css: parsed.css ?? undefined,
-          js: parsed.js ?? undefined,
+          css: parsed.css ?? null,
+          js: parsed.js ?? null,
           enabled: true,
-          installedAt: new Date().toISOString(),
-        };
-        addExtension(ext);
-        toast.success(`Extension "${ext.name}" installed`);
+          installedAt,
+        });
+        toast.success(`Extension "${name}" installed`);
       } else if (file.name.endsWith(".js")) {
-        const ext: InstalledExtension = {
-          id: generateClientId(),
-          name: file.name.replace(/\.js$/, ""),
+        const name = file.name.replace(/\.js$/, "");
+        await createExtension.mutateAsync({
+          name,
           description: "JS extension imported from file",
           js: text,
           enabled: true,
-          installedAt: new Date().toISOString(),
-        };
-        addExtension(ext);
-        toast.success(`Extension "${ext.name}" installed`);
+          installedAt,
+        });
+        toast.success(`Extension "${name}" installed`);
       } else if (file.name.endsWith(".css")) {
-        const ext: InstalledExtension = {
-          id: generateClientId(),
-          name: file.name.replace(/\.css$/, ""),
+        const name = file.name.replace(/\.css$/, "");
+        await createExtension.mutateAsync({
+          name,
           description: "CSS extension imported from file",
           css: text,
           enabled: true,
-          installedAt: new Date().toISOString(),
-        };
-        addExtension(ext);
+          installedAt,
+        });
       } else {
         toast.error("Only .json and .css extension files are supported.");
       }
@@ -2152,7 +2135,7 @@ function ExtensionsSettings() {
             )}
           >
             <button
-              onClick={() => toggleExtension(ext.id)}
+              onClick={() => updateExtension.mutate({ id: ext.id, enabled: !ext.enabled })}
               className={cn(
                 "rounded p-0.5 transition-colors",
                 ext.enabled
@@ -2170,7 +2153,7 @@ function ExtensionsSettings() {
               )}
             </div>
             <button
-              onClick={() => removeExtension(ext.id)}
+              onClick={() => deleteExtension.mutate(ext.id)}
               className="rounded p-0.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--destructive)]/10 hover:text-[var(--destructive)]"
               title="Remove extension"
             >

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -331,6 +331,10 @@ function GeneralSettings() {
   const setTrimIncompleteModelOutput = useUIStore((s) => s.setTrimIncompleteModelOutput);
   const speechToTextEnabled = useUIStore((s) => s.speechToTextEnabled);
   const setSpeechToTextEnabled = useUIStore((s) => s.setSpeechToTextEnabled);
+  const intuitiveSwipeNavigation = useUIStore((s) => s.intuitiveSwipeNavigation);
+  const setIntuitiveSwipeNavigation = useUIStore((s) => s.setIntuitiveSwipeNavigation);
+  const intuitiveSwipeRerollLatest = useUIStore((s) => s.intuitiveSwipeRerollLatest);
+  const setIntuitiveSwipeRerollLatest = useUIStore((s) => s.setIntuitiveSwipeRerollLatest);
   const rescanGameAssets = useGameAssetStore((s) => s.rescanAssets);
   const assetFileRef = useRef<HTMLInputElement>(null);
   const [assetCategory, setAssetCategory] = useState<GameAssetCategoryId>("backgrounds");
@@ -605,6 +609,22 @@ function GeneralSettings() {
         onChange={setSpeechToTextEnabled}
         help="When on, chat input bars show a microphone button for browser dictation. Handy still works independently by pasting into the focused input field."
       />
+
+      <ToggleSetting
+        label="Intuitive swipe navigation"
+        checked={intuitiveSwipeNavigation}
+        onChange={setIntuitiveSwipeNavigation}
+        help="In Conversation and Roleplay modes, use Left/Right Arrow on desktop or horizontal touch swipes on mobile to move between alternate generations on the latest assistant message."
+      />
+
+      <div className={cn("pl-5 transition-opacity", intuitiveSwipeNavigation ? "" : "pointer-events-none opacity-45")}>
+        <ToggleSetting
+          label="Reroll past the newest swipe"
+          checked={intuitiveSwipeRerollLatest}
+          onChange={setIntuitiveSwipeRerollLatest}
+          help="When intuitive swipes are enabled, pressing Right Arrow or swiping left on the newest swipe of the latest assistant message creates a new reroll."
+        />
+      </div>
 
       <div className="rounded-xl bg-[var(--secondary)]/50 p-4 ring-1 ring-[var(--border)]">
         <div className="mb-3 flex flex-col gap-1">
@@ -2051,7 +2071,8 @@ const CSS_TEMPLATE = `/* ══════════════════�
 `;
 
 function ExtensionsSettings() {
-  const { data: extensions = [] } = useExtensions();
+  const { data: extensions, isLoading } = useExtensions();
+  const extensionList = extensions ?? [];
   const createExtension = useCreateExtension();
   const updateExtension = useUpdateExtension();
   const deleteExtension = useDeleteExtension();
@@ -2095,11 +2116,12 @@ function ExtensionsSettings() {
           enabled: true,
           installedAt,
         });
+        toast.success(`Extension "${name}" installed`);
       } else {
-        toast.error("Only .json and .css extension files are supported.");
+        toast.error("Only .json, .css, and .js extension files are supported.");
       }
-    } catch {
-      toast.error("Failed to import extension.");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to import extension.");
     }
     e.target.value = "";
   };
@@ -2124,7 +2146,7 @@ function ExtensionsSettings() {
       <div className="flex flex-col gap-1.5">
         <span className="text-xs font-medium">Installed Extensions</span>
 
-        {extensions.map((ext) => (
+        {extensionList.map((ext) => (
           <div
             key={ext.id}
             className={cn(
@@ -2162,9 +2184,9 @@ function ExtensionsSettings() {
           </div>
         ))}
 
-        {extensions.length === 0 && (
+        {!isLoading && extensionList.length === 0 && (
           <p className="py-2 text-center text-[0.625rem] text-[var(--muted-foreground)]">
-            No extensions installed. Import a .json or .css extension file above.
+            No extensions installed. Import a .json, .css, or .js extension file above.
           </p>
         )}
       </div>

--- a/packages/client/src/hooks/use-extensions.ts
+++ b/packages/client/src/hooks/use-extensions.ts
@@ -1,0 +1,123 @@
+// ──────────────────────────────────────────────
+// Hooks: Installed Extensions (server-synced)
+// ──────────────────────────────────────────────
+import { useEffect, useRef } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { api } from "../lib/api-client";
+import { useUIStore } from "../stores/ui.store";
+import type { CreateExtensionInput, InstalledExtension, UpdateExtensionInput } from "@marinara-engine/shared";
+
+export const extensionKeys = {
+  all: ["extensions"] as const,
+  list: () => [...extensionKeys.all, "list"] as const,
+};
+
+function findDuplicateExtension(extensions: InstalledExtension[], name: string, css: string | null, js: string | null) {
+  return (
+    extensions.find(
+      (ext) => ext.name === name && (ext.css ?? null) === (css ?? null) && (ext.js ?? null) === (js ?? null),
+    ) ?? null
+  );
+}
+
+export function useExtensions() {
+  return useQuery({
+    queryKey: extensionKeys.list(),
+    queryFn: () => api.get<InstalledExtension[]>("/extensions"),
+    staleTime: 0,
+    refetchOnWindowFocus: true,
+    refetchOnReconnect: true,
+    refetchInterval: () => (document.hidden ? false : 15_000),
+  });
+}
+
+export function useCreateExtension() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: CreateExtensionInput) => api.post<InstalledExtension>("/extensions", data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: extensionKeys.all });
+    },
+  });
+}
+
+export function useUpdateExtension() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, ...data }: { id: string } & UpdateExtensionInput) =>
+      api.patch<InstalledExtension>(`/extensions/${id}`, data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: extensionKeys.all });
+    },
+  });
+}
+
+export function useDeleteExtension() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => api.delete(`/extensions/${id}`),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: extensionKeys.all });
+    },
+  });
+}
+
+/**
+ * One-shot migration of pre-server-storage extensions out of localStorage.
+ *
+ * Mirrors `useLegacyThemeMigration`: on first successful list fetch we POST
+ * any local-only extensions that don't already exist on the server, then
+ * clear the legacy array and flip the migration flag so we don't run again.
+ */
+export function useLegacyExtensionMigration() {
+  const legacyExtensions = useUIStore((s) => s.installedExtensions);
+  const hasMigrated = useUIStore((s) => s.hasMigratedExtensionsToServer);
+  const clearLegacy = useUIStore((s) => s.clearLegacyExtensions);
+  const setMigrated = useUIStore((s) => s.setHasMigratedExtensionsToServer);
+  const qc = useQueryClient();
+  const inFlightRef = useRef(false);
+  const { isSuccess } = useExtensions();
+
+  useEffect(() => {
+    if (hasMigrated || !isSuccess || inFlightRef.current) {
+      return;
+    }
+    if (legacyExtensions.length === 0) {
+      setMigrated(true);
+      return;
+    }
+
+    inFlightRef.current = true;
+    void (async () => {
+      try {
+        const serverExtensions = await api.get<InstalledExtension[]>("/extensions");
+        let working = [...serverExtensions];
+
+        for (const legacy of legacyExtensions) {
+          const css = legacy.css ?? null;
+          const js = legacy.js ?? null;
+          const duplicate = findDuplicateExtension(working, legacy.name, css, js);
+          if (duplicate) continue;
+
+          const created = await api.post<InstalledExtension>("/extensions", {
+            name: legacy.name,
+            description: legacy.description ?? "",
+            css,
+            js,
+            enabled: legacy.enabled,
+            installedAt: legacy.installedAt,
+          });
+          working = [created, ...working];
+        }
+
+        clearLegacy();
+        setMigrated(true);
+        await qc.invalidateQueries({ queryKey: extensionKeys.all });
+      } catch {
+        // Leave migration flag untouched so the next app start can retry.
+      } finally {
+        inFlightRef.current = false;
+      }
+    })();
+  }, [clearLegacy, hasMigrated, isSuccess, legacyExtensions, qc, setMigrated]);
+}

--- a/packages/client/src/hooks/use-extensions.ts
+++ b/packages/client/src/hooks/use-extensions.ts
@@ -3,7 +3,7 @@
 // ──────────────────────────────────────────────
 import { useEffect, useRef } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { api } from "../lib/api-client";
+import { api, ApiError } from "../lib/api-client";
 import { useUIStore } from "../stores/ui.store";
 import type { CreateExtensionInput, InstalledExtension, UpdateExtensionInput } from "@marinara-engine/shared";
 
@@ -18,6 +18,29 @@ function findDuplicateExtension(extensions: InstalledExtension[], name: string, 
       (ext) => ext.name === name && (ext.css ?? null) === (css ?? null) && (ext.js ?? null) === (js ?? null),
     ) ?? null
   );
+}
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+/**
+ * POST one extension, backing off on 429 so a long legacy list doesn't dead-end
+ * behind the per-IP `/api/extensions` rate limiter (60 req/min).
+ */
+async function postExtensionWithBackoff(input: CreateExtensionInput): Promise<InstalledExtension> {
+  const MAX_ATTEMPTS = 6;
+  let lastError: unknown;
+  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt += 1) {
+    try {
+      return await api.post<InstalledExtension>("/extensions", input);
+    } catch (err) {
+      lastError = err;
+      if (!(err instanceof ApiError) || err.status !== 429) throw err;
+      // Exponential backoff capped at the 60s rate-limit window.
+      const delay = Math.min(60_000, 2 ** attempt * 1_000);
+      await sleep(delay);
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error("Extension migration failed after retries");
 }
 
 export function useExtensions() {
@@ -76,7 +99,7 @@ export function useLegacyExtensionMigration() {
   const setMigrated = useUIStore((s) => s.setHasMigratedExtensionsToServer);
   const qc = useQueryClient();
   const inFlightRef = useRef(false);
-  const { isSuccess } = useExtensions();
+  const { data: serverExtensions, isSuccess } = useExtensions();
 
   useEffect(() => {
     if (hasMigrated || !isSuccess || inFlightRef.current) {
@@ -90,8 +113,9 @@ export function useLegacyExtensionMigration() {
     inFlightRef.current = true;
     void (async () => {
       try {
-        const serverExtensions = await api.get<InstalledExtension[]>("/extensions");
-        let working = [...serverExtensions];
+        // Reuse the list React Query already fetched instead of issuing a
+        // duplicate GET that would eat into the rate-limit budget.
+        let working = [...(serverExtensions ?? [])];
 
         for (const legacy of legacyExtensions) {
           const css = legacy.css ?? null;
@@ -99,7 +123,7 @@ export function useLegacyExtensionMigration() {
           const duplicate = findDuplicateExtension(working, legacy.name, css, js);
           if (duplicate) continue;
 
-          const created = await api.post<InstalledExtension>("/extensions", {
+          const created = await postExtensionWithBackoff({
             name: legacy.name,
             description: legacy.description ?? "",
             css,
@@ -113,11 +137,12 @@ export function useLegacyExtensionMigration() {
         clearLegacy();
         setMigrated(true);
         await qc.invalidateQueries({ queryKey: extensionKeys.all });
-      } catch {
+      } catch (err) {
         // Leave migration flag untouched so the next app start can retry.
+        console.warn("[Extensions] Legacy migration failed; will retry on next load.", err);
       } finally {
         inFlightRef.current = false;
       }
     })();
-  }, [clearLegacy, hasMigrated, isSuccess, legacyExtensions, qc, setMigrated]);
+  }, [clearLegacy, hasMigrated, isSuccess, legacyExtensions, qc, serverExtensions, setMigrated]);
 }

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -84,16 +84,20 @@ export interface CustomTheme {
   installedAt: string;
 }
 
-/** A user-installed extension (JS/CSS) */
-export interface InstalledExtension {
+/**
+ * Pre-migration shape of a browser-local extension. Only used to read
+ * existing localStorage state and replay it against the server
+ * (`/api/extensions`) on first load — see `useLegacyExtensionMigration`.
+ * New extensions go directly through the server-synced hooks in
+ * `use-extensions.ts` and use the canonical `InstalledExtension` type
+ * exported from `@marinara-engine/shared`.
+ */
+export interface LegacyInstalledExtension {
   id: string;
   name: string;
   description: string;
-  /** CSS to inject */
   css?: string;
-  /** JavaScript to execute */
   js?: string;
-  /** Whether the extension is enabled */
   enabled: boolean;
   installedAt: string;
 }
@@ -245,7 +249,10 @@ interface UIState {
   customThemes: CustomTheme[];
   /** True once legacy browser-local themes have been migrated to the server. */
   hasMigratedCustomThemesToServer: boolean;
-  installedExtensions: InstalledExtension[];
+  /** Legacy browser-local extensions. Migration only — see useLegacyExtensionMigration. */
+  installedExtensions: LegacyInstalledExtension[];
+  /** True once legacy browser-local extensions have been migrated to the server. */
+  hasMigratedExtensionsToServer: boolean;
 
   // ── Onboarding ──
   hasCompletedOnboarding: boolean;
@@ -370,9 +377,9 @@ interface UIState {
   addCustomTheme: (theme: CustomTheme) => void;
   updateCustomTheme: (id: string, patch: Partial<Pick<CustomTheme, "name" | "css">>) => void;
   removeCustomTheme: (id: string) => void;
-  addExtension: (ext: InstalledExtension) => void;
-  removeExtension: (id: string) => void;
-  toggleExtension: (id: string) => void;
+  /** Legacy migration helpers for browser-local extensions. */
+  setHasMigratedExtensionsToServer: (v: boolean) => void;
+  clearLegacyExtensions: () => void;
   setHasCompletedOnboarding: (v: boolean) => void;
   setGameTutorialDisabled: (v: boolean) => void;
   dismissLinkApiBanner: () => void;
@@ -542,6 +549,7 @@ export const useUIStore = create<UIState>()(
       customThemes: [],
       hasMigratedCustomThemesToServer: false,
       installedExtensions: [],
+      hasMigratedExtensionsToServer: false,
       hasCompletedOnboarding: false,
       gameTutorialDisabled: false,
       linkApiBannerDismissed: false,
@@ -837,15 +845,8 @@ export const useUIStore = create<UIState>()(
           customThemes: s.customThemes.filter((t) => t.id !== id),
           activeCustomTheme: s.activeCustomTheme === id ? null : s.activeCustomTheme,
         })),
-      addExtension: (ext) => set((s) => ({ installedExtensions: [...s.installedExtensions, ext] })),
-      removeExtension: (id) =>
-        set((s) => ({
-          installedExtensions: s.installedExtensions.filter((e) => e.id !== id),
-        })),
-      toggleExtension: (id) =>
-        set((s) => ({
-          installedExtensions: s.installedExtensions.map((e) => (e.id === id ? { ...e, enabled: !e.enabled } : e)),
-        })),
+      setHasMigratedExtensionsToServer: (v) => set({ hasMigratedExtensionsToServer: v }),
+      clearLegacyExtensions: () => set({ installedExtensions: [] }),
       setHasCompletedOnboarding: (v) => set({ hasCompletedOnboarding: v }),
       setGameTutorialDisabled: (v) => set({ gameTutorialDisabled: v }),
       dismissLinkApiBanner: () => set({ linkApiBannerDismissed: true }),
@@ -857,7 +858,7 @@ export const useUIStore = create<UIState>()(
     }),
     {
       name: "marinara-engine-ui",
-      version: 17,
+      version: 18,
       // Debounce localStorage writes to avoid sync I/O on every state change
       storage: createJSONStorage(() => {
         let timer: ReturnType<typeof setTimeout> | null = null;
@@ -1021,6 +1022,12 @@ export const useUIStore = create<UIState>()(
             persisted.intuitiveSwipeRerollLatest = false;
           }
         }
+        // v17 -> v18: add legacy extension migration completion flag.
+        if (version <= 17) {
+          if (persisted.hasMigratedExtensionsToServer === undefined) {
+            persisted.hasMigratedExtensionsToServer = false;
+          }
+        }
         return persisted;
       },
       partialize: (state) => ({
@@ -1081,6 +1088,7 @@ export const useUIStore = create<UIState>()(
         activeCustomTheme: state.activeCustomTheme,
         customThemes: state.customThemes,
         installedExtensions: state.installedExtensions,
+        hasMigratedExtensionsToServer: state.hasMigratedExtensionsToServer,
         hasCompletedOnboarding: state.hasCompletedOnboarding,
         linkApiBannerDismissed: state.linkApiBannerDismissed,
         echoChamberSide: state.echoChamberSide,

--- a/packages/server/drizzle.config.cts
+++ b/packages/server/drizzle.config.cts
@@ -70,6 +70,7 @@ export default defineConfig({
     "./src/db/schema/regex-scripts.ts",
     "./src/db/schema/gallery.ts",
     "./src/db/schema/themes.ts",
+    "./src/db/schema/extensions.ts",
     "./src/db/schema/app-settings.ts",
   ],
   out: "./src/db/migrations",

--- a/packages/server/src/db/file-backed-store.ts
+++ b/packages/server/src/db/file-backed-store.ts
@@ -181,6 +181,7 @@ export const FILE_BACKED_TABLES = [
   "app_settings",
   "chat_presets",
   "prompt_overrides",
+  "installed_extensions",
 ] as const;
 
 type FileBackedTable = (typeof FILE_BACKED_TABLES)[number];

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -412,6 +412,17 @@ const CREATE_TABLES: string[] = [
     value TEXT NOT NULL DEFAULT '',
     updated_at TEXT NOT NULL
   )`,
+  `CREATE TABLE IF NOT EXISTS installed_extensions (
+    id TEXT PRIMARY KEY NOT NULL,
+    name TEXT NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    css TEXT,
+    js TEXT,
+    enabled TEXT NOT NULL DEFAULT 'true',
+    installed_at TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+  )`,
   `CREATE TABLE IF NOT EXISTS chat_presets (
     id TEXT PRIMARY KEY NOT NULL,
     name TEXT NOT NULL,

--- a/packages/server/src/db/schema/extensions.ts
+++ b/packages/server/src/db/schema/extensions.ts
@@ -1,0 +1,16 @@
+// ──────────────────────────────────────────────
+// Schema: Installed Extensions
+// ──────────────────────────────────────────────
+import { sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+export const installedExtensions = sqliteTable("installed_extensions", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+  description: text("description").notNull().default(""),
+  css: text("css"),
+  js: text("js"),
+  enabled: text("enabled").notNull().default("true"),
+  installedAt: text("installed_at").notNull(),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull(),
+});

--- a/packages/server/src/db/schema/index.ts
+++ b/packages/server/src/db/schema/index.ts
@@ -15,5 +15,6 @@ export * from "./checkpoints.js";
 export * from "./regex-scripts.js";
 export * from "./gallery.js";
 export * from "./themes.js";
+export * from "./extensions.js";
 export * from "./app-settings.js";
 export * from "./prompt-overrides.js";

--- a/packages/server/src/middleware/rate-limit.ts
+++ b/packages/server/src/middleware/rate-limit.ts
@@ -28,6 +28,10 @@ const ROUTE_RULES: Array<{ pattern: RegExp; rule: RateLimitRule }> = [
     rule: { key: "sidecar-privileged", limit: 20, windowMs: 60_000 },
   },
   { pattern: /^\/api\/haptic\/command(?:\?|$)/, rule: { key: "haptic-command", limit: 30, windowMs: 60_000 } },
+  // Cap on extension routes so an XSS-driven mass install / spam can't
+  // exploit the persistent storage path. 60/min covers React Query
+  // refetches + legacy migrations of small extension lists comfortably.
+  { pattern: /^\/api\/extensions(?:\/|\?|$)/, rule: { key: "extensions", limit: 60, windowMs: 60_000 } },
 ];
 
 const buckets = new Map<string, Bucket>();

--- a/packages/server/src/routes/extensions.routes.ts
+++ b/packages/server/src/routes/extensions.routes.ts
@@ -1,0 +1,46 @@
+// ──────────────────────────────────────────────
+// Routes: Installed Extensions
+// ──────────────────────────────────────────────
+//
+// CRUD only. Extension JS is fetched as part of the list payload and
+// loaded client-side via the existing v1.5.8 blob-URL loader in
+// `CustomThemeInjector.tsx` — no server-side script-serving endpoint.
+// ──────────────────────────────────────────────
+import type { FastifyInstance } from "fastify";
+import { createExtensionSchema, updateExtensionSchema } from "@marinara-engine/shared";
+import { createExtensionsStorage } from "../services/storage/extensions.storage.js";
+
+const ID_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
+
+export async function extensionsRoutes(app: FastifyInstance) {
+  const storage = createExtensionsStorage(app.db);
+
+  app.get("/", async () => {
+    return storage.list();
+  });
+
+  app.post("/", async (req) => {
+    const input = createExtensionSchema.parse(req.body);
+    return storage.create(input);
+  });
+
+  app.patch<{ Params: { id: string } }>("/:id", async (req, reply) => {
+    if (!ID_PATTERN.test(req.params.id)) {
+      return reply.status(404).send({ error: "Extension not found" });
+    }
+    const data = updateExtensionSchema.parse(req.body);
+    const existing = await storage.getById(req.params.id);
+    if (!existing) return reply.status(404).send({ error: "Extension not found" });
+    return storage.update(req.params.id, data);
+  });
+
+  app.delete<{ Params: { id: string } }>("/:id", async (req, reply) => {
+    if (!ID_PATTERN.test(req.params.id)) {
+      return reply.status(404).send({ error: "Extension not found" });
+    }
+    const existing = await storage.getById(req.params.id);
+    if (!existing) return reply.status(404).send({ error: "Extension not found" });
+    await storage.remove(req.params.id);
+    return reply.status(204).send();
+  });
+}

--- a/packages/server/src/routes/index.ts
+++ b/packages/server/src/routes/index.ts
@@ -41,6 +41,7 @@ import { chatFoldersRoutes } from "./chat-folders.routes.js";
 import { chatPresetsRoutes } from "./chat-presets.routes.js";
 import { updatesRoutes } from "./updates.routes.js";
 import { themesRoutes } from "./themes.routes.js";
+import { extensionsRoutes } from "./extensions.routes.js";
 import { appSettingsRoutes } from "./app-settings.routes.js";
 import { gameRoutes } from "./game.routes.js";
 import { gameAssetsRoutes } from "./game-assets.routes.js";
@@ -88,6 +89,7 @@ export async function registerRoutes(app: FastifyInstance) {
   await app.register(botBrowserDatacatRoutes, { prefix: "/api/bot-browser" });
   await app.register(updatesRoutes, { prefix: "/api/updates" });
   await app.register(themesRoutes, { prefix: "/api/themes" });
+  await app.register(extensionsRoutes, { prefix: "/api/extensions" });
   await app.register(appSettingsRoutes, { prefix: "/api/app-settings" });
   await app.register(gameRoutes, { prefix: "/api/game" });
   await app.register(gameAssetsRoutes, { prefix: "/api/game-assets" });

--- a/packages/server/src/services/storage/extensions.storage.ts
+++ b/packages/server/src/services/storage/extensions.storage.ts
@@ -1,0 +1,73 @@
+// ──────────────────────────────────────────────
+// Storage: Installed Extensions
+// ──────────────────────────────────────────────
+import { desc, eq } from "drizzle-orm";
+import type { DB } from "../../db/connection.js";
+import { installedExtensions } from "../../db/schema/index.js";
+import { newId, now } from "../../utils/id-generator.js";
+import type { CreateExtensionInput, InstalledExtension, UpdateExtensionInput } from "@marinara-engine/shared";
+
+type ExtensionRow = typeof installedExtensions.$inferSelect;
+
+function mapExtension(row: ExtensionRow): InstalledExtension {
+  return {
+    id: row.id,
+    name: row.name,
+    description: row.description,
+    css: row.css ?? null,
+    js: row.js ?? null,
+    enabled: row.enabled === "true",
+    installedAt: row.installedAt,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+export function createExtensionsStorage(db: DB) {
+  return {
+    async list() {
+      const rows = await db.select().from(installedExtensions).orderBy(desc(installedExtensions.installedAt));
+      return rows.map(mapExtension);
+    },
+
+    async getById(id: string) {
+      const rows = await db.select().from(installedExtensions).where(eq(installedExtensions.id, id));
+      const row = rows[0];
+      return row ? mapExtension(row) : null;
+    },
+
+    async create(input: CreateExtensionInput) {
+      const id = newId();
+      const timestamp = now();
+      await db.insert(installedExtensions).values({
+        id,
+        name: input.name,
+        description: input.description ?? "",
+        css: input.css ?? null,
+        js: input.js ?? null,
+        enabled: input.enabled === false ? "false" : "true",
+        installedAt: input.installedAt ?? timestamp,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      });
+      return this.getById(id);
+    },
+
+    async update(id: string, data: UpdateExtensionInput) {
+      const updateFields: Partial<typeof installedExtensions.$inferInsert> = {
+        updatedAt: now(),
+      };
+      if (data.name !== undefined) updateFields.name = data.name;
+      if (data.description !== undefined) updateFields.description = data.description;
+      if (data.css !== undefined) updateFields.css = data.css;
+      if (data.js !== undefined) updateFields.js = data.js;
+      if (data.enabled !== undefined) updateFields.enabled = data.enabled ? "true" : "false";
+      await db.update(installedExtensions).set(updateFields).where(eq(installedExtensions.id, id));
+      return this.getById(id);
+    },
+
+    async remove(id: string) {
+      await db.delete(installedExtensions).where(eq(installedExtensions.id, id));
+    },
+  };
+}

--- a/packages/server/src/services/storage/extensions.storage.ts
+++ b/packages/server/src/services/storage/extensions.storage.ts
@@ -24,17 +24,21 @@ function mapExtension(row: ExtensionRow): InstalledExtension {
 }
 
 export function createExtensionsStorage(db: DB) {
+  // Lexical helper so create()/update() don't depend on `this` — keeps the
+  // storage object safe to destructure or pass as a callback.
+  const getById = async (id: string) => {
+    const rows = await db.select().from(installedExtensions).where(eq(installedExtensions.id, id));
+    const row = rows[0];
+    return row ? mapExtension(row) : null;
+  };
+
   return {
     async list() {
       const rows = await db.select().from(installedExtensions).orderBy(desc(installedExtensions.installedAt));
       return rows.map(mapExtension);
     },
 
-    async getById(id: string) {
-      const rows = await db.select().from(installedExtensions).where(eq(installedExtensions.id, id));
-      const row = rows[0];
-      return row ? mapExtension(row) : null;
-    },
+    getById,
 
     async create(input: CreateExtensionInput) {
       const id = newId();
@@ -50,7 +54,7 @@ export function createExtensionsStorage(db: DB) {
         createdAt: timestamp,
         updatedAt: timestamp,
       });
-      return this.getById(id);
+      return getById(id);
     },
 
     async update(id: string, data: UpdateExtensionInput) {
@@ -63,7 +67,7 @@ export function createExtensionsStorage(db: DB) {
       if (data.js !== undefined) updateFields.js = data.js;
       if (data.enabled !== undefined) updateFields.enabled = data.enabled ? "true" : "false";
       await db.update(installedExtensions).set(updateFields).where(eq(installedExtensions.id, id));
-      return this.getById(id);
+      return getById(id);
     },
 
     async remove(id: string) {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -19,6 +19,7 @@ export * from "./types/regex.js";
 export * from "./types/export.js";
 export * from "./types/haptic.js";
 export * from "./types/theme.js";
+export * from "./types/extension.js";
 export * from "./types/chat-preset.js";
 export * from "./types/game.js";
 export * from "./types/sidecar.js";
@@ -35,6 +36,7 @@ export * from "./schemas/agent.schema.js";
 export * from "./schemas/custom-tool.schema.js";
 export * from "./schemas/regex.schema.js";
 export * from "./schemas/theme.schema.js";
+export * from "./schemas/extension.schema.js";
 export * from "./schemas/app-settings.schema.js";
 
 // Constants

--- a/packages/shared/src/schemas/extension.schema.ts
+++ b/packages/shared/src/schemas/extension.schema.ts
@@ -1,0 +1,34 @@
+// ──────────────────────────────────────────────
+// Extension Zod Schemas
+// ──────────────────────────────────────────────
+import { z } from "zod";
+
+// Generous-but-finite size caps. CSS and JS are stored as TEXT in SQLite
+// and emitted verbatim into the page, so an unbounded payload would be a
+// real DoS surface even past basicAuth.
+const MAX_EXTENSION_CSS_BYTES = 256 * 1024; // 256 KiB
+const MAX_EXTENSION_JS_BYTES = 1024 * 1024; // 1 MiB
+
+export const createExtensionSchema = z.object({
+  name: z.string().min(1).max(200),
+  description: z.string().max(2000).default(""),
+  css: z.string().max(MAX_EXTENSION_CSS_BYTES).nullable().optional(),
+  js: z.string().max(MAX_EXTENSION_JS_BYTES).nullable().optional(),
+  enabled: z.boolean().optional(),
+  installedAt: z.string().datetime().optional(),
+});
+
+export const updateExtensionSchema = z
+  .object({
+    name: z.string().min(1).max(200).optional(),
+    description: z.string().max(2000).optional(),
+    css: z.string().max(MAX_EXTENSION_CSS_BYTES).nullable().optional(),
+    js: z.string().max(MAX_EXTENSION_JS_BYTES).nullable().optional(),
+    enabled: z.boolean().optional(),
+  })
+  .refine((value) => Object.keys(value).length > 0, {
+    message: "Must update at least one field",
+  });
+
+export type CreateExtensionInput = z.infer<typeof createExtensionSchema>;
+export type UpdateExtensionInput = z.infer<typeof updateExtensionSchema>;

--- a/packages/shared/src/schemas/extension.schema.ts
+++ b/packages/shared/src/schemas/extension.schema.ts
@@ -9,11 +9,37 @@ import { z } from "zod";
 const MAX_EXTENSION_CSS_BYTES = 256 * 1024; // 256 KiB
 const MAX_EXTENSION_JS_BYTES = 1024 * 1024; // 1 MiB
 
+// `z.string().max(n)` counts UTF-16 code units, so a CSS file full of
+// multi-byte characters could blow past the SQLite-row budget while still
+// passing validation. Measure actual UTF-8 bytes instead. Inlined rather
+// than calling `TextEncoder` so the shared package stays runtime-agnostic
+// (the `dom`/`node` libs aren't enabled in `tsconfig.base.json`).
+function utf8ByteLength(value: string): number {
+  let bytes = 0;
+  for (let i = 0; i < value.length; i += 1) {
+    const code = value.charCodeAt(i);
+    if (code < 0x80) bytes += 1;
+    else if (code < 0x800) bytes += 2;
+    else if (code >= 0xd800 && code < 0xdc00) {
+      // High surrogate — the pair encodes one supplementary code point as 4 UTF-8 bytes.
+      bytes += 4;
+      i += 1;
+    } else bytes += 3;
+  }
+  return bytes;
+}
+
+const cssByteLimit = (value: string | null | undefined) => value == null || utf8ByteLength(value) <= MAX_EXTENSION_CSS_BYTES;
+const jsByteLimit = (value: string | null | undefined) => value == null || utf8ByteLength(value) <= MAX_EXTENSION_JS_BYTES;
+
+const cssByteMessage = `CSS must be at most ${MAX_EXTENSION_CSS_BYTES} bytes`;
+const jsByteMessage = `JS must be at most ${MAX_EXTENSION_JS_BYTES} bytes`;
+
 export const createExtensionSchema = z.object({
   name: z.string().min(1).max(200),
   description: z.string().max(2000).default(""),
-  css: z.string().max(MAX_EXTENSION_CSS_BYTES).nullable().optional(),
-  js: z.string().max(MAX_EXTENSION_JS_BYTES).nullable().optional(),
+  css: z.string().nullable().optional().refine(cssByteLimit, { message: cssByteMessage }),
+  js: z.string().nullable().optional().refine(jsByteLimit, { message: jsByteMessage }),
   enabled: z.boolean().optional(),
   installedAt: z.string().datetime().optional(),
 });
@@ -22,8 +48,8 @@ export const updateExtensionSchema = z
   .object({
     name: z.string().min(1).max(200).optional(),
     description: z.string().max(2000).optional(),
-    css: z.string().max(MAX_EXTENSION_CSS_BYTES).nullable().optional(),
-    js: z.string().max(MAX_EXTENSION_JS_BYTES).nullable().optional(),
+    css: z.string().nullable().optional().refine(cssByteLimit, { message: cssByteMessage }),
+    js: z.string().nullable().optional().refine(jsByteLimit, { message: jsByteMessage }),
     enabled: z.boolean().optional(),
   })
   .refine((value) => Object.keys(value).length > 0, {

--- a/packages/shared/src/types/extension.ts
+++ b/packages/shared/src/types/extension.ts
@@ -1,0 +1,26 @@
+// ──────────────────────────────────────────────
+// Extension Types
+// ──────────────────────────────────────────────
+
+/**
+ * A user-installed extension stored on the Marinara server.
+ *
+ * Extension JS is executed in the page via a same-origin <script src> tag
+ * pointing at /api/extensions/:id/script.js so the strict CSP (`script-src 'self'`)
+ * can stay in place — there is no `new Function(...)` or `eval` involved.
+ */
+export interface InstalledExtension {
+  id: string;
+  name: string;
+  description: string;
+  /** Optional CSS injected as a <style> tag while enabled. */
+  css?: string | null;
+  /** Optional JavaScript served at /api/extensions/:id/script.js while enabled. */
+  js?: string | null;
+  /** Whether the extension is currently active. */
+  enabled: boolean;
+  /** When the user originally imported it. */
+  installedAt: string;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/packages/shared/src/types/extension.ts
+++ b/packages/shared/src/types/extension.ts
@@ -5,9 +5,10 @@
 /**
  * A user-installed extension stored on the Marinara server.
  *
- * Extension JS is executed in the page via a same-origin <script src> tag
- * pointing at /api/extensions/:id/script.js so the strict CSP (`script-src 'self'`)
- * can stay in place — there is no `new Function(...)` or `eval` involved.
+ * Extension JS is delivered to the client as part of the list payload and
+ * executed in the page via the existing blob-URL loader in
+ * `CustomThemeInjector.tsx`. There is no server-side script-serving endpoint —
+ * CSP/eval characteristics are governed entirely by that loader.
  */
 export interface InstalledExtension {
   id: string;
@@ -15,7 +16,7 @@ export interface InstalledExtension {
   description: string;
   /** Optional CSS injected as a <style> tag while enabled. */
   css?: string | null;
-  /** Optional JavaScript served at /api/extensions/:id/script.js while enabled. */
+  /** Optional JavaScript payload consumed by the client loader while enabled. */
   js?: string | null;
   /** Whether the extension is currently active. */
   enabled: boolean;


### PR DESCRIPTION
## Linked issue

Closes #465

## Why this change

Extensions in Marinara are stored in browser `localStorage`, so they're per-device + per-browser. A user on desktop + phone has to import each extension twice and toggle each one's enabled state separately on every device. Custom themes already solve this with server-side storage + `useLegacyThemeMigration` — extensions should follow the same pattern.

This is the *storage* slice of @kolacheee's earlier proposal in #431. This PR keeps the loader exactly as-is and only changes where the extension list lives.

## What changed

**New (server):**

- `installed_extensions` table — both file-backed (`FILE_BACKED_TABLES`) and legacy SQLite (`migrate.ts` `CREATE TABLE`).
- `/api/extensions` CRUD route (`GET /`, `POST /`, `PATCH /:id`, `DELETE /:id`). No script-serving endpoint.
- Drizzle schema, storage adapter, drizzle-kit config entry, route registration, schema barrel re-export.

**New (shared):**

- `InstalledExtension` type + `createExtensionSchema` / `updateExtensionSchema` zod schemas, with `.max()` size caps on `css` (256 KiB) and `js` (1 MiB).

**New (client):**

- `useExtensions()` / `useCreateExtension()` / `useUpdateExtension()` / `useDeleteExtension()` React Query hooks. `useExtensions()` mirrors `useThemes()` exactly: `staleTime: 0`, `refetchOnWindowFocus: true`, `refetchOnReconnect: true`, `refetchInterval: 15s`.
- `useLegacyExtensionMigration()` — one-shot replay of pre-migration `localStorage` entries against `/api/extensions`, dedupe by `name + css + js`, then flip a `hasMigratedExtensionsToServer` flag.

**Modified (client, surgical):**

- `CustomThemeInjector.tsx` — data source switches from `useUIStore((s) => s.installedExtensions)` to `useExtensions()`. **Loader code (the `import(blob:URL)` pipeline, IIFE wrapper, API map management) is unchanged.** Plus an extension-side `apiFetch` denylist for `/extensions/*` and `/admin/*` (a malicious extension shouldn't be able to re-install itself after deletion or pivot to admin endpoints).
- `SettingsPanel.tsx` — extension actions switch from Zustand mutators to React Query mutations.
- `App.tsx` — wires `useLegacyExtensionMigration()` next to `useLegacyThemeMigration()`.
- `ui.store.ts` — renames `InstalledExtension` to `LegacyInstalledExtension` (kept solely for migration replay), removes `addExtension` / `removeExtension` / `toggleExtension` actions, adds migration helpers + flag, bumps persist version `17 → 18` with a one-line migration step.
- `rate-limit.ts` — new entry: `/api/extensions` capped at 60 req/min/IP.

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

What was verified by the contributor on a private staging instance:

1. **`pnpm check`** — passes on this branch (TS + ESLint + production build).
2. **Container build** — built via Docker autoDeploy on a private staging instance; container restarted healthy, basicAuth gate responding HTTP 401 as expected.
3. **Cross-device sync** — installed an extension on desktop browser at the staging URL → opened the same URL on phone (separate browser, separate localStorage, same basicAuth) → after the 15s refetch interval, phone saw the extension. Toggled enabled state on phone → desktop reflected within a refetch cycle.
4. **Migration** — fresh device with extensions in `localStorage` from a pre-PR build → on first load after upgrade, all extensions migrate to `/api/extensions`, `localStorage` is cleared, migration flag flips, no duplicates.
5. **No regression on the loader** — installed [@kolacheee's AIO extension](https://github.com/kolacheee/Marinara-kolaches-aio-extension) on the staging deploy, all three columns of its UI render and operate, no console errors, loader behavior identical to before.
6. **Hardening — `apiFetch` denylist** — an extension that calls `marinara.apiFetch("/extensions", ...)` (any method) is rejected with a denial error before any network request is made. `/admin/*` likewise denied. Allowed control: `marinara.apiFetch("/themes")` succeeds.
7. **Hardening — size cap** — importing a 1.07 MiB JS extension via Settings → Import returns "Failed to import extension" (zod `js.max()` rejects server-side). 256 KiB CSS / 1 MiB JS caps confirmed enforced.
8. **Hardening — rate limit** — 60 req/min on `/api/extensions` covers React Query polling + legacy migration of any reasonable extension count without affecting normal use.

## Docs and release impact

- [x] No docs changes needed

Reviewer to decide whether `CHANGELOG.md` should mention this for the next minor release. Happy to add a one-liner if you want it noted.

## UI evidence (if applicable)

The Settings → Extensions panel UI is unchanged in look and feel — same import button, same enable/disable/delete row controls. The only behavior difference is that mutations now hit the server instead of `localStorage`. Cross-device sync is invisible to the user except as "extensions appear on my other device."

---

Credit: storage layer + migration shape adapted from @kolacheee's earlier work in #431. Thanks to them for surfacing the cross-device gap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Import extensions from .json/.css/.js files via the Settings panel.
  * Extension management is now server-backed with UI controls to enable/disable, update, and delete.

* **Chores**
  * Local/browser extensions are automatically migrated to server storage.
  * Backend and database updated to store and serve installed extensions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
