### PR TITLE
Enable markdown in game journal notes

### DIFF
--- a/docs/pr-evidence/issue-567/journal-markdown-proof.txt
+++ b/docs/pr-evidence/issue-567/journal-markdown-proof.txt
@@ -1,0 +1,12 @@
+Issue 567 verification notes
+
+Claim:
+Game journal library entries and player notes render markdown formatting while the note editor keeps raw plain text editing.
+
+Machine verification:
+- pnpm check passed.
+- Diff review confirms GameJournal renders journal library text and player-note preview text through the existing markdown renderer.
+- The textarea remains the raw editable source for player notes, so plaintext editing behavior is preserved.
+
+Browser screenshot limitation:
+An attempted fresh-browser verification landed in game setup before a usable journal overlay state. A faithful real-app screenshot needs a seeded game-mode fixture with journal content already present.

--- a/packages/client/src/components/game/GameJournal.tsx
+++ b/packages/client/src/components/game/GameJournal.tsx
@@ -9,6 +9,7 @@ import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { X, MapPin, Swords, ScrollText, Package, Users, PenLine, BookOpen, Trash2 } from "lucide-react";
 import { cn } from "../../lib/utils";
 import { api } from "../../lib/api-client";
+import { applyInlineMarkdown, renderMarkdownBlocks } from "../../lib/markdown";
 import { AnimatedText } from "./AnimatedText";
 
 import type { GameNpc } from "@marinara-engine/shared";
@@ -111,6 +112,10 @@ function pruneJournalNpc(journal: Journal, npcName: string): Journal {
 
 function shouldShowNpcDescription(npc: GameNpc): boolean {
   return (npc as GameNpc & { descriptionSource?: string }).descriptionSource === "model" && !!npc.description?.trim();
+}
+
+function JournalMarkdown({ text, className }: { text: string; className?: string }) {
+  return <div className={cn("mari-message-content", className)}>{renderMarkdownBlocks(text, applyInlineMarkdown, "gj")}</div>;
 }
 
 export function GameJournal({ chatId, npcs, onClose, onNpcPortraitClick, onNpcRemove }: GameJournalProps) {
@@ -485,7 +490,7 @@ function LibraryView({ entries }: { entries: JournalEntry[] }) {
               </span>
               <span className="ml-auto text-[0.5625rem] text-white/30">{entry.timestamp}</span>
             </div>
-            <div className="mt-1.5 whitespace-pre-wrap text-xs leading-relaxed text-white/70">{text}</div>
+            <JournalMarkdown text={text} className="mt-1.5 text-xs leading-relaxed text-white/70" />
           </div>
         );
       })}
@@ -506,11 +511,19 @@ function NotesView({ notes, onChange, saved }: { notes: string; onChange: (text:
           {saved ? "Saved" : "Saving..."}
         </span>
       </div>
+      {notes.trim() && (
+        <div className="min-h-0 flex-1 overflow-y-auto rounded-lg border border-white/10 bg-black/30 px-3 py-2.5">
+          <JournalMarkdown text={notes} className="text-xs leading-relaxed text-white/80" />
+        </div>
+      )}
       <textarea
         value={notes}
         onChange={(e) => onChange(e.target.value)}
         placeholder="Write your notes here... track clues, plans, NPC names, theories — anything you want to remember."
-        className="flex-1 resize-none rounded-lg border border-white/10 bg-black/40 px-3 py-2.5 text-xs leading-relaxed text-white/80 outline-none placeholder:text-white/25 focus:border-white/20"
+        className={cn(
+          "resize-none rounded-lg border border-white/10 bg-black/40 px-3 py-2.5 text-xs leading-relaxed text-white/80 outline-none placeholder:text-white/25 focus:border-white/20",
+          notes.trim() ? "min-h-36 flex-[0_0_35%]" : "flex-1",
+        )}
         spellCheck={false}
       />
     </div>


### PR DESCRIPTION
## Linked issue

Closes #567

## Why this change

Game journal notes were plain text only. Players can now use lightweight markdown in journal entries and the player notes preview without losing raw text editing.

## What changed

- Rendered journal library entries and player note previews through the existing markdown renderer.
- Kept the player notes textarea as the raw editable source.
- Added evidence notes for the markdown proof and the remaining browser fixture limitation.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `pnpm check` passed.
- Review of `packages/client/src/components/game/GameJournal.tsx` confirms journal entries and player notes are rendered through the markdown helper while editing stays in the textarea.
- Proof artifact: `docs/pr-evidence/issue-567/journal-markdown-proof.txt`.
- A faithful live-app browser screenshot still needs a seeded game fixture that opens directly into the journal overlay; the fresh browser session landed in setup before that state.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

N/A for now. The current verification artifact is a code/proof note because the journal overlay screenshot still needs a dedicated seeded fixture.
