### PR TITLE
Add character avatar removal

### DIFF
--- a/packages/client/src/components/characters/CharacterEditor.tsx
+++ b/packages/client/src/components/characters/CharacterEditor.tsx
@@ -11,6 +11,7 @@ import {
   useCharacter,
   useUpdateCharacter,
   useUploadAvatar,
+  useRemoveAvatar,
   useDeleteCharacter,
   useDuplicateCharacter,
   useCreatePersona,
@@ -164,6 +165,7 @@ export function CharacterEditor() {
   const { data: rawCharacter, isLoading } = useCharacter(characterId);
   const updateCharacter = useUpdateCharacter();
   const uploadAvatar = useUploadAvatar();
+  const removeAvatar = useRemoveAvatar();
   const deleteCharacter = useDeleteCharacter();
   const duplicateCharacter = useDuplicateCharacter();
   const createPersona = useCreatePersona();
@@ -438,6 +440,35 @@ export function CharacterEditor() {
       uploadAvatar,
     ],
   );
+
+  const handleAvatarRemove = useCallback(async () => {
+    if (!characterId || !avatarPreview) return;
+    if (saving) {
+      toast.error("Wait for the current save to finish before removing the avatar.");
+      return;
+    }
+    if (avatarUploadInFlightRef.current) {
+      toast.error("Wait for the current avatar upload to finish before removing the avatar.");
+      return;
+    }
+
+    const confirmed = await showConfirmDialog({
+      title: "Remove Avatar",
+      message: `Remove the avatar from ${formData?.name || "this character"}? This clears the character card's avatar without deleting the character.`,
+      confirmLabel: "Remove",
+      tone: "destructive",
+    });
+    if (!confirmed) return;
+
+    try {
+      await removeAvatar.mutateAsync(characterId);
+      setAvatarPreview(null);
+      if (fileInputRef.current) fileInputRef.current.value = "";
+      toast.success("Avatar removed.");
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to remove avatar.");
+    }
+  }, [avatarPreview, characterId, formData?.name, removeAvatar, saving]);
 
   const handleDelete = async () => {
     if (!characterId) return;
@@ -897,6 +928,8 @@ export function CharacterEditor() {
                 removeTag={removeTag}
                 removeAllTags={removeAllTags}
                 avatarPreview={avatarPreview}
+                onRemoveAvatar={handleAvatarRemove}
+                removingAvatar={removeAvatar.isPending}
               />
             )}
             {activeTab === "description" && (
@@ -1221,6 +1254,8 @@ function MetadataTab({
   removeTag,
   removeAllTags,
   avatarPreview,
+  onRemoveAvatar,
+  removingAvatar,
 }: {
   characterId: string | null;
   formData: CharacterData;
@@ -1233,6 +1268,8 @@ function MetadataTab({
   removeTag: (tag: string) => void;
   removeAllTags: () => void;
   avatarPreview: string | null;
+  onRemoveAvatar: () => void;
+  removingAvatar: boolean;
 }) {
   // Read existing crop in either current or legacy shape; the widget handles both
   // and writes back the current shape on first interaction.
@@ -1249,6 +1286,8 @@ function MetadataTab({
           alt={formData.name}
           crop={savedCrop}
           onChange={(next) => updateExtension("avatarCrop", next)}
+          onRemove={onRemoveAvatar}
+          removing={removingAvatar}
         />
       )}
 

--- a/packages/client/src/components/ui/AvatarCropWidget.tsx
+++ b/packages/client/src/components/ui/AvatarCropWidget.tsx
@@ -12,7 +12,7 @@
 // container's full area. Square-in-source-pixels crops survive any source aspect
 // ratio without distortion.
 import { useEffect, useRef, useState } from "react";
-import { Crop, Maximize2, RotateCcw, X } from "lucide-react";
+import { Crop, Maximize2, RotateCcw, Trash2, X } from "lucide-react";
 import { type AvatarCrop, type LegacyAvatarCrop, getAvatarCropStyle, isLegacyAvatarCrop } from "../../lib/utils";
 
 interface CropPx {
@@ -33,13 +33,15 @@ export interface AvatarCropWidgetProps {
   /** Fired on every change (drag, corner resize, reset). Always emits the
    *  current AvatarCrop shape. */
   onChange: (next: AvatarCrop) => void;
+  onRemove?: () => void;
+  removing?: boolean;
 }
 
 const MIN_CROP_PX = 24;
 const MAX_DISPLAY_W = 360;
 const MAX_DISPLAY_H = 360;
 
-export function AvatarCropWidget({ src, alt, crop, onChange }: AvatarCropWidgetProps) {
+export function AvatarCropWidget({ src, alt, crop, onChange, onRemove, removing = false }: AvatarCropWidgetProps) {
   const imgRef = useRef<HTMLImageElement>(null);
   const [imgRect, setImgRect] = useState<{ w: number; h: number } | null>(null);
   const [cropPx, setCropPx] = useState<CropPx | null>(null);
@@ -233,6 +235,17 @@ export function AvatarCropWidget({ src, alt, crop, onChange }: AvatarCropWidgetP
           >
             <RotateCcw size="0.625rem" /> Reset
           </button>
+          {onRemove && (
+            <button
+              type="button"
+              onClick={onRemove}
+              disabled={removing}
+              className="inline-flex items-center gap-1 rounded-lg bg-[var(--destructive)]/10 px-2 py-1 text-[0.625rem] font-medium text-[var(--destructive)] transition-colors hover:bg-[var(--destructive)]/15 disabled:opacity-45"
+              title="Remove avatar"
+            >
+              <Trash2 size="0.625rem" /> {removing ? "Removing..." : "Remove"}
+            </button>
+          )}
         </div>
       </div>
       <p className="text-[0.625rem] text-[var(--muted-foreground)]">

--- a/packages/client/src/hooks/use-characters.ts
+++ b/packages/client/src/hooks/use-characters.ts
@@ -150,6 +150,17 @@ export function useUploadAvatar() {
   });
 }
 
+export function useRemoveAvatar() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => api.delete(`/characters/${id}/avatar`),
+    onSuccess: (_data, id) => {
+      qc.invalidateQueries({ queryKey: characterKeys.list() });
+      qc.invalidateQueries({ queryKey: characterKeys.detail(id) });
+    },
+  });
+}
+
 export function useDeleteCharacter() {
   const qc = useQueryClient();
   return useMutation({

--- a/packages/server/src/routes/characters.routes.ts
+++ b/packages/server/src/routes/characters.routes.ts
@@ -699,6 +699,15 @@ export async function charactersRoutes(app: FastifyInstance) {
     return storage.updateAvatar(id, avatarPath);
   });
 
+  app.delete<{ Params: { id: string } }>("/:id/avatar", async (req, reply) => {
+    const { id } = req.params;
+    const char = await storage.getById(id);
+    if (!char) return reply.status(404).send({ error: "Character not found" });
+
+    const updated = await storage.updateAvatar(id, null);
+    return updated ?? reply.status(404).send({ error: "Character not found" });
+  });
+
   // ── Personas ──
 
   app.get("/personas/list", async () => {

--- a/packages/server/src/services/storage/characters.storage.ts
+++ b/packages/server/src/services/storage/characters.storage.ts
@@ -182,11 +182,11 @@ export function createCharactersStorage(db: DB) {
       return this.getById(id);
     },
 
-    async updateAvatar(id: string, avatarPath: string) {
+    async updateAvatar(id: string, avatarPath: string | null) {
       const existing = await this.getById(id);
       if (!existing) return null;
       if (existing.avatarPath !== avatarPath) {
-        await this.createVersionSnapshot(id, { source: "manual", reason: "Avatar update" });
+        await this.createVersionSnapshot(id, { source: "manual", reason: avatarPath ? "Avatar update" : "Avatar removed" });
       }
       await db.update(characters).set({ avatarPath, updatedAt: now() }).where(eq(characters.id, id));
       return this.getById(id);


### PR DESCRIPTION
## Linked issue

Closes #994

## Why this change

- Users can upload and crop character avatars, but there was no obvious way to remove an avatar from an existing character card, especially after importing cards with unwanted placeholder avatars.

## What changed

- Added a Remove action beside the avatar crop controls.
- Added a character avatar removal mutation on the client.
- Added `DELETE /api/characters/:id/avatar` on the server.
- Updated character avatar storage so the avatar path can be cleared to `null` and recorded in version history as “Avatar removed.”

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Codex ran `pnpm check` successfully in a clean `upstream/staging` worktree.
- Codex ran `scratch/issue-994-avatar-remove-repro.mjs` against the real local app. The script created a character, uploaded an avatar, opened the character editor, verified `Full image`, `Reset`, and `Remove` appeared in the avatar crop controls, clicked `Remove`, confirmed the dialog, and verified the character API returned `avatarPath: null`.
- Bunny review passed on the current diff before PR creation.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

The avatar removal flow was verified with an automated browser proof against the real app. No GitHub-renderable screenshot is attached yet.
