### PR TITLE
Fix custom agent prompt section names

### DIFF
--- a/docs/pr-evidence/issue-789/repro-output.json
+++ b/docs/pr-evidence/issue-789/repro-output.json
@@ -1,0 +1,25 @@
+{
+  "passed": true,
+  "results": [
+    {
+      "name": "single XML injection uses current agent name",
+      "passed": true,
+      "output": "<probability_engine>\n[INSTRUCTION FROM PROBABILITY ENGINE: Actions are not contested.]\n</probability_engine>"
+    },
+    {
+      "name": "single Markdown injection uses current agent name",
+      "passed": true,
+      "output": "## Probability Engine\n[INSTRUCTION FROM PROBABILITY ENGINE: Actions are not contested.]"
+    },
+    {
+      "name": "multiple injections use each current name",
+      "passed": true,
+      "output": "<probability_engine>\n[INSTRUCTION FROM PROBABILITY ENGINE: Actions are not contested.]\n</probability_engine>\n\n<narrative_director>\nKeep the pacing deliberate.\n</narrative_director>"
+    },
+    {
+      "name": "legacy cached injection falls back to agent type",
+      "passed": true,
+      "output": "<director>\nKeep the pacing deliberate.\n</director>"
+    }
+  ]
+}

--- a/packages/client/src/components/agents/ContextInjectionPanel.tsx
+++ b/packages/client/src/components/agents/ContextInjectionPanel.tsx
@@ -43,11 +43,11 @@ function findLastAssistant(messages: Message[] | undefined): Message | null {
   return null;
 }
 
-function agentLabel(agentType: string): string {
-  return INJECTION_LABEL[agentType] ?? agentType;
+function agentLabel(agentType: string, agentName?: string): string {
+  return agentName?.trim() || INJECTION_LABEL[agentType] || agentType;
 }
 
-type CachedInjection = { agentType: string; text: string };
+type CachedInjection = { agentType: string; agentName?: string; text: string };
 
 type AgentCadenceStatus = {
   agentType: string;
@@ -68,9 +68,13 @@ function normalizeContextInjections(raw: unknown): CachedInjection[] {
       continue;
     }
     if (!entry || typeof entry !== "object") continue;
-    const candidate = entry as { agentType?: unknown; text?: unknown };
+    const candidate = entry as { agentType?: unknown; agentName?: unknown; text?: unknown };
     if (typeof candidate.agentType !== "string" || typeof candidate.text !== "string") continue;
-    normalized.push({ agentType: candidate.agentType, text: candidate.text });
+    normalized.push({
+      agentType: candidate.agentType,
+      agentName: typeof candidate.agentName === "string" ? candidate.agentName : undefined,
+      text: candidate.text,
+    });
   }
   return normalized;
 }
