### PR TITLE
feat(lorebooks): ReDoS hardening for keyword regex activation

### DIFF
--- a/packages/server/src/services/lorebook/keyword-scanner.ts
+++ b/packages/server/src/services/lorebook/keyword-scanner.ts
@@ -12,6 +12,7 @@ import type {
   LorebookSchedule,
 } from "@marinara-engine/shared";
 import { testPrimaryKeys, testSecondaryKeys } from "@marinara-engine/shared";
+import { vmRegexExecutor } from "./regex-timeout.js";
 
 /** Compute cosine similarity between two vectors. Returns 0 for empty/mismatched vectors. */
 function cosineSimilarity(a: number[], b: number[]): number {
@@ -463,6 +464,7 @@ export function scanForActivatedEntries(
       useRegex: entry.useRegex,
       matchWholeWords: entry.matchWholeWords,
       caseSensitive: entry.caseSensitive,
+      regexExecutor: vmRegexExecutor,
     };
 
     // Test primary keys

--- a/packages/server/src/services/lorebook/regex-timeout.ts
+++ b/packages/server/src/services/lorebook/regex-timeout.ts
@@ -1,0 +1,55 @@
+// Server-side execution timeout for compiled regex tests against chat context.
+//
+// The shared static check (isPatternSafe) catches the common ReDoS shapes before
+// compilation, but expert-crafted patterns can still pass that check and explode
+// on specific input. This wrapper runs the regex.test call inside a fresh V8 vm
+// context with a hard timeout — the engine inserts interrupt checks during
+// regex execution, so catastrophic backtracking aborts instead of stalling the
+// event loop indefinitely.
+//
+// On timeout: log a warning with the pattern source so the lorebook author can
+// see why an entry stopped activating, and return false. We deliberately do NOT
+// fall back to literal substring on timeout — the pattern compiled and may have
+// matched on simpler input; substituting literal-substring semantics here would
+// cause silent surprise matches.
+
+import * as vm from "node:vm";
+import { logger } from "../../lib/logger.js";
+
+/** Default per-call timeout for a single regex.test against chat context, in ms. */
+export const DEFAULT_REGEX_TIMEOUT_MS = 50;
+
+/** Build a regex executor that runs `regex.test(text)` under a vm timeout. */
+export function createTimeoutRegexExecutor(timeoutMs: number = DEFAULT_REGEX_TIMEOUT_MS) {
+  return function vmRegexExecutor(regex: RegExp, text: string): boolean {
+    // The vm context only needs the regex + text; we recompile inside the vm so
+    // the interrupt check is wired through the new isolate's regex execution.
+    const context = vm.createContext({ __pattern: regex.source, __flags: regex.flags, __text: text });
+    try {
+      const result = vm.runInContext("(new RegExp(__pattern, __flags)).test(__text)", context, {
+        timeout: timeoutMs,
+        displayErrors: false,
+      });
+      return Boolean(result);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      // V8 surfaces timeouts as "Script execution timed out." — log warn and skip the entry.
+      if (message.includes("timed out")) {
+        logger.warn(
+          "Lorebook regex /%s/%s exceeded %dms timeout against chat context (length=%d) — entry will not match this scan",
+          regex.source,
+          regex.flags,
+          timeoutMs,
+          text.length,
+        );
+        return false;
+      }
+      // Anything else (rare — invalid regex would have thrown earlier) — let testKeyword's
+      // outer catch handle it via its literal-substring fallback by re-throwing.
+      throw err;
+    }
+  };
+}
+
+/** Default executor used by keyword-scanner.ts. */
+export const vmRegexExecutor = createTimeoutRegexExecutor();

--- a/packages/server/src/services/lorebook/regex-timeout.ts
+++ b/packages/server/src/services/lorebook/regex-timeout.ts
@@ -44,8 +44,11 @@ export function createTimeoutRegexExecutor(timeoutMs: number = DEFAULT_REGEX_TIM
         );
         return false;
       }
