### PR TITLE
fix(image-gen): harden OpenRouter image response parsing

### DIFF
--- a/packages/server/src/services/image/image-generation.ts
+++ b/packages/server/src/services/image/image-generation.ts
@@ -24,6 +24,7 @@ import {
 } from "@marinara-engine/shared";
 import { isImageLocalUrlsEnabled } from "../../config/runtime-config.js";
 import { generateRunPodComfyUI } from "./runpod-comfyui.service.js";
+import { logger } from "../../lib/logger.js";
 import { normalizeLoopbackUrl, safeFetch, validateOutboundUrl } from "../../utils/security.js";
 
 const GALLERY_DIR = join(DATA_DIR, "gallery");
@@ -221,6 +222,7 @@ function imageFetch(url: string | URL, init?: RequestInit, options: { allowLocal
       flagName: "IMAGE_LOCAL_URLS_ENABLED",
     },
     maxResponseBytes: MAX_IMAGE_RESPONSE_BYTES,
+    decodeCompressedResponse: true,
   });
 }
 
@@ -1461,15 +1463,57 @@ async function generateOpenRouter(baseUrl: string, apiKey: string, request: Imag
     throw new Error(`OpenRouter image generation failed (${resp.status}): ${sanitizeErrorText(errText)}`);
   }
 
-  const data = (await resp.json()) as { choices?: Array<{ message?: unknown }> };
-  const message = data.choices?.[0]?.message;
+  // Some OpenRouter image models (e.g. raw provider passthrough) return the
+  // image bytes directly instead of a chat-completions JSON envelope. Sniff
+  // the content-type and the first bytes before deciding how to parse.
+  const contentType = resp.headers.get("content-type") ?? "";
+  const buffer = Buffer.from(await resp.arrayBuffer());
+  const isImageContentType = contentType.startsWith("image/");
+  const looksLikeImageBytes =
+    buffer.length >= 4 &&
+    ((buffer[0] === 0x89 && buffer[1] === 0x50 && buffer[2] === 0x4e && buffer[3] === 0x47) || // PNG
+      (buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff) || // JPEG
+      (buffer[0] === 0x47 && buffer[1] === 0x49 && buffer[2] === 0x46) || // GIF
+      (buffer[0] === 0x52 && buffer[1] === 0x49 && buffer[2] === 0x46 && buffer[3] === 0x46)); // RIFF/WEBP
+
+  if (isImageContentType || looksLikeImageBytes) {
+    const base64 = buffer.toString("base64");
+    let mimeType = detectImageMimeType(base64);
+    if (!mimeType && contentType.startsWith("image/")) mimeType = contentType.split(";")[0]!.trim();
+    if (!mimeType) mimeType = "image/png";
+    return { base64, mimeType, ext: imageExtensionFromMimeType(mimeType) };
+  }
+
+  let data: { choices?: Array<{ message?: unknown; finish_reason?: string }>; error?: unknown };
+  try {
+    data = JSON.parse(buffer.toString("utf8")) as typeof data;
+  } catch {
+    throw new Error(
+      `OpenRouter returned unparseable response (content-type: ${contentType || "unknown"}, first 80 bytes hex: ${buffer.subarray(0, 80).toString("hex")})`,
+    );
+  }
+  if (data.error) {
+    throw new Error(`OpenRouter returned an error: ${JSON.stringify(data.error).slice(0, 400)}`);
+  }
+  const choice = data.choices?.[0];
+  const message = choice?.message;
   const imageUrl = extractImageUrlFromMessage(message);
   if (!imageUrl) {
+    logger.warn(
+      "[image-gen] OpenRouter response had no extractable image. model=%s finish_reason=%s shape=%s",
+      request.model ?? "(default)",
+      choice?.finish_reason ?? "(none)",
+      JSON.stringify(message ?? data).slice(0, 800),
+    );
     const content =
       message && typeof message === "object" && typeof (message as Record<string, unknown>).content === "string"
         ? ((message as Record<string, string>).content ?? "")
         : "";
-    throw new Error(`No image data in OpenRouter response: ${content.slice(0, 200)}`);
+    const messageKeys =
+      message && typeof message === "object" ? Object.keys(message as Record<string, unknown>).join(",") : "(no message)";
+    throw new Error(
+      `No image data in OpenRouter response (finish_reason=${choice?.finish_reason ?? "none"}, message keys=[${messageKeys}], content="${content.slice(0, 200)}")`,
+    );
   }
 
   return downloadImageUrl(imageUrl, request.allowLocalUrls);


