### PR TITLE
Fix Memory Recall refresh after message edits

### DIFF
--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -80,6 +80,7 @@ import {
   useChatMemories,
   useDeleteChatMemory,
   useClearChatMemories,
+  useRefreshChatMemories,
   useChatNotes,
   useDeleteChatNote,
   useClearChatNotes,
@@ -4800,6 +4801,7 @@ function MemoryRecallMemoriesModal({ chatId, open, onClose }: { chatId: string; 
   const memoriesQuery = useChatMemories(chatId, open);
   const deleteMemory = useDeleteChatMemory(chatId);
   const clearMemories = useClearChatMemories(chatId);
+  const refreshMemories = useRefreshChatMemories(chatId);
   const memories = useMemo(() => memoriesQuery.data ?? [], [memoriesQuery.data]);
   const totalTokens = useMemo(() => estimateMemoryTokens(memories), [memories]);
 
@@ -4841,12 +4843,15 @@ function MemoryRecallMemoriesModal({ chatId, open, onClose }: { chatId: string; 
           <div className="flex items-center gap-1">
             <button
               type="button"
-              onClick={() => void memoriesQuery.refetch()}
-              disabled={memoriesQuery.isFetching}
+              onClick={() => refreshMemories.mutate()}
+              disabled={memoriesQuery.isFetching || refreshMemories.isPending}
               className="rounded-lg p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] disabled:opacity-50"
-              title="Refresh"
+              title="Rebuild memories from current chat messages"
             >
-              <RefreshCw size="0.8125rem" className={cn(memoriesQuery.isFetching && "animate-spin")} />
+              <RefreshCw
+                size="0.8125rem"
+                className={cn((memoriesQuery.isFetching || refreshMemories.isPending) && "animate-spin")}
+              />
             </button>
             <button
               type="button"

--- a/packages/client/src/hooks/use-chats.ts
+++ b/packages/client/src/hooks/use-chats.ts
@@ -152,6 +152,16 @@ export function useClearChatMemories(chatId: string | null) {
   });
 }
 
+export function useRefreshChatMemories(chatId: string | null) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () => api.post<{ rebuilt: number }>(`/chats/${chatId}/memories/refresh`),
+    onSuccess: () => {
+      if (chatId) qc.invalidateQueries({ queryKey: chatKeys.memories(chatId) });
+    },
+  });
+}
+
 export function useChatNotes(chatId: string | null) {
   return useQuery({
     queryKey: chatKeys.notes(chatId ?? ""),

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -20,6 +20,7 @@ import { createRegexScriptsStorage } from "../services/storage/regex-scripts.sto
 import { getLocalSidecarProvider, LOCAL_SIDECAR_MODEL } from "../services/llm/local-sidecar.js";
 import { createLLMProvider } from "../services/llm/provider-registry.js";
 import { generateMissingConversationSummaries } from "../services/conversation/auto-summary.service.js";
+import { rebuildMemoryChunks } from "../services/memory-recall.js";
 import { wrapContent } from "../services/prompt/format-engine.js";
 import { newId } from "../utils/id-generator.js";
 import { characters, gameStateSnapshots, memoryChunks } from "../db/schema/index.js";
@@ -587,6 +588,39 @@ export async function chatsRoutes(app: FastifyInstance) {
           hasEmbedding: !!embedding,
         }) satisfies ChatMemoryChunk,
     );
+  });
+
+  // Rebuild memory-recall chunks for this chat from the current message log.
+  app.post<{ Params: { id: string } }>("/:id/memories/refresh", async (req, reply) => {
+    const chat = await storage.getById(req.params.id);
+    if (!chat) return reply.status(404).send({ error: "Chat not found" });
+
+    const characterIds: string[] = Array.isArray(chat.characterIds)
+      ? chat.characterIds
+      : typeof chat.characterIds === "string"
+        ? JSON.parse(chat.characterIds)
+        : [];
+    const charactersStore = createCharactersStorage(app.db);
+    const characterNames: Record<string, string> = {};
+    for (const characterId of characterIds) {
+      const row = await charactersStore.getById(characterId);
+      if (!row) continue;
+      try {
+        const data = JSON.parse(row.data as string) as { name?: unknown };
+        characterNames[characterId] = typeof data.name === "string" && data.name.trim() ? data.name : "Character";
+      } catch {
+        characterNames[characterId] = "Character";
+      }
+    }
+
+    const personas = await charactersStore.listPersonas();
+    const persona =
+      (chat.personaId ? personas.find((candidate) => candidate.id === chat.personaId) : null) ??
+      personas.find((candidate) => candidate.isActive === "true");
+    const userName = persona?.name ?? "User";
+
+    const rebuilt = await rebuildMemoryChunks(app.db, req.params.id, { userName, characterNames });
+    return { rebuilt };
   });
 
   // Clear all memory-recall chunks for this chat.

