### PR TITLE
Fix nested SillyTavern random macro parsing

### DIFF
--- a/packages/server/test/macro-engine.test.ts
+++ b/packages/server/test/macro-engine.test.ts
@@ -22,7 +22,9 @@ function withMockedRandom(values: number[], run: () => string): string {
   };
 
   try {
-    return run();
+    const output = run();
+    assert.equal(index, values.length, "test did not consume all expected random values");
+    return output;
   } finally {
     Math.random = originalRandom;
   }

--- a/packages/server/test/macro-engine.test.ts
+++ b/packages/server/test/macro-engine.test.ts
@@ -1,0 +1,58 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { resolveMacros, type MacroContext } from "@marinara-engine/shared";
+
+function macroContext(variables: Record<string, string> = {}): MacroContext {
+  return {
+    user: "User",
+    char: "Char",
+    characters: ["Char"],
+    variables,
+  };
+}
+
+function withMockedRandom(values: number[], run: () => string): string {
+  const originalRandom = Math.random;
+  let index = 0;
+  Math.random = () => {
+    const value = values[index];
+    assert.notEqual(value, undefined, "test consumed more random values than expected");
+    index += 1;
+    return value;
+  };
+
+  try {
+    return run();
+  } finally {
+    Math.random = originalRandom;
+  }
+}
+
+test("random choices respect nested random macros as a single option", () => {
+  const output = withMockedRandom([0.3, 0.5], () =>
+    resolveMacros(
+      "{{random::None::{{random::Alice::Bob::Carl}} appears.::The world ends.::{{random::Doug::Erin::Frank}} leaves.::A nearby car explodes.}}",
+      macroContext(),
+    ),
+  );
+
+  assert.equal(output, "Bob appears.");
+});
+
+test("random choices can resolve nested variable macros", () => {
+  const output = withMockedRandom([0.2], () =>
+    resolveMacros("{{random::{{getvar::actor}} leaves.::The world ends.}}", macroContext({ actor: "Doug" })),
+  );
+
+  assert.equal(output, "Doug leaves.");
+});
+
+test("setvar values can resolve nested random choices", () => {
+  const ctx = macroContext();
+  const output = withMockedRandom([0.8], () =>
+    resolveMacros("{{setvar::actor::{{random::Alice::Bob}}}}{{getvar::actor}}", ctx),
+  );
+
+  assert.equal(output, "Bob");
+  assert.equal(ctx.variables.actor, "Bob");
+});

--- a/packages/shared/src/utils/macro-engine.ts
+++ b/packages/shared/src/utils/macro-engine.ts
@@ -184,6 +184,98 @@ function expandBracketedCharacterBlocks(template: string, ctx: MacroContext): st
   return changed ? expandedLines.join("\n") : template;
 }
 
