### PR TITLE
Fix Pygmalion avatar content type fallback

### DIFF
--- a/packages/server/src/routes/bot-browser-pygmalion.routes.ts
+++ b/packages/server/src/routes/bot-browser-pygmalion.routes.ts
@@ -3,7 +3,7 @@
 // ──────────────────────────────────────────────
 import type { FastifyInstance } from "fastify";
 import { logger } from "../lib/logger.js";
-import { safeFetch } from "../utils/security.js";
+import { isAllowedImageBuffer, safeFetch } from "../utils/security.js";
 
 const PYGMALION_API_BASE = "https://server.pygmalion.chat/galatea.v1.PublicCharacterService";
 const PYGMALION_ORIGIN = "https://pygmalion.chat";
@@ -254,12 +254,21 @@ export async function botBrowserPygmalionRoutes(app: FastifyInstance) {
       const res = await safeFetch(url, {
         signal: controller.signal,
         policy: { allowedProtocols: ["https:"] },
-        allowedContentTypes: ["image/"],
         maxResponseBytes: 10 * 1024 * 1024,
       });
       if (!res.ok) return reply.status(404).send({ error: "Avatar not found" });
       const buf = Buffer.from(await res.arrayBuffer());
-      const ct = res.headers.get("content-type") || "image/webp";
+      const contentType = res.headers.get("content-type")?.toLowerCase() ?? "";
+      const imageInfo = isAllowedImageBuffer(buf);
+      if (contentType && !contentType.startsWith("image/") && !imageInfo) {
+        logger.warn("[bot-browser] Pygmalion avatar returned unsupported content type: %s", contentType);
+        return reply.status(415).send({ error: "Unsupported avatar content type" });
+      }
+      if (!contentType && !imageInfo) {
+        logger.warn("[bot-browser] Pygmalion avatar response was missing a usable image content type");
+        return reply.status(415).send({ error: "Unsupported avatar content type" });
+      }
+      const ct = contentType || imageInfo?.mimeType || "image/webp";
       return reply.header("Content-Type", ct).header("Cache-Control", "public, max-age=86400").send(buf);
     } finally {
       clearTimeout(timeout);


### PR DESCRIPTION
## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #687

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- Pygmalion avatar proxy requests could return HTTP 500 when the upstream image response omitted `Content-Type`, which surfaced while browsing/logging into Pygmalion after the security hardening switched the avatar path to `safeFetch`.

## What changed

<!-- List the key changes in this PR -->

- Keeps Pygmalion avatar proxy requests on `safeFetch` for outbound URL policy and byte caps.
- Validates buffered avatar responses with image magic bytes when `Content-Type` is missing.
- Rejects non-image responses with HTTP 415 instead of proxying them or throwing a generic 500.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Codex reproduced the original route failure with `pnpm --filter @marinara-engine/server exec tsx ../../scratch/issue-687-pygmalion-avatar-repro.mjs missing-content-type`: before the fix, a valid PNG avatar response without `Content-Type` returned HTTP 500.
- Codex re-ran the same repro after the fix: the missing-content-type valid PNG case returned HTTP 200 with `image/png`.
- Codex checked adjacent cases: a normal `image/png` response still returned HTTP 200, and a `text/plain` non-image response returned HTTP 415.
- Codex ran `pnpm check`; it passed `impeccable:check`, lint, and production build.
- No human-only verification blockers remain for the route-level core claim. A real Pygmalion account/token smoke test is still useful before release if someone has a current token handy.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs or release metadata changes needed; this is a narrow server bug fix.

## UI evidence (if applicable)

N/A: backend route bug. Route-level proof:

```json
{
  "beforeFixMissingContentType": { "statusCode": 500, "contentType": "application/json; charset=utf-8" },
  "afterFixMissingContentType": { "statusCode": 200, "contentType": "image/png" },
  "afterFixNormalImageContentType": { "statusCode": 200, "contentType": "image/png" },
  "afterFixTextResponse": { "statusCode": 415, "bodyPreview": "{\"error\":\"Unsupported avatar content type\"}" }
}
```
