### PR TITLE
ci: add staging issue status labels

### DIFF
--- a/.github/workflows/issue-status-from-prs.yml
+++ b/.github/workflows/issue-status-from-prs.yml
@@ -1,0 +1,198 @@
+name: Issue Status From Pull Requests
+
+on:
+  pull_request_target:
+    types: [opened, reopened, edited, synchronize, closed]
+    branches: [staging]
+
+concurrency:
+  group: issue-status-from-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  update-linked-issues:
+    name: Update linked issue status
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: read
+    steps:
+      - name: Label linked issues
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            const labels = {
+              'in-pr': {
+                color: '1d76db',
+                description: 'Has an open pull request targeting staging',
+              },
+              'fixed-in-staging': {
+                color: '0e8a16',
+                description: 'Already fixed in staging and is pending closure when staging is merged to main',
+              },
+            };
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pr = context.payload.pull_request;
+            const targetsStaging = pr.base?.ref === 'staging';
+            const closingLinePattern = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)(?:[^.\n]*)/gi;
+            const issueReferencePattern = /(?:(?<owner>[\w.-]+)\/(?<repo>[\w.-]+))?#(?<number>\d+)/g;
+
+            function linkedIssueNumbers(body) {
+              const issueNumbers = new Set();
+
+              for (const closingLine of String(body || '').matchAll(closingLinePattern)) {
+                for (const issueReference of closingLine[0].matchAll(issueReferencePattern)) {
+                  const referencedOwner = issueReference.groups.owner;
+                  const referencedRepo = issueReference.groups.repo;
+
+                  if (
+                    referencedOwner &&
+                    (
+                      referencedOwner.toLowerCase() !== owner.toLowerCase() ||
+                      referencedRepo.toLowerCase() !== repo.toLowerCase()
+                    )
+                  ) {
+                    continue;
+                  }
+
+                  issueNumbers.add(Number(issueReference.groups.number));
+                }
+              }
+
+              return [...issueNumbers];
+            }
+
+            async function ensureLabel(name) {
+              const opts = { owner, repo };
+              try {
+                await github.rest.issues.createLabel({ ...opts, name, ...labels[name] });
+              } catch (error) {
+                if (error.status === 422) {
+                  await github.rest.issues.updateLabel({ ...opts, name, ...labels[name] });
+                  return;
+                }
+                throw error;
+              }
+            }
+
+            async function addLabel(issue_number, label) {
+              await ensureLabel(label);
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number,
+                labels: [label],
+              });
+            }
+
+            async function removeLabel(issue_number, label) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number,
+                  name: label,
+                });
+              } catch (error) {
+                if (error.status !== 404) {
+                  throw error;
+                }
+              }
+            }
+
+            async function isOpenIssue(issue_number) {
+              try {
+                const response = await github.rest.issues.get({
+                  owner,
+                  repo,
+                  issue_number,
+                });
+
+                return !response.data.pull_request && response.data.state === 'open';
+              } catch (error) {
+                if (error.status === 404) {
+                  core.warning(`Skipping #${issue_number}: issue not found.`);
+                  return false;
+                }
+                throw error;
+              }
+            }
+
+            async function hasOtherOpenStagingPr(issueNumber) {
+              const linkedIssues = await openStagingPrIssueNumbers();
+
+              return linkedIssues.has(issueNumber);
+            }
+
+            async function openStagingPrIssueNumbers() {
+              const openPulls = await github.paginate(github.rest.pulls.list, {
+                owner,
+                repo,
+                state: 'open',
+                base: 'staging',
+                per_page: 100,
+              });
+
+              const issueNumbers = new Set();
+
+              for (const openPr of openPulls) {
+                for (const issueNumber of linkedIssueNumbers(openPr.body)) {
+                  issueNumbers.add(issueNumber);
+                }
+              }
+
+              return issueNumbers;
+            }
+
+            async function openIssuesWithLabel(label) {
+              const issues = await github.paginate(github.rest.issues.listForRepo, {
+                owner,
+                repo,
+                state: 'open',
+                labels: label,
+                per_page: 100,
+              });
+
+              return issues.filter((issue) => !issue.pull_request);
+            }
+
+            const issues = linkedIssueNumbers(pr.body);
+
+            if (!issues.length) {
+              core.info('No closing issue references found in the pull request body.');
+            } else if (!targetsStaging) {
+              core.info('Pull request does not target staging; only reconciling existing in-pr labels.');
+            } else {
+              for (const issueNumber of issues) {
+                if (!(await isOpenIssue(issueNumber))) {
+                  core.info(`Skipping #${issueNumber}: not an open issue.`);
+                  continue;
+                }
+
+                if (pr.state === 'closed') {
+                  if (pr.merged) {
+                    await addLabel(issueNumber, 'fixed-in-staging');
+                  }
+
+                  if (!(await hasOtherOpenStagingPr(issueNumber))) {
+                    await removeLabel(issueNumber, 'in-pr');
+                  }
+
+                  continue;
+                }
+
+                await addLabel(issueNumber, 'in-pr');
+              }
+            }
+
+            await ensureLabel('in-pr');
+            const activeOpenPrIssues = await openStagingPrIssueNumbers();
+            const inPrIssues = await openIssuesWithLabel('in-pr');
+
+            for (const issue of inPrIssues) {
+              if (!activeOpenPrIssues.has(issue.number)) {
+                await removeLabel(issue.number, 'in-pr');
+              }
+            }

