### PR TITLE
Fix OpenRouter Gemini reasoning replay

### DIFF
--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -888,6 +888,12 @@ function readChatCompletionsReasoningMetadata(value: unknown): Record<string, un
   return Object.keys(metadata).length ? metadata : undefined;
 }
 
+function shouldReplayStoredChatCompletionsReasoning(provider: string, model: string): boolean {
+  if (provider !== "openrouter") return true;
+  const normalizedModel = model.toLowerCase();
+  return !normalizedModel.startsWith("google/gemini") && !normalizedModel.includes("/gemini-");
+}
+
 function isStandaloneCharacterProfileBlock(content: string, characterName: string): boolean {
   const trimmed = content.trim();
   if (!trimmed) return false;
@@ -1227,7 +1233,9 @@ export async function generateRoutes(app: FastifyInstance) {
           providerMetadata.geminiParts = extra.geminiParts;
         }
         const chatCompletionsReasoning =
-          m.role === "assistant" ? readChatCompletionsReasoningMetadata(extra.chatCompletionsReasoning) : undefined;
+          m.role === "assistant" && shouldReplayStoredChatCompletionsReasoning(conn.provider, conn.model)
+            ? readChatCompletionsReasoningMetadata(extra.chatCompletionsReasoning)
+            : undefined;
         if (chatCompletionsReasoning) {
           Object.assign(providerMetadata, chatCompletionsReasoning);
         }

--- a/packages/server/src/services/llm/providers/openai.provider.ts
+++ b/packages/server/src/services/llm/providers/openai.provider.ts
@@ -342,17 +342,16 @@ export class OpenAIProvider extends BaseLLMProvider {
     model?: string,
   ): Record<string, unknown> {
     if (!providerMetadata) return {};
+    if (model && !this.shouldReplayChatCompletionsReasoning(model)) return {};
     const metadata = OpenAIProvider.extractReasoningMetadata(providerMetadata);
     if (Array.isArray(metadata.reasoning_details) && metadata.reasoning_details.length) {
       return { reasoning_details: metadata.reasoning_details };
     }
-    if (model && this.supportsOpenRouterUnifiedReasoning(model)) {
-      return {};
-    }
     return metadata;
   }
 
-  private static emitChatCompletionsReasoning(options: ChatOptions, metadata: Record<string, unknown>): void {
+  private emitChatCompletionsReasoning(options: ChatOptions, metadata: Record<string, unknown>): void {
+    if (!this.shouldReplayChatCompletionsReasoning(options.model)) return;
     if (OpenAIProvider.hasReasoningMetadata(metadata)) {
       options.onChatCompletionsReasoning?.(metadata);
     }
@@ -508,13 +507,26 @@ export class OpenAIProvider extends BaseLLMProvider {
   }
 
   private isOpenRouterEndpoint(): boolean {
-    return !this.isGenericCustomProvider() && this.baseUrl.includes("openrouter.ai");
+    return (
+      this.providerKind === "openrouter" ||
+      (!this.isGenericCustomProvider() && this.baseUrl.includes("openrouter.ai"))
+    );
   }
 
   private supportsOpenRouterUnifiedReasoning(model: string): boolean {
     if (!this.isOpenRouterEndpoint()) return false;
     const m = model.toLowerCase();
     return m.includes("claude-3.7") || /claude-(?:opus|sonnet|haiku)-4(?:[.-]|\b)/.test(m);
+  }
+
+  private isOpenRouterGeminiModel(model: string): boolean {
+    if (!this.isOpenRouterEndpoint()) return false;
+    const m = model.toLowerCase();
+    return m.startsWith("google/gemini") || m.includes("/gemini-");
+  }
+
+  private shouldReplayChatCompletionsReasoning(model: string): boolean {
+    return !this.isOpenRouterGeminiModel(model) && !this.supportsOpenRouterUnifiedReasoning(model);
   }
 
   private shouldSendReasoningEffort(model: string, reasoningEffort?: string | null): boolean {
@@ -826,7 +838,7 @@ export class OpenAIProvider extends BaseLLMProvider {
       const msg = choices[0]?.message;
       const refusal = typeof msg?.refusal === "string" && msg.refusal ? msg.refusal : "";
       const reasoningMetadata = OpenAIProvider.extractReasoningMetadata(msg);
-      OpenAIProvider.emitChatCompletionsReasoning(options, reasoningMetadata);
+      this.emitChatCompletionsReasoning(options, reasoningMetadata);
       const reasoning = OpenAIProvider.extractReasoning(msg);
       if (reasoning && options.onThinking) {
         options.onThinking(reasoning);
@@ -876,7 +888,7 @@ export class OpenAIProvider extends BaseLLMProvider {
           const data = OpenAIProvider.extractSseData(trimmed);
           if (data == null) continue;
           if (data === "[DONE]") {
-            OpenAIProvider.emitChatCompletionsReasoning(options, reasoningMetadata);
+            this.emitChatCompletionsReasoning(options, reasoningMetadata);
             if (streamUsage) return streamUsage;
             return;
           }
@@ -924,7 +936,7 @@ export class OpenAIProvider extends BaseLLMProvider {
     } finally {
       if (options.signal) options.signal.removeEventListener("abort", onAbort);
     }
-    OpenAIProvider.emitChatCompletionsReasoning(options, reasoningMetadata);
+    this.emitChatCompletionsReasoning(options, reasoningMetadata);
     if (streamUsage) return streamUsage;
   }
 
@@ -1044,7 +1056,7 @@ export class OpenAIProvider extends BaseLLMProvider {
 
       const choice = choices[0];
       const reasoningMetadata = OpenAIProvider.extractReasoningMetadata(choice?.message);
-      OpenAIProvider.emitChatCompletionsReasoning(options, reasoningMetadata);
+      this.emitChatCompletionsReasoning(options, reasoningMetadata);
       const reasoning = OpenAIProvider.extractReasoning(choice?.message);
       if (reasoning && options.onThinking) {
         options.onThinking(reasoning);
@@ -1200,7 +1212,7 @@ export class OpenAIProvider extends BaseLLMProvider {
       toolCalls.push(toolCallsMap.get(key)!);
     }
 
-    OpenAIProvider.emitChatCompletionsReasoning(options, reasoningMetadata);
+    this.emitChatCompletionsReasoning(options, reasoningMetadata);
 
     return {
       content: content || null,


### PR DESCRIPTION
<!-- Target branch: `staging`. The default base in this UI is `main` (release branch). -->
<!-- Change the base to `staging` before submitting unless this is a maintainer-approved mainline change. -->
<!-- See CONTRIBUTING.md § Branches. -->

## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #1097

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- OpenRouter Gemini requests were replaying stored Chat Completions reasoning metadata from prior assistant messages, which inflated prompt token usage for Gemini-family models that do not need that metadata for continuity.

## What changed

<!-- List the key changes in this PR -->

- Skips replaying and capturing Chat Completions reasoning metadata for OpenRouter Gemini-family models.
- Keeps replay behavior intact for providers/models that still need it, such as DeepSeek reasoning metadata.
- Ignores stored Gemini reasoning metadata during prompt hydration so existing affected chats recover without manual cleanup.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Codex proof: `pnpm --filter @marinara-engine/server exec tsx ../../scratch/issue-1097-repro.mjs google/gemini-3.5-flash google-vertex/global ../../scratch/issue-1097-after-gemini.json` now shows no replayed assistant `reasoning` / `reasoning_details` and no captured Gemini reasoning for future replay.
- Codex edge case: `pnpm --filter @marinara-engine/server exec tsx ../../scratch/issue-1097-repro.mjs deepseek/deepseek-r1 default ../../scratch/issue-1097-after-deepseek.json` still replays/captures reasoning metadata for DeepSeek.
- Codex edge case: `pnpm --filter @marinara-engine/server exec tsx ../../scratch/issue-1097-repro.mjs anthropic/claude-sonnet-4 default ../../scratch/issue-1097-after-claude.json` keeps OpenRouter unified reasoning replay suppressed.
- Codex baseline: `pnpm check` passed locally.
- Non-blocking limitation: actual OpenRouter billing/token accounting was not measured because this environment does not have the reporter's OpenRouter BYOK credentials; the harness verifies the owned request-body and metadata-callback behavior that caused the inflated prompt input.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

N/A - server/provider message serialization change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of previously stored AI reasoning across different providers
  * Added special handling for specific model types
  * Enhanced provider endpoint detection
  * Refined reasoning metadata processing consistency in different response modes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1103?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->