### PR TITLE
Support random expression sprite groups

### DIFF
--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -63,6 +63,7 @@ import { executeToolCalls, type MetadataPatchInput } from "../services/tools/too
 import { createAgentPipeline, type ResolvedAgent, type AgentInjection } from "../services/agents/agent-pipeline.js";
 import { DATA_DIR } from "../utils/data-dir.js";
 import { executeAgent, normalizeAgentContextSize, resolveAgentResultType } from "../services/agents/agent-executor.js";
+import { buildSpriteExpressionChoices, listCharacterSprites } from "../services/game/sprite.service.js";
 import { getLocalSidecarProvider, LOCAL_SIDECAR_MODEL } from "../services/llm/local-sidecar.js";
 import {
   parseCharacterCommands,
@@ -3854,18 +3855,21 @@ export async function generateRoutes(app: FastifyInstance) {
       // If the expression agent is enabled, load available sprite expressions per character
       if (resolvedAgents.some((a) => a.type === "expression")) {
         try {
-          const { readdirSync, existsSync: existsSyncFs } = await import("fs");
-          const { join: joinPath, extname: extnameFs } = await import("path");
-          const spritesRoot = joinPath(DATA_DIR, "sprites");
-          const spriteExts = new Set([".png", ".jpg", ".jpeg", ".gif", ".webp", ".avif", ".svg"]);
-          const perChar: Array<{ characterId: string; characterName: string; expressions: string[] }> = [];
+          const perChar: Array<{
+            characterId: string;
+            characterName: string;
+            expressions: string[];
+            expressionChoices: string[];
+          }> = [];
           for (const char of agentContext.characters) {
-            const charDir = joinPath(spritesRoot, char.id);
-            if (!existsSyncFs(charDir)) continue;
-            const files = readdirSync(charDir).filter((f: string) => spriteExts.has(extnameFs(f).toLowerCase()));
-            const exprNames = files.map((f: string) => f.slice(0, -extnameFs(f).length));
-            if (exprNames.length > 0) {
-              perChar.push({ characterId: char.id, characterName: char.name, expressions: exprNames });
+            const sprites = listCharacterSprites(char.id);
+            if (sprites && sprites.expressions.length > 0) {
+              perChar.push({
+                characterId: char.id,
+                characterName: char.name,
+                expressions: sprites.expressions,
+                expressionChoices: buildSpriteExpressionChoices(sprites.expressions),
+              });
             }
           }
           if (perChar.length > 0) {

--- a/packages/server/src/routes/generate/expression-agent-utils.ts
+++ b/packages/server/src/routes/generate/expression-agent-utils.ts
@@ -2,6 +2,7 @@ export type AvailableSpriteCharacter = {
   characterId: string;
   characterName: string;
   expressions: string[];
+  expressionChoices?: string[];
 };
 
 export type SpriteExpressionEntry = {
@@ -54,6 +55,17 @@ function hasUsefulContainmentMatch(candidate: string, option: string): boolean {
   return candidate.includes(option) || option.includes(candidate);
 }
 
+function pickRandomExpression(expressions: string[]): string | null {
+  if (expressions.length === 0) return null;
+  return expressions[Math.floor(Math.random() * expressions.length)] ?? expressions[0] ?? null;
+}
+
+function getExpressionPrefixVariant(expression: string, groupKey: string): boolean {
+  const lower = expression.toLowerCase();
+  const normalizedGroup = groupKey.trim().toLowerCase();
+  return lower.startsWith(`${normalizedGroup}_`);
+}
+
 function resolveCharacter(
   entry: SpriteExpressionEntry,
   availableSprites: AvailableSpriteCharacter[],
@@ -97,6 +109,11 @@ function resolveExpression(expression: string, availableExpressions: string[]): 
   if (!trimmed) return null;
 
   const lower = trimmed.toLowerCase();
+
+  const prefixMatches = availableExpressions.filter((entry) => getExpressionPrefixVariant(entry, trimmed));
+  const randomPrefixMatch = prefixMatches.length > 1 ? pickRandomExpression(prefixMatches) : null;
+  if (randomPrefixMatch) return randomPrefixMatch;
+
   const exact = availableExpressions.find((entry) => entry.toLowerCase() === lower);
   if (exact) return exact;
 

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -7,7 +7,7 @@ import {
   type AgentResult,
 } from "@marinara-engine/shared";
 import { eq } from "drizzle-orm";
-import { listCharacterSprites } from "../../services/game/sprite.service.js";
+import { buildSpriteExpressionChoices, listCharacterSprites } from "../../services/game/sprite.service.js";
 import { DATA_DIR } from "../../utils/data-dir.js";
 import type { ResolvedAgent } from "../../services/agents/agent-pipeline.js";
 import { executeAgent, executeAgentBatch, normalizeAgentContextSize } from "../../services/agents/agent-executor.js";
@@ -296,11 +296,21 @@ async function buildRetryAgentContext(args: {
   // If the expression agent is being retried, load available sprite expressions per character
   if (resolvedAgentTypes.has("expression")) {
     try {
-      const perChar: Array<{ characterId: string; characterName: string; expressions: string[] }> = [];
+      const perChar: Array<{
+        characterId: string;
+        characterName: string;
+        expressions: string[];
+        expressionChoices: string[];
+      }> = [];
       for (const char of agentContext.characters) {
         const sprites = listCharacterSprites(char.id);
         if (sprites && sprites.expressions.length > 0) {
-          perChar.push({ characterId: char.id, characterName: char.name, expressions: sprites.expressions });
+          perChar.push({
+            characterId: char.id,
+            characterName: char.name,
+            expressions: sprites.expressions,
+            expressionChoices: buildSpriteExpressionChoices(sprites.expressions),
+          });
         }
       }
       if (perChar.length > 0) {

--- a/packages/server/src/services/agents/agent-executor.ts
+++ b/packages/server/src/services/agents/agent-executor.ts
@@ -874,10 +874,12 @@ function buildAvailableSpritesBlock(context: AgentContext): string {
     characterId: string;
     characterName: string;
     expressions: string[];
+    expressionChoices?: string[];
   }>;
   const parts: string[] = [`<available_sprites>`];
   for (const char of sprites) {
-    parts.push(`${char.characterName} (${char.characterId}): ${char.expressions.join(", ")}`);
+    const choices = char.expressionChoices?.length ? char.expressionChoices : char.expressions;
+    parts.push(`${char.characterName} (${char.characterId}): ${choices.join(", ")}`);
   }
   parts.push(`</available_sprites>`);
   return parts.join("\n");

--- a/packages/server/src/services/game/sprite.service.ts
+++ b/packages/server/src/services/game/sprite.service.ts
@@ -25,10 +25,58 @@ const AUTOMATIC_FULL_BODY_POSES = new Set([
 export interface CharacterSpriteInfo {
   name: string;
   expressions: string[];
+  expressionChoices: string[];
   /** Custom full-body aliases the model may intentionally choose. */
   fullBody: string[];
   /** Engine-assigned standard full-body poses; not exposed to the model. */
   automaticFullBody: string[];
+}
+
+function getSpriteExpressionGroupKey(expression: string): string | null {
+  const underscoreIndex = expression.indexOf("_");
+  if (underscoreIndex <= 0) return null;
+  const key = expression.slice(0, underscoreIndex).trim();
+  return key || null;
+}
+
+/**
+ * Collapse variant filenames like joy_01 / joy_blush into the simple group key
+ * that the expression agent should see. The full concrete filenames stay in
+ * expressions so validation can randomly resolve the group at runtime.
+ */
+export function buildSpriteExpressionChoices(expressions: string[]): string[] {
+  const groupKeys = new Map<string, { key: string; count: number }>();
+
+  for (const expression of expressions) {
+    const groupKey = getSpriteExpressionGroupKey(expression);
+    if (!groupKey) continue;
+
+    const lookupKey = groupKey.toLowerCase();
+    const existing = groupKeys.get(lookupKey);
+    if (existing) {
+      existing.count += 1;
+    } else {
+      groupKeys.set(lookupKey, { key: groupKey, count: 1 });
+    }
+  }
+
+  const choices: string[] = [];
+  const emitted = new Set<string>();
+
+  for (const expression of expressions) {
+    const expressionLookup = expression.toLowerCase();
+    const groupKey = getSpriteExpressionGroupKey(expression);
+    const group = groupKey ? groupKeys.get(groupKey.toLowerCase()) : undefined;
+    const choice = group && group.count > 1 ? group.key : expression;
+
+    const choiceLookup = choice.toLowerCase();
+    if (emitted.has(choiceLookup)) continue;
+
+    choices.push(choice);
+    emitted.add(choiceLookup);
+  }
+
+  return choices;
 }
 
 /**
@@ -78,7 +126,7 @@ export function listPartySprites(characters: Array<{ id: string; name: string }>
   for (const char of characters) {
     const sprites = listCharacterSprites(char.id);
     if (sprites) {
-      result.push({ name: char.name, ...sprites });
+      result.push({ name: char.name, expressionChoices: buildSpriteExpressionChoices(sprites.expressions), ...sprites });
     }
   }
   return result;

--- a/packages/shared/src/constants/agent-prompts.ts
+++ b/packages/shared/src/constants/agent-prompts.ts
@@ -87,6 +87,7 @@ If no issues found, return: { "issues": [], "verdict": "clean" }`,
   /* ────────────────────────────────────────── */
   expression: `Analyze the emotional state of each character in the latest assistant message and pick the best matching sprite expression from their AVAILABLE sprites, listed in <available_sprites>.
 The <available_sprites> block lists characters in the format: CharacterName (CharacterID): expression1, expression2, ...
+Some listed expressions are simple group keys. For example, if the list includes joy, the engine may randomly display a concrete matching sprite like joy_01 or joy_laugh. Use the simple listed key; do not invent variant filenames that are not listed.
 Respond ONLY with valid JSON.
 Output format:
 {
@@ -94,7 +95,7 @@ Output format:
     {
       "characterId": "string (MUST be the exact CharacterID from the parentheses in <available_sprites>)",
       "characterName": "string",
-      "expression": "string (MUST be one of the character's available sprite names)",
+      "expression": "string (MUST be one of the character's listed available expressions or group keys)",
       "transition": "crossfade | bounce | shake | hop | none"
     }
   ]
@@ -108,7 +109,7 @@ Transition guide:
 Instructions:
 1. ONLY include characters listed in <available_sprites>. If a character is not listed there, do NOT include them.
 2. The characterId MUST be the exact ID string from the parentheses, e.g. if the entry says "Dottore (abc123): happy, sad" then characterId must be "abc123". Never invent, reuse, or copy a different ID from chat history.
-3. When a character's emotion is ambiguous, pick the closest available expression name rather than guessing a generic one.`,
+3. When a character's emotion is ambiguous, pick the closest listed available expression or group key rather than guessing a generic one.`,
 
   /* ────────────────────────────────────────── */
   "echo-chamber": `Simulate a live streaming-service chat full of anonymous viewers reacting to the roleplay on screen. Generate a batch of short messages from fictional viewers commenting on the latest story beat.


### PR DESCRIPTION
## Linked issue

Closes #471

## Why this change

- Expression Engine currently exposes concrete sprite filenames to the agent, which makes characters with multiple variants for the same mood harder to configure and bloats the available sprite prompt. This lets users keep simple SillyTavern-style keys like `joy` while the engine rotates through matching `joy_*` sprite variants.

## What changed

- Added compact expression choices that collapse repeated underscore-prefixed variants like `joy_01` / `joy_laugh` into the group key `joy` for agent prompt context.
- Updated Expression Engine validation to resolve group keys to a random concrete matching sprite before persisting or sending results to the client.
- Reused the grouped sprite catalog in normal generation and retry-agent generation.
- Updated the built-in Expression Engine prompt to explain group keys.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Codex verification in clean worktree `C:\tmp\Marinara-Engine-issue-471`:
  - `pnpm --filter @marinara-engine/server exec tsx ../../scratch/verify-random-expression-groups.ts`
  - `pnpm check`
- Scratch proof confirmed compact choices expose `joy`, hide `joy_01` / `joy_laugh`, resolve repeated `joy` selections across both concrete variants, and keep one-off `side_eye` exact.
- Manual browser/app verification pending: create or use a character with multiple `joy_*` expression sprites, have Expression Engine choose `joy`, and confirm repeated runs rotate among matching variants.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

N/A. This is server-side expression selection behavior; no UI layout changed.
