### PR TITLE
Fix game scene time drift

### DIFF
--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -47,7 +47,14 @@ import {
 import { resolveCombatRound, type CombatantStats } from "../services/game/combat.service.js";
 import { getElementPreset, listElementPresets } from "../services/game/element-reactions.service.js";
 import { generateCombatLoot, generateLootTable } from "../services/game/loot.service.js";
-import { advanceTime, formatGameTime, createInitialTime, type GameTime } from "../services/game/time.service.js";
+import {
+  advanceTime,
+  formatGameTime,
+  createInitialTime,
+  setTimeOfDay,
+  type GameTime,
+  type TimeOfDay,
+} from "../services/game/time.service.js";
 import { generateWeather, inferBiome, shouldWeatherChange } from "../services/game/weather.service.js";
 import { rollEncounter, rollEnemyCount } from "../services/game/encounter.service.js";
 import { processReputationActions } from "../services/game/reputation.service.js";
@@ -492,6 +499,10 @@ function parseMeta(raw: unknown): Record<string, unknown> {
     }
   }
   return (raw as Record<string, unknown>) ?? {};
+}
+
+function isTimeOfDayLabel(action: string): action is TimeOfDay {
+  return ["dawn", "morning", "afternoon", "evening", "night", "midnight"].includes(action);
 }
 
 function normalizeCharacterLookupName(value: string): string {
@@ -5146,24 +5157,9 @@ export async function gameRoutes(app: FastifyInstance) {
 
     const meta = parseMeta(chat.metadata);
     const currentTime = (meta.gameTime as GameTime) ?? createInitialTime();
-
-    // Scene analyzer sends a time-of-day label (dawn, morning, etc.) — set directly
-    const TOD_HOURS: Record<string, number> = {
-      dawn: 6,
-      morning: 8,
-      noon: 12,
-      afternoon: 14,
-      evening: 18,
-      night: 21,
-      midnight: 0,
-    };
     let newTime: GameTime;
-    if (TOD_HOURS[action] != null) {
-      newTime = { ...currentTime, hour: TOD_HOURS[action]!, minute: 0 };
-      // If the target hour is behind current, advance to next day
-      if (newTime.hour <= currentTime.hour) {
-        newTime.day = currentTime.day + 1;
-      }
+    if (isTimeOfDayLabel(action)) {
+      newTime = setTimeOfDay(currentTime, action);
     } else {
       newTime = advanceTime(currentTime, action);
     }

--- a/packages/server/src/services/game/gm-prompts.ts
+++ b/packages/server/src/services/game/gm-prompts.ts
@@ -724,7 +724,9 @@ export function buildGmFormatReminder(
       ``,
       `HUD WIDGETS:`,
       ...buildWidgetSummaryLines(hudWidgets),
-      `Widget usage: emit widget commands only when tracked state changes. value = bars/gauges, count = counters, stat = one stat_block entry, add/remove = rotating list items, running/seconds = timers.`,
+      `Widget usage: emit widget commands for every real change to these visible HUD widgets. Do not skip a changed widget just because another system tracks related player or party stats.`,
+      `HUD widgets are visual UI state only. Player stats, inventory, party member HP, party relationships, and other durable game facts remain in their own canonical systems; use [widget:] only to mirror a visible widget when that widget's displayed value should change.`,
+      `Command mapping: value = bars/gauges, count = counters, stat = one stat_block entry, add/remove = rotating list items, running/seconds = timers.`,
       `Widget commands: [widget: id, value: n] [widget: id, stat: "Name", value: x] [widget: id, count: n] [widget: id, add: "Item"] [widget: id, remove: "Item"] [widget: id, running: true, seconds: 60]`,
       `List widgets: keep at most 5 short entries visible; remove stale items freely.`,
     );

--- a/packages/server/src/services/game/time.service.ts
+++ b/packages/server/src/services/game/time.service.ts
@@ -16,6 +16,15 @@ export interface GameTime {
 
 export type TimeOfDay = "dawn" | "morning" | "afternoon" | "evening" | "night" | "midnight";
 
+const TIME_OF_DAY_HOURS: Record<TimeOfDay, number> = {
+  dawn: 6,
+  morning: 8,
+  afternoon: 14,
+  evening: 18,
+  night: 21,
+  midnight: 0,
+};
+
 /** Minutes advanced per action type. */
 const ACTION_DURATIONS: Record<string, number> = {
   dialogue: 15,
@@ -55,8 +64,18 @@ export function getTimeOfDay(hour: number): TimeOfDay {
   if (hour >= 7 && hour < 12) return "morning";
   if (hour >= 12 && hour < 17) return "afternoon";
   if (hour >= 17 && hour < 20) return "evening";
-  if (hour >= 20 || hour < 0) return "night";
+  if (hour >= 20) return "night";
   return "midnight";
+}
+
+/** Apply a scene analyzer time-of-day label without inventing a day skip on repeated labels. */
+export function setTimeOfDay(current: GameTime, label: TimeOfDay): GameTime {
+  const currentLabel = getTimeOfDay(current.hour);
+  if (label === currentLabel) return current;
+
+  const targetHour = TIME_OF_DAY_HOURS[label];
+  const targetDay = targetHour <= current.hour ? current.day + 1 : current.day;
+  return { ...current, day: targetDay, hour: targetHour, minute: 0 };
 }
 
 /** Format time as a human-readable string for narration injection. */

--- a/packages/server/test/game-session-prompts.test.ts
+++ b/packages/server/test/game-session-prompts.test.ts
@@ -231,6 +231,29 @@ test("GM format reminder documents the simplified resolved skill_check command",
   assert.doesNotMatch(prompt, /\bmode=/);
 });
 
+test("GM format reminder separates HUD widget updates from durable stats", () => {
+  const prompt = buildGmFormatReminder({
+    gameActiveState: "exploration",
+    sessionNumber: 1,
+    partyNames: ["Aster"],
+    playerName: "Mari",
+    hudWidgets: [
+      {
+        id: "party_bonds",
+        label: "Party Bonds",
+        type: "stat_block",
+        position: "hud_left",
+        config: { stats: [{ name: "Aster", value: 50 }] },
+      },
+    ],
+  });
+
+  assert.match(prompt, /emit widget commands for every real change to these visible HUD widgets/);
+  assert.match(prompt, /Do not skip a changed widget just because another system tracks related player or party stats/);
+  assert.match(prompt, /HUD widgets are visual UI state only/);
+  assert.match(prompt, /party member HP, party relationships, and other durable game facts remain in their own canonical systems/);
+});
+
 test("session conclusion prompt combines summary progression and cards in one JSON shape", () => {
   const promptWithCards = buildSessionConclusionPrompt({ language: "Polish", includeCharacterCards: true });
   const promptWithoutCards = buildSessionConclusionPrompt({ includeCharacterCards: false });

--- a/packages/server/test/game-time.test.ts
+++ b/packages/server/test/game-time.test.ts
@@ -1,0 +1,25 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { setTimeOfDay, type GameTime } from "../src/services/game/time.service.js";
+
+test("setTimeOfDay keeps repeated scene labels on the same day", () => {
+  let time: GameTime = { day: 1, hour: 21, minute: 0 };
+
+  for (let i = 0; i < 5; i++) {
+    time = setTimeOfDay(time, "night");
+  }
+
+  assert.deepEqual(time, { day: 1, hour: 21, minute: 0 });
+});
+
+test("setTimeOfDay advances within the same day for later labels", () => {
+  const time = setTimeOfDay({ day: 2, hour: 8, minute: 15 }, "afternoon");
+
+  assert.deepEqual(time, { day: 2, hour: 14, minute: 0 });
+});
+
+test("setTimeOfDay rolls over only when moving to an earlier phase", () => {
+  const time = setTimeOfDay({ day: 3, hour: 21, minute: 30 }, "morning");
+
+  assert.deepEqual(time, { day: 4, hour: 8, minute: 0 });
+});


### PR DESCRIPTION
## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #516

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- Scene analysis was treating repeated time-of-day observations as clock commands. When the scene analyzer kept returning the same label such as `night`, the HUD day counter advanced by one day per turn even if the narration had not moved forward.
- The GM widget prompt also did not clearly separate visual HUD widget mirroring from durable player/party stat storage, which made widget/stat ownership easier for the model to blur.

## What changed

<!-- List the key changes in this PR -->

- Added `setTimeOfDay()` so scene-analysis labels preserve the current day when the label already matches the current phase, advance within the same day for later phases, and roll over only for true earlier-phase transitions.
- Updated `/game/time/advance` to use the new scene-label helper instead of directly incrementing the day whenever the target hour was less than or equal to the current hour.
- Hardened the GM format reminder so HUD widgets are updated consistently as visible UI state while durable player/party facts remain in their canonical systems.
- Added server regression coverage for repeated scene labels and the widget/stat prompt boundary.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Machine verification: `node scratch\issue-516-time-repro.mjs`

  ```text
  Issue #516 time repro
  Input labels: night, night, night, night, night
  Before fix: {"day":6,"hour":21,"minute":0}
  After fix: {"day":1,"hour":21,"minute":0}
  ```

- Machine verification: `pnpm --filter @marinara-engine/server exec tsx --test test/game-time.test.ts test/game-session-prompts.test.ts`
  - 13 tests passed.
- Machine verification: `pnpm check`
  - Passed: impeccable context check, lint/type checks, shared/server/client builds.
- Manual follow-up worth doing before merge: run a short real Game mode session with a configured scene-analysis model and confirm the HUD day no longer increments when the scene remains in the same time-of-day phase.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs or release metadata changed.

## UI evidence (if applicable)

N/A - backend/game-state logic and GM prompt behavior. The raw command proof above captures the before/after state transition.
