### PR TITLE
Prefer trimming old history over collapsing completion budget

### DIFF
--- a/packages/server/src/services/llm/base-provider.ts
+++ b/packages/server/src/services/llm/base-provider.ts
@@ -330,7 +330,11 @@ export function fitMessagesToContext(
       : Math.max(1, Math.min(requestedMaxTokens, Math.max(1, usableWindow - reservedInputFloor)));
   let inputBudget = Math.max(0, usableWindow - (maxTokens ?? 0));
 
-  if (estimatedTokensBefore > inputBudget && maxTokens !== undefined) {
+  // If the requested output budget consumes nearly the whole context window,
+  // make room for the prompt before trimming. Otherwise, prefer trimming old
+  // history first so a large-but-valid response budget does not collapse to the
+  // 128-token floor just because the prompt is slightly over budget.
+  if (estimatedTokensBefore > inputBudget && maxTokens !== undefined && inputBudget <= reservedInputFloor) {
     const minimumOutputBudget = Math.min(MIN_OUTPUT_BUDGET_TOKENS, Math.max(1, usableWindow - 1));
     const headroom = Math.min(OUTPUT_BUDGET_REDUCTION_HEADROOM_TOKENS, Math.max(0, usableWindow - 1));
     const maxTokensThatFitPrompt = Math.max(1, usableWindow - estimatedTokensBefore - headroom);
@@ -356,14 +360,25 @@ export function fitMessagesToContext(
 
   const fittedMessages = cloneMessages(messages);
   let estimatedTokensAfter = estimateMessagesTokens(fittedMessages);
+  const hasAnnotatedHistory = fittedMessages.some((message) => message.contextKind === "history");
 
   while (estimatedTokensAfter > inputBudget && fittedMessages.length > 1) {
-    const block =
-      findOldestRemovableConversationBlock(fittedMessages, "history") ??
-      findOldestRemovableConversationBlock(fittedMessages);
+    const block = findOldestRemovableConversationBlock(fittedMessages, "history");
     if (!block) break;
     fittedMessages.splice(block.start, block.deleteCount);
     estimatedTokensAfter = estimateMessagesTokens(fittedMessages);
+  }
+
+  // Some legacy/manual prompt paths do not annotate chat turns. Only treat
+  // unmarked non-system messages as removable history when the whole prompt
+  // lacks history hints; otherwise those messages may be preset/setup blocks.
+  if (!hasAnnotatedHistory) {
+    while (estimatedTokensAfter > inputBudget && fittedMessages.length > 1) {
+      const block = findOldestRemovableConversationBlock(fittedMessages);
+      if (!block) break;
+      fittedMessages.splice(block.start, block.deleteCount);
+      estimatedTokensAfter = estimateMessagesTokens(fittedMessages);
+    }
   }
 
   if (estimatedTokensAfter > inputBudget && maxTokens !== undefined) {
@@ -374,6 +389,13 @@ export function fitMessagesToContext(
       maxTokens = reducedMaxTokens;
       inputBudget = Math.max(0, usableWindow - maxTokens);
     }
+  }
+
+  while (estimatedTokensAfter > inputBudget && fittedMessages.length > 1) {
+    const block = findOldestRemovableConversationBlock(fittedMessages);
+    if (!block) break;
+    fittedMessages.splice(block.start, block.deleteCount);
+    estimatedTokensAfter = estimateMessagesTokens(fittedMessages);
   }
 
   while (estimatedTokensAfter > inputBudget && fittedMessages.length > 1) {

--- a/packages/server/test/context-fit.test.ts
+++ b/packages/server/test/context-fit.test.ts
@@ -44,6 +44,66 @@ test("context fitting reduces completion budget before truncating protected prom
   assert.ok((fit.estimatedTokensAfter ?? 0) <= (fit.inputBudget ?? 0));
 });
 
+test("context fitting trims old history before collapsing a usable completion budget", () => {
+  const messages: ChatMessage[] = [
+    { role: "system", content: repeated("prompt", 100) },
+    { role: "user", content: repeated("old user", 3000), contextKind: "history" },
+    { role: "user", content: "current turn", contextKind: "history" },
+  ];
+
+  const fit = fitMessagesToContext(messages, { maxContext: 1000, maxTokens: 300 });
+
+  assert.equal(fit.maxTokens, 300);
+  assert.equal(
+    fit.messages.some((message) => message.content.includes("old user:")),
+    false,
+  );
+  assert.equal(fit.messages.at(-1)?.content, "current turn");
+  assert.ok((fit.estimatedTokensAfter ?? 0) <= (fit.inputBudget ?? 0));
+});
+
+test("context fitting trims unmarked old turns before collapsing a usable completion budget", () => {
+  const messages: ChatMessage[] = [
+    { role: "system", content: repeated("prompt", 100) },
+    { role: "user", content: repeated("old unmarked user", 3000) },
+    { role: "user", content: "current turn" },
+  ];
+
+  const fit = fitMessagesToContext(messages, { maxContext: 1000, maxTokens: 300 });
+
+  assert.equal(fit.maxTokens, 300);
+  assert.equal(
+    fit.messages.some((message) => message.content.includes("old unmarked user:")),
+    false,
+  );
+  assert.equal(fit.messages.at(-1)?.content, "current turn");
+  assert.ok((fit.estimatedTokensAfter ?? 0) <= (fit.inputBudget ?? 0));
+});
+
+test("context fitting reduces completion budget before removing non-history prompt blocks", () => {
+  const importantPromptBlock = repeated("important setup", 2600);
+  const messages: ChatMessage[] = [
+    { role: "system", content: repeated("prompt", 100) },
+    { role: "user", content: importantPromptBlock },
+    { role: "assistant", content: repeated("old assistant", 300), contextKind: "history" },
+    { role: "user", content: "current turn", contextKind: "history" },
+  ];
+
+  const fit = fitMessagesToContext(messages, { maxContext: 1000, maxTokens: 300 });
+
+  assert.equal(
+    fit.messages.some((message) => message.content === importantPromptBlock),
+    true,
+  );
+  assert.equal(
+    fit.messages.some((message) => message.content.includes("old assistant:")),
+    false,
+  );
+  assert.equal(fit.messages.at(-1)?.content, "current turn");
+  assert.ok((fit.maxTokens ?? 0) < 300);
+  assert.ok((fit.estimatedTokensAfter ?? 0) <= (fit.inputBudget ?? 0));
+});
+
 test("context fitting preserves agent context by reducing oversized local output budget first", () => {
   const prompt = repeated("agent prompt", 1000);
   const messages: ChatMessage[] = [


### PR DESCRIPTION
When the input prompt slightly exceeds the remaining budget, the context fitter now trims annotated history and unmarked old turns before reducing the output token budget. The output budget is only reduced when the requested budget consumes nearly the whole context window, preventing a valid large response budget from collapsing to the minimum floor.

## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- Fixes a generation bug where context fitting could shrink the model’s usable completion budget down to the internal 128-token floor instead of trimming older chat history first. This could produce visibly truncated responses and make post-processing agents fail downstream.

## What changed

<!-- List the key changes in this PR -->

- Updated LLM context fitting to prefer trimming old marked chat history before reducing a usable output budget.
- Preserved legacy/manual prompt behavior for prompts that do not annotate history with `contextKind`.
- Kept important non-history prompt blocks protected by reducing output before removing broader prompt content.
- Added regression tests for marked history, unmarked history, prompt-block protection, and oversized output-budget behavior.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [X] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [X] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [X] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Automated validation run by Codex:
  - `pnpm --filter @marinara-engine/server exec tsx --test test/context-fit.test.ts`
  - `pnpm check`
- Confirmed I didn't straight up break generations, but please review if this is the right fix.

## Docs and release impact

- [X] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)


## UI evidence (if applicable)

<!-- Add before/after screenshots or recordings for UI changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Better handling of token budget enforcement to avoid dropping protected prompt content.
* **Refactor**
  * Trimming is now annotation-driven: prioritize removing annotated "history" blocks, with a fallback to older turns; system-message trimming now continues via conversation-block trimming until fits.
* **Tests**
  * Added and tightened unit tests covering budget reduction and prioritized trimming behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->