### PR TITLE
feat(connections): add folders for organising API connections

### DIFF
--- a/packages/client/src/components/panels/ConnectionsPanel.tsx
+++ b/packages/client/src/components/panels/ConnectionsPanel.tsx
@@ -1,19 +1,34 @@
 // ──────────────────────────────────────────────
-// Panel: API Connections (polished)
+// Panel: API Connections (polished, with folders)
 // ──────────────────────────────────────────────
 import { useState, useEffect, useMemo } from "react";
+import { Reorder, useDragControls } from "framer-motion";
 import {
   useConnections,
   useDuplicateConnection,
   useDeleteConnection,
   useUpdateConnection,
 } from "../../hooks/use-connections";
+import {
+  useConnectionFolders,
+  useCreateConnectionFolder,
+  useUpdateConnectionFolder,
+  useDeleteConnectionFolder,
+  useReorderConnectionFolders,
+  useMoveConnection,
+} from "../../hooks/use-connection-folders";
 import { useAgentConfigs, useCreateAgent, useUpdateAgent } from "../../hooks/use-agents";
 import { useChatStore } from "../../stores/chat.store";
 import { useUIStore } from "../../stores/ui.store";
 import { useSidecarStore } from "../../stores/sidecar.store";
-import { BUILT_IN_AGENTS, LOCAL_SIDECAR_CONNECTION_ID, getDefaultAgentPrompt } from "@marinara-engine/shared";
+import {
+  BUILT_IN_AGENTS,
+  LOCAL_SIDECAR_CONNECTION_ID,
+  getDefaultAgentPrompt,
+  type ConnectionFolder,
+} from "@marinara-engine/shared";
 import { showConfirmDialog } from "../../lib/app-dialogs";
+import { Modal } from "../ui/Modal";
 import {
   Plus,
   Trash2,
@@ -27,6 +42,11 @@ import {
   Settings2,
   ChevronDown,
   ChevronUp,
+  ChevronRight,
+  FolderPlus,
+  FolderOpen,
+  GripVertical,
+  Pencil,
 } from "lucide-react";
 import { cn } from "../../lib/utils";
 import { toast } from "sonner";
@@ -283,11 +303,245 @@ function SidecarCard() {
   );
 }
 
