### PR TITLE
Support Grok image generation

### DIFF
--- a/packages/server/src/services/image/image-generation.ts
+++ b/packages/server/src/services/image/image-generation.ts
@@ -75,6 +75,7 @@ const EXPLICIT_IMAGE_SOURCES = new Set([
   "togetherai",
   "novelai",
   "horde",
+  "xai",
   "comfyui",
   "automatic1111",
   "gemini_image",
@@ -138,6 +139,8 @@ export async function generateImage(
       return generateNovelAI(normalizedBaseUrl, apiKey, scopedRequest);
     case "horde":
       return generateHorde(normalizedBaseUrl, apiKey, scopedRequest);
+    case "xai":
+      return generateXAI(normalizedBaseUrl, apiKey, scopedRequest);
     case "comfyui":
       return generateComfyUI(normalizedBaseUrl, scopedRequest);
     case "automatic1111":
@@ -243,6 +246,34 @@ function openAIImageSize(request: ImageGenRequest): string {
   if (ratio > 1.12) return "1536x1024";
   if (ratio < 0.88) return "1024x1536";
   return "1024x1024";
+}
+
+const XAI_IMAGE_ASPECT_RATIOS = [
+  ["1:1", 1],
+  ["16:9", 16 / 9],
+  ["9:16", 9 / 16],
+  ["4:3", 4 / 3],
+  ["3:4", 3 / 4],
+  ["3:2", 3 / 2],
+  ["2:3", 2 / 3],
+  ["2:1", 2],
+  ["1:2", 1 / 2],
+  ["19.5:9", 19.5 / 9],
+  ["9:19.5", 9 / 19.5],
+  ["20:9", 20 / 9],
+  ["9:20", 9 / 20],
+] as const;
+
+function xAIImageAspectRatio(width?: number, height?: number): string {
+  if (!width || !height) return "auto";
+  if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+    throw new Error(`xAI image generation requires positive width and height values, got ${width}x${height}`);
+  }
+
+  const ratio = width / height;
+  return XAI_IMAGE_ASPECT_RATIOS.reduce((best, candidate) =>
+    Math.abs(candidate[1] - ratio) < Math.abs(best[1] - ratio) ? candidate : best,
+  )[0];
 }
 
 function imageDataUrlFromReference(reference: string): string {
@@ -512,6 +543,50 @@ async function generateOpenAI(baseUrl: string, apiKey: string, request: ImageGen
   );
 
   return readOpenAIImageResult(resp, request, "generation");
+}
+
+function xAIImagesUrl(baseUrl: string): string {
+  return openAIImagesUrl(baseUrl, "generations");
+}
+
+async function generateXAI(baseUrl: string, apiKey: string, request: ImageGenRequest): Promise<ImageGenResult> {
+  if (request.referenceImage || request.referenceImages?.length) {
+    throw new Error("xAI image generation does not support reference images in Marinara yet.");
+  }
+
+  const body: Record<string, unknown> = {
+    prompt: request.prompt,
+    n: 1,
+    aspect_ratio: xAIImageAspectRatio(request.width, request.height),
+    response_format: "b64_json",
+  };
+  if (request.model) body.model = request.model;
+
+  const resp = await imageFetch(
+    xAIImagesUrl(baseUrl),
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(IMAGE_GEN_TIMEOUT),
+    },
+    { allowLocal: request.allowLocalUrls },
+  );
+
+  if (!resp.ok) {
+    const errText = await resp.text().catch(() => "Unknown error");
+    throw new Error(`xAI image generation failed (${resp.status}): ${sanitizeErrorText(errText)}`);
+  }
+
+  const data = (await resp.json()) as { data?: Array<{ b64_json?: string; url?: string }> };
+  const result = data.data?.[0];
+  if (result?.b64_json) return { base64: result.b64_json, mimeType: "image/png", ext: "png" };
+  if (result?.url) return downloadImageUrl(result.url, request.allowLocalUrls);
+
+  throw new Error("No image data in xAI response");
 }
 
 async function generateNanoGPT(baseUrl: string, apiKey: string, request: ImageGenRequest): Promise<ImageGenResult> {

--- a/packages/shared/src/constants/model-lists.ts
+++ b/packages/shared/src/constants/model-lists.ts
@@ -450,6 +450,13 @@ export const IMAGE_GENERATION_SOURCES: ImageGenSource[] = [
     requiresApiKey: true,
   },
   {
+    id: "xai",
+    name: "xAI / Grok Imagine",
+    description: "Grok Imagine image generation via xAI's Images API.",
+    defaultBaseUrl: "https://api.x.ai/v1",
+    requiresApiKey: true,
+  },
+  {
     id: "pollinations",
     name: "Pollinations",
     description: "Free, no-key-needed image generation via Pollinations AI.",
@@ -539,6 +546,9 @@ const IMAGE_GEN_MODELS: KnownModel[] = [
     context: 0,
     maxOutput: 0,
   },
+  // xAI / Grok Imagine
+  { id: "grok-imagine-image", name: "Grok Imagine Image", context: 0, maxOutput: 0 },
+  { id: "grok-2-image", name: "Grok 2 Image", context: 0, maxOutput: 0 },
   // NovelAI
   { id: "nai-diffusion-4-curated-preview", name: "NAI Diffusion 4 Curated", context: 0, maxOutput: 0 },
   { id: "nai-diffusion-4-5-full", name: "NAI Diffusion 4.5 Full", context: 0, maxOutput: 0 },
@@ -563,6 +573,7 @@ export function inferImageSource(model: string, baseUrl: string): string {
     m === "horde" ||
     m === "blockentropy" ||
     m === "openrouter" ||
+    m === "xai" ||
     m === "comfyui" ||
     m === "automatic1111" ||
     m === "gemini_image"
@@ -572,6 +583,9 @@ export function inferImageSource(model: string, baseUrl: string): string {
   if (m === "drawthings") return "automatic1111";
   if (u.includes("nano-gpt.com")) return "nanogpt";
   if (u.includes("openrouter.ai")) return "openrouter";
+  if (u.includes("api.x.ai") || u.includes("x.ai")) return "xai";
+  if (m.startsWith("grok-") && m.includes("image")) return "xai";
+  if (m.includes("grok") && m.includes("imagine")) return "xai";
   if (m.startsWith("dall-e") || m.startsWith("gpt-image") || u.includes("openai.com")) return "openai";
   if (m.startsWith("sd3") || u.includes("stability.ai")) return "stability";
   if (m.includes("nai-diffusion") || u.includes("novelai.net")) return "novelai";


### PR DESCRIPTION
## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #751

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- Grok / xAI image generation expects aspect-ratio based image sizing, so routing it through Marinara's existing OpenAI-style image generation path sends the wrong shape for size configuration.

## What changed

<!-- List the key changes in this PR -->

- Added xAI / Grok Imagine as an explicit image generation source with default base URL and model entries.
- Taught image source inference to detect xAI image connections from `api.x.ai` URLs and Grok image model names.
- Added an xAI image generation backend that sends `aspect_ratio` instead of OpenAI's `size` field and reads either base64 or URL image responses.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Codex ran `pnpm --filter @marinara-engine/server lint`.
- Codex ran `pnpm check`.
- Codex ran `node scratch\issue-751-xai-image-request.mjs` against a local stub server. The proof confirmed xAI image generation posts to `/v1/images/generations` with `aspect_ratio`, `response_format: "b64_json"`, and no `size` field.
- Manual xAI credential verification is still needed: create an image generation connection with `https://api.x.ai/v1`, select a Grok image model, and run the test image flow with a real xAI key.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

N/A - server/shared image provider support only.
