### PR TITLE
fix(chat): prevent duplicate assistant bubble while finalizing

### DIFF
--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -759,6 +759,9 @@ export function ChatRoleplaySurface({
   const linkedChatName = chat?.connectedChatId ? allChats?.find((c) => c.id === chat.connectedChatId)?.name : undefined;
   const sidebarOpen = useUIStore((s) => s.sidebarOpen);
   const rightPanelOpen = useUIStore((s) => s.rightPanelOpen);
+  const persistedStreamingMessageId = useChatStore((s) => s.persistedStreamingMessageIds.get(activeChatId) ?? null);
+  const isStreamingMessagePersisted =
+    !!persistedStreamingMessageId && !!messages?.some((message) => message.id === persistedStreamingMessageId);
   const hideEchoChamberOnMobile =
     sidebarOpen || rightPanelOpen || settingsOpen || filesOpen || galleryOpen || wizardOpen;
 
@@ -1103,7 +1106,7 @@ export function ChatRoleplaySurface({
 
                 {!isStreaming && <CyoaChoices messages={messages} />}
 
-                {isStreaming && !regenerateMessageId && (
+                {isStreaming && !isStreamingMessagePersisted && !regenerateMessageId && (
                   <StreamingIndicator
                     activeChatId={activeChatId}
                     chatCharIds={chatCharIds}

--- a/packages/client/src/components/chat/ConversationView.tsx
+++ b/packages/client/src/components/chat/ConversationView.tsx
@@ -159,6 +159,7 @@ export function ConversationView({
   const streamBuffer = useChatStore((s) => s.streamBuffer);
   const thinkingBuffer = useChatStore((s) => s.thinkingBuffer);
   const regenerateMessageId = useChatStore((s) => s.regenerateMessageId);
+  const persistedStreamingMessageId = useChatStore((s) => s.persistedStreamingMessageIds.get(chatId) ?? null);
   const streamingCharacterId = useChatStore((s) => s.streamingCharacterId);
   const typingCharacterName = useChatStore((s) => s.typingCharacterName);
   const delayedCharacterInfo = useChatStore((s) => s.delayedCharacterInfo);
@@ -396,6 +397,10 @@ export function ConversationView({
     }
     return items;
   }, [messages, characterMap, chatCharIds, totalMessageCount]);
+  const isStreamingMessagePersisted = useMemo(
+    () => !!persistedStreamingMessageId && !!messages?.some((message) => message.id === persistedStreamingMessageId),
+    [messages, persistedStreamingMessageId],
+  );
 
   // ── Staggered reveal for split assistant lines ──
   // When a new multi-line assistant message arrives, show lines one by one
@@ -859,7 +864,7 @@ export function ConversationView({
         )}
 
         {/* Streaming message — only shown once actual content starts arriving */}
-        {isStreaming && !regenerateMessageId && (streamBuffer || thinkingBuffer) && (
+        {isStreaming && !isStreamingMessagePersisted && !regenerateMessageId && (streamBuffer || thinkingBuffer) && (
           <ConversationMessage
             message={{
               id: "__streaming__",

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -419,6 +419,7 @@ export function useGenerate() {
   const setMariPhase = useChatStore((s) => s.setMariPhase);
   const setStreamBuffer = useChatStore((s) => s.setStreamBuffer);
   const clearStreamBuffer = useChatStore((s) => s.clearStreamBuffer);
+  const setPersistedStreamingMessageId = useChatStore((s) => s.setPersistedStreamingMessageId);
   const appendThinkingBuffer = useChatStore((s) => s.appendThinkingBuffer);
   const clearThinkingBuffer = useChatStore((s) => s.clearThinkingBuffer);
   const setRegenerateMessageId = useChatStore((s) => s.setRegenerateMessageId);
@@ -1017,6 +1018,7 @@ export function useGenerate() {
                 thinkCloseTag = "</think>";
                 setStreamBuffer("", params.chatId);
                 clearThinkingBuffer(params.chatId);
+                setPersistedStreamingMessageId(params.chatId, null);
               }
 
               if (isActiveChat()) setStreamingCharacterId(turn.characterId);
@@ -1114,6 +1116,8 @@ export function useGenerate() {
               // duplicate message that vanishes on refresh.
               if (params.regenerateMessageId || !streamingEnabled) {
                 upsertPersistedMessages(qc, params.chatId, [savedMessage]);
+              } else {
+                setPersistedStreamingMessageId(params.chatId, savedMessage.id);
               }
               break;
             }
@@ -1445,10 +1449,9 @@ export function useGenerate() {
           if (useChatStore.getState().streamingChatId === params.chatId) {
             // Authoritative refresh BEFORE clearing streaming state. This
             // fetches the latest messages from DB (including illustrations and
-            // other post-processing attachments). React 19 batches the React
-            // Query cache update and the Zustand streaming state update into
-            // one commit since they happen in the same microtask after the
-            // await resolves — preventing both duplicate-flash and empty-flash.
+            // other post-processing attachments). The renderers hide the
+            // temporary stream bubble once this saved message appears, so the
+            // handoff cannot show both copies at once.
             await refreshMessagesAuthoritatively(qc, params.chatId, persistedMessages.values());
             setStreaming(false);
             clearStreamBuffer(params.chatId);
@@ -1532,6 +1535,7 @@ export function useGenerate() {
       setMariPhase,
       setStreamBuffer,
       clearStreamBuffer,
+      setPersistedStreamingMessageId,
       appendThinkingBuffer,
       clearThinkingBuffer,
       setRegenerateMessageId,

--- a/packages/client/src/stores/chat.store.ts
+++ b/packages/client/src/stores/chat.store.ts
@@ -55,6 +55,8 @@ interface ChatState {
   streamBuffer: string;
   /** Per-chat stream text for active generations, so switching chats does not lose in-flight UI state. */
   streamBuffers: Map<string, string>;
+  /** Per-chat saved message that is replacing the temporary streaming bubble. */
+  persistedStreamingMessageIds: Map<string, string>;
   thinkingBuffer: string;
   /** Per-chat live thinking text for active generations. */
   thinkingBuffers: Map<string, string>;
@@ -118,6 +120,7 @@ interface ChatState {
   appendStreamBuffer: (text: string, chatId?: string) => void;
   setStreamBuffer: (text: string, chatId?: string) => void;
   clearStreamBuffer: (chatId?: string) => void;
+  setPersistedStreamingMessageId: (chatId: string, messageId: string | null) => void;
   appendThinkingBuffer: (text: string, chatId?: string) => void;
   setThinkingBuffer: (text: string, chatId?: string) => void;
   clearThinkingBuffer: (chatId?: string) => void;
@@ -167,6 +170,7 @@ export const useChatStore = create<ChatState>()(
     mariPhaseByChatId: new Map(),
     streamBuffer: "",
     streamBuffers: new Map(),
+    persistedStreamingMessageIds: new Map(),
     thinkingBuffer: "",
     thinkingBuffers: new Map(),
     abortControllers: new Map(),
@@ -340,6 +344,13 @@ export const useChatStore = create<ChatState>()(
           ...(state.activeChatId === targetChatId ? { streamBuffer: "" } : {}),
         };
       }),
+    setPersistedStreamingMessageId: (chatId, messageId) =>
+      set((state) => {
+        const m = new Map(state.persistedStreamingMessageIds);
+        if (messageId) m.set(chatId, messageId);
+        else m.delete(chatId);
+        return { persistedStreamingMessageIds: m };
+      }),
     appendThinkingBuffer: (text, chatId) =>
       set((state) => {
         const targetChatId = chatId ?? state.streamingChatId ?? state.activeChatId ?? "";
@@ -411,13 +422,16 @@ export const useChatStore = create<ChatState>()(
         const t = new Map(state.perChatTyping);
         const d = new Map(state.perChatDelayed);
         const thoughts = new Map(state.thinkingBuffers);
+        const persistedStreaming = new Map(state.persistedStreamingMessageIds);
         t.delete(chatId);
         d.delete(chatId);
         thoughts.delete(chatId);
+        persistedStreaming.delete(chatId);
         return {
           perChatTyping: t,
           perChatDelayed: d,
           thinkingBuffers: thoughts,
+          persistedStreamingMessageIds: persistedStreaming,
           ...(state.activeChatId === chatId ? { thinkingBuffer: "" } : {}),
         };
       }),
@@ -514,6 +528,7 @@ export const useChatStore = create<ChatState>()(
         mariPhaseByChatId: new Map(),
         streamBuffer: "",
         streamBuffers: new Map(),
+        persistedStreamingMessageIds: new Map(),
         thinkingBuffer: "",
         thinkingBuffers: new Map(),
         abortControllers: new Map(),


### PR DESCRIPTION
Track the saved streaming message id and hide the temporary streaming indicator once the persisted message is present in the message list. This keeps the React Query to Zustand handoff from rendering both copies at once.

## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

I've been seeing duplicate assistant messages during response streaming in roleplay chat the last couple of days, but haven't seen anyone else report this bug.

Closes #

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- Fixes a duplicate assistant response bubble that could appear briefly while a streamed message was finalizing and being refreshed from the database.

## What changed

<!-- List the key changes in this PR -->

- Added per-chat tracking for the saved message that replaces the temporary streaming bubble.
- Updated generation handling so streamed `message_saved` events record the persisted message ID instead of immediately showing a duplicate saved copy.
- Updated conversation and roleplay renderers to hide the temporary streaming bubble once the real saved message appears.
- Kept regeneration behavior unchanged.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [X] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [X] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [X] Above manual verification completed (describe below)
- [X] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Automated validation run: `pnpm check` passed locally.
- Sent message in roleplay chat and verified duplicate message no longer appears.
- Manually tested Conversation mode streaming: no duplicate final assistant bubble observed.
- Noted a brief multi-line reveal flash in Conversation mode before staggered line reveal begins; this appears related to existing Conversation line-stagger behavior and is not addressed by this PR.


## Docs and release impact

- [X] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

<!-- Add before/after screenshots or recordings for UI changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where the streaming indicator would duplicate when switching between chats or reloading the page. The streaming message placeholder now correctly displays only once per response, preventing duplicate content in the conversation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->