### PR TITLE
Fix embedded lorebook deletion and ghost editor states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 - Game mode party changes made from Chat Settings now sync to game metadata and carry into future sessions.
 - NanoGPT GPT Image 2 requests now normalize image size to a supported pixel budget instead of forwarding too-small canvases.
 - Conversation manual generations now share the autonomous in-progress guard, preventing async catch-up replies from duplicating the same user turn.
+- Edits made via "Edit Linked Lorebook" on a character with an embedded lorebook now persist back to the character's V2 `character_book`, so deleted entries no longer reappear when the character is reopened, and deleting the linked lorebook clears the embedded copy on the character and evicts the cached lorebook detail instead of leaving stale entries, a phantom Reimport button, and a ghost lorebook editor behind. Imported character cards no longer carry over a foreign `lorebookId` pointer in their extensions, the character editor verifies the linked lorebook actually exists before showing "Edit Linked Lorebook", and the lorebook editor surfaces a 404 with a toast instead of an infinite loading shimmer when opened against a deleted lorebook.
 
 ## [1.5.7]
 

--- a/packages/client/src/components/characters/CharacterEditor.tsx
+++ b/packages/client/src/components/characters/CharacterEditor.tsx
@@ -30,7 +30,7 @@ import {
   type SpriteInfo,
 } from "../../hooks/use-characters";
 import { useUIStore } from "../../stores/ui.store";
