### PR TITLE
Fix hidden message regeneration crash

### DIFF
--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -885,8 +885,11 @@ export async function generateRoutes(app: FastifyInstance) {
 
       // ── Regeneration as swipe: exclude the target message from context ──
       if (input.regenerateMessageId) {
-        regenMsg = chatMessages.find((m: any) => m.id === input.regenerateMessageId);
-        if (!regenMsg) return reply.code(404).send({ error: "Regenerated message not found" });
+        regenMsg = scopedMessages.find((m: any) => m.id === input.regenerateMessageId);
+        if (!regenMsg) {
+          sendSseEvent(reply, { type: "error", data: "Regenerated message not found" });
+          return;
+        }
         chatMessages = chatMessages.filter((m: any) => m.id !== input.regenerateMessageId);
         lorebookKeeperMessages = lorebookKeeperMessages.filter((m: any) => m.id !== input.regenerateMessageId);
       }
@@ -6547,10 +6550,14 @@ export async function generateRoutes(app: FastifyInstance) {
         }
 
         if (regenGroupChatIndividual) {
-          if (regenMsg?.chatId !== input.chatId)
-            return reply.code(400).send({ error: "Regenerated message does not belong to this chat" });
-          if (!regenMsg?.characterId)
-            return reply.code(400).send({ error: "Regenerated message is missing character" });
+          if (regenMsg?.chatId !== input.chatId) {
+            sendSseEvent(reply, { type: "error", data: "Regenerated message does not belong to this chat" });
+            return;
+          }
+          if (!regenMsg?.characterId) {
+            sendSseEvent(reply, { type: "error", data: "Regenerated message is missing character" });
+            return;
+          }
 
           // Get character of regenerated message and append "Respond ONLY as [name]" instruction
           targetCharId = regenMsg?.characterId ?? null;

--- a/packages/server/test/generate-hidden-regenerate.test.ts
+++ b/packages/server/test/generate-hidden-regenerate.test.ts
@@ -1,0 +1,155 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import Fastify from "fastify";
+import { createClient } from "@libsql/client";
+import { drizzle } from "drizzle-orm/libsql";
+import type { DB } from "../src/db/connection.js";
+import { runMigrations } from "../src/db/migrate.js";
+import {
+  apiConnections,
+  characters,
+  chats,
+  messages,
+  messageSwipes,
+} from "../src/db/schema/index.js";
+import { generateRoutes } from "../src/routes/generate.routes.js";
+
+const now = "2026-05-12T12:00:00.000Z";
+
+function buildCharacterData(id: string, name: string) {
+  return {
+    spec: "chara_card_v2",
+    spec_version: "2.0",
+    data: {
+      id,
+      name,
+      description: `${name} description`,
+      personality: "",
+      scenario: "",
+      first_mes: "",
+      mes_example: "",
+      creator_notes: "",
+      system_prompt: "",
+      post_history_instructions: "",
+      alternate_greetings: [],
+      tags: [],
+      creator: "",
+      character_version: "",
+      extensions: {},
+    },
+  };
+}
+
+function timestamp(index: number) {
+  return `2026-05-12T12:${String(index).padStart(2, "0")}:00.000Z`;
+}
+
+test("regenerating a hidden roleplay assistant message does not treat the target as missing", async () => {
+  const client = createClient({ url: "file::memory:" });
+  const db = drizzle(client) as unknown as DB;
+  const capturedErrors: Error[] = [];
+
+  try {
+    await runMigrations(db);
+
+    await db.insert(apiConnections).values({
+      id: "conn-744",
+      name: "Repro connection",
+      provider: "custom",
+      baseUrl: "http://127.0.0.1:9/v1",
+      apiKeyEncrypted: "",
+      model: "repro-model",
+      maxContext: 4096,
+      isDefault: "false",
+      useForRandom: "false",
+      enableCaching: "false",
+      defaultForAgents: "false",
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    await db.insert(characters).values({
+      id: "char-744",
+      data: JSON.stringify(buildCharacterData("char-744", "Rina")),
+      comment: "",
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    await db.insert(chats).values({
+      id: "chat-744",
+      name: "Hidden regen repro",
+      mode: "roleplay",
+      characterIds: JSON.stringify(["char-744"]),
+      connectionId: "conn-744",
+      metadata: "{}",
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const transcript = [
+      { id: "m1", role: "user", content: "Setup one", extra: {} },
+      { id: "m2", role: "assistant", content: "Reply one", extra: { hiddenFromAI: true } },
+      { id: "m3", role: "user", content: "Setup two", extra: { hiddenFromAI: true } },
+      { id: "m4", role: "assistant", content: "Reply two", extra: { hiddenFromAI: true } },
+      { id: "target-hidden", role: "assistant", content: "Regenerate me", extra: { hiddenFromAI: true } },
+    ] as const;
+
+    for (let index = 0; index < transcript.length; index++) {
+      const row = transcript[index]!;
+      const createdAt = timestamp(index + 1);
+      await db.insert(messages).values({
+        id: row.id,
+        chatId: "chat-744",
+        role: row.role,
+        characterId: row.role === "assistant" ? "char-744" : null,
+        content: row.content,
+        activeSwipeIndex: 0,
+        extra: JSON.stringify(row.extra),
+        createdAt,
+      });
+      await db.insert(messageSwipes).values({
+        id: `swipe-${row.id}-0`,
+        messageId: row.id,
+        index: 0,
+        content: row.content,
+        extra: JSON.stringify(row.extra),
+        createdAt,
+      });
+    }
+
+    const app = Fastify({ logger: false });
+    app.decorate("db", db);
+    app.setErrorHandler((err, _request, reply) => {
+      capturedErrors.push(err);
+      void reply.status(500).send({ error: err.message });
+    });
+
+    try {
+      await app.register(generateRoutes, { prefix: "/api/generate" });
+      await app.ready();
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/generate/",
+        payload: {
+          chatId: "chat-744",
+          connectionId: "conn-744",
+          userMessage: null,
+          regenerateMessageId: "target-hidden",
+        },
+      });
+
+      assert.equal(response.statusCode, 200);
+      assert.equal(capturedErrors.length, 0);
+      assert.match(response.body, /"type":"progress"/);
+      assert.match(response.body, /"type":"error"/);
+      assert.doesNotMatch(response.body, /Regenerated message not found/);
+      assert.doesNotMatch(response.body, /Reply was already sent/);
+    } finally {
+      await app.close();
+    }
+  } finally {
+    client.close();
+  }
+});


### PR DESCRIPTION
## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #744

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- Regenerating a roleplay assistant message that was hidden from AI could treat the target as missing after SSE had already started, which could surface Fastify's `Reply was already sent` failure and crash the server.

## What changed

<!-- List the key changes in this PR -->

- Look up regenerate targets from the scoped transcript before hidden-from-AI filtering, while still removing hidden messages from the model-visible context.
- Send late regenerate validation failures as SSE error events instead of normal Fastify replies after the stream has started.
- Added a server regression test covering a hidden regenerate target with several recent hidden messages.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Codex proof: scratch route repro failed before the fix because hidden regenerate targets were treated as missing, then passed after the fix without `Regenerated message not found` or `Reply was already sent`.
- Codex proof: `pnpm --dir packages/server exec tsx --import ./test/setup-env.ts --test C:/tmp/Marinara-Engine-issue-744/scratch/issue-744-hidden-regen-repro.ts` passed.
- Codex proof: `pnpm --dir packages/server exec tsx --import ./test/setup-env.ts --test test/generate-hidden-regenerate.test.ts` passed.
- Codex proof: `pnpm --filter @marinara-engine/server test` passed 291 tests.
- Codex proof: `pnpm check` passed.
- Codex proof after fast-forwarding to current `upstream/main`: focused scratch repro and permanent regression test both still passed.
- No human-only verification blocker identified for the core server-crash claim.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs or release metadata changes are needed for this narrow server bug fix.

## UI evidence (if applicable)

N/A - backend/server crash fix. The repro is covered by the server route harness and regression test above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message regeneration to correctly locate target messages in conversation context
  * Enhanced error handling during failed regeneration attempts to provide reliable streaming responses instead of HTTP errors

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/760)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->