-export function ConnectionsPanel() {
-  const { data: connections, isLoading } = useConnections();
+type ConnectionRowData = {
+  id: string;
+  name: string;
+  provider: string;
+  model: string;
+  useForRandom?: string;
+  folderId?: string | null;
+};
+
+function ConnectionRow({
+  conn,
+  isSelected,
+  onClickRow,
+  onMove,
+  showMoveButton,
+}: {
+  conn: ConnectionRowData;
+  isSelected: boolean;
+  onClickRow: () => void;
+  onMove: () => void;
+  showMoveButton: boolean;
+}) {
   const duplicateConnection = useDuplicateConnection();
   const deleteConnection = useDeleteConnection();
   const updateConnection = useUpdateConnection();
+  const openConnectionDetail = useUIStore((s) => s.openConnectionDetail);
+
+  const inRandomPool = conn.useForRandom === "true";
+  const colors = PROVIDER_COLORS[conn.provider] ?? DEFAULT_COLOR;
+
+  return (
+    <div
+      onClick={onClickRow}
+      className={cn(
+        "group relative flex cursor-pointer items-center gap-3 rounded-xl p-2.5 transition-all hover:bg-[var(--sidebar-accent)]",
+        isSelected && `ring-1 ${colors.ring} bg-[var(--sidebar-accent)]/50`,
+      )}
+    >
+      <div
+        className={cn(
+          "relative flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br text-white shadow-sm",
+          colors.from,
+          colors.to,
+        )}
+      >
+        <Link size="1rem" />
+        {isSelected && (
+          <div
+            className={cn(
+              "absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-full shadow-sm",
+              colors.badge,
+            )}
+          >
+            <Check size="0.625rem" className="text-white" />
+          </div>
+        )}
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-sm font-medium" title={conn.name}>
+          {conn.name}
+        </div>
+        <div className="truncate text-[0.6875rem] text-[var(--muted-foreground)]">
+          {conn.provider} • {conn.model || "No model set"}
+        </div>
+      </div>
+      <div className="absolute right-2 top-1/2 -translate-y-1/2 flex shrink-0 items-center gap-0.5 rounded-lg bg-[var(--sidebar)] px-1 py-0.5 opacity-0 shadow-sm ring-1 ring-[var(--border)] transition-opacity group-hover:opacity-100 max-md:opacity-100">
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            updateConnection.mutate({ id: conn.id, useForRandom: !inRandomPool });
+          }}
+          className={cn(
+            "rounded-lg p-1.5 transition-all active:scale-90",
+            inRandomPool
+              ? "bg-amber-400/15 text-amber-400"
+              : "text-[var(--muted-foreground)] hover:bg-amber-400/10 hover:text-amber-400",
+          )}
+          title={inRandomPool ? "In random pool (click to remove)" : "Add to random pool"}
+        >
+          <Shuffle size="0.75rem" />
+        </button>
+        {showMoveButton && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onMove();
+            }}
+            className="rounded-lg p-1.5 text-[var(--muted-foreground)] transition-all hover:bg-[var(--accent)] hover:text-[var(--foreground)] active:scale-90"
+            title="Move to folder"
+          >
+            <FolderOpen size="0.75rem" />
+          </button>
+        )}
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            duplicateConnection.mutate(conn.id, {
+              onSuccess: (data: any) => {
+                if (data?.id) openConnectionDetail(data.id);
+              },
+            });
+          }}
+          className="rounded-lg p-1.5 text-[var(--muted-foreground)] transition-all hover:bg-sky-400/10 hover:text-sky-400 active:scale-90"
+          title="Duplicate"
+        >
+          <Copy size="0.75rem" />
+        </button>
+        <button
+          onClick={async (e) => {
+            e.stopPropagation();
+            if (
+              !(await showConfirmDialog({
+                title: "Delete Connection",
+                message: `Delete "${conn.name}"? This cannot be undone.`,
+                confirmLabel: "Delete",
+                tone: "destructive",
+              }))
+            ) {
+              return;
+            }
+            deleteConnection.mutate(conn.id);
+          }}
+          className="rounded-lg p-1.5 transition-all hover:bg-[var(--destructive)]/15 active:scale-90"
+          title="Delete"
+        >
+          <Trash2 size="0.75rem" className="text-[var(--destructive)]" />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function ConnectionFolderRow({
+  folder,
+  entries,
+  renderConnectionRow,
+  onToggleCollapse,
+  onRename,
+  onDelete,
+}: {
+  folder: ConnectionFolder;
+  entries: ConnectionRowData[];
+  renderConnectionRow: (conn: ConnectionRowData) => React.ReactNode;
+  onToggleCollapse: (folder: ConnectionFolder) => void;
+  onRename: (id: string, name: string) => void;
+  onDelete: (folder: ConnectionFolder) => void;
+}) {
+  const dragControls = useDragControls();
+  const [renaming, setRenaming] = useState(false);
+  const [renameValue, setRenameValue] = useState(folder.name);
+
+  return (
+    <Reorder.Item value={folder.id} dragListener={false} dragControls={dragControls} as="div" className="flex flex-col">
+      {/* Folder header */}
+      <div
+        onClick={() => onToggleCollapse(folder)}
+        className="group relative flex items-center gap-1.5 rounded-lg px-2 py-1.5 hover:bg-[var(--sidebar-accent)]/40"
+      >
+        <div
+          onPointerDown={(e) => dragControls.start(e)}
+          className="cursor-grab touch-none opacity-0 transition-opacity active:cursor-grabbing group-hover:opacity-100 max-md:opacity-100"
+        >
+          <GripVertical size="0.625rem" className="text-[var(--muted-foreground)]" />
+        </div>
+        <ChevronRight
+          size="0.75rem"
+          className={cn("text-[var(--muted-foreground)] transition-transform", !folder.collapsed && "rotate-90")}
+        />
+        <div
+          className="h-2 w-2 rounded-full flex-shrink-0"
+          style={{ backgroundColor: folder.color || "#6b7280" }}
+          title={folder.name}
+        />
+        {renaming ? (
+          <input
+            autoFocus
+            value={renameValue}
+            onClick={(e) => e.stopPropagation()}
+            onChange={(e) => setRenameValue(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                onRename(folder.id, renameValue);
+                setRenaming(false);
+              }
+              if (e.key === "Escape") {
+                setRenaming(false);
+                setRenameValue(folder.name);
+              }
+            }}
+            onBlur={() => {
+              onRename(folder.id, renameValue);
+              setRenaming(false);
+            }}
+            className="flex-1 bg-transparent text-xs font-medium text-[var(--foreground)] outline-none"
+          />
+        ) : (
+          <span className="flex-1 cursor-pointer truncate text-xs font-medium text-[var(--muted-foreground)]">
+            {folder.name}
+          </span>
+        )}
+        {entries.length > 0 && (
+          <span className="text-[0.5625rem] text-[var(--muted-foreground)]">{entries.length}</span>
+        )}
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            setRenameValue(folder.name);
+            setRenaming(true);
+          }}
+          className="shrink-0 rounded-md p-1 opacity-0 transition-all hover:bg-[var(--accent)] group-hover:opacity-100 max-md:opacity-100"
+          title="Rename folder"
+        >
+          <Pencil size="0.75rem" className="text-[var(--muted-foreground)]" />
+        </button>
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onDelete(folder);
+          }}
+          className="shrink-0 rounded-md p-1 opacity-0 transition-all hover:bg-[var(--destructive)]/20 group-hover:opacity-100 max-md:opacity-100"
+          title="Delete folder"
+        >
+          <Trash2 size="0.75rem" className="text-[var(--destructive)]" />
+        </button>
+      </div>
+      {/* Folder contents */}
+      {!folder.collapsed && entries.length > 0 && (
+        <div className="ml-4 flex flex-col gap-0.5 border-l border-[var(--border)]/20 pl-1">
+          {entries.map((c) => (
+            <div key={c.id}>{renderConnectionRow(c)}</div>
+          ))}
+        </div>
+      )}
+    </Reorder.Item>
+  );
+}
+
+export function ConnectionsPanel() {
+  const { data: connections, isLoading } = useConnections();
   const activeChat = useChatStore((s) => s.activeChat);
 
   const activeConnectionId = activeChat?.connectionId ?? null;
@@ -295,6 +549,119 @@ export function ConnectionsPanel() {
   const openModal = useUIStore((s) => s.openModal);
   const linkApiBannerDismissed = useUIStore((s) => s.linkApiBannerDismissed);
   const dismissLinkApiBanner = useUIStore((s) => s.dismissLinkApiBanner);
+
+  // Folder hooks
+  const { data: folders } = useConnectionFolders();
+  const createFolderMut = useCreateConnectionFolder();
+  const updateFolderMut = useUpdateConnectionFolder();
+  const deleteFolderMut = useDeleteConnectionFolder();
+  const reorderFoldersMut = useReorderConnectionFolders();
+  const moveConnectionMut = useMoveConnection();
+
+  // Folder UI state
+  const [creatingFolder, setCreatingFolder] = useState(false);
+  const [newFolderName, setNewFolderName] = useState("");
+  const [movingConnectionId, setMovingConnectionId] = useState<string | null>(null);
+
+  const connectionsList = useMemo(
+    () => (connections as ConnectionRowData[] | undefined) ?? [],
+    [connections],
+  );
+
+  // Sorted folder list + local order for optimistic drag-to-reorder
+  const sortedFolders = useMemo(() => {
+    if (!folders) return [] as ConnectionFolder[];
+    return [...folders].sort((a, b) => a.sortOrder - b.sortOrder);
+  }, [folders]);
+
+  const [localFolderOrder, setLocalFolderOrder] = useState<string[]>([]);
+  useEffect(() => {
+    setLocalFolderOrder(sortedFolders.map((f) => f.id));
+  }, [sortedFolders]);
+
+  // Split connections into per-folder + unfiled buckets
+  const { unfiledConnections, folderConnectionsMap } = useMemo(() => {
+    const unfiled: ConnectionRowData[] = [];
+    const map = new Map<string, ConnectionRowData[]>();
+    for (const c of connectionsList) {
+      const fid = c.folderId ?? null;
+      if (fid && sortedFolders.some((f) => f.id === fid)) {
+        const arr = map.get(fid) ?? [];
+        arr.push(c);
+        map.set(fid, arr);
+      } else {
+        unfiled.push(c);
+      }
+    }
+    return { unfiledConnections: unfiled, folderConnectionsMap: map };
+  }, [connectionsList, sortedFolders]);
+
+  const handleCreateFolder = () => {
+    const name = newFolderName.trim();
+    if (!name) {
+      setCreatingFolder(false);
+      setNewFolderName("");
+      return;
+    }
+    createFolderMut.mutate(
+      { name },
+      {
+        onSuccess: () => {
+          setNewFolderName("");
+          setCreatingFolder(false);
+        },
+      },
+    );
+  };
+
+  const handleFolderReorder = (newOrder: string[]) => {
+    setLocalFolderOrder(newOrder);
+    reorderFoldersMut.mutate(newOrder);
+  };
+
+  const handleToggleCollapse = (folder: ConnectionFolder) => {
+    updateFolderMut.mutate({ id: folder.id, collapsed: !folder.collapsed });
+  };
+
+  const handleRenameFolder = (id: string, name: string) => {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    updateFolderMut.mutate({ id, name: trimmed });
+  };
+
+  const handleDeleteFolder = async (folder: ConnectionFolder) => {
+    const ok = await showConfirmDialog({
+      title: "Delete Folder",
+      message: `Delete folder "${folder.name}"? Connections inside will move back to Unfiled.`,
+      confirmLabel: "Delete",
+      tone: "destructive",
+    });
+    if (!ok) return;
+    deleteFolderMut.mutate(folder.id);
+  };
+
+  const handleMoveConnection = (connectionId: string, folderId: string | null) => {
+    moveConnectionMut.mutate({ connectionId, folderId });
+    setMovingConnectionId(null);
+  };
+
+  const renderConnectionRow = (conn: ConnectionRowData) => {
+    const isSelected = activeConnectionId === conn.id;
+    return (
+      <ConnectionRow
+        key={conn.id}
+        conn={conn}
+        isSelected={isSelected}
+        onClickRow={() => openConnectionDetail(conn.id)}
+        onMove={() => setMovingConnectionId(conn.id)}
+        showMoveButton={sortedFolders.length > 0}
+      />
+    );
+  };
+
+  const movingConnection = movingConnectionId
+    ? connectionsList.find((c) => c.id === movingConnectionId) ?? null
+    : null;
 
   return (
     <div className="flex flex-col gap-2 p-3">
@@ -311,6 +678,42 @@ export function ConnectionsPanel() {
         <Plus size="0.8125rem" />
         Add Connection
       </button>
+
+      {/* ── New folder button / inline input ── */}
+      {creatingFolder ? (
+        <div className="flex items-center gap-1.5 rounded-lg border border-[var(--border)]/40 bg-[var(--secondary)]/30 px-2.5 py-1.5">
+          <FolderPlus size="0.75rem" className="text-[var(--muted-foreground)]" />
+          <input
+            autoFocus
+            value={newFolderName}
+            onChange={(e) => setNewFolderName(e.target.value)}
+            placeholder="Folder name"
+            onKeyDown={(e) => {
+              if (e.key === "Enter") handleCreateFolder();
+              if (e.key === "Escape") {
+                setCreatingFolder(false);
+                setNewFolderName("");
+              }
+            }}
+            onBlur={() => {
+              if (newFolderName.trim()) handleCreateFolder();
+              else {
+                setCreatingFolder(false);
+                setNewFolderName("");
+              }
+            }}
+            className="flex-1 bg-transparent text-xs text-[var(--foreground)] outline-none placeholder:text-[var(--muted-foreground)]"
+          />
+        </div>
+      ) : (
+        <button
+          onClick={() => setCreatingFolder(true)}
+          className="flex items-center justify-center gap-1.5 rounded-lg px-2.5 py-1.5 text-[0.6875rem] text-[var(--muted-foreground)] transition-all hover:bg-[var(--sidebar-accent)]/40 hover:text-[var(--foreground)]"
+        >
+          <FolderPlus size="0.75rem" />
+          New Folder
+        </button>
+      )}
 
       {isLoading && (
         <div className="flex flex-col gap-2 py-2">
@@ -365,109 +768,80 @@ export function ConnectionsPanel() {
         </div>
       )}
 
+      {/* Folders (drag-to-reorder) */}
+      {localFolderOrder.length > 0 && (
+        <Reorder.Group
+          axis="y"
+          values={localFolderOrder}
+          onReorder={handleFolderReorder}
+          as="div"
+          className="flex flex-col gap-0.5 mt-1"
+        >
+          {localFolderOrder.map((folderId) => {
+            const folder = sortedFolders.find((f) => f.id === folderId);
+            if (!folder) return null;
+            const folderEntries = folderConnectionsMap.get(folderId) ?? [];
+            return (
+              <ConnectionFolderRow
+                key={folderId}
+                folder={folder}
+                entries={folderEntries}
+                renderConnectionRow={renderConnectionRow}
+                onToggleCollapse={handleToggleCollapse}
+                onRename={handleRenameFolder}
+                onDelete={handleDeleteFolder}
+              />
+            );
+          })}
+        </Reorder.Group>
+      )}
+
+      {/* Unfiled connections */}
       <div className="stagger-children flex flex-col gap-1">
-        {(
-          connections as Array<{ id: string; name: string; provider: string; model: string; useForRandom?: string }>
-        )?.map((conn) => {
-          const isSelected = activeConnectionId === conn.id;
-          const inRandomPool = conn.useForRandom === "true";
-          const colors = PROVIDER_COLORS[conn.provider] ?? DEFAULT_COLOR;
-          return (
-            <div
-              key={conn.id}
-              onClick={() => openConnectionDetail(conn.id)}
-              className={cn(
-                "group relative flex cursor-pointer items-center gap-3 rounded-xl p-2.5 transition-all hover:bg-[var(--sidebar-accent)]",
-                isSelected && `ring-1 ${colors.ring} bg-[var(--sidebar-accent)]/50`,
-              )}
-            >
-              <div
-                className={cn(
-                  "relative flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br text-white shadow-sm",
-                  colors.from,
-                  colors.to,
-                )}
-              >
-                <Link size="1rem" />
-                {isSelected && (
-                  <div
-                    className={cn(
-                      "absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-full shadow-sm",
-                      colors.badge,
-                    )}
-                  >
-                    <Check size="0.625rem" className="text-white" />
-                  </div>
-                )}
-              </div>
-              <div className="min-w-0 flex-1">
-                <div className="truncate text-sm font-medium" title={conn.name}>
-                  {conn.name}
-                </div>
-                <div className="truncate text-[0.6875rem] text-[var(--muted-foreground)]">
-                  {conn.provider} • {conn.model || "No model set"}
-                </div>
-              </div>
-              <div className="absolute right-2 top-1/2 -translate-y-1/2 flex shrink-0 items-center gap-0.5 rounded-lg bg-[var(--sidebar)] px-1 py-0.5 opacity-0 shadow-sm ring-1 ring-[var(--border)] transition-opacity group-hover:opacity-100 max-md:opacity-100">
-                <button
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    updateConnection.mutate({ id: conn.id, useForRandom: !inRandomPool });
-                  }}
-                  className={cn(
-                    "rounded-lg p-1.5 transition-all active:scale-90",
-                    inRandomPool
-                      ? "bg-amber-400/15 text-amber-400"
-                      : "text-[var(--muted-foreground)] hover:bg-amber-400/10 hover:text-amber-400",
-                  )}
-                  title={inRandomPool ? "In random pool (click to remove)" : "Add to random pool"}
-                >
-                  <Shuffle size="0.75rem" />
-                </button>
-                <button
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    duplicateConnection.mutate(conn.id, {
-                      onSuccess: (data: any) => {
-                        if (data?.id) openConnectionDetail(data.id);
-                      },
-                    });
-                  }}
-                  className="rounded-lg p-1.5 text-[var(--muted-foreground)] transition-all hover:bg-sky-400/10 hover:text-sky-400 active:scale-90"
-                  title="Duplicate"
-                >
-                  <Copy size="0.75rem" />
-                </button>
-                <button
-                  onClick={async (e) => {
-                    e.stopPropagation();
-                    if (
-                      !(await showConfirmDialog({
-                        title: "Delete Connection",
-                        message: `Delete "${conn.name}"? This cannot be undone.`,
-                        confirmLabel: "Delete",
-                        tone: "destructive",
-                      }))
-                    ) {
-                      return;
-                    }
-                    deleteConnection.mutate(conn.id);
-                  }}
-                  className="rounded-lg p-1.5 transition-all hover:bg-[var(--destructive)]/15 active:scale-90"
-                  title="Delete"
-                >
-                  <Trash2 size="0.75rem" className="text-[var(--destructive)]" />
-                </button>
-              </div>
-            </div>
-          );
-        })}
+        {unfiledConnections.map(renderConnectionRow)}
       </div>
+
       {activeChat && (
         <p className="px-1 text-[0.625rem] text-[var(--muted-foreground)]/60">
           Click to edit · Set active connection in Chat Settings
         </p>
       )}
+
+      {/* ── Move to Folder Modal ── */}
+      <Modal
+        open={movingConnectionId !== null}
+        onClose={() => setMovingConnectionId(null)}
+        title="Move to Folder"
+        width="max-w-xs"
+      >
+        {movingConnection && (
+          <div className="flex flex-col gap-1">
+            <button
+              onClick={() => handleMoveConnection(movingConnection.id, null)}
+              className={cn(
+                "flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-left text-xs transition-all hover:bg-[var(--accent)]",
+                !movingConnection.folderId && "bg-[var(--accent)] font-medium",
+              )}
+            >
+              <Link size="0.75rem" className="text-[var(--muted-foreground)]" />
+              Unfiled
+            </button>
+            {sortedFolders.map((f) => (
+              <button
+                key={f.id}
+                onClick={() => handleMoveConnection(movingConnection.id, f.id)}
+                className={cn(
+                  "flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-left text-xs transition-all hover:bg-[var(--accent)]",
+                  movingConnection.folderId === f.id && "bg-[var(--accent)] font-medium",
+                )}
+              >
+                <div className="h-2 w-2 rounded-full flex-shrink-0" style={{ backgroundColor: f.color || "#6b7280" }} />
+                {f.name}
+              </button>
+            ))}
+          </div>
+        )}
+      </Modal>
     </div>
   );
 }

