### PR TITLE
Fix JannyAI Bot Browser definitions

### DIFF
--- a/packages/client/src/components/bot-browser/BotBrowserView.tsx
+++ b/packages/client/src/components/bot-browser/BotBrowserView.tsx
@@ -641,6 +641,7 @@ const jannyProvider: ProviderConfig = {
       .replace(/[^a-z0-9]+/g, "-")
       .replace(/^-|-$/g, "");
     const pageUrl = `https://jannyai.com/characters/${charId}_character-${slug}`;
+    const apiPageUrl = `https://api.jannyai.com/characters/${charId}_character-${slug}`;
 
     // Helper to decode Astro's [type, data] serialization
     function decodeAstro(value: unknown): unknown {
@@ -663,7 +664,14 @@ const jannyProvider: ProviderConfig = {
 
     // Helper to parse character from HTML
     function parseCharFromHtml(html: string): Record<string, unknown> | null {
-      if (!html || html.includes("Just a moment") || html.includes("cf-challenge")) return null;
+      if (
+        !html ||
+        html.includes("Just a moment") ||
+        html.includes("cf-challenge") ||
+        html.includes("challenge-platform")
+      ) {
+        return null;
+      }
       let astroMatch = html.match(/astro-island[^>]*component-export="CharacterButtons"[^>]*props="([^"]+)"/);
       if (!astroMatch) astroMatch = html.match(/astro-island[^>]*props="([^"]*character[^"]*)"/);
       if (!astroMatch?.[1]) return null;
@@ -681,29 +689,39 @@ const jannyProvider: ProviderConfig = {
       }
     }
 
-    // Strategy 1: corsproxy.io from browser (preferred — bypasses Cloudflare via the
-    // user's browser TLS fingerprint + any cf_clearance cookie they have for jannyai.com)
+    const detailFromCharacter = (char: Record<string, unknown> | null | undefined): CardDetail | null => {
+      if (!char || !(char.personality || char.firstMessage)) return null;
+      return {
+        description: (char.personality as string) || undefined,
+        scenario: (char.scenario as string) || undefined,
+        firstMessage: (char.firstMessage as string) || undefined,
+        exampleDialogs: (char.exampleDialogs as string) || undefined,
+        creatorNotes: char.description
+          ? typeof char.description === "string"
+            ? char.description.replace(/<[^>]*>/g, "").trim()
+            : undefined
+          : undefined,
+      };
+    };
+
+    const fetchHtmlDetail = async (url: string): Promise<CardDetail | null> => {
+      const res = await fetch(url, { headers: { Accept: "text/html,application/xhtml+xml,*/*" } });
+      if (!res.ok) return null;
+      return detailFromCharacter(parseCharFromHtml(await res.text()));
+    };
+
+    // JannyAI's public API mirror serves the same Astro payload with permissive CORS.
     try {
-      const proxyRes = await fetch(`https://corsproxy.io/?url=${encodeURIComponent(pageUrl)}`, {
-        headers: { Accept: "text/html,application/xhtml+xml,*/*" },
-      });
-      if (proxyRes.ok) {
-        const html = await proxyRes.text();
-        const char = parseCharFromHtml(html);
-        if (char && (char.personality || char.firstMessage)) {
-          return {
-            description: (char.personality as string) || undefined,
-            scenario: (char.scenario as string) || undefined,
-            firstMessage: (char.firstMessage as string) || undefined,
-            exampleDialogs: (char.exampleDialogs as string) || undefined,
-            creatorNotes: char.description
-              ? typeof char.description === "string"
-                ? char.description.replace(/<[^>]*>/g, "").trim()
-                : undefined
-              : undefined,
-          };
-        }
-      }
+      const apiDetail = await fetchHtmlDetail(apiPageUrl);
+      if (apiDetail) return apiDetail;
+    } catch {
+      /* fall through */
+    }
+
+    // Fall back to corsproxy.io via the user's browser TLS fingerprint and cookies.
+    try {
+      const proxyDetail = await fetchHtmlDetail(`https://corsproxy.io/?url=${encodeURIComponent(pageUrl)}`);
+      if (proxyDetail) return proxyDetail;
     } catch {
       /* fall through */
     }
@@ -713,20 +731,8 @@ const jannyProvider: ProviderConfig = {
       const res = await fetch(`/api/bot-browser/janny/character/${charId}?slug=character-${slug}`);
       if (res.ok) {
         const data = await res.json();
-        const char = data?.character;
-        if (char && (char.personality || char.firstMessage)) {
-          return {
-            description: char.personality || undefined,
-            scenario: char.scenario || undefined,
-            firstMessage: char.firstMessage || undefined,
-            exampleDialogs: char.exampleDialogs || undefined,
-            creatorNotes: char.description
-              ? typeof char.description === "string"
-                ? char.description.replace(/<[^>]*>/g, "").trim()
-                : undefined
-              : undefined,
-          };
-        }
+        const serverDetail = detailFromCharacter(data?.character);
+        if (serverDetail) return serverDetail;
       }
     } catch {
       /* fall through */
@@ -2701,7 +2707,6 @@ function DetailView({
   onImport,
   tagImportMode,
   onTagImportModeChange,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   onDetailUpdate,
 }: {
   card: BrowseCard;
@@ -2721,7 +2726,11 @@ function DetailView({
   const handleDownloadPng = async () => {
     setDownloading(true);
     try {
-      const d = displayDetail;
+      let d = displayDetail;
+      if (!d && !loading) {
+        d = await provider.fetchDetail(card);
+        if (d) onDetailUpdate?.(d);
+      }
       const descriptionText = d?.description || "";
       const personalityText = d?.personality || "";
       const charData: Record<string, unknown> = {

--- a/packages/server/src/routes/bot-browser-janny.routes.ts
+++ b/packages/server/src/routes/bot-browser-janny.routes.ts
@@ -6,6 +6,7 @@ import type { FastifyInstance } from "fastify";
 const JANNY_SEARCH_URL = "https://search.jannyai.com/multi-search";
 const JANNY_IMAGE_BASE = "https://image.jannyai.com/bot-avatars/";
 const JANNY_SITE_BASE = "https://jannyai.com";
+const JANNY_API_SITE_BASE = "https://api.jannyai.com";
 const JANNY_FALLBACK_TOKEN = "88a6463b66e04fb07ba87ee3db06af337f492ce511d93df6e2d2968cb2ff2b30";
 
 const BROWSER_UA =
@@ -302,38 +303,43 @@ export async function botBrowserJannyRoutes(app: FastifyInstance) {
 
     const slug = (req.query as Record<string, string>)?.slug || "character";
     const pageUrl = `${JANNY_SITE_BASE}/characters/${charId}_${slug}`;
+    const apiPageUrl = `${JANNY_API_SITE_BASE}/characters/${charId}_${slug}`;
+
+    const isUsableCharacterHtml = (value: string) =>
+      value.length >= 1000 &&
+      !value.includes("Just a moment") &&
+      !value.includes("cf-challenge") &&
+      !value.includes("challenge-platform") &&
+      value.includes("astro-island");
 
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 30_000);
     try {
       let html = "";
 
-      // Strategy 1: Direct fetch
-      try {
-        const directRes = await fetch(pageUrl, {
-          headers: {
-            Accept: "text/html,application/xhtml+xml,*/*",
-            "User-Agent":
-              "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
-            Referer: "https://jannyai.com/",
-          },
-          signal: controller.signal,
-          redirect: "follow",
-        });
-        if (directRes.ok) {
-          html = await directRes.text();
-          if (
-            html.length < 1000 ||
-            html.includes("Just a moment") ||
-            html.includes("cf-challenge") ||
-            html.includes("challenge-platform") ||
-            !html.includes("astro-island")
-          ) {
-            html = "";
+      // Strategy 1: Direct fetch. Try JannyAI's public API mirror first because
+      // it serves the same Astro payload with fewer bot gates than the main site.
+      for (const url of [apiPageUrl, pageUrl]) {
+        try {
+          const directRes = await fetch(url, {
+            headers: {
+              Accept: "text/html,application/xhtml+xml,*/*",
+              "User-Agent": BROWSER_UA,
+              Referer: "https://jannyai.com/",
+            },
+            signal: controller.signal,
+            redirect: "follow",
+          });
+          if (directRes.ok) {
+            const directHtml = await directRes.text();
+            if (isUsableCharacterHtml(directHtml)) {
+              html = directHtml;
+              break;
+            }
           }
+        } catch {
+          /* fall through */
         }
-      } catch {
-        /* fall through */
       }
 
       // Strategy 2: corsproxy.io
@@ -348,13 +354,7 @@ export async function botBrowserJannyRoutes(app: FastifyInstance) {
           });
           if (proxyRes.ok) {
             html = await proxyRes.text();
-            if (
-              html.length < 1000 ||
-              html.includes("Just a moment") ||
-              html.includes("cf-challenge") ||
-              html.includes("challenge-platform") ||
-              !html.includes("astro-island")
-            ) {
+            if (!isUsableCharacterHtml(html)) {
               html = "";
             }
           }


### PR DESCRIPTION
<!-- Target branch: `staging`. The default base in this UI is `main` (release branch). -->
<!-- Change the base to `staging` before submitting unless this is a maintainer-approved mainline change. -->
<!-- See CONTRIBUTING.md § Branches. -->

## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #1066

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- JannyAI Bot Browser imports could fall back to search-result metadata only when the main site/corsproxy/server scrape path did not return a full character payload, so imported cards and locally rebuilt PNGs omitted definitions such as first message and example dialogs.

## What changed

<!-- List the key changes in this PR -->

- Try JannyAI's public `api.jannyai.com` character page mirror before the existing main-site/corsproxy/server detail fallbacks.
- Share the Janny detail-to-card mapping inside the client fetch path so all successful detail strategies preserve the same definition fields.
- Make "Download as PNG" fetch missing detail data before rebuilding the local PNG card.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Codex repro before fix: `node scratch/issue-1066-janny-detail-repro.mjs current` returned `hasDefinition: false` and only `creatorNotes`.
- Codex verification after fix: `node scratch/issue-1066-janny-detail-repro.mjs fixed` returned `hasDefinition: true` with `firstMessage` and `exampleDialogs` from `api.jannyai.com`.
- Codex edge case: `node scratch/issue-1066-janny-detail-repro.mjs offline` preserved the metadata-only creator-notes fallback when every detail fetch path failed.
- Codex baseline: `pnpm check` passed locally.
- Bunny review: pass on the current diff before opening this PR.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs or release metadata changes are needed for this scoped provider fallback fix.

## UI evidence (if applicable)

N/A - non-visual import/data mapping fix. Local proof report: `scratch/issue-1066-proof.html`.
