### PR TITLE
Keep UI sizing device-local

### DIFF
--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -1473,7 +1473,7 @@ function AppearanceSettings() {
       <label className="flex flex-col gap-1">
         <span className="text-xs font-medium inline-flex items-center gap-1">
           Display Size{" "}
-          <HelpTooltip text="Adjusts the base font size across the whole app. Larger sizes improve readability. Default is 17px." />
+          <HelpTooltip text="Adjusts the base font size across the whole app on this device. Larger sizes improve readability. Default is 17px." />
         </span>
         <select
           value={String(fontSize)}
@@ -1492,7 +1492,7 @@ function AppearanceSettings() {
       <label className="flex flex-col gap-1">
         <span className="text-xs font-medium inline-flex items-center gap-1">
           Chat Font Size{" "}
-          <HelpTooltip text="Adjusts the font size of chat messages. Drag the slider to find your preferred reading size. Default is 16px." />
+          <HelpTooltip text="Adjusts the font size of chat messages on this device. Drag the slider to find your preferred reading size. Default is 16px." />
         </span>
         <div className="flex items-center gap-3">
           <input

--- a/packages/client/src/hooks/use-settings-sync.ts
+++ b/packages/client/src/hooks/use-settings-sync.ts
@@ -2,9 +2,12 @@
 // Hook: Cross-device UI settings sync
 // ──────────────────────────────────────────────
 // On mount: fetches the server's saved settings blob and overlays it onto the
-// UI store so every browser/device sees the same preferences. If the server
-// has no blob yet, the current local state is pushed as the initial seed
-// (one-time migration for users upgrading from browser-only storage).
+// UI store so every browser/device sees the same shared preferences. Device-
+// local preferences such as interface and chat text size stay in browser
+// storage and are ignored when older server blobs still contain them. If the
+// server has no blob yet, the current local shared state is pushed as the
+// initial seed (one-time migration for users upgrading from browser-only
+// storage).
 //
 // While the app runs: subscribes to UI store changes, debounces serialization,
 // and pushes the synced subset to the server. Only user-facing preference
@@ -30,6 +33,17 @@ const DEBOUNCE_MS = 1000;
 
 type SyncedSettingsObject = ReturnType<typeof pickSyncedSettings>;
 type ServerSettingsPayload = SyncedSettingsObject & { __updatedAt?: number };
+type ParsedSettings = Partial<SyncedSettingsObject> & Record<string, unknown>;
+
+const DEVICE_LOCAL_SETTING_KEYS = ["fontSize", "chatFontSize"] as const;
+
+export function omitDeviceLocalSettings(settings: ParsedSettings): ParsedSettings {
+  const sanitized = { ...settings };
+  for (const key of DEVICE_LOCAL_SETTING_KEYS) {
+    delete sanitized[key];
+  }
+  return sanitized;
+}
 
 function readLocalUpdatedAt(): number | null {
   const value = window.localStorage.getItem(LOCAL_UPDATED_AT_KEY);
@@ -55,7 +69,7 @@ function buildServerSettingsValue(settings: SyncedSettingsObject, updatedAt: num
 }
 
 function parseServerSettingsValue(value: string): {
-  settings: Partial<SyncedSettingsObject> & Record<string, unknown>;
+  settings: ParsedSettings;
   updatedAt: number | null;
 } {
   const parsed = JSON.parse(value) as unknown;
@@ -147,6 +161,9 @@ export function useSettingsSync() {
           try {
             const parsed = parseServerSettingsValue(data.value);
             if (parsed.settings && typeof parsed.settings === "object") {
+              const hadDeviceLocalSettings = DEVICE_LOCAL_SETTING_KEYS.some((key) => key in parsed.settings);
+              parsed.settings = omitDeviceLocalSettings(parsed.settings);
+
               // Migrate old flat gradient fields → per-scheme nested (v10 → v11).
               if ("convoGradientFrom" in parsed.settings || "convoGradientTo" in parsed.settings) {
                 const legacyGradientFrom =
@@ -189,6 +206,16 @@ export function useSettingsSync() {
                 useUIStore.setState(parsed.settings);
                 lastPushed = serialize();
                 if (serverUpdatedAt !== null) writeLocalUpdatedAt(serverUpdatedAt);
+                if (hadDeviceLocalSettings) {
+                  try {
+                    await api.put(SETTINGS_PATH, {
+                      value: buildServerSettingsValue(pickSyncedSettings(useUIStore.getState()), serverUpdatedAt ?? Date.now()),
+                    });
+                  } catch {
+                    // Cleanup is best-effort; this browser still ignores
+                    // legacy size values from the server blob.
+                  }
+                }
               }
             }
           } catch {

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -646,9 +646,9 @@ function restoreMobileDetailReturnPanel(panel: Panel | null) {
 
 /**
  * Returns the subset of UI state that is synced to the server so it persists
- * across devices and browsers. Excludes legacy migration flags, auto-computed
- * fields (userStatus), and items tracked via their own server resources
- * (custom themes, extensions).
+ * across devices and browsers. Excludes device-local sizing preferences,
+ * legacy migration flags, auto-computed fields (userStatus), and items tracked
+ * via their own server resources (custom themes, extensions).
  */
 export function pickSyncedSettings(state: UIState) {
   return {
@@ -668,9 +668,7 @@ export function pickSyncedSettings(state: UIState) {
     theme: state.theme,
     chatBackground: state.chatBackground,
     chatBackgroundBlur: state.chatBackgroundBlur,
-    fontSize: state.fontSize,
     language: state.language,
-    chatFontSize: state.chatFontSize,
     fontFamily: state.fontFamily,
     enableStreaming: state.enableStreaming,
     streamingSpeed: state.streamingSpeed,


### PR DESCRIPTION
## Linked issue

Closes #1099

## Why this change

- Display Size and Chat Font Size were included in the server-synced UI settings blob, so a size that worked on one device could overwrite the preferred size on another device.
- These two settings are comfort/accessibility preferences that should stay local to each browser/device.

## What changed

- Removed `fontSize` and `chatFontSize` from the server-synced settings payload.
- Added legacy server-blob cleanup so old saved server values for those fields are ignored before settings apply locally.
- Updated the Display Size and Chat Font Size tooltips to say they apply on this device.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Codex ran `pnpm install --frozen-lockfile` in a clean worktree.
- Codex ran `pnpm --filter @marinara-engine/shared build`.
- Codex ran `packages\server\node_modules\.bin\tsx.cmd scratch\issue-1099-device-local-settings.ts`, proving:
  - `pickSyncedSettings` omits `fontSize` and `chatFontSize`.
  - legacy server blobs cannot overwrite local `fontSize` and `chatFontSize`.
  - shared settings such as `theme`, `sidebarWidth`, and `fontFamily` still survive serialization/sanitization.
- Codex ran `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\issue-1099-risk-claim.json`.
- Codex ran `pnpm check`.
- Bunny review passed for the scoped diff.
- Manual physical-device smoke test still recommended: set different Display Size / Chat Font Size values on phone and PC and confirm they remain independent.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

N/A. This changes settings persistence behavior and tooltip copy; no visual layout change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced Settings panel tooltips to clarify that Display Size and Chat Font Size adjustments apply to your current device only, with default values now displayed (17px and 16px respectively).

* **Bug Fixes**
  * Corrected settings synchronization logic to properly isolate device-specific font size preferences, preventing them from incorrectly syncing across your devices.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1111?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->