### PR TITLE
Show estimated token counts for character cards

### DIFF
--- a/packages/client/src/components/characters/CharacterLibraryView.tsx
+++ b/packages/client/src/components/characters/CharacterLibraryView.tsx
@@ -3,6 +3,7 @@ import {
   ArrowLeft,
   ArrowUpDown,
   Download,
+  Hash,
   MessageCircle,
   Pencil,
   Plus,
@@ -14,6 +15,7 @@ import {
 import { useCharacters } from "../../hooks/use-characters";
 import { useStartChatFromCharacter } from "../../hooks/use-start-chat-from-character";
 import { getCharacterTitle } from "../../lib/character-display";
+import { estimateCharacterCardTokens, formatEstimatedTokens } from "../../lib/character-token-count";
 import { cn, getAvatarCropStyle, type AvatarCropValue } from "../../lib/utils";
 import { useUIStore } from "../../stores/ui.store";
 import type { CharacterData } from "@marinara-engine/shared";
@@ -146,6 +148,7 @@ function CharacterLibraryDetailCard({
   const characterMeta = getCharacterMeta(character);
   const creatorNotes = getText(character.parsed.creator_notes);
   const sections = getCharacterSections(character);
+  const tokenEstimate = estimateCharacterCardTokens(character.parsed);
 
   return (
     <div className="space-y-4">
@@ -179,11 +182,20 @@ function CharacterLibraryDetailCard({
                   </p>
                 )}
               </div>
-              {character.parsed.extensions?.fav && (
-                <span className="inline-flex items-center gap-1 rounded-full bg-amber-500/10 px-2.5 py-1 text-[0.6875rem] font-medium text-amber-300">
-                  <Star size="0.75rem" className="fill-current" /> Favorite
+              <div className="flex shrink-0 flex-col items-end gap-1.5">
+                <span
+                  className="inline-flex items-center gap-1 rounded-full bg-[var(--secondary)] px-2.5 py-1 text-[0.6875rem] font-medium text-[var(--muted-foreground)] ring-1 ring-[var(--border)]"
+                  title="Estimated from character card text fields; actual tokenizer counts vary by model."
+                >
+                  <Hash size="0.75rem" />
+                  {formatEstimatedTokens(tokenEstimate)}
                 </span>
-              )}
+                {character.parsed.extensions?.fav && (
+                  <span className="inline-flex items-center gap-1 rounded-full bg-amber-500/10 px-2.5 py-1 text-[0.6875rem] font-medium text-amber-300">
+                    <Star size="0.75rem" className="fill-current" /> Favorite
+                  </span>
+                )}
+              </div>
             </div>
 
             {creatorNotes && (
@@ -462,6 +474,7 @@ export function CharacterLibraryView() {
                 const charTitle = getCharacterTitle({ name: charName, comment: char.comment });
                 const cardSummary = truncateText(getCharacterSummary(char), 180);
                 const cardMeta = getCharacterMeta(char);
+                const tokenEstimate = estimateCharacterCardTokens(char.parsed);
                 const isFavorite = !!char.parsed.extensions?.fav;
                 const tags = getCharacterTags(char);
                 const isActive = selectedCharacterId === char.id;
@@ -524,6 +537,13 @@ export function CharacterLibraryView() {
                         </p>
 
                         <div className="mt-auto flex flex-wrap gap-1 sm:gap-1.5">
+                          <span
+                            className="inline-flex items-center gap-1 rounded-full bg-[var(--secondary)] px-1.5 py-0.5 text-[0.5625rem] font-medium text-[var(--muted-foreground)] ring-1 ring-[var(--border)] sm:px-2 sm:py-1 sm:text-[0.625rem]"
+                            title="Estimated from character card text fields; actual tokenizer counts vary by model."
+                          >
+                            <Hash size="0.5625rem" />
+                            {formatEstimatedTokens(tokenEstimate)}
+                          </span>
                           {tags.slice(0, 2).map((tag) => (
                             <span
                               key={tag}

--- a/packages/client/src/components/panels/CharactersPanel.tsx
+++ b/packages/client/src/components/panels/CharactersPanel.tsx
@@ -43,11 +43,13 @@ import {
   MessageCircle,
   Star,
   Wand2,
+  Hash,
   Minus,
 } from "lucide-react";
 import { getCharacterTitle } from "../../lib/character-display";
 import { useUIStore } from "../../stores/ui.store";
 import { cn, getAvatarCropStyle, type AvatarCropValue } from "../../lib/utils";
+import { estimateCharacterCardTokens, formatEstimatedTokens } from "../../lib/character-token-count";
 import { ExportFormatDialog, type ExportFormatChoice } from "../ui/ExportFormatDialog";
 
 type CharacterRow = {
@@ -1139,6 +1141,7 @@ export function CharactersPanel() {
           const targetGroup = assigningToGroup ? parsedGroups.find((g) => g.id === assigningToGroup) : null;
           const isInTargetGroup = targetGroup?.memberIds.includes(char.id) ?? false;
           const previewMetadata = getCharacterPreviewMetadata(char);
+          const tokenEstimate = estimateCharacterCardTokens(char.parsed);
 
           return (
             <div
@@ -1249,6 +1252,15 @@ export function CharactersPanel() {
                         ? "In group — click to remove"
                         : "Click to add to group"
                       : previewMetadata}
+                  </div>
+                )}
+                {!assigningToGroup && (
+                  <div
+                    className="flex items-center gap-1 text-[0.625rem] text-[var(--muted-foreground)]"
+                    title="Estimated from character card text fields; actual tokenizer counts vary by model."
+                  >
+                    <Hash size="0.5625rem" />
+                    {formatEstimatedTokens(tokenEstimate)}
                   </div>
                 )}
                 {!assigningToGroup && charTags.length > 0 && (

--- a/packages/client/src/lib/character-token-count.ts
+++ b/packages/client/src/lib/character-token-count.ts
@@ -1,0 +1,91 @@
+import type { CharacterBook, CharacterBookEntry, CharacterData, DepthPrompt } from "@marinara-engine/shared";
+
+const CHARS_PER_TOKEN = 4;
+
+type CharacterTokenData = Partial<Omit<CharacterData, "alternate_greetings" | "character_book" | "extensions">> & {
+  alternate_greetings?: unknown;
+  character_book?: unknown;
+  extensions?: unknown;
+};
+
+const CARD_TEXT_FIELDS: Array<keyof CharacterData> = [
+  "name",
+  "description",
+  "personality",
+  "scenario",
+  "first_mes",
+  "mes_example",
+  "creator_notes",
+  "system_prompt",
+  "post_history_instructions",
+];
+
+function estimateTokens(text: string): number {
+  return Math.ceil(text.length / CHARS_PER_TOKEN);
+}
+
+function asString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+}
+
+function collectString(value: unknown, output: string[]) {
+  const text = asString(value);
+  if (text) output.push(text);
+}
+
+function collectStringArray(value: unknown, output: string[]) {
+  if (!Array.isArray(value)) return;
+  for (const item of value) collectString(item, output);
+}
+
+function collectDepthPrompt(value: unknown, output: string[]) {
+  const depthPrompt = asRecord(value) as Partial<DepthPrompt>;
+  collectString(depthPrompt.prompt, output);
+}
+
+function collectCharacterBookEntry(entry: Partial<CharacterBookEntry>, output: string[]) {
+  collectString(entry.name, output);
+  collectString(entry.comment, output);
+  collectString(entry.content, output);
+  collectStringArray(entry.keys, output);
+  collectStringArray(entry.secondary_keys, output);
+}
+
+function collectCharacterBook(value: unknown, output: string[]) {
+  const book = asRecord(value) as Partial<CharacterBook>;
+  collectString(book.name, output);
+  collectString(book.description, output);
+
+  if (!Array.isArray(book.entries)) return;
+  for (const entry of book.entries) {
+    collectCharacterBookEntry(asRecord(entry) as Partial<CharacterBookEntry>, output);
+  }
+}
+
+export function estimateCharacterCardTokens(data: CharacterTokenData): number {
+  const textParts: string[] = [];
+
+  for (const field of CARD_TEXT_FIELDS) {
+    collectString(data[field], textParts);
+  }
+
+  collectStringArray(data.alternate_greetings, textParts);
+
+  const extensions = asRecord(data.extensions);
+  collectString(extensions.backstory, textParts);
+  collectString(extensions.appearance, textParts);
+  collectString(extensions.world, textParts);
+  collectDepthPrompt(extensions.depth_prompt, textParts);
+
+  collectCharacterBook(data.character_book, textParts);
+
+  return estimateTokens(textParts.join("\n"));
+}
+
+export function formatEstimatedTokens(tokens: number): string {
+  return `~${tokens.toLocaleString()} tokens`;
+}


### PR DESCRIPTION
## Linked issue

Closes #1098

## Why this change

- Users need an easy way to estimate how much context a character card consumes before starting or editing chats with it.

## What changed

- Added a shared client-side character card token estimator using the existing rough chars-per-token convention.
- Shows estimated token counts in the Characters panel rows.
- Shows estimated token badges in the full character library grid and selected-card detail view.
- Labels the count as estimated because tokenizer-specific counts vary by model.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Codex ran `pnpm check` successfully.
- Codex ran the app with `pnpm dev:client`.
- Codex verified with Playwright that real local character rows in the Characters panel display `~N tokens`.
- Codex verified with Playwright that the full character library grid/detail view displays `~N tokens`.
- Evidence screenshots were captured locally at:
  - `scratch/issue-1098-clean-characters-panel.png`
  - `scratch/issue-1098-clean-character-library.png`

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

Characters panel:

![Characters panel showing estimated token counts](https://gist.githubusercontent.com/cha1latte/115ed55eb47d16351a3e3d6b26bca782/raw/35e4d5a50eaa10fd8a9b85945bdfff7159765f8f/issue-1098-clean-characters-panel.png)

Full character library:

![Full character library showing estimated token badges](https://gist.githubusercontent.com/cha1latte/115ed55eb47d16351a3e3d6b26bca782/raw/b1cb649055a196880aa924fc96a263d1ea891fe8/issue-1098-clean-character-library.png)
