### PR TITLE
fix(client): restore HTMLAudioElement calls in combat voice playback

### DIFF
--- a/packages/client/src/components/game/GameCombatUI.tsx
+++ b/packages/client/src/components/game/GameCombatUI.tsx
@@ -729,7 +729,9 @@ export function GameCombatUI({
   const stopCombatVoicePlayback = useCallback(() => {
     combatVoiceSequenceRef.current += 1;
     if (combatVoiceAudioRef.current) {
-      combatVoiceAudioRef.current.stop();
+      combatVoiceAudioRef.current.pause();
+      combatVoiceAudioRef.current.onended = null;
+      combatVoiceAudioRef.current.onerror = null;
       combatVoiceAudioRef.current = null;
     }
     setCombatVoicePlaying(false);
@@ -841,8 +843,8 @@ export function GameCombatUI({
 
   useEffect(() => {
     if (!combatVoiceAudioRef.current) return;
-    combatVoiceAudioRef.current.setVolume(normalizedGameVoiceVolume);
-    combatVoiceAudioRef.current.setMuted(normalizedGameVoiceVolume <= 0);
+    audioManager.setMediaElementVolume(combatVoiceAudioRef.current, normalizedGameVoiceVolume);
+    combatVoiceAudioRef.current.muted = normalizedGameVoiceVolume <= 0;
   }, [normalizedGameVoiceVolume]);
 
   useEffect(() => {


### PR DESCRIPTION
## Linked issue

Closes #842

## Why this change

The client build is currently broken on `main` (`fd768bfe`). `pnpm --filter @marinara-engine/client run build` (and `pnpm check`) fails with:

```
src/components/game/GameCombatUI.tsx(732,35): error TS2339: Property 'stop' does not exist on type 'HTMLAudioElement'.
src/components/game/GameCombatUI.tsx(844,33): error TS2551: Property 'setVolume' does not exist on type 'HTMLAudioElement'. Did you mean 'volume'?
src/components/game/GameCombatUI.tsx(845,33): error TS2339: Property 'setMuted' does not exist on type 'HTMLAudioElement'.
```

In `fd768bfe`, three calls in `GameCombatUI.tsx` were rewritten as if `combatVoiceAudioRef` held one of the audio layer handles from `packages/client/src/lib/game-audio.ts` (the `OneShotAudioLayer` / `LoopingAudioLayer` interfaces, which DO expose `stop` / `setVolume` / `setMuted`). It doesn't — `combatVoiceAudioRef` is `useRef<HTMLAudioElement | null>(null)` (line 634), assigned via `new Audio(url)` (line 781). So the three calls don't compile.

This blocks anyone building from `main`, including any autoDeploy pipeline pointed at it. The tagged `v1.5.9` release predates `fd768bfe`, so published artifacts aren't affected.

## What changed

`packages/client/src/components/game/GameCombatUI.tsx` only. Restored the three call sites to the `HTMLAudioElement` surface that the rest of the same component already uses on this ref:

- `stopCombatVoicePlayback` cleanup → `pause()` + clear `onended` / `onerror` (matches the pause/resume effect on line 821 already calling `.pause()` directly, and detaches the handlers assigned during playback).
- Volume-update effect → `audioManager.setMediaElementVolume(combatVoiceAudioRef.current, normalizedGameVoiceVolume)` + `audioManager` is already in scope and used the same way on the creation path (line 783). The mute toggle is set with direct `.muted =` assignment, mirroring line 784 in the same file.

No other files touched; no behavior change beyond restoring the pre-`fd768bfe` semantics.

## Validation

- [ ] ``pnpm check`` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Manually verify combat voice playback in Game Mode: trigger a combat turn that produces voice lines, confirm audio plays.
- Manually verify combat voice stop: cancel / switch turn mid-playback and confirm the audio stops cleanly with no error handler leftovers firing.
- Manually verify the game voice volume slider takes effect on an in-progress combat voice line (the path this PR re-fixes).
- Manually verify muting (slider at 0) silences in-progress combat voice without stopping playback.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

No UI surface changed; this is a build-time TS regression fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced audio playback cleanup and volume handling in combat scenarios for improved stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/844)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->