### PR TITLE
fix(diagnostics): self-serviceable network rejection errors + CORS hot-reload + auto-create .env

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -88,7 +88,7 @@ Marinara Engine ships with layered access-control mechanisms designed for users 
 
 > Looking for a step-by-step walkthrough rather than a reference? See [Remote Access — Setting Up Basic Auth or an IP Allowlist](REMOTE_ACCESS.md).
 
-> **Hot reload:** changes to access-control variables (`BASIC_AUTH_*`, `IP_ALLOWLIST`, `IP_ALLOWLIST_ENABLED`, `ALLOW_UNAUTHENTICATED_*`, `TRUSTED_PRIVATE_NETWORKS`, `ADMIN_SECRET`, `CSRF_TRUSTED_ORIGINS`) take effect within a couple of seconds of saving `.env` — no restart required. The server logs an `[env-watcher]` line for each change. A short list of low-level variables (`PORT`, `HOST`, `SSL_CERT`/`SSL_KEY`, `CORS_ORIGINS`, storage paths, `ENCRYPTION_KEY`, `TZ`) still need a restart; see [Remote Access § When a restart is required](REMOTE_ACCESS.md#when-a-restart-is-required).
+> **Hot reload:** changes to access-control variables (`BASIC_AUTH_*`, `IP_ALLOWLIST`, `IP_ALLOWLIST_ENABLED`, `ALLOW_UNAUTHENTICATED_*`, `TRUSTED_PRIVATE_NETWORKS`, `ADMIN_SECRET`, `CSRF_TRUSTED_ORIGINS`, `CORS_ORIGINS`) take effect within a couple of seconds of saving `.env` — no restart required. The server logs an `[env-watcher]` line for each change. A short list of low-level variables (`PORT`, `HOST`, `SSL_CERT`/`SSL_KEY`, storage paths, `ENCRYPTION_KEY`, `TZ`) still need a restart; see [Remote Access § When a restart is required](REMOTE_ACCESS.md#when-a-restart-is-required). For `CORS_ORIGINS` specifically, only the rare transition between an explicit list and `*` (which flips the credentials behavior) requires a restart.
 
 ### Safe-by-default lockdown
 

--- a/docs/REMOTE_ACCESS.md
+++ b/docs/REMOTE_ACCESS.md
@@ -152,7 +152,7 @@ For sensitive deployments, consider Tailscale or Cloudflare Access — they avoi
 
 The server watches `.env` for changes and applies most updates within a couple of seconds — no restart needed. That includes `BASIC_AUTH_USER` / `BASIC_AUTH_PASS` / `BASIC_AUTH_REALM`, `IP_ALLOWLIST` / `IP_ALLOWLIST_ENABLED`, `ALLOW_UNAUTHENTICATED_PRIVATE_NETWORK`, `ALLOW_UNAUTHENTICATED_REMOTE`, `TRUSTED_PRIVATE_NETWORKS`, `ADMIN_SECRET`, `CSRF_TRUSTED_ORIGINS`, `LOG_LEVEL`, and the various `*_LOCAL_URLS_ENABLED` / privileged-feature flags.
 
-Changes to these still need a restart because they're bound at startup: `PORT`, `HOST`, `SSL_CERT`, `SSL_KEY`, `CORS_ORIGINS`, `DATA_DIR`, `STORAGE_BACKEND`, `FILE_STORAGE_DIR`, `DATABASE_URL`, `ENCRYPTION_KEY`, `TZ`, `AUTO_OPEN_BROWSER`, `AUTO_CREATE_DEFAULT_CONNECTION`. The server logs a warning when one of these changes so you don't wonder why it didn't take effect.
+Changes to these still need a restart because they're bound at startup: `PORT`, `HOST`, `SSL_CERT`, `SSL_KEY`, `DATA_DIR`, `STORAGE_BACKEND`, `FILE_STORAGE_DIR`, `DATABASE_URL`, `ENCRYPTION_KEY`, `TZ`, `AUTO_OPEN_BROWSER`, `AUTO_CREATE_DEFAULT_CONNECTION`. The server logs a warning when one of these changes so you don't wonder why it didn't take effect. (Note: `CORS_ORIGINS` *is* hot-reloadable for adding/removing origins; only switching between an explicit list and `*` still needs a restart.)
 
 ## Verifying it works
 
@@ -174,7 +174,9 @@ Different error than 403?
 
 - **Connection refused / timeout** — the server isn't bound to a reachable interface. Set `HOST=0.0.0.0` in `.env`.
 - **404 / wrong page** — you're hitting the wrong port. Default is `7860`; check `PORT` in `.env`.
-- **CORS error in the browser console** — set `CORS_ORIGINS` to include the URL you're connecting from (e.g. `http://192.168.1.10:7860`).
+- **CORS error in the browser console** — Marinara's server log will show a `[cors]` line with the rejected origin and the exact `CORS_ORIGINS=…` line to add to `.env`. Adding it takes effect within ~2s — no restart needed.
+- **`{"error": "Origin '…' is not in the trusted list (CSRF_TRUSTED_ORIGINS)."}`** — copy the offending origin into `CSRF_TRUSTED_ORIGINS` in `.env` (the error body's `hint` field has the exact line). No restart needed.
+- **`Refused to fetch http://… : '…' is in a private, loopback, metadata, or reserved IP range.`** — Marinara is refusing to call your local LLM provider for SSRF safety. The error message names the exact env var to set (`PROVIDER_LOCAL_URLS_ENABLED` for LLMs, `IMAGE_LOCAL_URLS_ENABLED` for image generation, etc.). Setting it takes effect on the next request.
 
 The full troubleshooting page is at [docs/TROUBLESHOOTING.md](TROUBLESHOOTING.md).
 

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -33,7 +33,7 @@ import {
   isFileStorageBackend,
   isAutoCreateDefaultConnectionDisabled,
 } from "./config/runtime-config.js";
-import { buildCorsPluginOptions } from "./config/cors-config.js";
+import { corsDelegate } from "./config/cors-config.js";
 import { sidecarProcessService } from "./services/sidecar/sidecar-process.service.js";
 
 const isLite = process.env.MARINARA_LITE === "true" || process.env.MARINARA_LITE === "1";
@@ -52,11 +52,11 @@ export async function buildApp(https?: { cert: Buffer; key: Buffer }) {
   });
 
   // ── Plugins ──
-  // CORS uses a function-based origin so CORS_ORIGINS is re-read per request
-  // (see cors-config.ts). Adding/removing origins takes effect within ~2s of
-  // a .env save; switching between an explicit list and "*" still needs a
-  // restart for the credentials side of the response to flip.
-  await app.register(cors, buildCorsPluginOptions());
+  // CORS uses a per-request delegator so the trusted set is re-read each
+  // request (CORS_ORIGINS hot-reloads in ~2s without a restart) AND so
+  // same-origin requests (Origin matches the request's Host header) are
+  // auto-allowed regardless of configuration. See cors-config.ts.
+  await app.register(cors, corsDelegate);
 
   await app.register(multipart, {
     limits: {

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -55,8 +55,10 @@ export async function buildApp(https?: { cert: Buffer; key: Buffer }) {
   // CORS uses a per-request delegator so the trusted set is re-read each
   // request (CORS_ORIGINS hot-reloads in ~2s without a restart) AND so
   // same-origin requests (Origin matches the request's Host header) are
-  // auto-allowed regardless of configuration. See cors-config.ts.
-  await app.register(cors, corsDelegate);
+  // auto-allowed regardless of configuration. @fastify/cors expects the
+  // delegator to be returned from a factory function passed as the plugin
+  // options. See cors-config.ts.
+  await app.register(cors, () => corsDelegate);
 
   await app.register(multipart, {
     limits: {

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -28,12 +28,12 @@ import { basename, join, resolve, dirname } from "path";
 import { fileURLToPath } from "url";
 import { getBuildCommit, getBuildLabel } from "./config/build-info.js";
 import {
-  getCorsConfig,
   getLogLevel,
   getNodeEnv,
   isFileStorageBackend,
   isAutoCreateDefaultConnectionDisabled,
 } from "./config/runtime-config.js";
+import { buildCorsPluginOptions } from "./config/cors-config.js";
 import { sidecarProcessService } from "./services/sidecar/sidecar-process.service.js";
 
 const isLite = process.env.MARINARA_LITE === "true" || process.env.MARINARA_LITE === "1";
@@ -42,7 +42,6 @@ const NO_STORE_FILES = new Set(["manifest.json", "sw.js", "registerSW.js"]);
 const MAX_UPLOAD_BYTES = 256 * 1024 * 1024;
 
 export async function buildApp(https?: { cert: Buffer; key: Buffer }) {
-  const corsConfig = getCorsConfig();
   const app = Fastify({
     logger: {
       level: getLogLevel(),
@@ -53,7 +52,11 @@ export async function buildApp(https?: { cert: Buffer; key: Buffer }) {
   });
 
   // ── Plugins ──
-  await app.register(cors, corsConfig);
+  // CORS uses a function-based origin so CORS_ORIGINS is re-read per request
+  // (see cors-config.ts). Adding/removing origins takes effect within ~2s of
+  // a .env save; switching between an explicit list and "*" still needs a
+  // restart for the credentials side of the response to flip.
+  await app.register(cors, buildCorsPluginOptions());
 
   await app.register(multipart, {
     limits: {

--- a/packages/server/src/config/cors-config.ts
+++ b/packages/server/src/config/cors-config.ts
@@ -1,17 +1,24 @@
 // ──────────────────────────────────────────────
-// CORS configuration with hot-reload support
+// CORS configuration with hot-reload + same-origin auto-allow
 // ──────────────────────────────────────────────
-// @fastify/cors registers once at boot, but its `origin` option accepts a
-// function that is invoked per request. We use that to re-read CORS_ORIGINS
-// on every request so the operator can edit .env and have the new value take
-// effect within the env-watcher's polling interval (~2s) without a restart.
+// We use @fastify/cors's delegator mode so the trusted origin set is
+// re-evaluated for every request. This buys us two things:
 //
-// Caveat: `credentials` is still a static option on the cors plugin. If the
-// operator switches between an explicit-origin list (credentials=true) and a
-// wildcard "*" (credentials=false), that specific transition still requires
-// a restart. Adding/removing origins within either mode is hot-reloadable.
+//  1. Adding / removing entries in CORS_ORIGINS takes effect within ~2s of
+//     saving .env (the env-watcher's polling interval), no restart required.
+//
+//  2. Same-origin requests are auto-allowed regardless of CORS_ORIGINS.
+//     If the browser's Origin header matches the URL the request actually
+//     reached (the Host header), it's by definition same-origin and CORS
+//     restrictions don't apply. This means a user who visits Marinara at
+//     http://localhost:7860 OR http://100.x.y.z:7860 (Tailscale) doesn't
+//     have to add either URL to CORS_ORIGINS — same-origin "just works."
+//     They only need CORS_ORIGINS for genuine cross-origin frontends (a
+//     dev Vite server on a different port, a separate hostname behind a
+//     reverse proxy that rewrites Host, etc.).
 
-import { getCorsConfig } from "./runtime-config.js";
+import type { FastifyRequest } from "fastify";
+import { getCorsConfig, getServerProtocol } from "./runtime-config.js";
 import { logger } from "../lib/logger.js";
 
 const announcedRejectedOrigins = new Set<string>();
@@ -20,10 +27,30 @@ function announceRejectedOrigin(origin: string) {
   if (announcedRejectedOrigins.has(origin)) return;
   announcedRejectedOrigins.add(origin);
   logger.warn(
-    `[cors] Rejected preflight from origin '${origin}' (not in CORS_ORIGINS). ` +
+    `[cors] Rejected cross-origin request from '${origin}' (not in CORS_ORIGINS, not same-origin). ` +
       `To allow this origin, add the following line to your .env (no restart needed): ` +
       `CORS_ORIGINS=${origin}`,
   );
+}
+
+function firstHeader(value: string | string[] | undefined): string | null {
+  if (!value) return null;
+  const raw = Array.isArray(value) ? value[0] : value;
+  return raw?.split(",")[0]?.trim() || null;
+}
+
+function selfOriginFromRequest(req: FastifyRequest): string | null {
+  const host = firstHeader(req.headers.host);
+  if (!host) return null;
+  // Honour the proxy-forwarded protocol when present, otherwise fall back
+  // to the protocol Marinara is actually serving on.
+  const forwardedProto = firstHeader(req.headers["x-forwarded-proto"]);
+  const protocol = forwardedProto === "https" || forwardedProto === "http" ? forwardedProto : getServerProtocol();
+  try {
+    return new URL(`${protocol}://${host}`).origin;
+  } catch {
+    return null;
+  }
 }
 
 function originIsAllowed(origin: string): boolean {
@@ -35,33 +62,37 @@ function originIsAllowed(origin: string): boolean {
   return false;
 }
 
-export type CorsCallback = (err: Error | null, allowed: boolean) => void;
+export type CorsDelegateCallback = (
+  err: Error | null,
+  options?: { origin: boolean | string; credentials?: boolean },
+) => void;
 
 /**
- * Per-request origin check passed to @fastify/cors. Returns true when the
- * incoming Origin matches the *current* CORS_ORIGINS configuration.
+ * Per-request CORS resolver. Order:
+ *   1. No Origin header → not a CORS request, no restrictions apply.
+ *   2. Origin matches the request's own host (same-origin) → always allowed.
+ *   3. Origin matches CORS_ORIGINS or "*" → allowed.
+ *   4. Otherwise → rejected, log a one-shot diagnostic for the operator.
  */
-export function checkCorsOrigin(origin: string | undefined, callback: CorsCallback) {
-  // Requests without an Origin header (curl, server-to-server, same-origin
-  // navigations) are not subject to CORS — let them through.
-  if (!origin) return callback(null, true);
+export function corsDelegate(req: FastifyRequest, callback: CorsDelegateCallback) {
+  const origin = firstHeader(req.headers.origin);
+  if (!origin) {
+    return callback(null, { origin: true });
+  }
 
-  if (originIsAllowed(origin)) return callback(null, true);
+  const selfOrigin = selfOriginFromRequest(req);
+  if (selfOrigin && origin === selfOrigin) {
+    return callback(null, { origin: true, credentials: getCorsConfig().credentials });
+  }
+
+  if (originIsAllowed(origin)) {
+    const config = getCorsConfig();
+    if (config.origin === "*") {
+      return callback(null, { origin: true, credentials: false });
+    }
+    return callback(null, { origin: true, credentials: config.credentials });
+  }
 
   announceRejectedOrigin(origin);
-  callback(null, false);
-}
-
-/**
- * Resolve the static @fastify/cors options. `origin` is a function so the
- * trusted set is re-read per request; `credentials` is bound at boot from
- * whatever mode (explicit list vs wildcard) was active when the server
- * started. See module docstring for the credentials-mode caveat.
- */
-export function buildCorsPluginOptions() {
-  const initial = getCorsConfig();
-  return {
-    origin: checkCorsOrigin,
-    credentials: initial.credentials,
-  };
+  callback(null, { origin: false });
 }

--- a/packages/server/src/config/cors-config.ts
+++ b/packages/server/src/config/cors-config.ts
@@ -1,0 +1,67 @@
+// ──────────────────────────────────────────────
+// CORS configuration with hot-reload support
+// ──────────────────────────────────────────────
+// @fastify/cors registers once at boot, but its `origin` option accepts a
+// function that is invoked per request. We use that to re-read CORS_ORIGINS
+// on every request so the operator can edit .env and have the new value take
+// effect within the env-watcher's polling interval (~2s) without a restart.
+//
+// Caveat: `credentials` is still a static option on the cors plugin. If the
+// operator switches between an explicit-origin list (credentials=true) and a
+// wildcard "*" (credentials=false), that specific transition still requires
+// a restart. Adding/removing origins within either mode is hot-reloadable.
+
+import { getCorsConfig } from "./runtime-config.js";
+import { logger } from "../lib/logger.js";
+
+const announcedRejectedOrigins = new Set<string>();
+
+function announceRejectedOrigin(origin: string) {
+  if (announcedRejectedOrigins.has(origin)) return;
+  announcedRejectedOrigins.add(origin);
+  logger.warn(
+    `[cors] Rejected preflight from origin '${origin}' (not in CORS_ORIGINS). ` +
+      `To allow this origin, add the following line to your .env (no restart needed): ` +
+      `CORS_ORIGINS=${origin}`,
+  );
+}
+
+function originIsAllowed(origin: string): boolean {
+  const config = getCorsConfig();
+  const candidate = config.origin;
+  if (candidate === "*") return true;
+  if (typeof candidate === "string") return candidate === origin;
+  if (Array.isArray(candidate)) return candidate.includes(origin);
+  return false;
+}
+
+export type CorsCallback = (err: Error | null, allowed: boolean) => void;
+
+/**
+ * Per-request origin check passed to @fastify/cors. Returns true when the
+ * incoming Origin matches the *current* CORS_ORIGINS configuration.
+ */
+export function checkCorsOrigin(origin: string | undefined, callback: CorsCallback) {
+  // Requests without an Origin header (curl, server-to-server, same-origin
+  // navigations) are not subject to CORS — let them through.
+  if (!origin) return callback(null, true);
+
+  if (originIsAllowed(origin)) return callback(null, true);
+
+  announceRejectedOrigin(origin);
+  callback(null, false);
+}
+
+/**
+ * Resolve the static @fastify/cors options. `origin` is a function so the
+ * trusted set is re-read per request; `credentials` is bound at boot from
+ * whatever mode (explicit list vs wildcard) was active when the server
+ * started. See module docstring for the credentials-mode caveat.
+ */
+export function buildCorsPluginOptions() {
+  const initial = getCorsConfig();
+  return {
+    origin: checkCorsOrigin,
+    credentials: initial.credentials,
+  };
+}

--- a/packages/server/src/config/cors-config.ts
+++ b/packages/server/src/config/cors-config.ts
@@ -28,8 +28,8 @@ function announceRejectedOrigin(origin: string) {
   announcedRejectedOrigins.add(origin);
   logger.warn(
     `[cors] Rejected cross-origin request from '${origin}' (not in CORS_ORIGINS, not same-origin). ` +
-      `To allow this origin, add the following line to your .env (no restart needed): ` +
-      `CORS_ORIGINS=${origin}`,
+      `To allow it, add '${origin}' to CORS_ORIGINS in your .env — comma-separated if you already have entries, ` +
+      `e.g. CORS_ORIGINS=http://existing.example,${origin}. No restart needed (takes effect within ~2s).`,
   );
 }
 

--- a/packages/server/src/config/env-watcher.ts
+++ b/packages/server/src/config/env-watcher.ts
@@ -16,6 +16,13 @@ import { getEnvFilePath, reloadRuntimeEnv, type EnvReloadResult } from "./runtim
 
 // Keys whose values are bound at process / app startup and won't take effect
 // without a full restart, even though we propagate them to process.env.
+//
+// CORS_ORIGINS is intentionally NOT in this list — the @fastify/cors plugin
+// uses a function-based origin that re-reads getCorsConfig() per request
+// (see cors-config.ts), so adding/removing origins is hot-reloadable. The
+// only sub-case that still needs a restart is switching between an explicit
+// origin list and "*" (the credentials response header changes), but that's
+// rare enough that we don't list the var here as "always restart-required."
 const RESTART_REQUIRED_KEYS = new Set<string>([
   "PORT",
   "HOST",
@@ -30,7 +37,6 @@ const RESTART_REQUIRED_KEYS = new Set<string>([
   "TZ",
   "AUTO_OPEN_BROWSER",
   "AUTO_CREATE_DEFAULT_CONNECTION",
-  "CORS_ORIGINS",
   "NODE_ENV",
 ]);
 

--- a/packages/server/src/config/runtime-config.ts
+++ b/packages/server/src/config/runtime-config.ts
@@ -1,6 +1,6 @@
 import dotenv from "dotenv";
 import { logger as sharedLogger } from "../lib/logger.js";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, isAbsolute, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -26,10 +26,40 @@ export function getEnvFilePath() {
   return resolve(MONOREPO_ROOT, ".env");
 }
 
+const EMPTY_ENV_HEADER = `# Marinara Engine - runtime configuration.
+# This file is empty by design. Copy any setting you want to change from
+# .env.example (same folder) and edit the value here. Most changes take
+# effect within ~2 seconds without a restart.
+`;
+
+/**
+ * Create an empty .env at the repo root if one doesn't exist yet so users
+ * can find the file without having to copy .env.example first. The write
+ * is best-effort: read-only filesystems (some Docker images, locked-down
+ * installs) silently fall back to "no .env" mode, which dotenv handles
+ * the same as today.
+ */
+function ensureEnvFileExists(envPath: string) {
+  if (existsSync(envPath)) return;
+  try {
+    // 'wx' = exclusive create. Race-safe across concurrent startups: a second
+    // process that loses the race gets EEXIST, which we ignore.
+    writeFileSync(envPath, EMPTY_ENV_HEADER, { flag: "wx" });
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException | null)?.code;
+    if (code === "EEXIST") return;
+    sharedLogger.warn(
+      { err, envPath },
+      "[runtime-config] Could not auto-create .env file; continuing without it",
+    );
+  }
+}
+
 export function loadRuntimeEnv() {
   if (envLoaded) return;
 
   const envPath = getEnvFilePath();
+  ensureEnvFileExists(envPath);
   if (existsSync(envPath)) {
     const result = dotenv.config({ path: envPath });
     if (result.parsed) {

--- a/packages/server/src/middleware/csrf-protection.ts
+++ b/packages/server/src/middleware/csrf-protection.ts
@@ -10,13 +10,11 @@ const SAFE_FETCH_SITES = new Set(["same-origin", "same-site", "none"]);
 // Throttle "origin not trusted" log lines so a misbehaving client can't flood
 // the log. Each unique origin is announced once per process.
 const announcedRejectedOrigins = new Set<string>();
-function announceRejectedOrigin(kind: "Origin" | "Referer", value: string, exampleLine: string) {
+function announceRejectedOrigin(kind: "Origin" | "Referer", value: string, hint: string) {
   const key = `${kind}:${value}`;
   if (announcedRejectedOrigins.has(key)) return;
   announcedRejectedOrigins.add(key);
-  logger.warn(
-    `[csrf] Rejected request: ${kind} '${value}' is not in the trusted list. To allow this, add the following to your .env (no restart needed): ${exampleLine}`,
-  );
+  logger.warn(`[csrf] Rejected request: ${kind} '${value}' is not in the trusted list. ${hint}`);
 }
 
 function firstHeader(value: string | string[] | undefined): string | null {
@@ -142,10 +140,15 @@ function canUseSameOriginCompatibility(
   return !!sourceOrigin && sourceOrigin === getRequestOrigin(request);
 }
 
-function originLine(origin: string): string {
-  // Suggest the exact .env line the operator should paste.
+function appendOriginHint(origin: string): string {
+  // Non-destructive instruction: tell the operator to APPEND the offending
+  // origin to CSRF_TRUSTED_ORIGINS rather than replace the variable, so a
+  // user who already trusts other origins doesn't accidentally clobber them.
   const normalized = normalizeOrigin(origin) ?? origin;
-  return `CSRF_TRUSTED_ORIGINS=${normalized}`;
+  return (
+    `Add '${normalized}' to CSRF_TRUSTED_ORIGINS in your .env — comma-separated if you already have entries, ` +
+    `e.g. CSRF_TRUSTED_ORIGINS=http://existing.example,${normalized}. No restart needed (takes effect within ~2s).`
+  );
 }
 
 export function csrfProtectionHook(request: FastifyRequest, reply: FastifyReply, done: () => void) {
@@ -163,33 +166,33 @@ export function csrfProtectionHook(request: FastifyRequest, reply: FastifyReply,
   const secFetchSite = firstHeader(request.headers["sec-fetch-site"]);
   if (secFetchSite && !SAFE_FETCH_SITES.has(secFetchSite.toLowerCase()) && !originTrusted) {
     const offender = origin ?? referer ?? "(unknown)";
-    if (origin || referer) announceRejectedOrigin(origin ? "Origin" : "Referer", offender, originLine(offender));
+    if (origin || referer) announceRejectedOrigin(origin ? "Origin" : "Referer", offender, appendOriginHint(offender));
     reply.status(403).send({
       error: "Cross-site unsafe requests are not allowed",
       origin: offender,
       hint: origin || referer
-        ? `To allow this origin, add to .env (no restart needed): ${originLine(offender)}`
+        ? appendOriginHint(offender)
         : "Browser did not send an Origin or Referer header — Marinara cannot verify this is a same-origin request.",
     });
     return;
   }
 
   if (origin && !originTrusted) {
-    announceRejectedOrigin("Origin", origin, originLine(origin));
+    announceRejectedOrigin("Origin", origin, appendOriginHint(origin));
     reply.status(403).send({
       error: `Origin '${origin}' is not in the trusted list (CSRF_TRUSTED_ORIGINS).`,
       origin,
-      hint: `Add to .env (no restart needed): ${originLine(origin)}`,
+      hint: appendOriginHint(origin),
     });
     return;
   }
 
   if (!origin && referer && !originTrusted) {
-    announceRejectedOrigin("Referer", referer, originLine(referer));
+    announceRejectedOrigin("Referer", referer, appendOriginHint(referer));
     reply.status(403).send({
       error: `Referer '${referer}' is not in the trusted list (CSRF_TRUSTED_ORIGINS).`,
       referer,
-      hint: `Add to .env (no restart needed): ${originLine(referer)}`,
+      hint: appendOriginHint(referer),
     });
     return;
   }

--- a/packages/server/src/middleware/csrf-protection.ts
+++ b/packages/server/src/middleware/csrf-protection.ts
@@ -1,10 +1,23 @@
 import type { FastifyReply, FastifyRequest } from "fastify";
 import { getCsrfTrustedOrigins, getHost, getPort, getServerProtocol } from "../config/runtime-config.js";
 import { CSRF_HEADER, CSRF_HEADER_VALUE } from "../utils/security.js";
+import { logger } from "../lib/logger.js";
 import { isPrivateNetworkIp, isLoopbackIp } from "./ip-allowlist.js";
 
 const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 const SAFE_FETCH_SITES = new Set(["same-origin", "same-site", "none"]);
+
+// Throttle "origin not trusted" log lines so a misbehaving client can't flood
+// the log. Each unique origin is announced once per process.
+const announcedRejectedOrigins = new Set<string>();
+function announceRejectedOrigin(kind: "Origin" | "Referer", value: string, exampleLine: string) {
+  const key = `${kind}:${value}`;
+  if (announcedRejectedOrigins.has(key)) return;
+  announcedRejectedOrigins.add(key);
+  logger.warn(
+    `[csrf] Rejected request: ${kind} '${value}' is not in the trusted list. To allow this, add the following to your .env (no restart needed): ${exampleLine}`,
+  );
+}
 
 function firstHeader(value: string | string[] | undefined): string | null {
   if (!value) return null;
@@ -129,6 +142,12 @@ function canUseSameOriginCompatibility(
   return !!sourceOrigin && sourceOrigin === getRequestOrigin(request);
 }
 
+function originLine(origin: string): string {
+  // Suggest the exact .env line the operator should paste.
+  const normalized = normalizeOrigin(origin) ?? origin;
+  return `CSRF_TRUSTED_ORIGINS=${normalized}`;
+}
+
 export function csrfProtectionHook(request: FastifyRequest, reply: FastifyReply, done: () => void) {
   if (!UNSAFE_METHODS.has(request.method.toUpperCase())) return done();
   if (!request.url.startsWith("/api/")) return done();
@@ -143,23 +162,44 @@ export function csrfProtectionHook(request: FastifyRequest, reply: FastifyReply,
   }
   const secFetchSite = firstHeader(request.headers["sec-fetch-site"]);
   if (secFetchSite && !SAFE_FETCH_SITES.has(secFetchSite.toLowerCase()) && !originTrusted) {
-    reply.status(403).send({ error: "Cross-site unsafe requests are not allowed" });
+    const offender = origin ?? referer ?? "(unknown)";
+    if (origin || referer) announceRejectedOrigin(origin ? "Origin" : "Referer", offender, originLine(offender));
+    reply.status(403).send({
+      error: "Cross-site unsafe requests are not allowed",
+      origin: offender,
+      hint: origin || referer
+        ? `To allow this origin, add to .env (no restart needed): ${originLine(offender)}`
+        : "Browser did not send an Origin or Referer header — Marinara cannot verify this is a same-origin request.",
+    });
     return;
   }
 
   if (origin && !originTrusted) {
-    reply.status(403).send({ error: "Request origin is not trusted" });
+    announceRejectedOrigin("Origin", origin, originLine(origin));
+    reply.status(403).send({
+      error: `Origin '${origin}' is not in the trusted list (CSRF_TRUSTED_ORIGINS).`,
+      origin,
+      hint: `Add to .env (no restart needed): ${originLine(origin)}`,
+    });
     return;
   }
 
   if (!origin && referer && !originTrusted) {
-    reply.status(403).send({ error: "Request referer is not trusted" });
+    announceRejectedOrigin("Referer", referer, originLine(referer));
+    reply.status(403).send({
+      error: `Referer '${referer}' is not in the trusted list (CSRF_TRUSTED_ORIGINS).`,
+      referer,
+      hint: `Add to .env (no restart needed): ${originLine(referer)}`,
+    });
     return;
   }
 
   if ((origin || referer || secFetchSite) && !hasCsrfHeader(request)) {
     if (canUseSameOriginCompatibility(request, origin, referer, originTrusted, secFetchSite)) return done();
-    reply.status(403).send({ error: `Missing ${CSRF_HEADER} header` });
+    reply.status(403).send({
+      error: `Missing ${CSRF_HEADER} header`,
+      hint: `Marinara's frontend sends this header automatically. If you're calling the API from a script, set ${CSRF_HEADER}: ${CSRF_HEADER_VALUE}.`,
+    });
     return;
   }
 

--- a/packages/server/src/routes/connections.routes.ts
+++ b/packages/server/src/routes/connections.routes.ts
@@ -18,13 +18,13 @@ function resolveImageGenerationSource(conn: Record<string, unknown>, baseUrl: st
 function localUrlPolicyForProvider(provider: string, imageSource: string) {
   const isLocalImageBackend =
     provider === "image_generation" && (imageSource === "comfyui" || imageSource === "automatic1111");
+  const isImage = provider === "image_generation";
   return {
     allowLocal:
-      isLocalImageBackend || (provider === "image_generation" && isImageLocalUrlsEnabled())
-        ? true
-        : isProviderLocalUrlsEnabled(),
+      isLocalImageBackend || (isImage && isImageLocalUrlsEnabled()) ? true : isProviderLocalUrlsEnabled(),
     allowLoopback: true,
     allowedProtocols: ["https:", "http:"],
+    flagName: isImage ? "IMAGE_LOCAL_URLS_ENABLED" : "PROVIDER_LOCAL_URLS_ENABLED",
   };
 }
 
@@ -361,6 +361,7 @@ export async function connectionsRoutes(app: FastifyInstance) {
             allowLocal: isProviderLocalUrlsEnabled(),
             allowLoopback: true,
             allowedProtocols: ["https:", "http:"],
+            flagName: "PROVIDER_LOCAL_URLS_ENABLED",
           },
           maxResponseBytes: 5 * 1024 * 1024,
         });
@@ -394,6 +395,7 @@ export async function connectionsRoutes(app: FastifyInstance) {
           allowLocal: isProviderLocalUrlsEnabled(),
           allowLoopback: true,
           allowedProtocols: ["https:", "http:"],
+          flagName: "PROVIDER_LOCAL_URLS_ENABLED",
         },
         maxResponseBytes: 5 * 1024 * 1024,
       });

--- a/packages/server/src/routes/translate.routes.ts
+++ b/packages/server/src/routes/translate.routes.ts
@@ -118,6 +118,7 @@ async function translateWithDeepLX(input: z.infer<typeof translateSchema>) {
   await validateOutboundUrl(url, {
     allowLocal: isDeeplxLocalUrlsEnabled(),
     allowedProtocols: ["https:", "http:"],
+    flagName: "DEEPLX_LOCAL_URLS_ENABLED",
   }).catch((err) => {
     throw Object.assign(new Error(err instanceof Error ? err.message : "DeepLX URL is not allowed"), {
       statusCode: 400,
@@ -133,7 +134,11 @@ async function translateWithDeepLX(input: z.infer<typeof translateSchema>) {
       target_lang: input.targetLanguage.toUpperCase(),
     }),
     signal: AbortSignal.timeout(15_000),
-    policy: { allowLocal: isDeeplxLocalUrlsEnabled(), allowedProtocols: ["https:", "http:"] },
+    policy: {
+      allowLocal: isDeeplxLocalUrlsEnabled(),
+      allowedProtocols: ["https:", "http:"],
+      flagName: "DEEPLX_LOCAL_URLS_ENABLED",
+    },
     maxResponseBytes: 1024 * 1024,
   }).catch((err) => {
     if (err.name === "TimeoutError") throw Object.assign(new Error("DeepLX request timed out"), { statusCode: 502 });

--- a/packages/server/src/routes/tts.routes.ts
+++ b/packages/server/src/routes/tts.routes.ts
@@ -417,7 +417,11 @@ async function fetchElevenLabsVoiceOptions(
     const res = await safeFetch(url, {
       headers: elevenLabsHeaders(apiKey),
       signal: AbortSignal.timeout(10_000),
-      policy: { allowLocal: isTtsLocalUrlsEnabled(), allowedProtocols: ["https:", "http:"] },
+      policy: {
+        allowLocal: isTtsLocalUrlsEnabled(),
+        allowedProtocols: ["https:", "http:"],
+        flagName: "TTS_LOCAL_URLS_ENABLED",
+      },
       maxResponseBytes: 2 * 1024 * 1024,
     });
 
@@ -466,7 +470,11 @@ async function fetchProviderVoices(cfg: TTSConfig): Promise<TTSVoicesResponse> {
   const res = await safeFetch(`${base}/audio/voices`, {
     headers: openAiHeaders(cfg.apiKey),
     signal: AbortSignal.timeout(10_000),
-    policy: { allowLocal: allowLocalTtsUrl(cfg), allowedProtocols: ["https:", "http:"] },
+    policy: {
+      allowLocal: allowLocalTtsUrl(cfg),
+      allowedProtocols: ["https:", "http:"],
+      flagName: "TTS_LOCAL_URLS_ENABLED",
+    },
     maxResponseBytes: 2 * 1024 * 1024,
   });
 
@@ -629,7 +637,11 @@ export async function ttsRoutes(app: FastifyInstance) {
                   ...(speechInstructions ? { instructions: speechInstructions } : {}),
                 }),
         signal: AbortSignal.timeout(60_000),
-        policy: { allowLocal: allowLocalTtsUrl(cfg), allowedProtocols: ["https:", "http:"] },
+        policy: {
+      allowLocal: allowLocalTtsUrl(cfg),
+      allowedProtocols: ["https:", "http:"],
+      flagName: "TTS_LOCAL_URLS_ENABLED",
+    },
         maxResponseBytes: MAX_TTS_AUDIO_BYTES,
         allowedContentTypes: ["audio/", "application/octet-stream"],
       });

--- a/packages/server/src/services/image/image-generation.ts
+++ b/packages/server/src/services/image/image-generation.ts
@@ -189,6 +189,7 @@ function imageFetch(url: string | URL, init?: RequestInit, options: { allowLocal
       allowLocal: options.allowLocal ?? isImageLocalUrlsEnabled(),
       allowLoopback: true,
       allowedProtocols: ["https:", "http:"],
+      flagName: "IMAGE_LOCAL_URLS_ENABLED",
     },
     maxResponseBytes: MAX_IMAGE_RESPONSE_BYTES,
   });

--- a/packages/server/src/services/llm/base-provider.ts
+++ b/packages/server/src/services/llm/base-provider.ts
@@ -21,7 +21,12 @@ export function llmFetch(url: string | URL, init?: RequestInit): Promise<Respons
   return safeFetch(url, {
     ...(init ?? {}),
     agentOptions: llmAgentOptions,
-    policy: { allowLocal: isProviderLocalUrlsEnabled(), allowLoopback: true, allowedProtocols: ["https:", "http:"] },
+    policy: {
+      allowLocal: isProviderLocalUrlsEnabled(),
+      allowLoopback: true,
+      allowedProtocols: ["https:", "http:"],
+      flagName: "PROVIDER_LOCAL_URLS_ENABLED",
+    },
     maxResponseBytes: 50 * 1024 * 1024,
     bufferResponse: false,
   });

--- a/packages/server/src/services/tools/tool-executor.ts
+++ b/packages/server/src/services/tools/tool-executor.ts
@@ -164,6 +164,7 @@ async function executeCustomTool(tool: CustomToolDef, args: Record<string, unkno
           policy: {
             allowLocal,
             allowedProtocols: allowLocal ? ["https:", "http:"] : ["https:"],
+            flagName: "WEBHOOK_LOCAL_URLS_ENABLED",
           },
           maxResponseBytes: 512 * 1024,
         });

--- a/packages/server/src/utils/security.ts
+++ b/packages/server/src/utils/security.ts
@@ -31,6 +31,12 @@ export interface OutboundUrlPolicy {
   allowLoopback?: boolean;
   allowedProtocols?: string[];
   maxRedirects?: number;
+  /**
+   * Optional name of the env var that, when set to true, would allow this
+   * fetch. Surfaced verbatim in the rejection error so the user knows which
+   * flag to flip (e.g. PROVIDER_LOCAL_URLS_ENABLED, IMAGE_LOCAL_URLS_ENABLED).
+   */
+  flagName?: string;
 }
 
 export interface SafeFetchOptions extends Omit<RequestInit, "dispatcher"> {
@@ -242,33 +248,59 @@ function isBlockedResolvedAddress(address: string, policy: OutboundUrlPolicy): b
   return !(policy.allowLoopback && isLoopbackIp(address));
 }
 
+function flagHint(policy: OutboundUrlPolicy): string {
+  if (!policy.flagName) return "";
+  return ` Set ${policy.flagName}=true in your .env file to allow this (changes take effect within ~2s without a restart).`;
+}
+
+function describeBlockedAddresses(addresses: Array<{ address: string }>, policy: OutboundUrlPolicy): string {
+  const blocked = addresses.filter((record) => isBlockedResolvedAddress(record.address, policy)).map((record) => record.address);
+  if (blocked.length === 0) return "";
+  return ` (resolved to ${blocked.join(", ")})`;
+}
+
 async function validateResolvedAddresses(
   hostname: string,
   policy: OutboundUrlPolicy,
+  originalUrl?: string,
 ): Promise<Array<{ address: string; family: 4 | 6 }>> {
   const addresses = await resolveHostname(hostname);
+  if (!policy.allowLocal && addresses.length === 0) {
+    const target = originalUrl ?? hostname;
+    throw new Error(
+      `Refused to fetch ${target}: hostname '${hostname}' did not resolve to any address.${flagHint(policy)}`,
+    );
+  }
   if (
     !policy.allowLocal &&
-    (addresses.length === 0 || addresses.some((record) => isBlockedResolvedAddress(record.address, policy)))
+    addresses.some((record) => isBlockedResolvedAddress(record.address, policy))
   ) {
-    throw new Error("Outbound URL resolved to a private, loopback, metadata, or reserved address");
+    const target = originalUrl ?? hostname;
+    throw new Error(
+      `Refused to fetch ${target}: '${hostname}'${describeBlockedAddresses(addresses, policy)} is in a private, loopback, metadata, or reserved IP range.${flagHint(policy)}`,
+    );
   }
   return addresses;
 }
 
 export async function validateOutboundUrl(url: string | URL, policy: OutboundUrlPolicy = {}): Promise<URL> {
   const parsed = typeof url === "string" ? new URL(url) : new URL(url.toString());
+  const original = typeof url === "string" ? url : parsed.toString();
   const allowedProtocols = policy.allowedProtocols ?? ["https:"];
   if (!allowedProtocols.includes(parsed.protocol)) {
-    throw new Error(`Outbound URL protocol is not allowed: ${parsed.protocol}`);
+    throw new Error(
+      `Refused to fetch ${original}: protocol '${parsed.protocol.replace(/:$/, "")}' is not allowed (allowed: ${allowedProtocols.map((proto) => proto.replace(/:$/, "")).join(", ")}).${flagHint(policy)}`,
+    );
   }
 
   if (!policy.allowLocal) {
     if (isLocalHostname(parsed.hostname) && !(policy.allowLoopback && isLoopbackHostname(parsed.hostname))) {
-      throw new Error("Outbound URL hostname is local or reserved");
+      throw new Error(
+        `Refused to fetch ${original}: hostname '${parsed.hostname}' is local or reserved.${flagHint(policy)}`,
+      );
     }
 
-    await validateResolvedAddresses(parsed.hostname, policy);
+    await validateResolvedAddresses(parsed.hostname, policy, original);
   }
 
   return parsed;
@@ -282,7 +314,8 @@ async function validateOutboundUrlForFetch(
   const parsed = await validateOutboundUrl(url, policy);
   if (policy.allowLocal) return { url: parsed, dispatcher: agentOptions ? new Agent(agentOptions) : undefined };
 
-  const addresses = await validateResolvedAddresses(parsed.hostname, policy);
+  const original = typeof url === "string" ? url : parsed.toString();
+  const addresses = await validateResolvedAddresses(parsed.hostname, policy, original);
   let used = false;
   const dispatcher = new Agent({
     ...(agentOptions ?? {}),

--- a/packages/server/src/utils/security.ts
+++ b/packages/server/src/utils/security.ts
@@ -266,15 +266,16 @@ async function validateResolvedAddresses(
 ): Promise<Array<{ address: string; family: 4 | 6 }>> {
   const addresses = await resolveHostname(hostname);
   if (!policy.allowLocal && addresses.length === 0) {
+    // DNS failure (NXDOMAIN, SRV mismatch, etc.). Setting the local-URLs flag
+    // wouldn't help here, so don't tell the operator to flip it.
     const target = originalUrl ?? hostname;
-    throw new Error(
-      `Refused to fetch ${target}: hostname '${hostname}' did not resolve to any address.${flagHint(policy)}`,
-    );
+    throw new Error(`Refused to fetch ${target}: hostname '${hostname}' did not resolve to any address.`);
   }
   if (
     !policy.allowLocal &&
     addresses.some((record) => isBlockedResolvedAddress(record.address, policy))
   ) {
+    // Genuine policy.allowLocal-driven rejection — naming the flag is useful.
     const target = originalUrl ?? hostname;
     throw new Error(
       `Refused to fetch ${target}: '${hostname}'${describeBlockedAddresses(addresses, policy)} is in a private, loopback, metadata, or reserved IP range.${flagHint(policy)}`,
@@ -288,13 +289,17 @@ export async function validateOutboundUrl(url: string | URL, policy: OutboundUrl
   const original = typeof url === "string" ? url : parsed.toString();
   const allowedProtocols = policy.allowedProtocols ?? ["https:"];
   if (!allowedProtocols.includes(parsed.protocol)) {
+    // Protocol gate is independent of policy.allowLocal — flipping
+    // PROVIDER_LOCAL_URLS_ENABLED won't allow gopher://, ftp://, etc.
+    // Don't append the flag hint to this rejection.
     throw new Error(
-      `Refused to fetch ${original}: protocol '${parsed.protocol.replace(/:$/, "")}' is not allowed (allowed: ${allowedProtocols.map((proto) => proto.replace(/:$/, "")).join(", ")}).${flagHint(policy)}`,
+      `Refused to fetch ${original}: protocol '${parsed.protocol.replace(/:$/, "")}' is not allowed (allowed: ${allowedProtocols.map((proto) => proto.replace(/:$/, "")).join(", ")}).`,
     );
   }
 
   if (!policy.allowLocal) {
     if (isLocalHostname(parsed.hostname) && !(policy.allowLoopback && isLoopbackHostname(parsed.hostname))) {
+      // Genuine policy.allowLocal-driven rejection — naming the flag is useful.
       throw new Error(
         `Refused to fetch ${original}: hostname '${parsed.hostname}' is local or reserved.${flagHint(policy)}`,
       );


### PR DESCRIPTION
## Summary

Four recurring user complaints in #︱👓-ask-prof-mari over a 15h window all reduced to the same pattern: the user hit a network gate (SSRF, CSRF, or CORS), the rejection message didn't name the env var that controls it, and they had to ask in Discord or grep the source. This PR makes those failures self-serviceable: every rejection now names the exact env var and the exact line to paste into `.env`, the var takes effect without a restart, and the `.env` file itself auto-creates on first run so users can find it.

**Concretely fixes:**

- **grrthemis & ly.chan #1** (SSRF on `10.0.8.10`, `192.168.x.x`) — the SSRF rejection now reads `Refused to fetch http://10.0.8.10:1234: '10.0.8.10' (resolved to 10.0.8.10) is in a private … IP range. Set PROVIDER_LOCAL_URLS_ENABLED=true in your .env file …` instead of the previous generic message. (The block itself is unchanged — same IPs blocked, same flag re-allows them.)
- **ly.chan #2** (CSRF on character import) — the 403 body now has `error`, `origin`, and `hint` fields with the exact `CSRF_TRUSTED_ORIGINS=…` line to paste. `CSRF_TRUSTED_ORIGINS` was already hot-reloadable (per-request read).
- **gunterlie** (Bifrost behind nginx-proxy-manager) — three pain points addressed: SSRF rejection now self-explains, CORS rejection now self-explains, and `CORS_ORIGINS` is now hot-reloadable so they don't need to restart after pasting the suggested line. Plus same-origin auto-allow means a typical reverse-proxy setup (where Host is preserved) just works without any CORS config at all.
- **Everyone** — fresh installs that never ran `cp .env.example .env` no longer have to wonder where their config file is. An empty `.env` with a header pointing at `.env.example` is created on first boot.

## Screenshot — new SSRF error surfaced in the Connection Test UI

<!-- DRAG THE SCREENSHOT INTO THIS LINE → it will replace this comment with the uploaded image -->

## What changed (per change, with rationale)

### 1. `OutboundUrlPolicy` carries an optional `flagName`; SSRF errors include it

`packages/server/src/utils/security.ts`

Extended `OutboundUrlPolicy` with an optional `flagName?: string` field. The three rejection sites in `validateOutboundUrl` / `validateResolvedAddresses` now build error messages that:

- Quote the actual URL the operator tried to reach.
- For DNS-resolved blocks, list the resolved IP(s) that triggered the rejection (`'lmstudio.local' (resolved to 10.0.8.10)`).
- Append `Set ${flagName}=true in your .env file …` when `flagName` is set.

All five outbound-fetch dispatch sites pass the right flag for their provider type:

| Site | Flag |
|---|---|
| `services/llm/base-provider.ts` (LLM provider HTTP calls) | `PROVIDER_LOCAL_URLS_ENABLED` |
| `services/image/image-generation.ts` (image gen) | `IMAGE_LOCAL_URLS_ENABLED` |
| `routes/translate.routes.ts` (DeepLX) | `DEEPLX_LOCAL_URLS_ENABLED` |
| `routes/tts.routes.ts` (TTS, three sites) | `TTS_LOCAL_URLS_ENABLED` |
| `services/tools/tool-executor.ts` (custom-tool webhooks) | `WEBHOOK_LOCAL_URLS_ENABLED` |
| `routes/connections.routes.ts` (`localUrlPolicyForProvider`, used for connection tests / model lists) | `IMAGE_LOCAL_URLS_ENABLED` for image providers, otherwise `PROVIDER_LOCAL_URLS_ENABLED` |

**No security/policy change**: the same set of IPs is blocked, the same flags re-allow them. Only the user-facing error text changed.

### 2. CSRF rejection 403 bodies include the offending origin and a paste-able hint

`packages/server/src/middleware/csrf-protection.ts`

The four 403 sites (`Cross-site unsafe`, `Origin not trusted`, `Referer not trusted`, `Missing X-Marinara-CSRF`) now return JSON like:

```json
{
  "error": "Origin 'https://marinara.gunter.lan' is not in the trusted list (CSRF_TRUSTED_ORIGINS).",
  "origin": "https://marinara.gunter.lan",
  "hint": "Add to .env (no restart needed): CSRF_TRUSTED_ORIGINS=https://marinara.gunter.lan"
}
```

The server also logs a one-shot `[csrf]` warning per unique rejected origin (throttled via a per-process `Set` so a misbehaving client can't flood). That gives the operator the same diagnostic in their console without having to inspect the failing request body.

The "Missing X-Marinara-CSRF" branch additionally explains who needs that header: Marinara's frontend sends it automatically; non-browser callers (curl, Postman, scripts) must set it.

**No security change**: the gating logic is unchanged. Only the rejection text and a logging line are new.

### 3. `CORS_ORIGINS` is now hot-reloadable

`packages/server/src/config/cors-config.ts` (new), `packages/server/src/app.ts`, `packages/server/src/config/env-watcher.ts`

`@fastify/cors` was registered once at boot with a static `getCorsConfig()` value, so `CORS_ORIGINS` was on the env-watcher's `RESTART_REQUIRED_KEYS` list. Switched to `@fastify/cors`'s per-request delegator (the `register(cors, () => delegateFn)` pattern) so the trusted set is re-evaluated on every request. `CORS_ORIGINS` is no longer in `RESTART_REQUIRED_KEYS`.

**Documented caveat**: the `credentials` field is still bound at boot, so the rare transition between an explicit-origin list (`credentials=true`) and a wildcard `*` (`credentials=false`) still requires a restart for the `Access-Control-Allow-Credentials` header to flip. Adding/removing entries within either mode is hot-reloadable.

### 4. CORS auto-allows same-origin requests regardless of `CORS_ORIGINS`

Same files as (3). Surfaced by my own diagnostic in (3) — the previous code (and original `@fastify/cors` registration before this branch) only checked the configured origin list, so a request from `http://localhost:7860` to a server hosted at the same address was treated identically to a cross-site request. Most browsers tolerated this for simple GETs but POST preflights silently failed. The new diagnostic exposed the latent issue immediately when testing on Tailscale (`http://<tailscale-ip>:7860`).

The new `corsDelegate(req, callback)` decision order:

1. **No `Origin` header** → not a CORS request, allow.
2. **`Origin` matches the request's own `Host`** (true same-origin) → allow regardless of `CORS_ORIGINS`. The browser controls both `Origin` and `Host` for in-browser requests; they match iff the page is genuinely talking to itself, which is by definition not subject to CORS.
3. **`Origin` matches `CORS_ORIGINS`** (or `*`) → allow with the configured credentials policy.
4. **Otherwise** → reject; emit a one-shot `[cors] Rejected cross-origin request from '<origin>' …` log line with the exact `CORS_ORIGINS=…` line the operator should add.

**No security loosening**: same-origin is by definition not subject to CORS. Net behavior is permissive for browser flows that were already legal but were being incorrectly blocked, and unchanged for genuinely cross-origin requests.

A small fix-up commit (`3a0ae06`) corrected the `@fastify/cors` registration shape — the delegator API expects `register(cors, () => delegateFn)`, not the delegate inline. The latter was being interpreted as a Fastify plugin definition function and crashed at boot when the loader called it with no request.

### 5. Auto-create empty `.env` on first run

`packages/server/src/config/runtime-config.ts`

Users frequently asked "where's my `.env`?" because Marinara doesn't ship with one — they're expected to `cp .env.example .env`, but many never do. `loadRuntimeEnv()` now calls `ensureEnvFileExists()` before parsing, which creates an empty `.env` (with a header pointing at `.env.example`) at the monorepo root iff one doesn't already exist.

Header content:

```
# Marinara Engine - runtime configuration.
# This file is empty by design. Copy any setting you want to change from
# .env.example (same folder) and edit the value here. Most changes take
# effect within ~2 seconds without a restart.
```

Edge cases handled:

- **Read-only filesystem** (some Docker images, locked-down installer setups) → `try/catch` swallows the error, logs a warn, server continues. dotenv treats missing `.env` and empty `.env` identically, so this is purely best-effort.
- **Race condition between concurrent startups** → uses the `wx` (write-exclusive) flag, ignores `EEXIST`. The losing process moves on without retry.
- **Existing user `.env`** → `existsSync` check first; never overwritten, even if currently empty.
- **Watcher self-trigger** → the create runs at module load (very early); `startEnvWatcher()` attaches later in `index.ts`. No spurious "env changed" event from the auto-creation. On subsequent restarts the file exists, so creation is skipped entirely.

## Files changed

```
docs/CONFIGURATION.md                              |  2 +-
docs/REMOTE_ACCESS.md                              |  6 +-
packages/server/src/app.ts                         | 11 ++-
packages/server/src/config/cors-config.ts          | 98 ++++++++++++++++++++++   (new file)
packages/server/src/config/env-watcher.ts          |  8 +-
packages/server/src/config/runtime-config.ts       | 32 ++++++-
packages/server/src/middleware/csrf-protection.ts  | 48 ++++++++++-
packages/server/src/routes/connections.routes.ts   |  8 +-
packages/server/src/routes/translate.routes.ts     |  7 +-
packages/server/src/routes/tts.routes.ts           | 18 +++-
packages/server/src/services/image/image-generation.ts  |  1 +
packages/server/src/services/llm/base-provider.ts  |  7 +-
packages/server/src/services/tools/tool-executor.ts     |  1 +
packages/server/src/utils/security.ts              | 45 ++++++++--
14 files changed, 266 insertions(+), 26 deletions(-)
```

## Why this PR has zero security cost

- **SSRF**: error text changed; the `safeFetch` block list is byte-identical. The flags users learn to set (`PROVIDER_LOCAL_URLS_ENABLED` etc.) and the IPs they unblock are the same as before.
- **CSRF**: gate logic unchanged; only the 403 body and a one-shot warn line are new. Disclosing the offending origin in the error is fine — the client already saw it (it's their own request).
- **CORS**:
  - Same-origin auto-allow: the browser cannot spoof `Host` to differ from `Origin` for an in-browser request, so this is the canonical definition of same-origin and not subject to CORS by spec.
  - Hot-reload: same protection as before, just available without a restart.
  - Per-rejected-origin warning: pure log line, no functional change.
- **Auto-create `.env`**: a placeholder file with a comment header. dotenv treats missing and empty `.env` identically. Read-only filesystems fall back to "no .env" mode just like today.

## Related issues

- **Related to #492** (open) — `"name.local"` base URL for OAI-compatible endpoint fails with `"Outbound URL is local or reserved"`. This PR does not change which URLs are blocked (`.local` suffixes are still in the SSRF reserved list), but the rejection error now reads `Refused to fetch http://name.local:5001/v1: hostname 'name.local' is local or reserved. Set PROVIDER_LOCAL_URLS_ENABLED=true in your .env file (changes take effect within ~2s without a restart).` — so the operator can self-serve by pasting that flag into `.env`. Consider whether you'd rather upgrade this to `Closes #492` (treating the opt-in as the documented answer) or keep it as a partial mitigation pending a different fix that restores pre-1.5.7 unconditional `.local` access.
- **Addresses recurrence pattern of #394 / #396 / #398** (closed) — these three closed bugs were the same kind of "post-1.5.7 hardening blocked me, the error didn't tell me what to do" pattern: #394 was loopback-mistakenly-blocked SSRF, #396 was `Request Origin Not Trusted` after enabling `ALLOW_UNAUTHENTICATED_PRIVATE_NETWORK`, #398 was a duplicate of #396. They were each fixed individually in the past, but a future user hitting any of them again would get a clearer, self-serviceable error after this PR — the SSRF rejection names `PROVIDER_LOCAL_URLS_ENABLED`, the CSRF rejection names `CSRF_TRUSTED_ORIGINS` with the exact value to add. Linked here so this PR shows up in their search trail if the same pattern resurfaces.

## Notes

- The motivation for this PR isn't a single open issue. It's a pattern I noticed repeating in the #︱👓-ask-prof-mari Discord support channel: multiple users in the same 15-hour window couldn't find their `.env` file, and several others hit SSRF / CSRF / CORS rejections without knowing which env var would fix them. They eventually learned and resolved it (often after Mari pointed them at the relevant flag), but the friction was the recurring theme rather than any specific bug.
- Rebased on top of `main` after PR #463 (env hot-reload) and #464 (Tailscale/Docker auth bypass) merged. Builds cleanly on the current `main`.

## CodeRabbit review responses

CodeRabbit raised four comments on the original commits. Status:

1. **`cors-config.ts` — append-style hint instead of replace-style** ✅ Applied. The `[cors] Rejected …` log line now says `add '<origin>' to CORS_ORIGINS in your .env — comma-separated if you already have entries, e.g. CORS_ORIGINS=http://existing.example,<origin>`.
2. **`csrf-protection.ts` — same fix for `CSRF_TRUSTED_ORIGINS`** ✅ Applied. New `appendOriginHint()` helper used in both the server log and the 403 `hint` field.
3. **`security.ts` — `flagHint` only on policy-driven rejections** ✅ Applied. Removed from protocol-mismatch and DNS-failure errors (setting `PROVIDER_LOCAL_URLS_ENABLED=true` doesn't unblock `gopher://` or `NXDOMAIN`); kept on the two `policy.allowLocal`-gated rejections (local hostname / blocked resolved IP) where it's actually actionable.
4. **`security.ts` — redact resolved IPs from error messages** ❌ Declined. Marinara is single-tenant self-hosted: the operator submitting the URL is the same person reading the error. The resolved IP is the most useful debugging info ("oh, my LAN DNS resolved my hostname to a private IP, that's why it was blocked") — for the operator-debugging case the disclosure value is high, and for the hypothetical attacker case the disclosure value is roughly zero (the attacker put the URL in; they could just `nslookup` it themselves or test specific IPs directly). Keeping the IP in the error message.

## Test plan (manually verified)

- [x] **Auto-create `.env`**: starting with no `.env` in the test dir, server boots, `.env` is created with the documented header.
- [x] **Idempotent auto-create**: editing `.env` (e.g. adding `BASIC_AUTH_USER=alice`), restarting → user's edit is preserved, no overwrite.
- [x] **Same-origin from Tailscale**: visiting `http://<tailscale-ip>:7830` from a phone, doing POST flows (persona create, connection edit, etc.) — works without `CORS_ORIGINS` config and without `[cors] Rejected …` warnings in the server log.
- [x] **Same-origin from loopback**: `http://localhost:7830` POST flows work without warnings.
- [x] **SSRF error names `PROVIDER_LOCAL_URLS_ENABLED`**: connection test against an LLM connection pointing at a private IP returns the new self-explaining error (see screenshot above).
- [x] **SSRF unblock takes effect without restart**: after the failure, adding `PROVIDER_LOCAL_URLS_ENABLED=true` to `.env`, saving (no restart), and re-clicking "Test" → Marinara is no longer the one blocking.
- [x] **SSRF for image-gen names `IMAGE_LOCAL_URLS_ENABLED`**: same flow with an image-generation connection.
- [x] **CSRF rejection has paste-able hint**: visiting via a custom hostname and doing a POST returns the new structured 403 body and a one-shot `[csrf]` server warning.
- [x] **CSRF unblock takes effect without restart**: pasting the suggested `CSRF_TRUSTED_ORIGINS=…` line into `.env`, saving, retrying the POST → succeeds without restart.
- [x] **`CORS_ORIGINS` hot-reloadable**: editing `CORS_ORIGINS` in `.env` while the server is running shows `[env-watcher] Updated: CORS_ORIGINS=…` and does NOT show up in the "These variables changed but require a server restart" warning.
- [x] **CORS rejection diagnostic**: a genuine cross-origin request (origin not in `CORS_ORIGINS`, not same-origin) emits a one-shot `[cors] Rejected …` log line with the exact `CORS_ORIGINS=…` line to add.
- [x] **Tailscale auth-bypass still works**: `[auth-bypass] BYPASS_AUTH_TAILSCALE=true …` log line fires once on first request from a Tailnet IP; phone session works without Basic Auth (sanity check that PR #464 still functions).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * CORS configuration now hot-reloads without restart for most changes (except wildcard switching).
  * Same-origin requests are automatically allowed based on Host matching.
  * `.env` file is auto-created on startup if missing.

* **Improvements**
  * Error messages now include actionable `.env` configuration hints for CORS, CSRF, and network issues.
  * Enhanced troubleshooting documentation with specific remediation steps.

* **Documentation**
  * Updated configuration guide with clarity on which settings require restarts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->