### PR TITLE
feat(game): drag-and-swap inventory items in Game Mode

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -11,6 +11,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
+    "@dnd-kit/core": "6.3.1",
     "@marinara-engine/shared": "workspace:*",
     "@tanstack/react-query": "^5.100.9",
     "class-variance-authority": "^0.7.1",

--- a/packages/client/src/components/game/GameInventory.tsx
+++ b/packages/client/src/components/game/GameInventory.tsx
@@ -1,5 +1,15 @@
 // Game: Inventory Panel
 import { useState, useCallback, useEffect } from "react";
+import {
+  DndContext,
+  type DragEndEvent,
+  MouseSensor,
+  TouchSensor,
+  useDraggable,
+  useDroppable,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
 import { Check, ChevronLeft, ChevronRight, Minus, Package, Plus, Wand2, X } from "lucide-react";
 import { cn } from "../../lib/utils";
 
@@ -48,8 +58,13 @@ export function GameInventory({
   const [addPending, setAddPending] = useState(false);
   const [amountPending, setAmountPending] = useState<"increment" | "decrement" | null>(null);
   const [pageIndex, setPageIndex] = useState(0);
-  const [dragSourceIndex, setDragSourceIndex] = useState<number | null>(null);
-  const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
+
+  // Mouse: 4px distance threshold so quick clicks still select.
+  // Touch: 200ms hold within 5px so swipe-to-scroll still works on mobile.
+  const sensors = useSensors(
+    useSensor(MouseSensor, { activationConstraint: { distance: 4 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 200, tolerance: 5 } }),
+  );
 
   const handleItemClick = useCallback(
     (item: InventoryItem) => {
@@ -162,54 +177,17 @@ export function GameInventory({
     [onRemoveItem],
   );
 
-  const handleDragStart = useCallback(
-    (event: React.DragEvent<HTMLButtonElement>, globalIndex: number) => {
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
       if (!onReorderItem) return;
-      event.dataTransfer.effectAllowed = "move";
-      // Some browsers require setData to fire drop events at all.
-      event.dataTransfer.setData("text/plain", String(globalIndex));
-      setDragSourceIndex(globalIndex);
+      const fromIndex = event.active.data.current?.index;
+      const toIndex = event.over?.data.current?.index;
+      if (typeof fromIndex !== "number" || typeof toIndex !== "number") return;
+      if (fromIndex === toIndex) return;
+      void onReorderItem(fromIndex, toIndex);
     },
     [onReorderItem],
   );
-
-  const handleDragOver = useCallback(
-    (event: React.DragEvent<HTMLButtonElement>, globalIndex: number, hasItem: boolean) => {
-      if (!onReorderItem || dragSourceIndex === null || !hasItem || dragSourceIndex === globalIndex) return;
-      event.preventDefault();
-      event.dataTransfer.dropEffect = "move";
-      if (dragOverIndex !== globalIndex) setDragOverIndex(globalIndex);
-    },
-    [dragOverIndex, dragSourceIndex, onReorderItem],
-  );
-
-  const handleDragLeave = useCallback(
-    (globalIndex: number) => {
-      if (dragOverIndex === globalIndex) setDragOverIndex(null);
-    },
-    [dragOverIndex],
-  );
-
-  const handleDrop = useCallback(
-    (event: React.DragEvent<HTMLButtonElement>, globalIndex: number, hasItem: boolean) => {
-      if (!onReorderItem || dragSourceIndex === null || !hasItem || dragSourceIndex === globalIndex) {
-        setDragSourceIndex(null);
-        setDragOverIndex(null);
-        return;
-      }
-      event.preventDefault();
-      const from = dragSourceIndex;
-      setDragSourceIndex(null);
-      setDragOverIndex(null);
-      void onReorderItem(from, globalIndex);
-    },
-    [dragSourceIndex, onReorderItem],
-  );
-
-  const handleDragEnd = useCallback(() => {
-    setDragSourceIndex(null);
-    setDragOverIndex(null);
-  }, []);
 
   if (!open) return null;
 
@@ -265,61 +243,23 @@ export function GameInventory({
                   </button>
                 </div>
               )}
-              <div className="grid grid-cols-5 gap-1.5">
-                {slots.map((item, i) => {
-                  const globalIndex = pageStart + i;
-                  const isDragSource = dragSourceIndex === globalIndex;
-                  const isDragOver = dragOverIndex === globalIndex;
-                  const draggable = Boolean(item && onReorderItem);
-                  return (
-                    <button
-                      key={`slot-${globalIndex}`}
-                      onClick={() => item && handleItemClick(item)}
-                      disabled={!item}
-                      draggable={draggable}
-                      onDragStart={draggable ? (event) => handleDragStart(event, globalIndex) : undefined}
-                      onDragOver={onReorderItem ? (event) => handleDragOver(event, globalIndex, Boolean(item)) : undefined}
-                      onDragLeave={onReorderItem ? () => handleDragLeave(globalIndex) : undefined}
-                      onDrop={onReorderItem ? (event) => handleDrop(event, globalIndex, Boolean(item)) : undefined}
-                      onDragEnd={onReorderItem ? handleDragEnd : undefined}
-                      title={item ? (item.quantity > 1 ? `${item.name} ×${item.quantity}` : item.name) : undefined}
-                      aria-label={item ? (item.quantity > 1 ? `${item.name} x${item.quantity}` : item.name) : undefined}
-                      aria-grabbed={draggable ? isDragSource : undefined}
-                      className={cn(
-                        "group relative flex aspect-square flex-col items-center justify-center overflow-hidden rounded border transition-all",
-                        item
-                          ? selectedItem === item.name
-                            ? "border-amber-500/50 bg-amber-500/10 shadow-[inset_0_0_12px_rgba(245,158,11,0.08)]"
-                            : "border-white/8 bg-white/[0.03] hover:border-white/15 hover:bg-white/[0.06]"
-                          : "cursor-default border-white/5 bg-white/[0.015]",
-                        draggable && "cursor-grab active:cursor-grabbing",
-                        isDragSource && "opacity-40",
-                        isDragOver && "border-amber-400/70 ring-2 ring-amber-400/60",
-                      )}
-                    >
-                    {item && (
-                      <>
-                        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded bg-gradient-to-b from-white/8 to-white/[0.02] text-sm font-bold text-amber-400/80 ring-1 ring-white/8">
-                          {item.name.charAt(0).toUpperCase()}
-                        </div>
-                        <div className="mt-1 flex min-h-0 w-full min-w-0 flex-1 flex-col items-center justify-center px-1">
-                          <div className="flex max-h-full min-h-0 w-full min-w-0 flex-col items-center gap-0.5 overflow-hidden max-md:overflow-y-auto max-md:overscroll-contain max-md:touch-pan-y">
-                            <span className="block w-full whitespace-normal break-words text-center text-[0.58rem] font-medium leading-tight text-white/80 [overflow-wrap:anywhere]">
-                              {item.name}
-                            </span>
-                            {item.quantity > 1 && (
-                              <span className="shrink-0 rounded bg-white/15 px-1.5 py-0.5 text-[0.55rem] font-semibold tabular-nums text-white/80">
-                                x{item.quantity}
-                              </span>
-                            )}
-                          </div>
-                        </div>
-                      </>
-                    )}
-                    </button>
-                  );
-                })}
-              </div>
+              <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
+                <div className="grid grid-cols-5 gap-1.5">
+                  {slots.map((item, i) => {
+                    const globalIndex = pageStart + i;
+                    return (
+                      <InventorySlot
+                        key={`slot-${globalIndex}`}
+                        item={item}
+                        globalIndex={globalIndex}
+                        selected={Boolean(item && selectedItem === item.name)}
+                        reorderEnabled={Boolean(onReorderItem)}
+                        onClick={() => item && handleItemClick(item)}
+                      />
+                    );
+                  })}
+                </div>
+              </DndContext>
             </>
           ) : (
             <div className="flex min-h-40 flex-col items-center justify-center rounded border border-dashed border-white/10 bg-white/[0.02] px-4 text-center">
@@ -433,5 +373,83 @@ export function GameInventory({
         )}
       </div>
     </div>
+  );
+}
+
+interface InventorySlotProps {
+  item: InventoryItem | null;
+  globalIndex: number;
+  selected: boolean;
+  reorderEnabled: boolean;
+  onClick: () => void;
+}
+
+function InventorySlot({ item, globalIndex, selected, reorderEnabled, onClick }: InventorySlotProps) {
+  const enabled = reorderEnabled && Boolean(item);
+  const slotData = { index: globalIndex };
+  const {
+    setNodeRef: setDragRef,
+    attributes,
+    listeners,
+    isDragging,
+  } = useDraggable({ id: `slot-drag-${globalIndex}`, data: slotData, disabled: !enabled });
+  const { setNodeRef: setDropRef, isOver } = useDroppable({
+    id: `slot-drop-${globalIndex}`,
+    data: slotData,
+    disabled: !enabled,
+  });
+  const setRefs = useCallback(
+    (node: HTMLButtonElement | null) => {
+      setDragRef(node);
+      setDropRef(node);
+    },
+    [setDragRef, setDropRef],
+  );
+
+  return (
+    <button
+      ref={setRefs}
+      {...attributes}
+      {...listeners}
+      onClick={onClick}
+      disabled={!item}
+      title={item ? (item.quantity > 1 ? `${item.name} ×${item.quantity}` : item.name) : undefined}
+      aria-label={item ? (item.quantity > 1 ? `${item.name} x${item.quantity}` : item.name) : undefined}
+      aria-pressed={enabled ? isDragging : undefined}
+      className={cn(
+        "group relative flex aspect-square flex-col items-center justify-center overflow-hidden rounded border transition-all",
+        // touch-action: none lets the TouchSensor activate without browser scroll-gestures stealing the touch.
+        // Scrolling the inventory panel is still possible by touching the modal background / pagination row.
+        enabled && "touch-none",
+        item
+          ? selected
+            ? "border-amber-500/50 bg-amber-500/10 shadow-[inset_0_0_12px_rgba(245,158,11,0.08)]"
+            : "border-white/8 bg-white/[0.03] hover:border-white/15 hover:bg-white/[0.06]"
+          : "cursor-default border-white/5 bg-white/[0.015]",
+        enabled && "cursor-grab active:cursor-grabbing",
+        isDragging && "opacity-40",
+        isOver && !isDragging && "border-amber-400/70 ring-2 ring-amber-400/60",
+      )}
+    >
+      {item && (
+        <>
+          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded bg-gradient-to-b from-white/8 to-white/[0.02] text-sm font-bold text-amber-400/80 ring-1 ring-white/8">
+            {item.name.charAt(0).toUpperCase()}
+          </div>
+          <div className="mt-1 flex min-h-0 w-full min-w-0 flex-1 flex-col items-center justify-center px-1">
+            <div className="flex max-h-full min-h-0 w-full min-w-0 flex-col items-center gap-0.5 overflow-hidden max-md:overflow-y-auto max-md:overscroll-contain max-md:touch-pan-y">
+              <span className="block w-full whitespace-normal break-words text-center text-[0.58rem] font-medium leading-tight text-white/80 [overflow-wrap:anywhere]">
+                {item.name}
+              </span>
+              {item.quantity > 1 && (
+                <span className="shrink-0 rounded bg-white/15 px-1.5 py-0.5 text-[0.55rem] font-semibold tabular-nums text-white/80">
+                  x{item.quantity}
+                </span>
+              )}
+            </div>
+          </div>
+        </>
+      )}
+    </button>
   );
 }

--- a/packages/client/src/components/game/GameInventory.tsx
+++ b/packages/client/src/components/game/GameInventory.tsx
@@ -22,6 +22,8 @@ interface GameInventoryProps {
   onRemoveItem?: (itemName: string) => void | Promise<void>;
   /** Called when the user wants to manually add one unit of an item */
   onIncrementItem?: (itemName: string) => void | Promise<void>;
+  /** Called when the user drags one item onto another to swap their positions */
+  onReorderItem?: (fromIndex: number, toIndex: number) => void | Promise<void>;
   /** Whether the player can interact (input phase) */
   canInteract?: boolean;
 }
@@ -37,6 +39,7 @@ export function GameInventory({
   onRenameItem,
   onRemoveItem,
   onIncrementItem,
+  onReorderItem,
   canInteract,
 }: GameInventoryProps) {
   const [selectedItem, setSelectedItem] = useState<string | null>(null);
@@ -45,6 +48,8 @@ export function GameInventory({
   const [addPending, setAddPending] = useState(false);
   const [amountPending, setAmountPending] = useState<"increment" | "decrement" | null>(null);
   const [pageIndex, setPageIndex] = useState(0);
+  const [dragSourceIndex, setDragSourceIndex] = useState<number | null>(null);
+  const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
 
   const handleItemClick = useCallback(
     (item: InventoryItem) => {
@@ -157,6 +162,55 @@ export function GameInventory({
     [onRemoveItem],
   );
 
+  const handleDragStart = useCallback(
+    (event: React.DragEvent<HTMLButtonElement>, globalIndex: number) => {
+      if (!onReorderItem) return;
+      event.dataTransfer.effectAllowed = "move";
+      // Some browsers require setData to fire drop events at all.
+      event.dataTransfer.setData("text/plain", String(globalIndex));
+      setDragSourceIndex(globalIndex);
+    },
+    [onReorderItem],
+  );
+
+  const handleDragOver = useCallback(
+    (event: React.DragEvent<HTMLButtonElement>, globalIndex: number, hasItem: boolean) => {
+      if (!onReorderItem || dragSourceIndex === null || !hasItem || dragSourceIndex === globalIndex) return;
+      event.preventDefault();
+      event.dataTransfer.dropEffect = "move";
+      if (dragOverIndex !== globalIndex) setDragOverIndex(globalIndex);
+    },
+    [dragOverIndex, dragSourceIndex, onReorderItem],
+  );
+
+  const handleDragLeave = useCallback(
+    (globalIndex: number) => {
+      if (dragOverIndex === globalIndex) setDragOverIndex(null);
+    },
+    [dragOverIndex],
+  );
+
+  const handleDrop = useCallback(
+    (event: React.DragEvent<HTMLButtonElement>, globalIndex: number, hasItem: boolean) => {
+      if (!onReorderItem || dragSourceIndex === null || !hasItem || dragSourceIndex === globalIndex) {
+        setDragSourceIndex(null);
+        setDragOverIndex(null);
+        return;
+      }
+      event.preventDefault();
+      const from = dragSourceIndex;
+      setDragSourceIndex(null);
+      setDragOverIndex(null);
+      void onReorderItem(from, globalIndex);
+    },
+    [dragSourceIndex, onReorderItem],
+  );
+
+  const handleDragEnd = useCallback(() => {
+    setDragSourceIndex(null);
+    setDragOverIndex(null);
+  }, []);
+
   if (!open) return null;
 
   const slots: Array<InventoryItem | null> = [];
@@ -212,22 +266,37 @@ export function GameInventory({
                 </div>
               )}
               <div className="grid grid-cols-5 gap-1.5">
-                {slots.map((item, i) => (
-                  <button
-                    key={`slot-${pageStart + i}`}
-                    onClick={() => item && handleItemClick(item)}
-                    disabled={!item}
-                    title={item ? (item.quantity > 1 ? `${item.name} ×${item.quantity}` : item.name) : undefined}
-                    aria-label={item ? (item.quantity > 1 ? `${item.name} x${item.quantity}` : item.name) : undefined}
-                    className={cn(
-                      "group relative flex aspect-square flex-col items-center justify-center overflow-hidden rounded border transition-all",
-                      item
-                        ? selectedItem === item.name
-                          ? "border-amber-500/50 bg-amber-500/10 shadow-[inset_0_0_12px_rgba(245,158,11,0.08)]"
-                          : "border-white/8 bg-white/[0.03] hover:border-white/15 hover:bg-white/[0.06]"
-                        : "cursor-default border-white/5 bg-white/[0.015]",
-                    )}
-                  >
+                {slots.map((item, i) => {
+                  const globalIndex = pageStart + i;
+                  const isDragSource = dragSourceIndex === globalIndex;
+                  const isDragOver = dragOverIndex === globalIndex;
+                  const draggable = Boolean(item && onReorderItem);
+                  return (
+                    <button
+                      key={`slot-${globalIndex}`}
+                      onClick={() => item && handleItemClick(item)}
+                      disabled={!item}
+                      draggable={draggable}
+                      onDragStart={draggable ? (event) => handleDragStart(event, globalIndex) : undefined}
+                      onDragOver={onReorderItem ? (event) => handleDragOver(event, globalIndex, Boolean(item)) : undefined}
+                      onDragLeave={onReorderItem ? () => handleDragLeave(globalIndex) : undefined}
+                      onDrop={onReorderItem ? (event) => handleDrop(event, globalIndex, Boolean(item)) : undefined}
+                      onDragEnd={onReorderItem ? handleDragEnd : undefined}
+                      title={item ? (item.quantity > 1 ? `${item.name} ×${item.quantity}` : item.name) : undefined}
+                      aria-label={item ? (item.quantity > 1 ? `${item.name} x${item.quantity}` : item.name) : undefined}
+                      aria-grabbed={draggable ? isDragSource : undefined}
+                      className={cn(
+                        "group relative flex aspect-square flex-col items-center justify-center overflow-hidden rounded border transition-all",
+                        item
+                          ? selectedItem === item.name
+                            ? "border-amber-500/50 bg-amber-500/10 shadow-[inset_0_0_12px_rgba(245,158,11,0.08)]"
+                            : "border-white/8 bg-white/[0.03] hover:border-white/15 hover:bg-white/[0.06]"
+                          : "cursor-default border-white/5 bg-white/[0.015]",
+                        draggable && "cursor-grab active:cursor-grabbing",
+                        isDragSource && "opacity-40",
+                        isDragOver && "border-amber-400/70 ring-2 ring-amber-400/60",
+                      )}
+                    >
                     {item && (
                       <>
                         <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded bg-gradient-to-b from-white/8 to-white/[0.02] text-sm font-bold text-amber-400/80 ring-1 ring-white/8">
@@ -247,8 +316,9 @@ export function GameInventory({
                         </div>
                       </>
                     )}
-                  </button>
-                ))}
+                    </button>
+                  );
+                })}
               </div>
             </>
           ) : (

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -5239,7 +5239,9 @@ export function GameSurface({
           gameInventory: updatedInventory,
         });
       } catch (error) {
-        setInventoryItems(previousInventory);
+        // Rollback only if no newer reorder superseded this one — otherwise
+        // a late failure from an older request would clobber newer state.
+        setInventoryItems((current) => (current === updatedInventory ? previousInventory : current));
         const message = error instanceof Error ? error.message : "Failed to reorder inventory.";
         toast.error(message);
       }

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -5217,6 +5217,36 @@ export function GameSurface({
     [activeChatId, inventoryItems, updateChatMetadata],
   );
 
+  const handleReorderInventoryItem = useCallback(
+    async (fromIndex: number, toIndex: number) => {
+      if (!activeChatId) return;
+      if (fromIndex === toIndex) return;
+      if (fromIndex < 0 || toIndex < 0) return;
+      if (fromIndex >= inventoryItems.length || toIndex >= inventoryItems.length) return;
+
+      const previousInventory = inventoryItems;
+      const updatedInventory = inventoryItems.slice();
+      [updatedInventory[fromIndex], updatedInventory[toIndex]] = [updatedInventory[toIndex], updatedInventory[fromIndex]];
+
+      // Optimistic local update so the swap feels instant; rollback on error.
+      // Only the visible gameInventory order is persisted — playerStats.inventory
+      // is name-indexed by the agent, so its array order is not observable.
+      setInventoryItems(updatedInventory);
+
+      try {
+        await updateChatMetadata.mutateAsync({
+          id: activeChatId,
+          gameInventory: updatedInventory,
+        });
+      } catch (error) {
+        setInventoryItems(previousInventory);
+        const message = error instanceof Error ? error.message : "Failed to reorder inventory.";
+        toast.error(message);
+      }
+    },
+    [activeChatId, inventoryItems, updateChatMetadata],
+  );
+
   const handleEditSegment = useCallback(
     (messageId: string, segmentIndex: number, edit: GameSegmentEdit) => {
       if (!messageId) return;
@@ -8529,6 +8559,7 @@ export function GameSurface({
                 onRenameItem={handleRenameInventoryItem}
                 onRemoveItem={handleRemoveInventoryItem}
                 onIncrementItem={handleIncrementInventoryItem}
+                onReorderItem={handleReorderInventoryItem}
                 canInteract={sessionInteractive && narrationDone && !isStreaming}
                 onUseItem={(itemName) => {
                   setInventoryOpen(false);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,9 @@ importers:
 
   packages/client:
     dependencies:
+      '@dnd-kit/core':
+        specifier: 6.3.1
+        version: 6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@marinara-engine/shared':
         specifier: workspace:*
         version: link:../shared
@@ -792,6 +795,22 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
@@ -4640,6 +4659,24 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@dnd-kit/accessibility@3.1.1(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.5)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+      tslib: 2.8.1
 
   '@emnapi/runtime@1.10.0':
     dependencies:


### PR DESCRIPTION
## Linked issue

Closes #861

## Why this change

Game Mode players currently have no way to manually organize their inventory — add/rename/use/remove exist, but the slot order is whatever order items were acquired in. The issue (filed from Discord by drakonbane, triaged `normal-scope` by @cha1latte) asks for drag-and-swap so the grid can be tidied.

Per the triage note I scoped this slice to "drag/swap within the current inventory grid first"; cross-page reorder is deliberately deferred.

## What changed

- `packages/client/src/components/game/GameInventory.tsx` — filled slots are draggable via `@dnd-kit/core`. Dragging item A onto item B (within the current page) triggers a swap; empty slots are non-droppable. While dragging, the source slot dims and the hovered target gets an amber ring for visual feedback. Refactored the slot rendering into an `InventorySlot` subcomponent because `useDraggable`/`useDroppable` are hooks. New optional `onReorderItem(fromIndex, toIndex)` prop; behavior is unchanged when the prop is omitted.
- `packages/client/src/components/game/GameSurface.tsx` — new `handleReorderInventoryItem` wired to the prop. Swaps two entries in `gameInventory`, applies the change optimistically, and persists via the existing `updateChatMetadata` mutation. On error, rolls back the local state and surfaces a toast.
- `packages/client/package.json` — adds `@dnd-kit/core@6.3.1` (MIT, ~12KB gzipped, zero GH advisories, ~16M weekly downloads, transitive footprint is only `tslib` via `@dnd-kit/utilities` + `@dnd-kit/accessibility`).

History note: the first commit used native HTML5 drag-and-drop with no new dependency. After review feedback flagged that HTML5 DnD events don't fire on iOS Safari, the second commit migrated to `@dnd-kit/core` to get real touch support. The `MouseSensor` is configured with a 4px distance threshold so quick clicks still select, and the `TouchSensor` uses a 200ms hold + 5px tolerance so swipe-to-scroll still works on mobile.

Design choices worth flagging:

- **No new server endpoint.** `gameInventory` is array-ordered and `normalizeGameInventoryItems` preserves order, so the existing `PATCH /chats/:id/metadata` route round-trips a reorder unchanged.
- **Swap semantics, not insertion-shift.** Drop on item B swaps A↔B. Matches the issue wording ("drag/swap") and avoids the edge-case complexity of "drop on empty slot → shift others right".
- **`playerStats.inventory` left untouched.** That array is the agent-facing detailed inventory (with `description`, `location`). The agent indexes by name; its array order is not observable. Skipping the mirror avoids a second PATCH and a second rollback path.
- **`aria-grabbed` replaced with `aria-pressed`.** `aria-grabbed` was deprecated in ARIA 1.1; current screen readers ignore it.
- **`touch-action: none` only on draggable slots.** Required for `TouchSensor` activation to win over browser scroll gestures. The modal background, pagination row, and action bar remain pannable.

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

Desktop / mouse:
- Manually verify dragging item A onto item B swaps their positions in the grid.
- Manually verify the new order persists after closing/reopening the inventory panel (round-trip via chat metadata).
- Manually verify the new order survives a full page reload (round-trip via server load).
- Manually verify dragging onto an empty slot does nothing (no shift, no swap, no PATCH).
- Manually verify clicking a slot (no mouse movement) still selects it — the 4px MouseSensor threshold means short clicks should not trigger drag.
- Manually verify the source slot dims and the drop target shows a ring during drag.
- Manually verify clicking a slot still selects it for rename / increment / decrement / use (no regression on existing interactions).
- Manually verify a network error during the swap surfaces a toast and the grid snaps back to the previous order.

Mobile / touch:
- Manually verify a 200ms+ press on a filled slot initiates drag (the TouchSensor delay).
- Manually verify a quick tap on a filled slot just selects it (no accidental drag).
- Manually verify swipe gestures over the slot grid don't initiate drag within the 200ms delay window — scroll-style touches should pass through.
- Manually verify the drag works on at least one iOS Safari device and one Android Chrome device, since HTML5 DnD historically didn't fire on iOS Safari and that was the reason for switching to `@dnd-kit/core`.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)
