### PR TITLE
Fix Claude (Subscription) silent model identity loss

### DIFF
--- a/packages/client/src/components/connections/ConnectionEditor.tsx
+++ b/packages/client/src/components/connections/ConnectionEditor.tsx
@@ -12,8 +12,10 @@ import {
   useTestConnection,
   useTestMessage,
   useTestImageGeneration,
+  useDiagnoseClaudeSubscription,
   useFetchModels,
   useSaveConnectionDefaults,
+  type ClaudeSubscriptionDiagnosis,
 } from "../../hooks/use-connections";
 import {
   ArrowLeft,
@@ -95,6 +97,7 @@ export function ConnectionEditor() {
   const testConnection = useTestConnection();
   const testMessage = useTestMessage();
   const testImageGeneration = useTestImageGeneration();
+  const diagnoseClaudeSubscription = useDiagnoseClaudeSubscription();
   const fetchModels = useFetchModels();
   const saveConnectionDefaults = useSaveConnectionDefaults();
   const { data: allConnections } = useConnections();
@@ -125,6 +128,7 @@ export function ConnectionEditor() {
   const [localComfyuiWorkflow, setLocalComfyuiWorkflow] = useState("");
   const [localImageService, setLocalImageService] = useState<string | null>(null);
   const [localMaxTokensOverride, setLocalMaxTokensOverride] = useState<number | null>(null);
+  const [localClaudeFastMode, setLocalClaudeFastMode] = useState(false);
   const [localDefaultParametersEnabled, setLocalDefaultParametersEnabled] = useState(false);
   const [localDefaultParameters, setLocalDefaultParameters] =
     useState<EditableGenerationParameters>(ROLEPLAY_PARAMETER_DEFAULTS);
@@ -147,6 +151,7 @@ export function ConnectionEditor() {
     prompt: string;
     error?: string;
   } | null>(null);
+  const [claudeDiagResult, setClaudeDiagResult] = useState<ClaudeSubscriptionDiagnosis | null>(null);
 
   // Model search
   const [modelSearch, setModelSearch] = useState("");
@@ -229,6 +234,7 @@ export function ConnectionEditor() {
     setLocalComfyuiWorkflow((c.comfyuiWorkflow as string) ?? "");
     setLocalImageService(imageService);
     setLocalMaxTokensOverride(typeof c.maxTokensOverride === "number" ? (c.maxTokensOverride as number) : null);
+    setLocalClaudeFastMode(c.claudeFastMode === "true" || c.claudeFastMode === true);
     setLocalDefaultParametersEnabled(!!parseEditableGenerationParameters(c.defaultParameters));
     setLocalDefaultParameters(getEditableGenerationParameters(ROLEPLAY_PARAMETER_DEFAULTS, c.defaultParameters));
     setLocalImageDefaults(
@@ -240,6 +246,7 @@ export function ConnectionEditor() {
     setTestResult(null);
     setMsgResult(null);
     setImgTestResult(null);
+    setClaudeDiagResult(null);
   }, [conn]);
 
   const comfyWorkflowValidation = useMemo(() => {
@@ -367,6 +374,7 @@ export function ConnectionEditor() {
       imageService:
         localProvider === "image_generation" ? localImageGenerationSource || localImageService || null : null,
       maxTokensOverride: localMaxTokensOverride ?? null,
+      claudeFastMode: localClaudeFastMode,
     };
     // Only send API key if user typed a new one
     if (localApiKey.trim()) {
@@ -416,6 +424,7 @@ export function ConnectionEditor() {
     localComfyuiWorkflow,
     localImageService,
     localMaxTokensOverride,
+    localClaudeFastMode,
     localDefaultParametersEnabled,
     localDefaultParameters,
     selectedImageDefaultsService,
@@ -480,6 +489,33 @@ export function ConnectionEditor() {
         }),
     });
   }, [connectionDetailId, dirty, handleSave, testMessage]);
+
+  const handleDiagnoseClaudeSubscription = useCallback(async () => {
+    if (!connectionDetailId) return;
+    if (dirty) {
+      try {
+        await handleSave();
+      } catch {
+        return;
+      }
+    }
+    setClaudeDiagResult(null);
+    diagnoseClaudeSubscription.mutate(connectionDetailId, {
+      onSuccess: (data) => setClaudeDiagResult(data),
+      onError: (err) =>
+        setClaudeDiagResult({
+          success: false,
+          requestedModel: localModel,
+          modelsBilled: [],
+          modelUsageDetail: [],
+          billedDifferent: false,
+          fastModeState: null,
+          response: "",
+          errors: [err instanceof Error ? err.message : "Failed"],
+          latencyMs: 0,
+        }),
+    });
+  }, [connectionDetailId, dirty, handleSave, diagnoseClaudeSubscription, localModel]);
 
   const handleTestImage = useCallback(async () => {
     if (!connectionDetailId) return;
@@ -1454,6 +1490,57 @@ export function ConnectionEditor() {
             )}
           </FieldGroup>
 
+          {/* ── Claude (Subscription) — Fast Mode toggle ── */}
+          {localProvider === "claude_subscription" && (
+            <FieldGroup
+              label="Fast Mode"
+              icon={<Zap size="0.875rem" className="text-amber-400" />}
+              help="When enabled, asks the Claude Agent SDK to use its faster routing tier — quicker responses but the SDK may use a smaller model behind the scenes (Sonnet/Haiku) even if you've selected Opus. Currently a no-op on every modern Claude model: Opus 4.7 has no faster variant to route to, and Anthropic dropped support for downgrading on the rest. The toggle is here for the day Anthropic re-enables it. Leave off."
+            >
+              <label className="flex items-start gap-3 rounded-xl bg-[var(--secondary)] px-3 py-2.5 ring-1 ring-[var(--border)]">
+                <input
+                  type="checkbox"
+                  checked={localClaudeFastMode}
+                  onChange={async (e) => {
+                    const next = e.target.checked;
+                    if (next) {
+                      const confirmed = await showConfirmDialog({
+                        title: "YOU DON'T WANT THIS SETTING ON!",
+                        message:
+                          "Fast mode is effectively a dead feature today — Claude/Anthropic removed support for downgrading current models, and Opus 4.7 has no faster variant for the SDK to route to. Turning this on does nothing useful for roleplay quality and may add overhead. The toggle exists only so we don't have to ship a new release if Anthropic re-enables it.\n\nAre you absolutely sure you want to enable it?",
+                        confirmLabel: "Enable anyway",
+                        cancelLabel: "Keep it off",
+                        tone: "destructive",
+                      });
+                      if (!confirmed) return;
+                    }
+                    setLocalClaudeFastMode(next);
+                    markDirty();
+                  }}
+                  className="mt-0.5 h-4 w-4 shrink-0 cursor-pointer accent-amber-400"
+                />
+                <div className="min-w-0 flex-1 text-[0.6875rem] leading-relaxed">
+                  <div className="font-medium text-[var(--foreground)]">Use Claude Code fast-mode routing</div>
+                  <p className="mt-0.5 text-[var(--muted-foreground)]">
+                    <strong className="text-amber-400">99% of users should leave this off.</strong> Fast mode is
+                    effectively a dead feature today — Claude/Anthropic removed support for downgrading current
+                    models, and Opus 4.7 has no faster variant to route to. Turning it on does nothing useful for
+                    roleplay quality and may add overhead. The toggle exists only so we don&apos;t have to ship a
+                    new release if Anthropic re-enables it. Leave off until that happens.
+                  </p>
+                  <p className="mt-1.5 flex items-start gap-1 text-[var(--muted-foreground)]">
+                    <AlertCircle size="0.625rem" className="mt-px shrink-0 text-amber-400" />
+                    <span>
+                      <strong className="text-amber-400">Doesn&apos;t work on Claude Opus 4.7 yet.</strong> There is no
+                      faster Opus 4.7 variant for the SDK to route to, so this toggle is a no-op when Opus 4.7 is the
+                      selected model.
+                    </span>
+                  </p>
+                </div>
+              </label>
+            </FieldGroup>
+          )}
+
           {/* ── Embedding Model (for lorebook vectorization) ── */}
           {localProvider !== "image_generation" && localProvider !== "claude_subscription" && (
             <FieldGroup
@@ -1572,6 +1659,21 @@ export function ConnectionEditor() {
                   Test Image
                 </button>
               )}
+              {localProvider === "claude_subscription" && (
+                <button
+                  onClick={handleDiagnoseClaudeSubscription}
+                  disabled={diagnoseClaudeSubscription.isPending || !localModel}
+                  className="flex items-center gap-1.5 rounded-xl bg-amber-400/10 px-4 py-2.5 text-xs font-medium text-amber-400 ring-1 ring-amber-400/20 transition-all hover:bg-amber-400/20 active:scale-[0.98] disabled:opacity-50"
+                  title="Verify which model the SDK actually bills against (catches silent fast-mode downgrades)"
+                >
+                  {diagnoseClaudeSubscription.isPending ? (
+                    <Loader2 size="0.8125rem" className="animate-spin" />
+                  ) : (
+                    <AlertCircle size="0.8125rem" />
+                  )}
+                  Diagnose Model Routing
+                </button>
+              )}
             </div>
 
             <p className="text-[0.625rem] text-[var(--muted-foreground)]">
@@ -1586,6 +1688,14 @@ export function ConnectionEditor() {
                 <>
                   {" "}
                   <strong>Test Image</strong> generates a 512×512 test image (requires saving first).
+                </>
+              )}
+              {localProvider === "claude_subscription" && (
+                <>
+                  {" "}
+                  <strong>Diagnose Model Routing</strong> sends a real prompt through the Claude Agent SDK and reports
+                  which model it actually billed against. Catches silent fast-mode / cooldown downgrades where you ask
+                  for Opus and quietly get Sonnet.
                 </>
               )}
             </p>
@@ -1624,6 +1734,119 @@ export function ConnectionEditor() {
                 ) : (
                   <span className="text-[var(--destructive)]">{imgTestResult.error || "No image returned"}</span>
                 )}
+              </TestResultCard>
+            )}
+
+            {/* Claude (Subscription) diagnosis result */}
+            {claudeDiagResult && (
+              <TestResultCard
+                label="Model Routing Diagnosis"
+                success={claudeDiagResult.success && !claudeDiagResult.billedDifferent}
+                latencyMs={claudeDiagResult.latencyMs}
+              >
+                <div className="mt-1.5 space-y-2">
+                  <div className="grid grid-cols-[max-content,1fr] gap-x-3 gap-y-1 text-[0.6875rem]">
+                    <span className="text-[var(--muted-foreground)]">Requested model:</span>
+                    <span className="font-mono">{claudeDiagResult.requestedModel}</span>
+                    <span className="text-[var(--muted-foreground)]">SDK billed against:</span>
+                    <span
+                      className={cn(
+                        "font-mono",
+                        claudeDiagResult.billedDifferent && "font-semibold text-[var(--destructive)]",
+                      )}
+                    >
+                      {(() => {
+                        const detail = claudeDiagResult.modelUsageDetail;
+                        if (detail.length === 0) {
+                          return claudeDiagResult.modelsBilled.length
+                            ? claudeDiagResult.modelsBilled.join(", ")
+                            : "(none reported)";
+                        }
+                        const primary = detail.filter((u) => u.model === claudeDiagResult.requestedModel);
+                        const secondary = detail.filter((u) => u.model !== claudeDiagResult.requestedModel);
+                        return (
+                          <span className="flex flex-col gap-1.5">
+                            {primary.length > 0 && (
+                              <span className="flex flex-col gap-0.5">
+                                <span className="text-[0.5625rem] font-sans uppercase tracking-wide text-emerald-400/80">
+                                  Roleplay generation
+                                </span>
+                                {primary.map((u) => (
+                                  <span key={u.model}>
+                                    {u.model}{" "}
+                                    <span className="text-[var(--muted-foreground)]">
+                                      (in {u.inputTokens}, out {u.outputTokens})
+                                    </span>
+                                  </span>
+                                ))}
+                              </span>
+                            )}
+                            {secondary.length > 0 && (
+                              <span className="flex flex-col gap-0.5">
+                                <span className="text-[0.5625rem] font-sans uppercase tracking-wide text-[var(--muted-foreground)]">
+                                  SDK session bookkeeping
+                                </span>
+                                {secondary.map((u) => (
+                                  <span key={u.model} className="text-[var(--muted-foreground)]">
+                                    {u.model} (in {u.inputTokens}, out {u.outputTokens})
+                                  </span>
+                                ))}
+                              </span>
+                            )}
+                          </span>
+                        );
+                      })()}
+                    </span>
+                    <span className="text-[var(--muted-foreground)]">Fast-mode state:</span>
+                    <span
+                      className={cn(
+                        "font-mono",
+                        claudeDiagResult.fastModeState && claudeDiagResult.fastModeState !== "off"
+                          ? "text-amber-400"
+                          : undefined,
+                      )}
+                    >
+                      {claudeDiagResult.fastModeState ?? "unknown"}
+                    </span>
+                  </div>
+                  {claudeDiagResult.billedDifferent && (
+                    <div className="rounded-lg bg-[var(--destructive)]/10 p-2.5 text-[0.6875rem] text-[var(--destructive)] ring-1 ring-[var(--destructive)]/30">
+                      Silent downgrade detected — you asked for{" "}
+                      <strong>{claudeDiagResult.requestedModel}</strong> but the SDK billed{" "}
+                      <strong>{claudeDiagResult.modelsBilled.join(", ")}</strong>. This is usually caused by Claude
+                      Code being in <code>cooldown</code> after hitting Opus rate limits, or fast mode being toggled
+                      on in your CLI settings. Run <code>claude /model</code> in your terminal to check.
+                    </div>
+                  )}
+                  {claudeDiagResult.modelUsageDetail.some(
+                    (u) => u.model !== claudeDiagResult.requestedModel,
+                  ) && (
+                    <div className="rounded-lg bg-[var(--secondary)]/50 p-2.5 text-[0.6875rem] text-[var(--muted-foreground)] ring-1 ring-[var(--border)]">
+                      <strong className="text-[var(--foreground)]">Why is Haiku in the list?</strong> The Claude Agent
+                      SDK runs a <code>UserPromptSubmit</code> hook on every call that uses its small/fast model
+                      (Haiku) to auto-generate a session title and optional context for the main model. This is Claude
+                      Code session bookkeeping — it&apos;s organic to the subscription path, can&apos;t be cleanly
+                      disabled, and doesn&apos;t serve any of your roleplay output. Your actual response always comes
+                      from the model labeled <em>Roleplay generation</em> above. The Haiku tagalong adds only a few
+                      output tokens per turn and a tiny slice of quota.
+                    </div>
+                  )}
+                  {claudeDiagResult.response && (
+                    <div className="rounded-lg bg-[var(--secondary)] p-2.5 ring-1 ring-[var(--border)]">
+                      <div className="text-[0.5625rem] font-sans uppercase tracking-wide text-[var(--muted-foreground)]">
+                        Model Self Identifies As
+                      </div>
+                      <div className="mt-0.5 text-sm font-semibold text-[var(--foreground)]">
+                        {claudeDiagResult.response}
+                      </div>
+                    </div>
+                  )}
+                  {claudeDiagResult.errors.length > 0 && (
+                    <div className="text-[0.6875rem] text-[var(--destructive)]">
+                      {claudeDiagResult.errors.join("; ")}
+                    </div>
+                  )}
+                </div>
               </TestResultCard>
             )}
           </div>

--- a/packages/client/src/hooks/use-connections.ts
+++ b/packages/client/src/hooks/use-connections.ts
@@ -83,6 +83,25 @@ export function useTestMessage() {
   });
 }
 
