### PR TITLE
Fix tracker panel refresh after retry trackers

### DIFF
--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -444,6 +444,32 @@ function applyGameMapUpdate(qc: QueryClient, chatId: string, map: GameMap) {
   }
 }
 
+function applyGameStatePatchToStore(chatId: string, patch: Record<string, unknown>) {
+  const current = useGameStateStore.getState().current;
+
+  if (current?.chatId === chatId) {
+    const merged = { ...current, ...patch, chatId };
+    if (patch.playerStats && typeof patch.playerStats === "object" && current.playerStats) {
+      const mergedPS = { ...current.playerStats, ...(patch.playerStats as object) };
+      const patchPS = patch.playerStats as Record<string, unknown>;
+      if (
+        Array.isArray(patchPS.activeQuests) &&
+        patchPS.activeQuests.length === 0 &&
+        current.playerStats.activeQuests?.length > 0
+      ) {
+        mergedPS.activeQuests = current.playerStats.activeQuests;
+      }
+      (merged as any).playerStats = mergedPS;
+    }
+    useGameStateStore.getState().setGameState(merged as any);
+    return;
+  }
+
+  // Agent data may arrive before the base game state is loaded. Seed a minimal
+  // state with chatId so mounted tracker/HUD views recognise it as current.
+  useGameStateStore.getState().setGameState({ ...patch, chatId } as any);
+}
+
 /**
  * Hook that handles streaming generation.
  * Returns a function to trigger generation which streams tokens
@@ -1123,31 +1149,7 @@ export function useGenerate() {
               const patch = event.data as Record<string, unknown>;
               console.warn(`[Generate] ${event.type} received:`, patch);
               if (!isActiveChat()) break;
-              const current = useGameStateStore.getState().current;
-              if (current) {
-                const merged = { ...current, ...patch };
-                // Deep-merge playerStats so partial updates don't clobber sibling fields
-                if (patch.playerStats && typeof patch.playerStats === "object" && current.playerStats) {
-                  const mergedPS = { ...current.playerStats, ...(patch.playerStats as object) };
-                  // Don't let an empty activeQuests overwrite existing quests
-                  const patchPS = patch.playerStats as Record<string, unknown>;
-                  if (
-                    Array.isArray(patchPS.activeQuests) &&
-                    patchPS.activeQuests.length === 0 &&
-                    current.playerStats.activeQuests?.length > 0
-                  ) {
-                    mergedPS.activeQuests = current.playerStats.activeQuests;
-                  }
-                  (merged as any).playerStats = mergedPS;
-                }
-                setGameState(merged as any);
-              } else {
-                // Agent data may arrive before the base game state is loaded —
-                // seed a minimal state so data isn't lost. Include chatId so the
-                // RoleplayHUD mount-guard (`existing?.chatId === chatId`) recognises
-                // this state belongs to the active chat and skips a redundant fetch.
-                setGameState({ chatId: params.chatId, ...patch } as any);
-              }
+              applyGameStatePatchToStore(params.chatId, patch);
               break;
             }
 
@@ -1869,26 +1871,7 @@ export function useGenerate() {
               const patch = event.data as Record<string, unknown>;
               console.warn(`[Retry] ${event.type} received:`, patch);
               if (!isActiveChat()) break;
-              const current = useGameStateStore.getState().current;
-              if (current) {
-                const merged = { ...current, ...patch };
-                if (patch.playerStats && typeof patch.playerStats === "object" && current.playerStats) {
-                  const mergedPS = { ...current.playerStats, ...(patch.playerStats as object) };
-                  // Don't let an empty activeQuests overwrite existing quests
-                  const patchPS = patch.playerStats as Record<string, unknown>;
-                  if (
-                    Array.isArray(patchPS.activeQuests) &&
-                    patchPS.activeQuests.length === 0 &&
-                    current.playerStats.activeQuests?.length > 0
-                  ) {
-                    mergedPS.activeQuests = current.playerStats.activeQuests;
-                  }
-                  (merged as any).playerStats = mergedPS;
-                }
-                setGameState(merged as any);
-              } else {
-                setGameState(patch as any);
-              }
+              applyGameStatePatchToStore(chatId, patch);
               break;
             }
             case "game_map_update": {


### PR DESCRIPTION
## Linked issue

No linked issue. This is a maintainer-approved follow-up fix for the tracker panel feature.

## Why this change

- The tracker panel could stay empty while it was already open if retry trackers produced the first visible tracker data for the active chat. Closing and reopening worked because the remount fetched the full game-state snapshot from the server.

## What changed

- Added a shared client helper for streamed game-state patches so both normal generation and retry tracker streams attach the owning chat id before writing to the shared game-state store.
- Preserved the existing same-chat merge behavior for standard tracker updates, including the partial `playerStats` merge and active quest protection.
- Avoided merging streamed tracker patches into a stale game-state snapshot from another chat.

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [X] Ran the app, clicked through the changes manually
- [X] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Code-path reproduction before fix: retry `game_state_patch` without `chatId` was ignored by the tracker panel selector.
- Code-path verification after fix: retry patch seeded with `chatId` is visible to the tracker panel selector.
- Edge check: same-chat patches still merge into existing state and preserve existing active quests when a partial empty quest list arrives.
- Edge check: patches for the active chat no longer merge into a stale snapshot from another chat.
- Automated validation run by Codex: `pnpm check` passed locally.
- 
- Used a chat where the panel starts empty, retried a tracker, confirmed data appears while the panel stays open.
- Retried a tracker on a chat that already had tracker data, confirmed it updates without wiping unrelated tracker sections.
- Retried Character, Persona, Quest, and Custom trackers one at a time, checking each section updates normally.
- Sent a regular roleplay message with automatic trackers enabled. Confirmed standard tracker updates still appear normally.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of game state updates to enhance consistency and reliability during streaming events.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/684)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->