### PR TITLE
Fix group prompt target lorebook scope

### DIFF
--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -159,6 +159,7 @@ import {
   preserveTrackerCharacterUiFields,
   resolveActiveCharacterIds,
   resolveBaseUrl,
+  resolvePromptCharacterIdsForTarget,
   resolveRegenerationGameStateFallbackMessageIds,
   resolveRegenerationGameStateAnchor,
   resolveUserRegenerationPersistentAttachments,
@@ -919,7 +920,7 @@ export async function generateRoutes(app: FastifyInstance) {
       if (regenCandidate?.chatId === input.chatId) {
         const replay = normalizeGenerationReplay(parseExtra(regenCandidate.extra).generationReplay);
         applyGenerationReplayToRegenerateInput(input, replay);
-        if (!input.forCharacterId && earlyMeta.groupResponseOrder === "manual" && regenCandidate.characterId) {
+        if (!input.forCharacterId && regenCandidate.characterId) {
           input.forCharacterId = regenCandidate.characterId;
         }
       }
@@ -1440,13 +1441,11 @@ export async function generateRoutes(app: FastifyInstance) {
               ? "individual"
               : "merged"
             : ((chatMeta.groupChatMode as string) ?? "merged");
-        const manualPromptTargetCharId =
-          promptGroupResponseOrder === "manual" &&
-          typeof input.forCharacterId === "string" &&
-          characterIds.includes(input.forCharacterId)
+        const promptTargetCharacterId =
+          typeof input.forCharacterId === "string" && characterIds.includes(input.forCharacterId)
             ? input.forCharacterId
             : null;
-        const promptCharacterIds = manualPromptTargetCharId ? [manualPromptTargetCharId] : characterIds;
+        const promptCharacterIds = resolvePromptCharacterIdsForTarget(characterIds, promptTargetCharacterId);
         const deferCharacterMacros =
           characterIds.length > 1 &&
           promptGroupChatMode === "individual" &&
@@ -3501,8 +3500,8 @@ export async function generateRoutes(app: FastifyInstance) {
         // in the <party> section, so skip fallback injection to avoid duplication.
         if (shouldInjectIdentityFallback({ chatMode, presetId })) {
           const allContent = finalMessages.map((m) => m.content).join("\n");
-          const fallbackCharInfo = manualPromptTargetCharId
-            ? charInfo.filter((c) => c.id === manualPromptTargetCharId)
+          const fallbackCharInfo = promptTargetCharacterId
+            ? charInfo.filter((c) => c.id === promptTargetCharacterId)
             : charInfo;
           for (const ci of fallbackCharInfo) {
             // Check if this character already appears by description snippet, XML tag, or markdown heading

--- a/packages/server/src/routes/generate/dry-run-route.ts
+++ b/packages/server/src/routes/generate/dry-run-route.ts
@@ -42,6 +42,7 @@ import {
   parseExtra,
   parseStoredGenerationParameters,
   resolveActiveCharacterIds,
+  resolvePromptCharacterIdsForTarget,
   resolveRegenerationGameStateAnchor,
   resolveVisibleGameStateAnchor,
   resolveBaseUrl,
@@ -727,6 +728,10 @@ export async function registerDryRunRoute(app: FastifyInstance) {
       mode: chatMode,
       allowEmpty: true,
     });
+    const promptCharacterIds = resolvePromptCharacterIdsForTarget(
+      characterIds,
+      typeof body.forCharacterId === "string" ? body.forCharacterId : null,
+    );
 
     // Persona resolution (same strategy as generation; read-only)
     let personaId: string | null = null;
@@ -824,7 +829,7 @@ export async function registerDryRunRoute(app: FastifyInstance) {
       requestChoices ?? (isDifferentPresetOverride ? (presetDefaultChoices ?? {}) : chatChoicesFromMeta);
     const promptMacroContext = await buildPromptMacroContext({
       db: app.db,
-      characterIds,
+      characterIds: promptCharacterIds,
       personaName,
       personaDescription,
       personaFields,
@@ -957,8 +962,8 @@ export async function registerDryRunRoute(app: FastifyInstance) {
       })();
 
       const characterBlocks: string[] = [];
-      if (includeCharacters && characterIds.length > 0) {
-        const charRows = await Promise.all(characterIds.map((id) => chars.getById(id)));
+      if (includeCharacters && promptCharacterIds.length > 0) {
+        const charRows = await Promise.all(promptCharacterIds.map((id) => chars.getById(id)));
         for (const row of charRows) {
           if (!row?.data) continue;
           try {
@@ -1027,7 +1032,7 @@ export async function registerDryRunRoute(app: FastifyInstance) {
             }));
             const lorebookResult = await processLorebooks(app.db, scanMessages, null, {
               chatId,
-              characterIds,
+              characterIds: promptCharacterIds,
               personaId,
               activeLorebookIds,
               excludedLorebookIds: lorebookScopeExclusions.excludedLorebookIds,
@@ -1203,7 +1208,7 @@ export async function registerDryRunRoute(app: FastifyInstance) {
         choiceBlocks: choiceBlocks as any,
         chatChoices,
         chatId,
-        characterIds,
+        characterIds: promptCharacterIds,
         personaId,
         personaName,
         personaDescription,
@@ -1320,7 +1325,7 @@ export async function registerDryRunRoute(app: FastifyInstance) {
       }));
       const lorebookResult = await processLorebooks(app.db, scanMessages, null, {
         chatId,
-        characterIds,
+        characterIds: promptCharacterIds,
         personaId,
         activeLorebookIds,
         excludedLorebookIds: lorebookScopeExclusions.excludedLorebookIds,
@@ -1362,7 +1367,7 @@ export async function registerDryRunRoute(app: FastifyInstance) {
     }
 
     if (usePromptParts || !effectivePresetId) {
-      const characterDepthEntries = await collectCharacterDepthPromptEntries(app.db, characterIds, promptMacroContext);
+      const characterDepthEntries = await collectCharacterDepthPromptEntries(app.db, promptCharacterIds, promptMacroContext);
       if (characterDepthEntries.length > 0) {
         finalMessages = injectAtDepth(finalMessages as any, characterDepthEntries) as any;
       }

--- a/packages/server/src/routes/generate/generate-route-utils.ts
+++ b/packages/server/src/routes/generate/generate-route-utils.ts
@@ -214,6 +214,16 @@ export function resolveActiveCharacterIds(
   return characterIds;
 }
 
+export function resolvePromptCharacterIdsForTarget(
+  characterIds: string[],
+  targetCharacterId: string | null | undefined,
+): string[] {
+  if (typeof targetCharacterId === "string" && characterIds.includes(targetCharacterId)) {
+    return [targetCharacterId];
+  }
+  return characterIds;
+}
+
 export function shouldPreferLatestVisibleGameState(input: {
   attachments?: unknown[] | null;
   impersonate?: boolean;


### PR DESCRIPTION
<!-- Target branch: `staging`. The default base in this UI is `main` (release branch). -->
<!-- Change the base to `staging` before submitting unless this is a maintainer-approved mainline change. -->
<!-- See CONTRIBUTING.md § Branches. -->

## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #1022

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- Group chats could assemble a single-character response prompt with the full group character scope, which let other characters' embedded lorebooks activate for the responder.

## What changed

<!-- List the key changes in this PR -->

- Added a shared prompt-scope helper that narrows prompt character IDs when a generation has an explicit target character.
- Applied that scope to `/api/generate` so targeted group responses and regenerations build macros/lorebook scope for the responder instead of the whole group.
- Applied the same scope to dry-run prompt assembly so debug/preview output mirrors targeted generation.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Codex repro: `pnpm --filter @marinara-engine/server exec tsx ../../scratch/issue-1022-repro.ts`
  - Legacy route logic reproduced the bug by keeping `john`, `billy`, and `bob` in scope when the target was `john`.
  - Updated helper returned only `john` for the target response.
  - Edge cases passed: no target keeps the full group scope; invalid target keeps the full group scope.
- Codex baseline: `pnpm check` passed.
- Bunny review: passed locally before opening the PR.
- No human-only verification blocker identified for this route-scope logic change.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs or release metadata changes needed; this is a server prompt-scoping bugfix.

## UI evidence (if applicable)

N/A - backend prompt assembly logic; no UI surface changed.
