### PR TITLE
Fix assistant command escaped text parsing

### DIFF
--- a/packages/server/src/services/conversation/character-commands.ts
+++ b/packages/server/src/services/conversation/character-commands.ts
@@ -280,10 +280,25 @@ const CREATE_CHAT_RE = /\[create_chat:\s*([^\]]+)\]/gi;
 const NAVIGATE_RE = /\[navigate:\s*([^\]]+)\]/gi;
 const FETCH_RE = /\[fetch:\s*([^\]]+)\]/gi;
 
+function decodeQuotedParamValue(value: string): string {
+  return value.replace(/\\(["\\nrt])/g, (_match, escaped: string) => {
+    switch (escaped) {
+      case "n":
+        return "\n";
+      case "r":
+        return "\r";
+      case "t":
+        return "\t";
+      default:
+        return escaped;
+    }
+  });
+}
+
 function parseQuotedParam(params: string, key: string, allowEmpty = false): string | undefined {
-  const match = params.match(new RegExp(`${key}="([^"]*)"`));
+  const match = params.match(new RegExp(`${key}="((?:\\\\.|[^"\\\\])*)"`));
   if (!match) return undefined;
-  const value = match[1] ?? "";
+  const value = decodeQuotedParamValue(match[1] ?? "");
   if (!allowEmpty && value.length === 0) return undefined;
   return value;
 }
@@ -598,14 +613,14 @@ export function parseCharacterCommands(content: string): {
   for (const match of content.matchAll(CREATE_PERSONA_RE)) {
     const params = match[1]!;
     const cmd: CreatePersonaCommand = { type: "create_persona", name: "" };
-    const nameMatch = params.match(/name="([^"]+)"/);
-    if (nameMatch) cmd.name = nameMatch[1]!;
-    const descMatch = params.match(/description="([^"]+)"/);
-    if (descMatch) cmd.description = descMatch[1]!;
-    const persMatch = params.match(/personality="([^"]+)"/);
-    if (persMatch) cmd.personality = persMatch[1]!;
-    const appMatch = params.match(/appearance="([^"]+)"/);
-    if (appMatch) cmd.appearance = appMatch[1]!;
+    const name = parseQuotedParam(params, "name");
+    if (name) cmd.name = name;
+    const description = parseQuotedParam(params, "description");
+    if (description) cmd.description = description;
+    const personality = parseQuotedParam(params, "personality");
+    if (personality) cmd.personality = personality;
+    const appearance = parseQuotedParam(params, "appearance");
+    if (appearance) cmd.appearance = appearance;
     if (cmd.name) commands.push(cmd);
   }
 
@@ -630,18 +645,18 @@ export function parseCharacterCommands(content: string): {
   for (const match of content.matchAll(UPDATE_PERSONA_RE)) {
     const params = match[1]!;
     const cmd: UpdatePersonaCommand = { type: "update_persona", name: "" };
-    const nameMatch = params.match(/name="([^"]+)"/);
-    if (nameMatch) cmd.name = nameMatch[1]!;
-    const descMatch = params.match(/description="([^"]*)"/);
-    if (descMatch) cmd.description = descMatch[1]!;
-    const persMatch = params.match(/personality="([^"]*)"/);
-    if (persMatch) cmd.personality = persMatch[1]!;
-    const appMatch = params.match(/appearance="([^"]*)"/);
-    if (appMatch) cmd.appearance = appMatch[1]!;
-    const scenarioMatch = params.match(/scenario="([^"]*)"/);
-    if (scenarioMatch) cmd.scenario = scenarioMatch[1]!;
-    const backstoryMatch = params.match(/backstory="([^"]*)"/);
-    if (backstoryMatch) cmd.backstory = backstoryMatch[1]!;
+    const name = parseQuotedParam(params, "name");
+    if (name) cmd.name = name;
+    const description = parseQuotedParam(params, "description", true);
+    if (description !== undefined) cmd.description = description;
+    const personality = parseQuotedParam(params, "personality", true);
+    if (personality !== undefined) cmd.personality = personality;
+    const appearance = parseQuotedParam(params, "appearance", true);
+    if (appearance !== undefined) cmd.appearance = appearance;
+    const scenario = parseQuotedParam(params, "scenario", true);
+    if (scenario !== undefined) cmd.scenario = scenario;
+    const backstory = parseQuotedParam(params, "backstory", true);
+    if (backstory !== undefined) cmd.backstory = backstory;
     if (cmd.name) commands.push(cmd);
   }
 