-      // Anything else (rare — invalid regex would have thrown earlier) — let testKeyword's
-      // outer catch handle it via its literal-substring fallback by re-throwing.
+      // Contract: non-timeout errors (rare — invalid regex would have thrown at compile time
+      // upstream, before we got here) are re-thrown so testKeyword's outer try/catch can swap
+      // in its literal-substring fallback. Do NOT swallow here — that catch in
+      // packages/shared/src/utils/lorebook-keyword-matching.ts is the intended landing pad,
+      // and silently returning false would mask a real executor-side bug.
       throw err;
     }
   };

--- a/packages/server/test/lorebook-regex-safety.test.ts
+++ b/packages/server/test/lorebook-regex-safety.test.ts
@@ -1,0 +1,93 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { isPatternSafe, testKeyword } from "@marinara-engine/shared";
+import { createTimeoutRegexExecutor } from "../src/services/lorebook/regex-timeout.js";
+
+test("isPatternSafe accepts simple safe patterns", () => {
+  assert.equal(isPatternSafe(""), true);
+  assert.equal(isPatternSafe("foo"), true);
+  assert.equal(isPatternSafe("foo|bar"), true);
+  assert.equal(isPatternSafe("foo+"), true);
+  assert.equal(isPatternSafe("foo.*bar"), true);
+  assert.equal(isPatternSafe("(foo)"), true);
+  assert.equal(isPatternSafe("(foo)+"), true);
+  assert.equal(isPatternSafe("\\d+"), true);
+  assert.equal(isPatternSafe("[a-z]+"), true);
+  assert.equal(isPatternSafe("[^abc]*"), true);
+  assert.equal(isPatternSafe("\\bword\\b"), true);
+  assert.equal(isPatternSafe("(?:foo|bar){1,5}"), true);
+  assert.equal(isPatternSafe("(?<name>foo)"), true);
+  assert.equal(isPatternSafe("foo(?=bar)"), true);
+});
+
+test("isPatternSafe rejects nested-quantifier ReDoS shapes", () => {
+  assert.equal(isPatternSafe("(a+)+"), false);
+  assert.equal(isPatternSafe("(a*)*"), false);
+  assert.equal(isPatternSafe("(a+)*"), false);
+  assert.equal(isPatternSafe("(a*)+"), false);
+  assert.equal(isPatternSafe("(a+|b)+"), false);
+  assert.equal(isPatternSafe("(.*)+"), false);
+  assert.equal(isPatternSafe("(\\d+)+$"), false);
+  assert.equal(isPatternSafe("((ab)+)+"), false);
+});
+
+test("isPatternSafe rejects oversized patterns and pathological repetition", () => {
+  assert.equal(isPatternSafe("a".repeat(1001)), false);
+  assert.equal(isPatternSafe("a{1,200}"), false);
+  assert.equal(isPatternSafe("a{500}"), false);
+  assert.equal(isPatternSafe("a{1,}"), false); // unbounded upper -> Infinity > maxRepetition
+  assert.equal(isPatternSafe("a{1,99}"), true);
+});
+
+test("isPatternSafe handles unbalanced groups defensively", () => {
+  assert.equal(isPatternSafe("(foo"), false);
+  assert.equal(isPatternSafe("foo)"), false);
+  assert.equal(isPatternSafe("[foo"), false);
+});
+
+test("testKeyword falls back to literal substring on unsafe regex", () => {
+  // (a+)+ is unsafe; with literal-substring fallback the keyword "(a+)+" matches
+  // only text containing the literal string "(a+)+", not arbitrary "aaaa".
+  assert.equal(
+    testKeyword("(a+)+", "aaaaaaaaaaaaaaaaaaaa", { useRegex: true, matchWholeWords: false, caseSensitive: false }),
+    false,
+  );
+  assert.equal(
+    testKeyword("(a+)+", "the literal (a+)+ token", { useRegex: true, matchWholeWords: false, caseSensitive: false }),
+    true,
+  );
+});
+
+test("testKeyword still matches safe regex patterns end-to-end", () => {
+  assert.equal(
+    testKeyword("foo|bar", "the bar is open", { useRegex: true, matchWholeWords: false, caseSensitive: false }),
+    true,
+  );
+  assert.equal(
+    testKeyword("\\bword\\b", "this is a word here", { useRegex: true, matchWholeWords: false, caseSensitive: false }),
+    true,
+  );
+});
+
+test("vmRegexExecutor aborts catastrophic backtracking under timeout", () => {
+  // Construct the canonical ReDoS pair at runtime so isPatternSafe doesn't see the source.
+  // (We're testing the SECOND line of defense — assume isPatternSafe was bypassed.)
+  const evilSource = "^" + "(a|aa)+".slice(0) + "$"; // literal "^(a|aa)+$"
+  const regex = new RegExp(evilSource);
+  const exec = createTimeoutRegexExecutor(50);
+  const start = Date.now();
+  const result = exec(regex, "a".repeat(28) + "!");
+  const elapsed = Date.now() - start;
+  // Either we got a quick false (timeout fired) or, on faster hardware, the regex completed —
+  // but it MUST not run for orders of magnitude past the timeout.
+  assert.equal(result, false);
+  assert.ok(elapsed < 1000, `expected timeout to abort within ~1s, took ${elapsed}ms`);
+});
+
+test("vmRegexExecutor passes safe patterns through unchanged", () => {
+  const exec = createTimeoutRegexExecutor(50);
+  assert.equal(exec(/foo/, "foo bar"), true);
+  assert.equal(exec(/foo/, "baz qux"), false);
+  assert.equal(exec(/^\d+$/, "12345"), true);
+  assert.equal(exec(/^\d+$/, "12a45"), false);
+});

