### PR TITLE
Promote misplaced thinking content to visible text

### DIFF
--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -5155,15 +5155,16 @@ export async function generateRoutes(app: FastifyInstance) {
 
       let fullResponse = "";
       let fullThinking = "";
+      let providerThinking = "";
       let allResponses: string[] = [];
 
-      // Callback for collecting thinking/reasoning from the model
-      const onThinking = showThoughts
-        ? (chunk: string) => {
-            fullThinking += chunk;
-            trySendSseEvent(reply, { type: "thinking", data: chunk });
-          }
-        : undefined;
+      const onThinking = (chunk: string) => {
+        providerThinking += chunk;
+        if (showThoughts) {
+          fullThinking += chunk;
+          trySendSseEvent(reply, { type: "thinking", data: chunk });
+        }
+      };
       const captureReasoning = chatMode === "roleplay" && showThoughts;
 
       // Helper: write text content progressively as small SSE token chunks
@@ -5448,6 +5449,7 @@ export async function generateRoutes(app: FastifyInstance) {
         // Reset per-character accumulators
         fullResponse = "";
         fullThinking = "";
+        providerThinking = "";
         let geminiResponseParts: unknown[] | null = null;
         let chatCompletionsReasoning: Record<string, unknown> | null = null;
         const rememberChatCompletionsReasoning = (metadata: Record<string, unknown>) => {
@@ -5843,6 +5845,27 @@ export async function generateRoutes(app: FastifyInstance) {
           // ── Parse and strip hidden character commands ──
           let parsedCommands: CharacterCommand[] = [];
           let contentReplaced = false;
+          const promotableThinking = providerThinking.trim() || fullThinking.trim();
+          // Some OpenAI-compatible providers misplace the actual assistant text
+          // in reasoning/thinking fields even when reasoning was not requested.
+          if (
+            chatMode === "conversation" &&
+            !fullResponse.trim() &&
+            promotableThinking &&
+            !enableThinking &&
+            !resolvedEffort
+          ) {
+            logger.warn(
+              "[generate] Promoting thinking-only response to visible text for chat %s (char: %s, model: %s)",
+              input.chatId,
+              targetCharId,
+              conn.model,
+            );
+            fullResponse = promotableThinking;
+            fullThinking = "";
+            providerThinking = "";
+            contentReplaced = true;
+          }
           if (chatMode === "conversation" && !input.impersonate) {
             const parsed = parseCharacterCommands(fullResponse);
             if (parsed.commands.length > 0) {


### PR DESCRIPTION
Some OpenAI-compatible providers put the actual assistant response in reasoning/thinking fields even when reasoning was not requested. When that happens in conversation mode, promote the thinking content to the visible response and log a warning.

## Linked issue

No linked issue yet. TODO: open or link a bug report before marking this PR ready for review.

## Why this change

- Conversation mode can report an empty model response even when an OpenAI-compatible provider returned a natural assistant reply in a reasoning/thinking field.
- This showed up in debug logs as `LLM response (0 chars)` with the actual reply under `Thinking tokens`, while reasoning was disabled (`EnableThinking: false`, `Effort: none`).
- The result is confusing for users because the provider did answer, but Marinara treats the visible response as empty.

## What changed

- Capture provider thinking/reasoning chunks separately from the user-facing `showThoughts` buffer.
- In Conversation mode only, promote thinking-only content into the visible response when visible text is empty and reasoning was not requested.
- Keep existing Convo command parsing after promotion so any visible character commands in the recovered text are still parsed and stripped.
- Clear the thinking buffer after promotion so recovered visible text is not also stored as thinking.

## Validation

- [X] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [X] Above manual verification completed (describe below)
- [X] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- I was able to repro this issue a user on discord was having.
- After implementing this fix/workaround, couldn't repro initial issue. The model conveniently started behaving itself, although logs still visibly show a "thinking" process before writing reply, so idk what that says about the whole enableThinking: False thing. Replies come back normal anyhow.

## Docs and release impact

- [X] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of AI-generated responses containing reasoning-only content
  * Enhanced separation of internal reasoning from user-visible response text

<!-- end of auto-generated comment: release notes by coderabbit.ai -->