### PR TITLE
Fix Game Mode scene intro after asset failure

### DIFF
--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -6427,7 +6427,8 @@ export function GameSurface({
   // (4) any in-flight image / NPC portrait generation has completed.
   // Once ALL conditions are met for the first time the screen never returns.
   // sceneProcessed is computed above (near scenePreparing).
-  const firstTurnFullyReady = hasEverHadContent && !isStreaming && sceneProcessed && !pendingAssetGeneration;
+  const firstTurnFullyReady =
+    hasEverHadContent && !isStreaming && sceneProcessed && (!pendingAssetGeneration || assetGenerationFailed);
   const sidecarStartupFailed = sidecarConfig.useForGameScene && sidecarStatus === "server_error" && !sidecarReady;
   // Don't auto-dismiss: wait for user to click Continue after typewriter finishes.
 
@@ -6494,7 +6495,7 @@ export function GameSurface({
                         <span>
                           {hasEverHadContent && !sceneProcessed
                             ? "Preparing the scene..."
-                            : hasEverHadContent && pendingAssetGeneration
+                            : hasEverHadContent && pendingAssetGeneration && !assetGenerationFailed
                               ? "Generating images..."
                               : hasEverHadContent && isStreaming
                                 ? "The GM is narrating..."


### PR DESCRIPTION
## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #604

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- Game Mode's first scene intro could remain stuck on the preparation screen after the API calls completed. The failure path I found is optional generated scene assets: the scene can already be marked processed, but a retained retry payload keeps the first-turn "Continue" gate blocked until switching chats remounts the surface and clears that local pending state.

## What changed

<!-- List the key changes in this PR -->

- Let the first-turn intro become ready when scene processing is complete and optional asset generation has failed.
- Keep the pending asset retry payload available; the change only stops that failed optional payload from blocking scene entry.
- Keep in-flight asset generation blocking as before, so successful image generation still gets a chance to finish before the intro continues.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

Codex-run proof:

- `node scratch\issue-604-gate-proof.mjs` passed before commit. It reproduced the old readiness gate as `before=false` for the state where scene processing is done, streaming is finished, optional asset generation failed, and the retry payload is retained. With this patch, the same state returns `after=true`.
- Edge cases from the same proof: in-flight asset generation still blocks, and completed asset generation still allows Continue.
- `pnpm check` passed in `C:\tmp\Marinara-Engine-issue-604`.

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- âš ï¸ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Optional manual follow-up: start a Game Mode scene with generated assets enabled and an image backend that times out/fails; after GM narration and scene processing complete, the intro should offer Continue instead of requiring a chat switch.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs or release metadata changed.

## UI evidence (if applicable)

<!-- Add before/after screenshots or recordings for UI changes -->

N/A. This is a focused state-gate fix for a race/failure path; the machine proof covers the readiness condition directly.
