### PR TITLE
Support ComfyUI Video Combine animated WebP outputs

### DIFF
--- a/packages/server/src/services/image/image-generation.ts
+++ b/packages/server/src/services/image/image-generation.ts
@@ -325,6 +325,24 @@ function imageExtensionFromMimeType(mimeType: string): string {
   return "png";
 }
 
+function imageResultMetadata(filename: string, contentType: string | null, base64: string): Pick<ImageGenResult, "mimeType" | "ext"> {
+  const normalizedContentType = contentType?.toLowerCase() ?? "";
+  const normalizedFilename = filename.toLowerCase();
+
+  if (normalizedContentType.includes("jpeg") || normalizedContentType.includes("jpg") || /\.jpe?g(?:$|[?#])/i.test(normalizedFilename)) {
+    return { mimeType: "image/jpeg", ext: "jpg" };
+  }
+  if (normalizedContentType.includes("webp") || /\.webp(?:$|[?#])/i.test(normalizedFilename)) {
+    return { mimeType: "image/webp", ext: "webp" };
+  }
+  if (normalizedContentType.includes("gif") || /\.gif(?:$|[?#])/i.test(normalizedFilename)) {
+    return { mimeType: "image/gif", ext: "gif" };
+  }
+
+  const detectedMimeType = detectImageMimeType(base64);
+  return { mimeType: detectedMimeType, ext: imageExtensionFromMimeType(detectedMimeType) };
+}
+
 function decodeImageDataUrl(imageUrl: string): ImageGenResult {
   const match = imageUrl.trim().match(/^data:(image\/(?:png|jpe?g|webp|gif));base64,([\s\S]+)$/i);
   if (!match) {
@@ -1557,6 +1575,18 @@ const DEFAULT_COMFYUI_WORKFLOW: Record<string, unknown> = {
 };
 
 const COMFYUI_GEN_TIMEOUT_SECONDS = Number(process.env.COMFYUI_GEN_TIMEOUT ?? 300);
+const COMFYUI_OUTPUT_FILE_KEYS = ["gifs", "images"] as const;
+
+interface ComfyUiOutputFile {
+  filename: string;
+  subfolder?: string;
+  type?: string;
+}
+
+interface ComfyUiNodeOutput {
+  images?: ComfyUiOutputFile[];
+  gifs?: ComfyUiOutputFile[];
+}
 
 function randomSeed(): number {
   return Math.floor(Math.random() * 2 ** 32);
@@ -1721,39 +1751,35 @@ async function generateComfyUI(baseUrl: string, request: ImageGenRequest): Promi
     });
     if (!historyResp.ok) continue;
 
-    const history = (await historyResp.json()) as Record<
-      string,
-      {
-        outputs?: Record<string, { images?: Array<{ filename: string; subfolder: string; type: string }> }>;
-      }
-    >;
+    const history = (await historyResp.json()) as Record<string, { outputs?: Record<string, ComfyUiNodeOutput> }>;
 
     const entry = history[prompt_id];
     if (!entry?.outputs) continue;
 
-    // Find the first output with images
-    for (const nodeOutput of Object.values(entry.outputs)) {
-      const images = nodeOutput.images;
-      if (images && images.length > 0) {
-        const img = images[0]!;
-        const params = new URLSearchParams({
-          filename: img.filename,
-          subfolder: img.subfolder || "",
-          type: img.type || "output",
-        });
+    // Video Helper Suite's Video Combine reports animated WebP files as "gifs".
+    for (const outputKey of COMFYUI_OUTPUT_FILE_KEYS) {
+      for (const nodeOutput of Object.values(entry.outputs)) {
+        const outputFiles = nodeOutput[outputKey];
+        if (outputFiles && outputFiles.length > 0) {
+          const img = outputFiles[0]!;
+          const params = new URLSearchParams({
+            filename: img.filename,
+            subfolder: img.subfolder || "",
+            type: img.type || "output",
+          });
 
-        const imgResp = await localImageBackendFetch(`${base}/view?${params}`, {
-          signal: AbortSignal.timeout(IMAGE_GEN_TIMEOUT),
-        });
-        if (!imgResp.ok) {
-          throw new Error(`ComfyUI image fetch failed (${imgResp.status})`);
+          const imgResp = await localImageBackendFetch(`${base}/view?${params}`, {
+            signal: AbortSignal.timeout(IMAGE_GEN_TIMEOUT),
+          });
+          if (!imgResp.ok) {
+            throw new Error(`ComfyUI image fetch failed (${imgResp.status})`);
+          }
+
+          const arrayBuffer = await imgResp.arrayBuffer();
+          const base64 = Buffer.from(arrayBuffer).toString("base64");
+          const { mimeType, ext } = imageResultMetadata(img.filename, imgResp.headers.get("content-type"), base64);
+          return { base64, mimeType, ext };
         }
-
-        const arrayBuffer = await imgResp.arrayBuffer();
-        const base64 = Buffer.from(arrayBuffer).toString("base64");
-        const ext = img.filename.endsWith(".jpg") || img.filename.endsWith(".jpeg") ? "jpg" : "png";
-        const mimeType = ext === "jpg" ? "image/jpeg" : "image/png";
-        return { base64, mimeType, ext };
       }
     }
   }

--- a/packages/server/test/image-generation-local.test.ts
+++ b/packages/server/test/image-generation-local.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import { Buffer } from "node:buffer";
+import { createServer } from "node:http";
+import { test } from "node:test";
+import { generateImage } from "../src/services/image/image-generation.js";
+
+const WEBP_BYTES = Buffer.from([0x52, 0x49, 0x46, 0x46, 0x0c, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50]);
+
+test("ComfyUI image generation collects animated WebP outputs from Video Combine", async () => {
+  const promptId = "prompt-video-combine";
+  let port = 0;
+  const server = createServer((req, res) => {
+    if (req.method === "POST" && req.url === "/prompt") {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ prompt_id: promptId }));
+      return;
+    }
+
+    if (req.method === "GET" && req.url === `/history/${promptId}`) {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(
+        JSON.stringify({
+          [promptId]: {
+            outputs: {
+              "42": {
+                gifs: [{ filename: "marinara_loop_00001.webp", subfolder: "", type: "output" }],
+              },
+            },
+          },
+        }),
+      );
+      return;
+    }
+
+    if (req.method === "GET" && req.url?.startsWith("/view?")) {
+      const url = new URL(req.url, `http://127.0.0.1:${port}`);
+      assert.equal(url.searchParams.get("filename"), "marinara_loop_00001.webp");
+      res.writeHead(200, { "content-type": "application/octet-stream" });
+      res.end(WEBP_BYTES);
+      return;
+    }
+
+    res.writeHead(404);
+    res.end();
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const addressInfo = server.address();
+  assert.ok(addressInfo && typeof addressInfo === "object");
+  port = addressInfo.port;
+
+  try {
+    const result = await generateImage("comfyui", `http://localhost:${port}`, "", "comfyui", {
+      prompt: "looping character selfie",
+      width: 512,
+      height: 512,
+    });
+
+    assert.equal(result.mimeType, "image/webp");
+    assert.equal(result.ext, "webp");
+    assert.equal(result.base64, WEBP_BYTES.toString("base64"));
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
+    });
+  }
+});


### PR DESCRIPTION
## Linked issue

Closes #980

## Why this change

- ComfyUI workflows that produce animated WebP loops through Video Combine report those files separately from normal Preview Image / Save Image outputs, so generated loops were not available as chat/selfie image results.

## What changed

- Collect ComfyUI `gifs` outputs in addition to normal `images` outputs.
- Prefer Video Combine-style outputs before still image outputs when both are present.
- Preserve returned media metadata for WebP/GIF/JPEG instead of treating every non-JPEG ComfyUI result as PNG.
- Added a focused local ComfyUI test for a Video Combine-style animated WebP history response.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Codex ran `pnpm --filter @marinara-engine/server exec tsx --test test/image-generation-local.test.ts`; it passed.
- Codex ran `pnpm check`; it passed.
- Codex did not run a real external ComfyUI Video Combine workflow in this environment. Manually verify with a real ComfyUI animated WebP workflow before treating that external-provider path as fully field-tested.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

N/A - server-side image output collection change.
