### PR TITLE
Round-trip persona & character native export/import (avatar, sprites, gallery)

### DIFF
--- a/packages/client/src/components/characters/CharacterEditor.tsx
+++ b/packages/client/src/components/characters/CharacterEditor.tsx
@@ -466,14 +466,6 @@ export function CharacterEditor() {
       </button>
 
       <button
-        onClick={() => api.download(`/characters/${characterId}/export-png`, "character.png")}
-        className={headerActionButtonClass}
-        title="Export as PNG card"
-      >
-        <ImageDown size="1rem" />
-      </button>
-
-      <button
         onClick={() => {
           if (!characterId) return;
           duplicateCharacter.mutate(characterId, {
@@ -505,11 +497,16 @@ export function CharacterEditor() {
         title="Export Character"
         description="Native keeps Marinara metadata. Compatible exports direct Chara Card V2 JSON for other platforms."
         compatibleDescription="Exports direct Chara Card V2 JSON without the Marinara wrapper."
+        showPngOption
         onClose={() => setExportDialogOpen(false)}
         onSelect={(format: ExportFormatChoice) => {
           if (!characterId) return;
           setExportDialogOpen(false);
-          void api.download(`/characters/${characterId}/export?format=${format}`);
+          if (format === "compatible-png") {
+            void api.download(`/characters/${characterId}/export-png`, "character.png");
+          } else {
+            void api.download(`/characters/${characterId}/export?format=${format}`);
+          }
         }}
       />
       <AvatarGenerationModal

--- a/packages/client/src/components/modals/ImportCharacterModal.tsx
+++ b/packages/client/src/components/modals/ImportCharacterModal.tsx
@@ -35,6 +35,12 @@ export function ImportCharacterModal({ open, onClose }: Props) {
   } | null>(null);
   const qc = useQueryClient();
 
+  const isZipFile = async (file: File): Promise<boolean> => {
+    if (file.size < 4) return false;
+    const head = new Uint8Array(await file.slice(0, 4).arrayBuffer());
+    return head[0] === 0x50 && head[1] === 0x4b;
+  };
+
   const handleFiles = async (files: File[], importEmbeddedLorebook?: boolean) => {
     if (files.length === 0) return;
     setStatus("loading");
@@ -44,11 +50,19 @@ export function ImportCharacterModal({ open, onClose }: Props) {
     try {
       const stCharacterFiles: File[] = [];
       const marinaraPayloads: Array<{ file: File; payload: Record<string, unknown> }> = [];
+      const marinaraPackages: File[] = [];
 
       for (const file of files) {
         const lower = file.name.toLowerCase();
         if (lower.endsWith(".png") || lower.endsWith(".charx")) {
           stCharacterFiles.push(file);
+          continue;
+        }
+
+        // Marinara native packages are .marinara zip files (data.json + avatar
+        // binary). Detect via the zip signature so a renamed file still works.
+        if (await isZipFile(file)) {
+          marinaraPackages.push(file);
           continue;
         }
 
@@ -144,6 +158,32 @@ export function ImportCharacterModal({ open, onClose }: Props) {
         } catch (error) {
           nextResults.push({
             filename: item.file.name,
+            success: false,
+            message: error instanceof Error ? error.message : "Import failed",
+          });
+        }
+      }
+
+      for (const file of marinaraPackages) {
+        try {
+          const form = new FormData();
+          form.append("file", file, file.name);
+          form.append(
+            "timestampOverrides",
+            JSON.stringify({ createdAt: file.lastModified, updatedAt: file.lastModified }),
+          );
+          const result = await api.upload<{ success: boolean; name?: string; error?: string }>(
+            "/import/marinara-package",
+            form,
+          );
+          nextResults.push({
+            filename: file.name,
+            success: result.success,
+            message: result.success ? `Imported "${result.name ?? file.name}"` : (result.error ?? "Import failed"),
+          });
+        } catch (error) {
+          nextResults.push({
+            filename: file.name,
             success: false,
             message: error instanceof Error ? error.message : "Import failed",
           });

--- a/packages/client/src/components/modals/ImportPersonaModal.tsx
+++ b/packages/client/src/components/modals/ImportPersonaModal.tsx
@@ -20,6 +20,12 @@ export function ImportPersonaModal({ open, onClose }: Props) {
   const [dragOver, setDragOver] = useState(false);
   const qc = useQueryClient();
 
+  const isZipFile = async (file: File): Promise<boolean> => {
+    if (file.size < 4) return false;
+    const head = new Uint8Array(await file.slice(0, 4).arrayBuffer());
+    return head[0] === 0x50 && head[1] === 0x4b;
+  };
+
   const handleFiles = async (files: File[]) => {
     if (files.length === 0) return;
     setStatus("loading");
@@ -28,6 +34,28 @@ export function ImportPersonaModal({ open, onClose }: Props) {
     const nextResults: Array<{ filename: string; success: boolean; message: string }> = [];
     for (const file of files) {
       try {
+        // Marinara native packages are .marinara files (zip with data.json +
+        // avatar binary). Detect via the zip signature so a renamed file
+        // still works.
+        if (await isZipFile(file)) {
+          const form = new FormData();
+          form.append("file", file, file.name);
+          form.append(
+            "timestampOverrides",
+            JSON.stringify({ createdAt: file.lastModified, updatedAt: file.lastModified }),
+          );
+          const data = await api.upload<{ success: boolean; name?: string; error?: string }>(
+            "/import/marinara-package",
+            form,
+          );
+          nextResults.push({
+            filename: file.name,
+            success: data.success,
+            message: data.success ? `Imported "${data.name ?? file.name}"` : (data.error ?? "Import failed"),
+          });
+          continue;
+        }
+
         const text = await file.text();
         const json = JSON.parse(text) as Record<string, unknown>;
 

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -2538,7 +2538,6 @@ function ImportSettings() {
       const head = file.size >= 4 ? new Uint8Array(await file.slice(0, 4).arrayBuffer()) : new Uint8Array();
       const isZip = head.length >= 2 && head[0] === 0x50 && head[1] === 0x4b;
       let res: Response;
-      let parseFailure = false;
       if (isZip) {
         const form = new FormData();
         form.append("file", file, file.name);
@@ -2548,7 +2547,6 @@ function ImportSettings() {
         try {
           envelope = JSON.parse(await file.text());
         } catch {
-          parseFailure = true;
           throw new Error("parse");
         }
         res = await fetch("/api/import/marinara", {

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -2535,14 +2535,28 @@ function ImportSettings() {
     const file = e.target.files?.[0];
     if (!file) return;
     try {
-      const text = await file.text();
-      const envelope = JSON.parse(text);
-      const res = await fetch("/api/import/marinara", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(envelope),
-      });
-      const data = await res.json();
+      // Detect .marinara native packages (zip with data.json + avatar) by
+      // their PK signature so they get routed to the multipart endpoint that
+      // unpacks the avatar; fall back to JSON for legacy .marinara.json
+      // envelopes and other marinara_* exports.
+      const head = file.size >= 4 ? new Uint8Array(await file.slice(0, 4).arrayBuffer()) : new Uint8Array();
+      const isZip = head.length >= 2 && head[0] === 0x50 && head[1] === 0x4b;
+      let data: { success?: boolean; name?: string; type?: string; error?: string };
+      if (isZip) {
+        const form = new FormData();
+        form.append("file", file, file.name);
+        const res = await fetch("/api/import/marinara-package", { method: "POST", body: form });
+        data = await res.json();
+      } else {
+        const text = await file.text();
+        const envelope = JSON.parse(text);
+        const res = await fetch("/api/import/marinara", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(envelope),
+        });
+        data = await res.json();
+      }
       if (data.success) {
         qc.invalidateQueries();
         toast.success(`Imported ${data.name ?? data.type} successfully!`);
@@ -2550,7 +2564,7 @@ function ImportSettings() {
         toast.error(`Import failed: ${data.error ?? "Unknown error"}`);
       }
     } catch {
-      toast.error("Import failed. Make sure this is a valid .marinara.json file.");
+      toast.error("Import failed. Make sure this is a valid .marinara file.");
     }
     e.target.value = "";
   };
@@ -2606,8 +2620,8 @@ function ImportSettings() {
       {/* Marinara import */}
       <label className="flex cursor-pointer items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-pink-500/20 to-orange-500/20 px-3 py-3 text-xs font-semibold ring-1 ring-pink-500/30 transition-all hover:ring-pink-500/50 active:scale-[0.98]">
         <Download size="1rem" />
-        Import Marinara File (.marinara.json)
-        <input type="file" accept=".json" onChange={handleMarinaraImport} className="hidden" />
+        Import Marinara File (.marinara / .json)
+        <input type="file" accept=".json,.marinara" onChange={handleMarinaraImport} className="hidden" />
       </label>
 
       <div className="retro-divider" />

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -2535,36 +2535,46 @@ function ImportSettings() {
     const file = e.target.files?.[0];
     if (!file) return;
     try {
-      // Detect .marinara native packages (zip with data.json + avatar) by
-      // their PK signature so they get routed to the multipart endpoint that
-      // unpacks the avatar; fall back to JSON for legacy .marinara.json
-      // envelopes and other marinara_* exports.
       const head = file.size >= 4 ? new Uint8Array(await file.slice(0, 4).arrayBuffer()) : new Uint8Array();
       const isZip = head.length >= 2 && head[0] === 0x50 && head[1] === 0x4b;
-      let data: { success?: boolean; name?: string; type?: string; error?: string };
+      let res: Response;
+      let parseFailure = false;
       if (isZip) {
         const form = new FormData();
         form.append("file", file, file.name);
-        const res = await fetch("/api/import/marinara-package", { method: "POST", body: form });
-        data = await res.json();
+        res = await fetch("/api/import/marinara-package", { method: "POST", body: form });
       } else {
-        const text = await file.text();
-        const envelope = JSON.parse(text);
-        const res = await fetch("/api/import/marinara", {
+        let envelope: unknown;
+        try {
+          envelope = JSON.parse(await file.text());
+        } catch {
+          parseFailure = true;
+          throw new Error("parse");
+        }
+        res = await fetch("/api/import/marinara", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(envelope),
         });
-        data = await res.json();
       }
-      if (data.success) {
+      const data = (await res.json().catch(() => ({}))) as {
+        success?: boolean;
+        name?: string;
+        type?: string;
+        error?: string;
+      };
+      if (res.ok && data.success) {
         qc.invalidateQueries();
         toast.success(`Imported ${data.name ?? data.type} successfully!`);
       } else {
-        toast.error(`Import failed: ${data.error ?? "Unknown error"}`);
+        toast.error(`Import failed: ${data.error ?? res.statusText ?? "Unknown error"}`);
       }
-    } catch {
-      toast.error("Import failed. Make sure this is a valid .marinara file.");
+    } catch (err) {
+      if (err instanceof Error && err.message === "parse") {
+        toast.error("Import failed. Make sure this is a valid .marinara or .json file.");
+      } else {
+        toast.error(`Import failed: ${err instanceof Error ? err.message : "network/server error"}`);
+      }
     }
     e.target.value = "";
   };

--- a/packages/client/src/components/ui/ExportFormatDialog.tsx
+++ b/packages/client/src/components/ui/ExportFormatDialog.tsx
@@ -1,8 +1,8 @@
-import { FileJson, Layers, X } from "lucide-react";
+import { FileJson, ImageDown, Layers, X } from "lucide-react";
 import { Modal } from "./Modal";
 import { cn } from "../../lib/utils";
 
-export type ExportFormatChoice = "native" | "compatible";
+export type ExportFormatChoice = "native" | "compatible" | "compatible-png";
 
 interface ExportFormatDialogProps {
   open: boolean;
@@ -10,6 +10,8 @@ interface ExportFormatDialogProps {
   description?: string;
   nativeDescription?: string;
   compatibleDescription?: string;
+  pngDescription?: string;
+  showPngOption?: boolean;
   onClose: () => void;
   onSelect: (format: ExportFormatChoice) => void;
 }
@@ -20,6 +22,8 @@ export function ExportFormatDialog({
   description = "Choose how Marinara should package this export.",
   nativeDescription = "Keeps Marinara-specific fields, folders, metadata, and import fidelity.",
   compatibleDescription = "Uses folderless, platform-friendly JSON where possible for tools like SillyTavern and Chub.",
+  pngDescription = "Chara Card V2 PNG with the avatar baked in — works in SillyTavern, Chub, and Risu.",
+  showPngOption = false,
   onClose,
   onSelect,
 }: ExportFormatDialogProps) {
@@ -31,13 +35,17 @@ export function ExportFormatDialog({
   }> = [
     { id: "native", label: "Marinara Native", icon: Layers, description: nativeDescription },
     { id: "compatible", label: "Compatible JSON", icon: FileJson, description: compatibleDescription },
+    ...(showPngOption
+      ? [{ id: "compatible-png" as const, label: "Compatible PNG Card", icon: ImageDown, description: pngDescription }]
+      : []),
   ];
 
   return (
     <Modal open={open} onClose={onClose} title={title} width="max-w-lg">
       <div className="space-y-4">
         <p className="text-xs leading-relaxed text-[var(--muted-foreground)]">{description}</p>
-        <div className="grid gap-2 sm:grid-cols-2">
+        <div className={cn("grid gap-2", showPngOption ? "sm:grid-cols-3" : "sm:grid-cols-2")}>
+
           {options.map((option) => {
             const Icon = option.icon;
             return (

--- a/packages/server/src/routes/characters.routes.ts
+++ b/packages/server/src/routes/characters.routes.ts
@@ -18,7 +18,7 @@ import { createConnectionsStorage } from "../services/storage/connections.storag
 import { generateImage } from "../services/image/image-generation.js";
 import { resolveConnectionImageDefaults } from "../services/image/image-generation-defaults.js";
 import { loadImageGenerationUserSettings } from "../services/image/image-generation-settings.js";
-import { writeFile, mkdir, readFile } from "fs/promises";
+import { writeFile, mkdir, readFile, readdir } from "fs/promises";
 import { join } from "path";
 import { DATA_DIR } from "../utils/data-dir.js";
 import { createWriteStream, existsSync, rmSync, unlinkSync } from "fs";
@@ -102,10 +102,101 @@ async function resolveAvatarGenerationConnection(app: FastifyInstance, body: Ava
 
 type ExportFormat = "native" | "compatible";
 
-function buildNativeCharacterEnvelope(
-  char: { createdAt: string; updatedAt: string; comment?: string | null },
+// Read an image file and return it as a base64 data URL, or null if the file
+// is missing, outside the expected dir, or not a recognized image type. Used
+// by native exports to embed binary data (avatars, sprites, gallery shots)
+// directly into the JSON envelope so personas/characters round-trip with
+// every image intact.
+async function readImageAsDataUrl(rootDir: string, filename: string): Promise<string | null> {
+  if (!filename || filename.includes("..") || filename.includes("/") || filename.includes("\\")) return null;
+  let filepath: string;
+  try {
+    filepath = assertInsideDir(rootDir, join(rootDir, filename));
+  } catch {
+    return null;
+  }
+  if (!existsSync(filepath)) return null;
+  try {
+    const buf = await readFile(filepath);
+    const info = isAllowedImageBuffer(buf, extname(filename));
+    if (!info) return null;
+    return `data:${info.mimeType};base64,${buf.toString("base64")}`;
+  } catch {
+    return null;
+  }
+}
+
+// Pull the avatar off disk for the persona/character row's avatarPath
+// (format: /api/avatars/file/<filename>). Returns null if missing/invalid.
+async function readAvatarDataUrl(avatarPath: string | null | undefined): Promise<string | null> {
+  if (!avatarPath || typeof avatarPath !== "string") return null;
+  const filename = avatarPath.split("?")[0]!.split("/").pop();
+  if (!filename) return null;
+  return readImageAsDataUrl(join(DATA_DIR, "avatars"), filename);
+}
+
+// Read every sprite file in data/sprites/<id>/ and return it as
+// { filename, data } so import can restore the same expression set under a
+// new id.
+async function readSpritesForId(
+  id: string,
+): Promise<Array<{ filename: string; data: string }>> {
+  const dir = join(DATA_DIR, "sprites", id);
+  if (!existsSync(dir)) return [];
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch {
+    return [];
+  }
+  const sprites: Array<{ filename: string; data: string }> = [];
+  for (const entry of entries) {
+    const dataUrl = await readImageAsDataUrl(dir, entry);
+    if (dataUrl) sprites.push({ filename: entry, data: dataUrl });
+  }
+  return sprites;
+}
+
+// Read every gallery image for a character (metadata row + binary on disk),
+// returning a serializable list that import can rebuild the gallery from.
+async function readGalleryForCharacter(
+  characterId: string,
+  galleryStorage: { listByCharacterId: (id: string) => Promise<any[]> },
+): Promise<Array<Record<string, unknown>>> {
+  const images = await galleryStorage.listByCharacterId(characterId);
+  const result: Array<Record<string, unknown>> = [];
+  for (const img of images) {
+    // img.filePath is stored relative to data/gallery/, e.g.
+    // "characters/<id>/<filename>". The original filename is the basename.
+    const relPath: string = typeof img.filePath === "string" ? img.filePath : "";
+    const filename = relPath.split("/").pop() ?? "";
+    if (!filename) continue;
+    const galleryDir = join(DATA_DIR, "gallery", "characters", characterId);
+    const dataUrl = await readImageAsDataUrl(galleryDir, filename);
+    if (!dataUrl) continue;
+    result.push({
+      filename,
+      data: dataUrl,
+      prompt: img.prompt ?? "",
+      provider: img.provider ?? "",
+      model: img.model ?? "",
+      width: img.width ?? null,
+      height: img.height ?? null,
+    });
+  }
+  return result;
+}
+
+async function buildNativeCharacterEnvelope(
+  char: { id: string; createdAt: string; updatedAt: string; comment?: string | null; avatarPath?: string | null },
   data: any,
+  galleryStorage: { listByCharacterId: (id: string) => Promise<any[]> },
 ) {
+  const [avatar, sprites, gallery] = await Promise.all([
+    readAvatarDataUrl(char.avatarPath),
+    readSpritesForId(char.id),
+    readGalleryForCharacter(char.id, galleryStorage),
+  ]);
   return {
     type: "marinara_character",
     version: 1,
@@ -114,6 +205,9 @@ function buildNativeCharacterEnvelope(
       spec: "chara_card_v2",
       spec_version: "2.0",
       data,
+      ...(avatar ? { avatar } : {}),
+      ...(sprites.length > 0 ? { sprites } : {}),
+      ...(gallery.length > 0 ? { gallery } : {}),
       metadata: {
         createdAt: char.createdAt,
         updatedAt: char.updatedAt,
@@ -131,14 +225,21 @@ function buildCompatibleCharacterExport(data: any) {
   };
 }
 
-function buildNativePersonaEnvelope(persona: Record<string, unknown>) {
-  const { id: _id, createdAt, updatedAt, avatarPath: _avatarPath, isActive: _isActive, ...personaData } = persona;
+async function buildNativePersonaEnvelope(persona: Record<string, unknown>) {
+  const { id: _id, createdAt, updatedAt, avatarPath, isActive: _isActive, ...personaData } = persona;
+  const personaId = typeof _id === "string" ? _id : "";
+  const [avatar, sprites] = await Promise.all([
+    readAvatarDataUrl(typeof avatarPath === "string" ? avatarPath : null),
+    personaId ? readSpritesForId(personaId) : Promise.resolve([] as Array<{ filename: string; data: string }>),
+  ]);
   return {
     type: "marinara_persona",
     version: 1,
     exportedAt: new Date().toISOString(),
     data: {
       ...personaData,
+      ...(avatar ? { avatar } : {}),
+      ...(sprites.length > 0 ? { sprites } : {}),
       metadata: {
         createdAt,
         updatedAt,
@@ -417,7 +518,7 @@ export async function charactersRoutes(app: FastifyInstance) {
     const compatible = req.query.format === "compatible";
     const payload = compatible
       ? buildCompatibleCharacterExport(charData)
-      : buildNativeCharacterEnvelope(char, charData);
+      : await buildNativeCharacterEnvelope(char, charData, characterGallery);
     return reply
       .header(
         "Content-Disposition",
@@ -441,7 +542,7 @@ export async function charactersRoutes(app: FastifyInstance) {
       const payload =
         format === "compatible"
           ? buildCompatibleCharacterExport(charData)
-          : buildNativeCharacterEnvelope(char, charData);
+          : await buildNativeCharacterEnvelope(char, charData, characterGallery);
       zip.addFile(
         `${toSafeExportName(String(charData.name ?? "character"), `character-${exportedCount + 1}`)}.${format === "compatible" ? "json" : "marinara.json"}`,
         Buffer.from(JSON.stringify(payload, null, 2), "utf-8"),
@@ -689,7 +790,7 @@ export async function charactersRoutes(app: FastifyInstance) {
       const compatible = req.query.format === "compatible";
       const payload = compatible
         ? buildCompatiblePersonaExport(persona as Record<string, unknown>)
-        : buildNativePersonaEnvelope(persona as Record<string, unknown>);
+        : await buildNativePersonaEnvelope(persona as Record<string, unknown>);
       return reply
         .header(
           "Content-Disposition",
@@ -713,7 +814,7 @@ export async function charactersRoutes(app: FastifyInstance) {
       const payload =
         format === "compatible"
           ? buildCompatiblePersonaExport(persona as Record<string, unknown>)
-          : buildNativePersonaEnvelope(persona as Record<string, unknown>);
+          : await buildNativePersonaEnvelope(persona as Record<string, unknown>);
       zip.addFile(
         `${toSafeExportName(String(persona.name ?? "persona"), `persona-${exportedCount + 1}`)}.${format === "compatible" ? "json" : "marinara.json"}`,
         Buffer.from(JSON.stringify(payload, null, 2), "utf-8"),

--- a/packages/server/src/routes/import.routes.ts
+++ b/packages/server/src/routes/import.routes.ts
@@ -458,9 +458,24 @@ export async function importRoutes(app: FastifyInstance) {
     } catch {
       return reply.status(400).send({ success: false, error: "Could not read .marinara package" });
     }
+    // Bounds checks before any getData() call — a legitimate .marinara package
+    // ships data.json plus at most one avatar.* entry, so anything way past
+    // that is either accidental cruft or a zip-bomb-style decompression
+    // attempt. Sizes are read off the entry headers, not the decompressed
+    // stream, so we reject before paying the memory cost.
+    const MAX_PACKAGE_ENTRIES = 8;
+    const MAX_DATA_JSON_BYTES = 5 * 1024 * 1024;
+    const MAX_AVATAR_BYTES = 20 * 1024 * 1024;
+    const entries = zip.getEntries();
+    if (entries.length > MAX_PACKAGE_ENTRIES) {
+      return reply.status(400).send({ success: false, error: ".marinara package has too many entries" });
+    }
     const dataEntry = zip.getEntry("data.json");
     if (!dataEntry) {
       return reply.status(400).send({ success: false, error: ".marinara package is missing data.json" });
+    }
+    if ((dataEntry.header.size ?? 0) > MAX_DATA_JSON_BYTES) {
+      return reply.status(400).send({ success: false, error: "data.json in package is too large" });
     }
     let envelope: Record<string, unknown>;
     try {
@@ -468,11 +483,10 @@ export async function importRoutes(app: FastifyInstance) {
     } catch {
       return reply.status(400).send({ success: false, error: "data.json is not valid JSON" });
     }
-    // Find an avatar.* entry (any image extension) and inject as data URL on
-    // envelope.data so the existing importer's avatar-handling kicks in.
-    const avatarEntry = zip
-      .getEntries()
-      .find((e) => /^avatar\.(png|jpe?g|webp|gif|avif)$/i.test(e.entryName));
+    const avatarEntry = entries.find((e) => /^avatar\.(png|jpe?g|webp|gif|avif)$/i.test(e.entryName));
+    if (avatarEntry && (avatarEntry.header.size ?? 0) > MAX_AVATAR_BYTES) {
+      return reply.status(400).send({ success: false, error: "Avatar image in package is too large" });
+    }
     if (avatarEntry && envelope.data && typeof envelope.data === "object") {
       const ext = avatarEntry.entryName.split(".").pop()!.toLowerCase();
       const mime =

--- a/packages/server/src/routes/import.routes.ts
+++ b/packages/server/src/routes/import.routes.ts
@@ -440,6 +440,64 @@ export async function importRoutes(app: FastifyInstance) {
     return importMarinara(payload as any, app.db);
   });
 
+  /**
+   * Import a Marinara Engine native package (.marinara file — a zip with
+   * data.json plus the avatar binary). Single-file multipart upload.
+   */
+  app.post("/marinara-package", async (req, reply) => {
+    const file = await req.file();
+    if (!file) return reply.status(400).send({ success: false, error: "No file uploaded" });
+    const buffer = await file.toBuffer();
+    if (buffer.length < 4 || buffer[0] !== 0x50 || buffer[1] !== 0x4b) {
+      return reply.status(400).send({ success: false, error: "Not a .marinara package (zip signature missing)" });
+    }
+    const AdmZip = (await import("adm-zip")).default;
+    let zip: InstanceType<typeof AdmZip>;
+    try {
+      zip = new AdmZip(buffer);
+    } catch {
+      return reply.status(400).send({ success: false, error: "Could not read .marinara package" });
+    }
+    const dataEntry = zip.getEntry("data.json");
+    if (!dataEntry) {
+      return reply.status(400).send({ success: false, error: ".marinara package is missing data.json" });
+    }
+    let envelope: Record<string, unknown>;
+    try {
+      envelope = JSON.parse(dataEntry.getData().toString("utf-8")) as Record<string, unknown>;
+    } catch {
+      return reply.status(400).send({ success: false, error: "data.json is not valid JSON" });
+    }
+    // Find an avatar.* entry (any image extension) and inject as data URL on
+    // envelope.data so the existing importer's avatar-handling kicks in.
+    const avatarEntry = zip
+      .getEntries()
+      .find((e) => /^avatar\.(png|jpe?g|webp|gif|avif)$/i.test(e.entryName));
+    if (avatarEntry && envelope.data && typeof envelope.data === "object") {
+      const ext = avatarEntry.entryName.split(".").pop()!.toLowerCase();
+      const mime =
+        ext === "jpg" || ext === "jpeg"
+          ? "image/jpeg"
+          : ext === "webp"
+            ? "image/webp"
+            : ext === "gif"
+              ? "image/gif"
+              : ext === "avif"
+                ? "image/avif"
+                : "image/png";
+      const dataUrl = `data:${mime};base64,${avatarEntry.getData().toString("base64")}`;
+      (envelope.data as Record<string, unknown>).avatar = dataUrl;
+    }
+    const timestampOverrides = readTimestampOverridesFromMultipart(file as any);
+    if (timestampOverrides && envelope.data && typeof envelope.data === "object") {
+      const data = envelope.data as Record<string, unknown>;
+      const existingMeta =
+        data.metadata && typeof data.metadata === "object" ? (data.metadata as Record<string, unknown>) : {};
+      data.metadata = { ...existingMeta, timestamps: timestampOverrides };
+    }
+    return importMarinara(envelope as any, app.db);
+  });
+
   /** Import a SillyTavern character (JSON body or PNG file upload). */
   app.post("/st-character", async (req) => {
     const contentType = req.headers["content-type"] ?? "";

--- a/packages/server/src/services/import/marinara.importer.ts
+++ b/packages/server/src/services/import/marinara.importer.ts
@@ -63,13 +63,15 @@ async function restoreSprites(sprites: unknown, id: string): Promise<void> {
   if (!Array.isArray(sprites) || sprites.length === 0) return;
   const dir = join(DATA_DIR, "sprites", id);
   await mkdir(dir, { recursive: true });
+  // Track names we've already written this batch so two exported sprites
+  // whose stems sanitize to the same string (e.g. "happy!" and "happy?" both
+  // collapsing to "happy_") don't silently overwrite each other.
+  const usedNames = new Set<string>();
   for (const sprite of sprites) {
     if (!sprite || typeof sprite !== "object") continue;
     const entry = sprite as Record<string, unknown>;
     const decoded = decodeImageDataUrl(entry.data);
     if (!decoded) continue;
-    // Take the original filename's stem (e.g. "happy" from "happy.png"), drop
-    // any path segments or .. tricks, and pair it with the verified extension.
     const rawName = typeof entry.filename === "string" ? entry.filename : "";
     const stem =
       rawName
@@ -79,7 +81,13 @@ async function restoreSprites(sprites: unknown, id: string): Promise<void> {
         ?.replace(/\.[^.]+$/, "")
         ?.replace(/[^a-zA-Z0-9_\- ]/g, "_")
         ?.slice(0, 80) || `sprite-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
-    const safeName = `${stem}.${decoded.ext}`;
+    let safeName = `${stem}.${decoded.ext}`;
+    let suffix = 1;
+    while (usedNames.has(safeName)) {
+      safeName = `${stem}-${suffix}.${decoded.ext}`;
+      suffix++;
+    }
+    usedNames.add(safeName);
     try {
       const filepath = assertInsideDir(dir, join(dir, safeName));
       await writeFile(filepath, decoded.buffer);

--- a/packages/server/src/services/import/marinara.importer.ts
+++ b/packages/server/src/services/import/marinara.importer.ts
@@ -5,9 +5,126 @@ import type { DB } from "../../db/connection.js";
 import { lorebookFilterModeSchema } from "@marinara-engine/shared";
 import type { ExportEnvelope, ExportType, LorebookFilterMode, LorebookMatchingSource } from "@marinara-engine/shared";
 import { createCharactersStorage } from "../storage/characters.storage.js";
+import { createCharacterGalleryStorage } from "../storage/character-gallery.storage.js";
 import { createLorebooksStorage } from "../storage/lorebooks.storage.js";
 import { createPromptsStorage } from "../storage/prompts.storage.js";
 import { normalizeTimestampOverrides, type TimestampOverrides } from "./import-timestamps.js";
+import { mkdir, writeFile } from "fs/promises";
+import { join } from "path";
+import { DATA_DIR } from "../../utils/data-dir.js";
+import { assertInsideDir, extensionFromImageMime, isAllowedImageBuffer } from "../../utils/security.js";
+
+// Decode a base64 data URL into validated image bytes. Returns null if the
+// payload is missing, malformed, or not a recognized image type — so callers
+// can treat optional images as "skip this one" rather than failing the whole
+// import.
+function decodeImageDataUrl(dataUrl: unknown): { buffer: Buffer; ext: string } | null {
+  if (typeof dataUrl !== "string" || dataUrl.length === 0) return null;
+  let base64 = dataUrl;
+  let hintedExt = ".png";
+  if (base64.startsWith("data:")) {
+    const match = base64.match(/^data:image\/([\w+]+);base64,/);
+    if (match?.[1]) hintedExt = `.${match[1].replace("+xml", "")}`;
+    const commaIdx = base64.indexOf(",");
+    if (commaIdx >= 0) base64 = base64.slice(commaIdx + 1);
+  }
+  let buffer: Buffer;
+  try {
+    buffer = Buffer.from(base64, "base64");
+  } catch {
+    return null;
+  }
+  if (buffer.length === 0) return null;
+  const info = isAllowedImageBuffer(buffer, hintedExt);
+  if (!info) return null;
+  return { buffer, ext: extensionFromImageMime(info.mimeType) };
+}
+
+// Decode an `avatar` data URL carried in a native export, validate it as a
+// real image, write it under data/avatars/, and return the URL path the row
+// should store. Returns null on any failure so the import still succeeds
+// without an avatar rather than 500-ing.
+async function saveAvatarFromDataUrl(dataUrl: unknown, prefix: string, id: string): Promise<string | null> {
+  const decoded = decodeImageDataUrl(dataUrl);
+  if (!decoded) return null;
+  const avatarsDir = join(DATA_DIR, "avatars");
+  await mkdir(avatarsDir, { recursive: true });
+  const filename = `${prefix}-${id}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.${decoded.ext}`;
+  const filepath = assertInsideDir(avatarsDir, join(avatarsDir, filename));
+  await writeFile(filepath, decoded.buffer);
+  return `/api/avatars/file/${filename}`;
+}
+
+// Restore sprites embedded as [{ filename, data }, ...] in a native export
+// by writing each one under data/sprites/<id>/. Filenames are sanitized to
+// just an expression stem + an extension matching the actual image bytes, so
+// a malicious export can't traverse out of the sprites dir.
+async function restoreSprites(sprites: unknown, id: string): Promise<void> {
+  if (!Array.isArray(sprites) || sprites.length === 0) return;
+  const dir = join(DATA_DIR, "sprites", id);
+  await mkdir(dir, { recursive: true });
+  for (const sprite of sprites) {
+    if (!sprite || typeof sprite !== "object") continue;
+    const entry = sprite as Record<string, unknown>;
+    const decoded = decodeImageDataUrl(entry.data);
+    if (!decoded) continue;
+    // Take the original filename's stem (e.g. "happy" from "happy.png"), drop
+    // any path segments or .. tricks, and pair it with the verified extension.
+    const rawName = typeof entry.filename === "string" ? entry.filename : "";
+    const stem =
+      rawName
+        .replace(/\\/g, "/")
+        .split("/")
+        .pop()
+        ?.replace(/\.[^.]+$/, "")
+        ?.replace(/[^a-zA-Z0-9_\- ]/g, "_")
+        ?.slice(0, 80) || `sprite-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+    const safeName = `${stem}.${decoded.ext}`;
+    try {
+      const filepath = assertInsideDir(dir, join(dir, safeName));
+      await writeFile(filepath, decoded.buffer);
+    } catch {
+      // skip this sprite
+    }
+  }
+}
+
+// Restore gallery images embedded as
+// [{ filename, data, prompt, provider, model, width, height }, ...]
+// in a native character export. Writes the binary under
+// data/gallery/characters/<id>/ and creates a matching row in
+// character_images so the gallery panel can find each shot.
+async function restoreCharacterGallery(
+  gallery: unknown,
+  characterId: string,
+  galleryStorage: ReturnType<typeof createCharacterGalleryStorage>,
+): Promise<void> {
+  if (!Array.isArray(gallery) || gallery.length === 0) return;
+  const dir = join(DATA_DIR, "gallery", "characters", characterId);
+  await mkdir(dir, { recursive: true });
+  for (const item of gallery) {
+    if (!item || typeof item !== "object") continue;
+    const entry = item as Record<string, unknown>;
+    const decoded = decodeImageDataUrl(entry.data);
+    if (!decoded) continue;
+    const safeFilename = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}.${decoded.ext}`;
+    try {
+      const filepath = assertInsideDir(dir, join(dir, safeFilename));
+      await writeFile(filepath, decoded.buffer);
+      await galleryStorage.create({
+        characterId,
+        filePath: `characters/${characterId}/${safeFilename}`,
+        prompt: typeof entry.prompt === "string" ? entry.prompt : "",
+        provider: typeof entry.provider === "string" ? entry.provider : "",
+        model: typeof entry.model === "string" ? entry.model : "",
+        width: typeof entry.width === "number" ? entry.width : undefined,
+        height: typeof entry.height === "number" ? entry.height : undefined,
+      });
+    } catch {
+      // skip this image
+    }
+  }
+}
 
 function readTimestampOverrides(value: unknown): TimestampOverrides | undefined {
   if (!value || typeof value !== "object") return undefined;
@@ -79,7 +196,16 @@ export async function importMarinara(
 
 async function importCharacter(data: unknown, db: DB) {
   const storage = createCharactersStorage(db);
-  const d = data as { data?: Record<string, unknown>; spec?: string; spec_version?: string; metadata?: unknown };
+  const galleryStorage = createCharacterGalleryStorage(db);
+  const d = data as {
+    data?: Record<string, unknown>;
+    spec?: string;
+    spec_version?: string;
+    metadata?: unknown;
+    avatar?: unknown;
+    sprites?: unknown;
+    gallery?: unknown;
+  };
   const charData = d?.data ? { ...(d.data as Record<string, unknown>) } : undefined;
   const metadata = d?.metadata && typeof d.metadata === "object" ? (d.metadata as Record<string, unknown>) : null;
   const comment = typeof metadata?.comment === "string" ? metadata.comment : undefined;
@@ -133,6 +259,14 @@ async function importCharacter(data: unknown, db: DB) {
   }
 
   const result = await storage.create(charData as any, undefined, readTimestampOverrides(d), comment);
+  if (result?.id) {
+    const avatarPath = await saveAvatarFromDataUrl(d.avatar, "character", result.id);
+    if (avatarPath) {
+      await storage.updateAvatar(result.id, avatarPath);
+    }
+    await restoreSprites(d.sprites, result.id);
+    await restoreCharacterGallery(d.gallery, result.id, galleryStorage);
+  }
   return {
     success: true,
     type: "marinara_character" as const,
@@ -149,11 +283,19 @@ async function importPersona(data: unknown, db: DB) {
   if (!d || typeof d !== "object") {
     return { success: false, type: "marinara_persona" as const, error: "Invalid persona data" };
   }
+  // Stringify JSON-array DB fields if the exporter sent them as parsed arrays;
+  // the table stores them as strings ("[]" when empty).
+  const stringifyJsonField = (value: unknown, fallback: string): string => {
+    if (typeof value === "string") return value;
+    if (Array.isArray(value) || (value && typeof value === "object")) return JSON.stringify(value);
+    return fallback;
+  };
   const result = await storage.createPersona(
     String(d.name ?? "Imported Persona"),
     String(d.description ?? ""),
     undefined,
     {
+      comment: typeof d.comment === "string" ? d.comment : "",
       personality: String(d.personality ?? ""),
       scenario: String(d.scenario ?? ""),
       backstory: String(d.backstory ?? ""),
@@ -161,6 +303,10 @@ async function importPersona(data: unknown, db: DB) {
       nameColor: String(d.nameColor ?? ""),
       dialogueColor: String(d.dialogueColor ?? ""),
       boxColor: String(d.boxColor ?? ""),
+      personaStats: typeof d.personaStats === "string" ? d.personaStats : "",
+      altDescriptions: stringifyJsonField(d.altDescriptions, "[]"),
+      tags: stringifyJsonField(d.tags, "[]"),
+      savedStatusOptions: stringifyJsonField(d.savedStatusOptions, "[]"),
       // avatarCrop is stored as a JSON string in the DB; the export round-trips it
       // as either an object or the empty string. Re-stringify objects on import.
       avatarCrop:
@@ -172,6 +318,13 @@ async function importPersona(data: unknown, db: DB) {
     },
     readTimestampOverrides(d),
   );
+  if (result?.id) {
+    const avatarPath = await saveAvatarFromDataUrl(d.avatar, "persona", result.id);
+    if (avatarPath) {
+      await storage.updatePersona(result.id, { avatarPath });
+    }
+    await restoreSprites(d.sprites, result.id);
+  }
   return {
     success: true,
     type: "marinara_persona" as const,


### PR DESCRIPTION
## Why

Closes #709.

Exporting a persona or character as **Marinara Native** and re-importing the file was dropping the profile picture and several other tab contents. The native envelope only carried the row's plain text fields — `avatarPath` was stripped (and the file was never embedded), sprites lived in a separate `data/sprites/<id>/` directory that the export ignored, and the character gallery was a whole separate table that nothing touched. On top of that, the persona importer was throwing away `comment`, `personaStats`, `altDescriptions`, `tags`, and `savedStatusOptions` because those fields weren't wired into `createPersona`.

The user's expectation is that Marinara Native means "everything round-trips." This PR makes that true.

## What changes

**Native export now embeds binary data as base64 data URLs inside the JSON envelope:**
- `data.avatar` — the profile picture (personas and characters)
- `data.sprites` — every file in `data/sprites/<id>/` as `{ filename, data }`
- `data.gallery` — every `character_images` row + the file on disk as `{ filename, prompt, provider, model, width, height, data }` (characters only)

**Native import** unpacks all three and writes them back: avatar to `data/avatars/`, sprites to `data/sprites/<newId>/` (filenames sanitized), gallery binaries to `data/gallery/characters/<newId>/` plus matching `character_images` rows. Image bytes are validated through `isAllowedImageBuffer` before anything hits disk.

**Persona importer** now also passes `comment`, `personaStats`, `altDescriptions`, `tags`, `savedStatusOptions` through to `createPersona` so they survive the round-trip.

**Compatible JSON** export/import is unchanged — it's still avatar-less and field-minimal, as expected by other tools.

**Export dialog UX (characters only):** a third "Compatible PNG Card" card joins Marinara Native and Compatible JSON, and the standalone PNG-card toolbar button is removed so the export menu isn't bloated. The PNG path still hits the existing `/characters/:id/export-png` endpoint.

**Backward compat:** an earlier iteration shipped a `.marinara` zip format briefly. The new `POST /import/marinara-package` multipart endpoint accepts those zips (data.json + avatar.*) so anyone who already exported one can still import it. Client modals detect the PK zip signature on dropped files and route to that endpoint automatically.

## Files

- `packages/server/src/routes/characters.routes.ts` — embed avatar/sprites/gallery in native envelopes
- `packages/server/src/routes/import.routes.ts` — new `/import/marinara-package` multipart route for legacy `.marinara` zip files
- `packages/server/src/services/import/marinara.importer.ts` — `restoreSprites`, `restoreCharacterGallery`, persona field passthrough, shared `decodeImageDataUrl` helper
- `packages/client/src/components/ui/ExportFormatDialog.tsx` — new `compatible-png` choice + `showPngOption` prop
- `packages/client/src/components/characters/CharacterEditor.tsx` — wire up PNG choice; drop the standalone toolbar button
- `packages/client/src/components/modals/ImportCharacterModal.tsx`, `ImportPersonaModal.tsx`, `panels/SettingsPanel.tsx` — zip-signature detection so legacy `.marinara` zips still import

## Validation

- `pnpm check` passes (impeccable-context + lint + build).
- Manually tested by author before opening this PR.

## Out of scope / known

- Compatible JSON intentionally still omits avatar/sprites/gallery to stay portable with other tools.
- Personas have no native PNG-card equivalent — the third option only appears for characters.