### PR TITLE
feat(image-gen): add Draw Things HTTP API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Preset system with drag-and-drop prompt ordering, lorebooks with keyword trigger
 
 ### Connections & Providers
 
-OpenAI, Anthropic, Google Gemini, Google Vertex AI, OpenRouter, NanoGPT, Mistral, Cohere, Pollinations, Stability AI, Together AI, NovelAI, ComfyUI, SD Web UI, and custom OpenAI-compatible endpoints. API keys are encrypted at rest with AES-256. Per-chat connection overrides.
+OpenAI, Anthropic, Google Gemini, Google Vertex AI, OpenRouter, NanoGPT, Mistral, Cohere, Pollinations, Stability AI, Together AI, NovelAI, ComfyUI, SD Web UI, Draw Things (Apple Silicon, Metal + Apple Neural Engine), and custom OpenAI-compatible endpoints. API keys are encrypted at rest with AES-256. Per-chat connection overrides.
 
 ### Export & Data
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -219,7 +219,7 @@ Destructive or high-risk features require `ADMIN_SECRET` in addition to the glob
 
 ### Local URL Opt-Ins
 
-Outbound provider, image, TTS, DeepLX, and webhook requests reject private/LAN/metadata destinations by default to prevent SSRF. Provider calls allow loopback endpoints (`127.0.0.1`, `::1`, `localhost`) so local OpenAI-compatible servers keep working on single-machine installs. Explicit ComfyUI and AUTOMATIC1111 image connections may use loopback or LAN/private-network hosts because those backends are normally self-hosted. Enable only the feature-specific switch you need for other non-loopback self-hosted services, such as `PROVIDER_LOCAL_URLS_ENABLED=true` for a LAN OpenAI-compatible endpoint or `IMAGE_LOCAL_URLS_ENABLED=true` for a custom image proxy on another private-network host.
+Outbound provider, image, TTS, DeepLX, and webhook requests reject private/LAN/metadata destinations by default to prevent SSRF. Provider calls allow loopback endpoints (`127.0.0.1`, `::1`, `localhost`) so local OpenAI-compatible servers keep working on single-machine installs. Explicit ComfyUI, AUTOMATIC1111, and Draw Things image connections may use loopback or LAN/private-network hosts because those backends are normally self-hosted. Enable only the feature-specific switch you need for other non-loopback self-hosted services, such as `PROVIDER_LOCAL_URLS_ENABLED=true` for a LAN OpenAI-compatible endpoint or `IMAGE_LOCAL_URLS_ENABLED=true` for a custom image proxy on another private-network host.
 
 Security headers and API rate limits are enabled by default. Chat HTML is sanitized after rendering transforms; SVG uploads/proxies are not accepted for avatar/background/image upload paths.
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -106,7 +106,7 @@ See [Professor Mari](PROFESSOR_MARI.md) for the full capabilities and safety not
 Marinara Engine supports a wide range of LLM and image generation providers:
 
 - **LLM:** OpenAI, Anthropic, Anthropic via Claude Pro / Max subscription (through the local Claude Agent SDK), Google Gemini, Google Vertex AI, OpenRouter, NanoGPT, Mistral, Cohere, Pollinations, Together AI, NovelAI, and any custom OpenAI-compatible endpoint (Ollama, LM Studio, KoboldCpp, etc.)
-- **Image generation:** Stability AI, ComfyUI, AUTOMATIC1111 / SD Web UI, and providers that support image output through their chat API
+- **Image generation:** Stability AI, ComfyUI, AUTOMATIC1111 / SD Web UI, Draw Things (Apple Silicon Macs — runs locally on Metal + Apple Neural Engine), and providers that support image output through their chat API
 
 You can configure multiple connections at once and assign different providers per chat. API keys are encrypted at rest with AES-256.
 

--- a/packages/server/src/services/image/image-generation.ts
+++ b/packages/server/src/services/image/image-generation.ts
@@ -24,7 +24,45 @@ import {
 } from "@marinara-engine/shared";
 import { isImageLocalUrlsEnabled } from "../../config/runtime-config.js";
 import { generateRunPodComfyUI } from "./runpod-comfyui.service.js";
