### PR TITLE
fix(file-storage): use err-first logger form in flush failure path

### DIFF
--- a/packages/server/src/db/file-backed-store.ts
+++ b/packages/server/src/db/file-backed-store.ts
@@ -938,7 +938,7 @@ class FileTableStore {
       this.dirtyTables.clear();
     } catch (err) {
       this.dirty = true;
-      logger.error({ err }, "[file-storage] Failed to persist file-native storage");
+      logger.error(err, "[file-storage] Failed to persist file-native storage");
     } finally {
       this.saving = false;
     }


### PR DESCRIPTION
## Linked issue

Closes #635

## Why this change

- `CLAUDE.md § Logging` requires Pino's err-first form for error logs (`logger.error(err, "...")`), but `FileTableStore.flush`'s catch block in `packages/server/src/db/file-backed-store.ts` was still using the metadata-first form (`logger.error({ err }, "...")`).
- PR #634 (commit d67d4f4) corrected the three sibling instances in this same file and intentionally left this pre-existing one out of scope to keep that PR focused. Issue #635 tracks the cleanup.

## What changed

- `packages/server/src/db/file-backed-store.ts`: switched the single remaining `logger.error({ err }, ...)` call in `FileTableStore.flush`'s catch block to err-first form. No behavior change — only the log shape, so flush-failure errors deserialize as the top-level `err` field, matching the rest of the file.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Manually verify the EasyPanel container builds with the change (Dockerfile build invokes `pnpm install --frozen-lockfile` and the package build steps).
- Manually verify the app loads and exercises the file-backed store: navigate to `/`, observe `/api/chats`, `/api/characters`, `/api/sprites`, `/api/avatars`, `/api/regex-scripts`, `/api/.../game-state` all return 200, no console errors. (The catch block only fires on flush failure, so the only runtime risk is a build/import regression — which `pnpm check` and a successful container start cover.)
- Manually verify (optional, hard to trigger naturally) that a forced flush failure logs with `err` as a top-level field instead of nested under `{ err }`.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

N/A — server-side log shape change with no UI surface.