### PR TITLE
Fix Illustrator retry image connection errors

### DIFF
--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -1943,6 +1943,12 @@ export function useGenerate() {
               }
               break;
             }
+            case "agent_error": {
+              const errData = event.data as { agentType: string; error: string };
+              hasError = true;
+              showError(errData.error || "Agent retry failed");
+              break;
+            }
             case "error": {
               hasError = true;
               showError((event.data as string) || "Agent retry failed");

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -1688,7 +1688,8 @@ async function applyRetryResultEffects(args: {
           const rawSavedNegativePrompt = illustratorAgent?.resolved.settings?.imageNegativePrompt;
           const imagePositivePrompt = typeof rawImagePositivePrompt === "string" ? rawImagePositivePrompt.trim() : "";
           const savedNegativePrompt = typeof rawSavedNegativePrompt === "string" ? rawSavedNegativePrompt.trim() : "";
-          let imgConnId = (illustratorAgent?.resolved.settings?.imageConnectionId as string) ?? null;
+          const configuredImgConnId = illustratorAgent?.resolved.settings?.imageConnectionId;
+          let imgConnId = typeof configuredImgConnId === "string" ? configuredImgConnId.trim() : null;
           if (!imgConnId) {
             const defaultImageConn = (await conns.list()).find(
               (c) =>
@@ -1698,6 +1699,9 @@ async function applyRetryResultEffects(args: {
           }
           if (imgConnId) {
             const imgConnFull = await conns.getWithKey(imgConnId);
+            if (!imgConnFull) {
+              throw new Error("Cannot resolve Illustrator image generation connection");
+            }
             if (imgConnFull) {
               const { generateImage, saveImageToDisk } = await import("../../services/image/image-generation.js");
               const { createGalleryStorage } = await import("../../services/storage/gallery.storage.js");
@@ -1856,6 +1860,16 @@ async function applyRetryResultEffects(args: {
                 (illData.reason as string | undefined)?.slice(0, 80) ?? imagePrompt.slice(0, 80),
               );
             }
+          } else {
+            logger.warn("[retry-agents] Illustrator wants to generate but no image generation connection is configured");
+            sendSseEvent(reply, {
+              type: "agent_error",
+              data: {
+                agentType: "illustrator",
+                error:
+                  "No image generation connection set on the Illustrator agent, and no default Illustrator image connection is configured. Go to Settings -> Connections and mark an image generation connection as the default for Illustrator, or assign one directly in Settings -> Agents -> Illustrator.",
+              },
+            });
           }
         }
       } catch (illErr) {


### PR DESCRIPTION
## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #877

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- Manual Illustrator retry could appear to complete successfully without producing an image when the retry path could not resolve an image-generation connection or emitted an `agent_error` the retry client ignored.

## What changed

<!-- List the key changes in this PR -->

- Normalize a blank Illustrator image connection override so retry falls back to the default image-generation connection.
- Emit an `agent_error` from retry when Illustrator wants to generate but no image connection resolves, and fail stale explicit image connection IDs instead of silently skipping image generation.
- Handle retry-stream `agent_error` events in the client so they show as failures and do not end with a misleading "Agent retry completed" success toast.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Codex reproduced the broken retry/error-path behavior with `node scratch/issue-877-repro.mjs`; before the fix, retry ignored `agent_error`, did not report a missing image connection, and did not fail a stale resolved image connection ID.
- Codex verified the fixed path with `node scratch/issue-877-repro.mjs --after`; it confirmed retry handles `agent_error`, missing image connections emit `agent_error`, stale explicit image connection IDs fail as `agent_error`, blank overrides fall back to the default image-generation connection, and the default image connection lookup still accepts boolean or string `defaultForAgents`.
- Codex ran `pnpm check`, which passed: impeccable context check, lint, shared/server/client build.
- Bunny review before PR: pass. Diff is two scoped files, based on `upstream/staging`, `git diff --check` is clean, no server `console.*`, and no schema/version/dependency/auth/storage/prompt-pipeline files changed.
- No manual-only blocker for the core claim; this is a retry stream/server error-path fix verified by static harness and baseline build.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs or release metadata changes are needed for this scoped bug fix.

## UI evidence (if applicable)

N/A - no layout or visual surface changed. The user-facing behavior is retry error handling/toast state, covered by the retry stream repro above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during agent retries with explicit error message display.
  * Added validation for image connection configuration to prevent silent failures.

* **New Features**
  * Enhanced error notifications when image generation connections are misconfigured, with guidance on setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/891)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->