### PR TITLE
feat: allow single-option preset variables as boolean toggles

### DIFF
--- a/packages/client/src/components/presets/ChoiceSelectionModal.tsx
+++ b/packages/client/src/components/presets/ChoiceSelectionModal.tsx
@@ -126,6 +126,8 @@ export function ChoiceSelectionModal({
   const allSelected = variables.every((v) => {
     const sel = selections[v.variableName];
     if (v.multiSelect) return Array.isArray(sel) && sel.length > 0;
+    // Single-option variables are boolean toggles — both ON and OFF are valid
+    if (v.options.length === 1) return sel !== undefined;
     return sel !== undefined && sel !== "";
   });
 
@@ -175,6 +177,11 @@ export function ChoiceSelectionModal({
                 <p className="text-[0.625rem] text-[var(--muted-foreground)]">
                   Variable: <code className="text-amber-400">{`{{${v.variableName}}}`}</code>
                 </p>
+                {v.options.length === 1 && !v.multiSelect && (
+                  <span className="flex items-center gap-0.5 rounded bg-purple-400/15 px-1.5 py-0.5 text-[0.5625rem] font-medium text-purple-400">
+                    Boolean toggle
+                  </span>
+                )}
                 {v.multiSelect && (
                   <span className="flex items-center gap-0.5 rounded bg-purple-400/15 px-1.5 py-0.5 text-[0.5625rem] font-medium text-purple-400">
                     {v.randomPick ? (
@@ -225,37 +232,82 @@ export function ChoiceSelectionModal({
                         </button>
                       );
                     })
-                  : // ── Single-select: radio-style ──
-                    v.options.map((opt) => {
-                      const isSelected = selections[v.variableName] === opt.value;
-                      return (
-                        <button
-                          key={opt.id}
-                          onClick={() => setOverrides((prev) => ({ ...prev, [v.variableName]: opt.value }))}
-                          className={cn(
-                            "flex w-full items-start gap-2.5 rounded-lg p-2.5 text-left transition-all",
-                            isSelected ? "bg-purple-400/10 ring-1 ring-purple-400/30" : "hover:bg-[var(--accent)]",
-                          )}
-                        >
-                          {isSelected ? (
-                            <CheckCircle2 size="0.875rem" className="mt-0.5 shrink-0 text-purple-400" />
-                          ) : (
-                            <Circle size="0.875rem" className="mt-0.5 shrink-0 text-[var(--muted-foreground)]" />
-                          )}
-                          <div className="min-w-0 flex-1">
-                            <span className={cn("text-xs font-medium", isSelected && "text-purple-400")}>
-                              {opt.label}
-                            </span>
-                            {opt.value && (
-                              <p className="mt-0.5 line-clamp-2 text-[0.625rem] text-[var(--muted-foreground)]">
-                                {opt.value.slice(0, 150)}
-                                {opt.value.length > 150 ? "…" : ""}
-                              </p>
+                  : v.options.length === 1
+                    ? // ── Boolean toggle: single option ──
+                      (() => {
+                        const opt = v.options[0];
+                        const isOn = selections[v.variableName] === opt.value;
+                        return (
+                          <button
+                            onClick={() =>
+                              setOverrides((prev) => ({
+                                ...prev,
+                                [v.variableName]: isOn ? "" : opt.value,
+                              }))
+                            }
+                            className={cn(
+                              "flex w-full items-center justify-between gap-2.5 rounded-lg p-2.5 text-left transition-all",
+                              isOn ? "bg-purple-400/10 ring-1 ring-purple-400/30" : "hover:bg-[var(--accent)]",
                             )}
-                          </div>
-                        </button>
-                      );
-                    })}
+                          >
+                            <div className="min-w-0 flex-1">
+                              <span className={cn("text-xs font-medium", isOn && "text-purple-400")}>
+                                {opt.label}
+                              </span>
+                              {opt.value && (
+                                <p className="mt-0.5 line-clamp-2 text-[0.625rem] text-[var(--muted-foreground)]">
+                                  {opt.value.slice(0, 150)}
+                                  {opt.value.length > 150 ? "…" : ""}
+                                </p>
+                              )}
+                            </div>
+                            <div
+                              className={cn(
+                                "relative inline-flex h-4 w-7 shrink-0 items-center rounded-full transition-colors",
+                                isOn ? "bg-purple-400" : "bg-[var(--border)]",
+                              )}
+                            >
+                              <span
+                                className={cn(
+                                  "pointer-events-none inline-block h-3 w-3 translate-y-0.5 rounded-full bg-white shadow transition-transform",
+                                  isOn ? "translate-x-3.5" : "translate-x-0.5",
+                                )}
+                              />
+                            </div>
+                          </button>
+                        );
+                      })()
+                    : // ── Single-select: radio-style ──
+                      v.options.map((opt) => {
+                        const isSelected = selections[v.variableName] === opt.value;
+                        return (
+                          <button
+                            key={opt.id}
+                            onClick={() => setOverrides((prev) => ({ ...prev, [v.variableName]: opt.value }))}
+                            className={cn(
+                              "flex w-full items-start gap-2.5 rounded-lg p-2.5 text-left transition-all",
+                              isSelected ? "bg-purple-400/10 ring-1 ring-purple-400/30" : "hover:bg-[var(--accent)]",
+                            )}
+                          >
+                            {isSelected ? (
+                              <CheckCircle2 size="0.875rem" className="mt-0.5 shrink-0 text-purple-400" />
+                            ) : (
+                              <Circle size="0.875rem" className="mt-0.5 shrink-0 text-[var(--muted-foreground)]" />
+                            )}
+                            <div className="min-w-0 flex-1">
+                              <span className={cn("text-xs font-medium", isSelected && "text-purple-400")}>
+                                {opt.label}
+                              </span>
+                              {opt.value && (
+                                <p className="mt-0.5 line-clamp-2 text-[0.625rem] text-[var(--muted-foreground)]">
+                                  {opt.value.slice(0, 150)}
+                                  {opt.value.length > 150 ? "…" : ""}
+                                </p>
+                              )}
+                            </div>
+                          </button>
+                        );
+                      })}
               </div>
             </div>
           ))}

--- a/packages/client/src/components/presets/PresetEditor.tsx
+++ b/packages/client/src/components/presets/PresetEditor.tsx
@@ -1577,6 +1577,11 @@ function VariableCard({
         <span className="shrink-0 rounded bg-amber-400/15 px-1.5 py-0.5 text-[0.5625rem] font-medium text-amber-400">
           {opts.length} options
         </span>
+        {opts.length === 1 && !isMultiSelect && (
+          <span className="shrink-0 rounded bg-purple-400/15 px-1.5 py-0.5 text-[0.5625rem] font-medium text-purple-400">
+            boolean
+          </span>
+        )}
         {isMultiSelect && (
           <span className="shrink-0 rounded bg-purple-400/15 px-1.5 py-0.5 text-[0.5625rem] font-medium text-purple-400">
             {isRandomPick ? "random" : "multi"}
@@ -1624,7 +1629,19 @@ function VariableCard({
             <VariableQuestionInput value={question} onCommit={(v) => update({ question: v })} />
           </div>
 
-          {/* Multi-Select & Random Pick */}
+          {/* Multi-Select & Random Pick (not shown for single-option/boolean variables) */}
+          {opts.length === 1 && !isMultiSelect ? (
+            <div className="space-y-1.5 rounded-lg bg-[var(--secondary)] p-2.5 ring-1 ring-[var(--border)]">
+              <div className="flex items-center gap-1.5">
+                <Shuffle size="0.75rem" className="text-purple-400" />
+                <span className="text-[0.625rem] font-medium text-purple-400">Boolean Toggle</span>
+              </div>
+              <p className="text-[0.5625rem] text-[var(--muted-foreground)]">
+                This variable has only one option, so it behaves as a Boolean toggle. Users can switch it on or off in the
+                Configure Preset Variables wizard.
+              </p>
+            </div>
+          ) : (
           <div className="space-y-2 rounded-lg bg-[var(--secondary)] p-2.5 ring-1 ring-[var(--border)]">
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-1.5">
@@ -1700,55 +1717,73 @@ function VariableCard({
               </div>
             )}
           </div>
+          )}
 
           {/* Options */}
           <div className="space-y-1.5">
             <label className="text-[0.625rem] font-medium text-[var(--muted-foreground)]">Options</label>
-            {opts.map((opt, oi) => (
-              <div
-                key={opt.id}
-                className="flex items-center gap-2 rounded-lg bg-[var(--secondary)] px-2.5 py-1.5 ring-1 ring-[var(--border)]"
-              >
-                <span className="shrink-0 text-[0.625rem] font-medium text-amber-400">{oi + 1}.</span>
-                <OptionFieldInput
-                  value={opt.label}
-                  onCommit={(v) => {
-                    const next = [...opts];
-                    next[oi] = { ...next[oi], label: v };
-                    updateOpts(next);
-                  }}
-                  className="flex-1 rounded bg-[var(--background)] px-1.5 py-0.5 text-xs focus:outline-none focus:ring-1 focus:ring-amber-400/50"
-                  placeholder="Label…"
-                />
-                <OptionFieldInput
-                  value={opt.value}
-                  onCommit={(v) => {
-                    const next = [...opts];
-                    next[oi] = { ...next[oi], value: v };
-                    updateOpts(next);
-                  }}
-                  className="flex-1 rounded bg-[var(--background)] px-1.5 py-0.5 font-mono text-xs focus:outline-none focus:ring-1 focus:ring-amber-400/50"
-                  placeholder="Value…"
-                />
-                <button
-                  onClick={() => setExpandedOptIdx(oi)}
-                  className="shrink-0 rounded p-0.5 text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
-                  title="Expand value editor"
+            {opts.map((opt, oi) => {
+              const valueBlank = !opt.value || !opt.value.trim();
+              return (
+              <div key={opt.id}>
+                <div
+                  className={cn(
+                    "flex items-center gap-2 rounded-lg px-2.5 py-1.5 ring-1",
+                    valueBlank
+                      ? "bg-[var(--destructive)]/5 ring-[var(--destructive)]/30"
+                      : "bg-[var(--secondary)] ring-[var(--border)]",
+                  )}
                 >
-                  <Maximize2 size="0.625rem" />
-                </button>
-                <button
-                  onClick={() => {
-                    if (opts.length <= 2) return toast.error("A variable needs at least 2 options.");
-                    updateOpts(opts.filter((_, i) => i !== oi));
-                  }}
-                  className="shrink-0 rounded p-0.5 hover:bg-[var(--destructive)]/15"
-                  title="Remove option"
-                >
-                  <X size="0.625rem" className="text-[var(--destructive)]" />
-                </button>
+                  <span className="shrink-0 text-[0.625rem] font-medium text-amber-400">{oi + 1}.</span>
+                  <OptionFieldInput
+                    value={opt.label}
+                    onCommit={(v) => {
+                      const next = [...opts];
+                      next[oi] = { ...next[oi], label: v };
+                      updateOpts(next);
+                    }}
+                    className="flex-1 rounded bg-[var(--background)] px-1.5 py-0.5 text-xs focus:outline-none focus:ring-1 focus:ring-amber-400/50"
+                    placeholder="Label…"
+                  />
+                  <OptionFieldInput
+                    value={opt.value}
+                    onCommit={(v) => {
+                      const next = [...opts];
+                      next[oi] = { ...next[oi], value: v };
+                      updateOpts(next);
+                    }}
+                    className={cn(
+                      "flex-1 rounded px-1.5 py-0.5 font-mono text-xs focus:outline-none focus:ring-1",
+                      valueBlank
+                        ? "bg-[var(--destructive)]/10 ring-1 ring-[var(--destructive)]/30 placeholder:text-[var(--destructive)]/40"
+                        : "bg-[var(--background)] focus:ring-amber-400/50",
+                    )}
+                    placeholder="Value…"
+                  />
+                  <button
+                    onClick={() => setExpandedOptIdx(oi)}
+                    className="shrink-0 rounded p-0.5 text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+                    title="Expand value editor"
+                  >
+                    <Maximize2 size="0.625rem" />
+                  </button>
+                  <button
+                    onClick={() => {
+                      if (opts.length <= 1) return toast.error("A variable needs at least 1 option.");
+                      updateOpts(opts.filter((_, i) => i !== oi));
+                    }}
+                    className="shrink-0 rounded p-0.5 hover:bg-[var(--destructive)]/15"
+                    title="Remove option"
+                  >
+                    <X size="0.625rem" className="text-[var(--destructive)]" />
+                  </button>
+                </div>
+                {valueBlank && (
+                  <p className="mt-1 pl-6 text-[0.5625rem] text-[var(--destructive)]">Value cannot be empty.</p>
+                )}
               </div>
-            ))}
+            );
+            })}
             <button
               onClick={() => {
                 const newOpt = {

--- a/packages/shared/src/schemas/prompt.schema.ts
+++ b/packages/shared/src/schemas/prompt.schema.ts
@@ -78,7 +78,7 @@ export const createChoiceBlockSchema = z.object({
   presetId: z.string(),
   variableName: z.string().min(1).max(100).regex(/^\w+$/, "Variable name must be alphanumeric/underscores only"),
   question: z.string().min(1).max(500),
-  options: z.array(choiceOptionSchema).min(2),
+  options: z.array(choiceOptionSchema).min(1),
   multiSelect: z.boolean().default(false),
   separator: z.string().max(20).default(", "),
   randomPick: z.boolean().default(false),
@@ -92,7 +92,7 @@ export const updateChoiceBlockSchema = z.object({
     .regex(/^\w+$/, "Variable name must be alphanumeric/underscores only")
     .optional(),
   question: z.string().min(1).max(500).optional(),
-  options: z.array(choiceOptionSchema).min(2).optional(),
+  options: z.array(choiceOptionSchema).min(1).optional(),
   multiSelect: z.boolean().optional(),
   separator: z.string().max(20).optional(),
   randomPick: z.boolean().optional(),


### PR DESCRIPTION
- Relax option minimum from 2 to 1 in createChoiceBlockSchema/updateChoiceBlockSchema
- Show boolean badge + info panel in PresetEditor when a variable has 1 option
- Render toggle switch in ChoiceSelectionModal for single-option variables
- Style toggle card consistently with existing radio/multi-select cards

## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #632

## Why this change

<!-- What user problem, bug, or goal does this solve? -->
1. The preset builder allows you to set a blank value for a variable, but the Configure Preset Variables treats blank values as unselected and blocks you from confirming your choices. 
2. I ran into this because I wanted to make an on/off type option and there is no obvious way to do that. 

## What changed

1. Added helper text is user has blanked out a variable's value so they know it is required. 
2. Reduced minimum option count from 2 to 1. If a variable only has one option, Configure Preset Variables will display it as a switch instead of a checkbox. 

-

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

1. Modified the built-in preset with a new boolean type variable
3. Verified that it does not appear in the prompt peeker when toggled off
4. Verified that it does appear in the prompt peeker when toggled on

-

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

<img width="750" height="313" alt="image" src="https://github.com/user-attachments/assets/30cf219b-d631-438a-853d-41e685866d5a" />
<img width="860" height="475" alt="Screenshot_20260510_020220" src="https://github.com/user-attachments/assets/d7f04a6f-57c1-4e9f-91f2-f8847c41ca6c" />
<img width="755" height="402" alt="image" src="https://github.com/user-attachments/assets/f8e18191-08df-47ed-8431-e5b9b37439a4" />
<img width="539" height="245" alt="Screenshot_20260510_020244" src="https://github.com/user-attachments/assets/5cbe1f03-c6f1-4a53-b29c-652a983d4879" />
<img width="539" height="242" alt="Screenshot_20260510_020251" src="https://github.com/user-attachments/assets/3a64bfe2-c022-47fd-a3fb-17c66973b695" />
<img width="557" height="357" alt="Screenshot_20260510_020313" src="https://github.com/user-attachments/assets/ce71c37f-d25b-4b46-91cc-77ff7a8d63b1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Single-option choice variables now display as boolean toggle buttons with on/off controls instead of radio-style selectors
  * Single-option variables labeled as "Boolean Toggle" for clarity
  * Enhanced validation with inline error messages for empty option values
  * Adjusted option removal restrictions for improved usability

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/633)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->