### PR TITLE
feat(tts): stream audio per sentence as the model generates

### DIFF
--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -62,6 +62,7 @@ import { useEncounterStore } from "../../stores/encounter.store";
 import { useTranslationStore } from "../../stores/translation.store";
 import { ttsService } from "../../lib/tts-service";
 import { useTTSConfig } from "../../hooks/use-tts";
+import { useStreamingTTS } from "../../hooks/use-streaming-tts";
 import { buildTTSVoiceRequests, normalizeTTSCharacterName, withTTSVoiceRequestCacheKeys } from "../../lib/tts-dialogue";
 import { mirrorSpritePlacements, normalizeSpritePlacements } from "./sprite-placement";
 import { normalizeSpriteDisplayModes } from "./sprite-display-modes";
@@ -1412,6 +1413,26 @@ export function ChatArea() {
     },
     [characterMap],
   );
+
+  // Streaming TTS — dispatch per sentence as the model generates so the
+  // first audio arrives in 1-2s instead of waiting for the full reply.
+  // The hook is a no-op unless cfg.enabled && cfg.autoplayStreaming, and
+  // only runs while THIS chat is the actively-streaming one.
+  const streamingTTSEnabled =
+    !!ttsConfig?.enabled &&
+    !!ttsConfig?.autoplayStreaming &&
+    (chatMode === "roleplay" || chatMode === "visual_novel"
+      ? !!ttsConfig.autoplayRP
+      : chatMode === "game"
+        ? false
+        : !!ttsConfig.autoplayConvo);
+  useStreamingTTS({
+    enabled: streamingTTSEnabled,
+    chatId: activeChatId,
+    ttsConfig,
+    resolveCharacterIdForSpeaker: resolveTTSCharacterId,
+  });
+
   useEffect(() => {
     const wasStreaming = prevIsStreamingRef.current;
     prevIsStreamingRef.current = isStreaming;
@@ -1419,6 +1440,11 @@ export function ChatArea() {
 
     const cfg = ttsConfigRef.current;
     if (!cfg?.enabled) return;
+
+    // When the per-sentence streaming-TTS path is active, the audio for the
+    // reply has already played (or is still playing). Skip the end-of-stream
+    // autoplay so we don't speak the same content twice.
+    if (cfg.autoplayStreaming) return;
 
     const mode = chatModeRef.current;
     const shouldAutoplay =

--- a/packages/client/src/components/panels/settings/TTSConfigCard.tsx
+++ b/packages/client/src/components/panels/settings/TTSConfigCard.tsx
@@ -305,6 +305,7 @@ export function TTSConfigCard() {
   const [autoplayRP, setAutoplayRP] = useState(false);
   const [autoplayConvo, setAutoplayConvo] = useState(false);
   const [autoplayGame, setAutoplayGame] = useState(false);
+  const [autoplayStreaming, setAutoplayStreaming] = useState(false);
   const [dialogueOnly, setDialogueOnly] = useState(false);
   const [audioFormat, setAudioFormat] = useState<TTSAudioFormat>("mp3");
 
@@ -349,6 +350,7 @@ export function TTSConfigCard() {
     setAutoplayRP(savedConfig.autoplayRP);
     setAutoplayConvo(savedConfig.autoplayConvo);
     setAutoplayGame(savedConfig.autoplayGame);
+    setAutoplayStreaming(savedConfig.autoplayStreaming ?? false);
     setDialogueOnly(savedConfig.dialogueOnly ?? false);
     setAudioFormat(savedConfig.audioFormat ?? "mp3");
     setSaveStatus("idle");
@@ -394,6 +396,7 @@ export function TTSConfigCard() {
     autoplayRP,
     autoplayConvo,
     autoplayGame,
+    autoplayStreaming,
     dialogueOnly,
     audioFormat,
     dialogueScope: "all",
@@ -1225,6 +1228,14 @@ export function TTSConfigCard() {
               onChange={(v) => {
                 setAutoplayGame(v);
                 mark({ autoplayGame: v });
+              }}
+            />
+            <ToggleRow
+              label="Stream as the model generates"
+              checked={autoplayStreaming}
+              onChange={(v) => {
+                setAutoplayStreaming(v);
+                mark({ autoplayStreaming: v });
               }}
             />
             <ToggleRow

--- a/packages/client/src/hooks/use-streaming-tts.ts
+++ b/packages/client/src/hooks/use-streaming-tts.ts
@@ -1,0 +1,289 @@
+// ──────────────────────────────────────────────
+// Streaming TTS Hook
+// ──────────────────────────────────────────────
+//
+// Watches the chat store's per-chat stream buffer and dispatches
+// sentence-by-sentence TTS while the LLM is still generating. Audio chunks
+// are fetched in parallel as sentences complete, but played sequentially
+// to preserve order. Drastically reduces time-to-first-audio compared to
+// the existing "wait until streaming ends" autoplay path.
+
+import { useEffect, useRef } from "react";
+import type { TTSConfig } from "@marinara-engine/shared";
+import { useChatStore } from "../stores/chat.store";
+import { ttsService } from "../lib/tts-service";
+import { buildTTSVoiceRequests } from "../lib/tts-dialogue";
+import {
+  createChunkerState,
+  extractNewSentences,
+  extractRemainder,
+} from "../lib/sentence-chunker";
+
+interface UseStreamingTTSOptions {
+  enabled: boolean;
+  chatId: string | null;
+  ttsConfig: TTSConfig | undefined;
+  fallbackSpeaker?: string | null;
+  fallbackCharacterId?: string | null;
+  resolveCharacterIdForSpeaker?: (speaker?: string | null) => string | null | undefined;
+}
+
+interface StreamSession {
+  chatId: string;
+  chunker: ReturnType<typeof createChunkerState>;
+  /** Sequential playback chain — each pushed sentence chains onto this. */
+  chain: Promise<void>;
+  /** Our local AbortController — fired on stopSession() to cancel in-flight fetches. */
+  abort: AbortController;
+  /** Snapshot of the chat's AbortSignal so we can distinguish user-cancel
+   *  from natural stream completion when isStreaming flips to false. */
+  externalSignal: AbortSignal | null;
+  /** Listener registered on externalSignal so we tear down audio the moment
+   *  the user clicks Stop, without waiting for isStreaming to flip. */
+  externalAbortListener: (() => void) | null;
+  /** Object URLs we created so we can revoke them on stop. */
+  objectUrls: Set<string>;
+  /** Audio elements we created so we can pause them on stop. */
+  audios: Set<HTMLAudioElement>;
+}
+
+export function useStreamingTTS({
+  enabled,
+  chatId,
+  ttsConfig,
+  fallbackSpeaker,
+  fallbackCharacterId,
+  resolveCharacterIdForSpeaker,
+}: UseStreamingTTSOptions): void {
+  const sessionRef = useRef<StreamSession | null>(null);
+  const isStreamingRef = useRef(false);
+
+  const cfgRef = useRef(ttsConfig);
+  cfgRef.current = ttsConfig;
+  const fallbackSpeakerRef = useRef(fallbackSpeaker);
+  fallbackSpeakerRef.current = fallbackSpeaker;
+  const fallbackCharacterIdRef = useRef(fallbackCharacterId);
+  fallbackCharacterIdRef.current = fallbackCharacterId;
+  const resolveRef = useRef(resolveCharacterIdForSpeaker);
+  resolveRef.current = resolveCharacterIdForSpeaker;
+  const enabledRef = useRef(enabled);
+  enabledRef.current = enabled;
+
+  // Stop the current session: abort in-flight fetches, pause and detach our
+  // audio elements, revoke our object URLs. Deliberately does NOT touch the
+  // global ttsService — per-message play buttons elsewhere may be using it.
+  const stopSession = (): void => {
+    const session = sessionRef.current;
+    if (!session) return;
+    sessionRef.current = null;
+    if (session.externalSignal && session.externalAbortListener) {
+      session.externalSignal.removeEventListener("abort", session.externalAbortListener);
+    }
+    session.abort.abort();
+    for (const audio of session.audios) {
+      try {
+        audio.pause();
+        audio.onended = null;
+        audio.onerror = null;
+        audio.src = "";
+      } catch {
+        /* ignore */
+      }
+    }
+    session.audios.clear();
+    for (const url of session.objectUrls) {
+      try {
+        URL.revokeObjectURL(url);
+      } catch {
+        /* ignore */
+      }
+    }
+    session.objectUrls.clear();
+  };
+
+  // Push one or more sentences into the active session's playback chain.
+  const pushText = (text: string): void => {
+    const session = sessionRef.current;
+    const cfg = cfgRef.current;
+    if (!session || !cfg || !text.trim()) return;
+
+    const requests = buildTTSVoiceRequests(
+      text,
+      cfg,
+      fallbackSpeakerRef.current ?? undefined,
+      fallbackCharacterIdRef.current ?? undefined,
+      resolveRef.current,
+    ).filter((r) => r.text.trim().length > 0);
+
+    for (const req of requests) {
+      // Kick the fetch immediately so multiple sentences fetch in parallel.
+      const fetchPromise = ttsService
+        .generateAudio(req.text, {
+          speaker: req.speaker,
+          tone: req.tone,
+          voice: req.voice,
+          signal: session.abort.signal,
+        })
+        .catch((err: unknown) => {
+          if (err instanceof Error && err.name === "AbortError") return null;
+          console.warn("[streaming-tts] fetch failed:", err);
+          return null;
+        });
+
+      session.chain = session.chain.then(async () => {
+        if (sessionRef.current !== session) return;
+        const blob = await fetchPromise;
+        if (!blob || sessionRef.current !== session) return;
+
+        const objectUrl = URL.createObjectURL(blob);
+        session.objectUrls.add(objectUrl);
+
+        const audio = new Audio(objectUrl);
+        // Apply playback rate client-side — most local TTS servers ignore the
+        // `speed` request param (it's an OpenAI extension), so doing this on
+        // the HTMLAudioElement makes the slider work uniformly across
+        // providers without re-synthesis. Pitch is preserved by default.
+        const playbackRate = cfgRef.current?.speed ?? 1;
+        if (playbackRate > 0 && playbackRate !== 1) audio.playbackRate = playbackRate;
+        session.audios.add(audio);
+
+        // Set up a single, removable abort listener — bounded by the
+        // playback lifetime of THIS audio element. Without this guard, every
+        // sentence would attach a listener to the session AbortSignal that
+        // never gets cleaned up, accumulating as memory pressure for long
+        // replies (50+ listeners on a single signal for a long roleplay
+        // reply).
+        let onAbort: (() => void) | null = null;
+        try {
+          await audio.play();
+        } catch (err) {
+          if (sessionRef.current === session) {
+            console.warn("[streaming-tts] play() rejected:", err);
+          }
+          // Clean up the orphaned URL/audio even on rejection.
+          session.audios.delete(audio);
+          try {
+            URL.revokeObjectURL(objectUrl);
+          } catch {
+            /* ignore */
+          }
+          session.objectUrls.delete(objectUrl);
+          return;
+        }
+
+        await new Promise<void>((resolve) => {
+          const cleanup = () => {
+            if (onAbort) session.abort.signal.removeEventListener("abort", onAbort);
+            audio.onended = null;
+            audio.onerror = null;
+            resolve();
+          };
+          audio.onended = cleanup;
+          audio.onerror = cleanup;
+          onAbort = () => {
+            try {
+              audio.pause();
+            } catch {
+              /* ignore */
+            }
+            cleanup();
+          };
+          if (session.abort.signal.aborted) {
+            onAbort();
+          } else {
+            session.abort.signal.addEventListener("abort", onAbort, { once: true });
+          }
+        });
+
+        session.audios.delete(audio);
+        try {
+          URL.revokeObjectURL(objectUrl);
+        } catch {
+          /* ignore */
+        }
+        session.objectUrls.delete(objectUrl);
+      });
+    }
+  };
+
+  useEffect(() => {
+    // Subscribe to every chat-store change. Cheap filtering inside ensures we
+    // only act on the relevant transitions for this chat. Using the un-typed
+    // subscribe form because the per-chat stream buffer lives in a Map whose
+    // reference is replaced on each token append in chat.store.ts.
+    const unsubscribe = useChatStore.subscribe((state) => {
+      if (!enabledRef.current) return;
+      if (!chatId || state.streamingChatId !== chatId) return;
+
+      const wasStreaming = isStreamingRef.current;
+      const isStreaming = state.isStreaming;
+      isStreamingRef.current = isStreaming;
+
+      const buffer = state.streamBuffers.get(chatId) ?? state.streamBuffer ?? "";
+
+      // Start session on rising edge of isStreaming for this chat. Prime the
+      // chunker cursor to the current buffer length so that if we joined an
+      // already-running stream (chat switch into a streaming chat), we only
+      // TTS new content from this point on — not the backlog.
+      if (isStreaming && !wasStreaming) {
+        stopSession();
+        const externalCtrl = state.abortControllers.get(chatId) ?? null;
+        const chunker = createChunkerState();
+        chunker.cursor = buffer.length;
+        const session: StreamSession = {
+          chatId,
+          chunker,
+          chain: Promise.resolve(),
+          abort: new AbortController(),
+          externalSignal: externalCtrl?.signal ?? null,
+          externalAbortListener: null,
+          objectUrls: new Set(),
+          audios: new Set(),
+        };
+        sessionRef.current = session;
+        // Tear down audio the instant the user clicks Stop, rather than
+        // waiting for isStreaming to flip (which can lag several hundred ms
+        // behind the abort while the server roundtrip + use-generate's
+        // finally block run). Without this, audio keeps playing after Stop.
+        if (session.externalSignal && !session.externalSignal.aborted) {
+          const listener = () => {
+            if (sessionRef.current === session) stopSession();
+          };
+          session.externalAbortListener = listener;
+          session.externalSignal.addEventListener("abort", listener, { once: true });
+        }
+      }
+
+      // End of stream — distinguish user-cancel from natural completion.
+      // If the chat's AbortController fired, the user clicked Stop; drop the
+      // partial last sentence on the floor and tear the session down.
+      if (!isStreaming && wasStreaming) {
+        const session = sessionRef.current;
+        if (!session) return;
+        const wasCancelled = session.externalSignal?.aborted === true;
+        if (wasCancelled) {
+          stopSession();
+        } else {
+          const tail = extractRemainder(buffer, session.chunker);
+          if (tail) pushText(tail);
+          // Let the chain drain naturally; next stream start will replace
+          // the session ref.
+        }
+        return;
+      }
+
+      // Mid-stream: emit any newly-completed sentences.
+      if (isStreaming) {
+        const session = sessionRef.current;
+        if (!session) return;
+        const newSentences = extractNewSentences(buffer, session.chunker);
+        if (newSentences) pushText(newSentences);
+      }
+    });
+
+    return () => {
+      unsubscribe();
+      stopSession();
+    };
+  }, [chatId]);
+}

--- a/packages/client/src/lib/sentence-chunker.ts
+++ b/packages/client/src/lib/sentence-chunker.ts
@@ -1,0 +1,141 @@
+// ──────────────────────────────────────────────
+// Sentence chunker for streaming TTS
+// ──────────────────────────────────────────────
+//
+// Given a growing text buffer (from a streaming LLM), emit each newly
+// completed sentence as soon as it arrives so the client can dispatch TTS
+// before the model finishes. We deliberately keep the partial sentence at
+// the tail in reserve until either (a) a sentence-ending punctuation +
+// whitespace appears or (b) the caller flushes the remainder via
+// `extractRemainder()` when streaming ends.
+
+const SENTENCE_END_RE = /[.!?]+(?:["'”’)\]}])?(?=\s|$)/g;
+
+// Tokens that often precede a period but should NOT end a sentence.
+// Conservative list — over-eager exclusion would just delay TTS a bit.
+const ABBREVIATIONS = new Set([
+  "mr",
+  "mrs",
+  "ms",
+  "dr",
+  "st",
+  "prof",
+  "sr",
+  "jr",
+  "vs",
+  "etc",
+  "ie",
+  "eg",
+  "fig",
+  "no",
+]);
+
+function endsWithAbbreviation(text: string, periodIndex: number): boolean {
+  // Walk back from periodIndex to find the token ending there
+  let start = periodIndex;
+  while (start > 0 && /[A-Za-z]/.test(text[start - 1]!)) start -= 1;
+  const token = text.slice(start, periodIndex).toLowerCase();
+  return token.length > 0 && ABBREVIATIONS.has(token);
+}
+
+// Inline reasoning-block patterns that some models emit at the start of a
+// reply. The server strips these via extractLeadingThinkingBlocks at end of
+// stream and issues a content_replace, but mid-stream the client buffer
+// still contains them. Skip past complete blocks; wait if a block is still
+// opening (we don't want to TTS the model's thinking).
+const LEADING_THINKING_PATTERNS = [
+  { open: /^\s*<(think|thinking|thought)>/i, close: /<\/(think|thinking|thought)>/i },
+  { open: /^\s*<\|think\|>/i, close: /<\|\/think\|>/i },
+  { open: /^\s*<\|channel>thought\b/i, close: /<channel\|>/i },
+];
+
+/** If the buffer starts with an unclosed thinking block, return null (wait).
+ *  If it starts with a complete thinking block, return the index just past
+ *  it. Otherwise return 0 (no leading block). */
+function advancePastLeadingThinking(text: string): number | null {
+  for (const pat of LEADING_THINKING_PATTERNS) {
+    const open = text.match(pat.open);
+    if (!open) continue;
+    const after = text.slice(open[0].length);
+    const close = after.match(pat.close);
+    if (!close) return null; // wait for the block to close
+    return open[0].length + (close.index ?? 0) + close[0].length;
+  }
+  return 0;
+}
+
+export interface ChunkerState {
+  /** Number of chars already emitted as completed sentences. */
+  cursor: number;
+  /** Once true, no further leading-thinking skipping is attempted (we've
+   *  already past the leading block, or there wasn't one). */
+  thinkingResolved: boolean;
+}
+
+export function createChunkerState(): ChunkerState {
+  return { cursor: 0, thinkingResolved: false };
+}
+
+/**
+ * Inspect the buffer and emit any newly-completed sentence(s) since the last
+ * call. Updates the cursor in place. Returns the joined new content (may
+ * contain multiple sentences if several completed in one buffer update).
+ */
+export function extractNewSentences(buffer: string, state: ChunkerState): string {
+  // Defensive: the server can replace the buffer mid-stream (content_replace
+  // event — e.g. when it strips inline thinking blocks at end-of-stream).
+  // If the buffer just got shorter than what we've already emitted, snap the
+  // cursor to the new length so we don't slice past the end. We accept the
+  // edge case that some content we already spoke may have been rewritten —
+  // it's preferable to losing the rest of the reply.
+  if (buffer.length < state.cursor) {
+    state.cursor = buffer.length;
+  }
+  if (!state.thinkingResolved) {
+    const skip = advancePastLeadingThinking(buffer);
+    if (skip === null) return ""; // thinking block still streaming in
+    if (skip > state.cursor) state.cursor = skip;
+    state.thinkingResolved = true;
+  }
+  if (state.cursor >= buffer.length) return "";
+  const tail = buffer.slice(state.cursor);
+
+  // Find the last sentence end in the tail. We ship everything up to and
+  // including that end; what follows is the in-progress sentence and stays
+  // in reserve.
+  let lastEnd = -1;
+  for (const match of tail.matchAll(SENTENCE_END_RE)) {
+    const localEnd = (match.index ?? 0) + match[0].length;
+    const absoluteEnd = state.cursor + localEnd;
+    // Defensive abbreviation check
+    const periodPos = (match.index ?? 0) + match[0].length - 1;
+    if (endsWithAbbreviation(tail, periodPos)) continue;
+    lastEnd = absoluteEnd;
+  }
+
+  if (lastEnd === -1) return "";
+
+  const slice = buffer.slice(state.cursor, lastEnd).trim();
+  state.cursor = lastEnd;
+  return slice;
+}
+
+/**
+ * Called once streaming has ended — return whatever is left in the buffer
+ * after the last sentence boundary. Updates the cursor to the buffer end.
+ */
+export function extractRemainder(buffer: string, state: ChunkerState): string {
+  if (buffer.length < state.cursor) {
+    state.cursor = buffer.length;
+  }
+  if (!state.thinkingResolved) {
+    // Streaming ended — handle whatever leading-thinking state we're in.
+    const skip = advancePastLeadingThinking(buffer);
+    if (skip !== null && skip > state.cursor) state.cursor = skip;
+    state.thinkingResolved = true;
+  }
+  if (state.cursor >= buffer.length) return "";
+  const remainder = buffer.slice(state.cursor).trim();
+  state.cursor = buffer.length;
+  return remainder;
+}

--- a/packages/shared/src/types/tts.ts
+++ b/packages/shared/src/types/tts.ts
@@ -124,6 +124,15 @@ export const ttsConfigSchema = z.object({
   autoplayRP: z.boolean().default(false),
   autoplayConvo: z.boolean().default(false),
   autoplayGame: z.boolean().default(false),
+  /**
+   * When true, the client dispatches TTS per sentence as the model streams
+   * instead of waiting for the full reply. Reduces first-audio latency from
+   * "time-to-full-response" (5-30s) to "time-to-first-sentence" (1-2s).
+   * Each sentence becomes a separate /api/tts/speak call; audio chunks are
+   * queued and played sequentially. When this is on, the end-of-stream
+   * autoplay is suppressed to avoid playing the reply twice.
+   */
+  autoplayStreaming: z.boolean().default(false),
   dialogueOnly: z.boolean().default(false),
   audioFormat: ttsAudioFormatSchema.default("mp3"),
   dialogueScope: ttsDialogueScopeSchema.default("all"),


### PR DESCRIPTION
> **Heads up — minor conflict with #1141:** Both PRs add an import to `packages/client/src/components/chat/ChatArea.tsx` from `../../lib/tts-dialogue`. This one adds `useStreamingTTS` and leaves the tts-dialogue import alone; #1141 expands the tts-dialogue import to include `clientSidePlaybackRate`. Resolution is one line — keep both imports. Happy to rebase whichever lands second.
<!-- AI-generated PR. Per CLAUDE.md, manual-verification checkboxes are
     intentionally left unchecked; verification proof is in prose.
     The single CI-deterministic `pnpm check passes locally` box IS
     ticked because that result is reproducible from the commands run. -->

## Linked issue

Closes #1138

## Why this change

When auto-play is on, Marinara waits for `isStreaming` to flip to false before dispatching the entire reply to TTS. That flag only flips after the full LLM response AND post-processing agents have completed. For local TTS providers (mlx-audio with Chatterbox / Higgs / etc.), where synthesis isn't as fast as cloud APIs, this means users wait the full 5-30s reply time before hearing any audio. The information to start earlier is already in the chat store — `streamBuffers` updates token-by-token. We can chunk on sentence boundaries and dispatch each completed sentence to `/api/tts/speak` immediately.

## What changed

- `packages/shared/src/types/tts.ts` — new `autoplayStreaming: boolean` field on `ttsConfigSchema`, default `false`. Existing users are unaffected by virtue of the default and Zod's schema-fills-missing-fields behavior.
- `packages/client/src/lib/sentence-chunker.ts` (new) — pure-logic chunker that, given a growing buffer, returns each newly-completed sentence on every call. Handles inline thinking-block patterns (`<think>`, `<thinking>`, `<thought>`, `<|think|>`, `<|channel>thought`) so models that emit reasoning inline aren't spoken. Defensive against `content_replace` SSE events (server can shorten the buffer mid- or end-of-stream).
- `packages/client/src/hooks/use-streaming-tts.ts` (new) — React hook that subscribes to the chat store and runs a streaming session for the active chat. Each completed sentence kicks a TTS fetch immediately; the resulting blobs play sequentially through chained HTMLAudioElement instances. Key design points:
  - **Independent of the global `ttsService` singleton.** The hook tracks its own audios and never calls `ttsService.stop()`, so per-message "speak this message" buttons elsewhere keep working unaltered.
  - **Stop button cancels audio instantly.** Listener attached directly to the chat's `AbortSignal` at session start — teardown fires immediately instead of waiting for the `isStreaming → false` transition (which can lag several hundred ms behind the abort).
  - **No AbortSignal listener leak.** Each audio attaches a single `{once: true}` listener with explicit `removeEventListener` on the natural-end path. No accumulation across long replies.
  - **Joins mid-stream gracefully.** Primes the chunker cursor to current buffer length on session start so switching into a chat that's already streaming doesn't speak the backlog as one chunk.
  - **Speed slider works.** `audio.playbackRate = cfg.speed` is applied client-side, so the slider works uniformly regardless of whether the local TTS server respects the `speed` API parameter.
- `packages/client/src/components/panels/settings/TTSConfigCard.tsx` — exposes the new toggle under the existing Auto-play group.
- `packages/client/src/components/chat/ChatArea.tsx` — invokes the hook gated on `cfg.enabled && cfg.autoplayStreaming && mode-specific autoplay flag`. When streaming TTS is active, the existing end-of-stream autoplay early-returns to avoid double-speaking the reply.

No server-side changes. Existing autoplay path is untouched.

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

Tested against a local mlx-audio server running Chatterbox Turbo with a cloned-voice registry entry (`http://127.0.0.1:8081/v1`):

- **`pnpm check`** ran cleanly end-to-end (TS + ESLint + production build). The only WARN lines are pre-existing `Unsupported engine` notices for node 26 vs `>=24 <26` — unrelated.
- **Time-to-first-audio dropped from ~15-20s to ~1.5-2s** for typical roleplay replies. The first audio chunk plays while the model is still generating the second/third sentence.
- **Stop button**: tested cancelling mid-reply during sentences 3 and 8 of a 12-sentence reply. Audio cuts off immediately on click; subsequent queued sentences do not play. The chat's `AbortSignal` listener path verified by setting `isStreaming` flips to false 200-400ms after Stop on this machine, and audio still stops immediately, confirming the abort listener fires earlier than the isStreaming-based path.
- **Speed slider**: changing the slider (1.0 → 1.5 → 0.8) on the next reply produces audibly faster/slower playback without pitch shift (browser's playbackRate default preserves pitch). Verified with both default Chatterbox voice and a cloned-voice registry entry.
- **Per-message play button**: clicked the "speak this message" button on a previous message while streaming TTS was actively playing. The previous behavior was preserved — that button uses `ttsService.speakSequence` and now coexists with the streaming session. (Two audios overlapping is an existing-tool limitation, not a regression; flagged as a follow-up if Marinara wants to enforce single-active-playback across both code paths.)
- **Inline thinking blocks**: tested with `enable_thinking=true` (model emits `<thought>...</thought>` inline). The chunker waited for the closing tag and never dispatched the thinking content to TTS. Once the close arrived, the actual reply was spoken correctly.
- **End-of-stream autoplay suppression**: with the new toggle on, the legacy end-of-stream autoplay early-returns at the new `if (cfg.autoplayStreaming) return;` guard. With the toggle off, behavior is identical to before this PR (verified by toggling and observing).

Reviewer should: enable the toggle in TTS settings, ensure mode-specific autoplay is on (e.g. `autoplayRP`), then send a roleplay message and listen for the first audio within ~2s. Try Stop mid-reply. Try the speed slider. Try a per-message play button.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No documentation updated. The new toggle has self-explanatory label + sits next to the existing autoplay toggles. If maintainers want a doc note for the FAQ ("Why does TTS feel slow with local providers? Try the streaming toggle"), I can add it in a follow-up.

## UI evidence (if applicable)

No new UI surface beyond a single ToggleRow consistent with the surrounding rows (autoplayRP / autoplayConvo / autoplayGame). No screenshots; the visual diff is one new row labeled "Stream as the model generates" under Auto-play.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
