### PR TITLE
feat: add RunPod Serverless ComfyUI image generation support

### DIFF
--- a/packages/client/src/components/connections/ConnectionEditor.tsx
+++ b/packages/client/src/components/connections/ConnectionEditor.tsx
@@ -151,6 +151,7 @@ export function ConnectionEditor() {
   const [localImageGenerationSource, setLocalImageGenerationSource] = useState("");
   const [localComfyuiWorkflow, setLocalComfyuiWorkflow] = useState("");
   const [localImageService, setLocalImageService] = useState<string | null>(null);
+  const [localImageEndpointId, setLocalImageEndpointId] = useState("");
   const [localMaxTokensOverride, setLocalMaxTokensOverride] = useState<number | null>(null);
   const [localClaudeFastMode, setLocalClaudeFastMode] = useState(false);
   const [localDefaultParametersEnabled, setLocalDefaultParametersEnabled] = useState(false);
@@ -260,6 +261,7 @@ export function ConnectionEditor() {
     setLocalImageGenerationSource(imageGenerationSource);
     setLocalComfyuiWorkflow((c.comfyuiWorkflow as string) ?? "");
     setLocalImageService(imageService);
+    setLocalImageEndpointId((c.imageEndpointId as string) ?? "");
     setLocalMaxTokensOverride(typeof c.maxTokensOverride === "number" ? (c.maxTokensOverride as number) : null);
     setLocalClaudeFastMode(c.claudeFastMode === "true" || c.claudeFastMode === true);
     setLocalDefaultParametersEnabled(!!parseEditableGenerationParameters(c.defaultParameters));
@@ -403,6 +405,10 @@ export function ConnectionEditor() {
       comfyuiWorkflow: localComfyuiWorkflow || null,
       imageService:
         localProvider === "image_generation" ? localImageGenerationSource || localImageService || null : null,
+      imageEndpointId:
+        localProvider === "image_generation" && selectedImageService === "runpod_comfyui"
+          ? localImageEndpointId || null
+          : null,
       maxTokensOverride: localMaxTokensOverride ?? null,
       claudeFastMode: localClaudeFastMode,
     };
@@ -456,6 +462,7 @@ export function ConnectionEditor() {
     localImageGenerationSource,
     localComfyuiWorkflow,
     localImageService,
+    localImageEndpointId,
     localMaxTokensOverride,
     localClaudeFastMode,
     localDefaultParametersEnabled,
@@ -1066,6 +1073,13 @@ export function ConnectionEditor() {
                 Pick the backend type once, then point Base URL to any host or port. Provider-specific features like
                 ComfyUI workflow JSON and checkpoint fetching use this selection, not the default localhost URL.
               </p>
+              {selectedImageService === "runpod_comfyui" && (
+                <div className="mt-2 rounded-lg border border-amber-400/20 bg-amber-400/5 px-3 py-2 text-[0.625rem] text-amber-300/80">
+                  <strong>RunPod configuration:</strong> Your endpoint ID goes in the <strong>Endpoint ID</strong> field below.
+                  The API key is your RunPod API token. The workflow JSON is <strong>required</strong> — the endpoint
+                  executes the workflow you supply. Use <code>%prompt%</code> placeholders in the CLIPTextEncode node.
+                </div>
+              )}
             </FieldGroup>
           )}
 
@@ -1311,12 +1325,36 @@ export function ConnectionEditor() {
             )}
           </FieldGroup>
 
-          {/* ── ComfyUI Workflow ── */}
-          {localProvider === "image_generation" && selectedImageService === "comfyui" && (
+          {/* ── RunPod Endpoint ID ── */}
+          {localProvider === "image_generation" && selectedImageService === "runpod_comfyui" && (
             <FieldGroup
-              label="ComfyUI Workflow (Optional)"
+              label="RunPod Endpoint ID"
+              icon={<Server size="0.875rem" className="text-sky-400" />}
+              help="Your RunPod serverless endpoint ID (e.g. 'abc123def456'). This is the unique identifier for your endpoint on RunPod."
+            >
+              <input
+                type="text"
+                value={localImageEndpointId}
+                onChange={(e) => {
+                  setLocalImageEndpointId(e.target.value);
+                  markDirty();
+                }}
+                placeholder="abc123def456"
+                className="w-full rounded-xl bg-[var(--secondary)] px-3 py-2.5 text-sm outline-none ring-1 ring-[var(--border)] transition-shadow placeholder:text-[var(--muted-foreground)]/50 focus:ring-sky-400/50"
+              />
+            </FieldGroup>
+          )}
+
+          {/* ── ComfyUI Workflow ── */}
+          {localProvider === "image_generation" &&
+            (selectedImageService === "comfyui" || selectedImageService === "runpod_comfyui") && (
+            <FieldGroup
+              label={`ComfyUI Workflow (${selectedImageService === "runpod_comfyui" ? "Required" : "Optional"})`}
               icon={<Zap size="0.875rem" className="text-sky-400" />}
-              help="Paste a custom ComfyUI workflow JSON (API format). Use placeholders like %prompt%, %negative_prompt%, %width%, %height%, %seed%, %model%, %steps%, %cfg%, %sampler%, %scheduler%, and %denoise%. Leave empty to use the built-in default txt2img workflow."
+              help={selectedImageService === "runpod_comfyui"
+                ? "Paste your ComfyUI workflow JSON (API format). RunPod needs the full workflow to execute — the endpoint sends this workflow to your serverless endpoint. Use placeholders like %prompt%, %seed%, %width%, and %height% to let Marinara inject generation parameters."
+                : "Paste a custom ComfyUI workflow JSON (API format). Use placeholders like %prompt%, %negative_prompt%, %width%, %height%, %seed%, %model%, %steps%, %cfg%, %sampler%, %scheduler%, and %denoise%. Leave empty to use the built-in default txt2img workflow."
+              }
             >
               <textarea
                 ref={comfyWorkflowTextareaRef}

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -730,6 +730,11 @@ const COLUMN_MIGRATIONS: ColumnMigration[] = [
     column: "sort_order",
     definition: "INTEGER NOT NULL DEFAULT 0",
   },
+  {
+    table: "api_connections",
+    column: "image_endpoint_id",
+    definition: "TEXT",
+  },
 ];
 
 /**

--- a/packages/server/src/db/schema/connections.ts
+++ b/packages/server/src/db/schema/connections.ts
@@ -50,6 +50,8 @@ export const apiConnections = sqliteTable("api_connections", {
   comfyuiWorkflow: text("comfyui_workflow"),
   /** Image generation: explicitly selected service ID (e.g. "comfyui", "automatic1111"). Overrides URL inference. */
   imageService: text("image_service"),
+  /** For endpoint-based image services (e.g. RunPod Serverless ComfyUI): the endpoint ID. */
+  imageEndpointId: text("image_endpoint_id"),
   /** Default generation parameters (stored as JSON) for new chats using this connection */
   defaultParameters: text("default_parameters"),
   /** Optional prompt preset override for roleplay/visual-novel chats using this connection */

--- a/packages/server/src/routes/connections.routes.ts
+++ b/packages/server/src/routes/connections.routes.ts
@@ -224,6 +224,14 @@ export async function connectionsRoutes(app: FastifyInstance) {
       } else if (conn.provider === "image_generation" && imageSource === "automatic1111") {
         // AUTOMATIC1111 / SD Web UI: ping the internal ping endpoint
         testUrl = `${baseUrl}/sdapi/v1/options`;
+      } else if (conn.provider === "image_generation" && imageSource === "runpod_comfyui") {
+        // RunPod: use Test Image to verify — no cheap endpoint test available
+        return {
+          success: true,
+          message: "RunPod endpoint configured. Use 'Test Image' to verify generation works.",
+          latencyMs: Date.now() - start,
+          modelName: conn.model,
+        };
       } else {
         testUrl = `${baseUrl}${provider?.modelsEndpoint || "/models"}`;
       }
@@ -572,6 +580,7 @@ export async function connectionsRoutes(app: FastifyInstance) {
       const result = await generateImage(imgSource, baseUrl, imgApiKey, imgServiceHint, {
         prompt: BASE_PROMPT,
         model: imgModel || undefined,
+        imageEndpointId: (conn.imageEndpointId as string | undefined) ?? undefined,
         width: 512,
         height: 512,
         comfyWorkflow: conn.comfyuiWorkflow || undefined,

--- a/packages/server/src/services/image/image-generation.ts
+++ b/packages/server/src/services/image/image-generation.ts
@@ -22,6 +22,7 @@ import {
   type NovelAiDefaults,
 } from "@marinara-engine/shared";
 import { isImageLocalUrlsEnabled } from "../../config/runtime-config.js";
+import { generateRunPodComfyUI } from "./runpod-comfyui.service.js";
 import { normalizeLoopbackUrl, safeFetch, validateOutboundUrl } from "../../utils/security.js";
 
 const GALLERY_DIR = join(DATA_DIR, "gallery");
@@ -43,6 +44,8 @@ export interface ImageGenRequest {
   width?: number;
   height?: number;
   model?: string;
+  /** For endpoint-based image services (e.g. RunPod): the endpoint/instance ID. */
+  imageEndpointId?: string;
   /** Optional ComfyUI workflow JSON. Placeholders like %prompt%, %width%, %height%, %seed% will be replaced. */
   comfyWorkflow?: string;
   /** Optional connection-scoped defaults for local Stable Diffusion backends. */
@@ -78,6 +81,7 @@ const EXPLICIT_IMAGE_SOURCES = new Set([
   "xai",
   "comfyui",
   "automatic1111",
+  "runpod_comfyui",
   "gemini_image",
 ]);
 
@@ -143,6 +147,16 @@ export async function generateImage(
       return generateXAI(normalizedBaseUrl, apiKey, scopedRequest);
     case "comfyui":
       return generateComfyUI(normalizedBaseUrl, scopedRequest);
+    case "runpod_comfyui": {
+      const endpointId = scopedRequest.imageEndpointId || "";
+      if (!endpointId) {
+        throw new Error(
+          "RunPod ComfyUI requires an endpoint ID. " +
+          "Enter your RunPod endpoint ID in the Endpoint ID field (e.g. 'abc123def456').",
+        );
+      }
+      return generateRunPodComfyUI(normalizedBaseUrl, endpointId, apiKey, scopedRequest);
+    }
     case "automatic1111":
       return generateAutomatic1111(normalizedBaseUrl, scopedRequest);
     case "gemini_image":

--- a/packages/server/src/services/image/runpod-comfyui.service.ts
+++ b/packages/server/src/services/image/runpod-comfyui.service.ts
@@ -1,0 +1,270 @@
+// ──────────────────────────────────────────────
+// Service: RunPod Serverless ComfyUI
+// ──────────────────────────────────────────────
+// Communicates with RunPod serverless endpoints running ComfyUI workflows.
+// Uses the RunPod async job API:
+//   POST /v2/{endpoint_id}/run  →  receive { id }
+//   GET  /v2/{endpoint_id}/status/{job_id}  →  poll until COMPLETED
+//   Extract images from output.images[n].data (raw base64)
+//
+// API format (confirmed via testing):
+//   Input:  { "input": { "workflow": <full ComfyUI workflow JSON> } }
+//   Output: { "output": { "images": [{ "data": "<base64>", "filename": "...", "type": "base64" }] } }
+//
+// The prompt is embedded in the workflow JSON (e.g. CLIPTextEncode node text),
+// so placeholder substitution (%prompt%, %seed%, etc.) must happen BEFORE sending.
+
+import type { ImageGenRequest, ImageGenResult } from "./image-generation.js";
+
+const RUNPOD_POLL_INTERVAL_MS = Number(process.env.RUNPOD_POLL_INTERVAL_MS ?? 2_000);
+const RUNPOD_MAX_POLLS = 90; // 90 × 2s = 3 minutes max
+const RUNPOD_API_BASE = process.env.RUNPOD_API_BASE_URL ?? "https://api.runpod.ai/v2";
+
+interface RunPodRunResponse {
+  id: string;
+}
+
+interface RunPodStatusResponse {
+  id: string;
+  status: "IN_QUEUE" | "IN_PROGRESS" | "COMPLETED" | "FAILED" | "CANCELLED";
+  output?: {
+    images?: Array<Record<string, unknown>>;
+  };
+  error?: string;
+}
+
+/**
+ * Generate an image via a RunPod Serverless ComfyUI endpoint.
+ *
+ * The endpoint ID comes from the dedicated `image_endpoint_id` connection field.
+ * The workflow JSON (with placeholders already substituted) comes from
+ * the connection's `comfyui_workflow` field.
+ *
+ * @param baseUrl     - RunPod API base URL (e.g. "https://api.runpod.ai/v2" or test URL)
+ * @param endpointId  - RunPod endpoint ID (e.g. "abc123def456")
+ * @param apiKey      - RunPod API Bearer token
+ * @param request     - Image gen request with comfyWorkflow containing prompt
+ */
+export async function generateRunPodComfyUI(
+  baseUrl: string,
+  endpointId: string,
+  apiKey: string,
+  request: ImageGenRequest,
+): Promise<ImageGenResult> {
+  const endpointUrl = `${baseUrl}/${endpointId}`;
+  const headers = {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${apiKey}`,
+  };
+
+  // The workflow JSON should already be substituted by the caller
+  // (see generateImage() switch case → placeholder replacement happens earlier).
+  // If there's no workflow, this is an error — RunPod needs the workflow.
+  if (!request.comfyWorkflow) {
+    throw new Error(
+      "RunPod ComfyUI requires a workflow JSON. " +
+      "Paste your ComfyUI workflow (API format) in the connection's workflow field.",
+    );
+  }
+
+  // ── Substitute placeholders (%prompt%, %seed%, etc.) ──
+  // The workflow JSON string contains placeholders like %prompt% and %seed%.
+  // Replace them before parsing, matching the local ComfyUI handler behaviour.
+  const seed = request.imageDefaults?.seed ?? -1;
+  const resolvedSeed = seed === -1 ? Math.floor(Math.random() * 2_147_483_647) : seed;
+
+  let wfStr = request.comfyWorkflow;
+  wfStr = wfStr.replace(/%prompt%/g, escapeJsonStr(request.prompt || ""));
+  wfStr = wfStr.replace(/%negative_prompt%/g, escapeJsonStr(request.negativePrompt || ""));
+  wfStr = wfStr.replace(/%width%/g, String(request.width ?? 512));
+  wfStr = wfStr.replace(/%height%/g, String(request.height ?? 768));
+  wfStr = wfStr.replace(/%seed%/g, String(resolvedSeed));
+
+  let workflow: Record<string, unknown>;
+  try {
+    workflow = JSON.parse(wfStr) as Record<string, unknown>;
+  } catch {
+    throw new Error("Invalid ComfyUI workflow JSON for RunPod endpoint");
+  }
+
+  // ── Step 1: Submit the job ──
+  const jobResp = await fetch(`${endpointUrl}/run`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ input: { workflow } }),
+    signal: AbortSignal.timeout(30_000),
+  });
+
+  if (!jobResp.ok) {
+    const errText = await jobResp.text().catch(() => "Unknown error");
+    throw new Error(
+      `RunPod job submission failed (${jobResp.status}): ${sanitizeRunPodError(errText)}`,
+    );
+  }
+
+  const { id: jobId } = (await jobResp.json()) as RunPodRunResponse;
+  if (!jobId) {
+    throw new Error("RunPod did not return a job ID");
+  }
+
+  // ── Step 2: Poll for completion ──
+  for (let attempt = 0; attempt < RUNPOD_MAX_POLLS; attempt++) {
+    await new Promise((r) => setTimeout(r, RUNPOD_POLL_INTERVAL_MS));
+
+    const statusResp = await fetch(`${endpointUrl}/status/${jobId}`, {
+      method: "GET",
+      headers,
+      signal: AbortSignal.timeout(30_000),
+    });
+
+    if (!statusResp.ok) {
+      const errText = await statusResp.text().catch(() => "Unknown error");
+      throw new Error(
+        `RunPod status check failed (${statusResp.status}): ${sanitizeRunPodError(errText)}`,
+      );
+    }
+
+    const status = (await statusResp.json()) as RunPodStatusResponse;
+
+    switch (status.status) {
+      case "COMPLETED":
+        return extractRunPodImage(status, endpointId);
+      case "FAILED":
+        throw new Error(`RunPod generation failed: ${status.error || "Unknown error"}`);
+      case "CANCELLED":
+        throw new Error("RunPod generation was cancelled");
+      // IN_QUEUE / IN_PROGRESS → keep polling
+    }
+  }
+
+  throw new Error("RunPod generation timed out after 3 minutes");
+}
+
+/**
+ * Extract the first image from a COMPLETED RunPod response.
+ *
+ * Expected format:
+ *   { output: { images: [{ data: "<base64>", filename: "...", type: "base64" }] } }
+ */
+function extractRunPodImage(
+  status: RunPodStatusResponse,
+  endpointId: string,
+): ImageGenResult {
+  const output = status.output;
+
+  if (!output) {
+    throw new Error(
+      `RunPod returned COMPLETED but no output data (endpoint: ${endpointId})`,
+    );
+  }
+
+  const images = output.images;
+  if (!Array.isArray(images) || images.length === 0) {
+    throw new Error(
+      `RunPod returned COMPLETED but output.images was empty or missing. ` +
+      `Check that your workflow has a SaveImage node connected to the output.`,
+    );
+  }
+
+  // Try each image in order, take the first valid one
+  for (const item of images) {
+    if (!item || typeof item !== "object") continue;
+    const img = item as Record<string, unknown>;
+
+    // Main field is "data" containing raw base64
+    const data = typeof img.data === "string" ? img.data : null;
+    if (data && data.length > 0) {
+      const trimmed = data.trim();
+      // Could be data URL or raw base64
+      if (trimmed.startsWith("data:")) {
+        return decodeDataUrl(trimmed);
+      }
+      // Raw base64 (most common for RunPod)
+      if (/^[A-Za-z0-9+/]*={0,2}$/.test(trimmed)) {
+        const mimeType = detectImageMimeType(trimmed);
+        return {
+          base64: trimmed,
+          mimeType,
+          ext: imageExtensionFromMimeType(mimeType),
+        };
+      }
+    }
+
+    // Also try "base64" or "image" keys (defensive fallback)
+    const fallbackBase64 =
+      typeof img.base64 === "string"
+        ? img.base64
+        : typeof img.image === "string"
+          ? img.image
+          : null;
+
+    if (fallbackBase64) {
+      const trimmed = fallbackBase64.trim();
+      const mimeType = detectImageMimeType(trimmed);
+      return {
+        base64: trimmed,
+        mimeType,
+        ext: imageExtensionFromMimeType(mimeType),
+      };
+    }
+  }
+
+  throw new Error(
+    `Could not extract image from RunPod output. ` +
+    `Found ${images.length} image(s) but none had valid base64 data. ` +
+    `Output preview: ${JSON.stringify(output).slice(0, 300)}`,
+  );
+}
+
+// ── Helpers ──
+
+function sanitizeRunPodError(text: string): string {
+  if (!text.includes("<")) return text.slice(0, 300);
+  return text.replace(/<[^>]*>/g, " ").replace(/\s+/g, " ").trim().slice(0, 300);
+}
+
+function detectImageMimeType(base64: string): string {
+  const bytes = Buffer.from(base64.slice(0, 64), "base64");
+  if (bytes[0] === 0x89 && bytes[1] === 0x50 && bytes[2] === 0x4e && bytes[3] === 0x47)
+    return "image/png";
+  if (bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) return "image/jpeg";
+  if (
+    bytes[0] === 0x52 &&
+    bytes[1] === 0x49 &&
+    bytes[2] === 0x46 &&
+    bytes[3] === 0x46 &&
+    bytes[8] === 0x57 &&
+    bytes[9] === 0x45 &&
+    bytes[10] === 0x42 &&
+    bytes[11] === 0x50
+  ) {
+    return "image/webp";
+  }
+  return "image/png";
+}
+
+function imageExtensionFromMimeType(mimeType: string): string {
+  if (mimeType.includes("jpeg") || mimeType.includes("jpg")) return "jpg";
+  if (mimeType.includes("webp")) return "webp";
+  if (mimeType.includes("gif")) return "gif";
+  return "png";
+}
+
+function decodeDataUrl(dataUrl: string): ImageGenResult {
+  const match = dataUrl.trim().match(/^data:(image\/(?:png|jpe?g|webp|gif));base64,([\s\S]+)$/i);
+  if (!match) throw new Error("Invalid image data URL from RunPod output");
+
+  const declaredMimeType = match[1]!.toLowerCase().replace("image/jpg", "image/jpeg");
+  const encoded = match[2]!.replace(/\s+/g, "");
+  const buffer = Buffer.from(encoded, "base64");
+  if (buffer.byteLength === 0) throw new Error("Empty image data from RunPod");
+
+  const base64 = buffer.toString("base64");
+  const mimeType = detectImageMimeType(base64) || declaredMimeType;
+  return { base64, mimeType, ext: imageExtensionFromMimeType(mimeType) };
+}
+
+/** Escape a string for safe insertion into a JSON string value (backslash + quote escaping). */
+function escapeJsonStr(str: string): string {
+  return str.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}

--- a/packages/server/src/services/storage/connections.storage.ts
+++ b/packages/server/src/services/storage/connections.storage.ts
@@ -88,6 +88,7 @@ export function createConnectionsStorage(db: DB) {
         imageGenerationSource: input.imageGenerationSource ?? null,
         comfyuiWorkflow: input.comfyuiWorkflow ?? null,
         imageService: input.imageService ?? null,
+        imageEndpointId: input.imageEndpointId ?? null,
         promptPresetId: input.promptPresetId ?? null,
         maxTokensOverride: input.maxTokensOverride ?? null,
         claudeFastMode: String(input.claudeFastMode ?? false),
@@ -166,6 +167,9 @@ export function createConnectionsStorage(db: DB) {
       if (data.imageService !== undefined) {
         updateFields.imageService = data.imageService;
       }
+      if (data.imageEndpointId !== undefined) {
+        updateFields.imageEndpointId = data.imageEndpointId;
+      }
       if (data.promptPresetId !== undefined) {
         updateFields.promptPresetId = data.promptPresetId;
       }
@@ -209,6 +213,7 @@ export function createConnectionsStorage(db: DB) {
         imageGenerationSource: source.imageGenerationSource,
         comfyuiWorkflow: source.comfyuiWorkflow,
         imageService: source.imageService,
+        imageEndpointId: source.imageEndpointId,
         promptPresetId: source.promptPresetId,
         maxTokensOverride: source.maxTokensOverride,
         maxParallelJobs: source.maxParallelJobs,

--- a/packages/server/test/runpod-comfyui.test.ts
+++ b/packages/server/test/runpod-comfyui.test.ts
@@ -1,0 +1,255 @@
+import assert from "node:assert/strict";
+import { createServer, type AddressInfo } from "node:http";
+import { test } from "node:test";
+
+const PNG_1X1_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/w8AAwMCAO+/p9sAAAAASUVORK5CYII=";
+
+const WORKFLOW_JSON = JSON.stringify({
+  "3": {
+    class_type: "KSampler",
+    inputs: { seed: 42, steps: 5, cfg: 1, sampler_name: "euler", scheduler: "normal", denoise: 1 },
+  },
+  "268": {
+    class_type: "CLIPTextEncode",
+    inputs: { text: "a cat", clip: ["39", 0] },
+  },
+});
+
+const { generateRunPodComfyUI } = await import(
+  "../src/services/image/runpod-comfyui.service.js"
+);
+
+test("RunPod — rejects missing workflow", async () => {
+  await assert.rejects(
+    () => generateRunPodComfyUI("http://localhost:9999", "ep-id", "key", { prompt: "test" }),
+    /requires a workflow/,
+  );
+});
+
+test("RunPod — rejects invalid workflow JSON", async () => {
+  await assert.rejects(
+    () => generateRunPodComfyUI("http://localhost:9999", "ep-id", "key", {
+      prompt: "test",
+      comfyWorkflow: "not-json{{{",
+    }),
+    /Invalid ComfyUI workflow JSON/,
+  );
+});
+
+test("RunPod — successful, completes on first poll", async () => {
+  const endpointId = "ep-pass-1";
+  const jobId = "job-001";
+  let pollCount = 0;
+
+  const server = createServer((req, res) => {
+    if (req.method === "POST" && req.url === `/v2/${endpointId}/run`) {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ id: jobId }));
+      return;
+    }
+    if (req.method === "GET" && req.url === `/v2/${endpointId}/status/${jobId}`) {
+      pollCount++;
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(
+        JSON.stringify({
+          id: jobId,
+          status: "COMPLETED",
+          output: { images: [{ data: PNG_1X1_BASE64, filename: "img.png", type: "base64" }] },
+        }),
+      );
+      return;
+    }
+    res.writeHead(404);
+    res.end("{}");
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+
+  process.env.RUNPOD_POLL_INTERVAL_MS = "10";
+  const result = await generateRunPodComfyUI(`http://127.0.0.1:${port}/v2`, endpointId, "key", {
+    prompt: "a cat",
+    comfyWorkflow: WORKFLOW_JSON,
+  });
+
+  assert.equal(pollCount, 1);
+  assert.ok(result.base64.length > 10); // 1x1 PNG is ~86 chars; any non-empty image passes
+  assert.equal(result.mimeType, "image/png");
+  assert.equal(result.ext, "png");
+  server.close();
+  delete process.env.RUNPOD_POLL_INTERVAL_MS;
+});
+
+test("RunPod — multiple polls before completion", async () => {
+  const endpointId = "ep-poll-2";
+  const jobId = "job-002";
+  let pollCount = 0;
+
+  const server = createServer((req, res) => {
+    if (req.method === "POST" && req.url === `/v2/${endpointId}/run`) {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ id: jobId }));
+      return;
+    }
+    if (req.method === "GET" && req.url === `/v2/${endpointId}/status/${jobId}`) {
+      pollCount++;
+      const status = pollCount <= 2 ? "IN_PROGRESS" : "COMPLETED";
+      const output =
+        status === "COMPLETED"
+          ? { images: [{ data: PNG_1X1_BASE64, filename: "img.png", type: "base64" }] }
+          : undefined;
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ id: jobId, status, output }));
+      return;
+    }
+    res.writeHead(404);
+    res.end("{}");
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+
+  process.env.RUNPOD_POLL_INTERVAL_MS = "10";
+  const result = await generateRunPodComfyUI(`http://127.0.0.1:${port}/v2`, endpointId, "key", {
+    prompt: "a cat",
+    comfyWorkflow: WORKFLOW_JSON,
+  });
+  delete process.env.RUNPOD_POLL_INTERVAL_MS;
+
+  assert.equal(pollCount, 3);
+  assert.ok(result.base64.length > 10);
+  server.close();
+});
+
+test("RunPod — rejects FAILED status", async () => {
+  const endpointId = "ep-fail-3";
+  const jobId = "job-003";
+
+  const server = createServer((req, res) => {
+    if (req.method === "POST" && req.url === `/v2/${endpointId}/run`) {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ id: jobId }));
+      return;
+    }
+    if (req.method === "GET" && req.url === `/v2/${endpointId}/status/${jobId}`) {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ id: jobId, status: "FAILED", error: "Out of memory" }));
+      return;
+    }
+    res.writeHead(404);
+    res.end("{}");
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+
+  process.env.RUNPOD_POLL_INTERVAL_MS = "10";
+  await assert.rejects(
+    () =>
+      generateRunPodComfyUI(`http://127.0.0.1:${port}/v2`, endpointId, "key", {
+        prompt: "test",
+        comfyWorkflow: WORKFLOW_JSON,
+      }),
+    /Out of memory/,
+  );
+  delete process.env.RUNPOD_POLL_INTERVAL_MS;
+  server.close();
+});
+
+test("RunPod — rejects CANCELLED status", async () => {
+  const endpointId = "ep-cancel-4";
+  const jobId = "job-004";
+
+  const server = createServer((req, res) => {
+    if (req.method === "POST" && req.url === `/v2/${endpointId}/run`) {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ id: jobId }));
+      return;
+    }
+    if (req.method === "GET" && req.url === `/v2/${endpointId}/status/${jobId}`) {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ id: jobId, status: "CANCELLED" }));
+      return;
+    }
+    res.writeHead(404);
+    res.end("{}");
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+
+  process.env.RUNPOD_POLL_INTERVAL_MS = "10";
+  await assert.rejects(
+    () =>
+      generateRunPodComfyUI(`http://127.0.0.1:${port}/v2`, endpointId, "key", {
+        prompt: "test",
+        comfyWorkflow: WORKFLOW_JSON,
+      }),
+    /cancelled/i,
+  );
+  delete process.env.RUNPOD_POLL_INTERVAL_MS;
+  server.close();
+});
+
+test("RunPod — rejects HTTP 401 on submit", async () => {
+  const endpointId = "ep-401-5";
+
+  const server = createServer((req, res) => {
+    if (req.method === "POST" && req.url === `/v2/${endpointId}/run`) {
+      res.writeHead(401, { "content-type": "application/json" });
+      res.end(JSON.stringify({ error: "Unauthorized" }));
+      return;
+    }
+    res.writeHead(404);
+    res.end("{}");
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+
+  await assert.rejects(
+    () =>
+      generateRunPodComfyUI(`http://127.0.0.1:${port}/v2`, endpointId, "bad-key", {
+        prompt: "test",
+        comfyWorkflow: WORKFLOW_JSON,
+      }),
+    /401/,
+  );
+  server.close();
+});
+
+test("RunPod — empty output.images throws clear error", async () => {
+  const endpointId = "ep-noimg-6";
+  const jobId = "job-006";
+
+  const server = createServer((req, res) => {
+    if (req.method === "POST" && req.url === `/v2/${endpointId}/run`) {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ id: jobId }));
+      return;
+    }
+    if (req.method === "GET" && req.url === `/v2/${endpointId}/status/${jobId}`) {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ id: jobId, status: "COMPLETED", output: { images: [] } }));
+      return;
+    }
+    res.writeHead(404);
+    res.end("{}");
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+
+  process.env.RUNPOD_POLL_INTERVAL_MS = "10";
+  await assert.rejects(
+    () =>
+      generateRunPodComfyUI(`http://127.0.0.1:${port}/v2`, endpointId, "key", {
+        prompt: "test",
+        comfyWorkflow: WORKFLOW_JSON,
+      }),
+    /empty or missing/,
+  );
+  delete process.env.RUNPOD_POLL_INTERVAL_MS;
+  server.close();
+});

