### PR TITLE
Fix Claude Subscription Docker HOME handling

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,6 @@ services:
       - marinara-data:/app/data
     environment:
       - NODE_ENV=production
-      - HOME=/app
       - DATA_DIR=/app/data
       - FILE_STORAGE_DIR=/app/data/storage
       - MARINARA_DOCKER=true

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -102,6 +102,11 @@ If you'd prefer to avoid the paste-back step on a LAN install, the cleanest fix 
 If a Docker or Podman container fails with permission errors on the data volume:
 
 - **Named volumes after updating:** The official images repair `/app/data` ownership at startup, then drop back to the non-root runtime user. Pull the latest image and restart with `docker compose pull && docker compose up -d`.
+
+If Claude (Subscription) returns an empty response in Docker:
+
+- Run Claude login as the container runtime user so the server and CLI read the same credentials, for example `docker exec -u node -e HOME=/home/node -it marinara-engine-marinara-1 claude login`.
+- Pull the latest image and restart. The official entrypoint now resets `HOME` to the non-root runtime user's home after dropping privileges, so server-side Claude Agent SDK calls look in the same place as `docker exec -u node`.
 - **Bind mounts:** Make the host directory writable by UID/GID `1000`, or use a named volume. If your filesystem blocks container `chown`, fix ownership on the host instead.
 - **SELinux (Fedora, RHEL):** Add the `:Z` suffix to the volume mount — e.g., `-v marinara-data:/app/data:Z`.
 - **Rootless Podman:** Make sure the host directory is owned by your user, or use a named volume instead of a bind mount.

