### PR TITLE
fix(combat): use configured persona/character HP at combat init

### DIFF
--- a/packages/server/src/routes/encounter.routes.ts
+++ b/packages/server/src/routes/encounter.routes.ts
@@ -109,8 +109,9 @@ async function buildCharacterContext(chars: ReturnType<typeof createCharactersSt
     // combat should always start at full HP regardless of the card's stale
     // `value` field — narrative damage applies after combat begins.
     const rpg = data.extensions?.rpgStats;
-    if (rpg?.enabled && rpg.hp?.max) {
-      ctx += `Max HP: ${rpg.hp.max}\n`;
+    const allyMaxHp = Number(rpg?.hp?.max);
+    if (rpg?.enabled && Number.isFinite(allyMaxHp) && allyMaxHp > 0) {
+      ctx += `Max HP: ${allyMaxHp}\n`;
       if (Array.isArray(rpg.attributes) && rpg.attributes.length > 0) {
         ctx += `Attributes: ${rpg.attributes.map((a: { name: string; value: number }) => `${a.name} ${a.value}`).join(", ")}\n`;
       }
@@ -161,9 +162,15 @@ async function buildPersonaContext(
   // The bar/stat `value` field is the running gameplay value and is not
   // authoritative for combat entry.
   if (personaStats?.enabled && Array.isArray(personaStats.bars) && personaStats.bars.length > 0) {
-    ctx += `Persona Stat Bars (configured max for each):\n`;
+    const renderedBars: string[] = [];
     for (const bar of personaStats.bars as Array<{ name: string; value: number; max: number }>) {
-      ctx += `- ${bar.name} max: ${bar.max}\n`;
+      const max = Number(bar.max);
+      if (Number.isFinite(max) && max > 0) {
+        renderedBars.push(`- ${bar.name} max: ${max}\n`);
+      }
+    }
+    if (renderedBars.length > 0) {
+      ctx += `Persona Stat Bars (configured max for each):\n${renderedBars.join("")}`;
     }
   }
   const personaRpg = personaStats?.rpgStats as
@@ -173,9 +180,10 @@ async function buildPersonaContext(
         hp?: { value: number; max: number };
       }
     | undefined;
-  if (personaRpg?.enabled && personaRpg.hp?.max) {
+  const personaMaxHp = Number(personaRpg?.hp?.max);
+  if (personaRpg?.enabled && Number.isFinite(personaMaxHp) && personaMaxHp > 0) {
     ctx += `Persona RPG Stats:\n`;
-    ctx += `- Max HP: ${personaRpg.hp.max}\n`;
+    ctx += `- Max HP: ${personaMaxHp}\n`;
     if (Array.isArray(personaRpg.attributes) && personaRpg.attributes.length > 0) {
       ctx += `- Attributes: ${personaRpg.attributes.map((a) => `${a.name} ${a.value}`).join(", ")}\n`;
     }

--- a/packages/server/src/routes/encounter.routes.ts
+++ b/packages/server/src/routes/encounter.routes.ts
@@ -103,6 +103,18 @@ async function buildCharacterContext(chars: ReturnType<typeof createCharactersSt
     ctx += `<character="${data.name}">\n`;
     if (data.description) ctx += `${data.description}\n`;
     if (data.personality) ctx += `${data.personality}\n`;
+    // RPG stats from the character card (Marinara extension). Surface the
+    // configured max HP so the combat-init AI honors the user-defined value
+    // instead of inventing one for allies. Only `max` is exposed because
+    // combat should always start at full HP regardless of the card's stale
+    // `value` field — narrative damage applies after combat begins.
+    const rpg = data.extensions?.rpgStats;
+    if (rpg?.enabled && rpg.hp?.max) {
+      ctx += `Max HP: ${rpg.hp.max}\n`;
+      if (Array.isArray(rpg.attributes) && rpg.attributes.length > 0) {
+        ctx += `Attributes: ${rpg.attributes.map((a: { name: string; value: number }) => `${a.name} ${a.value}`).join(", ")}\n`;
+      }
+    }
     ctx += `</character>\n\n`;
   }
   return ctx;
@@ -130,6 +142,44 @@ async function buildPersonaContext(
   if (persona.personality) ctx += `${persona.personality}\n`;
   if (persona.backstory) ctx += `${persona.backstory}\n`;
   if (persona.appearance) ctx += `${persona.appearance}\n`;
+  // Surface configured persona stats (status bars + RPG attributes) so the
+  // combat-init AI uses the user-defined HP instead of inventing values.
+  // `personaStats` is stored as a JSON string of { enabled, bars, rpgStats? }.
+  let personaStats: Record<string, unknown> | null = null;
+  if (persona.personaStats) {
+    if (typeof persona.personaStats === "string") {
+      try {
+        personaStats = JSON.parse(persona.personaStats);
+      } catch {
+        personaStats = null;
+      }
+    } else {
+      personaStats = persona.personaStats as Record<string, unknown>;
+    }
+  }
+  // Only configured maxes are exposed — combat always starts at full HP.
+  // The bar/stat `value` field is the running gameplay value and is not
+  // authoritative for combat entry.
+  if (personaStats?.enabled && Array.isArray(personaStats.bars) && personaStats.bars.length > 0) {
+    ctx += `Persona Stat Bars (configured max for each):\n`;
+    for (const bar of personaStats.bars as Array<{ name: string; value: number; max: number }>) {
+      ctx += `- ${bar.name} max: ${bar.max}\n`;
+    }
+  }
+  const personaRpg = personaStats?.rpgStats as
+    | {
+        enabled?: boolean;
+        attributes?: Array<{ name: string; value: number }>;
+        hp?: { value: number; max: number };
+      }
+    | undefined;
+  if (personaRpg?.enabled && personaRpg.hp?.max) {
+    ctx += `Persona RPG Stats:\n`;
+    ctx += `- Max HP: ${personaRpg.hp.max}\n`;
+    if (Array.isArray(personaRpg.attributes) && personaRpg.attributes.length > 0) {
+      ctx += `- Attributes: ${personaRpg.attributes.map((a) => `${a.name} ${a.value}`).join(", ")}\n`;
+    }
+  }
   return { personaName: persona.name, personaCtx: ctx };
 }
 
@@ -279,8 +329,8 @@ function buildInitPrompt(
   inst += `- dialogueCues: optional, short, and only for named allies, named enemies, bosses, or important NPCs. Generic unnamed enemies should not get voiced lines.\n`;
   inst += `- visuals: set isBossFight true only for bosses/story-significant enemies. backgroundPrompt/illustrationPrompt are optional and only for important fights.\n`;
   inst += `- statuses: format {"name":"Status","emoji":"💀","duration":X,"modifier":-2,"stat":"attack|defense|speed|hp"}\n`;
-  inst += `- Use the player's stats/inventory from the context to populate their data.\n`;
-  inst += `- Ensure HP values are realistic for the setting. Return ONLY the JSON.\n`;
+  inst += `- HP values: if the persona section above lists a configured Max HP (from stat bars named HP/Health/etc, or from "Max HP" under Persona RPG Stats), use that EXACT number for the player's maxHp, and set hp = maxHp so combat starts at full health. If a character ally has a "Max HP: N" line in its block, do the same for that ally. Do NOT invent or "rebalance" a defined Max HP, and do NOT start any combatant below full HP at combat init. Only invent HP for combatants (enemies, unstatted allies) that have no defined HP in the context.\n`;
+  inst += `- Use the player's stats/inventory from the context to populate their data. Return ONLY the JSON.\n`;
   inst += `- Write ALL text values (environment, descriptions, attack names, item names, etc.) in the same language the chat history is written in.\n`;
 
   msgs.push({ role: "user", content: inst });


### PR DESCRIPTION
## Linked issue

Closes #551

## Why this change

In Game Mode, when the GM emits `[state: combat]` the client calls `POST /encounter/init` to generate the combat blueprint. The init-prompt builders sent no HP information about the configured persona or party characters, so the AI had nothing to copy from and was forced to invent fresh HP/maxHp for every party combatant — and the explicit instruction "Ensure HP values are realistic for the setting" further encouraged invention. A persona configured with Max HP 1000 would routinely enter combat with some unrelated lower number; companions with character-card RPG stats got the same treatment.

## What changed

In `packages/server/src/routes/encounter.routes.ts`:

- `buildPersonaContext` now parses `persona.personaStats` and surfaces the configured stat bars (max only) and `personaStats.rpgStats` (Max HP + attributes) when enabled.
- `buildCharacterContext` now surfaces each ally's `data.extensions.rpgStats` (Max HP + attributes) when enabled.
- The `buildInitPrompt` instruction line was rewritten: if a combatant has a configured Max HP in the context, copy it into `maxHp` and set `hp = maxHp` so combat starts at full health. Enemies and unstatted combatants still get AI-generated HP.

Only `max` is exposed (not the running `value` field) so a depleted in-narrative HP value doesn't drag the player into a fresh fight at low/zero HP — combat entry is always full health, and the GM can apply damage tags afterwards if narration calls for it.

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

Tested on a Docker-deployed dev instance against the live `/encounter/init` route with a frontier model:

1. Started a Game Mode chat with a persona configured via `personaStats.bars` (HP bar set with `max = 1000`) and a party that included a companion character card with `extensions.rpgStats.enabled = true, hp.max = 100`.
2. Played until the GM emitted `[state: combat]`.
3. **Before fix:** persona showed up at e.g. `100/1000` (or unrelated values), party characters at `0/100` with KO icons.
4. **After fix:** persona entered combat at `1000/1000`, party characters at `100/100`, all at full health. Enemies still received sensible AI-generated HP.

Edge cases not exercised in browser:
- A persona/character with no configured stats — the gating `if` branches simply skip the extra context, and the AI-invents path still applies as before. No regression expected.

## Docs and release impact

- [x] No docs changes needed

## UI evidence (if applicable)

Server-side prompt fix; no UI changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced encounter generation to properly honor user-configured character HP and persona statistics. Combat encounters now consistently use configured maximum HP values and character attributes as defined in character/persona settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->