### PR TITLE
Fix JSONL chat file imports

### DIFF
--- a/packages/client/src/components/chat/ChatFilesDrawer.tsx
+++ b/packages/client/src/components/chat/ChatFilesDrawer.tsx
@@ -48,8 +48,8 @@ export function ChatFilesDrawer({ chat, open, onClose }: ChatFilesDrawerProps) {
     setIsImporting(true);
     try {
       const formData = new FormData();
-      formData.append("file", file);
       formData.append("chatId", chat.id);
+      formData.append("file", file);
       const res = await fetch("/api/import/st-chat-into-group", { method: "POST", body: formData });
       const data = await res.json().catch(() => ({}));
       if (!res.ok || data?.success === false || data?.error) {

--- a/packages/server/src/routes/import.routes.ts
+++ b/packages/server/src/routes/import.routes.ts
@@ -1,7 +1,7 @@
 // ──────────────────────────────────────────────
 // Routes: Import (SillyTavern data)
 // ──────────────────────────────────────────────
-import type { FastifyInstance } from "fastify";
+import type { FastifyInstance, FastifyRequest } from "fastify";
 import { execFile } from "child_process";
 import { platform, homedir } from "os";
 import { readdir, stat } from "fs/promises";
@@ -322,6 +322,27 @@ function invalidTagImportModeResponse() {
   };
 }
 
+type MultipartImportFile = { filename?: string; buffer: Buffer };
+
+async function readMultipartFileWithFields(req: FastifyRequest) {
+  let file: MultipartImportFile | null = null;
+  const fields: Record<string, unknown> = {};
+
+  for await (const part of req.parts()) {
+    if (part.type === "file") {
+      file = {
+        filename: part.filename,
+        buffer: await part.toBuffer(),
+      };
+      continue;
+    }
+
+    fields[part.fieldname] = part.value;
+  }
+
+  return { file, fields };
+}
+
 async function importCharacterBuffer(
   fileName: string,
   buffer: Buffer,
@@ -450,12 +471,10 @@ export async function importRoutes(app: FastifyInstance) {
    * "chat file" instead of spawning a new character entry.
    */
   app.post("/st-chat-into-group", async (req, reply) => {
-    const data = await req.file();
-    if (!data) return reply.status(400).send({ success: false, error: "No file uploaded" });
+    const { file, fields } = await readMultipartFileWithFields(req);
+    if (!file) return reply.status(400).send({ success: false, error: "No file uploaded" });
 
-    const targetChatField = (data as any).fields?.chatId;
-    const targetChatId =
-      (Array.isArray(targetChatField) ? targetChatField.at(-1)?.value : targetChatField?.value) ?? null;
+    const targetChatId = typeof fields.chatId === "string" ? fields.chatId : null;
     if (!targetChatId || typeof targetChatId !== "string") {
       return reply.status(400).send({ success: false, error: "Missing chatId" });
     }
@@ -464,9 +483,8 @@ export async function importRoutes(app: FastifyInstance) {
     const targetChat = await storage.getById(targetChatId);
     if (!targetChat) return reply.status(404).send({ success: false, error: "Target chat not found" });
 
-    const content = await data.toBuffer();
-    const text = content.toString("utf-8");
-    const timestampOverrides = readTimestampOverridesFromMultipart(data as any);
+    const text = file.buffer.toString("utf-8");
+    const timestampOverrides = readTimestampOverridesValue(fields.timestampOverrides ?? fields.__timestampOverrides);
 
     // Auto-create a groupId on the target chat if it isn't already in one, so
     // the imported transcript can sit alongside it as a branch (mirrors the
@@ -508,7 +526,7 @@ export async function importRoutes(app: FastifyInstance) {
       }
     }
 
-    const rawName = data.filename ?? "";
+    const rawName = file.filename ?? "";
     const branchName =
       rawName
         .replace(/\.jsonl$/i, "")

--- a/packages/server/test/st-chat-import-routes.test.ts
+++ b/packages/server/test/st-chat-import-routes.test.ts
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import multipart from "@fastify/multipart";
+import Fastify from "fastify";
+import { eq } from "drizzle-orm";
+import { createFileNativeDB } from "../src/db/file-backed-store.js";
+import { messages } from "../src/db/schema/index.js";
+import { importRoutes } from "../src/routes/import.routes.js";
+import { createChatsStorage } from "../src/services/storage/chats.storage.js";
+
+const jsonl = [
+  JSON.stringify({
+    user_name: "User",
+    character_name: "Princess Vivienne",
+    create_date: "2026-05-13T12:00:00.000Z",
+    chat_metadata: {},
+  }),
+  JSON.stringify({
+    name: "User",
+    is_user: true,
+    is_system: false,
+    mes: "Hello.",
+    send_date: "2026-05-13T12:00:01.000Z",
+  }),
+  JSON.stringify({
+    name: "Princess Vivienne",
+    is_user: false,
+    is_system: false,
+    mes: "Welcome back.",
+    send_date: "2026-05-13T12:00:02.000Z",
+  }),
+].join("\n");
+
+function withFileStorageDir<T>(dir: string, fn: () => Promise<T>) {
+  const previous = process.env.FILE_STORAGE_DIR;
+  process.env.FILE_STORAGE_DIR = dir;
+  return fn().finally(() => {
+    if (previous === undefined) {
+      delete process.env.FILE_STORAGE_DIR;
+    } else {
+      process.env.FILE_STORAGE_DIR = previous;
+    }
+  });
+}
+
+function multipartPayload(chatId: string, order: "file-first" | "field-first") {
+  const boundary = `----st-chat-import-${order}`;
+  const fieldPart = [
+    `--${boundary}`,
+    'Content-Disposition: form-data; name="chatId"',
+    "",
+    chatId,
+  ].join("\r\n");
+  const filePart = [
+    `--${boundary}`,
+    'Content-Disposition: form-data; name="file"; filename="Princess Vivienne.jsonl"',
+    "Content-Type: application/jsonl",
+    "",
+    jsonl,
+  ].join("\r\n");
+  const parts = order === "file-first" ? [filePart, fieldPart] : [fieldPart, filePart];
+  return {
+    boundary,
+    payload: Buffer.from(`${parts.join("\r\n")}\r\n--${boundary}--\r\n`, "utf8"),
+  };
+}
+
+test("chat file import accepts JSONL branch uploads regardless of multipart field order", async () => {
+  const root = mkdtempSync(join(tmpdir(), "marinara-st-chat-import-route-"));
+  try {
+    await withFileStorageDir(join(root, "storage"), async () => {
+      const db = await createFileNativeDB([]);
+      const app = Fastify();
+      try {
+        await app.register(multipart);
+        app.decorate("db", db);
+        await app.register(importRoutes, { prefix: "/api/import" });
+
+        const storage = createChatsStorage(db);
+        const target = await storage.create({
+          name: "Princess Vivienne",
+          mode: "roleplay",
+          characterIds: [],
+          groupId: null,
+          personaId: null,
+          promptPresetId: null,
+          connectionId: null,
+        });
+        assert.ok(target, "target chat should be created");
+
+        for (const order of ["file-first", "field-first"] as const) {
+          const body = multipartPayload(target.id, order);
+          const response = await app.inject({
+            method: "POST",
+            url: "/api/import/st-chat-into-group",
+            headers: {
+              "content-type": `multipart/form-data; boundary=${body.boundary}`,
+            },
+            payload: body.payload,
+          });
+          const payload = JSON.parse(response.body) as {
+            success?: boolean;
+            chatId?: string;
+            messagesImported?: number;
+            error?: string;
+          };
+
+          assert.equal(response.statusCode, 200, `${order} upload should not fail with ${payload.error ?? "error"}`);
+          assert.equal(payload.success, true);
+          assert.equal(payload.messagesImported, 2);
+          assert.ok(payload.chatId);
+
+          const rows = await db.select().from(messages).where(eq(messages.chatId, payload.chatId));
+          assert.deepEqual(
+            rows.map((message) => message.content),
+            ["Hello.", "Welcome back."],
+          );
+        }
+      } finally {
+        await app.close();
+        await db._fileStore.close();
+      }
+    });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #800

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- JSONL chat exports could hit the branch-import endpoint without the target chat id being available to the server, surfacing `Import failed: Missing chatId` instead of importing the transcript as a chat file.

## What changed

<!-- List the key changes in this PR -->

- Parse `/api/import/st-chat-into-group` multipart requests with `req.parts()` so the file and `chatId` field are collected regardless of multipart field order.
- Send the target `chatId` before the file from the Manage Chat Files drawer.
- Added a server route regression test that imports a Marinara-style JSONL transcript with both file-first and field-first multipart ordering and verifies imported messages persist.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Codex route proof: `pnpm --filter @marinara-engine/server exec tsx --import ./test/setup-env.ts --test test/st-chat-import-routes.test.ts` passed. The test covers JSONL branch import with file-first and field-first multipart bodies and verifies the imported message contents.
- Codex baseline: `pnpm check` passed after the route regression test was added.
- Codex scratch proof: `pnpm --dir packages/server exec tsx ../../scratch/issue-800-jsonl-import-repro.ts --expect-fixed` passed for file-first and field-first multipart branch imports.
- Limitation: I could not replay the exact Termux UI session or the reporter's attached `Princess Vivienne.jsonl` file because the attachment binary is not available in this environment. The route-level behavior and Marinara-style JSONL payload are covered by the regression test.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs or release metadata changes needed.

## UI evidence (if applicable)

N/A. This is a route/import handling fix with regression coverage; no visible UI layout changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multipart file upload handling for chat imports, ensuring uploads work correctly regardless of field order.

* **Tests**
  * Added tests verifying chat file imports work consistently with different multipart field orderings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/808)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->