### PR TITLE
feat(chat): up-arrow recalls last user message for editing

### DIFF
--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -862,6 +862,15 @@ export function ChatArea() {
     return null;
   }, [messages]);
 
+  const latestUserMessageForEdit = useMemo(() => {
+    if (!messages) return null;
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const candidate = messages[i]!;
+      if (candidate.role === "user") return candidate;
+    }
+    return null;
+  }, [messages]);
+
   const intuitiveSwipeBlocked =
     settingsOpen ||
     filesOpen ||
@@ -915,8 +924,38 @@ export function ChatArea() {
   useEffect(() => {
     if (!intuitiveSwipeNavigation || intuitiveSwipeBlocked) return;
 
+    const supportsMode = chatMode === "conversation" || isRoleplay;
+
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.defaultPrevented) return;
+
+      if (event.key === "ArrowUp") {
+        if (!supportsMode || !latestUserMessageForEdit) return;
+        if (event.repeat || event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) return;
+        const target = event.target;
+        if (target instanceof Element) {
+          // Don't hijack up-arrow when the user is typing or already editing.
+          // Allow it from the chat input only when it's empty (shell-style recall).
+          if (target.tagName === "TEXTAREA") {
+            const ta = target as HTMLTextAreaElement;
+            if (ta.value.length > 0) return;
+          } else if (
+            target.tagName === "INPUT" ||
+            target.tagName === "SELECT" ||
+            target.getAttribute("contenteditable") === "true"
+          ) {
+            return;
+          }
+        }
+        event.preventDefault();
+        window.dispatchEvent(
+          new CustomEvent("marinara:start-edit-message", {
+            detail: { messageId: latestUserMessageForEdit.id },
+          }),
+        );
+        return;
+      }
+
       if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
       if (shouldIgnoreIntuitiveSwipeTarget(event.target)) return;
 
@@ -932,7 +971,15 @@ export function ChatArea() {
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [intuitiveSwipeBlocked, intuitiveSwipeNavigation, latestAssistantMessageForSwipes, navigateLatestSwipe]);
+  }, [
+    chatMode,
+    intuitiveSwipeBlocked,
+    intuitiveSwipeNavigation,
+    isRoleplay,
+    latestAssistantMessageForSwipes,
+    latestUserMessageForEdit,
+    navigateLatestSwipe,
+  ]);
 
   useEffect(() => {
     if (!intuitiveSwipeNavigation || intuitiveSwipeBlocked) return;

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -860,6 +860,16 @@ export const ChatMessage = memo(function ChatMessage({
     setEditing(true);
   }, []);
 
+  useEffect(() => {
+    if (message.role !== "user" || !onEdit) return;
+    const handler = (event: Event) => {
+      const detail = (event as CustomEvent<{ messageId?: string }>).detail;
+      if (detail?.messageId === message.id) startEditing();
+    };
+    window.addEventListener("marinara:start-edit-message", handler);
+    return () => window.removeEventListener("marinara:start-edit-message", handler);
+  }, [message.id, message.role, onEdit, startEditing]);
+
   const handleSaveEdit = useCallback(
     (content: string) => {
       if (content.trim() !== message.content) {

--- a/packages/client/src/components/chat/ConversationMessage.tsx
+++ b/packages/client/src/components/chat/ConversationMessage.tsx
@@ -530,6 +530,18 @@ export const ConversationMessage = memo(function ConversationMessage({
     });
   }, [message.content]);
 
+  useEffect(() => {
+    if (message.role !== "user" || !onEdit) return;
+    const handler = (event: Event) => {
+      const detail = (event as CustomEvent<{ messageId?: string }>).detail;
+      if (detail?.messageId !== message.id) return;
+      if (onEditClick) onEditClick();
+      else startEditing();
+    };
+    window.addEventListener("marinara:start-edit-message", handler);
+    return () => window.removeEventListener("marinara:start-edit-message", handler);
+  }, [message.id, message.role, onEdit, onEditClick, startEditing]);
+
   const editValueRef = useRef(editValue);
   editValueRef.current = editValue;
 

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -618,7 +618,7 @@ function GeneralSettings() {
         label="Intuitive swipe navigation"
         checked={intuitiveSwipeNavigation}
         onChange={setIntuitiveSwipeNavigation}
-        help="In Conversation and Roleplay modes, use Left/Right Arrow on desktop or horizontal touch swipes on mobile to move between alternate generations on the latest assistant message."
+        help="In Conversation and Roleplay modes, use Left/Right Arrow on desktop or horizontal touch swipes on mobile to move between alternate generations on the latest assistant message. Up Arrow edits your last sent message (only when the chat input is empty)."
       />
 
       <div className={cn("pl-5 transition-opacity", intuitiveSwipeNavigation ? "" : "pointer-events-none opacity-45")}>


### PR DESCRIPTION
## Summary

Extends the existing **Intuitive swipe navigation** toggle so that, in Conversation and Roleplay modes, pressing the **Up Arrow** key opens the most recent user message in inline edit mode — shell/Discord style.

- Recall only fires when the chat input is empty, so plain typing is unaffected (Up still moves the cursor inside non-empty textareas).
- Inputs, single-line `<input>`s, selects, and `contenteditable` regions are skipped, so other text fields are not hijacked.
- Modifier keys (Ctrl/Alt/Meta/Shift) and key-repeat are ignored.
- Honors the same blockers as Left/Right swipe navigation (settings drawer, files drawer, gallery, wizard, multi-select, delete dialog, peek-prompt, encounter, etc.).
- Help text on the **Intuitive swipe navigation** toggle (`?` tooltip in Settings) now mentions the new Up Arrow behavior.

## Implementation

- `ChatArea.tsx` — Adds `latestUserMessageForEdit` memo and an `ArrowUp` branch in the existing intuitive-swipe keydown effect. On a valid press it dispatches a `marinara:start-edit-message` window event with the user message id.
- `ChatMessage.tsx` (Roleplay) — Listens for the event and calls `startEditing()` when the id matches and the message is from the user.
- `ConversationMessage.tsx` (Conversation) — Same listener; defers to `onEditClick` when present so `SplitMessageGroup`'s group-wide editor is used for split messages.
- `SettingsPanel.tsx` — Updates the tooltip on the Intuitive swipe navigation toggle.

No new state, no new dependencies. The feature is gated behind the existing toggle and the same `chatMode === "conversation" || isRoleplay` check used for swipe navigation.

## Notes

- No linked issue/feature request — one should be opened to track this if the project's convention requires it.
- No new automated tests; the project does not have a frontend test suite (per CLAUDE.md).
- A separate, pre-existing build issue (`GameSurface` chunk over the 500 kB bundle-budget plugin limit) currently fails `pnpm build` on `main`. It is unrelated to this PR and should be addressed in its own change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Up Arrow keyboard shortcut to edit your most recent message instantly when the chat input is empty, enabling quick corrections and refinements.

* **Documentation**
  * Updated settings help text to document the new Up Arrow editing behavior alongside existing keyboard and touch navigation features.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/639)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->