### PR TITLE
Fix Memory Recall storing rerolls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,8 +13,8 @@ This file is a thin maintainer note for contributors using Codex. Canonical work
 
 - Keep edits non-destructive. Do not revert unrelated work in the tree.
 - Prefer focused patches that keep code, docs, and release metadata aligned in the same change.
-- Before starting issue work, check for an existing issue-linked branch, open PR, draft PR, or project board item so multiple agents do not duplicate effort.
-- When implementation effort starts for an issue, open a draft PR immediately so the project Kanban board shows the work in progress.
+- Agent-specific coordination rule: before starting issue work, check for an existing issue-linked branch, open PR, draft PR, or project board item so multiple agents do not duplicate effort. See `CONTRIBUTING.md` for the general contributor workflow.
+- Agent-specific coordination rule: when implementation effort starts for an issue, open a draft PR immediately so the project Kanban board shows the work in progress.
 - When preparing a PR, make the why explicit in the description so reviewers can see the user problem or rationale, not just the file changes.
 - Check `README.md`, `android/README.md`, `CONTRIBUTING.md`, `CHANGELOG.md`, `docs/CONFIGURATION.md`, `docs/TROUBLESHOOTING.md`, and `docs/FAQ.md` together when install, update, or release behavior changes.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ This file is a thin maintainer note for contributors using Codex. Canonical work
 - Prefer focused patches that keep code, docs, and release metadata aligned in the same change.
 - Agent-specific coordination rule: before starting issue work, check for an existing issue-linked branch, open PR, draft PR, or project board item so multiple agents do not duplicate effort. See `CONTRIBUTING.md` for the general contributor workflow.
 - Agent-specific coordination rule: when implementation effort starts for an issue, open a draft PR immediately so the project Kanban board shows the work in progress.
+- Agent-specific coordination rule: when starting work on an issue, tag or identify the GitHub user or agent owning that issue/PR on the single issue so ownership is visible before implementation proceeds.
 - When preparing a PR, make the why explicit in the description so reviewers can see the user problem or rationale, not just the file changes.
 - Check `README.md`, `android/README.md`, `CONTRIBUTING.md`, `CHANGELOG.md`, `docs/CONFIGURATION.md`, `docs/TROUBLESHOOTING.md`, and `docs/FAQ.md` together when install, update, or release behavior changes.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,8 @@ This file is a thin maintainer note for contributors using Codex. Canonical work
 
 - Keep edits non-destructive. Do not revert unrelated work in the tree.
 - Prefer focused patches that keep code, docs, and release metadata aligned in the same change.
+- Before starting issue work, check for an existing issue-linked branch, open PR, draft PR, or project board item so multiple agents do not duplicate effort.
+- When implementation effort starts for an issue, open a draft PR immediately so the project Kanban board shows the work in progress.
 - When preparing a PR, make the why explicit in the description so reviewers can see the user problem or rationale, not just the file changes.
 - Check `README.md`, `android/README.md`, `CONTRIBUTING.md`, `CHANGELOG.md`, `docs/CONFIGURATION.md`, `docs/TROUBLESHOOTING.md`, and `docs/FAQ.md` together when install, update, or release behavior changes.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,8 +13,8 @@ This file is a thin maintainer note for contributors using Claude. Canonical wor
 
 - Keep edits non-destructive. Do not revert unrelated work in the tree.
 - Prefer focused patches that keep code, docs, and release metadata aligned in the same change.
-- Before starting issue work, check for an existing issue-linked branch, open PR, draft PR, or project board item so multiple agents do not duplicate effort.
-- When implementation effort starts for an issue, open a draft PR immediately so the project Kanban board shows the work in progress.
+- Agent-specific coordination rule: before starting issue work, check for an existing issue-linked branch, open PR, draft PR, or project board item so multiple agents do not duplicate effort. See `CONTRIBUTING.md` for the general contributor workflow.
+- Agent-specific coordination rule: when implementation effort starts for an issue, open a draft PR immediately so the project Kanban board shows the work in progress.
 - When preparing a PR, make the why explicit in the description so reviewers can see the user problem or rationale, not just the file changes.
 - Check `README.md`, `android/README.md`, `CONTRIBUTING.md`, `CHANGELOG.md`, `docs/CONFIGURATION.md`, `docs/TROUBLESHOOTING.md`, and `docs/FAQ.md` together when install, update, or release behavior changes.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ This file is a thin maintainer note for contributors using Claude. Canonical wor
 - Prefer focused patches that keep code, docs, and release metadata aligned in the same change.
 - Agent-specific coordination rule: before starting issue work, check for an existing issue-linked branch, open PR, draft PR, or project board item so multiple agents do not duplicate effort. See `CONTRIBUTING.md` for the general contributor workflow.
 - Agent-specific coordination rule: when implementation effort starts for an issue, open a draft PR immediately so the project Kanban board shows the work in progress.
