### PR TITLE
fix(game,combat): apply sheet attribute modifiers to skill checks and combat init

### DIFF
--- a/packages/client/src/components/game/GameCharacterSheet.tsx
+++ b/packages/client/src/components/game/GameCharacterSheet.tsx
@@ -79,6 +79,12 @@ const DEFAULT_ATTRIBUTES = [
   { name: "CHA", value: 10 },
 ];
 
+// Mirrors server's attributeModifier in skill-check.service.ts: floor((score - 10) / 2).
+function formatAttributeModifier(score: number): string {
+  const mod = Math.floor((score - 10) / 2);
+  return mod >= 0 ? `+${mod}` : `${mod}`;
+}
+
 const FIELD_LABEL_CLASS = "text-[0.6875rem] font-semibold uppercase tracking-wider text-[var(--muted-foreground)]";
 const TEXT_INPUT_CLASS =
   "w-full rounded-lg border border-[var(--border)] bg-[var(--secondary)]/60 px-3 py-2 text-sm text-[var(--foreground)] outline-none transition-colors focus:border-[var(--primary)]/40";
@@ -790,6 +796,9 @@ export function GameCharacterSheet({
                         {attr.name}
                       </span>
                       <span className="text-lg font-bold leading-tight text-[var(--foreground)]">{attr.value}</span>
+                      <span className="text-[0.625rem] font-mono leading-none text-[var(--muted-foreground)]">
+                        {formatAttributeModifier(attr.value)}
+                      </span>
                     </div>
                   ))}
                 </div>

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -3107,6 +3107,7 @@ export function GameSurface({
             dc: sc.dc,
             advantage: sc.advantage,
             disadvantage: sc.disadvantage,
+            preRolledD20: sc.preRolledD20,
           },
           {
             onSuccess: (res) => setPendingSkillCheck(res.result),

--- a/packages/client/src/hooks/use-game.ts
+++ b/packages/client/src/hooks/use-game.ts
@@ -487,8 +487,14 @@ export function useRollDice() {
 
 export function useSkillCheck() {
   return useMutation({
-    mutationFn: (data: { chatId: string; skill: string; dc: number; advantage?: boolean; disadvantage?: boolean }) =>
-      api.post<{ result: import("@marinara-engine/shared").SkillCheckResult }>("/game/skill-check", data),
+    mutationFn: (data: {
+      chatId: string;
+      skill: string;
+      dc: number;
+      advantage?: boolean;
+      disadvantage?: boolean;
+      preRolledD20?: number;
+    }) => api.post<{ result: import("@marinara-engine/shared").SkillCheckResult }>("/game/skill-check", data),
   });
 }
 

--- a/packages/client/src/lib/game-tag-parser.ts
+++ b/packages/client/src/lib/game-tag-parser.ts
@@ -35,6 +35,12 @@ export interface SkillCheckTag {
   advantage?: boolean;
   disadvantage?: boolean;
   resolvedResult?: SkillCheckResult;
+  /**
+   * Player-submitted d20 echoed by the GM when a `[dice:1d20]` was rolled
+   * before the check. Forwarded to the server resolver so the sheet's
+   * attribute modifier is applied on top of the player's number.
+   */
+  preRolledD20?: number;
 }
 
 export interface ElementAttackTag {
@@ -318,6 +324,15 @@ function parseSkillCheckTagBody(body: string): SkillCheckTag | null {
   const modeValue = values.get("mode")?.trim().toLowerCase();
 
   if (!rollsValue || Number.isNaN(modifier) || Number.isNaN(total) || !resultValue) {
+    // Sparse tag — server resolver will roll + apply modifier. If the GM echoed
+    // a single integer in rolls="...", treat it as a player-submitted d20.
+    if (rollsValue) {
+      const trimmed = rollsValue.trim();
+      if (/^-?\d+$/.test(trimmed)) {
+        const n = Number.parseInt(trimmed, 10);
+        if (Number.isInteger(n) && n >= 1 && n <= 20) tag.preRolledD20 = n;
+      }
+    }
     return tag;
   }
 

--- a/packages/server/src/routes/encounter.routes.ts
+++ b/packages/server/src/routes/encounter.routes.ts
@@ -7,6 +7,7 @@ import { createConnectionsStorage } from "../services/storage/connections.storag
 import { createCharactersStorage } from "../services/storage/characters.storage.js";
 import { createGameStateStorage } from "../services/storage/game-state.storage.js";
 import { createLorebooksStorage } from "../services/storage/lorebooks.storage.js";
+import { mapSheetAttributesToRPG } from "../services/game/skill-check.service.js";
 import { createLLMProvider } from "../services/llm/provider-registry.js";
 import type { ChatMessage } from "../services/llm/base-provider.js";
 import type {
@@ -196,6 +197,7 @@ async function buildGameStateContext(
   gsStorage: ReturnType<typeof createGameStateStorage>,
   chatId: string,
   personaName: string,
+  chatMeta?: Record<string, unknown> | null,
 ) {
   const gs = await gsStorage.getLatest(chatId);
   if (!gs) return "";
@@ -224,6 +226,34 @@ async function buildGameStateContext(
     if (playerStats.attributes) {
       const a = playerStats.attributes;
       ctx += `Attributes: STR ${a.str}, DEX ${a.dex}, CON ${a.con}, INT ${a.int}, WIS ${a.wis}, CHA ${a.cha}\n`;
+    }
+  }
+
+  // Fallback: if playerStats.attributes is missing (it is never seeded today),
+  // surface the player's Game Mode character-sheet attributes so the encounter
+  // init prompt can scale combat stats to match the build.
+  if (!playerStats?.attributes && chatMeta) {
+    const cards = Array.isArray(chatMeta.gameCharacterCards)
+      ? (chatMeta.gameCharacterCards as Array<Record<string, unknown>>)
+      : [];
+    const playerCard = cards[0];
+    const rpgStats = playerCard?.rpgStats as
+      | { attributes?: Array<{ name: string; value: number }> }
+      | undefined;
+    const mapped = mapSheetAttributesToRPG(rpgStats?.attributes);
+    const ordered: Array<keyof typeof mapped> = ["str", "dex", "con", "int", "wis", "cha"];
+    const present = ordered.filter((k) => mapped[k] != null);
+    if (present.length > 0) {
+      const labels: Record<string, string> = {
+        str: "STR",
+        dex: "DEX",
+        con: "CON",
+        int: "INT",
+        wis: "WIS",
+        cha: "CHA",
+      };
+      const line = present.map((k) => `${labels[k]} ${mapped[k]}`).join(", ");
+      ctx += `${personaName}'s Character Sheet Attributes: ${line}\n`;
     }
   }
 
@@ -338,6 +368,7 @@ function buildInitPrompt(
   inst += `- visuals: set isBossFight true only for bosses/story-significant enemies. backgroundPrompt/illustrationPrompt are optional and only for important fights.\n`;
   inst += `- statuses: format {"name":"Status","emoji":"💀","duration":X,"modifier":-2,"stat":"attack|defense|speed|hp"}\n`;
   inst += `- HP values: if the persona section above lists a configured Max HP (from stat bars named HP/Health/etc, or from "Max HP" under Persona RPG Stats), use that EXACT number for the player's maxHp, and set hp = maxHp so combat starts at full health. If a character ally has a "Max HP: N" line in its block, do the same for that ally. Do NOT invent or "rebalance" a defined Max HP, and do NOT start any combatant below full HP at combat init. Only invent HP for combatants (enemies, unstatted allies) that have no defined HP in the context.\n`;
+  inst += `- RPG attribute scaling: when the context lists Attributes for the player or an ally (STR/DEX/CON/INT/WIS/CHA, on a roughly 8-20 D&D-style scale), let those values shape the generated stats: high STR → stronger physical attack power; high DEX → higher speed and accuracy; high CON → larger HP pool when HP is not already defined; high INT/WIS/CHA → stronger magical/support attack power for casters. Treat 10 as average and scale proportionally. Do NOT override an explicitly configured Max HP using these attributes.\n`;
   inst += `- Use the player's stats/inventory from the context to populate their data. Return ONLY the JSON.\n`;
   inst += `- Write ALL text values (environment, descriptions, attack names, item names, etc.) in the same language the chat history is written in.\n`;
 
@@ -513,7 +544,11 @@ export async function encounterRoutes(app: FastifyInstance) {
       const characterIds: string[] = JSON.parse(chat.characterIds as string);
       const characterCtx = await buildCharacterContext(chars, characterIds);
       const { personaName, personaCtx } = await buildPersonaContext(chars, chat.personaId ?? null);
-      const gameStateCtx = await buildGameStateContext(gsStorage, chatId, personaName);
+      const chatMeta =
+        typeof chat.metadata === "string"
+          ? (JSON.parse(chat.metadata) as Record<string, unknown>)
+          : ((chat.metadata as Record<string, unknown> | null) ?? null);
+      const gameStateCtx = await buildGameStateContext(gsStorage, chatId, personaName, chatMeta);
       const spellbookCtx = await loadSpellbookContext(spellbookId);
 
       // Get recent chat messages for history

--- a/packages/server/src/routes/encounter.routes.ts
+++ b/packages/server/src/routes/encounter.routes.ts
@@ -544,10 +544,16 @@ export async function encounterRoutes(app: FastifyInstance) {
       const characterIds: string[] = JSON.parse(chat.characterIds as string);
       const characterCtx = await buildCharacterContext(chars, characterIds);
       const { personaName, personaCtx } = await buildPersonaContext(chars, chat.personaId ?? null);
-      const chatMeta =
-        typeof chat.metadata === "string"
-          ? (JSON.parse(chat.metadata) as Record<string, unknown>)
-          : ((chat.metadata as Record<string, unknown> | null) ?? null);
+      let chatMeta: Record<string, unknown> | null = null;
+      if (typeof chat.metadata === "string") {
+        try {
+          chatMeta = JSON.parse(chat.metadata) as Record<string, unknown>;
+        } catch {
+          chatMeta = null;
+        }
+      } else {
+        chatMeta = (chat.metadata as Record<string, unknown> | null) ?? null;
+      }
       const gameStateCtx = await buildGameStateContext(gsStorage, chatId, personaName, chatMeta);
       const spellbookCtx = await loadSpellbookContext(spellbookId);
 

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -59,7 +59,12 @@ import { generateWeather, inferBiome, shouldWeatherChange } from "../services/ga
 import { rollEncounter, rollEnemyCount } from "../services/game/encounter.service.js";
 import { processReputationActions } from "../services/game/reputation.service.js";
 import { createCheckpointService, type CheckpointTrigger } from "../services/game/checkpoint.service.js";
-import { resolveSkillCheck, attributeModifier, getGoverningAttribute } from "../services/game/skill-check.service.js";
+import {
+  resolveSkillCheck,
+  attributeModifier,
+  getGoverningAttribute,
+  mapSheetAttributesToRPG,
+} from "../services/game/skill-check.service.js";
 import { applyAllSegmentEdits, stripGmCommandTags } from "../services/game/segment-edits.js";
 import { processLorebooks } from "../services/lorebook/index.js";
 import {
@@ -4709,6 +4714,7 @@ export async function gameRoutes(app: FastifyInstance) {
     dc: z.number().int().min(1).max(40),
     advantage: z.boolean().optional(),
     disadvantage: z.boolean().optional(),
+    preRolledD20: z.number().int().min(1).max(20).optional(),
   });
 
   app.post("/skill-check", async (req) => {
@@ -4721,13 +4727,27 @@ export async function gameRoutes(app: FastifyInstance) {
     // Look up skill modifier
     const skillMod = playerStats?.skills?.[input.skill] ?? playerStats?.skills?.[input.skill.toLowerCase()] ?? 0;
 
-    // Look up governing attribute modifier
+    // Look up governing attribute modifier. Prefer playerStats.attributes
+    // (engine-shape), fall back to the player's character-sheet rpgStats
+    // (free-form names) since playerStats.attributes is never seeded today.
+    const attr = getGoverningAttribute(input.skill);
     let attrMod = 0;
-    if (playerStats?.attributes) {
-      const attr = getGoverningAttribute(input.skill);
-      const score = playerStats.attributes[attr] ?? 10;
-      attrMod = attributeModifier(score);
+    let attrScore: number | null = null;
+    if (playerStats?.attributes && Number.isFinite(Number(playerStats.attributes[attr]))) {
+      attrScore = Number(playerStats.attributes[attr]);
+    } else {
+      const chats = createChatsStorage(app.db);
+      const chat = await chats.getById(input.chatId);
+      const meta = chat ? parseMeta(chat.metadata) : {};
+      const cards = Array.isArray(meta.gameCharacterCards)
+        ? (meta.gameCharacterCards as Array<Record<string, unknown>>)
+        : [];
+      const playerCard = cards[0];
+      const rpgStats = playerCard?.rpgStats as { attributes?: Array<{ name: string; value: number }> } | undefined;
+      const mapped = mapSheetAttributesToRPG(rpgStats?.attributes);
+      if (mapped[attr] != null) attrScore = mapped[attr]!;
     }
+    if (attrScore != null) attrMod = attributeModifier(attrScore);
 
     const result = resolveSkillCheck({
       skill: input.skill,
@@ -4736,6 +4756,7 @@ export async function gameRoutes(app: FastifyInstance) {
       attributeModifier: attrMod,
       advantage: input.advantage,
       disadvantage: input.disadvantage,
+      preRolledD20: input.preRolledD20,
     });
 
     return { result };

--- a/packages/server/src/services/game/gm-prompts.ts
+++ b/packages/server/src/services/game/gm-prompts.ts
@@ -684,11 +684,11 @@ export function buildGmFormatReminder(
 
   if (ctx.playerDiceRollSubmitted) {
     lines.push(
-      `- [skill_check: skill="Skill Name" dc="1-20" rolls="player's dice result" modifier="0-10" total="roll + modifier | 1 | 20" result="critical_success | success | failure | critical_failure"] - if the player presented you with a [dice: ...] roll, start the turn with the check and narrate the consequences in the same turn. Choose DC fairly (5 trivial, 10 routine under pressure, 15 hard, 20 desperate).`,
+      `- [skill_check: skill="Skill Name" dc="1-20" rolls="player's d20 result"] - if the player presented you with a [dice: ...] roll, start the turn with the check tag (echo the player's d20 in rolls=) and narrate the consequences in the same turn. Choose DC fairly (5 trivial, 10 routine under pressure, 15 hard, 20 desperate). The engine applies the player's attribute modifier on top of the rolled number — do NOT compute or invent rolls/modifier/total/result fields, the system fills those in.`,
     );
   } else {
     lines.push(
-      `- [skill_check: skill="Skill Name" dc="1-20" rolls="1-20" modifier="0-10" total="roll + modifier | 1 | 20" result="critical_success | success | failure | critical_failure"] - only when uncertainty or the player's actions should be resolved mechanically. Abandon positivity bias: choose DC (5 trivial, 10 routine under pressure, 15 hard, 20 desperate), roll honestly, and narrate the consequence in the same turn.`,
+      `- [skill_check: skill="Skill Name" dc="1-20"] - only when uncertainty or the player's actions should be resolved mechanically. Abandon positivity bias: choose DC fairly (5 trivial, 10 routine under pressure, 15 hard, 20 desperate) and narrate the consequence in the same turn. Do NOT include rolls/modifier/total/result — the engine rolls the d20, applies the player's attribute modifier, and resolves success/failure deterministically.`,
     );
   }
 

--- a/packages/server/src/services/game/skill-check.service.ts
+++ b/packages/server/src/services/game/skill-check.service.ts
@@ -20,6 +20,12 @@ export interface SkillCheckInput {
   /** Roll with advantage (take higher of 2) or disadvantage (take lower). */
   advantage?: boolean;
   disadvantage?: boolean;
+  /**
+   * Player-submitted d20 result (1-20). When present, skips internal d20()
+   * and uses this value as the used roll, so a [dice:1d20] pre-roll flows
+   * through the same modifier-application code path. Ignored if out of range.
+   */
+  preRolledD20?: number;
 }
 
 export interface SkillCheckResult {
@@ -101,22 +107,68 @@ export function getGoverningAttribute(skill: string): keyof RPGAttributes {
 }
 
 /**
+ * Map character-sheet attribute names (free-form, e.g. "STR", "Strength",
+ * "Dexterity") to the strict {str,dex,...} RPGAttributes shape used for skill
+ * resolution. Case-insensitive; unrecognised names are dropped.
+ */
+const ATTRIBUTE_NAME_MAP: Record<string, keyof RPGAttributes> = {
+  str: "str",
+  strength: "str",
+  dex: "dex",
+  dexterity: "dex",
+  con: "con",
+  constitution: "con",
+  int: "int",
+  intelligence: "int",
+  wis: "wis",
+  wisdom: "wis",
+  cha: "cha",
+  charisma: "cha",
+};
+
+export function mapSheetAttributesToRPG(
+  attrs: ReadonlyArray<{ name: string; value: number }> | null | undefined,
+): Partial<RPGAttributes> {
+  if (!Array.isArray(attrs)) return {};
+  const out: Partial<RPGAttributes> = {};
+  for (const attr of attrs) {
+    if (!attr || typeof attr.name !== "string") continue;
+    const key = ATTRIBUTE_NAME_MAP[attr.name.trim().toLowerCase()];
+    if (!key) continue;
+    const value = Number(attr.value);
+    if (!Number.isFinite(value)) continue;
+    out[key] = value;
+  }
+  return out;
+}
+
+/**
  * Resolve a skill check with d20 + modifiers vs DC.
  */
 export function resolveSkillCheck(input: SkillCheckInput): SkillCheckResult {
   const modifier = input.skillModifier + input.attributeModifier;
 
-  // Roll d20 (twice if advantage/disadvantage)
-  const useAdvantage = input.advantage && !input.disadvantage;
-  const useDisadvantage = input.disadvantage && !input.advantage;
+  // Player-submitted [dice:1d20] short-circuits internal rolling so the
+  // sheet's attribute modifier still applies on top of the player's number.
+  const preRoll =
+    Number.isInteger(input.preRolledD20) && input.preRolledD20! >= 1 && input.preRolledD20! <= 20
+      ? input.preRolledD20!
+      : null;
+
+  // Roll d20 (twice if advantage/disadvantage; ignored when preRoll present)
+  const useAdvantage = !preRoll && input.advantage && !input.disadvantage;
+  const useDisadvantage = !preRoll && input.disadvantage && !input.advantage;
   const rollTwice = useAdvantage || useDisadvantage;
 
-  const rolls = rollTwice ? [d20(), d20()] : [d20()];
-  const usedRoll = rollTwice
-    ? useAdvantage
-      ? Math.max(rolls[0]!, rolls[1]!)
-      : Math.min(rolls[0]!, rolls[1]!)
-    : rolls[0]!;
+  const rolls = preRoll != null ? [preRoll] : rollTwice ? [d20(), d20()] : [d20()];
+  const usedRoll =
+    preRoll != null
+      ? preRoll
+      : rollTwice
+        ? useAdvantage
+          ? Math.max(rolls[0]!, rolls[1]!)
+          : Math.min(rolls[0]!, rolls[1]!)
+        : rolls[0]!;
 
   const total = usedRoll + modifier;
   const criticalSuccess = usedRoll === 20;

--- a/packages/server/test/game-session-prompts.test.ts
+++ b/packages/server/test/game-session-prompts.test.ts
@@ -211,7 +211,7 @@ test("GM format reminder only allows explicit content for NSFW games", () => {
   assert.match(nsfwPrompt, /Adult mode enabled, explicit content allowed\./);
 });
 
-test("GM format reminder documents the simplified resolved skill_check command", () => {
+test("GM format reminder documents the sparse skill_check command for engine-resolved checks", () => {
   const prompt = buildGmFormatReminder({
     gameActiveState: "exploration",
     sessionNumber: 1,
@@ -219,16 +219,28 @@ test("GM format reminder documents the simplified resolved skill_check command",
     playerName: "Mari",
   });
 
-  assert.match(
-    prompt,
-    /\[skill_check: skill="Skill Name" dc="1-20" rolls="1-20" modifier="0-10" total="roll \+ modifier \| 1 \| 20" result="critical_success \| success \| failure \| critical_failure"\]/,
-  );
+  // AI-initiated checks emit only skill + dc; the engine fills in the rest.
+  assert.match(prompt, /\[skill_check: skill="Skill Name" dc="1-20"\]/);
   assert.match(prompt, /when uncertainty or the player's actions should be resolved mechanically\./);
   assert.match(prompt, /Abandon positivity bias/);
-  assert.match(prompt, /roll honestly, and narrate the consequence in the same turn\./);
+  assert.match(prompt, /Do NOT include rolls\/modifier\/total\/result/);
   assert.doesNotMatch(prompt, /Legacy fallback:/);
   assert.doesNotMatch(prompt, /\bused=/);
   assert.doesNotMatch(prompt, /\bmode=/);
+});
+
+test("GM format reminder uses sparse skill_check tag echoing player d20 when a dice roll was submitted", () => {
+  const prompt = buildGmFormatReminder({
+    gameActiveState: "exploration",
+    sessionNumber: 1,
+    partyNames: ["Aster"],
+    playerName: "Mari",
+    playerDiceRollSubmitted: true,
+  });
+
+  assert.match(prompt, /\[skill_check: skill="Skill Name" dc="1-20" rolls="player's d20 result"\]/);
+  assert.match(prompt, /engine applies the player's attribute modifier on top of the rolled number/);
+  assert.match(prompt, /do NOT compute or invent rolls\/modifier\/total\/result fields/);
 });
 
 test("GM format reminder separates HUD widget updates from durable stats", () => {


### PR DESCRIPTION
## Linked issue

Closes #592

## Why this change

- Game Mode skill checks didn't actually use the character sheet's RPG attributes — the GM was instructed to invent the `rolls/modifier/total/result` itself, and the deterministic server resolver almost never ran. Setting `STR 20` on the sheet made no difference to a Strength check outcome.
- Combat Mode encounter init never received the player's character-sheet attributes either — the prompt builder reads from `playerStats.attributes` which is `null` for every chat. The LLM generated `attack/defense/hp` with no link to the player's intended build.
- Three converging gaps caused this: `PlayerStats.attributes` is initialised to `null` in every game-state writer and never seeded; the GM prompt asked the AI to fill in roll math; and the sheet's free-form `Array<{name,value}>` shape never had a mapper to the strict `RPGAttributes: { str, dex, con, int, wis, cha }` shape the engine wants.

## What changed

- **Sheet display** (`packages/client/src/components/game/GameCharacterSheet.tsx`): show the D&D-style modifier next to each attribute on the read-only grid (`STR 17 (+3)`), using the same `floor((score - 10) / 2)` formula the server already implements for skill checks.
- **Name mapper + lazy fallback** (`packages/server/src/services/game/skill-check.service.ts`): added `mapSheetAttributesToRPG` — case-insensitive map from `Array<{name,value}>` (sheet shape; accepts `STR/Str/Strength`, `DEX/Dexterity`, etc.) to `Partial<RPGAttributes>`. Custom names are dropped.
- **Skill-check route** (`packages/server/src/routes/game.routes.ts`): when `playerStats.attributes` is null, falls back to mapping the player's `gameCharacterCards[0].rpgStats.attributes` from chat metadata. No DB migration; existing chats benefit immediately. Schema now also accepts `preRolledD20: 1-20` so a player-submitted `[dice:1d20]` can be applied through the same modifier-aware code path.
- **`resolveSkillCheck`** (`packages/server/src/services/game/skill-check.service.ts`): honours `preRolledD20` — when present, skips internal d20 rolling and uses the player's number as the `usedRoll`, with the attribute modifier applied on top.
- **GM prompt** (`packages/server/src/services/game/gm-prompts.ts`): emits sparse `[skill_check: skill="..." dc="..."]` (or `…rolls="<player's d20>"` after a player pre-roll). The instruction is explicit that the engine fills in modifier/total/result; do not invent them. The client at `components/game/GameSurface.tsx` already had a fallback path to call `/skill-check` when those fields are absent — this PR turns that fallback into the primary path.
- **Tag parser** (`packages/client/src/lib/game-tag-parser.ts`): when a sparse tag carries a single integer in `rolls=`, surfaces it as `preRolledD20` on the parsed tag so the client mutation forwards it to the server.
- **Combat init** (`packages/server/src/routes/encounter.routes.ts`): same lazy fallback — when `playerStats.attributes` is null, reads the player's character-sheet attributes from chat metadata and emits a `Character Sheet Attributes: STR x, DEX y, ...` line in the encounter context. Adds a one-line prompt note instructing the LLM to scale generated `attack/defense/hp` (when not configured) by attribute values on a 10-as-average baseline. Configured Max HP still wins.
- **Tests** (`packages/server/test/game-session-prompts.test.ts`): updated the `skill_check` format-reminder assertions for both the AI-initiated and player-prerolled prompt shapes; added a case for the player-prerolled branch.

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Manually verify that the Game Mode character sheet now shows a `(+N)` / `(−N)` modifier underneath each attribute value in the read-only Attributes grid, matching `floor((score - 10) / 2)`.
- Manually verify that a Strength-governed skill check (e.g. forcing a door) on a character with `STR 20` resolves with a noticeably higher success rate / final total than the same character with `STR 1`.
- Manually verify that the GM no longer narrates invented `rolls/modifier/total/result` numbers — the resolved skill-check popup should reflect the server-rolled d20 plus the deterministic attribute modifier.
- Manually verify the player-prerolled path: submit a `[dice:1d20]` first, then take an action; the resolved roll should equal your d20 plus the sheet's attribute modifier.
- Manually verify a combat encounter init: trigger `[state: combat]` from the GM and confirm the generated party member's `attack/defense/hp` reflects the character's RPG attributes (high STR → noticeably higher attack power; high DEX → higher speed).
- Manually verify the no-data fallback: a chat with no RPG stats configured should still produce a clean d20-vs-DC resolution (modifier `0`), with no broken state.
- Edge case: a chat created before this change has `playerStats.attributes = null` and no migration is needed — the lazy fallback should still pick up the sheet attributes.

## Docs and release impact

- [x] No docs changes needed

## UI evidence (if applicable)

The read-only attribute grid in `GameCharacterSheet` now renders a third row under each value:

```
STR        DEX        CON
17         24         18
+3         +7         +4
```

<img width="993" height="280" alt="image" src="https://github.com/user-attachments/assets/44a046fd-0c2c-47e5-a88e-e310ae74110c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * RPG attribute modifiers now display next to attribute values in character sheets
  * Skill checks now support player-submitted pre-rolled D20 values
  * Character sheet attributes serve as fallback data for combat encounter initialization

* **Improvements**
  * Simplified skill check tag format in GM prompts for clearer instructions

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/593)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->