### PR TITLE
Fix macro resolution in lorebooks and regex scripts

### DIFF
--- a/packages/client/src/components/agents/RegexScriptEditor.tsx
+++ b/packages/client/src/components/agents/RegexScriptEditor.tsx
@@ -28,7 +28,7 @@ import {
 } from "lucide-react";
 import { cn } from "../../lib/utils";
 import { HelpTooltip } from "../ui/HelpTooltip";
-import { applyRegexReplacement, type RegexPlacement } from "@marinara-engine/shared";
+import { applyRegexReplacement, resolveMacros, type MacroContext, type RegexPlacement } from "@marinara-engine/shared";
 
 // ═══════════════════════════════════════════════
 //  Placement metadata
@@ -43,6 +43,35 @@ const PLACEMENT_META: Record<RegexPlacement, { label: string; description: strin
     description: "Applied to your messages before they are sent.",
   },
 };
+
+function createLiveTestMacroContext(input: string): MacroContext {
+  return {
+    user: "User",
+    char: "Character",
+    characters: ["Character"],
+    variables: {},
+    lastInput: input || "Sample input",
+    characterFields: {
+      description: "Character description",
+      personality: "Character personality",
+      backstory: "Character backstory",
+      appearance: "Character appearance",
+      scenario: "Character scenario",
+      example: "Character example",
+    },
+    personaFields: {
+      description: "Persona description",
+      personality: "Persona personality",
+      backstory: "Persona backstory",
+      appearance: "Persona appearance",
+      scenario: "Persona scenario",
+    },
+  };
+}
+
+function resolveLiveTestMacros(value: string, context: MacroContext): string {
+  return resolveMacros(value, context, { trimResult: false });
+}
 
 // ═══════════════════════════════════════════════
 //  Main Editor
