### PR TITLE
Fix CJK Google font shard loading

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -31,6 +31,17 @@ type HealthResponse = {
   version: string;
 };
 
+type CustomFontFace = {
+  filename: string;
+  family: string;
+  url: string;
+  weight?: string;
+  style?: string;
+  unicodeRange?: string;
+};
+
+const registeredCustomFontFaceKeys = new Set<string>();
+
 function stripFontFamilyQuotes(family: string): string {
   const trimmed = family.trim();
   if (trimmed.length < 2) return trimmed;
@@ -46,6 +57,10 @@ function stripFontFamilyQuotes(family: string): string {
 function toCssFontFamilyValue(family: string): string {
   const cleanFamily = stripFontFamilyQuotes(family);
   return `"${cleanFamily.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+function customFontFaceKey(family: string, font: CustomFontFace): string {
+  return [family, font.url, font.weight ?? "400", font.style ?? "normal", font.unicodeRange ?? ""].join("|");
 }
 
 function syncRangeSliderProgress(input: HTMLInputElement) {
@@ -216,8 +231,8 @@ export function App() {
     }
   }, [fontFamily]);
 
-  // Pre-load custom fonts at startup so switching to Appearance tab doesn't cause a flash
-  const { data: customFonts } = useQuery<{ filename: string; family: string; url: string }[]>({
+  // Register custom font faces without forcing every shard to load at startup.
+  const { data: customFonts } = useQuery<CustomFontFace[]>({
     queryKey: ["custom-fonts"],
     queryFn: () => api.get("/fonts"),
     staleTime: Infinity,
@@ -242,19 +257,20 @@ export function App() {
           return;
         }
 
+        const key = customFontFaceKey(family, f);
+        if (registeredCustomFontFaceKeys.has(key)) {
+          return;
+        }
+
         const fontFace = new FontFace(family, `url("${f.url}")`, {
           display: "swap",
-          weight: "400",
+          weight: f.weight ?? "400",
+          style: f.style ?? "normal",
+          ...(f.unicodeRange ? { unicodeRange: f.unicodeRange } : {}),
         });
 
-        fontFace
-          .load()
-          .then((loadedFace) => {
-            document.fonts.add(loadedFace);
-          })
-          .catch(() => {
-            // Ignore individual font load errors to avoid breaking others
-          });
+        document.fonts.add(fontFace);
+        registeredCustomFontFaceKeys.add(key);
       } catch {
         // Ignore construction errors for invalid font definitions
       }

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -69,6 +69,15 @@ import { DraftNumberInput } from "../ui/DraftNumberInput";
 import { ExportFormatDialog, type ExportFormatChoice } from "../ui/ExportFormatDialog";
 import { inspectCharacterFilesForEmbeddedLorebooks } from "../../lib/character-import";
 
+type CustomFontFace = {
+  filename: string;
+  family: string;
+  url: string;
+  weight?: string;
+  style?: string;
+  unicodeRange?: string;
+};
+
 const TABS = [
   { id: "general", label: "General" },
   { id: "appearance", label: "Appearance" },
@@ -967,18 +976,29 @@ function AppearanceSettings() {
   const [draftStrokeColor, setDraftStrokeColor] = useState(textStrokeColor);
 
   // Custom fonts — query is pre-warmed in App.tsx, no fetch here
-  const { data: customFonts } = useQuery<{ filename: string; family: string; url: string }[]>({
+  const { data: customFonts } = useQuery<CustomFontFace[]>({
     queryKey: ["custom-fonts"],
     queryFn: () => api.get("/fonts"),
     staleTime: Infinity,
   });
+  const customFontOptions = React.useMemo(() => {
+    const seen = new Set<string>();
+    return (customFonts ?? []).filter((font) => {
+      const family = font.family.trim();
+      if (!family || seen.has(family)) return false;
+      seen.add(family);
+      return true;
+    });
+  }, [customFonts]);
 
   // Google Fonts download
   const [googleFontName, setGoogleFontName] = useState("");
   const queryClient = useQueryClient();
   const googleFontMutation = useMutation({
     mutationFn: (family: string) =>
-      api.post<{ filename: string; family: string; url: string }>("/fonts/google/download", { family }),
+      api.post<{ filename: string; family: string; url: string; files?: CustomFontFace[] }>("/fonts/google/download", {
+        family,
+      }),
     onSuccess: (data) => {
       toast.success(`Installed "${data.family}"`);
       setGoogleFontName("");
@@ -1056,7 +1076,7 @@ function AppearanceSettings() {
           className="rounded-lg bg-[var(--secondary)] px-3 py-2 text-xs outline-none ring-1 ring-transparent transition-shadow focus:ring-[var(--primary)]"
         >
           <option value="">Default (Inter)</option>
-          {customFonts?.map((f) => (
+          {customFontOptions.map((f) => (
             <option key={f.family} value={f.family}>
               {f.family}
             </option>

--- a/packages/server/src/routes/fonts.routes.ts
+++ b/packages/server/src/routes/fonts.routes.ts
@@ -4,13 +4,14 @@
 import type { FastifyInstance } from "fastify";
 import { logger } from "../lib/logger.js";
 import { existsSync, mkdirSync, createReadStream } from "fs";
-import { readdir, writeFile } from "fs/promises";
+import { readdir, readFile, rename, unlink, writeFile } from "fs/promises";
 import { join, extname, basename } from "path";
 import { execFile } from "child_process";
 import { platform } from "os";
 import { DATA_DIR } from "../utils/data-dir.js";
 
 const FONTS_DIR = join(DATA_DIR, "fonts");
+const FONT_METADATA_FILE = join(FONTS_DIR, "font-metadata.json");
 
 const FONT_EXTS = new Set([".ttf", ".otf", ".woff", ".woff2"]);
 
@@ -27,6 +28,41 @@ const MIME_MAP: Record<string, string> = {
   ".woff2": "font/woff2",
 };
 
+interface FontMetadataEntry {
+  family: string;
+  weight?: string;
+  style?: string;
+  unicodeRange?: string;
+  source?: "google";
+}
+
+interface CustomFontFace {
+  filename: string;
+  family: string;
+  url: string;
+  weight: string;
+  style: string;
+  unicodeRange?: string;
+}
+
+interface GoogleFontFace {
+  url: string;
+  weight: string;
+  style: string;
+  unicodeRange?: string;
+}
+
+interface GoogleCssResult {
+  css: string | null;
+  reachedGoogle: boolean;
+}
+
+interface DownloadedFontFile {
+  filename: string;
+  face: GoogleFontFace;
+  buffer: Buffer;
+}
+
 function ensureDir() {
   if (!existsSync(FONTS_DIR)) {
     mkdirSync(FONTS_DIR, { recursive: true });
@@ -34,10 +70,15 @@ function ensureDir() {
 }
 
 /** Derive a display name from a font filename: "Roboto-Regular.woff2" → "Roboto" */
-function fontDisplayName(filename: string): string {
+export function fontDisplayName(filename: string): string {
   const name = basename(filename, extname(filename));
   return (
     name
+      // Strip Marinara-downloaded Google Fonts shard suffixes.
+      .replace(
+        /[-_](Regular|BoldItalic|Bold|Italic|Light|Medium|SemiBold|ExtraBold|Thin|Black|Variable.*)[-_]\d{3}$/i,
+        "",
+      )
       // Strip common weight/style suffixes
       .replace(/[-_](Regular|Bold|Italic|Light|Medium|SemiBold|ExtraBold|Thin|Black|BoldItalic|Variable.*)/gi, "")
       // Split camelCase: "OpenSans" → "Open Sans"
@@ -52,35 +93,243 @@ function fontDisplayName(filename: string): string {
   );
 }
 
+function normalizeMetadataEntry(value: unknown): FontMetadataEntry | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const entry = value as Partial<FontMetadataEntry>;
+  if (typeof entry.family !== "string" || !entry.family.trim()) return null;
+  return {
+    family: entry.family.trim(),
+    weight: typeof entry.weight === "string" && entry.weight.trim() ? entry.weight.trim() : undefined,
+    style: typeof entry.style === "string" && entry.style.trim() ? entry.style.trim() : undefined,
+    unicodeRange:
+      typeof entry.unicodeRange === "string" && entry.unicodeRange.trim() ? entry.unicodeRange.trim() : undefined,
+    source: entry.source === "google" ? "google" : undefined,
+  };
+}
+
+async function readFontMetadata(): Promise<Record<string, FontMetadataEntry>> {
+  try {
+    const raw = await readFile(FONT_METADATA_FILE, "utf-8");
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+
+    const metadata: Record<string, FontMetadataEntry> = {};
+    for (const [filename, value] of Object.entries(parsed)) {
+      const entry = normalizeMetadataEntry(value);
+      if (entry) metadata[filename] = entry;
+    }
+    return metadata;
+  } catch {
+    return {};
+  }
+}
+
+async function writeFontMetadata(metadata: Record<string, FontMetadataEntry>) {
+  ensureDir();
+  const tempFile = `${FONT_METADATA_FILE}.${Date.now()}-${Math.random().toString(36).slice(2)}.tmp`;
+  try {
+    await writeFile(tempFile, `${JSON.stringify(metadata, null, 2)}\n`, "utf-8");
+    await rename(tempFile, FONT_METADATA_FILE);
+  } catch (err) {
+    await unlink(tempFile).catch(() => {});
+    throw err;
+  }
+}
+
+function inferFontWeight(filename: string): string {
+  const base = basename(filename, extname(filename));
+  if (/Thin/i.test(base)) return "100";
+  if (/ExtraLight|UltraLight/i.test(base)) return "200";
+  if (/Light/i.test(base)) return "300";
+  if (/Medium/i.test(base)) return "500";
+  if (/SemiBold|DemiBold/i.test(base)) return "600";
+  if (/ExtraBold|UltraBold/i.test(base)) return "800";
+  if (/Black|Heavy/i.test(base)) return "900";
+  if (/Bold/i.test(base)) return "700";
+  return "400";
+}
+
+function inferFontStyle(filename: string): string {
+  return /Italic|Oblique/i.test(basename(filename, extname(filename))) ? "italic" : "normal";
+}
+
+function stripCssQuotes(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length >= 2) {
+    const quote = trimmed[0];
+    if ((quote === `"` || quote === `'`) && trimmed[trimmed.length - 1] === quote) {
+      return trimmed.slice(1, -1).trim();
+    }
+  }
+  return trimmed;
+}
+
+function readCssDescriptor(block: string, name: string): string | undefined {
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = block.match(new RegExp(`${escaped}\\s*:\\s*([^;]+);`, "i"));
+  return match?.[1]?.trim();
+}
+
+export function parseGoogleFontFaces(css: string): GoogleFontFace[] {
+  const faces: GoogleFontFace[] = [];
+  const seen = new Set<string>();
+  const blocks = css.matchAll(/@font-face\s*\{([\s\S]*?)\}/g);
+
+  for (const blockMatch of blocks) {
+    const block = blockMatch[1] ?? "";
+    const url = block.match(/url\((?:"|')?(https:\/\/fonts\.gstatic\.com\/s\/[^\s)"']+\.woff2)(?:"|')?\)/i)?.[1];
+    if (!url) continue;
+
+    const weight = stripCssQuotes(readCssDescriptor(block, "font-weight") ?? "400");
+    const style = stripCssQuotes(readCssDescriptor(block, "font-style") ?? "normal");
+    const unicodeRange = readCssDescriptor(block, "unicode-range");
+    const key = `${url}|${weight}|${style}|${unicodeRange ?? ""}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    faces.push({ url, weight, style, unicodeRange });
+  }
+
+  return faces;
+}
+
+async function fetchGoogleCss(url: string): Promise<GoogleCssResult> {
+  try {
+    const cssRes = await fetch(url, {
+      headers: {
+        "User-Agent":
+          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+      },
+      signal: AbortSignal.timeout(15_000),
+    });
+    if (!cssRes.ok) return { css: null, reachedGoogle: true };
+    return { css: await cssRes.text(), reachedGoogle: true };
+  } catch {
+    return { css: null, reachedGoogle: false };
+  }
+}
+
+async function loadGoogleFontFaces(
+  family: string,
+): Promise<{ faces: GoogleFontFace[] | null; reachedGoogle: boolean }> {
+  const encodedFamily = encodeURIComponent(family);
+  const css2Url = `https://fonts.googleapis.com/css2?family=${encodedFamily}:wght@400&display=swap`;
+  const legacyCssUrl = `https://fonts.googleapis.com/css?family=${encodedFamily}:400&display=swap`;
+
+  const css2 = await fetchGoogleCss(css2Url);
+  const css2Faces = css2.css ? parseGoogleFontFaces(css2.css) : [];
+
+  // Some CJK families expose the full glyph shards only through the legacy CSS endpoint.
+  // Prefer it when it contains a richer face list than css2.
+  const legacyCss = await fetchGoogleCss(legacyCssUrl);
+  const legacyFaces = legacyCss.css ? parseGoogleFontFaces(legacyCss.css) : [];
+
+  const faces = legacyFaces.length > css2Faces.length ? legacyFaces : css2Faces;
+  return {
+    faces: faces.length > 0 ? faces : null,
+    reachedGoogle: css2.reachedGoogle || legacyCss.reachedGoogle,
+  };
+}
+
+function isManagedGoogleFamilyFile(filename: string, safeName: string, metadata: Record<string, FontMetadataEntry>) {
+  const ext = extname(filename).toLowerCase();
+  return (
+    FONT_EXTS.has(ext) &&
+    metadata[filename]?.source === "google" &&
+    (filename === `${safeName}-Regular.woff2` || filename.startsWith(`${safeName}-Regular-`))
+  );
+}
+
+async function replaceManagedGoogleFontFiles(
+  safeName: string,
+  family: string,
+  metadata: Record<string, FontMetadataEntry>,
+  downloaded: DownloadedFontFile[],
+) {
+  ensureDir();
+  const operationId = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const tempFiles: Array<{ target: DownloadedFontFile; tempFilename: string }> = [];
+  const backups: Array<{ filename: string; backupFilename: string }> = [];
+  const installedTargets: string[] = [];
+
+  try {
+    for (const target of downloaded) {
+      const tempFilename = `${target.filename}.${operationId}.tmp`;
+      tempFiles.push({ target, tempFilename });
+      await writeFile(join(FONTS_DIR, tempFilename), target.buffer);
+    }
+
+    const entries = await readdir(FONTS_DIR, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isFile()) continue;
+      if (!isManagedGoogleFamilyFile(entry.name, safeName, metadata)) continue;
+      const backupFilename = `${entry.name}.${operationId}.bak`;
+      await rename(join(FONTS_DIR, entry.name), join(FONTS_DIR, backupFilename));
+      backups.push({ filename: entry.name, backupFilename });
+    }
+
+    for (const { target, tempFilename } of tempFiles) {
+      await rename(join(FONTS_DIR, tempFilename), join(FONTS_DIR, target.filename));
+      installedTargets.push(target.filename);
+    }
+
+    const nextMetadata = { ...metadata };
+    for (const { filename } of backups) {
+      delete nextMetadata[filename];
+    }
+    for (const item of downloaded) {
+      nextMetadata[item.filename] = {
+        family,
+        weight: item.face.weight,
+        style: item.face.style,
+        ...(item.face.unicodeRange ? { unicodeRange: item.face.unicodeRange } : {}),
+        source: "google",
+      };
+    }
+    await writeFontMetadata(nextMetadata);
+
+    await Promise.all(backups.map(({ backupFilename }) => unlink(join(FONTS_DIR, backupFilename)).catch(() => {})));
+  } catch (err) {
+    await Promise.all(installedTargets.map((filename) => unlink(join(FONTS_DIR, filename)).catch(() => {})));
+    await Promise.all(
+      backups.map(({ filename, backupFilename }) =>
+        rename(join(FONTS_DIR, backupFilename), join(FONTS_DIR, filename)).catch(() => {}),
+      ),
+    );
+    await Promise.all(tempFiles.map(({ tempFilename }) => unlink(join(FONTS_DIR, tempFilename)).catch(() => {})));
+    throw err;
+  }
+}
+
 export async function fontsRoutes(app: FastifyInstance) {
   /** List available custom fonts from data/fonts/ */
   app.get("/", async () => {
     ensureDir();
     const entries = await readdir(FONTS_DIR, { withFileTypes: true });
-    const fonts: { filename: string; family: string; url: string }[] = [];
+    const metadata = await readFontMetadata();
+    const managedShardLegacyFiles = new Set(
+      Object.entries(metadata)
+        .filter(([filename, meta]) => meta.source === "google" && /-Regular-\d{3}\.woff2$/i.test(filename))
+        .map(([filename]) => filename.replace(/-Regular-\d{3}\.woff2$/i, "-Regular.woff2")),
+    );
+    const fonts: CustomFontFace[] = [];
 
     for (const e of entries) {
       if (!e.isFile()) continue;
       const ext = extname(e.name).toLowerCase();
       if (!FONT_EXTS.has(ext)) continue;
+      const meta = metadata[e.name];
+      if (!meta && managedShardLegacyFiles.has(e.name)) continue;
       fonts.push({
         filename: e.name,
-        family: fontDisplayName(e.name),
+        family: meta?.family ?? fontDisplayName(e.name),
         url: `/api/fonts/file/${encodeURIComponent(e.name)}`,
+        weight: meta?.weight ?? inferFontWeight(e.name),
+        style: meta?.style ?? inferFontStyle(e.name),
+        ...(meta?.unicodeRange ? { unicodeRange: meta.unicodeRange } : {}),
       });
     }
 
-    // Deduplicate by family name (keep first occurrence)
-    const seen = new Set<string>();
-    const unique: typeof fonts = [];
-    for (const f of fonts) {
-      if (!seen.has(f.family)) {
-        seen.add(f.family);
-        unique.push(f);
-      }
-    }
-
-    return unique;
+    return fonts.sort((a, b) => a.family.localeCompare(b.family) || a.filename.localeCompare(b.filename));
   });
 
   /** Serve a font file */
@@ -134,13 +383,7 @@ export async function fontsRoutes(app: FastifyInstance) {
       return reply.status(400).send({ error: "Invalid font family name. Use only letters, numbers, and spaces." });
     }
 
-    // Check if already installed
     const safeName = sanitized.replace(/ /g, "");
-    const targetFile = `${safeName}-Regular.woff2`;
-    const targetPath = join(FONTS_DIR, targetFile);
-    if (existsSync(targetPath)) {
-      return reply.status(409).send({ error: `"${sanitized}" is already installed` });
-    }
 
     // Prevent concurrent downloads of the same font
     if (downloadingFonts.has(safeName)) {
@@ -149,47 +392,35 @@ export async function fontsRoutes(app: FastifyInstance) {
     downloadingFonts.add(safeName);
 
     try {
-      // Fetch the CSS from Google Fonts (woff2 format via modern user-agent)
-      const encodedFamily = encodeURIComponent(sanitized);
-      const cssUrl = `https://fonts.googleapis.com/css2?family=${encodedFamily}:wght@400&display=swap`;
-
-      let css: string;
-      try {
-        const cssRes = await fetch(cssUrl, {
-          headers: {
-            "User-Agent":
-              "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
-          },
-          signal: AbortSignal.timeout(15_000),
-        });
-        if (!cssRes.ok) {
-          return reply.status(404).send({ error: `Font "${sanitized}" not found on Google Fonts` });
+      // Fetch the CSS from Google Fonts (woff2 format via modern user-agent).
+      // CJK families are often split into many unicode-range shards, so keep all faces.
+      const { faces, reachedGoogle } = await loadGoogleFontFaces(sanitized);
+      if (!faces) {
+        if (!reachedGoogle) {
+          return reply.status(502).send({ error: "Could not reach Google Fonts. Check your internet connection." });
         }
-        css = await cssRes.text();
-      } catch {
-        return reply.status(502).send({ error: "Could not reach Google Fonts. Check your internet connection." });
-      }
-
-      // Extract woff2 URL — only allow fonts.gstatic.com to prevent SSRF
-      const urlMatches = [...css.matchAll(/url\((https:\/\/fonts\.gstatic\.com\/s\/[^\s)]+\.woff2)\)/g)];
-      if (urlMatches.length === 0) {
         return reply
           .status(404)
           .send({ error: `Font "${sanitized}" not found on Google Fonts, or has no regular (400) weight available` });
       }
 
-      // Take the last match (latin subset)
-      const lastMatch = urlMatches[urlMatches.length - 1];
-      const fontFileUrl = lastMatch?.[1];
-      if (!fontFileUrl) {
-        return reply.status(500).send({ error: "Could not extract font file from Google Fonts response" });
+      const metadata = await readFontMetadata();
+      const faceTargets = faces.map((face, i) => {
+        const suffix = faces.length === 1 ? "" : `-${String(i + 1).padStart(3, "0")}`;
+        return { face, filename: `${safeName}-Regular${suffix}.woff2` };
+      });
+      const unmanagedConflict = faceTargets.find(
+        ({ filename }) => existsSync(join(FONTS_DIR, filename)) && metadata[filename]?.source !== "google",
+      );
+      if (unmanagedConflict) {
+        return reply.status(409).send({ error: `"${sanitized}" is already installed` });
       }
 
-      // Download the actual font file with size limit
-      let buffer: Buffer;
-      try {
-        const fontRes = await fetch(fontFileUrl, { signal: AbortSignal.timeout(30_000) });
-        if (!fontRes.ok) {
+      const downloaded: Array<{ filename: string; face: GoogleFontFace; buffer: Buffer }> = [];
+      for (const target of faceTargets) {
+        const { face, filename } = target;
+        const fontRes = await fetch(face.url, { signal: AbortSignal.timeout(30_000) }).catch(() => null);
+        if (!fontRes || !fontRes.ok) {
           return reply.status(502).send({ error: "Failed to download font file" });
         }
 
@@ -198,27 +429,35 @@ export async function fontsRoutes(app: FastifyInstance) {
           return reply.status(413).send({ error: "Font file is too large (max 10 MB)" });
         }
 
-        buffer = Buffer.from(await fontRes.arrayBuffer());
+        const buffer = Buffer.from(await fontRes.arrayBuffer());
         if (buffer.length > MAX_FONT_BYTES) {
           return reply.status(413).send({ error: "Font file is too large (max 10 MB)" });
         }
-      } catch {
-        return reply.status(502).send({ error: "Failed to download font file. Check your internet connection." });
+
+        // Validate woff2 magic bytes ("wOF2")
+        if (buffer.length < 4 || buffer[0] !== 0x77 || buffer[1] !== 0x4f || buffer[2] !== 0x46 || buffer[3] !== 0x32) {
+          return reply.status(502).send({ error: "Downloaded file is not a valid woff2 font" });
+        }
+
+        downloaded.push({ filename, face, buffer });
       }
 
-      // Validate woff2 magic bytes ("wOF2")
-      if (buffer.length < 4 || buffer[0] !== 0x77 || buffer[1] !== 0x4f || buffer[2] !== 0x46 || buffer[3] !== 0x32) {
-        return reply.status(502).send({ error: "Downloaded file is not a valid woff2 font" });
-      }
+      await replaceManagedGoogleFontFiles(safeName, sanitized, metadata, downloaded);
 
-      // Save to fonts directory
-      ensureDir();
-      await writeFile(targetPath, buffer);
+      const files = downloaded.map(({ filename, face }) => ({
+        filename,
+        family: sanitized,
+        url: `/api/fonts/file/${encodeURIComponent(filename)}`,
+        weight: face.weight,
+        style: face.style,
+        ...(face.unicodeRange ? { unicodeRange: face.unicodeRange } : {}),
+      }));
 
       return {
-        filename: targetFile,
-        family: fontDisplayName(targetFile),
-        url: `/api/fonts/file/${encodeURIComponent(targetFile)}`,
+        filename: files[0]?.filename ?? `${safeName}-Regular.woff2`,
+        family: sanitized,
+        url: files[0]?.url ?? `/api/fonts/file/${encodeURIComponent(`${safeName}-Regular.woff2`)}`,
+        files,
       };
     } finally {
       downloadingFonts.delete(safeName);

--- a/packages/server/src/routes/fonts.routes.ts
+++ b/packages/server/src/routes/fonts.routes.ts
@@ -230,12 +230,23 @@ async function loadGoogleFontFaces(
   };
 }
 
+export function isLegacyManagedGoogleFilename(filename: string, safeName: string) {
+  const ext = extname(filename).toLowerCase();
+  if (ext !== ".woff2") return false;
+
+  const base = basename(filename, ext).toLowerCase();
+  const legacyBase = `${safeName}-Regular`.toLowerCase();
+  if (base === legacyBase) return true;
+  if (!base.startsWith(`${legacyBase}-`)) return false;
+  return /^\d{3}$/.test(base.slice(legacyBase.length + 1));
+}
+
 function isManagedGoogleFamilyFile(filename: string, safeName: string, metadata: Record<string, FontMetadataEntry>) {
   const ext = extname(filename).toLowerCase();
   return (
     FONT_EXTS.has(ext) &&
-    metadata[filename]?.source === "google" &&
-    (filename === `${safeName}-Regular.woff2` || filename.startsWith(`${safeName}-Regular-`))
+    isLegacyManagedGoogleFilename(filename, safeName) &&
+    (metadata[filename]?.source === "google" || !metadata[filename])
   );
 }
 
@@ -410,7 +421,8 @@ export async function fontsRoutes(app: FastifyInstance) {
         return { face, filename: `${safeName}-Regular${suffix}.woff2` };
       });
       const unmanagedConflict = faceTargets.find(
-        ({ filename }) => existsSync(join(FONTS_DIR, filename)) && metadata[filename]?.source !== "google",
+        ({ filename }) =>
+          existsSync(join(FONTS_DIR, filename)) && metadata[filename] && metadata[filename].source !== "google",
       );
       if (unmanagedConflict) {
         return reply.status(409).send({ error: `"${sanitized}" is already installed` });

--- a/packages/server/test/fonts-routes.test.ts
+++ b/packages/server/test/fonts-routes.test.ts
@@ -1,0 +1,42 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { fontDisplayName, parseGoogleFontFaces } from "../src/routes/fonts.routes.js";
+
+test("parseGoogleFontFaces keeps unicode-range shards for CJK fonts", () => {
+  const css = `
+@font-face {
+  font-family: 'Noto Sans SC';
+  font-style: normal;
+  font-weight: 400;
+  src: url(https://fonts.gstatic.com/s/notosanssc/v40/chinese.woff2) format('woff2');
+  unicode-range: U+4E00-9FFF;
+}
+@font-face {
+  font-family: 'Noto Sans SC';
+  font-style: normal;
+  font-weight: 400;
+  src: url(https://fonts.gstatic.com/s/notosanssc/v40/latin.woff2) format('woff2');
+  unicode-range: U+0000-00FF;
+}
+`;
+
+  assert.deepEqual(parseGoogleFontFaces(css), [
+    {
+      url: "https://fonts.gstatic.com/s/notosanssc/v40/chinese.woff2",
+      weight: "400",
+      style: "normal",
+      unicodeRange: "U+4E00-9FFF",
+    },
+    {
+      url: "https://fonts.gstatic.com/s/notosanssc/v40/latin.woff2",
+      weight: "400",
+      style: "normal",
+      unicodeRange: "U+0000-00FF",
+    },
+  ]);
+});
+
+test("fontDisplayName collapses Google font shard filenames to one family", () => {
+  assert.equal(fontDisplayName("NotoSansSC-Regular-001.woff2"), "Noto Sans SC");
+  assert.equal(fontDisplayName("NotoSansSC-Regular-099.woff2"), "Noto Sans SC");
+});

--- a/packages/server/test/fonts-routes.test.ts
+++ b/packages/server/test/fonts-routes.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { fontDisplayName, parseGoogleFontFaces } from "../src/routes/fonts.routes.js";
+import { fontDisplayName, isLegacyManagedGoogleFilename, parseGoogleFontFaces } from "../src/routes/fonts.routes.js";
 
 test("parseGoogleFontFaces keeps unicode-range shards for CJK fonts", () => {
   const css = `
@@ -39,4 +39,12 @@ test("parseGoogleFontFaces keeps unicode-range shards for CJK fonts", () => {
 test("fontDisplayName collapses Google font shard filenames to one family", () => {
   assert.equal(fontDisplayName("NotoSansSC-Regular-001.woff2"), "Noto Sans SC");
   assert.equal(fontDisplayName("NotoSansSC-Regular-099.woff2"), "Noto Sans SC");
+});
+
+test("isLegacyManagedGoogleFilename matches app-generated Google font filenames", () => {
+  assert.equal(isLegacyManagedGoogleFilename("NotoSansSC-Regular.woff2", "NotoSansSC"), true);
+  assert.equal(isLegacyManagedGoogleFilename("NotoSansSC-Regular-001.woff2", "NotoSansSC"), true);
+  assert.equal(isLegacyManagedGoogleFilename("NotoSansSC-Regular-abc.woff2", "NotoSansSC"), false);
+  assert.equal(isLegacyManagedGoogleFilename("NotoSansSC-Bold.woff2", "NotoSansSC"), false);
+  assert.equal(isLegacyManagedGoogleFilename("Other-Regular.woff2", "NotoSansSC"), false);
 });


### PR DESCRIPTION
## Linked issue

No linked issue yet. This came from a user report that Chinese text did not receive the selected Google font even though the font family supports CJK glyphs.

## Why this change

Users installing CJK Google fonts such as Noto Sans SC could see the font apply to Latin characters while Chinese characters fell back to another font. Google Fonts serves these families as unicode-range shards, but Marinara only kept a single downloaded file, so the CJK shards were missing.

## What changed

- Parse every Google Fonts `@font-face` block and preserve each shard's weight, style, and unicode range.
- Register custom font faces on the client with unicode ranges so browsers can lazily fetch the shard needed for the rendered text.
- Keep the settings dropdown grouped by family instead of showing every shard as a separate option.
- Replace managed Google font files with a temp/backup flow so failed reinstalls can roll back instead of deleting a working font first.
- Add focused server coverage for CJK shard parsing and display-name collapsing.

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

Automated/local commands run by Codex:

- `pnpm --filter @marinara-engine/server exec tsx --import ./test/setup-env.ts --test test/fonts-routes.test.ts`
- `pnpm --filter @marinara-engine/server lint`
- `pnpm --filter @marinara-engine/client lint`
- `pnpm check`
- Post-rebase `pnpm check`

Xel verified manual browser font install flow works as intended.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs or release files were changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for installing Google Fonts directly in the application
  * Implemented persistent font metadata storage for improved font management
  * Enhanced font information display with additional details like weight and style variants

* **Bug Fixes**
  * Improved custom font deduplication to prevent duplicate entries in the font list

* **Tests**
  * Added comprehensive test coverage for font management functionality

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/729)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->