### PR TITLE
fix(game): respect persona avatarCrop on all Game Mode portraits

### DIFF
--- a/packages/client/src/components/game/GameNarration.tsx
+++ b/packages/client/src/components/game/GameNarration.tsx
@@ -1054,7 +1054,7 @@ export function GameNarration({
       if (c.avatarUrl) setAvatarInfo(c.name, { url: c.avatarUrl, crop: c.avatarCrop });
     }
     if (personaInfo?.name && personaInfo.avatarUrl) {
-      setAvatarInfo(personaInfo.name, { url: personaInfo.avatarUrl });
+      setAvatarInfo(personaInfo.name, { url: personaInfo.avatarUrl, crop: personaInfo.avatarCrop });
     }
     if (speakerAvatarMap) {
       for (const [name, avatarInfo] of speakerAvatarMap) {

--- a/packages/client/src/components/game/GameSetupWizard.tsx
+++ b/packages/client/src/components/game/GameSetupWizard.tsx
@@ -23,7 +23,7 @@ import {
 import type { GameSetupConfig, GameGmMode } from "@marinara-engine/shared";
 import { getCharacterTitle } from "../../lib/character-display";
 import { api } from "../../lib/api-client";
-import { cn, getAvatarCropStyle, type AvatarCropValue } from "../../lib/utils";
+import { cn, getAvatarCropStyle, parseAvatarCropJson, type AvatarCropValue } from "../../lib/utils";
 import { Modal } from "../ui/Modal";
 import {
   GenerationParametersFields,
@@ -381,7 +381,14 @@ export function GameSetupWizard({ onComplete, onCancel, isLoading, characters }:
   );
   const imageConnections = useMemo(() => connections.filter((c) => c.provider === "image_generation"), [connections]);
   const personas = useMemo(
-    () => (personasList as Array<{ id: string; name: string; avatarPath?: string | null; comment?: string }>) ?? [],
+    () =>
+      (personasList as Array<{
+        id: string;
+        name: string;
+        avatarPath?: string | null;
+        avatarCrop?: string | null;
+        comment?: string;
+      }>) ?? [],
     [personasList],
   );
 
@@ -1051,18 +1058,13 @@ export function GameSetupWizard({ onComplete, onCancel, isLoading, characters }:
                   const title = getPersonaTitle(p);
                   return (
                     <div className="mb-2 flex items-center gap-2.5 rounded-lg bg-[var(--primary)]/10 px-3 py-2 ring-1 ring-[var(--primary)]/30">
-                      {p.avatarPath ? (
-                        <img
-                          src={p.avatarPath}
-                          alt={p.name}
-                          loading="lazy"
-                          className="h-6 w-6 rounded-full object-cover"
-                        />
-                      ) : (
-                        <div className="flex h-6 w-6 items-center justify-center rounded-full bg-[var(--accent)] text-[0.5625rem] font-bold">
-                          {p.name[0]}
-                        </div>
-                      )}
+                      <CharacterAvatar
+                        character={{
+                          name: p.name,
+                          avatarUrl: p.avatarPath ?? null,
+                          avatarCrop: parseAvatarCropJson(p.avatarCrop),
+                        }}
+                      />
                       <div className="flex-1 min-w-0">
                         <span className="block truncate text-xs">{p.name}</span>
                         {title && (
@@ -1101,18 +1103,13 @@ export function GameSetupWizard({ onComplete, onCancel, isLoading, characters }:
                           p.id === personaId && "bg-[var(--primary)]/5",
                         )}
                       >
-                        {p.avatarPath ? (
-                          <img
-                            src={p.avatarPath}
-                            alt={p.name}
-                            loading="lazy"
-                            className="h-6 w-6 rounded-full object-cover"
-                          />
-                        ) : (
-                          <div className="flex h-6 w-6 items-center justify-center rounded-full bg-[var(--accent)] text-[0.5625rem] font-bold">
-                            {p.name[0]}
-                          </div>
-                        )}
+                        <CharacterAvatar
+                          character={{
+                            name: p.name,
+                            avatarUrl: p.avatarPath ?? null,
+                            avatarCrop: parseAvatarCropJson(p.avatarCrop),
+                          }}
+                        />
                         <div className="flex-1 min-w-0">
                           <span className="block truncate text-xs">{p.name}</span>
                           {title && (

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -5605,6 +5605,7 @@ export function GameSurface({
           id: personaId,
           name: personaInfo.name,
           avatarUrl: personaInfo.avatarUrl ?? null,
+          avatarCrop: personaInfo.avatarCrop ?? null,
           nameColor: personaInfo.nameColor,
           dialogueColor: personaInfo.dialogueColor,
           canRemove: false,
@@ -6277,6 +6278,7 @@ export function GameSurface({
         title: personaInfo.name,
         subtitle: "Player Character",
         avatarUrl: personaInfo.avatarUrl ?? null,
+        avatarCrop: personaInfo.avatarCrop ?? null,
         level: sessionNumber,
         status: gameSnapshot?.playerStats?.status || undefined,
         stats: [


### PR DESCRIPTION
## Linked issue

Closes #926

## Why this change

- The user persona portrait in Game Mode rendered with the **uncropped** source image everywhere it appeared (party bar, sidebar, player character sheet, inline dialogue portraits next to `{{user}}` lines, and the setup wizard's persona picker), ignoring the crop set in the persona's Avatar Crop widget.
- Party-character portraits in the same surfaces respect their crop correctly, so the data plumbing works end-to-end for characters. The persona branches were just missed when avatar-crop propagation landed for chat surfaces in #665 / #669.
- `personaInfo.avatarCrop` is already populated upstream at [`packages/client/src/components/chat/ChatArea.tsx`](https://github.com/Pasta-Devs/Marinara-Engine/blob/staging/packages/client/src/components/chat/ChatArea.tsx) via `parseAvatarCropJson`, and the `PersonaInfo` type already declares the field. Four Game Mode builders just don't read it.

## What changed

- `packages/client/src/components/game/GameNarration.tsx` — the persona's `setAvatarInfo` call inside `speakerAvatarInfos` now passes `crop: personaInfo.avatarCrop`, mirroring the character branch one line above.
- `packages/client/src/components/game/GameSurface.tsx` — both the `partyMembers` persona branch and the `partyCards` player-persona-card branch now include `avatarCrop: personaInfo.avatarCrop ?? null`. Downstream consumers (`GamePartyBar`, `GamePartySidebar`, `GameCharacterSheet`) already read `avatarCrop` and call `getAvatarCropStyle`, so feeding the field through is sufficient.
- `packages/client/src/components/game/GameSetupWizard.tsx` — extended the inline `personas` row type with `avatarCrop?: string | null`, imported `parseAvatarCropJson`, and routed the two persona render sites through the existing `CharacterAvatar` helper (which already handles `getAvatarCropStyle`) instead of raw `<img>` blocks.

No prompt, schema, server, or persisted-data changes — purely client-side render plumbing.

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

What I verified on a fork build deployed to my private EasyPanel instance:

- Picked a persona with a non-square portrait and a tight face crop in the Avatar Crop widget.
- Started a Game Mode chat with that persona and confirmed the cropped region is shown in: the party portrait bar (top), the party sidebar, the player character sheet card, and the inline dialogue portraits next to my `{{user}}` lines.
- Opened the Game Setup wizard and confirmed both the selected persona row and the persona list rows now render the crop instead of the full source.
- Switched between Game Mode and Roleplay / Conversation in the same chat list to confirm chat-side portraits are still cropped correctly (unchanged path).
- Confirmed character (non-persona) portraits in Game Mode still respect their crop (unchanged path).

Things I'd appreciate maintainers double-checking:

- A persona that has the legacy zoom+offset crop shape — render-only compatibility goes through the same `getAvatarCropStyle` path, but worth a sanity check.
- A persona with no `avatarCrop` set at all — should fall back to the uncropped circle exactly as before (the helpers all guard on `null`).
- The Game Setup wizard persona list with a long list of personas, since the `<img>` blocks were replaced with the styled `CharacterAvatar` component — visual sizing should match (both used `h-6 w-6 rounded-full`).

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Persona avatars now display consistently with proper framing across the game setup, narration, and gameplay screens.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/928?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->