### PR TITLE
Fix Game Mode asset regeneration portraits

### DIFF
--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -115,7 +115,10 @@ import { GameWidgetPanel, GameWidgetSessionPrepModal, MobileWidgetPanel } from "
 import { WeatherEffects } from "../chat/WeatherEffects";
 import { GameInventory } from "./GameInventory";
 import { GameReadableDisplay } from "./GameReadableDisplay";
-import { buildMissingSceneAssetGenerationPayload } from "./game-asset-generation-payload";
+import {
+  buildMissingSceneAssetGenerationPayload,
+  normalizeSceneAssetNameForGeneration,
+} from "./game-asset-generation-payload";
 import { ChatGalleryDrawer } from "../chat/ChatGalleryDrawer";
 import type { ReadableTag } from "../../lib/game-tag-parser";
 import type { DirectionCommand, GameNpc } from "@marinara-engine/shared";
@@ -780,7 +783,7 @@ function extractNarrationNpcCandidates(
     const name = rawName.trim();
     if (!isLikelyNarrationNpcName(name)) return;
 
-    const normalizedName = normalizeSceneAssetName(name);
+    const normalizedName = normalizeSceneAssetNameForGeneration(name);
     if (
       !normalizedName ||
       excluded.has(normalizedName) ||

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -115,6 +115,7 @@ import { GameWidgetPanel, GameWidgetSessionPrepModal, MobileWidgetPanel } from "
 import { WeatherEffects } from "../chat/WeatherEffects";
 import { GameInventory } from "./GameInventory";
 import { GameReadableDisplay } from "./GameReadableDisplay";
+import { buildMissingSceneAssetGenerationPayload } from "./game-asset-generation-payload";
 import { ChatGalleryDrawer } from "../chat/ChatGalleryDrawer";
 import type { ReadableTag } from "../../lib/game-tag-parser";
 import type { DirectionCommand, GameNpc } from "@marinara-engine/shared";
@@ -995,16 +996,6 @@ function addInventoryUnit<T extends { name: string; quantity: number }>(items: T
 
 function normalizeInventoryName(value: string): string {
   return value.trim().replace(/\s+/g, " ");
-}
-
-function getMissingBackgroundTag(
-  backgroundTag: string | undefined | null,
-  manifest: Record<string, { path: string }> | null,
-): string | null {
-  const cleaned = backgroundTag?.trim();
-  if (!cleaned || cleaned === "black" || cleaned === "none") return null;
-  const resolved = resolveAssetTag(cleaned, "backgrounds", manifest);
-  return manifest?.[resolved] ? null : cleaned;
 }
 
 function interactiveCommandKey(chatId: string, messageId: string): string {
@@ -2829,28 +2820,25 @@ export function GameSurface({
     chatMeta.gameImageConnectionId.trim().length > 0;
 
   const missingSceneAssetGeneration = useMemo(() => {
-    if (!gameImageGenerationEnabled) return null;
-    if (!activeChatId) return null;
-
-    const unresolvedBackground = getMissingBackgroundTag(
-      currentBackground || (chatMeta.gameSceneBackground as string | undefined),
-      assetManifest?.assets ?? null,
-    );
-
-    if (!unresolvedBackground && npcsNeedingAvatars.length === 0) return null;
-
-    return {
-      chatId: activeChatId,
-      backgroundTag: unresolvedBackground ?? undefined,
-      npcsNeedingAvatars: npcsNeedingAvatars.length > 0 ? npcsNeedingAvatars : undefined,
-    };
+    return buildMissingSceneAssetGenerationPayload({
+      gameImageGenerationEnabled,
+      activeChatId,
+      currentBackground,
+      savedSceneBackground: chatMeta.gameSceneBackground as string | undefined,
+      assetMap: assetManifest?.assets ?? null,
+      sceneAssetNpcs,
+      npcAvatarLookup,
+      npcsNeedingAvatars,
+    });
   }, [
     activeChatId,
     assetManifest,
     chatMeta.gameSceneBackground,
     currentBackground,
     gameImageGenerationEnabled,
+    npcAvatarLookup,
     npcsNeedingAvatars,
+    sceneAssetNpcs,
   ]);
 
   const retryableAssetGeneration = pendingAssetGeneration ?? missingSceneAssetGeneration;

--- a/packages/client/src/components/game/game-asset-generation-payload.ts
+++ b/packages/client/src/components/game/game-asset-generation-payload.ts
@@ -1,0 +1,81 @@
+import { resolveAssetTag } from "../../lib/asset-fuzzy-match";
+
+type AssetManifestMap = Record<string, { path: string }> | null;
+
+export type SceneAssetNpcAvatarCandidate = {
+  name: string;
+  description: string;
+  avatarUrl?: string | null;
+};
+
+type MissingSceneAssetGenerationPayload = {
+  chatId: string;
+  backgroundTag?: string;
+  npcsNeedingAvatars?: Array<{ name: string; description: string }>;
+  forceNpcAvatarNames?: string[];
+};
+
+type MissingSceneAssetGenerationInput = {
+  gameImageGenerationEnabled: boolean;
+  activeChatId: string | null;
+  currentBackground: string | null;
+  savedSceneBackground: string | undefined;
+  assetMap: AssetManifestMap;
+  sceneAssetNpcs: SceneAssetNpcAvatarCandidate[];
+  npcAvatarLookup: Map<string, string>;
+  npcsNeedingAvatars: Array<{ name: string; description: string }>;
+};
+
+function normalizeSceneAssetNameForGeneration(value: string): string {
+  return value.trim().toLowerCase().replace(/[_-]+/g, " ").replace(/\s+/g, " ");
+}
+
+export function getMissingBackgroundTag(
+  backgroundTag: string | undefined | null,
+  manifest: AssetManifestMap,
+): string | null {
+  const cleaned = backgroundTag?.trim();
+  if (!cleaned || cleaned === "black" || cleaned === "none") return null;
+  const resolved = resolveAssetTag(cleaned, "backgrounds", manifest);
+  return manifest?.[resolved] ? null : cleaned;
+}
+
+export function buildMissingSceneAssetGenerationPayload({
+  gameImageGenerationEnabled,
+  activeChatId,
+  currentBackground,
+  savedSceneBackground,
+  assetMap,
+  sceneAssetNpcs,
+  npcAvatarLookup,
+  npcsNeedingAvatars,
+}: MissingSceneAssetGenerationInput): MissingSceneAssetGenerationPayload | null {
+  if (!gameImageGenerationEnabled) return null;
+  if (!activeChatId) return null;
+
+  const unresolvedBackground = getMissingBackgroundTag(currentBackground || savedSceneBackground, assetMap);
+  const savedGeneratedBackgroundMissing =
+    !!savedSceneBackground &&
+    unresolvedBackground === savedSceneBackground &&
+    savedSceneBackground.startsWith("backgrounds:");
+  const npcAssetCandidates = sceneAssetNpcs
+    .filter((npc) => npc.description && npc.name)
+    .map((npc) => ({ name: npc.name, description: npc.description }))
+    .slice(0, 10);
+  const forceNpcAvatarNames = savedGeneratedBackgroundMissing
+    ? npcAssetCandidates
+        .filter((npc) => npcAvatarLookup.has(normalizeSceneAssetNameForGeneration(npc.name)))
+        .map((npc) => npc.name)
+    : [];
+  const npcPayload =
+    savedGeneratedBackgroundMissing && forceNpcAvatarNames.length > 0 ? npcAssetCandidates : npcsNeedingAvatars;
+
+  if (!unresolvedBackground && npcPayload.length === 0) return null;
+
+  return {
+    chatId: activeChatId,
+    backgroundTag: unresolvedBackground ?? undefined,
+    npcsNeedingAvatars: npcPayload.length > 0 ? npcPayload : undefined,
+    forceNpcAvatarNames: forceNpcAvatarNames.length > 0 ? forceNpcAvatarNames : undefined,
+  };
+}

--- a/packages/client/src/components/game/game-asset-generation-payload.ts
+++ b/packages/client/src/components/game/game-asset-generation-payload.ts
@@ -26,7 +26,7 @@ type MissingSceneAssetGenerationInput = {
   npcsNeedingAvatars: Array<{ name: string; description: string }>;
 };
 
-function normalizeSceneAssetNameForGeneration(value: string): string {
+export function normalizeSceneAssetNameForGeneration(value: string): string {
   return value.trim().toLowerCase().replace(/[_-]+/g, " ").replace(/\s+/g, " ");
 }
 

--- a/packages/client/src/stores/game-mode.store.ts
+++ b/packages/client/src/stores/game-mode.store.ts
@@ -295,7 +295,7 @@ export const useGameModeStore = create<GameModeStore>((set) => ({
       let modified = false;
       const nextNpcs = s.npcs.map((npc) => {
         const match = avatars.find((a) => a.name.toLowerCase() === npc.name.toLowerCase());
-        if (match && !npc.avatarUrl) {
+        if (match && match.avatarUrl !== npc.avatarUrl) {
           modified = true;
           return { ...npc, avatarUrl: match.avatarUrl };
         }

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -2407,7 +2407,7 @@ function upsertGameNpcAvatarEntries(currentNpcs: GameNpc[], avatarEntries: Scene
       const existing = nextNpcs[existingIndex]!;
       let nextNpc = existing;
 
-      if (!existing.avatarUrl) {
+      if (existing.avatarUrl !== entry.avatarUrl) {
         nextNpc = { ...nextNpc, avatarUrl: entry.avatarUrl };
       }
       if (!nextNpc.description && entry.description) {
@@ -7182,7 +7182,7 @@ export async function gameRoutes(app: FastifyInstance) {
         if (avatarUrl) {
           generatedNpcAvatars.push({
             name: npc.name,
-            avatarUrl: forceNpcAvatar ? `${avatarUrl.split("?")[0]}?v=${Date.now()}` : avatarUrl,
+            avatarUrl: `${avatarUrl.split("?")[0]}?v=${Date.now()}`,
           });
         }
       }


### PR DESCRIPTION
## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #895

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- Game Mode could keep treating old NPC portrait URLs as final after generated assets were deleted or regenerated, so the background regenerated while portraits appeared skipped or stale.

## What changed

<!-- List the key changes in this PR -->

- Extracted the missing Game Mode asset payload calculation into a pure helper.
- When a saved generated background is missing from the asset manifest, the asset retry payload now schedules the background and the full NPC portrait set, forcing existing generated NPC portrait names so the set can refresh together.
- Refreshed NPC portrait URLs now replace stale NPC avatar URLs in both client state and persisted Game Mode metadata.
- Generated NPC portrait responses always include a cache-busting query string so regenerated files are visible immediately.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Codex scratch repro before the fix: `pnpm --filter @marinara-engine/server exec tsx ../../scratch/issue-895-npc-avatar-repro.ts` exited 1 because `patchNpcAvatars` kept `/api/avatars/npc/chat-895/mira.png` instead of applying `/api/avatars/npc/chat-895/mira.png?v=895`.
- Codex scratch repro after the fix: the same command passed, confirming refreshed NPC avatar URLs replace stale ones, newly discovered NPC avatars are still added, and a missing saved generated background schedules background regeneration plus forced portrait regeneration for the full NPC set.
- Codex baseline: `pnpm check` passed.
- Bunny review: passed before opening this PR.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs or release metadata changes needed; this is a focused Game Mode bug fix.

## UI evidence (if applicable)

N/A - this is a Game Mode asset-regeneration state/payload fix verified with a focused scratch repro and `pnpm check`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NPC avatar synchronization to reliably update avatars when they change, rather than only when missing.
  * Fixed cache behavior to consistently refresh generated avatars, ensuring the latest versions are displayed.

* **Refactor**
  * Consolidated asset generation logic for cleaner code organization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/903?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->