### PR TITLE
feat(chat): import JSONL into existing chat as a new branch

### DIFF
--- a/packages/client/src/components/chat/ChatFilesDrawer.tsx
+++ b/packages/client/src/components/chat/ChatFilesDrawer.tsx
@@ -2,11 +2,15 @@
 // Chat: Manage Chat Files — switch between branches
 // Like SillyTavern's "Manage chat files" feature
 // ──────────────────────────────────────────────
-import { X, Trash2, FileText, MessageSquare, Download, Pencil } from "lucide-react";
+import { useRef, useState } from "react";
+import { X, Trash2, FileText, MessageSquare, Download, Pencil, Upload } from "lucide-react";
+import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 import { showConfirmDialog } from "../../lib/app-dialogs";
 import { getChatDisplayName } from "../../lib/chat-display";
 import { cn } from "../../lib/utils";
 import {
+  chatKeys,
   useChatGroup,
   useDeleteChat,
   useDeleteChatGroup,
@@ -30,8 +34,45 @@ export function ChatFilesDrawer({ chat, open, onClose }: ChatFilesDrawerProps) {
   const exportChat = useExportChat();
   const setActiveChatId = useChatStore((s) => s.setActiveChatId);
   const activeChatId = useChatStore((s) => s.activeChatId);
+  const qc = useQueryClient();
+  const importInputRef = useRef<HTMLInputElement>(null);
+  const [isImporting, setIsImporting] = useState(false);
 
   const chatFiles = (groupChats ?? []) as Chat[];
+
+  const handleImportChat = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    e.target.value = "";
+
+    setIsImporting(true);
+    try {
+      const formData = new FormData();
+      formData.append("file", file);
+      formData.append("chatId", chat.id);
+      const res = await fetch("/api/import/st-chat-into-group", { method: "POST", body: formData });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok || data?.success === false || data?.error) {
+        toast.error(`Import failed: ${data?.error ?? res.statusText ?? "Unknown error"}`);
+        return;
+      }
+      toast.success(`Imported ${data.messagesImported ?? 0} messages as a new chat file`);
+      qc.invalidateQueries({ queryKey: chatKeys.list() });
+      // The target chat may have just been assigned a groupId server-side, so
+      // refetch its detail before refreshing the (now-correct) group list.
+      await qc.invalidateQueries({ queryKey: chatKeys.detail(chat.id) });
+      const newGroupId = data.groupId ?? groupId;
+      if (newGroupId) {
+        await qc.invalidateQueries({ queryKey: chatKeys.group(newGroupId) });
+      }
+      await refetchGroupChats();
+      if (data.chatId) setActiveChatId(data.chatId);
+    } catch (err) {
+      toast.error(err instanceof Error ? `Import failed: ${err.message}` : "Import failed.");
+    } finally {
+      setIsImporting(false);
+    }
+  };
 
   const handleSwitch = (chatId: string) => {
     setActiveChatId(chatId);
@@ -115,6 +156,30 @@ export function ChatFilesDrawer({ chat, open, onClose }: ChatFilesDrawerProps) {
               </button>
             </div>
           </div>
+          <div className="border-b border-[var(--border)] px-4 py-3">
+            <p className="mb-1.5 text-[0.625rem] font-medium uppercase tracking-wider text-[var(--muted-foreground)]/60">
+              Import Chat
+            </p>
+            <button
+              type="button"
+              onClick={() => importInputRef.current?.click()}
+              disabled={isImporting}
+              className="flex w-full items-center justify-center gap-1.5 rounded-xl bg-[var(--secondary)] px-3 py-2.5 text-xs font-medium text-[var(--foreground)] ring-1 ring-[var(--border)] transition-all hover:bg-[var(--accent)] active:scale-[0.98] disabled:opacity-50"
+            >
+              <Upload size="0.8125rem" />
+              {isImporting ? "Importing…" : "JSONL"}
+            </button>
+            <p className="mt-2 text-center text-[0.625rem] text-[var(--muted-foreground)]/60">
+              Adds the file as a new branch in this chat
+            </p>
+            <input
+              ref={importInputRef}
+              type="file"
+              accept=".jsonl"
+              onChange={handleImportChat}
+              className="hidden"
+            />
+          </div>
           <div className="flex flex-1 flex-col items-center justify-center gap-3 px-6 text-center">
             <FileText size="2rem" className="text-[var(--muted-foreground)]/40" />
             <p className="text-xs text-[var(--muted-foreground)]">
@@ -173,6 +238,32 @@ export function ChatFilesDrawer({ chat, open, onClose }: ChatFilesDrawerProps) {
           <p className="mt-2 text-center text-[0.625rem] text-[var(--muted-foreground)]/60">
             {chatFiles.length} chat file{chatFiles.length !== 1 ? "s" : ""} in this group
           </p>
+        </div>
+
+        {/* Import tools */}
+        <div className="border-b border-[var(--border)] px-4 py-3">
+          <p className="mb-1.5 text-[0.625rem] font-medium uppercase tracking-wider text-[var(--muted-foreground)]/60">
+            Import Chat
+          </p>
+          <button
+            type="button"
+            onClick={() => importInputRef.current?.click()}
+            disabled={isImporting}
+            className="flex w-full items-center justify-center gap-1.5 rounded-xl bg-[var(--secondary)] px-3 py-2.5 text-xs font-medium text-[var(--foreground)] ring-1 ring-[var(--border)] transition-all hover:bg-[var(--accent)] active:scale-[0.98] disabled:opacity-50"
+          >
+            <Upload size="0.8125rem" />
+            {isImporting ? "Importing…" : "JSONL"}
+          </button>
+          <p className="mt-2 text-center text-[0.625rem] text-[var(--muted-foreground)]/60">
+            Adds the file as a new branch in this chat
+          </p>
+          <input
+            ref={importInputRef}
+            type="file"
+            accept=".jsonl"
+            onChange={handleImportChat}
+            className="hidden"
+          />
         </div>
 
         {/* Chat files list */}

--- a/packages/server/src/routes/import.routes.ts
+++ b/packages/server/src/routes/import.routes.ts
@@ -21,6 +21,8 @@ import { importSTLorebook } from "../services/import/st-lorebook.importer.js";
 import { importMarinara } from "../services/import/marinara.importer.js";
 import { scanSTFolder, runSTBulkImport, type STBulkImportOptions } from "../services/import/st-bulk.importer.js";
 import { characters as charactersTable } from "../db/schema/index.js";
+import { createChatsStorage } from "../services/storage/chats.storage.js";
+import { newId } from "../utils/id-generator.js";
 import { normalizeTimestampOverrides } from "../services/import/import-timestamps.js";
 import { getImportAllowedRoots } from "../config/runtime-config.js";
 import { requirePrivilegedAccess } from "../middleware/privileged-gate.js";
@@ -439,6 +441,95 @@ export async function importRoutes(app: FastifyInstance) {
       ...(characterId ? { characterId } : {}),
       ...(timestampOverrides ? { timestampOverrides } : {}),
     });
+  });
+
+  /**
+   * Import a SillyTavern JSONL chat file as a new branch of an existing chat.
+   * Inherits the target chat's group, character roster, persona, connection,
+   * and prompt preset so the imported transcript shows up as a sibling
+   * "chat file" instead of spawning a new character entry.
+   */
+  app.post("/st-chat-into-group", async (req, reply) => {
+    const data = await req.file();
+    if (!data) return reply.status(400).send({ success: false, error: "No file uploaded" });
+
+    const targetChatField = (data as any).fields?.chatId;
+    const targetChatId =
+      (Array.isArray(targetChatField) ? targetChatField.at(-1)?.value : targetChatField?.value) ?? null;
+    if (!targetChatId || typeof targetChatId !== "string") {
+      return reply.status(400).send({ success: false, error: "Missing chatId" });
+    }
+
+    const storage = createChatsStorage(app.db);
+    const targetChat = await storage.getById(targetChatId);
+    if (!targetChat) return reply.status(404).send({ success: false, error: "Target chat not found" });
+
+    const content = await data.toBuffer();
+    const text = content.toString("utf-8");
+    const timestampOverrides = readTimestampOverridesFromMultipart(data as any);
+
+    // Auto-create a groupId on the target chat if it isn't already in one, so
+    // the imported transcript can sit alongside it as a branch (mirrors the
+    // behavior of POST /chats/:id/branch).
+    let groupId = (targetChat.groupId as string | null) ?? null;
+    if (!groupId) {
+      groupId = newId();
+      await storage.update(targetChatId, { groupId });
+    }
+
+    // Inherit the existing chat's character roster instead of trying to match
+    // characters out of the JSONL header — that path creates new characters
+    // when no match is found, which is exactly what we want to avoid here.
+    let inheritedCharacterIds: string[] = [];
+    try {
+      const parsed = JSON.parse(targetChat.characterIds as string);
+      if (Array.isArray(parsed)) inheritedCharacterIds = parsed.filter((cid): cid is string => typeof cid === "string");
+    } catch {
+      inheritedCharacterIds = [];
+    }
+
+    // For multi-character chats, map each speaker name in the JSONL to one of
+    // the existing characters so per-message attribution survives the import.
+    let speakerMap: Record<string, string> | undefined;
+    if (inheritedCharacterIds.length > 1) {
+      speakerMap = {};
+      const allChars = await app.db.select().from(charactersTable);
+      const byId = new Map(allChars.map((ch) => [ch.id, ch] as const));
+      for (const cid of inheritedCharacterIds) {
+        const ch = byId.get(cid);
+        if (!ch) continue;
+        try {
+          const charData = JSON.parse(ch.data);
+          const charName = typeof charData?.name === "string" ? charData.name.trim() : "";
+          if (charName) speakerMap[charName] = cid;
+        } catch {
+          // skip
+        }
+      }
+    }
+
+    const rawName = data.filename ?? "";
+    const branchName =
+      rawName
+        .replace(/\.jsonl$/i, "")
+        .replace(/_/g, " ")
+        .trim() || "Imported";
+
+    const result = await importSTChat(text, app.db, {
+      groupId,
+      chatName: targetChat.name,
+      branchName,
+      mode: targetChat.mode as any,
+      ...(inheritedCharacterIds.length === 1 ? { characterId: inheritedCharacterIds[0] } : {}),
+      ...(inheritedCharacterIds.length > 0 ? { characterIds: inheritedCharacterIds } : {}),
+      ...(speakerMap ? { speakerMap } : {}),
+      personaId: targetChat.personaId ?? null,
+      connectionId: targetChat.connectionId ?? null,
+      promptPresetId: targetChat.promptPresetId ?? null,
+      ...(timestampOverrides ? { timestampOverrides } : {}),
+    });
+
+    return { ...result, groupId };
   });
 
   /** Import a Marinara Engine export (.marinara.json). */

