### PR TITLE
Show agent failure details in the HUD

### DIFF
--- a/packages/client/src/components/chat/RoleplayHUD.tsx
+++ b/packages/client/src/components/chat/RoleplayHUD.tsx
@@ -21,6 +21,7 @@ import {
 } from "lucide-react";
 import { cn } from "../../lib/utils";
 import { api } from "../../lib/api-client";
+import type { AgentFailure } from "../../lib/agent-failures";
 import { TrackerPanelIcon } from "../ui/TrackerPanelIcon";
 import { useGameStateStore } from "../../stores/game-state.store";
 import { useAgentStore } from "../../stores/agent.store";
@@ -134,6 +135,7 @@ export function RoleplayHUD({
   const thoughtBubbles = useAgentStore((s) => s.thoughtBubbles);
   const isAgentProcessing = useAgentStore((s) => s.isProcessing);
   const failedAgentTypes = useAgentStore((s) => s.failedAgentTypes);
+  const failedAgentFailures = useAgentStore((s) => s.failedAgentFailures);
   const dismissThoughtBubble = useAgentStore((s) => s.dismissThoughtBubble);
   const clearThoughtBubbles = useAgentStore((s) => s.clearThoughtBubbles);
   const resetAgentStore = useAgentStore((s) => s.reset);
@@ -252,6 +254,7 @@ export function RoleplayHUD({
         onRetriggerTrackers={onRetriggerTrackers}
         onRetryFailedAgents={onRetryFailedAgents}
         failedAgentTypes={failedAgentTypes}
+        failedAgentFailures={failedAgentFailures}
         showInjectionsTab={showInjectionsTab}
         showSecretPlotTab={showSecretPlotTab}
       />
@@ -465,6 +468,7 @@ interface ActionsGroupProps {
   onRetriggerTrackers?: () => void;
   onRetryFailedAgents?: () => void;
   failedAgentTypes: string[];
+  failedAgentFailures: AgentFailure[];
   showInjectionsTab?: boolean;
   showSecretPlotTab?: boolean;
 }
@@ -486,6 +490,7 @@ function ActionsGroup({
   onRetriggerTrackers,
   onRetryFailedAgents,
   failedAgentTypes,
+  failedAgentFailures,
   showInjectionsTab,
   showSecretPlotTab,
 }: ActionsGroupProps) {
@@ -561,6 +566,7 @@ function ActionsGroup({
             onRetriggerTrackers={onRetriggerTrackers}
             onRetryFailedAgents={onRetryFailedAgents}
             failedAgentTypes={failedAgentTypes}
+            failedAgentFailures={failedAgentFailures}
             onClose={() => setAgentsOpen(false)}
             showInjectionsTab={showInjectionsTab}
             showSecretPlotTab={showSecretPlotTab}

--- a/packages/client/src/components/chat/RoleplayHUDActionsMenu.tsx
+++ b/packages/client/src/components/chat/RoleplayHUDActionsMenu.tsx
@@ -13,6 +13,12 @@ import {
 } from "lucide-react";
 import { BUILT_IN_AGENTS, type Message } from "@marinara-engine/shared";
 import { useUpdateAgentRunData, type AgentConfigRow, type AgentRunRow } from "../../hooks/use-agents";
+import {
+  formatAgentFailureDetail,
+  formatAgentFailureTitle,
+  toAgentFailure,
+  type AgentFailure,
+} from "../../lib/agent-failures";
 import { ContextInjectionPanel } from "../agents/ContextInjectionPanel";
 
 const SecretPlotPanel = lazy(async () =>
@@ -48,6 +54,7 @@ interface RoleplayHUDActionsMenuProps {
   onRetriggerTrackers?: () => void;
   onRetryFailedAgents?: () => void;
   failedAgentTypes?: string[];
+  failedAgentFailures?: AgentFailure[];
   onClose: () => void;
   showInjectionsTab?: boolean;
   showSecretPlotTab?: boolean;
@@ -73,6 +80,7 @@ export function RoleplayHUDActionsMenu({
   onRetriggerTrackers,
   onRetryFailedAgents,
   failedAgentTypes,
+  failedAgentFailures,
   onClose,
   showInjectionsTab,
   showSecretPlotTab,
@@ -100,6 +108,13 @@ export function RoleplayHUDActionsMenu({
   const activeTab = currentTab.id;
   const showTrackerActions = activeTab === "activity";
   const showRetryFailedAction = !!(onRetryFailedAgents && failedAgentTypes && failedAgentTypes.length > 0);
+  const displayedFailures = useMemo(
+    () =>
+      failedAgentFailures && failedAgentFailures.length > 0
+        ? failedAgentFailures
+        : (failedAgentTypes ?? []).map((agentType) => toAgentFailure({ agentType })),
+    [failedAgentFailures, failedAgentTypes],
+  );
   const showFooterActions = showEcho || showTrackerActions || showRetryFailedAction;
 
   useEffect(() => {
@@ -238,6 +253,28 @@ export function RoleplayHUDActionsMenu({
 
       {showFooterActions && (
         <div className="border-t border-white/5 divide-y divide-white/5">
+          {showRetryFailedAction && displayedFailures.length > 0 && (
+            <div className="space-y-1.5 px-3 py-2">
+              <div className="flex items-center gap-1.5 text-[0.5625rem] font-semibold uppercase tracking-wide text-amber-300/90">
+                <AlertTriangle size="0.625rem" />
+                Failed agents
+              </div>
+              <div className="space-y-1">
+                {displayedFailures.map((failure) => (
+                  <div
+                    key={failure.agentType}
+                    className="rounded-md border border-amber-400/15 bg-amber-500/10 px-2 py-1.5 text-[0.625rem]"
+                    title={failure.error ?? undefined}
+                  >
+                    <div className="font-semibold text-amber-200">{formatAgentFailureTitle(failure)}</div>
+                    <div className="mt-0.5 max-h-8 overflow-hidden break-words text-amber-100/65">
+                      {formatAgentFailureDetail(failure)}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
           {showEcho && (
             <button
               onClick={toggleEchoChamber}

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -6,6 +6,7 @@ import type { AvatarCropValue } from "../lib/utils";
 import { useQueryClient, type InfiniteData, type QueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { api } from "../lib/api-client";
+import { formatAgentFailuresToast, toAgentFailure } from "../lib/agent-failures";
 import { chatBackgroundMetadataToUrl } from "../lib/backgrounds";
 import { agentKeys } from "./use-agents";
 import type { PendingCardUpdate } from "../stores/agent.store";
@@ -557,7 +558,7 @@ export function useGenerate() {
   const setCyoaChoices = useAgentStore((s) => s.setCyoaChoices);
   const clearCyoaChoices = useAgentStore((s) => s.clearCyoaChoices);
   const enqueuePendingCardUpdate = useAgentStore((s) => s.enqueuePendingCardUpdate);
-  const setFailedAgentTypes = useAgentStore((s) => s.setFailedAgentTypes);
+  const setFailedAgentFailures = useAgentStore((s) => s.setFailedAgentFailures);
   const clearFailedAgentTypes = useAgentStore((s) => s.clearFailedAgentTypes);
   const setGameState = useGameStateStore((s) => s.setGameState);
 
@@ -1359,8 +1360,10 @@ export function useGenerate() {
             }
 
             case "agent_error": {
-              const errData = event.data as { agentType: string; error: string };
-              toast.error(errData.error);
+              const errData = event.data as { agentType: string; agentName?: string | null; error: string };
+              const failure = toAgentFailure(errData);
+              setFailedAgentFailures([failure]);
+              showError(formatAgentFailuresToast([failure]));
               break;
             }
 
@@ -1521,12 +1524,14 @@ export function useGenerate() {
             }
 
             case "agents_retry_failed": {
-              const failedList = event.data as Array<{ agentType: string; error: string | null }>;
-              const types = failedList.map((f) => f.agentType);
-              setFailedAgentTypes(types);
-              showError(
-                `${types.length} agent${types.length > 1 ? "s" : ""} failed after retry. Use the retry button in the chat header to try again.`,
-              );
+              const failedList = event.data as Array<{
+                agentType: string;
+                agentName?: string | null;
+                error: string | null;
+              }>;
+              const failures = failedList.map(toAgentFailure);
+              setFailedAgentFailures(failures);
+              showError(formatAgentFailuresToast(failures));
               break;
             }
           }
@@ -1740,7 +1745,7 @@ export function useGenerate() {
       clearCyoaChoices,
       enqueuePendingCardUpdate,
       clearFailedAgentTypes,
-      setFailedAgentTypes,
+      setFailedAgentFailures,
       setGameState,
     ],
   );
@@ -1773,6 +1778,7 @@ export function useGenerate() {
         }
 
         let hasError = false;
+        const failedRetryFailures: Array<ReturnType<typeof toAgentFailure>> = [];
         for await (const event of api.streamEvents(
           "/generate/retry-agents",
           {
@@ -1907,17 +1913,22 @@ export function useGenerate() {
               }
               if (!result.success && result.error) {
                 hasError = true;
-                showError(`${result.agentName ?? result.agentType} failed: ${result.error}`);
+                const failure = toAgentFailure(result);
+                failedRetryFailures.push(failure);
+                setFailedAgentFailures(failedRetryFailures);
+                showError(formatAgentFailuresToast([failure]));
               }
               break;
             }
             case "agents_retry_failed": {
-              const failedList = event.data as Array<{ agentType: string; error: string | null }>;
-              const types = failedList.map((f) => f.agentType);
-              setFailedAgentTypes(types);
-              showError(
-                `${types.length} agent${types.length > 1 ? "s" : ""} failed after retry. Use the retry button in the chat header to try again.`,
-              );
+              const failedList = event.data as Array<{
+                agentType: string;
+                agentName?: string | null;
+                error: string | null;
+              }>;
+              const failures = failedList.map(toAgentFailure);
+              setFailedAgentFailures(failures);
+              showError(formatAgentFailuresToast(failures));
               break;
             }
             case "game_state":
@@ -1944,9 +1955,11 @@ export function useGenerate() {
               break;
             }
             case "agent_error": {
-              const errData = event.data as { agentType: string; error: string };
+              const errData = event.data as { agentType: string; agentName?: string | null; error: string };
               hasError = true;
-              showError(errData.error || "Agent retry failed");
+              const failure = toAgentFailure(errData);
+              setFailedAgentFailures([failure]);
+              showError(formatAgentFailuresToast([failure]));
               break;
             }
             case "error": {
@@ -1988,7 +2001,7 @@ export function useGenerate() {
       clearFailedAgentTypes,
       clearThoughtBubbles,
       setCyoaChoices,
-      setFailedAgentTypes,
+      setFailedAgentFailures,
       setProcessing,
       setGameState,
       qc,

--- a/packages/client/src/lib/agent-failures.ts
+++ b/packages/client/src/lib/agent-failures.ts
@@ -1,0 +1,85 @@
+export interface AgentFailure {
+  agentType: string;
+  agentName: string;
+  error: string | null;
+  reasonLabel: string | null;
+}
+
+interface RawAgentFailure {
+  agentType: string;
+  agentName?: string | null;
+  error?: string | null;
+}
+
+function classifyAgentFailureReason(error: string | null | undefined): string | null {
+  if (!error) return null;
+  const value = error.toLowerCase();
+
+  if (
+    /\b(max(?:imum)? length|too many tokens|prompt too long|context_length_exceeded)\b/.test(value) ||
+    (/\b(context|prompt|input)\b/.test(value) &&
+      /\b(limit|length|window|too long|max(?:imum)? tokens?|tokens? limit)\b/.test(value))
+  ) {
+    return "Context limit";
+  }
+  if (/\b(timed?\s*out|timeout|etimedout|deadline|aborted|aborterror)\b/.test(value)) {
+    return "Timeout";
+  }
+  if (/\b(refus(?:ed|al)|reject(?:ed|ion)|blocked|content policy|safety|moderation)\b/.test(value)) {
+    return "Rejection";
+  }
+  if (/\b(unauthorized|forbidden|invalid api key|api key|401|403|permission|credential|auth)\b/.test(value)) {
+    return "Authentication";
+  }
+  if (/\b(rate limit|too many requests|quota|429)\b/.test(value)) {
+    return "Rate limit";
+  }
+  if (/\b(network|fetch failed|econn|enotfound|dns|socket|connection|connect)\b/.test(value)) {
+    return "Connection";
+  }
+  if (/\b(json|parse|schema|invalid response|malformed)\b/.test(value)) {
+    return "Invalid response";
+  }
+  if (/\btool\b/.test(value)) {
+    return "Tool error";
+  }
+
+  return null;
+}
+
+export function toAgentFailure(raw: RawAgentFailure): AgentFailure {
+  const fallbackName = raw.agentType.trim() || "Agent";
+  const agentName = raw.agentName?.trim() || fallbackName;
+  const error = raw.error?.trim() || null;
+
+  return {
+    agentType: raw.agentType,
+    agentName,
+    error,
+    reasonLabel: classifyAgentFailureReason(error),
+  };
+}
+
+export function formatAgentFailureTitle(failure: AgentFailure): string {
+  return failure.reasonLabel ? `${failure.agentName} (${failure.reasonLabel})` : failure.agentName;
+}
+
+export function formatAgentFailureDetail(failure: AgentFailure): string {
+  if (failure.reasonLabel && failure.error) return `${failure.reasonLabel}: ${failure.error}`;
+  if (failure.reasonLabel) return failure.reasonLabel;
+  return failure.error ?? "No error details were provided.";
+}
+
+export function formatAgentFailuresToast(failures: AgentFailure[]): string {
+  if (failures.length === 0) return "Agent retry failed.";
+
+  if (failures.length === 1) {
+    const failure = failures[0]!;
+    const reason = failure.reasonLabel ? `: ${failure.reasonLabel}` : "";
+    return `${failure.agentName} failed${reason}. Use the retry button in the chat header to try again.`;
+  }
+
+  const visible = failures.slice(0, 3).map(formatAgentFailureTitle).join(", ");
+  const remaining = failures.length > 3 ? `, +${failures.length - 3} more` : "";
+  return `${failures.length} agents failed: ${visible}${remaining}. Use the retry button in the chat header to try again.`;
+}

--- a/packages/client/src/stores/agent.store.ts
+++ b/packages/client/src/stores/agent.store.ts
@@ -3,6 +3,7 @@
 // ──────────────────────────────────────────────
 import { create } from "zustand";
 import type { AgentResult, CharacterCardFieldUpdate } from "@marinara-engine/shared";
+import type { AgentFailure } from "../lib/agent-failures";
 
 /**
  * A character_card_update result awaiting user confirmation.
@@ -52,6 +53,8 @@ interface AgentState {
   isProcessing: boolean;
   /** Agent types that failed even after auto-retry — manual retry available */
   failedAgentTypes: string[];
+  /** Rich failure details for the retry UI and troubleshooting copy */
+  failedAgentFailures: AgentFailure[];
   thoughtBubbles: Array<{
     agentId: string;
     agentName: string;
@@ -83,6 +86,7 @@ interface AgentState {
   addDebugEntry: (entry: Omit<AgentDebugEntry, "timestamp"> & { timestamp?: number }) => void;
   clearDebugLog: () => void;
   setFailedAgentTypes: (types: string[]) => void;
+  setFailedAgentFailures: (failures: AgentFailure[]) => void;
   clearFailedAgentTypes: () => void;
   addThoughtBubble: (agentId: string, agentName: string, content: string) => void;
   dismissThoughtBubble: (index: number) => void;
@@ -107,6 +111,7 @@ export const useAgentStore = create<AgentState>((set) => ({
   debugLog: [],
   isProcessing: false,
   failedAgentTypes: [],
+  failedAgentFailures: [],
   thoughtBubbles: [],
   echoMessages: [],
   echoVisibleCount: 0,
@@ -138,8 +143,22 @@ export const useAgentStore = create<AgentState>((set) => ({
 
   clearDebugLog: () => set({ debugLog: [] }),
 
-  setFailedAgentTypes: (types) => set({ failedAgentTypes: types }),
-  clearFailedAgentTypes: () => set({ failedAgentTypes: [] }),
+  setFailedAgentTypes: (types) =>
+    set({
+      failedAgentTypes: types,
+      failedAgentFailures: types.map((agentType) => ({
+        agentType,
+        agentName: agentType,
+        error: null,
+        reasonLabel: null,
+      })),
+    }),
+  setFailedAgentFailures: (failures) =>
+    set({
+      failedAgentTypes: failures.map((failure) => failure.agentType),
+      failedAgentFailures: failures,
+    }),
+  clearFailedAgentTypes: () => set({ failedAgentTypes: [], failedAgentFailures: [] }),
 
   addThoughtBubble: (agentId, agentName, content) =>
     set((s) => ({
@@ -182,6 +201,7 @@ export const useAgentStore = create<AgentState>((set) => ({
       debugLog: [],
       isProcessing: false,
       failedAgentTypes: [],
+      failedAgentFailures: [],
       thoughtBubbles: [],
       echoMessages: [],
       echoVisibleCount: 0,

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -5165,6 +5165,7 @@ export async function generateRoutes(app: FastifyInstance) {
                   type: "agent_error",
                   data: {
                     agentType: "knowledge-retrieval",
+                    agentName: knowledgeRetrievalAgent!.name,
                     error: err instanceof Error ? err.message : "Knowledge retrieval failed",
                   },
                 });
@@ -7079,7 +7080,11 @@ export async function generateRoutes(app: FastifyInstance) {
             reply.raw.write(
               `data: ${JSON.stringify({
                 type: "agents_retry_failed",
-                data: stillFailed.map((r) => ({ agentType: r.agentType, error: r.error })),
+                data: stillFailed.map((r) => ({
+                  agentType: r.agentType,
+                  agentName: resolvedAgents.find((agent) => agent.type === r.agentType)?.name ?? r.agentType,
+                  error: r.error,
+                })),
               })}\n\n`,
             );
           }
@@ -7200,6 +7205,7 @@ export async function generateRoutes(app: FastifyInstance) {
                       type: "agent_error",
                       data: {
                         agentType: "background",
+                        agentName: currentBackgroundAgent?.name ?? "Background",
                         error:
                           "No image generation connection set on the Background agent, and no default agent image connection is configured. Assign one in Settings → Agents → Background.",
                       },
@@ -7254,6 +7260,7 @@ export async function generateRoutes(app: FastifyInstance) {
                         type: "agent_error",
                         data: {
                           agentType: "background",
+                          agentName: currentBackgroundAgent?.name ?? "Background",
                           error: "Background image generation failed. Check the image connection and server logs.",
                         },
                       });
@@ -7266,6 +7273,7 @@ export async function generateRoutes(app: FastifyInstance) {
                     type: "agent_error",
                     data: {
                       agentType: "background",
+                      agentName: currentBackgroundAgent?.name ?? "Background",
                       error: `Background image generation failed: ${bgData.error}`,
                     },
                   });
@@ -8197,6 +8205,7 @@ export async function generateRoutes(app: FastifyInstance) {
                         type: "agent_error",
                         data: {
                           agentType: "illustrator",
+                          agentName: illustratorAgent?.name ?? "Illustrator",
                           error: `Image generation failed: ${illErr instanceof Error ? illErr.message : String(illErr)}`,
                         },
                       })}\n\n`,
@@ -8210,6 +8219,7 @@ export async function generateRoutes(app: FastifyInstance) {
                     type: "agent_error",
                     data: {
                       agentType: "illustrator",
+                      agentName: illustratorAgent?.name ?? "Illustrator",
                       error:
                         "No image generation connection set on the Illustrator agent, and no default Illustrator image connection is configured. Go to Settings → Connections and mark an image generation connection as the default for Illustrator, or assign one directly in Settings → Agents → Illustrator.",
                     },

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -1672,6 +1672,9 @@ async function applyRetryResultEffects(args: {
 
     // ── ILLUSTRATOR: generate image from agent prompt ──
     if (result.success && result.type === "image_prompt" && result.data && typeof result.data === "object") {
+      const illustratorFailureName =
+        resolvedAgents.find((a) => a.resolved.id === result.agentId || a.resolved.type === "illustrator")?.cfg.name ??
+        "Illustrator";
       try {
         const illData = result.data as Record<string, unknown>;
         const shouldGenerate = illData.shouldGenerate === true;
@@ -1861,11 +1864,14 @@ async function applyRetryResultEffects(args: {
               );
             }
           } else {
-            logger.warn("[retry-agents] Illustrator wants to generate but no image generation connection is configured");
+            logger.warn(
+              "[retry-agents] Illustrator wants to generate but no image generation connection is configured",
+            );
             sendSseEvent(reply, {
               type: "agent_error",
               data: {
                 agentType: "illustrator",
+                agentName: illustratorFailureName,
                 error:
                   "No image generation connection set on the Illustrator agent, and no default Illustrator image connection is configured. Go to Settings -> Connections and mark an image generation connection as the default for Illustrator, or assign one directly in Settings -> Agents -> Illustrator.",
               },
@@ -1878,6 +1884,7 @@ async function applyRetryResultEffects(args: {
           type: "agent_error",
           data: {
             agentType: "illustrator",
+            agentName: illustratorFailureName,
             error: illErr instanceof Error ? illErr.message : "Image generation failed",
           },
         });


### PR DESCRIPTION
## Linked issue

Closes #859

## Why this change

- Agent failures currently surface as generic failure UI, which makes it hard to tell which agent failed or whether the likely cause was a context limit, timeout, rejection, or another common error category.

## What changed

- Preserve failed agent display names in server SSE failure payloads for retry summaries and agent-specific error events.
- Store rich failed-agent details in the client while keeping the existing agent type list for retry behavior.
- Add shared client formatting/classification helpers for common agent failure reasons.
- Show failed agent names, inferred reason labels, and error details in the roleplay HUD actions menu and failure toast.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Codex ran `pnpm exec esbuild scratch/verify-issue-859-agent-failures.ts --bundle --platform=node --format=esm --outfile=scratch/verify-issue-859-agent-failures.mjs` and `node scratch/verify-issue-859-agent-failures.mjs`; the scratch proof classified context-limit, timeout, and rejection failures, preserved retry agent types, and verified legacy type-only fallback details.
- Codex rendered the real `RoleplayHUDActionsMenu` component through a scratch browser proof page at `http://127.0.0.1:5859/issue-859-ui-proof.html`; Playwright snapshot showed `Failed agents`, `World State (Context limit)`, `Expression Engine (Timeout)`, and `Retry Failed Agents (2)`.
- Codex ran `pnpm check`; it passed locally.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs or release metadata changes needed; this changes existing agent failure UI behavior only.

## UI evidence (if applicable)

Playwright browser snapshot from the scratch component proof showed the roleplay HUD actions menu rendering failed agent names and inferred reason labels:

- `World State (Context limit)`
- `Expression Engine (Timeout)`
- `Retry Failed Agents (2)`