--- a/packages/server/src/services/conversation/character-commands.ts
+++ b/packages/server/src/services/conversation/character-commands.ts
@@ -295,10 +295,48 @@ function decodeQuotedParamValue(value: string): string {
   });
 }
 
+const QUOTE_PAIRS: Record<string, string> = {
+  '"': '"',
+  "\u201c": "\u201d",
+  "\u201d": "\u201d",
+  "\u2018": "\u2019",
+  "\u2019": "\u2019",
+};
+
 function parseQuotedParam(params: string, key: string, allowEmpty = false): string | undefined {
-  const match = params.match(new RegExp(`${key}="((?:\\\\.|[^"\\\\])*)"`));
-  if (!match) return undefined;
-  const value = decodeQuotedParamValue(match[1] ?? "");
+  const match = params.match(new RegExp(`${key}\\s*=\\s*(["\u201c\u201d\u2018\u2019])`));
+  if (!match || match.index === undefined) return undefined;
+
+  const openingQuote = match[1] ?? '"';
+  const closingQuote = QUOTE_PAIRS[openingQuote] ?? openingQuote;
+  let rawValue = "";
+  let index = match.index + match[0].length;
+
+  while (index < params.length) {
+    const char = params[index] ?? "";
+    const nextChar = params[index + 1];
+
+    if (char === "\\" && nextChar !== undefined) {
+      rawValue += char + nextChar;
+      index += 2;
+      continue;
+    }
+
+    const remainder = params.slice(index + 1).trimStart();
+    if (
+      char === closingQuote &&
+      (remainder.length === 0 || remainder.startsWith(",") || /^[A-Za-z_][A-Za-z0-9_]*\s*=/.test(remainder))
+    ) {
+      break;
+    }
+
+    rawValue += char;
+    index += 1;
+  }
+
+  if (index >= params.length) return undefined;
+
+  const value = decodeQuotedParamValue(rawValue);
   if (!allowEmpty && value.length === 0) return undefined;
   return value;
 }

--- a/packages/server/test/character-commands.test.ts
+++ b/packages/server/test/character-commands.test.ts
@@ -53,6 +53,52 @@ test("parses update_character with the expanded safe text fields", () => {
   ]);
 });
 
+test("parses assistant update text fields with escaped quotes and newlines", () => {
+  const { commands, cleanContent } = parseCharacterCommands(
+    `[update_character: name="Luna", description="She goes by \\"The Bread Witch\\" and everyone knows it.", scenario="First paragraph\\n\\nSecond paragraph"]` +
+      `[update_persona: name="Alex Storm", description="Known as \\"The Anchor\\"", backstory="Line one\\nLine two"]`,
+  );
+
+  assert.equal(cleanContent, "");
+  assert.deepEqual(commands, [
+    {
+      type: "update_character",
+      name: "Luna",
+      description: 'She goes by "The Bread Witch" and everyone knows it.',
+      scenario: "First paragraph\n\nSecond paragraph",
+    },
+    {
+      type: "update_persona",
+      name: "Alex Storm",
+      description: 'Known as "The Anchor"',
+      backstory: "Line one\nLine two",
+    },
+  ]);
+});
+
+test("keeps adjacent assistant command parsing stable with escaped characters", () => {
+  const { commands } = parseCharacterCommands(
+    `[create_character: name="Luna", first_message="She said \\"hello\\". Path C:\\\\Moon", tags="mystic, seer", alternate_greetings="Hi || Hello"]` +
+      `[update_character: name="Luna", system_prompt="", depth_prompt_role="system"]`,
+  );
+
+  assert.deepEqual(commands, [
+    {
+      type: "create_character",
+      name: "Luna",
+      firstMessage: 'She said "hello". Path C:\\Moon',
+      tags: ["mystic", "seer"],
+      alternateGreetings: ["Hi", "Hello"],
+    },
+    {
+      type: "update_character",
+      name: "Luna",
+      systemPrompt: "",
+      depthPromptRole: "system",
+    },
+  ]);
+});
+
 test("parses update_persona with scenario and backstory", () => {
   const { commands, cleanContent } = parseCharacterCommands(
     `[update_persona: name="Alex Storm", scenario="Urban fantasy city", backstory="Former detective"]`,

--- a/packages/server/test/character-commands.test.ts
+++ b/packages/server/test/character-commands.test.ts
@@ -76,6 +76,22 @@ test("parses assistant update text fields with escaped quotes and newlines", () 
   ]);
 });
 
