### PR TITLE
fix: add global agent enable/disable toggle and gate chat settings on active agents

### DIFF
--- a/.github/workflows/issue-status-from-prs.yml
+++ b/.github/workflows/issue-status-from-prs.yml
@@ -120,12 +120,6 @@ jobs:
               }
             }
 
-            async function hasOtherOpenStagingPr(issueNumber) {
-              const linkedIssues = await openStagingPrIssueNumbers();
-
-              return linkedIssues.has(issueNumber);
-            }
-
             async function openStagingPrIssueNumbers() {
               const openPulls = await github.paginate(github.rest.pulls.list, {
                 owner,
@@ -165,6 +159,8 @@ jobs:
             } else if (!targetsStaging) {
               core.info('Pull request does not target staging; only reconciling existing in-pr labels.');
             } else {
+              const openStagingPrIssues = pr.state === 'closed' ? await openStagingPrIssueNumbers() : new Set();
+
               for (const issueNumber of issues) {
                 if (!(await isOpenIssue(issueNumber))) {
                   core.info(`Skipping #${issueNumber}: not an open issue.`);
@@ -176,7 +172,7 @@ jobs:
                     await addLabel(issueNumber, 'fixed-in-staging');
                   }
 
-                  if (!(await hasOtherOpenStagingPr(issueNumber))) {
+                  if (!openStagingPrIssues.has(issueNumber)) {
                     await removeLabel(issueNumber, 'in-pr');
                   }
 

--- a/.github/workflows/issue-status-from-prs.yml
+++ b/.github/workflows/issue-status-from-prs.yml
@@ -3,6 +3,7 @@ name: Issue Status From Pull Requests
 on:
   pull_request_target:
     types: [opened, reopened, edited, synchronize, closed]
+    branches: [staging]
 
 concurrency:
   group: issue-status-from-pr-${{ github.event.pull_request.number }}
@@ -25,7 +26,7 @@ jobs:
                 color: '1d76db',
                 description: 'Has an open pull request targeting staging',
               },
-              staging: {
+              'fixed-in-staging': {
                 color: '0e8a16',
                 description: 'Already fixed in staging and is pending closure when staging is merged to main',
               },
@@ -172,7 +173,7 @@ jobs:
 
                 if (pr.state === 'closed') {
                   if (pr.merged) {
-                    await addLabel(issueNumber, 'staging');
+                    await addLabel(issueNumber, 'fixed-in-staging');
                   }
 
                   if (!(await hasOtherOpenStagingPr(issueNumber))) {

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -504,6 +504,7 @@ export function ChatSettingsDrawer({
     for (const a of BUILT_IN_AGENTS) {
       if (HIDDEN_ROLEPLAY_AGENTS.has(a.id)) continue;
       const existing = agentConfigsByType.get(a.id);
+      if (existing?.enabled === "false") continue;
       agents.push({
         id: a.id,
         name: existing?.name ?? a.name,
@@ -517,6 +518,7 @@ export function ChatSettingsDrawer({
     if (agentConfigs) {
       for (const c of agentConfigs as AgentConfigRow[]) {
         if (!BUILT_IN_AGENTS.some((b) => b.id === c.type)) {
+          if (c.enabled === "false") continue;
           agents.push({
             id: c.type,
             name: c.name,
@@ -566,6 +568,10 @@ export function ChatSettingsDrawer({
   const expressionEnabledByDefault = isEnabledFlag(expressionConfig?.enabled);
   const expressionActive =
     activeAgentIds.includes("expression") || (activeAgentIds.length === 0 && expressionEnabledByDefault);
+  const hapticConfig = agentConfigsByType.get("haptic") ?? null;
+  const hapticEnabledByDefault = isEnabledFlag(hapticConfig?.enabled);
+  const hapticActive =
+    activeAgentIds.includes("haptic") || (activeAgentIds.length === 0 && hapticEnabledByDefault);
   const lorebookKeeperTargetLorebookId =
     typeof metadata.lorebookKeeperTargetLorebookId === "string" ? metadata.lorebookKeeperTargetLorebookId : "";
   const lorebookKeeperReadBehindMessages = normalizeNonNegativeInteger(
@@ -3878,7 +3884,7 @@ export function ChatSettingsDrawer({
                   </div>
                 )}
 
-                {metadata.enableAgents && !isGame && (
+                {metadata.enableAgents && !isGame && lorebookKeeperActive && (
                   <div className="space-y-2 rounded-xl border border-[var(--border)] bg-[var(--secondary)]/70 p-3">
                     <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
                       <div className="min-w-0">
@@ -3960,7 +3966,7 @@ export function ChatSettingsDrawer({
                   </div>
                 )}
 
-                {metadata.enableAgents && !isGame && (
+                {metadata.enableAgents && !isGame && expressionActive && (
                   <div className="space-y-2 rounded-xl border border-[var(--border)] bg-[var(--secondary)]/70 p-3">
                     <div className="flex items-start gap-2">
                       <Image size="0.75rem" className="mt-0.5 text-[var(--primary)]" />
@@ -4196,7 +4202,7 @@ export function ChatSettingsDrawer({
                 )}
 
                 {/* Love Toys Control — not for game mode */}
-                {metadata.enableAgents && !isGame && (
+                {metadata.enableAgents && !isGame && hapticActive && (
                   <div className="space-y-1.5">
                     <button
                       onClick={() => {

--- a/packages/client/src/components/panels/AgentsPanel.tsx
+++ b/packages/client/src/components/panels/AgentsPanel.tsx
@@ -18,7 +18,7 @@ import {
   ToggleRight,
 } from "lucide-react";
 import { useUIStore } from "../../stores/ui.store";
-import { useAgentConfigs, useDeleteAgent, type AgentConfigRow } from "../../hooks/use-agents";
+import { useAgentConfigs, useDeleteAgent, useToggleAgent, type AgentConfigRow } from "../../hooks/use-agents";
 import { useCustomTools, useDeleteCustomTool, type CustomToolRow } from "../../hooks/use-custom-tools";
 import {
   useRegexScripts,
@@ -37,6 +37,7 @@ export function AgentsPanel() {
   const { data: customTools } = useCustomTools();
   const { data: regexScripts } = useRegexScripts();
   const deleteAgent = useDeleteAgent();
+  const toggleAgent = useToggleAgent();
   const deleteTool = useDeleteCustomTool();
   const deleteRegex = useDeleteRegexScript();
   const updateRegex = useUpdateRegexScript();
@@ -147,6 +148,10 @@ export function AgentsPanel() {
 
   const activeAgents = statusAgents.filter((agent) => agent.enabled);
   const inactiveAgents = statusAgents.filter((agent) => !agent.enabled);
+
+  const handleToggleAgent = (agentType: string) => {
+    toggleAgent.mutate(agentType);
+  };
 
   const handleCreateAgent = () => {
     // Create a new custom agent immediately in DB then open editor
@@ -388,7 +393,9 @@ export function AgentsPanel() {
               desc: "Utilities, combat, illustrations, and other helpers.",
             },
           ].map(({ category, title, icon, desc }) => {
-            const agents = BUILT_IN_AGENTS.filter((a) => a.category === category);
+            const agents = BUILT_IN_AGENTS.filter(
+              (a) => a.category === category && configByType.get(a.id)?.enabled !== "false",
+            );
             return (
               <PanelSection key={category} title={title} icon={icon}>
                 <div className="mb-1.5 text-[0.625rem] text-[var(--muted-foreground)]">{desc}</div>
@@ -404,15 +411,39 @@ export function AgentsPanel() {
                       name: agent.name,
                       description: agent.description,
                       category: agent.category,
-                      enabled: configByType.get(agent.id)?.enabled !== "false",
+                      enabled: true,
                       custom: false,
                       openAgentDetail,
+                      onToggleEnabled: handleToggleAgent,
                     }),
                   )
                 )}
               </PanelSection>
             );
           })}
+
+          {/* ── Disabled Built-in Agents ── */}
+          {(() => {
+            const disabled = BUILT_IN_AGENTS.filter((a) => configByType.get(a.id)?.enabled === "false");
+            if (!disabled.length) return null;
+            return (
+              <PanelSection title="Disabled Agents" icon={<Sparkles size="0.8125rem" />} defaultOpen={false}>
+                {disabled.map((agent) =>
+                  renderAgentCard({
+                    id: agent.id,
+                    type: agent.id,
+                    name: agent.name,
+                    description: agent.description,
+                    category: agent.category,
+                    enabled: false,
+                    custom: false,
+                    openAgentDetail,
+                    onToggleEnabled: handleToggleAgent,
+                  }),
+                )}
+              </PanelSection>
+            );
+          })()}
         </>
       ) : (
         <>
@@ -423,14 +454,14 @@ export function AgentsPanel() {
             {!activeAgents.length ? (
               <p className="px-1 py-2 text-[0.625rem] text-[var(--muted-foreground)]">No active agents.</p>
             ) : (
-              activeAgents.map((agent) => renderAgentCard({ ...agent, openAgentDetail }))
+              activeAgents.map((agent) => renderAgentCard({ ...agent, openAgentDetail, onToggleEnabled: handleToggleAgent }))
             )}
           </PanelSection>
           <PanelSection title="Disabled Agents" icon={<Sparkles size="0.8125rem" />}>
             {!inactiveAgents.length ? (
               <p className="px-1 py-2 text-[0.625rem] text-[var(--muted-foreground)]">No inactive agents.</p>
             ) : (
-              inactiveAgents.map((agent) => renderAgentCard({ ...agent, openAgentDetail }))
+              inactiveAgents.map((agent) => renderAgentCard({ ...agent, openAgentDetail, onToggleEnabled: handleToggleAgent }))
             )}
           </PanelSection>
         </>
@@ -581,6 +612,7 @@ function renderAgentCard({
   enabled,
   custom,
   openAgentDetail,
+  onToggleEnabled,
 }: {
   id: string;
   type: string;
@@ -590,13 +622,15 @@ function renderAgentCard({
   enabled: boolean;
   custom: boolean;
   openAgentDetail: (id: string) => void;
+  onToggleEnabled?: (agentType: string) => void;
 }) {
-  void enabled;
-
   return (
     <div
       key={id}
-      className="flex items-start gap-2.5 rounded-lg p-2 transition-colors hover:bg-[var(--sidebar-accent)]"
+      className={cn(
+        "flex items-start gap-2.5 rounded-lg p-2 transition-colors hover:bg-[var(--sidebar-accent)]",
+        !enabled && "opacity-55",
+      )}
     >
       <Sparkles size="0.875rem" className="mt-0.5 shrink-0 text-[var(--primary)]" />
       <button className="min-w-0 flex-1 text-left" onClick={() => openAgentDetail(custom ? id : type)}>
@@ -608,6 +642,15 @@ function renderAgentCard({
           {custom ? "custom" : category}
         </div>
       </button>
+      {onToggleEnabled && (
+        <button
+          className="mt-0.5 shrink-0 text-[var(--muted-foreground)] transition-colors hover:text-[var(--primary)]"
+          title={enabled ? "Disable agent" : "Enable agent"}
+          onClick={() => onToggleEnabled(type)}
+        >
+          {enabled ? <ToggleRight size="1rem" className="text-emerald-400" /> : <ToggleLeft size="1rem" />}
+        </button>
+      )}
       <button
         className="mt-0.5 shrink-0 text-[var(--muted-foreground)] transition-colors hover:text-[var(--primary)]"
         title="Edit agent"


### PR DESCRIPTION
## Linked issue

Closes #1008

## Why this change

- Users had no way to fully disable agents. The `useToggleAgent` hook and `PUT /agents/toggle/:agentType` server endpoint existed but were never wired to any UI button, so agents could not be moved into the "Disabled Agents" section.
- The only "disable" toggle in the agent editor controlled prompt injection (`Add as Prompt Section`), not whether the agent runs.
- Lorebook Keeper, Expression Engine Sprites, and Love Toys Control config sections always appeared in Chat Settings even when their backing agents were not active in the chat, which was confusing.

## What changed

- Wired `useToggleAgent` to a toggle button on every agent card in the Agents sidebar panel (both "By Category" and "By Status" views).
- In "By Category" view, disabled agents move out of their category into a dedicated "Disabled Agents" collapsible section (collapsed by default).
- Disabled agent cards render at reduced opacity with a grey toggle icon; enabled agents show a green toggle.
- Gated Lorebook Keeper, Expression Engine Sprites, and Love Toys Control chat settings sections on per-chat active state — they only appear after the user adds the agent to the chat.
- Filtered globally-disabled agents out of the per-chat agent picker so they cannot be added to a chat while disabled.
- Manual Trackers toggle remains always visible since it is a behavior flag, not agent-backed.

## Validation

- [x] `pnpm check` passes locally
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `pnpm check` passes (TypeScript, ESLint, full production build).
- Manually verified agent toggle buttons appear and work in both "By Category" and "By Status" views.
- Verified disabled agents move to the "Disabled Agents" section and re-enabling returns them to their category.
- Verified Lorebook Keeper, Expression Engine Sprites, and Love Toys Control sections only appear in Chat Settings when their agent is active in the chat.
- Verified globally-disabled agents do not appear in the per-chat agent picker.
- Verified Manual Trackers toggle remains visible regardless of agent state.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)