### PR TITLE
Fix game mode empty response recovery

### DIFF
--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -6481,15 +6481,13 @@ export async function generateRoutes(app: FastifyInstance) {
           let contentReplaced = false;
           const promotableThinking = providerThinking.trim() || fullThinking.trim();
           // Some OpenAI-compatible providers misplace the actual assistant text
-          // in reasoning/thinking fields even when reasoning was not requested.
+          // in reasoning/thinking fields. Conversation mode only recovers when
+          // reasoning was not requested; game mode requests reasoning by default,
+          // so it still needs the recovery path to avoid empty GM turns.
           const isGlmModel = conn.model.toLowerCase().includes("glm");
-          if (
-            chatMode === "conversation" &&
-            !fullResponse.trim() &&
-            promotableThinking &&
-            !enableThinking &&
-            !resolvedEffort
-          ) {
+          const shouldPromoteThinkingOnlyResponse =
+            chatMode === "conversation" ? !enableThinking && !resolvedEffort : chatMode === "game";
+          if (!fullResponse.trim() && promotableThinking && shouldPromoteThinkingOnlyResponse) {
             if (isGlmModel) {
               logger.warn(
                 "[generate] Refusing to promote GLM thinking-only response for chat %s (char: %s, model: %s)",
@@ -6499,7 +6497,8 @@ export async function generateRoutes(app: FastifyInstance) {
               );
             } else {
               logger.warn(
-                "[generate] Promoting thinking-only response to visible text for chat %s (char: %s, model: %s)",
+                "[generate] Promoting thinking-only response to visible text for %s chat %s (char: %s, model: %s)",
+                chatMode,
                 input.chatId,
                 targetCharId,
                 conn.model,


### PR DESCRIPTION
<!-- Target branch: `staging`. The default base in this UI is `main` (release branch). -->
<!-- Change the base to `staging` before submitting unless this is a maintainer-approved mainline change. -->
<!-- See CONTRIBUTING.md § Branches. -->

## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

No linked GitHub issue. Bug report was provided directly in Codex; open an issue before final submission if the team wants every PR linked.

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- Game mode can fail with `The AI returned an empty response` when an OpenAI-compatible provider returns usable GM narration in a reasoning/thinking field but no visible `content`.

## What changed

<!-- List the key changes in this PR -->

- Extends the existing thinking-only response recovery path to game mode.
- Keeps the existing conversation behavior and GLM safety guard.
- Leaves roleplay thinking-only responses unchanged.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Codex reproduced the failure with `pnpm --dir packages/server exec tsx scratch/game-empty-response-repro.ts` before the fix: the generated SSE included `The AI returned an empty response` and no assistant message was saved.
- Codex re-ran the original repro after the fix: the generated SSE included `content_replace`, no empty-response error was emitted, and the assistant message was saved with the recovered narration.
- Codex ran edge checks with the same scratch harness:
  - game visible-content response still saves normally
  - conversation thinking-only recovery still works
  - roleplay thinking-only response still errors as before
- `pnpm check` passed locally.
- Bunny review passed for the current diff.
- No human-only verification is required for the core claim; the provider behavior is covered by the mocked OpenAI-compatible route repro.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs or release metadata changes needed for this narrow server-side recovery fix.

## UI evidence (if applicable)

N/A. The visible toast is caused by the server SSE error path; Codex verified the server `/api/generate` SSE and message persistence path directly with a focused scratch repro.