+import { logger } from "../../lib/logger.js";
 import { normalizeLoopbackUrl, safeFetch, validateOutboundUrl } from "../../utils/security.js";
+
+// sharp is an optional native module (no prebuilds on some platforms like Termux).
+// Lazy-load so the server boots even when sharp is missing; the only callers that
+// need it (Draw Things img2img init resize) fall back to passing the original.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type SharpFn = any;
+let _sharp: SharpFn | null = null;
+let _sharpLoadAttempted = false;
+async function tryLoadSharp(): Promise<SharpFn | null> {
+  if (_sharp || _sharpLoadAttempted) return _sharp;
+  _sharpLoadAttempted = true;
+  try {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore - optional native dep
+    const mod = await import("sharp");
+    _sharp = (mod.default ?? mod) as SharpFn;
+    return _sharp;
+  } catch {
+    return null;
+  }
+}
+
+async function resizeBase64ToExactSize(b64: string, width: number, height: number): Promise<string> {
+  const sharpFn = await tryLoadSharp();
+  if (!sharpFn) return b64;
+  try {
+    const buf = Buffer.from(b64, "base64");
+    const out = await sharpFn(buf)
+      .resize(width, height, { fit: "cover", position: "attention" })
+      .png()
+      .toBuffer();
+    return out.toString("base64");
+  } catch (err) {
+    logger.warn(err, "[image-gen] init image resize failed, sending original");
+    return b64;
+  }
+}
 
 const GALLERY_DIR = join(DATA_DIR, "gallery");
 const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
@@ -159,7 +197,7 @@ export async function generateImage(
       return generateRunPodComfyUI(normalizedBaseUrl, endpointId, apiKey, scopedRequest);
     }
     case "automatic1111":
-      return generateAutomatic1111(normalizedBaseUrl, scopedRequest);
+      return generateAutomatic1111(normalizedBaseUrl, scopedRequest, serviceHint);
     case "gemini_image":
       return generateViaChatCompletions(normalizedBaseUrl, apiKey, scopedRequest);
     default:
@@ -1794,17 +1832,15 @@ async function generateComfyUI(baseUrl: string, request: ImageGenRequest): Promi
 
 // ── AUTOMATIC1111 / SD Web UI / Forge ──
 
