### PR TITLE
Document random expression sprite groups

### DIFF
--- a/packages/client/src/components/characters/CharacterEditor.tsx
+++ b/packages/client/src/components/characters/CharacterEditor.tsx
@@ -2644,6 +2644,10 @@ function SpritesTab({
             bulk-import a folder of PNGs (each filename = expression name, e.g. admiration.png → "admiration")
           </li>
           <li>
+            • To make one expression randomly rotate between variants, use a shared prefix before an underscore, e.g.
+            happy_01.png and happy_blush.png are offered to the agent as "happy"
+          </li>
+          <li>
             • Enable the <strong className="text-[var(--foreground)]">Expression Engine</strong> agent in the Agents
             panel
           </li>


### PR DESCRIPTION
## Linked issue

Closes #471

## Why this change

- Users asked how the random expression sprite group behavior works, but the in-app sprite help text did not explain the filename convention.

## What changed

- Added a short note to the character sprite "How sprites work" block explaining that filenames like `happy_01.png` and `happy_blush.png` are grouped under `happy`.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Codex ran `pnpm check` successfully in a clean worktree at `C:\tmp\Marinara-Engine-sprite-help-doc`.
- Manual browser verification was not run; this is a copy-only update to existing help text.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

This PR updates in-app documentation/help copy only. No README, changelog, version, or release files were changed.

## UI evidence (if applicable)

N/A - copy-only update to an existing help block.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced sprite configuration guidance in the character editor to include instructions on creating expression variants that randomly rotate between different sprite states using a shared naming prefix pattern.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/657)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->