-import { lorebookKeys } from "../../hooks/use-lorebooks";
+import { lorebookKeys, useLorebook } from "../../hooks/use-lorebooks";
 import { showConfirmDialog } from "../../lib/app-dialogs";
 import { SpriteGenerationModal } from "../ui/SpriteGenerationModal";
 import {
@@ -2453,8 +2453,18 @@ function LorebookTab({ characterId, formData }: { characterId: string | null; fo
     importMetadata.embeddedLorebook && typeof importMetadata.embeddedLorebook === "object"
       ? (importMetadata.embeddedLorebook as Record<string, unknown>)
       : {};
-  const linkedLorebookId =
+  const rawLinkedLorebookId =
     typeof embeddedLorebookMetadata.lorebookId === "string" ? embeddedLorebookMetadata.lorebookId : null;
+  // Verify the pointed-to lorebook actually exists. Cards exported from
+  // another Marinara instance can carry a stale `lorebookId` in their
+  // extensions, and an auto-import that errored silently can leave the
+  // pointer set without a real DB row. If we trust the raw pointer the
+  // "Edit Linked Lorebook" button opens an editor that can never resolve
+  // (its loading state is `isLoading || !lorebook`, and a 404'd query
+  // satisfies the second clause forever), so verify before showing it.
+  const linkedLorebookQuery = useLorebook(rawLinkedLorebookId);
+  const linkedLorebookId =
+    rawLinkedLorebookId && (linkedLorebookQuery.isLoading || linkedLorebookQuery.data) ? rawLinkedLorebookId : null;
   const hasEmbeddedLorebook = entries.length > 0 || embeddedLorebookMetadata.hasEmbeddedLorebook === true;
 
   const handleImportEmbeddedLorebook = async () => {

--- a/packages/client/src/components/lorebooks/LorebookEditor.tsx
+++ b/packages/client/src/components/lorebooks/LorebookEditor.tsx
@@ -126,7 +126,7 @@ const SORT_OPTIONS: Array<{ value: EntrySortKey; label: string }> = [
 export function LorebookEditor() {
   const lorebookId = useUIStore((s) => s.lorebookDetailId);
   const closeDetail = useUIStore((s) => s.closeLorebookDetail);
-  const { data: rawLorebook, isLoading } = useLorebook(lorebookId);
+  const { data: rawLorebook, isLoading, isError } = useLorebook(lorebookId);
   const { data: rawLorebooks } = useLorebooks();
   const { data: rawEntries } = useLorebookEntries(lorebookId);
   const { data: rawFolders } = useLorebookFolders(lorebookId);
@@ -683,6 +683,20 @@ export function LorebookEditor() {
       closeDetail();
     }
   }, [lorebookDirty, closeDetail]);
+
+  // If the editor is opened with a `lorebookId` that no longer resolves on
+  // the server (a stale pointer carried over from another Marinara
+  // instance's character export, or one that survived an auto-import that
+  // errored), the loading branch — `isLoading || !lorebook` — would render
+  // a shimmer forever. Detect the 404 explicitly and bail back to the
+  // previous view with a toast so the user is not stranded.
+  useEffect(() => {
+    if (!lorebookId) return;
+    if (isError) {
+      toast.error("Lorebook not found — it may have been deleted");
+      closeDetail();
+    }
+  }, [lorebookId, isError, closeDetail]);
 
   const handleDelete = useCallback(async () => {
     if (!lorebookId) return;

--- a/packages/client/src/hooks/use-lorebooks.ts
+++ b/packages/client/src/hooks/use-lorebooks.ts
@@ -4,6 +4,7 @@
 import { useQuery, useQueries, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "../lib/api-client";
 import type { Lorebook, LorebookEntry, LorebookFolder } from "@marinara-engine/shared";
+import { characterKeys } from "./use-characters";
 
 export const lorebookKeys = {
   all: ["lorebooks"] as const,
@@ -62,8 +63,25 @@ export function useDeleteLorebook() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (id: string) => api.delete(`/lorebooks/${id}`),
-    onSuccess: () => {
+    onSuccess: (_data, id) => {
+      // Evict the deleted lorebook's detail + entries instead of just
+      // marking them stale. `useLorebook`/`useLorebookEntries` set
+      // staleTime to 5 minutes, and TanStack returns cached `data` even
+      // after a refetch errors — so without explicit removal the next
+      // "Edit Linked Lorebook" click would render a ghost editor with
+      // the deleted lorebook's name and metadata while the entries
+      // query reports 0 entries from the server.
+      qc.removeQueries({ queryKey: lorebookKeys.detail(id) });
+      qc.removeQueries({ queryKey: lorebookKeys.entries(id) });
       qc.invalidateQueries({ queryKey: lorebookKeys.all });
+      // The server clears `character_book` and the
+      // `extensions.importMetadata.embeddedLorebook` pointer for any
+      // character this lorebook was linked to. We do not know that
+      // characterId client-side (the detail cache may already be gone
+      // by this point), so blanket-invalidate character queries —
+      // missing this lets the character editor keep rendering stale
+      // entries and a broken "Edit Linked Lorebook" button.
+      qc.invalidateQueries({ queryKey: characterKeys.all });
     },
   });
 }
@@ -132,6 +150,12 @@ export function useCreateLorebookEntry() {
     onSuccess: (_data, variables) => {
       qc.invalidateQueries({ queryKey: lorebookKeys.entries(variables.lorebookId) });
       qc.invalidateQueries({ queryKey: [...lorebookKeys.all, "active"] });
+      // Entry mutations on a character-linked lorebook are mirrored
+      // server-side into `character.data.character_book`, so any
+      // currently-mounted CharacterEditor must refetch — otherwise its
+      // Lorebook tab keeps rendering pre-mutation entries (the
+      // character query has a 5-minute staleTime).
+      qc.invalidateQueries({ queryKey: characterKeys.all });
     },
   });
 }
@@ -145,6 +169,7 @@ export function useUpdateLorebookEntry() {
       qc.invalidateQueries({ queryKey: lorebookKeys.entries(variables.lorebookId) });
       qc.invalidateQueries({ queryKey: lorebookKeys.entry(variables.entryId) });
       qc.invalidateQueries({ queryKey: [...lorebookKeys.all, "active"] });
+      qc.invalidateQueries({ queryKey: characterKeys.all });
     },
   });
 }
@@ -157,6 +182,7 @@ export function useDeleteLorebookEntry() {
     onSuccess: (_data, variables) => {
       qc.invalidateQueries({ queryKey: lorebookKeys.entries(variables.lorebookId) });
       qc.invalidateQueries({ queryKey: [...lorebookKeys.all, "active"] });
+      qc.invalidateQueries({ queryKey: characterKeys.all });
     },
   });
 }
