### PR TITLE
fix: retry conversation generation from send button

### DIFF
--- a/packages/client/src/components/chat/ConversationInput.tsx
+++ b/packages/client/src/components/chat/ConversationInput.tsx
@@ -1,11 +1,25 @@
 // ──────────────────────────────────────────────
 // Chat: Conversation Input — Discord-style
 // ──────────────────────────────────────────────
-import { useState, useRef, useCallback, useEffect } from "react";
-import { Send, Smile, StopCircle, X, Plus, ImagePlay, AtSign, Users, UserCheck, Languages, Loader2, FileText } from "lucide-react";
+import { useState, useRef, useCallback, useEffect, useMemo } from "react";
+import {
+  Send,
+  Smile,
+  StopCircle,
+  X,
+  Plus,
+  ImagePlay,
+  AtSign,
+  Users,
+  UserCheck,
+  Languages,
+  Loader2,
+  FileText,
+  RefreshCw,
+} from "lucide-react";
 import { createPortal } from "react-dom";
 import { toast } from "sonner";
-import { useQueryClient } from "@tanstack/react-query";
+import { useQueryClient, type InfiniteData } from "@tanstack/react-query";
 import { useChatStore } from "../../stores/chat.store";
 import { useUIStore } from "../../stores/ui.store";
 import { useGenerate } from "../../hooks/use-generate";
@@ -30,6 +44,7 @@ import { SpeechToTextButton } from "../ui/SpeechToTextButton";
 import { MariThinkingIndicator } from "./MariThinkingIndicator";
 import { MariCapabilityNotice } from "./MariCapabilityNotice";
 import { SlashCommandFeedback } from "./SlashCommandFeedback";
+import type { Message } from "@marinara-engine/shared";
 
 interface Attachment {
   type: string;
@@ -203,6 +218,28 @@ export function ConversationInput({
   const fileInputRef = useRef<HTMLInputElement>(null);
   const isReadingAttachments = pendingAttachmentReads > 0;
   const hasPendingAttachments = isReadingAttachments || attachments.length > 0;
+
+  // Read from the existing infinite-message cache so an empty Send can retry
+  // after a failed generation without adding a second user message.
+  const [, bumpMessagesTick] = useState(0);
+  useEffect(() => {
+    if (!activeChatId) return;
+    const targetKey = JSON.stringify(chatKeys.messages(activeChatId));
+    return qc.getQueryCache().subscribe((event) => {
+      if (JSON.stringify(event.query.queryKey) === targetKey) {
+        bumpMessagesTick((n) => n + 1);
+      }
+    });
+  }, [activeChatId, qc]);
+  const messagesData = qc.getQueryData<InfiniteData<Message[]>>(chatKeys.messages(activeChatId ?? ""));
+  const lastMessageRole = useMemo(() => {
+    const firstPage = messagesData?.pages?.[0];
+    return firstPage?.[firstPage.length - 1]?.role ?? null;
+  }, [messagesData]);
+  const canRetry = !isStreaming && groupResponseOrder !== "manual" && lastMessageRole === "user";
+  const canSubmit = hasInput || attachments.length > 0 || canRetry;
+  const showRetrySendState = canRetry && !hasInput && attachments.length === 0;
+  const sendButtonTitle = isActuallyGenerating ? "Stop generating" : showRetrySendState ? "Retry generation" : "Send";
 
   const syncInputState = useCallback(
     (value: string) => {
@@ -378,6 +415,14 @@ export function ConversationInput({
     }
     const raw = textareaRef.current?.value.trim() ?? "";
     if (!raw && attachments.length === 0) {
+      if (canRetry) {
+        try {
+          await generate({ chatId: activeChatId, connectionId: null });
+        } catch (error) {
+          const msg = error instanceof Error ? error.message : "Generation failed";
+          toast.error(msg);
+        }
+      }
       return;
     }
 
@@ -526,6 +571,7 @@ export function ConversationInput({
   }, [
     activeChatId,
     attachments,
+    canRetry,
     isReadingAttachments,
     isStreaming,
     generate,
@@ -1143,18 +1189,24 @@ export function ConversationInput({
 
           <button
             onClick={isActuallyGenerating ? () => useChatStore.getState().stopGeneration() : handleSend}
-            disabled={!isActuallyGenerating && isReadingAttachments}
+            disabled={!isActuallyGenerating && (isReadingAttachments || !activeChatId || !canSubmit)}
             className={cn(
               "flex h-8 w-8 items-center justify-center rounded-xl transition-all duration-200",
               isActuallyGenerating
                 ? "text-foreground hover:opacity-80"
-                : (hasInput || attachments.length > 0) && !isReadingAttachments
+                : canSubmit && !isReadingAttachments
                   ? "text-foreground hover:text-foreground/80 active:scale-90"
                   : "text-foreground/20",
             )}
-            title={isActuallyGenerating ? "Stop generating" : "Send"}
+            title={sendButtonTitle}
           >
-            {isActuallyGenerating ? <StopCircle size="1rem" /> : <Send size="0.9375rem" />}
+            {isActuallyGenerating ? (
+              <StopCircle size="1rem" />
+            ) : showRetrySendState ? (
+              <RefreshCw size="0.9375rem" />
+            ) : (
+              <Send size="0.9375rem" />
+            )}
           </button>
         </div>
       </div>

--- a/packages/client/src/components/chat/ConversationInput.tsx
+++ b/packages/client/src/components/chat/ConversationInput.tsx
@@ -1190,6 +1190,7 @@ export function ConversationInput({
           <button
             onClick={isActuallyGenerating ? () => useChatStore.getState().stopGeneration() : handleSend}
             disabled={!isActuallyGenerating && (isReadingAttachments || !activeChatId || !canSubmit)}
+            aria-label={sendButtonTitle}
             className={cn(
               "flex h-8 w-8 items-center justify-center rounded-xl transition-all duration-200",
               isActuallyGenerating


### PR DESCRIPTION
## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- Conversation-mode generation failures could leave users stuck copying and resending their last message because the send button was inactive when the input was empty.
- This makes retrying a failed assistant response easier and more consistent with roleplay mode.

## What changed

<!-- List the key changes in this PR -->

- Added empty-input retry support to the conversation chat send button when the latest message is from the user.
- Updated the send button affordance to show a retry icon/title when retry is available.
- Kept manual group-response mode from auto-retrying, so manual character triggering behavior stays unchanged.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [X] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [X] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [X] Above manual verification completed (describe below)
- [X] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- [X] Started conversation chat with character, sent message and immediately stopped generation.
- [X] Verified greyed out send button becomes a "Retry" button.
- [X] Verified pressing retry triggers a generate request.

## Docs and release impact

- [X] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

<!-- Add before/after screenshots or recordings for UI changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retry messaging: Users can retry sending messages when previous responses are available.
  * Enhanced Send button: Conversation input now shows Send, Stop, and Retry states that adjust to chat activity.
  * Attachment state handling: Improved handling and feedback for attachments during message composition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->