### PR TITLE
Request identity encoding for provider responses

### DIFF
--- a/packages/server/src/services/llm/base-provider.ts
+++ b/packages/server/src/services/llm/base-provider.ts
@@ -13,6 +13,14 @@ import { safeFetch, type SafeFetchOptions } from "../../utils/security.js";
 const LLM_HEADERS_TIMEOUT = 5 * 60 * 1000; // 5 minutes
 const llmAgentOptions = { bodyTimeout: 0, headersTimeout: LLM_HEADERS_TIMEOUT };
 
+function providerRequestHeaders(headersInit: RequestInit["headers"] | undefined): Headers {
+  const headers = new Headers(headersInit);
+  if (!headers.has("accept-encoding")) {
+    headers.set("accept-encoding", "identity");
+  }
+  return headers;
+}
+
 /**
  * Drop-in replacement for `fetch()` that uses a custom undici dispatcher
  * with no body/headers timeout. Use this for all outgoing LLM requests.
@@ -24,6 +32,7 @@ export function llmFetch(
   const bufferResponse = init?.bufferResponse ?? false;
   return safeFetch(url, {
     ...(init ?? {}),
+    headers: providerRequestHeaders(init?.headers),
     agentOptions: llmAgentOptions,
     policy: {
       allowLocal: isProviderLocalUrlsEnabled(),

--- a/packages/server/src/services/llm/base-provider.ts
+++ b/packages/server/src/services/llm/base-provider.ts
@@ -3,7 +3,7 @@
 // ──────────────────────────────────────────────
 import { logger } from "../../lib/logger.js";
 import { isProviderLocalUrlsEnabled } from "../../config/runtime-config.js";
-import { safeFetch, type SafeFetchOptions } from "../../utils/security.js";
+import { requestHeadersWithIdentityEncoding, safeFetch, type SafeFetchOptions } from "../../utils/security.js";
 
 /**
  * Shared undici Agent with a 5-minute headers timeout (time to first byte)
@@ -12,14 +12,6 @@ import { safeFetch, type SafeFetchOptions } from "../../utils/security.js";
  */
 const LLM_HEADERS_TIMEOUT = 5 * 60 * 1000; // 5 minutes
 const llmAgentOptions = { bodyTimeout: 0, headersTimeout: LLM_HEADERS_TIMEOUT };
