### PR TITLE
fix(chat): play roleplay notification sounds

### DIFF
--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -33,6 +33,7 @@ import {
 } from "lucide-react";
 import { cn } from "../../lib/utils";
 import { getConnectedChatDisplayName } from "../../lib/chat-display";
+import { playNotificationPing } from "../../lib/notification-sound";
 import { useUIStore } from "../../stores/ui.store";
 import { useChatStore } from "../../stores/chat.store";
 import { useGameStateStore } from "../../stores/game-state.store";
@@ -95,6 +96,7 @@ const TRACKER_FOREGROUND_AVOIDANCE_CLASS =
   "md:pl-[var(--tracker-chat-avoid-left)] md:pr-[var(--tracker-chat-avoid-right)] md:transition-[padding] md:duration-200 md:ease-[cubic-bezier(0.16,1,0.3,1)]";
 const PANEL_CONTAINER =
   "relative max-h-[calc(100dvh-4rem)] w-full max-w-sm overflow-y-auto rounded-xl border border-[var(--border)] bg-[var(--card)] p-3 shadow-2xl shadow-black/40 animate-message-in";
+const roleplayNotificationSeenKeys = new Set<string>();
 
 function WeatherEffectsConnected() {
   const gs = useGameStateStore((s) => s.current);
@@ -713,8 +715,54 @@ export function ChatRoleplaySurface({
   const sidebarOpen = useUIStore((s) => s.sidebarOpen);
   const rightPanelOpen = useUIStore((s) => s.rightPanelOpen);
   const chatBackgroundBlur = useUIStore((s) => s.chatBackgroundBlur);
+  const initialLoadSettledRef = useRef(false);
+  const prevMessageKeysRef = useRef<Set<string>>(new Set());
+  const seenMessageKeysRef = useRef(roleplayNotificationSeenKeys);
   const hideEchoChamberOnMobile =
     sidebarOpen || rightPanelOpen || settingsOpen || filesOpen || galleryOpen || wizardOpen;
+
+  useEffect(() => {
+    initialLoadSettledRef.current = false;
+    prevMessageKeysRef.current = new Set();
+  }, [activeChatId]);
+
+  useEffect(() => {
+    if (!messages) return;
+    const currentKeys = new Set(messages.map((message) => `${activeChatId}:${message.id}`));
+
+    if (!initialLoadSettledRef.current) {
+      if (currentKeys.size > 0) {
+        prevMessageKeysRef.current = currentKeys;
+        for (const key of currentKeys) seenMessageKeysRef.current.add(key);
+        initialLoadSettledRef.current = true;
+      }
+      return;
+    }
+
+    const prevKeys = prevMessageKeysRef.current;
+    const seenKeys = seenMessageKeysRef.current;
+    const now = Date.now();
+    const FRESHNESS_MS = 15_000;
+    let hasNewAssistantMessage = false;
+
+    for (const message of messages) {
+      const key = `${activeChatId}:${message.id}`;
+      if (prevKeys.has(key) || seenKeys.has(key)) continue;
+
+      const createdAt = new Date(message.createdAt).getTime();
+      const isFresh = Number.isFinite(createdAt) && now - createdAt < FRESHNESS_MS;
+      if (isFresh && message.role === "assistant") {
+        hasNewAssistantMessage = true;
+      }
+    }
+
+    for (const key of currentKeys) seenKeys.add(key);
+    prevMessageKeysRef.current = currentKeys;
+
+    if (hasNewAssistantMessage && useUIStore.getState().rpNotificationSound) {
+      playNotificationPing();
+    }
+  }, [activeChatId, messages]);
 
   return (
     <div data-component="ChatArea.Roleplay" className="flex flex-1 overflow-hidden">


### PR DESCRIPTION
<!-- Target branch: `staging`. The default base in this UI is `main` (release branch). -->
<!-- Change the base to `staging` before submitting unless this is a maintainer-approved mainline change. -->
<!-- See CONTRIBUTING.md § Branches. -->

## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #956

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- Roleplay chats did not play the enabled notification ping when a fresh assistant message appeared in the active roleplay surface, while conversation mode already did.

## What changed

<!-- List the key changes in this PR -->

- Added fresh assistant-message notification tracking to `ChatRoleplaySurface`.
- Gated the roleplay ping behind the existing `rpNotificationSound` setting.
- Kept initial history loads and stale refetches silent so opening or refreshing a roleplay chat does not replay old sounds.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Codex reproduced the missing roleplay notification path before the fix with `node scratch/issue-956-roleplay-notification-proof.mjs`.
- Codex reran `node scratch/issue-956-roleplay-notification-proof.mjs` after the fix. It passed these checks:
  - conversation mode has the existing fresh assistant-message notification path
  - roleplay mode imports and calls the notification sound player
  - roleplay mode uses the `rpNotificationSound` setting
  - initial roleplay history load stays silent
  - stale assistant messages from refetch stay silent
  - one fresh roleplay assistant message pings once
  - disabling the Roleplay notification sound setting keeps it silent
- Codex ran `pnpm check`; it passed.
- Bunny review pass: passed after the post-push diff check. Scope is one client file, no whitespace damage, and the PR targets `staging`.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

N/A. This is an audio notification behavior fix with no visible UI state to screenshot.
