### PR TITLE
Fix Conversation generation abort on passive disconnect

### DIFF
--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -147,6 +147,7 @@ import {
   resolveRegenerationGameStateAnchor,
   resolveVisibleGameStateAnchor,
   shouldPreferLatestVisibleGameState,
+  shouldAbortOnPassiveGenerationDisconnect,
   shouldEnableAgentsForGeneration,
   wrapFields,
   type PromptAttachment,
@@ -883,8 +884,24 @@ export async function generateRoutes(app: FastifyInstance) {
     startSseReply(reply, { "X-Accel-Buffering": "no" });
 
     let generationComplete = false;
+    let clientDisconnected = false;
+    const originalSseWrite = reply.raw.write.bind(reply.raw);
+    reply.raw.write = ((chunk: any, encodingOrCallback?: any, callback?: any) => {
+      if (clientDisconnected || reply.raw.destroyed) return false;
+      try {
+        return originalSseWrite(chunk, encodingOrCallback, callback);
+      } catch {
+        return false;
+      }
+    }) as typeof reply.raw.write;
+
     const onClose = () => {
       if (generationComplete) return;
+      clientDisconnected = true;
+      if (!shouldAbortOnPassiveGenerationDisconnect({ chatMode: requestChatMode, impersonate: input.impersonate })) {
+        logger.info("[generate] Conversation client disconnected; generation will continue for chat: %s", input.chatId);
+        return;
+      }
       logger.info("[abort] Client disconnected — aborting generation");
       abortController.abort();
       if (activeGenerations) activeGenerations.delete(input.chatId);
@@ -9379,7 +9396,9 @@ export async function generateRoutes(app: FastifyInstance) {
       }
       reply.raw.off("close", onClose);
       if (activeGenerations) activeGenerations.delete(input.chatId);
-      reply.raw.end();
+      if (!clientDisconnected && !reply.raw.destroyed) {
+        reply.raw.end();
+      }
     }
   });
 

--- a/packages/server/src/routes/generate/generate-route-utils.ts
+++ b/packages/server/src/routes/generate/generate-route-utils.ts
@@ -36,6 +36,13 @@ function isPlainRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
 }
 
+export function shouldAbortOnPassiveGenerationDisconnect(args: {
+  chatMode: string;
+  impersonate?: boolean;
+}): boolean {
+  return args.chatMode !== "conversation" || args.impersonate === true;
+}
+
 export function mergeCustomParameters(
   base: Record<string, unknown> | null | undefined,
   next: Record<string, unknown> | null | undefined,

--- a/packages/server/test/generate-route-utils.test.ts
+++ b/packages/server/test/generate-route-utils.test.ts
@@ -1,6 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { shouldEnableAgentsForGeneration } from "../src/routes/generate/generate-route-utils.js";
+import {
+  shouldAbortOnPassiveGenerationDisconnect,
+  shouldEnableAgentsForGeneration,
+} from "../src/routes/generate/generate-route-utils.js";
 
 test("disables agents before resolution when impersonate blocks agents", () => {
   assert.equal(
@@ -82,4 +85,27 @@ test("keeps conversation mode agent pipeline disabled", () => {
     }),
     false,
   );
+});
+
+test("does not abort normal conversation generation on passive SSE disconnect", () => {
+  assert.equal(
+    shouldAbortOnPassiveGenerationDisconnect({
+      chatMode: "conversation",
+      impersonate: false,
+    }),
+    false,
+  );
+});
+
+test("keeps passive disconnect aborts for non-conversation or impersonation generations", () => {
+  const cases = [
+    { chatMode: "conversation", impersonate: true },
+    { chatMode: "roleplay", impersonate: false },
+    { chatMode: "game", impersonate: false },
+    { chatMode: "visual_novel", impersonate: false },
+  ];
+
+  for (const item of cases) {
+    assert.equal(shouldAbortOnPassiveGenerationDisconnect(item), true);
+  }
 });


### PR DESCRIPTION
## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #853

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- In Docker Conversation mode, a passive SSE disconnect after the user switches focus could be treated like an explicit cancel, aborting the LinkAPI provider call and surfacing a generic network error.

## What changed

<!-- List the key changes in this PR -->

- Kept explicit `/api/generate/abort` cancellation behavior intact.
- Changed passive SSE close handling so normal Conversation generations continue and persist even if the client disconnects mid-generation.
- Guarded server-side SSE writes after passive disconnect so background completion does not throw on a closed response stream.
- Added regression coverage for the passive-disconnect abort policy.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

Automated verification performed:

- `pnpm --dir packages/server exec tsx --import ./test/setup-env.ts --test test/generate-route-utils.test.ts` passed.
- `pnpm check` passed.

Suggested manual verification:

1. Run Marinara Engine through Docker with a LinkAPI text connection configured.
2. Open or create a Conversation-mode chat using that connection.
3. Send a message that takes long enough to generate that you can switch focus while it is running.
4. Switch to another browser tab, another app, or another screen before the response completes.
5. Return to Marinara Engine and confirm the assistant response completes or appears after refresh without a generic LinkAPI `network error`.
6. Repeat once using the Stop button during generation and confirm explicit cancellation still stops the request.

## Docs and release impact

- [x] No docs changes needed
- [x] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [x] Version/release files updated (only if this PR includes a version bump)

No docs, schema, release metadata, dependency, or version files were changed.

## UI evidence (if applicable)

<img width="292" height="213" alt="image" src="https://github.com/user-attachments/assets/8fa4d37f-d870-4895-bfd9-ab4efc7191f2" />


N/A. This is a server-side generation lifecycle fix; no UI surface was changed.