-
-function providerRequestHeaders(headersInit: RequestInit["headers"] | undefined): Headers {
-  const headers = new Headers(headersInit);
-  if (!headers.has("accept-encoding")) {
-    headers.set("accept-encoding", "identity");
-  }
-  return headers;
-}
 
 /**
  * Drop-in replacement for `fetch()` that uses a custom undici dispatcher
@@ -32,7 +24,7 @@ export function llmFetch(
   const bufferResponse = init?.bufferResponse ?? false;
   return safeFetch(url, {
     ...(init ?? {}),
-    headers: providerRequestHeaders(init?.headers),
+    headers: requestHeadersWithIdentityEncoding(init?.headers),
     agentOptions: llmAgentOptions,
     policy: {
       allowLocal: isProviderLocalUrlsEnabled(),

--- a/packages/server/src/utils/security.ts
+++ b/packages/server/src/utils/security.ts
@@ -522,6 +522,14 @@ function tryDecodeCompressedBody(buffer: Buffer, algorithm: "gzip" | "br" | "zst
   }
 }
 
+function requestHeadersWithIdentityEncoding(headersInit: RequestInit["headers"] | undefined): Headers {
+  const headers = new Headers(headersInit);
+  if (!headers.has("accept-encoding")) {
+    headers.set("accept-encoding", "identity");
+  }
+  return headers;
+}
+
 export async function safeFetch(url: string | URL, options: SafeFetchOptions = {}): Promise<Response> {
   const {
     policy,
@@ -531,6 +539,7 @@ export async function safeFetch(url: string | URL, options: SafeFetchOptions = {
     decodeCompressedResponse = false,
     agentOptions,
     dispatcher,
+    headers,
     ...init
   } = options;
   if (dispatcher && !policy?.allowLocal) {
@@ -542,8 +551,10 @@ export async function safeFetch(url: string | URL, options: SafeFetchOptions = {
 
   for (let i = 0; i <= redirects; i += 1) {
     const internalDispatcher = dispatcher ? undefined : current.dispatcher;
+    const requestHeaders = decodeCompressedResponse ? requestHeadersWithIdentityEncoding(headers) : headers;
     const response = await fetch(current.url, {
       ...init,
+      ...(requestHeaders ? { headers: requestHeaders } : {}),
       redirect: "manual",
       dispatcher: dispatcher ?? internalDispatcher,
     } as unknown as RequestInit);

--- a/packages/server/src/utils/security.ts
+++ b/packages/server/src/utils/security.ts
@@ -522,7 +522,7 @@ function tryDecodeCompressedBody(buffer: Buffer, algorithm: "gzip" | "br" | "zst
   }
 }
 
-function requestHeadersWithIdentityEncoding(headersInit: RequestInit["headers"] | undefined): Headers {
+export function requestHeadersWithIdentityEncoding(headersInit: RequestInit["headers"] | undefined): Headers {
   const headers = new Headers(headersInit);
   if (!headers.has("accept-encoding")) {
     headers.set("accept-encoding", "identity");

--- a/packages/server/test/openai-provider-reasoning.test.ts
+++ b/packages/server/test/openai-provider-reasoning.test.ts
@@ -330,6 +330,50 @@ test("custom compatible streams accept SSE data lines without a space", async ()
   }
 });
 
+test("LLM streaming requests ask providers for identity encoding", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalLocalUrls = process.env.PROVIDER_LOCAL_URLS_ENABLED;
+  const seenAcceptEncodings: Array<string | null> = [];
+  const encoder = new TextEncoder();
+
+  globalThis.fetch = async (_input: string | URL | Request, init?: RequestInit) => {
+    seenAcceptEncodings.push(new Headers(init?.headers).get("accept-encoding"));
+    return new Response(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoder.encode('data:{"choices":[{"delta":{"content":"identity"}}]}\n\n'));
+          controller.enqueue(encoder.encode("data:[DONE]\n\n"));
+          controller.close();
+        },
+      }),
+      { status: 200, headers: { "Content-Type": "text/event-stream" } },
+    );
+  };
+
+  try {
+    process.env.PROVIDER_LOCAL_URLS_ENABLED = "true";
+    const provider = createLLMProvider("custom", "https://api.venice.ai/api/v1", "test-key");
+    const tokenChunks: string[] = [];
+    const result = await provider.chatComplete([{ role: "user", content: "Hello" }], {
+      model: "venice/test-model",
+      stream: true,
+      maxTokens: 512,
+      onToken: (chunk) => tokenChunks.push(chunk),
+    });
+
+    assert.equal(seenAcceptEncodings[0], "identity");
+    assert.equal(tokenChunks.join(""), "identity");
+    assert.equal(result.content, "identity");
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (originalLocalUrls === undefined) {
+      delete process.env.PROVIDER_LOCAL_URLS_ENABLED;
+    } else {
+      process.env.PROVIDER_LOCAL_URLS_ENABLED = originalLocalUrls;
+    }
+  }
+});
+
 test("OpenRouter non-stream chat decodes raw gzip JSON without content-encoding", async () => {
   const originalFetch = globalThis.fetch;
   const originalLocalUrls = process.env.PROVIDER_LOCAL_URLS_ENABLED;

--- a/packages/server/test/security-utils.test.ts
+++ b/packages/server/test/security-utils.test.ts
@@ -277,6 +277,31 @@ test("safeFetch leaves raw compressed bodies alone unless decoding is opted in",
   assert.deepEqual(Buffer.from(await response.arrayBuffer()), compressed);
 });
 
+test("safeFetch asks for identity encoding when compressed decoding is opted in", async () => {
+  const originalFetch = globalThis.fetch;
+  const seenAcceptEncodings: Array<string | null> = [];
+
+  globalThis.fetch = async (_input: string | URL | Request, init?: RequestInit) => {
+    seenAcceptEncodings.push(new Headers(init?.headers).get("accept-encoding"));
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+
+  try {
+    const response = await safeFetch("https://example.com/models", {
+      policy: { allowLocal: true },
+      decodeCompressedResponse: true,
+    });
+
+    assert.deepEqual(await response.json(), { ok: true });
+    assert.equal(seenAcceptEncodings[0], "identity");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test("decodePossiblyCompressedBody handles raw gzip, brotli, and zstd JSON bodies", () => {
   const json = Buffer.from(JSON.stringify({ ok: true }));
   const cases = [gzipSync(json), brotliCompressSync(json), zstdCompressSync(json)];


### PR DESCRIPTION
## Linked issue

Follow-up to #825 and #834. No new GitHub issue exists yet for the Venice-specific follow-up report.

## Why this change

- After #834, the user no longer showed compressed JSON parse errors but still got an empty model response from generation.
- A direct Venice probe showed the models endpoint returns plain JSON with `Accept-Encoding: identity`, but returns zstd-compressed bytes when broader encodings are advertised.
- That means the safest follow-up is to ask the provider/proxy for identity encoding on both LLM streams and opted-in provider JSON fetches, instead of depending on every runtime/proxy path to decode the same way.

## What changed

- LLM provider requests now default `Accept-Encoding` to `identity`.
- Buffered provider/API JSON fetches that opt into compressed-response normalization now also default `Accept-Encoding` to `identity`.
- Explicit caller-provided `accept-encoding` headers are preserved.
- Added regression coverage for OpenAI-compatible streaming `chatComplete()` and opted-in `safeFetch` provider JSON requests.

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Ran `pnpm --filter @marinara-engine/server exec tsx --import ./test/setup-env.ts --test test/security-utils.test.ts test/openai-provider-reasoning.test.ts`; passed.
- Ran `pnpm check`; passed with the existing Node `DEP0190` warning during the server build.
- Not run: live authenticated Venice streaming chat verification with a real API key.
- Not run: Docker/Podman container verification.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs or release metadata changes expected; this is a narrow server/provider request negotiation fix.

## UI evidence (if applicable)

N/A. Server/provider request handling only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced request header management for LLM and security-related fetch operations to ensure proper and consistent encoding handling across all outgoing server requests.

* **Tests**
  * Added test coverage to verify correct request header encoding in LLM streaming requests and security utility functions, ensuring expected behavior is maintained.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/836)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->