--- a/packages/client/src/hooks/use-connection-folders.ts
+++ b/packages/client/src/hooks/use-connection-folders.ts
@@ -1,0 +1,75 @@
+// ──────────────────────────────────────────────
+// React Query: Connection Folder hooks
+// ──────────────────────────────────────────────
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "../lib/api-client";
+import type { ConnectionFolder } from "@marinara-engine/shared";
+import { connectionKeys } from "./use-connections";
+
+export const connectionFolderKeys = {
+  all: ["connection-folders"] as const,
+  list: () => [...connectionFolderKeys.all, "list"] as const,
+};
+
+export function useConnectionFolders() {
+  return useQuery({
+    queryKey: connectionFolderKeys.list(),
+    queryFn: () => api.get<ConnectionFolder[]>("/connection-folders"),
+    staleTime: 2 * 60_000,
+  });
+}
+
+export function useCreateConnectionFolder() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: { name: string; color?: string }) =>
+      api.post<ConnectionFolder>("/connection-folders", data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: connectionFolderKeys.list() }),
+  });
+}
+
+export function useUpdateConnectionFolder() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      id,
+      ...data
+    }: {
+      id: string;
+      name?: string;
+      color?: string;
+      sortOrder?: number;
+      collapsed?: boolean;
+    }) => api.patch<ConnectionFolder>(`/connection-folders/${id}`, data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: connectionFolderKeys.list() }),
+  });
+}
+
+export function useDeleteConnectionFolder() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => api.delete(`/connection-folders/${id}`),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: connectionFolderKeys.list() });
+      qc.invalidateQueries({ queryKey: connectionKeys.list() });
+    },
+  });
+}
+
+export function useReorderConnectionFolders() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (orderedIds: string[]) =>
+      api.post("/connection-folders/reorder", { orderedIds }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: connectionFolderKeys.list() }),
+  });
+}
+
+export function useMoveConnection() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: { connectionId: string; folderId: string | null }) =>
+      api.post("/connection-folders/move-connection", data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: connectionKeys.list() }),
+  });
+}

