### PR TITLE
Fix storm ambience for non-storm rain

### DIFF
--- a/packages/server/test/game-audio-score.test.ts
+++ b/packages/server/test/game-audio-score.test.ts
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { scoreAmbient } from "@marinara-engine/shared";
+
+const availableAmbient = [
+  "ambient:nature:autumn-wind-leaves",
+  "ambient:nature:birds-singing",
+  "ambient:nature:howling-wind",
+  "ambient:nature:rain-thunder",
+  "ambient:nature:river-flowing",
+  "ambient:interior:rain-on-roof",
+];
+
+test("ambient scoring does not use thunder ambience for plain rain", () => {
+  const selected = scoreAmbient({
+    state: "exploration",
+    weather: "rain",
+    timeOfDay: null,
+    locationKind: "nature",
+    currentAmbient: null,
+    availableAmbient,
+    background: null,
+  });
+
+  assert.ok(selected);
+  assert.doesNotMatch(selected, /thunder|storm|lightning/i);
+});
+
+test("ambient scoring can use thunder ambience for storm weather", () => {
+  const selected = scoreAmbient({
+    state: "exploration",
+    weather: "storm",
+    timeOfDay: null,
+    locationKind: "nature",
+    currentAmbient: null,
+    availableAmbient,
+    background: null,
+  });
+
+  assert.equal(selected, "ambient:nature:rain-thunder");
+});

--- a/packages/shared/src/utils/music-score.ts
+++ b/packages/shared/src/utils/music-score.ts
@@ -131,9 +131,9 @@ const WEATHER_AMBIENT: Record<string, string[]> = {
   clear: ["birds", "wind", "water"],
   cloudy: ["wind"],
   overcast: ["wind", "eerie"],
-  rain: ["rain", "thunder"],
-  rainy: ["rain", "thunder"],
-  heavy_rain: ["rain", "thunder", "howling"],
+  rain: ["rain"],
+  rainy: ["rain"],
+  heavy_rain: ["rain", "howling"],
   storm: ["rain", "thunder", "howling"],
   stormy: ["rain", "thunder", "howling"],
   snow: ["wind", "howling"],
@@ -394,6 +394,17 @@ function ambientKeywordScore(parts: string[], keywords: string[]): number {
   return score;
 }
 
+function weatherAllowsStormAudio(weather?: string | null): boolean {
+  const normalized = normalizeToken(weather);
+  return normalized === "storm" || normalized === "stormy" || normalized === "thunderstorm";
+}
+
+function ambientStormAudioScore(parts: string[], weather?: string | null): number {
+  const hasStormAudio = parts.includes("thunder") || parts.includes("lightning") || parts.includes("storm");
+  if (!hasStormAudio) return 0;
+  return weatherAllowsStormAudio(weather) ? 2 : -6;
+}
+
 function ambientLocationScore(parts: string[], locationKind: LocationKind | null): number {
   if (!locationKind) return 0;
   const subcategory = parts[1] ?? "";
@@ -446,7 +457,10 @@ export function scoreAmbient(input: AmbientScoreInput): string | null {
       .toLowerCase()
       .split(/[:\-_]+/)
       .filter((part) => part.length > 1);
-    const score = ambientLocationScore(parts, locationKind) + ambientKeywordScore(parts, keywords);
+    const score =
+      ambientLocationScore(parts, locationKind) +
+      ambientKeywordScore(parts, keywords) +
+      ambientStormAudioScore(parts, weather);
     return { tag, score };
   });
 


### PR DESCRIPTION
<!-- Target branch: `staging`. The default base in this UI is `main` (release branch). -->
<!-- Change the base to `staging` before submitting unless this is a maintainer-approved mainline change. -->
<!-- See CONTRIBUTING.md § Branches. -->

## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

No linked issue yet. Bug reported directly in Codex: storm weather SFX/ambience was heard in game mode when the story did not have a storm.

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- Game mode could select thunder-bearing ambient weather audio for plain rain or non-storm contexts because the ambient scorer treated `rain`/`rainy` as thunder keywords and did not penalize storm-audio assets unless the tracked weather was actually stormy.

## What changed

<!-- List the key changes in this PR -->

- Removed thunder from non-storm rain ambient keywords.
- Added storm-audio scoring so thunder/lightning/storm ambient assets are penalized unless tracked weather is storm/stormy/thunderstorm, and lightly boosted when it is.
- Added regression coverage for plain rain avoiding thunder ambience and actual storm weather still selecting the thunder loop.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Codex scratch repro before the fix: plain rain outdoors selected `ambient:nature:rain-thunder`.
- Codex scratch repro after the fix: plain rain, rainy weather, and unset combat weather avoid thunder ambience; actual storm weather selects `ambient:nature:rain-thunder`; interior rain selects `ambient:interior:rain-on-roof`.
- `pnpm --filter @marinara-engine/server test -- test/game-audio-score.test.ts` passed. The script currently runs the full server test suite; 358 tests passed.
- `pnpm check` passed locally.
- Bunny review passed before opening the PR.
- No human-only verification blocker for the core claim; this is deterministic scorer logic, not provider/hardware-dependent behavior.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs or release metadata changes needed for this internal scoring fix.

## UI evidence (if applicable)

N/A: no UI surface changed. Proof is the deterministic scorer repro and regression test above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ambient audio selection to properly differentiate between rain and storm weather conditions, ensuring rain uses appropriate background audio while storms trigger suitable thunder effects.

* **Tests**
  * Added test coverage for ambient audio scoring across different weather scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/915?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->