### PR TITLE
Fix lorebook triggers in prompt preview

### DIFF
--- a/docs/pr-evidence/issue-518/repro-output.txt
+++ b/docs/pr-evidence/issue-518/repro-output.txt
@@ -1,0 +1,13 @@
+Command:
+pnpm --dir packages/server exec tsx ../../scratch/issue-518-repro.ts
+
+Output:
+{
+  "activeScanEntryIds": [
+    "constant-entry",
+    "roleplay-entry"
+  ],
+  "previewWithoutRoleplayIncludesTriggeredEntry": false,
+  "previewWithRoleplayIncludesTriggeredEntry": true,
+  "previewWithDisabledOverrideIncludesTriggeredEntry": false
+}

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -176,6 +176,11 @@ function formatPeekTrackerContextBlock(args: {
   return `# Context\n*(Established state as of the last message. Do not re-describe — advance from here.)*\n${trackerParts.join("\n")}`;
 }
 
+function resolveLorebookGenerationTriggers(mode: unknown): string[] {
+  const modeTrigger = mode === "game" ? "game" : typeof mode === "string" && mode.trim() ? mode.trim() : "roleplay";
+  return Array.from(new Set([modeTrigger, "chat"]));
+}
+
 export async function chatsRoutes(app: FastifyInstance) {
   const storage = createChatsStorage(app.db);
 
@@ -1049,6 +1054,10 @@ export async function chatsRoutes(app: FastifyInstance) {
             activeLorebookIds: Array.isArray(chatMeta.activeLorebookIds)
               ? (chatMeta.activeLorebookIds as string[])
               : [],
+            entryStateOverrides:
+              (chatMeta.entryStateOverrides as Record<string, { ephemeral?: number | null; enabled?: boolean }>) ??
+              undefined,
+            generationTriggers: resolveLorebookGenerationTriggers(chat.mode),
             groupScenarioOverrideText:
               typeof chatMeta.groupScenarioText === "string" && (chatMeta.groupScenarioText as string).trim()
                 ? (chatMeta.groupScenarioText as string).trim()

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -868,7 +868,7 @@ export async function chatsRoutes(app: FastifyInstance) {
 
     // ── Fallback: live assembly preview (no generation has happened yet) ──
     // This is a best-effort approximation; it won't include runtime-only
-    // injections like lorebooks, game state, scene context, semantic memory, etc.
+    // injections like cached game state, scene context, semantic memory, etc.
     const presetId = chat.mode === "conversation" ? null : (chat.promptPresetId ?? chatMeta.presetId);
     if (presetId) {
       try {

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -31,6 +31,7 @@ import { normalizeTimestampOverrides } from "../services/import/import-timestamp
 import { findLastIndex, parseExtra, shouldEnableAgentsForGeneration } from "./generate/generate-route-utils.js";
 
 type TrackerWrapFormat = "xml" | "markdown" | "none";
+type EntryStateOverrides = Record<string, { ephemeral?: number | null; enabled?: boolean }>;
 
 async function loadLatestChatGameSnapshot(app: FastifyInstance, chatId: string) {
   const committedRows = await app.db
@@ -179,6 +180,24 @@ function formatPeekTrackerContextBlock(args: {
 function resolveLorebookGenerationTriggers(mode: unknown): string[] {
   const modeTrigger = mode === "game" ? "game" : typeof mode === "string" && mode.trim() ? mode.trim() : "roleplay";
   return Array.from(new Set([modeTrigger, "chat"]));
+}
+
+function resolveEntryStateOverrides(value: unknown): EntryStateOverrides | undefined {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return undefined;
+
+  const overrides: EntryStateOverrides = {};
+  for (const [entryId, override] of Object.entries(value)) {
+    if (typeof override !== "object" || override === null || Array.isArray(override)) return undefined;
+    const { ephemeral, enabled } = override as Record<string, unknown>;
+    if (ephemeral !== undefined && ephemeral !== null && typeof ephemeral !== "number") return undefined;
+    if (enabled !== undefined && typeof enabled !== "boolean") return undefined;
+    overrides[entryId] = {
+      ...(ephemeral !== undefined ? { ephemeral } : {}),
+      ...(enabled !== undefined ? { enabled } : {}),
+    };
+  }
+
+  return overrides;
 }
 
 export async function chatsRoutes(app: FastifyInstance) {
@@ -1032,6 +1051,7 @@ export async function chatsRoutes(app: FastifyInstance) {
             chatId: req.params.id,
           });
           const resolvePromptMacros = (value: string) => resolveMacros(value, promptMacroContext);
+          const entryStateOverrides = resolveEntryStateOverrides(chatMeta.entryStateOverrides);
 
           const assembled = await assemblePrompt({
             db: app.db,
@@ -1054,9 +1074,7 @@ export async function chatsRoutes(app: FastifyInstance) {
             activeLorebookIds: Array.isArray(chatMeta.activeLorebookIds)
               ? (chatMeta.activeLorebookIds as string[])
               : [],
-            entryStateOverrides:
-              (chatMeta.entryStateOverrides as Record<string, { ephemeral?: number | null; enabled?: boolean }>) ??
-              undefined,
+            entryStateOverrides,
             generationTriggers: resolveLorebookGenerationTriggers(chat.mode),
             groupScenarioOverrideText:
               typeof chatMeta.groupScenarioText === "string" && (chatMeta.groupScenarioText as string).trim()


### PR DESCRIPTION
## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #518

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- Active World Info could report roleplay-triggered lorebook entries as active while the live assembled prompt preview omitted them. The preview assembled lorebook markers with only the default `chat` trigger context, while the scan/generation paths include the chat mode trigger such as `roleplay` or `game`.

## What changed

<!-- List the key changes in this PR -->

- Added mode-aware lorebook generation triggers to the live `/api/chats/:id/peek-prompt` assembler path.
- Passed per-chat lorebook entry state overrides into that same preview assembly path so preview remains aligned with generation when entries are disabled or ephemeral in one chat.
- Added committed command-output evidence for the issue repro.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- âš ï¸ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Machine repro: `pnpm --dir packages/server exec tsx ../../scratch/issue-518-repro.ts`
- Repro proof: Active World Info-equivalent scan includes `constant-entry` and `roleplay-entry`; old preview-equivalent `chat`-only trigger context excludes the roleplay entry; fixed route-equivalent roleplay trigger context includes it.
- Edge case: the same repro verifies a per-chat disabled `entryStateOverrides` entry remains excluded from preview.
- Baseline: `pnpm check` passed locally.
- Evidence: https://raw.githubusercontent.com/cha1latte/Marinara-Engine/bdbe5c5ed4f9da5a5d5c5a19e067b8e80b0d27ef/docs/pr-evidence/issue-518/repro-output.txt

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

N/A. This is a server-side prompt preview assembly fix; the committed command evidence above captures the assembled prompt inclusion/exclusion behavior directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced the prompt preview endpoint with refined trigger resolution logic based on chat mode, ensuring more consistent behavior across different chat configurations.

* **Tests**
  * Added reproduction output documentation for issue validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->