### PR TITLE
feat(avatar-crop): re-apply PR #661 with chat-side propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 ### Added
 
 - Added optional image generation for the Background agent so Roleplay can create and reuse missing scene backgrounds from an agent-selected image connection.
+- Reworked the avatar crop tool into a square-region selector with corner handles + interior pan, so users can pick the exact part of the source image that becomes the circle avatar. Replaces the prior zoom + pan slider on Character avatars and adds the same widget to Personas (previously had no crop UI). The original avatar file is never overwritten — the Roleplay glued side panel still shows the full portrait.
 
 ### Fixed
 

--- a/packages/client/src/components/characters/CharacterEditor.tsx
+++ b/packages/client/src/components/characters/CharacterEditor.tsx
@@ -38,6 +38,7 @@ import { useConnections } from "../../hooks/use-connections";
 import { showConfirmDialog } from "../../lib/app-dialogs";
 import { SpriteGenerationModal } from "../ui/SpriteGenerationModal";
 import { AvatarGenerationModal } from "../ui/AvatarGenerationModal";
+import { AvatarCropWidget } from "../ui/AvatarCropWidget";
 import {
   ArrowLeft,
   Save,
@@ -75,7 +76,7 @@ import {
   History,
   RotateCcw,
 } from "lucide-react";
-import { cn, generateClientId, getAvatarCropStyle } from "../../lib/utils";
+import { cn, generateClientId, getAvatarCropStyle, type AvatarCrop, type LegacyAvatarCrop } from "../../lib/utils";
 import { extractColorsFromImage } from "../../lib/avatar-color-extraction";
 import { HelpTooltip } from "../ui/HelpTooltip";
 import { api } from "../../lib/api-client";
@@ -229,6 +230,10 @@ export function CharacterEditor() {
     reader.onload = async () => {
       const dataUrl = reader.result as string;
       setAvatarPreview(dataUrl);
+      // Clear any saved avatarCrop — the new image almost certainly has different
+      // framing, so the prior normalized crop coords are meaningless and would
+      // produce a stale framing on the new file.
+      updateExtension("avatarCrop", undefined);
       try {
         await uploadAvatar.mutateAsync({ id: characterId, avatar: dataUrl });
       } catch {
@@ -242,10 +247,11 @@ export function CharacterEditor() {
     async (avatarDataUrl: string) => {
       if (!characterId) return;
       setAvatarPreview(avatarDataUrl);
+      updateExtension("avatarCrop", undefined);
       await uploadAvatar.mutateAsync({ id: characterId, avatar: avatarDataUrl });
       toast.success("Character avatar generated.");
     },
-    [characterId, uploadAvatar],
+    [characterId, updateExtension, uploadAvatar],
   );
 
   const handleDelete = async () => {
@@ -539,9 +545,7 @@ export function CharacterEditor() {
                 src={avatarPreview}
                 alt={formData.name}
                 className="h-full w-full object-cover"
-                style={getAvatarCropStyle(
-                  formData.extensions.avatarCrop as { zoom: number; offsetX: number; offsetY: number } | undefined,
-                )}
+                style={getAvatarCropStyle(formData.extensions.avatarCrop as AvatarCrop | LegacyAvatarCrop | undefined)}
               />
             ) : (
               <User size="1.375rem" className="text-white" />
@@ -1009,148 +1013,22 @@ function MetadataTab({
   removeTag: (tag: string) => void;
   avatarPreview: string | null;
 }) {
-  // Defensive read: a previously saved `avatarCrop` may be either the legacy
-  // zoom/offset shape this editor produces, or a future/foreign shape (e.g.
-  // {srcX, srcY, srcWidth, srcHeight}) written by a different version of the
-  // editor that was later rolled back. Anything that doesn't look like the
-  // legacy shape gets treated as "no crop" so the slider starts fresh and the
-  // editor doesn't crash on undefined `.zoom`.
-  const rawCrop = formData.extensions.avatarCrop as
-    | { zoom?: unknown; offsetX?: unknown; offsetY?: unknown }
-    | undefined
-    | null;
-  const crop =
-    rawCrop &&
-    typeof rawCrop.zoom === "number" &&
-    typeof rawCrop.offsetX === "number" &&
-    typeof rawCrop.offsetY === "number"
-      ? { zoom: rawCrop.zoom, offsetX: rawCrop.offsetX, offsetY: rawCrop.offsetY }
-      : { zoom: 1, offsetX: 0, offsetY: 0 };
-
-  const setCrop = (next: { zoom: number; offsetX: number; offsetY: number }) => {
-    updateExtension("avatarCrop", next);
-  };
-
-  // Drag-to-reposition state
-  const dragRef = useRef<{ startX: number; startY: number; startOX: number; startOY: number } | null>(null);
-  const didDragRef = useRef(false);
-  const previewRef = useRef<HTMLDivElement>(null);
-  const [showFullImage, setShowFullImage] = useState(false);
-
-  const onPointerDown = (e: React.PointerEvent) => {
-    if (crop.zoom <= 1) return;
-    e.preventDefault();
-    (e.target as HTMLElement).setPointerCapture(e.pointerId);
-    dragRef.current = { startX: e.clientX, startY: e.clientY, startOX: crop.offsetX, startOY: crop.offsetY };
-    didDragRef.current = false;
-  };
-
-  const onPointerMove = (e: React.PointerEvent) => {
-    if (!dragRef.current || !previewRef.current) return;
-    didDragRef.current = true;
-    const rect = previewRef.current.getBoundingClientRect();
-    const dx = ((e.clientX - dragRef.current.startX) / rect.width) * 100;
-    const dy = ((e.clientY - dragRef.current.startY) / rect.height) * 100;
-    const maxOffset = ((crop.zoom - 1) / crop.zoom) * 50;
-    const ox = Math.max(-maxOffset, Math.min(maxOffset, dragRef.current.startOX + dx / crop.zoom));
-    const oy = Math.max(-maxOffset, Math.min(maxOffset, dragRef.current.startOY + dy / crop.zoom));
-    setCrop({ ...crop, offsetX: Math.round(ox * 100) / 100, offsetY: Math.round(oy * 100) / 100 });
-  };
-
-  const onPointerUp = () => {
-    dragRef.current = null;
-  };
+  // Read existing crop in either current or legacy shape; the widget handles both
+  // and writes back the current shape on first interaction.
+  const savedCrop = (formData.extensions.avatarCrop as AvatarCrop | LegacyAvatarCrop | undefined) ?? null;
 
   return (
     <div className="space-y-5">
       <SectionHeader title="Metadata" subtitle="Basic character info — name, creator, version, tags." />
 
-      {/* Avatar Crop / Zoom */}
+      {/* Avatar Crop */}
       {avatarPreview && (
-        <div className="space-y-3 rounded-xl border border-[var(--border)] bg-[var(--secondary)] p-4">
-          <span className="inline-flex items-center gap-1 text-xs font-medium text-[var(--muted-foreground)]">
-            <Crop size="0.75rem" /> Avatar Zoom & Position
-          </span>
-          <div className="flex items-start gap-4 max-sm:flex-col max-sm:items-center">
-            {/* Preview */}
-            <div
-              ref={previewRef}
-              className="relative h-28 w-28 shrink-0 cursor-grab overflow-hidden rounded-full bg-black/20 ring-2 ring-[var(--border)] active:cursor-grabbing touch-none"
-              onPointerDown={onPointerDown}
-              onPointerMove={onPointerMove}
-              onPointerUp={onPointerUp}
-              onPointerCancel={onPointerUp}
-              onClick={() => {
-                if (crop.zoom <= 1 || !didDragRef.current) setShowFullImage(true);
-              }}
-              title="Click to view full image"
-            >
-              <img
-                src={avatarPreview}
-                alt={formData.name}
-                className="h-full w-full object-cover"
-                draggable={false}
-                style={{
-                  transform:
-                    crop.zoom > 1 ? `scale(${crop.zoom}) translate(${crop.offsetX}%, ${crop.offsetY}%)` : undefined,
-                }}
-              />
-            </div>
-            {/* Controls */}
-            <div className="flex flex-1 flex-col gap-2">
-              <label className="space-y-1">
-                <span className="text-[0.625rem] text-[var(--muted-foreground)]">Zoom: {crop.zoom.toFixed(2)}x</span>
-                <input
-                  type="range"
-                  min={1}
-                  max={3}
-                  step={0.05}
-                  value={crop.zoom}
-                  onChange={(e) => {
-                    const z = parseFloat(e.target.value);
-                    const maxOffset = ((z - 1) / z) * 50;
-                    setCrop({
-                      zoom: z,
-                      offsetX: Math.max(-maxOffset, Math.min(maxOffset, crop.offsetX)),
-                      offsetY: Math.max(-maxOffset, Math.min(maxOffset, crop.offsetY)),
-                    });
-                  }}
-                  className="w-full accent-[var(--primary)]"
-                />
-              </label>
-              <p className="text-[0.625rem] text-[var(--muted-foreground)]">
-                {crop.zoom > 1 ? "Drag the preview to reposition" : "Click preview to view full image"}
-              </p>
-              {crop.zoom > 1 && (
-                <button
-                  type="button"
-                  onClick={() => setCrop({ zoom: 1, offsetX: 0, offsetY: 0 })}
-                  className="self-start rounded-lg bg-[var(--accent)] px-2.5 py-1 text-[0.625rem] font-medium text-[var(--muted-foreground)] transition-all hover:text-[var(--foreground)]"
-                >
-                  Reset
-                </button>
-              )}
-            </div>
-          </div>
-          {showFullImage && (
-            <div
-              className="fixed inset-0 z-[100] flex items-center justify-center bg-black/80"
-              onClick={() => setShowFullImage(false)}
-            >
-              <img
-                src={avatarPreview}
-                alt={formData.name}
-                className="max-h-[85vh] max-w-[90vw] rounded-lg object-contain shadow-2xl"
-              />
-              <button
-                onClick={() => setShowFullImage(false)}
-                className="absolute right-3 top-3 rounded-lg bg-black/60 p-2 text-white transition-colors hover:bg-black/80"
-              >
-                <X size="1rem" />
-              </button>
-            </div>
-          )}
-        </div>
+        <AvatarCropWidget
+          src={avatarPreview}
+          alt={formData.name}
+          crop={savedCrop}
+          onChange={(next) => updateExtension("avatarCrop", next)}
+        />
       )}
 
       <div className="grid gap-4 sm:grid-cols-2">

--- a/packages/client/src/components/characters/CharacterLibraryView.tsx
+++ b/packages/client/src/components/characters/CharacterLibraryView.tsx
@@ -14,7 +14,7 @@ import {
 import { useCharacters } from "../../hooks/use-characters";
 import { useStartChatFromCharacter } from "../../hooks/use-start-chat-from-character";
 import { getCharacterTitle } from "../../lib/character-display";
-import { cn, getAvatarCropStyle } from "../../lib/utils";
+import { cn, getAvatarCropStyle, type AvatarCropValue } from "../../lib/utils";
 import { useUIStore } from "../../stores/ui.store";
 import type { CharacterData } from "@marinara-engine/shared";
 
@@ -111,7 +111,7 @@ function CharacterLibraryDetailCard({
               className="h-full w-full object-cover"
               style={getAvatarCropStyle(
                 character.parsed.extensions?.avatarCrop as
-                  | { zoom: number; offsetX: number; offsetY: number }
+                  | AvatarCropValue
                   | undefined,
               )}
             />
@@ -435,7 +435,7 @@ export function CharacterLibraryView() {
                             className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.03]"
                             style={getAvatarCropStyle(
                               char.parsed.extensions?.avatarCrop as
-                                | { zoom: number; offsetX: number; offsetY: number }
+                                | AvatarCropValue
                                 | undefined,
                             )}
                           />

--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -44,7 +44,7 @@ import { BookOpen, Check, HelpCircle, MessageSquare, Theater, X } from "lucide-r
 import type { SpritePlacement, SpriteSide } from "@marinara-engine/shared";
 import { useUIStore } from "../../stores/ui.store";
 import { useAgentStore } from "../../stores/agent.store";
-import { cn } from "../../lib/utils";
+import { cn, parseAvatarCropJson } from "../../lib/utils";
 import { Modal } from "../ui/Modal";
 import { useEncounter } from "../../hooks/use-encounter";
 import { useScene } from "../../hooks/use-scene";
@@ -331,6 +331,7 @@ export function ChatArea() {
       appearance?: string;
       altDescriptions?: string;
       avatarPath?: string | null;
+      avatarCrop?: string;
       nameColor?: string;
       dialogueColor?: string;
       boxColor?: string;
@@ -364,6 +365,7 @@ export function ChatArea() {
       backstory: persona.backstory || undefined,
       appearance: persona.appearance || undefined,
       avatarUrl: persona.avatarPath || undefined,
+      avatarCrop: parseAvatarCropJson(persona.avatarCrop),
       nameColor: persona.nameColor || undefined,
       dialogueColor: persona.dialogueColor || undefined,
       boxColor: persona.boxColor || undefined,

--- a/packages/client/src/components/chat/ChatInput.tsx
+++ b/packages/client/src/components/chat/ChatInput.tsx
@@ -20,7 +20,7 @@ import {
   type SlashCommandContext,
 } from "../../lib/slash-commands";
 import { isPromptPreviewMacro, resolveInputMacrosForChat } from "../../lib/chat-macros";
-import { cn, getAvatarCropStyle } from "../../lib/utils";
+import { cn, getAvatarCropStyle, type AvatarCropValue } from "../../lib/utils";
 import { translateDraftText } from "../../lib/draft-translation";
 import { EmojiPicker } from "../ui/EmojiPicker";
 import { SpeechToTextButton } from "../ui/SpeechToTextButton";
@@ -102,7 +102,7 @@ interface ChatInputProps {
     id: string;
     name: string;
     avatarUrl: string | null;
-    avatarCrop?: { zoom: number; offsetX: number; offsetY: number } | null;
+    avatarCrop?: AvatarCropValue | null;
   }>;
   onExpressionChange?: (
     characterId: string,
@@ -1080,7 +1080,7 @@ export const ChatInput = memo(function ChatInput({
                   className="flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-left transition-all hover:bg-[var(--accent)]"
                 >
                   {char.avatarUrl ? (
-                    <span className="h-7 w-7 shrink-0 overflow-hidden rounded-full">
+                    <span className="relative h-7 w-7 shrink-0 overflow-hidden rounded-full">
                       <img
                         src={char.avatarUrl}
                         alt={char.name}

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -1,7 +1,7 @@
 // ──────────────────────────────────────────────
 // Chat: Message — mode-aware rendering
 // ──────────────────────────────────────────────
-import { cn, copyToClipboard, getAvatarCropStyle } from "../../lib/utils";
+import { cn, copyToClipboard, getAvatarCropStyle, parseAvatarCropJson, type AvatarCropValue } from "../../lib/utils";
 import { applyInlineMarkdown, renderMarkdownBlocks, applyInlineMarkdownHTML } from "../../lib/markdown";
 import {
   User,
@@ -965,7 +965,10 @@ export const ChatMessage = memo(function ChatMessage({
 
   const displayName = isUser ? userName : charName;
   const avatarUrl = isUser ? (msgPersona?.avatarUrl ?? personaInfo?.avatarUrl ?? null) : (charInfo?.avatarUrl ?? null);
-  const avatarCropStyle = isUser ? {} : getAvatarCropStyle(charInfo?.avatarCrop);
+  const personaAvatarCrop = isUser
+    ? (parseAvatarCropJson(msgPersona?.avatarCrop) ?? personaInfo?.avatarCrop ?? null)
+    : null;
+  const avatarCropStyle = isUser ? getAvatarCropStyle(personaAvatarCrop) : getAvatarCropStyle(charInfo?.avatarCrop);
 
   // Resolve colors: character colors for assistant, persona colors for user
   // Prefer per-message persona snapshot colors over current persona
@@ -1008,7 +1011,7 @@ export const ChatMessage = memo(function ChatMessage({
         if (!info?.avatarUrl) return null;
         return { url: info.avatarUrl, crop: info.avatarCrop };
       })
-      .filter(Boolean) as { url: string; crop?: { zoom: number; offsetX: number; offsetY: number } | null }[];
+      .filter(Boolean) as { url: string; crop?: AvatarCropValue | null }[];
   }, [isMergedGroup, characterMap, chatCharacterIds]);
   const mergedNameColors = useMemo(() => {
     if (!isMergedGroup || !characterMap || !chatCharacterIds) return [];
@@ -1382,7 +1385,7 @@ export const ChatMessage = memo(function ChatMessage({
                 <div className={cn(!isUser && "rpg-avatar-glow")}>
                   <button
                     type="button"
-                    className={cn("cursor-pointer overflow-hidden ring-2 ring-white/10", compactAvatarFrameClass)}
+                    className={cn("relative cursor-pointer overflow-hidden ring-2 ring-white/10", compactAvatarFrameClass)}
                     onClick={() => openImageLightbox(avatarUrl)}
                     aria-label={`Open ${displayName} avatar`}
                   >
@@ -1855,7 +1858,7 @@ export const ChatMessage = memo(function ChatMessage({
             ) : avatarUrl ? (
               <button
                 type="button"
-                className="h-8 w-8 cursor-pointer overflow-hidden rounded-full"
+                className="relative h-8 w-8 cursor-pointer overflow-hidden rounded-full"
                 onClick={() => openImageLightbox(avatarUrl)}
                 aria-label={`Open ${displayName} avatar`}
               >

--- a/packages/client/src/components/chat/ChatNotificationBubbles.tsx
+++ b/packages/client/src/components/chat/ChatNotificationBubbles.tsx
@@ -11,7 +11,7 @@ import { X, MessageCircle } from "lucide-react";
 import { useChatStore } from "../../stores/chat.store";
 import { useGameModeStore } from "../../stores/game-mode.store";
 import { useUIStore } from "../../stores/ui.store";
-import { cn, getAvatarCropStyle } from "../../lib/utils";
+import { cn, getAvatarCropStyle, type AvatarCropValue } from "../../lib/utils";
 import { AnimatePresence, motion } from "framer-motion";
 
 export function ChatNotificationBubbles() {
@@ -145,7 +145,7 @@ function NotificationBubble({
     chatId: string;
     characterName: string;
     avatarUrl: string | null;
-    avatarCrop?: { zoom: number; offsetX: number; offsetY: number } | null;
+    avatarCrop?: AvatarCropValue | null;
     count: number;
   };
   onNavigate: () => void;

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -2039,7 +2039,7 @@ export function ChatSettingsDrawer({
                             title="Open character card"
                           >
                             {c.avatarPath ? (
-                              <span className="block h-7 w-7 shrink-0 overflow-hidden rounded-full">
+                              <span className="relative block h-7 w-7 shrink-0 overflow-hidden rounded-full">
                                 <img
                                   src={c.avatarPath}
                                   alt={name}
@@ -2330,7 +2330,7 @@ export function ChatSettingsDrawer({
                             title="Open character card"
                           >
                             {c.avatarPath ? (
-                              <span className="block h-7 w-7 shrink-0 overflow-hidden rounded-full">
+                              <span className="relative block h-7 w-7 shrink-0 overflow-hidden rounded-full">
                                 <img
                                   src={c.avatarPath}
                                   alt={name}
@@ -2408,7 +2408,7 @@ export function ChatSettingsDrawer({
                           className="flex items-center gap-2.5 rounded-lg px-3 py-2 text-left transition-all hover:bg-[var(--accent)]"
                         >
                           {c.avatarPath ? (
-                            <span className="block h-6 w-6 shrink-0 overflow-hidden rounded-full">
+                            <span className="relative block h-6 w-6 shrink-0 overflow-hidden rounded-full">
                               <img
                                 src={c.avatarPath}
                                 alt={name}
@@ -3856,7 +3856,7 @@ export function ChatSettingsDrawer({
                                 title="Open character card"
                               >
                                 {character.avatarPath ? (
-                                  <span className="block h-8 w-8 shrink-0 overflow-hidden rounded-full">
+                                  <span className="relative block h-8 w-8 shrink-0 overflow-hidden rounded-full">
                                     <img
                                       src={character.avatarPath}
                                       alt={name}

--- a/packages/client/src/components/chat/ChatSetupWizard.tsx
+++ b/packages/client/src/components/chat/ChatSetupWizard.tsx
@@ -145,7 +145,7 @@ function CharacterAvatarImage({
   className: string;
 }) {
   return (
-    <span className={cn("block shrink-0 overflow-hidden", className)}>
+    <span className={cn("relative block shrink-0 overflow-hidden", className)}>
       <img
         src={src}
         alt={alt}

--- a/packages/client/src/components/chat/ConversationInput.tsx
+++ b/packages/client/src/components/chat/ConversationInput.tsx
@@ -35,7 +35,7 @@ import {
   type SlashCommandContext,
 } from "../../lib/slash-commands";
 import { isPromptPreviewMacro, resolveInputMacrosForChat } from "../../lib/chat-macros";
-import { cn, getAvatarCropStyle } from "../../lib/utils";
+import { cn, getAvatarCropStyle, type AvatarCropValue } from "../../lib/utils";
 import { translateDraftText } from "../../lib/draft-translation";
 import { QuickConnectionSwitcher } from "./QuickConnectionSwitcher";
 import { QuickPersonaSwitcher } from "./QuickPersonaSwitcher";
@@ -205,7 +205,7 @@ interface ConversationInputProps {
     id: string;
     name: string;
     avatarUrl: string | null;
-    avatarCrop?: { zoom: number; offsetX: number; offsetY: number } | null;
+    avatarCrop?: AvatarCropValue | null;
     conversationStatus?: "online" | "idle" | "dnd" | "offline";
     conversationActivity?: string;
   }>;
@@ -1500,7 +1500,7 @@ export function ConversationInput({
                 >
                   <div className="relative shrink-0">
                     {char.avatarUrl ? (
-                      <span className="block h-7 w-7 overflow-hidden rounded-full">
+                      <span className="relative block h-7 w-7 overflow-hidden rounded-full">
                         <img
                           src={char.avatarUrl}
                           alt={char.name}

--- a/packages/client/src/components/chat/ConversationMessage.tsx
+++ b/packages/client/src/components/chat/ConversationMessage.tsx
@@ -20,7 +20,7 @@ import { useQueryClient, type InfiniteData } from "@tanstack/react-query";
 import type { Message } from "@marinara-engine/shared";
 import { useUIStore } from "../../stores/ui.store";
 import { useChatStore } from "../../stores/chat.store";
-import { cn, copyToClipboard, getAvatarCropStyle } from "../../lib/utils";
+import { cn, copyToClipboard, getAvatarCropStyle, parseAvatarCropJson } from "../../lib/utils";
 import { applyInlineMarkdown, renderMarkdownBlocks } from "../../lib/markdown";
 import { chatKeys } from "../../hooks/use-chats";
 import { resolveMessageMacros } from "../../lib/chat-macros";
@@ -338,7 +338,10 @@ export const ConversationMessage = memo(function ConversationMessage({
   // Fall back to the current personaInfo prop for older messages without snapshots.
   const msgPersona = isUser && extra.personaSnapshot ? extra.personaSnapshot : null;
   const avatarUrl = isUser ? (msgPersona?.avatarUrl ?? personaInfo?.avatarUrl ?? null) : (charInfo?.avatarUrl ?? null);
-  const avatarCropStyle = isUser ? undefined : getAvatarCropStyle(charInfo?.avatarCrop);
+  const personaAvatarCrop = isUser
+    ? (parseAvatarCropJson(msgPersona?.avatarCrop) ?? personaInfo?.avatarCrop ?? null)
+    : null;
+  const avatarCropStyle = isUser ? getAvatarCropStyle(personaAvatarCrop) : getAvatarCropStyle(charInfo?.avatarCrop);
   const displayName = isUser
     ? (msgPersona?.name ?? personaInfo?.name ?? "You")
     : (primaryCharInfo?.name ?? "Assistant");
@@ -682,7 +685,7 @@ export const ConversationMessage = memo(function ConversationMessage({
                     <div className="flex gap-4">
                       {/* Avatar */}
                       <div className="w-10 flex-shrink-0">
-                        <div className="h-10 w-10 overflow-hidden rounded-full bg-[var(--accent)]">
+                        <div className="relative h-10 w-10 overflow-hidden rounded-full bg-[var(--accent)]">
                           {segAvatar ? (
                             <img
                               src={segAvatar}
@@ -937,7 +940,7 @@ export const ConversationMessage = memo(function ConversationMessage({
       <div className="mari-message-avatar w-10 flex-shrink-0">
         {!isGrouped && (
           <>
-            <div className="h-10 w-10 overflow-hidden rounded-full bg-[var(--accent)]">
+            <div className="relative h-10 w-10 overflow-hidden rounded-full bg-[var(--accent)]">
               {avatarUrl ? (
                 <img
                   src={avatarUrl}

--- a/packages/client/src/components/chat/ConversationView.tsx
+++ b/packages/client/src/components/chat/ConversationView.tsx
@@ -32,7 +32,7 @@ import { ActiveWorldInfoButton, ActiveWorldInfoModal } from "./ActiveWorldInfoBu
 import { useChatStore } from "../../stores/chat.store";
 import { useUIStore } from "../../stores/ui.store";
 import { playNotificationPing } from "../../lib/notification-sound";
-import { getAvatarCropStyle } from "../../lib/utils";
+import { getAvatarCropStyle, type AvatarCropValue } from "../../lib/utils";
 import { characterKeys } from "../../hooks/use-characters";
 import { api } from "../../lib/api-client";
 import type { CharacterMap, MessageSelectionToggle, PersonaInfo } from "./chat-area.types";
@@ -706,7 +706,7 @@ export function ConversationView({
             const chars = chatCharIds.map((id) => characterMap.get(id)).filter(Boolean) as Array<{
               name: string;
               avatarUrl: string | null;
-              avatarCrop?: { zoom: number; offsetX: number; offsetY: number } | null;
+              avatarCrop?: AvatarCropValue | null;
               conversationStatus?: "online" | "idle" | "dnd" | "offline";
               conversationActivity?: string;
             }>;
@@ -729,7 +729,7 @@ export function ConversationView({
                 <div className="flex items-center gap-2 rounded-lg bg-[var(--card)]/80 px-2.5 py-1.5 backdrop-blur-sm dark:bg-black/30">
                   <div className="relative flex-shrink-0">
                     {c.avatarUrl ? (
-                      <span className="block h-5 w-5 overflow-hidden rounded-full">
+                      <span className="relative block h-5 w-5 overflow-hidden rounded-full">
                         <img
                           src={c.avatarUrl}
                           alt={c.name}
@@ -767,7 +767,7 @@ export function ConversationView({
                     <div key={i} className="absolute top-0" style={{ left: i * 12 }}>
                       <div className="relative">
                         {c.avatarUrl ? (
-                          <span className="block h-5 w-5 overflow-hidden rounded-full ring-1 ring-[var(--border)]">
+                          <span className="relative block h-5 w-5 overflow-hidden rounded-full ring-1 ring-[var(--border)]">
                             <img
                               src={c.avatarUrl}
                               alt={c.name}

--- a/packages/client/src/components/chat/ExpressionPanel.tsx
+++ b/packages/client/src/components/chat/ExpressionPanel.tsx
@@ -138,7 +138,7 @@ export function ExpressionPanel({ characterIds, messages, characterMap, isRolepl
                 )}
               >
                 {info?.avatarUrl ? (
-                  <span className="block h-4 w-4 shrink-0 overflow-hidden rounded-full">
+                  <span className="relative block h-4 w-4 shrink-0 overflow-hidden rounded-full">
                     <img
                       src={info.avatarUrl}
                       alt=""
@@ -224,7 +224,7 @@ function ExpressionSprite({
         {info?.avatarUrl ? (
           <div
             className={cn(
-              "h-32 w-32 overflow-hidden rounded-2xl shadow-lg",
+              "relative h-32 w-32 overflow-hidden rounded-2xl shadow-lg",
               isRoleplay ? "ring-2 ring-white/10" : "ring-2 ring-[var(--border)]",
             )}
           >

--- a/packages/client/src/components/chat/QuickPersonaSwitcher.tsx
+++ b/packages/client/src/components/chat/QuickPersonaSwitcher.tsx
@@ -7,12 +7,14 @@ import { ChevronDown, ChevronRight, FolderOpen, Folder } from "lucide-react";
 import { usePersonas, usePersonaGroups } from "../../hooks/use-characters";
 import { useUpdateChat, useChat } from "../../hooks/use-chats";
 import { useChatStore } from "../../stores/chat.store";
-import { cn } from "../../lib/utils";
+import { cn, getAvatarCropStyle, parseAvatarCropJson } from "../../lib/utils";
 
 interface Persona {
   id: string;
   name: string;
   avatarPath?: string | null;
+  /** JSON-encoded AvatarCrop from the persona row. */
+  avatarCrop?: string;
   comment?: string | null;
   description?: string | null;
 }
@@ -162,11 +164,14 @@ export function QuickPersonaSwitcher({ className }: { className?: string }) {
         )}
       >
         {persona.avatarPath ? (
-          <img
-            src={persona.avatarPath}
-            alt={persona.name}
-            className="h-9 w-9 shrink-0 rounded-full border border-[var(--border)] object-cover"
-          />
+          <div className="relative h-9 w-9 shrink-0 overflow-hidden rounded-full border border-[var(--border)]">
+            <img
+              src={persona.avatarPath}
+              alt={persona.name}
+              className="h-full w-full object-cover"
+              style={getAvatarCropStyle(parseAvatarCropJson(persona.avatarCrop))}
+            />
+          </div>
         ) : (
           <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-[var(--border)] bg-[var(--secondary)] text-xs font-semibold text-[var(--muted-foreground)]">
             {(persona.name || "?")[0].toUpperCase()}
@@ -198,7 +203,7 @@ export function QuickPersonaSwitcher({ className }: { className?: string }) {
             : "Quick Persona Switcher"
         }
         className={cn(
-          "flex h-8 w-8 items-center justify-center rounded-full overflow-hidden transition-all border-2",
+          "relative flex h-8 w-8 items-center justify-center rounded-full overflow-hidden transition-all border-2",
           open ? "border-foreground/40" : "border-transparent hover:border-foreground/30 hover:opacity-90",
           className,
         )}
@@ -208,6 +213,7 @@ export function QuickPersonaSwitcher({ className }: { className?: string }) {
             src={activePersona.avatarPath}
             alt={activePersona.name}
             className="h-full w-full object-cover rounded-full"
+            style={getAvatarCropStyle(parseAvatarCropJson(activePersona.avatarCrop))}
           />
         ) : (
           <div className="flex h-full w-full items-center justify-center rounded-full bg-[var(--secondary)] text-[0.75rem] font-semibold text-[var(--muted-foreground)]">
@@ -262,11 +268,14 @@ export function QuickPersonaSwitcher({ className }: { className?: string }) {
                     )}
                   >
                     {firstMember?.avatarPath ? (
-                      <img
-                        src={firstMember.avatarPath}
-                        alt={group.name}
-                        className="h-9 w-9 shrink-0 rounded-full border border-[var(--border)] object-cover"
-                      />
+                      <div className="relative h-9 w-9 shrink-0 overflow-hidden rounded-full border border-[var(--border)]">
+                        <img
+                          src={firstMember.avatarPath}
+                          alt={group.name}
+                          className="h-full w-full object-cover"
+                          style={getAvatarCropStyle(parseAvatarCropJson(firstMember.avatarCrop))}
+                        />
+                      </div>
                     ) : (
                       <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-[var(--border)] bg-[var(--secondary)] text-xs font-semibold text-[var(--muted-foreground)]">
                         {group.name[0].toUpperCase()}

--- a/packages/client/src/components/chat/QuickSwitcherMobile.tsx
+++ b/packages/client/src/components/chat/QuickSwitcherMobile.tsx
@@ -9,12 +9,14 @@ import { useConnections, useUpdateConnection } from "../../hooks/use-connections
 import { usePersonas, usePersonaGroups } from "../../hooks/use-characters";
 import { useUpdateChat, useChat } from "../../hooks/use-chats";
 import { useChatStore } from "../../stores/chat.store";
-import { cn } from "../../lib/utils";
+import { cn, getAvatarCropStyle, parseAvatarCropJson } from "../../lib/utils";
 
 interface Persona {
   id: string;
   name: string;
   avatarPath?: string | null;
+  /** JSON-encoded AvatarCrop from the persona row. */
+  avatarCrop?: string;
   comment?: string | null;
 }
 
@@ -195,11 +197,14 @@ export function QuickSwitcherMobile() {
         )}
       >
         {persona.avatarPath ? (
-          <img
-            src={persona.avatarPath}
-            alt={persona.name}
-            className="h-9 w-9 shrink-0 rounded-full border border-[var(--border)] object-cover"
-          />
+          <div className="relative h-9 w-9 shrink-0 overflow-hidden rounded-full border border-[var(--border)]">
+            <img
+              src={persona.avatarPath}
+              alt={persona.name}
+              className="h-full w-full object-cover"
+              style={getAvatarCropStyle(parseAvatarCropJson(persona.avatarCrop))}
+            />
+          </div>
         ) : (
           <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-[var(--border)] bg-[var(--secondary)] text-xs font-semibold text-[var(--muted-foreground)]">
             {(persona.name || "?")[0].toUpperCase()}
@@ -363,11 +368,14 @@ export function QuickSwitcherMobile() {
                         )}
                       >
                         {firstMember?.avatarPath ? (
-                          <img
-                            src={firstMember.avatarPath}
-                            alt={group.name}
-                            className="h-9 w-9 shrink-0 rounded-full border border-[var(--border)] object-cover"
-                          />
+                          <div className="relative h-9 w-9 shrink-0 overflow-hidden rounded-full border border-[var(--border)]">
+                            <img
+                              src={firstMember.avatarPath}
+                              alt={group.name}
+                              className="h-full w-full object-cover"
+                              style={getAvatarCropStyle(parseAvatarCropJson(firstMember.avatarCrop))}
+                            />
+                          </div>
                         ) : (
                           <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-[var(--border)] bg-[var(--secondary)] text-xs font-semibold text-[var(--muted-foreground)]">
                             {group.name[0].toUpperCase()}

--- a/packages/client/src/components/chat/RecentChats.tsx
+++ b/packages/client/src/components/chat/RecentChats.tsx
@@ -7,7 +7,7 @@ import { MessageSquare, BookOpen } from "lucide-react";
 import { useChats } from "../../hooks/use-chats";
 import { useCharacters } from "../../hooks/use-characters";
 import { useChatStore } from "../../stores/chat.store";
-import { cn, getAvatarCropStyle } from "../../lib/utils";
+import { cn, getAvatarCropStyle, type AvatarCropValue } from "../../lib/utils";
 import type { Chat } from "@marinara-engine/shared";
 
 const MODE_BADGE: Record<string, { icon: React.ReactNode; bg: string; label: string }> = {
@@ -36,7 +36,7 @@ export function RecentChats() {
   const charLookup = useMemo(() => {
     const map = new Map<
       string,
-      { name: string; avatarUrl: string | null; avatarCrop?: { zoom: number; offsetX: number; offsetY: number } | null }
+      { name: string; avatarUrl: string | null; avatarCrop?: AvatarCropValue | null }
     >();
     if (!allCharacters) return map;
     for (const char of allCharacters as Array<{ id: string; data: string; avatarPath: string | null }>) {
@@ -83,7 +83,7 @@ function RecentChatChip({
   chat: Chat;
   charLookup: Map<
     string,
-    { name: string; avatarUrl: string | null; avatarCrop?: { zoom: number; offsetX: number; offsetY: number } | null }
+    { name: string; avatarUrl: string | null; avatarCrop?: AvatarCropValue | null }
   >;
   onClick: () => void;
 }) {
@@ -114,7 +114,7 @@ function RecentChatChip({
       {/* Small avatar with mode dot */}
       <div className="relative flex-shrink-0">
         {firstAvatar?.avatarUrl ? (
-          <span className="block h-5 w-5 overflow-hidden rounded-md">
+          <span className="relative block h-5 w-5 overflow-hidden rounded-md">
             <img
               src={firstAvatar.avatarUrl}
               alt={firstAvatar.name}

--- a/packages/client/src/components/chat/chat-area.types.ts
+++ b/packages/client/src/components/chat/chat-area.types.ts
@@ -1,4 +1,5 @@
 import type { Message } from "@marinara-engine/shared";
+import type { AvatarCrop, LegacyAvatarCrop } from "../../lib/utils";
 
 export type CharacterMap = Map<
   string,
@@ -14,7 +15,7 @@ export type CharacterMap = Map<
     nameColor?: string;
     dialogueColor?: string;
     boxColor?: string;
-    avatarCrop?: { zoom: number; offsetX: number; offsetY: number } | null;
+    avatarCrop?: AvatarCrop | LegacyAvatarCrop | null;
     conversationStatus?: "online" | "idle" | "dnd" | "offline";
     conversationActivity?: string;
   }
@@ -28,6 +29,7 @@ export type PersonaInfo = {
   appearance?: string;
   scenario?: string;
   avatarUrl?: string;
+  avatarCrop?: AvatarCrop | LegacyAvatarCrop | null;
   nameColor?: string;
   dialogueColor?: string;
   boxColor?: string;

--- a/packages/client/src/components/game/GameCharacterSheet.tsx
+++ b/packages/client/src/components/game/GameCharacterSheet.tsx
@@ -18,7 +18,7 @@ import {
   X,
   Zap,
 } from "lucide-react";
-import { cn, getAvatarCropStyle } from "../../lib/utils";
+import { cn, getAvatarCropStyle, type AvatarCropValue } from "../../lib/utils";
 
 export interface GameCharacterSheetGameCard {
   shortDescription: string;
@@ -40,7 +40,7 @@ export interface CharacterSheetCard {
   status?: string;
   level?: number;
   avatarUrl?: string | null;
-  avatarCrop?: { zoom: number; offsetX: number; offsetY: number } | null;
+  avatarCrop?: AvatarCropValue | null;
   stats?: Array<{ name: string; value: number; max?: number; color?: string }>;
   inventory?: Array<{ name: string; quantity?: number; location?: string }>;
   customFields?: Record<string, string>;
@@ -446,7 +446,7 @@ export function GameCharacterSheet({
         <div className="relative border-b border-[var(--border)] bg-[var(--secondary)]/50 px-5 py-4">
           <div className="flex items-center gap-4">
             {card.avatarUrl ? (
-              <span className="block h-20 w-20 overflow-hidden rounded-xl border-2 border-[var(--border)] shadow-xl">
+              <span className="relative block h-20 w-20 overflow-hidden rounded-xl border-2 border-[var(--border)] shadow-xl">
                 <img
                   src={card.avatarUrl}
                   alt={card.title}

--- a/packages/client/src/components/game/GameNarration.tsx
+++ b/packages/client/src/components/game/GameNarration.tsx
@@ -32,7 +32,7 @@ import {
   Loader2,
   Wand2,
 } from "lucide-react";
-import { cn, copyToClipboard, getAvatarCropStyle, type AvatarCrop } from "../../lib/utils";
+import { cn, copyToClipboard, getAvatarCropStyle, type AvatarCrop, type LegacyAvatarCrop } from "../../lib/utils";
 import { findNamedMapValue } from "../../lib/game-character-name-match";
 import type { GameSegmentEdit } from "../../lib/game-segment-edits";
 import { parseGmTags, stripGmTagsKeepReadables } from "../../lib/game-tag-parser";
@@ -234,7 +234,7 @@ interface NarrationSegment {
 
 type SpeakerAvatarInfo = {
   url: string;
-  crop?: AvatarCrop | null;
+  crop?: AvatarCrop | LegacyAvatarCrop | null;
   nameColor?: string;
   dialogueColor?: string;
 };
@@ -4201,11 +4201,11 @@ function CroppedAvatar({
 }: {
   src: string;
   alt: string;
-  crop?: AvatarCrop | null;
+  crop?: AvatarCrop | LegacyAvatarCrop | null;
   className?: string;
 }) {
   return (
-    <div className={cn("overflow-hidden", className)}>
+    <div className={cn("relative overflow-hidden", className)}>
       <img src={src} alt={alt} className="h-full w-full object-cover" style={getAvatarCropStyle(crop)} />
     </div>
   );

--- a/packages/client/src/components/game/GamePartyBar.tsx
+++ b/packages/client/src/components/game/GamePartyBar.tsx
@@ -3,13 +3,13 @@
 // ──────────────────────────────────────────────
 import { X } from "lucide-react";
 import { useGameModeStore } from "../../stores/game-mode.store";
-import { getAvatarCropStyle } from "../../lib/utils";
+import { getAvatarCropStyle, type AvatarCropValue } from "../../lib/utils";
 
 interface PartyBarMember {
   id: string;
   name: string;
   avatarUrl?: string | null;
-  avatarCrop?: { zoom: number; offsetX: number; offsetY: number } | null;
+  avatarCrop?: AvatarCropValue | null;
   nameColor?: string;
   canRemove?: boolean;
 }
@@ -21,7 +21,7 @@ interface PartyBarCard {
   status?: string;
   level?: number;
   avatarUrl?: string | null;
-  avatarCrop?: { zoom: number; offsetX: number; offsetY: number } | null;
+  avatarCrop?: AvatarCropValue | null;
   stats?: Array<{ name: string; value: number; max?: number; color?: string }>;
   inventory?: Array<{ name: string; quantity?: number; location?: string }>;
   customFields?: Record<string, string>;
@@ -60,7 +60,7 @@ export function GamePartyBar({
               title={`${member.name} - Click to open character sheet`}
             >
               {avatarSrc ? (
-                <span className="block h-9 w-9 overflow-hidden rounded-full border-2 border-white/20 shadow-lg transition-colors group-hover:border-white/40">
+                <span className="relative block h-9 w-9 overflow-hidden rounded-full border-2 border-white/20 shadow-lg transition-colors group-hover:border-white/40">
                   <img
                     src={avatarSrc}
                     alt={member.name}

--- a/packages/client/src/components/game/GamePartySidebar.tsx
+++ b/packages/client/src/components/game/GamePartySidebar.tsx
@@ -3,7 +3,7 @@
 // ──────────────────────────────────────────────
 import { useEffect, useRef, useState, type KeyboardEvent } from "react";
 import { Users, Send, ChevronLeft, ChevronRight, Swords, Heart, Sparkles } from "lucide-react";
-import { cn, getAvatarCropStyle } from "../../lib/utils";
+import { cn, getAvatarCropStyle, type AvatarCropValue } from "../../lib/utils";
 import { AnimatedText } from "./AnimatedText";
 
 interface PartyChatMessage {
@@ -25,7 +25,7 @@ interface GamePartySidebarProps {
     id: string;
     name: string;
     avatarUrl?: string | null;
-    avatarCrop?: { zoom: number; offsetX: number; offsetY: number } | null;
+    avatarCrop?: AvatarCropValue | null;
     nameColor?: string;
     dialogueColor?: string;
   }>;
@@ -38,7 +38,7 @@ interface GamePartySidebarProps {
       status?: string;
       level?: number;
       avatarUrl?: string | null;
-      avatarCrop?: { zoom: number; offsetX: number; offsetY: number } | null;
+      avatarCrop?: AvatarCropValue | null;
       stats?: Array<{ name: string; value: number; max?: number; color?: string }>;
       inventory?: Array<{ name: string; quantity?: number; location?: string }>;
       customFields?: Record<string, string>;
@@ -137,7 +137,7 @@ export function GamePartySidebar({
                   title={m.name}
                 >
                   {m.avatarUrl ? (
-                    <span className="block h-8 w-8 overflow-hidden rounded-full">
+                    <span className="relative block h-8 w-8 overflow-hidden rounded-full">
                       <img
                         src={m.avatarUrl}
                         alt={m.name}
@@ -166,7 +166,7 @@ export function GamePartySidebar({
                 <div className="relative border-b border-amber-500/15 bg-gradient-to-r from-amber-900/20 via-amber-800/10 to-amber-900/20 px-2.5 py-2">
                   <div className="flex items-center gap-2">
                     {selectedCard.avatarUrl ? (
-                      <span className="block h-10 w-10 shrink-0 overflow-hidden rounded-md border border-amber-500/25 shadow-md">
+                      <span className="relative block h-10 w-10 shrink-0 overflow-hidden rounded-md border border-amber-500/25 shadow-md">
                         <img
                           src={selectedCard.avatarUrl}
                           alt={selectedCard.title}
@@ -313,7 +313,7 @@ export function GamePartySidebar({
                 return (
                   <div key={msg.id} className="flex items-start gap-1.5 text-xs">
                     {msg.characterAvatar ? (
-                      <span className="mt-0.5 block h-5 w-5 shrink-0 overflow-hidden rounded-full">
+                      <span className="relative mt-0.5 block h-5 w-5 shrink-0 overflow-hidden rounded-full">
                         <img
                           src={msg.characterAvatar}
                           alt=""

--- a/packages/client/src/components/game/GameSetupWizard.tsx
+++ b/packages/client/src/components/game/GameSetupWizard.tsx
@@ -23,7 +23,7 @@ import {
 import type { GameSetupConfig, GameGmMode } from "@marinara-engine/shared";
 import { getCharacterTitle } from "../../lib/character-display";
 import { api } from "../../lib/api-client";
-import { cn, getAvatarCropStyle } from "../../lib/utils";
+import { cn, getAvatarCropStyle, type AvatarCropValue } from "../../lib/utils";
 import { Modal } from "../ui/Modal";
 import {
   GenerationParametersFields,
@@ -52,7 +52,7 @@ interface GameSetupWizardProps {
     name: string;
     comment?: string | null;
     avatarUrl?: string | null;
-    avatarCrop?: { zoom: number; offsetX: number; offsetY: number } | null;
+    avatarCrop?: AvatarCropValue | null;
   }>;
 }
 
@@ -68,7 +68,7 @@ function CharacterAvatar({
   character: {
     name: string;
     avatarUrl?: string | null;
-    avatarCrop?: { zoom: number; offsetX: number; offsetY: number } | null;
+    avatarCrop?: AvatarCropValue | null;
   };
   className?: string;
 }) {
@@ -80,7 +80,7 @@ function CharacterAvatar({
     );
   }
   return (
-    <span className={cn("block shrink-0 overflow-hidden", className)}>
+    <span className={cn("relative block shrink-0 overflow-hidden", className)}>
       <img
         src={character.avatarUrl}
         alt={character.name}

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -45,7 +45,7 @@ import { useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
 import { spriteKeys, type SpriteInfo } from "../../hooks/use-characters";
 import { api, getJsonRepairRequest, type JsonRepairRequest } from "../../lib/api-client";
 import { showConfirmDialog } from "../../lib/app-dialogs";
-import { cn } from "../../lib/utils";
+import { cn, type AvatarCrop, type LegacyAvatarCrop } from "../../lib/utils";
 import { audioManager } from "../../lib/game-audio";
 import {
   parseGmTags,
@@ -2532,7 +2532,7 @@ export function GameSurface({
       string,
       {
         url: string;
-        crop?: { zoom: number; offsetX: number; offsetY: number } | null;
+        crop?: AvatarCrop | LegacyAvatarCrop | null;
         nameColor?: string;
         dialogueColor?: string;
       }

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -45,7 +45,7 @@ import { useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
 import { spriteKeys, type SpriteInfo } from "../../hooks/use-characters";
 import { api, getJsonRepairRequest, type JsonRepairRequest } from "../../lib/api-client";
 import { showConfirmDialog } from "../../lib/app-dialogs";
-import { cn, type AvatarCrop, type LegacyAvatarCrop } from "../../lib/utils";
+import { cn, type AvatarCrop, type LegacyAvatarCrop, type AvatarCropValue } from "../../lib/utils";
 import { audioManager } from "../../lib/game-audio";
 import {
   parseGmTags,
@@ -291,7 +291,7 @@ type GamePartyMemberInfo = {
   id: string;
   name: string;
   avatarUrl: string | null;
-  avatarCrop?: { zoom: number; offsetX: number; offsetY: number } | null;
+  avatarCrop?: AvatarCropValue | null;
   nameColor?: string;
   dialogueColor?: string;
   canRemove?: boolean;
@@ -1644,7 +1644,7 @@ interface GameSurfaceProps {
     backstory?: string;
     appearance?: string;
     tags?: string[];
-    avatarCrop?: { zoom: number; offsetX: number; offsetY: number } | null;
+    avatarCrop?: AvatarCropValue | null;
     nameColor?: string;
     dialogueColor?: string;
   }>;
@@ -5867,7 +5867,7 @@ export function GameSurface({
         status?: string;
         level?: number;
         avatarUrl?: string | null;
-        avatarCrop?: { zoom: number; offsetX: number; offsetY: number } | null;
+        avatarCrop?: AvatarCropValue | null;
         stats?: Array<{ name: string; value: number; max?: number; color?: string }>;
         inventory?: Array<{ name: string; quantity?: number; location?: string }>;
         customFields?: Record<string, string>;

--- a/packages/client/src/components/layout/ChatSidebar.tsx
+++ b/packages/client/src/components/layout/ChatSidebar.tsx
@@ -41,7 +41,7 @@ import { useCharacters } from "../../hooks/use-characters";
 import { useChatStore } from "../../stores/chat.store";
 import { showConfirmDialog } from "../../lib/app-dialogs";
 import { useUIStore, type UserStatus } from "../../stores/ui.store";
-import { cn, getAvatarCropStyle } from "../../lib/utils";
+import { cn, getAvatarCropStyle, type AvatarCropValue } from "../../lib/utils";
 import { useState, useCallback, useMemo, useRef, useEffect } from "react";
 import type { Chat, ChatFolder, ChatMode } from "@marinara-engine/shared";
 import { Modal } from "../ui/Modal";
@@ -142,7 +142,7 @@ export function ChatSidebar() {
       {
         name: string;
         avatarUrl: string | null;
-        avatarCrop?: { zoom: number; offsetX: number; offsetY: number } | null;
+        avatarCrop?: AvatarCropValue | null;
         conversationStatus?: string;
       }
     >();
@@ -161,7 +161,7 @@ export function ChatSidebar() {
         map.set(char.id, {
           name,
           avatarUrl: char.avatarPath ?? null,
-          avatarCrop: (extensions.avatarCrop as { zoom: number; offsetX: number; offsetY: number } | undefined) ?? null,
+          avatarCrop: (extensions.avatarCrop as AvatarCropValue | undefined) ?? null,
           conversationStatus,
         });
       } catch {
@@ -624,7 +624,7 @@ export function ChatSidebar() {
               .filter(Boolean) as {
               name: string;
               avatarUrl: string | null;
-              avatarCrop?: { zoom: number; offsetX: number; offsetY: number } | null;
+              avatarCrop?: AvatarCropValue | null;
               conversationStatus?: string;
             }[];
 
@@ -665,7 +665,7 @@ export function ChatSidebar() {
               const a = avatars[0]!;
               return a.avatarUrl ? (
                 <div className="relative h-7 w-7 flex-shrink-0 transition-transform group-active:scale-90">
-                  <span className="block h-7 w-7 overflow-hidden rounded-full">
+                  <span className="relative block h-7 w-7 overflow-hidden rounded-full">
                     <img
                       src={a.avatarUrl}
                       alt={a.name}

--- a/packages/client/src/components/panels/CharactersPanel.tsx
+++ b/packages/client/src/components/panels/CharactersPanel.tsx
@@ -46,7 +46,7 @@ import {
 } from "lucide-react";
 import { getCharacterTitle } from "../../lib/character-display";
 import { useUIStore } from "../../stores/ui.store";
-import { cn, getAvatarCropStyle } from "../../lib/utils";
+import { cn, getAvatarCropStyle, type AvatarCropValue } from "../../lib/utils";
 import { ExportFormatDialog, type ExportFormatChoice } from "../ui/ExportFormatDialog";
 
 type CharacterRow = {
@@ -1032,7 +1032,7 @@ export function CharactersPanel() {
                       className="h-full w-full object-cover"
                       style={getAvatarCropStyle(
                         char.parsed.extensions?.avatarCrop as
-                          | { zoom: number; offsetX: number; offsetY: number }
+                          | AvatarCropValue
                           | undefined,
                       )}
                     />

--- a/packages/client/src/components/panels/PersonasPanel.tsx
+++ b/packages/client/src/components/panels/PersonasPanel.tsx
@@ -40,7 +40,7 @@ import {
   Tag,
 } from "lucide-react";
 import { showConfirmDialog } from "../../lib/app-dialogs";
-import { cn, getAvatarCropStyle, type AvatarCrop, type LegacyAvatarCrop } from "../../lib/utils";
+import { cn, getAvatarCropStyle, parseAvatarCropJson } from "../../lib/utils";
 import { HelpTooltip } from "../ui/HelpTooltip";
 import { api } from "../../lib/api-client";
 import { ExportFormatDialog, type ExportFormatChoice } from "../ui/ExportFormatDialog";
@@ -61,55 +61,6 @@ type PersonaRow = {
   createdAt: string;
   tags?: string;
 };
-
-/** Parses the persona row's JSON-encoded avatarCrop field with defensive shape
- *  validation. Accepts either the current source-relative shape (srcX/Y/W/H) or
- *  the legacy zoom+offset shape, so a malformed cell never breaks rendering. */
-function parsePersonaAvatarCrop(raw: string | undefined): AvatarCrop | LegacyAvatarCrop | null {
-  if (!raw) return null;
-  try {
-    const obj = JSON.parse(raw);
-    if (!obj || typeof obj !== "object") return null;
-    // Validate geometry — finite, positive, within normalized bounds. Anything
-    // malformed is dropped so the panel falls back to the uncropped render
-    // instead of producing NaN transforms or an off-canvas image.
-    if (
-      Number.isFinite(obj.srcX) &&
-      Number.isFinite(obj.srcY) &&
-      Number.isFinite(obj.srcWidth) &&
-      Number.isFinite(obj.srcHeight) &&
-      obj.srcWidth > 0 &&
-      obj.srcHeight > 0 &&
-      obj.srcX >= 0 &&
-      obj.srcY >= 0 &&
-      obj.srcX + obj.srcWidth <= 1.001 &&
-      obj.srcY + obj.srcHeight <= 1.001
-    ) {
-      return {
-        srcX: obj.srcX,
-        srcY: obj.srcY,
-        srcWidth: obj.srcWidth,
-        srcHeight: obj.srcHeight,
-      };
-    }
-    if (
-      Number.isFinite(obj.zoom) &&
-      Number.isFinite(obj.offsetX) &&
-      Number.isFinite(obj.offsetY) &&
-      obj.zoom > 0
-    ) {
-      return {
-        zoom: obj.zoom,
-        offsetX: obj.offsetX,
-        offsetY: obj.offsetY,
-        ...(obj.fullImage ? { fullImage: true } : {}),
-      };
-    }
-  } catch {
-    /* fall through to null */
-  }
-  return null;
-}
 
 type PersonaGroupRow = { id: string; name: string; description: string; personaIds: string };
 
@@ -740,7 +691,7 @@ export function PersonasPanel() {
                                       src={p.avatarPath}
                                       alt=""
                                       className="h-full w-full rounded-lg object-cover"
-                                      style={getAvatarCropStyle(parsePersonaAvatarCrop(p.avatarCrop))}
+                                      style={getAvatarCropStyle(parseAvatarCropJson(p.avatarCrop))}
                                     />
                                   ) : (
                                     <User size="0.625rem" />
@@ -868,7 +819,7 @@ export function PersonasPanel() {
                       alt=""
                       loading="lazy"
                       className="h-full w-full rounded-xl object-cover"
-                      style={getAvatarCropStyle(parsePersonaAvatarCrop(persona.avatarCrop))}
+                      style={getAvatarCropStyle(parseAvatarCropJson(persona.avatarCrop))}
                     />
                   ) : (
                     <User size="1rem" />

--- a/packages/client/src/components/panels/PersonasPanel.tsx
+++ b/packages/client/src/components/panels/PersonasPanel.tsx
@@ -40,7 +40,7 @@ import {
   Tag,
 } from "lucide-react";
 import { showConfirmDialog } from "../../lib/app-dialogs";
-import { cn } from "../../lib/utils";
+import { cn, getAvatarCropStyle, type AvatarCrop, type LegacyAvatarCrop } from "../../lib/utils";
 import { HelpTooltip } from "../ui/HelpTooltip";
 import { api } from "../../lib/api-client";
 import { ExportFormatDialog, type ExportFormatChoice } from "../ui/ExportFormatDialog";
@@ -55,10 +55,61 @@ type PersonaRow = {
   backstory: string;
   appearance: string;
   avatarPath: string | null;
+  /** JSON-encoded AvatarCrop, or empty string when unset. */
+  avatarCrop?: string;
   isActive: string | boolean;
   createdAt: string;
   tags?: string;
 };
+
+/** Parses the persona row's JSON-encoded avatarCrop field with defensive shape
+ *  validation. Accepts either the current source-relative shape (srcX/Y/W/H) or
+ *  the legacy zoom+offset shape, so a malformed cell never breaks rendering. */
+function parsePersonaAvatarCrop(raw: string | undefined): AvatarCrop | LegacyAvatarCrop | null {
+  if (!raw) return null;
+  try {
+    const obj = JSON.parse(raw);
+    if (!obj || typeof obj !== "object") return null;
+    // Validate geometry — finite, positive, within normalized bounds. Anything
+    // malformed is dropped so the panel falls back to the uncropped render
+    // instead of producing NaN transforms or an off-canvas image.
+    if (
+      Number.isFinite(obj.srcX) &&
+      Number.isFinite(obj.srcY) &&
+      Number.isFinite(obj.srcWidth) &&
+      Number.isFinite(obj.srcHeight) &&
+      obj.srcWidth > 0 &&
+      obj.srcHeight > 0 &&
+      obj.srcX >= 0 &&
+      obj.srcY >= 0 &&
+      obj.srcX + obj.srcWidth <= 1.001 &&
+      obj.srcY + obj.srcHeight <= 1.001
+    ) {
+      return {
+        srcX: obj.srcX,
+        srcY: obj.srcY,
+        srcWidth: obj.srcWidth,
+        srcHeight: obj.srcHeight,
+      };
+    }
+    if (
+      Number.isFinite(obj.zoom) &&
+      Number.isFinite(obj.offsetX) &&
+      Number.isFinite(obj.offsetY) &&
+      obj.zoom > 0
+    ) {
+      return {
+        zoom: obj.zoom,
+        offsetX: obj.offsetX,
+        offsetY: obj.offsetY,
+        ...(obj.fullImage ? { fullImage: true } : {}),
+      };
+    }
+  } catch {
+    /* fall through to null */
+  }
+  return null;
+}
 
 type PersonaGroupRow = { id: string; name: string; description: string; personaIds: string };
 
@@ -683,9 +734,14 @@ export function PersonasPanel() {
                             if (!p) return null;
                             return (
                               <div key={pid} className="flex items-center gap-2 rounded-lg px-1 py-1 text-xs">
-                                <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-lg bg-gradient-to-br from-emerald-400 to-teal-500 text-white">
+                                <div className="relative flex h-6 w-6 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-gradient-to-br from-emerald-400 to-teal-500 text-white">
                                   {p.avatarPath ? (
-                                    <img src={p.avatarPath} alt="" className="h-full w-full rounded-lg object-cover" />
+                                    <img
+                                      src={p.avatarPath}
+                                      alt=""
+                                      className="h-full w-full rounded-lg object-cover"
+                                      style={getAvatarCropStyle(parsePersonaAvatarCrop(p.avatarCrop))}
+                                    />
                                   ) : (
                                     <User size="0.625rem" />
                                   )}
@@ -798,16 +854,26 @@ export function PersonasPanel() {
                 className="relative flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-emerald-400 to-teal-500 text-white shadow-sm group/avatar"
                 title="Change avatar"
               >
-                {persona.avatarPath ? (
-                  <img
-                    src={persona.avatarPath}
-                    alt=""
-                    loading="lazy"
-                    className="h-full w-full rounded-xl object-cover"
-                  />
-                ) : (
-                  <User size="1rem" />
-                )}
+                {/* Inner clip wrapper — needed because new-format avatarCrop renders the
+                    <img> with position:absolute and dimensions larger than the container.
+                    The wrapper provides both `position:relative` (so the absolute img
+                    resolves here) and `overflow:hidden` (so the oversized img is clipped
+                    to the rounded-xl shape). The wrapper can't be the button itself
+                    because the active-indicator star and the camera-hover overlay live
+                    outside the avatar bounds via negative offsets / absolute inset-0. */}
+                <div className="relative h-full w-full overflow-hidden rounded-xl">
+                  {persona.avatarPath ? (
+                    <img
+                      src={persona.avatarPath}
+                      alt=""
+                      loading="lazy"
+                      className="h-full w-full rounded-xl object-cover"
+                      style={getAvatarCropStyle(parsePersonaAvatarCrop(persona.avatarCrop))}
+                    />
+                  ) : (
+                    <User size="1rem" />
+                  )}
+                </div>
                 <div className="absolute inset-0 flex items-center justify-center rounded-xl bg-black/40 opacity-0 transition-opacity group-hover/avatar:opacity-100">
                   <Camera size="0.75rem" className="text-white" />
                 </div>

--- a/packages/client/src/components/personas/PersonaEditor.tsx
+++ b/packages/client/src/components/personas/PersonaEditor.tsx
@@ -37,7 +37,7 @@ import {
   RotateCcw,
   Crop,
 } from "lucide-react";
-import { cn, generateClientId } from "../../lib/utils";
+import { cn, generateClientId, getAvatarCropStyle, type AvatarCrop, type LegacyAvatarCrop } from "../../lib/utils";
 import { showAlertDialog, showConfirmDialog } from "../../lib/app-dialogs";
 import { extractColorsFromImage } from "../../lib/avatar-color-extraction";
 import { HelpTooltip } from "../ui/HelpTooltip";
@@ -57,6 +57,7 @@ import {
 import { useQueryClient } from "@tanstack/react-query";
 import { SpriteGenerationModal } from "../ui/SpriteGenerationModal";
 import { AvatarGenerationModal } from "../ui/AvatarGenerationModal";
+import { AvatarCropWidget } from "../ui/AvatarCropWidget";
 import { SpriteFrameEditor } from "../ui/SpriteFrameEditor";
 import { SpriteWandCleanupEditor } from "../ui/SpriteWandCleanupEditor";
 import { ExportFormatDialog, type ExportFormatChoice } from "../ui/ExportFormatDialog";
@@ -97,6 +98,10 @@ interface PersonaFormData {
   personaStats: string;
   altDescriptions: AltDescriptionEntry[];
   tags: string[];
+  /** Avatar crop region (parsed from the persona row's JSON-encoded `avatarCrop`).
+   *  May be the current source-relative shape, the legacy zoom+offset shape (held
+   *  through until the user re-edits via the cropper), or null when unset. */
+  avatarCrop: AvatarCrop | LegacyAvatarCrop | null;
 }
 
 interface PersonaRow {
@@ -109,6 +114,8 @@ interface PersonaRow {
   backstory: string;
   appearance: string;
   avatarPath: string | null;
+  /** JSON-encoded AvatarCrop, or empty string when unset. */
+  avatarCrop?: string;
   isActive: string | boolean;
   nameColor?: string;
   dialogueColor?: string;
@@ -167,6 +174,55 @@ export function PersonaEditor() {
       /* ignore */
     }
 
+    let parsedAvatarCrop: AvatarCrop | LegacyAvatarCrop | null = null;
+    try {
+      const raw = rawPersona.avatarCrop;
+      if (raw) {
+        const obj = JSON.parse(raw);
+        // Defensive: accept either the current source-relative shape or the
+        // legacy zoom+offset shape. Anything else is silently dropped so a
+        // malformed cell can't break the editor with NaN transforms.
+        if (obj && typeof obj === "object") {
+          // Validate geometry — finite, positive, within normalized bounds.
+          // Anything malformed is dropped so the editor falls back to defaults
+          // instead of producing NaN transforms or an off-screen overlay.
+          if (
+            Number.isFinite(obj.srcX) &&
+            Number.isFinite(obj.srcY) &&
+            Number.isFinite(obj.srcWidth) &&
+            Number.isFinite(obj.srcHeight) &&
+            obj.srcWidth > 0 &&
+            obj.srcHeight > 0 &&
+            obj.srcX >= 0 &&
+            obj.srcY >= 0 &&
+            obj.srcX + obj.srcWidth <= 1.001 &&
+            obj.srcY + obj.srcHeight <= 1.001
+          ) {
+            parsedAvatarCrop = {
+              srcX: obj.srcX,
+              srcY: obj.srcY,
+              srcWidth: obj.srcWidth,
+              srcHeight: obj.srcHeight,
+            };
+          } else if (
+            Number.isFinite(obj.zoom) &&
+            Number.isFinite(obj.offsetX) &&
+            Number.isFinite(obj.offsetY) &&
+            obj.zoom > 0
+          ) {
+            parsedAvatarCrop = {
+              zoom: obj.zoom,
+              offsetX: obj.offsetX,
+              offsetY: obj.offsetY,
+              ...(obj.fullImage ? { fullImage: true } : {}),
+            };
+          }
+        }
+      }
+    } catch {
+      /* ignore — empty / malformed crop just stays null */
+    }
+
     setFormData({
       name: rawPersona.name,
       comment: rawPersona.comment ?? "",
@@ -187,6 +243,7 @@ export function PersonaEditor() {
           return [];
         }
       })(),
+      avatarCrop: parsedAvatarCrop,
     });
     setAvatarPreview(rawPersona.avatarPath);
     setDirty(false);
@@ -201,12 +258,15 @@ export function PersonaEditor() {
     if (!personaId || !formData) return;
     setSaving(true);
     try {
-      const { altDescriptions, tags, ...rest } = formData;
+      const { altDescriptions, tags, avatarCrop, ...rest } = formData;
       await updatePersona.mutateAsync({
         id: personaId,
         ...rest,
         altDescriptions: JSON.stringify(altDescriptions),
         tags: JSON.stringify(tags),
+        // Persist as JSON string; empty string means "no crop" so the row keeps
+        // the legacy default in render sites.
+        avatarCrop: avatarCrop ? JSON.stringify(avatarCrop) : "",
       });
       setDirty(false);
     } finally {
@@ -221,12 +281,18 @@ export function PersonaEditor() {
     const uploadToken = generateClientId();
     latestAvatarUploadTokenRef.current = uploadToken;
     const fallbackAvatarPath = rawPersona?.avatarPath ?? null;
+    // Capture the saved crop so we can revert if the upload fails. The new image
+    // almost certainly has different framing/dimensions, so the old normalized
+    // crop coords are meaningless for it — clear immediately on upload start
+    // and let the cropper re-init from default centered max-square.
+    const fallbackAvatarCrop = formData?.avatarCrop ?? null;
 
     const reader = new FileReader();
     reader.onload = async () => {
       if (latestAvatarUploadTokenRef.current !== uploadToken) return;
       const dataUrl = reader.result as string;
       setAvatarPreview(dataUrl);
+      updateField("avatarCrop", null);
       try {
         await uploadAvatar.mutateAsync({
           id: personaId,
@@ -236,6 +302,7 @@ export function PersonaEditor() {
       } catch {
         if (latestAvatarUploadTokenRef.current !== uploadToken) return;
         setAvatarPreview(fallbackAvatarPath);
+        updateField("avatarCrop", fallbackAvatarCrop);
       }
     };
     reader.readAsDataURL(file);
@@ -248,6 +315,9 @@ export function PersonaEditor() {
       const uploadToken = generateClientId();
       latestAvatarUploadTokenRef.current = uploadToken;
       setAvatarPreview(avatarDataUrl);
+      // Same rationale as handleAvatarUpload — a freshly generated avatar
+      // shouldn't inherit the prior image's crop coords.
+      updateField("avatarCrop", null);
       await uploadAvatar.mutateAsync({
         id: personaId,
         avatar: avatarDataUrl,
@@ -255,7 +325,7 @@ export function PersonaEditor() {
       });
       toast.success("Persona avatar generated.");
     },
-    [personaId, uploadAvatar],
+    [personaId, updateField, uploadAvatar],
   );
 
   const handleDelete = async () => {
@@ -339,7 +409,12 @@ export function PersonaEditor() {
           onClick={() => fileInputRef.current?.click()}
         >
           {avatarPreview ? (
-            <img src={avatarPreview} alt={formData.name} className="h-full w-full object-cover" />
+            <img
+              src={avatarPreview}
+              alt={formData.name}
+              className="h-full w-full object-cover"
+              style={getAvatarCropStyle(formData.avatarCrop)}
+            />
           ) : (
             <User size="1.375rem" className="text-white" />
           )}
@@ -481,7 +556,12 @@ export function PersonaEditor() {
         <div className="flex-1 overflow-y-auto p-6 @max-5xl:p-4">
           <div className="mx-auto max-w-2xl">
             {activeTab === "description" && (
-              <DescriptionTab formData={formData} updateField={updateField} setDirty={setDirty} />
+              <DescriptionTab
+                formData={formData}
+                updateField={updateField}
+                setDirty={setDirty}
+                avatarPreview={avatarPreview}
+              />
             )}
             {activeTab === "personality" && (
               <TextareaTab
@@ -1743,10 +1823,12 @@ function DescriptionTab({
   formData,
   updateField,
   setDirty: _setDirty,
+  avatarPreview,
 }: {
   formData: PersonaFormData;
   updateField: <K extends keyof PersonaFormData>(key: K, value: PersonaFormData[K]) => void;
   setDirty: (v: boolean) => void;
+  avatarPreview: string | null;
 }) {
   const altDescs = formData.altDescriptions;
   const [expandedField, setExpandedField] = useState<"description" | string | null>(null);
@@ -1787,8 +1869,21 @@ function DescriptionTab({
     updateAltDescs(altDescs.filter((d) => d.id !== id));
   };
 
+  // Pass through whichever shape is saved (or null when unset). The widget
+  // initializes the cropper from the saved value or a centered max-square.
+  const avatarCrop: AvatarCrop | LegacyAvatarCrop | null = formData.avatarCrop;
+
   return (
     <div className="space-y-6">
+      {/* Avatar Crop / Zoom */}
+      {avatarPreview && (
+        <AvatarCropWidget
+          src={avatarPreview}
+          alt={formData.name}
+          crop={avatarCrop}
+          onChange={(next) => updateField("avatarCrop", next)}
+        />
+      )}
       {/* Main description */}
       <div>
         <div className="flex items-center justify-between mb-4">

--- a/packages/client/src/components/ui/AvatarCropWidget.tsx
+++ b/packages/client/src/components/ui/AvatarCropWidget.tsx
@@ -1,0 +1,424 @@
+// ──────────────────────────────────────────────
+// AvatarCropWidget — square crop selector for circle avatars
+// ──────────────────────────────────────────────
+// The user drags a square selection over the source image to pick exactly which
+// region becomes the avatar. The crop is stored as a region of the SOURCE image
+// (normalized to source dimensions), so the original avatar file is never
+// rewritten — Roleplay full-image side panels keep showing the untouched portrait.
+//
+// Render contract (`getAvatarCropStyle` in `lib/utils.ts`): a saved AvatarCrop
+// produces an absolutely-positioned `<img>` inside an `overflow:hidden;
+// position:relative` container, sized so the crop rectangle maps onto the
+// container's full area. Square-in-source-pixels crops survive any source aspect
+// ratio without distortion.
+import { useEffect, useRef, useState } from "react";
+import { Crop, Maximize2, RotateCcw, X } from "lucide-react";
+import {
+  type AvatarCrop,
+  type LegacyAvatarCrop,
+  getAvatarCropStyle,
+  isLegacyAvatarCrop,
+} from "../../lib/utils";
+
+interface CropPx {
+  x: number;
+  y: number;
+  size: number;
+}
+
+type DragHandle = "pan" | "tl" | "tr" | "bl" | "br";
+
+export interface AvatarCropWidgetProps {
+  /** Image URL or data URL to crop. */
+  src: string;
+  alt: string;
+  /** Currently saved crop. Pass null when none has been set. Accepts the legacy
+   *  shape for read; on first interaction the widget writes the current shape. */
+  crop: AvatarCrop | LegacyAvatarCrop | null;
+  /** Fired on every change (drag, corner resize, reset). Always emits the
+   *  current AvatarCrop shape. */
+  onChange: (next: AvatarCrop) => void;
+}
+
+const MIN_CROP_PX = 24;
+const MAX_DISPLAY_W = 360;
+const MAX_DISPLAY_H = 360;
+
+export function AvatarCropWidget({ src, alt, crop, onChange }: AvatarCropWidgetProps) {
+  const imgRef = useRef<HTMLImageElement>(null);
+  const [imgRect, setImgRect] = useState<{ w: number; h: number } | null>(null);
+  const [cropPx, setCropPx] = useState<CropPx | null>(null);
+  const [showFullView, setShowFullView] = useState(false);
+
+  const dragRef = useRef<{
+    handle: DragHandle;
+    startX: number;
+    startY: number;
+    startCrop: CropPx;
+  } | null>(null);
+
+  // Initialize / reinitialize when source changes
+  useEffect(() => {
+    setImgRect(null);
+    setCropPx(null);
+  }, [src]);
+
+  // Cached images are the dominant case in practice (the persona/character
+  // panel just rendered a thumbnail of the same URL), and the browser fires
+  // the `load` event so quickly that React's onLoad listener can miss it
+  // even with `key={src}` forcing a remount. After every render, if the IMG
+  // is already complete and we haven't initialized yet, run handleImgLoad
+  // ourselves. The `imgRect == null` guard makes this a no-op once initialized.
+  useEffect(() => {
+    const img = imgRef.current;
+    if (img && img.complete && img.naturalWidth > 0 && imgRect === null) {
+      handleImgLoad();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  });
+
+  // Re-sync the local overlay when the parent's `crop` prop changes for the
+  // SAME source (e.g. parent reloaded form data, or the saved crop arrived
+  // late after initial mount). Without this, late-arriving crop data would be
+  // silently replaced by the default centered max-square on first interaction.
+  // Skip while a drag is in flight so the user's in-progress edit isn't wiped
+  // by their own onChange roundtrip — the drag handler keeps cropPx in sync
+  // during the drag, and the parent's crop already mirrors that.
+  useEffect(() => {
+    if (!imgRect || dragRef.current) return;
+    const { w, h } = imgRect;
+    if (crop && !isLegacyAvatarCrop(crop)) {
+      const size = clamp(crop.srcWidth * w, MIN_CROP_PX, Math.min(w, h));
+      setCropPx({
+        x: clamp(crop.srcX * w, 0, w - size),
+        y: clamp(crop.srcY * h, 0, h - size),
+        size,
+      });
+      return;
+    }
+    // Legacy crop OR null → default to centered max-square. Legacy data still
+    // renders correctly via getAvatarCropStyle's transform path; the cropper
+    // overlay just shows a fresh selection the user can adjust.
+    const size = Math.min(w, h);
+    setCropPx({ x: (w - size) / 2, y: (h - size) / 2, size });
+  }, [crop, imgRect]);
+
+  const emitFromPx = (px: CropPx, w: number, h: number) => {
+    onChange({
+      srcX: px.x / w,
+      srcY: px.y / h,
+      srcWidth: px.size / w,
+      srcHeight: px.size / h,
+    });
+  };
+
+  const handleImgLoad = () => {
+    const img = imgRef.current;
+    if (!img) return;
+    // Compute display dimensions: fit inside MAX_DISPLAY_W x MAX_DISPLAY_H,
+    // never upscale past natural size. Canvas matches these dims so cropPx
+    // coords are also image-pixel coords (in the displayed scale).
+    const natW = img.naturalWidth || 1;
+    const natH = img.naturalHeight || 1;
+    const scale = Math.min(MAX_DISPLAY_W / natW, MAX_DISPLAY_H / natH, 1);
+    const w = natW * scale;
+    const h = natH * scale;
+    setImgRect({ w, h });
+
+    // Init crop overlay from saved value when possible. Legacy crops convert
+    // to "centered max square" because the legacy zoom/pan model can't be
+    // losslessly mapped without a render-time round-trip; the user can re-crop
+    // precisely once the editor opens.
+    let initial: CropPx;
+    if (crop && !isLegacyAvatarCrop(crop)) {
+      initial = {
+        x: crop.srcX * w,
+        y: crop.srcY * h,
+        // srcWidth and srcHeight refer to the same square in source pixels by
+        // design, so scaling either one through the displayed dim gives the
+        // same value. Trust srcWidth as canonical.
+        size: crop.srcWidth * w,
+      };
+    } else {
+      const size = Math.min(w, h);
+      initial = { x: (w - size) / 2, y: (h - size) / 2, size };
+    }
+    setCropPx(initial);
+    // Intentionally DO NOT emit on init: opening the editor on an existing
+    // avatar shouldn't dirty the form. The first actual drag / corner-resize /
+    // reset is what commits the (possibly identical) value upstream. Live
+    // preview still reads cropPx so it stays in sync with the overlay.
+  };
+
+  const onPointerDown = (e: React.PointerEvent, handle: DragHandle) => {
+    if (!cropPx || !imgRect) return;
+    e.preventDefault();
+    e.stopPropagation();
+    (e.target as HTMLElement).setPointerCapture(e.pointerId);
+    dragRef.current = {
+      handle,
+      startX: e.clientX,
+      startY: e.clientY,
+      startCrop: { ...cropPx },
+    };
+  };
+
+  const onPointerMove = (e: React.PointerEvent) => {
+    const d = dragRef.current;
+    if (!d || !imgRect) return;
+    const dx = e.clientX - d.startX;
+    const dy = e.clientY - d.startY;
+    const W = imgRect.w;
+    const H = imgRect.h;
+    const start = d.startCrop;
+    let next: CropPx;
+
+    if (d.handle === "pan") {
+      next = {
+        size: start.size,
+        x: clamp(start.x + dx, 0, W - start.size),
+        y: clamp(start.y + dy, 0, H - start.size),
+      };
+    } else {
+      // Corner resize, square-locked. The opposite corner is the anchor; the
+      // dragged corner moves freely; the new size is the smaller of the two
+      // available dimensions so the square always fits inside the canvas.
+      const startTL = { x: start.x, y: start.y };
+      const startBR = { x: start.x + start.size, y: start.y + start.size };
+      next = resizeCorner(d.handle, startTL, startBR, dx, dy, W, H);
+    }
+
+    setCropPx(next);
+    emitFromPx(next, W, H);
+  };
+
+  const onPointerUp = () => {
+    dragRef.current = null;
+  };
+
+  const reset = () => {
+    if (!imgRect) return;
+    const size = Math.min(imgRect.w, imgRect.h);
+    const next: CropPx = { x: (imgRect.w - size) / 2, y: (imgRect.h - size) / 2, size };
+    setCropPx(next);
+    emitFromPx(next, imgRect.w, imgRect.h);
+  };
+
+  // Live preview reads cropPx (instant) rather than the saved crop prop, so the
+  // preview stays in sync with the overlay even between onChange ticks.
+  const previewCrop: AvatarCrop | null =
+    imgRect && cropPx
+      ? {
+          srcX: cropPx.x / imgRect.w,
+          srcY: cropPx.y / imgRect.h,
+          srcWidth: cropPx.size / imgRect.w,
+          srcHeight: cropPx.size / imgRect.h,
+        }
+      : null;
+
+  return (
+    <div className="space-y-3 rounded-xl border border-[var(--border)] bg-[var(--secondary)] p-4">
+      <div className="flex items-center justify-between gap-2">
+        <span className="inline-flex items-center gap-1 text-xs font-medium text-[var(--muted-foreground)]">
+          <Crop size="0.75rem" /> Avatar Crop
+        </span>
+        <div className="flex items-center gap-1.5">
+          <button
+            type="button"
+            onClick={() => setShowFullView(true)}
+            className="inline-flex items-center gap-1 rounded-lg bg-[var(--accent)] px-2 py-1 text-[0.625rem] font-medium text-[var(--muted-foreground)] transition-colors hover:text-[var(--foreground)]"
+            title="Open full image"
+          >
+            <Maximize2 size="0.625rem" /> Full image
+          </button>
+          <button
+            type="button"
+            onClick={reset}
+            className="inline-flex items-center gap-1 rounded-lg bg-[var(--accent)] px-2 py-1 text-[0.625rem] font-medium text-[var(--muted-foreground)] transition-colors hover:text-[var(--foreground)]"
+            title="Reset to centered max-square crop"
+          >
+            <RotateCcw size="0.625rem" /> Reset
+          </button>
+        </div>
+      </div>
+      <p className="text-[0.625rem] text-[var(--muted-foreground)]">
+        Drag the square to pan, the corners to resize. The avatar shows exactly the region inside the square.
+      </p>
+
+      <div className="flex gap-4 max-md:flex-col max-md:items-center">
+        {/* Crop canvas — sized to fit the displayed image exactly so overlay
+            coords are also image coords. */}
+        <div
+          className="relative overflow-hidden rounded-lg bg-black/40 select-none"
+          style={{
+            width: imgRect?.w ?? MAX_DISPLAY_W,
+            height: imgRect?.h ?? MAX_DISPLAY_H,
+          }}
+        >
+          {/* key={src} forces remount when the source changes (e.g. switching
+              between personas/characters in the editor). Without this, only the
+              `src` attribute updates on the existing element, and if the new
+              image is already in browser cache the `load` event never fires for
+              React's onLoad listener — so `handleImgLoad` doesn't run and the
+              crop overlay never initializes. */}
+          <img
+            key={src}
+            ref={imgRef}
+            src={src}
+            alt={alt}
+            onLoad={handleImgLoad}
+            draggable={false}
+            className="block h-full w-full"
+            style={{ objectFit: "fill" }}
+          />
+          {cropPx && imgRect && (
+            <div
+              className="absolute touch-none"
+              style={{
+                left: cropPx.x,
+                top: cropPx.y,
+                width: cropPx.size,
+                height: cropPx.size,
+                boxShadow: "0 0 0 9999px rgba(0,0,0,0.55)",
+                outline: "2px solid white",
+                cursor: "move",
+              }}
+              onPointerDown={(e) => onPointerDown(e, "pan")}
+              onPointerMove={onPointerMove}
+              onPointerUp={onPointerUp}
+              onPointerCancel={onPointerUp}
+            >
+              <CornerHandle pos="tl" onPointerDown={(e) => onPointerDown(e, "tl")} onPointerMove={onPointerMove} onPointerUp={onPointerUp} />
+              <CornerHandle pos="tr" onPointerDown={(e) => onPointerDown(e, "tr")} onPointerMove={onPointerMove} onPointerUp={onPointerUp} />
+              <CornerHandle pos="bl" onPointerDown={(e) => onPointerDown(e, "bl")} onPointerMove={onPointerMove} onPointerUp={onPointerUp} />
+              <CornerHandle pos="br" onPointerDown={(e) => onPointerDown(e, "br")} onPointerMove={onPointerMove} onPointerUp={onPointerUp} />
+            </div>
+          )}
+        </div>
+
+        {/* Live preview — circle avatar at typical sidebar size */}
+        <div className="flex shrink-0 flex-col items-center gap-2">
+          <span className="text-[0.625rem] text-[var(--muted-foreground)]">Preview</span>
+          <div className="relative h-24 w-24 overflow-hidden rounded-full bg-black/20 ring-2 ring-[var(--border)]">
+            <img src={src} alt={alt} className="h-full w-full object-cover" style={getAvatarCropStyle(previewCrop)} />
+          </div>
+        </div>
+      </div>
+
+      {showFullView && (
+        <div
+          className="fixed inset-0 z-[100] flex items-center justify-center bg-black/80"
+          onClick={() => setShowFullView(false)}
+        >
+          <img src={src} alt={alt} className="max-h-[85vh] max-w-[90vw] rounded-lg object-contain shadow-2xl" />
+          <button
+            onClick={() => setShowFullView(false)}
+            className="absolute right-3 top-3 rounded-lg bg-black/60 p-2 text-white transition-colors hover:bg-black/80"
+          >
+            <X size="1rem" />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CornerHandle({
+  pos,
+  onPointerDown,
+  onPointerMove,
+  onPointerUp,
+}: {
+  pos: "tl" | "tr" | "bl" | "br";
+  onPointerDown: (e: React.PointerEvent) => void;
+  onPointerMove: (e: React.PointerEvent) => void;
+  onPointerUp: () => void;
+}) {
+  const base: React.CSSProperties = {
+    position: "absolute",
+    width: 14,
+    height: 14,
+    background: "white",
+    border: "1px solid black",
+    borderRadius: 2,
+  };
+  const cursorByPos = { tl: "nwse-resize", tr: "nesw-resize", bl: "nesw-resize", br: "nwse-resize" } as const;
+  const positionByPos: Record<typeof pos, React.CSSProperties> = {
+    tl: { top: -8, left: -8 },
+    tr: { top: -8, right: -8 },
+    bl: { bottom: -8, left: -8 },
+    br: { bottom: -8, right: -8 },
+  };
+  return (
+    <div
+      style={{ ...base, ...positionByPos[pos], cursor: cursorByPos[pos] }}
+      onPointerDown={(e) => {
+        e.stopPropagation();
+        onPointerDown(e);
+      }}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+      onPointerCancel={onPointerUp}
+    />
+  );
+}
+
+function clamp(v: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, v));
+}
+
+function resizeCorner(
+  handle: Exclude<DragHandle, "pan">,
+  startTL: { x: number; y: number },
+  startBR: { x: number; y: number },
+  dx: number,
+  dy: number,
+  W: number,
+  H: number,
+): CropPx {
+  // Each corner anchors the OPPOSITE corner and moves freely. The square's new
+  // size is the smaller of the two distances from anchor to dragged-pointer
+  // (so the square stays inside the canvas), then clamped to canvas bounds and
+  // a minimum size.
+  if (handle === "br") {
+    const px = startBR.x + dx;
+    const py = startBR.y + dy;
+    const size = clamp(
+      Math.min(px - startTL.x, py - startTL.y),
+      MIN_CROP_PX,
+      Math.min(W - startTL.x, H - startTL.y),
+    );
+    return { x: startTL.x, y: startTL.y, size };
+  }
+  if (handle === "tl") {
+    const px = startTL.x + dx;
+    const py = startTL.y + dy;
+    const size = clamp(
+      Math.min(startBR.x - px, startBR.y - py),
+      MIN_CROP_PX,
+      Math.min(startBR.x, startBR.y),
+    );
+    return { x: startBR.x - size, y: startBR.y - size, size };
+  }
+  if (handle === "tr") {
+    const anchor = { x: startTL.x, y: startBR.y };
+    const px = startBR.x + dx;
+    const py = startTL.y + dy;
+    const size = clamp(
+      Math.min(px - anchor.x, anchor.y - py),
+      MIN_CROP_PX,
+      Math.min(W - anchor.x, anchor.y),
+    );
+    return { x: anchor.x, y: anchor.y - size, size };
+  }
+  // bl
+  const anchor = { x: startBR.x, y: startTL.y };
+  const px = startTL.x + dx;
+  const py = startBR.y + dy;
+  const size = clamp(
+    Math.min(anchor.x - px, py - anchor.y),
+    MIN_CROP_PX,
+    Math.min(anchor.x, H - anchor.y),
+  );
+  return { x: anchor.x - size, y: anchor.y, size };
+}

--- a/packages/client/src/hooks/use-background-autonomous.ts
+++ b/packages/client/src/hooks/use-background-autonomous.ts
@@ -6,6 +6,7 @@
 // The active chat's autonomous messaging is handled by ConversationView.
 
 import { useEffect, useRef } from "react";
+import type { AvatarCropValue } from "../lib/utils";
 import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { api } from "../lib/api-client";
@@ -159,7 +160,7 @@ export function useBackgroundAutonomousPolling() {
                 // Resolve character name for the notification
                 let charName = "Someone";
                 let charAvatar: string | null = null;
-                let charAvatarCrop: { zoom: number; offsetX: number; offsetY: number } | null = null;
+                let charAvatarCrop: AvatarCropValue | null = null;
                 try {
                   // Find the triggering character's name
                   const charRow = await api.get<RawCharacter>(`/characters/${characterId}`);

--- a/packages/client/src/hooks/use-characters.ts
+++ b/packages/client/src/hooks/use-characters.ts
@@ -341,6 +341,7 @@ export function useCreatePersona() {
       altDescriptions?: string;
       tags?: string;
       savedStatusOptions?: string;
+      avatarCrop?: string;
     }) => api.post("/characters/personas", data),
     onSuccess: () => qc.invalidateQueries({ queryKey: characterKeys.personas }),
   });
@@ -368,6 +369,7 @@ export function useUpdatePersona() {
       altDescriptions?: string;
       tags?: string;
       savedStatusOptions?: string;
+      avatarCrop?: string;
     }) => api.patch(`/characters/personas/${id}`, data),
     onSuccess: (updatedPersona, variables) => {
       qc.setQueryData<unknown[] | undefined>(characterKeys.personas, (old) => {

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -2,6 +2,7 @@
 // React Query: Generation (streaming + agent pipeline)
 // ──────────────────────────────────────────────
 import { useCallback } from "react";
+import type { AvatarCropValue } from "../lib/utils";
 import { useQueryClient, type InfiniteData, type QueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { api } from "../lib/api-client";
@@ -82,7 +83,7 @@ function resolveCachedCharacterIdentity(
 ): {
   name: string | null;
   avatarUrl: string | null;
-  avatarCrop?: { zoom: number; offsetX: number; offsetY: number } | null;
+  avatarCrop?: AvatarCropValue | null;
 } {
   if (!characterId) return { name: fallbackName, avatarUrl: null };
 
@@ -97,7 +98,7 @@ function resolveCachedCharacterIdentity(
     "Character";
   const avatarCrop =
     parsed && typeof parsed.extensions === "object" && parsed.extensions && "avatarCrop" in parsed.extensions
-      ? ((parsed.extensions as { avatarCrop?: { zoom: number; offsetX: number; offsetY: number } | null }).avatarCrop ??
+      ? ((parsed.extensions as { avatarCrop?: AvatarCropValue | null }).avatarCrop ??
         null)
       : null;
 
@@ -519,6 +520,7 @@ export function useGenerate() {
             backstory?: string;
             appearance?: string;
             avatarPath?: string | null;
+            avatarCrop?: string;
             nameColor?: string;
             dialogueColor?: string;
             boxColor?: string;
@@ -542,6 +544,7 @@ export function useGenerate() {
               backstory: snapshotPersona.backstory || "",
               appearance: snapshotPersona.appearance || "",
               avatarUrl: snapshotPersona.avatarPath || null,
+              avatarCrop: snapshotPersona.avatarCrop || null,
               nameColor: snapshotPersona.nameColor || null,
               dialogueColor: snapshotPersona.dialogueColor || null,
               boxColor: snapshotPersona.boxColor || null,

--- a/packages/client/src/lib/utils.ts
+++ b/packages/client/src/lib/utils.ts
@@ -67,9 +67,62 @@ export interface LegacyAvatarCrop {
   fullImage?: boolean;
 }
 
+/** Union alias for either crop shape — handy when threading a value through
+ *  type-narrow interfaces that just need "a crop, either format". */
+export type AvatarCropValue = AvatarCrop | LegacyAvatarCrop;
+
 /** Discriminator: legacy crops have `zoom`, current crops have `srcWidth`. */
 export function isLegacyAvatarCrop(c: AvatarCrop | LegacyAvatarCrop): c is LegacyAvatarCrop {
   return typeof (c as LegacyAvatarCrop).zoom === "number" && typeof (c as AvatarCrop).srcWidth !== "number";
+}
+
+/** Parses a JSON-encoded avatarCrop string (as stored on persona rows and as
+ *  emitted from extensions on character rows when serialized) with defensive
+ *  shape validation. Accepts either the current source-relative shape
+ *  (srcX/Y/W/H) or the legacy zoom+offset shape, so a malformed cell never
+ *  breaks rendering — returns null and the caller falls back to the uncropped
+ *  render. */
+export function parseAvatarCropJson(raw: string | undefined | null): AvatarCrop | LegacyAvatarCrop | null {
+  if (!raw) return null;
+  try {
+    const obj = JSON.parse(raw);
+    if (!obj || typeof obj !== "object") return null;
+    if (
+      Number.isFinite(obj.srcX) &&
+      Number.isFinite(obj.srcY) &&
+      Number.isFinite(obj.srcWidth) &&
+      Number.isFinite(obj.srcHeight) &&
+      obj.srcWidth > 0 &&
+      obj.srcHeight > 0 &&
+      obj.srcX >= 0 &&
+      obj.srcY >= 0 &&
+      obj.srcX + obj.srcWidth <= 1.001 &&
+      obj.srcY + obj.srcHeight <= 1.001
+    ) {
+      return {
+        srcX: obj.srcX,
+        srcY: obj.srcY,
+        srcWidth: obj.srcWidth,
+        srcHeight: obj.srcHeight,
+      };
+    }
+    if (
+      Number.isFinite(obj.zoom) &&
+      Number.isFinite(obj.offsetX) &&
+      Number.isFinite(obj.offsetY) &&
+      obj.zoom > 0
+    ) {
+      return {
+        zoom: obj.zoom,
+        offsetX: obj.offsetX,
+        offsetY: obj.offsetY,
+        ...(obj.fullImage ? { fullImage: true } : {}),
+      };
+    }
+  } catch {
+    /* fall through to null */
+  }
+  return null;
 }
 
 /** Returns inline styles for a cropped avatar image. Container must have

--- a/packages/client/src/lib/utils.ts
+++ b/packages/client/src/lib/utils.ts
@@ -41,21 +41,78 @@ export async function copyToClipboard(text: string): Promise<boolean> {
   }
 }
 
-/** Avatar crop data stored in character extensions. */
+/** Avatar crop — current format. A rectangular region of the source image,
+ *  expressed in coordinates normalized to the source's intrinsic dimensions. The
+ *  editor enforces a square crop in source pixels (`srcWidth * sourceW ===
+ *  srcHeight * sourceH`); the data shape itself is generic enough to allow
+ *  freeform rectangles in the future without a migration. */
 export interface AvatarCrop {
+  /** Crop top-left X, normalized to source width. Range [0, 1 - srcWidth]. */
+  srcX: number;
+  /** Crop top-left Y, normalized to source height. Range [0, 1 - srcHeight]. */
+  srcY: number;
+  /** Crop width, normalized to source width. Range (0, 1]. */
+  srcWidth: number;
+  /** Crop height, normalized to source height. Range (0, 1]. */
+  srcHeight: number;
+}
+
+/** Avatar crop — legacy format (zoom + pan offset). Render-only path so previously
+ *  saved crops display unchanged until the user re-edits them, at which point the
+ *  editor writes the current AvatarCrop format. No automatic migration on read. */
+export interface LegacyAvatarCrop {
   zoom: number;
   offsetX: number;
   offsetY: number;
+  fullImage?: boolean;
 }
 
-/** Returns inline styles for a cropped/zoomed avatar image.
- *  The parent container must have `overflow: hidden`. Defensively treats any
- *  non-legacy-shaped crop as "no crop" so foreign data (e.g. {srcX, srcY,
- *  srcWidth, srcHeight} written by a later editor that was rolled back) renders
- *  uncropped instead of producing invalid CSS. */
-export function getAvatarCropStyle(crop?: AvatarCrop | null): CSSProperties {
-  if (!crop || typeof crop.zoom !== "number" || crop.zoom <= 1) return {};
+/** Discriminator: legacy crops have `zoom`, current crops have `srcWidth`. */
+export function isLegacyAvatarCrop(c: AvatarCrop | LegacyAvatarCrop): c is LegacyAvatarCrop {
+  return typeof (c as LegacyAvatarCrop).zoom === "number" && typeof (c as AvatarCrop).srcWidth !== "number";
+}
+
+/** Returns inline styles for a cropped avatar image. Container must have
+ *  `overflow: hidden`; for current-format crops it must also have
+ *  `position: relative` (the `<img>` is rendered absolutely-positioned and sized
+ *  larger than the container so it can be panned to expose any source region).
+ *
+ *  Three modes:
+ *  - No crop: returns `{}` so the consumer's `<img>` (typically with
+ *    `object-cover` Tailwind class) renders exactly as before.
+ *  - Legacy crop: returns the historical CSS transform — preserves the old visual
+ *    so already-shipped data isn't disturbed by the data-model change.
+ *  - Current crop: positions the `<img>` so the crop rectangle maps onto the
+ *    container's full area. Works for any source aspect ratio without distorting
+ *    the image, because a square-in-source-pixels crop makes the `<img>` element
+ *    box take the source's aspect ratio, and `object-fit: fill` then fills that
+ *    box undistorted. */
+export function getAvatarCropStyle(crop?: AvatarCrop | LegacyAvatarCrop | null): CSSProperties {
+  if (!crop) return {};
+
+  if (isLegacyAvatarCrop(crop)) {
+    if (crop.fullImage) {
+      return {
+        objectFit: "contain",
+        transform: `scale(${crop.zoom}) translate(${crop.offsetX}%, ${crop.offsetY}%)`,
+      };
+    }
+    if (crop.zoom <= 1) return {};
+    return {
+      transform: `scale(${crop.zoom}) translate(${crop.offsetX}%, ${crop.offsetY}%)`,
+    };
+  }
+
+  const { srcX, srcY, srcWidth, srcHeight } = crop;
+  if (srcWidth <= 0 || srcHeight <= 0) return {};
   return {
-    transform: `scale(${crop.zoom}) translate(${crop.offsetX}%, ${crop.offsetY}%)`,
+    position: "absolute",
+    width: `${100 / srcWidth}%`,
+    height: `${100 / srcHeight}%`,
+    left: `${(-srcX / srcWidth) * 100}%`,
+    top: `${(-srcY / srcHeight) * 100}%`,
+    maxWidth: "none",
+    maxHeight: "none",
+    objectFit: "fill",
   };
 }

--- a/packages/client/src/stores/chat.store.ts
+++ b/packages/client/src/stores/chat.store.ts
@@ -2,6 +2,7 @@
 // Zustand Store: Chat Slice
 // ──────────────────────────────────────────────
 import { create } from "zustand";
+import type { AvatarCropValue } from "../lib/utils";
 import { subscribeWithSelector } from "zustand/middleware";
 import type { Chat, ChatMode, Message } from "@marinara-engine/shared";
 import { useAgentStore } from "./agent.store";
@@ -10,7 +11,7 @@ import { useGameStateStore } from "./game-state.store";
 const STORAGE_KEY = "marinara-active-chat-id";
 const DRAFTS_KEY = "marinara-input-drafts";
 
-type NotificationAvatarCrop = { zoom: number; offsetX: number; offsetY: number } | null;
+type NotificationAvatarCrop = AvatarCropValue | null;
 
 /** Read drafts from localStorage so typed input survives reloads, tab closes, and app restarts. */
 function loadDrafts(): Map<string, string> {

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -70,6 +70,7 @@ const CREATE_TABLES: string[] = [
     backstory TEXT NOT NULL DEFAULT '',
     appearance TEXT NOT NULL DEFAULT '',
     avatar_path TEXT,
+    avatar_crop TEXT NOT NULL DEFAULT '',
     is_active TEXT NOT NULL DEFAULT 'false',
     name_color TEXT NOT NULL DEFAULT '',
     dialogue_color TEXT NOT NULL DEFAULT '',
@@ -686,6 +687,11 @@ const COLUMN_MIGRATIONS: ColumnMigration[] = [
     table: "api_connections",
     column: "claude_fast_mode",
     definition: "TEXT NOT NULL DEFAULT 'false'",
+  },
+  {
+    table: "personas",
+    column: "avatar_crop",
+    definition: "TEXT NOT NULL DEFAULT ''",
   },
 ];
 

--- a/packages/server/src/db/schema/characters.ts
+++ b/packages/server/src/db/schema/characters.ts
@@ -44,6 +44,8 @@ export const personas = sqliteTable("personas", {
   backstory: text("backstory").notNull().default(""),
   appearance: text("appearance").notNull().default(""),
   avatarPath: text("avatar_path"),
+  /** Avatar zoom/position settings (JSON of { zoom, offsetX, offsetY, fullImage? }). Empty string = unset. */
+  avatarCrop: text("avatar_crop").notNull().default(""),
   isActive: text("is_active").notNull().default("false"),
   /** Name display color/gradient (CSS value) */
   nameColor: text("name_color").notNull().default(""),

--- a/packages/server/src/routes/characters.routes.ts
+++ b/packages/server/src/routes/characters.routes.ts
@@ -621,6 +621,7 @@ export async function charactersRoutes(app: FastifyInstance) {
       nameColor?: string;
       dialogueColor?: string;
       boxColor?: string;
+      avatarCrop?: string;
       createdAt?: string;
       updatedAt?: string;
       savedStatusOptions?: string;

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -732,6 +732,7 @@ export async function generateRoutes(app: FastifyInstance) {
               backstory: snapshotPersona.backstory ?? "",
               appearance: snapshotPersona.appearance ?? "",
               avatarUrl: snapshotPersona.avatarPath || null,
+              avatarCrop: snapshotPersona.avatarCrop || null,
               nameColor: snapshotPersona.nameColor || null,
               dialogueColor: snapshotPersona.dialogueColor || null,
               boxColor: snapshotPersona.boxColor || null,

--- a/packages/server/src/services/import/marinara.importer.ts
+++ b/packages/server/src/services/import/marinara.importer.ts
@@ -161,6 +161,14 @@ async function importPersona(data: unknown, db: DB) {
       nameColor: String(d.nameColor ?? ""),
       dialogueColor: String(d.dialogueColor ?? ""),
       boxColor: String(d.boxColor ?? ""),
+      // avatarCrop is stored as a JSON string in the DB; the export round-trips it
+      // as either an object or the empty string. Re-stringify objects on import.
+      avatarCrop:
+        typeof d.avatarCrop === "string"
+          ? d.avatarCrop
+          : d.avatarCrop && typeof d.avatarCrop === "object"
+            ? JSON.stringify(d.avatarCrop)
+            : "",
     },
     readTimestampOverrides(d),
   );

--- a/packages/server/src/services/storage/characters.storage.ts
+++ b/packages/server/src/services/storage/characters.storage.ts
@@ -240,6 +240,7 @@ export function createCharactersStorage(db: DB) {
         altDescriptions?: string;
         tags?: string;
         savedStatusOptions?: string;
+        avatarCrop?: string;
       },
       timestampOverrides?: TimestampOverrides | null,
     ) {
@@ -255,6 +256,7 @@ export function createCharactersStorage(db: DB) {
         backstory: extra?.backstory ?? "",
         appearance: extra?.appearance ?? "",
         avatarPath: avatarPath ?? null,
+        avatarCrop: extra?.avatarCrop ?? "",
         isActive: "false",
         nameColor: extra?.nameColor ?? "",
         dialogueColor: extra?.dialogueColor ?? "",
@@ -295,6 +297,7 @@ export function createCharactersStorage(db: DB) {
         backstory: source.backstory ?? "",
         appearance: source.appearance ?? "",
         avatarPath: source.avatarPath,
+        avatarCrop: source.avatarCrop ?? "",
         isActive: "false",
         nameColor: source.nameColor ?? "",
         dialogueColor: source.dialogueColor ?? "",
@@ -320,6 +323,7 @@ export function createCharactersStorage(db: DB) {
         backstory?: string;
         appearance?: string;
         avatarPath?: string;
+        avatarCrop?: string;
         nameColor?: string;
         dialogueColor?: string;
         boxColor?: string;
@@ -338,6 +342,7 @@ export function createCharactersStorage(db: DB) {
       if (updates.backstory !== undefined) sets.backstory = updates.backstory;
       if (updates.appearance !== undefined) sets.appearance = updates.appearance;
       if (updates.avatarPath !== undefined) sets.avatarPath = updates.avatarPath;
+      if (updates.avatarCrop !== undefined) sets.avatarCrop = updates.avatarCrop;
       if (updates.nameColor !== undefined) sets.nameColor = updates.nameColor;
       if (updates.dialogueColor !== undefined) sets.dialogueColor = updates.dialogueColor;
       if (updates.boxColor !== undefined) sets.boxColor = updates.boxColor;

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -306,6 +306,8 @@ export interface MessageExtra {
     personaId: string;
     name: string;
     avatarUrl?: string | null;
+    /** JSON-encoded AvatarCrop captured at send time so re-edits don't restyle past messages. */
+    avatarCrop?: string | null;
     nameColor?: string | null;
     dialogueColor?: string | null;
     boxColor?: string | null;

--- a/packages/shared/src/types/persona.ts
+++ b/packages/shared/src/types/persona.ts
@@ -15,6 +15,10 @@ export interface Persona {
   appearance: string;
   /** Avatar image path */
   avatarPath: string | null;
+  /** Avatar crop settings for the circle avatar. Accepts both the current
+   *  source-rectangle shape and the legacy zoom+offset shape (kept readable so
+   *  previously saved crops display unchanged until the user re-edits). */
+  avatarCrop?: PersonaAvatarCrop | LegacyPersonaAvatarCrop | null;
   /** Whether this is the currently active persona */
   isActive: boolean;
   /** Name display color/gradient (CSS value) */
@@ -33,6 +37,27 @@ export interface Persona {
   savedStatusOptions?: string[];
   createdAt: string;
   updatedAt: string;
+}
+
+/** Avatar crop — current source-rectangle format. A square region of the source
+ *  image (`srcWidth * sourceW === srcHeight * sourceH` in editor-enforced data),
+ *  expressed in coordinates normalized to the source's intrinsic dimensions.
+ *  Mirror of the client `AvatarCrop` declared in `client/src/lib/utils.ts`,
+ *  duplicated here so the shared package doesn't depend on client code. */
+export interface PersonaAvatarCrop {
+  srcX: number;
+  srcY: number;
+  srcWidth: number;
+  srcHeight: number;
+}
+
+/** Avatar crop — legacy zoom + offset format. Render-only compatibility path so
+ *  previously saved crops display unchanged until the user re-edits them. */
+export interface LegacyPersonaAvatarCrop {
+  zoom: number;
+  offsetX: number;
+  offsetY: number;
+  fullImage?: boolean;
 }
 
 /** A toggleable alternative/extended description block for a persona. */


### PR DESCRIPTION
## Linked issue

Closes #669

## Why this change

PR #661 shipped the new full-image avatar cropper and persona crop UI but explicitly deferred chat-side propagation. With #661 live, four chat surfaces rendered broken avatars on any saved new-format crop (see #665), so PR #666 reverted it. This PR re-applies #661 and lands the deferred chat-side propagation so the cropper can ship.

Verified end-to-end on a fork deployment with the four #665 surfaces all rendering clean.

## What changed

Two commits so the review can separate "re-apply" from "new work":

1. **`Revert \"Merge pull request #666...\"`** — exact `git revert -m 1` of the revert PR. Brings back PR #661 unchanged.
2. **`feat(avatar-crop): propagate new-format crop through chat surfaces`** — the deferred scope:

### Part A — data plumbing

- Widen `CharacterMap.avatarCrop` to `AvatarCrop | LegacyAvatarCrop | null` and add `PersonaInfo.avatarCrop` in `chat-area.types.ts`.
- Thread `avatarCrop` from the persona row through `ChatArea.tsx`'s `userPersonaInfo` useMemo so all chat consumers receive it.
- Snapshot `avatarCrop` on user messages (`shared` type + `server/generate.routes.ts` + `client/use-generate.ts`) so the rendered avatar matches the persona that was active when the message was sent, not the current one.
- `ChatMessage` / `ConversationMessage` now resolve a persona crop style on user messages (`msgPersona.avatarCrop` → `personaInfo.avatarCrop`, parsed via `parseAvatarCropJson`) and pass it to `getAvatarCropStyle`.
- `QuickPersonaSwitcher` and `QuickSwitcherMobile` apply the crop to both the picker rows and the active chip in the chat header.

### Refactor

- Move `parsePersonaAvatarCrop` from `PersonasPanel` into `lib/utils.ts` (renamed `parseAvatarCropJson`) since it's now used by both panel and chat.
- Introduce `AvatarCropValue = AvatarCrop | LegacyAvatarCrop` in `lib/utils.ts` and replace inline narrow `{ zoom; offsetX; offsetY }` types across 17 client files so character-side crop data can also flow in the new shape.

### Part B — container clipping

The new-format crop renders the `<img>` with `position: absolute`, so each immediate parent needs `position: relative` (in addition to the existing `overflow: hidden`). Sweeps `relative` onto 22 parents covering:

- Chat surfaces — `ChatInput`, `ChatMessage` (compact + RP single-avatar variants), `ChatSettingsDrawer` (4 sites), `ChatSetupWizard`, `ConversationInput`, `ConversationMessage` (chat bubble + segment-level bubble), `ConversationView` (2 sites), `ExpressionPanel` (2 sites), `QuickPersonaSwitcher` active chip, `RecentChats`.
- Game-mode widgets — `GameCharacterSheet`, `GamePartyBar`, `GamePartySidebar` (3 sites), `GameSetupWizard`.
- Layout — `ChatSidebar`.

Where the original parent had siblings needing to render outside the avatar bounds (e.g. active-indicator dots), the `QuickPersonaSwitcher` picker rows use the same inner-wrapper pattern PR #661 already applied to the persona panel.

No data migration; legacy crops keep rendering via the legacy CSS transform path.

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Manually verify a character with a new-format `avatarCrop` (e.g. a tall portrait re-cropped via the editor): RP scene top character avatar renders the chosen framing, no stripey artifacts at container edges (was #665 surface 1).
- Manually verify a persona with a saved new-format crop, in a Conversation-mode chat: the persona avatar next to "You" message bubbles shows the full cropped face, not a vertical sliver (was #665 surface 2).
- Manually verify a character with a saved new-format crop, in a Conversation-mode chat: the character avatar next to its message bubble shows the cropped circle, not a giant horizontal banner across the chat (was #665 surface 3).
- Manually verify the `QuickPersonaSwitcher` chip in the chat header and its dropdown picker rows: active persona avatar renders centered, picker rows render correctly (was #665 surface 4).
- Manually verify `QuickSwitcherMobile` (narrow viewport / mobile DPI) — same persona rows render correctly.
- Manually verify pre-existing surfaces from PR #661 still work — Persona panel main rows + group member tiles, RP chat list sidebar, RP chat top header.
- Manually verify legacy `{ zoom, offsetX, offsetY }` crops still render unchanged (slider-era data on existing characters). Legacy CSS transform path is preserved.
- Manually verify a character with no `avatarCrop` extension at all renders identically to before (uncropped `object-cover`).
- Manually verify game-mode party widgets — `GamePartyBar` and `GamePartySidebar` member tiles, `GameCharacterSheet` portrait — render cropped avatars cleanly.

## Docs and release impact

- [x] No docs changes needed (CHANGELOG entry from #661 is restored by the revert-of-revert commit)
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

Behavioral fix; the editor-side UX is unchanged from PR #661 (already screenshotted there). Chat-side surfaces now render cropped avatars cleanly instead of the four #665 failure modes.