### PR TITLE
Decode compressed provider responses

### DIFF
--- a/packages/server/src/routes/connections.routes.ts
+++ b/packages/server/src/routes/connections.routes.ts
@@ -234,6 +234,7 @@ export async function connectionsRoutes(app: FastifyInstance) {
         headers: testHeaders,
         policy: localUrlPolicyForProvider(conn.provider, imageSource),
         maxResponseBytes: 2 * 1024 * 1024,
+        decodeCompressedResponse: true,
       });
       const latencyMs = Date.now() - start;
 
@@ -323,6 +324,7 @@ export async function connectionsRoutes(app: FastifyInstance) {
           headers,
           policy: localUrlPolicyForProvider(conn.provider, imageSource),
           maxResponseBytes: 2 * 1024 * 1024,
+          decodeCompressedResponse: true,
         });
         if (!accountRes.ok) {
           const body = await accountRes.text();
@@ -336,6 +338,7 @@ export async function connectionsRoutes(app: FastifyInstance) {
             headers,
             policy: localUrlPolicyForProvider(conn.provider, imageSource),
             maxResponseBytes: 5 * 1024 * 1024,
+            decodeCompressedResponse: true,
           });
           if (!res.ok) {
             const body = await res.text();
@@ -378,6 +381,7 @@ export async function connectionsRoutes(app: FastifyInstance) {
         const res = await safeFetch(`${baseUrl}/object_info/CheckpointLoaderSimple`, {
           policy: localUrlPolicyForProvider(conn.provider, imageSource),
           maxResponseBytes: 5 * 1024 * 1024,
+          decodeCompressedResponse: true,
         });
         if (!res.ok) {
           return reply.status(502).send({ error: `ComfyUI returned ${res.status}` });
@@ -394,6 +398,7 @@ export async function connectionsRoutes(app: FastifyInstance) {
         const res = await safeFetch(`${baseUrl}/sdapi/v1/sd-models`, {
           policy: localUrlPolicyForProvider(conn.provider, imageSource),
           maxResponseBytes: 5 * 1024 * 1024,
+          decodeCompressedResponse: true,
         });
         if (!res.ok) {
           return reply.status(502).send({ error: `SD Web UI returned ${res.status}` });
@@ -417,6 +422,7 @@ export async function connectionsRoutes(app: FastifyInstance) {
             flagName: "PROVIDER_LOCAL_URLS_ENABLED",
           },
           maxResponseBytes: 5 * 1024 * 1024,
+          decodeCompressedResponse: true,
         });
         if (!res.ok) {
           const body = await res.text();
@@ -443,6 +449,7 @@ export async function connectionsRoutes(app: FastifyInstance) {
           headers,
           policy: localUrlPolicyForProvider(conn.provider, imageSource),
           maxResponseBytes: 5 * 1024 * 1024,
+          decodeCompressedResponse: true,
         });
         if (!res.ok) {
           const body = await res.text();
@@ -467,6 +474,7 @@ export async function connectionsRoutes(app: FastifyInstance) {
           headers: hordeHeaders(conn.apiKey),
           policy: localUrlPolicyForProvider(conn.provider, imageSource),
           maxResponseBytes: 5 * 1024 * 1024,
+          decodeCompressedResponse: true,
         });
         if (!res.ok) {
           const body = await res.text();
@@ -509,6 +517,7 @@ export async function connectionsRoutes(app: FastifyInstance) {
           flagName: "PROVIDER_LOCAL_URLS_ENABLED",
         },
         maxResponseBytes: 5 * 1024 * 1024,
+        decodeCompressedResponse: true,
       });
       if (!res.ok) {
         const body = await res.text();

--- a/packages/server/src/services/llm/base-provider.ts
+++ b/packages/server/src/services/llm/base-provider.ts
@@ -610,6 +610,7 @@ export abstract class BaseLLMProvider {
       headers,
       body: JSON.stringify({ input: texts, model }),
       signal: AbortSignal.timeout(60_000),
+      bufferResponse: true,
     });
     if (!res.ok) {
       const body = await res.text();

--- a/packages/server/src/services/llm/base-provider.ts
+++ b/packages/server/src/services/llm/base-provider.ts
@@ -19,8 +19,9 @@ const llmAgentOptions = { bodyTimeout: 0, headersTimeout: LLM_HEADERS_TIMEOUT };
  */
 export function llmFetch(
   url: string | URL,
-  init?: RequestInit & Pick<SafeFetchOptions, "bufferResponse">,
+  init?: RequestInit & Pick<SafeFetchOptions, "bufferResponse" | "decodeCompressedResponse">,
 ): Promise<Response> {
+  const bufferResponse = init?.bufferResponse ?? false;
   return safeFetch(url, {
     ...(init ?? {}),
     agentOptions: llmAgentOptions,
@@ -32,7 +33,8 @@ export function llmFetch(
       flagName: "PROVIDER_LOCAL_URLS_ENABLED",
     },
     maxResponseBytes: 50 * 1024 * 1024,
-    bufferResponse: init?.bufferResponse ?? false,
+    bufferResponse,
+    decodeCompressedResponse: init?.decodeCompressedResponse ?? bufferResponse,
   });
 }
 

--- a/packages/server/src/services/llm/openai-chatgpt-auth.ts
+++ b/packages/server/src/services/llm/openai-chatgpt-auth.ts
@@ -196,6 +196,7 @@ async function refreshAuth(auth: CodexAuthJson, authFilePath: string): Promise<O
     }),
     policy: authPolicy(),
     maxResponseBytes: 1024 * 1024,
+    decodeCompressedResponse: true,
   });
 
   if (!res.ok) {
@@ -265,6 +266,7 @@ export async function fetchOpenAIChatGPTModels(): Promise<Array<{ id: string; na
     },
     policy: authPolicy(),
     maxResponseBytes: 5 * 1024 * 1024,
+    decodeCompressedResponse: true,
   });
 
   if (!res.ok) {

--- a/packages/server/src/services/llm/providers/anthropic.provider.ts
+++ b/packages/server/src/services/llm/providers/anthropic.provider.ts
@@ -147,6 +147,7 @@ export class AnthropicProvider extends BaseLLMProvider {
         "anthropic-version": "2023-06-01",
       },
       body: JSON.stringify(body),
+      bufferResponse: options.stream === false,
       ...(options.signal ? { signal: options.signal } : {}),
     });
 

