### PR TITLE
Add registered prompt override editor

### DIFF
--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -78,6 +78,7 @@ import { TrackerSizeTierIcon } from "../ui/TrackerSizeTierIcon";
 import { ImageUploadDropzone } from "../ui/ImageUploadDropzone";
 import { ConversationSoundSetting, ToggleSetting } from "./settings/SettingControls";
 import { TrackerCardColorSettings } from "./settings/TrackerCardColorSettings";
+import { PromptOverridesEditor } from "./settings/PromptOverridesEditor";
 import { DraftNumberInput } from "../ui/DraftNumberInput";
 import { ExportFormatDialog, type ExportFormatChoice } from "../ui/ExportFormatDialog";
 import { inspectCharacterFilesForEmbeddedLorebooks } from "../../lib/character-import";
@@ -3895,6 +3896,8 @@ function AdvancedSettings() {
           </button>
         </div>
       </div>
+
+      <PromptOverridesEditor />
 
       {/* ── Updates ── */}
       <div className="flex flex-col gap-2">

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -3897,8 +3897,6 @@ function AdvancedSettings() {
         </div>
       </div>
 
-      <PromptOverridesEditor />
-
       {/* ── Updates ── */}
       <div className="flex flex-col gap-2">
         <div className="flex items-center gap-1.5">
@@ -4051,6 +4049,8 @@ function AdvancedSettings() {
           />
         </div>
       </div>
+
+      <PromptOverridesEditor />
 
       <div className="retro-divider" />
       <div

--- a/packages/client/src/components/panels/settings/PromptOverridesEditor.tsx
+++ b/packages/client/src/components/panels/settings/PromptOverridesEditor.tsx
@@ -258,7 +258,6 @@ function PromptOverridesEditorBody() {
           {entries.map((entry) => (
             <option key={entry.key} value={entry.key}>
               {humanizePromptKey(entry.key)}
-              {entry.hasOverride ? (entry.enabled ? " · custom" : " · paused") : ""}
             </option>
           ))}
         </select>

--- a/packages/client/src/components/panels/settings/PromptOverridesEditor.tsx
+++ b/packages/client/src/components/panels/settings/PromptOverridesEditor.tsx
@@ -1,0 +1,344 @@
+// ──────────────────────────────────────────────
+// Settings: registered prompt overrides editor
+// ──────────────────────────────────────────────
+import { useEffect, useMemo, useRef, useState } from "react";
+import { AlertTriangle, Check, Code2, FileText, Loader2, RotateCcw, Save, Sparkles } from "lucide-react";
+import { toast } from "sonner";
+import {
+  usePromptOverride,
+  usePromptOverrideDefault,
+  usePromptOverrides,
+  useResetPromptOverride,
+  useSavePromptOverride,
+  type PromptOverrideSummary,
+} from "../../../hooks/use-prompt-overrides";
+import { ApiError } from "../../../lib/api-client";
+import { showConfirmDialog } from "../../../lib/app-dialogs";
+import { cn } from "../../../lib/utils";
+import { HelpTooltip } from "../../ui/HelpTooltip";
+
+const PREFERRED_PROMPT_KEY = "conversation.selfie";
+
+function humanizePromptKey(key: string) {
+  return key
+    .replace(/\./g, " ")
+    .replace(/([a-z])([A-Z])/g, "$1 $2")
+    .replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+function promptOverrideStatus(entry: PromptOverrideSummary | undefined) {
+  if (!entry?.hasOverride) return { label: "Default", className: "bg-[var(--secondary)] text-[var(--muted-foreground)]" };
+  if (entry.enabled) {
+    return { label: "Custom active", className: "bg-[var(--primary)]/15 text-[var(--primary)]" };
+  }
+  return { label: "Custom paused", className: "bg-amber-500/15 text-amber-300" };
+}
+
+function getPromptOverrideErrorMessage(error: unknown) {
+  if (error instanceof ApiError && error.payload && typeof error.payload === "object") {
+    const payload = error.payload as { unknownVariables?: unknown; error?: unknown };
+    if (Array.isArray(payload.unknownVariables) && payload.unknownVariables.length > 0) {
+      return `Unknown variable${payload.unknownVariables.length === 1 ? "" : "s"}: ${payload.unknownVariables.join(", ")}`;
+    }
+    if (typeof payload.error === "string" && payload.error.trim()) return payload.error;
+  }
+  return error instanceof Error ? error.message : "Failed to save prompt override.";
+}
+
+function buildEditableDefaultTemplate(
+  renderedDefault: string,
+  exampleContext: Record<string, string | number | undefined> | undefined,
+  variables: Array<{ name: string; example?: string }>,
+) {
+  if (!renderedDefault || !exampleContext) return renderedDefault;
+  let template = renderedDefault;
+  const replacements = variables
+    .map((variable) => {
+      const value = exampleContext[variable.name] ?? variable.example;
+      const example = value === undefined || value === null ? "" : String(value);
+      return { example, token: "$" + "{" + variable.name + "}" };
+    })
+    .filter((item) => item.example.length > 1)
+    .sort((a, b) => b.example.length - a.example.length);
+
+  for (const { example, token } of replacements) {
+    template = template.split(example).join(token);
+  }
+  return template;
+}
+
+export function PromptOverridesEditor() {
+  const { data: entries = [], isLoading: loadingEntries, isError: listFailed } = usePromptOverrides();
+  const [selectedKey, setSelectedKey] = useState<string | null>(null);
+  const selectedEntry = useMemo(
+    () => entries.find((entry) => entry.key === selectedKey),
+    [entries, selectedKey],
+  );
+  const detailQuery = usePromptOverride(selectedKey);
+  const defaultQuery = usePromptOverrideDefault(selectedKey);
+  const saveOverride = useSavePromptOverride();
+  const resetOverride = useResetPromptOverride();
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const [draft, setDraft] = useState("");
+  const [enabled, setEnabled] = useState(true);
+  const [lastError, setLastError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (selectedKey || entries.length === 0) return;
+    setSelectedKey(entries.some((entry) => entry.key === PREFERRED_PROMPT_KEY) ? PREFERRED_PROMPT_KEY : entries[0].key);
+  }, [entries, selectedKey]);
+
+  useEffect(() => {
+    if (!selectedKey || entries.length === 0) return;
+    if (!entries.some((entry) => entry.key === selectedKey)) setSelectedKey(entries[0].key);
+  }, [entries, selectedKey]);
+
+  const detail = detailQuery.data;
+  const variables = useMemo(
+    () => detail?.variables ?? selectedEntry?.variables ?? [],
+    [detail?.variables, selectedEntry?.variables],
+  );
+  const defaultTemplate = useMemo(
+    () => buildEditableDefaultTemplate(defaultQuery.data?.template ?? "", defaultQuery.data?.exampleContext, variables),
+    [defaultQuery.data?.exampleContext, defaultQuery.data?.template, variables],
+  );
+  const sourceTemplate = detail?.override?.template ?? defaultTemplate;
+  const sourceEnabled = detail?.override?.enabled ?? true;
+  const loadingPrompt = !!selectedKey && (detailQuery.isLoading || defaultQuery.isLoading);
+  const status = promptOverrideStatus(selectedEntry);
+  const isDirty = draft !== sourceTemplate || enabled !== sourceEnabled;
+  const canSave = !!selectedKey && draft.trim().length > 0 && isDirty && !saveOverride.isPending && !loadingPrompt;
+  const canReset = !!selectedKey && (detail?.override || draft !== defaultTemplate) && !resetOverride.isPending;
+
+  useEffect(() => {
+    if (!selectedKey || !defaultQuery.data || detailQuery.isLoading) return;
+    setDraft(sourceTemplate);
+    setEnabled(sourceEnabled);
+    setLastError(null);
+  }, [defaultQuery.data, detailQuery.isLoading, selectedKey, sourceEnabled, sourceTemplate]);
+
+  const insertVariable = (name: string) => {
+    const token = "$" + "{" + name + "}";
+    const textarea = textareaRef.current;
+    if (!textarea) {
+      setDraft((current) => `${current}${token}`);
+      return;
+    }
+    const start = textarea.selectionStart ?? draft.length;
+    const end = textarea.selectionEnd ?? draft.length;
+    const nextDraft = `${draft.slice(0, start)}${token}${draft.slice(end)}`;
+    setDraft(nextDraft);
+    setLastError(null);
+    requestAnimationFrame(() => {
+      textarea.focus();
+      const cursor = start + token.length;
+      textarea.setSelectionRange(cursor, cursor);
+    });
+  };
+
+  const handleSave = async () => {
+    if (!selectedKey) return;
+    if (!draft.trim()) {
+      setLastError("Template must not be empty.");
+      return;
+    }
+    try {
+      setLastError(null);
+      await saveOverride.mutateAsync({ key: selectedKey, template: draft, enabled });
+      toast.success("Prompt override saved.");
+    } catch (error) {
+      const message = getPromptOverrideErrorMessage(error);
+      setLastError(message);
+      toast.error(message);
+    }
+  };
+
+  const handleReset = async () => {
+    if (!selectedKey) return;
+    if (!detail?.override) {
+      setDraft(defaultTemplate);
+      setEnabled(true);
+      setLastError(null);
+      return;
+    }
+
+    const confirmed = await showConfirmDialog({
+      title: "Reset prompt override?",
+      message: `${humanizePromptKey(selectedKey)} will use its built-in default again. Your custom template for this key will be removed.`,
+      confirmLabel: "Reset to Default",
+      cancelLabel: "Cancel",
+      tone: "destructive",
+    });
+    if (!confirmed) return;
+
+    try {
+      setLastError(null);
+      await resetOverride.mutateAsync(selectedKey);
+      setDraft(defaultTemplate);
+      setEnabled(true);
+      toast.success("Prompt override reset to default.");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to reset prompt override.";
+      setLastError(message);
+      toast.error(message);
+    }
+  };
+
+  if (listFailed) {
+    return (
+      <section className="rounded-xl bg-[var(--secondary)]/40 p-3 ring-1 ring-[var(--border)]">
+        <div className="flex items-start gap-2 text-xs text-[var(--destructive)]">
+          <AlertTriangle size="0.875rem" className="mt-0.5 shrink-0" />
+          Could not load registered prompt overrides.
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="rounded-xl bg-[var(--secondary)]/40 p-3 ring-1 ring-[var(--border)]">
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <div className="flex items-center gap-1.5">
+            <FileText size="0.75rem" className="text-[var(--muted-foreground)]" />
+            <span className="text-xs font-medium">Prompt Overrides</span>
+            <HelpTooltip text="Global templates for registered prompt builders. Chat-specific selfie prompts still override the global conversation selfie template." />
+          </div>
+          <p className="mt-1 text-[0.625rem] leading-relaxed text-[var(--muted-foreground)]">
+            Edit the templates used by image and sprite prompt builders.
+          </p>
+        </div>
+        <span className={cn("shrink-0 rounded-full px-2 py-0.5 text-[0.5625rem] font-semibold", status.className)}>
+          {status.label}
+        </span>
+      </div>
+
+      <div className="mt-3 flex flex-col gap-2.5">
+        <label className="flex flex-col gap-1">
+          <span className="text-[0.625rem] font-medium text-[var(--muted-foreground)]">Registered prompt</span>
+          <select
+            value={selectedKey ?? ""}
+            disabled={loadingEntries || entries.length === 0}
+            onChange={(event) => setSelectedKey(event.target.value)}
+            className="w-full rounded-lg bg-[var(--background)] px-3 py-2 text-xs text-[var(--foreground)] outline-none ring-1 ring-[var(--border)] focus:ring-[var(--primary)] disabled:opacity-60"
+          >
+            {loadingEntries && <option value="">Loading prompts...</option>}
+            {!loadingEntries && entries.length === 0 && <option value="">No registered prompts</option>}
+            {entries.map((entry) => (
+              <option key={entry.key} value={entry.key}>
+                {humanizePromptKey(entry.key)}
+                {entry.hasOverride ? (entry.enabled ? " · custom" : " · paused") : ""}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        {selectedEntry && (
+          <p className="rounded-lg bg-[var(--background)]/50 px-2.5 py-2 text-[0.625rem] leading-relaxed text-[var(--muted-foreground)] ring-1 ring-[var(--border)]/70">
+            {selectedEntry.description}
+          </p>
+        )}
+
+        {variables.length > 0 && (
+          <div className="flex flex-col gap-1">
+            <span className="text-[0.625rem] font-medium text-[var(--muted-foreground)]">Available variables</span>
+            <div className="flex flex-wrap gap-1.5">
+              {variables.map((variable) => (
+                <button
+                  type="button"
+                  key={variable.name}
+                  onClick={() => insertVariable(variable.name)}
+                  title={variable.description}
+                  className="inline-flex items-center gap-1 rounded-md bg-[var(--background)] px-2 py-1 font-mono text-[0.6rem] text-[var(--primary)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)]"
+                >
+                  <Code2 size="0.625rem" />
+                  {"${" + variable.name + "}"}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        <label className="flex flex-col gap-1">
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-[0.625rem] font-medium text-[var(--muted-foreground)]">Template</span>
+            <span className="text-[0.5625rem] text-[var(--muted-foreground)]">{draft.length} chars</span>
+          </div>
+          <textarea
+            ref={textareaRef}
+            value={loadingPrompt ? "" : draft}
+            disabled={loadingPrompt || !selectedKey}
+            onChange={(event) => {
+              setDraft(event.target.value);
+              setLastError(null);
+            }}
+            placeholder={loadingPrompt ? "Loading template..." : "Write a prompt template..."}
+            className="min-h-52 resize-y rounded-lg border border-[var(--border)] bg-[var(--background)] p-2.5 font-mono text-[0.6875rem] leading-relaxed text-[var(--foreground)] outline-none transition-colors placeholder:text-[var(--muted-foreground)]/45 focus:border-[var(--primary)]/50 disabled:cursor-wait disabled:opacity-60"
+          />
+        </label>
+
+        <label className="flex cursor-pointer items-start gap-2 rounded-lg bg-[var(--background)]/45 px-2.5 py-2 ring-1 ring-[var(--border)]/70">
+          <input
+            type="checkbox"
+            checked={enabled}
+            disabled={loadingPrompt || !selectedKey}
+            onChange={(event) => setEnabled(event.target.checked)}
+            className="mt-0.5 h-3.5 w-3.5 rounded border-[var(--border)] accent-[var(--primary)]"
+          />
+          <span className="min-w-0">
+            <span className="block text-xs font-medium text-[var(--foreground)]">Apply this override</span>
+            <span className="block text-[0.625rem] leading-relaxed text-[var(--muted-foreground)]">
+              Turn this off to keep the template saved without using it.
+            </span>
+          </span>
+        </label>
+
+        {lastError && (
+          <div className="flex items-start gap-1.5 rounded-lg bg-[var(--destructive)]/10 px-2.5 py-2 text-[0.625rem] text-[var(--destructive)] ring-1 ring-[var(--destructive)]/20">
+            <AlertTriangle size="0.75rem" className="mt-0.5 shrink-0" />
+            <span>{lastError}</span>
+          </div>
+        )}
+
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={() => void handleSave()}
+            disabled={!canSave}
+            className={cn(
+              "inline-flex flex-1 items-center justify-center gap-1.5 rounded-lg px-3 py-2 text-xs font-medium transition-all active:scale-95 disabled:cursor-not-allowed disabled:opacity-50",
+              canSave
+                ? "bg-[var(--primary)] text-[var(--primary-foreground)] hover:opacity-90"
+                : "bg-[var(--muted)] text-[var(--muted-foreground)]",
+            )}
+          >
+            {saveOverride.isPending ? <Loader2 size="0.8125rem" className="animate-spin" /> : <Save size="0.8125rem" />}
+            Save
+          </button>
+          <button
+            type="button"
+            onClick={() => void handleReset()}
+            disabled={!canReset}
+            className="inline-flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-[var(--background)] px-3 py-2 text-xs font-medium text-[var(--foreground)] ring-1 ring-[var(--border)] transition-all hover:bg-[var(--accent)] active:scale-95 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {resetOverride.isPending ? (
+              <Loader2 size="0.8125rem" className="animate-spin" />
+            ) : detail?.override ? (
+              <RotateCcw size="0.8125rem" />
+            ) : (
+              <Sparkles size="0.8125rem" />
+            )}
+            Reset to Default
+          </button>
+        </div>
+
+        {detail?.override && !isDirty && (
+          <div className="flex items-center gap-1.5 text-[0.625rem] text-[var(--muted-foreground)]">
+            <Check size="0.6875rem" className="text-green-500" />
+            Saved {new Date(detail.override.updatedAt).toLocaleString()}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/packages/client/src/components/panels/settings/PromptOverridesEditor.tsx
+++ b/packages/client/src/components/panels/settings/PromptOverridesEditor.tsx
@@ -69,14 +69,20 @@ function buildEditableDefaultTemplate(
 
 export function PromptOverridesEditor() {
   const [isOpen, setIsOpen] = useState(false);
+  const [hasOpened, setHasOpened] = useState(false);
   const contentId = useId();
+
+  const toggleOpen = () => {
+    setHasOpened(true);
+    setIsOpen((open) => !open);
+  };
 
   return (
     <section className="overflow-hidden rounded-xl bg-[var(--secondary)]/40 ring-1 ring-[var(--border)]">
       <div className="flex items-start gap-2 p-3">
         <button
           type="button"
-          onClick={() => setIsOpen((open) => !open)}
+          onClick={toggleOpen}
           aria-expanded={isOpen}
           aria-controls={contentId}
           className="flex min-w-0 flex-1 items-start gap-2 rounded-lg text-left transition-colors hover:text-[var(--primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)]"
@@ -103,8 +109,8 @@ export function PromptOverridesEditor() {
         </span>
       </div>
 
-      {isOpen && (
-        <div id={contentId} className="border-t border-[var(--border)]/70 p-3 pt-2.5">
+      {hasOpened && (
+        <div id={contentId} hidden={!isOpen} className="border-t border-[var(--border)]/70 p-3 pt-2.5">
           <PromptOverridesEditorBody />
         </div>
       )}

--- a/packages/client/src/components/panels/settings/PromptOverridesEditor.tsx
+++ b/packages/client/src/components/panels/settings/PromptOverridesEditor.tsx
@@ -1,8 +1,8 @@
 // ──────────────────────────────────────────────
 // Settings: registered prompt overrides editor
 // ──────────────────────────────────────────────
-import { useEffect, useMemo, useRef, useState } from "react";
-import { AlertTriangle, Check, Code2, FileText, Loader2, RotateCcw, Save, Sparkles } from "lucide-react";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
+import { AlertTriangle, Check, ChevronDown, Code2, FileText, Loader2, RotateCcw, Save, Sparkles } from "lucide-react";
 import { toast } from "sonner";
 import {
   usePromptOverride,
@@ -68,6 +68,51 @@ function buildEditableDefaultTemplate(
 }
 
 export function PromptOverridesEditor() {
+  const [isOpen, setIsOpen] = useState(false);
+  const contentId = useId();
+
+  return (
+    <section className="overflow-hidden rounded-xl bg-[var(--secondary)]/40 ring-1 ring-[var(--border)]">
+      <div className="flex items-start gap-2 p-3">
+        <button
+          type="button"
+          onClick={() => setIsOpen((open) => !open)}
+          aria-expanded={isOpen}
+          aria-controls={contentId}
+          className="flex min-w-0 flex-1 items-start gap-2 rounded-lg text-left transition-colors hover:text-[var(--primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)]"
+        >
+          <ChevronDown
+            size="0.875rem"
+            className={cn(
+              "mt-0.5 shrink-0 text-[var(--muted-foreground)] transition-transform",
+              !isOpen && "-rotate-90",
+            )}
+          />
+          <span className="min-w-0">
+            <span className="flex items-center gap-1.5">
+              <FileText size="0.75rem" className="text-[var(--muted-foreground)]" />
+              <span className="text-xs font-medium text-[var(--foreground)]">Prompt Overrides</span>
+            </span>
+            <span className="mt-1 block text-[0.625rem] leading-relaxed text-[var(--muted-foreground)]">
+              Edit the templates used by image and sprite prompt builders.
+            </span>
+          </span>
+        </button>
+        <span className="mt-0.5 shrink-0">
+          <HelpTooltip text="Global templates for registered prompt builders. Chat-specific selfie prompts still override the global conversation selfie template." />
+        </span>
+      </div>
+
+      {isOpen && (
+        <div id={contentId} className="border-t border-[var(--border)]/70 p-3 pt-2.5">
+          <PromptOverridesEditorBody />
+        </div>
+      )}
+    </section>
+  );
+}
+
+function PromptOverridesEditorBody() {
   const { data: entries = [], isLoading: loadingEntries, isError: listFailed } = usePromptOverrides();
   const [selectedKey, setSelectedKey] = useState<string | null>(null);
   const selectedEntry = useMemo(
@@ -186,159 +231,144 @@ export function PromptOverridesEditor() {
 
   if (listFailed) {
     return (
-      <section className="rounded-xl bg-[var(--secondary)]/40 p-3 ring-1 ring-[var(--border)]">
-        <div className="flex items-start gap-2 text-xs text-[var(--destructive)]">
-          <AlertTriangle size="0.875rem" className="mt-0.5 shrink-0" />
-          Could not load registered prompt overrides.
-        </div>
-      </section>
+      <div className="flex items-start gap-2 text-xs text-[var(--destructive)]">
+        <AlertTriangle size="0.875rem" className="mt-0.5 shrink-0" />
+        Could not load registered prompt overrides.
+      </div>
     );
   }
 
   return (
-    <section className="rounded-xl bg-[var(--secondary)]/40 p-3 ring-1 ring-[var(--border)]">
-      <div className="flex items-start justify-between gap-2">
-        <div className="min-w-0">
-          <div className="flex items-center gap-1.5">
-            <FileText size="0.75rem" className="text-[var(--muted-foreground)]" />
-            <span className="text-xs font-medium">Prompt Overrides</span>
-            <HelpTooltip text="Global templates for registered prompt builders. Chat-specific selfie prompts still override the global conversation selfie template." />
-          </div>
-          <p className="mt-1 text-[0.625rem] leading-relaxed text-[var(--muted-foreground)]">
-            Edit the templates used by image and sprite prompt builders.
-          </p>
-        </div>
-        <span className={cn("shrink-0 rounded-full px-2 py-0.5 text-[0.5625rem] font-semibold", status.className)}>
-          {status.label}
-        </span>
-      </div>
-
-      <div className="mt-3 flex flex-col gap-2.5">
-        <label className="flex flex-col gap-1">
+    <div className="flex flex-col gap-2.5">
+      <label className="flex flex-col gap-1">
+        <span className="flex items-center justify-between gap-2">
           <span className="text-[0.625rem] font-medium text-[var(--muted-foreground)]">Registered prompt</span>
-          <select
-            value={selectedKey ?? ""}
-            disabled={loadingEntries || entries.length === 0}
-            onChange={(event) => setSelectedKey(event.target.value)}
-            className="w-full rounded-lg bg-[var(--background)] px-3 py-2 text-xs text-[var(--foreground)] outline-none ring-1 ring-[var(--border)] focus:ring-[var(--primary)] disabled:opacity-60"
-          >
-            {loadingEntries && <option value="">Loading prompts...</option>}
-            {!loadingEntries && entries.length === 0 && <option value="">No registered prompts</option>}
-            {entries.map((entry) => (
-              <option key={entry.key} value={entry.key}>
-                {humanizePromptKey(entry.key)}
-                {entry.hasOverride ? (entry.enabled ? " · custom" : " · paused") : ""}
-              </option>
-            ))}
-          </select>
-        </label>
-
-        {selectedEntry && (
-          <p className="rounded-lg bg-[var(--background)]/50 px-2.5 py-2 text-[0.625rem] leading-relaxed text-[var(--muted-foreground)] ring-1 ring-[var(--border)]/70">
-            {selectedEntry.description}
-          </p>
-        )}
-
-        {variables.length > 0 && (
-          <div className="flex flex-col gap-1">
-            <span className="text-[0.625rem] font-medium text-[var(--muted-foreground)]">Available variables</span>
-            <div className="flex flex-wrap gap-1.5">
-              {variables.map((variable) => (
-                <button
-                  type="button"
-                  key={variable.name}
-                  onClick={() => insertVariable(variable.name)}
-                  title={variable.description}
-                  className="inline-flex items-center gap-1 rounded-md bg-[var(--background)] px-2 py-1 font-mono text-[0.6rem] text-[var(--primary)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)]"
-                >
-                  <Code2 size="0.625rem" />
-                  {"${" + variable.name + "}"}
-                </button>
-              ))}
-            </div>
-          </div>
-        )}
-
-        <label className="flex flex-col gap-1">
-          <div className="flex items-center justify-between gap-2">
-            <span className="text-[0.625rem] font-medium text-[var(--muted-foreground)]">Template</span>
-            <span className="text-[0.5625rem] text-[var(--muted-foreground)]">{draft.length} chars</span>
-          </div>
-          <textarea
-            ref={textareaRef}
-            value={loadingPrompt ? "" : draft}
-            disabled={loadingPrompt || !selectedKey}
-            onChange={(event) => {
-              setDraft(event.target.value);
-              setLastError(null);
-            }}
-            placeholder={loadingPrompt ? "Loading template..." : "Write a prompt template..."}
-            className="min-h-52 resize-y rounded-lg border border-[var(--border)] bg-[var(--background)] p-2.5 font-mono text-[0.6875rem] leading-relaxed text-[var(--foreground)] outline-none transition-colors placeholder:text-[var(--muted-foreground)]/45 focus:border-[var(--primary)]/50 disabled:cursor-wait disabled:opacity-60"
-          />
-        </label>
-
-        <label className="flex cursor-pointer items-start gap-2 rounded-lg bg-[var(--background)]/45 px-2.5 py-2 ring-1 ring-[var(--border)]/70">
-          <input
-            type="checkbox"
-            checked={enabled}
-            disabled={loadingPrompt || !selectedKey}
-            onChange={(event) => setEnabled(event.target.checked)}
-            className="mt-0.5 h-3.5 w-3.5 rounded border-[var(--border)] accent-[var(--primary)]"
-          />
-          <span className="min-w-0">
-            <span className="block text-xs font-medium text-[var(--foreground)]">Apply this override</span>
-            <span className="block text-[0.625rem] leading-relaxed text-[var(--muted-foreground)]">
-              Turn this off to keep the template saved without using it.
-            </span>
+          <span className={cn("shrink-0 rounded-full px-2 py-0.5 text-[0.5625rem] font-semibold", status.className)}>
+            {loadingEntries ? "Loading" : status.label}
           </span>
-        </label>
+        </span>
+        <select
+          value={selectedKey ?? ""}
+          disabled={loadingEntries || entries.length === 0}
+          onChange={(event) => setSelectedKey(event.target.value)}
+          className="w-full rounded-lg bg-[var(--background)] px-3 py-2 text-xs text-[var(--foreground)] outline-none ring-1 ring-[var(--border)] focus:ring-[var(--primary)] disabled:opacity-60"
+        >
+          {loadingEntries && <option value="">Loading prompts...</option>}
+          {!loadingEntries && entries.length === 0 && <option value="">No registered prompts</option>}
+          {entries.map((entry) => (
+            <option key={entry.key} value={entry.key}>
+              {humanizePromptKey(entry.key)}
+              {entry.hasOverride ? (entry.enabled ? " · custom" : " · paused") : ""}
+            </option>
+          ))}
+        </select>
+      </label>
 
-        {lastError && (
-          <div className="flex items-start gap-1.5 rounded-lg bg-[var(--destructive)]/10 px-2.5 py-2 text-[0.625rem] text-[var(--destructive)] ring-1 ring-[var(--destructive)]/20">
-            <AlertTriangle size="0.75rem" className="mt-0.5 shrink-0" />
-            <span>{lastError}</span>
+      {selectedEntry && (
+        <p className="rounded-lg bg-[var(--background)]/50 px-2.5 py-2 text-[0.625rem] leading-relaxed text-[var(--muted-foreground)] ring-1 ring-[var(--border)]/70">
+          {selectedEntry.description}
+        </p>
+      )}
+
+      {variables.length > 0 && (
+        <div className="flex flex-col gap-1">
+          <span className="text-[0.625rem] font-medium text-[var(--muted-foreground)]">Available variables</span>
+          <div className="flex flex-wrap gap-1.5">
+            {variables.map((variable) => (
+              <button
+                type="button"
+                key={variable.name}
+                onClick={() => insertVariable(variable.name)}
+                title={variable.description}
+                className="inline-flex items-center gap-1 rounded-md bg-[var(--background)] px-2 py-1 font-mono text-[0.6rem] text-[var(--primary)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)]"
+              >
+                <Code2 size="0.625rem" />
+                {"${" + variable.name + "}"}
+              </button>
+            ))}
           </div>
-        )}
-
-        <div className="flex flex-wrap gap-2">
-          <button
-            type="button"
-            onClick={() => void handleSave()}
-            disabled={!canSave}
-            className={cn(
-              "inline-flex flex-1 items-center justify-center gap-1.5 rounded-lg px-3 py-2 text-xs font-medium transition-all active:scale-95 disabled:cursor-not-allowed disabled:opacity-50",
-              canSave
-                ? "bg-[var(--primary)] text-[var(--primary-foreground)] hover:opacity-90"
-                : "bg-[var(--muted)] text-[var(--muted-foreground)]",
-            )}
-          >
-            {saveOverride.isPending ? <Loader2 size="0.8125rem" className="animate-spin" /> : <Save size="0.8125rem" />}
-            Save
-          </button>
-          <button
-            type="button"
-            onClick={() => void handleReset()}
-            disabled={!canReset}
-            className="inline-flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-[var(--background)] px-3 py-2 text-xs font-medium text-[var(--foreground)] ring-1 ring-[var(--border)] transition-all hover:bg-[var(--accent)] active:scale-95 disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            {resetOverride.isPending ? (
-              <Loader2 size="0.8125rem" className="animate-spin" />
-            ) : detail?.override ? (
-              <RotateCcw size="0.8125rem" />
-            ) : (
-              <Sparkles size="0.8125rem" />
-            )}
-            Reset to Default
-          </button>
         </div>
+      )}
 
-        {detail?.override && !isDirty && (
-          <div className="flex items-center gap-1.5 text-[0.625rem] text-[var(--muted-foreground)]">
-            <Check size="0.6875rem" className="text-green-500" />
-            Saved {new Date(detail.override.updatedAt).toLocaleString()}
-          </div>
-        )}
+      <label className="flex flex-col gap-1">
+        <div className="flex items-center justify-between gap-2">
+          <span className="text-[0.625rem] font-medium text-[var(--muted-foreground)]">Template</span>
+          <span className="text-[0.5625rem] text-[var(--muted-foreground)]">{draft.length} chars</span>
+        </div>
+        <textarea
+          ref={textareaRef}
+          value={loadingPrompt ? "" : draft}
+          disabled={loadingPrompt || !selectedKey}
+          onChange={(event) => {
+            setDraft(event.target.value);
+            setLastError(null);
+          }}
+          placeholder={loadingPrompt ? "Loading template..." : "Write a prompt template..."}
+          className="min-h-52 resize-y rounded-lg border border-[var(--border)] bg-[var(--background)] p-2.5 font-mono text-[0.6875rem] leading-relaxed text-[var(--foreground)] outline-none transition-colors placeholder:text-[var(--muted-foreground)]/45 focus:border-[var(--primary)]/50 disabled:cursor-wait disabled:opacity-60"
+        />
+      </label>
+
+      <label className="flex cursor-pointer items-start gap-2 rounded-lg bg-[var(--background)]/45 px-2.5 py-2 ring-1 ring-[var(--border)]/70">
+        <input
+          type="checkbox"
+          checked={enabled}
+          disabled={loadingPrompt || !selectedKey}
+          onChange={(event) => setEnabled(event.target.checked)}
+          className="mt-0.5 h-3.5 w-3.5 rounded border-[var(--border)] accent-[var(--primary)]"
+        />
+        <span className="min-w-0">
+          <span className="block text-xs font-medium text-[var(--foreground)]">Apply this override</span>
+          <span className="block text-[0.625rem] leading-relaxed text-[var(--muted-foreground)]">
+            Turn this off to keep the template saved without using it.
+          </span>
+        </span>
+      </label>
+
+      {lastError && (
+        <div className="flex items-start gap-1.5 rounded-lg bg-[var(--destructive)]/10 px-2.5 py-2 text-[0.625rem] text-[var(--destructive)] ring-1 ring-[var(--destructive)]/20">
+          <AlertTriangle size="0.75rem" className="mt-0.5 shrink-0" />
+          <span>{lastError}</span>
+        </div>
+      )}
+
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="button"
+          onClick={() => void handleSave()}
+          disabled={!canSave}
+          className={cn(
+            "inline-flex flex-1 items-center justify-center gap-1.5 rounded-lg px-3 py-2 text-xs font-medium transition-all active:scale-95 disabled:cursor-not-allowed disabled:opacity-50",
+            canSave
+              ? "bg-[var(--primary)] text-[var(--primary-foreground)] hover:opacity-90"
+              : "bg-[var(--muted)] text-[var(--muted-foreground)]",
+          )}
+        >
+          {saveOverride.isPending ? <Loader2 size="0.8125rem" className="animate-spin" /> : <Save size="0.8125rem" />}
+          Save
+        </button>
+        <button
+          type="button"
+          onClick={() => void handleReset()}
+          disabled={!canReset}
+          className="inline-flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-[var(--background)] px-3 py-2 text-xs font-medium text-[var(--foreground)] ring-1 ring-[var(--border)] transition-all hover:bg-[var(--accent)] active:scale-95 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {resetOverride.isPending ? (
+            <Loader2 size="0.8125rem" className="animate-spin" />
+          ) : detail?.override ? (
+            <RotateCcw size="0.8125rem" />
+          ) : (
+            <Sparkles size="0.8125rem" />
+          )}
+          Reset to Default
+        </button>
       </div>
-    </section>
+
+      {detail?.override && !isDirty && (
+        <div className="flex items-center gap-1.5 text-[0.625rem] text-[var(--muted-foreground)]">
+          <Check size="0.6875rem" className="text-green-500" />
+          Saved {new Date(detail.override.updatedAt).toLocaleString()}
+        </div>
+      )}
+    </div>
   );
 }

--- a/packages/client/src/hooks/use-prompt-overrides.ts
+++ b/packages/client/src/hooks/use-prompt-overrides.ts
@@ -1,0 +1,98 @@
+// ──────────────────────────────────────────────
+// React Query: Registered prompt overrides
+// ──────────────────────────────────────────────
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { api } from "../lib/api-client";
+
+export interface PromptOverrideVariable {
+  name: string;
+  description: string;
+  example?: string;
+}
+
+export interface PromptOverrideSummary {
+  key: string;
+  description: string;
+  variables: PromptOverrideVariable[];
+  hasOverride: boolean;
+  enabled: boolean;
+  updatedAt: string | null;
+}
+
+export interface PromptOverrideRow {
+  key: string;
+  template: string;
+  enabled: boolean;
+  updatedAt: string;
+}
+
+export interface PromptOverrideDetail {
+  key: string;
+  description: string;
+  variables: PromptOverrideVariable[];
+  override: PromptOverrideRow | null;
+}
+
+export interface PromptOverrideDefault {
+  key: string;
+  template: string;
+  exampleContext: Record<string, string | number | undefined>;
+}
+
+export const promptOverrideKeys = {
+  all: ["prompt-overrides"] as const,
+  list: () => [...promptOverrideKeys.all, "list"] as const,
+  detail: (key: string) => [...promptOverrideKeys.all, "detail", key] as const,
+  default: (key: string) => [...promptOverrideKeys.all, "default", key] as const,
+};
+
+export function usePromptOverrides() {
+  return useQuery({
+    queryKey: promptOverrideKeys.list(),
+    queryFn: () => api.get<PromptOverrideSummary[]>("/prompt-overrides"),
+    staleTime: 60_000,
+  });
+}
+
+export function usePromptOverride(key: string | null) {
+  return useQuery({
+    queryKey: promptOverrideKeys.detail(key ?? ""),
+    queryFn: () => api.get<PromptOverrideDetail>(`/prompt-overrides/${key}`),
+    enabled: !!key,
+    staleTime: 60_000,
+  });
+}
+
+export function usePromptOverrideDefault(key: string | null) {
+  return useQuery({
+    queryKey: promptOverrideKeys.default(key ?? ""),
+    queryFn: () => api.get<PromptOverrideDefault>(`/prompt-overrides/${key}/default`),
+    enabled: !!key,
+    staleTime: 60_000,
+  });
+}
+
+export function useSavePromptOverride() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ key, template, enabled }: { key: string; template: string; enabled: boolean }) =>
+      api.put<PromptOverrideRow>(`/prompt-overrides/${key}`, { template, enabled }),
+    onSuccess: (_row, variables) => {
+      qc.invalidateQueries({ queryKey: promptOverrideKeys.list() });
+      qc.invalidateQueries({ queryKey: promptOverrideKeys.detail(variables.key) });
+      qc.invalidateQueries({ queryKey: promptOverrideKeys.default(variables.key) });
+    },
+  });
+}
+
+export function useResetPromptOverride() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (key: string) => api.delete<void>(`/prompt-overrides/${key}`),
+    onSuccess: (_row, key) => {
+      qc.invalidateQueries({ queryKey: promptOverrideKeys.list() });
+      qc.invalidateQueries({ queryKey: promptOverrideKeys.detail(key) });
+      qc.invalidateQueries({ queryKey: promptOverrideKeys.default(key) });
+    },
+  });
+}

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -48,8 +48,7 @@ import { createLorebooksStorage } from "../services/storage/lorebooks.storage.js
 import { createRegexScriptsStorage } from "../services/storage/regex-scripts.storage.js";
 import { applyRegexScriptsToPromptMessages } from "../services/regex/regex-application.js";
 import { createPromptOverridesStorage } from "../services/storage/prompt-overrides.storage.js";
-import { loadPrompt, CONVERSATION_SELFIE } from "../services/prompt-overrides/index.js";
-import { renderTemplate } from "../services/prompt-overrides/template.js";
+import { resolveConversationSelfieSystemPrompt } from "../services/conversation/selfie-prompt.js";
 import { processLorebooks } from "../services/lorebook/index.js";
 import {
   filterGameInternalAgentIds,
@@ -8886,22 +8885,12 @@ export async function generateRoutes(app: FastifyInstance) {
                         conn.openrouterProvider,
                         conn.maxTokensOverride,
                       );
-                      const selfiePromptContext = {
+                      const selfieSystemPrompt = await resolveConversationSelfieSystemPrompt({
+                        promptOverridesStorage: createPromptOverridesStorage(app.db),
+                        chatPromptTemplate: selfiePromptTemplate,
                         appearance,
                         charName,
-                        selfieTagsBlock: "",
-                      };
-                      const selfieSystemPrompt = selfiePromptTemplate
-                        ? renderTemplate(
-                            selfiePromptTemplate,
-                            selfiePromptContext,
-                            CONVERSATION_SELFIE.variables.map((variable) => variable.name),
-                          )
-                        : await loadPrompt(
-                            createPromptOverridesStorage(app.db),
-                            CONVERSATION_SELFIE,
-                            selfiePromptContext,
-                          );
+                      });
                       const promptResult = await promptBuilder.chatComplete(
                         [
                           {

--- a/packages/server/src/services/conversation/selfie-prompt.ts
+++ b/packages/server/src/services/conversation/selfie-prompt.ts
@@ -1,0 +1,28 @@
+import type { ConversationSelfieCtx } from "../prompt-overrides/index.js";
+import { CONVERSATION_SELFIE, loadPrompt, renderTemplate } from "../prompt-overrides/index.js";
+import type { PromptOverridesStorage } from "../storage/prompt-overrides.storage.js";
+
+export async function resolveConversationSelfieSystemPrompt(input: {
+  promptOverridesStorage: PromptOverridesStorage;
+  chatPromptTemplate?: string | null;
+  appearance: string;
+  charName: string;
+  selfieTagsBlock?: string;
+}): Promise<string> {
+  const promptContext: ConversationSelfieCtx = {
+    appearance: input.appearance,
+    charName: input.charName,
+    selfieTagsBlock: input.selfieTagsBlock ?? "",
+  };
+  const chatPromptTemplate = input.chatPromptTemplate?.trim() ?? "";
+
+  if (chatPromptTemplate) {
+    return renderTemplate(
+      chatPromptTemplate,
+      promptContext,
+      CONVERSATION_SELFIE.variables.map((variable) => variable.name),
+    );
+  }
+
+  return loadPrompt(input.promptOverridesStorage, CONVERSATION_SELFIE, promptContext);
+}

--- a/packages/server/test/conversation-selfie-prompt.test.ts
+++ b/packages/server/test/conversation-selfie-prompt.test.ts
@@ -5,9 +5,12 @@ import type { PromptOverridesStorage } from "../src/services/storage/prompt-over
 
 type CapturedMessage = { role: "system" | "user"; content: string };
 
+const EXPECTED_PROMPT_KEY = "conversation.selfie";
+
 function promptOverrideStorage(template: string, enabled = true): PromptOverridesStorage {
   return {
     async get(key) {
+      assert.equal(key, EXPECTED_PROMPT_KEY);
       return {
         key,
         template,

--- a/packages/server/test/conversation-selfie-prompt.test.ts
+++ b/packages/server/test/conversation-selfie-prompt.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { resolveConversationSelfieSystemPrompt } from "../src/services/conversation/selfie-prompt.js";
+import type { PromptOverridesStorage } from "../src/services/storage/prompt-overrides.storage.js";
+
+type CapturedMessage = { role: "system" | "user"; content: string };
+
+function promptOverrideStorage(template: string, enabled = true): PromptOverridesStorage {
+  return {
+    async get(key) {
+      return {
+        key,
+        template,
+        enabled,
+        updatedAt: "2026-05-22T00:00:00.000Z",
+      };
+    },
+    async list() {
+      return [];
+    },
+    async upsert(input) {
+      return { ...input, updatedAt: "2026-05-22T00:00:00.000Z" };
+    },
+    async remove() {},
+  };
+}
+
+async function sendToFakeSelfiePromptBuilder(systemPrompt: string): Promise<{
+  capturedMessages: CapturedMessage[];
+  content: string;
+}> {
+  const capturedMessages: CapturedMessage[] = [
+    { role: "system", content: systemPrompt },
+    { role: "user", content: "Generate a casual selfie based on the current conversation context." },
+  ];
+
+  return { capturedMessages, content: "" };
+}
+
+test("registered conversation.selfie override is sent as the selfie prompt-builder system message", async () => {
+  const systemPrompt = await resolveConversationSelfieSystemPrompt({
+    promptOverridesStorage: promptOverrideStorage(
+      "GLOBAL SELFIE OVERRIDE for ${charName}: ${appearance}${selfieTagsBlock}",
+    ),
+    appearance: "silver hair, violet eyes, black jacket",
+    charName: "Mira",
+    selfieTagsBlock: "\n\nAlways include these tags/modifiers in the prompt: cinematic lighting",
+  });
+
+  const fakeResult = await sendToFakeSelfiePromptBuilder(systemPrompt);
+
+  assert.equal(fakeResult.content, "");
+  assert.equal(fakeResult.capturedMessages[0]?.role, "system");
+  assert.equal(
+    fakeResult.capturedMessages[0]?.content,
+    "GLOBAL SELFIE OVERRIDE for Mira: silver hair, violet eyes, black jacket\n\nAlways include these tags/modifiers in the prompt: cinematic lighting",
+  );
+});
+
+test("chat-scoped selfie prompt template still takes priority over the global registered override", async () => {
+  const systemPrompt = await resolveConversationSelfieSystemPrompt({
+    promptOverridesStorage: promptOverrideStorage("GLOBAL ${charName}"),
+    chatPromptTemplate: "CHAT SELFIE OVERRIDE for ${charName}: ${appearance}",
+    appearance: "short blue hair",
+    charName: "Lyra",
+  });
+
+  const fakeResult = await sendToFakeSelfiePromptBuilder(systemPrompt);
+
+  assert.equal(fakeResult.content, "");
+  assert.equal(fakeResult.capturedMessages[0]?.content, "CHAT SELFIE OVERRIDE for Lyra: short blue hair");
+});


### PR DESCRIPTION
<!-- Target branch: `staging`. The default base in this UI is `main` (release branch). -->
<!-- Change the base to `staging` before submitting unless this is a maintainer-approved mainline change. -->
<!-- See CONTRIBUTING.md § Branches. -->

## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #1075

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- Registered prompt overrides already have server support, but users had no app UI for editing or resetting them. This gives power users a discoverable editor without requiring DevTools or direct API calls.

## What changed

<!-- List the key changes in this PR -->

- Added React Query hooks for listing prompt override keys, loading one override, loading its default, saving, and resetting.
- Added an Advanced settings Prompt Overrides editor for registered keys such as `conversation.selfie`.
- Shows allowed `${variable}` tokens and inserts them into the template editor.
- Converts example-rendered defaults back into editable token templates where possible before showing them in the editor.
- Supports enable/disable for a saved override and Reset to Default by deleting the saved override row.
- Moved conversation selfie prompt resolution into a small server helper so it can be tested without starting a real image generation.
- Added a focused server test that fakes prompt override storage and the prompt-builder response, then captures the system prompt that would be sent for selfie prompt-building.
- Moved Prompt Overrides below Updates and made it a collapsed drawer by default.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Ran `pnpm --filter @marinara-engine/client lint`.
- Ran `pnpm build:client`.
- Ran `pnpm --filter @marinara-engine/server lint`.
- Ran `pnpm build:server` (completed with the existing Node DEP0190 warning from the build command).
- Ran `pnpm --filter @marinara-engine/server exec tsx --test test/conversation-selfie-prompt.test.ts`.
- Opened the local app with an existing server on port 7860 and a Vite client on port 5173.
- Opened Settings > Advanced and verified the Prompt Overrides section renders.
- Verified Updates appears above the collapsed Prompt Overrides drawer.
- Verified Prompt Overrides starts collapsed (`aria-expanded="false"`) and expands to show the registered prompt editor.
- Verified an unsaved editor draft survives collapsing and reopening the Prompt Overrides drawer.
- Verified `conversation.selfie` is selected by default when available.
- Verified the default editor text contains `${appearance}`, `${charName}`, and `${selfieTagsBlock}` tokens rather than only sample rendered values.
- Clicked a variable token and verified the editor becomes dirty, the textarea remains focused, and Save/Reset become enabled.
- Clicked Reset to Default while no override was saved and verified the draft returns to default and Save/Reset become disabled again.
- Verified the focused server test renders a registered `conversation.selfie` override into the selfie prompt-builder system message and returns empty fake content, so no image-generation request is needed.
- Did not press Save during browser smoke, to avoid changing local prompt override data.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

<!-- Add before/after screenshots or recordings for UI changes -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a prompt overrides editor in Advanced Settings, allowing users to customize and manage prompt templates.
  * Users can view, edit, save, and reset custom prompts with real-time character count feedback and enable/disable toggling.
  * Added support for inserting variable tokens and persisting prompt customizations with confirmation dialogs for destructive actions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1089?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->