### PR TITLE
Fix NovelAI image request settings

### DIFF
--- a/packages/client/src/components/connections/ConnectionEditor.tsx
+++ b/packages/client/src/components/connections/ConnectionEditor.tsx
@@ -60,6 +60,8 @@ import {
   IMAGE_DEFAULTS_STORAGE_KEY,
   COMFYUI_SAMPLER_OPTIONS,
   COMFYUI_SCHEDULER_OPTIONS,
+  NOVELAI_NOISE_SCHEDULE_OPTIONS,
+  NOVELAI_SAMPLER_OPTIONS,
   SD_WEBUI_SAMPLER_OPTIONS,
   SD_WEBUI_SCHEDULER_OPTIONS,
   createDefaultImageGenerationProfile,
@@ -1938,6 +1940,7 @@ function ImageGenerationDefaultsPanel({
 
   const automatic1111 = value.automatic1111 ?? createDefaultImageGenerationProfile("automatic1111").automatic1111!;
   const comfyui = value.comfyui ?? createDefaultImageGenerationProfile("comfyui").comfyui!;
+  const novelai = value.novelai ?? createDefaultImageGenerationProfile("novelai").novelai!;
 
   const updateAutomatic1111 = (patch: Partial<typeof automatic1111>) => {
     onChange({
@@ -1955,6 +1958,14 @@ function ImageGenerationDefaultsPanel({
     });
   };
 
+  const updateNovelAi = (patch: Partial<typeof novelai>) => {
+    onChange({
+      ...value,
+      service: "novelai",
+      novelai: { ...novelai, ...patch },
+    });
+  };
+
   return (
     <FieldGroup
       label="Local Image Defaults"
@@ -1969,10 +1980,14 @@ function ImageGenerationDefaultsPanel({
         >
           <div className="min-w-0">
             <div className="text-xs font-medium text-[var(--foreground)]">
-              {service === "comfyui" ? "ComfyUI generation setup" : "AUTOMATIC1111 / Forge setup"}
+              {service === "comfyui"
+                ? "ComfyUI generation setup"
+                : service === "novelai"
+                  ? "NovelAI generation setup"
+                  : "AUTOMATIC1111 / Forge setup"}
             </div>
             <p className="mt-0.5 text-[0.625rem] text-[var(--muted-foreground)]">
-              Prompt prefixes, sampler, scheduler, steps, CFG, seed, clip skip, and denoise.
+              Prompt prefixes, sampler, scheduler, steps, guidance, seed, clip skip, and denoise.
             </p>
           </div>
           <ChevronDown
@@ -2032,7 +2047,7 @@ function ImageGenerationDefaultsPanel({
                     onCommit={(denoisingStrength) => updateAutomatic1111({ denoisingStrength })}
                   />
                 </>
-              ) : (
+              ) : service === "comfyui" ? (
                 <>
                   <NumberSetting
                     label="Steps"
@@ -2063,6 +2078,39 @@ function ImageGenerationDefaultsPanel({
                     min={0}
                     max={12}
                     onCommit={(clipSkip) => updateComfyUi({ clipSkip: clipSkip > 0 ? clipSkip : null })}
+                  />
+                </>
+              ) : (
+                <>
+                  <NumberSetting
+                    label="Steps"
+                    value={novelai.steps}
+                    min={1}
+                    max={150}
+                    onCommit={(steps) => updateNovelAi({ steps })}
+                  />
+                  <NumberSetting
+                    label="Prompt Guidance"
+                    value={novelai.promptGuidance}
+                    min={0}
+                    max={30}
+                    integer={false}
+                    onCommit={(promptGuidance) => updateNovelAi({ promptGuidance })}
+                  />
+                  <NumberSetting
+                    label="Guidance Rescale"
+                    value={novelai.promptGuidanceRescale}
+                    min={0}
+                    max={1}
+                    integer={false}
+                    onCommit={(promptGuidanceRescale) => updateNovelAi({ promptGuidanceRescale })}
+                  />
+                  <NumberSetting
+                    label="UC Preset"
+                    value={novelai.undesiredContentPreset}
+                    min={0}
+                    max={4}
+                    onCommit={(undesiredContentPreset) => updateNovelAi({ undesiredContentPreset })}
                   />
                 </>
               )}
@@ -2106,7 +2154,7 @@ function ImageGenerationDefaultsPanel({
                   <span className="text-xs text-[var(--foreground)]">Restore faces</span>
                 </label>
               </>
-            ) : (
+            ) : service === "comfyui" ? (
               <>
                 <TextSetting
                   label="Prompt Prefix"
@@ -2137,6 +2185,39 @@ function ImageGenerationDefaultsPanel({
                 <p className="text-[0.55rem] text-[var(--muted-foreground)]">
                   Custom ComfyUI workflows can use %steps%, %cfg%, %sampler%, %scheduler%, %denoise%, and %clip_skip%
                   placeholders.
+                </p>
+              </>
+            ) : (
+              <>
+                <TextSetting
+                  label="Prompt Prefix"
+                  value={novelai.promptPrefix}
+                  onChange={(promptPrefix) => updateNovelAi({ promptPrefix })}
+                  placeholder="e.g. masterpiece, best quality"
+                />
+                <TextSetting
+                  label="Negative Prefix"
+                  value={novelai.negativePromptPrefix}
+                  onChange={(negativePromptPrefix) => updateNovelAi({ negativePromptPrefix })}
+                  placeholder="e.g. low quality, blurry"
+                />
+                <div className="grid gap-2 sm:grid-cols-2">
+                  <ChoiceSetting
+                    label="Sampler"
+                    value={novelai.sampler}
+                    options={NOVELAI_SAMPLER_OPTIONS}
+                    onChange={(sampler) => updateNovelAi({ sampler })}
+                  />
+                  <ChoiceSetting
+                    label="Noise Schedule"
+                    value={novelai.noiseSchedule}
+                    options={NOVELAI_NOISE_SCHEDULE_OPTIONS}
+                    onChange={(noiseSchedule) => updateNovelAi({ noiseSchedule })}
+                  />
+                </div>
+                <p className="text-[0.55rem] text-[var(--muted-foreground)]">
+                  These values are sent with native NovelAI requests and embedded in generated PNG metadata for
+                  troubleshooting.
                 </p>
               </>
             )}

--- a/packages/server/src/services/image/image-generation-defaults.ts
+++ b/packages/server/src/services/image/image-generation-defaults.ts
@@ -18,6 +18,7 @@ export interface ImageDefaultsConnection {
 export function resolveImageGenerationService(conn: ImageDefaultsConnection): string {
   const explicit = (conn.imageService || conn.imageGenerationSource || "").trim();
   if (explicit) return explicit.toLowerCase();
+  if (conn.baseUrl?.toLowerCase().includes("novelai.net")) return "novelai";
   return inferImageSource(conn.model || "", conn.baseUrl || "");
 }
 

--- a/packages/server/src/services/image/image-generation.ts
+++ b/packages/server/src/services/image/image-generation.ts
@@ -12,17 +12,20 @@ import { newId } from "../../utils/id-generator.js";
 import {
   DEFAULT_AUTOMATIC1111_DEFAULTS,
   DEFAULT_COMFYUI_DEFAULTS,
+  DEFAULT_NOVELAI_DEFAULTS,
   mergeNegativePrompt,
   mergePromptPrefix,
   inferImageSource,
   type Automatic1111Defaults,
   type ComfyUiDefaults,
   type ImageGenerationDefaultsProfile,
+  type NovelAiDefaults,
 } from "@marinara-engine/shared";
 import { isImageLocalUrlsEnabled } from "../../config/runtime-config.js";
 import { normalizeLoopbackUrl, safeFetch, validateOutboundUrl } from "../../utils/security.js";
 
 const GALLERY_DIR = join(DATA_DIR, "gallery");
+const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
 
 /** Strip HTML tags and collapse whitespace — keeps error messages readable when APIs return HTML error pages. */
 function sanitizeErrorText(text: string): string {
@@ -654,28 +657,38 @@ async function generateNovelAI(baseUrl: string, apiKey: string, request: ImageGe
   const url = `${baseUrl.replace(/\/+$/, "")}/ai/generate-image`;
   const model = request.model || "nai-diffusion-4-5-full";
   const isV4 = model.includes("nai-diffusion-4");
+  const defaults = resolveNovelAiDefaults(request);
+  const prompt = mergePromptPrefix(defaults.promptPrefix, request.prompt);
+  const negativePrompt = mergeNegativePrompt(defaults.negativePromptPrefix, request.negativePrompt);
+  const seed = resolveSeed(request.imageDefaults);
 
   const parameters: Record<string, unknown> = {
     width: request.width ?? 832,
     height: request.height ?? 1216,
     n_samples: 1,
-    ucPreset: 0,
-    negative_prompt: request.negativePrompt ?? "",
-    seed: Math.floor(Math.random() * 2 ** 32),
-    scale: 6,
-    steps: 28,
-    sampler: "k_euler_ancestral",
+    ucPreset: defaults.undesiredContentPreset,
+    negative_prompt: negativePrompt,
+    seed,
+    scale: defaults.promptGuidance,
+    steps: defaults.steps,
+    sampler: defaults.sampler,
   };
+  if (defaults.noiseSchedule) {
+    parameters.noise_schedule = defaults.noiseSchedule;
+  }
+  if (isV4) {
+    parameters.cfg_rescale = defaults.promptGuidanceRescale;
+  }
 
   if (isV4) {
     parameters.params_version = 3;
     parameters.v4_prompt = {
-      caption: { base_caption: request.prompt, char_captions: [] },
+      caption: { base_caption: prompt, char_captions: [] },
       use_coords: false,
       use_order: true,
     };
     parameters.v4_negative_prompt = {
-      caption: { base_caption: request.negativePrompt ?? "", char_captions: [] },
+      caption: { base_caption: negativePrompt, char_captions: [] },
       use_coords: false,
       use_order: true,
     };
@@ -695,7 +708,7 @@ async function generateNovelAI(baseUrl: string, apiKey: string, request: ImageGe
   }
 
   const body: Record<string, unknown> = {
-    input: isV4 ? "" : request.prompt,
+    input: isV4 ? "" : prompt,
     model,
     action: "generate",
     parameters,
@@ -728,14 +741,16 @@ async function generateNovelAI(baseUrl: string, apiKey: string, request: ImageGe
   if (bytes[0] === 0x50 && bytes[1] === 0x4b) {
     const extracted = extractFirstFileFromZip(bytes);
     if (extracted) {
-      const base64 = Buffer.from(extracted).toString("base64");
+      const imageBytes = appendNovelAiGenerationMetadata(Buffer.from(extracted), body);
+      const base64 = imageBytes.toString("base64");
       return { base64, mimeType: "image/png", ext: "png" };
     }
   }
 
   // Check if it's a PNG directly
   if (bytes[0] === 0x89 && bytes[1] === 0x50) {
-    const base64 = Buffer.from(bytes).toString("base64");
+    const imageBytes = appendNovelAiGenerationMetadata(Buffer.from(bytes), body);
+    const base64 = imageBytes.toString("base64");
     return { base64, mimeType: "image/png", ext: "png" };
   }
 
@@ -750,6 +765,71 @@ async function generateNovelAI(baseUrl: string, apiKey: string, request: ImageGe
   }
 
   throw new Error("Could not parse NovelAI image response");
+}
+
+function appendNovelAiGenerationMetadata(image: Buffer, body: Record<string, unknown>): Buffer {
+  try {
+    const metadata = JSON.stringify({
+      source: "marinara-engine",
+      provider: "novelai",
+      request: body,
+    });
+    return injectPngTextChunk(image, "marinara_novelai_request", metadata);
+  } catch {
+    return image;
+  }
+}
+
+function injectPngTextChunk(png: Buffer, keyword: string, text: string): Buffer {
+  if (png.subarray(0, 8).compare(PNG_SIGNATURE) !== 0) {
+    throw new Error("Invalid PNG signature");
+  }
+
+  const textData = Buffer.concat([Buffer.from(keyword, "latin1"), Buffer.from([0]), Buffer.from(text, "latin1")]);
+  const textChunk = buildPngChunk("tEXt", textData);
+  const parts: Buffer[] = [PNG_SIGNATURE];
+  let offset = 8;
+  let inserted = false;
+
+  while (offset < png.length) {
+    const chunkLen = png.readUInt32BE(offset);
+    const chunkType = png.subarray(offset + 4, offset + 8).toString("ascii");
+    const totalChunkSize = 4 + 4 + chunkLen + 4;
+    const chunkBuf = png.subarray(offset, offset + totalChunkSize);
+
+    if (chunkType === "IDAT" && !inserted) {
+      parts.push(textChunk);
+      inserted = true;
+    }
+    parts.push(chunkBuf);
+    offset += totalChunkSize;
+  }
+
+  if (!inserted) {
+    parts.splice(parts.length - 1, 0, textChunk);
+  }
+
+  return Buffer.concat(parts);
+}
+
+function buildPngChunk(type: string, data: Buffer): Buffer {
+  const typeBytes = Buffer.from(type, "ascii");
+  const length = Buffer.alloc(4);
+  length.writeUInt32BE(data.length);
+  const crc = Buffer.alloc(4);
+  crc.writeUInt32BE(crc32(Buffer.concat([typeBytes, data])) >>> 0);
+  return Buffer.concat([length, typeBytes, data, crc]);
+}
+
+function crc32(buf: Buffer): number {
+  let crc = 0xffffffff;
+  for (let i = 0; i < buf.length; i++) {
+    crc ^= buf[i]!;
+    for (let j = 0; j < 8; j++) {
+      crc = (crc >>> 1) ^ (crc & 1 ? 0xedb88320 : 0);
+    }
+  }
+  return (crc ^ 0xffffffff) >>> 0;
 }
 
 /**
@@ -934,6 +1014,13 @@ function randomSeed(): number {
 
 function resolveSeed(profile: ImageGenerationDefaultsProfile | null | undefined): number {
   return typeof profile?.seed === "number" && profile.seed >= 0 ? profile.seed : randomSeed();
+}
+
+function resolveNovelAiDefaults(request: ImageGenRequest): NovelAiDefaults {
+  if (request.imageDefaults?.service === "novelai" && request.imageDefaults.novelai) {
+    return request.imageDefaults.novelai;
+  }
+  return DEFAULT_NOVELAI_DEFAULTS;
 }
 
 function resolveAutomatic1111Defaults(request: ImageGenRequest): Automatic1111Defaults {

--- a/packages/server/src/services/image/image-generation.ts
+++ b/packages/server/src/services/image/image-generation.ts
@@ -785,8 +785,7 @@ function injectPngTextChunk(png: Buffer, keyword: string, text: string): Buffer 
     throw new Error("Invalid PNG signature");
   }
 
-  const textData = Buffer.concat([Buffer.from(keyword, "latin1"), Buffer.from([0]), Buffer.from(text, "latin1")]);
-  const textChunk = buildPngChunk("tEXt", textData);
+  const textChunk = buildPngChunk("iTXt", buildPngInternationalTextData(keyword, text));
   const parts: Buffer[] = [PNG_SIGNATURE];
   let offset = 8;
   let inserted = false;
@@ -810,6 +809,14 @@ function injectPngTextChunk(png: Buffer, keyword: string, text: string): Buffer 
   }
 
   return Buffer.concat(parts);
+}
+
+function buildPngInternationalTextData(keyword: string, text: string): Buffer {
+  return Buffer.concat([
+    Buffer.from(keyword, "latin1"),
+    Buffer.from([0, 0, 0, 0, 0]),
+    Buffer.from(text, "utf8"),
+  ]);
 }
 
 function buildPngChunk(type: string, data: Buffer): Buffer {

--- a/packages/server/test/image-generation-local.test.ts
+++ b/packages/server/test/image-generation-local.test.ts
@@ -3,8 +3,30 @@ import { createServer } from "node:http";
 import { Buffer } from "node:buffer";
 import { test } from "node:test";
 import { generateImage } from "../src/services/image/image-generation.js";
+import { resolveConnectionImageDefaults } from "../src/services/image/image-generation-defaults.js";
 
 const PNG_1X1_BASE64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
+
+function readPngTextChunks(png: Buffer): Array<{ keyword: string; text: string }> {
+  const chunks: Array<{ keyword: string; text: string }> = [];
+  let offset = 8;
+  while (offset < png.length) {
+    const chunkLen = png.readUInt32BE(offset);
+    const chunkType = png.subarray(offset + 4, offset + 8).toString("ascii");
+    const chunkData = png.subarray(offset + 8, offset + 8 + chunkLen);
+    if (chunkType === "tEXt") {
+      const nullIdx = chunkData.indexOf(0);
+      if (nullIdx > 0) {
+        chunks.push({
+          keyword: chunkData.subarray(0, nullIdx).toString("latin1"),
+          text: chunkData.subarray(nullIdx + 1).toString("latin1"),
+        });
+      }
+    }
+    offset += 4 + 4 + chunkLen + 4;
+  }
+  return chunks;
+}
 
 test("local OpenAI-compatible image generation normalizes localhost URLs", async () => {
   const imageBytes = Buffer.from(PNG_1X1_BASE64, "base64");
@@ -40,6 +62,106 @@ test("local OpenAI-compatible image generation normalizes localhost URLs", async
 
     assert.equal(result.mimeType, "image/png");
     assert.equal(result.base64, PNG_1X1_BASE64);
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
+    });
+  }
+});
+
+test("native NovelAI image generation sends stable request settings and embeds metadata", async () => {
+  const imageBytes = Buffer.from(PNG_1X1_BASE64, "base64");
+  let capturedBody: Record<string, unknown> | null = null;
+  let port = 0;
+  const server = createServer((req, res) => {
+    if (req.method === "POST" && req.url?.endsWith("/ai/generate-image")) {
+      let raw = "";
+      req.setEncoding("utf8");
+      req.on("data", (chunk) => {
+        raw += chunk;
+      });
+      req.on("end", () => {
+        capturedBody = JSON.parse(raw) as Record<string, unknown>;
+        res.writeHead(200, { "content-type": "image/png" });
+        res.end(imageBytes);
+      });
+      return;
+    }
+
+    res.writeHead(404);
+    res.end();
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const addressInfo = server.address();
+  assert.ok(addressInfo && typeof addressInfo === "object");
+  port = addressInfo.port;
+
+  try {
+    const imageDefaults = resolveConnectionImageDefaults({
+      baseUrl: "https://image.novelai.net",
+      model: "nai-diffusion-4-5-full",
+      imageService: "novelai",
+      defaultParameters: {
+        imageGeneration: {
+          version: 1,
+          service: "novelai",
+          seed: 12345,
+          novelai: {
+            promptPrefix: "best quality",
+            negativePromptPrefix: "bad anatomy",
+            sampler: "k_dpmpp_2m",
+            noiseSchedule: "native",
+            steps: 33,
+            promptGuidance: 4.75,
+            promptGuidanceRescale: 0.35,
+            undesiredContentPreset: 2,
+          },
+        },
+      },
+    });
+
+    const result = await generateImage(
+      "novelai",
+      `http://127.0.0.1:${port}/novelai.net`,
+      "test-key",
+      "novelai",
+      {
+        prompt: "cat cafe",
+        negativePrompt: "lowres",
+        model: "nai-diffusion-4-5-full",
+        width: 640,
+        height: 960,
+        imageDefaults,
+        allowLocalUrls: true,
+      },
+    );
+
+    const parameters = capturedBody?.parameters as Record<string, unknown>;
+    assert.equal(capturedBody?.input, "");
+    assert.equal(capturedBody?.model, "nai-diffusion-4-5-full");
+    assert.equal(parameters.seed, 12345);
+    assert.equal(parameters.steps, 33);
+    assert.equal(parameters.scale, 4.75);
+    assert.equal(parameters.cfg_rescale, 0.35);
+    assert.equal(parameters.sampler, "k_dpmpp_2m");
+    assert.equal(parameters.noise_schedule, "native");
+    assert.equal(parameters.ucPreset, 2);
+    assert.equal(parameters.negative_prompt, "bad anatomy, lowres");
+    assert.deepEqual((parameters.v4_prompt as Record<string, unknown>).caption, {
+      base_caption: "best quality, cat cafe",
+      char_captions: [],
+    });
+    assert.deepEqual((parameters.v4_negative_prompt as Record<string, unknown>).caption, {
+      base_caption: "bad anatomy, lowres",
+      char_captions: [],
+    });
+
+    const output = Buffer.from(result.base64, "base64");
+    const requestMetadata = readPngTextChunks(output).find((chunk) => chunk.keyword === "marinara_novelai_request");
+    assert.ok(requestMetadata);
+    const metadata = JSON.parse(requestMetadata.text) as { request: Record<string, unknown> };
+    assert.deepEqual(metadata.request, capturedBody);
   } finally {
     await new Promise<void>((resolve, reject) => {
       server.close((err) => (err ? reject(err) : resolve()));

--- a/packages/server/test/image-generation-local.test.ts
+++ b/packages/server/test/image-generation-local.test.ts
@@ -22,6 +22,19 @@ function readPngTextChunks(png: Buffer): Array<{ keyword: string; text: string }
           text: chunkData.subarray(nullIdx + 1).toString("latin1"),
         });
       }
+    } else if (chunkType === "iTXt") {
+      const keywordEnd = chunkData.indexOf(0);
+      if (keywordEnd > 0) {
+        const languageTagStart = keywordEnd + 3;
+        const languageTagEnd = chunkData.indexOf(0, languageTagStart);
+        const translatedKeywordEnd = languageTagEnd >= 0 ? chunkData.indexOf(0, languageTagEnd + 1) : -1;
+        if (translatedKeywordEnd >= 0) {
+          chunks.push({
+            keyword: chunkData.subarray(0, keywordEnd).toString("latin1"),
+            text: chunkData.subarray(translatedKeywordEnd + 1).toString("utf8"),
+          });
+        }
+      }
     }
     offset += 4 + 4 + chunkLen + 4;
   }
@@ -127,8 +140,8 @@ test("native NovelAI image generation sends stable request settings and embeds m
       "test-key",
       "novelai",
       {
-        prompt: "cat cafe",
-        negativePrompt: "lowres",
+        prompt: "cat cafe with 東京 neon",
+        negativePrompt: "lowres, déjà vu",
         model: "nai-diffusion-4-5-full",
         width: 640,
         height: 960,
@@ -147,13 +160,13 @@ test("native NovelAI image generation sends stable request settings and embeds m
     assert.equal(parameters.sampler, "k_dpmpp_2m");
     assert.equal(parameters.noise_schedule, "native");
     assert.equal(parameters.ucPreset, 2);
-    assert.equal(parameters.negative_prompt, "bad anatomy, lowres");
+    assert.equal(parameters.negative_prompt, "bad anatomy, lowres, déjà vu");
     assert.deepEqual((parameters.v4_prompt as Record<string, unknown>).caption, {
-      base_caption: "best quality, cat cafe",
+      base_caption: "best quality, cat cafe with 東京 neon",
       char_captions: [],
     });
     assert.deepEqual((parameters.v4_negative_prompt as Record<string, unknown>).caption, {
-      base_caption: "bad anatomy, lowres",
+      base_caption: "bad anatomy, lowres, déjà vu",
       char_captions: [],
     });
 

--- a/packages/shared/src/constants/image-generation-defaults.ts
+++ b/packages/shared/src/constants/image-generation-defaults.ts
@@ -3,12 +3,13 @@ import type {
   ComfyUiDefaults,
   ImageDefaultsService,
   ImageGenerationDefaultsProfile,
+  NovelAiDefaults,
 } from "../types/image-generation-defaults.js";
 
 export const IMAGE_DEFAULTS_STORAGE_KEY = "imageGeneration";
 export const IMAGE_GENERATION_DEFAULTS_VERSION = 1 as const;
 
-export const IMAGE_DEFAULTS_SERVICES: ImageDefaultsService[] = ["automatic1111", "comfyui"];
+export const IMAGE_DEFAULTS_SERVICES: ImageDefaultsService[] = ["automatic1111", "comfyui", "novelai"];
 
 export const DEFAULT_AUTOMATIC1111_DEFAULTS: Automatic1111Defaults = {
   promptPrefix: "",
@@ -31,6 +32,17 @@ export const DEFAULT_COMFYUI_DEFAULTS: ComfyUiDefaults = {
   cfgScale: 7,
   denoisingStrength: 1,
   clipSkip: null,
+};
+
+export const DEFAULT_NOVELAI_DEFAULTS: NovelAiDefaults = {
+  promptPrefix: "",
+  negativePromptPrefix: "",
+  sampler: "k_euler_ancestral",
+  noiseSchedule: "karras",
+  steps: 28,
+  promptGuidance: 6,
+  promptGuidanceRescale: 0,
+  undesiredContentPreset: 0,
 };
 
 export const SD_WEBUI_SAMPLER_OPTIONS = [
@@ -84,6 +96,21 @@ export const COMFYUI_SCHEDULER_OPTIONS = [
   { value: "ddim_uniform", label: "DDIM uniform" },
 ] as const;
 
+export const NOVELAI_SAMPLER_OPTIONS = [
+  { value: "k_euler_ancestral", label: "Euler ancestral" },
+  { value: "k_euler", label: "Euler" },
+  { value: "k_dpmpp_2m", label: "DPM++ 2M" },
+  { value: "k_dpmpp_sde", label: "DPM++ SDE" },
+  { value: "ddim", label: "DDIM" },
+] as const;
+
+export const NOVELAI_NOISE_SCHEDULE_OPTIONS = [
+  { value: "karras", label: "Karras" },
+  { value: "native", label: "Native" },
+  { value: "exponential", label: "Exponential" },
+  { value: "polyexponential", label: "Polyexponential" },
+] as const;
+
 export interface NormalizeImageGenerationProfileResult {
   profile: ImageGenerationDefaultsProfile;
   changed: boolean;
@@ -108,6 +135,7 @@ export function createDefaultImageGenerationProfile(service: ImageDefaultsServic
   };
   if (service === "automatic1111") profile.automatic1111 = { ...DEFAULT_AUTOMATIC1111_DEFAULTS };
   if (service === "comfyui") profile.comfyui = { ...DEFAULT_COMFYUI_DEFAULTS };
+  if (service === "novelai") profile.novelai = { ...DEFAULT_NOVELAI_DEFAULTS };
   return profile;
 }
 
@@ -124,8 +152,10 @@ export function normalizeImageGenerationProfile(
 
   if (service === "automatic1111") {
     profile.automatic1111 = normalizeAutomatic1111Defaults(rawProfile.automatic1111);
-  } else {
+  } else if (service === "comfyui") {
     profile.comfyui = normalizeComfyUiDefaults(rawProfile.comfyui);
+  } else {
+    profile.novelai = normalizeNovelAiDefaults(rawProfile.novelai);
   }
 
   const changed = JSON.stringify(profile) !== JSON.stringify(rawProfile);
@@ -181,6 +211,30 @@ function normalizeComfyUiDefaults(rawDefaults: unknown): ComfyUiDefaults {
     cfgScale: readNumber(raw.cfgScale, DEFAULT_COMFYUI_DEFAULTS.cfgScale, 0, 30),
     denoisingStrength: readNumber(raw.denoisingStrength, DEFAULT_COMFYUI_DEFAULTS.denoisingStrength, 0, 1),
     clipSkip: readNullableInteger(raw.clipSkip, DEFAULT_COMFYUI_DEFAULTS.clipSkip, 1, 12),
+  };
+}
+
+function normalizeNovelAiDefaults(rawDefaults: unknown): NovelAiDefaults {
+  const raw = isRecord(rawDefaults) ? rawDefaults : {};
+  return {
+    promptPrefix: readString(raw.promptPrefix, DEFAULT_NOVELAI_DEFAULTS.promptPrefix),
+    negativePromptPrefix: readString(raw.negativePromptPrefix, DEFAULT_NOVELAI_DEFAULTS.negativePromptPrefix),
+    sampler: readString(raw.sampler, DEFAULT_NOVELAI_DEFAULTS.sampler),
+    noiseSchedule: readString(raw.noiseSchedule, DEFAULT_NOVELAI_DEFAULTS.noiseSchedule),
+    steps: readInteger(raw.steps, DEFAULT_NOVELAI_DEFAULTS.steps, 1, 150),
+    promptGuidance: readNumber(raw.promptGuidance, DEFAULT_NOVELAI_DEFAULTS.promptGuidance, 0, 30),
+    promptGuidanceRescale: readNumber(
+      raw.promptGuidanceRescale,
+      DEFAULT_NOVELAI_DEFAULTS.promptGuidanceRescale,
+      0,
+      1,
+    ),
+    undesiredContentPreset: readInteger(
+      raw.undesiredContentPreset,
+      DEFAULT_NOVELAI_DEFAULTS.undesiredContentPreset,
+      0,
+      4,
+    ),
   };
 }
 

--- a/packages/shared/src/types/image-generation-defaults.ts
+++ b/packages/shared/src/types/image-generation-defaults.ts
@@ -1,4 +1,4 @@
-export type ImageDefaultsService = "automatic1111" | "comfyui";
+export type ImageDefaultsService = "automatic1111" | "comfyui" | "novelai";
 
 export interface Automatic1111Defaults {
   promptPrefix: string;
@@ -23,10 +23,22 @@ export interface ComfyUiDefaults {
   clipSkip: number | null;
 }
 
+export interface NovelAiDefaults {
+  promptPrefix: string;
+  negativePromptPrefix: string;
+  sampler: string;
+  noiseSchedule: string;
+  steps: number;
+  promptGuidance: number;
+  promptGuidanceRescale: number;
+  undesiredContentPreset: number;
+}
+
 export interface ImageGenerationDefaultsProfile {
   version: 1;
   service: ImageDefaultsService;
   seed: number;
   automatic1111?: Automatic1111Defaults;
   comfyui?: ComfyUiDefaults;
+  novelai?: NovelAiDefaults;
 }


### PR DESCRIPTION
## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #608

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- Illustrator Agent images generated through native NovelAI used a small hardcoded settings set, so users could not tune or inspect key NovelAI V4/V4.5 request settings such as prompt guidance rescale or noise schedule.

## What changed

<!-- List the key changes in this PR -->

- Added NovelAI to the existing connection-scoped image defaults profile.
- Applied NovelAI defaults to native NovelAI image requests: prompt/negative prefixes, seed, steps, prompt guidance, prompt guidance rescale, sampler, noise schedule, and UC preset.
- Embedded a compact `marinara_novelai_request` PNG text metadata chunk in native NovelAI PNG results so users can inspect the exact request body later.
- Added NovelAI controls to the connection editor's image defaults panel.
- Added a focused regression test that captures the outgoing native NovelAI request and verifies the generated PNG metadata snapshot.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Codex ran `pnpm --dir packages/server exec tsx --test test/image-generation-local.test.ts`.
- Codex ran `pnpm check`.
- The focused NovelAI test uses a local mock native endpoint rather than real NovelAI credentials. It verifies request construction and metadata preservation, but not live NovelAI output quality.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

Not applicable. This is a provider request-building/backend behavior fix; the connection editor only exposes the new provider defaults fields.
