### PR TITLE
Fix NPC avatar matching for professor names

### DIFF
--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -13,7 +13,7 @@ import {
   resolveMacros,
   summariesPatchSchema,
 } from "@marinara-engine/shared";
-import type { CharacterData, ChatMemoryChunk, LorebookEntryTimingState } from "@marinara-engine/shared";
+import type { CharacterData, ChatMemoryChunk, GameNpc, LorebookEntryTimingState } from "@marinara-engine/shared";
 import { createChatsStorage } from "../services/storage/chats.storage.js";
 import { createCharactersStorage } from "../services/storage/characters.storage.js";
 import { createConnectionsStorage } from "../services/storage/connections.storage.js";
@@ -47,9 +47,26 @@ import {
   resolveMemoryRecallEmbeddingSource,
 } from "../services/memory-recall-embedding.js";
 import { applyRegexScriptsToPromptMessages } from "../services/regex/regex-application.js";
+import { sanitizeGameNpcAvatarUrls } from "../services/game/npc-avatar-utils.js";
 
 type TrackerWrapFormat = "xml" | "markdown" | "none";
 type EntryStateOverrides = Record<string, { ephemeral?: number | null; enabled?: boolean }>;
+
+function sanitizeChatGameNpcAvatars<T extends { metadata?: unknown }>(chat: T): T {
+  const metadata = typeof chat.metadata === "string" ? JSON.parse(chat.metadata) : (chat.metadata ?? {});
+  if (!metadata || typeof metadata !== "object") return chat;
+  const gameNpcs = Array.isArray((metadata as Record<string, unknown>).gameNpcs)
+    ? ((metadata as Record<string, unknown>).gameNpcs as GameNpc[])
+    : null;
+  if (!gameNpcs) return chat;
+  const sanitizedNpcs = sanitizeGameNpcAvatarUrls(gameNpcs);
+  if (sanitizedNpcs === gameNpcs) return chat;
+  const sanitizedMetadata = { ...(metadata as Record<string, unknown>), gameNpcs: sanitizedNpcs };
+  return {
+    ...chat,
+    metadata: typeof chat.metadata === "string" ? JSON.stringify(sanitizedMetadata) : sanitizedMetadata,
+  };
+}
 
 async function loadLatestChatGameSnapshot(
   app: FastifyInstance,
@@ -266,19 +283,21 @@ export async function chatsRoutes(app: FastifyInstance) {
 
   // List all chats
   app.get("/", async () => {
-    return storage.list();
+    const chats = await storage.list();
+    return chats.map(sanitizeChatGameNpcAvatars);
   });
 
   // List chats by group
   app.get<{ Params: { groupId: string } }>("/group/:groupId", async (req) => {
-    return storage.listByGroup(req.params.groupId);
+    const chats = await storage.listByGroup(req.params.groupId);
+    return chats.map(sanitizeChatGameNpcAvatars);
   });
 
   // Get single chat
   app.get<{ Params: { id: string } }>("/:id", async (req, reply) => {
     const chat = await storage.getById(req.params.id);
     if (!chat) return reply.status(404).send({ error: "Chat not found" });
-    return chat;
+    return sanitizeChatGameNpcAvatars(chat);
   });
 
   // Create chat

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -64,6 +64,7 @@ import {
 import { generateWeather, inferBiome, shouldWeatherChange } from "../services/game/weather.service.js";
 import { rollEncounter, rollEnemyCount } from "../services/game/encounter.service.js";
 import { processReputationActions } from "../services/game/reputation.service.js";
+import { sanitizeGameNpcAvatarUrls } from "../services/game/npc-avatar-utils.js";
 import { createCheckpointService, type CheckpointTrigger } from "../services/game/checkpoint.service.js";
 import {
   resolveSkillCheck,
@@ -144,7 +145,21 @@ import {
 // Helpers
 // ──────────────────────────────────────────────
 
-const AVATAR_NAME_TITLE_WORDS = new Set(["a", "an", "the", "il", "lo", "la", "le", "l", "el", "sir", "lady", "lord"]);
+const AVATAR_NAME_TITLE_WORDS = new Set([
+  "a",
+  "an",
+  "the",
+  "il",
+  "lo",
+  "la",
+  "le",
+  "l",
+  "el",
+  "sir",
+  "lady",
+  "lord",
+  "professor",
+]);
 
 function normalizeAvatarLookupName(value: string): string {
   return value
@@ -172,7 +187,7 @@ function avatarLookupAliases(value: string): string[] {
   ).filter(Boolean);
 }
 
-function addNameLookupEntry(map: Map<string, string>, name: unknown, value: unknown): void {
+export function addNameLookupEntry(map: Map<string, string>, name: unknown, value: unknown): void {
   if (typeof name !== "string" || typeof value !== "string") return;
   const trimmedValue = value.trim();
   if (!trimmedValue) return;
@@ -207,7 +222,7 @@ const generatedOptionalStringSchema = z.preprocess((value) => generatedStringVal
  * Title aliases make "Il Dottore" resolve to a saved "Dottore" card and
  * "Il Capitano" resolve to "Capitano" before any image generation is attempted.
  */
-function findCharAvatarFuzzy(npcName: string, charAvatarByName: Map<string, string>): string | undefined {
+export function findCharAvatarFuzzy(npcName: string, charAvatarByName: Map<string, string>): string | undefined {
   const npcAliases = avatarLookupAliases(npcName);
 
   // 1. Exact
@@ -2395,8 +2410,9 @@ function buildSceneAssetNpcCandidates(
 function upsertGameNpcAvatarEntries(currentNpcs: GameNpc[], avatarEntries: SceneAssetNpcAvatarEntry[]): GameNpc[] {
   if (avatarEntries.length === 0) return currentNpcs;
 
-  const nextNpcs = [...currentNpcs];
-  let changed = false;
+  const sanitizedCurrentNpcs = sanitizeGameNpcAvatarUrls(currentNpcs);
+  const nextNpcs = [...sanitizedCurrentNpcs];
+  let changed = sanitizedCurrentNpcs !== currentNpcs;
 
   for (const entry of avatarEntries) {
     const normalizedName = normalizeJournalMatch(entry.name);
@@ -2650,6 +2666,11 @@ export async function gameRoutes(app: FastifyInstance) {
     const latestState = await gameStateStore.getLatest(chatId);
 
     let hydratedMeta = baseMeta;
+    const gameNpcs = Array.isArray(hydratedMeta.gameNpcs) ? (hydratedMeta.gameNpcs as GameNpc[]) : null;
+    if (gameNpcs) {
+      const sanitizedNpcs = sanitizeGameNpcAvatarUrls(gameNpcs);
+      if (sanitizedNpcs !== gameNpcs) hydratedMeta = { ...hydratedMeta, gameNpcs: sanitizedNpcs };
+    }
     const presentCharacterNames = extractPresentCharacterNames(latestState?.presentCharacters);
     if (presentCharacterNames.length > 0) {
       hydratedMeta = markNpcsMetByNames(hydratedMeta, presentCharacterNames);

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -76,6 +76,7 @@ import { DATA_DIR } from "../utils/data-dir.js";
 import { executeAgent, normalizeAgentContextSize, resolveAgentResultType } from "../services/agents/agent-executor.js";
 import { buildSpriteExpressionChoices, listCharacterSprites } from "../services/game/sprite.service.js";
 import { generateChatBackground } from "../services/game/game-asset-generation.js";
+import { sanitizeGameNpcAvatarUrls } from "../services/game/npc-avatar-utils.js";
 import { getLocalSidecarProvider, LOCAL_SIDECAR_MODEL } from "../services/llm/local-sidecar.js";
 import {
   parseCharacterCommands,
@@ -7523,7 +7524,11 @@ export async function generateRoutes(app: FastifyInstance) {
               // 2. Fall back to stored NPC avatars (per-chat generated/uploaded)
               const NPC_AVATAR_DIR = join(DATA_DIR, "avatars", "npc");
               const storedNpcAvatarByName = new Map<string, string>();
-              for (const npc of (chatMeta.gameNpcs as GameNpc[]) ?? []) {
+              const gameNpcs = sanitizeGameNpcAvatarUrls((chatMeta.gameNpcs as GameNpc[]) ?? []);
+              if (gameNpcs !== chatMeta.gameNpcs) {
+                chatMeta.gameNpcs = gameNpcs;
+              }
+              for (const npc of gameNpcs) {
                 const name = typeof npc.name === "string" ? npc.name.trim().toLowerCase() : "";
                 if (name && npc.avatarUrl) storedNpcAvatarByName.set(name, npc.avatarUrl);
               }

--- a/packages/server/src/services/game/npc-avatar-utils.ts
+++ b/packages/server/src/services/game/npc-avatar-utils.ts
@@ -1,0 +1,36 @@
+import type { GameNpc } from "@marinara-engine/shared";
+
+export const BUILT_IN_MARI_AVATAR = "/sprites/mari/Mari_profile.png";
+
+function normalizeNpcName(name: string): string {
+  return name
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/'/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function isMariNpcName(name: unknown): boolean {
+  if (typeof name !== "string") return false;
+  const normalized = normalizeNpcName(name);
+  return normalized === "mari" || normalized === "professor mari";
+}
+
+export function isInvalidBuiltInMariNpcAvatar(npc: Pick<GameNpc, "name" | "avatarUrl">): boolean {
+  const avatarPath = typeof npc.avatarUrl === "string" ? npc.avatarUrl.split("?")[0] : "";
+  return avatarPath === BUILT_IN_MARI_AVATAR && !isMariNpcName(npc.name);
+}
+
+export function sanitizeGameNpcAvatarUrls(npcs: GameNpc[]): GameNpc[] {
+  let changed = false;
+  const sanitized = npcs.map((npc) => {
+    if (!isInvalidBuiltInMariNpcAvatar(npc)) return npc;
+    changed = true;
+    const { avatarUrl: _avatarUrl, ...rest } = npc;
+    return rest;
+  });
+  return changed ? sanitized : npcs;
+}


### PR DESCRIPTION
<!-- Target branch: `staging`. The default base in this UI is `main` (release branch). -->
<!-- Change the base to `staging` before submitting unless this is a maintainer-approved mainline change. -->
<!-- See CONTRIBUTING.md § Branches. -->

## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

No linked GitHub issue. Bug was reported directly in Codex; an issue should be opened before non-draft submission if the team wants one.

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- Professor Oak could render with Professor Mari's built-in portrait in Game mode because the NPC avatar matcher treated the shared title word `professor` as a fuzzy avatar alias.

## What changed

<!-- List the key changes in this PR -->

- Treat `professor` as a title/honorific for NPC avatar aliases, so `Professor Mari` can still match `Mari` without matching every professor NPC.
- Added a shared NPC avatar sanitizer that strips Mari's built-in avatar from non-Mari game NPCs.
- Applied the sanitizer when reading chat metadata, hydrating Game mode metadata, upserting NPC avatar entries, and reusing stored NPC avatars during character-tracker updates.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Codex reproduced the bad state on the Pi app via `http://100.64.240.39:7860/api/chats`: chat `KmSLNSsePLyUwHOuwZUb7` had `gameNpcs[0].name` as `Professor Oak` with `avatarUrl` set to `/sprites/mari/Mari_profile.png`.
- Codex ran `pnpm --dir packages/server exec tsx ../../scratch/prof-oak-avatar-repro.ts`; the focused repro showed Oak no longer resolves from Mari-only aliases, exact Oak/title aliases still work, and stale Mari avatars are stripped from Professor Oak while preserved for Professor Mari.
- Codex ran `pnpm check`; it passed.
- Bunny review pass: passed for the current diff.
- Recommended after deploy: visually confirm on the Pi Docker app that Professor Oak no longer renders Professor Mari's portrait in the active game chat.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs, release metadata, schema, or dependency changes.

## UI evidence (if applicable)

Original UI evidence was supplied in the bug report screenshot. The changed server path was verified with a focused repro script; a post-deploy visual check on the Pi Docker app is still recommended.