+function findBalancedMacroEnd(input: string, start: number): number {
+  let depth = 0;
+
+  for (let index = start; index < input.length - 1; index++) {
+    if (input[index] === "{" && input[index + 1] === "{") {
+      depth += 1;
+      index += 1;
+      continue;
+    }
+
+    if (input[index] === "}" && input[index + 1] === "}") {
+      depth -= 1;
+      index += 1;
+      if (depth === 0) return index + 1;
+    }
+  }
+
+  return -1;
+}
+
+function replaceBalancedMacros(
+  input: string,
+  replacer: (body: string, original: string) => string | undefined,
+): string {
+  let result = "";
+  let index = 0;
+
+  while (index < input.length) {
+    const start = input.indexOf("{{", index);
+    if (start === -1) {
+      result += input.slice(index);
+      break;
+    }
+
+    result += input.slice(index, start);
+
+    const end = findBalancedMacroEnd(input, start);
+    if (end === -1) {
+      result += input.slice(start);
+      break;
+    }
+
+    const original = input.slice(start, end);
+    const body = input.slice(start + 2, end - 2);
+    const replacement = replacer(body, original);
+
+    if (replacement !== undefined) {
+      result += replacement;
+      index = end;
+    } else {
+      result += "{{";
+      index = start + 2;
+    }
+  }
+
+  return result;
+}
+
+function splitTopLevelDoubleColon(input: string): string[] {
+  const parts: string[] = [];
+  let current = "";
+  let depth = 0;
+
+  for (let index = 0; index < input.length; index++) {
+    if (input[index] === "{" && input[index + 1] === "{") {
+      depth += 1;
+      current += "{{";
+      index += 1;
+      continue;
+    }
+
+    if (input[index] === "}" && input[index + 1] === "}" && depth > 0) {
+      depth -= 1;
+      current += "}}";
+      index += 1;
+      continue;
+    }
+
+    if (depth === 0 && input[index] === ":" && input[index + 1] === ":") {
+      parts.push(current);
+      current = "";
+      index += 1;
+      continue;
+    }
+
+    current += input[index];
+  }
+
+  parts.push(current);
+  return parts;
+}
+
 /**
  * Replace macros in a prompt string with their values.
  *
@@ -271,13 +363,16 @@ export function resolveMacros(template: string, ctx: MacroContext, options: Reso
 
   // ── Random values ──
   result = result.replace(/\{\{random\}\}/gi, () => String(Math.floor(Math.random() * 101)));
-  result = result.replace(/\{\{random::([^}]*)\}\}/gi, (_, body) => {
-    const choices = String(body)
-      .split("::")
+  result = replaceBalancedMacros(result, (body) => {
+    const match = body.match(/^random::([\s\S]*)$/i);
+    if (!match) return undefined;
+
+    const choices = splitTopLevelDoubleColon(match[1] ?? "")
       .map((choice) => choice.trim())
       .filter(Boolean);
     if (choices.length === 0) return "";
-    return choices[Math.floor(Math.random() * choices.length)] ?? "";
+    const choice = choices[Math.floor(Math.random() * choices.length)] ?? "";
+    return resolveMacros(choice, ctx, { ...options, trimResult: false });
   });
   result = result.replace(/\{\{random:(\d+):(\d+)\}\}/gi, (_, min, max) => {
     const lo = parseInt(min, 10);
@@ -295,31 +390,33 @@ export function resolveMacros(template: string, ctx: MacroContext, options: Reso
   });
 
   // ── Variable operations — resolve left-to-right so lorebook entries can set values for later entries. ──
-  result = result.replace(
-    /\{\{(?:(getvar|incvar|decvar)::([\w.-]+)|(setvar|addvar)::([\w.-]+)::([^}]*))\}\}/gi,
-    (_, readOp, readName, writeOp, writeName, val) => {
-      const op = String(readOp ?? writeOp).toLowerCase();
-      const name = String(readName ?? writeName);
-      switch (op) {
-        case "getvar":
-          return ctx.variables[name] ?? "";
-        case "setvar":
-          ctx.variables[name] = val ?? "";
-          return "";
-        case "addvar":
-          ctx.variables[name] = (ctx.variables[name] ?? "") + (val ?? "");
-          return "";
-        case "incvar":
-          ctx.variables[name] = String((parseInt(ctx.variables[name] ?? "0", 10) || 0) + 1);
-          return "";
-        case "decvar":
-          ctx.variables[name] = String((parseInt(ctx.variables[name] ?? "0", 10) || 0) - 1);
-          return "";
-        default:
-          return "";
-      }
-    },
-  );
+  result = replaceBalancedMacros(result, (body) => {
+    const readMatch = body.match(/^(getvar|incvar|decvar)::([\w.-]+)$/i);
+    const writeMatch = body.match(/^(setvar|addvar)::([\w.-]+)::([\s\S]*)$/i);
+    const op = String(readMatch?.[1] ?? writeMatch?.[1] ?? "").toLowerCase();
+    const name = readMatch?.[2] ?? writeMatch?.[2];
+    if (!op || !name) return undefined;
+
+    switch (op) {
+      case "getvar":
+        return ctx.variables[name] ?? "";
+      case "setvar":
+        ctx.variables[name] = resolveMacros(writeMatch?.[3] ?? "", ctx, { ...options, trimResult: false });
+        return "";
+      case "addvar":
+        ctx.variables[name] =
+          (ctx.variables[name] ?? "") + resolveMacros(writeMatch?.[3] ?? "", ctx, { ...options, trimResult: false });
+        return "";
+      case "incvar":
+        ctx.variables[name] = String((parseInt(ctx.variables[name] ?? "0", 10) || 0) + 1);
+        return "";
+      case "decvar":
+        ctx.variables[name] = String((parseInt(ctx.variables[name] ?? "0", 10) || 0) - 1);
+        return "";
+      default:
+        return "";
+    }
+  });
 
   // ── Case transforms ──
   result = result.replace(/\{\{uppercase\}\}([\s\S]*?)\{\{\/uppercase\}\}/gi, (_, inner) =>


### PR DESCRIPTION
## Linked issue

No linked GitHub issue yet. The original report came from a Discord "Feature request/Possible bug report" screenshot about SillyTavern random macro parity.

This should stay draft until a GitHub issue is opened/linked or a maintainer confirms the Discord report is enough context.

## Why this change

- Marinara advertises SillyTavern-style macros, but nested macros inside `{{random::...}}` were parsed incorrectly.
- A random macro such as `{{random::None::{{random::Alice::Bob}} appears.::The world ends.}}` could leak pieces of multiple unchosen branches into the assembled prompt instead of returning exactly one selected branch.

## What changed

- Added balanced macro scanning so random and variable macros can contain nested `{{...}}` expressions.
- Split `{{random::...}}` choices only on top-level `::` separators, leaving nested macro arguments intact.
- Resolve nested macros inside the selected random branch and inside `setvar`/`addvar` values.
- Added regression tests for nested random, nested `getvar`, and `setvar` values containing random choices.

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Targeted macro test passed:
  - `pnpm --filter @marinara-engine/server exec tsx --import ./test/setup-env.ts --test test/macro-engine.test.ts`
- Baseline validation passed:
  - `pnpm check`
- Manual console repro after fix returned only the selected branch:
  - `Bob appears.`
- Wider server test suite was also attempted:
  - `pnpm --filter @marinara-engine/server test`
  - The new macro tests passed inside that run.
  - One unrelated provider test failed in `openai-provider-reasoning.test.ts`: `custom compatible GPT-5.5 endpoints route through Responses without Chat Completions streaming extras`, expecting `body.max_output_tokens` to equal `512` but receiving `undefined`. The same provider test failed when isolated.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

Not applicable; this is shared prompt macro parsing logic.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Macro engine now supports nested macros — macro calls within macro options and values are properly resolved, enabling more complex template scenarios.

* **Tests**
  * Added test suite for nested macro evaluation, including scenarios with random selection, variable operations, and combined macro nesting.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/682)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->