### PR TITLE
Fix character PNG export for non-PNG avatars

### DIFF
--- a/packages/server/src/routes/characters.routes.ts
+++ b/packages/server/src/routes/characters.routes.ts
@@ -644,9 +644,13 @@ export async function charactersRoutes(app: FastifyInstance) {
       const filename = char.avatarPath.split("?")[0]!.split("/").pop()!;
       const avatarFile = join(DATA_DIR, "avatars", filename);
       if (existsSync(avatarFile)) {
-        const avatarBuffer = await readFile(avatarFile);
-        const imageInfo = isAllowedImageBuffer(avatarBuffer, extname(filename));
-        pngBuffer = imageInfo?.mimeType === "image/png" ? avatarBuffer : createMinimalPng();
+        try {
+          const avatarBuffer = await readFile(avatarFile);
+          const imageInfo = isAllowedImageBuffer(avatarBuffer, extname(filename));
+          pngBuffer = imageInfo?.mimeType === "image/png" ? avatarBuffer : createMinimalPng();
+        } catch {
+          pngBuffer = createMinimalPng();
+        }
       } else {
         pngBuffer = createMinimalPng();
       }

--- a/packages/server/src/routes/characters.routes.ts
+++ b/packages/server/src/routes/characters.routes.ts
@@ -644,7 +644,9 @@ export async function charactersRoutes(app: FastifyInstance) {
       const filename = char.avatarPath.split("?")[0]!.split("/").pop()!;
       const avatarFile = join(DATA_DIR, "avatars", filename);
       if (existsSync(avatarFile)) {
-        pngBuffer = await readFile(avatarFile);
+        const avatarBuffer = await readFile(avatarFile);
+        const imageInfo = isAllowedImageBuffer(avatarBuffer, extname(filename));
+        pngBuffer = imageInfo?.mimeType === "image/png" ? avatarBuffer : createMinimalPng();
       } else {
         pngBuffer = createMinimalPng();
       }


### PR DESCRIPTION
<!-- Target branch: `staging`. The default base in this UI is `main` (release branch). -->
<!-- Change the base to `staging` before submitting unless this is a maintainer-approved mainline change. -->
<!-- See CONTRIBUTING.md § Branches. -->

## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #1081

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- Character PNG export could fail with `Invalid PNG signature` when the stored character avatar was not already a PNG, which blocked the Android/Termux reporter's PNG export path.

## What changed

<!-- List the key changes in this PR -->

- Guard character PNG export so only real PNG avatar bytes are passed into PNG metadata injection.
- Fall back to the existing generated PNG carrier for non-PNG, missing, or unsupported avatar bytes so the character metadata still exports as a valid PNG card.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Codex reproduced the original server route failure with `pnpm --filter @marinara-engine/server exec tsx ..\..\scratch\issue-1081-export-png-repro.ts`: JPEG avatar export returned 500 and the server logged `Invalid PNG signature`.
- Codex verified the fixed JPEG-avatar route with `pnpm --filter @marinara-engine/server exec tsx ..\..\scratch\issue-1081-export-png-repro.ts --expect-pass`: export returned 200, `image/png`, and a valid PNG signature.
- Codex independently checked PNG-avatar and no-avatar route rows during PR review with a temporary route harness: JPEG-avatar, PNG-avatar, and no-avatar exports each returned 200 `image/png`; the PNG-avatar row preserved the uploaded PNG carrier and the JPEG/no-avatar rows used the generated fallback carrier.
- Codex ran `pnpm check`, which passed.
- Codex ran the Marinara proof gate on `scratch/bugfix-verification.json`, which passed.
- Manual Android check still useful: export a character as PNG from Firefox on Android and from the Marinara Android WebView shell. This machine cannot run the Android shell, but the Termux server error path from the report is covered by the route harness.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

N/A - backend route export fix. The scratch route harness captured before/after JSON evidence locally under `scratch/issue-1081-*.json`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Character PNG export now verifies avatar files are valid PNG format; non-PNG or unreadable avatar files automatically fall back to a default 1×1 transparent placeholder during export.
  * Prevents corrupted or incompatible avatar images from appearing in exported character PNGs, improving export reliability and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1085?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
