### PR TITLE
fix(game-map): preserve explicit move past metadata hydration

### DIFF
--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -2502,6 +2502,7 @@ export async function gameRoutes(app: FastifyInstance) {
   const buildHydratedGameMeta = async (
     chatId: string,
     baseMeta: Record<string, unknown>,
+    options: { explicitLocation?: string | null } = {},
   ): Promise<Record<string, unknown>> => {
     const gameStateStore = createGameStateStorage(app.db);
     const latestState = await gameStateStore.getLatest(chatId);
@@ -2513,7 +2514,12 @@ export async function gameRoutes(app: FastifyInstance) {
     }
 
     const activeQuests = extractActiveQuests(latestState?.playerStats);
-    const currentLocation = typeof latestState?.location === "string" ? latestState.location : null;
+    // Prefer a caller-supplied explicit location over the most recent snapshot. The snapshot's
+    // location field only refreshes after /generate persists a new game state, so callers that
+    // have just committed a deliberate move (e.g. /map/move) need to override it — otherwise the
+    // sync and journal reconciliation below run against the previous location.
+    const snapshotLocation = typeof latestState?.location === "string" ? latestState.location : null;
+    const currentLocation = options.explicitLocation ?? snapshotLocation;
     hydratedMeta = syncGameMapMetaPartyPosition(hydratedMeta, currentLocation);
     const currentJournal = (hydratedMeta.gameJournal as Journal) ?? createJournal();
     return {
@@ -4892,12 +4898,19 @@ export async function gameRoutes(app: FastifyInstance) {
       }
     }
 
+    // Resolve the destination's label so hydration's location-derived reconciliation
+    // (syncGameMapMetaPartyPosition + reconcileJournal) runs against the explicit move
+    // instead of the stale snapshot location.
+    const explicitLocation =
+      typeof position === "string"
+        ? (updatedMap.nodes?.find((node) => node.id === position)?.label ?? position)
+        : (updatedMap.cells?.find((cell) => cell.x === position.x && cell.y === position.y)?.label ?? null);
+
     const nextMeta = markNpcsMetAtCurrentLocation(withActiveGameMapMeta(meta, updatedMap));
-    const hydratedMeta = await buildHydratedGameMeta(chatId, nextMeta);
-    // `buildHydratedGameMeta` runs `syncGameMapMetaPartyPosition` against the most recent game state
-    // snapshot — which still records the OLD location until the next /generate run produces a new
-    // snapshot. That sync stomps the explicit move we just persisted, leaving the marker stuck at
-    // the previous node. Re-apply the user's chosen position on top so the explicit move wins.
+    const hydratedMeta = await buildHydratedGameMeta(chatId, nextMeta, { explicitLocation });
+    // syncGameMapMetaPartyPosition matches by label, so an unusual label collision could
+    // still land on a different node. Re-apply the exact chosen position to defend against
+    // that and keep the response identical to what the client clicked.
     const hydratedActiveMap = (hydratedMeta.gameMap as GameMap | null) ?? updatedMap;
     const finalMap: GameMap = { ...hydratedActiveMap, partyPosition: position };
     const finalMeta = withActiveGameMapMeta(hydratedMeta, finalMap);

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -4894,12 +4894,19 @@ export async function gameRoutes(app: FastifyInstance) {
 
     const nextMeta = markNpcsMetAtCurrentLocation(withActiveGameMapMeta(meta, updatedMap));
     const hydratedMeta = await buildHydratedGameMeta(chatId, nextMeta);
-    await chats.updateMetadata(chatId, hydratedMeta);
+    // `buildHydratedGameMeta` runs `syncGameMapMetaPartyPosition` against the most recent game state
+    // snapshot — which still records the OLD location until the next /generate run produces a new
+    // snapshot. That sync stomps the explicit move we just persisted, leaving the marker stuck at
+    // the previous node. Re-apply the user's chosen position on top so the explicit move wins.
+    const hydratedActiveMap = (hydratedMeta.gameMap as GameMap | null) ?? updatedMap;
+    const finalMap: GameMap = { ...hydratedActiveMap, partyPosition: position };
+    const finalMeta = withActiveGameMapMeta(hydratedMeta, finalMap);
+    await chats.updateMetadata(chatId, finalMeta);
 
     return {
-      map: (hydratedMeta.gameMap as GameMap) ?? updatedMap,
-      maps: getGameMapsFromMeta(hydratedMeta),
-      activeGameMapId: (hydratedMeta.activeGameMapId as string | null) ?? getGameMapId(hydratedMeta.gameMap as GameMap),
+      map: (finalMeta.gameMap as GameMap) ?? finalMap,
+      maps: getGameMapsFromMeta(finalMeta),
+      activeGameMapId: (finalMeta.activeGameMapId as string | null) ?? getGameMapId(finalMeta.gameMap as GameMap),
     };
   });
 

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -4908,11 +4908,15 @@ export async function gameRoutes(app: FastifyInstance) {
 
     const nextMeta = markNpcsMetAtCurrentLocation(withActiveGameMapMeta(meta, updatedMap));
     const hydratedMeta = await buildHydratedGameMeta(chatId, nextMeta, { explicitLocation });
-    // syncGameMapMetaPartyPosition matches by label, so an unusual label collision could
-    // still land on a different node. Re-apply the exact chosen position to defend against
-    // that and keep the response identical to what the client clicked.
-    const hydratedActiveMap = (hydratedMeta.gameMap as GameMap | null) ?? updatedMap;
-    const finalMap: GameMap = { ...hydratedActiveMap, partyPosition: position };
+    // syncGameMapMetaPartyPosition matches by label across all maps, so a label collision
+    // could leave hydratedMeta.gameMap pointing at a different map than the one the client
+    // clicked within. Anchor finalMap to the hydrated copy of the target map (falling back
+    // to updatedMap) and re-apply the exact chosen position so the response stays consistent
+    // with the user's click.
+    const hydratedMaps = getGameMapsFromMeta(hydratedMeta);
+    const hydratedTargetMap =
+      hydratedMaps.find((entry, index) => getGameMapId(entry, index) === targetMapId) ?? updatedMap;
+    const finalMap: GameMap = { ...hydratedTargetMap, partyPosition: position };
     const finalMeta = withActiveGameMapMeta(hydratedMeta, finalMap);
     await chats.updateMetadata(chatId, finalMeta);
 


### PR DESCRIPTION
## Linked issue

Closes #484

## Why this change

- After a player clicked **Set destination** on the Game Mode map, the marker stayed stuck at the previous node. The GM still narrated the move (because the user message contains `*moves to <label>*`), but `chat.metadata.gameMap.partyPosition` never advanced — so subsequent prompts kept building from the stale location and the map widget never updated.

## What changed

- In `packages/server/src/routes/game.routes.ts`, the `/map/move` handler now re-applies the user's chosen `partyPosition` on top of the hydrated meta after `buildHydratedGameMeta`. That helper calls `syncGameMapMetaPartyPosition(meta, currentLocation)` where `currentLocation` is read from the latest `gameStateSnapshot.location`. Until the next `/generate` run persists a new snapshot, that location still records the previous node, so the sync was silently snapping `partyPosition` back to the old node before persistence.
- A `withActiveGameMapMeta` call rebuilds `gameMaps[]` and `activeGameMapId` consistently with the corrected map.

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Built and deployed the patched server image to a self-hosted Docker (EasyPanel) instance running Marinara Engine 1.5.8.
- Opened an in-progress Game Mode chat with a node-style map and an active scene.
- Clicked an adjacent node, confirmed **Set destination**, and sent a turn.
- Before the fix: map marker remained on the previous node; on the next round the GM still framed the player as being at the old location even though it had narrated the move.
- After the fix: the map marker jumps to the chosen node immediately on send, and the next GM round narrates from the new location. The destination indicator clears as before. No client-side errors in DevTools.

## Docs and release impact

- [x] No docs changes needed

## UI evidence (if applicable)

No UI code changed. Behaviour change is observed in the existing map widget — the marker now follows the user's destination click. Happy to attach a short screen recording if reviewers want one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Player moves now reliably take precedence over background updates so chosen positions are not reverted.
  * Deliberate location overrides are immediately reflected in saved game state and activity logs.
  * After a move, the displayed map is anchored to the persisted map so the final view matches the stored game state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->