### PR TITLE
Add ComfyUI missing-reference placeholder fallback

### DIFF
--- a/packages/client/src/components/connections/ConnectionEditor.tsx
+++ b/packages/client/src/components/connections/ConnectionEditor.tsx
@@ -2409,9 +2409,26 @@ function ImageGenerationDefaultsPanel({
                     onChange={(scheduler) => updateComfyUi({ scheduler })}
                   />
                 </div>
+                <label className="flex cursor-pointer items-start gap-3 rounded-lg bg-[var(--card)] px-3 py-2 ring-1 ring-[var(--border)]">
+                  <input
+                    type="checkbox"
+                    checked={comfyui.uploadPlaceholderOnMissingReference}
+                    onChange={(event) => updateComfyUi({ uploadPlaceholderOnMissingReference: event.target.checked })}
+                    className="mt-0.5 h-4 w-4 accent-sky-400"
+                  />
+                  <span className="min-w-0">
+                    <span className="block text-xs text-[var(--foreground)]">
+                      Upload a 1x1 placeholder when no reference image is provided
+                    </span>
+                    <span className="mt-0.5 block text-[0.55rem] text-[var(--muted-foreground)]">
+                      Custom workflows using %reference_image% or %reference_image_name% receive a tiny PNG instead
+                      of the raw placeholder text.
+                    </span>
+                  </span>
+                </label>
                 <p className="text-[0.55rem] text-[var(--muted-foreground)]">
-                  Custom ComfyUI workflows can use %steps%, %cfg%, %sampler%, %scheduler%, %denoise%, and %clip_skip%
-                  placeholders.
+                  Custom ComfyUI workflows can use %steps%, %cfg%, %sampler%, %scheduler%, %denoise%, %clip_skip%,
+                  %reference_image%, and %reference_image_name% placeholders.
                 </p>
               </>
             ) : (

--- a/packages/server/src/services/image/image-generation.ts
+++ b/packages/server/src/services/image/image-generation.ts
@@ -1557,6 +1557,8 @@ const DEFAULT_COMFYUI_WORKFLOW: Record<string, unknown> = {
 };
 
 const COMFYUI_GEN_TIMEOUT_SECONDS = Number(process.env.COMFYUI_GEN_TIMEOUT ?? 300);
+const COMFYUI_PLACEHOLDER_REFERENCE_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
 
 function randomSeed(): number {
   return Math.floor(Math.random() * 2 ** 32);
@@ -1688,7 +1690,10 @@ async function generateComfyUI(baseUrl: string, request: ImageGenRequest): Promi
   if (request.model) {
     replacements["%model%"] = request.model;
   }
-  const reference = request.referenceImage ?? request.referenceImages?.[0];
+  const reference =
+    request.referenceImage ??
+    request.referenceImages?.[0] ??
+    (defaults.uploadPlaceholderOnMissingReference ? COMFYUI_PLACEHOLDER_REFERENCE_BASE64 : undefined);
   if (reference) {
     replacements["%reference_image%"] = reference;
     if (JSON.stringify(workflow).includes("%reference_image_name%")) {

--- a/packages/shared/src/constants/image-generation-defaults.ts
+++ b/packages/shared/src/constants/image-generation-defaults.ts
@@ -32,6 +32,7 @@ export const DEFAULT_COMFYUI_DEFAULTS: ComfyUiDefaults = {
   cfgScale: 7,
   denoisingStrength: 1,
   clipSkip: null,
+  uploadPlaceholderOnMissingReference: false,
 };
 
 export const DEFAULT_NOVELAI_DEFAULTS: NovelAiDefaults = {
@@ -211,6 +212,10 @@ function normalizeComfyUiDefaults(rawDefaults: unknown): ComfyUiDefaults {
     cfgScale: readNumber(raw.cfgScale, DEFAULT_COMFYUI_DEFAULTS.cfgScale, 0, 30),
     denoisingStrength: readNumber(raw.denoisingStrength, DEFAULT_COMFYUI_DEFAULTS.denoisingStrength, 0, 1),
     clipSkip: readNullableInteger(raw.clipSkip, DEFAULT_COMFYUI_DEFAULTS.clipSkip, 1, 12),
+    uploadPlaceholderOnMissingReference: readBoolean(
+      raw.uploadPlaceholderOnMissingReference,
+      DEFAULT_COMFYUI_DEFAULTS.uploadPlaceholderOnMissingReference,
+    ),
   };
 }
 

--- a/packages/shared/src/types/image-generation-defaults.ts
+++ b/packages/shared/src/types/image-generation-defaults.ts
@@ -21,6 +21,7 @@ export interface ComfyUiDefaults {
   cfgScale: number;
   denoisingStrength: number;
   clipSkip: number | null;
+  uploadPlaceholderOnMissingReference: boolean;
 }
 
 export interface NovelAiDefaults {


### PR DESCRIPTION
## Linked issue

Closes #973

## Why this change

- ComfyUI custom workflows can include `%reference_image%` and `%reference_image_name%` placeholders even when a generation request does not have a reference image.
- When those placeholders are left raw, workflows with `LoadImage` chains can fail because ComfyUI receives placeholder text instead of a real image payload or filename.

## What changed

- Added a ComfyUI connection default for uploading a 1x1 placeholder image when no reference image is provided.
- Added the checkbox to the ComfyUI local image defaults editor.
- Updated ComfyUI workflow resolution so missing-reference requests can substitute the bundled placeholder base64 and upload it when `%reference_image_name%` is used.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Codex ran `packages\server\node_modules\.bin\tsx.cmd scratch\verify-issue-973-comfyui-placeholder.ts`; the fake-ComfyUI harness verified enabled fallback uploads/substitutes the placeholder and disabled fallback preserves existing unsubstituted placeholder behavior.
- Codex ran `pnpm check`; it passed.
- Codex clicked through the connection editor locally and verified the checkbox renders, can be checked, saved, and persists as `uploadPlaceholderOnMissingReference: true`.
- Container build was not run.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

UI change is a small checkbox in the existing ComfyUI local image defaults panel. Codex verified it through the local browser click-through; no screenshot is attached.
