### PR TITLE
feat: character-scoped regex scripts with ST card import

### DIFF
--- a/packages/client/src/components/characters/CharacterEditor.tsx
+++ b/packages/client/src/components/characters/CharacterEditor.tsx
@@ -4,7 +4,7 @@
 // Sections: Metadata, Description, Personality, Backstory,
 //           Appearance, Scenario, Dialogue, Advanced, Lorebook
 // ──────────────────────────────────────────────
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { toast } from "sonner";
 import { useQueryClient } from "@tanstack/react-query";
 import {
@@ -33,6 +33,7 @@ import {
 } from "../../hooks/use-characters";
 import { useUIStore } from "../../stores/ui.store";
 import { lorebookKeys, useLorebook } from "../../hooks/use-lorebooks";
+import { useRegexScripts, useUpdateRegexScript, useDeleteRegexScript, type RegexScriptRow } from "../../hooks/use-regex-scripts";
 import { useStartChatFromCharacter } from "../../hooks/use-start-chat-from-character";
 import { useConnections } from "../../hooks/use-connections";
 import { showConfirmDialog } from "../../lib/app-dialogs";
@@ -75,6 +76,7 @@ import {
   UserPlus,
   History,
   RotateCcw,
+  Code2,
 } from "lucide-react";
 import { cn, generateClientId, getAvatarCropStyle, type AvatarCrop, type LegacyAvatarCrop } from "../../lib/utils";
 import { extractColorsFromImage } from "../../lib/avatar-color-extraction";
@@ -104,6 +106,7 @@ const TABS = [
   { id: "stats", label: "Stats", icon: Swords },
   { id: "advanced", label: "Advanced", icon: Settings2 },
   { id: "lorebook", label: "Lorebook", icon: Library },
+  { id: "regex-scripts", label: "Regex Scripts", icon: Code2 },
 ] as const;
 
 type TabId = (typeof TABS)[number]["id"];
@@ -965,6 +968,7 @@ export function CharacterEditor() {
             )}
             {activeTab === "stats" && <StatsTab formData={formData} updateExtension={updateExtension} />}
             {activeTab === "lorebook" && <LorebookTab characterId={characterId} formData={formData} />}
+            {activeTab === "regex-scripts" && characterId && <RegexScriptsTab characterId={characterId} />}
           </div>
         </div>
       </div>
