### PR TITLE
fix(commands): keep Professor Mari going after fetch + parse bracketed params

### DIFF
--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -1280,6 +1280,11 @@ export async function generateRoutes(app: FastifyInstance) {
 
       // eslint-disable-next-line no-constant-condition
       while (true) {
+      // Per-iteration flag: set when a Mari [fetch:] command actually returned
+      // data AND persisted mariContext. The follow-up branch at the bottom of
+      // the loop body gates on this so a fetch that found nothing or threw
+      // doesn't burn an extra generation pass with no new context to read.
+      let mariFetchSucceededThisIteration = false;
       let finalMessages: Array<{
         role: "system" | "user" | "assistant";
         content: string;
@@ -1375,15 +1380,23 @@ export async function generateRoutes(app: FastifyInstance) {
 
       // ── Apply regex scripts to prompt message content ──
       // Macro context is available now, so regex find/replace/trim fields can use prompt macros.
-      applyRegexScriptsToPromptMessages(mappedMessages, await regexScriptsStore.list(), {
-        resolveMacros: (value) => resolveMacros(value, promptMacroContext, { trimResult: false }),
-      });
+      // Gated to iteration 0 because applyRegexScriptsToPromptMessages mutates
+      // message.content in place — running it again on a Mari follow-up pass
+      // would stack non-idempotent user regex scripts on already-rewritten text.
+      // The newly appended Mari turn is run through the same transforms below
+      // before it lands in runningMessagesForFollowUp, so each message still
+      // gets exactly one pass.
+      if (followUpIteration === 0) {
+        applyRegexScriptsToPromptMessages(mappedMessages, await regexScriptsStore.list(), {
+          resolveMacros: (value) => resolveMacros(value, promptMacroContext, { trimResult: false }),
+        });
 
-      // Always collapse 3+ consecutive blank lines into a double newline —
-      // these waste tokens and produce messy logs regardless of user regex settings.
-      // Matches pure newlines AND lines that contain only whitespace.
-      for (const msg of mappedMessages) {
-        msg.content = msg.content.replace(/\n([ \t]*\n){2,}/g, "\n\n");
+        // Always collapse 3+ consecutive blank lines into a double newline —
+        // these waste tokens and produce messy logs regardless of user regex settings.
+        // Matches pure newlines AND lines that contain only whitespace.
+        for (const msg of mappedMessages) {
+          msg.content = msg.content.replace(/\n([ \t]*\n){2,}/g, "\n\n");
+        }
       }
       promptMacroContext.lastInput = [...mappedMessages].reverse().find((message) => message.role === "user")?.content;
       const toLorebookScanMessages = () =>
@@ -9539,6 +9552,17 @@ export async function generateRoutes(app: FastifyInstance) {
                     currentMeta.mariContext = mariContext;
                     await chats.updateMetadata(input.chatId, currentMeta);
 
+                    // Record success for the follow-up trigger, but only when
+                    // the fetch came from Mari (or a Mari-included chat). The
+                    // follow-up loop gates on this so a missed/errored fetch
+                    // doesn't burn another generation pass.
+                    if (
+                      characterId === PROFESSOR_MARI_ID ||
+                      (characterId === null && characterIds.includes(PROFESSOR_MARI_ID))
+                    ) {
+                      mariFetchSucceededThisIteration = true;
+                    }
+
                     reply.raw.write(
                       `data: ${JSON.stringify({
                         type: "assistant_action",
@@ -9569,54 +9593,58 @@ export async function generateRoutes(app: FastifyInstance) {
         }
       }
 
-      // ── Trigger follow-up generation if Professor Mari just fetched data ──
+      // ── Trigger follow-up generation if Professor Mari's fetch landed ──
       // Mari's fetched payload was persisted to chatMeta.mariContext by the
-      // command handler above, but mariContext is only read into the prompt
-      // at the start of a generation pass — without a follow-up turn she'd
-      // go silent right after the fetch snackbar.
-      const fetchCommandsThisTurn = collectedCommands.filter((c) => c.command.type === "fetch");
+      // fetch handler above, but mariContext is only read into the prompt at
+      // the start of a generation pass — without a follow-up turn Mari would
+      // go silent right after the fetch snackbar. Gating on the success flag
+      // (rather than just the presence of a parsed [fetch:]) avoids burning
+      // an extra pass when the fetch handler found nothing or threw.
       if (
-        fetchCommandsThisTurn.length > 0 &&
+        mariFetchSucceededThisIteration &&
         chatMode === "conversation" &&
         !input.impersonate &&
         !input.regenerateMessageId &&
         !abortController.signal.aborted &&
         followUpIteration < MAX_FOLLOW_UP_ITERATIONS
       ) {
-        const mariFetched = fetchCommandsThisTurn.some(
-          (c) =>
-            c.characterId === PROFESSOR_MARI_ID ||
-            (c.characterId === null && characterIds.includes(PROFESSOR_MARI_ID)),
+        followUpIteration++;
+        logger.info(
+          "[generate] Professor Mari fetch succeeded; triggering follow-up generation (iteration %d)",
+          followUpIteration,
         );
-        if (mariFetched) {
-          followUpIteration++;
-          logger.info(
-            "[generate] Professor Mari executed fetch; triggering follow-up generation (iteration %d)",
-            followUpIteration,
-          );
 
-          // Carry the just-streamed assistant turn into the next prompt so
-          // Mari sees her own prior message before speaking again.
-          const lastResponseText = allResponses.join("\n\n");
-          if (lastResponseText) {
-            runningMessagesForFollowUp.push({ role: "assistant", content: lastResponseText });
-          }
-
-          // Re-read chat metadata so the freshly-persisted mariContext is
-          // visible to the next pass.
-          const freshChat = await chats.getById(input.chatId);
-          if (freshChat) {
-            chatMeta = parseExtra(freshChat.metadata) as Record<string, unknown>;
-          }
-
-          // Reset hoisted per-iteration accumulators before continuing.
-          // (firstSavedMsg stays — it's "first across the whole turn".
-          //  lastSavedMsg, pendingIllustration are overwritten naturally.)
-          collectedCommands.length = 0;
-          collectedOocMessages.length = 0;
-
-          continue;
+        // Carry the just-streamed assistant turn into the next prompt so
+        // Mari sees her own prior message before speaking again. Apply the
+        // same regex-script + blank-line compaction transforms here, since
+        // the iteration-0 block above only runs on the original history.
+        const lastResponseText = allResponses.join("\n\n");
+        if (lastResponseText) {
+          const newMariMsg: { role: "assistant"; content: string } = {
+            role: "assistant",
+            content: lastResponseText,
+          };
+          applyRegexScriptsToPromptMessages([newMariMsg], await regexScriptsStore.list(), {
+            resolveMacros: (value) => resolveMacros(value, promptMacroContext, { trimResult: false }),
+          });
+          newMariMsg.content = newMariMsg.content.replace(/\n([ \t]*\n){2,}/g, "\n\n");
+          runningMessagesForFollowUp.push(newMariMsg);
         }
+
+        // Re-read chat metadata so the freshly-persisted mariContext is
+        // visible to the next pass.
+        const freshChat = await chats.getById(input.chatId);
+        if (freshChat) {
+          chatMeta = parseExtra(freshChat.metadata) as Record<string, unknown>;
+        }
+
+        // Reset hoisted per-iteration accumulators before continuing.
+        // (firstSavedMsg stays — it's "first across the whole turn".
+        //  lastSavedMsg, pendingIllustration are overwritten naturally.)
+        collectedCommands.length = 0;
+        collectedOocMessages.length = 0;
+
+        continue;
       }
 
       // ── Background: chunk & embed new messages for memory recall ──

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -990,7 +990,7 @@ export async function generateRoutes(app: FastifyInstance) {
       releaseActiveGeneration();
       return reply.status(400).send({ error: "No base URL configured for this connection" });
     }
-    const chatMeta = parseExtra(chat.metadata) as Record<string, unknown>;
+    let chatMeta = parseExtra(chat.metadata) as Record<string, unknown>;
     let memoryRecallEmbeddingSource: Awaited<ReturnType<typeof resolveMemoryRecallEmbeddingSource>> | null = null;
     try {
       memoryRecallEmbeddingSource = await resolveMemoryRecallEmbeddingSource(app.db, {
@@ -1254,12 +1254,38 @@ export async function generateRoutes(app: FastifyInstance) {
       const chatChoices: Record<string, string | string[]> =
         overrideDefaultChoices ?? ((chatMeta.presetChoices ?? {}) as Record<string, string | string[]>);
 
+      // ── Professor Mari fetch follow-up loop ──
+      // After Mari executes a [fetch:], the fetched data is persisted to
+      // chatMeta.mariContext but only injected into the prompt at the START
+      // of a generation pass. Without a follow-up turn she goes silent
+      // ("snackbar without follow-up", #898). The loop re-runs the generation
+      // up to MAX_FOLLOW_UP_ITERATIONS additional times if a fetch fired in
+      // the previous pass, so Mari can speak to the data she just pulled.
+      let runningMessagesForFollowUp = [...mappedMessages];
+      let followUpIteration = 0;
+      const MAX_FOLLOW_UP_ITERATIONS = 2;
+
+      // Hoisted out of the loop so the SSE flush, OOC posting, and
+      // illustration await at the end see state from the latest iteration.
+      let firstSavedMsg: any = null;
+      let lastSavedMsg: any = null;
+      let pendingIllustration: Promise<void> | null = null;
+      const collectedCommands: Array<{
+        command: CharacterCommand;
+        characterId: string | null;
+        messageId: string;
+        swipeIndex: number;
+      }> = [];
+      const collectedOocMessages: string[] = [];
+
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
       let finalMessages: Array<{
         role: "system" | "user" | "assistant";
         content: string;
         images?: string[];
         providerMetadata?: Record<string, unknown>;
-      }> = mappedMessages;
+      }> = [...runningMessagesForFollowUp];
       let conversationCommandsReminder: string | null = null;
       const conversationCommandsEnabled = chatMode === "conversation" && chatMeta.characterCommands !== false;
       let temperature = 1;
@@ -5712,7 +5738,10 @@ export async function generateRoutes(app: FastifyInstance) {
       // were already resolved earlier for the agent pipeline and are reused here.
 
       // ── Impersonate: inject instruction to respond as the user's character ──
-      if (input.impersonate) {
+      // Only on the user's actual turn (iteration 0). A Mari follow-up pass
+      // is a continuation of the assistant's prior message, not a new user
+      // turn, so re-injecting impersonate/prefill would scramble the prompt.
+      if (input.impersonate && followUpIteration === 0) {
         const impersonateInstruction = buildImpersonateInstruction({
           customPrompt: input.impersonatePromptTemplate || chatMeta.impersonatePrompt,
           direction: input.userMessage,
@@ -5722,7 +5751,7 @@ export async function generateRoutes(app: FastifyInstance) {
         finalMessages.push({ role: "user", content: impersonateInstruction });
       }
 
-      if (assistantPrefill.trim()) {
+      if (assistantPrefill.trim() && followUpIteration === 0) {
         finalMessages.push({ role: "assistant", content: assistantPrefill });
         logger.debug(
           "[generate] Injected assistant prefill (%d chars) as final assistant message",
@@ -6796,15 +6825,8 @@ export async function generateRoutes(app: FastifyInstance) {
       }
 
       // ── Run generation ──
-      let firstSavedMsg: any = null;
-      let lastSavedMsg: any = null;
-      const collectedCommands: Array<{
-        command: CharacterCommand;
-        characterId: string | null;
-        messageId: string;
-        swipeIndex: number;
-      }> = [];
-      const collectedOocMessages: string[] = [];
+      // (firstSavedMsg/lastSavedMsg/collectedCommands/collectedOocMessages
+      // are declared above the follow-up loop so they survive iterations.)
 
       const normalizedGenerationGuide = typeof input.generationGuide === "string" ? input.generationGuide.trim() : "";
       const generationGuideInstruction = normalizedGenerationGuide
@@ -6988,8 +7010,8 @@ export async function generateRoutes(app: FastifyInstance) {
       const hasPostProcessingAgents = resolvedAgents.some((a) => a.phase === "post_processing");
       const combinedResponse = allResponses.join("\n\n");
       let lorebookKeeperProcessedMessageId = "";
-      // Illustration runs asynchronously so it doesn't block other agents
-      let pendingIllustration: Promise<void> | null = null;
+      // Illustration runs asynchronously so it doesn't block other agents.
+      // (pendingIllustration is hoisted above the follow-up loop.)
       const hasPostWork = hasPostProcessingAgents || parallelResults.length > 0;
       if (hasPostWork && combinedResponse && !abortController.signal.aborted) {
         reply.raw.write(`data: ${JSON.stringify({ type: "agent_start", data: { phase: "post_generation" } })}\n\n`);
@@ -9547,6 +9569,74 @@ export async function generateRoutes(app: FastifyInstance) {
         }
       }
 
+      // ── Trigger follow-up generation if Professor Mari just fetched data ──
+      // Mari's fetched payload was persisted to chatMeta.mariContext by the
+      // command handler above, but mariContext is only read into the prompt
+      // at the start of a generation pass — without a follow-up turn she'd
+      // go silent right after the fetch snackbar.
+      const fetchCommandsThisTurn = collectedCommands.filter((c) => c.command.type === "fetch");
+      if (
+        fetchCommandsThisTurn.length > 0 &&
+        chatMode === "conversation" &&
+        !input.impersonate &&
+        !input.regenerateMessageId &&
+        !abortController.signal.aborted &&
+        followUpIteration < MAX_FOLLOW_UP_ITERATIONS
+      ) {
+        const mariFetched = fetchCommandsThisTurn.some(
+          (c) =>
+            c.characterId === PROFESSOR_MARI_ID ||
+            (c.characterId === null && characterIds.includes(PROFESSOR_MARI_ID)),
+        );
+        if (mariFetched) {
+          followUpIteration++;
+          logger.info(
+            "[generate] Professor Mari executed fetch; triggering follow-up generation (iteration %d)",
+            followUpIteration,
+          );
+
+          // Carry the just-streamed assistant turn into the next prompt so
+          // Mari sees her own prior message before speaking again.
+          const lastResponseText = allResponses.join("\n\n");
+          if (lastResponseText) {
+            runningMessagesForFollowUp.push({ role: "assistant", content: lastResponseText });
+          }
+
+          // Re-read chat metadata so the freshly-persisted mariContext is
+          // visible to the next pass.
+          const freshChat = await chats.getById(input.chatId);
+          if (freshChat) {
+            chatMeta = parseExtra(freshChat.metadata) as Record<string, unknown>;
+          }
+
+          // Reset hoisted per-iteration accumulators before continuing.
+          // (firstSavedMsg stays — it's "first across the whole turn".
+          //  lastSavedMsg, pendingIllustration are overwritten naturally.)
+          collectedCommands.length = 0;
+          collectedOocMessages.length = 0;
+
+          continue;
+        }
+      }
+
+      // ── Background: chunk & embed new messages for memory recall ──
+      // Runs once on the final iteration (fire-and-forget). Lives inside the
+      // loop because charInfo is scoped here; only executes when we break.
+      {
+        const charNameMap: Record<string, string> = {};
+        for (const ci of charInfo) {
+          charNameMap[ci.id] = ci.name;
+        }
+        chunkAndEmbedMessages(
+          app.db,
+          input.chatId,
+          { userName: personaName, characterNames: charNameMap },
+          { embeddingSource: memoryRecallEmbeddingSource },
+        ).catch((err) => logger.error(err, "[memory-recall] Background chunking failed"));
+      }
+      break;
+      } // end of Professor Mari follow-up loop
+
       // ── Post OOC messages to connected conversation (Roleplay → Conversation) ──
       if (collectedOocMessages.length > 0 && chat.connectedChatId && !abortController.signal.aborted) {
         try {
@@ -9580,21 +9670,6 @@ export async function generateRoutes(app: FastifyInstance) {
 
       // Signal completion
       sendSseEvent(reply, { type: "done", data: "" });
-
-      // ── Background: chunk & embed new messages for memory recall ──
-      // Always chunk (so memories are available if the user enables recall later)
-      {
-        const charNameMap: Record<string, string> = {};
-        for (const ci of charInfo) {
-          charNameMap[ci.id] = ci.name;
-        }
-        chunkAndEmbedMessages(
-          app.db,
-          input.chatId,
-          { userName: personaName, characterNames: charNameMap },
-          { embeddingSource: memoryRecallEmbeddingSource },
-        ).catch((err) => logger.error(err, "[memory-recall] Background chunking failed"));
-      }
     } catch (err) {
       const message =
         err instanceof Error

--- a/packages/server/src/services/conversation/character-commands.ts
+++ b/packages/server/src/services/conversation/character-commands.ts
@@ -256,29 +256,35 @@ export type CharacterCommand =
   | SpotifyCommand
   | AssistantCommand;
 
+// Param block matcher: any char that isn't `"` or `]`, OR a complete
+// double-quoted string (with `\"`-style escapes). Lets a `]` inside a
+// quoted parameter value (e.g. `description="Status: [VIP]"`) sit inside
+// the command instead of terminating it early.
+const QUOTED_PARAM_BLOCK = '(?:[^"\\]]|"(?:\\\\.|[^"])*")*';
+
 /** Regex patterns for each command type */
-const SCHEDULE_UPDATE_RE = /\[schedule_update:\s*([^\]]+)\]/gi;
+const SCHEDULE_UPDATE_RE = new RegExp(`\\[schedule_update:\\s*(${QUOTED_PARAM_BLOCK})\\]`, "gi");
 const CROSS_POST_RE = /\[cross_post:\s*target="([^"]+)"\]/gi;
 const SELFIE_RE = /\[selfie(?::\s*(?:context="([^"]*)"|"([^"]*)"|([^\]\r\n"]+)))?\]/gi;
 const MEMORY_RE = /\[memory:\s*target="([^"]+)"\s*,\s*summary="([^"]+)"\]/gi;
-const SCENE_RE = /\[scene:\s*([^\]]+)\]/gi;
-const HAPTIC_RE = /\[haptic:\s*([^\]]+)\]/gi;
-const SPOTIFY_RE = /\[spotify:\s*([^\]]+)\]/gi;
-const DIRECT_MESSAGE_RE = /\[dm:\s*([^\]]+)\]/gi;
+const SCENE_RE = new RegExp(`\\[scene:\\s*(${QUOTED_PARAM_BLOCK})\\]`, "gi");
+const HAPTIC_RE = new RegExp(`\\[haptic:\\s*(${QUOTED_PARAM_BLOCK})\\]`, "gi");
+const SPOTIFY_RE = new RegExp(`\\[spotify:\\s*(${QUOTED_PARAM_BLOCK})\\]`, "gi");
+const DIRECT_MESSAGE_RE = new RegExp(`\\[dm:\\s*(${QUOTED_PARAM_BLOCK})\\]`, "gi");
 const INFLUENCE_RE = /<influence>([\s\S]*?)<\/influence>/gi;
 const NOTE_RE = /<note>([\s\S]*?)<\/note>/gi;
 
 // Assistant command regexes
-const CREATE_PERSONA_RE = /\[create_persona:\s*([^\]]+)\]/gi;
-const CREATE_CHARACTER_RE = /\[create_character:\s*([^\]]+)\]/gi;
-const UPDATE_CHARACTER_RE = /\[update_character:\s*([^\]]+)\]/gi;
-const UPDATE_PERSONA_RE = /\[update_persona:\s*([^\]]+)\]/gi;
-const CREATE_LOREBOOK_RE = /\[create_lorebook:\s*([^\]]+)\]/gi;
+const CREATE_PERSONA_RE = new RegExp(`\\[create_persona:\\s*(${QUOTED_PARAM_BLOCK})\\]`, "gi");
+const CREATE_CHARACTER_RE = new RegExp(`\\[create_character:\\s*(${QUOTED_PARAM_BLOCK})\\]`, "gi");
+const UPDATE_CHARACTER_RE = new RegExp(`\\[update_character:\\s*(${QUOTED_PARAM_BLOCK})\\]`, "gi");
+const UPDATE_PERSONA_RE = new RegExp(`\\[update_persona:\\s*(${QUOTED_PARAM_BLOCK})\\]`, "gi");
+const CREATE_LOREBOOK_RE = new RegExp(`\\[create_lorebook:\\s*(${QUOTED_PARAM_BLOCK})\\]`, "gi");
 const CREATE_LOREBOOK_BLOCK_RE = /<create_lorebook>([\s\S]*?)<\/create_lorebook>/gi;
 const UPDATE_LOREBOOK_BLOCK_RE = /<update_lorebook>([\s\S]*?)<\/update_lorebook>/gi;
