### PR TITLE
Render grouped conversation selfie images

### DIFF
--- a/packages/client/src/components/chat/ConversationMessage.tsx
+++ b/packages/client/src/components/chat/ConversationMessage.tsx
@@ -747,6 +747,41 @@ export const ConversationMessage = memo(function ConversationMessage({
           <span className="ml-14 inline-block h-4 w-[0.125rem] animate-pulse rounded-full bg-[var(--foreground)]/50" />
         )}
 
+        {/* Image attachments (selfies, illustrations) */}
+        {extra.attachments && extra.attachments.length > 0 && !IMAGE_URL_RE.test(renderedContent.trim()) && (
+          <div className="ml-14 mt-1.5 flex flex-col items-start gap-2">
+            {extra.attachments.map((att: any, i: number) =>
+              att.type === "image" || att.type?.startsWith("image/") ? (
+                <div key={i} className="group/att relative inline-block">
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setImageLightbox({ url: att.url || att.data, prompt: att.prompt });
+                    }}
+                    className="block cursor-zoom-in rounded-lg text-left"
+                    title="Open image"
+                  >
+                    <img
+                      src={att.url || att.data}
+                      alt={att.filename || att.name || "image"}
+                      className="max-h-80 max-w-full rounded-lg"
+                      loading="lazy"
+                    />
+                  </button>
+                  <button
+                    onClick={() => handleRemoveAttachment(i)}
+                    title="Remove from message"
+                    className="absolute top-1.5 right-1.5 rounded-full bg-black/60 p-1 text-white/80 transition-opacity hover:bg-black/80 hover:text-white sm:opacity-0 sm:group-hover/att:opacity-100"
+                  >
+                    <X size="0.875rem" />
+                  </button>
+                </div>
+              ) : null,
+            )}
+          </div>
+        )}
+
         {!hideActions && hasSwipes && (
           <div className="ml-14 mt-2 flex items-center gap-1.5 px-1 text-[0.6875rem] text-[var(--muted-foreground)]">
             <button


### PR DESCRIPTION
## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #570

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- Generated selfie images were saved and announced by toast, but multi-character conversation messages could render through the grouped speaker branch, which did not include image attachment rendering.

## What changed

<!-- List the key changes in this PR -->

- Render image attachments in the grouped multi-speaker conversation branch, matching normal conversation message behavior.
- Preserve the same lightbox and remove-attachment interactions used by the normal branch.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Codex verification: `node scratch/issue-570-group-selfie-attachments-repro.mjs` passed after the fix, showing both normal and grouped conversation branches render image attachments.
- Worker verification: `pnpm check` passed in the issue worktree.
- Coordinator review: re-ran the focused scratch proof after reviewing the diff.
- Not run: full provider-backed selfie generation from a real configured chat, because this isolated worktree does not have image-generation/LLM provider credentials. This is disclosed as non-blocking because the dropped grouped-renderer path was reproduced and fixed directly.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs or release metadata changes included.

## UI evidence (if applicable)

N/A - behavior is covered by a focused grouped-renderer repro script.