+export interface ClaudeSubscriptionDiagnosis {
+  success: boolean;
+  requestedModel: string;
+  modelsBilled: string[];
+  modelUsageDetail: Array<{ model: string; inputTokens: number; outputTokens: number }>;
+  billedDifferent: boolean;
+  fastModeState: "off" | "cooldown" | "on" | null;
+  response: string;
+  errors: string[];
+  latencyMs: number;
+}
+
+export function useDiagnoseClaudeSubscription() {
+  return useMutation({
+    mutationFn: (id: string) =>
+      api.post<ClaudeSubscriptionDiagnosis>(`/connections/${id}/diagnose-claude-subscription`),
+  });
+}
+
 export function useTestImageGeneration() {
   return useMutation({
     mutationFn: (id: string) =>

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -639,6 +639,11 @@ const COLUMN_MIGRATIONS: ColumnMigration[] = [
     column: "additional_matching_sources",
     definition: "TEXT NOT NULL DEFAULT '[]'",
   },
+  {
+    table: "api_connections",
+    column: "claude_fast_mode",
+    definition: "TEXT NOT NULL DEFAULT 'false'",
+  },
 ];
 
 /**

--- a/packages/server/src/db/schema/connections.ts
+++ b/packages/server/src/db/schema/connections.ts
@@ -51,6 +51,14 @@ export const apiConnections = sqliteTable("api_connections", {
   defaultParameters: text("default_parameters"),
   /** Optional hard cap on max_tokens for the API response (for providers like DeepSeek that have lower limits). */
   maxTokensOverride: integer("max_tokens_override"),
+  /**
+   * Claude (Subscription) only. When "true", Marinara passes `settings.fastMode = true`
+   * to the Claude Agent SDK, asking the SDK to use its faster, cheaper routing tier
+   * (response speed up, but lower-quality model behind the scenes). When "false"
+   * (default), Marinara explicitly forces fast mode off for every request so the
+   * exact model chosen on the connection is what runs.
+   */
+  claudeFastMode: text("claude_fast_mode").notNull().default("false"),
   createdAt: text("created_at").notNull(),
   updatedAt: text("updated_at").notNull(),
 });

