### PR TITLE
Fix OpenAI ChatGPT request shape

### DIFF
--- a/packages/server/src/services/llm/providers/openai.provider.ts
+++ b/packages/server/src/services/llm/providers/openai.provider.ts
@@ -342,6 +342,10 @@ export class OpenAIProvider extends BaseLLMProvider {
     return this.providerKind === "custom";
   }
 
+  private isOpenAIChatGPTProvider(): boolean {
+    return this.providerKind === "openai-chatgpt";
+  }
+
   private isGpt55Model(model: string): boolean {
     return model.toLowerCase().startsWith("gpt-5.5");
   }
@@ -508,7 +512,7 @@ export class OpenAIProvider extends BaseLLMProvider {
 
   /** Check if a model requires or benefits from the Responses API instead of Chat Completions */
   private useResponsesAPI(model: string, options?: Pick<ChatOptions, "captureReasoning">): boolean {
-    if (this.providerKind === "openai-chatgpt") return true;
+    if (this.isOpenAIChatGPTProvider()) return true;
     // Custom providers generally only implement /chat/completions — never force
     // /responses for them, even for GPT-5.5. Reasoning-model parameter tweaks
     // (max_completion_tokens, temperature suppression) still apply via
@@ -540,6 +544,7 @@ export class OpenAIProvider extends BaseLLMProvider {
   }
 
   private supportsGpt5Verbosity(model: string): boolean {
+    if (this.isOpenAIChatGPTProvider()) return false;
     return (!this.isGenericCustomProvider() || this.isGpt55Model(model)) && model.toLowerCase().startsWith("gpt-5");
   }
 
@@ -1236,10 +1241,11 @@ export class OpenAIProvider extends BaseLLMProvider {
   /** Build the Responses API request body */
   private buildResponsesBody(messages: ChatMessage[], options: ChatOptions): Record<string, unknown> {
     const { instructions, input } = this.formatResponsesInput(messages);
+    const isOpenAIChatGPT = this.isOpenAIChatGPTProvider();
 
     // Replay encrypted reasoning items from the previous turn so the model
     // retains its reasoning context and avoids re-deriving (and re-narrating) the same conclusions.
-    if (options.encryptedReasoningItems?.length) {
+    if (!isOpenAIChatGPT && options.encryptedReasoningItems?.length) {
       let lastAssistantIdx = -1;
       for (let i = input.length - 1; i >= 0; i--) {
         if ((input[i] as Record<string, unknown>).role === "assistant") {
@@ -1255,22 +1261,25 @@ export class OpenAIProvider extends BaseLLMProvider {
     const body: Record<string, unknown> = {
       model: options.model,
       input,
-      stream: options.stream ?? true,
+      stream: isOpenAIChatGPT ? true : (options.stream ?? true),
       store: false, // don't persist responses on OpenAI side
-      // Request encrypted reasoning items so we can replay them on the next turn
-      include: ["reasoning.encrypted_content"],
     };
 
-    if (instructions) {
-      body.instructions = instructions;
+    if (!isOpenAIChatGPT) {
+      // Request encrypted reasoning items so we can replay them on the next turn.
+      body.include = ["reasoning.encrypted_content"];
     }
 
-    if (options.maxTokens && !this.isXAIMultiAgentModel(options.model)) {
+    if (instructions || isOpenAIChatGPT) {
+      body.instructions = instructions || "You are a helpful assistant.";
+    }
+
+    if (!isOpenAIChatGPT && options.maxTokens && !this.isXAIMultiAgentModel(options.model)) {
       body.max_output_tokens = options.maxTokens;
     }
 
     // o-series models never support temperature/topP; GPT-5.x only with effort=none
-    if (!this.isNoTemperatureModel(options.model, options.reasoningEffort)) {
+    if (!isOpenAIChatGPT && !this.isNoTemperatureModel(options.model, options.reasoningEffort)) {
       if (options.temperature != null) body.temperature = options.temperature;
       const topP = OpenAIProvider.normalizeTopP(options.topP);
       if (topP != null) body.top_p = topP;
@@ -1280,21 +1289,27 @@ export class OpenAIProvider extends BaseLLMProvider {
       }
     }
 
-    this.applyResponsesReasoning(body, options);
+    if (!isOpenAIChatGPT) {
+      this.applyResponsesReasoning(body, options);
+    }
 
     // GPT-5+ verbosity and Responses structured output / JSON mode.
-    this.applyResponsesTextOptions(body, options);
+    if (!isOpenAIChatGPT) {
+      this.applyResponsesTextOptions(body, options);
+    }
 
     const openrouterProvider = this.resolveOpenrouterProvider(options.openrouterProvider);
     if (this.shouldApplyOpenRouterProviderOverride(openrouterProvider)) {
       body.provider = { order: [openrouterProvider] };
     }
 
-    if (options.tools?.length && !this.isXAIMultiAgentModel(options.model)) {
+    if (!isOpenAIChatGPT && options.tools?.length && !this.isXAIMultiAgentModel(options.model)) {
       body.tools = this.formatResponsesTools(options.tools);
     }
 
-    this.applyCustomParameters(body, options);
+    if (!isOpenAIChatGPT) {
+      this.applyCustomParameters(body, options);
+    }
 
     return body;
   }
@@ -1355,7 +1370,9 @@ export class OpenAIProvider extends BaseLLMProvider {
       }
     }
 
-    if (!options.stream) {
+    const parseAsStream = this.isOpenAIChatGPTProvider() || (options.stream ?? true);
+
+    if (!parseAsStream) {
       // Non-streaming: parse the full response
       const json = await OpenAIProvider.parseJsonBody<Record<string, unknown>>(
         response,

--- a/packages/server/test/openai-provider-reasoning.test.ts
+++ b/packages/server/test/openai-provider-reasoning.test.ts
@@ -614,6 +614,37 @@ test("responses requests include fallback input for system-only prompts", () => 
   assert.deepEqual(body.input, [{ role: "user", content: "Continue." }]);
 });
 
+test("OpenAI ChatGPT responses requests omit unsupported Codex parameters", () => {
+  const provider = new OpenAIProvider(
+    "https://chatgpt.com/backend-api/codex",
+    "test-key",
+    undefined,
+    null,
+    null,
+    "openai-chatgpt",
+  ) as any;
+  const body = provider.buildResponsesBody([{ role: "user", content: "Hello" }], {
+    model: "gpt-5.2",
+    stream: false,
+    maxTokens: 128,
+    temperature: 0.7,
+    topP: 0.9,
+    reasoningEffort: "high",
+    enableThinking: true,
+    verbosity: "medium",
+  } satisfies ChatOptions) as Record<string, unknown>;
+
+  assert.equal(body.stream, true);
+  assert.equal(body.instructions, "You are a helpful assistant.");
+  assert.equal("max_output_tokens" in body, false);
+  assert.equal(body.store, false);
+  assert.equal("include" in body, false);
+  assert.equal("temperature" in body, false);
+  assert.equal("top_p" in body, false);
+  assert.equal("reasoning" in body, false);
+  assert.equal("text" in body, false);
+});
+
 test("responses requests translate responseFormat to text.format", () => {
   const provider = new OpenAIProvider("https://example.com/v1", "test-key") as any;
   const body = provider.buildResponsesBody([{ role: "user", content: "Return JSON." }], {


### PR DESCRIPTION
## Linked issue

No linked issue yet; this came from a local provider bug report and one should be opened before submission if the team wants issue tracking.

## Why this change

- The OpenAI (ChatGPT) provider was sending the normal OpenAI Responses API request shape to the ChatGPT Codex endpoint.
- That endpoint rejected chat/test requests with 400 errors such as `{"detail":"Instructions are required"}` and `{"detail":"Unsupported parameter: max_output_tokens"}`.

## What changed

- Special-cased the `openai-chatgpt` provider so Responses requests always send the Codex-compatible shape: `stream: true`, `store: false`, `instructions`, `model`, and `input`.
- Omitted unsupported OpenAI API fields for this provider, including `max_output_tokens`, `include`, sampling parameters, reasoning options, text options, tools, and custom parameters.
- Parsed OpenAI (ChatGPT) responses as streamed SSE even when the caller requested non-streaming output, matching the endpoint requirement.
- Added regression coverage for the OpenAI (ChatGPT) request body.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Codex live provider verification passed using the local Codex ChatGPT auth session: the OpenAI (ChatGPT) provider returned `{"ok":true,"text":"ok"}`.
- Focused regression passed: `pnpm exec tsx --import ./test/setup-env.ts --test --test-name-pattern "OpenAI ChatGPT responses requests omit unsupported Codex parameters" test/openai-provider-reasoning.test.ts`.
- Baseline validation passed: `pnpm check`.
- Diff hygiene passed: `git diff --check`.
- Server logging hygiene passed: `rg -n "console\\." packages/server/src/services/llm/providers/openai.provider.ts` found no console statements.
- No UI/manual browser verification is applicable; this is a backend provider request-shape fix.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs, schema, dependency, version, or release metadata changes.

## UI evidence (if applicable)

N/A - backend provider request-shape fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized OpenAI ChatGPT provider request handling and improved streaming behavior management.

* **Tests**
  * Added comprehensive test coverage for OpenAI ChatGPT provider request construction.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/670)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->