### PR TITLE
Fix Game Mode Illustrate style prompts

### DIFF
--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -107,6 +107,35 @@ function parseSettingsRecord(value: unknown): Record<string, unknown> {
   return typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
 }
 
+function getGameImageStylePrompt(chat: any, chatMeta: Record<string, unknown>): string {
+  if (((chat as any).mode ?? "conversation") !== "game") return "";
+  const setupConfig = parseSettingsRecord(chatMeta.gameSetupConfig);
+  return typeof setupConfig.artStylePrompt === "string" ? setupConfig.artStylePrompt.trim() : "";
+}
+
+function buildIllustratorImagePrompt(args: {
+  gameArtStylePrompt: string;
+  style: string;
+  imagePrompt: string;
+  imagePositivePrompt: string;
+}): string {
+  const imagePrompt = args.imagePrompt.trim();
+  const imagePromptLower = imagePrompt.toLowerCase();
+  const prefixParts: string[] = [];
+  const seen = new Set<string>();
+
+  for (const part of [args.gameArtStylePrompt, args.style]) {
+    const trimmed = part.trim();
+    const key = trimmed.toLowerCase();
+    if (!trimmed || seen.has(key) || imagePromptLower.includes(key)) continue;
+    seen.add(key);
+    prefixParts.push(trimmed);
+  }
+
+  const fullPrompt = [...prefixParts, imagePrompt].join(", ");
+  return args.imagePositivePrompt ? `${fullPrompt}, ${args.imagePositivePrompt}` : fullPrompt;
+}
+
 async function resolvePersonaContext(
   chars: ReturnType<typeof createCharactersStorage>,
   chat: any,
@@ -274,6 +303,11 @@ async function buildRetryAgentContext(args: {
     streaming,
     memory: {},
   };
+
+  const gameImageStylePrompt = getGameImageStylePrompt(chat, chatMeta);
+  if (gameImageStylePrompt) {
+    agentContext.memory._gameImageStylePrompt = gameImageStylePrompt;
+  }
 
   if (resolvedAgentTypes.has("lorebook-keeper")) {
     const lorebookKeeperSettings = getLorebookKeeperSettings(chatMeta);
@@ -1738,7 +1772,8 @@ async function applyRetryResultEffects(args: {
               const imageSettings = await loadImageGenerationUserSettings(app.db);
 
               const chatMeta = typeof chat.metadata === "string" ? JSON.parse(chat.metadata) : (chat.metadata ?? {});
-              const selfieRes = (chatMeta.selfieResolution as string) ?? "";
+              const isGameIllustration = ((chat as any).mode ?? "conversation") === "game";
+              const selfieRes = isGameIllustration ? "" : ((chatMeta.selfieResolution as string) ?? "");
               const resParts = selfieRes.split("x").map(Number);
               const parsedW = resParts[0] ?? 0;
               const parsedH = resParts[1] ?? 0;
@@ -1747,15 +1782,24 @@ async function applyRetryResultEffects(args: {
               if (parsedW > 0 && parsedH > 0) {
                 imgWidth = parsedW;
                 imgHeight = parsedH;
+              } else if (isGameIllustration) {
+                imgWidth = imageSettings.background.width;
+                imgHeight = imageSettings.background.height;
               } else {
                 imgWidth = imageSettings.selfie.width;
                 imgHeight = imageSettings.selfie.height;
               }
 
-              let fullPrompt = style ? `${style}, ${imagePrompt}` : imagePrompt;
-              if (imagePositivePrompt) {
-                fullPrompt = `${fullPrompt}, ${imagePositivePrompt}`;
-              }
+              const gameArtStylePrompt =
+                typeof agentContext.memory._gameImageStylePrompt === "string"
+                  ? agentContext.memory._gameImageStylePrompt
+                  : "";
+              const fullPrompt = buildIllustratorImagePrompt({
+                gameArtStylePrompt,
+                style,
+                imagePrompt,
+                imagePositivePrompt,
+              });
               const finalNegativePrompt = [negativePrompt, savedNegativePrompt].filter(Boolean).join(", ");
 
               // Collect character avatar references when enabled

--- a/packages/server/src/services/agents/agent-executor.ts
+++ b/packages/server/src/services/agents/agent-executor.ts
@@ -1085,6 +1085,23 @@ function buildAgentExtras(context: AgentContext, agentTypes: string[] = []): str
     parts.push(`</current_game_state>`);
   }
 
+  const gameImageStylePrompt =
+    context.chatMode === "game" && typeof context.memory._gameImageStylePrompt === "string"
+      ? context.memory._gameImageStylePrompt.trim()
+      : "";
+  if (agentTypes.includes("illustrator") && gameImageStylePrompt) {
+    parts.push(`<game_image_instructions>`);
+    parts.push(
+      `This chat is in Game Mode. Gallery -> Illustrate should produce a scene illustration for the current VN/game beat, not a generic character selfie.`,
+    );
+    parts.push(`Required visual style prompt: ${escapeXml(gameImageStylePrompt)}`);
+    parts.push(
+      `Carry this visual style into both the JSON "style" field and the generated "prompt". Do not replace it with a generic art style.`,
+    );
+    parts.push(`Prefer a landscape/16:9 scene composition unless the latest assistant message clearly calls for another framing.`);
+    parts.push(`</game_image_instructions>`);
+  }
+
   if (agentTypes.includes("expression")) {
     const availableSpritesBlock = buildAvailableSpritesBlock(context);
     if (availableSpritesBlock) parts.push(availableSpritesBlock);


### PR DESCRIPTION
<!-- Target branch: `staging`. The default base in this UI is `main` (release branch). -->
<!-- Change the base to `staging` before submitting unless this is a maintainer-approved mainline change. -->
<!-- See CONTRIBUTING.md § Branches. -->

## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

No linked issue. This was reported directly by Celia; a tracking issue should be opened before submission if the team wants one.

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- In Game Mode, Gallery -> Illustrate could ignore the game setup's image style prompt after the first generated scene/image path because the manual Illustrator retry path did not carry the stored game art style into the agent prompt or the final provider prompt.

## What changed

<!-- List the key changes in this PR -->

- Pass the Game Mode `artStylePrompt` from chat setup metadata into the retry-agent context for Illustrator.
- Add Game Mode scene-image instructions to the Illustrator agent prompt so manual Gallery -> Illustrate remains a VN/game scene illustration path.
- Prefix the final image-provider prompt with the game art style and use the background/scene image canvas size for Game Mode illustrations instead of selfie sizing.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Codex proof: `pnpm build:shared` completed successfully before the focused scratch repro.
- Codex proof: `packages\server\node_modules\.bin\tsx.cmd scratch/repro-game-illustrator-style.mjs` passed. The repro asserts that Game Mode Illustrator receives `<game_image_instructions>`, sees the stored art style prompt, prefixes the provider prompt through `buildIllustratorImagePrompt`, and uses background/scene canvas dimensions.
- Codex proof: `pnpm check` passed locally.
- Not manually verified in a real image provider: final aesthetic adherence still depends on configured image-generation provider behavior and human visual judgment.
- The previous `packages/server/test/game-session-prompts.test.ts` targeted test could not be rerun because that test file is not present on current `upstream/staging`.
- Bunny review pass: pass. The branch is based on `upstream/staging`, pushes go to `origin`, the diff is two focused server files, `git diff --check` had no whitespace errors beyond CRLF warnings, no server `console.*` was added, and the proof exercises the changed path directly.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs or version files changed.

## UI evidence (if applicable)

N/A. This is a server-side prompt assembly/image-generation route fix. The proof is a focused route/agent prompt repro plus `pnpm check`.
