### PR TITLE
feat: expand groups from the whole row

### DIFF
--- a/packages/client/src/components/panels/PersonasPanel.tsx
+++ b/packages/client/src/components/panels/PersonasPanel.tsx
@@ -591,9 +591,15 @@ export function PersonasPanel() {
               return (
                 <div key={group.id} className="rounded-xl bg-[var(--secondary)]/60 ring-1 ring-[var(--border)]/50">
                   {/* Group header */}
-                  <div className="flex items-center gap-1.5 px-2.5 py-2">
+                  <div
+                    className="flex cursor-pointer items-center gap-1.5 px-2.5 py-2"
+                    onClick={() => setExpandedGroupId(isExpanded ? null : group.id)}
+                  >
                     <button
-                      onClick={() => setExpandedGroupId(isExpanded ? null : group.id)}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setExpandedGroupId(isExpanded ? null : group.id);
+                      }}
                       className="shrink-0 text-[var(--muted-foreground)]"
                     >
                       {isExpanded ? <ChevronDown size="0.75rem" /> : <ChevronRight size="0.75rem" />}
@@ -611,6 +617,7 @@ export function PersonasPanel() {
                             setEditGroupName("");
                           }
                         }}
+                        onClick={(e) => e.stopPropagation()}
                         onBlur={() => handleRenameGroup(group.id)}
                         className="min-w-0 flex-1 bg-transparent text-xs font-medium outline-none"
                       />
@@ -623,7 +630,8 @@ export function PersonasPanel() {
                     {/* Actions */}
                     <div className="flex items-center gap-0.5">
                       <button
-                        onClick={() => {
+                        onClick={(e) => {
+                          e.stopPropagation();
                           if (assigningToGroup !== group.id) exitSelectionMode();
                           setAssigningToGroup(assigningToGroup === group.id ? null : group.id);
                         }}
@@ -638,7 +646,8 @@ export function PersonasPanel() {
                         <UserPlus size="0.75rem" />
                       </button>
                       <button
-                        onClick={() => {
+                        onClick={(e) => {
+                          e.stopPropagation();
                           setEditingGroupId(group.id);
                           setEditGroupName(group.name);
                         }}
@@ -648,7 +657,8 @@ export function PersonasPanel() {
                         <Pencil size="0.75rem" />
                       </button>
                       <button
-                        onClick={async () => {
+                        onClick={async (e) => {
+                          e.stopPropagation();
                           if (
                             !(await showConfirmDialog({
                               title: "Delete Group",


### PR DESCRIPTION
## Linked issue

Closes #1100

## Why this change

- Character and persona groups should be easier to expand and collapse when navigating long rosters.

## What changed

- Persona group headers now expand/collapse when clicking the whole group row.
- Persona group action buttons and rename input stop click propagation so they do not accidentally toggle the group.
- Character group row behavior was already present and was regression-tested.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Codex browser proof: persona group row click opened and closed the group, and the assign button did not toggle it.
- Codex browser proof: character group row click opened and closed the group, and the assign button did not toggle it.
- `pnpm check` passed locally.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

Interaction-only UI change; verified with local browser assertions rather than reviewer-facing screenshots.
