### PR TITLE
Fix OpenAI ChatGPT chatComplete SSE parsing

### DIFF
--- a/packages/server/src/services/llm/providers/openai.provider.ts
+++ b/packages/server/src/services/llm/providers/openai.provider.ts
@@ -1299,7 +1299,7 @@ export class OpenAIProvider extends BaseLLMProvider {
     }
 
     const openrouterProvider = this.resolveOpenrouterProvider(options.openrouterProvider);
-    if (this.shouldApplyOpenRouterProviderOverride(openrouterProvider)) {
+    if (!isOpenAIChatGPT && this.shouldApplyOpenRouterProviderOverride(openrouterProvider)) {
       body.provider = { order: [openrouterProvider] };
     }
 
@@ -1514,7 +1514,8 @@ export class OpenAIProvider extends BaseLLMProvider {
    */
   private async chatCompleteResponses(messages: ChatMessage[], options: ChatOptions): Promise<ChatCompletionResult> {
     const url = `${this.baseUrl}/responses`;
-    const useStream = options.stream ?? !!options.onToken;
+    const callerWantsStream = options.stream ?? !!options.onToken;
+    const useStream = this.isOpenAIChatGPTProvider() || callerWantsStream;
     const body = this.buildResponsesBody(messages, { ...options, stream: useStream });
     logger.debug(
       "[OpenAI chatCompleteResponses] reasoning=%s onThinking=%s",

--- a/packages/server/test/openai-provider-reasoning.test.ts
+++ b/packages/server/test/openai-provider-reasoning.test.ts
@@ -645,6 +645,54 @@ test("OpenAI ChatGPT responses requests omit unsupported Codex parameters", () =
   assert.equal("text" in body, false);
 });
 
+test("OpenAI ChatGPT chatComplete decodes SSE when caller requests non-streaming", async () => {
+  const requests: Array<Record<string, unknown>> = [];
+  const originalFetch = globalThis.fetch;
+  const originalLocalUrls = process.env.PROVIDER_LOCAL_URLS_ENABLED;
+
+  globalThis.fetch = async (_input: string | URL | Request, init?: RequestInit) => {
+    requests.push(JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>);
+    return new Response(
+      [
+        'data: {"type":"response.output_text.delta","delta":"hel"}',
+        'data: {"type":"response.output_text.delta","delta":"lo"}',
+        'data: {"type":"response.completed","response":{"status":"completed","output":[{"type":"message","content":[{"type":"output_text","text":"hello"}]}]}}',
+        "data: [DONE]",
+        "",
+      ].join("\n"),
+      { status: 200, headers: { "Content-Type": "text/event-stream" } },
+    );
+  };
+
+  try {
+    process.env.PROVIDER_LOCAL_URLS_ENABLED = "true";
+    const provider = new OpenAIProvider(
+      "https://chatgpt.com/backend-api/codex",
+      "test-key",
+      undefined,
+      null,
+      null,
+      "openai-chatgpt",
+    );
+    const result = await provider.chatComplete([{ role: "user", content: "Hi" }], {
+      model: "gpt-5.2",
+      stream: false,
+      maxTokens: 128,
+    });
+
+    assert.equal(result.content, "hello");
+    assert.equal(requests.length, 1);
+    assert.equal(requests[0]!.stream, true);
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (originalLocalUrls === undefined) {
+      delete process.env.PROVIDER_LOCAL_URLS_ENABLED;
+    } else {
+      process.env.PROVIDER_LOCAL_URLS_ENABLED = originalLocalUrls;
+    }
+  }
+});
+
 test("responses requests translate responseFormat to text.format", () => {
   const provider = new OpenAIProvider("https://example.com/v1", "test-key") as any;
   const body = provider.buildResponsesBody([{ role: "user", content: "Return JSON." }], {


### PR DESCRIPTION
## Linked issue

Follow-up to #670 after review feedback on the merged OpenAI (ChatGPT) provider fix.

## Why this change

- #670 fixed the OpenAI (ChatGPT) request shape by forcing ChatGPT/Codex Responses requests to stream.
- The `chatCompleteResponses()` path still used the caller's `stream:false` preference to choose the non-streaming JSON parser.
- That left non-streaming `chatComplete()` calls able to receive SSE from Codex but parse it as JSON.

## What changed

- Forces `chatCompleteResponses()` to parse OpenAI (ChatGPT) Responses results as SSE even when the caller requested non-streaming output.
- Adds a defensive `!isOpenAIChatGPT` guard around the Responses OpenRouter provider override.
- Adds a regression test that stubs a multi-event SSE response and verifies `chatComplete(... stream:false ...)` decodes the full text.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Focused regression passed: `pnpm exec tsx --import ./test/setup-env.ts --test --test-name-pattern "OpenAI ChatGPT chatComplete decodes SSE when caller requests non-streaming" test/openai-provider-reasoning.test.ts`.
- Baseline validation passed: `pnpm check`.
- Diff hygiene passed: `git diff --check`.
- Server logging hygiene passed: `rg -n "console\\." packages/server/src/services/llm/providers/openai.provider.ts` found no console statements.
- No UI/manual browser verification is applicable; this is a backend provider response parsing fix.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs, schema, dependency, version, or release metadata changes.

## UI evidence (if applicable)

N/A - backend provider response parsing fix.
