### PR TITLE
Fix profile import completeness

### DIFF
--- a/packages/server/src/routes/backup.routes.ts
+++ b/packages/server/src/routes/backup.routes.ts
@@ -2,10 +2,12 @@
 // Routes: Backup
 // ──────────────────────────────────────────────
 import type { FastifyInstance, FastifyReply } from "fastify";
-import { basename, join, relative } from "path";
+import { basename, dirname, join, relative } from "path";
 import { existsSync, readdirSync, statSync } from "fs";
-import { cp, mkdir, copyFile, readFile, writeFile } from "fs/promises";
+import { cp, mkdir, copyFile, readFile, readdir, writeFile } from "fs/promises";
 import AdmZip from "adm-zip";
+import { FILE_BACKED_TABLES } from "../db/file-backed-store.js";
+import * as schema from "../db/schema/index.js";
 import { createCharactersStorage } from "../services/storage/characters.storage.js";
 import { createLorebooksStorage } from "../services/storage/lorebooks.storage.js";
 import { createPromptsStorage } from "../services/storage/prompts.storage.js";
@@ -22,9 +24,17 @@ import { logger } from "../lib/logger.js";
 
 /** Directories inside DATA_DIR that should be included in every backup. */
 const BACKUP_DIRS = ["storage", "avatars", "sprites", "backgrounds", "gallery", "fonts", "knowledge-sources"];
+const PROFILE_ASSET_DIRS = BACKUP_DIRS.filter((dirName) => dirName !== "storage");
 const PROFILE_IMPORT_BODY_LIMIT_BYTES = 256 * 1024 * 1024;
 
 type ExportFormat = "native" | "compatible";
