### PR TITLE
Fix disabled updater apply guidance

### DIFF
--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -13,7 +13,7 @@ import {
 import { cn } from "../../lib/utils";
 import { useExtensions, useCreateExtension, useDeleteExtension, useUpdateExtension } from "../../hooks/use-extensions";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { ADMIN_SECRET_STORAGE_KEY, api, getAdminSecretHeader } from "../../lib/api-client";
+import { ADMIN_SECRET_STORAGE_KEY, ApiError, api, getAdminSecretHeader } from "../../lib/api-client";
 import { chatBackgroundUrlToMetadata } from "../../lib/backgrounds";
 import { forceRefreshSpa } from "@/lib/browser-runtime";
 import React, { useRef, useState, useCallback, useEffect } from "react";
@@ -3002,6 +3002,7 @@ function AdvancedSettings() {
     applyAvailable?: boolean;
     updatesApplyEnabled?: boolean;
     applyUnavailableReason?: "disabled" | "unsupported-install" | null;
+    manualUpdateCommand?: string | null;
   }>({
     queryKey: ["update-check"],
     queryFn: () => api.get("/updates/check"),
@@ -3027,7 +3028,16 @@ function AdvancedSettings() {
       }
     },
     onError: (err: unknown) => {
-      const message = err instanceof Error ? err.message : "Update failed";
+      const message =
+        err instanceof ApiError &&
+        err.payload &&
+        typeof err.payload === "object" &&
+        "message" in err.payload &&
+        typeof err.payload.message === "string"
+          ? err.payload.message
+          : err instanceof Error
+            ? err.message
+            : "Update failed";
       toast.error(message);
     },
   });
@@ -3037,9 +3047,10 @@ function AdvancedSettings() {
   const currentBuildLabel = currentCommit ? `Build: ${currentCommit.slice(0, 7)}` : "Build: unavailable";
   const commitsBehind = updateCheck.data?.commitsBehind ?? 0;
   const applyUnavailableReason = updateCheck.data?.applyUnavailableReason ?? null;
+  const manualUpdateCommand = updateCheck.data?.manualUpdateCommand ?? null;
   const applyUnavailableCopy =
     applyUnavailableReason === "disabled"
-      ? "This install can check for updates, but applying them from the browser is disabled. Relaunch the app if you use the launcher, or update manually. Advanced git installs can enable server-side apply with UPDATES_APPLY_ENABLED=true."
+      ? "This install can check for updates, but applying them from the browser is disabled. Update manually with the command below. Advanced git installs can enable server-side apply with UPDATES_APPLY_ENABLED=true."
       : "This install can check for updates, but it cannot apply them from the browser. Relaunch the app if you use the launcher, or update manually for your install type.";
   const isClearing = clearAllData.isPending || expungeData.isPending;
   const isAllScopesSelected = selectedScopes.length === EXPUNGE_SCOPE_OPTIONS.length;
@@ -3214,11 +3225,11 @@ function AdvancedSettings() {
                     Android APK assets are WebView shells, not standalone apps. Start Marinara in Termux first.
                   </span>
                 )}
-                {applyUnavailableReason === "unsupported-install" && (
+                {manualUpdateCommand && (
                   <span className="text-[0.625rem] text-[var(--muted-foreground)]">
-                    Docker users:{" "}
-                    <code className="rounded bg-[var(--background)] px-1 py-0.5">
-                      docker compose pull && docker compose up -d
+                    Manual update:{" "}
+                    <code className="break-all rounded bg-[var(--background)] px-1 py-0.5">
+                      {manualUpdateCommand}
                     </code>
                   </span>
                 )}

--- a/packages/server/src/routes/updates.routes.ts
+++ b/packages/server/src/routes/updates.routes.ts
@@ -23,6 +23,8 @@ const UPDATE_REMOTE = "origin";
 const UPDATE_BRANCH = "main";
 const UPDATE_REF = `${UPDATE_REMOTE}/${UPDATE_BRANCH}`;
 const DEFAULT_PNPM_VERSION = "10.33.2";
+const MANUAL_GIT_UPDATE_COMMAND = "git pull && pnpm install && pnpm build && pnpm start";
+const DOCKER_UPDATE_COMMAND = "docker compose pull && docker compose up -d";
 const ANDROID_APK_NOTICE =
   "> [!IMPORTANT]\n" +
   "> **Android APK notice:** The APK is not a standalone Marinara Engine app yet. It is a WebView shell for the local Marinara server, so Termux must be installed and `./start-termux.sh` must be running on the same Android device before you open the APK.";
@@ -320,6 +322,7 @@ function getApplyAvailability(gitInstall: boolean) {
       applyAvailable: false,
       updatesApplyEnabled: enabled,
       applyUnavailableReason: "unsupported-install",
+      manualUpdateCommand: DOCKER_UPDATE_COMMAND,
     };
   }
   if (!enabled) {
@@ -327,12 +330,14 @@ function getApplyAvailability(gitInstall: boolean) {
       applyAvailable: false,
       updatesApplyEnabled: false,
       applyUnavailableReason: "disabled",
+      manualUpdateCommand: MANUAL_GIT_UPDATE_COMMAND,
     };
   }
   return {
     applyAvailable: true,
     updatesApplyEnabled: true,
     applyUnavailableReason: null,
+    manualUpdateCommand: null,
   };
 }
 
