### PR TITLE
ci: automate issue status labels for staging PRs

### DIFF
--- a/.github/workflows/issue-status-from-prs.yml
+++ b/.github/workflows/issue-status-from-prs.yml
@@ -1,0 +1,197 @@
+name: Issue Status From Pull Requests
+
+on:
+  pull_request_target:
+    types: [opened, reopened, edited, synchronize, closed]
+
+concurrency:
+  group: issue-status-from-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  update-linked-issues:
+    name: Update linked issue status
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: read
+    steps:
+      - name: Label linked issues
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            const labels = {
+              'in-pr': {
+                color: '1d76db',
+                description: 'Has an open pull request targeting staging',
+              },
+              staging: {
+                color: '0e8a16',
+                description: 'Already fixed in staging and is pending closure when staging is merged to main',
+              },
+            };
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pr = context.payload.pull_request;
+            const targetsStaging = pr.base?.ref === 'staging';
+            const closingLinePattern = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)(?:[^.\n]*)/gi;
+            const issueReferencePattern = /(?:(?<owner>[\w.-]+)\/(?<repo>[\w.-]+))?#(?<number>\d+)/g;
+
+            function linkedIssueNumbers(body) {
+              const issueNumbers = new Set();
+
+              for (const closingLine of String(body || '').matchAll(closingLinePattern)) {
+                for (const issueReference of closingLine[0].matchAll(issueReferencePattern)) {
+                  const referencedOwner = issueReference.groups.owner;
+                  const referencedRepo = issueReference.groups.repo;
+
+                  if (
+                    referencedOwner &&
+                    (
+                      referencedOwner.toLowerCase() !== owner.toLowerCase() ||
+                      referencedRepo.toLowerCase() !== repo.toLowerCase()
+                    )
+                  ) {
+                    continue;
+                  }
+
+                  issueNumbers.add(Number(issueReference.groups.number));
+                }
+              }
+
+              return [...issueNumbers];
+            }
+
+            async function ensureLabel(name) {
+              const opts = { owner, repo };
+              try {
+                await github.rest.issues.createLabel({ ...opts, name, ...labels[name] });
+              } catch (error) {
+                if (error.status === 422) {
+                  await github.rest.issues.updateLabel({ ...opts, name, ...labels[name] });
+                  return;
+                }
+                throw error;
+              }
+            }
+
+            async function addLabel(issue_number, label) {
+              await ensureLabel(label);
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number,
+                labels: [label],
+              });
+            }
+
+            async function removeLabel(issue_number, label) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number,
+                  name: label,
+                });
+              } catch (error) {
+                if (error.status !== 404) {
+                  throw error;
+                }
+              }
+            }
+
+            async function isOpenIssue(issue_number) {
+              try {
+                const response = await github.rest.issues.get({
+                  owner,
+                  repo,
+                  issue_number,
+                });
+
+                return !response.data.pull_request && response.data.state === 'open';
+              } catch (error) {
+                if (error.status === 404) {
+                  core.warning(`Skipping #${issue_number}: issue not found.`);
+                  return false;
+                }
+                throw error;
+              }
+            }
+
+            async function hasOtherOpenStagingPr(issueNumber) {
+              const linkedIssues = await openStagingPrIssueNumbers();
+
+              return linkedIssues.has(issueNumber);
+            }
+
+            async function openStagingPrIssueNumbers() {
+              const openPulls = await github.paginate(github.rest.pulls.list, {
+                owner,
+                repo,
+                state: 'open',
+                base: 'staging',
+                per_page: 100,
+              });
+
+              const issueNumbers = new Set();
+
+              for (const openPr of openPulls) {
+                for (const issueNumber of linkedIssueNumbers(openPr.body)) {
+                  issueNumbers.add(issueNumber);
+                }
+              }
+
+              return issueNumbers;
+            }
+
+            async function openIssuesWithLabel(label) {
+              const issues = await github.paginate(github.rest.issues.listForRepo, {
+                owner,
+                repo,
+                state: 'open',
+                labels: label,
+                per_page: 100,
+              });
+
+              return issues.filter((issue) => !issue.pull_request);
+            }
+
+            const issues = linkedIssueNumbers(pr.body);
+
+            if (!issues.length) {
+              core.info('No closing issue references found in the pull request body.');
+            } else if (!targetsStaging) {
+              core.info('Pull request does not target staging; only reconciling existing in-pr labels.');
+            } else {
+              for (const issueNumber of issues) {
+                if (!(await isOpenIssue(issueNumber))) {
+                  core.info(`Skipping #${issueNumber}: not an open issue.`);
+                  continue;
+                }
+
+                if (pr.state === 'closed') {
+                  if (pr.merged) {
+                    await addLabel(issueNumber, 'staging');
+                  }
+
+                  if (!(await hasOtherOpenStagingPr(issueNumber))) {
+                    await removeLabel(issueNumber, 'in-pr');
+                  }
+
+                  continue;
+                }
+
+                await addLabel(issueNumber, 'in-pr');
+              }
+            }
+
+            await ensureLabel('in-pr');
+            const activeOpenPrIssues = await openStagingPrIssueNumbers();
+            const inPrIssues = await openIssuesWithLabel('in-pr');
+
+            for (const issue of inPrIssues) {
+              if (!activeOpenPrIssues.has(issue.number)) {
+                await removeLabel(issue.number, 'in-pr');
+              }
+            }


### PR DESCRIPTION
## Linked issue

No linked issue. This follows up on the staging issue-status cleanup where PRs targeting `staging` were not making linked issues appear in progress or fixed-in-staging.

## Why this change

- Issues referenced by PRs targeting `staging` can remain visibly open without clear status because GitHub does not close them until the fix reaches the default branch.
- Maintainers need issues with open staging PRs to show as in progress, and issues already merged to staging to show as pending release closure.

## What changed

- Added a `pull_request_target` workflow for PRs that reference issues with `Closes`, `Fixes`, or `Resolves`.
- Adds `in-pr` to open linked issues while an open PR targeting `staging` references them.
- Adds `staging` to open linked issues when the referencing PR is merged into `staging`.
- Reconciles stale `in-pr` labels against the current set of open staging PRs so edited PR bodies or retargeted PRs do not leave stale issue status.
- Ignores closed issues and cross-repository issue references.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Codex parsed `.github/workflows/issue-status-from-prs.yml` as YAML successfully.
- Codex syntax-checked the embedded `actions/github-script` JavaScript by wrapping it in an async function and running `node --check`.
- Codex ran parser smoke coverage for `Closes #1, #2`, same-repo qualified references, cross-repo references, unrelated issue references, and empty bodies; it passed.
- Codex ran `pnpm check` in a clean worktree based on `upstream/staging`; it passed.
- Codex ran Bunny review before opening the PR; it passed with no blocking findings.
- Manual verification after merge: open or edit a PR targeting `staging` with `Closes #...` and confirm the linked issue receives `in-pr`; merge that PR into `staging` and confirm the issue receives `staging` and loses `in-pr`.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No user-facing docs or release metadata changed; this is repository workflow automation only.

## UI evidence (if applicable)

N/A. This is GitHub issue/PR workflow automation with no app UI surface.
