### PR TITLE
fix(library): use square aspect for character card image to undistort saved crops

### DIFF
--- a/packages/client/src/components/characters/CharacterLibraryView.tsx
+++ b/packages/client/src/components/characters/CharacterLibraryView.tsx
@@ -103,7 +103,7 @@ function CharacterLibraryDetailCard({
   return (
     <div className="space-y-4">
       <div className="overflow-hidden rounded-[1.5rem] border border-[var(--border)]/50 bg-[var(--background)]/70 shadow-[0_24px_70px_-40px_rgba(15,23,42,0.95)] sm:rounded-[2rem]">
-        <div className="relative aspect-[4/3] overflow-hidden bg-gradient-to-br from-pink-400/25 via-rose-500/15 to-sky-400/15">
+        <div className="relative aspect-square overflow-hidden bg-gradient-to-br from-pink-400/25 via-rose-500/15 to-sky-400/15">
           {character.avatarPath ? (
             <img
               src={character.avatarPath}
@@ -426,7 +426,7 @@ export function CharacterLibraryView() {
                           : "border-[var(--border)]/50",
                       )}
                     >
-                      <div className="relative h-24 w-24 shrink-0 overflow-hidden bg-gradient-to-br from-pink-400/25 via-rose-500/15 to-sky-400/15 sm:h-auto sm:w-full sm:aspect-[4/3]">
+                      <div className="relative h-24 w-24 shrink-0 overflow-hidden bg-gradient-to-br from-pink-400/25 via-rose-500/15 to-sky-400/15 sm:h-auto sm:w-full sm:aspect-square">
                         {char.avatarPath ? (
                           <img
                             src={char.avatarPath}

--- a/packages/client/src/components/characters/CharacterLibraryView.tsx
+++ b/packages/client/src/components/characters/CharacterLibraryView.tsx
@@ -384,7 +384,7 @@ export function CharacterLibraryView() {
           {isLoading && (
             <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
               {[1, 2, 3, 4, 5, 6].map((item) => (
-                <div key={item} className="shimmer aspect-[4/5] rounded-[1.75rem]" />
+                <div key={item} className="shimmer aspect-square rounded-[1.75rem]" />
               ))}
             </div>
           )}


### PR DESCRIPTION
## Linked issue

Closes #769

## Why this change

- Saved avatar crops in the current source-rectangle format are stored as a square in source pixels (see `AvatarCropWidget`). The Character Library card thumbnail and the detail-panel hero rendered them in an `aspect-[4/3]` container, and `getAvatarCropStyle` produces an `<img>` sized to `(cw/srcWidth × ch/srcHeight)` with `object-fit: fill` — so the square crop was stretched horizontally by exactly the container's aspect ratio (4/3). Faces looked compressed vertically / wide. A Discord user reported the bug and verified that overriding the container aspect to `1/1` via custom-theme CSS fixed the visual.

## What changed

- `packages/client/src/components/characters/CharacterLibraryView.tsx`: switched the detail-panel hero image container and the grid card image container from `aspect-[4/3]` / `sm:aspect-[4/3]` to `aspect-square` / `sm:aspect-square` so the saved square crop renders undistorted. Cards become slightly taller; uncropped portrait avatars now show more of the source than before, less cropped top/bottom.
- A related bypass (`rectangleSafeCropStyle` in `ChatMessage.tsx`) is left untouched — fixing the root math in `getAvatarCropStyle` would touch ~30 consumers and is out of scope for this report.

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Manually verify the Character Library grid: each card's image area is now a square; previously-cropped characters render with correct face proportions, not horizontally stretched.
- Manually verify the Character Library detail panel: clicking a card opens a detail view whose hero image is also square and shows the saved crop undistorted.
- Manually verify the mobile / narrow viewport: the small `h-24 w-24` thumbnail variant (below the `sm:` breakpoint) is unchanged — only the `sm:`-and-up rendering switches to `sm:aspect-square`.
- Manually verify a character with **no** saved crop still renders sanely (image fills the square via existing `object-cover` on the `<img>`).

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

Reproduced and verified on a live deploy of this branch. JS inspection confirms every Character Library image container computes at exactly 1:1 (282×282 in the grid) and `aspect-[4/3]` is absent from the rendered tree. No console errors introduced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated character avatar and thumbnail display aspect ratios to square format throughout the character library interface. Visual styling adjustments have been applied to the character detail card image containers, character loading state placeholder backgrounds, and character grid card avatars, ensuring a more uniform and consistent visual presentation across all sections.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/770)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->