### PR TITLE
Fix double-encoded Game Mode setup JSON

### DIFF
--- a/packages/server/src/services/game/jsonish.ts
+++ b/packages/server/src/services/game/jsonish.ts
@@ -131,25 +131,40 @@ function repairJsonish(raw: string): string {
   );
 }
 
+function unwrapJsonString(value: unknown): unknown {
+  let next = value;
+  for (let depth = 0; depth < 2 && typeof next === "string"; depth++) {
+    const nested = stripFences(next.trim());
+    if (!nested.startsWith("{") && !nested.startsWith("[")) break;
+
+    try {
+      next = JSON.parse(nested);
+    } catch {
+      break;
+    }
+  }
+  return next;
+}
+
 export function parseGameJsonish(raw: string): unknown {
   const trimmed = raw.trim();
   try {
-    return JSON.parse(trimmed);
+    return unwrapJsonString(JSON.parse(trimmed));
   } catch {
     // Continue through the increasingly tolerant parse path below.
   }
 
   const unfenced = stripFences(trimmed);
   try {
-    return JSON.parse(unfenced.trim());
+    return unwrapJsonString(JSON.parse(unfenced.trim()));
   } catch {
     // Continue.
   }
 
   const candidate = extractObjectCandidate(unfenced);
   try {
-    return JSON.parse(repairJsonish(candidate));
+    return unwrapJsonString(JSON.parse(repairJsonish(candidate)));
   } catch {
-    return JSON.parse(candidate);
+    return unwrapJsonString(JSON.parse(candidate));
   }
 }

--- a/packages/server/test/game-readable-edits.test.ts
+++ b/packages/server/test/game-readable-edits.test.ts
@@ -1,5 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { parseGameJsonish } from "../src/services/game/jsonish.js";
 import { createJournal, addNoteEntry } from "../src/services/game/journal.service.js";
 import { applySegmentEdits } from "../src/services/game/segment-edits.js";
 
@@ -39,4 +40,31 @@ test("applySegmentEdits rebuilds readable tags with edited content", () => {
 
   assert.match(edited, /\[Note: The new passphrase is hidden under the bronze lamp\.\]/);
   assert.doesNotMatch(edited, /old passphrase/);
+});
+
+test("parseGameJsonish unwraps JSON objects returned as escaped strings", () => {
+  const setupPayload = {
+    worldOverview: "A small town waits under festival lights.",
+    storyArc: "The opening mystery starts at the amusement pier.",
+    plotTwists: ["The mascot knows where the missing tickets went."],
+    startingNpcs: [{ name: "Laila", description: "Runs the prize stall.", location: "pier", reputation: 0 }],
+    blueprint: {
+      hudWidgets: [
+        {
+          id: "laila_amusement",
+          type: "gauge",
+          label: "Laila's Amusement",
+          position: "hud_left",
+          accent: "#ff7da0",
+          config: { value: 20, max: 100, dangerBelow: 10 },
+        },
+      ],
+      introSequence: [{ effect: "fade_from_black", duration: 3 }],
+      visualTheme: { palette: "pastel", uiStyle: "glassy", moodDefault: "cheerful" },
+    },
+  };
+
+  const parsed = parseGameJsonish(JSON.stringify(JSON.stringify(setupPayload)));
+
+  assert.deepEqual(parsed, setupPayload);
 });


### PR DESCRIPTION
﻿## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #655

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- Game Mode setup can receive valid world JSON from a provider as an escaped JSON string. In that shape, Marinara parsed the outer string successfully but never unwrapped the inner setup object, so validation treated the setup as missing required fields and the generated blueprint/widgets were not applied.

## What changed

<!-- List the key changes in this PR -->

- Unwrap JSON strings inside the tolerant Game Mode JSON parser before returning parsed setup data.
- Added a regression test that covers a provider returning a complete Game Mode setup object as an escaped string, including `blueprint.hudWidgets`.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Codex proof: `pnpm --filter @marinara-engine/server exec tsx --import ./test/setup-env.ts --test test/game-readable-edits.test.ts` passed.
- Codex proof: `node scratch/issue-655-repro.mjs` unwrapped a screenshot-shaped double-encoded Game Mode setup payload and preserved HUD widgets `laila_amusement` and `mansion_gossip`.
- Codex proof: `pnpm check` passed after fast-forwarding this branch to current `upstream/main`.
- Manual browser/provider verification not run: this fix is in provider response parsing, and the core claim is covered by the parser regression plus screenshot-shaped setup payload repro.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs or release metadata changes needed; this is a narrow parser bugfix.

## UI evidence (if applicable)

N/A — parser/logic bug; no UI rendering changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced JSON parsing to handle double-encoded and nested stringified JSON responses, including code fence-wrapped content. Improves robustness when processing complex or unconventional JSON formats.

* **Tests**
  * Added test coverage validating JSON unwrapping functionality across multiple encoding layers.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/656)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->