### PR TITLE
fix(avatar-crop): defensively skip non-legacy crops in editor and renderer

### DIFF
--- a/packages/client/src/components/characters/CharacterEditor.tsx
+++ b/packages/client/src/components/characters/CharacterEditor.tsx
@@ -1009,11 +1009,23 @@ function MetadataTab({
   removeTag: (tag: string) => void;
   avatarPreview: string | null;
 }) {
-  const crop = (formData.extensions.avatarCrop as { zoom: number; offsetX: number; offsetY: number } | undefined) ?? {
-    zoom: 1,
-    offsetX: 0,
-    offsetY: 0,
-  };
+  // Defensive read: a previously saved `avatarCrop` may be either the legacy
+  // zoom/offset shape this editor produces, or a future/foreign shape (e.g.
+  // {srcX, srcY, srcWidth, srcHeight}) written by a different version of the
+  // editor that was later rolled back. Anything that doesn't look like the
+  // legacy shape gets treated as "no crop" so the slider starts fresh and the
+  // editor doesn't crash on undefined `.zoom`.
+  const rawCrop = formData.extensions.avatarCrop as
+    | { zoom?: unknown; offsetX?: unknown; offsetY?: unknown }
+    | undefined
+    | null;
+  const crop =
+    rawCrop &&
+    typeof rawCrop.zoom === "number" &&
+    typeof rawCrop.offsetX === "number" &&
+    typeof rawCrop.offsetY === "number"
+      ? { zoom: rawCrop.zoom, offsetX: rawCrop.offsetX, offsetY: rawCrop.offsetY }
+      : { zoom: 1, offsetX: 0, offsetY: 0 };
 
   const setCrop = (next: { zoom: number; offsetX: number; offsetY: number }) => {
     updateExtension("avatarCrop", next);

--- a/packages/client/src/lib/utils.ts
+++ b/packages/client/src/lib/utils.ts
@@ -49,9 +49,12 @@ export interface AvatarCrop {
 }
 
 /** Returns inline styles for a cropped/zoomed avatar image.
- *  The parent container must have `overflow: hidden`. */
+ *  The parent container must have `overflow: hidden`. Defensively treats any
+ *  non-legacy-shaped crop as "no crop" so foreign data (e.g. {srcX, srcY,
+ *  srcWidth, srcHeight} written by a later editor that was rolled back) renders
+ *  uncropped instead of producing invalid CSS. */
 export function getAvatarCropStyle(crop?: AvatarCrop | null): CSSProperties {
-  if (!crop || crop.zoom <= 1) return {};
+  if (!crop || typeof crop.zoom !== "number" || crop.zoom <= 1) return {};
   return {
     transform: `scale(${crop.zoom}) translate(${crop.offsetX}%, ${crop.offsetY}%)`,
   };


### PR DESCRIPTION
## Linked issue

Closes #667

## Why this change

After PR #666 reverted PR #661, any character whose `extensions.avatarCrop` was saved with the new \`{srcX, srcY, srcWidth, srcHeight}\` cropper (during the brief PR #661 window) now crashes the CharacterEditor on open:

> `TypeError: can't access property \"toFixed\", v.zoom is undefined`

The reverted editor and renderer both assume the legacy zoom/offset shape and read `.zoom` directly. With foreign data present, the editor renders a blank screen and the avatar transform produces invalid CSS.

The repro is narrow (only users who beta-tested PR #661 and pulled the revert), but it's a hard crash that locks them out of the editor entirely.

## What changed

- `packages/client/src/components/characters/CharacterEditor.tsx` — replaces the unchecked cast on `formData.extensions.avatarCrop` with a runtime shape check. Only treats the saved value as a legacy crop when all three of `zoom`, `offsetX`, `offsetY` are numbers; anything else falls back to `{ zoom: 1, offsetX: 0, offsetY: 0 }` so the slider starts fresh and the editor opens.
- `packages/client/src/lib/utils.ts` — `getAvatarCropStyle` now guards on `typeof crop.zoom === \"number\"` before returning a transform. Foreign shapes render uncropped instead of producing `scale(undefined) translate(undefined%, undefined%)`.

No data is rewritten. The user can re-edit the crop (which saves in the legacy shape, overwriting the foreign value) or just leave it — both editor and renderer are now tolerant.

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Manually verify opening a character with a legacy-shape \`avatarCrop\` (just zoom + offsets) still renders unchanged in the editor — slider position matches the saved zoom, drag-to-pan works.
- Manually verify opening a character with a foreign-shape \`avatarCrop\` (e.g. saved during PR #661 testing) no longer crashes. Editor opens, slider at 1.0×, preview shows the avatar uncropped. Re-saving the form should overwrite the foreign value with the legacy shape.
- Manually verify opening a character with no \`avatarCrop\` extension at all renders identically to before.
- Manually verify renderer surfaces (sidebar, chat header, message bubbles) still show legacy-cropped avatars correctly, and show foreign-shape crops uncropped instead of producing CSS warnings.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

Defensive change; behavior matches the pre-#661 baseline except that foreign-shape data is now tolerated instead of crashing. No new screenshots vs the legacy editor flow.