### PR TITLE
Add gallery image generation feedback

### DIFF
--- a/packages/client/src/components/chat/ChatGallery.tsx
+++ b/packages/client/src/components/chat/ChatGallery.tsx
@@ -2,7 +2,18 @@
 // Chat Gallery — Image grid for per-chat generated images
 // ──────────────────────────────────────────────
 import { useState, useRef } from "react";
-import { ImagePlus, Paintbrush, Trash2, X, ZoomIn, Download, Sparkles, Pin, Minimize2 } from "lucide-react";
+import {
+  ImagePlus,
+  Paintbrush,
+  Trash2,
+  X,
+  ZoomIn,
+  Download,
+  Sparkles,
+  Pin,
+  Minimize2,
+  Loader2,
+} from "lucide-react";
 import {
   useGalleryImages,
   useUploadGalleryImage,
@@ -15,7 +26,7 @@ import { ImagePromptPanel } from "./ImagePromptPanel";
 interface ChatGalleryProps {
   chatId: string;
   /** Manually trigger the Illustrator agent */
-  onIllustrate?: () => void;
+  onIllustrate?: () => void | Promise<void>;
 }
 
 function formatImageMeta(image: ChatImage) {
@@ -33,7 +44,9 @@ export function ChatGallery({ chatId, onIllustrate }: ChatGalleryProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [lightbox, setLightbox] = useState<ChatImage | null>(null);
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+  const isIllustrating = useGalleryStore((s) => s.illustratingChatIds.has(chatId));
   const pinImage = useGalleryStore((s) => s.pinImage);
+  const setChatIllustrating = useGalleryStore((s) => s.setChatIllustrating);
   const lightboxPrompt = lightbox?.prompt.trim() ?? "";
   const lightboxMeta = lightbox ? formatImageMeta(lightbox) : "";
 
@@ -54,17 +67,41 @@ export function ChatGallery({ chatId, onIllustrate }: ChatGalleryProps) {
     if (lightbox?.id === id) setLightbox(null);
   };
 
+  const handleIllustrate = async () => {
+    if (!onIllustrate || useGalleryStore.getState().illustratingChatIds.has(chatId)) return;
+
+    setChatIllustrating(chatId, true);
+    try {
+      await onIllustrate();
+    } finally {
+      setChatIllustrating(chatId, false);
+    }
+  };
+
   return (
     <div className="flex flex-col gap-3 p-4">
       {/* Illustrate button */}
       {onIllustrate && (
         <button
-          onClick={onIllustrate}
-          className="flex items-center justify-center gap-2 rounded-xl bg-[var(--primary)]/15 px-4 py-3 text-xs font-medium text-[var(--primary)] transition-all hover:bg-[var(--primary)]/25"
+          type="button"
+          onClick={() => void handleIllustrate()}
+          disabled={isIllustrating}
+          aria-busy={isIllustrating}
+          className="flex items-center justify-center gap-2 rounded-xl bg-[var(--primary)]/15 px-4 py-3 text-xs font-medium text-[var(--primary)] transition-all hover:bg-[var(--primary)]/25 disabled:cursor-wait disabled:opacity-75"
         >
-          <Paintbrush size="1rem" />
-          Illustrate
+          {isIllustrating ? <Loader2 size="1rem" className="animate-spin" /> : <Paintbrush size="1rem" />}
+          {isIllustrating ? "Generating image..." : "Illustrate"}
         </button>
+      )}
+
+      {isIllustrating && (
+        <div
+          className="rounded-xl border border-[var(--primary)]/25 bg-[var(--primary)]/10 px-3 py-2 text-xs text-[var(--primary)]"
+          role="status"
+          aria-live="polite"
+        >
+          AI image generation is running. The new image will appear here when it finishes.
+        </div>
       )}
 
       {/* Upload button */}

--- a/packages/client/src/components/chat/ChatGallery.tsx
+++ b/packages/client/src/components/chat/ChatGallery.tsx
@@ -22,6 +22,7 @@ import {
 } from "../../hooks/use-gallery";
 import { useGalleryStore } from "../../stores/gallery.store";
 import { ImagePromptPanel } from "./ImagePromptPanel";
+import { toast } from "sonner";
 
 interface ChatGalleryProps {
   chatId: string;
@@ -73,6 +74,8 @@ export function ChatGallery({ chatId, onIllustrate }: ChatGalleryProps) {
     setChatIllustrating(chatId, true);
     try {
       await onIllustrate();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Image generation failed.");
     } finally {
       setChatIllustrating(chatId, false);
     }

--- a/packages/client/src/components/chat/ChatGalleryDrawer.tsx
+++ b/packages/client/src/components/chat/ChatGalleryDrawer.tsx
@@ -10,7 +10,7 @@ interface ChatGalleryDrawerProps {
   open: boolean;
   onClose: () => void;
   /** Manually trigger the Illustrator agent */
-  onIllustrate?: () => void;
+  onIllustrate?: () => void | Promise<void>;
 }
 
 export function ChatGalleryDrawer({ chat, open, onClose, onIllustrate }: ChatGalleryDrawerProps) {

--- a/packages/client/src/stores/gallery.store.ts
+++ b/packages/client/src/stores/gallery.store.ts
@@ -7,13 +7,17 @@ import type { ChatImage } from "../hooks/use-gallery";
 interface GalleryState {
   /** Images pinned to the chat area as floating overlays */
   pinnedImages: ChatImage[];
+  /** Chat IDs with an in-flight manual gallery illustration request. */
+  illustratingChatIds: Set<string>;
   pinImage: (image: ChatImage) => void;
   unpinImage: (imageId: string) => void;
   clearPinned: () => void;
+  setChatIllustrating: (chatId: string, illustrating: boolean) => void;
 }
 
 export const useGalleryStore = create<GalleryState>((set) => ({
   pinnedImages: [],
+  illustratingChatIds: new Set(),
 
   pinImage: (image) =>
     set((s) => (s.pinnedImages.some((p) => p.id === image.id) ? s : { pinnedImages: [...s.pinnedImages, image] })),
@@ -21,4 +25,12 @@ export const useGalleryStore = create<GalleryState>((set) => ({
   unpinImage: (imageId) => set((s) => ({ pinnedImages: s.pinnedImages.filter((p) => p.id !== imageId) })),
 
   clearPinned: () => set({ pinnedImages: [] }),
+
+  setChatIllustrating: (chatId, illustrating) =>
+    set((s) => {
+      const next = new Set(s.illustratingChatIds);
+      if (illustrating) next.add(chatId);
+      else next.delete(chatId);
+      return { illustratingChatIds: next };
+    }),
 }));


### PR DESCRIPTION
<!-- Target branch: `staging`. The default base in this UI is `main` (release branch). -->
<!-- Change the base to `staging` before submitting unless this is a maintainer-approved mainline change. -->
<!-- See CONTRIBUTING.md § Branches. -->

## Linked issue

No linked issue. Requested directly in Codex; an issue should be opened before submission if required.

## Why this change

- When users click the gallery Illustrate button, the drawer did not show clear in-progress feedback while AI image generation was running.

## What changed

- Added a spinner, disabled state, and "Generating image..." label to the gallery Illustrate button while generation is pending.
- Added an accessible live status message explaining that AI image generation is running.
- Stored pending illustration state per chat so closing and reopening the gallery keeps the feedback and prevents duplicate clicks.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Codex ran `pnpm check` successfully in a clean worktree based on `upstream/staging`.
- Codex ran a local Playwright remount proof: start gallery image generation, hide the gallery, show it again, confirm "Generating image..." remains visible, confirm the status message remains visible, and confirm duplicate illustration calls are blocked.
- Bunny review passed for the current diff before opening this PR.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

No GitHub-rendered screenshot is attached. Codex captured local proof during the Playwright remount run; reviewers should manually verify the gallery loading feedback in-browser if visual confirmation is needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Illustration feature now supports asynchronous operations with improved user feedback.
  * Added loading spinner and status message during illustration generation.
  * "Illustrate" button is disabled during generation, preventing accidental re-triggering.
  * Enhanced per-chat illustration state tracking for accurate status display.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/988?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->