### PR TITLE
Fix local LM studio connection json error

### DIFF
--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -147,6 +147,29 @@ function getConfiguredGameAssetImageSizes(): NonNullable<GameAssetGenerationPayl
   };
 }
 
+const GAME_ASSET_GENERATION_TIMEOUT_MS = 240_000;
+const GAME_ASSET_PREVIEW_TIMEOUT_MS = 180_000;
+const GAME_ASSET_PROMPT_REVIEW_TIMEOUT_MS = 180_000;
+
+function withTimeout<T>(promise: Promise<T>, ms: number, onTimeout?: () => void): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timeoutId = window.setTimeout(() => {
+      onTimeout?.();
+      reject(new Error(`Operation timed out after ${ms / 1000} seconds`));
+    }, ms);
+
+    promise
+      .then((value) => {
+        window.clearTimeout(timeoutId);
+        resolve(value);
+      })
+      .catch((error) => {
+        window.clearTimeout(timeoutId);
+        reject(error);
+      });
+  });
+}
+
 type GameTimeMeta = {
   day?: number;
   hour?: number;
@@ -3177,19 +3200,35 @@ export function GameSurface({
       };
 
       if (useUIStore.getState().reviewImagePromptsBeforeSend) {
-        const preview = await api.post<{ items: GameImagePromptReviewItem[] }>(
-          "/game/generate-assets/preview",
-          payload,
+        const preview = await withTimeout(
+          api.post<{ items: GameImagePromptReviewItem[] }>("/game/generate-assets/preview", payload),
+          GAME_ASSET_PREVIEW_TIMEOUT_MS,
+          () => {
+            toast.error("Image prompt preview timed out. Continuing with the default prompts.");
+          },
         );
         if (preview.items.length > 0) {
-          const overrides = await openImagePromptReview(preview.items);
+          const overrides = await withTimeout(
+            openImagePromptReview(preview.items),
+            GAME_ASSET_PROMPT_REVIEW_TIMEOUT_MS,
+            () => {
+              closeImagePromptReview(null);
+              toast.error("Image prompt review timed out. Continuing with the default prompts.");
+            },
+          );
           if (!overrides) return null;
           setImagePromptReviewSubmitting(true);
           payload.promptOverrides = overrides;
         }
       }
 
-      return api.post<GameAssetGenerationResult>("/game/generate-assets", payload);
+      return await withTimeout(
+        api.post<GameAssetGenerationResult>("/game/generate-assets", payload),
+        GAME_ASSET_GENERATION_TIMEOUT_MS,
+        () => {
+          toast.error("Image generation timed out. The scene will continue without generated assets.");
+        },
+      );
     },
     [openImagePromptReview],
   );

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -2512,7 +2512,9 @@ export function GameSurface({
   // Track which message has had its scene effects prepared so narration
   // isn't displayed until backgrounds/music/etc. are ready.
   const sceneReadyMsgIdRef = useRef<string | undefined>(undefined);
-  const applySceneResultRef = useRef<((result: import("@marinara-engine/shared").SceneAnalysis) => void) | null>(null);
+  const applySceneResultRef = useRef<((result: import("@marinara-engine/shared").SceneAnalysis) => void | Promise<void>) | null>(
+    null,
+  );
   const [sceneReadyTick, setSceneReadyTick] = useState(0);
   void sceneReadyTick; // used only to trigger re-renders
 
@@ -3168,23 +3170,22 @@ export function GameSurface({
   }
 
   const installGeneratedIllustration = useCallback(
-    (illustration: { tag: string; segment?: number }) => {
+    async (illustration: { tag: string; segment?: number }) => {
       void queryClient.invalidateQueries({ queryKey: ["gallery", activeChatId] });
-      fetchManifest().then(() => {
-        if (illustration.segment !== undefined && illustration.segment > 0) {
-          setPendingSegmentEffects((previous) => {
-            const existingIndex = previous.findIndex((effect) => effect.segment === illustration.segment);
-            if (existingIndex >= 0) {
-              return previous.map((effect, index) =>
-                index === existingIndex ? { ...effect, background: illustration.tag } : effect,
-              );
-            }
-            return [...previous, { segment: illustration.segment!, background: illustration.tag }];
-          });
-          return;
-        }
-        useGameAssetStore.getState().setCurrentBackground(illustration.tag);
-      });
+      await fetchManifest();
+      if (illustration.segment !== undefined && illustration.segment > 0) {
+        setPendingSegmentEffects((previous) => {
+          const existingIndex = previous.findIndex((effect) => effect.segment === illustration.segment);
+          if (existingIndex >= 0) {
+            return previous.map((effect, index) =>
+              index === existingIndex ? { ...effect, background: illustration.tag } : effect,
+            );
+          }
+          return [...previous, { segment: illustration.segment!, background: illustration.tag }];
+        });
+        return;
+      }
+      useGameAssetStore.getState().setCurrentBackground(illustration.tag);
     },
     [activeChatId, fetchManifest, queryClient],
   );
@@ -3276,7 +3277,7 @@ export function GameSurface({
         useGameAssetStore.getState().setCurrentBackground(res.generatedBackground!);
       }
       if (res.generatedIllustration) {
-        installGeneratedIllustration(res.generatedIllustration);
+        await installGeneratedIllustration(res.generatedIllustration);
       }
       if (res.generatedNpcAvatars?.length) {
         useGameModeStore.getState().patchNpcAvatars(res.generatedNpcAvatars);
@@ -3285,13 +3286,9 @@ export function GameSurface({
     [fetchManifest, installGeneratedIllustration],
   );
 
-  function applySceneResult(result: import("@marinara-engine/shared").SceneAnalysis, msg: { id: string }) {
+  async function applySceneResult(result: import("@marinara-engine/shared").SceneAnalysis, msg: { id: string }) {
     console.log("[scene-analysis] Result from model:", JSON.stringify(result, null, 2));
     setSceneAnalysisFailed(false);
-    if (sceneReadyMsgIdRef.current !== msg.id) {
-      sceneReadyMsgIdRef.current = msg.id;
-      setSceneReadyTick((t) => t + 1);
-    }
     // NOTE: Game state transitions are owned exclusively by the GM model via [state: ...] tags.
     // The scene model no longer emits stateChange to avoid conflicting state flips.
 
@@ -3400,10 +3397,10 @@ export function GameSurface({
       result.segmentEffects?.some((fx) => fx.background?.startsWith("backgrounds:generated:")) ||
       result.background?.startsWith("backgrounds:generated:");
     if (hasGeneratedBg) {
-      fetchManifest();
+      await fetchManifest();
     }
     if (result.generatedIllustration) {
-      installGeneratedIllustration(result.generatedIllustration);
+      await installGeneratedIllustration(result.generatedIllustration);
     }
     if (result.generatedNpcAvatars?.length) {
       useGameModeStore.getState().patchNpcAvatars(result.generatedNpcAvatars);
@@ -3497,7 +3494,7 @@ export function GameSurface({
 
         setPendingAssetGeneration(null);
         if (!res) return null;
-        applyGeneratedAssets(res);
+        await applyGeneratedAssets(res);
         if (
           options?.showSuccessToast &&
           (res.generatedBackground || res.generatedIllustration || res.generatedNpcAvatars?.length)

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -3018,6 +3018,10 @@ export function GameSurface({
             onComplete();
             setSceneAnalysisFailed(true);
             applyInlineTags(tags, assets, msg);
+            if (sceneReadyMsgIdRef.current !== msg.id) {
+              sceneReadyMsgIdRef.current = msg.id;
+              setSceneReadyTick((t) => t + 1);
+            }
           },
         },
       );
@@ -3039,6 +3043,10 @@ export function GameSurface({
             console.warn("[scene-wrapup] scene-wrap failed:", err);
             setSceneAnalysisFailed(true);
             applyInlineTags(tags, assets, msg);
+            if (sceneReadyMsgIdRef.current !== msg.id) {
+              sceneReadyMsgIdRef.current = msg.id;
+              setSceneReadyTick((t) => t + 1);
+            }
           },
         },
       );
@@ -3056,6 +3064,10 @@ export function GameSurface({
         console.warn("[scene-wrapup] Scene analysis timed out after 120s, falling back to inline tags");
         setSceneAnalysisFailed(true);
         applyInlineTags(tags, assets, msg);
+        if (sceneReadyMsgIdRef.current !== msg.id) {
+          sceneReadyMsgIdRef.current = msg.id;
+          setSceneReadyTick((t) => t + 1);
+        }
       }
     }, 120_000);
   };
@@ -3202,6 +3214,10 @@ export function GameSurface({
   function applySceneResult(result: import("@marinara-engine/shared").SceneAnalysis, msg: { id: string }) {
     console.log("[scene-analysis] Result from model:", JSON.stringify(result, null, 2));
     setSceneAnalysisFailed(false);
+    if (sceneReadyMsgIdRef.current !== msg.id) {
+      sceneReadyMsgIdRef.current = msg.id;
+      setSceneReadyTick((t) => t + 1);
+    }
     // NOTE: Game state transitions are owned exclusively by the GM model via [state: ...] tags.
     // The scene model no longer emits stateChange to avoid conflicting state flips.
 
@@ -3348,15 +3364,14 @@ export function GameSurface({
         setAssetGenerationFailed(false);
         runGameAssetGeneration(assetPayload)
           .then((res) => {
-            setPendingAssetGeneration(null);
             if (res) applyGeneratedAssets(res);
-            // Ungate narration after assets are ready
-            sceneReadyMsgIdRef.current = msg.id;
-            setSceneReadyTick((t) => t + 1);
           })
           .catch(() => {
             setAssetGenerationFailed(true);
-            // Still ungate on failure so the user can interact
+          })
+          .finally(() => {
+            setPendingAssetGeneration(null);
+            // Ungate narration after assets are ready or failed
             sceneReadyMsgIdRef.current = msg.id;
             setSceneReadyTick((t) => t + 1);
           });

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -152,8 +152,10 @@ const GAME_ASSET_PREVIEW_TIMEOUT_MS = 180_000;
 const GAME_ASSET_PROMPT_REVIEW_TIMEOUT_MS = 180_000;
 
 function withTimeout<T>(promise: Promise<T>, ms: number, onTimeout?: () => void): Promise<T> {
+  const controller = new AbortController();
   return new Promise<T>((resolve, reject) => {
     const timeoutId = window.setTimeout(() => {
+      controller.abort();
       onTimeout?.();
       reject(new Error(`Operation timed out after ${ms / 1000} seconds`));
     }, ms);
@@ -3200,25 +3202,41 @@ export function GameSurface({
       };
 
       if (useUIStore.getState().reviewImagePromptsBeforeSend) {
-        const preview = await withTimeout(
-          api.post<{ items: GameImagePromptReviewItem[] }>("/game/generate-assets/preview", payload),
-          GAME_ASSET_PREVIEW_TIMEOUT_MS,
-          () => {
-            toast.error("Image prompt preview timed out. Continuing with the default prompts.");
-          },
-        );
-        if (preview.items.length > 0) {
-          const overrides = await withTimeout(
-            openImagePromptReview(preview.items),
-            GAME_ASSET_PROMPT_REVIEW_TIMEOUT_MS,
+        let preview: { items: GameImagePromptReviewItem[] } | undefined;
+        try {
+          preview = await withTimeout(
+            api.post<{ items: GameImagePromptReviewItem[] }>("/game/generate-assets/preview", payload),
+            GAME_ASSET_PREVIEW_TIMEOUT_MS,
             () => {
-              closeImagePromptReview(null);
-              toast.error("Image prompt review timed out. Continuing with the default prompts.");
+              toast.error("Image prompt preview timed out. Continuing with the default prompts.");
             },
           );
-          if (!overrides) return null;
-          setImagePromptReviewSubmitting(true);
-          payload.promptOverrides = overrides;
+        } catch {
+          // Timeout — treat as empty preview (proceed with default prompts)
+          preview = { items: [] };
+        }
+
+        if (preview.items.length > 0) {
+          let overrides: GameImagePromptOverride[] | null | undefined;
+          try {
+            overrides = await withTimeout(
+              openImagePromptReview(preview.items),
+              GAME_ASSET_PROMPT_REVIEW_TIMEOUT_MS,
+              () => {
+                closeImagePromptReview(null);
+                toast.error("Image prompt review timed out. Continuing with the default prompts.");
+              },
+            );
+          } catch {
+            // Timeout — treat as null (proceed with default prompts)
+            overrides = null;
+          }
+
+          if (overrides === undefined) return null; // User explicitly cancelled
+          if (overrides) {
+            setImagePromptReviewSubmitting(true);
+            payload.promptOverrides = overrides;
+          }
         }
       }
 
@@ -3234,11 +3252,10 @@ export function GameSurface({
   );
 
   const applyGeneratedAssets = useCallback(
-    (res: GameAssetGenerationResult) => {
+    async (res: GameAssetGenerationResult) => {
       if (res.generatedBackground) {
-        fetchManifest().then(() => {
-          useGameAssetStore.getState().setCurrentBackground(res.generatedBackground!);
-        });
+        await fetchManifest();
+        useGameAssetStore.getState().setCurrentBackground(res.generatedBackground!);
       }
       if (res.generatedIllustration) {
         installGeneratedIllustration(res.generatedIllustration);
@@ -3402,15 +3419,20 @@ export function GameSurface({
         setPendingAssetGeneration(assetPayload);
         setAssetGenerationFailed(false);
         runGameAssetGeneration(assetPayload)
-          .then((res) => {
-            if (res) applyGeneratedAssets(res);
+          .then(async (res) => {
+            if (res) {
+              await applyGeneratedAssets(res);
+              setPendingAssetGeneration(null);
+            } else {
+              setPendingAssetGeneration(null);
+            }
+            // Ungate narration after assets are installed
+            sceneReadyMsgIdRef.current = msg.id;
+            setSceneReadyTick((t) => t + 1);
           })
           .catch(() => {
             setAssetGenerationFailed(true);
-          })
-          .finally(() => {
-            setPendingAssetGeneration(null);
-            // Ungate narration after assets are ready or failed
+            // Keep pendingAssetGeneration so retry UI/button remain visible
             sceneReadyMsgIdRef.current = msg.id;
             setSceneReadyTick((t) => t + 1);
           });

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -150,6 +150,7 @@ function getConfiguredGameAssetImageSizes(): NonNullable<GameAssetGenerationPayl
 const GAME_ASSET_GENERATION_TIMEOUT_MS = 240_000;
 const GAME_ASSET_PREVIEW_TIMEOUT_MS = 180_000;
 const GAME_ASSET_PROMPT_REVIEW_TIMEOUT_MS = 180_000;
+const IMAGE_PROMPT_REVIEW_TIMED_OUT = Symbol("IMAGE_PROMPT_REVIEW_TIMED_OUT");
 
 class TimeoutError extends Error {
   constructor(ms: number) {
@@ -3231,7 +3232,7 @@ export function GameSurface({
         }
 
         if (preview.items.length > 0) {
-          let overrides: GameImagePromptOverride[] | null | undefined;
+          let overrides: GameImagePromptOverride[] | null | typeof IMAGE_PROMPT_REVIEW_TIMED_OUT | undefined;
           try {
             overrides = await withTimeout(
               () => openImagePromptReview(preview.items),
@@ -3243,14 +3244,14 @@ export function GameSurface({
             );
           } catch (error) {
             if (isTimeoutError(error)) {
-              overrides = null;
+              overrides = IMAGE_PROMPT_REVIEW_TIMED_OUT;
             } else {
               throw error;
             }
           }
 
-          if (overrides === undefined) return null; // User explicitly cancelled
-          if (overrides) {
+          if (overrides === null || overrides === undefined) return null;
+          if (overrides !== IMAGE_PROMPT_REVIEW_TIMED_OUT) {
             setImagePromptReviewSubmitting(true);
             payload.promptOverrides = overrides;
           }

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -151,16 +151,27 @@ const GAME_ASSET_GENERATION_TIMEOUT_MS = 240_000;
 const GAME_ASSET_PREVIEW_TIMEOUT_MS = 180_000;
 const GAME_ASSET_PROMPT_REVIEW_TIMEOUT_MS = 180_000;
 
-function withTimeout<T>(promise: Promise<T>, ms: number, onTimeout?: () => void): Promise<T> {
+class TimeoutError extends Error {
+  constructor(ms: number) {
+    super(`Operation timed out after ${ms / 1000} seconds`);
+    this.name = "TimeoutError";
+  }
+}
+
+function isTimeoutError(error: unknown): error is TimeoutError {
+  return error instanceof TimeoutError;
+}
+
+function withTimeout<T>(run: (signal: AbortSignal) => Promise<T>, ms: number, onTimeout?: () => void): Promise<T> {
   const controller = new AbortController();
   return new Promise<T>((resolve, reject) => {
     const timeoutId = window.setTimeout(() => {
       controller.abort();
       onTimeout?.();
-      reject(new Error(`Operation timed out after ${ms / 1000} seconds`));
+      reject(new TimeoutError(ms));
     }, ms);
 
-    promise
+    run(controller.signal)
       .then((value) => {
         window.clearTimeout(timeoutId);
         resolve(value);
@@ -3205,31 +3216,37 @@ export function GameSurface({
         let preview: { items: GameImagePromptReviewItem[] } | undefined;
         try {
           preview = await withTimeout(
-            api.post<{ items: GameImagePromptReviewItem[] }>("/game/generate-assets/preview", payload),
+            (signal) => api.post<{ items: GameImagePromptReviewItem[] }>("/game/generate-assets/preview", payload, { signal }),
             GAME_ASSET_PREVIEW_TIMEOUT_MS,
             () => {
               toast.error("Image prompt preview timed out. Continuing with the default prompts.");
             },
           );
-        } catch {
-          // Timeout — treat as empty preview (proceed with default prompts)
-          preview = { items: [] };
+        } catch (error) {
+          if (isTimeoutError(error)) {
+            preview = { items: [] };
+          } else {
+            throw error;
+          }
         }
 
         if (preview.items.length > 0) {
           let overrides: GameImagePromptOverride[] | null | undefined;
           try {
             overrides = await withTimeout(
-              openImagePromptReview(preview.items),
+              () => openImagePromptReview(preview.items),
               GAME_ASSET_PROMPT_REVIEW_TIMEOUT_MS,
               () => {
                 closeImagePromptReview(null);
                 toast.error("Image prompt review timed out. Continuing with the default prompts.");
               },
             );
-          } catch {
-            // Timeout — treat as null (proceed with default prompts)
-            overrides = null;
+          } catch (error) {
+            if (isTimeoutError(error)) {
+              overrides = null;
+            } else {
+              throw error;
+            }
           }
 
           if (overrides === undefined) return null; // User explicitly cancelled
@@ -3241,14 +3258,14 @@ export function GameSurface({
       }
 
       return await withTimeout(
-        api.post<GameAssetGenerationResult>("/game/generate-assets", payload),
+        (signal) => api.post<GameAssetGenerationResult>("/game/generate-assets", payload, { signal }),
         GAME_ASSET_GENERATION_TIMEOUT_MS,
         () => {
           toast.error("Image generation timed out. The scene will continue without generated assets.");
         },
       );
     },
-    [openImagePromptReview],
+    [closeImagePromptReview, openImagePromptReview],
   );
 
   const applyGeneratedAssets = useCallback(

--- a/packages/client/src/lib/api-client.ts
+++ b/packages/client/src/lib/api-client.ts
@@ -111,8 +111,9 @@ export const api = {
 
   get: <T>(path: string, init?: RequestInit) => request<T>(path, init),
 
-  post: <T>(path: string, body?: unknown) =>
+  post: <T>(path: string, body?: unknown, init?: RequestInit) =>
     request<T>(path, {
+      ...init,
       method: "POST",
       body: body !== undefined ? JSON.stringify(body) : undefined,
     }),

--- a/packages/server/src/services/llm/providers/openai.provider.ts
+++ b/packages/server/src/services/llm/providers/openai.provider.ts
@@ -128,6 +128,16 @@ export class OpenAIProvider extends BaseLLMProvider {
     return Math.min(topP, 1);
   }
 
+  private normalizeChatCompletionsResponseFormat(responseFormat?: { type: string }): unknown | undefined {
+    if (!responseFormat) return undefined;
+
+    if (this.isGenericCustomProvider() && responseFormat.type === "json_object") {
+      return { type: "json_schema", json_schema: { name: "response", schema: { type: "object" }, strict: true } };
+    }
+
+    return responseFormat;
+  }
+
   /**
    * Extract text and thinking from an OpenRouter/Anthropic-style content block array.
    * OpenRouter may return `content` as an array of typed blocks instead of a plain string:
@@ -669,8 +679,9 @@ export class OpenAIProvider extends BaseLLMProvider {
     this.applyOpenRouterPromptCaching(body, options);
 
     // Force response format (e.g. JSON mode)
-    if (options.responseFormat) {
-      body.response_format = options.responseFormat;
+    const normalizedResponseFormat = this.normalizeChatCompletionsResponseFormat(options.responseFormat);
+    if (normalizedResponseFormat) {
+      body.response_format = normalizedResponseFormat;
     }
 
     this.applyCustomParameters(body, options);
@@ -877,8 +888,9 @@ export class OpenAIProvider extends BaseLLMProvider {
     this.applyOpenRouterPromptCaching(body, options);
 
     // Force response format (e.g. JSON mode)
-    if (options.responseFormat) {
-      body.response_format = options.responseFormat;
+    const normalizedResponseFormat = this.normalizeChatCompletionsResponseFormat(options.responseFormat);
+    if (normalizedResponseFormat) {
+      body.response_format = normalizedResponseFormat;
     }
 
     this.applyCustomParameters(body, options);

--- a/packages/server/src/services/llm/providers/openai.provider.ts
+++ b/packages/server/src/services/llm/providers/openai.provider.ts
@@ -131,7 +131,7 @@ export class OpenAIProvider extends BaseLLMProvider {
   private normalizeChatCompletionsResponseFormat(responseFormat?: { type: string }): unknown | undefined {
     if (!responseFormat) return undefined;
 
-    if ((this.isGenericCustomProvider() || this.providerKind === "local-sidecar") && responseFormat.type === "json_object") {
+    if (this.isGenericCustomProvider() && responseFormat.type === "json_object") {
       return { type: "json_schema", json_schema: { name: "response", schema: { type: "object" }, strict: true } };
     }
 

--- a/packages/server/src/services/llm/providers/openai.provider.ts
+++ b/packages/server/src/services/llm/providers/openai.provider.ts
@@ -131,7 +131,7 @@ export class OpenAIProvider extends BaseLLMProvider {
   private normalizeChatCompletionsResponseFormat(responseFormat?: { type: string }): unknown | undefined {
     if (!responseFormat) return undefined;
 
-    if (this.isGenericCustomProvider() && responseFormat.type === "json_object") {
+    if ((this.isGenericCustomProvider() || this.providerKind === "local-sidecar") && responseFormat.type === "json_object") {
       return { type: "json_schema", json_schema: { name: "response", schema: { type: "object" }, strict: true } };
     }
 


### PR DESCRIPTION
# Description
Closes #496

## What changed

Core fix is converting json_object request to json_schema request type: https://github.com/Pasta-Devs/Marinara-Engine/pull/490/changes#diff-41cf0ca77fcb41665c8a4bff06a93d6e8623103b53fc2389d2ffa27c8057aa8fR131-R139

The other changes are relating to some error handling which I needed to add to get things moving forward in my environment. I can get rid of them if a more focused PR is preferred, but these improvements seem nice-to-have:

  * Tightened synchronization so narration reliably unlocks only after scene assets (backgrounds, music, images) finish applying, with deterministic handling on success, error, or timeout paths and consistent advancement of narration gating.
  * Improved asset-generation flow with explicit timeouts, cancellation handling, deterministic pending-state clearing, and timed protection for preview/prompt-review to avoid hangs and ensure consistent outcomes.

## Why this change
Because LM studio for starting new games does not work (see issue linked above)

## Validation
- [x] pnpm check
- [x] pnpm version:check
- [x] pnpm build
- [x] Manually verified I can now start games properly without getting stuck and failing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved game scene loading reliability with explicit readiness gating across asset generation pathways.
  * Enhanced timeout handling for asset generation with graceful fallbacks and deterministic error recovery.

* **Improvements**
  * Better compatibility with OpenAI-compatible LLM providers through response format normalization.
  * Extended API flexibility to support custom request configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->