### PR TITLE
Show image generation prompt in lightbox

### DIFF
--- a/packages/client/src/components/chat/ChatGallery.tsx
+++ b/packages/client/src/components/chat/ChatGallery.tsx
@@ -10,11 +10,20 @@ import {
   type ChatImage,
 } from "../../hooks/use-gallery";
 import { useGalleryStore } from "../../stores/gallery.store";
+import { ImagePromptPanel } from "./ImagePromptPanel";
 
 interface ChatGalleryProps {
   chatId: string;
   /** Manually trigger the Illustrator agent */
   onIllustrate?: () => void;
+}
+
+function formatImageMeta(image: ChatImage) {
+  const details: string[] = [];
+  if (image.model) details.push(image.model);
+  if (image.provider) details.push(image.provider.replace(/_/g, " "));
+  if (image.width && image.height) details.push(`${image.width} x ${image.height}`);
+  return details.join(" | ");
 }
 
 export function ChatGallery({ chatId, onIllustrate }: ChatGalleryProps) {
@@ -25,6 +34,8 @@ export function ChatGallery({ chatId, onIllustrate }: ChatGalleryProps) {
   const [lightbox, setLightbox] = useState<ChatImage | null>(null);
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
   const pinImage = useGalleryStore((s) => s.pinImage);
+  const lightboxPrompt = lightbox?.prompt.trim() ?? "";
+  const lightboxMeta = lightbox ? formatImageMeta(lightbox) : "";
 
   const handleUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
     const input = e.currentTarget;
@@ -162,44 +173,54 @@ export function ChatGallery({ chatId, onIllustrate }: ChatGalleryProps) {
           className="fixed inset-0 z-[100] flex items-center justify-center bg-black/80 max-md:pt-[env(safe-area-inset-top)]"
           onClick={() => setLightbox(null)}
         >
-          <div className="relative max-h-[90vh] max-w-[90vw] w-[min(90vw,90vh)]" onClick={(e) => e.stopPropagation()}>
-            <img
-              src={lightbox.url}
-              alt={lightbox.prompt || "Gallery image"}
-              decoding="async"
-              className="max-h-[85vh] w-full rounded-lg object-contain shadow-2xl"
-            />
-            {/* Controls */}
-            <div className="absolute right-2 top-2 flex gap-2">
-              <button
-                type="button"
-                onClick={() => {
-                  pinImage(lightbox);
-                  setLightbox(null);
-                }}
-                aria-label="Pin image to chat"
-                className="rounded-lg bg-black/60 p-2 text-white transition-colors hover:bg-black/80"
-                title="Pin to chat"
-              >
-                <Minimize2 size="0.875rem" />
-              </button>
-              <a
-                href={lightbox.url}
-                download
-                aria-label="Download image"
-                className="rounded-lg bg-black/60 p-2 text-white transition-colors hover:bg-black/80"
-              >
-                <Download size="0.875rem" />
-              </a>
-              <button
-                type="button"
-                onClick={() => setLightbox(null)}
-                aria-label="Close image"
-                className="rounded-lg bg-black/60 p-2 text-white transition-colors hover:bg-black/80"
-              >
-                <X size="0.875rem" />
-              </button>
+          <div
+            className="flex max-h-[90vh] w-[min(90vw,64rem)] max-w-[90vw] flex-col items-center gap-2"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="relative flex min-h-0 max-w-full justify-center">
+              <img
+                src={lightbox.url}
+                alt={lightbox.prompt || "Gallery image"}
+                decoding="async"
+                className={
+                  lightboxPrompt || lightboxMeta
+                    ? "max-h-[calc(90vh-10rem)] max-w-full rounded-lg object-contain shadow-2xl"
+                    : "max-h-[85vh] max-w-full rounded-lg object-contain shadow-2xl"
+                }
+              />
+              {/* Controls */}
+              <div className="absolute right-2 top-2 flex gap-2">
+                <button
+                  type="button"
+                  onClick={() => {
+                    pinImage(lightbox);
+                    setLightbox(null);
+                  }}
+                  aria-label="Pin image to chat"
+                  className="rounded-lg bg-black/60 p-2 text-white transition-colors hover:bg-black/80"
+                  title="Pin to chat"
+                >
+                  <Minimize2 size="0.875rem" />
+                </button>
+                <a
+                  href={lightbox.url}
+                  download
+                  aria-label="Download image"
+                  className="rounded-lg bg-black/60 p-2 text-white transition-colors hover:bg-black/80"
+                >
+                  <Download size="0.875rem" />
+                </a>
+                <button
+                  type="button"
+                  onClick={() => setLightbox(null)}
+                  aria-label="Close image"
+                  className="rounded-lg bg-black/60 p-2 text-white transition-colors hover:bg-black/80"
+                >
+                  <X size="0.875rem" />
+                </button>
+              </div>
             </div>
+            <ImagePromptPanel prompt={lightboxPrompt} meta={lightboxMeta} className="w-full max-w-3xl" />
           </div>
         </div>
       )}

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -42,6 +42,7 @@ import { buildTTSMessageText, resolveTTSVoiceForSpeaker } from "../../lib/tts-di
 import { DIALOGUE_QUOTE_PATTERN_SOURCE, HTML_SAFE_DIALOGUE_QUOTE_PATTERN_SOURCE } from "../../lib/dialogue-quotes";
 import DOMPurify from "dompurify";
 import type { CharacterMap, MessageSelectionToggle, PersonaInfo } from "./chat-area.types";
+import { ImagePromptPanel } from "./ImagePromptPanel";
 
 const MESSAGE_ACTION_ICON_SIZE = "1em";
 const MESSAGE_SWIPE_ICON_SIZE = "1.15em";
@@ -696,8 +697,17 @@ export const ChatMessage = memo(function ChatMessage({
   const [showThinking, setShowThinking] = useState(false);
   const [showActions, setShowActions] = useState(false);
   const [avatarLightbox, setAvatarLightbox] = useState<string | null>(null);
+  const [avatarLightboxPrompt, setAvatarLightboxPrompt] = useState<string | null>(null);
   const scrollRestoreRef = useRef<{ el: HTMLElement; top: number } | null>(null);
   const msgRef = useRef<HTMLDivElement>(null);
+  const openImageLightbox = useCallback((url: string, prompt?: unknown) => {
+    setAvatarLightbox(url);
+    setAvatarLightboxPrompt(typeof prompt === "string" ? prompt.trim() : null);
+  }, []);
+  const closeImageLightbox = useCallback(() => {
+    setAvatarLightbox(null);
+    setAvatarLightboxPrompt(null);
+  }, []);
 
   // Translation
   const { translate, translations, translating } = useTranslate();
@@ -1325,7 +1335,7 @@ export const ChatMessage = memo(function ChatMessage({
                   )}
                   onClick={() => {
                     const visible = mergedAvatars[cycleIndexRef.current];
-                    if (visible) setAvatarLightbox(visible.url);
+                    if (visible) openImageLightbox(visible.url);
                   }}
                   aria-label={`Open ${displayName} avatar`}
                 >
@@ -1349,7 +1359,7 @@ export const ChatMessage = memo(function ChatMessage({
                   <button
                     type="button"
                     className={cn("cursor-pointer overflow-hidden ring-2 ring-white/10", compactAvatarFrameClass)}
-                    onClick={() => setAvatarLightbox(avatarUrl)}
+                    onClick={() => openImageLightbox(avatarUrl)}
                     aria-label={`Open ${displayName} avatar`}
                   >
                     <img
@@ -1466,7 +1476,7 @@ export const ChatMessage = memo(function ChatMessage({
                           className="rpg-avatar-panel-media rpg-avatar-panel absolute inset-0 block h-full w-full cursor-zoom-in overflow-hidden"
                           onClick={() => {
                             const visible = mergedAvatars[cycleIndexRef.current];
-                            if (visible) setAvatarLightbox(visible.url);
+                            if (visible) openImageLightbox(visible.url);
                           }}
                           aria-label={`Open ${displayName} avatar`}
                         >
@@ -1492,7 +1502,7 @@ export const ChatMessage = memo(function ChatMessage({
                             "rpg-avatar-panel-media absolute inset-0 block h-full w-full cursor-zoom-in overflow-hidden",
                             !isUser && "rpg-avatar-panel",
                           )}
-                          onClick={() => setAvatarLightbox(avatarUrl)}
+                          onClick={() => openImageLightbox(avatarUrl)}
                           aria-label={`Open ${displayName} avatar`}
                         >
                           <img
@@ -1555,7 +1565,7 @@ export const ChatMessage = memo(function ChatMessage({
                     <div key={i} className="group/att relative inline-block">
                       <button
                         type="button"
-                        onClick={() => setAvatarLightbox(att.url || att.data)}
+                        onClick={() => openImageLightbox(att.url || att.data, att.prompt)}
                         className="block"
                         title="Open image"
                         aria-label={`Open ${att.filename || att.name || "image"}`}
@@ -1734,17 +1744,27 @@ export const ChatMessage = memo(function ChatMessage({
         {avatarLightbox && (
           <div
             className="fixed inset-0 z-[100] flex items-center justify-center bg-black/80"
-            onClick={() => setAvatarLightbox(null)}
+            onClick={closeImageLightbox}
           >
-            <img
-              src={avatarLightbox}
-              alt={displayName}
-              decoding="async"
-              className="max-h-[85vh] max-w-[90vw] rounded-lg object-contain shadow-2xl"
-            />
+            <div
+              className="flex max-h-[90vh] w-[min(90vw,64rem)] max-w-[90vw] flex-col items-center gap-2"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <img
+                src={avatarLightbox}
+                alt={displayName}
+                decoding="async"
+                className={
+                  avatarLightboxPrompt?.trim()
+                    ? "max-h-[calc(90vh-9rem)] max-w-full rounded-lg object-contain shadow-2xl"
+                    : "max-h-[85vh] max-w-full rounded-lg object-contain shadow-2xl"
+                }
+              />
+              <ImagePromptPanel prompt={avatarLightboxPrompt} className="w-full max-w-3xl" />
+            </div>
             <button
               type="button"
-              onClick={() => setAvatarLightbox(null)}
+              onClick={closeImageLightbox}
               aria-label="Close image"
               className="absolute right-3 top-3 rounded-lg bg-black/60 p-2 text-white transition-colors hover:bg-black/80"
             >
@@ -1789,7 +1809,7 @@ export const ChatMessage = memo(function ChatMessage({
                 className="relative h-8 w-8 cursor-pointer overflow-hidden rounded-full"
                 onClick={() => {
                   const visible = mergedAvatars[cycleIndexRef.current];
-                  if (visible) setAvatarLightbox(visible.url);
+                  if (visible) openImageLightbox(visible.url);
                 }}
                 aria-label={`Open ${displayName} avatar`}
               >
@@ -1812,7 +1832,7 @@ export const ChatMessage = memo(function ChatMessage({
               <button
                 type="button"
                 className="h-8 w-8 cursor-pointer overflow-hidden rounded-full"
-                onClick={() => setAvatarLightbox(avatarUrl)}
+                onClick={() => openImageLightbox(avatarUrl)}
                 aria-label={`Open ${displayName} avatar`}
               >
                 <img
@@ -1932,7 +1952,7 @@ export const ChatMessage = memo(function ChatMessage({
                   <div key={i} className="group/att relative inline-block">
                     <button
                       type="button"
-                      onClick={() => setAvatarLightbox(att.url || att.data)}
+                      onClick={() => openImageLightbox(att.url || att.data, att.prompt)}
                       className="block"
                       title="Open image"
                       aria-label={`Open ${att.filename || att.name || "image"}`}
@@ -2107,17 +2127,27 @@ export const ChatMessage = memo(function ChatMessage({
       {avatarLightbox && (
         <div
           className="fixed inset-0 z-[100] flex items-center justify-center bg-black/80"
-          onClick={() => setAvatarLightbox(null)}
+          onClick={closeImageLightbox}
         >
-          <img
-            src={avatarLightbox}
-            alt={displayName}
-            decoding="async"
-            className="max-h-[85vh] max-w-[90vw] rounded-lg object-contain shadow-2xl"
-          />
+          <div
+            className="flex max-h-[90vh] w-[min(90vw,64rem)] max-w-[90vw] flex-col items-center gap-2"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <img
+              src={avatarLightbox}
+              alt={displayName}
+              decoding="async"
+              className={
+                avatarLightboxPrompt?.trim()
+                  ? "max-h-[calc(90vh-9rem)] max-w-full rounded-lg object-contain shadow-2xl"
+                  : "max-h-[85vh] max-w-full rounded-lg object-contain shadow-2xl"
+              }
+            />
+            <ImagePromptPanel prompt={avatarLightboxPrompt} className="w-full max-w-3xl" />
+          </div>
           <button
             type="button"
-            onClick={() => setAvatarLightbox(null)}
+            onClick={closeImageLightbox}
             aria-label="Close image"
             className="absolute right-3 top-3 rounded-lg bg-black/60 p-2 text-white transition-colors hover:bg-black/80"
           >

--- a/packages/client/src/components/chat/ConversationMessage.tsx
+++ b/packages/client/src/components/chat/ConversationMessage.tsx
@@ -27,6 +27,7 @@ import { resolveMessageMacros } from "../../lib/chat-macros";
 import { useTranslate } from "../../hooks/use-translate";
 import { api } from "../../lib/api-client";
 import type { CharacterMap, MessageSelectionToggle, PersonaInfo } from "./chat-area.types";
+import { ImagePromptPanel } from "./ImagePromptPanel";
 
 /** Build style object for name color (supports gradients). */
 function nameColorStyle(color?: string): CSSProperties | undefined {
@@ -228,7 +229,7 @@ interface MessageData {
     } | null;
     isConversationStart?: boolean;
     thinking?: string | null;
-    attachments?: Array<{ type: string; url: string; filename?: string }>;
+    attachments?: Array<{ type: string; url: string; filename?: string; prompt?: string; galleryId?: string }>;
   };
   createdAt: string;
 }
@@ -288,7 +289,7 @@ export const ConversationMessage = memo(function ConversationMessage({
   const [showActions, setShowActions] = useState(false);
   const [copied, setCopied] = useState(false);
   const [showThinking, setShowThinking] = useState(false);
-  const [imageLightbox, setImageLightbox] = useState<string | null>(null);
+  const [imageLightbox, setImageLightbox] = useState<{ url: string; prompt?: string | null } | null>(null);
   const editRef = useRef<HTMLTextAreaElement>(null);
   const hasInput = useChatStore((s) => s.currentInput.trim().length > 0);
   const guideGenerations = useUIStore((s) => s.guideGenerations);
@@ -980,7 +981,11 @@ export const ConversationMessage = memo(function ConversationMessage({
               </div>
             ) : (
               <>
-                <MessageContent content={renderedContent} mentionNames={mentionNames} onImageOpen={setImageLightbox} />
+                <MessageContent
+                  content={renderedContent}
+                  mentionNames={mentionNames}
+                  onImageOpen={(url) => setImageLightbox({ url })}
+                />
                 {isStreaming && (
                   <span className="ml-0.5 inline-block h-4 w-[0.125rem] animate-pulse rounded-full bg-[var(--foreground)]/50" />
                 )}
@@ -1012,7 +1017,7 @@ export const ConversationMessage = memo(function ConversationMessage({
                     type="button"
                     onClick={(e) => {
                       e.stopPropagation();
-                      setImageLightbox(att.url || att.data);
+                      setImageLightbox({ url: att.url || att.data, prompt: att.prompt });
                     }}
                     className="block cursor-zoom-in rounded-lg text-left"
                     title="Open image"
@@ -1142,12 +1147,21 @@ export const ConversationMessage = memo(function ConversationMessage({
             className="fixed inset-0 z-[100] flex items-center justify-center bg-black/80 p-4 backdrop-blur-sm max-md:pt-[env(safe-area-inset-top)]"
             onClick={() => setImageLightbox(null)}
           >
-            <img
-              src={imageLightbox}
-              alt="Expanded image"
-              className="max-h-[90vh] max-w-[90vw] rounded-lg object-contain shadow-2xl"
+            <div
+              className="flex max-h-[90vh] w-[min(90vw,64rem)] max-w-[90vw] flex-col items-center gap-2"
               onClick={(e) => e.stopPropagation()}
-            />
+            >
+              <img
+                src={imageLightbox.url}
+                alt="Expanded image"
+                className={
+                  imageLightbox.prompt?.trim()
+                    ? "max-h-[calc(90vh-9rem)] max-w-full rounded-lg object-contain shadow-2xl"
+                    : "max-h-[90vh] max-w-full rounded-lg object-contain shadow-2xl"
+                }
+              />
+              <ImagePromptPanel prompt={imageLightbox.prompt} className="w-full max-w-3xl" />
+            </div>
             <button
               onClick={() => setImageLightbox(null)}
               className="absolute right-4 top-4 rounded-full bg-black/50 p-2 text-white/80 transition-colors hover:bg-black/70 hover:text-white"

--- a/packages/client/src/components/chat/ImagePromptPanel.tsx
+++ b/packages/client/src/components/chat/ImagePromptPanel.tsx
@@ -1,0 +1,37 @@
+import { cn } from "../../lib/utils";
+
+interface ImagePromptPanelProps {
+  prompt?: string | null;
+  meta?: string | null;
+  className?: string;
+}
+
+export function ImagePromptPanel({ prompt, meta, className }: ImagePromptPanelProps) {
+  const promptText = prompt?.trim() ?? "";
+  const metaText = meta?.trim() ?? "";
+
+  if (!promptText && !metaText) return null;
+
+  return (
+    <div
+      className={cn(
+        "rounded-lg border border-white/10 bg-neutral-950/95 px-3 py-2 text-left shadow-2xl",
+        className,
+      )}
+    >
+      {promptText && (
+        <>
+          <div className="mb-1 text-[0.6875rem] font-semibold text-white/55">Prompt</div>
+          <p className="max-h-32 overflow-y-auto whitespace-pre-wrap break-words text-[0.75rem] leading-relaxed text-white/85">
+            {promptText}
+          </p>
+        </>
+      )}
+      {metaText && (
+        <p className={cn("text-[0.6875rem] text-white/45", promptText && "mt-1.5 border-t border-white/10 pt-1.5")}>
+          {metaText}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -7337,6 +7337,8 @@ export async function generateRoutes(app: FastifyInstance) {
                         type: "image",
                         url: imageUrl,
                         filename: `illustration.${imageResult.ext}`,
+                        prompt: fullPrompt,
+                        galleryId: (galleryEntry as any)?.id,
                       };
 
                       // Always persist to the swipe row so the attachment survives
@@ -7742,6 +7744,8 @@ export async function generateRoutes(app: FastifyInstance) {
                           type: "image",
                           url: imageUrl,
                           filename: `selfie_${charName.toLowerCase().replace(/\s+/g, "_")}.${imageResult.ext}`,
+                          prompt: imagePrompt,
+                          galleryId: (galleryEntry as any)?.id,
                         };
                         await chats.appendSwipeAttachment(messageId, generationSwipeIndex, attachment);
 

--- a/packages/server/src/routes/generate/generate-route-utils.ts
+++ b/packages/server/src/routes/generate/generate-route-utils.ts
@@ -10,9 +10,12 @@ export type SimpleMessage = { role: "system" | "user" | "assistant"; content: st
 export type StoredGenerationParameters = Partial<GenerationParameters>;
 export type PromptAttachment = {
   type?: string | null;
+  url?: string | null;
   data?: string | null;
   filename?: string | null;
   name?: string | null;
+  prompt?: string | null;
+  galleryId?: string | null;
 };
 
 const TEXT_ATTACHMENT_CHAR_LIMIT = 60_000;

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -1100,7 +1100,13 @@ async function applyRetryResultEffects(args: {
               // Attach to message
               if (retryMessageId) {
                 const chatsDb = createChatsStorage(app.db);
-                const attachment = { type: "image", url: imageUrl, filename: `illustration.${imageResult.ext}` };
+                const attachment = {
+                  type: "image",
+                  url: imageUrl,
+                  filename: `illustration.${imageResult.ext}`,
+                  prompt: fullPrompt,
+                  galleryId: (galleryEntry as any)?.id,
+                };
                 const swipeRow = (await chatsDb.getSwipes(retryMessageId)).find(
                   (s: any) => s.index === retrySwipeIndex,
                 );


### PR DESCRIPTION
Add prompt and metadata display to image lightboxes across ChatGallery, ChatMessage, and ConversationMessage. Persist prompt and galleryId on image attachments from server routes so the prompt is available at view time.

## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #475 

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- Generated images already store their prompts in the gallery, but opening an image from a chat message/lightbox did not show the prompt that produced it. This makes it harder to inspect, reuse, or debug image generations after the fact.

## What changed

<!-- List the key changes in this PR -->

- Store generated illustration/selfie prompt metadata on chat image attachments.
- Include gallery IDs on generated image attachments so the attachment can stay linked to its gallery entry.
- Add a reusable `ImagePromptPanel` component for lightbox prompt display.
- Show prompt metadata in gallery, roleplay message, and conversation message image lightboxes.
- Preserve existing behavior for images that do not have prompt metadata.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [X] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [X] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [X] Above manual verification completed (describe below)
- [X] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- nah, it'll be fine

## Docs and release impact

- [X] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

<img width="1264" height="805" alt="marinara-issue-475-gallery-prompt" src="https://github.com/user-attachments/assets/ad3f0afc-4fb3-486d-8b16-36f71f828e0c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Enhanced image lightbox with fullscreen modal overlay and new controls (pin, download, close)
* Added image metadata and generation prompt display alongside expanded images
* Improved context visibility when viewing generated images with associated prompt information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->