### PR TITLE
Fix lorebook update payload persistence

### DIFF
--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -1697,7 +1697,7 @@ function inferKeeperKeys(entryName: string, tag: string): string[] {
   return Array.from(new Set([...words.slice(0, 5), tag].filter(Boolean))).slice(0, 6);
 }
 
-function normalizeGameLorebookKeeperEntries(raw: unknown): GameLorebookKeeperEntry[] {
+export function normalizeGameLorebookKeeperEntries(raw: unknown): GameLorebookKeeperEntry[] {
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) return [];
   const container = raw as { entries?: unknown; updates?: unknown };
   const rawEntries = Array.isArray(container.entries)
@@ -1710,20 +1710,39 @@ function normalizeGameLorebookKeeperEntries(raw: unknown): GameLorebookKeeperEnt
     .flatMap((entry): GameLorebookKeeperEntry[] => {
       if (!entry || typeof entry !== "object" || Array.isArray(entry)) return [];
       const source = entry as Record<string, unknown>;
+      const nestedEntry =
+        source.entry && typeof source.entry === "object" && !Array.isArray(source.entry)
+          ? (source.entry as Record<string, unknown>)
+          : {};
       const rawName =
-        typeof source.entryName === "string" ? source.entryName : typeof source.name === "string" ? source.name : "";
-      const content = typeof source.content === "string" ? source.content.trim() : "";
+        typeof source.entryName === "string"
+          ? source.entryName
+          : typeof source.name === "string"
+            ? source.name
+            : typeof nestedEntry.name === "string"
+              ? nestedEntry.name
+              : "";
+      const content =
+        typeof source.content === "string"
+          ? source.content.trim()
+          : typeof nestedEntry.content === "string"
+            ? nestedEntry.content.trim()
+            : "";
       if (!rawName.trim() || !content) return [];
 
       const tag =
         typeof source.tag === "string" && source.tag.trim()
           ? source.tag.trim().replace(/\s+/g, "_").toLowerCase()
+          : typeof nestedEntry.tag === "string" && nestedEntry.tag.trim()
+            ? nestedEntry.tag.trim().replace(/\s+/g, "_").toLowerCase()
           : "game_lore";
       const entryName = truncateKeeperName(rawName);
-      const keys = normalizeKeeperStringList(source.keys, 10);
+      const keys = normalizeKeeperStringList(source.keys ?? nestedEntry.keys, 10);
       const description =
         typeof source.description === "string" && source.description.trim()
           ? source.description.trim()
+          : typeof nestedEntry.description === "string" && nestedEntry.description.trim()
+            ? nestedEntry.description.trim()
           : `Game Lorebook Keeper entry tagged ${tag}.`;
 
       return [

--- a/packages/server/src/routes/generate/lorebook-keeper-utils.ts
+++ b/packages/server/src/routes/generate/lorebook-keeper-utils.ts
@@ -312,6 +312,45 @@ function getExplicitUpdateReplacementContent(update: Record<string, unknown>): s
   return replacement.length > 0 ? replacement : null;
 }
 
+function readNestedEntry(update: Record<string, unknown>): Record<string, unknown> {
+  return update.entry && typeof update.entry === "object" && !Array.isArray(update.entry)
+    ? (update.entry as Record<string, unknown>)
+    : {};
+}
+
+function readKeeperUpdateName(update: Record<string, unknown>): string {
+  const nestedEntry = readNestedEntry(update);
+  const rawName =
+    typeof update.entryName === "string"
+      ? update.entryName
+      : typeof update.name === "string"
+        ? update.name
+        : typeof nestedEntry.name === "string"
+          ? nestedEntry.name
+          : "";
+  return rawName.trim();
+}
+
+function readKeeperUpdateContent(update: Record<string, unknown>): string {
+  const nestedEntry = readNestedEntry(update);
+  return typeof update.content === "string"
+    ? update.content
+    : typeof nestedEntry.content === "string"
+      ? nestedEntry.content
+      : "";
+}
+
+function readKeeperUpdateKeys(update: Record<string, unknown>): string[] {
+  const nestedEntry = readNestedEntry(update);
+  const rawKeys = Array.isArray(update.keys) ? update.keys : Array.isArray(nestedEntry.keys) ? nestedEntry.keys : [];
+  return rawKeys.filter((key): key is string => typeof key === "string");
+}
+
+function readKeeperUpdateTag(update: Record<string, unknown>): string {
+  const nestedEntry = readNestedEntry(update);
+  return typeof update.tag === "string" ? update.tag : typeof nestedEntry.tag === "string" ? nestedEntry.tag : "";
+}
+
 export async function persistLorebookKeeperUpdates(args: {
   lorebooksStore: LorebooksStore;
   chatId: string;
@@ -353,12 +392,12 @@ export async function persistLorebookKeeperUpdates(args: {
   }
 
   for (const update of updates) {
-    const rawName = typeof update.entryName === "string" ? update.entryName.trim() : "";
+    const rawName = readKeeperUpdateName(update);
     if (!rawName) continue;
 
-    const content = typeof update.content === "string" ? update.content : "";
-    const keys = Array.isArray(update.keys) ? update.keys.filter((key): key is string => typeof key === "string") : [];
-    const tag = typeof update.tag === "string" ? update.tag : "";
+    const content = readKeeperUpdateContent(update);
+    const keys = readKeeperUpdateKeys(update);
+    const tag = readKeeperUpdateTag(update);
     const existing = entryByName.get(rawName.toLowerCase());
 
     if (existing && (existing.locked === true || existing.locked === "true")) {

--- a/packages/server/src/services/conversation/character-commands.ts
+++ b/packages/server/src/services/conversation/character-commands.ts
@@ -451,18 +451,49 @@ function parseUpdateLorebookBlock(raw: string): UpdateLorebookCommand | null {
       .map((entry): UpdateLorebookEntryCommand | null => {
         if (!entry || typeof entry !== "object") return null;
         const data = entry as Record<string, unknown>;
-        const entryName = typeof data.name === "string" ? data.name.trim() : "";
+        const nestedEntry = data.entry && typeof data.entry === "object" ? (data.entry as Record<string, unknown>) : {};
+        const entryName =
+          typeof data.name === "string"
+            ? data.name.trim()
+            : typeof nestedEntry.name === "string"
+              ? nestedEntry.name.trim()
+              : "";
         if (!entryName) return null;
         return {
           name: entryName,
           matchName: typeof data.matchName === "string" ? data.matchName.trim() : undefined,
-          content: typeof data.content === "string" ? data.content : undefined,
-          description: typeof data.description === "string" ? data.description : undefined,
-          keys: parseUnknownStringList(data.keys),
-          secondaryKeys: parseUnknownStringList(data.secondaryKeys),
-          tag: typeof data.tag === "string" ? data.tag : undefined,
-          constant: typeof data.constant === "boolean" ? data.constant : undefined,
-          selective: typeof data.selective === "boolean" ? data.selective : undefined,
+          content:
+            typeof data.content === "string"
+              ? data.content
+              : typeof nestedEntry.content === "string"
+                ? nestedEntry.content
+                : undefined,
+          description:
+            typeof data.description === "string"
+              ? data.description
+              : typeof nestedEntry.description === "string"
+                ? nestedEntry.description
+                : undefined,
+          keys: parseUnknownStringList(data.keys ?? nestedEntry.keys),
+          secondaryKeys: parseUnknownStringList(data.secondaryKeys ?? nestedEntry.secondaryKeys),
+          tag:
+            typeof data.tag === "string"
+              ? data.tag
+              : typeof nestedEntry.tag === "string"
+                ? nestedEntry.tag
+                : undefined,
+          constant:
+            typeof data.constant === "boolean"
+              ? data.constant
+              : typeof nestedEntry.constant === "boolean"
+                ? nestedEntry.constant
+                : undefined,
+          selective:
+            typeof data.selective === "boolean"
+              ? data.selective
+              : typeof nestedEntry.selective === "boolean"
+                ? nestedEntry.selective
+                : undefined,
         } satisfies UpdateLorebookEntryCommand;
       })
       .filter((entry): entry is UpdateLorebookEntryCommand => entry !== null);


### PR DESCRIPTION
<!-- Target branch: `staging`. The default base in this UI is `main` (release branch). -->
<!-- Change the base to `staging` before submitting unless this is a maintainer-approved mainline change. -->
<!-- See CONTRIBUTING.md § Branches. -->

## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #1107

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- Game Mode and Professor Mari could receive lorebook update payloads shaped like the shared `LorebookUpdateResult` contract, with entry details nested under `entry`.
- The existing persistence/parser paths only read top-level `entryName` / `content` fields, so those nested updates could result in no persisted lorebook entry even though the model-facing flow appeared successful.

## What changed

<!-- List the key changes in this PR -->

- Accept nested `entry.name`, `entry.content`, `entry.keys`, `entry.tag`, and related fields in Lorebook Keeper persistence.
- Accept the same nested entry shape in Professor Mari `update_lorebook` commands.
- Accept nested session entry payloads in the Game Lorebook Keeper session-end normalizer while preserving the existing top-level shape.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Machine verification: `packages\server\node_modules\.bin\tsx.cmd scratch/issue-1107-lorebook-persistence-repro.mjs` passed after reproducing the pre-fix failure. The harness covers nested LorebookUpdateResult-shaped creates, Professor Mari nested `update_lorebook` parsing, Game Lorebook Keeper nested session entry normalization, legacy top-level updates, malformed nested entries, and locked-entry protection.
- Machine verification: `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json` passed.
- Machine verification: `pnpm check` passed. The first run timed out at 124 seconds with no failure; the rerun completed successfully.
- Proof output: https://gist.github.com/cha1latte/788b594a5f06e1013cd994aa64b19b78

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

N/A - backend lorebook payload parsing/persistence fix.