@@ -169,6 +195,7 @@ export function useBulkCreateEntries() {
     onSuccess: (_data, variables) => {
       qc.invalidateQueries({ queryKey: lorebookKeys.entries(variables.lorebookId) });
       qc.invalidateQueries({ queryKey: [...lorebookKeys.all, "active"] });
+      qc.invalidateQueries({ queryKey: characterKeys.all });
     },
   });
 }

--- a/packages/client/src/hooks/use-lorebooks.ts
+++ b/packages/client/src/hooks/use-lorebooks.ts
@@ -2,7 +2,7 @@
 // React Query: Lorebook hooks
 // ──────────────────────────────────────────────
 import { useQuery, useQueries, useMutation, useQueryClient } from "@tanstack/react-query";
-import { api } from "../lib/api-client";
+import { api, ApiError } from "../lib/api-client";
 import type { Lorebook, LorebookEntry, LorebookFolder } from "@marinara-engine/shared";
 import { characterKeys } from "./use-characters";
 
@@ -33,6 +33,7 @@ export function useLorebook(id: string | null) {
     queryFn: () => api.get<Lorebook>(`/lorebooks/${id}`),
     enabled: !!id,
     staleTime: 5 * 60_000,
+    retry: (failureCount, error) => !(error instanceof ApiError && error.status === 404) && failureCount < 3,
   });
 }
 
@@ -230,6 +231,7 @@ export function useTransferLorebookEntries() {
       qc.invalidateQueries({ queryKey: lorebookKeys.entries(variables.sourceLorebookId) });
       qc.invalidateQueries({ queryKey: lorebookKeys.entries(variables.targetLorebookId) });
       qc.invalidateQueries({ queryKey: [...lorebookKeys.all, "active"] });
+      qc.invalidateQueries({ queryKey: characterKeys.all });
     },
   });
 }

--- a/packages/server/src/routes/lorebooks.routes.ts
+++ b/packages/server/src/routes/lorebooks.routes.ts
@@ -215,7 +215,7 @@ export async function lorebooksRoutes(app: FastifyInstance) {
     await storage.remove(req.params.id);
 
     if (linkedCharacterId) {
-      await clearCharacterEmbeddedLorebook(app.db, linkedCharacterId);
+      await clearCharacterEmbeddedLorebook(app.db, linkedCharacterId, req.params.id);
     }
     return reply.status(204).send();
   });

--- a/packages/server/src/routes/lorebooks.routes.ts
+++ b/packages/server/src/routes/lorebooks.routes.ts
@@ -18,6 +18,10 @@ import { createChatsStorage } from "../services/storage/chats.storage.js";
 import { createCharactersStorage } from "../services/storage/characters.storage.js";
 import { createConnectionsStorage } from "../services/storage/connections.storage.js";
 import { processLorebooks } from "../services/lorebook/index.js";
+import {
+  syncCharacterBookFromLorebook,
+  clearCharacterEmbeddedLorebook,
+} from "../services/lorebook/character-book-sync.js";
 import { createLLMProvider } from "../services/llm/provider-registry.js";
 import type { APIProvider } from "@marinara-engine/shared";
 import { normalizeTimestampOverrides } from "../services/import/import-timestamps.js";
@@ -198,9 +202,21 @@ export async function lorebooksRoutes(app: FastifyInstance) {
   });
 
   app.delete<{ Params: { id: string } }>("/:id", async (req, reply) => {
+    // Capture the linked characterId BEFORE removal — once the row is gone
+    // we can no longer recover it, and the character still holds a stale
+    // pointer at extensions.importMetadata.embeddedLorebook that needs
+    // clearing alongside the V2 character_book mirror.
+    const lorebook = (await storage.getById(req.params.id)) as Record<string, unknown> | null;
+    const linkedCharacterId =
+      lorebook && typeof lorebook.characterId === "string" ? lorebook.characterId : null;
+
     const chatsStorage = createChatsStorage(app.db);
     await chatsStorage.removeLorebookFromChatMetadata(req.params.id);
     await storage.remove(req.params.id);
+
+    if (linkedCharacterId) {
+      await clearCharacterEmbeddedLorebook(app.db, linkedCharacterId);
+    }
     return reply.status(204).send();
   });
 
