### PR TITLE
Fix profile export fallback for large assets

### DIFF
--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -80,6 +80,7 @@ import { TrackerCardColorSettings } from "./settings/TrackerCardColorSettings";
 import { DraftNumberInput } from "../ui/DraftNumberInput";
 import { ExportFormatDialog, type ExportFormatChoice } from "../ui/ExportFormatDialog";
 import { inspectCharacterFilesForEmbeddedLorebooks } from "../../lib/character-import";
+import { showConfirmDialog } from "../../lib/app-dialogs";
 
 type CustomFontFace = {
   filename: string;
@@ -2895,6 +2896,12 @@ type ProfileImportStats = {
   files?: number;
 };
 
+type ProfileImportWarning = {
+  type?: string;
+  path?: string;
+  message?: string;
+};
+
 type ProfileImportProgressData = {
   phase: string;
   label: string;
@@ -2911,13 +2918,23 @@ type ProfileImportProgressState = {
   startedAt: number;
   elapsedSeconds: number;
   imported?: ProfileImportStats;
+  warnings?: ProfileImportWarning[];
   error?: string;
 };
 
 type ProfileImportStreamEvent =
   | { type: "started"; data?: { label?: string; totalItems?: number } }
   | { type: "progress"; data?: ProfileImportProgressData }
-  | { type: "done"; data?: { success?: boolean; imported?: ProfileImportStats; error?: string; message?: string } }
+  | {
+      type: "done";
+      data?: {
+        success?: boolean;
+        imported?: ProfileImportStats;
+        warnings?: ProfileImportWarning[];
+        error?: string;
+        message?: string;
+      };
+    }
   | { type: "error"; data?: string | { error?: string; message?: string } };
 
 function formatProfileImportDuration(seconds: number) {
@@ -2971,6 +2988,79 @@ function getProfileImportErrorMessage(data: unknown) {
     if (typeof record.error === "string") return record.error;
   }
   return "Unknown error";
+}
+
+function normalizeProfileImportWarnings(warnings: unknown): ProfileImportWarning[] {
+  if (!Array.isArray(warnings)) return [];
+  return warnings.flatMap((warning) => {
+    if (!warning || typeof warning !== "object") return [];
+    const record = warning as { type?: unknown; path?: unknown; message?: unknown };
+    const path = typeof record.path === "string" ? record.path : undefined;
+    const message = typeof record.message === "string" ? record.message : undefined;
+    const type = typeof record.type === "string" ? record.type : undefined;
+    if (!path && !message) return [];
+    return [{ type, path, message }];
+  });
+}
+
+function formatProfileImportWarningSummary(warnings: ProfileImportWarning[]) {
+  const missingAssets = warnings.filter((warning) => warning.type === "missing_asset" || warning.path);
+  if (missingAssets.length > 0) {
+    return `${missingAssets.length} asset file${missingAssets.length === 1 ? "" : "s"} missing from the ZIP. Imported the rest.`;
+  }
+  return `${warnings.length} import warning${warnings.length === 1 ? "" : "s"}.`;
+}
+
+function formatProfileImportWarningDetails(warnings: ProfileImportWarning[]) {
+  const paths = warnings.map((warning) => warning.path).filter((path): path is string => !!path);
+  if (paths.length === 0) return warnings[0]?.message ?? "";
+  const visible = paths.slice(0, 3).join(", ");
+  const extra = paths.length > 3 ? `, +${paths.length - 3} more` : "";
+  return `Missing: ${visible}${extra}`;
+}
+
+function getDownloadFilename(res: Response, fallback: string) {
+  const disposition = res.headers.get("Content-Disposition");
+  const match = disposition?.match(/filename="?([^";\n]+)"?/);
+  return match?.[1] ? decodeURIComponent(match[1]) : fallback;
+}
+
+type ProfileExportFailure = {
+  code?: string;
+  message: string;
+  fallbackFormat?: string;
+};
+
+async function readProfileExportFailure(res: Response, fallback: string): Promise<ProfileExportFailure> {
+  const contentType = res.headers.get("content-type") ?? "";
+
+  try {
+    if (contentType.includes("application/json")) {
+      const payload = (await res.json()) as {
+        code?: unknown;
+        error?: unknown;
+        message?: unknown;
+        fallbackFormat?: unknown;
+      };
+      const message = typeof payload.message === "string" ? payload.message : payload.error;
+      return {
+        code: typeof payload.code === "string" ? payload.code : undefined,
+        fallbackFormat: typeof payload.fallbackFormat === "string" ? payload.fallbackFormat : undefined,
+        message: typeof message === "string" && message.trim() ? message : fallback,
+      };
+    }
+
+    const text = (await res.text()).trim();
+    return { message: text ? text.slice(0, 500) : fallback };
+  } catch {
+    return { message: fallback };
+  }
+}
+
+async function isZipFile(file: File) {
+  if (file.size < 2) return false;
+  const head = new Uint8Array(await file.slice(0, 2).arrayBuffer());
+  return head[0] === 0x50 && head[1] === 0x4b;
 }
 
 async function* readProfileImportStream(res: Response): AsyncGenerator<ProfileImportStreamEvent> {
@@ -3078,39 +3168,46 @@ function ImportSettings() {
       elapsedSeconds: 0,
     });
     try {
-      const text = await file.text();
-      const envelope = JSON.parse(text) as { type?: string };
-      if (envelope.type !== "marinara_profile") {
-        setProfileImportProgress({
-          status: "error",
-          label: "Profile import failed",
-          completedItems: 0,
-          totalItems: 1,
-          startedAt,
-          elapsedSeconds: Math.floor((Date.now() - startedAt) / 1000),
-          error: "Not a valid profile export file.",
-        });
-        toast.error("Not a valid profile export file.");
-        return;
+      const isZip = await isZipFile(file);
+      let body: BodyInit;
+      if (isZip) {
+        const form = new FormData();
+        form.append("file", file, file.name);
+        body = form;
+      } else {
+        const text = await file.text();
+        const envelope = JSON.parse(text) as { type?: string };
+        if (envelope.type !== "marinara_profile") {
+          setProfileImportProgress({
+            status: "error",
+            label: "Profile import failed",
+            completedItems: 0,
+            totalItems: 1,
+            startedAt,
+            elapsedSeconds: Math.floor((Date.now() - startedAt) / 1000),
+            error: "Not a valid profile export file.",
+          });
+          toast.error("Not a valid profile export file.");
+          return;
+        }
+        body = text;
       }
       setProfileImportProgress((current) =>
         current
           ? {
               ...current,
               status: "starting",
-              label: "Starting profile import",
+              label: isZip ? "Uploading profile archive" : "Starting profile import",
               elapsedSeconds: Math.floor((Date.now() - startedAt) / 1000),
             }
           : current,
       );
-      const res = await fetch("/api/backup/import-profile", {
+      const res = await api.raw("/backup/import-profile", {
         method: "POST",
         headers: {
-          "Content-Type": "application/json",
           Accept: "text/event-stream",
-          ...getAdminSecretHeader(),
         },
-        body: text,
+        body,
       });
       if (!res.ok) {
         const data = (await res.json().catch(() => ({}))) as { error?: string; message?: string };
@@ -3147,26 +3244,33 @@ function ImportSettings() {
           if (event.data?.success === false) throw new Error(event.data.error ?? event.data.message ?? "Unknown error");
           qc.invalidateQueries();
           const imported = event.data?.imported;
+          const warnings = normalizeProfileImportWarnings(event.data?.warnings);
           const summary = formatProfileImportStats(imported);
           setProfileImportProgress((current) => {
             const totalItems = Math.max(1, current?.totalItems ?? 1);
             return {
               status: "success",
-              label: "Profile import complete",
+              label: warnings.length > 0 ? "Profile import complete with missing assets" : "Profile import complete",
               completedItems: totalItems,
               totalItems,
               startedAt,
               elapsedSeconds: Math.floor((Date.now() - startedAt) / 1000),
               imported,
+              warnings,
             };
           });
-          toast.success(summary ? `Imported: ${summary}` : "Profile imported.");
+          if (warnings.length > 0) {
+            const warningSummary = formatProfileImportWarningSummary(warnings);
+            toast.warning(summary ? `Imported: ${summary}. ${warningSummary}` : warningSummary);
+          } else {
+            toast.success(summary ? `Imported: ${summary}` : "Profile imported.");
+          }
         }
       }
     } catch (err) {
       const message =
         err instanceof SyntaxError
-          ? "Import failed. Make sure this is a valid profile JSON file."
+          ? "Import failed. Make sure this is a valid profile JSON or ZIP file."
           : `Import failed: ${err instanceof Error ? err.message : "network/server error"}`;
       setProfileImportProgress({
         status: "error",
@@ -3186,7 +3290,7 @@ function ImportSettings() {
     <div className="flex flex-col gap-3">
       <div className="text-xs text-[var(--muted-foreground)]">
         Import data from Marinara exports, SillyTavern, or other tools. Full profile imports also restore synced custom
-        themes.
+        themes and profile archive assets.
       </div>
 
       {/* Profile import */}
@@ -3197,10 +3301,10 @@ function ImportSettings() {
         )}
       >
         {profileImportBusy ? <Loader2 size="1rem" className="animate-spin" /> : <Download size="1rem" />}
-        {profileImportBusy ? "Importing Profile..." : "Import Profile (JSON)"}
+        {profileImportBusy ? "Importing Profile..." : "Import Profile (JSON/ZIP)"}
         <input
           type="file"
-          accept=".json"
+          accept=".json,.zip,application/json,application/zip"
           onChange={handleProfileImport}
           disabled={profileImportBusy}
           className="hidden"
@@ -3215,14 +3319,18 @@ function ImportSettings() {
             "flex flex-col gap-2 rounded-lg border px-3 py-2 text-xs",
             profileImportProgress.status === "error"
               ? "border-[var(--destructive)]/40 bg-[var(--destructive)]/10 text-[var(--destructive)]"
-              : profileImportProgress.status === "success"
-                ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-300"
-                : "border-emerald-500/30 bg-emerald-500/10 text-[var(--foreground)]",
+              : profileImportProgress.status === "success" && profileImportProgress.warnings?.length
+                ? "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-200"
+                : profileImportProgress.status === "success"
+                  ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-300"
+                  : "border-emerald-500/30 bg-emerald-500/10 text-[var(--foreground)]",
           )}
         >
           <div className="flex items-center justify-between gap-3">
             <div className="flex min-w-0 items-center gap-2">
-              {profileImportProgress.status === "success" ? (
+              {profileImportProgress.status === "success" && profileImportProgress.warnings?.length ? (
+                <AlertTriangle size="0.875rem" className="shrink-0" />
+              ) : profileImportProgress.status === "success" ? (
                 <Check size="0.875rem" className="shrink-0" />
               ) : profileImportProgress.status === "error" ? (
                 <AlertTriangle size="0.875rem" className="shrink-0" />
@@ -3242,7 +3350,11 @@ function ImportSettings() {
                 <div
                   className={cn(
                     "h-full rounded-full transition-all duration-300",
-                    profileImportProgress.status === "success" ? "bg-emerald-500" : "bg-emerald-400",
+                    profileImportProgress.status === "success" && profileImportProgress.warnings?.length
+                      ? "bg-amber-500"
+                      : profileImportProgress.status === "success"
+                        ? "bg-emerald-500"
+                        : "bg-emerald-400",
                   )}
                   style={{ width: `${getProfileImportPercent(profileImportProgress)}%` }}
                 />
@@ -3262,6 +3374,16 @@ function ImportSettings() {
                   Imported so far: {formatProfileImportStats(profileImportProgress.imported)}
                 </div>
               )}
+              {profileImportProgress.warnings?.length ? (
+                <div className="rounded-md border border-amber-500/30 bg-amber-500/10 px-2 py-1.5 text-[0.6875rem] text-amber-700 dark:text-amber-200">
+                  <div className="font-medium">{formatProfileImportWarningSummary(profileImportProgress.warnings)}</div>
+                  {formatProfileImportWarningDetails(profileImportProgress.warnings) && (
+                    <div className="mt-0.5 break-words text-amber-700/80 dark:text-amber-100/80">
+                      {formatProfileImportWarningDetails(profileImportProgress.warnings)}
+                    </div>
+                  )}
+                </div>
+              ) : null}
             </>
           )}
 
@@ -3452,27 +3574,61 @@ function AdvancedSettings() {
     if (enabled) setQuickRepliesDrawerOpen(true);
   };
 
-  const handleExportProfile = async (format: ExportFormatChoice) => {
+  type ProfileExportFormat = "native" | "compatible" | "zip";
+  const profileExportFallbackNames: Record<ProfileExportFormat, string> = {
+    native: "marinara-profile.json",
+    compatible: "marinara-compatible-export.zip",
+    zip: "marinara-profile.zip",
+  };
+  const profileExportSuccessMessages: Record<ProfileExportFormat, string> = {
+    native: "Profile exported!",
+    compatible: "Compatible export created!",
+    zip: "Profile ZIP exported!",
+  };
+
+  const handleExportProfile = async (format: ProfileExportFormat) => {
     setExportingProfile(true);
     setExportProfileDialogOpen(false);
     try {
-      const res = await fetch(`/api/backup/export-profile?format=${format}`, {
-        headers: getAdminSecretHeader(),
-      });
-      if (!res.ok) throw new Error(await readSettingsResponseError(res, "Export failed"));
+      const res = await api.raw(`/backup/export-profile?format=${format}`);
+      if (!res.ok) {
+        const failure = await readProfileExportFailure(res, "Export failed");
+        if (
+          format === "native" &&
+          failure.code === "PROFILE_EXPORT_JSON_TOO_LARGE" &&
+          failure.fallbackFormat === "zip"
+        ) {
+          const confirmed = await showConfirmDialog({
+            title: "Export profile as ZIP?",
+            message: failure.message,
+            confirmLabel: "Export ZIP",
+            cancelLabel: "Cancel",
+          });
+          if (confirmed) {
+            await handleExportProfile("zip");
+          }
+          return;
+        }
+        throw new Error(failure.message);
+      }
       const blob = await res.blob();
       const url = URL.createObjectURL(blob);
       const a = document.createElement("a");
       a.href = url;
-      a.download = format === "compatible" ? "marinara-compatible-export.zip" : "marinara-profile.json";
+      a.download = getDownloadFilename(res, profileExportFallbackNames[format]);
       a.click();
       URL.revokeObjectURL(url);
-      toast.success(format === "compatible" ? "Compatible export created!" : "Profile exported!");
+      toast.success(profileExportSuccessMessages[format]);
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Failed to export profile");
     } finally {
       setExportingProfile(false);
     }
+  };
+
+  const handleExportProfileChoice = (format: ExportFormatChoice) => {
+    if (format === "compatible-png") return;
+    void handleExportProfile(format);
   };
 
   const handleForceRefreshSpa = async () => {
@@ -3705,11 +3861,11 @@ function AdvancedSettings() {
       <ExportFormatDialog
         open={exportProfileDialogOpen}
         title="Export Profile"
-        description="Native creates a Marinara profile JSON for restoring your data in Marinara. Compatible creates a ZIP of folderless JSON files for other platforms."
-        nativeDescription="Keeps Marinara fields, lorebook folders, character/persona metadata, presets, agents, and themes for re-import."
+        description="Native creates a Marinara profile JSON for restoring your data in Marinara. If the JSON would be too large, Marinara will offer a profile ZIP instead."
+        nativeDescription="Keeps Marinara fields, lorebook folders, character/persona metadata, presets, agents, themes, and inline assets for re-import."
         compatibleDescription="Exports direct character JSON, simple persona JSON, and folderless lorebooks for other roleplay tools."
         onClose={() => setExportProfileDialogOpen(false)}
-        onSelect={handleExportProfile}
+        onSelect={handleExportProfileChoice}
       />
 
       <div className="text-xs text-[var(--muted-foreground)]">Advanced settings for power users.</div>
@@ -4086,7 +4242,7 @@ function AdvancedSettings() {
         <div className="flex items-center gap-1.5">
           <Download size="0.75rem" className="text-[var(--muted-foreground)]" />
           <span className="text-xs font-medium">Backup & Export</span>
-          <HelpTooltip text="Download a full backup as a .zip archive (storage snapshots + avatars, sprites, backgrounds, gallery, fonts, knowledge sources). The zip also includes marinara-profile.json for one-click restore through Import Profile (JSON). The raw folders are for manual recovery." />
+          <HelpTooltip text="Download a full backup as a .zip archive (storage snapshots + avatars, sprites, backgrounds, gallery, fonts, knowledge sources). Import Profile can restore the zip directly. The raw folders are for manual recovery." />
         </div>
         <button
           onClick={handleCreateBackup}
@@ -4118,7 +4274,7 @@ function AdvancedSettings() {
           ) : (
             <>
               <Download size="0.8125rem" />
-              Export Profile (JSON)
+              Export Profile
             </>
           )}
         </button>

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -3188,6 +3188,7 @@ function ImportSettings() {
             error: "Not a valid profile export file.",
           });
           toast.error("Not a valid profile export file.");
+          e.target.value = "";
           return;
         }
         body = text;
@@ -3213,6 +3214,7 @@ function ImportSettings() {
         const data = (await res.json().catch(() => ({}))) as { error?: string; message?: string };
         throw new Error(data.message ?? data.error ?? res.statusText ?? "Unknown error");
       }
+      let importCompleted = false;
       for await (const event of readProfileImportStream(res)) {
         if (event.type === "started") {
           setProfileImportProgress((current) => ({
@@ -3242,6 +3244,7 @@ function ImportSettings() {
         }
         if (event.type === "done") {
           if (event.data?.success === false) throw new Error(event.data.error ?? event.data.message ?? "Unknown error");
+          importCompleted = true;
           qc.invalidateQueries();
           const imported = event.data?.imported;
           const warnings = normalizeProfileImportWarnings(event.data?.warnings);
@@ -3266,6 +3269,9 @@ function ImportSettings() {
             toast.success(summary ? `Imported: ${summary}` : "Profile imported.");
           }
         }
+      }
+      if (!importCompleted) {
+        throw new Error("Profile import stream closed before completion.");
       }
     } catch (err) {
       const message =

--- a/packages/client/src/components/ui/ExportFormatDialog.tsx
+++ b/packages/client/src/components/ui/ExportFormatDialog.tsx
@@ -39,12 +39,13 @@ export function ExportFormatDialog({
       ? [{ id: "compatible-png" as const, label: "Compatible PNG Card", icon: ImageDown, description: pngDescription }]
       : []),
   ];
+  const gridColumns = options.length === 3 ? "sm:grid-cols-3" : "sm:grid-cols-2";
 
   return (
     <Modal open={open} onClose={onClose} title={title} width="max-w-lg">
       <div className="space-y-4">
         <p className="text-xs leading-relaxed text-[var(--muted-foreground)]">{description}</p>
-        <div className={cn("grid gap-2", showPngOption ? "sm:grid-cols-3" : "sm:grid-cols-2")}>
+        <div className={cn("grid gap-2", gridColumns)}>
           {options.map((option) => {
             const Icon = option.icon;
             return (

--- a/packages/server/src/routes/backup.routes.ts
+++ b/packages/server/src/routes/backup.routes.ts
@@ -74,6 +74,7 @@ type ProfileZipEntry = {
   isDirectory: boolean;
   header: {
     method: number;
+    crc32: number;
     compressedSize: number;
     size: number;
     dataOffset: number;
@@ -134,6 +135,12 @@ class ProfileArchiveTooLargeError extends Error {}
 class ProfileImportRequestError extends Error {}
 
 class ProfileImportArchiveTooLargeError extends ProfileImportRequestError {}
+
+function sendProfileImportRequestError(reply: FastifyReply, err: ProfileImportRequestError) {
+  const message = err.message || "Profile import file could not be read.";
+  const statusCode = err instanceof ProfileImportArchiveTooLargeError ? 413 : 400;
+  return reply.status(statusCode).send({ error: "Invalid profile export", message });
+}
 
 function resolveBackupDir(dataDir: string, dirName: string) {
   return dirName === "storage" ? getFileStorageDir() : join(dataDir, dirName);
@@ -262,6 +269,17 @@ function resolveAvatarWritePath(dataDir: string, avatarPath: unknown) {
   const filename = avatarPath.split("?")[0]?.split("/").filter(Boolean).pop();
   if (!filename) return null;
   return assertInsideDir(join(dataDir, "avatars"), join(dataDir, "avatars", filename));
+}
+
+function resolveProfileExportFilePath(dataDir: string, filePath: unknown) {
+  if (typeof filePath !== "string" || !filePath.trim()) return null;
+  const cleanPath = filePath.split("?")[0];
+  if (!cleanPath) return null;
+  try {
+    return assertInsideDir(dataDir, join(dataDir, cleanPath));
+  } catch {
+    return null;
+  }
 }
 
 function redactAgentSecrets(agent: any) {
@@ -549,7 +567,7 @@ async function importProfileStorageSnapshot(
       restoredFileBytes += expectedSize;
       assertProfileArchiveTotalLimit(restoredFileBytes);
       if (buffer.length !== expectedSize) {
-        throw new Error(`Profile asset ${safePath} does not match its manifest size.`);
+        throw new ProfileImportRequestError(`Profile asset ${safePath} does not match its manifest size.`);
       }
       const outputPath = assertInsideDir(getDataDir(), join(getDataDir(), ...safePath.split("/")));
       await mkdir(dirname(outputPath), { recursive: true });
@@ -583,7 +601,7 @@ async function buildProfileExportEnvelope(
   const characterExports = await Promise.all(
     allChars.map(async (c: any) => {
       let avatarBase64: string | null = null;
-      const avatarPath = c.avatarPath ? join(dataDir, c.avatarPath) : null;
+      const avatarPath = resolveProfileExportFilePath(dataDir, c.avatarPath);
       if (includeLegacyAvatarBase64 && avatarPath && existsSync(avatarPath)) {
         avatarBase64 = await readInlineBase64File(avatarPath, inlineJsonBudget);
       }
@@ -595,7 +613,7 @@ async function buildProfileExportEnvelope(
   const allPersonas = await Promise.all(
     (allPersonaRows as any[]).map(async (p: any) => {
       let avatarBase64: string | null = null;
-      const avatarPath = p.avatarPath ? join(dataDir, p.avatarPath) : null;
+      const avatarPath = resolveProfileExportFilePath(dataDir, p.avatarPath);
       if (includeLegacyAvatarBase64 && avatarPath && existsSync(avatarPath)) {
         avatarBase64 = await readInlineBase64File(avatarPath, inlineJsonBudget);
       }
@@ -1192,6 +1210,7 @@ async function readProfileZipArchive(filePath: string): Promise<ProfileZipArchiv
         throw new ProfileImportRequestError("Profile archive encrypted ZIP entries are not supported.");
       }
       const method = centralDirectory.readUInt16LE(offset + 10);
+      const crc32 = centralDirectory.readUInt32LE(offset + 16);
       const compressedSize = readZip32Value(centralDirectory, offset + 20, "entry compressed size");
       const size = readZip32Value(centralDirectory, offset + 24, "entry size");
       const fileNameLength = centralDirectory.readUInt16LE(offset + 28);
@@ -1223,7 +1242,7 @@ async function readProfileZipArchive(filePath: string): Promise<ProfileZipArchiv
       const entry: ProfileZipEntry = {
         entryName: normalizedName,
         isDirectory: normalizedName.endsWith("/"),
-        header: { method, compressedSize, size, dataOffset },
+        header: { method, crc32, compressedSize, size, dataOffset },
       };
       entries.push(entry);
       if (normalizedName && !entriesByName.has(normalizedName)) entriesByName.set(normalizedName, entry);
@@ -1314,6 +1333,9 @@ async function readProfileArchiveEntryBuffer(zip: ProfileZipArchive, entry: Prof
   }
   if (data.length !== expectedSize) {
     throw new ProfileImportRequestError(`Profile archive entry ${entry.entryName} does not match its manifest size.`);
+  }
+  if (crc32Buffer(data) !== entry.header.crc32) {
+    throw new ProfileImportRequestError(`Profile archive entry ${entry.entryName} failed CRC check.`);
   }
   return data;
 }
@@ -1651,9 +1673,11 @@ export async function backupRoutes(app: FastifyInstance) {
     try {
       importInput = await readProfileImportRequest(req);
     } catch (err) {
+      if (err instanceof ProfileImportRequestError) {
+        return sendProfileImportRequestError(reply, err);
+      }
       const message = err instanceof Error ? err.message : "Profile import file could not be read.";
-      const statusCode = err instanceof ProfileImportArchiveTooLargeError ? 413 : 400;
-      return reply.status(statusCode).send({ error: "Invalid profile export", message });
+      return reply.status(400).send({ error: "Invalid profile export", message });
     }
 
     try {
@@ -2064,11 +2088,22 @@ export async function backupRoutes(app: FastifyInstance) {
       } catch (err) {
         if (wantsProgressStream) {
           const message = getBackupErrorMessage(err, "Profile import failed. Check the server logs for details.");
-          const logError = err instanceof Error ? err : new Error(message);
-          logger.error(logError, "[backup] Profile import failed");
-          sendEvent({ type: "error", data: { error: "Profile import failed", message } });
+          if (!(err instanceof ProfileImportRequestError)) {
+            const logError = err instanceof Error ? err : new Error(message);
+            logger.error(logError, "[backup] Profile import failed");
+          }
+          sendEvent({
+            type: "error",
+            data: {
+              error: err instanceof ProfileImportRequestError ? "Invalid profile export" : "Profile import failed",
+              message,
+            },
+          });
           reply.raw.end();
           return;
+        }
+        if (err instanceof ProfileImportRequestError) {
+          return sendProfileImportRequestError(reply, err);
         }
         return sendBackupRouteError(reply, err, "Profile import");
       }

--- a/packages/server/src/routes/backup.routes.ts
+++ b/packages/server/src/routes/backup.routes.ts
@@ -1,10 +1,15 @@
 // ──────────────────────────────────────────────
 // Routes: Backup
 // ──────────────────────────────────────────────
-import type { FastifyInstance, FastifyReply } from "fastify";
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { basename, dirname, join, relative } from "path";
-import { existsSync, readdirSync, statSync } from "fs";
-import { cp, mkdir, copyFile, readFile, readdir, writeFile } from "fs/promises";
+import { createReadStream, createWriteStream, existsSync, readdirSync, statSync } from "fs";
+import type { WriteStream } from "fs";
+import { cp, mkdir, copyFile, readFile, readdir, writeFile, stat, mkdtemp, rm, open } from "fs/promises";
+import type { FileHandle } from "fs/promises";
+import { tmpdir } from "os";
+import { pipeline } from "stream/promises";
+import { inflateRawSync } from "zlib";
 import AdmZip from "adm-zip";
 import { FILE_BACKED_TABLES } from "../db/file-backed-store.js";
 import * as schema from "../db/schema/index.js";
@@ -26,14 +31,75 @@ import { logger } from "../lib/logger.js";
 const BACKUP_DIRS = ["storage", "avatars", "sprites", "backgrounds", "gallery", "fonts", "knowledge-sources"];
 const PROFILE_ASSET_DIRS = BACKUP_DIRS.filter((dirName) => dirName !== "storage");
 const PROFILE_IMPORT_BODY_LIMIT_BYTES = 256 * 1024 * 1024;
+const PROFILE_IMPORT_ARCHIVE_LIMIT_BYTES = 1024 * 1024 * 1024;
+const PROFILE_ARCHIVE_ENTRY_LIMIT_BYTES = 256 * 1024 * 1024;
+const PROFILE_ARCHIVE_CENTRAL_DIRECTORY_LIMIT_BYTES = 64 * 1024 * 1024;
+const PROFILE_ARCHIVE_TOTAL_UNCOMPRESSED_LIMIT_BYTES = 1024 * 1024 * 1024;
+const PROFILE_EXPORT_JSON_TOO_LARGE_CODE = "PROFILE_EXPORT_JSON_TOO_LARGE";
+const ZIP32_MAX_VALUE = 0xffffffff;
+const ZIP_EOCD_SIGNATURE = 0x06054b50;
+const ZIP_CENTRAL_DIRECTORY_SIGNATURE = 0x02014b50;
+const ZIP_LOCAL_FILE_HEADER_SIGNATURE = 0x04034b50;
+const ZIP_EOCD_MIN_SIZE = 22;
+const ZIP_EOCD_MAX_COMMENT_BYTES = 0xffff;
+const ZIP_ENCRYPTED_FLAG = 0x0001;
 
-type ExportFormat = "native" | "compatible";
+type ExportFormat = "native" | "compatible" | "zip";
 type ProfileTableSnapshots = Record<string, Array<Record<string, unknown>>>;
-type ProfileFileAsset = { path: string; data: string; size: number };
+type ProfileFileAsset = { path: string; data?: string; size: number };
 type ProfileStorageSnapshot = {
   version: 1;
   tables: ProfileTableSnapshots;
   files: ProfileFileAsset[];
+};
+type ProfileExportEnvelopeOptions = {
+  includeFileStorage?: boolean;
+  inlineFileData?: boolean;
+  includeLegacyAvatarBase64?: boolean;
+  inlineJsonBudget?: ProfileInlineJsonBudget;
+};
+type ProfileStorageSnapshotOptions = {
+  inlineFileData?: boolean;
+  inlineJsonBudget?: ProfileInlineJsonBudget;
+};
+type ProfileInlineJsonBudget = {
+  limitBytes: number;
+  estimatedBytes: number;
+};
+type ProfileAssetReader = (safePath: string) => Buffer | null | Promise<Buffer | null>;
+type ProfileArchiveAssetIndex = Map<string, { entryName: string; expectedSize: number }>;
+type ProfileImportWarning = { type: "missing_asset"; path: string; message: string };
+type ProfileZipEntry = {
+  entryName: string;
+  isDirectory: boolean;
+  header: {
+    method: number;
+    compressedSize: number;
+    size: number;
+    dataOffset: number;
+  };
+};
+type ProfileZipArchive = {
+  filePath: string;
+  entries: ProfileZipEntry[];
+  entriesByName: Map<string, ProfileZipEntry>;
+};
+type StoredZipEntrySource =
+  | { entryName: string; data: Buffer; mtime?: Date }
+  | { entryName: string; filePath: string; size: number; mtime?: Date };
+type StoredZipEntryRecord = {
+  entryName: string;
+  crc32: number;
+  size: number;
+  localHeaderOffset: number;
+  dosTime: number;
+  dosDate: number;
+};
+type ProfileImportInput = {
+  envelope: ExportEnvelope;
+  readAsset?: ProfileAssetReader;
+  warnings?: ProfileImportWarning[];
+  cleanup?: () => Promise<void>;
 };
 type ProfileImportStats = {
   characters: number;
@@ -56,6 +122,18 @@ type ProfileImportProgress = {
   imported: ProfileImportStats;
 };
 type ProfileImportProgressReporter = (progress: ProfileImportProgress) => void;
+
+class ProfileJsonTooLargeError extends Error {
+  constructor(public estimatedBytes: number) {
+    super("Profile export is too large for JSON");
+  }
+}
+
+class ProfileArchiveTooLargeError extends Error {}
+
+class ProfileImportRequestError extends Error {}
+
+class ProfileImportArchiveTooLargeError extends ProfileImportRequestError {}
 
 function resolveBackupDir(dataDir: string, dirName: string) {
   return dirName === "storage" ? getFileStorageDir() : join(dataDir, dirName);
@@ -138,7 +216,10 @@ function buildCompatibleLorebookExport(lb: Record<string, any>) {
 }
 
 async function buildCompatibleProfileZip(app: FastifyInstance) {
-  const envelope = await buildProfileExportEnvelope(app);
+  const envelope = await buildProfileExportEnvelope(app, {
+    includeFileStorage: false,
+    includeLegacyAvatarBase64: false,
+  });
   const data = envelope.data as Record<string, any>;
   const zip = new AdmZip();
 
@@ -268,8 +349,67 @@ function normalizeProfileAssetPath(pathValue: unknown) {
   return parts.join("/");
 }
 
-async function collectProfileAssetFiles(dataDir: string): Promise<ProfileFileAsset[]> {
+function profileArchiveSizeError(label: string, size: number, limit: number) {
+  return `${label} is too large for profile ZIP import/export (${size} bytes, limit ${limit} bytes).`;
+}
+
+function getProfileAssetManifestSize(file: unknown, safePath: string) {
+  const size = (file as { size?: unknown } | null)?.size;
+  if (typeof size !== "number" || !Number.isSafeInteger(size) || size < 0) {
+    throw new ProfileImportRequestError(`Profile archive asset ${safePath} has an invalid size manifest.`);
+  }
+  return size;
+}
+
+function assertProfileArchiveEntryLimit(label: string, size: number) {
+  if (size > PROFILE_ARCHIVE_ENTRY_LIMIT_BYTES) {
+    throw new ProfileImportRequestError(profileArchiveSizeError(label, size, PROFILE_ARCHIVE_ENTRY_LIMIT_BYTES));
+  }
+}
+
+function assertProfileArchiveTotalLimit(total: number) {
+  if (total > PROFILE_ARCHIVE_TOTAL_UNCOMPRESSED_LIMIT_BYTES) {
+    throw new ProfileImportRequestError(
+      profileArchiveSizeError("Profile archive restored assets", total, PROFILE_ARCHIVE_TOTAL_UNCOMPRESSED_LIMIT_BYTES),
+    );
+  }
+}
+
+function getZipEntryUncompressedSize(entry: ProfileZipEntry) {
+  const size = entry.header.size;
+  return Number.isSafeInteger(size) && size >= 0 ? size : null;
+}
+
+function getZipEntryCompressedSize(entry: ProfileZipEntry) {
+  const size = entry.header.compressedSize;
+  return Number.isSafeInteger(size) && size >= 0 ? size : null;
+}
+
+function estimateBase64Length(byteLength: number) {
+  return Math.ceil(byteLength / 3) * 4;
+}
+
+function reserveInlineJsonBudget(budget: ProfileInlineJsonBudget | undefined, bytes: number) {
+  if (!budget) return;
+  budget.estimatedBytes += bytes;
+  if (budget.estimatedBytes > budget.limitBytes) {
+    throw new ProfileJsonTooLargeError(budget.estimatedBytes);
+  }
+}
+
+async function readInlineBase64File(filePath: string, budget?: ProfileInlineJsonBudget) {
+  const fileStat = await stat(filePath);
+  reserveInlineJsonBudget(budget, estimateBase64Length(fileStat.size));
+  const buffer = await readFile(filePath);
+  return buffer.toString("base64");
+}
+
+async function collectProfileAssetFiles(
+  dataDir: string,
+  options: ProfileStorageSnapshotOptions = {},
+): Promise<ProfileFileAsset[]> {
   const files: ProfileFileAsset[] = [];
+  const inlineFileData = options.inlineFileData ?? true;
 
   for (const dirName of PROFILE_ASSET_DIRS) {
     const src = join(dataDir, dirName);
@@ -287,8 +427,14 @@ async function collectProfileAssetFiles(dataDir: string): Promise<ProfileFileAss
         const relPath = [dirName, relative(src, full)].filter(Boolean).join("/").split(/[\\/]/g).join("/");
         const safePath = normalizeProfileAssetPath(relPath);
         if (!safePath) continue;
-        const buffer = await readFile(full);
-        files.push({ path: safePath, data: buffer.toString("base64"), size: buffer.length });
+        const fileStat = await stat(full);
+        const asset: ProfileFileAsset = { path: safePath, size: fileStat.size };
+        if (inlineFileData) {
+          reserveInlineJsonBudget(options.inlineJsonBudget, estimateBase64Length(fileStat.size));
+          const buffer = await readFile(full);
+          asset.data = buffer.toString("base64");
+        }
+        files.push(asset);
       }
     }
   }
@@ -296,11 +442,14 @@ async function collectProfileAssetFiles(dataDir: string): Promise<ProfileFileAss
   return files;
 }
 
-async function buildProfileStorageSnapshot(app: FastifyInstance): Promise<ProfileStorageSnapshot> {
+async function buildProfileStorageSnapshot(
+  app: FastifyInstance,
+  options: ProfileStorageSnapshotOptions = {},
+): Promise<ProfileStorageSnapshot> {
   return {
     version: 1,
     tables: await buildProfileTableSnapshot(app),
-    files: await collectProfileAssetFiles(getDataDir()),
+    files: await collectProfileAssetFiles(getDataDir(), options),
   };
 }
 
@@ -345,6 +494,7 @@ async function importProfileStorageSnapshot(
   app: FastifyInstance,
   snapshot: ProfileStorageSnapshot,
   onProgress?: ProfileImportProgressReporter,
+  readAsset?: ProfileAssetReader,
 ) {
   const totalItems = Math.max(1, countProfileStorageSnapshotItems(snapshot));
   let completedItems = 0;
@@ -386,13 +536,24 @@ async function importProfileStorageSnapshot(
   }
 
   let files = 0;
+  let restoredFileBytes = 0;
   if (Array.isArray(snapshot.files)) {
     for (const file of snapshot.files) {
       const safePath = normalizeProfileAssetPath(file?.path);
-      if (!safePath || typeof file.data !== "string") continue;
+      if (!safePath) continue;
+      const expectedSize = getProfileAssetManifestSize(file, safePath);
+      assertProfileArchiveEntryLimit(safePath, expectedSize);
+      const buffer =
+        typeof file.data === "string" ? Buffer.from(file.data, "base64") : readAsset ? await readAsset(safePath) : null;
+      if (!buffer) continue;
+      restoredFileBytes += expectedSize;
+      assertProfileArchiveTotalLimit(restoredFileBytes);
+      if (buffer.length !== expectedSize) {
+        throw new Error(`Profile asset ${safePath} does not match its manifest size.`);
+      }
       const outputPath = assertInsideDir(getDataDir(), join(getDataDir(), ...safePath.split("/")));
       await mkdir(dirname(outputPath), { recursive: true });
-      await writeFile(outputPath, Buffer.from(file.data, "base64"));
+      await writeFile(outputPath, buffer);
       files++;
       completedItems++;
       emit("files", `Restoring ${safePath}`, files);
@@ -403,7 +564,14 @@ async function importProfileStorageSnapshot(
   return buildProfileImportStats(tableCounts, files);
 }
 
-async function buildProfileExportEnvelope(app: FastifyInstance): Promise<ExportEnvelope> {
+async function buildProfileExportEnvelope(
+  app: FastifyInstance,
+  options: ProfileExportEnvelopeOptions = {},
+): Promise<ExportEnvelope> {
+  const includeFileStorage = options.includeFileStorage ?? true;
+  const inlineFileData = options.inlineFileData ?? true;
+  const includeLegacyAvatarBase64 = options.includeLegacyAvatarBase64 ?? true;
+  const inlineJsonBudget = options.inlineJsonBudget;
   const chars = createCharactersStorage(app.db);
   const lbs = createLorebooksStorage(app.db);
   const presets = createPromptsStorage(app.db);
@@ -415,9 +583,9 @@ async function buildProfileExportEnvelope(app: FastifyInstance): Promise<ExportE
   const characterExports = await Promise.all(
     allChars.map(async (c: any) => {
       let avatarBase64: string | null = null;
-      if (c.avatarPath && existsSync(join(dataDir, c.avatarPath))) {
-        const buf = await readFile(join(dataDir, c.avatarPath));
-        avatarBase64 = buf.toString("base64");
+      const avatarPath = c.avatarPath ? join(dataDir, c.avatarPath) : null;
+      if (includeLegacyAvatarBase64 && avatarPath && existsSync(avatarPath)) {
+        avatarBase64 = await readInlineBase64File(avatarPath, inlineJsonBudget);
       }
       return { ...c, avatarBase64 };
     }),
@@ -427,9 +595,9 @@ async function buildProfileExportEnvelope(app: FastifyInstance): Promise<ExportE
   const allPersonas = await Promise.all(
     (allPersonaRows as any[]).map(async (p: any) => {
       let avatarBase64: string | null = null;
-      if (p.avatarPath && existsSync(join(dataDir, p.avatarPath))) {
-        const buf = await readFile(join(dataDir, p.avatarPath));
-        avatarBase64 = buf.toString("base64");
+      const avatarPath = p.avatarPath ? join(dataDir, p.avatarPath) : null;
+      if (includeLegacyAvatarBase64 && avatarPath && existsSync(avatarPath)) {
+        avatarBase64 = await readInlineBase64File(avatarPath, inlineJsonBudget);
       }
       return { ...p, avatarBase64 };
     }),
@@ -456,21 +624,804 @@ async function buildProfileExportEnvelope(app: FastifyInstance): Promise<ExportE
 
   const allAgents = (await agents.list()).map(redactAgentSecrets);
   const allThemes = await themes.list();
+  const data: Record<string, unknown> = {
+    characters: characterExports,
+    personas: allPersonas,
+    lorebooks: lorebookExports,
+    presets: presetExports,
+    agents: allAgents,
+    themes: allThemes,
+  };
+  if (includeFileStorage) {
+    data.fileStorage = await buildProfileStorageSnapshot(app, { inlineFileData, inlineJsonBudget });
+  }
 
   return {
     type: "marinara_profile",
     version: 1,
     exportedAt: new Date().toISOString(),
-    data: {
-      characters: characterExports,
-      personas: allPersonas,
-      lorebooks: lorebookExports,
-      presets: presetExports,
-      agents: allAgents,
-      themes: allThemes,
-      fileStorage: await buildProfileStorageSnapshot(app),
-    },
+    data,
   };
+}
+
+function normalizeProfileArchiveEntryPath(entryName: string) {
+  return entryName.replace(/\\/g, "/").replace(/^\/+/, "");
+}
+
+function profileArchiveBasePath(profileEntryName: string) {
+  const normalized = normalizeProfileArchiveEntryPath(profileEntryName);
+  const slashIndex = normalized.lastIndexOf("/");
+  return slashIndex >= 0 ? normalized.slice(0, slashIndex) : "";
+}
+
+function profileArchiveEntryPath(basePath: string, safePath: string) {
+  return basePath ? `${basePath}/${safePath}` : safePath;
+}
+
+function getProfileStorageSnapshotFromEnvelope(envelope: ExportEnvelope) {
+  const data = envelope.data as Record<string, unknown>;
+  return isProfileStorageSnapshot(data.fileStorage) ? data.fileStorage : null;
+}
+
+async function collectProfileAssetZipSources(envelope: ExportEnvelope) {
+  const snapshot = getProfileStorageSnapshotFromEnvelope(envelope);
+  if (!snapshot || !Array.isArray(snapshot.files)) return [];
+
+  const dataDir = getDataDir();
+  const sources: StoredZipEntrySource[] = [];
+  let totalUncompressedBytes = 0;
+  const seenEntryNames = new Set<string>();
+
+  for (const file of snapshot.files) {
+    const safePath = normalizeProfileAssetPath(file.path);
+    if (!safePath) continue;
+    const inputPath = assertInsideDir(dataDir, join(dataDir, ...safePath.split("/")));
+    if (!existsSync(inputPath)) continue;
+    const fileStat = await stat(inputPath);
+    if (!fileStat.isFile()) continue;
+    if (fileStat.size !== file.size) {
+      throw new Error(`Profile asset changed while exporting: ${safePath}`);
+    }
+    if (fileStat.size > PROFILE_ARCHIVE_ENTRY_LIMIT_BYTES) {
+      throw new ProfileArchiveTooLargeError(
+        profileArchiveSizeError(safePath, fileStat.size, PROFILE_ARCHIVE_ENTRY_LIMIT_BYTES),
+      );
+    }
+    totalUncompressedBytes += fileStat.size;
+    if (totalUncompressedBytes > PROFILE_ARCHIVE_TOTAL_UNCOMPRESSED_LIMIT_BYTES) {
+      throw new ProfileArchiveTooLargeError(
+        profileArchiveSizeError(
+          "Profile ZIP assets",
+          totalUncompressedBytes,
+          PROFILE_ARCHIVE_TOTAL_UNCOMPRESSED_LIMIT_BYTES,
+        ),
+      );
+    }
+    if (seenEntryNames.has(safePath)) continue;
+    seenEntryNames.add(safePath);
+    sources.push({ entryName: safePath, filePath: inputPath, size: fileStat.size, mtime: fileStat.mtime });
+  }
+
+  return sources;
+}
+
+async function writeNativeProfileZip(app: FastifyInstance, outputPath: string) {
+  const envelope = await buildProfileExportEnvelope(app, {
+    inlineFileData: false,
+    includeLegacyAvatarBase64: false,
+  });
+  const manifest = Buffer.from(JSON.stringify(envelope, null, 2), "utf8");
+  if (manifest.length > PROFILE_IMPORT_BODY_LIMIT_BYTES) {
+    throw new ProfileArchiveTooLargeError(
+      profileArchiveSizeError("Profile ZIP manifest", manifest.length, PROFILE_IMPORT_BODY_LIMIT_BYTES),
+    );
+  }
+  const assetSources = await collectProfileAssetZipSources(envelope);
+  await writeStoredZipArchive(outputPath, [{ entryName: "marinara-profile.json", data: manifest }, ...assetSources]);
+}
+
+function cleanupTempDirAfterReply(reply: FastifyReply, dirPath: string) {
+  let cleaned = false;
+  const cleanup = () => {
+    if (cleaned) return;
+    cleaned = true;
+    void rm(dirPath, { recursive: true, force: true }).catch((err) => {
+      logger.warn(err, "[backup] Failed to remove temporary profile ZIP");
+    });
+  };
+  reply.raw.once("finish", cleanup);
+  reply.raw.once("close", cleanup);
+}
+
+async function sendNativeProfileZipExport(app: FastifyInstance, reply: FastifyReply) {
+  const tempDir = await mkdtemp(join(tmpdir(), "marinara-profile-export-"));
+  const archivePath = join(tempDir, "marinara-profile.zip");
+  try {
+    await writeNativeProfileZip(app, archivePath);
+    const archiveStat = await stat(archivePath);
+    cleanupTempDirAfterReply(reply, tempDir);
+    return reply
+      .header("Content-Disposition", `attachment; filename="marinara-profile.zip"`)
+      .header("Content-Type", "application/zip")
+      .header("Content-Length", archiveStat.size.toString())
+      .send(createReadStream(archivePath));
+  } catch (err) {
+    await rm(tempDir, { recursive: true, force: true }).catch(() => {});
+    throw err;
+  }
+}
+
+function getProfileJsonExportLimitBytes() {
+  const configured = Number(process.env.PROFILE_EXPORT_JSON_LIMIT_BYTES);
+  return Number.isFinite(configured) && configured > 0 ? configured : PROFILE_IMPORT_BODY_LIMIT_BYTES;
+}
+
+function estimateJsonStringLength(value: unknown, seen = new WeakSet<object>()): number {
+  if (value === null || value === undefined) return 4;
+  if (typeof value === "string") return value.length + 2;
+  if (typeof value === "number" || typeof value === "boolean") return String(value).length;
+  if (typeof value !== "object") return 2;
+
+  if (seen.has(value)) return 2;
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    return 2 + value.reduce((total, item) => total + estimateJsonStringLength(item, seen) + 1, 0);
+  }
+
+  return (
+    2 +
+    Object.entries(value).reduce(
+      (total, [key, item]) => total + key.length + 3 + estimateJsonStringLength(item, seen) + 1,
+      0,
+    )
+  );
+}
+
+function isJsonStringSizeError(err: unknown) {
+  return (
+    err instanceof RangeError &&
+    /invalid string length|cannot create a string longer than|failed to allocate string/i.test(err.message)
+  );
+}
+
+function sendProfileJsonTooLarge(reply: FastifyReply, estimatedBytes: number, limitBytes: number) {
+  return reply.status(413).send({
+    error: "Profile export is too large for JSON",
+    code: PROFILE_EXPORT_JSON_TOO_LARGE_CODE,
+    message: "This profile is too large for the JSON profile exporter. Export it as a profile ZIP instead.",
+    fallbackFormat: "zip",
+    estimatedBytes,
+    limitBytes,
+  });
+}
+
+async function sendNativeProfileJsonExport(app: FastifyInstance, reply: FastifyReply) {
+  const limitBytes = getProfileJsonExportLimitBytes();
+  const inlineJsonBudget: ProfileInlineJsonBudget = { limitBytes, estimatedBytes: 0 };
+  let envelope: ExportEnvelope;
+  try {
+    envelope = await buildProfileExportEnvelope(app, {
+      inlineFileData: true,
+      includeLegacyAvatarBase64: true,
+      inlineJsonBudget,
+    });
+  } catch (err) {
+    if (err instanceof ProfileJsonTooLargeError) {
+      return sendProfileJsonTooLarge(reply, err.estimatedBytes, limitBytes);
+    }
+    if (isJsonStringSizeError(err)) {
+      return sendProfileJsonTooLarge(reply, inlineJsonBudget.estimatedBytes, limitBytes);
+    }
+    throw err;
+  }
+  const estimatedBytes = Math.ceil(estimateJsonStringLength(envelope) * 1.05);
+
+  if (estimatedBytes > limitBytes) {
+    return sendProfileJsonTooLarge(reply, estimatedBytes, limitBytes);
+  }
+
+  let body: string;
+  try {
+    body = JSON.stringify(envelope);
+  } catch (err) {
+    if (isJsonStringSizeError(err)) {
+      return sendProfileJsonTooLarge(reply, estimatedBytes, limitBytes);
+    }
+    throw err;
+  }
+
+  const bodyBytes = Buffer.byteLength(body);
+  if (bodyBytes > limitBytes) {
+    return sendProfileJsonTooLarge(reply, bodyBytes, limitBytes);
+  }
+
+  return reply
+    .header("Content-Type", "application/json; charset=utf-8")
+    .header("Content-Disposition", `attachment; filename="marinara-profile.json"`)
+    .header("Content-Length", bodyBytes.toString())
+    .send(body);
+}
+
+const CRC32_TABLE = (() => {
+  const table = new Uint32Array(256);
+  for (let index = 0; index < 256; index++) {
+    let value = index;
+    for (let bit = 0; bit < 8; bit++) {
+      value = value & 1 ? 0xedb88320 ^ (value >>> 1) : value >>> 1;
+    }
+    table[index] = value >>> 0;
+  }
+  return table;
+})();
+
+function updateCrc32State(state: number, chunk: Buffer | Uint8Array) {
+  let crc = state >>> 0;
+  for (const byte of chunk) {
+    crc = CRC32_TABLE[(crc ^ byte) & 0xff]! ^ (crc >>> 8);
+  }
+  return crc >>> 0;
+}
+
+function finishCrc32(state: number) {
+  return (state ^ 0xffffffff) >>> 0;
+}
+
+function crc32Buffer(buffer: Buffer) {
+  return finishCrc32(updateCrc32State(0xffffffff, buffer));
+}
+
+async function crc32File(filePath: string) {
+  let state = 0xffffffff;
+  for await (const chunk of createReadStream(filePath)) {
+    state = updateCrc32State(state, Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return finishCrc32(state);
+}
+
+function getZipDosTimeDate(mtime?: Date) {
+  const date = mtime ?? new Date();
+  const year = Math.min(2107, Math.max(1980, date.getFullYear()));
+  const month = Math.min(12, Math.max(1, date.getMonth() + 1));
+  const day = Math.min(31, Math.max(1, date.getDate()));
+  const dosTime = (date.getHours() << 11) | (date.getMinutes() << 5) | Math.floor(date.getSeconds() / 2);
+  const dosDate = ((year - 1980) << 9) | (month << 5) | day;
+  return { dosTime, dosDate };
+}
+
+function normalizeStoredZipEntryName(entryName: string) {
+  const normalized = normalizeProfileArchiveEntryPath(entryName);
+  const parts = normalized.split("/").filter(Boolean);
+  if (
+    !normalized ||
+    normalized.includes("\0") ||
+    normalized.endsWith("/") ||
+    parts.length === 0 ||
+    parts.some((part) => part === "." || part === ".." || part.includes(":"))
+  ) {
+    throw new Error(`Invalid profile ZIP entry name: ${entryName}`);
+  }
+  return parts.join("/");
+}
+
+function assertZip32Value(value: number, label: string) {
+  if (!Number.isSafeInteger(value) || value < 0 || value > ZIP32_MAX_VALUE) {
+    throw new Error(`Profile ZIP ${label} exceeds the ZIP32 size limit.`);
+  }
+}
+
+async function waitForWritableDrain(stream: WriteStream) {
+  await new Promise<void>((resolve, reject) => {
+    const cleanup = () => {
+      stream.off("drain", onDrain);
+      stream.off("error", onError);
+    };
+    const onDrain = () => {
+      cleanup();
+      resolve();
+    };
+    const onError = (err: Error) => {
+      cleanup();
+      reject(err);
+    };
+    stream.once("drain", onDrain);
+    stream.once("error", onError);
+  });
+}
+
+async function writeZipBuffer(stream: WriteStream, buffer: Buffer) {
+  if (!stream.write(buffer)) {
+    await waitForWritableDrain(stream);
+  }
+}
+
+function buildLocalFileHeader(record: StoredZipEntryRecord) {
+  const filename = Buffer.from(record.entryName, "utf8");
+  if (filename.length > 0xffff) throw new Error(`Profile ZIP entry name is too long: ${record.entryName}`);
+  const header = Buffer.alloc(30);
+  header.writeUInt32LE(0x04034b50, 0);
+  header.writeUInt16LE(20, 4);
+  header.writeUInt16LE(0x0800, 6);
+  header.writeUInt16LE(0, 8);
+  header.writeUInt16LE(record.dosTime, 10);
+  header.writeUInt16LE(record.dosDate, 12);
+  header.writeUInt32LE(record.crc32, 14);
+  header.writeUInt32LE(record.size, 18);
+  header.writeUInt32LE(record.size, 22);
+  header.writeUInt16LE(filename.length, 26);
+  header.writeUInt16LE(0, 28);
+  return Buffer.concat([header, filename]);
+}
+
+function buildCentralDirectoryHeader(record: StoredZipEntryRecord) {
+  const filename = Buffer.from(record.entryName, "utf8");
+  const header = Buffer.alloc(46);
+  header.writeUInt32LE(0x02014b50, 0);
+  header.writeUInt16LE(20, 4);
+  header.writeUInt16LE(20, 6);
+  header.writeUInt16LE(0x0800, 8);
+  header.writeUInt16LE(0, 10);
+  header.writeUInt16LE(record.dosTime, 12);
+  header.writeUInt16LE(record.dosDate, 14);
+  header.writeUInt32LE(record.crc32, 16);
+  header.writeUInt32LE(record.size, 20);
+  header.writeUInt32LE(record.size, 24);
+  header.writeUInt16LE(filename.length, 28);
+  header.writeUInt16LE(0, 30);
+  header.writeUInt16LE(0, 32);
+  header.writeUInt16LE(0, 34);
+  header.writeUInt16LE(0, 36);
+  header.writeUInt32LE(0, 38);
+  header.writeUInt32LE(record.localHeaderOffset, 42);
+  return Buffer.concat([header, filename]);
+}
+
+function buildEndOfCentralDirectory(entryCount: number, centralDirectorySize: number, centralDirectoryOffset: number) {
+  if (entryCount > 0xffff) throw new Error("Profile ZIP contains too many entries.");
+  const header = Buffer.alloc(22);
+  header.writeUInt32LE(0x06054b50, 0);
+  header.writeUInt16LE(0, 4);
+  header.writeUInt16LE(0, 6);
+  header.writeUInt16LE(entryCount, 8);
+  header.writeUInt16LE(entryCount, 10);
+  header.writeUInt32LE(centralDirectorySize, 12);
+  header.writeUInt32LE(centralDirectoryOffset, 16);
+  header.writeUInt16LE(0, 20);
+  return header;
+}
+
+async function writeStoredZipFileEntry(
+  stream: WriteStream,
+  source: StoredZipEntrySource,
+  position: number,
+): Promise<{ record: StoredZipEntryRecord; position: number }> {
+  const entryName = normalizeStoredZipEntryName(source.entryName);
+  const { dosTime, dosDate } = getZipDosTimeDate(source.mtime);
+  const size = "data" in source ? source.data.length : source.size;
+  assertZip32Value(size, `${entryName} size`);
+  assertZip32Value(position, `${entryName} offset`);
+
+  const crc32 = "data" in source ? crc32Buffer(source.data) : await crc32File(source.filePath);
+  const record: StoredZipEntryRecord = {
+    entryName,
+    crc32,
+    size,
+    localHeaderOffset: position,
+    dosTime,
+    dosDate,
+  };
+  const header = buildLocalFileHeader(record);
+  await writeZipBuffer(stream, header);
+  position += header.length;
+
+  if ("data" in source) {
+    await writeZipBuffer(stream, source.data);
+    position += source.data.length;
+  } else {
+    let written = 0;
+    for await (const chunk of createReadStream(source.filePath)) {
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      await writeZipBuffer(stream, buffer);
+      written += buffer.length;
+      position += buffer.length;
+    }
+    if (written !== source.size) {
+      throw new Error(`Profile ZIP source changed while exporting: ${entryName}`);
+    }
+  }
+
+  return { record, position };
+}
+
+async function finishZipStream(stream: WriteStream) {
+  await new Promise<void>((resolve, reject) => {
+    const onError = (err: Error) => {
+      stream.off("finish", onFinish);
+      reject(err);
+    };
+    const onFinish = () => {
+      stream.off("error", onError);
+      resolve();
+    };
+    stream.once("error", onError);
+    stream.once("finish", onFinish);
+    stream.end();
+  });
+}
+
+async function writeStoredZipArchive(outputPath: string, sources: StoredZipEntrySource[]) {
+  const stream = createWriteStream(outputPath);
+  const records: StoredZipEntryRecord[] = [];
+  let position = 0;
+
+  try {
+    for (const source of sources) {
+      const result = await writeStoredZipFileEntry(stream, source, position);
+      records.push(result.record);
+      position = result.position;
+    }
+
+    const centralDirectoryOffset = position;
+    assertZip32Value(centralDirectoryOffset, "central directory offset");
+    for (const record of records) {
+      const header = buildCentralDirectoryHeader(record);
+      await writeZipBuffer(stream, header);
+      position += header.length;
+    }
+    const centralDirectorySize = position - centralDirectoryOffset;
+    assertZip32Value(centralDirectorySize, "central directory size");
+    const end = buildEndOfCentralDirectory(records.length, centralDirectorySize, centralDirectoryOffset);
+    await writeZipBuffer(stream, end);
+    await finishZipStream(stream);
+  } catch (err) {
+    stream.destroy();
+    throw err;
+  }
+}
+
+async function readProfileZipBytes(handle: FileHandle, buffer: Buffer, position: number, label: string) {
+  let offset = 0;
+  while (offset < buffer.length) {
+    const { bytesRead } = await handle.read(buffer, offset, buffer.length - offset, position + offset);
+    if (bytesRead === 0) {
+      throw new ProfileImportRequestError(`Profile archive ${label} ended unexpectedly.`);
+    }
+    offset += bytesRead;
+  }
+}
+
+async function readProfileArchiveFileRange(filePath: string, position: number, length: number, label: string) {
+  if (!Number.isSafeInteger(position) || position < 0 || !Number.isSafeInteger(length) || length < 0) {
+    throw new ProfileImportRequestError(`Profile archive ${label} has an invalid offset.`);
+  }
+  if (length > PROFILE_ARCHIVE_ENTRY_LIMIT_BYTES) {
+    throw new ProfileImportRequestError(profileArchiveSizeError(label, length, PROFILE_ARCHIVE_ENTRY_LIMIT_BYTES));
+  }
+  const buffer = Buffer.alloc(length);
+  if (length === 0) return buffer;
+  const handle = await open(filePath, "r");
+  try {
+    await readProfileZipBytes(handle, buffer, position, label);
+    return buffer;
+  } finally {
+    await handle.close();
+  }
+}
+
+function findEndOfCentralDirectory(buffer: Buffer) {
+  for (let offset = buffer.length - ZIP_EOCD_MIN_SIZE; offset >= 0; offset--) {
+    if (buffer.readUInt32LE(offset) !== ZIP_EOCD_SIGNATURE) continue;
+    const commentLength = buffer.readUInt16LE(offset + 20);
+    if (offset + ZIP_EOCD_MIN_SIZE + commentLength === buffer.length) return offset;
+  }
+  return -1;
+}
+
+function readZip32Value(buffer: Buffer, offset: number, label: string) {
+  const value = buffer.readUInt32LE(offset);
+  if (value === ZIP32_MAX_VALUE) {
+    throw new ProfileImportRequestError(`Profile archive ${label} uses unsupported ZIP64 metadata.`);
+  }
+  return value;
+}
+
+async function readProfileZipArchive(filePath: string): Promise<ProfileZipArchive> {
+  const archiveStat = await stat(filePath);
+  if (archiveStat.size > PROFILE_IMPORT_ARCHIVE_LIMIT_BYTES) {
+    throw new ProfileImportArchiveTooLargeError(
+      profileArchiveSizeError("Profile archive", archiveStat.size, PROFILE_IMPORT_ARCHIVE_LIMIT_BYTES),
+    );
+  }
+  if (archiveStat.size < ZIP_EOCD_MIN_SIZE) {
+    throw new ProfileImportRequestError("Profile archive is not a valid ZIP file.");
+  }
+
+  const handle = await open(filePath, "r");
+  try {
+    const eocdSearchLength = Math.min(archiveStat.size, ZIP_EOCD_MIN_SIZE + ZIP_EOCD_MAX_COMMENT_BYTES);
+    const eocdSearch = Buffer.alloc(eocdSearchLength);
+    await readProfileZipBytes(handle, eocdSearch, archiveStat.size - eocdSearchLength, "end record");
+
+    const eocdOffset = findEndOfCentralDirectory(eocdSearch);
+    if (eocdOffset < 0) {
+      throw new ProfileImportRequestError("Profile archive is missing a ZIP end record.");
+    }
+
+    const diskNumber = eocdSearch.readUInt16LE(eocdOffset + 4);
+    const centralDirectoryDisk = eocdSearch.readUInt16LE(eocdOffset + 6);
+    const entriesOnDisk = eocdSearch.readUInt16LE(eocdOffset + 8);
+    const totalEntries = eocdSearch.readUInt16LE(eocdOffset + 10);
+    if (diskNumber !== 0 || centralDirectoryDisk !== 0 || entriesOnDisk !== totalEntries) {
+      throw new ProfileImportRequestError("Profile archive split ZIP files are not supported.");
+    }
+    if (totalEntries === 0xffff) {
+      throw new ProfileImportRequestError("Profile archive uses unsupported ZIP64 metadata.");
+    }
+
+    const centralDirectorySize = readZip32Value(eocdSearch, eocdOffset + 12, "central directory size");
+    const centralDirectoryOffset = readZip32Value(eocdSearch, eocdOffset + 16, "central directory offset");
+    if (centralDirectorySize > PROFILE_ARCHIVE_CENTRAL_DIRECTORY_LIMIT_BYTES) {
+      throw new ProfileImportRequestError(
+        profileArchiveSizeError(
+          "Profile archive central directory",
+          centralDirectorySize,
+          PROFILE_ARCHIVE_CENTRAL_DIRECTORY_LIMIT_BYTES,
+        ),
+      );
+    }
+    if (centralDirectoryOffset + centralDirectorySize > archiveStat.size) {
+      throw new ProfileImportRequestError("Profile archive central directory is outside the ZIP file.");
+    }
+
+    const centralDirectory = Buffer.alloc(centralDirectorySize);
+    await readProfileZipBytes(handle, centralDirectory, centralDirectoryOffset, "central directory");
+
+    const entries: ProfileZipEntry[] = [];
+    const entriesByName = new Map<string, ProfileZipEntry>();
+    let offset = 0;
+    for (let index = 0; index < totalEntries; index++) {
+      if (
+        offset + 46 > centralDirectory.length ||
+        centralDirectory.readUInt32LE(offset) !== ZIP_CENTRAL_DIRECTORY_SIGNATURE
+      ) {
+        throw new ProfileImportRequestError("Profile archive central directory is damaged.");
+      }
+
+      const flags = centralDirectory.readUInt16LE(offset + 8);
+      if ((flags & ZIP_ENCRYPTED_FLAG) !== 0) {
+        throw new ProfileImportRequestError("Profile archive encrypted ZIP entries are not supported.");
+      }
+      const method = centralDirectory.readUInt16LE(offset + 10);
+      const compressedSize = readZip32Value(centralDirectory, offset + 20, "entry compressed size");
+      const size = readZip32Value(centralDirectory, offset + 24, "entry size");
+      const fileNameLength = centralDirectory.readUInt16LE(offset + 28);
+      const extraLength = centralDirectory.readUInt16LE(offset + 30);
+      const commentLength = centralDirectory.readUInt16LE(offset + 32);
+      const localHeaderOffset = readZip32Value(centralDirectory, offset + 42, "entry offset");
+      const nextOffset = offset + 46 + fileNameLength + extraLength + commentLength;
+      if (nextOffset > centralDirectory.length) {
+        throw new ProfileImportRequestError("Profile archive central directory entry is damaged.");
+      }
+
+      if (localHeaderOffset + 30 > archiveStat.size) {
+        throw new ProfileImportRequestError("Profile archive entry points outside the ZIP file.");
+      }
+      const localHeader = Buffer.alloc(30);
+      await readProfileZipBytes(handle, localHeader, localHeaderOffset, "local file header");
+      if (localHeader.readUInt32LE(0) !== ZIP_LOCAL_FILE_HEADER_SIGNATURE) {
+        throw new ProfileImportRequestError("Profile archive local file header is damaged.");
+      }
+      const localFileNameLength = localHeader.readUInt16LE(26);
+      const localExtraLength = localHeader.readUInt16LE(28);
+      const dataOffset = localHeaderOffset + 30 + localFileNameLength + localExtraLength;
+      if (dataOffset + compressedSize > archiveStat.size) {
+        throw new ProfileImportRequestError("Profile archive entry data is outside the ZIP file.");
+      }
+
+      const entryName = centralDirectory.subarray(offset + 46, offset + 46 + fileNameLength).toString("utf8");
+      const normalizedName = normalizeProfileArchiveEntryPath(entryName);
+      const entry: ProfileZipEntry = {
+        entryName: normalizedName,
+        isDirectory: normalizedName.endsWith("/"),
+        header: { method, compressedSize, size, dataOffset },
+      };
+      entries.push(entry);
+      if (normalizedName && !entriesByName.has(normalizedName)) entriesByName.set(normalizedName, entry);
+      offset = nextOffset;
+    }
+
+    if (offset !== centralDirectory.length) {
+      throw new ProfileImportRequestError("Profile archive central directory has unexpected trailing data.");
+    }
+
+    return { filePath, entries, entriesByName };
+  } finally {
+    await handle.close();
+  }
+}
+
+function getProfileZipEntry(zip: ProfileZipArchive, entryName: string) {
+  return zip.entriesByName.get(normalizeProfileArchiveEntryPath(entryName));
+}
+
+async function readProfileEnvelopeFromArchive(zip: ProfileZipArchive) {
+  const profileEntry =
+    zip.entries.find((entry) => !entry.isDirectory && entry.entryName === "marinara-profile.json") ??
+    zip.entries.find((entry) => !entry.isDirectory && entry.entryName.endsWith("/marinara-profile.json"));
+
+  if (!profileEntry) {
+    throw new ProfileImportRequestError("Profile archive is missing marinara-profile.json.");
+  }
+
+  try {
+    const profileEntrySize = getZipEntryUncompressedSize(profileEntry);
+    if (profileEntrySize === null || profileEntrySize > PROFILE_IMPORT_BODY_LIMIT_BYTES) {
+      throw new ProfileImportRequestError(
+        profileArchiveSizeError(
+          "Profile archive marinara-profile.json",
+          profileEntrySize ?? -1,
+          PROFILE_IMPORT_BODY_LIMIT_BYTES,
+        ),
+      );
+    }
+    const profileBuffer = await readProfileArchiveEntryBuffer(zip, profileEntry, profileEntrySize);
+    return {
+      envelope: JSON.parse(profileBuffer.toString("utf8")) as ExportEnvelope,
+      basePath: profileArchiveBasePath(profileEntry.entryName),
+    };
+  } catch (err) {
+    if (err instanceof ProfileImportRequestError) throw err;
+    throw new ProfileImportRequestError("Profile archive contains an unreadable marinara-profile.json.");
+  }
+}
+
+async function readProfileArchiveEntryBuffer(zip: ProfileZipArchive, entry: ProfileZipEntry, expectedSize: number) {
+  const compressedSize = getZipEntryCompressedSize(entry);
+  const uncompressedSize = getZipEntryUncompressedSize(entry);
+  if (compressedSize === null || uncompressedSize === null) {
+    throw new ProfileImportRequestError(`Profile archive entry ${entry.entryName} has an invalid size header.`);
+  }
+  if (compressedSize > PROFILE_ARCHIVE_ENTRY_LIMIT_BYTES || uncompressedSize > PROFILE_ARCHIVE_ENTRY_LIMIT_BYTES) {
+    throw new ProfileImportRequestError(
+      profileArchiveSizeError(
+        entry.entryName,
+        Math.max(compressedSize, uncompressedSize),
+        PROFILE_ARCHIVE_ENTRY_LIMIT_BYTES,
+      ),
+    );
+  }
+  if (uncompressedSize !== expectedSize) {
+    throw new ProfileImportRequestError(`Profile archive entry ${entry.entryName} does not match its manifest size.`);
+  }
+
+  const compressed = await readProfileArchiveFileRange(
+    zip.filePath,
+    entry.header.dataOffset,
+    compressedSize,
+    entry.entryName,
+  );
+  let data: Buffer;
+  if (entry.header.method === 0) {
+    data = compressed;
+  } else if (entry.header.method === 8) {
+    try {
+      data = inflateRawSync(compressed, { maxOutputLength: expectedSize });
+    } catch {
+      throw new ProfileImportRequestError(`Profile archive entry ${entry.entryName} could not be decompressed.`);
+    }
+  } else {
+    throw new ProfileImportRequestError(`Profile archive entry ${entry.entryName} uses an unsupported ZIP method.`);
+  }
+  if (data.length !== expectedSize) {
+    throw new ProfileImportRequestError(`Profile archive entry ${entry.entryName} does not match its manifest size.`);
+  }
+  return data;
+}
+
+function validateProfileArchiveAssets(
+  zip: ProfileZipArchive,
+  basePath: string,
+  envelope: ExportEnvelope,
+  warnings: ProfileImportWarning[],
+) {
+  const snapshot = getProfileStorageSnapshotFromEnvelope(envelope);
+  const assets: ProfileArchiveAssetIndex = new Map();
+  if (!snapshot || !Array.isArray(snapshot.files)) return assets;
+
+  let totalUncompressedBytes = 0;
+  for (const file of snapshot.files) {
+    if (typeof file?.data === "string") continue;
+    const safePath = normalizeProfileAssetPath(file?.path);
+    if (!safePath) continue;
+    const entryName = profileArchiveEntryPath(basePath, safePath);
+    const expectedSize = getProfileAssetManifestSize(file, safePath);
+    assertProfileArchiveEntryLimit(safePath, expectedSize);
+    const entry = getProfileZipEntry(zip, entryName);
+    if (!entry || entry.isDirectory) {
+      warnings.push({
+        type: "missing_asset",
+        path: safePath,
+        message: `Profile archive is missing ${safePath}. Imported the rest of the profile without that asset.`,
+      });
+      continue;
+    }
+    const entrySize = getZipEntryUncompressedSize(entry);
+    if (entrySize === null || entrySize !== expectedSize) {
+      throw new ProfileImportRequestError(`Profile archive asset ${safePath} does not match its manifest size.`);
+    }
+    const compressedSize = getZipEntryCompressedSize(entry);
+    if (compressedSize === null || compressedSize > PROFILE_ARCHIVE_ENTRY_LIMIT_BYTES) {
+      throw new ProfileImportRequestError(
+        profileArchiveSizeError(safePath, compressedSize ?? -1, PROFILE_ARCHIVE_ENTRY_LIMIT_BYTES),
+      );
+    }
+    totalUncompressedBytes += expectedSize;
+    assertProfileArchiveTotalLimit(totalUncompressedBytes);
+    assets.set(safePath, { entryName, expectedSize });
+  }
+  return assets;
+}
+
+async function readProfileArchiveAsset(
+  zip: ProfileZipArchive,
+  archiveAssets: ProfileArchiveAssetIndex,
+  safePath: string,
+) {
+  const normalized = normalizeProfileAssetPath(safePath);
+  if (!normalized) return null;
+  const asset = archiveAssets.get(normalized);
+  if (!asset) return null;
+  const entry = getProfileZipEntry(zip, asset.entryName);
+  if (!entry || entry.isDirectory) return null;
+  return readProfileArchiveEntryBuffer(zip, entry, asset.expectedSize);
+}
+
+async function readProfileImportRequest(req: FastifyRequest): Promise<ProfileImportInput> {
+  const contentType = String(req.headers["content-type"] ?? "").toLowerCase();
+  if (!contentType.includes("multipart/form-data")) {
+    return { envelope: req.body as ExportEnvelope };
+  }
+
+  const uploadDir = await mkdtemp(join(tmpdir(), "marinara-profile-import-"));
+  const archivePath = join(uploadDir, "profile.zip");
+  try {
+    const file = await req.file({ limits: { fileSize: PROFILE_IMPORT_ARCHIVE_LIMIT_BYTES } });
+    if (!file) throw new ProfileImportRequestError("No profile archive uploaded.");
+    const fileStream = file.file as typeof file.file & { truncated?: boolean };
+    await pipeline(fileStream, createWriteStream(archivePath));
+    if (fileStream.truncated) {
+      throw new ProfileImportArchiveTooLargeError(
+        profileArchiveSizeError(
+          "Profile archive",
+          PROFILE_IMPORT_ARCHIVE_LIMIT_BYTES + 1,
+          PROFILE_IMPORT_ARCHIVE_LIMIT_BYTES,
+        ),
+      );
+    }
+    const zip = await readProfileZipArchive(archivePath);
+    const { envelope, basePath } = await readProfileEnvelopeFromArchive(zip);
+    const warnings: ProfileImportWarning[] = [];
+    const archiveAssets = validateProfileArchiveAssets(zip, basePath, envelope, warnings);
+    return {
+      envelope,
+      readAsset: (safePath) => readProfileArchiveAsset(zip, archiveAssets, safePath),
+      warnings,
+      cleanup: () => rm(uploadDir, { recursive: true, force: true }),
+    };
+  } catch (err) {
+    await rm(uploadDir, { recursive: true, force: true }).catch(() => {});
+    if ((err as { code?: string }).code === "FST_REQ_FILE_TOO_LARGE") {
+      throw new ProfileImportArchiveTooLargeError(
+        profileArchiveSizeError(
+          "Profile archive",
+          PROFILE_IMPORT_ARCHIVE_LIMIT_BYTES + 1,
+          PROFILE_IMPORT_ARCHIVE_LIMIT_BYTES,
+        ),
+      );
+    }
+    if (err instanceof ProfileImportRequestError) throw err;
+    throw new ProfileImportRequestError(getBackupErrorMessage(err, "Profile archive could not be read."));
+  }
 }
 
 function buildBackupRestoreNotes() {
@@ -480,9 +1431,9 @@ function buildBackupRestoreNotes() {
     "This archive contains a raw filesystem backup for manual recovery.",
     "",
     "For one-click import inside Marinara:",
-    "1. Extract marinara-profile.json from this zip.",
-    "2. Open Settings -> Import.",
-    "3. Use Import Profile (JSON), not Import Marinara File (.marinara.json).",
+    "1. Open Settings -> Import.",
+    "2. Use Import Profile and select the downloaded backup zip archive.",
+    "3. If this backup has been extracted, marinara-profile.json restores data without asset files.",
     "",
     "The .marinara.json importer is for individual characters, personas, lorebooks, and presets.",
   ].join("\n");
@@ -518,7 +1469,10 @@ export async function backupRoutes(app: FastifyInstance) {
       const backupDir = join(backupsRoot, backupName);
 
       await mkdir(backupDir, { recursive: true });
-      const profileEnvelope = await buildProfileExportEnvelope(app);
+      const profileEnvelope = await buildProfileExportEnvelope(app, {
+        inlineFileData: false,
+        includeLegacyAvatarBase64: false,
+      });
       await writeFile(join(backupDir, "marinara-profile.json"), JSON.stringify(profileEnvelope, null, 2), "utf8");
       await writeFile(join(backupDir, "RESTORE.txt"), buildBackupRestoreNotes(), "utf8");
 
@@ -565,7 +1519,10 @@ export async function backupRoutes(app: FastifyInstance) {
       const backupName = `marinara-backup-${timestamp}`;
 
       const zip = new AdmZip();
-      const profileEnvelope = await buildProfileExportEnvelope(app);
+      const profileEnvelope = await buildProfileExportEnvelope(app, {
+        inlineFileData: false,
+        includeLegacyAvatarBase64: false,
+      });
       zip.addFile(`${backupName}/marinara-profile.json`, Buffer.from(JSON.stringify(profileEnvelope, null, 2), "utf8"));
       zip.addFile(`${backupName}/RESTORE.txt`, Buffer.from(buildBackupRestoreNotes(), "utf8"));
 
@@ -653,8 +1610,7 @@ export async function backupRoutes(app: FastifyInstance) {
   });
 
   // ── Profile Export ──
-  // Returns a portable JSON envelope with characters, personas, lorebooks,
-  // presets (+ groups/sections/choices), agent configs, and synced custom themes.
+  // Native keeps the original profile JSON shape; ZIP is offered when JSON gets too large.
   app.get<{ Querystring: { format?: ExportFormat } }>("/export-profile", async (req, reply) => {
     if (!requirePrivilegedAccess(req, reply, { feature: "Profile export" })) return;
 
@@ -669,430 +1625,455 @@ export async function backupRoutes(app: FastifyInstance) {
           .send(buffer);
       }
 
-      const envelope = await buildProfileExportEnvelope(app);
+      if (req.query.format === "zip") {
+        return await sendNativeProfileZipExport(app, reply);
+      }
 
-      return reply
-        .header("Content-Disposition", `attachment; filename="marinara-profile.json"`)
-        .header("Content-Type", "application/json")
-        .send(envelope);
+      return await sendNativeProfileJsonExport(app, reply);
     } catch (err) {
+      if (err instanceof ProfileArchiveTooLargeError) {
+        return reply.status(413).send({
+          error: "Profile ZIP export is too large",
+          message: err.message,
+        });
+      }
       return sendBackupRouteError(reply, err, "Profile export");
     }
   });
 
   // ── Profile Import ──
-  // Accepts a profile JSON envelope and creates all entities.
+  // Accepts a profile JSON envelope or profile ZIP archive and creates all entities.
   app.post("/import-profile", { bodyLimit: PROFILE_IMPORT_BODY_LIMIT_BYTES }, async (req, reply) => {
     if (!requirePrivilegedAccess(req, reply, { feature: "Profile import" })) return;
-    const envelope = req.body as ExportEnvelope;
-    if (!envelope || envelope.type !== "marinara_profile" || envelope.version !== 1) {
-      return reply.status(400).send({ error: "Invalid profile export" });
-    }
 
-    const data = envelope.data as Record<string, any>;
     const wantsProgressStream = String(req.headers.accept ?? "").includes("text/event-stream");
-    const totalItems = isProfileStorageSnapshot(data.fileStorage)
-      ? Math.max(1, countProfileStorageSnapshotItems(data.fileStorage))
-      : Math.max(1, countLegacyProfileImportItems(data));
-    const sendEvent = (event: { type: string; data?: unknown; [key: string]: unknown }) => {
-      if (wantsProgressStream && !reply.raw.destroyed) {
-        reply.raw.write(`data: ${JSON.stringify(event)}\n\n`);
-      }
-    };
-    const sendProgress = (progress: ProfileImportProgress) => {
-      sendEvent({ type: "progress", data: progress });
-    };
-
-    if (wantsProgressStream) {
-      reply.raw.writeHead(200, {
-        "Content-Type": "text/event-stream",
-        "Cache-Control": "no-cache",
-        Connection: "keep-alive",
-      });
-      sendEvent({
-        type: "started",
-        data: {
-          label: "Profile import started",
-          totalItems,
-        },
-      });
+    let importInput: ProfileImportInput;
+    try {
+      importInput = await readProfileImportRequest(req);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Profile import file could not be read.";
+      const statusCode = err instanceof ProfileImportArchiveTooLargeError ? 413 : 400;
+      return reply.status(statusCode).send({ error: "Invalid profile export", message });
     }
 
     try {
-      if (isProfileStorageSnapshot(data.fileStorage)) {
-        const imported = await importProfileStorageSnapshot(
-          app,
-          data.fileStorage,
-          wantsProgressStream ? sendProgress : undefined,
-        );
-        if (wantsProgressStream) {
-          sendEvent({ type: "done", data: { success: true, imported } });
-          reply.raw.end();
-          return;
-        }
-        return { success: true, imported };
+      const envelope = importInput.envelope;
+      if (!envelope || envelope.type !== "marinara_profile" || envelope.version !== 1) {
+        return reply.status(400).send({ error: "Invalid profile export" });
       }
 
-      const chars = createCharactersStorage(app.db);
-      const lbs = createLorebooksStorage(app.db);
-      const presets = createPromptsStorage(app.db);
-      const agents = createAgentsStorage(app.db);
-      const themes = createThemesStorage(app.db);
-
-      const stats = { characters: 0, personas: 0, lorebooks: 0, presets: 0, agents: 0, themes: 0 };
-      let completedItems = 0;
-      const emitLegacyProgress = (phase: string, label: string) => {
-        if (!wantsProgressStream) return;
-        sendProgress({
-          phase,
-          label,
-          completedItems,
-          totalItems,
-          imported: { ...stats },
-        });
+      const data = envelope.data as Record<string, any>;
+      const warnings = importInput.warnings ?? [];
+      const totalItems = isProfileStorageSnapshot(data.fileStorage)
+        ? Math.max(1, countProfileStorageSnapshotItems(data.fileStorage))
+        : Math.max(1, countLegacyProfileImportItems(data));
+      const sendEvent = (event: { type: string; data?: unknown; [key: string]: unknown }) => {
+        if (wantsProgressStream && !reply.raw.destroyed) {
+          reply.raw.write(`data: ${JSON.stringify(event)}\n\n`);
+        }
+      };
+      const sendProgress = (progress: ProfileImportProgress) => {
+        sendEvent({ type: "progress", data: progress });
       };
 
-      // Import characters
-      if (Array.isArray(data.characters)) {
-        for (const c of data.characters) {
-          try {
+      if (wantsProgressStream) {
+        reply.raw.writeHead(200, {
+          "Content-Type": "text/event-stream",
+          "Cache-Control": "no-cache",
+          Connection: "keep-alive",
+        });
+        sendEvent({
+          type: "started",
+          data: {
+            label: "Profile import started",
+            totalItems,
+          },
+        });
+      }
+
+      try {
+        if (isProfileStorageSnapshot(data.fileStorage)) {
+          const imported = await importProfileStorageSnapshot(
+            app,
+            data.fileStorage,
+            wantsProgressStream ? sendProgress : undefined,
+            importInput.readAsset,
+          );
+          const payload = { success: true, imported, warnings };
+          if (wantsProgressStream) {
+            sendEvent({ type: "done", data: payload });
+            reply.raw.end();
+            return;
+          }
+          return payload;
+        }
+
+        const chars = createCharactersStorage(app.db);
+        const lbs = createLorebooksStorage(app.db);
+        const presets = createPromptsStorage(app.db);
+        const agents = createAgentsStorage(app.db);
+        const themes = createThemesStorage(app.db);
+
+        const stats = { characters: 0, personas: 0, lorebooks: 0, presets: 0, agents: 0, themes: 0 };
+        let completedItems = 0;
+        const emitLegacyProgress = (phase: string, label: string) => {
+          if (!wantsProgressStream) return;
+          sendProgress({
+            phase,
+            label,
+            completedItems,
+            totalItems,
+            imported: { ...stats },
+          });
+        };
+
+        // Import characters
+        if (Array.isArray(data.characters)) {
+          for (const c of data.characters) {
+            try {
+              emitLegacyProgress("characters", "Importing characters");
+              const charData = typeof c.data === "string" ? JSON.parse(c.data) : c.data;
+              const result = await chars.create(
+                charData,
+                c.avatarPath ?? undefined,
+                normalizeTimestampOverrides({ createdAt: c.createdAt, updatedAt: c.updatedAt }),
+                typeof c.comment === "string" ? c.comment : undefined,
+              );
+              // Restore avatar from base64 if provided
+              if (c.avatarBase64 && result?.avatarPath) {
+                const dataDir = getDataDir();
+                const avatarDir = join(dataDir, "avatars");
+                await mkdir(avatarDir, { recursive: true });
+                const { writeFile } = await import("fs/promises");
+                const avatarFile = resolveAvatarWritePath(dataDir, result.avatarPath);
+                if (avatarFile) {
+                  await writeFile(avatarFile, Buffer.from(c.avatarBase64, "base64"));
+                }
+              }
+              stats.characters++;
+            } catch {
+              /* skip failed entries */
+            }
+            completedItems++;
             emitLegacyProgress("characters", "Importing characters");
-            const charData = typeof c.data === "string" ? JSON.parse(c.data) : c.data;
-            const result = await chars.create(
-              charData,
-              c.avatarPath ?? undefined,
-              normalizeTimestampOverrides({ createdAt: c.createdAt, updatedAt: c.updatedAt }),
-              typeof c.comment === "string" ? c.comment : undefined,
-            );
-            // Restore avatar from base64 if provided
-            if (c.avatarBase64 && result?.avatarPath) {
-              const dataDir = getDataDir();
-              const avatarDir = join(dataDir, "avatars");
-              await mkdir(avatarDir, { recursive: true });
-              const { writeFile } = await import("fs/promises");
-              const avatarFile = resolveAvatarWritePath(dataDir, result.avatarPath);
-              if (avatarFile) {
-                await writeFile(avatarFile, Buffer.from(c.avatarBase64, "base64"));
-              }
-            }
-            stats.characters++;
-          } catch {
-            /* skip failed entries */
           }
-          completedItems++;
-          emitLegacyProgress("characters", "Importing characters");
         }
-      }
 
-      // Import personas
-      if (Array.isArray(data.personas)) {
-        for (const p of data.personas) {
-          try {
-            emitLegacyProgress("personas", "Importing personas");
-            // Restore persona avatar from base64 if provided
-            let personaAvatarPath: string | undefined;
-            if (p.avatarBase64) {
-              const dataDir = getDataDir();
-              const avatarDir = join(dataDir, "avatars");
-              await mkdir(avatarDir, { recursive: true });
-              const ext = ".png";
-              const avatarName = `persona-${Date.now()}-${Math.random().toString(36).slice(2, 8)}${ext}`;
-              personaAvatarPath = `avatars/${avatarName}`;
-              const { writeFile } = await import("fs/promises");
-              await writeFile(join(dataDir, personaAvatarPath), Buffer.from(p.avatarBase64, "base64"));
-            }
-            await chars.createPersona(
-              p.name,
-              p.description ?? "",
-              personaAvatarPath,
-              {
-                comment: p.comment,
-                personality: p.personality,
-                backstory: p.backstory,
-                appearance: p.appearance,
-                scenario: p.scenario,
-                nameColor: p.nameColor,
-                dialogueColor: p.dialogueColor,
-                boxColor: p.boxColor,
-                trackerCardColors:
-                  typeof p.trackerCardColors === "string"
-                    ? p.trackerCardColors
-                    : JSON.stringify(p.trackerCardColors ?? { mode: "chat" }),
-                personaStats: p.personaStats,
-                altDescriptions:
-                  typeof p.altDescriptions === "string" ? p.altDescriptions : JSON.stringify(p.altDescriptions ?? []),
-              },
-              normalizeTimestampOverrides({ createdAt: p.createdAt, updatedAt: p.updatedAt }),
-            );
-            stats.personas++;
-          } catch {
-            /* skip */
-          }
-          completedItems++;
-          emitLegacyProgress("personas", "Importing personas");
-        }
-      }
-
-      // Import lorebooks + entries
-      if (Array.isArray(data.lorebooks)) {
-        for (const lb of data.lorebooks) {
-          try {
-            emitLegacyProgress("lorebooks", "Importing lorebooks");
-            const created = await lbs.create(
-              {
-                name: lb.name,
-                description: lb.description ?? "",
-                category: lb.category ?? "uncategorized",
-                scanDepth: lb.scanDepth,
-                tokenBudget: lb.tokenBudget,
-                recursiveScanning: lb.recursiveScanning,
-                maxRecursionDepth: lb.maxRecursionDepth,
-                enabled: lb.enabled ?? true,
-                characterId: lb.characterId ?? null,
-                characterIds: Array.isArray(lb.characterIds)
-                  ? lb.characterIds.filter((value: unknown): value is string => typeof value === "string")
-                  : typeof lb.characterId === "string"
-                    ? [lb.characterId]
-                    : [],
-                personaId: lb.personaId ?? null,
-                personaIds: Array.isArray(lb.personaIds)
-                  ? lb.personaIds.filter((value: unknown): value is string => typeof value === "string")
-                  : typeof lb.personaId === "string"
-                    ? [lb.personaId]
-                    : [],
-                chatId: lb.chatId ?? null,
-                isGlobal: lb.isGlobal ?? false,
-                tags: Array.isArray(lb.tags) ? lb.tags : [],
-                generatedBy: lb.generatedBy ?? null,
-                sourceAgentId: lb.sourceAgentId ?? null,
-              },
-              normalizeTimestampOverrides({ createdAt: lb.createdAt, updatedAt: lb.updatedAt }),
-            );
-            const folderIdMap = new Map<string, string>();
-            if (created && Array.isArray(lb.folders)) {
-              for (const folder of lb.folders) {
-                const oldId = typeof folder.id === "string" ? folder.id : null;
-                const createdFolder = (await lbs.createFolder((created as any).id, {
-                  name: folder.name ?? "Folder",
-                  enabled: folder.enabled === "true" || folder.enabled === true,
-                  parentFolderId: null,
-                  order: folder.order ?? 0,
-                })) as { id?: string } | null;
-                if (oldId && createdFolder?.id) folderIdMap.set(oldId, createdFolder.id);
+        // Import personas
+        if (Array.isArray(data.personas)) {
+          for (const p of data.personas) {
+            try {
+              emitLegacyProgress("personas", "Importing personas");
+              // Restore persona avatar from base64 if provided
+              let personaAvatarPath: string | undefined;
+              if (p.avatarBase64) {
+                const dataDir = getDataDir();
+                const avatarDir = join(dataDir, "avatars");
+                await mkdir(avatarDir, { recursive: true });
+                const ext = ".png";
+                const avatarName = `persona-${Date.now()}-${Math.random().toString(36).slice(2, 8)}${ext}`;
+                personaAvatarPath = `avatars/${avatarName}`;
+                const { writeFile } = await import("fs/promises");
+                await writeFile(join(dataDir, personaAvatarPath), Buffer.from(p.avatarBase64, "base64"));
               }
-            }
-            if (created && Array.isArray(lb.entries)) {
-              for (const entry of lb.entries) {
-                const folderId =
-                  typeof entry.folderId === "string" && folderIdMap.has(entry.folderId)
-                    ? folderIdMap.get(entry.folderId)
-                    : null;
-                await lbs.createEntry({ ...entry, lorebookId: (created as any).id, folderId });
-              }
-            }
-            stats.lorebooks++;
-          } catch {
-            /* skip */
-          }
-          completedItems++;
-          emitLegacyProgress("lorebooks", "Importing lorebooks");
-        }
-      }
-
-      // Import presets with full hierarchy (groups, sections, choice blocks)
-      if (Array.isArray(data.presets)) {
-        for (const p of data.presets) {
-          try {
-            emitLegacyProgress("presets", "Importing presets");
-            const existing = await presets.getById(p.id);
-            if (!existing) {
-              const created = await presets.create(
+              await chars.createPersona(
+                p.name,
+                p.description ?? "",
+                personaAvatarPath,
                 {
-                  name: `${p.name} (imported)`,
-                  description: p.description ?? "",
-                  parameters:
-                    typeof p.parameters === "string" ? JSON.parse(p.parameters) : (p.parameters ?? p.generationParams),
-                  variableGroups:
-                    typeof p.variableGroups === "string" ? JSON.parse(p.variableGroups) : (p.variableGroups ?? []),
-                  variableValues:
-                    typeof p.variableValues === "string" ? JSON.parse(p.variableValues) : (p.variableValues ?? {}),
+                  comment: p.comment,
+                  personality: p.personality,
+                  backstory: p.backstory,
+                  appearance: p.appearance,
+                  scenario: p.scenario,
+                  nameColor: p.nameColor,
+                  dialogueColor: p.dialogueColor,
+                  boxColor: p.boxColor,
+                  trackerCardColors:
+                    typeof p.trackerCardColors === "string"
+                      ? p.trackerCardColors
+                      : JSON.stringify(p.trackerCardColors ?? { mode: "chat" }),
+                  personaStats: p.personaStats,
+                  altDescriptions:
+                    typeof p.altDescriptions === "string" ? p.altDescriptions : JSON.stringify(p.altDescriptions ?? []),
                 },
                 normalizeTimestampOverrides({ createdAt: p.createdAt, updatedAt: p.updatedAt }),
               );
-              if (created) {
-                const newPresetId = (created as any).id;
-                // Map old group IDs → new group IDs for section groupId references
-                const groupIdMap = new Map<string, string>();
+              stats.personas++;
+            } catch {
+              /* skip */
+            }
+            completedItems++;
+            emitLegacyProgress("personas", "Importing personas");
+          }
+        }
 
-                // Import groups — two passes to handle parent→child ordering
-                if (Array.isArray(p.groups)) {
-                  // Pass 1: create all groups without parent references
-                  for (const g of p.groups) {
-                    try {
-                      const newGroup = await presets.createGroup({
-                        presetId: newPresetId,
-                        name: g.name,
-                        parentGroupId: null,
-                        order: g.order ?? 100,
-                        enabled: g.enabled === "true" || g.enabled === true,
-                      });
-                      if (newGroup) groupIdMap.set(g.id, (newGroup as any).id);
-                    } catch {
-                      /* skip individual group */
-                    }
-                  }
-                  // Pass 2: fix parent references using the fully-populated map
-                  for (const g of p.groups) {
-                    if (g.parentGroupId && groupIdMap.has(g.id) && groupIdMap.has(g.parentGroupId)) {
+        // Import lorebooks + entries
+        if (Array.isArray(data.lorebooks)) {
+          for (const lb of data.lorebooks) {
+            try {
+              emitLegacyProgress("lorebooks", "Importing lorebooks");
+              const created = await lbs.create(
+                {
+                  name: lb.name,
+                  description: lb.description ?? "",
+                  category: lb.category ?? "uncategorized",
+                  scanDepth: lb.scanDepth,
+                  tokenBudget: lb.tokenBudget,
+                  recursiveScanning: lb.recursiveScanning,
+                  maxRecursionDepth: lb.maxRecursionDepth,
+                  enabled: lb.enabled ?? true,
+                  characterId: lb.characterId ?? null,
+                  characterIds: Array.isArray(lb.characterIds)
+                    ? lb.characterIds.filter((value: unknown): value is string => typeof value === "string")
+                    : typeof lb.characterId === "string"
+                      ? [lb.characterId]
+                      : [],
+                  personaId: lb.personaId ?? null,
+                  personaIds: Array.isArray(lb.personaIds)
+                    ? lb.personaIds.filter((value: unknown): value is string => typeof value === "string")
+                    : typeof lb.personaId === "string"
+                      ? [lb.personaId]
+                      : [],
+                  chatId: lb.chatId ?? null,
+                  isGlobal: lb.isGlobal ?? false,
+                  tags: Array.isArray(lb.tags) ? lb.tags : [],
+                  generatedBy: lb.generatedBy ?? null,
+                  sourceAgentId: lb.sourceAgentId ?? null,
+                },
+                normalizeTimestampOverrides({ createdAt: lb.createdAt, updatedAt: lb.updatedAt }),
+              );
+              const folderIdMap = new Map<string, string>();
+              if (created && Array.isArray(lb.folders)) {
+                for (const folder of lb.folders) {
+                  const oldId = typeof folder.id === "string" ? folder.id : null;
+                  const createdFolder = (await lbs.createFolder((created as any).id, {
+                    name: folder.name ?? "Folder",
+                    enabled: folder.enabled === "true" || folder.enabled === true,
+                    parentFolderId: null,
+                    order: folder.order ?? 0,
+                  })) as { id?: string } | null;
+                  if (oldId && createdFolder?.id) folderIdMap.set(oldId, createdFolder.id);
+                }
+              }
+              if (created && Array.isArray(lb.entries)) {
+                for (const entry of lb.entries) {
+                  const folderId =
+                    typeof entry.folderId === "string" && folderIdMap.has(entry.folderId)
+                      ? folderIdMap.get(entry.folderId)
+                      : null;
+                  await lbs.createEntry({ ...entry, lorebookId: (created as any).id, folderId });
+                }
+              }
+              stats.lorebooks++;
+            } catch {
+              /* skip */
+            }
+            completedItems++;
+            emitLegacyProgress("lorebooks", "Importing lorebooks");
+          }
+        }
+
+        // Import presets with full hierarchy (groups, sections, choice blocks)
+        if (Array.isArray(data.presets)) {
+          for (const p of data.presets) {
+            try {
+              emitLegacyProgress("presets", "Importing presets");
+              const existing = await presets.getById(p.id);
+              if (!existing) {
+                const created = await presets.create(
+                  {
+                    name: `${p.name} (imported)`,
+                    description: p.description ?? "",
+                    parameters:
+                      typeof p.parameters === "string"
+                        ? JSON.parse(p.parameters)
+                        : (p.parameters ?? p.generationParams),
+                    variableGroups:
+                      typeof p.variableGroups === "string" ? JSON.parse(p.variableGroups) : (p.variableGroups ?? []),
+                    variableValues:
+                      typeof p.variableValues === "string" ? JSON.parse(p.variableValues) : (p.variableValues ?? {}),
+                  },
+                  normalizeTimestampOverrides({ createdAt: p.createdAt, updatedAt: p.updatedAt }),
+                );
+                if (created) {
+                  const newPresetId = (created as any).id;
+                  // Map old group IDs → new group IDs for section groupId references
+                  const groupIdMap = new Map<string, string>();
+
+                  // Import groups — two passes to handle parent→child ordering
+                  if (Array.isArray(p.groups)) {
+                    // Pass 1: create all groups without parent references
+                    for (const g of p.groups) {
                       try {
-                        await presets.updateGroup(groupIdMap.get(g.id)!, {
-                          parentGroupId: groupIdMap.get(g.parentGroupId)!,
+                        const newGroup = await presets.createGroup({
+                          presetId: newPresetId,
+                          name: g.name,
+                          parentGroupId: null,
+                          order: g.order ?? 100,
+                          enabled: g.enabled === "true" || g.enabled === true,
                         });
+                        if (newGroup) groupIdMap.set(g.id, (newGroup as any).id);
                       } catch {
-                        /* skip */
+                        /* skip individual group */
+                      }
+                    }
+                    // Pass 2: fix parent references using the fully-populated map
+                    for (const g of p.groups) {
+                      if (g.parentGroupId && groupIdMap.has(g.id) && groupIdMap.has(g.parentGroupId)) {
+                        try {
+                          await presets.updateGroup(groupIdMap.get(g.id)!, {
+                            parentGroupId: groupIdMap.get(g.parentGroupId)!,
+                          });
+                        } catch {
+                          /* skip */
+                        }
                       }
                     }
                   }
-                }
 
-                // Import sections
-                if (Array.isArray(p.sections)) {
-                  for (const s of p.sections) {
-                    try {
-                      await presets.createSection({
-                        presetId: newPresetId,
-                        identifier: s.identifier,
-                        name: s.name,
-                        content: s.content ?? "",
-                        role: s.role ?? "system",
-                        enabled: s.enabled === "true" || s.enabled === true,
-                        isMarker: s.isMarker === "true" || s.isMarker === true,
-                        groupId: s.groupId ? (groupIdMap.get(s.groupId) ?? null) : null,
-                        markerConfig:
-                          typeof s.markerConfig === "string" ? JSON.parse(s.markerConfig) : (s.markerConfig ?? null),
-                        injectionPosition: s.injectionPosition ?? "ordered",
-                        injectionDepth: s.injectionDepth ?? 0,
-                        injectionOrder: s.injectionOrder ?? 100,
-                        forbidOverrides: s.forbidOverrides === "true" || s.forbidOverrides === true,
-                      });
-                    } catch {
-                      /* skip individual section */
+                  // Import sections
+                  if (Array.isArray(p.sections)) {
+                    for (const s of p.sections) {
+                      try {
+                        await presets.createSection({
+                          presetId: newPresetId,
+                          identifier: s.identifier,
+                          name: s.name,
+                          content: s.content ?? "",
+                          role: s.role ?? "system",
+                          enabled: s.enabled === "true" || s.enabled === true,
+                          isMarker: s.isMarker === "true" || s.isMarker === true,
+                          groupId: s.groupId ? (groupIdMap.get(s.groupId) ?? null) : null,
+                          markerConfig:
+                            typeof s.markerConfig === "string" ? JSON.parse(s.markerConfig) : (s.markerConfig ?? null),
+                          injectionPosition: s.injectionPosition ?? "ordered",
+                          injectionDepth: s.injectionDepth ?? 0,
+                          injectionOrder: s.injectionOrder ?? 100,
+                          forbidOverrides: s.forbidOverrides === "true" || s.forbidOverrides === true,
+                        });
+                      } catch {
+                        /* skip individual section */
+                      }
                     }
                   }
-                }
 
-                // Import choice blocks
-                if (Array.isArray(p.choices)) {
-                  for (const cb of p.choices) {
-                    try {
-                      await presets.createChoiceBlock({
-                        presetId: newPresetId,
-                        variableName: cb.variableName,
-                        question: cb.question,
-                        options: typeof cb.options === "string" ? JSON.parse(cb.options) : (cb.options ?? []),
-                        multiSelect: cb.multiSelect === "true" || cb.multiSelect === true,
-                        separator: cb.separator ?? ", ",
-                        randomPick: cb.randomPick === "true" || cb.randomPick === true,
-                      });
-                    } catch {
-                      /* skip individual choice block */
+                  // Import choice blocks
+                  if (Array.isArray(p.choices)) {
+                    for (const cb of p.choices) {
+                      try {
+                        await presets.createChoiceBlock({
+                          presetId: newPresetId,
+                          variableName: cb.variableName,
+                          question: cb.question,
+                          options: typeof cb.options === "string" ? JSON.parse(cb.options) : (cb.options ?? []),
+                          multiSelect: cb.multiSelect === "true" || cb.multiSelect === true,
+                          separator: cb.separator ?? ", ",
+                          randomPick: cb.randomPick === "true" || cb.randomPick === true,
+                        });
+                      } catch {
+                        /* skip individual choice block */
+                      }
                     }
                   }
-                }
 
-                stats.presets++;
+                  stats.presets++;
+                }
               }
+            } catch {
+              /* skip */
             }
-          } catch {
-            /* skip */
+            completedItems++;
+            emitLegacyProgress("presets", "Importing presets");
           }
-          completedItems++;
-          emitLegacyProgress("presets", "Importing presets");
         }
-      }
 
-      // Import agent configs
-      if (Array.isArray(data.agents)) {
-        for (const a of data.agents) {
-          try {
+        // Import agent configs
+        if (Array.isArray(data.agents)) {
+          for (const a of data.agents) {
+            try {
+              emitLegacyProgress("agents", "Importing agents");
+              // Only import if this agent type doesn't already exist
+              const existing = await agents.getByType(a.type);
+              if (!existing) {
+                await agents.create({
+                  type: a.type,
+                  name: a.name,
+                  description: a.description ?? "",
+                  phase: a.phase,
+                  enabled: a.enabled === "true" || a.enabled === true,
+                  connectionId: a.connectionId ?? null,
+                  promptTemplate: a.promptTemplate ?? "",
+                  settings: typeof a.settings === "string" ? JSON.parse(a.settings) : (a.settings ?? {}),
+                });
+                stats.agents++;
+              }
+            } catch {
+              /* skip */
+            }
+            completedItems++;
             emitLegacyProgress("agents", "Importing agents");
-            // Only import if this agent type doesn't already exist
-            const existing = await agents.getByType(a.type);
-            if (!existing) {
-              await agents.create({
-                type: a.type,
-                name: a.name,
-                description: a.description ?? "",
-                phase: a.phase,
-                enabled: a.enabled === "true" || a.enabled === true,
-                connectionId: a.connectionId ?? null,
-                promptTemplate: a.promptTemplate ?? "",
-                settings: typeof a.settings === "string" ? JSON.parse(a.settings) : (a.settings ?? {}),
-              });
-              stats.agents++;
-            }
-          } catch {
-            /* skip */
           }
-          completedItems++;
-          emitLegacyProgress("agents", "Importing agents");
         }
-      }
 
-      // Import synced custom themes
-      let importedActiveThemeId: string | null = null;
-      if (Array.isArray(data.themes)) {
-        for (const theme of data.themes) {
-          try {
+        // Import synced custom themes
+        let importedActiveThemeId: string | null = null;
+        if (Array.isArray(data.themes)) {
+          for (const theme of data.themes) {
+            try {
+              emitLegacyProgress("themes", "Importing themes");
+              const duplicate = await themes.findDuplicate(theme.name ?? "", theme.css ?? "");
+              const syncedTheme =
+                duplicate ??
+                (await themes.create({
+                  name: theme.name ?? "Imported Theme",
+                  css: theme.css ?? "",
+                  installedAt: theme.installedAt,
+                }));
+
+              if (!duplicate && syncedTheme) {
+                stats.themes++;
+              }
+
+              if (syncedTheme && (theme.isActive === true || theme.isActive === "true")) {
+                importedActiveThemeId = syncedTheme.id;
+              }
+            } catch {
+              /* skip */
+            }
+            completedItems++;
             emitLegacyProgress("themes", "Importing themes");
-            const duplicate = await themes.findDuplicate(theme.name ?? "", theme.css ?? "");
-            const syncedTheme =
-              duplicate ??
-              (await themes.create({
-                name: theme.name ?? "Imported Theme",
-                css: theme.css ?? "",
-                installedAt: theme.installedAt,
-              }));
+          }
+        }
 
-            if (!duplicate && syncedTheme) {
-              stats.themes++;
-            }
-
-            if (syncedTheme && (theme.isActive === true || theme.isActive === "true")) {
-              importedActiveThemeId = syncedTheme.id;
-            }
+        if (importedActiveThemeId) {
+          try {
+            await themes.setActive(importedActiveThemeId);
           } catch {
             /* skip */
           }
-          completedItems++;
-          emitLegacyProgress("themes", "Importing themes");
         }
-      }
 
-      if (importedActiveThemeId) {
-        try {
-          await themes.setActive(importedActiveThemeId);
-        } catch {
-          /* skip */
+        const payload = { success: true, imported: stats, warnings };
+        if (wantsProgressStream) {
+          sendEvent({ type: "done", data: payload });
+          reply.raw.end();
+          return;
         }
+        return payload;
+      } catch (err) {
+        if (wantsProgressStream) {
+          const message = getBackupErrorMessage(err, "Profile import failed. Check the server logs for details.");
+          const logError = err instanceof Error ? err : new Error(message);
+          logger.error(logError, "[backup] Profile import failed");
+          sendEvent({ type: "error", data: { error: "Profile import failed", message } });
+          reply.raw.end();
+          return;
+        }
+        return sendBackupRouteError(reply, err, "Profile import");
       }
-
-      if (wantsProgressStream) {
-        sendEvent({ type: "done", data: { success: true, imported: stats } });
-        reply.raw.end();
-        return;
-      }
-      return { success: true, imported: stats };
-    } catch (err) {
-      if (wantsProgressStream) {
-        const message = getBackupErrorMessage(err, "Profile import failed. Check the server logs for details.");
-        const logError = err instanceof Error ? err : new Error(message);
-        logger.error(logError, "[backup] Profile import failed");
-        sendEvent({ type: "error", data: { error: "Profile import failed", message } });
-        reply.raw.end();
-        return;
-      }
-      return sendBackupRouteError(reply, err, "Profile import");
+    } finally {
+      await importInput.cleanup?.();
     }
   });
 }


### PR DESCRIPTION
## Linked issue

No linked issue yet. This bug came from local profile export investigation; an issue should be opened or linked before this draft leaves WIP.

## Why this change

Large avatar/sprite assets could make native profile export build one huge JSON response. Older or heavier installs could fail when the app tried to stringify/send that data, leaving users without a reliable profile export path.

## What changed

- Kept the default profile export as the existing compact JSON format for normal profiles.
- Added oversized JSON detection that tells the client to offer ZIP export as a fallback.
- Added profile ZIP export/import support for profile assets and full backup ZIP imports.
- Streamed profile ZIP export through a temp archive instead of buffering the whole ZIP response.
- Made ZIP import validate sizes, avoid loading the whole uploaded archive at once, reject truncated uploads, and warn instead of failing when asset files are missing from an otherwise importable ZIP.
- Updated Settings import/export UI for ZIP fallback, ZIP import, and missing-asset warnings.

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

Automated validation performed:

- `pnpm --dir packages/server exec tsx ../../.codex-scratchpads/profile-export-large-assets-repro.ts`
- `pnpm check`
- `git diff --check`

### Manual verification notes

- Synced to the TEST folder for manual app testing.
- Manual click-through still pending.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

Pending manual TEST verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Profile import now accepts both JSON and ZIP file formats with real-time progress tracking
  * Profile export supports multiple output formats with automatic ZIP fallback when JSON files exceed size limits
  * Import warnings are displayed with amber status indicator and detailed warning summary

* **Improvements**
  * Enhanced export format selection dialog
  * Updated UI labels and descriptions for profile import/export functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1019?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->