### PR TITLE
fix: remove unsupported .returning() call in lorebook update (issue #627)

### DIFF
--- a/packages/server/src/services/storage/lorebooks.storage.ts
+++ b/packages/server/src/services/storage/lorebooks.storage.ts
@@ -283,8 +283,8 @@ export function createLorebooksStorage(db: DB) {
       if (input.sourceAgentId !== undefined) updates.sourceAgentId = input.sourceAgentId;
 
       await db.transaction(async (tx) => {
-        const updatedRows = await tx.update(lorebooks).set(updates).where(eq(lorebooks.id, id)).returning({ id: lorebooks.id });
-        if (updatedRows.length > 0 && (shouldUpdateCharacterLinks || shouldUpdatePersonaLinks)) {
+        await tx.update(lorebooks).set(updates).where(eq(lorebooks.id, id));
+        if (shouldUpdateCharacterLinks || shouldUpdatePersonaLinks) {
           await syncLorebookLinks(tx, id, nextCharacterIds, nextPersonaIds);
         }
       });


### PR DESCRIPTION
## Linked issue

Closes #627

## Why this change

The file-backed store's UpdateWhereBuilder does not implement .returning(), causing a TypeError on every lorebook metadata save. The existence check was already performed earlier in the method, so the .returning() result was redundant.

## What changed

- Removed .returning({ id: lorebooks.id }) from the update chain in lorebooks.storage.ts update() method
- Simplified the link-sync conditional to check shouldUpdateCharacterLinks || shouldUpdatePersonaLinks directly, since lorebook existence is already verified on lines 268-269

## Validation

- [x] `pnpm check` passes locally
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Read and followed `CONTRIBUTING.md`

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined the synchronization of character and persona links when updating lorebooks to ensure consistent behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/628)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->