@@ -299,7 +315,9 @@ export async function lorebooksRoutes(app: FastifyInstance) {
       lorebookId: req.params.id,
     });
     try {
-      return await storage.createEntry(input);
+      const created = await storage.createEntry(input);
+      await syncCharacterBookFromLorebook(app.db, req.params.id);
+      return created;
     } catch (err) {
       if (err instanceof Error && err.message === "folderId does not belong to this lorebook") {
         return reply.status(400).send({ error: err.message });
@@ -313,6 +331,7 @@ export async function lorebooksRoutes(app: FastifyInstance) {
     try {
       const updated = await storage.updateEntry(req.params.entryId, input);
       if (!updated) return reply.status(404).send({ error: "Entry not found" });
+      await syncCharacterBookFromLorebook(app.db, req.params.id);
       return updated;
     } catch (err) {
       if (err instanceof Error && err.message === "folderId does not belong to this lorebook") {
@@ -326,6 +345,7 @@ export async function lorebooksRoutes(app: FastifyInstance) {
     "/:lorebookId/entries/:entryId",
     async (req, reply) => {
       await storage.removeEntry(req.params.entryId);
+      await syncCharacterBookFromLorebook(app.db, req.params.lorebookId);
       return reply.status(204).send();
     },
   );
@@ -341,7 +361,9 @@ export async function lorebooksRoutes(app: FastifyInstance) {
       });
       return rest;
     });
-    return storage.bulkCreateEntries(req.params.id, entries);
+    const result = await storage.bulkCreateEntries(req.params.id, entries);
+    await syncCharacterBookFromLorebook(app.db, req.params.id);
+    return result;
   });
 
   app.post<{ Params: { id: string } }>("/:id/entries/transfer", async (req, reply) => {

--- a/packages/server/src/routes/lorebooks.routes.ts
+++ b/packages/server/src/routes/lorebooks.routes.ts
@@ -198,6 +198,7 @@ export async function lorebooksRoutes(app: FastifyInstance) {
     const input = updateLorebookSchema.parse(req.body);
     const updated = await storage.update(req.params.id, input);
     if (!updated) return reply.status(404).send({ error: "Lorebook not found" });
+    await syncCharacterBookFromLorebook(app.db, req.params.id);
     return updated;
   });
 
@@ -417,7 +418,9 @@ export async function lorebooksRoutes(app: FastifyInstance) {
       for (const entry of sourceEntries) {
         await storage.removeEntry(entry.id);
       }
+      await syncCharacterBookFromLorebook(app.db, req.params.id);
     }
+    await syncCharacterBookFromLorebook(app.db, targetLorebookId);
 
     return {
       operation,

--- a/packages/server/src/services/import/marinara.importer.ts
+++ b/packages/server/src/services/import/marinara.importer.ts
@@ -92,8 +92,25 @@ async function importCharacter(data: unknown, db: DB) {
       : {};
   const existingImportMetadata =
     extensions.importMetadata && typeof extensions.importMetadata === "object"
-      ? (extensions.importMetadata as Record<string, unknown>)
+      ? ({ ...(extensions.importMetadata as Record<string, unknown>) } as Record<string, unknown>)
       : {};
+  // Drop any `lorebookId` carried over from the exporter's database. It
+  // refers to a row in their lorebook table, not ours, so keeping it
+  // leaves an orphan that makes the character editor's "Edit Linked
+  // Lorebook" button open a 404 editor stuck on a permanent shimmer
+  // (`isLoading || !lorebook`). The user can click "Import Embedded
+  // Lorebook" post-import to create a real linked lorebook in this DB.
+  const carriedEmbeddedLorebook =
+    typeof existingImportMetadata.embeddedLorebook === "object" && existingImportMetadata.embeddedLorebook
+      ? (existingImportMetadata.embeddedLorebook as Record<string, unknown>)
+      : null;
+  if (carriedEmbeddedLorebook && "lorebookId" in carriedEmbeddedLorebook) {
+    const { lorebookId: _staleLorebookId, ...sanitized } = carriedEmbeddedLorebook;
+    void _staleLorebookId;
+    existingImportMetadata.embeddedLorebook = sanitized;
+    extensions.importMetadata = existingImportMetadata;
+    charData.extensions = extensions;
+  }
   const cardSpecMetadata =
     typeof d?.spec === "string" || typeof d?.spec_version === "string"
       ? {

--- a/packages/server/src/services/import/st-character.importer.ts
+++ b/packages/server/src/services/import/st-character.importer.ts
@@ -75,13 +75,24 @@ export async function importSTCharacter(raw: Record<string, unknown>, db: DB, op
   const cardSpecMetadata = buildCardSpecMetadata(raw);
   const embeddedLorebookEntries = countEmbeddedLorebookEntries(data.character_book);
   const hasEmbeddedLorebook = embeddedLorebookEntries > 0;
+  // Strip any `lorebookId` carried by the source card. That ID references
+  // the exporter's database (e.g. a different Marinara instance), not
+  // ours, so preserving it leaves an orphan pointer that makes "Edit
+  // Linked Lorebook" open a 404 editor before the auto-import below has
+  // a chance to set the real ID. The fresh value is written below at the
+  // end of the auto-import branch when (and only when) we actually
+  // created a lorebook in this DB.
+  const carriedEmbeddedLorebook =
+    typeof existingImportMetadata.embeddedLorebook === "object" && existingImportMetadata.embeddedLorebook
+      ? (existingImportMetadata.embeddedLorebook as Record<string, unknown>)
+      : {};
+  const { lorebookId: _staleLorebookId, ...sanitizedEmbeddedLorebook } = carriedEmbeddedLorebook;
+  void _staleLorebookId;
   data.extensions[IMPORT_METADATA_KEY] = {
     ...existingImportMetadata,
     ...(cardSpecMetadata ? { card: cardSpecMetadata } : {}),
     embeddedLorebook: {
-      ...(typeof existingImportMetadata.embeddedLorebook === "object" && existingImportMetadata.embeddedLorebook
-        ? (existingImportMetadata.embeddedLorebook as Record<string, unknown>)
-        : {}),
+      ...sanitizedEmbeddedLorebook,
       hasEmbeddedLorebook,
     },
   };

--- a/packages/server/src/services/lorebook/character-book-sync.ts
+++ b/packages/server/src/services/lorebook/character-book-sync.ts
@@ -79,10 +79,29 @@ function toCharacterBook(lorebook: LorebookRow, entries: LoreEntryRow[]): Charac
   };
 }
 
+function getEmbeddedLorebookId(characterData: Record<string, unknown>): string | null {
+  const extensions =
+    characterData.extensions && typeof characterData.extensions === "object"
+      ? (characterData.extensions as Record<string, unknown>)
+      : null;
+  const importMetadata =
+    extensions?.importMetadata && typeof extensions.importMetadata === "object"
+      ? (extensions.importMetadata as Record<string, unknown>)
+      : null;
+  const embeddedLorebook =
+    importMetadata?.embeddedLorebook && typeof importMetadata.embeddedLorebook === "object"
+      ? (importMetadata.embeddedLorebook as Record<string, unknown>)
+      : null;
+  return typeof embeddedLorebook?.lorebookId === "string" ? embeddedLorebook.lorebookId : null;
+}
+
 /**
  * Mirror the current state of a standalone lorebook into its source
  * character's `data.character_book`. No-op when the lorebook has no
- * `characterId` (i.e. it is not the imported copy of an embedded lorebook).
+ * `characterId`, or when the character's embedded-lorebook metadata does
+ * not point at this lorebook. Ordinary character-scoped lorebooks also use
+ * `characterId` for auto-activation, but they must not overwrite the V2
+ * embedded `character_book`.
  *
  * Sync errors are logged but never thrown — the user's primary mutation
  * (entry create/update/delete) has already succeeded by the time this is
@@ -99,6 +118,9 @@ export async function syncCharacterBookFromLorebook(db: DB, lorebookId: string):
     const charactersStorage = createCharactersStorage(db);
     const character = await charactersStorage.getById(characterId);
     if (!character) return;
+
+    const currentData = JSON.parse(character.data) as Record<string, unknown>;
+    if (getEmbeddedLorebookId(currentData) !== lorebookId) return;
 
     const entries = (await lorebookStorage.listEntries(lorebookId)) as LoreEntryRow[];
     const nextBook = toCharacterBook(lorebook, entries);
@@ -128,13 +150,15 @@ export async function syncCharacterBookFromLorebook(db: DB, lorebookId: string):
  * subtree explicitly instead of relying on the merge to preserve sibling
  * keys.
  */
-export async function clearCharacterEmbeddedLorebook(db: DB, characterId: string): Promise<void> {
+export async function clearCharacterEmbeddedLorebook(db: DB, characterId: string, lorebookId: string): Promise<void> {
   try {
     const charactersStorage = createCharactersStorage(db);
     const character = await charactersStorage.getById(characterId);
     if (!character) return;
 
     const currentData = JSON.parse(character.data) as Record<string, unknown>;
+    if (getEmbeddedLorebookId(currentData) !== lorebookId) return;
+
     const extensions =
       currentData.extensions && typeof currentData.extensions === "object"
         ? ({ ...(currentData.extensions as Record<string, unknown>) } as Record<string, unknown>)

--- a/packages/server/src/services/lorebook/character-book-sync.ts
+++ b/packages/server/src/services/lorebook/character-book-sync.ts
@@ -79,6 +79,11 @@ function toCharacterBook(lorebook: LorebookRow, entries: LoreEntryRow[]): Charac
   };
 }
 
+function parseCharacterData(data: unknown): Record<string, unknown> {
+  if (typeof data === "string") return JSON.parse(data) as Record<string, unknown>;
+  return data && typeof data === "object" ? (data as Record<string, unknown>) : {};
+}
+
 function getEmbeddedLorebookId(characterData: Record<string, unknown>): string | null {
   const extensions =
     characterData.extensions && typeof characterData.extensions === "object"
@@ -119,7 +124,7 @@ export async function syncCharacterBookFromLorebook(db: DB, lorebookId: string):
     const character = await charactersStorage.getById(characterId);
     if (!character) return;
 
-    const currentData = JSON.parse(character.data) as Record<string, unknown>;
+    const currentData = parseCharacterData(character.data);
     if (getEmbeddedLorebookId(currentData) !== lorebookId) return;
 
     const entries = (await lorebookStorage.listEntries(lorebookId)) as LoreEntryRow[];
@@ -156,7 +161,7 @@ export async function clearCharacterEmbeddedLorebook(db: DB, characterId: string
     const character = await charactersStorage.getById(characterId);
     if (!character) return;
 
-    const currentData = JSON.parse(character.data) as Record<string, unknown>;
+    const currentData = parseCharacterData(character.data);
     if (getEmbeddedLorebookId(currentData) !== lorebookId) return;
 
     const extensions =

--- a/packages/server/src/services/lorebook/character-book-sync.ts
+++ b/packages/server/src/services/lorebook/character-book-sync.ts
@@ -1,0 +1,163 @@
+// ──────────────────────────────────────────────
+// Service: Character ↔ Linked Lorebook sync
+// ──────────────────────────────────────────────
+//
+// When an embedded lorebook is imported via
+// POST /characters/:id/embedded-lorebook/import the resulting standalone
+// lorebook keeps a back-pointer (`lorebooks.characterId`) to its source
+// character, and the character keeps a forward pointer at
+// `data.extensions.importMetadata.embeddedLorebook.lorebookId`.
+//
+// Subsequent edits flow through /lorebooks/* — they mutate the standalone
+// row and entries but, without sync, leave the V2 `data.character_book`
+// frozen at import time. The character editor's Lorebook tab reads from
+// `data.character_book` directly, so deletes/edits made via "Edit Linked
+// Lorebook" appeared to roll back when the editor was reopened (issue:
+// users could not delete embedded lorebook entries).
+//
+// These helpers mirror standalone-lorebook mutations back into the
+// character's `data.character_book` so the two stores stay coherent.
+
+import type { DB } from "../../db/connection.js";
+import type { CharacterBook, CharacterBookEntry } from "@marinara-engine/shared";
+import { createLorebooksStorage } from "../storage/lorebooks.storage.js";
+import { createCharactersStorage } from "../storage/characters.storage.js";
+import { logger } from "../../lib/logger.js";
+
+type LoreEntryRow = Record<string, unknown>;
+type LorebookRow = Record<string, unknown>;
+
+function asString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function asNumber(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.map(String).filter(Boolean) : [];
+}
+
+/**
+ * Map a standalone-lorebook entry row (post `parseEntryRow`) onto a V2
+ * Character Book entry. Field mapping mirrors the inverse done by
+ * `importSTLorebook`. Position 1 in the DB maps to "after_char"; anything
+ * else collapses to "before_char" because the V2 spec only has those two
+ * values.
+ */
+function toCharacterBookEntry(entry: LoreEntryRow, index: number): CharacterBookEntry {
+  const order = asNumber(entry.order, 100);
+  const position = entry.position === 1 ? "after_char" : "before_char";
+  return {
+    keys: asStringArray(entry.keys),
+    content: asString(entry.content),
+    extensions: {},
+    enabled: entry.enabled === true,
+    insertion_order: order,
+    case_sensitive: entry.caseSensitive === true,
+    name: asString(entry.name, `Entry ${index + 1}`),
+    priority: order,
+    id: index,
+    comment: asString(entry.description),
+    selective: entry.selective === true,
+    secondary_keys: asStringArray(entry.secondaryKeys),
+    constant: entry.constant === true,
+    position,
+  };
+}
+
+function toCharacterBook(lorebook: LorebookRow, entries: LoreEntryRow[]): CharacterBook {
+  return {
+    name: asString(lorebook.name, "Character Lorebook"),
+    description: asString(lorebook.description),
+    scan_depth: asNumber(lorebook.scanDepth, 2),
+    token_budget: asNumber(lorebook.tokenBudget, 2048),
+    recursive_scanning: lorebook.recursiveScanning === true,
+    extensions: {},
+    entries: entries.map((entry, index) => toCharacterBookEntry(entry, index)),
+  };
+}
+
+/**
+ * Mirror the current state of a standalone lorebook into its source
+ * character's `data.character_book`. No-op when the lorebook has no
+ * `characterId` (i.e. it is not the imported copy of an embedded lorebook).
+ *
+ * Sync errors are logged but never thrown — the user's primary mutation
+ * (entry create/update/delete) has already succeeded by the time this is
+ * called, and a sync failure should not surface as an HTTP error.
+ */
+export async function syncCharacterBookFromLorebook(db: DB, lorebookId: string): Promise<void> {
+  try {
+    const lorebookStorage = createLorebooksStorage(db);
+    const lorebook = (await lorebookStorage.getById(lorebookId)) as LorebookRow | null;
+    if (!lorebook) return;
+    const characterId = typeof lorebook.characterId === "string" ? lorebook.characterId : null;
+    if (!characterId) return;
+
+    const charactersStorage = createCharactersStorage(db);
+    const character = await charactersStorage.getById(characterId);
+    if (!character) return;
+
+    const entries = (await lorebookStorage.listEntries(lorebookId)) as LoreEntryRow[];
+    const nextBook = toCharacterBook(lorebook, entries);
+
+    await charactersStorage.update(
+      characterId,
+      { character_book: nextBook },
+      undefined,
+      { skipVersionSnapshot: true },
+    );
+  } catch (err) {
+    logger.error(err, "Failed to sync character_book from lorebook %s", lorebookId);
+  }
+}
+
+/**
+ * Clear the embedded-lorebook footprint from a character: drop
+ * `data.character_book` and the
+ * `extensions.importMetadata.embeddedLorebook` pointer. Called when the
+ * standalone lorebook is being deleted, so the V2 `character_book` cannot
+ * resurrect on the next character open and the dangling
+ * `lorebookId` pointer cannot leave a broken "Edit Linked Lorebook"
+ * button behind.
+ *
+ * The character storage layer's `update` does a shallow merge of
+ * `CharacterData` fields, so we read-modify-write the `extensions`
+ * subtree explicitly instead of relying on the merge to preserve sibling
+ * keys.
+ */
+export async function clearCharacterEmbeddedLorebook(db: DB, characterId: string): Promise<void> {
+  try {
+    const charactersStorage = createCharactersStorage(db);
+    const character = await charactersStorage.getById(characterId);
+    if (!character) return;
+
+    const currentData = JSON.parse(character.data) as Record<string, unknown>;
+    const extensions =
+      currentData.extensions && typeof currentData.extensions === "object"
+        ? ({ ...(currentData.extensions as Record<string, unknown>) } as Record<string, unknown>)
+        : {};
+    const importMetadata =
+      extensions.importMetadata && typeof extensions.importMetadata === "object"
+        ? ({ ...(extensions.importMetadata as Record<string, unknown>) } as Record<string, unknown>)
+        : null;
+    if (importMetadata && "embeddedLorebook" in importMetadata) {
+      delete importMetadata.embeddedLorebook;
+      extensions.importMetadata = importMetadata;
+    }
+
+    await charactersStorage.update(
+      characterId,
+      {
+        character_book: null,
+        extensions: extensions as never,
+      },
+      undefined,
+      { skipVersionSnapshot: true },
+    );
+  } catch (err) {
+    logger.error(err, "Failed to clear embedded lorebook for character %s", characterId);
+  }
+}


### PR DESCRIPTION
## Linked issue

https://github.com/Pasta-Devs/Marinara-Engine/issues/554

Closes #554 

## Why this change

Edits made via "Edit Linked Lorebook" on a character with an embedded lorebook silently failed to persist: deleted entries reappeared after reopening the character, deleting the lorebook left ghost preview entries plus a phantom Reimport / Edit button, and clicking Edit on a fresh import sometimes opened an editor stuck on a permanent shimmer.

Three coupled root causes:
- An embedded lorebook lives in two stores once imported (the V2 character_book inside the character JSON, and a standalone DB row), but /lorebooks/* mutations only ever wrote to the standalone row. The character editor's Lorebook tab reads character_book directly, so anything done via "Edit Linked Lorebook" appeared to roll back.
- The character query and the lorebook detail/entries queries both set staleTime: 5 minutes. Lorebook delete invalidated only lorebookKeys.all, never characters, and TanStack returns previously cached `data` even after a refetch errors with 404 — so a stale pointer rendered a populated-looking ghost editor while the entries query honestly reported empty.
- Imported character cards can carry extensions.importMetadata.embeddedLorebook.lorebookId baked in (any card round-tripped through another Marinara instance), and an auto-import that errored silently left the same orphan. LorebookEditor's loading branch is `isLoading || !lorebook`, which a 404'd query satisfies forever.

## What changed

Server:
- New services/lorebook/character-book-sync.ts mirrors entry create / update / delete / bulk back into character.data.character_book when the lorebook is character-linked, and clears character_book + extensions.importMetadata.embeddedLorebook when the linked lorebook is deleted. Sync errors are logged via Pino and never thrown — the user's primary mutation has already succeeded.
- importSTCharacter and the marinara importer now strip any carried-over lorebookId from extensions.importMetadata.embeddedLorebook. The auto-import in importSTCharacter still writes a fresh ID when (and only when) it actually creates a row in this DB.

Client:
- useDeleteLorebook removeQueries the deleted lorebook's detail and entries (eviction, not just invalidation, since 404'd queries hold their last-good data) and invalidates characterKeys.all so the character editor refetches and drops character_book + the stale embedded-lorebook pointer.
- The four entry-mutation hooks (create / update / delete / bulk) also invalidate characterKeys.all, since the new server-side sync writes to character_book on every entry CRUD.
- LorebookTab in CharacterEditor verifies the linked lorebook actually exists via useLorebook(rawLinkedLorebookId) before showing "Edit Linked Lorebook"; a 404 collapses the tab back to "Import Embedded Lorebook" so existing characters with stale pointers still recover.
- LorebookEditor reads isError from useLorebook and, on error, fires a toast and calls closeDetail so the user is no longer stranded on a permanent shimmer if a stale pointer slips through.

## Validation

- [x] `pnpm check` passes locally
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Read and followed `CONTRIBUTING.md`

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Edits to linked lorebooks now persist to characters with embedded lorebooks.
  * Deleting a linked lorebook clears the embedded copy from the character and evicts cached lorebook detail.
  * Prevented stale UI states (phantom reimport buttons, infinite loading, ghost editor panels).
  * Imported character cards no longer retain incorrect embedded lorebook pointers.
  * "Edit Linked Lorebook" now validates existence and shows a not-found error when missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->