### PR TITLE
Fix RP DM routing to linked conversations

### DIFF
--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -3609,7 +3609,7 @@ export async function generateRoutes(app: FastifyInstance) {
           [
             `<dm_commands>`,
             `Optional hidden command, use only when it naturally fits the scene:`,
-            `- [dm: character="${dmTargetHint}" message="short text"] - only if a roleplay character sends {{user}} a direct message through a phone, communicator, letter app, terminal, or similar in-world channel. Marinara strips the command from the roleplay reply, creates a new DM conversation with that character, and posts the message there.`,
+            `- [dm: character="${dmTargetHint}" message="short text"] - only if a roleplay character sends {{user}} a direct message through a phone, communicator, letter app, terminal, or similar in-world channel. Marinara strips the command from the roleplay reply and posts the full message into the linked conversation when one exists; otherwise it creates a new DM conversation with that character.`,
             `Do not also quote the exact same direct-message text in the roleplay narration unless the user should see it in both places.`,
             `</dm_commands>`,
           ].join("\n"),
@@ -7988,7 +7988,7 @@ export async function generateRoutes(app: FastifyInstance) {
               }
 
               if (command.type === "dm") {
-                // ── Roleplay DM: create a conversation chat and post the character's direct message there ──
+                // ── Roleplay DM: post into the linked conversation when available; otherwise create a DM chat ──
                 const dmCmd = command as DirectMessageCommand;
                 try {
                   const requestedTarget = dmCmd.character.trim();
@@ -8022,6 +8022,43 @@ export async function generateRoutes(app: FastifyInstance) {
 
                   if (!targetCharId) {
                     logger.warn('[commands] DM target character "%s" not found', dmCmd.character);
+                    continue;
+                  }
+
+                  const freshChat = await chats.getById(input.chatId);
+                  const connectedId = freshChat?.connectedChatId as string | null;
+                  const connectedChat = connectedId ? await chats.getById(connectedId) : null;
+                  const linkedConversationId = connectedChat?.mode === "conversation" ? connectedChat.id : null;
+
+                  if (linkedConversationId) {
+                    const dmMessage = await chats.createMessage({
+                      chatId: linkedConversationId,
+                      role: "assistant",
+                      characterId: targetCharId,
+                      content: messageText,
+                    });
+                    recordAssistantActivity(linkedConversationId, targetCharId);
+
+                    reply.raw.write(
+                      `data: ${JSON.stringify({
+                        type: "assistant_action",
+                        data: {
+                          action: "dm_posted",
+                          chatId: linkedConversationId,
+                          mode: "conversation",
+                          characterName: targetName,
+                          sourceChatId: input.chatId,
+                          sourceMessageId: messageId || null,
+                          messageId: dmMessage?.id ?? null,
+                        },
+                      })}\n\n`,
+                    );
+                    logger.info(
+                      '[commands] Roleplay DM from "%s" posted to linked conversation %s from chat %s',
+                      targetName,
+                      linkedConversationId,
+                      input.chatId,
+                    );
                     continue;
                   }
 


### PR DESCRIPTION
## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #601

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- RP mode direct-message commands from a linked roleplay chat were creating a fresh `DM with <character>` Conversation thread every time, leaving the ongoing linked Conversation empty.

## What changed

<!-- List the key changes in this PR -->

- Route `[dm]` commands from a linked roleplay chat into the existing linked Conversation chat when that linked chat exists and is in `conversation` mode.
- Keep the existing standalone `DM with <character>` creation fallback for unlinked roleplay chats.
- Update the model-facing DM command reminder so it describes the linked-conversation behavior instead of always promising a new DM chat.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

Codex-run proof:

- `pnpm --dir packages/server exec tsx ..\..\scratch\issue-601-rp-dm-route-repro.ts` failed before the fix on the original issue symptom: linked Conversation message count was `0`, and an extra `DM with Mara` chat was created.
- `pnpm --dir packages/server exec tsx ..\..\scratch\issue-601-rp-dm-route-repro.ts` passed after the fix: the linked Conversation received exactly one assistant message containing all three DM sentences, and no extra DM chat was created for the linked case.
- The same scratch harness also verified the unlinked fallback still creates exactly one standalone `DM with Mara` Conversation with one grouped assistant message.
- `pnpm check` passed locally after the fix.

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- âš ï¸ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- No human-only verification is needed for the core routing claim. The scratch harness exercises the real `/api/generate` route with a fake local OpenAI-compatible provider and verifies both the linked and unlinked DM command paths.
- Local proof files: `scratch/issue-601-before-output.txt`, `scratch/issue-601-after-output.txt`, and `scratch/bugfix-verification.json`.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs, release, schema, dependency, or version files were changed.

## UI evidence (if applicable)

N/A. This is backend/logic command routing with terminal proof from the scratch harness.
