### PR TITLE
fix(client): hide raw conversation streaming buffer

### DIFF
--- a/packages/client/src/components/chat/ConversationView.tsx
+++ b/packages/client/src/components/chat/ConversationView.tsx
@@ -162,6 +162,16 @@ export function ConversationView({
   const streamingCharacterId = useChatStore((s) => s.streamingCharacterId);
   const typingCharacterName = useChatStore((s) => s.typingCharacterName);
   const delayedCharacterInfo = useChatStore((s) => s.delayedCharacterInfo);
+  const liveTypingName = useMemo(() => {
+    if (typingCharacterName) return typingCharacterName;
+    if (streamingCharacterId) return characterMap.get(streamingCharacterId)?.name ?? "Character";
+    if (chatCharIds.length === 1) return characterMap.get(chatCharIds[0]!)?.name ?? "Character";
+    if (characterNames.length > 0) return characterNames.join(", ");
+    return "Character";
+  }, [characterMap, characterNames, chatCharIds, streamingCharacterId, typingCharacterName]);
+  const liveTypingVerb = liveTypingName.includes(",") || liveTypingName.includes(" & ") ? "are" : "is";
+  const showTypingIndicator =
+    isStreaming && !delayedCharacterInfo && (!regenerateMessageId || (!streamBuffer && !thinkingBuffer));
 
   // ── Periodic status refresh (every 60s) ──
   // Keeps status dots in sync with the character's schedule regardless of autonomous messaging
@@ -425,7 +435,7 @@ export function ConversationView({
     setHiddenLineKeys(new Set());
   }
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const currentKeys = new Set(renderedItems.filter((i) => i.type === "message").map((i) => i.key));
 
     // On the very first render that has messages, just snapshot the keys and
@@ -838,7 +848,7 @@ export function ConversationView({
         )}
 
         {/* Typing indicator — shown when generation is actively running */}
-        {isStreaming && !streamBuffer && !thinkingBuffer && typingCharacterName && (
+        {showTypingIndicator && (
           <div className="flex items-center gap-2 px-4 py-1.5 text-[0.8125rem] text-[var(--text-secondary)]">
             <span className="flex gap-0.5">
               <span
@@ -854,34 +864,10 @@ export function ConversationView({
                 style={{ animationDelay: "300ms" }}
               />
             </span>
-            <span className="italic">{typingCharacterName} is typing...</span>
+            <span className="italic">
+              {liveTypingName} {liveTypingVerb} typing...
+            </span>
           </div>
-        )}
-
-        {/* Streaming message — only shown once actual content starts arriving */}
-        {isStreaming && !regenerateMessageId && (streamBuffer || thinkingBuffer) && (
-          <ConversationMessage
-            message={{
-              id: "__streaming__",
-              chatId,
-              role: "assistant",
-              characterId: streamingCharacterId ?? chatCharIds[0] ?? null,
-              content: streamBuffer || "Thinking...",
-              activeSwipeIndex: 0,
-              extra: {
-                displayText: null,
-                isGenerated: true,
-                tokenCount: 0,
-                generationInfo: null,
-                thinking: thinkingBuffer || null,
-              },
-              createdAt: new Date().toISOString(),
-            }}
-            isStreaming
-            characterMap={characterMap}
-            personaInfo={personaInfo as any}
-            chatCharacterIds={chatCharIds}
-          />
         )}
 
         {/* Scene banner — inline at bottom of messages (origin variant only) */}

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -347,6 +347,15 @@ function parseChatMetadata(metadata: Chat["metadata"] | string | null | undefine
   return metadata as Record<string, unknown>;
 }
 
+function getCachedChatMode(qc: QueryClient, chatId: string): Chat["mode"] | undefined {
+  const detail = qc.getQueryData<Chat>(chatKeys.detail(chatId));
+  if (detail?.mode) return detail.mode;
+  const activeChat = useChatStore.getState().activeChat;
+  if (activeChat?.id === chatId) return activeChat.mode;
+  const list = qc.getQueryData<Chat[]>(chatKeys.list());
+  return list?.find((chat) => chat.id === chatId)?.mode;
+}
+
 function slugifyGameMapId(value: string): string {
   return value
     .trim()
@@ -565,6 +574,8 @@ export function useGenerate() {
       // Speed is controlled by the user's streamingSpeed setting (1–100).
       const transportStreaming = useUIStore.getState().enableStreaming;
       const streamingEnabled = transportStreaming;
+      const shouldDisplayRawStream =
+        getCachedChatMode(qc, params.chatId) !== "conversation" || !!params.regenerateMessageId;
       let fullBuffer = ""; // What the user sees (or accumulates silently when streaming is off)
       let pendingText = ""; // Tokens waiting to be typed out
       let receivedContent = false; // Whether any actual message content was received
@@ -619,7 +630,7 @@ export function useGenerate() {
         fullBuffer += pendingText;
         pendingText = "";
         typingActive = false;
-        if (streamingEnabled && fullBuffer) setStreamBuffer(fullBuffer, params.chatId);
+        if (streamingEnabled && shouldDisplayRawStream && fullBuffer) setStreamBuffer(fullBuffer, params.chatId);
       };
 
       const startTypewriter = () => {
@@ -750,7 +761,7 @@ export function useGenerate() {
 
               if (!chunk) break;
 
-              if (streamingEnabled) {
+              if (streamingEnabled && shouldDisplayRawStream) {
                 pendingText += chunk;
                 startTypewriter();
               } else {
@@ -1086,7 +1097,7 @@ export function useGenerate() {
                   }
                 }
                 fullBuffer = rw.editedText;
-                if (streamingEnabled) setStreamBuffer(rw.editedText, params.chatId);
+                if (streamingEnabled && shouldDisplayRawStream) setStreamBuffer(rw.editedText, params.chatId);
               }
               break;
             }
@@ -1100,7 +1111,7 @@ export function useGenerate() {
                 typingActive = false;
               }
               fullBuffer = cleanContent;
-              if (streamingEnabled) setStreamBuffer(cleanContent, params.chatId);
+              if (streamingEnabled && shouldDisplayRawStream) setStreamBuffer(cleanContent, params.chatId);
               break;
             }
 
@@ -1353,7 +1364,7 @@ export function useGenerate() {
         }
 
         // Wait for typewriter to finish draining pending text (streaming mode only)
-        if (streamingEnabled && isActiveChat() && (pendingText.length > 0 || typingActive)) {
+        if (streamingEnabled && shouldDisplayRawStream && isActiveChat() && (pendingText.length > 0 || typingActive)) {
           await new Promise<void>((resolve) => {
             if (pendingText.length === 0 && !typingActive) {
               resolve();
@@ -1364,7 +1375,7 @@ export function useGenerate() {
           });
         }
         // Final flush — ensure full content is set (only for the viewed chat)
-        if (streamingEnabled) setStreamBuffer(fullBuffer + pendingText, params.chatId);
+        if (streamingEnabled && shouldDisplayRawStream) setStreamBuffer(fullBuffer + pendingText, params.chatId);
       } catch (error) {
         // Flush everything instantly on error so user sees what arrived
         flushTypewriterBuffer();


### PR DESCRIPTION
## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->
Nobody reported it yet, but I got Luka to repro the bug and confirm I'm not just tripping. I think my earlier change to Conversation Send button becoming regenerate caused the underlying bug to surface. Maybe. I really hope I didn't cause it, lol

Closes #
## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- Fixes Conversation mode briefly showing the full raw streamed assistant response before replacing it with the intended staggered message bubbles.
- Keeps Conversation mode behavior closer to texting: typing indicator first, then saved messages appear in staggered chunks.

## What changed

<!-- List the key changes in this PR -->

- Stopped Conversation mode from rendering the raw `streamBuffer` as a temporary assistant message during normal generation.
- Kept raw stream display available outside Conversation mode, and for in-place regeneration flows where it is still expected.
- Kept a typing indicator visible while Conversation mode generation is running.
- Changed stagger setup from `useEffect` to `useLayoutEffect` so hidden split bubbles are applied before the browser paints.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [X] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [X] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [X] Above manual verification completed (describe below)
- [X] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Ran `pnpm check` locally; it passed.
- Started the dev app against the test data directory.
- Manually tested a Conversation mode response and confirmed the raw full response no longer appears before the staggered bubbles.
- User confirmed the fix appears to work in-app.

## Docs and release impact

- [X] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved typing indicator display to show multiple character names with proper pluralization
  * Enhanced timing synchronization for message display updates
  * Refined raw streaming output display behavior to prevent unwanted text in conversation chats

<!-- end of auto-generated comment: release notes by coderabbit.ai -->