### PR TITLE
Fix llama sidecar context slot sizing

### DIFF
--- a/packages/server/src/services/sidecar/sidecar-launch-plan.ts
+++ b/packages/server/src/services/sidecar/sidecar-launch-plan.ts
@@ -3,6 +3,8 @@ export type LlamaStartupPlan = {
   label: string;
 };
 
+const LLAMA_SERVER_PARALLEL_SLOTS = 2;
+
 export function buildLlamaArgs(options: {
   modelPath: string;
   gpuLayers: number;
@@ -10,15 +12,17 @@ export function buildLlamaArgs(options: {
   contextSize: number;
   runtimeVariant: string;
 }): string[] {
+  // llama-server divides --ctx-size across --parallel slots; Marinara's setting is the per-request budget.
+  const totalContextSize = options.contextSize * LLAMA_SERVER_PARALLEL_SLOTS;
   const args = [
     "-m",
     options.modelPath,
     "--host",
     "127.0.0.1",
     "--parallel",
-    "2",
+    String(LLAMA_SERVER_PARALLEL_SLOTS),
     "--ctx-size",
-    String(options.contextSize),
+    String(totalContextSize),
     "--port",
     String(options.port),
   ];


### PR DESCRIPTION
<!-- Target branch: `staging`. The default base in this UI is `main` (release branch). -->
<!-- Change the base to `staging` before submitting unless this is a maintainer-approved mainline change. -->
<!-- See CONTRIBUTING.md § Branches. -->

## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #993

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- The bundled llama.cpp sidecar was launched with `--parallel 2 --ctx-size 8192`, which gives each llama-server slot only 4096 tokens. Tracker batches configured for an 8192-token local sidecar could still exceed the effective slot context and fail with 400 context-size errors.

## What changed

<!-- List the key changes in this PR -->

- Treat the sidecar `contextSize` setting as the per-request/slot budget.
- Scale the llama-server `--ctx-size` total by the configured parallel slot count so two slots each receive the requested context budget.
- Centralize the parallel slot count in the launch-plan helper so `--parallel` and `--ctx-size` stay in sync.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Machine proof: `pnpm --filter @marinara-engine/server exec tsx ../../scratch/issue-993-ctx-size-repro.ts before` reproduced the bug before the fix: `--parallel 2 --ctx-size 8192` produced an effective per-slot context of 4096.
- Machine proof: `pnpm --filter @marinara-engine/server exec tsx ../../scratch/issue-993-ctx-size-repro.ts after` passed after the fix: `--parallel 2 --ctx-size 16384` produced an effective per-slot context of 8192.
- Edge proof: the same scratch repro passed for 4096 context, 32768 context, and CPU/runtime `gpuLayers=0`.
- Baseline: `pnpm check` passed locally.
- Bunny: pre-PR Bunny review passed for the current diff.
- Optional affected-machine smoke: restart the downloaded b9222 Windows CUDA sidecar and confirm its slot log reports `n_ctx = 8192`. This needs the affected runtime/model/GPU setup; the launch-argument path is covered by the scratch proof above.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs, schema, dependency, or release/version files changed.

## UI evidence (if applicable)

N/A - server-side launch-argument fix; no UI surface changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized backend service initialization for improved parallel processing efficiency and resource management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1010?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->