### PR TITLE
fix(chat): make Up-Arrow recall always available and edit any role

### DIFF
--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -134,6 +134,7 @@ export function ChatArea() {
   const guideGenerations = useUIStore((s) => s.guideGenerations);
   const intuitiveSwipeNavigation = useUIStore((s) => s.intuitiveSwipeNavigation);
   const intuitiveSwipeRerollLatest = useUIStore((s) => s.intuitiveSwipeRerollLatest);
+  const editLastMessageOnArrowUp = useUIStore((s) => s.editLastMessageOnArrowUp);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const prevScrollHeightRef = useRef(0);
@@ -924,11 +925,23 @@ export function ChatArea() {
     return null;
   }, [messages]);
 
-  const latestUserMessageForEdit = useMemo(() => {
+  const latestMessageForEdit = useMemo(() => {
     if (!messages) return null;
     for (let i = messages.length - 1; i >= 0; i--) {
       const candidate = messages[i]!;
-      if (candidate.role === "user") return candidate;
+      if (candidate.role !== "user" && candidate.role !== "assistant") continue;
+      const extra =
+        typeof candidate.extra === "string"
+          ? (() => {
+              try {
+                return JSON.parse(candidate.extra as unknown as string);
+              } catch {
+                return {};
+              }
+            })()
+          : (candidate.extra ?? {});
+      if (extra?.hiddenFromUser === true) continue;
+      return candidate;
     }
     return null;
   }, [messages]);
@@ -986,37 +999,8 @@ export function ChatArea() {
   useEffect(() => {
     if (!intuitiveSwipeNavigation || intuitiveSwipeBlocked) return;
 
-    const supportsMode = chatMode === "conversation" || isRoleplay;
-
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.defaultPrevented) return;
-
-      if (event.key === "ArrowUp") {
-        if (!supportsMode || !latestUserMessageForEdit) return;
-        if (event.repeat || event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) return;
-        const target = event.target;
-        if (target instanceof Element) {
-          // Don't hijack up-arrow when the user is typing or already editing.
-          // Allow it from the chat input only when it's empty (shell-style recall).
-          if (target.tagName === "TEXTAREA") {
-            const ta = target as HTMLTextAreaElement;
-            if (ta.value.length > 0) return;
-          } else if (
-            target.tagName === "INPUT" ||
-            target.tagName === "SELECT" ||
-            target.getAttribute("contenteditable") === "true"
-          ) {
-            return;
-          }
-        }
-        event.preventDefault();
-        window.dispatchEvent(
-          new CustomEvent("marinara:start-edit-message", {
-            detail: { messageId: latestUserMessageForEdit.id },
-          }),
-        );
-        return;
-      }
 
       if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
       if (shouldIgnoreIntuitiveSwipeTarget(event.target)) return;
@@ -1034,13 +1018,61 @@ export function ChatArea() {
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [
-    chatMode,
     intuitiveSwipeBlocked,
     intuitiveSwipeNavigation,
-    isRoleplay,
     latestAssistantMessageForSwipes,
-    latestUserMessageForEdit,
     navigateLatestSwipe,
+  ]);
+
+  // Up-Arrow recall of the most recent message (user OR assistant) — runs
+  // independently of swipe nav so the shortcut works with that toggle off.
+  useEffect(() => {
+    if (!editLastMessageOnArrowUp || intuitiveSwipeBlocked) return;
+    const supportsMode = chatMode === "conversation" || isRoleplay;
+    if (!supportsMode) return;
+
+    const handleArrowUp = (event: KeyboardEvent) => {
+      if (event.defaultPrevented) return;
+      if (event.key !== "ArrowUp") return;
+      if (event.repeat || event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) return;
+      if (!latestMessageForEdit) return;
+      // Don't try to edit a message that's currently streaming/regenerating.
+      if (isStreaming || agentProcessing) return;
+
+      const target = event.target;
+      if (target instanceof Element) {
+        // Allow recall when the chat input textarea is focused but empty
+        // (shell-style). Otherwise leave typing/editing alone.
+        if (target.tagName === "TEXTAREA") {
+          const ta = target as HTMLTextAreaElement;
+          if (ta.value.length > 0) return;
+        } else if (
+          target.tagName === "INPUT" ||
+          target.tagName === "SELECT" ||
+          target.getAttribute("contenteditable") === "true"
+        ) {
+          return;
+        }
+      }
+
+      event.preventDefault();
+      window.dispatchEvent(
+        new CustomEvent("marinara:start-edit-message", {
+          detail: { messageId: latestMessageForEdit.id },
+        }),
+      );
+    };
+
+    window.addEventListener("keydown", handleArrowUp);
+    return () => window.removeEventListener("keydown", handleArrowUp);
+  }, [
+    agentProcessing,
+    chatMode,
+    editLastMessageOnArrowUp,
+    intuitiveSwipeBlocked,
+    isRoleplay,
+    isStreaming,
+    latestMessageForEdit,
   ]);
 
   useEffect(() => {

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -874,14 +874,14 @@ export const ChatMessage = memo(function ChatMessage({
   }, []);
 
   useEffect(() => {
-    if (message.role !== "user" || !onEdit) return;
+    if (!onEdit) return;
     const handler = (event: Event) => {
       const detail = (event as CustomEvent<{ messageId?: string }>).detail;
       if (detail?.messageId === message.id) startEditing();
     };
     window.addEventListener("marinara:start-edit-message", handler);
     return () => window.removeEventListener("marinara:start-edit-message", handler);
-  }, [message.id, message.role, onEdit, startEditing]);
+  }, [message.id, onEdit, startEditing]);
 
   const handleSaveEdit = useCallback(
     (content: string) => {

--- a/packages/client/src/components/chat/ConversationMessage.tsx
+++ b/packages/client/src/components/chat/ConversationMessage.tsx
@@ -535,7 +535,7 @@ export const ConversationMessage = memo(function ConversationMessage({
   }, [message.content]);
 
   useEffect(() => {
-    if (message.role !== "user" || !onEdit) return;
+    if (!onEdit) return;
     const handler = (event: Event) => {
       const detail = (event as CustomEvent<{ messageId?: string }>).detail;
       if (detail?.messageId !== message.id) return;
@@ -544,7 +544,7 @@ export const ConversationMessage = memo(function ConversationMessage({
     };
     window.addEventListener("marinara:start-edit-message", handler);
     return () => window.removeEventListener("marinara:start-edit-message", handler);
-  }, [message.id, message.role, onEdit, onEditClick, startEditing]);
+  }, [message.id, onEdit, onEditClick, startEditing]);
 
   const editValueRef = useRef(editValue);
   editValueRef.current = editValue;

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -443,6 +443,8 @@ function GeneralSettings() {
   const setIntuitiveSwipeNavigation = useUIStore((s) => s.setIntuitiveSwipeNavigation);
   const intuitiveSwipeRerollLatest = useUIStore((s) => s.intuitiveSwipeRerollLatest);
   const setIntuitiveSwipeRerollLatest = useUIStore((s) => s.setIntuitiveSwipeRerollLatest);
+  const editLastMessageOnArrowUp = useUIStore((s) => s.editLastMessageOnArrowUp);
+  const setEditLastMessageOnArrowUp = useUIStore((s) => s.setEditLastMessageOnArrowUp);
   const rescanGameAssets = useGameAssetStore((s) => s.rescanAssets);
   const assetFileRef = useRef<HTMLInputElement>(null);
   const [assetCategory, setAssetCategory] = useState<GameAssetCategoryId>("backgrounds");
@@ -729,7 +731,7 @@ function GeneralSettings() {
         label="Intuitive swipe navigation"
         checked={intuitiveSwipeNavigation}
         onChange={setIntuitiveSwipeNavigation}
-        help="In Conversation and Roleplay modes, use Left/Right Arrow on desktop or horizontal touch swipes on mobile to move between alternate generations on the latest assistant message. Up Arrow edits your last sent message (only when the chat input is empty)."
+        help="In Conversation and Roleplay modes, use Left/Right Arrow on desktop or horizontal touch swipes on mobile to move between alternate generations on the latest assistant message."
       />
 
       <div className={cn("pl-5 transition-opacity", intuitiveSwipeNavigation ? "" : "pointer-events-none opacity-45")}>
@@ -740,6 +742,13 @@ function GeneralSettings() {
           help="When intuitive swipes are enabled, pressing Right Arrow or swiping left on the newest swipe of the latest assistant message creates a new reroll."
         />
       </div>
+
+      <ToggleSetting
+        label="Up Arrow edits last message"
+        checked={editLastMessageOnArrowUp}
+        onChange={setEditLastMessageOnArrowUp}
+        help="In Conversation and Roleplay modes, press Up Arrow while the chat input is empty to open the most recent message in the chat for editing — whether it's yours or the AI's."
+      />
 
       <div className="rounded-xl bg-[var(--secondary)]/50 p-4 ring-1 ring-[var(--border)]">
         <div className="mb-3 flex flex-col gap-1">

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -276,6 +276,8 @@ interface UIState {
   intuitiveSwipeNavigation: boolean;
   /** When true, moving past the newest swipe on the latest assistant message creates a new reroll. */
   intuitiveSwipeRerollLatest: boolean;
+  /** When true, pressing Up Arrow with an empty chat input opens the last user message for editing (Conversation/Roleplay). */
+  editLastMessageOnArrowUp: boolean;
 
   // ── Text Appearance ──
   /** Color for narrator text in RP mode (empty = default amber) */
@@ -471,6 +473,7 @@ interface UIState {
   setSpotifyMobileWidgetPosition: (position: FloatingWidgetPosition) => void;
   setIntuitiveSwipeNavigation: (v: boolean) => void;
   setIntuitiveSwipeRerollLatest: (v: boolean) => void;
+  setEditLastMessageOnArrowUp: (v: boolean) => void;
   setNarrationFontColor: (v: string) => void;
   setNarrationOpacity: (v: number) => void;
   setChatFontColor: (v: string) => void;
@@ -582,6 +585,7 @@ export function pickSyncedSettings(state: UIState) {
     spotifyMobileWidgetPosition: state.spotifyMobileWidgetPosition,
     intuitiveSwipeNavigation: state.intuitiveSwipeNavigation,
     intuitiveSwipeRerollLatest: state.intuitiveSwipeRerollLatest,
+    editLastMessageOnArrowUp: state.editLastMessageOnArrowUp,
     narrationFontColor: state.narrationFontColor,
     narrationOpacity: state.narrationOpacity,
     chatFontColor: state.chatFontColor,
@@ -691,6 +695,7 @@ export const useUIStore = create<UIState>()(
       spotifyMobileWidgetPosition: { x: 16, y: 96 },
       intuitiveSwipeNavigation: false,
       intuitiveSwipeRerollLatest: false,
+      editLastMessageOnArrowUp: true,
       narrationFontColor: "",
       narrationOpacity: 80,
       chatFontColor: "",
@@ -1023,6 +1028,7 @@ export const useUIStore = create<UIState>()(
         }),
       setIntuitiveSwipeNavigation: (v) => set({ intuitiveSwipeNavigation: v }),
       setIntuitiveSwipeRerollLatest: (v) => set({ intuitiveSwipeRerollLatest: v }),
+      setEditLastMessageOnArrowUp: (v) => set({ editLastMessageOnArrowUp: v }),
       setNarrationFontColor: (v) => set({ narrationFontColor: v }),
       setNarrationOpacity: (v) => set({ narrationOpacity: Math.max(0, Math.min(100, v)) }),
       setChatFontColor: (v) => set({ chatFontColor: v }),
@@ -1110,7 +1116,7 @@ export const useUIStore = create<UIState>()(
     }),
     {
       name: "marinara-engine-ui",
-      version: 27,
+      version: 28,
       // Debounce localStorage writes to avoid sync I/O on every state change
       storage: createJSONStorage(() => {
         let timer: ReturnType<typeof setTimeout> | null = null;
@@ -1360,6 +1366,10 @@ export const useUIStore = create<UIState>()(
           if (persisted.roleplaySpriteScale === undefined) {
             persisted.roleplaySpriteScale = 1;
           }
+        }
+        // v27 -> v28: enable Up-Arrow recall of the last user message by default.
+        if (version <= 27 && persisted.editLastMessageOnArrowUp === undefined) {
+          persisted.editLastMessageOnArrowUp = true;
         }
         return persisted;
       },


### PR DESCRIPTION
## Why

PR #639 introduced an Up-Arrow shortcut to recall the last message for inline editing, but two problems made it look broken after merge:

1. The shortcut was gated behind the existing **Intuitive swipe navigation** toggle, which defaults to `false`. Anyone who hadn't already opted into swipe nav pressed Up Arrow and saw nothing happen.
2. The help-text update describing the new behavior was attached to that same disabled toggle, so the discoverability hint was hidden behind the off switch too.

It also only ever recalled the most recent **user** message, which surprised users who expected "edit the last thing in the chat" to mean the last bubble period — including the AI's response.

## What this changes

- Adds a dedicated **"Up Arrow edits last message"** toggle in Settings, defaulted **on**, with its own help text. UI store version bumped `27 -> 28` so existing users pick up the new default.
- Splits the keydown handler in `ChatArea` so the Up-Arrow recall runs in its own effect, independent of the swipe-nav toggle and effect.
- Targets the most recent visible message regardless of role — user or assistant — skipping `hiddenFromUser` system messages and bailing while a generation is streaming or an agent is processing.
- Drops the user-only guard from the per-message event listeners in `ChatMessage` and `ConversationMessage` so any role responds to the recall event, matching the existing Pencil button behavior.
- Reverts the **Intuitive swipe navigation** help text to swipe-only wording now that Up Arrow lives in its own setting.

## Linked issue

No GitHub issue was opened for this — it's a follow-up to the merged PR #639. One should be filed if we want to track the regression formally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Up Arrow edits last message" setting toggle in Settings to quickly edit the most recent message with keyboard shortcut
  * Up Arrow now supports editing both user and assistant messages in Conversation and Roleplay modes
  * Setting is configurable and persists across sessions

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/703)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->