### PR TITLE
Fix Windows installer shallow release checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Fixed Windows installer updates for existing shallow release checkouts by fetching the resolved release commit before checkout.
 - Fixed mobile Game Mode character and party controls so sheet actions stay compact, long character names can remain accessible, and crowded party rosters collapse into a scrollable mobile party picker.
 - Fixed mobile Game Mode choice prompts so large choice sets stay readable and scroll inside the available play area instead of squishing buttons or pushing custom input off-screen.
 - Fixed mobile Game Mode side dialogue voice playback so voiced dialogue cues can play when the side line first appears.

--- a/win/installer/install.bat
+++ b/win/installer/install.bat
@@ -237,6 +237,21 @@ if defined RELEASE_COMMIT if /I not "!TARGET_HEAD!"=="%RELEASE_COMMIT%" (
     echo  [WARN] Release %RELEASE_TAG% resolved to !TARGET_HEAD!, not the installer-expected %RELEASE_COMMIT%.
     echo         Continuing with the fetched release tag because hotfix tags may move.
 )
+git cat-file -e "!TARGET_HEAD!" >nul 2>&1
+if errorlevel 1 (
+    echo  [..] Release commit is missing locally, fetching main history...
+    git fetch --quiet --force origin "+refs/heads/main:refs/remotes/origin/main"
+    git cat-file -e "!TARGET_HEAD!" >nul 2>&1
+    if errorlevel 1 (
+        echo  [..] Fetching the release commit directly...
+        git fetch --quiet --force origin "!TARGET_HEAD!"
+    )
+    git cat-file -e "!TARGET_HEAD!" >nul 2>&1
+    if errorlevel 1 (
+        set "INSTALL_ERROR=Fetched release %RELEASE_TAG%, but the target commit was not available locally."
+        goto :fatal
+    )
+)
 if /I "!OLD_HEAD!"=="!TARGET_HEAD!" (
     echo  [OK] Repository already up to date
     goto :deps
@@ -254,7 +269,7 @@ if "!DIRTY!"=="1" (
     if "!STASHED!"=="1" for /f "tokens=*" %%i in ('git stash list -1 --format^=%%gd 2^>nul') do set "STASH_REF=%%i"
 )
 
-git checkout --detach "!TARGET_HEAD!"
+git checkout "!TARGET_HEAD!"
 if errorlevel 1 (
     if "!STASHED!"=="1" call :restore_stashed_changes
     set "INSTALL_ERROR=Failed to check out release %RELEASE_TAG%."

--- a/win/installer/installer.nsi
+++ b/win/installer/installer.nsi
@@ -380,7 +380,32 @@ Please restart your computer and run this installer again."
       DetailPrint "Warning: ${RELEASE_TAG} resolved to $3, not the installer-expected ${RELEASE_COMMIT}. Continuing with fetched tag."
     ${EndIf}
 
-    nsExec::ExecToLog 'git checkout --detach $3'
+    nsExec::ExecToLog 'cmd /c git cat-file -e $3 >nul 2>&1'
+    Pop $0
+    ${If} $0 != 0
+      DetailPrint "Release commit is missing locally — fetching main history..."
+      nsExec::ExecToLog 'git fetch --quiet --force origin +refs/heads/main:refs/remotes/origin/main'
+      Pop $0
+      nsExec::ExecToLog 'cmd /c git cat-file -e $3 >nul 2>&1'
+      Pop $0
+      ${If} $0 != 0
+        DetailPrint "Fetching the release commit directly..."
+        nsExec::ExecToLog 'git fetch --quiet --force origin $3'
+        Pop $0
+      ${EndIf}
+      nsExec::ExecToLog 'cmd /c git cat-file -e $3 >nul 2>&1'
+      Pop $0
+      ${If} $0 != 0
+        ${If} $5 == "1"
+          nsExec::ExecToLog 'git stash apply -q'
+          Pop $1
+        ${EndIf}
+        MessageBox MB_OK|MB_ICONSTOP "Fetched release ${RELEASE_TAG}, but the target commit was not available locally.$\r$\n$\r$\nPlease check your internet connection and run the installer again."
+        Abort
+      ${EndIf}
+    ${EndIf}
+
+    nsExec::ExecToLog 'git checkout $3'
     Pop $0
     ${If} $0 != 0
       ${If} $5 == "1"


### PR DESCRIPTION
## Linked issue

No linked issue yet. This came from a Discord/user support report of the Windows installer failing while updating an existing install to `v1.6.0`.

## Why this change

Users with installer-created shallow release checkouts can hit a confusing Git failure while updating when the fetched release tag resolves to a commit that is not available in the local object database yet. In that state, checkout can fail before the installer reaches dependency install/build, leaving users stuck even though their data folder is untouched.

## What changed

- Verifies the resolved release commit exists locally before checkout in the NSIS installer and batch installer.
- Fetches `origin/main`, then the exact resolved commit as a fallback, when the target commit is missing from a shallow checkout.
- Uses plain `git checkout <commit>` after commit verification so the installer still lands in detached HEAD without relying on the `--detach <commit>` syntax.
- Adds an Unreleased changelog note for the Windows installer update fix.

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Ran `pnpm check`.
- Ran `pnpm version:check`.
- Ran `pnpm guard:installer-artifacts`.
- Ran `node scripts/check-windows-installer-layout.mjs`.
- Smoke-tested a disposable shallow `v1.5.9` clone by fetching `v1.6.0`, resolving `c247b2ebd6f2b6274cb7284e37d6ad382aafa6ac`, verifying it with `git cat-file`, and checking it out with the patched command.
- Smoke-tested the fallback path where `c247b2ebd6f2b6274cb7284e37d6ad382aafa6ac` is missing before fetching `origin/main`, then verified checkout lands on the expected commit in detached HEAD.
- Did not compile the NSIS installer executable locally because `makensis` is not installed in this environment.

## Docs and release impact

- [ ] No docs changes needed
- [x] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

Not applicable; installer/update script change only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
  * Fixed Windows installer to properly update existing shallow release checkouts. The installer now validates the target release commit exists locally before checkout, automatically fetching it if needed to ensure smooth and reliable updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/967?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->