### PR TITLE
Fix regenerate replay for command prompts

### DIFF
--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -42,7 +42,13 @@ import { chatBackgroundMetadataToUrl, chatBackgroundUrlToMetadata } from "../../
 import { useGameStateStore } from "../../stores/game-state.store";
 import { toast } from "sonner";
 import { BookOpen, Check, HelpCircle, MessageSquare, Theater, X } from "lucide-react";
-import type { SpritePlacement, SpriteSide } from "@marinara-engine/shared";
+import {
+  APP_VERSION,
+  BUILT_IN_AGENTS,
+  buildGuidedGenerationInstructionMessage,
+  type SpritePlacement,
+  type SpriteSide,
+} from "@marinara-engine/shared";
 import { useUIStore } from "../../stores/ui.store";
 import { useAgentStore } from "../../stores/agent.store";
 import { cn, parseAvatarCropJson } from "../../lib/utils";
@@ -50,8 +56,6 @@ import { Modal } from "../ui/Modal";
 import { useEncounter } from "../../hooks/use-encounter";
 import { useScene } from "../../hooks/use-scene";
 import { useEncounterStore } from "../../stores/encounter.store";
-import { APP_VERSION } from "@marinara-engine/shared";
-import { BUILT_IN_AGENTS } from "@marinara-engine/shared";
 import { useTranslationStore } from "../../stores/translation.store";
 import { ttsService } from "../../lib/tts-service";
 import { useTTSConfig } from "../../hooks/use-tts";
@@ -798,7 +802,7 @@ export function ChatArea() {
                 chatId: activeChatId,
                 connectionId: null,
                 regenerateMessageId: messageId,
-                generationGuide: currentInput?.toString(),
+                generationGuide: buildGuidedGenerationInstructionMessage(currentInput.toString()),
                 generationGuideSource: "guide",
               }
             : { chatId: activeChatId, connectionId: null, regenerateMessageId: messageId },

--- a/packages/client/src/components/chat/ChatInput.tsx
+++ b/packages/client/src/components/chat/ChatInput.tsx
@@ -24,7 +24,7 @@ import { useGenerate } from "../../hooks/use-generate";
 import { useApplyRegex } from "../../hooks/use-apply-regex";
 import { useCreateMessage, useDeleteMessage, useUpdateMessageExtra, chatKeys } from "../../hooks/use-chats";
 import { characterKeys } from "../../hooks/use-characters";
