### PR TITLE
Fix Chub browser import card data

### DIFF
--- a/packages/client/src/components/bot-browser/BotBrowserView.tsx
+++ b/packages/client/src/components/bot-browser/BotBrowserView.tsx
@@ -35,6 +35,7 @@ import { useUIStore } from "../../stores/ui.store";
 import { toast } from "sonner";
 import { cn } from "../../lib/utils";
 import { confirmEmbeddedLorebookImport, readEmbeddedLorebookFromCharacterPayload } from "../../lib/character-import";
+import { mergeChubDetailIntoCharacterJson } from "../../lib/chub-character-card";
 
 // ════════════════════════════════════════════════
 // Types
@@ -126,8 +127,12 @@ interface CardDetail {
   exampleDialogs?: string;
   alternateGreetings?: string[];
   creatorNotes?: string;
+  systemPrompt?: string;
+  postHistoryInstructions?: string;
+  characterVersion?: string;
   hasLorebook?: boolean;
   embeddedLorebook?: unknown;
+  extensions?: Record<string, unknown>;
   extra?: { title: string; content: string }[];
 }
 
@@ -177,6 +182,18 @@ function attachEmbeddedLorebookToCharacterJson(raw: Record<string, unknown>, emb
   }
 
   return cloned;
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function optionalStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.map(String) : [];
+}
+
+function optionalRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : undefined;
 }
 
 // ════════════════════════════════════════════════
@@ -416,15 +433,19 @@ const chubProvider: ProviderConfig = {
     if (!node) return null;
     const def = node.definition || {};
     return {
-      description: def.personality || undefined,
-      personality: def.tavern_personality || undefined,
-      scenario: def.scenario || undefined,
-      firstMessage: def.first_message || undefined,
-      exampleDialogs: def.example_dialogs || undefined,
-      alternateGreetings: def.alternate_greetings || [],
-      creatorNotes: def.description || undefined,
+      description: optionalString(def.personality),
+      personality: optionalString(def.tavern_personality),
+      scenario: optionalString(def.scenario),
+      firstMessage: optionalString(def.first_message),
+      exampleDialogs: optionalString(def.example_dialogs),
+      alternateGreetings: optionalStringArray(def.alternate_greetings),
+      creatorNotes: optionalString(def.description),
+      systemPrompt: optionalString(def.system_prompt),
+      postHistoryInstructions: optionalString(def.post_history_instructions),
+      characterVersion: optionalString(def.character_version),
       hasLorebook: !!def.embedded_lorebook,
       embeddedLorebook: def.embedded_lorebook,
+      extensions: optionalRecord(def.extensions),
     };
   },
   importCard: async () => {},
