### PR TITLE
Hotfix tracker alias lookup, NPC avatars, and HUD temperature units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 - Added a Marinara-specific AI agent workflow overlay, adapted from the Chai Agent Workflow Pack, covering proof discipline, bugfix/feature lanes, issue filing, PR gates, and risky-work claim boundaries.
 - Added a None option for Roleplay message avatars so messages can render without avatar attachments.
+- Added default starting values for numeric Game HUD widgets, with setup/editor clamps that keep start values within the configured max.
+- Added a prompt override editor for registered prompt templates, including conversation selfie overrides, collapsible settings, and draft preservation.
+- Added shared drag-and-drop image upload dropzones for character avatars, chat gallery images, and background imports.
 - Added a manual Game Mode combat start control with confirmation so players can trigger encounter setup when a scene should enter combat.
 - Added a General quote-format preference for straight or curly dialogue quotes and apostrophes, with editor/input formatting support across chat, presets, characters, and personas.
 - Added conditional prompt macros, macro comment blocks, and Macro Reference guidance so presets and character/persona cards can keep author-only notes or branch prompt text by speaker/character.
@@ -29,6 +32,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 - Removed the Conversation, Roleplay, and Game mode shortcuts from the topbar because the sidebar already owns mode navigation.
 - Widened the Glued Side Panel roleplay avatar presentation so the portrait strip has more visual presence.
+- Improved sprite wand cleanup with halo edge cleanup, clean/paint brush tools, unified brush controls, and better multi-pointer handling.
+- Polished Tracker Panel visual controls, thought bubbles, persona/tracker card styling, responsive world-state temperature display, and color preview restore/legacy tint behavior.
 - Improved Game Mode combat setup so encounter generation can run in the background after scene analysis, with debug logging and a wait state only when the player reaches combat before setup is ready.
 - Removed unreliable met/unmet status tracking from Game Mode NPC prompt context.
 - Improved Roleplay group chat Individual mode prompting so only the currently responding character card is included, other characters' prior messages are treated as user-side context, and the turn-owner instruction can be toggled.
@@ -45,9 +50,14 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 ### Fixed
 
 - Fixed mobile Conversation chats where optional toolbar actions could squeeze the message textarea down until it appeared missing on narrow phone viewports.
+- Fixed tracker character-card lookup so active-chat card aliases from title/comment text resolve tracker rows before out-of-chat fallback cards, keeping group-chat tracker portraits and color settings attached to the intended character.
+- Fixed character tracker refreshes preserving user-uploaded NPC portraits and portrait framing across agent updates, including first snapshot writes.
+- Fixed the Roleplay HUD temperature chip so it respects the shared Tracker Panel Celsius/Fahrenheit display setting.
 - Added a stale client artifact cleanup step for the obsolete tracker data sidebar folder so installs, updates, checks, and builds are not tripped up by leftover local files after the tracker panel refactor.
 - Fixed Docker builds so the stale client artifact cleanup script is available before dependency install/build scripts run.
 - Fixed streaming Roleplay messages in Glued Side Panel avatar mode so the avatar frame keeps the selected scale and is revealed by the growing message instead of rescaling while tokens arrive.
+- Fixed Quest Board state merges so tracker updates no longer revert quest progress or keep completed empty-objective quests.
+- Fixed profile export/import fallback handling for large assets so profile exports can recover cleanly when embedded asset payloads are too large.
 - Fixed Windows installer updates for existing shallow release checkouts by fetching the resolved release commit before checkout.
 - Fixed mobile Game Mode character and party controls so sheet actions stay compact, long character names can remain accessible, and crowded party rosters collapse into a scrollable mobile party picker.
 - Fixed mobile Game Mode choice prompts so large choice sets stay readable and scroll inside the available play area instead of squishing buttons or pushing custom input off-screen.