@@ -136,22 +165,29 @@ export function RegexScriptEditor() {
   const regexError = useMemo(() => {
     if (!localFindRegex) return null;
     try {
-      new RegExp(localFindRegex, localFlags);
+      const findRegex = resolveLiveTestMacros(localFindRegex, createLiveTestMacroContext(testInput));
+      if (!findRegex) return null;
+      new RegExp(findRegex, localFlags);
       return null;
     } catch (e) {
       return (e as Error).message;
     }
-  }, [localFindRegex, localFlags]);
+  }, [localFindRegex, localFlags, testInput]);
 
   // Test result
   const testResult = useMemo(() => {
     if (!testInput || !localFindRegex || regexError) return testInput;
     try {
-      const re = new RegExp(localFindRegex, localFlags);
-      let result = applyRegexReplacement(testInput, re, localReplaceString);
+      const macroContext = createLiveTestMacroContext(testInput);
+      const resolveTestMacros = (value: string) => resolveLiveTestMacros(value, macroContext);
+      const findRegex = resolveTestMacros(localFindRegex);
+      if (!findRegex) return testInput;
+      const re = new RegExp(findRegex, localFlags);
+      let result = applyRegexReplacement(testInput, re, localReplaceString, resolveTestMacros);
       // Apply trim strings
       for (const trim of localTrimStrings) {
-        if (trim) result = result.split(trim).join("");
+        const resolvedTrim = resolveTestMacros(trim);
+        if (resolvedTrim) result = result.split(resolvedTrim).join("");
       }
       return result;
     } catch {
@@ -374,7 +410,7 @@ export function RegexScriptEditor() {
           <FieldGroup
             label="Find Pattern (Regex)"
             icon={<Regex size="0.875rem" className="text-orange-400" />}
-            help="The regular expression pattern to search for. Written without delimiters — e.g. \\*([^*]+)\\* to match text between asterisks."
+            help="The regular expression pattern to search for. Written without delimiters. Macros resolve with sample values in Live Test and chat values at runtime."
           >
             <div className="relative">
               <input
@@ -596,7 +632,7 @@ export function RegexScriptEditor() {
           <FieldGroup
             label="Live Test"
             icon={<Play size="0.875rem" className="text-orange-400" />}
-            help="Test your regex pattern against sample text. The result updates in real-time."
+            help="Test your regex pattern against sample text. Macros use sample User and Character values here."
           >
             <div className="space-y-2">
               <textarea

--- a/packages/client/src/components/chat/ChatInput.tsx
+++ b/packages/client/src/components/chat/ChatInput.tsx
@@ -19,7 +19,7 @@ import {
   type SlashCommand,
   type SlashCommandContext,
 } from "../../lib/slash-commands";
-import { isPromptPreviewMacro, resolveInputMacrosForChat } from "../../lib/chat-macros";
+import { createInputMacroResolverForChat, isPromptPreviewMacro } from "../../lib/chat-macros";
 import { cn, getAvatarCropStyle, type AvatarCropValue } from "../../lib/utils";
 import { translateDraftText } from "../../lib/draft-translation";
 import { EmojiPicker } from "../ui/EmojiPicker";
@@ -459,7 +459,10 @@ export const ChatInput = memo(function ChatInput({
       return;
     }
 
-    let message = applyToUserInput(normalized);
+    const cachedCharacters = qc.getQueryData<Array<{ id: string; data: unknown }>>(characterKeys.list());
+    const cachedPersonas = qc.getQueryData<Array<Record<string, unknown>>>(characterKeys.personas);
+    const resolveInputMacros = createInputMacroResolverForChat(chat, cachedCharacters, cachedPersonas, normalized);
+    let message = applyToUserInput(normalized, { resolveMacros: resolveInputMacros });
 
     // Input translation: translate user's message before sending
     const chatMeta = chat?.metadata
@@ -477,9 +480,7 @@ export const ChatInput = memo(function ChatInput({
       }
     }
 
-    const cachedCharacters = qc.getQueryData<Array<{ id: string; data: unknown }>>(characterKeys.list());
-    const cachedPersonas = qc.getQueryData<Array<Record<string, unknown>>>(characterKeys.personas);
-    message = resolveInputMacrosForChat(message, chat, cachedCharacters, cachedPersonas);
+    message = resolveInputMacros(message);
 
     if (textareaRef.current) {
       textareaRef.current.value = "";

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -39,7 +39,7 @@ import { createPortal } from "react-dom";
 import { useQueryClient, type InfiniteData } from "@tanstack/react-query";
 import { chatKeys } from "../../hooks/use-chats";
 import { useShallow } from "zustand/react/shallow";
-import { resolveMessageMacros } from "../../lib/chat-macros";
+import { createMessageMacroResolver } from "../../lib/chat-macros";
 import { useApplyRegex } from "../../hooks/use-apply-regex";
 import { useUIStore } from "../../stores/ui.store";
 import { useChatStore } from "../../stores/chat.store";
@@ -957,8 +957,7 @@ export const ChatMessage = memo(function ChatMessage({
   }, [charName, scopedCharacterMap]);
 
   const displayContent = useMemo(() => {
-    const text = isUser || isSystem ? message.content : applyToAIOutput(message.content, messageDepth);
-    return resolveMessageMacros(text, {
+    const macroContext = {
       userName,
       persona: {
         name: userName,
@@ -970,7 +969,13 @@ export const ChatMessage = memo(function ChatMessage({
       },
       primaryCharacter: primaryCharInfo ?? { name: charName },
       characters: macroCharacters,
-    });
+    };
+    const resolveDisplayMacros = createMessageMacroResolver(macroContext);
+    const text =
+      isUser || isSystem
+        ? message.content
+        : applyToAIOutput(message.content, { depth: messageDepth, resolveMacros: resolveDisplayMacros });
+    return resolveDisplayMacros(text);
   }, [
     applyToAIOutput,
     charName,

--- a/packages/client/src/components/chat/ConversationInput.tsx
+++ b/packages/client/src/components/chat/ConversationInput.tsx
@@ -34,7 +34,7 @@ import {
   type SlashCommand,
   type SlashCommandContext,
 } from "../../lib/slash-commands";
-import { isPromptPreviewMacro, resolveInputMacrosForChat } from "../../lib/chat-macros";
+import { createInputMacroResolverForChat, isPromptPreviewMacro } from "../../lib/chat-macros";
 import { cn, getAvatarCropStyle, type AvatarCropValue } from "../../lib/utils";
 import { translateDraftText } from "../../lib/draft-translation";
 import { QuickConnectionSwitcher } from "./QuickConnectionSwitcher";
@@ -530,9 +530,12 @@ export function ConversationInput({
     // triggering another generation — the in-progress generation will see
     // it (server re-reads messages after any busy delay).
     if (isStreaming) {
-      let message = applyToUserInput(raw);
-      // Input translation for streaming path too
       const activeChatData = useChatStore.getState().activeChat;
+      const cachedCharacters = qc.getQueryData<Array<{ id: string; data: unknown }>>(characterKeys.list());
+      const cachedPersonas = qc.getQueryData<Array<Record<string, unknown>>>(characterKeys.personas);
+      const resolveInputMacros = createInputMacroResolverForChat(activeChatData, cachedCharacters, cachedPersonas, raw);
+      let message = applyToUserInput(raw, { resolveMacros: resolveInputMacros });
+      // Input translation for streaming path too
       const streamMeta = activeChatData?.metadata
         ? typeof activeChatData.metadata === "string"
           ? JSON.parse(activeChatData.metadata)
@@ -547,9 +550,7 @@ export function ConversationInput({
           toast.error("Failed to translate message — sending original");
         }
       }
-      const cachedCharacters = qc.getQueryData<Array<{ id: string; data: unknown }>>(characterKeys.list());
-      const cachedPersonas = qc.getQueryData<Array<Record<string, unknown>>>(characterKeys.personas);
-      message = resolveInputMacrosForChat(message, activeChatData, cachedCharacters, cachedPersonas);
+      message = resolveInputMacros(message);
       if (textareaRef.current) {
         textareaRef.current.value = "";
         textareaRef.current.style.height = "auto";
@@ -598,10 +599,13 @@ export function ConversationInput({
       return;
     }
 
-    let message = applyToUserInput(raw);
+    const activeChat = useChatStore.getState().activeChat;
+    const cachedCharacters = qc.getQueryData<Array<{ id: string; data: unknown }>>(characterKeys.list());
+    const cachedPersonas = qc.getQueryData<Array<Record<string, unknown>>>(characterKeys.personas);
+    const resolveInputMacros = createInputMacroResolverForChat(activeChat, cachedCharacters, cachedPersonas, raw);
+    let message = applyToUserInput(raw, { resolveMacros: resolveInputMacros });
 
     // Input translation: translate user's message before sending
-    const activeChat = useChatStore.getState().activeChat;
     const chatMeta = activeChat?.metadata
       ? typeof activeChat.metadata === "string"
         ? JSON.parse(activeChat.metadata)
@@ -617,9 +621,7 @@ export function ConversationInput({
       }
     }
 
-    const cachedCharacters = qc.getQueryData<Array<{ id: string; data: unknown }>>(characterKeys.list());
-    const cachedPersonas = qc.getQueryData<Array<Record<string, unknown>>>(characterKeys.personas);
-    message = resolveInputMacrosForChat(message, activeChat, cachedCharacters, cachedPersonas);
+    message = resolveInputMacros(message);
 
     if (textareaRef.current) {
       textareaRef.current.value = "";

--- a/packages/client/src/components/chat/ConversationInput.tsx
+++ b/packages/client/src/components/chat/ConversationInput.tsx
@@ -534,6 +534,7 @@ export function ConversationInput({
       const cachedCharacters = qc.getQueryData<Array<{ id: string; data: unknown }>>(characterKeys.list());
       const cachedPersonas = qc.getQueryData<Array<Record<string, unknown>>>(characterKeys.personas);
       const resolveInputMacros = createInputMacroResolverForChat(activeChatData, cachedCharacters, cachedPersonas, raw);
+      // First pass: resolve macros against raw input, so {{input}} uses the pre-translation text.
       let message = applyToUserInput(raw, { resolveMacros: resolveInputMacros });
       // Input translation for streaming path too
       const streamMeta = activeChatData?.metadata
@@ -550,6 +551,7 @@ export function ConversationInput({
           toast.error("Failed to translate message — sending original");
         }
       }
+      // Final pass: resolve macros introduced by translation while {{input}} still points to raw.
       message = resolveInputMacros(message);
       if (textareaRef.current) {
         textareaRef.current.value = "";
@@ -603,6 +605,7 @@ export function ConversationInput({
     const cachedCharacters = qc.getQueryData<Array<{ id: string; data: unknown }>>(characterKeys.list());
     const cachedPersonas = qc.getQueryData<Array<Record<string, unknown>>>(characterKeys.personas);
     const resolveInputMacros = createInputMacroResolverForChat(activeChat, cachedCharacters, cachedPersonas, raw);
+    // First pass: resolve macros against raw input, so {{input}} uses the pre-translation text.
     let message = applyToUserInput(raw, { resolveMacros: resolveInputMacros });
 
     // Input translation: translate user's message before sending
@@ -621,6 +624,7 @@ export function ConversationInput({
       }
     }
 
+    // Final pass: resolve macros introduced by translation while {{input}} still points to raw.
     message = resolveInputMacros(message);
 
     if (textareaRef.current) {

--- a/packages/client/src/components/game/GameNarration.tsx
+++ b/packages/client/src/components/game/GameNarration.tsx
@@ -50,7 +50,7 @@ import { useApplyRegex } from "../../hooks/use-apply-regex";
 import { useGameAssetStore } from "../../stores/game-asset.store";
 import { useGameModeStore } from "../../stores/game-mode.store";
 import { useUIStore } from "../../stores/ui.store";
-import { findCharacterByName, resolveMessageMacros } from "../../lib/chat-macros";
+import { createMessageMacroResolver, findCharacterByName } from "../../lib/chat-macros";
 import { animateTextHtml } from "./AnimatedText";
 import { ttsService } from "../../lib/tts-service";
 import { getOrCreateCachedTTSAudioBlob } from "../../lib/tts-audio-cache";
@@ -1249,9 +1249,17 @@ export function GameNarration({
   );
 
   const applyOutputRegexForSource = useCallback(
-    (text: string, sourceMessageId: string | null | undefined, sourceRole: Message["role"] | null | undefined) => {
+    (
+      text: string,
+      sourceMessageId: string | null | undefined,
+      sourceRole: Message["role"] | null | undefined,
+      resolveMacrosForText: (value: string) => string,
+    ) => {
       if (sourceRole !== "assistant" && sourceRole !== "narrator") return text;
-      return applyToAIOutput(text, sourceMessageId ? messageDepthById.get(sourceMessageId) : undefined);
+      return applyToAIOutput(text, {
+        depth: sourceMessageId ? messageDepthById.get(sourceMessageId) : undefined,
+        resolveMacros: resolveMacrosForText,
+      });
     },
     [applyToAIOutput, messageDepthById],
   );
@@ -1263,13 +1271,15 @@ export function GameNarration({
       sourceMessageId: string | null | undefined,
       sourceRole: Message["role"] | null | undefined,
     ) => {
-      const regexApplied = applyOutputRegexForSource(text, sourceMessageId, sourceRole);
-      return resolveMessageMacros(regexApplied, {
+      const macroContext = {
         userName: personaInfo?.name || "You",
         persona: personaInfo,
         primaryCharacter: resolveMacroCharacter(speaker),
         characters: macroCharacters,
-      });
+      };
+      const resolveMacrosForText = createMessageMacroResolver(macroContext);
+      const regexApplied = applyOutputRegexForSource(text, sourceMessageId, sourceRole, resolveMacrosForText);
+      return resolveMacrosForText(regexApplied);
     },
     [applyOutputRegexForSource, macroCharacters, personaInfo, resolveMacroCharacter],
   );

--- a/packages/client/src/hooks/use-apply-regex.ts
+++ b/packages/client/src/hooks/use-apply-regex.ts
@@ -41,7 +41,7 @@ function applyScripts(
   text: string,
   scripts: ReturnType<typeof parseScript>[],
   placement: RegexPlacement,
-  options?: { promptOnly?: boolean; depth?: number },
+  options?: { promptOnly?: boolean; depth?: number; resolveMacros?: (value: string) => string },
 ): string {
   let result = text;
   for (const script of scripts) {
@@ -57,11 +57,16 @@ function applyScripts(
     }
 
     try {
-      const re = new RegExp(script.findRegex, script.flags);
-      result = applyRegexReplacement(result, re, script.replaceString);
+      const findRegex = options?.resolveMacros ? options.resolveMacros(script.findRegex) : script.findRegex;
+      if (!findRegex) continue;
+      const re = new RegExp(findRegex, script.flags);
+      result = applyRegexReplacement(result, re, script.replaceString, (value) =>
+        options?.resolveMacros ? options.resolveMacros(value) : value,
+      );
       // Apply trim strings
       for (const trim of script.trimStrings) {
-        if (trim) result = result.split(trim).join("");
+        const resolvedTrim = options?.resolveMacros ? options.resolveMacros(trim) : trim;
+        if (resolvedTrim) result = result.split(resolvedTrim).join("");
       }
     } catch {
       // Invalid regex — skip silently
@@ -87,19 +92,24 @@ export function useApplyRegex() {
   }, [regexScripts]);
 
   const applyToAIOutput = useCallback(
-    (text: string, depth?: number) => applyScripts(text, parsedScripts, "ai_output", { depth }),
+    (text: string, options?: { depth?: number; resolveMacros?: (value: string) => string }) =>
+      applyScripts(text, parsedScripts, "ai_output", options),
     [parsedScripts],
   );
 
   const applyToUserInput = useCallback(
-    (text: string, depth?: number) => applyScripts(text, parsedScripts, "user_input", { depth }),
+    (text: string, options?: { depth?: number; resolveMacros?: (value: string) => string }) =>
+      applyScripts(text, parsedScripts, "user_input", options),
     [parsedScripts],
   );
 
   // Applies scripts in prompt context, including scripts marked prompt-only.
   const applyPromptOnly = useCallback(
-    (text: string, placement: RegexPlacement, depth?: number) =>
-      applyScripts(text, parsedScripts, placement, { promptOnly: true, depth }),
+    (
+      text: string,
+      placement: RegexPlacement,
+      options?: { depth?: number; resolveMacros?: (value: string) => string },
+    ) => applyScripts(text, parsedScripts, placement, { promptOnly: true, ...options }),
     [parsedScripts],
   );
 

--- a/packages/client/src/lib/chat-macros.ts
+++ b/packages/client/src/lib/chat-macros.ts
@@ -210,7 +210,12 @@ export function resolveMessageMacros(
   template: string,
   context: Parameters<typeof buildMessageMacroContext>[0],
 ): string {
-  return resolveMacros(template, buildMessageMacroContext(context), { trimResult: false });
+  return createMessageMacroResolver(context)(template);
+}
+
+export function createMessageMacroResolver(context: Parameters<typeof buildMessageMacroContext>[0]) {
+  const macroContext = buildMessageMacroContext(context);
+  return (template: string) => resolveMacros(template, macroContext, { trimResult: false });
 }
 
 export function isPromptPreviewMacro(input: string): boolean {
@@ -222,12 +227,23 @@ export function resolveInputMacrosForChat(
   chat: { characterIds?: unknown; personaId?: string | null; mode?: string | null } | null | undefined,
   characters: Array<{ id: string; data: unknown }> | undefined,
   personas: Array<Record<string, unknown>> | undefined,
+  lastInput?: string,
 ): string {
+  return createInputMacroResolverForChat(chat, characters, personas, lastInput)(template);
+}
+
+export function createInputMacroResolverForChat(
+  chat: { characterIds?: unknown; personaId?: string | null; mode?: string | null } | null | undefined,
+  characters: Array<{ id: string; data: unknown }> | undefined,
+  personas: Array<Record<string, unknown>> | undefined,
+  lastInput?: string,
+) {
   const chatCharacters = selectChatCharacters(chat, characters);
   const activePersona = selectActivePersona(chat, personas);
-  return resolveMessageMacros(template, {
+  return createMessageMacroResolver({
     persona: activePersona,
     primaryCharacter: chatCharacters[0] ?? null,
     characters: chatCharacters,
+    lastInput,
   });
 }

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -1000,10 +1000,6 @@ export async function chatsRoutes(app: FastifyInstance) {
             mappedMessages.pop();
           }
 
-          // Apply regex scripts to prompt context (mirrors generate.routes.ts).
-          const regexStore = createRegexScriptsStorage(app.db);
-          applyRegexScriptsToPromptMessages(mappedMessages, await regexStore.list());
-
           const [sections, groups, choiceBlocks] = await Promise.all([
             presetStore.listSections(presetId),
             presetStore.listGroups(presetId),
@@ -1082,6 +1078,14 @@ export async function chatsRoutes(app: FastifyInstance) {
             chatId: req.params.id,
           });
           const resolvePromptMacros = (value: string) => resolveMacros(value, promptMacroContext);
+          // Apply regex scripts to prompt context (mirrors generate.routes.ts).
+          const regexStore = createRegexScriptsStorage(app.db);
+          applyRegexScriptsToPromptMessages(mappedMessages, await regexStore.list(), {
+            resolveMacros: (value) => resolveMacros(value, promptMacroContext, { trimResult: false }),
+          });
+          promptMacroContext.lastInput = [...mappedMessages]
+            .reverse()
+            .find((message) => message.role === "user")?.content;
           const entryStateOverrides = resolveEntryStateOverrides(chatMeta.entryStateOverrides);
           const chatMode = (chat.mode as string) ?? "roleplay";
           const lorebookScopeExclusions = resolveGameLorebookScopeExclusions(chatMode, chatMeta);

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -29,7 +29,11 @@ import {
   type GmPromptContext,
 } from "../services/game/gm-prompts.js";
 import { buildPartySystemPrompt } from "../services/game/party-prompts.js";
-import { buildPromptMacroContext, getCharacterDescriptionWithExtensions } from "../services/prompt/index.js";
+import {
+  buildPromptMacroContext,
+  getCharacterDescriptionWithExtensions,
+  resolveMacrosWithVariableSnapshot,
+} from "../services/prompt/index.js";
 import { listPartySprites, readPreferredFullBodySpriteBase64 } from "../services/game/sprite.service.js";
 import {
   buildSceneAnalyzerSystemPrompt,
@@ -3152,18 +3156,25 @@ export async function gameRoutes(app: FastifyInstance) {
       }
     }
 
+    const setupPersonaId = chat.personaId || setupConfig.personaId || null;
+    const setupPersona = setupPersonaId ? await characters.getPersona(setupPersonaId) : null;
+
     // Load persona info so the GM can tailor the experience
     let personaCard: string | null = null;
-    if (chat.personaId || setupConfig.personaId) {
-      const persona = await characters.getPersona(chat.personaId || setupConfig.personaId!);
-      if (persona) {
-        const parts = [`Name: ${persona.name}`];
-        if (persona.description) parts.push(`Description: ${persona.description}`);
-        if (persona.personality) parts.push(`Personality: ${persona.personality}`);
-        if (persona.backstory) parts.push(`Backstory: ${persona.backstory}`);
-        if (persona.appearance) parts.push(`Appearance: ${persona.appearance}`);
-        personaCard = parts.join("\n");
-      }
+    const setupPersonaFields = {
+      description: setupPersona?.description ?? "",
+      personality: setupPersona?.personality ?? "",
+      backstory: setupPersona?.backstory ?? "",
+      appearance: setupPersona?.appearance ?? "",
+      scenario: setupPersona?.scenario ?? "",
+    };
+    if (setupPersona) {
+      const parts = [`Name: ${setupPersona.name}`];
+      if (setupPersona.description) parts.push(`Description: ${setupPersona.description}`);
+      if (setupPersona.personality) parts.push(`Personality: ${setupPersona.personality}`);
+      if (setupPersona.backstory) parts.push(`Backstory: ${setupPersona.backstory}`);
+      if (setupPersona.appearance) parts.push(`Appearance: ${setupPersona.appearance}`);
+      personaCard = parts.join("\n");
     }
 
     // Load party character cards for context (full detail)
@@ -3202,29 +3213,43 @@ export async function gameRoutes(app: FastifyInstance) {
       attributes: Array<{ name: string; value: number }>;
       hp: { value: number; max: number };
     } | null = null;
-    let personaName: string | null = null;
-    if (chat.personaId || setupConfig.personaId) {
-      const persona = await characters.getPersona(chat.personaId || setupConfig.personaId!);
-      if (persona) {
-        personaName = persona.name;
-        try {
-          const statsData = persona.personaStats ? JSON.parse(persona.personaStats) : null;
-          if (statsData?.rpgStats?.enabled) {
-            personaRpgStats = statsData.rpgStats;
-          }
-        } catch {
-          /* skip */
+    const personaName: string | null = setupPersona?.name ?? null;
+    if (setupPersona) {
+      try {
+        const statsData = setupPersona.personaStats ? JSON.parse(setupPersona.personaStats) : null;
+        if (statsData?.rpgStats?.enabled) {
+          personaRpgStats = statsData.rpgStats;
         }
+      } catch {
+        /* skip */
       }
     }
 
     let setupLorebookContext: string | undefined;
     if ((setupConfig.activeLorebookIds?.length ?? 0) > 0) {
+      const setupPromptMacroContext = await buildPromptMacroContext({
+        db: app.db,
+        characterIds: setupConfig.partyCharacterIds,
+        personaName: personaName ?? "User",
+        personaDescription: setupPersonaFields.description,
+        personaFields: setupPersonaFields,
+        variables: {},
+        chatId,
+      });
+      const resolveSetupLorebookMacrosForFinal = (value: string) =>
+        resolveMacrosWithVariableSnapshot(value, setupPromptMacroContext);
+      const resolveSetupLorebookMacrosForScan = (value: string) =>
+        resolveMacros(value, {
+          ...setupPromptMacroContext,
+          variables: { ...setupPromptMacroContext.variables },
+        });
       const lorebookResult = await processLorebooks(app.db, [], null, {
         characterIds: setupConfig.partyCharacterIds,
-        personaId: setupConfig.personaId ?? null,
+        personaId: setupPersonaId,
         activeLorebookIds: setupConfig.activeLorebookIds,
         generationTriggers: ["game_setup", "game"],
+        resolveContent: resolveSetupLorebookMacrosForFinal,
+        resolveContentForScan: resolveSetupLorebookMacrosForScan,
       });
       const combinedLore = [
         lorebookResult.worldInfoBefore,

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -3238,18 +3238,12 @@ export async function gameRoutes(app: FastifyInstance) {
       });
       const resolveSetupLorebookMacrosForFinal = (value: string) =>
         resolveMacrosWithVariableSnapshot(value, setupPromptMacroContext);
-      const resolveSetupLorebookMacrosForScan = (value: string) =>
-        resolveMacros(value, {
-          ...setupPromptMacroContext,
-          variables: { ...setupPromptMacroContext.variables },
-        });
       const lorebookResult = await processLorebooks(app.db, [], null, {
         characterIds: setupConfig.partyCharacterIds,
         personaId: setupPersonaId,
         activeLorebookIds: setupConfig.activeLorebookIds,
         generationTriggers: ["game_setup", "game"],
         resolveContent: resolveSetupLorebookMacrosForFinal,
-        resolveContentForScan: resolveSetupLorebookMacrosForScan,
       });
       const combinedLore = [
         lorebookResult.worldInfoBefore,

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -1119,11 +1119,6 @@ export async function generateRoutes(app: FastifyInstance) {
       const resolvePromptMacros = (value: string) => resolveMacros(value, promptMacroContext);
       const resolvePromptMacrosForLorebook = (value: string) =>
         resolveMacrosWithVariableSnapshot(value, promptMacroContext);
-      const resolvePromptMacrosForLorebookScan = (value: string) =>
-        resolveMacros(value, {
-          ...promptMacroContext,
-          variables: { ...promptMacroContext.variables },
-        });
 
       // ── Apply regex scripts to prompt message content ──
       // Macro context is available now, so regex find/replace/trim fields can use prompt macros.
@@ -2343,7 +2338,6 @@ export async function generateRoutes(app: FastifyInstance) {
             entryTimingStates: (chatMeta.entryTimingStates as Record<string, LorebookEntryTimingState>) ?? undefined,
             generationTriggers: lorebookGenerationTriggers,
             resolveContent: resolvePromptMacrosForLorebook,
-            resolveContentForScan: resolvePromptMacrosForLorebookScan,
           });
 
           if (lorebookResult.updatedEntryStateOverrides)
@@ -2398,7 +2392,6 @@ export async function generateRoutes(app: FastifyInstance) {
           entryTimingStates: (chatMeta.entryTimingStates as Record<string, LorebookEntryTimingState>) ?? undefined,
           generationTriggers: lorebookGenerationTriggers,
           resolveContent: resolvePromptMacrosForLorebook,
-          resolveContentForScan: resolvePromptMacrosForLorebookScan,
         });
 
         if (lorebookResult.updatedEntryStateOverrides)
@@ -3471,7 +3464,6 @@ export async function generateRoutes(app: FastifyInstance) {
               entryTimingStates: (chatMeta.entryTimingStates as Record<string, LorebookEntryTimingState>) ?? undefined,
               generationTriggers: lorebookGenerationTriggers,
               resolveContent: resolvePromptMacrosForLorebook,
-              resolveContentForScan: resolvePromptMacrosForLorebookScan,
             },
           );
 

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -55,6 +55,7 @@ import {
   buildPromptMacroContext,
   collectCharacterDepthPromptEntries,
   getCharacterDescriptionWithExtensions,
+  resolveMacrosWithVariableSnapshot,
   type AssemblerInput,
 } from "../services/prompt/index.js";
 import { mergeAdjacentMessages } from "../services/prompt/merger.js";
@@ -957,18 +958,6 @@ export async function generateRoutes(app: FastifyInstance) {
         applyAllSegmentEdits(mappedMessages, chatMeta as Record<string, unknown>, chatMessages);
       }
 
-      // ── Apply regex scripts to prompt message content ──
-      // Normal scripts apply to both prompt context and display; Prompt Only
-      // scripts are excluded only from display by the client.
-      applyRegexScriptsToPromptMessages(mappedMessages, await regexScriptsStore.list());
-
-      // Always collapse 3+ consecutive blank lines into a double newline —
-      // these waste tokens and produce messy logs regardless of user regex settings.
-      // Matches pure newlines AND lines that contain only whitespace.
-      for (const msg of mappedMessages) {
-        msg.content = msg.content.replace(/\n([ \t]*\n){2,}/g, "\n\n");
-      }
-
       // Resolve persona — prefer per-chat personaId, fall back to globally active persona
       // (Game mode skips the fallback — persona must be explicitly selected in the setup wizard)
       let personaId: string | null = null;
@@ -1128,6 +1117,27 @@ export async function generateRoutes(app: FastifyInstance) {
         model: conn.model,
       });
       const resolvePromptMacros = (value: string) => resolveMacros(value, promptMacroContext);
+      const resolvePromptMacrosForLorebook = (value: string) =>
+        resolveMacrosWithVariableSnapshot(value, promptMacroContext);
+      const resolvePromptMacrosForLorebookScan = (value: string) =>
+        resolveMacros(value, {
+          ...promptMacroContext,
+          variables: { ...promptMacroContext.variables },
+        });
+
+      // ── Apply regex scripts to prompt message content ──
+      // Macro context is available now, so regex find/replace/trim fields can use prompt macros.
+      applyRegexScriptsToPromptMessages(mappedMessages, await regexScriptsStore.list(), {
+        resolveMacros: (value) => resolveMacros(value, promptMacroContext, { trimResult: false }),
+      });
+
+      // Always collapse 3+ consecutive blank lines into a double newline —
+      // these waste tokens and produce messy logs regardless of user regex settings.
+      // Matches pure newlines AND lines that contain only whitespace.
+      for (const msg of mappedMessages) {
+        msg.content = msg.content.replace(/\n([ \t]*\n){2,}/g, "\n\n");
+      }
+      promptMacroContext.lastInput = [...mappedMessages].reverse().find((message) => message.role === "user")?.content;
 
       // ── Compute chat embedding for semantic lorebook matching (if any entries are vectorized) ──
       sendProgress("embedding");
@@ -2332,6 +2342,8 @@ export async function generateRoutes(app: FastifyInstance) {
               undefined,
             entryTimingStates: (chatMeta.entryTimingStates as Record<string, LorebookEntryTimingState>) ?? undefined,
             generationTriggers: lorebookGenerationTriggers,
+            resolveContent: resolvePromptMacrosForLorebook,
+            resolveContentForScan: resolvePromptMacrosForLorebookScan,
           });
 
           if (lorebookResult.updatedEntryStateOverrides)
@@ -2357,13 +2369,7 @@ export async function generateRoutes(app: FastifyInstance) {
           }
           // Inject depth-based lorebook entries into the message array
           if (lorebookResult.depthEntries.length > 0) {
-            finalMessages = injectAtDepth(
-              finalMessages,
-              lorebookResult.depthEntries.map((entry) => ({
-                ...entry,
-                content: resolvePromptMacros(entry.content),
-              })),
-            );
+            finalMessages = injectAtDepth(finalMessages, lorebookResult.depthEntries);
           }
         }
       }
@@ -2391,6 +2397,8 @@ export async function generateRoutes(app: FastifyInstance) {
             undefined,
           entryTimingStates: (chatMeta.entryTimingStates as Record<string, LorebookEntryTimingState>) ?? undefined,
           generationTriggers: lorebookGenerationTriggers,
+          resolveContent: resolvePromptMacrosForLorebook,
+          resolveContentForScan: resolvePromptMacrosForLorebookScan,
         });
 
         if (lorebookResult.updatedEntryStateOverrides)
@@ -2412,13 +2420,7 @@ export async function generateRoutes(app: FastifyInstance) {
           finalMessages.splice(insertAt, 0, { role: "system" as const, content: loreBlock });
         }
         if (lorebookResult.depthEntries.length > 0) {
-          finalMessages = injectAtDepth(
-            finalMessages,
-            lorebookResult.depthEntries.map((entry) => ({
-              ...entry,
-              content: resolvePromptMacros(entry.content),
-            })),
-          );
+          finalMessages = injectAtDepth(finalMessages, lorebookResult.depthEntries);
         }
       }
 
@@ -3468,6 +3470,8 @@ export async function generateRoutes(app: FastifyInstance) {
                 undefined,
               entryTimingStates: (chatMeta.entryTimingStates as Record<string, LorebookEntryTimingState>) ?? undefined,
               generationTriggers: lorebookGenerationTriggers,
+              resolveContent: resolvePromptMacrosForLorebook,
+              resolveContentForScan: resolvePromptMacrosForLorebookScan,
             },
           );
 
@@ -3484,7 +3488,6 @@ export async function generateRoutes(app: FastifyInstance) {
           });
           const loreContent = [lorebookResult.worldInfoBefore, lorebookResult.worldInfoAfter]
             .filter(Boolean)
-            .map((content) => resolvePromptMacros(content))
             .join("\n");
           if (loreContent) {
             const loreBlock = `<lore>\n${loreContent}\n</lore>`;
@@ -3497,13 +3500,7 @@ export async function generateRoutes(app: FastifyInstance) {
             }
           }
           if (lorebookResult.depthEntries.length > 0) {
-            finalMessages = injectAtDepth(
-              finalMessages,
-              lorebookResult.depthEntries.map((entry) => ({
-                ...entry,
-                content: resolvePromptMacros(entry.content),
-              })),
-            );
+            finalMessages = injectAtDepth(finalMessages, lorebookResult.depthEntries);
           }
         }
 

--- a/packages/server/src/routes/generate/dry-run-route.ts
+++ b/packages/server/src/routes/generate/dry-run-route.ts
@@ -835,11 +835,6 @@ export async function registerDryRunRoute(app: FastifyInstance) {
     const resolvePromptMacros = (value: string) => resolveMacros(value, promptMacroContext);
     const resolvePromptMacrosForLorebook = (value: string) =>
       resolveMacrosWithVariableSnapshot(value, promptMacroContext);
-    const resolvePromptMacrosForLorebookScan = (value: string) =>
-      resolveMacros(value, {
-        ...promptMacroContext,
-        variables: { ...promptMacroContext.variables },
-      });
 
     // Apply regex scripts to prompt messages (mirrors main /generate, but stays read-only).
     applyRegexScriptsToPromptMessages(mappedMessages, await regexScriptsStore.list(), {
@@ -1049,7 +1044,6 @@ export async function registerDryRunRoute(app: FastifyInstance) {
               generationTriggers: lorebookGenerationTriggers,
               previewOnly: true,
               resolveContent: resolvePromptMacrosForLorebook,
-              resolveContentForScan: resolvePromptMacrosForLorebookScan,
             });
             const loreContent = [lorebookResult.worldInfoBefore, lorebookResult.worldInfoAfter]
               .filter((content): content is string => typeof content === "string" && content.length > 0)
@@ -1343,7 +1337,6 @@ export async function registerDryRunRoute(app: FastifyInstance) {
         generationTriggers: lorebookGenerationTriggers,
         previewOnly: true,
         resolveContent: resolvePromptMacrosForLorebook,
-        resolveContentForScan: resolvePromptMacrosForLorebookScan,
       });
       const loreContent = [lorebookResult.worldInfoBefore, lorebookResult.worldInfoAfter]
         .filter((content): content is string => typeof content === "string" && content.length > 0)

--- a/packages/server/src/routes/generate/dry-run-route.ts
+++ b/packages/server/src/routes/generate/dry-run-route.ts
@@ -24,6 +24,7 @@ import {
   buildPromptMacroContext,
   collectCharacterDepthPromptEntries,
   getCharacterDescriptionWithExtensions,
+  resolveMacrosWithVariableSnapshot,
   type AssemblerInput,
 } from "../../services/prompt/index.js";
 import { mergeAdjacentMessages } from "../../services/prompt/merger.js";
@@ -707,13 +708,6 @@ export async function registerDryRunRoute(app: FastifyInstance) {
       applyAllSegmentEdits(mappedMessages, chatMeta, chatMessages);
     }
 
-    // Apply regex scripts to prompt messages (mirrors main /generate, but stays read-only).
-    applyRegexScriptsToPromptMessages(mappedMessages, await regexScriptsStore.list());
-
-    for (const msg of mappedMessages) {
-      msg.content = msg.content.replace(/\n([ \t]*\n){2,}/g, "\n\n");
-    }
-
     // Build prompt messages
     let finalMessages: Array<{ role: "system" | "user" | "assistant"; content: string; images?: string[] }> = [];
     let wrapFormat: WrapFormat = "xml";
@@ -839,6 +833,23 @@ export async function registerDryRunRoute(app: FastifyInstance) {
       chatId,
     });
     const resolvePromptMacros = (value: string) => resolveMacros(value, promptMacroContext);
+    const resolvePromptMacrosForLorebook = (value: string) =>
+      resolveMacrosWithVariableSnapshot(value, promptMacroContext);
+    const resolvePromptMacrosForLorebookScan = (value: string) =>
+      resolveMacros(value, {
+        ...promptMacroContext,
+        variables: { ...promptMacroContext.variables },
+      });
+
+    // Apply regex scripts to prompt messages (mirrors main /generate, but stays read-only).
+    applyRegexScriptsToPromptMessages(mappedMessages, await regexScriptsStore.list(), {
+      resolveMacros: (value) => resolveMacros(value, promptMacroContext, { trimResult: false }),
+    });
+
+    for (const msg of mappedMessages) {
+      msg.content = msg.content.replace(/\n([ \t]*\n){2,}/g, "\n\n");
+    }
+    promptMacroContext.lastInput = [...mappedMessages].reverse().find((message) => message.role === "user")?.content;
 
     const usePromptParts = !!promptParts;
     if (usePromptParts) {
@@ -1037,10 +1048,11 @@ export async function registerDryRunRoute(app: FastifyInstance) {
                   : undefined,
               generationTriggers: lorebookGenerationTriggers,
               previewOnly: true,
+              resolveContent: resolvePromptMacrosForLorebook,
+              resolveContentForScan: resolvePromptMacrosForLorebookScan,
             });
             const loreContent = [lorebookResult.worldInfoBefore, lorebookResult.worldInfoAfter]
               .filter((content): content is string => typeof content === "string" && content.length > 0)
-              .map((content) => resolvePromptMacros(content))
               .join("\n");
             const loreBlock = loreContent ? `<lore>\n${loreContent}\n</lore>` : "";
             return { loreBlock, depthEntries: lorebookResult.depthEntries };
@@ -1159,13 +1171,7 @@ export async function registerDryRunRoute(app: FastifyInstance) {
             lorebookPayload.depthEntries.length > 0 &&
             finalMessages.some((m) => m.role === "user" || m.role === "assistant")
           ) {
-            finalMessages = injectAtDepth(
-              finalMessages as any,
-              lorebookPayload.depthEntries.map((entry) => ({
-                ...entry,
-                content: resolvePromptMacros(entry.content),
-              })),
-            ) as any;
+            finalMessages = injectAtDepth(finalMessages as any, lorebookPayload.depthEntries) as any;
           }
           continue;
         }
@@ -1336,10 +1342,11 @@ export async function registerDryRunRoute(app: FastifyInstance) {
             : undefined,
         generationTriggers: lorebookGenerationTriggers,
         previewOnly: true,
+        resolveContent: resolvePromptMacrosForLorebook,
+        resolveContentForScan: resolvePromptMacrosForLorebookScan,
       });
       const loreContent = [lorebookResult.worldInfoBefore, lorebookResult.worldInfoAfter]
         .filter((content): content is string => typeof content === "string" && content.length > 0)
-        .map((content) => resolvePromptMacros(content))
         .join("\n");
       if (loreContent) {
         const loreBlock = `<lore>\n${loreContent}\n</lore>`;
@@ -1348,13 +1355,7 @@ export async function registerDryRunRoute(app: FastifyInstance) {
         finalMessages.splice(insertAt, 0, { role: "system", content: loreBlock });
       }
       if (lorebookResult.depthEntries.length > 0) {
-        finalMessages = injectAtDepth(
-          finalMessages as any,
-          lorebookResult.depthEntries.map((entry) => ({
-            ...entry,
-            content: resolvePromptMacros(entry.content),
-          })),
-        ) as any;
+        finalMessages = injectAtDepth(finalMessages as any, lorebookResult.depthEntries) as any;
       }
     }
 

--- a/packages/server/src/routes/lorebooks.routes.ts
+++ b/packages/server/src/routes/lorebooks.routes.ts
@@ -9,6 +9,7 @@ import {
   updateLorebookEntrySchema,
   createLorebookFolderSchema,
   updateLorebookFolderSchema,
+  resolveMacros,
   type CreateLorebookEntryInput,
   type LorebookEntryTimingState,
   type LorebookEntry,
@@ -20,6 +21,7 @@ import { createCharactersStorage } from "../services/storage/characters.storage.
 import { createConnectionsStorage } from "../services/storage/connections.storage.js";
 import { processLorebooks } from "../services/lorebook/index.js";
 import { resolveGameLorebookScopeExclusions } from "../services/lorebook/game-lorebook-scope.js";
+import { buildPromptMacroContext, resolveMacrosWithVariableSnapshot } from "../services/prompt/index.js";
 import {
   syncCharacterBookFromLorebook,
   clearCharacterEmbeddedLorebook,
@@ -577,6 +579,47 @@ export async function lorebooksRoutes(app: FastifyInstance) {
       content: typeof m.content === "string" ? m.content : "",
     }));
 
+    const lorebookMacroResolvers = await (async () => {
+      try {
+        const charactersStorage = createCharactersStorage(app.db);
+        let personaName = "User";
+        let personaDescription = "";
+        let personaFields: { personality?: string; scenario?: string; backstory?: string; appearance?: string } = {};
+        if (personaId) {
+          const persona = await charactersStorage.getPersona(personaId);
+          if (persona) {
+            personaName = persona.name || personaName;
+            personaDescription = persona.description ?? "";
+            personaFields = {
+              personality: persona.personality ?? "",
+              scenario: persona.scenario ?? "",
+              backstory: persona.backstory ?? "",
+              appearance: persona.appearance ?? "",
+            };
+          }
+        }
+        const macroContext = await buildPromptMacroContext({
+          db: app.db,
+          characterIds,
+          personaName,
+          personaDescription,
+          personaFields,
+          variables: {},
+          chatId,
+        });
+        return {
+          resolveContent: (value: string) => resolveMacrosWithVariableSnapshot(value, macroContext),
+          resolveContentForScan: (value: string) =>
+            resolveMacros(value, {
+              ...macroContext,
+              variables: { ...macroContext.variables },
+            }),
+        };
+      } catch {
+        return undefined;
+      }
+    })();
+
     const result = await processLorebooks(app.db, scanMessages, null, {
       chatId,
       characterIds,
@@ -603,7 +646,11 @@ export async function lorebooksRoutes(app: FastifyInstance) {
           : undefined,
       previewOnly: true,
       generationTriggers: resolveScanGenerationTriggers(chat?.mode),
+      resolveContent: lorebookMacroResolvers?.resolveContent,
+      resolveContentForScan: lorebookMacroResolvers?.resolveContentForScan,
     });
+
+    const resolvedContentById = new Map(result.activatedEntries.map((entry) => [entry.id, entry.content]));
 
     // Fetch full entry data for the activated IDs
     const activeEntries =
@@ -617,7 +664,8 @@ export async function lorebooksRoutes(app: FastifyInstance) {
       entries: activeEntries.map((e) => ({
         id: (e as Record<string, unknown>).id,
         name: (e as Record<string, unknown>).name,
-        content: (e as Record<string, unknown>).content,
+        content:
+          resolvedContentById.get(String((e as Record<string, unknown>).id)) ?? (e as Record<string, unknown>).content,
         keys: (e as Record<string, unknown>).keys,
         lorebookId: (e as Record<string, unknown>).lorebookId,
         order: (e as Record<string, unknown>).order,

--- a/packages/server/src/routes/lorebooks.routes.ts
+++ b/packages/server/src/routes/lorebooks.routes.ts
@@ -9,7 +9,6 @@ import {
   updateLorebookEntrySchema,
   createLorebookFolderSchema,
   updateLorebookFolderSchema,
-  resolveMacros,
   type CreateLorebookEntryInput,
   type LorebookEntryTimingState,
   type LorebookEntry,
@@ -578,6 +577,7 @@ export async function lorebooksRoutes(app: FastifyInstance) {
       role: (m.role === "narrator" ? "system" : m.role) as string,
       content: typeof m.content === "string" ? m.content : "",
     }));
+    const lastInput = [...scanMessages].reverse().find((message) => message.role === "user")?.content;
 
     const lorebookMacroResolvers = await (async () => {
       try {
@@ -605,15 +605,11 @@ export async function lorebooksRoutes(app: FastifyInstance) {
           personaDescription,
           personaFields,
           variables: {},
+          lastInput,
           chatId,
         });
         return {
           resolveContent: (value: string) => resolveMacrosWithVariableSnapshot(value, macroContext),
-          resolveContentForScan: (value: string) =>
-            resolveMacros(value, {
-              ...macroContext,
-              variables: { ...macroContext.variables },
-            }),
         };
       } catch {
         return undefined;
@@ -647,7 +643,6 @@ export async function lorebooksRoutes(app: FastifyInstance) {
       previewOnly: true,
       generationTriggers: resolveScanGenerationTriggers(chat?.mode),
       resolveContent: lorebookMacroResolvers?.resolveContent,
-      resolveContentForScan: lorebookMacroResolvers?.resolveContentForScan,
     });
 
     const resolvedContentById = new Map(result.activatedEntries.map((entry) => [entry.id, entry.content]));

--- a/packages/server/src/services/lorebook/index.ts
+++ b/packages/server/src/services/lorebook/index.ts
@@ -15,7 +15,6 @@ import { createCharactersStorage } from "../storage/characters.storage.js";
 import { createLorebooksStorage } from "../storage/lorebooks.storage.js";
 import {
   scanForActivatedEntries,
-  recursiveScan,
   type ScanMessage,
   type ScanOptions,
   type GameStateForScanning,
@@ -32,6 +31,7 @@ export interface LorebookScanResult {
   totalEntries: number;
   totalTokensEstimate: number;
   activatedEntryIds: string[];
+  activatedEntries: Array<{ id: string; content: string }>;
   /** Updated per-chat entry state overrides (ephemeral countdown). Caller should persist to chat metadata. */
   updatedEntryStateOverrides?: Record<string, { ephemeral?: number | null; enabled?: boolean }>;
   /** Updated per-chat timing states for sticky/cooldown/delay. Caller should persist to chat metadata. */
@@ -263,6 +263,282 @@ export function applyPerLorebookTokenBudgets(
   return budgeted.sort((a, b) => a.injectionOrder - b.injectionOrder);
 }
 
+export interface LorebookContentResolution {
+  content: string;
+  commit?: () => void;
+  rollback?: () => void;
+}
+
+export type LorebookFinalContentResolver = (value: string) => string | LorebookContentResolution;
+
+export function resolveActivatedLorebookEntryContent(
+  activatedEntries: ActivatedEntry[],
+  resolveContent?: (value: string) => string,
+  options: { useRawContent?: boolean } = {},
+): ActivatedEntry[] {
+  if (!resolveContent) return activatedEntries;
+  return activatedEntries.map((entry) => ({
+    ...entry,
+    rawContent: entry.rawContent ?? entry.entry.content,
+    entry: {
+      ...entry.entry,
+      content: resolveContent(options.useRawContent ? (entry.rawContent ?? entry.entry.content) : entry.entry.content),
+    },
+  }));
+}
+
+function resolveFinalLorebookContent(
+  activatedEntry: ActivatedEntry,
+  resolveContent?: LorebookFinalContentResolver,
+): LorebookContentResolution {
+  const rawContent = activatedEntry.rawContent ?? activatedEntry.entry.content;
+  if (!resolveContent) return { content: rawContent };
+  const result = resolveContent(rawContent);
+  return typeof result === "string" ? { content: result } : result;
+}
+
+function lorebookSelectionOrder(a: ActivatedEntry, b: ActivatedEntry): number {
+  if (a.entry.constant && !b.entry.constant) return -1;
+  if (!a.entry.constant && b.entry.constant) return 1;
+  return a.injectionOrder - b.injectionOrder;
+}
+
+function lorebookInjectionOrder(a: ActivatedEntry, b: ActivatedEntry): number {
+  return a.injectionOrder - b.injectionOrder;
+}
+
+function estimateLorebookTokens(content: string): number {
+  return Math.ceil(content.length / 4);
+}
+
+type LorebookBudgetSelectionState = {
+  selected: ActivatedEntry[];
+  selectedIds: Set<string>;
+  perLorebookTokens: Map<string, number>;
+  totalTokens: number;
+};
+
+function createLorebookBudgetSelectionState(): LorebookBudgetSelectionState {
+  return {
+    selected: [],
+    selectedIds: new Set(),
+    perLorebookTokens: new Map(),
+    totalTokens: 0,
+  };
+}
+
+function cloneLorebookBudgetSelectionState(state: LorebookBudgetSelectionState): LorebookBudgetSelectionState {
+  return {
+    selected: [...state.selected],
+    selectedIds: new Set(state.selectedIds),
+    perLorebookTokens: new Map(state.perLorebookTokens),
+    totalTokens: state.totalTokens,
+  };
+}
+
+type LorebookResolutionPass = {
+  entries: ActivatedEntry[];
+  resolutions: LorebookContentResolution[];
+};
+
+function resolveLorebookResolutionPass(
+  candidates: ActivatedEntry[],
+  resolveContent?: LorebookFinalContentResolver,
+): LorebookResolutionPass {
+  const entries: ActivatedEntry[] = [];
+  const resolutions: LorebookContentResolution[] = [];
+
+  for (const candidate of [...candidates].sort(lorebookInjectionOrder)) {
+    const resolved = resolveFinalLorebookContent(candidate, resolveContent);
+    resolutions.push(resolved);
+    entries.push({
+      ...candidate,
+      rawContent: candidate.rawContent ?? candidate.entry.content,
+      entry: {
+        ...candidate.entry,
+        content: resolved.content,
+      },
+    });
+  }
+
+  return { entries, resolutions };
+}
+
+function commitLorebookResolutionPass(pass: LorebookResolutionPass): void {
+  for (const resolution of pass.resolutions) {
+    resolution.commit?.();
+  }
+}
+
+function rollbackLorebookResolutionPass(pass: LorebookResolutionPass): void {
+  for (const resolution of [...pass.resolutions].reverse()) {
+    resolution.rollback?.();
+  }
+}
+
+function sameActivatedEntrySet(a: ActivatedEntry[], b: ActivatedEntry[]): boolean {
+  if (a.length !== b.length) return false;
+  const bIds = new Set(b.map((entry) => entry.entry.id));
+  return a.every((entry) => bIds.has(entry.entry.id));
+}
+
+function trySelectBudgetedLorebookEntry(
+  candidate: ActivatedEntry,
+  state: LorebookBudgetSelectionState,
+  lorebooksById: ReadonlyMap<string, Pick<Lorebook, "tokenBudget">>,
+  tokenBudget: number,
+  maxEntries: number,
+): ActivatedEntry | null {
+  if (state.selectedIds.has(candidate.entry.id)) return null;
+  if (maxEntries > 0 && state.selected.length >= maxEntries) return null;
+
+  const entryTokens = estimateLorebookTokens(candidate.entry.content);
+  const lorebookBudget = lorebooksById.get(candidate.entry.lorebookId)?.tokenBudget ?? 0;
+  const lorebookTokens = state.perLorebookTokens.get(candidate.entry.lorebookId) ?? 0;
+  const exceedsLorebookBudget = lorebookBudget > 0 && lorebookTokens + entryTokens > lorebookBudget;
+  const exceedsGlobalBudget = tokenBudget > 0 && state.totalTokens + entryTokens > tokenBudget;
+
+  if (exceedsLorebookBudget || exceedsGlobalBudget) return null;
+
+  state.selected.push(candidate);
+  state.selectedIds.add(candidate.entry.id);
+  state.perLorebookTokens.set(candidate.entry.lorebookId, lorebookTokens + entryTokens);
+  state.totalTokens += entryTokens;
+
+  return candidate;
+}
+
+function selectBudgetedLorebookEntryBatch(
+  candidates: ActivatedEntry[],
+  baseState: LorebookBudgetSelectionState,
+  lorebooksById: ReadonlyMap<string, Pick<Lorebook, "tokenBudget">>,
+  tokenBudget: number,
+  maxEntries: number,
+  resolveContent?: LorebookFinalContentResolver,
+): { selectedFromCandidates: ActivatedEntry[]; state: LorebookBudgetSelectionState } {
+  let pool = candidates;
+  const maxPasses = Math.max(1, candidates.length + 1);
+
+  for (let passIndex = 0; passIndex < maxPasses; passIndex++) {
+    const pass = resolveLorebookResolutionPass(pool, resolveContent);
+    const nextState = cloneLorebookBudgetSelectionState(baseState);
+    const selectedFromCandidates: ActivatedEntry[] = [];
+
+    for (const candidate of [...pass.entries].sort(lorebookSelectionOrder)) {
+      if (maxEntries > 0 && nextState.selected.length >= maxEntries) break;
+      const selected = trySelectBudgetedLorebookEntry(
+        candidate,
+        nextState,
+        lorebooksById,
+        tokenBudget,
+        maxEntries,
+      );
+      if (selected) selectedFromCandidates.push(selected);
+    }
+
+    selectedFromCandidates.sort(lorebookInjectionOrder);
+
+    if (sameActivatedEntrySet(pool, selectedFromCandidates)) {
+      commitLorebookResolutionPass(pass);
+      return { selectedFromCandidates, state: nextState };
+    }
+
+    rollbackLorebookResolutionPass(pass);
+    pool = selectedFromCandidates;
+  }
+
+  const pass = resolveLorebookResolutionPass(pool, resolveContent);
+  const nextState = cloneLorebookBudgetSelectionState(baseState);
+  const selectedFromCandidates: ActivatedEntry[] = [];
+
+  for (const candidate of [...pass.entries].sort(lorebookSelectionOrder)) {
+    if (maxEntries > 0 && nextState.selected.length >= maxEntries) break;
+    const selected = trySelectBudgetedLorebookEntry(candidate, nextState, lorebooksById, tokenBudget, maxEntries);
+    if (selected) selectedFromCandidates.push(selected);
+  }
+
+  selectedFromCandidates.sort(lorebookInjectionOrder);
+  if (sameActivatedEntrySet(pool, selectedFromCandidates)) {
+    commitLorebookResolutionPass(pass);
+    return { selectedFromCandidates, state: nextState };
+  }
+
+  rollbackLorebookResolutionPass(pass);
+  return { selectedFromCandidates: [], state: cloneLorebookBudgetSelectionState(baseState) };
+}
+
+export function resolveAndBudgetActivatedLorebookEntries(
+  activatedEntries: ActivatedEntry[],
+  lorebooksById: ReadonlyMap<string, Pick<Lorebook, "tokenBudget">>,
+  tokenBudget: number,
+  maxEntries: number,
+  resolveContent?: LorebookFinalContentResolver,
+): ActivatedEntry[] {
+  if (activatedEntries.length === 0) return [];
+
+  const { state } = selectBudgetedLorebookEntryBatch(
+    activatedEntries,
+    createLorebookBudgetSelectionState(),
+    lorebooksById,
+    tokenBudget,
+    maxEntries,
+    resolveContent,
+  );
+
+  return state.selected.sort(lorebookInjectionOrder);
+}
+
+export function resolveBudgetAndRecursivelyActivateLorebookEntries(
+  messages: ScanMessage[],
+  entries: LorebookEntry[],
+  options: ScanOptions,
+  maxDepth: number,
+  lorebooksById: ReadonlyMap<string, Pick<Lorebook, "tokenBudget">>,
+  tokenBudget: number,
+  maxEntries: number,
+  resolveContent?: LorebookFinalContentResolver,
+): ActivatedEntry[] {
+  let state = createLorebookBudgetSelectionState();
+  const processedIds = new Set<string>();
+  let frontier = scanForActivatedEntries(messages, entries, options);
+
+  for (let depth = 0; frontier.length > 0; depth++) {
+    const candidates = frontier.filter(
+      (candidate) => !processedIds.has(candidate.entry.id) && !state.selectedIds.has(candidate.entry.id),
+    );
+    for (const candidate of candidates) {
+      processedIds.add(candidate.entry.id);
+    }
+
+    const selectedBatch = selectBudgetedLorebookEntryBatch(
+      candidates,
+      state,
+      lorebooksById,
+      tokenBudget,
+      maxEntries,
+      resolveContent,
+    );
+    state = selectedBatch.state;
+
+    const recursiveContentParts = selectedBatch.selectedFromCandidates
+      .filter((selected) => !selected.entry.preventRecursion)
+      .map((selected) => selected.entry.content);
+
+    if (depth >= maxDepth) break;
+    if (maxEntries > 0 && state.selected.length >= maxEntries) break;
+
+    const recursiveContent = recursiveContentParts.join("\n");
+    if (!recursiveContent) break;
+
+    const remaining = entries.filter((entry) => !processedIds.has(entry.id) && !state.selectedIds.has(entry.id));
+    if (remaining.length === 0) break;
+
+    frontier = scanForActivatedEntries([{ role: "system", content: recursiveContent }], remaining, options);
+  }
+
+  return state.selected.sort(lorebookInjectionOrder);
+}
+
 /**
  * Main lorebook processing for a generation request.
  * 1. Fetch all active entries from enabled lorebooks
@@ -295,6 +571,10 @@ export async function processLorebooks(
     previewOnly?: boolean;
     /** Generation trigger labels used by per-entry include/exclude filters. */
     generationTriggers?: string[];
+    /** Resolves prompt macros for final included lorebook entries. May apply macro side effects. */
+    resolveContent?: LorebookFinalContentResolver;
+    /** @deprecated Macro-aware budgeting and recursion now use resolveContent so scan/final text stays identical. */
+    resolveContentForScan?: (value: string) => string;
   },
 ): Promise<LorebookScanResult> {
   const storage = createLorebooksStorage(db);
@@ -356,6 +636,7 @@ export async function processLorebooks(
       totalEntries: 0,
       totalTokensEstimate: 0,
       activatedEntryIds: [],
+      activatedEntries: [],
       ...(!previewOnly && hasSerializedTimingStates(options?.entryTimingStates)
         ? { updatedEntryTimingStates: {} }
         : {}),
@@ -397,15 +678,24 @@ export async function processLorebooks(
     3,
   );
 
-  let activated: ActivatedEntry[];
-  if (anyRecursive) {
-    activated = recursiveScan(messages, allEntries, scanOpts, maxRecursionDepth);
-  } else {
-    activated = scanForActivatedEntries(messages, allEntries, scanOpts);
-  }
-
-  const perLorebookBudgeted = applyPerLorebookTokenBudgets(activated, relevantLorebooksById);
-  const cappedActivated = enforceMaxActivatedEntries(perLorebookBudgeted);
+  const finalActivated = anyRecursive
+    ? resolveBudgetAndRecursivelyActivateLorebookEntries(
+        messages,
+        allEntries,
+        scanOpts,
+        maxRecursionDepth,
+        relevantLorebooksById,
+        tokenBudget,
+        LIMITS.MAX_LOREBOOK_ENTRIES,
+        options?.resolveContent,
+      )
+    : resolveAndBudgetActivatedLorebookEntries(
+        scanForActivatedEntries(messages, allEntries, scanOpts),
+        relevantLorebooksById,
+        tokenBudget,
+        LIMITS.MAX_LOREBOOK_ENTRIES,
+        options?.resolveContent,
+      );
 
   // Decrement ephemeral counters for activated entries.
   // When per-chat overrides are provided, track the countdown in those overrides
@@ -419,7 +709,7 @@ export async function processLorebooks(
   } else if (overrides) {
     // Per-chat tracking: write to overrides, leave global entry untouched
     updatedOverrides = { ...overrides };
-    for (const a of cappedActivated) {
+    for (const a of finalActivated) {
       if (a.entry.ephemeral !== null && a.entry.ephemeral > 0) {
         const remaining = a.entry.ephemeral - 1;
         updatedOverrides[a.entry.id] = {
@@ -432,7 +722,7 @@ export async function processLorebooks(
   } else if (options?.chatId) {
     // Legacy path: first call for this chat (no overrides yet) — initialise per-chat overrides
     updatedOverrides = {};
-    for (const a of cappedActivated) {
+    for (const a of finalActivated) {
       if (a.entry.ephemeral !== null && a.entry.ephemeral > 0) {
         const remaining = a.entry.ephemeral - 1;
         updatedOverrides[a.entry.id] = {
@@ -448,17 +738,18 @@ export async function processLorebooks(
   // Process into injectable content
   const updatedTimingMap = previewOnly
     ? undefined
-    : updateTimingStatesForScan(allEntries, cappedActivated, timingStates, currentMessageIndex);
+    : updateTimingStatesForScan(allEntries, finalActivated, timingStates, currentMessageIndex);
   const updatedEntryTimingStates =
     updatedTimingMap && (timingStates.size > 0 || updatedTimingMap.size > 0)
       ? serializeTimingStateMap(updatedTimingMap)
       : undefined;
 
-  const result = processActivatedEntries(cappedActivated, tokenBudget);
+  const result = processActivatedEntries(finalActivated, 0);
 
   return {
     ...result,
-    activatedEntryIds: cappedActivated.map((a) => a.entry.id),
+    activatedEntryIds: finalActivated.map((a) => a.entry.id),
+    activatedEntries: finalActivated.map((a) => ({ id: a.entry.id, content: a.entry.content })),
     ...(updatedOverrides ? { updatedEntryStateOverrides: updatedOverrides } : {}),
     ...(updatedEntryTimingStates ? { updatedEntryTimingStates } : {}),
   };

--- a/packages/server/src/services/lorebook/index.ts
+++ b/packages/server/src/services/lorebook/index.ts
@@ -4,6 +4,7 @@
 // ──────────────────────────────────────────────
 import type { DB } from "../../db/connection.js";
 import { LIMITS } from "@marinara-engine/shared";
+import { logger } from "../../lib/logger.js";
 import type {
   CharacterData,
   Lorebook,
@@ -307,6 +308,8 @@ function lorebookInjectionOrder(a: ActivatedEntry, b: ActivatedEntry): number {
   return a.injectionOrder - b.injectionOrder;
 }
 
+// Lorebook budgets currently use the project-wide chars/4 approximation.
+// This can drift for CJK, emoji, and long-tail vocabulary until a canonical tokenizer is available here.
 function estimateLorebookTokens(content: string): number {
   return Math.ceil(content.length / 4);
 }
@@ -418,9 +421,13 @@ function selectBudgetedLorebookEntryBatch(
 ): { selectedFromCandidates: ActivatedEntry[]; state: LorebookBudgetSelectionState } {
   let pool = candidates;
   const maxPasses = Math.max(1, candidates.length + 1);
+  let resolutionPasses = 0;
+  let resolvedEntryCount = 0;
 
   for (let passIndex = 0; passIndex < maxPasses; passIndex++) {
     const pass = resolveLorebookResolutionPass(pool, resolveContent);
+    resolutionPasses += 1;
+    resolvedEntryCount += pass.resolutions.length;
     const nextState = cloneLorebookBudgetSelectionState(baseState);
     const selectedFromCandidates: ActivatedEntry[] = [];
 
@@ -448,6 +455,8 @@ function selectBudgetedLorebookEntryBatch(
   }
 
   const pass = resolveLorebookResolutionPass(pool, resolveContent);
+  resolutionPasses += 1;
+  resolvedEntryCount += pass.resolutions.length;
   const nextState = cloneLorebookBudgetSelectionState(baseState);
   const selectedFromCandidates: ActivatedEntry[] = [];
 
@@ -464,6 +473,14 @@ function selectBudgetedLorebookEntryBatch(
   }
 
   rollbackLorebookResolutionPass(pass);
+  logger.warn(
+    "[lorebook] Budgeted selection failed to converge after %d passes (maxPasses=%d candidates=%d pool=%d resolved=%d); dropping batch",
+    resolutionPasses,
+    maxPasses,
+    candidates.length,
+    pool.length,
+    resolvedEntryCount,
+  );
   return { selectedFromCandidates: [], state: cloneLorebookBudgetSelectionState(baseState) };
 }
 
@@ -573,8 +590,6 @@ export async function processLorebooks(
     generationTriggers?: string[];
     /** Resolves prompt macros for final included lorebook entries. May apply macro side effects. */
     resolveContent?: LorebookFinalContentResolver;
-    /** @deprecated Macro-aware budgeting and recursion now use resolveContent so scan/final text stays identical. */
-    resolveContentForScan?: (value: string) => string;
   },
 ): Promise<LorebookScanResult> {
   const storage = createLorebooksStorage(db);

--- a/packages/server/src/services/lorebook/keyword-scanner.ts
+++ b/packages/server/src/services/lorebook/keyword-scanner.ts
@@ -37,6 +37,8 @@ export interface ScanMessage {
 /** Result of scanning: an activated entry plus metadata. */
 export interface ActivatedEntry {
   entry: LorebookEntry;
+  /** Original stored content when entry.content has been macro-expanded for scanning or budgeting. */
+  rawContent?: string;
   /** Which key(s) matched */
   matchedKeys: string[];
   /** Priority order for injection */
@@ -602,13 +604,14 @@ export function recursiveScan(
   options: ScanOptions = {},
   maxDepth: number = 3,
 ): ActivatedEntry[] {
-  let allActivated = scanForActivatedEntries(messages, entries, options);
+  const allActivated = scanForActivatedEntries(messages, entries, options);
   const activatedIds = new Set(allActivated.map((a) => a.entry.id));
+  let newlyActivated = allActivated;
 
   for (let depth = 0; depth < maxDepth; depth++) {
     // Build text from newly activated entries, excluding those with preventRecursion
-    const newContent = allActivated
-      .filter((a) => (!activatedIds.has(a.entry.id) || depth === 0) && !a.entry.preventRecursion)
+    const newContent = newlyActivated
+      .filter((a) => !a.entry.preventRecursion)
       .map((a) => a.entry.content)
       .join("\n");
 
@@ -621,9 +624,11 @@ export function recursiveScan(
 
     if (newActivated.length === 0) break;
 
+    newlyActivated = [];
     for (const a of newActivated) {
       activatedIds.add(a.entry.id);
       allActivated.push(a);
+      newlyActivated.push(a);
     }
   }
 

--- a/packages/server/src/services/prompt/assembler.ts
+++ b/packages/server/src/services/prompt/assembler.ts
@@ -21,7 +21,11 @@ import { wrapContent, wrapGroup } from "./format-engine.js";
 import { expandMarker, type MarkerContext } from "./marker-expander.js";
 import { mergeAdjacentMessages, squashLeadingSystemMessages } from "./merger.js";
 import { injectAtDepth } from "../lorebook/prompt-injector.js";
-import { buildPromptMacroContext, collectCharacterDepthPromptEntries } from "./macro-context.js";
+import {
+  buildPromptMacroContext,
+  collectCharacterDepthPromptEntries,
+  resolveMacrosWithVariableSnapshot,
+} from "./macro-context.js";
 
 // ═══════════════════════════════════════════════
 //  Public Interface
@@ -244,6 +248,12 @@ export async function assemblePrompt(input: AssemblerInput): Promise<AssemblerOu
     gameState: input.gameState ?? null,
     generationTriggers: input.generationTriggers ?? ["chat"],
     previewOnly: input.previewOnly === true,
+    resolveLorebookContent: (value) => resolveMacrosWithVariableSnapshot(value, macroCtx),
+    resolveLorebookContentForScan: (value) =>
+      resolveMacros(value, {
+        ...macroCtx,
+        variables: { ...macroCtx.variables },
+      }),
     groupScenarioOverrideText: input.groupScenarioOverrideText ?? null,
   };
 
@@ -383,12 +393,7 @@ export async function assemblePrompt(input: AssemblerInput): Promise<AssemblerOu
   }
 
   if (markerCtx.lorebookDepthEntries && markerCtx.lorebookDepthEntries.length > 0) {
-    allDepthEntries.push(
-      markerCtx.lorebookDepthEntries.map((entry) => ({
-        ...entry,
-        content: resolveMacros(entry.content, macroCtx),
-      })),
-    );
+    allDepthEntries.push(markerCtx.lorebookDepthEntries);
   }
 
   const characterDepthEntries = await collectCharacterDepthPromptEntries(input.db, input.characterIds, macroCtx);
@@ -470,6 +475,7 @@ async function resolveSection(
   const role = section.role as "system" | "user" | "assistant";
 
   let content = section.content;
+  let contentMacrosResolved = false;
 
   // Handle marker sections
   if (section.isMarker === "true" && section.markerConfig) {
@@ -503,12 +509,16 @@ async function resolveSection(
     } else {
       // Other markers return content to be wrapped
       content = expanded.content;
+      contentMacrosResolved =
+        markerConfig.type === "world_info_before" ||
+        markerConfig.type === "world_info_after" ||
+        markerConfig.type === "lorebook";
       if (!content.trim()) return null;
     }
   }
 
   // Resolve macros
-  content = resolveMacros(content, ctx.macroCtx);
+  content = contentMacrosResolved ? content : resolveMacros(content, ctx.macroCtx);
   if (!content.trim()) return null;
 
   // Auto-wrap in the preset's format

--- a/packages/server/src/services/prompt/assembler.ts
+++ b/packages/server/src/services/prompt/assembler.ts
@@ -249,11 +249,6 @@ export async function assemblePrompt(input: AssemblerInput): Promise<AssemblerOu
     generationTriggers: input.generationTriggers ?? ["chat"],
     previewOnly: input.previewOnly === true,
     resolveLorebookContent: (value) => resolveMacrosWithVariableSnapshot(value, macroCtx),
-    resolveLorebookContentForScan: (value) =>
-      resolveMacros(value, {
-        ...macroCtx,
-        variables: { ...macroCtx.variables },
-      }),
     groupScenarioOverrideText: input.groupScenarioOverrideText ?? null,
   };
 

--- a/packages/server/src/services/prompt/index.ts
+++ b/packages/server/src/services/prompt/index.ts
@@ -7,8 +7,10 @@ export { expandMarker, type MarkerContext, type ExpandedMarker } from "./marker-
 export {
   buildPromptMacroContext,
   collectCharacterDepthPromptEntries,
+  resolveMacrosWithVariableSnapshot,
   resolveCharacterMacroData,
   type CharacterMacroData,
+  type MacroResolutionTransaction,
   type PromptDepthEntry,
 } from "./macro-context.js";
 export { mergeAdjacentMessages, squashLeadingSystemMessages } from "./merger.js";

--- a/packages/server/src/services/prompt/macro-context.ts
+++ b/packages/server/src/services/prompt/macro-context.ts
@@ -5,8 +5,12 @@
 // assembler. Keeps card macros and depth prompts consistent everywhere.
 // ──────────────────────────────────────────────
 
-import type { CharacterData, MacroContext } from "@marinara-engine/shared";
-import { resolveMacros } from "@marinara-engine/shared";
+import {
+  resolveMacros,
+  type CharacterData,
+  type MacroContext,
+  type ResolveMacroOptions,
+} from "@marinara-engine/shared";
 import type { DB } from "../../db/connection.js";
 import { createCharactersStorage } from "../storage/characters.storage.js";
 import { getCharacterDescriptionWithExtensions } from "./character-description-extensions.js";
@@ -30,6 +34,34 @@ export interface CharacterMacroData {
   names: string[];
   profiles: NonNullable<MacroContext["characterProfiles"]>;
   primaryFields?: NonNullable<MacroContext["characterFields"]>;
+}
+
+export interface MacroResolutionTransaction {
+  content: string;
+  commit: () => void;
+  rollback: () => void;
+}
+
+export function resolveMacrosWithVariableSnapshot(
+  template: string,
+  macroCtx: MacroContext,
+  options?: ResolveMacroOptions,
+): MacroResolutionTransaction {
+  const before = { ...macroCtx.variables };
+  const content = resolveMacros(template, macroCtx, options);
+  let settled = false;
+
+  const rollback = () => {
+    if (settled) return;
+    macroCtx.variables = before;
+    settled = true;
+  };
+
+  const commit = () => {
+    settled = true;
+  };
+
+  return { content, commit, rollback };
 }
 
 export type PromptDepthEntry = {

--- a/packages/server/src/services/prompt/marker-expander.ts
+++ b/packages/server/src/services/prompt/marker-expander.ts
@@ -13,7 +13,11 @@ import type {
 } from "@marinara-engine/shared";
 import { createCharactersStorage } from "../storage/characters.storage.js";
 import { createAgentsStorage } from "../storage/agents.storage.js";
-import { processLorebooks } from "../lorebook/index.js";
+import {
+  processLorebooks,
+  type LorebookFinalContentResolver,
+  type LorebookScanResult,
+} from "../lorebook/index.js";
 import { wrapContent } from "./format-engine.js";
 import { getCharacterDescriptionWithExtensions } from "./character-description-extensions.js";
 import { agentRuns } from "../../db/schema/index.js";
@@ -65,12 +69,20 @@ export interface MarkerContext {
   generationTriggers?: string[];
   /** Preview/debug expansion: lorebook markers should not consume timing or ephemeral state. */
   previewOnly?: boolean;
+  /** Resolves prompt macros for final included lorebook entries. May apply macro side effects. */
+  resolveLorebookContent?: LorebookFinalContentResolver;
+  /** Resolves prompt macros for scan/budget estimates with isolated macro side effects. */
+  resolveLorebookContentForScan?: (value: string) => string;
   /** Collector for lorebook depth entries — populated during expansion, consumed by the assembler. */
   lorebookDepthEntries?: Array<{ content: string; role: "system" | "user" | "assistant"; depth: number }>;
   /** Collector for updated entry state overrides after ephemeral processing — saved to chat metadata by caller. */
   updatedEntryStateOverrides?: Record<string, { ephemeral?: number | null; enabled?: boolean }>;
   /** Collector for updated sticky/cooldown/delay timing state — saved to chat metadata by caller. */
   updatedEntryTimingStates?: Record<string, LorebookEntryTimingState>;
+  /** Cached lorebook scan for all lorebook marker sections in this prompt build. */
+  lorebookScanResult?: LorebookScanResult;
+  /** True once cached lorebook state/depth side effects have been applied to this marker context. */
+  lorebookScanResultApplied?: boolean;
   /** When set, replaces all individual character scenario fields with this shared group scenario. */
   groupScenarioOverrideText?: string | null;
 }
@@ -250,36 +262,44 @@ async function expandPersona(_config: MarkerConfig, ctx: MarkerContext): Promise
 async function expandLorebook(config: MarkerConfig, ctx: MarkerContext): Promise<ExpandedMarker> {
   if (ctx.disableLorebooks === true) return { content: "" };
 
-  const result = await processLorebooks(ctx.db, ctx.chatMessages, ctx.gameState ?? null, {
-    chatId: ctx.chatId,
-    characterIds: ctx.characterIds,
-    personaId: ctx.personaId ?? null,
-    activeLorebookIds: ctx.activeLorebookIds,
-    excludedLorebookIds: ctx.excludedLorebookIds,
-    excludedSourceAgentIds: ctx.excludedLorebookSourceAgentIds,
-    tokenBudget: ctx.lorebookTokenBudget,
-    chatEmbedding: ctx.chatEmbedding ?? null,
-    entryStateOverrides: ctx.entryStateOverrides,
-    entryTimingStates: ctx.entryTimingStates,
-    generationTriggers: ctx.generationTriggers ?? ["chat"],
-    previewOnly: ctx.previewOnly === true,
-  });
+  const result =
+    ctx.lorebookScanResult ??
+    (ctx.lorebookScanResult = await processLorebooks(ctx.db, ctx.chatMessages, ctx.gameState ?? null, {
+      chatId: ctx.chatId,
+      characterIds: ctx.characterIds,
+      personaId: ctx.personaId ?? null,
+      activeLorebookIds: ctx.activeLorebookIds,
+      excludedLorebookIds: ctx.excludedLorebookIds,
+      excludedSourceAgentIds: ctx.excludedLorebookSourceAgentIds,
+      tokenBudget: ctx.lorebookTokenBudget,
+      chatEmbedding: ctx.chatEmbedding ?? null,
+      entryStateOverrides: ctx.entryStateOverrides,
+      entryTimingStates: ctx.entryTimingStates,
+      generationTriggers: ctx.generationTriggers ?? ["chat"],
+      previewOnly: ctx.previewOnly === true,
+      resolveContent: ctx.resolveLorebookContent,
+      resolveContentForScan: ctx.resolveLorebookContentForScan,
+    }));
 
-  // Collect updated per-chat entry state overrides for the caller to persist
-  if (result.updatedEntryStateOverrides) {
-    ctx.updatedEntryStateOverrides = result.updatedEntryStateOverrides;
-    ctx.entryStateOverrides = result.updatedEntryStateOverrides;
-  }
-  if (result.updatedEntryTimingStates !== undefined) {
-    ctx.updatedEntryTimingStates = result.updatedEntryTimingStates;
-    ctx.entryTimingStates = result.updatedEntryTimingStates;
-  }
+  if (ctx.lorebookScanResultApplied !== true) {
+    ctx.lorebookScanResultApplied = true;
 
-  // Collect depth entries for the assembler to inject later
-  if (result.depthEntries.length > 0) {
-    ctx.lorebookDepthEntries ??= [];
-    for (const de of result.depthEntries) {
-      ctx.lorebookDepthEntries.push({ content: de.content, role: de.role, depth: de.depth });
+    // Collect updated per-chat entry state overrides for the caller to persist.
+    if (result.updatedEntryStateOverrides) {
+      ctx.updatedEntryStateOverrides = result.updatedEntryStateOverrides;
+      ctx.entryStateOverrides = result.updatedEntryStateOverrides;
+    }
+    if (result.updatedEntryTimingStates !== undefined) {
+      ctx.updatedEntryTimingStates = result.updatedEntryTimingStates;
+      ctx.entryTimingStates = result.updatedEntryTimingStates;
+    }
+
+    // Collect depth entries for the assembler to inject later.
+    if (result.depthEntries.length > 0) {
+      ctx.lorebookDepthEntries ??= [];
+      for (const de of result.depthEntries) {
+        ctx.lorebookDepthEntries.push({ content: de.content, role: de.role, depth: de.depth });
+      }
     }
   }
 

--- a/packages/server/src/services/prompt/marker-expander.ts
+++ b/packages/server/src/services/prompt/marker-expander.ts
@@ -71,8 +71,6 @@ export interface MarkerContext {
   previewOnly?: boolean;
   /** Resolves prompt macros for final included lorebook entries. May apply macro side effects. */
   resolveLorebookContent?: LorebookFinalContentResolver;
-  /** Resolves prompt macros for scan/budget estimates with isolated macro side effects. */
-  resolveLorebookContentForScan?: (value: string) => string;
   /** Collector for lorebook depth entries — populated during expansion, consumed by the assembler. */
   lorebookDepthEntries?: Array<{ content: string; role: "system" | "user" | "assistant"; depth: number }>;
   /** Collector for updated entry state overrides after ephemeral processing — saved to chat metadata by caller. */
@@ -278,7 +276,6 @@ async function expandLorebook(config: MarkerConfig, ctx: MarkerContext): Promise
       generationTriggers: ctx.generationTriggers ?? ["chat"],
       previewOnly: ctx.previewOnly === true,
       resolveContent: ctx.resolveLorebookContent,
-      resolveContentForScan: ctx.resolveLorebookContentForScan,
     }));
 
   if (ctx.lorebookScanResultApplied !== true) {

--- a/packages/server/src/services/regex/regex-application.ts
+++ b/packages/server/src/services/regex/regex-application.ts
@@ -21,6 +21,12 @@ export type RegexMessageLike = {
   content: string;
 };
 
+type RegexMacroResolver = (value: string) => string;
+
+type ApplyRegexScriptOptions = {
+  resolveMacros?: RegexMacroResolver;
+};
+
 function isEnabled(value: unknown): boolean {
   return value === true || value === "true";
 }
@@ -53,11 +59,16 @@ function depthValue(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
 
+function resolveScriptString(value: string, options: ApplyRegexScriptOptions | undefined): string {
+  return options?.resolveMacros ? options.resolveMacros(value) : value;
+}
+
 export function applyRegexScriptsToPromptText(
   text: string,
   scripts: RegexScriptLike[],
   placement: RegexPlacement,
   depth: number,
+  options?: ApplyRegexScriptOptions,
 ): string {
   let result = text;
   for (const script of scripts) {
@@ -69,16 +80,17 @@ export function applyRegexScriptsToPromptText(
     if (minDepth != null && depth < minDepth) continue;
     if (maxDepth != null && depth > maxDepth) continue;
 
-    const findRegex = typeof script.findRegex === "string" ? script.findRegex : "";
+    const findRegex = typeof script.findRegex === "string" ? resolveScriptString(script.findRegex, options) : "";
     if (!findRegex) continue;
 
     try {
       const flags = typeof script.flags === "string" ? script.flags : "";
-      const replacement = typeof script.replaceString === "string" ? script.replaceString : "";
       const re = new RegExp(findRegex, flags);
-      result = applyRegexReplacement(result, re, replacement);
+      const replacement = typeof script.replaceString === "string" ? script.replaceString : "";
+      result = applyRegexReplacement(result, re, replacement, (value) => resolveScriptString(value, options));
       for (const trim of parseTrimStrings(script.trimStrings)) {
-        if (trim) result = result.split(trim).join("");
+        const resolvedTrim = resolveScriptString(trim, options);
+        if (resolvedTrim) result = result.split(resolvedTrim).join("");
       }
     } catch {
       /* invalid regex — skip */
@@ -90,6 +102,7 @@ export function applyRegexScriptsToPromptText(
 export function applyRegexScriptsToPromptMessages<T extends RegexMessageLike>(
   messages: T[],
   scripts: RegexScriptLike[],
+  options?: ApplyRegexScriptOptions,
 ): void {
   if (scripts.length === 0 || messages.length === 0) return;
   const totalMessages = messages.length;
@@ -97,6 +110,6 @@ export function applyRegexScriptsToPromptMessages<T extends RegexMessageLike>(
     const message = messages[index]!;
     const placement = message.role === "user" ? "user_input" : "ai_output";
     const depth = totalMessages - 1 - index;
-    message.content = applyRegexScriptsToPromptText(message.content, scripts, placement, depth);
+    message.content = applyRegexScriptsToPromptText(message.content, scripts, placement, depth, options);
   }
 }

--- a/packages/server/test/lorebook-processing.test.ts
+++ b/packages/server/test/lorebook-processing.test.ts
@@ -109,6 +109,11 @@ function tokenContent(tokens: number): string {
   return "x".repeat(tokens * 4);
 }
 
+function snapshotMacroVariables(variables: MacroContext["variables"]): MacroContext["variables"] {
+  // Macro variables are string-only, so a shallow clone is a complete rollback snapshot.
+  return { ...variables };
+}
+
 function dbLorebookEntry(id: string, overrides: Partial<ReturnType<typeof lorebookEntryRow>> = {}) {
   return {
     ...lorebookEntryRow(id),
@@ -188,7 +193,7 @@ test("lorebook final budgets use resolved variable macro content and roll back s
     variables: {},
   };
   const resolveActual = (value: string) => {
-    const before = { ...macroContext.variables };
+    const before = snapshotMacroVariables(macroContext.variables);
     const content = resolveMacros(value, macroContext, { trimResult: false });
     let settled = false;
     return {
@@ -260,7 +265,7 @@ test("lorebook macro side effects resolve in final injection order", () => {
     variables: {},
   };
   const resolveActual = (value: string) => {
-    const before = { ...macroContext.variables };
+    const before = snapshotMacroVariables(macroContext.variables);
     const content = resolveMacros(value, macroContext, { trimResult: false });
     let settled = false;
     return {
@@ -321,7 +326,7 @@ test("constant lorebook entries keep selection priority while macros resolve in 
     variables: {},
   };
   const resolveActual = (value: string) => {
-    const before = { ...macroContext.variables };
+    const before = snapshotMacroVariables(macroContext.variables);
     const content = resolveMacros(value, macroContext, { trimResult: false });
     let settled = false;
     return {

--- a/packages/server/test/lorebook-processing.test.ts
+++ b/packages/server/test/lorebook-processing.test.ts
@@ -1,18 +1,34 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import type { Lorebook, LorebookEntry } from "@marinara-engine/shared";
+import { createClient } from "@libsql/client";
+import { drizzle } from "drizzle-orm/libsql";
+import {
+  DEFAULT_GENERATION_PARAMS,
+  resolveMacros,
+  type Lorebook,
+  type LorebookEntry,
+  type MacroContext,
+} from "@marinara-engine/shared";
+import type { DB } from "../src/db/connection.js";
+import { runMigrations } from "../src/db/migrate.js";
+import { lorebookEntries, lorebooks } from "../src/db/schema/index.js";
 import {
   applyLorebookDefaults,
   applyPerLorebookTokenBudgets,
   enforceMaxActivatedEntries,
   filterRelevantLorebooks,
+  resolveAndBudgetActivatedLorebookEntries,
+  resolveActivatedLorebookEntryContent,
+  resolveBudgetAndRecursivelyActivateLorebookEntries,
   serializeTimingStateMap,
 } from "../src/services/lorebook/index.js";
+import { processActivatedEntries } from "../src/services/lorebook/prompt-injector.js";
 import {
   scanForActivatedEntries,
   updateTimingStatesForScan,
   type ActivatedEntry,
 } from "../src/services/lorebook/keyword-scanner.js";
+import { assemblePrompt } from "../src/services/prompt/assembler.js";
 
 function makeLorebook(overrides: Partial<Lorebook> = {}): Lorebook {
   return {
@@ -92,6 +108,477 @@ function makeEntry(overrides: Partial<LorebookEntry> = {}): LorebookEntry {
 function tokenContent(tokens: number): string {
   return "x".repeat(tokens * 4);
 }
+
+function dbLorebookEntry(id: string, overrides: Partial<ReturnType<typeof lorebookEntryRow>> = {}) {
+  return {
+    ...lorebookEntryRow(id),
+    ...overrides,
+  };
+}
+
+function lorebookEntryRow(id: string) {
+  return {
+    id,
+    lorebookId: "book-1",
+    folderId: null,
+    name: id,
+    content: "Lore entry",
+    description: "",
+    keys: JSON.stringify(["marker-key"]),
+    secondaryKeys: "[]",
+    enabled: "true",
+    constant: "false",
+    selective: "false",
+    selectiveLogic: "and" as const,
+    probability: null,
+    scanDepth: null,
+    matchWholeWords: "false",
+    caseSensitive: "false",
+    useRegex: "false",
+    characterFilterMode: "any" as const,
+    characterFilterIds: "[]",
+    characterTagFilterMode: "any" as const,
+    characterTagFilters: "[]",
+    generationTriggerFilterMode: "any" as const,
+    generationTriggerFilters: "[]",
+    additionalMatchingSources: "[]",
+    position: 0,
+    depth: 4,
+    order: 100,
+    role: "system" as const,
+    sticky: null,
+    cooldown: null,
+    delay: null,
+    ephemeral: null,
+    group: "",
+    groupWeight: null,
+    locked: "false",
+    tag: "",
+    relationships: "{}",
+    dynamicState: "{}",
+    activationConditions: "[]",
+    schedule: null,
+    preventRecursion: "false",
+    embedding: null,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+test("macro-expanded lorebook content is budgeted and estimated after expansion", () => {
+  const expandedContent = tokenContent(20);
+  const activated = resolveActivatedLorebookEntryContent(
+    [{ entry: makeEntry({ content: "{{description}}" }), matchedKeys: ["keyword"], injectionOrder: 100 }],
+    (value) => value.replace("{{description}}", expandedContent),
+  );
+  const budgetedOut = applyPerLorebookTokenBudgets(activated, new Map([["book-1", makeLorebook({ tokenBudget: 5 })]]));
+  const processed = processActivatedEntries(activated, 0);
+
+  assert.deepEqual(budgetedOut, []);
+  assert.equal(processed.worldInfoBefore, expandedContent);
+  assert.equal(processed.totalTokensEstimate, 20);
+});
+
+test("lorebook final budgets use resolved variable macro content and roll back skipped side effects", () => {
+  const longPayload = tokenContent(20);
+  const macroContext: MacroContext = {
+    user: "User",
+    char: "Char",
+    characters: ["Char"],
+    variables: {},
+  };
+  const resolveActual = (value: string) => {
+    const before = { ...macroContext.variables };
+    const content = resolveMacros(value, macroContext, { trimResult: false });
+    let settled = false;
+    return {
+      content,
+      commit: () => {
+        settled = true;
+      },
+      rollback: () => {
+        if (settled) return;
+        macroContext.variables = before;
+        settled = true;
+      },
+    };
+  };
+  const resolveIsolated = (value: string) =>
+    resolveMacros(
+      value,
+      {
+        ...macroContext,
+        variables: { ...macroContext.variables },
+      },
+      { trimResult: false },
+    );
+  const activated: ActivatedEntry[] = [
+    {
+      entry: makeEntry({
+        id: "setter",
+        content: `{{setvar::payload::${longPayload}}}`,
+        order: 100,
+      }),
+      matchedKeys: ["keyword"],
+      injectionOrder: 100,
+    },
+    {
+      entry: makeEntry({
+        id: "reader",
+        content: "{{getvar::payload}}",
+        order: 200,
+      }),
+      matchedKeys: ["keyword"],
+      injectionOrder: 200,
+    },
+  ];
+
+  const previewResolved = resolveActivatedLorebookEntryContent(activated, resolveIsolated);
+  assert.equal(macroContext.variables.payload, undefined);
+  assert.equal(previewResolved[1]?.entry.content, "");
+  const selected = resolveAndBudgetActivatedLorebookEntries(
+    previewResolved,
+    new Map([["book-1", makeLorebook({ tokenBudget: 100 })]]),
+    5,
+    10,
+    resolveActual,
+  );
+
+  assert.deepEqual(
+    selected.map((entry) => entry.entry.id),
+    ["setter"],
+  );
+  assert.equal(macroContext.variables.payload, longPayload);
+  assert.equal(selected[0]?.entry.content, "");
+});
+
+test("lorebook macro side effects resolve in final injection order", () => {
+  const macroContext: MacroContext = {
+    user: "User",
+    char: "Char",
+    characters: ["Char"],
+    variables: {},
+  };
+  const resolveActual = (value: string) => {
+    const before = { ...macroContext.variables };
+    const content = resolveMacros(value, macroContext, { trimResult: false });
+    let settled = false;
+    return {
+      content,
+      commit: () => {
+        settled = true;
+      },
+      rollback: () => {
+        if (settled) return;
+        macroContext.variables = before;
+        settled = true;
+      },
+    };
+  };
+  const activated: ActivatedEntry[] = [
+    {
+      entry: makeEntry({
+        id: "reader",
+        constant: true,
+        content: "Reader sees {{getvar::tone}}",
+        order: 20,
+      }),
+      matchedKeys: ["[constant]"],
+      injectionOrder: 20,
+    },
+    {
+      entry: makeEntry({
+        id: "setter",
+        content: "{{setvar::tone::scarlet}}",
+        order: 10,
+      }),
+      matchedKeys: ["keyword"],
+      injectionOrder: 10,
+    },
+  ];
+
+  const selected = resolveAndBudgetActivatedLorebookEntries(
+    activated,
+    new Map([["book-1", makeLorebook({ tokenBudget: 100 })]]),
+    100,
+    10,
+    resolveActual,
+  );
+
+  assert.deepEqual(
+    selected.map((entry) => entry.entry.id),
+    ["setter", "reader"],
+  );
+  assert.equal(selected[1]?.entry.content, "Reader sees scarlet");
+  assert.equal(macroContext.variables.tone, "scarlet");
+});
+
+test("constant lorebook entries keep selection priority while macros resolve in injection order", () => {
+  const macroContext: MacroContext = {
+    user: "User",
+    char: "Char",
+    characters: ["Char"],
+    variables: {},
+  };
+  const resolveActual = (value: string) => {
+    const before = { ...macroContext.variables };
+    const content = resolveMacros(value, macroContext, { trimResult: false });
+    let settled = false;
+    return {
+      content,
+      commit: () => {
+        settled = true;
+      },
+      rollback: () => {
+        if (settled) return;
+        macroContext.variables = before;
+        settled = true;
+      },
+    };
+  };
+  const activated: ActivatedEntry[] = [
+    {
+      entry: makeEntry({
+        id: "setter",
+        content: "{{setvar::tone::scarlet}}",
+        order: 10,
+      }),
+      matchedKeys: ["keyword"],
+      injectionOrder: 10,
+    },
+    {
+      entry: makeEntry({
+        id: "reader",
+        constant: true,
+        content: "Reader sees {{getvar::tone}}",
+        order: 20,
+      }),
+      matchedKeys: ["[constant]"],
+      injectionOrder: 20,
+    },
+    {
+      entry: makeEntry({
+        id: "extra",
+        content: "Extra keyword lore",
+        order: 30,
+      }),
+      matchedKeys: ["keyword"],
+      injectionOrder: 30,
+    },
+  ];
+
+  const selected = resolveAndBudgetActivatedLorebookEntries(
+    activated,
+    new Map([["book-1", makeLorebook({ tokenBudget: 100 })]]),
+    100,
+    2,
+    resolveActual,
+  );
+
+  assert.deepEqual(
+    selected.map((entry) => entry.entry.id),
+    ["setter", "reader"],
+  );
+  assert.equal(selected[1]?.entry.content, "Reader sees scarlet");
+  assert.equal(macroContext.variables.tone, "scarlet");
+});
+
+test("macro-aware lorebook max-entry selection keeps constants before lower-order keywords", () => {
+  const activated: ActivatedEntry[] = [
+    {
+      entry: makeEntry({
+        id: "keyword",
+        content: "Keyword lore",
+        order: 10,
+      }),
+      matchedKeys: ["keyword"],
+      injectionOrder: 10,
+    },
+    {
+      entry: makeEntry({
+        id: "constant",
+        constant: true,
+        content: "Constant lore",
+        order: 20,
+      }),
+      matchedKeys: ["[constant]"],
+      injectionOrder: 20,
+    },
+  ];
+
+  const selected = resolveAndBudgetActivatedLorebookEntries(
+    activated,
+    new Map([["book-1", makeLorebook({ tokenBudget: 100 })]]),
+    100,
+    1,
+  );
+
+  assert.deepEqual(
+    selected.map((entry) => entry.entry.id),
+    ["constant"],
+  );
+});
+
+test("recursive lorebook scans use macro-expanded activated entry content", () => {
+  const activated = resolveBudgetAndRecursivelyActivateLorebookEntries(
+    [{ role: "user", content: "first-key" }],
+    [
+      makeEntry({ id: "entry-a", keys: ["first-key"], content: "{{description}}" }),
+      makeEntry({ id: "entry-b", keys: ["nested-key"], content: "Nested lore" }),
+    ],
+    {},
+    3,
+    new Map([["book-1", makeLorebook({ tokenBudget: 100 })]]),
+    100,
+    10,
+    (value) => value.replace("{{description}}", "nested-key"),
+  );
+
+  assert.deepEqual(
+    activated.map((entry) => entry.entry.id),
+    ["entry-a", "entry-b"],
+  );
+  assert.equal(activated[0]?.entry.content, "nested-key");
+});
+
+test("recursive lorebook scans reuse the selected final macro content", () => {
+  let randomMacroResolutions = 0;
+  const activated = resolveBudgetAndRecursivelyActivateLorebookEntries(
+    [{ role: "user", content: "first-key" }],
+    [
+      makeEntry({ id: "entry-a", keys: ["first-key"], content: "{{random::dragon::castle}}", order: 100 }),
+      makeEntry({ id: "entry-b", keys: ["dragon"], content: "Dragon lore", order: 200 }),
+      makeEntry({ id: "entry-c", keys: ["castle"], content: "Castle lore", order: 300 }),
+    ],
+    {},
+    3,
+    new Map([["book-1", makeLorebook({ tokenBudget: 100 })]]),
+    100,
+    10,
+    (value) => {
+      if (value !== "{{random::dragon::castle}}") return value;
+      randomMacroResolutions++;
+      return {
+        content: randomMacroResolutions === 1 ? "dragon" : "castle",
+        commit: () => {},
+        rollback: () => {},
+      };
+    },
+  );
+
+  assert.deepEqual(
+    activated.map((entry) => entry.entry.id),
+    ["entry-a", "entry-b"],
+  );
+  assert.equal(activated[0]?.entry.content, "dragon");
+  assert.equal(randomMacroResolutions, 1);
+});
+
+test("multiple lorebook markers share one macro side-effect pass per prompt assembly", async () => {
+  const client = createClient({ url: "file::memory:" });
+  const db = drizzle(client) as unknown as DB;
+
+  try {
+    await runMigrations(db);
+
+    await db.insert(lorebooks).values({
+      id: "book-1",
+      name: "World Info",
+      description: "",
+      category: "world",
+      scanDepth: 2,
+      tokenBudget: 2048,
+      recursiveScanning: "false",
+      maxRecursionDepth: 3,
+      characterId: null,
+      personaId: null,
+      chatId: null,
+      isGlobal: "true",
+      enabled: "true",
+      tags: "[]",
+      generatedBy: null,
+      sourceAgentId: null,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    });
+    await db.insert(lorebookEntries).values([
+      dbLorebookEntry("before-entry", {
+        content: "Before {{incvar::markerSmoke}}{{getvar::markerSmoke}}",
+        position: 0,
+        order: 10,
+      }),
+      dbLorebookEntry("after-entry", {
+        content: "After {{incvar::markerSmoke}}{{getvar::markerSmoke}}",
+        position: 1,
+        order: 20,
+      }),
+    ]);
+
+    const result = await assemblePrompt({
+      db,
+      preset: {
+        id: "preset-1",
+        name: "Preset",
+        sectionOrder: JSON.stringify(["before-section", "after-section"]),
+        groupOrder: "[]",
+        wrapFormat: "none",
+        parameters: JSON.stringify(DEFAULT_GENERATION_PARAMS),
+        variableGroups: "[]",
+        variableValues: "{}",
+      },
+      sections: [
+        {
+          id: "before-section",
+          presetId: "preset-1",
+          identifier: "before",
+          name: "Before",
+          content: "",
+          role: "system",
+          enabled: "true",
+          isMarker: "true",
+          groupId: null,
+          markerConfig: JSON.stringify({ type: "world_info_before" }),
+          injectionPosition: "ordered",
+          injectionDepth: 0,
+          injectionOrder: 0,
+          forbidOverrides: "false",
+        },
+        {
+          id: "after-section",
+          presetId: "preset-1",
+          identifier: "after",
+          name: "After",
+          content: "",
+          role: "system",
+          enabled: "true",
+          isMarker: "true",
+          groupId: null,
+          markerConfig: JSON.stringify({ type: "world_info_after" }),
+          injectionPosition: "ordered",
+          injectionDepth: 0,
+          injectionOrder: 1,
+          forbidOverrides: "false",
+        },
+      ],
+      groups: [],
+      choiceBlocks: [],
+      chatChoices: {},
+      chatId: "chat-1",
+      characterIds: [],
+      personaName: "User",
+      personaDescription: "",
+      chatMessages: [{ role: "user", content: "marker-key" }],
+      activeLorebookIds: [],
+    });
+
+    const content = result.messages.map((message) => message.content).join("\n");
+    assert.match(content, /Before 1/);
+    assert.match(content, /After 2/);
+    assert.doesNotMatch(content, /After 4/);
+  } finally {
+    client.close();
+  }
+});
 
 test("entries inherit their lorebook scan depth when no per-entry override is set", () => {
   const entry = makeEntry();

--- a/packages/server/test/regex-application.test.ts
+++ b/packages/server/test/regex-application.test.ts
@@ -1,0 +1,87 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { resolveMacros, type MacroContext } from "@marinara-engine/shared";
+import { applyRegexScriptsToPromptText } from "../src/services/regex/regex-application.js";
+
+function macroContext(): MacroContext {
+  return {
+    user: "Rhea",
+    char: "Ari",
+    characters: ["Ari"],
+    variables: {},
+  };
+}
+
+function resolvePromptMacros(value: string): string {
+  return resolveMacros(value, macroContext(), { trimResult: false });
+}
+
+test("regex prompt application resolves macros in find, replace, and trim strings", () => {
+  const result = applyRegexScriptsToPromptText(
+    "Hello Ari!",
+    [
+      {
+        enabled: true,
+        placement: ["ai_output"],
+        findRegex: "{{char}}",
+        replaceString: "{{user}}",
+        flags: "g",
+        trimStrings: ["Hello {{user}}"],
+      },
+    ],
+    "ai_output",
+    0,
+    { resolveMacros: resolvePromptMacros },
+  );
+
+  assert.equal(result, "!");
+});
+
+test("regex replacement macros resolve once per matched replacement", () => {
+  let replacementCalls = 0;
+  const result = applyRegexScriptsToPromptText(
+    "Ari Ari",
+    [
+      {
+        enabled: true,
+        placement: ["ai_output"],
+        findRegex: "{{char}}",
+        replaceString: "{{random}}",
+        flags: "g",
+      },
+    ],
+    "ai_output",
+    0,
+    {
+      resolveMacros: (value) => {
+        if (value === "{{char}}") return "Ari";
+        if (value === "{{random}}") return String(++replacementCalls);
+        return value;
+      },
+    },
+  );
+
+  assert.equal(result, "1 2");
+  assert.equal(replacementCalls, 2);
+});
+
+test("regex replacement macros can share state across matched replacements", () => {
+  const ctx = macroContext();
+  const result = applyRegexScriptsToPromptText(
+    "TOKEN TOKEN TOKEN",
+    [
+      {
+        enabled: true,
+        placement: ["ai_output"],
+        findRegex: "TOKEN",
+        replaceString: "[{{incvar::rx_smoke}}/{{getvar::rx_smoke}}]",
+        flags: "g",
+      },
+    ],
+    "ai_output",
+    0,
+    { resolveMacros: (value) => resolveMacros(value, ctx, { trimResult: false }) },
+  );
+
+  assert.equal(result, "[/1] [/2] [/3]");
+});

--- a/packages/shared/src/utils/regex-replacement.ts
+++ b/packages/shared/src/utils/regex-replacement.ts
@@ -129,7 +129,12 @@ export function expandRegexReplacement(replacement: string, ctx: RegexReplaceMat
   return result;
 }
 
-export function applyRegexReplacement(text: string, regex: RegExp, replacement: string): string {
+export function applyRegexReplacement(
+  text: string,
+  regex: RegExp,
+  replacement: string,
+  resolveReplacement?: (replacement: string) => string,
+): string {
   return text.replace(regex, (...args: unknown[]) => {
     const hasGroups = typeof args.at(-1) === "object" && args.at(-1) !== null;
     const groups = hasGroups ? (args.at(-1) as Record<string, string>) : undefined;
@@ -137,6 +142,12 @@ export function applyRegexReplacement(text: string, regex: RegExp, replacement: 
     const offset = args.at(hasGroups ? -3 : -2) as number;
     const match = args[0] as string;
     const captures = args.slice(1, hasGroups ? -3 : -2).map((capture) => (capture == null ? "" : String(capture)));
-    return expandRegexReplacement(replacement, { match, captures, offset, input, groups });
+    return expandRegexReplacement(resolveReplacement ? resolveReplacement(replacement) : replacement, {
+      match,
+      captures,
+      offset,
+      input,
+      groups,
+    });
   });
 }


### PR DESCRIPTION
## Linked issue

#738 

## Why this change

- Lorebook entries and regex scripts now support prompt macros, but several paths either left macro text unresolved or resolved it at the wrong point in the prompt pipeline.
- That could make lorebook budgets inaccurate, recursive activation disagree with final prompt text, regex replacements run with literal macro text, or macro side effects commit in the wrong order.

## What changed

- Resolve lorebook entry content before final budgeting and token estimates, while preserving constant-entry selection priority.
- Commit selected lorebook macro side effects in final injection order so variable macros behave like the prompt that is sent.
- Reuse selected/resolved lorebook content for recursive scans and active world-info display.
- Resolve regex macros in find, replacement, and trim strings on server and client paths, including user-input draft context for `{{input}}`.
- Update the regex editor live test to resolve macros against sample User/Character context.
- Add focused lorebook and regex regression tests.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

Automated/local validation run by Codex:

- `pnpm --filter @marinara-engine/server exec tsx --import ./test/setup-env.ts --test test/lorebook-processing.test.ts test/regex-application.test.ts` passed, 30 tests.
- `pnpm --filter @marinara-engine/client lint` passed.
- `pnpm check` passed.
- `git diff --check` passed with only line-ending normalization warnings.
- Server touched-area `console.` scan found no matches.

- Verified through recursive lorebook testing, manual variable lorebook testing, and regex macro live testing. All gave expected results.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs or release/version files were changed in this branch.

## UI evidence (if applicable)

Not included yet. The regex editor live-test behavior should get a quick manual browser check before marking this ready for review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Regex script editor now supports macro-aware live testing with runtime value resolution.
  * Macros in regex find/replace patterns are now resolved contextually during script application.
  * Lorebook entries now support macro resolution with proper context awareness.

* **Improvements**
  * Enhanced macro resolution consistency across chat messages, input fields, and game narration.
  * Macro resolution now integrates with regex script processing for unified variable handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/736)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->