### PR TITLE
Fix Termux startup when sharp cannot load

### DIFF
--- a/packages/server/src/routes/game-assets.routes.ts
+++ b/packages/server/src/routes/game-assets.routes.ts
@@ -59,21 +59,29 @@ function saveMeta(meta: Record<string, FolderMeta>) {
 type SharpFn = any;
 let cachedSharp: SharpFn | null = null;
 let sharpLoadFailed = false;
+let sharpLoadPromise: Promise<SharpFn | null> | null = null;
 async function getSharp(): Promise<SharpFn | null> {
   if (cachedSharp) return cachedSharp;
   if (sharpLoadFailed) return null;
+  if (sharpLoadPromise) return sharpLoadPromise;
 
-  try {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore - optional native dep, may not load on some platforms
-    const mod = await import("sharp");
-    cachedSharp = (mod.default ?? mod) as SharpFn;
-    return cachedSharp;
-  } catch (error) {
-    sharpLoadFailed = true;
-    logger.debug(error, "[game-assets] Image metadata unavailable because sharp could not be loaded");
-    return null;
-  }
+  sharpLoadPromise = (async () => {
+    try {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore - optional native dep, may not load on some platforms
+      const mod = await import("sharp");
+      cachedSharp = (mod.default ?? mod) as SharpFn;
+      return cachedSharp;
+    } catch (error) {
+      sharpLoadFailed = true;
+      logger.debug(error, "[game-assets] Image metadata unavailable because sharp could not be loaded");
+      return null;
+    } finally {
+      sharpLoadPromise = null;
+    }
+  })();
+
+  return sharpLoadPromise;
 }
 
 const MIME_MAP: Record<string, string> = {
@@ -980,8 +988,8 @@ export async function gameAssetsRoutes(app: FastifyInstance) {
             info.width = metadata.width;
             info.height = metadata.height;
             info.format = metadata.format;
-          } catch {
-            // ignore sharp errors
+          } catch (error) {
+            logger.debug(error, "[game-assets] Could not extract image metadata for %s", wildcard);
           }
         }
       }

--- a/packages/server/src/routes/game-assets.routes.ts
+++ b/packages/server/src/routes/game-assets.routes.ts
@@ -21,7 +21,6 @@ import { execFile } from "child_process";
 import { platform } from "os";
 import { z } from "zod";
 import { pipeline } from "stream/promises";
-import sharp from "sharp";
 import { MUSIC_GENRES, MUSIC_INTENSITIES } from "@marinara-engine/shared";
 import { GAME_ASSETS_DIR, buildAssetManifest, getAssetManifest } from "../services/game/asset-manifest.service.js";
 import { assertInsideDir } from "../utils/security.js";
@@ -51,6 +50,30 @@ function loadMeta(): Record<string, FolderMeta> {
  */
 function saveMeta(meta: Record<string, FolderMeta>) {
   writeFileSync(META_PATH, JSON.stringify(meta, null, 2), "utf-8");
+}
+
+// sharp can fail to load on Android/Termux because it has no native Android
+// prebuild. Lazy-load it so metadata enrichment can degrade without blocking
+// server startup.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type SharpFn = any;
+let cachedSharp: SharpFn | null = null;
+let sharpLoadFailed = false;
+async function getSharp(): Promise<SharpFn | null> {
+  if (cachedSharp) return cachedSharp;
+  if (sharpLoadFailed) return null;
+
+  try {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore - optional native dep, may not load on some platforms
+    const mod = await import("sharp");
+    cachedSharp = (mod.default ?? mod) as SharpFn;
+    return cachedSharp;
+  } catch (error) {
+    sharpLoadFailed = true;
+    logger.debug(error, "[game-assets] Image metadata unavailable because sharp could not be loaded");
+    return null;
+  }
 }
 
 const MIME_MAP: Record<string, string> = {
@@ -950,13 +973,16 @@ export async function gameAssetsRoutes(app: FastifyInstance) {
     if (stat.isFile()) {
       const ext = extname(wildcard).toLowerCase();
       if (IMAGE_EXTS.has(ext)) {
-        try {
-          const metadata = await sharp(filePath).metadata();
-          info.width = metadata.width;
-          info.height = metadata.height;
-          info.format = metadata.format;
-        } catch {
-          // ignore sharp errors
+        const sharp = await getSharp();
+        if (sharp) {
+          try {
+            const metadata = await sharp(filePath).metadata();
+            info.width = metadata.width;
+            info.height = metadata.height;
+            info.format = metadata.format;
+          } catch {
+            // ignore sharp errors
+          }
         }
       }
     }


### PR DESCRIPTION
## Linked issue

Related: #746
Related: #752

## Why this change

Termux users can reach the startup banner and then the server exits while loading `sharp` with the Android ARM64 runtime. Game asset image metadata is nice-to-have enrichment, but it should not block the entire app from booting on platforms where `sharp` cannot load.

## What changed

- Lazy-load `sharp` inside the Game Assets route instead of importing it during server startup.
- Skip optional width/height/format metadata when `sharp` is unavailable, while still returning basic file info.

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

Automated/local proof performed:

- Reproduced the startup import failure by importing `packages/server/dist/routes/game-assets.routes.js` with a Node ESM loader that makes `sharp` throw during module evaluation. Before the fix, this exited with `IMPORT_FAILED`.
- Rebuilt the server and reran the same import simulation. After the fix, it exited with `IMPORT_OK`.
- Checked `GET /api/game-assets/file-info/backgrounds/fantasy/mock.png` with `sharp` forced unavailable. The endpoint returned `200` with basic file info and omitted optional image metadata fields.
- Ran `pnpm check`; it passed locally.

Still needs human/device verification:

- Run `./start-termux.sh` on an Android/Termux install that previously crashed with the `sharp` android-arm64 runtime error.

nah, gl guys

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

Not applicable; this is a server startup/runtime fallback fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved platform compatibility by implementing lazy loading of native dependencies, preventing startup issues on systems without native support.
  * Enhanced image metadata enrichment to conditionally extract and display image dimensions and format information with robust error handling for extraction failures.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/758)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->