### PR TITLE
Fix smart group selector Response Orchestrator settings

### DIFF
--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -10,6 +10,9 @@ import {
   findKnownModel,
   nameToXmlTag,
   DEFAULT_AGENT_TOOLS,
+  DEFAULT_AGENT_MAX_TOKENS,
+  MAX_AGENT_MAX_TOKENS,
+  MIN_AGENT_MAX_TOKENS,
   LOCAL_SIDECAR_CONNECTION_ID,
   resolveMacros,
   LIMITS,
@@ -494,6 +497,16 @@ function normalizeDmTargetName(value: string): string {
 function normalizeMaxContext(value: unknown): number | undefined {
   if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) return undefined;
   return Math.floor(value);
+}
+
+function normalizeAgentMaxTokens(value: unknown, fallback = DEFAULT_AGENT_MAX_TOKENS): number {
+  const parsed = typeof value === "number" ? value : typeof value === "string" && value.trim() ? Number(value) : NaN;
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.max(MIN_AGENT_MAX_TOKENS, Math.min(MAX_AGENT_MAX_TOKENS, Math.trunc(parsed)));
+}
+
+function applyProviderMaxTokensOverride(provider: BaseLLMProvider, maxTokens: number): number {
+  return provider.maxTokensOverrideValue !== null ? Math.min(maxTokens, provider.maxTokensOverrideValue) : maxTokens;
 }
 
 function minContextLimit(...limits: Array<number | undefined>): number | undefined {
@@ -2705,6 +2718,8 @@ export async function generateRoutes(app: FastifyInstance) {
       const agentConnectionWarnings: AgentConnectionWarning[] = [];
       const skippedLocalSidecarAgents: string[] = [];
       const defaultAgentConnectionAgents: string[] = [];
+      let responseOrchestratorSelectorAgent: ResolvedAgent | null = null;
+      let responseOrchestratorSelectorUnavailable = false;
       for (const cfg of enabledConfigs) {
         // If this chat has a per-chat agent list, only include agents in that list
         if (hasPerChatAgentList && !perChatAgentSet.has(cfg.type)) continue;
@@ -2813,6 +2828,99 @@ export async function generateRoutes(app: FastifyInstance) {
           model: builtInCached?.model ?? conn.model,
           maxParallelJobs: builtInCached?.maxParallelJobs ?? chatConnectionMaxParallelJobs,
         });
+      }
+
+      // The smart group speaker picker is an internal Response Orchestrator call,
+      // not a normal pipeline agent. Resolve only that agent's config so its
+      // connection/model/budget controls apply without enabling unrelated agents.
+      const shouldResolveResponseOrchestratorSelector =
+        !input.impersonate && characterIds.length > 1 && (chatMeta.groupResponseOrder as string) === "smart";
+      if (shouldResolveResponseOrchestratorSelector) {
+        const resolvedResponseOrchestratorAgent = resolvedAgents.find((agent) => agent.type === "response-orchestrator");
+        if (resolvedResponseOrchestratorAgent) {
+          responseOrchestratorSelectorAgent = resolvedResponseOrchestratorAgent;
+        } else {
+          const storedResponseOrchestratorConfig = await agentsStore.getByType("response-orchestrator");
+          const cfg =
+            storedResponseOrchestratorConfig ??
+            (defaultAgentConn
+              ? (BUILT_IN_AGENTS.find((agent) => agent.id === "response-orchestrator") ?? null)
+              : null);
+          if (cfg) {
+            const settings =
+              "settings" in cfg && cfg.settings
+                ? JSON.parse(cfg.settings as string)
+                : getDefaultBuiltInAgentSettings("response-orchestrator");
+            let agentProvider = provider;
+            let agentModel = conn.model;
+            let agentMaxParallelJobs = chatConnectionMaxParallelJobs;
+            const requestedConnectionId = "connectionId" in cfg ? (cfg.connectionId as string | null) : null;
+            const effectiveConnectionId = resolveAgentConnectionId({
+              requestedConnectionId,
+              defaultAgentConnectionId: defaultAgentConn?.id ?? null,
+              localSidecarAvailable: localSidecarAvailableForTrackers,
+            });
+
+            if (effectiveConnectionId === "skip-local-sidecar") {
+              responseOrchestratorSelectorUnavailable = true;
+              const alreadyWarned = skippedLocalSidecarAgents.some((agentName) => agentName === "Response Orchestrator");
+              if (!alreadyWarned) {
+                agentConnectionWarnings.push(buildLocalSidecarUnavailableWarning(["Response Orchestrator"]));
+              }
+              logger.warn(
+                "[group-smart] Skipping Response Orchestrator Local Model override for chat %s because the sidecar is unavailable",
+                input.chatId,
+              );
+            } else {
+              if (defaultAgentConn && effectiveConnectionId === defaultAgentConn.id) {
+                defaultAgentConnectionAgents.push("Response Orchestrator");
+              }
+              if (effectiveConnectionId) {
+                const cached = agentProviderCache.get(effectiveConnectionId);
+                if (cached) {
+                  agentProvider = cached.provider;
+                  agentModel = cached.model;
+                  agentMaxParallelJobs = cached.maxParallelJobs;
+                } else {
+                  const agentConn = await connections.getWithKey(effectiveConnectionId);
+                  if (agentConn) {
+                    const agentBaseUrl = resolveBaseUrl(agentConn);
+                    if (agentBaseUrl) {
+                      agentProvider = createLLMProvider(
+                        agentConn.provider,
+                        agentBaseUrl,
+                        agentConn.apiKey,
+                        agentConn.maxContext,
+                        agentConn.openrouterProvider,
+                        agentConn.maxTokensOverride,
+                      );
+                      agentModel = agentConn.model;
+                      agentMaxParallelJobs = Number(agentConn.maxParallelJobs) || 1;
+                      agentProviderCache.set(effectiveConnectionId, {
+                        provider: agentProvider,
+                        model: agentModel,
+                        maxParallelJobs: agentMaxParallelJobs,
+                      });
+                    }
+                  }
+                }
+              }
+
+              responseOrchestratorSelectorAgent = {
+                id: "id" in cfg ? String(cfg.id) : "builtin:response-orchestrator",
+                type: "response-orchestrator",
+                name: "name" in cfg ? String(cfg.name) : "Response Orchestrator",
+                phase: "phase" in cfg ? String(cfg.phase) : "pre_generation",
+                promptTemplate: "promptTemplate" in cfg ? String(cfg.promptTemplate ?? "") : "",
+                connectionId: effectiveConnectionId,
+                settings,
+                provider: agentProvider,
+                model: agentModel,
+                maxParallelJobs: agentMaxParallelJobs,
+              };
+            }
+          }
+        }
       }
 
       if (defaultAgentConn && defaultAgentConnectionAgents.length > 0) {
@@ -5482,6 +5590,7 @@ export async function generateRoutes(app: FastifyInstance) {
       const selectSmartGroupResponders = async (): Promise<string[]> => {
         const explicitMentionIds = getExplicitlyMentionedCharacterIds();
         if (explicitMentionIds.length > 0) return explicitMentionIds;
+        if (responseOrchestratorSelectorUnavailable) return fallbackSmartGroupResponders();
 
         const recentTranscript = chatMessages
           .slice(-16)
@@ -5537,10 +5646,23 @@ export async function generateRoutes(app: FastifyInstance) {
         ];
 
         try {
-          const result = await provider.chatComplete(selectionPrompt, {
-            model: conn.model,
-            temperature: 0.2,
-            maxTokens: 512,
+          const orchestratorAgent =
+            responseOrchestratorSelectorAgent ?? resolvedAgents.find((agent) => agent.type === "response-orchestrator");
+          const selectorProvider = orchestratorAgent?.provider ?? provider;
+          const selectorModel = orchestratorAgent?.model ?? conn.model;
+          const selectorTemperature =
+            typeof orchestratorAgent?.settings.temperature === "number" ? orchestratorAgent.settings.temperature : 0.2;
+          const selectorMaxTokens = orchestratorAgent
+            ? applyProviderMaxTokensOverride(
+                selectorProvider,
+                normalizeAgentMaxTokens(orchestratorAgent.settings.maxTokens, 512),
+              )
+            : applyProviderMaxTokensOverride(selectorProvider, 512);
+
+          const result = await selectorProvider.chatComplete(selectionPrompt, {
+            model: selectorModel,
+            temperature: selectorTemperature,
+            maxTokens: selectorMaxTokens,
             maxContext: effectiveMaxContext,
             topP: 1,
             stream: false,

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -2833,8 +2833,19 @@ export async function generateRoutes(app: FastifyInstance) {
       // The smart group speaker picker is an internal Response Orchestrator call,
       // not a normal pipeline agent. Resolve only that agent's config so its
       // connection/model/budget controls apply without enabling unrelated agents.
+      const selectorGroupResponseOrder = (chatMeta.groupResponseOrder as string) ?? "sequential";
+      const selectorGroupChatMode =
+        chatMode === "conversation"
+          ? selectorGroupResponseOrder === "manual"
+            ? "individual"
+            : "merged"
+          : ((chatMeta.groupChatMode as string) ?? "merged");
       const shouldResolveResponseOrchestratorSelector =
-        !input.impersonate && characterIds.length > 1 && (chatMeta.groupResponseOrder as string) === "smart";
+        !input.impersonate &&
+        !input.regenerateMessageId &&
+        characterIds.length > 1 &&
+        selectorGroupChatMode === "individual" &&
+        selectorGroupResponseOrder === "smart";
       if (shouldResolveResponseOrchestratorSelector) {
         const resolvedResponseOrchestratorAgent = resolvedAgents.find((agent) => agent.type === "response-orchestrator");
         if (resolvedResponseOrchestratorAgent) {
@@ -5652,12 +5663,10 @@ export async function generateRoutes(app: FastifyInstance) {
           const selectorModel = orchestratorAgent?.model ?? conn.model;
           const selectorTemperature =
             typeof orchestratorAgent?.settings.temperature === "number" ? orchestratorAgent.settings.temperature : 0.2;
-          const selectorMaxTokens = orchestratorAgent
-            ? applyProviderMaxTokensOverride(
-                selectorProvider,
-                normalizeAgentMaxTokens(orchestratorAgent.settings.maxTokens, 512),
-              )
-            : applyProviderMaxTokensOverride(selectorProvider, 512);
+          const selectorMaxTokens = applyProviderMaxTokensOverride(
+            selectorProvider,
+            normalizeAgentMaxTokens(orchestratorAgent?.settings?.maxTokens),
+          );
 
           const result = await selectorProvider.chatComplete(selectionPrompt, {
             model: selectorModel,

--- a/packages/server/test/generate-hidden-regenerate.test.ts
+++ b/packages/server/test/generate-hidden-regenerate.test.ts
@@ -1,11 +1,13 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import Fastify from "fastify";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { createClient } from "@libsql/client";
 import { drizzle } from "drizzle-orm/libsql";
 import type { DB } from "../src/db/connection.js";
 import { runMigrations } from "../src/db/migrate.js";
 import {
+  agentConfigs,
   apiConnections,
   characters,
   chats,
@@ -42,6 +44,47 @@ function buildCharacterData(id: string, name: string) {
 
 function timestamp(index: number) {
   return `2026-05-12T12:${String(index).padStart(2, "0")}:00.000Z`;
+}
+
+function readRequestBody(req: IncomingMessage): Promise<Record<string, unknown>> {
+  return new Promise((resolve, reject) => {
+    let body = "";
+    req.setEncoding("utf8");
+    req.on("data", (chunk) => {
+      body += chunk;
+    });
+    req.on("end", () => {
+      try {
+        resolve(body ? (JSON.parse(body) as Record<string, unknown>) : {});
+      } catch (error) {
+        reject(error);
+      }
+    });
+    req.on("error", reject);
+  });
+}
+
+function writeChatCompletion(res: ServerResponse, content: string) {
+  res.writeHead(200, { "content-type": "application/json" });
+  res.end(
+    JSON.stringify({
+      id: "chatcmpl-test",
+      object: "chat.completion",
+      created: 0,
+      model: "test-model",
+      choices: [{ index: 0, message: { role: "assistant", content }, finish_reason: "stop" }],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    }),
+  );
+}
+
+function closeServer(server: ReturnType<typeof createServer>): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
 }
 
 test("regenerating a hidden roleplay assistant message does not treat the target as missing", async () => {
@@ -151,5 +194,152 @@ test("regenerating a hidden roleplay assistant message does not treat the target
     }
   } finally {
     client.close();
+  }
+});
+
+test("smart group selector uses the configured Response Orchestrator connection and budget", async () => {
+  const selectorRequests: Record<string, unknown>[] = [];
+  const mainRequests: Record<string, unknown>[] = [];
+  const selectorServer = createServer(async (req, res) => {
+    const body = await readRequestBody(req);
+    selectorRequests.push(body);
+    writeChatCompletion(res, JSON.stringify({ characterIds: ["char-alpha"], reason: "most relevant" }));
+  });
+  const mainServer = createServer(async (req, res) => {
+    const body = await readRequestBody(req);
+    mainRequests.push(body);
+    writeChatCompletion(res, "Alpha replies from the main model.");
+  });
+  const selectorUrl = await new Promise<string>((resolve) => {
+    selectorServer.listen(0, "127.0.0.1", () => {
+      const address = selectorServer.address();
+      assert.ok(address && typeof address === "object");
+      resolve(`http://127.0.0.1:${address.port}/v1`);
+    });
+  });
+  const mainUrl = await new Promise<string>((resolve) => {
+    mainServer.listen(0, "127.0.0.1", () => {
+      const address = mainServer.address();
+      assert.ok(address && typeof address === "object");
+      resolve(`http://127.0.0.1:${address.port}/v1`);
+    });
+  });
+  const client = createClient({ url: "file::memory:" });
+  const db = drizzle(client) as unknown as DB;
+
+  try {
+    await runMigrations(db);
+
+    await db.insert(apiConnections).values([
+      {
+        id: "conn-main",
+        name: "Main connection",
+        provider: "custom",
+        baseUrl: mainUrl,
+        apiKeyEncrypted: "",
+        model: "main-model",
+        maxContext: 4096,
+        isDefault: "false",
+        useForRandom: "false",
+        enableCaching: "false",
+        defaultForAgents: "false",
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        id: "conn-orchestrator",
+        name: "Orchestrator connection",
+        provider: "custom",
+        baseUrl: selectorUrl,
+        apiKeyEncrypted: "",
+        model: "orchestrator-model",
+        maxContext: 4096,
+        isDefault: "false",
+        useForRandom: "false",
+        enableCaching: "false",
+        defaultForAgents: "false",
+        createdAt: now,
+        updatedAt: now,
+      },
+    ]);
+
+    await db.insert(agentConfigs).values({
+      id: "agent-response-orchestrator",
+      type: "response-orchestrator",
+      name: "Response Orchestrator",
+      description: "Selects group speakers",
+      phase: "pre_generation",
+      enabled: "true",
+      connectionId: "conn-orchestrator",
+      promptTemplate: "",
+      settings: JSON.stringify({ maxTokens: 2048, temperature: 0.4 }),
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    await db.insert(characters).values([
+      {
+        id: "char-alpha",
+        data: JSON.stringify(buildCharacterData("char-alpha", "Alpha")),
+        comment: "",
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        id: "char-beta",
+        data: JSON.stringify(buildCharacterData("char-beta", "Beta")),
+        comment: "",
+        createdAt: now,
+        updatedAt: now,
+      },
+    ]);
+
+    await db.insert(chats).values({
+      id: "chat-smart-selector",
+      name: "Smart selector repro",
+      mode: "roleplay",
+      characterIds: JSON.stringify(["char-alpha", "char-beta"]),
+      connectionId: "conn-main",
+      metadata: JSON.stringify({
+        enableAgents: true,
+        activeAgentIds: [],
+        groupChatMode: "individual",
+        groupResponseOrder: "smart",
+      }),
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const app = Fastify({ logger: false });
+    app.decorate("db", db);
+    try {
+      await app.register(generateRoutes, { prefix: "/api/generate" });
+      await app.ready();
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/generate/",
+        payload: {
+          chatId: "chat-smart-selector",
+          connectionId: "conn-main",
+          userMessage: "Who wants to answer this?",
+          streaming: false,
+        },
+      });
+
+      assert.equal(response.statusCode, 200);
+      assert.equal(selectorRequests.length, 1);
+      assert.equal(mainRequests.length, 1);
+      assert.equal(selectorRequests[0]!.model, "orchestrator-model");
+      assert.equal(selectorRequests[0]!.max_tokens, 2048);
+      assert.equal(selectorRequests[0]!.temperature, 0.4);
+      assert.equal(selectorRequests[0]!.stream, false);
+      assert.equal(mainRequests[0]!.model, "main-model");
+    } finally {
+      await app.close();
+    }
+  } finally {
+    client.close();
+    await Promise.all([closeServer(selectorServer), closeServer(mainServer)]);
   }
 });

--- a/packages/server/test/generate-hidden-regenerate.test.ts
+++ b/packages/server/test/generate-hidden-regenerate.test.ts
@@ -210,14 +210,16 @@ test("smart group selector uses the configured Response Orchestrator connection 
     mainRequests.push(body);
     writeChatCompletion(res, "Alpha replies from the main model.");
   });
-  const selectorUrl = await new Promise<string>((resolve) => {
+  const selectorUrl = await new Promise<string>((resolve, reject) => {
+    selectorServer.once("error", reject);
     selectorServer.listen(0, "127.0.0.1", () => {
       const address = selectorServer.address();
       assert.ok(address && typeof address === "object");
       resolve(`http://127.0.0.1:${address.port}/v1`);
     });
   });
-  const mainUrl = await new Promise<string>((resolve) => {
+  const mainUrl = await new Promise<string>((resolve, reject) => {
+    mainServer.once("error", reject);
     mainServer.listen(0, "127.0.0.1", () => {
       const address = mainServer.address();
       assert.ok(address && typeof address === "object");
@@ -323,7 +325,7 @@ test("smart group selector uses the configured Response Orchestrator connection 
           chatId: "chat-smart-selector",
           connectionId: "conn-main",
           userMessage: "Who wants to answer this?",
-          streaming: false,
+          streaming: true,
         },
       });
 


### PR DESCRIPTION
## Linked issue

Closes #775

## Why this change

- Smart group chats use a hidden speaker-selection call to decide which character responds next.
- That selector was using the chat/default connection plumbing with a small fixed budget instead of the saved Response Orchestrator agent connection and settings.
- Users configuring Response Orchestrator could therefore see no effect on the actual hidden chooser call.

## What changed

- Resolved the Response Orchestrator config for smart group speaker selection without enabling unrelated pipeline agents.
- Applied the configured Response Orchestrator provider/model, temperature, max-token budget, and provider max-token override to the hidden chooser call.
- Reused an already-resolved active Response Orchestrator agent to avoid duplicate Local Model/default-agent billing warnings.
- Added a regression test proving the selector uses the Response Orchestrator connection/settings while main generation stays on the chat connection.
- Awaited the fake provider HTTP server shutdowns in the regression test.

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Codex ran `pnpm --filter @marinara-engine/server test -- test/generate-hidden-regenerate.test.ts`; all 292 server tests passed.
- Codex ran `pnpm check`; it passed.
- Codex ran `docker build -t marinara-engine:response-orchestrator-selector .`; it passed.
- Human manual verification: configured/tested the smart group Response Orchestrator path and confirmed it works.

## Docs and release impact

- [x] No docs changes needed
- [x] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [x] Version/release files updated (only if this PR includes a version bump)

No docs, release, or version files changed.

## UI evidence (if applicable)

N/A. Server-side routing/configuration fix; no UI changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced "smart" group speaker selection to use dedicated orchestrator agent's model and token budget settings.
  * Added configurable token-clamping with provider-specific maximum token overrides.
  * Improved fallback behavior when orchestrator configuration is unavailable.

* **Tests**
  * Added test coverage for smart group speaker selector routing and agent integration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/776)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->