### PR TITLE
Add audio format selection (mp3/wav)

### DIFF
--- a/packages/client/src/components/panels/settings/TTSConfigCard.tsx
+++ b/packages/client/src/components/panels/settings/TTSConfigCard.tsx
@@ -971,7 +971,7 @@ export function TTSConfigCard() {
             </FieldRow>
           )}
 
-          {/* Audio Format */}
+          {source !== "elevenlabs" && (
           <FieldRow
             label="Audio Format"
             help="Output audio format. WAV are useful for local/self-hosted TTS servers that do not support MP3."
@@ -989,6 +989,7 @@ export function TTSConfigCard() {
               <option value="wav">WAV</option>
             </select>
           </FieldRow>
+          )}
 
           {source === "elevenlabs" && (
             <FieldRow

--- a/packages/client/src/components/panels/settings/TTSConfigCard.tsx
+++ b/packages/client/src/components/panels/settings/TTSConfigCard.tsx
@@ -22,7 +22,7 @@ import { useTTSConfig, useUpdateTTSConfig, useTTSVoices } from "../../../hooks/u
 import { useCharacters } from "../../../hooks/use-characters";
 import { ttsService } from "../../../lib/tts-service";
 import { parseCharacterDisplayData } from "../../../lib/character-display";
-import type { TTSConfig, TTSSource, TTSVoiceAssignment, TTSVoiceMode } from "@marinara-engine/shared";
+import type { TTSConfig, TTSSource, TTSVoiceAssignment, TTSVoiceMode, TTSAudioFormat } from "@marinara-engine/shared";
 import { ELEVENLABS_TTS_LANGUAGE_OPTIONS, TTS_API_KEY_MASK } from "@marinara-engine/shared";
 import { HelpTooltip } from "../../ui/HelpTooltip";
 
@@ -304,6 +304,7 @@ export function TTSConfigCard() {
   const [autoplayConvo, setAutoplayConvo] = useState(false);
   const [autoplayGame, setAutoplayGame] = useState(false);
   const [dialogueOnly, setDialogueOnly] = useState(false);
+  const [audioFormat, setAudioFormat] = useState<TTSAudioFormat>("mp3");
 
   const [expanded, setExpanded] = useState(false);
   const [saveStatus, setSaveStatus] = useState<"idle" | "saving" | "saved" | "error">("idle");
@@ -345,6 +346,7 @@ export function TTSConfigCard() {
     setAutoplayConvo(savedConfig.autoplayConvo);
     setAutoplayGame(savedConfig.autoplayGame);
     setDialogueOnly(savedConfig.dialogueOnly ?? false);
+    setAudioFormat(savedConfig.audioFormat ?? "mp3");
     setSaveStatus("idle");
   }, [savedConfig]);
 
@@ -387,6 +389,7 @@ export function TTSConfigCard() {
     autoplayConvo,
     autoplayGame,
     dialogueOnly,
+    audioFormat,
     dialogueScope: "all",
     dialogueCharacterName: "",
     ...overrides,
@@ -967,6 +970,25 @@ export function TTSConfigCard() {
               </div>
             </FieldRow>
           )}
+
+          {/* Audio Format */}
+          <FieldRow
+            label="Audio Format"
+            help="Output audio format. WAV are useful for local/self-hosted TTS servers that do not support MP3."
+          >
+            <select
+              value={audioFormat}
+              onChange={(e) => {
+                const next = e.target.value as TTSAudioFormat;
+                setAudioFormat(next);
+                mark({ audioFormat: next });
+              }}
+              className={cn(INPUT_CLS, "cursor-pointer appearance-none")}
+            >
+              <option value="mp3">MP3</option>
+              <option value="wav">WAV</option>
+            </select>
+          </FieldRow>
 
           {source === "elevenlabs" && (
             <FieldRow

--- a/packages/server/src/routes/tts.routes.ts
+++ b/packages/server/src/routes/tts.routes.ts
@@ -378,15 +378,6 @@ function audioFormatMimeType(format: string): string {
   }
 }
 
-function elevenLabsOutputFormat(format: string): string {
-  switch (format) {
-    case "wav":
-      return "wav";
-    default:
-      return "mp3_44100_128";
-  }
-}
-
 function buildSpeechInstructions(input: { speaker?: string; tone?: string; includeSpeaker?: boolean }) {
   const parts: string[] = [];
   if (input.includeSpeaker !== false && input.speaker?.trim()) {
@@ -618,7 +609,7 @@ export async function ttsRoutes(app: FastifyInstance) {
       : usePocketTtsSpeech
         ? `${base}/tts`
         : cfg.source === "elevenlabs"
-          ? `${elevenLabsApiRoot(base)}/v1/text-to-speech/${encodeURIComponent(requestVoice)}?output_format=${elevenLabsOutputFormat(audioFormat)}`
+          ? `${elevenLabsApiRoot(base)}/v1/text-to-speech/${encodeURIComponent(requestVoice)}?output_format=mp3_44100_128`
           : `${base}/audio/speech`;
     const providerText = cfg.source === "elevenlabs" ? buildElevenLabsTextInput(text, tone) : text;
     const elevenLabsLanguageCode = cfg.elevenLabsLanguageCode?.trim();

--- a/packages/server/src/routes/tts.routes.ts
+++ b/packages/server/src/routes/tts.routes.ts
@@ -369,6 +369,24 @@ export function isAllowedTTSAudioContentType(contentType: string | null): boolea
   return normalized.includes("audio/") || normalized.includes("application/octet-stream");
 }
 
+function audioFormatMimeType(format: string): string {
+  switch (format) {
+    case "wav":
+      return "audio/wav";
+    default:
+      return "audio/mpeg";
+  }
+}
+
+function elevenLabsOutputFormat(format: string): string {
+  switch (format) {
+    case "wav":
+      return "wav";
+    default:
+      return "mp3_44100_128";
+  }
+}
+
 function buildSpeechInstructions(input: { speaker?: string; tone?: string; includeSpeaker?: boolean }) {
   const parts: string[] = [];
   if (input.includeSpeaker !== false && input.speaker?.trim()) {
@@ -594,12 +612,13 @@ export async function ttsRoutes(app: FastifyInstance) {
       });
     }
 
+    const audioFormat = cfg.audioFormat ?? "mp3";
     const url = useNanoGptSpeech
       ? `${nanoGptV1BaseUrl(base)}/audio/speech`
       : usePocketTtsSpeech
         ? `${base}/tts`
         : cfg.source === "elevenlabs"
-          ? `${elevenLabsApiRoot(base)}/v1/text-to-speech/${encodeURIComponent(requestVoice)}?output_format=mp3_44100_128`
+          ? `${elevenLabsApiRoot(base)}/v1/text-to-speech/${encodeURIComponent(requestVoice)}?output_format=${elevenLabsOutputFormat(audioFormat)}`
           : `${base}/audio/speech`;
     const providerText = cfg.source === "elevenlabs" ? buildElevenLabsTextInput(text, tone) : text;
     const elevenLabsLanguageCode = cfg.elevenLabsLanguageCode?.trim();
@@ -616,6 +635,7 @@ export async function ttsRoutes(app: FastifyInstance) {
       if (pocketTtsForm) {
         pocketTtsForm.set("text", providerText);
         if (requestVoice.trim()) pocketTtsForm.set("voice_url", requestVoice.trim());
+        if (audioFormat !== "mp3") pocketTtsForm.set("output_format", audioFormat);
       }
 
       providerRes = await safeFetch(url, {
@@ -635,7 +655,7 @@ export async function ttsRoutes(app: FastifyInstance) {
                 input: providerText,
                 voice: requestVoice || "alloy",
                 speed: cfg.speed,
-                response_format: "mp3",
+                response_format: audioFormat,
                 ...(speechInstructions ? { instructions: speechInstructions } : {}),
               })
             : cfg.source === "elevenlabs"
@@ -653,7 +673,7 @@ export async function ttsRoutes(app: FastifyInstance) {
                   input: providerText,
                   voice: requestVoice,
                   speed: cfg.speed,
-                  response_format: "mp3",
+                  response_format: audioFormat,
                   ...(speechInstructions ? { instructions: speechInstructions } : {}),
                 }),
         signal: AbortSignal.timeout(60_000),
@@ -688,7 +708,7 @@ export async function ttsRoutes(app: FastifyInstance) {
     }
 
     const audioBuffer = await providerRes.arrayBuffer();
-    reply.header("Content-Type", contentType?.startsWith("audio/") ? contentType : "audio/mpeg");
+    reply.header("Content-Type", contentType?.startsWith("audio/") ? contentType : audioFormatMimeType(audioFormat));
     reply.header("Content-Length", String(audioBuffer.byteLength));
     return reply.send(Buffer.from(audioBuffer));
   });

--- a/packages/shared/src/types/tts.ts
+++ b/packages/shared/src/types/tts.ts
@@ -6,6 +6,9 @@ import { z } from "zod";
 export const ttsSourceSchema = z.enum(["openai", "elevenlabs", "pockettts"]);
 export type TTSSource = z.infer<typeof ttsSourceSchema>;
 
+export const ttsAudioFormatSchema = z.enum(["mp3", "wav"]);
+export type TTSAudioFormat = z.infer<typeof ttsAudioFormatSchema>;
+
 export const ttsDialogueScopeSchema = z.enum(["all", "character"]);
 export type TTSDialogueScope = z.infer<typeof ttsDialogueScopeSchema>;
 
@@ -120,6 +123,7 @@ export const ttsConfigSchema = z.object({
   autoplayConvo: z.boolean().default(false),
   autoplayGame: z.boolean().default(false),
   dialogueOnly: z.boolean().default(false),
+  audioFormat: ttsAudioFormatSchema.default("mp3"),
   dialogueScope: ttsDialogueScopeSchema.default("all"),
   dialogueCharacterName: z.string().default(""),
 });


### PR DESCRIPTION
## Linked issue

Closes #1057

## Why this change

- Some TTS API does not support mp3.

## What changed

- Add audio format selection (mp3/wav).

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

I clone this from repo, build it, ran it in different modes, checked mobile, and generate OpenAI-compatible audio.
Here we have 1 default button added and 1 variable flies away instead of a fixed string.
And, I dunno need this Docs or not.

## Docs and release impact

- [ ] No docs changes needed ?
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

<img width="1486" height="870" alt="image" src="https://github.com/user-attachments/assets/0528b5af-b6dd-467e-93f1-ac20d75cb705" />