--- a/packages/server/src/routes/connections.routes.ts
+++ b/packages/server/src/routes/connections.routes.ts
@@ -479,6 +479,97 @@ export async function connectionsRoutes(app: FastifyInstance) {
     }
   });
 
+  // ── Diagnose Claude (Subscription) — verifies which model the SDK actually
+  //    billed against. The Claude Agent SDK can silently route a request to a
+  //    smaller model (fast mode, post-rate-limit `cooldown` state, account-tier
+  //    gating) without surfacing the swap to the caller. We send a tiny prompt
+  //    through the SDK with fast mode forced off, then return the model(s) the
+  //    SDK reports in `modelUsage` plus its `fast_mode_state` so the UI can
+  //    show "you asked for X, the SDK billed Y." ──
+  app.post<{ Params: { id: string } }>("/:id/diagnose-claude-subscription", async (req, reply) => {
+    const conn = await storage.getWithKey(req.params.id);
+    if (!conn) return reply.status(404).send({ error: "Connection not found" });
+    if (conn.provider !== "claude_subscription") {
+      return reply.status(400).send({ error: "Not a Claude (Subscription) connection" });
+    }
+    if (!conn.model) {
+      return reply.status(400).send({ error: "No model configured. Pick a model first." });
+    }
+
+    const start = Date.now();
+    const requestedModel = conn.model;
+    let responseText = "";
+    let modelsBilled: string[] = [];
+    let modelUsageDetail: Array<{ model: string; inputTokens: number; outputTokens: number }> = [];
+    let fastModeState: string | null = null;
+    const errors: string[] = [];
+
+    try {
+      const sdk = await import("@anthropic-ai/claude-agent-sdk");
+      // The user's empirically reliable self-ID prompt. Asking the model "which
+      // Claude family are you (Opus/Sonnet/Haiku)" with a one-word constraint
+      // produces consistent, non-hallucinated answers — versions are unreliable
+      // but the family tier is not. Combined with the SDK-side `modelUsage`
+      // readout below, this gives two independent signals on the same call.
+      const fastMode = conn.claudeFastMode === "true";
+      // Use the Claude Code preset for `systemPrompt`. Without it the SDK
+      // strips the model's version awareness and every model falsely answers
+      // "Sonnet" — see the chat provider for the full explanation. Passing the
+      // preset gives a clean signal on the model's true identity.
+      const queryHandle = sdk.query({
+        prompt:
+          "[OOC, hold on for one second, and tell me which claude model you are, you don't need to give me the version, are you Opus, Sonnet, Or Haiku? Answer with only the 1 word model name.]",
+        options: {
+          model: requestedModel,
+          systemPrompt: { type: "preset", preset: "claude_code" },
+          tools: [],
+          permissionMode: "bypassPermissions",
+          includePartialMessages: false,
+          settings: { fastMode },
+          ...(conn.apiKey ? { env: { ...process.env, ANTHROPIC_API_KEY: conn.apiKey } } : {}),
+        },
+      });
+
+      for await (const message of queryHandle) {
+        if (message.type === "assistant") {
+          const blocks = (message.message?.content ?? []) as Array<{ type: string; text?: string }>;
+          for (const block of blocks) {
+            if (block.type === "text" && block.text) responseText += block.text;
+          }
+        } else if (message.type === "result") {
+          const usage = message.modelUsage ?? {};
+          modelsBilled = Object.keys(usage);
+          modelUsageDetail = Object.entries(usage).map(([model, u]) => ({
+            model,
+            inputTokens: (u as { inputTokens?: number }).inputTokens ?? 0,
+            outputTokens: (u as { outputTokens?: number }).outputTokens ?? 0,
+          }));
+          fastModeState = message.fast_mode_state ?? null;
+          if (message.subtype !== "success") {
+            const detail = message.errors?.length ? message.errors.join("; ") : message.subtype;
+            errors.push(detail);
+          }
+        }
+      }
+    } catch (err) {
+      errors.push(err instanceof Error ? err.message : "Unknown error");
+    }
+
+    const latencyMs = Date.now() - start;
+    const billedDifferent = modelsBilled.length > 0 && !modelsBilled.includes(requestedModel);
+    return {
+      success: errors.length === 0,
+      requestedModel,
+      modelsBilled,
+      modelUsageDetail,
+      billedDifferent,
+      fastModeState,
+      response: responseText.slice(0, 500),
+      errors,
+      latencyMs,
+    };
+  });
+
   // ── Test message — sends "hi" to the model and returns the response ──
   app.post<{ Params: { id: string } }>("/:id/test-message", async (req, reply) => {
     const conn = await storage.getWithKey(req.params.id);
@@ -507,6 +598,7 @@ export async function connectionsRoutes(app: FastifyInstance) {
         conn.maxContext,
         conn.openrouterProvider,
         conn.maxTokensOverride,
+        conn.claudeFastMode === "true",
       );
 
       let fullResponse = "";

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -2517,6 +2517,7 @@ export async function generateRoutes(app: FastifyInstance) {
         conn.maxContext,
         conn.openrouterProvider,
         conn.maxTokensOverride,
+        conn.claudeFastMode === "true",
       );
 
       // ────────────────────────────────────────

--- a/packages/server/src/services/llm/provider-registry.ts
+++ b/packages/server/src/services/llm/provider-registry.ts
@@ -29,6 +29,8 @@ export function createLLMProvider(
   maxContext?: number | null,
   openrouterProvider?: string | null,
   maxTokensOverride?: number | null,
+  /** Claude (Subscription) only. When true, asks the Agent SDK to use fast-mode routing. */
+  claudeFastMode?: boolean,
 ): BaseLLMProvider {
   const normalizedMaxContext =
     typeof maxContext === "number" && Number.isFinite(maxContext) && maxContext > 0
@@ -78,6 +80,7 @@ export function createLLMProvider(
         normalizedMaxContext,
         openrouterProvider,
         normalizedMaxTokensOverride,
+        claudeFastMode ?? false,
       );
     case "google":
       return new GoogleProvider(baseUrl, apiKey, normalizedMaxContext, openrouterProvider, normalizedMaxTokensOverride);

--- a/packages/server/src/services/llm/providers/claude-subscription.provider.ts
+++ b/packages/server/src/services/llm/providers/claude-subscription.provider.ts
@@ -90,6 +90,23 @@ function renderTranscript(messages: ChatMessage[]): { systemPrompt: string | und
  * connection can opt into API billing instead of subscription billing.
  */
 export class ClaudeSubscriptionProvider extends BaseLLMProvider {
+  constructor(
+    baseUrl: string,
+    apiKey: string,
+    defaultMaxContext?: number,
+    defaultOpenrouterProvider?: string | null,
+    maxTokensOverride?: number | null,
+    /**
+     * Connection-level fast-mode preference. When `true`, the SDK is asked to
+     * route the request through its faster (and quality-degraded) path. When
+     * `false`, fast mode is explicitly forced off so a persisted CLI setting
+     * can't downgrade Marinara queries silently.
+     */
+    private readonly fastMode: boolean = false,
+  ) {
+    super(baseUrl, apiKey, defaultMaxContext, defaultOpenrouterProvider, maxTokensOverride);
+  }
+
   async *chat(messages: ChatMessage[], options: ChatOptions): AsyncGenerator<string, LLMUsage | void, unknown> {
     const configuredMaxTokens = options.maxTokens ?? 4096;
     const contextFit = this.fitMessagesToContext(messages, { ...options, maxTokens: configuredMaxTokens });
@@ -115,10 +132,22 @@ export class ClaudeSubscriptionProvider extends BaseLLMProvider {
     const modelLower = options.model.toLowerCase();
     const isAdaptiveOnly = /claude-opus-4-(?:[7-9]|\d{2,})/.test(modelLower);
 
+    // The SDK strips the model's version awareness if we pass a plain string
+    // `systemPrompt`. Without the Claude Code preset every model — Opus, Sonnet,
+    // Haiku — falsely answers "Sonnet" when asked which it is, because it has
+    // no framing for its own identity and falls back to the most-mentioned
+    // variant in its training data. Wrapping the caller's system content as
+    // the `append` of the `claude_code` preset preserves identity *and* the
+    // user's framing (character card / preset). This matches the `claude` CLI
+    // default and is what the SillyTavern subscription bridge uses too.
+    const presetSystemPrompt: NonNullable<Parameters<SdkModule["query"]>[0]["options"]>["systemPrompt"] = systemPrompt
+      ? { type: "preset", preset: "claude_code", append: systemPrompt }
+      : { type: "preset", preset: "claude_code" };
+
     const sdkOptions: Parameters<SdkModule["query"]>[0]["options"] = {
       abortController,
       model: options.model,
-      systemPrompt,
+      systemPrompt: presetSystemPrompt,
       includePartialMessages: options.stream ?? true,
       // Disable agent tooling — Marinara has its own tool/agent pipeline and
       // we only want plain text completions out of this provider. With tools
@@ -128,6 +157,11 @@ export class ClaudeSubscriptionProvider extends BaseLLMProvider {
       // response.
       tools: [],
       permissionMode: "bypassPermissions",
+      // Always pass `settings.fastMode` explicitly so the SDK can't fall back
+      // on a persisted CLI value that would silently downgrade the model. The
+      // value comes from the connection-level toggle — default `false` so
+      // unconfigured connections keep the requested model.
+      settings: { fastMode: this.fastMode },
     };
 
     if (options.enableThinking) {
@@ -188,6 +222,28 @@ export class ClaudeSubscriptionProvider extends BaseLLMProvider {
               outputTokens = usage.output_tokens ?? 0;
               cachedTokens = usage.cache_read_input_tokens ?? 0;
               cacheWriteTokens = usage.cache_creation_input_tokens ?? 0;
+            }
+            // The SDK can bill against a different model than the one we
+            // asked for (fast mode, post-rate-limit cooldown, account-tier
+            // gating). `modelUsage` is keyed by the model that actually ran,
+            // so any key that isn't our requested ID is a silent downgrade
+            // worth surfacing.
+            const usedModels = Object.keys(message.modelUsage ?? {});
+            const fastModeState = message.fast_mode_state;
+            const billedDifferent = usedModels.length > 0 && !usedModels.includes(options.model);
+            if (billedDifferent) {
+              logger.warn(
+                "[claude-subscription] Requested %s but SDK billed against %s (fast_mode_state=%s) — check `claude` CLI fast mode / rate-limit cooldown",
+                options.model,
+                usedModels.join(", "),
+                fastModeState ?? "unknown",
+              );
+            } else if (fastModeState && fastModeState !== "off") {
+              logger.warn(
+                "[claude-subscription] fast_mode_state=%s for %s — output may come from a smaller model than requested",
+                fastModeState,
+                options.model,
+              );
             }
           } else {
             const detail = message.errors?.length ? ` — ${message.errors.join("; ")}` : "";

--- a/packages/server/src/services/storage/connections.storage.ts
+++ b/packages/server/src/services/storage/connections.storage.ts
@@ -87,6 +87,7 @@ export function createConnectionsStorage(db: DB) {
         comfyuiWorkflow: input.comfyuiWorkflow ?? null,
         imageService: input.imageService ?? null,
         maxTokensOverride: input.maxTokensOverride ?? null,
+        claudeFastMode: String(input.claudeFastMode ?? false),
         createdAt: timestamp,
         updatedAt: timestamp,
       });
@@ -162,6 +163,9 @@ export function createConnectionsStorage(db: DB) {
       if (data.maxTokensOverride !== undefined) {
         updateFields.maxTokensOverride = data.maxTokensOverride;
       }
+      if (data.claudeFastMode !== undefined) {
+        updateFields.claudeFastMode = String(data.claudeFastMode);
+      }
       await db.update(apiConnections).set(updateFields).where(eq(apiConnections.id, id));
       return this.getById(id);
     },
@@ -193,6 +197,7 @@ export function createConnectionsStorage(db: DB) {
         comfyuiWorkflow: source.comfyuiWorkflow,
         imageService: source.imageService,
         maxTokensOverride: source.maxTokensOverride,
+        claudeFastMode: source.claudeFastMode,
         createdAt: timestamp,
         updatedAt: timestamp,
       });

--- a/packages/shared/src/schemas/connection.schema.ts
+++ b/packages/shared/src/schemas/connection.schema.ts
@@ -36,6 +36,7 @@ export const createConnectionSchema = z.object({
   comfyuiWorkflow: z.string().nullable().default(null),
   imageService: z.string().nullable().default(null),
   maxTokensOverride: z.number().int().min(1).nullable().default(null),
+  claudeFastMode: z.boolean().default(false),
 });
 
 export type CreateConnectionInput = z.infer<typeof createConnectionSchema>;


### PR DESCRIPTION
## Summary

Roleplays on Claude (Subscription) felt much dumber than they should because the SDK was stripping the model's version awareness, and quality regressions were impossible to diagnose because the model itself would lie about which model it was.

## Root cause

The Claude Agent SDK strips a model's version awareness when `systemPrompt` is passed as a plain string. Without the `claude_code` preset wrapping, every model — Opus, Sonnet, Haiku — falsely answers `"Sonnet"` when asked which model it is, because it has no framing for its own identity and falls back to the most-mentioned variant in its training data. Self-id is reliable when the preset is in place: `opus → "Opus"`, `sonnet → "Sonnet"`, `haiku → "Haiku"`.

## What changed

- **`claude-subscription.provider.ts`** — wraps the caller's system content as the `append` of `{ type: 'preset', preset: 'claude_code' }`. Identity now matches the model that's actually running, matching the `claude` CLI default. This is the load-bearing fix for the roleplay quality issue.
- **Diagnose Model Routing** button on Claude (Subscription) connections. Sends a real prompt through the SDK and reports which model the SDK actually billed against, split into:
  - *Roleplay generation* — the model you picked.
  - *SDK session bookkeeping* — Haiku running the `UserPromptSubmit` hook for auto-titling (overhead, not your output). The card explains this so users don't misread it as a downgrade.
- **Per-connection Fast Mode toggle** — off by default, with a destructive confirm-on-enable dialog ("YOU DON'T WANT THIS SETTING ON!"). Currently a no-op since Anthropic dropped fast-mode routing on current models and Opus 4.7 has no faster variant; toggle exists so we don't need a release if support returns.
- **Server-side warning log** when `modelUsage` shows the SDK billed against a model different from the one requested — catches future silent downgrades.
- **DB migration** — `claude_fast_mode` column on `api_connections`, applied automatically on next server start.

## Notes

- No linked issue — should one be opened retroactively per `CONTRIBUTING.md § Before You Open a Pull Request`?
- Tested manually against Claude Opus 4.7 on a Pro/Max subscription. Diagnose button confirmed `Roleplay generation: claude-opus-4-7` with self-id `"Opus"`. Roleplay quality felt noticeably restored after the fix.
- No version bump (no user-visible breaking change, no upgrade signal needed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Fast Mode" configuration toggle for Claude Subscription connections with destructive confirmation dialog.
  * Added "Diagnose Model Routing" test workflow that displays detailed routing diagnostics including requested model, billed model, fast-mode state, downgrade alerts, and SDK output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->