### PR TITLE
Fix silent empty responses from OpenAI models

### DIFF
--- a/packages/server/src/services/llm/providers/openai.provider.ts
+++ b/packages/server/src/services/llm/providers/openai.provider.ts
@@ -740,10 +740,11 @@ export class OpenAIProvider extends BaseLLMProvider {
 
     if (!effectiveStream) {
       const json = await OpenAIProvider.parseJsonBody<{
-        choices: Array<{ message: Record<string, unknown> & { content: string | unknown[] } }>;
+        choices: Array<{ message: Record<string, unknown> & { content: string | unknown[] | null; refusal?: string } }>;
         usage?: ChatCompletionsUsagePayload;
       }>(response, "OpenAI chat() non-stream response");
       const msg = json.choices[0]?.message;
+      const refusal = typeof msg?.refusal === "string" && msg.refusal ? msg.refusal : "";
       const reasoningMetadata = OpenAIProvider.extractReasoningMetadata(msg);
       OpenAIProvider.emitChatCompletionsReasoning(options, reasoningMetadata);
       const reasoning = OpenAIProvider.extractReasoning(msg);
@@ -754,9 +755,9 @@ export class OpenAIProvider extends BaseLLMProvider {
       const blocks = OpenAIProvider.extractContentBlocks(msg?.content);
       if (blocks) {
         if (!reasoning && blocks.thinking && options.onThinking) options.onThinking(blocks.thinking);
-        yield blocks.text;
+        yield blocks.text || refusal;
       } else {
-        yield (msg?.content as string) ?? "";
+        yield (typeof msg?.content === "string" ? msg.content : "") || refusal;
       }
       return OpenAIProvider.extractChatCompletionsUsage(json.usage);
     }
@@ -1466,7 +1467,7 @@ export class OpenAIProvider extends BaseLLMProvider {
               const resp = parsed.response as Record<string, unknown> | undefined;
               const error = resp?.error as Record<string, unknown> | undefined;
               const msg = (error?.message as string) ?? "unknown error";
-              logger.warn("[OpenAI Responses] Stream ended with response.failed: %s", msg);
+              logger.error(new Error(msg), "[OpenAI Responses] Stream ended with response.failed");
               break;
             }
             case "response.incomplete": {
@@ -1717,7 +1718,7 @@ export class OpenAIProvider extends BaseLLMProvider {
               const resp = parsed.response as Record<string, unknown> | undefined;
               const error = resp?.error as Record<string, unknown> | undefined;
               const msg = (error?.message as string) ?? "unknown error";
-              logger.warn("[OpenAI Responses] chatCompleteResponses stream failed: %s", msg);
+              logger.error(new Error(msg), "[OpenAI Responses] chatCompleteResponses stream failed");
               break;
             }
             case "response.incomplete": {

--- a/packages/server/src/services/llm/providers/openai.provider.ts
+++ b/packages/server/src/services/llm/providers/openai.provider.ts
@@ -822,6 +822,8 @@ export class OpenAIProvider extends BaseLLMProvider {
               if (blocks.text) yield blocks.text;
             } else if (delta?.content) {
               yield delta.content as string;
+            } else if (typeof delta?.refusal === "string" && delta.refusal) {
+              yield delta.refusal;
             }
           } catch {
             // Skip malformed JSON lines
@@ -962,6 +964,10 @@ export class OpenAIProvider extends BaseLLMProvider {
       } else {
         resolvedContent = (choice?.message?.content as string) ?? null;
       }
+      // Fall back to refusal text so the user sees why the model declined
+      if (!resolvedContent && typeof choice?.message?.refusal === "string" && choice.message.refusal) {
+        resolvedContent = choice.message.refusal;
+      }
       const usage = OpenAIProvider.extractChatCompletionsUsage(json.usage);
       return {
         content: resolvedContent,
@@ -1051,6 +1057,9 @@ export class OpenAIProvider extends BaseLLMProvider {
           } else if (delta?.content) {
             content += delta.content as string;
             options.onToken?.(delta.content as string);
+          } else if (typeof delta?.refusal === "string" && delta.refusal) {
+            content += delta.refusal;
+            options.onToken?.(delta.refusal);
           }
 
           // Accumulate tool call deltas
@@ -1379,6 +1388,7 @@ export class OpenAIProvider extends BaseLLMProvider {
     const decoder = new TextDecoder();
     let buffer = "";
     let streamUsage: LLMUsage | undefined;
+    let yieldedAny = false;
 
     while (true) {
       const { done, value } = await reader.read();
@@ -1414,7 +1424,10 @@ export class OpenAIProvider extends BaseLLMProvider {
           switch (eventType) {
             case "response.output_text.delta": {
               const delta = parsed.delta as string | undefined;
-              if (delta) yield delta;
+              if (delta) {
+                yieldedAny = true;
+                yield delta;
+              }
               break;
             }
             case "response.reasoning_summary_text.delta": {
@@ -1425,7 +1438,10 @@ export class OpenAIProvider extends BaseLLMProvider {
             case "response.refusal.delta": {
               // Treat refusals as regular text so the user sees the message
               const delta = parsed.delta as string | undefined;
-              if (delta) yield delta;
+              if (delta) {
+                yieldedAny = true;
+                yield delta;
+              }
               break;
             }
             case "response.completed": {
@@ -1434,7 +1450,29 @@ export class OpenAIProvider extends BaseLLMProvider {
               if (resp) {
                 streamUsage = this.extractResponsesUsage(resp);
                 this.emitEncryptedReasoning(resp, options);
+                // If no text was streamed (e.g. refusal or content only in the
+                // completed payload), extract it as a last-resort fallback.
+                if (!yieldedAny) {
+                  const fallback = this.extractResponsesText(resp);
+                  if (fallback) {
+                    yieldedAny = true;
+                    yield fallback;
+                  }
+                }
               }
+              break;
+            }
+            case "response.failed": {
+              const resp = parsed.response as Record<string, unknown> | undefined;
+              const error = resp?.error as Record<string, unknown> | undefined;
+              const msg = (error?.message as string) ?? "unknown error";
+              logger.warn("[OpenAI Responses] Stream ended with response.failed: %s", msg);
+              break;
+            }
+            case "response.incomplete": {
+              const resp = parsed.response as Record<string, unknown> | undefined;
+              const reason = (resp?.incomplete_details as Record<string, unknown>)?.reason ?? "unknown";
+              logger.warn("[OpenAI Responses] Stream ended with response.incomplete (reason=%s)", reason);
               break;
             }
             // Ignore other event types (response.created, response.in_progress, etc.)
@@ -1586,6 +1624,15 @@ export class OpenAIProvider extends BaseLLMProvider {
               break;
             }
 
+            case "response.refusal.delta": {
+              const delta = parsed.delta as string | undefined;
+              if (delta) {
+                content += delta;
+                options.onToken?.(delta);
+              }
+              break;
+            }
+
             case "response.reasoning_summary_text.delta": {
               const delta = parsed.delta as string | undefined;
               if (delta && options.onThinking) options.onThinking(delta);
@@ -1654,7 +1701,30 @@ export class OpenAIProvider extends BaseLLMProvider {
                 this.emitEncryptedReasoning(resp, options);
                 const status = resp.status as string | undefined;
                 if (status === "incomplete") finishReason = "length";
+                // Fallback: extract text/refusal from the completed response
+                // if nothing was streamed (e.g. model returned only in payload)
+                if (!content) {
+                  const fallback = this.extractResponsesText(resp);
+                  if (fallback) {
+                    content = fallback;
+                    options.onToken?.(fallback);
+                  }
+                }
               }
+              break;
+            }
+            case "response.failed": {
+              const resp = parsed.response as Record<string, unknown> | undefined;
+              const error = resp?.error as Record<string, unknown> | undefined;
+              const msg = (error?.message as string) ?? "unknown error";
+              logger.warn("[OpenAI Responses] chatCompleteResponses stream failed: %s", msg);
+              break;
+            }
+            case "response.incomplete": {
+              const resp = parsed.response as Record<string, unknown> | undefined;
+              const reason = (resp?.incomplete_details as Record<string, unknown>)?.reason ?? "unknown";
+              logger.warn("[OpenAI Responses] chatCompleteResponses stream incomplete (reason=%s)", reason);
+              finishReason = "length";
               break;
             }
           }
@@ -1685,7 +1755,11 @@ export class OpenAIProvider extends BaseLLMProvider {
 
     // Otherwise walk the output items
     const output = json.output as Array<Record<string, unknown>> | undefined;
-    if (!output) return "";
+    if (!output) {
+      // Fall back to top-level refusal field
+      if (typeof json.refusal === "string" && json.refusal) return json.refusal;
+      return "";
+    }
 
     let text = "";
     for (const item of output) {
@@ -1695,10 +1769,16 @@ export class OpenAIProvider extends BaseLLMProvider {
           for (const part of content) {
             if (part.type === "output_text" && typeof part.text === "string") {
               text += part.text;
+            } else if (part.type === "refusal" && typeof part.refusal === "string") {
+              text += part.refusal;
             }
           }
         }
       }
+    }
+    // Fall back to top-level refusal if no text was found in output items
+    if (!text && typeof json.refusal === "string" && json.refusal) {
+      text = json.refusal;
     }
     return text;
   }


### PR DESCRIPTION
## Linked Issue

Closes #644

## Why this change

A user reported GPT-5.5 consistently returning empty responses. Investigation revealed multiple code paths where model responses could silently become empty — particularly when models refuse requests or when the Responses API returns non-standard completion states. While the specific GPT-5.5 case was routed through the Responses API (which already handled `response.refusal.delta`), the Chat Completions paths had no refusal handling at all, and neither API path handled failure/incomplete states.

## What changed

- **Fixes refusal-only responses producing empty output.** When OpenAI models refuse a request via the Chat Completions API, the refusal text is sent in `delta.refusal` (not `delta.content`). The stream parser only checked `delta.content`, so refusal-only responses silently became 0-char empty responses shown to users as "The AI returned an empty response."
- **Adds `response.failed` and `response.incomplete` event handling to Responses API streams.** Previously these events were silently swallowed — if the API returned a failed or incomplete response, the user got an empty response with no diagnostic information in server logs.
- **Extracts refusal content from non-streaming Responses API responses.** The `extractResponsesText()` method now checks refusal content parts and the top-level `refusal` field as fallbacks when no regular text output is found.

### Affected code paths (all in `openai.provider.ts`)

| Path | Issue | Fix |
|------|-------|-----|
| `chat()` streaming (Chat Completions) | `delta.refusal` ignored | Yield `delta.refusal` as text |
| `chatComplete()` streaming (Chat Completions) | `delta.refusal` ignored | Accumulate `delta.refusal` into content |
| `chatComplete()` non-streaming (Chat Completions) | `message.refusal` ignored | Fall back to `message.refusal` when `content` is null |
| `extractResponsesText()` (Responses API) | Refusal content parts and top-level `refusal` ignored | Extract both as fallbacks |
| `chatResponses()` streaming (Responses API) | `response.failed`/`response.incomplete` silently swallowed; no fallback text extraction from `response.completed` | Log warnings; extract text from completed response when nothing was streamed |
| `chatCompleteResponses()` streaming (Responses API) | Missing `response.refusal.delta` handler; no `response.failed`/`response.incomplete` handling; no fallback extraction | Add all three |

## Validation

- [x] Manually verify with an OpenAI model (e.g., GPT-4o) that triggers a refusal — the refusal text should now appear as the response instead of "empty response"
- [x] Manually verify with GPT-5.5 that normal responses still stream correctly
- [x] Manually verify that non-OpenAI providers (Anthropic, Google) are unaffected
- [x] Check server logs for `[OpenAI Responses]` warning messages when a response fails or is incomplete

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## Summary by CodeRabbit

## Bug Fixes
* Improved handling of model refusals, now properly displayed as text to users.
* Enhanced fallback text extraction when API responses contain incomplete or missing output data.
* Strengthened error handling and logging for failed or incomplete streaming response scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/643)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of AI model refusals to display them as user-visible text.
  * Enhanced fallback text extraction when API responses don't include expected output.
  * Better error state handling for streaming API responses.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/643)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->