+type ProfileTableSnapshots = Record<string, Array<Record<string, unknown>>>;
+type ProfileFileAsset = { path: string; data: string; size: number };
+type ProfileStorageSnapshot = {
+  version: 1;
+  tables: ProfileTableSnapshots;
+  files: ProfileFileAsset[];
+};
 
 function resolveBackupDir(dataDir: string, dirName: string) {
   return dirName === "storage" ? getFileStorageDir() : join(dataDir, dirName);
@@ -182,6 +192,173 @@ function redactAgentSecrets(agent: any) {
   return { ...agent, settings: redactSettings(agent.settings) };
 }
 
+function symbolValue<T>(target: object, symbolName: string): T | undefined {
+  const symbol = Object.getOwnPropertySymbols(target).find((entry) => String(entry) === symbolName);
+  return symbol ? (target as Record<symbol, T>)[symbol] : undefined;
+}
+
+function isSchemaTable(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && symbolValue(value as object, "Symbol(drizzle:IsDrizzleTable)"));
+}
+
+function schemaTableName(table: Record<string, unknown>) {
+  return symbolValue<string>(table, "Symbol(drizzle:Name)") ?? null;
+}
+
+const profileTableObjects = new Map<string, Record<string, unknown>>();
+for (const candidate of Object.values(schema)) {
+  if (!isSchemaTable(candidate)) continue;
+  const tableName = schemaTableName(candidate);
+  if (tableName && FILE_BACKED_TABLES.includes(tableName as (typeof FILE_BACKED_TABLES)[number])) {
+    profileTableObjects.set(tableName, candidate);
+  }
+}
+
+function sanitizeProfileTableRows(tableName: string, rows: Array<Record<string, unknown>>) {
+  if (tableName === "api_connections") {
+    return rows.map((row) => ({ ...row, apiKeyEncrypted: "" }));
+  }
+  if (tableName === "agent_configs") {
+    return rows.map((row) => redactAgentSecrets(row));
+  }
+  return rows;
+}
+
+async function buildProfileTableSnapshot(app: FastifyInstance): Promise<ProfileTableSnapshots> {
+  const tables: ProfileTableSnapshots = {};
+
+  for (const tableName of FILE_BACKED_TABLES) {
+    const table = profileTableObjects.get(tableName);
+    if (!table) continue;
+    const rows = (await app.db.select().from(table as any)) as Array<Record<string, unknown>>;
+    tables[tableName] = sanitizeProfileTableRows(tableName, rows);
+  }
+
+  return tables;
+}
+
+function normalizeProfileAssetPath(pathValue: unknown) {
+  if (typeof pathValue !== "string" || !pathValue.trim()) return null;
+  if (pathValue.includes("\0")) return null;
+  const parts = pathValue
+    .replace(/\\/g, "/")
+    .split("/")
+    .filter(Boolean);
+  if (parts.length < 2) return null;
+  if (!PROFILE_ASSET_DIRS.includes(parts[0]!)) return null;
+  if (parts.some((part) => part === "." || part === ".." || part.includes(":"))) return null;
+  return parts.join("/");
+}
+
+async function collectProfileAssetFiles(dataDir: string): Promise<ProfileFileAsset[]> {
+  const files: ProfileFileAsset[] = [];
+
+  for (const dirName of PROFILE_ASSET_DIRS) {
+    const src = join(dataDir, dirName);
+    if (!existsSync(src)) continue;
+    const stack = [src];
+    while (stack.length > 0) {
+      const current = stack.pop()!;
+      for (const entry of await readdir(current, { withFileTypes: true })) {
+        const full = join(current, entry.name);
+        if (entry.isDirectory()) {
+          stack.push(full);
+          continue;
+        }
+        if (!entry.isFile()) continue;
+        const relPath = [dirName, relative(src, full)].filter(Boolean).join("/").split(/[\\/]/g).join("/");
+        const safePath = normalizeProfileAssetPath(relPath);
+        if (!safePath) continue;
+        const buffer = await readFile(full);
+        files.push({ path: safePath, data: buffer.toString("base64"), size: buffer.length });
+      }
+    }
+  }
+
+  return files;
+}
+
+async function buildProfileStorageSnapshot(app: FastifyInstance): Promise<ProfileStorageSnapshot> {
+  return {
+    version: 1,
+    tables: await buildProfileTableSnapshot(app),
+    files: await collectProfileAssetFiles(getDataDir()),
+  };
+}
+
+function isProfileStorageSnapshot(value: unknown): value is ProfileStorageSnapshot {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Partial<ProfileStorageSnapshot>;
+  return candidate.version === 1 && !!candidate.tables && typeof candidate.tables === "object";
+}
+
+async function restoreProfileAssetFiles(dataDir: string, files: ProfileFileAsset[] | undefined) {
+  let restored = 0;
+  if (!Array.isArray(files)) return restored;
+
+  for (const file of files) {
+    const safePath = normalizeProfileAssetPath(file?.path);
+    if (!safePath || typeof file.data !== "string") continue;
+    const outputPath = assertInsideDir(dataDir, join(dataDir, ...safePath.split("/")));
+    await mkdir(dirname(outputPath), { recursive: true });
+    await writeFile(outputPath, Buffer.from(file.data, "base64"));
+    restored++;
+  }
+
+  return restored;
+}
+
+async function importProfileTableSnapshots(app: FastifyInstance, tables: ProfileTableSnapshots) {
+  const imported: Record<string, number> = {};
+
+  for (const tableName of FILE_BACKED_TABLES) {
+    const table = profileTableObjects.get(tableName);
+    const rows = tables[tableName];
+    if (!table || !Array.isArray(rows) || rows.length === 0) {
+      imported[tableName] = 0;
+      continue;
+    }
+
+    const primaryKey = (table as Record<string, unknown>).id;
+    for (const row of rows) {
+      const cleanRow = { ...row };
+      if (tableName === "api_connections") cleanRow.apiKeyEncrypted = "";
+      const insert = (app.db.insert(table as any).values(cleanRow as any) as any);
+      if (primaryKey) {
+        await insert.onConflictDoUpdate({ target: primaryKey, set: cleanRow });
+      } else {
+        await insert;
+      }
+    }
+    imported[tableName] = rows.length;
+  }
+
+  return imported;
+}
+
+function buildProfileImportStats(tableCounts: Record<string, number>, files: number) {
+  return {
+    characters: tableCounts.characters ?? 0,
+    personas: tableCounts.personas ?? 0,
+    lorebooks: tableCounts.lorebooks ?? 0,
+    presets: tableCounts.prompt_presets ?? 0,
+    agents: tableCounts.agent_configs ?? 0,
+    themes: tableCounts.custom_themes ?? 0,
+    chats: tableCounts.chats ?? 0,
+    messages: tableCounts.messages ?? 0,
+    connections: tableCounts.api_connections ?? 0,
+    files,
+    tables: tableCounts,
+  };
+}
+
+async function importProfileStorageSnapshot(app: FastifyInstance, snapshot: ProfileStorageSnapshot) {
+  const tableCounts = await importProfileTableSnapshots(app, snapshot.tables);
+  const files = await restoreProfileAssetFiles(getDataDir(), snapshot.files);
+  await flushDB();
+  return buildProfileImportStats(tableCounts, files);
+}
+
 async function buildProfileExportEnvelope(app: FastifyInstance): Promise<ExportEnvelope> {
   const chars = createCharactersStorage(app.db);
   const lbs = createLorebooksStorage(app.db);
@@ -247,6 +424,7 @@ async function buildProfileExportEnvelope(app: FastifyInstance): Promise<ExportE
       presets: presetExports,
       agents: allAgents,
       themes: allThemes,
+      fileStorage: await buildProfileStorageSnapshot(app),
     },
   };
 }
