### PR TITLE
Add Termux skip-update start option

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -4,7 +4,7 @@ The Android app is a thin WebView wrapper around Marinara Engine running locally
 
 ## How It Works
 
-- Start Marinara Engine in Termux with `./start-termux.sh`.
+- Start Marinara Engine in Termux with `./start-termux.sh`, or use `./start-termux.sh --skip-update` to start the current local install without checking for updates.
 - The APK opens `http://127.0.0.1:<PORT>` inside a fullscreen WebView. The default build-time port is `7860`.
 - The server, launcher updates, and `AUTO_OPEN_BROWSER` behavior are owned by the Termux launcher, not by this APK.
 - Release and versioning policy follows the main repo docs in [../CONTRIBUTING.md](../CONTRIBUTING.md): root `package.json` is canonical, Android `versionName` should match the app version, and `versionCode` must increase for every shipped APK.
@@ -82,6 +82,8 @@ cd android
    ```bash
    ./start-termux.sh
    ```
+
+   To skip the update check and start the already-installed local copy, run `./start-termux.sh --skip-update`.
 
 2. Open the **Marinara Engine** app from your home screen.
 3. The app shows "Connecting..." until the local server is ready, then loads automatically.

--- a/docs/installation/android-termux.md
+++ b/docs/installation/android-termux.md
@@ -37,6 +37,13 @@ cd Marinara-Engine
 ./start-termux.sh
 ```
 
+That command checks for updates before starting. If you want to start the already-installed local copy without checking GitHub or applying updates, run:
+
+```bash
+cd Marinara-Engine
+./start-termux.sh --skip-update
+```
+
 ## Optional: Android App Shell (APK)
 
 If you want a dedicated home-screen icon that opens Marinara Engine like a native app, see [android/README.md](../../android/README.md). The APK is a WebView wrapper around the Termux-served app — the Termux server must be running for the APK to work.
@@ -56,6 +63,8 @@ The `start-termux.sh` launcher automatically updates Marinara Engine on each run
 5. Starts the app on the current version
 
 Simply run `./start-termux.sh` to get the latest version each time.
+
+If an update is temporarily broken or you need to stay on the current local copy, run `./start-termux.sh --skip-update` instead. The skip-update command still installs missing dependencies and builds missing output when needed; it only skips the GitHub update check and fast-forward step.
 
 ### In-App Update Check
 

--- a/start-termux.sh
+++ b/start-termux.sh
@@ -13,6 +13,27 @@ echo ""
 # Navigate to script directory
 cd "$(dirname "$0")"
 
+SKIP_UPDATE=0
+for arg in "$@"; do
+    case "$arg" in
+        --skip-update|--no-update)
+            SKIP_UPDATE=1
+            ;;
+        -h|--help)
+            echo "Usage: ./start-termux.sh [--skip-update]"
+            echo ""
+            echo "  ./start-termux.sh               Check for updates, then start Marinara Engine"
+            echo "  ./start-termux.sh --skip-update Start the current local install without checking for updates"
+            exit 0
+            ;;
+        *)
+            echo "  [ERROR] Unknown option: $arg"
+            echo "          Run ./start-termux.sh --help for usage."
+            exit 1
+            ;;
+    esac
+done
+
 # ── Ensure required Termux packages ──
 for pkg_name in git; do
     if ! dpkg -s "$pkg_name" &> /dev/null; then
@@ -148,7 +169,9 @@ restore_stashed_changes() {
 }
 
 # ── Auto-update from Git ──
-if [ -d ".git" ]; then
+if [ "$SKIP_UPDATE" = "1" ]; then
+    echo "  [OK] Skipping update check; starting the current local install."
+elif [ -d ".git" ]; then
     echo "  [..] Checking for updates..."
     OLD_HEAD=$(git rev-parse HEAD 2>/dev/null)
     if ! git fetch origin main --quiet 2>/dev/null; then


### PR DESCRIPTION
## Linked issue

Closes #759

## Why this change

- Termux users need a discoverable way to start the already-installed local copy when the normal launcher update path is temporarily broken or unwanted.

## What changed

- Added `--skip-update` / `--no-update` support to `start-termux.sh`.
- Added `--help` usage text for the Termux launcher.
- Documented the normal update-and-start command and the skip-update start command in the Termux and Android APK docs.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Codex ran `bash -n start-termux.sh` with Git Bash.
- Codex ran `bash start-termux.sh --help` with Git Bash.
- Codex ran `scratch/verify-termux-skip-update.sh`, which confirmed `--skip-update` reaches server start without calling `git fetch` or `git merge`.
- Codex ran `pnpm check`, which passed.
- Manual Termux-device verification is still recommended: run `./start-termux.sh --skip-update` on Android/Termux and confirm it starts the existing local install without checking GitHub.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

N/A; command-line launcher and docs change only.
