### PR TITLE
fix(spotify): unbreak Game Mode playlist source on Development Mode apps

### DIFF
--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -416,9 +416,9 @@ export function ChatSettingsDrawer({
   const spotifyPlaylistsQuery = useQuery({
     queryKey: ["spotify", "playlists", 50],
     queryFn: () =>
-      api.get<{ playlists: Array<{ id: string; name: string; uri: string; trackCount: number }> }>(
-        "/spotify/playlists?limit=50",
-      ),
+      api.get<{
+        playlists: Array<{ id: string; name: string; uri: string; trackCount: number | null; owned: boolean }>;
+      }>("/spotify/playlists?limit=50"),
     enabled: open && isGame && gameUseSpotifyMusic && gameSpotifySourceType === "playlist",
     staleTime: 60_000,
     retry: false,
@@ -3674,11 +3674,20 @@ export function ChatSettingsDrawer({
                                 className="w-full rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-2.5 py-1.5 text-xs text-[var(--foreground)]"
                               >
                                 <option value="">Choose playlist...</option>
-                                {spotifyPlaylistsQuery.data.playlists.map((playlist) => (
-                                  <option key={playlist.id} value={playlist.id}>
-                                    {playlist.name} ({playlist.trackCount})
-                                  </option>
-                                ))}
+                                {spotifyPlaylistsQuery.data.playlists.map((playlist) => {
+                                  const suffix =
+                                    typeof playlist.trackCount === "number"
+                                      ? ` (${playlist.trackCount})`
+                                      : playlist.owned
+                                        ? ""
+                                        : " (followed — unavailable)";
+                                  return (
+                                    <option key={playlist.id} value={playlist.id}>
+                                      {playlist.name}
+                                      {suffix}
+                                    </option>
+                                  );
+                                })}
                               </select>
                             ) : (
                               <input

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -417,7 +417,13 @@ export function ChatSettingsDrawer({
     queryKey: ["spotify", "playlists", 50],
     queryFn: () =>
       api.get<{
-        playlists: Array<{ id: string; name: string; uri: string; trackCount: number | null; owned: boolean }>;
+        playlists: Array<{
+          id: string;
+          name: string;
+          uri: string;
+          trackCount: number | null;
+          owned: boolean | null;
+        }>;
       }>("/spotify/playlists?limit=50"),
     enabled: open && isGame && gameUseSpotifyMusic && gameSpotifySourceType === "playlist",
     staleTime: 60_000,
@@ -3678,9 +3684,9 @@ export function ChatSettingsDrawer({
                                   const suffix =
                                     typeof playlist.trackCount === "number"
                                       ? ` (${playlist.trackCount})`
-                                      : playlist.owned
-                                        ? ""
-                                        : " (followed — unavailable)";
+                                      : playlist.owned === false
+                                        ? " (followed — unavailable)"
+                                        : "";
                                   return (
                                     <option key={playlist.id} value={playlist.id}>
                                       {playlist.name}

--- a/packages/client/src/components/game/GameSetupWizard.tsx
+++ b/packages/client/src/components/game/GameSetupWizard.tsx
@@ -325,9 +325,9 @@ export function GameSetupWizard({ onComplete, onCancel, isLoading, characters }:
   const spotifyPlaylistsQuery = useQuery({
     queryKey: ["spotify", "playlists", 50],
     queryFn: () =>
-      api.get<{ playlists: Array<{ id: string; name: string; uri: string; trackCount: number }> }>(
-        "/spotify/playlists?limit=50",
-      ),
+      api.get<{
+        playlists: Array<{ id: string; name: string; uri: string; trackCount: number | null; owned: boolean }>;
+      }>("/spotify/playlists?limit=50"),
     enabled: enableSpotifyDj && gameSpotifySourceType === "playlist",
     staleTime: 60_000,
     retry: false,
@@ -1293,11 +1293,20 @@ export function GameSetupWizard({ onComplete, onCancel, isLoading, characters }:
                               className="w-full rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-2.5 py-1.5 text-xs text-[var(--foreground)]"
                             >
                               <option value="">Choose playlist...</option>
-                              {spotifyPlaylistsQuery.data.playlists.map((playlist) => (
-                                <option key={playlist.id} value={playlist.id}>
-                                  {playlist.name} ({playlist.trackCount})
-                                </option>
-                              ))}
+                              {spotifyPlaylistsQuery.data.playlists.map((playlist) => {
+                                const suffix =
+                                  typeof playlist.trackCount === "number"
+                                    ? ` (${playlist.trackCount})`
+                                    : playlist.owned
+                                      ? ""
+                                      : " (followed — unavailable)";
+                                return (
+                                  <option key={playlist.id} value={playlist.id}>
+                                    {playlist.name}
+                                    {suffix}
+                                  </option>
+                                );
+                              })}
                             </select>
                           ) : (
                             <input

--- a/packages/client/src/components/game/GameSetupWizard.tsx
+++ b/packages/client/src/components/game/GameSetupWizard.tsx
@@ -326,7 +326,13 @@ export function GameSetupWizard({ onComplete, onCancel, isLoading, characters }:
     queryKey: ["spotify", "playlists", 50],
     queryFn: () =>
       api.get<{
-        playlists: Array<{ id: string; name: string; uri: string; trackCount: number | null; owned: boolean }>;
+        playlists: Array<{
+          id: string;
+          name: string;
+          uri: string;
+          trackCount: number | null;
+          owned: boolean | null;
+        }>;
       }>("/spotify/playlists?limit=50"),
     enabled: enableSpotifyDj && gameSpotifySourceType === "playlist",
     staleTime: 60_000,
@@ -1297,9 +1303,9 @@ export function GameSetupWizard({ onComplete, onCancel, isLoading, characters }:
                                 const suffix =
                                   typeof playlist.trackCount === "number"
                                     ? ` (${playlist.trackCount})`
-                                    : playlist.owned
-                                      ? ""
-                                      : " (followed — unavailable)";
+                                    : playlist.owned === false
+                                      ? " (followed — unavailable)"
+                                      : "";
                                 return (
                                   <option key={playlist.id} value={playlist.id}>
                                     {playlist.name}

--- a/packages/server/src/routes/spotify-auth.routes.ts
+++ b/packages/server/src/routes/spotify-auth.routes.ts
@@ -506,16 +506,48 @@ export async function spotifyAuthRoutes(app: FastifyInstance) {
       return reply.status(res.status).send({ error: await readSpotifyError(res, "Spotify playlists failed") });
     }
     const data = (await res.json()) as {
-      items?: Array<{ id?: string; name?: string; uri?: string; tracks?: { total?: number } }>;
+      items?: Array<{
+        id?: string;
+        name?: string;
+        uri?: string;
+        tracks?: { total?: number };
+        owner?: { id?: string };
+      }>;
     };
-    return {
-      playlists: (data.items ?? []).map((playlist) => ({
-        id: playlist.id ?? "",
-        name: playlist.name ?? "Untitled playlist",
-        uri: playlist.uri ?? "",
-        trackCount: playlist.tracks?.total ?? 0,
-      })),
-    };
+
+    // Spotify strips `tracks.total` from /me/playlists for Development Mode
+    // apps. Look up real counts by hitting /playlists/{id}/items?limit=1 in
+    // parallel for playlists owned by the connected user (followed playlists
+    // 403 and stay unknown). Falls back gracefully if Spotify changes its mind.
+    const meRes = await fetchSpotifyApi(credentials, "/me").catch(() => null);
+    const myId = meRes && meRes.ok ? ((await meRes.json()) as { id?: string }).id : null;
+
+    const playlists = await Promise.all(
+      (data.items ?? []).map(async (playlist) => {
+        const reported = playlist.tracks?.total;
+        const owned = !!myId && playlist.owner?.id === myId;
+        let trackCount: number | null = typeof reported === "number" ? reported : null;
+        if (trackCount === null && owned && playlist.id) {
+          const itemsRes = await fetchSpotifyApi(
+            credentials,
+            `/playlists/${encodeURIComponent(playlist.id)}/items?limit=1`,
+          ).catch(() => null);
+          if (itemsRes && itemsRes.ok) {
+            const itemsData = (await itemsRes.json().catch(() => null)) as { total?: number } | null;
+            if (typeof itemsData?.total === "number") trackCount = itemsData.total;
+          }
+        }
+        return {
+          id: playlist.id ?? "",
+          name: playlist.name ?? "Untitled playlist",
+          uri: playlist.uri ?? "",
+          trackCount,
+          owned,
+        };
+      }),
+    );
+
+    return { playlists };
   });
 
   app.post<{ Body: { agentId?: string; deviceId?: string | null } }>("/dj-mari-playlist", async (req, reply) => {

--- a/packages/server/src/routes/spotify-auth.routes.ts
+++ b/packages/server/src/routes/spotify-auth.routes.ts
@@ -519,15 +519,24 @@ export async function spotifyAuthRoutes(app: FastifyInstance) {
     // apps. Look up real counts by hitting /playlists/{id}/items?limit=1 in
     // parallel for playlists owned by the connected user (followed playlists
     // 403 and stay unknown). Falls back gracefully if Spotify changes its mind.
-    const meRes = await fetchSpotifyApi(credentials, "/me").catch(() => null);
+    const meRes = await fetchSpotifyApi(credentials, "/me").catch((err) => {
+      logger.warn(err, "Spotify /me lookup failed while resolving playlist ownership");
+      return null;
+    });
     const myId = meRes && meRes.ok ? ((await meRes.json()) as { id?: string }).id : null;
+    if (!myId) {
+      logger.warn("Could not resolve Spotify user id; playlist ownership will be unknown");
+    }
 
     const playlists = await Promise.all(
       (data.items ?? []).map(async (playlist) => {
         const reported = playlist.tracks?.total;
-        const owned = !!myId && playlist.owner?.id === myId;
+        // Tri-state: true (owned), false (followed), null (unknown — e.g. /me lookup failed).
+        // Null prevents the client from mislabeling owned playlists as "followed — unavailable"
+        // when /me transiently fails.
+        const owned: boolean | null = myId ? playlist.owner?.id === myId : null;
         let trackCount: number | null = typeof reported === "number" ? reported : null;
-        if (trackCount === null && owned && playlist.id) {
+        if (trackCount === null && owned === true && playlist.id) {
           const itemsRes = await fetchSpotifyApi(
             credentials,
             `/playlists/${encodeURIComponent(playlist.id)}/items?limit=1`,

--- a/packages/server/src/services/spotify/game-spotify-music.service.ts
+++ b/packages/server/src/services/spotify/game-spotify-music.service.ts
@@ -290,15 +290,23 @@ function pruneSpotifyTrackCache() {
   }
 }
 
+// /me/tracks wraps each track under `.track`, while /playlists/{id}/items wraps
+// it under `.item` (the singular field, because an item may also be a podcast
+// episode). Accept either shape so the same mapper covers both endpoints.
+type SpotifyTrackInner = {
+  uri?: string;
+  name?: string;
+  artists?: Array<{ name?: string }>;
+  album?: { name?: string };
+};
+
 function mapSpotifyTrackItems(
-  items: Array<{
-    track?: { uri?: string; name?: string; artists?: Array<{ name?: string }>; album?: { name?: string } } | null;
-  }>,
+  items: Array<{ track?: SpotifyTrackInner | null; item?: SpotifyTrackInner | null }>,
   offset: number,
 ): SceneSpotifyTrackCandidate[] {
   return items
     .map((item, index): SceneSpotifyTrackCandidate | null => {
-      const track = item.track;
+      const track = item.track ?? item.item;
       if (!track?.uri?.startsWith("spotify:track:")) return null;
       return {
         uri: track.uri,
@@ -355,9 +363,7 @@ async function fetchSpotifyTrackIndex(
     }
 
     const data = (await res.json()) as {
-      items?: Array<{
-        track?: { uri?: string; name?: string; artists?: Array<{ name?: string }>; album?: { name?: string } } | null;
-      }>;
+      items?: Array<{ track?: SpotifyTrackInner | null; item?: SpotifyTrackInner | null }>;
       total?: number;
       next?: string | null;
     };

--- a/packages/server/src/services/spotify/game-spotify-music.service.ts
+++ b/packages/server/src/services/spotify/game-spotify-music.service.ts
@@ -333,12 +333,23 @@ async function fetchSpotifyTrackIndex(
 
   while (offset < SPOTIFY_TRACK_INDEX_MAX_TRACKS) {
     const pageSize = Math.min(batchSize, SPOTIFY_TRACK_INDEX_MAX_TRACKS - offset);
+    // Use /playlists/{id}/items (the supported endpoint) rather than the deprecated
+    // /tracks variant. After Spotify's 2026-03 Web API migration, /tracks returns
+    // 403 for Development Mode apps and only the /items path works.
     const endpoint =
       sourceKey === "liked"
         ? `/me/tracks?${new URLSearchParams({ limit: String(pageSize), offset: String(offset) })}`
-        : `/playlists/${encodeURIComponent(sourceKey)}/tracks?${new URLSearchParams({ limit: String(pageSize), offset: String(offset) })}`;
+        : `/playlists/${encodeURIComponent(sourceKey)}/items?${new URLSearchParams({ limit: String(pageSize), offset: String(offset) })}`;
     const res = await fetchSpotifyApi(credentials, endpoint, { signal: AbortSignal.timeout(15_000) });
     if (!res.ok) {
+      // Development Mode apps without Extended Quota can only read playlists owned
+      // by the connected Spotify user; followed/editorial playlists 403.
+      if (res.status === 403 && sourceKey !== "liked") {
+        spotifyError(
+          403,
+          "Spotify denied access to this playlist's contents. Spotify only allows reading playlists owned by the connected account; followed or editorial playlists are blocked for Development Mode apps. Pick a playlist you own, switch to Liked Songs, or use Any Spotify.",
+        );
+      }
       const body = await res.text();
       spotifyError(res.status, `Spotify track index failed (${res.status}): ${body.slice(0, 200)}`);
     }


### PR DESCRIPTION
## Linked issue

Closes #680

## Why this change

After Spotify's 2026-03 Web API migration, Game Mode's `playlist` source is completely broken for every Spotify Developer app in Development Mode (i.e. anyone who hasn't been granted Extended Quota Mode — which now requires 250k+ MAUs and so excludes essentially all self-hosted / hobby installs). Two distinct breaks:

1. **Playback path** — server hits `/playlists/{id}/tracks` (deprecated). Spotify 403s every call, even for playlists the connected user owns. Scene music never plays from any playlist.
2. **Selection path** — dropdown reads `playlist.tracks.total` from `/me/playlists`, but Spotify strips the `tracks` field entirely from those items under Dev Mode. Every playlist renders as `Playlist Name (0)`, leaving users unable to tell which playlist has content and which is empty — or even that the data is unreliable.

The end-to-end effect: a user on a fresh Spotify dev app sees a dropdown of `(0)` playlists, picks one anyway, and gets a generic failure toast. There is no diagnostic visible to the user — the actual cause (Spotify policy) is invisible.

## What changed

Server (`packages/server/src/services/spotify/game-spotify-music.service.ts`)
- Switched `fetchSpotifyTrackIndex` from `/playlists/{id}/tracks` to `/playlists/{id}/items`. The replacement endpoint is the supported one and serves content for playlists owned by the connected user under Development Mode.
- Coalesced the mapper to accept both response shapes: `/me/tracks` wraps each track under `.track`, while `/playlists/{id}/items` wraps the playable under `.item` (because an item may be a podcast episode). Mapping unchanged downstream.
- On 403 from a non-`liked` source, surface a clearer message so the user understands the limitation: \"Spotify only allows reading playlists owned by the connected account; followed or editorial playlists are blocked for Development Mode apps.\"

Server (`packages/server/src/routes/spotify-auth.routes.ts`)
- `/playlists` now resolves real track counts for self-owned playlists by calling `/playlists/{id}/items?limit=1` in parallel and using the returned `total`. The previous code read `tracks.total` from `/me/playlists`, which Dev Mode strips, so every entry was 0.
- Returns `trackCount: number | null` and a new `owned: boolean` so the client can render usable counts and label unusable playlists.

Client (`packages/client/src/components/chat/ChatSettingsDrawer.tsx`, `packages/client/src/components/game/GameSetupWizard.tsx`)
- Updated the type for `/spotify/playlists` to `trackCount: number | null` and `owned: boolean`.
- Dropdown suffix renders:
  - `Background (75)` — owned, real count known
  - `Custom Mix` — owned, count unknown for any reason (no misleading `(0)`)
  - `Fantasy vibes (followed — unavailable)` — followed playlist, picking it will fail

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

Verified end-to-end on a live EasyPanel deployment running this branch's commits:

- **Self-owned playlist** (\"Background\", 75 tracks): drop down rendered `Background (75)`; scene-music shortlist returned 75 indexed tracks; sample candidate names (Peace Sign, Hijo de la Luna - Epic Orchestral Version, Hero of Our Time, Count the Teeth, Guren no Yumiya) matched the actual playlist; track played through the SDK device.
- **Self-owned empty playlist** (\"JQBX :: Queue\", 0 tracks): rendered `JQBX :: Queue (0)`; correctly identified as empty by the server.
- **Followed playlist** (\"Fantasy vibes\", owned by another user): rendered `Fantasy vibes (followed — unavailable)`; if explicitly selected and a scene triggered, the new clearer 403 message surfaces (\"Spotify denied access to this playlist's contents...\") instead of a generic failure.
- **Liked Songs source** (control): still works unchanged — `/me/tracks` path uses the existing `.track` wrapper which the coalesced mapper still handles.
- **\"Any Spotify\" source** (control): still works unchanged — `/search` path is untouched by this PR.

Manual verification to perform locally before merge:

- Manually verify on a Dev Mode Spotify app: playlist dropdown shows real counts for self-owned playlists and `(followed — unavailable)` for followed ones.
- Manually verify scene playback from a self-owned playlist with the in-app Web Playback SDK device registered (i.e. mini player toggled on).
- Manually verify Liked Songs source still produces a non-empty shortlist.
- Manually verify that on an Extended Quota Mode app (if accessible) the existing behavior still holds — `tracks.total` if Spotify provides it, otherwise the new `/items` lookup fills it in.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

N/A — the visible change is the dropdown suffix; no layout or theming changes. (The before-state, `Background (0)`, is documented in #680 with a screenshot.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Spotify playlists with unavailable or missing track count information
  * Playlist selection now displays clearer availability indicators: owned playlists omit track count when unavailable, while followed playlists clearly show "(followed — unavailable)" status
  * Enhanced reliability of Spotify track count retrieval and playlist indexing through optimized data fetching

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/681)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->