### PR TITLE
fix(container): Avoid recursive app chown layers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,7 @@ COPY scripts/docker-entrypoint.mjs /usr/local/bin/marinara-docker-entrypoint.mjs
 
 # Ensure /app/data exists for runtime use (file storage, uploads, generated assets)
 RUN mkdir -p /app/data && \
-    chown -R node:node /app
+    chown node:node /app/data
 
 # Point the server at /app/data regardless of working directory
 ENV DATA_DIR=/app/data

--- a/Dockerfile.lite
+++ b/Dockerfile.lite
@@ -113,7 +113,7 @@ COPY scripts/docker-entrypoint.mjs /usr/local/bin/marinara-docker-entrypoint.mjs
 
 # Ensure data directory exists
 RUN mkdir -p /app/data && \
-    chown -R nonroot:nonroot /app
+    chown nonroot:nonroot /app/data
 
 # Runtime feature flag
 ENV MARINARA_LITE=true


### PR DESCRIPTION
## Why

The current regular and lite container images recursively `chown` `/app` after `node_modules` and build artifacts are copied. Docker/Podman records that ownership rewrite as a large additional layer, inflating the published image sizes without adding runtime content.

## What

- Limit build-time ownership changes in `Dockerfile` to `/app/data`.
- Limit build-time ownership changes in `Dockerfile.lite` to `/app/data`.
- Keep the writable data directory owned by the runtime user without rewriting the whole `/app` tree.

##  Validation

- [x] Built and ran the lite image locally.
- [x] Inspected the resulting image history: the data ownership layer is `2.05 kB` instead of the previous `599 MB` recursive chown layer.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
- Refined Docker container runtime configurations in both production and lightweight image variants. Data directory file ownership is now managed with targeted precision, applying ownership changes to specific directories rather than recursively across the entire application folder, improving operational efficiency and security boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->