### PR TITLE
Notify when game scene prep completes

### DIFF
--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -2591,10 +2591,14 @@ export function GameSurface({
     sceneReadyMsgIdRef.current = messageId;
     setSceneReadyTick((t) => t + 1);
 
-    if (!options?.notify || pendingSceneReadyNotificationMsgIdRef.current !== messageId) {
+    const isPendingNotification = pendingSceneReadyNotificationMsgIdRef.current === messageId;
+    if (isPendingNotification) {
+      pendingSceneReadyNotificationMsgIdRef.current = null;
+    }
+
+    if (!options?.notify || !isPendingNotification) {
       return;
     }
-    pendingSceneReadyNotificationMsgIdRef.current = null;
     if (notifiedSceneReadyMsgIdsRef.current.has(messageId)) {
       return;
     }
@@ -2622,6 +2626,11 @@ export function GameSurface({
         notification.close();
       };
     }
+  }, [activeChatId]);
+
+  useEffect(() => {
+    pendingSceneReadyNotificationMsgIdRef.current = null;
+    notifiedSceneReadyMsgIdsRef.current.clear();
   }, [activeChatId]);
 
   useEffect(() => {

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -113,6 +113,7 @@ import { GameReadableDisplay } from "./GameReadableDisplay";
 import { ChatGalleryDrawer } from "../chat/ChatGalleryDrawer";
 import type { ReadableTag } from "../../lib/game-tag-parser";
 import type { DirectionCommand, GameNpc } from "@marinara-engine/shared";
+import { playNotificationPing } from "../../lib/notification-sound";
 
 type JournalReadable = ReadableTag & {
   sourceMessageId?: string | null;
@@ -152,6 +153,7 @@ const GAME_ASSET_GENERATION_TIMEOUT_MS = 240_000;
 const GAME_ASSET_PREVIEW_TIMEOUT_MS = 180_000;
 const GAME_ASSET_PROMPT_REVIEW_TIMEOUT_MS = 180_000;
 const IMAGE_PROMPT_REVIEW_TIMED_OUT = Symbol("IMAGE_PROMPT_REVIEW_TIMED_OUT");
+const SCENE_READY_TITLE_PREFIX = "Scene ready - ";
 
 class TimeoutError extends Error {
   constructor(ms: number) {
@@ -2579,8 +2581,68 @@ export function GameSurface({
   const applySceneResultRef = useRef<((result: import("@marinara-engine/shared").SceneAnalysis) => void | Promise<void>) | null>(
     null,
   );
+  const pendingSceneReadyNotificationMsgIdRef = useRef<string | null>(null);
+  const notifiedSceneReadyMsgIdsRef = useRef<Set<string>>(new Set());
+  const sceneReadyOriginalTitleRef = useRef<string | null>(null);
   const [sceneReadyTick, setSceneReadyTick] = useState(0);
   void sceneReadyTick; // used only to trigger re-renders
+
+  const markSceneReady = useCallback((messageId: string, options?: { notify?: boolean }) => {
+    sceneReadyMsgIdRef.current = messageId;
+    setSceneReadyTick((t) => t + 1);
+
+    if (!options?.notify || pendingSceneReadyNotificationMsgIdRef.current !== messageId) {
+      return;
+    }
+    pendingSceneReadyNotificationMsgIdRef.current = null;
+    if (notifiedSceneReadyMsgIdsRef.current.has(messageId)) {
+      return;
+    }
+    notifiedSceneReadyMsgIdsRef.current.add(messageId);
+
+    toast.success("Scene ready.", { description: "Preparation finished. You can continue the game.", duration: 6000 });
+    if (useUIStore.getState().rpNotificationSound) {
+      playNotificationPing();
+    }
+
+    if (document.visibilityState === "hidden") {
+      if (sceneReadyOriginalTitleRef.current == null) {
+        sceneReadyOriginalTitleRef.current = document.title;
+      }
+      document.title = `${SCENE_READY_TITLE_PREFIX}${sceneReadyOriginalTitleRef.current}`;
+    }
+
+    if ("Notification" in window && Notification.permission === "granted") {
+      const notification = new Notification("Scene ready", {
+        body: "Scene preparation finished. Marinara is ready when you are.",
+        tag: `marinara-scene-ready-${activeChatId}`,
+      });
+      notification.onclick = () => {
+        window.focus();
+        notification.close();
+      };
+    }
+  }, [activeChatId]);
+
+  useEffect(() => {
+    const restoreSceneReadyTitle = () => {
+      if (document.visibilityState !== "visible" || sceneReadyOriginalTitleRef.current == null) {
+        return;
+      }
+      document.title = sceneReadyOriginalTitleRef.current;
+      sceneReadyOriginalTitleRef.current = null;
+    };
+    document.addEventListener("visibilitychange", restoreSceneReadyTitle);
+    window.addEventListener("focus", restoreSceneReadyTitle);
+    return () => {
+      document.removeEventListener("visibilitychange", restoreSceneReadyTitle);
+      window.removeEventListener("focus", restoreSceneReadyTitle);
+      if (sceneReadyOriginalTitleRef.current != null) {
+        document.title = sceneReadyOriginalTitleRef.current;
+        sceneReadyOriginalTitleRef.current = null;
+      }
+    };
+  }, []);
 
   // On first render, mark existing messages as scene-ready (avoid false loading).
   // Only pre-seed sceneReadyMsgIdRef (narration gating) and weatherMsgRef.
@@ -3214,6 +3276,7 @@ export function GameSurface({
     }
 
     console.warn("[scene-wrapup] path:", useSidecar ? "sidecar" : sceneConnId ? "connection" : "inline-only");
+    pendingSceneReadyNotificationMsgIdRef.current = useSidecar || sceneConnId ? msg.id : null;
 
     // Only send assets the LLM actually picks from: backgrounds (capped 50) and SFX (capped 50).
     // Music and ambient are handled by deterministic server-side scoring — not sent.
@@ -3270,11 +3333,8 @@ export function GameSurface({
           onError: () => {
             onComplete();
             setSceneAnalysisFailed(true);
+            pendingSceneReadyNotificationMsgIdRef.current = null;
             applyInlineTags(tags, assets, msg);
-            if (sceneReadyMsgIdRef.current !== msg.id) {
-              sceneReadyMsgIdRef.current = msg.id;
-              setSceneReadyTick((t) => t + 1);
-            }
           },
         },
       );
@@ -3295,11 +3355,8 @@ export function GameSurface({
             onComplete();
             console.warn("[scene-wrapup] scene-wrap failed:", err);
             setSceneAnalysisFailed(true);
+            pendingSceneReadyNotificationMsgIdRef.current = null;
             applyInlineTags(tags, assets, msg);
-            if (sceneReadyMsgIdRef.current !== msg.id) {
-              sceneReadyMsgIdRef.current = msg.id;
-              setSceneReadyTick((t) => t + 1);
-            }
           },
         },
       );
@@ -3316,11 +3373,8 @@ export function GameSurface({
       if (sceneReadyMsgIdRef.current !== msg.id) {
         console.warn("[scene-wrapup] Scene analysis timed out after 120s, falling back to inline tags");
         setSceneAnalysisFailed(true);
+        pendingSceneReadyNotificationMsgIdRef.current = null;
         applyInlineTags(tags, assets, msg);
-        if (sceneReadyMsgIdRef.current !== msg.id) {
-          sceneReadyMsgIdRef.current = msg.id;
-          setSceneReadyTick((t) => t + 1);
-        }
       }
     }, 120_000);
   };
@@ -3379,8 +3433,7 @@ export function GameSurface({
       }
     }
     // Scene effects are applied — ungate narration
-    sceneReadyMsgIdRef.current = msg.id;
-    setSceneReadyTick((t) => t + 1);
+    markSceneReady(msg.id, { notify: true });
   }
 
   const installGeneratedIllustration = useCallback(
@@ -3666,14 +3719,12 @@ export function GameSurface({
               setPendingAssetGeneration(null);
             }
             // Ungate narration after assets are installed
-            sceneReadyMsgIdRef.current = msg.id;
-            setSceneReadyTick((t) => t + 1);
+            markSceneReady(msg.id, { notify: true });
           })
           .catch(() => {
             setAssetGenerationFailed(true);
             // Keep pendingAssetGeneration so retry UI/button remain visible
-            sceneReadyMsgIdRef.current = msg.id;
-            setSceneReadyTick((t) => t + 1);
+            markSceneReady(msg.id);
           });
         // Don't fall through — narration stays gated until assets finish
         return;
@@ -3681,8 +3732,7 @@ export function GameSurface({
     }
 
     // Scene effects are applied — ungate narration (no pending assets)
-    sceneReadyMsgIdRef.current = msg.id;
-    setSceneReadyTick((t) => t + 1);
+    markSceneReady(msg.id, { notify: true });
   }
 
   // Keep ref up-to-date so retry button can call it


### PR DESCRIPTION
## Linked issue

Closes #472

## Why this change

- Game Mode users can wait several minutes for scene preparation after the GM finishes narrating. This adds a clear ready signal so users do not have to keep checking the tab manually.

## What changed

- Added a scene-ready notification path when async Game Mode scene preparation completes successfully.
- Reused the existing RP notification sound setting for the completion ping.
- Added an in-app toast, browser notification when permission is already granted, and a temporary hidden-tab title signal.
- Kept the notification tied to the actual narration ungate point so generated scene assets can finish before users are pinged.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Codex ran `pnpm check` successfully in a clean worktree.
- Manual browser verification still needed: grant browser notifications, run a Game Mode turn with async scene preparation, switch away from the tab, and confirm the toast/sound/title/browser notification behavior when preparation finishes.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

N/A. This is a notification/lifecycle behavior change; no static UI layout changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced scene readiness notifications with toast alerts, optional sound effects, and document title updates when scene preparation completes.
  * Improved notification logic to prevent duplicate alerts across different scene analysis phases and asset generation flows.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/618)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->