--- a/packages/server/test/lorebook-regex-safety.test.ts
+++ b/packages/server/test/lorebook-regex-safety.test.ts
@@ -70,16 +70,16 @@ test("testKeyword still matches safe regex patterns end-to-end", () => {
 });
 
 test("vmRegexExecutor aborts catastrophic backtracking under timeout", () => {
-  // Construct the canonical ReDoS pair at runtime so isPatternSafe doesn't see the source.
-  // (We're testing the SECOND line of defense — assume isPatternSafe was bypassed.)
-  const evilSource = "^" + "(a|aa)+".slice(0) + "$"; // literal "^(a|aa)+$"
-  const regex = new RegExp(evilSource);
+  // The canonical alternation-overlap ReDoS shape passes isPatternSafe (star-height 1)
+  // but still backtracks catastrophically on the right input. This is exactly the case
+  // the executor's timeout is for — the static check can't predict input-dependent blow-up.
+  const regex = /^(a|aa)+$/;
   const exec = createTimeoutRegexExecutor(50);
   const start = Date.now();
   const result = exec(regex, "a".repeat(28) + "!");
   const elapsed = Date.now() - start;
-  // Either we got a quick false (timeout fired) or, on faster hardware, the regex completed —
-  // but it MUST not run for orders of magnitude past the timeout.
+  // Either timeout fired (result false, elapsed ~50-200ms) or the regex completed quickly
+  // on faster hardware — either way it must NOT pin the thread for orders of magnitude past the timeout.
   assert.equal(result, false);
   assert.ok(elapsed < 1000, `expected timeout to abort within ~1s, took ${elapsed}ms`);
 });

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -59,3 +59,4 @@ export * from "./utils/regex-replacement.js";
 export * from "./utils/skill-check-format.js";
 export * from "./utils/generation-guide.js";
 export * from "./utils/lorebook-keyword-matching.js";
+export * from "./utils/regex-safety.js";

--- a/packages/shared/src/utils/lorebook-keyword-matching.ts
+++ b/packages/shared/src/utils/lorebook-keyword-matching.ts
@@ -3,40 +3,58 @@
 // preview cannot drift from the real activation rules.
 
 import type { SelectiveLogic } from "../types/lorebook.js";