+test("parses assistant update fields delimited by smart quotes", () => {
+  const { commands, cleanContent } = parseCharacterCommands(
+    `[update_character: name=“Luna”, description=“She says ‘hi’ — then writes alternate greetings.”, alternate_greetings=““Hello” — warm || ‘Goodnight’ — soft”]`,
+  );
+
+  assert.equal(cleanContent, "");
+  assert.deepEqual(commands, [
+    {
+      type: "update_character",
+      name: "Luna",
+      description: "She says ‘hi’ — then writes alternate greetings.",
+      alternateGreetings: ["“Hello” — warm", "‘Goodnight’ — soft"],
+    },
+  ]);
+});
+
 test("keeps adjacent assistant command parsing stable with escaped characters", () => {
   const { commands } = parseCharacterCommands(
     `[create_character: name="Luna", first_message="She said \\"hello\\". Path C:\\\\Moon", tags="mystic, seer", alternate_greetings="Hi || Hello"]` +


### PR DESCRIPTION
## Linked issue

Closes #787
Closes #799

## Why this change

Professor Mari's `[update_character]` command parser treated an escaped double quote inside a text value as the end of that field. That truncated saved character fields at the first `\"` and left a trailing backslash.

The same parser path also kept escaped newline sequences as literal `\n` text instead of converting them to actual line breaks before the update command was persisted.

The adjacent smart-punctuation report showed that assistant commands using curly quote delimiters could parse as no command at all, which made character card writes appear successful from the assistant's point of view while no update reached the card-writing path.

## What changed

- Updated assistant quoted-parameter parsing so escaped quotes and backslash escapes are read as part of the field value.
- Accepted paired curly/smart quote delimiters for assistant command values while preserving smart punctuation inside the stored text.
- Decoded common escaped text sequences (`\"`, `\\`, `\n`, `\r`, `\t`) before command values are stored.
- Reused the safer quoted-parameter helper for nearby `create_persona` and `update_persona` assistant text fields.
- Added parser regression coverage for quoted values, escaped newlines, backslashes, empty-string clearing, list parsing, and adjacent assistant commands.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

Codex machine verification:

- Reproduced the original parser failure with `pnpm --filter @marinara-engine/server exec tsx ../../scratch/issue-787-repro.mjs`: before the fix, `description` parsed as `She goes by \` and `scenario` remained literal `First paragraph\n\nSecond paragraph`.
- Re-ran the same scratch repro after the fix; it parsed `She goes by "The Bread Witch" and everyone knows it.` and `First paragraph` / `Second paragraph` separated by real newline characters.
- Reproduced the smart-punctuation parser failure with `pnpm --filter @marinara-engine/server exec tsx ../../scratch/issue-799-repro.mjs ../../scratch/issue-799-proof-before.json`: before the fix, the smart-quoted `[update_character]` command parsed as no command (`commands: []`).
- Re-ran the same smart-punctuation repro after the fix with `pnpm --filter @marinara-engine/server exec tsx ../../scratch/issue-799-repro.mjs ../../scratch/issue-799-proof-after.json`; it parsed the character name, description, em dash, and alternate greetings.
- Ran `pnpm --filter @marinara-engine/server exec tsx --import ./test/setup-env.ts --test test/character-commands.test.ts`; all 13 parser tests passed.
- Ran `pnpm check`; it passed.

No true human-only verification is required for the core claim. This is parser logic with focused command-output proof rather than a visible UI change.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs, release, schema, dependency, or version files changed.

## UI evidence (if applicable)

N/A. This is assistant command parser logic, not a visible UI change. Proof is command-output based in the validation notes above.
