### PR TITLE
feat(tts): stream audio per sentence as the model generates

### DIFF
--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -62,6 +62,7 @@ import { useEncounterStore } from "../../stores/encounter.store";
 import { useTranslationStore } from "../../stores/translation.store";
 import { ttsService } from "../../lib/tts-service";
 import { useTTSConfig } from "../../hooks/use-tts";
+import { useStreamingTTS } from "../../hooks/use-streaming-tts";
 import {
   buildTTSVoiceRequests,
   clientSidePlaybackRate,
@@ -1417,6 +1418,26 @@ export function ChatArea() {
     },
     [characterMap],
   );
+
+  // Streaming TTS — dispatch per sentence as the model generates so the
+  // first audio arrives in 1-2s instead of waiting for the full reply.
+  // The hook is a no-op unless cfg.enabled && cfg.autoplayStreaming, and
+  // only runs while THIS chat is the actively-streaming one.
+  const streamingTTSEnabled =
+    !!ttsConfig?.enabled &&
+    !!ttsConfig?.autoplayStreaming &&
+    (chatMode === "roleplay" || chatMode === "visual_novel"
+      ? !!ttsConfig.autoplayRP
+      : chatMode === "game"
+        ? false
+        : !!ttsConfig.autoplayConvo);
+  useStreamingTTS({
+    enabled: streamingTTSEnabled,
+    chatId: activeChatId,
+    ttsConfig,
+    resolveCharacterIdForSpeaker: resolveTTSCharacterId,
+  });
+
   useEffect(() => {
     const wasStreaming = prevIsStreamingRef.current;
     prevIsStreamingRef.current = isStreaming;
@@ -1424,6 +1445,11 @@ export function ChatArea() {
 
     const cfg = ttsConfigRef.current;
     if (!cfg?.enabled) return;
+
+    // When the per-sentence streaming-TTS path is active, the audio for the
+    // reply has already played (or is still playing). Skip the end-of-stream
+    // autoplay so we don't speak the same content twice.
+    if (cfg.autoplayStreaming) return;
 
     const mode = chatModeRef.current;
     const shouldAutoplay =

--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -62,7 +62,12 @@ import { useEncounterStore } from "../../stores/encounter.store";
 import { useTranslationStore } from "../../stores/translation.store";
 import { ttsService } from "../../lib/tts-service";
 import { useTTSConfig } from "../../hooks/use-tts";
-import { buildTTSVoiceRequests, normalizeTTSCharacterName, withTTSVoiceRequestCacheKeys } from "../../lib/tts-dialogue";
+import {
+  buildTTSVoiceRequests,
+  clientSidePlaybackRate,
+  normalizeTTSCharacterName,
+  withTTSVoiceRequestCacheKeys,
+} from "../../lib/tts-dialogue";
 import { mirrorSpritePlacements, normalizeSpritePlacements } from "./sprite-placement";
 import { normalizeSpriteDisplayModes } from "./sprite-display-modes";
 import type {
@@ -1451,7 +1456,9 @@ export function ChatArea() {
     );
     if (ttsRequests.length === 0) return;
 
-    void ttsService.speakSequence(withTTSVoiceRequestCacheKeys(ttsRequests, cfg, lastMsg.id), lastMsg.id);
+    void ttsService.speakSequence(withTTSVoiceRequestCacheKeys(ttsRequests, cfg, lastMsg.id), lastMsg.id, {
+      playbackRate: clientSidePlaybackRate(cfg),
+    });
   }, [characterMap, isStreaming, resolveTTSCharacterId]);
 
   const newestMsgId = msgData?.pages[0]?.[msgData.pages[0].length - 1]?.id;

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -48,7 +48,12 @@ import { useTranslate } from "../../hooks/use-translate";
 import { api } from "../../lib/api-client";
 import { ttsService } from "../../lib/tts-service";
 import { useTTSConfig } from "../../hooks/use-tts";
-import { buildTTSVoiceRequests, normalizeTTSCharacterName, withTTSVoiceRequestCacheKeys } from "../../lib/tts-dialogue";
+import {
+  buildTTSVoiceRequests,
+  clientSidePlaybackRate,
+  normalizeTTSCharacterName,
+  withTTSVoiceRequestCacheKeys,
+} from "../../lib/tts-dialogue";
 import { DIALOGUE_QUOTE_PATTERN_SOURCE, HTML_SAFE_DIALOGUE_QUOTE_PATTERN_SOURCE } from "../../lib/dialogue-quotes";
 import DOMPurify from "dompurify";
 import type { CharacterMap, ExpressionAvatarResolver, MessageSelectionToggle, PersonaInfo } from "./chat-area.types";
@@ -888,9 +893,11 @@ export const ChatMessage = memo(function ChatMessage({
       ttsService.stop();
     } else {
       if (!hasTTSContent) return;
-      void ttsService.speakSequence(ttsVoiceRequests, message.id);
+      void ttsService.speakSequence(ttsVoiceRequests, message.id, {
+        playbackRate: clientSidePlaybackRate(ttsConfig),
+      });
     }
-  }, [hasTTSContent, message.id, ttsVoiceRequests]);
+  }, [hasTTSContent, message.id, ttsVoiceRequests, ttsConfig]);
 
   const handlePauseResumeTTS = useCallback(() => {
     if (ttsService.getActiveId() !== message.id) return;

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -49,6 +49,11 @@ import { api } from "../../lib/api-client";
 import { ttsService } from "../../lib/tts-service";
 import { useTTSConfig } from "../../hooks/use-tts";
 import {
+  isStreamingTTSActive,
+  stopStreamingTTS,
+  subscribeStreamingTTSActive,
+} from "../../hooks/use-streaming-tts";
+import {
   buildTTSVoiceRequests,
   clientSidePlaybackRate,
   normalizeTTSCharacterName,
@@ -881,8 +886,21 @@ export const ChatMessage = memo(function ChatMessage({
   const isSpeakingThis = ttsActiveId === message.id;
   const isLoadingThis = isSpeakingThis && ttsState === "loading";
   const isPausedThis = isSpeakingThis && ttsState === "paused";
+  // Track whether the streaming-TTS hook is actively playing. When true,
+  // every speaker icon acts as a "stop" affordance — clicking any of them
+  // halts the streaming-TTS session.
+  const [streamingTTSActive, setStreamingTTSActive] = useState<boolean>(() => isStreamingTTSActive());
+  useEffect(() => subscribeStreamingTTSActive(setStreamingTTSActive), []);
 
   const handleSpeak = useCallback(() => {
+    // If a streaming-TTS session is running (autoplayStreaming), stop it.
+    // This serves as the "stop audio" interaction for streaming playback —
+    // the chat's generation-abort path only fires WHILE the LLM is streaming;
+    // after natural completion the queued audio keeps playing otherwise.
+    if (isStreamingTTSActive()) {
+      stopStreamingTTS();
+      return;
+    }
     // Read directly from the singleton so we never act on stale React state
     const liveState = ttsService.getState();
     const liveActiveId = ttsService.getActiveId();
@@ -2030,7 +2048,7 @@ export const ChatMessage = memo(function ChatMessage({
                     icon={
                       isLoadingThis ? (
                         <Loader2 size={MESSAGE_ACTION_ICON_SIZE} className="animate-spin" />
-                      ) : isSpeakingThis ? (
+                      ) : isSpeakingThis || streamingTTSActive ? (
                         <VolumeX size={MESSAGE_ACTION_ICON_SIZE} />
                       ) : (
                         <Volume2 size={MESSAGE_ACTION_ICON_SIZE} />
@@ -2038,16 +2056,18 @@ export const ChatMessage = memo(function ChatMessage({
                     }
                     onClick={handleSpeak}
                     title={
-                      !hasTTSContent
-                        ? "No dialogue to speak"
-                        : isLoadingThis
-                          ? "Loading…"
-                          : isSpeakingThis
-                            ? "Stop speaking"
-                            : "Speak"
+                      streamingTTSActive
+                        ? "Stop streaming narration"
+                        : !hasTTSContent
+                          ? "No dialogue to speak"
+                          : isLoadingThis
+                            ? "Loading…"
+                            : isSpeakingThis
+                              ? "Stop speaking"
+                              : "Speak"
                     }
-                    className={isSpeakingThis ? "text-sky-400 hover:text-sky-300" : undefined}
-                    disabled={!hasTTSContent || (ttsBusy && !isSpeakingThis)}
+                    className={isSpeakingThis || streamingTTSActive ? "text-sky-400 hover:text-sky-300" : undefined}
+                    disabled={!streamingTTSActive && (!hasTTSContent || (ttsBusy && !isSpeakingThis))}
                     dark
                   />
                 </>
@@ -2457,7 +2477,7 @@ export const ChatMessage = memo(function ChatMessage({
                   icon={
                     isLoadingThis ? (
                       <Loader2 size={MESSAGE_ACTION_ICON_SIZE} className="animate-spin" />
-                    ) : isSpeakingThis ? (
+                    ) : isSpeakingThis || streamingTTSActive ? (
                       <VolumeX size={MESSAGE_ACTION_ICON_SIZE} />
                     ) : (
                       <Volume2 size={MESSAGE_ACTION_ICON_SIZE} />
@@ -2465,16 +2485,18 @@ export const ChatMessage = memo(function ChatMessage({
                   }
                   onClick={handleSpeak}
                   title={
-                    !hasTTSContent
-                      ? "No dialogue to speak"
-                      : isLoadingThis
-                        ? "Loading…"
-                        : isSpeakingThis
-                          ? "Stop speaking"
-                          : "Speak"
+                    streamingTTSActive
+                      ? "Stop streaming narration"
+                      : !hasTTSContent
+                        ? "No dialogue to speak"
+                        : isLoadingThis
+                          ? "Loading…"
+                          : isSpeakingThis
+                            ? "Stop speaking"
+                            : "Speak"
                   }
-                  className={isSpeakingThis ? "text-sky-500" : undefined}
-                  disabled={!hasTTSContent || (ttsBusy && !isSpeakingThis)}
+                  className={isSpeakingThis || streamingTTSActive ? "text-sky-500" : undefined}
+                  disabled={!streamingTTSActive && (!hasTTSContent || (ttsBusy && !isSpeakingThis))}
                 />
               </>
             )}

--- a/packages/client/src/components/panels/settings/TTSConfigCard.tsx
+++ b/packages/client/src/components/panels/settings/TTSConfigCard.tsx
@@ -21,6 +21,7 @@ import { toast } from "sonner";
 import { useTTSConfig, useUpdateTTSConfig, useTTSVoices } from "../../../hooks/use-tts";
 import { useCharacters } from "../../../hooks/use-characters";
 import { ttsService } from "../../../lib/tts-service";
+import { clientSidePlaybackRate } from "../../../lib/tts-dialogue";
 import { parseCharacterDisplayData } from "../../../lib/character-display";
 import type { TTSConfig, TTSSource, TTSVoiceAssignment, TTSVoiceMode, TTSAudioFormat } from "@marinara-engine/shared";
 import { ELEVENLABS_TTS_LANGUAGE_OPTIONS, TTS_API_KEY_MASK } from "@marinara-engine/shared";
@@ -488,6 +489,7 @@ export function TTSConfigCard() {
         await ttsService.speak("Hello! This is a preview of the text to speech voice.", "tts-preview", {
           throwOnError: true,
           voice: previewVoice,
+          playbackRate: clientSidePlaybackRate(payload),
         });
       } catch (error) {
         const message = error instanceof Error ? error.message : "TTS preview failed.";

--- a/packages/client/src/components/panels/settings/TTSConfigCard.tsx
+++ b/packages/client/src/components/panels/settings/TTSConfigCard.tsx
@@ -306,6 +306,7 @@ export function TTSConfigCard() {
   const [autoplayRP, setAutoplayRP] = useState(false);
   const [autoplayConvo, setAutoplayConvo] = useState(false);
   const [autoplayGame, setAutoplayGame] = useState(false);
+  const [autoplayStreaming, setAutoplayStreaming] = useState(false);
   const [dialogueOnly, setDialogueOnly] = useState(false);
   const [audioFormat, setAudioFormat] = useState<TTSAudioFormat>("mp3");
 
@@ -350,6 +351,7 @@ export function TTSConfigCard() {
     setAutoplayRP(savedConfig.autoplayRP);
     setAutoplayConvo(savedConfig.autoplayConvo);
     setAutoplayGame(savedConfig.autoplayGame);
+    setAutoplayStreaming(savedConfig.autoplayStreaming ?? false);
     setDialogueOnly(savedConfig.dialogueOnly ?? false);
     setAudioFormat(savedConfig.audioFormat ?? "mp3");
     setSaveStatus("idle");
@@ -395,6 +397,7 @@ export function TTSConfigCard() {
     autoplayRP,
     autoplayConvo,
     autoplayGame,
+    autoplayStreaming,
     dialogueOnly,
     audioFormat,
     dialogueScope: "all",
@@ -1227,6 +1230,14 @@ export function TTSConfigCard() {
               onChange={(v) => {
                 setAutoplayGame(v);
                 mark({ autoplayGame: v });
+              }}
+            />
+            <ToggleRow
+              label="Stream as the model generates"
+              checked={autoplayStreaming}
+              onChange={(v) => {
+                setAutoplayStreaming(v);
+                mark({ autoplayStreaming: v });
               }}
             />
             <ToggleRow

--- a/packages/client/src/hooks/use-streaming-tts.ts
+++ b/packages/client/src/hooks/use-streaming-tts.ts
@@ -1,0 +1,368 @@
+// ──────────────────────────────────────────────
+// Streaming TTS Hook
+// ──────────────────────────────────────────────
+//
+// Watches the chat store's per-chat stream buffer and dispatches
+// sentence-by-sentence TTS while the LLM is still generating. Audio chunks
+// are fetched in parallel as sentences complete, but played sequentially
+// to preserve order. Drastically reduces time-to-first-audio compared to
+// the existing "wait until streaming ends" autoplay path.
+
+import { useEffect, useRef } from "react";
+import type { TTSConfig } from "@marinara-engine/shared";
+import { useChatStore } from "../stores/chat.store";
+import { ttsService } from "../lib/tts-service";
+import { buildTTSVoiceRequests } from "../lib/tts-dialogue";
+import {
+  createChunkerState,
+  extractNewSentences,
+  extractRemainder,
+} from "../lib/sentence-chunker";
+
+interface UseStreamingTTSOptions {
+  enabled: boolean;
+  chatId: string | null;
+  ttsConfig: TTSConfig | undefined;
+  fallbackSpeaker?: string | null;
+  fallbackCharacterId?: string | null;
+  resolveCharacterIdForSpeaker?: (speaker?: string | null) => string | null | undefined;
+}
+
+// Module-level handle so any UI can stop the currently active streaming-TTS
+// session (e.g. a per-message speaker icon, a global "stop audio" button,
+// or an Escape keybinding). The hook registers/clears its stop function
+// here as sessions start/end.
+let activeStopHandler: (() => void) | null = null;
+const activeListeners = new Set<(active: boolean) => void>();
+
+function notifyActiveChange(): void {
+  const active = activeStopHandler !== null;
+  for (const fn of activeListeners) {
+    try {
+      fn(active);
+    } catch {
+      /* ignore listener errors */
+    }
+  }
+}
+
+/** Stop any in-progress streaming-TTS session. Safe to call even when no
+ *  session is active (no-op). */
+export function stopStreamingTTS(): void {
+  activeStopHandler?.();
+}
+
+/** Whether a streaming-TTS session is currently active (audio queued or playing). */
+export function isStreamingTTSActive(): boolean {
+  return activeStopHandler !== null;
+}
+
+/** Subscribe to streaming-TTS active-state changes. Returns an unsubscribe
+ *  function. The listener is fired with the new active state each time a
+ *  session starts or stops. */
+export function subscribeStreamingTTSActive(fn: (active: boolean) => void): () => void {
+  activeListeners.add(fn);
+  return () => {
+    activeListeners.delete(fn);
+  };
+}
+
+interface StreamSession {
+  chatId: string;
+  chunker: ReturnType<typeof createChunkerState>;
+  /** Sequential playback chain — each pushed sentence chains onto this. */
+  chain: Promise<void>;
+  /** Our local AbortController — fired on stopSession() to cancel in-flight fetches. */
+  abort: AbortController;
+  /** Snapshot of the chat's AbortSignal so we can distinguish user-cancel
+   *  from natural stream completion when isStreaming flips to false. */
+  externalSignal: AbortSignal | null;
+  /** Listener registered on externalSignal so we tear down audio the moment
+   *  the user clicks Stop, without waiting for isStreaming to flip. */
+  externalAbortListener: (() => void) | null;
+  /** Object URLs we created so we can revoke them on stop. */
+  objectUrls: Set<string>;
+  /** Audio elements we created so we can pause them on stop. */
+  audios: Set<HTMLAudioElement>;
+}
+
+export function useStreamingTTS({
+  enabled,
+  chatId,
+  ttsConfig,
+  fallbackSpeaker,
+  fallbackCharacterId,
+  resolveCharacterIdForSpeaker,
+}: UseStreamingTTSOptions): void {
+  const sessionRef = useRef<StreamSession | null>(null);
+  const isStreamingRef = useRef(false);
+
+  const cfgRef = useRef(ttsConfig);
+  cfgRef.current = ttsConfig;
+  const fallbackSpeakerRef = useRef(fallbackSpeaker);
+  fallbackSpeakerRef.current = fallbackSpeaker;
+  const fallbackCharacterIdRef = useRef(fallbackCharacterId);
+  fallbackCharacterIdRef.current = fallbackCharacterId;
+  const resolveRef = useRef(resolveCharacterIdForSpeaker);
+  resolveRef.current = resolveCharacterIdForSpeaker;
+  const enabledRef = useRef(enabled);
+  enabledRef.current = enabled;
+
+  // Stop the current session: abort in-flight fetches, pause and detach our
+  // audio elements, revoke our object URLs. Deliberately does NOT touch the
+  // global ttsService — per-message play buttons elsewhere may be using it.
+  const stopSession = (): void => {
+    const session = sessionRef.current;
+    if (!session) return;
+    sessionRef.current = null;
+    if (activeStopHandler === stopSession) {
+      activeStopHandler = null;
+      notifyActiveChange();
+    }
+    if (session.externalSignal && session.externalAbortListener) {
+      session.externalSignal.removeEventListener("abort", session.externalAbortListener);
+    }
+    session.abort.abort();
+    for (const audio of session.audios) {
+      try {
+        audio.pause();
+        audio.onended = null;
+        audio.onerror = null;
+        audio.src = "";
+      } catch {
+        /* ignore */
+      }
+    }
+    session.audios.clear();
+    for (const url of session.objectUrls) {
+      try {
+        URL.revokeObjectURL(url);
+      } catch {
+        /* ignore */
+      }
+    }
+    session.objectUrls.clear();
+  };
+
+  // Push one or more sentences into the active session's playback chain.
+  const pushText = (text: string): void => {
+    const session = sessionRef.current;
+    const cfg = cfgRef.current;
+    if (!session || !cfg || !text.trim()) return;
+
+    const requests = buildTTSVoiceRequests(
+      text,
+      cfg,
+      fallbackSpeakerRef.current ?? undefined,
+      fallbackCharacterIdRef.current ?? undefined,
+      resolveRef.current,
+    ).filter((r) => r.text.trim().length > 0);
+
+    for (const req of requests) {
+      // Kick the fetch immediately so multiple sentences fetch in parallel.
+      const fetchPromise = ttsService
+        .generateAudio(req.text, {
+          speaker: req.speaker,
+          tone: req.tone,
+          voice: req.voice,
+          signal: session.abort.signal,
+        })
+        .catch((err: unknown) => {
+          if (err instanceof Error && err.name === "AbortError") return null;
+          console.warn("[streaming-tts] fetch failed:", err);
+          return null;
+        });
+
+      session.chain = session.chain.then(async () => {
+        if (sessionRef.current !== session) return;
+        const blob = await fetchPromise;
+        if (!blob || sessionRef.current !== session) return;
+
+        const objectUrl = URL.createObjectURL(blob);
+        session.objectUrls.add(objectUrl);
+
+        const audio = new Audio(objectUrl);
+        // Apply playback rate client-side — most local TTS servers ignore the
+        // `speed` request param (it's an OpenAI extension), so doing this on
+        // the HTMLAudioElement makes the slider work uniformly across
+        // providers without re-synthesis. Pitch is preserved by default.
+        const playbackRate = cfgRef.current?.speed ?? 1;
+        if (playbackRate > 0 && playbackRate !== 1) audio.playbackRate = playbackRate;
+        session.audios.add(audio);
+
+        // Set up a single, removable abort listener — bounded by the
+        // playback lifetime of THIS audio element. Without this guard, every
+        // sentence would attach a listener to the session AbortSignal that
+        // never gets cleaned up, accumulating as memory pressure for long
+        // replies (50+ listeners on a single signal for a long roleplay
+        // reply).
+        let onAbort: (() => void) | null = null;
+        try {
+          await audio.play();
+        } catch (err) {
+          if (sessionRef.current === session) {
+            console.warn("[streaming-tts] play() rejected:", err);
+          }
+          // Clean up the orphaned URL/audio even on rejection.
+          session.audios.delete(audio);
+          try {
+            URL.revokeObjectURL(objectUrl);
+          } catch {
+            /* ignore */
+          }
+          session.objectUrls.delete(objectUrl);
+          return;
+        }
+
+        await new Promise<void>((resolve) => {
+          const cleanup = () => {
+            if (onAbort) session.abort.signal.removeEventListener("abort", onAbort);
+            audio.onended = null;
+            audio.onerror = null;
+            resolve();
+          };
+          audio.onended = cleanup;
+          audio.onerror = cleanup;
+          onAbort = () => {
+            try {
+              audio.pause();
+            } catch {
+              /* ignore */
+            }
+            cleanup();
+          };
+          if (session.abort.signal.aborted) {
+            onAbort();
+          } else {
+            session.abort.signal.addEventListener("abort", onAbort, { once: true });
+          }
+        });
+
+        session.audios.delete(audio);
+        try {
+          URL.revokeObjectURL(objectUrl);
+        } catch {
+          /* ignore */
+        }
+        session.objectUrls.delete(objectUrl);
+      });
+    }
+  };
+
+  useEffect(() => {
+    // Subscribe to every chat-store change. Cheap filtering inside ensures we
+    // only act on the relevant transitions for this chat. Using the un-typed
+    // subscribe form because the per-chat stream buffer lives in a Map whose
+    // reference is replaced on each token append in chat.store.ts.
+    const unsubscribe = useChatStore.subscribe((state) => {
+      // Track "is THIS chat currently streaming". When a stream ends,
+      // chat.store sets isStreaming=false AND streamingChatId=null in the
+      // same update — if we early-returned on the streamingChatId mismatch
+      // before updating isStreamingRef, the ref would stay stuck at `true`
+      // and the NEXT stream's rising-edge check would fail (wasStreaming=
+      // true, isStreaming=true → no session start). Update the ref FIRST,
+      // unconditionally, so it always reflects reality.
+      const isStreaming = state.isStreaming && state.streamingChatId === chatId;
+      const wasStreaming = isStreamingRef.current;
+      isStreamingRef.current = isStreaming;
+
+      if (!enabledRef.current) return;
+      if (!chatId) return;
+
+      const buffer = state.streamBuffers.get(chatId) ?? state.streamBuffer ?? "";
+
+      // Start session on rising edge of isStreaming for this chat. Prime the
+      // chunker cursor to the current buffer length so that if we joined an
+      // already-running stream (chat switch into a streaming chat), we only
+      // TTS new content from this point on — not the backlog.
+      if (isStreaming && !wasStreaming) {
+        stopSession();
+        const externalCtrl = state.abortControllers.get(chatId) ?? null;
+        const chunker = createChunkerState();
+        // Skip any pre-existing buffer content as backlog. We intentionally
+        // do NOT set highWaterMark here — it must start at 0 so the natural
+        // emission flow can grow it. Setting it to buffer.length at session
+        // start breaks regenerate: setStreaming(true) fires before
+        // clearStreamBuffer(), so the buffer still holds the previous reply
+        // — anchoring the hwm there would block emission until the new
+        // reply exceeds the old reply's length.
+        chunker.cursor = buffer.length;
+        const session: StreamSession = {
+          chatId,
+          chunker,
+          chain: Promise.resolve(),
+          abort: new AbortController(),
+          externalSignal: externalCtrl?.signal ?? null,
+          externalAbortListener: null,
+          objectUrls: new Set(),
+          audios: new Set(),
+        };
+        sessionRef.current = session;
+        // Expose this session's stop function so any UI element can call
+        // `stopStreamingTTS()` to halt playback (the chat's generation-
+        // abort path only fires WHILE the LLM is streaming; after natural
+        // completion, queued audio keeps playing with no way to interrupt
+        // unless a UI surface targets this handler).
+        activeStopHandler = stopSession;
+        notifyActiveChange();
+        // Tear down audio the instant the user clicks Stop, rather than
+        // waiting for isStreaming to flip (which can lag several hundred ms
+        // behind the abort while the server roundtrip + use-generate's
+        // finally block run). Without this, audio keeps playing after Stop.
+        if (session.externalSignal && !session.externalSignal.aborted) {
+          const listener = () => {
+            if (sessionRef.current === session) stopSession();
+          };
+          session.externalAbortListener = listener;
+          session.externalSignal.addEventListener("abort", listener, { once: true });
+        }
+      }
+
+      // End of stream — distinguish user-cancel from natural completion.
+      // If the chat's AbortController fired, the user clicked Stop; drop the
+      // partial last sentence on the floor and tear the session down.
+      if (!isStreaming && wasStreaming) {
+        const session = sessionRef.current;
+        if (!session) return;
+        const wasCancelled = session.externalSignal?.aborted === true;
+        if (wasCancelled) {
+          stopSession();
+        } else {
+          const tail = extractRemainder(buffer, session.chunker);
+          if (tail) pushText(tail);
+          // Once the queued audio finishes draining, clear the active-stop
+          // handle so UI elements (speaker icons) flip back from "stop" to
+          // "play". Without this, the icons stay stuck in stop-state after
+          // natural completion until a new stream begins.
+          session.chain = session.chain.then(() => {
+            if (sessionRef.current !== session) return;
+            sessionRef.current = null;
+            if (activeStopHandler === stopSession) {
+              activeStopHandler = null;
+              notifyActiveChange();
+            }
+          });
+        }
+        return;
+      }
+
+      // Mid-stream: emit any newly-completed sentences.
+      if (isStreaming) {
+        const session = sessionRef.current;
+        if (!session) return;
+        const newSentences = extractNewSentences(buffer, session.chunker);
+        if (newSentences) pushText(newSentences);
+      }
+    });
+
+    return () => {
+      unsubscribe();
+      stopSession();
+    };
+    // `stopSession` / `pushText` are intentionally not in the deps — they are
+    // closures over per-render refs and stable singletons. Adding them would
+    // re-subscribe to the chat store on every render, defeating the point of
+    // keying the subscription to chatId.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [chatId]);
+}

--- a/packages/client/src/lib/sentence-chunker.ts
+++ b/packages/client/src/lib/sentence-chunker.ts
@@ -1,0 +1,205 @@
+// ──────────────────────────────────────────────
+// Sentence chunker for streaming TTS
+// ──────────────────────────────────────────────
+//
+// Given a growing text buffer (from a streaming LLM), emit each newly
+// completed sentence as soon as it arrives so the client can dispatch TTS
+// before the model finishes. We deliberately keep the partial sentence at
+// the tail in reserve until either (a) a sentence-ending punctuation +
+// whitespace appears or (b) the caller flushes the remainder via
+// `extractRemainder()` when streaming ends.
+
+const SENTENCE_END_RE = /[.!?]+(?:["'”’)\]}])?(?=\s|$)/g;
+
+// Tokens that often precede a period but should NOT end a sentence.
+// Conservative list — over-eager exclusion would just delay TTS a bit.
+const ABBREVIATIONS = new Set([
+  "mr",
+  "mrs",
+  "ms",
+  "dr",
+  "st",
+  "prof",
+  "sr",
+  "jr",
+  "vs",
+  "etc",
+  "ie",
+  "eg",
+  "fig",
+  "no",
+]);
+
+function endsWithAbbreviation(text: string, periodIndex: number): boolean {
+  // Walk back from periodIndex to find the token ending there
+  let start = periodIndex;
+  while (start > 0 && /[A-Za-z]/.test(text[start - 1]!)) start -= 1;
+  const token = text.slice(start, periodIndex).toLowerCase();
+  return token.length > 0 && ABBREVIATIONS.has(token);
+}
+
+// Inline reasoning-block patterns that some models emit (chain-of-thought,
+// scratch-pad reasoning, etc.). The server strips these at end of stream via
+// content_replace, but mid-stream the client buffer still contains them.
+// We need to (a) pause emission while inside an UNCLOSED block, and
+// (b) strip CLOSED blocks from emitted text — otherwise TTS speaks the
+// model's reasoning aloud before it gets hidden.
+//
+// `[^>]*` allows attributes like `<thought type="cot">`. Backreference `\1`
+// ensures we match the corresponding closing tag.
+const THINKING_BLOCK_RE = /<(think|thinking|thought)\b[^>]*>[\s\S]*?<\/\1>/gi;
+// Special-token variants that some models emit (no XML close form).
+const SPECIAL_THINKING_BLOCK_RES = [
+  { open: /<\|think\|>/i, close: /<\|\/think\|>/i },
+  { open: /<\|channel>thought\b/i, close: /<channel\|>/i },
+];
+// Open-tag regex used to detect an UNCLOSED block in the tail. We test this
+// against a "masked" string where all CLOSED blocks have been replaced with
+// spaces of equal length, so we don't mistake the open tag of a closed pair
+// for an unclosed one.
+const THINKING_OPEN_TAG_RE = /<(think|thinking|thought)\b[^>]*>/i;
+
+/** Strip all closed thinking blocks from `text` (returns the stripped text). */
+function stripClosedThinkingBlocks(text: string): string {
+  let out = text.replace(THINKING_BLOCK_RE, "");
+  for (const { open, close } of SPECIAL_THINKING_BLOCK_RES) {
+    let openMatch = out.match(open);
+    while (openMatch && openMatch.index !== undefined) {
+      const rest = out.slice(openMatch.index + openMatch[0].length);
+      const closeMatch = rest.match(close);
+      if (!closeMatch || closeMatch.index === undefined) break;
+      const blockEnd = openMatch.index + openMatch[0].length + closeMatch.index + closeMatch[0].length;
+      out = out.slice(0, openMatch.index) + out.slice(blockEnd);
+      openMatch = out.match(open);
+    }
+  }
+  return out;
+}
+
+/** Return the position in `tail` where an UNCLOSED thinking block begins,
+ *  or `null` if no unclosed block is present. Mask CLOSED blocks first so
+ *  their open tags don't get reported as unclosed. */
+function findUnclosedThinkingStart(tail: string): number | null {
+  // Replace closed blocks with same-length space runs to preserve indices.
+  let masked = tail.replace(THINKING_BLOCK_RE, (m) => " ".repeat(m.length));
+  for (const { open, close } of SPECIAL_THINKING_BLOCK_RES) {
+    let openMatch = masked.match(open);
+    while (openMatch && openMatch.index !== undefined) {
+      const rest = masked.slice(openMatch.index + openMatch[0].length);
+      const closeMatch = rest.match(close);
+      if (!closeMatch || closeMatch.index === undefined) break;
+      const start = openMatch.index;
+      const blockLen = openMatch[0].length + closeMatch.index + closeMatch[0].length;
+      masked = masked.slice(0, start) + " ".repeat(blockLen) + masked.slice(start + blockLen);
+      openMatch = masked.match(open);
+    }
+  }
+  const m = masked.match(THINKING_OPEN_TAG_RE);
+  if (m && m.index !== undefined) return m.index;
+  for (const { open } of SPECIAL_THINKING_BLOCK_RES) {
+    const sm = masked.match(open);
+    if (sm && sm.index !== undefined) return sm.index;
+  }
+  return null;
+}
+
+export interface ChunkerState {
+  /** Number of chars already emitted as completed sentences. */
+  cursor: number;
+  /** Furthest buffer offset we have ever emitted to. Used to guard against
+   *  re-emitting content after the server fires a `content_replace` event
+   *  (use-generate.ts) — that rewinds the streamBuffer to a common prefix
+   *  and re-types the cleaned tail via the typewriter. Without this, the
+   *  chunker would emit sentences again as the buffer grows back and the
+   *  streaming-TTS hook would play them a second time. */
+  highWaterMark: number;
+}
+
+export function createChunkerState(): ChunkerState {
+  return { cursor: 0, highWaterMark: 0 };
+}
+
+/**
+ * Inspect the buffer and emit any newly-completed sentence(s) since the last
+ * call. Updates the cursor in place. Returns the joined new content (may
+ * contain multiple sentences if several completed in one buffer update).
+ */
+export function extractNewSentences(buffer: string, state: ChunkerState): string {
+  // Defensive: the server can replace the buffer mid-stream (content_replace
+  // event — e.g. when it strips inline thinking blocks at end-of-stream).
+  // If the buffer just got shorter than what we've already emitted, snap the
+  // cursor to the new length so we don't slice past the end. We accept the
+  // edge case that some content we already spoke may have been rewritten —
+  // it's preferable to losing the rest of the reply.
+  if (buffer.length < state.cursor) {
+    state.cursor = buffer.length;
+  }
+  // Never re-emit content past the high-water mark. After a `content_replace`
+  // rewind the cursor snaps to the smaller buffer length, but the typewriter
+  // is about to re-type the cleaned tail — we already spoke the original.
+  const startAt = Math.max(state.cursor, state.highWaterMark);
+  if (startAt >= buffer.length) return "";
+  const tail = buffer.slice(startAt);
+
+  // If the tail contains an UNCLOSED thinking block, treat the position of
+  // that open tag as the effective end of the scannable region — we never
+  // emit content past an unclosed thinking block (the model is still
+  // reasoning; once it closes, the server's content_replace will strip the
+  // block and our hwm guard prevents replay).
+  const unclosedAt = findUnclosedThinkingStart(tail);
+  const scannable = unclosedAt === null ? tail : tail.slice(0, unclosedAt);
+
+  // Find the last sentence end in the scannable region. We ship everything
+  // up to and including that end; what follows is the in-progress sentence
+  // and stays in reserve.
+  let lastEnd = -1;
+  for (const match of scannable.matchAll(SENTENCE_END_RE)) {
+    const localEnd = (match.index ?? 0) + match[0].length;
+    const absoluteEnd = startAt + localEnd;
+    const periodPos = (match.index ?? 0) + match[0].length - 1;
+    // Reject multi-dot ellipses ("..", "...", etc.) — continuations, not ends.
+    const matched = match[0];
+    const onlyDots = /^\.{2,}["'”’)\]}]?$/.test(matched);
+    if (onlyDots) continue;
+    if (endsWithAbbreviation(scannable, periodPos)) continue;
+    lastEnd = absoluteEnd;
+  }
+
+  if (lastEnd === -1) return "";
+
+  // Strip any CLOSED thinking blocks from the emitted text. The cursor still
+  // advances over the original byte positions (so we don't reprocess), but
+  // the TTS layer never sees the thinking content.
+  const rawSlice = buffer.slice(startAt, lastEnd);
+  const cleanSlice = stripClosedThinkingBlocks(rawSlice).trim();
+  state.cursor = lastEnd;
+  state.highWaterMark = lastEnd;
+  return cleanSlice;
+}
+
+/**
+ * Called once streaming has ended — return whatever is left in the buffer
+ * after the last sentence boundary. Updates the cursor to the buffer end.
+ */
+export function extractRemainder(buffer: string, state: ChunkerState): string {
+  if (buffer.length < state.cursor) {
+    state.cursor = buffer.length;
+  }
+  const startAt = Math.max(state.cursor, state.highWaterMark);
+  if (startAt >= buffer.length) {
+    state.cursor = buffer.length;
+    state.highWaterMark = buffer.length;
+    return "";
+  }
+  // Drop everything from any UNCLOSED thinking block onward — if the stream
+  // ended with the model still inside a thinking block, the tail is partial
+  // reasoning we should never speak.
+  const tail = buffer.slice(startAt);
+  const unclosedAt = findUnclosedThinkingStart(tail);
+  const usable = unclosedAt === null ? tail : tail.slice(0, unclosedAt);
+  // Strip any CLOSED thinking blocks from the usable tail too.
+  const remainder = stripClosedThinkingBlocks(usable).trim();
+  state.cursor = buffer.length;
+  state.highWaterMark = buffer.length;
+  return remainder;
+}

--- a/packages/client/src/lib/tts-dialogue.ts
+++ b/packages/client/src/lib/tts-dialogue.ts
@@ -1,6 +1,32 @@
 import type { TTSConfig } from "@marinara-engine/shared";
 import { DIALOGUE_QUOTE_CAPTURE_GROUP_PATTERN_SOURCE, stripSurroundingDialogueQuotes } from "./dialogue-quotes";
 
+/**
+ * Returns the HTMLAudioElement `playbackRate` to apply client-side based on
+ * the configured TTS provider.
+ *
+ * OpenAI's cloud TTS honors the `speed` parameter in `/v1/audio/speech`, so
+ * the audio comes back already time-stretched and no client-side override
+ * is needed (and would in fact double-apply, e.g. 1.5 * 1.5 = 2.25× speed).
+ * Most local OAI-compatible TTS servers (mlx-audio, openedai-speech, etc.)
+ * silently ignore the `speed` request param, so the audio arrives at 1×
+ * and the user's slider has no effect. For those we fall back to setting
+ * `audio.playbackRate` on the HTMLAudioElement, which preserves pitch by
+ * default in modern browsers.
+ *
+ * For non-OpenAI sources (ElevenLabs, PocketTTS), we trust the provider's
+ * own handling of duration / prosody and don't apply a client-side rate.
+ */
+export function clientSidePlaybackRate(cfg: TTSConfig | null | undefined): number {
+  if (!cfg || cfg.source !== "openai") return 1;
+  const baseUrl = (cfg.baseUrl || "").toLowerCase();
+  // Real OpenAI cloud — server already speed-stretched the audio.
+  if (baseUrl.includes("api.openai.com")) return 1;
+  // Local / custom OAI-compatible server — assume `speed` request param
+  // wasn't honored, apply client-side as a fallback.
+  return cfg.speed && cfg.speed > 0 ? cfg.speed : 1;
+}
+
 export interface TTSUtterance {
   text: string;
   speaker?: string;

--- a/packages/client/src/lib/tts-service.ts
+++ b/packages/client/src/lib/tts-service.ts
@@ -15,6 +15,11 @@ export interface TTSSpeakOptions {
   throwOnError?: boolean;
   cacheKey?: string;
   cacheAliases?: string[];
+  /** Override the HTMLAudioElement playback rate. Useful when the configured
+   *  TTS server ignores the `speed` request parameter (most local /v1/audio/speech
+   *  servers do — only OpenAI's cloud and a few others honor it). Pitch is
+   *  preserved by the browser. Defaults to 1.0 (no change). */
+  playbackRate?: number;
 }
 
 export interface TTSSpeakRequest {
@@ -152,6 +157,9 @@ class TTSService {
     this.currentObjectUrl = objectUrl;
 
     const audio = new Audio(objectUrl);
+    if (options.playbackRate && options.playbackRate > 0 && options.playbackRate !== 1) {
+      audio.playbackRate = options.playbackRate;
+    }
     this.audio = audio;
 
     audio.onended = () => {
@@ -185,7 +193,7 @@ class TTSService {
   async speakSequence(
     requests: TTSSpeakRequest[],
     id?: string,
-    options: Pick<TTSSpeakOptions, "signal" | "throwOnError"> = {},
+    options: Pick<TTSSpeakOptions, "signal" | "throwOnError" | "playbackRate"> = {},
   ): Promise<void> {
     const playableRequests = requests.filter((request) => request.text.trim().length > 0);
     if (playableRequests.length === 0) return;
@@ -260,6 +268,9 @@ class TTSService {
       this.currentObjectUrl = objectUrl;
 
       const audio = new Audio(objectUrl);
+      if (options.playbackRate && options.playbackRate > 0 && options.playbackRate !== 1) {
+        audio.playbackRate = options.playbackRate;
+      }
       this.audio = audio;
 
       audio.onended = () => {

--- a/packages/shared/src/types/tts.ts
+++ b/packages/shared/src/types/tts.ts
@@ -124,6 +124,15 @@ export const ttsConfigSchema = z.object({
   autoplayRP: z.boolean().default(false),
   autoplayConvo: z.boolean().default(false),
   autoplayGame: z.boolean().default(false),
+  /**
+   * When true, the client dispatches TTS per sentence as the model streams
+   * instead of waiting for the full reply. Reduces first-audio latency from
+   * "time-to-full-response" (5-30s) to "time-to-first-sentence" (1-2s).
+   * Each sentence becomes a separate /api/tts/speak call; audio chunks are
+   * queued and played sequentially. When this is on, the end-of-stream
+   * autoplay is suppressed to avoid playing the reply twice.
+   */
+  autoplayStreaming: z.boolean().default(false),
   dialogueOnly: z.boolean().default(false),
   audioFormat: ttsAudioFormatSchema.default("mp3"),
   dialogueScope: ttsDialogueScopeSchema.default("all"),


### PR DESCRIPTION
## Linked issue

Closes #1138

## Why this change

When auto-play is enabled, Marinara today waits for `isStreaming` to flip false before dispatching the entire reply to TTS. For local TTS providers (mlx-audio Chatterbox, openedai-speech, etc.) where synthesis is much slower than cloud APIs, this means the user waits the *full* generate time before hearing any audio. With a 30-second roleplay reply on a local M-series box, time-to-first-audio is 30+ seconds — the assistant has finished writing before it even starts speaking.

The information needed to start TTS much earlier is already available in the chat store: `streamBuffers` updates token-by-token as the LLM streams. We can split on sentence boundaries and dispatch each completed sentence as it arrives, then play the resulting clips sequentially. Time-to-first-audio drops to ~1-2 seconds (the time for the model to produce the first sentence plus one TTS round-trip).

## What changed

**Client — new streaming-TTS hook**

- `packages/client/src/hooks/use-streaming-tts.ts`: new `useStreamingTTS` hook subscribes to the chat store, runs a sentence chunker against the growing stream buffer, and dispatches `ttsService.generateAudio` per completed sentence. Audio fetches run in parallel; playback is serialized through a chained promise so order is preserved. Aborts cleanly on user-cancel (the existing chat-abort signal is forwarded, plus a local AbortController fires on `stopSession`). Per-audio AbortListener is bounded to that element's playback lifetime so long replies don't pile up 50+ listeners on a single signal.
- The hook exports a module-level `stopStreamingTTS()` / `isStreamingTTSActive()` / `subscribeStreamingTTSActive()` trio so any UI surface can interrupt or observe the active session — the per-message speaker icon hooks into this.

**Client — sentence chunker**

- `packages/client/src/lib/sentence-chunker.ts`: new module. Maintains a `cursor` + `highWaterMark` over the growing buffer; `extractNewSentences` emits each completed sentence as soon as a sentence-ending punctuation + whitespace appears. Multi-dot ellipses (`..`, `...`) are explicitly NOT treated as sentence ends (continuations, not terminators). Known abbreviations (`Mr.`, `Dr.`, etc.) are skipped. The high-water mark prevents replay if the server later emits a `content_replace` SSE event that rewinds the buffer to a common prefix (used to strip character commands at end-of-stream).

**Client — stop affordance on speaker icons**

- `packages/client/src/components/chat/ChatMessage.tsx`: every speaker icon subscribes to the streaming-TTS active state. While a session is active, the icon flips to `VolumeX`, shows "Stop streaming narration" as tooltip, and clicking any icon halts playback. The chat's generation-abort signal only fires *while* the LLM is streaming; without this affordance there's no way to interrupt audio after natural completion.

**Wiring**

- `packages/client/src/components/chat/ChatArea.tsx`: invokes `useStreamingTTS` when the chat is in a mode that supports autoplay and `ttsConfig.autoplayStreaming` is on. The legacy "speak the whole reply at end-of-stream" path is gated on `if (cfg.autoplayStreaming) return;` so the reply isn't spoken twice.
- `packages/client/src/components/panels/settings/TTSConfigCard.tsx`: adds the **"Stream as the model generates"** toggle under TTS settings (default off — no behavior change for existing users).
- `packages/shared/src/types/tts.ts`: adds `autoplayStreaming?: boolean` to `TTSConfig`.

## Known limitation

The speaker icon does **not** visually flip back to "play" after natural stream completion — it stays in stop-state until a new stream starts. Click-to-stop continues to function (clicking a stuck stop-icon is a safe no-op since there's nothing to stop). Will track in a follow-up; not blocking.

## Dependency

Includes #1141 (client-side playback rate) as a base commit so the streaming-TTS path can honor the speed slider too. Once #1141 merges, this PR's diff will shrink to just the streaming TTS changes.

## Validation

- [x] `pnpm check` passes locally

- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

> Generated PR — unchecked boxes are left for the merger to confirm manually per the repo's AI-PR guidance.

**What was verified on the branch (against a running Marinara dev server, local mlx-audio TTS, local Gemma 4 26B LLM, Roleplay mode with autoplay + streaming-TTS toggle on):**

- Streaming TTS fires per sentence during a long reply — first audio audible within ~1-2 seconds of model start.
- Pressing any speaker icon mid-stream halts audio (the chained playback queue stops at the current element).
- Regenerating a response correctly starts a fresh streaming-TTS session for the new reply (verified after fixing the cursor initialization race against `setStreaming(true) → clearStreamBuffer()`).
- Ellipses like `"But tell me, human..."` don't cause mid-sentence cuts; the chunker waits for a real terminator.
- Local Gemma's end-of-stream `content_replace` (strips character commands) no longer replays the cleaned tail — the high-water mark guards against re-emission.

**To verify in browser:**

- Enable "Stream as the model generates" in TTS settings, autoplay on, Roleplay mode.
- Send a message and confirm audio starts before the model finishes writing.
- Mid-stream, click the speaker icon on the streaming message — audio stops.
- Disable the toggle — behavior reverts to the existing "speak after stream ends" path.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

No new UI surface beyond the toggle in TTS settings. The speaker-icon swap (Volume2 ↔ VolumeX + sky-blue tint while streaming) is in-place, no new components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)