### PR TITLE
Fix startup port collision handling

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -10,6 +10,10 @@ import { logCsrfTrustSummary } from "./middleware/csrf-protection.js";
 import { startEnvWatcher } from "./config/env-watcher.js";
 import { migrateTaskbarShortcuts } from "./services/setup/taskbar-shortcut-migration.js";
 
+function isAddressInUseError(err: unknown): err is NodeJS.ErrnoException {
+  return err instanceof Error && "code" in err && err.code === "EADDRINUSE";
+}
+
 function scheduleTaskbarShortcutMigration() {
   const timeout = setTimeout(() => {
     const installDir = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
@@ -68,7 +72,15 @@ async function main() {
       return;
     }
 
-    logger.error(err);
+    if (isAddressInUseError(err)) {
+      logger.error(
+        err,
+        "Port %d is already in use. Marinara Engine could not start. Close the app using that port or set PORT to another value, for example PORT=7869 bash ./start.sh on macOS/Linux or set PORT=7869 && start.bat in Windows cmd.",
+        port,
+      );
+    } else {
+      logger.error(err);
+    }
     process.exit(1);
   }
 }

--- a/scripts/check-port-available.mjs
+++ b/scripts/check-port-available.mjs
@@ -1,0 +1,44 @@
+import { createServer } from "node:net";
+
+const rawPort = process.env.PORT ?? "7860";
+const port = Number.parseInt(rawPort, 10);
+const host = process.env.HOST ?? "0.0.0.0";
+
+function printPortBusyMessage() {
+  console.error("");
+  console.error(`  [ERROR] Port ${rawPort} is already in use.`);
+  console.error("  Marinara Engine did not start, and the browser was not opened to avoid showing another local service.");
+  console.error("  Close the app using that port or start Marinara on another port:");
+  console.error("");
+  console.error("    macOS/Linux:       PORT=7869 bash ./start.sh");
+  console.error("    Windows PowerShell: $env:PORT=7869; .\\start.bat");
+  console.error("    Windows cmd:        set PORT=7869 && start.bat");
+  console.error("");
+}
+
+if (!Number.isFinite(port) || port <= 0 || port > 65_535) {
+  console.error("");
+  console.error(`  [ERROR] PORT must be a number from 1 to 65535. Received: ${rawPort}`);
+  console.error("");
+  process.exit(1);
+}
+
+const server = createServer();
+
+server.once("error", (err) => {
+  if (err && typeof err === "object" && "code" in err && err.code === "EADDRINUSE") {
+    printPortBusyMessage();
+  } else {
+    console.error("");
+    console.error(`  [ERROR] Could not check whether ${host}:${rawPort} is available.`);
+    console.error(err);
+    console.error("");
+  }
+  process.exit(1);
+});
+
+server.listen({ host, port }, () => {
+  server.close(() => {
+    process.exit(0);
+  });
+});

--- a/start.bat
+++ b/start.bat
@@ -258,6 +258,12 @@ if defined AUTO_OPEN_BROWSER (
     if /I "%AUTO_OPEN_BROWSER%"=="off" set "AUTO_OPEN_BROWSER_ENABLED="
 )
 
+node scripts\check-port-available.mjs
+if errorlevel 1 (
+    pause
+    goto :eof
+)
+
 echo.
 echo  ==========================================
 echo    Starting Marinara Engine on %PROTOCOL%://127.0.0.1:%PORT%

--- a/start.sh
+++ b/start.sh
@@ -217,6 +217,10 @@ case "$AUTO_OPEN_BROWSER_NORMALIZED" in
   *) AUTO_OPEN_BROWSER_ENABLED=1 ;;
 esac
 
+if ! node scripts/check-port-available.mjs; then
+  exit 1
+fi
+
 echo ""
 echo "  ══════════════════════════════════════════"
 echo "    Starting Marinara Engine on ${PROTOCOL}://127.0.0.1:$PORT"


### PR DESCRIPTION
## Linked issue

Closes #890

## Why this change

- Marinara defaults to port `7860`, which is also a common local image-generation port. When that port is already occupied, startup previously fell through to a raw `EADDRINUSE` path, and the launch scripts could still schedule the browser open before confirming Marinara had bound the port.

## What changed

- Added a shared launcher preflight script that checks whether the configured `PORT` is available before the browser-open step runs.
- Wired the preflight into `start.sh` and `start.bat` so occupied ports print a clear recovery message instead of opening the browser to another local service.
- Added a clearer direct-server `EADDRINUSE` log message for users who bypass the launch scripts.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Codex reproduced the pre-fix failure with `scratch/issue-890-port-repro.mjs --expect=before`, which binds `7860` first and then starts the Marinara server path. Before the fix, startup exited with raw `EADDRINUSE` and no recovery hint.
- Codex verified the fixed direct-server path with `scratch/issue-890-port-repro.mjs --expect=after --out=scratch/issue-890-after-server.txt`; it now prints a clear "Port 7860 is already in use" recovery message.
- Codex verified the fixed launcher preflight with `scratch/issue-890-port-repro.mjs --expect=after --target=preflight --out=scratch/issue-890-after-preflight.txt`; it exits before the banner/browser-open step and tells the user how to choose another port.
- Codex checked edge cases: free default port exits cleanly, occupied alternate port `7869` gets the same recovery message, and invalid `PORT` exits with a numeric range error.
- `pnpm check` passed locally in the issue worktree.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs or version files changed. This PR intentionally does not change Marinara's canonical default port; it only makes occupied-port startup truthful and recoverable.

## UI evidence (if applicable)

Not applicable; this is command/startup behavior. Codex captured visual proof of the command output locally at `scratch/issue-890-after-preflight.png`.
