### PR TITLE
fix(client): normalize custom font family names

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -29,6 +29,23 @@ type HealthResponse = {
   version: string;
 };
 
+function stripFontFamilyQuotes(family: string): string {
+  const trimmed = family.trim();
+  if (trimmed.length < 2) return trimmed;
+
+  const quote = trimmed[0];
+  if ((quote !== `"` && quote !== `'`) || trimmed[trimmed.length - 1] !== quote) {
+    return trimmed;
+  }
+
+  return trimmed.slice(1, -1).trim();
+}
+
+function toCssFontFamilyValue(family: string): string {
+  const cleanFamily = stripFontFamilyQuotes(family);
+  return `"${cleanFamily.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
 async function recoverFromVersionSkew(serverVersion: string) {
   if (sessionStorage.getItem(VERSION_RECOVERY_KEY) === serverVersion) {
     return;
@@ -140,8 +157,9 @@ export function App() {
 
   // Apply custom font family via CSS variable
   useEffect(() => {
-    if (fontFamily) {
-      document.documentElement.style.setProperty("--font-user", `"${fontFamily}"`);
+    const family = fontFamily ? stripFontFamilyQuotes(fontFamily) : "";
+    if (family) {
+      document.documentElement.style.setProperty("--font-user", toCssFontFamilyValue(family));
     } else {
       document.documentElement.style.removeProperty("--font-user");
     }
@@ -168,8 +186,14 @@ export function App() {
       }
 
       try {
-        const fontFace = new FontFace(f.family, `url("${f.url}")`, {
+        const family = stripFontFamilyQuotes(f.family);
+        if (!family) {
+          return;
+        }
+
+        const fontFace = new FontFace(family, `url("${f.url}")`, {
           display: "swap",
+          weight: "400",
         });
 
         fontFace


### PR DESCRIPTION
## What?

Normalize custom font family names before registering browser `FontFace` objects and before writing the `--font-user` CSS variable.

Closes #501.

## Why?

Custom fonts selected in Settings could be registered with embedded quote characters in the family name, such as `"Noto Sans"` instead of `Noto Sans`. That malformed family could interfere with matching custom theme `@font-face` rules for the same family and cause text to render at the wrong weight.

## How?

- Added a small helper to strip one accidental matching quote wrapper from stored or returned font family names.
- Kept CSS variable output quoted and escaped, so names with spaces remain valid `font-family` values.
- Passed the unquoted family name to the `FontFace` constructor.
- Registered downloaded/custom font files with `weight: "400"` to match the regular font files Marinara serves from the font loader.

## Testing?

Ran locally:

```sh
pnpm check
```

Manual verification still needed before release:

- [ ] Manually verify selecting a custom Google Font in Settings registers `document.fonts` with an unquoted family name.
- [ ] Manually verify custom theme `@font-face` rules for the same family still match their intended weights.
- [ ] Manually verify default font selection still removes `--font-user`.

## Screenshots (optional)

Not included. This is a font registration fix; visual verification should be done with the reporter's DevTools `document.fonts` check and a custom theme weight check.

## Anything Else?

This is intentionally scoped to the client-side font registration path. It does not change the server font file scanner or Google Fonts download route.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling and validation of custom font-family inputs for more reliable font loading and display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->