### PR DESCRIPTION
## Linked issue

Closes #1026

## Why this change

OpenRouter's image-generation endpoint surfaces several response shapes depending on the underlying provider and the model's \`modalities\` config, and Marinara's current parser only handles the chat-completions JSON envelope cleanly. Two real failure modes today:

1. **Raw image bytes.** Some OpenRouter image models (raw provider passthrough) return PNG / JPEG / GIF / WEBP bytes directly with an \`image/*\` content-type instead of a JSON envelope. The current \`await resp.json()\` throws \`SyntaxError: Unexpected token ... is not valid JSON\` and the user sees a JSON-parse crash instead of an image.
2. **JSON envelope with no image (model refusal, text-only response, etc.).** The existing \"no image\" error message is just \`No image data in OpenRouter response: <first 200 chars>\` with no \`finish_reason\`, no shape hint, and no log line. There is no way to tell from this error whether the issue is a wrong API key, a model that doesn't support image output, a prompt that was refused, or a misconfigured \`modalities\` setting.
3. **Gzipped responses.** OpenRouter sometimes returns \`Content-Encoding: gzip\` from upstream providers. The shared \`imageFetch\` helper does not set \`decodeCompressedResponse: true\`, so those buffers fail the JSON-parse path even when the underlying payload is a valid envelope.

This PR is the split-out half of #970 that the reviewer asked to move into its own change.

## What changed

\`packages/server/src/services/image/image-generation.ts\`:

- \`generateOpenRouter\`: read the response into a \`Buffer\` first, then sniff the content-type and magic bytes. If it looks like an image, base64-encode it and return directly via the existing \`detectImageMimeType\` / \`imageExtensionFromMimeType\` helpers.
- Otherwise parse as JSON. If the parse fails, throw an error that includes the content-type and the first 80 bytes (hex) so the user can immediately tell what shape they actually received.
- If the JSON has a top-level \`error\` field, surface it verbatim (truncated to 400 chars).
- If JSON parses but no image URL is extractable, log the full message shape via \`logger.warn\` (model, \`finish_reason\`, first 800 chars of the message body) and throw an error that includes \`finish_reason\` and the message-object keys.
- Enable \`decodeCompressedResponse: true\` on the shared \`imageFetch\` helper so gzipped responses are decoded transparently. The other image-related callers already work on decoded buffers, so this is a no-op for them.
- Add the missing \`import { logger }\` referenced by the new \`logger.warn\` call.

No behavior change for OpenRouter responses that were already producing images successfully — the new path only branches on the response shape.

## Validation

- [x] \`pnpm check\` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed \`CONTRIBUTING.md\`

> Only ticking \`pnpm check\` because it is a deterministic command result that this agent ran on the final commit. The manual-verification boxes are intentionally left unchecked per the AI-Generated PR guidance — those are a to-do list for the human contributor and reviewer, not evidence that work is done. The work I actually exercised is described below as prose.

### What I ran locally (prose, for reviewer reference)

- \`pnpm check\` green on the final commit (\`tsc -b\` + ESLint across shared/server/client; server tsc-noemit; client build).
- Triggered the raw-image-bytes path by pointing the OpenRouter connection at a model that returns a direct PNG response. Without the patch the call crashed with a JSON SyntaxError; with the patch the image was returned and displayed in chat.
- Triggered the \"JSON envelope with no extractable image\" path by sending a refusal-likely prompt; the error message now reports \`finish_reason\` and the message-object keys, and a \`logger.warn\` line is written with the full shape.

**Manual verification a reviewer should still do** (these are paths I could not easily fixture locally):

- Verify a gzipped OpenRouter response still parses correctly end-to-end — I enabled \`decodeCompressedResponse: true\` but did not have a gzipped fixture handy. Worth running one OpenRouter call through a debug proxy that forces \`Content-Encoding: gzip\`.
- Sanity-check that no other image-flow caller (Stability AI, Pollinations, custom OpenAI-compatible, NovelAI, ComfyUI, AUTOMATIC1111, etc.) regresses with \`decodeCompressedResponse: true\` on the shared helper. Those callers already work on decoded buffers, but the flag is shared, so worth a smoke test in CI.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

Purely a server-side parser hardening. No docs or release-metadata changes.

## UI evidence (if applicable)

No UI surface touched.

## Note on relationship to #970

#970 (Draw Things) was originally a single combined PR with these OpenRouter parsing improvements bundled in. Per the reviewer's call to split unrelated work, those OpenRouter changes have been pulled out into this PR; #970 now only contains Draw Things support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)