### PR TITLE
Enable map regeneration after restored turns

### DIFF
--- a/packages/client/src/components/game/GameMap.tsx
+++ b/packages/client/src/components/game/GameMap.tsx
@@ -374,6 +374,7 @@ interface GameMapProps {
   onMove: (position: { x: number; y: number } | string) => void;
   selectedPosition?: { x: number; y: number } | string | null;
   onGenerateMap?: () => void;
+  generateMapDisabled?: boolean;
   /** Disable interactive elements (e.g. during narration playback) */
   disabled?: boolean;
   /** Current game state — shown as icon left of the location name */
@@ -429,6 +430,7 @@ export function GameMapPanel({
   onMove,
   selectedPosition,
   onGenerateMap,
+  generateMapDisabled,
   disabled,
   gameState,
   timeOfDay,
@@ -571,7 +573,7 @@ export function GameMapPanel({
             showPartyPosition={activeMap}
             zoom={mapZoom}
             topLeftAction={
-              onGenerateMap ? <MapGenerateButton onGenerateMap={onGenerateMap} disabled={disabled} /> : null
+              onGenerateMap ? <MapGenerateButton onGenerateMap={onGenerateMap} disabled={generateMapDisabled} /> : null
             }
             topRightAction={zoomControls}
           />
@@ -584,7 +586,7 @@ export function GameMapPanel({
             showPartyPosition={activeMap}
             zoom={mapZoom}
             topLeftAction={
-              onGenerateMap ? <MapGenerateButton onGenerateMap={onGenerateMap} disabled={disabled} /> : null
+              onGenerateMap ? <MapGenerateButton onGenerateMap={onGenerateMap} disabled={generateMapDisabled} /> : null
             }
             topRightAction={zoomControls}
           />
@@ -604,6 +606,7 @@ interface MobileMapButtonProps {
   onMove: (position: { x: number; y: number } | string) => void;
   selectedPosition?: { x: number; y: number } | string | null;
   onGenerateMap?: () => void;
+  generateMapDisabled?: boolean;
   disabled?: boolean;
   gameState?: GameActiveState;
   timeOfDay?: string | null;
@@ -621,6 +624,7 @@ export function MobileMapButton({
   onMove,
   selectedPosition,
   onGenerateMap,
+  generateMapDisabled,
   disabled,
   gameState,
   timeOfDay,
@@ -798,7 +802,7 @@ export function MobileMapButton({
                     onGenerateMap ? (
                       <MapGenerateButton
                         onGenerateMap={onGenerateMap}
-                        disabled={disabled}
+                        disabled={generateMapDisabled}
                         onAfterGenerate={() => {
                           setOpen(false);
                           setSelectedNode(null);
@@ -824,7 +828,7 @@ export function MobileMapButton({
                     onGenerateMap ? (
                       <MapGenerateButton
                         onGenerateMap={onGenerateMap}
-                        disabled={disabled}
+                        disabled={generateMapDisabled}
                         onAfterGenerate={() => {
                           setOpen(false);
                           setSelectedNode(null);

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -5628,6 +5628,7 @@ export function GameSurface({
   );
 
   const handleGenerateMap = useCallback(() => {
+    if (isStreaming || !sessionInteractive) return;
     const locationType = gameSnapshot?.location?.trim() || "current location";
     const context = [
       `Location: ${gameSnapshot?.location ?? "Unknown"}`,
@@ -5650,7 +5651,9 @@ export function GameSurface({
     gameSnapshot?.time,
     gameSnapshot?.weather,
     generateMap,
+    isStreaming,
     latestNarrationText,
+    sessionInteractive,
   ]);
 
   const isSameMapPosition = useCallback(
@@ -6867,6 +6870,7 @@ export function GameSurface({
                       onMove={handleMapMove}
                       selectedPosition={viewedMapIsActive ? (pendingMapMove?.position ?? null) : null}
                       onGenerateMap={handleGenerateMap}
+                      generateMapDisabled={isStreaming || !sessionInteractive}
                       disabled={isStreaming || !narrationDone || !sessionInteractive}
                       gameState={gameState}
                       timeOfDay={gameSnapshot?.time ?? metaTime ?? null}
@@ -6885,6 +6889,7 @@ export function GameSurface({
                       onMove={handleMapMove}
                       selectedPosition={viewedMapIsActive ? (pendingMapMove?.position ?? null) : null}
                       onGenerateMap={handleGenerateMap}
+                      generateMapDisabled={isStreaming || !sessionInteractive}
                       disabled={isStreaming || !narrationDone || !sessionInteractive}
                       gameState={gameState}
                       timeOfDay={gameSnapshot?.time ?? metaTime ?? null}


### PR DESCRIPTION
## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #565

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- The map panel reused the movement disabled state for the "Generate another map" button. That state includes narration completion, so restored or already-finished turns could leave map generation blocked even when the session was interactive.

## What changed

<!-- List the key changes in this PR -->

- Added a separate `generateMapDisabled` prop for map generation controls.
- Kept map movement narration-gated while allowing map generation whenever the session is interactive and not streaming.
- Added the same streaming/session guard inside `handleGenerateMap`.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Codex verification: `pnpm --dir packages/server exec tsx ..\..\scratch\issue-565-generate-map-gate-repro.ts` passed. It proves the old rule disabled map generation when `isStreaming=false`, `sessionInteractive=true`, and `narrationDone=false`; the new rule enables generation in that state while movement remains narration-gated.
- Codex verification: `pnpm --dir packages/server exec tsx ..\..\scratch\issue-565-map-repro.ts` passed. It proves same-name generated maps remain distinct and the newly generated map becomes active.
- Worker verification: `pnpm check` passed in the issue worktree.
- Coordinator review: re-ran both scratch proofs after reviewing the diff.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs or release metadata changes included.

## UI evidence (if applicable)

N/A - behavior is covered by focused map-state repro scripts.
