### PR TITLE
docs: document staging as the active development branch

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,7 @@
+<!-- Target branch: `staging`. The default base in this UI is `main` (release branch). -->
+<!-- Change the base to `staging` before submitting unless this is a maintainer-approved mainline change. -->
+<!-- See CONTRIBUTING.md § Branches. -->
+
 ## Linked issue
 
 <!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ This file is a thin maintainer note for contributors using Codex. Canonical work
 ## Repo-Specific Cautions
 
 - Keep edits non-destructive. Do not revert unrelated work in the tree.
-- Make Marinara Engine changes against `staging` first; do not target `main` directly unless the user or maintainer explicitly asks for a mainline change.
+- Make Marinara Engine changes against `staging` first; do not target `main` directly unless the user or maintainer explicitly asks for a mainline change. See `CONTRIBUTING.md § Branches`.
 - Prefer focused patches that keep code, docs, and release metadata aligned in the same change.
 - Agent-specific coordination rule: before starting issue work, check for an existing issue-linked branch, open PR, draft PR, or project board item so multiple agents do not duplicate effort. See `CONTRIBUTING.md` for the general contributor workflow.
 - Agent-specific coordination rule: when implementation effort starts for an issue, open a draft PR immediately so the project Kanban board shows the work in progress.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ This file is a thin maintainer note for contributors using Claude. Canonical wor
 ## Repo-Specific Cautions
 
 - Keep edits non-destructive. Do not revert unrelated work in the tree.
+- Make Marinara Engine changes against `staging` first; do not target `main` directly unless the user or maintainer explicitly asks for a mainline change. See `CONTRIBUTING.md § Branches`.
 - Prefer focused patches that keep code, docs, and release metadata aligned in the same change.
 - Agent-specific coordination rule: before starting issue work, check for an existing issue-linked branch, open PR, draft PR, or project board item so multiple agents do not duplicate effort. See `CONTRIBUTING.md` for the general contributor workflow.
 - Agent-specific coordination rule: when implementation effort starts for an issue, open a draft PR immediately so the project Kanban board shows the work in progress.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,10 +25,13 @@ Typical local setup:
 ```bash
 git clone https://github.com/Pasta-Devs/Marinara-Engine.git
 cd Marinara-Engine
+git checkout staging
 pnpm install
 pnpm build
 pnpm dev
 ```
+
+> Active development happens on `staging`, not `main`. See [Branches](#branches) below before opening a PR.
 
 Useful entry points:
 
@@ -38,6 +41,22 @@ Useful entry points:
 - `start.bat`, `start.sh`, and `start-termux.sh` run the launcher flow, including git-based auto-update and optional browser auto-open.
 
 Copy `.env.example` to `.env` when you need to change ports, HTTPS settings, or launcher behavior such as `AUTO_OPEN_BROWSER=false`.
+
+## Branches
+
+Marinara Engine uses two long-lived branches:
+
+| Branch    | Role                                                                                                |
+| --------- | --------------------------------------------------------------------------------------------------- |
+| `staging` | Active development. All feature branches, bug fixes, and documentation PRs should target this.     |
+| `main`    | Release branch. Updated by maintainers as part of the release flow; do not target it directly.     |
+
+Guidelines:
+
+- **Base your feature branch on `staging`**, not `main`. Run `git checkout staging && git pull` before branching.
+- **Open PRs against `staging`**. The GitHub web UI defaults to `main` (the repo's default branch); change the base to `staging` when filing the PR.
+- Do not target `main` directly unless a maintainer explicitly asks for a mainline-only change (e.g. release hotfix).
+- Update checks and installation guides continue to track `main`, since end users install from released versions.
 
 ## Repo Layout
 
@@ -129,6 +148,7 @@ All server-side logging goes through a shared [Pino](https://getpino.io/) logger
 
 ## Pull Request Expectations
 
+- Target the `staging` branch. The GitHub UI defaults to `main`; change the base before submitting. See [Branches](#branches).
 - Link the issue or feature request your PR addresses. If there isn't one yet, open one first (see [Before You Open a Pull Request](#before-you-open-a-pull-request)).
 - Keep PRs focused. Separate unrelated refactors from user-facing fixes or documentation work.
 - Explain the why clearly in the PR description. Reviewers should understand the user problem, regression, or tradeoff being addressed, not just the implementation summary.


### PR DESCRIPTION
## Linked issue

No linked issue — docs-only clarification.

## Why this change

`staging` is the active development branch, but the contributor docs don't say so anywhere a new contributor would notice. `CONTRIBUTING.md`'s setup block just clones the repo (which lands on `main`, the release branch), and the PR template doesn't mention that the GitHub UI defaults the base to `main`. The result is that new contributors keep filing PRs against `main` and have to be re-pointed.

The only place the staging-first rule appeared was `AGENTS.md`, which most contributors don't read.

## What changed

- `CONTRIBUTING.md`
  - Added a new **Branches** section explaining `main` (release) vs `staging` (active dev) and the rules for targeting them.
  - Added a `git checkout staging` step to the typical local setup block and a callout pointing readers at the new section.
  - Added a top-of-list bullet to **Pull Request Expectations** reminding contributors to change the base to `staging`.
- `CLAUDE.md` — brought to parity with `AGENTS.md` by adding the same staging-first caution bullet. Both bullets now cross-reference `CONTRIBUTING.md § Branches` so the rule has one source of truth.
- `.github/pull_request_template.md` — prepended a 3-line HTML comment at the very top reminding contributors that the default base in the UI is `main` and to switch it to `staging` before submitting.

Installation guides (`docs/installation/*.md`) were intentionally left alone — they correctly track `main` for end-user updates since releases are cut from `main`.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Read the rendered `CONTRIBUTING.md` Branches section on the PR's Files Changed tab and confirm the table + bullet wording reads correctly.
- Skim `CLAUDE.md` and `AGENTS.md` to confirm both staging-first bullets are consistent and both link to `CONTRIBUTING.md § Branches`.
- Open the PR template preview (when filing any future PR) and confirm the new top-of-template comment renders correctly and is not visible in the final PR body.

## Docs and release impact

- [ ] No docs changes needed
- [x] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)