### PR TITLE
fix(chat): allow clearing translation connection via placeholder option

### DIFF
--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -4997,7 +4997,7 @@ export function ChatSettingsDrawer({
                   <select
                     value={metadata.translationConnectionId ?? ""}
                     onChange={(e) =>
-                      updateMeta.mutate({ id: chat.id, translationConnectionId: e.target.value || undefined })
+                      updateMeta.mutate({ id: chat.id, translationConnectionId: e.target.value })
                     }
                     className="mt-0.5 w-full rounded-lg bg-[var(--secondary)] px-3 py-2 text-xs outline-none ring-1 ring-transparent transition-shadow focus:ring-[var(--primary)]/40"
                   >


### PR DESCRIPTION
## Linked issue

Closes #935

## Why this change

- Sister bug to #914 / PR #934. In **Chat Settings → Translation → Provider: AI**, picking the empty "Select connection…" placeholder option in the **Connection** dropdown looks like it clears the binding, but the prior connection silently reappears after closing/reopening the drawer.
- Root cause is the same `|| undefined` → `JSON.stringify`-drops-key → server-side spread merge chain that #934 fixed. The translation Connection `<select>` dispatched `translationConnectionId: e.target.value || undefined`, so an empty value became `undefined`, dropped out of the PATCH body entirely, and the server's `{ ...existing, ...incoming }` at `packages/server/src/routes/chats.routes.ts:369` preserved the old value.

## What changed

- `packages/client/src/components/chat/ChatSettingsDrawer.tsx:5000` — drop the `|| undefined`. The `<select>`'s placeholder option has `value=""`, and the empty string now flows through verbatim. JSON.stringify keeps the key, the server merge overwrites the prior connection, and the cleared state persists.
- Server-side is unchanged: the AI-translation guard at `packages/server/src/routes/translate.routes.ts:59` (`if (!input.connectionId)`) treats empty string the same as undefined, so AI translation behavior with no connection bound is identical to before.

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- On a fork build deployed to my private EasyPanel instance, set the chat's translation Provider to AI and pick any AI connection — the value persisted (`afterSet.translationConnectionId === <connId>`).
- Picked the empty "Select connection…" placeholder; the buggy onChange path (pre-fix) dispatched `JSON.stringify({translationConnectionId: undefined})` which serialized to `"{}"` and the server PATCH returned 200 but kept the old value (`afterClear.translationConnectionId === <connId>` still).
- With the fix deployed, the same onChange now sends `{"translationConnectionId":""}`, the server merge writes `""`, and a re-fetch confirms the value is cleared (`afterClear.translationConnectionId === ""`).
- Inspected the deployed minified bundle to confirm the patched onChange is in the build: `onChange:t=>o.mutate({id:r.id,translationConnectionId:t.target.value})` — no `||void 0` remains.

Things I'd appreciate the maintainers double-checking, on the normal install:

- Toggle a chat's translation Provider to AI, select any connection, then pick the placeholder. Close and reopen the drawer (or reload) — the Connection dropdown should land on the placeholder, not the previously-selected entry.
- Confirm subsequent AI translations on that chat fall back to the "no connection bound" 400 (`Connection ID is required for AI translation`) instead of silently using the cleared connection.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)