### PR TITLE
Fix character system prompt help text

### DIFF
--- a/packages/client/src/components/characters/CharacterEditor.tsx
+++ b/packages/client/src/components/characters/CharacterEditor.tsx
@@ -1851,7 +1851,7 @@ function AdvancedTab({
         <div className="flex items-center justify-between">
           <span className="inline-flex items-center gap-1 text-xs font-medium text-[var(--muted-foreground)]">
             System Prompt{" "}
-            <HelpTooltip text="Overrides or appends to the main system prompt when this character is active. Use this for character-specific instructions the AI must follow." />
+            <HelpTooltip text="Character-specific instructions inserted by the prompt preset's character block or wherever the preset uses {{charSysInfo}}. This does not replace the chat's main system prompt." />
           </span>
           <button
             type="button"
@@ -1867,7 +1867,7 @@ function AdvancedTab({
           onChange={(e) => updateField("system_prompt", e.target.value)}
           rows={6}
           className="w-full resize-y rounded-xl border border-[var(--border)] bg-[var(--secondary)] p-4 text-sm outline-none placeholder:text-[var(--muted-foreground)]/40 focus:border-[var(--primary)]/40 focus:ring-1 focus:ring-[var(--primary)]/20"
-          placeholder="Override or append to the system prompt for this character…"
+          placeholder="Character-specific instructions inserted through {{charSysInfo}} or the character prompt block…"
         />
       </label>
 
@@ -1953,7 +1953,7 @@ function AdvancedTab({
         title="System Prompt"
         value={formData.system_prompt}
         onChange={(value) => updateField("system_prompt", value)}
-        placeholder="Override or append to the system prompt for this character…"
+        placeholder="Character-specific instructions inserted through {{charSysInfo}} or the character prompt block…"
       />
       <ExpandedTextarea
         open={expandedField === "post_history"}


### PR DESCRIPTION
<!-- Target branch: `staging`. The default base in this UI is `main` (release branch). -->
<!-- Change the base to `staging` before submitting unless this is a maintainer-approved mainline change. -->
<!-- See CONTRIBUTING.md § Branches. -->

## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #1072

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- The Character Card Advanced tab described the System Prompt field as "overrides or appends," which made it unclear whether character system prompt text replaces the main prompt or is inserted through the prompt preset/macro path.

## What changed

<!-- List the key changes in this PR -->

- Reworded the System Prompt help tooltip to say the field is inserted by the prompt preset's character block or `{{charSysInfo}}`.
- Reworded the inline and expanded editor placeholders to match that behavior.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Codex static repro before fix: `Select-String packages/client/src/components/characters/CharacterEditor.tsx -Pattern "Overrides or appends|Override or append"` found the ambiguous tooltip and both matching placeholders.
- Codex verification after fix: the same static repro returns no matches for the ambiguous wording.
- Codex browser verification: Playwright MCP opened Character Library → Edit Character → Advanced and observed the System Prompt textarea placeholder as `Character-specific instructions inserted through {{charSysInfo}} or the character prompt block…`.
- Codex baseline: `pnpm check` passed locally.
- Bunny pre-PR review passed for the current one-file diff.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

N/A. This is a copy clarification in an existing editor field; Playwright MCP verified the replacement text in the live Character Advanced tab, but no committed screenshot is included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified character-specific system prompt instructions in the Advanced tab to improve clarity on how system instructions are applied.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1082?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->