### PR TITLE
fix(combat): render enemy avatars + wire portrait generation pipeline

### DIFF
--- a/packages/client/src/components/game/GameCombatUI.tsx
+++ b/packages/client/src/components/game/GameCombatUI.tsx
@@ -49,6 +49,27 @@ import {
   X,
 } from "lucide-react";
 
+// `combatant.sprite` is populated either from a real avatar URL (player party,
+// from the character sheet's `avatarUrl`) or from the encounter LLM, which is
+// instructed to emit "emoji or brief visual description" (see
+// `packages/server/src/routes/encounter.routes.ts`). Treat the field as a
+// shape-tagged value so the renderer picks `<img>`, an emoji glyph, or the
+// initials fallback instead of stuffing free text into `<img src>`.
+type SpriteKind = { kind: "url"; value: string } | { kind: "emoji"; value: string } | { kind: "none" };
+
+function resolveSpriteKind(sprite: string | null | undefined): SpriteKind {
+  if (!sprite) return { kind: "none" };
+  const trimmed = sprite.trim();
+  if (!trimmed) return { kind: "none" };
+  if (/^(https?:|\/|data:|blob:)/i.test(trimmed)) return { kind: "url", value: trimmed };
+  // Emoji / single glyph: short strings (≤12 chars to allow ZWJ sequences and
+  // skin-tone modifiers) that contain at least one Extended_Pictographic codepoint.
+  if (trimmed.length <= 12 && /\p{Extended_Pictographic}/u.test(trimmed)) {
+    return { kind: "emoji", value: trimmed };
+  }
+  return { kind: "none" };
+}
+
 // Mobile layout breakpoint. Uses Tailwind's `sm` boundary so the existing
 // desktop classes (`sm:`, `md:`, `lg:`, `xl:`) continue to apply unchanged on
 // the desktop branch and the mobile branch only renders below 640px.
