### PR TITLE
Fix tracker panel overlapping editor controls

### DIFF
--- a/packages/client/src/components/layout/AppShell.tsx
+++ b/packages/client/src/components/layout/AppShell.tsx
@@ -474,8 +474,10 @@ export function AppShell() {
   const showAmbientDecor = isPageActive && !activeChatId && !detailView && !botBrowserOpen && !gameAssetsBrowserOpen;
   const hasDetailView = detailView != null;
   const trackerPanelActive = trackerPanelEnabled && trackerPanelOpen;
+  const trackerPanelSurfaceAvailable = !botBrowserOpen && !gameAssetsBrowserOpen && !hasDetailView;
+  const trackerPanelVisible = trackerPanelActive && trackerPanelSurfaceAvailable;
   useEffect(() => {
-    if (trackerPanelActive) {
+    if (trackerPanelVisible) {
       trackerPanelWasActiveRef.current = true;
       setTrackerPanelExitLayoutHold(false);
       return;
@@ -486,10 +488,10 @@ export function AppShell() {
     setTrackerPanelExitLayoutHold(true);
     const timeout = window.setTimeout(() => setTrackerPanelExitLayoutHold(false), TRACKER_PANEL_DESKTOP_EXIT_MS);
     return () => window.clearTimeout(timeout);
-  }, [trackerPanelActive]);
+  }, [trackerPanelVisible]);
 
-  const trackerPanelPendingExit = !trackerPanelActive && trackerPanelWasActiveRef.current;
-  const trackerPanelAnchoredForMotion = trackerPanelActive || trackerPanelExitLayoutHold || trackerPanelPendingExit;
+  const trackerPanelPendingExit = !trackerPanelVisible && trackerPanelWasActiveRef.current;
+  const trackerPanelAnchoredForMotion = trackerPanelVisible || trackerPanelExitLayoutHold || trackerPanelPendingExit;
   const trackerPanelDockToEdge = trackerPanelAnchoredForMotion && trackerPanelHideHudWidgets;
   const updateTrackerPanelToggleAnchor = useCallback(() => {
     const root = mainRef.current;
@@ -533,7 +535,7 @@ export function AppShell() {
   }, [trackerPanelDockToEdge]);
 
   useLayoutEffect(() => {
-    if (isMobile || trackerPanelActive || botBrowserOpen || gameAssetsBrowserOpen || hasDetailView) return;
+    if (isMobile || trackerPanelVisible || !trackerPanelSurfaceAvailable) return;
 
     let frame = 0;
     let discoveryObserver: MutationObserver | null = null;
@@ -583,14 +585,14 @@ export function AppShell() {
     botBrowserOpen,
     gameAssetsBrowserOpen,
     centerCompact,
-    hasDetailView,
     isMobile,
-    trackerPanelActive,
+    trackerPanelSurfaceAvailable,
+    trackerPanelVisible,
     updateTrackerPanelToggleAnchor,
   ]);
 
   useLayoutEffect(() => {
-    if (isMobile || !trackerPanelAnchoredForMotion || botBrowserOpen || gameAssetsBrowserOpen || hasDetailView) {
+    if (isMobile || !trackerPanelAnchoredForMotion || !trackerPanelSurfaceAvailable) {
       setTrackerPanelTop(TRACKER_PANEL_EDGE_OFFSET);
       return;
     }
@@ -642,24 +644,24 @@ export function AppShell() {
     botBrowserOpen,
     gameAssetsBrowserOpen,
     centerCompact,
-    hasDetailView,
     isMobile,
     trackerPanelAnchoredForMotion,
     trackerPanelDockToEdge,
+    trackerPanelSurfaceAvailable,
     updateTrackerPanelTop,
   ]);
 
   const trackerPanelChatAvoidance =
-    !isMobile && trackerPanelAnchoredForMotion && !botBrowserOpen && !gameAssetsBrowserOpen && !hasDetailView
+    !isMobile && trackerPanelAnchoredForMotion && trackerPanelSurfaceAvailable
       ? Math.round(liveTrackerPanelWidth * 0.62)
       : 0;
   const trackerPanelHudClearance =
-    !isMobile && trackerPanelAnchoredForMotion && trackerPanelHideHudWidgets && !botBrowserOpen && !gameAssetsBrowserOpen && !hasDetailView
+    !isMobile && trackerPanelAnchoredForMotion && trackerPanelHideHudWidgets && trackerPanelSurfaceAvailable
       ? liveTrackerPanelWidth + TRACKER_PANEL_HUD_GAP
       : 0;
 
   const trackerPanelDesktop = (side: "left" | "right") =>
-    trackerPanelActive && trackerPanelSide === side ? (
+    trackerPanelVisible && trackerPanelSide === side ? (
       <motion.aside
         key={`tracker-${side}`}
         initial={{
@@ -802,7 +804,7 @@ export function AppShell() {
         />
       )}
 
-      <AnimatePresence initial={false}>{!isMobile && !botBrowserOpen && !gameAssetsBrowserOpen && trackerPanelDesktop("left")}</AnimatePresence>
+      <AnimatePresence initial={false}>{!isMobile && trackerPanelSurfaceAvailable && trackerPanelDesktop("left")}</AnimatePresence>
 
       {/* Center content */}
       <main
@@ -840,10 +842,10 @@ export function AppShell() {
         <ChatNotificationBubbles />
       </main>
 
-      <AnimatePresence initial={false}>{!isMobile && !botBrowserOpen && !gameAssetsBrowserOpen && trackerPanelDesktop("right")}</AnimatePresence>
+      <AnimatePresence initial={false}>{!isMobile && trackerPanelSurfaceAvailable && trackerPanelDesktop("right")}</AnimatePresence>
 
       {/* Mobile tracker panel backdrop */}
-      {trackerPanelActive && !botBrowserOpen && !gameAssetsBrowserOpen && (
+      {trackerPanelVisible && (
         <div
           className="fixed inset-0 z-40 bg-black/50 backdrop-blur-sm md:hidden"
           onClick={() => setTrackerPanelOpen(false)}
@@ -853,7 +855,7 @@ export function AppShell() {
       {/* Mobile tracker panel */}
       {isMobile && (
         <AnimatePresence mode="wait">
-          {trackerPanelActive && !botBrowserOpen && !gameAssetsBrowserOpen && (
+          {trackerPanelVisible && (
             <motion.aside
               key="mobile-tracker"
               initial={{ x: trackerPanelSide === "left" ? "-100%" : "100%" }}


### PR DESCRIPTION
## Linked issue

Fixes a user-reported tracker/editor overlap. Closes #832

## Why this change

- Expanded tracker side panels could remain rendered while master setting editors were open. Because the tracker overlay no longer had a chat-surface anchor in that state, it could move up and block editor header actions like Back or Save.

## What changed

- Centralized tracker panel surface availability in `AppShell`.
- Render tracker overlays only while the chat/play surface is active, preserving the user's tracker open/side/width preferences while editors are open.
- Keeps normal roleplay behavior unchanged: returning from an editor shows the tracker panel again.

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Reproduced the bug locally with a seeded roleplay chat, expanded right-side tracker panel, and Agent editor detail open. Before the fix, the tracker panel covered the Save button.
- Verified after the fix that the right-side tracker is not rendered over editor detail views, and the Save button receives pointer hits.
- Verified the left-side tracker case with the Agent editor open; the Back button receives pointer hits.
- Verified returning to the normal roleplay surface shows the expanded tracker panel again.
- Ran `pnpm --filter @marinara-engine/client lint`.
- Ran `pnpm check`.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

- Browser geometry checks confirmed the tracker overlay no longer covers editor Back/Save controls while preserving normal roleplay tracker rendering.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined tracker panel visibility to prevent display conflicts with other interface elements.
  * The tracker panel now correctly hides when using the bot browser, game assets browser, or detail editors.
  * Enhanced consistency of tracker panel behavior on both desktop and mobile platforms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/829)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->