--- a/packages/server/src/services/memory-recall.ts
+++ b/packages/server/src/services/memory-recall.ts
@@ -142,6 +142,26 @@ export async function chunkAndEmbedMessages(
 }
 
 /**
+ * Rebuild all memory-recall chunks for a chat from the current message log.
+ */
+export async function rebuildMemoryChunks(
+  db: DB,
+  chatId: string,
+  nameMap: { userName: string; characterNames: Record<string, string> },
+): Promise<number> {
+  if (isLite) return 0;
+
+  await db.delete(memoryChunks).where(eq(memoryChunks.chatId, chatId));
+  await chunkAndEmbedMessages(db, chatId, nameMap);
+
+  const rebuilt = await db
+    .select({ id: memoryChunks.id })
+    .from(memoryChunks)
+    .where(eq(memoryChunks.chatId, chatId));
+  return rebuilt.length;
+}
+
+/**
  * Recall relevant conversation memories for a given query.
  * Searches only the specified chat IDs for relevant chunks.
  */

--- a/packages/server/src/services/storage/chats.storage.ts
+++ b/packages/server/src/services/storage/chats.storage.ts
@@ -12,6 +12,7 @@ import {
   conversationNotes,
   agentRuns,
   agentMemory,
+  memoryChunks,
 } from "../../db/schema/index.js";
 import { newId, now } from "../../utils/id-generator.js";
 import { existsSync, rmSync } from "fs";
@@ -100,6 +101,15 @@ function parseMessageCursor(before?: string): { createdAt: string; rowid: number
     createdAt: before.slice(0, separatorIndex),
     rowid,
   };
+}
+
+async function invalidateMemoryChunksFrom(db: DB, chatId: string, createdAt: string) {
+  await db
+    .delete(memoryChunks)
+    .where(and(eq(memoryChunks.chatId, chatId), gt(memoryChunks.lastMessageAt, createdAt)));
+  await db
+    .delete(memoryChunks)
+    .where(and(eq(memoryChunks.chatId, chatId), eq(memoryChunks.lastMessageAt, createdAt)));
 }
 
 /** Create the chat storage facade used by routes and importers. */