@@ -1332,11 +1353,22 @@ export function GameCombatUI({
               phase === "target-select") && (
               <div className="flex shrink-0 items-center gap-2 border-b border-white/5 px-3 py-1.5">
                 <div className="flex h-7 w-7 items-center justify-center overflow-hidden rounded-full bg-blue-500/20 text-blue-300 ring-1 ring-blue-400/40">
-                  {activePlayer.sprite ? (
-                    <img src={activePlayer.sprite} alt={activePlayer.name} className="h-full w-full object-cover" />
-                  ) : (
-                    <span className="text-[0.65rem] font-bold">{activePlayer.name.charAt(0).toUpperCase()}</span>
-                  )}
+                  {(() => {
+                    const spriteKind = resolveSpriteKind(activePlayer.sprite);
+                    if (spriteKind.kind === "url") {
+                      return (
+                        <img
+                          src={spriteKind.value}
+                          alt={activePlayer.name}
+                          className="h-full w-full object-cover"
+                        />
+                      );
+                    }
+                    if (spriteKind.kind === "emoji") {
+                      return <span className="text-base leading-none">{spriteKind.value}</span>;
+                    }
+                    return <span className="text-[0.65rem] font-bold">{activePlayer.name.charAt(0).toUpperCase()}</span>;
+                  })()}
                 </div>
                 <div className="min-w-0 flex-1">
                   <div className="truncate text-xs font-semibold text-white">{activePlayer.name}</div>
@@ -1842,11 +1874,22 @@ export function GameCombatUI({
             {/* Active character indicator */}
             <div className="mb-1 flex items-center gap-2 sm:mb-0 sm:min-w-[140px]">
               <div className="flex h-8 w-8 items-center justify-center overflow-hidden rounded-full bg-blue-500/20 text-blue-300 ring-1 ring-blue-400/40">
-                {activePlayer.sprite ? (
-                  <img src={activePlayer.sprite} alt={activePlayer.name} className="h-full w-full object-cover" />
-                ) : (
-                  <span className="text-xs font-bold">{activePlayer.name.charAt(0).toUpperCase()}</span>
-                )}
+                {(() => {
+                  const spriteKind = resolveSpriteKind(activePlayer.sprite);
+                  if (spriteKind.kind === "url") {
+                    return (
+                      <img
+                        src={spriteKind.value}
+                        alt={activePlayer.name}
+                        className="h-full w-full object-cover"
+                      />
+                    );
+                  }
+                  if (spriteKind.kind === "emoji") {
+                    return <span className="text-lg leading-none">{spriteKind.value}</span>;
+                  }
+                  return <span className="text-xs font-bold">{activePlayer.name.charAt(0).toUpperCase()}</span>;
+                })()}
               </div>
               <div>
                 <div className="text-xs font-semibold text-white">{activePlayer.name}</div>
@@ -2340,19 +2383,36 @@ function CombatantCard({
           impactTone === "miss" && "game-combatant-impact--miss",
         )}
       >
-        {/* Placeholder sprite (initials) */}
-        {combatant.sprite ? (
-          <img src={combatant.sprite} alt={combatant.name} className="h-full w-full rounded-lg object-cover" />
-        ) : (
-          <span
-            className={cn(
-              "text-xl font-bold sm:text-2xl xl:text-3xl",
-              side === "enemy" ? "text-red-300/60" : "text-blue-300/60",
-            )}
-          >
-            {combatant.name.charAt(0).toUpperCase()}
-          </span>
-        )}
+        {/* Avatar: real image URL, LLM-suggested emoji, or initials placeholder. */}
+        {(() => {
+          const spriteKind = resolveSpriteKind(combatant.sprite);
+          if (spriteKind.kind === "url") {
+            return (
+              <img
+                src={spriteKind.value}
+                alt={combatant.name}
+                className="h-full w-full rounded-lg object-cover"
+              />
+            );
+          }
+          if (spriteKind.kind === "emoji") {
+            return (
+              <span className="text-2xl leading-none sm:text-3xl xl:text-4xl" aria-hidden="true">
+                {spriteKind.value}
+              </span>
+            );
+          }
+          return (
+            <span
+              className={cn(
+                "text-xl font-bold sm:text-2xl xl:text-3xl",
+                side === "enemy" ? "text-red-300/60" : "text-blue-300/60",
+              )}
+            >
+              {combatant.name.charAt(0).toUpperCase()}
+            </span>
+          );
+        })()}
 
         {/* KO overlay */}
         {isKo && (
@@ -2483,11 +2543,20 @@ function MobileCombatantChip({
           side === "enemy" ? "bg-red-500/15 text-red-300/65" : "bg-blue-500/15 text-blue-300/65",
         )}
       >
-        {combatant.sprite ? (
-          <img src={combatant.sprite} alt={combatant.name} className="h-full w-full object-cover" />
-        ) : (
-          <span className="text-sm font-bold">{combatant.name.charAt(0).toUpperCase()}</span>
-        )}
+        {(() => {
+          const spriteKind = resolveSpriteKind(combatant.sprite);
+          if (spriteKind.kind === "url") {
+            return <img src={spriteKind.value} alt={combatant.name} className="h-full w-full object-cover" />;
+          }
+          if (spriteKind.kind === "emoji") {
+            return (
+              <span className="text-lg leading-none" aria-hidden="true">
+                {spriteKind.value}
+              </span>
+            );
+          }
+          return <span className="text-sm font-bold">{combatant.name.charAt(0).toUpperCase()}</span>;
+        })()}
         {isKo && (
           <div className="absolute inset-0 flex items-center justify-center bg-black/55">
             <Skull className="h-4 w-4 text-red-400/80" />

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -4838,30 +4838,37 @@ export function GameSurface({
         // any failure the emoji-fallback renderer in GameCombatUI takes over
         // and we proceed without retrying.
         if (chatMeta.enableSpriteGeneration && combatants.enemies.length > 0) {
+          // Build two lookups for the LLM's portrait prompts:
+          //   - by lowercased name (handles reordering, the schema's documented contract)
+          //   - by index (recovers the prompt when the LLM emits subtly different names
+          //     but keeps the array aligned with `enemies[]`, which is the common case)
+          // Try name first, then index — neither alone covers both failure modes.
           const enemyPromptByName = new Map<string, string>();
-          for (const ep of visuals?.enemyImagePrompts ?? []) {
-            if (ep?.name && ep?.prompt) enemyPromptByName.set(ep.name, ep.prompt);
-          }
-          const descriptionByName = new Map<string, string>();
-          for (const rawEnemy of response.combatState.enemies ?? []) {
-            if (rawEnemy?.name && rawEnemy.description) {
-              descriptionByName.set(rawEnemy.name, rawEnemy.description);
-            }
-          }
+          const enemyPromptByIndex = new Map<number, string>();
+          (visuals?.enemyImagePrompts ?? []).forEach((ep, idx) => {
+            if (!ep?.prompt) return;
+            enemyPromptByIndex.set(idx, ep.prompt);
+            if (ep.name) enemyPromptByName.set(ep.name.toLowerCase(), ep.prompt);
+          });
 
-          // Dedupe by enemy name so e.g. three "Goblin"s share one portrait.
+          // Dedupe by enemy name (case-insensitive) so e.g. three "Goblin"s share one portrait.
           const seen = new Set<string>();
           const npcsNeedingAvatars: Array<{ name: string; description: string }> = [];
-          for (const enemy of combatants.enemies) {
-            if (!enemy.name || seen.has(enemy.name)) continue;
-            seen.add(enemy.name);
+          combatants.enemies.forEach((enemy, index) => {
+            const name = enemy.name?.trim();
+            if (!name) return;
+            const dedupeKey = name.toLowerCase();
+            if (seen.has(dedupeKey)) return;
+            seen.add(dedupeKey);
+            const rawEnemy = response.combatState.enemies?.[index];
             const description = (
-              enemyPromptByName.get(enemy.name) ||
-              descriptionByName.get(enemy.name) ||
-              enemy.name
+              enemyPromptByName.get(dedupeKey) ||
+              enemyPromptByIndex.get(index) ||
+              rawEnemy?.description ||
+              name
             ).slice(0, 1000);
-            npcsNeedingAvatars.push({ name: enemy.name, description });
-          }
+            npcsNeedingAvatars.push({ name, description });
+          });
 
           if (npcsNeedingAvatars.length > 0) {
             try {

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -4821,13 +4821,71 @@ export function GameSurface({
         settings: GAME_COMBAT_GENERATION_SETTINGS,
         spellbookId: null,
       })
-      .then((response) => {
+      .then(async (response) => {
         const combatants = hydrateGeneratedCombatState(response.combatState);
         if (!combatants) {
           throw new Error("Combat generator returned an empty party or enemy list.");
         }
 
         const visuals = response.combatState.visuals;
+
+        // ── Generate enemy portraits before combat starts ──
+        // The encounter LLM emits `enemy.sprite` as an emoji or short visual
+        // description, never a URL. To get a real portrait, feed each unique
+        // enemy through the same `npcsNeedingAvatars` pipeline NPCs use, then
+        // overwrite the hydrated combatant.sprite with the resulting URL.
+        // Block here so combat starts with portraits already populated; on
+        // any failure the emoji-fallback renderer in GameCombatUI takes over
+        // and we proceed without retrying.
+        if (chatMeta.enableSpriteGeneration && combatants.enemies.length > 0) {
+          const enemyPromptByName = new Map<string, string>();
+          for (const ep of visuals?.enemyImagePrompts ?? []) {
+            if (ep?.name && ep?.prompt) enemyPromptByName.set(ep.name, ep.prompt);
+          }
+          const descriptionByName = new Map<string, string>();
+          for (const rawEnemy of response.combatState.enemies ?? []) {
+            if (rawEnemy?.name && rawEnemy.description) {
+              descriptionByName.set(rawEnemy.name, rawEnemy.description);
+            }
+          }
+
+          // Dedupe by enemy name so e.g. three "Goblin"s share one portrait.
+          const seen = new Set<string>();
+          const npcsNeedingAvatars: Array<{ name: string; description: string }> = [];
+          for (const enemy of combatants.enemies) {
+            if (!enemy.name || seen.has(enemy.name)) continue;
+            seen.add(enemy.name);
+            const description = (
+              enemyPromptByName.get(enemy.name) ||
+              descriptionByName.get(enemy.name) ||
+              enemy.name
+            ).slice(0, 1000);
+            npcsNeedingAvatars.push({ name: enemy.name, description });
+          }
+
+          if (npcsNeedingAvatars.length > 0) {
+            try {
+              const assetResult = await runGameAssetGeneration({
+                chatId: activeChatId,
+                npcsNeedingAvatars: npcsNeedingAvatars.slice(0, 10),
+                debugMode: useUIStore.getState().debugMode,
+              });
+              const avatarByName = new Map<string, string>();
+              for (const generated of assetResult?.generatedNpcAvatars ?? []) {
+                if (generated.name && generated.avatarUrl) {
+                  avatarByName.set(generated.name, generated.avatarUrl);
+                }
+              }
+              for (const enemy of combatants.enemies) {
+                const url = avatarByName.get(enemy.name);
+                if (url) enemy.sprite = url;
+              }
+            } catch (err) {
+              console.warn("[game-combat] enemy avatar generation failed; falling back to emoji", err);
+            }
+          }
+        }
+
         const shouldGenerateBossVisuals = !!visuals?.isBossFight && !!chatMeta.enableSpriteGeneration;
         if (shouldGenerateBossVisuals && (visuals.backgroundPrompt || visuals.illustrationPrompt)) {
           const illustrationPrompt = visuals.illustrationPrompt?.trim() || "";
@@ -4887,6 +4945,7 @@ export function GameSurface({
     pendingEncounter,
     queuedCombatGeneration,
     requestAssetGeneration,
+    runGameAssetGeneration,
     scenePreparing,
     transitionGameState,
   ]);

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -4877,14 +4877,19 @@ export function GameSurface({
                 npcsNeedingAvatars: npcsNeedingAvatars.slice(0, 10),
                 debugMode: useUIStore.getState().debugMode,
               });
+              // Match case-insensitively so the assignment stays consistent
+              // with the case-insensitive dedupe above — defends against
+              // casing drift between the request name and what the server
+              // echoes back.
               const avatarByName = new Map<string, string>();
               for (const generated of assetResult?.generatedNpcAvatars ?? []) {
                 if (generated.name && generated.avatarUrl) {
-                  avatarByName.set(generated.name, generated.avatarUrl);
+                  avatarByName.set(generated.name.trim().toLowerCase(), generated.avatarUrl);
                 }
               }
               for (const enemy of combatants.enemies) {
-                const url = avatarByName.get(enemy.name);
+                const key = enemy.name?.trim().toLowerCase();
+                const url = key ? avatarByName.get(key) : undefined;
                 if (url) enemy.sprite = url;
               }
             } catch (err) {


### PR DESCRIPTION
## Linked issue

Closes #594

## Why this change

- Game Mode combat shows broken-image placeholders for every enemy. Two related defects feed into the same symptom: the renderer treats `enemy.sprite` as a URL when the LLM is instructed to emit an emoji or short visual description, and the per-enemy portrait pipeline the encounter prompt asks for is never wired to a generator.
- Even with sprite generation enabled and a working image-gen connection, combat enemies cannot get a real portrait today — there's no client code that turns the LLM's `visuals.enemyImagePrompts` (or `enemy.description`) into a generated image.

## What changed

- **Renderer** (`packages/client/src/components/game/GameCombatUI.tsx`): added `resolveSpriteKind()` that classifies `combatant.sprite` as URL / emoji glyph / unrenderable. Applied to all four sprite sites — active-player mini bar, action-menu indicator, desktop combatant card, mobile horizontal row. URL → `<img>`, emoji → glyph span, anything else → existing initials fallback.
- **Pipeline** (`packages/client/src/components/game/GameSurface.tsx`): in the combat-init `.then(...)` handler, after hydrating combatants and before `setCombatEnemies`, dedupe enemies by name (so identical-named enemies share one portrait), build `npcsNeedingAvatars` from `visuals.enemyImagePrompts[i].prompt` when present else `enemy.description` else the enemy name, await `runGameAssetGeneration`, and overwrite each `combatant.sprite` with the matching `generatedNpcAvatars[i].avatarUrl`. Combat blocks here so portraits exist before the UI renders. Any failure (timeout, generation disabled, no image connection) falls through to the renderer's emoji/initials fallback with no retries. Capped at the server's `npcsNeedingAvatars.max(10)` limit. Respects the existing `chatMeta.enableSpriteGeneration` gate.

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Manually verify in a Game Mode chat with sprite generation **enabled** and a working image-gen connection: trigger an encounter; confirm combat starts after a brief portrait-generation pause and each enemy displays a real generated portrait. Confirm identical-named enemies (e.g. multiple "Drone"s) share one portrait.
- Manually verify the **fallback path**: trigger an encounter with sprite generation disabled, or with no image-gen connection configured. Confirm combat starts cleanly and enemies render either the LLM-suggested emoji glyph or initials — never a broken-image placeholder.
- Manually verify that the existing **boss-fight background/illustration** generation (the `shouldGenerateBossVisuals` branch that fires after enemy avatars) still runs on boss encounters.
- Manually verify a **non-boss** encounter (`isBossFight: false`) still gets per-enemy portraits, which it didn't before.
- Manually verify the player party row still renders correctly (no regression — `activePlayer.sprite` is a real `avatarUrl`, so it routes through the new helper to the same `<img>` path).

## Docs and release impact

- [x] No docs changes needed

## UI evidence (if applicable)

Reporter screenshot in #594 shows three enemies (Tideborn Alpha + two Tideborn Drones) rendering as broken-image icons with the name leaking through as alt text, while the player party (Sasuke Uchiha, Emilia, Barbara) shows real avatars on the same row. After this PR: enemies show generated portraits when sprite gen is on, or the LLM-suggested emoji / initials when off, never a broken `<img>`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Combat sprites now support multiple formats: image URLs, emoji glyphs, and fallback character initials when unavailable
  * Enemy portraits are automatically generated and rendered before combat initializes when sprite generation is enabled
  * Improved sprite handling across combat interface elements for consistent avatar display

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/595)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->