@@ -82,6 +92,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 - Added explicit Illustrator try-again controls when image generation fails, including a toast action and a persistent Roleplay HUD retry button. ([#797](https://github.com/Pasta-Devs/Marinara-Engine/issues/797))
 - Added Local Model sidecar as a first-class embedding source, including an Embedding Connection option, lorebook vectorization support, and a stable `/api/sidecar/v1/embeddings` endpoint. ([#780](https://github.com/Pasta-Devs/Marinara-Engine/issues/780))
 - Added opt-in Turn Data Access settings for custom post-processing agents so they can receive current-turn pre-generation injections and parallel agent results without exposing that data to existing agents by default. ([#778](https://github.com/Pasta-Devs/Marinara-Engine/issues/778))
+- Added Memory Recall export/import for moving chat recall data between profiles or installs.
+- Added weighted random macro choices for SillyTavern-style random prompt variants.
 - Added a native Appearance background blur slider for Roleplay and Game mode backgrounds. ([#763](https://github.com/Pasta-Devs/Marinara-Engine/issues/763))
 - Added excluded-tag filtering for the character browser, including `-tag:"tag name"` search syntax and exclude toggles in the character tag picker. ([#702](https://github.com/Pasta-Devs/Marinara-Engine/issues/702))
 - Added a server-side autonomous conversation scheduler so enabled characters can generate restrained scheduled messages while the browser poller is absent, with client-presence checks to avoid duplicate client/server generations. ([#698](https://github.com/Pasta-Devs/Marinara-Engine/issues/698))
@@ -125,6 +137,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 - Fixed Game Mode asset generation prompt review, NPC portrait matching, sprite recovery, Professor-name avatar matching, and command-prompt regeneration replay.
 - Fixed Game Session Log flicker, deletion offsets, manual deletion persistence, and dice-roll dismissal when advancing dialogue.
 - Fixed Game Mode weather, storm ambience, sun overlay behavior, CYOA live updates, skill checks, inventory notifications, combat voice audio, mobile party access, tracker refreshes, and tracker edit persistence.
+- Fixed CJK Google font shard loading and scene-summary max-token overrides.
+- Fixed manual chat file deletion persistence and regenerate replay for command prompts.
 - Fixed Conversation disconnection aborts on Docker, markdown block preservation, hidden-message regeneration crashes, Up Arrow recall behavior, role editing, DM schedule inheritance, random connection schedule generation, and connected-chat placeholder branch names.
 - Fixed character avatar uploads preserving unsaved drafts, chat folder click targets, drag reorder behavior, text selection while dragging, folder storage atomicity, and Professor Mari continuation after tool/fetch work.
 - Fixed OpenAI ChatGPT request shape and SSE parsing, compressed provider JSON decoding (`gzip`, raw `gzip`, and Brotli), Gemini gzip decoding, provider identity handling, NovelAI V4 prompt/model handling, ComfyUI numeric workflow placeholders, Horde image endpoints, and Pygmalion avatar content-type fallback.
@@ -155,6 +169,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 - Per-connection max parallel agent job controls, allowing agent-heavy chats to split same-connection work across multiple LLM calls.
 - Editable Game Session History map JSON in the current-session spoiler section.
 - Markdown rendering and live preview for Game journal notes.
+- Tracker Data Sidebar for viewing and editing live tracker data from the side panel.
 - `/emote name="Character" expression="expression"` for listing and manually switching roleplay sprite expressions.
 - Duplicate action for individual prompt preset blocks.
 - Close controls for Game mode choice prompts and quick-time event windows.

--- a/packages/client/src/components/chat/RoleplayHUD.tsx
+++ b/packages/client/src/components/chat/RoleplayHUD.tsx
@@ -29,6 +29,12 @@ import { useAgentConfigs, useCustomAgentRuns, type AgentConfigRow } from "../../
 import { useChat } from "../../hooks/use-chats";
 import { discardPendingGameStatePatch, useGameStatePatcher } from "../../hooks/use-game-state-patcher";
 import { useUIStore } from "../../stores/ui.store";
+import {
+  getTemperatureColor,
+  getTemperatureGaugeDisplay,
+  getTemperatureKeywordHint,
+  parseTemperatureValue,
+} from "../../features/tracker-panel/lib/world-state-display";
 import type {
   GameState,
   PresentCharacter,
@@ -38,7 +44,7 @@ import type {
   CustomTrackerField,
   Message,
 } from "@marinara-engine/shared";
-import type { HudPosition } from "../../stores/ui.store";
+import type { HudPosition, TrackerTemperatureUnit } from "../../stores/ui.store";
 
 const ACTIONS_DROPDOWN_WIDTH_PX = 288;
 
@@ -142,6 +148,7 @@ export function RoleplayHUD({
   const trackerPanelEnabled = useUIStore((s) => s.trackerPanelEnabled);
   const trackerPanelOpen = useUIStore((s) => s.trackerPanelOpen);
   const trackerPanelHideHudWidgets = useUIStore((s) => s.trackerPanelHideHudWidgets);
+  const trackerTemperatureUnit = useUIStore((s) => s.trackerTemperatureUnit);
   const toggleTrackerPanel = useUIStore((s) => s.toggleTrackerPanel);
 
   const isTrackerBusy = isAgentProcessing || isStreaming || gameStateRefreshing;
@@ -269,6 +276,7 @@ export function RoleplayHUD({
               time={time ?? ""}
               weather={weather ?? ""}
               temperature={temperature ?? ""}
+              trackerTemperatureUnit={trackerTemperatureUnit}
               onSaveLocation={(v) => patchField("location", v)}
               onSaveDate={(v) => patchField("date", v)}
               onSaveTime={(v) => patchField("time", v)}
@@ -334,6 +342,7 @@ export function RoleplayHUD({
               time={time ?? ""}
               weather={weather ?? ""}
               temperature={temperature ?? ""}
+              trackerTemperatureUnit={trackerTemperatureUnit}
               onSaveLocation={(v) => patchField("location", v)}
               onSaveDate={(v) => patchField("date", v)}
               onSaveTime={(v) => patchField("time", v)}
@@ -1264,6 +1273,7 @@ function CombinedWorldWidget({
   time,
   weather,
   temperature,
+  trackerTemperatureUnit,
   onSaveLocation,
   onSaveDate,
   onSaveTime,
@@ -1278,6 +1288,7 @@ function CombinedWorldWidget({
   time: string;
   weather: string;
   temperature: string;
+  trackerTemperatureUnit: TrackerTemperatureUnit;
   onSaveLocation: (v: string) => void;
   onSaveDate: (v: string) => void;
   onSaveTime: (v: string) => void;
@@ -1291,18 +1302,10 @@ function CombinedWorldWidget({
   const buttonRef = useRef<HTMLButtonElement>(null);
   const weatherEmoji = weather ? getWeatherEmoji(weather) : "🌤️";
   const pinColor = getLocationPinColor(location);
-  const tempNumeric = temperature ? parseTemperature(temperature) : null;
+  const temperatureDisplay = getTemperatureGaugeDisplay(temperature, trackerTemperatureUnit);
+  const tempNumeric = temperature ? parseTemperatureValue(temperature) : null;
   const temp = tempNumeric ?? (temperature ? getTemperatureKeywordHint(temperature) : null);
-  const tempColor =
-    temp !== null
-      ? temp < 0
-        ? "text-blue-400"
-        : temp < 15
-          ? "text-sky-400"
-          : temp < 30
-            ? "text-amber-400"
-            : "text-red-400"
-      : "text-rose-400/50";
+  const tempColor = getTemperatureColor(temperature);
 
   // Dynamic calendar: show day number
   const dateParts = date ? parseDateLabel(date) : { day: null, month: null };
@@ -1313,10 +1316,9 @@ function CombinedWorldWidget({
   const hourAngle = hour >= 0 ? (hour % 12) * 30 + minute * 0.5 : 0;
   const minuteAngle = minute * 6;
 
-  // Thermometer fill fraction (clamp -20..50°C → 0..1)
-  const tempFill = temp !== null ? Math.max(0, Math.min(1, (temp + 20) / 70)) : 0.3;
-  const tempFillColor =
-    temp !== null ? (temp < 0 ? "#60a5fa" : temp < 15 ? "#38bdf8" : temp < 30 ? "#fbbf24" : "#f87171") : "#fb7185";
+  const tempFill =
+    temperatureDisplay.percent == null ? 0.3 : Math.max(0, Math.min(1, temperatureDisplay.percent / 100));
+  const tempFillColor = temperatureDisplay.color;
 
   return (
     <div className="relative">
@@ -1462,7 +1464,7 @@ function CombinedWorldWidget({
         </svg>
         {tempNumeric !== null && (
           <span className={cn("text-[0.5rem] md:text-[0.5625rem] font-bold leading-none shrink-0", tempColor)}>
-            {tempNumeric}°
+            {temperatureDisplay.label}
           </span>
         )}
       </button>
@@ -1565,26 +1567,6 @@ function getWeatherEmoji(weather: string): string {
   if (w.includes("hot") || w.includes("swelter")) return "🥵";
   if (w.includes("cold") || w.includes("freez")) return "🥶";
   return "🌤️";
-}
-
-function parseTemperature(temp: string): number | null {
-  const m = temp.match(/-?\d+(\.\d+)?/);
-  if (!m) return null;
-  const num = parseFloat(m[0]!);
-  if (/°?\s*f/i.test(temp)) return Math.round((num - 32) * (5 / 9));
-  return Math.round(num);
-}
-
-/** Map descriptive temperature words to a numeric-equivalent hint (°C). */
-function getTemperatureKeywordHint(text: string): number | null {
-  const t = text.toLowerCase();
-  if (/\b(freez|frigid|arctic|glacial|sub-?zero|blizzard)/.test(t)) return -10;
-  if (/\b(cold|chill|frost|wintry|icy|bitter|nipp)/.test(t)) return 2;
-  if (/\b(cool|brisk|crisp|refresh)/.test(t)) return 12;
-  if (/\b(mild|pleasant|comfort|temperate|fair)/.test(t)) return 20;
-  if (/\b(warm|balmy|toasty|muggy|humid|stuffy|sultry)/.test(t)) return 28;
-  if (/\b(hot|swelter|blaz|scorch|burn|heat|boil|sear|bak)/.test(t)) return 38;
-  return null;
 }
 
 /** Categorise location text into a colour for the map-pin icon. */

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -631,7 +631,7 @@ function TrackerPanelAppearanceDrawer({
           <div className="mt-2 flex min-h-8 items-center justify-between gap-2">
             <span className="inline-flex items-center gap-1 text-[0.6875rem] font-medium">
               Temperature unit
-              <HelpTooltip text="Only changes the Tracker Panel display. It does not rewrite the saved world-state temperature or affect the older HUD widgets." />
+              <HelpTooltip text="Changes Tracker Panel and roleplay HUD temperature displays without rewriting the saved world-state temperature." />
             </span>
             <button
               type="button"

--- a/packages/client/src/components/panels/settings/TrackerCardColorSettings.tsx
+++ b/packages/client/src/components/panels/settings/TrackerCardColorSettings.tsx
@@ -23,6 +23,8 @@ import {
 } from "../../../lib/tracker-card-colors";
 import { useTrackerGameState } from "../../../features/tracker-panel/hooks/use-tracker-game-state";
 import {
+  addAliasLookups,
+  addExactNameLookups,
   normalizeLookupText,
   normalizeMaybeJsonStringArray,
 } from "../../../features/tracker-panel/lib/tracker-metadata";
@@ -234,14 +236,21 @@ export function TrackerCardColorSettings() {
       : [];
     const charactersById = new Map(characterRows.map((character) => [character.id, character]));
     const idByLookupText = new Map<string, string>();
+    const activeChatCharacterIds = normalizeMaybeJsonStringArray(
+      (activeChat as { characterIds?: unknown } | null | undefined)?.characterIds,
+    );
+    const activeChatCharacterIdSet = new Set(activeChatCharacterIds);
+    const displayRows = characterRows.map((character) => ({
+      character,
+      display: parseCharacterDisplayData(character),
+    }));
+    const chatDisplayRows = displayRows.filter(({ character }) => activeChatCharacterIdSet.has(character.id));
+    const fallbackDisplayRows = displayRows.filter(({ character }) => !activeChatCharacterIdSet.has(character.id));
 
-    for (const character of characterRows) {
-      const display = parseCharacterDisplayData(character);
-      const nameKey = normalizeLookupText(display.name);
-      const commentKey = normalizeLookupText(display.comment);
-      if (nameKey && !idByLookupText.has(nameKey)) idByLookupText.set(nameKey, character.id);
-      if (commentKey && !idByLookupText.has(commentKey)) idByLookupText.set(commentKey, character.id);
-    }
+    addExactNameLookups(chatDisplayRows, idByLookupText);
+    addAliasLookups(chatDisplayRows, idByLookupText);
+    addExactNameLookups(fallbackDisplayRows, idByLookupText);
+    addAliasLookups(fallbackDisplayRows, idByLookupText);
 
     const nextTargets: TrackerCardColorTarget[] = [];
     const chatPersonaId =
@@ -278,9 +287,6 @@ export function TrackerCardColorSettings() {
     }
 
     const presentCharacterIds = new Set<string>();
-    const activeChatCharacterIds = normalizeMaybeJsonStringArray(
-      (activeChat as { characterIds?: unknown } | null | undefined)?.characterIds,
-    );
     for (const id of activeChatCharacterIds) {
       if (charactersById.has(id)) presentCharacterIds.add(id);
     }

--- a/packages/client/src/features/tracker-panel/hooks/use-tracker-sprite-lookup.ts
+++ b/packages/client/src/features/tracker-panel/hooks/use-tracker-sprite-lookup.ts
@@ -4,7 +4,7 @@ import { useCharacters } from "../../../hooks/use-characters";
 import { parseCharacterDisplayData } from "../../../lib/character-display";
 import type { TrackerSpriteLookup } from "../tracker-panel.types";
 import { isSpriteLookupCharacterId } from "../lib/sprite-expressions";
-import { normalizeLookupText } from "../lib/tracker-metadata";
+import { addAliasLookups, addExactNameLookups, normalizeLookupText } from "../lib/tracker-metadata";
 import { getCharacterProfileColors } from "../lib/tracker-profile-style";
 
 interface UseTrackerSpriteLookupOptions {
@@ -29,16 +29,21 @@ export function useTrackerSpriteLookup({ enabled, chatCharacterIds }: UseTracker
     const idByName = new Map<string, string>();
     const pictureById: Record<string, string> = {};
     const profileColorsById: TrackerSpriteLookup["profileColorsById"] = {};
+    const displayRows = orderedRows.map((character) => ({
+      character,
+      display: parseCharacterDisplayData(character),
+    }));
+    const chatDisplayRows = displayRows.filter(({ character }) => chatIdSet.has(character.id));
+    const fallbackDisplayRows = displayRows.filter(({ character }) => !chatIdSet.has(character.id));
     for (const character of orderedRows) {
       if (character.avatarPath) pictureById[character.id] = character.avatarPath;
       const profileColors = getCharacterProfileColors(character.data);
       if (profileColors) profileColorsById[character.id] = profileColors;
-      const display = parseCharacterDisplayData(character);
-      const nameKey = normalizeLookupText(display.name);
-      if (nameKey && !idByName.has(nameKey)) idByName.set(nameKey, character.id);
-      const commentKey = normalizeLookupText(display.comment);
-      if (commentKey && !idByName.has(commentKey)) idByName.set(commentKey, character.id);
     }
+    addExactNameLookups(chatDisplayRows, idByName);
+    addAliasLookups(chatDisplayRows, idByName);
+    addExactNameLookups(fallbackDisplayRows, idByName);
+    addAliasLookups(fallbackDisplayRows, idByName);
     return { knownIds, idByName, pictureById, profileColorsById };
   }, [charactersData, chatCharacterIds]);
 

--- a/packages/client/src/features/tracker-panel/lib/tracker-metadata.ts
+++ b/packages/client/src/features/tracker-panel/lib/tracker-metadata.ts
@@ -1,3 +1,10 @@
+import { getCharacterLookupAliases, type CharacterDisplayInfo } from "../../../lib/character-display";
+
+export interface CharacterLookupDisplayRow {
+  character: { id: string };
+  display: CharacterDisplayInfo;
+}
+
 export function parseMetadataRecord(raw: unknown): Record<string, unknown> {
   if (!raw) return {};
   if (typeof raw === "string") {
@@ -50,4 +57,28 @@ export function normalizeMaybeJsonStringArray(value: unknown): string[] {
 
 export function normalizeLookupText(value: string | null | undefined) {
   return (value ?? "").trim().toLowerCase();
+}
+
+export function addExactNameLookups(
+  candidates: readonly CharacterLookupDisplayRow[],
+  idByLookupText: Map<string, string>,
+) {
+  for (const { character, display } of candidates) {
+    const nameKey = normalizeLookupText(display.name);
+    if (nameKey && !idByLookupText.has(nameKey)) idByLookupText.set(nameKey, character.id);
+  }
+}
+
+export function addAliasLookups(
+  candidates: readonly CharacterLookupDisplayRow[],
+  idByLookupText: Map<string, string>,
+) {
+  for (const { character, display } of candidates) {
+    const nameKey = normalizeLookupText(display.name);
+    for (const alias of getCharacterLookupAliases(display)) {
+      const aliasKey = normalizeLookupText(alias);
+      if (aliasKey === nameKey) continue;
+      if (aliasKey && !idByLookupText.has(aliasKey)) idByLookupText.set(aliasKey, character.id);
+    }
+  }
 }

--- a/packages/client/src/lib/character-display.ts
+++ b/packages/client/src/lib/character-display.ts
@@ -3,9 +3,49 @@ export interface CharacterDisplayInfo {
   comment?: string | null;
 }
 
+const LOOKUP_ALIAS_SEPARATOR = /\s+(?:-|\/|\||:|\u2013|\u2014)\s+/;
+const LOOKUP_ALIAS_PARENS = /\(([^)]{1,96})\)|\[([^\]]{1,96})\]/g;
+const LOOKUP_ALIAS_EDGE_PUNCTUATION = /^[\s"'([{]+|[\s"')\]}.,:;]+$/g;
+
+function addLookupAlias(aliases: string[], seen: Set<string>, value: string | null | undefined) {
+  const alias = (value ?? "").replace(/\s+/g, " ").replace(LOOKUP_ALIAS_EDGE_PUNCTUATION, "").trim();
+  if (!alias || alias.length > 96) return;
+  const key = alias.toLowerCase();
+  if (seen.has(key)) return;
+  seen.add(key);
+  aliases.push(alias);
+}
+
+function addLeadingLookupAlias(aliases: string[], seen: Set<string>, value: string | null | undefined) {
+  const [leadingAlias] = (value ?? "").split(LOOKUP_ALIAS_SEPARATOR);
+  addLookupAlias(aliases, seen, leadingAlias);
+}
+
 export function getCharacterTitle(character: CharacterDisplayInfo | null | undefined): string | null {
   const title = typeof character?.comment === "string" ? character.comment.trim() : "";
   return title || null;
+}
+
+export function getCharacterLookupAliases(character: CharacterDisplayInfo | null | undefined): string[] {
+  const aliases: string[] = [];
+  const seen = new Set<string>();
+
+  addLookupAlias(aliases, seen, character?.name);
+
+  const title = getCharacterTitle(character);
+  if (!title) return aliases;
+
+  addLookupAlias(aliases, seen, title);
+
+  for (const match of title.matchAll(LOOKUP_ALIAS_PARENS)) {
+    addLookupAlias(aliases, seen, match[1] ?? match[2]);
+  }
+
+  const withoutParenthetical = title.replace(LOOKUP_ALIAS_PARENS, " ");
+  addLookupAlias(aliases, seen, withoutParenthetical);
+  addLeadingLookupAlias(aliases, seen, withoutParenthetical);
+
+  return aliases;
 }
 
 export function parseCharacterDisplayData(raw: { data: unknown; comment?: string | null }): CharacterDisplayInfo {

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -8891,10 +8891,14 @@ export async function generateRoutes(app: FastifyInstance) {
                 const ctData = result.data as Record<string, unknown>;
                 const chars = (ctData.presentCharacters as any[]) ?? [];
                 const snapBeforeUpdate = await gameStateStore.getByMessage(messageId, targetSwipeIndex);
-                const oldChars: any[] = snapBeforeUpdate?.presentCharacters
-                  ? typeof snapBeforeUpdate.presentCharacters === "string"
-                    ? JSON.parse(snapBeforeUpdate.presentCharacters)
-                    : snapBeforeUpdate.presentCharacters
+                const previousCharacterSnapshot =
+                  snapBeforeUpdate ??
+                  baseGameStateSnapshot ??
+                  (allowLatestGameStateFallback ? await gameStateStore.getLatest(input.chatId) : null);
+                const oldChars: any[] = previousCharacterSnapshot?.presentCharacters
+                  ? typeof previousCharacterSnapshot.presentCharacters === "string"
+                    ? JSON.parse(previousCharacterSnapshot.presentCharacters)
+                    : previousCharacterSnapshot.presentCharacters
                   : [];
                 preserveTrackerCharacterUiFields(chars, oldChars);
 

--- a/packages/server/src/routes/generate/generate-route-utils.ts
+++ b/packages/server/src/routes/generate/generate-route-utils.ts
@@ -565,14 +565,31 @@ export function wrapFields(
   return parts;
 }
 
+function trackerCharacterIdKey(character: Record<string, unknown>) {
+  return typeof character.characterId === "string" ? character.characterId.trim().toLowerCase() : "";
+}
+
+function trackerCharacterNameKey(character: Record<string, unknown>) {
+  return typeof character.name === "string" ? character.name.trim().toLowerCase() : "";
+}
+
 function trackerCharacterKey(character: Record<string, unknown>) {
-  const id = typeof character.characterId === "string" ? character.characterId.trim().toLowerCase() : "";
-  const name = typeof character.name === "string" ? character.name.trim().toLowerCase() : "";
-  return id || name || null;
+  return trackerCharacterIdKey(character) || trackerCharacterNameKey(character) || null;
+}
+
+function isNpcTrackerAvatarPath(value: unknown): value is string {
+  return typeof value === "string" && value.trim().startsWith("/api/avatars/npc/");
 }
 
 export function isManualTrackerCharacterId(value: unknown): boolean {
   return typeof value === "string" && value.trim().startsWith("manual-");
+}
+
+function canUseManualTrackerNameFallback(character: Record<string, unknown>) {
+  const id = trackerCharacterIdKey(character);
+  if (!id || isManualTrackerCharacterId(id)) return true;
+  const name = trackerCharacterNameKey(character);
+  return !!name && id === name;
 }
 
 export function preserveTrackerCharacterUiFields(
@@ -580,17 +597,36 @@ export function preserveTrackerCharacterUiFields(
   previousCharacters: Array<Record<string, unknown>>,
 ): void {
   const previousByKey = new Map<string, Record<string, unknown>>();
+  const previousManualByName = new Map<string, Record<string, unknown>>();
+  const previousNameCounts = new Map<string, number>();
   for (const character of previousCharacters) {
     const key = trackerCharacterKey(character);
     if (key) previousByKey.set(key, character);
+    const name = trackerCharacterNameKey(character);
+    if (name) previousNameCounts.set(name, (previousNameCounts.get(name) ?? 0) + 1);
+    if (name && isManualTrackerCharacterId(character.characterId)) {
+      previousManualByName.set(name, character);
+    }
   }
 
   for (const character of nextCharacters) {
     const key = trackerCharacterKey(character);
-    const previous = key ? previousByKey.get(key) : null;
+    const name = trackerCharacterNameKey(character);
+    const previous =
+      (key ? previousByKey.get(key) : null) ??
+      (name && previousNameCounts.get(name) === 1 && canUseManualTrackerNameFallback(character)
+        ? previousManualByName.get(name)
+        : null);
     const previousPortraitFocusX = previous?.portraitFocusX;
     const previousPortraitFocusY = previous?.portraitFocusY;
     const previousPortraitZoom = previous?.portraitZoom;
+    const previousAvatarPath = previous?.avatarPath;
+    if (
+      (typeof character.avatarPath !== "string" || !character.avatarPath.trim()) &&
+      isNpcTrackerAvatarPath(previousAvatarPath)
+    ) {
+      character.avatarPath = previousAvatarPath.trim();
+    }
     if (
       (typeof character.portraitFocusX !== "number" || !Number.isFinite(character.portraitFocusX)) &&
       typeof previousPortraitFocusX === "number" &&


### PR DESCRIPTION
<!-- Target branch: `staging`. The default base in this UI is `main` (release branch). -->
<!-- Change the base to `staging` before submitting unless this is a maintainer-approved mainline change. -->
<!-- See CONTRIBUTING.md § Branches. -->

## Linked issue

No linked issue found. Maintainer-requested mainline hotfix for legacy 1.6.1.

## Why this change

- Fixes tracker card resolution in group chats where the chat/tracker name can be an alias that differs from the character card's main display name.
- Keeps manually uploaded NPC tracker portraits and portrait framing from resetting to emoji/defaults when agents refresh tracker state.
- Keeps the Roleplay HUD temperature chip aligned with the shared Tracker Panel Celsius/Fahrenheit setting.

## What changed

- Added shared character lookup aliases and updated tracker sprite/color lookup to prioritize active-chat exact names, active-chat aliases, fallback exact names, then fallback aliases.
- Preserved NPC avatar URLs and portrait focus/zoom fields during tracker refresh writes, including first-snapshot generation writes.
- Reused shared world-state display helpers in the Roleplay HUD and clarified the temperature-unit settings tooltip.
- Recorded the tracker hotfix under the 1.6.1 changelog and backfilled recent legacy release notes without PR-link tails.

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `pnpm check` passed locally on this branch. The server build emitted the existing Node `[DEP0190]` deprecation warning, but the command completed successfully.
- `pnpm version:check` passed.
- `git diff --check origin/main` passed.
- Earlier branch validation included a Chromium browser pass with a seeded group chat where the tracker alias differed from the character card name, verifying lookup resolved to the intended card/avatar.
- Earlier targeted sanity checks covered character alias lookup ordering and NPC avatar preservation helper behavior.
- Docker/container validation was not run.

## Docs and release impact

- [ ] No docs changes needed
- [x] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

`CHANGELOG.md` was updated for the planned legacy 1.6.1 hotfix. No version bump is included.

## UI evidence (if applicable)

No new screenshots attached. The relevant UI behavior was exercised in the earlier Chromium pass for the tracker alias scenario.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Temperature unit setting now consistently applies to both Tracker Panel and Roleplay HUD displays.
  * Improved character lookup with alias support for better character matching.
  * Enhanced preservation of tracker character UI properties during updates.

* **Documentation**
  * Updated CHANGELOG with new entries for versions 1.6.1, 1.6.0, and 1.5.9.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1137?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->