### PR TITLE
Fix GM scene image instructions

### DIFF
--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -3886,6 +3886,8 @@ export async function generateRoutes(app: FastifyInstance) {
             tone: (setupConfig?.tone as string) || "balanced",
             rating: (setupConfig?.rating as "sfw" | "nsfw") || "sfw",
             campaignPlan: gameBlueprint?.campaignPlan ?? null,
+            canGenerateBackgrounds: !!chatMeta.enableSpriteGeneration && !!chatMeta.gameImageConnectionId,
+            artStylePrompt: (setupConfig?.artStylePrompt as string) || undefined,
             gameTime,
             weatherContext,
             playerNotes,
@@ -4042,6 +4044,8 @@ export async function generateRoutes(app: FastifyInstance) {
               characterSprites: gmCtx.characterSprites,
               language: gmCtx.language,
               rating: gmCtx.rating,
+              canGenerateBackgrounds: gmCtx.canGenerateBackgrounds,
+              artStylePrompt: gmCtx.artStylePrompt,
               addressMode,
               playerDiceRollSubmitted,
               playerInventory: (() => {

--- a/packages/server/src/services/game/gm-prompts.ts
+++ b/packages/server/src/services/game/gm-prompts.ts
@@ -50,6 +50,10 @@ export interface GmPromptContext {
   rating?: "sfw" | "nsfw";
   /** Whether a separate scene model handles bg, music, sfx, ambient, widgets, expressions */
   hasSceneModel?: boolean;
+  /** Whether inline GM scene tags may request generated location backgrounds. */
+  canGenerateBackgrounds?: boolean;
+  /** Unified image style/instructions generated during game setup. */
+  artStylePrompt?: string;
   /** Whether the player moved to a new location since last turn (false = send location summary instead of full map) */
   playerMoved?: boolean;
   /** Approximate turn number in the current session (1-based, used for prompt gating) */
@@ -607,6 +611,8 @@ export function buildGmFormatReminder(
   ctx: Pick<
     GmPromptContext,
     | "hasSceneModel"
+    | "canGenerateBackgrounds"
+    | "artStylePrompt"
     | "hudWidgets"
     | "turnNumber"
     | "gameActiveState"
@@ -781,6 +787,16 @@ export function buildGmFormatReminder(
 
   if (!ctx.hasSceneModel) {
     lines.push(`Scene tags allowed: [sfx: ...] [bg: ...] [ambient: ...]`);
+    if (ctx.canGenerateBackgrounds) {
+      lines.push(
+        `- If the scene moves to a new visually important location and no existing background tag fits, use [bg: backgrounds:generated:<short-location-slug>].`,
+      );
+      if (ctx.artStylePrompt?.trim()) {
+        lines.push(
+          `- Generated scene images must follow this visual instruction: ${normalizePromptText(ctx.artStylePrompt)}.`,
+        );
+      }
+    }
   }
 
   if (hudWidgets.length > 0) {

--- a/packages/server/src/services/game/gm-prompts.ts
+++ b/packages/server/src/services/game/gm-prompts.ts
@@ -792,9 +792,14 @@ export function buildGmFormatReminder(
         `- If the scene moves to a new visually important location and no existing background tag fits, use [bg: backgrounds:generated:<short-location-slug>].`,
       );
       if (ctx.artStylePrompt?.trim()) {
-        lines.push(
-          `- Generated scene images must follow this visual instruction: ${normalizePromptText(ctx.artStylePrompt)}.`,
-        );
+        const safeArtStylePrompt = normalizePromptText(ctx.artStylePrompt)
+          .replace(/[\r\n\t]+/g, " ")
+          .replace(/[<>{}[\]]/g, "")
+          .replace(/\s{2,}/g, " ")
+          .trim();
+        if (safeArtStylePrompt) {
+          lines.push(`- Generated scene images must follow this visual instruction: ${safeArtStylePrompt}.`);
+        }
       }
     }
   }


### PR DESCRIPTION
<!-- Target branch: `staging`. The default base in this UI is `main` (release branch). -->
<!-- Change the base to `staging` before submitting unless this is a maintainer-approved mainline change. -->
<!-- See CONTRIBUTING.md Section Branches. -->

## Linked issue

No linked issue yet; one should be opened before submission.

## Why this change

- In GM mode without a separate scene model, scene tags are emitted by the GM format reminder, but that reminder did not receive the generated-background capability or the setup art style prompt. As a result, scene image instructions from game setup were not respected for inline GM scene image tags.

## What changed

- Threaded game image generation capability and the setup `artStylePrompt` into the GM prompt context.
- Added inline GM format reminder guidance for generated background tags and the visual instruction when generated backgrounds are enabled.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Codex scratch repro: `packages\server\node_modules\.bin\tsx.cmd scratch\gm-scene-image-instructions-repro.ts`
  - Before fix: `GM format reminder includes scene image instructions: false`
  - After fix: `GM format reminder includes scene image instructions: true`
  - Follow-up hardening: `GM format reminder strips injected art-style syntax: true`
- Codex baseline: `pnpm check` passed locally.
- Codex review gates: `git diff --check` passed; touched server files have no `console.*` matches; Bunny review pass completed before PR open and after the CodeRabbit follow-up.
- CodeRabbit follow-up: sanitized generated `artStylePrompt` text to a single plain-text line before inserting it into the GM format reminder.
- No true human-only blocker identified for the core prompt assembly claim.

## Docs and release impact

- No docs or release metadata changes needed; this is a scoped server prompt bugfix.

## UI evidence (if applicable)

N/A. This is a backend prompt assembly bug verified with a focused scratch harness; no visible UI state changes.
