### PR TITLE
Fix idle presence restore on message send

### DIFF
--- a/packages/client/src/hooks/use-autonomous-messaging.ts
+++ b/packages/client/src/hooks/use-autonomous-messaging.ts
@@ -8,6 +8,7 @@
 import { useEffect, useRef, useCallback } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { api } from "../lib/api-client";
+import { recordUserMessageActivity } from "../lib/user-presence-activity";
 import { useChatStore } from "../stores/chat.store";
 import { useUIStore } from "../stores/ui.store";
 import { useGenerate } from "./use-generate";
@@ -50,14 +51,9 @@ export function useAutonomousMessaging(
   // Record that the user sent a message
   const recordUserActivity = useCallback(async () => {
     if (!chatId) return;
-    try {
-      await api.post("/conversation/activity/user", {
-        chatId,
-        preserveGenerationInProgress: useChatStore.getState().abortControllers.has(chatId),
-      });
-    } catch {
-      // non-critical
-    }
+    await recordUserMessageActivity(chatId, {
+      preserveGenerationInProgress: useChatStore.getState().abortControllers.has(chatId),
+    });
   }, [chatId]);
 
   // Record that an assistant message was received

--- a/packages/client/src/lib/user-presence-activity.ts
+++ b/packages/client/src/lib/user-presence-activity.ts
@@ -1,0 +1,28 @@
+import { api } from "./api-client";
+import { useUIStore, type UserStatus } from "../stores/ui.store";
+
+export function restoreAvailableAfterUserMessage(): UserStatus {
+  const { userStatus, userStatusManual, setUserStatus } = useUIStore.getState();
+
+  if (userStatusManual === "active" && userStatus === "idle") {
+    setUserStatus("active");
+    return "active";
+  }
+
+  return userStatus;
+}
+
+export async function recordUserMessageActivity(
+  chatId: string,
+  options: { preserveGenerationInProgress?: boolean } = {},
+): Promise<void> {
+  const userStatus = restoreAvailableAfterUserMessage();
+
+  await Promise.allSettled([
+    api.post("/conversation/activity/user", {
+      chatId,
+      preserveGenerationInProgress: options.preserveGenerationInProgress === true,
+    }),
+    api.post("/conversation/activity/presence", { chatId, userStatus }),
+  ]);
+}


### PR DESCRIPTION
<!-- Target branch: `staging`. The default base in this UI is `main` (release branch). -->
<!-- Change the base to `staging` before submitting unless this is a maintainer-approved mainline change. -->
<!-- See CONTRIBUTING.md § Branches. -->

## Linked issue

Closes #1105

## Why this change

- Sending a conversation message after the app auto-marked the user Idle still left the user presence as Idle. A message send should be the explicit activity signal that restores Available while preserving intentional DND.

## What changed

- Added a small client presence activity helper that restores effective Idle to Active only when the manual status is Available.
- Reused that helper from the conversation autonomous activity path so successful user messages also report the current presence to `/conversation/activity/presence`.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Codex ran `packages\server\node_modules\.bin\tsx.cmd scratch/issue-1105-presence-repro.ts`.
  - Before fix: repro failed because no message-send presence restore helper existed.
  - After fix: repro passed; message activity restores Idle/Available to Active, reports Active when already active, and preserves manual DND.
- Codex ran `pnpm check` successfully.
- Codex ran `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch/bugfix-verification.json` successfully.
- Visual proof URL was checked with `curl.exe -I` and returned `HTTP 200` with `Content-Type: image/png`.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

Logic/state proof screenshot from the local verification run:

![Issue 1105 presence proof](https://gist.githubusercontent.com/cha1latte/8311d36d3f8a236f269366d97e32b127/raw/8fb7f577f307d0c58ff9d2f9bb5572f411ac6435/issue-1105-proof.png)

Raw proof page: https://gist.githubusercontent.com/cha1latte/8311d36d3f8a236f269366d97e32b127/raw/b21cfaa618b31a5a7fc007a3b7fa80a03ce2c9ea/issue-1105-proof.html
