### PR TITLE
feat(impersonate): add configurable impersonation controls

### DIFF
--- a/docs/CONVERSATION.md
+++ b/docs/CONVERSATION.md
@@ -56,6 +56,20 @@ A single toggle in the chat settings drawer.
 
 A toggle in the chat settings drawer (visible only when you have multiple characters) that lets characters chat with **each other** rather than only with you. With this on, the response orchestrator can decide a character should address another character. With it off, all responses are directed at you.
 
+## Impersonating your persona
+
+Use `/impersonate [direction]` when you want Marinara to draft a message as **you** instead of as a character. The model reads your selected persona, recent chat context, and the optional direction text, then writes a user-side reply you can keep, edit, or swipe like other generated text.
+
+The chat settings drawer has an **Impersonate** section with global defaults for this workflow:
+
+- **Prompt Template** — overrides the built-in impersonation instruction. Leave it empty to use the chat-specific prompt, or the built-in default if the chat has none.
+- **Preset** — optionally route roleplay-style impersonation through a specific prompt preset. Conversation Mode falls back to the chat default because it does not use prompt presets.
+- **Connection** — optionally send impersonation calls to a different model, such as a cheaper or faster connection.
+- **Quick button** — shows a one-click impersonate button in the input bar.
+- **Skip agents** — when enabled, skips agents during impersonation so drafting stays fast and does not mutate trackers or world state.
+
+For per-chat prompt tuning, use `/impersonate_prompt "your prompt"` or `/impersonate_prompt reset`.
+
 ## Conversation-specific features
 
 These are features Conversation Mode has that other modes don't.

--- a/docs/ROLEPLAY.md
+++ b/docs/ROLEPLAY.md
@@ -60,6 +60,20 @@ Each widget has a popover panel for inline editing. You can manually re-run a si
 
 The widgets are **populated by the World-State agent** (a default for Roleplay), which reads each turn's narrative and extracts structured fields. The agent isn't a separate prompt to the user — it runs automatically alongside the main response.
 
+## Impersonating your persona
+
+Use `/impersonate [direction]` when you want Marinara to draft the next message as **your persona**. This is useful when you know what your character is trying to do, but want the model to help phrase it in the current scene voice.
+
+Open the chat settings drawer's **Impersonate** section to configure the workflow:
+
+- **Prompt Template** — global instructions for how impersonation should write. Empty means the chat-specific prompt or built-in default is used.
+- **Preset** — optionally use a specific prompt preset for impersonation instead of the chat's preset.
+- **Connection** — optionally route impersonation to a different model/provider.
+- **Quick button** — adds a one-click impersonate button to the input bar.
+- **Agent pipeline** — skip agents during impersonation when you want a fast draft that does not update trackers, lorebook routers, or world state.
+
+You can also set a per-chat prompt with `/impersonate_prompt "your prompt"` and reset it with `/impersonate_prompt reset`.
+
 ## Sprite expressions
 
 Each character can have a **sprite library** with expressions for different emotions. The default expression set includes:

--- a/packages/client/src/components/chat/ChatInput.tsx
+++ b/packages/client/src/components/chat/ChatInput.tsx
@@ -2,7 +2,7 @@
 // Chat: Input — mode-aware styling
 // ──────────────────────────────────────────────
 import { useState, useRef, useCallback, useEffect, useMemo, memo } from "react";
-import { Send, Paperclip, StopCircle, X, Smile, Users, Languages, Loader2, FileText } from "lucide-react";
+import { Send, Paperclip, StopCircle, X, Smile, Users, UserCheck, Languages, Loader2, FileText } from "lucide-react";
 import { createPortal } from "react-dom";
 import { toast } from "sonner";
 import { useQueryClient, type InfiniteData } from "@tanstack/react-query";
