### PR TITLE
Fix built-in agent prompt sections and KR roleplay leakage

### DIFF
--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -700,7 +700,7 @@ function replaceRuntimeAgentSection(
   return replaced;
 }
 
-function splitRuntimeHandledAgentInjections(
+export function splitRuntimeHandledAgentInjectionsForTest(
   messages: Array<{ content: string }>,
   tokenMap: ReadonlyMap<RuntimeAgentSectionType, RuntimeAgentSectionTokens>,
   injections: AgentInjection[],
@@ -719,6 +719,8 @@ function splitRuntimeHandledAgentInjections(
   }
   return { fallbackInjections, handledTypes };
 }
+
+const splitRuntimeHandledAgentInjections = splitRuntimeHandledAgentInjectionsForTest;
 
 export function clearUnusedRuntimeAgentSectionsForTest(
   messages: Array<{ content: string }>,
@@ -5336,7 +5338,6 @@ export async function generateRoutes(app: FastifyInstance) {
           runtimeAgentSectionTokens,
           contextInjections,
         );
-        contextInjections = runtimeHandledPreGen.fallbackInjections;
 
         // Inject pre-gen agent context at depth 0 (very bottom of prompt)
         if (runtimeHandledPreGen.fallbackInjections.length > 0) {

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -648,9 +648,8 @@ const REVIEWABLE_WRITER_AGENT_TYPES = new Set(
   ).map((agent) => agent.id),
 );
 
-type RuntimeAgentSectionType = "knowledge-retrieval" | "knowledge-router";
+type RuntimeAgentSectionType = string;
 
-const RUNTIME_AGENT_SECTION_TYPES = new Set<string>(["knowledge-retrieval", "knowledge-router"]);
 const RUNTIME_AGENT_SECTION_TOKEN_PREFIX = "__MARINARA_RUNTIME_AGENT_SECTION__";
 
 interface RuntimeAgentSectionTokens {
@@ -659,8 +658,11 @@ interface RuntimeAgentSectionTokens {
   end: string;
 }
 
-function toRuntimeAgentSectionType(agentType: string): RuntimeAgentSectionType | null {
-  return RUNTIME_AGENT_SECTION_TYPES.has(agentType) ? (agentType as RuntimeAgentSectionType) : null;
+function toRuntimeAgentSectionType(
+  agentType: string,
+  eligibleAgentTypes: ReadonlySet<string>,
+): RuntimeAgentSectionType | null {
+  return eligibleAgentTypes.has(agentType) ? agentType : null;
 }
 
 function makeRuntimeAgentSectionTokens(
@@ -696,6 +698,26 @@ function replaceRuntimeAgentSection(
     replaced = true;
   }
   return replaced;
+}
+
+function splitRuntimeHandledAgentInjections(
+  messages: Array<{ content: string }>,
+  tokenMap: ReadonlyMap<RuntimeAgentSectionType, RuntimeAgentSectionTokens>,
+  injections: AgentInjection[],
+): { fallbackInjections: AgentInjection[]; handledTypes: Set<string> } {
+  const fallbackInjections: AgentInjection[] = [];
+  const handledTypes = new Set<string>();
+  for (const injection of injections) {
+    const tokens = tokenMap.get(injection.agentType);
+    const handledByPresetSection =
+      tokens !== undefined && replaceRuntimeAgentSection(messages, tokens, injection.text);
+    if (handledByPresetSection) {
+      handledTypes.add(injection.agentType);
+    } else {
+      fallbackInjections.push(injection);
+    }
+  }
+  return { fallbackInjections, handledTypes };
 }
 
 export function clearUnusedRuntimeAgentSectionsForTest(
@@ -1272,6 +1294,16 @@ export async function generateRoutes(app: FastifyInstance) {
       const chatActiveAgentIds: string[] = filterGameInternalAgentIds(chatMode, persistedChatActiveAgentIds).filter(
         (agentId) => !(gameSpotifyMusicEnabled && agentId === "spotify"),
       );
+      const runtimeSectionEligibleAgentTypes = new Set(
+        BUILT_IN_AGENTS.filter(
+          (agent) =>
+            chatActiveAgentIds.includes(agent.id) &&
+            agent.phase === "pre_generation" &&
+            agent.id !== "html" &&
+            resolveAgentResultType({ type: agent.id, settings: getDefaultBuiltInAgentSettings(agent.id) }) ===
+              "context_injection",
+        ).map((agent) => agent.id),
+      );
       const chatActiveLorebookIds: string[] = Array.isArray(chatMeta.activeLorebookIds)
         ? (chatMeta.activeLorebookIds as string[])
         : [];
@@ -1413,7 +1445,7 @@ export async function generateRoutes(app: FastifyInstance) {
             const markerConfig = JSON.parse(section.markerConfig) as { type?: unknown; agentType?: unknown };
             const runtimeType =
               markerConfig.type === "agent_data" && typeof markerConfig.agentType === "string"
-                ? toRuntimeAgentSectionType(markerConfig.agentType)
+                ? toRuntimeAgentSectionType(markerConfig.agentType, runtimeSectionEligibleAgentTypes)
                 : null;
             if (runtimeType) runtimeAgentSectionTypes.add(runtimeType);
           } catch {
@@ -5299,9 +5331,16 @@ export async function generateRoutes(app: FastifyInstance) {
           }
         }
 
+        const runtimeHandledPreGen = splitRuntimeHandledAgentInjections(
+          finalMessages,
+          runtimeAgentSectionTokens,
+          contextInjections,
+        );
+        contextInjections = runtimeHandledPreGen.fallbackInjections;
+
         // Inject pre-gen agent context at depth 0 (very bottom of prompt)
-        if (contextInjections.length > 0) {
-          const wrapped = formatAgentInjections(contextInjections, wrapFormat);
+        if (runtimeHandledPreGen.fallbackInjections.length > 0) {
+          const wrapped = formatAgentInjections(runtimeHandledPreGen.fallbackInjections, wrapFormat);
           finalMessages = injectAtDepth(finalMessages, [{ content: wrapped, role: "system", depth: 0 }]);
         }
 
@@ -5312,7 +5351,9 @@ export async function generateRoutes(app: FastifyInstance) {
           if (krText) {
             const tokens = runtimeAgentSectionTokens.get("knowledge-retrieval");
             const handledByPresetSection =
-              tokens !== undefined && replaceRuntimeAgentSection(finalMessages, tokens, krText);
+              !runtimeHandledPreGen.handledTypes.has("knowledge-retrieval") &&
+              tokens !== undefined &&
+              replaceRuntimeAgentSection(finalMessages, tokens, krText);
             if (!handledByPresetSection) {
               appendSeparateAgentInjection("knowledge-retrieval", krText);
             }
@@ -5329,7 +5370,9 @@ export async function generateRoutes(app: FastifyInstance) {
           if (routerText) {
             const tokens = runtimeAgentSectionTokens.get("knowledge-router");
             const handledByPresetSection =
-              tokens !== undefined && replaceRuntimeAgentSection(finalMessages, tokens, routerText);
+              !runtimeHandledPreGen.handledTypes.has("knowledge-router") &&
+              tokens !== undefined &&
+              replaceRuntimeAgentSection(finalMessages, tokens, routerText);
             if (!handledByPresetSection) {
               appendSeparateAgentInjection("knowledge-router", routerText);
             }
@@ -5412,10 +5455,16 @@ export async function generateRoutes(app: FastifyInstance) {
         // Without this split, KR/Router cached output would be replayed in the wrong prompt
         // position with different wrapping than the original generation, subtly changing the
         // model's behavior on regenerate/swipe.
-        const cachedPipelineInjections = contextInjections.filter(
+        const runtimeHandledCached = splitRuntimeHandledAgentInjections(
+          finalMessages,
+          runtimeAgentSectionTokens,
+          contextInjections,
+        );
+
+        const cachedPipelineInjections = runtimeHandledCached.fallbackInjections.filter(
           (inj) => !SEPARATE_INJECTION_AGENTS.has(inj.agentType),
         );
-        const cachedSeparateInjections = contextInjections.filter((inj) =>
+        const cachedSeparateInjections = runtimeHandledCached.fallbackInjections.filter((inj) =>
           SEPARATE_INJECTION_AGENTS.has(inj.agentType),
         );
 
@@ -5425,7 +5474,7 @@ export async function generateRoutes(app: FastifyInstance) {
         }
 
         for (const inj of cachedSeparateInjections) {
-          const runtimeType = toRuntimeAgentSectionType(inj.agentType);
+          const runtimeType = toRuntimeAgentSectionType(inj.agentType, runtimeSectionEligibleAgentTypes);
           const tokens = runtimeType ? runtimeAgentSectionTokens.get(runtimeType) : undefined;
           const handledByPresetSection =
             tokens !== undefined && replaceRuntimeAgentSection(finalMessages, tokens, inj.text);

--- a/packages/server/src/services/agents/agent-executor.ts
+++ b/packages/server/src/services/agents/agent-executor.ts
@@ -122,6 +122,8 @@ export async function executeAgent(
     const messages =
       config.type === "expression"
         ? buildExpressionAgentMessages(template, context)
+        : config.type === "knowledge-retrieval"
+          ? buildKnowledgeRetrievalAgentMessages(config, template, context)
         : config.type === "spotify" && context.chatMode === "game"
           ? buildGameSpotifyAgentMessages(template, context)
           : buildStandardAgentMessages(config, template, context);
@@ -639,6 +641,75 @@ function buildStandardAgentMessages(config: AgentExecConfig, template: string, c
   // Build multi-turn message array for this agent (sliced to its own contextSize)
   const agentContextSize = normalizeAgentContextSize(config.settings.contextSize);
   return buildAgentMessages(systemParts.join("\n"), context, config.type, agentContextSize);
+}
+
+export function buildKnowledgeRetrievalAgentMessagesForTest(
+  config: AgentExecConfig,
+  template: string,
+  context: AgentContext,
+): ChatMessage[] {
+  return buildKnowledgeRetrievalAgentMessages(config, template, context);
+}
+
+function buildKnowledgeRetrievalAgentMessages(
+  config: AgentExecConfig,
+  template: string,
+  context: AgentContext,
+): ChatMessage[] {
+  const systemParts: string[] = [];
+  systemParts.push(`<role>`);
+  systemParts.push(
+    `You are a specialized knowledge retrieval agent. Extract relevant facts from source material; do not roleplay, continue the conversation, write dialogue, or answer as any character.`,
+  );
+  systemParts.push(`</role>`);
+  systemParts.push(``);
+  systemParts.push(`<agents>`);
+  systemParts.push(template);
+  systemParts.push(`</agents>`);
+  const extras = buildAgentExtras(context, [config.type]);
+  if (extras) {
+    systemParts.push(``);
+    systemParts.push(extras);
+  }
+
+  const agentContextSize = normalizeAgentContextSize(config.settings.contextSize);
+  const recent = context.recentMessages.slice(-agentContextSize).filter((message) => message.content.trim());
+  const userParts: string[] = [];
+
+  if (recent.length > 0) {
+    userParts.push(`<conversation_messages>`);
+    for (const message of recent) {
+      const speaker = knowledgeRetrievalSpeakerLabel(message, context);
+      userParts.push(`${speaker}: ${truncateAgentText(message.content, 2000)}`);
+    }
+    userParts.push(`</conversation_messages>`);
+    userParts.push(``);
+  }
+
+  userParts.push(
+    `Use the conversation messages only to identify which source-material facts are relevant. Return a concise factual summary from <source_material>. If no source material is relevant, output: "No relevant information found."`,
+  );
+  userParts.push(`Now return the requested format.`);
+
+  return [
+    { role: "system", content: systemParts.join("\n"), contextKind: "prompt" },
+    { role: "user", content: userParts.join("\n"), contextKind: "history" },
+  ];
+}
+
+function knowledgeRetrievalSpeakerLabel(
+  message: { role: string; characterId?: string },
+  context: AgentContext,
+): string {
+  if (message.role === "user") return context.persona?.name?.trim() || "User";
+  if (message.role === "assistant") {
+    if (message.characterId) {
+      const character = context.characters.find((entry) => entry.id === message.characterId);
+      if (character?.name?.trim()) return character.name.trim();
+    }
+    return context.characters[0]?.name?.trim() || "Assistant";
+  }
+  return message.role || "Message";
 }
 
 function truncateAgentText(text: string, maxChars: number): string {

--- a/packages/server/test/agent-executor-expression.test.ts
+++ b/packages/server/test/agent-executor-expression.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import type { AgentContext } from "@marinara-engine/shared";
 import type { BaseLLMProvider, ChatMessage, ChatCompletionResult } from "../src/services/llm/base-provider.js";
 import {
+  buildKnowledgeRetrievalAgentMessagesForTest,
   executeAgent,
   executeAgentBatch,
   normalizeAgentContextSize,
@@ -132,4 +133,35 @@ test("batched execution runs expression separately from larger tracker prompts",
   const expressionPrompt = expressionCall.map((message) => message.content).join("\n");
   assert.doesNotMatch(expressionPrompt, /agent_task id="world-state"/);
   assert.doesNotMatch(expressionPrompt, /ancient-history-marker-0/);
+});
+
+test("knowledge retrieval receives conversation as neutral source context", () => {
+  const messages = buildKnowledgeRetrievalAgentMessagesForTest(
+    makeConfig("knowledge-retrieval", { contextSize: 5 }),
+    "Extract relevant source facts only.",
+    {
+      ...makeExpressionContext(),
+      recentMessages: [
+        { role: "user", content: "Let's enter the old library." },
+        { role: "assistant", characterId: "mira", content: "Mira opens the door and whispers about dusk." },
+      ],
+      memory: {
+        _sourceMaterial: "## Old Library\nThe old library closes at dusk.",
+      },
+    },
+  );
+
+  assert.equal(messages.length, 2);
+  assert.deepEqual(messages.map((message) => message.role), ["system", "user"]);
+
+  const system = messages[0]!.content;
+  const user = messages[1]!.content;
+  assert.match(system, /<source_material>/);
+  assert.match(system, /old library closes at dusk/i);
+  assert.match(system, /do not roleplay, continue the conversation/i);
+  assert.doesNotMatch(system, /Fulfill the requested task here/);
+  assert.match(user, /<conversation_messages>/);
+  assert.match(user, /Player: Let's enter the old library\./);
+  assert.match(user, /Mira: Mira opens the door/);
+  assert.match(user, /Now return the requested format\./);
 });

--- a/packages/server/test/lorebook-processing.test.ts
+++ b/packages/server/test/lorebook-processing.test.ts
@@ -749,6 +749,71 @@ test("agent_data marker uses runtime agent data when supplied", async () => {
   }
 });
 
+test("agent_data marker accepts runtime data for generic context injection agents", async () => {
+  const client = createClient({ url: "file::memory:" });
+  const db = drizzle(client) as unknown as DB;
+
+  try {
+    await runMigrations(db);
+
+    const result = await assemblePrompt({
+      db,
+      preset: {
+        id: "preset-1",
+        name: "Preset",
+        sectionOrder: JSON.stringify(["prose-section"]),
+        groupOrder: "[]",
+        wrapFormat: "xml",
+        parameters: JSON.stringify(DEFAULT_GENERATION_PARAMS),
+        variableGroups: "[]",
+        variableValues: "{}",
+      },
+      sections: [
+        {
+          id: "prose-section",
+          presetId: "preset-1",
+          identifier: "agent_prose-guardian",
+          name: "Prose Guardian (Agent)",
+          content: "Writing guidance:\n{{agent::prose-guardian}}",
+          role: "system",
+          enabled: "true",
+          isMarker: "true",
+          groupId: null,
+          markerConfig: JSON.stringify({ type: "agent_data", agentType: "prose-guardian" }),
+          injectionPosition: "ordered",
+          injectionDepth: 0,
+          injectionOrder: 0,
+          forbidOverrides: "false",
+        },
+      ],
+      groups: [],
+      choiceBlocks: [],
+      chatChoices: {},
+      chatId: "chat-1",
+      characterIds: [],
+      personaName: "User",
+      personaDescription: "",
+      chatMessages: [{ role: "user", content: "hello" }],
+      runtimeAgentData: {
+        "prose-guardian": {
+          text: "Avoid repeating doorway imagery.",
+          startToken: "__runtime_start__",
+          endToken: "__runtime_end__",
+        },
+      },
+    });
+
+    const content = result.messages.map((message) => message.content).join("\n");
+    assert.match(content, /__runtime_start__/);
+    assert.match(content, /Writing guidance:/);
+    assert.match(content, /Avoid repeating doorway imagery\./);
+    assert.match(content, /__runtime_end__/);
+    assert.deepEqual(result.runtimeAgentTypesUsed, ["prose-guardian"]);
+  } finally {
+    client.close();
+  }
+});
+
 test("runtime agent section boundaries are skipped when the macro is absent", async () => {
   const client = createClient({ url: "file::memory:" });
   const db = drizzle(client) as unknown as DB;

--- a/packages/server/test/runtime-agent-section-cleanup.test.ts
+++ b/packages/server/test/runtime-agent-section-cleanup.test.ts
@@ -1,6 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { clearUnusedRuntimeAgentSectionsForTest } from "../src/routes/generate.routes.js";
+import {
+  clearUnusedRuntimeAgentSectionsForTest,
+  splitRuntimeHandledAgentInjectionsForTest,
+} from "../src/routes/generate.routes.js";
 
 test("unused runtime agent section cleanup removes empty XML group wrappers", () => {
   const messages = [
@@ -15,6 +18,28 @@ test("unused runtime agent section cleanup removes empty XML group wrappers", ()
   ]);
 
   assert.deepEqual(messages, []);
+});
+
+test("runtime handled agent injections stay available for persistence", () => {
+  const messages = [{ content: "Before __start____placeholder____end__ After" }];
+  const contextInjections = [
+    { agentType: "prose-guardian", agentName: "Prose Guardian", text: "Keep the prose crisp." },
+    { agentType: "style-mirror", agentName: "Style Mirror", text: "Match the user's cadence." },
+  ];
+
+  const result = splitRuntimeHandledAgentInjectionsForTest(
+    messages,
+    new Map([["prose-guardian", { placeholder: "__placeholder__", start: "__start__", end: "__end__" }]]),
+    contextInjections,
+  );
+
+  assert.equal(messages[0]?.content, "Before Keep the prose crisp. After");
+  assert.deepEqual(result.fallbackInjections, [contextInjections[1]]);
+  assert.deepEqual(Array.from(result.handledTypes), ["prose-guardian"]);
+  assert.deepEqual(contextInjections, [
+    { agentType: "prose-guardian", agentName: "Prose Guardian", text: "Keep the prose crisp." },
+    { agentType: "style-mirror", agentName: "Style Mirror", text: "Match the user's cadence." },
+  ]);
 });
 
 test("removes empty XML group wrapper but preserves surrounding content", () => {

--- a/packages/shared/src/constants/agent-prompts.ts
+++ b/packages/shared/src/constants/agent-prompts.ts
@@ -546,8 +546,9 @@ If no changes were needed, return the original text with an empty changes array.
 
   /* ────────────────────────────────────────── */
   "knowledge-retrieval": `You are a knowledge retrieval agent. Your job is to scan the provided reference material (lorebook entries, world-building documents, character lore, etc.) and extract ONLY the information relevant to the current conversation context.
+You are not a roleplay participant. Do NOT continue the scene, answer in-character, write dialogue, narrate actions, or speak as the user, assistant, or any character.
 You receive:
-1. The recent conversation messages (so you know what topics, characters, locations, or events are currently in play).
+1. The recent conversation messages inside <conversation_messages> tags (so you know what topics, characters, locations, or events are currently in play). Treat these as source context to analyze, not as chat turns to continue.
 2. A body of reference material inside <source_material> tags.
 Your task:
 1. READ the recent conversation carefully. Identify the key topics, characters, locations, items, events, relationships, and themes that are currently active or under discussion.


### PR DESCRIPTION
## Linked issue

Closes #851
Closes #854

## Why this change

- Built-in pre-generation agent outputs such as Prose Guardian could miss their explicit prompt preset section and fall back to generic bottom-of-prompt injection.
- Knowledge Retrieval could receive recent RP chat as normal conversation turns, which made smaller/local models continue the scene in-character instead of summarizing source material.

## What changed

- Generalized runtime prompt-section replacement from Knowledge Retrieval/Router to any active built-in pre-generation context-injection agent.
- Kept KR/Router fallback behavior so they still append when no explicit preset section handles their output.
- Added a Knowledge Retrieval-specific agent prompt message shape that wraps recent chat as `<conversation_messages>` in a final user message instead of sending it as continuation-ready chat turns.
- Strengthened the default Knowledge Retrieval prompt to explicitly avoid roleplay and treat conversation messages as analysis context.
- Added focused server coverage for generic runtime agent sections and Knowledge Retrieval prompt shape.

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Automated validation run by Codex: `pnpm --filter @marinara-engine/server exec tsx --import ./test/setup-env.ts --test test/lorebook-processing.test.ts test/runtime-agent-section-cleanup.test.ts test/agent-executor-expression.test.ts`; passed.
- Automated validation run by Codex: `pnpm check`; passed after running `pnpm install` to hydrate the local missing `@dnd-kit/core` package from the existing lockfile.
- Not run: live RP prompt preset manual verification with Prose Guardian/Knowledge Retrieval and a real model.
- Not run: Docker/Podman container verification.

## Docs and release impact

- [x] No docs changes needed
- [x] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [x] Version/release files updated (only if this PR includes a version bump)

No docs or release metadata changes expected; this is a narrow server prompt assembly and agent prompt-shaping fix.

## UI evidence (if applicable)

N/A. Server prompt assembly and agent prompt behavior only; no UI surface changed.
