### PR TITLE
Optimize expression agent prompts and normalize context sizes

### DIFF
--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -60,7 +60,7 @@ import {
 import { executeToolCalls, type MetadataPatchInput } from "../services/tools/tool-executor.js";
 import { createAgentPipeline, type ResolvedAgent, type AgentInjection } from "../services/agents/agent-pipeline.js";
 import { DATA_DIR } from "../utils/data-dir.js";
-import { executeAgent, resolveAgentResultType } from "../services/agents/agent-executor.js";
+import { executeAgent, normalizeAgentContextSize, resolveAgentResultType } from "../services/agents/agent-executor.js";
 import { getLocalSidecarProvider, LOCAL_SIDECAR_MODEL } from "../services/llm/local-sidecar.js";
 import {
   parseCharacterCommands,
@@ -3599,7 +3599,9 @@ export async function generateRoutes(app: FastifyInstance) {
       // Build base agent context (without mainResponse — that comes after generation)
       // Fetch enough history for the hungriest agent — individual agents trim to their own contextSize.
       const agentContextSize =
-        resolvedAgents.length > 0 ? Math.max(...resolvedAgents.map((a) => (a.settings.contextSize as number) || 5)) : 5;
+        resolvedAgents.length > 0
+          ? Math.max(...resolvedAgents.map((a) => normalizeAgentContextSize(a.settings.contextSize)))
+          : 5;
       const agentSlice = chatMessages.slice(-agentContextSize);
 
       // Batch-fetch committed game state snapshots for assistant messages in the agent context

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -10,7 +10,7 @@ import { eq } from "drizzle-orm";
 import { listCharacterSprites } from "../../services/game/sprite.service.js";
 import { DATA_DIR } from "../../utils/data-dir.js";
 import type { ResolvedAgent } from "../../services/agents/agent-pipeline.js";
-import { executeAgent, executeAgentBatch } from "../../services/agents/agent-executor.js";
+import { executeAgent, executeAgentBatch, normalizeAgentContextSize } from "../../services/agents/agent-executor.js";
 import { getLocalSidecarProvider, LOCAL_SIDECAR_MODEL } from "../../services/llm/local-sidecar.js";
 import { createLLMProvider } from "../../services/llm/provider-registry.js";
 import { sidecarModelService } from "../../services/sidecar/sidecar-model.service.js";
@@ -191,7 +191,7 @@ async function buildRetryAgentContext(args: {
       ? Math.max(
           ...enabledConfigs.map((c: any) => {
             const settings = typeof c.settings === "string" ? JSON.parse(c.settings) : (c.settings ?? {});
-            return (settings.contextSize as number) || 5;
+            return normalizeAgentContextSize(settings.contextSize);
           }),
         )
       : 5;

--- a/packages/server/src/services/agents/agent-executor.ts
+++ b/packages/server/src/services/agents/agent-executor.ts
@@ -13,6 +13,11 @@ import {
 import { isDebugAgentsEnabled } from "../../config/runtime-config.js";
 import { logger } from "../../lib/logger.js";
 
+const MAX_AGENT_CONTEXT_MESSAGES = 200;
+const EXPRESSION_AGENT_RECENT_CONTEXT_MESSAGES = 2;
+const EXPRESSION_AGENT_CONTEXT_CHAR_LIMIT = 1200;
+const EXPRESSION_AGENT_RESPONSE_CHAR_LIMIT = 6000;
+
 /** Strip HTML/XML-style tags (e.g. <div style="..."> <br> <speaker>) from text to save tokens. */
 function stripHtmlTags(text: string): string {
   return text
@@ -36,6 +41,13 @@ export interface AgentExecConfig {
 export interface AgentToolContext {
   tools: LLMToolDefinition[];
   executeToolCall: (call: LLMToolCall) => Promise<string>;
+}
+
+export function normalizeAgentContextSize(value: unknown, fallback = DEFAULT_AGENT_CONTEXT_SIZE): number {
+  const parsed =
+    typeof value === "number" ? value : typeof value === "string" && value.trim() ? Number(value) : fallback;
+  if (!Number.isFinite(parsed) || parsed < 1) return fallback;
+  return Math.max(1, Math.min(MAX_AGENT_CONTEXT_MESSAGES, Math.trunc(parsed)));
 }
 
 function redactSensitiveValue(value: unknown): unknown {
@@ -102,32 +114,15 @@ export async function executeAgent(
   const startTime = Date.now();
 
   try {
-    // Build the agent's system prompt with <role> + <lore> + <agents> + extras
     const template = config.promptTemplate || getDefaultAgentPrompt(config.type);
     if (!template) {
       return makeError(config, "No prompt template configured", startTime);
     }
 
-    const systemParts: string[] = [];
-    systemParts.push(`<role>`);
-    systemParts.push(`You are a specialized agent. Fulfill your task and return the requested output.`);
-    systemParts.push(`</role>`);
-    systemParts.push(``);
-    systemParts.push(buildLoreBlock(context));
-    systemParts.push(``);
-    systemParts.push(`<agents>`);
-    systemParts.push(`Fulfill the requested task here and return the output in the format specified:`);
-    systemParts.push(template);
-    systemParts.push(`</agents>`);
-    const extras = buildAgentExtras(context, [config.type]);
-    if (extras) {
-      systemParts.push(``);
-      systemParts.push(extras);
-    }
-
-    // Build multi-turn message array for this agent (sliced to its own contextSize)
-    const agentContextSize = (config.settings.contextSize as number) || DEFAULT_AGENT_CONTEXT_SIZE;
-    const messages = buildAgentMessages(systemParts.join("\n"), context, config.type, agentContextSize);
+    const messages =
+      config.type === "expression"
+        ? buildExpressionAgentMessages(template, context)
+        : buildStandardAgentMessages(config, template, context);
 
     // Agents use lower temperature for reliability
     const temperature = (config.settings.temperature as number) ?? 0.3;
@@ -320,6 +315,29 @@ export async function executeAgentBatch(
   model: string,
 ): Promise<AgentResult[]> {
   if (configs.length === 0) return [];
+  const isolatedConfigs = configs.filter(shouldRunAgentIndividually);
+  if (isolatedConfigs.length > 0 && isolatedConfigs.length < configs.length) {
+    logger.info(
+      "[agent-batch] Running %d compact agent(s) outside batch: [%s]",
+      isolatedConfigs.length,
+      isolatedConfigs.map((c) => c.type).join(", "),
+    );
+    const batchedConfigs = configs.filter((config) => !shouldRunAgentIndividually(config));
+    const [batchedResults, isolatedSettled] = await Promise.all([
+      executeAgentBatch(batchedConfigs, context, provider, model),
+      Promise.allSettled(isolatedConfigs.map((config) => executeAgent(config, context, provider, model))),
+    ]);
+    const isolatedResults = isolatedSettled.map((entry, index) =>
+      entry.status === "fulfilled"
+        ? entry.value
+        : makeError(
+            isolatedConfigs[index]!,
+            entry.reason instanceof Error ? entry.reason.message : "Agent execution failed",
+            Date.now(),
+          ),
+    );
+    return [...batchedResults, ...isolatedResults];
+  }
   if (configs.length === 1) {
     logger.info(`[agent-batch] Only 1 agent (${configs[0]!.type}), running individually`);
     return [await executeAgent(configs[0]!, context, provider, model)];
@@ -333,9 +351,7 @@ export async function executeAgentBatch(
     // Build merged system prompt (includes lore + agent extras)
     const systemPrompt = buildBatchSystemPrompt(configs, context);
     // Batch uses the max contextSize among its members
-    const batchContextSize = Math.max(
-      ...configs.map((c) => (c.settings.contextSize as number) || DEFAULT_AGENT_CONTEXT_SIZE),
-    );
+    const batchContextSize = Math.max(...configs.map((c) => normalizeAgentContextSize(c.settings.contextSize)));
     const messages = buildAgentMessages(systemPrompt, context, "__batch__", batchContextSize);
 
     // Each agent reserves its own configured output budget. The context fitter
@@ -574,6 +590,104 @@ function makeError(config: AgentExecConfig, error: string, startTime: number): A
   };
 }
 
+function shouldRunAgentIndividually(config: Pick<AgentExecConfig, "type">): boolean {
+  return config.type === "expression";
+}
+
+function buildStandardAgentMessages(config: AgentExecConfig, template: string, context: AgentContext): ChatMessage[] {
+  // Build the agent's system prompt with <role> + <lore> + <agents> + extras
+  const systemParts: string[] = [];
+  systemParts.push(`<role>`);
+  systemParts.push(`You are a specialized agent. Fulfill your task and return the requested output.`);
+  systemParts.push(`</role>`);
+  systemParts.push(``);
+  systemParts.push(buildLoreBlock(context));
+  systemParts.push(``);
+  systemParts.push(`<agents>`);
+  systemParts.push(`Fulfill the requested task here and return the output in the format specified:`);
+  systemParts.push(template);
+  systemParts.push(`</agents>`);
+  const extras = buildAgentExtras(context, [config.type]);
+  if (extras) {
+    systemParts.push(``);
+    systemParts.push(extras);
+  }
+
+  // Build multi-turn message array for this agent (sliced to its own contextSize)
+  const agentContextSize = normalizeAgentContextSize(config.settings.contextSize);
+  return buildAgentMessages(systemParts.join("\n"), context, config.type, agentContextSize);
+}
+
+function truncateAgentText(text: string, maxChars: number): string {
+  const cleaned = stripHtmlTags(text);
+  const chars = Array.from(cleaned);
+  if (chars.length <= maxChars) return cleaned;
+
+  const marker = "\n\n[Trimmed to keep this agent request compact]\n\n";
+  const available = Math.max(0, maxChars - marker.length);
+  const head = Math.floor(available * 0.4);
+  const tail = available - head;
+  return chars.slice(0, head).join("") + marker + chars.slice(-tail).join("");
+}
+
+function findLatestAssistantMessage(context: AgentContext): { index: number; content: string } | null {
+  for (let index = context.recentMessages.length - 1; index >= 0; index--) {
+    const message = context.recentMessages[index]!;
+    if (message.role === "assistant" && message.content.trim()) {
+      return { index, content: message.content };
+    }
+  }
+  return null;
+}
+
+function buildExpressionAgentMessages(template: string, context: AgentContext): ChatMessage[] {
+  const systemParts: string[] = [];
+  systemParts.push(`<role>`);
+  systemParts.push(`You are a specialized expression-selection agent. Keep the request compact and return only JSON.`);
+  systemParts.push(`</role>`);
+  systemParts.push(``);
+  systemParts.push(`<agents>`);
+  systemParts.push(`Fulfill the requested task here and return the output in the format specified:`);
+  systemParts.push(template);
+  systemParts.push(`</agents>`);
+
+  const spritesBlock = buildAvailableSpritesBlock(context);
+  if (spritesBlock) {
+    systemParts.push(``);
+    systemParts.push(spritesBlock);
+  }
+
+  const latestAssistant = findLatestAssistantMessage(context);
+  const responseText = context.mainResponse?.trim() || latestAssistant?.content || "";
+  const contextEndIndex = context.mainResponse?.trim() ? context.recentMessages.length : (latestAssistant?.index ?? 0);
+  const recentContext = context.recentMessages
+    .slice(0, contextEndIndex)
+    .slice(-EXPRESSION_AGENT_RECENT_CONTEXT_MESSAGES)
+    .filter((message) => message.content.trim());
+
+  const userParts: string[] = [];
+  if (recentContext.length > 0) {
+    userParts.push(`<recent_context>`);
+    for (const message of recentContext) {
+      const role = message.role === "assistant" ? "assistant" : "user";
+      userParts.push(`[${role}] ${truncateAgentText(message.content, EXPRESSION_AGENT_CONTEXT_CHAR_LIMIT)}`);
+    }
+    userParts.push(`</recent_context>`);
+    userParts.push(``);
+  }
+
+  userParts.push(`<assistant_response>`);
+  userParts.push(truncateAgentText(responseText, EXPRESSION_AGENT_RESPONSE_CHAR_LIMIT));
+  userParts.push(`</assistant_response>`);
+  userParts.push(``);
+  userParts.push(`Now return the requested format.`);
+
+  return [
+    { role: "system", content: systemParts.join("\n"), contextKind: "prompt" },
+    { role: "user", content: userParts.join("\n"), contextKind: "history" },
+  ];
+}
+
 /** Extract a useful message from fetch/network errors (preserves err.cause). */
 export function extractErrorMessage(err: unknown, fallback = "Agent execution failed"): string {
   if (!(err instanceof Error)) return fallback;
@@ -746,6 +860,22 @@ function buildLoreBlock(context: AgentContext): string {
   return parts.join("\n");
 }
 
+function buildAvailableSpritesBlock(context: AgentContext): string {
+  if (!context.memory._availableSprites) return "";
+
+  const sprites = context.memory._availableSprites as Array<{
+    characterId: string;
+    characterName: string;
+    expressions: string[];
+  }>;
+  const parts: string[] = [`<available_sprites>`];
+  for (const char of sprites) {
+    parts.push(`${char.characterName} (${char.characterId}): ${char.expressions.join(", ")}`);
+  }
+  parts.push(`</available_sprites>`);
+  return parts.join("\n");
+}
+
 /**
  * Build agent-specific context blocks (sprites, backgrounds, source material, etc.)
  * that go into the system message after lore.
@@ -789,17 +919,9 @@ function buildAgentExtras(context: AgentContext, agentTypes: string[] = []): str
     parts.push(`</current_game_state>`);
   }
 
-  if (context.memory._availableSprites) {
-    const sprites = context.memory._availableSprites as Array<{
-      characterId: string;
-      characterName: string;
-      expressions: string[];
-    }>;
-    parts.push(`<available_sprites>`);
-    for (const char of sprites) {
-      parts.push(`${char.characterName} (${char.characterId}): ${char.expressions.join(", ")}`);
-    }
-    parts.push(`</available_sprites>`);
+  if (agentTypes.includes("expression")) {
+    const availableSpritesBlock = buildAvailableSpritesBlock(context);
+    if (availableSpritesBlock) parts.push(availableSpritesBlock);
   }
 
   if (context.memory._availableBackgrounds) {

--- a/packages/server/test/agent-executor-expression.test.ts
+++ b/packages/server/test/agent-executor-expression.test.ts
@@ -1,0 +1,135 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { AgentContext } from "@marinara-engine/shared";
+import type { BaseLLMProvider, ChatMessage, ChatCompletionResult } from "../src/services/llm/base-provider.js";
+import {
+  executeAgent,
+  executeAgentBatch,
+  normalizeAgentContextSize,
+  type AgentExecConfig,
+} from "../src/services/agents/agent-executor.js";
+
+function makeExpressionContext(): AgentContext {
+  const oldMessages = Array.from({ length: 40 }, (_, index) => ({
+    role: index % 2 === 0 ? "user" : "assistant",
+    content: `ancient-history-marker-${index} ${"old context ".repeat(200)}`,
+  }));
+
+  return {
+    chatId: "chat-1",
+    chatMode: "roleplay",
+    recentMessages: [
+      ...oldMessages,
+      { role: "user", content: "Can you answer her question?" },
+      { role: "assistant", content: "She waits quietly, trying not to look nervous." },
+    ],
+    mainResponse: "Mira's shoulders ease, and she answers with a small, relieved smile.",
+    gameState: null,
+    characters: [
+      {
+        id: "mira",
+        name: "Mira",
+        description: `character-description-marker ${"very long character card ".repeat(300)}`,
+      },
+    ],
+    persona: {
+      name: "Player",
+      description: `persona-description-marker ${"very long persona ".repeat(300)}`,
+    },
+    memory: {
+      _availableSprites: [{ characterId: "mira", characterName: "Mira", expressions: ["neutral", "happy", "worried"] }],
+    },
+    activatedLorebookEntries: [
+      { id: "lore-1", name: "Lore", tag: "world", content: `lore-marker ${"very long lore ".repeat(300)}` },
+    ],
+    writableLorebookIds: null,
+    chatSummary: `summary-marker ${"very long summary ".repeat(300)}`,
+    streaming: false,
+  };
+}
+
+function makeConfig(type: string, settings: Record<string, unknown> = {}): AgentExecConfig {
+  return {
+    id: `${type}-id`,
+    type,
+    name: type,
+    phase: "post_processing",
+    promptTemplate: `Return valid JSON for ${type}.`,
+    connectionId: null,
+    settings,
+  };
+}
+
+function makeCapturingProvider(captured: ChatMessage[][]): BaseLLMProvider {
+  return {
+    get maxTokensOverrideValue() {
+      return null;
+    },
+    chatComplete: async (messages: ChatMessage[]): Promise<ChatCompletionResult> => {
+      captured.push(messages);
+      const system = messages[0]?.content ?? "";
+      const content = system.includes("world-state")
+        ? '{"date":null,"time":null,"location":null,"weather":null,"temperature":null}'
+        : '{"expressions":[]}';
+      return {
+        content,
+        toolCalls: [],
+        finishReason: "stop",
+        usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+      };
+    },
+  } as unknown as BaseLLMProvider;
+}
+
+test("normalizes runaway agent context sizes as message counts", () => {
+  assert.equal(normalizeAgentContextSize(12_000), 200);
+  assert.equal(normalizeAgentContextSize("7"), 7);
+  assert.equal(normalizeAgentContextSize(0), 5);
+});
+
+test("expression agent prompt stays compact and omits unrelated lore", async () => {
+  const captured: ChatMessage[][] = [];
+  const provider = makeCapturingProvider(captured);
+
+  await executeAgent(
+    makeConfig("expression", { contextSize: 12_000 }),
+    makeExpressionContext(),
+    provider,
+    "test-model",
+  );
+
+  assert.equal(captured.length, 1);
+  const prompt = captured[0]!.map((message) => message.content).join("\n");
+
+  assert.match(prompt, /<available_sprites>/);
+  assert.match(prompt, /Mira \(mira\): neutral, happy, worried/);
+  assert.match(prompt, /relieved smile/);
+  assert.doesNotMatch(prompt, /ancient-history-marker-0/);
+  assert.doesNotMatch(prompt, /character-description-marker/);
+  assert.doesNotMatch(prompt, /persona-description-marker/);
+  assert.doesNotMatch(prompt, /lore-marker/);
+  assert.doesNotMatch(prompt, /summary-marker/);
+  assert.ok(prompt.length < 10_000);
+});
+
+test("batched execution runs expression separately from larger tracker prompts", async () => {
+  const captured: ChatMessage[][] = [];
+  const provider = makeCapturingProvider(captured);
+
+  await executeAgentBatch(
+    [makeConfig("world-state", { contextSize: 12_000 }), makeConfig("expression", { contextSize: 1 })],
+    makeExpressionContext(),
+    provider,
+    "test-model",
+  );
+
+  assert.equal(captured.length, 2);
+
+  const expressionCall = captured.find((messages) =>
+    messages.some((message) => message.content.includes("expression-selection agent")),
+  );
+  assert.ok(expressionCall);
+  const expressionPrompt = expressionCall.map((message) => message.content).join("\n");
+  assert.doesNotMatch(expressionPrompt, /agent_task id="world-state"/);
+  assert.doesNotMatch(expressionPrompt, /ancient-history-marker-0/);
+});


### PR DESCRIPTION
Expression agents now use a compact dedicated message builder that omits lore, character cards, persona descriptions, and summaries. They are also run outside the batch pipeline to avoid inflating batch context. Context sizes are clamped to 1–200 via a shared normalizeAgentContextSize helper.

## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #436 

## Why this change

- Fixes Expression Engine prompts growing with oversized saved agent context settings, which can make tiny scenes consume nearly the full model context window.

## What changed

- Added server-side normalization so agent context size is treated as a bounded message count.
- Built a compact Expression Engine prompt that includes only sprite options, minimal recent context, and the latest assistant response.
- Runs Expression Engine separately from larger batched agent prompts so it does not inherit unrelated lore or tracker context.
- Added focused server tests for runaway context size, compact expression prompts, and mixed batch behavior.

## Validation

- [X] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [X] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [X] Above manual verification completed (describe below)
- [X] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `pnpm --filter @marinara-engine/server test`
- `pnpm check`
- [X] Exchanged messages in chat with Expression Engine enabled, verifying agents all still work normally.

## Docs and release impact

- [X] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

<!-- Add before/after screenshots or recordings for UI changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expression agents now support rendering available sprites in their execution context

* **Bug Fixes**
  * Enhanced agent context size validation to prevent invalid or out-of-bounds values

* **Tests**
  * Added test suite covering expression agent workflows and context normalization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->