### PR TITLE
Fix saved sprite cleanup fallback

### DIFF
--- a/packages/client/src/components/characters/CharacterEditor.tsx
+++ b/packages/client/src/components/characters/CharacterEditor.tsx
@@ -2330,7 +2330,7 @@ function SpritesTab({
     if (
       !(await showConfirmDialog({
         title: "Clean Sprite Backgrounds",
-        message: `Run the local backgroundremover model on ${visibleSprites.length} saved ${modeLabel} sprite${visibleSprites.length === 1 ? "" : "s"} at strength ${savedCleanupStrength}? Marinara will keep a restore point in case the cleanup looks wrong.`,
+        message: `Clean backgrounds on ${visibleSprites.length} saved ${modeLabel} sprite${visibleSprites.length === 1 ? "" : "s"} at strength ${savedCleanupStrength}? Marinara will keep a restore point in case the cleanup looks wrong.`,
         confirmLabel: "Clean",
       }))
     ) {
@@ -2343,13 +2343,19 @@ function SpritesTab({
         characterId,
         expressions: visibleSprites.map((sprite) => sprite.expression),
         cleanupStrength: savedCleanupStrength,
-        engine: "backgroundremover",
+        engine: "auto",
       });
 
       if (result.processed > 0) {
         setLastCleanupBackupId(result.backupId ?? null);
+        const engineDetails =
+          result.backgroundRemoverProcessed && result.builtinProcessed
+            ? ` with backgroundremover and built-in fallback`
+            : result.backgroundRemoverProcessed
+              ? ` with backgroundremover`
+              : ` with built-in cleanup`;
         toast.success(
-          `Cleaned ${result.processed} saved sprite${result.processed === 1 ? "" : "s"} with backgroundremover.`,
+          `Cleaned ${result.processed} saved sprite${result.processed === 1 ? "" : "s"}${engineDetails}.`,
         );
       }
       if (result.failed.length > 0) {
@@ -2507,16 +2513,13 @@ function SpritesTab({
               disabled={
                 cleaningSprites ||
                 backgroundCleanupUnavailable ||
-                backgroundRemoverUnavailable ||
                 visibleSprites.length === 0
               }
               className="flex min-w-0 items-center justify-center gap-1.5 rounded-lg bg-[var(--secondary)] px-3 py-1.5 text-center text-[0.6875rem] font-medium leading-tight text-[var(--muted-foreground)] ring-1 ring-[var(--border)] transition-all hover:bg-[var(--accent)] hover:text-[var(--foreground)] disabled:opacity-40 max-md:flex-1 max-md:basis-[calc(50%-0.25rem)] max-md:px-2.5"
               title={
                 backgroundCleanupUnavailable
                   ? backgroundCleanupReason
-                  : backgroundRemoverUnavailable
-                    ? backgroundRemoverReason
-                    : "Run the local backgroundremover model on the currently visible saved sprites"
+                  : "Clean backgrounds on the currently visible saved sprites"
               }
             >
               {cleaningSprites ? <Loader2 size="0.8125rem" className="animate-spin" /> : <Eraser size="0.8125rem" />}

--- a/packages/client/src/components/personas/PersonaEditor.tsx
+++ b/packages/client/src/components/personas/PersonaEditor.tsx
@@ -868,7 +868,7 @@ function PersonaSpritesTab({
     if (
       !(await showConfirmDialog({
         title: "Clean Sprite Backgrounds",
-        message: `Run the local backgroundremover model on ${visibleSprites.length} saved ${modeLabel} sprite${visibleSprites.length === 1 ? "" : "s"} at strength ${savedCleanupStrength}? Marinara will keep a restore point in case the cleanup looks wrong.`,
+        message: `Clean backgrounds on ${visibleSprites.length} saved ${modeLabel} sprite${visibleSprites.length === 1 ? "" : "s"} at strength ${savedCleanupStrength}? Marinara will keep a restore point in case the cleanup looks wrong.`,
         confirmLabel: "Clean",
       }))
     ) {
@@ -881,13 +881,19 @@ function PersonaSpritesTab({
         characterId: personaId,
         expressions: visibleSprites.map((sprite) => sprite.expression),
         cleanupStrength: savedCleanupStrength,
-        engine: "backgroundremover",
+        engine: "auto",
       });
 
       if (result.processed > 0) {
         setLastCleanupBackupId(result.backupId ?? null);
+        const engineDetails =
+          result.backgroundRemoverProcessed && result.builtinProcessed
+            ? ` with backgroundremover and built-in fallback`
+            : result.backgroundRemoverProcessed
+              ? ` with backgroundremover`
+              : ` with built-in cleanup`;
         toast.success(
-          `Cleaned ${result.processed} saved sprite${result.processed === 1 ? "" : "s"} with backgroundremover.`,
+          `Cleaned ${result.processed} saved sprite${result.processed === 1 ? "" : "s"}${engineDetails}.`,
         );
       }
       if (result.failed.length > 0) {
@@ -1047,16 +1053,13 @@ function PersonaSpritesTab({
               disabled={
                 cleaningSprites ||
                 backgroundCleanupUnavailable ||
-                backgroundRemoverUnavailable ||
                 visibleSprites.length === 0
               }
               className="flex min-w-0 items-center justify-center gap-1.5 rounded-lg bg-[var(--secondary)] px-3 py-1.5 text-center text-[0.6875rem] font-medium leading-tight text-[var(--muted-foreground)] ring-1 ring-[var(--border)] transition-all hover:bg-[var(--accent)] hover:text-[var(--foreground)] disabled:opacity-40 max-md:flex-1 max-md:basis-[calc(50%-0.25rem)] max-md:px-2.5"
               title={
                 backgroundCleanupUnavailable
                   ? backgroundCleanupReason
-                  : backgroundRemoverUnavailable
-                    ? backgroundRemoverReason
-                    : "Run the local backgroundremover model on the currently visible saved sprites"
+                  : "Clean backgrounds on the currently visible saved sprites"
               }
             >
               {cleaningSprites ? <Loader2 size="0.8125rem" className="animate-spin" /> : <Eraser size="0.8125rem" />}


### PR DESCRIPTION
<!-- Target branch: `staging`. The default base in this UI is `main` (release branch). -->
<!-- Change the base to `staging` before submitting unless this is a maintainer-approved mainline change. -->
<!-- See CONTRIBUTING.md § Branches. -->

## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

No linked issue yet; filed from Celia's local bug report that saved sprite cleanup showed "No saved sprites were cleaned" even though the cleanup tool was installed.

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- The saved-sprite cleanup button forced the optional `backgroundremover` engine. If that executable was present but failed at runtime, the whole cleanup request failed instead of using Marinara's built-in fallback cleanup.

## What changed

<!-- List the key changes in this PR -->

- Saved character and persona sprite cleanup now requests `engine: "auto"` so the server can fall back to the built-in cleanup path when `backgroundremover` cannot run.
- Updated the confirmation text, tooltip, and success toast so the UI does not promise that every cleanup used `backgroundremover`.
- Kept the existing restore-point behavior and per-sprite failure warnings.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Codex ran `packages\server\node_modules\.bin\tsx.cmd scratch\repro-saved-sprite-cleanup-auto-fallback.ts`.
- The repro showed the old forced `backgroundremover` request fails with `500` and `No saved sprites were cleaned` when the command cannot run.
- The same repro showed `engine: "auto"` succeeds with `processed=1`, `builtinProcessed=1`, and changed the saved PNG corner alpha from `255` to `0`.
- Codex ran `pnpm check`; it passed.
- Manual browser click-through is still recommended before merge because this is a button copy/behavior change, but the core cleanup request path is machine-proven.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs or version changes needed.

## UI evidence (if applicable)

No screenshot attached; this is a UI-triggered behavior fix, but the visible UI only changes confirmation/toast copy. The core behavior is covered by the saved-sprite cleanup route repro above.