@@ -422,10 +427,23 @@ export async function updatesRoutes(app: FastifyInstance) {
   // POST /api/updates/apply
   // Fast-forwards to origin/main, installs, rebuilds, then signals the process to restart.
   app.post<{ Body: ApplyUpdateBody }>("/apply", async (req, reply) => {
+    if (!isGitInstall()) {
+      return reply.status(400).send({
+        error: "Auto-update apply is unavailable for this install type",
+        message: `Auto-update is only available for git-based installs. For Docker, run: ${DOCKER_UPDATE_COMMAND}`,
+        installType: "standalone",
+        applyUnavailableReason: "unsupported-install",
+        manualUpdateCommand: DOCKER_UPDATE_COMMAND,
+      });
+    }
+
     if (!isUpdatesApplyEnabled()) {
       return reply.status(403).send({
-        error: "Auto-update apply is disabled",
-        message: "Set UPDATES_APPLY_ENABLED=true to enable server-side update application.",
+        error: "Auto-update apply is disabled for this install",
+        message: `Update manually with: ${MANUAL_GIT_UPDATE_COMMAND}. Advanced git installs can enable server-side update application with UPDATES_APPLY_ENABLED=true.`,
+        installType: "git",
+        applyUnavailableReason: "disabled",
+        manualUpdateCommand: MANUAL_GIT_UPDATE_COMMAND,
       });
     }
 
@@ -436,14 +454,6 @@ export async function updatesRoutes(app: FastifyInstance) {
       })
     ) {
       return;
-    }
-
-    if (!isGitInstall()) {
-      return reply.status(400).send({
-        error:
-          "Auto-update is only available for git-based installs. For Docker, run: docker compose pull && docker compose up -d",
-        installType: "standalone",
-      });
     }
 
     const root = getMonorepoRoot();


### PR DESCRIPTION
## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #856

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- The updater apply path could surface `Auto-update apply is disabled` without a useful next step, leaving source/git install users unable to tell how to update manually.

## What changed

<!-- List the key changes in this PR -->

- Return manual update commands and structured unavailable reasons from the update apply/check responses.
- Show the manual update command in Advanced settings when browser-based apply is unavailable.
- Prefer the server's user-facing `message` in the update-apply error toast.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- âš ï¸ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Codex repro before fix: `pnpm --filter @marinara-engine/server exec tsx C:\tmp\Marinara-Engine-issue-856\scratch\issue-856-update-apply-repro.mjs` returned `403` with `error: "Auto-update apply is disabled"` and only the `UPDATES_APPLY_ENABLED=true` hint.
- Codex repro after fix: the same command returns `403` with `message: "Update manually with: git pull && pnpm install && pnpm build && pnpm start..."`, `applyUnavailableReason: "disabled"`, and `manualUpdateCommand`.
- Codex baseline: `pnpm check` passed.
- Playwright MCP screenshot capture was unavailable because the local MCP browser profile was locked; this issue is a backend/API error-path fix, and the raw before/after command outputs are saved locally under `scratch/issue-856-before.json` and `scratch/issue-856-after.json`.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No version, schema, dependency, release metadata, or docs files were changed.

## UI evidence (if applicable)

N/A. The issue is the update-apply API/error guidance; validation is the before/after route repro above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error messaging when update operations fail, displaying actionable guidance to users

* **New Features**
  * Update UI now displays manual update commands tailored to your installation type and configuration, replacing generic placeholder text
  * Clearer messaging indicating why automatic updates are unavailable in your environment

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/866)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->