### PR TITLE
Fix Horde image generation endpoints

### DIFF
--- a/packages/server/src/routes/connections.routes.ts
+++ b/packages/server/src/routes/connections.routes.ts
@@ -53,6 +53,30 @@ function buildStabilityUrl(baseUrl: string, targetPath: string): string {
   }
 }
 
+function buildHordeUrl(baseUrl: string, targetPath: string): string {
+  try {
+    const url = new URL(baseUrl);
+    const parts = url.pathname.split("/").filter(Boolean);
+    const versionIndex = parts.findIndex((part, index) => part === "api" && parts[index + 1] === "v2");
+    const prefix = versionIndex >= 0 ? parts.slice(0, versionIndex + 2) : [...parts, "api", "v2"];
+    url.pathname = `/${[...prefix, ...targetPath.split("/").filter(Boolean)].join("/")}`;
+    url.search = "";
+    url.hash = "";
+    return url.toString().replace(/\/+$/, "");
+  } catch {
+    return `${baseUrl.replace(/\/+$/, "")}/api/v2/${targetPath.replace(/^\/+/, "")}`;
+  }
+}
+
+function hordeHeaders(apiKey: string): Record<string, string> {
+  return {
+    "Content-Type": "application/json",
+    Accept: "application/json",
+    apikey: apiKey.trim() || "0000000000",
+    "Client-Agent": "Marinara-Engine",
+  };
+}
+
 function isStabilityV1Base(baseUrl: string): boolean {
   try {
     const parts = new URL(baseUrl).pathname.split("/").filter(Boolean);
@@ -188,6 +212,9 @@ export async function connectionsRoutes(app: FastifyInstance) {
       if (conn.provider === "image_generation" && imageSource === "novelai") {
         // NovelAI: validate the API key via the user subscription endpoint
         testUrl = "https://api.novelai.net/user/subscription";
+      } else if (conn.provider === "image_generation" && imageSource === "horde") {
+        // Horde: heartbeat is the lightweight health endpoint for the public API.
+        testUrl = buildHordeUrl(baseUrl, "status/heartbeat");
       } else if (conn.provider === "image_generation" && imageSource === "stability") {
         // Stability's generation endpoints live under v2beta, but account/key checks are v1.
         testUrl = buildStabilityUrl(baseUrl, "v1/user/account");
@@ -201,8 +228,10 @@ export async function connectionsRoutes(app: FastifyInstance) {
         testUrl = `${baseUrl}${provider?.modelsEndpoint || "/models"}`;
       }
 
+      const testHeaders =
+        conn.provider === "image_generation" && imageSource === "horde" ? hordeHeaders(conn.apiKey) : headers;
       const res = await safeFetch(testUrl, {
-        headers,
+        headers: testHeaders,
         policy: localUrlPolicyForProvider(conn.provider, imageSource),
         maxResponseBytes: 2 * 1024 * 1024,
       });
@@ -431,6 +460,38 @@ export async function connectionsRoutes(app: FastifyInstance) {
           });
         }
         return { models: normalizeModelsResponse("openrouter", json) };
+      }
+
+      if (conn.provider === "image_generation" && imageSource === "horde") {
+        const res = await safeFetch(`${buildHordeUrl(baseUrl, "status/models")}?type=image`, {
+          headers: hordeHeaders(conn.apiKey),
+          policy: localUrlPolicyForProvider(conn.provider, imageSource),
+          maxResponseBytes: 5 * 1024 * 1024,
+        });
+        if (!res.ok) {
+          const body = await res.text();
+          return reply.status(502).send({
+            error: `Horde returned ${res.status}: ${sanitizeProviderBody(body)}`,
+          });
+        }
+        const text = await res.text();
+        let json: unknown;
+        try {
+          json = JSON.parse(text);
+        } catch {
+          return reply.status(502).send({
+            error: `Failed to fetch models: ${sanitizeProviderBody(text)}`,
+          });
+        }
+        const models = (Array.isArray(json) ? json : [])
+          .map((model) => {
+            if (!model || typeof model !== "object") return null;
+            const record = model as { name?: string; id?: string };
+            const id = record.name ?? record.id ?? "";
+            return id ? { id, name: id } : null;
+          })
+          .filter((model): model is { id: string; name: string } => Boolean(model));
+        return { models };
       }
 
       let modelsUrl = `${baseUrl}${provider?.modelsEndpoint ?? "/models"}`;

--- a/packages/server/src/services/image/image-generation.ts
+++ b/packages/server/src/services/image/image-generation.ts
@@ -74,6 +74,7 @@ const EXPLICIT_IMAGE_SOURCES = new Set([
   "stability",
   "togetherai",
   "novelai",
+  "horde",
   "comfyui",
   "automatic1111",
   "gemini_image",
@@ -135,6 +136,8 @@ export async function generateImage(
       return generateTogetherAI(normalizedBaseUrl, apiKey, scopedRequest);
     case "novelai":
       return generateNovelAI(normalizedBaseUrl, apiKey, scopedRequest);
+    case "horde":
+      return generateHorde(normalizedBaseUrl, apiKey, scopedRequest);
     case "comfyui":
       return generateComfyUI(normalizedBaseUrl, scopedRequest);
     case "automatic1111":
@@ -586,6 +589,146 @@ async function generatePollinations(request: ImageGenRequest): Promise<ImageGenR
   const base64 = Buffer.from(arrayBuffer).toString("base64");
 
   return { base64, mimeType: "image/jpeg", ext: "jpg" };
+}
+
+const HORDE_ANON_API_KEY = "0000000000";
+
+function hordeUrl(baseUrl: string, targetPath: string): string {
+  try {
+    const url = new URL(baseUrl);
+    const parts = url.pathname.split("/").filter(Boolean);
+    const versionIndex = parts.findIndex((part, index) => part === "api" && parts[index + 1] === "v2");
+    const prefix = versionIndex >= 0 ? parts.slice(0, versionIndex + 2) : [...parts, "api", "v2"];
+    url.pathname = `/${[...prefix, ...targetPath.split("/").filter(Boolean)].join("/")}`;
+    url.search = "";
+    url.hash = "";
+    return url.toString().replace(/\/+$/, "");
+  } catch {
+    return `${baseUrl.replace(/\/+$/, "")}/api/v2/${targetPath.replace(/^\/+/, "")}`;
+  }
+}
+
+function hordeHeaders(apiKey: string): Record<string, string> {
+  return {
+    "Content-Type": "application/json",
+    Accept: "application/json",
+    apikey: apiKey.trim() || HORDE_ANON_API_KEY,
+    "Client-Agent": "Marinara-Engine",
+  };
+}
+
+function hordePrompt(request: ImageGenRequest): string {
+  const prompt = request.prompt.trim();
+  const negativePrompt = request.negativePrompt?.trim();
+  return negativePrompt ? `${prompt} ### ${negativePrompt}` : prompt;
+}
+
+async function readHordeJson<T>(resp: Response, fallback: string): Promise<T> {
+  const text = await resp.text();
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    throw new Error(`${fallback}: ${sanitizeErrorText(text)}`);
+  }
+}
+
+async function generateHorde(baseUrl: string, apiKey: string, request: ImageGenRequest): Promise<ImageGenResult> {
+  const body: Record<string, unknown> = {
+    prompt: hordePrompt(request),
+    params: {
+      n: 1,
+      width: request.width ?? 512,
+      height: request.height ?? 512,
+      steps: 30,
+      cfg_scale: 7,
+      sampler_name: "k_euler",
+    },
+  };
+  if (request.model) body.models = [request.model];
+
+  const startResp = await imageFetch(
+    hordeUrl(baseUrl, "generate/async"),
+    {
+      method: "POST",
+      headers: hordeHeaders(apiKey),
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(IMAGE_GEN_TIMEOUT),
+    },
+    { allowLocal: request.allowLocalUrls },
+  );
+
+  if (!startResp.ok) {
+    const errText = await startResp.text().catch(() => "Unknown error");
+    throw new Error(`Horde image generation failed (${startResp.status}): ${sanitizeErrorText(errText)}`);
+  }
+
+  const start = await readHordeJson<{ id?: string }>(startResp, "Could not parse Horde generation response");
+  const jobId = start.id?.trim();
+  if (!jobId) throw new Error("Horde image generation did not return a job id");
+
+  const maxAttempts = Math.max(1, Math.ceil(IMAGE_GEN_TIMEOUT / 2000));
+  let completed = false;
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const checkResp = await imageFetch(
+      hordeUrl(baseUrl, `generate/check/${encodeURIComponent(jobId)}`),
+      {
+        headers: hordeHeaders(apiKey),
+        signal: AbortSignal.timeout(IMAGE_GEN_TIMEOUT),
+      },
+      { allowLocal: request.allowLocalUrls },
+    );
+
+    if (!checkResp.ok) {
+      const errText = await checkResp.text().catch(() => "Unknown error");
+      throw new Error(`Horde image generation check failed (${checkResp.status}): ${sanitizeErrorText(errText)}`);
+    }
+
+    const check = await readHordeJson<{ done?: boolean; is_possible?: boolean; faulted?: boolean }>(
+      checkResp,
+      "Could not parse Horde generation check response",
+    );
+    if (check.is_possible === false || check.faulted) {
+      throw new Error("Horde image generation could not be completed by available workers");
+    }
+    if (check.done) {
+      completed = true;
+      break;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+  }
+
+  if (!completed) {
+    throw new Error("Horde image generation timed out before the worker finished");
+  }
+
+  const statusResp = await imageFetch(
+    hordeUrl(baseUrl, `generate/status/${encodeURIComponent(jobId)}`),
+    {
+      headers: hordeHeaders(apiKey),
+      signal: AbortSignal.timeout(IMAGE_GEN_TIMEOUT),
+    },
+    { allowLocal: request.allowLocalUrls },
+  );
+
+  if (!statusResp.ok) {
+    const errText = await statusResp.text().catch(() => "Unknown error");
+    throw new Error(`Horde image generation status failed (${statusResp.status}): ${sanitizeErrorText(errText)}`);
+  }
+
+  const status = await readHordeJson<{ generations?: Array<{ img?: string; censored?: boolean }> }>(
+    statusResp,
+    "Could not parse Horde generation status response",
+  );
+  const generation = status.generations?.find((item) => item.img);
+  if (!generation?.img) throw new Error("No image data in Horde response");
+  if (generation.censored) throw new Error("Horde image generation was censored by the worker");
+
+  const image = generation.img.trim();
+  if (image.startsWith("data:")) return decodeImageDataUrl(image);
+  if (/^https?:\/\//i.test(image)) return downloadImageUrl(image, request.allowLocalUrls);
+
+  const mimeType = detectImageMimeType(image);
+  return { base64: image, mimeType, ext: imageExtensionFromMimeType(mimeType) };
 }
 
 function buildStabilityUrl(baseUrl: string, targetPath: string): string {

--- a/packages/server/test/connections-horde-routes.test.ts
+++ b/packages/server/test/connections-horde-routes.test.ts
@@ -1,0 +1,119 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import Fastify from "fastify";
+import { connectionsRoutes } from "../src/routes/connections.routes.js";
+
+function createMockDb(baseUrl: string) {
+  const connection = {
+    id: "conn-horde",
+    name: "Horde",
+    provider: "image_generation",
+    baseUrl,
+    apiKeyEncrypted: "",
+    apiKey: "test-key",
+    model: "",
+    maxContext: 0,
+    isDefault: "false",
+    useForRandom: "false",
+    defaultForAgents: "false",
+    enableCaching: "false",
+    cachingAtDepth: 5,
+    embeddingModel: "",
+    embeddingBaseUrl: "",
+    embeddingConnectionId: null,
+    openrouterProvider: null,
+    imageGenerationSource: "horde",
+    comfyuiWorkflow: null,
+    imageService: "horde",
+    defaultParameters: null,
+    maxTokensOverride: null,
+    maxParallelJobs: 1,
+    claudeFastMode: "false",
+    createdAt: "2026-05-11T00:00:00.000Z",
+    updatedAt: "2026-05-11T00:00:00.000Z",
+  };
+
+  return {
+    select() {
+      return {
+        from() {
+          return {
+            where() {
+              return Promise.resolve([connection]);
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+async function withHordeServer(run: (baseUrl: string, requests: string[]) => Promise<void>) {
+  const requests: string[] = [];
+  const server = createServer((req, res) => {
+    requests.push(`${req.method} ${req.url}`);
+    if (req.method === "GET" && req.url === "/api/v2/status/heartbeat") {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ message: "ok" }));
+      return;
+    }
+    if (req.method === "GET" && req.url === "/api/v2/status/models?type=image") {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify([{ name: "stable_diffusion" }, { name: "flux" }]));
+      return;
+    }
+
+    res.writeHead(404, { "content-type": "text/html" });
+    res.end("<!doctype html><title>404 Not Found</title>");
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+
+  try {
+    await run(`http://127.0.0.1:${address.port}/api/v2`, requests);
+  } finally {
+    await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
+  }
+}
+
+test("Horde connection test uses the heartbeat endpoint", async () => {
+  await withHordeServer(async (baseUrl, requests) => {
+    const app = Fastify({ logger: false });
+    app.decorate("db", createMockDb(baseUrl));
+    try {
+      await app.register(connectionsRoutes, { prefix: "/api/connections" });
+      await app.ready();
+
+      const res = await app.inject({ method: "POST", url: "/api/connections/conn-horde/test" });
+      assert.equal(res.statusCode, 200);
+      assert.equal(res.json<{ success: boolean }>().success, true);
+      assert.deepEqual(requests, ["GET /api/v2/status/heartbeat"]);
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+test("Horde model fetch uses the image status models endpoint", async () => {
+  await withHordeServer(async (baseUrl, requests) => {
+    const app = Fastify({ logger: false });
+    app.decorate("db", createMockDb(baseUrl));
+    try {
+      await app.register(connectionsRoutes, { prefix: "/api/connections" });
+      await app.ready();
+
+      const res = await app.inject({ method: "GET", url: "/api/connections/conn-horde/models" });
+      assert.equal(res.statusCode, 200);
+      assert.deepEqual(res.json<{ models: Array<{ id: string; name: string }> }>().models, [
+        { id: "stable_diffusion", name: "stable_diffusion" },
+        { id: "flux", name: "flux" },
+      ]);
+      assert.deepEqual(requests, ["GET /api/v2/status/models?type=image"]);
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/packages/server/test/image-generation-local.test.ts
+++ b/packages/server/test/image-generation-local.test.ts
@@ -150,6 +150,80 @@ test("OpenRouter image generation uses chat completions modalities and image dat
   }
 });
 
+test("Horde image generation uses native async endpoints", async () => {
+  let capturedBody: Record<string, unknown> | null = null;
+  const requests: Array<{ method?: string; url?: string }> = [];
+  let port = 0;
+  const server = createServer((req, res) => {
+    requests.push({ method: req.method, url: req.url });
+    if (req.method === "POST" && req.url === "/api/v2/generate/async") {
+      let raw = "";
+      req.setEncoding("utf8");
+      req.on("data", (chunk) => {
+        raw += chunk;
+      });
+      req.on("end", () => {
+        capturedBody = JSON.parse(raw) as Record<string, unknown>;
+        res.writeHead(202, { "content-type": "application/json" });
+        res.end(JSON.stringify({ id: "job-711" }));
+      });
+      return;
+    }
+
+    if (req.method === "GET" && req.url === "/api/v2/generate/check/job-711") {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ done: true, is_possible: true }));
+      return;
+    }
+
+    if (req.method === "GET" && req.url === "/api/v2/generate/status/job-711") {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ generations: [{ img: PNG_1X1_BASE64 }] }));
+      return;
+    }
+
+    res.writeHead(404, { "content-type": "text/html" });
+    res.end("<!doctype html><html><title>404 Not Found</title></html>");
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const addressInfo = server.address();
+  assert.ok(addressInfo && typeof addressInfo === "object");
+  port = addressInfo.port;
+
+  try {
+    const result = await generateImage("horde", `http://127.0.0.1:${port}/api/v2`, "", "horde", {
+      prompt: "spaghetti",
+      negativePrompt: "burned",
+      model: "stable_diffusion",
+      width: 512,
+      height: 640,
+      allowLocalUrls: true,
+    });
+
+    assert.equal(result.mimeType, "image/png");
+    assert.equal(result.base64, PNG_1X1_BASE64);
+    assert.deepEqual(
+      requests.map((req) => `${req.method} ${req.url}`),
+      ["POST /api/v2/generate/async", "GET /api/v2/generate/check/job-711", "GET /api/v2/generate/status/job-711"],
+    );
+    assert.equal(capturedBody?.prompt, "spaghetti ### burned");
+    assert.deepEqual(capturedBody?.models, ["stable_diffusion"]);
+    assert.deepEqual(capturedBody?.params, {
+      n: 1,
+      width: 512,
+      height: 640,
+      steps: 30,
+      cfg_scale: 7,
+      sampler_name: "k_euler",
+    });
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
+    });
+  }
+});
+
 test("native NovelAI image generation sends stable request settings and embeds metadata", async () => {
   const imageBytes = Buffer.from(PNG_1X1_BASE64, "base64");
   let capturedBody: Record<string, unknown> | null = null;


### PR DESCRIPTION
## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #711

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- Stable Horde image-generation connections were being treated like OpenAI-compatible image APIs, so the default Horde base URL hit `/models` and `/images/generations` paths that Horde does not serve and returned HTML 404 responses.

## What changed

<!-- List the key changes in this PR -->

- Added native Horde image generation through `/api/v2/generate/async`, `/api/v2/generate/check/{id}`, and `/api/v2/generate/status/{id}`.
- Routed Horde connection tests through `/api/v2/status/heartbeat`.
- Routed Horde model fetching through `/api/v2/status/models?type=image`.
- Added focused server tests for Horde test-image generation, model fetching, and connection testing.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Machine proof: `scratch/issue-711-horde-repro.mjs` reproduced the old failure against a Horde-shaped local API: before the fix, generation posted to `/api/v2/images/generations` and failed with `OpenAI image generation failed (404): 404 Not Found Not Found`.
- Machine proof: the same repro now passes and records requests to `/api/v2/generate/async`, `/api/v2/generate/check/job-711`, and `/api/v2/generate/status/job-711`.
- Machine proof: `pnpm --dir packages/server exec tsx --import ./test/setup-env.ts --test test/image-generation-local.test.ts test/connections-horde-routes.test.ts` passed 7 tests.
- Machine proof: `pnpm check` passed.
- Evidence ledger: `scratch/bugfix-verification.json` records the repro, verification, baseline, and final done gate locally.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs or release metadata changes were needed; this changes provider routing behavior only.

## UI evidence (if applicable)

N/A — backend/provider-routing fix with command-level proof; no UI layout changed.
