### PR TITLE
Decode brotli provider JSON responses

### DIFF
--- a/packages/server/src/utils/security.ts
+++ b/packages/server/src/utils/security.ts
@@ -1,7 +1,7 @@
 import { promises as dns } from "node:dns";
 import { createHash, timingSafeEqual } from "node:crypto";
 import { basename, extname, relative, resolve, sep, win32 } from "node:path";
-import { gunzipSync, zstdDecompressSync } from "node:zlib";
+import { brotliDecompressSync, gunzipSync, zstdDecompressSync } from "node:zlib";
 import { Agent } from "undici";
 import { isLoopbackIp, isPrivateNetworkIp } from "../middleware/ip-allowlist.js";
 import { logger } from "../lib/logger.js";
@@ -489,14 +489,27 @@ function decodeByMagicBytes(buffer: Buffer, maxBytes: number): Buffer | null {
   if (buffer.length >= 4 && buffer[0] === 0x28 && buffer[1] === 0xb5 && buffer[2] === 0x2f && buffer[3] === 0xfd) {
     return tryDecodeCompressedBody(buffer, "zstd", maxBytes);
   }
+  if (!looksLikeProviderJsonOrSseBody(buffer)) {
+    const brotli = tryDecodeCompressedBody(buffer, "br", maxBytes);
+    if (brotli && looksLikeProviderJsonOrSseBody(brotli)) {
+      return brotli;
+    }
+  }
   return null;
 }
 
-function tryDecodeCompressedBody(buffer: Buffer, algorithm: "gzip" | "zstd", maxBytes: number): Buffer | null {
+function looksLikeProviderJsonOrSseBody(buffer: Buffer): boolean {
+  const preview = buffer.subarray(0, 32).toString("utf8").trimStart();
+  return preview.startsWith("{") || preview.startsWith("[") || preview.startsWith("data:");
+}
+
+function tryDecodeCompressedBody(buffer: Buffer, algorithm: "gzip" | "br" | "zstd", maxBytes: number): Buffer | null {
   try {
     switch (algorithm) {
       case "gzip":
         return gunzipSync(buffer, { maxOutputLength: maxBytes });
+      case "br":
+        return brotliDecompressSync(buffer, { maxOutputLength: maxBytes });
       case "zstd":
         return zstdDecompressSync(buffer, { maxOutputLength: maxBytes });
     }

--- a/packages/server/test/openai-provider-reasoning.test.ts
+++ b/packages/server/test/openai-provider-reasoning.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { gzipSync, zstdCompressSync } from "node:zlib";
+import { brotliCompressSync, gzipSync, zstdCompressSync } from "node:zlib";
 import { MODEL_LISTS } from "../../shared/src/constants/model-lists.ts";
 import { createLLMProvider } from "../src/services/llm/provider-registry.js";
 import { OpenAIProvider } from "../src/services/llm/providers/openai.provider.js";
@@ -406,6 +406,46 @@ test("OpenAI-compatible non-stream chat decodes raw zstd JSON without content-en
     }
 
     assert.equal(chunks.join(""), "decoded from zstd");
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (originalLocalUrls === undefined) {
+      delete process.env.PROVIDER_LOCAL_URLS_ENABLED;
+    } else {
+      process.env.PROVIDER_LOCAL_URLS_ENABLED = originalLocalUrls;
+    }
+  }
+});
+
+test("OpenAI-compatible chatComplete decodes raw brotli JSON without content-encoding", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalLocalUrls = process.env.PROVIDER_LOCAL_URLS_ENABLED;
+
+  globalThis.fetch = async () =>
+    new Response(
+      brotliCompressSync(
+        Buffer.from(
+          JSON.stringify({
+            choices: [{ message: { content: "decoded from brotli" }, finish_reason: "stop" }],
+            usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+          }),
+        ),
+      ),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+
+  try {
+    process.env.PROVIDER_LOCAL_URLS_ENABLED = "true";
+    const provider = new OpenAIProvider("https://api.venice.ai/api/v1", "test-key");
+    const result = await provider.chatComplete([{ role: "user", content: "Hello" }], {
+      model: "venice/test-model",
+      stream: false,
+      maxTokens: 512,
+    });
+
+    assert.equal(result.content, "decoded from brotli");
   } finally {
     globalThis.fetch = originalFetch;
     if (originalLocalUrls === undefined) {

--- a/packages/server/test/security-utils.test.ts
+++ b/packages/server/test/security-utils.test.ts
@@ -4,7 +4,7 @@ import { promises as dns } from "node:dns";
 import { mkdtemp, rm } from "node:fs/promises";
 import { join, resolve, win32 } from "node:path";
 import { tmpdir } from "node:os";
-import { gzipSync, zstdCompressSync } from "node:zlib";
+import { brotliCompressSync, gzipSync, zstdCompressSync } from "node:zlib";
 import {
   assertInsideDir,
   decodePossiblyCompressedBody,
@@ -277,9 +277,9 @@ test("safeFetch leaves raw compressed bodies alone unless decoding is opted in",
   assert.deepEqual(Buffer.from(await response.arrayBuffer()), compressed);
 });
 
-test("decodePossiblyCompressedBody handles raw gzip and zstd bodies", () => {
+test("decodePossiblyCompressedBody handles raw gzip, brotli, and zstd JSON bodies", () => {
   const json = Buffer.from(JSON.stringify({ ok: true }));
-  const cases = [gzipSync(json), zstdCompressSync(json)];
+  const cases = [gzipSync(json), brotliCompressSync(json), zstdCompressSync(json)];
 
   for (const body of cases) {
     assert.deepEqual(JSON.parse(decodePossiblyCompressedBody(body).toString("utf8")), { ok: true });


### PR DESCRIPTION
## Linked issue

Follow-up to #825. No new GitHub issue exists yet for the Venice-specific follow-up report.

## Why this change

- A Venice API user still received compressed-looking bytes after #825, now in an OpenAI-compatible non-stream `chatComplete()` response during conversation summary generation.
- The failing body preview starts with bytes that match raw brotli output rather than gzip or zstd.
- #825 intentionally narrowed fallback decoding to gzip/zstd, so raw brotli provider JSON could still reach JSON parsing and fail.
- After the brotli fallback, the remaining empty-response report no longer showed JSON parse errors, which points at streaming responses still being compressed before the SSE parser sees them.

## What changed

- Added brotli as a narrow fallback in the existing opt-in buffered provider JSON normalization path.
- Only accepts a brotli decode when the decoded body looks like provider JSON or SSE text.
- LLM provider requests now default `Accept-Encoding` to `identity`, while still preserving any explicit caller-provided encoding header.
- Added regression coverage for OpenAI-compatible non-stream `chatComplete()` receiving raw brotli JSON.
- Extended the shared compressed-body decoder test to cover gzip, brotli, and zstd JSON.
- Added coverage that streaming LLM requests ask providers for identity encoding.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Ran `pnpm --filter @marinara-engine/server exec tsx --import ./test/setup-env.ts --test test/security-utils.test.ts test/openai-provider-reasoning.test.ts`; passed.
- Ran `pnpm check`; passed.
- Not run: live authenticated Venice chat/test-message verification with a real API key.
- Not run: Docker/Podman container verification.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs or release metadata changes expected; this is a narrow server/provider response decoding follow-up.

## UI evidence (if applicable)

N/A. Server/provider response decoding only.
