### PR TITLE
Preserve file-native backups during self-heal

### DIFF
--- a/packages/server/src/db/file-backed-store.ts
+++ b/packages/server/src/db/file-backed-store.ts
@@ -325,16 +325,19 @@ function looksNulFilled(path: string): boolean {
   }
 }
 
-function atomicWriteFile(path: string, content: string) {
+function atomicWriteFile(path: string, content: string, options: { refreshBackup?: boolean } = {}) {
   mkdirSync(dirname(path), { recursive: true });
   const tmpPath = `${path}.tmp-${process.pid}-${Date.now()}`;
+  const refreshBackup = options.refreshBackup ?? true;
   try {
     // Refresh the .bak via tmp + fsync + rename so a hard crash mid-write
     // can't leave both main and backup zero-filled (NTFS allocates blocks
     // and updates metadata before the cache manager flushes data).
+    // Callers can also skip refresh when this write is repairing a file that
+    // was just recovered from backup; the corrupt primary is not backup input.
     // Skip the refresh if the existing main is NUL-corrupted — copying garbage
     // over a valid .bak would destroy the recovery source we just used.
-    if (existsSync(path) && !looksNulFilled(path)) {
+    if (refreshBackup && existsSync(path) && !looksNulFilled(path)) {
       const bakPath = `${path}.bak`;
       const bakTmpPath = `${bakPath}.tmp-${process.pid}-${Date.now()}`;
       try {
@@ -775,6 +778,7 @@ async function readLegacyRows(dbPath: string, table: string) {
 class FileTableStore {
   private tables = new Map<string, Row[]>();
   private dirtyTables = new Set<string>();
+  private backupRecoveredPaths = new Set<string>();
   private dirty = false;
   private saving = false;
   private debounceTimer: NodeJS.Timeout | null = null;
@@ -1019,9 +1023,13 @@ class FileTableStore {
     let loadedManifest: TableSnapshotManifest | null = null;
     let needsManifestRewrite = false;
     try {
-      const result = parseJsonFile<TableSnapshotManifest | null>(manifestPath(this.rootDir), null);
+      const path = manifestPath(this.rootDir);
+      const result = parseJsonFile<TableSnapshotManifest | null>(path, null);
       loadedManifest = result.value;
       needsManifestRewrite = result.recoveredFromBackup;
+      if (result.recoveredFromBackup) {
+        this.backupRecoveredPaths.add(path);
+      }
     } catch (err) {
       logger.error(
         err,
@@ -1042,11 +1050,13 @@ class FileTableStore {
     const counts: Record<string, number> = {};
     for (const table of FILE_BACKED_TABLES) {
       const meta = getMeta(table);
-      const { value: rows, recoveredFromBackup } = parseJsonFile<Row[]>(tableFilePath(this.rootDir, table), []);
+      const path = tableFilePath(this.rootDir, table);
+      const { value: rows, recoveredFromBackup } = parseJsonFile<Row[]>(path, []);
       const normalized = (Array.isArray(rows) ? rows : []).map((row) => normalizeRow(meta, row));
       this.tables.set(table, normalized);
       counts[table] = normalized.length;
       if (recoveredFromBackup) {
+        this.backupRecoveredPaths.add(path);
         // Same self-heal: rewrite the corrupt main file from in-memory data
         // (which now matches the recovered backup) on the next flush.
         this.dirtyTables.add(table);
@@ -1197,8 +1207,9 @@ class FileTableStore {
     for (const table of FILE_BACKED_TABLES) {
       const rows = this.rows(table);
       tables[table] = rows.length;
-      if (this.dirtyTables.has(table) || !existsSync(tableFilePath(this.rootDir, table))) {
-        atomicWriteFile(tableFilePath(this.rootDir, table), JSON.stringify(rows));
+      const path = tableFilePath(this.rootDir, table);
+      if (this.dirtyTables.has(table) || !existsSync(path)) {
+        atomicWriteFile(path, JSON.stringify(rows), { refreshBackup: !this.backupRecoveredPaths.has(path) });
       }
     }
 
@@ -1210,7 +1221,9 @@ class FileTableStore {
       ...(this.legacyRepair && { legacyRepair: this.legacyRepair }),
       tables,
     };
-    atomicWriteFile(manifestPath(this.rootDir), JSON.stringify(manifest, null, 2));
+    const path = manifestPath(this.rootDir);
+    atomicWriteFile(path, JSON.stringify(manifest, null, 2), { refreshBackup: !this.backupRecoveredPaths.has(path) });
+    this.backupRecoveredPaths.clear();
   }
 
   private installAutosave() {

--- a/packages/server/test/file-backed-store.test.ts
+++ b/packages/server/test/file-backed-store.test.ts
@@ -57,6 +57,60 @@ function withEnv<T>(name: string, value: string, fn: () => Promise<T>) {
   });
 }
 
+function readJsonFile<T>(path: string): T {
+  return JSON.parse(readFileSync(path, "utf8")) as T;
+}
+
+function validChatRows(id = "recovered-chat") {
+  const timestamp = "2026-05-11T00:00:00.000Z";
+  return [
+    {
+      id,
+      name: "Recovered Chat",
+      mode: "roleplay",
+      characterIds: "[]",
+      groupId: null,
+      personaId: null,
+      promptPresetId: null,
+      connectionId: null,
+      metadata: "{}",
+      connectedChatId: null,
+      folderId: null,
+      sortOrder: 0,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    },
+  ];
+}
+
+function writeFileStorageManifest(storageDir: string, tables: Record<string, number>) {
+  writeFileSync(
+    join(storageDir, "manifest.json"),
+    JSON.stringify({
+      version: 2,
+      savedAt: "2026-05-11T00:00:00.000Z",
+      backend: "file-native",
+      tables,
+    }),
+  );
+}
+
+function assertRecoveredChatIds(ids: string[]) {
+  assert.deepEqual(ids, ["recovered-chat"]);
+}
+
+async function loadChatIds(storageDir: string) {
+  return withFileStorageDir(storageDir, async () => {
+    const db = await createFileNativeDB([]);
+    try {
+      const rows = await db.select().from(chats);
+      return rows.map((row) => row.id);
+    } finally {
+      await db._fileStore.close();
+    }
+  });
+}
+
 async function removeTempDir(path: string) {
   for (let attempt = 0; attempt < 8; attempt += 1) {
     try {
@@ -74,6 +128,99 @@ async function removeTempDir(path: string) {
     }
   }
 }
+
+test("file-native self-heal preserves a valid backup when table primary has non-NUL corrupt JSON", async () => {
+  const root = mkdtempSync(join(tmpdir(), "marinara-file-table-backup-heal-"));
+  try {
+    const storageDir = join(root, "storage");
+    const tablesDir = join(storageDir, "tables");
+    const tablePath = join(tablesDir, "chats.json");
+    const backupPath = `${tablePath}.bak`;
+    const rows = validChatRows();
+    mkdirSync(tablesDir, { recursive: true });
+    writeFileStorageManifest(storageDir, { chats: rows.length });
+    writeFileSync(tablePath, '{"id":');
+    writeFileSync(backupPath, JSON.stringify(rows));
+
+    assertRecoveredChatIds(await loadChatIds(storageDir));
+
+    const healedRows = readJsonFile<Array<{ id: string }>>(tablePath);
+    const backupRows = readJsonFile<Array<{ id: string }>>(backupPath);
+    assert.deepEqual(
+      healedRows.map((row) => row.id),
+      ["recovered-chat"],
+    );
+    assert.deepEqual(
+      backupRows.map((row) => row.id),
+      ["recovered-chat"],
+    );
+
+    writeFileSync(tablePath, "[");
+    assertRecoveredChatIds(await loadChatIds(storageDir));
+  } finally {
+    await removeTempDir(root);
+  }
+});
+
+test("file-native self-heal preserves a valid backup when manifest primary has non-NUL corrupt JSON", async () => {
+  const root = mkdtempSync(join(tmpdir(), "marinara-file-manifest-backup-heal-"));
+  try {
+    const storageDir = join(root, "storage");
+    const tablesDir = join(storageDir, "tables");
+    const rows = validChatRows();
+    mkdirSync(tablesDir, { recursive: true });
+    writeFileSync(join(tablesDir, "chats.json"), JSON.stringify(rows));
+    writeFileSync(join(storageDir, "manifest.json"), '{"version":');
+    writeFileSync(
+      join(storageDir, "manifest.json.bak"),
+      JSON.stringify({
+        version: 2,
+        savedAt: "2026-05-11T00:00:00.000Z",
+        backend: "file-native",
+        tables: { chats: rows.length },
+      }),
+    );
+
+    assertRecoveredChatIds(await loadChatIds(storageDir));
+
+    const manifest = readJsonFile<{ tables: Record<string, number> }>(join(storageDir, "manifest.json"));
+    const backupManifest = readJsonFile<{ tables: Record<string, number> }>(join(storageDir, "manifest.json.bak"));
+    assert.equal(manifest.tables.chats, 1);
+    assert.equal(backupManifest.tables.chats, 1);
+  } finally {
+    await removeTempDir(root);
+  }
+});
+
+test("file-native self-heal keeps a valid backup when table primary is NUL-filled", async () => {
+  const root = mkdtempSync(join(tmpdir(), "marinara-file-nul-backup-heal-"));
+  try {
+    const storageDir = join(root, "storage");
+    const tablesDir = join(storageDir, "tables");
+    const tablePath = join(tablesDir, "chats.json");
+    const backupPath = `${tablePath}.bak`;
+    const rows = validChatRows();
+    mkdirSync(tablesDir, { recursive: true });
+    writeFileStorageManifest(storageDir, { chats: rows.length });
+    writeFileSync(tablePath, Buffer.alloc(8));
+    writeFileSync(backupPath, JSON.stringify(rows));
+
+    assertRecoveredChatIds(await loadChatIds(storageDir));
+
+    const healedRows = readJsonFile<Array<{ id: string }>>(tablePath);
+    const backupRows = readJsonFile<Array<{ id: string }>>(backupPath);
+    assert.deepEqual(
+      healedRows.map((row) => row.id),
+      ["recovered-chat"],
+    );
+    assert.deepEqual(
+      backupRows.map((row) => row.id),
+      ["recovered-chat"],
+    );
+  } finally {
+    await removeTempDir(root);
+  }
+});
 
 test("file-native import merges chats from every known legacy database source", async () => {
   const root = mkdtempSync(join(tmpdir(), "marinara-file-import-"));


### PR DESCRIPTION
## Linked issue

Closes #728

## Why this change

- File-native startup can recover a table or manifest from `.bak`, then the self-heal save copies the still-corrupt non-NUL primary over that valid `.bak` before rewriting the primary.
- If the repair write is interrupted, or another failure lands before `.bak` is refreshed from a valid primary, the recovery source is gone.

## What changed

- Track file paths that were recovered from `.bak` during startup.
- Skip `.bak` refresh for the self-heal write of those recovered files, so the valid backup remains available while the primary is repaired.
- Clear recovery markers after the flush succeeds, allowing later normal saves to refresh `.bak` from repaired primaries.
- Added regression tests for malformed non-NUL `chats.json` and `manifest.json` with valid `.bak` files.

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Verified malformed non-NUL `tables/chats.json` recovers from a valid `.bak`, repairs the primary file, and leaves `.bak` parseable.
- Verified malformed non-NUL `manifest.json` recovers from a valid `.bak`, repairs the primary file, and leaves `.bak` parseable.
- Verified the existing NUL-filled primary recovery path still keeps `.bak` parseable.
- Ran `pnpm --dir packages/server exec tsx --import ./test/setup-env.ts --test test/file-backed-store.test.ts`.
- Ran `pnpm check`, `pnpm version:check`, and `pnpm guard:installer-artifacts`.
- Built and ran the Docker image, then checked `/` and `/api/health`.
- Launched the built app locally with a clean temp data dir and checked basic app navigation in Chrome at desktop and mobile viewports, including light/dark theme behavior.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

N/A - backend file-storage recovery behavior only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automatic backup recovery and self-healing: The system now detects corrupted data and manifest files, automatically recovering from backups without requiring manual intervention.

* **Bug Fixes**
  * Enhanced data resilience against file corruption, ensuring critical information is preserved and accessible.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/730)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->