### PR TITLE
Fix generated game asset filename length

### DIFF
--- a/packages/server/src/services/game/game-asset-generation.ts
+++ b/packages/server/src/services/game/game-asset-generation.ts
@@ -8,6 +8,7 @@
 // ──────────────────────────────────────────────
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { createHash } from "crypto";
 import { logger } from "../../lib/logger.js";
 import { basename, join } from "path";
 import { DATA_DIR } from "../../utils/data-dir.js";
@@ -31,6 +32,7 @@ const GAME_BACKGROUND_NEGATIVE_PROMPT =
   "text, letters, captions, subtitles, UI, watermark, logo, signature, people, character, portrait, split screen, panel, collage, contact sheet, grid, multiple frames, low quality";
 const GAME_ILLUSTRATION_NEGATIVE_PROMPT =
   "text, letters, captions, subtitles, UI, watermark, logo, signature, speech bubble, split screen, panel, collage, contact sheet, character sheet, grid, four images, duplicated face, extra head, unrelated character, bad anatomy, low quality";
+const MAX_GENERATED_ASSET_SLUG_BYTES = 180;
 
 // sharp is optional in the server package. Generated game backgrounds should be
 // stored at the VN canvas ratio when possible, but generation must still work on
@@ -191,6 +193,28 @@ function safeName(name: string): string {
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/(^-|-$)/g, "");
+}
+
+function truncateSlugByBytes(slug: string, maxBytes: number): string {
+  let truncated = slug;
+  while (Buffer.byteLength(truncated, "utf8") > maxBytes) {
+    truncated = truncated.slice(0, -1);
+  }
+  return truncated.replace(/-+$/g, "");
+}
+
+export function safeGeneratedAssetSlug(name: string, opts: { maxBytes?: number; suffix?: string } = {}): string {
+  const maxBytes = opts.maxBytes ?? MAX_GENERATED_ASSET_SLUG_BYTES;
+  const slug = safeName(name) || "asset";
+  const suffix = opts.suffix ? safeName(opts.suffix) : "";
+  const candidate = suffix ? `${slug}-${suffix}` : slug;
+  if (Buffer.byteLength(candidate, "utf8") <= maxBytes) return candidate;
+
+  const hash = createHash("sha256").update(slug).digest("hex").slice(0, 8);
+  const tail = [hash, suffix].filter(Boolean).join("-");
+  const prefixBudget = Math.max(1, maxBytes - Buffer.byteLength(tail, "utf8") - 1);
+  const prefix = truncateSlugByBytes(slug, prefixBudget) || "asset";
+  return `${prefix}-${tail}`;
 }
 
 function hasExplicitNonHumanCue(value: string): boolean {
@@ -435,7 +459,7 @@ export async function buildSceneIllustrationImagePrompt(req: SceneIllustrationGe
  * asset manifest. Returns the asset tag on success, or null on failure.
  */
 export async function generateBackground(req: BackgroundGenRequest): Promise<string | null> {
-  const slug = safeName(req.locationSlug);
+  const slug = safeGeneratedAssetSlug(req.locationSlug);
   if (!slug) return null;
 
   const subcategory = genreToFolder(req.genre);
@@ -506,7 +530,7 @@ export async function generateBackground(req: BackgroundGenRequest): Promise<str
  * Returns the saved filename on success, or null on failure.
  */
 export async function generateChatBackground(req: ChatBackgroundGenRequest): Promise<string | null> {
-  const baseSlug = safeName(req.locationSlug || req.sceneDescription.slice(0, 80));
+  const baseSlug = safeGeneratedAssetSlug(req.locationSlug || req.sceneDescription.slice(0, 80), { maxBytes: 160 });
   if (!baseSlug) return null;
 
   const slug = `generated-${baseSlug}`;
@@ -571,8 +595,9 @@ export async function generateChatBackground(req: ChatBackgroundGenRequest): Pro
 }
 
 export async function generateSceneIllustration(req: SceneIllustrationGenRequest): Promise<string | null> {
-  const baseSlug = safeName(req.slug || req.reason || req.prompt.slice(0, 80)) || "scene-illustration";
-  const slug = `${baseSlug}-${Date.now().toString(36)}`;
+  const slug = safeGeneratedAssetSlug(req.slug || req.reason || req.prompt.slice(0, 80) || "scene-illustration", {
+    suffix: Date.now().toString(36),
+  });
   const targetDir = join(GAME_ASSETS_DIR, "backgrounds", "illustrations");
   const tag = `backgrounds:illustrations:${slug}`;
 

--- a/packages/server/test/game-asset-generation.test.ts
+++ b/packages/server/test/game-asset-generation.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { safeGeneratedAssetSlug } from "../src/services/game/game-asset-generation.js";
+
+test("generated asset slugs stay under platform filename limits", () => {
+  const longSceneSlug =
+    "story defining moment of intimate emotional recognition akari s deliberate disobedience rewarded hassan s possessive desire deepened power dynamics established the song performance is the emotional and narrative climax of this scene where vulnerability becomes weaponized intimacy";
+  const slug = safeGeneratedAssetSlug(longSceneSlug, { suffix: "mp3ckuzn" });
+  const filename = `${slug}.png`;
+
+  assert.equal(Buffer.byteLength(filename, "utf8") <= 255, true);
+  assert.equal(slug.endsWith("-mp3ckuzn"), true);
+  assert.match(slug, /-[a-f0-9]{8}-mp3ckuzn$/);
+});
+
+test("generated asset slugs keep short readable names unchanged", () => {
+  assert.equal(safeGeneratedAssetSlug("Dark Forest Clearing", { suffix: "abc123" }), "dark-forest-clearing-abc123");
+});


### PR DESCRIPTION
## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #790

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- Game Mode scene illustrations can receive long scene-analyzer slugs, and those slugs were being used directly as generated background filenames. On Android/Termux this could exceed the 255-byte filename limit and prevent the image from saving with `ENAMETOOLONG`.

## What changed

<!-- List the key changes in this PR -->

- Added a shared generated-asset slug helper that sanitizes names, caps the byte length, and appends a short hash when truncation is needed.
- Applied that helper to generated game backgrounds, roleplay chat backgrounds, and rare scene illustrations before constructing filesystem filenames.
- Added a focused regression test for the issue slug and for short readable slugs.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Codex reproduced the issue filename with `pnpm --dir packages/server exec tsx ../../scratch/issue-790-filename-repro.ts before`: the generated filename was 293 bytes, above the 255-byte Android/Termux filename limit.
- Codex re-ran the same repro after the fix with `pnpm --dir packages/server exec tsx ../../scratch/issue-790-filename-repro.ts after`: the generated filename was 184 bytes, below the 255-byte limit, and the write succeeded.
- Codex ran `pnpm --dir packages/server exec tsx --import ./test/setup-env.ts --test test/game-asset-generation.test.ts`: 2 tests passed.
- Codex ran `pnpm check`: passed.
- No true human-only verification is required for the core filename-length claim. An Android/Termux runtime smoke test would still be useful as an environment regression check, but the core slug/filename limit is proven by the script and regression test.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs or release metadata changes needed; this is a narrow server-side filename safety fix.

## UI evidence (if applicable)

N/A - this is not a visual/UI issue. The proof is command output from the filename-limit repro and server regression test.