--- a/packages/server/src/db/file-backed-store.ts
+++ b/packages/server/src/db/file-backed-store.ts
@@ -182,6 +182,7 @@ export const FILE_BACKED_TABLES = [
   "conversation_notes",
   "memory_chunks",
   "chat_folders",
+  "api_connection_folders",
   "custom_themes",
   "app_settings",
   "chat_presets",

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -423,6 +423,15 @@ const CREATE_TABLES: string[] = [
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL
   )`,
+  `CREATE TABLE IF NOT EXISTS api_connection_folders (
+    id TEXT PRIMARY KEY NOT NULL,
+    name TEXT NOT NULL,
+    color TEXT NOT NULL DEFAULT '',
+    sort_order INTEGER NOT NULL DEFAULT 0,
+    collapsed TEXT NOT NULL DEFAULT 'false',
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+  )`,
   `CREATE TABLE IF NOT EXISTS custom_themes (
     id TEXT PRIMARY KEY NOT NULL,
     name TEXT NOT NULL,
@@ -698,6 +707,16 @@ const COLUMN_MIGRATIONS: ColumnMigration[] = [
     table: "personas",
     column: "avatar_crop",
     definition: "TEXT NOT NULL DEFAULT ''",
+  },
+  {
+    table: "api_connections",
+    column: "folder_id",
+    definition: "TEXT",
+  },
+  {
+    table: "api_connections",
+    column: "sort_order",
+    definition: "INTEGER NOT NULL DEFAULT 0",
   },
 ];
 

--- a/packages/server/src/db/schema/connection-folders.ts
+++ b/packages/server/src/db/schema/connection-folders.ts
@@ -1,0 +1,14 @@
+// ──────────────────────────────────────────────
+// Schema: API Connection Folders
+// ──────────────────────────────────────────────
+import { sqliteTable, text, integer } from "drizzle-orm/sqlite-core";
+
+export const apiConnectionFolders = sqliteTable("api_connection_folders", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+  color: text("color").notNull().default(""),
+  sortOrder: integer("sort_order").notNull().default(0),
+  collapsed: text("collapsed").notNull().default("false"),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull(),
+});

