### PR TITLE
Fix Consistency Editor JSON repair ellipsis handling

### DIFF
--- a/packages/server/src/services/agents/agent-executor.ts
+++ b/packages/server/src/services/agents/agent-executor.ts
@@ -1426,9 +1426,61 @@ function extractJson(text: string): string {
 
 /** Fix common LLM JSON mistakes: trailing commas, comments, ellipsis placeholders. */
 function repairJson(str: string): string {
-  return str
-    .replace(/\/\/[^\n]*/g, "") // remove single-line comments
-    .replace(/\/\*[\s\S]*?\*\//g, "") // remove multi-line comments
-    .replace(/,\s*([\]\}])/g, "$1") // remove trailing commas before ] or }
-    .replace(/\.\.\.[^"\n]*/g, ""); // remove ... continuations/placeholders
+  try {
+    JSON.parse(str);
+    return str;
+  } catch {
+    return stripJsonRepairTokens(str).replace(/,\s*([\]\}])/g, "$1");
+  }
+}
+
+function stripJsonRepairTokens(str: string): string {
+  let repaired = "";
+  let inString = false;
+  let escaped = false;
+
+  for (let index = 0; index < str.length; index += 1) {
+    const char = str[index] ?? "";
+    const next = str[index + 1];
+    const nextTwo = str.slice(index, index + 3);
+
+    if (inString) {
+      repaired += char;
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inString = true;
+      repaired += char;
+      continue;
+    }
+
+    if (char === "/" && next === "/") {
+      while (index + 1 < str.length && str[index + 1] !== "\n") index += 1;
+      continue;
+    }
+
+    if (char === "/" && next === "*") {
+      index += 2;
+      while (index + 1 < str.length && !(str[index] === "*" && str[index + 1] === "/")) index += 1;
+      index += 1;
+      continue;
+    }
+
+    if (nextTwo === "...") {
+      index += 2;
+      continue;
+    }
+
+    repaired += char;
+  }
+
+  return repaired;
 }


### PR DESCRIPTION
<!-- Target branch: `staging`. The default base in this UI is `main` (release branch). -->
<!-- Change the base to `staging` before submitting unless this is a maintainer-approved mainline change. -->
<!-- See CONTRIBUTING.md § Branches. -->

## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #1037

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- The Consistency Editor JSON repair path could rewrite valid JSON narration strings containing ellipses, such as `"It's... it's very warm,"`, before parsing the response.

## What changed

<!-- List the key changes in this PR -->

- Leave already-valid JSON unchanged before attempting repair.
- Strip JSON repair comments and bare ellipsis placeholders only outside quoted strings.
- Keep trailing-comma repair behavior after placeholder cleanup.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Codex ran `node scratch\issue-1037-repair-json-repro.mjs`; the source-level repro now passes for valid narration ellipses, valid `//` string content, trailing-comma repair, trailing comma plus narration ellipsis, and bare ellipsis placeholders outside strings.
- Codex ran `pnpm check`; it passed. Dependency install used a D: pnpm store/virtual-store because `C:\tmp` did not have enough space for a normal install.
- Not run by Codex: Docker container runtime verification.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

Codex assessment: no docs or release metadata changes are needed for this server-side bugfix.

## UI evidence (if applicable)

N/A - this is a server-side JSON repair bug with no visual UI surface.
