### PR TITLE
feat(game-setup): allow removing learned chips in Game Setup wizard

### DIFF
--- a/packages/client/src/components/game/GameSetupWizard.tsx
+++ b/packages/client/src/components/game/GameSetupWizard.tsx
@@ -164,12 +164,14 @@ function LearnedOptionChips({
   expanded,
   onToggleExpanded,
   onSelect,
+  onForget,
   selected,
 }: {
   options: string[];
   expanded: boolean;
   onToggleExpanded: () => void;
   onSelect: (value: string) => void;
+  onForget?: (value: string) => void;
   selected?: (value: string) => boolean;
 }) {
   if (options.length === 0) return null;
@@ -182,19 +184,37 @@ function LearnedOptionChips({
       {visible.map((option) => {
         const isSelected = selected?.(option) ?? false;
         return (
-          <button
+          <span
             key={option}
-            type="button"
-            onClick={() => onSelect(option)}
             className={cn(
-              "rounded-full px-2 py-0.5 text-[0.625rem] transition-colors",
+              "group/learned inline-flex items-center rounded-full text-[0.625rem] transition-colors",
               isSelected
                 ? "bg-[var(--primary)]/20 text-[var(--primary)] ring-1 ring-[var(--primary)]/35"
                 : "bg-[var(--secondary)] text-[var(--muted-foreground)] hover:bg-[var(--primary)]/10 hover:text-[var(--primary)]",
             )}
           >
-            {option}
-          </button>
+            <button
+              type="button"
+              onClick={() => onSelect(option)}
+              className="px-2 py-0.5"
+            >
+              {option}
+            </button>
+            {onForget && (
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onForget(option);
+                }}
+                aria-label={`Forget ${option}`}
+                title="Forget this option"
+                className="ml-0.5 mr-1 inline-flex rounded-full p-0.5 opacity-40 transition-opacity hover:bg-[var(--destructive)]/20 hover:text-[var(--destructive)] hover:opacity-100 focus-visible:opacity-100 group-hover/learned:opacity-100"
+              >
+                <X size={9} />
+              </button>
+            )}
+          </span>
         );
       })}
       {(hiddenCount > 0 || expanded) && (
@@ -302,6 +322,7 @@ export function GameSetupWizard({ onComplete, onCancel, isLoading, characters }:
   const sidecarConfig = useSidecarStore((s) => s.config);
   const learnedGameSetupOptions = useUIStore((s) => s.learnedGameSetupOptions);
   const rememberGameSetupOptions = useUIStore((s) => s.rememberGameSetupOptions);
+  const forgetGameSetupOption = useUIStore((s) => s.forgetGameSetupOption);
   const sidecarAvailable = !!sidecarConfig.modelPath && sidecarStatus !== "not_downloaded";
 
   // Fetch sidecar status on mount so the dropdown is populated without visiting Connections first
@@ -623,6 +644,7 @@ export function GameSetupWizard({ onComplete, onCancel, isLoading, characters }:
                 expanded={expandedLearnedOptions.genres}
                 onToggleExpanded={() => toggleLearnedOptions("genres")}
                 onSelect={toggleGenre}
+                onForget={(value) => forgetGameSetupOption("genres", value)}
                 selected={(value) => genres.includes(value)}
               />
               <div className="mt-2 flex items-center gap-1.5">
@@ -671,6 +693,7 @@ export function GameSetupWizard({ onComplete, onCancel, isLoading, characters }:
                 expanded={expandedLearnedOptions.settings}
                 onToggleExpanded={() => toggleLearnedOptions("settings")}
                 onSelect={setSetting}
+                onForget={(value) => forgetGameSetupOption("settings", value)}
               />
             </div>
 
@@ -713,6 +736,7 @@ export function GameSetupWizard({ onComplete, onCancel, isLoading, characters }:
                 expanded={expandedLearnedOptions.tones}
                 onToggleExpanded={() => toggleLearnedOptions("tones")}
                 onSelect={toggleTone}
+                onForget={(value) => forgetGameSetupOption("tones", value)}
                 selected={(value) => tones.includes(value)}
               />
               <div className="mt-2 flex items-center gap-1.5">
@@ -1521,6 +1545,7 @@ export function GameSetupWizard({ onComplete, onCancel, isLoading, characters }:
                 expanded={expandedLearnedOptions.goals}
                 onToggleExpanded={() => toggleLearnedOptions("goals")}
                 onSelect={setPlayerGoals}
+                onForget={(value) => forgetGameSetupOption("goals", value)}
               />
             </div>
 
@@ -1552,6 +1577,7 @@ export function GameSetupWizard({ onComplete, onCancel, isLoading, characters }:
                 expanded={expandedLearnedOptions.preferences}
                 onToggleExpanded={() => toggleLearnedOptions("preferences")}
                 onSelect={setPreferences}
+                onForget={(value) => forgetGameSetupOption("preferences", value)}
               />
             </div>
 

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -496,6 +496,7 @@ interface UIState {
     options: Partial<GameSetupLearnedOptions>,
     text?: Partial<GameSetupRememberedText>,
   ) => void;
+  forgetGameSetupOption: (group: keyof GameSetupLearnedOptions, value: string) => void;
   setEnterToSendRP: (v: boolean) => void;
   setEnterToSendConvo: (v: boolean) => void;
   setEnterToSendGame: (v: boolean) => void;
@@ -1077,6 +1078,19 @@ export const useUIStore = create<UIState>()(
                   ? normalizeRememberedGameSetupText(text.preferences)
                   : remembered.preferences,
             },
+          };
+        }),
+      forgetGameSetupOption: (group, value) =>
+        set((state) => {
+          const learned = state.learnedGameSetupOptions ?? DEFAULT_GAME_SETUP_LEARNED_OPTIONS;
+          const targetKey = normalizeLearnedGameSetupOption(value).toLowerCase();
+          if (!targetKey) return state;
+          const next = learned[group].filter(
+            (entry) => normalizeLearnedGameSetupOption(entry).toLowerCase() !== targetKey,
+          );
+          if (next.length === learned[group].length) return state;
+          return {
+            learnedGameSetupOptions: { ...learned, [group]: next },
           };
         }),
       setEnterToSendRP: (v) => set({ enterToSendRP: v }),


### PR DESCRIPTION
## Linked issue

Closes #716

## Why this change

- The Game Setup wizard auto-saves anything typed into the custom Genre / Setting / Tone / Player Goals / Additional Preferences fields and surfaces it as a chip the next time the wizard opens.
- Today there is no UI affordance to remove an individual learned entry, so typos and one-off experiments accumulate up to the 60-per-group cap and there is no way to prune them without nuking `localStorage`.

## What changed

- `packages/client/src/stores/ui.store.ts`: new `forgetGameSetupOption(group, value)` action that filters the named learned array by normalized key and persists via the existing Zustand `persist` middleware.
- `packages/client/src/components/game/GameSetupWizard.tsx`: `LearnedOptionChips` now renders each chip as a wrapper containing two buttons — the existing select-on-click body plus a small forget × on the right (lucide `X`, `aria-label="Forget <value>"`). The × is `opacity-40` by default and `opacity-100` on hover/focus, matching the visual weight of the chips around it without grabbing attention.
- `onForget` is wired into all five callsites (genres / tones / settings / goals / preferences). Built-in suggestion chips (e.g. "A neon-lit city of hackers and megacorps") and the currently-selected custom-genre/tone chips at the top are unchanged — only the *learned* list gets the × forget button.

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Manually verify in the wizard's **Setting** section: type a one-off value like `Skyrim`, complete the wizard, reopen → `Skyrim` shows as a learned chip with a faint × on the right.
- Manually verify clicking the × removes the chip from the visible list and any `+N more` collapses by one. Click the chip body itself (not the ×) and confirm it still applies the value to the Setting input.
- Manually verify the forget persists across a full page reload (Zustand `persist` writes to `localStorage`).
- Repeat for **custom Genres**, **Tones**, **Player Goals**, and **Additional Preferences**.
- Mobile/touch: confirm the × is tappable at default 40% opacity (it is always rendered, not hover-gated, so touch reaches it).
- Edge cases checked: forgetting a value that matches a built-in suggestion is a no-op (built-ins are not in the learned arrays); forgetting the same value twice is idempotent (case-insensitive normalized-key match).

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

Tested live on a self-hosted EasyPanel deployment of the fork. Before: every learned chip is select-only. After: each learned chip gets a faint × on the right that brightens on hover/focus; clicking it removes that single entry from the persisted list while leaving every other chip and the built-in suggestions untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to forget individual game setup options. Learned option chips for genres, settings, tones, goals, and preferences now display an inline forget button. Users can easily remove specific selections without affecting other learned options, providing more granular control over their game setup preferences and choices.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/717)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->