+- Agent-specific coordination rule: when starting work on an issue, tag or identify the GitHub user or agent owning that issue/PR on the single issue so ownership is visible before implementation proceeds.
 - When preparing a PR, make the why explicit in the description so reviewers can see the user problem or rationale, not just the file changes.
 - Check `README.md`, `android/README.md`, `CONTRIBUTING.md`, `CHANGELOG.md`, `docs/CONFIGURATION.md`, `docs/TROUBLESHOOTING.md`, and `docs/FAQ.md` together when install, update, or release behavior changes.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,8 @@ This file is a thin maintainer note for contributors using Claude. Canonical wor
 
 - Keep edits non-destructive. Do not revert unrelated work in the tree.
 - Prefer focused patches that keep code, docs, and release metadata aligned in the same change.
+- Before starting issue work, check for an existing issue-linked branch, open PR, draft PR, or project board item so multiple agents do not duplicate effort.
+- When implementation effort starts for an issue, open a draft PR immediately so the project Kanban board shows the work in progress.
 - When preparing a PR, make the why explicit in the description so reviewers can see the user problem or rationale, not just the file changes.
 - Check `README.md`, `android/README.md`, `CONTRIBUTING.md`, `CHANGELOG.md`, `docs/CONFIGURATION.md`, `docs/TROUBLESHOOTING.md`, and `docs/FAQ.md` together when install, update, or release behavior changes.
 

--- a/packages/server/src/services/storage/chats.storage.ts
+++ b/packages/server/src/services/storage/chats.storage.ts
@@ -646,6 +646,7 @@ export function createChatsStorage(db: DB) {
       const remaining = swipes.filter((s: any) => s.index !== index);
       const currentExtra = typeof msg.extra === "string" ? JSON.parse(msg.extra) : (msg.extra ?? {});
 
+      const activeSwipeRemoved = msg.activeSwipeIndex === index;
       let nextActiveSwipeIndex = msg.activeSwipeIndex;
       let nextContent = msg.content;
       let nextExtra = currentExtra;
@@ -681,7 +682,9 @@ export function createChatsStorage(db: DB) {
           extra: JSON.stringify(nextExtra),
         })
         .where(eq(messages.id, messageId));
-      await invalidateMemoryChunksFrom(db, msg.chatId, msg.createdAt);
+      if (activeSwipeRemoved) {
+        await invalidateMemoryChunksFrom(db, msg.chatId, msg.createdAt);
+      }
 
       return this.getMessage(messageId);
     },

--- a/packages/server/src/services/storage/chats.storage.ts
+++ b/packages/server/src/services/storage/chats.storage.ts
@@ -594,6 +594,9 @@ export function createChatsStorage(db: DB) {
           .update(messages)
           .set({ activeSwipeIndex: nextIndex, content, extra: JSON.stringify(clearedExtra) })
           .where(eq(messages.id, messageId));
+        if (msg) {
+          await invalidateMemoryChunksFrom(db, msg.chatId, msg.createdAt);
+        }
       }
       return { id, index: nextIndex };
     },
@@ -626,6 +629,9 @@ export function createChatsStorage(db: DB) {
           extra: JSON.stringify(swipeExtra),
         })
         .where(eq(messages.id, messageId));
+      if (msg) {
+        await invalidateMemoryChunksFrom(db, msg.chatId, msg.createdAt);
+      }
       return this.getMessage(messageId);
     },
 
@@ -675,6 +681,7 @@ export function createChatsStorage(db: DB) {
           extra: JSON.stringify(nextExtra),
         })
         .where(eq(messages.id, messageId));