@@ -1514,10 +1535,18 @@ export function BotBrowserView() {
         const file = new File([blob], "character.png", { type: "image/png" });
         const { json, imageDataUrl } = await parsePngCharacterCard(file);
         const cardDetail = sourceId === "chub" ? (detail ?? (await provider.fetchDetail(card))) : detail;
-        const importJson = attachEmbeddedLorebookToCharacterJson(
+        const importJsonWithLorebook = attachEmbeddedLorebookToCharacterJson(
           json as Record<string, unknown>,
           cardDetail?.embeddedLorebook,
         );
+        const importJson =
+          sourceId === "chub"
+            ? mergeChubDetailIntoCharacterJson(
+                importJsonWithLorebook,
+                { name: card.name, creator: card.creator, tags: card.tags },
+                cardDetail,
+              )
+            : importJsonWithLorebook;
         const importEmbeddedLorebook = confirmEmbeddedLorebookImport(
           card.name,
           cardDetail?.embeddedLorebook ?? readEmbeddedLorebookFromCharacterPayload(importJson),

--- a/packages/client/src/components/modals/BotBrowserModal.tsx
+++ b/packages/client/src/components/modals/BotBrowserModal.tsx
@@ -20,6 +20,7 @@ import { characterKeys } from "../../hooks/use-characters";
 import { lorebookKeys } from "../../hooks/use-lorebooks";
 import { parsePngCharacterCard } from "../../lib/png-parser";
 import { confirmEmbeddedLorebookImport, readEmbeddedLorebookFromCharacterPayload } from "../../lib/character-import";
+import { mergeChubDetailIntoCharacterJson } from "../../lib/chub-character-card";
 import { toast } from "sonner";
 
 interface Props {
@@ -58,6 +59,11 @@ interface ChubDefinition {
   example_dialogs: string;
   alternate_greetings: string[];
   embedded_lorebook?: unknown;
+  tavern_personality?: string;
+  system_prompt?: string;
+  post_history_instructions?: string;
+  character_version?: string;
+  extensions?: Record<string, unknown>;
 }
 
 interface ChubDetailNode extends ChubCard {
@@ -200,9 +206,33 @@ export function BotBrowserModal({ open, onClose }: Props) {
           cardDetail = rawDetail?.data?.node ?? rawDetail?.node ?? null;
         }
       }
-      const importJson = attachEmbeddedLorebookToCharacterJson(
+      const importJsonWithLorebook = attachEmbeddedLorebookToCharacterJson(
         json as Record<string, unknown>,
         cardDetail?.definition?.embedded_lorebook,
+      );
+      const importJson = mergeChubDetailIntoCharacterJson(
+        importJsonWithLorebook,
+        {
+          name: cardDetail?.name,
+          creator: fullPath.split("/")[0] ?? "",
+          tags: cardDetail?.topics ?? [],
+        },
+        cardDetail
+          ? {
+              description: cardDetail.definition?.personality,
+              personality: cardDetail.definition?.tavern_personality,
+              scenario: cardDetail.definition?.scenario,
+              firstMessage: cardDetail.definition?.first_message,
+              exampleDialogs: cardDetail.definition?.example_dialogs,
+              alternateGreetings: cardDetail.definition?.alternate_greetings ?? [],
+              creatorNotes: cardDetail.definition?.description,
+              systemPrompt: cardDetail.definition?.system_prompt,
+              postHistoryInstructions: cardDetail.definition?.post_history_instructions,
+              characterVersion: cardDetail.definition?.character_version,
+              embeddedLorebook: cardDetail.definition?.embedded_lorebook,
+              extensions: cardDetail.definition?.extensions,
+            }
+          : null,
       );
       const importEmbeddedLorebook = confirmEmbeddedLorebookImport(
         cardDetail?.name ?? "This character",

--- a/packages/client/src/lib/chub-character-card.ts
+++ b/packages/client/src/lib/chub-character-card.ts
@@ -1,0 +1,81 @@
+interface ChubImportSummary {
+  name?: string;
+  creator?: string;
+  tags?: string[];
+}
+
+export interface ChubImportDetail {
+  description?: string;
+  personality?: string;
+  scenario?: string;
+  firstMessage?: string;
+  exampleDialogs?: string;
+  alternateGreetings?: string[];
+  creatorNotes?: string;
+  systemPrompt?: string;
+  postHistoryInstructions?: string;
+  characterVersion?: string;
+  embeddedLorebook?: unknown;
+  extensions?: Record<string, unknown>;
+}
+
+function hasCharacterBookEntries(value: unknown): boolean {
+  if (!value || typeof value !== "object") return false;
+  const entries = (value as Record<string, unknown>).entries;
+  if (Array.isArray(entries)) return entries.length > 0;
+  return !!entries && typeof entries === "object" && Object.keys(entries).length > 0;
+}
+
+function setStringField(target: Record<string, unknown>, field: string, value: string | undefined) {
+  if (value !== undefined) target[field] = value;
+}
+
+function getCharacterDataTarget(raw: Record<string, unknown>) {
+  const cloned: Record<string, unknown> = { ...raw };
+  const target =
+    (cloned.spec === "chara_card_v2" || cloned.spec === "chara_card_v3") &&
+    cloned.data &&
+    typeof cloned.data === "object"
+      ? { ...(cloned.data as Record<string, unknown>) }
+      : cloned;
+
+  if (target !== cloned) cloned.data = target;
+  return { cloned, target };
+}
+
+export function mergeChubDetailIntoCharacterJson(
+  raw: Record<string, unknown>,
+  summary: ChubImportSummary,
+  detail: ChubImportDetail | null | undefined,
+) {
+  if (!detail) return raw;
+
+  const { cloned, target } = getCharacterDataTarget(raw);
+
+  setStringField(target, "description", detail.description);
+  setStringField(target, "personality", detail.personality);
+  setStringField(target, "scenario", detail.scenario);
+  setStringField(target, "first_mes", detail.firstMessage);
+  setStringField(target, "mes_example", detail.exampleDialogs);
+  setStringField(target, "creator_notes", detail.creatorNotes);
+  setStringField(target, "system_prompt", detail.systemPrompt);
+  setStringField(target, "post_history_instructions", detail.postHistoryInstructions);
+  setStringField(target, "character_version", detail.characterVersion);
+
+  if (summary.name) target.name = summary.name;
+  if (summary.creator !== undefined) target.creator = summary.creator;
+  if (summary.tags) target.tags = summary.tags;
+  if (detail.alternateGreetings) target.alternate_greetings = detail.alternateGreetings;
+
+  if (detail.extensions) {
+    const currentExtensions =
+      target.extensions && typeof target.extensions === "object" ? (target.extensions as Record<string, unknown>) : {};
+    target.extensions = { ...currentExtensions, ...detail.extensions };
+  }
+
+  if (!target.character_book && hasCharacterBookEntries(detail.embeddedLorebook)) {
+    target.character_book = detail.embeddedLorebook;
+  }
+
+  return cloned;
+}


### PR DESCRIPTION
<!-- Target branch: `staging`. The default base in this UI is `main` (release branch). -->
<!-- Change the base to `staging` before submitting unless this is a maintainer-approved mainline change. -->
<!-- See CONTRIBUTING.md § Branches. -->

## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #1007

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- Chub browser imports could use stale/reduced PNG card metadata even when Chub's detail API had the full current V2 card fields, causing imported characters to miss long description, first message, post-history instructions, and other card data compared with the source preview.

## What changed

<!-- List the key changes in this PR -->

- Added a Chub card merge helper that applies Chub detail API fields over the downloaded PNG/card payload while preserving the PNG avatar and wrapped V2/V3 card shape.
- Updated the full bot browser import path to fetch and merge Chub detail fields before posting to the standard ST character importer.
- Updated the legacy browser modal path to use the same merge helper so both Chub import surfaces preserve the same detail fields.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Codex reproduced the source mismatch with `node scratch/repro-issue-1007-chub-import.mjs`: the live Chub example's static PNG path had description length 128, first message length 4, and post-history instructions length 0, while Chub's detail API had description length 9666, first message length 1769, and post-history instructions length 6494.
- Codex verified the fix with `packages\server\node_modules\.bin\tsx.cmd scratch/verify-issue-1007-chub-import.ts`: the production merge helper restored the Chub detail API field lengths over the stale PNG payload and passed edge cases for missing detail, wrapped V2 cards, and embedded lorebook fill-in.
- Codex ran `pnpm check`; it passed `impeccable:check`, lint, and shared/server/client builds.
- No true human-only blocker remains for the core claim. A human should still manually try one Chub browser import before merge because the source report was a user-facing import flow.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

Docs/release note: no docs, schema, dependency, or version files changed.

## UI evidence (if applicable)

Not applicable. This is a data import mapping fix; proof is the before/after Chub import field-length verifier above.