--- a/.github/workflows/issue-status-from-prs.yml
+++ b/.github/workflows/issue-status-from-prs.yml
@@ -120,12 +120,6 @@ jobs:
               }
             }
 
-            async function hasOtherOpenStagingPr(issueNumber) {
-              const linkedIssues = await openStagingPrIssueNumbers();
-
-              return linkedIssues.has(issueNumber);
-            }
-
             async function openStagingPrIssueNumbers() {
               const openPulls = await github.paginate(github.rest.pulls.list, {
                 owner,
@@ -165,6 +159,8 @@ jobs:
             } else if (!targetsStaging) {
               core.info('Pull request does not target staging; only reconciling existing in-pr labels.');
             } else {
+              const openStagingPrIssues = pr.state === 'closed' ? await openStagingPrIssueNumbers() : new Set();
+
               for (const issueNumber of issues) {
                 if (!(await isOpenIssue(issueNumber))) {
                   core.info(`Skipping #${issueNumber}: not an open issue.`);
@@ -176,7 +172,7 @@ jobs:
                     await addLabel(issueNumber, 'fixed-in-staging');
                   }
 
-                  if (!(await hasOtherOpenStagingPr(issueNumber))) {
+                  if (!openStagingPrIssues.has(issueNumber)) {
                     await removeLabel(issueNumber, 'in-pr');
                   }
 


### PR DESCRIPTION
## Linked issue

Related: #979, #980, #981

## Why this change

- Issues #979, #980, and #981 were fixed by PRs merged into `staging`, but they did not receive the `fixed-in-staging` label.
- The status workflow existed only on the staging-side branch, while `pull_request_target` runs from the base repository's default-branch context.
- The draft workflow also used a `staging` label name even though the repository's real status label is `fixed-in-staging`.

## What changed

- Added the issue-status workflow on `main`, where GitHub can load it for `pull_request_target` events.
- Scoped the workflow to pull requests targeting `staging`.
- Made merged staging PRs add `fixed-in-staging` and keep `in-pr` cleanup behavior for open staging PRs.
- Backfilled `fixed-in-staging` manually on #979, #980, and #981 because their already-merged PR events cannot replay.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Codex ran `node scratch\issue-status-label-repro.mjs`; it passes and confirms the workflow has the `pull_request_target` staging trigger, defines `fixed-in-staging`, adds `fixed-in-staging` on merged PRs, and does not use the legacy `staging` label.
- Codex ran `pnpm exec prettier --check .github/workflows/issue-status-from-prs.yml`; it passed.
- Codex ran `pnpm check`; it passed after installing dependencies in the clean worktree.
- Codex verified #979, #980, and #981 now have the `fixed-in-staging` label on GitHub.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No app docs, release metadata, schema, dependency, auth, storage, or prompt-pipeline changes.

## UI evidence (if applicable)

N/A - GitHub Actions workflow/status-label automation only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated workflow to sync pull request and issue statuses, improving development process tracking and issue label management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/997?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->