### PR TITLE
Fix combat voice audio element calls

### DIFF
--- a/packages/client/src/components/game/GameCombatUI.tsx
+++ b/packages/client/src/components/game/GameCombatUI.tsx
@@ -729,7 +729,9 @@ export function GameCombatUI({
   const stopCombatVoicePlayback = useCallback(() => {
     combatVoiceSequenceRef.current += 1;
     if (combatVoiceAudioRef.current) {
-      combatVoiceAudioRef.current.stop();
+      combatVoiceAudioRef.current.pause();
+      combatVoiceAudioRef.current.onended = null;
+      combatVoiceAudioRef.current.onerror = null;
       combatVoiceAudioRef.current = null;
     }
     setCombatVoicePlaying(false);
@@ -841,8 +843,8 @@ export function GameCombatUI({
 
   useEffect(() => {
     if (!combatVoiceAudioRef.current) return;
-    combatVoiceAudioRef.current.setVolume(normalizedGameVoiceVolume);
-    combatVoiceAudioRef.current.setMuted(normalizedGameVoiceVolume <= 0);
+    audioManager.setMediaElementVolume(combatVoiceAudioRef.current, normalizedGameVoiceVolume);
+    combatVoiceAudioRef.current.muted = normalizedGameVoiceVolume <= 0;
   }, [normalizedGameVoiceVolume]);
 
   useEffect(() => {


### PR DESCRIPTION
## Linked issue

Closes #842

## Why this change

- `upstream/main` currently fails `pnpm build` in `GameCombatUI.tsx` because combat voice playback stores a browser `HTMLAudioElement` but calls custom audio-layer methods on it: `stop`, `setVolume`, and `setMuted`.

## What changed

- Stops combat voice playback with valid `HTMLAudioElement` APIs: `pause()`, cleared event handlers, and a nulled ref.
- Keeps the newer audio manager volume path by using `audioManager.setMediaElementVolume(...)`.
- Updates mute state through the native `HTMLAudioElement.muted` property.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Reproduced the failure with `pnpm --filter @marinara-engine/client build`; it failed on `HTMLAudioElement.stop`, `setVolume`, and `setMuted`.
- After the fix, `pnpm --filter @marinara-engine/client build` passed.
- After the fix, `pnpm check` passed.
- Local Docker container verification was not run because Docker Desktop / the Linux engine was not available on this machine.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs, release metadata, schema, dependency, or version files changed.

## UI evidence (if applicable)

N/A — this is a TypeScript build fix for combat voice playback.