### PR TITLE
Fix Knowledge Retrieval prompt preset sections

### DIFF
--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -652,6 +652,107 @@ const REVIEWABLE_WRITER_AGENT_TYPES = new Set(
   ).map((agent) => agent.id),
 );
 
+type RuntimeAgentSectionType = "knowledge-retrieval" | "knowledge-router";
+
+const RUNTIME_AGENT_SECTION_TYPES = new Set<string>(["knowledge-retrieval", "knowledge-router"]);
+const RUNTIME_AGENT_SECTION_TOKEN_PREFIX = "__MARINARA_RUNTIME_AGENT_SECTION__";
+
+interface RuntimeAgentSectionTokens {
+  placeholder: string;
+  start: string;
+  end: string;
+}
+
+function toRuntimeAgentSectionType(agentType: string): RuntimeAgentSectionType | null {
+  return RUNTIME_AGENT_SECTION_TYPES.has(agentType) ? (agentType as RuntimeAgentSectionType) : null;
+}
+
+function makeRuntimeAgentSectionTokens(
+  agentType: RuntimeAgentSectionType,
+  nonce: string,
+): RuntimeAgentSectionTokens {
+  return {
+    placeholder: `${RUNTIME_AGENT_SECTION_TOKEN_PREFIX}${nonce}__${agentType}__VALUE__`,
+    start: `${RUNTIME_AGENT_SECTION_TOKEN_PREFIX}${nonce}__${agentType}__START__`,
+    end: `${RUNTIME_AGENT_SECTION_TOKEN_PREFIX}${nonce}__${agentType}__END__`,
+  };
+}
+
+function replaceRuntimeAgentSection(
+  messages: Array<{ content: string }>,
+  tokens: RuntimeAgentSectionTokens,
+  text: string,
+): boolean {
+  let replaced = false;
+  for (let i = 0; i < messages.length; i++) {
+    const message = messages[i]!;
+    if (!message.content.includes(tokens.placeholder)) continue;
+    messages[i] = {
+      ...message,
+      content: message.content
+        .split(tokens.start)
+        .join("")
+        .split(tokens.end)
+        .join("")
+        .split(tokens.placeholder)
+        .join(text),
+    };
+    replaced = true;
+  }
+  return replaced;
+}
+
+export function clearUnusedRuntimeAgentSectionsForTest(
+  messages: Array<{ content: string }>,
+  tokenEntries: Iterable<[RuntimeAgentSectionType, RuntimeAgentSectionTokens]>,
+): void {
+  let changed = false;
+  for (const [, tokens] of tokenEntries) {
+    const sectionPattern = new RegExp(
+      escapeRegExp(tokens.start) + "[\\s\\S]*?" + escapeRegExp(tokens.end),
+      "g",
+    );
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const message = messages[i]!;
+      if (!message.content.includes(tokens.start)) continue;
+      const content = message.content.replace(sectionPattern, "").trim();
+      if (content) {
+        messages[i] = { ...message, content };
+      } else {
+        messages.splice(i, 1);
+      }
+      changed = true;
+    }
+  }
+  if (changed) {
+    pruneEmptyPromptWrappers(messages);
+  }
+}
+
+const clearUnusedRuntimeAgentSections = clearUnusedRuntimeAgentSectionsForTest;
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function pruneEmptyPromptWrappers(messages: Array<{ content: string }>): void {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const content = messages[i]!.content.trim();
+    if (isEmptyPromptWrapper(content)) {
+      messages.splice(i, 1);
+    } else if (content !== messages[i]!.content) {
+      messages[i] = { ...messages[i]!, content };
+    }
+  }
+}
+
+function isEmptyPromptWrapper(content: string): boolean {
+  if (!content) return true;
+  const xmlMatch = content.match(/^<([A-Za-z][\w.-]*)>\s*<\/\1>$/);
+  if (xmlMatch) return true;
+  return /^#{1,6}\s+\S.*$/m.test(content) && content.split(/\r?\n/).slice(1).every((line) => !line.trim());
+}
+
 function normalizeChatTopP(value: unknown): number | undefined {
   if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
   if (value <= 0) return 1;
@@ -1130,6 +1231,8 @@ export async function generateRoutes(app: FastifyInstance) {
       let assistantPrefill = "";
       let customParameters: Record<string, unknown> = {};
       let wrapFormat: "xml" | "markdown" | "none" = "xml";
+      const runtimeAgentSectionTypes = new Set<RuntimeAgentSectionType>();
+      const runtimeAgentSectionTokens = new Map<RuntimeAgentSectionType, RuntimeAgentSectionTokens>();
       const connectionMaxContext = normalizeMaxContext(conn.maxContext);
       const knownModelContext = normalizeMaxContext(findKnownModel(conn.provider as APIProvider, conn.model)?.context);
       let effectiveMaxContext = minContextLimit(connectionMaxContext, knownModelContext);
@@ -1283,6 +1386,34 @@ export async function generateRoutes(app: FastifyInstance) {
           presets.listGroups(presetId),
           presets.listChoiceBlocksForPreset(presetId),
         ]);
+        for (const section of sections) {
+          if (section.enabled !== "true" || section.isMarker !== "true" || !section.markerConfig) continue;
+          try {
+            const markerConfig = JSON.parse(section.markerConfig) as { type?: unknown; agentType?: unknown };
+            const runtimeType =
+              markerConfig.type === "agent_data" && typeof markerConfig.agentType === "string"
+                ? toRuntimeAgentSectionType(markerConfig.agentType)
+                : null;
+            if (runtimeType) runtimeAgentSectionTypes.add(runtimeType);
+          } catch {
+            /* ignore malformed marker config */
+          }
+        }
+        const runtimeAgentNonce = `${Date.now().toString(36)}_${Math.random().toString(36).slice(2)}`;
+        const runtimeAgentData = Object.fromEntries(
+          Array.from(runtimeAgentSectionTypes).map((agentType) => {
+            const tokens = makeRuntimeAgentSectionTokens(agentType, runtimeAgentNonce);
+            runtimeAgentSectionTokens.set(agentType, tokens);
+            return [
+              agentType,
+              {
+                text: tokens.placeholder,
+                startToken: tokens.start,
+                endToken: tokens.end,
+              },
+            ];
+          }),
+        );
 
         const assemblerInput: AssemblerInput = {
           db: app.db,
@@ -1326,6 +1457,7 @@ export async function generateRoutes(app: FastifyInstance) {
             typeof chatMeta.groupScenarioText === "string" && (chatMeta.groupScenarioText as string).trim()
               ? (chatMeta.groupScenarioText as string).trim()
               : null,
+          runtimeAgentData,
         };
 
         const assembled = await assemblePrompt(assemblerInput);
@@ -5175,7 +5307,12 @@ export async function generateRoutes(app: FastifyInstance) {
           const krText =
             typeof krResult.data === "string" ? krResult.data : ((krResult.data as { text?: string })?.text ?? "");
           if (krText) {
-            appendSeparateAgentInjection("knowledge-retrieval", krText);
+            const tokens = runtimeAgentSectionTokens.get("knowledge-retrieval");
+            const handledByPresetSection =
+              tokens !== undefined && replaceRuntimeAgentSection(finalMessages, tokens, krText);
+            if (!handledByPresetSection) {
+              appendSeparateAgentInjection("knowledge-retrieval", krText);
+            }
             contextInjections.push({ agentType: "knowledge-retrieval", text: krText });
           }
         }
@@ -5187,10 +5324,16 @@ export async function generateRoutes(app: FastifyInstance) {
               ? routerResult.data
               : ((routerResult.data as { text?: string })?.text ?? "");
           if (routerText) {
-            appendSeparateAgentInjection("knowledge-router", routerText);
+            const tokens = runtimeAgentSectionTokens.get("knowledge-router");
+            const handledByPresetSection =
+              tokens !== undefined && replaceRuntimeAgentSection(finalMessages, tokens, routerText);
+            if (!handledByPresetSection) {
+              appendSeparateAgentInjection("knowledge-router", routerText);
+            }
             contextInjections.push({ agentType: "knowledge-router", text: routerText });
           }
         }
+        clearUnusedRuntimeAgentSections(finalMessages, runtimeAgentSectionTokens);
       } else if (input.regenerateMessageId) {
         // Regeneration — try to reuse cached context injections from the original generation.
         // This must run regardless of whether `hasPreGenAgents` is true, because the cached
@@ -5279,8 +5422,17 @@ export async function generateRoutes(app: FastifyInstance) {
         }
 
         for (const inj of cachedSeparateInjections) {
-          appendSeparateAgentInjection(inj.agentType as "knowledge-retrieval" | "knowledge-router", inj.text);
+          const runtimeType = toRuntimeAgentSectionType(inj.agentType);
+          const tokens = runtimeType ? runtimeAgentSectionTokens.get(runtimeType) : undefined;
+          const handledByPresetSection =
+            tokens !== undefined && replaceRuntimeAgentSection(finalMessages, tokens, inj.text);
+          if (!handledByPresetSection) {
+            appendSeparateAgentInjection(inj.agentType as "knowledge-retrieval" | "knowledge-router", inj.text);
+          }
         }
+        clearUnusedRuntimeAgentSections(finalMessages, runtimeAgentSectionTokens);
+      } else {
+        clearUnusedRuntimeAgentSections(finalMessages, runtimeAgentSectionTokens);
       }
 
       // ────────────────────────────────────────

--- a/packages/server/src/services/prompt/assembler.ts
+++ b/packages/server/src/services/prompt/assembler.ts
@@ -503,9 +503,17 @@ async function resolveSection(
         : null;
     const runtimeAgentData =
       runtimeAgentType !== null ? ctx.runtimeAgentData[runtimeAgentType] : undefined;
-    runtimeAgentText = typeof runtimeAgentData === "string" ? runtimeAgentData : (runtimeAgentData?.text ?? "");
-    runtimeAgentStartToken = typeof runtimeAgentData === "string" ? undefined : runtimeAgentData?.startToken;
-    runtimeAgentEndToken = typeof runtimeAgentData === "string" ? undefined : runtimeAgentData?.endToken;
+    const normalizedRuntimeAgentData: RuntimeAgentData =
+      typeof runtimeAgentData === "string"
+        ? { text: runtimeAgentData }
+        : {
+            text: runtimeAgentData?.text ?? "",
+            startToken: runtimeAgentData?.startToken,
+            endToken: runtimeAgentData?.endToken,
+          };
+    runtimeAgentText = normalizedRuntimeAgentData.text;
+    runtimeAgentStartToken = normalizedRuntimeAgentData.startToken;
+    runtimeAgentEndToken = normalizedRuntimeAgentData.endToken;
     const hasRuntimeAgentData =
       runtimeAgentType !== null && Object.prototype.hasOwnProperty.call(ctx.runtimeAgentData, runtimeAgentType);
     const expanded = hasRuntimeAgentData ? { content: runtimeAgentText } : await expandMarker(markerConfig, ctx.markerCtx);

--- a/packages/server/src/services/prompt/assembler.ts
+++ b/packages/server/src/services/prompt/assembler.ts
@@ -552,7 +552,12 @@ async function resolveSection(
   content = contentMacrosResolved ? content : resolveMacros(content, ctx.macroCtx);
   if (!content.trim()) return null;
   const shouldWrapRuntimeAgentSection =
-    Boolean(runtimeAgentStartToken && runtimeAgentEndToken) && content.includes(runtimeAgentText);
+    Boolean(
+      runtimeAgentStartToken &&
+        runtimeAgentEndToken &&
+        runtimeAgentText.trim().length > 0 &&
+        content.includes(runtimeAgentText),
+    );
 
   // Auto-wrap in the preset's format
   const wrapped = wrapContent(content, section.name, ctx.wrapFormat);

--- a/packages/server/src/services/prompt/assembler.ts
+++ b/packages/server/src/services/prompt/assembler.ts
@@ -27,6 +27,12 @@ import {
   resolveMacrosWithVariableSnapshot,
 } from "./macro-context.js";
 
+interface RuntimeAgentData {
+  text: string;
+  startToken?: string;
+  endToken?: string;
+}
+
 // ═══════════════════════════════════════════════
 //  Public Interface
 // ═══════════════════════════════════════════════
@@ -134,6 +140,8 @@ export interface AssemblerInput {
   previewOnly?: boolean;
   /** When set, replaces individual character scenario fields with this group scenario. */
   groupScenarioOverrideText?: string | null;
+  /** Per-generation agent data keyed by agent type. Used when an agent section must consume fresh output. */
+  runtimeAgentData?: Record<string, string | RuntimeAgentData>;
 }
 
 /** Output of the assembler. */
@@ -148,6 +156,8 @@ export interface AssemblerOutput {
   updatedEntryStateOverrides?: Record<string, { ephemeral?: number | null; enabled?: boolean }>;
   /** Updated per-chat sticky/cooldown/delay timing state. Caller should persist to chat metadata. */
   updatedEntryTimingStates?: Record<string, LorebookEntryTimingState>;
+  /** Agent types whose runtime data was consumed by enabled agent_data sections. */
+  runtimeAgentTypesUsed?: string[];
 }
 
 // ═══════════════════════════════════════════════
@@ -261,6 +271,7 @@ export async function assemblePrompt(input: AssemblerInput): Promise<AssemblerOu
   const depthSections: ResolvedSection[] = [];
   let lorebookDepthEntriesCount = 0;
   let hasChatSummaryMarker = false;
+  const runtimeAgentTypesUsed = new Set<string>();
 
   for (const sectionId of sectionOrder) {
     const section = sectionMap.get(sectionId);
@@ -287,6 +298,8 @@ export async function assemblePrompt(input: AssemblerInput): Promise<AssemblerOu
       macroCtx,
       markerCtx,
       wrapFormat,
+      runtimeAgentData: input.runtimeAgentData ?? {},
+      runtimeAgentTypesUsed,
     });
 
     if (!resolved) continue;
@@ -440,6 +453,7 @@ export async function assemblePrompt(input: AssemblerInput): Promise<AssemblerOu
     ...(markerCtx.updatedEntryTimingStates !== undefined
       ? { updatedEntryTimingStates: markerCtx.updatedEntryTimingStates }
       : {}),
+    ...(runtimeAgentTypesUsed.size > 0 ? { runtimeAgentTypesUsed: Array.from(runtimeAgentTypesUsed) } : {}),
   };
 }
 
