### PR TITLE
Fix llama.cpp embedding response parsing

### DIFF
--- a/packages/server/src/services/llm/base-provider.ts
+++ b/packages/server/src/services/llm/base-provider.ts
@@ -608,9 +608,23 @@ export abstract class BaseLLMProvider {
       const body = await res.text();
       throw new Error(`Embedding request failed (${res.status}): ${sanitizeApiError(body)}`);
     }
-    const json = (await res.json()) as { data: Array<{ embedding: number[] }> };
-    return json.data.map((d) => d.embedding);
+    const json = await res.json();
+    return parseEmbeddingResponse(json);
   }
+}
+
+export function parseEmbeddingResponse(json: unknown): number[][] {
+  const data = Array.isArray(json) ? json : isPlainRecord(json) ? json.data : undefined;
+  if (!Array.isArray(data)) {
+    throw new Error("Embedding response did not include an embedding array.");
+  }
+
+  return data.map((item) => {
+    if (!isPlainRecord(item) || !Array.isArray(item.embedding)) {
+      throw new Error("Embedding response contained an invalid embedding item.");
+    }
+    return item.embedding as number[];
+  });
 }
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/server/test/embedding-response.test.ts
+++ b/packages/server/test/embedding-response.test.ts
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { parseEmbeddingResponse } from "../src/services/llm/base-provider.js";
+
+test("parseEmbeddingResponse accepts OpenAI-compatible data wrappers", () => {
+  assert.deepEqual(parseEmbeddingResponse({ data: [{ embedding: [0.1, 0.2] }] }), [[0.1, 0.2]]);
+});
+
+test("parseEmbeddingResponse accepts llama.cpp /embeddings arrays", () => {
+  assert.deepEqual(parseEmbeddingResponse([{ embedding: [0.3, 0.4] }]), [[0.3, 0.4]]);
+});
+
+test("parseEmbeddingResponse rejects invalid response shapes with a clear error", () => {
+  assert.throws(() => parseEmbeddingResponse({ embedding: [0.1, 0.2] }), /embedding array/i);
+  assert.throws(() => parseEmbeddingResponse({ data: [{ value: [0.1, 0.2] }] }), /invalid embedding item/i);
+});


### PR DESCRIPTION
## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #534

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- Lorebook Vectorize can call OpenAI-compatible embedding endpoints served by llama.cpp. llama.cpp's `/embeddings` response can be a top-level array of `{ embedding }` items, while Marinara only accepted the OpenAI `/v1/embeddings` `{ data: [...] }` wrapper and crashed with `Cannot read properties of undefined (reading 'map')`.

## What changed

<!-- List the key changes in this PR -->

- Normalized embedding responses in the shared provider path so both OpenAI `{ data: [{ embedding }] }` responses and llama.cpp `[{ embedding }]` responses are accepted.
- Added focused server tests for OpenAI-shaped responses, llama.cpp-shaped responses, and malformed provider responses.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Reproduced the issue before the fix with `pnpm --dir packages/server exec tsx ..\..\scratch\issue-534-embed-repro.ts` against a local mock llama.cpp-style `/embeddings` endpoint. Before the fix it returned `{"ok":false,"error":"Cannot read properties of undefined (reading 'map')"}`.
- Re-ran the same scratch repro after the fix. It returned `{"ok":true,"embeddings":[[0.1,0.2,0.3]]}`.
- Ran `pnpm --dir packages/server exec tsx --test test\embedding-response.test.ts`: 3 tests passed, covering OpenAI wrapper responses, llama.cpp top-level array responses, and malformed response error paths.
- Ran `pnpm check`: passed.
- Container/Podman runtime was not rebuilt locally; the core claim is covered by the provider-level repro and baseline build.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

N/A - backend/provider response parsing fix; no visible UI state changed.