--- a/packages/server/src/utils/security.ts
+++ b/packages/server/src/utils/security.ts
@@ -1,7 +1,7 @@
 import { promises as dns } from "node:dns";
 import { createHash, timingSafeEqual } from "node:crypto";
 import { basename, extname, relative, resolve, sep, win32 } from "node:path";
-import { brotliDecompressSync, gunzipSync, inflateRawSync, inflateSync, zstdDecompressSync } from "node:zlib";
+import { gunzipSync, zstdDecompressSync } from "node:zlib";
 import { Agent } from "undici";
 import { isLoopbackIp, isPrivateNetworkIp } from "../middleware/ip-allowlist.js";
 import { logger } from "../lib/logger.js";
@@ -47,6 +47,7 @@ export interface SafeFetchOptions extends Omit<RequestInit, "dispatcher"> {
   maxResponseBytes?: number;
   allowedContentTypes?: string[];
   bufferResponse?: boolean;
+  decodeCompressedResponse?: boolean;
   agentOptions?: Omit<AgentOptions, "connect">;
   dispatcher?: unknown;
 }
@@ -366,7 +367,12 @@ async function validateOutboundUrlForFetch(
   return { url: parsed, dispatcher };
 }
 
-async function readCappedResponse(response: Response, maxBytes: number, dispatcher?: Agent): Promise<Response> {
+async function readCappedResponse(
+  response: Response,
+  maxBytes: number,
+  dispatcher?: Agent,
+  decodeCompressedResponse = false,
+): Promise<Response> {
   if (!response.body) {
     await dispatcher?.close().catch(() => undefined);
     return response;
@@ -388,17 +394,21 @@ async function readCappedResponse(response: Response, maxBytes: number, dispatch
   } finally {
     await dispatcher?.close().catch(() => undefined);
   }
-  const body = normalizeCompressedBody(Buffer.concat(chunks), response.headers, maxBytes);
-  return new Response(body, {
+  const rawBody = Buffer.concat(chunks);
+  const normalized = decodeCompressedResponse
+    ? normalizeCompressedBody(rawBody, response.headers, maxBytes)
+    : { body: rawBody, headers: response.headers };
+  return new Response(normalized.body, {
     status: response.status,
     statusText: response.statusText,
-    headers: response.headers,
+    headers: normalized.headers,
   });
 }
 
-function normalizeCompressedBody(body: Buffer, headers: Headers, maxBytes: number): Buffer {
+function normalizeCompressedBody(body: Buffer, headers: Headers, maxBytes: number): { body: Buffer; headers: Headers } {
   const encoding = headers.get("content-encoding");
-  const normalized = decodePossiblyCompressedBody(body, encoding, maxBytes);
+  const normalized = decodePossiblyCompressedBody(body, maxBytes);
+  const shouldStripCompressionHeaders = normalized !== body || encoding != null;
   if (normalized !== body) {
     logger.debug(
       "Decoded compressed outbound response body; contentEncoding=%s compressedBytes=%d decodedBytes=%d maxBytes=%d",
@@ -408,7 +418,13 @@ function normalizeCompressedBody(body: Buffer, headers: Headers, maxBytes: numbe
       maxBytes,
     );
   }
-  return normalized;
+  if (shouldStripCompressionHeaders) {
+    const normalizedHeaders = new Headers(headers);
+    normalizedHeaders.delete("content-encoding");
+    normalizedHeaders.delete("content-length");
+    return { body: normalized, headers: normalizedHeaders };
+  }
+  return { body, headers };
 }
 
 function capStreamingResponse(response: Response, maxBytes: number, dispatcher?: Agent): Response {
@@ -452,22 +468,9 @@ function capStreamingResponse(response: Response, maxBytes: number, dispatcher?:
   });
 }
 
-export function decodePossiblyCompressedBody(
-  buffer: Buffer,
-  contentEncoding?: string | null,
-  maxBytes = DEFAULT_MAX_RESPONSE_BYTES,
-): Buffer {
-  const encodings = parseContentEncodings(contentEncoding);
+export function decodePossiblyCompressedBody(buffer: Buffer, maxBytes = DEFAULT_MAX_RESPONSE_BYTES): Buffer {
   let current = buffer;
   let decoded = false;
-
-  for (const encoding of encodings.reverse()) {
-    const next = decodeByEncoding(current, encoding, maxBytes);
-    if (next) {
-      current = next;
-      decoded = true;
-    }
-  }
 
   for (let i = 0; i < 2; i += 1) {
     const next = decodeByMagicBytes(current, maxBytes);
@@ -479,34 +482,6 @@ export function decodePossiblyCompressedBody(
   return decoded ? current : buffer;
 }
 
-function parseContentEncodings(contentEncoding?: string | null): string[] {
-  return (
-    contentEncoding
-      ?.toLowerCase()
-      .split(",")
-      .map((part) => part.trim())
-      .filter(Boolean) ?? []
-  );
-}
-
-function decodeByEncoding(buffer: Buffer, encoding: string, maxBytes: number): Buffer | null {
-  switch (encoding) {
-    case "gzip":
-    case "x-gzip":
-      return tryDecodeCompressedBody(buffer, "gzip", maxBytes);
-    case "br":
-      return tryDecodeCompressedBody(buffer, "br", maxBytes);
-    case "zstd":
-      return tryDecodeCompressedBody(buffer, "zstd", maxBytes);
-    case "deflate":
-      return (
-        tryDecodeCompressedBody(buffer, "deflate", maxBytes) ?? tryDecodeCompressedBody(buffer, "deflate-raw", maxBytes)
-      );
-    default:
-      return null;
-  }
-}
-
 function decodeByMagicBytes(buffer: Buffer, maxBytes: number): Buffer | null {
   if (buffer.length >= 2 && buffer[0] === 0x1f && buffer[1] === 0x8b) {
     return tryDecodeCompressedBody(buffer, "gzip", maxBytes);
@@ -514,38 +489,16 @@ function decodeByMagicBytes(buffer: Buffer, maxBytes: number): Buffer | null {
   if (buffer.length >= 4 && buffer[0] === 0x28 && buffer[1] === 0xb5 && buffer[2] === 0x2f && buffer[3] === 0xfd) {
     return tryDecodeCompressedBody(buffer, "zstd", maxBytes);
   }
-  if (looksLikeZlibDeflate(buffer)) {
-    return tryDecodeCompressedBody(buffer, "deflate", maxBytes);
-  }
   return null;
 }
 
-function looksLikeZlibDeflate(buffer: Buffer): boolean {
-  if (buffer.length < 2) return false;
-  const first = buffer[0]!;
-  const second = buffer[1]!;
-  const compressionMethod = first & 0x0f;
-  if (compressionMethod !== 8) return false;
-  return ((first << 8) + second) % 31 === 0;
-}
-
-function tryDecodeCompressedBody(
-  buffer: Buffer,
-  algorithm: "gzip" | "br" | "zstd" | "deflate" | "deflate-raw",
-  maxBytes: number,
-): Buffer | null {
+function tryDecodeCompressedBody(buffer: Buffer, algorithm: "gzip" | "zstd", maxBytes: number): Buffer | null {
   try {
     switch (algorithm) {
       case "gzip":
         return gunzipSync(buffer, { maxOutputLength: maxBytes });
-      case "br":
-        return brotliDecompressSync(buffer, { maxOutputLength: maxBytes });
       case "zstd":
         return zstdDecompressSync(buffer, { maxOutputLength: maxBytes });
-      case "deflate":
-        return inflateSync(buffer, { maxOutputLength: maxBytes });
-      case "deflate-raw":
-        return inflateRawSync(buffer, { maxOutputLength: maxBytes });
     }
     return null;
   } catch (err) {
@@ -562,6 +515,7 @@ export async function safeFetch(url: string | URL, options: SafeFetchOptions = {
     maxResponseBytes = DEFAULT_MAX_RESPONSE_BYTES,
     allowedContentTypes,
     bufferResponse = true,
+    decodeCompressedResponse = false,
     agentOptions,
     dispatcher,
     ...init
@@ -601,7 +555,7 @@ export async function safeFetch(url: string | URL, options: SafeFetchOptions = {
     }
 
     return bufferResponse
-      ? readCappedResponse(response, maxResponseBytes, internalDispatcher)
+      ? readCappedResponse(response, maxResponseBytes, internalDispatcher, decodeCompressedResponse)
       : capStreamingResponse(response, maxResponseBytes, internalDispatcher);
   }
 

--- a/packages/server/src/utils/security.ts
+++ b/packages/server/src/utils/security.ts
@@ -1,7 +1,7 @@
 import { promises as dns } from "node:dns";
 import { createHash, timingSafeEqual } from "node:crypto";
 import { basename, extname, relative, resolve, sep, win32 } from "node:path";
-import { gunzipSync } from "node:zlib";
+import { brotliDecompressSync, gunzipSync, inflateRawSync, inflateSync, zstdDecompressSync } from "node:zlib";
 import { Agent } from "undici";
 import { isLoopbackIp, isPrivateNetworkIp } from "../middleware/ip-allowlist.js";
 import { logger } from "../lib/logger.js";
@@ -388,7 +388,7 @@ async function readCappedResponse(response: Response, maxBytes: number, dispatch
   } finally {
     await dispatcher?.close().catch(() => undefined);
   }
-  const body = normalizeRawCompressedBody(Buffer.concat(chunks), response.headers, maxBytes);
+  const body = normalizeCompressedBody(Buffer.concat(chunks), response.headers, maxBytes);
   return new Response(body, {
     status: response.status,
     statusText: response.statusText,
@@ -396,22 +396,19 @@ async function readCappedResponse(response: Response, maxBytes: number, dispatch
   });
 }
 
-function normalizeRawCompressedBody(body: Buffer, headers: Headers, maxBytes: number): Buffer {
-  const encoding = headers.get("content-encoding")?.toLowerCase().trim();
-  if (encoding || body.length < 2 || body[0] !== 0x1f || body[1] !== 0x8b) return body;
-  try {
+function normalizeCompressedBody(body: Buffer, headers: Headers, maxBytes: number): Buffer {
+  const encoding = headers.get("content-encoding");
+  const normalized = decodePossiblyCompressedBody(body, encoding, maxBytes);
+  if (normalized !== body) {
     logger.debug(
-      "Detected raw gzip-compressed outbound response without content-encoding header; compressedBytes=%d maxBytes=%d",
+      "Decoded compressed outbound response body; contentEncoding=%s compressedBytes=%d decodedBytes=%d maxBytes=%d",
+      encoding?.trim() || "sniffed",
       body.length,
+      normalized.length,
       maxBytes,
     );
-    return gunzipSync(body, { maxOutputLength: maxBytes });
-  } catch (err) {
-    if (err instanceof Error && "code" in err && err.code === "ERR_BUFFER_TOO_LARGE") {
-      throw new Error(`Outbound response exceeded ${maxBytes} bytes`);
-    }
-    return body;
   }
+  return normalized;
 }
 
 function capStreamingResponse(response: Response, maxBytes: number, dispatcher?: Agent): Response {
@@ -455,11 +452,108 @@ function capStreamingResponse(response: Response, maxBytes: number, dispatcher?:
   });
 }
 
-export function decodePossiblyCompressedBody(buffer: Buffer): Buffer {
-  if (buffer.length >= 2 && buffer[0] === 0x1f && buffer[1] === 0x8b) {
-    return gunzipSync(buffer);
+export function decodePossiblyCompressedBody(
+  buffer: Buffer,
+  contentEncoding?: string | null,
+  maxBytes = DEFAULT_MAX_RESPONSE_BYTES,
+): Buffer {
+  const encodings = parseContentEncodings(contentEncoding);
+  let current = buffer;
+  let decoded = false;
+
+  for (const encoding of encodings.reverse()) {
+    const next = decodeByEncoding(current, encoding, maxBytes);
+    if (next) {
+      current = next;
+      decoded = true;
+    }
   }
-  return buffer;
+
+  for (let i = 0; i < 2; i += 1) {
+    const next = decodeByMagicBytes(current, maxBytes);
+    if (!next) break;
+    current = next;
+    decoded = true;
+  }
+
+  return decoded ? current : buffer;
+}
+
+function parseContentEncodings(contentEncoding?: string | null): string[] {
+  return (
+    contentEncoding
+      ?.toLowerCase()
+      .split(",")
+      .map((part) => part.trim())
+      .filter(Boolean) ?? []
+  );
+}
+
+function decodeByEncoding(buffer: Buffer, encoding: string, maxBytes: number): Buffer | null {
+  switch (encoding) {
+    case "gzip":
+    case "x-gzip":
+      return tryDecodeCompressedBody(buffer, "gzip", maxBytes);
+    case "br":
+      return tryDecodeCompressedBody(buffer, "br", maxBytes);
+    case "zstd":
+      return tryDecodeCompressedBody(buffer, "zstd", maxBytes);
+    case "deflate":
+      return (
+        tryDecodeCompressedBody(buffer, "deflate", maxBytes) ?? tryDecodeCompressedBody(buffer, "deflate-raw", maxBytes)
+      );
+    default:
+      return null;
+  }
+}
+
+function decodeByMagicBytes(buffer: Buffer, maxBytes: number): Buffer | null {
+  if (buffer.length >= 2 && buffer[0] === 0x1f && buffer[1] === 0x8b) {
+    return tryDecodeCompressedBody(buffer, "gzip", maxBytes);
+  }
+  if (buffer.length >= 4 && buffer[0] === 0x28 && buffer[1] === 0xb5 && buffer[2] === 0x2f && buffer[3] === 0xfd) {
+    return tryDecodeCompressedBody(buffer, "zstd", maxBytes);
+  }
+  if (looksLikeZlibDeflate(buffer)) {
+    return tryDecodeCompressedBody(buffer, "deflate", maxBytes);
+  }
+  return null;
+}
+
+function looksLikeZlibDeflate(buffer: Buffer): boolean {
+  if (buffer.length < 2) return false;
+  const first = buffer[0]!;
+  const second = buffer[1]!;
+  const compressionMethod = first & 0x0f;
+  if (compressionMethod !== 8) return false;
+  return ((first << 8) + second) % 31 === 0;
+}
+
+function tryDecodeCompressedBody(
+  buffer: Buffer,
+  algorithm: "gzip" | "br" | "zstd" | "deflate" | "deflate-raw",
+  maxBytes: number,
+): Buffer | null {
+  try {
+    switch (algorithm) {
+      case "gzip":
+        return gunzipSync(buffer, { maxOutputLength: maxBytes });
+      case "br":
+        return brotliDecompressSync(buffer, { maxOutputLength: maxBytes });
+      case "zstd":
+        return zstdDecompressSync(buffer, { maxOutputLength: maxBytes });
+      case "deflate":
+        return inflateSync(buffer, { maxOutputLength: maxBytes });
+      case "deflate-raw":
+        return inflateRawSync(buffer, { maxOutputLength: maxBytes });
+    }
+    return null;
+  } catch (err) {
+    if (err instanceof Error && "code" in err && err.code === "ERR_BUFFER_TOO_LARGE") {
+      throw new Error(`Outbound response exceeded ${maxBytes} bytes`);
+    }
+    return null;
+  }
 }
 
 export async function safeFetch(url: string | URL, options: SafeFetchOptions = {}): Promise<Response> {

--- a/packages/server/test/anthropic-provider-opus47.test.ts
+++ b/packages/server/test/anthropic-provider-opus47.test.ts
@@ -1,5 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { zstdCompressSync } from "node:zlib";
 import { AnthropicProvider } from "../src/services/llm/providers/anthropic.provider.js";
 import type { ChatOptions } from "../src/services/llm/base-provider.js";
 
@@ -96,4 +97,48 @@ test("Anthropic prompt caching uses configured conversation depth", async () => 
   const messages = body.messages as Array<{ role: string; content: unknown }>;
   assert.deepEqual(messages[2]?.content, [{ type: "text", text: "u2", cache_control: { type: "ephemeral" } }]);
   assert.equal(messages[4]?.content, "u3");
+});
+
+test("Anthropic non-stream chat decodes raw zstd JSON without content-encoding", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalLocalUrls = process.env.PROVIDER_LOCAL_URLS_ENABLED;
+
+  globalThis.fetch = async () =>
+    new Response(
+      zstdCompressSync(
+        Buffer.from(
+          JSON.stringify({
+            content: [{ type: "text", text: "decoded from zstd" }],
+            usage: { input_tokens: 1, output_tokens: 1 },
+          }),
+        ),
+      ),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+
+  try {
+    process.env.PROVIDER_LOCAL_URLS_ENABLED = "true";
+    const provider = new AnthropicProvider("https://api.anthropic.com/v1", "test-key");
+    const chunks: string[] = [];
+
+    for await (const chunk of provider.chat([{ role: "user", content: "Hello" }], {
+      model: "claude-sonnet-4-5",
+      stream: false,
+      maxTokens: 512,
+    })) {
+      chunks.push(chunk);
+    }
+
+    assert.equal(chunks.join(""), "decoded from zstd");
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (originalLocalUrls === undefined) {
+      delete process.env.PROVIDER_LOCAL_URLS_ENABLED;
+    } else {
+      process.env.PROVIDER_LOCAL_URLS_ENABLED = originalLocalUrls;
+    }
+  }
 });

--- a/packages/server/test/embedding-response.test.ts
+++ b/packages/server/test/embedding-response.test.ts
@@ -1,6 +1,8 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { zstdCompressSync } from "node:zlib";
 import { parseEmbeddingResponse } from "../src/services/llm/base-provider.js";
+import { OpenAIProvider } from "../src/services/llm/providers/openai.provider.js";
 
 test("parseEmbeddingResponse accepts OpenAI-compatible data wrappers", () => {
   assert.deepEqual(parseEmbeddingResponse({ data: [{ embedding: [0.1, 0.2] }] }), [[0.1, 0.2]]);
@@ -13,4 +15,38 @@ test("parseEmbeddingResponse accepts llama.cpp /embeddings arrays", () => {
 test("parseEmbeddingResponse rejects invalid response shapes with a clear error", () => {
   assert.throws(() => parseEmbeddingResponse({ embedding: [0.1, 0.2] }), /embedding array/i);
   assert.throws(() => parseEmbeddingResponse({ data: [{ value: [0.1, 0.2] }] }), /invalid embedding item/i);
+});
+
+test("embed decodes raw zstd JSON without content-encoding", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalLocalUrls = process.env.PROVIDER_LOCAL_URLS_ENABLED;
+
+  globalThis.fetch = async () =>
+    new Response(
+      zstdCompressSync(
+        Buffer.from(
+          JSON.stringify({
+            data: [{ embedding: [0.1, 0.2] }],
+          }),
+        ),
+      ),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+
+  try {
+    process.env.PROVIDER_LOCAL_URLS_ENABLED = "true";
+    const provider = new OpenAIProvider("https://api.venice.ai/api/v1", "test-key");
+
+    assert.deepEqual(await provider.embed(["hello"], "embedding-model"), [[0.1, 0.2]]);
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (originalLocalUrls === undefined) {
+      delete process.env.PROVIDER_LOCAL_URLS_ENABLED;
+    } else {
+      process.env.PROVIDER_LOCAL_URLS_ENABLED = originalLocalUrls;
+    }
+  }
 });

--- a/packages/server/test/openai-provider-reasoning.test.ts
+++ b/packages/server/test/openai-provider-reasoning.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { gzipSync } from "node:zlib";
+import { gzipSync, zstdCompressSync } from "node:zlib";
 import { MODEL_LISTS } from "../../shared/src/constants/model-lists.ts";
 import { createLLMProvider } from "../src/services/llm/provider-registry.js";
 import { OpenAIProvider } from "../src/services/llm/providers/openai.provider.js";
@@ -363,6 +363,49 @@ test("OpenRouter non-stream chat decodes raw gzip JSON without content-encoding"
     }
 
     assert.equal(chunks.join(""), "decoded");
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (originalLocalUrls === undefined) {
+      delete process.env.PROVIDER_LOCAL_URLS_ENABLED;
+    } else {
+      process.env.PROVIDER_LOCAL_URLS_ENABLED = originalLocalUrls;
+    }
+  }
+});
+
+test("OpenAI-compatible non-stream chat decodes raw zstd JSON without content-encoding", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalLocalUrls = process.env.PROVIDER_LOCAL_URLS_ENABLED;
+
+  globalThis.fetch = async () =>
+    new Response(
+      zstdCompressSync(
+        Buffer.from(
+          JSON.stringify({
+            choices: [{ message: { content: "decoded from zstd" } }],
+            usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+          }),
+        ),
+      ),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+
+  try {
+    process.env.PROVIDER_LOCAL_URLS_ENABLED = "true";
+    const provider = new OpenAIProvider("https://api.venice.ai/api/v1", "test-key");
+    const chunks: string[] = [];
+    for await (const chunk of provider.chat([{ role: "user", content: "Hello" }], {
+      model: "venice/test-model",
+      stream: false,
+      maxTokens: 512,
+    })) {
+      chunks.push(chunk);
+    }
+
+    assert.equal(chunks.join(""), "decoded from zstd");
   } finally {
     globalThis.fetch = originalFetch;
     if (originalLocalUrls === undefined) {

--- a/packages/server/test/security-utils.test.ts
+++ b/packages/server/test/security-utils.test.ts
@@ -4,9 +4,10 @@ import { promises as dns } from "node:dns";
 import { mkdtemp, rm } from "node:fs/promises";
 import { join, resolve, win32 } from "node:path";
 import { tmpdir } from "node:os";
-import { gzipSync } from "node:zlib";
+import { brotliCompressSync, deflateSync, gzipSync, zstdCompressSync } from "node:zlib";
 import {
   assertInsideDir,
+  decodePossiblyCompressedBody,
   isAllowedImageBuffer,
   normalizeLoopbackUrl,
   safeFetch,
@@ -214,6 +215,47 @@ test("safeFetch decodes raw gzip bodies when providers omit content-encoding", a
   });
 
   assert.deepEqual(await response.json(), { models: [{ id: "openrouter/test" }] });
+});
+
+test("safeFetch decodes raw zstd bodies when providers omit content-encoding", async () => {
+  const response = await safeFetch("https://example.com/models", {
+    policy: { allowLocal: true },
+    dispatcher: {
+      dispatch(
+        _options: unknown,
+        handler: {
+          onConnect: (abort: () => void) => void;
+          onHeaders: (status: number, headers: string[], resume: () => void) => void;
+          onData: (chunk: Buffer) => void;
+          onComplete: (trailers: string[]) => void;
+        },
+      ) {
+        handler.onConnect(() => undefined);
+        handler.onHeaders(200, ["content-type", "application/json"], () => undefined);
+        handler.onData(zstdCompressSync(Buffer.from(JSON.stringify({ models: [{ id: "venice/test" }] }))));
+        handler.onComplete([]);
+        return true;
+      },
+    },
+  });
+
+  assert.deepEqual(await response.json(), { models: [{ id: "venice/test" }] });
+});
+
+test("decodePossiblyCompressedBody handles compressed bodies left after content-encoding", () => {
+  const json = Buffer.from(JSON.stringify({ ok: true }));
+  const cases: Array<[string, Buffer]> = [
+    ["gzip", gzipSync(json)],
+    ["br", brotliCompressSync(json)],
+    ["zstd", zstdCompressSync(json)],
+    ["deflate", deflateSync(json)],
+  ];
+
+  for (const [encoding, body] of cases) {
+    assert.deepEqual(JSON.parse(decodePossiblyCompressedBody(body, encoding).toString("utf8")), { ok: true });
+  }
+
+  assert.equal(decodePossiblyCompressedBody(json, "zstd").toString("utf8"), json.toString("utf8"));
 });
 
 test("safeFetch caps decoded raw gzip bodies when providers omit content-encoding", async () => {

--- a/packages/server/test/security-utils.test.ts
+++ b/packages/server/test/security-utils.test.ts
@@ -4,7 +4,7 @@ import { promises as dns } from "node:dns";
 import { mkdtemp, rm } from "node:fs/promises";
 import { join, resolve, win32 } from "node:path";
 import { tmpdir } from "node:os";
-import { brotliCompressSync, deflateSync, gzipSync, zstdCompressSync } from "node:zlib";
+import { gzipSync, zstdCompressSync } from "node:zlib";
 import {
   assertInsideDir,
   decodePossiblyCompressedBody,
@@ -195,6 +195,7 @@ test("safeFetch can return a streaming capped response without buffering", async
 test("safeFetch decodes raw gzip bodies when providers omit content-encoding", async () => {
   const response = await safeFetch("https://example.com/models", {
     policy: { allowLocal: true },
+    decodeCompressedResponse: true,
     dispatcher: {
       dispatch(
         _options: unknown,
@@ -217,7 +218,41 @@ test("safeFetch decodes raw gzip bodies when providers omit content-encoding", a
   assert.deepEqual(await response.json(), { models: [{ id: "openrouter/test" }] });
 });
 
-test("safeFetch decodes raw zstd bodies when providers omit content-encoding", async () => {
+test("safeFetch decodes raw zstd bodies and clears stale compression headers", async () => {
+  const compressed = zstdCompressSync(Buffer.from(JSON.stringify({ models: [{ id: "venice/test" }] })));
+  const response = await safeFetch("https://example.com/models", {
+    policy: { allowLocal: true },
+    decodeCompressedResponse: true,
+    dispatcher: {
+      dispatch(
+        _options: unknown,
+        handler: {
+          onConnect: (abort: () => void) => void;
+          onHeaders: (status: number, headers: string[], resume: () => void) => void;
+          onData: (chunk: Buffer) => void;
+          onComplete: (trailers: string[]) => void;
+        },
+      ) {
+        handler.onConnect(() => undefined);
+        handler.onHeaders(
+          200,
+          ["content-type", "application/json", "content-encoding", "zstd", "content-length", String(compressed.length)],
+          () => undefined,
+        );
+        handler.onData(compressed);
+        handler.onComplete([]);
+        return true;
+      },
+    },
+  });
+
+  assert.equal(response.headers.get("content-encoding"), null);
+  assert.equal(response.headers.get("content-length"), null);
+  assert.deepEqual(await response.json(), { models: [{ id: "venice/test" }] });
+});
+
+test("safeFetch leaves raw compressed bodies alone unless decoding is opted in", async () => {
+  const compressed = gzipSync(Buffer.from(JSON.stringify({ models: [{ id: "openrouter/test" }] })));
   const response = await safeFetch("https://example.com/models", {
     policy: { allowLocal: true },
     dispatcher: {
@@ -232,30 +267,25 @@ test("safeFetch decodes raw zstd bodies when providers omit content-encoding", a
       ) {
         handler.onConnect(() => undefined);
         handler.onHeaders(200, ["content-type", "application/json"], () => undefined);
-        handler.onData(zstdCompressSync(Buffer.from(JSON.stringify({ models: [{ id: "venice/test" }] }))));
+        handler.onData(compressed);
         handler.onComplete([]);
         return true;
       },
     },
   });
 
-  assert.deepEqual(await response.json(), { models: [{ id: "venice/test" }] });
+  assert.deepEqual(Buffer.from(await response.arrayBuffer()), compressed);
 });
 
-test("decodePossiblyCompressedBody handles compressed bodies left after content-encoding", () => {
+test("decodePossiblyCompressedBody handles raw gzip and zstd bodies", () => {
   const json = Buffer.from(JSON.stringify({ ok: true }));
-  const cases: Array<[string, Buffer]> = [
-    ["gzip", gzipSync(json)],
-    ["br", brotliCompressSync(json)],
-    ["zstd", zstdCompressSync(json)],
-    ["deflate", deflateSync(json)],
-  ];
+  const cases = [gzipSync(json), zstdCompressSync(json)];
 
-  for (const [encoding, body] of cases) {
-    assert.deepEqual(JSON.parse(decodePossiblyCompressedBody(body, encoding).toString("utf8")), { ok: true });
+  for (const body of cases) {
+    assert.deepEqual(JSON.parse(decodePossiblyCompressedBody(body).toString("utf8")), { ok: true });
   }
 
-  assert.equal(decodePossiblyCompressedBody(json, "zstd").toString("utf8"), json.toString("utf8"));
+  assert.equal(decodePossiblyCompressedBody(json).toString("utf8"), json.toString("utf8"));
 });
 
 test("safeFetch caps decoded raw gzip bodies when providers omit content-encoding", async () => {
@@ -264,6 +294,7 @@ test("safeFetch caps decoded raw gzip bodies when providers omit content-encodin
       safeFetch("https://example.com/models", {
         policy: { allowLocal: true },
         maxResponseBytes: 64,
+        decodeCompressedResponse: true,
         dispatcher: {
           dispatch(
             _options: unknown,


### PR DESCRIPTION
## Linked issue

Follow-up to #781 and #784. No new GitHub issue exists yet for the Venice-specific report.

## Why this change

- A Venice API user reported that model fetching and the connection test message started returning garbled binary-looking text instead of readable JSON.
- The previous provider response fix handled unlabeled raw gzip bytes, but Venice/Cloudflare can also return zstd-compressed provider responses.
- When those bytes reach JSON parsing still compressed, Marinara surfaces unreadable text and fails before it can show the provider's actual response.

## What changed

- Added an opt-in compressed-response normalization path for buffered provider/API JSON fetches.
- Decode raw gzip and zstd bodies when opted-in provider JSON responses arrive still compressed.
- Strip stale `content-encoding` and `content-length` headers after normalization.
- Opted in model-list/connection checks, OpenAI-compatible non-stream chat JSON, embeddings, Anthropic non-stream JSON, and ChatGPT auth/model JSON fetches.
- Left general `safeFetch` consumers and streaming/SSE responses unchanged.
- Added focused regression tests for raw gzip/zstd decoding, opt-in behavior, OpenAI-compatible non-stream chat, embeddings, and Anthropic non-stream chat.

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Ran `pnpm --filter @marinara-engine/server exec tsx --import ./test/setup-env.ts --test test/security-utils.test.ts test/openai-provider-reasoning.test.ts test/connections-horde-routes.test.ts test/embedding-response.test.ts test/anthropic-provider-opus47.test.ts`; passed.
- Ran `pnpm check`; passed.
- Live unauthenticated probe of Venice `/models` confirmed Venice/Cloudflare can return `content-encoding: zstd` when the client advertises zstd support.
- Not run: live authenticated Venice chat/test-message verification with a real API key.
- Not run: Docker/Podman container verification.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs or release metadata changes expected; this is a narrow server/provider response decoding fix.

## UI evidence (if applicable)

N/A. Server/provider response decoding only.
