### PR TITLE
Fix chat background switch race

### DIFF
--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -434,10 +434,17 @@ export function ChatArea() {
   // only set on truthy values, leaving the global chatBackground stale when
   // switching to a chat whose metadata has been cleared, which made a removed
   // background re-appear after a chat switch round-trip.
+  const restoredChatBackgroundRef = useRef<{ chatId: string | null; url: string | null; isSyncing: boolean }>({
+    chatId: null,
+    url: null,
+    isSyncing: false,
+  });
   useEffect(() => {
     if (!chat?.id) return;
     const bg = chatMeta.background as string | null | undefined;
-    useUIStore.getState().setChatBackground(bg ? `/api/backgrounds/file/${encodeURIComponent(bg)}` : null);
+    const restoredUrl = bg ? `/api/backgrounds/file/${encodeURIComponent(bg)}` : null;
+    restoredChatBackgroundRef.current = { chatId: chat.id, url: restoredUrl, isSyncing: true };
+    useUIStore.getState().setChatBackground(restoredUrl);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [chat?.id]);
 
@@ -452,6 +459,14 @@ export function ChatArea() {
   useEffect(() => {
     if (!chat?.id) return;
     const savedFilename = (chatMeta.background as string | null | undefined) ?? null;
+    const restoredBackground = restoredChatBackgroundRef.current;
+
+    if (restoredBackground.isSyncing && (restoredBackground.chatId !== chat.id || chatBackground !== restoredBackground.url)) {
+      return;
+    }
+    if (restoredBackground.isSyncing) {
+      restoredBackground.isSyncing = false;
+    }
 
     if (!chatBackground) {
       if (savedFilename === null) return;


### PR DESCRIPTION
## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #547

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- Rapidly switching between chats could let the background metadata persist effect write the previous chat's background into the newly active chat before the metadata restore finished.

## What changed

<!-- List the key changes in this PR -->

- Track when `ChatArea` is restoring a chat background from metadata during a chat switch.
- Skip persistence while the UI background still reflects the previous chat, then resume normal persistence once the restored background value has landed.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Codex verification: `node scratch/issue-547-background-race-repro.mjs old` reproduced the old race by overwriting chat B metadata from `b.png` to `a.png`.
- Codex verification: `node scratch/issue-547-background-race-repro.mjs fixed` preserved chat B as `b.png`, still persisted a manual background change after restore, and preserved a null saved background.
- Worker verification: `pnpm check` passed in the issue worktree.
- Coordinator review: re-ran both scratch repro modes after reviewing the diff.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs or release metadata changes included.

## UI evidence (if applicable)

N/A - behavior is covered by a focused state-transition repro script.
