### PR TITLE
Fix Spotify DJ playlist creation endpoint

### DIFF
--- a/packages/server/src/services/spotify/dj-mari-playlist.service.ts
+++ b/packages/server/src/services/spotify/dj-mari-playlist.service.ts
@@ -580,14 +580,7 @@ async function createSpotifyPlaylist(
 ): Promise<
   Omit<DjMariPlaylistResult, "success" | "requestedTrackCount" | "tracks" | "playbackStarted" | "playbackError">
 > {
-  const profileRes = await fetchSpotifyApi(credentials, "/me", { signal: AbortSignal.timeout(15_000) });
-  if (!profileRes.ok) {
-    fail(profileRes.status, `Spotify profile failed: ${await readSpotifyError(profileRes, "Could not read profile.")}`);
-  }
-  const profile = (await profileRes.json()) as { id?: string };
-  if (!profile.id) fail(502, "Spotify profile did not include a user ID.");
-
-  const playlistRes = await fetchSpotifyApi(credentials, `/users/${encodeURIComponent(profile.id)}/playlists`, {
+  const playlistRes = await fetchSpotifyApi(credentials, "/me/playlists", {
     method: "POST",
     body: JSON.stringify({
       name,
@@ -611,7 +604,7 @@ async function createSpotifyPlaylist(
   if (!playlist.id || !playlist.uri) fail(502, "Spotify playlist creation returned an incomplete response.");
 
   const uris = tracks.map((track) => track.uri);
-  const addRes = await fetchSpotifyApi(credentials, `/playlists/${encodeURIComponent(playlist.id)}/tracks`, {
+  const addRes = await fetchSpotifyApi(credentials, `/playlists/${encodeURIComponent(playlist.id)}/items`, {
     method: "POST",
     body: JSON.stringify({ uris }),
     signal: AbortSignal.timeout(15_000),


### PR DESCRIPTION
## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #622

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- DJ Mari's Spotify playlist action could fail with `Spotify playlist creation failed: Forbidden` even when the connected Spotify token already had the playlist write scopes requested by #622.

## What changed

<!-- List the key changes in this PR -->

- Create DJ Mari playlists through Spotify's current `/me/playlists` endpoint instead of `/users/{id}/playlists`.
- Add matched tracks through `/playlists/{id}/items` so the write path uses the current Spotify Web API playlist item endpoint.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ?? If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Codex reproduced the original failure on a local personal install at `http://127.0.0.1:7861`: `POST /api/spotify/dj-mari-playlist` returned `403` with `{"error":"Spotify playlist creation failed: Forbidden"}`.
- Codex verified the stored Spotify grant had no missing scopes before the fix: `playlist-modify-private`, `playlist-modify-public`, `user-library-read`, `user-read-private`, and playback scopes were present.
- Codex rebuilt and restarted the local server, reran the same Playwright browser action, and `POST /api/spotify/dj-mari-playlist` returned `200 OK`, creating playlist `DJ Mari 2026-05-09` with 48 tracks.
- The resulting response had `playbackStarted: false` with `No active device found`, which is expected when Spotify has no active playback device and is separate from playlist creation.
- `pnpm check` passed locally.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs or release metadata changes are included; this is a narrow server-side Spotify endpoint fix.

## UI evidence (if applicable)

N/A. This is a server-side Spotify Web API endpoint fix. Browser network proof showed the same UI action changed from `403 Forbidden` before the fix to `200 OK` after the fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Optimized Spotify playlist creation and track management workflow for improved efficiency and reliability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/624)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->