### PR TITLE
chore: staging-first policy note + pnpm supply-chain guardrails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ This file is a thin maintainer note for contributors using Codex. Canonical work
 ## Repo-Specific Cautions
 
 - Keep edits non-destructive. Do not revert unrelated work in the tree.
+- Make Marinara Engine changes against `staging` first; do not target `main` directly unless the user or maintainer explicitly asks for a mainline change.
 - Prefer focused patches that keep code, docs, and release metadata aligned in the same change.
 - Agent-specific coordination rule: before starting issue work, check for an existing issue-linked branch, open PR, draft PR, or project board item so multiple agents do not duplicate effort. See `CONTRIBUTING.md` for the general contributor workflow.
 - Agent-specific coordination rule: when implementation effort starts for an issue, open a draft PR immediately so the project Kanban board shows the work in progress.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,9 @@
 packages:
   - "packages/*"
+
+# Supply-chain guardrails: delay newly published package versions long enough for
+# registry takedowns and advisory systems to catch common compromise waves.
+minimumReleaseAge: 1440
+minimumReleaseAgeIgnoreMissingTime: false
+trustPolicy: no-downgrade
+blockExoticSubdeps: true


### PR DESCRIPTION
## Linked issue

No tracking issue — bundling two small repo-hygiene changes that surfaced together.

## Why this change

- **Staging-first branch policy isn't documented for agents.** The repo uses `staging` as the integration branch ahead of `main`, but `AGENTS.md` doesn't say so, and agents (Codex and others) have been opening PRs directly against `main`. One bullet under the existing Repo-Specific Cautions stops that without needing a wider CONTRIBUTING rewrite.
- **No supply-chain guardrails on the workspace.** pnpm ships settings (`minimumReleaseAge` etc.) for exactly the npm-compromise wave class of incident. Adopting them in `pnpm-workspace.yaml` costs nothing for normal upgrades and gives the registry / advisory ecosystem a ~24h window to catch malicious publishes before our installs pick them up.

## What changed

**`AGENTS.md`** — one bullet under "Repo-Specific Cautions" stating that Marinara Engine changes go against `staging` first, and that `main` should only be targeted when the user or maintainer explicitly asks.

**`pnpm-workspace.yaml`** — added pnpm supply-chain guardrails:
- `minimumReleaseAge: 1440` — 24h hold on newly published package versions.
- `minimumReleaseAgeIgnoreMissingTime: false` — when pnpm can't determine a publish time, treat that as a reason to block rather than let the version through.
- `trustPolicy: no-downgrade` — refuse resolutions that would downgrade relative to the lockfile.
- `blockExoticSubdeps: true` — refuse non-registry (git URL / tarball) transitive deps appearing deep in the tree.

Existing installs are unaffected because the lockfile already pins versions older than 24h.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

Docs + workspace-config only — no runtime behavior change, so UI / container / edge-case checks aren't meaningful here. The pnpm settings are inert until someone adds or upgrades a dep; the lockfile-pinned graph keeps resolving as-is.

- The `AGENTS.md` bullet lives in the existing Repo-Specific Cautions list, so it inherits whatever path agents already follow for that section.
- The `pnpm-workspace.yaml` keys take effect on the next install / upgrade; no migration step is required for current workspaces.

Leaving the `pnpm check` / container boxes unchecked so a maintainer can re-verify on their own setup.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

`AGENTS.md` is itself the contributor-facing doc being updated — no README / CONTRIBUTING / CHANGELOG sync is needed to match.

## UI evidence (if applicable)

N/A — no UI changes.