+      await invalidateMemoryChunksFrom(db, msg.chatId, msg.createdAt);
 
       return this.getMessage(messageId);
     },

--- a/packages/server/test/memory-recall.test.ts
+++ b/packages/server/test/memory-recall.test.ts
@@ -6,7 +6,7 @@ import { drizzle } from "drizzle-orm/libsql";
 import { eq } from "drizzle-orm";
 import type { DB } from "../src/db/connection.js";
 import { runMigrations } from "../src/db/migrate.js";
-import { apiConnections, chats, memoryChunks, messages } from "../src/db/schema/index.js";
+import { apiConnections, chats, memoryChunks, messages, messageSwipes } from "../src/db/schema/index.js";
 import { chatsRoutes } from "../src/routes/chats.routes.js";
 import { chunkAndEmbedMessages, recallMemories } from "../src/services/memory-recall.js";
 import { resolveMemoryRecallEmbeddingSource } from "../src/services/memory-recall-embedding.js";
@@ -72,13 +72,16 @@ test("editing a message invalidates stale memory chunks and refresh rebuilds fro
 
     const app = Fastify({ logger: false });
     app.decorate("db", db);
-    await app.register(chatsRoutes, { prefix: "/api/chats" });
-    await app.ready();
+    try {
+      await app.register(chatsRoutes, { prefix: "/api/chats" });
+      await app.ready();
 
-    const res = await app.inject({ method: "POST", url: "/api/chats/chat-445/memories/refresh" });
-    assert.equal(res.statusCode, 200);
-    assert.deepEqual(res.json(), { rebuilt: 1 });
-    await app.close();
+      const res = await app.inject({ method: "POST", url: "/api/chats/chat-445/memories/refresh" });
+      assert.equal(res.statusCode, 200);
+      assert.deepEqual(res.json(), { rebuilt: 1 });
+    } finally {
+      await app.close();
+    }
 
     const rebuiltChunks = await db.select().from(memoryChunks).where(eq(memoryChunks.chatId, "chat-445"));
 
@@ -254,6 +257,14 @@ test("rerolling a message invalidates stale memory chunks and refresh rebuilds f
       extra: "{}",
       createdAt: "2026-05-08T00:05:00.000Z",
     });
