### PR TITLE
Add option to use CYOA choices as impersonate directions

### DIFF
--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -5074,6 +5074,8 @@ function ImpersonateSettingsContent({
   const setPromptTemplate = useUIStore((s) => s.setImpersonatePromptTemplate);
   const showQuickButton = useUIStore((s) => s.impersonateShowQuickButton);
   const setShowQuickButton = useUIStore((s) => s.setImpersonateShowQuickButton);
+  const cyoaChoices = useUIStore((s) => s.impersonateCyoaChoices);
+  const setCyoaChoices = useUIStore((s) => s.setImpersonateCyoaChoices);
   const presetId = useUIStore((s) => s.impersonatePresetId);
   const setPresetId = useUIStore((s) => s.setImpersonatePresetId);
   const connectionId = useUIStore((s) => s.impersonateConnectionId);
@@ -5197,6 +5199,21 @@ function ImpersonateSettingsContent({
             />
             <span onClick={(e) => e.preventDefault()}>
               <HelpTooltip text="When enabled, the agent pipeline (trackers, lorebook routers, etc.) is suppressed during impersonate so generations stay fast and don't trigger world-state mutations." />
+            </span>
+          </span>
+        </label>
+
+        <label className="order-5 flex min-h-[2.875rem] min-w-0 items-center justify-between gap-2 rounded-lg bg-[var(--secondary)]/25 px-2.5 py-1.5 text-xs font-semibold ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)]/40 sm:col-span-2">
+          <span className="min-w-0">Use CYOA as direction</span>
+          <span className="flex shrink-0 items-center gap-1.5">
+            <input
+              type="checkbox"
+              checked={cyoaChoices}
+              onChange={(e) => setCyoaChoices(e.target.checked)}
+              className="h-3.5 w-3.5 rounded border-[var(--border)] accent-[var(--primary)]"
+            />
+            <span onClick={(e) => e.preventDefault()}>
+              <HelpTooltip text="When enabled, clicking a CYOA option uses it as the direction for an impersonate generation instead of sending the option as a normal user message." />
             </span>
           </span>
         </label>

--- a/packages/client/src/components/chat/CyoaChoices.tsx
+++ b/packages/client/src/components/chat/CyoaChoices.tsx
@@ -7,6 +7,7 @@ import { useUpdateMessageExtra } from "../../hooks/use-chats";
 import { useAgentStore } from "../../stores/agent.store";
 import { useGenerate } from "../../hooks/use-generate";
 import { useChatStore } from "../../stores/chat.store";
+import { useUIStore } from "../../stores/ui.store";
 import type { Message } from "@marinara-engine/shared";
 
 type CyoaChoice = {
@@ -34,6 +35,7 @@ export function CyoaChoices({ messages }: Props) {
   const { generate, retryAgents } = useGenerate();
   const activeChatId = useChatStore((s) => s.activeChatId);
   const isStreaming = useChatStore((s) => s.isStreaming);
+  const impersonateCyoaChoices = useUIStore((s) => s.impersonateCyoaChoices);
   const updateMessageExtra = useUpdateMessageExtra(activeChatId);
   const [isEditing, setIsEditing] = useState(false);
   const [isRerolling, setIsRerolling] = useState(false);
@@ -96,13 +98,30 @@ export function CyoaChoices({ messages }: Props) {
     async (text: string) => {
       if (!activeChatId || isStreaming || isEditing) return;
       clearCyoaChoices();
+      if (impersonateCyoaChoices) {
+        const { impersonatePresetId, impersonateConnectionId, impersonateBlockAgents, impersonatePromptTemplate } =
+          useUIStore.getState();
+        const trimmedPromptTemplate = impersonatePromptTemplate.trim();
+        await generate({
+          chatId: activeChatId,
+          connectionId: null,
+          impersonate: true,
+          userMessage: text,
+          ...(impersonatePresetId ? { impersonatePresetId } : {}),
+          ...(impersonateConnectionId ? { impersonateConnectionId } : {}),
+          ...(impersonateBlockAgents ? { impersonateBlockAgents: true } : {}),
+          ...(trimmedPromptTemplate ? { impersonatePromptTemplate: trimmedPromptTemplate } : {}),
+        });
+        return;
+      }
+
       await generate({
         chatId: activeChatId,
         connectionId: null,
         userMessage: text,
       });
     },
-    [activeChatId, isStreaming, isEditing, clearCyoaChoices, generate],
+    [activeChatId, isStreaming, isEditing, impersonateCyoaChoices, clearCyoaChoices, generate],
   );
 
   const handleReroll = useCallback(async () => {
@@ -159,6 +178,11 @@ export function CyoaChoices({ messages }: Props) {
           <Sparkles size="0.625rem" />
           <span>What will you do?</span>
         </div>
+        {impersonateCyoaChoices && (
+          <span className="rounded-full border border-purple-400/20 bg-purple-500/10 px-1.5 py-0.5 text-[0.5625rem] font-semibold text-purple-700 dark:text-purple-200">
+            Impersonate
+          </span>
+        )}
         <button
           type="button"
           onClick={isEditing ? handleCancelEdit : handleStartEdit}

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -279,6 +279,8 @@ interface UIState {
   impersonatePromptTemplate: string;
   /** Show a quick /impersonate button in the chat input toolbar. Persisted. */
   impersonateShowQuickButton: boolean;
+  /** When true, CYOA choices generate impersonate requests instead of normal user messages. Persisted. */
+  impersonateCyoaChoices: boolean;
   /** Override preset used when impersonating (null = use chat default). Persisted. */
   impersonatePresetId: string | null;
   /** Override connection used when impersonating (null = use chat default). Persisted. */
@@ -386,6 +388,7 @@ interface UIState {
   // Impersonate settings actions
   setImpersonatePromptTemplate: (v: string) => void;
   setImpersonateShowQuickButton: (v: boolean) => void;
+  setImpersonateCyoaChoices: (v: boolean) => void;
   setImpersonatePresetId: (id: string | null) => void;
   setImpersonateConnectionId: (id: string | null) => void;
   setImpersonateBlockAgents: (v: boolean) => void;
@@ -480,6 +483,7 @@ export function pickSyncedSettings(state: UIState) {
     scheduleGenerationPreferences: state.scheduleGenerationPreferences,
     impersonatePromptTemplate: state.impersonatePromptTemplate,
     impersonateShowQuickButton: state.impersonateShowQuickButton,
+    impersonateCyoaChoices: state.impersonateCyoaChoices,
     impersonatePresetId: state.impersonatePresetId,
     impersonateConnectionId: state.impersonateConnectionId,
     impersonateBlockAgents: state.impersonateBlockAgents,
@@ -588,6 +592,7 @@ export const useUIStore = create<UIState>()(
       // Impersonate settings defaults
       impersonatePromptTemplate: "",
       impersonateShowQuickButton: false,
+      impersonateCyoaChoices: false,
       impersonatePresetId: null,
       impersonateConnectionId: null,
       impersonateBlockAgents: false,
@@ -866,6 +871,7 @@ export const useUIStore = create<UIState>()(
       setHudPosition: (v) => set({ hudPosition: v }),
       setImpersonatePromptTemplate: (v) => set({ impersonatePromptTemplate: v }),
       setImpersonateShowQuickButton: (v) => set({ impersonateShowQuickButton: v }),
+      setImpersonateCyoaChoices: (v) => set({ impersonateCyoaChoices: v }),
       setImpersonatePresetId: (id) => set({ impersonatePresetId: id }),
       setImpersonateConnectionId: (id) => set({ impersonateConnectionId: id }),
       setImpersonateBlockAgents: (v) => set({ impersonateBlockAgents: v }),
@@ -895,7 +901,7 @@ export const useUIStore = create<UIState>()(
     }),
     {
       name: "marinara-engine-ui",
-      version: 18,
+      version: 19,
       // Debounce localStorage writes to avoid sync I/O on every state change
       storage: createJSONStorage(() => {
         let timer: ReturnType<typeof setTimeout> | null = null;
@@ -1070,6 +1076,10 @@ export const useUIStore = create<UIState>()(
             persisted.hasMigratedExtensionsToServer = false;
           }
         }
+        // v18 -> v19: let CYOA choices opt into impersonate generation.
+        if (version <= 18) {
+          if (persisted.impersonateCyoaChoices === undefined) persisted.impersonateCyoaChoices = false;
+        }
         return persisted;
       },
       partialize: (state) => ({
@@ -1143,6 +1153,7 @@ export const useUIStore = create<UIState>()(
         scheduleGenerationPreferences: state.scheduleGenerationPreferences,
         impersonatePromptTemplate: state.impersonatePromptTemplate,
         impersonateShowQuickButton: state.impersonateShowQuickButton,
+        impersonateCyoaChoices: state.impersonateCyoaChoices,
         impersonatePresetId: state.impersonatePresetId,
         impersonateConnectionId: state.impersonateConnectionId,
         impersonateBlockAgents: state.impersonateBlockAgents,


### PR DESCRIPTION
When enabled in the impersonate settings, clicking a CYOA option triggers an impersonate generation using the configured preset, connection, and prompt template instead of sending the option as a normal user message. Bumps UI store schema to v19.

## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->
None, I just wanted it.

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- Lets users click generated CYOA choices as directions for `/impersonate`, so the choice guides a generated user/persona reply instead of always sending a normal user message.

## What changed

<!-- List the key changes in this PR -->

- Added an impersonate setting: “Use CYOA as direction”.
- Persisted and synced the new setting through the UI store.
- Updated CYOA choice clicks to call impersonate generation when the setting is enabled.
- Added a small “Impersonate” badge when CYOA choices are currently in impersonate mode.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [X] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [X] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [X] Above manual verification completed (describe below)
- [X] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Started roleplay chat with CYOA enabled.
- Verified choosing CYOA choice maintains regular behavior.
- Enabled "Use CYOA as direction" and chose a CYOA option.
- Verified choice was used as impersonation direction and generated a user message accordingly.
- Disabled setting, chose CYOA option, normal behavior resumed.

## Docs and release impact

- [X] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

<!-- Add before/after screenshots or recordings for UI changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Use CYOA as direction" setting in chat preferences to enable CYOA choices as impersonation triggers.
  * When enabled, selecting a CYOA option initiates an impersonate request instead of sending a standard message.
  * Setting syncs across devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->