### PR TITLE
Fix card evolution auditor cadence

### DIFF
--- a/packages/client/src/lib/agent-cadence.ts
+++ b/packages/client/src/lib/agent-cadence.ts
@@ -26,6 +26,14 @@ export function getAgentRunIntervalMeta(agentType: string, isBuiltIn = true): Ag
         defaultValue: 8,
         max: 100,
       };
+    case "card-evolution-auditor":
+      return {
+        label: "Run Interval",
+        unit: "assistant messages",
+        help: "How many assistant messages should pass between Card Evolution Auditor checks.",
+        defaultValue: 8,
+        max: 100,
+      };
     case "chat-summary":
       return {
         label: "Triggers After",

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -4212,6 +4212,26 @@ export async function generateRoutes(app: FastifyInstance) {
       // ────────────────────────────────────────
       // Tracker Data Injection
       // ────────────────────────────────────────
+      // The Card Evolution Auditor proposes user-facing character-card edits,
+      // so gate it by assistant-message cadence instead of auditing every turn.
+      if (resolvedAgents.some((a) => a.type === "card-evolution-auditor")) {
+        const ceaAgent = resolvedAgents.find((a) => a.type === "card-evolution-auditor")!;
+        const defaultInterval = (getDefaultBuiltInAgentSettings("card-evolution-auditor").runInterval as number) ?? 8;
+        const runInterval = (ceaAgent.settings.runInterval as number) ?? defaultInterval;
+
+        if (runInterval > 1) {
+          const lastRun = await agentsStore.getLastSuccessfulRunByType("card-evolution-auditor", input.chatId);
+          if (lastRun) {
+            const lastRunIdx = allChatMessages.findIndex((m: any) => m.id === lastRun.messageId);
+            const assistantMsgsSince =
+              lastRunIdx >= 0 ? allChatMessages.slice(lastRunIdx + 1).filter((m: any) => m.role === "assistant") : [];
+            if (assistantMsgsSince.length + 1 < runInterval) {
+              resolvedAgents.splice(resolvedAgents.indexOf(ceaAgent), 1);
+            }
+          }
+        }
+      }
+
       // Always inject committed tracker data as a system message regardless of
       // preset configuration. This replaces the old agent_data marker approach.
       if (chatEnableAgents && chatActiveAgentIds.length > 0) {

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -456,6 +456,7 @@ export const BUILT_IN_AGENTS: BuiltInAgentMeta[] = [
 export const BUILT_IN_AGENT_RUN_INTERVAL_DEFAULTS: Readonly<Record<string, number>> = {
   director: 5,
   "lorebook-keeper": 8,
+  "card-evolution-auditor": 8,
   "chat-summary": 5,
 };
 


### PR DESCRIPTION
## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #690

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- The Card Evolution Auditor was able to run on every automatic post-processing pass once enabled. Because it proposes sensitive character-card edits, that made it too easy for repeated audits to surface marginal updates and bloat cards over time.

## What changed

<!-- List the key changes in this PR -->

- Added a default `runInterval` of 8 assistant messages for the built-in Card Evolution Auditor.
- Added automatic generation-route cadence gating so the auditor skips post-processing turns until the interval has elapsed since its last successful run.
- Exposed the same Card Evolution Auditor cadence metadata in the client agent cadence UI.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

Codex-run proof:

- Before-fix repro against `upstream/main`: `node scratch\issue-690-card-evo-cadence.mjs upstream/main` failed all cadence checks:
  - `FAIL default run interval exists`
  - `FAIL generation route gates auditor by last successful run`
  - `FAIL client exposes built-in cadence control`
- After-fix verification: `node scratch\issue-690-card-evo-cadence.mjs` passed all cadence checks:
  - `PASS default run interval exists`
  - `PASS generation route gates auditor by last successful run`
  - `PASS client exposes built-in cadence control`
- Baseline: `pnpm check` passed locally, including impeccable context check, shared/server/client lint, and shared/server/client build.
- Edge cases considered:
  - Manual retry path remains ungated on purpose, so a user can deliberately rerun the auditor.
  - Setting `runInterval` to 1 still allows every-turn auditor checks for users who explicitly opt in.

No true human-only verification is required for the core claim.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs, release, schema, or version files changed.

## UI evidence (if applicable)

N/A - backend/shared cadence behavior with a small client metadata addition; no visible UI layout changed.
