### PR TITLE
fix(diagnostics): bound the rejection-announce caches + unify CSRF 403 schema

### DIFF
--- a/packages/server/src/config/cors-config.ts
+++ b/packages/server/src/config/cors-config.ts
@@ -21,10 +21,19 @@ import type { FastifyRequest } from "fastify";
 import { getCorsConfig, getServerProtocol } from "./runtime-config.js";
 import { logger } from "../lib/logger.js";
 
+// Bounded log throttle: same pattern as csrf-protection.ts. Each unique
+// rejected origin is logged once. When the cap is reached we drop the oldest
+// entry (Set preserves insertion order) so a stream of attacker-controlled
+// origins can't grow process memory without bound.
+const MAX_ANNOUNCED_REJECTED_ORIGINS = 2048;
 const announcedRejectedOrigins = new Set<string>();
 
 function announceRejectedOrigin(origin: string) {
   if (announcedRejectedOrigins.has(origin)) return;
+  if (announcedRejectedOrigins.size >= MAX_ANNOUNCED_REJECTED_ORIGINS) {
+    const oldest = announcedRejectedOrigins.values().next().value;
+    if (oldest !== undefined) announcedRejectedOrigins.delete(oldest);
+  }
   announcedRejectedOrigins.add(origin);
   logger.warn(
     `[cors] Rejected cross-origin request from '${origin}' (not in CORS_ORIGINS, not same-origin). ` +

--- a/packages/server/src/middleware/csrf-protection.ts
+++ b/packages/server/src/middleware/csrf-protection.ts
@@ -8,11 +8,20 @@ const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 const SAFE_FETCH_SITES = new Set(["same-origin", "same-site", "none"]);
 
 // Throttle "origin not trusted" log lines so a misbehaving client can't flood
-// the log. Each unique origin is announced once per process.
+// the log. Each unique origin is announced once. The cache is bounded so an
+// attacker streaming unique origins can't grow process memory without bound;
+// when the cap is reached we drop the oldest entry (Set preserves insertion
+// order), which means a fresh origin from a long-lived attacker may eventually
+// re-log once — acceptable trade-off for log volume vs. memory.
+const MAX_ANNOUNCED_REJECTED_ORIGINS = 2048;
 const announcedRejectedOrigins = new Set<string>();
 function announceRejectedOrigin(kind: "Origin" | "Referer", value: string, hint: string) {
   const key = `${kind}:${value}`;
   if (announcedRejectedOrigins.has(key)) return;
+  if (announcedRejectedOrigins.size >= MAX_ANNOUNCED_REJECTED_ORIGINS) {
+    const oldest = announcedRejectedOrigins.values().next().value;
+    if (oldest !== undefined) announcedRejectedOrigins.delete(oldest);
+  }
   announcedRejectedOrigins.add(key);
   logger.warn(`[csrf] Rejected request: ${kind} '${value}' is not in the trusted list. ${hint}`);
 }
@@ -189,9 +198,13 @@ export function csrfProtectionHook(request: FastifyRequest, reply: FastifyReply,
 
   if (!origin && referer && !originTrusted) {
     announceRejectedOrigin("Referer", referer, appendOriginHint(referer));
+    // Use the same `origin` key as the sibling branches even though this
+    // rejection was driven by the Referer header. Stable schema for clients
+    // parsing 403 bodies; the error string still names "Referer" so the
+    // operator knows which header carried the offending value.
     reply.status(403).send({
       error: `Referer '${referer}' is not in the trusted list (CSRF_TRUSTED_ORIGINS).`,
-      referer,
+      origin: referer,
       hint: appendOriginHint(referer),
     });
     return;


### PR DESCRIPTION
## Summary

Two follow-ups from CodeRabbit's post-merge review of #507:

1. **Bound the one-shot log-throttle Sets** in `csrf-protection.ts` and `cors-config.ts`. They were keyed by attacker-controlled strings (Origin / Referer values) so a long-lived client streaming unique values could grow process memory without bound. Both sites now hold at most 2048 entries and drop the oldest when full (Set's insertion order acts as a FIFO). The rare case of a fresh origin from a long-lived attacker eventually re-logging once is an acceptable trade-off for unbounded growth.
2. **Normalise the CSRF 403 body schema.** The "Referer not trusted" branch was returning a `referer` field while the sibling branches returned `origin`. Clients parsing the body had to handle both keys. Standardised on `origin` (the error string still names "Referer" so the operator knows which header carried the offending value).

## Why

Both items were flagged by CodeRabbit's second review pass after #507 merged:

- **Bounded cache** ([review comment](https://github.com/Pasta-Devs/Marinara-Engine/pull/507#discussion_r3199802801)) — flagged on the CSRF site only, but the same exact pattern existed in `cors-config.ts`. Fixing both for consistency rather than waiting for the next review round.
- **Schema consistency** ([review comment](https://github.com/Pasta-Devs/Marinara-Engine/pull/507#discussion_r3199802808)) — minor but real footgun for any client doing programmatic 403 parsing.

## What changed

- `packages/server/src/middleware/csrf-protection.ts` — added `MAX_ANNOUNCED_REJECTED_ORIGINS = 2048` cap with FIFO eviction in `announceRejectedOrigin`. Renamed the 403 `referer` field to `origin` for the Referer-not-trusted branch.
- `packages/server/src/config/cors-config.ts` — same cap + FIFO eviction pattern in the cross-origin announce site (proactive, not flagged but identical code).

## Notes

- No security or behaviour change beyond what's described above. The cap of 2048 is large enough that a normally-functioning install will never reach it (legitimate origins per process are typically a handful); it kicks in only under adversarial flooding.
- Eviction is FIFO via `Set.values().next()` (Set preserves insertion order in JS). Could be upgraded to LRU later if we ever see real-world recycling patterns, but that's overkill for a log-throttle cache.
- Builds clean against current `main` (rebased after the unrelated `base-provider.ts` / `context-fit.test.ts` merge).

## Test plan

- [x] Manually verify the CSRF 403 body for a referer-only request now returns `origin: "<value>"` and not `referer: "<value>"`. (Easiest: hit any POST to `/api/...` from a browser context where the page strips Origin but leaves Referer; or curl with `--referer https://other.example` and no Origin.)
- [x] Manually verify the CORS rejection log line (`[cors] Rejected cross-origin request from …`) still fires for cross-origin requests not in `CORS_ORIGINS`.
- [x] Manually verify the CSRF rejection log line (`[csrf] Rejected request: Origin '…' is not in the trusted list. …`) still fires for requests whose Origin is unknown.
- [x] Sanity-check that the bounded cache doesn't break the throttle: hit Marinara from the same untrusted origin twice in a row; confirm the warning fires once, not twice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential unbounded memory growth by implementing bounded logging for rejected requests. Oldest entries are automatically removed when capacity is exceeded.
  * Added rate-limiting to prevent excessive security-related warning logs, improving system stability and reducing noise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->