@@ -3320,6 +3324,118 @@ function LorebookTab({ characterId, formData }: { characterId: string | null; fo
               <p className="mt-2 text-xs text-[var(--muted-foreground)] line-clamp-3">{entry.content}</p>
             </div>
           ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function RegexScriptsTab({ characterId }: { characterId: string }) {
+  const { data: allScripts } = useRegexScripts([characterId]);
+  const updateScript = useUpdateRegexScript();
+  const deleteScript = useDeleteRegexScript();
+
+  const scripts = useMemo(
+    () => (allScripts ?? []).filter((s) => s.characterId === characterId),
+    [allScripts, characterId],
+  );
+
+  const toggleEnabled = (script: RegexScriptRow) => {
+    updateScript.mutate({ id: script.id, enabled: script.enabled !== "true" });
+  };
+
+  const handleDelete = async (script: RegexScriptRow) => {
+    const confirmed = await showConfirmDialog({ message: `Delete regex script "${script.name}"?` });
+    if (confirmed) deleteScript.mutate(script.id);
+  };
+
+  const parsePlacement = (raw: string): string[] => {
+    try {
+      return JSON.parse(raw) as string[];
+    } catch {
+      return [];
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <SectionHeader
+        title="Character Regex Scripts"
+        subtitle="Find-and-replace scripts imported with this character. Applied only when this character is active in a chat."
+      />
+
+      {scripts.length === 0 ? (
+        <div className="flex flex-col items-center gap-3 rounded-xl border-2 border-dashed border-[var(--border)] py-12 text-center">
+          <Code2 size="1.5rem" className="text-[var(--muted-foreground)]/40" />
+          <div>
+            <p className="text-sm font-medium text-[var(--muted-foreground)]">No regex scripts</p>
+            <p className="mt-0.5 text-xs text-[var(--muted-foreground)]/60">
+              Import a character with embedded regex scripts to see them here.
+            </p>
+          </div>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {scripts.map((script) => {
+            const enabled = script.enabled === "true";
+            const placements = parsePlacement(script.placement);
+            return (
+              <div
+                key={script.id}
+                className={cn(
+                  "group relative rounded-xl border p-3 transition-all",
+                  enabled
+                    ? "border-[var(--border)] bg-[var(--card)]"
+                    : "border-[var(--border)]/50 bg-[var(--card)]/50 opacity-60",
+                )}
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <div className="min-w-0 flex-1">
+                    <p className="text-sm font-medium">{script.name}</p>
+                    <p className="mt-1 font-mono text-[0.625rem] text-[var(--muted-foreground)] break-all">
+                      /{script.findRegex}/{script.flags}
+                    </p>
+                    {script.replaceString && (
+                      <p className="mt-0.5 font-mono text-[0.625rem] text-[var(--muted-foreground)] break-all">
+                        → {script.replaceString}
+                      </p>
+                    )}
+                    <div className="mt-1.5 flex flex-wrap gap-1">
+                      {placements.map((p) => (
+                        <span
+                          key={p}
+                          className="rounded-full bg-[var(--primary)]/10 px-1.5 py-0.5 text-[0.5625rem] font-medium text-[var(--primary)]"
+                        >
+                          {p === "ai_output" ? "AI Output" : p === "user_input" ? "User Input" : p}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                  <div className="flex shrink-0 items-center gap-1">
+                    <button
+                      type="button"
+                      onClick={() => toggleEnabled(script)}
+                      className={cn(
+                        "rounded-lg px-2 py-1 text-[0.625rem] font-medium transition-all",
+                        enabled
+                          ? "bg-emerald-500/15 text-emerald-500 hover:bg-emerald-500/25"
+                          : "bg-[var(--muted-foreground)]/15 text-[var(--muted-foreground)] hover:bg-[var(--muted-foreground)]/25",
+                      )}
+                    >
+                      {enabled ? "On" : "Off"}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleDelete(script)}
+                      className="flex h-6 w-6 items-center justify-center rounded-lg text-[var(--destructive)] transition-colors hover:bg-[var(--destructive)]/15 active:scale-90"
+                    >
+                      <Trash2 size="0.75rem" />
+                    </button>
+                  </div>
+                </div>
+              </div>
+            );
+          })}
         </div>
       )}
     </div>

--- a/packages/client/src/components/chat/ChatInput.tsx
+++ b/packages/client/src/components/chat/ChatInput.tsx
@@ -181,7 +181,11 @@ export const ChatInput = memo(function ChatInput({
     [activeChatCharacters, characterNames],
   );
   const { generate } = useGenerate();
-  const { applyToUserInput } = useApplyRegex();
+  const chatCharacterIds = useMemo(
+    () => activeChatCharacters?.map((c) => c.id),
+    [activeChatCharacters],
+  );
+  const { applyToUserInput } = useApplyRegex(chatCharacterIds);
   const enterToSend = useUIStore((s) => s.enterToSendRP);
   const guideGenerations = useUIStore((s) => s.guideGenerations);
   const showQuickRepliesMenu = useUIStore((s) => s.showQuickRepliesMenu);

--- a/packages/client/src/components/chat/ChatInput.tsx
+++ b/packages/client/src/components/chat/ChatInput.tsx
@@ -21,7 +21,7 @@ import { useQueryClient, type InfiniteData } from "@tanstack/react-query";
 import { useChatStore } from "../../stores/chat.store";
 import { useUIStore } from "../../stores/ui.store";
 import { useGenerate } from "../../hooks/use-generate";
-import { useApplyRegex } from "../../hooks/use-apply-regex";
+import { useApplyRegex, type ScopedRegexMode } from "../../hooks/use-apply-regex";
 import { useCreateMessage, useDeleteMessage, useUpdateMessageExtra, chatKeys } from "../../hooks/use-chats";
 import { characterKeys } from "../../hooks/use-characters";
 import { buildGuidedGenerationInstructionMessage, type Message } from "@marinara-engine/shared";
@@ -584,10 +584,13 @@ export const ChatInput = memo(function ChatInput({
     const cachedCharacters = qc.getQueryData<Array<{ id: string; data: unknown }>>(characterKeys.list());
     const cachedPersonas = qc.getQueryData<Array<Record<string, unknown>>>(characterKeys.personas);
     const resolveInputMacros = createInputMacroResolverForChat(chat, cachedCharacters, cachedPersonas, normalized);
-    let message = applyToUserInput(normalized, { resolveMacros: resolveInputMacros });
+    const chatMeta = parseChatMetadata(chat?.metadata);
+    let message = applyToUserInput(normalized, {
+      scopedMode: (chatMeta.scopedRegexMode as ScopedRegexMode) || "exclusive",
+      resolveMacros: resolveInputMacros,
+    });
 
     // Input translation: translate user's message before sending
-    const chatMeta = parseChatMetadata(chat?.metadata);
     if (chatMeta.translateInput && message.trim()) {
       try {
         const { translateText } = await import("../../lib/translate-text");
@@ -761,9 +764,12 @@ export const ChatInput = memo(function ChatInput({
     const cachedCharacters = qc.getQueryData<Array<{ id: string; data: unknown }>>(characterKeys.list());
     const cachedPersonas = qc.getQueryData<Array<Record<string, unknown>>>(characterKeys.personas);
     const resolveInputMacros = createInputMacroResolverForChat(chat, cachedCharacters, cachedPersonas, normalized);
-    let message = applyToUserInput(normalized, { resolveMacros: resolveInputMacros });
-
     const chatMeta = parseChatMetadata(chat?.metadata);
+    let message = applyToUserInput(normalized, {
+      scopedMode: (chatMeta.scopedRegexMode as ScopedRegexMode) || "exclusive",
+      resolveMacros: resolveInputMacros,
+    });
+
     if (chatMeta.translateInput && message.trim()) {
       try {
         const { translateText } = await import("../../lib/translate-text");

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -1001,7 +1001,7 @@ export const ChatMessage = memo(function ChatMessage({
   }, []);
 
   // Apply regex scripts to AI output (assistant/narrator roles)
-  const { applyToAIOutput } = useApplyRegex();
+  const { applyToAIOutput } = useApplyRegex(chatCharacterIds);
 
   const scopedCharacterMap = useMemo(() => {
     if (!characterMap) return null;

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -1002,6 +1002,13 @@ export const ChatMessage = memo(function ChatMessage({
 
   // Apply regex scripts to AI output (assistant/narrator roles)
   const { applyToAIOutput } = useApplyRegex(chatCharacterIds);
+  const scopedRegexMode = useChatStore((s) => {
+    const meta = s.activeChat?.metadata;
+    if (!meta) return "exclusive";
+    const parsed = typeof meta === "string" ? (() => { try { return JSON.parse(meta); } catch { return {}; } })() : meta;
+    const mode = parsed?.scopedRegexMode;
+    return mode === "disabled" || mode === "chat" ? mode : "exclusive";
+  });
 
   const scopedCharacterMap = useMemo(() => {
     if (!characterMap) return null;
@@ -1059,7 +1066,12 @@ export const ChatMessage = memo(function ChatMessage({
     const text =
       isUser || isSystem
         ? message.content
-        : applyToAIOutput(message.content, { depth: messageDepth, resolveMacros: resolveDisplayMacros });
+        : applyToAIOutput(message.content, {
+            scopedMode: scopedRegexMode,
+            characterId: message.characterId ?? undefined,
+            depth: messageDepth,
+            resolveMacros: resolveDisplayMacros,
+          });
     return resolveDisplayMacros(text);
   }, [
     applyToAIOutput,
@@ -1067,8 +1079,10 @@ export const ChatMessage = memo(function ChatMessage({
     isSystem,
     isUser,
     macroCharacters,
+    message.characterId,
     message.content,
     messageDepth,
+    scopedRegexMode,
     personaAppearance,
     personaBackstory,
     personaDescription,

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -54,6 +54,7 @@ import {
   Drama,
   RotateCcw,
   Music2,
+  Code2,
 } from "lucide-react";
 import { cn, getAvatarCropStyle, type AvatarCrop } from "../../lib/utils";
 import { showAlertDialog, showConfirmDialog, showPromptDialog } from "../../lib/app-dialogs";
@@ -155,6 +156,7 @@ import {
   useHapticDisconnect,
   useHapticStartScan,
 } from "../../hooks/use-haptic";
+import { useRegexScripts, useUpdateRegexScript, type RegexScriptRow } from "../../hooks/use-regex-scripts";
 import { normalizeSpritePlacements } from "./sprite-placement";
 import {
   DEFAULT_SPRITE_DISPLAY_MODES,
@@ -325,6 +327,7 @@ export function ChatSettingsDrawer({
   const { data: characterGroups } = useCharacterGroups();
   const { data: lorebooks } = useLorebooks();
   const { data: presets } = usePresets();
+  const updateRegexScript = useUpdateRegexScript();
   const chatMode = (chat as unknown as { mode?: string }).mode ?? "roleplay";
   const isConversation = chatMode === "conversation";
   const isGame = chatMode === "game";
@@ -375,6 +378,11 @@ export function ChatSettingsDrawer({
     [chatCharIds, inactiveCharacterIds],
   );
   const supportsCharacterActivityToggle = chatCharIds.length > 1 && !isGame;
+  const { data: allRegexScripts } = useRegexScripts(activeCharacterIds);
+  const scopedRegexScripts = useMemo(
+    () => (allRegexScripts ?? []).filter((s) => s.characterId !== null),
+    [allRegexScripts],
+  );
   const isSceneChat = metadata.sceneStatus === "active" || typeof metadata.sceneOriginChatId === "string";
   const hasGeneratedConversationSchedules =
     !!metadata.characterSchedules &&
@@ -3602,6 +3610,26 @@ export function ChatSettingsDrawer({
             )}
           </Section>
 
+          {/* Scoped Regex Scripts — character-scoped scripts for active characters */}
+          {scopedRegexScripts.length > 0 && (
+            <Section
+              label="Scoped Regex Scripts"
+              icon={<Code2 size="0.875rem" />}
+              count={scopedRegexScripts.length}
+              help="Find-and-replace scripts imported with characters. These are scoped to specific characters and can be configured per chat."
+            >
+              <ScopedRegexModeSelector
+                mode={typeof metadata.scopedRegexMode === "string" ? metadata.scopedRegexMode : "exclusive"}
+                onChange={(mode) => updateMeta.mutate({ id: chat.id, scopedRegexMode: mode })}
+              />
+              <ScopedRegexCharacterGroups
+                scripts={scopedRegexScripts}
+                charNameMap={charNameMap}
+                onToggle={(id, enabled) => updateRegexScript.mutate({ id, enabled })}
+              />
+            </Section>
+          )}
+
           {/* Agents — hidden for conversation mode */}
           {!isConversation && (
             <Section
@@ -6434,6 +6462,165 @@ function SpriteDisplayModeToggle({
           );
         })}
       </div>
+    </div>
+  );
+}
+
+// ── Scoped regex mode selector (tri-state: disabled / exclusive / chat) ──
+function ScopedRegexModeSelector({
+  mode,
+  onChange,
+}: {
+  mode: string;
+  onChange: (mode: string) => void;
+}) {
+  const options = [
+    {
+      id: "disabled",
+      label: "Disabled",
+      tooltip: "Scoped scripts don't run — only global regex scripts apply",
+    },
+    {
+      id: "exclusive",
+      label: "Exclusive",
+      tooltip: "Each character's scripts only apply to that character's own messages",
+    },
+    {
+      id: "chat",
+      label: "Chat",
+      tooltip: "All scoped scripts apply to every message, including user and persona input",
+    },
+  ];
+
+  return (
+    <div className="space-y-1.5 rounded-lg bg-[var(--background)]/75 px-3 py-2 ring-1 ring-[var(--border)]">
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-[0.6875rem] font-medium text-[var(--foreground)]">Script Mode</span>
+      </div>
+      <div className="grid grid-cols-3 overflow-hidden rounded-md ring-1 ring-[var(--border)]">
+        {options.map((option, index) => {
+          const active = mode === option.id;
+          return (
+            <button
+              key={option.id}
+              type="button"
+              onClick={() => onChange(option.id)}
+              className={cn(
+                "min-w-0 px-2.5 py-1.5 text-[0.625rem] font-medium transition-colors",
+                index > 0 && "border-l border-[var(--border)]",
+                active
+                  ? "bg-[var(--primary)] text-[var(--primary-foreground)]"
+                  : "text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]",
+              )}
+              title={option.tooltip}
+            >
+              {option.label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// ── Scoped regex scripts grouped by character (collapsible) ──
+function ScopedRegexCharacterGroups({
+  scripts,
+  charNameMap,
+  onToggle,
+}: {
+  scripts: RegexScriptRow[];
+  charNameMap: Map<string, string>;
+  onToggle: (id: string, enabled: boolean) => void;
+}) {
+  const grouped = useMemo(() => {
+    const map = new Map<string, RegexScriptRow[]>();
+    for (const script of scripts) {
+      if (!script.characterId) continue;
+      const existing = map.get(script.characterId);
+      if (existing) existing.push(script);
+      else map.set(script.characterId, [script]);
+    }
+    return map;
+  }, [scripts]);
+
+  return (
+    <div className="space-y-1.5 mt-2">
+      {[...grouped.entries()].map(([charId, charScripts]) => (
+        <ScopedRegexCharacterGroup
+          key={charId}
+          characterName={charNameMap.get(charId) ?? "Unknown"}
+          scripts={charScripts}
+          onToggle={onToggle}
+        />
+      ))}
+    </div>
+  );
+}
+
+function ScopedRegexCharacterGroup({
+  characterName,
+  scripts,
+  onToggle,
+}: {
+  characterName: string;
+  scripts: RegexScriptRow[];
+  onToggle: (id: string, enabled: boolean) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const enabledCount = scripts.filter((s) => s.enabled === "true").length;
+
+  return (
+    <div className="rounded-lg border border-[var(--border)] overflow-hidden">
+      <button
+        onClick={() => setOpen((o) => !o)}
+        className="flex w-full items-center gap-2 px-3 py-2 text-left transition-colors hover:bg-[var(--accent)]/50"
+      >
+        <div className="flex-1 min-w-0">
+          <span className="text-[0.6875rem] font-semibold">{characterName}</span>
+        </div>
+        <span className="rounded-full bg-[var(--primary)]/15 px-1.5 py-0.5 text-[0.5625rem] font-medium text-[var(--primary)]">
+          {enabledCount}/{scripts.length}
+        </span>
+        <ChevronDown
+          size="0.625rem"
+          className={cn("text-[var(--muted-foreground)] transition-transform shrink-0", open && "rotate-180")}
+        />
+      </button>
+      {open && (
+        <div className="px-3 pb-2.5 space-y-1">
+          {scripts.map((script) => {
+            const isEnabled = script.enabled === "true";
+            return (
+              <div
+                key={script.id}
+                className="flex items-center gap-2 rounded-md px-2 py-1.5 ring-1 ring-[var(--border)] bg-[var(--card)]"
+              >
+                <div className="flex-1 min-w-0">
+                  <p className="text-[0.625rem] font-medium text-[var(--foreground)] truncate">
+                    {script.name || script.findRegex}
+                  </p>
+                  <p className="text-[0.5625rem] text-[var(--muted-foreground)] truncate">
+                    /{script.findRegex}/ &rarr; {script.replaceString || "(empty)"}
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => onToggle(script.id, !isEnabled)}
+                  className={cn(
+                    "shrink-0 rounded-md px-2 py-0.5 text-[0.5625rem] font-medium transition-colors",
+                    isEnabled
+                      ? "bg-[var(--primary)] text-[var(--primary-foreground)]"
+                      : "bg-[var(--secondary)] text-[var(--muted-foreground)]",
+                  )}
+                >
+                  {isEnabled ? "On" : "Off"}
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -373,10 +373,25 @@ export function ChatSettingsDrawer({
         : [],
     [chatCharIds, metadata.inactiveCharacterIds],
   );
-  const activeCharacterIds = useMemo<string[]>(
-    () => chatCharIds.filter((id) => !inactiveCharacterIds.includes(id)),
-    [chatCharIds, inactiveCharacterIds],
-  );
+  const activeCharacterIds = useMemo<string[]>(() => {
+    const base = chatCharIds.filter((id) => !inactiveCharacterIds.includes(id));
+    if (!isGame) return base;
+    // In game mode, include GM and party member character IDs so their
+    // scoped regex scripts are fetched and shown in the settings drawer.
+    const ids = new Set(base);
+    const config = metadata.gameSetupConfig as Record<string, unknown> | undefined;
+    if (typeof config?.gmCharacterId === "string") ids.add(config.gmCharacterId);
+    if (Array.isArray(metadata.gamePartyCharacterIds)) {
+      for (const id of metadata.gamePartyCharacterIds as string[]) {
+        if (typeof id === "string" && id.trim()) ids.add(id);
+      }
+    } else if (Array.isArray(config?.partyCharacterIds)) {
+      for (const id of config.partyCharacterIds as string[]) {
+        if (typeof id === "string" && id.trim()) ids.add(id);
+      }
+    }
+    return [...ids];
+  }, [chatCharIds, inactiveCharacterIds, isGame, metadata]);
   const supportsCharacterActivityToggle = chatCharIds.length > 1 && !isGame;
   const { data: allRegexScripts } = useRegexScripts(activeCharacterIds);
   const scopedRegexScripts = useMemo(

--- a/packages/client/src/components/chat/ConversationInput.tsx
+++ b/packages/client/src/components/chat/ConversationInput.tsx
@@ -224,7 +224,6 @@ export function ConversationInput({
   const setCurrentInput = useChatStore((s) => s.setCurrentInput);
   const currentInput = useChatStore((s) => s.currentInput);
   const { generate } = useGenerate();
-  const { applyToUserInput } = useApplyRegex();
   const enterToSend = useUIStore((s) => s.enterToSendConvo);
   const guideGenerations = useUIStore((s) => s.guideGenerations);
   const showQuickRepliesMenu = useUIStore((s) => s.showQuickRepliesMenu);
@@ -258,6 +257,11 @@ export function ConversationInput({
     () => chatCharacters?.filter((character) => !inactiveCharacterIds.has(character.id)),
     [chatCharacters, inactiveCharacterIds],
   );
+  const chatCharacterIds = useMemo(
+    () => activeChatCharacters?.map((c) => c.id),
+    [activeChatCharacters],
+  );
+  const { applyToUserInput } = useApplyRegex(chatCharacterIds);
   const activeCharacterNames = useMemo(
     () => (activeChatCharacters ? activeChatCharacters.map((character) => character.name) : characterNames),
     [activeChatCharacters, characterNames],

--- a/packages/client/src/components/chat/ConversationInput.tsx
+++ b/packages/client/src/components/chat/ConversationInput.tsx
@@ -26,7 +26,7 @@ import { useQueryClient, type InfiniteData } from "@tanstack/react-query";
 import { useChatStore } from "../../stores/chat.store";
 import { useUIStore } from "../../stores/ui.store";
 import { useGenerate } from "../../hooks/use-generate";
-import { useApplyRegex } from "../../hooks/use-apply-regex";
+import { useApplyRegex, type ScopedRegexMode } from "../../hooks/use-apply-regex";
 import { useCreateMessage, useDeleteMessage, useUpdateMessageExtra, useChat, chatKeys } from "../../hooks/use-chats";
 import { characterKeys, usePersonas, useUpdatePersona } from "../../hooks/use-characters";
 import {
@@ -582,9 +582,12 @@ export function ConversationInput({
       const cachedPersonas = qc.getQueryData<Array<Record<string, unknown>>>(characterKeys.personas);
       const resolveInputMacros = createInputMacroResolverForChat(activeChatData, cachedCharacters, cachedPersonas, raw);
       // First pass: resolve macros against raw input, so {{input}} uses the pre-translation text.
-      let message = applyToUserInput(raw, { resolveMacros: resolveInputMacros });
-      // Input translation for streaming path too
       const streamMeta = parseChatMetadata(activeChatData?.metadata);
+      let message = applyToUserInput(raw, {
+        scopedMode: (streamMeta.scopedRegexMode as ScopedRegexMode) || "exclusive",
+        resolveMacros: resolveInputMacros,
+      });
+      // Input translation for streaming path too
       if (streamMeta.translateInput && message.trim()) {
         try {
           const { translateText } = await import("../../lib/translate-text");
@@ -687,10 +690,13 @@ export function ConversationInput({
     const cachedPersonas = qc.getQueryData<Array<Record<string, unknown>>>(characterKeys.personas);
     const resolveInputMacros = createInputMacroResolverForChat(activeChat, cachedCharacters, cachedPersonas, raw);
     // First pass: resolve macros against raw input, so {{input}} uses the pre-translation text.
-    let message = applyToUserInput(raw, { resolveMacros: resolveInputMacros });
+    const chatMeta = parseChatMetadata(activeChat?.metadata);
+    let message = applyToUserInput(raw, {
+      scopedMode: (chatMeta.scopedRegexMode as ScopedRegexMode) || "exclusive",
+      resolveMacros: resolveInputMacros,
+    });
 
     // Input translation: translate user's message before sending
-    const chatMeta = parseChatMetadata(activeChat?.metadata);
     if (chatMeta.translateInput && message.trim()) {
       try {
         const { translateText } = await import("../../lib/translate-text");
@@ -879,9 +885,12 @@ export function ConversationInput({
     const cachedCharacters = qc.getQueryData<Array<{ id: string; data: unknown }>>(characterKeys.list());
     const cachedPersonas = qc.getQueryData<Array<Record<string, unknown>>>(characterKeys.personas);
     const resolveInputMacros = createInputMacroResolverForChat(activeChatData, cachedCharacters, cachedPersonas, raw);
-    let message = applyToUserInput(raw, { resolveMacros: resolveInputMacros });
-
     const chatMeta = parseChatMetadata(activeChatData?.metadata);
+    let message = applyToUserInput(raw, {
+      scopedMode: (chatMeta.scopedRegexMode as ScopedRegexMode) || "exclusive",
+      resolveMacros: resolveInputMacros,
+    });
+
     if (chatMeta.translateInput && message.trim()) {
       try {
         const { translateText } = await import("../../lib/translate-text");

--- a/packages/client/src/components/game/GameNarration.tsx
+++ b/packages/client/src/components/game/GameNarration.tsx
@@ -50,6 +50,7 @@ import type { SpriteInfo } from "../../hooks/use-characters";
 import { useTranslate } from "../../hooks/use-translate";
 import { useTTSConfig } from "../../hooks/use-tts";
 import { useApplyRegex } from "../../hooks/use-apply-regex";
+import { useChatStore } from "../../stores/chat.store";
 import { useGameAssetStore } from "../../stores/game-asset.store";
 import { useGameModeStore } from "../../stores/game-mode.store";
 import { useUIStore } from "../../stores/ui.store";
@@ -940,6 +941,13 @@ export function GameNarration({
 }: GameNarrationProps) {
   const { translations, translating } = useTranslate();
   const { applyToAIOutput } = useApplyRegex(activeCharacterIds);
+  const scopedRegexMode = useChatStore((s) => {
+    const meta = s.activeChat?.metadata;
+    if (!meta) return "exclusive";
+    const parsed = typeof meta === "string" ? (() => { try { return JSON.parse(meta); } catch { return {}; } })() : meta;
+    const mode = parsed?.scopedRegexMode;
+    return mode === "disabled" || mode === "chat" ? mode : "exclusive";
+  });
   const [activeIndex, setActiveIndex] = useState(0);
   const [visibleChars, setVisibleChars] = useState(0);
   const [logsOpen, setLogsOpen] = useState(false);
@@ -1060,6 +1068,14 @@ export function GameNarration({
       byId.set(messages[index]!.id, depth);
     }
     return byId;
+  }, [messages]);
+
+  const msgCharIdMap = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const msg of messages) {
+      if (msg.characterId) map.set(msg.id, msg.characterId);
+    }
+    return map;
   }, [messages]);
 
   const speakerAvatarInfos = useMemo(() => {
@@ -1321,11 +1337,13 @@ export function GameNarration({
     ) => {
       if (sourceRole !== "assistant" && sourceRole !== "narrator") return text;
       return applyToAIOutput(text, {
+        scopedMode: scopedRegexMode,
+        characterId: sourceMessageId ? msgCharIdMap.get(sourceMessageId) : undefined,
         depth: sourceMessageId ? messageDepthById.get(sourceMessageId) : undefined,
         resolveMacros: resolveMacrosForText,
       });
     },
-    [applyToAIOutput, messageDepthById],
+    [applyToAIOutput, messageDepthById, msgCharIdMap, scopedRegexMode],
   );
 
   const prepareSegmentText = useCallback(

--- a/packages/client/src/components/game/GameNarration.tsx
+++ b/packages/client/src/components/game/GameNarration.tsx
@@ -939,7 +939,7 @@ export function GameNarration({
   onMaxNavOffsetChange,
 }: GameNarrationProps) {
   const { translations, translating } = useTranslate();
-  const { applyToAIOutput } = useApplyRegex();
+  const { applyToAIOutput } = useApplyRegex(activeCharacterIds);
   const [activeIndex, setActiveIndex] = useState(0);
   const [visibleChars, setVisibleChars] = useState(0);
   const [logsOpen, setLogsOpen] = useState(false);

--- a/packages/client/src/hooks/use-apply-regex.ts
+++ b/packages/client/src/hooks/use-apply-regex.ts
@@ -5,6 +5,10 @@ import { useCallback, useMemo } from "react";
 import { useRegexScripts, type RegexScriptRow } from "./use-regex-scripts";
 import { applyRegexReplacement, type RegexPlacement } from "@marinara-engine/shared";
 
+export type ScopedRegexMode = "disabled" | "exclusive" | "chat";
+
+type ParsedScript = ReturnType<typeof parseScript>;
+
 /**
  * Parses a RegexScriptRow from DB into a usable form.
  */
@@ -32,6 +36,18 @@ function parseScript(row: RegexScriptRow) {
   };
 }
 
+function filterForMode(
+  scripts: ParsedScript[],
+  mode: ScopedRegexMode,
+  characterId: string | undefined,
+): ParsedScript[] {
+  if (mode === "disabled") return scripts.filter((s) => s.characterId === null);
+  if (mode === "chat") return scripts;
+  // "exclusive": global + only the owning character's scripts
+  if (!characterId) return scripts.filter((s) => s.characterId === null);
+  return scripts.filter((s) => s.characterId === null || s.characterId === characterId);
+}
+
 /**
  * Applies all enabled regex scripts for a given placement to the input text.
  * @param depth — message depth (0 = latest message, 1 = one before, etc.). When
@@ -39,7 +55,7 @@ function parseScript(row: RegexScriptRow) {
  */
 function applyScripts(
   text: string,
-  scripts: ReturnType<typeof parseScript>[],
+  scripts: ParsedScript[],
   placement: RegexPlacement,
   options?: { promptOnly?: boolean; depth?: number; resolveMacros?: (value: string) => string },
 ): string {
@@ -79,12 +95,20 @@ function applyScripts(
   return result;
 }
 
+interface RegexApplyOptions {
+  scopedMode?: ScopedRegexMode;
+  characterId?: string;
+  depth?: number;
+  resolveMacros?: (value: string) => string;
+}
+
 /**
  * Hook that provides functions to apply regex transformations.
  *
- * Usage:
- *   const { applyToAIOutput, applyToUserInput } = useApplyRegex();
- *   const displayText = applyToAIOutput(message.content);
+ * Scoped regex modes control how character-scoped scripts are applied:
+ * - `disabled` — scoped scripts are ignored; only global scripts run.
+ * - `exclusive` (default) — scoped scripts only apply to their owning character's messages.
+ * - `chat` — all scoped scripts apply to every message, including user input.
  */
 export function useApplyRegex(characterIds?: string[]) {
   const { data: regexScripts } = useRegexScripts(characterIds);
@@ -96,24 +120,30 @@ export function useApplyRegex(characterIds?: string[]) {
   }, [regexScripts]);
 
   const applyToAIOutput = useCallback(
-    (text: string, options?: { depth?: number; resolveMacros?: (value: string) => string }) =>
-      applyScripts(text, parsedScripts, "ai_output", options),
+    (text: string, options?: RegexApplyOptions) => {
+      const mode = options?.scopedMode ?? "exclusive";
+      const filtered = filterForMode(parsedScripts, mode, options?.characterId);
+      return applyScripts(text, filtered, "ai_output", options);
+    },
     [parsedScripts],
   );
 
   const applyToUserInput = useCallback(
-    (text: string, options?: { depth?: number; resolveMacros?: (value: string) => string }) =>
-      applyScripts(text, parsedScripts, "user_input", options),
+    (text: string, options?: RegexApplyOptions) => {
+      const mode = options?.scopedMode ?? "exclusive";
+      const filtered = filterForMode(parsedScripts, mode, options?.characterId);
+      return applyScripts(text, filtered, "user_input", options);
+    },
     [parsedScripts],
   );
 
   // Applies scripts in prompt context. Visual scripts are intentionally skipped.
   const applyPromptOnly = useCallback(
-    (
-      text: string,
-      placement: RegexPlacement,
-      options?: { depth?: number; resolveMacros?: (value: string) => string },
-    ) => applyScripts(text, parsedScripts, placement, { promptOnly: true, ...options }),
+    (text: string, placement: RegexPlacement, options?: RegexApplyOptions) => {
+      const mode = options?.scopedMode ?? "exclusive";
+      const filtered = filterForMode(parsedScripts, mode, options?.characterId);
+      return applyScripts(text, filtered, placement, { promptOnly: true, ...options });
+    },
     [parsedScripts],
   );
 

--- a/packages/client/src/hooks/use-apply-regex.ts
+++ b/packages/client/src/hooks/use-apply-regex.ts
@@ -86,8 +86,8 @@ function applyScripts(
  *   const { applyToAIOutput, applyToUserInput } = useApplyRegex();
  *   const displayText = applyToAIOutput(message.content);
  */
-export function useApplyRegex() {
-  const { data: regexScripts } = useRegexScripts();
+export function useApplyRegex(characterIds?: string[]) {
+  const { data: regexScripts } = useRegexScripts(characterIds);
 
   // Pre-parse all scripts (sorted by order, which is done server-side)
   const parsedScripts = useMemo(() => {

--- a/packages/client/src/hooks/use-regex-scripts.ts
+++ b/packages/client/src/hooks/use-regex-scripts.ts
@@ -11,6 +11,7 @@ const regexKeys = {
 
 export interface RegexScriptRow {
   id: string;
+  characterId: string | null;
   name: string;
   enabled: string;
   findRegex: string;
@@ -26,10 +27,11 @@ export interface RegexScriptRow {
   updatedAt: string;
 }
 
-export function useRegexScripts() {
+export function useRegexScripts(characterIds?: string[]) {
+  const queryParam = characterIds?.length ? `?characterIds=${characterIds.join(",")}` : "";
   return useQuery({
-    queryKey: regexKeys.all,
-    queryFn: () => api.get<RegexScriptRow[]>("/regex-scripts"),
+    queryKey: characterIds?.length ? [...regexKeys.all, ...characterIds] : regexKeys.all,
+    queryFn: () => api.get<RegexScriptRow[]>(`/regex-scripts${queryParam}`),
   });
 }
 

--- a/packages/server/src/db/schema/regex-scripts.ts
+++ b/packages/server/src/db/schema/regex-scripts.ts
@@ -5,6 +5,8 @@ import { sqliteTable, text, integer } from "drizzle-orm/sqlite-core";
 
 export const regexScripts = sqliteTable("regex_scripts", {
   id: text("id").primaryKey(),
+  /** Null = global script; non-null = scoped to a specific character */
+  characterId: text("character_id"),
   name: text("name").notNull(),
   enabled: text("enabled").notNull().default("true"),
   /** The regex pattern (without delimiters) */

--- a/packages/server/src/routes/characters.routes.ts
+++ b/packages/server/src/routes/characters.routes.ts
@@ -25,6 +25,7 @@ import { createWriteStream, existsSync, rmSync, unlinkSync } from "fs";
 import { normalizeTimestampOverrides } from "../services/import/import-timestamps.js";
 import { assertInsideDir, extensionFromImageMime, isAllowedImageBuffer } from "../utils/security.js";
 import { importSTLorebook } from "../services/import/st-lorebook.importer.js";
+import { createRegexScriptsStorage } from "../services/storage/regex-scripts.storage.js";
 import AdmZip from "adm-zip";
 import { extname } from "path";
 import { pipeline } from "stream/promises";
@@ -411,6 +412,7 @@ export async function charactersRoutes(app: FastifyInstance) {
     if (existsSync(galleryDir)) {
       rmSync(galleryDir, { recursive: true, force: true });
     }
+    await createRegexScriptsStorage(app.db).removeByCharacter(req.params.id);
     await storage.remove(req.params.id);
     return reply.status(204).send();
   });

--- a/packages/server/src/routes/import.routes.ts
+++ b/packages/server/src/routes/import.routes.ts
@@ -396,6 +396,8 @@ async function inspectCharacterBuffer(fileName: string, buffer: Buffer) {
         error: "No character data found in PNG. Make sure this is a valid character card with embedded metadata.",
         hasEmbeddedLorebook: false,
         embeddedLorebookEntries: 0,
+        hasEmbeddedRegexScripts: false,
+        embeddedRegexScriptCount: 0,
       };
     }
     return inspectSTCharacter(charData);
@@ -415,6 +417,8 @@ async function inspectCharacterBuffer(fileName: string, buffer: Buffer) {
         "Invalid file format. Expected a JSON character card, a PNG with embedded character data, or a .charx file.",
       hasEmbeddedLorebook: false,
       embeddedLorebookEntries: 0,
+      hasEmbeddedRegexScripts: false,
+      embeddedRegexScriptCount: 0,
     };
   }
 }
@@ -708,6 +712,8 @@ export async function importRoutes(app: FastifyInstance) {
           error: error instanceof Error ? error.message : "Inspection failed",
           hasEmbeddedLorebook: false,
           embeddedLorebookEntries: 0,
+          hasEmbeddedRegexScripts: false,
+          embeddedRegexScriptCount: 0,
         });
       }
     }

--- a/packages/server/src/routes/regex-scripts.routes.ts
+++ b/packages/server/src/routes/regex-scripts.routes.ts
@@ -8,7 +8,12 @@ import { createRegexScriptsStorage } from "../services/storage/regex-scripts.sto
 export async function regexScriptsRoutes(app: FastifyInstance) {
   const storage = createRegexScriptsStorage(app.db);
 
-  app.get("/", async () => {
+  app.get<{ Querystring: { characterIds?: string } }>("/", async (req) => {
+    const raw = req.query.characterIds;
+    if (raw) {
+      const ids = raw.split(",").filter(Boolean);
+      return storage.listForCharacters(ids);
+    }
     return storage.list();
   });
 

--- a/packages/server/src/services/import/st-character.importer.ts
+++ b/packages/server/src/services/import/st-character.importer.ts
@@ -5,8 +5,9 @@ import type { DB } from "../../db/connection.js";
 import { characters as charactersTable } from "../../db/schema/index.js";
 import { logger } from "../../lib/logger.js";
 import { createCharactersStorage } from "../storage/characters.storage.js";
+import { createRegexScriptsStorage } from "../storage/regex-scripts.storage.js";
 import { importSTLorebook } from "./st-lorebook.importer.js";
-import type { CharacterData } from "@marinara-engine/shared";
+import type { CharacterData, CreateRegexScriptInput, RegexPlacement } from "@marinara-engine/shared";
 import { existsSync, mkdirSync } from "fs";
 import { writeFile } from "fs/promises";
 import { join } from "path";
@@ -28,6 +29,74 @@ function countEmbeddedLorebookEntries(book: unknown): number {
   return getCharacterBookEntries(book).length;
 }
 
+function extractEmbeddedRegexScripts(raw: Record<string, unknown>): unknown[] {
+  const data = (raw.data ?? raw) as Record<string, unknown>;
+  const extensions = data.extensions as Record<string, unknown> | undefined;
+  if (!extensions) return [];
+  const scripts = extensions.regex_scripts;
+  return Array.isArray(scripts) ? scripts : [];
+}
+
+function convertSTPlacement(placement: unknown): RegexPlacement[] {
+  if (Array.isArray(placement)) {
+    return placement.flatMap((p) => convertSTPlacement(p));
+  }
+  if (typeof placement === "number") {
+    if (placement === 1) return ["user_input"];
+    if (placement === 2) return ["ai_output"];
+    return ["ai_output"];
+  }
+  if (typeof placement === "string") {
+    if (placement === "user_input") return ["user_input"];
+    if (placement === "ai_output") return ["ai_output"];
+  }
+  return ["ai_output"];
+}
+
+function parseSTRegexPattern(findRegex: string): { pattern: string; flags: string } {
+  const match = findRegex.match(/^\/(.+)\/([gimsuy]*)$/s);
+  if (match) return { pattern: match[1] ?? findRegex, flags: match[2] ?? "gi" };
+  return { pattern: findRegex, flags: "gi" };
+}
+
+function convertSTRegexScript(
+  raw: Record<string, unknown>,
+  characterId: string,
+  order: number,
+): CreateRegexScriptInput | null {
+  const findRegex = typeof raw.findRegex === "string" ? raw.findRegex : null;
+  if (!findRegex) return null;
+
+  const { pattern, flags } = parseSTRegexPattern(findRegex);
+  if (!pattern) return null;
+
+  const name =
+    typeof raw.scriptName === "string" && raw.scriptName.trim()
+      ? raw.scriptName.trim()
+      : typeof raw.name === "string" && raw.name.trim()
+        ? raw.name.trim()
+        : `Script ${order + 1}`;
+
+  const enabled = raw.disabled != null ? !raw.disabled : raw.enabled != null ? Boolean(raw.enabled) : true;
+
+  const trimStrings: string[] = Array.isArray(raw.trimStrings) ? raw.trimStrings.map(String) : [];
+
+  return {
+    characterId,
+    name,
+    enabled,
+    findRegex: pattern,
+    replaceString: typeof raw.replaceString === "string" ? raw.replaceString : "",
+    trimStrings,
+    placement: convertSTPlacement(raw.placement),
+    flags,
+    promptOnly: Boolean(raw.promptOnly),
+    order,
+    minDepth: typeof raw.minDepth === "number" ? raw.minDepth : null,
+    maxDepth: typeof raw.maxDepth === "number" ? raw.maxDepth : null,
+  };
+}
+
 /**
  * Import a SillyTavern character card (JSON format).
  * Handles V1, V2, Pygmalion, and RisuAI formats.
@@ -38,12 +107,15 @@ export interface STCharacterImportPreview {
   name?: string;
   hasEmbeddedLorebook: boolean;
   embeddedLorebookEntries: number;
+  hasEmbeddedRegexScripts: boolean;
+  embeddedRegexScriptCount: number;
   error?: string;
 }
 
 export interface STCharacterImportOptions {
   timestampOverrides?: TimestampOverrides | null;
   importEmbeddedLorebook?: boolean;
+  importEmbeddedRegexScripts?: boolean;
   tagImportMode?: STCharacterTagImportMode;
   existingTagKeys?: ReadonlySet<string>;
 }
@@ -54,6 +126,7 @@ export async function importSTCharacter(raw: Record<string, unknown>, db: DB, op
   const storage = createCharactersStorage(db);
   const normalizedTimestamps = normalizeTimestampOverrides(options?.timestampOverrides);
   const shouldImportEmbeddedLorebook = options?.importEmbeddedLorebook ?? true;
+  const shouldImportEmbeddedRegexScripts = options?.importEmbeddedRegexScripts ?? true;
   const tagImportMode = options?.tagImportMode ?? "all";
 
   // Extract avatar data URL if present (from PNG import)
@@ -83,6 +156,9 @@ export async function importSTCharacter(raw: Record<string, unknown>, db: DB, op
   const cardSpecMetadata = buildCardSpecMetadata(raw);
   const embeddedLorebookEntries = countEmbeddedLorebookEntries(data.character_book);
   const hasEmbeddedLorebook = embeddedLorebookEntries > 0;
+  const rawRegexScripts = extractEmbeddedRegexScripts(raw);
+  const embeddedRegexScriptCount = rawRegexScripts.length;
+  const hasEmbeddedRegexScripts = embeddedRegexScriptCount > 0;
   // Strip any `lorebookId` carried by the source card. That ID references
   // the exporter's database (e.g. a different Marinara instance), not
   // ours, so preserving it leaves an orphan pointer that makes "Edit
@@ -178,6 +254,26 @@ export async function importSTCharacter(raw: Record<string, unknown>, db: DB, op
     }
   }
 
+  // Import embedded regex scripts as character-scoped scripts
+  let regexImported = 0;
+  if (shouldImportEmbeddedRegexScripts && hasEmbeddedRegexScripts && charId) {
+    try {
+      const regexStorage = createRegexScriptsStorage(db);
+      const converted: CreateRegexScriptInput[] = [];
+      for (let i = 0; i < rawRegexScripts.length; i++) {
+        const scriptRaw = rawRegexScripts[i];
+        if (!scriptRaw || typeof scriptRaw !== "object") continue;
+        const script = convertSTRegexScript(scriptRaw as Record<string, unknown>, charId, i);
+        if (script) converted.push(script);
+      }
+      if (converted.length > 0) {
+        regexImported = await regexStorage.createBatch(converted);
+      }
+    } catch (err) {
+      logger.warn(err, "Regex script extraction failed for character import");
+    }
+  }
+
   return {
     success: true,
     characterId: charId,
@@ -188,6 +284,12 @@ export async function importSTCharacter(raw: Record<string, unknown>, db: DB, op
       imported: !!lorebookResult,
       skipped: hasEmbeddedLorebook && !shouldImportEmbeddedLorebook,
     },
+    embeddedRegexScripts: {
+      hasEmbeddedRegexScripts,
+      count: embeddedRegexScriptCount,
+      imported: regexImported,
+      skipped: hasEmbeddedRegexScripts && !shouldImportEmbeddedRegexScripts,
+    },
     ...(lorebookResult ? { lorebook: lorebookResult } : {}),
   };
 }
@@ -196,17 +298,22 @@ export function inspectSTCharacter(raw: Record<string, unknown>): STCharacterImp
   try {
     const data = normalizeCharacterData(raw);
     const embeddedLorebookEntries = countEmbeddedLorebookEntries(data.character_book);
+    const embeddedRegexScriptCount = extractEmbeddedRegexScripts(raw).length;
     return {
       success: true,
       name: data.name,
       hasEmbeddedLorebook: embeddedLorebookEntries > 0,
       embeddedLorebookEntries,
+      hasEmbeddedRegexScripts: embeddedRegexScriptCount > 0,
+      embeddedRegexScriptCount,
     };
   } catch (error) {
     return {
       success: false,
       hasEmbeddedLorebook: false,
       embeddedLorebookEntries: 0,
+      hasEmbeddedRegexScripts: false,
+      embeddedRegexScriptCount: 0,
       error: error instanceof Error ? error.message : "Invalid character card",
     };
   }
@@ -274,6 +381,8 @@ export function inspectCharX(buf: Buffer): STCharacterImportPreview {
         success: false,
         hasEmbeddedLorebook: false,
         embeddedLorebookEntries: 0,
+        hasEmbeddedRegexScripts: false,
+        embeddedRegexScriptCount: 0,
         error: "Invalid .charx file: missing card.json at root.",
       };
     }
@@ -283,6 +392,8 @@ export function inspectCharX(buf: Buffer): STCharacterImportPreview {
       success: false,
       hasEmbeddedLorebook: false,
       embeddedLorebookEntries: 0,
+      hasEmbeddedRegexScripts: false,
+      embeddedRegexScriptCount: 0,
       error: error instanceof Error ? error.message : "Invalid .charx file",
     };
   }

--- a/packages/server/src/services/storage/regex-scripts.storage.ts
+++ b/packages/server/src/services/storage/regex-scripts.storage.ts
@@ -10,7 +10,7 @@ import type { CreateRegexScriptInput } from "@marinara-engine/shared";
 export function createRegexScriptsStorage(db: DB) {
   return {
     async list() {
-      return db.select().from(regexScripts).orderBy(asc(regexScripts.order));
+      return db.select().from(regexScripts).where(isNull(regexScripts.characterId)).orderBy(asc(regexScripts.order));
     },
 
     async listForCharacters(characterIds: string[]) {

--- a/packages/server/src/services/storage/regex-scripts.storage.ts
+++ b/packages/server/src/services/storage/regex-scripts.storage.ts
@@ -1,7 +1,7 @@
 // ──────────────────────────────────────────────
 // Storage: Regex Scripts
 // ──────────────────────────────────────────────
-import { eq, asc } from "drizzle-orm";
+import { eq, asc, isNull, inArray, or } from "drizzle-orm";
 import type { DB } from "../../db/connection.js";
 import { regexScripts } from "../../db/schema/index.js";
 import { newId, now } from "../../utils/id-generator.js";
@@ -11,6 +11,25 @@ export function createRegexScriptsStorage(db: DB) {
   return {
     async list() {
       return db.select().from(regexScripts).orderBy(asc(regexScripts.order));
+    },
+
+    async listForCharacters(characterIds: string[]) {
+      if (characterIds.length === 0) {
+        return db.select().from(regexScripts).where(isNull(regexScripts.characterId)).orderBy(asc(regexScripts.order));
+      }
+      return db
+        .select()
+        .from(regexScripts)
+        .where(or(isNull(regexScripts.characterId), inArray(regexScripts.characterId, characterIds)))
+        .orderBy(asc(regexScripts.order));
+    },
+
+    async listByCharacter(characterId: string) {
+      return db
+        .select()
+        .from(regexScripts)
+        .where(eq(regexScripts.characterId, characterId))
+        .orderBy(asc(regexScripts.order));
     },
 
     async getById(id: string) {
@@ -23,6 +42,7 @@ export function createRegexScriptsStorage(db: DB) {
       const timestamp = now();
       await db.insert(regexScripts).values({
         id,
+        characterId: input.characterId ?? null,
         name: input.name,
         enabled: String(input.enabled ?? true),
         findRegex: input.findRegex,
@@ -40,8 +60,33 @@ export function createRegexScriptsStorage(db: DB) {
       return this.getById(id);
     },
 
+    async createBatch(inputs: CreateRegexScriptInput[]): Promise<number> {
+      if (inputs.length === 0) return 0;
+      const timestamp = now();
+      const rows = inputs.map((input, i) => ({
+        id: newId(),
+        characterId: input.characterId ?? null,
+        name: input.name,
+        enabled: String(input.enabled ?? true),
+        findRegex: input.findRegex,
+        replaceString: input.replaceString ?? "",
+        trimStrings: JSON.stringify(input.trimStrings ?? []),
+        placement: JSON.stringify(input.placement),
+        flags: input.flags ?? "gi",
+        promptOnly: String(input.promptOnly ?? false),
+        order: input.order ?? i,
+        minDepth: input.minDepth ?? null,
+        maxDepth: input.maxDepth ?? null,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      }));
+      await db.insert(regexScripts).values(rows);
+      return rows.length;
+    },
+
     async update(id: string, data: Partial<CreateRegexScriptInput>) {
       const updateFields: Record<string, unknown> = { updatedAt: now() };
+      if (data.characterId !== undefined) updateFields.characterId = data.characterId;
       if (data.name !== undefined) updateFields.name = data.name;
       if (data.enabled !== undefined) updateFields.enabled = String(data.enabled);
       if (data.findRegex !== undefined) updateFields.findRegex = data.findRegex;
@@ -69,6 +114,10 @@ export function createRegexScriptsStorage(db: DB) {
 
     async remove(id: string) {
       await db.delete(regexScripts).where(eq(regexScripts.id, id));
+    },
+
+    async removeByCharacter(characterId: string) {
+      await db.delete(regexScripts).where(eq(regexScripts.characterId, characterId));
     },
   };
 }

--- a/packages/shared/src/schemas/regex.schema.ts
+++ b/packages/shared/src/schemas/regex.schema.ts
@@ -6,6 +6,7 @@ import { z } from "zod";
 export const regexPlacementSchema = z.enum(["ai_output", "user_input"]);
 
 export const createRegexScriptSchema = z.object({
+  characterId: z.string().nullable().default(null),
   name: z.string().min(1).max(200),
   enabled: z.boolean().default(true),
   findRegex: z.string().min(1),

--- a/packages/shared/src/types/regex.ts
+++ b/packages/shared/src/types/regex.ts
@@ -8,6 +8,8 @@ export type RegexPlacement = "ai_output" | "user_input";
 /** A find/replace regex script. */
 export interface RegexScript {
   id: string;
+  /** Null = global script; non-null = scoped to a specific character */
+  characterId: string | null;
   /** Display name */
   name: string;
   /** Whether this script is active */


### PR DESCRIPTION
## Summary

- Adds a nullable `characterId` column to the regex scripts table, enabling scripts to be scoped to a specific character rather than applying globally
- Automatically extracts and imports embedded regex scripts from SillyTavern character cards during import, converting ST format to ME format
- Client hooks pass active chat character IDs so character-scoped scripts load alongside global scripts during chat
- Per-character regex isolation with a tri-state mode selector (Disabled / Exclusive / Chat) persisted in chat metadata
- Chat Settings UI with collapsible per-character script groups and individual on/off toggles
- Character Editor gains a "Regex Scripts" tab for viewing imported scripts
- Global Regex Scripts panel no longer shows character-scoped entries

## Why

SillyTavern character cards embed `regex_scripts` in their extensions metadata — these scripts transform AI output to render custom UI elements like expression sprites, mood widgets, and structural HTML. Without importing these scripts, cards that rely on regex-driven theming (like the KZK card) render without their intended visual presentation.

In group chats, scoped scripts must be isolated per-character so one character's regexes don't transform another character's messages. The tri-state mode gives users control: **Exclusive** (default) keeps each character's scripts on their own messages, **Disabled** turns off scoped scripts entirely, and **Chat** applies all scoped scripts globally (useful for 1-on-1 chats where users want scoped scripts to also apply to their own persona).

## Changes

**Schema & types:**
- `packages/server/src/db/schema/regex-scripts.ts` — add `character_id` column
- `packages/shared/src/types/regex.ts` — add `characterId` to `RegexScript`
- `packages/shared/src/schemas/regex.schema.ts` — add `characterId` to create schema

**Storage & API:**
- `packages/server/src/services/storage/regex-scripts.storage.ts` — add `listForCharacters`, `listByCharacter`, `createBatch`, `removeByCharacter` methods; `list()` filtered to global-only (`characterId IS NULL`)
- `packages/server/src/routes/regex-scripts.routes.ts` — support `?characterIds=` query param on list endpoint
- `packages/server/src/routes/characters.routes.ts` — clean up character-scoped scripts on character deletion

**Import:**
- `packages/server/src/services/import/st-character.importer.ts` — extract `extensions.regex_scripts` from ST cards, convert format (numeric placements → named, `disabled` → `enabled`, `/pattern/flags` → separate fields), batch-create as character-scoped scripts
- `packages/server/src/routes/import.routes.ts` — add regex script fields to inspect preview responses

**Client — per-character isolation:**
- `packages/client/src/hooks/use-apply-regex.ts` — tri-state `ScopedRegexMode` (`disabled` / `exclusive` / `chat`) with `filterForMode()` that gates which scripts run per message
- `packages/client/src/components/chat/ChatMessage.tsx` — passes `message.characterId` and `scopedRegexMode` from chat metadata to `applyToAIOutput`
- `packages/client/src/components/game/GameNarration.tsx` — maps messageId → characterId for source attribution, passes `scopedMode` and `characterId` per message
- `packages/client/src/components/chat/ChatInput.tsx` — passes `scopedMode` to `applyToUserInput`
- `packages/client/src/components/chat/ConversationInput.tsx` — passes `scopedMode` to `applyToUserInput` at all three call sites

**Client — Chat Settings UI:**
- `packages/client/src/components/chat/ChatSettingsDrawer.tsx` — new "Scoped Regex Scripts" section with `ScopedRegexModeSelector` (tri-state button group with hover tooltips) and `ScopedRegexCharacterGroups` (collapsible per-character groups with enabled/total counts and individual On/Off toggles)

**Client — Character Editor:**
- `packages/client/src/components/characters/CharacterEditor.tsx` — new "Regex Scripts" tab (after Lorebook) showing imported scripts with pattern, flags, replacement, placement badges, on/off toggle, and delete with confirmation

## Test plan
- [ ] Import a SillyTavern character card with embedded regex scripts — verify scripts appear in the regex editor with the character association
- [ ] Verify imported scripts apply to AI output in chat with that character
- [ ] Verify global regex scripts still work alongside character-scoped ones
- [ ] Delete a character with scoped scripts — verify the scripts are cleaned up
- [ ] Import a card without regex scripts — verify no errors, lorebook import unaffected
- [ ] In a group chat, verify Exclusive mode only applies each character's scripts to their own messages
- [ ] Verify Disabled mode turns off all scoped scripts (global scripts still apply)
- [ ] Verify Chat mode applies all scoped scripts to every message including user input
- [ ] Verify the mode selector persists across page reloads (stored in chat metadata)
- [ ] In Chat Settings, expand a character group and toggle individual scripts on/off — verify changes take effect
- [ ] In Character Editor, verify the Regex Scripts tab shows imported scripts with correct metadata
- [ ] Verify the global Regex Scripts panel (sidebar) does not show character-scoped entries


🤖 Generated with [Claude Code](https://claude.com/claude-code)