### PR TITLE
fix(game-start): silent race recovery when an intro already exists

### DIFF
--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -4545,7 +4545,14 @@ export function GameSurface({
     startGame.mutate(
       { chatId: activeChatId },
       {
-        onSuccess: () => {
+        onSuccess: (res) => {
+          // Race recovery (#821): if the server detected an existing GM turn,
+          // it has already restored status to "active" — skip the duplicate
+          // generation and let the UI move past the Start Game screen on the
+          // next chat refetch.
+          if (res?.alreadyStarted) {
+            return;
+          }
           generateInitialGameTurn();
         },
         onError: (err) => {

--- a/packages/client/src/hooks/use-game.ts
+++ b/packages/client/src/hooks/use-game.ts
@@ -49,6 +49,12 @@ interface SetupResponse {
 
 interface StartGameResponse {
   status: string;
+  /**
+   * True when the server detected that a GM turn already exists for this chat
+   * (race recovery — see #821). Callers must skip generating another initial
+   * turn in this case; the existing intro is already saved.
+   */
+  alreadyStarted?: boolean;
 }
 
 interface StartSessionResponse {

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -3465,31 +3465,48 @@ export async function gameRoutes(app: FastifyInstance) {
       throw new Error(`Cannot start game: status is "${meta.gameSessionStatus}", expected "ready"`);
     }
 
-    // Race-recovery guard: an existing GM turn means the game has already started,
-    // even though gameSessionStatus is back at "ready". This happens when a concurrent
-    // metadata-write race transiently reverts the status from "active" to "ready" mid-
-    // stream (same root race as #321 / #821 — see PR #320 for the original audit and
-    // remaining call sites the team hasn't migrated to chats.patchMetadata yet).
-    //
-    // Without this branch, a second Start Game click during that race window would
-    // fire a duplicate /api/generate and produce two back-to-back GM intros with no
-    // user message between them. Instead: re-flip status back to "active" silently,
-    // tell the client we already started, and let it skip generateInitialGameTurn so
-    // the UI can simply progress past the Start Game screen.
+    // Stale-meta recovery (#321 / #821): an existing GM turn means the game has
+    // already started, even though gameSessionStatus is back at "ready". This
+    // happens when a concurrent metadata-write race transiently reverts the
+    // status from "active" to "ready" mid-stream (see PR #320 for the original
+    // audit and remaining call sites the team hasn't migrated to
+    // chats.patchMetadata yet). Without this branch, a second Start Game click
+    // during that race window would fire a duplicate /api/generate. Instead:
+    // re-flip status back to "active" silently and tell the client we already
+    // started so it skips generateInitialGameTurn.
     const existingMessages = await chats.listMessages(chatId);
     const hasGmTurn = existingMessages.some(
       (m) => m.role === "assistant" && typeof m.content === "string" && m.content.trim().length > 0,
     );
     if (hasGmTurn) {
       logger.warn(
-        "[game/start] Race recovery for chatId=%s — GM turn already exists; restoring status to active without re-firing intro",
+        "[game/start] Stale-meta recovery for chatId=%s — GM turn already exists; restoring status to active without re-firing intro",
         chatId,
       );
-      await chats.updateMetadata(chatId, { ...meta, gameSessionStatus: "active" });
+      await chats.patchMetadata(chatId, { gameSessionStatus: "active" });
       return { status: "active", alreadyStarted: true };
     }
 
-    await chats.updateMetadata(chatId, { ...meta, gameSessionStatus: "active" });
+    // Atomic ready→active claim: route the transition through patchMetadata's
+    // per-chat queue so two concurrent /start requests can't both observe
+    // "ready" + no GM turn and both fire a generate. Only the first call wins
+    // the claim; the rest fall through to the alreadyStarted: true branch
+    // below.
+    let claimedStart = false;
+    await chats.patchMetadata(chatId, (current) => {
+      if (current.gameSessionStatus !== "ready") return {};
+      claimedStart = true;
+      return { gameSessionStatus: "active" };
+    });
+
+    if (!claimedStart) {
+      const latestChat = await chats.getById(chatId);
+      const latestStatus = latestChat ? (parseMeta(latestChat.metadata).gameSessionStatus as string) : null;
+      if (latestStatus === "active") {
+        return { status: "active", alreadyStarted: true };
+      }
+      throw new Error(`Cannot start game: status is "${latestStatus}", expected "ready"`);
+    }
 
     return { status: "active", alreadyStarted: false };
   });

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -3465,9 +3465,33 @@ export async function gameRoutes(app: FastifyInstance) {
       throw new Error(`Cannot start game: status is "${meta.gameSessionStatus}", expected "ready"`);
     }
 
+    // Race-recovery guard: an existing GM turn means the game has already started,
+    // even though gameSessionStatus is back at "ready". This happens when a concurrent
+    // metadata-write race transiently reverts the status from "active" to "ready" mid-
+    // stream (same root race as #321 / #821 — see PR #320 for the original audit and
+    // remaining call sites the team hasn't migrated to chats.patchMetadata yet).
+    //
+    // Without this branch, a second Start Game click during that race window would
+    // fire a duplicate /api/generate and produce two back-to-back GM intros with no
+    // user message between them. Instead: re-flip status back to "active" silently,
+    // tell the client we already started, and let it skip generateInitialGameTurn so
+    // the UI can simply progress past the Start Game screen.
+    const existingMessages = await chats.listMessages(chatId);
+    const hasGmTurn = existingMessages.some(
+      (m) => m.role === "assistant" && typeof m.content === "string" && m.content.trim().length > 0,
+    );
+    if (hasGmTurn) {
+      logger.warn(
+        "[game/start] Race recovery for chatId=%s — GM turn already exists; restoring status to active without re-firing intro",
+        chatId,
+      );
+      await chats.updateMetadata(chatId, { ...meta, gameSessionStatus: "active" });
+      return { status: "active", alreadyStarted: true };
+    }
+
     await chats.updateMetadata(chatId, { ...meta, gameSessionStatus: "active" });
 
-    return { status: "active" };
+    return { status: "active", alreadyStarted: false };
   });
 
   const pendingSessionStarts = new Map<

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -3461,6 +3461,12 @@ export async function gameRoutes(app: FastifyInstance) {
     if (!chat) throw new Error("Chat not found");
 
     const meta = parseMeta(chat.metadata);
+    // Idempotent guard: a late second click that arrives after the first /start
+    // has already flipped the status to "active" should not error out — let the
+    // client skip its duplicate generation by returning alreadyStarted: true.
+    if (meta.gameSessionStatus === "active") {
+      return { status: "active", alreadyStarted: true };
+    }
     if (meta.gameSessionStatus !== "ready") {
       throw new Error(`Cannot start game: status is "${meta.gameSessionStatus}", expected "ready"`);
     }


### PR DESCRIPTION
## Linked issue

Closes #821

## Why this change

[#821](https://github.com/Pasta-Devs/Marinara-Engine/issues/821) reproduces the same Game Mode race as the earlier-fixed [#321](https://github.com/Pasta-Devs/Marinara-Engine/issues/321) — on 1.5.9, clicking **Start Game** snaps back to the idle Start Game screen mid-stream and a second click produces a duplicate GM intro turn. Confirmed in a live trace: two `POST /api/game/start` calls **both return 200** because a concurrent `chats.updateMetadata({ ...meta, … })` writer reverts `gameSessionStatus` from `"active"` back to `"ready"` between the two clicks.

[#320](https://github.com/Pasta-Devs/Marinara-Engine/pull/320) audited and migrated 7 stale-meta writes in `packages/server/src/routes/generate.routes.ts` to the `freshChat` → `freshMeta` → field-only update pattern. All 6 remaining `chats.updateMetadata(input.chatId, …)` sites in that file now re-fetch, but at least one stale-write writer remains elsewhere (likely in `packages/server/src/routes/game.routes.ts`) and the race still reproduces.

A complete audit of every `chats.updateMetadata(…, { ...meta, … })` and a migration of partial updates to the existing race-safe `chats.patchMetadata(…)` helper at [packages/server/src/services/storage/chats.storage.ts:303](packages/server/src/services/storage/chats.storage.ts#L303) is the proper root-cause fix. That is a large, code-touchy change. This PR ships a narrow defensive guard that makes the user-visible symptom impossible while the deeper audit happens separately.

## What changed

**Server — `packages/server/src/routes/game.routes.ts`**

`POST /game/start` already throws when `meta.gameSessionStatus !== "ready"`. After that check it now also lists the chat's messages and looks for any non-empty `role: "assistant"` message. If one exists, the game has clearly already started — the only way we got back into the `"ready"` branch is the race. Instead of throwing (which leaves the UI stuck on Start Game with a generic 500 toast) the handler:

- emits a `logger.warn` describing the race recovery (so this is visible in logs if it fires in production),
- writes `gameSessionStatus: "active"` back to the DB,
- returns `{ status: "active", alreadyStarted: true }`.

**Client — `packages/client/src/hooks/use-game.ts`** and **`packages/client/src/components/game/GameSurface.tsx`**

The `StartGameResponse` interface now carries an optional `alreadyStarted` flag. `GameSurface`'s `useStartGame.mutate` `onSuccess` callback checks that flag and **skips `generateInitialGameTurn`** when it's true — so the second click no longer fires a second `/api/generate`. The chat detail invalidate that already runs on `useStartGame.onSuccess` re-fetches the freshly-restored `"active"` status, and the existing `awaitingFirstTurn` logic moves the UI past the Start Game screen.

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

I tested on a fork build autoDeployed to a private EasyPanel instance. Both the stuck-state recovery path and the full fresh-game flow were verified:

- **Repro confirmed twice** on a freshly-set-up Game Mode chat with HUD widgets (Fantasy / dark / heroic): clicking Start Game produces the intro typewriter, the screen falls back to the idle Start Game button mid-stream, the second click on that button reproduces the duplicate-intro pattern reported in #821 (two `role: "assistant"` messages back-to-back, no user message between).
- **Stuck-chat recovery** (intro already saved, status reverted to `"ready"`): clicked Start Game once on the existing stuck chat. Server emitted the `[game/start] Race recovery` warn, returned `alreadyStarted: true`, client skipped `generateInitialGameTurn`. UI progressed past Start Game on the next chat refetch. No duplicate intro. Note: post-stream hooks (scene-wrap, generate-assets) that failed to fire on the original stuck stream are not re-played — the saved intro lacks background art on a recovered chat. That's acceptable for a race-recovery edge; fresh games are unaffected.
- **Fresh-game flow with the fix:** new game from scratch, full setup, intro generation, race fires, screen snaps back to Start Game button, second click fires `/game/start` and gets `alreadyStarted: true`, no duplicate intro, no error toast, UI lands in the active game with exactly one GM intro message.

To-verify by upstream maintainers, on each platform's normal install (Docker / installer / source):

- Manually verify Game Mode Start Game on a fresh chat — the first click should still kick off the intro generation as before, and **the chat should contain exactly one `role: "assistant"` message** at the end of the intro.
- Manually verify that a forced-retry path (refresh between Start click and intro arriving) does not produce a duplicate intro.
- Manually verify normal turns and `/api/generate` flow are unaffected — the new branch in `/game/start` only runs on the start path.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

n/a — server-side guard + small client onSuccess branch. The user-visible difference is "second Start Game click no longer creates a duplicate intro turn."


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a race condition where game initialization could be triggered multiple times. The system now detects when a game has already started and prevents redundant setup processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/824)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->