+import { isPatternSafe } from "./regex-safety.js";
+
+/** Pluggable executor for compiled regex test calls. Server passes a vm-timeout-bounded executor. */
+export type RegexExecutor = (regex: RegExp, text: string) => boolean;
+
+const defaultRegexExecutor: RegexExecutor = (regex, text) => regex.test(text);
 
 export interface KeywordMatchOptions {
   useRegex: boolean;
   matchWholeWords: boolean;
   caseSensitive: boolean;
+  /** Optional override for executing the compiled regex. Server injects a vm.runInNewContext-bounded
+   *  executor so a pathological pattern that survived the static safety check can still be aborted. */
+  regexExecutor?: RegexExecutor;
+}
+
+function literalMatch(keyword: string, text: string, options: KeywordMatchOptions): boolean {
+  const needle = options.caseSensitive ? keyword : keyword.toLowerCase();
+  const haystack = options.caseSensitive ? text : text.toLowerCase();
+  return haystack.includes(needle);
 }
 
 /** Test whether a single keyword would match the given text under the given options. */
 export function testKeyword(keyword: string, text: string, options: KeywordMatchOptions): boolean {
   if (!keyword) return false;
+  const exec = options.regexExecutor ?? defaultRegexExecutor;
 
   try {
     if (options.useRegex) {
+      // Static ReDoS guard: refuse to compile patterns with nested quantifiers,
+      // pathological repetition counts, or oversized sources. Fall back to literal
+      // substring match — same posture as the existing invalid-regex catch below.
+      if (!isPatternSafe(keyword)) {
+        return literalMatch(keyword, text, options);
+      }
       const flags = options.caseSensitive ? "g" : "gi";
       const regex = new RegExp(keyword, flags);
-      return regex.test(text);
+      return exec(regex, text);
     }
 
-    const needle = options.caseSensitive ? keyword : keyword.toLowerCase();
-    const haystack = options.caseSensitive ? text : text.toLowerCase();
-
     if (options.matchWholeWords) {
+      const needle = options.caseSensitive ? keyword : keyword.toLowerCase();
       const escaped = needle.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
       const flags = options.caseSensitive ? "g" : "gi";
       const regex = new RegExp(`\\b${escaped}\\b`, flags);
-      return regex.test(text);
+      return exec(regex, text);
     }
 
-    return haystack.includes(needle);
+    return literalMatch(keyword, text, options);
   } catch {
-    // Invalid regex — fall back to plain substring
-    const needle = options.caseSensitive ? keyword : keyword.toLowerCase();
-    const haystack = options.caseSensitive ? text : text.toLowerCase();
-    return haystack.includes(needle);
+    // Invalid regex or executor failure — fall back to plain substring
+    return literalMatch(keyword, text, options);
   }
 }
 

--- a/packages/shared/src/utils/lorebook-keyword-matching.ts
+++ b/packages/shared/src/utils/lorebook-keyword-matching.ts
@@ -14,8 +14,11 @@ export interface KeywordMatchOptions {
   useRegex: boolean;
   matchWholeWords: boolean;
   caseSensitive: boolean;
-  /** Optional override for executing the compiled regex. Server injects a vm.runInNewContext-bounded
-   *  executor so a pathological pattern that survived the static safety check can still be aborted. */
+  /** Optional override for executing user-supplied regex patterns. Server injects a
+   *  vm.runInNewContext-bounded executor so a pathological pattern that survived the
+   *  static safety check can still be aborted. Only applied to the `useRegex` path —
+   *  the matchWholeWords branch builds its regex from escaped-literal text and cannot
+   *  ReDoS, so it skips the executor (and its per-call vm overhead). */
   regexExecutor?: RegexExecutor;
 }
 
