### PR TITLE
Add connection prompt preset overrides

### DIFF
--- a/packages/client/src/components/connections/ConnectionEditor.tsx
+++ b/packages/client/src/components/connections/ConnectionEditor.tsx
@@ -17,6 +17,7 @@ import {
   useSaveConnectionDefaults,
   type ClaudeSubscriptionDiagnosis,
 } from "../../hooks/use-connections";
+import { usePresets } from "../../hooks/use-presets";
 import {
   ArrowLeft,
   Save,
@@ -24,6 +25,7 @@ import {
   Link,
   Wifi,
   MessageSquare,
+  FileText,
   Search,
   Tag,
   Check,
@@ -119,6 +121,7 @@ export function ConnectionEditor() {
   const fetchModels = useFetchModels();
   const saveConnectionDefaults = useSaveConnectionDefaults();
   const { data: allConnections } = useConnections();
+  const { data: allPresets } = usePresets();
 
   const [dirty, setDirty] = useState(false);
   const setEditorDirty = useUIStore((s) => s.setEditorDirty);
@@ -143,6 +146,7 @@ export function ConnectionEditor() {
   const [localEmbeddingModel, setLocalEmbeddingModel] = useState("");
   const [localEmbeddingBaseUrl, setLocalEmbeddingBaseUrl] = useState("");
   const [localEmbeddingConnectionId, setLocalEmbeddingConnectionId] = useState("");
+  const [localPromptPresetId, setLocalPromptPresetId] = useState("");
   const [localOpenrouterProvider, setLocalOpenrouterProvider] = useState("");
   const [localImageGenerationSource, setLocalImageGenerationSource] = useState("");
   const [localComfyuiWorkflow, setLocalComfyuiWorkflow] = useState("");
@@ -240,6 +244,7 @@ export function ConnectionEditor() {
     setLocalEmbeddingModel((c.embeddingModel as string) ?? "");
     setLocalEmbeddingBaseUrl((c.embeddingBaseUrl as string) ?? "");
     setLocalEmbeddingConnectionId((c.embeddingConnectionId as string) ?? "");
+    setLocalPromptPresetId((c.promptPresetId as string) ?? "");
     setLocalOpenrouterProvider((c.openrouterProvider as string) ?? "");
     const imageGenerationSource =
       (c.provider as APIProvider) === "image_generation"
@@ -391,6 +396,7 @@ export function ConnectionEditor() {
       embeddingModel: localEmbeddingModel,
       embeddingBaseUrl: localEmbeddingBaseUrl,
       embeddingConnectionId: localEmbeddingConnectionId || null,
+      promptPresetId: localProvider !== "image_generation" ? localPromptPresetId || null : null,
       openrouterProvider: localOpenrouterProvider || null,
       imageGenerationSource:
         localProvider === "image_generation" ? localImageGenerationSource || localImageService || null : null,
@@ -445,6 +451,7 @@ export function ConnectionEditor() {
     localEmbeddingModel,
     localEmbeddingBaseUrl,
     localEmbeddingConnectionId,
+    localPromptPresetId,
     localOpenrouterProvider,
     localImageGenerationSource,
     localComfyuiWorkflow,
@@ -1471,6 +1478,35 @@ export function ConnectionEditor() {
               <p className="mt-1 text-[0.625rem] text-[var(--muted-foreground)]">
                 Agent batches for the same connection can be split across this many parallel jobs. Set to 1 for the
                 safest provider behavior.
+              </p>
+            </FieldGroup>
+          )}
+
+          {/* ── Prompt Preset Override ── */}
+          {localProvider !== "image_generation" && (
+            <FieldGroup
+              label="Prompt Preset Override"
+              icon={<FileText size="0.875rem" className="text-violet-400" />}
+              help="Optional. When roleplay or visual novel chats use this connection, Marinara assembles this prompt preset instead of the chat's selected prompt preset. Conversation and game mode keep their built-in prompt flows."
+            >
+              <select
+                value={localPromptPresetId}
+                onChange={(e) => {
+                  setLocalPromptPresetId(e.target.value);
+                  markDirty();
+                }}
+                className="w-full rounded-xl bg-[var(--secondary)] px-3 py-2.5 text-sm ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+              >
+                <option value="">Use chat&apos;s prompt preset</option>
+                {(allPresets ?? []).map((preset) => (
+                  <option key={preset.id} value={preset.id}>
+                    {preset.name}
+                  </option>
+                ))}
+              </select>
+              <p className="mt-1 text-[0.625rem] text-[var(--muted-foreground)]">
+                Use this for models that need a different prompt structure. If this preset has variables, Marinara uses
+                the preset&apos;s saved defaults unless the chat already uses the same preset.
               </p>
             </FieldGroup>
           )}

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -257,6 +257,7 @@ const CREATE_TABLES: string[] = [
     use_for_random TEXT NOT NULL DEFAULT 'false',
     enable_caching TEXT NOT NULL DEFAULT 'false',
     caching_at_depth INTEGER NOT NULL DEFAULT 5,
+    prompt_preset_id TEXT,
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL
   )`,
@@ -626,6 +627,11 @@ const COLUMN_MIGRATIONS: ColumnMigration[] = [
   {
     table: "api_connections",
     column: "default_parameters",
+    definition: "TEXT",
+  },
+  {
+    table: "api_connections",
+    column: "prompt_preset_id",
     definition: "TEXT",
   },
   {

--- a/packages/server/src/db/schema/connections.ts
+++ b/packages/server/src/db/schema/connections.ts
@@ -52,6 +52,8 @@ export const apiConnections = sqliteTable("api_connections", {
   imageService: text("image_service"),
   /** Default generation parameters (stored as JSON) for new chats using this connection */
   defaultParameters: text("default_parameters"),
+  /** Optional prompt preset override for roleplay/visual-novel chats using this connection */
+  promptPresetId: text("prompt_preset_id"),
   /** Optional hard cap on max_tokens for the API response (for providers like DeepSeek that have lower limits). */
   maxTokensOverride: integer("max_tokens_override"),
   /** Maximum number of agent LLM jobs Marinara may run at once for this connection. */

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -177,6 +177,10 @@ import {
   normalizeStringArray,
 } from "./generate/agent-normalizers.js";
 import {
+  buildGenerationPromptPresetCandidates,
+  type PromptPresetCandidateSource,
+} from "./generate/prompt-preset-selection.js";
+import {
   createJournal,
   addLocationEntry,
   addEventEntry,
@@ -218,6 +222,16 @@ function bumpCharacterVersion(value: unknown): string {
 
 function hasConversationSchedules(value: unknown): value is Record<string, any> {
   return !!value && typeof value === "object" && Object.keys(value as Record<string, unknown>).length > 0;
+}
+
+function parsePromptPresetChoices(value: unknown): Record<string, string | string[]> | null {
+  try {
+    const parsed = typeof value === "string" ? JSON.parse(value) : value;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+    return parsed as Record<string, string | string[]>;
+  } catch {
+    return null;
+  }
 }
 
 function areConversationSchedulesEnabled(meta: Record<string, any>): boolean {
@@ -1000,38 +1014,41 @@ export async function generateRoutes(app: FastifyInstance) {
         postToDiscordWebhook(discordWebhookUrl, { content: pendingUserDiscordMsg, username: personaName });
       }
 
-      // ── Assembler path: use preset if the chat has one ──
-      let presetId =
-        chatMode === "conversation"
-          ? undefined
-          : input.impersonate && input.impersonatePresetId
-            ? input.impersonatePresetId
-            : ((chat.promptPresetId as string | null) ?? undefined);
-      let resolvedPreset = presetId ? await presets.getById(presetId) : null;
-      const usingImpersonatePreset = !!(input.impersonate && input.impersonatePresetId);
-      if (usingImpersonatePreset && !resolvedPreset) {
-        presetId = (chat.promptPresetId as string | null) ?? undefined;
-        resolvedPreset = presetId ? await presets.getById(presetId) : null;
+      // ── Assembler path: use the highest-priority prompt preset for this generation ──
+      const chatPromptPresetId = (chat.promptPresetId as string | null) ?? null;
+      const presetCandidates = buildGenerationPromptPresetCandidates({
+        chatMode,
+        chatPromptPresetId,
+        connectionPromptPresetId: conn.promptPresetId,
+        impersonate: input.impersonate,
+        impersonatePromptPresetId: input.impersonatePresetId,
+      });
+      let presetId: string | undefined;
+      let resolvedPreset: Awaited<ReturnType<typeof presets.getById>> | null = null;
+      let presetSource: PromptPresetCandidateSource | null = null;
+      for (const candidate of presetCandidates) {
+        const candidatePreset = await presets.getById(candidate.id);
+        if (candidatePreset) {
+          presetId = candidate.id;
+          resolvedPreset = candidatePreset;
+          presetSource = candidate.source;
+          break;
+        }
+        if (candidate.source !== "chat") {
+          logger.warn(
+            "[generate] %s prompt preset override %s was not found; falling back to the next preset candidate",
+            candidate.source,
+            candidate.id,
+          );
+        }
       }
-      const usingResolvedImpersonatePreset =
-        usingImpersonatePreset && !!resolvedPreset && presetId === input.impersonatePresetId;
-      const impersonatePresetDiffers =
-        usingResolvedImpersonatePreset && input.impersonatePresetId !== chat.promptPresetId;
-      const impersonateDefaultChoices = impersonatePresetDiffers
-        ? (() => {
-            try {
-              const raw = resolvedPreset?.defaultChoices as string | undefined;
-              if (!raw) return {};
-              const parsed = typeof raw === "string" ? JSON.parse(raw) : raw;
-              if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
-              return parsed as Record<string, string | string[]>;
-            } catch {
-              return {};
-            }
-          })()
-        : null;
+      const selectedPresetDiffersFromChat = !!resolvedPreset && !!presetId && presetId !== chatPromptPresetId;
+      const overrideDefaultChoices =
+        selectedPresetDiffersFromChat && presetSource !== "chat"
+          ? (parsePromptPresetChoices((resolvedPreset as { defaultChoices?: unknown }).defaultChoices) ?? {})
+          : null;
       const chatChoices: Record<string, string | string[]> =
-        impersonateDefaultChoices ?? ((chatMeta.presetChoices ?? {}) as Record<string, string | string[]>);
+        overrideDefaultChoices ?? ((chatMeta.presetChoices ?? {}) as Record<string, string | string[]>);
 
       let finalMessages: Array<{
         role: "system" | "user" | "assistant";

--- a/packages/server/src/routes/generate/dry-run-route.ts
+++ b/packages/server/src/routes/generate/dry-run-route.ts
@@ -784,11 +784,13 @@ export async function registerDryRunRoute(app: FastifyInstance) {
         });
     let effectivePresetId: string | null = null;
     let effectivePresetSource: PromptPresetCandidateSource | null = null;
+    let effectivePreset: Awaited<ReturnType<typeof presets.getById>> | null = null;
     for (const candidate of promptPresetCandidates) {
       const candidatePreset = await presets.getById(candidate.id);
       if (candidatePreset) {
         effectivePresetId = candidate.id;
         effectivePresetSource = candidate.source;
+        effectivePreset = candidatePreset;
         break;
       }
       if (candidate.source !== "chat") {
@@ -818,9 +820,7 @@ export async function registerDryRunRoute(app: FastifyInstance) {
       effectivePresetSource !== "chat" &&
       effectivePresetId !== ((chat.promptPresetId as string | null) ?? null);
     const presetDefaultChoices =
-      isDifferentPresetOverride && effectivePresetId
-        ? parsePresetChoices((await presets.getById(effectivePresetId))?.defaultChoices)
-        : null;
+      isDifferentPresetOverride && effectivePreset ? parsePresetChoices(effectivePreset.defaultChoices) : null;
 
     const chatChoices: Record<string, string | string[]> =
       requestChoices ?? (isDifferentPresetOverride ? (presetDefaultChoices ?? {}) : chatChoicesFromMeta);
@@ -849,11 +849,8 @@ export async function registerDryRunRoute(app: FastifyInstance) {
         promptParts.wrapFormat === "xml"
       ) {
         wrapFormat = promptParts.wrapFormat;
-      } else if (effectivePresetId) {
-        const preset = await presets.getById(effectivePresetId);
-        if (preset) {
-          wrapFormat = (preset.wrapFormat as "xml" | "markdown" | "none") || "xml";
-        }
+      } else if (effectivePreset) {
+        wrapFormat = (effectivePreset.wrapFormat as "xml" | "markdown" | "none") || "xml";
       }
 
       type PromptPartKey =
@@ -1180,94 +1177,92 @@ export async function registerDryRunRoute(app: FastifyInstance) {
           continue;
         }
       }
-    } else if (effectivePresetId) {
-      const preset = await presets.getById(effectivePresetId);
-      if (preset) {
-        wrapFormat = (preset.wrapFormat as "xml" | "markdown" | "none") || "xml";
-        const [sections, groups, choiceBlocks] = await Promise.all([
-          presets.listSections(effectivePresetId),
-          presets.listGroups(effectivePresetId),
-          presets.listChoiceBlocksForPreset(effectivePresetId),
-        ]);
+    } else if (effectivePresetId && effectivePreset) {
+      const preset = effectivePreset;
+      wrapFormat = (preset.wrapFormat as "xml" | "markdown" | "none") || "xml";
+      const [sections, groups, choiceBlocks] = await Promise.all([
+        presets.listSections(effectivePresetId),
+        presets.listGroups(effectivePresetId),
+        presets.listChoiceBlocksForPreset(effectivePresetId),
+      ]);
 
-        const assemblerInput: AssemblerInput = {
-          db: app.db,
-          preset: preset as any,
-          sections: sections as any,
-          groups: groups as any,
-          choiceBlocks: choiceBlocks as any,
-          chatChoices,
-          chatId,
-          characterIds,
-          personaId,
-          personaName,
-          personaDescription,
-          personaFields,
-          personaStats: (() => {
-            if (!persona?.personaStats) return undefined;
-            if (typeof persona.personaStats !== "string") return persona.personaStats;
-            try {
-              return JSON.parse(persona.personaStats);
-            } catch {
-              return undefined;
-            }
-          })(),
-          chatMessages: mappedMessages,
-          chatSummary: resolvedInjectChatSummary ? ((chatMeta.summary as string) ?? "").trim() || null : null,
-          enableAgents: false,
-          activeAgentIds: [],
-          activeLorebookIds: resolvedInjectLorebook
-            ? Array.isArray(chatMeta.activeLorebookIds)
-              ? (chatMeta.activeLorebookIds as string[])
-              : []
-            : [],
-          excludedLorebookIds: lorebookScopeExclusions.excludedLorebookIds,
-          excludedLorebookSourceAgentIds: lorebookScopeExclusions.excludedSourceAgentIds,
-          chatEmbedding: null,
-          entryStateOverrides:
-            (chatMeta.entryStateOverrides ?? chatMeta.lorebookEntryStateOverrides) &&
-            typeof (chatMeta.entryStateOverrides ?? chatMeta.lorebookEntryStateOverrides) === "object"
-              ? ((chatMeta.entryStateOverrides ?? chatMeta.lorebookEntryStateOverrides) as Record<
-                  string,
-                  { ephemeral?: number | null; enabled?: boolean }
-                >)
-              : undefined,
-          entryTimingStates:
-            (chatMeta.entryTimingStates ?? chatMeta.lorebookEntryTimingStates) &&
-            typeof (chatMeta.entryTimingStates ?? chatMeta.lorebookEntryTimingStates) === "object"
-              ? ((chatMeta.entryTimingStates ?? chatMeta.lorebookEntryTimingStates) as Record<
-                  string,
-                  LorebookEntryTimingState
-                >)
-              : undefined,
-          lorebookTokenBudget,
-          generationTriggers: lorebookGenerationTriggers,
-          previewOnly: true,
-          groupScenarioOverrideText:
-            typeof chatMeta.groupScenarioText === "string" && (chatMeta.groupScenarioText as string).trim()
-              ? (chatMeta.groupScenarioText as string).trim()
-              : null,
-        };
+      const assemblerInput: AssemblerInput = {
+        db: app.db,
+        preset: preset as any,
+        sections: sections as any,
+        groups: groups as any,
+        choiceBlocks: choiceBlocks as any,
+        chatChoices,
+        chatId,
+        characterIds,
+        personaId,
+        personaName,
+        personaDescription,
+        personaFields,
+        personaStats: (() => {
+          if (!persona?.personaStats) return undefined;
+          if (typeof persona.personaStats !== "string") return persona.personaStats;
+          try {
+            return JSON.parse(persona.personaStats);
+          } catch {
+            return undefined;
+          }
+        })(),
+        chatMessages: mappedMessages,
+        chatSummary: resolvedInjectChatSummary ? ((chatMeta.summary as string) ?? "").trim() || null : null,
+        enableAgents: false,
+        activeAgentIds: [],
+        activeLorebookIds: resolvedInjectLorebook
+          ? Array.isArray(chatMeta.activeLorebookIds)
+            ? (chatMeta.activeLorebookIds as string[])
+            : []
+          : [],
+        excludedLorebookIds: lorebookScopeExclusions.excludedLorebookIds,
+        excludedLorebookSourceAgentIds: lorebookScopeExclusions.excludedSourceAgentIds,
+        chatEmbedding: null,
+        entryStateOverrides:
+          (chatMeta.entryStateOverrides ?? chatMeta.lorebookEntryStateOverrides) &&
+          typeof (chatMeta.entryStateOverrides ?? chatMeta.lorebookEntryStateOverrides) === "object"
+            ? ((chatMeta.entryStateOverrides ?? chatMeta.lorebookEntryStateOverrides) as Record<
+                string,
+                { ephemeral?: number | null; enabled?: boolean }
+              >)
+            : undefined,
+        entryTimingStates:
+          (chatMeta.entryTimingStates ?? chatMeta.lorebookEntryTimingStates) &&
+          typeof (chatMeta.entryTimingStates ?? chatMeta.lorebookEntryTimingStates) === "object"
+            ? ((chatMeta.entryTimingStates ?? chatMeta.lorebookEntryTimingStates) as Record<
+                string,
+                LorebookEntryTimingState
+              >)
+            : undefined,
+        lorebookTokenBudget,
+        generationTriggers: lorebookGenerationTriggers,
+        previewOnly: true,
+        groupScenarioOverrideText:
+          typeof chatMeta.groupScenarioText === "string" && (chatMeta.groupScenarioText as string).trim()
+            ? (chatMeta.groupScenarioText as string).trim()
+            : null,
+      };
 
-        const assembled = await assemblePrompt(assemblerInput);
-        finalMessages = assembled.messages;
-        temperature = assembled.parameters.temperature;
-        maxTokens = assembled.parameters.maxTokens;
-        topP = assembled.parameters.topP ?? 1;
-        topK = assembled.parameters.topK ?? 0;
-        frequencyPenalty = assembled.parameters.frequencyPenalty ?? 0;
-        presencePenalty = assembled.parameters.presencePenalty ?? 0;
-        showThoughts = assembled.parameters.showThoughts ?? true;
-        reasoningEffort = assembled.parameters.reasoningEffort ?? null;
-        verbosity = assembled.parameters.verbosity ?? null;
-        assistantPrefill = assembled.parameters.assistantPrefill ?? "";
-        customParameters = mergeCustomParameters(customParameters, assembled.parameters.customParameters);
+      const assembled = await assemblePrompt(assemblerInput);
+      finalMessages = assembled.messages;
+      temperature = assembled.parameters.temperature;
+      maxTokens = assembled.parameters.maxTokens;
+      topP = assembled.parameters.topP ?? 1;
+      topK = assembled.parameters.topK ?? 0;
+      frequencyPenalty = assembled.parameters.frequencyPenalty ?? 0;
+      presencePenalty = assembled.parameters.presencePenalty ?? 0;
+      showThoughts = assembled.parameters.showThoughts ?? true;
+      reasoningEffort = assembled.parameters.reasoningEffort ?? null;
+      verbosity = assembled.parameters.verbosity ?? null;
+      assistantPrefill = assembled.parameters.assistantPrefill ?? "";
+      customParameters = mergeCustomParameters(customParameters, assembled.parameters.customParameters);
 
-        const presetMaxContext = assembled.parameters.useMaxContext
-          ? knownModelContext
-          : normalizeMaxContext(assembled.parameters.maxContext);
-        effectiveMaxContext = minContextLimit(effectiveMaxContext, presetMaxContext);
-      }
+      const presetMaxContext = assembled.parameters.useMaxContext
+        ? knownModelContext
+        : normalizeMaxContext(assembled.parameters.maxContext);
+      effectiveMaxContext = minContextLimit(effectiveMaxContext, presetMaxContext);
     }
 
     applyParameterOverrides(connectionParams);

--- a/packages/server/src/routes/generate/dry-run-route.ts
+++ b/packages/server/src/routes/generate/dry-run-route.ts
@@ -43,6 +43,7 @@ import {
   resolveBaseUrl,
   type PromptAttachment,
 } from "../generate/generate-route-utils.js";
+import { buildGenerationPromptPresetCandidates, type PromptPresetCandidateSource } from "./prompt-preset-selection.js";
 import { gameStateSnapshots as gameStateSnapshotsTable } from "../../db/schema/index.js";
 import { and, desc, eq } from "drizzle-orm";
 import { logger } from "../../lib/logger.js";
@@ -556,10 +557,6 @@ export async function registerDryRunRoute(app: FastifyInstance) {
     const resolvedInjectTrackers = body.injectTrackers === true || body.injectTrackerMetadata === true;
     const resolvedInjectChatSummary = body.injectChatSummary === true || body.injectChatSummaryInjection === true;
 
-    // Extensions sometimes send presetId as a number or `{id}`; accept these to avoid
-    // silently falling back to the chat's default preset.
-    const presetIdOverride =
-      (impersonate ? asNonEmptyString(body.impersonatePresetId) : null) || asNonEmptyString(body.presetId);
     const skipPreset = body.skipPreset === true;
     const presetText = typeof body.presetText === "string" ? body.presetText : "";
 
@@ -775,33 +772,55 @@ export async function registerDryRunRoute(app: FastifyInstance) {
       /* non-critical */
     }
 
-    const effectivePresetId =
-      skipPreset || chatMode === "conversation"
-        ? null
-        : (presetIdOverride ?? (chat.promptPresetId as string | null) ?? null);
+    const promptPresetCandidates = skipPreset
+      ? []
+      : buildGenerationPromptPresetCandidates({
+          chatMode,
+          chatPromptPresetId: chat.promptPresetId,
+          connectionPromptPresetId: conn.promptPresetId,
+          impersonate,
+          impersonatePromptPresetId: body.impersonatePresetId,
+          requestPromptPresetId: body.presetId,
+        });
+    let effectivePresetId: string | null = null;
+    let effectivePresetSource: PromptPresetCandidateSource | null = null;
+    for (const candidate of promptPresetCandidates) {
+      const candidatePreset = await presets.getById(candidate.id);
+      if (candidatePreset) {
+        effectivePresetId = candidate.id;
+        effectivePresetSource = candidate.source;
+        break;
+      }
+      if (candidate.source !== "chat") {
+        logger.warn(
+          "[dryRun] %s prompt preset override %s was not found; falling back to the next preset candidate",
+          candidate.source,
+          candidate.id,
+        );
+      }
+    }
 
     // Choice selections are stored per-chat (chat metadata), not per prompt preset.
-    // If an extension overrides the prompt preset, reusing the chat's stored selections can make it
+    // If a request or connection overrides the prompt preset, reusing the chat's stored selections can make it
     // *look* like the wrong preset is being used (because variables like {{role}} resolve to values
     // picked under a different preset).
     //
     // Dry-run-only behavior:
     // - If the request explicitly provides presetChoices, use those.
-    // - Else if the request overrides presetId to something different than the chat's promptPresetId,
+    // - Else if the effective preset differs from the chat's promptPresetId,
     //   start with empty choices so the assembler falls back to the preset's default/first options.
     // - Else fall back to the chat's stored selections.
     const requestChoices = parsePresetChoices((body as any).presetChoices);
 
     const chatChoicesFromMeta = (chatMeta.presetChoices ?? {}) as Record<string, string | string[]>;
     const isDifferentPresetOverride =
-      chatMode !== "conversation" &&
-      !!presetIdOverride &&
-      presetIdOverride !== ((chat.promptPresetId as string | null) ?? null);
-    const presetDefaultChoices = isDifferentPresetOverride
-      ? skipPreset
-        ? null
-        : parsePresetChoices((await presets.getById(presetIdOverride))?.defaultChoices)
-      : null;
+      !!effectivePresetId &&
+      effectivePresetSource !== "chat" &&
+      effectivePresetId !== ((chat.promptPresetId as string | null) ?? null);
+    const presetDefaultChoices =
+      isDifferentPresetOverride && effectivePresetId
+        ? parsePresetChoices((await presets.getById(effectivePresetId))?.defaultChoices)
+        : null;
 
     const chatChoices: Record<string, string | string[]> =
       requestChoices ?? (isDifferentPresetOverride ? (presetDefaultChoices ?? {}) : chatChoicesFromMeta);

--- a/packages/server/src/routes/generate/prompt-preset-selection.ts
+++ b/packages/server/src/routes/generate/prompt-preset-selection.ts
@@ -1,0 +1,63 @@
+export type PromptPresetCandidateSource = "impersonate" | "request" | "connection" | "chat";
+
+export interface PromptPresetCandidate {
+  id: string;
+  source: PromptPresetCandidateSource;
+}
+
+function asNonEmptyString(value: unknown): string | null {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed ? trimmed : null;
+  }
+  if (typeof value === "number" && Number.isFinite(value)) return String(value);
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    const id = (value as { id?: unknown }).id;
+    if (typeof id === "string") {
+      const trimmed = id.trim();
+      return trimmed ? trimmed : null;
+    }
+  }
+  return null;
+}
+
+function pushUnique(
+  candidates: PromptPresetCandidate[],
+  seen: Set<string>,
+  id: string | null,
+  source: PromptPresetCandidateSource,
+) {
+  if (!id || seen.has(id)) return;
+  candidates.push({ id, source });
+  seen.add(id);
+}
+
+export function supportsConnectionPromptPresetOverride(chatMode: unknown): boolean {
+  return chatMode === "roleplay" || chatMode === "visual_novel";
+}
+
+export function buildGenerationPromptPresetCandidates(args: {
+  chatMode: unknown;
+  chatPromptPresetId?: unknown;
+  connectionPromptPresetId?: unknown;
+  impersonate?: boolean;
+  impersonatePromptPresetId?: unknown;
+  requestPromptPresetId?: unknown;
+}): PromptPresetCandidate[] {
+  if (args.chatMode === "conversation") return [];
+
+  const candidates: PromptPresetCandidate[] = [];
+  const seen = new Set<string>();
+
+  if (args.impersonate) {
+    pushUnique(candidates, seen, asNonEmptyString(args.impersonatePromptPresetId), "impersonate");
+  }
+  pushUnique(candidates, seen, asNonEmptyString(args.requestPromptPresetId), "request");
+
+  if (supportsConnectionPromptPresetOverride(args.chatMode)) {
+    pushUnique(candidates, seen, asNonEmptyString(args.connectionPromptPresetId), "connection");
+  }
+
+  pushUnique(candidates, seen, asNonEmptyString(args.chatPromptPresetId), "chat");
+  return candidates;
+}

--- a/packages/server/src/services/storage/connections.storage.ts
+++ b/packages/server/src/services/storage/connections.storage.ts
@@ -88,6 +88,7 @@ export function createConnectionsStorage(db: DB) {
         imageGenerationSource: input.imageGenerationSource ?? null,
         comfyuiWorkflow: input.comfyuiWorkflow ?? null,
         imageService: input.imageService ?? null,
+        promptPresetId: input.promptPresetId ?? null,
         maxTokensOverride: input.maxTokensOverride ?? null,
         claudeFastMode: String(input.claudeFastMode ?? false),
         createdAt: timestamp,
@@ -165,6 +166,9 @@ export function createConnectionsStorage(db: DB) {
       if (data.imageService !== undefined) {
         updateFields.imageService = data.imageService;
       }
+      if (data.promptPresetId !== undefined) {
+        updateFields.promptPresetId = data.promptPresetId;
+      }
       if (data.maxTokensOverride !== undefined) {
         updateFields.maxTokensOverride = data.maxTokensOverride;
       }
@@ -205,6 +209,7 @@ export function createConnectionsStorage(db: DB) {
         imageGenerationSource: source.imageGenerationSource,
         comfyuiWorkflow: source.comfyuiWorkflow,
         imageService: source.imageService,
+        promptPresetId: source.promptPresetId,
         maxTokensOverride: source.maxTokensOverride,
         maxParallelJobs: source.maxParallelJobs,
         claudeFastMode: source.claudeFastMode,

--- a/packages/server/test/connection-prompt-preset-selection.test.ts
+++ b/packages/server/test/connection-prompt-preset-selection.test.ts
@@ -1,0 +1,78 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { buildGenerationPromptPresetCandidates } from "../src/routes/generate/prompt-preset-selection.js";
+
+test("connection prompt preset overrides chat preset for roleplay modes", () => {
+  assert.deepEqual(
+    buildGenerationPromptPresetCandidates({
+      chatMode: "roleplay",
+      chatPromptPresetId: "chat-preset",
+      connectionPromptPresetId: "connection-preset",
+    }),
+    [
+      { id: "connection-preset", source: "connection" },
+      { id: "chat-preset", source: "chat" },
+    ],
+  );
+
+  assert.deepEqual(
+    buildGenerationPromptPresetCandidates({
+      chatMode: "visual_novel",
+      chatPromptPresetId: "chat-preset",
+      connectionPromptPresetId: "connection-preset",
+    }),
+    [
+      { id: "connection-preset", source: "connection" },
+      { id: "chat-preset", source: "chat" },
+    ],
+  );
+});
+
+test("explicit impersonate preset stays ahead of connection prompt preset", () => {
+  assert.deepEqual(
+    buildGenerationPromptPresetCandidates({
+      chatMode: "roleplay",
+      chatPromptPresetId: "chat-preset",
+      connectionPromptPresetId: "connection-preset",
+      impersonate: true,
+      impersonatePromptPresetId: "impersonate-preset",
+    }),
+    [
+      { id: "impersonate-preset", source: "impersonate" },
+      { id: "connection-preset", source: "connection" },
+      { id: "chat-preset", source: "chat" },
+    ],
+  );
+});
+
+test("connection prompt preset does not affect conversation or game prompt flows", () => {
+  assert.deepEqual(
+    buildGenerationPromptPresetCandidates({
+      chatMode: "conversation",
+      chatPromptPresetId: "chat-preset",
+      connectionPromptPresetId: "connection-preset",
+    }),
+    [],
+  );
+
+  assert.deepEqual(
+    buildGenerationPromptPresetCandidates({
+      chatMode: "game",
+      chatPromptPresetId: "chat-preset",
+      connectionPromptPresetId: "connection-preset",
+    }),
+    [{ id: "chat-preset", source: "chat" }],
+  );
+});
+
+test("duplicate prompt preset candidates are collapsed in priority order", () => {
+  assert.deepEqual(
+    buildGenerationPromptPresetCandidates({
+      chatMode: "roleplay",
+      chatPromptPresetId: "same-preset",
+      connectionPromptPresetId: "same-preset",
+      requestPromptPresetId: "same-preset",
+    }),
+    [{ id: "same-preset", source: "request" }],
+  );
+});

--- a/packages/server/test/db-migrations.test.ts
+++ b/packages/server/test/db-migrations.test.ts
@@ -276,3 +276,49 @@ test("startup migrations add max parallel jobs to existing connections", async (
     client.close();
   }
 });
+
+test("startup migrations add prompt preset override to existing connections", async () => {
+  const client = createClient({ url: "file::memory:" });
+  const db = drizzle(client) as unknown as DB;
+
+  try {
+    await db.run(
+      sql.raw(`CREATE TABLE api_connections (
+        id TEXT PRIMARY KEY NOT NULL,
+        name TEXT NOT NULL,
+        provider TEXT NOT NULL,
+        base_url TEXT NOT NULL DEFAULT '',
+        api_key_encrypted TEXT NOT NULL DEFAULT '',
+        model TEXT NOT NULL DEFAULT '',
+        max_context INTEGER NOT NULL DEFAULT 128000,
+        is_default TEXT NOT NULL DEFAULT 'false',
+        use_for_random TEXT NOT NULL DEFAULT 'false',
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      )`),
+    );
+    await db.run(
+      sql.raw(`INSERT INTO api_connections (
+        id, name, provider, base_url, api_key_encrypted, model, max_context,
+        is_default, use_for_random, created_at, updated_at
+      ) VALUES (
+        'legacy-preset-override', 'Legacy Preset Override', 'openai', 'https://api.openai.com/v1', '',
+        'gpt-5.1', 128000, 'false', 'false',
+        '2026-01-01T00:00:00.000Z', '2026-01-01T00:00:00.000Z'
+      )`),
+    );
+
+    await runMigrations(db);
+    await runMigrations(db);
+
+    const columns = await db.all<{ name: string }>(sql.raw("PRAGMA table_info(api_connections)"));
+    const rows = await db.all<{ id: string; prompt_preset_id: string | null }>(
+      sql.raw(`SELECT id, prompt_preset_id FROM api_connections WHERE id = 'legacy-preset-override'`),
+    );
+
+    assert.ok(columns.some((column) => column.name === "prompt_preset_id"));
+    assert.deepEqual(rows, [{ id: "legacy-preset-override", prompt_preset_id: null }]);
+  } finally {
+    client.close();
+  }
+});

--- a/packages/shared/src/schemas/connection.schema.ts
+++ b/packages/shared/src/schemas/connection.schema.ts
@@ -37,6 +37,7 @@ export const createConnectionSchema = z.object({
   imageGenerationSource: z.string().nullable().default(null),
   comfyuiWorkflow: z.string().nullable().default(null),
   imageService: z.string().nullable().default(null),
+  promptPresetId: z.string().nullable().default(null),
   maxTokensOverride: z.number().int().min(1).nullable().default(null),
   maxParallelJobs: z.number().int().min(1).max(16).default(1),
   claudeFastMode: z.boolean().default(false),

--- a/packages/shared/src/types/connection.ts
+++ b/packages/shared/src/types/connection.ts
@@ -52,6 +52,8 @@ export interface APIConnection {
   imageService: string | null;
   /** Default generation parameters for new chats using this connection (JSON) */
   defaultParameters: string | null;
+  /** Prompt preset to use instead of a chat's selected preset when this connection is active */
+  promptPresetId: string | null;
   /** Hard cap on max_tokens for the API response (for providers with lower limits, e.g. DeepSeek at 8192). */
   maxTokensOverride: number | null;
   /** Maximum number of agent LLM jobs Marinara may run at once for this connection. */


### PR DESCRIPTION
## Linked issue

No linked issue yet; this came from a maintainer-requested feature for model-specific connection behavior.

## Why this change

Some models need a different prompt structure than the chat's normal prompt preset. Before this change, switching a chat to a specialized Connection still used the chat-level preset, so users had to manually change chat settings or keep duplicate chats just to target a model-specific prompt format.

## What changed

- Added an optional prompt preset override on API Connections.
- Updated roleplay and visual novel generation to prefer impersonate/request presets, then the connection override, then the chat preset.
- Mirrored the same selection behavior in prompt dry-run previews.
- Added the Connection editor control and schema/storage/migration support for `prompt_preset_id`.
- Added focused tests for preset priority and the startup migration.

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Local validation run: `pnpm --filter @marinara-engine/server exec tsx --import ./test/setup-env.ts --test test/connection-prompt-preset-selection.test.ts test/db-migrations.test.ts`
- Local validation run: `pnpm check`
- Maintainer manually tested that generation uses the selected connection preset, preserves the right preset choices, and falls back correctly if the selected connection preset is later deleted.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs, release, or version files changed.

## UI evidence (if applicable)

<img width="1119" height="317" alt="image" src="https://github.com/user-attachments/assets/2eb85b9a-d93e-4a5d-885c-1b3ab1e3f76b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now assign a specific prompt preset to API connections, overriding the chat's default preset when that connection is active (for roleplay and visual novel chats).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/727)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->