### PR TITLE
Fix Mari notification sound settings guidance

### DIFF
--- a/packages/server/src/db/seed-mari.ts
+++ b/packages/server/src/db/seed-mari.ts
@@ -186,6 +186,13 @@ Characters automatically know what's happening in their other chats. When the us
 - The user MUST set up at least one connection before they can chat
 - Set up in the Connections panel (right sidebar → link icon)
 
+### Settings, Audio, and Notification Sounds
+- App-wide settings live in the Settings panel, opened from the right panel/top bar settings button.
+- Notification pings are NOT browser-only. Marinara has in-app notification sound toggles at **Settings > Appearance > Notification Sounds**.
+- The Notification Sounds section has separate toggles for **Conversation mode** and **Roleplay mode**. Tell users to open the Appearance tab, then look for "Notification Sounds".
+- If you want to take the user there, use [navigate: panel="settings", tab="appearance"] and then tell them to scroll to Notification Sounds.
+- Game Mode has its own in-session audio controls on the Game surface volume button/popover for master, music, SFX, ambience, and voice/TTS volume.
+
 ### Built-In Local Gemma Model
 - Marinara Engine also has an optional built-in local model: **Google Gemma 4 E2B**.
 - The user can set it up from the **Local Model** card in the Connections panel or from the onboarding tutorial's **Open Local Model** step.
@@ -366,6 +373,7 @@ You can't complete the entire Game Setup Wizard by hidden assistant command — 
 - **Sidebar** (left): All chats, search, + button to create new chats
 - **Right Panel** (top bar buttons): Characters, Lorebooks, Presets, Connections, Agents, Personas, Settings
 - **Settings tabs**: General, Appearance, Themes, Extensions, Import (SillyTavern migration), Advanced
+- For notification pings specifically: Settings > Appearance > Notification Sounds.
 </app_knowledge>
 
 <assistant_commands>


### PR DESCRIPTION
<!-- Target branch: `staging`. The default base in this UI is `main` (release branch). -->
<!-- Change the base to `staging` before submitting unless this is a maintainer-approved mainline change. -->
<!-- See CONTRIBUTING.md § Branches. -->

## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #959

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- Professor Mari could give stale guidance for notification pings because her built-in assistant knowledge did not mention the current in-app Notification Sounds controls under Settings > Appearance.

## What changed

<!-- List the key changes in this PR -->

- Added current Settings > Appearance > Notification Sounds guidance to Professor Mari's seeded assistant prompt.
- Added the two current notification sound toggles, Conversation mode and Roleplay mode, plus the settings navigation command target.
- Noted that Game Mode audio volume lives on the Game surface volume popover, separate from notification pings.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Codex repro before fix: `node scratch/repro-issue-959-mari-settings-guidance.mjs` failed because the UI exposed Notification Sounds in Appearance while Mari's prompt lacked current guidance.
- Codex repro after fix: `node scratch/repro-issue-959-mari-settings-guidance.mjs` passed:

```text
issue-959 uiHasNotificationControls=true
issue-959 promptHasCurrentGuidance=true
issue-959 promptAvoidsReportedStaleFallbacks=true
issue-959 pass=true
```

- Codex baseline: `pnpm check` passed. The first 120s attempt timed out before completion, then the longer rerun completed successfully.
- Bunny review before PR: pass. Branch is based on `upstream/staging`; diff is one focused seed-prompt file; no schema/version/dependency/auth/storage changes; no server `console.*`; `git diff --check upstream/staging` passed.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No user-facing docs or release metadata changed; this only updates Professor Mari's seeded internal guidance.

## UI evidence (if applicable)

N/A. This is a seeded assistant prompt/knowledge fix, not a UI rendering change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced the Professor Mari assistant with improved navigation guidance. Users now receive explicit in-app instructions on locating notification sound settings for Conversations and Roleplay modes in Settings > Appearance > Notification Sounds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/974?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->