### PR TITLE
feat: creator notes CSS injection with tri-state mode

### DIFF
--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -432,13 +432,12 @@ export function ChatArea() {
   );
   const hasCustomSpritePlacements = Object.keys(spritePlacements).length > 0;
 
-  // Card CSS — filter out characters whose creator-notes CSS the user has disabled
-  const cardCssCharIds = useMemo(() => {
-    const disabled: unknown = chatMeta.disabledCardCssCharIds;
-    if (!Array.isArray(disabled) || disabled.length === 0) return chatCharIds;
-    const disabledSet = new Set(disabled.filter((id): id is string => typeof id === "string"));
-    return chatCharIds.filter((id) => !disabledSet.has(id));
-  }, [chatCharIds, chatMeta.disabledCardCssCharIds]);
+  // Card CSS mode — controls how creator-notes CSS is applied
+  const cardCssMode = (() => {
+    const mode = chatMeta.cardCssMode;
+    if (mode === "disabled" || mode === "exclusive") return mode;
+    return "chat" as const;
+  })();
 
   // Prefer per-swipe expressions from the last assistant message's extra (survives swipe switching),
   // falling back to chat-level metadata for backward compatibility.
@@ -1728,7 +1727,8 @@ export function ChatArea() {
         <>
           <CreatorNotesCssInjector
             characters={allCharacters as Array<{ id: string; data: string; avatarPath: string | null }> | undefined}
-            chatCharacterIds={cardCssCharIds}
+            chatCharacterIds={chatCharIds}
+            mode={cardCssMode}
           />
           <GameSurface
             activeChatId={activeChatId}
@@ -1799,7 +1799,8 @@ export function ChatArea() {
       <>
         <CreatorNotesCssInjector
           characters={allCharacters as Array<{ id: string; data: string; avatarPath: string | null }> | undefined}
-          chatCharacterIds={cardCssCharIds}
+          chatCharacterIds={chatCharIds}
+          mode={cardCssMode}
         />
         <Suspense fallback={surfaceFallback}>
           <ChatConversationSurface
@@ -1887,7 +1888,8 @@ export function ChatArea() {
     <>
       <CreatorNotesCssInjector
         characters={allCharacters as Array<{ id: string; data: string; avatarPath: string | null }> | undefined}
-        chatCharacterIds={cardCssCharIds}
+        chatCharacterIds={chatCharIds}
+        mode={cardCssMode}
       />
       <Suspense fallback={surfaceFallback}>
         <ChatRoleplaySurface

--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -431,6 +431,15 @@ export function ChatArea() {
     [chatMeta.spritePlacements],
   );
   const hasCustomSpritePlacements = Object.keys(spritePlacements).length > 0;
+
+  // Card CSS — filter out characters whose creator-notes CSS the user has disabled
+  const cardCssCharIds = useMemo(() => {
+    const disabled: unknown = chatMeta.disabledCardCssCharIds;
+    if (!Array.isArray(disabled) || disabled.length === 0) return chatCharIds;
+    const disabledSet = new Set(disabled.filter((id): id is string => typeof id === "string"));
+    return chatCharIds.filter((id) => !disabledSet.has(id));
+  }, [chatCharIds, chatMeta.disabledCardCssCharIds]);
+
   // Prefer per-swipe expressions from the last assistant message's extra (survives swipe switching),
   // falling back to chat-level metadata for backward compatibility.
   const spriteExpressions: Record<string, string> = useMemo(() => {
@@ -1719,7 +1728,7 @@ export function ChatArea() {
         <>
           <CreatorNotesCssInjector
             characters={allCharacters as Array<{ id: string; data: string; avatarPath: string | null }> | undefined}
-            chatCharacterIds={chatCharIds}
+            chatCharacterIds={cardCssCharIds}
           />
           <GameSurface
             activeChatId={activeChatId}
@@ -1790,7 +1799,7 @@ export function ChatArea() {
       <>
         <CreatorNotesCssInjector
           characters={allCharacters as Array<{ id: string; data: string; avatarPath: string | null }> | undefined}
-          chatCharacterIds={chatCharIds}
+          chatCharacterIds={cardCssCharIds}
         />
         <Suspense fallback={surfaceFallback}>
           <ChatConversationSurface
@@ -1878,7 +1887,7 @@ export function ChatArea() {
     <>
       <CreatorNotesCssInjector
         characters={allCharacters as Array<{ id: string; data: string; avatarPath: string | null }> | undefined}
-        chatCharacterIds={chatCharIds}
+        chatCharacterIds={cardCssCharIds}
       />
       <Suspense fallback={surfaceFallback}>
         <ChatRoleplaySurface

--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -69,6 +69,7 @@ import { RecentChats } from "./RecentChats";
 import { HomeFaq } from "./HomeFaq";
 import { NewChatConnectionGate } from "./NewChatConnectionGate";
 import { ChatCommonOverlays } from "./ChatCommonOverlays";
+import { CreatorNotesCssInjector } from "./CreatorNotesCssInjector";
 
 export type { CharacterMap };
 
@@ -1716,6 +1717,10 @@ export function ChatArea() {
     return (
       <Suspense fallback={surfaceFallback}>
         <>
+          <CreatorNotesCssInjector
+            characters={allCharacters as Array<{ id: string; data: string; avatarPath: string | null }> | undefined}
+            chatCharacterIds={chatCharIds}
+          />
           <GameSurface
             activeChatId={activeChatId}
             chat={chat!}
@@ -1783,6 +1788,10 @@ export function ChatArea() {
   if (chatMode === "conversation") {
     return (
       <>
+        <CreatorNotesCssInjector
+          characters={allCharacters as Array<{ id: string; data: string; avatarPath: string | null }> | undefined}
+          chatCharacterIds={chatCharIds}
+        />
         <Suspense fallback={surfaceFallback}>
           <ChatConversationSurface
             activeChatId={activeChatId}
@@ -1867,6 +1876,10 @@ export function ChatArea() {
 
   return (
     <>
+      <CreatorNotesCssInjector
+        characters={allCharacters as Array<{ id: string; data: string; avatarPath: string | null }> | undefined}
+        chatCharacterIds={chatCharIds}
+      />
       <Suspense fallback={surfaceFallback}>
         <ChatRoleplaySurface
           activeChatId={activeChatId}

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -51,6 +51,7 @@ import { useTTSConfig } from "../../hooks/use-tts";
 import { buildTTSMessageText, resolveTTSVoiceForSpeaker } from "../../lib/tts-dialogue";
 import { DIALOGUE_QUOTE_PATTERN_SOURCE, HTML_SAFE_DIALOGUE_QUOTE_PATTERN_SOURCE } from "../../lib/dialogue-quotes";
 import DOMPurify from "dompurify";
+import { extractChatStyleBlocks, scopeChatCss } from "../../lib/chat-css";
 import type { CharacterMap, MessageSelectionToggle, PersonaInfo } from "./chat-area.types";
 import { GenerationReplayDetailsModal, hasGenerationReplayDetails } from "./GenerationReplayDetailsModal";
 import { ImagePromptPanel } from "./ImagePromptPanel";
@@ -471,9 +472,6 @@ const CHAT_HTML_ALLOWED_ATTR = [
   "title",
 ] as const;
 
-const CHAT_STYLE_BLOCK_RE = /<style\b[^>]*>([\s\S]*?)<\/style>/gi;
-const CSS_SELECTOR_RE = /(^|[{}])\s*([^@{}][^{]*)\{/g;
-
 function sanitizeChatHtml(html: string, options: { allowStyle?: boolean } = {}) {
   const allowedAttr = options.allowStyle
     ? [...CHAT_HTML_ALLOWED_ATTR]
@@ -485,50 +483,6 @@ function sanitizeChatHtml(html: string, options: { allowStyle?: boolean } = {}) 
     ALLOW_UNKNOWN_PROTOCOLS: false,
     FORBID_TAGS: ["animate", "embed", "foreignObject", "iframe", "math", "object", "script", "svg", "style"],
     FORBID_ATTR: ["onerror", "onload", "onclick", "srcdoc"],
-  });
-}
-
-function extractChatStyleBlocks(html: string): { html: string; css: string } {
-  const cssBlocks: string[] = [];
-  const withoutStyles = html.replace(CHAT_STYLE_BLOCK_RE, (_match, css: string) => {
-    cssBlocks.push(css);
-    return "";
-  });
-  return { html: withoutStyles, css: cssBlocks.join("\n") };
-}
-
-function sanitizeChatCss(css: string): string {
-  return css
-    .replace(/<\/?style\b[^>]*>/gi, "")
-    .replace(/@import\s+[^;]+;?/gi, "")
-    .replace(/@namespace\s+[^;]+;?/gi, "")
-    .replace(/expression\s*\([^)]*\)/gi, "")
-    .replace(/javascript\s*:/gi, "")
-    .replace(/vbscript\s*:/gi, "")
-    .replace(/behavior\s*:/gi, "x-behavior:")
-    .replace(/-moz-binding\s*:/gi, "x-moz-binding:")
-    .replace(/url\s*\(\s*(['"]?)(?!data:image\/|https?:\/\/)[^)]+\)/gi, "none")
-    .replace(/<\/style/gi, "<\\/style")
-    .trim();
-}
-
-function scopeChatCss(css: string, scopeSelector: string): string {
-  const sanitized = sanitizeChatCss(css);
-  if (!sanitized) return "";
-  return sanitized.replace(CSS_SELECTOR_RE, (_match, boundary: string, selectors: string) => {
-    const scopedSelectors = selectors
-      .split(",")
-      .map((selector) => {
-        const trimmed = selector.trim();
-        if (!trimmed) return "";
-        if (/^(from|to|\d+(?:\.\d+)?%)$/i.test(trimmed)) return trimmed;
-        if (trimmed.startsWith(scopeSelector)) return trimmed;
-        if (trimmed === ":root" || trimmed === "html" || trimmed === "body") return scopeSelector;
-        return `${scopeSelector} ${trimmed}`;
-      })
-      .filter(Boolean)
-      .join(", ");
-    return `${boundary} ${scopedSelectors}{`;
   });
 }
 

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -1369,6 +1369,7 @@ export const ChatMessage = memo(function ChatMessage({
             "mari-message mari-message-narrator rpg-narrator-msg group mb-4 px-2",
             multiSelectMode && isSelected && "rounded-lg bg-[var(--destructive)]/5 ring-2 ring-[var(--destructive)]/50",
           )}
+          data-card-css={message.characterId ?? undefined}
           onClick={handleMobileTap}
         >
           <div className="flex gap-3">
@@ -1439,6 +1440,7 @@ export const ChatMessage = memo(function ChatMessage({
           )}
           data-message-id={message.id}
           data-message-role={message.role}
+          data-card-css={message.characterId ?? undefined}
           onClick={handleMobileTap}
           style={roleplayAvatarScaleStyle}
         >
@@ -1964,6 +1966,7 @@ export const ChatMessage = memo(function ChatMessage({
       )}
       data-message-id={message.id}
       data-message-role={message.role}
+      data-card-css={message.characterId ?? undefined}
       onClick={handleMobileTap}
     >
       <div

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -766,7 +766,7 @@ export function ChatRoleplaySurface({
 
   return (
     <div data-component="ChatArea.Roleplay" className="flex flex-1 overflow-hidden">
-      <div className="rpg-chat-area mari-chat-area relative flex flex-1 flex-col overflow-hidden">
+      <div className="rpg-chat-area mari-chat-area mari-card-css relative flex flex-1 flex-col overflow-hidden" style={{ isolation: "isolate" }}>
         <CrossfadeBackground url={chatBackground} blurPx={chatBackgroundBlur} />
         <div className="rpg-overlay absolute inset-0" />
         <div className="rpg-vignette pointer-events-none absolute inset-0" />

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -766,7 +766,7 @@ export function ChatRoleplaySurface({
 
   return (
     <div data-component="ChatArea.Roleplay" className="flex flex-1 overflow-hidden">
-      <div className="rpg-chat-area mari-chat-area mari-card-css relative flex flex-1 flex-col overflow-hidden" style={{ isolation: "isolate" }}>
+      <div className="rpg-chat-area mari-chat-area mari-card-css relative flex flex-1 flex-col overflow-hidden" data-chat-mode="roleplay" style={{ isolation: "isolate" }}>
         <CrossfadeBackground url={chatBackground} blurPx={chatBackgroundBlur} />
         <div className="rpg-overlay absolute inset-0" />
         <div className="rpg-vignette pointer-events-none absolute inset-0" />

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -681,11 +681,11 @@ export function ChatSettingsDrawer({
     return result;
   }, [chatCharIds, characters, charNameMap]);
 
-  const disabledCardCssCharIds = useMemo<string[]>(() => {
-    const raw: unknown = metadata.disabledCardCssCharIds;
-    if (!Array.isArray(raw)) return [];
-    return raw.filter((id): id is string => typeof id === "string");
-  }, [metadata.disabledCardCssCharIds]);
+  const cardCssMode = useMemo(() => {
+    const mode = metadata.cardCssMode;
+    if (mode === "disabled" || mode === "exclusive") return mode;
+    return "chat";
+  }, [metadata.cardCssMode]);
 
   const getCharacterInfo = useCallback(
     (c: { id?: string; data: string; comment?: string | null }) => {
@@ -3629,51 +3629,43 @@ export function ChatSettingsDrawer({
             )}
           </Section>
 
-          {/* Card Theming — per-character CSS from creator_notes */}
+          {/* Card Theming — creator-notes CSS mode selector */}
           {cardCssCharacters.length > 0 && (
             <Section
               label="Card Theming"
               icon={<Paintbrush size="0.875rem" />}
-              count={cardCssCharacters.length - disabledCardCssCharIds.length}
-              help="Characters can embed custom CSS in their creator notes to theme the chat UI. Toggle which characters are allowed to apply their visual styling."
+              count={cardCssMode !== "disabled" ? cardCssCharacters.length : 0}
+              help="Characters can embed custom CSS in their creator notes to theme the chat. Choose how broadly their styles are applied."
             >
               <div className="space-y-1.5">
+                <CardCssModeSelector
+                  mode={cardCssMode}
+                  onChange={(mode) => updateMeta.mutate({ id: chat.id, cardCssMode: mode })}
+                />
                 <p className="px-1 text-[0.625rem] text-[var(--muted-foreground)]">
-                  Enable or disable each character's embedded CSS. Only characters with CSS in their creator notes are
-                  shown.
+                  {cardCssMode === "disabled"
+                    ? "Card CSS is disabled — no character styling is applied."
+                    : cardCssMode === "exclusive"
+                      ? "Each character's CSS only affects their own messages."
+                      : "All card CSS affects the entire chat area, including UI elements."}
                 </p>
-                {cardCssCharacters.map((char) => {
-                  const isEnabled = !disabledCardCssCharIds.includes(char.id);
-                  return (
-                    <div
-                      key={char.id}
-                      className="flex items-center gap-2 rounded-lg px-3 py-2 ring-1 ring-[var(--border)] bg-[var(--card)]"
-                    >
-                      <span className="flex-1 text-[0.6875rem] font-medium text-[var(--foreground)] truncate">
-                        {char.name}
-                      </span>
-                      <button
-                        type="button"
-                        onClick={() => {
-                          const current = disabledCardCssCharIds;
-                          const next = isEnabled
-                            ? [...current, char.id]
-                            : current.filter((id) => id !== char.id);
-                          updateMeta.mutate({ id: chat.id, disabledCardCssCharIds: next });
-                        }}
-                        className={cn(
-                          "shrink-0 rounded-md px-2.5 py-1 text-[0.625rem] font-medium transition-colors",
-                          isEnabled
-                            ? "bg-[var(--primary)] text-[var(--primary-foreground)]"
-                            : "bg-[var(--secondary)] text-[var(--muted-foreground)]",
-                        )}
-                        title={isEnabled ? "Click to disable this character's CSS theming" : "Click to enable this character's CSS theming"}
+                {cardCssMode !== "disabled" && (
+                  <div className="space-y-1">
+                    <span className="block px-1 text-[0.625rem] font-medium text-[var(--muted-foreground)]">
+                      Characters with CSS:
+                    </span>
+                    {cardCssCharacters.map((char) => (
+                      <div
+                        key={char.id}
+                        className="flex items-center gap-2 rounded-lg px-3 py-1.5 ring-1 ring-[var(--border)] bg-[var(--card)]"
                       >
-                        {isEnabled ? "On" : "Off"}
-                      </button>
-                    </div>
-                  );
-                })}
+                        <span className="flex-1 text-[0.6875rem] font-medium text-[var(--foreground)] truncate">
+                          {char.name}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                )}
               </div>
             </Section>
           )}
@@ -7236,5 +7228,62 @@ function ConversationNotesSection({ chatId }: { chatId: string }) {
         )}
       </div>
     </Section>
+  );
+}
+
+// ── Card CSS mode selector (Disabled / Exclusive / Chat) ──
+function CardCssModeSelector({
+  mode,
+  onChange,
+}: {
+  mode: string;
+  onChange: (mode: string) => void;
+}) {
+  const options = [
+    {
+      id: "disabled",
+      label: "Disabled",
+      tooltip: "No card CSS is applied — characters' embedded styles are ignored",
+    },
+    {
+      id: "exclusive",
+      label: "Exclusive",
+      tooltip: "Each character's CSS only affects their own messages",
+    },
+    {
+      id: "chat",
+      label: "Chat",
+      tooltip: "All card CSS affects the entire chat area, including UI elements",
+    },
+  ];
+
+  return (
+    <div className="space-y-1.5 rounded-lg bg-[var(--background)]/75 px-3 py-2 ring-1 ring-[var(--border)]">
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-[0.6875rem] font-medium text-[var(--foreground)]">CSS Mode</span>
+      </div>
+      <div className="grid grid-cols-3 overflow-hidden rounded-md ring-1 ring-[var(--border)]">
+        {options.map((option, index) => {
+          const active = mode === option.id;
+          return (
+            <button
+              key={option.id}
+              type="button"
+              onClick={() => onChange(option.id)}
+              className={cn(
+                "min-w-0 px-2.5 py-1.5 text-[0.625rem] font-medium transition-colors",
+                index > 0 && "border-l border-[var(--border)]",
+                active
+                  ? "bg-[var(--primary)] text-[var(--primary-foreground)]"
+                  : "text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]",
+              )}
+              title={option.tooltip}
+            >
+              {option.label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
   );
 }

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -54,6 +54,7 @@ import {
   Drama,
   RotateCcw,
   Music2,
+  Paintbrush,
 } from "lucide-react";
 import { cn, getAvatarCropStyle, type AvatarCrop } from "../../lib/utils";
 import { showAlertDialog, showConfirmDialog, showPromptDialog } from "../../lib/app-dialogs";
@@ -123,6 +124,7 @@ import type {
   ConversationNote,
   ExportEnvelope,
 } from "@marinara-engine/shared";
+import { extractCreatorNotesCss } from "@marinara-engine/shared";
 import { useAgentConfigs, useCreateAgent, useUpdateAgent, type AgentConfigRow } from "../../hooks/use-agents";
 import { useAgentStore } from "../../stores/agent.store";
 import {
@@ -659,6 +661,31 @@ export function ChatSettingsDrawer({
     }
     return map;
   }, [charInfoMap]);
+
+  // Characters in this chat that have CSS in their creator_notes
+  const cardCssCharacters = useMemo(() => {
+    const result: Array<{ id: string; name: string }> = [];
+    for (const id of chatCharIds) {
+      const char = characters.find((c) => c.id === id);
+      if (!char) continue;
+      try {
+        const parsed = typeof char.data === "string" ? JSON.parse(char.data) : char.data;
+        const notes: string = parsed?.creator_notes ?? "";
+        if (!notes) continue;
+        const { css } = extractCreatorNotesCss(notes);
+        if (css.trim()) result.push({ id, name: charNameMap.get(id) ?? "Unknown" });
+      } catch {
+        // skip malformed data
+      }
+    }
+    return result;
+  }, [chatCharIds, characters, charNameMap]);
+
+  const disabledCardCssCharIds = useMemo<string[]>(() => {
+    const raw: unknown = metadata.disabledCardCssCharIds;
+    if (!Array.isArray(raw)) return [];
+    return raw.filter((id): id is string => typeof id === "string");
+  }, [metadata.disabledCardCssCharIds]);
 
   const getCharacterInfo = useCallback(
     (c: { id?: string; data: string; comment?: string | null }) => {
@@ -3601,6 +3628,55 @@ export function ChatSettingsDrawer({
               </PickerDropdown>
             )}
           </Section>
+
+          {/* Card Theming — per-character CSS from creator_notes */}
+          {cardCssCharacters.length > 0 && (
+            <Section
+              label="Card Theming"
+              icon={<Paintbrush size="0.875rem" />}
+              count={cardCssCharacters.length - disabledCardCssCharIds.length}
+              help="Characters can embed custom CSS in their creator notes to theme the chat UI. Toggle which characters are allowed to apply their visual styling."
+            >
+              <div className="space-y-1.5">
+                <p className="px-1 text-[0.625rem] text-[var(--muted-foreground)]">
+                  Enable or disable each character's embedded CSS. Only characters with CSS in their creator notes are
+                  shown.
+                </p>
+                {cardCssCharacters.map((char) => {
+                  const isEnabled = !disabledCardCssCharIds.includes(char.id);
+                  return (
+                    <div
+                      key={char.id}
+                      className="flex items-center gap-2 rounded-lg px-3 py-2 ring-1 ring-[var(--border)] bg-[var(--card)]"
+                    >
+                      <span className="flex-1 text-[0.6875rem] font-medium text-[var(--foreground)] truncate">
+                        {char.name}
+                      </span>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          const current = disabledCardCssCharIds;
+                          const next = isEnabled
+                            ? [...current, char.id]
+                            : current.filter((id) => id !== char.id);
+                          updateMeta.mutate({ id: chat.id, disabledCardCssCharIds: next });
+                        }}
+                        className={cn(
+                          "shrink-0 rounded-md px-2.5 py-1 text-[0.625rem] font-medium transition-colors",
+                          isEnabled
+                            ? "bg-[var(--primary)] text-[var(--primary-foreground)]"
+                            : "bg-[var(--secondary)] text-[var(--muted-foreground)]",
+                        )}
+                        title={isEnabled ? "Click to disable this character's CSS theming" : "Click to enable this character's CSS theming"}
+                      >
+                        {isEnabled ? "On" : "Off"}
+                      </button>
+                    </div>
+                  );
+                })}
+              </div>
+            </Section>
+          )}
 
           {/* Agents — hidden for conversation mode */}
           {!isConversation && (

--- a/packages/client/src/components/chat/ConversationMessage.tsx
+++ b/packages/client/src/components/chat/ConversationMessage.tsx
@@ -720,6 +720,7 @@ export const ConversationMessage = memo(function ConversationMessage({
           isStreaming && "bg-[var(--secondary)]/20",
           multiSelectMode && isSelected && "bg-[var(--destructive)]/10",
         )}
+        data-card-css={message.characterId ?? undefined}
         onClick={handleMobileTap}
       >
         {/* Multi-select checkbox */}
@@ -1028,6 +1029,7 @@ export const ConversationMessage = memo(function ConversationMessage({
       )}
       data-message-id={message.id}
       data-message-role={message.role}
+      data-card-css={message.characterId ?? undefined}
       onClick={handleMobileTap}
     >
       {/* Multi-select checkbox */}

--- a/packages/client/src/components/chat/ConversationView.tsx
+++ b/packages/client/src/components/chat/ConversationView.tsx
@@ -773,7 +773,7 @@ export function ConversationView({
   }, [hiddenCount]);
 
   return (
-    <div className="mari-chat-area relative flex flex-1 flex-col overflow-hidden" style={gradientStyle}>
+    <div className="mari-chat-area mari-card-css relative flex flex-1 flex-col overflow-hidden" style={{ ...gradientStyle, isolation: "isolate" }}>
       {/* ── Messages scroll area ── */}
       <div ref={scrollRef} className="mari-messages-scroll flex-1 overflow-y-auto overflow-x-hidden">
         {/* Floating header — character info + action buttons */}

--- a/packages/client/src/components/chat/ConversationView.tsx
+++ b/packages/client/src/components/chat/ConversationView.tsx
@@ -773,7 +773,7 @@ export function ConversationView({
   }, [hiddenCount]);
 
   return (
-    <div className="mari-chat-area mari-card-css relative flex flex-1 flex-col overflow-hidden" style={{ ...gradientStyle, isolation: "isolate" }}>
+    <div className="mari-chat-area mari-card-css relative flex flex-1 flex-col overflow-hidden" data-chat-mode="conversation" style={{ ...gradientStyle, isolation: "isolate" }}>
       {/* ── Messages scroll area ── */}
       <div ref={scrollRef} className="mari-messages-scroll flex-1 overflow-y-auto overflow-x-hidden">
         {/* Floating header — character info + action buttons */}

--- a/packages/client/src/components/chat/CreatorNotesCssInjector.tsx
+++ b/packages/client/src/components/chat/CreatorNotesCssInjector.tsx
@@ -5,12 +5,18 @@
 // creator_notes, sanitises + scopes them, then injects
 // a single <style> element into <head>.
 //
-// Scoped to `.mari-card-css` — the chat surface wrapper
-// sets this class so card styles only affect the chat area.
+// Supports three modes:
+// - "disabled": no card CSS is injected
+// - "exclusive": each character's CSS is scoped to their
+//   own messages via [data-card-css="<charId>"]
+// - "chat": all card CSS is scoped to .mari-card-css
+//   (the entire chat area)
 // ──────────────────────────────────────────────
 import { useEffect, useMemo } from "react";
 import { extractCreatorNotesCss } from "@marinara-engine/shared";
 import { scopeChatCss } from "../../lib/chat-css";
+
+export type CardCssMode = "disabled" | "exclusive" | "chat";
 
 const CARD_CSS_SCOPE = ".mari-card-css";
 const STYLE_ELEMENT_ID = "marinara-card-css";
@@ -18,11 +24,14 @@ const STYLE_ELEMENT_ID = "marinara-card-css";
 export function CreatorNotesCssInjector({
   characters,
   chatCharacterIds,
+  mode = "chat",
 }: {
   characters: Array<{ id: string; data: string; avatarPath: string | null }> | undefined;
   chatCharacterIds: string[];
+  mode?: CardCssMode;
 }) {
   const scopedCss = useMemo(() => {
+    if (mode === "disabled") return "";
     if (!characters?.length || !chatCharacterIds.length) return "";
 
     const activeIdSet = new Set(chatCharacterIds);
@@ -35,15 +44,24 @@ export function CreatorNotesCssInjector({
         const creatorNotes: string = parsed.creator_notes ?? "";
         if (!creatorNotes) continue;
         const { css } = extractCreatorNotesCss(creatorNotes);
-        if (css) cssBlocks.push(css);
+        if (!css) continue;
+
+        if (mode === "exclusive") {
+          // Scope each character's CSS to only their message elements
+          cssBlocks.push(scopeChatCss(css, `${CARD_CSS_SCOPE} [data-card-css="${char.id}"]`));
+        } else {
+          // "chat" mode — collect raw CSS, scope all together to the chat area
+          cssBlocks.push(css);
+        }
       } catch {
         // Malformed data — skip silently
       }
     }
 
     if (!cssBlocks.length) return "";
-    return scopeChatCss(cssBlocks.join("\n"), CARD_CSS_SCOPE);
-  }, [characters, chatCharacterIds]);
+    // In exclusive mode, blocks are already scoped individually
+    return mode === "exclusive" ? cssBlocks.join("\n") : scopeChatCss(cssBlocks.join("\n"), CARD_CSS_SCOPE);
+  }, [characters, chatCharacterIds, mode]);
 
   useEffect(() => {
     let style = document.getElementById(STYLE_ELEMENT_ID) as HTMLStyleElement | null;

--- a/packages/client/src/components/chat/CreatorNotesCssInjector.tsx
+++ b/packages/client/src/components/chat/CreatorNotesCssInjector.tsx
@@ -1,0 +1,69 @@
+// ──────────────────────────────────────────────
+// Creator Notes CSS Injector
+//
+// Extracts <style> blocks from each active character's
+// creator_notes, sanitises + scopes them, then injects
+// a single <style> element into <head>.
+//
+// Scoped to `.mari-card-css` — the chat surface wrapper
+// sets this class so card styles only affect the chat area.
+// ──────────────────────────────────────────────
+import { useEffect, useMemo } from "react";
+import { extractCreatorNotesCss } from "@marinara-engine/shared";
+import { scopeChatCss } from "../../lib/chat-css";
+
+const CARD_CSS_SCOPE = ".mari-card-css";
+const STYLE_ELEMENT_ID = "marinara-card-css";
+
+export function CreatorNotesCssInjector({
+  characters,
+  chatCharacterIds,
+}: {
+  characters: Array<{ id: string; data: string; avatarPath: string | null }> | undefined;
+  chatCharacterIds: string[];
+}) {
+  const scopedCss = useMemo(() => {
+    if (!characters?.length || !chatCharacterIds.length) return "";
+
+    const activeIdSet = new Set(chatCharacterIds);
+    const cssBlocks: string[] = [];
+
+    for (const char of characters) {
+      if (!activeIdSet.has(char.id)) continue;
+      try {
+        const parsed = typeof char.data === "string" ? JSON.parse(char.data) : char.data;
+        const creatorNotes: string = parsed.creator_notes ?? "";
+        if (!creatorNotes) continue;
+        const { css } = extractCreatorNotesCss(creatorNotes);
+        if (css) cssBlocks.push(css);
+      } catch {
+        // Malformed data — skip silently
+      }
+    }
+
+    if (!cssBlocks.length) return "";
+    return scopeChatCss(cssBlocks.join("\n"), CARD_CSS_SCOPE);
+  }, [characters, chatCharacterIds]);
+
+  useEffect(() => {
+    let style = document.getElementById(STYLE_ELEMENT_ID) as HTMLStyleElement | null;
+
+    if (!scopedCss) {
+      style?.remove();
+      return;
+    }
+
+    if (!style) {
+      style = document.createElement("style");
+      style.id = STYLE_ELEMENT_ID;
+      document.head.appendChild(style);
+    }
+    style.textContent = scopedCss;
+
+    return () => {
+      style?.remove();
+    };
+  }, [scopedCss]);
+
+  return null;
+}

--- a/packages/client/src/components/game/GameNarration.tsx
+++ b/packages/client/src/components/game/GameNarration.tsx
@@ -3753,7 +3753,6 @@ export function GameNarration({
 
         <div
           data-game-skip-bg-nav="true"
-          data-card-css={active?.sourceMessageId ? (sourceMessagesById.get(active.sourceMessageId)?.characterId ?? undefined) : undefined}
           className="shrink-0 rounded-2xl border border-[var(--border)] bg-[var(--card)]/90 p-3 shadow-[0_16px_38px_rgba(0,0,0,0.45)] backdrop-blur-md dark:border-white/15 dark:bg-black/50"
         >
           {/* Scene preparation gate: wait for effects before showing narration */}
@@ -3923,6 +3922,7 @@ export function GameNarration({
                       <div className="relative">
                         <div
                           ref={activeSegmentScrollRef}
+                          data-card-css={active.sourceMessageId ? (sourceMessagesById.get(active.sourceMessageId)?.characterId ?? undefined) : undefined}
                           onPointerDown={(event) => handleMobileSegmentPointerDown(event, active)}
                           onPointerUp={(event) => handleMobileSegmentTapToEdit(event, active)}
                           className={cn(
@@ -4071,6 +4071,7 @@ export function GameNarration({
 
               <div
                 ref={activeSegmentScrollRef}
+                data-card-css={active.sourceMessageId ? (sourceMessagesById.get(active.sourceMessageId)?.characterId ?? undefined) : undefined}
                 onPointerDown={(event) => handleMobileSegmentPointerDown(event, active)}
                 onPointerUp={(event) => handleMobileSegmentTapToEdit(event, active)}
                 className="relative game-narration-prose max-h-40 overflow-y-auto rounded-xl border border-[var(--border)] bg-[var(--muted)]/20 px-3 py-2.5 sm:max-h-48 dark:border-white/10 dark:bg-black/35"
@@ -4189,6 +4190,7 @@ export function GameNarration({
 
               <div
                 ref={activeSegmentScrollRef}
+                data-card-css={active.sourceMessageId ? (sourceMessagesById.get(active.sourceMessageId)?.characterId ?? undefined) : undefined}
                 className="relative game-narration-prose max-h-40 overflow-y-auto rounded-xl border border-amber-400/20 bg-amber-950/20 px-3 py-2.5 sm:max-h-48"
               >
                 <div

--- a/packages/client/src/components/game/GameNarration.tsx
+++ b/packages/client/src/components/game/GameNarration.tsx
@@ -3753,6 +3753,7 @@ export function GameNarration({
 
         <div
           data-game-skip-bg-nav="true"
+          data-card-css={active?.sourceMessageId ? (sourceMessagesById.get(active.sourceMessageId)?.characterId ?? undefined) : undefined}
           className="shrink-0 rounded-2xl border border-[var(--border)] bg-[var(--card)]/90 p-3 shadow-[0_16px_38px_rgba(0,0,0,0.45)] backdrop-blur-md dark:border-white/15 dark:bg-black/50"
         >
           {/* Scene preparation gate: wait for effects before showing narration */}

--- a/packages/client/src/components/game/GameNarration.tsx
+++ b/packages/client/src/components/game/GameNarration.tsx
@@ -3632,7 +3632,11 @@ export function GameNarration({
                 }}
               >
                 {stackedLogEntries.map((entry) => (
-                  <div key={entry.messageId} className="space-y-1.5">
+                  <div
+                    key={entry.messageId}
+                    className="space-y-1.5"
+                    data-card-css={sourceMessagesById.get(entry.messageId)?.characterId ?? undefined}
+                  >
                     {entry.segments.map((seg) => renderStackedLogSegment(seg))}
                   </div>
                 ))}
@@ -4381,7 +4385,11 @@ export function GameNarration({
                 const translatedEntryText = sourceMessage ? translations[entry.messageId] : undefined;
                 const entryIsTranslating = sourceMessage ? !!translating[entry.messageId] : false;
                 return (
-                  <div key={entry.messageId} className="space-y-1.5">
+                  <div
+                    key={entry.messageId}
+                    className="space-y-1.5"
+                    data-card-css={sourceMessage?.characterId ?? undefined}
+                  >
                     {entry.segments.map((seg) => {
                       const sourceMessageId = seg.sourceMessageId ?? entry.messageId;
                       const hasSourceSegmentIndex = seg.sourceSegmentIndex != null;

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -7956,7 +7956,7 @@ export function GameSurface({
   }
 
   return (
-    <div className="relative flex h-full overflow-hidden bg-black mari-card-css" style={{ isolation: "isolate" }}>
+    <div className="relative flex h-full overflow-hidden bg-black mari-card-css" data-chat-mode="game" style={{ isolation: "isolate" }}>
       <GameTransitionManager gameState={gameState} location={gameSnapshot?.location ?? null}>
         <DirectionEngine
           directions={activeDirections}

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -7956,7 +7956,7 @@ export function GameSurface({
   }
 
   return (
-    <div className="relative flex h-full overflow-hidden bg-black">
+    <div className="relative flex h-full overflow-hidden bg-black mari-card-css" style={{ isolation: "isolate" }}>
       <GameTransitionManager gameState={gameState} location={gameSnapshot?.location ?? null}>
         <DirectionEngine
           directions={activeDirections}

--- a/packages/client/src/lib/chat-css.ts
+++ b/packages/client/src/lib/chat-css.ts
@@ -1,0 +1,61 @@
+// ──────────────────────────────────────────────
+// Chat CSS: sanitisation & scoping utilities
+// ──────────────────────────────────────────────
+
+const CHAT_STYLE_BLOCK_RE = /<style\b[^>]*>([\s\S]*?)<\/style>/gi;
+const CSS_SELECTOR_RE = /(^|[{}])\s*([^@{}][^{]*)\{/g;
+
+/** Extract `<style>` blocks from HTML and return the CSS + the HTML without them. */
+export function extractChatStyleBlocks(html: string): { html: string; css: string } {
+  const cssBlocks: string[] = [];
+  const withoutStyles = html.replace(CHAT_STYLE_BLOCK_RE, (_match, css: string) => {
+    cssBlocks.push(css);
+    return "";
+  });
+  return { html: withoutStyles, css: cssBlocks.join("\n") };
+}
+
+/**
+ * Strip known-dangerous CSS constructs while preserving visual features
+ * like animations, gradients, pseudo-elements, and safe `url()` values.
+ */
+export function sanitizeChatCss(css: string): string {
+  return css
+    .replace(/<\/?style\b[^>]*>/gi, "")
+    .replace(/@import\s+[^;]+;?/gi, "")
+    .replace(/@namespace\s+[^;]+;?/gi, "")
+    .replace(/expression\s*\([^)]*\)/gi, "")
+    .replace(/javascript\s*:/gi, "")
+    .replace(/vbscript\s*:/gi, "")
+    .replace(/behavior\s*:/gi, "x-behavior:")
+    .replace(/-moz-binding\s*:/gi, "x-moz-binding:")
+    .replace(/url\s*\(\s*(['"]?)(?!data:image\/|https?:\/\/)[^)]+\)/gi, "none")
+    .replace(/position\s*:\s*fixed/gi, "position: absolute")
+    .replace(/<\/style/gi, "<\\/style")
+    .trim();
+}
+
+/**
+ * Prefix every CSS selector with a scope class so the styles only apply
+ * inside a designated container. Keyframe selectors (`from`, `to`, `%`)
+ * are preserved as-is; `body`/`html`/`:root` are rewritten to the scope.
+ */
+export function scopeChatCss(css: string, scopeSelector: string): string {
+  const sanitized = sanitizeChatCss(css);
+  if (!sanitized) return "";
+  return sanitized.replace(CSS_SELECTOR_RE, (_match, boundary: string, selectors: string) => {
+    const scopedSelectors = selectors
+      .split(",")
+      .map((selector) => {
+        const trimmed = selector.trim();
+        if (!trimmed) return "";
+        if (/^(from|to|\d+(?:\.\d+)?%)$/i.test(trimmed)) return trimmed;
+        if (trimmed.startsWith(scopeSelector)) return trimmed;
+        if (trimmed === ":root" || trimmed === "html" || trimmed === "body") return scopeSelector;
+        return `${scopeSelector} ${trimmed}`;
+      })
+      .filter(Boolean)
+      .join(", ");
+    return `${boundary} ${scopedSelectors}{`;
+  });
+}

--- a/packages/client/src/lib/chat-css.ts
+++ b/packages/client/src/lib/chat-css.ts
@@ -98,6 +98,8 @@ export function extractChatStyleBlocks(html: string): { html: string; css: strin
 export function sanitizeChatCss(css: string): string {
   return (
     css
+      // Strip CSS comments — they confuse the selector-scoping regex
+      .replace(/\/\*[\s\S]*?\*\//g, "")
       .replace(/<\/?style\b[^>]*>/gi, "")
       .replace(/@import\s+[^;]+;?/gi, "")
       .replace(/@namespace\s+[^;]+;?/gi, "")

--- a/packages/client/src/lib/chat-css.ts
+++ b/packages/client/src/lib/chat-css.ts
@@ -5,6 +5,78 @@
 const CHAT_STYLE_BLOCK_RE = /<style\b[^>]*>([\s\S]*?)<\/style>/gi;
 const CSS_SELECTOR_RE = /(^|[{}])\s*([^@{}][^{]*)\{/g;
 
+// ── Theme-token blocklist ────────────────────
+// App theme custom properties (shadcn / Tailwind) that card CSS must NOT
+// override. Declarations like `--background: red;` are stripped so a card
+// cannot repaint the application UI outside the chat surface.
+//
+// Card creators can still define their OWN custom properties
+// (e.g. `--my-char-glow: cyan`) — only the tokens below are blocked.
+const BLOCKED_THEME_TOKENS: readonly string[] = [
+  // shadcn core design tokens
+  "background",
+  "foreground",
+  "card",
+  "card-foreground",
+  "popover",
+  "popover-foreground",
+  "primary",
+  "primary-foreground",
+  "secondary",
+  "secondary-foreground",
+  "muted",
+  "muted-foreground",
+  "accent",
+  "accent-foreground",
+  "destructive",
+  "destructive-foreground",
+  "border",
+  "input",
+  "ring",
+  "radius",
+  // Sidebar tokens
+  "sidebar",
+  "sidebar-foreground",
+  "sidebar-border",
+  "sidebar-accent",
+  "sidebar-accent-foreground",
+  // Tailwind v4 `--color-*` aliases
+  "color-background",
+  "color-foreground",
+  "color-card",
+  "color-card-foreground",
+  "color-popover",
+  "color-popover-foreground",
+  "color-primary",
+  "color-primary-foreground",
+  "color-secondary",
+  "color-secondary-foreground",
+  "color-muted",
+  "color-muted-foreground",
+  "color-accent",
+  "color-accent-foreground",
+  "color-destructive",
+  "color-destructive-foreground",
+  "color-border",
+  "color-input",
+  "color-ring",
+  "color-sidebar",
+  "color-sidebar-foreground",
+  "color-sidebar-border",
+  "color-sidebar-accent",
+  "color-sidebar-accent-foreground",
+] as const;
+
+// Sort longest-first so regex alternation is greedy-safe.
+const sortedTokens = [...BLOCKED_THEME_TOKENS].sort((a, b) => b.length - a.length);
+
+// Matches `--<token>\s*:<value>;` — the `\s*:` ensures partial names like
+// `--background-image` are not accidentally caught.
+const THEME_TOKEN_RE = new RegExp(
+  `--(?:${sortedTokens.join("|")})\\s*:[^;}]+;?`,
+  "g",
+);
+
 /** Extract `<style>` blocks from HTML and return the CSS + the HTML without them. */
 export function extractChatStyleBlocks(html: string): { html: string; css: string } {
   const cssBlocks: string[] = [];
@@ -18,32 +90,90 @@ export function extractChatStyleBlocks(html: string): { html: string; css: strin
 /**
  * Strip known-dangerous CSS constructs while preserving visual features
  * like animations, gradients, pseudo-elements, and safe `url()` values.
+ *
+ * Also strips declarations of app theme custom properties (`--background`,
+ * `--card`, `--foreground`, etc.) to prevent card CSS from repainting the
+ * application UI outside the chat surface.
  */
 export function sanitizeChatCss(css: string): string {
-  return css
-    .replace(/<\/?style\b[^>]*>/gi, "")
-    .replace(/@import\s+[^;]+;?/gi, "")
-    .replace(/@namespace\s+[^;]+;?/gi, "")
-    .replace(/expression\s*\([^)]*\)/gi, "")
-    .replace(/javascript\s*:/gi, "")
-    .replace(/vbscript\s*:/gi, "")
-    .replace(/behavior\s*:/gi, "x-behavior:")
-    .replace(/-moz-binding\s*:/gi, "x-moz-binding:")
-    .replace(/url\s*\(\s*(['"]?)(?!data:image\/|https?:\/\/)[^)]+\)/gi, "none")
-    .replace(/position\s*:\s*fixed/gi, "position: absolute")
-    .replace(/<\/style/gi, "<\\/style")
-    .trim();
+  return (
+    css
+      .replace(/<\/?style\b[^>]*>/gi, "")
+      .replace(/@import\s+[^;]+;?/gi, "")
+      .replace(/@namespace\s+[^;]+;?/gi, "")
+      .replace(/expression\s*\([^)]*\)/gi, "")
+      .replace(/javascript\s*:/gi, "")
+      .replace(/vbscript\s*:/gi, "")
+      .replace(/behavior\s*:/gi, "x-behavior:")
+      .replace(/-moz-binding\s*:/gi, "x-moz-binding:")
+      .replace(/url\s*\(\s*(['"]?)(?!data:image\/|https?:\/\/)[^)]+\)/gi, "none")
+      .replace(/position\s*:\s*fixed/gi, "position: absolute")
+      .replace(/<\/style/gi, "<\\/style")
+      // Strip app theme token overrides
+      .replace(THEME_TOKEN_RE, "/* [blocked] */")
+      .trim()
+  );
 }
+
+/**
+ * Namespace `@keyframes` names with a prefix so card animations cannot
+ * collide with (or override) application-level animations.
+ * Also rewrites `animation` / `animation-name` property values to match.
+ */
+function namespaceKeyframes(css: string, prefix: string): string {
+  const names: string[] = [];
+
+  // 1. Rename @keyframes declarations
+  let result = css.replace(/@keyframes\s+([\w-]+)/g, (_m, name: string) => {
+    names.push(name);
+    return `@keyframes ${prefix}${name}`;
+  });
+
+  if (!names.length) return result;
+
+  // 2. Sort longest-first to prevent partial-name replacement issues
+  names.sort((a, b) => b.length - a.length);
+
+  // 3. Build a pattern matching any collected name bounded by CSS identifier edges
+  //    (hyphens are part of CSS identifiers, so \b alone is insufficient)
+  const escaped = names.map((n) => n.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+  const nameRe = new RegExp(`(?<![\\w-])(${escaped.join("|")})(?![\\w-])`, "g");
+
+  // 4. Rewrite animation / animation-name property values only
+  result = result.replace(
+    /(animation(?:-name)?\s*:[^;{}]*)/g,
+    (_m, propDecl: string) => propDecl.replace(nameRe, `${prefix}$1`),
+  );
+
+  return result;
+}
+
+// Matches :root, html, or body at the start of a selector, followed by
+// a CSS combinator/attachment boundary (space, [, :, ., #, >, +, ~, ,)
+// or end-of-string.  This allows compound selectors like
+// `:root[data-chat-mode="roleplay"]` to be rewritten correctly.
+const ROOT_SELECTOR_RE = /^(:root|html|body)(?=$|[\s[:.#>+~,])/;
 
 /**
  * Prefix every CSS selector with a scope class so the styles only apply
  * inside a designated container. Keyframe selectors (`from`, `to`, `%`)
  * are preserved as-is; `body`/`html`/`:root` are rewritten to the scope.
+ *
+ * Compound selectors like `:root[data-chat-mode="roleplay"] .foo` are
+ * rewritten to `<scope>[data-chat-mode="roleplay"] .foo` so card creators
+ * can target specific chat modes.
+ *
+ * Also namespaces `@keyframes` to prevent global animation-name collisions
+ * and strips app theme custom-property overrides.
  */
 export function scopeChatCss(css: string, scopeSelector: string): string {
   const sanitized = sanitizeChatCss(css);
   if (!sanitized) return "";
-  return sanitized.replace(CSS_SELECTOR_RE, (_match, boundary: string, selectors: string) => {
+
+  // Namespace @keyframes before scoping selectors
+  const withNsKeyframes = namespaceKeyframes(sanitized, "mc-");
+
+  return withNsKeyframes.replace(CSS_SELECTOR_RE, (_match, boundary: string, selectors: string) => {
     const scopedSelectors = selectors
       .split(",")
       .map((selector) => {
@@ -51,7 +181,11 @@ export function scopeChatCss(css: string, scopeSelector: string): string {
         if (!trimmed) return "";
         if (/^(from|to|\d+(?:\.\d+)?%)$/i.test(trimmed)) return trimmed;
         if (trimmed.startsWith(scopeSelector)) return trimmed;
-        if (trimmed === ":root" || trimmed === "html" || trimmed === "body") return scopeSelector;
+        // Replace :root / html / body prefix with the scope selector,
+        // preserving any compound suffix (e.g. [data-chat-mode="game"])
+        if (ROOT_SELECTOR_RE.test(trimmed)) {
+          return trimmed.replace(ROOT_SELECTOR_RE, scopeSelector);
+        }
         return `${scopeSelector} ${trimmed}`;
       })
       .filter(Boolean)

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -63,3 +63,4 @@ export * from "./utils/regex-safety.js";
 export * from "./utils/game-state-text.js";
 export * from "./utils/chat-summary-entries.js";
 export * from "./utils/quest-state.js";
+export * from "./utils/creator-notes-css.js";

--- a/packages/shared/src/utils/creator-notes-css.ts
+++ b/packages/shared/src/utils/creator-notes-css.ts
@@ -1,0 +1,23 @@
+// ──────────────────────────────────────────────
+// Creator Notes: CSS extraction
+// ──────────────────────────────────────────────
+
+const STYLE_BLOCK_RE = /<style\b[^>]*>([\s\S]*?)<\/style>/gi;
+
+/**
+ * Separate CSS `<style>` blocks from the human-readable portion
+ * of a character card's `creator_notes` field.
+ */
+export function extractCreatorNotesCss(creatorNotes: string): {
+  css: string;
+  text: string;
+} {
+  const cssBlocks: string[] = [];
+  const text = creatorNotes
+    .replace(STYLE_BLOCK_RE, (_match, css: string) => {
+      cssBlocks.push(css);
+      return "";
+    })
+    .trim();
+  return { css: cssBlocks.join("\n"), text };
+}


### PR DESCRIPTION
## Summary
- Extracts `<style>` blocks from character creator notes and injects them as scoped CSS into the chat area
- Adds a **tri-state mode selector** (Disabled / Exclusive / Chat) in Chat Settings → Card Theming:
  - **Disabled**: no card CSS is applied — characters' embedded styles are ignored
  - **Exclusive**: each character's CSS only affects their own messages (scoped via `data-card-css` attribute)
  - **Chat**: all card CSS affects the entire chat area, including UI elements (default)
- CSS is sanitized (`sanitizeChatCss`) and scoped (`scopeChatCss`) before injection
- `data-card-css` attributes added to message wrappers in all surface modes (roleplay, conversation, game narration)
- Chat metadata key: `cardCssMode` (replaces earlier `disabledCardCssCharIds` approach)

## Files changed
- `CreatorNotesCssInjector.tsx` — new component: extracts, sanitizes, scopes, and injects card CSS per mode
- `ChatArea.tsx` — reads `cardCssMode` from chat metadata, passes mode to injector in all 3 surface modes
- `ChatMessage.tsx` — adds `data-card-css` to narrator, roleplay, and iMessage wrapper elements
- `ConversationMessage.tsx` — adds `data-card-css` to grouped and regular message wrappers
- `GameNarration.tsx` — adds `data-card-css` to stacked and regular log entries
- `ChatSettingsDrawer.tsx` — replaces per-character on/off toggles with `CardCssModeSelector` tri-state UI

## Test plan
- [ ] Import a character card with `<style>` blocks in creator notes
- [ ] Verify **Chat** mode applies CSS to the entire chat area (including UI coloring)
- [ ] Verify **Exclusive** mode scopes CSS to only the character's own messages
- [ ] Verify **Disabled** mode removes all card CSS from the page
- [ ] Test with multiple characters that have CSS — verify exclusive mode isolates each
- [ ] Verify mode persists across page reloads (stored in chat metadata)
- [ ] Test in all surface modes: roleplay, conversation, and game narration
- [ ] Verify no CSS leaks outside the `.mari-card-css` scope in Chat and Exclusive modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)