@@ -165,7 +169,9 @@ export function ContextInjectionPanel({
   const handleSaveOne = useCallback(
     (agentType: string) => {
       const text = drafts[agentType] ?? "";
-      const list = injections.map((inj) => (inj.agentType === agentType ? { agentType, text } : { ...inj }));
+      const list = injections.map((inj) =>
+        inj.agentType === agentType ? { agentType, agentName: inj.agentName, text } : { ...inj },
+      );
       if (!target || !chatId) return;
       setSavingType(agentType);
       setSavedType(null);
@@ -298,7 +304,7 @@ export function ContextInjectionPanel({
                         )}
                       />
                       <span className="truncate text-[0.625rem] font-semibold text-[var(--popover-foreground)]">
-                        {agentLabel(inj.agentType)}
+                        {agentLabel(inj.agentType, inj.agentName)}
                       </span>
                       {dirty && (
                         <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--primary)]" title="Unsaved edit" />
@@ -311,8 +317,8 @@ export function ContextInjectionPanel({
                           disabled={isGenerationBusy || !!rerollingType || updateExtra.isPending}
                           onClick={() => handleReroll(inj.agentType)}
                           className="inline-flex h-6 w-6 items-center justify-center rounded-md text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)]/55 hover:text-[var(--accent-foreground)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--ring)] disabled:opacity-40 max-md:h-7 max-md:w-7"
-                          title={`Re-run ${agentLabel(inj.agentType)} injection`}
-                          aria-label={`Re-run ${agentLabel(inj.agentType)} injection`}
+                          title={`Re-run ${agentLabel(inj.agentType, inj.agentName)} injection`}
+                          aria-label={`Re-run ${agentLabel(inj.agentType, inj.agentName)} injection`}
                         >
                           <RefreshCw size="0.625rem" className={cn(rerollBusy && "animate-spin")} />
                         </button>
@@ -324,13 +330,13 @@ export function ContextInjectionPanel({
                         className="inline-flex h-6 w-6 items-center justify-center rounded-md text-[var(--primary)] transition-colors hover:bg-[var(--primary)]/15 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--ring)] disabled:opacity-40 max-md:h-7 max-md:w-7"
                         title={
                           saved
-                            ? `${agentLabel(inj.agentType)} injection saved`
-                            : `Save ${agentLabel(inj.agentType)} injection`
+                            ? `${agentLabel(inj.agentType, inj.agentName)} injection saved`
+                            : `Save ${agentLabel(inj.agentType, inj.agentName)} injection`
                         }
                         aria-label={
                           saved
-                            ? `${agentLabel(inj.agentType)} injection saved`
-                            : `Save ${agentLabel(inj.agentType)} injection`
+                            ? `${agentLabel(inj.agentType, inj.agentName)} injection saved`
+                            : `Save ${agentLabel(inj.agentType, inj.agentName)} injection`
                         }
                       >
                         {saved ? (

--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -237,6 +237,7 @@ export function ChatArea() {
     if (!agentInjectionReview) return;
     const overrides = agentInjectionReview.injections.map((injection) => ({
       agentType: injection.agentType,
+      agentName: injection.agentName,
       text: agentInjectionDrafts[injection.agentType] ?? injection.text,
     }));
     const chatId = agentInjectionReview.chatId;

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -531,7 +531,7 @@ export function useGenerate() {
       mentionedCharacterNames?: string[];
       forCharacterId?: string;
       generationGuide?: string;
-      agentInjectionOverrides?: Array<{ agentType: string; text: string }>;
+      agentInjectionOverrides?: Array<{ agentType: string; agentName?: string; text: string }>;
       impersonatePresetId?: string;
       impersonateConnectionId?: string;
       impersonateBlockAgents?: boolean;

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -586,22 +586,25 @@ function packRecalledMemories(
 
 /**
  * Format agent injection results into a wrapped block for prompt injection.
- * Each agent gets its own XML/markdown section with its type as the tag name.
+ * Each agent gets its own XML/markdown section with its current display name
+ * as the section label, falling back to the stable type for legacy caches.
  */
 function formatAgentInjections(injections: AgentInjection[], wrapFormat: string): string {
   if (injections.length === 1) {
-    const { agentType, text } = injections[0]!;
-    const tag = agentType.replace(/[^a-z0-9_-]/gi, "_");
-    if (wrapFormat === "markdown") return `## ${tag}\n${text}`;
+    const { agentType, agentName, text } = injections[0]!;
+    const label = agentName?.trim() || agentType;
+    const tag = nameToXmlTag(label) || agentType.replace(/[^a-z0-9_-]/gi, "_");
+    if (wrapFormat === "markdown") return `## ${label}\n${text}`;
     if (wrapFormat === "xml") return `<${tag}>\n${text}\n</${tag}>`;
     return text;
   }
   // Multiple agents — wrap each individually
   const parts: string[] = [];
-  for (const { agentType, text } of injections) {
-    const tag = agentType.replace(/[^a-z0-9_-]/gi, "_");
+  for (const { agentType, agentName, text } of injections) {
+    const label = agentName?.trim() || agentType;
+    const tag = nameToXmlTag(label) || agentType.replace(/[^a-z0-9_-]/gi, "_");
     if (wrapFormat === "markdown") {
-      parts.push(`## ${tag}\n${text}`);
+      parts.push(`## ${label}\n${text}`);
     } else if (wrapFormat === "xml") {
       parts.push(`<${tag}>\n${text}\n</${tag}>`);
     } else {
@@ -4839,8 +4842,15 @@ export async function generateRoutes(app: FastifyInstance) {
       // prose-guardian) which improve writing quality and should run every time.
       // On regens, reuse cached injections from the first generation to save tokens.
       // Post-gen agents still run after every response.
+      const agentNameByType = new Map(resolvedAgents.map((agent) => [agent.type, agent.name] as const));
+      const attachAgentName = (entry: AgentInjection): AgentInjection => ({
+        ...entry,
+        agentName: agentNameByType.get(entry.agentType) ?? entry.agentName,
+      });
       const reviewedAgentInjections: AgentInjection[] = input.agentInjectionOverrides
-        .map((entry) => ({ agentType: entry.agentType.trim(), text: entry.text }))
+        .map((entry) =>
+          attachAgentName({ agentType: entry.agentType.trim(), agentName: entry.agentName, text: entry.text }),
+        )
         .filter((entry) => entry.agentType && entry.text.trim().length > 0);
       const reviewedAgentTypes = new Set(reviewedAgentInjections.map((entry) => entry.agentType));
       let contextInjections: AgentInjection[] = reviewedAgentInjections;
@@ -4915,9 +4925,9 @@ export async function generateRoutes(app: FastifyInstance) {
                 );
               }
               const _tAgents = Date.now();
-              const injections = await pipeline.preGenerate(
-                (t) => !EXCLUDED_FROM_PIPELINE.has(t) && !reviewedAgentTypes.has(t),
-              );
+              const injections = (
+                await pipeline.preGenerate((t) => !EXCLUDED_FROM_PIPELINE.has(t) && !reviewedAgentTypes.has(t))
+              ).map(attachAgentName);
               logger.debug(`[timing] Pre-gen agents: ${Date.now() - _tAgents}ms`);
               return injections;
             })()
@@ -5181,7 +5191,7 @@ export async function generateRoutes(app: FastifyInstance) {
                 type: "agent_result",
                 data: {
                   agentType: inj.agentType,
-                  agentName: inj.agentType,
+                  agentName: agentNameByType.get(inj.agentType) ?? inj.agentName ?? inj.agentType,
                   resultType: "context_injection",
                   data: { text: inj.text },
                   success: true,
@@ -5199,9 +5209,11 @@ export async function generateRoutes(app: FastifyInstance) {
           if (hasContextInjectionAgents) {
             reply.raw.write(`data: ${JSON.stringify({ type: "agent_start", data: { phase: "pre_generation" } })}\n\n`);
             // On regens, exclude secret-plot-driver — it only triggers on new user messages
-            contextInjections = await pipeline.preGenerate(
-              (agentType) => !EXCLUDED_FROM_PIPELINE.has(agentType) && agentType !== "secret-plot-driver",
-            );
+            contextInjections = (
+              await pipeline.preGenerate(
+                (agentType) => !EXCLUDED_FROM_PIPELINE.has(agentType) && agentType !== "secret-plot-driver",
+              )
+            ).map(attachAgentName);
 
             // Failure gate — same as the new-message path
             const regenPreGenResults = pipeline.results.filter(

--- a/packages/server/src/routes/generate/agent-normalizers.ts
+++ b/packages/server/src/routes/generate/agent-normalizers.ts
@@ -12,10 +12,16 @@ export function normalizeContextInjections(raw: unknown): AgentInjection[] {
       continue;
     }
     if (!entry || typeof entry !== "object") continue;
-    const candidate = entry as { agentType?: unknown; text?: unknown };
+    const candidate = entry as { agentType?: unknown; agentName?: unknown; text?: unknown };
     if (typeof candidate.agentType !== "string" || typeof candidate.text !== "string") continue;
     const text = candidate.text.trim();
-    if (text) normalized.push({ agentType: candidate.agentType, text });
+    if (text) {
+      normalized.push({
+        agentType: candidate.agentType,
+        agentName: typeof candidate.agentName === "string" ? candidate.agentName : undefined,
+        text,
+      });
+    }
   }
   return normalized;
 }

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -1373,7 +1373,8 @@ async function applyRetryResultEffects(args: {
           );
           const trimmedText = text.trim();
           if (trimmedText) {
-            const entry = { agentType: result.agentType, text: trimmedText };
+            const agentName = resolvedAgents.find((entry) => entry.resolved.type === result.agentType)?.cfg.name;
+            const entry = { agentType: result.agentType, agentName, text: trimmedText };
             const idx = list.findIndex((e) => e.agentType === result.agentType);
             if (idx >= 0) list[idx] = entry;
             else list.push(entry);

--- a/packages/server/src/services/agents/agent-pipeline.ts
+++ b/packages/server/src/services/agents/agent-pipeline.ts
@@ -27,6 +27,7 @@ export interface ResolvedAgent extends AgentExecConfig {
 
 export interface AgentInjection {
   agentType: string;
+  agentName?: string;
   text: string;
 }
 
@@ -255,7 +256,8 @@ export async function runPreGenerationAgents(
     // prose-guardian & director produce text to inject
     if (result.type === "context_injection" || result.type === "director_event") {
       const text = typeof result.data === "string" ? result.data : ((result.data as any)?.text ?? "");
-      if (text) injections.push({ agentType: result.agentType, text });
+      const agentName = agents.find((agent) => agent.type === result.agentType)?.name;
+      if (text) injections.push({ agentType: result.agentType, agentName, text });
     }
     // prompt_review is informational — the onResult callback streams it
   }

--- a/packages/shared/src/schemas/chat.schema.ts
+++ b/packages/shared/src/schemas/chat.schema.ts
@@ -41,6 +41,7 @@ export const generateRequestSchema = z.object({
     .array(
       z.object({
         agentType: z.string().min(1).max(100),
+        agentName: z.string().min(1).max(200).optional(),
         text: z.string().max(50_000),
       }),
     )

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -324,7 +324,7 @@ export interface MessageExtra {
    * Cached pipeline injections (prose-guardian, director, knowledge-retrieval, etc.)
    * saved with this assistant message — reused when regenerating that swipe unless refreshed.
    */
-  contextInjections?: Array<{ agentType: string; text: string }> | null;
+  contextInjections?: Array<{ agentType: string; agentName?: string; text: string }> | null;
 }
 
 /** Metadata about how a message was generated. */


### PR DESCRIPTION
## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #789

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- Pre-generation custom agent prompt sections were wrapped with tags derived from the agent's stable type, which is generated from the original name. After renaming a custom agent, the main prompt could still show the stale original name in the wrapper.
- The stale wrapper text is visible to the main model, so names like `test-agent` can influence how seriously the model treats the injected section.

## What changed

<!-- List the key changes in this PR -->

- Preserve the current agent display name on pre-generation context injections while keeping `agentType` as the stable matching key.
- Format XML/Markdown prompt-section wrappers from the current display name, with legacy fallback to `agentType` for older cached injections.
- Carry `agentName` through cached injection normalization, retry-agent cache refresh, injection review overrides, and the cached injections panel label.
- Added committed command-output proof at `docs/pr-evidence/issue-789/repro-output.json`.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Codex reproduced the bug before the fix with `pnpm --filter @marinara-engine/server exec tsx ../../scratch/issue-789-repro.ts`; the prompt wrapper used `<custom-test-agent-a9e721ff-9ea8-4c8a-ba9d-5f3885fb30ba>`.
- Codex reran the same repro after the fix and verified the wrapper now uses `<probability_engine>` for the renamed custom agent.
- Codex also verified Markdown wrappers, multiple injected agents, and legacy cached injections that only have `{ agentType, text }`.
- Codex ran `pnpm check` successfully after rebasing onto current `upstream/main`.
- Proof artifact: https://raw.githubusercontent.com/cha1latte/Marinara-Engine/04f6f1567996373315ac3faa4144363eaf5808b2/docs/pr-evidence/issue-789/repro-output.json

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No user-facing docs or release metadata changes are needed. The committed file under `docs/pr-evidence/` is PR proof only.

## UI evidence (if applicable)

N/A. This is prompt assembly / cached injection metadata behavior, not a visible UI rendering bug. Command-output proof is linked above.
