### PR TITLE
Add comma-separated bulk tag entry

### DIFF
--- a/packages/client/src/components/characters/CharacterEditor.tsx
+++ b/packages/client/src/components/characters/CharacterEditor.tsx
@@ -145,6 +145,19 @@ function normalizeAltDescriptions(value: unknown): AltDescriptionEntry[] {
     }));
 }
 
+function appendNewTags(existingTags: string[], rawInput: string) {
+  const seen = new Set(existingTags);
+  const additions: string[] = [];
+
+  for (const tag of rawInput.split(",").map((part) => part.trim())) {
+    if (!tag || seen.has(tag)) continue;
+    seen.add(tag);
+    additions.push(tag);
+  }
+
+  return additions.length > 0 ? [...existingTags, ...additions] : existingTags;
+}
+
 export function CharacterEditor() {
   const characterId = useUIStore((s) => s.characterDetailId);
   const closeDetail = useUIStore((s) => s.closeCharacterDetail);
@@ -560,10 +573,10 @@ export function CharacterEditor() {
   }, [avatarUploading, closeDetail, setDirtyState]);
 
   const addTag = () => {
-    const tag = newTag.trim();
-    if (!tag || !formData) return;
-    if (formData.tags.includes(tag)) return;
-    updateField("tags", [...formData.tags, tag]);
+    if (!formData) return;
+    const nextTags = appendNewTags(formData.tags, newTag);
+    if (nextTags === formData.tags) return;
+    updateField("tags", nextTags);
     setNewTag("");
   };
 
@@ -1339,7 +1352,12 @@ function MetadataTab({
           <input
             value={newTag}
             onChange={(e) => setNewTag(e.target.value)}
-            onKeyDown={(e) => e.key === "Enter" && addTag()}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                addTag();
+              }
+            }}
             placeholder="Add tag…"
             className="flex-1 rounded-xl border border-[var(--border)] bg-[var(--secondary)] px-3 py-1.5 text-xs outline-none focus:border-[var(--primary)]/40"
           />

--- a/packages/client/src/components/lorebooks/LorebookEditor.tsx
+++ b/packages/client/src/components/lorebooks/LorebookEditor.tsx
@@ -116,6 +116,19 @@ function writeCollapsedFolderIds(lorebookId: string, ids: Set<string>) {
   }
 }
 
+function appendNewTags(existingTags: string[], rawInput: string) {
+  const seen = new Set(existingTags);
+  const additions: string[] = [];
+
+  for (const tag of rawInput.split(",").map((part) => part.trim())) {
+    if (!tag || seen.has(tag)) continue;
+    seen.add(tag);
+    additions.push(tag);
+  }
+
+  return additions.length > 0 ? [...existingTags, ...additions] : existingTags;
+}
+
 // ── Types ──
 type LinkedResourceItem = {
   id: string;
@@ -631,6 +644,15 @@ export function LorebookEditor() {
 
   // ── Handlers ──
   const markLorebookDirty = useCallback(() => setLorebookDirty(true), []);
+
+  const handleAddTags = useCallback(() => {
+    const nextTags = appendNewTags(formTags, newTag);
+    if (nextTags === formTags) return;
+    setFormTags(nextTags);
+    markLorebookDirty();
+    setNewTag("");
+  }, [formTags, markLorebookDirty, newTag]);
+
   const exitEntrySelectionMode = useCallback(() => {
     setEntrySelectionMode(false);
     setSelectedEntryIds(new Set());
@@ -1200,28 +1222,16 @@ export function LorebookEditor() {
                       value={newTag}
                       onChange={(e) => setNewTag(e.target.value)}
                       onKeyDown={(e) => {
-                        if (e.key === "Enter" && newTag.trim()) {
+                        if (e.key === "Enter") {
                           e.preventDefault();
-                          const t = newTag.trim();
-                          if (!formTags.includes(t)) {
-                            setFormTags([...formTags, t]);
-                            markLorebookDirty();
-                          }
-                          setNewTag("");
+                          handleAddTags();
                         }
                       }}
                       placeholder="Add tag…"
                       className="flex-1 rounded-xl bg-[var(--secondary)] px-3 py-2 text-xs ring-1 ring-[var(--border)] placeholder:text-[var(--muted-foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
                     />
                     <button
-                      onClick={() => {
-                        const t = newTag.trim();
-                        if (t && !formTags.includes(t)) {
-                          setFormTags([...formTags, t]);
-                          markLorebookDirty();
-                        }
-                        setNewTag("");
-                      }}
+                      onClick={handleAddTags}
                       className="rounded-xl bg-[var(--secondary)] px-3 py-2 text-xs font-medium ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)]"
                     >
                       <Plus size="0.75rem" />

--- a/packages/client/src/components/personas/PersonaEditor.tsx
+++ b/packages/client/src/components/personas/PersonaEditor.tsx
@@ -129,6 +129,19 @@ interface PersonaRow {
   tags?: string;
 }
 
+function appendNewTags(existingTags: string[], rawInput: string) {
+  const seen = new Set(existingTags);
+  const additions: string[] = [];
+
+  for (const tag of rawInput.split(",").map((part) => part.trim())) {
+    if (!tag || seen.has(tag)) continue;
+    seen.add(tag);
+    additions.push(tag);
+  }
+
+  return additions.length > 0 ? [...existingTags, ...additions] : existingTags;
+}
+
 export function PersonaEditor() {
   const personaId = useUIStore((s) => s.personaDetailId);
   const closeDetail = useUIStore((s) => s.closePersonaDetail);
@@ -1872,10 +1885,9 @@ function DescriptionTab({
   const [newTag, setNewTag] = useState("");
 
   const addTag = () => {
-    const tag = newTag.trim();
-    if (!tag) return;
-    if (formData.tags.includes(tag)) return;
-    updateField("tags", [...formData.tags, tag]);
+    const nextTags = appendNewTags(formData.tags, newTag);
+    if (nextTags === formData.tags) return;
+    updateField("tags", nextTags);
     setNewTag("");
   };
 


### PR DESCRIPTION
<!-- Target branch: `staging`. The default base in this UI is `main` (release branch). -->
<!-- Change the base to `staging` before submitting unless this is a maintainer-approved mainline change. -->
<!-- See CONTRIBUTING.md § Branches. -->

## Linked issue

Closes #1035

## Why this change

- Adding many tags was tedious because each tag had to be entered one at a time.

## What changed

- Allow comma-separated tag entry in the character editor.
- Allow comma-separated tag entry in the persona editor.
- Allow comma-separated tag entry in the lorebook editor.
- Trim blank entries and skip duplicate tags while preserving the existing tag order.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Codex ran `pnpm check`; it passed.
- Codex ran `scratch/verify-issue-1035-tags-cdp.mjs` against the real local app and API. The script created a temporary character, persona, and lorebook, entered `bulk-alpha, bulk-beta, existing, bulk-alpha, bulk-gamma` into each visible tag input, saved each editor, and confirmed the persisted tags were `existing`, `bulk-alpha`, `bulk-beta`, and `bulk-gamma`.
- Bunny review pass completed with no blocking findings.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

No visual layout change. Behavioral UI proof is covered by the local browser/CDP verification script above.
