### PR TITLE
Fix Claude subscription empty result fallback

### DIFF
--- a/docs/pr-evidence/issue-992/result-fallback-proof.svg
+++ b/docs/pr-evidence/issue-992/result-fallback-proof.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1240" height="210" viewBox="0 0 1240 210">
+  <rect width="1240" height="210" fill="#111827"/>
+  <text x="32" y="36" class="title">Issue 992 Claude Subscription result fallback proof</text>
+  <text x="32" y="74" class="mono">packages\server\node_modules\.bin\tsx.cmd scratch\issue-992-claude-result-repro.ts</text>
+  <text x="32" y="114" class="pass">PASSED result-only success fallback: Hello from the SDK result field.</text>
+  <text x="32" y="146" class="pass">PASSED stream delta remains authoritative: Hello from a stream delta.</text>
+  <text x="32" y="178" class="pass">PASSED assistant block remains authoritative: Hello from an assistant block.</text>
+  <style>
+    .title { fill: #f9fafb; font: 700 20px ui-monospace, SFMono-Regular, Consolas, monospace; }
+    .mono { fill: #d1d5db; font: 15px ui-monospace, SFMono-Regular, Consolas, monospace; }
+    .pass { fill: #86efac; font: 16px ui-monospace, SFMono-Regular, Consolas, monospace; }
+  </style>
+</svg>

--- a/docs/pr-evidence/issue-992/result-fallback-proof.txt
+++ b/docs/pr-evidence/issue-992/result-fallback-proof.txt
@@ -1,0 +1,3 @@
+PASSED result-only success fallback: Hello from the SDK result field.
+PASSED stream delta remains authoritative: Hello from a stream delta.
+PASSED assistant block remains authoritative: Hello from an assistant block.

--- a/packages/server/src/services/llm/providers/claude-subscription.provider.ts
+++ b/packages/server/src/services/llm/providers/claude-subscription.provider.ts
@@ -186,6 +186,7 @@ export class ClaudeSubscriptionProvider extends BaseLLMProvider {
     let outputTokens = 0;
     let cachedTokens = 0;
     let cacheWriteTokens = 0;
+    let emittedText = false;
 
     try {
       const queryHandle = query({ prompt, options: sdkOptions });
@@ -199,6 +200,7 @@ export class ClaudeSubscriptionProvider extends BaseLLMProvider {
           if (event.type === "content_block_delta" && event.delta) {
             if (event.delta.type === "text_delta" && event.delta.text) {
               yield event.delta.text;
+              emittedText = true;
             } else if (event.delta.type === "thinking_delta" && event.delta.thinking && options.onThinking) {
               options.onThinking(event.delta.thinking);
             }
@@ -210,6 +212,7 @@ export class ClaudeSubscriptionProvider extends BaseLLMProvider {
           for (const block of blocks) {
             if (block.type === "text" && block.text) {
               yield block.text;
+              emittedText = true;
             } else if (block.type === "thinking" && block.thinking && options.onThinking) {
               options.onThinking(block.thinking);
             }
@@ -244,6 +247,11 @@ export class ClaudeSubscriptionProvider extends BaseLLMProvider {
                 fastModeState,
                 options.model,
               );
+            }
+            const finalResult = typeof message.result === "string" ? message.result : "";
+            if (!emittedText && finalResult.trim()) {
+              yield finalResult;
+              emittedText = true;
             }
           } else {
             const detail = message.errors?.length ? ` — ${message.errors.join("; ")}` : "";


### PR DESCRIPTION
<!-- Target branch: `staging`. The default base in this UI is `main` (release branch). -->
<!-- Change the base to `staging` before submitting unless this is a maintainer-approved mainline change. -->
<!-- See CONTRIBUTING.md § Branches. -->

## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #992

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- Claude Subscription in Docker can report a successful Claude Agent SDK call while Marinara receives no emitted text, causing Send Test Message to show an empty response and RP chat to fail with "The AI returned an empty response."

## What changed

<!-- List the key changes in this PR -->

- Added a fallback in the Claude Subscription provider that emits the SDK success `result` text when no stream delta or assistant block has already emitted text.
- Kept stream deltas and assistant blocks authoritative so the final SDK `result` is not duplicated during normal streaming or non-streaming responses.
- Added scoped PR evidence for the scratch repro under `docs/pr-evidence/issue-992/`.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Codex reproduced the broken provider path before the fix with `packages\server\node_modules\.bin\tsx.cmd scratch\issue-992-claude-result-repro.ts`: a fake Claude Agent SDK yielded a successful result-only response, and Marinara emitted an empty string.
- After the fix, the same scratch repro passed:
  - result-only success fallback emits `Hello from the SDK result field.`
  - stream delta remains authoritative and does not duplicate final result text
  - assistant block remains authoritative and does not duplicate final result text
- Codex ran `pnpm check`; it passed.
- Raw proof: https://raw.githubusercontent.com/cha1latte/Marinara-Engine/7d518bc85f102068dcd302436fec3364274493ff/docs/pr-evidence/issue-992/result-fallback-proof.txt
- Manual verification still needed before marking ready: run the original Docker + `claude login` flow from #992 with a real Claude subscription session, because Codex does not have the reporter's Docker OAuth environment or Claude subscription credentials.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No user-facing docs or release metadata changed. The only `docs/` files added are PR evidence artifacts.

## UI evidence (if applicable)

Not a UI change. Command-harness proof:

![Issue 992 Claude Subscription result fallback proof](https://raw.githubusercontent.com/cha1latte/Marinara-Engine/7d518bc85f102068dcd302436fec3364274493ff/docs/pr-evidence/issue-992/result-fallback-proof.svg)