@@ -460,6 +474,8 @@ interface ResolveSectionCtx {
   macroCtx: MacroContext;
   markerCtx: MarkerContext;
   wrapFormat: WrapFormat;
+  runtimeAgentData: Record<string, string | RuntimeAgentData>;
+  runtimeAgentTypesUsed: Set<string>;
 }
 
 // ═══════════════════════════════════════════════
@@ -474,11 +490,25 @@ async function resolveSection(
 
   let content = section.content;
   let contentMacrosResolved = false;
+  let runtimeAgentText = "";
+  let runtimeAgentStartToken: string | undefined;
+  let runtimeAgentEndToken: string | undefined;
 
   // Handle marker sections
   if (section.isMarker === "true" && section.markerConfig) {
     const markerConfig = JSON.parse(section.markerConfig) as MarkerConfig;
-    const expanded = await expandMarker(markerConfig, ctx.markerCtx);
+    const runtimeAgentType =
+      markerConfig.type === "agent_data" && markerConfig.agentType
+        ? markerConfig.agentType
+        : null;
+    const runtimeAgentData =
+      runtimeAgentType !== null ? ctx.runtimeAgentData[runtimeAgentType] : undefined;
+    runtimeAgentText = typeof runtimeAgentData === "string" ? runtimeAgentData : (runtimeAgentData?.text ?? "");
+    runtimeAgentStartToken = typeof runtimeAgentData === "string" ? undefined : runtimeAgentData?.startToken;
+    runtimeAgentEndToken = typeof runtimeAgentData === "string" ? undefined : runtimeAgentData?.endToken;
+    const hasRuntimeAgentData =
+      runtimeAgentType !== null && Object.prototype.hasOwnProperty.call(ctx.runtimeAgentData, runtimeAgentType);
+    const expanded = hasRuntimeAgentData ? { content: runtimeAgentText } : await expandMarker(markerConfig, ctx.markerCtx);
 
     // Chat history marker returns multiple messages
     if (markerConfig.type === "chat_history" && expanded.messages) {
@@ -501,8 +531,11 @@ async function resolveSection(
       const agentType = markerConfig.agentType ?? "";
       ctx.macroCtx.agentData = {
         ...ctx.macroCtx.agentData,
-        [agentType]: expanded.content,
+        [agentType]: hasRuntimeAgentData ? runtimeAgentText : expanded.content,
       };
+      if (hasRuntimeAgentData) {
+        ctx.runtimeAgentTypesUsed.add(agentType);
+      }
       content = section.content;
     } else {
       // Other markers return content to be wrapped
@@ -518,15 +551,21 @@ async function resolveSection(
   // Resolve macros
   content = contentMacrosResolved ? content : resolveMacros(content, ctx.macroCtx);
   if (!content.trim()) return null;
+  const shouldWrapRuntimeAgentSection =
+    Boolean(runtimeAgentStartToken && runtimeAgentEndToken) && content.includes(runtimeAgentText);
 
   // Auto-wrap in the preset's format
   const wrapped = wrapContent(content, section.name, ctx.wrapFormat);
+  const messageContent =
+    shouldWrapRuntimeAgentSection
+      ? `${runtimeAgentStartToken}${wrapped || content}${runtimeAgentEndToken}`
+      : wrapped || content;
 
   return {
     id: section.id,
     groupId: section.groupId,
     role,
-    messages: [{ role, content: wrapped || content, contextKind: "prompt" }],
+    messages: [{ role, content: messageContent, contextKind: "prompt" }],
     depth: section.injectionDepth,
   };
 }

--- a/packages/server/test/lorebook-processing.test.ts
+++ b/packages/server/test/lorebook-processing.test.ts
@@ -585,6 +585,134 @@ test("multiple lorebook markers share one macro side-effect pass per prompt asse
   }
 });
 
+test("agent_data marker uses runtime agent data when supplied", async () => {
+  const client = createClient({ url: "file::memory:" });
+  const db = drizzle(client) as unknown as DB;
+
+  try {
+    await runMigrations(db);
+
+    const result = await assemblePrompt({
+      db,
+      preset: {
+        id: "preset-1",
+        name: "Preset",
+        sectionOrder: JSON.stringify(["knowledge-section"]),
+        groupOrder: "[]",
+        wrapFormat: "xml",
+        parameters: JSON.stringify(DEFAULT_GENERATION_PARAMS),
+        variableGroups: "[]",
+        variableValues: "{}",
+      },
+      sections: [
+        {
+          id: "knowledge-section",
+          presetId: "preset-1",
+          identifier: "agent_knowledge-retrieval",
+          name: "Knowledge Retrieval (Agent)",
+          content: "Fresh guidance:\n{{agent::knowledge-retrieval}}",
+          role: "system",
+          enabled: "true",
+          isMarker: "true",
+          groupId: null,
+          markerConfig: JSON.stringify({ type: "agent_data", agentType: "knowledge-retrieval" }),
+          injectionPosition: "ordered",
+          injectionDepth: 0,
+          injectionOrder: 0,
+          forbidOverrides: "false",
+        },
+      ],
+      groups: [],
+      choiceBlocks: [],
+      chatChoices: {},
+      chatId: "chat-1",
+      characterIds: [],
+      personaName: "User",
+      personaDescription: "",
+      chatMessages: [{ role: "user", content: "tell me about the library" }],
+      runtimeAgentData: {
+        "knowledge-retrieval": {
+          text: "The old library closes at dusk.",
+          startToken: "__runtime_start__",
+          endToken: "__runtime_end__",
+        },
+      },
+    });
+
+    const content = result.messages.map((message) => message.content).join("\n");
+    assert.match(content, /__runtime_start__/);
+    assert.match(content, /Fresh guidance:/);
+    assert.match(content, /The old library closes at dusk\./);
+    assert.match(content, /__runtime_end__/);
+    assert.deepEqual(result.runtimeAgentTypesUsed, ["knowledge-retrieval"]);
+  } finally {
+    client.close();
+  }
+});
+
+test("runtime agent section boundaries are skipped when the macro is absent", async () => {
+  const client = createClient({ url: "file::memory:" });
+  const db = drizzle(client) as unknown as DB;
+
+  try {
+    await runMigrations(db);
+
+    const result = await assemblePrompt({
+      db,
+      preset: {
+        id: "preset-1",
+        name: "Preset",
+        sectionOrder: JSON.stringify(["knowledge-section"]),
+        groupOrder: "[]",
+        wrapFormat: "xml",
+        parameters: JSON.stringify(DEFAULT_GENERATION_PARAMS),
+        variableGroups: "[]",
+        variableValues: "{}",
+      },
+      sections: [
+        {
+          id: "knowledge-section",
+          presetId: "preset-1",
+          identifier: "agent_knowledge-retrieval",
+          name: "Knowledge Retrieval (Agent)",
+          content: "Keep this custom instruction.",
+          role: "system",
+          enabled: "true",
+          isMarker: "true",
+          groupId: null,
+          markerConfig: JSON.stringify({ type: "agent_data", agentType: "knowledge-retrieval" }),
+          injectionPosition: "ordered",
+          injectionDepth: 0,
+          injectionOrder: 0,
+          forbidOverrides: "false",
+        },
+      ],
+      groups: [],
+      choiceBlocks: [],
+      chatChoices: {},
+      chatId: "chat-1",
+      characterIds: [],
+      personaName: "User",
+      personaDescription: "",
+      chatMessages: [{ role: "user", content: "hello" }],
+      runtimeAgentData: {
+        "knowledge-retrieval": {
+          text: "__placeholder__",
+          startToken: "__runtime_start__",
+          endToken: "__runtime_end__",
+        },
+      },
+    });
+
+    const content = result.messages.map((message) => message.content).join("\n");
+    assert.match(content, /Keep this custom instruction\./);
+    assert.doesNotMatch(content, /__runtime_start__/);
+    assert.doesNotMatch(content, /__runtime_end__/);
+  } finally {
+    client.close();
+  }
+});
+
 test("assembler can scan guide-only lorebook text without adding it to chat history", async () => {
   const client = createClient({ url: "file::memory:" });
   const db = drizzle(client) as unknown as DB;

--- a/packages/server/test/runtime-agent-section-cleanup.test.ts
+++ b/packages/server/test/runtime-agent-section-cleanup.test.ts
@@ -17,6 +17,21 @@ test("unused runtime agent section cleanup removes empty XML group wrappers", ()
   assert.deepEqual(messages, []);
 });
 
+test("removes empty XML group wrapper but preserves surrounding content", () => {
+  const messages = [
+    {
+      content:
+        "Before\n__start__<agent_group>\n    <knowledge_retrieval_agent>\n        __placeholder__\n    </knowledge_retrieval_agent>\n</agent_group>__end__\nAfter",
+    },
+  ];
+
+  clearUnusedRuntimeAgentSectionsForTest(messages, [
+    ["knowledge-retrieval", { placeholder: "__placeholder__", start: "__start__", end: "__end__" }],
+  ]);
+
+  assert.deepEqual(messages, [{ content: "Before\n\nAfter" }]);
+});
+
 test("unused runtime agent section cleanup removes empty Markdown group wrappers", () => {
   const messages = [
     {
@@ -29,4 +44,18 @@ test("unused runtime agent section cleanup removes empty Markdown group wrappers
   ]);
 
   assert.deepEqual(messages, []);
+});
+
+test("unused runtime agent section cleanup removes empty Markdown group wrappers but preserves surrounding content", () => {
+  const messages = [
+    {
+      content: "Before\n__start__# Agent Group\n## Knowledge Retrieval Agent\n__placeholder____end__\nAfter",
+    },
+  ];
+
+  clearUnusedRuntimeAgentSectionsForTest(messages, [
+    ["knowledge-retrieval", { placeholder: "__placeholder__", start: "__start__", end: "__end__" }],
+  ]);
+
+  assert.deepEqual(messages, [{ content: "Before\n\nAfter" }]);
 });

--- a/packages/server/test/runtime-agent-section-cleanup.test.ts
+++ b/packages/server/test/runtime-agent-section-cleanup.test.ts
@@ -1,0 +1,32 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { clearUnusedRuntimeAgentSectionsForTest } from "../src/routes/generate.routes.js";
+
+test("unused runtime agent section cleanup removes empty XML group wrappers", () => {
+  const messages = [
+    {
+      content:
+        "<agent_group>\n    __start__<knowledge_retrieval_agent>\n        __placeholder__\n    </knowledge_retrieval_agent>__end__\n</agent_group>",
+    },
+  ];
+
+  clearUnusedRuntimeAgentSectionsForTest(messages, [
+    ["knowledge-retrieval", { placeholder: "__placeholder__", start: "__start__", end: "__end__" }],
+  ]);
+
+  assert.deepEqual(messages, []);
+});
+
+test("unused runtime agent section cleanup removes empty Markdown group wrappers", () => {
+  const messages = [
+    {
+      content: "# Agent Group\n__start__## Knowledge Retrieval Agent\n__placeholder____end__",
+    },
+  ];
+
+  clearUnusedRuntimeAgentSectionsForTest(messages, [
+    ["knowledge-retrieval", { placeholder: "__placeholder__", start: "__start__", end: "__end__" }],
+  ]);
+
+  assert.deepEqual(messages, []);
+});


### PR DESCRIPTION
## Linked issue

Closes #828

## Why this change

- Knowledge Retrieval output could be generated when enabled through chat settings, but the same agent's "Add as Prompt Section" marker in an RP prompt preset resolved before the agent had fresh output, so the section was omitted from the prompt sent to the model.
- If Knowledge Retrieval or Knowledge Router is enabled through both chat settings and a prompt preset section, the output should be inserted once at the configured preset location.

## What changed

- Added runtime agent data support to prompt assembly so KR/Router agent marker sections can receive fresh per-generation output instead of stale saved runs.
- Updated generation routing to replace only nonce-scoped runtime marker placeholders and avoid duplicate append-at-end injection when a preset section handled the output.
- Removed unused runtime marker sections and empty group wrappers when KR/Router produce no output.
- Added focused server coverage for runtime agent marker insertion, macro-absent marker preservation, and cleanup of empty XML/Markdown grouped runtime sections.

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Automated validation run by Codex: `pnpm --filter @marinara-engine/server exec tsx --import ./test/setup-env.ts --test test/lorebook-processing.test.ts test/runtime-agent-section-cleanup.test.ts`; passed.
- Automated validation run by Codex: `pnpm check`; passed.
- Not run: desktop app RP prompt preset manual verification with a live Knowledge Retrieval source.
- Not run: Docker/Podman container verification.

## Docs and release impact

- [x] No docs changes needed
- [x] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [x] Version/release files updated (only if this PR includes a version bump)

No docs or release metadata changes expected; this is a narrow server prompt assembly and generation routing fix.

## UI evidence (if applicable)

N/A. Server prompt assembly behavior only; no UI surface changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runtime agent section support for knowledge-retrieval and knowledge-router preset outputs with token placeholders
  * Enhanced prompt assembly to better integrate agent-generated content with automatic cleanup of unused sections

* **Tests**
  * Added comprehensive tests for runtime agent section handling and prompt assembly with agent data

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/838)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->