### PR TITLE
Add HOME default to Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - marinara-data:/app/data
     environment:
       - NODE_ENV=production
+      - HOME=/app
       - DATA_DIR=/app/data
       - FILE_STORAGE_DIR=/app/data/storage
       - MARINARA_DOCKER=true


### PR DESCRIPTION
## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #783

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- Container users who mount SillyTavern data into Marinara can hit import/path permission checks because the container HOME falls back to `/root`. Setting HOME to `/app` by default aligns those checks with the writable application directory used by the official image.

## What changed

<!-- List the key changes in this PR -->

- Added `HOME=/app` to the default `docker-compose.yml` environment block.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Codex ran `docker compose config` and confirmed the rendered `marinara` service environment includes `HOME: /app`.
- Codex ran `pnpm check`; it passed after installing locked dependencies in the isolated worktree.
- Codex built a local branch image with `docker build -t marinara-engine:issue-783-compose-home .`, then ran it through Docker Compose using a scratch override for that image.
- Codex confirmed the running branch-built container reports `HOME=/app`, stays up on `127.0.0.1:7860->7860/tcp`, and has no startup warnings in `docker compose logs --tail 120 marinara`.
- Codex ran `docker compose down` after verification; no test containers were left running.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs or release metadata changes. The default compose file now carries the HOME value directly.

## UI evidence (if applicable)

N/A; this is a Docker Compose configuration change.
