### PR TITLE
Feat/summary popover metadata

### DIFF
--- a/docs/ROLEPLAY.md
+++ b/docs/ROLEPLAY.md
@@ -256,7 +256,7 @@ Two diagnostic steps:
 Long contexts compress when they hit the model's window. Things to try:
 
 - Bump to a model with a larger context window.
-- Use the **Summary** panel (toolbar button) to write down major events explicitly — the summary is injected into prompts and survives compression.
+- Use the **Summary** panel (toolbar button) to write down major events explicitly. Marinara stores rolling summary entries for manual and automated updates, then compiles enabled entries into the summary text injected into prompts.
 - Author key facts into a lorebook as **constant** entries — they'll always be in scope regardless of where they were established in chat.
 
 ### Regenerating a reply keeps using the wrong guidance

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -10,7 +10,12 @@ import {
   type ReactNode,
   type RefObject,
 } from "react";
-import { type SceneForkMode, type SpritePlacement, type SpriteSide } from "@marinara-engine/shared";
+import {
+  type ChatSummaryEntry,
+  type SceneForkMode,
+  type SpritePlacement,
+  type SpriteSide,
+} from "@marinara-engine/shared";
 import {
   FolderOpen,
   Image,
@@ -325,6 +330,7 @@ function ToolbarMenu({ children }: { children: ReactNode }) {
 function SummaryButton({
   chatId,
   summary,
+  summaryEntries,
   summaryContextSize,
   summaryPromptTemplates,
   activeSummaryPromptTemplateId,
@@ -332,6 +338,7 @@ function SummaryButton({
 }: {
   chatId: string | null;
   summary: string | null;
+  summaryEntries?: ChatSummaryEntry[];
   summaryContextSize: number;
   summaryPromptTemplates?: ComponentProps<typeof SummaryPopover>["promptTemplates"];
   activeSummaryPromptTemplateId?: string | null;
@@ -364,6 +371,7 @@ function SummaryButton({
           <SummaryPopover
             chatId={chatId}
             summary={summary}
+            summaryEntries={summaryEntries}
             contextSize={summaryContextSize}
             promptTemplates={summaryPromptTemplates}
             activePromptTemplateId={activeSummaryPromptTemplateId}
@@ -747,6 +755,9 @@ export function ChatRoleplaySurface({
                     <SummaryButton
                       chatId={chat?.id ?? null}
                       summary={chatMeta.summary ?? null}
+                      summaryEntries={
+                        Array.isArray(chatMeta.summaryEntries) ? (chatMeta.summaryEntries as ChatSummaryEntry[]) : []
+                      }
                       summaryContextSize={summaryContextSize}
                       summaryPromptTemplates={
                         Array.isArray(chatMeta.summaryPromptTemplates) ? chatMeta.summaryPromptTemplates : []
@@ -841,6 +852,9 @@ export function ChatRoleplaySurface({
                         <SummaryButton
                           chatId={chat?.id ?? null}
                           summary={chatMeta.summary ?? null}
+                          summaryEntries={
+                            Array.isArray(chatMeta.summaryEntries) ? (chatMeta.summaryEntries as ChatSummaryEntry[]) : []
+                          }
                           summaryContextSize={summaryContextSize}
                           summaryPromptTemplates={
                             Array.isArray(chatMeta.summaryPromptTemplates) ? chatMeta.summaryPromptTemplates : []
@@ -907,6 +921,9 @@ export function ChatRoleplaySurface({
                       <SummaryButton
                         chatId={chat?.id ?? null}
                         summary={chatMeta.summary ?? null}
+                        summaryEntries={
+                          Array.isArray(chatMeta.summaryEntries) ? (chatMeta.summaryEntries as ChatSummaryEntry[]) : []
+                        }
                         summaryContextSize={summaryContextSize}
                         summaryPromptTemplates={
                           Array.isArray(chatMeta.summaryPromptTemplates) ? chatMeta.summaryPromptTemplates : []

--- a/packages/client/src/components/chat/SummaryPopover.tsx
+++ b/packages/client/src/components/chat/SummaryPopover.tsx
@@ -1080,6 +1080,14 @@ export function SummaryPopover({
                     />
                   </label>
                 </div>
+                <p
+                  className={cn(
+                    "px-0.5 text-[0.625rem] leading-snug",
+                    rangeTooLarge ? "text-[var(--destructive)]" : "text-[var(--muted-foreground)]",
+                  )}
+                >
+                  {rangeStatusText}
+                </p>
               </div>
             )}
           </div>

--- a/packages/client/src/components/chat/SummaryPopover.tsx
+++ b/packages/client/src/components/chat/SummaryPopover.tsx
@@ -2,7 +2,7 @@
 // Summary Popover — View / edit / generate chat summary
 // Shown via the scroll icon in the chat header bar.
 // ──────────────────────────────────────────────
-import { useState, useEffect, useRef, useCallback, useMemo, type MouseEvent, type RefObject } from "react";
+import { useState, useEffect, useRef, useCallback, useMemo, type MouseEvent as ReactMouseEvent, type RefObject } from "react";
 import { createPortal } from "react-dom";
 import {
   useBulkSetMessagesHiddenFromAI,
@@ -205,7 +205,7 @@ export function SummaryPopover({
   // mousedown from the tap that *opened* the popover doesn't
   // immediately close it on touch devices (Android / iPadOS).
   useEffect(() => {
-    const handler = (e: MouseEvent) => {
+    const handler = (e: globalThis.MouseEvent) => {
       if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
         onClose();
       }
@@ -231,7 +231,7 @@ export function SummaryPopover({
   // Close the settings flyout when clicking elsewhere in the summary popover.
   useEffect(() => {
     if (!scopeSettingsOpen) return;
-    const handler = (e: MouseEvent) => {
+    const handler = (e: globalThis.MouseEvent) => {
       const target = e.target as Node;
       if (scopeSettingsRef.current?.contains(target) || scopeSettingsButtonRef.current?.contains(target)) return;
       setScopeSettingsOpen(false);
@@ -620,7 +620,7 @@ export function SummaryPopover({
   const isMobile = typeof window !== "undefined" && window.innerWidth < 768;
 
   const handlePanelMouseDown = useCallback(
-    (event: MouseEvent<HTMLDivElement>) => {
+    (event: ReactMouseEvent<HTMLDivElement>) => {
       if (scopeSettingsOpen) {
         const target = event.target as Node;
         if (!scopeSettingsRef.current?.contains(target) && !scopeSettingsButtonRef.current?.contains(target)) {

--- a/packages/client/src/components/chat/SummaryPopover.tsx
+++ b/packages/client/src/components/chat/SummaryPopover.tsx
@@ -476,9 +476,9 @@ export function SummaryPopover({
     if (entriesToUpdate.length === 0) return;
 
     try {
-      await Promise.all(
-        entriesToUpdate.map((entry) => toggleSummaryEntry.mutateAsync({ chatId, entryId: entry.id, enabled: nextEnabled })),
-      );
+      for (const entry of entriesToUpdate) {
+        await toggleSummaryEntry.mutateAsync({ chatId, entryId: entry.id, enabled: nextEnabled });
+      }
       if (nextEnabled) setShowInactiveSummaries(false);
     } catch {
       toast.error("Could not update summary entries.");

--- a/packages/client/src/components/chat/SummaryPopover.tsx
+++ b/packages/client/src/components/chat/SummaryPopover.tsx
@@ -22,12 +22,19 @@ import {
 } from "lucide-react";
 import { cn, generateClientId } from "../../lib/utils";
 import { useUIStore } from "../../stores/ui.store";
-import { DEFAULT_AGENT_PROMPTS, type ChatSummaryPromptTemplate } from "@marinara-engine/shared";
+import {
+  DEFAULT_AGENT_PROMPTS,
+  createChatSummaryEntry,
+  normalizeChatSummaryEntries,
+  type ChatSummaryEntry,
+  type ChatSummaryPromptTemplate,
+} from "@marinara-engine/shared";
 import { showConfirmDialog } from "../../lib/app-dialogs";
 
 interface SummaryPopoverProps {
   chatId: string;
   summary: string | null;
+  summaryEntries?: ChatSummaryEntry[];
   contextSize: number;
   promptTemplates?: ChatSummaryPromptTemplate[];
   activePromptTemplateId?: string | null;
@@ -95,9 +102,44 @@ function parseSummarySections(value: string): SummarySection[] {
   return sections;
 }
 
+function createSingleEditableSummaryEntry(args: {
+  content: string;
+  summary: string | null;
+  summaryEntries?: ChatSummaryEntry[];
+}): ChatSummaryEntry[] {
+  const content = args.content.trim();
+  if (!content) return [];
+
+  const now = new Date().toISOString();
+  const existingEntries = normalizeChatSummaryEntries(args.summaryEntries, {
+    legacySummary: args.summary,
+    now,
+  });
+  const existing = existingEntries.length === 1 ? existingEntries[0] : null;
+
+  return [
+    createChatSummaryEntry(
+      {
+        ...(existing ?? {}),
+        id: existing?.id ?? generateClientId(),
+        kind: "rolling",
+        origin: "manual",
+        title: existing?.title && existing.origin !== "automated" ? existing.title : "Manual summary",
+        content,
+        enabled: true,
+        sourceMode: existing?.sourceMode ?? "last",
+        createdAt: existing?.createdAt ?? now,
+        updatedAt: now,
+      },
+      { createId: generateClientId, now },
+    ),
+  ];
+}
+
 export function SummaryPopover({
   chatId,
   summary,
+  summaryEntries,
   contextSize,
   promptTemplates = [],
   activePromptTemplateId = null,
@@ -297,9 +339,14 @@ export function SummaryPopover({
   ]);
 
   const handleSave = useCallback(() => {
-    updateMeta.mutate({ id: chatId, summary: draft || null });
+    const content = draft.trim();
+    updateMeta.mutate({
+      id: chatId,
+      summary: content || null,
+      summaryEntries: createSingleEditableSummaryEntry({ content, summary, summaryEntries }),
+    });
     setEditing(false);
-  }, [chatId, draft, updateMeta]);
+  }, [chatId, draft, summary, summaryEntries, updateMeta]);
 
   const persistPromptTemplates = useCallback(
     (templates: ChatSummaryPromptTemplate[], activeId: string | null) => {

--- a/packages/client/src/components/chat/SummaryPopover.tsx
+++ b/packages/client/src/components/chat/SummaryPopover.tsx
@@ -302,8 +302,9 @@ export function SummaryPopover({
     (total, entry) => (entry.enabled ? total + entry.tokenEstimate : total),
     0,
   );
+  const hasPersistedEntries = displayEntries.length > 0;
   const hasEntries = visibleEntries.length > 0;
-  const allEntriesDisabled = hasEntries && enabledEntryCount === 0;
+  const allEntriesDisabled = hasPersistedEntries && enabledEntryCount === 0;
   const tokenWarning = enabledTokenEstimate > SUMMARY_TOKEN_WARNING_THRESHOLD;
   const entryMutationPending =
     updateSummaryEntry.isPending || deleteSummaryEntry.isPending || toggleSummaryEntry.isPending;
@@ -414,22 +415,31 @@ export function SummaryPopover({
       toast.error("Summary content is required.");
       return;
     }
-    try {
-      await updateSummaryEntry.mutateAsync({
-        chatId,
-        entry: {
+    const existingEntry = displayEntries.find((entry) => entry.id === draftEntry.id);
+    const entryPayload = existingEntry
+      ? {
+          id: draftEntry.id,
+          title,
+          content,
+          tokenEstimate: estimateChatSummaryTokens(content),
+        }
+      : {
           ...draftEntry,
           title,
           content,
           tokenEstimate: estimateChatSummaryTokens(content),
-        },
+        };
+    try {
+      await updateSummaryEntry.mutateAsync({
+        chatId,
+        entry: entryPayload,
       });
       setEditingEntryId(null);
       setDraftEntry(null);
     } catch {
       toast.error("Could not save summary entry.");
     }
-  }, [chatId, draftEntry, updateSummaryEntry]);
+  }, [chatId, displayEntries, draftEntry, updateSummaryEntry]);
 
   const handleToggleEntry = useCallback(
     async (entry: ChatSummaryEntry, enabled: boolean) => {

--- a/packages/client/src/components/chat/SummaryPopover.tsx
+++ b/packages/client/src/components/chat/SummaryPopover.tsx
@@ -2,7 +2,7 @@
 // Summary Popover — View / edit / generate chat summary
 // Shown via the scroll icon in the chat header bar.
 // ──────────────────────────────────────────────
-import { useState, useEffect, useRef, useCallback, useMemo, type ReactNode, type RefObject } from "react";
+import { useState, useEffect, useRef, useCallback, useMemo, type MouseEvent, type RefObject } from "react";
 import { createPortal } from "react-dom";
 import {
   useBulkSetMessagesHiddenFromAI,
@@ -14,10 +14,8 @@ import {
 } from "../../hooks/use-chats";
 import {
   Check,
-  ChevronDown,
   ChevronRight,
   Copy,
-  Info,
   Loader2,
   PenLine,
   Plus,
@@ -74,10 +72,7 @@ function parsePositiveInteger(value: string): number | null {
 }
 
 function formatSummaryHeading(value: string): string {
-  return value
-    .replace(/^#+\s*/, "")
-    .replace(/^\*\*|\*\*$/g, "")
-    .trim();
+  return value.replace(/^#+\s*/, "").replace(/^\*\*|\*\*$/g, "").trim();
 }
 
 function parseSummarySections(value: string): SummarySection[] {
@@ -131,6 +126,10 @@ function getSummaryEntrySourceLabel(entry: ChatSummaryEntry): string | null {
   return null;
 }
 
+function getSummaryEntryMetaLine(entry: ChatSummaryEntry): string {
+  return [getSummaryEntrySourceLabel(entry), `~${formatTokenCount(entry.tokenEstimate)} tokens`].filter(Boolean).join(" · ");
+}
+
 function createBlankManualSummaryEntry(): ChatSummaryEntry {
   const now = new Date().toISOString();
   return {
@@ -162,6 +161,7 @@ export function SummaryPopover({
   const [draftEntry, setDraftEntry] = useState<ChatSummaryEntry | null>(null);
   const [templateEditorOpen, setTemplateEditorOpen] = useState(false);
   const [templateSelectOpen, setTemplateSelectOpen] = useState(false);
+  const [showInactiveSummaries, setShowInactiveSummaries] = useState(false);
   const [editingTemplateId, setEditingTemplateId] = useState<string | null>(null);
   const [templateNameDraft, setTemplateNameDraft] = useState("");
   const [templatePromptDraft, setTemplatePromptDraft] = useState("");
@@ -187,6 +187,8 @@ export function SummaryPopover({
   const toggleSummaryEntry = useToggleSummaryEntry();
   const entryTextareaRef = useRef<HTMLTextAreaElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
+  const scopeSettingsButtonRef = useRef<HTMLButtonElement>(null);
+  const scopeSettingsRef = useRef<HTMLDivElement>(null);
 
   const persistSummaryContextSize = useCallback(
     (size: number) => {
@@ -225,6 +227,19 @@ export function SummaryPopover({
     document.addEventListener("keydown", handler);
     return () => document.removeEventListener("keydown", handler);
   }, [onClose]);
+
+  // Close the settings flyout when clicking elsewhere in the summary popover.
+  useEffect(() => {
+    if (!scopeSettingsOpen) return;
+    const handler = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (scopeSettingsRef.current?.contains(target) || scopeSettingsButtonRef.current?.contains(target)) return;
+      setScopeSettingsOpen(false);
+      setTemplateSelectOpen(false);
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [scopeSettingsOpen]);
 
   // Sync local size when the persisted/default context size changes externally.
   useEffect(() => {
@@ -270,8 +285,8 @@ export function SummaryPopover({
         ? `Using ${Math.min(normalizedLastSize, totalMessageCount)} of ${totalMessageCount} messages`
         : "No messages yet";
   const rangeStatusText = rangeTooLarge
-    ? `Choose ${MAX_SUMMARY_MESSAGES} messages or fewer.`
-    : `${selectedRangeCount} ${selectedRangeCount === 1 ? "message" : "messages"} selected.`;
+      ? `Choose ${MAX_SUMMARY_MESSAGES} messages or fewer.`
+      : `${selectedRangeCount} ${selectedRangeCount === 1 ? "message" : "messages"} selected.`;
   const cleanedPromptTemplates = promptTemplates.filter(
     (template) =>
       typeof template.id === "string" &&
@@ -293,17 +308,20 @@ export function SummaryPopover({
       }),
     [summary, summaryEntries],
   );
-  const visibleEntries = useMemo(() => {
-    if (!draftEntry || displayEntries.some((entry) => entry.id === draftEntry.id)) return displayEntries;
-    return [...displayEntries, draftEntry];
-  }, [displayEntries, draftEntry]);
   const enabledEntryCount = displayEntries.filter((entry) => entry.enabled).length;
+  const inactiveEntryCount = displayEntries.length - enabledEntryCount;
+  const visibleEntries = useMemo(() => {
+    const filteredEntries = showInactiveSummaries ? displayEntries : displayEntries.filter((entry) => entry.enabled);
+    if (!draftEntry || filteredEntries.some((entry) => entry.id === draftEntry.id)) return filteredEntries;
+    return [...filteredEntries, draftEntry];
+  }, [displayEntries, draftEntry, showInactiveSummaries]);
   const enabledTokenEstimate = displayEntries.reduce(
     (total, entry) => (entry.enabled ? total + entry.tokenEstimate : total),
     0,
   );
   const hasPersistedEntries = displayEntries.length > 0;
   const hasEntries = visibleEntries.length > 0;
+  const allVisibleEntriesHidden = hasPersistedEntries && !hasEntries;
   const allEntriesDisabled = hasPersistedEntries && enabledEntryCount === 0;
   const tokenWarning = enabledTokenEstimate > SUMMARY_TOKEN_WARNING_THRESHOLD;
   const entryMutationPending =
@@ -452,6 +470,21 @@ export function SummaryPopover({
     [chatId, toggleSummaryEntry],
   );
 
+  const handleToggleAllEntries = useCallback(async () => {
+    const nextEnabled = enabledEntryCount === 0;
+    const entriesToUpdate = displayEntries.filter((entry) => entry.enabled !== nextEnabled);
+    if (entriesToUpdate.length === 0) return;
+
+    try {
+      await Promise.all(
+        entriesToUpdate.map((entry) => toggleSummaryEntry.mutateAsync({ chatId, entryId: entry.id, enabled: nextEnabled })),
+      );
+      if (nextEnabled) setShowInactiveSummaries(false);
+    } catch {
+      toast.error("Could not update summary entries.");
+    }
+  }, [chatId, displayEntries, enabledEntryCount, toggleSummaryEntry]);
+
   const handleDeleteEntry = useCallback(
     async (entry: ChatSummaryEntry) => {
       const confirmed = await showConfirmDialog({
@@ -516,12 +549,15 @@ export function SummaryPopover({
     setTemplateEditorOpen(true);
   }, [cleanedPromptTemplates.length]);
 
-  const handleDuplicatePromptTemplate = useCallback((template: ChatSummaryPromptTemplate | null) => {
-    setEditingTemplateId(null);
-    setTemplateNameDraft(`${template?.name ?? "Built-in default"} copy`);
-    setTemplatePromptDraft(template?.prompt ?? DEFAULT_AGENT_PROMPTS["chat-summary"] ?? "");
-    setTemplateEditorOpen(true);
-  }, []);
+  const handleDuplicatePromptTemplate = useCallback(
+    (template: ChatSummaryPromptTemplate | null) => {
+      setEditingTemplateId(null);
+      setTemplateNameDraft(`${template?.name ?? "Built-in default"} copy`);
+      setTemplatePromptDraft(template?.prompt ?? DEFAULT_AGENT_PROMPTS["chat-summary"] ?? "");
+      setTemplateEditorOpen(true);
+    },
+    [],
+  );
 
   const handleSavePromptTemplate = useCallback(() => {
     if (!hasTemplateDraft) return;
@@ -539,9 +575,7 @@ export function SummaryPopover({
             prompt: trimmedPrompt,
           },
         ];
-    const nextActiveId = isEditingExistingTemplate
-      ? activePromptTemplateId
-      : nextTemplates[nextTemplates.length - 1]!.id;
+    const nextActiveId = isEditingExistingTemplate ? activePromptTemplateId : nextTemplates[nextTemplates.length - 1]!.id;
     persistPromptTemplates(nextTemplates, nextActiveId ?? null);
     resetTemplateDraft();
   }, [
@@ -572,17 +606,37 @@ export function SummaryPopover({
       persistPromptTemplates(nextTemplates, activePromptTemplateId === templateId ? null : activePromptTemplateId);
       if (editingTemplateId === templateId) resetTemplateDraft();
     },
-    [activePromptTemplateId, cleanedPromptTemplates, editingTemplateId, persistPromptTemplates, resetTemplateDraft],
+    [
+      activePromptTemplateId,
+      cleanedPromptTemplates,
+      editingTemplateId,
+      persistPromptTemplates,
+      resetTemplateDraft,
+    ],
   );
 
   const isGenerating = generateSummary.isPending;
 
   const isMobile = typeof window !== "undefined" && window.innerWidth < 768;
 
+  const handlePanelMouseDown = useCallback(
+    (event: MouseEvent<HTMLDivElement>) => {
+      if (scopeSettingsOpen) {
+        const target = event.target as Node;
+        if (!scopeSettingsRef.current?.contains(target) && !scopeSettingsButtonRef.current?.contains(target)) {
+          setScopeSettingsOpen(false);
+          setTemplateSelectOpen(false);
+        }
+      }
+      event.stopPropagation();
+    },
+    [scopeSettingsOpen],
+  );
+
   const content = (
     <div
       ref={panelRef}
-      onMouseDown={(e) => e.stopPropagation()}
+      onMouseDown={handlePanelMouseDown}
       className={cn(
         isMobile
           ? "fixed inset-0 z-[9999] flex items-center justify-center p-4 max-md:pt-[max(1rem,env(safe-area-inset-top))]"
@@ -590,28 +644,29 @@ export function SummaryPopover({
       )}
     >
       {/* Mobile backdrop */}
-      {isMobile && <div className="absolute inset-0 bg-black/30" onClick={onClose} />}
+      {isMobile && <div className="absolute inset-0 bg-black/50 backdrop-blur-sm" onClick={onClose} />}
       <div
         className={cn(
-          "relative rounded-xl border border-[var(--border)] bg-[var(--card)] shadow-2xl shadow-black/40",
+          "relative overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--background)] shadow-2xl shadow-black/50 backdrop-blur-xl",
           isMobile ? "relative w-full max-w-md max-h-[calc(100dvh-4rem)] overflow-y-auto" : "w-[28rem]",
         )}
       >
         {/* Header */}
-        <div className="flex items-start justify-between gap-3 border-b border-[var(--border)] px-3 py-2.5">
-          <div className="min-w-0 space-y-0.5">
-            <div className="flex min-w-0 items-center gap-1.5 text-xs font-semibold">
+        <div className="flex items-center justify-between gap-3 border-b border-[var(--border)] bg-[var(--card)]/80 px-3 py-2.5 backdrop-blur-sm">
+          <div className="min-w-0">
+            <div className="flex min-w-0 items-center gap-1.5 text-sm font-semibold">
               <ScrollText size="0.8125rem" className="shrink-0 text-[var(--muted-foreground)]" />
               <span className="truncate">Chat Summary</span>
             </div>
             <p className="truncate text-[0.625rem] text-[var(--muted-foreground)]">
               {hasEntries
-                ? `${enabledEntryCount} enabled · ~${formatTokenCount(enabledTokenEstimate)} tokens`
+                ? `${enabledEntryCount} active · ~${formatTokenCount(enabledTokenEstimate)} tokens`
                 : "No summaries yet"}
             </p>
           </div>
           <div className="flex shrink-0 items-center gap-1">
             <button
+              ref={scopeSettingsButtonRef}
               type="button"
               onClick={() => setScopeSettingsOpen((open) => !open)}
               className={cn(
@@ -636,139 +691,44 @@ export function SummaryPopover({
         </div>
 
         {scopeSettingsOpen && (
-          <div className="absolute right-2 top-12 z-10 max-h-[min(34rem,calc(100vh-7rem))] w-[calc(100%-1rem)] max-w-80 overflow-y-auto rounded-xl border border-[var(--border)] bg-[var(--popover)] p-2.5 text-[var(--popover-foreground)] shadow-xl shadow-black/30 ring-1 ring-white/5">
-            <div className="mb-2.5 flex items-start justify-between gap-3 px-1">
+          <div
+            ref={scopeSettingsRef}
+            className="absolute right-2 top-12 z-10 max-h-[min(34rem,calc(100vh-7rem))] w-[calc(100%-1rem)] max-w-80 overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--background)] text-[var(--popover-foreground)] shadow-2xl shadow-black/50 ring-1 ring-white/5 backdrop-blur-xl"
+          >
+            <div className="flex items-center justify-between gap-3 border-b border-[var(--border)] bg-[var(--card)]/80 px-3 py-2.5 backdrop-blur-sm">
               <div className="min-w-0">
-                <p className="text-[0.625rem] font-semibold uppercase text-[var(--muted-foreground)]">Summary Scope</p>
-                <p className="truncate text-xs font-semibold text-[var(--popover-foreground)]">{sourceSummary}</p>
+                <p className="text-xs font-semibold text-[var(--popover-foreground)]">Summary settings</p>
               </div>
-              <span className="shrink-0 pt-0.5 text-right text-[0.625rem] text-[var(--muted-foreground)]">
-                {sourceDetail}
-              </span>
             </div>
 
-            <div className="space-y-2 rounded-lg border border-[var(--border)] bg-[var(--secondary)]/40 p-2.5">
-              <div className="grid grid-cols-2 gap-1 rounded-lg bg-[var(--background)]/30 p-1">
-                {(["last", "range"] as const).map((mode) => (
-                  <button
-                    key={mode}
-                    type="button"
-                    onClick={() => handleSourceModeChange(mode)}
-                    className={cn(
-                      "rounded-md px-2 py-1 text-[0.625rem] font-semibold transition-colors",
-                      sourceMode === mode
-                        ? "bg-[var(--accent)] text-[var(--foreground)] ring-1 ring-[var(--border)]"
-                        : "text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]",
-                    )}
-                  >
-                    {mode === "last" ? "Last" : "Range"}
-                  </button>
-                ))}
-              </div>
-
-              {sourceMode === "last" ? (
-                <label className="flex items-center justify-between gap-2 text-[0.6875rem] text-[var(--muted-foreground)]">
-                  <span>Messages</span>
-                  <input
-                    type="number"
-                    min={MIN_SUMMARY_MESSAGES}
-                    max={MAX_SUMMARY_MESSAGES}
-                    value={localSize}
-                    onFocus={() => {
-                      sizeInputFocused.current = true;
-                    }}
-                    onChange={(e) => {
-                      setLocalSize(e.target.value);
-                      const next = parsePositiveInteger(e.target.value);
-                      if (next !== null) {
-                        setSummaryPopoverSettings({ contextSize: clampSummaryCount(next) });
-                      }
-                    }}
-                    onBlur={() => {
-                      sizeInputFocused.current = false;
-                      const clamped = clampSummaryCount(parsePositiveInteger(localSize) ?? 50);
-                      setLocalSize(String(clamped));
-                      persistSummaryContextSize(clamped);
-                    }}
-                    className="w-16 rounded-md bg-[var(--card)] px-2 py-1 text-center text-xs tabular-nums text-[var(--foreground)] ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
-                  />
-                </label>
-              ) : (
-                <div className="space-y-1.5">
-                  <div className="grid grid-cols-2 gap-2">
-                    <label className="space-y-1 text-[0.625rem] font-medium text-[var(--muted-foreground)]">
-                      From
-                      <input
-                        type="number"
-                        min={1}
-                        max={Math.max(1, totalMessageCount)}
-                        value={rangeStart}
-                        onFocus={() => {
-                          rangeInputFocused.current = true;
-                        }}
-                        onChange={(e) => {
-                          setRangeStart(e.target.value);
-                          const next = parsePositiveInteger(e.target.value);
-                          if (next !== null) {
-                            setSummaryPopoverSettings({
-                              rangeStart: Math.max(1, Math.min(totalMessageCount || 1, next)),
-                            });
-                          }
-                        }}
-                        onBlur={() => {
-                          rangeInputFocused.current = false;
-                          setRangeStart(String(normalizedRangeStart));
-                          setSummaryPopoverSettings({ rangeStart: normalizedRangeStart });
-                        }}
-                        className="w-full rounded-md bg-[var(--card)] px-2 py-1 text-center text-xs tabular-nums text-[var(--foreground)] ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
-                      />
-                    </label>
-                    <label className="space-y-1 text-[0.625rem] font-medium text-[var(--muted-foreground)]">
-                      To
-                      <input
-                        type="number"
-                        min={1}
-                        max={Math.max(1, totalMessageCount)}
-                        value={rangeEnd}
-                        onFocus={() => {
-                          rangeInputFocused.current = true;
-                        }}
-                        onChange={(e) => {
-                          setRangeEnd(e.target.value);
-                          const next = parsePositiveInteger(e.target.value);
-                          if (next !== null) {
-                            setSummaryPopoverSettings({
-                              rangeEnd: Math.max(1, Math.min(totalMessageCount || 1, next)),
-                            });
-                          }
-                        }}
-                        onBlur={() => {
-                          rangeInputFocused.current = false;
-                          setRangeEnd(String(normalizedRangeEnd));
-                          setSummaryPopoverSettings({ rangeEnd: normalizedRangeEnd });
-                        }}
-                        className="w-full rounded-md bg-[var(--card)] px-2 py-1 text-center text-xs tabular-nums text-[var(--foreground)] ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
-                      />
-                    </label>
-                  </div>
-                  <p
-                    className={cn("text-[0.625rem]", rangeTooLarge ? "text-red-300" : "text-[var(--muted-foreground)]")}
-                  >
-                    {rangeStatusText}
-                  </p>
+            <div className="max-h-[min(31rem,calc(100vh-10rem))] overflow-y-auto p-2.5">
+              <div className="space-y-2 rounded-lg border border-[var(--border)] bg-[var(--secondary)]/40 p-2.5">
+                <p className="px-1 text-xs font-semibold text-[var(--popover-foreground)]">Summary Scope</p>
+                <div className="grid grid-cols-2 gap-1 rounded-lg bg-[var(--background)]/30 p-1">
+                  {(["last", "range"] as const).map((mode) => (
+                    <button
+                      key={mode}
+                      type="button"
+                      onClick={() => handleSourceModeChange(mode)}
+                      className={cn(
+                        "rounded-md px-2 py-1 text-xs font-semibold transition-colors",
+                        sourceMode === mode
+                          ? "bg-[var(--accent)] text-[var(--foreground)] ring-1 ring-[var(--border)]"
+                          : "text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]",
+                      )}
+                    >
+                      {mode === "last" ? "Last" : "Range"}
+                    </button>
+                  ))}
                 </div>
-              )}
-            </div>
+              </div>
 
-            <div className="space-y-2 pt-2">
-              <div className="space-y-2 rounded-lg border border-[var(--border)] bg-[var(--secondary)]/35 p-2.5">
-                <div className="flex items-start justify-between gap-2">
+              <div className="space-y-2 pt-2">
+                <div className="space-y-2 rounded-lg border border-[var(--border)] bg-[var(--secondary)]/35 p-2.5">
+                <div className="flex items-center justify-between gap-2">
                   <div className="min-w-0">
-                    <p className="text-[0.625rem] font-semibold uppercase text-[var(--muted-foreground)]">
+                    <p className="text-xs font-semibold text-[var(--popover-foreground)]">
                       Summary Prompt
-                    </p>
-                    <p className="truncate text-xs font-semibold text-[var(--popover-foreground)]">
-                      {promptTemplateSummary}
                     </p>
                   </div>
                   <button
@@ -778,7 +738,7 @@ export function SummaryPopover({
                       if (templateEditorOpen) resetTemplateDraft();
                     }}
                     className={cn(
-                      "shrink-0 rounded-md px-2 py-1 text-[0.625rem] font-semibold transition-colors",
+                      "shrink-0 rounded-md px-2 py-1 text-xs transition-colors",
                       templateEditorOpen
                         ? "bg-[var(--accent)] text-[var(--foreground)] ring-1 ring-[var(--border)]"
                         : "text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]",
@@ -793,17 +753,17 @@ export function SummaryPopover({
                     <button
                       type="button"
                       onClick={() => setTemplateSelectOpen((open) => !open)}
-                      className="flex w-full min-w-0 items-center justify-between gap-2 rounded-md bg-[var(--card)] py-1 pl-2 pr-2 text-left text-[0.6875rem] text-[var(--foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+                      className="flex w-full min-w-0 items-center justify-between gap-2 rounded-md bg-[var(--card)] py-1 pl-2 pr-2 text-left truncate text-xs font-semibold text-[var(--foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
                       aria-haspopup="listbox"
                       aria-expanded={templateSelectOpen}
                       aria-label="Summary prompt template"
                     >
                       <span className="min-w-0 truncate">{promptTemplateSummary}</span>
-                      <ChevronDown
+                      <ChevronRight
                         size="0.75rem"
                         className={cn(
                           "shrink-0 text-[var(--muted-foreground)] transition-transform",
-                          templateSelectOpen && "rotate-180",
+                          templateSelectOpen && "rotate-90",
                         )}
                       />
                     </button>
@@ -910,28 +870,59 @@ export function SummaryPopover({
                     )}
                   </div>
                 )}
-              </div>
+                </div>
 
-              <div className="space-y-1 rounded-lg border border-[var(--border)] bg-[var(--secondary)]/25 p-2">
-                <p className="px-1 text-[0.625rem] font-semibold uppercase text-[var(--muted-foreground)]">Display</p>
-                <SummarySettingsToggle
-                  label="Hide summarised messages"
-                  checked={summaryPopoverSettings.hideSummarisedMessages}
-                  onChange={(checked) => setSummaryPopoverSettings({ hideSummarisedMessages: checked })}
-                />
-                <SummarySettingsToggle
-                  label="Collapse hidden messages"
-                  checked={summaryPopoverSettings.collapseHiddenMessages}
-                  onChange={(checked) => setSummaryPopoverSettings({ collapseHiddenMessages: checked })}
-                />
+                <div className="space-y-1 rounded-lg border border-[var(--border)] bg-[var(--secondary)]/25 p-2">
+                  <p className="px-1 text-xs font-semibold text-[var(--popover-foreground)]">
+                    Display
+                  </p>
+                  <SummarySettingsToggle
+                    label="Hide summarised messages"
+                    checked={summaryPopoverSettings.hideSummarisedMessages}
+                    onChange={(checked) => setSummaryPopoverSettings({ hideSummarisedMessages: checked })}
+                  />
+                  <SummarySettingsToggle
+                    label="Collapse hidden messages"
+                    checked={summaryPopoverSettings.collapseHiddenMessages}
+                    onChange={(checked) => setSummaryPopoverSettings({ collapseHiddenMessages: checked })}
+                  />
+                </div>
               </div>
             </div>
           </div>
         )}
 
         {/* Body */}
-        <div className="max-h-[min(26rem,calc(100dvh-15rem))] overflow-y-auto p-3">
+        <div className="max-h-[min(26rem,calc(100dvh-15rem))] overflow-y-auto p-2.5">
           <div className="space-y-2">
+            {hasPersistedEntries && (
+              <div className="flex items-center justify-end gap-1.5 px-0.5">
+                  {inactiveEntryCount > 0 && (
+                    <button
+                      type="button"
+                      onClick={() => setShowInactiveSummaries((show) => !show)}
+                      className={cn(
+                        "rounded-md px-1 py-0.5 text-[0.625rem] font-semibold transition-colors hover:text-[var(--foreground)]",
+                        showInactiveSummaries
+                          ? "text-[var(--foreground)]"
+                          : "text-[var(--muted-foreground)]",
+                      )}
+                    >
+                      {showInactiveSummaries ? "Hide Inactive" : "Show Inactive"}
+                    </button>
+                  )}
+                  {inactiveEntryCount === 0 && <span aria-hidden="true" />}
+                  <button
+                    type="button"
+                    onClick={() => void handleToggleAllEntries()}
+                    disabled={entryMutationPending}
+                    className="rounded-md px-1 py-0.5 text-[0.625rem] font-semibold text-[var(--muted-foreground)] transition-colors hover:text-[var(--foreground)] disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    {enabledEntryCount === 0 ? "Activate All" : "Deactivate All"}
+                  </button>
+              </div>
+            )}
+
             {tokenWarning && (
               <div className="rounded-lg border border-amber-400/30 bg-amber-500/10 px-2.5 py-2 text-[0.6875rem] leading-relaxed text-amber-200">
                 Enabled summaries are around {formatTokenCount(enabledTokenEstimate)} tokens. Consider disabling older
@@ -970,6 +961,14 @@ export function SummaryPopover({
                   onDelete={() => void handleDeleteEntry(entry)}
                 />
               ))
+            ) : allVisibleEntriesHidden ? (
+              <button
+                type="button"
+                onClick={() => setShowInactiveSummaries(true)}
+                className="w-full rounded-lg border border-dashed border-[var(--border)] bg-[var(--secondary)]/20 p-5 text-center text-xs italic text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)]/35"
+              >
+                Inactive summaries are hidden. Show inactive summaries to view them.
+              </button>
             ) : (
               <button
                 type="button"
@@ -983,17 +982,113 @@ export function SummaryPopover({
         </div>
 
         {/* Source controls */}
-        <div className="border-t border-[var(--border)] px-3 py-2.5">
-          <div className="mb-2 grid grid-cols-[1fr_auto] items-center gap-2 rounded-lg bg-[var(--secondary)]/25 px-2.5 py-1.5 text-[0.625rem] text-[var(--muted-foreground)]">
-            <span className="min-w-0 truncate">Source: {sourceSummary}</span>
-            <span className="shrink-0 text-right">{sourceDetail}</span>
+        <div className="border-t border-[var(--border)] bg-[var(--card)]/45 px-3 py-2.5">
+          <div className="mb-2.5 space-y-2">
+            <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)] items-start gap-3">
+              <div className="min-w-0">
+                <p className="truncate text-xs font-semibold text-[var(--foreground)]">{sourceSummary}</p>
+                <p className="truncate text-[0.625rem] text-[var(--muted-foreground)]">{sourceDetail}</p>
+              </div>
+              <div className="min-w-0 text-right">
+                <p className="truncate text-xs font-semibold text-[var(--foreground)]">Active Prompt</p>
+                <p className="truncate text-[0.625rem] text-[var(--muted-foreground)]">{promptTemplateSummary}</p>
+              </div>
+            </div>
+
+            {sourceMode === "last" ? (
+              <label className="flex items-center justify-between gap-2 text-[0.6875rem] text-[var(--muted-foreground)]">
+                <span>Messages</span>
+                <input
+                  type="number"
+                  min={MIN_SUMMARY_MESSAGES}
+                  max={MAX_SUMMARY_MESSAGES}
+                  value={localSize}
+                  onFocus={() => {
+                    sizeInputFocused.current = true;
+                  }}
+                  onChange={(e) => {
+                    setLocalSize(e.target.value);
+                    const next = parsePositiveInteger(e.target.value);
+                    if (next !== null) {
+                      setSummaryPopoverSettings({ contextSize: clampSummaryCount(next) });
+                    }
+                  }}
+                  onBlur={() => {
+                    sizeInputFocused.current = false;
+                    const clamped = clampSummaryCount(parsePositiveInteger(localSize) ?? 50);
+                    setLocalSize(String(clamped));
+                    persistSummaryContextSize(clamped);
+                  }}
+                  className="w-16 rounded-md bg-[var(--card)] px-2 py-1 text-center text-xs tabular-nums text-[var(--foreground)] ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+                />
+              </label>
+            ) : (
+              <div className="space-y-1.5">
+                <div className="grid grid-cols-2 gap-2">
+                  <label className="space-y-1 text-[0.625rem] font-medium text-[var(--muted-foreground)]">
+                    From
+                    <input
+                      type="number"
+                      min={1}
+                      max={Math.max(1, totalMessageCount)}
+                      value={rangeStart}
+                      onFocus={() => {
+                        rangeInputFocused.current = true;
+                      }}
+                      onChange={(e) => {
+                        setRangeStart(e.target.value);
+                        const next = parsePositiveInteger(e.target.value);
+                        if (next !== null) {
+                          setSummaryPopoverSettings({
+                            rangeStart: Math.max(1, Math.min(totalMessageCount || 1, next)),
+                          });
+                        }
+                      }}
+                      onBlur={() => {
+                        rangeInputFocused.current = false;
+                        setRangeStart(String(normalizedRangeStart));
+                        setSummaryPopoverSettings({ rangeStart: normalizedRangeStart });
+                      }}
+                      className="w-full rounded-md bg-[var(--card)] px-2 py-1 text-center text-xs tabular-nums text-[var(--foreground)] ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+                    />
+                  </label>
+                  <label className="space-y-1 text-[0.625rem] font-medium text-[var(--muted-foreground)]">
+                    To
+                    <input
+                      type="number"
+                      min={1}
+                      max={Math.max(1, totalMessageCount)}
+                      value={rangeEnd}
+                      onFocus={() => {
+                        rangeInputFocused.current = true;
+                      }}
+                      onChange={(e) => {
+                        setRangeEnd(e.target.value);
+                        const next = parsePositiveInteger(e.target.value);
+                        if (next !== null) {
+                          setSummaryPopoverSettings({
+                            rangeEnd: Math.max(1, Math.min(totalMessageCount || 1, next)),
+                          });
+                        }
+                      }}
+                      onBlur={() => {
+                        rangeInputFocused.current = false;
+                        setRangeEnd(String(normalizedRangeEnd));
+                        setSummaryPopoverSettings({ rangeEnd: normalizedRangeEnd });
+                      }}
+                      className="w-full rounded-md bg-[var(--card)] px-2 py-1 text-center text-xs tabular-nums text-[var(--foreground)] ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+                    />
+                  </label>
+                </div>
+              </div>
+            )}
           </div>
 
           <div className="grid grid-cols-[auto_1fr] gap-1.5">
             <button
               type="button"
               onClick={handleCreateManualEntry}
-              className="flex items-center justify-center gap-1.5 rounded-lg px-3 py-2 text-xs font-semibold text-[var(--foreground)] ring-1 ring-[var(--border)] transition-all hover:bg-[var(--accent)] active:scale-[0.98]"
+              className="flex items-center justify-center gap-1.5 rounded-lg px-3 py-2 text-xs font-semibold text-[var(--muted-foreground)] transition-all hover:bg-[var(--accent)] hover:text-[var(--foreground)] active:scale-[0.98]"
               title="Write summary entry"
             >
               <PenLine size="0.8125rem" />
@@ -1017,17 +1112,6 @@ export function SummaryPopover({
           </div>
         </div>
 
-        {/* Info tip */}
-        <div className="border-t border-[var(--border)] bg-[var(--secondary)]/15 px-3 py-2">
-          <p className="flex items-start gap-1.5 text-[0.625rem] leading-relaxed text-[var(--muted-foreground)]">
-            <Info size="0.6875rem" className="mt-0.5 shrink-0 text-[var(--muted-foreground)]" />
-            <span>
-              Use the Generate button above to update the summary manually. Add an{" "}
-              <strong className="font-medium text-[var(--foreground)]/70">Automated Chat Summary</strong> agent to the
-              chat if you&apos;d like it to be updated automatically every X messages.
-            </span>
-          </p>
-        </div>
       </div>
     </div>
   );
@@ -1086,37 +1170,59 @@ function SummaryEntryRow({
   onSaveEdit,
   onDelete,
 }: SummaryEntryRowProps) {
+  const metaLine = getSummaryEntryMetaLine(entry);
   return (
     <div
       className={cn(
-        "rounded-lg border border-[var(--border)] bg-[var(--secondary)]/20 transition-colors",
-        entry.enabled ? "text-[var(--foreground)]" : "text-[var(--muted-foreground)] opacity-75",
+        "group overflow-hidden rounded-lg border shadow-sm shadow-black/10 ring-1 ring-[var(--border)]/25 transition-colors",
+        expanded
+          ? "border-[var(--primary)]/45 bg-[var(--accent)]/22 ring-[var(--primary)]/20"
+          : "border-[var(--border)]/80 bg-[var(--secondary)]/28 hover:border-[var(--primary)]/30 hover:bg-[var(--accent)]/30",
+        entry.enabled
+          ? "text-[var(--foreground)]"
+          : "border-dashed bg-[var(--secondary)]/14 text-[var(--muted-foreground)] opacity-75 ring-[var(--border)]/35",
+        editing && "border-[var(--primary)]/60 bg-[var(--primary)]/10 ring-[var(--primary)]/30",
       )}
     >
-      <div className="grid grid-cols-[auto_1fr_auto] items-start gap-2 p-2.5">
-        <input
-          type="checkbox"
-          checked={entry.enabled}
+      <div className="grid grid-cols-[auto_1fr_auto] items-center gap-2 px-2 py-1.5">
+        <button
+          type="button"
+          onClick={() => onToggleEnabled(!entry.enabled)}
           disabled={mutationPending}
-          onChange={(event) => onToggleEnabled(event.target.checked)}
-          className="mt-1 h-3.5 w-3.5 shrink-0 accent-[var(--muted-foreground)]"
+          className={cn(
+            "flex h-5 w-5 shrink-0 items-center justify-center rounded-md transition-colors disabled:cursor-not-allowed disabled:opacity-50",
+            entry.enabled
+              ? "bg-[var(--primary)]/15 text-[var(--primary)] ring-1 ring-[var(--primary)]/30"
+              : "text-[var(--muted-foreground)] ring-1 ring-[var(--border)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]",
+          )}
           title={entry.enabled ? "Disable summary" : "Enable summary"}
           aria-label={entry.enabled ? "Disable summary" : "Enable summary"}
-        />
+          aria-pressed={entry.enabled}
+        >
+          <Check size="0.6875rem" className={cn(!entry.enabled && "opacity-0")} />
+        </button>
 
         <button type="button" onClick={onToggleExpanded} className="min-w-0 text-left">
           <div className="flex min-w-0 items-center gap-1.5">
             <SummaryEntryOriginIcon entry={entry} />
             <span className="min-w-0 truncate text-xs font-semibold">{entry.title}</span>
+            {editing && (
+              <span className="shrink-0 rounded bg-[var(--primary)]/15 px-1.5 py-0.5 text-[0.5625rem] font-semibold text-[var(--primary)]">
+                Editing
+              </span>
+            )}
           </div>
-          <SummaryEntryMetaChips entry={entry} />
+          <p className="mt-0.5 truncate text-[0.625rem] text-[var(--muted-foreground)]">{metaLine}</p>
         </button>
 
-        <div className="flex shrink-0 items-center gap-0.5 rounded-md bg-[var(--card)] px-0.5 py-0.5 ring-1 ring-[var(--border)] max-md:opacity-100 md:opacity-90">
+        <div className="flex shrink-0 items-center gap-0.5 rounded-md px-0.5 py-0.5 max-md:opacity-100 md:opacity-55 md:transition-opacity md:group-hover:opacity-100 md:group-focus-within:opacity-100">
           <button
             type="button"
             onClick={onToggleExpanded}
-            className="rounded p-1 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] active:scale-90"
+            className={cn(
+              "rounded p-1 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] active:scale-90",
+              expanded && "bg-[var(--accent)] text-[var(--foreground)]",
+            )}
             title={expanded ? "Collapse" : "Expand"}
             aria-label={expanded ? "Collapse summary entry" : "Expand summary entry"}
           >
@@ -1145,7 +1251,7 @@ function SummaryEntryRow({
       </div>
 
       {expanded && (
-        <div className="border-t border-[var(--border)] px-2.5 pb-2.5 pt-2">
+        <div className="border-t border-[var(--border)]/60 px-2.5 pb-2.5 pt-2">
           {editing && draftEntry ? (
             <SummaryEntryEditor
               entry={draftEntry}
@@ -1156,7 +1262,7 @@ function SummaryEntryRow({
               onSave={onSaveEdit}
             />
           ) : (
-            <div className="space-y-3 rounded-md bg-[var(--card)]/45 p-2.5 ring-1 ring-[var(--border)]">
+            <div className="space-y-3 px-0.5 py-0.5">
               {parseSummarySections(entry.content).map((section, sectionIndex) => (
                 <SummaryReadableSection
                   key={`${entry.id}-${section.title ?? "summary"}-${sectionIndex}`}
@@ -1182,8 +1288,13 @@ interface SummaryEntryEditorProps {
 }
 
 function SummaryEntryEditor({ entry, textareaRef, mutationPending, onChange, onCancel, onSave }: SummaryEntryEditorProps) {
+  const metaLine = getSummaryEntryMetaLine(entry);
   return (
     <div className="space-y-2">
+      <div className="flex flex-wrap items-center justify-between gap-2 text-[0.625rem] text-[var(--muted-foreground)]">
+        <span className="min-w-0 truncate">{metaLine || "Manual summary"}</span>
+        <span>{entry.enabled ? "Active" : "Inactive"}</span>
+      </div>
       <input
         value={entry.title}
         onChange={(event) => onChange({ ...entry, title: event.target.value })}
@@ -1200,7 +1311,9 @@ function SummaryEntryEditor({ entry, textareaRef, mutationPending, onChange, onC
         className="max-h-64 min-h-36 w-full resize-y rounded-md bg-[var(--card)] p-2.5 text-xs leading-relaxed text-[var(--foreground)] ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
       />
       <div className="flex flex-wrap items-center justify-between gap-2">
-        <SummaryTokenBadge tokens={estimateChatSummaryTokens(entry.content)} />
+        <span className="text-[0.625rem] text-[var(--muted-foreground)]">
+          ~{formatTokenCount(estimateChatSummaryTokens(entry.content))} tokens
+        </span>
         <div className="flex justify-end gap-1.5">
           <button
             type="button"
@@ -1222,33 +1335,6 @@ function SummaryEntryEditor({ entry, textareaRef, mutationPending, onChange, onC
       </div>
     </div>
   );
-}
-
-function SummaryEntryMetaChips({ entry }: { entry: ChatSummaryEntry }) {
-  const sourceLabel = getSummaryEntrySourceLabel(entry);
-  return (
-    <div className="mt-1 flex flex-wrap gap-1">
-      {sourceLabel && <SummaryMetaChip>{sourceLabel}</SummaryMetaChip>}
-      {entry.messageCount && entry.sourceMode !== "last" && (
-        <SummaryMetaChip>
-          {entry.messageCount} {entry.messageCount === 1 ? "message" : "messages"}
-        </SummaryMetaChip>
-      )}
-      <SummaryTokenBadge tokens={entry.tokenEstimate} />
-    </div>
-  );
-}
-
-function SummaryMetaChip({ children }: { children: ReactNode }) {
-  return (
-    <span className="rounded-full bg-[var(--card)] px-1.5 py-0.5 text-[0.5625rem] font-medium text-[var(--muted-foreground)] ring-1 ring-[var(--border)]">
-      {children}
-    </span>
-  );
-}
-
-function SummaryTokenBadge({ tokens }: { tokens: number }) {
-  return <SummaryMetaChip>~{formatTokenCount(tokens)} tokens</SummaryMetaChip>;
 }
 
 function SummaryEntryOriginIcon({ entry }: { entry: ChatSummaryEntry }) {
@@ -1279,10 +1365,7 @@ interface SummaryReadableSectionProps {
 }
 
 function SummaryReadableSection({ section, sectionIndex }: SummaryReadableSectionProps) {
-  const paragraphs = section.lines
-    .join("\n")
-    .split(/\n\s*\n/)
-    .filter((paragraph) => paragraph.trim().length > 0);
+  const paragraphs = section.lines.join("\n").split(/\n\s*\n/).filter((paragraph) => paragraph.trim().length > 0);
 
   return (
     <section className="space-y-1.5">
@@ -1374,9 +1457,7 @@ function SummaryPromptTemplateRow({
     <div
       className={cn(
         "group flex items-center gap-1 rounded-md px-1.5 py-1 transition-colors",
-        active
-          ? "bg-[var(--accent)] text-[var(--foreground)] ring-1 ring-[var(--border)]"
-          : "hover:bg-[var(--accent)]/45",
+        active ? "bg-[var(--accent)] text-[var(--foreground)] ring-1 ring-[var(--border)]" : "hover:bg-[var(--accent)]/45",
       )}
     >
       <button
@@ -1396,7 +1477,9 @@ function SummaryPromptTemplateRow({
           <Check size="0.625rem" />
         </span>
         <span className="min-w-0">
-          <span className="block truncate text-[0.6875rem] font-semibold text-[var(--popover-foreground)]">{name}</span>
+          <span className="block truncate text-[0.6875rem] font-semibold text-[var(--popover-foreground)]">
+            {name}
+          </span>
           <span className="block truncate text-[0.5625rem] text-[var(--muted-foreground)]">{detail}</span>
         </span>
       </button>

--- a/packages/client/src/components/chat/SummaryPopover.tsx
+++ b/packages/client/src/components/chat/SummaryPopover.tsx
@@ -262,7 +262,7 @@ export function SummaryPopover({
         { chatId, rangeStartIndex: rangeLow, rangeEndIndex: rangeHigh, promptTemplateId: activePromptTemplateId },
         {
           onSuccess: (data) => {
-            setDraft(data.summary);
+            setDraft(data.summary ?? "");
             setEditing(false);
             maybeHideSummarisedMessages(data.messageIds);
           },
@@ -276,7 +276,7 @@ export function SummaryPopover({
       { chatId, contextSize: normalizedLastSize, promptTemplateId: activePromptTemplateId },
       {
         onSuccess: (data) => {
-          setDraft(data.summary);
+          setDraft(data.summary ?? "");
           setEditing(false);
           maybeHideSummarisedMessages(data.messageIds);
         },

--- a/packages/client/src/components/chat/SummaryPopover.tsx
+++ b/packages/client/src/components/chat/SummaryPopover.tsx
@@ -2,12 +2,20 @@
 // Summary Popover — View / edit / generate chat summary
 // Shown via the scroll icon in the chat header bar.
 // ──────────────────────────────────────────────
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef, useCallback, useMemo, type ReactNode, type RefObject } from "react";
 import { createPortal } from "react-dom";
-import { useBulkSetMessagesHiddenFromAI, useGenerateSummary, useUpdateChatMetadata } from "../../hooks/use-chats";
+import {
+  useBulkSetMessagesHiddenFromAI,
+  useDeleteSummaryEntry,
+  useGenerateSummary,
+  useToggleSummaryEntry,
+  useUpdateChatMetadata,
+  useUpdateSummaryEntry,
+} from "../../hooks/use-chats";
 import {
   Check,
   ChevronDown,
+  ChevronRight,
   Copy,
   Info,
   Loader2,
@@ -20,11 +28,12 @@ import {
   Trash2,
   X,
 } from "lucide-react";
+import { toast } from "sonner";
 import { cn, generateClientId } from "../../lib/utils";
 import { useUIStore } from "../../stores/ui.store";
 import {
   DEFAULT_AGENT_PROMPTS,
-  createChatSummaryEntry,
+  estimateChatSummaryTokens,
   normalizeChatSummaryEntries,
   type ChatSummaryEntry,
   type ChatSummaryPromptTemplate,
@@ -46,6 +55,7 @@ type SummarySourceMode = "last" | "range";
 
 const MIN_SUMMARY_MESSAGES = 5;
 const MAX_SUMMARY_MESSAGES = 200;
+const SUMMARY_TOKEN_WARNING_THRESHOLD = 1800;
 const SUMMARY_HEADING_PATTERN = /^(?:#{1,6}\s*)?(?:\*\*)?([^:\n]{3,80})(?:\*\*)?:\s*$/;
 const SUMMARY_BULLET_PATTERN = /^[-*•]\s+/;
 
@@ -102,38 +112,39 @@ function parseSummarySections(value: string): SummarySection[] {
   return sections;
 }
 
-function createSingleEditableSummaryEntry(args: {
-  content: string;
-  summary: string | null;
-  summaryEntries?: ChatSummaryEntry[];
-}): ChatSummaryEntry[] {
-  const content = args.content.trim();
-  if (!content) return [];
+function formatTokenCount(tokens: number): string {
+  if (tokens >= 1000) {
+    const rounded = Math.round(tokens / 100) / 10;
+    return `${Number.isInteger(rounded) ? rounded.toFixed(0) : rounded.toFixed(1)}k`;
+  }
+  return String(tokens);
+}
 
+function getSummaryEntrySourceLabel(entry: ChatSummaryEntry): string | null {
+  if (entry.sourceMode === "range" && entry.rangeStartIndex && entry.rangeEndIndex) {
+    return `Messages ${entry.rangeStartIndex}-${entry.rangeEndIndex}`;
+  }
+  if (entry.sourceMode === "last" && entry.messageCount) {
+    return `${entry.messageCount} ${entry.messageCount === 1 ? "message" : "messages"}`;
+  }
+  if (entry.sourceMode === "agent") return "Agent";
+  return null;
+}
+
+function createBlankManualSummaryEntry(): ChatSummaryEntry {
   const now = new Date().toISOString();
-  const existingEntries = normalizeChatSummaryEntries(args.summaryEntries, {
-    legacySummary: args.summary,
-    now,
-  });
-  const existing = existingEntries.length === 1 ? existingEntries[0] : null;
-
-  return [
-    createChatSummaryEntry(
-      {
-        ...(existing ?? {}),
-        id: existing?.id ?? generateClientId(),
-        kind: "rolling",
-        origin: "manual",
-        title: existing?.title && existing.origin !== "automated" ? existing.title : "Manual summary",
-        content,
-        enabled: true,
-        sourceMode: existing?.sourceMode ?? "last",
-        createdAt: existing?.createdAt ?? now,
-        updatedAt: now,
-      },
-      { createId: generateClientId, now },
-    ),
-  ];
+  return {
+    id: generateClientId(),
+    kind: "rolling",
+    origin: "manual",
+    title: "Manual summary",
+    content: "",
+    enabled: true,
+    sourceMode: "last",
+    tokenEstimate: 0,
+    createdAt: now,
+    updatedAt: now,
+  };
 }
 
 export function SummaryPopover({
@@ -146,8 +157,9 @@ export function SummaryPopover({
   totalMessageCount,
   onClose,
 }: SummaryPopoverProps) {
-  const [editing, setEditing] = useState(false);
-  const [draft, setDraft] = useState(summary ?? "");
+  const [expandedEntryIds, setExpandedEntryIds] = useState<Set<string>>(() => new Set());
+  const [editingEntryId, setEditingEntryId] = useState<string | null>(null);
+  const [draftEntry, setDraftEntry] = useState<ChatSummaryEntry | null>(null);
   const [templateEditorOpen, setTemplateEditorOpen] = useState(false);
   const [templateSelectOpen, setTemplateSelectOpen] = useState(false);
   const [editingTemplateId, setEditingTemplateId] = useState<string | null>(null);
@@ -170,7 +182,10 @@ export function SummaryPopover({
   const generateSummary = useGenerateSummary();
   const bulkSetMessagesHiddenFromAI = useBulkSetMessagesHiddenFromAI();
   const updateMeta = useUpdateChatMetadata();
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const updateSummaryEntry = useUpdateSummaryEntry();
+  const deleteSummaryEntry = useDeleteSummaryEntry();
+  const toggleSummaryEntry = useToggleSummaryEntry();
+  const entryTextareaRef = useRef<HTMLTextAreaElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
 
   const persistSummaryContextSize = useCallback(
@@ -211,11 +226,6 @@ export function SummaryPopover({
     return () => document.removeEventListener("keydown", handler);
   }, [onClose]);
 
-  // Sync draft when summary changes (e.g. after generation)
-  useEffect(() => {
-    setDraft(summary ?? "");
-  }, [summary]);
-
   // Sync local size when the persisted/default context size changes externally.
   useEffect(() => {
     if (!sizeInputFocused.current) {
@@ -230,12 +240,12 @@ export function SummaryPopover({
     setRangeEnd(String(Math.max(1, totalMessageCount)));
   }, [persistedContextSize, sourceMode, totalMessageCount]);
 
-  // Focus textarea when entering edit mode
+  // Focus textarea when entering entry edit mode.
   useEffect(() => {
-    if (editing) {
-      setTimeout(() => textareaRef.current?.focus(), 50);
+    if (editingEntryId) {
+      setTimeout(() => entryTextareaRef.current?.focus(), 50);
     }
-  }, [editing]);
+  }, [editingEntryId]);
 
   const normalizedLastSize = clampSummaryCount(parsePositiveInteger(localSize) ?? persistedContextSize ?? 50);
   const normalizedRangeStart = Math.max(1, Math.min(totalMessageCount || 1, parsePositiveInteger(rangeStart) ?? 1));
@@ -276,7 +286,27 @@ export function SummaryPopover({
   const promptTemplateSummary = activePromptTemplate?.name ?? "Built-in default";
   const isEditingExistingTemplate = !!editingTemplateId;
   const hasTemplateDraft = templateNameDraft.trim().length > 0 && templatePromptDraft.trim().length > 0;
-  const summarySections = parseSummarySections(draft);
+  const displayEntries = useMemo(
+    () =>
+      normalizeChatSummaryEntries(summaryEntries, {
+        legacySummary: summary,
+      }),
+    [summary, summaryEntries],
+  );
+  const visibleEntries = useMemo(() => {
+    if (!draftEntry || displayEntries.some((entry) => entry.id === draftEntry.id)) return displayEntries;
+    return [...displayEntries, draftEntry];
+  }, [displayEntries, draftEntry]);
+  const enabledEntryCount = displayEntries.filter((entry) => entry.enabled).length;
+  const enabledTokenEstimate = displayEntries.reduce(
+    (total, entry) => (entry.enabled ? total + entry.tokenEstimate : total),
+    0,
+  );
+  const hasEntries = visibleEntries.length > 0;
+  const allEntriesDisabled = hasEntries && enabledEntryCount === 0;
+  const tokenWarning = enabledTokenEstimate > SUMMARY_TOKEN_WARNING_THRESHOLD;
+  const entryMutationPending =
+    updateSummaryEntry.isPending || deleteSummaryEntry.isPending || toggleSummaryEntry.isPending;
 
   const handleSourceModeChange = useCallback(
     (mode: SummarySourceMode) => {
@@ -304,10 +334,14 @@ export function SummaryPopover({
         { chatId, rangeStartIndex: rangeLow, rangeEndIndex: rangeHigh, promptTemplateId: activePromptTemplateId },
         {
           onSuccess: (data) => {
-            setDraft(data.summary ?? "");
-            setEditing(false);
+            if (data.entry?.id) {
+              setExpandedEntryIds((current) => new Set(current).add(data.entry!.id));
+            }
+            setEditingEntryId(null);
+            setDraftEntry(null);
             maybeHideSummarisedMessages(data.messageIds);
           },
+          onError: () => toast.error("Could not generate summary."),
         },
       );
       return;
@@ -318,10 +352,14 @@ export function SummaryPopover({
       { chatId, contextSize: normalizedLastSize, promptTemplateId: activePromptTemplateId },
       {
         onSuccess: (data) => {
-          setDraft(data.summary ?? "");
-          setEditing(false);
+          if (data.entry?.id) {
+            setExpandedEntryIds((current) => new Set(current).add(data.entry!.id));
+          }
+          setEditingEntryId(null);
+          setDraftEntry(null);
           maybeHideSummarisedMessages(data.messageIds);
         },
+        onError: () => toast.error("Could not generate summary."),
       },
     );
   }, [
@@ -338,15 +376,96 @@ export function SummaryPopover({
     summaryPopoverSettings.hideSummarisedMessages,
   ]);
 
-  const handleSave = useCallback(() => {
-    const content = draft.trim();
-    updateMeta.mutate({
-      id: chatId,
-      summary: content || null,
-      summaryEntries: createSingleEditableSummaryEntry({ content, summary, summaryEntries }),
+  const handleToggleExpanded = useCallback((entryId: string) => {
+    setExpandedEntryIds((current) => {
+      const next = new Set(current);
+      if (next.has(entryId)) {
+        next.delete(entryId);
+      } else {
+        next.add(entryId);
+      }
+      return next;
     });
-    setEditing(false);
-  }, [chatId, draft, summary, summaryEntries, updateMeta]);
+  }, []);
+
+  const handleStartEditEntry = useCallback((entry: ChatSummaryEntry) => {
+    setEditingEntryId(entry.id);
+    setDraftEntry({ ...entry });
+    setExpandedEntryIds((current) => new Set(current).add(entry.id));
+  }, []);
+
+  const handleCreateManualEntry = useCallback(() => {
+    const entry = createBlankManualSummaryEntry();
+    setEditingEntryId(entry.id);
+    setDraftEntry(entry);
+    setExpandedEntryIds((current) => new Set(current).add(entry.id));
+  }, []);
+
+  const handleCancelEditEntry = useCallback(() => {
+    setEditingEntryId(null);
+    setDraftEntry(null);
+  }, []);
+
+  const handleSaveEntry = useCallback(async () => {
+    if (!draftEntry) return;
+    const content = draftEntry.content.trim();
+    const title = draftEntry.title.trim() || "Manual summary";
+    if (!content) {
+      toast.error("Summary content is required.");
+      return;
+    }
+    try {
+      await updateSummaryEntry.mutateAsync({
+        chatId,
+        entry: {
+          ...draftEntry,
+          title,
+          content,
+          tokenEstimate: estimateChatSummaryTokens(content),
+        },
+      });
+      setEditingEntryId(null);
+      setDraftEntry(null);
+    } catch {
+      toast.error("Could not save summary entry.");
+    }
+  }, [chatId, draftEntry, updateSummaryEntry]);
+
+  const handleToggleEntry = useCallback(
+    async (entry: ChatSummaryEntry, enabled: boolean) => {
+      try {
+        await toggleSummaryEntry.mutateAsync({ chatId, entryId: entry.id, enabled });
+      } catch {
+        toast.error("Could not update summary entry.");
+      }
+    },
+    [chatId, toggleSummaryEntry],
+  );
+
+  const handleDeleteEntry = useCallback(
+    async (entry: ChatSummaryEntry) => {
+      const confirmed = await showConfirmDialog({
+        title: "Delete summary entry?",
+        message: `Delete "${entry.title}"? This will change the summary context sent to the model.`,
+        confirmLabel: "Delete",
+        cancelLabel: "Cancel",
+        tone: "destructive",
+      });
+      if (!confirmed) return;
+      try {
+        await deleteSummaryEntry.mutateAsync({ chatId, entryId: entry.id });
+        if (editingEntryId === entry.id) handleCancelEditEntry();
+        setExpandedEntryIds((current) => {
+          const next = new Set(current);
+          next.delete(entry.id);
+          return next;
+        });
+      } catch {
+        toast.error("Could not delete summary entry.");
+      }
+    },
+    [chatId, deleteSummaryEntry, editingEntryId, handleCancelEditEntry],
+  );
 
   const persistPromptTemplates = useCallback(
     (templates: ChatSummaryPromptTemplate[], activeId: string | null) => {
@@ -465,7 +584,7 @@ export function SummaryPopover({
       <div
         className={cn(
           "relative rounded-xl border border-[var(--border)] bg-[var(--card)] shadow-2xl shadow-black/40",
-          isMobile ? "relative w-full max-w-sm max-h-[calc(100dvh-4rem)] overflow-y-auto" : "w-[22rem]",
+          isMobile ? "relative w-full max-w-md max-h-[calc(100dvh-4rem)] overflow-y-auto" : "w-[28rem]",
         )}
       >
         {/* Header */}
@@ -475,7 +594,11 @@ export function SummaryPopover({
               <ScrollText size="0.8125rem" className="shrink-0 text-[var(--muted-foreground)]" />
               <span className="truncate">Chat Summary</span>
             </div>
-            <p className="truncate text-[0.625rem] text-[var(--muted-foreground)]">{sourceSummary}</p>
+            <p className="truncate text-[0.625rem] text-[var(--muted-foreground)]">
+              {hasEntries
+                ? `${enabledEntryCount} enabled · ~${formatTokenCount(enabledTokenEstimate)} tokens`
+                : "No summaries yet"}
+            </p>
           </div>
           <div className="flex shrink-0 items-center gap-1">
             <button
@@ -797,67 +920,56 @@ export function SummaryPopover({
         )}
 
         {/* Body */}
-        <div className="max-h-80 overflow-y-auto p-3">
-          {editing ? (
-            <div className="space-y-2">
-              <textarea
-                ref={textareaRef}
-                value={draft}
-                onChange={(e) => setDraft(e.target.value)}
-                rows={6}
-                className="max-h-48 w-full resize-y rounded-lg bg-[var(--secondary)] p-2.5 text-xs ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
-                placeholder="Write or paste a summary of this chat…"
-              />
-              <div className="flex justify-end gap-1.5">
-                <button
-                  onClick={() => {
-                    setDraft(summary ?? "");
-                    setEditing(false);
-                  }}
-                  className="rounded-lg px-2.5 py-1 text-[0.625rem] font-medium text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)]"
-                >
-                  Cancel
-                </button>
-                <button
-                  onClick={handleSave}
-                  disabled={updateMeta.isPending}
-                  className="flex items-center gap-1 rounded-lg bg-[var(--secondary)] px-2.5 py-1 text-[0.625rem] font-medium text-[var(--foreground)] ring-1 ring-[var(--border)] transition-all hover:bg-[var(--accent)] active:scale-[0.98] disabled:opacity-50"
-                >
-                  <Save size="0.625rem" />
-                  Save
-                </button>
+        <div className="max-h-[min(26rem,calc(100dvh-15rem))] overflow-y-auto p-3">
+          <div className="space-y-2">
+            {tokenWarning && (
+              <div className="rounded-lg border border-amber-400/30 bg-amber-500/10 px-2.5 py-2 text-[0.6875rem] leading-relaxed text-amber-200">
+                Enabled summaries are around {formatTokenCount(enabledTokenEstimate)} tokens. Consider disabling older
+                entries if prompt context feels crowded.
               </div>
-            </div>
-          ) : (
-            <div>
-              {draft ? (
-                <div
-                  className="cursor-pointer rounded-lg border border-[var(--border)] bg-[var(--secondary)]/25 p-3 transition-colors hover:bg-[var(--accent)]/45"
-                  onClick={() => setEditing(true)}
-                  title="Click to edit"
-                >
-                  <div className="space-y-3">
-                    {summarySections.map((section, sectionIndex) => (
-                      <SummaryReadableSection
-                        key={`${section.title ?? "summary"}-${sectionIndex}`}
-                        section={section}
-                        sectionIndex={sectionIndex}
-                      />
-                    ))}
-                  </div>
-                </div>
-              ) : (
-                <div
-                  className="cursor-pointer rounded-lg border border-dashed border-[var(--border)] bg-[var(--secondary)]/20 p-5 transition-colors hover:bg-[var(--accent)]/35"
-                  onClick={() => setEditing(true)}
-                >
-                  <p className="text-center text-xs italic text-[var(--muted-foreground)]">
-                    No summary yet. Click to write one, or press Generate.
-                  </p>
-                </div>
-              )}
-            </div>
-          )}
+            )}
+
+            {allEntriesDisabled && (
+              <div className="rounded-lg border border-[var(--border)] bg-[var(--secondary)]/20 px-2.5 py-2 text-[0.6875rem] leading-relaxed text-[var(--muted-foreground)]">
+                All summaries are disabled. The model will not receive summary context.
+              </div>
+            )}
+
+            {draftEntry && !displayEntries.some((entry) => entry.id === draftEntry.id) && (
+              <div className="rounded-lg border border-[var(--border)] bg-[var(--secondary)]/20 px-2.5 py-2 text-[0.6875rem] leading-relaxed text-[var(--muted-foreground)]">
+                New manual summary. Save it to include it in prompt context.
+              </div>
+            )}
+
+            {hasEntries ? (
+              visibleEntries.map((entry) => (
+                <SummaryEntryRow
+                  key={entry.id}
+                  entry={entry}
+                  expanded={expandedEntryIds.has(entry.id)}
+                  editing={editingEntryId === entry.id}
+                  draftEntry={editingEntryId === entry.id ? draftEntry : null}
+                  textareaRef={entryTextareaRef}
+                  mutationPending={entryMutationPending}
+                  onToggleExpanded={() => handleToggleExpanded(entry.id)}
+                  onToggleEnabled={(enabled) => handleToggleEntry(entry, enabled)}
+                  onStartEdit={() => handleStartEditEntry(entry)}
+                  onDraftChange={setDraftEntry}
+                  onCancelEdit={handleCancelEditEntry}
+                  onSaveEdit={handleSaveEntry}
+                  onDelete={() => void handleDeleteEntry(entry)}
+                />
+              ))
+            ) : (
+              <button
+                type="button"
+                onClick={handleCreateManualEntry}
+                className="w-full rounded-lg border border-dashed border-[var(--border)] bg-[var(--secondary)]/20 p-5 text-center text-xs italic text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)]/35"
+              >
+                No summaries yet. Generate one or write your own.
+              </button>
+            )}
+          </div>
         </div>
 
         {/* Source controls */}
@@ -867,20 +979,32 @@ export function SummaryPopover({
             <span className="shrink-0 text-right">{sourceDetail}</span>
           </div>
 
-          <button
-            onClick={handleGenerate}
-            disabled={isGenerating || !canGenerate}
-            className={cn(
-              "mt-2 flex w-full items-center justify-center gap-1.5 rounded-lg px-3 py-2 text-xs font-semibold transition-all",
-              isGenerating || !canGenerate
-                ? "cursor-not-allowed bg-[var(--secondary)] text-[var(--muted-foreground)]"
-                : "bg-[var(--secondary)] text-[var(--foreground)] ring-1 ring-[var(--border)] hover:bg-[var(--accent)] active:scale-[0.98]",
-            )}
-            title="Generate summary with AI"
-          >
-            {isGenerating ? <Loader2 size="0.8125rem" className="animate-spin" /> : <Sparkles size="0.8125rem" />}
-            {isGenerating ? "Generating..." : "Generate"}
-          </button>
+          <div className="grid grid-cols-[auto_1fr] gap-1.5">
+            <button
+              type="button"
+              onClick={handleCreateManualEntry}
+              className="flex items-center justify-center gap-1.5 rounded-lg px-3 py-2 text-xs font-semibold text-[var(--foreground)] ring-1 ring-[var(--border)] transition-all hover:bg-[var(--accent)] active:scale-[0.98]"
+              title="Write summary entry"
+            >
+              <PenLine size="0.8125rem" />
+              Write
+            </button>
+            <button
+              type="button"
+              onClick={handleGenerate}
+              disabled={isGenerating || !canGenerate}
+              className={cn(
+                "flex items-center justify-center gap-1.5 rounded-lg px-3 py-2 text-xs font-semibold transition-all",
+                isGenerating || !canGenerate
+                  ? "cursor-not-allowed bg-[var(--secondary)] text-[var(--muted-foreground)]"
+                  : "bg-[var(--secondary)] text-[var(--foreground)] ring-1 ring-[var(--border)] hover:bg-[var(--accent)] active:scale-[0.98]",
+              )}
+              title="Generate summary with AI"
+            >
+              {isGenerating ? <Loader2 size="0.8125rem" className="animate-spin" /> : <Sparkles size="0.8125rem" />}
+              {isGenerating ? "Generating..." : "Generate"}
+            </button>
+          </div>
         </div>
 
         {/* Info tip */}
@@ -919,6 +1043,224 @@ function SummarySettingsToggle({ label, checked, onChange }: SummarySettingsTogg
       />
     </label>
   );
+}
+
+interface SummaryEntryRowProps {
+  entry: ChatSummaryEntry;
+  expanded: boolean;
+  editing: boolean;
+  draftEntry: ChatSummaryEntry | null;
+  textareaRef: RefObject<HTMLTextAreaElement | null>;
+  mutationPending: boolean;
+  onToggleExpanded: () => void;
+  onToggleEnabled: (enabled: boolean) => void;
+  onStartEdit: () => void;
+  onDraftChange: (entry: ChatSummaryEntry | null) => void;
+  onCancelEdit: () => void;
+  onSaveEdit: () => void;
+  onDelete: () => void;
+}
+
+function SummaryEntryRow({
+  entry,
+  expanded,
+  editing,
+  draftEntry,
+  textareaRef,
+  mutationPending,
+  onToggleExpanded,
+  onToggleEnabled,
+  onStartEdit,
+  onDraftChange,
+  onCancelEdit,
+  onSaveEdit,
+  onDelete,
+}: SummaryEntryRowProps) {
+  return (
+    <div
+      className={cn(
+        "rounded-lg border border-[var(--border)] bg-[var(--secondary)]/20 transition-colors",
+        entry.enabled ? "text-[var(--foreground)]" : "text-[var(--muted-foreground)] opacity-75",
+      )}
+    >
+      <div className="grid grid-cols-[auto_1fr_auto] items-start gap-2 p-2.5">
+        <input
+          type="checkbox"
+          checked={entry.enabled}
+          disabled={mutationPending}
+          onChange={(event) => onToggleEnabled(event.target.checked)}
+          className="mt-1 h-3.5 w-3.5 shrink-0 accent-[var(--muted-foreground)]"
+          title={entry.enabled ? "Disable summary" : "Enable summary"}
+          aria-label={entry.enabled ? "Disable summary" : "Enable summary"}
+        />
+
+        <button type="button" onClick={onToggleExpanded} className="min-w-0 text-left">
+          <div className="flex min-w-0 items-center gap-1.5">
+            <SummaryEntryOriginIcon entry={entry} />
+            <span className="min-w-0 truncate text-xs font-semibold">{entry.title}</span>
+          </div>
+          <SummaryEntryMetaChips entry={entry} />
+        </button>
+
+        <div className="flex shrink-0 items-center gap-0.5 rounded-md bg-[var(--card)] px-0.5 py-0.5 ring-1 ring-[var(--border)] max-md:opacity-100 md:opacity-90">
+          <button
+            type="button"
+            onClick={onToggleExpanded}
+            className="rounded p-1 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] active:scale-90"
+            title={expanded ? "Collapse" : "Expand"}
+            aria-label={expanded ? "Collapse summary entry" : "Expand summary entry"}
+          >
+            <ChevronRight size="0.75rem" className={cn("transition-transform", expanded && "rotate-90")} />
+          </button>
+          <button
+            type="button"
+            onClick={onStartEdit}
+            className="rounded p-1 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] active:scale-90"
+            title="Edit"
+            aria-label="Edit summary entry"
+          >
+            <PenLine size="0.75rem" />
+          </button>
+          <button
+            type="button"
+            onClick={onDelete}
+            disabled={mutationPending}
+            className="rounded p-1 text-[var(--destructive)] transition-colors hover:bg-[var(--destructive)]/15 active:scale-90 disabled:cursor-not-allowed disabled:opacity-50"
+            title="Delete"
+            aria-label="Delete summary entry"
+          >
+            <Trash2 size="0.75rem" />
+          </button>
+        </div>
+      </div>
+
+      {expanded && (
+        <div className="border-t border-[var(--border)] px-2.5 pb-2.5 pt-2">
+          {editing && draftEntry ? (
+            <SummaryEntryEditor
+              entry={draftEntry}
+              textareaRef={textareaRef}
+              mutationPending={mutationPending}
+              onChange={onDraftChange}
+              onCancel={onCancelEdit}
+              onSave={onSaveEdit}
+            />
+          ) : (
+            <div className="space-y-3 rounded-md bg-[var(--card)]/45 p-2.5 ring-1 ring-[var(--border)]">
+              {parseSummarySections(entry.content).map((section, sectionIndex) => (
+                <SummaryReadableSection
+                  key={`${entry.id}-${section.title ?? "summary"}-${sectionIndex}`}
+                  section={section}
+                  sectionIndex={sectionIndex}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface SummaryEntryEditorProps {
+  entry: ChatSummaryEntry;
+  textareaRef: RefObject<HTMLTextAreaElement | null>;
+  mutationPending: boolean;
+  onChange: (entry: ChatSummaryEntry) => void;
+  onCancel: () => void;
+  onSave: () => void;
+}
+
+function SummaryEntryEditor({ entry, textareaRef, mutationPending, onChange, onCancel, onSave }: SummaryEntryEditorProps) {
+  return (
+    <div className="space-y-2">
+      <input
+        value={entry.title}
+        onChange={(event) => onChange({ ...entry, title: event.target.value })}
+        maxLength={120}
+        placeholder="Summary title"
+        className="w-full rounded-md bg-[var(--card)] px-2.5 py-1.5 text-xs font-semibold text-[var(--foreground)] ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+      />
+      <textarea
+        ref={textareaRef}
+        value={entry.content}
+        onChange={(event) => onChange({ ...entry, content: event.target.value })}
+        rows={7}
+        placeholder="Write or paste a summary of this chat..."
+        className="max-h-64 min-h-36 w-full resize-y rounded-md bg-[var(--card)] p-2.5 text-xs leading-relaxed text-[var(--foreground)] ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+      />
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <SummaryTokenBadge tokens={estimateChatSummaryTokens(entry.content)} />
+        <div className="flex justify-end gap-1.5">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded-md px-2.5 py-1 text-[0.625rem] font-medium text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)]"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onSave}
+            disabled={mutationPending || !entry.content.trim()}
+            className="flex items-center gap-1 rounded-md bg-[var(--secondary)] px-2.5 py-1 text-[0.625rem] font-semibold text-[var(--foreground)] ring-1 ring-[var(--border)] transition-all hover:bg-[var(--accent)] active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <Save size="0.625rem" />
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SummaryEntryMetaChips({ entry }: { entry: ChatSummaryEntry }) {
+  const sourceLabel = getSummaryEntrySourceLabel(entry);
+  return (
+    <div className="mt-1 flex flex-wrap gap-1">
+      {sourceLabel && <SummaryMetaChip>{sourceLabel}</SummaryMetaChip>}
+      {entry.messageCount && entry.sourceMode !== "last" && (
+        <SummaryMetaChip>
+          {entry.messageCount} {entry.messageCount === 1 ? "message" : "messages"}
+        </SummaryMetaChip>
+      )}
+      <SummaryTokenBadge tokens={entry.tokenEstimate} />
+    </div>
+  );
+}
+
+function SummaryMetaChip({ children }: { children: ReactNode }) {
+  return (
+    <span className="rounded-full bg-[var(--card)] px-1.5 py-0.5 text-[0.5625rem] font-medium text-[var(--muted-foreground)] ring-1 ring-[var(--border)]">
+      {children}
+    </span>
+  );
+}
+
+function SummaryTokenBadge({ tokens }: { tokens: number }) {
+  return <SummaryMetaChip>~{formatTokenCount(tokens)} tokens</SummaryMetaChip>;
+}
+
+function SummaryEntryOriginIcon({ entry }: { entry: ChatSummaryEntry }) {
+  if (entry.origin === "automated") {
+    return (
+      <Sparkles
+        size="0.75rem"
+        className="shrink-0 text-[var(--primary)]"
+        aria-label="Automated summary"
+      />
+    );
+  }
+  if (entry.origin === "legacy") {
+    return (
+      <ScrollText
+        size="0.75rem"
+        className="shrink-0 text-[var(--muted-foreground)]"
+        aria-label="Legacy summary"
+      />
+    );
+  }
+  return <PenLine size="0.75rem" className="shrink-0 text-[var(--muted-foreground)]" aria-label="Manual summary" />;
 }
 
 interface SummaryReadableSectionProps {

--- a/packages/client/src/hooks/use-chats.ts
+++ b/packages/client/src/hooks/use-chats.ts
@@ -14,6 +14,7 @@ import { lorebookKeys } from "./use-lorebooks";
 import type {
   Chat,
   ChatMemoryChunk,
+  ChatSummaryEntry,
   ConversationNote,
   Message,
   MessageSwipe,
@@ -482,6 +483,60 @@ export function useUpdateChatSummaries() {
   });
 }
 
+export type SummaryEntryOperation =
+  | { operation: "replace"; entry: Partial<ChatSummaryEntry> & { id: string; content: string } }
+  | { operation: "delete"; entryId: string }
+  | { operation: "toggle"; entryId: string; enabled: boolean };
+
+function useSummaryEntryMutation() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ chatId, ...body }: { chatId: string } & SummaryEntryOperation) =>
+      api.patch<Chat>(`/chats/${chatId}/summary-entries`, body),
+    onSuccess: (data, vars) => {
+      if (data) {
+        qc.setQueryData(chatKeys.detail(vars.chatId), data);
+      } else {
+        qc.invalidateQueries({ queryKey: chatKeys.detail(vars.chatId) });
+      }
+      qc.invalidateQueries({ queryKey: chatKeys.list() });
+      qc.invalidateQueries({ queryKey: lorebookKeys.active(vars.chatId) });
+    },
+  });
+}
+
+export function useUpdateSummaryEntry() {
+  const mutation = useSummaryEntryMutation();
+  return {
+    ...mutation,
+    mutate: (input: { chatId: string; entry: Partial<ChatSummaryEntry> & { id: string; content: string } }) =>
+      mutation.mutate({ ...input, operation: "replace" }),
+    mutateAsync: (input: { chatId: string; entry: Partial<ChatSummaryEntry> & { id: string; content: string } }) =>
+      mutation.mutateAsync({ ...input, operation: "replace" }),
+  };
+}
+
+export function useDeleteSummaryEntry() {
+  const mutation = useSummaryEntryMutation();
+  return {
+    ...mutation,
+    mutate: (input: { chatId: string; entryId: string }) => mutation.mutate({ ...input, operation: "delete" }),
+    mutateAsync: (input: { chatId: string; entryId: string }) =>
+      mutation.mutateAsync({ ...input, operation: "delete" }),
+  };
+}
+
+export function useToggleSummaryEntry() {
+  const mutation = useSummaryEntryMutation();
+  return {
+    ...mutation,
+    mutate: (input: { chatId: string; entryId: string; enabled: boolean }) =>
+      mutation.mutate({ ...input, operation: "toggle" }),
+    mutateAsync: (input: { chatId: string; entryId: string; enabled: boolean }) =>
+      mutation.mutateAsync({ ...input, operation: "toggle" }),
+  };
+}
+
 /** Backfill missing conversation day/week summaries via the LLM. */
 export function useBackfillConversationSummaries() {
   const qc = useQueryClient();
@@ -791,7 +846,12 @@ export function useGenerateSummary() {
       rangeEndIndex,
       promptTemplateId,
     }: GenerateSummaryInput) =>
-      api.post<{ summary: string; messageIds: string[] }>(`/chats/${chatId}/generate-summary`, {
+      api.post<{
+        summary: string | null;
+        entry: ChatSummaryEntry | null;
+        entries: ChatSummaryEntry[];
+        messageIds: string[];
+      }>(`/chats/${chatId}/generate-summary`, {
         contextSize,
         rangeStartMessageId,
         rangeEndMessageId,

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -430,7 +430,13 @@ export async function chatsRoutes(app: FastifyInstance) {
       return reply.status(400).send({ error: "Invalid summary entry operation" });
     }
     if (body.operation === "replace") {
-      if (!body.entry || typeof body.entry.id !== "string" || typeof body.entry.content !== "string") {
+      if (
+        !body.entry ||
+        typeof body.entry.id !== "string" ||
+        !body.entry.id.trim() ||
+        typeof body.entry.content !== "string" ||
+        !body.entry.content.trim()
+      ) {
         return reply.status(400).send({ error: "replace requires entry.id and entry.content" });
       }
     } else if (body.operation === "delete") {

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -7,14 +7,24 @@ import {
   LOCAL_SIDECAR_CONNECTION_ID,
   createChatSchema,
   createMessageSchema,
+  appendChatSummaryEntryToMetadata,
+  compileChatSummaryEntries,
+  createChatSummaryEntry,
   getDefaultAgentPrompt,
   markAutonomousUnreadSchema,
   nameToXmlTag,
+  normalizeChatSummaryEntries,
   resolveMacros,
   summariesPatchSchema,
   coerceGameStateTextValue,
 } from "@marinara-engine/shared";
-import type { CharacterData, ChatMemoryChunk, GameNpc, LorebookEntryTimingState } from "@marinara-engine/shared";
+import type {
+  CharacterData,
+  ChatMemoryChunk,
+  ChatSummaryEntry,
+  GameNpc,
+  LorebookEntryTimingState,
+} from "@marinara-engine/shared";
 import { createChatsStorage } from "../services/storage/chats.storage.js";
 import { createCharactersStorage } from "../services/storage/characters.storage.js";
 import { createConnectionsStorage } from "../services/storage/connections.storage.js";
@@ -69,6 +79,10 @@ function sanitizeChatGameNpcAvatars<T extends { metadata?: unknown }>(chat: T): 
     metadata: typeof chat.metadata === "string" ? JSON.stringify(sanitizedMetadata) : sanitizedMetadata,
   };
 }
+type SummaryEntriesPatchBody =
+  | { operation: "replace"; entry: Partial<ChatSummaryEntry> & { id: string; content: string } }
+  | { operation: "delete"; entryId: string }
+  | { operation: "toggle"; entryId: string; enabled: boolean };
 
 async function loadLatestChatGameSnapshot(
   app: FastifyInstance,
@@ -407,6 +421,72 @@ export async function chatsRoutes(app: FastifyInstance) {
       weekSummaries: { ...(existing.weekSummaries ?? {}), ...(parsed.data.weekSummaries ?? {}) },
     };
     return storage.updateMetadata(req.params.id, merged);
+  });
+
+  // Update rolling summary entries without replacing unrelated chat metadata.
+  app.patch<{ Params: { id: string }; Body: SummaryEntriesPatchBody }>("/:id/summary-entries", async (req, reply) => {
+    const body = req.body;
+    if (!body || typeof body !== "object" || !("operation" in body)) {
+      return reply.status(400).send({ error: "Invalid summary entry operation" });
+    }
+    if (body.operation === "replace") {
+      if (!body.entry || typeof body.entry.id !== "string" || typeof body.entry.content !== "string") {
+        return reply.status(400).send({ error: "replace requires entry.id and entry.content" });
+      }
+    } else if (body.operation === "delete") {
+      if (typeof body.entryId !== "string" || !body.entryId.trim()) {
+        return reply.status(400).send({ error: "delete requires entryId" });
+      }
+    } else if (body.operation === "toggle") {
+      if (typeof body.entryId !== "string" || !body.entryId.trim() || typeof body.enabled !== "boolean") {
+        return reply.status(400).send({ error: "toggle requires entryId and enabled" });
+      }
+    } else {
+      return reply.status(400).send({ error: "Unsupported summary entry operation" });
+    }
+
+    const updated = await storage.patchMetadata(req.params.id, (freshMeta) => {
+      const entries = normalizeChatSummaryEntries(freshMeta.summaryEntries, {
+        legacySummary: typeof freshMeta.summary === "string" ? freshMeta.summary : null,
+      });
+      let nextEntries: ChatSummaryEntry[];
+
+      if (body.operation === "replace") {
+        const now = new Date().toISOString();
+        const existing = entries.find((entry) => entry.id === body.entry.id);
+        const replacement = createChatSummaryEntry(
+          {
+            ...existing,
+            ...body.entry,
+            id: body.entry.id,
+            content: body.entry.content,
+            updatedAt: now,
+            createdAt: existing?.createdAt ?? body.entry.createdAt ?? now,
+          },
+          { createId: newId, now },
+        );
+        nextEntries = entries.some((entry) => entry.id === replacement.id)
+          ? entries.map((entry) => (entry.id === replacement.id ? replacement : entry))
+          : [...entries, replacement];
+      } else if (body.operation === "delete") {
+        nextEntries = entries.filter((entry) => entry.id !== body.entryId);
+      } else if (body.operation === "toggle") {
+        const now = new Date().toISOString();
+        nextEntries = entries.map((entry) =>
+          entry.id === body.entryId ? { ...entry, enabled: body.enabled, updatedAt: now } : entry,
+        );
+      } else {
+        nextEntries = entries;
+      }
+
+      return {
+        summaryEntries: nextEntries,
+        summary: compileChatSummaryEntries(nextEntries),
+      };
+    });
+
+    if (!updated) return reply.status(404).send({ error: "Chat not found" });
+    return updated;
   });
 
   // Generate any missing conversation day/week summaries on demand. This uses
@@ -1923,6 +2003,8 @@ export async function chatsRoutes(app: FastifyInstance) {
     // Hidden-from-AI messages are excluded from summary generation even when
     // they fall inside the selected range.
     const allMessages = await storage.listMessages(req.params.id);
+    let selectedRangeStartIndex: number | undefined;
+    let selectedRangeEndIndex: number | undefined;
     const selectedMessages = hasRange
       ? (() => {
           const startIndex = hasRangeByIndex
@@ -1943,6 +2025,8 @@ export async function chatsRoutes(app: FastifyInstance) {
           if (count > 200) {
             return { error: "Summary ranges cannot include more than 200 messages" as const };
           }
+          selectedRangeStartIndex = from + 1;
+          selectedRangeEndIndex = to + 1;
           return allMessages.slice(from, to + 1).filter((message) => !isMessageHiddenFromAI(message));
         })()
       : allMessages.slice(-contextSize).filter((message) => !isMessageHiddenFromAI(message));
@@ -2013,18 +2097,47 @@ export async function chatsRoutes(app: FastifyInstance) {
       summaryText = result.content.trim();
     }
 
-    // Append to the latest summary without replacing concurrent metadata changes.
-    let combined = summaryText;
+    // Append as a structured entry and recompile the prompt-facing summary
+    // without replacing concurrent metadata changes.
+    let combined: string | null = summaryText;
+    let createdEntry: ChatSummaryEntry | null = null;
+    let summaryEntries: ChatSummaryEntry[] = [];
     const updatedChat = await storage.patchMetadata(req.params.id, (freshMeta) => {
-      const existing = ((freshMeta.summary as string) ?? "").trim();
-      combined = existing ? `${existing}\n\n${summaryText}` : summaryText;
+      const now = new Date().toISOString();
+      const result = appendChatSummaryEntryToMetadata(
+        freshMeta,
+        {
+          kind: "rolling",
+          origin: "manual",
+          sourceMode: hasRange ? "range" : "last",
+          content: summaryText,
+          enabled: true,
+          messageCount: selectedMessages.length,
+          rangeStartIndex: selectedRangeStartIndex,
+          rangeEndIndex: selectedRangeEndIndex,
+          messageIds: selectedMessages.map((message) => message.id),
+          promptTemplateId: requestedPromptTemplateId,
+          createdAt: now,
+          updatedAt: now,
+        },
+        { createId: newId, now },
+      );
+      combined = result.summary;
+      createdEntry = result.entry;
+      summaryEntries = result.entries;
       return {
-        summary: combined,
+        summary: result.summary,
+        summaryEntries: result.entries,
         ...(!hasRange && typeof body.contextSize !== "undefined" ? { summaryContextSize: contextSize } : {}),
       };
     });
     if (!updatedChat) return reply.status(404).send({ error: "Chat not found" });
 
-    return { summary: combined, messageIds: selectedMessages.map((message) => message.id) };
+    return {
+      summary: combined,
+      entry: createdEntry,
+      entries: summaryEntries,
+      messageIds: selectedMessages.map((message) => message.id),
+    };
   });
 }

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -1094,7 +1094,7 @@ export async function generateRoutes(app: FastifyInstance) {
       const allChatMessages = await chats.listMessages(input.chatId);
       const chatMode = requestChatMode;
       const lorebookGenerationTriggers = resolveLorebookGenerationTriggers(input, chatMode);
-      const supportsHiddenFromAI = chatMode === "roleplay" || chatMode === "visual_novel";
+      const supportsHiddenFromAI = chatMode === "conversation" || chatMode === "roleplay" || chatMode === "visual_novel";
       const preferLatestVisibleGameState = shouldPreferLatestVisibleGameState(input);
 
       // ── Conversation-start filter: find the latest "isConversationStart" marker ──

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -19,6 +19,7 @@ import {
   hasDeferredCharacterMacros,
   LIMITS,
   coerceGameStateTextValue,
+  appendChatSummaryEntryToMetadata,
 } from "@marinara-engine/shared";
 import type {
   AgentContext,
@@ -32,6 +33,7 @@ import type {
   HapticDeviceCommand,
   PlayerStats,
   LorebookEntryTimingState,
+  ChatSummaryEntry,
 } from "@marinara-engine/shared";
 import { createChatsStorage } from "../services/storage/chats.storage.js";
 import { createConnectionsStorage } from "../services/storage/connections.storage.js";
@@ -8104,12 +8106,24 @@ export async function generateRoutes(app: FastifyInstance) {
               const csData = result.data as Record<string, unknown>;
               const newText = ((csData.summary as string) ?? "").trim();
               if (newText) {
+                let createdEntry: ChatSummaryEntry | null = null;
+                let summaryEntries: ChatSummaryEntry[] = [];
                 const updatedMeta = await updateChatMetadataForTools((currentMeta) => {
-                  const existing = ((currentMeta.summary as string) ?? "").trim();
-                  return { summary: existing ? `${existing}\n\n${newText}` : newText };
+                  const result = appendChatSummaryEntryToMetadata(currentMeta, {
+                    kind: "rolling",
+                    origin: "automated",
+                    sourceMode: "agent",
+                    content: newText,
+                    enabled: true,
+                  });
+                  createdEntry = result.entry;
+                  summaryEntries = result.entries;
+                  return { summary: result.summary, summaryEntries: result.entries };
                 });
                 const combined = typeof updatedMeta.summary === "string" ? updatedMeta.summary : newText;
-                reply.raw.write(`data: ${JSON.stringify({ type: "chat_summary", data: { summary: combined } })}\n\n`);
+                reply.raw.write(
+                  `data: ${JSON.stringify({ type: "chat_summary", data: { summary: combined, entry: createdEntry, entries: summaryEntries } })}\n\n`,
+                );
               }
             } catch {
               // Non-critical

--- a/packages/server/src/routes/generate/dry-run-route.ts
+++ b/packages/server/src/routes/generate/dry-run-route.ts
@@ -628,7 +628,7 @@ export async function registerDryRunRoute(app: FastifyInstance) {
     // Pull existing messages, apply the same conversation-start + context limit filtering
     const allChatMessages = await chats.listMessages(chatId);
     const chatMode = (chat.mode as string) ?? "roleplay";
-    const supportsHiddenFromAI = chatMode === "roleplay" || chatMode === "visual_novel";
+    const supportsHiddenFromAI = chatMode === "conversation" || chatMode === "roleplay" || chatMode === "visual_novel";
     let startIdx = 0;
     for (let i = allChatMessages.length - 1; i >= 0; i--) {
       const extra = parseExtra(allChatMessages[i]!.extra);

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -2004,7 +2004,8 @@ export async function registerRetryAgentsRoute(app: FastifyInstance) {
         };
       }
 
-      const supportsHiddenFromAI = chat.mode === "roleplay" || chat.mode === "visual_novel";
+      const supportsHiddenFromAI =
+        chat.mode === "conversation" || chat.mode === "roleplay" || chat.mode === "visual_novel";
       if (supportsHiddenFromAI) {
         recentMessages = recentMessages.filter((message: any) => !isMessageHiddenFromAI(message));
         if (preGenerationRecentMessages) {

--- a/packages/server/src/services/storage/chats.storage.ts
+++ b/packages/server/src/services/storage/chats.storage.ts
@@ -658,11 +658,17 @@ export function createChatsStorage(db: DB) {
     async bulkSetHiddenFromAI(chatId: string, messageIds: string[], hidden: boolean): Promise<number> {
       if (messageIds.length === 0) return 0;
       const uniqueIds = Array.from(new Set(messageIds));
-      const scopedRows = await db
-        .select({ id: messages.id })
-        .from(messages)
-        .where(and(eq(messages.chatId, chatId), inArray(messages.id, uniqueIds)));
-      const scopedIds = scopedRows.map((row) => row.id);
+      const scopedRows: { id: string }[] = [];
+      const CHUNK = 500;
+      for (let i = 0; i < uniqueIds.length; i += CHUNK) {
+        const batch = uniqueIds.slice(i, i + CHUNK);
+        const batchRows = await db
+          .select({ id: messages.id })
+          .from(messages)
+          .where(and(eq(messages.chatId, chatId), inArray(messages.id, batch)));
+        scopedRows.push(...batchRows);
+      }
+      const scopedIds = Array.from(new Set(scopedRows.map((row) => row.id)));
 
       for (const id of scopedIds) {
         await this.updateMessageExtra(id, { hiddenFromAI: hidden });

--- a/packages/server/src/services/storage/chats.storage.ts
+++ b/packages/server/src/services/storage/chats.storage.ts
@@ -657,10 +657,14 @@ export function createChatsStorage(db: DB) {
      */
     async bulkSetHiddenFromAI(chatId: string, messageIds: string[], hidden: boolean): Promise<number> {
       if (messageIds.length === 0) return 0;
-      let updatedCount = 0;
-      for (const id of messageIds) {
-        const msg = await this.getMessage(id);
-        if (!msg || msg.chatId !== chatId) continue;
+      const uniqueIds = Array.from(new Set(messageIds));
+      const scopedRows = await db
+        .select({ id: messages.id })
+        .from(messages)
+        .where(and(eq(messages.chatId, chatId), inArray(messages.id, uniqueIds)));
+      const scopedIds = scopedRows.map((row) => row.id);
+
+      for (const id of scopedIds) {
         await this.updateMessageExtra(id, { hiddenFromAI: hidden });
         // Mirror what the single-message /extra route does: propagate the flag
         // to all swipe rows so setActiveSwipe() cannot clobber it.
@@ -668,9 +672,8 @@ export function createChatsStorage(db: DB) {
         for (const swipe of swipes) {
           await this.updateSwipeExtra(id, swipe.index, { hiddenFromAI: hidden });
         }
-        updatedCount += 1;
       }
-      return updatedCount;
+      return scopedIds.length;
     },
 
     /** Atomically append an attachment to a message's extra JSON field. */

--- a/packages/server/src/services/tools/tool-executor.ts
+++ b/packages/server/src/services/tools/tool-executor.ts
@@ -42,7 +42,6 @@ export type MetadataUpdater = (current: MetadataPatch) => MetadataPatch | Promis
 export type MetadataPatchInput = MetadataPatch | MetadataUpdater;
 
 const MAX_APPEND_BYTES = 16 * 1024;
-const MAX_TOTAL_SUMMARY_BYTES = 64 * 1024;
 const MAX_CHAT_VARIABLE_KEY_LENGTH = 128;
 const MAX_CHAT_VARIABLE_VALUE_BYTES = 64 * 1024;
 const MAX_CHAT_VARIABLES = 256;
@@ -475,8 +474,7 @@ async function appendChatSummary(
         enabled: true,
       },
     );
-    const summary = trimToUtf8Bytes(result.summary ?? "", MAX_TOTAL_SUMMARY_BYTES, true).trim() || null;
-    return { summary, summaryEntries: result.entries };
+    return { summary: result.summary, summaryEntries: result.entries };
   });
   return { summary: typeof updated.summary === "string" ? updated.summary : sanitizedText };
 }

--- a/packages/server/src/services/tools/tool-executor.ts
+++ b/packages/server/src/services/tools/tool-executor.ts
@@ -8,6 +8,7 @@ import { isCustomToolScriptEnabled, isWebhookLocalUrlsEnabled } from "../../conf
 import { safeFetch } from "../../utils/security.js";
 import { logger } from "../../lib/logger.js";
 import { normalizeSpotifySearchQuery } from "../spotify/spotify.service.js";
+import { appendChatSummaryEntryToMetadata } from "@marinara-engine/shared";
 
 export interface ToolExecutionResult {
   toolCallId: string;
@@ -462,10 +463,20 @@ async function appendChatSummary(
   }
 
   const updated = await context.onUpdateMetadata((currentMeta) => {
-    const existing =
-      typeof currentMeta.summary === "string" ? sanitizePersistedSummaryText(currentMeta.summary.trim()) : "";
-    const summary = existing ? `${existing}\n\n${sanitizedText}` : sanitizedText;
-    return { summary: trimToUtf8Bytes(summary, MAX_TOTAL_SUMMARY_BYTES, true).trim() };
+    const existingSummary =
+      typeof currentMeta.summary === "string" ? sanitizePersistedSummaryText(currentMeta.summary.trim()) : null;
+    const result = appendChatSummaryEntryToMetadata(
+      { ...currentMeta, summary: existingSummary },
+      {
+        kind: "rolling",
+        origin: "automated",
+        sourceMode: "agent",
+        content: sanitizedText,
+        enabled: true,
+      },
+    );
+    const summary = trimToUtf8Bytes(result.summary ?? "", MAX_TOTAL_SUMMARY_BYTES, true).trim() || null;
+    return { summary, summaryEntries: result.entries };
   });
   return { summary: typeof updated.summary === "string" ? updated.summary : sanitizedText };
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -61,3 +61,4 @@ export * from "./utils/generation-guide.js";
 export * from "./utils/lorebook-keyword-matching.js";
 export * from "./utils/regex-safety.js";
 export * from "./utils/game-state-text.js";
+export * from "./utils/chat-summary-entries.js";

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -84,6 +84,34 @@ export interface ChatSummaryPromptTemplate {
   prompt: string;
 }
 
+/** Rolling summary entry category. Extensible beyond rolling summaries later. */
+export type ChatSummaryEntryKind = "rolling";
+
+/** Whether a rolling summary entry was user-created, agent-created, or migrated from the legacy blob. */
+export type ChatSummaryEntryOrigin = "manual" | "automated" | "legacy";
+
+/** Source selector used to create a rolling summary entry. */
+export type ChatSummaryEntrySource = "last" | "range" | "agent";
+
+/** A single structured rolling chat summary entry. */
+export interface ChatSummaryEntry {
+  id: string;
+  kind: ChatSummaryEntryKind;
+  origin: ChatSummaryEntryOrigin;
+  title: string;
+  content: string;
+  enabled: boolean;
+  sourceMode: ChatSummaryEntrySource;
+  messageCount?: number;
+  rangeStartIndex?: number;
+  rangeEndIndex?: number;
+  messageIds?: string[];
+  promptTemplateId?: string | null;
+  tokenEstimate: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
 /** A vectorized recall fragment created from one chat's messages. */
 export interface ChatMemoryChunk {
   id: string;
@@ -101,8 +129,10 @@ export interface ChatMemoryChunk {
 
 /** Extra metadata stored on a chat. */
 export interface ChatMetadata {
-  /** Summary text for context injection */
+  /** Compiled enabled rolling summary text for context injection. Derived from summaryEntries when present. */
   summary: string | null;
+  /** Structured rolling summary entries. Missing means legacy summary-only metadata. */
+  summaryEntries?: ChatSummaryEntry[];
   /** Recent message count used by manual rolling summary generation and the automated summary agent. */
   summaryContextSize?: number;
   /** Chat-scoped manual summary prompt templates. Missing or empty uses the built-in default. */

--- a/packages/shared/src/utils/chat-summary-entries.ts
+++ b/packages/shared/src/utils/chat-summary-entries.ts
@@ -9,6 +9,8 @@ const VALID_KINDS = new Set<ChatSummaryEntryKind>(["rolling"]);
 const VALID_ORIGINS = new Set<ChatSummaryEntryOrigin>(["manual", "automated", "legacy"]);
 const VALID_SOURCES = new Set<ChatSummaryEntrySource>(["last", "range", "agent"]);
 
+export const COMPILED_CHAT_SUMMARY_MAX_BYTES = 64 * 1024;
+
 export type ChatSummaryEntryInput = Partial<ChatSummaryEntry> & {
   content: string;
 };
@@ -34,6 +36,49 @@ function fallbackId(prefix: string, seed: string) {
 
 function trimString(value: unknown) {
   return typeof value === "string" ? value.trim() : "";
+}
+
+function utf8ByteLength(text: string): number {
+  let bytes = 0;
+  for (let i = 0; i < text.length; i += 1) {
+    const code = text.charCodeAt(i);
+    if (code < 0x80) {
+      bytes += 1;
+    } else if (code < 0x800) {
+      bytes += 2;
+    } else if (code >= 0xd800 && code <= 0xdbff && i + 1 < text.length) {
+      const next = text.charCodeAt(i + 1);
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        bytes += 4;
+        i += 1;
+      } else {
+        bytes += 3;
+      }
+    } else {
+      bytes += 3;
+    }
+  }
+  return bytes;
+}
+
+function trimToUtf8Bytes(text: string, maxBytes: number, fromStart = true): string {
+  if (maxBytes <= 0) return "";
+  if (utf8ByteLength(text) <= maxBytes) return text;
+
+  let low = 0;
+  let high = text.length;
+  while (low < high) {
+    const mid = Math.ceil((low + high) / 2);
+    const candidate = fromStart ? text.slice(text.length - mid) : text.slice(0, mid);
+    if (utf8ByteLength(candidate) <= maxBytes) {
+      low = mid;
+    } else {
+      high = mid - 1;
+    }
+  }
+
+  const trimmed = fromStart ? text.slice(text.length - low) : text.slice(0, low);
+  return fromStart ? trimmed.replace(/^[\uDC00-\uDFFF]/, "") : trimmed.replace(/[\uD800-\uDBFF]$/, "");
 }
 
 function normalizeIsoTimestamp(value: unknown, fallback: string) {
@@ -214,7 +259,8 @@ export function compileChatSummaryEntries(entries: ChatSummaryEntry[]): string |
     .filter(Boolean)
     .join("\n\n")
     .trim();
-  return compiled || null;
+  if (!compiled) return null;
+  return trimToUtf8Bytes(compiled, COMPILED_CHAT_SUMMARY_MAX_BYTES, true).trim() || null;
 }
 
 export function appendChatSummaryEntryToMetadata(

--- a/packages/shared/src/utils/chat-summary-entries.ts
+++ b/packages/shared/src/utils/chat-summary-entries.ts
@@ -1,0 +1,236 @@
+import type {
+  ChatSummaryEntry,
+  ChatSummaryEntryKind,
+  ChatSummaryEntryOrigin,
+  ChatSummaryEntrySource,
+} from "../types/chat.js";
+
+const VALID_KINDS = new Set<ChatSummaryEntryKind>(["rolling"]);
+const VALID_ORIGINS = new Set<ChatSummaryEntryOrigin>(["manual", "automated", "legacy"]);
+const VALID_SOURCES = new Set<ChatSummaryEntrySource>(["last", "range", "agent"]);
+
+export type ChatSummaryEntryInput = Partial<ChatSummaryEntry> & {
+  content: string;
+};
+
+export interface ChatSummaryEntryNormalizeOptions {
+  legacySummary?: string | null;
+  createId?: () => string;
+  now?: string;
+}
+
+function defaultNow() {
+  return new Date().toISOString();
+}
+
+function fallbackId(prefix: string, seed: string) {
+  let hash = 2166136261;
+  for (let i = 0; i < seed.length; i += 1) {
+    hash ^= seed.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return `${prefix}-${(hash >>> 0).toString(36)}`;
+}
+
+function trimString(value: unknown) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function normalizeIsoTimestamp(value: unknown, fallback: string) {
+  const text = trimString(value);
+  return text && !Number.isNaN(Date.parse(text)) ? text : fallback;
+}
+
+function normalizePositiveInteger(value: unknown) {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : undefined;
+}
+
+function normalizeMessageIds(value: unknown) {
+  if (!Array.isArray(value)) return undefined;
+  const ids = Array.from(new Set(value.filter((id): id is string => typeof id === "string" && id.trim().length > 0)));
+  return ids.length > 0 ? ids : undefined;
+}
+
+function sourceFromOrigin(origin: ChatSummaryEntryOrigin): ChatSummaryEntrySource {
+  return origin === "automated" ? "agent" : "last";
+}
+
+/** Cheap token approximation for UI and metadata. */
+export function estimateChatSummaryTokens(content: string): number {
+  const normalized = content.trim();
+  if (!normalized) return 0;
+  return Math.max(1, Math.ceil(normalized.length / 4));
+}
+
+/** Generate a concise default title from an entry's origin and source metadata. */
+export function generateChatSummaryEntryTitle(entry: Pick<
+  ChatSummaryEntry,
+  "origin" | "sourceMode" | "messageCount" | "rangeStartIndex" | "rangeEndIndex"
+>): string {
+  if (entry.origin === "legacy") return "Legacy summary";
+  if (entry.origin === "automated") return "Automated summary";
+  if (entry.sourceMode === "range" && entry.rangeStartIndex && entry.rangeEndIndex) {
+    return `Summary messages ${entry.rangeStartIndex}-${entry.rangeEndIndex}`;
+  }
+  if (entry.messageCount) return `Summary of ${entry.messageCount} messages`;
+  return "Manual summary";
+}
+
+export function createLegacyChatSummaryEntry(
+  summary: string | null | undefined,
+  options: ChatSummaryEntryNormalizeOptions = {},
+): ChatSummaryEntry | null {
+  const content = trimString(summary);
+  if (!content) return null;
+  const now = options.now ?? defaultNow();
+  const id = options.createId?.() ?? fallbackId("summary-legacy", content);
+  return {
+    id,
+    kind: "rolling",
+    origin: "legacy",
+    title: "Legacy summary",
+    content,
+    enabled: true,
+    sourceMode: "last",
+    tokenEstimate: estimateChatSummaryTokens(content),
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+export function normalizeChatSummaryEntry(
+  raw: unknown,
+  options: ChatSummaryEntryNormalizeOptions = {},
+): ChatSummaryEntry | null {
+  if (!raw || typeof raw !== "object") return null;
+  const value = raw as Record<string, unknown>;
+  const content = trimString(value.content);
+  if (!content) return null;
+
+  const now = options.now ?? defaultNow();
+  const origin = VALID_ORIGINS.has(value.origin as ChatSummaryEntryOrigin)
+    ? (value.origin as ChatSummaryEntryOrigin)
+    : "legacy";
+  const sourceMode = VALID_SOURCES.has(value.sourceMode as ChatSummaryEntrySource)
+    ? (value.sourceMode as ChatSummaryEntrySource)
+    : sourceFromOrigin(origin);
+  const base: ChatSummaryEntry = {
+    id: trimString(value.id) || options.createId?.() || fallbackId("summary", `${origin}:${content}:${now}`),
+    kind: VALID_KINDS.has(value.kind as ChatSummaryEntryKind) ? (value.kind as ChatSummaryEntryKind) : "rolling",
+    origin,
+    title: trimString(value.title),
+    content,
+    enabled: typeof value.enabled === "boolean" ? value.enabled : true,
+    sourceMode,
+    tokenEstimate:
+      typeof value.tokenEstimate === "number" && Number.isFinite(value.tokenEstimate) && value.tokenEstimate >= 0
+        ? Math.round(value.tokenEstimate)
+        : estimateChatSummaryTokens(content),
+    createdAt: normalizeIsoTimestamp(value.createdAt, now),
+    updatedAt: normalizeIsoTimestamp(value.updatedAt, now),
+  };
+
+  const messageCount = normalizePositiveInteger(value.messageCount);
+  if (messageCount !== undefined) base.messageCount = messageCount;
+  const rangeStartIndex = normalizePositiveInteger(value.rangeStartIndex);
+  if (rangeStartIndex !== undefined) base.rangeStartIndex = rangeStartIndex;
+  const rangeEndIndex = normalizePositiveInteger(value.rangeEndIndex);
+  if (rangeEndIndex !== undefined) base.rangeEndIndex = rangeEndIndex;
+  const messageIds = normalizeMessageIds(value.messageIds);
+  if (messageIds) base.messageIds = messageIds;
+  if (typeof value.promptTemplateId === "string") {
+    base.promptTemplateId = value.promptTemplateId.trim() || null;
+  } else if (value.promptTemplateId === null) {
+    base.promptTemplateId = null;
+  }
+
+  if (!base.title) base.title = generateChatSummaryEntryTitle(base);
+  return base;
+}
+
+export function createChatSummaryEntry(
+  input: ChatSummaryEntryInput,
+  options: ChatSummaryEntryNormalizeOptions = {},
+): ChatSummaryEntry {
+  const entry = normalizeChatSummaryEntry(
+    {
+      ...input,
+      id: input.id || options.createId?.(),
+      createdAt: input.createdAt ?? options.now,
+      updatedAt: input.updatedAt ?? options.now,
+    },
+    options,
+  );
+  if (!entry) {
+    throw new Error("Chat summary entry content is required");
+  }
+  return entry;
+}
+
+export function sortChatSummaryEntries(entries: ChatSummaryEntry[]): ChatSummaryEntry[] {
+  return entries
+    .map((entry, index) => ({ entry, index }))
+    .sort((a, b) => {
+      const aRange = a.entry.rangeStartIndex ?? Number.MAX_SAFE_INTEGER;
+      const bRange = b.entry.rangeStartIndex ?? Number.MAX_SAFE_INTEGER;
+      if (aRange !== bRange) return aRange - bRange;
+      const created = Date.parse(a.entry.createdAt) - Date.parse(b.entry.createdAt);
+      if (created !== 0) return created;
+      return a.index - b.index;
+    })
+    .map(({ entry }) => entry);
+}
+
+export function normalizeChatSummaryEntries(
+  rawEntries: unknown,
+  options: ChatSummaryEntryNormalizeOptions = {},
+): ChatSummaryEntry[] {
+  const seen = new Set<string>();
+  const entries = (Array.isArray(rawEntries) ? rawEntries : [])
+    .map((entry) => normalizeChatSummaryEntry(entry, options))
+    .filter((entry): entry is ChatSummaryEntry => !!entry)
+    .map((entry) => {
+      if (!seen.has(entry.id)) {
+        seen.add(entry.id);
+        return entry;
+      }
+      const replacementId = options.createId?.() ?? fallbackId("summary", `${entry.id}:${entry.content}:${seen.size}`);
+      seen.add(replacementId);
+      return { ...entry, id: replacementId };
+    });
+
+  if (entries.length === 0) {
+    const legacy = createLegacyChatSummaryEntry(options.legacySummary, options);
+    if (legacy) entries.push(legacy);
+  }
+
+  return sortChatSummaryEntries(entries);
+}
+
+export function compileChatSummaryEntries(entries: ChatSummaryEntry[]): string | null {
+  const compiled = sortChatSummaryEntries(entries)
+    .filter((entry) => entry.enabled)
+    .map((entry) => entry.content.trim())
+    .filter(Boolean)
+    .join("\n\n")
+    .trim();
+  return compiled || null;
+}
+
+export function appendChatSummaryEntryToMetadata(
+  metadata: Record<string, unknown>,
+  input: ChatSummaryEntryInput,
+  options: ChatSummaryEntryNormalizeOptions = {},
+): { entry: ChatSummaryEntry; entries: ChatSummaryEntry[]; summary: string | null } {
+  const entries = normalizeChatSummaryEntries(metadata.summaryEntries, {
+    ...options,
+    legacySummary: typeof metadata.summary === "string" ? metadata.summary : null,
+  });
+  const entry = createChatSummaryEntry(input, options);
+  const nextEntries = sortChatSummaryEntries([...entries, entry]);
+  return {
+    entry,
+    entries: nextEntries,
+    summary: compileChatSummaryEntries(nextEntries),
+  };
+}


### PR DESCRIPTION
## Linked issue

Closes #933

## Why this change

- Long-running chats and roleplay sessions can accumulate multiple manual, automated, imported, and legacy summaries, but the old single summary field made provenance, enablement, editing, and token awareness hard to manage.
- This gives users structured summary controls while preserving the compiled prompt-facing summary string used by existing generation flows.

## What changed

- Added structured rolling summary entry types and shared helpers for compiling, estimating, normalizing, and managing summary metadata.
- Updated manual, automated, and tool-driven summary paths to append summary entries while keeping `metadata.summary` backward compatible.
- Added API and storage support for editing, enabling/disabling, and deleting summary entries.
- Reworked the chat summary popover into structured entry rows with origin, status, token, edit, delete, toggle, and manual write controls.
- Added persisted summary popover source/display settings and preserved the upstream Chibi Professor Mari persisted-store migration during the rebase.
- Updated chat surfaces to support hiding and collapsing summarized messages.

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Not run by Codex for this PR preparation pass.

## Docs and release impact

- [x] No docs changes needed
- [x] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [x] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

- Not attached yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Summary management now supports individual rolling entries that can be enabled, disabled, edited, and deleted
  * Token estimates displayed for each summary entry
  * Enhanced summary generation with structured entry creation

* **Improvements**
  * Expanded "hidden from AI" message filtering to conversation mode chats

* **Documentation**
  * Updated troubleshooting guide to explain rolling summary entry compilation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/938?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->