### PR TITLE
Fix manual chat file deletion persistence

### DIFF
--- a/packages/client/src/components/chat/ChatFilesDrawer.tsx
+++ b/packages/client/src/components/chat/ChatFilesDrawer.tsx
@@ -27,7 +27,7 @@ interface ChatFilesDrawerProps {
 }
 
 export function ChatFilesDrawer({ chat, open, onClose }: ChatFilesDrawerProps) {
-  const groupId = (chat as any).groupId as string | null;
+  const groupId = chat.groupId;
   const { data: groupChats, refetch: refetchGroupChats } = useChatGroup(groupId);
   const deleteChat = useDeleteChat();
   const deleteChatGroup = useDeleteChatGroup();
@@ -107,10 +107,16 @@ export function ChatFilesDrawer({ chat, open, onClose }: ChatFilesDrawerProps) {
     ) {
       return;
     }
-    deleteChat.mutate(chatId);
-    if (chatId === activeChatId && chatFiles.length > 1) {
-      const next = chatFiles.find((c) => c.id !== chatId);
-      if (next) setActiveChatId(next.id);
+    const nextActiveChatId = chatId === activeChatId ? chatFiles.find((c) => c.id !== chatId)?.id : null;
+    try {
+      await deleteChat.mutateAsync({ id: chatId, groupId });
+      if (nextActiveChatId) setActiveChatId(nextActiveChatId);
+      if (groupId) {
+        await qc.invalidateQueries({ queryKey: chatKeys.group(groupId) });
+        await refetchGroupChats();
+      }
+    } catch (err) {
+      toast.error(err instanceof Error ? `Delete failed: ${err.message}` : "Delete failed.");
     }
   };
 
@@ -320,8 +326,9 @@ export function ChatFilesDrawer({ chat, open, onClose }: ChatFilesDrawerProps) {
                       <button
                         onClick={(e) => {
                           e.stopPropagation();
-                          handleDelete(cf.id);
+                          void handleDelete(cf.id);
                         }}
+                        disabled={deleteChat.isPending}
                         className="rounded-lg p-1.5 transition-all hover:bg-[var(--destructive)]/15"
                         title="Delete branch"
                       >

--- a/packages/client/src/components/chat/ChatFilesDrawer.tsx
+++ b/packages/client/src/components/chat/ChatFilesDrawer.tsx
@@ -111,10 +111,6 @@ export function ChatFilesDrawer({ chat, open, onClose }: ChatFilesDrawerProps) {
     try {
       await deleteChat.mutateAsync({ id: chatId, groupId });
       if (nextActiveChatId) setActiveChatId(nextActiveChatId);
-      if (groupId) {
-        await qc.invalidateQueries({ queryKey: chatKeys.group(groupId) });
-        await refetchGroupChats();
-      }
     } catch (err) {
       toast.error(err instanceof Error ? `Delete failed: ${err.message}` : "Delete failed.");
     }

--- a/packages/client/src/hooks/use-chats.ts
+++ b/packages/client/src/hooks/use-chats.ts
@@ -332,7 +332,11 @@ export function useDeleteChat() {
       return { previous, previousGroup, groupId };
     },
     onError: (_err, _id, context) => {
-      if (context?.previous) qc.setQueryData(chatKeys.list(), context.previous);
+      if (context?.previous) {
+        qc.setQueryData(chatKeys.list(), context.previous);
+      } else {
+        qc.invalidateQueries({ queryKey: chatKeys.list() });
+      }
       if (context?.groupId) {
         if (context.previousGroup) {
           qc.setQueryData(chatKeys.group(context.groupId), context.previousGroup);

--- a/packages/client/src/hooks/use-chats.ts
+++ b/packages/client/src/hooks/use-chats.ts
@@ -279,6 +279,16 @@ export function useChatGroup(groupId: string | null) {
   });
 }
 
+type DeleteChatInput = string | { id: string; groupId?: string | null };
+
+function getDeleteChatId(input: DeleteChatInput) {
+  return typeof input === "string" ? input : input.id;
+}
+
+function getDeleteChatGroupId(input: DeleteChatInput) {
+  return typeof input === "string" ? null : (input.groupId ?? null);
+}
+
 export function useCreateChat() {
   const qc = useQueryClient();
   return useMutation({
@@ -300,30 +310,42 @@ export function useCreateChat() {
 export function useDeleteChat() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (id: string) => api.delete(`/chats/${id}`),
-    onMutate: async (id) => {
+    mutationFn: (input: DeleteChatInput) => api.delete(`/chats/${getDeleteChatId(input)}`),
+    onMutate: async (input) => {
+      const id = getDeleteChatId(input);
+      const providedGroupId = getDeleteChatGroupId(input);
       await qc.cancelQueries({ queryKey: chatKeys.list() });
+      if (providedGroupId) {
+        await qc.cancelQueries({ queryKey: chatKeys.group(providedGroupId) });
+      }
       const previous = qc.getQueryData<Chat[]>(chatKeys.list());
-      const deletedChat = previous?.find((c) => c.id === id) ?? null;
+      const previousGroup = providedGroupId ? qc.getQueryData<Chat[]>(chatKeys.group(providedGroupId)) : undefined;
+      const deletedChat = previous?.find((c) => c.id === id) ?? previousGroup?.find((c) => c.id === id) ?? null;
+      const groupId = deletedChat?.groupId ?? providedGroupId;
 
       qc.setQueryData<Chat[]>(chatKeys.list(), (old) => old?.filter((c) => c.id !== id));
 
-      if (deletedChat?.groupId) {
-        qc.setQueryData<Chat[]>(chatKeys.group(deletedChat.groupId), (old) => old?.filter((c) => c.id !== id));
+      if (groupId) {
+        qc.setQueryData<Chat[]>(chatKeys.group(groupId), (old) => old?.filter((c) => c.id !== id));
       }
 
-      return { previous, deletedChat };
+      return { previous, previousGroup, groupId };
     },
     onError: (_err, _id, context) => {
       if (context?.previous) qc.setQueryData(chatKeys.list(), context.previous);
-      if (context?.deletedChat?.groupId) {
-        qc.invalidateQueries({ queryKey: chatKeys.group(context.deletedChat.groupId) });
+      if (context?.groupId) {
+        if (context.previousGroup) {
+          qc.setQueryData(chatKeys.group(context.groupId), context.previousGroup);
+        } else {
+          qc.invalidateQueries({ queryKey: chatKeys.group(context.groupId) });
+        }
       }
     },
-    onSettled: (_data, _err, _id, context) => {
+    onSettled: (_data, _err, input, context) => {
+      const groupId = context?.groupId ?? getDeleteChatGroupId(input);
       qc.invalidateQueries({ queryKey: chatKeys.list() });
-      if (context?.deletedChat?.groupId) {
-        qc.invalidateQueries({ queryKey: chatKeys.group(context.deletedChat.groupId) });
+      if (groupId) {
+        qc.invalidateQueries({ queryKey: chatKeys.group(groupId) });
       }
     },
   });

--- a/packages/server/src/db/file-backed-store.ts
+++ b/packages/server/src/db/file-backed-store.ts
@@ -1099,6 +1099,7 @@ class FileTableStore {
     const existingPaths = [...new Set(dbPaths.filter((path) => existsSync(path)))];
     if (existingPaths.length === 0) return false;
 
+    legacyReaderUsed = null;
     const counts: Record<string, number> = {};
     let totalRows = 0;
     for (const table of FILE_BACKED_TABLES) {
@@ -1110,10 +1111,17 @@ class FileTableStore {
 
     if (totalRows === 0) return false;
 
+    const importedAt = new Date().toISOString();
     this.migratedFromSqlite = {
       path: existingPaths[0],
       paths: existingPaths,
-      importedAt: new Date().toISOString(),
+      importedAt,
+    };
+    this.legacyRepair = {
+      paths: existingPaths,
+      repairedAt: importedAt,
+      tables: {},
+      reader: legacyReaderUsed ?? undefined,
     };
     for (const table of FILE_BACKED_TABLES) this.dirtyTables.add(table);
     this.dirty = true;

--- a/packages/server/test/file-backed-store.test.ts
+++ b/packages/server/test/file-backed-store.test.ts
@@ -7,6 +7,7 @@ import { test } from "node:test";
 import { and, eq } from "drizzle-orm";
 import { characterCardVersions, characters, chats, lorebookFolders, lorebooks } from "../src/db/schema/index.js";
 import { createFileNativeDB } from "../src/db/file-backed-store.js";
+import { createChatsStorage } from "../src/services/storage/chats.storage.js";
 
 async function writeLegacyDb(path: string, rows: Array<{ id: string; name: string; updatedAt: string }>) {
   const { DatabaseSync } = await import("node:sqlite");
@@ -315,6 +316,48 @@ test("file-native import falls back to node:sqlite when libSQL is unavailable", 
           assert.deepEqual(
             rows.map((row) => row.id),
             ["node-sqlite-chat"],
+          );
+        } finally {
+          await db._fileStore.close();
+        }
+      }),
+    );
+  } finally {
+    await removeTempDir(root);
+  }
+});
+
+test("file-native storage does not resurrect a deleted chat from the legacy import source", async () => {
+  const root = mkdtempSync(join(tmpdir(), "marinara-file-delete-legacy-"));
+  try {
+    const storageDir = join(root, "storage");
+    const legacyDb = join(root, "legacy.db");
+    await writeLegacyDb(legacyDb, [
+      { id: "keep-chat", name: "Keep Chat", updatedAt: "2026-05-02T00:00:00.000Z" },
+      { id: "delete-chat", name: "Delete Chat", updatedAt: "2026-05-02T00:00:00.000Z" },
+    ]);
+
+    await withEnv("MARINARA_DISABLE_LIBSQL_LEGACY_READER", "true", () =>
+      withFileStorageDir(storageDir, async () => {
+        let db = await createFileNativeDB([legacyDb]);
+        try {
+          const storage = createChatsStorage(db);
+          await storage.remove("delete-chat");
+          const afterDelete = await db.select().from(chats);
+          assert.deepEqual(
+            afterDelete.map((row) => row.id).sort(),
+            ["keep-chat"],
+          );
+        } finally {
+          await db._fileStore.close();
+        }
+
+        db = await createFileNativeDB([legacyDb]);
+        try {
+          const afterRestart = await db.select().from(chats);
+          assert.deepEqual(
+            afterRestart.map((row) => row.id).sort(),
+            ["keep-chat"],
           );
         } finally {
           await db._fileStore.close();


### PR DESCRIPTION
## Linked issue

Discord bug report: “Chat files not deleting with manual deletion” on Termux / Marinara 1.5.9. No GitHub issue exists yet.

## Why this change

- Users deleting chat files from Manage Chat Files could see the confirmation complete, but the deleted chat file would still be present after refreshing/restarting Marinara.
- The reproduced root cause is in the v1.5.7+ file-native migration path: after a successful legacy SQLite import, the startup repair pass could treat an intentionally deleted imported chat as a missing legacy row and restore it from the old recovery database.

## What changed

- Mark successful legacy SQLite imports as already reconciled so later startup repair does not resurrect intentionally deleted imported rows.
- Add a regression test proving a deleted imported chat stays deleted after reopening file-native storage with the legacy DB still present.
- Make the Manage Chat Files delete path await the delete mutation, pass the known group ID for cache updates, refetch the group list, and show an error toast if deletion fails.

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Automated repro before fix: imported two legacy chats, deleted one from file-native storage, reopened storage with the legacy DB still present, and observed the deleted chat return.
- Automated repro after fix: same sequence leaves the deleted chat absent after reopening storage.
- Ran `pnpm --filter @marinara-engine/server exec tsx --import ./test/setup-env.ts --test test/file-backed-store.test.ts`.
- Ran `pnpm check`.
- Manual browser verification on this branch:
  - Built the current client bundle so the server served the updated Manage Chat Files drawer.
  - Started Marinara against an isolated file-native data directory seeded with a legacy SQLite database containing two grouped chat files.
  - Opened the real app UI, opened Manage Chat Files, deleted one branch, and confirmed the drawer refetched to one remaining chat file.
  - Restarted the server with the legacy database still present and confirmed the deleted branch stayed absent in both API data and the Manage Chat Files UI.
- Manual Termux confirmation is still recommended because the original report came from a Discord user device.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

N/A. The UI behavior is unchanged except for awaiting/refetching the existing delete action and surfacing delete failures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed issue where deleted chats could reappear after restart when imported from legacy databases.
  * Improved error handling for chat deletion operations with on-screen notifications.

* **Improvements**
  * Enhanced chat branch deletion with more reliable state management and recovery logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/756)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->