--- a/packages/server/src/services/import/st-chat.importer.ts
+++ b/packages/server/src/services/import/st-chat.importer.ts
@@ -39,6 +39,8 @@ interface ParsedSTChatMessageInput {
 export interface ImportSTChatOptions {
   /** Link chat to this character ID */
   characterId?: string | null;
+  /** Multi-character override; takes precedence over characterId when provided */
+  characterIds?: string[];
   /** Override mode (defaults to roleplay) */
   mode?: ChatMode;
   /** Explicitly set the chat name instead of deriving from header */
@@ -49,6 +51,12 @@ export interface ImportSTChatOptions {
   speakerMap?: Record<string, string>;
   /** Group ID to associate this chat with (for grouping branches) */
   groupId?: string | null;
+  /** Persona to attach to the imported chat */
+  personaId?: string | null;
+  /** Connection to attach to the imported chat */
+  connectionId?: string | null;
+  /** Prompt preset to attach to the imported chat */
+  promptPresetId?: string | null;
   /** Source file timestamps to preserve when trustworthy */
   timestampOverrides?: TimestampOverrides | null;
 }
@@ -116,9 +124,15 @@ export async function importSTChat(jsonlContent: string, db: DB, opts?: ImportST
   const characterName = header.character_name ?? "Unknown";
   const userName = header.user_name ?? "User";
 
-  // Build characterIds array
+  // Build characterIds array. Caller-supplied list wins so an import-into-group
+  // can fully inherit the existing chat's roster instead of being limited to a
+  // single matched character.
   const characterIds: string[] = [];
-  if (opts?.characterId) {
+  if (opts?.characterIds?.length) {
+    for (const cid of opts.characterIds) {
+      if (cid && !characterIds.includes(cid)) characterIds.push(cid);
+    }
+  } else if (opts?.characterId) {
     characterIds.push(opts.characterId);
   }
   // For group chats, collect all unique character IDs from speakerMap
@@ -185,9 +199,9 @@ export async function importSTChat(jsonlContent: string, db: DB, opts?: ImportST
       mode: (opts?.mode ?? "roleplay") as ChatMode,
       characterIds,
       groupId: opts?.groupId ?? null,
-      personaId: null,
-      promptPresetId: null,
-      connectionId: null,
+      personaId: opts?.personaId ?? null,
+      promptPresetId: opts?.promptPresetId ?? null,
+      connectionId: opts?.connectionId ?? null,
     },
     chatTimestamps,
   );


### PR DESCRIPTION
## Summary

Adds an **Import Chat** button to the **Manage Chat Files** drawer so a JSONL exported from one chat can be brought back as a sibling branch of another chat — instead of dropping into Settings → Import Chat, which spawns a brand-new character entry at the top of the chat list.

## Why

Right now, the only "Import Chat" UI lives in Settings, and it always creates a new top-level chat (and, when no character match is found, it can effectively orphan the transcript away from the character you actually want it on). The drawer for an individual chat only offers **Export Chat**, which is asymmetric — there's no way to round-trip a JSONL back into the same conversation as a new chat file. This PR makes Manage Chat Files symmetric: you can export a branch and import a branch from the same place, and the imported one lands alongside the others as a chat file.

## Changes

- **`packages/server/src/services/import/st-chat.importer.ts`** — `ImportSTChatOptions` now accepts `characterIds`, `personaId`, `connectionId`, and `promptPresetId` so callers can fully inherit an existing chat's settings (previously these were always nulled).
- **`packages/server/src/routes/import.routes.ts`** — new `POST /api/import/st-chat-into-group` endpoint. Looks up the target chat, auto-assigns a `groupId` if it doesn't have one (same trick the existing `POST /chats/:id/branch` endpoint uses at `chats.routes.ts:1579`), inherits the target chat's character roster / persona / connection / prompt preset, and for multi-character chats builds a `name → characterId` speaker map from the target roster so per-message attribution survives the import. **No new character is created in any path.**
- **`packages/client/src/components/chat/ChatFilesDrawer.tsx`** — adds an **Import Chat** section under Export Chat in both the grouped and ungrouped drawer states. Posts the file + the current chat id to the new endpoint, invalidates list/detail/group caches (the target chat may have just been freshly assigned a groupId), refetches the branch list, and switches the active chat to the newly imported branch.

## Notes for reviewer

- The new endpoint *never* reads the JSONL header's `character_name` to match or create characters — it only uses the target chat's existing roster. Speakers in the JSONL whose name doesn't match anyone in that roster fall back to the first inherited character (existing `importSTChat` fallback behavior).
- Same auto-groupId behavior as `POST /chats/:id/branch`, so importing into a chat that's never been branched will quietly give it a `groupId` and the imported file becomes its first branch.
- UI lives in the existing drawer; styling reuses the same secondary/border/ring tokens as Export Chat and the existing branch list, so it inherits theming and mobile layout from the surrounding section.