@@ -468,6 +646,11 @@ export async function backupRoutes(app: FastifyInstance) {
     }
 
     const data = envelope.data as Record<string, any>;
+    if (isProfileStorageSnapshot(data.fileStorage)) {
+      const imported = await importProfileStorageSnapshot(app, data.fileStorage);
+      return { success: true, imported };
+    }
+
     const chars = createCharactersStorage(app.db);
     const lbs = createLorebooksStorage(app.db);
     const presets = createPromptsStorage(app.db);

--- a/packages/server/test/profile-backup-routes.test.ts
+++ b/packages/server/test/profile-backup-routes.test.ts
@@ -1,0 +1,217 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import Fastify, { type FastifyInstance } from "fastify";
+import { backupRoutes } from "../src/routes/backup.routes.js";
+import { createFileNativeDB } from "../src/db/file-backed-store.js";
+import {
+  apiConnections,
+  characterImages,
+  characters,
+  chatImages,
+  chats,
+  lorebookCharacterLinks,
+  lorebooks,
+  messages,
+} from "../src/db/schema/index.js";
+
+const timestamp = "2026-05-15T00:00:00.000Z";
+
+async function withProfileApp<T>(dataDir: string, fn: (app: FastifyInstance) => Promise<T>) {
+  const previousDataDir = process.env.DATA_DIR;
+  const previousStorageDir = process.env.FILE_STORAGE_DIR;
+  process.env.DATA_DIR = dataDir;
+  process.env.FILE_STORAGE_DIR = join(dataDir, "storage");
+
+  const db = await createFileNativeDB([]);
+  const app = Fastify({ logger: false });
+  app.decorate("db", db);
+  await app.register(backupRoutes, { prefix: "/api/backup" });
+
+  try {
+    return await fn(app);
+  } finally {
+    await app.close();
+    await db._fileStore.close();
+    if (previousDataDir === undefined) delete process.env.DATA_DIR;
+    else process.env.DATA_DIR = previousDataDir;
+    if (previousStorageDir === undefined) delete process.env.FILE_STORAGE_DIR;
+    else process.env.FILE_STORAGE_DIR = previousStorageDir;
+  }
+}
+
+async function seedProfileRows(app: FastifyInstance, dataDir: string) {
+  await app.db.insert(characters).values({
+    id: "char-847",
+    data: JSON.stringify({ name: "Profile Character", description: "Roundtrip fixture" }),
+    comment: "",
+    avatarPath: "avatars/char-847.png",
+    spriteFolderPath: null,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  });
+  await app.db.insert(apiConnections).values({
+    id: "conn-847",
+    name: "Roundtrip Connection",
+    provider: "custom",
+    baseUrl: "http://127.0.0.1:1234",
+    apiKeyEncrypted: "redacted-on-profile-export",
+    model: "test-model",
+    maxContext: 8192,
+    isDefault: "false",
+    useForRandom: "false",
+    enableCaching: "false",
+    cachingAtDepth: 5,
+    defaultForAgents: "false",
+    embeddingModel: "",
+    embeddingBaseUrl: "",
+    embeddingConnectionId: null,
+    openrouterProvider: null,
+    imageGenerationSource: null,
+    comfyuiWorkflow: null,
+    imageService: null,
+    defaultParameters: null,
+    promptPresetId: null,
+    maxTokensOverride: null,
+    maxParallelJobs: 1,
+    claudeFastMode: "false",
+    folderId: null,
+    sortOrder: 0,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  });
+  await app.db.insert(chats).values({
+    id: "chat-847",
+    name: "Roundtrip Chat",
+    mode: "roleplay",
+    characterIds: JSON.stringify(["char-847"]),
+    groupId: null,
+    personaId: null,
+    promptPresetId: null,
+    connectionId: "conn-847",
+    metadata: "{}",
+    connectedChatId: null,
+    folderId: null,
+    sortOrder: 0,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  });
+  await app.db.insert(messages).values({
+    id: "msg-847",
+    chatId: "chat-847",
+    role: "user",
+    characterId: null,
+    content: "This message should survive profile import.",
+    activeSwipeIndex: 0,
+    extra: "{}",
+    createdAt: timestamp,
+  });
+  await app.db.insert(lorebooks).values({
+    id: "lore-847",
+    name: "Roundtrip Lorebook",
+    description: "",
+    category: "world",
+    scanDepth: 2,
+    tokenBudget: 2048,
+    recursiveScanning: "false",
+    maxRecursionDepth: 3,
+    characterId: "char-847",
+    personaId: null,
+    chatId: null,
+    isGlobal: "false",
+    enabled: "true",
+    tags: "[]",
+    generatedBy: null,
+    sourceAgentId: null,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  });
+  await app.db.insert(lorebookCharacterLinks).values({
+    id: "link-847",
+    lorebookId: "lore-847",
+    characterId: "char-847",
+    createdAt: timestamp,
+  });
+  await app.db.insert(characterImages).values({
+    id: "character-image-847",
+    characterId: "char-847",
+    filePath: "characters/char-847/gallery.png",
+    prompt: "character gallery",
+    provider: "test",
+    model: "fixture",
+    width: 1,
+    height: 1,
+    createdAt: timestamp,
+  });
+  await app.db.insert(chatImages).values({
+    id: "chat-image-847",
+    chatId: "chat-847",
+    filePath: "chats/chat-847/gallery.png",
+    prompt: "chat gallery",
+    provider: "test",
+    model: "fixture",
+    width: 1,
+    height: 1,
+    createdAt: timestamp,
+  });
+
+  mkdirSync(join(dataDir, "avatars"), { recursive: true });
+  mkdirSync(join(dataDir, "gallery", "characters", "char-847"), { recursive: true });
+  mkdirSync(join(dataDir, "gallery", "chats", "chat-847"), { recursive: true });
+  writeFileSync(join(dataDir, "avatars", "char-847.png"), Buffer.from("avatar"));
+  writeFileSync(join(dataDir, "gallery", "characters", "char-847", "gallery.png"), Buffer.from("character-gallery"));
+  writeFileSync(join(dataDir, "gallery", "chats", "chat-847", "gallery.png"), Buffer.from("chat-gallery"));
+}
+
+test("profile export/import preserves file-native chats, connections, lorebook links, and images", async () => {
+  const root = join(tmpdir(), `marinara-profile-roundtrip-${process.pid}-${Date.now()}`);
+  try {
+    let envelope: Record<string, any> | null = null;
+    await withProfileApp(join(root, "source"), async (app) => {
+      await seedProfileRows(app, join(root, "source"));
+      const response = await app.inject({ method: "GET", url: "/api/backup/export-profile" });
+      assert.equal(response.statusCode, 200, response.body);
+      envelope = JSON.parse(response.body) as Record<string, any>;
+
+      assert.ok(envelope.data.fileStorage?.tables?.chats?.some((row: any) => row.id === "chat-847"));
+      assert.ok(envelope.data.fileStorage?.tables?.messages?.some((row: any) => row.id === "msg-847"));
+      assert.ok(envelope.data.fileStorage?.tables?.api_connections?.some((row: any) => row.id === "conn-847"));
+      assert.equal(
+        envelope.data.fileStorage.tables.api_connections.find((row: any) => row.id === "conn-847").apiKeyEncrypted,
+        "",
+      );
+    });
+
+    await withProfileApp(join(root, "target"), async (app) => {
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/backup/import-profile",
+        headers: { "content-type": "application/json" },
+        payload: JSON.stringify(envelope),
+      });
+      assert.equal(response.statusCode, 200, response.body);
+
+      const restoredChats = await app.db.select().from(chats);
+      const restoredMessages = await app.db.select().from(messages);
+      const restoredConnections = await app.db.select().from(apiConnections);
+      const restoredLinks = await app.db.select().from(lorebookCharacterLinks);
+      const restoredChatImages = await app.db.select().from(chatImages);
+      const restoredCharacterImages = await app.db.select().from(characterImages);
+      const targetDir = join(root, "target");
+
+      assert.ok(restoredChats.some((row) => row.id === "chat-847"));
+      assert.ok(restoredMessages.some((row) => row.id === "msg-847"));
+      assert.ok(restoredConnections.some((row) => row.id === "conn-847" && row.apiKeyEncrypted === ""));
+      assert.ok(restoredLinks.some((row) => row.lorebookId === "lore-847" && row.characterId === "char-847"));
+      assert.ok(restoredChatImages.some((row) => row.id === "chat-image-847"));
+      assert.ok(restoredCharacterImages.some((row) => row.id === "character-image-847"));
+      assert.equal(existsSync(join(targetDir, "avatars", "char-847.png")), true);
+      assert.equal(existsSync(join(targetDir, "gallery", "characters", "char-847", "gallery.png")), true);
+      assert.equal(existsSync(join(targetDir, "gallery", "chats", "chat-847", "gallery.png")), true);
+    });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #847

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- Profile export/import could silently round-trip only a subset of a user's data. Chats, messages, connections, gallery image rows, and other file-native tables were not included in the profile envelope, and semantic lorebook import could leave links pointing at old character IDs.

## What changed

<!-- List the key changes in this PR -->

- Adds a `fileStorage` snapshot to native profile exports so file-native tables round-trip with stable IDs.
- Restores exported profile asset files from `avatars`, `sprites`, `backgrounds`, `gallery`, `fonts`, and `knowledge-sources` during profile import.
- Keeps the existing semantic profile importer as the fallback for older exported profile JSON files.
- Redacts API connection keys and agent secret-like settings in profile snapshots; connection definitions restore, but API keys still need to be re-entered after import.
- Adds a server regression test covering chats, messages, connections, lorebook character links, avatar/gallery files, and API key redaction.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Codex reproduced the bug before the fix with `pnpm --dir packages/server exec tsx ../../scratch/issue-847-profile-roundtrip-repro.ts`: the exported profile lacked a file-native table snapshot, and import restored 0 chats, 0 messages, 0 connections, 0 chat image rows, 0 character image rows, and no gallery files.
- Codex re-ran the same scratch repro after the fix. It now exports `fileStorage` and restores 1 chat, 1 message, 1 connection, 1 lorebook character link, 1 chat image row, 1 character image row, the avatar file, and both gallery files. Output saved locally at `scratch/issue-847-after-output.txt`.
- Codex ran `pnpm --dir packages/server exec tsx --test test/profile-backup-routes.test.ts`; it passed.
- Codex ran `pnpm check`; it passed.
- True human/manual limitation: the reporter's real 82.9 MB Google Drive profile was not imported on this machine. The synthetic repro exercises the same profile export/import route and affected data classes.
- Security note: API key secrets remain intentionally redacted from profile exports, so restored connections may require re-entering API keys.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs or release metadata changed.

## UI evidence (if applicable)

N/A — backend profile export/import route fix. Command proof is listed above.