--- a/packages/server/src/db/schema/connections.ts
+++ b/packages/server/src/db/schema/connections.ts
@@ -66,6 +66,10 @@ export const apiConnections = sqliteTable("api_connections", {
    * exact model chosen on the connection is what runs.
    */
   claudeFastMode: text("claude_fast_mode").notNull().default("false"),
+  /** Folder this connection belongs to (null = root/unfiled). */
+  folderId: text("folder_id"),
+  /** Manual sort order within a folder (lower = higher). 0 = use default sort. */
+  sortOrder: integer("sort_order").notNull().default(0),
   createdAt: text("created_at").notNull(),
   updatedAt: text("updated_at").notNull(),
 });

--- a/packages/server/src/db/schema/index.ts
+++ b/packages/server/src/db/schema/index.ts
@@ -7,6 +7,7 @@ export * from "./characters.js";
 export * from "./lorebooks.js";
 export * from "./prompts.js";
 export * from "./connections.js";
+export * from "./connection-folders.js";
 export * from "./assets.js";
 export * from "./agents.js";
 export * from "./custom-tools.js";

--- a/packages/server/src/routes/connection-folders.routes.ts
+++ b/packages/server/src/routes/connection-folders.routes.ts
@@ -1,0 +1,86 @@
+// ──────────────────────────────────────────────
+// Routes: API Connection Folders
+// ──────────────────────────────────────────────
+import type { FastifyInstance } from "fastify";
+import { createConnectionFoldersStorage } from "../services/storage/connection-folders.storage.js";
+
+export async function connectionFoldersRoutes(app: FastifyInstance) {
+  const storage = createConnectionFoldersStorage(app.db);
+
+  // ── List all folders ──
+  app.get("/", async (_req, reply) => {
+    const folders = await storage.list();
+    return reply.send(
+      folders.map((f) => ({
+        ...f,
+        collapsed: f.collapsed === "true",
+      })),
+    );
+  });
+
+  // ── Create a folder ──
+  app.post<{
+    Body: { name: string; color?: string };
+  }>("/", async (req, reply) => {
+    const { name, color } = req.body;
+    if (!name?.trim()) return reply.status(400).send({ error: "Name is required" });
+    const folder = await storage.create({ name: name.trim(), color });
+    return reply.send({ ...folder, collapsed: folder!.collapsed === "true" });
+  });
+
+  // ── Update a folder ──
+  app.patch<{
+    Params: { id: string };
+    Body: Partial<{ name: string; color: string; sortOrder: number; collapsed: boolean }>;
+  }>("/:id", async (req, reply) => {
+    const existing = await storage.getById(req.params.id);
+    if (!existing) return reply.status(404).send({ error: "Folder not found" });
+    const folder = await storage.update(req.params.id, req.body);
+    return reply.send({ ...folder, collapsed: folder!.collapsed === "true" });
+  });
+
+  // ── Delete a folder (connections are moved to root) ──
+  app.delete<{
+    Params: { id: string };
+  }>("/:id", async (req, reply) => {
+    const existing = await storage.getById(req.params.id);
+    if (!existing) return reply.status(404).send({ error: "Folder not found" });
+    await storage.remove(req.params.id);
+    return reply.send({ ok: true });
+  });
+
+  // ── Reorder folders ──
+  app.post<{
+    Body: { orderedIds: string[] };
+  }>("/reorder", async (req, reply) => {
+    const { orderedIds } = req.body;
+    if (!Array.isArray(orderedIds)) return reply.status(400).send({ error: "orderedIds must be an array" });
+    await storage.reorder(orderedIds);
+    return reply.send({ ok: true });
+  });
+
+  // ── Move a connection into (or out of) a folder ──
+  app.post<{
+    Body: { connectionId: string; folderId: string | null };
+  }>("/move-connection", async (req, reply) => {
+    const { connectionId, folderId } = req.body;
+    if (!connectionId) return reply.status(400).send({ error: "connectionId is required" });
+    if (folderId) {
+      const folder = await storage.getById(folderId);
+      if (!folder) return reply.status(404).send({ error: "Folder not found" });
+    }
+    await storage.moveConnection(connectionId, folderId);
+    return reply.send({ ok: true });
+  });
+
+  // ── Reorder connections within a folder (or root) ──
+  app.post<{
+    Body: { orderedConnectionIds: string[]; folderId: string | null };
+  }>("/reorder-connections", async (req, reply) => {
+    const { orderedConnectionIds, folderId } = req.body;
+    if (!Array.isArray(orderedConnectionIds))
+      return reply.status(400).send({ error: "orderedConnectionIds must be an array" });
+    await storage.reorderConnections(orderedConnectionIds, folderId);
+    return reply.send({ ok: true });
+  });
+}

