### PR TITLE
Fix NovelAI V4 native prompt input

### DIFF
--- a/packages/server/src/services/image/image-generation.ts
+++ b/packages/server/src/services/image/image-generation.ts
@@ -708,7 +708,7 @@ async function generateNovelAI(baseUrl: string, apiKey: string, request: ImageGe
   }
 
   const body: Record<string, unknown> = {
-    input: isV4 ? "" : prompt,
+    input: prompt,
     model,
     action: "generate",
     parameters,

--- a/packages/server/test/image-generation-local.test.ts
+++ b/packages/server/test/image-generation-local.test.ts
@@ -151,7 +151,7 @@ test("native NovelAI image generation sends stable request settings and embeds m
     );
 
     const parameters = capturedBody?.parameters as Record<string, unknown>;
-    assert.equal(capturedBody?.input, "");
+    assert.equal(capturedBody?.input, "best quality, cat cafe with 東京 neon");
     assert.equal(capturedBody?.model, "nai-diffusion-4-5-full");
     assert.equal(parameters.seed, 12345);
     assert.equal(parameters.steps, 33);
@@ -175,6 +175,64 @@ test("native NovelAI image generation sends stable request settings and embeds m
     assert.ok(requestMetadata);
     const metadata = JSON.parse(requestMetadata.text) as { request: Record<string, unknown> };
     assert.deepEqual(metadata.request, capturedBody);
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
+    });
+  }
+});
+
+test("native NovelAI image generation keeps V3 prompt shape", async () => {
+  const imageBytes = Buffer.from(PNG_1X1_BASE64, "base64");
+  let capturedBody: Record<string, unknown> | null = null;
+  let port = 0;
+  const server = createServer((req, res) => {
+    if (req.method === "POST" && req.url?.endsWith("/ai/generate-image")) {
+      let raw = "";
+      req.setEncoding("utf8");
+      req.on("data", (chunk) => {
+        raw += chunk;
+      });
+      req.on("end", () => {
+        capturedBody = JSON.parse(raw) as Record<string, unknown>;
+        res.writeHead(200, { "content-type": "image/png" });
+        res.end(imageBytes);
+      });
+      return;
+    }
+
+    res.writeHead(404);
+    res.end();
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const addressInfo = server.address();
+  assert.ok(addressInfo && typeof addressInfo === "object");
+  port = addressInfo.port;
+
+  try {
+    await generateImage(
+      "novelai",
+      `http://127.0.0.1:${port}/novelai.net`,
+      "test-key",
+      "novelai",
+      {
+        prompt: "cat cafe",
+        negativePrompt: "lowres",
+        model: "nai-diffusion-3",
+        width: 640,
+        height: 960,
+        allowLocalUrls: true,
+      },
+    );
+
+    const parameters = capturedBody?.parameters as Record<string, unknown>;
+    assert.equal(capturedBody?.input, "cat cafe");
+    assert.equal(capturedBody?.model, "nai-diffusion-3");
+    assert.equal(parameters.negative_prompt, "lowres");
+    assert.equal(parameters.params_version, undefined);
+    assert.equal(parameters.v4_prompt, undefined);
+    assert.equal(parameters.v4_negative_prompt, undefined);
   } finally {
     await new Promise<void>((resolve, reject) => {
       server.close((err) => (err ? reject(err) : resolve()));


### PR DESCRIPTION
## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #587

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- Native NovelAI image generation sent V4/V4.5 requests with an empty top-level `input`, which can make NovelAI return a 500 even though V3 requests succeed.

## What changed

<!-- List the key changes in this PR -->

- Keep the merged prompt text in NovelAI's top-level `input` for V4/V4.5 requests while preserving the existing `v4_prompt` and `v4_negative_prompt` parameters.
- Updated the focused native NovelAI regression test to assert the V4.5 payload keeps `input`.
- Added V3 coverage to confirm non-V4 requests keep their existing prompt shape and do not receive V4-only fields.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Codex reproduced the original request-shape failure with `node scratch\issue-587-novelai-v4-repro.mjs` before the fix: the mock native NovelAI endpoint rejected the V4.5 request because `input` was `""` and returned `NovelAI image generation failed (500): {"statusCode":500,"message":"Internal Server Error"}`.
- Codex reran `node scratch\issue-587-novelai-v4-repro.mjs` after the fix: the same V4.5 flow succeeded with `input: "cat cafe"` and `hasV4Prompt: true`.
- Codex ran `pnpm --filter @marinara-engine/server exec tsx --test test/image-generation-local.test.ts`; all 3 focused image-generation tests passed, including V4.5 payload metadata and V3 prompt-shape coverage.
- Codex ran `pnpm check`; it passed.
- Live NovelAI generation was not run because this environment does not have NovelAI credentials. The core request-shape claim is covered by the captured outbound payload tests.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs or release metadata changes are needed for this backend request payload fix.

## UI evidence (if applicable)

N/A. This is a backend/provider request-building fix with command-level before/after proof.
