### PR TITLE
Fix Quest Board state reversion after tracker updates

### DIFF
--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -11,6 +11,7 @@ import { chatBackgroundMetadataToUrl } from "../lib/backgrounds";
 import { agentKeys } from "./use-agents";
 import type { PendingCardUpdate } from "../stores/agent.store";
 import {
+  applyQuestUpdatesToPlayerStats,
   EDITABLE_CHARACTER_CARD_FIELDS,
   type CharacterCardFieldUpdate,
   type EditableCharacterCardField,
@@ -1065,7 +1066,7 @@ export function useGenerate() {
               // Apply quest updates directly so the widget updates immediately
               if (result.success && result.agentType === "quest" && result.data) {
                 const qd = result.data as Record<string, unknown>;
-                const updates = (qd.updates as any[]) ?? [];
+                const updates = Array.isArray(qd.updates) ? qd.updates : [];
                 console.warn(`[Agent] Quest data:`, qd);
                 console.warn(`[Agent] Quest updates: ${updates.length} update(s)`, updates);
                 if (updates.length > 0) {
@@ -1079,28 +1080,11 @@ export function useGenerate() {
                     activeQuests: [],
                     status: "",
                   };
-                  const quests: any[] = [...(existing.activeQuests ?? [])];
-                  for (const u of updates) {
-                    const idx = quests.findIndex((q: any) => q.name === u.questName);
-                    if (u.action === "create" && idx === -1) {
-                      quests.push({
-                        questEntryId: u.questName,
-                        name: u.questName,
-                        currentStage: 0,
-                        objectives: u.objectives ?? [],
-                        completed: false,
-                      });
-                    } else if (idx !== -1) {
-                      if (u.action === "update" && u.objectives) quests[idx].objectives = u.objectives;
-                      else if (u.action === "complete") {
-                        quests[idx].completed = true;
-                        if (u.objectives) quests[idx].objectives = u.objectives;
-                      } else if (u.action === "fail") quests.splice(idx, 1);
-                    }
-                  }
+                  const questMerge = applyQuestUpdatesToPlayerStats(existing, updates);
+                  const quests = questMerge.quests;
                   const merged = cur
-                    ? { ...cur, playerStats: { ...existing, activeQuests: quests } }
-                    : { playerStats: { ...existing, activeQuests: quests } };
+                    ? { ...cur, playerStats: questMerge.playerStats }
+                    : { playerStats: questMerge.playerStats };
                   console.warn(`[Agent] Quest merge result — activeQuests:`, quests);
                   setGameState(merged as any);
                 } else {
@@ -1897,7 +1881,7 @@ export function useGenerate() {
                 // Apply quest updates directly so the widget updates immediately
                 if (result.agentType === "quest") {
                   const qd = result.data as Record<string, unknown>;
-                  const updates = (qd.updates as any[]) ?? [];
+                  const updates = Array.isArray(qd.updates) ? qd.updates : [];
                   if (updates.length > 0) {
                     const cur = useGameStateStore.getState().current;
                     const existing = cur?.playerStats ?? {
@@ -1908,28 +1892,10 @@ export function useGenerate() {
                       activeQuests: [],
                       status: "",
                     };
-                    const quests: any[] = [...(existing.activeQuests ?? [])];
-                    for (const u of updates) {
-                      const idx = quests.findIndex((q: any) => q.name === u.questName);
-                      if (u.action === "create" && idx === -1) {
-                        quests.push({
-                          questEntryId: u.questName,
-                          name: u.questName,
-                          currentStage: 0,
-                          objectives: u.objectives ?? [],
-                          completed: false,
-                        });
-                      } else if (idx !== -1) {
-                        if (u.action === "update" && u.objectives) quests[idx].objectives = u.objectives;
-                        else if (u.action === "complete") {
-                          quests[idx].completed = true;
-                          if (u.objectives) quests[idx].objectives = u.objectives;
-                        } else if (u.action === "fail") quests.splice(idx, 1);
-                      }
-                    }
+                    const questMerge = applyQuestUpdatesToPlayerStats(existing, updates);
                     const merged = cur
-                      ? { ...cur, playerStats: { ...existing, activeQuests: quests } }
-                      : { playerStats: { ...existing, activeQuests: quests } };
+                      ? { ...cur, playerStats: questMerge.playerStats }
+                      : { playerStats: questMerge.playerStats };
                     setGameState(merged as any);
                   }
                 }

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -20,6 +20,8 @@ import {
   LIMITS,
   coerceGameStateTextValue,
   appendChatSummaryEntryToMetadata,
+  applyQuestUpdatesToPlayerStats,
+  buildQuestJournalData,
 } from "@marinara-engine/shared";
 import type {
   AgentContext,
@@ -8081,7 +8083,7 @@ export async function generateRoutes(app: FastifyInstance) {
             if (result.success && result.type === "quest_update" && result.data && typeof result.data === "object") {
               try {
                 const qData = result.data as Record<string, unknown>;
-                const updates = (qData.updates as any[]) ?? [];
+                const updates = Array.isArray(qData.updates) ? qData.updates : [];
                 logger.debug(
                   "[generate] Quest agent result — updates: %d, data keys: %s %s",
                   updates.length,
@@ -8102,46 +8104,14 @@ export async function generateRoutes(app: FastifyInstance) {
                       ? JSON.parse(snap.playerStats)
                       : snap.playerStats
                     : { stats: [], attributes: null, skills: {}, inventory: [], activeQuests: [], status: "" };
-                  const originalQuests: any[] = existingPS.activeQuests ?? [];
-                  const quests: any[] = [...originalQuests];
-                  for (const u of updates) {
-                    const idx = quests.findIndex((q: any) => q.name === u.questName);
-                    if (u.action === "create" && idx === -1) {
-                      quests.push({
-                        questEntryId: u.questName,
-                        name: u.questName,
-                        currentStage: 0,
-                        objectives: u.objectives ?? [],
-                        completed: false,
-                      });
-                    } else if (idx !== -1) {
-                      if (u.action === "update") {
-                        if (u.objectives) quests[idx].objectives = u.objectives;
-                      } else if (u.action === "complete") {
-                        quests[idx].completed = true;
-                        if (u.objectives) quests[idx].objectives = u.objectives;
-                      } else if (u.action === "fail") {
-                        quests.splice(idx, 1);
-                      }
-                    }
-                  }
-                  // Auto-remove quests that are fully completed (all objectives done)
-                  for (let i = quests.length - 1; i >= 0; i--) {
-                    const q = quests[i];
-                    if (
-                      q.completed &&
-                      Array.isArray(q.objectives) &&
-                      q.objectives.length > 0 &&
-                      q.objectives.every((o: any) => o.completed)
-                    ) {
-                      quests.splice(i, 1);
-                    }
-                  }
+                  const questMerge = applyQuestUpdatesToPlayerStats(existingPS, updates, {
+                    autoRemoveFullyCompleted: true,
+                  });
+                  const { quests } = questMerge;
 
                   // Only persist + send if quests actually changed
-                  const changed = JSON.stringify(quests) !== JSON.stringify(originalQuests);
-                  if (changed) {
-                    const mergedPS = { ...existingPS, activeQuests: quests };
+                  if (questMerge.changed) {
+                    const mergedPS = questMerge.playerStats;
                     if (snap) {
                       await app.db
                         .update(gameStateSnapshotsTable)
@@ -8154,25 +8124,14 @@ export async function generateRoutes(app: FastifyInstance) {
                     );
 
                     // Auto-populate journal: quest updates
-                    for (const u of updates) {
-                      const questData = {
-                        id: u.questName,
-                        name: u.questName,
-                        status: (u.action === "complete" ? "completed" : u.action === "fail" ? "failed" : "active") as
-                          | "active"
-                          | "completed"
-                          | "failed",
-                        description: u.description || u.questName,
-                        objectives: (u.objectives ?? []).map((o: any) =>
-                          typeof o === "string" ? o : o.text || o.description || "",
-                        ),
-                      };
+                    for (const u of questMerge.updates) {
+                      const questData = buildQuestJournalData(u);
                       updateJournal(app.db, input.chatId, (j) => upsertQuest(j, questData));
                     }
                   }
                 }
-              } catch {
-                // Non-critical
+              } catch (err) {
+                logger.warn(err, "[generate] Quest tracker persistence failed");
               }
             }
 

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -4,6 +4,7 @@ import {
   BUILT_IN_AGENTS,
   BUILT_IN_TOOLS,
   DEFAULT_AGENT_TOOLS,
+  applyQuestUpdatesToPlayerStats,
   getDefaultBuiltInAgentSettings,
   type AgentContext,
   type AgentResult,
@@ -1612,7 +1613,7 @@ async function applyRetryResultEffects(args: {
     if (result.success && result.type === "quest_update" && result.data && typeof result.data === "object") {
       try {
         const qData = result.data as Record<string, unknown>;
-        const updates = (qData.updates as any[]) ?? [];
+        const updates = Array.isArray(qData.updates) ? qData.updates : [];
         logger.debug(
           "[retry-agents] Quest agent result — updates: %d, data keys: %s %s",
           updates.length,
@@ -1626,32 +1627,10 @@ async function applyRetryResultEffects(args: {
               ? JSON.parse(snap.playerStats)
               : snap.playerStats
             : { stats: [], attributes: null, skills: {}, inventory: [], activeQuests: [], status: "" };
-          const originalQuests: any[] = existingPS.activeQuests ?? [];
-          const quests: any[] = [...originalQuests];
-          for (const update of updates) {
-            const idx = quests.findIndex((quest: any) => quest.name === update.questName);
-            if (update.action === "create" && idx === -1) {
-              quests.push({
-                questEntryId: update.questName,
-                name: update.questName,
-                currentStage: 0,
-                objectives: update.objectives ?? [],
-                completed: false,
-              });
-            } else if (idx !== -1) {
-              if (update.action === "update") {
-                if (update.objectives) quests[idx].objectives = update.objectives;
-              } else if (update.action === "complete") {
-                quests[idx].completed = true;
-                if (update.objectives) quests[idx].objectives = update.objectives;
-              } else if (update.action === "fail") {
-                quests.splice(idx, 1);
-              }
-            }
-          }
-          const changed = JSON.stringify(quests) !== JSON.stringify(originalQuests);
-          if (changed) {
-            const mergedPS = { ...existingPS, activeQuests: quests };
+          const questMerge = applyQuestUpdatesToPlayerStats(existingPS, updates);
+          const { quests } = questMerge;
+          if (questMerge.changed) {
+            const mergedPS = questMerge.playerStats;
             if (snap) {
               await app.db
                 .update(gameStateSnapshotsTable)
@@ -1661,8 +1640,8 @@ async function applyRetryResultEffects(args: {
             sendSseEvent(reply, { type: "game_state_patch", data: { playerStats: { activeQuests: quests } } });
           }
         }
-      } catch {
-        // Non-critical patching failure.
+      } catch (err) {
+        logger.warn(err, "[retry-agents] Quest tracker persistence failed");
       }
     }
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -62,3 +62,4 @@ export * from "./utils/lorebook-keyword-matching.js";
 export * from "./utils/regex-safety.js";
 export * from "./utils/game-state-text.js";
 export * from "./utils/chat-summary-entries.js";
+export * from "./utils/quest-state.js";

--- a/packages/shared/src/utils/quest-state.ts
+++ b/packages/shared/src/utils/quest-state.ts
@@ -256,8 +256,7 @@ export function applyQuestUpdatesToPlayerStats(
       const quest = quests[index]!;
       if (
         quest.completed &&
-        quest.objectives.length > 0 &&
-        quest.objectives.every((objective) => objective.completed)
+        (quest.objectives.length === 0 || quest.objectives.every((objective) => objective.completed))
       ) {
         quests.splice(index, 1);
       }

--- a/packages/shared/src/utils/quest-state.ts
+++ b/packages/shared/src/utils/quest-state.ts
@@ -1,0 +1,290 @@
+import type { PlayerStats, QuestProgress } from "../types/game-state.js";
+
+type QuestObjective = QuestProgress["objectives"][number];
+
+export type QuestUpdateAction = "create" | "update" | "complete" | "fail";
+
+export interface NormalizedQuestUpdate {
+  action: QuestUpdateAction;
+  questName: string;
+  description?: string;
+  objectives?: QuestObjective[];
+  rewards?: string[];
+  notes?: string;
+}
+
+export interface QuestMergeResult {
+  updates: NormalizedQuestUpdate[];
+  originalQuests: QuestProgress[];
+  quests: QuestProgress[];
+  playerStats: PlayerStats & Record<string, unknown>;
+  changed: boolean;
+}
+
+const DEFAULT_PLAYER_STATS: PlayerStats = {
+  stats: [],
+  attributes: null,
+  skills: {},
+  inventory: [],
+  activeQuests: [],
+  status: "",
+};
+
+const NESTED_OBJECTIVE_KEYS = ["objectives", "tasks", "steps", "items", "subtasks", "children", "goals"] as const;
+const NESTED_QUEST_KEYS = ["quests", "activeQuests", "groups", "items", "children"] as const;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function firstString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value !== "string") continue;
+    const trimmed = value.trim();
+    if (trimmed) return trimmed;
+  }
+  return undefined;
+}
+
+function normalizeQuestAction(value: unknown): QuestUpdateAction | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "completed") return "complete";
+  if (normalized === "failed") return "fail";
+  return normalized === "create" || normalized === "update" || normalized === "complete" || normalized === "fail"
+    ? normalized
+    : null;
+}
+
+function normalizeCompleted(value: unknown): boolean {
+  if (value === true) return true;
+  if (typeof value !== "string") return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized === "complete" || normalized === "completed" || normalized === "done" || normalized === "true";
+}
+
+function normalizeObjective(value: unknown): QuestObjective | null {
+  if (typeof value === "string") {
+    const text = value.trim();
+    return text ? { text, completed: false } : null;
+  }
+  if (!isRecord(value)) return null;
+
+  const text = firstString(value.text, value.description, value.objective, value.name, value.title);
+  if (!text) return null;
+  return { text, completed: normalizeCompleted(value.completed ?? value.status ?? value.done) };
+}
+
+function collectNestedObjectives(value: Record<string, unknown>, depth: number): QuestObjective[] {
+  const nested: QuestObjective[] = [];
+  for (const key of NESTED_OBJECTIVE_KEYS) {
+    if (value[key] === undefined) continue;
+    nested.push(...collectObjectives(value[key], depth + 1));
+  }
+  return nested;
+}
+
+function collectObjectives(value: unknown, depth = 0): QuestObjective[] {
+  if (value == null || depth > 5) return [];
+
+  if (Array.isArray(value)) {
+    return value.flatMap((entry) => collectObjectives(entry, depth + 1));
+  }
+
+  if (isRecord(value)) {
+    const nested = collectNestedObjectives(value, depth);
+    if (nested.length > 0) return nested;
+  }
+
+  const direct = normalizeObjective(value);
+  if (direct) return [direct];
+
+  if (!isRecord(value)) return [];
+  return Object.values(value).flatMap((entry) => collectObjectives(entry, depth + 1));
+}
+
+function normalizeObjectives(value: unknown): QuestObjective[] | undefined {
+  if (value === undefined || value === null) return undefined;
+  return collectObjectives(value);
+}
+
+function cloneQuest(quest: QuestProgress): QuestProgress {
+  return {
+    ...quest,
+    objectives: quest.objectives.map((objective) => ({ ...objective })),
+  };
+}
+
+function hasQuestProgressFields(value: Record<string, unknown>): boolean {
+  return (
+    value.questEntryId !== undefined ||
+    value.objectives !== undefined ||
+    value.currentStage !== undefined ||
+    value.completed !== undefined
+  );
+}
+
+function normalizeQuestProgress(value: unknown, fallbackName?: string): QuestProgress | null {
+  if (!isRecord(value)) return null;
+
+  const explicitName = firstString(value.name, value.questName, value.title, value.questEntryId);
+  const name = explicitName ?? (hasQuestProgressFields(value) ? firstString(fallbackName) : undefined);
+  if (!name) return null;
+
+  const rawStage = value.currentStage;
+  const currentStage = typeof rawStage === "number" && Number.isFinite(rawStage) ? rawStage : 0;
+  const questEntryId = firstString(value.questEntryId, value.id, name) ?? name;
+
+  return {
+    ...value,
+    questEntryId,
+    name,
+    currentStage,
+    objectives: normalizeObjectives(value.objectives) ?? [],
+    completed: value.completed === true,
+  } as QuestProgress;
+}
+
+function collectNestedQuests(value: Record<string, unknown>, depth: number): QuestProgress[] {
+  const nested: QuestProgress[] = [];
+  for (const key of NESTED_QUEST_KEYS) {
+    if (value[key] === undefined) continue;
+    nested.push(...normalizeQuestCollectionForQuestMerge(value[key], depth + 1));
+  }
+  return nested;
+}
+
+export function normalizeQuestCollectionForQuestMerge(value: unknown, depth = 0): QuestProgress[] {
+  if (value == null || depth > 5) return [];
+
+  if (Array.isArray(value)) {
+    return value.flatMap((entry) => normalizeQuestCollectionForQuestMerge(entry, depth + 1));
+  }
+
+  if (!isRecord(value)) return [];
+
+  const nested = collectNestedQuests(value, depth);
+  if (nested.length > 0) return nested;
+
+  const singleQuest = normalizeQuestProgress(value);
+  if (singleQuest) return [singleQuest];
+
+  return Object.entries(value).flatMap(([key, entry]) => {
+    const keyedQuest = normalizeQuestProgress(entry, key);
+    return keyedQuest ? [keyedQuest] : normalizeQuestCollectionForQuestMerge(entry, depth + 1);
+  });
+}
+
+function normalizeQuestUpdate(value: unknown): NormalizedQuestUpdate | null {
+  if (!isRecord(value)) return null;
+
+  const action = normalizeQuestAction(value.action);
+  const questName = firstString(value.questName, value.name, value.title, value.questEntryId);
+  if (!action || !questName) return null;
+
+  const objectives = normalizeObjectives(value.objectives);
+  const rewards = Array.isArray(value.rewards)
+    ? value.rewards.flatMap((reward) => {
+        const text = firstString(reward);
+        return text ? [text] : [];
+      })
+    : undefined;
+
+  return {
+    action,
+    questName,
+    description: firstString(value.description),
+    ...(objectives !== undefined ? { objectives } : {}),
+    ...(rewards !== undefined ? { rewards } : {}),
+    notes: firstString(value.notes),
+  };
+}
+
+export function normalizeQuestUpdates(value: unknown): NormalizedQuestUpdate[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((entry) => {
+    const update = normalizeQuestUpdate(entry);
+    return update ? [update] : [];
+  });
+}
+
+export function normalizePlayerStatsForQuestMerge(value: unknown): PlayerStats & Record<string, unknown> {
+  const existing = isRecord(value) ? value : {};
+  return {
+    ...DEFAULT_PLAYER_STATS,
+    ...existing,
+    activeQuests: normalizeQuestCollectionForQuestMerge(existing.activeQuests),
+  };
+}
+
+export function applyQuestUpdatesToPlayerStats(
+  value: unknown,
+  updatesValue: unknown,
+  options: { autoRemoveFullyCompleted?: boolean } = {},
+): QuestMergeResult {
+  const updates = normalizeQuestUpdates(updatesValue);
+  const rawActiveQuests = isRecord(value) ? value.activeQuests : undefined;
+  const rawActiveQuestsJson = JSON.stringify(rawActiveQuests ?? []);
+  const playerStats = normalizePlayerStatsForQuestMerge(value);
+  const originalQuests = playerStats.activeQuests.map(cloneQuest);
+  const quests = originalQuests.map(cloneQuest);
+
+  for (const update of updates) {
+    const idx = quests.findIndex((quest) => quest.name === update.questName || quest.questEntryId === update.questName);
+    if (update.action === "create" && idx === -1) {
+      quests.push({
+        questEntryId: update.questName,
+        name: update.questName,
+        currentStage: 0,
+        objectives: update.objectives ?? [],
+        completed: false,
+      });
+    } else if (idx !== -1) {
+      if (update.action === "update") {
+        if (update.objectives !== undefined) quests[idx]!.objectives = update.objectives;
+      } else if (update.action === "complete") {
+        quests[idx]!.completed = true;
+        if (update.objectives !== undefined) quests[idx]!.objectives = update.objectives;
+      } else if (update.action === "fail") {
+        quests.splice(idx, 1);
+      }
+    }
+  }
+
+  if (options.autoRemoveFullyCompleted === true) {
+    for (let index = quests.length - 1; index >= 0; index--) {
+      const quest = quests[index]!;
+      if (
+        quest.completed &&
+        quest.objectives.length > 0 &&
+        quest.objectives.every((objective) => objective.completed)
+      ) {
+        quests.splice(index, 1);
+      }
+    }
+  }
+
+  return {
+    updates,
+    originalQuests,
+    quests,
+    playerStats: { ...playerStats, activeQuests: quests },
+    changed: JSON.stringify(quests) !== rawActiveQuestsJson,
+  };
+}
+
+export function buildQuestJournalData(update: NormalizedQuestUpdate): {
+  id: string;
+  name: string;
+  status: "active" | "completed" | "failed";
+  description: string;
+  objectives: string[];
+} {
+  return {
+    id: update.questName,
+    name: update.questName,
+    status: update.action === "complete" ? "completed" : update.action === "fail" ? "failed" : "active",
+    description: update.description || update.questName,
+    objectives: (update.objectives ?? []).map((objective) => objective.text),
+  };
+}


### PR DESCRIPTION
## Linked issue

Closes #1033 

## Why this change

- The Quest Board HUD could briefly show the quest tracker agent's newest updates, then revert at the end of the turn when the authoritative game-state patch arrived.
- The original report in #1002 suspected sampling/JSON adherence, but investigation found a state merge bug: client optimistic updates and server persistence handled legacy/grouped quest shapes differently.
- Fixing the merge path reduces the need to solve this specific Quest Board reversion by changing agent sampling settings.

## What changed

- Added a shared quest-state merge helper for client and server quest tracker updates.
- Normalized legacy/grouped `activeQuests` shapes, keyed quest maps, grouped objective containers, and object-shaped objective payloads before writing `playerStats.activeQuests`.
- Updated normal generation, retry-agent persistence, and client optimistic Quest Board updates to use the same shared merge behavior.
- Preserved server-side completed-quest auto-removal for normal generation while keeping client optimistic updates immediate.

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Focused `tsx` smokes passed for keyed quest maps, nested keyed maps, object-shaped objectives, grouped arrays, and completed quest auto-removal.
- `pnpm --filter @marinara-engine/shared lint` passed.
- `pnpm --filter @marinara-engine/client lint` passed.
- `pnpm --filter @marinara-engine/server lint` passed.
- `pnpm --filter @marinara-engine/client build` passed.
- `git diff --check` passed with line-ending warnings only.
- Browser smoke pass used a disposable RP chat and confirmed Quest Board counts stayed aligned with `/game-state`; no browser console warnings/errors were observed.
- Still needs human verification during a real RP generation with more than three objectives/groups before marking ready.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

Not attached yet. A human RP verification pass should add screenshot/recording evidence before this draft is marked ready.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved quest state handling to use shared utilities for consistent processing across the application.
  * Enhanced quest tracking with automatic removal of fully completed quests.
  * Added improved error handling for quest update persistence with clearer logging.
  * Standardized quest data normalization for better internal consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1028?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->