### PR TITLE
Clear game choices on typed turns

### DIFF
--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -5738,6 +5738,7 @@ export function GameSurface({
       if (options?.commitPendingMove && pendingMapMove) {
         moveOnMap.mutate({ chatId: activeChatId, position: pendingMapMove.position, mapId: activeMapId });
       }
+      setActiveChoices(null);
       sendMessage(message, attachments);
       if (options?.commitPendingMove && pendingMapMove) {
         setPendingMapMove(null);


### PR DESCRIPTION
## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #560

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- In game mode, clicking a displayed choice cleared the active choices prompt before sending, but typing the same choice into the chat input sent a normal turn without clearing `activeChoices`, leaving the choices prompt stuck.

## What changed

<!-- List the key changes in this PR -->

- Clear `activeChoices` in the typed game turn send path before calling `sendMessage`, matching the existing clicked-choice cleanup behavior.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Codex verification: `node scratch/issue-560-typed-choice-repro.mjs` passed with both clicked and typed choice paths clearing choices before send.
- Codex verification: `node scratch/issue-560-edge-cases.mjs` passed for clicked choice cleanup, typed turn cleanup, pending map move ordering, and retry-turn cleanup.
- Worker verification: `pnpm check` passed in the issue worktree after installing locked dependencies.
- Coordinator review: re-ran both scratch verification scripts after reviewing the diff.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs or release metadata changes included.

## UI evidence (if applicable)

N/A - behavior is covered by focused send-path repro scripts.
