### PR TITLE
fix(avatar-crop): bypass new-format crops on RP rectangle avatars

### DIFF
--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -1145,9 +1145,12 @@ export const ChatMessage = memo(function ChatMessage({
   // panel) can't apply the new source-rectangle crop format directly — that
   // format renders the <img> with position: absolute and non-aspect-preserving
   // width/height, which stretches when forced into a rectangle whose aspect
-  // ratio differs from the (square) crop. Instead, convert the new-format
-  // crop into an `object-position` focal point so `object-cover` still fills
-  // the rectangle without distortion, but centered on the user's chosen face.
+  // ratio differs from the (square) crop. Bypass the crop entirely for new
+  // format so the <img>'s className (object-cover [object-top]) governs.
+  // A previous attempt mapped the crop center to `object-position`, but on a
+  // short message the glued panel becomes a wide rectangle — `object-cover`
+  // against a tall source then crops the top off and 50%/50% (or any centered
+  // focal point on a top-of-source face) lands on chin/chest instead of face.
   // Legacy {zoom, offsetX, offsetY} crops compose fine with object-cover
   // (they're a CSS transform) so they pass through unchanged.
   const rectangleSafeCropStyle = (
@@ -1156,11 +1159,7 @@ export const ChatMessage = memo(function ChatMessage({
   ): React.CSSProperties => {
     if (!crop) return fallback;
     if (isLegacyAvatarCrop(crop)) return fallback;
-    const centerX = crop.srcX + crop.srcWidth / 2;
-    const centerY = crop.srcY + crop.srcHeight / 2;
-    return {
-      objectPosition: `${(centerX * 100).toFixed(2)}% ${(centerY * 100).toFixed(2)}%`,
-    };
+    return {};
   };
   const compactAvatarCrop: AvatarCropValue | null = isUser
     ? (personaAvatarCrop ?? null)


### PR DESCRIPTION
## Linked issue

Closes #675

## Why this change

PR #674 mapped the new-format avatar crop center to `object-position` on RP rectangle sites (compact "rectangles" style and the glued side panel). On a SHORT user message the glued panel becomes a wide rectangle, and `object-cover` of a tall portrait into a wide rectangle then crops the top off — any centered focal point (50%/50% for a face at top-of-source) lands on chin/chest instead of the face.

Reported in #675 as a follow-up regression to PR #674.

## What changed

- `packages/client/src/components/chat/ChatMessage.tsx` — `rectangleSafeCropStyle` now returns `{}` for new-format crops on RP rectangle sites instead of computing an `objectPosition`. This lets the `<img>`'s existing className (`object-cover [object-top]`) govern, which is the pre-PR #674 baseline that handled the short-message wide-rectangle case correctly.
- Legacy `{zoom, offsetX, offsetY}` crops still pass through unchanged (they compose with `object-cover` as a CSS transform).
- The `rectangleSafeCropStyle` helper indirection is kept so the legacy passthrough remains correct on rectangle sites.

This is a partial revert of PR #674 — only the new-format branch reverts; the legacy passthrough that PR #674 also covered is preserved.

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Manually verify a short user message (e.g. `test`) with a persona that has a saved new-format `avatarCrop` whose subject is at the top of the source — in **Glued Side Panel** mode, the panel should show the persona's face/head, not chin/chest. Spot-check the same with **Small Rectangles** compact style.
- Manually verify a longer assistant message in **Glued Side Panel** with a character avatar — the panel is now tall and should still render the face/upper body without distortion (parity with pre-PR-#674 behavior on tall panels).
- Manually verify a character or persona with a legacy `{zoom, offsetX, offsetY}` crop — the transform should still apply on rectangles (this PR does not change the legacy path).

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

Reporter screenshot in #675 shows the pre-fix Glued Side Panel cutting off the face on a short user message ("Oh right, the ritual…what's the ritual?"). Post-fix, the panel uses `object-cover object-top` on the raw source, restoring the head/face visibility.