@@ -28,7 +31,6 @@ function literalMatch(keyword: string, text: string, options: KeywordMatchOption
 /** Test whether a single keyword would match the given text under the given options. */
 export function testKeyword(keyword: string, text: string, options: KeywordMatchOptions): boolean {
   if (!keyword) return false;
-  const exec = options.regexExecutor ?? defaultRegexExecutor;
 
   try {
     if (options.useRegex) {
@@ -40,6 +42,7 @@ export function testKeyword(keyword: string, text: string, options: KeywordMatch
       }
       const flags = options.caseSensitive ? "g" : "gi";
       const regex = new RegExp(keyword, flags);
+      const exec = options.regexExecutor ?? defaultRegexExecutor;
       return exec(regex, text);
     }
 
@@ -48,7 +51,8 @@ export function testKeyword(keyword: string, text: string, options: KeywordMatch
       const escaped = needle.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
       const flags = options.caseSensitive ? "g" : "gi";
       const regex = new RegExp(`\\b${escaped}\\b`, flags);
-      return exec(regex, text);
+      // No regexExecutor here — pattern is built from escaped-literal text, can't ReDoS.
+      return regex.test(text);
     }
 
     return literalMatch(keyword, text, options);

--- a/packages/shared/src/utils/regex-safety.ts
+++ b/packages/shared/src/utils/regex-safety.ts
@@ -50,7 +50,6 @@ export function isPatternSafe(source: string, options: PatternSafetyOptions = {}
   // regex parser to catch the common ReDoS shapes.
 
   let i = 0;
-  let inCharClass = false;
   let groupDepth = 0;
   // For each open group, the running max star height of atoms inside it.
   const groupInnerHeight: number[] = [];
@@ -87,23 +86,15 @@ export function isPatternSafe(source: string, options: PatternSafetyOptions = {}
       return false; // Trailing backslash
     }
 
-    if (inCharClass) {
-      if (c === "]") inCharClass = false;
-      i += 1;
-      continue;
-    }
-
     if (c === "[") {
-      inCharClass = true;
-      // Character class is one atom; check for quantifier after the closing ]
-      // We'll re-check height when we hit ]; simpler to look ahead.
+      // Character class is one atom; consume the whole class via lookahead and
+      // pick up any quantifier sitting after the closing `]`.
       const closeIdx = findCharClassClose(source, i);
       if (closeIdx === -1) return false;
       const after = source[closeIdx + 1];
       const quantHeight = isQuantifierStart(after) ? 1 : 0;
       recordAtomHeight(quantHeight);
       i = closeIdx + 1;
-      inCharClass = false;
       if (quantHeight > 0) {
         const consumed = consumeQuantifier(source, i, maxRepetition);
         if (consumed === null) return false;
@@ -161,7 +152,7 @@ export function isPatternSafe(source: string, options: PatternSafetyOptions = {}
     }
   }
 
-  if (groupDepth !== 0 || inCharClass) return false; // Unbalanced
+  if (groupDepth !== 0) return false; // Unbalanced
   if (topLevelHeight > maxStarHeight) return false;
   return true;
 }

--- a/packages/shared/src/utils/regex-safety.ts
+++ b/packages/shared/src/utils/regex-safety.ts
@@ -1,0 +1,215 @@
+// Static safety heuristic for user-supplied regex patterns.
+//
+// Catches the most common ReDoS shapes — nested quantifiers like (a+)+, (a*)*,
+// (a+|b)+ — plus pathological repetition counts and oversized sources, before
+// the pattern is ever handed to RegExp.
+//
+// Not a full safe-regex replacement: false negatives are possible against
+// expert-crafted patterns that pass star-height inspection but still backtrack
+// catastrophically. The server-side timeout executor in
+// packages/server/src/services/lorebook/regex-timeout.ts is the second line of
+// defense for those cases.
+
+export interface PatternSafetyOptions {
+  /** Reject any source string longer than this. Default 1000. */
+  maxLength?: number;
+  /** Reject star height greater than this. 1 allows `a+`, `(a+)`, `(a)+`; rejects `(a+)+`. Default 1. */
+  maxStarHeight?: number;
+  /** Reject `{n,m}` (or `{n,}`) where m (or the unbounded upper) exceeds this. Default 100. */
+  maxRepetition?: number;
+}
+
+const DEFAULTS: Required<PatternSafetyOptions> = {
+  maxLength: 1000,
+  maxStarHeight: 1,
+  maxRepetition: 100,
+};
+
+/**
+ * Decide whether a regex source string is safe to compile and run against
+ * untrusted input. Returns false for patterns likely to cause catastrophic
+ * backtracking; the caller should fall back to literal substring matching.
+ */
+export function isPatternSafe(source: string, options: PatternSafetyOptions = {}): boolean {
+  const { maxLength, maxStarHeight, maxRepetition } = { ...DEFAULTS, ...options };
+
+  if (typeof source !== "string") return false;
+  if (source.length === 0) return true;
+  if (source.length > maxLength) return false;
+
+  // Walk the source once, tracking:
+  //   - whether we are inside a character class (where quantifier semantics differ)
+  //   - whether the previous character is escaped
+  //   - the stack of group "has-quantifier-after-close" markers, to compute star height
+  //
+  // Star height here is the maximum number of nested groups whose closing `)`
+  // is followed by a quantifier (`*`, `+`, `?`, `{n,m}`), counted along with
+  // immediate-quantifier atoms. A bare `a+` has star height 1; `(a+)+` has 2.
+  //
+  // The walker is deliberately conservative — it does not need to be a full
+  // regex parser to catch the common ReDoS shapes.
+
+  let i = 0;
+  let inCharClass = false;
+  let groupDepth = 0;
+  // For each open group, the running max star height of atoms inside it.
+  const groupInnerHeight: number[] = [];
+  let topLevelHeight = 0;
+
+  const recordAtomHeight = (h: number) => {
+    if (groupDepth > 0) {
+      const idx = groupInnerHeight.length - 1;
+      if (h > groupInnerHeight[idx]!) groupInnerHeight[idx] = h;
+    } else if (h > topLevelHeight) {
+      topLevelHeight = h;
+    }
+  };
+
+  while (i < source.length) {
+    const c = source[i]!;
+
+    if (c === "\\") {
+      // Escape: skip the next char (counts as one atom)
+      const next = source[i + 1];
+      if (next !== undefined) {
+        // If the escape is followed by a quantifier, atom contributes height 1
+        const after = source[i + 2];
+        const quantHeight = isQuantifierStart(after) ? 1 : 0;
+        recordAtomHeight(quantHeight);
+        i += 2;
+        if (quantHeight > 0) {
+          const consumed = consumeQuantifier(source, i, maxRepetition);
+          if (consumed === null) return false;
+          i = consumed;
+        }
+        continue;
+      }
+      return false; // Trailing backslash
+    }
+
+    if (inCharClass) {
+      if (c === "]") inCharClass = false;
+      i += 1;
+      continue;
+    }
+
+    if (c === "[") {
+      inCharClass = true;
+      // Character class is one atom; check for quantifier after the closing ]
+      // We'll re-check height when we hit ]; simpler to look ahead.
+      const closeIdx = findCharClassClose(source, i);
+      if (closeIdx === -1) return false;
+      const after = source[closeIdx + 1];
+      const quantHeight = isQuantifierStart(after) ? 1 : 0;
+      recordAtomHeight(quantHeight);
+      i = closeIdx + 1;
+      inCharClass = false;
+      if (quantHeight > 0) {
+        const consumed = consumeQuantifier(source, i, maxRepetition);
+        if (consumed === null) return false;
+        i = consumed;
+      }
+      continue;
+    }
+
+    if (c === "(") {
+      groupDepth += 1;
+      groupInnerHeight.push(0);
+      // Skip group prefix: (?:, (?=, (?!, (?<=, (?<!, (?<name>
+      if (source[i + 1] === "?") {
+        if (source[i + 2] === "<" && source[i + 3] !== "=" && source[i + 3] !== "!") {
+          // Named capture (?<name>...)
+          const close = source.indexOf(">", i + 3);
+          if (close === -1) return false;
+          i = close + 1;
+        } else {
+          i += 3; // (?: (?= (?! (?<= (?<!  — skip the prefix chars; lookbehind needs +1 more but we re-check below
+          if (source[i - 1] === "<") i += 1; // (?<=  or (?<!  — already consumed up to `<`, advance past `=`/`!`
+        }
+      } else {
+        i += 1;
+      }
+      continue;
+    }
+
+    if (c === ")") {
+      const innerHeight = groupInnerHeight.pop() ?? 0;
+      groupDepth -= 1;
+      const after = source[i + 1];
+      const quantified = isQuantifierStart(after);
+      const groupHeight = innerHeight + (quantified ? 1 : 0);
+      if (groupHeight > maxStarHeight) return false;
+      recordAtomHeight(groupHeight);
+      i += 1;
+      if (quantified) {
+        const consumed = consumeQuantifier(source, i, maxRepetition);
+        if (consumed === null) return false;
+        i = consumed;
+      }
+      continue;
+    }
+
+    // Plain literal character: atom of height 0 unless quantified, then 1.
+    const after = source[i + 1];
+    const quantHeight = isQuantifierStart(after) ? 1 : 0;
+    recordAtomHeight(quantHeight);
+    i += 1;
+    if (quantHeight > 0) {
+      const consumed = consumeQuantifier(source, i, maxRepetition);
+      if (consumed === null) return false;
+      i = consumed;
+    }
+  }
+
+  if (groupDepth !== 0 || inCharClass) return false; // Unbalanced
+  if (topLevelHeight > maxStarHeight) return false;
+  return true;
+}
+
+function isQuantifierStart(ch: string | undefined): boolean {
+  return ch === "*" || ch === "+" || ch === "?" || ch === "{";
+}
+
+/** Advance past a quantifier starting at `i`, validating `{n,m}` bounds. Returns new index, or null if invalid/over budget. */
+function consumeQuantifier(source: string, i: number, maxRepetition: number): number | null {
+  const c = source[i];
+  if (c === "*" || c === "+" || c === "?") {
+    // Optional lazy/possessive marker
+    const next = source[i + 1];
+    return next === "?" || next === "+" ? i + 2 : i + 1;
+  }
+  if (c === "{") {
+    const close = source.indexOf("}", i + 1);
+    if (close === -1) return null;
+    const body = source.slice(i + 1, close);
+    const m = /^(\d+)(,(\d*))?$/.exec(body);
+    if (!m) return null;
+    const lo = Number(m[1]);
+    const upperRaw = m[3];
+    const hi = m[2] === undefined ? lo : upperRaw === "" || upperRaw === undefined ? Infinity : Number(upperRaw);
+    if (!Number.isFinite(lo) || lo > maxRepetition) return null;
+    if (!Number.isFinite(hi) || hi > maxRepetition) return null;
+    let next = close + 1;
+    if (source[next] === "?" || source[next] === "+") next += 1;
+    return next;
+  }
+  return i;
+}
+
+function findCharClassClose(source: string, openIdx: number): number {
+  // The first ] after [ closes the class, except for an immediate `]` which is literal in many
+  // dialects. Account for `[]...]` and escape sequences.
+  let j = openIdx + 1;
+  if (source[j] === "^") j += 1;
+  if (source[j] === "]") j += 1; // Leading ] is literal
+  while (j < source.length) {
+    const c = source[j]!;
+    if (c === "\\") {
+      j += 2;
+      continue;
+    }
+    if (c === "]") return j;
+    j += 1;
+  }
+  return -1;
+}


### PR DESCRIPTION
## Linked issue

Closes #846

## Why this change

Lorebook entries support author-supplied regex keys (`entry.useRegex` + `entry.keys[]`). When `useRegex` is on, the matcher does `new RegExp(keyword, flags).test(text)` against chat context — and after #845, against keyword-test sample text in the editor preview. A pathological pattern like `(a+)+` against `"a".repeat(N) + "!"` triggers catastrophic backtracking and stalls the thread that runs it: server-side that affects every live chat on the instance, client-side that jams the editor tab.

Trust model is mostly self-contained today (you write the regex, you run it on your own chat), so it's footgun more than vulnerability — but the SillyTavern lorebook import path crosses that boundary, and the 2026-04 issue here is that the failure mode is invisible until the right input shows up. I want a guard at the activation seam that applies uniformly across server scanning, client preview, and any future caller, without changing semantics for safe patterns.

## What changed

Two-layer defense, both gated at the activation boundary instead of the leaf `testKeyword` helper (per the #845 review thread that scoped this out of the leaf):

**1. Static safety heuristic in `@marinara-engine/shared` (`isPatternSafe`)** — `packages/shared/src/utils/regex-safety.ts`
- Star-height check rejects nested quantifiers like `(a+)+`, `(a*)*`, `(a+|b)+`, `((ab)+)+`
- Pattern length cap (1000 chars)
- `{n,m}` repetition cap (100, also catches unbounded `{1,}`)
- Walks the source once, tracks character classes / escapes / group prefixes (`(?:`, `(?=`, `(?<name>`) without depending on `safe-regex`/`ret`. Keeps `@marinara-engine/shared` at zero new deps.

Wired into `testKeyword`: when `useRegex` is on and `isPatternSafe` returns false, the helper falls back to literal substring matching — same posture as the existing invalid-regex `catch` fallback, principle of least surprise.

**2. Server-side execution timeout (`vmRegexExecutor`)** — `packages/server/src/services/lorebook/regex-timeout.ts`
- Runs `regex.test` inside `vm.runInNewContext` with a 50 ms timeout. V8's interrupt checks fire during regex execution, so catastrophic backtracking aborts instead of pinning the event loop.
- On timeout: logs a warn with the pattern source + flags + text length and returns `false`. **Doesn't** substitute literal-substring semantics on timeout — the pattern compiled and may have matched on simpler input; switching meanings mid-run would be a silent surprise.
- Injected via the new optional `regexExecutor` on `KeywordMatchOptions` so the shared helper stays runtime-agnostic; the client preview keeps using the default executor.

Client-side has the static check only. A browser-side sync timeout would require re-architecting the helper around Web Workers (sync `regex.test` on the main thread has no clean interrupt seam), which is a heavier change than the symptom warrants — a frozen tab is recoverable, a frozen Node event loop isn't.

`packages/shared/src/utils/regex-replacement.ts` is intentionally out of scope. Same posture, different feature surface (regex scripts on display/output, separate call sites). Filing a follow-up so this one stays focused on the lorebook activation layer.

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- 8 new tests in `packages/server/test/lorebook-regex-safety.test.ts` cover both layers — `isPatternSafe` for safe / nested-quantifier / oversized / unbalanced patterns, `testKeyword` fallback semantics, and the canonical `(a|aa)+` × `"a".repeat(28) + "!"` ReDoS pair under the vm timeout (verifies the abort actually fires within ~1 s on the runner).
- Manually verify in browser on a real lorebook with `useRegex: true`: paste a pathological pattern like `(a+)+` and confirm the keyword-test panel from #845 stays responsive — without this change, that combo freezes the editor tab.
- Manually verify safe regex keys still match — e.g. `\bword\b`, `foo|bar`, `(?:foo){1,5}`. The static check accepts these; behavior should be unchanged.
- Manually verify the literal-substring fallback by setting an unsafe pattern as a key and pasting text containing that pattern's source verbatim — entry should still activate (matching the existing invalid-regex fallback).
- Manually check server logs for the new warn line on a contrived pathological pattern that survives the static check (e.g. add one via direct DB insert) — should see `Lorebook regex /…/… exceeded 50ms timeout against chat context (length=…) — entry will not match this scan`.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

No UI changes — purely runtime hardening behind the existing `useRegex` flag and the keyword-test panel from #845.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added regex safety validation and timeout protection (50ms default) for keyword matching to prevent pattern hangs; unsafe patterns automatically fall back to literal substring matching.

* **Tests**
  * Added comprehensive test suite for regex safety validation and timeout behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/882)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->