### PR TITLE
Fix Lorebook Keeper duplicate paragraph persistence

### DIFF
--- a/packages/server/src/routes/generate/lorebook-keeper-utils.ts
+++ b/packages/server/src/routes/generate/lorebook-keeper-utils.ts
@@ -228,7 +228,7 @@ function normalizeKeeperFacts(value: unknown): string[] {
 
 function dedupeKeeperContentParagraphs(content: string): string {
   const paragraphs = content
-    .split(/\n{2,}/)
+    .split(/\r?\n\s*\r?\n+/)
     .map((paragraph) => paragraph.trim())
     .filter(Boolean);
   const seen = new Set<string>();
@@ -284,7 +284,7 @@ export function mergeLorebookKeeperUpdateContent(args: {
     if (replacementComparable.includes(existingComparable)) return replacement;
     if (existingComparable.includes(replacementComparable)) return existing;
 
-    return `${existing}\n\n${replacement}`;
+    return dedupeKeeperContentParagraphs(`${existing}\n\n${replacement}`);
   }
 
   const baseContent = existing || replacement;

--- a/packages/server/src/routes/generate/lorebook-keeper-utils.ts
+++ b/packages/server/src/routes/generate/lorebook-keeper-utils.ts
@@ -226,6 +226,24 @@ function normalizeKeeperFacts(value: unknown): string[] {
   return facts;
 }
 
+function dedupeKeeperContentParagraphs(content: string): string {
+  const paragraphs = content
+    .split(/\n{2,}/)
+    .map((paragraph) => paragraph.trim())
+    .filter(Boolean);
+  const seen = new Set<string>();
+  const deduped: string[] = [];
+
+  for (const paragraph of paragraphs) {
+    const comparable = normalizeKeeperFactForComparison(paragraph);
+    if (!comparable || seen.has(comparable)) continue;
+    seen.add(comparable);
+    deduped.push(paragraph);
+  }
+
+  return deduped.join("\n\n");
+}
+
 function mergeLorebookKeys(existingKeys: unknown, newKeys: string[]): string[] {
   const merged: string[] = [];
   const seen = new Set<string>();
@@ -251,8 +269,10 @@ export function mergeLorebookKeeperUpdateContent(args: {
   replacementContent: unknown;
   newFacts: unknown;
 }): string {
-  const existing = typeof args.existingContent === "string" ? args.existingContent.trim() : "";
-  const replacement = typeof args.replacementContent === "string" ? args.replacementContent.trim() : "";
+  const existing =
+    typeof args.existingContent === "string" ? dedupeKeeperContentParagraphs(args.existingContent) : "";
+  const replacement =
+    typeof args.replacementContent === "string" ? dedupeKeeperContentParagraphs(args.replacementContent) : "";
   const facts = normalizeKeeperFacts(args.newFacts);
 
   if (facts.length === 0) {

--- a/packages/server/src/routes/generate/lorebook-keeper-utils.ts
+++ b/packages/server/src/routes/generate/lorebook-keeper-utils.ts
@@ -287,7 +287,8 @@ export function mergeLorebookKeeperUpdateContent(args: {
     return dedupeKeeperContentParagraphs(`${existing}\n\n${replacement}`);
   }
 
-  const baseContent = existing || replacement;
+  const baseContent =
+    existing && replacement ? dedupeKeeperContentParagraphs(`${existing}\n\n${replacement}`) : existing || replacement;
   const existingComparable = normalizeKeeperFactForComparison(baseContent);
   const novelFacts = facts.filter((fact) => {
     const comparable = normalizeKeeperFactForComparison(fact);


### PR DESCRIPTION
## What?
Fixes Lorebook Keeper update persistence so repeated duplicate paragraphs are collapsed before content is saved.

This hardens the existing Lorebook Keeper merge path against model outputs that repeat the same replacement paragraph multiple times.

Fixes #459

## Why?
Issue #459 reports Lorebook Keeper accumulating 3-6 copies of the same paragraph for a character instead of replacing or adding only new information.

Even with the newer `newFacts` prompt path, the server should defensively dedupe repeated replacement content because LLM output can ignore formatting instructions.

## How?
Added paragraph-level deduplication inside `mergeLorebookKeeperUpdateContent`.

The helper normalizes paragraph text for comparison, keeps the first copy, and still preserves novel replacement paragraphs and novel `newFacts`.

## Testing?
- `pnpm --dir packages/server exec tsx ../../scratch/issue-459-lorebook-keeper-repro.ts`
  - Before the fix: failed with 3 occurrences of the same paragraph.
  - After the fix: passed.
  - Edge cases covered: duplicate replacement paragraphs collapse, novel replacement content is preserved, duplicate `newFacts` collapse.
- `pnpm check` passed.

## Screenshots / Visual Proof
![Issue #459 visual proof](https://gist.githubusercontent.com/cha1latte/bdffc47430091cbccda9266a85d5e74d/raw/issue-459-visual-proof.svg)

Visual proof shows the before repro failing with 3 duplicate paragraph occurrences, and the after repro passing with the duplicate collapsed to 1 copy.

## Anything Else?
Opened as draft for maintainer review. No manual hardware, provider, or UI verification is required for the core claim.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved merging of lorebook keeper updates: paragraph content is now normalized, trimmed, deduplicated, and rejoined with proper spacing to prevent duplicate paragraphs and produce cleaner, consolidated lorebook entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->