### PR TITLE
Fix NovelAI Illustrator prompt handling

### DIFF
--- a/packages/server/src/services/image/image-generation.ts
+++ b/packages/server/src/services/image/image-generation.ts
@@ -1025,7 +1025,7 @@ const NOVELAI_V4_PROMPT_HINT =
   "NovelAI V4/V4.5 prompts support roughly 512 T5 tokens and reject most Unicode prompt characters; try a shorter ASCII prompt without emoji or non-Latin text.";
 
 function isNovelAiV4Model(model: string): boolean {
-  return /nai-diffusion-(?:4|4-5)/i.test(model);
+  return /^nai-diffusion-(?:4(?:-(?:curated-preview|full))?|4-5(?:-(?:curated|full))?)$/i.test(model.trim());
 }
 
 function sanitizeNovelAiV4Prompt(value: string): string {
@@ -1067,7 +1067,7 @@ async function generateNovelAI(baseUrl: string, apiKey: string, request: ImageGe
 
   const url = `${baseUrl.replace(/\/+$/, "")}/ai/generate-image`;
   const model = request.model || "nai-diffusion-4-5-full";
-  const isV4 = model.includes("nai-diffusion-4");
+  const isV4 = isNovelAiV4Model(model);
   const defaults = resolveNovelAiDefaults(request);
   const prompt = prepareNovelAiPrompt(mergePromptPrefix(defaults.promptPrefix, request.prompt), "prompt", model);
   const negativePrompt = prepareNovelAiPrompt(

--- a/packages/server/src/services/image/image-generation.ts
+++ b/packages/server/src/services/image/image-generation.ts
@@ -1021,6 +1021,41 @@ async function generateTogetherAI(baseUrl: string, apiKey: string, request: Imag
   return { base64: b64, mimeType: "image/png", ext: "png" };
 }
 
+const NOVELAI_V4_PROMPT_HINT =
+  "NovelAI V4/V4.5 prompts support roughly 512 T5 tokens and reject most Unicode prompt characters; try a shorter ASCII prompt without emoji or non-Latin text.";
+
+function isNovelAiV4Model(model: string): boolean {
+  return /nai-diffusion-(?:4|4-5)/i.test(model);
+}
+
+function sanitizeNovelAiV4Prompt(value: string): string {
+  return value
+    .replace(/[\u2018\u2019\u201A\u201B]/g, "'")
+    .replace(/[\u201C\u201D\u201E\u201F]/g, '"')
+    .replace(/[\u2010-\u2015\u2212]/g, "-")
+    .replace(/\u2026/g, "...")
+    .replace(/\u00A0/g, " ")
+    .replace(/[\u200B-\u200D\uFEFF]/g, "")
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^\x09\x0A\x0D\x20-\x7E]/g, " ")
+    .replace(/[ \t]+/g, " ")
+    .replace(/\s*\n\s*/g, "\n")
+    .trim();
+}
+
+function prepareNovelAiPrompt(value: string, fieldName: string, model: string): string {
+  if (!isNovelAiV4Model(model)) return value;
+
+  const sanitized = sanitizeNovelAiV4Prompt(value);
+  if (value.trim() && !sanitized) {
+    throw new Error(
+      `NovelAI ${fieldName} contains only unsupported V4/V4.5 prompt characters. ${NOVELAI_V4_PROMPT_HINT}`,
+    );
+  }
+  return sanitized;
+}
+
 async function generateNovelAI(baseUrl: string, apiKey: string, request: ImageGenRequest): Promise<ImageGenResult> {
   // Only use the native NovelAI API format when hitting the actual NovelAI domain.
   // Proxies (linkapi.ai, etc.) expose OpenAI-compatible chat completions that return
@@ -1034,8 +1069,12 @@ async function generateNovelAI(baseUrl: string, apiKey: string, request: ImageGe
   const model = request.model || "nai-diffusion-4-5-full";
   const isV4 = model.includes("nai-diffusion-4");
   const defaults = resolveNovelAiDefaults(request);
-  const prompt = mergePromptPrefix(defaults.promptPrefix, request.prompt);
-  const negativePrompt = mergeNegativePrompt(defaults.negativePromptPrefix, request.negativePrompt);
+  const prompt = prepareNovelAiPrompt(mergePromptPrefix(defaults.promptPrefix, request.prompt), "prompt", model);
+  const negativePrompt = prepareNovelAiPrompt(
+    mergeNegativePrompt(defaults.negativePromptPrefix, request.negativePrompt),
+    "negative prompt",
+    model,
+  );
   const seed = resolveSeed(request.imageDefaults);
 
   const parameters: Record<string, unknown> = {
@@ -1106,7 +1145,8 @@ async function generateNovelAI(baseUrl: string, apiKey: string, request: ImageGe
 
   if (!resp.ok) {
     const errText = await resp.text().catch(() => "Unknown error");
-    throw new Error(`NovelAI image generation failed (${resp.status}): ${sanitizeErrorText(errText)}`);
+    const hint = isV4 ? ` ${NOVELAI_V4_PROMPT_HINT}` : "";
+    throw new Error(`NovelAI image generation failed (${resp.status}): ${sanitizeErrorText(errText)}${hint}`);
   }
 
   // NovelAI returns a zip file containing the image

--- a/packages/server/test/image-generation-local.test.ts
+++ b/packages/server/test/image-generation-local.test.ts
@@ -277,8 +277,8 @@ test("native NovelAI image generation sends stable request settings and embeds m
     });
 
     const result = await generateImage("novelai", `http://127.0.0.1:${port}/novelai.net`, "test-key", "novelai", {
-      prompt: "cat cafe with 東京 neon",
-      negativePrompt: "lowres, déjà vu",
+      prompt: "cat cafe with \u201Cquoted\u201D neon \u2728",
+      negativePrompt: "lowres, d\u00E9j\u00E0 vu",
       model: "nai-diffusion-4-5-full",
       width: 640,
       height: 960,
@@ -287,7 +287,7 @@ test("native NovelAI image generation sends stable request settings and embeds m
     });
 
     const parameters = capturedBody?.parameters as Record<string, unknown>;
-    assert.equal(capturedBody?.input, "best quality, cat cafe with 東京 neon");
+    assert.equal(capturedBody?.input, 'best quality, cat cafe with "quoted" neon');
     assert.equal(capturedBody?.model, "nai-diffusion-4-5-full");
     assert.equal(parameters.seed, 12345);
     assert.equal(parameters.steps, 33);
@@ -296,13 +296,13 @@ test("native NovelAI image generation sends stable request settings and embeds m
     assert.equal(parameters.sampler, "k_dpmpp_2m");
     assert.equal(parameters.noise_schedule, "native");
     assert.equal(parameters.ucPreset, 2);
-    assert.equal(parameters.negative_prompt, "bad anatomy, lowres, déjà vu");
+    assert.equal(parameters.negative_prompt, "bad anatomy, lowres, deja vu");
     assert.deepEqual((parameters.v4_prompt as Record<string, unknown>).caption, {
-      base_caption: "best quality, cat cafe with 東京 neon",
+      base_caption: 'best quality, cat cafe with "quoted" neon',
       char_captions: [],
     });
     assert.deepEqual((parameters.v4_negative_prompt as Record<string, unknown>).caption, {
-      base_caption: "bad anatomy, lowres, déjà vu",
+      base_caption: "bad anatomy, lowres, deja vu",
       char_captions: [],
     });
 
@@ -363,6 +363,46 @@ test("native NovelAI image generation keeps V3 prompt shape", async () => {
     assert.equal(parameters.params_version, undefined);
     assert.equal(parameters.v4_prompt, undefined);
     assert.equal(parameters.v4_negative_prompt, undefined);
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
+    });
+  }
+});
+
+test("native NovelAI V4 generation errors include prompt guidance", async () => {
+  let port = 0;
+  const server = createServer((req, res) => {
+    if (req.method === "POST" && req.url?.endsWith("/ai/generate-image")) {
+      req.resume();
+      req.on("end", () => {
+        res.writeHead(500, { "content-type": "application/json" });
+        res.end(JSON.stringify({ statusCode: 500, message: "Internal Server Error" }));
+      });
+      return;
+    }
+
+    res.writeHead(404);
+    res.end();
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const addressInfo = server.address();
+  assert.ok(addressInfo && typeof addressInfo === "object");
+  port = addressInfo.port;
+
+  try {
+    await assert.rejects(
+      () =>
+        generateImage("novelai", `http://127.0.0.1:${port}/novelai.net`, "test-key", "novelai", {
+          prompt: "cat cafe",
+          model: "nai-diffusion-4-5-full",
+          width: 640,
+          height: 960,
+          allowLocalUrls: true,
+        }),
+      /shorter ASCII prompt/,
+    );
   } finally {
     await new Promise<void>((resolve, reject) => {
       server.close((err) => (err ? reject(err) : resolve()));


### PR DESCRIPTION
## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #852

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- The Illustrator agent can send LLM-authored prompts to NovelAI V4/V4.5 that contain unsupported Unicode characters, while the connection test only proves a simple ASCII prompt. That makes the connection test pass but the Illustrator path fail with an opaque NovelAI 500.

## What changed

<!-- List the key changes in this PR -->

- Normalize NovelAI V4/V4.5 prompt and negative prompt text before sending the native NovelAI request, converting common smart punctuation/diacritics and removing unsupported Unicode prompt characters.
- Add an actionable NovelAI-specific hint to remaining V4/V4.5 provider 500 errors so the UI can explain the likely prompt constraints instead of only showing `Internal Server Error`.
- Extend the local image-generation tests to cover sanitized V4 prompt payloads, unchanged V3 prompt behavior, and the new NovelAI V4 error guidance.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- âš ï¸ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Codex reproduced the request-shape failure with a mocked native NovelAI endpoint: before the fix, a connection-test-like ASCII prompt passed while an Illustrator-like prompt with unsupported Unicode failed with `NovelAI image generation failed (500)`.
- Codex reran the same repro after the fix with output saved at `scratch/issue-852-after-output.txt`: connection-test-like prompt passed, Illustrator-like prompt passed, Unicode negative prompt passed, reference images still passed, and an unsupported-only V4 prompt failed locally with the new actionable error.
- Codex manually exercised the two route call shapes against a local fake native NovelAI endpoint with output saved at `scratch/issue-852-manual-like-output.txt`: the Settings connection-test-shaped request passed, the Illustrator-shaped request passed, the submitted Illustrator prompt/negative prompt were ASCII-normalized, and one reference image was preserved in the NovelAI V4 payload.
- Codex ran `pnpm --dir packages/server exec tsx --import ./test/setup-env.ts --test test/image-generation-local.test.ts` and all 6 tests passed.
- Codex ran `pnpm check` and it passed.
- Real provider/device verification was not available from this environment: no NovelAI API/account credential was present, and the reported Android/Termux setup was not available. Recommended human follow-up: generate one Illustrator image against a real NovelAI account/API key, ideally on Android/Termux.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

N/A - server-side image generation request handling only.
