### PR TITLE
Fix mobile party member access

### DIFF
--- a/packages/client/src/components/game/GamePartyBar.tsx
+++ b/packages/client/src/components/game/GamePartyBar.tsx
@@ -45,7 +45,7 @@ export function GamePartyBar({
   if (partyMembers.length === 0) return null;
 
   return (
-    <div className="flex items-center gap-1.5">
+    <div className="scrollbar-hide flex max-w-full touch-pan-x items-center gap-1.5 overflow-x-auto px-0.5 py-1 [-webkit-overflow-scrolling:touch]">
       {partyMembers.map((member) => {
         const card = partyCards[member.id];
         const avatarSrc = card?.avatarUrl ?? member.avatarUrl;
@@ -56,7 +56,7 @@ export function GamePartyBar({
             <button
               type="button"
               onClick={() => openCharacterSheet(member.id)}
-              className="block"
+              className="block rounded-full focus:outline-none focus:ring-2 focus:ring-white/45"
               title={`${member.name} - Click to open character sheet`}
             >
               {avatarSrc ? (

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -7743,7 +7743,7 @@ export function GameSurface({
                 {/* Top-left: Map + Party portraits side by side */}
                 <div
                   className={cn(
-                    "pointer-events-auto absolute left-3 z-20 flex items-start gap-2",
+                    "pointer-events-auto absolute left-3 right-14 z-20 flex min-w-0 items-start gap-2 md:right-auto",
                     topOverlayOffsetClass,
                   )}
                 >
@@ -7790,7 +7790,7 @@ export function GameSurface({
 
                   {/* Party portraits — right of map */}
                   {partyMembers.length > 0 && (
-                    <div data-tour="game-party">
+                    <div data-tour="game-party" className="min-w-0 flex-1 md:flex-none">
                       <GamePartyBar
                         partyMembers={partyMembers}
                         partyCards={partyCards}


### PR DESCRIPTION
## Linked issue

No linked issue yet; this fixes a mobile bug report provided via screenshot.

## Why this change

- On mobile game mode, party members beyond the first few portraits could not reliably be opened because the party strip ran under the top-right game actions button or offscreen.

## What changed

- Constrain the mobile top-left HUD overlay so it leaves room for the top-right actions button.
- Make the compact party portrait bar horizontally scrollable on touch devices, so every party member portrait can be reached and tapped.

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `pnpm check` passed locally.
- Reproduced the mobile layout failure with a local 360px-wide headless Chrome harness matching the GameSurface overlay geometry: before the fix, member 5 hit-tested as the game actions control and member 6 was offscreen, with no horizontal scroll range.
- Verified the same harness after the fix: the party strip gains horizontal scroll range, and after scrolling member 5 and member 6 hit-test as their own portrait buttons.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

- Local headless before/after screenshots were generated for verification, but no reviewer-visible screenshots are attached yet. Manual mobile screenshot/recording should be added after device verification.
