### PR TITLE
Add lorebook entry vectorization exclusions

### DIFF
--- a/packages/client/src/components/lorebooks/LorebookEditor.tsx
+++ b/packages/client/src/components/lorebooks/LorebookEditor.tsx
@@ -1897,12 +1897,14 @@ function VectorizeSection({ lorebookId, entries }: { lorebookId: string; entries
   const [selectedConnectionId, setSelectedConnectionId] = useState<string>("");
   const [vectorizing, setVectorizing] = useState(false);
   const [result, setResult] = useState<{ success: boolean; message: string } | null>(null);
-  const entryCount = entries.length;
-  const vectorizedCount = entries.filter(
+  const excludedCount = entries.filter((entry) => entry.excludeFromVectorization).length;
+  const vectorizableEntries = entries.filter((entry) => !entry.excludeFromVectorization);
+  const vectorizableEntryCount = vectorizableEntries.length;
+  const vectorizedCount = vectorizableEntries.filter(
     (entry) => Array.isArray(entry.embedding) && entry.embedding.length > 0,
   ).length;
-  const missingCount = Math.max(0, entryCount - vectorizedCount);
-  const allVectorized = entryCount > 0 && missingCount === 0;
+  const missingCount = Math.max(0, vectorizableEntryCount - vectorizedCount);
+  const allVectorized = vectorizableEntryCount > 0 && missingCount === 0;
 
   // Auto-select first embedding connection
   useEffect(() => {
@@ -1954,9 +1956,10 @@ function VectorizeSection({ lorebookId, entries }: { lorebookId: string; entries
           )}
         >
           {allVectorized ? <Check size="0.625rem" /> : <AlertTriangle size="0.625rem" />}
-          {vectorizedCount}/{entryCount} entries vectorized
+          {vectorizedCount}/{vectorizableEntryCount} entries vectorized
         </span>
         {missingCount > 0 && <span>{missingCount} still need embeddings.</span>}
+        {excludedCount > 0 && <span>{excludedCount} excluded.</span>}
       </div>
       {embeddingConnections.length === 0 ? (
         <p className="text-[0.625rem] text-[var(--muted-foreground)]">
@@ -1978,14 +1981,14 @@ function VectorizeSection({ lorebookId, entries }: { lorebookId: string; entries
             </select>
             <button
               onClick={handleVectorize}
-              disabled={vectorizing || entryCount === 0}
+              disabled={vectorizing || vectorizableEntryCount === 0}
               className="flex items-center gap-1.5 rounded-xl bg-violet-500/15 px-3 py-1.5 text-xs font-medium text-violet-400 ring-1 ring-violet-500/30 transition-all hover:bg-violet-500/25 active:scale-[0.98] disabled:opacity-50"
             >
               {vectorizing ? <Loader2 size="0.75rem" className="animate-spin" /> : <Sparkles size="0.75rem" />}
               {vectorizing
                 ? "Vectorizing..."
                 : allVectorized
-                  ? `Re-vectorize ${entryCount} entries`
+                  ? `Re-vectorize ${vectorizableEntryCount} entries`
                   : `Vectorize ${missingCount} missing`}
             </button>
           </div>

--- a/packages/client/src/components/lorebooks/LorebookEntryRow.tsx
+++ b/packages/client/src/components/lorebooks/LorebookEntryRow.tsx
@@ -13,6 +13,7 @@ import {
   type MouseEvent as ReactMouseEvent,
 } from "react";
 import {
+  Ban,
   ChevronDown,
   CheckCircle2,
   CheckSquare2,
@@ -308,9 +309,14 @@ export function LorebookEntryRow({
   );
 
   const showDepthInput = localPosition === 2;
+  const isVectorExcluded = entry.excludeFromVectorization === true;
   const isVectorized = Array.isArray(entry.embedding) && entry.embedding.length > 0;
-  const vectorStatusLabel = isVectorized ? "Vectorized" : "Not vectorized";
-  const vectorStatusTitle = isVectorized ? "This entry has been vectorized" : "This entry has not been vectorized yet";
+  const vectorStatusLabel = isVectorExcluded ? "Vector excluded" : isVectorized ? "Vectorized" : "Not vectorized";
+  const vectorStatusTitle = isVectorExcluded
+    ? "This entry is excluded from vectorization"
+    : isVectorized
+      ? "This entry has been vectorized"
+      : "This entry has not been vectorized yet";
 
   return (
     <div
@@ -447,7 +453,9 @@ export function LorebookEntryRow({
           type="button"
           className={cn(
             "relative inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-[0.625rem] ring-1 transition-colors focus:outline-none focus:ring-2 focus:ring-[var(--ring)]",
-            isVectorized
+            isVectorExcluded
+              ? "bg-rose-400/10 text-rose-400 ring-rose-400/20"
+              : isVectorized
               ? "bg-emerald-400/10 text-emerald-400 ring-emerald-400/20"
               : "bg-[var(--background)]/55 text-[var(--muted-foreground)] ring-[var(--border)] hover:text-[var(--foreground)]",
           )}
@@ -462,7 +470,13 @@ export function LorebookEntryRow({
             setShowVectorStatus(true);
           }}
         >
-          {isVectorized ? <CheckCircle2 size="0.75rem" /> : <CircleDashed size="0.75rem" />}
+          {isVectorExcluded ? (
+            <Ban size="0.75rem" />
+          ) : isVectorized ? (
+            <CheckCircle2 size="0.75rem" />
+          ) : (
+            <CircleDashed size="0.75rem" />
+          )}
           {showVectorStatus && (
             <span className="pointer-events-none absolute left-1/2 top-full z-20 mt-1 -translate-x-1/2 whitespace-nowrap rounded-md bg-[var(--popover)] px-2 py-1 text-[0.625rem] font-medium text-[var(--popover-foreground)] shadow-lg ring-1 ring-[var(--border)]">
               {vectorStatusLabel}
@@ -893,6 +907,7 @@ function buildEntrySavePayload(form: Partial<LorebookEntry>) {
     tag: form.tag,
     locked: form.locked,
     preventRecursion: form.preventRecursion,
+    excludeFromVectorization: form.excludeFromVectorization,
   };
 }
 
@@ -1264,7 +1279,7 @@ function ExpandedDrawer({
 
       {/* Toggles row — note: enable / regex / trigger mode are now on the row header,
           so they are intentionally omitted from this block to avoid duplication. */}
-      <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+      <div className="grid grid-cols-2 gap-2 sm:grid-cols-5">
         <ToggleButton
           label="Whole Words"
           value={form.matchWholeWords ?? false}
@@ -1286,6 +1301,12 @@ function ExpandedDrawer({
           value={form.preventRecursion ?? false}
           onChange={(v) => update({ preventRecursion: v })}
           tooltip="When enabled, this entry's content won't trigger additional entries during recursive scanning."
+        />
+        <ToggleButton
+          label="No Vector"
+          value={form.excludeFromVectorization ?? false}
+          onChange={(v) => update({ excludeFromVectorization: v })}
+          tooltip="When enabled, bulk vectorization skips this entry and removes any stored embedding."
         />
       </div>
 

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -185,6 +185,7 @@ const CREATE_TABLES: string[] = [
     activation_conditions TEXT NOT NULL DEFAULT '[]',
     schedule TEXT,
     prevent_recursion TEXT NOT NULL DEFAULT 'false',
+    exclude_from_vectorization TEXT NOT NULL DEFAULT 'false',
     embedding TEXT,
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL
@@ -697,6 +698,11 @@ const COLUMN_MIGRATIONS: ColumnMigration[] = [
     table: "lorebook_entries",
     column: "additional_matching_sources",
     definition: "TEXT NOT NULL DEFAULT '[]'",
+  },
+  {
+    table: "lorebook_entries",
+    column: "exclude_from_vectorization",
+    definition: "TEXT NOT NULL DEFAULT 'false'",
   },
   {
     table: "api_connections",

--- a/packages/server/src/db/schema/lorebooks.ts
+++ b/packages/server/src/db/schema/lorebooks.ts
@@ -159,6 +159,9 @@ export const lorebookEntries = sqliteTable("lorebook_entries", {
   /** When true, this entry's content won't trigger further entries during recursive scanning */
   preventRecursion: text("prevent_recursion").notNull().default("false"),
 
+  /** When true, bulk vectorization skips this entry and semantic matching ignores stored vectors */
+  excludeFromVectorization: text("exclude_from_vectorization").notNull().default("false"),
+
   /** Pre-computed embedding vector (JSON array of floats) for semantic matching */
   embedding: text("embedding"),
 

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -1180,7 +1180,9 @@ export async function generateRoutes(app: FastifyInstance) {
           excludedLorebookIds: gameLorebookScopeExclusions.excludedLorebookIds,
           excludedSourceAgentIds: gameLorebookScopeExclusions.excludedSourceAgentIds,
         });
-        const hasVectorizedEntries = (activeEntries as Array<Record<string, unknown>>).some((e) => e.embedding != null);
+        const hasVectorizedEntries = (activeEntries as Array<Record<string, unknown>>).some(
+          (e) => !e.excludeFromVectorization && e.embedding != null,
+        );
         if (hasVectorizedEntries) {
           // Embed the last ~10 messages as context
           const recentMsgs = mappedMessages

--- a/packages/server/src/routes/lorebooks.routes.ts
+++ b/packages/server/src/routes/lorebooks.routes.ts
@@ -169,6 +169,7 @@ function buildTransferredEntryInput(
     groupWeight: entry.groupWeight,
     folderId: null,
     preventRecursion: entry.preventRecursion,
+    excludeFromVectorization: entry.excludeFromVectorization,
     locked: entry.locked,
     tag: entry.tag,
     relationships: entry.relationships,
@@ -685,12 +686,15 @@ export async function lorebooksRoutes(app: FastifyInstance) {
 
     const allEntries = await storage.listEntries(req.params.id);
     if (!allEntries.length) return { vectorized: 0, total: 0, skipped: 0 };
+    const vectorizableEntries = allEntries.filter(
+      (entry) => !(entry as Record<string, unknown>).excludeFromVectorization,
+    );
     const entries = body.onlyMissing
-      ? allEntries.filter((entry) => {
+      ? vectorizableEntries.filter((entry) => {
           const embedding = (entry as Record<string, unknown>).embedding;
           return !Array.isArray(embedding) || embedding.length === 0;
         })
-      : allEntries;
+      : vectorizableEntries;
     if (!entries.length) return { vectorized: 0, total: allEntries.length, skipped: allEntries.length };
 
     // Use dedicated embedding base URL if configured, otherwise the connection's base URL

--- a/packages/server/src/services/import/marinara.importer.ts
+++ b/packages/server/src/services/import/marinara.importer.ts
@@ -449,6 +449,7 @@ async function importLorebook(data: unknown, db: DB) {
         folderId: newFolderId,
         locked: Boolean(e.locked),
         preventRecursion: Boolean(e.preventRecursion),
+        excludeFromVectorization: Boolean(e.excludeFromVectorization),
         tag: String(e.tag ?? ""),
         relationships: (e.relationships as any) ?? {},
         dynamicState: (e.dynamicState as any) ?? {},

--- a/packages/server/src/services/lorebook/keyword-scanner.ts
+++ b/packages/server/src/services/lorebook/keyword-scanner.ts
@@ -569,6 +569,7 @@ export function scanForActivatedEntries(
   if (chatEmbedding && chatEmbedding.length > 0) {
     for (const entry of entries) {
       if (!entry.enabled || entry.constant || activatedIds.has(entry.id)) continue;
+      if (entry.excludeFromVectorization) continue;
       if (!entry.embedding || entry.embedding.length === 0) continue;
       const timingState = timingStates.get(entry.id);
       if (!passesActivationGate(entry, timingState, filterContext, gameState, ignoreTiming)) continue;

--- a/packages/server/src/services/storage/lorebooks.storage.ts
+++ b/packages/server/src/services/storage/lorebooks.storage.ts
@@ -86,6 +86,7 @@ function parseEntryRow(row: Record<string, unknown>) {
     useRegex: row.useRegex === "true",
     locked: row.locked === "true",
     preventRecursion: row.preventRecursion === "true",
+    excludeFromVectorization: row.excludeFromVectorization === "true",
     folderId: (row.folderId as string | null | undefined) ?? null,
     keys: parseStringArray(row.keys),
     secondaryKeys: parseStringArray(row.secondaryKeys),
@@ -468,6 +469,7 @@ export function createLorebooksStorage(db: DB) {
         schedule: input.schedule ? JSON.stringify(input.schedule) : null,
         locked: String(input.locked ?? false),
         preventRecursion: String(input.preventRecursion ?? false),
+        excludeFromVectorization: String(input.excludeFromVectorization ?? false),
         createdAt: timestamp,
         updatedAt: timestamp,
       });
@@ -480,7 +482,8 @@ export function createLorebooksStorage(db: DB) {
         input.name !== undefined ||
         input.content !== undefined ||
         input.keys !== undefined ||
-        input.secondaryKeys !== undefined;
+        input.secondaryKeys !== undefined ||
+        input.excludeFromVectorization === true;
       if (input.name !== undefined) updates.name = input.name;
       if (input.content !== undefined) updates.content = input.content;
       if (input.description !== undefined) updates.description = input.description;
@@ -548,6 +551,8 @@ export function createLorebooksStorage(db: DB) {
       if (input.schedule !== undefined) updates.schedule = input.schedule ? JSON.stringify(input.schedule) : null;
       if (input.locked !== undefined) updates.locked = String(input.locked);
       if (input.preventRecursion !== undefined) updates.preventRecursion = String(input.preventRecursion);
+      if (input.excludeFromVectorization !== undefined)
+        updates.excludeFromVectorization = String(input.excludeFromVectorization);
       if (shouldClearEmbedding) updates.embedding = null;
 
       await db.update(lorebookEntries).set(updates).where(eq(lorebookEntries.id, id));

--- a/packages/server/test/db-migrations.test.ts
+++ b/packages/server/test/db-migrations.test.ts
@@ -102,6 +102,7 @@ test("startup migrations add lorebook folders schema to existing installs", asyn
 
     assert.equal(folderTables.length, 1);
     assert.ok(entryColumns.some((column) => column.name === "folder_id"));
+    assert.ok(entryColumns.some((column) => column.name === "exclude_from_vectorization"));
     const lorebookColumns = await db.all<{ name: string }>(sql.raw("PRAGMA table_info(lorebooks)"));
     const migratedBooks = await db.all<{ id: string; is_global: string }>(
       sql.raw(`SELECT id, is_global FROM lorebooks WHERE id = 'legacy-book'`),

--- a/packages/server/test/knowledge-router.test.ts
+++ b/packages/server/test/knowledge-router.test.ts
@@ -58,6 +58,7 @@ function makeEntry(overrides: Partial<LorebookEntry> = {}): LorebookEntry {
     dynamicState: {},
     activationConditions: [],
     schedule: null,
+    excludeFromVectorization: false,
     embedding: null,
     createdAt: "2026-01-01T00:00:00.000Z",
     updatedAt: "2026-01-01T00:00:00.000Z",

--- a/packages/server/test/lorebook-processing.test.ts
+++ b/packages/server/test/lorebook-processing.test.ts
@@ -98,6 +98,7 @@ function makeEntry(overrides: Partial<LorebookEntry> = {}): LorebookEntry {
     dynamicState: {},
     activationConditions: [],
     schedule: null,
+    excludeFromVectorization: false,
     embedding: null,
     createdAt: "2026-01-01T00:00:00.000Z",
     updatedAt: "2026-01-01T00:00:00.000Z",
@@ -164,6 +165,7 @@ function lorebookEntryRow(id: string) {
     activationConditions: "[]",
     schedule: null,
     preventRecursion: "false",
+    excludeFromVectorization: "false",
     embedding: null,
     createdAt: "2026-01-01T00:00:00.000Z",
     updatedAt: "2026-01-01T00:00:00.000Z",
@@ -680,6 +682,21 @@ test("entry probability is not re-rolled by semantic fallback after a keyword ma
 
   assert.equal(activated.length, 0);
   assert.equal(rolls, 1);
+});
+
+test("entries excluded from vectorization do not activate through semantic fallback", () => {
+  const entry = makeEntry({
+    keys: ["no-keyword-match"],
+    embedding: [1, 0],
+    excludeFromVectorization: true,
+  });
+
+  const activated = scanForActivatedEntries([{ role: "user", content: "ordinary chat" }], [entry], {
+    chatEmbedding: [1, 0],
+    semanticThreshold: 0.5,
+  });
+
+  assert.equal(activated.length, 0);
 });
 
 test("entry probability allows activation when the roll is below the configured percentage", () => {

--- a/packages/server/test/lorebooks-routes.test.ts
+++ b/packages/server/test/lorebooks-routes.test.ts
@@ -51,6 +51,7 @@ function lorebookEntry(id: string, keyword: string, name: string, content: strin
     activationConditions: "[]",
     schedule: null,
     preventRecursion: "false",
+    excludeFromVectorization: "false",
     embedding: null,
     createdAt: "2026-05-10T00:00:00.000Z",
     updatedAt: "2026-05-10T00:00:00.000Z",

--- a/packages/shared/src/schemas/lorebook.schema.ts
+++ b/packages/shared/src/schemas/lorebook.schema.ts
@@ -164,6 +164,7 @@ export const createLorebookEntrySchema = z.object({
   dynamicState: z.record(z.unknown()).default({}),
   activationConditions: z.array(activationConditionSchema).default([]),
   schedule: lorebookScheduleSchema.nullable().default(null),
+  excludeFromVectorization: z.boolean().default(false),
 });
 
 export const updateLorebookEntrySchema = z.object({
@@ -206,6 +207,7 @@ export const updateLorebookEntrySchema = z.object({
   dynamicState: z.record(z.unknown()).optional(),
   activationConditions: z.array(activationConditionSchema).optional(),
   schedule: lorebookScheduleSchema.nullable().optional(),
+  excludeFromVectorization: z.boolean().optional(),
 });
 
 export type CreateLorebookInput = z.input<typeof createLorebookSchema>;

--- a/packages/shared/src/types/lorebook.ts
+++ b/packages/shared/src/types/lorebook.ts
@@ -186,6 +186,8 @@ export interface LorebookEntry {
   /** Schedule: only active during certain in-game times/dates */
   schedule: LorebookSchedule | null;
 
+  /** When true, bulk vectorization skips this entry and semantic matching ignores any stored vector */
+  excludeFromVectorization: boolean;
   /** Pre-computed embedding vector for semantic matching (null if not vectorized) */
   embedding: number[] | null;
 


### PR DESCRIPTION
## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #741

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

Lorebooks could only vectorize every entry together, which made key-only entries discoverable through semantic search even when users wanted them to activate only through explicit keys.

## What changed

<!-- List the key changes in this PR -->

- Added a per-entry `excludeFromVectorization` flag across shared types, schemas, storage, import, and migration paths.
- Updated bulk lorebook vectorization and semantic lorebook scanning to skip excluded entries while leaving key-based activation intact.
- Added lorebook editor UI for marking an entry as `No Vector`, plus overview/row status updates that count excluded entries separately.
- Added migration and lorebook processing coverage for the new field and semantic exclusion behavior.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- `pnpm --filter @marinara-engine/shared build` passed.
- `pnpm --filter @marinara-engine/server exec tsx --import ./test/setup-env.ts --test test/lorebook-processing.test.ts test/db-migrations.test.ts` passed: 33 tests.
- `pnpm check` passed.
- `pnpm db:push` was attempted for the schema change, but this checkout has no `db:push` script (`Command "db:push" not found`).
- Ran the app locally with the server on `PORT=7861`, created a lorebook entry with `excludeFromVectorization: true`, opened it in the real lorebook editor, and verified the entry row shows the vector-excluded state, the expanded drawer shows `No Vector`, and the overview reports `0/0 entries vectorized` with `1 excluded.`

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

Verified in the local app with Playwright MCP. Screenshots were captured locally for the implementation run but are not attached to this PR.
