### PR TITLE
feat: add structured chat summary metadata controls

### DIFF
--- a/docs/ROLEPLAY.md
+++ b/docs/ROLEPLAY.md
@@ -256,7 +256,7 @@ Two diagnostic steps:
 Long contexts compress when they hit the model's window. Things to try:
 
 - Bump to a model with a larger context window.
-- Use the **Summary** panel (toolbar button) to write down major events explicitly — the summary is injected into prompts and survives compression.
+- Use the **Summary** panel (toolbar button) to write down major events explicitly. Marinara stores rolling summary entries for manual and automated updates, then compiles enabled entries into the summary text injected into prompts.
 - Author key facts into a lorebook as **constant** entries — they'll always be in scope regardless of where they were established in chat.
 
 ### Regenerating a reply keeps using the wrong guidance

--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -1811,6 +1811,7 @@ export function ChatArea() {
             onRegenerate={handleRegenerate}
             onEdit={handleEdit}
             onSetActiveSwipe={handleSetActiveSwipe}
+            onToggleHiddenFromAI={handleToggleHiddenFromAI}
             onPeekPrompt={handlePeekPrompt}
             onToggleSelectMessage={handleToggleSelectMessage}
             onSwitchChat={chat?.connectedChatId ? () => setActiveChatId(chat.connectedChatId!) : undefined}

--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -440,12 +440,6 @@ export function ChatArea() {
 
   const updateMeta = useUpdateChatMetadata();
   const summaryContextSize: number = (chatMeta.summaryContextSize as number) ?? 50;
-  const handleSummaryContextSizeChange = useCallback(
-    (size: number) => {
-      if (chat?.id) updateMeta.mutate({ id: chat.id, summaryContextSize: size });
-    },
-    [chat?.id, updateMeta],
-  );
 
   // Sync translation config from chat metadata to the translation store
   useEffect(() => {
@@ -1904,6 +1898,7 @@ export function ChatArea() {
           shouldAnimateMessages={shouldAnimateMessages}
           summaryContextSize={summaryContextSize}
           totalMessageCount={totalMessageCount}
+          messageIdByOrderIndex={messageIdByOrderIndex}
           lastAssistantMessageId={lastAssistantMessageId}
           settingsOpen={settingsOpen}
           filesOpen={filesOpen}
@@ -1931,7 +1926,6 @@ export function ChatArea() {
           onCloneSceneFromHere={isSceneChat ? handleCloneSceneFromHere : undefined}
           isCloneSceneFromHereDisabled={isForking || isStreaming}
           onToggleSelectMessage={handleToggleSelectMessage}
-          onSummaryContextSizeChange={handleSummaryContextSizeChange}
           onRerunTrackers={handleRerunTrackers}
           onRerunSingleTracker={handleRerunSingleTracker}
           onStartEncounter={() => startEncounter()}

--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -1899,7 +1899,6 @@ export function ChatArea() {
           shouldAnimateMessages={shouldAnimateMessages}
           summaryContextSize={summaryContextSize}
           totalMessageCount={totalMessageCount}
-          messageIdByOrderIndex={messageIdByOrderIndex}
           lastAssistantMessageId={lastAssistantMessageId}
           settingsOpen={settingsOpen}
           filesOpen={filesOpen}

--- a/packages/client/src/components/chat/ChatConversationSurface.tsx
+++ b/packages/client/src/components/chat/ChatConversationSurface.tsx
@@ -50,6 +50,7 @@ type ConversationSurfaceProps = {
   onRegenerate: (messageId: string) => void;
   onEdit: (messageId: string, content: string) => void;
   onSetActiveSwipe: (messageId: string, index: number) => void;
+  onToggleHiddenFromAI: (messageId: string, current: boolean) => void;
   onPeekPrompt: () => void;
   onToggleSelectMessage: (toggle: MessageSelectionToggle) => void;
   onSwitchChat?: () => void;
@@ -112,6 +113,7 @@ export function ChatConversationSurface({
   onRegenerate,
   onEdit,
   onSetActiveSwipe,
+  onToggleHiddenFromAI,
   onPeekPrompt,
   onToggleSelectMessage,
   onSwitchChat,
@@ -163,6 +165,7 @@ export function ChatConversationSurface({
           onRegenerate={onRegenerate}
           onEdit={onEdit}
           onSetActiveSwipe={onSetActiveSwipe}
+          onToggleHiddenFromAI={onToggleHiddenFromAI}
           onPeekPrompt={onPeekPrompt}
           lastAssistantMessageId={lastAssistantMessageId}
           onOpenSettings={onOpenSettings}

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -31,6 +31,8 @@ import {
   Loader2,
   Pause,
   Play,
+  ChevronRight,
+  EyeOff,
 } from "lucide-react";
 import type { Message } from "@marinara-engine/shared";
 import { memo, useState, useMemo, useRef, useEffect, useLayoutEffect, useCallback, type ReactNode } from "react";
@@ -56,6 +58,52 @@ import { SwipeJumpControl } from "./SwipeJumpControl";
 
 const MESSAGE_ACTION_ICON_SIZE = "1em";
 const MESSAGE_SWIPE_ICON_SIZE = "1.15em";
+
+function HiddenFromAIMessageButton({
+  roleplay,
+  canCollapse,
+  onExpand,
+  isHiddenExpanded,
+}: {
+  roleplay?: boolean;
+  canCollapse: boolean;
+  onExpand: () => void;
+  isHiddenExpanded: boolean;
+}) {
+  const statusClassName = cn(
+    "inline-flex items-center gap-1 rounded px-1 py-0.5 text-[0.625rem] font-medium text-amber-500/80",
+    roleplay && "text-amber-200/60",
+  );
+
+  if (!canCollapse) {
+    return (
+      <span className={cn(statusClassName, "align-middle")} title="Hidden from AI">
+        <EyeOff size="0.7rem" className="shrink-0" />
+        <span className="whitespace-nowrap">Hidden from AI</span>
+      </span>
+    );
+  }
+
+  return (
+    <span className="inline-flex items-center gap-1 align-middle">
+      <button
+        type="button"
+        onClick={onExpand}
+        className={cn(
+          "inline-flex items-center gap-1 rounded px-1 py-0.5 text-[0.625rem] font-medium text-amber-500/80 transition-colors hover:bg-amber-500/10 hover:text-amber-400",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400/40",
+          roleplay && "text-amber-200/60 hover:bg-white/5 hover:text-amber-100/80",
+        )}
+        aria-label={isHiddenExpanded ? "Collapse hidden from AI message" : "Expand hidden from AI message"}
+        title={isHiddenExpanded ? "Collapse hidden from AI message" : "Expand hidden from AI message"}
+      >
+        <ChevronRight size="0.7rem" className={cn("shrink-0 transition-transform", isHiddenExpanded && "rotate-90")} />
+        <EyeOff size="0.7rem" className="shrink-0" />
+        <span className="whitespace-nowrap">Hidden from AI</span>
+      </button>
+    </span>
+  );
+}
 
 /** Isolated edit textarea — uncontrolled to avoid React re-renders on every keystroke. */
 const EditTextarea = memo(function EditTextarea({
@@ -713,6 +761,8 @@ export const ChatMessage = memo(function ChatMessage({
   const [showThinking, setShowThinking] = useState(false);
   const [showGenerationReplay, setShowGenerationReplay] = useState(false);
   const [showActions, setShowActions] = useState(false);
+  const [manuallyExpandedHidden, setManuallyExpandedHidden] = useState(false);
+  const collapseHiddenMessages = useUIStore((s) => s.summaryPopoverSettings.collapseHiddenMessages);
   const [avatarLightbox, setAvatarLightbox] = useState<string | null>(null);
   const [avatarLightboxPrompt, setAvatarLightboxPrompt] = useState<string | null>(null);
   const scrollRestoreRef = useRef<{ el: HTMLElement; top: number } | null>(null);
@@ -828,6 +878,14 @@ export const ChatMessage = memo(function ChatMessage({
   const isHiddenFromAI = extra.hiddenFromAI === true;
   const thinking = extra.thinking as string | undefined;
   const generationReplay = hasGenerationReplayDetails(extra.generationReplay) ? extra.generationReplay : null;
+
+  useEffect(() => {
+    setManuallyExpandedHidden(false);
+  }, [message.id]);
+
+  useEffect(() => {
+    if (!isHiddenFromAI || !collapseHiddenMessages) setManuallyExpandedHidden(false);
+  }, [collapseHiddenMessages, isHiddenFromAI]);
 
   useEffect(() => {
     if (!generationReplay) setShowGenerationReplay(false);
@@ -1232,7 +1290,18 @@ export const ChatMessage = memo(function ChatMessage({
       </div>
     ) : null
   ) : null;
-  const roleplayBubbleContent = editing ? (
+  const isHiddenExpanded =
+    isHiddenFromAI && (!collapseHiddenMessages || manuallyExpandedHidden || editing || !!isStreaming);
+  const isHiddenCollapsed = isHiddenFromAI && collapseHiddenMessages && !isHiddenExpanded;
+  const hiddenFromAIHeader = isHiddenFromAI ? (
+    <HiddenFromAIMessageButton
+      roleplay={isRoleplay}
+      canCollapse={collapseHiddenMessages}
+      isHiddenExpanded={isHiddenExpanded}
+      onExpand={() => setManuallyExpandedHidden((value) => !value)}
+    />
+  ) : null;
+  const roleplayBubbleContent = isHiddenCollapsed ? null : editing ? (
     <EditTextarea
       initialContent={message.content}
       fontSize={chatFontSize}
@@ -1360,15 +1429,18 @@ export const ChatMessage = memo(function ChatMessage({
               )}
               <div className="mb-1 flex items-center gap-2 text-[0.625rem] font-semibold uppercase tracking-widest text-amber-400/70">
                 <span className="h-px flex-1 bg-amber-400/20" />
+                {hiddenFromAIHeader}
                 Narrator
                 <span className="h-px flex-1 bg-amber-400/20" />
               </div>
-              <div
-                className={cn("mari-message-content break-words italic", !isHtmlContent && "whitespace-pre-wrap")}
-                style={messageTextStyle}
-              >
-                {renderedContent}
-              </div>
+              {!isHiddenCollapsed && (
+                <div
+                  className={cn("mari-message-content break-words italic", !isHtmlContent && "whitespace-pre-wrap")}
+                  style={messageTextStyle}
+                >
+                  {renderedContent}
+                </div>
+              )}
             </div>
           </div>
         </div>
@@ -1499,6 +1571,7 @@ export const ChatMessage = memo(function ChatMessage({
             {/* Name + time (only if not grouped) */}
             {!isGrouped && (
               <div className={cn("flex items-baseline gap-2 px-1", isUser && "flex-row-reverse")}>
+                {hiddenFromAIHeader}
                 <span
                   className={cn(
                     "mari-message-name text-[0.75rem] font-bold tracking-tight",
@@ -1638,10 +1711,10 @@ export const ChatMessage = memo(function ChatMessage({
                       />
                     </div>
                   </div>
-                  <div className="min-w-0 flex-1 px-3 py-3">{roleplayBubbleContent}</div>
+                  {roleplayBubbleContent && <div className="min-w-0 flex-1 px-3 py-3">{roleplayBubbleContent}</div>}
                 </div>
               ) : (
-                <div className="px-4 py-3">{roleplayBubbleContent}</div>
+                roleplayBubbleContent ? <div className="px-4 py-3">{roleplayBubbleContent}</div> : null
               )}
             </div>
 
@@ -1734,7 +1807,11 @@ export const ChatMessage = memo(function ChatMessage({
               {onToggleHiddenFromAI && (
                 <ActionBtn
                   icon={
-                    isHiddenFromAI ? <Circle size={MESSAGE_ACTION_ICON_SIZE} /> : <X size={MESSAGE_ACTION_ICON_SIZE} />
+                    isHiddenFromAI ? (
+                      <Circle size={MESSAGE_ACTION_ICON_SIZE} />
+                    ) : (
+                      <EyeOff size={MESSAGE_ACTION_ICON_SIZE} />
+                    )
                   }
                   onClick={() => onToggleHiddenFromAI(message.id, isHiddenFromAI)}
                   title={isHiddenFromAI ? "Unhide from AI" : "Hide from AI"}
@@ -1982,15 +2059,18 @@ export const ChatMessage = memo(function ChatMessage({
         >
           {/* Name — only for first in group */}
           {!isGrouped && !isUser && (
-            <span
-              className={cn(
-                "mari-message-name px-3 text-[0.6875rem] font-semibold",
-                !msgNameColor && !isMergedGroup && "text-[var(--muted-foreground)]",
-              )}
-              style={!isMergedGroup ? nameColorStyle(msgNameColor) : undefined}
-            >
-              {isMergedGroup ? mergedNameElement : displayName}
-            </span>
+            <div className="flex items-center gap-2 px-3">
+              {hiddenFromAIHeader}
+              <span
+                className={cn(
+                  "mari-message-name text-[0.6875rem] font-semibold",
+                  !msgNameColor && !isMergedGroup && "text-[var(--muted-foreground)]",
+                )}
+                style={!isMergedGroup ? nameColorStyle(msgNameColor) : undefined}
+              >
+                {isMergedGroup ? mergedNameElement : displayName}
+              </span>
+            </div>
           )}
 
           {/* Conversation start marker */}
@@ -2019,7 +2099,7 @@ export const ChatMessage = memo(function ChatMessage({
             )}
             style={{ ...messageTextStyle, ...(boxBgColor ? { backgroundColor: boxBgColor } : {}) }}
           >
-            {editing ? (
+            {isHiddenCollapsed ? null : editing ? (
               <EditTextarea
                 initialContent={message.content}
                 fontSize={chatFontSize}
@@ -2192,6 +2272,17 @@ export const ChatMessage = memo(function ChatMessage({
                 onClick={() => onCloneSceneFromHere(message.id)}
                 title="Clone from here"
                 disabled={isCloneSceneFromHereDisabled}
+              />
+            )}
+            {onToggleHiddenFromAI && (
+              <ActionBtn
+                icon={
+                  isHiddenFromAI ? <Circle size={MESSAGE_ACTION_ICON_SIZE} /> : <EyeOff size={MESSAGE_ACTION_ICON_SIZE} />
+                }
+                onClick={() => onToggleHiddenFromAI(message.id, isHiddenFromAI)}
+                title={isHiddenFromAI ? "Unhide from AI" : "Hide from AI"}
+                className={isHiddenFromAI ? "text-amber-400/90 hover:text-amber-300" : undefined}
+                dark
               />
             )}
             <ActionBtn

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -22,8 +22,8 @@ import {
   X,
   Flag,
   Eye,
+  Search,
   ScrollText,
-  Circle,
   Brain,
   Languages,
   Volume2,
@@ -79,7 +79,6 @@ function HiddenFromAIMessageButton({
     return (
       <span className={cn(statusClassName, "align-middle")} title="Hidden from AI">
         <EyeOff size="0.7rem" className="shrink-0" />
-        <span className="whitespace-nowrap">Hidden from AI</span>
       </span>
     );
   }
@@ -99,7 +98,6 @@ function HiddenFromAIMessageButton({
       >
         <ChevronRight size="0.7rem" className={cn("shrink-0 transition-transform", isHiddenExpanded && "rotate-90")} />
         <EyeOff size="0.7rem" className="shrink-0" />
-        <span className="whitespace-nowrap">Hidden from AI</span>
       </button>
     </span>
   );
@@ -1808,7 +1806,7 @@ export const ChatMessage = memo(function ChatMessage({
                 <ActionBtn
                   icon={
                     isHiddenFromAI ? (
-                      <Circle size={MESSAGE_ACTION_ICON_SIZE} />
+                      <Eye size={MESSAGE_ACTION_ICON_SIZE} />
                     ) : (
                       <EyeOff size={MESSAGE_ACTION_ICON_SIZE} />
                     )
@@ -1821,7 +1819,7 @@ export const ChatMessage = memo(function ChatMessage({
               )}
               {isLastAssistantMessage && !isUser && (
                 <ActionBtn
-                  icon={<Eye size={MESSAGE_ACTION_ICON_SIZE} />}
+                  icon={<Search size={MESSAGE_ACTION_ICON_SIZE} />}
                   onClick={() => onPeekPrompt?.()}
                   title="Peek prompt"
                   dark
@@ -2240,7 +2238,7 @@ export const ChatMessage = memo(function ChatMessage({
             />
             {isLastAssistantMessage && !isUser && (
               <ActionBtn
-                icon={<Eye size={MESSAGE_ACTION_ICON_SIZE} />}
+                icon={<Search size={MESSAGE_ACTION_ICON_SIZE} />}
                 onClick={() => onPeekPrompt?.()}
                 title="Peek prompt"
               />
@@ -2277,7 +2275,7 @@ export const ChatMessage = memo(function ChatMessage({
             {onToggleHiddenFromAI && (
               <ActionBtn
                 icon={
-                  isHiddenFromAI ? <Circle size={MESSAGE_ACTION_ICON_SIZE} /> : <EyeOff size={MESSAGE_ACTION_ICON_SIZE} />
+                  isHiddenFromAI ? <Eye size={MESSAGE_ACTION_ICON_SIZE} /> : <EyeOff size={MESSAGE_ACTION_ICON_SIZE} />
                 }
                 onClick={() => onToggleHiddenFromAI(message.id, isHiddenFromAI)}
                 title={isHiddenFromAI ? "Unhide from AI" : "Hide from AI"}

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -327,13 +327,11 @@ function SummaryButton({
   summary,
   summaryContextSize,
   totalMessageCount,
-  messageIdByOrderIndex,
 }: {
   chatId: string | null;
   summary: string | null;
   summaryContextSize: number;
   totalMessageCount: number;
-  messageIdByOrderIndex: Map<number, string>;
 }) {
   const [open, setOpen] = useState(false);
   const compact = useUIStore((s) => s.centerCompact);
@@ -364,7 +362,6 @@ function SummaryButton({
             summary={summary}
             contextSize={summaryContextSize}
             totalMessageCount={totalMessageCount}
-            messageIdByOrderIndex={messageIdByOrderIndex}
             onClose={() => setOpen(false)}
           />
         </Suspense>
@@ -508,7 +505,6 @@ type RoleplaySurfaceProps = {
   shouldAnimateMessages: boolean;
   summaryContextSize: number;
   totalMessageCount: number;
-  messageIdByOrderIndex: Map<number, string>;
   lastAssistantMessageId: string | null;
   settingsOpen: boolean;
   filesOpen: boolean;
@@ -608,7 +604,6 @@ export function ChatRoleplaySurface({
   shouldAnimateMessages,
   summaryContextSize,
   totalMessageCount,
-  messageIdByOrderIndex,
   lastAssistantMessageId,
   settingsOpen,
   filesOpen,
@@ -748,7 +743,6 @@ export function ChatRoleplaySurface({
                       summary={chatMeta.summary ?? null}
                       summaryContextSize={summaryContextSize}
                       totalMessageCount={totalMessageCount}
-                      messageIdByOrderIndex={messageIdByOrderIndex}
                     />
                     <ActiveWorldInfoButton chatId={chat?.id ?? null} />
                     <AuthorNotesButton chatId={chat?.id ?? null} chatMeta={chatMeta} />
@@ -835,7 +829,6 @@ export function ChatRoleplaySurface({
                           summary={chatMeta.summary ?? null}
                           summaryContextSize={summaryContextSize}
                           totalMessageCount={totalMessageCount}
-                          messageIdByOrderIndex={messageIdByOrderIndex}
                         />
                         <ActiveWorldInfoButton chatId={chat?.id ?? null} />
                         <AuthorNotesButton chatId={chat?.id ?? null} chatMeta={chatMeta} />
@@ -894,7 +887,6 @@ export function ChatRoleplaySurface({
                         summary={chatMeta.summary ?? null}
                         summaryContextSize={summaryContextSize}
                         totalMessageCount={totalMessageCount}
-                        messageIdByOrderIndex={messageIdByOrderIndex}
                       />
                       <ActiveWorldInfoButton chatId={chat?.id ?? null} />
                       <AuthorNotesButton chatId={chat?.id ?? null} chatMeta={chatMeta} />

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -326,12 +326,14 @@ function SummaryButton({
   chatId,
   summary,
   summaryContextSize,
-  onContextSizeChange,
+  totalMessageCount,
+  messageIdByOrderIndex,
 }: {
   chatId: string | null;
   summary: string | null;
   summaryContextSize: number;
-  onContextSizeChange: (size: number) => void;
+  totalMessageCount: number;
+  messageIdByOrderIndex: Map<number, string>;
 }) {
   const [open, setOpen] = useState(false);
   const compact = useUIStore((s) => s.centerCompact);
@@ -361,7 +363,8 @@ function SummaryButton({
             chatId={chatId}
             summary={summary}
             contextSize={summaryContextSize}
-            onContextSizeChange={onContextSizeChange}
+            totalMessageCount={totalMessageCount}
+            messageIdByOrderIndex={messageIdByOrderIndex}
             onClose={() => setOpen(false)}
           />
         </Suspense>
@@ -505,6 +508,7 @@ type RoleplaySurfaceProps = {
   shouldAnimateMessages: boolean;
   summaryContextSize: number;
   totalMessageCount: number;
+  messageIdByOrderIndex: Map<number, string>;
   lastAssistantMessageId: string | null;
   settingsOpen: boolean;
   filesOpen: boolean;
@@ -532,7 +536,6 @@ type RoleplaySurfaceProps = {
   onCloneSceneFromHere?: (messageId: string) => void;
   isCloneSceneFromHereDisabled?: boolean;
   onToggleSelectMessage: (toggle: MessageSelectionToggle) => void;
-  onSummaryContextSizeChange: (size: number) => void;
   onRerunTrackers: () => void;
   onRerunSingleTracker: (agentType: string) => void;
   onRetryFailedAgents?: () => void;
@@ -605,6 +608,7 @@ export function ChatRoleplaySurface({
   shouldAnimateMessages,
   summaryContextSize,
   totalMessageCount,
+  messageIdByOrderIndex,
   lastAssistantMessageId,
   settingsOpen,
   filesOpen,
@@ -632,7 +636,6 @@ export function ChatRoleplaySurface({
   onCloneSceneFromHere,
   isCloneSceneFromHereDisabled,
   onToggleSelectMessage,
-  onSummaryContextSizeChange,
   onRerunTrackers,
   onRerunSingleTracker,
   onRetryFailedAgents,
@@ -744,7 +747,8 @@ export function ChatRoleplaySurface({
                       chatId={chat?.id ?? null}
                       summary={chatMeta.summary ?? null}
                       summaryContextSize={summaryContextSize}
-                      onContextSizeChange={onSummaryContextSizeChange}
+                      totalMessageCount={totalMessageCount}
+                      messageIdByOrderIndex={messageIdByOrderIndex}
                     />
                     <ActiveWorldInfoButton chatId={chat?.id ?? null} />
                     <AuthorNotesButton chatId={chat?.id ?? null} chatMeta={chatMeta} />
@@ -830,7 +834,8 @@ export function ChatRoleplaySurface({
                           chatId={chat?.id ?? null}
                           summary={chatMeta.summary ?? null}
                           summaryContextSize={summaryContextSize}
-                          onContextSizeChange={onSummaryContextSizeChange}
+                          totalMessageCount={totalMessageCount}
+                          messageIdByOrderIndex={messageIdByOrderIndex}
                         />
                         <ActiveWorldInfoButton chatId={chat?.id ?? null} />
                         <AuthorNotesButton chatId={chat?.id ?? null} chatMeta={chatMeta} />
@@ -888,7 +893,8 @@ export function ChatRoleplaySurface({
                         chatId={chat?.id ?? null}
                         summary={chatMeta.summary ?? null}
                         summaryContextSize={summaryContextSize}
-                        onContextSizeChange={onSummaryContextSizeChange}
+                        totalMessageCount={totalMessageCount}
+                        messageIdByOrderIndex={messageIdByOrderIndex}
                       />
                       <ActiveWorldInfoButton chatId={chat?.id ?? null} />
                       <AuthorNotesButton chatId={chat?.id ?? null} chatMeta={chatMeta} />

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -326,11 +326,15 @@ function SummaryButton({
   chatId,
   summary,
   summaryContextSize,
+  summaryPromptTemplates,
+  activeSummaryPromptTemplateId,
   totalMessageCount,
 }: {
   chatId: string | null;
   summary: string | null;
   summaryContextSize: number;
+  summaryPromptTemplates?: ComponentProps<typeof SummaryPopover>["promptTemplates"];
+  activeSummaryPromptTemplateId?: string | null;
   totalMessageCount: number;
 }) {
   const [open, setOpen] = useState(false);
@@ -361,6 +365,8 @@ function SummaryButton({
             chatId={chatId}
             summary={summary}
             contextSize={summaryContextSize}
+            promptTemplates={summaryPromptTemplates}
+            activePromptTemplateId={activeSummaryPromptTemplateId}
             totalMessageCount={totalMessageCount}
             onClose={() => setOpen(false)}
           />
@@ -742,6 +748,12 @@ export function ChatRoleplaySurface({
                       chatId={chat?.id ?? null}
                       summary={chatMeta.summary ?? null}
                       summaryContextSize={summaryContextSize}
+                      summaryPromptTemplates={Array.isArray(chatMeta.summaryPromptTemplates) ? chatMeta.summaryPromptTemplates : []}
+                      activeSummaryPromptTemplateId={
+                        typeof chatMeta.activeSummaryPromptTemplateId === "string"
+                          ? chatMeta.activeSummaryPromptTemplateId
+                          : null
+                      }
                       totalMessageCount={totalMessageCount}
                     />
                     <ActiveWorldInfoButton chatId={chat?.id ?? null} />
@@ -828,6 +840,14 @@ export function ChatRoleplaySurface({
                           chatId={chat?.id ?? null}
                           summary={chatMeta.summary ?? null}
                           summaryContextSize={summaryContextSize}
+                          summaryPromptTemplates={
+                            Array.isArray(chatMeta.summaryPromptTemplates) ? chatMeta.summaryPromptTemplates : []
+                          }
+                          activeSummaryPromptTemplateId={
+                            typeof chatMeta.activeSummaryPromptTemplateId === "string"
+                              ? chatMeta.activeSummaryPromptTemplateId
+                              : null
+                          }
                           totalMessageCount={totalMessageCount}
                         />
                         <ActiveWorldInfoButton chatId={chat?.id ?? null} />
@@ -886,6 +906,14 @@ export function ChatRoleplaySurface({
                         chatId={chat?.id ?? null}
                         summary={chatMeta.summary ?? null}
                         summaryContextSize={summaryContextSize}
+                        summaryPromptTemplates={
+                          Array.isArray(chatMeta.summaryPromptTemplates) ? chatMeta.summaryPromptTemplates : []
+                        }
+                        activeSummaryPromptTemplateId={
+                          typeof chatMeta.activeSummaryPromptTemplateId === "string"
+                            ? chatMeta.activeSummaryPromptTemplateId
+                            : null
+                        }
                         totalMessageCount={totalMessageCount}
                       />
                       <ActiveWorldInfoButton chatId={chat?.id ?? null} />

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -10,7 +10,12 @@ import {
   type ReactNode,
   type RefObject,
 } from "react";
-import { type SceneForkMode, type SpritePlacement, type SpriteSide } from "@marinara-engine/shared";
+import {
+  type ChatSummaryEntry,
+  type SceneForkMode,
+  type SpritePlacement,
+  type SpriteSide,
+} from "@marinara-engine/shared";
 import {
   FolderOpen,
   Image,
@@ -325,6 +330,7 @@ function ToolbarMenu({ children }: { children: ReactNode }) {
 function SummaryButton({
   chatId,
   summary,
+  summaryEntries,
   summaryContextSize,
   summaryPromptTemplates,
   activeSummaryPromptTemplateId,
@@ -332,6 +338,7 @@ function SummaryButton({
 }: {
   chatId: string | null;
   summary: string | null;
+  summaryEntries?: ChatSummaryEntry[];
   summaryContextSize: number;
   summaryPromptTemplates?: ComponentProps<typeof SummaryPopover>["promptTemplates"];
   activeSummaryPromptTemplateId?: string | null;
@@ -364,6 +371,7 @@ function SummaryButton({
           <SummaryPopover
             chatId={chatId}
             summary={summary}
+            summaryEntries={summaryEntries}
             contextSize={summaryContextSize}
             promptTemplates={summaryPromptTemplates}
             activePromptTemplateId={activeSummaryPromptTemplateId}
@@ -747,6 +755,9 @@ export function ChatRoleplaySurface({
                     <SummaryButton
                       chatId={chat?.id ?? null}
                       summary={chatMeta.summary ?? null}
+                      summaryEntries={
+                        Array.isArray(chatMeta.summaryEntries) ? (chatMeta.summaryEntries as ChatSummaryEntry[]) : []
+                      }
                       summaryContextSize={summaryContextSize}
                       summaryPromptTemplates={Array.isArray(chatMeta.summaryPromptTemplates) ? chatMeta.summaryPromptTemplates : []}
                       activeSummaryPromptTemplateId={
@@ -839,6 +850,9 @@ export function ChatRoleplaySurface({
                         <SummaryButton
                           chatId={chat?.id ?? null}
                           summary={chatMeta.summary ?? null}
+                          summaryEntries={
+                            Array.isArray(chatMeta.summaryEntries) ? (chatMeta.summaryEntries as ChatSummaryEntry[]) : []
+                          }
                           summaryContextSize={summaryContextSize}
                           summaryPromptTemplates={
                             Array.isArray(chatMeta.summaryPromptTemplates) ? chatMeta.summaryPromptTemplates : []
@@ -905,6 +919,9 @@ export function ChatRoleplaySurface({
                       <SummaryButton
                         chatId={chat?.id ?? null}
                         summary={chatMeta.summary ?? null}
+                        summaryEntries={
+                          Array.isArray(chatMeta.summaryEntries) ? (chatMeta.summaryEntries as ChatSummaryEntry[]) : []
+                        }
                         summaryContextSize={summaryContextSize}
                         summaryPromptTemplates={
                           Array.isArray(chatMeta.summaryPromptTemplates) ? chatMeta.summaryPromptTemplates : []

--- a/packages/client/src/components/chat/ConversationMessage.tsx
+++ b/packages/client/src/components/chat/ConversationMessage.tsx
@@ -9,13 +9,13 @@ import {
   Copy,
   RefreshCw,
   Eye,
+  Search,
   ScrollText,
   Brain,
   X,
   User,
   Languages,
   ChevronRight,
-  Circle,
   EyeOff,
 } from "lucide-react";
 import { useQueryClient, type InfiniteData } from "@tanstack/react-query";
@@ -64,7 +64,6 @@ function HiddenFromAIConversationButton({
     return (
       <span className="inline-flex items-center gap-1 align-middle text-[0.625rem] font-medium text-amber-500/80" title="Hidden from AI">
         <EyeOff size="0.7rem" className="shrink-0" />
-        <span className="whitespace-nowrap">Hidden from AI</span>
       </span>
     );
   }
@@ -86,7 +85,6 @@ function HiddenFromAIConversationButton({
           className={cn("shrink-0 transition-transform", isHiddenExpanded && "rotate-90")}
         />
         <EyeOff size="0.7rem" className="shrink-0" />
-        <span className="whitespace-nowrap">Hidden from AI</span>
       </button>
     </span>
   );
@@ -894,14 +892,14 @@ export const ConversationMessage = memo(function ConversationMessage({
           />
           {onToggleHiddenFromAI && (
             <MsgAction
-              icon={isHiddenFromAI ? <Circle size="0.75rem" /> : <EyeOff size="0.75rem" />}
+              icon={isHiddenFromAI ? <Eye size="0.75rem" /> : <EyeOff size="0.75rem" />}
               onClick={() => onToggleHiddenFromAI(message.id, isHiddenFromAI)}
               title={isHiddenFromAI ? "Unhide from AI" : "Hide from AI"}
               className={isHiddenFromAI ? "text-amber-400" : undefined}
             />
           )}
           {isLastAssistantMessage && (
-            <MsgAction icon={<Eye size="0.75rem" />} onClick={() => onPeekPrompt?.()} title="Peek prompt" />
+            <MsgAction icon={<Search size="0.75rem" />} onClick={() => onPeekPrompt?.()} title="Peek prompt" />
           )}
           {generationReplay && (
             <MsgAction
@@ -1204,14 +1202,14 @@ export const ConversationMessage = memo(function ConversationMessage({
           )}
           {onToggleHiddenFromAI && (
             <MsgAction
-              icon={isHiddenFromAI ? <Circle size="0.75rem" /> : <EyeOff size="0.75rem" />}
+              icon={isHiddenFromAI ? <Eye size="0.75rem" /> : <EyeOff size="0.75rem" />}
               onClick={() => onToggleHiddenFromAI(message.id, isHiddenFromAI)}
               title={isHiddenFromAI ? "Unhide from AI" : "Hide from AI"}
               className={isHiddenFromAI ? "text-amber-400" : undefined}
             />
           )}
           {isLastAssistantMessage && !isUser && (
-            <MsgAction icon={<Eye size="0.75rem" />} onClick={() => onPeekPrompt?.()} title="Peek prompt" />
+            <MsgAction icon={<Search size="0.75rem" />} onClick={() => onPeekPrompt?.()} title="Peek prompt" />
           )}
           {generationReplay && (
             <MsgAction

--- a/packages/client/src/components/chat/ConversationMessage.tsx
+++ b/packages/client/src/components/chat/ConversationMessage.tsx
@@ -14,6 +14,9 @@ import {
   X,
   User,
   Languages,
+  ChevronRight,
+  Circle,
+  EyeOff,
 } from "lucide-react";
 import { useQueryClient, type InfiniteData } from "@tanstack/react-query";
 import type { Message, MessageExtra } from "@marinara-engine/shared";
@@ -46,6 +49,47 @@ function nameColorStyle(color?: string): CSSProperties | undefined {
     };
   }
   return { color };
+}
+
+function HiddenFromAIConversationButton({
+  canCollapse,
+  onExpand,
+  isHiddenExpanded,
+}: {
+  canCollapse: boolean;
+  onExpand: () => void;
+  isHiddenExpanded: boolean;
+}) {
+  if (!canCollapse) {
+    return (
+      <span className="inline-flex items-center gap-1 align-middle text-[0.625rem] font-medium text-amber-500/80" title="Hidden from AI">
+        <EyeOff size="0.7rem" className="shrink-0" />
+        <span className="whitespace-nowrap">Hidden from AI</span>
+      </span>
+    );
+  }
+
+  return (
+    <span className="inline-flex items-center gap-1 align-middle">
+      <button
+        type="button"
+        onClick={onExpand}
+        className={cn(
+          "inline-flex items-center gap-1 rounded px-1 py-0.5 text-[0.625rem] font-medium text-amber-500/80 transition-colors hover:bg-amber-500/10 hover:text-amber-400",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400/40",
+        )}
+        aria-label={isHiddenExpanded ? "Collapse hidden from AI message" : "Expand hidden from AI message"}
+        title={isHiddenExpanded ? "Collapse hidden from AI message" : "Expand hidden from AI message"}
+      >
+        <ChevronRight
+          size="0.7rem"
+          className={cn("shrink-0 transition-transform", isHiddenExpanded && "rotate-90")}
+        />
+        <EyeOff size="0.7rem" className="shrink-0" />
+        <span className="whitespace-nowrap">Hidden from AI</span>
+      </button>
+    </span>
+  );
 }
 
 /** Regex to detect a message that is just an image/GIF URL */
@@ -229,6 +273,7 @@ interface MessageData {
       duration?: number;
     } | null;
     isConversationStart?: boolean;
+    hiddenFromAI?: boolean;
     thinking?: string | null;
     generationReplay?: MessageExtra["generationReplay"];
     attachments?: Array<{ type: string; url: string; filename?: string; prompt?: string; galleryId?: string }>;
@@ -247,6 +292,7 @@ interface ConversationMessageProps {
   onRegenerate?: (messageId: string) => void;
   onEdit?: (messageId: string, content: string) => void;
   onSetActiveSwipe?: (messageId: string, index: number) => void;
+  onToggleHiddenFromAI?: (messageId: string, current: boolean) => void;
   onPeekPrompt?: () => void;
   isLastAssistantMessage?: boolean;
   characterMap?: CharacterMap;
@@ -274,6 +320,7 @@ export const ConversationMessage = memo(function ConversationMessage({
   onRegenerate,
   onEdit,
   onSetActiveSwipe,
+  onToggleHiddenFromAI,
   onPeekPrompt,
   isLastAssistantMessage,
   characterMap,
@@ -292,6 +339,8 @@ export const ConversationMessage = memo(function ConversationMessage({
   const [copied, setCopied] = useState(false);
   const [showThinking, setShowThinking] = useState(false);
   const [showGenerationReplay, setShowGenerationReplay] = useState(false);
+  const [manuallyExpandedHidden, setManuallyExpandedHidden] = useState(false);
+  const collapseHiddenMessages = useUIStore((s) => s.summaryPopoverSettings.collapseHiddenMessages);
   const [imageLightbox, setImageLightbox] = useState<{ url: string; prompt?: string | null } | null>(null);
   const editRef = useRef<HTMLTextAreaElement>(null);
   const hasInput = useChatStore((s) => s.currentInput.trim().length > 0);
@@ -318,10 +367,19 @@ export const ConversationMessage = memo(function ConversationMessage({
     if (!message.extra) return {} as Record<string, any>;
     return typeof message.extra === "string" ? JSON.parse(message.extra) : message.extra;
   }, [message.extra]);
+  const isHiddenFromAI = extra.hiddenFromAI === true;
   const generationReplay = hasGenerationReplayDetails(extra.generationReplay) ? extra.generationReplay : null;
   // canRegenerate lets assistant messages retry; isUser messages need generationReplay
   // metadata from hasGenerationReplayDetails, such as /impersonate.
   const canRegenerate = !isUser || generationReplay !== null;
+
+  useEffect(() => {
+    setManuallyExpandedHidden(false);
+  }, [message.id]);
+
+  useEffect(() => {
+    if (!isHiddenFromAI || !collapseHiddenMessages) setManuallyExpandedHidden(false);
+  }, [collapseHiddenMessages, isHiddenFromAI]);
 
   useEffect(() => {
     if (!generationReplay) setShowGenerationReplay(false);
@@ -593,6 +651,17 @@ export const ConversationMessage = memo(function ConversationMessage({
     );
   }
 
+  const isHiddenExpanded =
+    isHiddenFromAI && (!collapseHiddenMessages || manuallyExpandedHidden || editing || !!isStreaming);
+  const isHiddenCollapsed = isHiddenFromAI && collapseHiddenMessages && !isHiddenExpanded;
+  const hiddenFromAIHeader = isHiddenFromAI ? (
+    <HiddenFromAIConversationButton
+      canCollapse={collapseHiddenMessages}
+      isHiddenExpanded={isHiddenExpanded}
+      onExpand={() => setManuallyExpandedHidden((value) => !value)}
+    />
+  ) : null;
+
   // ── Render: grouped multi-speaker message (merged group chat) ──
   if (groupedSegments && !editing && !isUser) {
     return (
@@ -823,6 +892,14 @@ export const ConversationMessage = memo(function ConversationMessage({
             title={regenerateButtonTitle}
             className={regenerateGuidedClass}
           />
+          {onToggleHiddenFromAI && (
+            <MsgAction
+              icon={isHiddenFromAI ? <Circle size="0.75rem" /> : <EyeOff size="0.75rem" />}
+              onClick={() => onToggleHiddenFromAI(message.id, isHiddenFromAI)}
+              title={isHiddenFromAI ? "Unhide from AI" : "Hide from AI"}
+              className={isHiddenFromAI ? "text-amber-400" : undefined}
+            />
+          )}
           {isLastAssistantMessage && (
             <MsgAction icon={<Eye size="0.75rem" />} onClick={() => onPeekPrompt?.()} title="Peek prompt" />
           )}
@@ -962,6 +1039,7 @@ export const ConversationMessage = memo(function ConversationMessage({
         {/* Header — name + timestamp (only for first in group) */}
         {!isGrouped && (
           <div className="mari-message-meta flex items-baseline gap-2 mb-0.5">
+            {hiddenFromAIHeader}
             <span
               className="mari-message-name text-[0.9375rem] font-semibold leading-tight hover:underline cursor-default"
               style={nameColorStyle(nameColor)}
@@ -975,7 +1053,7 @@ export const ConversationMessage = memo(function ConversationMessage({
         )}
 
         {/* Message body */}
-        {editing ? (
+        {isHiddenCollapsed ? null : editing ? (
           <div className="space-y-2">
             <textarea
               ref={editRef}
@@ -1122,6 +1200,14 @@ export const ConversationMessage = memo(function ConversationMessage({
               onClick={() => onRegenerate?.(message.id)}
               title={regenerateButtonTitle}
               className={regenerateGuidedClass}
+            />
+          )}
+          {onToggleHiddenFromAI && (
+            <MsgAction
+              icon={isHiddenFromAI ? <Circle size="0.75rem" /> : <EyeOff size="0.75rem" />}
+              onClick={() => onToggleHiddenFromAI(message.id, isHiddenFromAI)}
+              title={isHiddenFromAI ? "Unhide from AI" : "Hide from AI"}
+              className={isHiddenFromAI ? "text-amber-400" : undefined}
             />
           )}
           {isLastAssistantMessage && !isUser && (

--- a/packages/client/src/components/chat/ConversationView.tsx
+++ b/packages/client/src/components/chat/ConversationView.tsx
@@ -63,6 +63,7 @@ interface ConversationViewProps {
   onRegenerate: (messageId: string) => void;
   onEdit: (messageId: string, content: string) => void;
   onSetActiveSwipe: (messageId: string, index: number) => void;
+  onToggleHiddenFromAI: (messageId: string, current: boolean) => void;
   onPeekPrompt: () => void;
   lastAssistantMessageId: string | null;
   onOpenSettings: () => void;
@@ -315,6 +316,7 @@ export function ConversationView({
   onRegenerate,
   onEdit,
   onSetActiveSwipe,
+  onToggleHiddenFromAI,
   onPeekPrompt,
   lastAssistantMessageId,
   onOpenSettings,
@@ -971,6 +973,7 @@ export function ConversationView({
                   onRegenerate={onRegenerate}
                   onEdit={onEdit}
                   onSetActiveSwipe={onSetActiveSwipe}
+                  onToggleHiddenFromAI={onToggleHiddenFromAI}
                   onPeekPrompt={onPeekPrompt}
                 />,
               );
@@ -1007,6 +1010,7 @@ export function ConversationView({
                 onRegenerate={onRegenerate}
                 onEdit={onEdit}
                 onSetActiveSwipe={onSetActiveSwipe}
+                onToggleHiddenFromAI={onToggleHiddenFromAI}
                 onPeekPrompt={onPeekPrompt}
                 isLastAssistantMessage={msg.id === lastAssistantMessageId}
                 characterMap={characterMap}
@@ -1138,6 +1142,7 @@ function SplitMessageGroup({
   onRegenerate,
   onEdit,
   onSetActiveSwipe,
+  onToggleHiddenFromAI,
   onPeekPrompt,
 }: {
   items: Array<{ key: string; msg: Message; isGrouped: boolean; index: number }>;
@@ -1153,6 +1158,7 @@ function SplitMessageGroup({
   onRegenerate: (id: string) => void;
   onEdit: (id: string, content: string) => void;
   onSetActiveSwipe: (id: string, index: number) => void;
+  onToggleHiddenFromAI: (id: string, current: boolean) => void;
   onPeekPrompt: () => void;
 }) {
   const [showActions, setShowActions] = useState(false);
@@ -1193,6 +1199,7 @@ function SplitMessageGroup({
           onRegenerate={onRegenerate}
           onEdit={onEdit}
           onSetActiveSwipe={onSetActiveSwipe}
+          onToggleHiddenFromAI={onToggleHiddenFromAI}
           onPeekPrompt={onPeekPrompt}
           isLastAssistantMessage={false}
           characterMap={characterMap}
@@ -1268,6 +1275,7 @@ function SplitMessageGroup({
                 onRegenerate={onRegenerate}
                 onEdit={onEdit}
                 onSetActiveSwipe={onSetActiveSwipe}
+                onToggleHiddenFromAI={onToggleHiddenFromAI}
                 onPeekPrompt={onPeekPrompt}
                 isLastAssistantMessage={false}
                 characterMap={characterMap}
@@ -1294,6 +1302,7 @@ function SplitMessageGroup({
               onRegenerate={onRegenerate}
               onEdit={onEdit}
               onSetActiveSwipe={onSetActiveSwipe}
+              onToggleHiddenFromAI={onToggleHiddenFromAI}
               onPeekPrompt={onPeekPrompt}
               onEditClick={handleStartEdit}
               isLastAssistantMessage={firstItem.msg.id === lastAssistantMessageId}
@@ -1321,6 +1330,7 @@ function SplitMessageGroup({
               onRegenerate={onRegenerate}
               onEdit={onEdit}
               onSetActiveSwipe={onSetActiveSwipe}
+              onToggleHiddenFromAI={onToggleHiddenFromAI}
               onPeekPrompt={onPeekPrompt}
               onEditClick={handleStartEdit}
               isLastAssistantMessage={msg.id === lastAssistantMessageId}

--- a/packages/client/src/components/chat/SummaryPopover.tsx
+++ b/packages/client/src/components/chat/SummaryPopover.tsx
@@ -5,8 +5,9 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { createPortal } from "react-dom";
 import { useGenerateSummary, useUpdateChatMetadata } from "../../hooks/use-chats";
-import { ChevronDown, Info, Loader2, Save, ScrollText, Sparkles, X } from "lucide-react";
+import { Info, Loader2, Save, ScrollText, Settings2, Sparkles, X } from "lucide-react";
 import { cn } from "../../lib/utils";
+import { useUIStore } from "../../stores/ui.store";
 
 interface SummaryPopoverProps {
   chatId: string;
@@ -41,11 +42,18 @@ export function SummaryPopover({
 }: SummaryPopoverProps) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(summary ?? "");
-  const [localSize, setLocalSize] = useState(String(contextSize || ""));
-  const [sourceMode, setSourceMode] = useState<SummarySourceMode>("last");
-  const [sourceOpen, setSourceOpen] = useState(false);
-  const [rangeStart, setRangeStart] = useState(() => String(Math.max(1, totalMessageCount - contextSize + 1)));
-  const [rangeEnd, setRangeEnd] = useState(() => String(Math.max(1, totalMessageCount)));
+  const summaryPopoverSettings = useUIStore((s) => s.summaryPopoverSettings);
+  const setSummaryPopoverSettings = useUIStore((s) => s.setSummaryPopoverSettings);
+  const persistedContextSize = summaryPopoverSettings.contextSize ?? contextSize;
+  const [localSize, setLocalSize] = useState(String(persistedContextSize || ""));
+  const sourceMode = summaryPopoverSettings.sourceMode;
+  const [scopeSettingsOpen, setScopeSettingsOpen] = useState(false);
+  const [rangeStart, setRangeStart] = useState(() =>
+    String(summaryPopoverSettings.rangeStart ?? Math.max(1, totalMessageCount - persistedContextSize + 1)),
+  );
+  const [rangeEnd, setRangeEnd] = useState(() =>
+    String(summaryPopoverSettings.rangeEnd ?? Math.max(1, totalMessageCount)),
+  );
   const sizeInputFocused = useRef(false);
   const rangeInputFocused = useRef(false);
   const generateSummary = useGenerateSummary();
@@ -85,19 +93,19 @@ export function SummaryPopover({
     setDraft(summary ?? "");
   }, [summary]);
 
-  // Sync local size when contextSize prop changes externally
+  // Sync local size when the persisted/default context size changes externally.
   useEffect(() => {
     if (!sizeInputFocused.current) {
-      setLocalSize(contextSize ? String(contextSize) : "");
+      setLocalSize(persistedContextSize ? String(persistedContextSize) : "");
     }
-  }, [contextSize]);
+  }, [persistedContextSize]);
 
   // Keep the default custom range aligned to the currently selected "last" window.
   useEffect(() => {
     if (rangeInputFocused.current || sourceMode === "range") return;
-    setRangeStart(String(Math.max(1, totalMessageCount - contextSize + 1)));
+    setRangeStart(String(Math.max(1, totalMessageCount - persistedContextSize + 1)));
     setRangeEnd(String(Math.max(1, totalMessageCount)));
-  }, [contextSize, sourceMode, totalMessageCount]);
+  }, [persistedContextSize, sourceMode, totalMessageCount]);
 
   // Focus textarea when entering edit mode
   useEffect(() => {
@@ -106,7 +114,7 @@ export function SummaryPopover({
     }
   }, [editing]);
 
-  const normalizedLastSize = clampSummaryCount(parsePositiveInteger(localSize) ?? contextSize ?? 50);
+  const normalizedLastSize = clampSummaryCount(parsePositiveInteger(localSize) ?? persistedContextSize ?? 50);
   const normalizedRangeStart = Math.max(1, Math.min(totalMessageCount || 1, parsePositiveInteger(rangeStart) ?? 1));
   const normalizedRangeEnd = Math.max(
     1,
@@ -139,13 +147,15 @@ export function SummaryPopover({
 
   const handleSourceModeChange = useCallback(
     (mode: SummarySourceMode) => {
-      setSourceMode(mode);
       if (mode === "range") {
         setRangeStart(String(rangeLow));
         setRangeEnd(String(rangeHigh));
+        setSummaryPopoverSettings({ sourceMode: mode, rangeStart: rangeLow, rangeEnd: rangeHigh });
+        return;
       }
+      setSummaryPopoverSettings({ sourceMode: mode });
     },
-    [rangeHigh, rangeLow],
+    [rangeHigh, rangeLow, setSummaryPopoverSettings],
   );
 
   const handleGenerate = useCallback(() => {
@@ -166,6 +176,7 @@ export function SummaryPopover({
       return;
     }
     setLocalSize(String(normalizedLastSize));
+    setSummaryPopoverSettings({ contextSize: normalizedLastSize });
     generateSummary.mutate(
       { chatId, contextSize: normalizedLastSize },
       {
@@ -184,6 +195,7 @@ export function SummaryPopover({
     rangeLow,
     rangeEndMessageId,
     rangeStartMessageId,
+    setSummaryPopoverSettings,
     sourceMode,
   ]);
 
@@ -210,7 +222,7 @@ export function SummaryPopover({
       {isMobile && <div className="absolute inset-0 bg-black/30" onClick={onClose} />}
       <div
         className={cn(
-          "rounded-xl border border-[var(--border)] bg-[var(--card)] shadow-2xl shadow-black/40",
+          "relative rounded-xl border border-[var(--border)] bg-[var(--card)] shadow-2xl shadow-black/40",
           isMobile ? "relative w-full max-w-sm max-h-[calc(100dvh-4rem)] overflow-y-auto" : "w-80",
         )}
       >
@@ -222,13 +234,173 @@ export function SummaryPopover({
           </div>
           <div className="flex items-center gap-1">
             <button
+              type="button"
+              onClick={() => setScopeSettingsOpen((open) => !open)}
+              className={cn(
+                "rounded-md p-1 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--ring)]",
+                scopeSettingsOpen && "bg-[var(--accent)] text-amber-300",
+              )}
+              title="Summary source settings"
+              aria-label="Summary source settings"
+              aria-expanded={scopeSettingsOpen}
+            >
+              <Settings2 size="0.75rem" />
+            </button>
+            <button
+              type="button"
               onClick={onClose}
               className="rounded-md p-1 text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+              aria-label="Close summary"
             >
               <X size="0.75rem" />
             </button>
           </div>
         </div>
+
+        {scopeSettingsOpen && (
+          <div className="absolute right-2 top-10 z-10 w-[calc(100%-1rem)] max-w-72 rounded-xl border border-[var(--border)] bg-[var(--popover)] p-2 text-[var(--popover-foreground)] shadow-xl shadow-black/30 ring-1 ring-white/5">
+            <div className="mb-2 flex items-start justify-between gap-3 px-1">
+              <div className="min-w-0">
+                <p className="text-[0.625rem] font-semibold uppercase text-[var(--muted-foreground)]">
+                  Summary Scope
+                </p>
+                <p className="truncate text-xs font-semibold text-[var(--popover-foreground)]">{sourceSummary}</p>
+              </div>
+              <span className="shrink-0 pt-0.5 text-right text-[0.625rem] text-[var(--muted-foreground)]">
+                {sourceDetail}
+              </span>
+            </div>
+
+            <div className="space-y-2 rounded-lg border border-[var(--border)] bg-[var(--secondary)]/40 p-2">
+              <div className="grid grid-cols-2 gap-1 rounded-lg bg-[var(--background)]/30 p-1">
+                {(["last", "range"] as const).map((mode) => (
+                  <button
+                    key={mode}
+                    type="button"
+                    onClick={() => handleSourceModeChange(mode)}
+                    className={cn(
+                      "rounded-md px-2 py-1 text-[0.625rem] font-semibold transition-colors",
+                      sourceMode === mode
+                        ? "bg-amber-400/20 text-amber-200 ring-1 ring-amber-300/30"
+                        : "text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]",
+                    )}
+                  >
+                    {mode === "last" ? "Last" : "Range"}
+                  </button>
+                ))}
+              </div>
+
+              {sourceMode === "last" ? (
+                <label className="flex items-center justify-between gap-2 text-[0.6875rem] text-[var(--muted-foreground)]">
+                  <span>Messages</span>
+                  <input
+                    type="number"
+                    min={MIN_SUMMARY_MESSAGES}
+                    max={MAX_SUMMARY_MESSAGES}
+                    value={localSize}
+                    onFocus={() => {
+                      sizeInputFocused.current = true;
+                    }}
+                    onChange={(e) => {
+                      setLocalSize(e.target.value);
+                      const next = parsePositiveInteger(e.target.value);
+                      if (next !== null) {
+                        setSummaryPopoverSettings({ contextSize: clampSummaryCount(next) });
+                      }
+                    }}
+                    onBlur={() => {
+                      sizeInputFocused.current = false;
+                      const clamped = clampSummaryCount(parsePositiveInteger(localSize) ?? 50);
+                      setLocalSize(String(clamped));
+                      setSummaryPopoverSettings({ contextSize: clamped });
+                    }}
+                    className="w-16 rounded-md bg-[var(--card)] px-2 py-1 text-center text-xs tabular-nums text-[var(--foreground)] ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+                  />
+                </label>
+              ) : (
+                <div className="space-y-1.5">
+                  <div className="grid grid-cols-2 gap-2">
+                    <label className="space-y-1 text-[0.625rem] font-medium text-[var(--muted-foreground)]">
+                      From
+                      <input
+                        type="number"
+                        min={1}
+                        max={Math.max(1, totalMessageCount)}
+                        value={rangeStart}
+                        onFocus={() => {
+                          rangeInputFocused.current = true;
+                        }}
+                        onChange={(e) => {
+                          setRangeStart(e.target.value);
+                          const next = parsePositiveInteger(e.target.value);
+                          if (next !== null) {
+                            setSummaryPopoverSettings({
+                              rangeStart: Math.max(1, Math.min(totalMessageCount || 1, next)),
+                            });
+                          }
+                        }}
+                        onBlur={() => {
+                          rangeInputFocused.current = false;
+                          setRangeStart(String(normalizedRangeStart));
+                          setSummaryPopoverSettings({ rangeStart: normalizedRangeStart });
+                        }}
+                        className="w-full rounded-md bg-[var(--card)] px-2 py-1 text-center text-xs tabular-nums text-[var(--foreground)] ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+                      />
+                    </label>
+                    <label className="space-y-1 text-[0.625rem] font-medium text-[var(--muted-foreground)]">
+                      To
+                      <input
+                        type="number"
+                        min={1}
+                        max={Math.max(1, totalMessageCount)}
+                        value={rangeEnd}
+                        onFocus={() => {
+                          rangeInputFocused.current = true;
+                        }}
+                        onChange={(e) => {
+                          setRangeEnd(e.target.value);
+                          const next = parsePositiveInteger(e.target.value);
+                          if (next !== null) {
+                            setSummaryPopoverSettings({
+                              rangeEnd: Math.max(1, Math.min(totalMessageCount || 1, next)),
+                            });
+                          }
+                        }}
+                        onBlur={() => {
+                          rangeInputFocused.current = false;
+                          setRangeEnd(String(normalizedRangeEnd));
+                          setSummaryPopoverSettings({ rangeEnd: normalizedRangeEnd });
+                        }}
+                        className="w-full rounded-md bg-[var(--card)] px-2 py-1 text-center text-xs tabular-nums text-[var(--foreground)] ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+                      />
+                    </label>
+                  </div>
+                  <p
+                    className={cn(
+                      "text-[0.625rem]",
+                      rangeTooLarge || !rangeMessagesLoaded ? "text-red-300" : "text-[var(--muted-foreground)]",
+                    )}
+                  >
+                    {rangeStatusText}
+                  </p>
+                </div>
+              )}
+            </div>
+
+            <div className="space-y-1.5 pt-1">
+              <SummarySettingsToggle
+                label="Hide summarised messages"
+                checked={summaryPopoverSettings.hideSummarisedMessages}
+                onChange={(checked) => setSummaryPopoverSettings({ hideSummarisedMessages: checked })}
+              />
+              <SummarySettingsToggle
+                label="Collapse hidden messages"
+                checked={summaryPopoverSettings.collapseHiddenMessages}
+                onChange={(checked) => setSummaryPopoverSettings({ collapseHiddenMessages: checked })}
+              />
+            </div>
+          </div>
+        )}
 
         {/* Body */}
         <div className="max-h-72 overflow-y-auto p-3">
@@ -288,116 +460,10 @@ export function SummaryPopover({
 
         {/* Source controls */}
         <div className="border-t border-[var(--border)] px-3 py-2">
-          <button
-            type="button"
-            onClick={() => setSourceOpen((open) => !open)}
-            className="flex w-full items-center justify-between gap-2 rounded-lg px-2 py-1.5 text-left transition-colors hover:bg-[var(--accent)]"
-          >
-            <span className="min-w-0">
-              <span className="block text-[0.625rem] font-medium uppercase text-[var(--muted-foreground)]">Source</span>
-              <span className="block truncate text-xs font-semibold text-[var(--foreground)]/85">{sourceSummary}</span>
-            </span>
-            <span className="flex min-w-0 shrink items-center justify-end gap-1 text-right text-[0.625rem] text-[var(--muted-foreground)]">
-              {sourceDetail}
-              <ChevronDown
-                size="0.75rem"
-                className={cn("transition-transform", sourceOpen && "rotate-180 text-amber-300")}
-              />
-            </span>
-          </button>
-
-          {sourceOpen && (
-            <div className="mt-2 space-y-2 rounded-lg border border-[var(--border)] bg-[var(--secondary)]/40 p-2">
-              <div className="grid grid-cols-2 gap-1 rounded-lg bg-[var(--background)]/30 p-1">
-                {(["last", "range"] as const).map((mode) => (
-                  <button
-                    key={mode}
-                    type="button"
-                    onClick={() => handleSourceModeChange(mode)}
-                    className={cn(
-                      "rounded-md px-2 py-1 text-[0.625rem] font-semibold transition-colors",
-                      sourceMode === mode
-                        ? "bg-amber-400/20 text-amber-200 ring-1 ring-amber-300/30"
-                        : "text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]",
-                    )}
-                  >
-                    {mode === "last" ? "Last" : "Range"}
-                  </button>
-                ))}
-              </div>
-
-              {sourceMode === "last" ? (
-                <label className="flex items-center justify-between gap-2 text-[0.6875rem] text-[var(--muted-foreground)]">
-                  <span>Messages</span>
-                  <input
-                    type="number"
-                    min={MIN_SUMMARY_MESSAGES}
-                    max={MAX_SUMMARY_MESSAGES}
-                    value={localSize}
-                    onFocus={() => {
-                      sizeInputFocused.current = true;
-                    }}
-                    onChange={(e) => setLocalSize(e.target.value)}
-                    onBlur={() => {
-                      sizeInputFocused.current = false;
-                      const clamped = clampSummaryCount(parsePositiveInteger(localSize) ?? 50);
-                      setLocalSize(String(clamped));
-                    }}
-                    className="w-16 rounded-md bg-[var(--card)] px-2 py-1 text-center text-xs tabular-nums text-[var(--foreground)] ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
-                  />
-                </label>
-              ) : (
-                <div className="space-y-1.5">
-                  <div className="grid grid-cols-2 gap-2">
-                    <label className="space-y-1 text-[0.625rem] font-medium text-[var(--muted-foreground)]">
-                      From
-                      <input
-                        type="number"
-                        min={1}
-                        max={Math.max(1, totalMessageCount)}
-                        value={rangeStart}
-                        onFocus={() => {
-                          rangeInputFocused.current = true;
-                        }}
-                        onChange={(e) => setRangeStart(e.target.value)}
-                        onBlur={() => {
-                          rangeInputFocused.current = false;
-                          setRangeStart(String(normalizedRangeStart));
-                        }}
-                        className="w-full rounded-md bg-[var(--card)] px-2 py-1 text-center text-xs tabular-nums text-[var(--foreground)] ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
-                      />
-                    </label>
-                    <label className="space-y-1 text-[0.625rem] font-medium text-[var(--muted-foreground)]">
-                      To
-                      <input
-                        type="number"
-                        min={1}
-                        max={Math.max(1, totalMessageCount)}
-                        value={rangeEnd}
-                        onFocus={() => {
-                          rangeInputFocused.current = true;
-                        }}
-                        onChange={(e) => setRangeEnd(e.target.value)}
-                        onBlur={() => {
-                          rangeInputFocused.current = false;
-                          setRangeEnd(String(normalizedRangeEnd));
-                        }}
-                        className="w-full rounded-md bg-[var(--card)] px-2 py-1 text-center text-xs tabular-nums text-[var(--foreground)] ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
-                      />
-                    </label>
-                  </div>
-                  <p
-                    className={cn(
-                      "text-[0.625rem]",
-                      rangeTooLarge || !rangeMessagesLoaded ? "text-red-300" : "text-[var(--muted-foreground)]",
-                    )}
-                  >
-                    {rangeStatusText}
-                  </p>
-                </div>
-              )}
-            </div>
-          )}
+          <div className="mb-2 flex items-center justify-between gap-2 px-2 text-[0.625rem] text-[var(--muted-foreground)]">
+            <span className="truncate">Source: {sourceSummary}</span>
+            <span className="shrink-0">{sourceDetail}</span>
+          </div>
 
           <button
             onClick={handleGenerate}
@@ -431,4 +497,24 @@ export function SummaryPopover({
   );
 
   return isMobile ? createPortal(content, document.body) : content;
+}
+
+interface SummarySettingsToggleProps {
+  label: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+}
+
+function SummarySettingsToggle({ label, checked, onChange }: SummarySettingsToggleProps) {
+  return (
+    <label className="flex cursor-pointer items-center justify-between gap-3 rounded-lg px-1.5 py-1 text-[0.6875rem] text-[var(--popover-foreground)] transition-colors hover:bg-[var(--accent)]/50">
+      <span className="min-w-0 truncate">{label}</span>
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(event) => onChange(event.target.checked)}
+        className="h-3.5 w-3.5 shrink-0 accent-amber-400"
+      />
+    </label>
+  );
 }

--- a/packages/client/src/components/chat/SummaryPopover.tsx
+++ b/packages/client/src/components/chat/SummaryPopover.tsx
@@ -14,7 +14,6 @@ interface SummaryPopoverProps {
   summary: string | null;
   contextSize: number;
   totalMessageCount: number;
-  messageIdByOrderIndex: Map<number, string>;
   onClose: () => void;
 }
 
@@ -37,7 +36,6 @@ export function SummaryPopover({
   summary,
   contextSize,
   totalMessageCount,
-  messageIdByOrderIndex,
   onClose,
 }: SummaryPopoverProps) {
   const [editing, setEditing] = useState(false);
@@ -126,10 +124,7 @@ export function SummaryPopover({
   const selectedRangeCount = rangeHigh - rangeLow + 1;
   const hasMessages = totalMessageCount > 0;
   const rangeTooLarge = sourceMode === "range" && selectedRangeCount > MAX_SUMMARY_MESSAGES;
-  const rangeStartMessageId = messageIdByOrderIndex.get(rangeLow - 1);
-  const rangeEndMessageId = messageIdByOrderIndex.get(rangeHigh - 1);
-  const rangeMessagesLoaded = sourceMode !== "range" || (!!rangeStartMessageId && !!rangeEndMessageId);
-  const canGenerate = hasMessages && !rangeTooLarge && rangeMessagesLoaded;
+  const canGenerate = hasMessages && !rangeTooLarge;
   const sourceSummary =
     sourceMode === "range"
       ? `Messages ${rangeLow}-${rangeHigh}`
@@ -140,9 +135,7 @@ export function SummaryPopover({
       : totalMessageCount > 0
         ? `Using ${Math.min(normalizedLastSize, totalMessageCount)} of ${totalMessageCount} messages`
         : "No messages yet";
-  const rangeStatusText = !rangeMessagesLoaded
-    ? "Load this range in the chat before generating."
-    : rangeTooLarge
+  const rangeStatusText = rangeTooLarge
       ? `Choose ${MAX_SUMMARY_MESSAGES} messages or fewer.`
       : `${selectedRangeCount} ${selectedRangeCount === 1 ? "message" : "messages"} selected.`;
 
@@ -168,9 +161,8 @@ export function SummaryPopover({
     if (sourceMode === "range") {
       setRangeStart(String(rangeLow));
       setRangeEnd(String(rangeHigh));
-      if (!rangeStartMessageId || !rangeEndMessageId) return;
       generateSummary.mutate(
-        { chatId, rangeStartMessageId, rangeEndMessageId },
+        { chatId, rangeStartIndex: rangeLow, rangeEndIndex: rangeHigh },
         {
           onSuccess: (data) => {
             setDraft(data.summary);
@@ -201,8 +193,6 @@ export function SummaryPopover({
     normalizedLastSize,
     rangeHigh,
     rangeLow,
-    rangeEndMessageId,
-    rangeStartMessageId,
     setSummaryPopoverSettings,
     sourceMode,
     summaryPopoverSettings.hideSummarisedMessages,
@@ -387,7 +377,7 @@ export function SummaryPopover({
                   <p
                     className={cn(
                       "text-[0.625rem]",
-                      rangeTooLarge || !rangeMessagesLoaded ? "text-red-300" : "text-[var(--muted-foreground)]",
+                      rangeTooLarge ? "text-red-300" : "text-[var(--muted-foreground)]",
                     )}
                   >
                     {rangeStatusText}

--- a/packages/client/src/components/chat/SummaryPopover.tsx
+++ b/packages/client/src/components/chat/SummaryPopover.tsx
@@ -4,7 +4,7 @@
 // ──────────────────────────────────────────────
 import { useState, useEffect, useRef, useCallback } from "react";
 import { createPortal } from "react-dom";
-import { useGenerateSummary, useUpdateChatMetadata } from "../../hooks/use-chats";
+import { useBulkSetMessagesHiddenFromAI, useGenerateSummary, useUpdateChatMetadata } from "../../hooks/use-chats";
 import { Info, Loader2, Save, ScrollText, Settings2, Sparkles, X } from "lucide-react";
 import { cn } from "../../lib/utils";
 import { useUIStore } from "../../stores/ui.store";
@@ -57,6 +57,7 @@ export function SummaryPopover({
   const sizeInputFocused = useRef(false);
   const rangeInputFocused = useRef(false);
   const generateSummary = useGenerateSummary();
+  const bulkSetMessagesHiddenFromAI = useBulkSetMessagesHiddenFromAI();
   const updateMeta = useUpdateChatMetadata();
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
@@ -160,6 +161,10 @@ export function SummaryPopover({
 
   const handleGenerate = useCallback(() => {
     if (!canGenerate) return;
+    const maybeHideSummarisedMessages = (messageIds: string[] | undefined) => {
+      if (!summaryPopoverSettings.hideSummarisedMessages || !messageIds?.length) return;
+      bulkSetMessagesHiddenFromAI.mutate({ chatId, messageIds, hidden: true });
+    };
     if (sourceMode === "range") {
       setRangeStart(String(rangeLow));
       setRangeEnd(String(rangeHigh));
@@ -170,6 +175,7 @@ export function SummaryPopover({
           onSuccess: (data) => {
             setDraft(data.summary);
             setEditing(false);
+            maybeHideSummarisedMessages(data.messageIds);
           },
         },
       );
@@ -183,10 +189,12 @@ export function SummaryPopover({
         onSuccess: (data) => {
           setDraft(data.summary);
           setEditing(false);
+          maybeHideSummarisedMessages(data.messageIds);
         },
       },
     );
   }, [
+    bulkSetMessagesHiddenFromAI,
     canGenerate,
     chatId,
     generateSummary,
@@ -197,6 +205,7 @@ export function SummaryPopover({
     rangeStartMessageId,
     setSummaryPopoverSettings,
     sourceMode,
+    summaryPopoverSettings.hideSummarisedMessages,
   ]);
 
   const handleSave = useCallback(() => {

--- a/packages/client/src/components/chat/SummaryPopover.tsx
+++ b/packages/client/src/components/chat/SummaryPopover.tsx
@@ -5,22 +5,49 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { createPortal } from "react-dom";
 import { useGenerateSummary, useUpdateChatMetadata } from "../../hooks/use-chats";
-import { ScrollText, Sparkles, X, Save, Loader2, Info } from "lucide-react";
+import { ChevronDown, Info, Loader2, Save, ScrollText, Sparkles, X } from "lucide-react";
 import { cn } from "../../lib/utils";
 
 interface SummaryPopoverProps {
   chatId: string;
   summary: string | null;
   contextSize: number;
-  onContextSizeChange: (size: number) => void;
+  totalMessageCount: number;
+  messageIdByOrderIndex: Map<number, string>;
   onClose: () => void;
 }
 
-export function SummaryPopover({ chatId, summary, contextSize, onContextSizeChange, onClose }: SummaryPopoverProps) {
+type SummarySourceMode = "last" | "range";
+
+const MIN_SUMMARY_MESSAGES = 5;
+const MAX_SUMMARY_MESSAGES = 200;
+
+function clampSummaryCount(value: number): number {
+  return Math.max(MIN_SUMMARY_MESSAGES, Math.min(MAX_SUMMARY_MESSAGES, value));
+}
+
+function parsePositiveInteger(value: string): number | null {
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+export function SummaryPopover({
+  chatId,
+  summary,
+  contextSize,
+  totalMessageCount,
+  messageIdByOrderIndex,
+  onClose,
+}: SummaryPopoverProps) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(summary ?? "");
   const [localSize, setLocalSize] = useState(String(contextSize || ""));
+  const [sourceMode, setSourceMode] = useState<SummarySourceMode>("last");
+  const [sourceOpen, setSourceOpen] = useState(false);
+  const [rangeStart, setRangeStart] = useState(() => String(Math.max(1, totalMessageCount - contextSize + 1)));
+  const [rangeEnd, setRangeEnd] = useState(() => String(Math.max(1, totalMessageCount)));
   const sizeInputFocused = useRef(false);
+  const rangeInputFocused = useRef(false);
   const generateSummary = useGenerateSummary();
   const updateMeta = useUpdateChatMetadata();
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -65,6 +92,13 @@ export function SummaryPopover({ chatId, summary, contextSize, onContextSizeChan
     }
   }, [contextSize]);
 
+  // Keep the default custom range aligned to the currently selected "last" window.
+  useEffect(() => {
+    if (rangeInputFocused.current || sourceMode === "range") return;
+    setRangeStart(String(Math.max(1, totalMessageCount - contextSize + 1)));
+    setRangeEnd(String(Math.max(1, totalMessageCount)));
+  }, [contextSize, sourceMode, totalMessageCount]);
+
   // Focus textarea when entering edit mode
   useEffect(() => {
     if (editing) {
@@ -72,9 +106,68 @@ export function SummaryPopover({ chatId, summary, contextSize, onContextSizeChan
     }
   }, [editing]);
 
+  const normalizedLastSize = clampSummaryCount(parsePositiveInteger(localSize) ?? contextSize ?? 50);
+  const normalizedRangeStart = Math.max(1, Math.min(totalMessageCount || 1, parsePositiveInteger(rangeStart) ?? 1));
+  const normalizedRangeEnd = Math.max(
+    1,
+    Math.min(totalMessageCount || 1, parsePositiveInteger(rangeEnd) ?? (totalMessageCount || 1)),
+  );
+  const rangeLow = Math.min(normalizedRangeStart, normalizedRangeEnd);
+  const rangeHigh = Math.max(normalizedRangeStart, normalizedRangeEnd);
+  const selectedRangeCount = rangeHigh - rangeLow + 1;
+  const hasMessages = totalMessageCount > 0;
+  const rangeTooLarge = sourceMode === "range" && selectedRangeCount > MAX_SUMMARY_MESSAGES;
+  const rangeStartMessageId = messageIdByOrderIndex.get(rangeLow - 1);
+  const rangeEndMessageId = messageIdByOrderIndex.get(rangeHigh - 1);
+  const rangeMessagesLoaded = sourceMode !== "range" || (!!rangeStartMessageId && !!rangeEndMessageId);
+  const canGenerate = hasMessages && !rangeTooLarge && rangeMessagesLoaded;
+  const sourceSummary =
+    sourceMode === "range"
+      ? `Messages ${rangeLow}-${rangeHigh}`
+      : `Last ${normalizedLastSize} ${normalizedLastSize === 1 ? "message" : "messages"}`;
+  const sourceDetail =
+    sourceMode === "range"
+      ? `${selectedRangeCount} ${selectedRangeCount === 1 ? "message" : "messages"} selected`
+      : totalMessageCount > 0
+        ? `Using ${Math.min(normalizedLastSize, totalMessageCount)} of ${totalMessageCount} messages`
+        : "No messages yet";
+  const rangeStatusText = !rangeMessagesLoaded
+    ? "Load this range in the chat before generating."
+    : rangeTooLarge
+      ? `Choose ${MAX_SUMMARY_MESSAGES} messages or fewer.`
+      : `${selectedRangeCount} ${selectedRangeCount === 1 ? "message" : "messages"} selected.`;
+
+  const handleSourceModeChange = useCallback(
+    (mode: SummarySourceMode) => {
+      setSourceMode(mode);
+      if (mode === "range") {
+        setRangeStart(String(rangeLow));
+        setRangeEnd(String(rangeHigh));
+      }
+    },
+    [rangeHigh, rangeLow],
+  );
+
   const handleGenerate = useCallback(() => {
+    if (!canGenerate) return;
+    if (sourceMode === "range") {
+      setRangeStart(String(rangeLow));
+      setRangeEnd(String(rangeHigh));
+      if (!rangeStartMessageId || !rangeEndMessageId) return;
+      generateSummary.mutate(
+        { chatId, rangeStartMessageId, rangeEndMessageId },
+        {
+          onSuccess: (data) => {
+            setDraft(data.summary);
+            setEditing(false);
+          },
+        },
+      );
+      return;
+    }
+    setLocalSize(String(normalizedLastSize));
     generateSummary.mutate(
-      { chatId, contextSize },
+      { chatId, contextSize: normalizedLastSize },
       {
         onSuccess: (data) => {
           setDraft(data.summary);
@@ -82,7 +175,17 @@ export function SummaryPopover({ chatId, summary, contextSize, onContextSizeChan
         },
       },
     );
-  }, [chatId, contextSize, generateSummary]);
+  }, [
+    canGenerate,
+    chatId,
+    generateSummary,
+    normalizedLastSize,
+    rangeHigh,
+    rangeLow,
+    rangeEndMessageId,
+    rangeStartMessageId,
+    sourceMode,
+  ]);
 
   const handleSave = useCallback(() => {
     updateMeta.mutate({ id: chatId, summary: draft || null });
@@ -118,48 +221,6 @@ export function SummaryPopover({ chatId, summary, contextSize, onContextSizeChan
             Chat Summary
           </div>
           <div className="flex items-center gap-1">
-            <div
-              className="flex items-center gap-1 mr-1"
-              title="Context size — number of recent messages used for summary generation"
-            >
-              <input
-                type="number"
-                min={5}
-                max={200}
-                value={localSize}
-                onFocus={() => {
-                  sizeInputFocused.current = true;
-                }}
-                onChange={(e) => setLocalSize(e.target.value)}
-                onBlur={() => {
-                  sizeInputFocused.current = false;
-                  const parsed = parseInt(localSize);
-                  if (!localSize || isNaN(parsed)) {
-                    setLocalSize("50");
-                    onContextSizeChange(50);
-                  } else {
-                    const clamped = Math.max(5, Math.min(200, parsed));
-                    setLocalSize(String(clamped));
-                    onContextSizeChange(clamped);
-                  }
-                }}
-                className="w-12 rounded-md bg-[var(--secondary)] px-1.5 py-0.5 text-center text-[0.625rem] tabular-nums ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
-              />
-            </div>
-            <button
-              onClick={handleGenerate}
-              disabled={isGenerating}
-              className={cn(
-                "flex items-center gap-1 rounded-lg px-2 py-1 text-[0.625rem] font-medium transition-all",
-                isGenerating
-                  ? "cursor-wait text-amber-300/60"
-                  : "text-amber-300 hover:bg-amber-400/15 hover:text-amber-200",
-              )}
-              title="Generate summary with AI"
-            >
-              {isGenerating ? <Loader2 size="0.6875rem" className="animate-spin" /> : <Sparkles size="0.6875rem" />}
-              {isGenerating ? "Generating…" : "Generate"}
-            </button>
             <button
               onClick={onClose}
               className="rounded-md p-1 text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
@@ -223,6 +284,135 @@ export function SummaryPopover({ chatId, summary, contextSize, onContextSizeChan
               )}
             </div>
           )}
+        </div>
+
+        {/* Source controls */}
+        <div className="border-t border-[var(--border)] px-3 py-2">
+          <button
+            type="button"
+            onClick={() => setSourceOpen((open) => !open)}
+            className="flex w-full items-center justify-between gap-2 rounded-lg px-2 py-1.5 text-left transition-colors hover:bg-[var(--accent)]"
+          >
+            <span className="min-w-0">
+              <span className="block text-[0.625rem] font-medium uppercase text-[var(--muted-foreground)]">Source</span>
+              <span className="block truncate text-xs font-semibold text-[var(--foreground)]/85">{sourceSummary}</span>
+            </span>
+            <span className="flex min-w-0 shrink items-center justify-end gap-1 text-right text-[0.625rem] text-[var(--muted-foreground)]">
+              {sourceDetail}
+              <ChevronDown
+                size="0.75rem"
+                className={cn("transition-transform", sourceOpen && "rotate-180 text-amber-300")}
+              />
+            </span>
+          </button>
+
+          {sourceOpen && (
+            <div className="mt-2 space-y-2 rounded-lg border border-[var(--border)] bg-[var(--secondary)]/40 p-2">
+              <div className="grid grid-cols-2 gap-1 rounded-lg bg-[var(--background)]/30 p-1">
+                {(["last", "range"] as const).map((mode) => (
+                  <button
+                    key={mode}
+                    type="button"
+                    onClick={() => handleSourceModeChange(mode)}
+                    className={cn(
+                      "rounded-md px-2 py-1 text-[0.625rem] font-semibold transition-colors",
+                      sourceMode === mode
+                        ? "bg-amber-400/20 text-amber-200 ring-1 ring-amber-300/30"
+                        : "text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]",
+                    )}
+                  >
+                    {mode === "last" ? "Last" : "Range"}
+                  </button>
+                ))}
+              </div>
+
+              {sourceMode === "last" ? (
+                <label className="flex items-center justify-between gap-2 text-[0.6875rem] text-[var(--muted-foreground)]">
+                  <span>Messages</span>
+                  <input
+                    type="number"
+                    min={MIN_SUMMARY_MESSAGES}
+                    max={MAX_SUMMARY_MESSAGES}
+                    value={localSize}
+                    onFocus={() => {
+                      sizeInputFocused.current = true;
+                    }}
+                    onChange={(e) => setLocalSize(e.target.value)}
+                    onBlur={() => {
+                      sizeInputFocused.current = false;
+                      const clamped = clampSummaryCount(parsePositiveInteger(localSize) ?? 50);
+                      setLocalSize(String(clamped));
+                    }}
+                    className="w-16 rounded-md bg-[var(--card)] px-2 py-1 text-center text-xs tabular-nums text-[var(--foreground)] ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+                  />
+                </label>
+              ) : (
+                <div className="space-y-1.5">
+                  <div className="grid grid-cols-2 gap-2">
+                    <label className="space-y-1 text-[0.625rem] font-medium text-[var(--muted-foreground)]">
+                      From
+                      <input
+                        type="number"
+                        min={1}
+                        max={Math.max(1, totalMessageCount)}
+                        value={rangeStart}
+                        onFocus={() => {
+                          rangeInputFocused.current = true;
+                        }}
+                        onChange={(e) => setRangeStart(e.target.value)}
+                        onBlur={() => {
+                          rangeInputFocused.current = false;
+                          setRangeStart(String(normalizedRangeStart));
+                        }}
+                        className="w-full rounded-md bg-[var(--card)] px-2 py-1 text-center text-xs tabular-nums text-[var(--foreground)] ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+                      />
+                    </label>
+                    <label className="space-y-1 text-[0.625rem] font-medium text-[var(--muted-foreground)]">
+                      To
+                      <input
+                        type="number"
+                        min={1}
+                        max={Math.max(1, totalMessageCount)}
+                        value={rangeEnd}
+                        onFocus={() => {
+                          rangeInputFocused.current = true;
+                        }}
+                        onChange={(e) => setRangeEnd(e.target.value)}
+                        onBlur={() => {
+                          rangeInputFocused.current = false;
+                          setRangeEnd(String(normalizedRangeEnd));
+                        }}
+                        className="w-full rounded-md bg-[var(--card)] px-2 py-1 text-center text-xs tabular-nums text-[var(--foreground)] ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+                      />
+                    </label>
+                  </div>
+                  <p
+                    className={cn(
+                      "text-[0.625rem]",
+                      rangeTooLarge || !rangeMessagesLoaded ? "text-red-300" : "text-[var(--muted-foreground)]",
+                    )}
+                  >
+                    {rangeStatusText}
+                  </p>
+                </div>
+              )}
+            </div>
+          )}
+
+          <button
+            onClick={handleGenerate}
+            disabled={isGenerating || !canGenerate}
+            className={cn(
+              "mt-2 flex w-full items-center justify-center gap-1.5 rounded-lg px-3 py-2 text-xs font-semibold transition-all",
+              isGenerating || !canGenerate
+                ? "cursor-not-allowed bg-[var(--secondary)] text-[var(--muted-foreground)]"
+                : "bg-gradient-to-r from-amber-400 to-orange-500 text-white shadow-sm hover:shadow-md active:scale-[0.98]",
+            )}
+            title="Generate summary with AI"
+          >
+            {isGenerating ? <Loader2 size="0.8125rem" className="animate-spin" /> : <Sparkles size="0.8125rem" />}
+            {isGenerating ? "Generating..." : "Generate"}
+          </button>
         </div>
 
         {/* Info tip */}

--- a/packages/client/src/components/chat/SummaryPopover.tsx
+++ b/packages/client/src/components/chat/SummaryPopover.tsx
@@ -5,14 +5,32 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { createPortal } from "react-dom";
 import { useBulkSetMessagesHiddenFromAI, useGenerateSummary, useUpdateChatMetadata } from "../../hooks/use-chats";
-import { Info, Loader2, Save, ScrollText, Settings2, Sparkles, X } from "lucide-react";
-import { cn } from "../../lib/utils";
+import {
+  Check,
+  ChevronDown,
+  Copy,
+  Info,
+  Loader2,
+  PenLine,
+  Plus,
+  Save,
+  ScrollText,
+  Settings2,
+  Sparkles,
+  Trash2,
+  X,
+} from "lucide-react";
+import { cn, generateClientId } from "../../lib/utils";
 import { useUIStore } from "../../stores/ui.store";
+import { DEFAULT_AGENT_PROMPTS, type ChatSummaryPromptTemplate } from "@marinara-engine/shared";
+import { showConfirmDialog } from "../../lib/app-dialogs";
 
 interface SummaryPopoverProps {
   chatId: string;
   summary: string | null;
   contextSize: number;
+  promptTemplates?: ChatSummaryPromptTemplate[];
+  activePromptTemplateId?: string | null;
   totalMessageCount: number;
   onClose: () => void;
 }
@@ -21,6 +39,13 @@ type SummarySourceMode = "last" | "range";
 
 const MIN_SUMMARY_MESSAGES = 5;
 const MAX_SUMMARY_MESSAGES = 200;
+const SUMMARY_HEADING_PATTERN = /^(?:#{1,6}\s*)?(?:\*\*)?([^:\n]{3,80})(?:\*\*)?:\s*$/;
+const SUMMARY_BULLET_PATTERN = /^[-*•]\s+/;
+
+interface SummarySection {
+  title: string | null;
+  lines: string[];
+}
 
 function clampSummaryCount(value: number): number {
   return Math.max(MIN_SUMMARY_MESSAGES, Math.min(MAX_SUMMARY_MESSAGES, value));
@@ -31,15 +56,58 @@ function parsePositiveInteger(value: string): number | null {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
 }
 
+function formatSummaryHeading(value: string): string {
+  return value.replace(/^#+\s*/, "").replace(/^\*\*|\*\*$/g, "").trim();
+}
+
+function parseSummarySections(value: string): SummarySection[] {
+  const sections: SummarySection[] = [];
+  let current: SummarySection = { title: null, lines: [] };
+
+  for (const rawLine of value.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line) {
+      if (current.lines.length > 0 && current.lines[current.lines.length - 1] !== "") {
+        current.lines.push("");
+      }
+      continue;
+    }
+
+    const headingMatch = line.match(SUMMARY_HEADING_PATTERN);
+    if (headingMatch && !SUMMARY_BULLET_PATTERN.test(line)) {
+      if (current.title || current.lines.some(Boolean)) sections.push(current);
+      current = { title: formatSummaryHeading(headingMatch[1] ?? line), lines: [] };
+      continue;
+    }
+
+    current.lines.push(line);
+  }
+
+  if (current.title || current.lines.some(Boolean)) sections.push(current);
+
+  if (sections.length === 0 && value.trim()) {
+    return [{ title: null, lines: [value.trim()] }];
+  }
+
+  return sections;
+}
+
 export function SummaryPopover({
   chatId,
   summary,
   contextSize,
+  promptTemplates = [],
+  activePromptTemplateId = null,
   totalMessageCount,
   onClose,
 }: SummaryPopoverProps) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(summary ?? "");
+  const [templateEditorOpen, setTemplateEditorOpen] = useState(false);
+  const [templateSelectOpen, setTemplateSelectOpen] = useState(false);
+  const [editingTemplateId, setEditingTemplateId] = useState<string | null>(null);
+  const [templateNameDraft, setTemplateNameDraft] = useState("");
+  const [templatePromptDraft, setTemplatePromptDraft] = useState("");
   const summaryPopoverSettings = useUIStore((s) => s.summaryPopoverSettings);
   const setSummaryPopoverSettings = useUIStore((s) => s.setSummaryPopoverSettings);
   const persistedContextSize = summaryPopoverSettings.contextSize ?? contextSize;
@@ -138,6 +206,21 @@ export function SummaryPopover({
   const rangeStatusText = rangeTooLarge
       ? `Choose ${MAX_SUMMARY_MESSAGES} messages or fewer.`
       : `${selectedRangeCount} ${selectedRangeCount === 1 ? "message" : "messages"} selected.`;
+  const cleanedPromptTemplates = promptTemplates.filter(
+    (template) =>
+      typeof template.id === "string" &&
+      template.id.trim().length > 0 &&
+      typeof template.name === "string" &&
+      typeof template.prompt === "string" &&
+      template.prompt.trim().length > 0,
+  );
+  const activePromptTemplate = activePromptTemplateId
+    ? cleanedPromptTemplates.find((template) => template.id === activePromptTemplateId)
+    : null;
+  const promptTemplateSummary = activePromptTemplate?.name ?? "Built-in default";
+  const isEditingExistingTemplate = !!editingTemplateId;
+  const hasTemplateDraft = templateNameDraft.trim().length > 0 && templatePromptDraft.trim().length > 0;
+  const summarySections = parseSummarySections(draft);
 
   const handleSourceModeChange = useCallback(
     (mode: SummarySourceMode) => {
@@ -162,7 +245,7 @@ export function SummaryPopover({
       setRangeStart(String(rangeLow));
       setRangeEnd(String(rangeHigh));
       generateSummary.mutate(
-        { chatId, rangeStartIndex: rangeLow, rangeEndIndex: rangeHigh },
+        { chatId, rangeStartIndex: rangeLow, rangeEndIndex: rangeHigh, promptTemplateId: activePromptTemplateId },
         {
           onSuccess: (data) => {
             setDraft(data.summary);
@@ -176,7 +259,7 @@ export function SummaryPopover({
     setLocalSize(String(normalizedLastSize));
     setSummaryPopoverSettings({ contextSize: normalizedLastSize });
     generateSummary.mutate(
-      { chatId, contextSize: normalizedLastSize },
+      { chatId, contextSize: normalizedLastSize, promptTemplateId: activePromptTemplateId },
       {
         onSuccess: (data) => {
           setDraft(data.summary);
@@ -195,6 +278,7 @@ export function SummaryPopover({
     rangeLow,
     setSummaryPopoverSettings,
     sourceMode,
+    activePromptTemplateId,
     summaryPopoverSettings.hideSummarisedMessages,
   ]);
 
@@ -202,6 +286,111 @@ export function SummaryPopover({
     updateMeta.mutate({ id: chatId, summary: draft || null });
     setEditing(false);
   }, [chatId, draft, updateMeta]);
+
+  const persistPromptTemplates = useCallback(
+    (templates: ChatSummaryPromptTemplate[], activeId: string | null) => {
+      updateMeta.mutate({
+        id: chatId,
+        summaryPromptTemplates: templates,
+        activeSummaryPromptTemplateId: activeId,
+      });
+    },
+    [chatId, updateMeta],
+  );
+
+  const handleSelectPromptTemplate = useCallback(
+    (templateId: string | null) => {
+      persistPromptTemplates(cleanedPromptTemplates, templateId);
+      setTemplateSelectOpen(false);
+    },
+    [cleanedPromptTemplates, persistPromptTemplates],
+  );
+
+  const resetTemplateDraft = useCallback(() => {
+    setEditingTemplateId(null);
+    setTemplateNameDraft("");
+    setTemplatePromptDraft("");
+  }, []);
+
+  const handleEditPromptTemplate = useCallback((template: ChatSummaryPromptTemplate) => {
+    setEditingTemplateId(template.id);
+    setTemplateNameDraft(template.name);
+    setTemplatePromptDraft(template.prompt);
+    setTemplateEditorOpen(true);
+  }, []);
+
+  const handleNewPromptTemplate = useCallback(() => {
+    setEditingTemplateId(null);
+    setTemplateNameDraft(`Summary Style ${cleanedPromptTemplates.length + 1}`);
+    setTemplatePromptDraft(DEFAULT_AGENT_PROMPTS["chat-summary"] ?? "");
+    setTemplateEditorOpen(true);
+  }, [cleanedPromptTemplates.length]);
+
+  const handleDuplicatePromptTemplate = useCallback(
+    (template: ChatSummaryPromptTemplate | null) => {
+      setEditingTemplateId(null);
+      setTemplateNameDraft(`${template?.name ?? "Built-in default"} copy`);
+      setTemplatePromptDraft(template?.prompt ?? DEFAULT_AGENT_PROMPTS["chat-summary"] ?? "");
+      setTemplateEditorOpen(true);
+    },
+    [],
+  );
+
+  const handleSavePromptTemplate = useCallback(() => {
+    if (!hasTemplateDraft) return;
+    const trimmedName = templateNameDraft.trim().slice(0, 80);
+    const trimmedPrompt = templatePromptDraft.trim();
+    const nextTemplates = isEditingExistingTemplate
+      ? cleanedPromptTemplates.map((template) =>
+          template.id === editingTemplateId ? { ...template, name: trimmedName, prompt: trimmedPrompt } : template,
+        )
+      : [
+          ...cleanedPromptTemplates,
+          {
+            id: generateClientId(),
+            name: trimmedName,
+            prompt: trimmedPrompt,
+          },
+        ];
+    const nextActiveId = isEditingExistingTemplate ? activePromptTemplateId : nextTemplates[nextTemplates.length - 1]!.id;
+    persistPromptTemplates(nextTemplates, nextActiveId ?? null);
+    resetTemplateDraft();
+  }, [
+    activePromptTemplateId,
+    cleanedPromptTemplates,
+    editingTemplateId,
+    hasTemplateDraft,
+    isEditingExistingTemplate,
+    persistPromptTemplates,
+    resetTemplateDraft,
+    templateNameDraft,
+    templatePromptDraft,
+  ]);
+
+  const handleDeletePromptTemplate = useCallback(
+    async (templateId: string) => {
+      const target = cleanedPromptTemplates.find((template) => template.id === templateId);
+      if (!target) return;
+      const confirmed = await showConfirmDialog({
+        title: "Delete summary template?",
+        message: `Delete "${target.name}" from this chat? Existing summaries will stay unchanged.`,
+        confirmLabel: "Delete",
+        cancelLabel: "Cancel",
+        tone: "destructive",
+      });
+      if (!confirmed) return;
+      const nextTemplates = cleanedPromptTemplates.filter((template) => template.id !== templateId);
+      persistPromptTemplates(nextTemplates, activePromptTemplateId === templateId ? null : activePromptTemplateId);
+      if (editingTemplateId === templateId) resetTemplateDraft();
+    },
+    [
+      activePromptTemplateId,
+      cleanedPromptTemplates,
+      editingTemplateId,
+      persistPromptTemplates,
+      resetTemplateDraft,
+    ],
+  );
 
   const isGenerating = generateSummary.isPending;
 
@@ -222,22 +411,25 @@ export function SummaryPopover({
       <div
         className={cn(
           "relative rounded-xl border border-[var(--border)] bg-[var(--card)] shadow-2xl shadow-black/40",
-          isMobile ? "relative w-full max-w-sm max-h-[calc(100dvh-4rem)] overflow-y-auto" : "w-80",
+          isMobile ? "relative w-full max-w-sm max-h-[calc(100dvh-4rem)] overflow-y-auto" : "w-[22rem]",
         )}
       >
         {/* Header */}
-        <div className="flex items-center justify-between border-b border-[var(--border)] px-3 py-2">
-          <div className="flex items-center gap-1.5 text-xs font-semibold">
-            <ScrollText size="0.8125rem" className="text-amber-400" />
-            Chat Summary
+        <div className="flex items-start justify-between gap-3 border-b border-[var(--border)] px-3 py-2.5">
+          <div className="min-w-0 space-y-0.5">
+            <div className="flex min-w-0 items-center gap-1.5 text-xs font-semibold">
+              <ScrollText size="0.8125rem" className="shrink-0 text-[var(--muted-foreground)]" />
+              <span className="truncate">Chat Summary</span>
+            </div>
+            <p className="truncate text-[0.625rem] text-[var(--muted-foreground)]">{sourceSummary}</p>
           </div>
-          <div className="flex items-center gap-1">
+          <div className="flex shrink-0 items-center gap-1">
             <button
               type="button"
               onClick={() => setScopeSettingsOpen((open) => !open)}
               className={cn(
                 "rounded-md p-1 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--ring)]",
-                scopeSettingsOpen && "bg-[var(--accent)] text-amber-300",
+                scopeSettingsOpen && "bg-[var(--accent)] text-[var(--foreground)] ring-1 ring-[var(--border)]",
               )}
               title="Summary source settings"
               aria-label="Summary source settings"
@@ -257,8 +449,8 @@ export function SummaryPopover({
         </div>
 
         {scopeSettingsOpen && (
-          <div className="absolute right-2 top-10 z-10 w-[calc(100%-1rem)] max-w-72 rounded-xl border border-[var(--border)] bg-[var(--popover)] p-2 text-[var(--popover-foreground)] shadow-xl shadow-black/30 ring-1 ring-white/5">
-            <div className="mb-2 flex items-start justify-between gap-3 px-1">
+          <div className="absolute right-2 top-12 z-10 max-h-[min(34rem,calc(100vh-7rem))] w-[calc(100%-1rem)] max-w-80 overflow-y-auto rounded-xl border border-[var(--border)] bg-[var(--popover)] p-2.5 text-[var(--popover-foreground)] shadow-xl shadow-black/30 ring-1 ring-white/5">
+            <div className="mb-2.5 flex items-start justify-between gap-3 px-1">
               <div className="min-w-0">
                 <p className="text-[0.625rem] font-semibold uppercase text-[var(--muted-foreground)]">
                   Summary Scope
@@ -270,7 +462,7 @@ export function SummaryPopover({
               </span>
             </div>
 
-            <div className="space-y-2 rounded-lg border border-[var(--border)] bg-[var(--secondary)]/40 p-2">
+            <div className="space-y-2 rounded-lg border border-[var(--border)] bg-[var(--secondary)]/40 p-2.5">
               <div className="grid grid-cols-2 gap-1 rounded-lg bg-[var(--background)]/30 p-1">
                 {(["last", "range"] as const).map((mode) => (
                   <button
@@ -280,7 +472,7 @@ export function SummaryPopover({
                     className={cn(
                       "rounded-md px-2 py-1 text-[0.625rem] font-semibold transition-colors",
                       sourceMode === mode
-                        ? "bg-amber-400/20 text-amber-200 ring-1 ring-amber-300/30"
+                        ? "bg-[var(--accent)] text-[var(--foreground)] ring-1 ring-[var(--border)]"
                         : "text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]",
                     )}
                   >
@@ -386,23 +578,179 @@ export function SummaryPopover({
               )}
             </div>
 
-            <div className="space-y-1.5 pt-1">
-              <SummarySettingsToggle
-                label="Hide summarised messages"
-                checked={summaryPopoverSettings.hideSummarisedMessages}
-                onChange={(checked) => setSummaryPopoverSettings({ hideSummarisedMessages: checked })}
-              />
-              <SummarySettingsToggle
-                label="Collapse hidden messages"
-                checked={summaryPopoverSettings.collapseHiddenMessages}
-                onChange={(checked) => setSummaryPopoverSettings({ collapseHiddenMessages: checked })}
-              />
+            <div className="space-y-2 pt-2">
+              <div className="space-y-2 rounded-lg border border-[var(--border)] bg-[var(--secondary)]/35 p-2.5">
+                <div className="flex items-start justify-between gap-2">
+                  <div className="min-w-0">
+                    <p className="text-[0.625rem] font-semibold uppercase text-[var(--muted-foreground)]">
+                      Summary Prompt
+                    </p>
+                    <p className="truncate text-xs font-semibold text-[var(--popover-foreground)]">
+                      {promptTemplateSummary}
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setTemplateEditorOpen((open) => !open);
+                      if (templateEditorOpen) resetTemplateDraft();
+                    }}
+                    className={cn(
+                      "shrink-0 rounded-md px-2 py-1 text-[0.625rem] font-semibold transition-colors",
+                      templateEditorOpen
+                        ? "bg-[var(--accent)] text-[var(--foreground)] ring-1 ring-[var(--border)]"
+                        : "text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]",
+                    )}
+                  >
+                    {templateEditorOpen ? "Done" : "Manage"}
+                  </button>
+                </div>
+
+                <div className="grid grid-cols-[1fr_auto] gap-1">
+                  <div className="relative min-w-0">
+                    <button
+                      type="button"
+                      onClick={() => setTemplateSelectOpen((open) => !open)}
+                      className="flex w-full min-w-0 items-center justify-between gap-2 rounded-md bg-[var(--card)] py-1 pl-2 pr-2 text-left text-[0.6875rem] text-[var(--foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+                      aria-haspopup="listbox"
+                      aria-expanded={templateSelectOpen}
+                      aria-label="Summary prompt template"
+                    >
+                      <span className="min-w-0 truncate">{promptTemplateSummary}</span>
+                      <ChevronDown
+                        size="0.75rem"
+                        className={cn(
+                          "shrink-0 text-[var(--muted-foreground)] transition-transform",
+                          templateSelectOpen && "rotate-180",
+                        )}
+                      />
+                    </button>
+                    {templateSelectOpen && (
+                      <div
+                        role="listbox"
+                        className="absolute left-0 right-0 top-[calc(100%+0.25rem)] z-20 max-h-40 overflow-y-auto rounded-md border border-[var(--border)] bg-[var(--popover)] p-1 text-[var(--popover-foreground)] shadow-xl shadow-black/25"
+                      >
+                        <SummaryPromptSelectOption
+                          active={!activePromptTemplateId}
+                          label="Built-in default"
+                          onSelect={() => handleSelectPromptTemplate(null)}
+                        />
+                        {cleanedPromptTemplates.map((template) => (
+                          <SummaryPromptSelectOption
+                            key={template.id}
+                            active={activePromptTemplateId === template.id}
+                            label={template.name}
+                            onSelect={() => handleSelectPromptTemplate(template.id)}
+                          />
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => handleDuplicatePromptTemplate(activePromptTemplate ?? null)}
+                    className="rounded-md p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+                    title="Copy current prompt to a new template"
+                    aria-label="Copy current prompt to a new template"
+                  >
+                    <Copy size="0.75rem" />
+                  </button>
+                </div>
+
+                {templateEditorOpen && (
+                  <div className="space-y-2 border-t border-[var(--border)] pt-2">
+                    <div className="max-h-28 space-y-1 overflow-y-auto pr-0.5">
+                      <SummaryPromptTemplateRow
+                        active={!activePromptTemplateId}
+                        name="Built-in default"
+                        detail="App default"
+                        onSelect={() => persistPromptTemplates(cleanedPromptTemplates, null)}
+                        onCopy={() => handleDuplicatePromptTemplate(null)}
+                      />
+                      {cleanedPromptTemplates.map((template) => (
+                        <SummaryPromptTemplateRow
+                          key={template.id}
+                          active={activePromptTemplateId === template.id}
+                          name={template.name}
+                          detail={`${Math.ceil(template.prompt.length / 4)} tokens est.`}
+                          onSelect={() => persistPromptTemplates(cleanedPromptTemplates, template.id)}
+                          onCopy={() => handleDuplicatePromptTemplate(template)}
+                          onEdit={() => handleEditPromptTemplate(template)}
+                          onDelete={() => void handleDeletePromptTemplate(template.id)}
+                        />
+                      ))}
+                    </div>
+
+                    <button
+                      type="button"
+                      onClick={handleNewPromptTemplate}
+                      className="flex w-full items-center justify-center gap-1.5 rounded-md border border-dashed border-[var(--border)] bg-[var(--accent)]/35 px-2 py-1.5 text-[0.625rem] font-semibold text-[var(--foreground)] transition-colors hover:bg-[var(--accent)]"
+                    >
+                      <Plus size="0.6875rem" />
+                      New template
+                    </button>
+
+                    {(templateNameDraft || templatePromptDraft) && (
+                      <div className="space-y-1.5 rounded-lg bg-[var(--background)]/30 p-2 ring-1 ring-[var(--border)]">
+                        <input
+                          value={templateNameDraft}
+                          onChange={(event) => setTemplateNameDraft(event.target.value)}
+                          maxLength={80}
+                          placeholder="Template name"
+                          className="w-full rounded-md bg-[var(--card)] px-2 py-1 text-[0.6875rem] font-semibold text-[var(--foreground)] ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+                        />
+                        <textarea
+                          value={templatePromptDraft}
+                          onChange={(event) => setTemplatePromptDraft(event.target.value)}
+                          rows={8}
+                          placeholder="Prompt instructions for manual summary generation..."
+                          className="max-h-48 w-full resize-y rounded-md bg-[var(--card)] px-2 py-1.5 font-mono text-[0.625rem] leading-relaxed text-[var(--foreground)] ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+                        />
+                        <div className="flex justify-end gap-1">
+                          <button
+                            type="button"
+                            onClick={resetTemplateDraft}
+                            className="rounded-md px-2 py-1 text-[0.625rem] font-medium text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)]"
+                          >
+                            Cancel
+                          </button>
+                          <button
+                            type="button"
+                            onClick={handleSavePromptTemplate}
+                            disabled={!hasTemplateDraft || updateMeta.isPending}
+                            className="flex items-center gap-1 rounded-md bg-[var(--secondary)] px-2 py-1 text-[0.625rem] font-semibold text-[var(--foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-50"
+                          >
+                            <Save size="0.625rem" />
+                            {isEditingExistingTemplate ? "Save" : "Add"}
+                          </button>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+
+              <div className="space-y-1 rounded-lg border border-[var(--border)] bg-[var(--secondary)]/25 p-2">
+                <p className="px-1 text-[0.625rem] font-semibold uppercase text-[var(--muted-foreground)]">
+                  Display
+                </p>
+                <SummarySettingsToggle
+                  label="Hide summarised messages"
+                  checked={summaryPopoverSettings.hideSummarisedMessages}
+                  onChange={(checked) => setSummaryPopoverSettings({ hideSummarisedMessages: checked })}
+                />
+                <SummarySettingsToggle
+                  label="Collapse hidden messages"
+                  checked={summaryPopoverSettings.collapseHiddenMessages}
+                  onChange={(checked) => setSummaryPopoverSettings({ collapseHiddenMessages: checked })}
+                />
+              </div>
             </div>
           </div>
         )}
 
         {/* Body */}
-        <div className="max-h-72 overflow-y-auto p-3">
+        <div className="max-h-80 overflow-y-auto p-3">
           {editing ? (
             <div className="space-y-2">
               <textarea
@@ -426,7 +774,7 @@ export function SummaryPopover({
                 <button
                   onClick={handleSave}
                   disabled={updateMeta.isPending}
-                  className="flex items-center gap-1 rounded-lg bg-gradient-to-r from-amber-400 to-orange-500 px-2.5 py-1 text-[0.625rem] font-medium text-white shadow-sm transition-all hover:shadow-md active:scale-[0.98] disabled:opacity-50"
+                  className="flex items-center gap-1 rounded-lg bg-[var(--secondary)] px-2.5 py-1 text-[0.625rem] font-medium text-[var(--foreground)] ring-1 ring-[var(--border)] transition-all hover:bg-[var(--accent)] active:scale-[0.98] disabled:opacity-50"
                 >
                   <Save size="0.625rem" />
                   Save
@@ -437,15 +785,23 @@ export function SummaryPopover({
             <div>
               {draft ? (
                 <div
-                  className="cursor-pointer rounded-lg p-2 transition-colors hover:bg-[var(--accent)]"
+                  className="cursor-pointer rounded-lg border border-[var(--border)] bg-[var(--secondary)]/25 p-3 transition-colors hover:bg-[var(--accent)]/45"
                   onClick={() => setEditing(true)}
                   title="Click to edit"
                 >
-                  <p className="whitespace-pre-wrap text-xs leading-relaxed text-[var(--foreground)]/80">{draft}</p>
+                  <div className="space-y-3">
+                    {summarySections.map((section, sectionIndex) => (
+                      <SummaryReadableSection
+                        key={`${section.title ?? "summary"}-${sectionIndex}`}
+                        section={section}
+                        sectionIndex={sectionIndex}
+                      />
+                    ))}
+                  </div>
                 </div>
               ) : (
                 <div
-                  className="cursor-pointer rounded-lg p-4 transition-colors hover:bg-[var(--accent)]"
+                  className="cursor-pointer rounded-lg border border-dashed border-[var(--border)] bg-[var(--secondary)]/20 p-5 transition-colors hover:bg-[var(--accent)]/35"
                   onClick={() => setEditing(true)}
                 >
                   <p className="text-center text-xs italic text-[var(--muted-foreground)]">
@@ -458,10 +814,10 @@ export function SummaryPopover({
         </div>
 
         {/* Source controls */}
-        <div className="border-t border-[var(--border)] px-3 py-2">
-          <div className="mb-2 flex items-center justify-between gap-2 px-2 text-[0.625rem] text-[var(--muted-foreground)]">
-            <span className="truncate">Source: {sourceSummary}</span>
-            <span className="shrink-0">{sourceDetail}</span>
+        <div className="border-t border-[var(--border)] px-3 py-2.5">
+          <div className="mb-2 grid grid-cols-[1fr_auto] items-center gap-2 rounded-lg bg-[var(--secondary)]/25 px-2.5 py-1.5 text-[0.625rem] text-[var(--muted-foreground)]">
+            <span className="min-w-0 truncate">Source: {sourceSummary}</span>
+            <span className="shrink-0 text-right">{sourceDetail}</span>
           </div>
 
           <button
@@ -471,7 +827,7 @@ export function SummaryPopover({
               "mt-2 flex w-full items-center justify-center gap-1.5 rounded-lg px-3 py-2 text-xs font-semibold transition-all",
               isGenerating || !canGenerate
                 ? "cursor-not-allowed bg-[var(--secondary)] text-[var(--muted-foreground)]"
-                : "bg-gradient-to-r from-amber-400 to-orange-500 text-white shadow-sm hover:shadow-md active:scale-[0.98]",
+                : "bg-[var(--secondary)] text-[var(--foreground)] ring-1 ring-[var(--border)] hover:bg-[var(--accent)] active:scale-[0.98]",
             )}
             title="Generate summary with AI"
           >
@@ -481,9 +837,9 @@ export function SummaryPopover({
         </div>
 
         {/* Info tip */}
-        <div className="border-t border-[var(--border)] px-3 py-2">
+        <div className="border-t border-[var(--border)] bg-[var(--secondary)]/15 px-3 py-2">
           <p className="flex items-start gap-1.5 text-[0.625rem] leading-relaxed text-[var(--muted-foreground)]">
-            <Info size="0.6875rem" className="mt-0.5 shrink-0 text-amber-400/70" />
+            <Info size="0.6875rem" className="mt-0.5 shrink-0 text-[var(--muted-foreground)]" />
             <span>
               Use the Generate button above to update the summary manually. Add an{" "}
               <strong className="font-medium text-[var(--foreground)]/70">Automated Chat Summary</strong> agent to the
@@ -506,14 +862,173 @@ interface SummarySettingsToggleProps {
 
 function SummarySettingsToggle({ label, checked, onChange }: SummarySettingsToggleProps) {
   return (
-    <label className="flex cursor-pointer items-center justify-between gap-3 rounded-lg px-1.5 py-1 text-[0.6875rem] text-[var(--popover-foreground)] transition-colors hover:bg-[var(--accent)]/50">
+    <label className="flex cursor-pointer items-center justify-between gap-3 rounded-md px-1.5 py-1.5 text-[0.6875rem] text-[var(--popover-foreground)] transition-colors hover:bg-[var(--accent)]/50">
       <span className="min-w-0 truncate">{label}</span>
       <input
         type="checkbox"
         checked={checked}
         onChange={(event) => onChange(event.target.checked)}
-        className="h-3.5 w-3.5 shrink-0 accent-amber-400"
+        className="h-3.5 w-3.5 shrink-0 accent-[var(--muted-foreground)]"
       />
     </label>
+  );
+}
+
+interface SummaryReadableSectionProps {
+  section: SummarySection;
+  sectionIndex: number;
+}
+
+function SummaryReadableSection({ section, sectionIndex }: SummaryReadableSectionProps) {
+  const paragraphs = section.lines.join("\n").split(/\n\s*\n/).filter((paragraph) => paragraph.trim().length > 0);
+
+  return (
+    <section className="space-y-1.5">
+      {section.title && (
+        <div className="flex items-center gap-2">
+          <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-[var(--accent)] text-[0.625rem] font-semibold text-[var(--foreground)] ring-1 ring-[var(--border)]">
+            {sectionIndex + 1}
+          </span>
+          <h3 className="min-w-0 truncate text-[0.6875rem] font-semibold uppercase text-[var(--muted-foreground)]">
+            {section.title}
+          </h3>
+        </div>
+      )}
+      <div className={cn("space-y-2", section.title && "pl-7")}>
+        {paragraphs.map((paragraph, paragraphIndex) => {
+          const lines = paragraph.split("\n").filter((line) => line.trim().length > 0);
+          const isBulletList = lines.length > 0 && lines.every((line) => SUMMARY_BULLET_PATTERN.test(line.trim()));
+
+          if (isBulletList) {
+            return (
+              <ul key={paragraphIndex} className="space-y-1 text-xs leading-relaxed text-[var(--foreground)]/85">
+                {lines.map((line, lineIndex) => (
+                  <li key={lineIndex} className="grid grid-cols-[0.75rem_1fr] gap-1.5">
+                    <span className="pt-[0.1875rem] text-[var(--muted-foreground)]">•</span>
+                    <span>{line.replace(SUMMARY_BULLET_PATTERN, "")}</span>
+                  </li>
+                ))}
+              </ul>
+            );
+          }
+
+          return (
+            <p key={paragraphIndex} className="whitespace-pre-wrap text-xs leading-relaxed text-[var(--foreground)]/85">
+              {paragraph}
+            </p>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+interface SummaryPromptSelectOptionProps {
+  active: boolean;
+  label: string;
+  onSelect: () => void;
+}
+
+function SummaryPromptSelectOption({ active, label, onSelect }: SummaryPromptSelectOptionProps) {
+  return (
+    <button
+      type="button"
+      role="option"
+      aria-selected={active}
+      onClick={onSelect}
+      className={cn(
+        "flex w-full min-w-0 items-center gap-1.5 rounded px-2 py-1.5 text-left text-[0.6875rem] transition-colors",
+        active
+          ? "bg-[var(--accent)] text-[var(--popover-foreground)] ring-1 ring-[var(--border)]"
+          : "text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]",
+      )}
+    >
+      <Check size="0.625rem" className={cn("shrink-0", active ? "opacity-100" : "opacity-0")} />
+      <span className="min-w-0 truncate">{label}</span>
+    </button>
+  );
+}
+
+interface SummaryPromptTemplateRowProps {
+  active: boolean;
+  name: string;
+  detail: string;
+  onSelect: () => void;
+  onCopy: () => void;
+  onEdit?: () => void;
+  onDelete?: () => void;
+}
+
+function SummaryPromptTemplateRow({
+  active,
+  name,
+  detail,
+  onSelect,
+  onCopy,
+  onEdit,
+  onDelete,
+}: SummaryPromptTemplateRowProps) {
+  return (
+    <div
+      className={cn(
+        "group flex items-center gap-1 rounded-md px-1.5 py-1 transition-colors",
+        active ? "bg-[var(--accent)] text-[var(--foreground)] ring-1 ring-[var(--border)]" : "hover:bg-[var(--accent)]/45",
+      )}
+    >
+      <button
+        type="button"
+        onClick={onSelect}
+        className="flex min-w-0 flex-1 items-center gap-1.5 text-left"
+        title={`Use ${name}`}
+      >
+        <span
+          className={cn(
+            "flex h-4 w-4 shrink-0 items-center justify-center rounded-full ring-1",
+            active
+              ? "bg-[var(--accent)] text-[var(--foreground)] ring-[var(--border)]"
+              : "text-transparent ring-[var(--border)]",
+          )}
+        >
+          <Check size="0.625rem" />
+        </span>
+        <span className="min-w-0">
+          <span className="block truncate text-[0.6875rem] font-semibold text-[var(--popover-foreground)]">
+            {name}
+          </span>
+          <span className="block truncate text-[0.5625rem] text-[var(--muted-foreground)]">{detail}</span>
+        </span>
+      </button>
+      <button
+        type="button"
+        onClick={onCopy}
+        className="shrink-0 rounded p-1 text-[var(--muted-foreground)] opacity-80 transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+        title="Duplicate template"
+        aria-label="Duplicate template"
+      >
+        <Copy size="0.625rem" />
+      </button>
+      {onEdit && (
+        <button
+          type="button"
+          onClick={onEdit}
+          className="shrink-0 rounded p-1 text-[var(--muted-foreground)] opacity-80 transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+          title="Edit template"
+          aria-label="Edit template"
+        >
+          <PenLine size="0.625rem" />
+        </button>
+      )}
+      {onDelete && (
+        <button
+          type="button"
+          onClick={onDelete}
+          className="shrink-0 rounded p-1 text-[var(--muted-foreground)] opacity-80 transition-colors hover:bg-[var(--destructive)]/15 hover:text-[var(--destructive)]"
+          title="Delete template"
+          aria-label="Delete template"
+        >
+          <Trash2 size="0.625rem" />
+        </button>
+      )}
+    </div>
   );
 }

--- a/packages/client/src/components/chat/SummaryPopover.tsx
+++ b/packages/client/src/components/chat/SummaryPopover.tsx
@@ -288,8 +288,9 @@ export function SummaryPopover({
     (total, entry) => (entry.enabled ? total + entry.tokenEstimate : total),
     0,
   );
+  const hasPersistedEntries = displayEntries.length > 0;
   const hasEntries = visibleEntries.length > 0;
-  const allEntriesDisabled = hasEntries && enabledEntryCount === 0;
+  const allEntriesDisabled = hasPersistedEntries && enabledEntryCount === 0;
   const tokenWarning = enabledTokenEstimate > SUMMARY_TOKEN_WARNING_THRESHOLD;
   const entryMutationPending =
     updateSummaryEntry.isPending || deleteSummaryEntry.isPending || toggleSummaryEntry.isPending;
@@ -400,22 +401,31 @@ export function SummaryPopover({
       toast.error("Summary content is required.");
       return;
     }
-    try {
-      await updateSummaryEntry.mutateAsync({
-        chatId,
-        entry: {
+    const existingEntry = displayEntries.find((entry) => entry.id === draftEntry.id);
+    const entryPayload = existingEntry
+      ? {
+          id: draftEntry.id,
+          title,
+          content,
+          tokenEstimate: estimateChatSummaryTokens(content),
+        }
+      : {
           ...draftEntry,
           title,
           content,
           tokenEstimate: estimateChatSummaryTokens(content),
-        },
+        };
+    try {
+      await updateSummaryEntry.mutateAsync({
+        chatId,
+        entry: entryPayload,
       });
       setEditingEntryId(null);
       setDraftEntry(null);
     } catch {
       toast.error("Could not save summary entry.");
     }
-  }, [chatId, draftEntry, updateSummaryEntry]);
+  }, [chatId, displayEntries, draftEntry, updateSummaryEntry]);
 
   const handleToggleEntry = useCallback(
     async (entry: ChatSummaryEntry, enabled: boolean) => {

--- a/packages/client/src/components/chat/SummaryPopover.tsx
+++ b/packages/client/src/components/chat/SummaryPopover.tsx
@@ -2,7 +2,7 @@
 // Summary Popover — View / edit / generate chat summary
 // Shown via the scroll icon in the chat header bar.
 // ──────────────────────────────────────────────
-import { useState, useEffect, useRef, useCallback, useMemo, type ReactNode, type RefObject } from "react";
+import { useState, useEffect, useRef, useCallback, useMemo, type MouseEvent, type RefObject } from "react";
 import { createPortal } from "react-dom";
 import {
   useBulkSetMessagesHiddenFromAI,
@@ -14,10 +14,8 @@ import {
 } from "../../hooks/use-chats";
 import {
   Check,
-  ChevronDown,
   ChevronRight,
   Copy,
-  Info,
   Loader2,
   PenLine,
   Plus,
@@ -128,6 +126,10 @@ function getSummaryEntrySourceLabel(entry: ChatSummaryEntry): string | null {
   return null;
 }
 
+function getSummaryEntryMetaLine(entry: ChatSummaryEntry): string {
+  return [getSummaryEntrySourceLabel(entry), `~${formatTokenCount(entry.tokenEstimate)} tokens`].filter(Boolean).join(" · ");
+}
+
 function createBlankManualSummaryEntry(): ChatSummaryEntry {
   const now = new Date().toISOString();
   return {
@@ -159,6 +161,7 @@ export function SummaryPopover({
   const [draftEntry, setDraftEntry] = useState<ChatSummaryEntry | null>(null);
   const [templateEditorOpen, setTemplateEditorOpen] = useState(false);
   const [templateSelectOpen, setTemplateSelectOpen] = useState(false);
+  const [showInactiveSummaries, setShowInactiveSummaries] = useState(false);
   const [editingTemplateId, setEditingTemplateId] = useState<string | null>(null);
   const [templateNameDraft, setTemplateNameDraft] = useState("");
   const [templatePromptDraft, setTemplatePromptDraft] = useState("");
@@ -184,6 +187,8 @@ export function SummaryPopover({
   const toggleSummaryEntry = useToggleSummaryEntry();
   const entryTextareaRef = useRef<HTMLTextAreaElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
+  const scopeSettingsButtonRef = useRef<HTMLButtonElement>(null);
+  const scopeSettingsRef = useRef<HTMLDivElement>(null);
 
   // Close on click outside — defer by one frame so the synthesised
   // mousedown from the tap that *opened* the popover doesn't
@@ -211,6 +216,19 @@ export function SummaryPopover({
     document.addEventListener("keydown", handler);
     return () => document.removeEventListener("keydown", handler);
   }, [onClose]);
+
+  // Close the settings flyout when clicking elsewhere in the summary popover.
+  useEffect(() => {
+    if (!scopeSettingsOpen) return;
+    const handler = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (scopeSettingsRef.current?.contains(target) || scopeSettingsButtonRef.current?.contains(target)) return;
+      setScopeSettingsOpen(false);
+      setTemplateSelectOpen(false);
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [scopeSettingsOpen]);
 
   // Sync local size when the persisted/default context size changes externally.
   useEffect(() => {
@@ -279,17 +297,20 @@ export function SummaryPopover({
       }),
     [summary, summaryEntries],
   );
-  const visibleEntries = useMemo(() => {
-    if (!draftEntry || displayEntries.some((entry) => entry.id === draftEntry.id)) return displayEntries;
-    return [...displayEntries, draftEntry];
-  }, [displayEntries, draftEntry]);
   const enabledEntryCount = displayEntries.filter((entry) => entry.enabled).length;
+  const inactiveEntryCount = displayEntries.length - enabledEntryCount;
+  const visibleEntries = useMemo(() => {
+    const filteredEntries = showInactiveSummaries ? displayEntries : displayEntries.filter((entry) => entry.enabled);
+    if (!draftEntry || filteredEntries.some((entry) => entry.id === draftEntry.id)) return filteredEntries;
+    return [...filteredEntries, draftEntry];
+  }, [displayEntries, draftEntry, showInactiveSummaries]);
   const enabledTokenEstimate = displayEntries.reduce(
     (total, entry) => (entry.enabled ? total + entry.tokenEstimate : total),
     0,
   );
   const hasPersistedEntries = displayEntries.length > 0;
   const hasEntries = visibleEntries.length > 0;
+  const allVisibleEntriesHidden = hasPersistedEntries && !hasEntries;
   const allEntriesDisabled = hasPersistedEntries && enabledEntryCount === 0;
   const tokenWarning = enabledTokenEstimate > SUMMARY_TOKEN_WARNING_THRESHOLD;
   const entryMutationPending =
@@ -438,6 +459,21 @@ export function SummaryPopover({
     [chatId, toggleSummaryEntry],
   );
 
+  const handleToggleAllEntries = useCallback(async () => {
+    const nextEnabled = enabledEntryCount === 0;
+    const entriesToUpdate = displayEntries.filter((entry) => entry.enabled !== nextEnabled);
+    if (entriesToUpdate.length === 0) return;
+
+    try {
+      await Promise.all(
+        entriesToUpdate.map((entry) => toggleSummaryEntry.mutateAsync({ chatId, entryId: entry.id, enabled: nextEnabled })),
+      );
+      if (nextEnabled) setShowInactiveSummaries(false);
+    } catch {
+      toast.error("Could not update summary entries.");
+    }
+  }, [chatId, displayEntries, enabledEntryCount, toggleSummaryEntry]);
+
   const handleDeleteEntry = useCallback(
     async (entry: ChatSummaryEntry) => {
       const confirmed = await showConfirmDialog({
@@ -572,10 +608,24 @@ export function SummaryPopover({
 
   const isMobile = typeof window !== "undefined" && window.innerWidth < 768;
 
+  const handlePanelMouseDown = useCallback(
+    (event: MouseEvent<HTMLDivElement>) => {
+      if (scopeSettingsOpen) {
+        const target = event.target as Node;
+        if (!scopeSettingsRef.current?.contains(target) && !scopeSettingsButtonRef.current?.contains(target)) {
+          setScopeSettingsOpen(false);
+          setTemplateSelectOpen(false);
+        }
+      }
+      event.stopPropagation();
+    },
+    [scopeSettingsOpen],
+  );
+
   const content = (
     <div
       ref={panelRef}
-      onMouseDown={(e) => e.stopPropagation()}
+      onMouseDown={handlePanelMouseDown}
       className={cn(
         isMobile
           ? "fixed inset-0 z-[9999] flex items-center justify-center p-4 max-md:pt-[max(1rem,env(safe-area-inset-top))]"
@@ -583,28 +633,29 @@ export function SummaryPopover({
       )}
     >
       {/* Mobile backdrop */}
-      {isMobile && <div className="absolute inset-0 bg-black/30" onClick={onClose} />}
+      {isMobile && <div className="absolute inset-0 bg-black/50 backdrop-blur-sm" onClick={onClose} />}
       <div
         className={cn(
-          "relative rounded-xl border border-[var(--border)] bg-[var(--card)] shadow-2xl shadow-black/40",
+          "relative overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--background)] shadow-2xl shadow-black/50 backdrop-blur-xl",
           isMobile ? "relative w-full max-w-md max-h-[calc(100dvh-4rem)] overflow-y-auto" : "w-[28rem]",
         )}
       >
         {/* Header */}
-        <div className="flex items-start justify-between gap-3 border-b border-[var(--border)] px-3 py-2.5">
-          <div className="min-w-0 space-y-0.5">
-            <div className="flex min-w-0 items-center gap-1.5 text-xs font-semibold">
+        <div className="flex items-center justify-between gap-3 border-b border-[var(--border)] bg-[var(--card)]/80 px-3 py-2.5 backdrop-blur-sm">
+          <div className="min-w-0">
+            <div className="flex min-w-0 items-center gap-1.5 text-sm font-semibold">
               <ScrollText size="0.8125rem" className="shrink-0 text-[var(--muted-foreground)]" />
               <span className="truncate">Chat Summary</span>
             </div>
             <p className="truncate text-[0.625rem] text-[var(--muted-foreground)]">
               {hasEntries
-                ? `${enabledEntryCount} enabled · ~${formatTokenCount(enabledTokenEstimate)} tokens`
+                ? `${enabledEntryCount} active · ~${formatTokenCount(enabledTokenEstimate)} tokens`
                 : "No summaries yet"}
             </p>
           </div>
           <div className="flex shrink-0 items-center gap-1">
             <button
+              ref={scopeSettingsButtonRef}
               type="button"
               onClick={() => setScopeSettingsOpen((open) => !open)}
               className={cn(
@@ -629,144 +680,44 @@ export function SummaryPopover({
         </div>
 
         {scopeSettingsOpen && (
-          <div className="absolute right-2 top-12 z-10 max-h-[min(34rem,calc(100vh-7rem))] w-[calc(100%-1rem)] max-w-80 overflow-y-auto rounded-xl border border-[var(--border)] bg-[var(--popover)] p-2.5 text-[var(--popover-foreground)] shadow-xl shadow-black/30 ring-1 ring-white/5">
-            <div className="mb-2.5 flex items-start justify-between gap-3 px-1">
+          <div
+            ref={scopeSettingsRef}
+            className="absolute right-2 top-12 z-10 max-h-[min(34rem,calc(100vh-7rem))] w-[calc(100%-1rem)] max-w-80 overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--background)] text-[var(--popover-foreground)] shadow-2xl shadow-black/50 ring-1 ring-white/5 backdrop-blur-xl"
+          >
+            <div className="flex items-center justify-between gap-3 border-b border-[var(--border)] bg-[var(--card)]/80 px-3 py-2.5 backdrop-blur-sm">
               <div className="min-w-0">
-                <p className="text-[0.625rem] font-semibold uppercase text-[var(--muted-foreground)]">
-                  Summary Scope
-                </p>
-                <p className="truncate text-xs font-semibold text-[var(--popover-foreground)]">{sourceSummary}</p>
+                <p className="text-xs font-semibold text-[var(--popover-foreground)]">Summary settings</p>
               </div>
-              <span className="shrink-0 pt-0.5 text-right text-[0.625rem] text-[var(--muted-foreground)]">
-                {sourceDetail}
-              </span>
             </div>
 
-            <div className="space-y-2 rounded-lg border border-[var(--border)] bg-[var(--secondary)]/40 p-2.5">
-              <div className="grid grid-cols-2 gap-1 rounded-lg bg-[var(--background)]/30 p-1">
-                {(["last", "range"] as const).map((mode) => (
-                  <button
-                    key={mode}
-                    type="button"
-                    onClick={() => handleSourceModeChange(mode)}
-                    className={cn(
-                      "rounded-md px-2 py-1 text-[0.625rem] font-semibold transition-colors",
-                      sourceMode === mode
-                        ? "bg-[var(--accent)] text-[var(--foreground)] ring-1 ring-[var(--border)]"
-                        : "text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]",
-                    )}
-                  >
-                    {mode === "last" ? "Last" : "Range"}
-                  </button>
-                ))}
-              </div>
-
-              {sourceMode === "last" ? (
-                <label className="flex items-center justify-between gap-2 text-[0.6875rem] text-[var(--muted-foreground)]">
-                  <span>Messages</span>
-                  <input
-                    type="number"
-                    min={MIN_SUMMARY_MESSAGES}
-                    max={MAX_SUMMARY_MESSAGES}
-                    value={localSize}
-                    onFocus={() => {
-                      sizeInputFocused.current = true;
-                    }}
-                    onChange={(e) => {
-                      setLocalSize(e.target.value);
-                      const next = parsePositiveInteger(e.target.value);
-                      if (next !== null) {
-                        setSummaryPopoverSettings({ contextSize: clampSummaryCount(next) });
-                      }
-                    }}
-                    onBlur={() => {
-                      sizeInputFocused.current = false;
-                      const clamped = clampSummaryCount(parsePositiveInteger(localSize) ?? 50);
-                      setLocalSize(String(clamped));
-                      setSummaryPopoverSettings({ contextSize: clamped });
-                    }}
-                    className="w-16 rounded-md bg-[var(--card)] px-2 py-1 text-center text-xs tabular-nums text-[var(--foreground)] ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
-                  />
-                </label>
-              ) : (
-                <div className="space-y-1.5">
-                  <div className="grid grid-cols-2 gap-2">
-                    <label className="space-y-1 text-[0.625rem] font-medium text-[var(--muted-foreground)]">
-                      From
-                      <input
-                        type="number"
-                        min={1}
-                        max={Math.max(1, totalMessageCount)}
-                        value={rangeStart}
-                        onFocus={() => {
-                          rangeInputFocused.current = true;
-                        }}
-                        onChange={(e) => {
-                          setRangeStart(e.target.value);
-                          const next = parsePositiveInteger(e.target.value);
-                          if (next !== null) {
-                            setSummaryPopoverSettings({
-                              rangeStart: Math.max(1, Math.min(totalMessageCount || 1, next)),
-                            });
-                          }
-                        }}
-                        onBlur={() => {
-                          rangeInputFocused.current = false;
-                          setRangeStart(String(normalizedRangeStart));
-                          setSummaryPopoverSettings({ rangeStart: normalizedRangeStart });
-                        }}
-                        className="w-full rounded-md bg-[var(--card)] px-2 py-1 text-center text-xs tabular-nums text-[var(--foreground)] ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
-                      />
-                    </label>
-                    <label className="space-y-1 text-[0.625rem] font-medium text-[var(--muted-foreground)]">
-                      To
-                      <input
-                        type="number"
-                        min={1}
-                        max={Math.max(1, totalMessageCount)}
-                        value={rangeEnd}
-                        onFocus={() => {
-                          rangeInputFocused.current = true;
-                        }}
-                        onChange={(e) => {
-                          setRangeEnd(e.target.value);
-                          const next = parsePositiveInteger(e.target.value);
-                          if (next !== null) {
-                            setSummaryPopoverSettings({
-                              rangeEnd: Math.max(1, Math.min(totalMessageCount || 1, next)),
-                            });
-                          }
-                        }}
-                        onBlur={() => {
-                          rangeInputFocused.current = false;
-                          setRangeEnd(String(normalizedRangeEnd));
-                          setSummaryPopoverSettings({ rangeEnd: normalizedRangeEnd });
-                        }}
-                        className="w-full rounded-md bg-[var(--card)] px-2 py-1 text-center text-xs tabular-nums text-[var(--foreground)] ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
-                      />
-                    </label>
-                  </div>
-                  <p
-                    className={cn(
-                      "text-[0.625rem]",
-                      rangeTooLarge ? "text-red-300" : "text-[var(--muted-foreground)]",
-                    )}
-                  >
-                    {rangeStatusText}
-                  </p>
+            <div className="max-h-[min(31rem,calc(100vh-10rem))] overflow-y-auto p-2.5">
+              <div className="space-y-2 rounded-lg border border-[var(--border)] bg-[var(--secondary)]/40 p-2.5">
+                <p className="px-1 text-xs font-semibold text-[var(--popover-foreground)]">Summary Scope</p>
+                <div className="grid grid-cols-2 gap-1 rounded-lg bg-[var(--background)]/30 p-1">
+                  {(["last", "range"] as const).map((mode) => (
+                    <button
+                      key={mode}
+                      type="button"
+                      onClick={() => handleSourceModeChange(mode)}
+                      className={cn(
+                        "rounded-md px-2 py-1 text-xs font-semibold transition-colors",
+                        sourceMode === mode
+                          ? "bg-[var(--accent)] text-[var(--foreground)] ring-1 ring-[var(--border)]"
+                          : "text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]",
+                      )}
+                    >
+                      {mode === "last" ? "Last" : "Range"}
+                    </button>
+                  ))}
                 </div>
-              )}
-            </div>
+              </div>
 
-            <div className="space-y-2 pt-2">
-              <div className="space-y-2 rounded-lg border border-[var(--border)] bg-[var(--secondary)]/35 p-2.5">
-                <div className="flex items-start justify-between gap-2">
+              <div className="space-y-2 pt-2">
+                <div className="space-y-2 rounded-lg border border-[var(--border)] bg-[var(--secondary)]/35 p-2.5">
+                <div className="flex items-center justify-between gap-2">
                   <div className="min-w-0">
-                    <p className="text-[0.625rem] font-semibold uppercase text-[var(--muted-foreground)]">
+                    <p className="text-xs font-semibold text-[var(--popover-foreground)]">
                       Summary Prompt
-                    </p>
-                    <p className="truncate text-xs font-semibold text-[var(--popover-foreground)]">
-                      {promptTemplateSummary}
                     </p>
                   </div>
                   <button
@@ -776,7 +727,7 @@ export function SummaryPopover({
                       if (templateEditorOpen) resetTemplateDraft();
                     }}
                     className={cn(
-                      "shrink-0 rounded-md px-2 py-1 text-[0.625rem] font-semibold transition-colors",
+                      "shrink-0 rounded-md px-2 py-1 text-xs transition-colors",
                       templateEditorOpen
                         ? "bg-[var(--accent)] text-[var(--foreground)] ring-1 ring-[var(--border)]"
                         : "text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]",
@@ -791,17 +742,17 @@ export function SummaryPopover({
                     <button
                       type="button"
                       onClick={() => setTemplateSelectOpen((open) => !open)}
-                      className="flex w-full min-w-0 items-center justify-between gap-2 rounded-md bg-[var(--card)] py-1 pl-2 pr-2 text-left text-[0.6875rem] text-[var(--foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+                      className="flex w-full min-w-0 items-center justify-between gap-2 rounded-md bg-[var(--card)] py-1 pl-2 pr-2 text-left truncate text-xs font-semibold text-[var(--foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
                       aria-haspopup="listbox"
                       aria-expanded={templateSelectOpen}
                       aria-label="Summary prompt template"
                     >
                       <span className="min-w-0 truncate">{promptTemplateSummary}</span>
-                      <ChevronDown
+                      <ChevronRight
                         size="0.75rem"
                         className={cn(
                           "shrink-0 text-[var(--muted-foreground)] transition-transform",
-                          templateSelectOpen && "rotate-180",
+                          templateSelectOpen && "rotate-90",
                         )}
                       />
                     </button>
@@ -908,30 +859,59 @@ export function SummaryPopover({
                     )}
                   </div>
                 )}
-              </div>
+                </div>
 
-              <div className="space-y-1 rounded-lg border border-[var(--border)] bg-[var(--secondary)]/25 p-2">
-                <p className="px-1 text-[0.625rem] font-semibold uppercase text-[var(--muted-foreground)]">
-                  Display
-                </p>
-                <SummarySettingsToggle
-                  label="Hide summarised messages"
-                  checked={summaryPopoverSettings.hideSummarisedMessages}
-                  onChange={(checked) => setSummaryPopoverSettings({ hideSummarisedMessages: checked })}
-                />
-                <SummarySettingsToggle
-                  label="Collapse hidden messages"
-                  checked={summaryPopoverSettings.collapseHiddenMessages}
-                  onChange={(checked) => setSummaryPopoverSettings({ collapseHiddenMessages: checked })}
-                />
+                <div className="space-y-1 rounded-lg border border-[var(--border)] bg-[var(--secondary)]/25 p-2">
+                  <p className="px-1 text-xs font-semibold text-[var(--popover-foreground)]">
+                    Display
+                  </p>
+                  <SummarySettingsToggle
+                    label="Hide summarised messages"
+                    checked={summaryPopoverSettings.hideSummarisedMessages}
+                    onChange={(checked) => setSummaryPopoverSettings({ hideSummarisedMessages: checked })}
+                  />
+                  <SummarySettingsToggle
+                    label="Collapse hidden messages"
+                    checked={summaryPopoverSettings.collapseHiddenMessages}
+                    onChange={(checked) => setSummaryPopoverSettings({ collapseHiddenMessages: checked })}
+                  />
+                </div>
               </div>
             </div>
           </div>
         )}
 
         {/* Body */}
-        <div className="max-h-[min(26rem,calc(100dvh-15rem))] overflow-y-auto p-3">
+        <div className="max-h-[min(26rem,calc(100dvh-15rem))] overflow-y-auto p-2.5">
           <div className="space-y-2">
+            {hasPersistedEntries && (
+              <div className="flex items-center justify-end gap-1.5 px-0.5">
+                  {inactiveEntryCount > 0 && (
+                    <button
+                      type="button"
+                      onClick={() => setShowInactiveSummaries((show) => !show)}
+                      className={cn(
+                        "rounded-md px-1 py-0.5 text-[0.625rem] font-semibold transition-colors hover:text-[var(--foreground)]",
+                        showInactiveSummaries
+                          ? "text-[var(--foreground)]"
+                          : "text-[var(--muted-foreground)]",
+                      )}
+                    >
+                      {showInactiveSummaries ? "Hide Inactive" : "Show Inactive"}
+                    </button>
+                  )}
+                  {inactiveEntryCount === 0 && <span aria-hidden="true" />}
+                  <button
+                    type="button"
+                    onClick={() => void handleToggleAllEntries()}
+                    disabled={entryMutationPending}
+                    className="rounded-md px-1 py-0.5 text-[0.625rem] font-semibold text-[var(--muted-foreground)] transition-colors hover:text-[var(--foreground)] disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    {enabledEntryCount === 0 ? "Activate All" : "Deactivate All"}
+                  </button>
+              </div>
+            )}
+
             {tokenWarning && (
               <div className="rounded-lg border border-amber-400/30 bg-amber-500/10 px-2.5 py-2 text-[0.6875rem] leading-relaxed text-amber-200">
                 Enabled summaries are around {formatTokenCount(enabledTokenEstimate)} tokens. Consider disabling older
@@ -970,6 +950,14 @@ export function SummaryPopover({
                   onDelete={() => void handleDeleteEntry(entry)}
                 />
               ))
+            ) : allVisibleEntriesHidden ? (
+              <button
+                type="button"
+                onClick={() => setShowInactiveSummaries(true)}
+                className="w-full rounded-lg border border-dashed border-[var(--border)] bg-[var(--secondary)]/20 p-5 text-center text-xs italic text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)]/35"
+              >
+                Inactive summaries are hidden. Show inactive summaries to view them.
+              </button>
             ) : (
               <button
                 type="button"
@@ -983,17 +971,113 @@ export function SummaryPopover({
         </div>
 
         {/* Source controls */}
-        <div className="border-t border-[var(--border)] px-3 py-2.5">
-          <div className="mb-2 grid grid-cols-[1fr_auto] items-center gap-2 rounded-lg bg-[var(--secondary)]/25 px-2.5 py-1.5 text-[0.625rem] text-[var(--muted-foreground)]">
-            <span className="min-w-0 truncate">Source: {sourceSummary}</span>
-            <span className="shrink-0 text-right">{sourceDetail}</span>
+        <div className="border-t border-[var(--border)] bg-[var(--card)]/45 px-3 py-2.5">
+          <div className="mb-2.5 space-y-2">
+            <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)] items-start gap-3">
+              <div className="min-w-0">
+                <p className="truncate text-xs font-semibold text-[var(--foreground)]">{sourceSummary}</p>
+                <p className="truncate text-[0.625rem] text-[var(--muted-foreground)]">{sourceDetail}</p>
+              </div>
+              <div className="min-w-0 text-right">
+                <p className="truncate text-xs font-semibold text-[var(--foreground)]">Active Prompt</p>
+                <p className="truncate text-[0.625rem] text-[var(--muted-foreground)]">{promptTemplateSummary}</p>
+              </div>
+            </div>
+
+            {sourceMode === "last" ? (
+              <label className="flex items-center justify-between gap-2 text-[0.6875rem] text-[var(--muted-foreground)]">
+                <span>Messages</span>
+                <input
+                  type="number"
+                  min={MIN_SUMMARY_MESSAGES}
+                  max={MAX_SUMMARY_MESSAGES}
+                  value={localSize}
+                  onFocus={() => {
+                    sizeInputFocused.current = true;
+                  }}
+                  onChange={(e) => {
+                    setLocalSize(e.target.value);
+                    const next = parsePositiveInteger(e.target.value);
+                    if (next !== null) {
+                      setSummaryPopoverSettings({ contextSize: clampSummaryCount(next) });
+                    }
+                  }}
+                  onBlur={() => {
+                    sizeInputFocused.current = false;
+                    const clamped = clampSummaryCount(parsePositiveInteger(localSize) ?? 50);
+                    setLocalSize(String(clamped));
+                    setSummaryPopoverSettings({ contextSize: clamped });
+                  }}
+                  className="w-16 rounded-md bg-[var(--card)] px-2 py-1 text-center text-xs tabular-nums text-[var(--foreground)] ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+                />
+              </label>
+            ) : (
+              <div className="space-y-1.5">
+                <div className="grid grid-cols-2 gap-2">
+                  <label className="space-y-1 text-[0.625rem] font-medium text-[var(--muted-foreground)]">
+                    From
+                    <input
+                      type="number"
+                      min={1}
+                      max={Math.max(1, totalMessageCount)}
+                      value={rangeStart}
+                      onFocus={() => {
+                        rangeInputFocused.current = true;
+                      }}
+                      onChange={(e) => {
+                        setRangeStart(e.target.value);
+                        const next = parsePositiveInteger(e.target.value);
+                        if (next !== null) {
+                          setSummaryPopoverSettings({
+                            rangeStart: Math.max(1, Math.min(totalMessageCount || 1, next)),
+                          });
+                        }
+                      }}
+                      onBlur={() => {
+                        rangeInputFocused.current = false;
+                        setRangeStart(String(normalizedRangeStart));
+                        setSummaryPopoverSettings({ rangeStart: normalizedRangeStart });
+                      }}
+                      className="w-full rounded-md bg-[var(--card)] px-2 py-1 text-center text-xs tabular-nums text-[var(--foreground)] ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+                    />
+                  </label>
+                  <label className="space-y-1 text-[0.625rem] font-medium text-[var(--muted-foreground)]">
+                    To
+                    <input
+                      type="number"
+                      min={1}
+                      max={Math.max(1, totalMessageCount)}
+                      value={rangeEnd}
+                      onFocus={() => {
+                        rangeInputFocused.current = true;
+                      }}
+                      onChange={(e) => {
+                        setRangeEnd(e.target.value);
+                        const next = parsePositiveInteger(e.target.value);
+                        if (next !== null) {
+                          setSummaryPopoverSettings({
+                            rangeEnd: Math.max(1, Math.min(totalMessageCount || 1, next)),
+                          });
+                        }
+                      }}
+                      onBlur={() => {
+                        rangeInputFocused.current = false;
+                        setRangeEnd(String(normalizedRangeEnd));
+                        setSummaryPopoverSettings({ rangeEnd: normalizedRangeEnd });
+                      }}
+                      className="w-full rounded-md bg-[var(--card)] px-2 py-1 text-center text-xs tabular-nums text-[var(--foreground)] ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+                    />
+                  </label>
+                </div>                
+              </div>
+            )}
           </div>
 
           <div className="grid grid-cols-[auto_1fr] gap-1.5">
             <button
               type="button"
               onClick={handleCreateManualEntry}
-              className="flex items-center justify-center gap-1.5 rounded-lg px-3 py-2 text-xs font-semibold text-[var(--foreground)] ring-1 ring-[var(--border)] transition-all hover:bg-[var(--accent)] active:scale-[0.98]"
+              className="flex items-center justify-center gap-1.5 rounded-lg px-3 py-2 text-xs font-semibold text-[var(--muted-foreground)] transition-all hover:bg-[var(--accent)] hover:text-[var(--foreground)] active:scale-[0.98]"
               title="Write summary entry"
             >
               <PenLine size="0.8125rem" />
@@ -1017,17 +1101,6 @@ export function SummaryPopover({
           </div>
         </div>
 
-        {/* Info tip */}
-        <div className="border-t border-[var(--border)] bg-[var(--secondary)]/15 px-3 py-2">
-          <p className="flex items-start gap-1.5 text-[0.625rem] leading-relaxed text-[var(--muted-foreground)]">
-            <Info size="0.6875rem" className="mt-0.5 shrink-0 text-[var(--muted-foreground)]" />
-            <span>
-              Use the Generate button above to update the summary manually. Add an{" "}
-              <strong className="font-medium text-[var(--foreground)]/70">Automated Chat Summary</strong> agent to the
-              chat if you&apos;d like it to be updated automatically every X messages.
-            </span>
-          </p>
-        </div>
       </div>
     </div>
   );
@@ -1086,37 +1159,59 @@ function SummaryEntryRow({
   onSaveEdit,
   onDelete,
 }: SummaryEntryRowProps) {
+  const metaLine = getSummaryEntryMetaLine(entry);
   return (
     <div
       className={cn(
-        "rounded-lg border border-[var(--border)] bg-[var(--secondary)]/20 transition-colors",
-        entry.enabled ? "text-[var(--foreground)]" : "text-[var(--muted-foreground)] opacity-75",
+        "group overflow-hidden rounded-lg border shadow-sm shadow-black/10 ring-1 ring-[var(--border)]/25 transition-colors",
+        expanded
+          ? "border-[var(--primary)]/45 bg-[var(--accent)]/22 ring-[var(--primary)]/20"
+          : "border-[var(--border)]/80 bg-[var(--secondary)]/28 hover:border-[var(--primary)]/30 hover:bg-[var(--accent)]/30",
+        entry.enabled
+          ? "text-[var(--foreground)]"
+          : "border-dashed bg-[var(--secondary)]/14 text-[var(--muted-foreground)] opacity-75 ring-[var(--border)]/35",
+        editing && "border-[var(--primary)]/60 bg-[var(--primary)]/10 ring-[var(--primary)]/30",
       )}
     >
-      <div className="grid grid-cols-[auto_1fr_auto] items-start gap-2 p-2.5">
-        <input
-          type="checkbox"
-          checked={entry.enabled}
+      <div className="grid grid-cols-[auto_1fr_auto] items-center gap-2 px-2 py-1.5">
+        <button
+          type="button"
+          onClick={() => onToggleEnabled(!entry.enabled)}
           disabled={mutationPending}
-          onChange={(event) => onToggleEnabled(event.target.checked)}
-          className="mt-1 h-3.5 w-3.5 shrink-0 accent-[var(--muted-foreground)]"
+          className={cn(
+            "flex h-5 w-5 shrink-0 items-center justify-center rounded-md transition-colors disabled:cursor-not-allowed disabled:opacity-50",
+            entry.enabled
+              ? "bg-[var(--primary)]/15 text-[var(--primary)] ring-1 ring-[var(--primary)]/30"
+              : "text-[var(--muted-foreground)] ring-1 ring-[var(--border)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]",
+          )}
           title={entry.enabled ? "Disable summary" : "Enable summary"}
           aria-label={entry.enabled ? "Disable summary" : "Enable summary"}
-        />
+          aria-pressed={entry.enabled}
+        >
+          <Check size="0.6875rem" className={cn(!entry.enabled && "opacity-0")} />
+        </button>
 
         <button type="button" onClick={onToggleExpanded} className="min-w-0 text-left">
           <div className="flex min-w-0 items-center gap-1.5">
             <SummaryEntryOriginIcon entry={entry} />
             <span className="min-w-0 truncate text-xs font-semibold">{entry.title}</span>
+            {editing && (
+              <span className="shrink-0 rounded bg-[var(--primary)]/15 px-1.5 py-0.5 text-[0.5625rem] font-semibold text-[var(--primary)]">
+                Editing
+              </span>
+            )}
           </div>
-          <SummaryEntryMetaChips entry={entry} />
+          <p className="mt-0.5 truncate text-[0.625rem] text-[var(--muted-foreground)]">{metaLine}</p>
         </button>
 
-        <div className="flex shrink-0 items-center gap-0.5 rounded-md bg-[var(--card)] px-0.5 py-0.5 ring-1 ring-[var(--border)] max-md:opacity-100 md:opacity-90">
+        <div className="flex shrink-0 items-center gap-0.5 rounded-md px-0.5 py-0.5 max-md:opacity-100 md:opacity-55 md:transition-opacity md:group-hover:opacity-100 md:group-focus-within:opacity-100">
           <button
             type="button"
             onClick={onToggleExpanded}
-            className="rounded p-1 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] active:scale-90"
+            className={cn(
+              "rounded p-1 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] active:scale-90",
+              expanded && "bg-[var(--accent)] text-[var(--foreground)]",
+            )}
             title={expanded ? "Collapse" : "Expand"}
             aria-label={expanded ? "Collapse summary entry" : "Expand summary entry"}
           >
@@ -1145,7 +1240,7 @@ function SummaryEntryRow({
       </div>
 
       {expanded && (
-        <div className="border-t border-[var(--border)] px-2.5 pb-2.5 pt-2">
+        <div className="border-t border-[var(--border)]/60 px-2.5 pb-2.5 pt-2">
           {editing && draftEntry ? (
             <SummaryEntryEditor
               entry={draftEntry}
@@ -1156,7 +1251,7 @@ function SummaryEntryRow({
               onSave={onSaveEdit}
             />
           ) : (
-            <div className="space-y-3 rounded-md bg-[var(--card)]/45 p-2.5 ring-1 ring-[var(--border)]">
+            <div className="space-y-3 px-0.5 py-0.5">
               {parseSummarySections(entry.content).map((section, sectionIndex) => (
                 <SummaryReadableSection
                   key={`${entry.id}-${section.title ?? "summary"}-${sectionIndex}`}
@@ -1182,8 +1277,13 @@ interface SummaryEntryEditorProps {
 }
 
 function SummaryEntryEditor({ entry, textareaRef, mutationPending, onChange, onCancel, onSave }: SummaryEntryEditorProps) {
+  const metaLine = getSummaryEntryMetaLine(entry);
   return (
     <div className="space-y-2">
+      <div className="flex flex-wrap items-center justify-between gap-2 text-[0.625rem] text-[var(--muted-foreground)]">
+        <span className="min-w-0 truncate">{metaLine || "Manual summary"}</span>
+        <span>{entry.enabled ? "Active" : "Inactive"}</span>
+      </div>
       <input
         value={entry.title}
         onChange={(event) => onChange({ ...entry, title: event.target.value })}
@@ -1200,7 +1300,9 @@ function SummaryEntryEditor({ entry, textareaRef, mutationPending, onChange, onC
         className="max-h-64 min-h-36 w-full resize-y rounded-md bg-[var(--card)] p-2.5 text-xs leading-relaxed text-[var(--foreground)] ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
       />
       <div className="flex flex-wrap items-center justify-between gap-2">
-        <SummaryTokenBadge tokens={estimateChatSummaryTokens(entry.content)} />
+        <span className="text-[0.625rem] text-[var(--muted-foreground)]">
+          ~{formatTokenCount(estimateChatSummaryTokens(entry.content))} tokens
+        </span>
         <div className="flex justify-end gap-1.5">
           <button
             type="button"
@@ -1222,33 +1324,6 @@ function SummaryEntryEditor({ entry, textareaRef, mutationPending, onChange, onC
       </div>
     </div>
   );
-}
-
-function SummaryEntryMetaChips({ entry }: { entry: ChatSummaryEntry }) {
-  const sourceLabel = getSummaryEntrySourceLabel(entry);
-  return (
-    <div className="mt-1 flex flex-wrap gap-1">
-      {sourceLabel && <SummaryMetaChip>{sourceLabel}</SummaryMetaChip>}
-      {entry.messageCount && entry.sourceMode !== "last" && (
-        <SummaryMetaChip>
-          {entry.messageCount} {entry.messageCount === 1 ? "message" : "messages"}
-        </SummaryMetaChip>
-      )}
-      <SummaryTokenBadge tokens={entry.tokenEstimate} />
-    </div>
-  );
-}
-
-function SummaryMetaChip({ children }: { children: ReactNode }) {
-  return (
-    <span className="rounded-full bg-[var(--card)] px-1.5 py-0.5 text-[0.5625rem] font-medium text-[var(--muted-foreground)] ring-1 ring-[var(--border)]">
-      {children}
-    </span>
-  );
-}
-
-function SummaryTokenBadge({ tokens }: { tokens: number }) {
-  return <SummaryMetaChip>~{formatTokenCount(tokens)} tokens</SummaryMetaChip>;
 }
 
 function SummaryEntryOriginIcon({ entry }: { entry: ChatSummaryEntry }) {

--- a/packages/client/src/components/chat/SummaryPopover.tsx
+++ b/packages/client/src/components/chat/SummaryPopover.tsx
@@ -248,7 +248,7 @@ export function SummaryPopover({
         { chatId, rangeStartIndex: rangeLow, rangeEndIndex: rangeHigh, promptTemplateId: activePromptTemplateId },
         {
           onSuccess: (data) => {
-            setDraft(data.summary);
+            setDraft(data.summary ?? "");
             setEditing(false);
             maybeHideSummarisedMessages(data.messageIds);
           },
@@ -262,7 +262,7 @@ export function SummaryPopover({
       { chatId, contextSize: normalizedLastSize, promptTemplateId: activePromptTemplateId },
       {
         onSuccess: (data) => {
-          setDraft(data.summary);
+          setDraft(data.summary ?? "");
           setEditing(false);
           maybeHideSummarisedMessages(data.messageIds);
         },

--- a/packages/client/src/components/chat/SummaryPopover.tsx
+++ b/packages/client/src/components/chat/SummaryPopover.tsx
@@ -2,7 +2,7 @@
 // Summary Popover — View / edit / generate chat summary
 // Shown via the scroll icon in the chat header bar.
 // ──────────────────────────────────────────────
-import { useState, useEffect, useRef, useCallback, useMemo, type MouseEvent, type RefObject } from "react";
+import { useState, useEffect, useRef, useCallback, useMemo, type MouseEvent as ReactMouseEvent, type RefObject } from "react";
 import { createPortal } from "react-dom";
 import {
   useBulkSetMessagesHiddenFromAI,
@@ -194,7 +194,7 @@ export function SummaryPopover({
   // mousedown from the tap that *opened* the popover doesn't
   // immediately close it on touch devices (Android / iPadOS).
   useEffect(() => {
-    const handler = (e: MouseEvent) => {
+    const handler = (e: globalThis.MouseEvent) => {
       if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
         onClose();
       }
@@ -220,7 +220,7 @@ export function SummaryPopover({
   // Close the settings flyout when clicking elsewhere in the summary popover.
   useEffect(() => {
     if (!scopeSettingsOpen) return;
-    const handler = (e: MouseEvent) => {
+    const handler = (e: globalThis.MouseEvent) => {
       const target = e.target as Node;
       if (scopeSettingsRef.current?.contains(target) || scopeSettingsButtonRef.current?.contains(target)) return;
       setScopeSettingsOpen(false);
@@ -609,7 +609,7 @@ export function SummaryPopover({
   const isMobile = typeof window !== "undefined" && window.innerWidth < 768;
 
   const handlePanelMouseDown = useCallback(
-    (event: MouseEvent<HTMLDivElement>) => {
+    (event: ReactMouseEvent<HTMLDivElement>) => {
       if (scopeSettingsOpen) {
         const target = event.target as Node;
         if (!scopeSettingsRef.current?.contains(target) && !scopeSettingsButtonRef.current?.contains(target)) {

--- a/packages/client/src/components/chat/SummaryPopover.tsx
+++ b/packages/client/src/components/chat/SummaryPopover.tsx
@@ -22,12 +22,19 @@ import {
 } from "lucide-react";
 import { cn, generateClientId } from "../../lib/utils";
 import { useUIStore } from "../../stores/ui.store";
-import { DEFAULT_AGENT_PROMPTS, type ChatSummaryPromptTemplate } from "@marinara-engine/shared";
+import {
+  DEFAULT_AGENT_PROMPTS,
+  createChatSummaryEntry,
+  normalizeChatSummaryEntries,
+  type ChatSummaryEntry,
+  type ChatSummaryPromptTemplate,
+} from "@marinara-engine/shared";
 import { showConfirmDialog } from "../../lib/app-dialogs";
 
 interface SummaryPopoverProps {
   chatId: string;
   summary: string | null;
+  summaryEntries?: ChatSummaryEntry[];
   contextSize: number;
   promptTemplates?: ChatSummaryPromptTemplate[];
   activePromptTemplateId?: string | null;
@@ -92,9 +99,44 @@ function parseSummarySections(value: string): SummarySection[] {
   return sections;
 }
 
+function createSingleEditableSummaryEntry(args: {
+  content: string;
+  summary: string | null;
+  summaryEntries?: ChatSummaryEntry[];
+}): ChatSummaryEntry[] {
+  const content = args.content.trim();
+  if (!content) return [];
+
+  const now = new Date().toISOString();
+  const existingEntries = normalizeChatSummaryEntries(args.summaryEntries, {
+    legacySummary: args.summary,
+    now,
+  });
+  const existing = existingEntries.length === 1 ? existingEntries[0] : null;
+
+  return [
+    createChatSummaryEntry(
+      {
+        ...(existing ?? {}),
+        id: existing?.id ?? generateClientId(),
+        kind: "rolling",
+        origin: "manual",
+        title: existing?.title && existing.origin !== "automated" ? existing.title : "Manual summary",
+        content,
+        enabled: true,
+        sourceMode: existing?.sourceMode ?? "last",
+        createdAt: existing?.createdAt ?? now,
+        updatedAt: now,
+      },
+      { createId: generateClientId, now },
+    ),
+  ];
+}
+
 export function SummaryPopover({
   chatId,
   summary,
+  summaryEntries,
   contextSize,
   promptTemplates = [],
   activePromptTemplateId = null,
@@ -283,9 +325,14 @@ export function SummaryPopover({
   ]);
 
   const handleSave = useCallback(() => {
-    updateMeta.mutate({ id: chatId, summary: draft || null });
+    const content = draft.trim();
+    updateMeta.mutate({
+      id: chatId,
+      summary: content || null,
+      summaryEntries: createSingleEditableSummaryEntry({ content, summary, summaryEntries }),
+    });
     setEditing(false);
-  }, [chatId, draft, updateMeta]);
+  }, [chatId, draft, summary, summaryEntries, updateMeta]);
 
   const persistPromptTemplates = useCallback(
     (templates: ChatSummaryPromptTemplate[], activeId: string | null) => {

--- a/packages/client/src/components/chat/SummaryPopover.tsx
+++ b/packages/client/src/components/chat/SummaryPopover.tsx
@@ -1068,7 +1068,15 @@ export function SummaryPopover({
                       className="w-full rounded-md bg-[var(--card)] px-2 py-1 text-center text-xs tabular-nums text-[var(--foreground)] ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
                     />
                   </label>
-                </div>                
+                </div>
+                <p
+                  className={cn(
+                    "px-0.5 text-[0.625rem] leading-snug",
+                    rangeTooLarge ? "text-[var(--destructive)]" : "text-[var(--muted-foreground)]",
+                  )}
+                >
+                  {rangeStatusText}
+                </p>
               </div>
             )}
           </div>

--- a/packages/client/src/components/chat/SummaryPopover.tsx
+++ b/packages/client/src/components/chat/SummaryPopover.tsx
@@ -2,12 +2,20 @@
 // Summary Popover — View / edit / generate chat summary
 // Shown via the scroll icon in the chat header bar.
 // ──────────────────────────────────────────────
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef, useCallback, useMemo, type ReactNode, type RefObject } from "react";
 import { createPortal } from "react-dom";
-import { useBulkSetMessagesHiddenFromAI, useGenerateSummary, useUpdateChatMetadata } from "../../hooks/use-chats";
+import {
+  useBulkSetMessagesHiddenFromAI,
+  useDeleteSummaryEntry,
+  useGenerateSummary,
+  useToggleSummaryEntry,
+  useUpdateChatMetadata,
+  useUpdateSummaryEntry,
+} from "../../hooks/use-chats";
 import {
   Check,
   ChevronDown,
+  ChevronRight,
   Copy,
   Info,
   Loader2,
@@ -20,11 +28,12 @@ import {
   Trash2,
   X,
 } from "lucide-react";
+import { toast } from "sonner";
 import { cn, generateClientId } from "../../lib/utils";
 import { useUIStore } from "../../stores/ui.store";
 import {
   DEFAULT_AGENT_PROMPTS,
-  createChatSummaryEntry,
+  estimateChatSummaryTokens,
   normalizeChatSummaryEntries,
   type ChatSummaryEntry,
   type ChatSummaryPromptTemplate,
@@ -46,6 +55,7 @@ type SummarySourceMode = "last" | "range";
 
 const MIN_SUMMARY_MESSAGES = 5;
 const MAX_SUMMARY_MESSAGES = 200;
+const SUMMARY_TOKEN_WARNING_THRESHOLD = 1800;
 const SUMMARY_HEADING_PATTERN = /^(?:#{1,6}\s*)?(?:\*\*)?([^:\n]{3,80})(?:\*\*)?:\s*$/;
 const SUMMARY_BULLET_PATTERN = /^[-*•]\s+/;
 
@@ -99,38 +109,39 @@ function parseSummarySections(value: string): SummarySection[] {
   return sections;
 }
 
-function createSingleEditableSummaryEntry(args: {
-  content: string;
-  summary: string | null;
-  summaryEntries?: ChatSummaryEntry[];
-}): ChatSummaryEntry[] {
-  const content = args.content.trim();
-  if (!content) return [];
+function formatTokenCount(tokens: number): string {
+  if (tokens >= 1000) {
+    const rounded = Math.round(tokens / 100) / 10;
+    return `${Number.isInteger(rounded) ? rounded.toFixed(0) : rounded.toFixed(1)}k`;
+  }
+  return String(tokens);
+}
 
+function getSummaryEntrySourceLabel(entry: ChatSummaryEntry): string | null {
+  if (entry.sourceMode === "range" && entry.rangeStartIndex && entry.rangeEndIndex) {
+    return `Messages ${entry.rangeStartIndex}-${entry.rangeEndIndex}`;
+  }
+  if (entry.sourceMode === "last" && entry.messageCount) {
+    return `${entry.messageCount} ${entry.messageCount === 1 ? "message" : "messages"}`;
+  }
+  if (entry.sourceMode === "agent") return "Agent";
+  return null;
+}
+
+function createBlankManualSummaryEntry(): ChatSummaryEntry {
   const now = new Date().toISOString();
-  const existingEntries = normalizeChatSummaryEntries(args.summaryEntries, {
-    legacySummary: args.summary,
-    now,
-  });
-  const existing = existingEntries.length === 1 ? existingEntries[0] : null;
-
-  return [
-    createChatSummaryEntry(
-      {
-        ...(existing ?? {}),
-        id: existing?.id ?? generateClientId(),
-        kind: "rolling",
-        origin: "manual",
-        title: existing?.title && existing.origin !== "automated" ? existing.title : "Manual summary",
-        content,
-        enabled: true,
-        sourceMode: existing?.sourceMode ?? "last",
-        createdAt: existing?.createdAt ?? now,
-        updatedAt: now,
-      },
-      { createId: generateClientId, now },
-    ),
-  ];
+  return {
+    id: generateClientId(),
+    kind: "rolling",
+    origin: "manual",
+    title: "Manual summary",
+    content: "",
+    enabled: true,
+    sourceMode: "last",
+    tokenEstimate: 0,
+    createdAt: now,
+    updatedAt: now,
+  };
 }
 
 export function SummaryPopover({
@@ -143,8 +154,9 @@ export function SummaryPopover({
   totalMessageCount,
   onClose,
 }: SummaryPopoverProps) {
-  const [editing, setEditing] = useState(false);
-  const [draft, setDraft] = useState(summary ?? "");
+  const [expandedEntryIds, setExpandedEntryIds] = useState<Set<string>>(() => new Set());
+  const [editingEntryId, setEditingEntryId] = useState<string | null>(null);
+  const [draftEntry, setDraftEntry] = useState<ChatSummaryEntry | null>(null);
   const [templateEditorOpen, setTemplateEditorOpen] = useState(false);
   const [templateSelectOpen, setTemplateSelectOpen] = useState(false);
   const [editingTemplateId, setEditingTemplateId] = useState<string | null>(null);
@@ -167,7 +179,10 @@ export function SummaryPopover({
   const generateSummary = useGenerateSummary();
   const bulkSetMessagesHiddenFromAI = useBulkSetMessagesHiddenFromAI();
   const updateMeta = useUpdateChatMetadata();
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const updateSummaryEntry = useUpdateSummaryEntry();
+  const deleteSummaryEntry = useDeleteSummaryEntry();
+  const toggleSummaryEntry = useToggleSummaryEntry();
+  const entryTextareaRef = useRef<HTMLTextAreaElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
 
   // Close on click outside — defer by one frame so the synthesised
@@ -197,11 +212,6 @@ export function SummaryPopover({
     return () => document.removeEventListener("keydown", handler);
   }, [onClose]);
 
-  // Sync draft when summary changes (e.g. after generation)
-  useEffect(() => {
-    setDraft(summary ?? "");
-  }, [summary]);
-
   // Sync local size when the persisted/default context size changes externally.
   useEffect(() => {
     if (!sizeInputFocused.current) {
@@ -216,12 +226,12 @@ export function SummaryPopover({
     setRangeEnd(String(Math.max(1, totalMessageCount)));
   }, [persistedContextSize, sourceMode, totalMessageCount]);
 
-  // Focus textarea when entering edit mode
+  // Focus textarea when entering entry edit mode.
   useEffect(() => {
-    if (editing) {
-      setTimeout(() => textareaRef.current?.focus(), 50);
+    if (editingEntryId) {
+      setTimeout(() => entryTextareaRef.current?.focus(), 50);
     }
-  }, [editing]);
+  }, [editingEntryId]);
 
   const normalizedLastSize = clampSummaryCount(parsePositiveInteger(localSize) ?? persistedContextSize ?? 50);
   const normalizedRangeStart = Math.max(1, Math.min(totalMessageCount || 1, parsePositiveInteger(rangeStart) ?? 1));
@@ -262,7 +272,27 @@ export function SummaryPopover({
   const promptTemplateSummary = activePromptTemplate?.name ?? "Built-in default";
   const isEditingExistingTemplate = !!editingTemplateId;
   const hasTemplateDraft = templateNameDraft.trim().length > 0 && templatePromptDraft.trim().length > 0;
-  const summarySections = parseSummarySections(draft);
+  const displayEntries = useMemo(
+    () =>
+      normalizeChatSummaryEntries(summaryEntries, {
+        legacySummary: summary,
+      }),
+    [summary, summaryEntries],
+  );
+  const visibleEntries = useMemo(() => {
+    if (!draftEntry || displayEntries.some((entry) => entry.id === draftEntry.id)) return displayEntries;
+    return [...displayEntries, draftEntry];
+  }, [displayEntries, draftEntry]);
+  const enabledEntryCount = displayEntries.filter((entry) => entry.enabled).length;
+  const enabledTokenEstimate = displayEntries.reduce(
+    (total, entry) => (entry.enabled ? total + entry.tokenEstimate : total),
+    0,
+  );
+  const hasEntries = visibleEntries.length > 0;
+  const allEntriesDisabled = hasEntries && enabledEntryCount === 0;
+  const tokenWarning = enabledTokenEstimate > SUMMARY_TOKEN_WARNING_THRESHOLD;
+  const entryMutationPending =
+    updateSummaryEntry.isPending || deleteSummaryEntry.isPending || toggleSummaryEntry.isPending;
 
   const handleSourceModeChange = useCallback(
     (mode: SummarySourceMode) => {
@@ -290,10 +320,14 @@ export function SummaryPopover({
         { chatId, rangeStartIndex: rangeLow, rangeEndIndex: rangeHigh, promptTemplateId: activePromptTemplateId },
         {
           onSuccess: (data) => {
-            setDraft(data.summary ?? "");
-            setEditing(false);
+            if (data.entry?.id) {
+              setExpandedEntryIds((current) => new Set(current).add(data.entry!.id));
+            }
+            setEditingEntryId(null);
+            setDraftEntry(null);
             maybeHideSummarisedMessages(data.messageIds);
           },
+          onError: () => toast.error("Could not generate summary."),
         },
       );
       return;
@@ -304,10 +338,14 @@ export function SummaryPopover({
       { chatId, contextSize: normalizedLastSize, promptTemplateId: activePromptTemplateId },
       {
         onSuccess: (data) => {
-          setDraft(data.summary ?? "");
-          setEditing(false);
+          if (data.entry?.id) {
+            setExpandedEntryIds((current) => new Set(current).add(data.entry!.id));
+          }
+          setEditingEntryId(null);
+          setDraftEntry(null);
           maybeHideSummarisedMessages(data.messageIds);
         },
+        onError: () => toast.error("Could not generate summary."),
       },
     );
   }, [
@@ -324,15 +362,96 @@ export function SummaryPopover({
     summaryPopoverSettings.hideSummarisedMessages,
   ]);
 
-  const handleSave = useCallback(() => {
-    const content = draft.trim();
-    updateMeta.mutate({
-      id: chatId,
-      summary: content || null,
-      summaryEntries: createSingleEditableSummaryEntry({ content, summary, summaryEntries }),
+  const handleToggleExpanded = useCallback((entryId: string) => {
+    setExpandedEntryIds((current) => {
+      const next = new Set(current);
+      if (next.has(entryId)) {
+        next.delete(entryId);
+      } else {
+        next.add(entryId);
+      }
+      return next;
     });
-    setEditing(false);
-  }, [chatId, draft, summary, summaryEntries, updateMeta]);
+  }, []);
+
+  const handleStartEditEntry = useCallback((entry: ChatSummaryEntry) => {
+    setEditingEntryId(entry.id);
+    setDraftEntry({ ...entry });
+    setExpandedEntryIds((current) => new Set(current).add(entry.id));
+  }, []);
+
+  const handleCreateManualEntry = useCallback(() => {
+    const entry = createBlankManualSummaryEntry();
+    setEditingEntryId(entry.id);
+    setDraftEntry(entry);
+    setExpandedEntryIds((current) => new Set(current).add(entry.id));
+  }, []);
+
+  const handleCancelEditEntry = useCallback(() => {
+    setEditingEntryId(null);
+    setDraftEntry(null);
+  }, []);
+
+  const handleSaveEntry = useCallback(async () => {
+    if (!draftEntry) return;
+    const content = draftEntry.content.trim();
+    const title = draftEntry.title.trim() || "Manual summary";
+    if (!content) {
+      toast.error("Summary content is required.");
+      return;
+    }
+    try {
+      await updateSummaryEntry.mutateAsync({
+        chatId,
+        entry: {
+          ...draftEntry,
+          title,
+          content,
+          tokenEstimate: estimateChatSummaryTokens(content),
+        },
+      });
+      setEditingEntryId(null);
+      setDraftEntry(null);
+    } catch {
+      toast.error("Could not save summary entry.");
+    }
+  }, [chatId, draftEntry, updateSummaryEntry]);
+
+  const handleToggleEntry = useCallback(
+    async (entry: ChatSummaryEntry, enabled: boolean) => {
+      try {
+        await toggleSummaryEntry.mutateAsync({ chatId, entryId: entry.id, enabled });
+      } catch {
+        toast.error("Could not update summary entry.");
+      }
+    },
+    [chatId, toggleSummaryEntry],
+  );
+
+  const handleDeleteEntry = useCallback(
+    async (entry: ChatSummaryEntry) => {
+      const confirmed = await showConfirmDialog({
+        title: "Delete summary entry?",
+        message: `Delete "${entry.title}"? This will change the summary context sent to the model.`,
+        confirmLabel: "Delete",
+        cancelLabel: "Cancel",
+        tone: "destructive",
+      });
+      if (!confirmed) return;
+      try {
+        await deleteSummaryEntry.mutateAsync({ chatId, entryId: entry.id });
+        if (editingEntryId === entry.id) handleCancelEditEntry();
+        setExpandedEntryIds((current) => {
+          const next = new Set(current);
+          next.delete(entry.id);
+          return next;
+        });
+      } catch {
+        toast.error("Could not delete summary entry.");
+      }
+    },
+    [chatId, deleteSummaryEntry, editingEntryId, handleCancelEditEntry],
+  );
 
   const persistPromptTemplates = useCallback(
     (templates: ChatSummaryPromptTemplate[], activeId: string | null) => {
@@ -458,7 +577,7 @@ export function SummaryPopover({
       <div
         className={cn(
           "relative rounded-xl border border-[var(--border)] bg-[var(--card)] shadow-2xl shadow-black/40",
-          isMobile ? "relative w-full max-w-sm max-h-[calc(100dvh-4rem)] overflow-y-auto" : "w-[22rem]",
+          isMobile ? "relative w-full max-w-md max-h-[calc(100dvh-4rem)] overflow-y-auto" : "w-[28rem]",
         )}
       >
         {/* Header */}
@@ -468,7 +587,11 @@ export function SummaryPopover({
               <ScrollText size="0.8125rem" className="shrink-0 text-[var(--muted-foreground)]" />
               <span className="truncate">Chat Summary</span>
             </div>
-            <p className="truncate text-[0.625rem] text-[var(--muted-foreground)]">{sourceSummary}</p>
+            <p className="truncate text-[0.625rem] text-[var(--muted-foreground)]">
+              {hasEntries
+                ? `${enabledEntryCount} enabled · ~${formatTokenCount(enabledTokenEstimate)} tokens`
+                : "No summaries yet"}
+            </p>
           </div>
           <div className="flex shrink-0 items-center gap-1">
             <button
@@ -797,67 +920,56 @@ export function SummaryPopover({
         )}
 
         {/* Body */}
-        <div className="max-h-80 overflow-y-auto p-3">
-          {editing ? (
-            <div className="space-y-2">
-              <textarea
-                ref={textareaRef}
-                value={draft}
-                onChange={(e) => setDraft(e.target.value)}
-                rows={6}
-                className="max-h-48 w-full resize-y rounded-lg bg-[var(--secondary)] p-2.5 text-xs ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
-                placeholder="Write or paste a summary of this chat…"
-              />
-              <div className="flex justify-end gap-1.5">
-                <button
-                  onClick={() => {
-                    setDraft(summary ?? "");
-                    setEditing(false);
-                  }}
-                  className="rounded-lg px-2.5 py-1 text-[0.625rem] font-medium text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)]"
-                >
-                  Cancel
-                </button>
-                <button
-                  onClick={handleSave}
-                  disabled={updateMeta.isPending}
-                  className="flex items-center gap-1 rounded-lg bg-[var(--secondary)] px-2.5 py-1 text-[0.625rem] font-medium text-[var(--foreground)] ring-1 ring-[var(--border)] transition-all hover:bg-[var(--accent)] active:scale-[0.98] disabled:opacity-50"
-                >
-                  <Save size="0.625rem" />
-                  Save
-                </button>
+        <div className="max-h-[min(26rem,calc(100dvh-15rem))] overflow-y-auto p-3">
+          <div className="space-y-2">
+            {tokenWarning && (
+              <div className="rounded-lg border border-amber-400/30 bg-amber-500/10 px-2.5 py-2 text-[0.6875rem] leading-relaxed text-amber-200">
+                Enabled summaries are around {formatTokenCount(enabledTokenEstimate)} tokens. Consider disabling older
+                entries if prompt context feels crowded.
               </div>
-            </div>
-          ) : (
-            <div>
-              {draft ? (
-                <div
-                  className="cursor-pointer rounded-lg border border-[var(--border)] bg-[var(--secondary)]/25 p-3 transition-colors hover:bg-[var(--accent)]/45"
-                  onClick={() => setEditing(true)}
-                  title="Click to edit"
-                >
-                  <div className="space-y-3">
-                    {summarySections.map((section, sectionIndex) => (
-                      <SummaryReadableSection
-                        key={`${section.title ?? "summary"}-${sectionIndex}`}
-                        section={section}
-                        sectionIndex={sectionIndex}
-                      />
-                    ))}
-                  </div>
-                </div>
-              ) : (
-                <div
-                  className="cursor-pointer rounded-lg border border-dashed border-[var(--border)] bg-[var(--secondary)]/20 p-5 transition-colors hover:bg-[var(--accent)]/35"
-                  onClick={() => setEditing(true)}
-                >
-                  <p className="text-center text-xs italic text-[var(--muted-foreground)]">
-                    No summary yet. Click to write one, or press Generate.
-                  </p>
-                </div>
-              )}
-            </div>
-          )}
+            )}
+
+            {allEntriesDisabled && (
+              <div className="rounded-lg border border-[var(--border)] bg-[var(--secondary)]/20 px-2.5 py-2 text-[0.6875rem] leading-relaxed text-[var(--muted-foreground)]">
+                All summaries are disabled. The model will not receive summary context.
+              </div>
+            )}
+
+            {draftEntry && !displayEntries.some((entry) => entry.id === draftEntry.id) && (
+              <div className="rounded-lg border border-[var(--border)] bg-[var(--secondary)]/20 px-2.5 py-2 text-[0.6875rem] leading-relaxed text-[var(--muted-foreground)]">
+                New manual summary. Save it to include it in prompt context.
+              </div>
+            )}
+
+            {hasEntries ? (
+              visibleEntries.map((entry) => (
+                <SummaryEntryRow
+                  key={entry.id}
+                  entry={entry}
+                  expanded={expandedEntryIds.has(entry.id)}
+                  editing={editingEntryId === entry.id}
+                  draftEntry={editingEntryId === entry.id ? draftEntry : null}
+                  textareaRef={entryTextareaRef}
+                  mutationPending={entryMutationPending}
+                  onToggleExpanded={() => handleToggleExpanded(entry.id)}
+                  onToggleEnabled={(enabled) => handleToggleEntry(entry, enabled)}
+                  onStartEdit={() => handleStartEditEntry(entry)}
+                  onDraftChange={setDraftEntry}
+                  onCancelEdit={handleCancelEditEntry}
+                  onSaveEdit={handleSaveEntry}
+                  onDelete={() => void handleDeleteEntry(entry)}
+                />
+              ))
+            ) : (
+              <button
+                type="button"
+                onClick={handleCreateManualEntry}
+                className="w-full rounded-lg border border-dashed border-[var(--border)] bg-[var(--secondary)]/20 p-5 text-center text-xs italic text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)]/35"
+              >
+                No summaries yet. Generate one or write your own.
+              </button>
+            )}
+          </div>
         </div>
 
         {/* Source controls */}
@@ -867,20 +979,32 @@ export function SummaryPopover({
             <span className="shrink-0 text-right">{sourceDetail}</span>
           </div>
 
-          <button
-            onClick={handleGenerate}
-            disabled={isGenerating || !canGenerate}
-            className={cn(
-              "mt-2 flex w-full items-center justify-center gap-1.5 rounded-lg px-3 py-2 text-xs font-semibold transition-all",
-              isGenerating || !canGenerate
-                ? "cursor-not-allowed bg-[var(--secondary)] text-[var(--muted-foreground)]"
-                : "bg-[var(--secondary)] text-[var(--foreground)] ring-1 ring-[var(--border)] hover:bg-[var(--accent)] active:scale-[0.98]",
-            )}
-            title="Generate summary with AI"
-          >
-            {isGenerating ? <Loader2 size="0.8125rem" className="animate-spin" /> : <Sparkles size="0.8125rem" />}
-            {isGenerating ? "Generating..." : "Generate"}
-          </button>
+          <div className="grid grid-cols-[auto_1fr] gap-1.5">
+            <button
+              type="button"
+              onClick={handleCreateManualEntry}
+              className="flex items-center justify-center gap-1.5 rounded-lg px-3 py-2 text-xs font-semibold text-[var(--foreground)] ring-1 ring-[var(--border)] transition-all hover:bg-[var(--accent)] active:scale-[0.98]"
+              title="Write summary entry"
+            >
+              <PenLine size="0.8125rem" />
+              Write
+            </button>
+            <button
+              type="button"
+              onClick={handleGenerate}
+              disabled={isGenerating || !canGenerate}
+              className={cn(
+                "flex items-center justify-center gap-1.5 rounded-lg px-3 py-2 text-xs font-semibold transition-all",
+                isGenerating || !canGenerate
+                  ? "cursor-not-allowed bg-[var(--secondary)] text-[var(--muted-foreground)]"
+                  : "bg-[var(--secondary)] text-[var(--foreground)] ring-1 ring-[var(--border)] hover:bg-[var(--accent)] active:scale-[0.98]",
+              )}
+              title="Generate summary with AI"
+            >
+              {isGenerating ? <Loader2 size="0.8125rem" className="animate-spin" /> : <Sparkles size="0.8125rem" />}
+              {isGenerating ? "Generating..." : "Generate"}
+            </button>
+          </div>
         </div>
 
         {/* Info tip */}
@@ -919,6 +1043,224 @@ function SummarySettingsToggle({ label, checked, onChange }: SummarySettingsTogg
       />
     </label>
   );
+}
+
+interface SummaryEntryRowProps {
+  entry: ChatSummaryEntry;
+  expanded: boolean;
+  editing: boolean;
+  draftEntry: ChatSummaryEntry | null;
+  textareaRef: RefObject<HTMLTextAreaElement | null>;
+  mutationPending: boolean;
+  onToggleExpanded: () => void;
+  onToggleEnabled: (enabled: boolean) => void;
+  onStartEdit: () => void;
+  onDraftChange: (entry: ChatSummaryEntry | null) => void;
+  onCancelEdit: () => void;
+  onSaveEdit: () => void;
+  onDelete: () => void;
+}
+
+function SummaryEntryRow({
+  entry,
+  expanded,
+  editing,
+  draftEntry,
+  textareaRef,
+  mutationPending,
+  onToggleExpanded,
+  onToggleEnabled,
+  onStartEdit,
+  onDraftChange,
+  onCancelEdit,
+  onSaveEdit,
+  onDelete,
+}: SummaryEntryRowProps) {
+  return (
+    <div
+      className={cn(
+        "rounded-lg border border-[var(--border)] bg-[var(--secondary)]/20 transition-colors",
+        entry.enabled ? "text-[var(--foreground)]" : "text-[var(--muted-foreground)] opacity-75",
+      )}
+    >
+      <div className="grid grid-cols-[auto_1fr_auto] items-start gap-2 p-2.5">
+        <input
+          type="checkbox"
+          checked={entry.enabled}
+          disabled={mutationPending}
+          onChange={(event) => onToggleEnabled(event.target.checked)}
+          className="mt-1 h-3.5 w-3.5 shrink-0 accent-[var(--muted-foreground)]"
+          title={entry.enabled ? "Disable summary" : "Enable summary"}
+          aria-label={entry.enabled ? "Disable summary" : "Enable summary"}
+        />
+
+        <button type="button" onClick={onToggleExpanded} className="min-w-0 text-left">
+          <div className="flex min-w-0 items-center gap-1.5">
+            <SummaryEntryOriginIcon entry={entry} />
+            <span className="min-w-0 truncate text-xs font-semibold">{entry.title}</span>
+          </div>
+          <SummaryEntryMetaChips entry={entry} />
+        </button>
+
+        <div className="flex shrink-0 items-center gap-0.5 rounded-md bg-[var(--card)] px-0.5 py-0.5 ring-1 ring-[var(--border)] max-md:opacity-100 md:opacity-90">
+          <button
+            type="button"
+            onClick={onToggleExpanded}
+            className="rounded p-1 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] active:scale-90"
+            title={expanded ? "Collapse" : "Expand"}
+            aria-label={expanded ? "Collapse summary entry" : "Expand summary entry"}
+          >
+            <ChevronRight size="0.75rem" className={cn("transition-transform", expanded && "rotate-90")} />
+          </button>
+          <button
+            type="button"
+            onClick={onStartEdit}
+            className="rounded p-1 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] active:scale-90"
+            title="Edit"
+            aria-label="Edit summary entry"
+          >
+            <PenLine size="0.75rem" />
+          </button>
+          <button
+            type="button"
+            onClick={onDelete}
+            disabled={mutationPending}
+            className="rounded p-1 text-[var(--destructive)] transition-colors hover:bg-[var(--destructive)]/15 active:scale-90 disabled:cursor-not-allowed disabled:opacity-50"
+            title="Delete"
+            aria-label="Delete summary entry"
+          >
+            <Trash2 size="0.75rem" />
+          </button>
+        </div>
+      </div>
+
+      {expanded && (
+        <div className="border-t border-[var(--border)] px-2.5 pb-2.5 pt-2">
+          {editing && draftEntry ? (
+            <SummaryEntryEditor
+              entry={draftEntry}
+              textareaRef={textareaRef}
+              mutationPending={mutationPending}
+              onChange={onDraftChange}
+              onCancel={onCancelEdit}
+              onSave={onSaveEdit}
+            />
+          ) : (
+            <div className="space-y-3 rounded-md bg-[var(--card)]/45 p-2.5 ring-1 ring-[var(--border)]">
+              {parseSummarySections(entry.content).map((section, sectionIndex) => (
+                <SummaryReadableSection
+                  key={`${entry.id}-${section.title ?? "summary"}-${sectionIndex}`}
+                  section={section}
+                  sectionIndex={sectionIndex}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface SummaryEntryEditorProps {
+  entry: ChatSummaryEntry;
+  textareaRef: RefObject<HTMLTextAreaElement | null>;
+  mutationPending: boolean;
+  onChange: (entry: ChatSummaryEntry) => void;
+  onCancel: () => void;
+  onSave: () => void;
+}
+
+function SummaryEntryEditor({ entry, textareaRef, mutationPending, onChange, onCancel, onSave }: SummaryEntryEditorProps) {
+  return (
+    <div className="space-y-2">
+      <input
+        value={entry.title}
+        onChange={(event) => onChange({ ...entry, title: event.target.value })}
+        maxLength={120}
+        placeholder="Summary title"
+        className="w-full rounded-md bg-[var(--card)] px-2.5 py-1.5 text-xs font-semibold text-[var(--foreground)] ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+      />
+      <textarea
+        ref={textareaRef}
+        value={entry.content}
+        onChange={(event) => onChange({ ...entry, content: event.target.value })}
+        rows={7}
+        placeholder="Write or paste a summary of this chat..."
+        className="max-h-64 min-h-36 w-full resize-y rounded-md bg-[var(--card)] p-2.5 text-xs leading-relaxed text-[var(--foreground)] ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+      />
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <SummaryTokenBadge tokens={estimateChatSummaryTokens(entry.content)} />
+        <div className="flex justify-end gap-1.5">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded-md px-2.5 py-1 text-[0.625rem] font-medium text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)]"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onSave}
+            disabled={mutationPending || !entry.content.trim()}
+            className="flex items-center gap-1 rounded-md bg-[var(--secondary)] px-2.5 py-1 text-[0.625rem] font-semibold text-[var(--foreground)] ring-1 ring-[var(--border)] transition-all hover:bg-[var(--accent)] active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <Save size="0.625rem" />
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SummaryEntryMetaChips({ entry }: { entry: ChatSummaryEntry }) {
+  const sourceLabel = getSummaryEntrySourceLabel(entry);
+  return (
+    <div className="mt-1 flex flex-wrap gap-1">
+      {sourceLabel && <SummaryMetaChip>{sourceLabel}</SummaryMetaChip>}
+      {entry.messageCount && entry.sourceMode !== "last" && (
+        <SummaryMetaChip>
+          {entry.messageCount} {entry.messageCount === 1 ? "message" : "messages"}
+        </SummaryMetaChip>
+      )}
+      <SummaryTokenBadge tokens={entry.tokenEstimate} />
+    </div>
+  );
+}
+
+function SummaryMetaChip({ children }: { children: ReactNode }) {
+  return (
+    <span className="rounded-full bg-[var(--card)] px-1.5 py-0.5 text-[0.5625rem] font-medium text-[var(--muted-foreground)] ring-1 ring-[var(--border)]">
+      {children}
+    </span>
+  );
+}
+
+function SummaryTokenBadge({ tokens }: { tokens: number }) {
+  return <SummaryMetaChip>~{formatTokenCount(tokens)} tokens</SummaryMetaChip>;
+}
+
+function SummaryEntryOriginIcon({ entry }: { entry: ChatSummaryEntry }) {
+  if (entry.origin === "automated") {
+    return (
+      <Sparkles
+        size="0.75rem"
+        className="shrink-0 text-[var(--primary)]"
+        aria-label="Automated summary"
+      />
+    );
+  }
+  if (entry.origin === "legacy") {
+    return (
+      <ScrollText
+        size="0.75rem"
+        className="shrink-0 text-[var(--muted-foreground)]"
+        aria-label="Legacy summary"
+      />
+    );
+  }
+  return <PenLine size="0.75rem" className="shrink-0 text-[var(--muted-foreground)]" aria-label="Manual summary" />;
 }
 
 interface SummaryReadableSectionProps {

--- a/packages/client/src/hooks/use-chats.ts
+++ b/packages/client/src/hooks/use-chats.ts
@@ -723,11 +723,22 @@ export function useBranchChat() {
 }
 
 /** Generate a rolling summary for a chat via the LLM */
+export type GenerateSummaryInput = {
+  chatId: string;
+  contextSize?: number;
+  rangeStartMessageId?: string;
+  rangeEndMessageId?: string;
+};
+
 export function useGenerateSummary() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: ({ chatId, contextSize }: { chatId: string; contextSize?: number }) =>
-      api.post<{ summary: string }>(`/chats/${chatId}/generate-summary`, { contextSize }),
+    mutationFn: ({ chatId, contextSize, rangeStartMessageId, rangeEndMessageId }: GenerateSummaryInput) =>
+      api.post<{ summary: string }>(`/chats/${chatId}/generate-summary`, {
+        contextSize,
+        rangeStartMessageId,
+        rangeEndMessageId,
+      }),
     onSuccess: (_data, vars) => {
       qc.invalidateQueries({ queryKey: chatKeys.detail(vars.chatId) });
     },

--- a/packages/client/src/hooks/use-chats.ts
+++ b/packages/client/src/hooks/use-chats.ts
@@ -774,16 +774,27 @@ export type GenerateSummaryInput = {
   contextSize?: number;
   rangeStartMessageId?: string;
   rangeEndMessageId?: string;
+  rangeStartIndex?: number;
+  rangeEndIndex?: number;
 };
 
 export function useGenerateSummary() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: ({ chatId, contextSize, rangeStartMessageId, rangeEndMessageId }: GenerateSummaryInput) =>
+    mutationFn: ({
+      chatId,
+      contextSize,
+      rangeStartMessageId,
+      rangeEndMessageId,
+      rangeStartIndex,
+      rangeEndIndex,
+    }: GenerateSummaryInput) =>
       api.post<{ summary: string; messageIds: string[] }>(`/chats/${chatId}/generate-summary`, {
         contextSize,
         rangeStartMessageId,
         rangeEndMessageId,
+        rangeStartIndex,
+        rangeEndIndex,
       }),
     onSuccess: (_data, vars) => {
       qc.invalidateQueries({ queryKey: chatKeys.detail(vars.chatId) });

--- a/packages/client/src/hooks/use-chats.ts
+++ b/packages/client/src/hooks/use-chats.ts
@@ -636,6 +636,52 @@ export function useUpdateMessageExtra(chatId: string | null) {
   });
 }
 
+export function useBulkSetMessagesHiddenFromAI() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ chatId, messageIds, hidden }: { chatId: string; messageIds: string[]; hidden: boolean }) =>
+      api.patch<{ updated: number }>(`/chats/${chatId}/messages/bulk-hidden`, { messageIds, hidden }),
+    onMutate: async ({ chatId, messageIds, hidden }) => {
+      await qc.cancelQueries({ queryKey: chatKeys.messages(chatId) });
+      const previous = qc.getQueryData<InfiniteData<Message[]>>(chatKeys.messages(chatId));
+      const idSet = new Set(messageIds);
+
+      qc.setQueryData<InfiniteData<Message[]>>(chatKeys.messages(chatId), (old) => {
+        if (!old?.pages) return old;
+        return {
+          ...old,
+          pages: old.pages.map((page) =>
+            page.map((msg) => {
+              if (!idSet.has(msg.id)) return msg;
+              let currentExtra: Record<string, unknown> = {};
+              try {
+                currentExtra =
+                  typeof msg.extra === "string"
+                    ? JSON.parse(msg.extra)
+                    : ((msg.extra ?? {}) as unknown as Record<string, unknown>);
+              } catch {
+                currentExtra = {};
+              }
+              return { ...msg, extra: { ...currentExtra, hiddenFromAI: hidden } as unknown as Message["extra"] };
+            }),
+          ),
+        };
+      });
+
+      return { previous };
+    },
+    onError: (_err, vars, context) => {
+      if (context?.previous) {
+        qc.setQueryData(chatKeys.messages(vars.chatId), context.previous);
+      }
+    },
+    onSettled: (_data, _err, vars) => {
+      qc.invalidateQueries({ queryKey: chatKeys.messages(vars.chatId) });
+      qc.invalidateQueries({ queryKey: lorebookKeys.active(vars.chatId) });
+    },
+  });
+}
+
 function replaceCachedMessage(
   old: InfiniteData<Message[]> | undefined,
   messageId: string,
@@ -734,7 +780,7 @@ export function useGenerateSummary() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: ({ chatId, contextSize, rangeStartMessageId, rangeEndMessageId }: GenerateSummaryInput) =>
-      api.post<{ summary: string }>(`/chats/${chatId}/generate-summary`, {
+      api.post<{ summary: string; messageIds: string[] }>(`/chats/${chatId}/generate-summary`, {
         contextSize,
         rangeStartMessageId,
         rangeEndMessageId,

--- a/packages/client/src/hooks/use-chats.ts
+++ b/packages/client/src/hooks/use-chats.ts
@@ -14,6 +14,7 @@ import { lorebookKeys } from "./use-lorebooks";
 import type {
   Chat,
   ChatMemoryChunk,
+  ChatSummaryEntry,
   ConversationNote,
   Message,
   MessageSwipe,
@@ -482,6 +483,60 @@ export function useUpdateChatSummaries() {
   });
 }
 
+export type SummaryEntryOperation =
+  | { operation: "replace"; entry: Partial<ChatSummaryEntry> & { id: string; content: string } }
+  | { operation: "delete"; entryId: string }
+  | { operation: "toggle"; entryId: string; enabled: boolean };
+
+function useSummaryEntryMutation() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ chatId, ...body }: { chatId: string } & SummaryEntryOperation) =>
+      api.patch<Chat>(`/chats/${chatId}/summary-entries`, body),
+    onSuccess: (data, vars) => {
+      if (data) {
+        qc.setQueryData(chatKeys.detail(vars.chatId), data);
+      } else {
+        qc.invalidateQueries({ queryKey: chatKeys.detail(vars.chatId) });
+      }
+      qc.invalidateQueries({ queryKey: chatKeys.list() });
+      qc.invalidateQueries({ queryKey: lorebookKeys.active(vars.chatId) });
+    },
+  });
+}
+
+export function useUpdateSummaryEntry() {
+  const mutation = useSummaryEntryMutation();
+  return {
+    ...mutation,
+    mutate: (input: { chatId: string; entry: Partial<ChatSummaryEntry> & { id: string; content: string } }) =>
+      mutation.mutate({ ...input, operation: "replace" }),
+    mutateAsync: (input: { chatId: string; entry: Partial<ChatSummaryEntry> & { id: string; content: string } }) =>
+      mutation.mutateAsync({ ...input, operation: "replace" }),
+  };
+}
+
+export function useDeleteSummaryEntry() {
+  const mutation = useSummaryEntryMutation();
+  return {
+    ...mutation,
+    mutate: (input: { chatId: string; entryId: string }) => mutation.mutate({ ...input, operation: "delete" }),
+    mutateAsync: (input: { chatId: string; entryId: string }) =>
+      mutation.mutateAsync({ ...input, operation: "delete" }),
+  };
+}
+
+export function useToggleSummaryEntry() {
+  const mutation = useSummaryEntryMutation();
+  return {
+    ...mutation,
+    mutate: (input: { chatId: string; entryId: string; enabled: boolean }) =>
+      mutation.mutate({ ...input, operation: "toggle" }),
+    mutateAsync: (input: { chatId: string; entryId: string; enabled: boolean }) =>
+      mutation.mutateAsync({ ...input, operation: "toggle" }),
+  };
+}
+
 /** Backfill missing conversation day/week summaries via the LLM. */
 export function useBackfillConversationSummaries() {
   const qc = useQueryClient();
@@ -791,7 +846,12 @@ export function useGenerateSummary() {
       rangeEndIndex,
       promptTemplateId,
     }: GenerateSummaryInput) =>
-      api.post<{ summary: string; messageIds: string[] }>(`/chats/${chatId}/generate-summary`, {
+      api.post<{
+        summary: string | null;
+        entry: ChatSummaryEntry | null;
+        entries: ChatSummaryEntry[];
+        messageIds: string[];
+      }>(`/chats/${chatId}/generate-summary`, {
         contextSize,
         rangeStartMessageId,
         rangeEndMessageId,

--- a/packages/client/src/hooks/use-chats.ts
+++ b/packages/client/src/hooks/use-chats.ts
@@ -776,6 +776,7 @@ export type GenerateSummaryInput = {
   rangeEndMessageId?: string;
   rangeStartIndex?: number;
   rangeEndIndex?: number;
+  promptTemplateId?: string | null;
 };
 
 export function useGenerateSummary() {
@@ -788,6 +789,7 @@ export function useGenerateSummary() {
       rangeEndMessageId,
       rangeStartIndex,
       rangeEndIndex,
+      promptTemplateId,
     }: GenerateSummaryInput) =>
       api.post<{ summary: string; messageIds: string[] }>(`/chats/${chatId}/generate-summary`, {
         contextSize,
@@ -795,6 +797,7 @@ export function useGenerateSummary() {
         rangeEndMessageId,
         rangeStartIndex,
         rangeEndIndex,
+        promptTemplateId,
       }),
     onSuccess: (_data, vars) => {
       qc.invalidateQueries({ queryKey: chatKeys.detail(vars.chatId) });

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -25,9 +25,18 @@ export type EchoChamberSide = "top-left" | "top-right" | "bottom-left" | "bottom
 export type UserStatus = "active" | "idle" | "dnd";
 export type RoleplayAvatarStyle = "circles" | "rectangles" | "panel";
 export type GameDialogueDisplayMode = "classic" | "stacked";
+export type SummaryPopoverSourceMode = "last" | "range";
 export interface FloatingWidgetPosition {
   x: number;
   y: number;
+}
+export interface SummaryPopoverSettings {
+  sourceMode: SummaryPopoverSourceMode;
+  contextSize: number | null;
+  rangeStart: number | null;
+  rangeEnd: number | null;
+  hideSummarisedMessages: boolean;
+  collapseHiddenMessages: boolean;
 }
 export const APP_LANGUAGE_OPTIONS = [{ id: "en", label: "English" }] as const;
 export type AppLanguage = (typeof APP_LANGUAGE_OPTIONS)[number]["id"];
@@ -79,6 +88,14 @@ const DEFAULT_GAME_SETUP_REMEMBERED_TEXT: GameSetupRememberedText = {
   playerGoals: "",
   preferences: "",
 };
+const DEFAULT_SUMMARY_POPOVER_SETTINGS: SummaryPopoverSettings = {
+  sourceMode: "last",
+  contextSize: null,
+  rangeStart: null,
+  rangeEnd: null,
+  hideSummarisedMessages: false,
+  collapseHiddenMessages: false,
+};
 
 function clampImageDimension(value: number) {
   const rounded = Number.isFinite(value) ? Math.round(value) : 0;
@@ -117,6 +134,20 @@ function normalizeTrackerPanelSectionOrder(value: unknown): TrackerPanelSectionO
   }
 
   return order;
+}
+
+function normalizeSummaryPopoverSettings(value: unknown): SummaryPopoverSettings {
+  const raw = typeof value === "object" && value !== null ? (value as Record<string, unknown>) : {};
+  const numberOrNull = (next: unknown) => (typeof next === "number" && Number.isFinite(next) ? Math.round(next) : null);
+
+  return {
+    sourceMode: raw.sourceMode === "range" ? "range" : "last",
+    contextSize: numberOrNull(raw.contextSize),
+    rangeStart: numberOrNull(raw.rangeStart),
+    rangeEnd: numberOrNull(raw.rangeEnd),
+    hideSummarisedMessages: raw.hideSummarisedMessages === true,
+    collapseHiddenMessages: raw.collapseHiddenMessages === true,
+  };
 }
 
 function normalizeLearnedGameSetupOption(value: unknown) {
@@ -286,6 +317,8 @@ interface UIState {
   intuitiveSwipeRerollLatest: boolean;
   /** When true, pressing Up Arrow with an empty chat input opens the last user message for editing (Conversation/Roleplay). */
   editLastMessageOnArrowUp: boolean;
+  /** Persisted controls shown in the Chat Summary popover settings window. */
+  summaryPopoverSettings: SummaryPopoverSettings;
 
   // ── Text Appearance ──
   /** Color for narrator text in RP mode (empty = default amber) */
@@ -489,6 +522,7 @@ interface UIState {
   setIntuitiveSwipeNavigation: (v: boolean) => void;
   setIntuitiveSwipeRerollLatest: (v: boolean) => void;
   setEditLastMessageOnArrowUp: (v: boolean) => void;
+  setSummaryPopoverSettings: (settings: Partial<SummaryPopoverSettings>) => void;
   setNarrationFontColor: (v: string) => void;
   setNarrationOpacity: (v: number) => void;
   setChatFontColor: (v: string) => void;
@@ -607,6 +641,7 @@ export function pickSyncedSettings(state: UIState) {
     intuitiveSwipeNavigation: state.intuitiveSwipeNavigation,
     intuitiveSwipeRerollLatest: state.intuitiveSwipeRerollLatest,
     editLastMessageOnArrowUp: state.editLastMessageOnArrowUp,
+    summaryPopoverSettings: state.summaryPopoverSettings,
     narrationFontColor: state.narrationFontColor,
     narrationOpacity: state.narrationOpacity,
     chatFontColor: state.chatFontColor,
@@ -723,6 +758,7 @@ export const useUIStore = create<UIState>()(
       intuitiveSwipeNavigation: false,
       intuitiveSwipeRerollLatest: false,
       editLastMessageOnArrowUp: true,
+      summaryPopoverSettings: DEFAULT_SUMMARY_POPOVER_SETTINGS,
       narrationFontColor: "",
       narrationOpacity: 80,
       chatFontColor: "",
@@ -1080,6 +1116,13 @@ export const useUIStore = create<UIState>()(
       setIntuitiveSwipeNavigation: (v) => set({ intuitiveSwipeNavigation: v }),
       setIntuitiveSwipeRerollLatest: (v) => set({ intuitiveSwipeRerollLatest: v }),
       setEditLastMessageOnArrowUp: (v) => set({ editLastMessageOnArrowUp: v }),
+      setSummaryPopoverSettings: (settings) =>
+        set((state) => ({
+          summaryPopoverSettings: normalizeSummaryPopoverSettings({
+            ...state.summaryPopoverSettings,
+            ...settings,
+          }),
+        })),
       setNarrationFontColor: (v) => set({ narrationFontColor: v }),
       setNarrationOpacity: (v) => set({ narrationOpacity: Math.max(0, Math.min(100, v)) }),
       setChatFontColor: (v) => set({ chatFontColor: v }),
@@ -1180,7 +1223,7 @@ export const useUIStore = create<UIState>()(
     }),
     {
       name: "marinara-engine-ui",
-      version: 30,
+      version: 31,
       // Debounce localStorage writes to avoid sync I/O on every state change
       storage: createJSONStorage(() => {
         let timer: ReturnType<typeof setTimeout> | null = null;
@@ -1450,6 +1493,11 @@ export const useUIStore = create<UIState>()(
         if (version <= 29 && persisted.chibiProfessorMariEnabled === undefined) {
           persisted.chibiProfessorMariEnabled = true;
         }
+        // v30 -> v31: persist Chat Summary popover source and display controls.
+        if (version <= 30) {
+          persisted.summaryPopoverSettings = normalizeSummaryPopoverSettings(persisted.summaryPopoverSettings);
+        }
+        persisted.summaryPopoverSettings = normalizeSummaryPopoverSettings(persisted.summaryPopoverSettings);
         return persisted;
       },
       partialize: (state) => ({
@@ -1507,6 +1555,8 @@ export const useUIStore = create<UIState>()(
         spotifyMobileWidgetPosition: state.spotifyMobileWidgetPosition,
         intuitiveSwipeNavigation: state.intuitiveSwipeNavigation,
         intuitiveSwipeRerollLatest: state.intuitiveSwipeRerollLatest,
+        editLastMessageOnArrowUp: state.editLastMessageOnArrowUp,
+        summaryPopoverSettings: state.summaryPopoverSettings,
         narrationFontColor: state.narrationFontColor,
         narrationOpacity: state.narrationOpacity,
         chatFontColor: state.chatFontColor,

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -36,6 +36,7 @@ import { normalizeTimestampOverrides } from "../services/import/import-timestamp
 import {
   findLastIndex,
   parseExtra,
+  isMessageHiddenFromAI,
   resolveVisibleGameStateAnchor,
   shouldEnableAgentsForGeneration,
 } from "./generate/generate-route-utils.js";
@@ -1855,7 +1856,15 @@ export async function chatsRoutes(app: FastifyInstance) {
     const requestedRangeStartMessageId =
       typeof body.rangeStartMessageId === "string" ? body.rangeStartMessageId : null;
     const requestedRangeEndMessageId = typeof body.rangeEndMessageId === "string" ? body.rangeEndMessageId : null;
-    const hasRange = !!requestedRangeStartMessageId && !!requestedRangeEndMessageId;
+    const requestedRangeStartIndex =
+      typeof body.rangeStartIndex === "number" && Number.isInteger(body.rangeStartIndex)
+        ? body.rangeStartIndex
+        : null;
+    const requestedRangeEndIndex =
+      typeof body.rangeEndIndex === "number" && Number.isInteger(body.rangeEndIndex) ? body.rangeEndIndex : null;
+    const hasRangeByMessageId = !!requestedRangeStartMessageId && !!requestedRangeEndMessageId;
+    const hasRangeByIndex = requestedRangeStartIndex !== null && requestedRangeEndIndex !== null;
+    const hasRange = hasRangeByMessageId || hasRangeByIndex;
 
     const chatConnId = chat.connectionId;
 
@@ -1913,14 +1922,23 @@ export async function chatsRoutes(app: FastifyInstance) {
       model = conn.model;
     }
 
-    // Build conversation context (use contextSize from popover, or a custom range)
+    // Build conversation context (use contextSize from popover, or a custom range).
+    // Hidden-from-AI messages are excluded from summary generation even when
+    // they fall inside the selected range.
     const allMessages = await storage.listMessages(req.params.id);
     const selectedMessages = hasRange
       ? (() => {
-          const startIndex = allMessages.findIndex((message) => message.id === requestedRangeStartMessageId);
-          const endIndex = allMessages.findIndex((message) => message.id === requestedRangeEndMessageId);
+          const startIndex = hasRangeByIndex
+            ? requestedRangeStartIndex! - 1
+            : allMessages.findIndex((message) => message.id === requestedRangeStartMessageId);
+          const endIndex = hasRangeByIndex
+            ? requestedRangeEndIndex! - 1
+            : allMessages.findIndex((message) => message.id === requestedRangeEndMessageId);
           if (startIndex === -1 || endIndex === -1) {
             return { error: "Summary range messages were not found in this chat" as const };
+          }
+          if (startIndex < 0 || endIndex < 0 || startIndex >= allMessages.length || endIndex >= allMessages.length) {
+            return { error: "Summary range is outside this chat's message history" as const };
           }
           const from = Math.min(startIndex, endIndex);
           const to = Math.max(startIndex, endIndex);
@@ -1928,14 +1946,14 @@ export async function chatsRoutes(app: FastifyInstance) {
           if (count > 200) {
             return { error: "Summary ranges cannot include more than 200 messages" as const };
           }
-          return allMessages.slice(from, to + 1);
+          return allMessages.slice(from, to + 1).filter((message) => !isMessageHiddenFromAI(message));
         })()
-      : allMessages.slice(-contextSize);
+      : allMessages.slice(-contextSize).filter((message) => !isMessageHiddenFromAI(message));
     if (selectedMessages && "error" in selectedMessages) {
       return reply.status(400).send({ error: selectedMessages.error });
     }
     if (selectedMessages.length === 0) {
-      return reply.status(400).send({ error: "No messages available for the requested summary range" });
+      return reply.status(400).send({ error: "No non-hidden messages available for the requested summary range" });
     }
     const chatLog = selectedMessages.map((m: any) => `[${m.role}]: ${(m.content as string).slice(0, 2000)}`).join("\n\n");
 

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -1845,12 +1845,17 @@ export async function chatsRoutes(app: FastifyInstance) {
 
     const chatMeta = typeof chat.metadata === "string" ? JSON.parse(chat.metadata) : (chat.metadata ?? {});
 
-    // Accept context size from request body, fall back to chat meta, then default 50
+    // Accept context size from request body, fall back to chat meta, then default 50.
+    // Manual UI generation may also pass inclusive message ID anchors.
     const body = (req.body ?? {}) as Record<string, unknown>;
     const contextSize = Math.max(
       5,
       Math.min(200, Number(body.contextSize) || (chatMeta.summaryContextSize as number) || 50),
     );
+    const requestedRangeStartMessageId =
+      typeof body.rangeStartMessageId === "string" ? body.rangeStartMessageId : null;
+    const requestedRangeEndMessageId = typeof body.rangeEndMessageId === "string" ? body.rangeEndMessageId : null;
+    const hasRange = !!requestedRangeStartMessageId && !!requestedRangeEndMessageId;
 
     const chatConnId = chat.connectionId;
 
@@ -1908,10 +1913,31 @@ export async function chatsRoutes(app: FastifyInstance) {
       model = conn.model;
     }
 
-    // Build conversation context (use contextSize from popover)
+    // Build conversation context (use contextSize from popover, or a custom range)
     const allMessages = await storage.listMessages(req.params.id);
-    const recentMessages = allMessages.slice(-contextSize);
-    const chatLog = recentMessages.map((m: any) => `[${m.role}]: ${(m.content as string).slice(0, 2000)}`).join("\n\n");
+    const selectedMessages = hasRange
+      ? (() => {
+          const startIndex = allMessages.findIndex((message) => message.id === requestedRangeStartMessageId);
+          const endIndex = allMessages.findIndex((message) => message.id === requestedRangeEndMessageId);
+          if (startIndex === -1 || endIndex === -1) {
+            return { error: "Summary range messages were not found in this chat" as const };
+          }
+          const from = Math.min(startIndex, endIndex);
+          const to = Math.max(startIndex, endIndex);
+          const count = to - from + 1;
+          if (count > 200) {
+            return { error: "Summary ranges cannot include more than 200 messages" as const };
+          }
+          return allMessages.slice(from, to + 1);
+        })()
+      : allMessages.slice(-contextSize);
+    if (selectedMessages && "error" in selectedMessages) {
+      return reply.status(400).send({ error: selectedMessages.error });
+    }
+    if (selectedMessages.length === 0) {
+      return reply.status(400).send({ error: "No messages available for the requested summary range" });
+    }
+    const chatLog = selectedMessages.map((m: any) => `[${m.role}]: ${(m.content as string).slice(0, 2000)}`).join("\n\n");
 
     const previousSummary = chatMeta.summary ?? null;
     const summaryPrompt = getDefaultAgentPrompt("chat-summary");
@@ -1950,11 +1976,14 @@ export async function chatsRoutes(app: FastifyInstance) {
       summaryText = result.content.trim();
     }
 
-    // Append to existing summary (don't replace)
-    const existing = ((chatMeta.summary as string) ?? "").trim();
-    const combined = existing ? `${existing}\n\n${summaryText}` : summaryText;
-    const merged = { ...chatMeta, summary: combined };
-    await storage.updateMetadata(req.params.id, merged);
+    // Append to the latest summary without replacing concurrent metadata changes.
+    let combined = summaryText;
+    const updatedChat = await storage.patchMetadata(req.params.id, (freshMeta) => {
+      const existing = ((freshMeta.summary as string) ?? "").trim();
+      combined = existing ? `${existing}\n\n${summaryText}` : summaryText;
+      return { summary: combined };
+    });
+    if (!updatedChat) return reply.status(404).send({ error: "Chat not found" });
 
     return { summary: combined };
   });

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -1985,6 +1985,6 @@ export async function chatsRoutes(app: FastifyInstance) {
     });
     if (!updatedChat) return reply.status(404).send({ error: "Chat not found" });
 
-    return { summary: combined };
+    return { summary: combined, messageIds: selectedMessages.map((message) => message.id) };
   });
 }

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -22,6 +22,7 @@ import type {
   CharacterData,
   ChatMemoryChunk,
   ChatSummaryEntry,
+  GameNpc,
   LorebookEntryTimingState,
 } from "@marinara-engine/shared";
 import { createChatsStorage } from "../services/storage/chats.storage.js";

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -7,14 +7,23 @@ import {
   LOCAL_SIDECAR_CONNECTION_ID,
   createChatSchema,
   createMessageSchema,
+  appendChatSummaryEntryToMetadata,
+  compileChatSummaryEntries,
+  createChatSummaryEntry,
   getDefaultAgentPrompt,
   markAutonomousUnreadSchema,
   nameToXmlTag,
+  normalizeChatSummaryEntries,
   resolveMacros,
   summariesPatchSchema,
   coerceGameStateTextValue,
 } from "@marinara-engine/shared";
-import type { CharacterData, ChatMemoryChunk, GameNpc, LorebookEntryTimingState } from "@marinara-engine/shared";
+import type {
+  CharacterData,
+  ChatMemoryChunk,
+  ChatSummaryEntry,
+  LorebookEntryTimingState,
+} from "@marinara-engine/shared";
 import { createChatsStorage } from "../services/storage/chats.storage.js";
 import { createCharactersStorage } from "../services/storage/characters.storage.js";
 import { createConnectionsStorage } from "../services/storage/connections.storage.js";
@@ -69,6 +78,10 @@ function sanitizeChatGameNpcAvatars<T extends { metadata?: unknown }>(chat: T): 
     metadata: typeof chat.metadata === "string" ? JSON.stringify(sanitizedMetadata) : sanitizedMetadata,
   };
 }
+type SummaryEntriesPatchBody =
+  | { operation: "replace"; entry: Partial<ChatSummaryEntry> & { id: string; content: string } }
+  | { operation: "delete"; entryId: string }
+  | { operation: "toggle"; entryId: string; enabled: boolean };
 
 async function loadLatestChatGameSnapshot(
   app: FastifyInstance,
@@ -409,6 +422,72 @@ export async function chatsRoutes(app: FastifyInstance) {
       weekSummaries: { ...(existing.weekSummaries ?? {}), ...(parsed.data.weekSummaries ?? {}) },
     };
     return storage.updateMetadata(req.params.id, merged);
+  });
+
+  // Update rolling summary entries without replacing unrelated chat metadata.
+  app.patch<{ Params: { id: string }; Body: SummaryEntriesPatchBody }>("/:id/summary-entries", async (req, reply) => {
+    const body = req.body;
+    if (!body || typeof body !== "object" || !("operation" in body)) {
+      return reply.status(400).send({ error: "Invalid summary entry operation" });
+    }
+    if (body.operation === "replace") {
+      if (!body.entry || typeof body.entry.id !== "string" || typeof body.entry.content !== "string") {
+        return reply.status(400).send({ error: "replace requires entry.id and entry.content" });
+      }
+    } else if (body.operation === "delete") {
+      if (typeof body.entryId !== "string" || !body.entryId.trim()) {
+        return reply.status(400).send({ error: "delete requires entryId" });
+      }
+    } else if (body.operation === "toggle") {
+      if (typeof body.entryId !== "string" || !body.entryId.trim() || typeof body.enabled !== "boolean") {
+        return reply.status(400).send({ error: "toggle requires entryId and enabled" });
+      }
+    } else {
+      return reply.status(400).send({ error: "Unsupported summary entry operation" });
+    }
+
+    const updated = await storage.patchMetadata(req.params.id, (freshMeta) => {
+      const entries = normalizeChatSummaryEntries(freshMeta.summaryEntries, {
+        legacySummary: typeof freshMeta.summary === "string" ? freshMeta.summary : null,
+      });
+      let nextEntries: ChatSummaryEntry[];
+
+      if (body.operation === "replace") {
+        const now = new Date().toISOString();
+        const existing = entries.find((entry) => entry.id === body.entry.id);
+        const replacement = createChatSummaryEntry(
+          {
+            ...existing,
+            ...body.entry,
+            id: body.entry.id,
+            content: body.entry.content,
+            updatedAt: now,
+            createdAt: existing?.createdAt ?? body.entry.createdAt ?? now,
+          },
+          { createId: newId, now },
+        );
+        nextEntries = entries.some((entry) => entry.id === replacement.id)
+          ? entries.map((entry) => (entry.id === replacement.id ? replacement : entry))
+          : [...entries, replacement];
+      } else if (body.operation === "delete") {
+        nextEntries = entries.filter((entry) => entry.id !== body.entryId);
+      } else if (body.operation === "toggle") {
+        const now = new Date().toISOString();
+        nextEntries = entries.map((entry) =>
+          entry.id === body.entryId ? { ...entry, enabled: body.enabled, updatedAt: now } : entry,
+        );
+      } else {
+        nextEntries = entries;
+      }
+
+      return {
+        summaryEntries: nextEntries,
+        summary: compileChatSummaryEntries(nextEntries),
+      };
+    });
+
+    if (!updated) return reply.status(404).send({ error: "Chat not found" });
+    return updated;
   });
 
   // Generate any missing conversation day/week summaries on demand. This uses
@@ -1926,6 +2005,8 @@ export async function chatsRoutes(app: FastifyInstance) {
     // Hidden-from-AI messages are excluded from summary generation even when
     // they fall inside the selected range.
     const allMessages = await storage.listMessages(req.params.id);
+    let selectedRangeStartIndex: number | undefined;
+    let selectedRangeEndIndex: number | undefined;
     const selectedMessages = hasRange
       ? (() => {
           const startIndex = hasRangeByIndex
@@ -1946,6 +2027,8 @@ export async function chatsRoutes(app: FastifyInstance) {
           if (count > 200) {
             return { error: "Summary ranges cannot include more than 200 messages" as const };
           }
+          selectedRangeStartIndex = from + 1;
+          selectedRangeEndIndex = to + 1;
           return allMessages.slice(from, to + 1).filter((message) => !isMessageHiddenFromAI(message));
         })()
       : allMessages.slice(-contextSize).filter((message) => !isMessageHiddenFromAI(message));
@@ -2014,15 +2097,43 @@ export async function chatsRoutes(app: FastifyInstance) {
       summaryText = result.content.trim();
     }
 
-    // Append to the latest summary without replacing concurrent metadata changes.
-    let combined = summaryText;
+    // Append as a structured entry and recompile the prompt-facing summary
+    // without replacing concurrent metadata changes.
+    let combined: string | null = summaryText;
+    let createdEntry: ChatSummaryEntry | null = null;
+    let summaryEntries: ChatSummaryEntry[] = [];
     const updatedChat = await storage.patchMetadata(req.params.id, (freshMeta) => {
-      const existing = ((freshMeta.summary as string) ?? "").trim();
-      combined = existing ? `${existing}\n\n${summaryText}` : summaryText;
-      return { summary: combined };
+      const now = new Date().toISOString();
+      const result = appendChatSummaryEntryToMetadata(
+        freshMeta,
+        {
+          kind: "rolling",
+          origin: "manual",
+          sourceMode: hasRange ? "range" : "last",
+          content: summaryText,
+          enabled: true,
+          messageCount: selectedMessages.length,
+          rangeStartIndex: selectedRangeStartIndex,
+          rangeEndIndex: selectedRangeEndIndex,
+          messageIds: selectedMessages.map((message) => message.id),
+          promptTemplateId: requestedPromptTemplateId,
+          createdAt: now,
+          updatedAt: now,
+        },
+        { createId: newId, now },
+      );
+      combined = result.summary;
+      createdEntry = result.entry;
+      summaryEntries = result.entries;
+      return { summary: result.summary, summaryEntries: result.entries };
     });
     if (!updatedChat) return reply.status(404).send({ error: "Chat not found" });
 
-    return { summary: combined, messageIds: selectedMessages.map((message) => message.id) };
+    return {
+      summary: combined,
+      entry: createdEntry,
+      entries: summaryEntries,
+      messageIds: selectedMessages.map((message) => message.id),
+    };
   });
 }

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -1958,7 +1958,27 @@ export async function chatsRoutes(app: FastifyInstance) {
     const chatLog = selectedMessages.map((m: any) => `[${m.role}]: ${(m.content as string).slice(0, 2000)}`).join("\n\n");
 
     const previousSummary = chatMeta.summary ?? null;
-    const summaryPrompt = getDefaultAgentPrompt("chat-summary");
+    const requestedPromptTemplateId =
+      typeof body.promptTemplateId === "string" && body.promptTemplateId.trim()
+        ? body.promptTemplateId.trim()
+        : typeof chatMeta.activeSummaryPromptTemplateId === "string" && chatMeta.activeSummaryPromptTemplateId.trim()
+          ? chatMeta.activeSummaryPromptTemplateId.trim()
+          : null;
+    const summaryPromptTemplates = Array.isArray(chatMeta.summaryPromptTemplates)
+      ? (chatMeta.summaryPromptTemplates as Array<Record<string, unknown>>)
+      : [];
+    const selectedSummaryPrompt = requestedPromptTemplateId
+      ? summaryPromptTemplates.find(
+          (template) =>
+            template.id === requestedPromptTemplateId &&
+            typeof template.prompt === "string" &&
+            template.prompt.trim().length > 0,
+        )
+      : null;
+    const summaryPrompt =
+      typeof selectedSummaryPrompt?.prompt === "string"
+        ? selectedSummaryPrompt.prompt.trim()
+        : (summaryAgentCfg?.promptTemplate as string | undefined)?.trim() || getDefaultAgentPrompt("chat-summary");
 
     const messages: Array<{ role: "system" | "user"; content: string }> = [
       { role: "system", content: summaryPrompt },

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -17,6 +17,7 @@ import {
   resolveMacros,
   LIMITS,
   coerceGameStateTextValue,
+  appendChatSummaryEntryToMetadata,
 } from "@marinara-engine/shared";
 import type {
   AgentContext,
@@ -29,6 +30,7 @@ import type {
   HapticDeviceCommand,
   PlayerStats,
   LorebookEntryTimingState,
+  ChatSummaryEntry,
 } from "@marinara-engine/shared";
 import { createChatsStorage } from "../services/storage/chats.storage.js";
 import { createConnectionsStorage } from "../services/storage/connections.storage.js";
@@ -7987,12 +7989,24 @@ export async function generateRoutes(app: FastifyInstance) {
               const csData = result.data as Record<string, unknown>;
               const newText = ((csData.summary as string) ?? "").trim();
               if (newText) {
+                let createdEntry: ChatSummaryEntry | null = null;
+                let summaryEntries: ChatSummaryEntry[] = [];
                 const updatedMeta = await updateChatMetadataForTools((currentMeta) => {
-                  const existing = ((currentMeta.summary as string) ?? "").trim();
-                  return { summary: existing ? `${existing}\n\n${newText}` : newText };
+                  const result = appendChatSummaryEntryToMetadata(currentMeta, {
+                    kind: "rolling",
+                    origin: "automated",
+                    sourceMode: "agent",
+                    content: newText,
+                    enabled: true,
+                  });
+                  createdEntry = result.entry;
+                  summaryEntries = result.entries;
+                  return { summary: result.summary, summaryEntries: result.entries };
                 });
                 const combined = typeof updatedMeta.summary === "string" ? updatedMeta.summary : newText;
-                reply.raw.write(`data: ${JSON.stringify({ type: "chat_summary", data: { summary: combined } })}\n\n`);
+                reply.raw.write(
+                  `data: ${JSON.stringify({ type: "chat_summary", data: { summary: combined, entry: createdEntry, entries: summaryEntries } })}\n\n`,
+                );
               }
             } catch {
               // Non-critical

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -1069,7 +1069,7 @@ export async function generateRoutes(app: FastifyInstance) {
       const allChatMessages = await chats.listMessages(input.chatId);
       const chatMode = requestChatMode;
       const lorebookGenerationTriggers = resolveLorebookGenerationTriggers(input, chatMode);
-      const supportsHiddenFromAI = chatMode === "roleplay" || chatMode === "visual_novel";
+      const supportsHiddenFromAI = chatMode === "conversation" || chatMode === "roleplay" || chatMode === "visual_novel";
       const preferLatestVisibleGameState = shouldPreferLatestVisibleGameState(input);
 
       // ── Conversation-start filter: find the latest "isConversationStart" marker ──

--- a/packages/server/src/routes/generate/dry-run-route.ts
+++ b/packages/server/src/routes/generate/dry-run-route.ts
@@ -628,7 +628,7 @@ export async function registerDryRunRoute(app: FastifyInstance) {
     // Pull existing messages, apply the same conversation-start + context limit filtering
     const allChatMessages = await chats.listMessages(chatId);
     const chatMode = (chat.mode as string) ?? "roleplay";
-    const supportsHiddenFromAI = chatMode === "roleplay" || chatMode === "visual_novel";
+    const supportsHiddenFromAI = chatMode === "conversation" || chatMode === "roleplay" || chatMode === "visual_novel";
     let startIdx = 0;
     for (let i = allChatMessages.length - 1; i >= 0; i--) {
       const extra = parseExtra(allChatMessages[i]!.extra);

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -2004,7 +2004,8 @@ export async function registerRetryAgentsRoute(app: FastifyInstance) {
         };
       }
 
-      const supportsHiddenFromAI = chat.mode === "roleplay" || chat.mode === "visual_novel";
+      const supportsHiddenFromAI =
+        chat.mode === "conversation" || chat.mode === "roleplay" || chat.mode === "visual_novel";
       if (supportsHiddenFromAI) {
         recentMessages = recentMessages.filter((message: any) => !isMessageHiddenFromAI(message));
         if (preGenerationRecentMessages) {

--- a/packages/server/src/services/storage/chats.storage.ts
+++ b/packages/server/src/services/storage/chats.storage.ts
@@ -657,7 +657,14 @@ export function createChatsStorage(db: DB) {
      */
     async bulkSetHiddenFromAI(chatId: string, messageIds: string[], hidden: boolean): Promise<number> {
       if (messageIds.length === 0) return 0;
-      for (const id of messageIds) {
+      const uniqueIds = Array.from(new Set(messageIds));
+      const scopedRows = await db
+        .select({ id: messages.id })
+        .from(messages)
+        .where(and(eq(messages.chatId, chatId), inArray(messages.id, uniqueIds)));
+      const scopedIds = scopedRows.map((row) => row.id);
+
+      for (const id of scopedIds) {
         await this.updateMessageExtra(id, { hiddenFromAI: hidden });
         // Mirror what the single-message /extra route does: propagate the flag
         // to all swipe rows so setActiveSwipe() cannot clobber it.
@@ -666,7 +673,7 @@ export function createChatsStorage(db: DB) {
           await this.updateSwipeExtra(id, swipe.index, { hiddenFromAI: hidden });
         }
       }
-      return messageIds.length;
+      return scopedIds.length;
     },
 
     /** Atomically append an attachment to a message's extra JSON field. */

--- a/packages/server/src/services/tools/tool-executor.ts
+++ b/packages/server/src/services/tools/tool-executor.ts
@@ -42,7 +42,6 @@ export type MetadataUpdater = (current: MetadataPatch) => MetadataPatch | Promis
 export type MetadataPatchInput = MetadataPatch | MetadataUpdater;
 
 const MAX_APPEND_BYTES = 16 * 1024;
-const MAX_TOTAL_SUMMARY_BYTES = 64 * 1024;
 const MAX_CHAT_VARIABLE_KEY_LENGTH = 128;
 const MAX_CHAT_VARIABLE_VALUE_BYTES = 64 * 1024;
 const MAX_CHAT_VARIABLES = 256;
@@ -475,8 +474,7 @@ async function appendChatSummary(
         enabled: true,
       },
     );
-    const summary = trimToUtf8Bytes(result.summary ?? "", MAX_TOTAL_SUMMARY_BYTES, true).trim() || null;
-    return { summary, summaryEntries: result.entries };
+    return { summary: result.summary, summaryEntries: result.entries };
   });
   return { summary: typeof updated.summary === "string" ? updated.summary : sanitizedText };
 }

--- a/packages/server/src/services/tools/tool-executor.ts
+++ b/packages/server/src/services/tools/tool-executor.ts
@@ -8,6 +8,7 @@ import { isCustomToolScriptEnabled, isWebhookLocalUrlsEnabled } from "../../conf
 import { safeFetch } from "../../utils/security.js";
 import { logger } from "../../lib/logger.js";
 import { normalizeSpotifySearchQuery } from "../spotify/spotify.service.js";
+import { appendChatSummaryEntryToMetadata } from "@marinara-engine/shared";
 
 export interface ToolExecutionResult {
   toolCallId: string;
@@ -462,10 +463,20 @@ async function appendChatSummary(
   }
 
   const updated = await context.onUpdateMetadata((currentMeta) => {
-    const existing =
-      typeof currentMeta.summary === "string" ? sanitizePersistedSummaryText(currentMeta.summary.trim()) : "";
-    const summary = existing ? `${existing}\n\n${sanitizedText}` : sanitizedText;
-    return { summary: trimToUtf8Bytes(summary, MAX_TOTAL_SUMMARY_BYTES, true).trim() };
+    const existingSummary =
+      typeof currentMeta.summary === "string" ? sanitizePersistedSummaryText(currentMeta.summary.trim()) : null;
+    const result = appendChatSummaryEntryToMetadata(
+      { ...currentMeta, summary: existingSummary },
+      {
+        kind: "rolling",
+        origin: "automated",
+        sourceMode: "agent",
+        content: sanitizedText,
+        enabled: true,
+      },
+    );
+    const summary = trimToUtf8Bytes(result.summary ?? "", MAX_TOTAL_SUMMARY_BYTES, true).trim() || null;
+    return { summary, summaryEntries: result.entries };
   });
   return { summary: typeof updated.summary === "string" ? updated.summary : sanitizedText };
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -61,3 +61,4 @@ export * from "./utils/generation-guide.js";
 export * from "./utils/lorebook-keyword-matching.js";
 export * from "./utils/regex-safety.js";
 export * from "./utils/game-state-text.js";
+export * from "./utils/chat-summary-entries.js";

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -84,6 +84,34 @@ export interface ChatSummaryPromptTemplate {
   prompt: string;
 }
 
+/** Rolling summary entry category. Extensible beyond rolling summaries later. */
+export type ChatSummaryEntryKind = "rolling";
+
+/** Whether a rolling summary entry was user-created, agent-created, or migrated from the legacy blob. */
+export type ChatSummaryEntryOrigin = "manual" | "automated" | "legacy";
+
+/** Source selector used to create a rolling summary entry. */
+export type ChatSummaryEntrySource = "last" | "range" | "agent";
+
+/** A single structured rolling chat summary entry. */
+export interface ChatSummaryEntry {
+  id: string;
+  kind: ChatSummaryEntryKind;
+  origin: ChatSummaryEntryOrigin;
+  title: string;
+  content: string;
+  enabled: boolean;
+  sourceMode: ChatSummaryEntrySource;
+  messageCount?: number;
+  rangeStartIndex?: number;
+  rangeEndIndex?: number;
+  messageIds?: string[];
+  promptTemplateId?: string | null;
+  tokenEstimate: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
 /** A vectorized recall fragment created from one chat's messages. */
 export interface ChatMemoryChunk {
   id: string;
@@ -101,8 +129,10 @@ export interface ChatMemoryChunk {
 
 /** Extra metadata stored on a chat. */
 export interface ChatMetadata {
-  /** Summary text for context injection */
+  /** Compiled enabled rolling summary text for context injection. Derived from summaryEntries when present. */
   summary: string | null;
+  /** Structured rolling summary entries. Missing means legacy summary-only metadata. */
+  summaryEntries?: ChatSummaryEntry[];
   /** Recent message count used by manual rolling summary generation and the automated summary agent. */
   summaryContextSize?: number;
   /** Chat-scoped manual summary prompt templates. Missing or empty uses the built-in default. */

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -96,6 +96,8 @@ export interface ChatMemoryChunk {
 export interface ChatMetadata {
   /** Summary text for context injection */
   summary: string | null;
+  /** Recent message count used by manual rolling summary generation and the automated summary agent. */
+  summaryContextSize?: number;
   /** Custom tags for organisation */
   tags: string[];
   /** Whether agents are enabled for this chat */

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -77,6 +77,13 @@ export interface WeekSummaryEntry {
   keyDetails: string[];
 }
 
+/** A chat-scoped prompt template used by manual rolling summary generation. */
+export interface ChatSummaryPromptTemplate {
+  id: string;
+  name: string;
+  prompt: string;
+}
+
 /** A vectorized recall fragment created from one chat's messages. */
 export interface ChatMemoryChunk {
   id: string;
@@ -98,6 +105,10 @@ export interface ChatMetadata {
   summary: string | null;
   /** Recent message count used by manual rolling summary generation and the automated summary agent. */
   summaryContextSize?: number;
+  /** Chat-scoped manual summary prompt templates. Missing or empty uses the built-in default. */
+  summaryPromptTemplates?: ChatSummaryPromptTemplate[];
+  /** Selected manual summary prompt template ID. Null/omitted uses the built-in default. */
+  activeSummaryPromptTemplateId?: string | null;
   /** Custom tags for organisation */
   tags: string[];
   /** Whether agents are enabled for this chat */

--- a/packages/shared/src/utils/chat-summary-entries.ts
+++ b/packages/shared/src/utils/chat-summary-entries.ts
@@ -9,6 +9,8 @@ const VALID_KINDS = new Set<ChatSummaryEntryKind>(["rolling"]);
 const VALID_ORIGINS = new Set<ChatSummaryEntryOrigin>(["manual", "automated", "legacy"]);
 const VALID_SOURCES = new Set<ChatSummaryEntrySource>(["last", "range", "agent"]);
 
+export const COMPILED_CHAT_SUMMARY_MAX_BYTES = 64 * 1024;
+
 export type ChatSummaryEntryInput = Partial<ChatSummaryEntry> & {
   content: string;
 };
@@ -34,6 +36,49 @@ function fallbackId(prefix: string, seed: string) {
 
 function trimString(value: unknown) {
   return typeof value === "string" ? value.trim() : "";
+}
+
+function utf8ByteLength(text: string): number {
+  let bytes = 0;
+  for (let i = 0; i < text.length; i += 1) {
+    const code = text.charCodeAt(i);
+    if (code < 0x80) {
+      bytes += 1;
+    } else if (code < 0x800) {
+      bytes += 2;
+    } else if (code >= 0xd800 && code <= 0xdbff && i + 1 < text.length) {
+      const next = text.charCodeAt(i + 1);
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        bytes += 4;
+        i += 1;
+      } else {
+        bytes += 3;
+      }
+    } else {
+      bytes += 3;
+    }
+  }
+  return bytes;
+}
+
+function trimToUtf8Bytes(text: string, maxBytes: number, fromStart = true): string {
+  if (maxBytes <= 0) return "";
+  if (utf8ByteLength(text) <= maxBytes) return text;
+
+  let low = 0;
+  let high = text.length;
+  while (low < high) {
+    const mid = Math.ceil((low + high) / 2);
+    const candidate = fromStart ? text.slice(text.length - mid) : text.slice(0, mid);
+    if (utf8ByteLength(candidate) <= maxBytes) {
+      low = mid;
+    } else {
+      high = mid - 1;
+    }
+  }
+
+  const trimmed = fromStart ? text.slice(text.length - low) : text.slice(0, low);
+  return fromStart ? trimmed.replace(/^[\uDC00-\uDFFF]/, "") : trimmed.replace(/[\uD800-\uDBFF]$/, "");
 }
 
 function normalizeIsoTimestamp(value: unknown, fallback: string) {
@@ -214,7 +259,8 @@ export function compileChatSummaryEntries(entries: ChatSummaryEntry[]): string |
     .filter(Boolean)
     .join("\n\n")
     .trim();
-  return compiled || null;
+  if (!compiled) return null;
+  return trimToUtf8Bytes(compiled, COMPILED_CHAT_SUMMARY_MAX_BYTES, true).trim() || null;
 }
 
 export function appendChatSummaryEntryToMetadata(

--- a/packages/shared/src/utils/chat-summary-entries.ts
+++ b/packages/shared/src/utils/chat-summary-entries.ts
@@ -1,0 +1,236 @@
+import type {
+  ChatSummaryEntry,
+  ChatSummaryEntryKind,
+  ChatSummaryEntryOrigin,
+  ChatSummaryEntrySource,
+} from "../types/chat.js";
+
+const VALID_KINDS = new Set<ChatSummaryEntryKind>(["rolling"]);
+const VALID_ORIGINS = new Set<ChatSummaryEntryOrigin>(["manual", "automated", "legacy"]);
+const VALID_SOURCES = new Set<ChatSummaryEntrySource>(["last", "range", "agent"]);
+
+export type ChatSummaryEntryInput = Partial<ChatSummaryEntry> & {
+  content: string;
+};
+
+export interface ChatSummaryEntryNormalizeOptions {
+  legacySummary?: string | null;
+  createId?: () => string;
+  now?: string;
+}
+
+function defaultNow() {
+  return new Date().toISOString();
+}
+
+function fallbackId(prefix: string, seed: string) {
+  let hash = 2166136261;
+  for (let i = 0; i < seed.length; i += 1) {
+    hash ^= seed.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return `${prefix}-${(hash >>> 0).toString(36)}`;
+}
+
+function trimString(value: unknown) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function normalizeIsoTimestamp(value: unknown, fallback: string) {
+  const text = trimString(value);
+  return text && !Number.isNaN(Date.parse(text)) ? text : fallback;
+}
+
+function normalizePositiveInteger(value: unknown) {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : undefined;
+}
+
+function normalizeMessageIds(value: unknown) {
+  if (!Array.isArray(value)) return undefined;
+  const ids = Array.from(new Set(value.filter((id): id is string => typeof id === "string" && id.trim().length > 0)));
+  return ids.length > 0 ? ids : undefined;
+}
+
+function sourceFromOrigin(origin: ChatSummaryEntryOrigin): ChatSummaryEntrySource {
+  return origin === "automated" ? "agent" : "last";
+}
+
+/** Cheap token approximation for UI and metadata. */
+export function estimateChatSummaryTokens(content: string): number {
+  const normalized = content.trim();
+  if (!normalized) return 0;
+  return Math.max(1, Math.ceil(normalized.length / 4));
+}
+
+/** Generate a concise default title from an entry's origin and source metadata. */
+export function generateChatSummaryEntryTitle(entry: Pick<
+  ChatSummaryEntry,
+  "origin" | "sourceMode" | "messageCount" | "rangeStartIndex" | "rangeEndIndex"
+>): string {
+  if (entry.origin === "legacy") return "Legacy summary";
+  if (entry.origin === "automated") return "Automated summary";
+  if (entry.sourceMode === "range" && entry.rangeStartIndex && entry.rangeEndIndex) {
+    return `Summary messages ${entry.rangeStartIndex}-${entry.rangeEndIndex}`;
+  }
+  if (entry.messageCount) return `Summary of ${entry.messageCount} messages`;
+  return "Manual summary";
+}
+
+export function createLegacyChatSummaryEntry(
+  summary: string | null | undefined,
+  options: ChatSummaryEntryNormalizeOptions = {},
+): ChatSummaryEntry | null {
+  const content = trimString(summary);
+  if (!content) return null;
+  const now = options.now ?? defaultNow();
+  const id = options.createId?.() ?? fallbackId("summary-legacy", content);
+  return {
+    id,
+    kind: "rolling",
+    origin: "legacy",
+    title: "Legacy summary",
+    content,
+    enabled: true,
+    sourceMode: "last",
+    tokenEstimate: estimateChatSummaryTokens(content),
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+export function normalizeChatSummaryEntry(
+  raw: unknown,
+  options: ChatSummaryEntryNormalizeOptions = {},
+): ChatSummaryEntry | null {
+  if (!raw || typeof raw !== "object") return null;
+  const value = raw as Record<string, unknown>;
+  const content = trimString(value.content);
+  if (!content) return null;
+
+  const now = options.now ?? defaultNow();
+  const origin = VALID_ORIGINS.has(value.origin as ChatSummaryEntryOrigin)
+    ? (value.origin as ChatSummaryEntryOrigin)
+    : "legacy";
+  const sourceMode = VALID_SOURCES.has(value.sourceMode as ChatSummaryEntrySource)
+    ? (value.sourceMode as ChatSummaryEntrySource)
+    : sourceFromOrigin(origin);
+  const base: ChatSummaryEntry = {
+    id: trimString(value.id) || options.createId?.() || fallbackId("summary", `${origin}:${content}:${now}`),
+    kind: VALID_KINDS.has(value.kind as ChatSummaryEntryKind) ? (value.kind as ChatSummaryEntryKind) : "rolling",
+    origin,
+    title: trimString(value.title),
+    content,
+    enabled: typeof value.enabled === "boolean" ? value.enabled : true,
+    sourceMode,
+    tokenEstimate:
+      typeof value.tokenEstimate === "number" && Number.isFinite(value.tokenEstimate) && value.tokenEstimate >= 0
+        ? Math.round(value.tokenEstimate)
+        : estimateChatSummaryTokens(content),
+    createdAt: normalizeIsoTimestamp(value.createdAt, now),
+    updatedAt: normalizeIsoTimestamp(value.updatedAt, now),
+  };
+
+  const messageCount = normalizePositiveInteger(value.messageCount);
+  if (messageCount !== undefined) base.messageCount = messageCount;
+  const rangeStartIndex = normalizePositiveInteger(value.rangeStartIndex);
+  if (rangeStartIndex !== undefined) base.rangeStartIndex = rangeStartIndex;
+  const rangeEndIndex = normalizePositiveInteger(value.rangeEndIndex);
+  if (rangeEndIndex !== undefined) base.rangeEndIndex = rangeEndIndex;
+  const messageIds = normalizeMessageIds(value.messageIds);
+  if (messageIds) base.messageIds = messageIds;
+  if (typeof value.promptTemplateId === "string") {
+    base.promptTemplateId = value.promptTemplateId.trim() || null;
+  } else if (value.promptTemplateId === null) {
+    base.promptTemplateId = null;
+  }
+
+  if (!base.title) base.title = generateChatSummaryEntryTitle(base);
+  return base;
+}
+
+export function createChatSummaryEntry(
+  input: ChatSummaryEntryInput,
+  options: ChatSummaryEntryNormalizeOptions = {},
+): ChatSummaryEntry {
+  const entry = normalizeChatSummaryEntry(
+    {
+      ...input,
+      id: input.id || options.createId?.(),
+      createdAt: input.createdAt ?? options.now,
+      updatedAt: input.updatedAt ?? options.now,
+    },
+    options,
+  );
+  if (!entry) {
+    throw new Error("Chat summary entry content is required");
+  }
+  return entry;
+}
+
+export function sortChatSummaryEntries(entries: ChatSummaryEntry[]): ChatSummaryEntry[] {
+  return entries
+    .map((entry, index) => ({ entry, index }))
+    .sort((a, b) => {
+      const aRange = a.entry.rangeStartIndex ?? Number.MAX_SAFE_INTEGER;
+      const bRange = b.entry.rangeStartIndex ?? Number.MAX_SAFE_INTEGER;
+      if (aRange !== bRange) return aRange - bRange;
+      const created = Date.parse(a.entry.createdAt) - Date.parse(b.entry.createdAt);
+      if (created !== 0) return created;
+      return a.index - b.index;
+    })
+    .map(({ entry }) => entry);
+}
+
+export function normalizeChatSummaryEntries(
+  rawEntries: unknown,
+  options: ChatSummaryEntryNormalizeOptions = {},
+): ChatSummaryEntry[] {
+  const seen = new Set<string>();
+  const entries = (Array.isArray(rawEntries) ? rawEntries : [])
+    .map((entry) => normalizeChatSummaryEntry(entry, options))
+    .filter((entry): entry is ChatSummaryEntry => !!entry)
+    .map((entry) => {
+      if (!seen.has(entry.id)) {
+        seen.add(entry.id);
+        return entry;
+      }
+      const replacementId = options.createId?.() ?? fallbackId("summary", `${entry.id}:${entry.content}:${seen.size}`);
+      seen.add(replacementId);
+      return { ...entry, id: replacementId };
+    });
+
+  if (entries.length === 0) {
+    const legacy = createLegacyChatSummaryEntry(options.legacySummary, options);
+    if (legacy) entries.push(legacy);
+  }
+
+  return sortChatSummaryEntries(entries);
+}
+
+export function compileChatSummaryEntries(entries: ChatSummaryEntry[]): string | null {
+  const compiled = sortChatSummaryEntries(entries)
+    .filter((entry) => entry.enabled)
+    .map((entry) => entry.content.trim())
+    .filter(Boolean)
+    .join("\n\n")
+    .trim();
+  return compiled || null;
+}
+
+export function appendChatSummaryEntryToMetadata(
+  metadata: Record<string, unknown>,
+  input: ChatSummaryEntryInput,
+  options: ChatSummaryEntryNormalizeOptions = {},
+): { entry: ChatSummaryEntry; entries: ChatSummaryEntry[]; summary: string | null } {
+  const entries = normalizeChatSummaryEntries(metadata.summaryEntries, {
+    ...options,
+    legacySummary: typeof metadata.summary === "string" ? metadata.summary : null,
+  });
+  const entry = createChatSummaryEntry(input, options);
+  const nextEntries = sortChatSummaryEntries([...entries, entry]);
+  return {
+    entry,
+    entries: nextEntries,
+    summary: compileChatSummaryEntries(nextEntries),
+  };
+}


### PR DESCRIPTION
## Linked issue

Closes #933

## Why this change

- Long-running chats and roleplay sessions can accumulate multiple manual, automated, imported, and legacy summaries, but the old single summary field made provenance, enablement, editing, and token awareness hard to manage.
- This gives users structured summary controls while preserving the compiled prompt-facing summary string used by existing generation flows.

## What changed

- Added structured rolling summary entry types and shared helpers for compiling, estimating, normalizing, and managing summary metadata.
- Updated manual, automated, and tool-driven summary paths to append summary entries while keeping `metadata.summary` backward compatible.
- Added API and storage support for editing, enabling/disabling, and deleting summary entries.
- Reworked the chat summary popover into structured entry rows with origin, status, token, edit, delete, toggle, and manual write controls.
- Added persisted summary popover source/display settings and preserved the upstream Chibi Professor Mari persisted-store migration during the rebase.
- Updated chat surfaces to support hiding and collapsing summarized messages.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Not run by Codex for this PR preparation pass.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

- Not attached yet.