### PR TITLE
Fix random connection schedule generation

### DIFF
--- a/packages/server/src/routes/conversation.routes.ts
+++ b/packages/server/src/routes/conversation.routes.ts
@@ -55,8 +55,26 @@ function getEnabledConversationSchedules(meta: Record<string, unknown>): Charact
 
 type SummaryEntry = { summary: string; keyDetails: string[] };
 type CharacterMemoryEntry = { from?: string; summary?: string; createdAt?: string };
+type ConnectionsStorage = ReturnType<typeof createConnectionsStorage>;
 
 const SCHEDULE_CONTINUITY_MAX_CHARS = 6000;
+
+async function resolveConversationScheduleConnection(connections: ConnectionsStorage, chatConnectionId: string | null) {
+  if (chatConnectionId === "random") {
+    const pool = await connections.listRandomPool();
+    if (!pool.length) {
+      return { conn: null, error: "No connections marked for the random pool" };
+    }
+    return { conn: pool[Math.floor(Math.random() * pool.length)] ?? null, error: null };
+  }
+
+  const connId = chatConnectionId ?? (await connections.getDefault())?.id;
+  if (!connId) {
+    return { conn: null, error: "No connection configured" };
+  }
+
+  return { conn: await connections.getWithKey(connId), error: null };
+}
 
 function parseDateKeyMs(dateKey: string): number {
   const match = dateKey.match(/^(\d{1,2})\.(\d{1,2})\.(\d{4})$/);
@@ -209,11 +227,9 @@ export async function conversationRoutes(app: FastifyInstance) {
     if (!chat) return reply.status(404).send({ error: "Chat not found" });
     if (chat.mode !== "conversation") return reply.status(400).send({ error: "Not a conversation chat" });
 
-    // Resolve connection (need getWithKey for decrypted API key)
-    const connId = chat.connectionId ?? (await connections.getDefault())?.id;
-    if (!connId) return reply.status(400).send({ error: "No connection configured" });
-    const conn = await connections.getWithKey(connId);
-    if (!conn) return reply.status(400).send({ error: "No connection configured" });
+    // Resolve connection (need decrypted API key; "random" is a sentinel, not a persisted connection id)
+    const { conn, error: connectionError } = await resolveConversationScheduleConnection(connections, chat.connectionId);
+    if (!conn) return reply.status(400).send({ error: connectionError ?? "No connection configured" });
     const baseUrl = resolveBaseUrl(conn);
     if (!baseUrl) return reply.status(400).send({ error: "No base URL" });
 


### PR DESCRIPTION
## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #693

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- Conversation schedule generation treated the saved random connection sentinel (`"random"`) as a real API connection id, so chats configured for random connections returned `400 No connection configured` instead of selecting from the random pool.

## What changed

<!-- List the key changes in this PR -->

- Added random-pool connection resolution to the conversation schedule generation route.
- Preserved the existing fixed-connection and default-connection fallback behavior.
- Return a clearer 400 when the chat is set to random but no connections are marked for the random pool.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- âš ï¸ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Codex reproduced the original route failure before the fix with a conversation chat whose `connectionId` was `"random"`: `/api/conversation/schedule/generate` returned `400` with `No connection configured`, and the stub provider received 0 calls.
- Codex reran the same route-level repro after the fix: random-pool schedule generation returned `200`, produced a generated weekly schedule, and the stub provider received 1 call.
- Codex also exercised edge cases with the same scratch route harness:
  - Empty random pool: returned `400 No connections marked for the random pool`, provider calls stayed at 0.
  - Fixed connection: returned `200`, generated a schedule, provider calls = 1.
  - Default connection fallback: returned `200`, generated a schedule, provider calls = 1.
- Codex ran `pnpm check`; Impeccable context check, lint, and shared/server/client builds passed.
- Scratch proof was recorded locally in `scratch/bugfix-verification.json` and `scratch/issue-693-after-random.json`.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs or version/release file changes are needed; this is a narrow server route bug fix.

## UI evidence (if applicable)

N/A - backend route behavior only. The bug was verified with a route-level scratch harness against the real server route.
