### PR TITLE
Fix custom OAI GPT-5.5 regression coverage

### DIFF
--- a/packages/server/test/openai-provider-reasoning.test.ts
+++ b/packages/server/test/openai-provider-reasoning.test.ts
@@ -11,11 +11,23 @@ async function captureChatRequestBody(
   baseUrl = "https://example.com/v1",
   provider = new OpenAIProvider(baseUrl, "test-key"),
 ) {
+  const request = await captureChatRequest(model, overrides, baseUrl, provider);
+  return request.body;
+}
+
+async function captureChatRequest(
+  model: string,
+  overrides: Partial<ChatOptions> = {},
+  baseUrl = "https://example.com/v1",
+  provider = new OpenAIProvider(baseUrl, "test-key"),
+) {
   const requests: Array<Record<string, unknown>> = [];
+  const urls: string[] = [];
   const originalFetch = globalThis.fetch;
   const originalLocalUrls = process.env.PROVIDER_LOCAL_URLS_ENABLED;
 
-  globalThis.fetch = async (_input: string | URL | Request, init?: RequestInit) => {
+  globalThis.fetch = async (input: string | URL | Request, init?: RequestInit) => {
+    urls.push(String(input));
     requests.push(JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>);
     return new Response(
       JSON.stringify({
@@ -52,7 +64,8 @@ async function captureChatRequestBody(
   }
 
   assert.equal(requests.length, 1);
-  return requests[0]!;
+  assert.equal(urls.length, 1);
+  return { url: urls[0]!, body: requests[0]! };
 }
 
 async function captureChatRequestBodyForMessages(
@@ -240,24 +253,27 @@ test("custom compatible endpoints keep OpenAI reasoning model names on a standar
   assert.equal("enable_thinking" in body, false);
 });
 
-test("custom compatible GPT-5.5 endpoints route through Responses without Chat Completions streaming extras", async () => {
+test("custom compatible GPT-5.5 endpoints stay on Chat Completions", async () => {
   const provider = createLLMProvider("custom", "https://example.com/v1", "test-key");
-  const body = await captureChatRequestBody(
+  const request = await captureChatRequest(
     "gpt-5.5",
     { reasoningEffort: "xhigh", verbosity: "high", temperature: 0.7, topP: 0.9 },
     "https://example.com/v1",
     provider,
   );
+  const body = request.body;
 
+  assert.equal(request.url, "https://example.com/v1/chat/completions");
   assert.equal(body.stream, false);
-  assert.equal(body.max_output_tokens, 512);
-  assert.deepEqual(body.input, [{ role: "user", content: "Hello" }]);
-  assert.deepEqual(body.reasoning, { effort: "xhigh" });
-  assert.deepEqual(body.text, { verbosity: "high" });
+  assert.equal(body.max_completion_tokens, 512);
+  assert.deepEqual(body.messages, [{ role: "user", content: "Hello" }]);
   assert.equal("stream_options" in body, false);
-  assert.equal("messages" in body, false);
   assert.equal("max_tokens" in body, false);
-  assert.equal("reasoning_effort" in body, false);
+  assert.equal("max_output_tokens" in body, false);
+  assert.equal("input" in body, false);
+  assert.equal("reasoning" in body, false);
+  assert.equal("text" in body, false);
+  assert.equal(body.reasoning_effort, "xhigh");
   assert.equal("temperature" in body, false);
   assert.equal("top_p" in body, false);
 });


### PR DESCRIPTION
## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #714

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- v1.5.9 users can hit `OpenAI Responses API error 404` when a Custom (OAI-Compatible) connection is tested with a local `/v1` backend that supports `/chat/completions` but not `/responses`.
- `upstream/main` already contains the runtime routing fix from `ca06324` so generic Custom providers do not force `/responses`; this PR updates the stale regression coverage so the fixed behavior is protected.

## What changed

<!-- List the key changes in this PR -->

- Updated the OpenAI provider regression helper to capture the outbound request URL as well as the JSON body.
- Changed the Custom GPT-5.5 regression to assert Custom OAI-compatible requests stay on `/chat/completions` and do not send a Responses-style payload.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- âš ï¸ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Codex ran `pnpm --dir packages/server exec tsx --import ./test/setup-env.ts --test test/openai-provider-reasoning.test.ts`; all 29 provider-routing tests passed.
- Codex ran `pnpm check`; impeccable context, lint, shared/server/client builds all passed.
- Edge coverage included: Custom GPT-5.5 asserts `/chat/completions`; normal OpenAI GPT-5.5 still asserts `/responses`; Custom non-GPT reasoning model remains on standard Chat Completions behavior.
- No manual browser verification was needed because this is server provider regression coverage only.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

N/A - no UI changes.