-import type { Message } from "@marinara-engine/shared";
+import { buildGuidedGenerationInstructionMessage, type Message } from "@marinara-engine/shared";
 import {
   matchSlashCommand,
   getSlashCompletions,
@@ -1058,7 +1058,7 @@ export const ChatInput = memo(function ChatInput({
                 chatId: activeChatId,
                 connectionId: null,
                 forCharacterId: characterId,
-                generationGuide: currentInput,
+                generationGuide: buildGuidedGenerationInstructionMessage(currentInput),
                 generationGuideSource: "guide",
               }
             : { chatId: activeChatId, connectionId: null, forCharacterId: characterId },

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -22,6 +22,7 @@ import {
   X,
   Flag,
   Eye,
+  ScrollText,
   Circle,
   Brain,
   Languages,
@@ -49,6 +50,7 @@ import { buildTTSMessageText, resolveTTSVoiceForSpeaker } from "../../lib/tts-di
 import { DIALOGUE_QUOTE_PATTERN_SOURCE, HTML_SAFE_DIALOGUE_QUOTE_PATTERN_SOURCE } from "../../lib/dialogue-quotes";
 import DOMPurify from "dompurify";
 import type { CharacterMap, MessageSelectionToggle, PersonaInfo } from "./chat-area.types";
+import { GenerationReplayDetailsModal, hasGenerationReplayDetails } from "./GenerationReplayDetailsModal";
 import { ImagePromptPanel } from "./ImagePromptPanel";
 import { SwipeJumpControl } from "./SwipeJumpControl";
 
@@ -709,6 +711,7 @@ export const ChatMessage = memo(function ChatMessage({
   const [copied, setCopied] = useState(false);
   const [editing, setEditing] = useState(false);
   const [showThinking, setShowThinking] = useState(false);
+  const [showGenerationReplay, setShowGenerationReplay] = useState(false);
   const [showActions, setShowActions] = useState(false);
   const [avatarLightbox, setAvatarLightbox] = useState<string | null>(null);
   const [avatarLightboxPrompt, setAvatarLightboxPrompt] = useState<string | null>(null);
@@ -824,6 +827,11 @@ export const ChatMessage = memo(function ChatMessage({
   const isConversationStart = !!extra.isConversationStart;
   const isHiddenFromAI = extra.hiddenFromAI === true;
   const thinking = extra.thinking as string | undefined;
+  const generationReplay = hasGenerationReplayDetails(extra.generationReplay) ? extra.generationReplay : null;
+
+  useEffect(() => {
+    if (!generationReplay) setShowGenerationReplay(false);
+  }, [generationReplay]);
 
   // Remove an attachment from this message (keeps it in gallery)
   const qc = useQueryClient();
@@ -1742,6 +1750,14 @@ export const ChatMessage = memo(function ChatMessage({
                   dark
                 />
               )}
+              {generationReplay && (
+                <ActionBtn
+                  icon={<ScrollText size={MESSAGE_ACTION_ICON_SIZE} />}
+                  onClick={() => setShowGenerationReplay(true)}
+                  title="Stored guidance"
+                  dark
+                />
+              )}
               {thinking && !isUser && (
                 <ActionBtn
                   icon={<Brain size={MESSAGE_ACTION_ICON_SIZE} />}
@@ -1832,6 +1848,13 @@ export const ChatMessage = memo(function ChatMessage({
 
         {/* Thinking modal */}
         {showThinking && thinking && <ThinkingModal thinking={thinking} onClose={() => setShowThinking(false)} />}
+        {generationReplay && (
+          <GenerationReplayDetailsModal
+            open={showGenerationReplay}
+            replay={generationReplay}
+            onClose={() => setShowGenerationReplay(false)}
+          />
+        )}
 
         {/* Avatar lightbox */}
         {avatarLightbox && (
@@ -2142,6 +2165,13 @@ export const ChatMessage = memo(function ChatMessage({
                 title="Peek prompt"
               />
             )}
+            {generationReplay && (
+              <ActionBtn
+                icon={<ScrollText size={MESSAGE_ACTION_ICON_SIZE} />}
+                onClick={() => setShowGenerationReplay(true)}
+                title="Stored guidance"
+              />
+            )}
             {thinking && !isUser && (
               <ActionBtn
                 icon={<Brain size={MESSAGE_ACTION_ICON_SIZE} />}
@@ -2225,6 +2255,13 @@ export const ChatMessage = memo(function ChatMessage({
 
       {/* Thinking modal */}
       {showThinking && thinking && <ThinkingModal thinking={thinking} onClose={() => setShowThinking(false)} />}
+      {generationReplay && (
+        <GenerationReplayDetailsModal
+          open={showGenerationReplay}
+          replay={generationReplay}
+          onClose={() => setShowGenerationReplay(false)}
+        />
+      )}
 
       {/* Avatar lightbox */}
       {avatarLightbox && (

--- a/packages/client/src/components/chat/ConversationInput.tsx
+++ b/packages/client/src/components/chat/ConversationInput.tsx
@@ -49,7 +49,7 @@ import { MariThinkingIndicator } from "./MariThinkingIndicator";
 import { MariCapabilityNotice } from "./MariCapabilityNotice";
 import { SlashCommandFeedback } from "./SlashCommandFeedback";
 import { QuickReplyMenu, type QuickReplyAction } from "./QuickReplyMenu";
-import type { Message } from "@marinara-engine/shared";
+import { buildGuidedGenerationInstructionMessage, type Message } from "@marinara-engine/shared";
 
 interface Attachment {
   type: string;
@@ -1303,7 +1303,7 @@ export function ConversationInput({
                 chatId: activeChatId,
                 connectionId: null,
                 forCharacterId: characterId,
-                generationGuide: currentInput,
+                generationGuide: buildGuidedGenerationInstructionMessage(currentInput),
                 generationGuideSource: "guide",
               }
             : { chatId: activeChatId, connectionId: null, forCharacterId: characterId },

--- a/packages/client/src/components/chat/ConversationMessage.tsx
+++ b/packages/client/src/components/chat/ConversationMessage.tsx
@@ -9,13 +9,14 @@ import {
   Copy,
   RefreshCw,
   Eye,
+  ScrollText,
   Brain,
   X,
   User,
   Languages,
 } from "lucide-react";
 import { useQueryClient, type InfiniteData } from "@tanstack/react-query";
-import type { Message } from "@marinara-engine/shared";
+import type { Message, MessageExtra } from "@marinara-engine/shared";
 import { useUIStore } from "../../stores/ui.store";
 import { useChatStore } from "../../stores/chat.store";
 import { cn, copyToClipboard, getAvatarCropStyle, parseAvatarCropJson } from "../../lib/utils";
@@ -25,6 +26,7 @@ import { resolveMessageMacros } from "../../lib/chat-macros";
 import { useTranslate } from "../../hooks/use-translate";
 import { api } from "../../lib/api-client";
 import type { CharacterMap, MessageSelectionToggle, PersonaInfo } from "./chat-area.types";
+import { GenerationReplayDetailsModal, hasGenerationReplayDetails } from "./GenerationReplayDetailsModal";
 import { ImagePromptPanel } from "./ImagePromptPanel";
 import { SwipeJumpControl } from "./SwipeJumpControl";
 
@@ -228,6 +230,7 @@ interface MessageData {
     } | null;
     isConversationStart?: boolean;
     thinking?: string | null;
+    generationReplay?: MessageExtra["generationReplay"];
     attachments?: Array<{ type: string; url: string; filename?: string; prompt?: string; galleryId?: string }>;
   };
   createdAt: string;
@@ -288,6 +291,7 @@ export const ConversationMessage = memo(function ConversationMessage({
   const [showActions, setShowActions] = useState(false);
   const [copied, setCopied] = useState(false);
   const [showThinking, setShowThinking] = useState(false);
+  const [showGenerationReplay, setShowGenerationReplay] = useState(false);
   const [imageLightbox, setImageLightbox] = useState<{ url: string; prompt?: string | null } | null>(null);
   const editRef = useRef<HTMLTextAreaElement>(null);
   const hasInput = useChatStore((s) => s.currentInput.trim().length > 0);
@@ -314,6 +318,12 @@ export const ConversationMessage = memo(function ConversationMessage({
     if (!message.extra) return {} as Record<string, any>;
     return typeof message.extra === "string" ? JSON.parse(message.extra) : message.extra;
   }, [message.extra]);
+  const generationReplay = hasGenerationReplayDetails(extra.generationReplay) ? extra.generationReplay : null;
+  const canRegenerate = !isUser || generationReplay !== null;
+
+  useEffect(() => {
+    if (!generationReplay) setShowGenerationReplay(false);
+  }, [generationReplay]);
 
   const scopedCharacterMap = useMemo(() => {
     if (!characterMap) return null;
@@ -814,6 +824,13 @@ export const ConversationMessage = memo(function ConversationMessage({
           {isLastAssistantMessage && (
             <MsgAction icon={<Eye size="0.75rem" />} onClick={() => onPeekPrompt?.()} title="Peek prompt" />
           )}
+          {generationReplay && (
+            <MsgAction
+              icon={<ScrollText size="0.75rem" />}
+              onClick={() => setShowGenerationReplay(true)}
+              title="Stored guidance"
+            />
+          )}
           {thinking && (
             <MsgAction icon={<Brain size="0.75rem" />} onClick={() => setShowThinking(true)} title="View thoughts" />
           )}
@@ -858,6 +875,13 @@ export const ConversationMessage = memo(function ConversationMessage({
             </div>,
             document.body,
           )}
+        {generationReplay && (
+          <GenerationReplayDetailsModal
+            open={showGenerationReplay}
+            replay={generationReplay}
+            onClose={() => setShowGenerationReplay(false)}
+          />
+        )}
       </div>
     );
   }
@@ -1090,7 +1114,7 @@ export const ConversationMessage = memo(function ConversationMessage({
             className={translatedText ? "text-blue-400" : undefined}
           />
           <MsgAction icon={<Pencil size="0.75rem" />} onClick={onEditClick ?? startEditing} title="Edit" />
-          {!isUser && (
+          {canRegenerate && (
             <MsgAction
               icon={<RefreshCw size="0.75rem" />}
               onClick={() => onRegenerate?.(message.id)}
@@ -1100,6 +1124,13 @@ export const ConversationMessage = memo(function ConversationMessage({
           )}
           {isLastAssistantMessage && !isUser && (
             <MsgAction icon={<Eye size="0.75rem" />} onClick={() => onPeekPrompt?.()} title="Peek prompt" />
+          )}
+          {generationReplay && (
+            <MsgAction
+              icon={<ScrollText size="0.75rem" />}
+              onClick={() => setShowGenerationReplay(true)}
+              title="Stored guidance"
+            />
           )}
           {thinking && !isUser && (
             <MsgAction icon={<Brain size="0.75rem" />} onClick={() => setShowThinking(true)} title="View thoughts" />
@@ -1143,9 +1174,16 @@ export const ConversationMessage = memo(function ConversationMessage({
                 </pre>
               </div>
             </div>
-          </div>,
-          document.body,
-        )}
+            </div>,
+            document.body,
+          )}
+      {generationReplay && (
+        <GenerationReplayDetailsModal
+          open={showGenerationReplay}
+          replay={generationReplay}
+          onClose={() => setShowGenerationReplay(false)}
+        />
+      )}
 
       {imageLightbox &&
         createPortal(

--- a/packages/client/src/components/chat/ConversationMessage.tsx
+++ b/packages/client/src/components/chat/ConversationMessage.tsx
@@ -319,6 +319,8 @@ export const ConversationMessage = memo(function ConversationMessage({
     return typeof message.extra === "string" ? JSON.parse(message.extra) : message.extra;
   }, [message.extra]);
   const generationReplay = hasGenerationReplayDetails(extra.generationReplay) ? extra.generationReplay : null;
+  // canRegenerate lets assistant messages retry; isUser messages need generationReplay
+  // metadata from hasGenerationReplayDetails, such as /impersonate.
   const canRegenerate = !isUser || generationReplay !== null;
 
   useEffect(() => {

--- a/packages/client/src/components/chat/GenerationReplayDetailsModal.tsx
+++ b/packages/client/src/components/chat/GenerationReplayDetailsModal.tsx
@@ -1,0 +1,119 @@
+import { stripGenerationGuideInstruction, type MessageExtra } from "@marinara-engine/shared";
+import { Modal } from "../ui/Modal";
+
+type GenerationReplay = NonNullable<MessageExtra["generationReplay"]>;
+type GuideSource = NonNullable<GenerationReplay["generationGuideSource"]>;
+
+const GUIDE_SOURCE_LABELS: Record<GuideSource, string> = {
+  narrator: "/narrator",
+  guide: "Guided regenerate",
+  game_start: "Game start",
+};
+
+function storedText(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function visibleGenerationGuide(replay: GenerationReplay | null): string | null {
+  const guide = storedText(replay?.generationGuide);
+  if (!guide) return null;
+  return replay?.generationGuideSource === "narrator" || replay?.generationGuideSource === "guide"
+    ? stripGenerationGuideInstruction(guide)
+    : guide;
+}
+
+export function hasGenerationReplayDetails(value: unknown): value is GenerationReplay {
+  if (!value || typeof value !== "object") return false;
+  const replay = value as GenerationReplay;
+  return replay.impersonate === true || storedText(replay.generationGuide) !== null;
+}
+
+function guideLabel(source: GenerationReplay["generationGuideSource"]): string {
+  return source && source in GUIDE_SOURCE_LABELS ? GUIDE_SOURCE_LABELS[source as GuideSource] : "Stored guidance";
+}
+
+function TextBlock({ label, value, muted = false }: { label: string; value: string; muted?: boolean }) {
+  return (
+    <section className="space-y-1.5">
+      <h3 className="text-[0.75rem] font-semibold uppercase tracking-normal text-[var(--muted-foreground)]">{label}</h3>
+      <pre
+        className={`max-h-48 overflow-y-auto whitespace-pre-wrap break-words rounded-lg border border-[var(--border)] bg-[var(--muted)]/30 px-3 py-2 text-[0.8125rem] leading-relaxed ${
+          muted ? "text-[var(--muted-foreground)]" : "text-[var(--foreground)]"
+        }`}
+      >
+        {value}
+      </pre>
+    </section>
+  );
+}
+
+function MetadataRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="grid grid-cols-[7rem_minmax(0,1fr)] gap-3 text-[0.8125rem] max-sm:grid-cols-1 max-sm:gap-1">
+      <dt className="font-medium text-[var(--muted-foreground)]">{label}</dt>
+      <dd className="min-w-0 break-words font-mono text-[var(--foreground)]">{value}</dd>
+    </div>
+  );
+}
+
+export function GenerationReplayDetailsModal({
+  open,
+  replay,
+  onClose,
+}: {
+  open: boolean;
+  replay: GenerationReplay | null;
+  onClose: () => void;
+}) {
+  const generationGuide = visibleGenerationGuide(replay);
+  const impersonateDirection = storedText(replay?.userMessage);
+  const impersonateGuidance = hasGenerationReplayDetails(replay) && replay?.impersonate === true
+    ? (generationGuide ?? impersonateDirection)
+    : null;
+  const impersonatePromptTemplate = storedText(replay?.impersonatePromptTemplate);
+  const hasImpersonate = replay?.impersonate === true;
+  const hasMetadata =
+    hasImpersonate &&
+    (storedText(replay?.impersonatePresetId) ||
+      storedText(replay?.impersonateConnectionId) ||
+      replay?.impersonateBlockAgents === true);
+
+  return (
+    <Modal open={open} onClose={onClose} title="Stored guidance" width="max-w-xl">
+      <div className="space-y-5">
+        {generationGuide && !hasImpersonate && (
+          <TextBlock label={guideLabel(replay?.generationGuideSource)} value={generationGuide} />
+        )}
+
+        {hasImpersonate && (
+          <section className="space-y-3">
+            <h3 className="text-[0.75rem] font-semibold uppercase tracking-normal text-[var(--muted-foreground)]">
+              /impersonate
+            </h3>
+            <TextBlock
+              label="Current guidance"
+              value={impersonateGuidance ?? "No guidance stored"}
+              muted={!impersonateGuidance}
+            />
+            {impersonatePromptTemplate && <TextBlock label="Prompt template" value={impersonatePromptTemplate} />}
+            {hasMetadata && (
+              <dl className="space-y-2 rounded-lg border border-[var(--border)] bg-[var(--muted)]/20 px-3 py-2">
+                {storedText(replay?.impersonatePresetId) && (
+                  <MetadataRow label="Preset" value={storedText(replay?.impersonatePresetId)!} />
+                )}
+                {storedText(replay?.impersonateConnectionId) && (
+                  <MetadataRow label="Connection" value={storedText(replay?.impersonateConnectionId)!} />
+                )}
+                {replay?.impersonateBlockAgents === true && <MetadataRow label="Agents" value="Blocked" />}
+              </dl>
+            )}
+          </section>
+        )}
+
+        {!generationGuide && !hasImpersonate && (
+          <p className="text-sm text-[var(--muted-foreground)]">No stored guidance on this swipe.</p>
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/packages/client/src/lib/slash-commands.ts
+++ b/packages/client/src/lib/slash-commands.ts
@@ -5,7 +5,12 @@ import { api } from "./api-client";
 import { useChatStore } from "../stores/chat.store";
 import { useUIStore } from "../stores/ui.store";
 import { toast } from "sonner";
-import { SUPPORTED_MACROS, type SceneCreateResponse, type ScenePlanResponse } from "@marinara-engine/shared";
+import {
+  SUPPORTED_MACROS,
+  buildNarratorInstructionMessage,
+  type SceneCreateResponse,
+  type ScenePlanResponse,
+} from "@marinara-engine/shared";
 
 export interface SlashCommand {
   name: string;
@@ -258,10 +263,6 @@ function isMessageHidden(msg: { extra?: unknown }): boolean {
   } catch {
     return false;
   }
-}
-
-export function buildNarratorInstructionMessage(direction: string): string {
-  return `[Narrator instruction — do not include a reply from {{user}}. Instead, write the next part of the narrative steering it toward the following: ${direction.trim()}]`;
 }
 
 // ── Command definitions ────────────────

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -185,6 +185,11 @@ import {
   type PromptPresetCandidateSource,
 } from "./generate/prompt-preset-selection.js";
 import {
+  applyGenerationReplayToRegenerateInput,
+  buildGenerationReplay,
+  normalizeGenerationReplay,
+} from "./generate/generation-replay.js";
+import {
   createJournal,
   addLocationEntry,
   addEventEntry,
@@ -758,6 +763,14 @@ export async function generateRoutes(app: FastifyInstance) {
         activeGenerations.delete(input.chatId);
       }
     };
+
+    if (input.regenerateMessageId) {
+      const regenCandidate = await chats.getMessage(input.regenerateMessageId);
+      if (regenCandidate?.chatId === input.chatId) {
+        const replay = normalizeGenerationReplay(parseExtra(regenCandidate.extra).generationReplay);
+        applyGenerationReplayToRegenerateInput(input, replay);
+      }
+    }
 
     // ── Discord webhook URL (parsed once, used for mirroring below) ──
     const earlyMeta = parseExtra(chat.metadata) as Record<string, unknown>;
@@ -6510,6 +6523,7 @@ export async function generateRoutes(app: FastifyInstance) {
             // Cache the exact prompt injections used for this swipe so future
             // regenerations and swipe switches replay the same guidance.
             extraUpdate.contextInjections = contextInjections.length > 0 ? contextInjections : null;
+            extraUpdate.generationReplay = buildGenerationReplay(input);
             // Cache the final prompt (what was actually sent to the model) for Peek Prompt
             extraUpdate.cachedPrompt = finalPromptSent.map((m) => ({ role: m.role, content: m.content }));
             await chats.updateMessageExtra(savedMsg.id, extraUpdate);

--- a/packages/server/src/routes/generate/generation-replay.ts
+++ b/packages/server/src/routes/generate/generation-replay.ts
@@ -1,4 +1,6 @@
-export type GenerationReplayGuideSource = "narrator" | "guide" | "game_start";
+import { stripGenerationGuideInstruction, type GenerationGuideSource } from "@marinara-engine/shared";
+
+export type GenerationReplayGuideSource = GenerationGuideSource;
 
 export interface GenerationReplay {
   impersonate?: true;
@@ -93,8 +95,20 @@ export function applyGenerationReplayToRegenerateInput(
       applied = true;
     }
 
-    if (!asNonEmptyString(input.userMessage) && replay.userMessage) {
+    const currentUserMessage = asNonEmptyString(input.userMessage);
+    const explicitGuide = asNonEmptyString(input.generationGuide);
+    if (explicitGuide) {
+      if (!currentUserMessage) {
+        input.userMessage = stripGenerationGuideInstruction(explicitGuide);
+      }
+      input.generationGuide = null;
+      input.generationGuideSource = null;
+      applied = true;
+    } else if (!currentUserMessage && replay.userMessage) {
       input.userMessage = replay.userMessage;
+      applied = true;
+    } else if (!currentUserMessage && replay.generationGuide) {
+      input.userMessage = stripGenerationGuideInstruction(replay.generationGuide);
       applied = true;
     }
 
@@ -119,7 +133,7 @@ export function applyGenerationReplayToRegenerateInput(
     }
   }
 
-  if (!asNonEmptyString(input.generationGuide) && replay.generationGuide) {
+  if (replay.impersonate !== true && !asNonEmptyString(input.generationGuide) && replay.generationGuide) {
     input.generationGuide = replay.generationGuide;
     input.generationGuideSource = replay.generationGuideSource ?? "guide";
     applied = true;

--- a/packages/server/src/routes/generate/generation-replay.ts
+++ b/packages/server/src/routes/generate/generation-replay.ts
@@ -27,6 +27,10 @@ export interface GenerationReplayInput {
 const GUIDE_SOURCES = new Set<GenerationReplayGuideSource>(["narrator", "guide", "game_start"]);
 
 function asNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function asTrimmedNonEmptyString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
 }
 
@@ -50,10 +54,10 @@ export function buildGenerationReplay(input: GenerationReplayInput): GenerationR
     replay.impersonate = true;
     replay.userMessage = asNonEmptyString(input.userMessage);
 
-    const impersonatePresetId = asNonEmptyString(input.impersonatePresetId);
+    const impersonatePresetId = asTrimmedNonEmptyString(input.impersonatePresetId);
     if (impersonatePresetId) replay.impersonatePresetId = impersonatePresetId;
 
-    const impersonateConnectionId = asNonEmptyString(input.impersonateConnectionId);
+    const impersonateConnectionId = asTrimmedNonEmptyString(input.impersonateConnectionId);
     if (impersonateConnectionId) replay.impersonateConnectionId = impersonateConnectionId;
 
     if (input.impersonateBlockAgents === true) replay.impersonateBlockAgents = true;
@@ -74,8 +78,8 @@ export function normalizeGenerationReplay(value: unknown): GenerationReplay | nu
     impersonate: raw.impersonate === true,
     generationGuide: asNonEmptyString(raw.generationGuide),
     generationGuideSource: asGuideSource(raw.generationGuideSource),
-    impersonatePresetId: asNonEmptyString(raw.impersonatePresetId),
-    impersonateConnectionId: asNonEmptyString(raw.impersonateConnectionId),
+    impersonatePresetId: asTrimmedNonEmptyString(raw.impersonatePresetId),
+    impersonateConnectionId: asTrimmedNonEmptyString(raw.impersonateConnectionId),
     impersonateBlockAgents: raw.impersonateBlockAgents === true,
     impersonatePromptTemplate: asNonEmptyString(raw.impersonatePromptTemplate),
   });
@@ -112,12 +116,12 @@ export function applyGenerationReplayToRegenerateInput(
       applied = true;
     }
 
-    if (!asNonEmptyString(input.impersonatePresetId) && replay.impersonatePresetId) {
+    if (!asTrimmedNonEmptyString(input.impersonatePresetId) && replay.impersonatePresetId) {
       input.impersonatePresetId = replay.impersonatePresetId;
       applied = true;
     }
 
-    if (!asNonEmptyString(input.impersonateConnectionId) && replay.impersonateConnectionId) {
+    if (!asTrimmedNonEmptyString(input.impersonateConnectionId) && replay.impersonateConnectionId) {
       input.impersonateConnectionId = replay.impersonateConnectionId;
       applied = true;
     }

--- a/packages/server/src/routes/generate/generation-replay.ts
+++ b/packages/server/src/routes/generate/generation-replay.ts
@@ -1,0 +1,129 @@
+export type GenerationReplayGuideSource = "narrator" | "guide" | "game_start";
+
+export interface GenerationReplay {
+  impersonate?: true;
+  userMessage?: string | null;
+  generationGuide?: string;
+  generationGuideSource?: GenerationReplayGuideSource;
+  impersonatePresetId?: string | null;
+  impersonateConnectionId?: string | null;
+  impersonateBlockAgents?: boolean;
+  impersonatePromptTemplate?: string | null;
+}
+
+export interface GenerationReplayInput {
+  userMessage?: string | null;
+  impersonate?: boolean;
+  generationGuide?: string | null;
+  generationGuideSource?: GenerationReplayGuideSource | null;
+  impersonatePresetId?: string | null;
+  impersonateConnectionId?: string | null;
+  impersonateBlockAgents?: boolean;
+  impersonatePromptTemplate?: string | null;
+}
+
+const GUIDE_SOURCES = new Set<GenerationReplayGuideSource>(["narrator", "guide", "game_start"]);
+
+function asNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function asGuideSource(value: unknown): GenerationReplayGuideSource | null {
+  return typeof value === "string" && GUIDE_SOURCES.has(value as GenerationReplayGuideSource)
+    ? (value as GenerationReplayGuideSource)
+    : null;
+}
+
+export function buildGenerationReplay(input: GenerationReplayInput): GenerationReplay | null {
+  const replay: GenerationReplay = {};
+  const guide = asNonEmptyString(input.generationGuide);
+  const guideSource = asGuideSource(input.generationGuideSource);
+
+  if (guide && guideSource) {
+    replay.generationGuide = guide;
+    replay.generationGuideSource = guideSource;
+  }
+
+  if (input.impersonate === true) {
+    replay.impersonate = true;
+    replay.userMessage = asNonEmptyString(input.userMessage);
+
+    const impersonatePresetId = asNonEmptyString(input.impersonatePresetId);
+    if (impersonatePresetId) replay.impersonatePresetId = impersonatePresetId;
+
+    const impersonateConnectionId = asNonEmptyString(input.impersonateConnectionId);
+    if (impersonateConnectionId) replay.impersonateConnectionId = impersonateConnectionId;
+
+    if (input.impersonateBlockAgents === true) replay.impersonateBlockAgents = true;
+
+    const impersonatePromptTemplate = asNonEmptyString(input.impersonatePromptTemplate);
+    if (impersonatePromptTemplate) replay.impersonatePromptTemplate = impersonatePromptTemplate;
+  }
+
+  return Object.keys(replay).length > 0 ? replay : null;
+}
+
+export function normalizeGenerationReplay(value: unknown): GenerationReplay | null {
+  if (!value || typeof value !== "object") return null;
+
+  const raw = value as Record<string, unknown>;
+  return buildGenerationReplay({
+    userMessage: asNonEmptyString(raw.userMessage),
+    impersonate: raw.impersonate === true,
+    generationGuide: asNonEmptyString(raw.generationGuide),
+    generationGuideSource: asGuideSource(raw.generationGuideSource),
+    impersonatePresetId: asNonEmptyString(raw.impersonatePresetId),
+    impersonateConnectionId: asNonEmptyString(raw.impersonateConnectionId),
+    impersonateBlockAgents: raw.impersonateBlockAgents === true,
+    impersonatePromptTemplate: asNonEmptyString(raw.impersonatePromptTemplate),
+  });
+}
+
+export function applyGenerationReplayToRegenerateInput(
+  input: GenerationReplayInput,
+  replay: GenerationReplay | null,
+): boolean {
+  if (!replay) return false;
+
+  let applied = false;
+
+  if (replay.impersonate === true) {
+    if (input.impersonate !== true) {
+      input.impersonate = true;
+      applied = true;
+    }
+
+    if (!asNonEmptyString(input.userMessage) && replay.userMessage) {
+      input.userMessage = replay.userMessage;
+      applied = true;
+    }
+
+    if (!asNonEmptyString(input.impersonatePresetId) && replay.impersonatePresetId) {
+      input.impersonatePresetId = replay.impersonatePresetId;
+      applied = true;
+    }
+
+    if (!asNonEmptyString(input.impersonateConnectionId) && replay.impersonateConnectionId) {
+      input.impersonateConnectionId = replay.impersonateConnectionId;
+      applied = true;
+    }
+
+    if (input.impersonateBlockAgents !== true && replay.impersonateBlockAgents === true) {
+      input.impersonateBlockAgents = true;
+      applied = true;
+    }
+
+    if (!asNonEmptyString(input.impersonatePromptTemplate) && replay.impersonatePromptTemplate) {
+      input.impersonatePromptTemplate = replay.impersonatePromptTemplate;
+      applied = true;
+    }
+  }
+
+  if (!asNonEmptyString(input.generationGuide) && replay.generationGuide) {
+    input.generationGuide = replay.generationGuide;
+    input.generationGuideSource = replay.generationGuideSource ?? "guide";
+    applied = true;
+  }
+
+  return applied;
+}

--- a/packages/server/src/services/storage/chats.storage.ts
+++ b/packages/server/src/services/storage/chats.storage.ts
@@ -703,6 +703,7 @@ export function createChatsStorage(db: DB) {
               thinking: null,
               generationInfo: null,
               attachments: null,
+              generationReplay: null,
             }
           : {};
         await db

--- a/packages/server/test/generation-replay.test.ts
+++ b/packages/server/test/generation-replay.test.ts
@@ -45,6 +45,38 @@ test("keeps an explicit regenerate guide instead of replacing it with replayed g
   assert.equal(input.generationGuideSource, "guide");
 });
 
+test("replays ordinary guided-regenerate guidance", () => {
+  const replay = buildGenerationReplay({
+    generationGuide: "Fresh regenerate direction.",
+    generationGuideSource: "guide",
+  });
+  const input = regenInput();
+
+  assert.deepEqual(replay, {
+    generationGuide: "Fresh regenerate direction.",
+    generationGuideSource: "guide",
+  });
+  assert.equal(applyGenerationReplayToRegenerateInput(input, replay), true);
+  assert.equal(input.generationGuide, "Fresh regenerate direction.");
+  assert.equal(input.generationGuideSource, "guide");
+});
+
+test("normalizes stored ordinary guide metadata", () => {
+  const replay = normalizeGenerationReplay({
+    generationGuide: "stale hidden guide",
+    generationGuideSource: "guide",
+  });
+  const input = regenInput();
+
+  assert.deepEqual(replay, {
+    generationGuide: "stale hidden guide",
+    generationGuideSource: "guide",
+  });
+  assert.equal(applyGenerationReplayToRegenerateInput(input, replay), true);
+  assert.equal(input.generationGuide, "stale hidden guide");
+  assert.equal(input.generationGuideSource, "guide");
+});
+
 test("replays impersonate direction and overrides onto a regenerate request", () => {
   const replay = buildGenerationReplay({
     impersonate: true,
@@ -65,6 +97,45 @@ test("replays impersonate direction and overrides onto a regenerate request", ()
   assert.equal(input.impersonatePromptTemplate, "Write as {{user}}: {{impersonate_direction}}");
 });
 
+test("uses explicit guided regenerate text as the new impersonate direction", () => {
+  const replay = buildGenerationReplay({
+    impersonate: true,
+    userMessage: "Old impersonate direction.",
+    impersonatePresetId: "preset-1",
+  });
+  const input = regenInput({
+    generationGuide:
+      "[Guided generation instruction — do not include a reply from {{user}}. Instead, write the next generated message steering it toward the following: New impersonate direction.]",
+    generationGuideSource: "guide",
+  });
+
+  assert.equal(applyGenerationReplayToRegenerateInput(input, replay), true);
+  assert.equal(input.impersonate, true);
+  assert.equal(input.userMessage, "New impersonate direction.");
+  assert.equal(input.generationGuide, null);
+  assert.equal(input.generationGuideSource, null);
+  assert.equal(input.impersonatePresetId, "preset-1");
+});
+
+test("clears generic guide injection when an explicit impersonate direction is already present", () => {
+  const replay = buildGenerationReplay({
+    impersonate: true,
+    userMessage: "Old impersonate direction.",
+  });
+  const input = regenInput({
+    userMessage: "Direct impersonate direction.",
+    generationGuide:
+      "[Guided generation instruction — do not include a reply from {{user}}. Instead, write the next generated message steering it toward the following: Generic guide.]",
+    generationGuideSource: "guide",
+  });
+
+  assert.equal(applyGenerationReplayToRegenerateInput(input, replay), true);
+  assert.equal(input.impersonate, true);
+  assert.equal(input.userMessage, "Direct impersonate direction.");
+  assert.equal(input.generationGuide, null);
+  assert.equal(input.generationGuideSource, null);
+});
+
 test("normalizes stored replay metadata before applying it", () => {
   const replay = normalizeGenerationReplay({
     impersonate: true,
@@ -78,7 +149,7 @@ test("normalizes stored replay metadata before applying it", () => {
   assert.equal(applyGenerationReplayToRegenerateInput(input, replay), true);
   assert.equal(input.impersonate, true);
   assert.equal(input.userMessage, "whisper it");
-  assert.equal(input.generationGuide, "keep the scene tense");
-  assert.equal(input.generationGuideSource, "narrator");
+  assert.equal(input.generationGuide, null);
+  assert.equal(input.generationGuideSource, null);
   assert.equal(input.impersonateBlockAgents, true);
 });

--- a/packages/server/test/generation-replay.test.ts
+++ b/packages/server/test/generation-replay.test.ts
@@ -1,0 +1,84 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  applyGenerationReplayToRegenerateInput,
+  buildGenerationReplay,
+  normalizeGenerationReplay,
+  type GenerationReplayInput,
+} from "../src/routes/generate/generation-replay.js";
+
+function regenInput(overrides: Partial<GenerationReplayInput> = {}): GenerationReplayInput {
+  return {
+    userMessage: null,
+    impersonate: false,
+    generationGuide: null,
+    generationGuideSource: null,
+    impersonateBlockAgents: false,
+    ...overrides,
+  };
+}
+
+test("replays narrator generation guidance onto a regenerate request", () => {
+  const replay = buildGenerationReplay({
+    generationGuide: "Take the scene toward the docks.",
+    generationGuideSource: "narrator",
+  });
+  const input = regenInput();
+
+  assert.equal(applyGenerationReplayToRegenerateInput(input, replay), true);
+  assert.equal(input.generationGuide, "Take the scene toward the docks.");
+  assert.equal(input.generationGuideSource, "narrator");
+});
+
+test("keeps an explicit regenerate guide instead of replacing it with replayed guidance", () => {
+  const replay = buildGenerationReplay({
+    generationGuide: "Original slash-command direction.",
+    generationGuideSource: "narrator",
+  });
+  const input = regenInput({
+    generationGuide: "Fresh regenerate direction.",
+    generationGuideSource: "guide",
+  });
+
+  assert.equal(applyGenerationReplayToRegenerateInput(input, replay), false);
+  assert.equal(input.generationGuide, "Fresh regenerate direction.");
+  assert.equal(input.generationGuideSource, "guide");
+});
+
+test("replays impersonate direction and overrides onto a regenerate request", () => {
+  const replay = buildGenerationReplay({
+    impersonate: true,
+    userMessage: "Answer like you are hiding something.",
+    impersonatePresetId: "preset-1",
+    impersonateConnectionId: "connection-1",
+    impersonateBlockAgents: true,
+    impersonatePromptTemplate: "Write as {{user}}: {{impersonate_direction}}",
+  });
+  const input = regenInput();
+
+  assert.equal(applyGenerationReplayToRegenerateInput(input, replay), true);
+  assert.equal(input.impersonate, true);
+  assert.equal(input.userMessage, "Answer like you are hiding something.");
+  assert.equal(input.impersonatePresetId, "preset-1");
+  assert.equal(input.impersonateConnectionId, "connection-1");
+  assert.equal(input.impersonateBlockAgents, true);
+  assert.equal(input.impersonatePromptTemplate, "Write as {{user}}: {{impersonate_direction}}");
+});
+
+test("normalizes stored replay metadata before applying it", () => {
+  const replay = normalizeGenerationReplay({
+    impersonate: true,
+    userMessage: "  whisper it  ",
+    generationGuide: "  keep the scene tense  ",
+    generationGuideSource: "narrator",
+    impersonateBlockAgents: true,
+  });
+  const input = regenInput();
+
+  assert.equal(applyGenerationReplayToRegenerateInput(input, replay), true);
+  assert.equal(input.impersonate, true);
+  assert.equal(input.userMessage, "whisper it");
+  assert.equal(input.generationGuide, "keep the scene tense");
+  assert.equal(input.generationGuideSource, "narrator");
+  assert.equal(input.impersonateBlockAgents, true);
+});

--- a/packages/server/test/generation-replay.test.ts
+++ b/packages/server/test/generation-replay.test.ts
@@ -1,5 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { buildGuidedGenerationInstructionMessage } from "@marinara-engine/shared";
 import {
   applyGenerationReplayToRegenerateInput,
   buildGenerationReplay,
@@ -63,17 +64,17 @@ test("replays ordinary guided-regenerate guidance", () => {
 
 test("normalizes stored ordinary guide metadata", () => {
   const replay = normalizeGenerationReplay({
-    generationGuide: "stale hidden guide",
+    generationGuide: "  stale hidden guide  ",
     generationGuideSource: "guide",
   });
   const input = regenInput();
 
   assert.deepEqual(replay, {
-    generationGuide: "stale hidden guide",
+    generationGuide: "  stale hidden guide  ",
     generationGuideSource: "guide",
   });
   assert.equal(applyGenerationReplayToRegenerateInput(input, replay), true);
-  assert.equal(input.generationGuide, "stale hidden guide");
+  assert.equal(input.generationGuide, "  stale hidden guide  ");
   assert.equal(input.generationGuideSource, "guide");
 });
 
@@ -84,7 +85,7 @@ test("replays impersonate direction and overrides onto a regenerate request", ()
     impersonatePresetId: "preset-1",
     impersonateConnectionId: "connection-1",
     impersonateBlockAgents: true,
-    impersonatePromptTemplate: "Write as {{user}}: {{impersonate_direction}}",
+    impersonatePromptTemplate: "  Write as {{user}}: {{impersonate_direction}}  ",
   });
   const input = regenInput();
 
@@ -94,7 +95,7 @@ test("replays impersonate direction and overrides onto a regenerate request", ()
   assert.equal(input.impersonatePresetId, "preset-1");
   assert.equal(input.impersonateConnectionId, "connection-1");
   assert.equal(input.impersonateBlockAgents, true);
-  assert.equal(input.impersonatePromptTemplate, "Write as {{user}}: {{impersonate_direction}}");
+  assert.equal(input.impersonatePromptTemplate, "  Write as {{user}}: {{impersonate_direction}}  ");
 });
 
 test("uses explicit guided regenerate text as the new impersonate direction", () => {
@@ -104,8 +105,7 @@ test("uses explicit guided regenerate text as the new impersonate direction", ()
     impersonatePresetId: "preset-1",
   });
   const input = regenInput({
-    generationGuide:
-      "[Guided generation instruction — do not include a reply from {{user}}. Instead, write the next generated message steering it toward the following: New impersonate direction.]",
+    generationGuide: buildGuidedGenerationInstructionMessage("New impersonate direction."),
     generationGuideSource: "guide",
   });
 
@@ -124,8 +124,7 @@ test("clears generic guide injection when an explicit impersonate direction is a
   });
   const input = regenInput({
     userMessage: "Direct impersonate direction.",
-    generationGuide:
-      "[Guided generation instruction — do not include a reply from {{user}}. Instead, write the next generated message steering it toward the following: Generic guide.]",
+    generationGuide: buildGuidedGenerationInstructionMessage("Generic guide."),
     generationGuideSource: "guide",
   });
 
@@ -136,7 +135,7 @@ test("clears generic guide injection when an explicit impersonate direction is a
   assert.equal(input.generationGuideSource, null);
 });
 
-test("normalizes stored replay metadata before applying it", () => {
+test("preserves stored replay metadata whitespace before applying it", () => {
   const replay = normalizeGenerationReplay({
     impersonate: true,
     userMessage: "  whisper it  ",
@@ -148,7 +147,7 @@ test("normalizes stored replay metadata before applying it", () => {
 
   assert.equal(applyGenerationReplayToRegenerateInput(input, replay), true);
   assert.equal(input.impersonate, true);
-  assert.equal(input.userMessage, "whisper it");
+  assert.equal(input.userMessage, "  whisper it  ");
   assert.equal(input.generationGuide, null);
   assert.equal(input.generationGuideSource, null);
   assert.equal(input.impersonateBlockAgents, true);

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -57,3 +57,4 @@ export * from "./utils/music-score.js";
 export * from "./utils/agent-cost.js";
 export * from "./utils/regex-replacement.js";
 export * from "./utils/skill-check-format.js";
+export * from "./utils/generation-guide.js";

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -2,6 +2,8 @@
 // Chat & Message Types
 // ──────────────────────────────────────────────
 
+import type { GenerationGuideSource } from "../utils/generation-guide.js";
+
 /** The four primary chat modes the engine supports. */
 export type ChatMode = "conversation" | "roleplay" | "visual_novel" | "game";
 
@@ -333,7 +335,7 @@ export interface MessageExtra {
     impersonate?: true;
     userMessage?: string | null;
     generationGuide?: string | null;
-    generationGuideSource?: "narrator" | "guide" | "game_start" | null;
+    generationGuideSource?: GenerationGuideSource | null;
     impersonatePresetId?: string | null;
     impersonateConnectionId?: string | null;
     impersonateBlockAgents?: boolean;

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -325,6 +325,20 @@ export interface MessageExtra {
    * saved with this assistant message — reused when regenerating that swipe unless refreshed.
    */
   contextInjections?: Array<{ agentType: string; agentName?: string; text: string }> | null;
+  /**
+   * Hidden command-generation options needed to make swipes/regenerations replay
+   * the same slash-command prompt behavior.
+   */
+  generationReplay?: {
+    impersonate?: true;
+    userMessage?: string | null;
+    generationGuide?: string | null;
+    generationGuideSource?: "narrator" | "guide" | "game_start" | null;
+    impersonatePresetId?: string | null;
+    impersonateConnectionId?: string | null;
+    impersonateBlockAgents?: boolean;
+    impersonatePromptTemplate?: string | null;
+  } | null;
 }
 
 /** Metadata about how a message was generated. */

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -327,7 +327,7 @@ export interface MessageExtra {
   contextInjections?: Array<{ agentType: string; agentName?: string; text: string }> | null;
   /**
    * Hidden command-generation options needed to make swipes/regenerations replay
-   * the same slash-command prompt behavior.
+   * the same slash-command or guided-regenerate prompt behavior.
    */
   generationReplay?: {
     impersonate?: true;

--- a/packages/shared/src/utils/generation-guide.ts
+++ b/packages/shared/src/utils/generation-guide.ts
@@ -1,0 +1,14 @@
+export type GenerationGuideSource = "narrator" | "guide" | "game_start";
+
+export function buildNarratorInstructionMessage(direction: string): string {
+  return `[Narrator instruction — do not include a reply from {{user}}. Instead, write the next part of the narrative steering it toward the following: ${direction.trim()}]`;
+}
+
+export function buildGuidedGenerationInstructionMessage(direction: string): string {
+  return `[Guided generation instruction — do not include a reply from {{user}}. Instead, write the next generated message steering it toward the following: ${direction.trim()}]`;
+}
+
+export function stripGenerationGuideInstruction(value: string): string {
+  const match = value.match(/^\[(?:Narrator|Guided generation) instruction [^\]]*? following:\s*([\s\S]*)\]$/);
+  return match?.[1]?.trim() || value;
+}


### PR DESCRIPTION
## Linked issue

Closes #820

## Why this change

- Regenerate/swipe requests only send the target message id, so slash-command prompt details from `/narrator` and `/impersonate` were lost on the next swipe.
- Guided regenerates also needed clearer replay behavior so users can tell which guidance is stored on each message/swipe.

## What changed

- Stores generation replay metadata on generated messages/swipes for `/narrator`, guided regenerate, game-start guidance, and `/impersonate`.
- Applies stored replay metadata server-side when regenerating a message, while preserving fresh guidance typed into the chat input.
- Adds a Stored guidance action to chat/conversation messages so users can inspect the guidance attached to the active swipe.
- Shares narrator/guided guidance template helpers across client and server to keep displayed/stored behavior aligned.
- Clears stale replay metadata when opening a fresh swipe before the completed generation writes the new metadata.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Ran `pnpm --filter @marinara-engine/shared build`.
- Ran `pnpm exec tsx --import ./test/setup-env.ts --test test/generation-replay.test.ts` from the server package.
- Ran `pnpm check`; it passed with the existing Node DEP0190 build warning.
- Codex Chromium pass covered `/narrator`, empty-input regenerate replay, guided regenerate override, cleared-input replay from a guided swipe, `/impersonate`, and guided impersonate regenerate against a local mock provider.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No version or release files changed. A follow-up docs note may be useful to explain stored replay/guidance semantics to users.

## UI evidence (if applicable)

Stored guidance modal was checked in the Chromium pass, but no screenshots are attached yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * View "Stored guidance" details for messages via a new modal.
  * Regenerations now persist and reapply stored generation guidance and impersonation settings for more reliable reproductions.
  * Shared generation-guide utilities and types added to public API.

* **Tests**
  * Added test coverage for generation-replay behavior across regenerate scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/822)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->