### PR TITLE
fix(avatar-crop): use focal-point object-position on RP rectangle and glued-panel avatars

### DIFF
--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -1,7 +1,14 @@
 // ──────────────────────────────────────────────
 // Chat: Message — mode-aware rendering
 // ──────────────────────────────────────────────
-import { cn, copyToClipboard, getAvatarCropStyle, parseAvatarCropJson, type AvatarCropValue } from "../../lib/utils";
+import {
+  cn,
+  copyToClipboard,
+  getAvatarCropStyle,
+  isLegacyAvatarCrop,
+  parseAvatarCropJson,
+  type AvatarCropValue,
+} from "../../lib/utils";
 import { applyInlineMarkdown, renderMarkdownBlocks, applyInlineMarkdownHTML } from "../../lib/markdown";
 import {
   User,
@@ -1134,6 +1141,40 @@ export const ChatMessage = memo(function ChatMessage({
   const compactAvatarFrameClass = useCompactRectangleAvatar
     ? "h-[calc(3.5rem*var(--roleplay-avatar-scale))] w-[calc(2.75rem*var(--roleplay-avatar-scale))] rounded-xl"
     : "h-[calc(2.5rem*var(--roleplay-avatar-scale))] w-[calc(2.5rem*var(--roleplay-avatar-scale))] rounded-full";
+  // RP rectangle avatars (compact "rectangles" style and the larger glued
+  // panel) can't apply the new source-rectangle crop format directly — that
+  // format renders the <img> with position: absolute and non-aspect-preserving
+  // width/height, which stretches when forced into a rectangle whose aspect
+  // ratio differs from the (square) crop. Instead, convert the new-format
+  // crop into an `object-position` focal point so `object-cover` still fills
+  // the rectangle without distortion, but centered on the user's chosen face.
+  // Legacy {zoom, offsetX, offsetY} crops compose fine with object-cover
+  // (they're a CSS transform) so they pass through unchanged.
+  const rectangleSafeCropStyle = (
+    crop: AvatarCropValue | null | undefined,
+    fallback: React.CSSProperties,
+  ): React.CSSProperties => {
+    if (!crop) return fallback;
+    if (isLegacyAvatarCrop(crop)) return fallback;
+    const centerX = crop.srcX + crop.srcWidth / 2;
+    const centerY = crop.srcY + crop.srcHeight / 2;
+    return {
+      objectPosition: `${(centerX * 100).toFixed(2)}% ${(centerY * 100).toFixed(2)}%`,
+    };
+  };
+  const compactAvatarCrop: AvatarCropValue | null = isUser
+    ? (personaAvatarCrop ?? null)
+    : (charInfo?.avatarCrop ?? null);
+  const compactAvatarCropStyle: React.CSSProperties = useCompactRectangleAvatar
+    ? rectangleSafeCropStyle(compactAvatarCrop, avatarCropStyle)
+    : avatarCropStyle;
+  const compactMergedAvatarCropStyle = (avatar: { crop?: AvatarCropValue | null }): React.CSSProperties =>
+    useCompactRectangleAvatar
+      ? rectangleSafeCropStyle(avatar.crop, getAvatarCropStyle(avatar.crop))
+      : getAvatarCropStyle(avatar.crop);
+  const panelAvatarCropStyle: React.CSSProperties = rectangleSafeCropStyle(compactAvatarCrop, avatarCropStyle);
+  const panelMergedAvatarCropStyle = (avatar: { crop?: AvatarCropValue | null }): React.CSSProperties =>
+    rectangleSafeCropStyle(avatar.crop, getAvatarCropStyle(avatar.crop));
   const compactAvatarSpacerClass = useCompactRectangleAvatar
     ? "w-[calc(2.75rem*var(--roleplay-avatar-scale))]"
     : "w-[calc(2.5rem*var(--roleplay-avatar-scale))]";
@@ -1156,7 +1197,7 @@ export const ChatMessage = memo(function ChatMessage({
             loading="lazy"
             decoding="async"
             className="rpg-avatar-panel-tail-image absolute inset-0 h-full w-full object-cover object-top transition-opacity duration-700"
-            style={{ opacity: i === 0 ? 1 : 0, ...getAvatarCropStyle(avatar.crop) }}
+            style={{ opacity: i === 0 ? 1 : 0, ...panelMergedAvatarCropStyle(avatar) }}
           />
         ))}
       </div>
@@ -1169,7 +1210,7 @@ export const ChatMessage = memo(function ChatMessage({
           loading="lazy"
           decoding="async"
           className="rpg-avatar-panel-tail-image absolute inset-0 h-full w-full object-cover object-top"
-          style={avatarCropStyle}
+          style={panelAvatarCropStyle}
         />
       </div>
     ) : null
@@ -1377,7 +1418,7 @@ export const ChatMessage = memo(function ChatMessage({
                       loading="lazy"
                       decoding="async"
                       className="absolute inset-0 h-full w-full object-cover transition-opacity duration-700"
-                      style={{ opacity: i === 0 ? 1 : 0, ...getAvatarCropStyle(avatar.crop) }}
+                      style={{ opacity: i === 0 ? 1 : 0, ...compactMergedAvatarCropStyle(avatar) }}
                     />
                   ))}
                 </button>
@@ -1395,7 +1436,7 @@ export const ChatMessage = memo(function ChatMessage({
                       loading="lazy"
                       decoding="async"
                       className="h-full w-full object-cover"
-                      style={avatarCropStyle}
+                      style={compactAvatarCropStyle}
                     />
                   </button>
                 </div>
@@ -1518,7 +1559,7 @@ export const ChatMessage = memo(function ChatMessage({
                               loading="lazy"
                               decoding="async"
                               className="absolute inset-0 h-full w-full object-cover object-top transition-opacity duration-700"
-                              style={{ opacity: i === 0 ? 1 : 0, ...getAvatarCropStyle(avatar.crop) }}
+                              style={{ opacity: i === 0 ? 1 : 0, ...panelMergedAvatarCropStyle(avatar) }}
                             />
                           ))}
                         </button>
@@ -1538,7 +1579,7 @@ export const ChatMessage = memo(function ChatMessage({
                             loading="lazy"
                             decoding="async"
                             className="h-full w-full object-cover object-top"
-                            style={avatarCropStyle}
+                            style={panelAvatarCropStyle}
                           />
                         </button>
                       ) : (


### PR DESCRIPTION
## Linked issue

Closes #673

## Why this change

PR #671 propagated the new source-rectangle avatar crop format through chat-side render sites. The format renders the `<img>` with `position: absolute`, `width: 100/srcWidth%`, `height: 100/srcHeight%`, and `object-fit: fill` — math that assumes the parent has the same aspect ratio as the (editor-enforced-square) crop.

For RP-mode rectangular sites — "Small Rectangles" compact style and "Glued Side Panel" — the parent is non-square. `object-fit: fill` then stretched the cropped face to the rectangle's aspect ratio. Symptoms (visible only when the user has saved a new-format avatar crop):

- Glued Side Panel: face squished horizontally or vertically depending on bubble height.
- Small Rectangles: face squished vertically.
- Short user messages in Glued Side Panel: the panel renders as a wide rectangle and `object-cover object-top` showed only the top of the source (e.g. just the character's hair).

## What changed

In `packages/client/src/components/chat/ChatMessage.tsx`:

- Add a `rectangleSafeCropStyle(crop, fallback)` helper that returns:
  - **Legacy** `{zoom, offsetX, offsetY}` crops → the fallback (unchanged transform-based path; composes with `object-cover`).
  - **New-format** crops → `{ objectPosition: 'X% Y%' }` derived from the crop's center, so `object-cover` keeps the user's chosen focal point centered in the rectangle.
- Derive five styles from that helper:
  - `compactAvatarCropStyle` and `compactMergedAvatarCropStyle(avatar)` for `compactAvatarFrameClass` sites (gated on `useCompactRectangleAvatar` — the round Small Circles variant still uses the unmodified `avatarCropStyle`).
  - `panelAvatarCropStyle` and `panelMergedAvatarCropStyle(avatar)` for `rpg-avatar-panel-tail-image` and `rpg-avatar-panel-media` (always-rectangular sites).
- Wire those into the six `<img>` sites in the file:
  - `rpg-avatar-panel-tail` single + merged (lines ~1146–1175).
  - `compactAvatarFrameClass` single + merged (lines ~1355–1400).
  - `rpg-avatar-panel-media` single + merged (lines ~1499–1542).

Round/square frames (Small Circles compact style + Conversation Mode bubble `h-8 w-8 rounded-full`) continue to use the unchanged `avatarCropStyle`, which is PR #661's original logic — correct when parent matches crop aspect ratio.

No data migration. Existing crops (both formats) render correctly without re-editing.

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Manually verify a character with a new-format `avatarCrop` saved (square crop region of a non-square source) in **Small Rectangles** style: the side avatar tile renders the chosen face centered, no horizontal/vertical squish.
- Manually verify the same character in **Glued Side Panel** style on both tall messages and short messages: the panel renders the face centered, no distortion, and short user-message panels (wide rectangles) center on the face instead of showing only the top of the source.
- Manually verify a character with a **legacy** `{zoom, offsetX, offsetY}` crop renders identically to before in all three RP avatar styles — the customization should still apply via the unchanged transform path.
- Manually verify **Small Circles** style and **Conversation Mode** chat bubbles still render new-format crops correctly with the unchanged PR #661 path (parent matches crop aspect ratio, no regression).
- Manually verify a character with **no** `avatarCrop` extension renders identically to before in all styles (the helper returns the fallback unchanged for `null` crops).
- Manually verify the user-side bubble in **Conversation Mode** still applies the persona crop on the round avatar (the persona-crop snapshot path from PR #671 is untouched).

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

Behavioral fix; the bug surface is identical to #673's repro steps. After: rectangles render the chosen face centered; no stretching, no banner-bleed on short messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved avatar image rendering to preserve aspect ratios and prevent stretching when using the latest avatar crop format.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/674)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->