### PR TITLE
Fix custom agent prompt section freshness

### DIFF
--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -710,6 +710,54 @@ function toRuntimeAgentSectionType(
   return eligibleAgentTypes.has(agentType) ? agentType : null;
 }
 
+function parseRuntimeAgentSettings(settings: unknown): Record<string, unknown> {
+  if (!settings) return {};
+  if (typeof settings === "string") {
+    try {
+      const parsed = JSON.parse(settings) as unknown;
+      return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+        ? (parsed as Record<string, unknown>)
+        : {};
+    } catch {
+      return {};
+    }
+  }
+  return typeof settings === "object" && !Array.isArray(settings) ? (settings as Record<string, unknown>) : {};
+}
+
+export function buildRuntimeAgentSectionEligibleTypesForTest(input: {
+  enableAgents: boolean;
+  activeAgentIds: string[];
+  configuredAgents?: Array<{ type: string; phase: string; settings?: unknown }>;
+}): Set<RuntimeAgentSectionType> {
+  const eligible = new Set<RuntimeAgentSectionType>();
+  if (!input.enableAgents || input.activeAgentIds.length === 0) return eligible;
+
+  const activeAgentIds = new Set(input.activeAgentIds);
+
+  for (const agent of BUILT_IN_AGENTS) {
+    if (!activeAgentIds.has(agent.id)) continue;
+    if (agent.phase !== "pre_generation" || agent.id === "html") continue;
+    if (
+      resolveAgentResultType({ type: agent.id, settings: getDefaultBuiltInAgentSettings(agent.id) }) !==
+      "context_injection"
+    ) {
+      continue;
+    }
+    eligible.add(agent.id);
+  }
+
+  for (const agent of input.configuredAgents ?? []) {
+    if (!activeAgentIds.has(agent.type)) continue;
+    if (agent.phase !== "pre_generation" || agent.type === "html") continue;
+    const settings = parseRuntimeAgentSettings(agent.settings);
+    if (resolveAgentResultType({ type: agent.type, settings }) !== "context_injection") continue;
+    eligible.add(agent.type);
+  }
+
+  return eligible;
+}
+
 function makeRuntimeAgentSectionTokens(agentType: RuntimeAgentSectionType, nonce: string): RuntimeAgentSectionTokens {
   return {
     placeholder: `${RUNTIME_AGENT_SECTION_TOKEN_PREFIX}${nonce}__${agentType}__VALUE__`,
@@ -1406,16 +1454,18 @@ export async function generateRoutes(app: FastifyInstance) {
         const chatActiveAgentIds: string[] = filterGameInternalAgentIds(chatMode, persistedChatActiveAgentIds).filter(
           (agentId) => !(gameSpotifyMusicEnabled && agentId === "spotify"),
         );
-        const runtimeSectionEligibleAgentTypes = new Set(
-          BUILT_IN_AGENTS.filter(
-            (agent) =>
-              chatActiveAgentIds.includes(agent.id) &&
-              agent.phase === "pre_generation" &&
-              agent.id !== "html" &&
-              resolveAgentResultType({ type: agent.id, settings: getDefaultBuiltInAgentSettings(agent.id) }) ===
-                "context_injection",
-          ).map((agent) => agent.id),
-        );
+        const hasPerChatAgentList = chatActiveAgentIds.length > 0;
+        const perChatAgentSet = new Set(chatActiveAgentIds);
+        const configuredPromptAgents = chatEnableAgents && hasPerChatAgentList ? await agentsStore.list() : [];
+        const runtimeSectionEligibleAgentTypes = buildRuntimeAgentSectionEligibleTypesForTest({
+          enableAgents: chatEnableAgents,
+          activeAgentIds: chatActiveAgentIds,
+          configuredAgents: configuredPromptAgents.map((agent) => ({
+            type: agent.type,
+            phase: agent.phase,
+            settings: agent.settings,
+          })),
+        });
         const chatActiveLorebookIds: string[] = Array.isArray(chatMeta.activeLorebookIds)
           ? (chatMeta.activeLorebookIds as string[])
           : [];
@@ -3073,12 +3123,9 @@ export async function generateRoutes(app: FastifyInstance) {
         // ────────────────────────────────────────
         // Agent Pipeline: resolve enabled agents
         // ────────────────────────────────────────
-        const hasPerChatAgentList = chatActiveAgentIds.length > 0;
-        const perChatAgentSet = new Set(chatActiveAgentIds);
-
         // Only run agents that are explicitly added to the chat.
         // Empty activeAgentIds = no agents (not "all globally-enabled").
-        const enabledConfigs = chatEnableAgents && hasPerChatAgentList ? await agentsStore.list() : [];
+        const enabledConfigs = configuredPromptAgents;
 
         // Build ResolvedAgent array — each agent gets its own provider/model or falls back to chat connection
         const resolvedAgents: ResolvedAgent[] = [];

--- a/packages/server/src/services/prompt/marker-expander.ts
+++ b/packages/server/src/services/prompt/marker-expander.ts
@@ -451,8 +451,9 @@ async function expandAgentData(config: MarkerConfig, ctx: MarkerContext): Promis
   ]);
   if (AUTO_INJECTED_TRACKERS.has(agentType)) return { content: "" };
 
-  // Per-chat active agent filter: if a per-chat list is set, only include agents in that list
-  if (ctx.activeAgentIds.length > 0 && !ctx.activeAgentIds.includes(agentType)) {
+  // Generation only runs agents explicitly added to the chat. If none are active,
+  // prompt sections must not keep replaying the last saved output forever.
+  if (ctx.activeAgentIds.length === 0 || !ctx.activeAgentIds.includes(agentType)) {
     return { content: "" };
   }
 

--- a/packages/server/src/services/prompt/marker-expander.ts
+++ b/packages/server/src/services/prompt/marker-expander.ts
@@ -45,7 +45,7 @@ export interface MarkerContext {
   wrapFormat: WrapFormat;
   /** When false, agent_data markers expand to empty strings */
   enableAgents: boolean;
-  /** Per-chat list of active agent type IDs (empty = use global enabled state) */
+  /** Per-chat list of active agent type IDs (empty = no active agents, marker expansion suppressed) */
   activeAgentIds: string[];
   /** Per-chat list of manually activated lorebook IDs from chat settings */
   activeLorebookIds: string[];


### PR DESCRIPTION
<!-- Target branch: `staging`. The default base in this UI is `main` (release branch). -->
<!-- Change the base to `staging` before submitting unless this is a maintainer-approved mainline change. -->
<!-- See CONTRIBUTING.md § Branches. -->

## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #1034

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- Custom pre-generation agent prompt sections could resolve from the last saved run before the current agent cadence run completed, leaving the prompt section one run behind and replaying stale output after agents were inactive.

## What changed

<!-- List the key changes in this PR -->

- Treat agent-data prompt sections as active-chat-only so inactive chats do not keep replaying the last saved custom agent run.
- Include active custom pre-generation `context_injection` agents in the runtime placeholder path that is filled after the current agent run completes.
- Reuse the preloaded agent config list for prompt-section eligibility and later agent resolution so the two paths stay aligned.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Codex scratch repro before the fix showed inactive and active-without-runtime custom agent prompt sections both contained `PREVIOUS_OUTPUT`, while the runtime replacement path contained `CURRENT_OUTPUT`.
- Codex reran `pnpm --filter @marinara-engine/server exec tsx ../../scratch/issue-1034-agent-section-repro.ts` after the fix. It showed:

```json
{
  "inactiveOutput": "",
  "activeWithoutRuntimeOutput": "<plot_consultant>\n    PREVIOUS_OUTPUT\n</plot_consultant>",
  "activeRouteOutput": "<plot_consultant>\n    CURRENT_OUTPUT\n</plot_consultant>",
  "inactiveCleared": true,
  "customAgentEligible": true,
  "routeRuntimePathWorks": true,
  "nonContextCustomEligible": false,
  "postProcessingCustomEligible": false,
  "edgeCasesPassed": true
}
```

- Codex ran `pnpm check`; it passed.
- Bunny review pass ran before opening this draft PR; no blocking findings.
- No human-only verification blocker identified for the core prompt-assembly claim.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

N/A - backend prompt assembly behavior, verified with a focused scratch repro.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced agent eligibility logic to properly evaluate both built-in and per-chat configured agents for prompt injection, ensuring accurate availability based on configuration.
  * Refined active agent filtering to ensure only explicitly enabled agents contribute their derived content when processing prompts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1043?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->