--- a/docs/pr-evidence/issue-1020/README.md
+++ b/docs/pr-evidence/issue-1020/README.md
@@ -4,3 +4,4 @@ This directory contains the raw before/after output from `scratch/issue-1020-rep
 
 - `repro-before.json`: pre-fix run. It fails the compose HOME check, entrypoint HOME normalization check, and successful-but-empty Claude SDK stream check.
 - `repro-after.json`: post-fix run. It passes the original checks plus adjacent checks for final-result fallback, non-streaming assistant text, and SDK error propagation.
+- `docker-home.txt`: real `node:24-slim` container run showing the patched entrypoint drops to UID 1000 and resets the child process HOME to `/home/node` even when the container starts with `HOME=/app`.

--- a/docs/pr-evidence/issue-1020/README.md
+++ b/docs/pr-evidence/issue-1020/README.md
@@ -1,0 +1,6 @@
+# Issue 1020 proof
+
+This directory contains the raw before/after output from `scratch/issue-1020-repro.ts`.
+
+- `repro-before.json`: pre-fix run. It fails the compose HOME check, entrypoint HOME normalization check, and successful-but-empty Claude SDK stream check.
+- `repro-after.json`: post-fix run. It passes the original checks plus adjacent checks for final-result fallback, non-streaming assistant text, and SDK error propagation.

--- a/docs/pr-evidence/issue-1020/docker-home.txt
+++ b/docs/pr-evidence/issue-1020/docker-home.txt
@@ -1,0 +1,10 @@
+Command:
+docker run --rm -v C:\tmp\Marinara-Engine-issue-1020:/app -w /app -e HOME=/app node:24-slim node scripts/docker-entrypoint.mjs node -e "console.log(JSON.stringify({uid:process.getuid?.(),home:process.env.HOME}))"
+
+Observed output:
+{"uid":1000,"home":"/home/node"}
+Unable to find image 'node:24-slim' locally
+24-slim: Pulling from library/node
+Digest: sha256:24dc26ef1e3c3690f27ebc4136c9c186c3133b25563ae4d7f0692e4d1fe5db0e
+Status: Downloaded newer image for node:24-slim
+[docker-entrypoint] Repairing ownership for /app/data

--- a/docs/pr-evidence/issue-1020/repro-after.json
+++ b/docs/pr-evidence/issue-1020/repro-after.json
@@ -1,0 +1,34 @@
+{
+  "results": [
+    {
+      "name": "compose-home",
+      "passed": true,
+      "detail": "docker-compose.yml no longer forces HOME=/app."
+    },
+    {
+      "name": "entrypoint-home-normalization",
+      "passed": true,
+      "detail": "docker entrypoint normalizes HOME for the dropped runtime user."
+    },
+    {
+      "name": "claude-empty-stream-error",
+      "passed": true,
+      "detail": "Provider threw: Claude (Subscription) returned no content. Check that `claude login` was run for the same HOME/user as the Marinara server, then retry with LOG_LEVEL=debug if needed (model=claude-haiku-4-5-20251001, successResult=true, inputTokens=0, outputTokens=0, fast_mode_state=off, billedModels=none, HOME=C:\\Users\\celia)."
+    },
+    {
+      "name": "claude-final-result-fallback",
+      "passed": true,
+      "detail": "Provider yielded [\"hello from final result\"]."
+    },
+    {
+      "name": "claude-non-streaming-assistant-text",
+      "passed": true,
+      "detail": "Provider yielded [\"hello from assistant\"]."
+    },
+    {
+      "name": "claude-sdk-error-still-surfaces",
+      "passed": true,
+      "detail": "Provider threw: Claude (Subscription) request failed: Claude (Subscription) request failed (error) — auth session missing"
+    }
+  ]
+}

--- a/docs/pr-evidence/issue-1020/repro-before.json
+++ b/docs/pr-evidence/issue-1020/repro-before.json
@@ -1,0 +1,19 @@
+{
+  "results": [
+    {
+      "name": "compose-home",
+      "passed": false,
+      "detail": "docker-compose.yml still forces HOME=/app, which diverges from the node user's /home/node credentials path."
+    },
+    {
+      "name": "entrypoint-home-normalization",
+      "passed": false,
+      "detail": "docker entrypoint drops privileges without normalizing HOME."
+    },
+    {
+      "name": "claude-empty-stream-error",
+      "passed": false,
+      "detail": "Provider completed without text and without an actionable error; chunks=[]."
+    }
+  ]
+}

--- a/packages/server/src/services/llm/providers/claude-subscription.provider.ts
+++ b/packages/server/src/services/llm/providers/claude-subscription.provider.ts
@@ -187,6 +187,9 @@ export class ClaudeSubscriptionProvider extends BaseLLMProvider {
     let cachedTokens = 0;
     let cacheWriteTokens = 0;
     let emittedText = false;
+    let sawSuccessResult = false;
+    let finalFastModeState: string | null = null;
+    let finalUsedModels: string[] = [];
 
     try {
       const queryHandle = query({ prompt, options: sdkOptions });
@@ -219,6 +222,7 @@ export class ClaudeSubscriptionProvider extends BaseLLMProvider {
           }
         } else if (message.type === "result") {
           if (message.subtype === "success") {
+            sawSuccessResult = true;
             const usage = message.usage ?? null;
             if (usage) {
               inputTokens = usage.input_tokens ?? 0;
@@ -233,6 +237,8 @@ export class ClaudeSubscriptionProvider extends BaseLLMProvider {
             // worth surfacing.
             const usedModels = Object.keys(message.modelUsage ?? {});
             const fastModeState = message.fast_mode_state;
+            finalUsedModels = usedModels;
+            finalFastModeState = fastModeState ?? null;
             const billedDifferent = usedModels.length > 0 && !usedModels.includes(options.model);
             if (billedDifferent) {
               logger.warn(
@@ -265,6 +271,22 @@ export class ClaudeSubscriptionProvider extends BaseLLMProvider {
       throw new Error(`Claude (Subscription) request failed: ${friendly}`);
     } finally {
       if (options.signal) options.signal.removeEventListener("abort", onUpstreamAbort);
+    }
+
+    if (!emittedText) {
+      const diagnostic = [
+        `model=${options.model}`,
+        `successResult=${sawSuccessResult}`,
+        `inputTokens=${inputTokens}`,
+        `outputTokens=${outputTokens}`,
+        `fast_mode_state=${finalFastModeState ?? "unknown"}`,
+        `billedModels=${finalUsedModels.length ? finalUsedModels.join(",") : "none"}`,
+        `HOME=${process.env.HOME ?? "unset"}`,
+      ].join(", ");
+      logger.warn("[claude-subscription] SDK completed without usable text (%s)", diagnostic);
+      throw new Error(
+        `Claude (Subscription) returned no content. Check that \`claude login\` was run for the same HOME/user as the Marinara server, then retry with LOG_LEVEL=debug if needed (${diagnostic}).`,
+      );
     }
 
     if (inputTokens || outputTokens) {

--- a/scripts/docker-entrypoint.mjs
+++ b/scripts/docker-entrypoint.mjs
@@ -37,6 +37,21 @@ function resolveGid(group) {
   return parseNameServiceFile("/etc/group", group, 2);
 }
 
+function resolveHomeDir(user) {
+  let rows;
+  try {
+    rows = readFileSync("/etc/passwd", "utf8").split("\n");
+  } catch {
+    return null;
+  }
+
+  for (const row of rows) {
+    const fields = row.split(":");
+    if (fields[0] === user || fields[2] === user) return fields[5] || null;
+  }
+  return null;
+}
+
 function resolveStoragePath(value) {
   if (!value) return null;
   return isAbsolute(value) ? value : resolve(process.cwd(), value);
@@ -104,6 +119,7 @@ function run() {
     const group = process.env.MARINARA_DOCKER_GROUP ?? user;
     const uid = resolveUid(user);
     const gid = resolveGid(group);
+    const homeDir = resolveHomeDir(user);
 
     if (uid == null || gid == null) {
       log(`Could not resolve runtime user "${user}:${group}"; continuing as root.`);
@@ -114,6 +130,9 @@ function run() {
         log(`Could not repair data directory ownership: ${error instanceof Error ? error.message : String(error)}`);
       }
       dropPrivileges(uid, gid);
+      if (homeDir) {
+        process.env.HOME = homeDir;
+      }
     }
   }
 


### PR DESCRIPTION
<!-- Target branch: `staging`. The default base in this UI is `main` (release branch). -->
<!-- Change the base to `staging` before submitting unless this is a maintainer-approved mainline change. -->
<!-- See CONTRIBUTING.md § Branches. -->

## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #1020

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- Docker compose preserved `HOME=/app` while the entrypoint dropped the server to the `node` user, so `claude login` and the server-side Claude Agent SDK could look in different credential directories.
- When the Claude Agent SDK completed successfully but produced no usable text, the provider yielded nothing and the route showed a generic empty-response message with no actionable upstream diagnostic.

## What changed

<!-- List the key changes in this PR -->

- Removes the compose-level `HOME=/app` override and resets `HOME` to the dropped runtime user's passwd home inside the Docker entrypoint.
- Throws a specific Claude Subscription provider error when the SDK completes without any emitted text, including model, token, fast-mode, billed-model, and HOME diagnostics in the server log/error path.
- Adds Docker/Claude Subscription troubleshooting guidance and committed repro evidence for the before/after behavior.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Codex verification: `pnpm --filter @marinara-engine/server exec tsx C:\tmp\Marinara-Engine-issue-1020\scratch\issue-1020-repro.ts scratch\issue-1020-before.json` reproduced the pre-fix failure.
- Codex verification: `pnpm --filter @marinara-engine/server exec tsx C:\tmp\Marinara-Engine-issue-1020\scratch\issue-1020-repro.ts scratch\issue-1020-after.json` passed after the fix, including edge cases for final `result` fallback, non-streaming assistant text, and SDK error-result propagation.
- Codex verification: `docker run --rm -v C:\tmp\Marinara-Engine-issue-1020:/app -w /app -e HOME=/app node:24-slim node scripts/docker-entrypoint.mjs node -e "console.log(JSON.stringify({uid:process.getuid?.(),home:process.env.HOME}))"` printed `{"uid":1000,"home":"/home/node"}`.
- Codex verification: `pnpm check` passed.
- Evidence: before repro output at https://raw.githubusercontent.com/cha1latte/Marinara-Engine/c25f3cba06b0170e2042fdb6dd6e5472cd6de5f4/docs/pr-evidence/issue-1020/repro-before.json
- Evidence: after repro output at https://raw.githubusercontent.com/cha1latte/Marinara-Engine/c25f3cba06b0170e2042fdb6dd6e5472cd6de5f4/docs/pr-evidence/issue-1020/repro-after.json
- Evidence: Docker HOME proof at https://raw.githubusercontent.com/cha1latte/Marinara-Engine/c25f3cba06b0170e2042fdb6dd6e5472cd6de5f4/docs/pr-evidence/issue-1020/docker-home.txt
- Limitation: I did not run a live Claude OAuth chat inside Docker because this environment does not have a Claude subscription session. The container HOME path and provider empty-stream behavior are covered by machine proof above.

## Docs and release impact

- [ ] No docs changes needed
- [x] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

N/A - backend/container behavior only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Docker troubleshooting guidance for authentication issues, including instructions to re-authenticate inside containers.

* **Bug Fixes**
  * Improved error messaging and diagnostics when encountering empty API responses in containerized environments.
  * Enhanced Docker container environment handling to properly resolve credentials and home directories.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1021?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->