-async function generateAutomatic1111(baseUrl: string, request: ImageGenRequest): Promise<ImageGenResult> {
+async function generateAutomatic1111(
+  baseUrl: string,
+  request: ImageGenRequest,
+  serviceHint?: string,
+): Promise<ImageGenResult> {
   const base = baseUrl.replace(/\/+$/, "");
+  const isDrawThings = serviceHint?.trim().toLowerCase() === "drawthings";
   const defaults = resolveAutomatic1111Defaults(request);
   const useImg2Img = !!(request.referenceImage || request.referenceImages?.length);
-  const overrideSettings: Record<string, unknown> = {};
-  if (request.model) {
-    overrideSettings.sd_model_checkpoint = request.model;
-  }
-  if (defaults.clipSkip) {
-    overrideSettings.CLIP_stop_at_last_layers = defaults.clipSkip;
-  }
 
   const body: Record<string, unknown> = {
     prompt: mergePromptPrefix(defaults.promptPrefix, request.prompt),
@@ -1812,25 +1848,50 @@ async function generateAutomatic1111(baseUrl: string, request: ImageGenRequest):
     width: request.width ?? 512,
     height: request.height ?? 768,
     steps: defaults.steps,
-    cfg_scale: defaults.cfgScale,
     seed: resolveSeed(request.imageDefaults),
     sampler_name: defaults.sampler || DEFAULT_AUTOMATIC1111_DEFAULTS.sampler,
-    batch_size: 1,
-    n_iter: 1,
-    restore_faces: defaults.restoreFaces,
   };
-  if (defaults.scheduler) {
-    body.scheduler = defaults.scheduler;
+
+  if (isDrawThings) {
+    // Draw Things' /sdapi/v1/txt2img diverges from A1111: it uses `guidance_scale`
+    // (not `cfg_scale`), `batch_count` (not `n_iter`/`batch_size`), and rejects
+    // unknown keys like `override_settings`, `scheduler`, and `restore_faces`.
+    // Model / LoRA selection is driven by the Draw Things UI state, not the request.
+    body.guidance_scale = defaults.cfgScale;
+    body.batch_count = 1;
+  } else {
+    body.cfg_scale = defaults.cfgScale;
+    body.batch_size = 1;
+    body.n_iter = 1;
+    body.restore_faces = defaults.restoreFaces;
+    if (defaults.scheduler) {
+      body.scheduler = defaults.scheduler;
+    }
+    const overrideSettings: Record<string, unknown> = {};
+    if (request.model) {
+      overrideSettings.sd_model_checkpoint = request.model;
+    }
+    if (defaults.clipSkip) {
+      overrideSettings.CLIP_stop_at_last_layers = defaults.clipSkip;
+    }
+    if (Object.keys(overrideSettings).length > 0) {
+      body.override_settings = overrideSettings;
+    }
   }
-  if (Object.keys(overrideSettings).length > 0) {
-    body.override_settings = overrideSettings;
-  }
+
   if (useImg2Img) {
-    body.init_images = [request.referenceImage ?? request.referenceImages?.[0]];
+    const rawInit = (request.referenceImage ?? request.referenceImages?.[0]) as string;
+    // Draw Things rejects img2img if init_images dimensions don't match the requested
+    // width/height exactly. A1111/Forge auto-resize internally; Draw Things does not.
+    const initImage = isDrawThings
+      ? await resizeBase64ToExactSize(rawInit, body.width as number, body.height as number)
+      : rawInit;
+    body.init_images = [initImage];
     body.denoising_strength = defaults.denoisingStrength;
   }
 
   const endpoint = useImg2Img ? `${base}/sdapi/v1/img2img` : `${base}/sdapi/v1/txt2img`;
+  const label = isDrawThings ? "Draw Things" : "AUTOMATIC1111";
 
   const resp = await localImageBackendFetch(endpoint, {
     method: "POST",
@@ -1841,12 +1902,17 @@ async function generateAutomatic1111(baseUrl: string, request: ImageGenRequest):
 
   if (!resp.ok) {
     const errText = await resp.text().catch(() => "Unknown error");
-    throw new Error(`AUTOMATIC1111 generation failed (${resp.status}): ${sanitizeErrorText(errText)}`);
+    throw new Error(`${label} generation failed (${resp.status}): ${sanitizeErrorText(errText)}`);
   }
 
   const data = (await resp.json()) as { images?: string[] };
   const b64 = data.images?.[0];
-  if (!b64) throw new Error("No image data in AUTOMATIC1111 response");
+  if (!b64) {
+    const hint = isDrawThings
+      ? " (check that a model is selected in Draw Things and the API server port matches)"
+      : "";
+    throw new Error(`No image data in ${label} response${hint}`);
+  }
 
   return { base64: b64, mimeType: "image/png", ext: "png" };
 }

--- a/packages/shared/src/constants/image-generation-defaults.ts
+++ b/packages/shared/src/constants/image-generation-defaults.ts
@@ -48,19 +48,37 @@ export const DEFAULT_NOVELAI_DEFAULTS: NovelAiDefaults = {
 
 export const SD_WEBUI_SAMPLER_OPTIONS = [
   { value: "", label: "Automatic / backend default" },
+  // Common to A1111/Forge and Draw Things
   { value: "Euler a", label: "Euler a" },
-  { value: "Euler", label: "Euler" },
-  { value: "DPM++ 2M", label: "DPM++ 2M" },
   { value: "DPM++ 2M Karras", label: "DPM++ 2M Karras" },
-  { value: "DPM++ SDE", label: "DPM++ SDE" },
   { value: "DPM++ SDE Karras", label: "DPM++ SDE Karras" },
-  { value: "DPM++ 2M SDE", label: "DPM++ 2M SDE" },
   { value: "UniPC", label: "UniPC" },
   { value: "DDIM", label: "DDIM" },
+  // A1111/Forge only
+  { value: "Euler", label: "Euler" },
+  { value: "DPM++ 2M", label: "DPM++ 2M" },
+  { value: "DPM++ SDE", label: "DPM++ SDE" },
+  { value: "DPM++ 2M SDE", label: "DPM++ 2M SDE" },
   { value: "LMS", label: "LMS" },
   { value: "Heun", label: "Heun" },
   { value: "DPM2", label: "DPM2" },
   { value: "DPM2 a", label: "DPM2 a" },
+  // Draw Things-specific samplers (AYS / Substep / Trailing / LCM / TCD / PLMS)
+  { value: "PLMS", label: "PLMS (Draw Things)" },
+  { value: "LCM", label: "LCM (Draw Things)" },
+  { value: "TCD", label: "TCD (Draw Things)" },
+  { value: "TCD Trailing", label: "TCD Trailing (Draw Things)" },
+  { value: "Euler A Substep", label: "Euler A Substep (Draw Things)" },
+  { value: "DPM++ SDE Substep", label: "DPM++ SDE Substep (Draw Things)" },
+  { value: "Euler A Trailing", label: "Euler A Trailing (Draw Things)" },
+  { value: "DPM++ SDE Trailing", label: "DPM++ SDE Trailing (Draw Things)" },
+  { value: "DPM++ 2M Trailing", label: "DPM++ 2M Trailing (Draw Things)" },
+  { value: "DDIM Trailing", label: "DDIM Trailing (Draw Things)" },
+  { value: "UniPC Trailing", label: "UniPC Trailing (Draw Things)" },
+  { value: "Euler A AYS", label: "Euler A AYS (Draw Things)" },
+  { value: "DPM++ 2M AYS", label: "DPM++ 2M AYS (Draw Things)" },
+  { value: "DPM++ SDE AYS", label: "DPM++ SDE AYS (Draw Things)" },
+  { value: "UniPC AYS", label: "UniPC AYS (Draw Things)" },
 ] as const;
 
 export const SD_WEBUI_SCHEDULER_OPTIONS = [


### PR DESCRIPTION
## Linked issue

Closes #969

## Why this change

- Marinara already aliases the `drawthings` provider to the AUTOMATIC1111 dispatch case, but Draw Things' HTTP server diverges from A1111 enough that the path silently fails today: requests sending `cfg_scale` return `HTTP 200 {"images": []}` (full generation cycle, no image), filling the connection editor's Model field causes `HTTP 422` because Draw Things rejects `override_settings`, and the sampler dropdown only overlaps on five names with Draw Things' actual sampler set. Out-of-the-box Draw Things connections look configured but generate nothing.
- Local-network image generation on Apple Silicon Macs is meaningfully faster via Draw Things (Metal + Apple Neural Engine + CoreML) than the ComfyUI Python path. Fixing this unlocks a working backend for that audience without adding a new provider abstraction — it's all behavior changes inside the existing `automatic1111` dispatch.

## What changed

- `packages/server/src/services/image/image-generation.ts`:
  - Passes the explicit `serviceHint` through to `generateAutomatic1111` and branches on `serviceHint === "drawthings"`.
  - Draw Things branch uses `guidance_scale` (not `cfg_scale`) and `batch_count` (not `n_iter`/`batch_size`); drops `override_settings`, `scheduler`, `restore_faces` which Draw Things 422s on.
  - Lazy-loads `sharp` (already a server dep, same load pattern as `sprites.routes.ts`) and resizes img2img init images to match request `width`/`height` exactly, since Draw Things does not auto-resize like A1111/Forge does. Falls back to the original image if `sharp` is unavailable.
  - Adds the missing `import { logger }` referenced at line 1430 — pre-existing bug that prevented the file from compiling.
- `packages/shared/src/constants/image-generation-defaults.ts`:
  - Extends `SD_WEBUI_SAMPLER_OPTIONS` with 16 Draw Things-specific samplers (`UniPC AYS`, `DPM++ SDE Substep/Trailing/AYS`, `TCD`, `TCD Trailing`, `LCM`, `PLMS`, etc.) labeled `(Draw Things)` so AUTOMATIC1111/Forge users can avoid them.
- `README.md`, `docs/FAQ.md`, `docs/CONFIGURATION.md`: adds Draw Things to the supported-image-providers list and to the SSRF-allowed local image backends section.
- Existing AUTOMATIC1111 and Forge connections see zero behavior change — the new branch only activates when the explicit hint is `drawthings`.

## Validation

- [x] \`pnpm check\` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed \`CONTRIBUTING.md\`

> Only ticking \`pnpm check\` because it is a deterministic command result that this agent ran on the final commit. The manual-verification boxes (container, browser click-through, light/dark/mobile, CONTRIBUTING re-read) are intentionally left unchecked per the AI-Generated PR guidance — those are a to-do list for the human contributor and reviewer, not evidence that work is done. The work I actually exercised is described below as prose.

### What I ran locally (prose, for reviewer reference)

Tested end-to-end on macOS / Apple M5 against Draw Things 1.20260430.0 driving the Anima 1.0 model (Qwen-Image architecture) on \`127.0.0.1:7861\`:

1. Installed Draw Things via \`brew install --cask draw-things\` and enabled its HTTP API server.
2. In Marinara: added an image-generation connection, provider Draw Things, base URL \`http://127.0.0.1:7861\`, no API key.
3. **Without the patch:** the connection's \"Test image\" button returned no image (HTTP 200, empty \`images\` array); filling the Model field made every request 422 with \`Unrecognized keys: [\"override_settings\"]\`; the sampler dropdown effectively only had \`Euler a\` as a working option.
4. **With the patch:**
   - Test image button returns a real PNG in ~30s.
   - Selectable samplers include the Draw Things-specific entries (\`UniPC AYS\`, etc.); switching between them is honored.
   - In-chat image generation works for both txt2img (default selfie path) and img2img (illustrator agent with a character avatar passed as \`referenceImage\` — confirmed the init image is resized server-side so Draw Things accepts it).
5. **Regression check:** an existing AUTOMATIC1111 connection still routes through the unmodified branch and works as before (verified by sampling the request body before/after — the \`cfg_scale\` / \`n_iter\` / \`batch_size\` / \`override_settings\` keys are still sent when \`serviceHint\` is not \`drawthings\`).
6. \`pnpm check\` was green on the final commit.

**Manual verification a reviewer should still do** (these are the cases I did not exercise):

- Light vs dark mode rendering of the new sampler labels in the connection editor dropdown — text-only change, no styling, but worth a glance.
- Mobile viewport for the same dropdown.
- Docker/Podman container build with the lazy \`sharp\` import on a platform without prebuilds (e.g. Termux/Android). Code follows the existing pattern in \`sprites.routes.ts\` and falls back to sending the original init image if \`sharp\` can't load.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

README provider list, FAQ image-generation entry, and CONFIGURATION's local-URL opt-ins section all add Draw Things alongside the existing self-hosted backends. No CHANGELOG or version bump in this PR. (Docs boxes left unchecked per the same AI-Generated PR rule above — verification of docs accuracy belongs to the human reviewer.)

## UI evidence (if applicable)

No new UI surface — the only client-visible change is the expanded sampler dropdown in the existing connection editor (text-only addition).

## Note on the OpenRouter changes from the earlier revision

Per reviewer feedback, the OpenRouter response-parsing improvements that were bundled into the original revision of this PR have been split out into a separate PR (#1027, linked to issue #1026) so this one stays scoped to Draw Things only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)