+    await db.insert(messageSwipes).values({
+      id: "swipe-548-reroll-0",
+      messageId: "message-548-reroll",
+      index: 0,
+      content: "The discarded response says the vault code is onion.",
+      extra: "{}",
+      createdAt: "2026-05-08T00:05:00.000Z",
+    });
 
     await db.insert(memoryChunks).values({
       id: "chunk-548",
@@ -274,13 +285,16 @@ test("rerolling a message invalidates stale memory chunks and refresh rebuilds f
 
     const app = Fastify({ logger: false });
     app.decorate("db", db);
-    await app.register(chatsRoutes, { prefix: "/api/chats" });
-    await app.ready();
+    try {
+      await app.register(chatsRoutes, { prefix: "/api/chats" });
+      await app.ready();
 
-    const res = await app.inject({ method: "POST", url: "/api/chats/chat-548/memories/refresh" });
-    assert.equal(res.statusCode, 200);
-    assert.deepEqual(res.json(), { rebuilt: 1 });
-    await app.close();
+      const res = await app.inject({ method: "POST", url: "/api/chats/chat-548/memories/refresh" });
+      assert.equal(res.statusCode, 200);
+      assert.deepEqual(res.json(), { rebuilt: 1 });
+    } finally {
+      await app.close();
+    }
 
     const rebuiltChunks = await db.select().from(memoryChunks).where(eq(memoryChunks.chatId, "chat-548"));
 

--- a/packages/server/test/memory-recall.test.ts
+++ b/packages/server/test/memory-recall.test.ts
@@ -212,3 +212,82 @@ test("memory recall embedding connection does not inherit the active connection 
     client.close();
   }
 });
+
+test("rerolling a message invalidates stale memory chunks and refresh rebuilds from the active swipe", async () => {
+  const client = createClient({ url: "file::memory:" });
+  const db = drizzle(client) as unknown as DB;
+
+  try {
+    await runMigrations(db);
+
+    const now = "2026-05-08T00:00:00.000Z";
+    await db.insert(chats).values({
+      id: "chat-548",
+      name: "Bug 548 repro",
+      mode: "roleplay",
+      characterIds: "[]",
+      metadata: "{}",
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    for (let i = 1; i <= 4; i++) {
+      await db.insert(messages).values({
+        id: `message-548-${i}`,
+        chatId: "chat-548",
+        role: i % 2 === 0 ? "assistant" : "user",
+        characterId: null,
+        content: `Setup message ${i}`,
+        activeSwipeIndex: 0,
+        extra: "{}",
+        createdAt: `2026-05-08T00:0${i}:00.000Z`,
+      });
+    }
+
+    await db.insert(messages).values({
+      id: "message-548-reroll",
+      chatId: "chat-548",
+      role: "assistant",
+      characterId: null,
+      content: "The discarded response says the vault code is onion.",
+      activeSwipeIndex: 0,
+      extra: "{}",
+      createdAt: "2026-05-08T00:05:00.000Z",
+    });
+
+    await db.insert(memoryChunks).values({
+      id: "chunk-548",
+      chatId: "chat-548",
+      content: "Assistant: The discarded response says the vault code is onion.",
+      embedding: null,
+      messageCount: 5,
+      firstMessageAt: "2026-05-08T00:01:00.000Z",
+      lastMessageAt: "2026-05-08T00:05:00.000Z",
+      createdAt: "2026-05-08T00:06:00.000Z",
+    });
+
+    const storage = createChatsStorage(db);
+    await storage.addSwipe("message-548-reroll", "The selected response says the vault code is basil.");
+
+    const chunksAfterReroll = await db.select().from(memoryChunks).where(eq(memoryChunks.chatId, "chat-548"));
+    assert.equal(chunksAfterReroll.length, 0);
+
+    const app = Fastify({ logger: false });
+    app.decorate("db", db);
+    await app.register(chatsRoutes, { prefix: "/api/chats" });
+    await app.ready();
+
+    const res = await app.inject({ method: "POST", url: "/api/chats/chat-548/memories/refresh" });
+    assert.equal(res.statusCode, 200);
+    assert.deepEqual(res.json(), { rebuilt: 1 });
+    await app.close();
+
+    const rebuiltChunks = await db.select().from(memoryChunks).where(eq(memoryChunks.chatId, "chat-548"));
+
+    assert.equal(rebuiltChunks.length, 1);
+    assert.ok(!rebuiltChunks[0]!.content.includes("onion"));
+    assert.ok(rebuiltChunks[0]!.content.includes("basil"));
+  } finally {
+    client.close();
+  }
+});


### PR DESCRIPTION
## What?

Fixes Memory Recall so discarded reroll/swipe content does not stay embedded in chat memory.

- Invalidates memory chunks when adding a non-silent swipe/reroll changes the active message content.
- Invalidates memory chunks when switching the active swipe.
- Invalidates memory chunks when deleting a swipe, including cases where the active content changes.
- Adds regression coverage proving a rerolled assistant message rebuilds memory from the selected swipe instead of the discarded response.
- Documents the project workflow expectation that issue implementation effort should be claimed with an early draft PR.

## Why?

Users reported that rerolled roleplay responses could still be saved into Memory Recall and later influence the narrative, even though those discarded responses are not the visible conversation outcome.

## How?

Message edits and deletes already invalidated memory chunks from the affected message timestamp onward. Swipe operations also mutate the canonical `messages.content` field, but did not invalidate already-built chunks. This change reuses the same invalidation helper in the swipe mutation paths so the next memory refresh or automatic chunking pass rebuilds from the currently active response text.

Silent swipe insertion is left unchanged because it only adds alternate swipe rows without changing the active message content.

## Testing?

- [ ] `pnpm --filter @marinara-engine/server exec tsx --test test/memory-recall.test.ts`
- [ ] `pnpm check`

## Screenshots (optional)

Not included. This is a server-side Memory Recall state correctness fix with no UI changes.

## Anything Else?

Closes #548.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Memory is now invalidated and refreshed when a message's active response/swipe changes, preventing stale cached memory chunks.

* **Tests**
  * Added an integration test covering the message reroll/swipe flow to verify memory chunks are rebuilt correctly.

* **Documentation**
  * Updated contributor guidelines with coordination rules for checking existing work, opening draft PRs when starting implementation, and tagging issue owners.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->