### PR TITLE
Support drag-and-drop image uploads

### DIFF
--- a/packages/client/src/components/characters/CharacterEditor.tsx
+++ b/packages/client/src/components/characters/CharacterEditor.tsx
@@ -40,6 +40,7 @@ import { showConfirmDialog } from "../../lib/app-dialogs";
 import { SpriteGenerationModal } from "../ui/SpriteGenerationModal";
 import { AvatarGenerationModal } from "../ui/AvatarGenerationModal";
 import { AvatarCropWidget } from "../ui/AvatarCropWidget";
+import { ImageUploadDropzone } from "../ui/ImageUploadDropzone";
 import {
   ArrowLeft,
   Save,
@@ -1981,19 +1982,12 @@ function CharacterGalleryTab({ characterId, characterName }: { characterId: stri
   const { data: images, isLoading } = useCharacterGalleryImages(characterId);
   const upload = useUploadCharacterGalleryImage(characterId);
   const remove = useDeleteCharacterGalleryImage(characterId);
-  const fileInputRef = useRef<HTMLInputElement>(null);
   const [lightbox, setLightbox] = useState<CharacterGalleryImage | null>(null);
 
   const handleUpload = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      const input = e.currentTarget;
-      const files = Array.from(input.files ?? []);
+    (files: File[]) => {
       if (files.length === 0) return;
-      upload.mutate(files, {
-        onSettled: () => {
-          input.value = "";
-        },
-      });
+      upload.mutate(files);
     },
     [upload],
   );
@@ -2023,17 +2017,15 @@ function CharacterGalleryTab({ characterId, characterName }: { characterId: stri
         subtitle="Keep reference art, alternate outfits, and other character images attached to this character even if chats get deleted."
       />
 
-      <input ref={fileInputRef} type="file" accept="image/*" multiple className="hidden" onChange={handleUpload} />
-
-      <button
-        type="button"
-        onClick={() => fileInputRef.current?.click()}
-        disabled={upload.isPending}
-        className="flex w-full items-center justify-center gap-2 rounded-xl border-2 border-dashed border-[var(--border)] px-4 py-6 text-xs text-[var(--muted-foreground)] transition-all hover:border-[var(--primary)] hover:text-[var(--primary)] disabled:opacity-50"
-      >
-        <Upload size="1rem" />
-        {upload.isPending ? "Uploading…" : "Upload Character Images"}
-      </button>
+      <ImageUploadDropzone
+        label="Upload Character Images"
+        pending={upload.isPending}
+        pendingLabel="Uploading…"
+        dragLabel="Drop character images to upload"
+        onFilesSelected={handleUpload}
+        icon={<Upload size="1rem" />}
+        className="w-full"
+      />
 
       {isLoading ? (
         <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4">

--- a/packages/client/src/components/chat/ChatGallery.tsx
+++ b/packages/client/src/components/chat/ChatGallery.tsx
@@ -1,19 +1,8 @@
 // ──────────────────────────────────────────────
 // Chat Gallery — Image grid for per-chat generated images
 // ──────────────────────────────────────────────
-import { useState, useRef } from "react";
-import {
-  ImagePlus,
-  Paintbrush,
-  Trash2,
-  X,
-  ZoomIn,
-  Download,
-  Sparkles,
-  Pin,
-  Minimize2,
-  Loader2,
-} from "lucide-react";
+import { useCallback, useState } from "react";
+import { ImagePlus, Paintbrush, Trash2, X, ZoomIn, Download, Sparkles, Pin, Minimize2, Loader2 } from "lucide-react";
 import {
   useGalleryImages,
   useUploadGalleryImage,
@@ -23,6 +12,7 @@ import {
 import { useGalleryStore } from "../../stores/gallery.store";
 import { ImagePromptPanel } from "./ImagePromptPanel";
 import { toast } from "sonner";
+import { ImageUploadDropzone } from "../ui/ImageUploadDropzone";
 
 interface ChatGalleryProps {
   chatId: string;
@@ -42,7 +32,6 @@ export function ChatGallery({ chatId, onIllustrate }: ChatGalleryProps) {
   const { data: images, isLoading } = useGalleryImages(chatId);
   const upload = useUploadGalleryImage(chatId);
   const remove = useDeleteGalleryImage(chatId);
-  const fileInputRef = useRef<HTMLInputElement>(null);
   const [lightbox, setLightbox] = useState<ChatImage | null>(null);
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
   const isIllustrating = useGalleryStore((s) => s.illustratingChatIds.has(chatId));
@@ -51,16 +40,13 @@ export function ChatGallery({ chatId, onIllustrate }: ChatGalleryProps) {
   const lightboxPrompt = lightbox?.prompt.trim() ?? "";
   const lightboxMeta = lightbox ? formatImageMeta(lightbox) : "";
 
-  const handleUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const input = e.currentTarget;
-    const files = Array.from(input.files ?? []);
-    if (files.length === 0) return;
-    upload.mutate(files, {
-      onSettled: () => {
-        input.value = "";
-      },
-    });
-  };
+  const handleUpload = useCallback(
+    (files: File[]) => {
+      if (files.length === 0) return;
+      upload.mutate(files);
+    },
+    [upload],
+  );
 
   const handleDelete = (id: string) => {
     remove.mutate(id);
@@ -107,16 +93,14 @@ export function ChatGallery({ chatId, onIllustrate }: ChatGalleryProps) {
         </div>
       )}
 
-      {/* Upload button */}
-      <button
-        onClick={() => fileInputRef.current?.click()}
-        disabled={upload.isPending}
-        className="flex items-center justify-center gap-2 rounded-xl border-2 border-dashed border-[var(--border)] px-4 py-6 text-xs text-[var(--muted-foreground)] transition-all hover:border-[var(--primary)] hover:text-[var(--primary)]"
-      >
-        <ImagePlus size="1rem" />
-        {upload.isPending ? "Uploading…" : "Upload Images"}
-      </button>
-      <input ref={fileInputRef} type="file" accept="image/*" multiple onChange={handleUpload} className="hidden" />
+      <ImageUploadDropzone
+        label="Upload Images"
+        pending={upload.isPending}
+        pendingLabel="Uploading…"
+        dragLabel="Drop images to upload"
+        onFilesSelected={handleUpload}
+        icon={<ImagePlus size="1rem" />}
+      />
 
       {/* Loading state */}
       {isLoading && <p className="text-center text-xs text-[var(--muted-foreground)]">Loading gallery…</p>}

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -75,6 +75,7 @@ import { chatKeys } from "../../hooks/use-chats";
 import { HelpTooltip } from "../ui/HelpTooltip";
 import { TrackerPanelIcon } from "../ui/TrackerPanelIcon";
 import { TrackerSizeTierIcon } from "../ui/TrackerSizeTierIcon";
+import { ImageUploadDropzone } from "../ui/ImageUploadDropzone";
 import { ConversationSoundSetting, ToggleSetting } from "./settings/SettingControls";
 import { TrackerCardColorSettings } from "./settings/TrackerCardColorSettings";
 import { DraftNumberInput } from "../ui/DraftNumberInput";
@@ -2053,7 +2054,6 @@ type BackgroundUploadResponse = {
 };
 
 function BackgroundPicker({ selected, onSelect }: { selected: string | null; onSelect: (url: string | null) => void }) {
-  const fileRef = useRef<HTMLInputElement>(null);
   const [uploading, setUploading] = useState(false);
   const [editingTags, setEditingTags] = useState<string | null>(null);
   const [tagInput, setTagInput] = useState("");
@@ -2105,8 +2105,7 @@ function BackgroundPicker({ selected, onSelect }: { selected: string | null; onS
     },
   });
 
-  const handleUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const files = Array.from(e.target.files ?? []);
+  const handleUpload = async (files: File[]) => {
     if (files.length === 0) return;
     setUploading(true);
     try {
@@ -2143,7 +2142,6 @@ function BackgroundPicker({ selected, onSelect }: { selected: string | null; onS
       toast.error("Background import failed.");
     } finally {
       setUploading(false);
-      e.target.value = "";
     }
   };
 
@@ -2163,16 +2161,15 @@ function BackgroundPicker({ selected, onSelect }: { selected: string | null; onS
 
   return (
     <div className="flex flex-col gap-2">
-      {/* Upload button */}
-      <button
-        onClick={() => fileRef.current?.click()}
-        disabled={uploading}
-        className="flex items-center justify-center gap-1.5 rounded-lg border-2 border-dashed border-[var(--border)] p-3 text-xs text-[var(--muted-foreground)] transition-all hover:border-[var(--primary)]/40 hover:bg-[var(--secondary)]/50"
-      >
-        {uploading ? <Loader2 size="0.875rem" className="animate-spin" /> : <Upload size="0.875rem" />}
-        {uploading ? "Importing..." : "Import Backgrounds"}
-      </button>
-      <input ref={fileRef} type="file" accept="image/*" multiple className="hidden" onChange={handleUpload} />
+      <ImageUploadDropzone
+        label="Import Backgrounds"
+        pending={uploading}
+        pendingLabel="Importing..."
+        dragLabel="Drop backgrounds to import"
+        onFilesSelected={(files) => void handleUpload(files)}
+        icon={uploading ? <Loader2 size="0.875rem" className="animate-spin" /> : <Upload size="0.875rem" />}
+        className="rounded-lg py-3 hover:border-[var(--primary)]/40 hover:bg-[var(--secondary)]/50"
+      />
 
       {/* Background grid */}
       {backgrounds && backgrounds.length > 0 && (

--- a/packages/client/src/components/ui/ImageUploadDropzone.tsx
+++ b/packages/client/src/components/ui/ImageUploadDropzone.tsx
@@ -1,0 +1,144 @@
+import { useRef, useState, type ChangeEvent, type DragEvent, type ReactNode } from "react";
+import { toast } from "sonner";
+import { cn } from "../../lib/utils";
+
+interface ImageUploadDropzoneProps {
+  label: string;
+  onFilesSelected: (files: File[]) => void;
+  icon?: ReactNode;
+  pending?: boolean;
+  pendingLabel?: string;
+  dragLabel?: string;
+  className?: string;
+  accept?: string;
+  multiple?: boolean;
+  disabled?: boolean;
+  ariaLabel?: string;
+}
+
+const IMAGE_EXTENSION_PATTERN = /\.(avif|gif|jpe?g|png|webp)$/i;
+
+function isFileDrag(event: DragEvent<HTMLElement>) {
+  return Array.from(event.dataTransfer.types).includes("Files");
+}
+
+function getSupportedImageFiles(files: FileList | null) {
+  return Array.from(files ?? []).filter(
+    (file) => file.type.startsWith("image/") || IMAGE_EXTENSION_PATTERN.test(file.name),
+  );
+}
+
+export function ImageUploadDropzone({
+  label,
+  onFilesSelected,
+  icon,
+  pending = false,
+  pendingLabel = "Uploading...",
+  dragLabel = "Drop images to upload",
+  className,
+  accept = "image/*",
+  multiple = true,
+  disabled = false,
+  ariaLabel,
+}: ImageUploadDropzoneProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const dragDepthRef = useRef(0);
+  const [isDragging, setIsDragging] = useState(false);
+  const isDisabled = disabled || pending;
+
+  const submitFiles = (files: FileList | null) => {
+    const imageFiles = getSupportedImageFiles(files);
+    if (imageFiles.length === 0) {
+      if (files && files.length > 0) {
+        toast.error("Drop image files to upload.");
+      }
+      return;
+    }
+    if (files && imageFiles.length < files.length) {
+      toast.warning("Only image files can be uploaded here.");
+    }
+    onFilesSelected(imageFiles);
+  };
+
+  const resetDragState = () => {
+    dragDepthRef.current = 0;
+    setIsDragging(false);
+  };
+
+  const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+    submitFiles(event.currentTarget.files);
+    event.currentTarget.value = "";
+  };
+
+  const handleDragEnter = (event: DragEvent<HTMLButtonElement>) => {
+    if (!isFileDrag(event)) return;
+    event.preventDefault();
+    event.stopPropagation();
+    if (isDisabled) return;
+    dragDepthRef.current += 1;
+    setIsDragging(true);
+  };
+
+  const handleDragOver = (event: DragEvent<HTMLButtonElement>) => {
+    if (!isFileDrag(event)) return;
+    event.preventDefault();
+    event.stopPropagation();
+    event.dataTransfer.dropEffect = isDisabled ? "none" : "copy";
+  };
+
+  const handleDragLeave = (event: DragEvent<HTMLButtonElement>) => {
+    if (!isFileDrag(event)) return;
+    event.preventDefault();
+    event.stopPropagation();
+    if (isDisabled) return;
+    dragDepthRef.current = Math.max(0, dragDepthRef.current - 1);
+    if (dragDepthRef.current === 0) {
+      setIsDragging(false);
+    }
+  };
+
+  const handleDrop = (event: DragEvent<HTMLButtonElement>) => {
+    if (!isFileDrag(event)) return;
+    event.preventDefault();
+    event.stopPropagation();
+    resetDragState();
+    if (isDisabled) return;
+    submitFiles(event.dataTransfer.files);
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => {
+          if (!isDisabled) inputRef.current?.click();
+        }}
+        onDragEnter={handleDragEnter}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+        aria-disabled={isDisabled}
+        aria-label={ariaLabel ?? label}
+        className={cn(
+          "flex items-center justify-center gap-2 rounded-xl border-2 border-dashed border-[var(--border)] px-4 py-6 text-xs text-[var(--muted-foreground)] transition-all hover:border-[var(--primary)] hover:text-[var(--primary)]",
+          isDragging &&
+            "border-[var(--primary)] bg-[var(--primary)]/10 text-[var(--primary)] ring-2 ring-[var(--primary)]/20",
+          isDisabled &&
+            "cursor-not-allowed opacity-50 hover:border-[var(--border)] hover:text-[var(--muted-foreground)]",
+          className,
+        )}
+      >
+        {icon}
+        {isDragging ? dragLabel : pending ? pendingLabel : label}
+      </button>
+      <input
+        ref={inputRef}
+        type="file"
+        accept={accept}
+        multiple={multiple}
+        onChange={handleInputChange}
+        className="hidden"
+      />
+    </>
+  );
+}


### PR DESCRIPTION
<!-- Target branch: `staging`. The default base in this UI is `main` (release branch). -->
<!-- Change the base to `staging` before submitting unless this is a maintainer-approved mainline change. -->
<!-- See CONTRIBUTING.md § Branches. -->

## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #1005

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- Users can already click gallery/background import buttons, but drag-and-drop image files onto those image upload areas did nothing. This makes the upload affordance match what users expect from image pickers.

## What changed

<!-- List the key changes in this PR -->

- Added a shared image upload dropzone component that preserves click-to-browse behavior while accepting dropped image files.
- Reused the dropzone in chat gallery uploads and character gallery uploads.
- Reused the same dropzone for background image imports so that importer also accepts dropped images.
- Filters dropped files to supported image types before using the existing upload/import paths.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Ran `pnpm --filter @marinara-engine/client lint`.
- Ran `pnpm build:client`.
- Opened the local app and verified the chat Gallery upload control renders with the new dropzone behavior.
- Verified a simulated file drag changes the chat Gallery label to `Drop images to upload`, then resets after drag leave.
- Verified the character Gallery upload control renders with the new dropzone behavior.
- Verified a simulated file drag changes the character Gallery label to `Drop character images to upload`, then resets after drag leave.
- Verified the Settings > Appearance background importer renders with the new dropzone behavior.
- Verified a simulated file drag changes the background importer label to `Drop backgrounds to import`, then resets after drag leave.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

<!-- Add before/after screenshots or recordings for UI changes -->