@@ -455,7 +465,11 @@ export function createChatsStorage(db: DB) {
     },
 
     async updateMessageContent(id: string, content: string) {
+      const existing = await this.getMessage(id);
       await db.update(messages).set({ content }).where(eq(messages.id, id));
+      if (existing) {
+        await invalidateMemoryChunksFrom(db, existing.chatId, existing.createdAt);
+      }
       // Also sync the edit to the active swipe row so it persists across swipe switches
       const msg = await this.getMessage(id);
       if (msg) {
@@ -500,18 +514,34 @@ export function createChatsStorage(db: DB) {
     },
 
     async removeMessage(id: string) {
+      const existing = await this.getMessage(id);
       await db.delete(messages).where(eq(messages.id, id));
+      if (existing) {
+        await invalidateMemoryChunksFrom(db, existing.chatId, existing.createdAt);
+      }
     },
 
     async removeMessages(ids: string[], chatId?: string) {
       if (ids.length === 0) return;
+      const earliestByChat = new Map<string, string>();
       const CHUNK = 500;
       for (let i = 0; i < ids.length; i += CHUNK) {
         const chunk = ids.slice(i, i + CHUNK);
         const condition = chatId
           ? and(inArray(messages.id, chunk), eq(messages.chatId, chatId))
           : inArray(messages.id, chunk);
+        const existingRows = await db
+          .select({ chatId: messages.chatId, createdAt: messages.createdAt })
+          .from(messages)
+          .where(condition);
+        for (const row of existingRows) {
+          const current = earliestByChat.get(row.chatId);
+          if (!current || row.createdAt < current) earliestByChat.set(row.chatId, row.createdAt);
+        }
         await db.delete(messages).where(condition);
+      }
+      for (const [affectedChatId, createdAt] of earliestByChat) {
+        await invalidateMemoryChunksFrom(db, affectedChatId, createdAt);
       }
     },
 

--- a/packages/server/test/memory-recall.test.ts
+++ b/packages/server/test/memory-recall.test.ts
@@ -1,0 +1,89 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import Fastify from "fastify";
+import { createClient } from "@libsql/client";
+import { drizzle } from "drizzle-orm/libsql";
+import { eq } from "drizzle-orm";
+import type { DB } from "../src/db/connection.js";
+import { runMigrations } from "../src/db/migrate.js";
+import { chats, memoryChunks, messages } from "../src/db/schema/index.js";
+import { chatsRoutes } from "../src/routes/chats.routes.js";
+import { createChatsStorage } from "../src/services/storage/chats.storage.js";
+
+test("editing a message invalidates stale memory chunks and refresh rebuilds from current text", async () => {
+  const client = createClient({ url: "file::memory:" });
+  const db = drizzle(client) as unknown as DB;
+
+  try {
+    await runMigrations(db);
+
+    const now = "2026-05-05T00:00:00.000Z";
+    await db.insert(chats).values({
+      id: "chat-445",
+      name: "Bug 445 repro",
+      mode: "game",
+      characterIds: "[]",
+      metadata: "{}",
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    await db.insert(messages).values({
+      id: "message-445",
+      chatId: "chat-445",
+      role: "assistant",
+      characterId: null,
+      content: "The ancient tome says florblesnatch is the password.",
+      activeSwipeIndex: 0,
+      extra: "{}",
+      createdAt: "2026-05-05T00:01:00.000Z",
+    });
+    for (let i = 2; i <= 5; i++) {
+      await db.insert(messages).values({
+        id: `message-445-${i}`,
+        chatId: "chat-445",
+        role: i % 2 === 0 ? "user" : "assistant",
+        characterId: null,
+        content: `Follow-up message ${i}`,
+        activeSwipeIndex: 0,
+        extra: "{}",
+        createdAt: `2026-05-05T00:0${i}:00.000Z`,
+      });
+    }
+
+    await db.insert(memoryChunks).values({
+      id: "chunk-445",
+      chatId: "chat-445",
+      content: "GM: The ancient tome says florblesnatch is the password.",
+      embedding: null,
+      messageCount: 5,
+      firstMessageAt: "2026-05-05T00:01:00.000Z",
+      lastMessageAt: "2026-05-05T00:05:00.000Z",
+      createdAt: "2026-05-05T00:06:00.000Z",
+    });
+
+    const storage = createChatsStorage(db);
+    await storage.updateMessageContent("message-445", "The ancient tome says silverleaf is the password.");
+
+    const chunksAfterEdit = await db.select().from(memoryChunks).where(eq(memoryChunks.chatId, "chat-445"));
+    assert.equal(chunksAfterEdit.length, 0);
+
+    const app = Fastify({ logger: false });
+    app.decorate("db", db);
+    await app.register(chatsRoutes, { prefix: "/api/chats" });
+    await app.ready();
+
+    const res = await app.inject({ method: "POST", url: "/api/chats/chat-445/memories/refresh" });
+    assert.equal(res.statusCode, 200);
+    assert.deepEqual(res.json(), { rebuilt: 1 });
+    await app.close();
+
+    const rebuiltChunks = await db.select().from(memoryChunks).where(eq(memoryChunks.chatId, "chat-445"));
+
+    assert.equal(rebuiltChunks.length, 1);
+    assert.ok(!rebuiltChunks[0]!.content.includes("florblesnatch"));
+    assert.ok(rebuiltChunks[0]!.content.includes("silverleaf"));
+  } finally {
+    client.close();
+  }
+});


### PR DESCRIPTION
## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #445

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- Memory Recall could keep showing stale fragments after a GM message was edited because refresh only refetched existing chunks instead of rebuilding them from the edited chat log.

## What changed

<!-- List the key changes in this PR -->

- Invalidate memory chunks from the edited/deleted message onward when chat messages change.
- Add a server refresh endpoint that clears and rebuilds Memory Recall chunks from current chat messages.
- Wire the Memory Recall refresh button to the rebuild endpoint.
- Add a route-level regression test for issue #445.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

Codex validation performed:

- `pnpm --filter @marinara-engine/server exec tsx scratch\bug-445-repro.ts` passed. Before the fix, the repro showed the edited message changed to `silverleaf` while the memory chunk still contained stale `florblesnatch`; after the fix, edit invalidation removed the stale chunk and refresh rebuilt one chunk with `silverleaf` and without `florblesnatch`.
- `pnpm --filter @marinara-engine/server exec tsx --test test\memory-recall.test.ts` passed.
- `pnpm check` passed.

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- âš ï¸ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Machine verification covered the storage invalidation and refresh/rebuild path with a scratch repro and a committed route-level regression test.
- I did not run a full browser click-through for the drawer button; the client change is limited to calling the new refresh mutation and invalidating the existing Memory Recall query.
- Container verification was not run.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs or release/version files changed.

## UI evidence (if applicable)

N/A - this fix is verified by server/storage repro output and a route-level regression test rather than a visible UI state.