@@ -143,6 +143,7 @@ export const ChatInput = memo(function ChatInput({
   const { applyToUserInput } = useApplyRegex();
   const enterToSend = useUIStore((s) => s.enterToSendRP);
   const guideGenerations = useUIStore((s) => s.guideGenerations);
+  const impersonateShowQuickButton = useUIStore((s) => s.impersonateShowQuickButton);
   const speechToTextEnabled = useUIStore((s) => s.speechToTextEnabled);
   const createMessage = useCreateMessage(activeChatId);
   const updateMessageExtra = useUpdateMessageExtra(activeChatId);
@@ -231,6 +232,7 @@ export const ChatInput = memo(function ChatInput({
   const canRetry = !isStreaming && lastMessageRole === "user";
   const canContinue = !isStreaming && mode === "roleplay" && lastMessageRole === "assistant";
   const isReadingAttachments = pendingAttachmentReads > 0;
+  const hasPendingAttachments = isReadingAttachments || attachments.length > 0;
 
   const removeAttachment = (idx: number) => {
     setAttachments((prev) => prev.filter((_, i) => i !== idx));
@@ -511,6 +513,51 @@ export const ChatInput = memo(function ChatInput({
     syncInputState,
     onPeekPrompt,
   ]);
+
+  const handleImpersonateQuickButton = useCallback(async () => {
+    if (!activeChatId || isStreaming) return;
+    if (hasPendingAttachments) {
+      toast.info("Clear or send attachments before using quick impersonate.");
+      return;
+    }
+    const submittingChatId = activeChatId;
+    const submittingInput = textareaRef.current?.value ?? "";
+    const text = submittingInput.trim();
+    if (!text) return;
+    const { impersonatePresetId, impersonateConnectionId, impersonateBlockAgents, impersonatePromptTemplate } =
+      useUIStore.getState();
+    const trimmedPromptTemplate = impersonatePromptTemplate.trim();
+    try {
+      const generated = await generate({
+        chatId: submittingChatId,
+        connectionId: null,
+        impersonate: true,
+        userMessage: text,
+        ...(impersonatePresetId ? { impersonatePresetId } : {}),
+        ...(impersonateConnectionId ? { impersonateConnectionId } : {}),
+        ...(impersonateBlockAgents ? { impersonateBlockAgents: true } : {}),
+        ...(trimmedPromptTemplate ? { impersonatePromptTemplate: trimmedPromptTemplate } : {}),
+      });
+      if (generated) {
+        const isSameDraft =
+          useChatStore.getState().activeChatId === submittingChatId && textareaRef.current?.value === submittingInput;
+        if (!isSameDraft) return;
+        if (draftTimerRef.current) {
+          clearTimeout(draftTimerRef.current);
+          draftTimerRef.current = null;
+        }
+        if (textareaRef.current) {
+          textareaRef.current.value = "";
+          textareaRef.current.style.height = "auto";
+        }
+        syncInputState("");
+        clearInputDraft(submittingChatId);
+      }
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : "Impersonate failed";
+      toast.error(msg);
+    }
+  }, [activeChatId, isStreaming, hasPendingAttachments, generate, syncInputState, clearInputDraft]);
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     // Autocomplete navigation
@@ -911,6 +958,23 @@ export const ChatInput = memo(function ChatInput({
             title={guideGenerations && hasInput ? "Trigger character response (guided)" : "Trigger character response"}
           >
             <Users size="1rem" />
+          </button>
+        )}
+
+        {/* Impersonate quick button */}
+        {impersonateShowQuickButton && (
+          <button
+            onClick={handleImpersonateQuickButton}
+            disabled={!hasInput || isStreaming || !activeChatId || hasPendingAttachments}
+            className={cn(
+              "flex h-8 w-8 items-center justify-center rounded-full transition-colors",
+              hasInput && activeChatId && !isStreaming && !hasPendingAttachments
+                ? "text-[var(--primary)] hover:bg-[var(--primary)]/15"
+                : "text-foreground/20",
+            )}
+            title="Generate as {{user}} using this text as direction"
+          >
+            <UserCheck size="1rem" />
           </button>
         )}
 

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -48,6 +48,8 @@ import {
   Download,
   Star,
   StickyNote,
+  Drama,
+  RotateCcw,
 } from "lucide-react";
 import { cn, getAvatarCropStyle, type AvatarCrop } from "../../lib/utils";
 import { showAlertDialog, showConfirmDialog, showPromptDialog } from "../../lib/app-dialogs";
@@ -117,6 +119,7 @@ import {
   BUILT_IN_TOOLS,
   DEFAULT_AGENT_CONTEXT_SIZE,
   DEFAULT_AGENT_TOOLS,
+  DEFAULT_IMPERSONATE_PROMPT,
   DEFAULT_AGENT_MAX_TOKENS,
   DEFAULT_AGENT_PROMPTS,
   MAX_AGENT_MAX_TOKENS,
@@ -260,6 +263,13 @@ export function ChatSettingsDrawer({
     () =>
       ((connections as Array<{ id: string; name: string; model?: string; provider?: string }>) ?? []).filter(
         (c) => c.provider === "image_generation",
+      ),
+    [connections],
+  );
+  const textConnectionsList = useMemo(
+    () =>
+      ((connections as Array<{ id: string; name: string; model?: string; provider?: string }>) ?? []).filter(
+        (c) => c.provider !== "image_generation",
       ),
     [connections],
   );
@@ -4249,6 +4259,18 @@ export function ChatSettingsDrawer({
               )}
             </div>
           </Section>
+
+          {/* Impersonate (global settings applied to /impersonate generations) */}
+          <Section
+            label="Impersonate"
+            icon={<Drama size="0.875rem" />}
+            help="Global settings applied to every /impersonate generation across all chats."
+          >
+            <ImpersonateSettingsContent
+              presets={(presets ?? []) as Array<{ id: string; name: string }>}
+              connections={textConnectionsList}
+            />
+          </Section>
         </div>
       </div>
 
@@ -4860,6 +4882,149 @@ function AdvancedParametersSection({
         onChange={setPromptDraft}
         placeholder="Enter your custom system prompt..."
       />
+    </div>
+  );
+}
+
+// ── Impersonate settings content (rendered inside an Impersonate Section) ──
+function ImpersonateSettingsContent({
+  presets,
+  connections,
+}: {
+  presets: Array<{ id: string; name: string }>;
+  connections: Array<{ id: string; name: string }>;
+}) {
+  const promptTemplate = useUIStore((s) => s.impersonatePromptTemplate);
+  const setPromptTemplate = useUIStore((s) => s.setImpersonatePromptTemplate);
+  const showQuickButton = useUIStore((s) => s.impersonateShowQuickButton);
+  const setShowQuickButton = useUIStore((s) => s.setImpersonateShowQuickButton);
+  const presetId = useUIStore((s) => s.impersonatePresetId);
+  const setPresetId = useUIStore((s) => s.setImpersonatePresetId);
+  const connectionId = useUIStore((s) => s.impersonateConnectionId);
+  const setConnectionId = useUIStore((s) => s.setImpersonateConnectionId);
+  const blockAgents = useUIStore((s) => s.impersonateBlockAgents);
+  const setBlockAgents = useUIStore((s) => s.setImpersonateBlockAgents);
+  const hasPromptTemplate = promptTemplate.trim().length > 0;
+
+  const [defaultOpen, setDefaultOpen] = useState(false);
+
+  return (
+    <div className="space-y-2.5">
+      <div className="space-y-1">
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex min-w-0 items-center gap-1.5">
+            <span className="text-xs font-semibold">Prompt Template</span>
+            <HelpTooltip text="Optional global instruction sent to the model when you /impersonate. Leave empty to use the chat-specific prompt, or the built-in default if that chat has none. Macros like {{user}}, {{persona_description}} and {{impersonate_direction}} are replaced before sending." />
+          </div>
+          <span className="shrink-0 text-[0.625rem] text-[var(--muted-foreground)]/80">
+            {hasPromptTemplate ? "Custom" : "Using chat/built-in default"}
+          </span>
+        </div>
+        <textarea
+          value={promptTemplate}
+          onChange={(e) => setPromptTemplate(e.target.value)}
+          placeholder="Empty = use chat/built-in default"
+          rows={4}
+          className="min-h-20 w-full resize-y rounded-lg bg-[var(--secondary)] px-3 py-1.5 font-mono text-xs leading-relaxed outline-none ring-1 ring-transparent transition-shadow focus:ring-[var(--primary)]/40"
+        />
+        <div className="flex items-center justify-between gap-2">
+          <button
+            onClick={() => setDefaultOpen((v) => !v)}
+            className="flex items-center gap-1 rounded-md px-1 py-0.5 text-[0.625rem] font-medium text-[var(--muted-foreground)] transition-colors hover:bg-[var(--secondary)]/70 hover:text-[var(--foreground)]"
+          >
+            {defaultOpen ? <ChevronDown size="0.6875rem" /> : <ChevronRight size="0.6875rem" />}
+            Built-in default
+          </button>
+          {hasPromptTemplate ? (
+            <button
+              onClick={() => setPromptTemplate("")}
+              className="flex items-center gap-1 rounded-md bg-[var(--secondary)] px-2 py-0.5 text-[0.625rem] text-[var(--muted-foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+              title="Reset to default"
+            >
+              <RotateCcw size="0.625rem" />
+              Reset
+            </button>
+          ) : (
+            <span className="text-[0.625rem] text-[var(--muted-foreground)]/80">Using chat/built-in default</span>
+          )}
+        </div>
+        {defaultOpen && (
+          <pre className="m-0 max-h-40 overflow-auto whitespace-pre-wrap break-words rounded-lg bg-[var(--secondary)]/40 px-3 py-2 font-mono text-[0.625rem] leading-relaxed text-[var(--muted-foreground)] ring-1 ring-[var(--border)]">
+            {DEFAULT_IMPERSONATE_PROMPT}
+          </pre>
+        )}
+      </div>
+
+      <div className="grid gap-x-2 gap-y-1.5 sm:grid-cols-[minmax(7.5rem,1fr)_8.75rem]">
+        <label className="order-1 space-y-1 rounded-lg bg-[var(--secondary)]/25 px-3 py-1.5 ring-1 ring-[var(--border)]">
+          <div className="flex items-center gap-1.5">
+            <span className="text-[0.6875rem] font-semibold">Preset</span>
+            <HelpTooltip text="Use a specific prompt preset for roleplay impersonate generations only. Conversation mode does not use prompt presets. Falls back to the chat's preset when set to 'Use chat default'." />
+          </div>
+          <select
+            value={presetId ?? ""}
+            onChange={(e) => setPresetId(e.target.value || null)}
+            className="w-full rounded-lg bg-[var(--secondary)] px-2.5 py-1.5 text-xs outline-none ring-1 ring-transparent transition-shadow focus:ring-[var(--primary)]/40"
+          >
+            <option value="">Use chat default</option>
+            {presets.map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.name}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="order-3 space-y-1 rounded-lg bg-[var(--secondary)]/25 px-3 py-1.5 ring-1 ring-[var(--border)] sm:order-3">
+          <div className="flex items-center gap-1.5">
+            <span className="text-[0.6875rem] font-semibold">Connection</span>
+            <HelpTooltip text="Use a specific connection (model/provider) for impersonate generations only. Useful for routing impersonate to a cheaper or faster model." />
+          </div>
+          <select
+            value={connectionId ?? ""}
+            onChange={(e) => setConnectionId(e.target.value || null)}
+            className="w-full rounded-lg bg-[var(--secondary)] px-2.5 py-1.5 text-xs outline-none ring-1 ring-transparent transition-shadow focus:ring-[var(--primary)]/40"
+          >
+            <option value="">Use chat default</option>
+            <option value="random">Random</option>
+            {connections.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="order-2 flex min-h-[2.875rem] min-w-0 items-center justify-between gap-1.5 rounded-lg bg-[var(--secondary)]/25 px-2.5 py-1.5 text-xs font-semibold ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)]/40 sm:order-2">
+          <span className="min-w-0">Quick button</span>
+          <span className="flex shrink-0 items-center gap-1.5">
+            <input
+              type="checkbox"
+              checked={showQuickButton}
+              onChange={(e) => setShowQuickButton(e.target.checked)}
+              className="h-3.5 w-3.5 rounded border-[var(--border)] accent-[var(--primary)]"
+            />
+            <span onClick={(e) => e.preventDefault()}>
+              <HelpTooltip text="Show a one-click impersonate button in the chat input toolbar. When pressed with text in the input, it sends that text as the impersonate direction." />
+            </span>
+          </span>
+        </label>
+
+        <label className="order-4 flex min-h-[2.875rem] min-w-0 items-center justify-between gap-1.5 rounded-lg bg-[var(--secondary)]/25 px-2.5 py-1.5 text-xs font-semibold ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)]/40">
+          <span className="min-w-0">Skip agents</span>
+          <span className="flex shrink-0 items-center gap-1.5">
+            <input
+              type="checkbox"
+              checked={blockAgents}
+              onChange={(e) => setBlockAgents(e.target.checked)}
+              className="h-3.5 w-3.5 rounded border-[var(--border)] accent-[var(--primary)]"
+            />
+            <span onClick={(e) => e.preventDefault()}>
+              <HelpTooltip text="When enabled, the agent pipeline (trackers, lorebook routers, etc.) is suppressed during impersonate so generations stay fast and don't trigger world-state mutations." />
+            </span>
+          </span>
+        </label>
+      </div>
     </div>
   );
 }

--- a/packages/client/src/components/chat/ConversationInput.tsx
+++ b/packages/client/src/components/chat/ConversationInput.tsx
@@ -2,7 +2,7 @@
 // Chat: Conversation Input — Discord-style
 // ──────────────────────────────────────────────
 import { useState, useRef, useCallback, useEffect } from "react";
-import { Send, Smile, StopCircle, X, Plus, ImagePlay, AtSign, Users, Languages, Loader2, FileText } from "lucide-react";
+import { Send, Smile, StopCircle, X, Plus, ImagePlay, AtSign, Users, UserCheck, Languages, Loader2, FileText } from "lucide-react";
 import { createPortal } from "react-dom";
 import { toast } from "sonner";
 import { useQueryClient } from "@tanstack/react-query";
@@ -195,12 +195,14 @@ export function ConversationInput({
   const { applyToUserInput } = useApplyRegex();
   const enterToSend = useUIStore((s) => s.enterToSendConvo);
   const guideGenerations = useUIStore((s) => s.guideGenerations);
+  const impersonateShowQuickButton = useUIStore((s) => s.impersonateShowQuickButton);
   const speechToTextEnabled = useUIStore((s) => s.speechToTextEnabled);
   const createMessage = useCreateMessage(activeChatId);
   const updateMessageExtra = useUpdateMessageExtra(activeChatId);
   const qc = useQueryClient();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const isReadingAttachments = pendingAttachmentReads > 0;
+  const hasPendingAttachments = isReadingAttachments || attachments.length > 0;
 
   const syncInputState = useCallback(
     (value: string) => {
@@ -538,6 +540,42 @@ export function ConversationInput({
     syncInputState,
     onPeekPrompt,
   ]);
+
+  const handleImpersonateQuickButton = useCallback(async () => {
+    if (!activeChatId || isStreaming) return;
+    if (hasPendingAttachments) {
+      toast.info("Clear or send attachments before using quick impersonate.");
+      return;
+    }
+    const text = textareaRef.current?.value?.trim() ?? "";
+    if (!text) return;
+    const { impersonatePresetId, impersonateConnectionId, impersonateBlockAgents, impersonatePromptTemplate } =
+      useUIStore.getState();
+    const trimmedPromptTemplate = impersonatePromptTemplate.trim();
+    try {
+      const generated = await generate({
+        chatId: activeChatId,
+        connectionId: null,
+        impersonate: true,
+        userMessage: text,
+        ...(impersonatePresetId ? { impersonatePresetId } : {}),
+        ...(impersonateConnectionId ? { impersonateConnectionId } : {}),
+        ...(impersonateBlockAgents ? { impersonateBlockAgents: true } : {}),
+        ...(trimmedPromptTemplate ? { impersonatePromptTemplate: trimmedPromptTemplate } : {}),
+      });
+      if (generated) {
+        if (textareaRef.current) {
+          textareaRef.current.value = "";
+          textareaRef.current.style.height = "auto";
+        }
+        syncInputState("");
+        clearInputDraft(activeChatId);
+      }
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : "Impersonate failed";
+      toast.error(msg);
+    }
+  }, [activeChatId, isStreaming, hasPendingAttachments, generate, syncInputState, clearInputDraft]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -1058,6 +1096,22 @@ export function ConversationInput({
               }
             >
               <Users size="1rem" />
+            </button>
+          )}
+
+          {impersonateShowQuickButton && (
+            <button
+              onClick={handleImpersonateQuickButton}
+              disabled={!hasInput || isStreaming || !activeChatId || hasPendingAttachments}
+              className={cn(
+                "flex h-8 w-8 items-center justify-center rounded-full transition-colors",
+                hasInput && activeChatId && !isStreaming && !hasPendingAttachments
+                  ? "text-[var(--primary)] hover:bg-[var(--primary)]/15"
+                  : "text-foreground/20",
+              )}
+              title="Generate as {{user}} using this text as direction"
+            >
+              <UserCheck size="1rem" />
             </button>
           )}
 

--- a/packages/client/src/components/chat/ConversationView.tsx
+++ b/packages/client/src/components/chat/ConversationView.tsx
@@ -102,6 +102,15 @@ function hasNamePrefixFormat(msg: Message, characterMap: CharacterMap, chatChara
   return false;
 }
 
+function isHiddenFromUser(message: Message) {
+  try {
+    const extra = typeof message.extra === "string" ? JSON.parse(message.extra) : (message.extra ?? {});
+    return extra.hiddenFromUser === true;
+  } catch {
+    return false;
+  }
+}
+
 // Module-level set that remembers which message keys have been "seen" across
 // component remounts. This prevents stagger animations and notification sounds
 // from replaying when the user navigates away from a chat and comes back.
@@ -287,6 +296,7 @@ export function ConversationView({
     let lastDay = "";
     for (let i = 0; i < messages.length; i++) {
       const msg = messages[i]!;
+      if (isHiddenFromUser(msg)) continue;
       const day = getDayKey(msg.createdAt);
       if (day !== lastDay) {
         items.push({ type: "separator", key: `sep-${day}`, label: formatDaySeparator(msg.createdAt) });

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -450,6 +450,10 @@ export function useGenerate() {
       mentionedCharacterNames?: string[];
       forCharacterId?: string;
       generationGuide?: string;
+      impersonatePresetId?: string;
+      impersonateConnectionId?: string;
+      impersonateBlockAgents?: boolean;
+      impersonatePromptTemplate?: string;
     }) => {
       // Prevent concurrent generations for the same chat. Different chats may
       // keep generating in the background while the user navigates elsewhere.

--- a/packages/client/src/lib/slash-commands.ts
+++ b/packages/client/src/lib/slash-commands.ts
@@ -27,6 +27,10 @@ export interface SlashCommandContext {
     userMessage?: string;
     impersonate?: boolean;
     attachments?: { type: string; data: string }[];
+    impersonatePresetId?: string;
+    impersonateConnectionId?: string;
+    impersonateBlockAgents?: boolean;
+    impersonatePromptTemplate?: string;
   }) => Promise<boolean | void>;
   /** Insert a message directly into the chat (no LLM) */
   createMessage: (data: { role: string; content: string; characterId?: string | null }) => void;
@@ -224,11 +228,18 @@ const COMMANDS: SlashCommand[] = [
     usage: "/impersonate [direction]",
     async execute(args, ctx) {
       const direction = args.trim();
+      const { impersonatePresetId, impersonateConnectionId, impersonateBlockAgents, impersonatePromptTemplate } =
+        useUIStore.getState();
+      const trimmedPromptTemplate = impersonatePromptTemplate.trim();
       await ctx.generate({
         chatId: ctx.chatId,
         connectionId: null,
         impersonate: true,
         ...(direction ? { userMessage: direction } : {}),
+        ...(impersonatePresetId ? { impersonatePresetId } : {}),
+        ...(impersonateConnectionId ? { impersonateConnectionId } : {}),
+        ...(impersonateBlockAgents !== undefined ? { impersonateBlockAgents } : {}),
+        ...(trimmedPromptTemplate ? { impersonatePromptTemplate: trimmedPromptTemplate } : {}),
       });
       return { handled: true };
     },

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -267,6 +267,18 @@ interface UIState {
   /** Optional short activity shown with the user's status in Conversation mode. */
   userActivity: string;
 
+  // ── Impersonate Settings ──
+  /** Custom prompt template for /impersonate (empty = use server default). Persisted. */
+  impersonatePromptTemplate: string;
+  /** Show a quick /impersonate button in the chat input toolbar. Persisted. */
+  impersonateShowQuickButton: boolean;
+  /** Override preset used when impersonating (null = use chat default). Persisted. */
+  impersonatePresetId: string | null;
+  /** Override connection used when impersonating (null = use chat default). Persisted. */
+  impersonateConnectionId: string | null;
+  /** When true, suppress agent pipeline during impersonate. Persisted. */
+  impersonateBlockAgents: boolean;
+
   /** Transient: true when center content area is too narrow (overflow detected) */
   centerCompact: boolean;
 
@@ -363,6 +375,14 @@ interface UIState {
   setEnterToSendGame: (v: boolean) => void;
   setWeatherEffects: (v: boolean) => void;
   setHudPosition: (v: HudPosition) => void;
+
+  // Impersonate settings actions
+  setImpersonatePromptTemplate: (v: string) => void;
+  setImpersonateShowQuickButton: (v: boolean) => void;
+  setImpersonatePresetId: (id: string | null) => void;
+  setImpersonateConnectionId: (id: string | null) => void;
+  setImpersonateBlockAgents: (v: boolean) => void;
+
   /** Legacy migration helpers for browser-local custom themes. */
   setHasMigratedCustomThemesToServer: (v: boolean) => void;
   clearLegacyCustomThemes: () => void;
@@ -451,6 +471,11 @@ export function pickSyncedSettings(state: UIState) {
     rpNotificationSound: state.rpNotificationSound,
     customConversationPrompt: state.customConversationPrompt,
     scheduleGenerationPreferences: state.scheduleGenerationPreferences,
+    impersonatePromptTemplate: state.impersonatePromptTemplate,
+    impersonateShowQuickButton: state.impersonateShowQuickButton,
+    impersonatePresetId: state.impersonatePresetId,
+    impersonateConnectionId: state.impersonateConnectionId,
+    impersonateBlockAgents: state.impersonateBlockAgents,
     learnedGameSetupOptions: state.learnedGameSetupOptions,
   };
 }
@@ -551,6 +576,13 @@ export const useUIStore = create<UIState>()(
       userStatus: "active" as UserStatus,
       userActivity: "",
       centerCompact: false,
+
+      // Impersonate settings defaults
+      impersonatePromptTemplate: "",
+      impersonateShowQuickButton: false,
+      impersonatePresetId: null,
+      impersonateConnectionId: null,
+      impersonateBlockAgents: false,
 
       toggleSidebar: () => set((s) => ({ sidebarOpen: !s.sidebarOpen })),
       setSidebarOpen: (open) => set({ sidebarOpen: open }),
@@ -824,6 +856,11 @@ export const useUIStore = create<UIState>()(
       setEnterToSendGame: (v) => set({ enterToSendGame: v }),
       setWeatherEffects: (v) => set({ weatherEffects: v }),
       setHudPosition: (v) => set({ hudPosition: v }),
+      setImpersonatePromptTemplate: (v) => set({ impersonatePromptTemplate: v }),
+      setImpersonateShowQuickButton: (v) => set({ impersonateShowQuickButton: v }),
+      setImpersonatePresetId: (id) => set({ impersonatePresetId: id }),
+      setImpersonateConnectionId: (id) => set({ impersonateConnectionId: id }),
+      setImpersonateBlockAgents: (v) => set({ impersonateBlockAgents: v }),
       setHasMigratedCustomThemesToServer: (v) => set({ hasMigratedCustomThemesToServer: v }),
       clearLegacyCustomThemes: () => set({ customThemes: [], activeCustomTheme: null }),
       setActiveCustomTheme: (id) => set({ activeCustomTheme: id }),
@@ -1006,8 +1043,13 @@ export const useUIStore = create<UIState>()(
             persisted.learnedGameSetupOptions = DEFAULT_GAME_SETUP_LEARNED_OPTIONS;
           }
         }
-        // v15 -> v16: opt-in output cleanup for incomplete final sentences.
+        // v15 -> v16: add impersonate settings and opt-in output cleanup for incomplete final sentences.
         if (version <= 15) {
+          if (persisted.impersonatePromptTemplate === undefined) persisted.impersonatePromptTemplate = "";
+          if (persisted.impersonateShowQuickButton === undefined) persisted.impersonateShowQuickButton = false;
+          if (persisted.impersonatePresetId === undefined) persisted.impersonatePresetId = null;
+          if (persisted.impersonateConnectionId === undefined) persisted.impersonateConnectionId = null;
+          if (persisted.impersonateBlockAgents === undefined) persisted.impersonateBlockAgents = false;
           if (persisted.trimIncompleteModelOutput === undefined) {
             persisted.trimIncompleteModelOutput = false;
           }
@@ -1091,6 +1133,11 @@ export const useUIStore = create<UIState>()(
         rpNotificationSound: state.rpNotificationSound,
         customConversationPrompt: state.customConversationPrompt,
         scheduleGenerationPreferences: state.scheduleGenerationPreferences,
+        impersonatePromptTemplate: state.impersonatePromptTemplate,
+        impersonateShowQuickButton: state.impersonateShowQuickButton,
+        impersonatePresetId: state.impersonatePresetId,
+        impersonateConnectionId: state.impersonateConnectionId,
+        impersonateBlockAgents: state.impersonateBlockAgents,
         learnedGameSetupOptions: state.learnedGameSetupOptions,
       }),
     },

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -8,7 +8,7 @@
     "dev": "tsx watch --ignore ./data --ignore ./node_modules --ignore ../../node_modules src/index.ts",
     "build": "tsc && node ./scripts/write-build-meta.mjs && node -e \"const fs=require('fs');fs.cpSync('src/db/default-preset.json','dist/db/default-preset.json');fs.cpSync('src/assets','dist/assets',{recursive:true});\"",
     "start": "node dist/index.js",
-    "test": "tsx --test test/**/*.test.ts",
+    "test": "pnpm --filter @marinara-engine/shared build && tsx --test test/**/*.test.ts",
     "clean": "node -e \"const fs=require('fs');['dist','tsconfig.tsbuildinfo'].forEach(p=>{try{fs.rmSync(p,{recursive:true,force:true})}catch{}})\"",
     "lint": "tsc -b ../shared && tsc --noEmit"
   },

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -22,13 +22,159 @@ import { createLLMProvider } from "../services/llm/provider-registry.js";
 import { generateMissingConversationSummaries } from "../services/conversation/auto-summary.service.js";
 import { wrapContent } from "../services/prompt/format-engine.js";
 import { newId } from "../utils/id-generator.js";
-import { characters, memoryChunks } from "../db/schema/index.js";
+import { characters, gameStateSnapshots, memoryChunks } from "../db/schema/index.js";
 import { and, desc, eq, inArray } from "drizzle-orm";
 import { existsSync } from "fs";
 import { join } from "path";
 import { DATA_DIR } from "../utils/data-dir.js";
 import { normalizeTimestampOverrides } from "../services/import/import-timestamps.js";
-import { parseExtra } from "./generate/generate-route-utils.js";
+import { findLastIndex, parseExtra, shouldEnableAgentsForGeneration } from "./generate/generate-route-utils.js";
+
+type TrackerWrapFormat = "xml" | "markdown" | "none";
+
+async function loadLatestChatGameSnapshot(app: FastifyInstance, chatId: string) {
+  const committedRows = await app.db
+    .select()
+    .from(gameStateSnapshots)
+    .where(and(eq(gameStateSnapshots.chatId, chatId), eq(gameStateSnapshots.committed, 1)))
+    .orderBy(desc(gameStateSnapshots.createdAt))
+    .limit(1);
+
+  let snap = committedRows[0];
+  if (!snap) {
+    const anyRows = await app.db
+      .select()
+      .from(gameStateSnapshots)
+      .where(eq(gameStateSnapshots.chatId, chatId))
+      .orderBy(desc(gameStateSnapshots.createdAt))
+      .limit(1);
+    snap = anyRows[0];
+  }
+
+  return snap ?? null;
+}
+
+function formatPeekTrackerContextBlock(args: {
+  wrapFormat: TrackerWrapFormat;
+  snap: typeof gameStateSnapshots.$inferSelect;
+  chatMeta: Record<string, unknown>;
+  activeAgentIds: string[];
+}): string | null {
+  const { wrapFormat, snap, chatMeta, activeAgentIds } = args;
+  const active = new Set(activeAgentIds);
+  const hasWorldState = active.has("world-state");
+  const hasCharTracker = active.has("character-tracker");
+  const hasPersonaStats = active.has("persona-stats");
+  const hasQuest = active.has("quest");
+  const hasCustomTracker = active.has("custom-tracker");
+
+  if (!hasWorldState && !hasCharTracker && !hasPersonaStats && !hasQuest && !hasCustomTracker) return null;
+
+  const trackerParts: string[] = [];
+
+  if (hasWorldState) {
+    const wsParts: string[] = [];
+    if (snap.date) wsParts.push(`Date: ${snap.date}`);
+    if (snap.time) wsParts.push(`Time: ${snap.time}`);
+    if (snap.location) wsParts.push(`Location: ${snap.location}`);
+    if (snap.weather) wsParts.push(`Weather: ${snap.weather}`);
+    if (snap.temperature) wsParts.push(`Temperature: ${snap.temperature}`);
+    if (wsParts.length > 0) trackerParts.push(wrapContent(wsParts.join("\n"), "World", wrapFormat));
+  }
+
+  if (hasCharTracker) {
+    try {
+      const presentChars = JSON.parse(snap.presentCharacters);
+      if (Array.isArray(presentChars) && presentChars.length > 0) {
+        const charLines = presentChars.map((c: any) => {
+          if (typeof c === "string") return `- ${c}`;
+          const details: string[] = [];
+          if (c.mood) details.push(`mood: ${c.mood}`);
+          if (c.appearance) details.push(`appearance: ${c.appearance}`);
+          if (c.outfit) details.push(`outfit: ${c.outfit}`);
+          if (c.thoughts) details.push(`thoughts: ${c.thoughts}`);
+          if (Array.isArray(c.stats) && c.stats.length > 0) {
+            const statStr = c.stats.map((s: any) => `${s.name}: ${s.value}${s.max ? `/${s.max}` : ""}`).join(", ");
+            details.push(`stats: ${statStr}`);
+          }
+          const detailStr = details.length > 0 ? ` (${details.join("; ")})` : "";
+          return `- ${c.emoji ?? ""} ${c.name ?? c}${detailStr}`;
+        });
+        trackerParts.push(wrapContent(charLines.join("\n"), "Present Characters", wrapFormat));
+      }
+    } catch {
+      /* ignore malformed tracker data */
+    }
+  }
+
+  if (hasPersonaStats && snap.personaStats) {
+    try {
+      const psBars = typeof snap.personaStats === "string" ? JSON.parse(snap.personaStats) : snap.personaStats;
+      if (Array.isArray(psBars) && psBars.length > 0) {
+        const barLines = psBars.map((b: any) => `- ${b.name}: ${b.value}/${b.max}`);
+        trackerParts.push(wrapContent(barLines.join("\n"), "Persona Stats", wrapFormat));
+      }
+    } catch {
+      /* ignore malformed tracker data */
+    }
+  }
+
+  if (snap.playerStats) {
+    try {
+      const stats = typeof snap.playerStats === "string" ? JSON.parse(snap.playerStats) : snap.playerStats;
+
+      if (hasPersonaStats && stats?.status) trackerParts.push(wrapContent(`Status: ${stats.status}`, "Status", wrapFormat));
+
+      if (hasQuest && Array.isArray(stats?.activeQuests) && stats.activeQuests.length > 0) {
+        const questLines = stats.activeQuests.map((q: any) => {
+          const objectives = Array.isArray(q.objectives)
+            ? q.objectives.map((o: any) => `  ${o.completed ? "[x]" : "[ ]"} ${o.text}`).join("\n")
+            : "";
+          return `- ${q.name}${q.completed ? " (completed)" : ""}${objectives ? "\n" + objectives : ""}`;
+        });
+        trackerParts.push(wrapContent(questLines.join("\n"), "Active Quests", wrapFormat));
+      }
+
+      if (hasPersonaStats && Array.isArray(stats?.inventory) && stats.inventory.length > 0) {
+        const invLines = stats.inventory.map(
+          (item: any) =>
+            `- ${item.name}${item.quantity > 1 ? ` x${item.quantity}` : ""}${item.description ? ` — ${item.description}` : ""}`,
+        );
+        trackerParts.push(wrapContent(invLines.join("\n"), "Inventory", wrapFormat));
+      }
+
+      if (hasPersonaStats && Array.isArray(stats?.stats) && stats.stats.length > 0) {
+        const statLines = stats.stats.map((s: any) => `- ${s.name}: ${s.value}${s.max ? `/${s.max}` : ""}`);
+        trackerParts.push(wrapContent(statLines.join("\n"), "Stats", wrapFormat));
+      }
+
+      if (hasCustomTracker && Array.isArray(stats?.customTrackerFields) && stats.customTrackerFields.length > 0) {
+        const customLines = stats.customTrackerFields.map((f: any) => `- ${f.name}: ${f.value}`);
+        trackerParts.push(wrapContent(customLines.join("\n"), "Custom Tracker", wrapFormat));
+      }
+    } catch {
+      /* ignore malformed tracker data */
+    }
+  }
+
+  const playerNotes = typeof chatMeta.gamePlayerNotes === "string" ? chatMeta.gamePlayerNotes.trim() : "";
+  if (playerNotes) {
+    trackerParts.push(
+      wrapContent(
+        `The player has written these personal notes. Consider them when narrating — they reflect what the player is tracking, their theories, and plans:\n${playerNotes}`,
+        "Player Notes",
+        wrapFormat,
+      ),
+    );
+  }
+
+  if (trackerParts.length <= 0) return null;
+  if (wrapFormat === "none") return trackerParts.join("\n\n");
+  if (wrapFormat === "xml") {
+    return `<context>\n${trackerParts.map((part) => "    " + part.replace(/\n/g, "\n    ")).join("\n")}\n</context>`;
+  }
+  return `# Context\n*(Established state as of the last message. Do not re-describe — advance from here.)*\n${trackerParts.join("\n")}`;
+}
 
 export async function chatsRoutes(app: FastifyInstance) {
   const storage = createChatsStorage(app.db);
@@ -1136,6 +1282,30 @@ export async function chatsRoutes(app: FastifyInstance) {
                 const firstUserIdx = assembled.messages.findIndex((m) => m.role === "user" || m.role === "assistant");
                 const insertAt = firstUserIdx >= 0 ? firstUserIdx : assembled.messages.length;
                 assembled.messages.splice(insertAt, 0, { role: "system", content: block });
+              }
+            }
+          }
+
+          // ── Tracker context fallback: mirror the read-only snapshot injection from /api/generate ──
+          const activeAgentIds = Array.isArray(chatMeta.activeAgentIds) ? (chatMeta.activeAgentIds as string[]) : [];
+          const chatEnableAgents = shouldEnableAgentsForGeneration({
+            chatEnableAgents: chatMeta.enableAgents === true,
+            chatMode,
+            impersonate: false,
+            impersonateBlockAgents: false,
+          });
+          if (chatEnableAgents && activeAgentIds.length > 0) {
+            const snap = await loadLatestChatGameSnapshot(app, req.params.id);
+            const contextBlock = snap
+              ? formatPeekTrackerContextBlock({ wrapFormat, snap, chatMeta, activeAgentIds })
+              : null;
+
+            if (contextBlock) {
+              const lastUserIdx = findLastIndex(assembled.messages, "user");
+              if (lastUserIdx >= 0) {
+                assembled.messages.splice(lastUserIdx, 0, { role: "system", content: contextBlock });
+              } else {
+                assembled.messages.splice(0, 0, { role: "system", content: contextBlock });
               }
             }
           }

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -119,6 +119,7 @@ import {
   parseStoredGenerationParameters,
   parseGameStateRow,
   resolveBaseUrl,
+  shouldEnableAgentsForGeneration,
   wrapFields,
   type PromptAttachment,
   type SimpleMessage,
@@ -661,7 +662,10 @@ export async function generateRoutes(app: FastifyInstance) {
     }
 
     // Resolve connection
-    let connId = input.connectionId ?? chat.connectionId;
+    const impersonateConnectionOverride =
+      input.impersonate && input.impersonateConnectionId ? input.impersonateConnectionId : null;
+    const fallbackConnectionId = input.connectionId || chat.connectionId;
+    let connId = impersonateConnectionOverride || fallbackConnectionId;
 
     // ── Random connection: pick one from the random pool ──
     if (connId === "random") {
@@ -676,7 +680,23 @@ export async function generateRoutes(app: FastifyInstance) {
     if (!connId) {
       return reply.status(400).send({ error: "No API connection configured for this chat" });
     }
-    const conn = await connections.getWithKey(connId);
+    let conn = await connections.getWithKey(connId);
+    if (!conn && impersonateConnectionOverride && connId === impersonateConnectionOverride && fallbackConnectionId) {
+      logger.warn(
+        "[generate] Impersonate connection override %s was not found; falling back to chat/request connection",
+        impersonateConnectionOverride,
+      );
+      connId = fallbackConnectionId;
+      if (connId === "random") {
+        const pool = await connections.listRandomPool();
+        if (!pool.length) {
+          return reply.status(400).send({ error: "No connections are marked for the random pool" });
+        }
+        const picked = pool[Math.floor(Math.random() * pool.length)];
+        connId = picked.id;
+      }
+      conn = connId ? await connections.getWithKey(connId) : null;
+    }
     if (!conn) {
       return reply.status(400).send({ error: "API connection not found" });
     }
@@ -922,8 +942,35 @@ export async function generateRoutes(app: FastifyInstance) {
       }
 
       // ── Assembler path: use preset if the chat has one ──
-      const presetId = chatMode === "conversation" ? undefined : ((chat.promptPresetId as string | null) ?? undefined);
-      const chatChoices = (chatMeta.presetChoices ?? {}) as Record<string, string | string[]>;
+      let presetId = chatMode === "conversation"
+        ? undefined
+        : (input.impersonate && input.impersonatePresetId
+            ? input.impersonatePresetId
+            : (chat.promptPresetId as string | null) ?? undefined);
+      let resolvedPreset = presetId ? await presets.getById(presetId) : null;
+      const usingImpersonatePreset = !!(input.impersonate && input.impersonatePresetId);
+      if (usingImpersonatePreset && !resolvedPreset) {
+        presetId = (chat.promptPresetId as string | null) ?? undefined;
+        resolvedPreset = presetId ? await presets.getById(presetId) : null;
+      }
+      const usingResolvedImpersonatePreset =
+        usingImpersonatePreset && !!resolvedPreset && presetId === input.impersonatePresetId;
+      const impersonatePresetDiffers = usingResolvedImpersonatePreset && input.impersonatePresetId !== chat.promptPresetId;
+      const impersonateDefaultChoices = impersonatePresetDiffers
+        ? (() => {
+            try {
+              const raw = resolvedPreset?.defaultChoices as string | undefined;
+              if (!raw) return {};
+              const parsed = typeof raw === "string" ? JSON.parse(raw) : raw;
+              if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+              return parsed as Record<string, string | string[]>;
+            } catch {
+              return {};
+            }
+          })()
+        : null;
+      const chatChoices: Record<string, string | string[]> = impersonateDefaultChoices
+        ?? (chatMeta.presetChoices ?? {}) as Record<string, string | string[]>;
 
       let finalMessages: Array<{
         role: "system" | "user" | "assistant";
@@ -951,7 +998,12 @@ export async function generateRoutes(app: FastifyInstance) {
       // Determine whether agents are enabled for this chat (needed by assembler + agent pipeline)
       // Conversation mode chats never run roleplay agents — force agents off.
       logger.info("[generate] chatId=%s, chatMode=%s", input.chatId, chatMode);
-      const chatEnableAgents = chatMeta.enableAgents === true && chatMode !== "conversation";
+      const chatEnableAgents = shouldEnableAgentsForGeneration({
+        chatEnableAgents: chatMeta.enableAgents === true,
+        chatMode,
+        impersonate: input.impersonate,
+        impersonateBlockAgents: input.impersonateBlockAgents,
+      });
       const chatActiveAgentIds: string[] = Array.isArray(chatMeta.activeAgentIds)
         ? (chatMeta.activeAgentIds as string[])
         : [];
@@ -1042,9 +1094,8 @@ export async function generateRoutes(app: FastifyInstance) {
 
       sendProgress("assembling");
       const _tAssemble = Date.now();
-      if (presetId) {
-        const preset = await presets.getById(presetId);
-        if (preset) {
+      if (presetId && resolvedPreset) {
+        const preset = resolvedPreset;
           wrapFormat = (preset.wrapFormat as "xml" | "markdown" | "none") || "xml";
           const [sections, groups, choiceBlocks] = await Promise.all([
             presets.listSections(presetId),
@@ -1119,7 +1170,6 @@ export async function generateRoutes(app: FastifyInstance) {
               entryStateOverrides: assembled.updatedEntryStateOverrides,
             });
           }
-        }
       }
 
       // ── Conversation mode: inject built-in DM-style system prompt when no preset ──
@@ -5078,7 +5128,7 @@ export async function generateRoutes(app: FastifyInstance) {
       // ── Impersonate: inject instruction to respond as the user's character ──
       if (input.impersonate) {
         const impersonateInstruction = buildImpersonateInstruction({
-          customPrompt: chatMeta.impersonatePrompt,
+          customPrompt: input.impersonatePromptTemplate || chatMeta.impersonatePrompt,
           direction: input.userMessage,
           personaName,
           personaDescription,
@@ -5896,17 +5946,31 @@ export async function generateRoutes(app: FastifyInstance) {
           // Exception: if the model emitted character commands (e.g. [fetch:...]) with
           // no surrounding prose, treat the commands as the useful output. Skip saving
           // a blank assistant bubble but still return the commands so they execute.
-          if (!fullResponse.trim() && !input.impersonate) {
-            if (parsedCommands.length > 0) {
+          if (!fullResponse.trim()) {
+            if (!input.impersonate && parsedCommands.length > 0) {
               logger.info(
-                "[generate] Model emitted %d command(s) with no visible prose for chat %s; executing commands without saving a message",
+                "[generate] Model emitted %d command(s) with no visible prose for chat %s; saving hidden command anchor",
                 parsedCommands.length,
                 input.chatId,
               );
-              if (markGenerationCommitted) {
+              const savedMsg = await chats.createMessage({
+                chatId: input.chatId,
+                role: "assistant",
+                characterId: targetCharId,
+                content: "",
+              });
+              const anchoredMsg = savedMsg?.id
+                ? await chats.updateMessageExtra(savedMsg.id, {
+                    hiddenFromUser: true,
+                    hiddenFromAI: true,
+                    commandOnly: true,
+                    isGenerated: true,
+                  })
+                : savedMsg;
+              if (markGenerationCommitted && anchoredMsg?.id) {
                 generationComplete = true;
               }
-              return { savedMsg: null, response: "", commands: parsedCommands, oocMessages, characterId: targetCharId };
+              return { savedMsg: anchoredMsg, response: "", commands: parsedCommands, oocMessages, characterId: targetCharId };
             }
             logger.warn(`[generate] Empty response from model for chat ${input.chatId} (char: ${targetCharId})`);
             reply.raw.write(

--- a/packages/server/src/routes/generate/dry-run-route.ts
+++ b/packages/server/src/routes/generate/dry-run-route.ts
@@ -543,14 +543,17 @@ export async function registerDryRunRoute(app: FastifyInstance) {
 
     // Extensions sometimes send presetId as a number or `{id}`; accept these to avoid
     // silently falling back to the chat's default preset.
-    const presetIdOverride = asNonEmptyString(body.presetId);
+    const presetIdOverride =
+      (impersonate ? asNonEmptyString(body.impersonatePresetId) : null) || asNonEmptyString(body.presetId);
     const skipPreset = body.skipPreset === true;
     const presetText = typeof body.presetText === "string" ? body.presetText : "";
 
     // Resolve connection (allow override; otherwise use chat connection)
     // Extensions may send connectionId like presetId (number or `{id}`); accept it.
-    let connId = asNonEmptyString(body.connectionId);
-    if (!connId) connId = (chat.connectionId as string | null) ?? null;
+    const impersonateConnectionOverride =
+      impersonate ? asNonEmptyString(body.impersonateConnectionId) : null;
+    const fallbackConnectionId = asNonEmptyString(body.connectionId) || ((chat.connectionId as string | null) ?? null);
+    let connId = impersonateConnectionOverride || fallbackConnectionId;
 
     if (connId === "random") {
       const pool = await connections.listRandomPool();
@@ -560,7 +563,21 @@ export async function registerDryRunRoute(app: FastifyInstance) {
     }
 
     if (!connId) return reply.status(400).send({ error: "No API connection configured for this chat" });
-    const conn = await connections.getWithKey(connId);
+    let conn = await connections.getWithKey(connId);
+    if (!conn && impersonateConnectionOverride && connId === impersonateConnectionOverride && fallbackConnectionId) {
+      logger.warn(
+        "[dryRun] Impersonate connection override %s was not found; falling back to chat/request connection",
+        impersonateConnectionOverride,
+      );
+      connId = fallbackConnectionId;
+      if (connId === "random") {
+        const pool = await connections.listRandomPool();
+        if (!pool.length) return reply.status(400).send({ error: "No connections are marked for the random pool" });
+        const picked = pool[Math.floor(Math.random() * pool.length)];
+        connId = picked.id;
+      }
+      conn = connId ? await connections.getWithKey(connId) : null;
+    }
     if (!conn) return reply.status(400).send({ error: "API connection not found" });
 
     const baseUrl = resolveBaseUrl(conn);
@@ -1306,7 +1323,7 @@ export async function registerDryRunRoute(app: FastifyInstance) {
     // ── Impersonate: same instruction block as POST /api/generate (no DB writes) ──
     if (impersonate) {
       const impersonateInstruction = buildImpersonateInstruction({
-        customPrompt: chatMeta.impersonatePrompt,
+        customPrompt: body.impersonatePromptTemplate ?? chatMeta.impersonatePrompt,
         direction: userMessage,
         personaName,
         personaDescription,

--- a/packages/server/src/routes/generate/generate-route-utils.ts
+++ b/packages/server/src/routes/generate/generate-route-utils.ts
@@ -166,6 +166,20 @@ export function resolveBaseUrl(connection: { baseUrl: string | null; provider: s
   return providerDef?.defaultBaseUrl ?? "";
 }
 
+export function shouldEnableAgentsForGeneration({
+  chatEnableAgents,
+  chatMode,
+  impersonate,
+  impersonateBlockAgents,
+}: {
+  chatEnableAgents: boolean;
+  chatMode: string;
+  impersonate: boolean;
+  impersonateBlockAgents: boolean;
+}): boolean {
+  return chatEnableAgents && chatMode !== "conversation" && !(impersonate && impersonateBlockAgents);
+}
+
 /** Parse connection/chat stored generation parameters without injecting schema defaults. */
 export function parseStoredGenerationParameters(raw: unknown): StoredGenerationParameters | null {
   let parsed = raw;

--- a/packages/server/src/services/conversation/impersonate-prompt.ts
+++ b/packages/server/src/services/conversation/impersonate-prompt.ts
@@ -1,3 +1,5 @@
+import { DEFAULT_IMPERSONATE_PROMPT } from "@marinara-engine/shared";
+
 interface BuildImpersonateInstructionArgs {
   customPrompt?: unknown;
   direction?: string | null;
@@ -31,6 +33,35 @@ function buildCustomImpersonateInstruction(customPrompt: string, direction: stri
   return `${customPrompt} ${punctuateDirection(direction)}`;
 }
 
+function renderImpersonateTemplate(
+  template: string,
+  {
+    direction,
+    personaName,
+    personaDescription,
+  }: {
+    direction: string;
+    personaName: string;
+    personaDescription: string;
+  },
+): string {
+  return template
+    .split(/\r?\n/)
+    .filter((line) => {
+      if (!personaDescription && line.includes("{{persona_description}}")) return false;
+      if (!direction && line.includes("{{impersonate_direction}}")) return false;
+      return true;
+    })
+    .map((line) =>
+      line
+        .replaceAll("{{user}}", personaName)
+        .replaceAll("{{persona_description}}", personaDescription)
+        .replaceAll("{{impersonate_direction}}", direction),
+    )
+    .join("\n")
+    .trim();
+}
+
 export function buildImpersonateInstruction({
   customPrompt,
   direction,
@@ -40,23 +71,22 @@ export function buildImpersonateInstruction({
   const normalizedCustomPrompt = normalizeText(customPrompt);
   const impersonationDirection = normalizeDirection(direction);
   const personaLabel = normalizeText(personaName) || "{{user}}";
-
-  if (normalizedCustomPrompt) {
-    const resolvedCustomPrompt = normalizedCustomPrompt.replaceAll("{{user}}", personaLabel);
-    return buildCustomImpersonateInstruction(resolvedCustomPrompt, impersonationDirection);
-  }
-
   const description = normalizeText(personaDescription);
 
-  return [
-    `<instruction>`,
-    `You are now writing as ${personaLabel}, the user's character.`,
-    `Study ${personaLabel}'s previous messages in the conversation and replicate their voice, mannerisms, speech patterns, and style as closely as possible.`,
-    description ? `Character description: ${description}` : "",
-    impersonationDirection ? `Additional direction for this reply: ${impersonationDirection}` : "",
-    `Write a single in-character response from ${personaLabel}'s perspective. Do NOT break character or add meta-commentary. Respond exactly as ${personaLabel} would.`,
-    `</instruction>`,
-  ]
-    .filter(Boolean)
-    .join("\n");
+  if (normalizedCustomPrompt) {
+    const resolvedCustomPrompt = renderImpersonateTemplate(normalizedCustomPrompt, {
+      direction: impersonationDirection,
+      personaName: personaLabel,
+      personaDescription: description,
+    });
+    return normalizedCustomPrompt.includes("{{impersonate_direction}}")
+      ? resolvedCustomPrompt
+      : buildCustomImpersonateInstruction(resolvedCustomPrompt, impersonationDirection);
+  }
+
+  return renderImpersonateTemplate(DEFAULT_IMPERSONATE_PROMPT, {
+    direction: impersonationDirection,
+    personaName: personaLabel,
+    personaDescription: description,
+  });
 }

--- a/packages/server/test/generate-route-utils.test.ts
+++ b/packages/server/test/generate-route-utils.test.ts
@@ -1,0 +1,85 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { shouldEnableAgentsForGeneration } from "../src/routes/generate/generate-route-utils.js";
+
+test("disables agents before resolution when impersonate blocks agents", () => {
+  assert.equal(
+    shouldEnableAgentsForGeneration({
+      chatEnableAgents: true,
+      chatMode: "roleplay",
+      impersonate: true,
+      impersonateBlockAgents: true,
+    }),
+    false,
+  );
+});
+
+test("disables agents when the chat agent setting is off", () => {
+  const cases = [
+    { chatMode: "roleplay", impersonate: false, impersonateBlockAgents: false },
+    { chatMode: "game", impersonate: true, impersonateBlockAgents: false },
+    { chatMode: "visual_novel", impersonate: true, impersonateBlockAgents: true },
+  ];
+
+  for (const item of cases) {
+    assert.equal(
+      shouldEnableAgentsForGeneration({
+        chatEnableAgents: false,
+        chatMode: item.chatMode,
+        impersonate: item.impersonate,
+        impersonateBlockAgents: item.impersonateBlockAgents,
+      }),
+      false,
+    );
+  }
+});
+
+test("keeps agents enabled for impersonation when blocking is disabled", () => {
+  assert.equal(
+    shouldEnableAgentsForGeneration({
+      chatEnableAgents: true,
+      chatMode: "roleplay",
+      impersonate: true,
+      impersonateBlockAgents: false,
+    }),
+    true,
+  );
+});
+
+test("keeps agents enabled for normal roleplay generations", () => {
+  assert.equal(
+    shouldEnableAgentsForGeneration({
+      chatEnableAgents: true,
+      chatMode: "roleplay",
+      impersonate: false,
+      impersonateBlockAgents: true,
+    }),
+    true,
+  );
+});
+
+test("keeps agents enabled for game and visual novel modes", () => {
+  for (const chatMode of ["game", "visual_novel"]) {
+    assert.equal(
+      shouldEnableAgentsForGeneration({
+        chatEnableAgents: true,
+        chatMode,
+        impersonate: false,
+        impersonateBlockAgents: false,
+      }),
+      true,
+    );
+  }
+});
+
+test("keeps conversation mode agent pipeline disabled", () => {
+  assert.equal(
+    shouldEnableAgentsForGeneration({
+      chatEnableAgents: true,
+      chatMode: "conversation",
+      impersonate: false,
+      impersonateBlockAgents: false,
+    }),
+    false,
+  );
+});

--- a/packages/server/test/impersonate-prompt.test.ts
+++ b/packages/server/test/impersonate-prompt.test.ts
@@ -24,6 +24,18 @@ test("resolves the user macro in custom impersonate prompts", () => {
   );
 });
 
+test("resolves persona and direction macros in custom impersonate prompts", () => {
+  assert.equal(
+    buildImpersonateInstruction({
+      customPrompt: "Write as {{user}}.\nPersona: {{persona_description}}\nDirection: {{impersonate_direction}}",
+      direction: "keep it quiet",
+      personaName: "Mari",
+      personaDescription: "A precise engineer.",
+    }),
+    "Write as Mari.\nPersona: A precise engineer.\nDirection: keep it quiet",
+  );
+});
+
 test("keeps the default impersonate instruction when no custom prompt is set", () => {
   const instruction = buildImpersonateInstruction({
     direction: "answer coldly",

--- a/packages/shared/src/constants/impersonate.ts
+++ b/packages/shared/src/constants/impersonate.ts
@@ -1,0 +1,19 @@
+/**
+ * Default impersonate prompt template.
+ *
+ * When no custom template is provided (empty string), the server falls back to
+ * this built-in instruction. The constant lives in the shared package so the
+ * client can display a read-only preview in the Impersonate Settings drawer
+ * without duplicating the string.
+ */
+export const DEFAULT_IMPERSONATE_PROMPT = [
+  `<instruction>`,
+  `You are now writing as {{user}}, the user's character.`,
+  `Study {{user}}'s previous messages in the conversation and replicate their voice, mannerisms, speech patterns, and style as closely as possible.`,
+  `Character description: {{persona_description}}`,
+  `Additional direction for this reply: {{impersonate_direction}}`,
+  `Write a single in-character response from {{user}}'s perspective. Do NOT break character or add meta-commentary. Respond exactly as {{user}} would.`,
+  `</instruction>`,
+]
+  .filter(Boolean)
+  .join("\n");

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -43,6 +43,7 @@ export * from "./constants/defaults.js";
 export * from "./constants/chat-modes.js";
 export * from "./constants/model-lists.js"; // also exports IMAGE_GENERATION_SOURCES
 export * from "./constants/agent-prompts.js";
+export * from "./constants/impersonate.js";
 export * from "./constants/image-generation-defaults.js";
 export * from "./constants/security.js";
 

--- a/packages/shared/src/schemas/chat.schema.ts
+++ b/packages/shared/src/schemas/chat.schema.ts
@@ -50,6 +50,12 @@ export const generateRequestSchema = z.object({
     )
     .optional()
     .default([]),
+
+  // Impersonate overrides (applied only when impersonate=true)
+  impersonatePresetId: z.string().nullish(),
+  impersonateConnectionId: z.string().nullish(),
+  impersonateBlockAgents: z.boolean().optional().default(false),
+  impersonatePromptTemplate: z.string().optional(),
 });
 
 // Auto-summarization entries — shape-only validation (no length caps).


### PR DESCRIPTION
## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- Adds a configurable impersonation workflow so users can more easily generate persona-side messages without manually switching context or rewriting prompts each time.
- Makes the Impersonate settings drawer more compact and easier to scan, especially around preset, connection, quick button, and agent pipeline options.

## What changed

<!-- List the key changes in this PR -->

- Added shared impersonation defaults and configuration plumbing.
- Added `/impersonate` and impersonation prompt handling.
- Added configurable Impersonate settings for prompt template, preset, connection, quick button visibility, and agent pipeline behavior.
- Polished the Impersonate settings drawer layout for better alignment and compactness.
- Added/updated docs for the impersonation workflow in conversation and roleplay docs.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [X] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [X] Ran the app, clicked through the changes manually
- [X] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [X] Above manual verification completed (describe below)
- [X] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- [X] `pnpm check` passed locally.
- [X] `pnpm build` passed while preparing the AppData test install.
- Manual browser/app verification:
  - [X] Open the Impersonate settings drawer.
  - [X] Confirm preset and connection selectors display correctly.
  - [X] Toggle Quick button and Agent pipeline settings.
  - [X] Confirm `/impersonate` works with the selected settings.
  - [X] Confirm `/impersonate_prompt` updates/resets the prompt template as expected.
  - [X] Check the drawer layout at normal and narrow widths.

## Docs and release impact

- [ ] No docs changes needed
- [X] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

- Updated docs:
  - `docs/CONVERSATION.md`
  - `docs/ROLEPLAY.md`
- No version or release files were changed.
- No README, CONTRIBUTING, Android, or CHANGELOG changes appeared necessary for this feature.

## UI evidence (if applicable)

<img width="337" height="537" alt="Screenshot 2026-05-07 000529" src="https://github.com/user-attachments/assets/1c30c1c3-fa92-41e6-bbcd-36cce2665c15" />

Quick button

<img width="196" height="73" alt="image" src="https://github.com/user-attachments/assets/a20667ff-ab93-4c03-9e9b-25219d623237" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Impersonation: generate as your persona via /impersonate and a new quick-action button
  * Impersonate settings: customizable prompt template, presets, connection, quick button, and per-chat prompt tuning
  * Hide messages: support for messages hidden from user view

* **Documentation**
  * Added impersonation guides to Conversation Mode and Roleplay docs

* **Tests**
  * Added tests for impersonation prompt rendering and agent-enablement logic
<!-- end of auto-generated comment: release notes by coderabbit.ai -->