### PR TITLE
Log TTS provider request failures

### DIFF
--- a/packages/server/src/routes/tts.routes.ts
+++ b/packages/server/src/routes/tts.routes.ts
@@ -648,6 +648,7 @@ export async function ttsRoutes(app: FastifyInstance) {
     } catch (err: unknown) {
       const msg =
         err instanceof Error && err.name === "TimeoutError" ? "TTS request timed out" : "TTS provider unreachable";
+      req.log.warn({ err }, "TTS provider request failed");
       return reply.status(502).send({ error: msg });
     }
 

--- a/packages/server/src/routes/tts.routes.ts
+++ b/packages/server/src/routes/tts.routes.ts
@@ -648,7 +648,7 @@ export async function ttsRoutes(app: FastifyInstance) {
     } catch (err: unknown) {
       const msg =
         err instanceof Error && err.name === "TimeoutError" ? "TTS request timed out" : "TTS provider unreachable";
-      req.log.warn({ err }, "TTS provider request failed");
+      req.log.error(err, "TTS provider request failed");
       return reply.status(502).send({ error: msg });
     }
 


### PR DESCRIPTION
## Linked issue

Closes #524

## Why this change

- Adding or previewing TTS can return `502 TTS provider unreachable` when the configured provider request fails before a provider response is available.
- Docker/server logs previously only showed the completed 502 request, which left operators without the sanitized provider/safeFetch failure reason needed to debug local URL blocking, DNS failures, refused connections, or timeouts.

## What changed

- Log caught `/api/tts/speak` provider request failures through the request logger before returning the existing 502 response.
- Keep the client response shape unchanged.

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Machine verification: `pnpm --dir packages/server exec tsx scratch/issue-524-tts-diagnostics-repro.ts` reproduced the TTS 502 path with `diagnosticLogCount: 0` before the fix.
- Machine verification: `EXPECT_TTS_DIAGNOSTIC_LOG=1 pnpm --dir packages/server exec tsx scratch/issue-524-tts-diagnostics-repro.ts` passed after the fix with `diagnosticLogCount: 1`.
- Baseline validation: `pnpm check` passed locally.
- Container validation: covered by GitHub `container-build-test`, which passed.
- App click-through: not applicable; this is a backend logging/diagnostics fix with no user-visible UI state change.
- Edge cases: the relevant provider failure/error path was covered by the scratch repro; light/dark/mobile/empty-state UI checks are not applicable to this backend-only change.
- No human-only verification is required for the core claim. This is a backend logging/diagnostics fix with no UI state change.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

N/A - backend diagnostics/logging fix only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Text-to-Speech service now delivers appropriate error messages when the provider is unreachable or the request times out, with improved diagnostic logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
