### PR TITLE
refactor(folders): null-guard route handlers and atomicity for storage loops

### DIFF
--- a/packages/server/src/routes/chat-folders.routes.ts
+++ b/packages/server/src/routes/chat-folders.routes.ts
@@ -31,7 +31,8 @@ export async function chatFoldersRoutes(app: FastifyInstance) {
       return reply.status(400).send({ error: "Invalid mode" });
     }
     const folder = await storage.create({ name: name.trim(), mode, color });
-    return reply.send({ ...folder, collapsed: folder!.collapsed === "true" });
+    if (!folder) return reply.status(500).send({ error: "Failed to create folder" });
+    return reply.send({ ...folder, collapsed: folder.collapsed === "true" });
   });
 
   // ── Update a folder ──
@@ -42,7 +43,8 @@ export async function chatFoldersRoutes(app: FastifyInstance) {
     const existing = await storage.getById(req.params.id);
     if (!existing) return reply.status(404).send({ error: "Folder not found" });
     const folder = await storage.update(req.params.id, req.body);
-    return reply.send({ ...folder, collapsed: folder!.collapsed === "true" });
+    if (!folder) return reply.status(500).send({ error: "Failed to update folder" });
+    return reply.send({ ...folder, collapsed: folder.collapsed === "true" });
   });
 
   // ── Delete a folder (chats are moved to root) ──

--- a/packages/server/src/routes/chat-folders.routes.ts
+++ b/packages/server/src/routes/chat-folders.routes.ts
@@ -90,13 +90,20 @@ export async function chatFoldersRoutes(app: FastifyInstance) {
   }>("/reorder-chats", async (req, reply) => {
     const { orderedChatIds, folderId } = req.body;
     if (!Array.isArray(orderedChatIds)) return reply.status(400).send({ error: "orderedChatIds must be an array" });
-    for (let i = 0; i < orderedChatIds.length; i++) {
-      const id = orderedChatIds[i]!;
-      // Update sortOrder on the visible representative chat, then propagate
-      // the folder assignment to its sibling branches.
-      await chatsStorage.update(id, { sortOrder: i + 1 });
-      await chatsStorage.setFolderForChat(id, folderId);
-    }
+    // Atomic: a partial failure mid-loop would leave chats with a mix of
+    // old and new sort_order / folder_id values across siblings of the
+    // same group. Chats-per-folder counts are O(dozens), well under the
+    // libSQL Windows transaction use-after-free threshold noted in
+    // chats.storage.ts:449.
+    await app.db.transaction(async (tx) => {
+      for (let i = 0; i < orderedChatIds.length; i++) {
+        const id = orderedChatIds[i]!;
+        // Update sortOrder on the visible representative chat, then propagate
+        // the folder assignment to its sibling branches.
+        await chatsStorage.update(id, { sortOrder: i + 1 }, { tx });
+        await chatsStorage.setFolderForChat(id, folderId, { tx });
+      }
+    });
     return reply.send({ ok: true });
   });
 }

--- a/packages/server/src/routes/connection-folders.routes.ts
+++ b/packages/server/src/routes/connection-folders.routes.ts
@@ -25,7 +25,8 @@ export async function connectionFoldersRoutes(app: FastifyInstance) {
     const { name, color } = req.body;
     if (!name?.trim()) return reply.status(400).send({ error: "Name is required" });
     const folder = await storage.create({ name: name.trim(), color });
-    return reply.send({ ...folder, collapsed: folder!.collapsed === "true" });
+    if (!folder) return reply.status(500).send({ error: "Failed to create folder" });
+    return reply.send({ ...folder, collapsed: folder.collapsed === "true" });
   });
 
   // ── Update a folder ──
@@ -36,7 +37,8 @@ export async function connectionFoldersRoutes(app: FastifyInstance) {
     const existing = await storage.getById(req.params.id);
     if (!existing) return reply.status(404).send({ error: "Folder not found" });
     const folder = await storage.update(req.params.id, req.body);
-    return reply.send({ ...folder, collapsed: folder!.collapsed === "true" });
+    if (!folder) return reply.status(500).send({ error: "Failed to update folder" });
+    return reply.send({ ...folder, collapsed: folder.collapsed === "true" });
   });
 
   // ── Delete a folder (connections are moved to root) ──

