### PR TITLE
Let knowledge agents use chat active lorebooks

### DIFF
--- a/packages/client/src/components/agents/AgentEditor.tsx
+++ b/packages/client/src/components/agents/AgentEditor.tsx
@@ -216,6 +216,7 @@ export function AgentEditor() {
   const [localEnabledTools, setLocalEnabledTools] = useState<string[]>([]);
   const [localSpotifyClientId, setLocalSpotifyClientId] = useState("");
   const [localSourceLorebookIds, setLocalSourceLorebookIds] = useState<string[]>([]);
+  const [localUseChatActiveLorebooks, setLocalUseChatActiveLorebooks] = useState(false);
   const [localSourceFileIds, setLocalSourceFileIds] = useState<string[]>([]);
   const [localAutoGenerateAvatars, setLocalAutoGenerateAvatars] = useState(false);
   const [localAutoGenerateBackgrounds, setLocalAutoGenerateBackgrounds] = useState(false);
@@ -272,6 +273,9 @@ export function AgentEditor() {
       setLocalEnabledTools(settings.enabledTools ?? DEFAULT_AGENT_TOOLS[dbConfig.type] ?? []);
       setLocalSpotifyClientId(settings.spotifyClientId ?? "");
       setLocalSourceLorebookIds(settings.sourceLorebookIds ?? []);
+      setLocalUseChatActiveLorebooks(
+        (settings.useChatActiveLorebooks as boolean | undefined) ?? (defaultSettings.useChatActiveLorebooks === true),
+      );
       setLocalSourceFileIds(settings.sourceFileIds ?? []);
       setLocalAutoGenerateAvatars(settings.autoGenerateAvatars ?? false);
       setLocalAutoGenerateBackgrounds(settings.autoGenerateBackgrounds ?? false);
@@ -296,6 +300,7 @@ export function AgentEditor() {
       setLocalEnabledTools(DEFAULT_AGENT_TOOLS[builtIn.id] ?? []);
       setLocalSpotifyClientId("");
       setLocalSourceLorebookIds([]);
+      setLocalUseChatActiveLorebooks(defaultSettings.useChatActiveLorebooks === true);
       setLocalSourceFileIds([]);
       setLocalAutoGenerateAvatars(false);
       setLocalAutoGenerateBackgrounds(false);
@@ -321,6 +326,7 @@ export function AgentEditor() {
       setLocalEnabledTools([]);
       setLocalSpotifyClientId("");
       setLocalSourceLorebookIds([]);
+      setLocalUseChatActiveLorebooks(false);
       setLocalSourceFileIds([]);
       setLocalAutoGenerateAvatars(false);
       setLocalAutoGenerateBackgrounds(false);
@@ -491,6 +497,9 @@ export function AgentEditor() {
         ...(localInjectAsSection ? { injectAsSection: true } : {}),
         enabledTools: localEnabledTools,
         ...(localSpotifyClientId ? { spotifyClientId: localSpotifyClientId } : {}),
+        ...(isKnowledgeRetrievalAgent || isKnowledgeRouterAgent
+          ? { useChatActiveLorebooks: localUseChatActiveLorebooks }
+          : {}),
         ...(localSourceLorebookIds.length > 0 ? { sourceLorebookIds: localSourceLorebookIds } : {}),
         // Only persist sourceFileIds for the Knowledge Retrieval agent — the Router
         // doesn't read this setting. Without this guard, switching an agent from
@@ -546,6 +555,7 @@ export function AgentEditor() {
     localInjectAsSection,
     localEnabledTools,
     localSpotifyClientId,
+    localUseChatActiveLorebooks,
     localSourceLorebookIds,
     localSourceFileIds,
     localAutoGenerateAvatars,
@@ -558,6 +568,7 @@ export function AgentEditor() {
     isCustomAgent,
     isNewCustomAgent,
     isKnowledgeRetrievalAgent,
+    isKnowledgeRouterAgent,
     updateAgent,
     createAgent,
     openAgentDetail,
@@ -1699,15 +1710,43 @@ export function AgentEditor() {
               icon={<BookOpen size="0.875rem" className="text-amber-400" />}
               help={
                 isKnowledgeRouterAgent
-                  ? "Select lorebooks for this agent to route over. The router picks relevant entries by id and they're injected verbatim."
-                  : "Select lorebooks and/or upload files for this agent to scan. Supported file types: .txt, .md, .csv, .json, .xml, .html, .pdf"
+                  ? "Use chat-active lorebooks by default, or select fixed lorebooks for this agent to route over. The router picks relevant entries by id and injects them verbatim."
+                  : "Use chat-active lorebooks by default, select fixed lorebooks, and/or upload files for this agent to scan. Supported file types: .txt, .md, .csv, .json, .xml, .html, .pdf"
               }
             >
               <div className="space-y-4">
+                <button
+                  type="button"
+                  onClick={() => {
+                    setLocalUseChatActiveLorebooks((value) => !value);
+                    markDirty();
+                  }}
+                  className={cn(
+                    "flex w-full items-start gap-3 rounded-xl p-3 text-left text-xs ring-1 transition-all",
+                    localUseChatActiveLorebooks
+                      ? "bg-[var(--primary)]/10 ring-[var(--primary)] text-[var(--foreground)]"
+                      : "ring-[var(--border)] text-[var(--muted-foreground)] hover:bg-[var(--accent)]",
+                  )}
+                >
+                  {localUseChatActiveLorebooks ? (
+                    <ToggleRight size="1.25rem" className="mt-0.5 shrink-0 text-emerald-400" />
+                  ) : (
+                    <ToggleLeft size="1.25rem" className="mt-0.5 shrink-0" />
+                  )}
+                  <span className="min-w-0">
+                    <span className="block font-semibold">Use this chat&apos;s active lorebooks</span>
+                    <span className="mt-0.5 block text-[0.625rem] leading-tight">
+                      When no fixed source is selected below, this agent scans the lorebooks attached to the current
+                      chat.
+                    </span>
+                  </span>
+                </button>
                 {/* ── Lorebooks ── */}
                 <div className="space-y-1.5">
                   <div className="flex items-center justify-between">
-                    <p className="text-[0.6875rem] font-medium text-[var(--muted-foreground)]">Lorebooks</p>
+                    <p className="text-[0.6875rem] font-medium text-[var(--muted-foreground)]">
+                      Fixed source override
+                    </p>
                     {/* Description coverage badge — Knowledge Router only.
                         Tells the user how many entries in their selected source lorebooks
                         have descriptions filled in. Routing precision drops sharply when
@@ -1793,14 +1832,19 @@ export function AgentEditor() {
                   ) : (
                     <p className="text-[0.625rem] text-[var(--muted-foreground)]">No lorebooks available.</p>
                   )}
+                  {localSourceLorebookIds.length > 0 && (
+                    <p className="text-[0.625rem] text-[var(--muted-foreground)]">
+                      Fixed selections override chat-active lorebooks for every chat that uses this agent.
+                    </p>
+                  )}
                   {/* Router-only tip explaining the description fallback behavior.
                       Without this, users have no way to know that filling in entry
                       descriptions improves routing precision — the fallback to a
                       content snippet works invisibly. */}
-                  {isKnowledgeRouterAgent && localSourceLorebookIds.length > 0 && (
+                  {isKnowledgeRouterAgent && (localSourceLorebookIds.length > 0 || localUseChatActiveLorebooks) && (
                     <p className="text-[0.625rem] italic text-[var(--muted-foreground)]">
-                      Tip: entries without a description fall back to a short content snippet. Adding tight one-line
-                      descriptions to your most important entries improves routing precision.
+                      Tip: entry descriptions help Knowledge Router choose entries; descriptions are not triggers by
+                      themselves. Entries without a description fall back to a short content snippet.
                     </p>
                   )}
                 </div>

--- a/packages/client/src/components/agents/AgentEditor.tsx
+++ b/packages/client/src/components/agents/AgentEditor.tsx
@@ -1717,6 +1717,10 @@ export function AgentEditor() {
               <div className="space-y-4">
                 <button
                   type="button"
+                  aria-pressed={localUseChatActiveLorebooks}
+                  aria-label={`Use this chat's active lorebooks: ${
+                    localUseChatActiveLorebooks ? "on" : "off"
+                  }`}
                   onClick={() => {
                     setLocalUseChatActiveLorebooks((value) => !value);
                     markDirty();

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -164,6 +164,7 @@ import {
   resolveRegenerationGameStateAnchor,
   resolveUserRegenerationPersistentAttachments,
   resolveVisibleGameStateAnchor,
+  resolveKnowledgeSourceLorebookIds,
   shouldPreferLatestVisibleGameState,
   shouldAbortOnPassiveGenerationDisconnect,
   shouldEnableAgentsForGeneration,
@@ -4674,7 +4675,10 @@ export async function generateRoutes(app: FastifyInstance) {
 
           // Load lorebook entries
           try {
-            const sourceIds = (knowledgeRetrievalAgent.settings.sourceLorebookIds as string[]) ?? [];
+            const { sourceLorebookIds: sourceIds } = resolveKnowledgeSourceLorebookIds({
+              settings: knowledgeRetrievalAgent.settings,
+              chatActiveLorebookIds: chatActiveLorebookIds,
+            });
             if (sourceIds.length > 0) {
               const entries = await lorebooksStore.listEntriesByLorebooks(sourceIds);
               const activeEntries = entries.filter((e: any) => e.enabled !== false);
@@ -4736,7 +4740,10 @@ export async function generateRoutes(app: FastifyInstance) {
         let knowledgeRouterKeywordScanEntries: LorebookEntry[] = [];
         if (knowledgeRouterAgent) {
           try {
-            const sourceIds = (knowledgeRouterAgent.settings.sourceLorebookIds as string[]) ?? [];
+            const { sourceLorebookIds: sourceIds } = resolveKnowledgeSourceLorebookIds({
+              settings: knowledgeRouterAgent.settings,
+              chatActiveLorebookIds: chatActiveLorebookIds,
+            });
             if (sourceIds.length > 0) {
               const entries = (await lorebooksStore.listEntriesByLorebooks(sourceIds)) as LorebookEntry[];
               // Honor per-chat entry state overrides — a user can disable an entry for

--- a/packages/server/src/routes/generate/generate-route-utils.ts
+++ b/packages/server/src/routes/generate/generate-route-utils.ts
@@ -59,6 +59,40 @@ export function mergeCustomParameters(
   return merged;
 }
 
+function normalizeStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+  for (const item of value) {
+    if (typeof item !== "string") continue;
+    const trimmed = item.trim();
+    if (!trimmed || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    normalized.push(trimmed);
+  }
+  return normalized;
+}
+
+export function resolveKnowledgeSourceLorebookIds(args: {
+  settings: Record<string, unknown> | null | undefined;
+  chatActiveLorebookIds: unknown;
+}): { sourceLorebookIds: string[]; source: "manual" | "chat_active" | "none" } {
+  const manualIds = normalizeStringArray(args.settings?.sourceLorebookIds);
+  if (manualIds.length > 0) {
+    return { sourceLorebookIds: manualIds, source: "manual" };
+  }
+
+  if (args.settings?.useChatActiveLorebooks === false) {
+    return { sourceLorebookIds: [], source: "none" };
+  }
+
+  const chatActiveIds = normalizeStringArray(args.chatActiveLorebookIds);
+  return {
+    sourceLorebookIds: chatActiveIds,
+    source: chatActiveIds.length > 0 ? "chat_active" : "none",
+  };
+}
+
 /** Find last message index matching a role (or predicate). Returns -1 if not found. */
 export function findLastIndex(messages: SimpleMessage[], role: string): number {
   for (let i = messages.length - 1; i >= 0; i--) {

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -484,6 +484,10 @@ export function getDefaultBuiltInAgentSettings(agentType: string): Record<string
     settings.runInterval = runInterval;
   }
 
+  if (agentType === "knowledge-retrieval" || agentType === "knowledge-router") {
+    settings.useChatActiveLorebooks = true;
+  }
+
   return settings;
 }
 


### PR DESCRIPTION
<!-- Target branch: `staging`. The default base in this UI is `main` (release branch). -->
<!-- Change the base to `staging` before submitting unless this is a maintainer-approved mainline change. -->
<!-- See CONTRIBUTING.md § Branches. -->

## Linked issue

Closes #1050

## Why this change

Knowledge Retrieval and Knowledge Router required fixed lorebook selections in agent settings, which made chat-scoped agents feel broken when a chat already had active lorebooks attached.

## What changed

- Added a `useChatActiveLorebooks` setting for Knowledge Retrieval and Knowledge Router.
- Defaulted both knowledge agents to use the current chat's active lorebooks when no fixed lorebook override is selected.
- Kept the manual lorebook picker as a fixed-source override.
- Updated the Agent Editor copy to explain chat-active lorebook behavior and clarify that entry descriptions help Knowledge Router choose entries but are not triggers by themselves.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Codex ran `pnpm --filter @marinara-engine/server exec tsx ../../scratch/issue-1050-knowledge-sources.ts`; source resolution passed for chat-active defaults, fixed manual overrides, explicit disable, and duplicate/invalid manual IDs.
- Codex ran `pnpm check`; it passed.
- Codex ran a headless Chromium/CDP UI check against `http://localhost:5173`; the Knowledge Router editor showed the chat-active toggle, fixed-source override label, and description-not-trigger copy.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

No reviewer-visible screenshot embedded. Codex verified the Agent Editor UI copy with a headless browser check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Knowledge Retrieval and Knowledge Router agents can use the current chat's active lorebooks.
  * Agent editor adds a toggle to enable/disable chat-active lorebook usage; built-in agents default to enabled.
  * Knowledge source UI shows a "fixed source override" note when fixed lorebooks are selected and updates tips/descriptions to reflect active vs fixed lorebook routing.
* **Behavior**
  * Generation now respects the chosen active vs fixed lorebook source when resolving lorebook entries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1053?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->