### PR TITLE
Fix Lite Docker install on CPU-only hosts

### DIFF
--- a/Dockerfile.lite
+++ b/Dockerfile.lite
@@ -30,9 +30,11 @@ COPY packages/shared/package.json packages/shared/
 COPY packages/server/package.json packages/server/
 COPY packages/client/package.json packages/client/
 
-# Install all dependencies (including dev for building)
+# Install all dependencies needed for building, skipping optional local-model
+# packages so onnxruntime-node cannot run its GPU postinstall in Lite builds.
 RUN --mount=type=cache,target=/app/.pnpm-store \
-    pnpm install --frozen-lockfile
+    pnpm install --frozen-lockfile --no-optional --ignore-scripts && \
+    pnpm rebuild esbuild
 
 # Copy source code
 COPY tsconfig.base.json ./
@@ -62,21 +64,9 @@ COPY packages/shared/package.json packages/shared/
 COPY packages/server/package.json packages/server/
 COPY packages/client/package.json packages/client/
 
-# Install production deps only, then strip non-core native modules.
+# Install production deps only without optional local-model packages.
 RUN --mount=type=cache,target=/app/.pnpm-store \
-    pnpm install --frozen-lockfile --prod && \
-    # ── Remove onnxruntime (native + WASM) ──
-    rm -rf /app/node_modules/.pnpm/onnxruntime-node@* \
-           /app/node_modules/.pnpm/onnxruntime-web@* \
-           /app/node_modules/.pnpm/onnxruntime-common@* \
-           /app/node_modules/onnxruntime-node \
-           /app/node_modules/onnxruntime-web \
-           /app/node_modules/onnxruntime-common && \
-    # ── Remove @huggingface/transformers (embedding model runtime) ──
-    rm -rf /app/node_modules/.pnpm/@huggingface+transformers@* \
-           /app/node_modules/@huggingface && \
-    # ── Sweep leftover native addons ──
-    find /app/node_modules/.pnpm -name '*.node' -path '*onnxruntime*' -delete 2>/dev/null; true
+    pnpm install --frozen-lockfile --prod --no-optional --ignore-scripts
 
 # Archive node_modules preserving pnpm symlinks — Docker COPY
 # dereferences them which would break module resolution.


### PR DESCRIPTION
## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #557

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- `Dockerfile.lite` advertised local model/runtime removal, but both dependency stages still ran normal `pnpm install` commands. That allowed `onnxruntime-node` optional postinstall scripts to run before the later cleanup step, which can fail on CPU-only hosts while trying to download GPU runtime packages.

## What changed

<!-- List the key changes in this PR -->

- Install Lite build dependencies with `--no-optional --ignore-scripts` so optional local-model packages are not installed and their postinstall scripts cannot run.
- Rebuild only `esbuild` in the builder stage so the client/server build still has the native bundler package it needs.
- Remove the runtime-stage cleanup block for onnxruntime/transformers because the production install now skips optional local-model packages up front.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Codex verification: `CI=true pnpm install --frozen-lockfile --no-optional --ignore-scripts` completed successfully and skipped optional dependencies, matching the new Lite install mode.
- Codex verification: `pnpm check` passed locally after the Dockerfile change.
- Attempted container verification: `docker build -f Dockerfile.lite --target builder --progress=plain -t marinara-engine-lite-issue557-builder .` could not run because the Docker Desktop Linux engine was not running locally (`failed to connect to the docker API at npipe:////./pipe/dockerDesktopLinuxEngine`). This does not block the core install-command claim, but the full container build still needs a human/CI environment with Docker available.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs or release metadata changes included.

## UI evidence (if applicable)

N/A - Dockerfile-only build fix.
