### PR TITLE
Fix GPT-5.5 empty responses on custom providers

### DIFF
--- a/packages/server/src/services/llm/providers/openai.provider.ts
+++ b/packages/server/src/services/llm/providers/openai.provider.ts
@@ -509,8 +509,12 @@ export class OpenAIProvider extends BaseLLMProvider {
   /** Check if a model requires or benefits from the Responses API instead of Chat Completions */
   private useResponsesAPI(model: string, options?: Pick<ChatOptions, "captureReasoning">): boolean {
     if (this.providerKind === "openai-chatgpt") return true;
-    if (this.isGpt55Model(model)) return true;
+    // Custom providers generally only implement /chat/completions — never force
+    // /responses for them, even for GPT-5.5. Reasoning-model parameter tweaks
+    // (max_completion_tokens, temperature suppression) still apply via
+    // isReasoningModel / isNoTemperatureModel which have their own GPT-5.5 gates.
     if (this.isGenericCustomProvider()) return false;
+    if (this.isGpt55Model(model)) return true;
     const m = model.toLowerCase();
     return (
       this.isXAIMultiAgentModel(model) ||


### PR DESCRIPTION
## Linked issue

Closes #644

## Why this change

PR #643 fixed silent empty responses for GPT-5.4 but **not GPT-5.5**. Users report that GPT-5.5 still returns blank responses on both custom (reverse-proxy) providers and the official OpenAI provider. The root causes are:

1. **Routing**: Custom providers were forced into the Responses API for GPT-5.5, but most reverse proxies only implement `/chat/completions`.
2. **Content format**: GPT-5.5 may return content parts with `type: "text"` instead of `"output_text"`, and streaming deltas as `response.text.delta` instead of `response.output_text.delta` — both silently ignored by the existing extraction logic.
3. **Silent failures**: The Responses API can return `status: "failed"` with HTTP 200, which was never checked.

## What changed

### Routing fix (`useResponsesAPI`)
- Reordered checks so `isGenericCustomProvider()` runs **before** `isGpt55Model()` — custom providers always use Chat Completions now, even for GPT-5.5.

### Non-streaming status validation (`chatResponses`, `chatCompleteResponses`)
- Added `status === "failed"` check that throws with the error message from the response.
- Added `status === "incomplete"` warning with the reason.

### Resilient content extraction (`extractResponsesText`)
- Accept `part.type === "text"` in addition to `"output_text"`.
- Fall back to string `item.content` when structured content array is absent.

### Streaming event coverage (`chatResponses`, `chatCompleteResponses`)
- Added `response.text.delta` as an alternative to `response.output_text.delta`.

### Diagnostic logging
- When non-streaming text extraction returns empty, log the response status, `output_text` type, and output item types.
- When streaming produces no text and the fallback also returns empty, log the same diagnostics.

## Validation

- [ ] `pnpm check` passes
- [ ] Manually test GPT-5.5 on a **custom provider** (reverse proxy) — should route to Chat Completions and return text
- [ ] Manually test GPT-5.5 on the **official OpenAI provider** — should return text via Responses API
- [ ] Manually test GPT-5.4 on the official OpenAI provider — should still work (no regression)
- [ ] Manually test "Send Test Message" in API Connections for GPT-5.5 — should show non-blank response
- [ ] If GPT-5.5 still returns empty, check server logs for `[OpenAI Responses]` warnings — they now show what the API actually returned

### Manual verification notes

- The diagnostic `[OpenAI Responses]` log lines are **critical** if the fix still doesn't resolve the issue — they reveal the exact structure GPT-5.5 returns (status, output_text type, output item types) so the extraction can be further tuned.
- The "Send Test Message" path uses non-streaming `provider.chat()` which exercises the `chatResponses` non-streaming path with the new status checks.
- The main chat path uses streaming which exercises the `chatResponses` streaming path with the new `response.text.delta` event.

## Docs and release impact

No docs or release metadata changes needed. This is a bug fix for existing OpenAI provider behavior.
