### PR TITLE
Improve sprite wand cleanup editor

### DIFF
--- a/packages/client/src/components/ui/SpriteWandCleanupEditor.tsx
+++ b/packages/client/src/components/ui/SpriteWandCleanupEditor.tsx
@@ -17,6 +17,7 @@ import {
   Hand,
   Loader2,
   Minus,
+  Pipette,
   Plus,
   RotateCcw,
   Undo2,
@@ -33,8 +34,9 @@ import {
   removeWandSelection,
   rgbaAt,
   type BrushMode,
+  type BrushStrokeOptions,
   type CanvasPoint,
-  type TargetCleanBrushOptions,
+  type Rgba,
   type WandResult,
 } from "../../lib/sprite-cleanup-tools";
 import { Modal } from "./Modal";
@@ -48,19 +50,19 @@ interface SpriteWandCleanupEditorProps {
 }
 
 interface HoverPoint extends CanvasPoint {
-  color: [number, number, number, number];
+  color: Rgba;
 }
 
-type CleanupTool = "wand" | "clean" | "erase" | "restore" | "blur" | "pan";
+type CleanupTool = "wand" | "clean" | "erase" | "brush" | "blur" | "pan";
+type BrushToolMode = "paint" | "restore";
 type PreviewBackground = "checker" | "dark" | "light" | "pink";
 
-interface PaintGesture {
+interface BrushGesture {
   pointerId: number;
   before: ImageData;
   lastPoint: CanvasPoint;
   changedPixels: number;
-  mode: BrushMode;
-  targetCleanOptions?: TargetCleanBrushOptions;
+  options: BrushStrokeOptions;
 }
 
 interface PanGesture {
@@ -94,10 +96,24 @@ interface ToggleControlProps {
   title?: string;
 }
 
+interface BrushStrokeBuildInput {
+  mode: BrushMode;
+  radius: number;
+  brushHardness: number;
+  brushOpacity: number;
+  blurStrength: number;
+  cleanTarget: Rgba;
+  cleanTolerance: number;
+  cleanEdgeGuard: number;
+  cleanFeather: number;
+  brushColor: string;
+}
+
 const DEFAULT_TOLERANCE = 36;
 const DEFAULT_BRUSH_SIZE = 18;
-const DEFAULT_ERASER_HARDNESS = 100;
-const DEFAULT_ERASER_OPACITY = 100;
+const DEFAULT_BRUSH_HARDNESS = 100;
+const DEFAULT_BRUSH_OPACITY = 100;
+const DEFAULT_BRUSH_COLOR = "#ffffff";
 const DEFAULT_BLUR_STRENGTH = 65;
 const DEFAULT_CLEAN_TOLERANCE = 36;
 const DEFAULT_CLEAN_EDGE_GUARD = 45;
@@ -144,12 +160,117 @@ const cleanupToolOptions: Array<{
   { tool: "wand", label: "Wand", title: "Select connected pixels", Icon: Wand2 },
   { tool: "clean", label: "Clean", title: "Brush away pixels matching the sampled color", Icon: Crosshair },
   { tool: "erase", label: "Erase", title: "Paint pixels transparent", Icon: Eraser },
-  { tool: "restore", label: "Restore", title: "Paint original pixels back in", Icon: Brush },
+  { tool: "brush", label: "Brush", title: "Paint color or restore original pixels", Icon: Brush },
   { tool: "blur", label: "Blur", title: "Paint alpha smoothing over jagged edges", Icon: Blend },
 ];
 
+const brushActionLabels: Record<BrushMode, string> = {
+  clean: "target-cleaned",
+  erase: "erased",
+  paint: "painted",
+  restore: "restored",
+  blur: "edge-blurred",
+};
+
 function clamp(value: number, min: number, max: number): number {
   return Math.max(min, Math.min(max, Number.isFinite(value) ? value : min));
+}
+
+function cleanupToolToBrushMode(tool: CleanupTool, brushToolMode: BrushToolMode): BrushMode | null {
+  switch (tool) {
+    case "clean":
+    case "erase":
+    case "blur":
+      return tool;
+    case "brush":
+      return brushToolMode;
+    default:
+      return null;
+  }
+}
+
+function usesOpacityHardnessControls(tool: CleanupTool): boolean {
+  return tool === "erase" || tool === "brush";
+}
+
+function brushOpacityTitle(mode: BrushMode | null): string {
+  switch (mode) {
+    case "paint":
+      return "How much color each brush stroke applies";
+    case "restore":
+      return "How strongly each stroke restores the original sprite";
+    default:
+      return "How much alpha each eraser stroke removes";
+  }
+}
+
+function brushHardnessTitle(mode: BrushMode | null): string {
+  switch (mode) {
+    case "paint":
+      return "How crisp the brush edge should be";
+    case "restore":
+      return "How crisp the restore brush edge should be";
+    default:
+      return "How crisp the eraser edge should be";
+  }
+}
+
+function colorComponentToHex(value: number): string {
+  return clamp(Math.round(value), 0, 255).toString(16).padStart(2, "0");
+}
+
+function rgbaToHex(color: Rgba): string {
+  return `#${colorComponentToHex(color[0])}${colorComponentToHex(color[1])}${colorComponentToHex(color[2])}`;
+}
+
+function hexToRgba(hex: string): Rgba {
+  const normalized = /^#[0-9a-f]{6}$/i.test(hex) ? hex : DEFAULT_BRUSH_COLOR;
+  return [
+    Number.parseInt(normalized.slice(1, 3), 16),
+    Number.parseInt(normalized.slice(3, 5), 16),
+    Number.parseInt(normalized.slice(5, 7), 16),
+    255,
+  ];
+}
+
+function createBrushStrokeOptions({
+  mode,
+  radius,
+  brushHardness,
+  brushOpacity,
+  blurStrength,
+  cleanTarget,
+  cleanTolerance,
+  cleanEdgeGuard,
+  cleanFeather,
+  brushColor,
+}: BrushStrokeBuildInput): BrushStrokeOptions {
+  switch (mode) {
+    case "clean":
+      return {
+        mode,
+        radius,
+        clean: {
+          target: cleanTarget,
+          tolerance: cleanTolerance,
+          edgeGuard: cleanEdgeGuard,
+          feather: cleanFeather,
+        },
+      };
+    case "paint":
+      return {
+        mode,
+        radius,
+        hardness: brushHardness,
+        opacity: brushOpacity,
+        paint: { color: hexToRgba(brushColor) },
+      };
+    case "blur":
+      return { mode, radius, blurStrength };
+    case "erase":
+    case "restore":
+      return { mode, radius, hardness: brushHardness, opacity: brushOpacity };
+  }
 }
 
 function clampZoom(value: number): number {
@@ -252,7 +373,7 @@ export function SpriteWandCleanupEditor({
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const originalImageRef = useRef<ImageData | null>(null);
   const currentImageRef = useRef<ImageData | null>(null);
-  const paintGestureRef = useRef<PaintGesture | null>(null);
+  const brushGestureRef = useRef<BrushGesture | null>(null);
   const panGestureRef = useRef<PanGesture | null>(null);
 
   const [tool, setTool] = useState<CleanupTool>("wand");
@@ -265,8 +386,11 @@ export function SpriteWandCleanupEditor({
   const [cleanEdgeGuard, setCleanEdgeGuard] = useState(DEFAULT_CLEAN_EDGE_GUARD);
   const [cleanFeather, setCleanFeather] = useState(DEFAULT_CLEAN_FEATHER);
   const [brushSize, setBrushSize] = useState(DEFAULT_BRUSH_SIZE);
-  const [eraserHardness, setEraserHardness] = useState(DEFAULT_ERASER_HARDNESS);
-  const [eraserOpacity, setEraserOpacity] = useState(DEFAULT_ERASER_OPACITY);
+  const [brushHardness, setBrushHardness] = useState(DEFAULT_BRUSH_HARDNESS);
+  const [brushOpacity, setBrushOpacity] = useState(DEFAULT_BRUSH_OPACITY);
+  const [brushToolMode, setBrushToolMode] = useState<BrushToolMode>("paint");
+  const [brushColor, setBrushColor] = useState(DEFAULT_BRUSH_COLOR);
+  const [pickingBrushColor, setPickingBrushColor] = useState(false);
   const [blurStrength, setBlurStrength] = useState(DEFAULT_BLUR_STRENGTH);
   const [zoom, setZoom] = useState(1);
   const [canvasSize, setCanvasSize] = useState({ width: 0, height: 0 });
@@ -324,6 +448,7 @@ export function SpriteWandCleanupEditor({
     setHasChanges(false);
     setHistory([]);
     setHoverPoint(null);
+    setPickingBrushColor(false);
     setZoom(1);
     originalImageRef.current = null;
     currentImageRef.current = null;
@@ -435,12 +560,12 @@ export function SpriteWandCleanupEditor({
     ],
   );
 
-  const commitPaintGesture = useCallback(
+  const commitBrushGesture = useCallback(
     (canvas: HTMLCanvasElement | null) => {
-      const gesture = paintGestureRef.current;
+      const gesture = brushGestureRef.current;
       if (!gesture) return;
 
-      paintGestureRef.current = null;
+      brushGestureRef.current = null;
       if (canvas?.hasPointerCapture(gesture.pointerId)) {
         canvas.releasePointerCapture(gesture.pointerId);
       }
@@ -452,14 +577,7 @@ export function SpriteWandCleanupEditor({
 
       pushHistory(gesture.before);
       setHasChanges(true);
-      const actionLabel =
-        gesture.mode === "erase"
-          ? "erased"
-          : gesture.mode === "restore"
-            ? "restored"
-            : gesture.mode === "clean"
-              ? "target-cleaned"
-              : "edge-blurred";
+      const actionLabel = brushActionLabels[gesture.options.mode];
       setStatus(`${gesture.changedPixels.toLocaleString()} px ${actionLabel}`);
       setError(null);
     },
@@ -503,48 +621,57 @@ export function SpriteWandCleanupEditor({
       const point = updateHoverPoint(event);
       if (!point) return;
 
+      const current = currentImageRef.current;
+      if (tool === "brush" && brushToolMode === "paint" && pickingBrushColor) {
+        if (!current) return;
+
+        const sampledColor = rgbaAt(current, point);
+        setBrushColor(rgbaToHex(sampledColor));
+        setPickingBrushColor(false);
+        setStatus(`Brush color picked: ${formatRgba(sampledColor)}`);
+        setError(null);
+        return;
+      }
+
       if (tool === "wand") {
         applyWandAtPoint(point);
         return;
       }
 
-      const current = currentImageRef.current;
       if (!current) return;
 
-      const mode: BrushMode =
-        tool === "erase" ? "erase" : tool === "restore" ? "restore" : tool === "blur" ? "blur" : "clean";
-      const targetCleanOptions =
-        mode === "clean"
-          ? {
-              target: rgbaAt(current, point),
-              tolerance: cleanTolerance,
-              edgeGuard: cleanEdgeGuard,
-              feather: cleanFeather,
-            }
-          : undefined;
+      const mode = cleanupToolToBrushMode(tool, brushToolMode);
+      if (!mode) return;
+
       const radius = Math.max(1, brushSize / 2);
+      const brushOptions = createBrushStrokeOptions({
+        mode,
+        radius,
+        brushHardness,
+        brushOpacity,
+        blurStrength,
+        cleanTarget: rgbaAt(current, point),
+        cleanTolerance,
+        cleanEdgeGuard,
+        cleanFeather,
+        brushColor,
+      });
       const before = cloneImageData(current);
       const changedPixels = applyBrushStamp(
         current,
         originalImageRef.current,
         point.x,
         point.y,
-        radius,
-        mode,
-        eraserHardness,
-        eraserOpacity,
-        blurStrength,
-        targetCleanOptions,
+        brushOptions,
       );
       putCurrentImage();
 
-      paintGestureRef.current = {
+      brushGestureRef.current = {
         pointerId: event.pointerId,
         before,
         lastPoint: point,
         changedPixels,
-        mode,
-        targetCleanOptions,
+        options: brushOptions,
       };
       canvas.setPointerCapture(event.pointerId);
     },
@@ -552,13 +679,16 @@ export function SpriteWandCleanupEditor({
       applyWandAtPoint,
       applying,
       blurStrength,
+      brushColor,
       brushSize,
+      brushToolMode,
       cleanEdgeGuard,
       cleanFeather,
       cleanTolerance,
-      eraserHardness,
-      eraserOpacity,
+      brushHardness,
+      brushOpacity,
       loading,
+      pickingBrushColor,
       putCurrentImage,
       tool,
       updateHoverPoint,
@@ -578,38 +708,32 @@ export function SpriteWandCleanupEditor({
       }
 
       const point = updateHoverPoint(event);
-      const paintGesture = paintGestureRef.current;
+      const brushGesture = brushGestureRef.current;
       const current = currentImageRef.current;
-      if (!point || !paintGesture || paintGesture.pointerId !== event.pointerId || !current) return;
+      if (!point || !brushGesture || brushGesture.pointerId !== event.pointerId || !current) return;
 
-      const radius = Math.max(1, brushSize / 2);
-      paintGesture.changedPixels += applyBrushLine(
+      brushGesture.changedPixels += applyBrushLine(
         current,
         originalImageRef.current,
-        paintGesture.lastPoint,
+        brushGesture.lastPoint,
         point,
-        radius,
-        paintGesture.mode,
-        eraserHardness,
-        eraserOpacity,
-        blurStrength,
-        paintGesture.targetCleanOptions,
+        brushGesture.options,
       );
-      paintGesture.lastPoint = point;
+      brushGesture.lastPoint = point;
       putCurrentImage();
     },
-    [blurStrength, brushSize, eraserHardness, eraserOpacity, putCurrentImage, updateHoverPoint],
+    [putCurrentImage, updateHoverPoint],
   );
 
   const handleCanvasPointerUp = useCallback((event: PointerEvent<HTMLCanvasElement>) => {
-    commitPaintGesture(event.currentTarget);
+    commitBrushGesture(event.currentTarget);
     commitPanGesture(event.currentTarget);
-  }, [commitPaintGesture, commitPanGesture]);
+  }, [commitBrushGesture, commitPanGesture]);
 
   const handleCanvasPointerCancel = useCallback((event: PointerEvent<HTMLCanvasElement>) => {
-    commitPaintGesture(event.currentTarget);
+    commitBrushGesture(event.currentTarget);
     commitPanGesture(event.currentTarget);
-  }, [commitPaintGesture, commitPanGesture]);
+  }, [commitBrushGesture, commitPanGesture]);
 
   const handleUndo = useCallback(() => {
     setHistory((prev) => {
@@ -643,6 +767,29 @@ export function SpriteWandCleanupEditor({
     setError(null);
   }, []);
 
+  const handleSelectTool = useCallback((nextTool: CleanupTool) => {
+    setTool(nextTool);
+    if (nextTool !== "brush") {
+      setPickingBrushColor(false);
+    }
+  }, []);
+
+  const handleSelectBrushToolMode = useCallback((nextMode: BrushToolMode) => {
+    setBrushToolMode(nextMode);
+    if (nextMode !== "paint") {
+      setPickingBrushColor(false);
+    }
+  }, []);
+
+  const handleToggleBrushColorPicker = useCallback(() => {
+    setPickingBrushColor((value) => {
+      const next = !value;
+      setStatus(next ? "Click the sprite to pick a brush color" : "Brush color picker canceled");
+      setError(null);
+      return next;
+    });
+  }, []);
+
   const handleApply = useCallback(async () => {
     const canvas = canvasRef.current;
     if (!canvas) return;
@@ -673,13 +820,12 @@ export function SpriteWandCleanupEditor({
     }),
     [canvasSize.height, canvasSize.width, zoom],
   );
+  const activeBrushMode = cleanupToolToBrushMode(tool, brushToolMode);
 
   const reticleStyle = useMemo<CSSProperties | null>(() => {
     if (!hoverPoint) return null;
     const diameter =
-      tool === "erase" || tool === "restore" || tool === "blur" || tool === "clean"
-        ? Math.max(8, brushSize * zoom)
-        : Math.max(12, 12 * zoom);
+      activeBrushMode && !pickingBrushColor ? Math.max(8, brushSize * zoom) : Math.max(12, 12 * zoom);
     return {
       width: `${diameter}px`,
       height: `${diameter}px`,
@@ -687,12 +833,12 @@ export function SpriteWandCleanupEditor({
       top: `${(hoverPoint.y + 0.5) * zoom}px`,
       transform: "translate(-50%, -50%)",
     };
-  }, [brushSize, hoverPoint, tool, zoom]);
+  }, [activeBrushMode, brushSize, hoverPoint, pickingBrushColor, zoom]);
 
   const cursorClass =
     tool === "pan"
       ? "cursor-grab active:cursor-grabbing"
-      : tool === "wand"
+      : tool === "wand" || pickingBrushColor
         ? "cursor-crosshair"
         : "cursor-none";
 
@@ -724,7 +870,7 @@ export function SpriteWandCleanupEditor({
             <button
               key={optionTool}
               type="button"
-              onClick={() => setTool(optionTool)}
+              onClick={() => handleSelectTool(optionTool)}
               disabled={loading || applying}
               className={toolButtonClass(tool === optionTool)}
               title={title}
@@ -736,7 +882,7 @@ export function SpriteWandCleanupEditor({
           <div className="ml-auto flex flex-wrap items-center gap-1 rounded-lg bg-[var(--secondary)] px-1.5 py-1">
             <button
               type="button"
-              onClick={() => setTool("pan")}
+              onClick={() => handleSelectTool("pan")}
               disabled={loading || applying}
               className={navigationButtonClass(tool === "pan")}
               aria-label="Pan"
@@ -831,7 +977,7 @@ export function SpriteWandCleanupEditor({
               </>
             )}
 
-            {(tool === "clean" || tool === "erase" || tool === "restore" || tool === "blur") && (
+            {activeBrushMode && (
               <>
                 <RangeControl
                   label="Brush"
@@ -844,6 +990,42 @@ export function SpriteWandCleanupEditor({
                   before={<Minus size="0.75rem" className="text-[var(--muted-foreground)]" />}
                   after={<Plus size="0.75rem" className="text-[var(--muted-foreground)]" />}
                 />
+                {tool === "brush" && (
+                  <div className="flex min-w-fit items-center gap-1 rounded-lg bg-[var(--secondary)] p-1 text-xs">
+                    <button
+                      type="button"
+                      onClick={() => handleSelectBrushToolMode("paint")}
+                      disabled={loading || applying}
+                      className={[
+                        "inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 font-medium transition-colors disabled:opacity-45",
+                        brushToolMode === "paint"
+                          ? "bg-[var(--primary)] text-[var(--primary-foreground)]"
+                          : "text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]",
+                      ].join(" ")}
+                      aria-pressed={brushToolMode === "paint"}
+                      title="Paint with the selected color"
+                    >
+                      <Brush size="0.75rem" />
+                      Color
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleSelectBrushToolMode("restore")}
+                      disabled={loading || applying}
+                      className={[
+                        "inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 font-medium transition-colors disabled:opacity-45",
+                        brushToolMode === "restore"
+                          ? "bg-[var(--primary)] text-[var(--primary-foreground)]"
+                          : "text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]",
+                      ].join(" ")}
+                      aria-pressed={brushToolMode === "restore"}
+                      title="Paint original pixels back in"
+                    >
+                      <Undo2 size="0.75rem" />
+                      Restore
+                    </button>
+                  </div>
+                )}
                 {tool === "clean" && (
                   <>
                     <RangeControl
@@ -878,26 +1060,64 @@ export function SpriteWandCleanupEditor({
                     />
                   </>
                 )}
-                {tool === "erase" && (
+                {tool === "brush" && brushToolMode === "paint" && (
+                  <div
+                    className="flex min-w-fit items-center gap-2 rounded-lg bg-[var(--secondary)] px-3 py-2 text-xs"
+                    title="Brush color"
+                  >
+                    <span className="shrink-0 whitespace-nowrap font-medium text-[var(--foreground)]">Color</span>
+                    <input
+                      type="color"
+                      value={brushColor}
+                      onChange={(event) => {
+                        setBrushColor(event.target.value);
+                        setPickingBrushColor(false);
+                      }}
+                      disabled={loading || applying}
+                      className="h-7 w-9 cursor-pointer rounded-md border border-[var(--border)] bg-transparent p-0.5 disabled:opacity-45"
+                      aria-label="Brush color"
+                    />
+                    <span className="font-mono text-[0.6875rem] uppercase text-[var(--muted-foreground)]">
+                      {brushColor}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={handleToggleBrushColorPicker}
+                      disabled={loading || applying}
+                      className={[
+                        "inline-flex items-center gap-1.5 rounded-md px-2 py-1 font-medium ring-1 transition-colors disabled:opacity-45",
+                        pickingBrushColor
+                          ? "bg-[var(--primary)] text-[var(--primary-foreground)] ring-transparent"
+                          : "text-[var(--muted-foreground)] ring-[var(--border)] hover:text-[var(--foreground)]",
+                      ].join(" ")}
+                      aria-pressed={pickingBrushColor}
+                      title="Pick brush color from the sprite"
+                    >
+                      <Pipette size="0.75rem" />
+                      Pick
+                    </button>
+                  </div>
+                )}
+                {usesOpacityHardnessControls(tool) && (
                   <>
                     <RangeControl
                       label="Opacity"
                       min={0}
                       max={100}
-                      value={eraserOpacity}
-                      onChange={setEraserOpacity}
+                      value={brushOpacity}
+                      onChange={setBrushOpacity}
                       disabled={loading || applying}
-                      title="How much alpha each eraser stroke removes"
+                      title={brushOpacityTitle(activeBrushMode)}
                       className="min-w-48 flex-1"
                     />
                     <RangeControl
                       label="Hardness"
                       min={0}
                       max={100}
-                      value={eraserHardness}
-                      onChange={setEraserHardness}
+                      value={brushHardness}
+                      onChange={setBrushHardness}
                       disabled={loading || applying}
-                      title="How crisp the eraser edge should be"
+                      title={brushHardnessTitle(activeBrushMode)}
                       className="min-w-48 flex-1"
                     />
                   </>
@@ -966,7 +1186,7 @@ export function SpriteWandCleanupEditor({
                 className={`block rounded-lg [touch-action:none] ${cursorClass}`}
                 style={canvasDisplayStyle}
                 aria-label={`Wand cleanup canvas for ${label}`}
-                title="Edit sprite transparency"
+                title={pickingBrushColor ? "Pick brush color" : "Edit sprite transparency"}
               />
               {reticleStyle && !loading && (
                 <span

--- a/packages/client/src/components/ui/SpriteWandCleanupEditor.tsx
+++ b/packages/client/src/components/ui/SpriteWandCleanupEditor.tsx
@@ -12,6 +12,7 @@ import {
 import {
   Blend,
   Brush,
+  Crosshair,
   Eraser,
   Hand,
   Loader2,
@@ -29,12 +30,11 @@ import {
   applyBrushStamp,
   cloneImageData,
   formatRgba,
-  removeConnectedColor,
-  removeConnectedColorDecontaminate,
-  removeConnectedColorSoftEdge,
+  removeWandSelection,
   rgbaAt,
   type BrushMode,
   type CanvasPoint,
+  type TargetCleanBrushOptions,
   type WandResult,
 } from "../../lib/sprite-cleanup-tools";
 import { Modal } from "./Modal";
@@ -51,7 +51,7 @@ interface HoverPoint extends CanvasPoint {
   color: [number, number, number, number];
 }
 
-type CleanupTool = "wand" | "erase" | "restore" | "blur" | "pan";
+type CleanupTool = "wand" | "clean" | "erase" | "restore" | "blur" | "pan";
 type PreviewBackground = "checker" | "dark" | "light" | "pink";
 
 interface PaintGesture {
@@ -60,6 +60,7 @@ interface PaintGesture {
   lastPoint: CanvasPoint;
   changedPixels: number;
   mode: BrushMode;
+  targetCleanOptions?: TargetCleanBrushOptions;
 }
 
 interface PanGesture {
@@ -96,9 +97,18 @@ interface ToggleControlProps {
 const DEFAULT_TOLERANCE = 36;
 const DEFAULT_BRUSH_SIZE = 18;
 const DEFAULT_ERASER_HARDNESS = 100;
+const DEFAULT_ERASER_OPACITY = 100;
 const DEFAULT_BLUR_STRENGTH = 65;
-const DEFAULT_EDGE_SOFTNESS = 60;
-const DEFAULT_EDGE_DECONTAMINATE = 0;
+const DEFAULT_CLEAN_TOLERANCE = 36;
+const DEFAULT_CLEAN_EDGE_GUARD = 45;
+const DEFAULT_CLEAN_FEATHER = 8;
+const DEFAULT_WAND_STRONG = false;
+const DEFAULT_WAND_SOFTNESS = 55;
+const DEFAULT_WAND_FEATHER = 12;
+const WAND_EDGE_GUARD = 55;
+const STRONG_WAND_EDGE_GUARD = 28;
+const WAND_EXPAND = 1;
+const STRONG_WAND_EXPAND = 2;
 const MAX_HISTORY = 12;
 const MIN_ZOOM = 0.125;
 const MAX_ZOOM = 8;
@@ -119,8 +129,8 @@ const previewBackgroundStyles: Record<PreviewBackground, CSSProperties> = {
 };
 
 const previewBackgroundOptions: Array<{ key: PreviewBackground; label: string }> = [
-  { key: "checker", label: "Grid" },
   { key: "dark", label: "Dark" },
+  { key: "checker", label: "Grid" },
   { key: "light", label: "Light" },
   { key: "pink", label: "Pink" },
 ];
@@ -132,6 +142,7 @@ const cleanupToolOptions: Array<{
   Icon: LucideIcon;
 }> = [
   { tool: "wand", label: "Wand", title: "Select connected pixels", Icon: Wand2 },
+  { tool: "clean", label: "Clean", title: "Brush away pixels matching the sampled color", Icon: Crosshair },
   { tool: "erase", label: "Erase", title: "Paint pixels transparent", Icon: Eraser },
   { tool: "restore", label: "Restore", title: "Paint original pixels back in", Icon: Brush },
   { tool: "blur", label: "Blur", title: "Paint alpha smoothing over jagged edges", Icon: Blend },
@@ -154,14 +165,17 @@ function RangeControl({
   onChange,
   step = 1,
   title,
-  className = "min-w-0 flex-1",
-  inputClassName = "min-w-24",
+  className = "min-w-[12rem] flex-[1_1_12rem]",
+  inputClassName = "min-w-0",
   before,
   after,
 }: RangeControlProps) {
   return (
-    <label className={`flex items-center gap-2 rounded-lg bg-[var(--secondary)] px-3 py-2 text-xs ${className}`} title={title}>
-      <span className="shrink-0 font-medium text-[var(--foreground)]">{label}</span>
+    <label
+      className={`flex min-w-0 items-center gap-2 rounded-lg bg-[var(--secondary)] px-3 py-2 text-xs ${className}`}
+      title={title}
+    >
+      <span className="shrink-0 whitespace-nowrap font-medium text-[var(--foreground)]">{label}</span>
       {before}
       <input
         type="range"
@@ -171,7 +185,7 @@ function RangeControl({
         value={value}
         onChange={(event) => onChange(Number(event.target.value))}
         disabled={disabled}
-        className={`${inputClassName} flex-1 accent-[var(--primary)] disabled:opacity-50`}
+        className={`${inputClassName} min-w-0 flex-1 accent-[var(--primary)] disabled:opacity-50`}
       />
       {after}
       <span className="w-8 shrink-0 text-right tabular-nums text-[var(--muted-foreground)]">{value}</span>
@@ -182,7 +196,7 @@ function RangeControl({
 function ToggleControl({ label, checked, disabled, onChange, title }: ToggleControlProps) {
   return (
     <label
-      className="flex items-center gap-2 rounded-lg bg-[var(--secondary)] px-3 py-2 text-xs font-medium text-[var(--foreground)]"
+      className="flex min-w-fit items-center gap-2 whitespace-nowrap rounded-lg bg-[var(--secondary)] px-3 py-2 text-xs font-medium text-[var(--foreground)]"
       title={title}
     >
       <input
@@ -242,14 +256,17 @@ export function SpriteWandCleanupEditor({
   const panGestureRef = useRef<PanGesture | null>(null);
 
   const [tool, setTool] = useState<CleanupTool>("wand");
-  const [classicStrong, setClassicStrong] = useState(false);
-  const [cleanEdge, setCleanEdge] = useState(false);
-  const [previewBackground, setPreviewBackground] = useState<PreviewBackground>("checker");
+  const [previewBackground, setPreviewBackground] = useState<PreviewBackground>("dark");
   const [tolerance, setTolerance] = useState(DEFAULT_TOLERANCE);
-  const [edgeSoftness, setEdgeSoftness] = useState(DEFAULT_EDGE_SOFTNESS);
-  const [edgeDecontaminate, setEdgeDecontaminate] = useState(DEFAULT_EDGE_DECONTAMINATE);
+  const [wandStrong, setWandStrong] = useState(DEFAULT_WAND_STRONG);
+  const [wandSoftness, setWandSoftness] = useState(DEFAULT_WAND_SOFTNESS);
+  const [wandFeather, setWandFeather] = useState(DEFAULT_WAND_FEATHER);
+  const [cleanTolerance, setCleanTolerance] = useState(DEFAULT_CLEAN_TOLERANCE);
+  const [cleanEdgeGuard, setCleanEdgeGuard] = useState(DEFAULT_CLEAN_EDGE_GUARD);
+  const [cleanFeather, setCleanFeather] = useState(DEFAULT_CLEAN_FEATHER);
   const [brushSize, setBrushSize] = useState(DEFAULT_BRUSH_SIZE);
   const [eraserHardness, setEraserHardness] = useState(DEFAULT_ERASER_HARDNESS);
+  const [eraserOpacity, setEraserOpacity] = useState(DEFAULT_ERASER_OPACITY);
   const [blurStrength, setBlurStrength] = useState(DEFAULT_BLUR_STRENGTH);
   const [zoom, setZoom] = useState(1);
   const [canvasSize, setCanvasSize] = useState({ width: 0, height: 0 });
@@ -385,24 +402,15 @@ export function SpriteWandCleanupEditor({
 
       const before = cloneImageData(current);
       const next = cloneImageData(current);
-      let result: WandResult;
-      if (cleanEdge) {
-        const cleanupTolerance = classicStrong ? Math.min(224, Math.round(tolerance * 1.65)) : tolerance;
-        result =
-          edgeDecontaminate > 0
-            ? removeConnectedColorDecontaminate(
-                next,
-                point.x,
-                point.y,
-                cleanupTolerance,
-                edgeDecontaminate,
-                edgeSoftness,
-              )
-            : removeConnectedColorSoftEdge(next, point.x, point.y, cleanupTolerance, edgeSoftness, edgeSoftness);
-      } else {
-        const selectionTolerance = classicStrong ? Math.min(224, Math.round(tolerance * 1.65)) : tolerance;
-        result = removeConnectedColor(next, point.x, point.y, selectionTolerance, classicStrong ? "all" : "cardinal");
-      }
+      const selectionTolerance = wandStrong ? Math.min(224, Math.round(tolerance * 1.55)) : tolerance;
+      const result: WandResult = removeWandSelection(next, point.x, point.y, selectionTolerance, {
+        mode: "connected",
+        radius: 0,
+        edgeGuard: wandStrong ? STRONG_WAND_EDGE_GUARD : WAND_EDGE_GUARD,
+        expand: wandStrong ? STRONG_WAND_EXPAND : WAND_EXPAND,
+        softness: wandSoftness,
+        feather: wandFeather,
+      });
 
       if (result.removed === 0) {
         setStatus("No opaque pixels selected");
@@ -413,26 +421,17 @@ export function SpriteWandCleanupEditor({
       currentImageRef.current = next;
       putCurrentImage();
       setHasChanges(true);
-      const optionLabel = [
-        classicStrong ? "strong" : null,
-        cleanEdge
-          ? `clean edge (${edgeSoftness}% softness${edgeDecontaminate > 0 ? `, ${edgeDecontaminate}% decontaminate` : ""})`
-          : null,
-      ]
-        .filter(Boolean)
-        .join(", ");
-      const modeLabel = optionLabel ? `wand (${optionLabel})` : "wand";
+      const modeLabel = `${wandStrong ? "strong " : ""}wand (${wandSoftness}% softness, ${wandFeather}% feather)`;
       setStatus(`${result.removed.toLocaleString()} px removed with ${modeLabel} from ${formatRgba(result.target)}`);
       setError(null);
     },
     [
-      classicStrong,
-      cleanEdge,
-      edgeDecontaminate,
-      edgeSoftness,
       pushHistory,
       putCurrentImage,
       tolerance,
+      wandFeather,
+      wandSoftness,
+      wandStrong,
     ],
   );
 
@@ -454,7 +453,13 @@ export function SpriteWandCleanupEditor({
       pushHistory(gesture.before);
       setHasChanges(true);
       const actionLabel =
-        gesture.mode === "erase" ? "erased" : gesture.mode === "restore" ? "restored" : "edge-blurred";
+        gesture.mode === "erase"
+          ? "erased"
+          : gesture.mode === "restore"
+            ? "restored"
+            : gesture.mode === "clean"
+              ? "target-cleaned"
+              : "edge-blurred";
       setStatus(`${gesture.changedPixels.toLocaleString()} px ${actionLabel}`);
       setError(null);
     },
@@ -506,7 +511,17 @@ export function SpriteWandCleanupEditor({
       const current = currentImageRef.current;
       if (!current) return;
 
-      const mode: BrushMode = tool === "erase" ? "erase" : tool === "restore" ? "restore" : "blur";
+      const mode: BrushMode =
+        tool === "erase" ? "erase" : tool === "restore" ? "restore" : tool === "blur" ? "blur" : "clean";
+      const targetCleanOptions =
+        mode === "clean"
+          ? {
+              target: rgbaAt(current, point),
+              tolerance: cleanTolerance,
+              edgeGuard: cleanEdgeGuard,
+              feather: cleanFeather,
+            }
+          : undefined;
       const radius = Math.max(1, brushSize / 2);
       const before = cloneImageData(current);
       const changedPixels = applyBrushStamp(
@@ -517,7 +532,9 @@ export function SpriteWandCleanupEditor({
         radius,
         mode,
         eraserHardness,
+        eraserOpacity,
         blurStrength,
+        targetCleanOptions,
       );
       putCurrentImage();
 
@@ -527,10 +544,25 @@ export function SpriteWandCleanupEditor({
         lastPoint: point,
         changedPixels,
         mode,
+        targetCleanOptions,
       };
       canvas.setPointerCapture(event.pointerId);
     },
-    [applyWandAtPoint, applying, blurStrength, brushSize, eraserHardness, loading, putCurrentImage, tool, updateHoverPoint],
+    [
+      applyWandAtPoint,
+      applying,
+      blurStrength,
+      brushSize,
+      cleanEdgeGuard,
+      cleanFeather,
+      cleanTolerance,
+      eraserHardness,
+      eraserOpacity,
+      loading,
+      putCurrentImage,
+      tool,
+      updateHoverPoint,
+    ],
   );
 
   const handleCanvasPointerMove = useCallback(
@@ -559,12 +591,14 @@ export function SpriteWandCleanupEditor({
         radius,
         paintGesture.mode,
         eraserHardness,
+        eraserOpacity,
         blurStrength,
+        paintGesture.targetCleanOptions,
       );
       paintGesture.lastPoint = point;
       putCurrentImage();
     },
-    [blurStrength, brushSize, eraserHardness, putCurrentImage, updateHoverPoint],
+    [blurStrength, brushSize, eraserHardness, eraserOpacity, putCurrentImage, updateHoverPoint],
   );
 
   const handleCanvasPointerUp = useCallback((event: PointerEvent<HTMLCanvasElement>) => {
@@ -600,6 +634,15 @@ export function SpriteWandCleanupEditor({
     setError(null);
   }, [restoreImageData]);
 
+  const handleResetWandDefaults = useCallback(() => {
+    setTolerance(DEFAULT_TOLERANCE);
+    setWandStrong(DEFAULT_WAND_STRONG);
+    setWandSoftness(DEFAULT_WAND_SOFTNESS);
+    setWandFeather(DEFAULT_WAND_FEATHER);
+    setStatus("Wand settings reset");
+    setError(null);
+  }, []);
+
   const handleApply = useCallback(async () => {
     const canvas = canvasRef.current;
     if (!canvas) return;
@@ -634,7 +677,7 @@ export function SpriteWandCleanupEditor({
   const reticleStyle = useMemo<CSSProperties | null>(() => {
     if (!hoverPoint) return null;
     const diameter =
-      tool === "erase" || tool === "restore" || tool === "blur"
+      tool === "erase" || tool === "restore" || tool === "blur" || tool === "clean"
         ? Math.max(8, brushSize * zoom)
         : Math.max(12, 12 * zoom);
     return {
@@ -739,6 +782,16 @@ export function SpriteWandCleanupEditor({
           <div className="flex flex-wrap items-center gap-2">
             {tool === "wand" && (
               <>
+                <button
+                  type="button"
+                  onClick={handleResetWandDefaults}
+                  disabled={loading || applying}
+                  className="inline-flex min-w-fit items-center gap-1.5 whitespace-nowrap rounded-lg bg-[var(--secondary)] px-3 py-2 text-xs font-medium text-[var(--muted-foreground)] ring-1 ring-[var(--border)] transition-colors hover:text-[var(--foreground)] disabled:opacity-45"
+                  title="Reset wand controls to their defaults"
+                >
+                  <RotateCcw size="0.875rem" />
+                  Defaults
+                </button>
                 <RangeControl
                   label="Tolerance"
                   min={4}
@@ -746,50 +799,39 @@ export function SpriteWandCleanupEditor({
                   value={tolerance}
                   onChange={setTolerance}
                   disabled={loading || applying}
-                  inputClassName="min-w-28"
+                  className="min-w-[12rem] flex-[1_1_12rem]"
                 />
                 <ToggleControl
                   label="Strong"
-                  checked={classicStrong}
-                  onChange={setClassicStrong}
+                  checked={wandStrong}
+                  onChange={setWandStrong}
                   disabled={loading || applying}
-                  title="Use diagonal fill with boosted tolerance"
+                  title="Reach farther into matching debris"
                 />
-                <ToggleControl
-                  label="Clean Edge"
-                  checked={cleanEdge}
-                  onChange={setCleanEdge}
+                <RangeControl
+                  label="Softness"
+                  min={0}
+                  max={100}
+                  value={wandSoftness}
+                  onChange={setWandSoftness}
                   disabled={loading || applying}
-                  title="Run edge cleanup after clearing the wand selection"
+                  title="0 is a hard cut; higher values leave a softer low-alpha edge"
+                  className="min-w-[14rem] flex-[1_1_14rem]"
                 />
-                {cleanEdge && (
-                  <>
-                    <RangeControl
-                      label="Softness"
-                      min={0}
-                      max={100}
-                      value={edgeSoftness}
-                      onChange={setEdgeSoftness}
-                      disabled={loading || applying}
-                      title="How much soft foreground-colored edge halo to add around the cut"
-                      className="min-w-48 flex-1"
-                    />
-                    <RangeControl
-                      label="Decontaminate"
-                      min={0}
-                      max={100}
-                      value={edgeDecontaminate}
-                      onChange={setEdgeDecontaminate}
-                      disabled={loading || applying}
-                      title="How much dirty matte color to pull out of anti-aliased edge pixels"
-                      className="min-w-48 flex-1"
-                    />
-                  </>
-                )}
+                <RangeControl
+                  label="Feather"
+                  min={0}
+                  max={100}
+                  value={wandFeather}
+                  onChange={setWandFeather}
+                  disabled={loading || applying}
+                  title="How much soft border the wand leaves behind, and how gradually it fades"
+                  className="min-w-[14rem] flex-[1_1_14rem]"
+                />
               </>
             )}
 
-            {(tool === "erase" || tool === "restore" || tool === "blur") && (
+            {(tool === "clean" || tool === "erase" || tool === "restore" || tool === "blur") && (
               <>
                 <RangeControl
                   label="Brush"
@@ -798,21 +840,67 @@ export function SpriteWandCleanupEditor({
                   value={brushSize}
                   onChange={setBrushSize}
                   disabled={loading || applying}
-                  inputClassName="min-w-28"
+                  inputClassName="min-w-20"
                   before={<Minus size="0.75rem" className="text-[var(--muted-foreground)]" />}
                   after={<Plus size="0.75rem" className="text-[var(--muted-foreground)]" />}
                 />
+                {tool === "clean" && (
+                  <>
+                    <RangeControl
+                      label="Tolerance"
+                      min={4}
+                      max={128}
+                      value={cleanTolerance}
+                      onChange={setCleanTolerance}
+                      disabled={loading || applying}
+                      title="How closely pixels must match the sampled cleanup color"
+                      className="min-w-[12rem] flex-[1_1_12rem]"
+                    />
+                    <RangeControl
+                      label="Edge Guard"
+                      min={0}
+                      max={100}
+                      value={cleanEdgeGuard}
+                      onChange={setCleanEdgeGuard}
+                      disabled={loading || applying}
+                      title="How strongly the brush avoids character-like edge pixels"
+                      className="min-w-[16rem] flex-[1_1_16rem]"
+                    />
+                    <RangeControl
+                      label="Feather"
+                      min={0}
+                      max={100}
+                      value={cleanFeather}
+                      onChange={setCleanFeather}
+                      disabled={loading || applying}
+                      title="Soften the edge of the cleaned brush stroke"
+                      className="min-w-[14rem] flex-[1_1_14rem]"
+                    />
+                  </>
+                )}
                 {tool === "erase" && (
-                  <RangeControl
-                    label="Hardness"
-                    min={0}
-                    max={100}
-                    value={eraserHardness}
-                    onChange={setEraserHardness}
-                    disabled={loading || applying}
-                    title="How crisp the eraser edge should be"
-                    className="min-w-48 flex-1"
-                  />
+                  <>
+                    <RangeControl
+                      label="Opacity"
+                      min={0}
+                      max={100}
+                      value={eraserOpacity}
+                      onChange={setEraserOpacity}
+                      disabled={loading || applying}
+                      title="How much alpha each eraser stroke removes"
+                      className="min-w-48 flex-1"
+                    />
+                    <RangeControl
+                      label="Hardness"
+                      min={0}
+                      max={100}
+                      value={eraserHardness}
+                      onChange={setEraserHardness}
+                      disabled={loading || applying}
+                      title="How crisp the eraser edge should be"
+                      className="min-w-48 flex-1"
+                    />
+                  </>
                 )}
                 {tool === "blur" && (
                   <RangeControl

--- a/packages/client/src/components/ui/SpriteWandCleanupEditor.tsx
+++ b/packages/client/src/components/ui/SpriteWandCleanupEditor.tsx
@@ -771,7 +771,7 @@ export function SpriteWandCleanupEditor({
                       value={edgeSoftness}
                       onChange={setEdgeSoftness}
                       disabled={loading || applying}
-                      title="How much alpha smoothing to apply near the kept edge"
+                      title="How much soft foreground-colored edge halo to add around the cut"
                       className="min-w-48 flex-1"
                     />
                     <RangeControl

--- a/packages/client/src/components/ui/SpriteWandCleanupEditor.tsx
+++ b/packages/client/src/components/ui/SpriteWandCleanupEditor.tsx
@@ -1,5 +1,42 @@
-import { useCallback, useEffect, useRef, useState, type CSSProperties, type PointerEvent } from "react";
-import { Eraser, Loader2, RotateCcw, Undo2, Wand2 } from "lucide-react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type ReactNode,
+  type PointerEvent,
+  type WheelEvent,
+} from "react";
+import {
+  Blend,
+  Brush,
+  Eraser,
+  Hand,
+  Loader2,
+  Minus,
+  Plus,
+  RotateCcw,
+  Undo2,
+  Wand2,
+  ZoomIn,
+  ZoomOut,
+  type LucideIcon,
+} from "lucide-react";
+import {
+  applyBrushLine,
+  applyBrushStamp,
+  cloneImageData,
+  formatRgba,
+  removeConnectedColor,
+  removeConnectedColorDecontaminate,
+  removeConnectedColorSoftEdge,
+  rgbaAt,
+  type BrushMode,
+  type CanvasPoint,
+  type WandResult,
+} from "../../lib/sprite-cleanup-tools";
 import { Modal } from "./Modal";
 
 interface SpriteWandCleanupEditorProps {
@@ -10,13 +47,61 @@ interface SpriteWandCleanupEditorProps {
   onClose: () => void;
 }
 
-interface WandResult {
-  removed: number;
-  target: [number, number, number, number];
+interface HoverPoint extends CanvasPoint {
+  color: [number, number, number, number];
+}
+
+type CleanupTool = "wand" | "erase" | "restore" | "blur" | "pan";
+type PreviewBackground = "checker" | "dark" | "light" | "pink";
+
+interface PaintGesture {
+  pointerId: number;
+  before: ImageData;
+  lastPoint: CanvasPoint;
+  changedPixels: number;
+  mode: BrushMode;
+}
+
+interface PanGesture {
+  pointerId: number;
+  startClientX: number;
+  startClientY: number;
+  startScrollLeft: number;
+  startScrollTop: number;
+}
+
+interface RangeControlProps {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  disabled: boolean;
+  onChange: (value: number) => void;
+  step?: number;
+  title?: string;
+  className?: string;
+  inputClassName?: string;
+  before?: ReactNode;
+  after?: ReactNode;
+}
+
+interface ToggleControlProps {
+  label: string;
+  checked: boolean;
+  disabled: boolean;
+  onChange: (checked: boolean) => void;
+  title?: string;
 }
 
 const DEFAULT_TOLERANCE = 36;
+const DEFAULT_BRUSH_SIZE = 18;
+const DEFAULT_ERASER_HARDNESS = 100;
+const DEFAULT_BLUR_STRENGTH = 65;
+const DEFAULT_EDGE_SOFTNESS = 60;
+const DEFAULT_EDGE_DECONTAMINATE = 0;
 const MAX_HISTORY = 12;
+const MIN_ZOOM = 0.125;
+const MAX_ZOOM = 8;
 
 const checkerboardStyle: CSSProperties = {
   backgroundColor: "var(--secondary)",
@@ -26,64 +111,90 @@ const checkerboardStyle: CSSProperties = {
   backgroundSize: "20px 20px",
 };
 
-function colorDistanceSquared(data: Uint8ClampedArray, offset: number, target: [number, number, number]): number {
-  const red = data[offset] - target[0];
-  const green = data[offset + 1] - target[1];
-  const blue = data[offset + 2] - target[2];
-  return red * red + green * green + blue * blue;
+const previewBackgroundStyles: Record<PreviewBackground, CSSProperties> = {
+  checker: checkerboardStyle,
+  dark: { backgroundColor: "#161321" },
+  light: { backgroundColor: "#f3eef8" },
+  pink: { backgroundColor: "#ff4fa3" },
+};
+
+const previewBackgroundOptions: Array<{ key: PreviewBackground; label: string }> = [
+  { key: "checker", label: "Grid" },
+  { key: "dark", label: "Dark" },
+  { key: "light", label: "Light" },
+  { key: "pink", label: "Pink" },
+];
+
+const cleanupToolOptions: Array<{
+  tool: Exclude<CleanupTool, "pan">;
+  label: string;
+  title: string;
+  Icon: LucideIcon;
+}> = [
+  { tool: "wand", label: "Wand", title: "Select connected pixels", Icon: Wand2 },
+  { tool: "erase", label: "Erase", title: "Paint pixels transparent", Icon: Eraser },
+  { tool: "restore", label: "Restore", title: "Paint original pixels back in", Icon: Brush },
+  { tool: "blur", label: "Blur", title: "Paint alpha smoothing over jagged edges", Icon: Blend },
+];
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, Number.isFinite(value) ? value : min));
 }
 
-function removeConnectedColor(imageData: ImageData, startX: number, startY: number, tolerance: number): WandResult {
-  const { data, width, height } = imageData;
-  const startIndex = startY * width + startX;
-  const startOffset = startIndex * 4;
-  const targetAlpha = data[startOffset + 3];
+function clampZoom(value: number): number {
+  return clamp(value, MIN_ZOOM, MAX_ZOOM);
+}
 
-  if (targetAlpha <= 8) {
-    return {
-      removed: 0,
-      target: [data[startOffset], data[startOffset + 1], data[startOffset + 2], targetAlpha],
-    };
-  }
+function RangeControl({
+  label,
+  value,
+  min,
+  max,
+  disabled,
+  onChange,
+  step = 1,
+  title,
+  className = "min-w-0 flex-1",
+  inputClassName = "min-w-24",
+  before,
+  after,
+}: RangeControlProps) {
+  return (
+    <label className={`flex items-center gap-2 rounded-lg bg-[var(--secondary)] px-3 py-2 text-xs ${className}`} title={title}>
+      <span className="shrink-0 font-medium text-[var(--foreground)]">{label}</span>
+      {before}
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(event) => onChange(Number(event.target.value))}
+        disabled={disabled}
+        className={`${inputClassName} flex-1 accent-[var(--primary)] disabled:opacity-50`}
+      />
+      {after}
+      <span className="w-8 shrink-0 text-right tabular-nums text-[var(--muted-foreground)]">{value}</span>
+    </label>
+  );
+}
 
-  const target: [number, number, number] = [data[startOffset], data[startOffset + 1], data[startOffset + 2]];
-  const totalPixels = width * height;
-  const threshold = tolerance * tolerance;
-  const visited = new Uint8Array(totalPixels);
-  const stack = new Int32Array(totalPixels);
-  let stackLength = 0;
-  let removed = 0;
-
-  const pushPixel = (index: number) => {
-    if (!visited[index]) {
-      visited[index] = 1;
-      stack[stackLength++] = index;
-    }
-  };
-
-  pushPixel(startIndex);
-
-  while (stackLength > 0) {
-    const index = stack[--stackLength];
-    const offset = index * 4;
-    if (data[offset + 3] <= 8 || colorDistanceSquared(data, offset, target) > threshold) {
-      continue;
-    }
-
-    data[offset + 3] = 0;
-    removed += 1;
-
-    const x = index % width;
-    if (x > 0) pushPixel(index - 1);
-    if (x < width - 1) pushPixel(index + 1);
-    if (index >= width) pushPixel(index - width);
-    if (index < totalPixels - width) pushPixel(index + width);
-  }
-
-  return {
-    removed,
-    target: [target[0], target[1], target[2], targetAlpha],
-  };
+function ToggleControl({ label, checked, disabled, onChange, title }: ToggleControlProps) {
+  return (
+    <label
+      className="flex items-center gap-2 rounded-lg bg-[var(--secondary)] px-3 py-2 text-xs font-medium text-[var(--foreground)]"
+      title={title}
+    >
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(event) => onChange(event.target.checked)}
+        disabled={disabled}
+        className="h-4 w-4 accent-[var(--primary)] disabled:opacity-50"
+      />
+      {label}
+    </label>
+  );
 }
 
 async function loadImageToCanvas(imageUrl: string, canvas: HTMLCanvasElement): Promise<ImageData> {
@@ -123,25 +234,67 @@ export function SpriteWandCleanupEditor({
   onApply,
   onClose,
 }: SpriteWandCleanupEditorProps) {
+  const stageRef = useRef<HTMLDivElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const originalImageRef = useRef<ImageData | null>(null);
+  const currentImageRef = useRef<ImageData | null>(null);
+  const paintGestureRef = useRef<PaintGesture | null>(null);
+  const panGestureRef = useRef<PanGesture | null>(null);
+
+  const [tool, setTool] = useState<CleanupTool>("wand");
+  const [classicStrong, setClassicStrong] = useState(false);
+  const [cleanEdge, setCleanEdge] = useState(false);
+  const [previewBackground, setPreviewBackground] = useState<PreviewBackground>("checker");
   const [tolerance, setTolerance] = useState(DEFAULT_TOLERANCE);
+  const [edgeSoftness, setEdgeSoftness] = useState(DEFAULT_EDGE_SOFTNESS);
+  const [edgeDecontaminate, setEdgeDecontaminate] = useState(DEFAULT_EDGE_DECONTAMINATE);
+  const [brushSize, setBrushSize] = useState(DEFAULT_BRUSH_SIZE);
+  const [eraserHardness, setEraserHardness] = useState(DEFAULT_ERASER_HARDNESS);
+  const [blurStrength, setBlurStrength] = useState(DEFAULT_BLUR_STRENGTH);
+  const [zoom, setZoom] = useState(1);
+  const [canvasSize, setCanvasSize] = useState({ width: 0, height: 0 });
+  const [hoverPoint, setHoverPoint] = useState<HoverPoint | null>(null);
   const [history, setHistory] = useState<ImageData[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [status, setStatus] = useState<string | null>(null);
   const [hasChanges, setHasChanges] = useState(false);
 
-  const restoreImageData = useCallback((imageData: ImageData) => {
+  const putCurrentImage = useCallback(() => {
     const canvas = canvasRef.current;
-    if (!canvas) return;
+    const imageData = currentImageRef.current;
+    if (!canvas || !imageData) return;
 
-    canvas.width = imageData.width;
-    canvas.height = imageData.height;
     const ctx = canvas.getContext("2d", { willReadFrequently: true });
     if (!ctx) return;
 
     ctx.putImageData(imageData, 0, 0);
+  }, []);
+
+  const restoreImageData = useCallback(
+    (imageData: ImageData) => {
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+
+      const next = cloneImageData(imageData);
+      canvas.width = next.width;
+      canvas.height = next.height;
+      currentImageRef.current = next;
+      setCanvasSize({ width: next.width, height: next.height });
+      putCurrentImage();
+    },
+    [putCurrentImage],
+  );
+
+  const fitCanvasToStage = useCallback(() => {
+    const canvas = canvasRef.current;
+    const stage = stageRef.current;
+    if (!canvas || !stage || canvas.width <= 0 || canvas.height <= 0) return;
+
+    const availableWidth = Math.max(1, stage.clientWidth - 32);
+    const availableHeight = Math.max(1, stage.clientHeight - 32);
+    const nextZoom = Math.min(1, availableWidth / canvas.width, availableHeight / canvas.height);
+    setZoom(clampZoom(nextZoom));
   }, []);
 
   useEffect(() => {
@@ -153,7 +306,10 @@ export function SpriteWandCleanupEditor({
     setStatus(null);
     setHasChanges(false);
     setHistory([]);
+    setHoverPoint(null);
+    setZoom(1);
     originalImageRef.current = null;
+    currentImageRef.current = null;
 
     const loadWhenCanvasMounts = () => {
       const canvas = canvasRef.current;
@@ -165,12 +321,10 @@ export function SpriteWandCleanupEditor({
       loadImageToCanvas(imageUrl, canvas)
         .then((imageData) => {
           if (cancelled) return;
-          originalImageRef.current = new ImageData(
-            new Uint8ClampedArray(imageData.data),
-            imageData.width,
-            imageData.height,
-          );
+          originalImageRef.current = cloneImageData(imageData);
+          restoreImageData(imageData);
           setLoading(false);
+          requestAnimationFrame(fitCanvasToStage);
         })
         .catch((err: any) => {
           if (cancelled) return;
@@ -185,44 +339,243 @@ export function SpriteWandCleanupEditor({
       cancelled = true;
       if (frameId !== null) cancelAnimationFrame(frameId);
     };
-  }, [imageUrl]);
+  }, [fitCanvasToStage, imageUrl, restoreImageData]);
 
-  const handleCanvasPointerDown = useCallback(
-    (event: PointerEvent<HTMLCanvasElement>) => {
-      if (loading || applying) return;
+  const canvasPointFromClient = useCallback((clientX: number, clientY: number): CanvasPoint | null => {
+    const canvas = canvasRef.current;
+    if (!canvas || canvas.width <= 0 || canvas.height <= 0) return null;
 
-      const canvas = canvasRef.current;
-      if (!canvas) return;
+    const rect = canvas.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) return null;
 
-      const rect = canvas.getBoundingClientRect();
-      const x = Math.floor(((event.clientX - rect.left) / rect.width) * canvas.width);
-      const y = Math.floor(((event.clientY - rect.top) / rect.height) * canvas.height);
+    const normalizedX = (clientX - rect.left) / rect.width;
+    const normalizedY = (clientY - rect.top) / rect.height;
+    if (normalizedX < 0 || normalizedY < 0 || normalizedX > 1 || normalizedY > 1) return null;
 
-      if (x < 0 || y < 0 || x >= canvas.width || y >= canvas.height) return;
+    return {
+      x: clamp(Math.floor(normalizedX * canvas.width), 0, canvas.width - 1),
+      y: clamp(Math.floor(normalizedY * canvas.height), 0, canvas.height - 1),
+    };
+  }, []);
 
-      const ctx = canvas.getContext("2d", { willReadFrequently: true });
-      if (!ctx) {
-        setError("Canvas is unavailable");
-        return;
+  const updateHoverPoint = useCallback(
+    (event: PointerEvent<HTMLCanvasElement>): CanvasPoint | null => {
+      const point = canvasPointFromClient(event.clientX, event.clientY);
+      const imageData = currentImageRef.current;
+
+      if (!point || !imageData) {
+        setHoverPoint(null);
+        return null;
       }
 
-      const before = ctx.getImageData(0, 0, canvas.width, canvas.height);
-      const next = new ImageData(new Uint8ClampedArray(before.data), before.width, before.height);
-      const result = removeConnectedColor(next, x, y, tolerance);
+      setHoverPoint({ ...point, color: rgbaAt(imageData, point) });
+      return point;
+    },
+    [canvasPointFromClient],
+  );
+
+  const pushHistory = useCallback((snapshot: ImageData) => {
+    setHistory((prev) => [...prev.slice(Math.max(0, prev.length - MAX_HISTORY + 1)), snapshot]);
+  }, []);
+
+  const applyWandAtPoint = useCallback(
+    (point: CanvasPoint) => {
+      const current = currentImageRef.current;
+      if (!current) return;
+
+      const before = cloneImageData(current);
+      const next = cloneImageData(current);
+      let result: WandResult;
+      if (cleanEdge) {
+        const cleanupTolerance = classicStrong ? Math.min(224, Math.round(tolerance * 1.65)) : tolerance;
+        result =
+          edgeDecontaminate > 0
+            ? removeConnectedColorDecontaminate(
+                next,
+                point.x,
+                point.y,
+                cleanupTolerance,
+                edgeDecontaminate,
+                edgeSoftness,
+              )
+            : removeConnectedColorSoftEdge(next, point.x, point.y, cleanupTolerance, edgeSoftness, edgeSoftness);
+      } else {
+        const selectionTolerance = classicStrong ? Math.min(224, Math.round(tolerance * 1.65)) : tolerance;
+        result = removeConnectedColor(next, point.x, point.y, selectionTolerance, classicStrong ? "all" : "cardinal");
+      }
 
       if (result.removed === 0) {
         setStatus("No opaque pixels selected");
         return;
       }
 
-      setHistory((prev) => [...prev.slice(Math.max(0, prev.length - MAX_HISTORY + 1)), before]);
-      ctx.putImageData(next, 0, 0);
+      pushHistory(before);
+      currentImageRef.current = next;
+      putCurrentImage();
       setHasChanges(true);
-      setStatus(`${result.removed.toLocaleString()} px removed`);
+      const optionLabel = [
+        classicStrong ? "strong" : null,
+        cleanEdge
+          ? `clean edge (${edgeSoftness}% softness${edgeDecontaminate > 0 ? `, ${edgeDecontaminate}% decontaminate` : ""})`
+          : null,
+      ]
+        .filter(Boolean)
+        .join(", ");
+      const modeLabel = optionLabel ? `wand (${optionLabel})` : "wand";
+      setStatus(`${result.removed.toLocaleString()} px removed with ${modeLabel} from ${formatRgba(result.target)}`);
       setError(null);
     },
-    [applying, loading, tolerance],
+    [
+      classicStrong,
+      cleanEdge,
+      edgeDecontaminate,
+      edgeSoftness,
+      pushHistory,
+      putCurrentImage,
+      tolerance,
+    ],
   );
+
+  const commitPaintGesture = useCallback(
+    (canvas: HTMLCanvasElement | null) => {
+      const gesture = paintGestureRef.current;
+      if (!gesture) return;
+
+      paintGestureRef.current = null;
+      if (canvas?.hasPointerCapture(gesture.pointerId)) {
+        canvas.releasePointerCapture(gesture.pointerId);
+      }
+
+      if (gesture.changedPixels === 0) {
+        setStatus("No pixels changed");
+        return;
+      }
+
+      pushHistory(gesture.before);
+      setHasChanges(true);
+      const actionLabel =
+        gesture.mode === "erase" ? "erased" : gesture.mode === "restore" ? "restored" : "edge-blurred";
+      setStatus(`${gesture.changedPixels.toLocaleString()} px ${actionLabel}`);
+      setError(null);
+    },
+    [pushHistory],
+  );
+
+  const commitPanGesture = useCallback((canvas: HTMLCanvasElement | null) => {
+    const gesture = panGestureRef.current;
+    if (!gesture) return;
+
+    panGestureRef.current = null;
+    if (canvas?.hasPointerCapture(gesture.pointerId)) {
+      canvas.releasePointerCapture(gesture.pointerId);
+    }
+  }, []);
+
+  const handleCanvasPointerDown = useCallback(
+    (event: PointerEvent<HTMLCanvasElement>) => {
+      if (loading || applying) return;
+
+      event.preventDefault();
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+
+      if (tool === "pan") {
+        const stage = stageRef.current;
+        if (!stage) return;
+
+        panGestureRef.current = {
+          pointerId: event.pointerId,
+          startClientX: event.clientX,
+          startClientY: event.clientY,
+          startScrollLeft: stage.scrollLeft,
+          startScrollTop: stage.scrollTop,
+        };
+        canvas.setPointerCapture(event.pointerId);
+        setStatus("Panning");
+        return;
+      }
+
+      const point = updateHoverPoint(event);
+      if (!point) return;
+
+      if (tool === "wand") {
+        applyWandAtPoint(point);
+        return;
+      }
+
+      const current = currentImageRef.current;
+      if (!current) return;
+
+      const mode: BrushMode = tool === "erase" ? "erase" : tool === "restore" ? "restore" : "blur";
+      const radius = Math.max(1, brushSize / 2);
+      const before = cloneImageData(current);
+      const changedPixels = applyBrushStamp(
+        current,
+        originalImageRef.current,
+        point.x,
+        point.y,
+        radius,
+        mode,
+        eraserHardness,
+        blurStrength,
+      );
+      putCurrentImage();
+
+      paintGestureRef.current = {
+        pointerId: event.pointerId,
+        before,
+        lastPoint: point,
+        changedPixels,
+        mode,
+      };
+      canvas.setPointerCapture(event.pointerId);
+    },
+    [applyWandAtPoint, applying, blurStrength, brushSize, eraserHardness, loading, putCurrentImage, tool, updateHoverPoint],
+  );
+
+  const handleCanvasPointerMove = useCallback(
+    (event: PointerEvent<HTMLCanvasElement>) => {
+      const panGesture = panGestureRef.current;
+      if (panGesture && panGesture.pointerId === event.pointerId) {
+        const stage = stageRef.current;
+        if (stage) {
+          stage.scrollLeft = panGesture.startScrollLeft - (event.clientX - panGesture.startClientX);
+          stage.scrollTop = panGesture.startScrollTop - (event.clientY - panGesture.startClientY);
+        }
+        return;
+      }
+
+      const point = updateHoverPoint(event);
+      const paintGesture = paintGestureRef.current;
+      const current = currentImageRef.current;
+      if (!point || !paintGesture || paintGesture.pointerId !== event.pointerId || !current) return;
+
+      const radius = Math.max(1, brushSize / 2);
+      paintGesture.changedPixels += applyBrushLine(
+        current,
+        originalImageRef.current,
+        paintGesture.lastPoint,
+        point,
+        radius,
+        paintGesture.mode,
+        eraserHardness,
+        blurStrength,
+      );
+      paintGesture.lastPoint = point;
+      putCurrentImage();
+    },
+    [blurStrength, brushSize, eraserHardness, putCurrentImage, updateHoverPoint],
+  );
+
+  const handleCanvasPointerUp = useCallback((event: PointerEvent<HTMLCanvasElement>) => {
+    commitPaintGesture(event.currentTarget);
+    commitPanGesture(event.currentTarget);
+  }, [commitPaintGesture, commitPanGesture]);
+
+  const handleCanvasPointerCancel = useCallback((event: PointerEvent<HTMLCanvasElement>) => {
+    commitPaintGesture(event.currentTarget);
+    commitPanGesture(event.currentTarget);
+  }, [commitPaintGesture, commitPanGesture]);
 
   const handleUndo = useCallback(() => {
     setHistory((prev) => {
@@ -259,28 +612,290 @@ export function SpriteWandCleanupEditor({
     }
   }, [onApply]);
 
+  const handleStageWheel = useCallback((event: WheelEvent<HTMLDivElement>) => {
+    if (!event.ctrlKey && !event.metaKey) return;
+    event.preventDefault();
+    const factor = event.deltaY < 0 ? 1.15 : 1 / 1.15;
+    setZoom((value) => clampZoom(value * factor));
+  }, []);
+
+  const zoomIn = useCallback(() => setZoom((value) => clampZoom(value * 1.25)), []);
+  const zoomOut = useCallback(() => setZoom((value) => clampZoom(value / 1.25)), []);
+
+  const canvasDisplayStyle = useMemo<CSSProperties>(
+    () => ({
+      width: canvasSize.width > 0 ? `${canvasSize.width * zoom}px` : undefined,
+      height: canvasSize.height > 0 ? `${canvasSize.height * zoom}px` : undefined,
+      imageRendering: zoom >= 2 ? "pixelated" : "auto",
+    }),
+    [canvasSize.height, canvasSize.width, zoom],
+  );
+
+  const reticleStyle = useMemo<CSSProperties | null>(() => {
+    if (!hoverPoint) return null;
+    const diameter =
+      tool === "erase" || tool === "restore" || tool === "blur"
+        ? Math.max(8, brushSize * zoom)
+        : Math.max(12, 12 * zoom);
+    return {
+      width: `${diameter}px`,
+      height: `${diameter}px`,
+      left: `${(hoverPoint.x + 0.5) * zoom}px`,
+      top: `${(hoverPoint.y + 0.5) * zoom}px`,
+      transform: "translate(-50%, -50%)",
+    };
+  }, [brushSize, hoverPoint, tool, zoom]);
+
+  const cursorClass =
+    tool === "pan"
+      ? "cursor-grab active:cursor-grabbing"
+      : tool === "wand"
+        ? "cursor-crosshair"
+        : "cursor-none";
+
+  const toolButtonClass = (active: boolean) =>
+    [
+      "inline-flex min-w-0 items-center justify-center gap-1.5 rounded-lg px-3 py-2 text-xs font-medium transition-colors ring-1 disabled:opacity-45",
+      active
+        ? "bg-[var(--primary)] text-[var(--primary-foreground)] ring-transparent"
+        : "bg-[var(--secondary)] text-[var(--muted-foreground)] ring-[var(--border)] hover:text-[var(--foreground)]",
+    ].join(" ");
+
+  const navigationButtonClass = (active = false) =>
+    [
+      "inline-flex h-7 w-7 items-center justify-center rounded-md transition-colors disabled:opacity-45",
+      active
+        ? "bg-[var(--primary)] text-[var(--primary-foreground)]"
+        : "text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]",
+    ].join(" ");
+
+  const hoverReadout = hoverPoint
+    ? `x ${hoverPoint.x}, y ${hoverPoint.y} · ${formatRgba(hoverPoint.color)}`
+    : "Move over the sprite to sample pixels";
+
   return (
-    <Modal open onClose={onClose} title={`Clean ${label}`} width="max-w-5xl">
-      <div className="flex min-h-0 flex-col gap-4">
-        <div className="flex flex-wrap items-center gap-2">
-          <span className="inline-flex items-center gap-1.5 rounded-lg bg-[var(--primary)] px-3 py-2 text-xs font-semibold text-[var(--primary-foreground)]">
-            <Wand2 size="0.875rem" />
-            Wand
-          </span>
-          <label className="flex min-w-0 flex-1 items-center gap-2 rounded-lg bg-[var(--secondary)] px-3 py-2 text-xs">
-            <span className="shrink-0 font-medium text-[var(--foreground)]">Tolerance</span>
-            <input
-              type="range"
-              min={4}
-              max={96}
-              step={1}
-              value={tolerance}
-              onChange={(event) => setTolerance(Number(event.target.value))}
+    <Modal open onClose={onClose} title={`Clean ${label}`} width="max-w-6xl">
+      <div className="flex h-[calc(100dvh-7rem)] min-h-0 flex-col gap-3 overflow-hidden sm:h-[min(44rem,calc(90dvh-6rem))]">
+        <div className="flex shrink-0 flex-wrap items-center gap-2">
+          {cleanupToolOptions.map(({ tool: optionTool, label: optionLabel, title, Icon }) => (
+            <button
+              key={optionTool}
+              type="button"
+              onClick={() => setTool(optionTool)}
               disabled={loading || applying}
-              className="min-w-28 flex-1 accent-[var(--primary)] disabled:opacity-50"
-            />
-            <span className="w-8 shrink-0 text-right tabular-nums text-[var(--muted-foreground)]">{tolerance}</span>
-          </label>
+              className={toolButtonClass(tool === optionTool)}
+              title={title}
+            >
+              <Icon size="0.875rem" />
+              {optionLabel}
+            </button>
+          ))}
+          <div className="ml-auto flex flex-wrap items-center gap-1 rounded-lg bg-[var(--secondary)] px-1.5 py-1">
+            <button
+              type="button"
+              onClick={() => setTool("pan")}
+              disabled={loading || applying}
+              className={navigationButtonClass(tool === "pan")}
+              aria-label="Pan"
+              aria-pressed={tool === "pan"}
+              title="Drag around while zoomed in"
+            >
+              <Hand size="0.875rem" />
+            </button>
+            <span aria-hidden="true" className="mx-0.5 h-4 w-px bg-[var(--border)]" />
+            <button
+              type="button"
+              onClick={zoomOut}
+              disabled={loading || applying}
+              className={navigationButtonClass()}
+              aria-label="Zoom out"
+              title="Zoom out"
+            >
+              <ZoomOut size="0.875rem" />
+            </button>
+            <button
+              type="button"
+              onClick={fitCanvasToStage}
+              disabled={loading || applying}
+              className="h-7 rounded-md px-2 text-[0.6875rem] font-medium tabular-nums text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] disabled:opacity-45"
+              title="Fit to view"
+            >
+              {Math.round(zoom * 100)}%
+            </button>
+            <button
+              type="button"
+              onClick={zoomIn}
+              disabled={loading || applying}
+              className={navigationButtonClass()}
+              aria-label="Zoom in"
+              title="Zoom in"
+            >
+              <ZoomIn size="0.875rem" />
+            </button>
+          </div>
+        </div>
+
+        <div className="grid shrink-0 gap-2 lg:grid-cols-[minmax(0,1fr)_auto]">
+          <div className="flex flex-wrap items-center gap-2">
+            {tool === "wand" && (
+              <>
+                <RangeControl
+                  label="Tolerance"
+                  min={4}
+                  max={128}
+                  value={tolerance}
+                  onChange={setTolerance}
+                  disabled={loading || applying}
+                  inputClassName="min-w-28"
+                />
+                <ToggleControl
+                  label="Strong"
+                  checked={classicStrong}
+                  onChange={setClassicStrong}
+                  disabled={loading || applying}
+                  title="Use diagonal fill with boosted tolerance"
+                />
+                <ToggleControl
+                  label="Clean Edge"
+                  checked={cleanEdge}
+                  onChange={setCleanEdge}
+                  disabled={loading || applying}
+                  title="Run edge cleanup after clearing the wand selection"
+                />
+                {cleanEdge && (
+                  <>
+                    <RangeControl
+                      label="Softness"
+                      min={0}
+                      max={100}
+                      value={edgeSoftness}
+                      onChange={setEdgeSoftness}
+                      disabled={loading || applying}
+                      title="How much alpha smoothing to apply near the kept edge"
+                      className="min-w-48 flex-1"
+                    />
+                    <RangeControl
+                      label="Decontaminate"
+                      min={0}
+                      max={100}
+                      value={edgeDecontaminate}
+                      onChange={setEdgeDecontaminate}
+                      disabled={loading || applying}
+                      title="How much dirty matte color to pull out of anti-aliased edge pixels"
+                      className="min-w-48 flex-1"
+                    />
+                  </>
+                )}
+              </>
+            )}
+
+            {(tool === "erase" || tool === "restore" || tool === "blur") && (
+              <>
+                <RangeControl
+                  label="Brush"
+                  min={2}
+                  max={96}
+                  value={brushSize}
+                  onChange={setBrushSize}
+                  disabled={loading || applying}
+                  inputClassName="min-w-28"
+                  before={<Minus size="0.75rem" className="text-[var(--muted-foreground)]" />}
+                  after={<Plus size="0.75rem" className="text-[var(--muted-foreground)]" />}
+                />
+                {tool === "erase" && (
+                  <RangeControl
+                    label="Hardness"
+                    min={0}
+                    max={100}
+                    value={eraserHardness}
+                    onChange={setEraserHardness}
+                    disabled={loading || applying}
+                    title="How crisp the eraser edge should be"
+                    className="min-w-48 flex-1"
+                  />
+                )}
+                {tool === "blur" && (
+                  <RangeControl
+                    label="Strength"
+                    min={0}
+                    max={100}
+                    value={blurStrength}
+                    onChange={setBlurStrength}
+                    disabled={loading || applying}
+                    title="How strongly the blur brush smooths alpha edges"
+                    className="min-w-48 flex-1"
+                  />
+                )}
+              </>
+            )}
+          </div>
+
+          <div className="flex flex-wrap items-center gap-1 rounded-lg bg-[var(--secondary)] p-1">
+            {previewBackgroundOptions.map((option) => (
+              <button
+                key={option.key}
+                type="button"
+                onClick={() => setPreviewBackground(option.key)}
+                className={[
+                  "rounded-md px-2 py-1 text-[0.6875rem] font-medium transition-colors",
+                  previewBackground === option.key
+                    ? "bg-[var(--primary)] text-[var(--primary-foreground)]"
+                    : "text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]",
+                ].join(" ")}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="relative min-h-0 flex-1 overflow-hidden">
+          <div
+            ref={stageRef}
+            onWheel={handleStageWheel}
+            className="relative flex h-full min-h-0 items-start justify-start overflow-auto rounded-xl border border-[var(--border)] p-3"
+            style={previewBackgroundStyles[previewBackground]}
+          >
+            {loading && (
+              <div className="absolute inset-0 z-10 flex items-center justify-center bg-[var(--background)]/60">
+                <Loader2 size="1.5rem" className="animate-spin text-[var(--primary)]" />
+              </div>
+            )}
+            <div
+              className="relative mx-auto my-auto shrink-0 rounded-lg shadow-xl shadow-black/30"
+              style={{
+                width: canvasDisplayStyle.width,
+                height: canvasDisplayStyle.height,
+              }}
+            >
+              <canvas
+                ref={canvasRef}
+                onPointerDown={handleCanvasPointerDown}
+                onPointerMove={handleCanvasPointerMove}
+                onPointerUp={handleCanvasPointerUp}
+                onPointerCancel={handleCanvasPointerCancel}
+                onPointerLeave={() => setHoverPoint(null)}
+                className={`block rounded-lg [touch-action:none] ${cursorClass}`}
+                style={canvasDisplayStyle}
+                aria-label={`Wand cleanup canvas for ${label}`}
+                title="Edit sprite transparency"
+              />
+              {reticleStyle && !loading && (
+                <span
+                  className="pointer-events-none absolute rounded-full border border-[var(--primary)] shadow-[0_0_0_1px_rgba(0,0,0,0.65),0_0_14px_rgba(255,179,217,0.35)]"
+                  style={reticleStyle}
+                />
+              )}
+            </div>
+          </div>
+
+        </div>
+
+        <div className="flex shrink-0 flex-wrap items-center gap-2">
+          <div className="min-w-0 flex-1 space-y-0.5 text-xs text-[var(--muted-foreground)]">
+            <div>{error ? <span className="text-[var(--destructive)]">{error}</span> : (status ?? "Wand ready")}</div>
+            <div className="font-mono text-[0.6875rem] text-[var(--muted-foreground)]/85">{hoverReadout}</div>
+          </div>
           <button
             type="button"
             onClick={handleUndo}
@@ -299,30 +914,6 @@ export function SpriteWandCleanupEditor({
             <RotateCcw size="0.875rem" />
             Reset
           </button>
-        </div>
-
-        <div
-          className="relative flex min-h-[22rem] items-center justify-center overflow-auto rounded-xl border border-[var(--border)] p-3 max-sm:min-h-[18rem]"
-          style={checkerboardStyle}
-        >
-          {loading && (
-            <div className="absolute inset-0 z-10 flex items-center justify-center bg-[var(--background)]/60">
-              <Loader2 size="1.5rem" className="animate-spin text-[var(--primary)]" />
-            </div>
-          )}
-          <canvas
-            ref={canvasRef}
-            onPointerDown={handleCanvasPointerDown}
-            className="max-h-[62dvh] max-w-full cursor-crosshair rounded-lg shadow-xl shadow-black/30 [touch-action:manipulation]"
-            aria-label={`Wand cleanup canvas for ${label}`}
-            title="Click an unwanted background patch"
-          />
-        </div>
-
-        <div className="flex flex-wrap items-center gap-2">
-          <div className="min-w-0 flex-1 text-xs text-[var(--muted-foreground)]">
-            {error ? <span className="text-[var(--destructive)]">{error}</span> : (status ?? "Wand ready")}
-          </div>
           <button
             type="button"
             onClick={onClose}

--- a/packages/client/src/components/ui/SpriteWandCleanupEditor.tsx
+++ b/packages/client/src/components/ui/SpriteWandCleanupEditor.tsx
@@ -223,6 +223,17 @@ function rgbaToHex(color: Rgba): string {
   return `#${colorComponentToHex(color[0])}${colorComponentToHex(color[1])}${colorComponentToHex(color[2])}`;
 }
 
+function imageDataEquals(left: ImageData | null, right: ImageData | null): boolean {
+  if (!left || !right || left.width !== right.width || left.height !== right.height) return false;
+  if (left.data.length !== right.data.length) return false;
+
+  for (let index = 0; index < left.data.length; index += 1) {
+    if (left.data[index] !== right.data[index]) return false;
+  }
+
+  return true;
+}
+
 function hexToRgba(hex: string): Rgba {
   const normalized = /^#[0-9a-f]{6}$/i.test(hex) ? hex : DEFAULT_BRUSH_COLOR;
   return [
@@ -530,6 +541,7 @@ export function SpriteWandCleanupEditor({
       const selectionTolerance = wandStrong ? Math.min(224, Math.round(tolerance * 1.55)) : tolerance;
       const result: WandResult = removeWandSelection(next, point.x, point.y, selectionTolerance, {
         mode: "connected",
+        neighborMode: wandStrong ? "all" : "cardinal",
         radius: 0,
         edgeGuard: wandStrong ? STRONG_WAND_EDGE_GUARD : WAND_EDGE_GUARD,
         expand: wandStrong ? STRONG_WAND_EXPAND : WAND_EXPAND,
@@ -561,9 +573,9 @@ export function SpriteWandCleanupEditor({
   );
 
   const commitBrushGesture = useCallback(
-    (canvas: HTMLCanvasElement | null) => {
+    (canvas: HTMLCanvasElement | null, pointerId: number) => {
       const gesture = brushGestureRef.current;
-      if (!gesture) return;
+      if (!gesture || gesture.pointerId !== pointerId) return;
 
       brushGestureRef.current = null;
       if (canvas?.hasPointerCapture(gesture.pointerId)) {
@@ -584,9 +596,9 @@ export function SpriteWandCleanupEditor({
     [pushHistory],
   );
 
-  const commitPanGesture = useCallback((canvas: HTMLCanvasElement | null) => {
+  const commitPanGesture = useCallback((canvas: HTMLCanvasElement | null, pointerId: number) => {
     const gesture = panGestureRef.current;
-    if (!gesture) return;
+    if (!gesture || gesture.pointerId !== pointerId) return;
 
     panGestureRef.current = null;
     if (canvas?.hasPointerCapture(gesture.pointerId)) {
@@ -726,13 +738,13 @@ export function SpriteWandCleanupEditor({
   );
 
   const handleCanvasPointerUp = useCallback((event: PointerEvent<HTMLCanvasElement>) => {
-    commitBrushGesture(event.currentTarget);
-    commitPanGesture(event.currentTarget);
+    commitBrushGesture(event.currentTarget, event.pointerId);
+    commitPanGesture(event.currentTarget, event.pointerId);
   }, [commitBrushGesture, commitPanGesture]);
 
   const handleCanvasPointerCancel = useCallback((event: PointerEvent<HTMLCanvasElement>) => {
-    commitBrushGesture(event.currentTarget);
-    commitPanGesture(event.currentTarget);
+    commitBrushGesture(event.currentTarget, event.pointerId);
+    commitPanGesture(event.currentTarget, event.pointerId);
   }, [commitBrushGesture, commitPanGesture]);
 
   const handleUndo = useCallback(() => {
@@ -742,7 +754,7 @@ export function SpriteWandCleanupEditor({
 
       restoreImageData(previous);
       const nextHistory = prev.slice(0, -1);
-      setHasChanges(nextHistory.length > 0);
+      setHasChanges(!imageDataEquals(previous, originalImageRef.current));
       setStatus("Undo applied");
       setError(null);
       return nextHistory;

--- a/packages/client/src/components/ui/SpriteWandCleanupEditor.tsx
+++ b/packages/client/src/components/ui/SpriteWandCleanupEditor.tsx
@@ -63,6 +63,7 @@ interface BrushGesture {
   lastPoint: CanvasPoint;
   changedPixels: number;
   options: BrushStrokeOptions;
+  interrupted: boolean;
 }
 
 interface PanGesture {
@@ -613,6 +614,7 @@ export function SpriteWandCleanupEditor({
       event.preventDefault();
       const canvas = canvasRef.current;
       if (!canvas) return;
+      if (brushGestureRef.current || panGestureRef.current) return;
 
       if (tool === "pan") {
         const stage = stageRef.current;
@@ -684,6 +686,7 @@ export function SpriteWandCleanupEditor({
         lastPoint: point,
         changedPixels,
         options: brushOptions,
+        interrupted: false,
       };
       canvas.setPointerCapture(event.pointerId);
     },
@@ -719,10 +722,31 @@ export function SpriteWandCleanupEditor({
         return;
       }
 
-      const point = updateHoverPoint(event);
       const brushGesture = brushGestureRef.current;
       const current = currentImageRef.current;
-      if (!point || !brushGesture || brushGesture.pointerId !== event.pointerId || !current) return;
+      if (brushGesture && brushGesture.pointerId !== event.pointerId) return;
+
+      const point = updateHoverPoint(event);
+      if (!brushGesture || !current) return;
+
+      if (!point) {
+        brushGesture.interrupted = true;
+        return;
+      }
+
+      if (brushGesture.interrupted) {
+        brushGesture.changedPixels += applyBrushStamp(
+          current,
+          originalImageRef.current,
+          point.x,
+          point.y,
+          brushGesture.options,
+        );
+        brushGesture.lastPoint = point;
+        brushGesture.interrupted = false;
+        putCurrentImage();
+        return;
+      }
 
       brushGesture.changedPixels += applyBrushLine(
         current,
@@ -876,7 +900,7 @@ export function SpriteWandCleanupEditor({
 
   return (
     <Modal open onClose={onClose} title={`Clean ${label}`} width="max-w-6xl">
-      <div className="flex h-[calc(100dvh-7rem)] min-h-0 flex-col gap-3 overflow-hidden sm:h-[min(44rem,calc(90dvh-6rem))]">
+      <div className="flex h-[calc(100dvh-7rem)] min-h-0 flex-col gap-3 overflow-x-hidden overflow-y-auto sm:h-[min(44rem,calc(90dvh-6rem))]">
         <div className="flex shrink-0 flex-wrap items-center gap-2">
           {cleanupToolOptions.map(({ tool: optionTool, label: optionLabel, title, Icon }) => (
             <button
@@ -885,6 +909,7 @@ export function SpriteWandCleanupEditor({
               onClick={() => handleSelectTool(optionTool)}
               disabled={loading || applying}
               className={toolButtonClass(tool === optionTool)}
+              aria-pressed={tool === optionTool}
               title={title}
             >
               <Icon size="0.875rem" />
@@ -1162,6 +1187,7 @@ export function SpriteWandCleanupEditor({
                     ? "bg-[var(--primary)] text-[var(--primary-foreground)]"
                     : "text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]",
                 ].join(" ")}
+                aria-pressed={previewBackground === option.key}
               >
                 {option.label}
               </button>

--- a/packages/client/src/components/ui/SpriteWandCleanupEditor.tsx
+++ b/packages/client/src/components/ui/SpriteWandCleanupEditor.tsx
@@ -110,7 +110,7 @@ interface BrushStrokeBuildInput {
   brushColor: string;
 }
 
-const DEFAULT_TOLERANCE = 36;
+const DEFAULT_WAND_TOLERANCE = 36;
 const DEFAULT_BRUSH_SIZE = 18;
 const DEFAULT_BRUSH_HARDNESS = 100;
 const DEFAULT_BRUSH_OPACITY = 100;
@@ -390,7 +390,7 @@ export function SpriteWandCleanupEditor({
 
   const [tool, setTool] = useState<CleanupTool>("wand");
   const [previewBackground, setPreviewBackground] = useState<PreviewBackground>("dark");
-  const [tolerance, setTolerance] = useState(DEFAULT_TOLERANCE);
+  const [wandTolerance, setWandTolerance] = useState(DEFAULT_WAND_TOLERANCE);
   const [wandStrong, setWandStrong] = useState(DEFAULT_WAND_STRONG);
   const [wandSoftness, setWandSoftness] = useState(DEFAULT_WAND_SOFTNESS);
   const [wandFeather, setWandFeather] = useState(DEFAULT_WAND_FEATHER);
@@ -539,11 +539,9 @@ export function SpriteWandCleanupEditor({
 
       const before = cloneImageData(current);
       const next = cloneImageData(current);
-      const selectionTolerance = wandStrong ? Math.min(224, Math.round(tolerance * 1.55)) : tolerance;
+      const selectionTolerance = wandStrong ? Math.min(224, Math.round(wandTolerance * 1.55)) : wandTolerance;
       const result: WandResult = removeWandSelection(next, point.x, point.y, selectionTolerance, {
-        mode: "connected",
         neighborMode: wandStrong ? "all" : "cardinal",
-        radius: 0,
         edgeGuard: wandStrong ? STRONG_WAND_EDGE_GUARD : WAND_EDGE_GUARD,
         expand: wandStrong ? STRONG_WAND_EXPAND : WAND_EXPAND,
         softness: wandSoftness,
@@ -566,7 +564,7 @@ export function SpriteWandCleanupEditor({
     [
       pushHistory,
       putCurrentImage,
-      tolerance,
+      wandTolerance,
       wandFeather,
       wandSoftness,
       wandStrong,
@@ -795,7 +793,7 @@ export function SpriteWandCleanupEditor({
   }, [restoreImageData]);
 
   const handleResetWandDefaults = useCallback(() => {
-    setTolerance(DEFAULT_TOLERANCE);
+    setWandTolerance(DEFAULT_WAND_TOLERANCE);
     setWandStrong(DEFAULT_WAND_STRONG);
     setWandSoftness(DEFAULT_WAND_SOFTNESS);
     setWandFeather(DEFAULT_WAND_FEATHER);
@@ -979,8 +977,8 @@ export function SpriteWandCleanupEditor({
                   label="Tolerance"
                   min={4}
                   max={128}
-                  value={tolerance}
-                  onChange={setTolerance}
+                  value={wandTolerance}
+                  onChange={setWandTolerance}
                   disabled={loading || applying}
                   className="min-w-[12rem] flex-[1_1_12rem]"
                 />
@@ -1223,7 +1221,7 @@ export function SpriteWandCleanupEditor({
                 onPointerLeave={() => setHoverPoint(null)}
                 className={`block rounded-lg [touch-action:none] ${cursorClass}`}
                 style={canvasDisplayStyle}
-                aria-label={`Wand cleanup canvas for ${label}`}
+                aria-label={`Sprite cleanup canvas for ${label}`}
                 title={pickingBrushColor ? "Pick brush color" : "Edit sprite transparency"}
               />
               {reticleStyle && !loading && (
@@ -1239,7 +1237,7 @@ export function SpriteWandCleanupEditor({
 
         <div className="flex shrink-0 flex-wrap items-center gap-2">
           <div className="min-w-0 flex-1 space-y-0.5 text-xs text-[var(--muted-foreground)]">
-            <div>{error ? <span className="text-[var(--destructive)]">{error}</span> : (status ?? "Wand ready")}</div>
+            <div>{error ? <span className="text-[var(--destructive)]">{error}</span> : (status ?? "Cleanup ready")}</div>
             <div className="font-mono text-[0.6875rem] text-[var(--muted-foreground)]/85">{hoverReadout}</div>
           </div>
           <button

--- a/packages/client/src/lib/sprite-cleanup-tools.ts
+++ b/packages/client/src/lib/sprite-cleanup-tools.ts
@@ -8,7 +8,7 @@ export interface CanvasPoint {
   y: number;
 }
 
-export type BrushMode = "erase" | "restore" | "blur" | "clean";
+export type BrushMode = "erase" | "restore" | "blur" | "clean" | "paint";
 
 type Rgb = [number, number, number];
 export type Rgba = [number, number, number, number];
@@ -31,6 +31,36 @@ export interface TargetCleanBrushOptions {
   feather: number;
 }
 
+export interface PaintBrushOptions {
+  color: Rgba;
+}
+
+export interface BrushStrokeBaseOptions {
+  radius: number;
+}
+
+export interface SoftBrushStrokeOptions extends BrushStrokeBaseOptions {
+  hardness: number;
+  opacity: number;
+}
+
+export type BrushStrokeOptions =
+  | (BrushStrokeBaseOptions & {
+      mode: "clean";
+      clean: TargetCleanBrushOptions;
+    })
+  | (SoftBrushStrokeOptions & {
+      mode: "paint";
+      paint: PaintBrushOptions;
+    })
+  | (SoftBrushStrokeOptions & {
+      mode: "erase" | "restore";
+    })
+  | (BrushStrokeBaseOptions & {
+      mode: "blur";
+      blurStrength: number;
+    });
+
 interface ConnectedSelection {
   selected: Uint8Array;
   target: Rgb;
@@ -52,11 +82,71 @@ function clampUnit(value: number): number {
   return clamp(value, 0, 1);
 }
 
+function brushFalloff(dx: number, dy: number, radius: number, hardnessAmount: number): number {
+  const normalizedDistance = Math.sqrt(dx * dx + dy * dy) / Math.max(1, radius);
+  const hardCore = hardnessAmount >= 0.99 ? 1 : Math.pow(hardnessAmount, 1.35);
+  const featherCurve = 1 + (1 - hardnessAmount) * 1.8;
+  return normalizedDistance <= hardCore
+    ? 1
+    : Math.pow(clampUnit((1 - normalizedDistance) / Math.max(0.001, 1 - hardCore)), featherCurve);
+}
+
 function colorDistanceSquared(data: Uint8ClampedArray, offset: number, target: Rgb): number {
   const red = data[offset] - target[0];
   const green = data[offset + 1] - target[1];
   const blue = data[offset + 2] - target[2];
   return red * red + green * green + blue * blue;
+}
+
+function writeRgbaIfChanged(data: Uint8ClampedArray, offset: number, next: Rgba): boolean {
+  if (
+    data[offset] === next[0] &&
+    data[offset + 1] === next[1] &&
+    data[offset + 2] === next[2] &&
+    data[offset + 3] === next[3]
+  ) {
+    return false;
+  }
+
+  data[offset] = next[0];
+  data[offset + 1] = next[1];
+  data[offset + 2] = next[2];
+  data[offset + 3] = next[3];
+  return true;
+}
+
+function compositeSourceOver(data: Uint8ClampedArray, offset: number, source: Rgba, sourceAlpha: number): Rgba {
+  const alpha = clampUnit(sourceAlpha);
+  const currentAlpha = clampUnit((data[offset + 3] ?? 0) / 255);
+  const retainedAlpha = currentAlpha * (1 - alpha);
+  const nextAlphaAmount = alpha + retainedAlpha;
+
+  if (nextAlphaAmount <= 0) return [0, 0, 0, 0];
+
+  return [
+    Math.round((source[0] * alpha + (data[offset] ?? 0) * retainedAlpha) / nextAlphaAmount),
+    Math.round((source[1] * alpha + (data[offset + 1] ?? 0) * retainedAlpha) / nextAlphaAmount),
+    Math.round((source[2] * alpha + (data[offset + 2] ?? 0) * retainedAlpha) / nextAlphaAmount),
+    Math.round(nextAlphaAmount * 255),
+  ];
+}
+
+function blendPixelToward(data: Uint8ClampedArray, offset: number, target: Rgba, amount: number): Rgba {
+  const mix = clampUnit(amount);
+  const currentAlpha = clampUnit((data[offset + 3] ?? 0) / 255);
+  const targetAlpha = clampUnit(target[3] / 255);
+  const currentAlphaWeight = currentAlpha * (1 - mix);
+  const targetAlphaWeight = targetAlpha * mix;
+  const nextAlphaAmount = currentAlphaWeight + targetAlphaWeight;
+
+  if (nextAlphaAmount <= 0) return [0, 0, 0, 0];
+
+  return [
+    Math.round(((data[offset] ?? 0) * currentAlphaWeight + target[0] * targetAlphaWeight) / nextAlphaAmount),
+    Math.round(((data[offset + 1] ?? 0) * currentAlphaWeight + target[1] * targetAlphaWeight) / nextAlphaAmount),
+    Math.round(((data[offset + 2] ?? 0) * currentAlphaWeight + target[2] * targetAlphaWeight) / nextAlphaAmount),
+    Math.round(nextAlphaAmount * 255),
+  ];
 }
 
 export function cloneImageData(imageData: ImageData): ImageData {
@@ -606,6 +696,64 @@ function softenKeptCutEdge(
   const { edgeDistance } = buildEdgeBand(selected, width, totalPixels, edgeRadius, "all");
   const softened = new Uint8ClampedArray(data);
   const matteTolerance = Math.max(1, tolerance * (1.14 + transitionAmount * 0.82));
+  const decontaminateAmount = clampUnit((softnessAmount * 0.65 + featherAmount * 0.55 - 0.3) / 0.7);
+  const sampleRadius = 2 + edgeRadius;
+  const targetLuma = target[0] * 0.2126 + target[1] * 0.7152 + target[2] * 0.0722;
+
+  const findForegroundColor = (index: number): { color: Rgb; luma: number; weight: number } | null => {
+    const x = index % width;
+    const y = Math.floor(index / width);
+    let redTotal = 0;
+    let greenTotal = 0;
+    let blueTotal = 0;
+    let weightTotal = 0;
+
+    for (let yOffset = -sampleRadius; yOffset <= sampleRadius; yOffset += 1) {
+      const sampleY = y + yOffset;
+      if (sampleY < 0 || sampleY >= height) continue;
+
+      for (let xOffset = -sampleRadius; xOffset <= sampleRadius; xOffset += 1) {
+        if (xOffset === 0 && yOffset === 0) continue;
+
+        const sampleDistance = Math.hypot(xOffset, yOffset);
+        if (sampleDistance > sampleRadius) continue;
+
+        const sampleX = x + xOffset;
+        if (sampleX < 0 || sampleX >= width) continue;
+
+        const sampleIndex = sampleY * width + sampleX;
+        if (selected[sampleIndex]) continue;
+
+        const sampleOffset = sampleIndex * 4;
+        const sampleAlpha = sourceData[sampleOffset + 3] ?? 0;
+        if (sampleAlpha <= 48) continue;
+
+        const targetDistance = Math.sqrt(colorDistanceSquared(sourceData, sampleOffset, target));
+        const matteSeparation = clampUnit((targetDistance - matteTolerance * 0.72) / Math.max(1, matteTolerance * 1.55));
+        if (matteSeparation <= 0) continue;
+
+        const distanceWeight = Math.pow(1 - sampleDistance / Math.max(1, sampleRadius + 0.001), 1.35);
+        const alphaWeight = Math.pow(sampleAlpha / 255, 1.1);
+        const weight = distanceWeight * alphaWeight * Math.pow(matteSeparation, 1.25);
+        if (weight <= 0) continue;
+
+        redTotal += (sourceData[sampleOffset] ?? 0) * weight;
+        greenTotal += (sourceData[sampleOffset + 1] ?? 0) * weight;
+        blueTotal += (sourceData[sampleOffset + 2] ?? 0) * weight;
+        weightTotal += weight;
+      }
+    }
+
+    if (weightTotal <= 0) return null;
+
+    const color: Rgb = [
+      Math.round(redTotal / weightTotal),
+      Math.round(greenTotal / weightTotal),
+      Math.round(blueTotal / weightTotal),
+    ];
+    const luma = color[0] * 0.2126 + color[1] * 0.7152 + color[2] * 0.0722;
+    return { color, luma, weight: weightTotal };
+  };
 
   for (let index = 0; index < totalPixels; index += 1) {
     const distanceFromCut = edgeDistance[index] ?? 0;
@@ -620,6 +768,39 @@ function softenKeptCutEdge(
     const targetDistance = Math.sqrt(colorDistanceSquared(sourceData, offset, target));
     const matteSimilarity = targetDistance <= matteTolerance ? 1 - targetDistance / matteTolerance : 0;
     const alphaVulnerability = clampUnit((248 - originalAlpha) / (218 - transitionAmount * 82));
+
+    if (decontaminateAmount > 0 && matteSimilarity > 0.05) {
+      const foreground = findForegroundColor(index);
+      if (foreground) {
+        const currentRed = sourceData[offset] ?? 0;
+        const currentGreen = sourceData[offset + 1] ?? 0;
+        const currentBlue = sourceData[offset + 2] ?? 0;
+        const currentLuma = currentRed * 0.2126 + currentGreen * 0.7152 + currentBlue * 0.0722;
+        const lightResidueBias =
+          targetLuma > foreground.luma
+            ? clampUnit((currentLuma - foreground.luma - 4) / Math.max(28, targetLuma - foreground.luma))
+            : 0;
+        const darkResidueBias =
+          targetLuma < foreground.luma
+            ? clampUnit((foreground.luma - currentLuma - 4) / Math.max(28, foreground.luma - targetLuma))
+            : 0;
+        const residueBias = Math.max(matteSimilarity, lightResidueBias, darkResidueBias);
+        const confidence = clampUnit(foreground.weight / (1.4 + sampleRadius * 0.42));
+        const colorPull = clampUnit(
+          decontaminateAmount *
+            Math.pow(edgePosition, 0.88) *
+            residueBias *
+            (0.42 + alphaVulnerability * 0.28 + confidence * 0.3),
+        );
+
+        if (colorPull > 0) {
+          softened[offset] = Math.round(currentRed * (1 - colorPull) + foreground.color[0] * colorPull);
+          softened[offset + 1] = Math.round(currentGreen * (1 - colorPull) + foreground.color[1] * colorPull);
+          softened[offset + 2] = Math.round(currentBlue * (1 - colorPull) + foreground.color[2] * colorPull);
+        }
+      }
+    }
+
     const softenStrength =
       transitionAmount *
       Math.pow(edgePosition, 0.92 + (1 - featherAmount) * 0.28) *
@@ -677,9 +858,22 @@ function softenKeptCutEdge(
     if (distanceFromCut === 0) continue;
 
     const offset = index * 4;
+    const nextRed = blurred[offset] ?? 0;
+    const nextGreen = blurred[offset + 1] ?? 0;
+    const nextBlue = blurred[offset + 2] ?? 0;
     const nextAlpha = blurred[offset + 3] ?? 0;
-    if (nextAlpha === data[offset + 3]) continue;
+    if (
+      nextRed === data[offset] &&
+      nextGreen === data[offset + 1] &&
+      nextBlue === data[offset + 2] &&
+      nextAlpha === data[offset + 3]
+    ) {
+      continue;
+    }
 
+    data[offset] = nextRed;
+    data[offset + 1] = nextGreen;
+    data[offset + 2] = nextBlue;
     data[offset + 3] = nextAlpha;
     changed += 1;
   }
@@ -1236,25 +1430,27 @@ export function applyBrushStamp(
   originalImage: ImageData | null,
   centerX: number,
   centerY: number,
-  radius: number,
-  mode: BrushMode,
-  eraserHardness: number,
-  eraserOpacity: number,
-  blurStrength: number,
-  targetCleanOptions?: TargetCleanBrushOptions,
+  options: BrushStrokeOptions,
 ): number {
   const { data, width, height } = imageData;
+  const { mode, radius } = options;
   const restoreSource = originalImage?.data ?? null;
   const blurSource = mode === "blur" ? new Uint8ClampedArray(data) : null;
   const cleanSource = mode === "clean" ? new Uint8ClampedArray(data) : null;
-  const eraserHardnessAmount = clampUnit(eraserHardness / 100);
-  const eraserOpacityAmount = clampUnit(eraserOpacity / 100);
-  const blurAmount = clampUnit(blurStrength / 100);
-  const cleanTarget = targetCleanOptions?.target ?? null;
+  const cleanOptions = options.mode === "clean" ? options.clean : null;
+  const paintOptions = options.mode === "paint" ? options.paint : null;
+  const cleanTarget = cleanOptions?.target ?? null;
   const cleanTargetRgb: Rgb | null = cleanTarget ? [cleanTarget[0], cleanTarget[1], cleanTarget[2]] : null;
-  const cleanTolerance = Math.max(1, targetCleanOptions?.tolerance ?? 1);
-  const cleanEdgeGuardAmount = clampUnit((targetCleanOptions?.edgeGuard ?? 0) / 100);
-  const cleanFeatherAmount = clampUnit((targetCleanOptions?.feather ?? 0) / 100);
+  const cleanTolerance = Math.max(1, cleanOptions?.tolerance ?? 1);
+  const cleanEdgeGuardAmount = clampUnit((cleanOptions?.edgeGuard ?? 0) / 100);
+  const cleanFeatherAmount = clampUnit((cleanOptions?.feather ?? 0) / 100);
+  const paintColor = paintOptions?.color ?? null;
+  const paintColorAlpha = clampUnit((paintColor?.[3] ?? 0) / 255);
+  const softBrushOptions =
+    options.mode === "paint" || options.mode === "erase" || options.mode === "restore" ? options : null;
+  const brushHardnessAmount = softBrushOptions ? clampUnit(softBrushOptions.hardness / 100) : 0;
+  const brushOpacityAmount = softBrushOptions ? clampUnit(softBrushOptions.opacity / 100) : 0;
+  const blurAmount = options.mode === "blur" ? clampUnit(options.blurStrength / 100) : 0;
   const minX = Math.max(0, Math.floor(centerX - radius));
   const maxX = Math.min(width - 1, Math.ceil(centerX + radius));
   const minY = Math.max(0, Math.floor(centerY - radius));
@@ -1357,18 +1553,25 @@ export function applyBrushStamp(
         continue;
       }
 
+      if (mode === "paint") {
+        if (!paintColor || brushOpacityAmount <= 0 || paintColorAlpha <= 0) continue;
+
+        const paintAmount = brushFalloff(dx, dy, radius, brushHardnessAmount);
+        const sourceAlpha = paintAmount * brushOpacityAmount * paintColorAlpha;
+        if (sourceAlpha <= 0.001) continue;
+
+        if (writeRgbaIfChanged(data, offset, compositeSourceOver(data, offset, paintColor, sourceAlpha))) {
+          changed += 1;
+        }
+        continue;
+      }
+
       if (mode === "erase") {
         const originalAlpha = data[offset + 3] ?? 0;
         if (originalAlpha <= 0) continue;
 
-        const normalizedDistance = Math.sqrt(dx * dx + dy * dy) / Math.max(1, radius);
-        const hardCore = eraserHardnessAmount >= 0.99 ? 1 : Math.pow(eraserHardnessAmount, 1.35);
-        const featherCurve = 1 + (1 - eraserHardnessAmount) * 1.8;
-        const eraseAmount =
-          normalizedDistance <= hardCore
-            ? 1
-            : Math.pow(clampUnit((1 - normalizedDistance) / Math.max(0.001, 1 - hardCore)), featherCurve);
-        const nextAlpha = Math.round(originalAlpha * (1 - eraseAmount * eraserOpacityAmount));
+        const eraseAmount = brushFalloff(dx, dy, radius, brushHardnessAmount);
+        const nextAlpha = Math.round(originalAlpha * (1 - eraseAmount * brushOpacityAmount));
         if (nextAlpha === originalAlpha) continue;
 
         data[offset + 3] = nextAlpha;
@@ -1376,19 +1579,30 @@ export function applyBrushStamp(
         continue;
       }
 
-      if (!restoreSource) continue;
-      const red = restoreSource[offset] ?? 0;
-      const green = restoreSource[offset + 1] ?? 0;
-      const blue = restoreSource[offset + 2] ?? 0;
-      const alpha = restoreSource[offset + 3] ?? 0;
-      if (data[offset] === red && data[offset + 1] === green && data[offset + 2] === blue && data[offset + 3] === alpha) {
-        continue;
+      if (mode === "restore") {
+        if (!restoreSource) continue;
+
+        const restoreAmount = brushFalloff(dx, dy, radius, brushHardnessAmount) * brushOpacityAmount;
+        if (restoreAmount <= 0) continue;
+
+        const restoredColor: Rgba = [
+          restoreSource[offset] ?? 0,
+          restoreSource[offset + 1] ?? 0,
+          restoreSource[offset + 2] ?? 0,
+          restoreSource[offset + 3] ?? 0,
+        ];
+
+        if (restoreAmount < 0.999) {
+          if (writeRgbaIfChanged(data, offset, blendPixelToward(data, offset, restoredColor, restoreAmount))) {
+            changed += 1;
+          }
+          continue;
+        }
+
+        if (writeRgbaIfChanged(data, offset, restoredColor)) {
+          changed += 1;
+        }
       }
-      data[offset] = red;
-      data[offset + 1] = green;
-      data[offset + 2] = blue;
-      data[offset + 3] = alpha;
-      changed += 1;
     }
   }
 
@@ -1400,15 +1614,10 @@ export function applyBrushLine(
   originalImage: ImageData | null,
   from: CanvasPoint,
   to: CanvasPoint,
-  radius: number,
-  mode: BrushMode,
-  eraserHardness: number,
-  eraserOpacity: number,
-  blurStrength: number,
-  targetCleanOptions?: TargetCleanBrushOptions,
+  options: BrushStrokeOptions,
 ): number {
   const distance = Math.hypot(to.x - from.x, to.y - from.y);
-  const steps = Math.max(1, Math.ceil(distance / Math.max(1, radius * 0.45)));
+  const steps = Math.max(1, Math.ceil(distance / Math.max(1, options.radius * 0.45)));
   let changed = 0;
 
   for (let step = 1; step <= steps; step += 1) {
@@ -1418,12 +1627,7 @@ export function applyBrushLine(
       originalImage,
       from.x + (to.x - from.x) * amount,
       from.y + (to.y - from.y) * amount,
-      radius,
-      mode,
-      eraserHardness,
-      eraserOpacity,
-      blurStrength,
-      targetCleanOptions,
+      options,
     );
   }
 

--- a/packages/client/src/lib/sprite-cleanup-tools.ts
+++ b/packages/client/src/lib/sprite-cleanup-tools.ts
@@ -1,0 +1,684 @@
+export interface WandResult {
+  removed: number;
+  target: Rgba;
+}
+
+export interface CanvasPoint {
+  x: number;
+  y: number;
+}
+
+export type BrushMode = "erase" | "restore" | "blur";
+
+type Rgb = [number, number, number];
+export type Rgba = [number, number, number, number];
+export type NeighborMode = "cardinal" | "all";
+
+interface ConnectedSelection {
+  selected: Uint8Array;
+  target: Rgb;
+  targetAlpha: number;
+  totalPixels: number;
+}
+
+interface EdgeBand {
+  edgeDistance: Uint8Array;
+  edgeNormalX: Int8Array;
+  edgeNormalY: Int8Array;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, Number.isFinite(value) ? value : min));
+}
+
+function clampUnit(value: number): number {
+  return clamp(value, 0, 1);
+}
+
+function colorDistanceSquared(data: Uint8ClampedArray, offset: number, target: Rgb): number {
+  const red = data[offset] - target[0];
+  const green = data[offset + 1] - target[1];
+  const blue = data[offset + 2] - target[2];
+  return red * red + green * green + blue * blue;
+}
+
+export function cloneImageData(imageData: ImageData): ImageData {
+  return new ImageData(new Uint8ClampedArray(imageData.data), imageData.width, imageData.height);
+}
+
+export function rgbaAt(imageData: ImageData, point: CanvasPoint): Rgba {
+  const offset = (point.y * imageData.width + point.x) * 4;
+  return [
+    imageData.data[offset] ?? 0,
+    imageData.data[offset + 1] ?? 0,
+    imageData.data[offset + 2] ?? 0,
+    imageData.data[offset + 3] ?? 0,
+  ];
+}
+
+export function formatRgba(color: Rgba): string {
+  return `rgba(${color[0]}, ${color[1]}, ${color[2]}, ${color[3]})`;
+}
+
+function readPixel(imageData: ImageData, index: number): Rgba {
+  const offset = index * 4;
+  return [
+    imageData.data[offset] ?? 0,
+    imageData.data[offset + 1] ?? 0,
+    imageData.data[offset + 2] ?? 0,
+    imageData.data[offset + 3] ?? 0,
+  ];
+}
+
+function getEmptyWandResult(imageData: ImageData, startX: number, startY: number): WandResult {
+  const target = readPixel(imageData, startY * imageData.width + startX);
+  return { removed: 0, target };
+}
+
+function visitNeighbors(
+  index: number,
+  width: number,
+  totalPixels: number,
+  mode: NeighborMode,
+  visit: (neighbor: number) => void,
+) {
+  const x = index % width;
+  const hasLeft = x > 0;
+  const hasRight = x < width - 1;
+  const hasTop = index >= width;
+  const hasBottom = index < totalPixels - width;
+
+  if (hasLeft) visit(index - 1);
+  if (hasRight) visit(index + 1);
+  if (hasTop) {
+    visit(index - width);
+    if (mode === "all") {
+      if (hasLeft) visit(index - width - 1);
+      if (hasRight) visit(index - width + 1);
+    }
+  }
+  if (hasBottom) {
+    visit(index + width);
+    if (mode === "all") {
+      if (hasLeft) visit(index + width - 1);
+      if (hasRight) visit(index + width + 1);
+    }
+  }
+}
+
+function selectConnectedRegion(
+  imageData: ImageData,
+  startX: number,
+  startY: number,
+  tolerance: number,
+  mode: NeighborMode,
+): ConnectedSelection | null {
+  const { data, width, height } = imageData;
+  const startIndex = startY * width + startX;
+  const [red, green, blue, targetAlpha] = readPixel(imageData, startIndex);
+
+  if (targetAlpha <= 8) return null;
+
+  const target: Rgb = [red, green, blue];
+  const totalPixels = width * height;
+  const threshold = tolerance * tolerance;
+  const selected = new Uint8Array(totalPixels);
+  const visited = new Uint8Array(totalPixels);
+  const stack = new Int32Array(totalPixels);
+  let stackLength = 0;
+
+  const pushPixel = (index: number) => {
+    if (visited[index]) return;
+
+    visited[index] = 1;
+    const offset = index * 4;
+    if (data[offset + 3] <= 8 || colorDistanceSquared(data, offset, target) > threshold) return;
+
+    selected[index] = 1;
+    stack[stackLength++] = index;
+  };
+
+  pushPixel(startIndex);
+
+  while (stackLength > 0) {
+    visitNeighbors(stack[--stackLength], width, totalPixels, mode, pushPixel);
+  }
+
+  return {
+    selected,
+    target,
+    targetAlpha,
+    totalPixels,
+  };
+}
+
+function clearSelection(imageData: ImageData, selected: Uint8Array): number {
+  const { data } = imageData;
+  let removed = 0;
+
+  for (let index = 0; index < selected.length; index += 1) {
+    if (!selected[index]) continue;
+
+    const offset = index * 4;
+    const originalAlpha = data[offset + 3] ?? 0;
+    data[offset + 3] = 0;
+    if (originalAlpha !== 0) removed += 1;
+  }
+
+  return removed;
+}
+
+function buildEdgeBand(
+  selected: Uint8Array,
+  width: number,
+  totalPixels: number,
+  radius: number,
+  mode: NeighborMode,
+): EdgeBand {
+  const edgeDistance = new Uint8Array(totalPixels);
+  const edgeNormalX = new Int8Array(totalPixels);
+  const edgeNormalY = new Int8Array(totalPixels);
+  const edgeQueue = new Int32Array(totalPixels);
+  let queueLength = 0;
+
+  const pushEdgePixel = (index: number, nextDistance: number, normalX: number, normalY: number) => {
+    if (selected[index] || edgeDistance[index] !== 0 || nextDistance > radius) return;
+
+    edgeDistance[index] = nextDistance;
+    edgeNormalX[index] = Math.sign(normalX);
+    edgeNormalY[index] = Math.sign(normalY);
+    edgeQueue[queueLength++] = index;
+  };
+
+  for (let index = 0; index < totalPixels; index += 1) {
+    if (!selected[index]) continue;
+
+    const selectedX = index % width;
+    const selectedY = Math.floor(index / width);
+    visitNeighbors(index, width, totalPixels, mode, (neighbor) => {
+      const neighborX = neighbor % width;
+      const neighborY = Math.floor(neighbor / width);
+      pushEdgePixel(neighbor, 1, neighborX - selectedX, neighborY - selectedY);
+    });
+  }
+
+  for (let queueIndex = 0; queueIndex < queueLength; queueIndex += 1) {
+    const index = edgeQueue[queueIndex];
+    const nextDistance = edgeDistance[index] + 1;
+    if (nextDistance > radius) continue;
+
+    const normalX = edgeNormalX[index] ?? 0;
+    const normalY = edgeNormalY[index] ?? 0;
+    visitNeighbors(index, width, totalPixels, mode, (neighbor) => pushEdgePixel(neighbor, nextDistance, normalX, normalY));
+  }
+
+  return { edgeDistance, edgeNormalX, edgeNormalY };
+}
+
+export function removeConnectedColor(
+  imageData: ImageData,
+  startX: number,
+  startY: number,
+  tolerance: number,
+  mode: NeighborMode = "cardinal",
+): WandResult {
+  const selection = selectConnectedRegion(imageData, startX, startY, tolerance, mode);
+  if (!selection) return getEmptyWandResult(imageData, startX, startY);
+
+  return {
+    removed: clearSelection(imageData, selection.selected),
+    target: [selection.target[0], selection.target[1], selection.target[2], selection.targetAlpha],
+  };
+}
+
+export function removeConnectedColorSoftEdge(
+  imageData: ImageData,
+  startX: number,
+  startY: number,
+  tolerance: number,
+  featherStrength: number,
+  blendStrength: number,
+): WandResult {
+  const { data, width, height } = imageData;
+  const featherAmount = clampUnit(featherStrength / 100);
+  const blendAmount = clampUnit(blendStrength / 100);
+  const softTolerance = Math.min(160, Math.round(tolerance * (1.1 + featherAmount * 0.22)));
+  const selection = selectConnectedRegion(imageData, startX, startY, softTolerance, "all");
+  if (!selection) return getEmptyWandResult(imageData, startX, startY);
+
+  const edgeRadius = featherAmount <= 0 ? 0 : 1 + Math.round(featherAmount * 2.8);
+  const { selected, target, targetAlpha, totalPixels } = selection;
+  const { edgeDistance } = buildEdgeBand(selected, width, totalPixels, edgeRadius, "all");
+  let removed = clearSelection(imageData, selected);
+
+  if (edgeRadius > 0 && blendAmount > 0) {
+    const edgeSource = new Uint8ClampedArray(data);
+    const blurRadius = 1 + Math.round(featherAmount * 1.4);
+    const blendBase = blendAmount * (0.32 + featherAmount * 0.48);
+
+    for (let index = 0; index < totalPixels; index += 1) {
+      if (selected[index]) continue;
+
+      const distanceFromCut = edgeDistance[index] ?? 0;
+      if (distanceFromCut === 0) continue;
+
+      const offset = index * 4;
+      const originalAlpha = edgeSource[offset + 3] ?? 0;
+      if (originalAlpha <= 0) continue;
+
+      const x = index % width;
+      const y = Math.floor(index / width);
+      let alphaTotal = 0;
+      let weightTotal = 0;
+
+      for (
+        let sampleY = Math.max(0, y - blurRadius);
+        sampleY <= Math.min(height - 1, y + blurRadius);
+        sampleY += 1
+      ) {
+        for (
+          let sampleX = Math.max(0, x - blurRadius);
+          sampleX <= Math.min(width - 1, x + blurRadius);
+          sampleX += 1
+        ) {
+          const sampleDistance = Math.hypot(sampleX - x, sampleY - y);
+          if (sampleDistance > blurRadius) continue;
+
+          const sampleIndex = sampleY * width + sampleX;
+          const sampleAlpha = selected[sampleIndex] ? 0 : (edgeSource[sampleIndex * 4 + 3] ?? 0);
+          const weight = sampleX === x && sampleY === y ? 1.6 : 1 / Math.max(1, sampleDistance);
+
+          alphaTotal += sampleAlpha * weight;
+          weightTotal += weight;
+        }
+      }
+
+      if (weightTotal <= 0) continue;
+
+      const averagedAlpha = Math.round(alphaTotal / weightTotal);
+      if (averagedAlpha >= originalAlpha) continue;
+
+      const edgePosition = clampUnit((edgeRadius - distanceFromCut + 1) / Math.max(1, edgeRadius));
+      const blendMix = clampUnit(blendBase * Math.pow(edgePosition, 0.8));
+      const nextAlpha = Math.round(originalAlpha * (1 - blendMix) + averagedAlpha * blendMix);
+      if (nextAlpha === originalAlpha) continue;
+
+      data[offset + 3] = nextAlpha;
+      removed += 1;
+    }
+  }
+
+  return {
+    removed,
+    target: [target[0], target[1], target[2], targetAlpha],
+  };
+}
+
+export function removeConnectedColorDecontaminate(
+  imageData: ImageData,
+  startX: number,
+  startY: number,
+  tolerance: number,
+  decontaminateStrength: number,
+  featherStrength: number,
+): WandResult {
+  const { data, width, height } = imageData;
+  const decontaminateAmount = clampUnit(decontaminateStrength / 100);
+  const featherAmount = clampUnit(featherStrength / 100);
+  const edgeStrength = Math.pow(decontaminateAmount, 0.72);
+  const selectionTolerance = Math.min(176, Math.round(tolerance * 1.24));
+  const selection = selectConnectedRegion(imageData, startX, startY, selectionTolerance, "all");
+  if (!selection) return getEmptyWandResult(imageData, startX, startY);
+
+  const { selected, target, targetAlpha, totalPixels } = selection;
+  const edgeRadius = 1 + Math.round(featherAmount * 7);
+  const matteTolerance = Math.min(244, Math.round(tolerance * (1.55 + edgeStrength * 0.7 + featherAmount * 0.25)));
+  const foregroundSearchRadius = 3 + edgeRadius + Math.round(edgeStrength * 2);
+  const sourceData = new Uint8ClampedArray(data);
+  const { edgeDistance, edgeNormalX, edgeNormalY } = buildEdgeBand(selected, width, totalPixels, edgeRadius, "all");
+  let removed = clearSelection(imageData, selected);
+  const findForegroundNeighborColor = (index: number): Rgb | null => {
+    const x = index % width;
+    const y = Math.floor(index / width);
+    const normalX = edgeNormalX[index] ?? 0;
+    const normalY = edgeNormalY[index] ?? 0;
+    const currentDistance = edgeDistance[index] ?? 0;
+
+    const sample = (directional: boolean): Rgb | null => {
+      let redTotal = 0;
+      let greenTotal = 0;
+      let blueTotal = 0;
+      let weightTotal = 0;
+
+      for (let yOffset = -foregroundSearchRadius; yOffset <= foregroundSearchRadius; yOffset += 1) {
+        const sampleY = y + yOffset;
+        if (sampleY < 0 || sampleY >= height) continue;
+
+        for (let xOffset = -foregroundSearchRadius; xOffset <= foregroundSearchRadius; xOffset += 1) {
+          if (xOffset === 0 && yOffset === 0) continue;
+
+          const sampleDistance = Math.hypot(xOffset, yOffset);
+          if (sampleDistance > foregroundSearchRadius) continue;
+
+          const dot = xOffset * normalX + yOffset * normalY;
+          if (directional && (normalX !== 0 || normalY !== 0) && dot <= 0) continue;
+
+          const sampleX = x + xOffset;
+          if (sampleX < 0 || sampleX >= width) continue;
+
+          const sampleIndex = sampleY * width + sampleX;
+          if (selected[sampleIndex]) continue;
+
+          const sampleEdgeDistance = edgeDistance[sampleIndex] ?? 0;
+          if (sampleEdgeDistance > 0 && sampleEdgeDistance <= currentDistance) continue;
+
+          const sampleOffset = sampleIndex * 4;
+          const alpha = sourceData[sampleOffset + 3] ?? 0;
+          if (alpha <= 40) continue;
+
+          const targetDistance = Math.sqrt(colorDistanceSquared(sourceData, sampleOffset, target));
+          if (alpha < 220 && targetDistance < selectionTolerance * 0.8) continue;
+
+          const directionWeight = directional
+            ? 1 + clampUnit(dot / Math.max(1, foregroundSearchRadius)) * 1.6
+            : 1;
+          const alphaWeight = Math.pow(alpha / 255, 2.2);
+          const colorSeparationWeight = 0.7 + clampUnit(targetDistance / Math.max(1, matteTolerance)) * 0.6;
+          const weight = (alphaWeight * colorSeparationWeight * directionWeight) / Math.max(1, sampleDistance);
+          redTotal += (sourceData[sampleOffset] ?? 0) * weight;
+          greenTotal += (sourceData[sampleOffset + 1] ?? 0) * weight;
+          blueTotal += (sourceData[sampleOffset + 2] ?? 0) * weight;
+          weightTotal += weight;
+        }
+      }
+
+      if (weightTotal <= 0) return null;
+      return [
+        Math.round(redTotal / weightTotal),
+        Math.round(greenTotal / weightTotal),
+        Math.round(blueTotal / weightTotal),
+      ];
+    };
+
+    return sample(true) ?? sample(false);
+  };
+
+  for (let index = 0; index < totalPixels; index += 1) {
+    if (selected[index]) continue;
+
+    const offset = index * 4;
+    const originalAlpha = sourceData[offset + 3] ?? 0;
+
+    const distanceFromCut = edgeDistance[index];
+    if (distanceFromCut === 0 || decontaminateAmount <= 0 || originalAlpha <= 8) continue;
+
+    const targetDistance = Math.sqrt(colorDistanceSquared(sourceData, offset, target));
+    const matteSimilarity = targetDistance <= matteTolerance ? 1 - targetDistance / matteTolerance : 0;
+    const foregroundColor = findForegroundNeighborColor(index);
+    const originalRed = sourceData[offset] ?? 0;
+    const originalGreen = sourceData[offset + 1] ?? 0;
+    const originalBlue = sourceData[offset + 2] ?? 0;
+    const foregroundDistance = foregroundColor
+      ? Math.hypot(originalRed - foregroundColor[0], originalGreen - foregroundColor[1], originalBlue - foregroundColor[2])
+      : 0;
+    const foregroundMismatch = foregroundColor
+      ? clampUnit((foregroundDistance - (14 - featherAmount * 8)) / (150 - featherAmount * 45))
+      : 0;
+    const alphaVulnerability = clampUnit((245 - originalAlpha) / (210 - featherAmount * 70));
+    const edgePosition = clampUnit((edgeRadius - distanceFromCut + 1) / Math.max(1, edgeRadius));
+    const proximity = Math.pow(edgePosition, 1.75 - featherAmount * 1.1);
+    const cleanupWeight =
+      Math.max(
+        matteSimilarity * (0.88 + featherAmount * 0.18),
+        foregroundMismatch,
+        alphaVulnerability * (0.34 + featherAmount * 0.32),
+      ) *
+      proximity *
+      edgeStrength *
+      (0.75 + featherAmount * 0.45);
+
+    if (cleanupWeight <= 0.01) continue;
+
+    let nextRed = originalRed;
+    let nextGreen = originalGreen;
+    let nextBlue = originalBlue;
+
+    if (foregroundColor) {
+      const colorPull = clampUnit(cleanupWeight * (0.86 + edgeStrength * 0.32 + featherAmount * 0.28));
+      nextRed = Math.round(originalRed * (1 - colorPull) + foregroundColor[0] * colorPull);
+      nextGreen = Math.round(originalGreen * (1 - colorPull) + foregroundColor[1] * colorPull);
+      nextBlue = Math.round(originalBlue * (1 - colorPull) + foregroundColor[2] * colorPull);
+    }
+
+    const alphaReduction =
+      cleanupWeight *
+      (0.06 + matteSimilarity * (0.15 + featherAmount * 0.2) + alphaVulnerability * (0.12 + featherAmount * 0.22));
+    const nextAlpha = Math.min(
+      originalAlpha,
+      Math.round(originalAlpha * clamp(1 - alphaReduction, 0.62 - featherAmount * 0.24, 1)),
+    );
+
+    if (
+      nextRed === originalRed &&
+      nextGreen === originalGreen &&
+      nextBlue === originalBlue &&
+      nextAlpha === originalAlpha
+    ) {
+      continue;
+    }
+
+    data[offset] = nextRed;
+    data[offset + 1] = nextGreen;
+    data[offset + 2] = nextBlue;
+    data[offset + 3] = nextAlpha;
+    removed += 1;
+  }
+
+  if (featherAmount > 0 && decontaminateAmount > 0) {
+    const smoothedSource = new Uint8ClampedArray(data);
+    const blurRadius = 1 + Math.round(featherAmount * 2);
+    const blurMixBase = featherAmount * (0.18 + edgeStrength * 0.56);
+
+    for (let index = 0; index < totalPixels; index += 1) {
+      if (selected[index]) continue;
+
+      const distanceFromCut = edgeDistance[index];
+      if (distanceFromCut === 0) continue;
+
+      const offset = index * 4;
+      const originalAlpha = smoothedSource[offset + 3] ?? 0;
+      if (originalAlpha <= 8) continue;
+
+      const x = index % width;
+      const y = Math.floor(index / width);
+      let alphaTotal = 0;
+      let weightTotal = 0;
+      let minAlpha = originalAlpha;
+      let maxAlpha = originalAlpha;
+      let touchesCut = false;
+
+      for (let yOffset = -blurRadius; yOffset <= blurRadius; yOffset += 1) {
+        const sampleY = y + yOffset;
+        if (sampleY < 0 || sampleY >= height) continue;
+
+        for (let xOffset = -blurRadius; xOffset <= blurRadius; xOffset += 1) {
+          const sampleDistance = Math.hypot(xOffset, yOffset);
+          if (sampleDistance > blurRadius) continue;
+
+          const sampleX = x + xOffset;
+          if (sampleX < 0 || sampleX >= width) continue;
+
+          const sampleIndex = sampleY * width + sampleX;
+          const sampleAlpha = selected[sampleIndex] ? 0 : (smoothedSource[sampleIndex * 4 + 3] ?? 0);
+          const weight = xOffset === 0 && yOffset === 0 ? 1.75 : 1 / Math.max(1, sampleDistance);
+
+          if (selected[sampleIndex]) touchesCut = true;
+          minAlpha = Math.min(minAlpha, sampleAlpha);
+          maxAlpha = Math.max(maxAlpha, sampleAlpha);
+          alphaTotal += sampleAlpha * weight;
+          weightTotal += weight;
+        }
+      }
+
+      if ((!touchesCut && maxAlpha - minAlpha < 18) || weightTotal <= 0) continue;
+
+      const averagedAlpha = Math.round(alphaTotal / weightTotal);
+      if (averagedAlpha >= originalAlpha) continue;
+
+      const targetDistance = Math.sqrt(colorDistanceSquared(smoothedSource, offset, target));
+      const matteAttraction =
+        targetDistance <= matteTolerance ? 0.35 + (1 - targetDistance / matteTolerance) * 0.65 : 0.35;
+      const edgePosition = clampUnit((edgeRadius - distanceFromCut + 1) / Math.max(1, edgeRadius));
+      const proximity = Math.pow(edgePosition, 0.55 + (1 - featherAmount) * 0.8);
+      const blurMix = clampUnit(blurMixBase * matteAttraction * proximity);
+      const nextAlpha = Math.min(originalAlpha, Math.round(originalAlpha * (1 - blurMix) + averagedAlpha * blurMix));
+
+      if (nextAlpha === originalAlpha) continue;
+
+      data[offset + 3] = nextAlpha;
+      removed += 1;
+    }
+  }
+
+  return {
+    removed,
+    target: [target[0], target[1], target[2], targetAlpha],
+  };
+}
+
+export function applyBrushStamp(
+  imageData: ImageData,
+  originalImage: ImageData | null,
+  centerX: number,
+  centerY: number,
+  radius: number,
+  mode: BrushMode,
+  eraserHardness: number,
+  blurStrength: number,
+): number {
+  const { data, width, height } = imageData;
+  const restoreSource = originalImage?.data ?? null;
+  const blurSource = mode === "blur" ? new Uint8ClampedArray(data) : null;
+  const eraserHardnessAmount = clampUnit(eraserHardness / 100);
+  const blurAmount = clampUnit(blurStrength / 100);
+  const minX = Math.max(0, Math.floor(centerX - radius));
+  const maxX = Math.min(width - 1, Math.ceil(centerX + radius));
+  const minY = Math.max(0, Math.floor(centerY - radius));
+  const maxY = Math.min(height - 1, Math.ceil(centerY + radius));
+  const radiusSquared = radius * radius;
+  let changed = 0;
+
+  for (let y = minY; y <= maxY; y += 1) {
+    for (let x = minX; x <= maxX; x += 1) {
+      const dx = x - centerX;
+      const dy = y - centerY;
+      if (dx * dx + dy * dy > radiusSquared) continue;
+
+      const offset = (y * width + x) * 4;
+      if (mode === "blur") {
+        if (!blurSource || blurAmount <= 0) continue;
+
+        const originalAlpha = blurSource[offset + 3] ?? 0;
+        if (originalAlpha <= 8) continue;
+
+        let minAlpha = originalAlpha;
+        let maxAlpha = originalAlpha;
+        let alphaTotal = 0;
+        let weightTotal = 0;
+
+        for (let sampleY = Math.max(0, y - 1); sampleY <= Math.min(height - 1, y + 1); sampleY += 1) {
+          for (let sampleX = Math.max(0, x - 1); sampleX <= Math.min(width - 1, x + 1); sampleX += 1) {
+            const sampleOffset = (sampleY * width + sampleX) * 4;
+            const sampleAlpha = blurSource[sampleOffset + 3] ?? 0;
+            const distance = Math.max(1, Math.hypot(sampleX - x, sampleY - y));
+            const weight = sampleX === x && sampleY === y ? 1.75 : 1 / distance;
+
+            minAlpha = Math.min(minAlpha, sampleAlpha);
+            maxAlpha = Math.max(maxAlpha, sampleAlpha);
+            alphaTotal += sampleAlpha * weight;
+            weightTotal += weight;
+          }
+        }
+
+        if (maxAlpha - minAlpha < 24 || weightTotal <= 0) continue;
+
+        const averagedAlpha = Math.round(alphaTotal / weightTotal);
+        const nextAlpha = Math.min(
+          originalAlpha,
+          Math.round(originalAlpha * (1 - blurAmount) + averagedAlpha * blurAmount),
+        );
+        if (nextAlpha === originalAlpha) continue;
+
+        data[offset + 3] = nextAlpha;
+        changed += 1;
+        continue;
+      }
+
+      if (mode === "erase") {
+        const originalAlpha = data[offset + 3] ?? 0;
+        if (originalAlpha <= 0) continue;
+
+        const normalizedDistance = Math.sqrt(dx * dx + dy * dy) / Math.max(1, radius);
+        const hardCore = eraserHardnessAmount >= 0.99 ? 1 : Math.pow(eraserHardnessAmount, 1.35);
+        const featherCurve = 1 + (1 - eraserHardnessAmount) * 1.8;
+        const eraseAmount =
+          normalizedDistance <= hardCore
+            ? 1
+            : Math.pow(clampUnit((1 - normalizedDistance) / Math.max(0.001, 1 - hardCore)), featherCurve);
+        const nextAlpha = Math.round(originalAlpha * (1 - eraseAmount));
+        if (nextAlpha === originalAlpha) continue;
+
+        data[offset + 3] = nextAlpha;
+        changed += 1;
+        continue;
+      }
+
+      if (!restoreSource) continue;
+      const red = restoreSource[offset] ?? 0;
+      const green = restoreSource[offset + 1] ?? 0;
+      const blue = restoreSource[offset + 2] ?? 0;
+      const alpha = restoreSource[offset + 3] ?? 0;
+      if (data[offset] === red && data[offset + 1] === green && data[offset + 2] === blue && data[offset + 3] === alpha) {
+        continue;
+      }
+      data[offset] = red;
+      data[offset + 1] = green;
+      data[offset + 2] = blue;
+      data[offset + 3] = alpha;
+      changed += 1;
+    }
+  }
+
+  return changed;
+}
+
+export function applyBrushLine(
+  imageData: ImageData,
+  originalImage: ImageData | null,
+  from: CanvasPoint,
+  to: CanvasPoint,
+  radius: number,
+  mode: BrushMode,
+  eraserHardness: number,
+  blurStrength: number,
+): number {
+  const distance = Math.hypot(to.x - from.x, to.y - from.y);
+  const steps = Math.max(1, Math.ceil(distance / Math.max(1, radius * 0.45)));
+  let changed = 0;
+
+  for (let step = 1; step <= steps; step += 1) {
+    const amount = step / steps;
+    changed += applyBrushStamp(
+      imageData,
+      originalImage,
+      from.x + (to.x - from.x) * amount,
+      from.y + (to.y - from.y) * amount,
+      radius,
+      mode,
+      eraserHardness,
+      blurStrength,
+    );
+  }
+
+  return changed;
+}

--- a/packages/client/src/lib/sprite-cleanup-tools.ts
+++ b/packages/client/src/lib/sprite-cleanup-tools.ts
@@ -215,6 +215,50 @@ function buildEdgeBand(
   return { edgeDistance, edgeNormalX, edgeNormalY };
 }
 
+function buildSelectedEdgeDistance(
+  selected: Uint8Array,
+  sourceData: Uint8ClampedArray,
+  width: number,
+  totalPixels: number,
+  radius: number,
+  mode: NeighborMode,
+): Uint8Array {
+  const edgeDistance = new Uint8Array(totalPixels);
+  const edgeQueue = new Int32Array(totalPixels);
+  let queueLength = 0;
+
+  const pushSelectedPixel = (index: number, nextDistance: number) => {
+    if (!selected[index] || edgeDistance[index] !== 0 || nextDistance > radius) return;
+
+    edgeDistance[index] = nextDistance;
+    edgeQueue[queueLength++] = index;
+  };
+
+  for (let index = 0; index < totalPixels; index += 1) {
+    if (!selected[index]) continue;
+
+    let touchesKeptOpaquePixel = false;
+    visitNeighbors(index, width, totalPixels, mode, (neighbor) => {
+      if (selected[neighbor]) return;
+
+      const neighborAlpha = sourceData[neighbor * 4 + 3] ?? 0;
+      if (neighborAlpha > 8) touchesKeptOpaquePixel = true;
+    });
+
+    if (touchesKeptOpaquePixel) pushSelectedPixel(index, 1);
+  }
+
+  for (let queueIndex = 0; queueIndex < queueLength; queueIndex += 1) {
+    const index = edgeQueue[queueIndex];
+    const nextDistance = edgeDistance[index] + 1;
+    if (nextDistance > radius) continue;
+
+    visitNeighbors(index, width, totalPixels, mode, (neighbor) => pushSelectedPixel(neighbor, nextDistance));
+  }
+
+  return edgeDistance;
+}
+
 export function removeConnectedColor(
   imageData: ImageData,
   startX: number,
@@ -246,65 +290,91 @@ export function removeConnectedColorSoftEdge(
   const selection = selectConnectedRegion(imageData, startX, startY, softTolerance, "all");
   if (!selection) return getEmptyWandResult(imageData, startX, startY);
 
-  const edgeRadius = featherAmount <= 0 ? 0 : 1 + Math.round(featherAmount * 2.8);
+  const haloRadius = featherAmount <= 0 ? 0 : 1 + Math.round(featherAmount * 2.25);
   const { selected, target, targetAlpha, totalPixels } = selection;
-  const { edgeDistance } = buildEdgeBand(selected, width, totalPixels, edgeRadius, "all");
+  const sourceData = new Uint8ClampedArray(data);
+  const selectedEdgeDistance = buildSelectedEdgeDistance(selected, sourceData, width, totalPixels, haloRadius, "all");
   let removed = clearSelection(imageData, selected);
 
-  if (edgeRadius > 0 && blendAmount > 0) {
-    const edgeSource = new Uint8ClampedArray(data);
-    const blurRadius = 1 + Math.round(featherAmount * 1.4);
-    const blendBase = blendAmount * (0.32 + featherAmount * 0.48);
-
-    for (let index = 0; index < totalPixels; index += 1) {
-      if (selected[index]) continue;
-
-      const distanceFromCut = edgeDistance[index] ?? 0;
-      if (distanceFromCut === 0) continue;
-
-      const offset = index * 4;
-      const originalAlpha = edgeSource[offset + 3] ?? 0;
-      if (originalAlpha <= 0) continue;
-
+  if (haloRadius > 0 && blendAmount > 0) {
+    const findHaloNeighborColor = (index: number): Rgb | null => {
       const x = index % width;
       const y = Math.floor(index / width);
-      let alphaTotal = 0;
+      const sampleRadius = 3 + Math.round(featherAmount * 3);
+      let redTotal = 0;
+      let greenTotal = 0;
+      let blueTotal = 0;
       let weightTotal = 0;
 
-      for (
-        let sampleY = Math.max(0, y - blurRadius);
-        sampleY <= Math.min(height - 1, y + blurRadius);
-        sampleY += 1
-      ) {
-        for (
-          let sampleX = Math.max(0, x - blurRadius);
-          sampleX <= Math.min(width - 1, x + blurRadius);
-          sampleX += 1
-        ) {
-          const sampleDistance = Math.hypot(sampleX - x, sampleY - y);
-          if (sampleDistance > blurRadius) continue;
+      for (let yOffset = -sampleRadius; yOffset <= sampleRadius; yOffset += 1) {
+        const sampleY = y + yOffset;
+        if (sampleY < 0 || sampleY >= height) continue;
+
+        for (let xOffset = -sampleRadius; xOffset <= sampleRadius; xOffset += 1) {
+          if (xOffset === 0 && yOffset === 0) continue;
+
+          const sampleDistance = Math.hypot(xOffset, yOffset);
+          if (sampleDistance > sampleRadius) continue;
+
+          const sampleX = x + xOffset;
+          if (sampleX < 0 || sampleX >= width) continue;
 
           const sampleIndex = sampleY * width + sampleX;
-          const sampleAlpha = selected[sampleIndex] ? 0 : (edgeSource[sampleIndex * 4 + 3] ?? 0);
-          const weight = sampleX === x && sampleY === y ? 1.6 : 1 / Math.max(1, sampleDistance);
+          if (selected[sampleIndex]) continue;
 
-          alphaTotal += sampleAlpha * weight;
+          const sampleOffset = sampleIndex * 4;
+          const alpha = sourceData[sampleOffset + 3] ?? 0;
+          if (alpha <= 36) continue;
+
+          const targetDistance = Math.sqrt(colorDistanceSquared(sourceData, sampleOffset, target));
+          const matteSeparation = clampUnit((targetDistance - tolerance * 0.45) / Math.max(1, tolerance * 1.65));
+          if (matteSeparation <= 0) continue;
+
+          const red = sourceData[sampleOffset] ?? 0;
+          const green = sourceData[sampleOffset + 1] ?? 0;
+          const blue = sourceData[sampleOffset + 2] ?? 0;
+          const luma = red * 0.2126 + green * 0.7152 + blue * 0.0722;
+          const lightBias = 0.18 + Math.pow(clampUnit((luma - 32) / 223), 2.6) * 4.4;
+          const weight =
+            (Math.pow(alpha / 255, 1.35) * Math.pow(matteSeparation, 1.2) * lightBias) /
+            Math.max(1, sampleDistance);
+
+          redTotal += red * weight;
+          greenTotal += green * weight;
+          blueTotal += blue * weight;
           weightTotal += weight;
         }
       }
 
-      if (weightTotal <= 0) continue;
+      if (weightTotal <= 0) return null;
 
-      const averagedAlpha = Math.round(alphaTotal / weightTotal);
-      if (averagedAlpha >= originalAlpha) continue;
+      return [
+        Math.round(redTotal / weightTotal),
+        Math.round(greenTotal / weightTotal),
+        Math.round(blueTotal / weightTotal),
+      ];
+    };
 
-      const edgePosition = clampUnit((edgeRadius - distanceFromCut + 1) / Math.max(1, edgeRadius));
-      const blendMix = clampUnit(blendBase * Math.pow(edgePosition, 0.8));
-      const nextAlpha = Math.round(originalAlpha * (1 - blendMix) + averagedAlpha * blendMix);
-      if (nextAlpha === originalAlpha) continue;
+    const maxHaloAlpha = 14 + featherAmount * 46;
 
-      data[offset + 3] = nextAlpha;
-      removed += 1;
+    for (let index = 0; index < totalPixels; index += 1) {
+      if (!selected[index]) continue;
+
+      const distanceFromCut = selectedEdgeDistance[index] ?? 0;
+      if (distanceFromCut === 0) continue;
+
+      const foregroundColor = findHaloNeighborColor(index);
+      if (!foregroundColor) continue;
+
+      const offset = index * 4;
+      const edgePosition = clampUnit((haloRadius - distanceFromCut + 1) / Math.max(1, haloRadius));
+      const haloAlpha = Math.round(maxHaloAlpha * blendAmount * Math.pow(edgePosition, 1.55));
+      if (haloAlpha <= 0) continue;
+
+      data[offset] = foregroundColor[0];
+      data[offset + 1] = foregroundColor[1];
+      data[offset + 2] = foregroundColor[2];
+      data[offset + 3] = Math.min(sourceData[offset + 3] ?? 255, haloAlpha);
     }
   }
 

--- a/packages/client/src/lib/sprite-cleanup-tools.ts
+++ b/packages/client/src/lib/sprite-cleanup-tools.ts
@@ -17,6 +17,7 @@ export type WandSelectionMode = "connected" | "local";
 
 export interface WandCleanupOptions {
   mode: WandSelectionMode;
+  neighborMode?: NeighborMode;
   radius: number;
   edgeGuard: number;
   expand: number;
@@ -72,6 +73,11 @@ interface EdgeBand {
   edgeDistance: Uint8Array;
   edgeNormalX: Int8Array;
   edgeNormalY: Int8Array;
+}
+
+interface BrushStampSourceOptions {
+  blurSource?: Uint8ClampedArray | null;
+  cleanSource?: Uint8ClampedArray | null;
 }
 
 function clamp(value: number, min: number, max: number): number {
@@ -323,6 +329,7 @@ function expandSelection(
   width: number,
   totalPixels: number,
   steps: number,
+  mode: NeighborMode,
   canSelect: (index: number, toleranceBoost: number) => boolean,
 ): Uint8Array {
   const expandSteps = Math.min(4, Math.max(0, Math.trunc(steps)));
@@ -337,7 +344,7 @@ function expandSelection(
     for (let index = 0; index < totalPixels; index += 1) {
       if (!current[index]) continue;
 
-      visitNeighbors(index, width, totalPixels, "all", (neighbor) => {
+      visitNeighbors(index, width, totalPixels, mode, (neighbor) => {
         if (current[neighbor] || !canSelect(neighbor, toleranceBoost)) return;
         next[neighbor] = 1;
       });
@@ -1034,6 +1041,7 @@ export function removeWandSelection(
   const totalPixels = width * height;
   const sourceData = new Uint8ClampedArray(data);
   const edgeGuardAmount = clampUnit(options.edgeGuard / 100);
+  const neighborMode = options.neighborMode ?? "cardinal";
   const localRadius = Math.max(2, Math.round(options.radius));
   const localRadiusSquared = localRadius * localRadius;
   const startLocalX = startX;
@@ -1117,7 +1125,7 @@ export function removeWandSelection(
     pushPixel(startIndex);
 
     while (stackLength > 0) {
-      visitNeighbors(stack[--stackLength], width, totalPixels, "all", pushPixel);
+      visitNeighbors(stack[--stackLength], width, totalPixels, neighborMode, pushPixel);
     }
   } else if (options.mode === "local") {
     const minX = Math.max(0, startLocalX - localRadius);
@@ -1146,7 +1154,7 @@ export function removeWandSelection(
     return { removed: 0, target: [target[0], target[1], target[2], targetAlpha] };
   }
 
-  const expandedSelection = expandSelection(selected, width, totalPixels, options.expand, canSelect);
+  const expandedSelection = expandSelection(selected, width, totalPixels, options.expand, neighborMode, canSelect);
   const removed = clearSelection(imageData, expandedSelection);
   softenKeptCutEdge(imageData, expandedSelection, sourceData, target, tolerance, options.softness, options.feather);
   addSelectedSoftHalo(imageData, expandedSelection, sourceData, target, tolerance, options.feather, options.softness);
@@ -1431,12 +1439,13 @@ export function applyBrushStamp(
   centerX: number,
   centerY: number,
   options: BrushStrokeOptions,
+  sources: BrushStampSourceOptions = {},
 ): number {
   const { data, width, height } = imageData;
   const { mode, radius } = options;
   const restoreSource = originalImage?.data ?? null;
-  const blurSource = mode === "blur" ? new Uint8ClampedArray(data) : null;
-  const cleanSource = mode === "clean" ? new Uint8ClampedArray(data) : null;
+  const blurSource = mode === "blur" ? (sources.blurSource ?? new Uint8ClampedArray(data)) : null;
+  const cleanSource = mode === "clean" ? (sources.cleanSource ?? new Uint8ClampedArray(data)) : null;
   const cleanOptions = options.mode === "clean" ? options.clean : null;
   const paintOptions = options.mode === "paint" ? options.paint : null;
   const cleanTarget = cleanOptions?.target ?? null;
@@ -1616,8 +1625,14 @@ export function applyBrushLine(
   to: CanvasPoint,
   options: BrushStrokeOptions,
 ): number {
+  if (from.x === to.x && from.y === to.y) return 0;
+
   const distance = Math.hypot(to.x - from.x, to.y - from.y);
   const steps = Math.max(1, Math.ceil(distance / Math.max(1, options.radius * 0.45)));
+  const sources: BrushStampSourceOptions = {
+    blurSource: options.mode === "blur" ? new Uint8ClampedArray(imageData.data) : null,
+    cleanSource: options.mode === "clean" ? new Uint8ClampedArray(imageData.data) : null,
+  };
   let changed = 0;
 
   for (let step = 1; step <= steps; step += 1) {
@@ -1628,6 +1643,7 @@ export function applyBrushLine(
       from.x + (to.x - from.x) * amount,
       from.y + (to.y - from.y) * amount,
       options,
+      sources,
     );
   }
 

--- a/packages/client/src/lib/sprite-cleanup-tools.ts
+++ b/packages/client/src/lib/sprite-cleanup-tools.ts
@@ -8,11 +8,28 @@ export interface CanvasPoint {
   y: number;
 }
 
-export type BrushMode = "erase" | "restore" | "blur";
+export type BrushMode = "erase" | "restore" | "blur" | "clean";
 
 type Rgb = [number, number, number];
 export type Rgba = [number, number, number, number];
 export type NeighborMode = "cardinal" | "all";
+export type WandSelectionMode = "connected" | "local";
+
+export interface WandCleanupOptions {
+  mode: WandSelectionMode;
+  radius: number;
+  edgeGuard: number;
+  expand: number;
+  softness: number;
+  feather: number;
+}
+
+export interface TargetCleanBrushOptions {
+  target: Rgba;
+  tolerance: number;
+  edgeGuard: number;
+  feather: number;
+}
 
 interface ConnectedSelection {
   selected: Uint8Array;
@@ -168,6 +185,80 @@ function clearSelection(imageData: ImageData, selected: Uint8Array): number {
   return removed;
 }
 
+function offsetSelection(
+  selected: Uint8Array,
+  sourceData: Uint8ClampedArray,
+  width: number,
+  totalPixels: number,
+  offset: number,
+): Uint8Array {
+  const steps = Math.min(8, Math.abs(Math.trunc(offset)));
+  if (steps === 0) return selected;
+
+  let current = new Uint8Array(selected);
+
+  for (let step = 0; step < steps; step += 1) {
+    const next = new Uint8Array(current);
+
+    if (offset > 0) {
+      for (let index = 0; index < totalPixels; index += 1) {
+        if (!current[index]) continue;
+
+        visitNeighbors(index, width, totalPixels, "all", (neighbor) => {
+          if ((sourceData[neighbor * 4 + 3] ?? 0) <= 8) return;
+          next[neighbor] = 1;
+        });
+      }
+    } else {
+      for (let index = 0; index < totalPixels; index += 1) {
+        if (!current[index]) continue;
+
+        let touchesOutside = false;
+        visitNeighbors(index, width, totalPixels, "all", (neighbor) => {
+          if (!current[neighbor]) touchesOutside = true;
+        });
+
+        if (touchesOutside) next[index] = 0;
+      }
+    }
+
+    current = next;
+  }
+
+  return current;
+}
+
+function expandSelection(
+  selected: Uint8Array,
+  width: number,
+  totalPixels: number,
+  steps: number,
+  canSelect: (index: number, toleranceBoost: number) => boolean,
+): Uint8Array {
+  const expandSteps = Math.min(4, Math.max(0, Math.trunc(steps)));
+  if (expandSteps === 0) return selected;
+
+  let current = new Uint8Array(selected);
+
+  for (let step = 0; step < expandSteps; step += 1) {
+    const next = new Uint8Array(current);
+    const toleranceBoost = 1.08 + step * 0.08;
+
+    for (let index = 0; index < totalPixels; index += 1) {
+      if (!current[index]) continue;
+
+      visitNeighbors(index, width, totalPixels, "all", (neighbor) => {
+        if (current[neighbor] || !canSelect(neighbor, toleranceBoost)) return;
+        next[neighbor] = 1;
+      });
+    }
+
+    current = next;
+  }
+
+  return current;
+}
+
 function buildEdgeBand(
   selected: Uint8Array,
   width: number,
@@ -259,6 +350,464 @@ function buildSelectedEdgeDistance(
   return edgeDistance;
 }
 
+function addSelectedMatteFeather(
+  imageData: ImageData,
+  selected: Uint8Array,
+  sourceData: Uint8ClampedArray,
+  featherStrength: number,
+  maxAlpha = 86,
+  radiusScale = 4,
+): number {
+  const { data, width } = imageData;
+  const featherAmount = clampUnit(featherStrength / 100);
+  if (featherAmount <= 0) return 0;
+
+  const totalPixels = selected.length;
+  const featherRadius = 1 + Math.round(featherAmount * radiusScale);
+  const selectedEdgeDistance = buildSelectedEdgeDistance(selected, sourceData, width, totalPixels, featherRadius, "all");
+  const maxFeatherAlpha = 4 + featherAmount * Math.max(0, maxAlpha - 4);
+  let changed = 0;
+
+  for (let index = 0; index < totalPixels; index += 1) {
+    if (!selected[index]) continue;
+
+    const distanceFromCut = selectedEdgeDistance[index] ?? 0;
+    if (distanceFromCut === 0) continue;
+
+    const offset = index * 4;
+    const sourceAlpha = sourceData[offset + 3] ?? 0;
+    if (sourceAlpha <= 0) continue;
+
+    const edgePosition = clampUnit((featherRadius - distanceFromCut + 1) / Math.max(1, featherRadius));
+    const featherAlpha = Math.min(sourceAlpha, Math.round(maxFeatherAlpha * Math.pow(edgePosition, 1.35)));
+    if (featherAlpha <= 0) continue;
+
+    const nextRed = sourceData[offset] ?? 0;
+    const nextGreen = sourceData[offset + 1] ?? 0;
+    const nextBlue = sourceData[offset + 2] ?? 0;
+    if (
+      data[offset] === nextRed &&
+      data[offset + 1] === nextGreen &&
+      data[offset + 2] === nextBlue &&
+      data[offset + 3] === featherAlpha
+    ) {
+      continue;
+    }
+
+    data[offset] = nextRed;
+    data[offset + 1] = nextGreen;
+    data[offset + 2] = nextBlue;
+    data[offset + 3] = featherAlpha;
+    changed += 1;
+  }
+
+  return changed;
+}
+
+function addSelectedSoftHalo(
+  imageData: ImageData,
+  selected: Uint8Array,
+  sourceData: Uint8ClampedArray,
+  target: Rgb,
+  tolerance: number,
+  feather: number,
+  softness: number,
+): number {
+  const { data, width, height } = imageData;
+  const featherAmount = clampUnit(feather / 100);
+  const softnessAmount = clampUnit(softness / 100);
+  if (featherAmount <= 0) return 0;
+
+  const totalPixels = selected.length;
+  const haloRadius = 1 + Math.round(featherAmount * 5);
+  const selectedEdgeDistance = buildSelectedEdgeDistance(selected, sourceData, width, totalPixels, haloRadius, "all");
+  const sampleRadius = haloRadius + 2 + Math.round(softnessAmount * 2);
+  const targetTolerance = Math.max(1, tolerance);
+  const maxHaloAlpha = 4 + featherAmount * (46 + softnessAmount * 18);
+  const halo = new Uint8ClampedArray(totalPixels * 4);
+
+  const findForegroundSample = (index: number): { color: Rgb; influence: number } | null => {
+    const x = index % width;
+    const y = Math.floor(index / width);
+    let redTotal = 0;
+    let greenTotal = 0;
+    let blueTotal = 0;
+    let weightTotal = 0;
+
+    for (let yOffset = -sampleRadius; yOffset <= sampleRadius; yOffset += 1) {
+      const sampleY = y + yOffset;
+      if (sampleY < 0 || sampleY >= height) continue;
+
+      for (let xOffset = -sampleRadius; xOffset <= sampleRadius; xOffset += 1) {
+        if (xOffset === 0 && yOffset === 0) continue;
+
+        const sampleDistance = Math.hypot(xOffset, yOffset);
+        if (sampleDistance > sampleRadius) continue;
+
+        const sampleX = x + xOffset;
+        if (sampleX < 0 || sampleX >= width) continue;
+
+        const sampleIndex = sampleY * width + sampleX;
+        if (selected[sampleIndex]) continue;
+
+        const sampleOffset = sampleIndex * 4;
+        const sampleAlpha = sourceData[sampleOffset + 3] ?? 0;
+        if (sampleAlpha <= 28) continue;
+
+        const targetDistance = Math.sqrt(colorDistanceSquared(sourceData, sampleOffset, target));
+        const matteSeparation = clampUnit((targetDistance - targetTolerance * 0.45) / (targetTolerance * 1.55));
+        if (matteSeparation <= 0) continue;
+
+        const distanceWeight = Math.pow(1 - sampleDistance / Math.max(1, sampleRadius + 0.001), 1.6);
+        const alphaWeight = Math.pow(sampleAlpha / 255, 1.15);
+        const weight = distanceWeight * alphaWeight * Math.pow(matteSeparation, 1.2);
+        if (weight <= 0) continue;
+
+        redTotal += (sourceData[sampleOffset] ?? 0) * weight;
+        greenTotal += (sourceData[sampleOffset + 1] ?? 0) * weight;
+        blueTotal += (sourceData[sampleOffset + 2] ?? 0) * weight;
+        weightTotal += weight;
+      }
+    }
+
+    if (weightTotal <= 0) return null;
+
+    return {
+      color: [
+        Math.round(redTotal / weightTotal),
+        Math.round(greenTotal / weightTotal),
+        Math.round(blueTotal / weightTotal),
+      ],
+      influence: clampUnit(weightTotal / (1.15 + sampleRadius * 0.38)),
+    };
+  };
+
+  for (let index = 0; index < totalPixels; index += 1) {
+    if (!selected[index]) continue;
+
+    const distanceFromCut = selectedEdgeDistance[index] ?? 0;
+    if (distanceFromCut === 0) continue;
+
+    const sample = findForegroundSample(index);
+    if (!sample) continue;
+
+    const offset = index * 4;
+    const sourceAlpha = sourceData[offset + 3] ?? 0;
+    if (sourceAlpha <= 0) continue;
+
+    const edgePosition = clampUnit((haloRadius - distanceFromCut + 1) / Math.max(1, haloRadius));
+    const edgeCurve = 1.72 - softnessAmount * 0.58 - featherAmount * 0.46;
+    const alpha = Math.min(
+      sourceAlpha,
+      Math.round(maxHaloAlpha * Math.pow(edgePosition, edgeCurve) * (0.55 + sample.influence * 0.45)),
+    );
+    if (alpha <= 0) continue;
+
+    halo[offset] = sample.color[0];
+    halo[offset + 1] = sample.color[1];
+    halo[offset + 2] = sample.color[2];
+    halo[offset + 3] = alpha;
+  }
+
+  const blurPasses = Math.round(softnessAmount * 2 + featherAmount * 2);
+  for (let pass = 0; pass < blurPasses; pass += 1) {
+    const previous = new Uint8ClampedArray(halo);
+
+    for (let index = 0; index < totalPixels; index += 1) {
+      if (!selected[index] || (selectedEdgeDistance[index] ?? 0) === 0) continue;
+
+      const x = index % width;
+      const y = Math.floor(index / width);
+      const offset = index * 4;
+      let redTotal = 0;
+      let greenTotal = 0;
+      let blueTotal = 0;
+      let alphaTotal = 0;
+      let weightTotal = 0;
+
+      for (let yOffset = -1; yOffset <= 1; yOffset += 1) {
+        const sampleY = y + yOffset;
+        if (sampleY < 0 || sampleY >= height) continue;
+
+        for (let xOffset = -1; xOffset <= 1; xOffset += 1) {
+          const sampleX = x + xOffset;
+          if (sampleX < 0 || sampleX >= width) continue;
+
+          const sampleIndex = sampleY * width + sampleX;
+          if (!selected[sampleIndex]) continue;
+
+          const sampleOffset = sampleIndex * 4;
+          const sampleDistance = Math.max(1, Math.hypot(xOffset, yOffset));
+          const weight = xOffset === 0 && yOffset === 0 ? 1.8 : 1 / sampleDistance;
+          const sampleAlpha = previous[sampleOffset + 3] ?? 0;
+          weightTotal += weight;
+
+          if (sampleAlpha <= 0) continue;
+          redTotal += (previous[sampleOffset] ?? 0) * sampleAlpha * weight;
+          greenTotal += (previous[sampleOffset + 1] ?? 0) * sampleAlpha * weight;
+          blueTotal += (previous[sampleOffset + 2] ?? 0) * sampleAlpha * weight;
+          alphaTotal += sampleAlpha * weight;
+        }
+      }
+
+      if (alphaTotal <= 0 || weightTotal <= 0) continue;
+
+      halo[offset] = Math.round(redTotal / alphaTotal);
+      halo[offset + 1] = Math.round(greenTotal / alphaTotal);
+      halo[offset + 2] = Math.round(blueTotal / alphaTotal);
+      halo[offset + 3] = Math.round(alphaTotal / weightTotal);
+    }
+  }
+
+  let changed = 0;
+  for (let index = 0; index < totalPixels; index += 1) {
+    if (!selected[index]) continue;
+
+    const offset = index * 4;
+    const alpha = halo[offset + 3] ?? 0;
+    if (alpha <= 0) continue;
+
+    if (
+      data[offset] === halo[offset] &&
+      data[offset + 1] === halo[offset + 1] &&
+      data[offset + 2] === halo[offset + 2] &&
+      data[offset + 3] === alpha
+    ) {
+      continue;
+    }
+
+    data[offset] = halo[offset] ?? 0;
+    data[offset + 1] = halo[offset + 1] ?? 0;
+    data[offset + 2] = halo[offset + 2] ?? 0;
+    data[offset + 3] = alpha;
+    changed += 1;
+  }
+
+  return changed;
+}
+
+function softenKeptCutEdge(
+  imageData: ImageData,
+  selected: Uint8Array,
+  sourceData: Uint8ClampedArray,
+  target: Rgb,
+  tolerance: number,
+  softness: number,
+  feather: number,
+): number {
+  const { data, width, height } = imageData;
+  const softnessAmount = clampUnit(softness / 100);
+  const featherAmount = clampUnit(feather / 100);
+  const transitionAmount = clampUnit(softnessAmount * 0.72 + featherAmount * 0.42);
+  if (transitionAmount <= 0) return 0;
+
+  const totalPixels = selected.length;
+  const edgeRadius = 1 + Math.round(softnessAmount * 2 + featherAmount * 3);
+  const { edgeDistance } = buildEdgeBand(selected, width, totalPixels, edgeRadius, "all");
+  const softened = new Uint8ClampedArray(data);
+  const matteTolerance = Math.max(1, tolerance * (1.14 + transitionAmount * 0.82));
+
+  for (let index = 0; index < totalPixels; index += 1) {
+    const distanceFromCut = edgeDistance[index] ?? 0;
+    if (distanceFromCut === 0) continue;
+
+    const offset = index * 4;
+    const currentAlpha = data[offset + 3] ?? 0;
+    const originalAlpha = sourceData[offset + 3] ?? 0;
+    if (currentAlpha <= 0 || originalAlpha <= 0) continue;
+
+    const edgePosition = clampUnit((edgeRadius - distanceFromCut + 1) / Math.max(1, edgeRadius));
+    const targetDistance = Math.sqrt(colorDistanceSquared(sourceData, offset, target));
+    const matteSimilarity = targetDistance <= matteTolerance ? 1 - targetDistance / matteTolerance : 0;
+    const alphaVulnerability = clampUnit((248 - originalAlpha) / (218 - transitionAmount * 82));
+    const softenStrength =
+      transitionAmount *
+      Math.pow(edgePosition, 0.92 + (1 - featherAmount) * 0.28) *
+      (0.16 + matteSimilarity * 0.58 + alphaVulnerability * 0.3);
+    softened[offset + 3] = Math.min(currentAlpha, Math.round(currentAlpha * (1 - clampUnit(softenStrength))));
+  }
+
+  const blurred = new Uint8ClampedArray(softened);
+  for (let index = 0; index < totalPixels; index += 1) {
+    const distanceFromCut = edgeDistance[index] ?? 0;
+    if (distanceFromCut === 0) continue;
+
+    const x = index % width;
+    const y = Math.floor(index / width);
+    const offset = index * 4;
+    const currentAlpha = softened[offset + 3] ?? 0;
+    if (currentAlpha <= 0) continue;
+
+    let alphaTotal = 0;
+    let weightTotal = 0;
+
+    for (let yOffset = -1; yOffset <= 1; yOffset += 1) {
+      const sampleY = y + yOffset;
+      if (sampleY < 0 || sampleY >= height) continue;
+
+      for (let xOffset = -1; xOffset <= 1; xOffset += 1) {
+        const sampleX = x + xOffset;
+        if (sampleX < 0 || sampleX >= width) continue;
+
+        const sampleIndex = sampleY * width + sampleX;
+        const sampleOffset = sampleIndex * 4;
+        const sampleAlpha = selected[sampleIndex] ? 0 : (softened[sampleOffset + 3] ?? 0);
+        const sampleDistance = Math.max(1, Math.hypot(xOffset, yOffset));
+        const weight = xOffset === 0 && yOffset === 0 ? 1.8 : 1 / sampleDistance;
+
+        alphaTotal += sampleAlpha * weight;
+        weightTotal += weight;
+      }
+    }
+
+    if (weightTotal <= 0) continue;
+
+    const edgePosition = clampUnit((edgeRadius - distanceFromCut + 1) / Math.max(1, edgeRadius));
+    const averagedAlpha = Math.round(alphaTotal / weightTotal);
+    const blurMix = transitionAmount * Math.pow(edgePosition, 0.72) * 0.64;
+    blurred[offset + 3] = Math.min(
+      currentAlpha,
+      Math.round(currentAlpha * (1 - blurMix) + averagedAlpha * blurMix),
+    );
+  }
+
+  let changed = 0;
+  for (let index = 0; index < totalPixels; index += 1) {
+    const distanceFromCut = edgeDistance[index] ?? 0;
+    if (distanceFromCut === 0) continue;
+
+    const offset = index * 4;
+    const nextAlpha = blurred[offset + 3] ?? 0;
+    if (nextAlpha === data[offset + 3]) continue;
+
+    data[offset + 3] = nextAlpha;
+    changed += 1;
+  }
+
+  return changed;
+}
+
+function addSelectedEdgeHalo(
+  imageData: ImageData,
+  selected: Uint8Array,
+  sourceData: Uint8ClampedArray,
+  target: Rgb,
+  tolerance: number,
+  featherStrength: number,
+  rimStrength: number,
+): number {
+  const { data, width, height } = imageData;
+  const featherAmount = clampUnit(featherStrength / 100);
+  const rimAmount = clampUnit(rimStrength / 100);
+  if (featherAmount <= 0 || rimAmount <= 0) return 0;
+
+  const totalPixels = width * height;
+  const haloRadius = 1 + Math.round(featherAmount * 3);
+  const selectedEdgeDistance = buildSelectedEdgeDistance(selected, sourceData, width, totalPixels, haloRadius, "all");
+  const sampleRadius = 3 + Math.round(featherAmount * 4);
+  const targetTolerance = Math.max(1, tolerance);
+  const maxHaloAlpha = 4 + rimAmount * 62;
+  let changed = 0;
+
+  const findHaloNeighborColor = (index: number): Rgb | null => {
+    const x = index % width;
+    const y = Math.floor(index / width);
+    let redTotal = 0;
+    let greenTotal = 0;
+    let blueTotal = 0;
+    let weightTotal = 0;
+
+    for (let yOffset = -sampleRadius; yOffset <= sampleRadius; yOffset += 1) {
+      const sampleY = y + yOffset;
+      if (sampleY < 0 || sampleY >= height) continue;
+
+      for (let xOffset = -sampleRadius; xOffset <= sampleRadius; xOffset += 1) {
+        if (xOffset === 0 && yOffset === 0) continue;
+
+        const sampleDistance = Math.hypot(xOffset, yOffset);
+        if (sampleDistance > sampleRadius) continue;
+
+        const sampleX = x + xOffset;
+        if (sampleX < 0 || sampleX >= width) continue;
+
+        const sampleIndex = sampleY * width + sampleX;
+        if (selected[sampleIndex]) continue;
+
+        const sampleOffset = sampleIndex * 4;
+        const alpha = data[sampleOffset + 3] ?? 0;
+        if (alpha <= 36) continue;
+
+        const targetDistance = Math.sqrt(colorDistanceSquared(data, sampleOffset, target));
+        const matteSeparation = clampUnit((targetDistance - targetTolerance * 0.45) / (targetTolerance * 1.65));
+        if (matteSeparation <= 0) continue;
+
+        const red = data[sampleOffset] ?? 0;
+        const green = data[sampleOffset + 1] ?? 0;
+        const blue = data[sampleOffset + 2] ?? 0;
+        const luma = red * 0.2126 + green * 0.7152 + blue * 0.0722;
+        const lightBias = 0.18 + Math.pow(clampUnit((luma - 32) / 223), 2.6) * 4.4;
+        const weight =
+          (Math.pow(alpha / 255, 1.35) * Math.pow(matteSeparation, 1.2) * lightBias) /
+          Math.max(1, sampleDistance);
+
+        redTotal += red * weight;
+        greenTotal += green * weight;
+        blueTotal += blue * weight;
+        weightTotal += weight;
+      }
+    }
+
+    if (weightTotal <= 0) return null;
+
+    return [
+      Math.round(redTotal / weightTotal),
+      Math.round(greenTotal / weightTotal),
+      Math.round(blueTotal / weightTotal),
+    ];
+  };
+
+  for (let index = 0; index < totalPixels; index += 1) {
+    if (!selected[index]) continue;
+
+    const distanceFromCut = selectedEdgeDistance[index] ?? 0;
+    if (distanceFromCut === 0) continue;
+
+    const foregroundColor = findHaloNeighborColor(index);
+    if (!foregroundColor) continue;
+
+    const offset = index * 4;
+    const sourceAlpha = sourceData[offset + 3] ?? 0;
+    if (sourceAlpha <= 0) continue;
+
+    const edgePosition = clampUnit((haloRadius - distanceFromCut + 1) / Math.max(1, haloRadius));
+    const haloAlpha = Math.round(maxHaloAlpha * Math.pow(edgePosition, 1.45));
+    if (haloAlpha <= 0) continue;
+
+    const existingAlpha = data[offset + 3] ?? 0;
+    const nextAlpha = Math.min(sourceAlpha, Math.max(existingAlpha, haloAlpha));
+    const haloMix = existingAlpha > 0 ? clampUnit(haloAlpha / Math.max(1, existingAlpha + haloAlpha)) : 1;
+    const nextRed = Math.round((data[offset] ?? 0) * (1 - haloMix) + foregroundColor[0] * haloMix);
+    const nextGreen = Math.round((data[offset + 1] ?? 0) * (1 - haloMix) + foregroundColor[1] * haloMix);
+    const nextBlue = Math.round((data[offset + 2] ?? 0) * (1 - haloMix) + foregroundColor[2] * haloMix);
+    if (
+      data[offset] === nextRed &&
+      data[offset + 1] === nextGreen &&
+      data[offset + 2] === nextBlue &&
+      data[offset + 3] === nextAlpha
+    ) {
+      continue;
+    }
+
+    data[offset] = nextRed;
+    data[offset + 1] = nextGreen;
+    data[offset + 2] = nextBlue;
+    data[offset + 3] = nextAlpha;
+    changed += 1;
+  }
+
+  return changed;
+}
+
 export function removeConnectedColor(
   imageData: ImageData,
   startX: number,
@@ -275,108 +824,167 @@ export function removeConnectedColor(
   };
 }
 
+export function removeWandSelection(
+  imageData: ImageData,
+  startX: number,
+  startY: number,
+  tolerance: number,
+  options: WandCleanupOptions,
+): WandResult {
+  const { data, width, height } = imageData;
+  const startIndex = startY * width + startX;
+  const [red, green, blue, targetAlpha] = readPixel(imageData, startIndex);
+  if (targetAlpha <= 8) return getEmptyWandResult(imageData, startX, startY);
+
+  const target: Rgb = [red, green, blue];
+  const totalPixels = width * height;
+  const sourceData = new Uint8ClampedArray(data);
+  const edgeGuardAmount = clampUnit(options.edgeGuard / 100);
+  const localRadius = Math.max(2, Math.round(options.radius));
+  const localRadiusSquared = localRadius * localRadius;
+  const startLocalX = startX;
+  const startLocalY = startY;
+
+  const canSelect = (index: number, toleranceBoost: number): boolean => {
+    const offset = index * 4;
+    const alpha = sourceData[offset + 3] ?? 0;
+    if (alpha <= 8) return false;
+
+    const boostedTolerance = Math.max(1, tolerance * toleranceBoost);
+    const targetDistanceSquared = colorDistanceSquared(sourceData, offset, target);
+    if (targetDistanceSquared > boostedTolerance * boostedTolerance) return false;
+    if (edgeGuardAmount <= 0) return true;
+
+    const targetDistance = Math.sqrt(targetDistanceSquared);
+    if (targetDistance <= tolerance * (0.18 + (1 - edgeGuardAmount) * 0.16)) return true;
+
+    const x = index % width;
+    const y = Math.floor(index / width);
+    let foregroundNeighbors = 0;
+    let neighborCount = 0;
+    let closestForegroundDistance = Number.POSITIVE_INFINITY;
+
+    for (let yOffset = -1; yOffset <= 1; yOffset += 1) {
+      const sampleY = y + yOffset;
+      if (sampleY < 0 || sampleY >= height) continue;
+
+      for (let xOffset = -1; xOffset <= 1; xOffset += 1) {
+        if (xOffset === 0 && yOffset === 0) continue;
+
+        const sampleX = x + xOffset;
+        if (sampleX < 0 || sampleX >= width) continue;
+
+        const sampleIndex = sampleY * width + sampleX;
+        const sampleOffset = sampleIndex * 4;
+        const sampleAlpha = sourceData[sampleOffset + 3] ?? 0;
+        if (sampleAlpha <= 32) continue;
+
+        neighborCount += 1;
+        const neighborTargetDistance = Math.sqrt(colorDistanceSquared(sourceData, sampleOffset, target));
+        if (neighborTargetDistance <= tolerance * (1.05 - edgeGuardAmount * 0.18)) continue;
+
+        foregroundNeighbors += 1;
+        const redDistance = (sourceData[offset] ?? 0) - (sourceData[sampleOffset] ?? 0);
+        const greenDistance = (sourceData[offset + 1] ?? 0) - (sourceData[sampleOffset + 1] ?? 0);
+        const blueDistance = (sourceData[offset + 2] ?? 0) - (sourceData[sampleOffset + 2] ?? 0);
+        closestForegroundDistance = Math.min(
+          closestForegroundDistance,
+          Math.hypot(redDistance, greenDistance, blueDistance),
+        );
+      }
+    }
+
+    if (foregroundNeighbors === 0 || neighborCount === 0) return true;
+
+    const edgePressure = foregroundNeighbors / neighborCount;
+    const weakTargetMatch = targetDistance > tolerance * (0.36 + (1 - edgeGuardAmount) * 0.32);
+    const pulledTowardForeground =
+      closestForegroundDistance < targetDistance * (1.1 + edgeGuardAmount * 1.15) + edgeGuardAmount * 10;
+    const crowdedByForeground = edgePressure > 0.18 + (1 - edgeGuardAmount) * 0.42;
+
+    return !(weakTargetMatch && pulledTowardForeground && crowdedByForeground);
+  };
+
+  const selected = new Uint8Array(totalPixels);
+
+  if (options.mode === "connected") {
+    const visited = new Uint8Array(totalPixels);
+    const stack = new Int32Array(totalPixels);
+    let stackLength = 0;
+
+    const pushPixel = (index: number) => {
+      if (visited[index]) return;
+      visited[index] = 1;
+      if (!canSelect(index, 1)) return;
+      selected[index] = 1;
+      stack[stackLength++] = index;
+    };
+
+    pushPixel(startIndex);
+
+    while (stackLength > 0) {
+      visitNeighbors(stack[--stackLength], width, totalPixels, "all", pushPixel);
+    }
+  } else if (options.mode === "local") {
+    const minX = Math.max(0, startLocalX - localRadius);
+    const maxX = Math.min(width - 1, startLocalX + localRadius);
+    const minY = Math.max(0, startLocalY - localRadius);
+    const maxY = Math.min(height - 1, startLocalY + localRadius);
+
+    for (let y = minY; y <= maxY; y += 1) {
+      for (let x = minX; x <= maxX; x += 1) {
+        const distanceX = x - startLocalX;
+        const distanceY = y - startLocalY;
+        if (distanceX * distanceX + distanceY * distanceY > localRadiusSquared) continue;
+
+        const index = y * width + x;
+        if (canSelect(index, 1)) selected[index] = 1;
+      }
+    }
+  }
+
+  let selectedCount = 0;
+  for (let index = 0; index < totalPixels; index += 1) {
+    if (selected[index]) selectedCount += 1;
+  }
+
+  if (selectedCount === 0) {
+    return { removed: 0, target: [target[0], target[1], target[2], targetAlpha] };
+  }
+
+  const expandedSelection = expandSelection(selected, width, totalPixels, options.expand, canSelect);
+  const removed = clearSelection(imageData, expandedSelection);
+  softenKeptCutEdge(imageData, expandedSelection, sourceData, target, tolerance, options.softness, options.feather);
+  addSelectedSoftHalo(imageData, expandedSelection, sourceData, target, tolerance, options.feather, options.softness);
+
+  return {
+    removed,
+    target: [target[0], target[1], target[2], targetAlpha],
+  };
+}
+
 export function removeConnectedColorSoftEdge(
   imageData: ImageData,
   startX: number,
   startY: number,
   tolerance: number,
   featherStrength: number,
-  blendStrength: number,
+  rimStrength: number,
+  edgeOffset = 0,
 ): WandResult {
-  const { data, width, height } = imageData;
+  const { data, width } = imageData;
   const featherAmount = clampUnit(featherStrength / 100);
-  const blendAmount = clampUnit(blendStrength / 100);
-  const softTolerance = Math.min(160, Math.round(tolerance * (1.1 + featherAmount * 0.22)));
+  const softTolerance = Math.min(160, Math.round(tolerance * (1.04 + featherAmount * 0.18)));
   const selection = selectConnectedRegion(imageData, startX, startY, softTolerance, "all");
   if (!selection) return getEmptyWandResult(imageData, startX, startY);
 
-  const haloRadius = featherAmount <= 0 ? 0 : 1 + Math.round(featherAmount * 2.25);
   const { selected, target, targetAlpha, totalPixels } = selection;
   const sourceData = new Uint8ClampedArray(data);
-  const selectedEdgeDistance = buildSelectedEdgeDistance(selected, sourceData, width, totalPixels, haloRadius, "all");
-  let removed = clearSelection(imageData, selected);
-
-  if (haloRadius > 0 && blendAmount > 0) {
-    const findHaloNeighborColor = (index: number): Rgb | null => {
-      const x = index % width;
-      const y = Math.floor(index / width);
-      const sampleRadius = 3 + Math.round(featherAmount * 3);
-      let redTotal = 0;
-      let greenTotal = 0;
-      let blueTotal = 0;
-      let weightTotal = 0;
-
-      for (let yOffset = -sampleRadius; yOffset <= sampleRadius; yOffset += 1) {
-        const sampleY = y + yOffset;
-        if (sampleY < 0 || sampleY >= height) continue;
-
-        for (let xOffset = -sampleRadius; xOffset <= sampleRadius; xOffset += 1) {
-          if (xOffset === 0 && yOffset === 0) continue;
-
-          const sampleDistance = Math.hypot(xOffset, yOffset);
-          if (sampleDistance > sampleRadius) continue;
-
-          const sampleX = x + xOffset;
-          if (sampleX < 0 || sampleX >= width) continue;
-
-          const sampleIndex = sampleY * width + sampleX;
-          if (selected[sampleIndex]) continue;
-
-          const sampleOffset = sampleIndex * 4;
-          const alpha = sourceData[sampleOffset + 3] ?? 0;
-          if (alpha <= 36) continue;
-
-          const targetDistance = Math.sqrt(colorDistanceSquared(sourceData, sampleOffset, target));
-          const matteSeparation = clampUnit((targetDistance - tolerance * 0.45) / Math.max(1, tolerance * 1.65));
-          if (matteSeparation <= 0) continue;
-
-          const red = sourceData[sampleOffset] ?? 0;
-          const green = sourceData[sampleOffset + 1] ?? 0;
-          const blue = sourceData[sampleOffset + 2] ?? 0;
-          const luma = red * 0.2126 + green * 0.7152 + blue * 0.0722;
-          const lightBias = 0.18 + Math.pow(clampUnit((luma - 32) / 223), 2.6) * 4.4;
-          const weight =
-            (Math.pow(alpha / 255, 1.35) * Math.pow(matteSeparation, 1.2) * lightBias) /
-            Math.max(1, sampleDistance);
-
-          redTotal += red * weight;
-          greenTotal += green * weight;
-          blueTotal += blue * weight;
-          weightTotal += weight;
-        }
-      }
-
-      if (weightTotal <= 0) return null;
-
-      return [
-        Math.round(redTotal / weightTotal),
-        Math.round(greenTotal / weightTotal),
-        Math.round(blueTotal / weightTotal),
-      ];
-    };
-
-    const maxHaloAlpha = 14 + featherAmount * 46;
-
-    for (let index = 0; index < totalPixels; index += 1) {
-      if (!selected[index]) continue;
-
-      const distanceFromCut = selectedEdgeDistance[index] ?? 0;
-      if (distanceFromCut === 0) continue;
-
-      const foregroundColor = findHaloNeighborColor(index);
-      if (!foregroundColor) continue;
-
-      const offset = index * 4;
-      const edgePosition = clampUnit((haloRadius - distanceFromCut + 1) / Math.max(1, haloRadius));
-      const haloAlpha = Math.round(maxHaloAlpha * blendAmount * Math.pow(edgePosition, 1.55));
-      if (haloAlpha <= 0) continue;
-
-      data[offset] = foregroundColor[0];
-      data[offset + 1] = foregroundColor[1];
-      data[offset + 2] = foregroundColor[2];
-      data[offset + 3] = Math.min(sourceData[offset + 3] ?? 255, haloAlpha);
-    }
-  }
+  const clearSelected = offsetSelection(selected, sourceData, width, totalPixels, edgeOffset);
+  const fringeSelected = edgeOffset < 0 ? selected : clearSelected;
+  const removed = clearSelection(imageData, clearSelected);
+  addSelectedMatteFeather(imageData, fringeSelected, sourceData, featherStrength);
+  addSelectedEdgeHalo(imageData, fringeSelected, sourceData, target, tolerance, featherStrength, rimStrength);
 
   return {
     removed,
@@ -391,6 +999,8 @@ export function removeConnectedColorDecontaminate(
   tolerance: number,
   decontaminateStrength: number,
   featherStrength: number,
+  rimStrength = 0,
+  edgeOffset = 0,
 ): WandResult {
   const { data, width, height } = imageData;
   const decontaminateAmount = clampUnit(decontaminateStrength / 100);
@@ -401,12 +1011,14 @@ export function removeConnectedColorDecontaminate(
   if (!selection) return getEmptyWandResult(imageData, startX, startY);
 
   const { selected, target, targetAlpha, totalPixels } = selection;
+  const clearSelected = offsetSelection(selected, new Uint8ClampedArray(data), width, totalPixels, edgeOffset);
+  const fringeSelected = edgeOffset < 0 ? selected : clearSelected;
   const edgeRadius = 1 + Math.round(featherAmount * 7);
   const matteTolerance = Math.min(244, Math.round(tolerance * (1.55 + edgeStrength * 0.7 + featherAmount * 0.25)));
   const foregroundSearchRadius = 3 + edgeRadius + Math.round(edgeStrength * 2);
   const sourceData = new Uint8ClampedArray(data);
-  const { edgeDistance, edgeNormalX, edgeNormalY } = buildEdgeBand(selected, width, totalPixels, edgeRadius, "all");
-  let removed = clearSelection(imageData, selected);
+  const { edgeDistance, edgeNormalX, edgeNormalY } = buildEdgeBand(clearSelected, width, totalPixels, edgeRadius, "all");
+  let removed = clearSelection(imageData, clearSelected);
   const findForegroundNeighborColor = (index: number): Rgb | null => {
     const x = index % width;
     const y = Math.floor(index / width);
@@ -437,7 +1049,7 @@ export function removeConnectedColorDecontaminate(
           if (sampleX < 0 || sampleX >= width) continue;
 
           const sampleIndex = sampleY * width + sampleX;
-          if (selected[sampleIndex]) continue;
+          if (clearSelected[sampleIndex]) continue;
 
           const sampleEdgeDistance = edgeDistance[sampleIndex] ?? 0;
           if (sampleEdgeDistance > 0 && sampleEdgeDistance <= currentDistance) continue;
@@ -474,7 +1086,7 @@ export function removeConnectedColorDecontaminate(
   };
 
   for (let index = 0; index < totalPixels; index += 1) {
-    if (selected[index]) continue;
+    if (clearSelected[index]) continue;
 
     const offset = index * 4;
     const originalAlpha = sourceData[offset + 3] ?? 0;
@@ -550,7 +1162,7 @@ export function removeConnectedColorDecontaminate(
     const blurMixBase = featherAmount * (0.18 + edgeStrength * 0.56);
 
     for (let index = 0; index < totalPixels; index += 1) {
-      if (selected[index]) continue;
+      if (clearSelected[index]) continue;
 
       const distanceFromCut = edgeDistance[index];
       if (distanceFromCut === 0) continue;
@@ -579,10 +1191,10 @@ export function removeConnectedColorDecontaminate(
           if (sampleX < 0 || sampleX >= width) continue;
 
           const sampleIndex = sampleY * width + sampleX;
-          const sampleAlpha = selected[sampleIndex] ? 0 : (smoothedSource[sampleIndex * 4 + 3] ?? 0);
+          const sampleAlpha = clearSelected[sampleIndex] ? 0 : (smoothedSource[sampleIndex * 4 + 3] ?? 0);
           const weight = xOffset === 0 && yOffset === 0 ? 1.75 : 1 / Math.max(1, sampleDistance);
 
-          if (selected[sampleIndex]) touchesCut = true;
+          if (clearSelected[sampleIndex]) touchesCut = true;
           minAlpha = Math.min(minAlpha, sampleAlpha);
           maxAlpha = Math.max(maxAlpha, sampleAlpha);
           alphaTotal += sampleAlpha * weight;
@@ -610,6 +1222,9 @@ export function removeConnectedColorDecontaminate(
     }
   }
 
+  addSelectedMatteFeather(imageData, fringeSelected, sourceData, featherStrength);
+  addSelectedEdgeHalo(imageData, fringeSelected, sourceData, target, tolerance, featherStrength, rimStrength);
+
   return {
     removed,
     target: [target[0], target[1], target[2], targetAlpha],
@@ -624,13 +1239,22 @@ export function applyBrushStamp(
   radius: number,
   mode: BrushMode,
   eraserHardness: number,
+  eraserOpacity: number,
   blurStrength: number,
+  targetCleanOptions?: TargetCleanBrushOptions,
 ): number {
   const { data, width, height } = imageData;
   const restoreSource = originalImage?.data ?? null;
   const blurSource = mode === "blur" ? new Uint8ClampedArray(data) : null;
+  const cleanSource = mode === "clean" ? new Uint8ClampedArray(data) : null;
   const eraserHardnessAmount = clampUnit(eraserHardness / 100);
+  const eraserOpacityAmount = clampUnit(eraserOpacity / 100);
   const blurAmount = clampUnit(blurStrength / 100);
+  const cleanTarget = targetCleanOptions?.target ?? null;
+  const cleanTargetRgb: Rgb | null = cleanTarget ? [cleanTarget[0], cleanTarget[1], cleanTarget[2]] : null;
+  const cleanTolerance = Math.max(1, targetCleanOptions?.tolerance ?? 1);
+  const cleanEdgeGuardAmount = clampUnit((targetCleanOptions?.edgeGuard ?? 0) / 100);
+  const cleanFeatherAmount = clampUnit((targetCleanOptions?.feather ?? 0) / 100);
   const minX = Math.max(0, Math.floor(centerX - radius));
   const maxX = Math.min(width - 1, Math.ceil(centerX + radius));
   const minY = Math.max(0, Math.floor(centerY - radius));
@@ -645,6 +1269,55 @@ export function applyBrushStamp(
       if (dx * dx + dy * dy > radiusSquared) continue;
 
       const offset = (y * width + x) * 4;
+      if (mode === "clean") {
+        if (!cleanSource || !cleanTarget || !cleanTargetRgb || cleanTarget[3] <= 8) continue;
+
+        const originalAlpha = data[offset + 3] ?? 0;
+        if (originalAlpha <= 0) continue;
+
+        const targetDistance = Math.sqrt(colorDistanceSquared(cleanSource, offset, cleanTargetRgb));
+        if (targetDistance > cleanTolerance) continue;
+
+        if (cleanEdgeGuardAmount > 0) {
+          let neighborCount = 0;
+          let foregroundNeighbors = 0;
+
+          for (let sampleY = Math.max(0, y - 1); sampleY <= Math.min(height - 1, y + 1); sampleY += 1) {
+            for (let sampleX = Math.max(0, x - 1); sampleX <= Math.min(width - 1, x + 1); sampleX += 1) {
+              if (sampleX === x && sampleY === y) continue;
+
+              const sampleOffset = (sampleY * width + sampleX) * 4;
+              const sampleAlpha = cleanSource[sampleOffset + 3] ?? 0;
+              if (sampleAlpha <= 32) continue;
+
+              neighborCount += 1;
+              const neighborTargetDistance = Math.sqrt(colorDistanceSquared(cleanSource, sampleOffset, cleanTargetRgb));
+              if (neighborTargetDistance > cleanTolerance * (1.04 - cleanEdgeGuardAmount * 0.18)) {
+                foregroundNeighbors += 1;
+              }
+            }
+          }
+
+          const weakTargetMatch = targetDistance > cleanTolerance * (0.22 + (1 - cleanEdgeGuardAmount) * 0.44);
+          const crowdedByForeground =
+            neighborCount > 0 && foregroundNeighbors / neighborCount > 0.22 + (1 - cleanEdgeGuardAmount) * 0.45;
+          if (weakTargetMatch && crowdedByForeground) continue;
+        }
+
+        const normalizedDistance = Math.sqrt(dx * dx + dy * dy) / Math.max(1, radius);
+        const hardCore = cleanFeatherAmount <= 0.01 ? 1 : 1 - cleanFeatherAmount * 0.84;
+        const eraseAmount =
+          normalizedDistance <= hardCore
+            ? 1
+            : Math.pow(clampUnit((1 - normalizedDistance) / Math.max(0.001, 1 - hardCore)), 1.65);
+        const nextAlpha = Math.round(originalAlpha * (1 - eraseAmount));
+        if (nextAlpha === originalAlpha) continue;
+
+        data[offset + 3] = nextAlpha;
+        changed += 1;
+        continue;
+      }
+
       if (mode === "blur") {
         if (!blurSource || blurAmount <= 0) continue;
 
@@ -695,7 +1368,7 @@ export function applyBrushStamp(
           normalizedDistance <= hardCore
             ? 1
             : Math.pow(clampUnit((1 - normalizedDistance) / Math.max(0.001, 1 - hardCore)), featherCurve);
-        const nextAlpha = Math.round(originalAlpha * (1 - eraseAmount));
+        const nextAlpha = Math.round(originalAlpha * (1 - eraseAmount * eraserOpacityAmount));
         if (nextAlpha === originalAlpha) continue;
 
         data[offset + 3] = nextAlpha;
@@ -730,7 +1403,9 @@ export function applyBrushLine(
   radius: number,
   mode: BrushMode,
   eraserHardness: number,
+  eraserOpacity: number,
   blurStrength: number,
+  targetCleanOptions?: TargetCleanBrushOptions,
 ): number {
   const distance = Math.hypot(to.x - from.x, to.y - from.y);
   const steps = Math.max(1, Math.ceil(distance / Math.max(1, radius * 0.45)));
@@ -746,7 +1421,9 @@ export function applyBrushLine(
       radius,
       mode,
       eraserHardness,
+      eraserOpacity,
       blurStrength,
+      targetCleanOptions,
     );
   }
 

--- a/packages/client/src/lib/sprite-cleanup-tools.ts
+++ b/packages/client/src/lib/sprite-cleanup-tools.ts
@@ -12,35 +12,32 @@ export type BrushMode = "erase" | "restore" | "blur" | "clean" | "paint";
 
 type Rgb = [number, number, number];
 export type Rgba = [number, number, number, number];
-export type NeighborMode = "cardinal" | "all";
-export type WandSelectionMode = "connected" | "local";
+type NeighborMode = "cardinal" | "all";
 
-export interface WandCleanupOptions {
-  mode: WandSelectionMode;
+interface WandCleanupOptions {
   neighborMode?: NeighborMode;
-  radius: number;
   edgeGuard: number;
   expand: number;
   softness: number;
   feather: number;
 }
 
-export interface TargetCleanBrushOptions {
+interface TargetCleanBrushOptions {
   target: Rgba;
   tolerance: number;
   edgeGuard: number;
   feather: number;
 }
 
-export interface PaintBrushOptions {
+interface PaintBrushOptions {
   color: Rgba;
 }
 
-export interface BrushStrokeBaseOptions {
+interface BrushStrokeBaseOptions {
   radius: number;
 }
 
-export interface SoftBrushStrokeOptions extends BrushStrokeBaseOptions {
+interface SoftBrushStrokeOptions extends BrushStrokeBaseOptions {
   hardness: number;
   opacity: number;
 }
@@ -61,13 +58,6 @@ export type BrushStrokeOptions =
       mode: "blur";
       blurStrength: number;
     });
-
-interface ConnectedSelection {
-  selected: Uint8Array;
-  target: Rgb;
-  targetAlpha: number;
-  totalPixels: number;
-}
 
 interface EdgeBand {
   edgeDistance: Uint8Array;
@@ -219,52 +209,6 @@ function visitNeighbors(
   }
 }
 
-function selectConnectedRegion(
-  imageData: ImageData,
-  startX: number,
-  startY: number,
-  tolerance: number,
-  mode: NeighborMode,
-): ConnectedSelection | null {
-  const { data, width, height } = imageData;
-  const startIndex = startY * width + startX;
-  const [red, green, blue, targetAlpha] = readPixel(imageData, startIndex);
-
-  if (targetAlpha <= 8) return null;
-
-  const target: Rgb = [red, green, blue];
-  const totalPixels = width * height;
-  const threshold = tolerance * tolerance;
-  const selected = new Uint8Array(totalPixels);
-  const visited = new Uint8Array(totalPixels);
-  const stack = new Int32Array(totalPixels);
-  let stackLength = 0;
-
-  const pushPixel = (index: number) => {
-    if (visited[index]) return;
-
-    visited[index] = 1;
-    const offset = index * 4;
-    if (data[offset + 3] <= 8 || colorDistanceSquared(data, offset, target) > threshold) return;
-
-    selected[index] = 1;
-    stack[stackLength++] = index;
-  };
-
-  pushPixel(startIndex);
-
-  while (stackLength > 0) {
-    visitNeighbors(stack[--stackLength], width, totalPixels, mode, pushPixel);
-  }
-
-  return {
-    selected,
-    target,
-    targetAlpha,
-    totalPixels,
-  };
-}
-
 function clearSelection(imageData: ImageData, selected: Uint8Array): number {
   const { data } = imageData;
   let removed = 0;
@@ -279,49 +223,6 @@ function clearSelection(imageData: ImageData, selected: Uint8Array): number {
   }
 
   return removed;
-}
-
-function offsetSelection(
-  selected: Uint8Array,
-  sourceData: Uint8ClampedArray,
-  width: number,
-  totalPixels: number,
-  offset: number,
-): Uint8Array {
-  const steps = Math.min(8, Math.abs(Math.trunc(offset)));
-  if (steps === 0) return selected;
-
-  let current = new Uint8Array(selected);
-
-  for (let step = 0; step < steps; step += 1) {
-    const next = new Uint8Array(current);
-
-    if (offset > 0) {
-      for (let index = 0; index < totalPixels; index += 1) {
-        if (!current[index]) continue;
-
-        visitNeighbors(index, width, totalPixels, "all", (neighbor) => {
-          if ((sourceData[neighbor * 4 + 3] ?? 0) <= 8) return;
-          next[neighbor] = 1;
-        });
-      }
-    } else {
-      for (let index = 0; index < totalPixels; index += 1) {
-        if (!current[index]) continue;
-
-        let touchesOutside = false;
-        visitNeighbors(index, width, totalPixels, "all", (neighbor) => {
-          if (!current[neighbor]) touchesOutside = true;
-        });
-
-        if (touchesOutside) next[index] = 0;
-      }
-    }
-
-    current = next;
-  }
-
-  return current;
 }
 
 function expandSelection(
@@ -445,60 +346,6 @@ function buildSelectedEdgeDistance(
   }
 
   return edgeDistance;
-}
-
-function addSelectedMatteFeather(
-  imageData: ImageData,
-  selected: Uint8Array,
-  sourceData: Uint8ClampedArray,
-  featherStrength: number,
-  maxAlpha = 86,
-  radiusScale = 4,
-): number {
-  const { data, width } = imageData;
-  const featherAmount = clampUnit(featherStrength / 100);
-  if (featherAmount <= 0) return 0;
-
-  const totalPixels = selected.length;
-  const featherRadius = 1 + Math.round(featherAmount * radiusScale);
-  const selectedEdgeDistance = buildSelectedEdgeDistance(selected, sourceData, width, totalPixels, featherRadius, "all");
-  const maxFeatherAlpha = 4 + featherAmount * Math.max(0, maxAlpha - 4);
-  let changed = 0;
-
-  for (let index = 0; index < totalPixels; index += 1) {
-    if (!selected[index]) continue;
-
-    const distanceFromCut = selectedEdgeDistance[index] ?? 0;
-    if (distanceFromCut === 0) continue;
-
-    const offset = index * 4;
-    const sourceAlpha = sourceData[offset + 3] ?? 0;
-    if (sourceAlpha <= 0) continue;
-
-    const edgePosition = clampUnit((featherRadius - distanceFromCut + 1) / Math.max(1, featherRadius));
-    const featherAlpha = Math.min(sourceAlpha, Math.round(maxFeatherAlpha * Math.pow(edgePosition, 1.35)));
-    if (featherAlpha <= 0) continue;
-
-    const nextRed = sourceData[offset] ?? 0;
-    const nextGreen = sourceData[offset + 1] ?? 0;
-    const nextBlue = sourceData[offset + 2] ?? 0;
-    if (
-      data[offset] === nextRed &&
-      data[offset + 1] === nextGreen &&
-      data[offset + 2] === nextBlue &&
-      data[offset + 3] === featherAlpha
-    ) {
-      continue;
-    }
-
-    data[offset] = nextRed;
-    data[offset + 1] = nextGreen;
-    data[offset + 2] = nextBlue;
-    data[offset + 3] = featherAlpha;
-    changed += 1;
-  }
-
-  return changed;
 }
 
 function addSelectedSoftHalo(
@@ -703,7 +550,7 @@ function softenKeptCutEdge(
   const { edgeDistance } = buildEdgeBand(selected, width, totalPixels, edgeRadius, "all");
   const softened = new Uint8ClampedArray(data);
   const matteTolerance = Math.max(1, tolerance * (1.14 + transitionAmount * 0.82));
-  const decontaminateAmount = clampUnit((softnessAmount * 0.65 + featherAmount * 0.55 - 0.3) / 0.7);
+  const residueCleanupAmount = clampUnit((softnessAmount * 0.65 + featherAmount * 0.55 - 0.3) / 0.7);
   const sampleRadius = 2 + edgeRadius;
   const targetLuma = target[0] * 0.2126 + target[1] * 0.7152 + target[2] * 0.0722;
 
@@ -776,7 +623,7 @@ function softenKeptCutEdge(
     const matteSimilarity = targetDistance <= matteTolerance ? 1 - targetDistance / matteTolerance : 0;
     const alphaVulnerability = clampUnit((248 - originalAlpha) / (218 - transitionAmount * 82));
 
-    if (decontaminateAmount > 0 && matteSimilarity > 0.05) {
+    if (residueCleanupAmount > 0 && matteSimilarity > 0.05) {
       const foreground = findForegroundColor(index);
       if (foreground) {
         const currentRed = sourceData[offset] ?? 0;
@@ -794,7 +641,7 @@ function softenKeptCutEdge(
         const residueBias = Math.max(matteSimilarity, lightResidueBias, darkResidueBias);
         const confidence = clampUnit(foreground.weight / (1.4 + sampleRadius * 0.42));
         const colorPull = clampUnit(
-          decontaminateAmount *
+          residueCleanupAmount *
             Math.pow(edgePosition, 0.88) *
             residueBias *
             (0.42 + alphaVulnerability * 0.28 + confidence * 0.3),
@@ -888,143 +735,6 @@ function softenKeptCutEdge(
   return changed;
 }
 
-function addSelectedEdgeHalo(
-  imageData: ImageData,
-  selected: Uint8Array,
-  sourceData: Uint8ClampedArray,
-  target: Rgb,
-  tolerance: number,
-  featherStrength: number,
-  rimStrength: number,
-): number {
-  const { data, width, height } = imageData;
-  const featherAmount = clampUnit(featherStrength / 100);
-  const rimAmount = clampUnit(rimStrength / 100);
-  if (featherAmount <= 0 || rimAmount <= 0) return 0;
-
-  const totalPixels = width * height;
-  const haloRadius = 1 + Math.round(featherAmount * 3);
-  const selectedEdgeDistance = buildSelectedEdgeDistance(selected, sourceData, width, totalPixels, haloRadius, "all");
-  const sampleRadius = 3 + Math.round(featherAmount * 4);
-  const targetTolerance = Math.max(1, tolerance);
-  const maxHaloAlpha = 4 + rimAmount * 62;
-  let changed = 0;
-
-  const findHaloNeighborColor = (index: number): Rgb | null => {
-    const x = index % width;
-    const y = Math.floor(index / width);
-    let redTotal = 0;
-    let greenTotal = 0;
-    let blueTotal = 0;
-    let weightTotal = 0;
-
-    for (let yOffset = -sampleRadius; yOffset <= sampleRadius; yOffset += 1) {
-      const sampleY = y + yOffset;
-      if (sampleY < 0 || sampleY >= height) continue;
-
-      for (let xOffset = -sampleRadius; xOffset <= sampleRadius; xOffset += 1) {
-        if (xOffset === 0 && yOffset === 0) continue;
-
-        const sampleDistance = Math.hypot(xOffset, yOffset);
-        if (sampleDistance > sampleRadius) continue;
-
-        const sampleX = x + xOffset;
-        if (sampleX < 0 || sampleX >= width) continue;
-
-        const sampleIndex = sampleY * width + sampleX;
-        if (selected[sampleIndex]) continue;
-
-        const sampleOffset = sampleIndex * 4;
-        const alpha = data[sampleOffset + 3] ?? 0;
-        if (alpha <= 36) continue;
-
-        const targetDistance = Math.sqrt(colorDistanceSquared(data, sampleOffset, target));
-        const matteSeparation = clampUnit((targetDistance - targetTolerance * 0.45) / (targetTolerance * 1.65));
-        if (matteSeparation <= 0) continue;
-
-        const red = data[sampleOffset] ?? 0;
-        const green = data[sampleOffset + 1] ?? 0;
-        const blue = data[sampleOffset + 2] ?? 0;
-        const luma = red * 0.2126 + green * 0.7152 + blue * 0.0722;
-        const lightBias = 0.18 + Math.pow(clampUnit((luma - 32) / 223), 2.6) * 4.4;
-        const weight =
-          (Math.pow(alpha / 255, 1.35) * Math.pow(matteSeparation, 1.2) * lightBias) /
-          Math.max(1, sampleDistance);
-
-        redTotal += red * weight;
-        greenTotal += green * weight;
-        blueTotal += blue * weight;
-        weightTotal += weight;
-      }
-    }
-
-    if (weightTotal <= 0) return null;
-
-    return [
-      Math.round(redTotal / weightTotal),
-      Math.round(greenTotal / weightTotal),
-      Math.round(blueTotal / weightTotal),
-    ];
-  };
-
-  for (let index = 0; index < totalPixels; index += 1) {
-    if (!selected[index]) continue;
-
-    const distanceFromCut = selectedEdgeDistance[index] ?? 0;
-    if (distanceFromCut === 0) continue;
-
-    const foregroundColor = findHaloNeighborColor(index);
-    if (!foregroundColor) continue;
-
-    const offset = index * 4;
-    const sourceAlpha = sourceData[offset + 3] ?? 0;
-    if (sourceAlpha <= 0) continue;
-
-    const edgePosition = clampUnit((haloRadius - distanceFromCut + 1) / Math.max(1, haloRadius));
-    const haloAlpha = Math.round(maxHaloAlpha * Math.pow(edgePosition, 1.45));
-    if (haloAlpha <= 0) continue;
-
-    const existingAlpha = data[offset + 3] ?? 0;
-    const nextAlpha = Math.min(sourceAlpha, Math.max(existingAlpha, haloAlpha));
-    const haloMix = existingAlpha > 0 ? clampUnit(haloAlpha / Math.max(1, existingAlpha + haloAlpha)) : 1;
-    const nextRed = Math.round((data[offset] ?? 0) * (1 - haloMix) + foregroundColor[0] * haloMix);
-    const nextGreen = Math.round((data[offset + 1] ?? 0) * (1 - haloMix) + foregroundColor[1] * haloMix);
-    const nextBlue = Math.round((data[offset + 2] ?? 0) * (1 - haloMix) + foregroundColor[2] * haloMix);
-    if (
-      data[offset] === nextRed &&
-      data[offset + 1] === nextGreen &&
-      data[offset + 2] === nextBlue &&
-      data[offset + 3] === nextAlpha
-    ) {
-      continue;
-    }
-
-    data[offset] = nextRed;
-    data[offset + 1] = nextGreen;
-    data[offset + 2] = nextBlue;
-    data[offset + 3] = nextAlpha;
-    changed += 1;
-  }
-
-  return changed;
-}
-
-export function removeConnectedColor(
-  imageData: ImageData,
-  startX: number,
-  startY: number,
-  tolerance: number,
-  mode: NeighborMode = "cardinal",
-): WandResult {
-  const selection = selectConnectedRegion(imageData, startX, startY, tolerance, mode);
-  if (!selection) return getEmptyWandResult(imageData, startX, startY);
-
-  return {
-    removed: clearSelection(imageData, selection.selected),
-    target: [selection.target[0], selection.target[1], selection.target[2], selection.targetAlpha],
-  };
-}
-
 export function removeWandSelection(
   imageData: ImageData,
   startX: number,
@@ -1042,10 +752,6 @@ export function removeWandSelection(
   const sourceData = new Uint8ClampedArray(data);
   const edgeGuardAmount = clampUnit(options.edgeGuard / 100);
   const neighborMode = options.neighborMode ?? "cardinal";
-  const localRadius = Math.max(2, Math.round(options.radius));
-  const localRadiusSquared = localRadius * localRadius;
-  const startLocalX = startX;
-  const startLocalY = startY;
 
   const canSelect = (index: number, toleranceBoost: number): boolean => {
     const offset = index * 4;
@@ -1108,41 +814,22 @@ export function removeWandSelection(
   };
 
   const selected = new Uint8Array(totalPixels);
+  const visited = new Uint8Array(totalPixels);
+  const stack = new Int32Array(totalPixels);
+  let stackLength = 0;
 
-  if (options.mode === "connected") {
-    const visited = new Uint8Array(totalPixels);
-    const stack = new Int32Array(totalPixels);
-    let stackLength = 0;
+  const pushPixel = (index: number) => {
+    if (visited[index]) return;
+    visited[index] = 1;
+    if (!canSelect(index, 1)) return;
+    selected[index] = 1;
+    stack[stackLength++] = index;
+  };
 
-    const pushPixel = (index: number) => {
-      if (visited[index]) return;
-      visited[index] = 1;
-      if (!canSelect(index, 1)) return;
-      selected[index] = 1;
-      stack[stackLength++] = index;
-    };
+  pushPixel(startIndex);
 
-    pushPixel(startIndex);
-
-    while (stackLength > 0) {
-      visitNeighbors(stack[--stackLength], width, totalPixels, neighborMode, pushPixel);
-    }
-  } else if (options.mode === "local") {
-    const minX = Math.max(0, startLocalX - localRadius);
-    const maxX = Math.min(width - 1, startLocalX + localRadius);
-    const minY = Math.max(0, startLocalY - localRadius);
-    const maxY = Math.min(height - 1, startLocalY + localRadius);
-
-    for (let y = minY; y <= maxY; y += 1) {
-      for (let x = minX; x <= maxX; x += 1) {
-        const distanceX = x - startLocalX;
-        const distanceY = y - startLocalY;
-        if (distanceX * distanceX + distanceY * distanceY > localRadiusSquared) continue;
-
-        const index = y * width + x;
-        if (canSelect(index, 1)) selected[index] = 1;
-      }
-    }
+  while (stackLength > 0) {
+    visitNeighbors(stack[--stackLength], width, totalPixels, neighborMode, pushPixel);
   }
 
   let selectedCount = 0;
@@ -1158,274 +845,6 @@ export function removeWandSelection(
   const removed = clearSelection(imageData, expandedSelection);
   softenKeptCutEdge(imageData, expandedSelection, sourceData, target, tolerance, options.softness, options.feather);
   addSelectedSoftHalo(imageData, expandedSelection, sourceData, target, tolerance, options.feather, options.softness);
-
-  return {
-    removed,
-    target: [target[0], target[1], target[2], targetAlpha],
-  };
-}
-
-export function removeConnectedColorSoftEdge(
-  imageData: ImageData,
-  startX: number,
-  startY: number,
-  tolerance: number,
-  featherStrength: number,
-  rimStrength: number,
-  edgeOffset = 0,
-): WandResult {
-  const { data, width } = imageData;
-  const featherAmount = clampUnit(featherStrength / 100);
-  const softTolerance = Math.min(160, Math.round(tolerance * (1.04 + featherAmount * 0.18)));
-  const selection = selectConnectedRegion(imageData, startX, startY, softTolerance, "all");
-  if (!selection) return getEmptyWandResult(imageData, startX, startY);
-
-  const { selected, target, targetAlpha, totalPixels } = selection;
-  const sourceData = new Uint8ClampedArray(data);
-  const clearSelected = offsetSelection(selected, sourceData, width, totalPixels, edgeOffset);
-  const fringeSelected = edgeOffset < 0 ? selected : clearSelected;
-  const removed = clearSelection(imageData, clearSelected);
-  addSelectedMatteFeather(imageData, fringeSelected, sourceData, featherStrength);
-  addSelectedEdgeHalo(imageData, fringeSelected, sourceData, target, tolerance, featherStrength, rimStrength);
-
-  return {
-    removed,
-    target: [target[0], target[1], target[2], targetAlpha],
-  };
-}
-
-export function removeConnectedColorDecontaminate(
-  imageData: ImageData,
-  startX: number,
-  startY: number,
-  tolerance: number,
-  decontaminateStrength: number,
-  featherStrength: number,
-  rimStrength = 0,
-  edgeOffset = 0,
-): WandResult {
-  const { data, width, height } = imageData;
-  const decontaminateAmount = clampUnit(decontaminateStrength / 100);
-  const featherAmount = clampUnit(featherStrength / 100);
-  const edgeStrength = Math.pow(decontaminateAmount, 0.72);
-  const selectionTolerance = Math.min(176, Math.round(tolerance * 1.24));
-  const selection = selectConnectedRegion(imageData, startX, startY, selectionTolerance, "all");
-  if (!selection) return getEmptyWandResult(imageData, startX, startY);
-
-  const { selected, target, targetAlpha, totalPixels } = selection;
-  const clearSelected = offsetSelection(selected, new Uint8ClampedArray(data), width, totalPixels, edgeOffset);
-  const fringeSelected = edgeOffset < 0 ? selected : clearSelected;
-  const edgeRadius = 1 + Math.round(featherAmount * 7);
-  const matteTolerance = Math.min(244, Math.round(tolerance * (1.55 + edgeStrength * 0.7 + featherAmount * 0.25)));
-  const foregroundSearchRadius = 3 + edgeRadius + Math.round(edgeStrength * 2);
-  const sourceData = new Uint8ClampedArray(data);
-  const { edgeDistance, edgeNormalX, edgeNormalY } = buildEdgeBand(clearSelected, width, totalPixels, edgeRadius, "all");
-  let removed = clearSelection(imageData, clearSelected);
-  const findForegroundNeighborColor = (index: number): Rgb | null => {
-    const x = index % width;
-    const y = Math.floor(index / width);
-    const normalX = edgeNormalX[index] ?? 0;
-    const normalY = edgeNormalY[index] ?? 0;
-    const currentDistance = edgeDistance[index] ?? 0;
-
-    const sample = (directional: boolean): Rgb | null => {
-      let redTotal = 0;
-      let greenTotal = 0;
-      let blueTotal = 0;
-      let weightTotal = 0;
-
-      for (let yOffset = -foregroundSearchRadius; yOffset <= foregroundSearchRadius; yOffset += 1) {
-        const sampleY = y + yOffset;
-        if (sampleY < 0 || sampleY >= height) continue;
-
-        for (let xOffset = -foregroundSearchRadius; xOffset <= foregroundSearchRadius; xOffset += 1) {
-          if (xOffset === 0 && yOffset === 0) continue;
-
-          const sampleDistance = Math.hypot(xOffset, yOffset);
-          if (sampleDistance > foregroundSearchRadius) continue;
-
-          const dot = xOffset * normalX + yOffset * normalY;
-          if (directional && (normalX !== 0 || normalY !== 0) && dot <= 0) continue;
-
-          const sampleX = x + xOffset;
-          if (sampleX < 0 || sampleX >= width) continue;
-
-          const sampleIndex = sampleY * width + sampleX;
-          if (clearSelected[sampleIndex]) continue;
-
-          const sampleEdgeDistance = edgeDistance[sampleIndex] ?? 0;
-          if (sampleEdgeDistance > 0 && sampleEdgeDistance <= currentDistance) continue;
-
-          const sampleOffset = sampleIndex * 4;
-          const alpha = sourceData[sampleOffset + 3] ?? 0;
-          if (alpha <= 40) continue;
-
-          const targetDistance = Math.sqrt(colorDistanceSquared(sourceData, sampleOffset, target));
-          if (alpha < 220 && targetDistance < selectionTolerance * 0.8) continue;
-
-          const directionWeight = directional
-            ? 1 + clampUnit(dot / Math.max(1, foregroundSearchRadius)) * 1.6
-            : 1;
-          const alphaWeight = Math.pow(alpha / 255, 2.2);
-          const colorSeparationWeight = 0.7 + clampUnit(targetDistance / Math.max(1, matteTolerance)) * 0.6;
-          const weight = (alphaWeight * colorSeparationWeight * directionWeight) / Math.max(1, sampleDistance);
-          redTotal += (sourceData[sampleOffset] ?? 0) * weight;
-          greenTotal += (sourceData[sampleOffset + 1] ?? 0) * weight;
-          blueTotal += (sourceData[sampleOffset + 2] ?? 0) * weight;
-          weightTotal += weight;
-        }
-      }
-
-      if (weightTotal <= 0) return null;
-      return [
-        Math.round(redTotal / weightTotal),
-        Math.round(greenTotal / weightTotal),
-        Math.round(blueTotal / weightTotal),
-      ];
-    };
-
-    return sample(true) ?? sample(false);
-  };
-
-  for (let index = 0; index < totalPixels; index += 1) {
-    if (clearSelected[index]) continue;
-
-    const offset = index * 4;
-    const originalAlpha = sourceData[offset + 3] ?? 0;
-
-    const distanceFromCut = edgeDistance[index];
-    if (distanceFromCut === 0 || decontaminateAmount <= 0 || originalAlpha <= 8) continue;
-
-    const targetDistance = Math.sqrt(colorDistanceSquared(sourceData, offset, target));
-    const matteSimilarity = targetDistance <= matteTolerance ? 1 - targetDistance / matteTolerance : 0;
-    const foregroundColor = findForegroundNeighborColor(index);
-    const originalRed = sourceData[offset] ?? 0;
-    const originalGreen = sourceData[offset + 1] ?? 0;
-    const originalBlue = sourceData[offset + 2] ?? 0;
-    const foregroundDistance = foregroundColor
-      ? Math.hypot(originalRed - foregroundColor[0], originalGreen - foregroundColor[1], originalBlue - foregroundColor[2])
-      : 0;
-    const foregroundMismatch = foregroundColor
-      ? clampUnit((foregroundDistance - (14 - featherAmount * 8)) / (150 - featherAmount * 45))
-      : 0;
-    const alphaVulnerability = clampUnit((245 - originalAlpha) / (210 - featherAmount * 70));
-    const edgePosition = clampUnit((edgeRadius - distanceFromCut + 1) / Math.max(1, edgeRadius));
-    const proximity = Math.pow(edgePosition, 1.75 - featherAmount * 1.1);
-    const cleanupWeight =
-      Math.max(
-        matteSimilarity * (0.88 + featherAmount * 0.18),
-        foregroundMismatch,
-        alphaVulnerability * (0.34 + featherAmount * 0.32),
-      ) *
-      proximity *
-      edgeStrength *
-      (0.75 + featherAmount * 0.45);
-
-    if (cleanupWeight <= 0.01) continue;
-
-    let nextRed = originalRed;
-    let nextGreen = originalGreen;
-    let nextBlue = originalBlue;
-
-    if (foregroundColor) {
-      const colorPull = clampUnit(cleanupWeight * (0.86 + edgeStrength * 0.32 + featherAmount * 0.28));
-      nextRed = Math.round(originalRed * (1 - colorPull) + foregroundColor[0] * colorPull);
-      nextGreen = Math.round(originalGreen * (1 - colorPull) + foregroundColor[1] * colorPull);
-      nextBlue = Math.round(originalBlue * (1 - colorPull) + foregroundColor[2] * colorPull);
-    }
-
-    const alphaReduction =
-      cleanupWeight *
-      (0.06 + matteSimilarity * (0.15 + featherAmount * 0.2) + alphaVulnerability * (0.12 + featherAmount * 0.22));
-    const nextAlpha = Math.min(
-      originalAlpha,
-      Math.round(originalAlpha * clamp(1 - alphaReduction, 0.62 - featherAmount * 0.24, 1)),
-    );
-
-    if (
-      nextRed === originalRed &&
-      nextGreen === originalGreen &&
-      nextBlue === originalBlue &&
-      nextAlpha === originalAlpha
-    ) {
-      continue;
-    }
-
-    data[offset] = nextRed;
-    data[offset + 1] = nextGreen;
-    data[offset + 2] = nextBlue;
-    data[offset + 3] = nextAlpha;
-    removed += 1;
-  }
-
-  if (featherAmount > 0 && decontaminateAmount > 0) {
-    const smoothedSource = new Uint8ClampedArray(data);
-    const blurRadius = 1 + Math.round(featherAmount * 2);
-    const blurMixBase = featherAmount * (0.18 + edgeStrength * 0.56);
-
-    for (let index = 0; index < totalPixels; index += 1) {
-      if (clearSelected[index]) continue;
-
-      const distanceFromCut = edgeDistance[index];
-      if (distanceFromCut === 0) continue;
-
-      const offset = index * 4;
-      const originalAlpha = smoothedSource[offset + 3] ?? 0;
-      if (originalAlpha <= 8) continue;
-
-      const x = index % width;
-      const y = Math.floor(index / width);
-      let alphaTotal = 0;
-      let weightTotal = 0;
-      let minAlpha = originalAlpha;
-      let maxAlpha = originalAlpha;
-      let touchesCut = false;
-
-      for (let yOffset = -blurRadius; yOffset <= blurRadius; yOffset += 1) {
-        const sampleY = y + yOffset;
-        if (sampleY < 0 || sampleY >= height) continue;
-
-        for (let xOffset = -blurRadius; xOffset <= blurRadius; xOffset += 1) {
-          const sampleDistance = Math.hypot(xOffset, yOffset);
-          if (sampleDistance > blurRadius) continue;
-
-          const sampleX = x + xOffset;
-          if (sampleX < 0 || sampleX >= width) continue;
-
-          const sampleIndex = sampleY * width + sampleX;
-          const sampleAlpha = clearSelected[sampleIndex] ? 0 : (smoothedSource[sampleIndex * 4 + 3] ?? 0);
-          const weight = xOffset === 0 && yOffset === 0 ? 1.75 : 1 / Math.max(1, sampleDistance);
-
-          if (clearSelected[sampleIndex]) touchesCut = true;
-          minAlpha = Math.min(minAlpha, sampleAlpha);
-          maxAlpha = Math.max(maxAlpha, sampleAlpha);
-          alphaTotal += sampleAlpha * weight;
-          weightTotal += weight;
-        }
-      }
-
-      if ((!touchesCut && maxAlpha - minAlpha < 18) || weightTotal <= 0) continue;
-
-      const averagedAlpha = Math.round(alphaTotal / weightTotal);
-      if (averagedAlpha >= originalAlpha) continue;
-
-      const targetDistance = Math.sqrt(colorDistanceSquared(smoothedSource, offset, target));
-      const matteAttraction =
-        targetDistance <= matteTolerance ? 0.35 + (1 - targetDistance / matteTolerance) * 0.65 : 0.35;
-      const edgePosition = clampUnit((edgeRadius - distanceFromCut + 1) / Math.max(1, edgeRadius));
-      const proximity = Math.pow(edgePosition, 0.55 + (1 - featherAmount) * 0.8);
-      const blurMix = clampUnit(blurMixBase * matteAttraction * proximity);
-      const nextAlpha = Math.min(originalAlpha, Math.round(originalAlpha * (1 - blurMix) + averagedAlpha * blurMix));
-
-      if (nextAlpha === originalAlpha) continue;
-
-      data[offset + 3] = nextAlpha;
-      removed += 1;
-    }
-  }
-
-  addSelectedMatteFeather(imageData, fringeSelected, sourceData, featherStrength);
-  addSelectedEdgeHalo(imageData, fringeSelected, sourceData, target, tolerance, featherStrength, rimStrength);
 
   return {
     removed,


### PR DESCRIPTION
## Linked issue

No linked issue yet.

## Why this change

Manual sprite cleanup needed more than one click-to-transparent wand pass. White matte debris around hair/details can need a safer connected wand, targeted cleanup brush, edge smoothing, restore/paint touchups, zoom/pan, and preview backgrounds so users can clean sprites without leaving Marinara.

## What changed

- Extracted sprite cleanup image-data operations into `packages/client/src/lib/sprite-cleanup-tools.ts`.
- Reworked `SpriteWandCleanupEditor` with zoom/pan, preview backgrounds, hover pixel readout, undo/reset, and scroll-safe editor chrome.
- Added connected wand controls for tolerance, Strong, Softness, and Feather.
- Added Clean, Erase, Brush/Restore, and Blur tools with brush size/opacity/hardness/strength controls.
- Hardened pointer gesture handling after review so extra touch pointers do not steal active strokes and re-entering the canvas does not draw stale connecting lines.
- Added pressed-state metadata for tool/background buttons.

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `pnpm --filter @marinara-engine/client lint` passed.
- `pnpm build:client` passed.
- `git diff --check` passed with the normal LF-to-CRLF working-copy warning.
- Browser/manual testing with one of Xel's real saved sprites is still needed.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

Browser/manual sprite evidence still needed before final review.
