### PR TITLE
Fix custom OpenAI endpoint error wording

### DIFF
--- a/packages/server/src/services/llm/providers/openai.provider.ts
+++ b/packages/server/src/services/llm/providers/openai.provider.ts
@@ -380,6 +380,39 @@ export class OpenAIProvider extends BaseLLMProvider {
     return this.providerKind === "openai-chatgpt";
   }
 
+  private chatCompletionsErrorLabel(): string {
+    switch (this.providerKind) {
+      case "custom":
+        return "Custom OpenAI-compatible endpoint";
+      case "openrouter":
+        return "OpenRouter API";
+      case "nanogpt":
+        return "NanoGPT API";
+      case "xai":
+        return "xAI API";
+      case "mistral":
+        return "Mistral API";
+      case "cohere":
+        return "Cohere OpenAI-compatible API";
+      case "local-sidecar":
+        return "Local sidecar OpenAI-compatible endpoint";
+      case "openai-chatgpt":
+        return "OpenAI ChatGPT endpoint";
+      case "openai":
+      default:
+        return "OpenAI API";
+    }
+  }
+
+  private formatChatCompletionsHttpError(status: number, errorText: string, stream: boolean): string {
+    const detail = sanitizeApiError(errorText);
+    const streamingHint =
+      this.isGenericCustomProvider() && stream && /\bstream(?:ing)?\b/i.test(detail)
+        ? " This custom endpoint rejected token streaming; disable token streaming and retry, or choose a model that supports streaming."
+        : "";
+    return `${this.chatCompletionsErrorLabel()} error ${status}: ${detail}${streamingHint}`;
+  }
+
   private isGpt55Model(model: string): boolean {
     return model.toLowerCase().startsWith("gpt-5.5");
   }
@@ -779,7 +812,7 @@ export class OpenAIProvider extends BaseLLMProvider {
 
     if (!response.ok) {
       const errorText = await response.text();
-      throw new Error(`OpenAI API error ${response.status}: ${sanitizeApiError(errorText)}`);
+      throw new Error(this.formatChatCompletionsHttpError(response.status, errorText, effectiveStream));
     }
 
     if (!effectiveStream) {
@@ -991,7 +1024,7 @@ export class OpenAIProvider extends BaseLLMProvider {
 
     if (!response.ok) {
       const errorText = await response.text();
-      throw new Error(`OpenAI API error ${response.status}: ${sanitizeApiError(errorText)}`);
+      throw new Error(this.formatChatCompletionsHttpError(response.status, errorText, useStream));
     }
 
     if (!useStream) {


### PR DESCRIPTION
<!-- Target branch: `staging`. The default base in this UI is `main` (release branch). -->
<!-- Change the base to `staging` before submitting unless this is a maintainer-approved mainline change. -->
<!-- See CONTRIBUTING.md § Branches. -->

## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #1086

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- Custom OpenAI-compatible endpoint failures were reported as `OpenAI API error`, which made a custom endpoint that rejected streaming look like Marinara had ignored the selected custom connection and fallen back to OpenAI.

## What changed

<!-- List the key changes in this PR -->

- Added provider-specific Chat Completions HTTP error labels for OpenAI-compatible providers.
- Custom provider failures now say `Custom OpenAI-compatible endpoint error` instead of `OpenAI API error`.
- When a custom endpoint rejects a streaming request, the error includes a concrete hint to disable token streaming or choose a streaming-capable endpoint/model.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Codex assigned issue #1086 and found no associated PR before starting.
- Codex reproduced the original failure with `scratch/issue-1086-custom-endpoint-repro.ts` against `upstream/staging`: a local OpenAI-compatible endpoint received `/v1/chat/completions` with `Bearer custom-secret`, but the thrown message was `OpenAI API error 400: streaming is not supported by this model`.
- Codex reran the same repro after the fix: the same custom endpoint path/key were used, the message changed to `Custom OpenAI-compatible endpoint error 400...`, and the streaming hint was present.
- Codex ran `scratch/issue-1086-edge-cases.ts` to cover:
  - custom streaming failure on `OpenAIProvider.chat`
  - custom non-streaming failure on `OpenAIProvider.chatComplete`
  - built-in OpenAI provider failure as a should-not-match negative control
- Codex captured backend visual proof at `scratch/issue-1086-proof.png` and recorded the structured proof in `scratch/bugfix-verification.json`.
- Codex ran `pnpm check` successfully.
- Codex ran `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json` successfully.
- Bunny review passed locally before opening this draft PR.

No manual human verification is required for the core claim; the provider path and error wording are covered by local harnesses.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs or release metadata changes.

## UI evidence (if applicable)

N/A; this is backend/provider error wording. The proof screenshot is a local backend proof artifact, not app UI evidence.
