### PR TITLE
Fix game sprite recovery

### DIFF
--- a/packages/client/src/components/game/GameNarration.tsx
+++ b/packages/client/src/components/game/GameNarration.tsx
@@ -420,6 +420,8 @@ interface GameNarrationProps {
   onNpcPortraitClick?: (npcName: string) => void;
   /** Generate or replace a tracked NPC portrait through the image provider. */
   onNpcPortraitGenerate?: (npcName: string) => void;
+  /** Notify the parent that a tracked NPC portrait URL failed to load. */
+  onNpcPortraitLoadError?: (npcName: string) => void;
   npcPortraitGenerationEnabled?: boolean;
   generatingNpcPortraitNames?: Set<string>;
   /** Pause auto-play while a blocking game overlay is open. */
@@ -901,6 +903,7 @@ export function GameNarration({
   onReadable,
   onNpcPortraitClick,
   onNpcPortraitGenerate,
+  onNpcPortraitLoadError,
   npcPortraitGenerationEnabled = false,
   generatingNpcPortraitNames,
   autoPlayBlocked,
@@ -3589,6 +3592,11 @@ export function GameNarration({
                                 alt={active.speaker || ""}
                                 crop={activeAvatar.crop}
                                 className={cn(GAME_DIALOGUE_AVATAR_CLASS, "transition-colors hover:border-white/30")}
+                                onLoadError={
+                                  activeCanGeneratePortrait && active.speaker
+                                    ? () => onNpcPortraitLoadError?.(active.speaker as string)
+                                    : undefined
+                                }
                               />
                             ) : (
                               <img
@@ -3630,6 +3638,11 @@ export function GameNarration({
                           alt={active.speaker || ""}
                           crop={activeAvatar.crop}
                           className={GAME_DIALOGUE_AVATAR_CLASS}
+                          onLoadError={
+                            activeCanGeneratePortrait && active.speaker
+                              ? () => onNpcPortraitLoadError?.(active.speaker as string)
+                              : undefined
+                          }
                         />
                       ) : (
                         <img
@@ -4497,6 +4510,11 @@ export function GameNarration({
                                       alt={seg.speaker || ""}
                                       crop={logAvatar.crop}
                                       className="h-8 w-8 rounded-lg border border-white/10 transition-colors hover:border-white/25"
+                                      onLoadError={
+                                        canGenerateLogPortrait && seg.speaker
+                                          ? () => onNpcPortraitLoadError?.(seg.speaker as string)
+                                          : undefined
+                                      }
                                     />
                                   ) : (
                                     <div className="flex h-8 w-8 items-center justify-center rounded-lg border border-white/10 bg-[var(--accent)] text-[0.5rem] font-bold transition-colors hover:border-white/25">
@@ -4533,6 +4551,11 @@ export function GameNarration({
                                 alt={seg.speaker || ""}
                                 crop={logAvatar.crop}
                                 className="h-8 w-8 shrink-0 rounded-lg border border-white/10"
+                                onLoadError={
+                                  canGenerateLogPortrait && seg.speaker
+                                    ? () => onNpcPortraitLoadError?.(seg.speaker as string)
+                                    : undefined
+                                }
                               />
                             ) : (
                               <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-white/10 bg-[var(--accent)] text-[0.5rem] font-bold">
@@ -4684,15 +4707,23 @@ function CroppedAvatar({
   alt,
   crop,
   className,
+  onLoadError,
 }: {
   src: string;
   alt: string;
   crop?: AvatarCrop | LegacyAvatarCrop | null;
   className?: string;
+  onLoadError?: () => void;
 }) {
   return (
     <div className={cn("relative overflow-hidden", className)}>
-      <img src={src} alt={alt} className="h-full w-full object-cover" style={getAvatarCropStyle(crop)} />
+      <img
+        src={src}
+        alt={alt}
+        className="h-full w-full object-cover"
+        style={getAvatarCropStyle(crop)}
+        onError={onLoadError}
+      />
     </div>
   );
 }

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -2153,6 +2153,7 @@ export function GameSurface({
   const [pendingAssetGeneration, setPendingAssetGeneration] = useState<GameAssetGenerationPayload | null>(null);
   const [assetGenerationBlocksScene, setAssetGenerationBlocksScene] = useState(false);
   const [assetGenerationFailed, setAssetGenerationFailed] = useState(false);
+  const [failedNpcAvatarNames, setFailedNpcAvatarNames] = useState<Set<string>>(() => new Set());
   const [imagePromptReviewItems, setImagePromptReviewItems] = useState<GameImagePromptReviewItem[]>([]);
   const [imagePromptReviewSubmitting, setImagePromptReviewSubmitting] = useState(false);
   const imagePromptReviewResolveRef = useRef<((overrides: GameImagePromptOverride[] | null) => void) | null>(null);
@@ -2851,6 +2852,7 @@ export function GameSurface({
       sceneAssetNpcs,
       npcAvatarLookup,
       npcsNeedingAvatars,
+      failedNpcAvatarNames,
     });
   }, [
     activeChatId,
@@ -2858,6 +2860,7 @@ export function GameSurface({
     chatMeta.gameSceneBackground,
     currentBackground,
     gameImageGenerationEnabled,
+    failedNpcAvatarNames,
     npcAvatarLookup,
     npcsNeedingAvatars,
     sceneAssetNpcs,
@@ -2868,6 +2871,28 @@ export function GameSurface({
   useEffect(() => {
     autoAssetGenerationKeyRef.current = null;
   }, [activeChatId]);
+
+  const clearFailedNpcAvatars = useCallback((names: Iterable<string>) => {
+    const normalizedNames = new Set([...names].map(normalizeSceneAssetName).filter(Boolean));
+    if (normalizedNames.size === 0) return;
+    setFailedNpcAvatarNames((current) => {
+      let modified = false;
+      const next = new Set(current);
+      for (const name of normalizedNames) {
+        if (next.delete(name)) modified = true;
+      }
+      return modified ? next : current;
+    });
+  }, []);
+
+  const handleNpcPortraitLoadError = useCallback((npcName: string) => {
+    const normalizedName = normalizeSceneAssetName(npcName);
+    if (!normalizedName) return;
+    setFailedNpcAvatarNames((current) => {
+      if (current.has(normalizedName)) return current;
+      return new Set(current).add(normalizedName);
+    });
+  }, []);
 
   const canRetryTurn = !!latestAssistantMsg?.id && !isStreaming;
   const canRetryScene = !!latestAssistantMsg?.content && !isStreaming && !sceneAnalysis.isPending;
@@ -4005,9 +4030,10 @@ export function GameSurface({
       }
       if (res.generatedNpcAvatars?.length) {
         useGameModeStore.getState().patchNpcAvatars(res.generatedNpcAvatars);
+        clearFailedNpcAvatars(res.generatedNpcAvatars.map((avatar) => avatar.name));
       }
     },
-    [fetchManifest, installGeneratedIllustration],
+    [clearFailedNpcAvatars, fetchManifest, installGeneratedIllustration],
   );
 
   async function applySceneResult(result: import("@marinara-engine/shared").SceneAnalysis, msg: { id: string }) {
@@ -4131,6 +4157,7 @@ export function GameSurface({
     }
     if (result.generatedNpcAvatars?.length) {
       useGameModeStore.getState().patchNpcAvatars(result.generatedNpcAvatars);
+      clearFailedNpcAvatars(result.generatedNpcAvatars.map((avatar) => avatar.name));
     }
 
     const manifest = useGameAssetStore.getState().manifest;
@@ -4807,12 +4834,13 @@ export function GameSurface({
         });
 
         useGameModeStore.getState().patchNpcAvatars([{ name: targetNpc.name, avatarUrl: response.avatarPath }]);
+        clearFailedNpcAvatars([targetNpc.name]);
         toast.success(`${targetNpc.name} portrait updated.`);
       } catch (error) {
         toast.error(error instanceof Error ? error.message : `Failed to update ${npcName} portrait.`);
       }
     },
-    [activeChatId, updateChatMetadata],
+    [activeChatId, clearFailedNpcAvatars, updateChatMetadata],
   );
 
   const handleNpcPortraitGenerate = useCallback(
@@ -4862,6 +4890,7 @@ export function GameSurface({
           (avatar) => avatar.name.trim().toLowerCase() === targetNpc.name.trim().toLowerCase(),
         );
         if (generated) {
+          clearFailedNpcAvatars([targetNpc.name]);
           toast.success(`${targetNpc.name} portrait generated.`);
         } else {
           toast.error(`No portrait was generated for ${targetNpc.name}.`);
@@ -4881,6 +4910,7 @@ export function GameSurface({
       applyGeneratedAssets,
       chatMeta.enableSpriteGeneration,
       chatMeta.gameImageConnectionId,
+      clearFailedNpcAvatars,
       runGameAssetGeneration,
     ],
   );
@@ -8271,6 +8301,7 @@ export function GameSurface({
                           onReadable={handleReadable}
                           onNpcPortraitClick={handleNpcPortraitClick}
                           onNpcPortraitGenerate={handleNpcPortraitGenerate}
+                          onNpcPortraitLoadError={handleNpcPortraitLoadError}
                           npcPortraitGenerationEnabled={
                             chatMeta.enableSpriteGeneration === true &&
                             typeof chatMeta.gameImageConnectionId === "string"
@@ -8350,6 +8381,7 @@ export function GameSurface({
                       onReadable={handleReadable}
                       onNpcPortraitClick={handleNpcPortraitClick}
                       onNpcPortraitGenerate={handleNpcPortraitGenerate}
+                      onNpcPortraitLoadError={handleNpcPortraitLoadError}
                       npcPortraitGenerationEnabled={
                         chatMeta.enableSpriteGeneration === true && typeof chatMeta.gameImageConnectionId === "string"
                       }

--- a/packages/client/src/components/game/game-asset-generation-payload.ts
+++ b/packages/client/src/components/game/game-asset-generation-payload.ts
@@ -24,6 +24,7 @@ type MissingSceneAssetGenerationInput = {
   sceneAssetNpcs: SceneAssetNpcAvatarCandidate[];
   npcAvatarLookup: Map<string, string>;
   npcsNeedingAvatars: Array<{ name: string; description: string }>;
+  failedNpcAvatarNames?: Iterable<string>;
 };
 
 export function normalizeSceneAssetNameForGeneration(value: string): string {
@@ -49,6 +50,7 @@ export function buildMissingSceneAssetGenerationPayload({
   sceneAssetNpcs,
   npcAvatarLookup,
   npcsNeedingAvatars,
+  failedNpcAvatarNames,
 }: MissingSceneAssetGenerationInput): MissingSceneAssetGenerationPayload | null {
   if (!gameImageGenerationEnabled) return null;
   if (!activeChatId) return null;
@@ -62,13 +64,38 @@ export function buildMissingSceneAssetGenerationPayload({
     .filter((npc) => npc.description && npc.name)
     .map((npc) => ({ name: npc.name, description: npc.description }))
     .slice(0, 10);
-  const forceNpcAvatarNames = savedGeneratedBackgroundMissing
-    ? npcAssetCandidates
-        .filter((npc) => npcAvatarLookup.has(normalizeSceneAssetNameForGeneration(npc.name)))
-        .map((npc) => npc.name)
-    : [];
+  const forceNpcAvatarNameSet = new Set<string>();
+  if (savedGeneratedBackgroundMissing) {
+    for (const npc of npcAssetCandidates) {
+      if (npcAvatarLookup.has(normalizeSceneAssetNameForGeneration(npc.name))) {
+        forceNpcAvatarNameSet.add(npc.name);
+      }
+    }
+  }
+  const failedNpcAvatarNameSet = new Set(
+    [...(failedNpcAvatarNames ?? [])].map(normalizeSceneAssetNameForGeneration).filter(Boolean),
+  );
+  for (const npc of npcAssetCandidates) {
+    if (failedNpcAvatarNameSet.has(normalizeSceneAssetNameForGeneration(npc.name))) {
+      forceNpcAvatarNameSet.add(npc.name);
+    }
+  }
+  const forceNpcAvatarNames = [...forceNpcAvatarNameSet];
+  const forcedNpcPayload = npcAssetCandidates.filter((npc) => forceNpcAvatarNameSet.has(npc.name));
   const npcPayload =
-    savedGeneratedBackgroundMissing && forceNpcAvatarNames.length > 0 ? npcAssetCandidates : npcsNeedingAvatars;
+    savedGeneratedBackgroundMissing && forceNpcAvatarNames.length > 0
+      ? npcAssetCandidates
+      : [
+          ...npcsNeedingAvatars,
+          ...forcedNpcPayload.filter(
+            (forcedNpc) =>
+              !npcsNeedingAvatars.some(
+                (npc) =>
+                  normalizeSceneAssetNameForGeneration(npc.name) ===
+                  normalizeSceneAssetNameForGeneration(forcedNpc.name),
+              ),
+          ),
+        ].slice(0, 10);
 
   if (!unresolvedBackground && npcPayload.length === 0) return null;
 


### PR DESCRIPTION
<!-- Target branch: `staging`. The default base in this UI is `main` (release branch). -->
<!-- Change the base to `staging` before submitting unless this is a maintainer-approved mainline change. -->
<!-- See CONTRIBUTING.md § Branches. -->

## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

No linked issue yet. User-reported bug: sometimes in game mode a sprite/portrait never generates even with image generation enabled, and the AI needs a way to recover.

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- A stale or broken generated NPC portrait URL could make game mode believe a sprite was already resolved, so automatic image generation would not retry and the missing sprite could stay missing indefinitely.

## What changed

<!-- List the key changes in this PR -->

- Track failed NPC portrait image loads from the game narration UI.
- Feed failed NPC names into the missing game asset payload so they are force-regenerated even when stale metadata still has an avatar URL.
- Clear the failed-load marker after a successful upload or generated portrait patch.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Codex reproduced the stuck state with `node scratch/repro-game-sprite-stale-avatar.mjs`: before the fix, a stale NPC avatar URL suppressed asset generation with a `null` payload.
- Codex re-ran `node scratch/repro-game-sprite-stale-avatar.mjs` after the fix: an observed failed avatar load now produces `npcsNeedingAvatars` and `forceNpcAvatarNames` for the NPC.
- Codex ran `pnpm check`; it passed `impeccable:check`, lint, and shared/server/client builds.
- Not manually verified against a real image provider because this environment does not have the user's image generation provider/API key configured. The retry decision path is covered by the scratch repro.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs, release metadata, schema, or dependency changes.

## UI evidence (if applicable)

N/A. This is a recovery-path fix for broken NPC portrait loads; Codex verified the payload path with a scratch repro rather than a provider-backed browser session.
