### PR TITLE
Fix agent Local Model fallback resolution

### DIFF
--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -142,6 +142,7 @@ import {
   buildDefaultAgentConnectionWarning,
   buildLocalSidecarUnavailableWarning,
   isLocalSidecarConnectionId,
+  resolveAgentConnectionId,
   type AgentConnectionWarning,
 } from "./generate/agent-connection-guards.js";
 import {
@@ -2572,7 +2573,13 @@ export async function generateRoutes(app: FastifyInstance) {
         let agentModel = conn.model;
 
         // Resolve connection: per-agent override > default-for-agents > chat connection
-        if (isLocalSidecarConnectionId(cfg.connectionId) && !localSidecarAvailableForTrackers) {
+        const effectiveConnectionId = resolveAgentConnectionId({
+          requestedConnectionId: cfg.connectionId as string | null,
+          defaultAgentConnectionId: defaultAgentConn?.id ?? null,
+          localSidecarAvailable: localSidecarAvailableForTrackers,
+        });
+
+        if (effectiveConnectionId === "skip-local-sidecar") {
           skippedLocalSidecarAgents.push(cfg.name ?? cfg.type);
           logger.warn(
             "[generate] Skipping agent %s for chat %s because Local Model was requested but the sidecar is unavailable",
@@ -2581,8 +2588,6 @@ export async function generateRoutes(app: FastifyInstance) {
           );
           continue;
         }
-
-        const effectiveConnectionId = cfg.connectionId ?? defaultAgentConn?.id ?? null;
         if (defaultAgentConn && effectiveConnectionId === defaultAgentConn.id) {
           defaultAgentConnectionAgents.push(cfg.name ?? cfg.type);
         }
@@ -2617,7 +2622,7 @@ export async function generateRoutes(app: FastifyInstance) {
           name: cfg.name,
           phase: cfg.phase as string,
           promptTemplate: cfg.promptTemplate as string,
-          connectionId: cfg.connectionId as string | null,
+          connectionId: effectiveConnectionId,
           settings,
           provider: agentProvider,
           model: agentModel,

--- a/packages/server/src/routes/generate/agent-connection-guards.ts
+++ b/packages/server/src/routes/generate/agent-connection-guards.ts
@@ -14,6 +14,18 @@ export function isLocalSidecarConnectionId(connectionId: unknown): boolean {
   return connectionId === LOCAL_SIDECAR_CONNECTION_ID;
 }
 
+export function resolveAgentConnectionId(args: {
+  requestedConnectionId: string | null | undefined;
+  defaultAgentConnectionId: string | null | undefined;
+  localSidecarAvailable: boolean;
+}): string | null | "skip-local-sidecar" {
+  if (isLocalSidecarConnectionId(args.requestedConnectionId) && !args.localSidecarAvailable) {
+    return args.defaultAgentConnectionId ?? "skip-local-sidecar";
+  }
+
+  return args.requestedConnectionId ?? args.defaultAgentConnectionId ?? null;
+}
+
 function formatAgentNameList(agentNames: string[]): string {
   if (agentNames.length === 0) return "Agent";
   if (agentNames.length === 1) return agentNames[0]!;

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -35,8 +35,10 @@ import {
 } from "./lorebook-keeper-utils.js";
 import { sendSseEvent, startSseReply } from "./sse.js";
 import {
+  buildDefaultAgentConnectionWarning,
   buildLocalSidecarUnavailableWarning,
   isLocalSidecarConnectionId,
+  resolveAgentConnectionId,
   type AgentConnectionWarning,
 } from "./agent-connection-guards.js";
 import { validateSpriteExpressionEntries } from "./expression-agent-utils.js";
@@ -387,18 +389,47 @@ async function resolveRetryAgents(args: {
   );
   const resolvedAgents: ResolvedRetryAgent[] = [];
   const skippedLocalSidecarAgents: string[] = [];
+  const defaultAgentConnectionAgents: string[] = [];
+  const defaultAgentConn = await conns.getDefaultForAgents();
+  const defaultAgentConnection = defaultAgentConn
+    ? (() => {
+        const baseUrl = resolveBaseUrl(defaultAgentConn);
+        if (!baseUrl) return null;
+        return {
+          connectionId: defaultAgentConn.id as string,
+          provider: createLLMProvider(
+            defaultAgentConn.provider,
+            baseUrl,
+            defaultAgentConn.apiKey,
+            defaultAgentConn.maxContext,
+            defaultAgentConn.openrouterProvider,
+            defaultAgentConn.maxTokensOverride,
+          ),
+          model: defaultAgentConn.model,
+        };
+      })()
+    : null;
   const localSidecarAvailableForTrackers =
     sidecarModelService.getConfig().useForTrackers && sidecarModelService.getConfiguredModelRef() !== null;
 
   for (const cfg of enabledConfigs) {
     let agentProvider = provider;
     let agentModel = conn.model;
+    const effectiveConnectionId = resolveAgentConnectionId({
+      requestedConnectionId: cfg.connectionId as string | null,
+      defaultAgentConnectionId: defaultAgentConn?.id ?? null,
+      localSidecarAvailable: localSidecarAvailableForTrackers,
+    });
 
-    if (cfg.connectionId) {
-      if (isLocalSidecarConnectionId(cfg.connectionId) && localSidecarAvailableForTrackers) {
+    if (effectiveConnectionId) {
+      if (isLocalSidecarConnectionId(effectiveConnectionId) && localSidecarAvailableForTrackers) {
         agentProvider = getLocalSidecarProvider();
         agentModel = LOCAL_SIDECAR_MODEL;
-      } else if (isLocalSidecarConnectionId(cfg.connectionId)) {
+      } else if (defaultAgentConnection && effectiveConnectionId === defaultAgentConnection.connectionId) {
+        agentProvider = defaultAgentConnection.provider;
+        agentModel = defaultAgentConnection.model;
+        defaultAgentConnectionAgents.push(cfg.name ?? cfg.type);
+      } else if (effectiveConnectionId === "skip-local-sidecar") {
         skippedLocalSidecarAgents.push(cfg.name ?? cfg.type);
         logger.warn(
           "[retry-agents] Skipping agent %s because Local Model was requested but the sidecar is unavailable",
@@ -406,7 +437,7 @@ async function resolveRetryAgents(args: {
         );
         continue;
       } else {
-        const agentConn = await conns.getWithKey(cfg.connectionId as string);
+        const agentConn = await conns.getWithKey(effectiveConnectionId);
         if (agentConn) {
           const agentBaseUrl = resolveBaseUrl(agentConn);
           if (agentBaseUrl) {
@@ -432,7 +463,7 @@ async function resolveRetryAgents(args: {
         name: cfg.name,
         phase: cfg.phase as string,
         promptTemplate: cfg.promptTemplate as string,
-        connectionId: cfg.connectionId as string | null,
+        connectionId: effectiveConnectionId,
         settings: typeof cfg.settings === "string" ? JSON.parse(cfg.settings) : (cfg.settings ?? {}),
         provider: agentProvider,
         model: agentModel,
@@ -446,6 +477,11 @@ async function resolveRetryAgents(args: {
     skippedLocalSidecarAgents.length > 0 ? [buildLocalSidecarUnavailableWarning(skippedLocalSidecarAgents)] : [];
 
   for (const builtIn of builtInFallbackConfigs) {
+    const builtInProvider = defaultAgentConnection ?? { provider, model: conn.model, connectionId: null };
+    if (defaultAgentConnection) {
+      defaultAgentConnectionAgents.push(builtIn.name);
+    }
+
     resolvedAgents.push({
       cfg: { id: `builtin:${builtIn.id}`, type: builtIn.id, name: builtIn.name } as any,
       resolved: {
@@ -454,14 +490,24 @@ async function resolveRetryAgents(args: {
         name: builtIn.name,
         phase: builtIn.phase,
         promptTemplate: "",
-        connectionId: null,
+        connectionId: builtInProvider.connectionId,
         settings: getDefaultBuiltInAgentSettings(builtIn.id),
-        provider,
-        model: conn.model,
+        provider: builtInProvider.provider,
+        model: builtInProvider.model,
       },
-      agentProvider: provider,
-      agentModel: conn.model,
+      agentProvider: builtInProvider.provider,
+      agentModel: builtInProvider.model,
     });
+  }
+
+  if (defaultAgentConn && defaultAgentConnectionAgents.length > 0) {
+    warnings.push(
+      buildDefaultAgentConnectionWarning({
+        agentNames: defaultAgentConnectionAgents,
+        connectionName: defaultAgentConn.name,
+        model: defaultAgentConn.model,
+      }),
+    );
   }
 
   return { conn, enabledConfigs, resolvedAgents, warnings };

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -421,6 +421,15 @@ async function resolveRetryAgents(args: {
       localSidecarAvailable: localSidecarAvailableForTrackers,
     });
 
+    if (effectiveConnectionId === "skip-local-sidecar") {
+      skippedLocalSidecarAgents.push(cfg.name ?? cfg.type);
+      logger.warn(
+        "[retry-agents] Skipping agent %s because Local Model was requested but the sidecar is unavailable",
+        cfg.type,
+      );
+      continue;
+    }
+
     if (effectiveConnectionId) {
       if (isLocalSidecarConnectionId(effectiveConnectionId) && localSidecarAvailableForTrackers) {
         agentProvider = getLocalSidecarProvider();
@@ -429,13 +438,6 @@ async function resolveRetryAgents(args: {
         agentProvider = defaultAgentConnection.provider;
         agentModel = defaultAgentConnection.model;
         defaultAgentConnectionAgents.push(cfg.name ?? cfg.type);
-      } else if (effectiveConnectionId === "skip-local-sidecar") {
-        skippedLocalSidecarAgents.push(cfg.name ?? cfg.type);
-        logger.warn(
-          "[retry-agents] Skipping agent %s because Local Model was requested but the sidecar is unavailable",
-          cfg.type,
-        );
-        continue;
       } else {
         const agentConn = await conns.getWithKey(effectiveConnectionId);
         if (agentConn) {

--- a/packages/server/test/agent-connection-guards.test.ts
+++ b/packages/server/test/agent-connection-guards.test.ts
@@ -5,12 +5,47 @@ import {
   buildDefaultAgentConnectionWarning,
   buildLocalSidecarUnavailableWarning,
   isLocalSidecarConnectionId,
+  resolveAgentConnectionId,
 } from "../src/routes/generate/agent-connection-guards.js";
 
 test("detects explicit Local Model connection ids", () => {
+  assert.equal(LOCAL_SIDECAR_CONNECTION_ID, "__local_sidecar__");
   assert.equal(isLocalSidecarConnectionId(LOCAL_SIDECAR_CONNECTION_ID), true);
   assert.equal(isLocalSidecarConnectionId("regular-connection"), false);
   assert.equal(isLocalSidecarConnectionId(null), false);
+});
+
+test("falls back to the default agent connection when Local Model is unavailable", () => {
+  assert.equal(
+    resolveAgentConnectionId({
+      requestedConnectionId: LOCAL_SIDECAR_CONNECTION_ID,
+      defaultAgentConnectionId: "paid-agent-default",
+      localSidecarAvailable: false,
+    }),
+    "paid-agent-default",
+  );
+});
+
+test("skips Local Model agents only when no default agent fallback is configured", () => {
+  assert.equal(
+    resolveAgentConnectionId({
+      requestedConnectionId: LOCAL_SIDECAR_CONNECTION_ID,
+      defaultAgentConnectionId: null,
+      localSidecarAvailable: false,
+    }),
+    "skip-local-sidecar",
+  );
+});
+
+test("keeps Local Model when the sidecar is available", () => {
+  assert.equal(
+    resolveAgentConnectionId({
+      requestedConnectionId: LOCAL_SIDECAR_CONNECTION_ID,
+      defaultAgentConnectionId: "paid-agent-default",
+      localSidecarAvailable: true,
+    }),
+    LOCAL_SIDECAR_CONNECTION_ID,
+  );
 });
 
 test("builds a user-visible warning for skipped local-only agents", () => {


### PR DESCRIPTION
## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #437

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- Agents that explicitly request Local Model could be skipped when the local sidecar was unavailable, even when the user had configured a default-for-agents paid API fallback.
- The retry-agents path also needed to use the same fallback resolution so regenerate/force-continue does not behave differently from normal generation.

## What changed

<!-- List the key changes in this PR -->

- Added a shared agent connection resolver that falls back from unavailable Local Model to the configured default-for-agents connection when one exists.
- Updated normal generation and retry-agent resolution to use the same fallback/skip decision.
- Added focused server tests for Local Model fallback, skip-without-fallback, and sidecar-available behavior.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Machine proof before fix: `node scratch/issue-437-repro.mjs` failed in a clean `upstream/main` worktree with `outcome: "skip-local-sidecar"` and `expected: "paid-agent-default"`.
- Machine proof after fix: `node scratch/issue-437-repro.mjs` passed on this branch with `outcome: "paid-agent-default"`.
- Focused server test: `pnpm --filter @marinara-engine/server exec tsx --test test/agent-connection-guards.test.ts` passed.
- Baseline validation: `pnpm check` passed.
- Earlier broad `pnpm --filter @marinara-engine/server test -- --test-name-pattern "falls back to the default agent connection"` ran the full server suite because of argument forwarding and exposed unrelated Lorebook Keeper failures; the focused guard-file test above is the relevant proof for this fix.
- Not manually verified in the browser because this is server-side agent connection resolution and does not require a UI layout/state check.
- Container build not run.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs or release metadata changes needed; this preserves the existing configured fallback behavior.

## UI evidence (if applicable)

N/A - server-side agent connection resolution; no UI surface changed.
