### PR TITLE
Fix Gemini gzip response decoding

### DIFF
--- a/packages/server/src/services/llm/providers/google.provider.ts
+++ b/packages/server/src/services/llm/providers/google.provider.ts
@@ -9,6 +9,7 @@ import {
   type ChatOptions,
   type LLMUsage,
 } from "../base-provider.js";
+import { decodePossiblyCompressedBody } from "../../../utils/security.js";
 
 /** A single Gemini response part (text, thought summary, or signature-only). */
 interface GeminiPart {
@@ -131,14 +132,18 @@ export class GoogleProvider extends BaseLLMProvider {
       ...(options.signal ? { signal: options.signal } : {}),
     });
 
+    async function readDecodedText() {
+      return decodePossiblyCompressedBody(Buffer.from(await response.arrayBuffer())).toString("utf8");
+    }
+
     if (!response.ok) {
-      const errorText = await response.text();
+      const errorText = await readDecodedText();
       throw new Error(`Gemini API error ${response.status}: ${sanitizeApiError(errorText)}`);
     }
 
     // ── Non-streaming path (also used when thinking is enabled) ──
     if (!useStreaming) {
-      const json = (await response.json()) as {
+      const json = JSON.parse(await readDecodedText()) as {
         candidates?: Array<{
           content: { parts: GeminiPart[] };
         }>;

--- a/packages/server/src/utils/security.ts
+++ b/packages/server/src/utils/security.ts
@@ -1,6 +1,7 @@
 import { promises as dns } from "node:dns";
 import { createHash, timingSafeEqual } from "node:crypto";
 import { basename, extname, relative, resolve, sep, win32 } from "node:path";
+import { gunzipSync } from "node:zlib";
 import { Agent } from "undici";
 import { isLoopbackIp, isPrivateNetworkIp } from "../middleware/ip-allowlist.js";
 import { CSRF_HEADER, CSRF_HEADER_VALUE } from "@marinara-engine/shared";
@@ -386,7 +387,8 @@ async function readCappedResponse(response: Response, maxBytes: number, dispatch
   } finally {
     await dispatcher?.close().catch(() => undefined);
   }
-  return new Response(Buffer.concat(chunks), {
+  const body = decodePossiblyCompressedBody(Buffer.concat(chunks));
+  return new Response(body, {
     status: response.status,
     statusText: response.statusText,
     headers: response.headers,
@@ -432,6 +434,13 @@ function capStreamingResponse(response: Response, maxBytes: number, dispatcher?:
     statusText: response.statusText,
     headers: response.headers,
   });
+}
+
+export function decodePossiblyCompressedBody(buffer: Buffer): Buffer {
+  if (buffer.length >= 2 && buffer[0] === 0x1f && buffer[1] === 0x8b) {
+    return gunzipSync(buffer);
+  }
+  return buffer;
 }
 
 export async function safeFetch(url: string | URL, options: SafeFetchOptions = {}): Promise<Response> {


### PR DESCRIPTION
## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #771

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- Gemini model fetching and non-streaming chat responses can fail with `Unexpected token '\u001f'` when a provider/proxy returns gzip-compressed JSON bytes without a usable `Content-Encoding` header.

## What changed

<!-- List the key changes in this PR -->

- Added gzip magic-byte decoding to the server outbound fetch wrapper after capped buffering, so provider model-list responses are readable even when gzip is unlabeled.
- Updated the native Google/Gemini non-streaming response parse path to decode the same gzip-byte shape before JSON parsing.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- âš ï¸ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Codex reproduced the failure with `pnpm --dir packages/server exec tsx ../../scratch/issue-771-gzip-repro.ts`: before the fix, an unlabeled gzip model response failed with the same raw gzip-byte JSON parse error.
- Codex re-ran the same scratch proof after the fix. Results: plain JSON parsed, header-labeled gzip parsed, unlabeled gzip parsed, and the Google provider non-streaming chat path returned `hello from gemini`.
- Codex ran `pnpm check`; it passed.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs or release metadata changes needed; this is a narrow provider response decoding fix.

## UI evidence (if applicable)

N/A. This is a server/provider response decoding bug with command-level proof.
