### PR TITLE
Fix conversation schedule inheritance for DMs

### DIFF
--- a/packages/server/src/routes/conversation.routes.ts
+++ b/packages/server/src/routes/conversation.routes.ts
@@ -435,8 +435,7 @@ export async function conversationRoutes(app: FastifyInstance) {
     const chat = await chats.getById(req.params.chatId);
     if (!chat) return reply.status(404).send({ error: "Chat not found" });
 
-    const meta = typeof chat.metadata === "string" ? JSON.parse(chat.metadata) : (chat.metadata ?? {});
-    const schedules: CharacterSchedules = getEnabledConversationSchedules(meta);
+    const schedules: CharacterSchedules = await chats.inheritFreshConversationSchedules(req.params.chatId);
     const characterIds: string[] =
       typeof chat.characterIds === "string" ? JSON.parse(chat.characterIds) : chat.characterIds;
 
@@ -530,7 +529,7 @@ export async function conversationRoutes(app: FastifyInstance) {
       return reply.send({ shouldTrigger: false, characterIds: [], reason: "disabled", inactivityMs: 0 });
     }
 
-    const schedules: CharacterSchedules = getEnabledConversationSchedules(meta);
+    const schedules: CharacterSchedules = await chats.inheritFreshConversationSchedules(chatId);
     const characterIds: string[] =
       typeof chat.characterIds === "string" ? JSON.parse(chat.characterIds) : chat.characterIds;
     const isGroup = characterIds.length > 1;
@@ -614,8 +613,7 @@ export async function conversationRoutes(app: FastifyInstance) {
     const chat = await chats.getById(chatId);
     if (!chat) return reply.status(404).send({ error: "Chat not found" });
 
-    const meta = typeof chat.metadata === "string" ? JSON.parse(chat.metadata) : (chat.metadata ?? {});
-    const schedules: CharacterSchedules = getEnabledConversationSchedules(meta);
+    const schedules: CharacterSchedules = await chats.inheritFreshConversationSchedules(chatId);
     const schedule = schedules[characterId];
 
     if (!schedule) {
@@ -652,7 +650,7 @@ export async function conversationRoutes(app: FastifyInstance) {
       return reply.send({ shouldTrigger: false, characterIds: [], reason: "exchanges_disabled", inactivityMs: 0 });
     }
 
-    const schedules: CharacterSchedules = getEnabledConversationSchedules(meta);
+    const schedules: CharacterSchedules = await chats.inheritFreshConversationSchedules(chatId);
     const messages = await chats.listMessages(chatId);
     initializeActivityFromMessages(
       chatId,

--- a/packages/server/src/services/storage/chats.storage.ts
+++ b/packages/server/src/services/storage/chats.storage.ts
@@ -24,6 +24,7 @@ import {
   normalizeTimestampOverrides,
   type TimestampOverrides,
 } from "../import/import-timestamps.js";
+import { scheduleNeedsRefresh, type CharacterSchedules, type WeekSchedule } from "../conversation/schedule.service.js";
 
 const GALLERY_DIR = join(DATA_DIR, "gallery");
 
@@ -76,6 +77,30 @@ function parseMetadata(raw: unknown): MetadataPatch {
   return typeof raw === "object" ? (raw as MetadataPatch) : {};
 }
 
+function hasConversationSchedules(value: unknown): value is CharacterSchedules {
+  return !!value && typeof value === "object" && Object.keys(value as Record<string, unknown>).length > 0;
+}
+
+function areConversationSchedulesEnabled(meta: MetadataPatch): boolean {
+  if (typeof meta.conversationSchedulesEnabled === "boolean") return meta.conversationSchedulesEnabled;
+  return hasConversationSchedules(meta.characterSchedules);
+}
+
+function parseCharacterIds(raw: unknown): string[] {
+  if (Array.isArray(raw)) return raw.filter((id): id is string => typeof id === "string" && id.length > 0);
+  if (typeof raw !== "string") return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((id): id is string => typeof id === "string" && id.length > 0) : [];
+  } catch {
+    return [];
+  }
+}
+
+function firstScheduleWeekStart(schedules: CharacterSchedules): string | undefined {
+  return Object.values(schedules).find((schedule): schedule is WeekSchedule => !!schedule)?.weekStart;
+}
+
 function resolveTimestamps(overrides?: TimestampOverrides | null) {
   const normalized = normalizeTimestampOverrides(overrides);
   const createdAt = normalized?.createdAt ?? now();
@@ -110,6 +135,31 @@ async function invalidateMemoryChunksFrom(db: DB, chatId: string, createdAt: str
 
 /** Create the chat storage facade used by routes and importers. */
 export function createChatsStorage(db: DB) {
+  async function collectFreshConversationSchedules(
+    characterIds: string[],
+    excludeChatId?: string,
+  ): Promise<CharacterSchedules> {
+    const wanted = new Set(characterIds);
+    const sharedSchedules: CharacterSchedules = {};
+    if (wanted.size === 0) return sharedSchedules;
+
+    const allChats = await db.select().from(chats).orderBy(desc(chats.updatedAt));
+    for (const chat of allChats) {
+      if (chat.id === excludeChatId || chat.mode !== "conversation") continue;
+      const meta = parseMetadata(chat.metadata);
+      if (!areConversationSchedulesEnabled(meta) || !hasConversationSchedules(meta.characterSchedules)) continue;
+
+      for (const [characterId, schedule] of Object.entries(meta.characterSchedules)) {
+        if (!wanted.has(characterId) || sharedSchedules[characterId] || scheduleNeedsRefresh(schedule)) continue;
+        sharedSchedules[characterId] = schedule;
+      }
+
+      if (Object.keys(sharedSchedules).length === wanted.size) break;
+    }
+
+    return sharedSchedules;
+  }
+
   return {
     async list() {
       return db.select().from(chats).orderBy(desc(chats.updatedAt));
@@ -123,6 +173,22 @@ export function createChatsStorage(db: DB) {
     async create(input: CreateChatInput, timestampOverrides?: TimestampOverrides | null) {
       const id = newId();
       const timestamp = resolveTimestamps(timestampOverrides);
+      const inheritedSchedules =
+        input.mode === "conversation" ? await collectFreshConversationSchedules(input.characterIds) : {};
+      const metadata: MetadataPatch = {
+        summary: null,
+        tags: [],
+        enableAgents: true,
+        agentOverrides: {},
+        activeAgentIds: [],
+        activeToolIds: [],
+      };
+      if (hasConversationSchedules(inheritedSchedules)) {
+        metadata.conversationSchedulesEnabled = true;
+        metadata.characterSchedules = inheritedSchedules;
+        const scheduleWeekStart = firstScheduleWeekStart(inheritedSchedules);
+        if (scheduleWeekStart) metadata.scheduleWeekStart = scheduleWeekStart;
+      }
       await db.insert(chats).values({
         id,
         name: input.name,
@@ -132,18 +198,40 @@ export function createChatsStorage(db: DB) {
         personaId: input.personaId,
         promptPresetId: input.mode === "conversation" ? null : input.promptPresetId,
         connectionId: input.connectionId,
-        metadata: JSON.stringify({
-          summary: null,
-          tags: [],
-          enableAgents: true,
-          agentOverrides: {},
-          activeAgentIds: [],
-          activeToolIds: [],
-        }),
+        metadata: JSON.stringify(metadata),
         createdAt: timestamp.createdAt,
         updatedAt: timestamp.updatedAt,
       });
       return this.getById(id);
+    },
+
+    async inheritFreshConversationSchedules(id: string) {
+      const chat = await this.getById(id);
+      if (!chat || chat.mode !== "conversation") return {};
+
+      const meta = parseMetadata(chat.metadata);
+      if (meta.conversationSchedulesEnabled === false) return {};
+
+      const characterIds = parseCharacterIds(chat.characterIds);
+      const currentSchedules = hasConversationSchedules(meta.characterSchedules) ? meta.characterSchedules : {};
+      const missingOrStaleIds = characterIds.filter((characterId) => {
+        const existing = currentSchedules[characterId];
+        return !existing || scheduleNeedsRefresh(existing);
+      });
+      if (missingOrStaleIds.length === 0) return currentSchedules;
+
+      const sharedSchedules = await collectFreshConversationSchedules(missingOrStaleIds, id);
+      if (!hasConversationSchedules(sharedSchedules)) return currentSchedules;
+
+      const nextSchedules: CharacterSchedules = { ...currentSchedules, ...sharedSchedules };
+      const scheduleWeekStart = firstScheduleWeekStart(nextSchedules);
+      await this.patchMetadata(id, {
+        conversationSchedulesEnabled: true,
+        characterSchedules: nextSchedules,
+        ...(scheduleWeekStart ? { scheduleWeekStart } : {}),
+      });
+
+      return nextSchedules;
     },
 
     async update(


### PR DESCRIPTION
## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #788

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- Creating a one-on-one conversation with a character who already has a generated group conversation schedule could leave the new chat with no local schedule, then status refreshes treated that character as unscheduled/online and overwrote the schedule-derived status used elsewhere.

## What changed

<!-- List the key changes in this PR -->

- Conversation chat creation now inherits fresh schedules from sibling conversation chats for the same characters.
- Existing conversation chats can repair missing or stale schedule entries from sibling chats before deriving status, autonomous checks, busy-delay responses, or character exchanges.
- Conversation status routes now use the repaired schedule map so opening an unscheduled one-on-one chat does not clobber a character's group schedule status.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- âš ï¸ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Codex route proof: `pnpm --dir packages/server exec tsx scratch/issue-788-status-repro.mjs`
  - Before the fix, the harness reproduced the bug: opening an unscheduled one-on-one conversation returned `online` / `unknown (no schedule)` and overwrote the character's schedule-derived `dnd` / `working` state.
  - After the fix, newly-created one-on-one conversations inherit the fresh group schedule, existing unscheduled one-on-one conversations repair from the sibling schedule, `/conversation/status/:chatId` returns `dnd` / `working`, `/conversation/busy-delay` returns `dnd` / `working`, and the character extension remains `dnd` / `working`.
- Codex baseline: `pnpm check` passed locally, including Impeccable context check, lint, and shared/server/client builds.
- No human-only verification blocker for the core claim; this is a server-side route/storage behavior with a scratch harness proof.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

N/A - this is a server-side schedule inheritance/status repair fix for an issue reported as not visual/UI.
