### PR TITLE
Fix GoogleProvider empty candidate scene summary crash

### DIFF
--- a/packages/server/src/services/llm/providers/google.provider.ts
+++ b/packages/server/src/services/llm/providers/google.provider.ts
@@ -139,12 +139,12 @@ export class GoogleProvider extends BaseLLMProvider {
     // ── Non-streaming path (also used when thinking is enabled) ──
     if (!useStreaming) {
       const json = (await response.json()) as {
-        candidates: Array<{
+        candidates?: Array<{
           content: { parts: GeminiPart[] };
         }>;
         usageMetadata?: { promptTokenCount: number; candidatesTokenCount: number; totalTokenCount: number };
       };
-      const parts = json.candidates[0]?.content?.parts ?? [];
+      const parts = json.candidates?.[0]?.content?.parts ?? [];
 
       // Report full parts (with thought signatures) for storage
       if (options.onResponseParts) options.onResponseParts(parts);


### PR DESCRIPTION
## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #600

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- Scene summary wrap-up can fail for GoogleProvider connections when Google returns a successful response without a usable `candidates` array. The provider then throws `Cannot read properties of undefined (reading '0')`, which bubbles up as a 502 during scene conclusion instead of returning a normal empty-response error.

## What changed

<!-- List the key changes in this PR -->

- Treat Google non-streaming `candidates` as optional before reading the first candidate's parts.
- Preserve the existing behavior where an empty provider response produces empty content for the scene route to handle.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Codex reproduced the crash before the fix with `pnpm --filter @marinara-engine/server exec tsx ../../scratch/issue-600-google-empty-candidates-repro.ts`: `missing candidates: FAIL` and `TypeError: Cannot read properties of undefined (reading '0')`.
- Codex re-ran the same scratch repro after the fix. It passed for a missing `candidates` field, an empty `candidates` array, and a normal text candidate.
- Codex ran `pnpm check`; it passed `impeccable:check`, lint, and shared/server/client build.
- Manual Docker-lite verification with a real GoogleProvider key was not performed in this environment. The patched provider path was exercised locally with a Gemini-compatible mock endpoint.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

N/A. This is a backend provider response-shape fix with no visible UI surface change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of edge cases in AI model response parsing to ensure stability when API responses lack expected data structures, preventing potential runtime errors.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/612)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->