### PR TITLE
Fix OpenRouter remote model metadata

### DIFF
--- a/packages/client/src/components/connections/ConnectionEditor.tsx
+++ b/packages/client/src/components/connections/ConnectionEditor.tsx
@@ -16,6 +16,7 @@ import {
   useFetchModels,
   useSaveConnectionDefaults,
   type ClaudeSubscriptionDiagnosis,
+  type RemoteConnectionModel,
 } from "../../hooks/use-connections";
 import { usePresets } from "../../hooks/use-presets";
 import {
@@ -230,7 +231,7 @@ export function ConnectionEditor() {
   }, [showModelDropdown]);
 
   // Remote models fetched from provider API
-  const [remoteModels, setRemoteModels] = useState<Array<{ id: string; name: string }>>([]);
+  const [remoteModels, setRemoteModels] = useState<RemoteConnectionModel[]>([]);
   const [fetchError, setFetchError] = useState<string | null>(null);
 
   // Populate from server
@@ -361,12 +362,16 @@ export function ConnectionEditor() {
 
   // Merge known models with remote models (remote first, deduped)
   const allModels = useMemo(() => {
-    const knownIds = new Set(providerModels.map((m) => m.id));
-    const uniqueRemote = remoteModels
-      .filter((m) => !knownIds.has(m.id))
-      .map((m) => ({ id: m.id, name: m.name, context: 0, maxOutput: 0, isRemote: true as const }));
-    const known = providerModels.map((m) => ({ ...m, isRemote: false as const }));
-    return [...known, ...uniqueRemote];
+    const remote = remoteModels.map((m) => ({
+      id: m.id,
+      name: m.name,
+      context: m.context ?? 0,
+      maxOutput: m.maxOutput ?? 0,
+      isRemote: true as const,
+    }));
+    const remoteIds = new Set(remote.map((m) => m.id));
+    const known = providerModels.filter((m) => !remoteIds.has(m.id)).map((m) => ({ ...m, isRemote: false as const }));
+    return [...remote, ...known];
   }, [providerModels, remoteModels]);
 
   const filteredModels = useMemo(() => {
@@ -376,8 +381,8 @@ export function ConnectionEditor() {
   }, [allModels, modelSearch]);
 
   const selectedModelInfo = useMemo(() => {
-    return providerModels.find((m) => m.id === localModel) ?? null;
-  }, [providerModels, localModel]);
+    return allModels.find((m) => m.id === localModel) ?? null;
+  }, [allModels, localModel]);
 
   // Clear remote models when provider changes
   useEffect(() => {
@@ -617,7 +622,7 @@ export function ConnectionEditor() {
     }
     fetchModels.mutate(connectionDetailId, {
       onSuccess: (data) => {
-        const result = data as { models: Array<{ id: string; name: string }> };
+        const result = data as { models: RemoteConnectionModel[] };
         setRemoteModels(result.models);
         setShowModelDropdown(true);
         requestAnimationFrame(() => {
@@ -631,9 +636,10 @@ export function ConnectionEditor() {
     });
   }, [connectionDetailId, dirty, handleSave, fetchModels]);
 
-  const selectModel = useCallback((model: { id: string; context?: number }) => {
+  const selectModel = useCallback((model: { id: string; context?: number; maxOutput?: number; isRemote?: boolean }) => {
     setLocalModel(model.id);
     if (model.context) setLocalMaxContext(Number(model.context));
+    if (model.isRemote && model.maxOutput) setLocalMaxTokensOverride(Number(model.maxOutput));
     setShowModelDropdown(false);
     setModelSearch("");
     setDirty(true);
@@ -1247,7 +1253,7 @@ export function ConnectionEditor() {
                               .map((m) => (
                                 <button
                                   key={m.id}
-                                  onClick={() => selectModel({ id: m.id })}
+                                  onClick={() => selectModel({ ...m, isRemote: true })}
                                   className={cn(
                                     "flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left transition-colors hover:bg-[var(--accent)]",
                                     localModel === m.id && "bg-sky-400/5",

--- a/packages/client/src/hooks/use-connections.ts
+++ b/packages/client/src/hooks/use-connections.ts
@@ -120,9 +120,16 @@ export function useTestImageGeneration() {
   });
 }
 
+export type RemoteConnectionModel = {
+  id: string;
+  name: string;
+  context?: number;
+  maxOutput?: number;
+};
+
 export function useFetchModels() {
   return useMutation({
-    mutationFn: (id: string) => api.get<{ models: Array<{ id: string; name: string }> }>(`/connections/${id}/models`),
+    mutationFn: (id: string) => api.get<{ models: RemoteConnectionModel[] }>(`/connections/${id}/models`),
   });
 }
 

--- a/packages/server/src/routes/connections.routes.ts
+++ b/packages/server/src/routes/connections.routes.ts
@@ -893,6 +893,29 @@ export async function connectionsRoutes(app: FastifyInstance) {
 interface RemoteModel {
   id: string;
   name: string;
+  context?: number;
+  maxOutput?: number;
+}
+
+function readProviderMetadataRecord(value: unknown): Record<string, unknown> | null {
+  return !!value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : null;
+}
+
+function readPositiveInteger(value: unknown): number | undefined {
+  const parsed = typeof value === "number" ? value : typeof value === "string" ? Number(value) : NaN;
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : undefined;
+}
+
+function readOpenAICompatibleModelLimits(model: Record<string, unknown>): Pick<RemoteModel, "context" | "maxOutput"> {
+  const topProvider = readProviderMetadataRecord(model.top_provider);
+  const context = readPositiveInteger(model.context_length) ?? readPositiveInteger(topProvider?.context_length);
+  const maxOutput =
+    readPositiveInteger(topProvider?.max_completion_tokens) ?? readPositiveInteger(model.max_completion_tokens);
+
+  return {
+    ...(context ? { context } : {}),
+    ...(maxOutput ? { maxOutput } : {}),
+  };
 }
 
 function normalizeModelsResponse(provider: string, json: Record<string, unknown>): RemoteModel[] {
@@ -972,14 +995,12 @@ function normalizeModelsResponse(provider: string, json: Record<string, unknown>
     default: {
       // OpenAI-compatible: { data: [{ id: "gpt-4o", ... }] }
       // This covers openai, mistral, openrouter, custom
-      const data = (json.data ?? []) as Array<{
-        id?: string;
-        name?: string;
-      }>;
+      const data = (json.data ?? []) as Array<Record<string, unknown> & { id?: string; name?: string }>;
       return data
         .map((m) => ({
           id: m.id ?? "",
           name: m.name ?? m.id ?? "",
+          ...readOpenAICompatibleModelLimits(m),
         }))
         .filter((m) => m.id);
     }


### PR DESCRIPTION
<!-- Target branch: `staging`. The default base in this UI is `main` (release branch). -->
<!-- Change the base to `staging` before submitting unless this is a maintainer-approved mainline change. -->
<!-- See CONTRIBUTING.md § Branches. -->

## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #1031

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- OpenRouter model fetches were discarding `context_length` and `top_provider.max_completion_tokens`, so API-fetched models could appear as unknown-capability models and save with the default 128k context instead of the provider-reported limit.

## What changed

<!-- List the key changes in this PR -->

- Preserved optional `context` and `maxOutput` values when normalizing OpenAI-compatible remote model payloads.
- Updated the connection model fetch hook and editor state to carry fetched model metadata through the client.
- Let API-fetched model selections update the connection context window and the existing max output override when provider metadata supplies those limits.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Codex reproduced the original metadata drop with `packages/server/node_modules/.bin/tsx.cmd scratch/issue-1031-repro.ts --expect-broken` before the fix.
- Codex verified the fix with `packages/server/node_modules/.bin/tsx.cmd scratch/issue-1031-repro.ts --expect-fixed`; the script confirmed the reported OpenRouter payload preserves `context: 1048576` and `maxOutput: 65536`.
- Codex edge cases covered nested `top_provider.context_length` / string numeric limits and plain OpenAI-compatible models with no metadata.
- Codex ran `pnpm check` successfully in the issue worktree.
- Bunny pre-PR review passed for the current diff.
- No true human-only verification blockers for the core claim.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs or release metadata changes were needed.

## UI evidence (if applicable)

N/A. This is a metadata normalization/data-flow fix, not a visual UI change.
