### PR TITLE
Fix Connected Chat placeholder branch names

### DIFF
--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -35,7 +35,7 @@ import { useCharacters, usePersonas } from "../../hooks/use-characters";
 import { useConnections } from "../../hooks/use-connections";
 import { usePageActivity } from "../../hooks/use-page-activity";
 import { api } from "../../lib/api-client";
-import { getChatDisplayName, parseChatMetadata } from "../../lib/chat-display";
+import { getChatDisplayName, getConnectedChatDisplayName, parseChatMetadata } from "../../lib/chat-display";
 import { parseCharacterDisplayData } from "../../lib/character-display";
 import { showConfirmDialog } from "../../lib/app-dialogs";
 import { chatBackgroundMetadataToUrl, chatBackgroundUrlToMetadata } from "../../lib/backgrounds";
@@ -1552,7 +1552,7 @@ export function ChatArea() {
   const chatList =
     (allChats as Array<{ id: string; name: string; metadata?: string | Record<string, unknown> }> | undefined) ?? [];
   const connectedChatName = chat?.connectedChatId
-    ? getChatDisplayName(chatList.find((item) => item.id === chat.connectedChatId))
+    ? getConnectedChatDisplayName(chatList.find((item) => item.id === chat.connectedChatId))
     : undefined;
   const activeSceneChat = chatMeta.activeSceneChatId
     ? chatList.find((item) => item.id === chatMeta.activeSceneChatId)

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -26,7 +26,7 @@ import {
   FlipHorizontal2,
 } from "lucide-react";
 import { cn } from "../../lib/utils";
-import { getChatDisplayName } from "../../lib/chat-display";
+import { getConnectedChatDisplayName } from "../../lib/chat-display";
 import { useUIStore } from "../../stores/ui.store";
 import { useChatStore } from "../../stores/chat.store";
 import { useGameStateStore } from "../../stores/game-state.store";
@@ -665,7 +665,7 @@ export function ChatRoleplaySurface({
   isGrouped,
 }: RoleplaySurfaceProps) {
   const linkedChatName = chat?.connectedChatId
-    ? getChatDisplayName(allChats?.find((c) => c.id === chat.connectedChatId))
+    ? getConnectedChatDisplayName(allChats?.find((c) => c.id === chat.connectedChatId))
     : undefined;
   const sidebarOpen = useUIStore((s) => s.sidebarOpen);
   const rightPanelOpen = useUIStore((s) => s.rightPanelOpen);

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -88,7 +88,7 @@ import {
   chatKeys,
 } from "../../hooks/use-chats";
 import { api } from "../../lib/api-client";
-import { getChatDisplayName } from "../../lib/chat-display";
+import { getConnectedChatDisplayName } from "../../lib/chat-display";
 import {
   getAgentRunIntervalMeta,
   getCadenceInputValue,
@@ -3120,7 +3120,7 @@ export function ChatSettingsDrawer({
                       <ArrowRightLeft size="0.875rem" className="text-[var(--primary)]" />
                       <div className="flex-1 min-w-0">
                         <span className="truncate text-xs font-medium">
-                          {linked ? getChatDisplayName(linked) : "Unknown chat"}
+                          {linked ? getConnectedChatDisplayName(linked) : "Unknown chat"}
                         </span>
                         <p className="text-[0.625rem] text-[var(--muted-foreground)]">
                           {linked ? (linked.mode === "roleplay" ? "Roleplay" : linked.mode) : "Deleted"}
@@ -3159,7 +3159,7 @@ export function ChatSettingsDrawer({
                         c.id !== chat.id &&
                         (c.mode === "roleplay" || c.mode === "game") &&
                         !c.connectedChatId &&
-                        getChatDisplayName(c).toLowerCase().includes(connectionSearch.toLowerCase()),
+                        getConnectedChatDisplayName(c).toLowerCase().includes(connectionSearch.toLowerCase()),
                     )
                     .map((c) => (
                       <button
@@ -3171,7 +3171,7 @@ export function ChatSettingsDrawer({
                         className="flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-left text-xs transition-colors hover:bg-[var(--accent)]"
                       >
                         <MessageSquare size="0.75rem" className="shrink-0 text-[var(--muted-foreground)]" />
-                        <span className="truncate">{getChatDisplayName(c)}</span>
+                        <span className="truncate">{getConnectedChatDisplayName(c)}</span>
                       </button>
                     ))}
                 </PickerDropdown>
@@ -3197,7 +3197,7 @@ export function ChatSettingsDrawer({
                         <MessageCircle size="0.875rem" className="text-[var(--primary)]" />
                         <div className="flex-1 min-w-0">
                           <span className="truncate text-xs font-medium">
-                            {linked ? getChatDisplayName(linked) : "Unknown chat"}
+                            {linked ? getConnectedChatDisplayName(linked) : "Unknown chat"}
                           </span>
                           <p className="text-[0.625rem] text-[var(--muted-foreground)]">Conversation</p>
                         </div>
@@ -3273,7 +3273,7 @@ export function ChatSettingsDrawer({
                     <MessageCircle size="0.875rem" className="text-[var(--primary)]" />
                     <div className="flex-1 min-w-0">
                       <span className="truncate text-xs font-medium">
-                        {linked ? getChatDisplayName(linked) : "Unknown chat"}
+                        {linked ? getConnectedChatDisplayName(linked) : "Unknown chat"}
                       </span>
                       <p className="text-[0.625rem] text-[var(--muted-foreground)]">Conversation</p>
                     </div>
@@ -3323,7 +3323,7 @@ export function ChatSettingsDrawer({
                         c.id !== chat.id &&
                         c.mode === "conversation" &&
                         !c.connectedChatId &&
-                        getChatDisplayName(c).toLowerCase().includes(connectionSearch.toLowerCase()),
+                        getConnectedChatDisplayName(c).toLowerCase().includes(connectionSearch.toLowerCase()),
                     )
                     .map((c) => (
                       <button
@@ -3335,7 +3335,7 @@ export function ChatSettingsDrawer({
                         className="flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-left text-xs transition-colors hover:bg-[var(--accent)]"
                       >
                         <MessageSquare size="0.75rem" className="shrink-0 text-[var(--muted-foreground)]" />
-                        <span className="truncate">{getChatDisplayName(c)}</span>
+                        <span className="truncate">{getConnectedChatDisplayName(c)}</span>
                       </button>
                     ))}
                 </PickerDropdown>

--- a/packages/client/src/lib/chat-display.ts
+++ b/packages/client/src/lib/chat-display.ts
@@ -21,5 +21,8 @@ export function parseChatMetadata(raw: unknown): Record<string, any> {
 export function getChatDisplayName(chat: ChatDisplaySource | null | undefined): string {
   if (!chat) return "";
   const metadata = parseChatMetadata(chat.metadata);
-  return typeof metadata.branchName === "string" && metadata.branchName.trim() ? metadata.branchName : chat.name;
+  if (typeof metadata.branchName !== "string") return chat.name;
+
+  const branchName = metadata.branchName.trim();
+  return branchName && branchName !== "New Branch" ? branchName : chat.name;
 }

--- a/packages/client/src/lib/chat-display.ts
+++ b/packages/client/src/lib/chat-display.ts
@@ -5,6 +5,8 @@ export type ChatDisplaySource = {
   metadata?: Chat["metadata"] | string | Record<string, unknown> | null;
 };
 
+const PLACEHOLDER_BRANCH_NAME = "New Branch";
+
 export function parseChatMetadata(raw: unknown): Record<string, any> {
   if (!raw) return {};
   if (typeof raw === "string") {
@@ -24,5 +26,10 @@ export function getChatDisplayName(chat: ChatDisplaySource | null | undefined): 
   if (typeof metadata.branchName !== "string") return chat.name;
 
   const branchName = metadata.branchName.trim();
-  return branchName && branchName !== "New Branch" ? branchName : chat.name;
+  return branchName || chat.name;
+}
+
+export function getConnectedChatDisplayName(chat: ChatDisplaySource | null | undefined): string {
+  const displayName = getChatDisplayName(chat);
+  return displayName === PLACEHOLDER_BRANCH_NAME ? (chat?.name ?? "") : displayName;
 }


### PR DESCRIPTION
## Linked issue

Closes #740

## Why this change

- Connected Chat uses chat display names for picker labels and search.
- Newly created branches are seeded with `metadata.branchName` set to `New Branch`, which is useful inside branch-management UI but confusing in Connected Chat because unrenamed RP/game links can appear as identical `New Branch` rows instead of their stable chat names.

## What changed

- Restored `getChatDisplayName` so branch-management UI can still show branch labels, including the `New Branch` placeholder.
- Added `getConnectedChatDisplayName` for connected-chat surfaces, where the `New Branch` placeholder falls back to `chat.name`.
- Updated Connected Chat labels/search to use the connected-chat-specific helper.

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Reproduced the original helper behavior before the first fix: `getChatDisplayName({ name: "Moonlit RP", metadata: { branchName: "New Branch" } })` returned `New Branch`.
- Verified the final helper behavior with `tsx`: branch UI helper keeps `New Branch`; connected-chat helper falls back to `Moonlit RP`; real branch label `Chapter 2` still displays; blank branch labels fall back; stringified JSON metadata follows the connected-chat placeholder fallback.
- Ran `pnpm check`; it passed locally.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

No browser screenshot attached. The affected Connected Chat surfaces now use `getConnectedChatDisplayName`; branch management keeps using `getChatDisplayName`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - Connected chat labels now properly display branch names when available instead of generic placeholders across chat interfaces, toolbars, and settings.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/750)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->