--- a/packages/shared/src/constants/model-lists.ts
+++ b/packages/shared/src/constants/model-lists.ts
@@ -485,6 +485,13 @@ export const IMAGE_GENERATION_SOURCES: ImageGenSource[] = [
     requiresApiKey: false,
   },
   {
+    id: "runpod_comfyui",
+    name: "RunPod Serverless (ComfyUI)",
+    description: "RunPod serverless endpoint running a ComfyUI workflow for text-to-image generation.",
+    defaultBaseUrl: "https://api.runpod.ai/v2",
+    requiresApiKey: true,
+  },
+  {
     id: "drawthings",
     name: "Draw Things",
     description: "macOS / iOS local image generation via Draw Things.",
@@ -576,6 +583,7 @@ export function inferImageSource(model: string, baseUrl: string): string {
     m === "xai" ||
     m === "comfyui" ||
     m === "automatic1111" ||
+    m === "runpod_comfyui" ||
     m === "gemini_image"
   ) {
     return m;
@@ -594,6 +602,7 @@ export function inferImageSource(model: string, baseUrl: string): string {
   if (u.includes("stablehorde.net")) return "horde";
   if (u.includes("blockentropy")) return "blockentropy";
   if (u.includes(":8188") || u.includes("comfyui")) return "comfyui";
+  if (u.includes("runpod.ai")) return "runpod_comfyui";
   if (u.includes(":7860") && !u.includes("drawthings")) return "automatic1111";
   // Gemini image models generate via chat completions (native or proxy)
   if (m.includes("gemini") && m.includes("image")) return "gemini_image";

--- a/packages/shared/src/schemas/connection.schema.ts
+++ b/packages/shared/src/schemas/connection.schema.ts
@@ -37,6 +37,7 @@ export const createConnectionSchema = z.object({
   imageGenerationSource: z.string().nullable().default(null),
   comfyuiWorkflow: z.string().nullable().default(null),
   imageService: z.string().nullable().default(null),
+  imageEndpointId: z.string().nullable().default(null),
   promptPresetId: z.string().nullable().default(null),
   maxTokensOverride: z.number().int().min(1).nullable().default(null),
   maxParallelJobs: z.number().int().min(1).max(16).default(1),

--- a/packages/shared/src/types/connection.ts
+++ b/packages/shared/src/types/connection.ts
@@ -50,6 +50,8 @@ export interface APIConnection {
   comfyuiWorkflow: string | null;
   /** Explicitly selected image generation service ID (e.g. "comfyui", "automatic1111"). Overrides URL inference when set. */
   imageService: string | null;
+  /** For endpoint-based image services (e.g. RunPod Serverless): the endpoint ID sent alongside the base URL. */
+  imageEndpointId: string | null;
   /** Default generation parameters for new chats using this connection (JSON) */
   defaultParameters: string | null;
   /** Prompt preset to use instead of a chat's selected preset when this connection is active */


### PR DESCRIPTION
## Linked issue

Closes #885

https://github.com/Pasta-Devs/Marinara-Engine/issues/885 - Integration of Runpod Serverless endpoint option for image gen.

## Why this change

This allows the creation of image gen connections targetting [runpod ](https://www.runpod.io/) [serverless](https://www.runpod.io/product/serverless) endpoints through the normal connection creation.

-

## What changed

9 files · 607 additions · 3 deletions

### New provider - RunPod Serverless ComfyUI

- Added runpod_comfyui to IMAGE_GENERATION_SOURCES, EXPLICIT_IMAGE_SOURCES, and inferImageSource() — registers RunPod Serverless ComfyUI as a first-class image generation backend

- New handler (packages/server/src/services/image/runpod-comfyui.service.ts) communicates with RunPod's async job API (POST /run → poll /status/{id} → extract base64 from output.images[0].data). Substitutes %prompt%, %seed%, %width%, %height% placeholders before sending the workflow JSON

### New DB column -image_endpoint_id

- Added to the api_connections schema, migration, and shared APIConnection type — a dedicated field for endpoint-based image services so users don't need to repurpose the model field

### UI - Connection editor

- New Endpoint ID text field when RunPod is selected in the image source dropdown
- ComfyUI workflow JSON textarea now visible for RunPod connections (labelled "Required")
- Amber config hint explaining the setup

### Route fix - /test endpoint

- RunPod connections return a friendly message directing users to "Test Image" instead of hitting /models and getting a 404

### Tests - 8 new unit tests

- Mock HTTP server tests covering: successful generation (first-poll and multi-poll), failed/cancelled jobs, auth errors, missing workflow, invalid JSON, and empty output handling

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

Have ran this as a container, created a connection to my runpod serverless endpoint and generated images sucessfully, including testing the connection and generating a test image and using it in GM mode as illustrator. This leverages mostly the normal comfyui features so changes are quite tight and limited in scope.

-

## Docs and release impact

- [X] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed - unsure if this is worthy of a changelog entry.
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

New state when creating:

<img width="766" height="1056" alt="image" src="https://github.com/user-attachments/assets/403e2576-8073-416d-9269-aba645b92ec5" />

And testing:

<img width="776" height="1047" alt="image" src="https://github.com/user-attachments/assets/f5112b5b-d550-4411-852b-93ba08ad8908" />