--- a/packages/server/src/services/storage/chat-folders.storage.ts
+++ b/packages/server/src/services/storage/chat-folders.storage.ts
@@ -20,23 +20,27 @@ export function createChatFoldersStorage(db: DB) {
     async create(input: { name: string; mode: string; color?: string }) {
       const id = newId();
       const timestamp = now();
-      // Shift existing folders down and place new folder at the top
-      const existing = await db.select().from(chatFolders);
-      for (const f of existing) {
-        await db
-          .update(chatFolders)
-          .set({ sortOrder: f.sortOrder + 1 })
-          .where(eq(chatFolders.id, f.id));
-      }
-      await db.insert(chatFolders).values({
-        id,
-        name: input.name,
-        mode: input.mode as "conversation" | "roleplay" | "visual_novel",
-        color: input.color ?? "",
-        sortOrder: 0,
-        collapsed: "false",
-        createdAt: timestamp,
-        updatedAt: timestamp,
+      // Shift existing folders down and place new folder at the top.
+      // Atomic so a partial failure can't leave the sort_order column in a
+      // half-shifted state with no new folder.
+      await db.transaction(async (tx) => {
+        const existing = await tx.select().from(chatFolders);
+        for (const f of existing) {
+          await tx
+            .update(chatFolders)
+            .set({ sortOrder: f.sortOrder + 1 })
+            .where(eq(chatFolders.id, f.id));
+        }
+        await tx.insert(chatFolders).values({
+          id,
+          name: input.name,
+          mode: input.mode as "conversation" | "roleplay" | "visual_novel",
+          color: input.color ?? "",
+          sortOrder: 0,
+          collapsed: "false",
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        });
       });
       return this.getById(id);
     },
@@ -62,9 +66,19 @@ export function createChatFoldersStorage(db: DB) {
     },
 
     async reorder(orderedIds: string[]) {
-      for (let i = 0; i < orderedIds.length; i++) {
-        await db.update(chatFolders).set({ sortOrder: i, updatedAt: now() }).where(eq(chatFolders.id, orderedIds[i]!));
-      }
+      // Atomic: a partial failure mid-loop would leave the folder list with
+      // mixed sort orders. Folder counts are O(dozens) per user so a single
+      // small transaction is safe (well under the libSQL Windows large-batch
+      // limit noted in chats.storage.ts).
+      const timestamp = now();
+      await db.transaction(async (tx) => {
+        for (let i = 0; i < orderedIds.length; i++) {
+          await tx
+            .update(chatFolders)
+            .set({ sortOrder: i, updatedAt: timestamp })
+            .where(eq(chatFolders.id, orderedIds[i]!));
+        }
+      });
     },
   };
 }

--- a/packages/server/src/services/storage/chat-folders.storage.ts
+++ b/packages/server/src/services/storage/chat-folders.storage.ts
@@ -67,9 +67,9 @@ export function createChatFoldersStorage(db: DB) {
 
     async reorder(orderedIds: string[]) {
       // Atomic: a partial failure mid-loop would leave the folder list with
-      // mixed sort orders. Folder counts are O(dozens) per user so a single
-      // small transaction is safe (well under the libSQL Windows large-batch
-      // limit noted in chats.storage.ts).
+      // mixed sort orders. Folder counts are O(dozens) per user, well below
+      // the loop size that triggers the libSQL Windows transaction
+      // use-after-free noted in chats.storage.ts:449.
       const timestamp = now();
       await db.transaction(async (tx) => {
         for (let i = 0; i < orderedIds.length; i++) {

--- a/packages/server/src/services/storage/chats.storage.ts
+++ b/packages/server/src/services/storage/chats.storage.ts
@@ -146,8 +146,13 @@ export function createChatsStorage(db: DB) {
       return this.getById(id);
     },
 
-    async update(id: string, data: Partial<CreateChatInput> & { folderId?: string | null; sortOrder?: number }) {
-      await db
+    async update(
+      id: string,
+      data: Partial<CreateChatInput> & { folderId?: string | null; sortOrder?: number },
+      opts?: { tx?: Pick<DB, "select" | "update"> },
+    ) {
+      const conn = opts?.tx ?? db;
+      await conn
         .update(chats)
         .set({
           ...(data.name !== undefined && { name: data.name }),
@@ -162,7 +167,10 @@ export function createChatsStorage(db: DB) {
           updatedAt: now(),
         })
         .where(eq(chats.id, id));
-      return this.getById(id);
+      // Caller-level read; uses outer db so it reads committed state when no
+      // tx is in flight, or the in-flight tx state when one is provided.
+      const rows = await conn.select().from(chats).where(eq(chats.id, id));
+      return rows[0] ?? null;
     },
 
     /**
@@ -176,16 +184,19 @@ export function createChatsStorage(db: DB) {
      * Sibling branches are updated without bumping updatedAt so categorizing
      * a chat doesn't silently reorder its branch history.
      */
-    async setFolderForChat(chatId: string, folderId: string | null) {
-      const chat = await this.getById(chatId);
+    async setFolderForChat(chatId: string, folderId: string | null, opts?: { tx?: Pick<DB, "select" | "update"> }) {
+      const conn = opts?.tx ?? db;
+      const rows = await conn.select().from(chats).where(eq(chats.id, chatId));
+      const chat = rows[0];
       if (!chat) return null;
       if (chat.groupId) {
-        await db.update(chats).set({ folderId }).where(eq(chats.groupId, chat.groupId));
-        await db.update(chats).set({ updatedAt: now() }).where(eq(chats.id, chatId));
+        await conn.update(chats).set({ folderId }).where(eq(chats.groupId, chat.groupId));
+        await conn.update(chats).set({ updatedAt: now() }).where(eq(chats.id, chatId));
       } else {
-        await db.update(chats).set({ folderId, updatedAt: now() }).where(eq(chats.id, chatId));
+        await conn.update(chats).set({ folderId, updatedAt: now() }).where(eq(chats.id, chatId));
       }
-      return this.getById(chatId);
+      const updated = await conn.select().from(chats).where(eq(chats.id, chatId));
+      return updated[0] ?? null;
     },
 
     /** List all chats belonging to a group. */

--- a/packages/server/src/services/storage/connection-folders.storage.ts
+++ b/packages/server/src/services/storage/connection-folders.storage.ts
@@ -21,21 +21,25 @@ export function createConnectionFoldersStorage(db: DB) {
       const id = newId();
       const timestamp = now();
       // Shift existing folders down and place new folder at the top.
-      const existing = await db.select().from(apiConnectionFolders);
-      for (const f of existing) {
-        await db
-          .update(apiConnectionFolders)
-          .set({ sortOrder: f.sortOrder + 1 })
-          .where(eq(apiConnectionFolders.id, f.id));
-      }
-      await db.insert(apiConnectionFolders).values({
-        id,
-        name: input.name,
-        color: input.color ?? "",
-        sortOrder: 0,
-        collapsed: "false",
-        createdAt: timestamp,
-        updatedAt: timestamp,
+      // Atomic so a partial failure can't leave the sort_order column in a
+      // half-shifted state with no new folder.
+      await db.transaction(async (tx) => {
+        const existing = await tx.select().from(apiConnectionFolders);
+        for (const f of existing) {
+          await tx
+            .update(apiConnectionFolders)
+            .set({ sortOrder: f.sortOrder + 1 })
+            .where(eq(apiConnectionFolders.id, f.id));
+        }
+        await tx.insert(apiConnectionFolders).values({
+          id,
+          name: input.name,
+          color: input.color ?? "",
+          sortOrder: 0,
+          collapsed: "false",
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        });
       });
       return this.getById(id);
     },
@@ -61,12 +65,17 @@ export function createConnectionFoldersStorage(db: DB) {
     },
 
     async reorder(orderedIds: string[]) {
-      for (let i = 0; i < orderedIds.length; i++) {
-        await db
-          .update(apiConnectionFolders)
-          .set({ sortOrder: i, updatedAt: now() })
-          .where(eq(apiConnectionFolders.id, orderedIds[i]!));
-      }
+      // Atomic: same rationale as chat-folders reorder — a partial failure
+      // would leave the folder list with mixed sort orders.
+      const timestamp = now();
+      await db.transaction(async (tx) => {
+        for (let i = 0; i < orderedIds.length; i++) {
+          await tx
+            .update(apiConnectionFolders)
+            .set({ sortOrder: i, updatedAt: timestamp })
+            .where(eq(apiConnectionFolders.id, orderedIds[i]!));
+        }
+      });
     },
 
     async moveConnection(connectionId: string, folderId: string | null) {
@@ -77,12 +86,18 @@ export function createConnectionFoldersStorage(db: DB) {
     },
 
     async reorderConnections(orderedIds: string[], folderId: string | null) {
-      for (let i = 0; i < orderedIds.length; i++) {
-        await db
-          .update(apiConnections)
-          .set({ sortOrder: i + 1, folderId, updatedAt: now() })
-          .where(eq(apiConnections.id, orderedIds[i]!));
-      }
+      // Atomic: prevents a partial failure from leaving connections with a
+      // mix of old and new sort_order / folder_id values within the same
+      // logical operation.
+      const timestamp = now();
+      await db.transaction(async (tx) => {
+        for (let i = 0; i < orderedIds.length; i++) {
+          await tx
+            .update(apiConnections)
+            .set({ sortOrder: i + 1, folderId, updatedAt: timestamp })
+            .where(eq(apiConnections.id, orderedIds[i]!));
+        }
+      });
     },
   };
 }


### PR DESCRIPTION
## Linked issue

Closes #747
Closes #748

## Why this change

Two follow-ups from CodeRabbit's review of [#745](https://github.com/Pasta-Devs/Marinara-Engine/pull/745), both of which I deferred at the time because applying them only to the new `connection-folders` files would have diverged from the existing `chat-folders` pattern. With #745 merged, this PR addresses both findings simultaneously in lockstep across both folder modules:

1. **#747** — POST/PATCH handlers in both folder route modules used `folder!.collapsed` non-null assertions. Safe under current semantics, but brittle to future error-handling changes.
2. **#748** — `create()`, `reorder()`, and `reorderConnections()` in the folder storage modules — plus `POST /api/chat-folders/reorder-chats` — issued per-row UPDATE loops without transaction boundaries. A partial failure mid-loop could leave `sort_order` / `folder_id` columns in a mixed state.

Folder counts in a single-user Marinara install are O(dozens), so the *performance* impact of the missing atomicity is negligible — but a transaction wrap gives us actual atomicity, matches the canonical pattern already used in `lorebooks.storage.ts` / `agents.storage.ts`, and costs almost nothing.

## What changed

**Routes — null-guard the create/update responses:**
- `packages/server/src/routes/chat-folders.routes.ts` — POST + PATCH: replace `folder!.collapsed` with an explicit `if (!folder) return reply.status(500)...` guard.
- `packages/server/src/routes/connection-folders.routes.ts` — same change.

**Storage — wrap per-row loops in `db.transaction()`:**
- `packages/server/src/services/storage/chat-folders.storage.ts` — `create()` (shift + insert) and `reorder()` (per-row sort_order update).
- `packages/server/src/services/storage/connection-folders.storage.ts` — `create()`, `reorder()`, and `reorderConnections()` (the route is wired but UI for drag-within-folder is still deferred — wrapping it now means the eventual UI flip is pure-frontend).
- `packages/server/src/services/storage/chats.storage.ts` — `update()` and `setFolderForChat()` now accept an optional `tx` parameter (typed structurally as `Pick<DB, "select" | "update">`, the same shape used by `syncLorebookLinks` in `lorebooks.storage.ts:154`). When `tx` is omitted the behaviour is identical to before.
- `packages/server/src/routes/chat-folders.routes.ts` — `POST /reorder-chats` now wraps the loop in `app.db.transaction()` and threads `tx` through both `chatsStorage.update` and `chatsStorage.setFolderForChat`, so the sortOrder write and the group-sibling folder propagation commit atomically.

Each transaction uses a single shared `now()` timestamp so all rows within one reorder share an `updated_at` value (intentional — the previous "later-timestamp-per-row" behaviour was an accidental side-effect of the per-row loop, not a deliberate semantic).

## Why not a single-query bulk UPDATE?

CodeRabbit's original suggestion was `tx.update(folders).set({ sortOrder: sql\`${folders.sortOrder} + 1\` })` to collapse the shift into one statement. That's a no-go on this codebase's default storage backend:

- Marinara v1.5.7+ defaults to `STORAGE_BACKEND=files` (see `packages/server/src/config/runtime-config.ts:245`).
- The file-native runtime in `packages/server/src/db/file-backed-store.ts:932` intentionally treats `run()` as a no-op and `.set()` patches as plain row literals — a Drizzle `sql` template silently breaks for any user not on opt-in `STORAGE_BACKEND=sqlite`.

The transaction wrap is portable across both backends (file-backed-store has its own `transaction` implementation at file-backed-store.ts:829 — a deep table snapshot with rollback-on-throw — and this PR's changes flow through it correctly).

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

Verified live against `me.romyromulus.com` after fork-deploy:

- **Atomic create (connection-folders)** — 5 existing folders pre-shift, created a new folder, confirmed via `GET /api/connection-folders` that the new folder is at `sortOrder=0` and the 5 originals shifted to `1..5` exactly.
- **Atomic create (chat-folders)** — same flow against `/api/chat-folders`, no existing folders, new folder inserted at `sortOrder=0`.
- **Atomic reorder (connection-folders)** — POSTed `{orderedIds: [...].reverse()}` to `/api/connection-folders/reorder`, confirmed full reverse applied (e.g. `LinkAPI LLM` from `5 → 0`, `Tx Test Folder` from `0 → 5`).
- **No console errors** under any of the above flows.
- **Cleanup** — test folders deleted, original 5 connection folders + their connections intact.

Things that would benefit from human verification before merge:

- Manually verify reorder-chats in the UI — drag chats between folders in CONVO/RP/GM tabs, confirm both the per-chat sortOrder and the group-sibling folder propagation still work end-to-end.
- Manually verify drag-to-reorder folders in the connections panel (the `Reorder.Group` integration).
- Manually verify the 500 path on the POST/PATCH null-guard — hard to trigger without inducing a real DB failure; safe to skip if the lower-risk happy paths are confirmed.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

No UI changes — pure backend/storage refactor. The connections panel and chat sidebar behaviour are identical to before from the user's point of view, just with stronger consistency guarantees under partial-failure scenarios.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling for folder creation and update operations
  * Enhanced reliability of folder reordering to prevent inconsistent states during concurrent updates

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/749)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->