-const CREATE_CHAT_RE = /\[create_chat:\s*([^\]]+)\]/gi;
-const NAVIGATE_RE = /\[navigate:\s*([^\]]+)\]/gi;
-const FETCH_RE = /\[fetch:\s*([^\]]+)\]/gi;
+const CREATE_CHAT_RE = new RegExp(`\\[create_chat:\\s*(${QUOTED_PARAM_BLOCK})\\]`, "gi");
+const NAVIGATE_RE = new RegExp(`\\[navigate:\\s*(${QUOTED_PARAM_BLOCK})\\]`, "gi");
+const FETCH_RE = new RegExp(`\\[fetch:\\s*(${QUOTED_PARAM_BLOCK})\\]`, "gi");
 
 function decodeQuotedParamValue(value: string): string {
   return value.replace(/\\(["\\nrt])/g, (_match, escaped: string) => {

--- a/packages/server/src/services/conversation/character-commands.ts
+++ b/packages/server/src/services/conversation/character-commands.ts
@@ -259,8 +259,10 @@ export type CharacterCommand =
 // Param block matcher: any char that isn't `"` or `]`, OR a complete
 // double-quoted string (with `\"`-style escapes). Lets a `]` inside a
 // quoted parameter value (e.g. `description="Status: [VIP]"`) sit inside
-// the command instead of terminating it early.
-const QUOTED_PARAM_BLOCK = '(?:[^"\\]]|"(?:\\\\.|[^"])*")*';
+// the command instead of terminating it early. The inner alternative
+// excludes `\\` so backslash is only consumed by the escape branch —
+// otherwise an escape-heavy value can trigger catastrophic backtracking.
+const QUOTED_PARAM_BLOCK = '(?:[^"\\]]|"(?:\\\\.|[^"\\\\])*")*';
 
 /** Regex patterns for each command type */
 const SCHEDULE_UPDATE_RE = new RegExp(`\\[schedule_update:\\s*(${QUOTED_PARAM_BLOCK})\\]`, "gi");


### PR DESCRIPTION
## Linked issue

Closes #898

## Why this change

Two related Professor Mari regressions filed in #898:

1. Update commands containing `]` inside a quoted parameter value (e.g. `[update_character: name="X", description="Status: [VIP] ..."]`) silently failed to parse and landed in the conversation as plain text.
2. After Mari emitted a `[fetch:...]`, the fetched payload was persisted to `chatMeta.mariContext` but mariContext is only injected at the START of a generation pass. Mari went silent right after the fetch snackbar and the user had to send another message before getting a response that used the freshly-fetched data.

## What changed

### Parser fix — `packages/server/src/services/conversation/character-commands.ts`

The catch-all `[^\]]+` capture group in the command regexes terminated at the first `]`, so a `]` inside a quoted parameter value cut the match short. Replaced the catch-all with a `QUOTED_PARAM_BLOCK` snippet that matches either a non-quote/non-`]` char OR a complete double-quoted string (with `\"`-style escapes). Applied to every `[command: ...]`-shape regex that takes free-form params (`schedule_update`, `scene`, `haptic`, `spotify`, `dm`, `create_persona`, `create_character`, `update_character`, `update_persona`, `create_lorebook`, `create_chat`, `navigate`, `fetch`). Leaving `selfie`, `cross_post`, `memory`, and the XML-style block regexes untouched since they already use field-specific patterns. Same bug shape as PR #231's GM tag stripper fix.

### Follow-up loop — `packages/server/src/routes/generate.routes.ts`

Wrapped the conversation-mode generation flow in a `while` loop capped at `MAX_FOLLOW_UP_ITERATIONS = 2` extra iterations. When Professor Mari (`PROFESSOR_MARI_ID`) executes a `[fetch:]` during an iteration, the loop:
- Appends the just-streamed assistant turn into `runningMessagesForFollowUp` so the next pass sees her prior message.
- Re-reads chat metadata via `chats.getById` so the freshly-persisted `mariContext` reaches the next prompt.
- Clears `collectedCommands` / `collectedOocMessages` (hoisted, accumulators) before continuing.
- Gates `impersonate` and `assistantPrefill` injections to iteration 0 only, so a follow-up turn isn't re-shaped as a fresh user turn.

Variables that need to survive across iterations (`firstSavedMsg`, `lastSavedMsg`, `pendingIllustration`, `collectedCommands`, `collectedOocMessages`) are hoisted above the loop so the end-of-stream OOC posting, illustration await, and SSE `done` event see state from the latest iteration. The background memory-recall chunking call was moved to live inside the loop body so `charInfo` stays in scope; it runs exactly once on the final iteration (before `break`).

The follow-up only triggers when:
- `chatMode === "conversation"` (Game/Roleplay modes are unaffected),
- the request isn't an impersonate turn,
- the request isn't a `regenerateMessageId` regen,
- the abort signal hasn't fired,
- the executed fetch was Professor Mari's (by `characterId === PROFESSOR_MARI_ID`, or `characterId === null` in a chat that includes Mari).

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

Tested on a fork build deployed to my private EasyPanel instance (NanoGPT - GLM connection, fresh Conversation chat with Professor Mari).

- **Bug 2 (fetch follow-up):** Asked Mari "Please fetch the Lumine character card and give me a short summary of her personality." Mari emitted a fetch (visible as "one sec, pulling her card up"), the fetch snackbar fired, and she continued in the same turn with card-specific details — INFJ traveler, golden eyes, sword made of wind, her twin Aether being taken. Before the fix the stream ended after the snackbar; with the loop she now speaks to the fetched data.
- **Bug 1 (parser):** Asked Mari "Please update the Lumine character. Add a new tag to her description: include the exact phrase `[STATUS: TRAVELLING]` (with square brackets) at the start of her description so I can grep for it later. Keep the rest intact." Mari ran the update; querying `/api/characters` directly confirmed Lumine's `description` now starts with the literal string `[STATUS: TRAVELLING] "The world is so vast..."` — the bracketed value made it through the parser cleanly. Before the fix this command would have failed to match the regex (terminated at the first `]`) and leaked as plain text.

Things I'd appreciate the maintainers double-checking:

- The hoisting of `firstSavedMsg` / `lastSavedMsg` / `pendingIllustration` out of the inner block — they now share state across iterations. `firstSavedMsg` is intentionally "first across the whole turn" rather than "first per iteration"; `pendingIllustration` will only await the most recent iteration's job (older illustration promises are fire-and-forget anyway). If anyone sees a case where iteration 1 needs a fresh `firstSavedMsg`, I'm happy to gate that.
- The `else if` chain branching on Mari's fetch result (`characterId === PROFESSOR_MARI_ID || (characterId === null && characterIds.includes(PROFESSOR_MARI_ID))`) — this matches the same heuristic used elsewhere in the file (e.g. line ~2239 `isMariChat`), but I haven't audited every legacy chat to confirm `null` characterId always lines up with Mari being the speaker in a Mari-included chat.
- Roleplay / Game-mode chats are explicitly excluded from the follow-up loop so this should not affect any GM flows, but worth a quick sanity pass.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

Not a UI change. The user-visible effect is that Mari now actually keeps talking after `[fetch:]` and update commands with brackets-in-quotes land cleanly instead of dumping as plain text.

## Credit

The shape of both fixes follows a patch shared by @timwu in the Discord thread linked from #898 ([fork commit](https://github.com/timwu/Marinara-Engine/commit/605f6d5473a94cc81a996522adba2b4ebd2fe50d)). I ported it forward to current `staging`, dropped an unrelated `charNameMap` refactor that was in the original patch, and verified end-to-end against the live deploy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of fetch command execution in conversations through enhanced iterative generation handling
  * Enhanced command parsing to correctly handle complex parameters containing special characters when properly quoted

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/910?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->