--- a/packages/server/src/routes/index.ts
+++ b/packages/server/src/routes/index.ts
@@ -38,6 +38,7 @@ import { botBrowserPygmalionRoutes } from "./bot-browser-pygmalion.routes.js";
 import { botBrowserWyvernRoutes } from "./bot-browser-wyvern.routes.js";
 import { botBrowserDatacatRoutes } from "./bot-browser-datacat.routes.js";
 import { chatFoldersRoutes } from "./chat-folders.routes.js";
+import { connectionFoldersRoutes } from "./connection-folders.routes.js";
 import { chatPresetsRoutes } from "./chat-presets.routes.js";
 import { updatesRoutes } from "./updates.routes.js";
 import { themesRoutes } from "./themes.routes.js";
@@ -58,6 +59,7 @@ export async function registerRoutes(app: FastifyInstance) {
   await app.register(lorebooksRoutes, { prefix: "/api/lorebooks" });
   await app.register(promptsRoutes, { prefix: "/api/prompts" });
   await app.register(connectionsRoutes, { prefix: "/api/connections" });
+  await app.register(connectionFoldersRoutes, { prefix: "/api/connection-folders" });
   await app.register(agentsRoutes, { prefix: "/api/agents" });
   await app.register(customToolsRoutes, { prefix: "/api/custom-tools" });
   await app.register(generateRoutes, { prefix: "/api/generate" });

--- a/packages/server/src/services/storage/connection-folders.storage.ts
+++ b/packages/server/src/services/storage/connection-folders.storage.ts
@@ -1,0 +1,88 @@
+// ──────────────────────────────────────────────
+// Storage: API Connection Folders
+// ──────────────────────────────────────────────
+import { eq } from "drizzle-orm";
+import type { DB } from "../../db/connection.js";
+import { apiConnectionFolders, apiConnections } from "../../db/schema/index.js";
+import { newId, now } from "../../utils/id-generator.js";
+
+export function createConnectionFoldersStorage(db: DB) {
+  return {
+    async list() {
+      return db.select().from(apiConnectionFolders).orderBy(apiConnectionFolders.sortOrder);
+    },
+
+    async getById(id: string) {
+      const rows = await db.select().from(apiConnectionFolders).where(eq(apiConnectionFolders.id, id));
+      return rows[0] ?? null;
+    },
+
+    async create(input: { name: string; color?: string }) {
+      const id = newId();
+      const timestamp = now();
+      // Shift existing folders down and place new folder at the top.
+      const existing = await db.select().from(apiConnectionFolders);
+      for (const f of existing) {
+        await db
+          .update(apiConnectionFolders)
+          .set({ sortOrder: f.sortOrder + 1 })
+          .where(eq(apiConnectionFolders.id, f.id));
+      }
+      await db.insert(apiConnectionFolders).values({
+        id,
+        name: input.name,
+        color: input.color ?? "",
+        sortOrder: 0,
+        collapsed: "false",
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      });
+      return this.getById(id);
+    },
+
+    async update(id: string, data: Partial<{ name: string; color: string; sortOrder: number; collapsed: boolean }>) {
+      await db
+        .update(apiConnectionFolders)
+        .set({
+          ...(data.name !== undefined && { name: data.name }),
+          ...(data.color !== undefined && { color: data.color }),
+          ...(data.sortOrder !== undefined && { sortOrder: data.sortOrder }),
+          ...(data.collapsed !== undefined && { collapsed: data.collapsed ? "true" : "false" }),
+          updatedAt: now(),
+        })
+        .where(eq(apiConnectionFolders.id, id));
+      return this.getById(id);
+    },
+
+    async remove(id: string) {
+      // Unfile all connections in this folder (move back to root).
+      await db.update(apiConnections).set({ folderId: null }).where(eq(apiConnections.folderId, id));
+      await db.delete(apiConnectionFolders).where(eq(apiConnectionFolders.id, id));
+    },
+
+    async reorder(orderedIds: string[]) {
+      for (let i = 0; i < orderedIds.length; i++) {
+        await db
+          .update(apiConnectionFolders)
+          .set({ sortOrder: i, updatedAt: now() })
+          .where(eq(apiConnectionFolders.id, orderedIds[i]!));
+      }
+    },
+
+    async moveConnection(connectionId: string, folderId: string | null) {
+      await db
+        .update(apiConnections)
+        .set({ folderId, updatedAt: now() })
+        .where(eq(apiConnections.id, connectionId));
+    },
+
+    async reorderConnections(orderedIds: string[], folderId: string | null) {
+      for (let i = 0; i < orderedIds.length; i++) {
+        await db
+          .update(apiConnections)
+          .set({ sortOrder: i + 1, folderId, updatedAt: now() })
+          .where(eq(apiConnections.id, orderedIds[i]!));
+      }
+    },
+  };
+}

--- a/packages/shared/src/types/connection.ts
+++ b/packages/shared/src/types/connection.ts
@@ -58,6 +58,21 @@ export interface APIConnection {
   maxTokensOverride: number | null;
   /** Maximum number of agent LLM jobs Marinara may run at once for this connection. */
   maxParallelJobs: number;
+  /** Folder this connection belongs to (null = root/unfiled). */
+  folderId: string | null;
+  /** Manual sort order within a folder (lower = higher). 0 = use default sort. */
+  sortOrder: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** A folder for organising API connections in the Connections panel. */
+export interface ConnectionFolder {
+  id: string;
+  name: string;
+  color: string;
+  sortOrder: number;
+  collapsed: boolean;
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
## Linked issue

Closes #686

## Why this change

Users with many connections (ComfyUI workflow variants, OpenRouter / NanoGPT model sets, etc.) currently see a flat scrollable list in the Connections panel. The reporter asked for a folder system mirroring the chat-folder UX. Triage labelled it `normal-scope` and suggested reusing the app's existing folder-style interaction model, starting with the smallest first slice — which is what this PR does.

## What changed

- **New table** `api_connection_folders` (id, name, color, sort_order, collapsed, timestamps), created via the idempotent runtime migrator in `packages/server/src/db/migrate.ts`.
- **`api_connections` table** gains nullable `folder_id` and `sort_order` columns. Pure additive `ALTER TABLE ADD COLUMN` migrations — safe on existing installs, zero impact on connection selection / generation / agent code paths.
- **Server**: new `connection-folders.storage.ts` (CRUD + reorder + move) and `connection-folders.routes.ts` mounted at `/api/connection-folders` for `GET /`, `POST /`, `PATCH /:id`, `DELETE /:id`, `POST /reorder`, `POST /move-connection`, `POST /reorder-connections`.
- **Shared**: `APIConnection` gains `folderId: string | null` and `sortOrder: number`; new `ConnectionFolder` type.
- **Client**: new `use-connection-folders.ts` React Query hook module; `ConnectionsPanel.tsx` now renders folders above the unfiled list with the same `FolderRow` UX pattern used by chat folders (drag-to-reorder, expand/collapse, rename, delete). Each connection row gains a "Move to folder" pill action when at least one folder exists.
- **Color picker UI is intentionally deferred** — the `color` column is reserved so a small follow-up can add the picker without another schema change.

Out-of-scope for this PR (deferred to follow-ups): drag-to-reorder *within* a folder, batch multi-select move, color picker UI, per-folder default connection.

## Validation

- [x] ``pnpm check`` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed ``CONTRIBUTING.md``

### Manual verification notes

- Manually verify creating a folder via inline input (Enter to confirm, Esc/blur to cancel).
- Manually verify moving a connection into a folder and back to Unfiled via the FolderOpen pill action + modal picker.
- Manually verify renaming a folder (Pencil button) and deleting one (Trash button → confirm dialog → connections inside reappear under Unfiled).
- Manually verify expand/collapse and the drag-handle reorder of folders.
- Manually verify Unfiled connections render unchanged when zero folders exist (no UX regression for users who never create a folder).
- Manually verify Add/Duplicate/Shuffle/Delete connection actions still work on both filed and unfiled rows.
- Manually verify in dark + light mode and at mobile viewport (action pill stays visible per panel conventions).

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

<img width="448" height="839" alt="image" src="https://github.com/user-attachments/assets/1a18d6f7-0bf1-4d6c-88cf-bdbb4d94ed59" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Organize connections into custom folders for improved organization
  * Rename, delete, and collapse folders to manage your workspace
  * Move connections between folders through a dedicated interface
  * Drag-to-reorder folders to customize your organization
  * Separate "Unfiled connections" section for unorganized items
  * Assign custom colors to folders for visual distinction

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/745)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->