### PR TITLE
fix: clear TTS credentials when clearing connections

### DIFF
--- a/packages/server/src/routes/admin.routes.ts
+++ b/packages/server/src/routes/admin.routes.ts
@@ -2,10 +2,10 @@
 // Routes: Admin (clear data, maintenance)
 // ──────────────────────────────────────────────
 import type { FastifyInstance, FastifyReply } from "fastify";
-import { ne } from "drizzle-orm";
+import { eq, ne } from "drizzle-orm";
 import { existsSync, readdirSync, rmSync } from "fs";
 import { join } from "path";
-import { PROFESSOR_MARI_ID } from "@marinara-engine/shared";
+import { PROFESSOR_MARI_ID, TTS_SETTINGS_KEY } from "@marinara-engine/shared";
 import { DATA_DIR } from "../utils/data-dir.js";
 import * as schema from "../db/schema/index.js";
 import { requirePrivilegedAccess } from "../middleware/privileged-gate.js";
@@ -110,6 +110,9 @@ export async function adminRoutes(app: FastifyInstance) {
 
     if (requestedScopes.includes("connections")) {
       await runDelete("api_connections", () => db.delete(schema.apiConnections).run());
+      await runDelete("app_settings", () =>
+        db.delete(schema.appSettings).where(eq(schema.appSettings.key, TTS_SETTINGS_KEY)).run(),
+      );
     }
 
     if (requestedScopes.includes("automation")) {

--- a/packages/server/test/admin-routes.test.ts
+++ b/packages/server/test/admin-routes.test.ts
@@ -1,0 +1,89 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import Fastify, { type FastifyInstance } from "fastify";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { TTS_SETTINGS_KEY } from "@marinara-engine/shared";
+import { createFileNativeDB } from "../src/db/file-backed-store.js";
+import { createAppSettingsStorage } from "../src/services/storage/app-settings.storage.js";
+
+type EnvPatch = Record<string, string | undefined>;
+
+function withEnv<T>(patch: EnvPatch, fn: () => Promise<T>) {
+  const previous = new Map<string, string | undefined>();
+  for (const key of Object.keys(patch)) {
+    previous.set(key, process.env[key]);
+    const value = patch[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+
+  return fn().finally(() => {
+    for (const [key, value] of previous) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+}
+
+async function withAdminApp<T>(fn: (app: FastifyInstance) => Promise<T>): Promise<T> {
+  const root = mkdtempSync(join(tmpdir(), "marinara-admin-routes-"));
+
+  return withEnv(
+    {
+      ADMIN_SECRET: undefined,
+      DATA_DIR: join(root, "data"),
+      FILE_STORAGE_DIR: join(root, "storage"),
+      MARINARA_REQUIRE_ADMIN_SECRET_ON_LOOPBACK: undefined,
+    },
+    async () => {
+      const { adminRoutes } = await import("../src/routes/admin.routes.js");
+      const db = await createFileNativeDB();
+      const app = Fastify({ logger: false });
+      app.decorate("db", db);
+      await app.register(adminRoutes, { prefix: "/api/admin" });
+      await app.ready();
+
+      try {
+        return await fn(app);
+      } finally {
+        await app.close();
+        await db._fileStore.close();
+        rmSync(root, { recursive: true, force: true });
+      }
+    },
+  );
+}
+
+test("clearing connections removes saved TTS settings", async () =>
+  withAdminApp(async (app) => {
+    const settings = createAppSettingsStorage(app.db);
+    const savedTtsConfig = JSON.stringify({
+      enabled: true,
+      source: "openai",
+      apiKey: "encrypted-test-key",
+    });
+
+    await settings.set(TTS_SETTINGS_KEY, savedTtsConfig);
+    const expunge = await app.inject({
+      method: "POST",
+      url: "/api/admin/expunge",
+      remoteAddress: "127.0.0.1",
+      payload: { confirm: true, scopes: ["connections"] },
+    });
+
+    assert.equal(expunge.statusCode, 200, expunge.body);
+    assert.equal(await settings.get(TTS_SETTINGS_KEY), null);
+
+    await settings.set(TTS_SETTINGS_KEY, savedTtsConfig);
+    const clearAll = await app.inject({
+      method: "POST",
+      url: "/api/admin/clear-all",
+      remoteAddress: "127.0.0.1",
+      payload: { confirm: true },
+    });
+
+    assert.equal(clearAll.statusCode, 200, clearAll.body);
+    assert.equal(await settings.get(TTS_SETTINGS_KEY), null);
+  }));


### PR DESCRIPTION
## Linked issue

Closes #995

## Why this change

TTS appears in the Connections panel and stores a provider API key, but its config is stored in `app_settings` instead of normal `api_connections`.

Clearing Connections and Clear All Data removed normal API connections while leaving the saved TTS key behind. That meant TTS could still show a saved key and use the old provider credential after the user cleared connection data.

## What changed

- Clear saved TTS credential material when Connections data is cleared.
- Cover Clear All Data through the same cleanup.
- Keep normal API connection cleanup behavior unchanged.
- Leave unrelated app settings unchanged.
- Add a server regression test for clearing saved TTS settings through both affected clear paths.

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `pnpm --filter @marinara-engine/server exec tsx --test test/admin-routes.test.ts` passed.
- `pnpm --filter @marinara-engine/server exec tsx --test test/*.test.ts` passed.
- `pnpm --filter @marinara-engine/server lint` passed.
- `pnpm --filter @marinara-engine/server build` passed.
- The internal testing suite check also passed: after both clear paths, TTS no longer reported a saved key and post-clear speech requests did not send the old Authorization bearer token.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)
