### PR TITLE
Fix game setup provider errors surfacing only in console

### DIFF
--- a/src/features/modes/game/components/GameSetupWizard.tsx
+++ b/src/features/modes/game/components/GameSetupWizard.tsx
@@ -38,6 +38,7 @@ import { useGameAssetStore } from "../stores/game-asset.store";
 import { useUIStore } from "../../../../shared/stores/ui.store";
 
 interface GameSetupWizardProps {
+  error?: string | null;
   onComplete: (
     config: GameSetupConfig,
     preferences: string,
@@ -267,7 +268,7 @@ function normalizeGameLanguage(language: string): string {
   return GAME_LANGUAGE_LOOKUP.get(trimmed.toLowerCase()) ?? trimmed;
 }
 
-export function GameSetupWizard({ onComplete, onCancel, isLoading, characters }: GameSetupWizardProps) {
+export function GameSetupWizard({ error, onComplete, onCancel, isLoading, characters }: GameSetupWizardProps) {
   const [step, setStep] = useState(0);
   const [gameName, setGameName] = useState("");
   const [genres, setGenres] = useState<string[]>(["Fantasy"]);
@@ -1658,6 +1659,17 @@ export function GameSetupWizard({ onComplete, onCancel, isLoading, characters }:
           Select a GM model on the &quot;You &amp; Model&quot; step before starting.
         </p>
       )}
+
+      {error ? (
+        <div
+          role="alert"
+          aria-live="polite"
+          className="rounded-lg border border-[var(--destructive)]/30 bg-[var(--destructive)]/10 px-3 py-2 text-xs text-[var(--destructive)]"
+        >
+          <p className="font-medium">Game setup failed</p>
+          <p className="mt-1 whitespace-pre-wrap text-[var(--foreground)]/80">{error}</p>
+        </div>
+      ) : null}
 
       {/* Footer */}
       <div className="flex items-center justify-between border-t border-[var(--border)]/30 pt-4">

--- a/src/features/modes/game/components/GameSurface.tsx
+++ b/src/features/modes/game/components/GameSurface.tsx
@@ -236,6 +236,11 @@ function isTimeoutError(error: unknown): error is TimeoutError {
   return error instanceof TimeoutError;
 }
 
+function getGameSetupFailureMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message : typeof error === "string" ? error : "";
+  return message.trim() || "Game setup failed. Check the selected model connection and try again.";
+}
+
 function withTimeout<T>(run: (signal: AbortSignal) => Promise<T>, ms: number, onTimeout?: () => void): Promise<T> {
   const controller = new AbortController();
   return new Promise<T>((resolve, reject) => {
@@ -1935,6 +1940,7 @@ export function GameSurface({
   const [viewedMapId, setViewedMapId] = useState<string | null>(null);
   const [startGameRequested, setStartGameRequested] = useState(false);
   const [startSessionRequested, setStartSessionRequested] = useState(false);
+  const [gameSetupFailure, setGameSetupFailure] = useState<string | null>(null);
   const [activeReadable, setActiveReadable] = useState<JournalReadable | null>(null);
   const readableQueueRef = useRef<JournalReadable[]>([]);
   const recentMusicHistoryRef = useRef<string[]>(normalizeRecentMusicHistory(chatMeta.gameRecentMusic));
@@ -4546,6 +4552,7 @@ export function GameSurface({
     gameSetupResetRef.current();
     startGameResetRef.current();
     startSessionResetRef.current();
+    setGameSetupFailure(null);
   }, [activeChatId]);
 
   const handleStartGameNow = useCallback(() => {
@@ -4581,6 +4588,14 @@ export function GameSurface({
     setJsonRepairRequest(request);
     return true;
   }, []);
+
+  const handleGameSetupFailure = useCallback(
+    (error: unknown) => {
+      if (handleJsonRepairError(error)) return;
+      setGameSetupFailure(getGameSetupFailureMessage(error));
+    },
+    [handleJsonRepairError],
+  );
 
   const handleGameDayChange = useCallback(
     async (day: number) => {
@@ -7250,7 +7265,9 @@ export function GameSurface({
     return (
       <>
         <GameSetupWizard
+          error={gameSetupFailure}
           onComplete={(config, preferences, conns, wizardGameName) => {
+            setGameSetupFailure(null);
             if (needsCreation) {
               // Create game structure first, then run setup
               createGame.mutate(
@@ -7270,19 +7287,21 @@ export function GameSurface({
                         preferences,
                         setupConfig: config,
                       },
-                      { onError: handleJsonRepairError },
+                      { onError: handleGameSetupFailure },
                     );
                   },
+                  onError: handleGameSetupFailure,
                 },
               );
             } else {
               gameSetup.mutate(
                 { chatId: activeChatId, connectionId: conns.gmConnectionId, preferences, setupConfig: config },
-                { onError: handleJsonRepairError },
+                { onError: handleGameSetupFailure },
               );
             }
           }}
           onCancel={() => {
+            setGameSetupFailure(null);
             if (needsCreation || sessionStatus === "setup") {
               // Delete the broken/empty game chat
               useChatStore.getState().setActiveChatId(null);


### PR DESCRIPTION
﻿## Summary

Fixes #1146.

When game setup fails during Start Game because the selected provider/connection returns an auth or config error, the New Game Setup modal now shows a persistent in-app error instead of relying on console/toast feedback only.

## Changes

- Store game setup failures in the Game mode surface during create/setup mutations.
- Pass the setup failure into the New Game Setup wizard.
- Render a clear `Game setup failed` alert with the provider error text inside the modal.

## Validation

- [ ] Reproduced the provider-auth failure before the fix during the refactor smoke test.
- [ ] Verified the setup modal now shows an in-app error after the fix.
- [ ] Verified GitHub-renderable evidence URLs return HTTP 200.
- [ ] `pnpm check:architecture` passed on `Pasta-Devs/Marinara-Engine` `refactor` worktree.
- [ ] `pnpm typecheck` passed on `Pasta-Devs/Marinara-Engine` `refactor` worktree.
- [ ] `pnpm check` passed on `Pasta-Devs/Marinara-Engine` `refactor` worktree.

## Evidence

Before: provider auth failure left the setup modal without a persistent in-modal error.

![Before provider auth failure](https://gist.githubusercontent.com/cha1latte/6929d153b5d78a3f409f82e16f187caf/raw/marinara-issue-1146-before.svg)

After: the setup modal shows `Game setup failed` with the provider error text.

![After provider auth failure](https://gist.githubusercontent.com/cha1latte/6929d153b5d78a3f409f82e16f187caf/raw/marinara-issue-1146-after.svg)

## Notes

The refactor work moved from `Pasta-Devs/Marinara-Engine-Refactor` to `Pasta-Devs/Marinara-Engine` branch `refactor`; this PR ports the already-verified two-file fix to the canonical branch.
