### PR TITLE
Fix NPC portrait slugs for non-ASCII names

### DIFF
--- a/packages/server/src/services/game/game-asset-generation.ts
+++ b/packages/server/src/services/game/game-asset-generation.ts
@@ -189,10 +189,15 @@ export function readAvatarBase64(avatarPath: string | null | undefined): string 
 
 /** Sanitise a name into a safe filesystem slug. */
 function safeName(name: string): string {
-  return name
+  const trimmed = name.trim();
+  const slug = trimmed
     .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/(^-|-$)/g, "");
+  if (slug || !trimmed) return slug;
+  return `asset-${createHash("sha256").update(trimmed).digest("hex").slice(0, 8)}`;
 }
 
 function truncateSlugByBytes(slug: string, maxBytes: number): string {


### PR DESCRIPTION
<!-- Target branch: `staging`. The default base in this UI is `main` (release branch). -->
<!-- Change the base to `staging` before submitting unless this is a maintainer-approved mainline change. -->
<!-- See CONTRIBUTING.md § Branches. -->

## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #1039

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- NPC portrait generation could skip image generation entirely when an NPC name used only non-ASCII characters because the generated filename slug was empty.

## What changed

<!-- List the key changes in this PR -->

- Normalized generated asset slugs through `NFKD` so simple accented names can fold to readable ASCII slugs.
- Added a deterministic `asset-<hash>` fallback for non-empty names that still collapse to an empty slug.
- Kept empty/whitespace-only names returning an empty slug so existing invalid-name behavior is preserved.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Codex reproduced the bug with `pnpm --filter @marinara-engine/server exec tsx ../../scratch/issue-1039-npc-safe-name-repro.ts`: `李雷` returned `null`, made `0` image backend requests, and saved no avatar.
- Codex verified the fix with `pnpm --filter @marinara-engine/server exec tsx ../../scratch/issue-1039-npc-safe-name-repro.ts --expect-fixed`: `李雷` generated `/api/avatars/npc/issue-1039-chat/asset-3a47328a.png` after hitting the local fake ComfyUI backend.
- Codex also verified edge cases in the same scratch repro: `Élodie` generated `elodie.png`, `Sir Robin` generated `sir-robin.png`, and a whitespace-only name still returned `null` without backend requests.
- Codex ran `pnpm check`; it passed locally.
- Bunny pre-PR review passed on the current diff.
- No human-only verification blockers for the core claim.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

Docs impact: no docs or release metadata changed.

## UI evidence (if applicable)

N/A - backend/game asset slug generation only; no UI surface changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved asset name sanitization to robustly handle edge cases. Whitespace-only input strings now reliably generate deterministic fallback identifiers instead of returning empty values, ensuring more consistent and predictable behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1044?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->