### PR TITLE
Fix refactor game segment unknown tag stripping

### DIFF
--- a/src/engine/modes/game/state/segment-edits.test.ts
+++ b/src/engine/modes/game/state/segment-edits.test.ts
@@ -14,6 +14,12 @@ describe("game segment edit command stripping", () => {
     ).toBe("Read this. [Note: nested [clue] text]");
   });
 
+  it("keeps unknown-looking text inside readable tag payloads", () => {
+    expect(stripGmCommandTags('[Note: Keep literal [debug: {"x":1}] text] [debug: {"drop":true}]')).toBe(
+      '[Note: Keep literal [debug: {"x":1}] text]',
+    );
+  });
+
   it("does not leak unknown nested tag fragments when applying segment edits", () => {
     const content = [
       'The room shifts. [debug: {"items":["torch"]}]',

--- a/src/engine/modes/game/state/segment-edits.test.ts
+++ b/src/engine/modes/game/state/segment-edits.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { applySegmentEdits, stripGmCommandTags } from "./segment-edits";
+
+describe("game segment edit command stripping", () => {
+  it("removes unknown balanced tags with nested JSON payloads", () => {
+    expect(stripGmCommandTags('The room shifts. [debug: {"items":["torch"]}] Continue forward.')).toBe(
+      "The room shifts.  Continue forward.",
+    );
+  });
+
+  it("keeps readable tags and ignores brackets inside quoted unknown tag values", () => {
+    expect(
+      stripGmCommandTags('Read this. [Note: nested [clue] text] [debug: {"text":"not ] done","items":["torch"]}]'),
+    ).toBe("Read this. [Note: nested [clue] text]");
+  });
+
+  it("does not leak unknown nested tag fragments when applying segment edits", () => {
+    const content = [
+      'The room shifts. [debug: {"items":["torch"]}]',
+      "",
+      "[Guide]: \"Keep moving.\"",
+    ].join("\n");
+
+    expect(applySegmentEdits(content, { 0: { content: "The room steadies." } })).toBe(
+      ['The room steadies.', '[Guide]: "Keep moving."'].join("\n\n"),
+    );
+  });
+});

--- a/src/engine/modes/game/state/segment-edits.ts
+++ b/src/engine/modes/game/state/segment-edits.ts
@@ -3,9 +3,8 @@ import { formatSkillCheckResultSummary } from "../../../shared/scoring/skill-che
 
 /**
  * Strip GM command tags from message content.
- * Mirrors the client's `stripGmTagsKeepReadables` (minus readable
- * preservation which is irrelevant for segment editing). Resolved skill checks
- * are preserved as plain text because the roll result is canonical history.
+ * Mirrors the client's `stripGmTagsKeepReadables`. Resolved skill checks are
+ * preserved as plain text because the roll result is canonical history.
  */
 export function stripGmCommandTags(content: string): string {
   let text = preserveResolvedSkillCheckResults(content)
@@ -154,7 +153,7 @@ function stripUnknownBracketTags(text: string, keep?: (tagName: string) => boole
       let cursor = index + 1;
       while (cursor < text.length && /[A-Za-z0-9_]/.test(text[cursor]!)) cursor += 1;
       const tagName = text.slice(index + 1, cursor);
-      if (cursor > index + 1 && text[cursor] === ":" && (!keep || !keep(tagName))) {
+      if (cursor > index + 1 && text[cursor] === ":") {
         let depth = 1;
         let inString: '"' | "'" | null = null;
         let escaped = false;
@@ -184,6 +183,9 @@ function stripUnknownBracketTags(text: string, keep?: (tagName: string) => boole
           }
         }
         if (end < text.length) {
+          if (keep?.(tagName)) {
+            out += text.slice(index, end + 1);
+          }
           index = end + 1;
           continue;
         }

--- a/src/engine/modes/game/state/segment-edits.ts
+++ b/src/engine/modes/game/state/segment-edits.ts
@@ -32,7 +32,7 @@ export function stripGmCommandTags(content: string): string {
   text = stripMapUpdateTag(text);
   text = stripBalancedTag(text, "[choices:");
   // Catch-all for unknown [tag: value] (but NOT [Name] or [Note:/Book:])
-  text = text.replace(/\[(?!Note:|Book:)\w+:[^\]]*\]/g, "");
+  text = stripUnknownBracketTags(text, (tagName) => /^note$/i.test(tagName) || /^book$/i.test(tagName));
   text = stripDanglingTagClosers(text);
   return text.trim();
 }
@@ -144,6 +144,55 @@ function stripBalancedTag(text: string, tagPrefix: string): string {
 
 function stripMapUpdateTag(text: string): string {
   return stripBalancedTag(text, "[map_update:").replace(/\[map_update:[^\r\n]*(?:\r?\n|$)/gi, "");
+}
+
+function stripUnknownBracketTags(text: string, keep?: (tagName: string) => boolean): string {
+  let out = "";
+  let index = 0;
+  while (index < text.length) {
+    if (text[index] === "[") {
+      let cursor = index + 1;
+      while (cursor < text.length && /[A-Za-z0-9_]/.test(text[cursor]!)) cursor += 1;
+      const tagName = text.slice(index + 1, cursor);
+      if (cursor > index + 1 && text[cursor] === ":" && (!keep || !keep(tagName))) {
+        let depth = 1;
+        let inString: '"' | "'" | null = null;
+        let escaped = false;
+        let end = cursor + 1;
+        for (; end < text.length; end += 1) {
+          const char = text[end]!;
+          if (escaped) {
+            escaped = false;
+            continue;
+          }
+          if (char === "\\") {
+            escaped = true;
+            continue;
+          }
+          if (inString) {
+            if (char === inString) inString = null;
+            continue;
+          }
+          if (char === '"' || char === "'") {
+            inString = char;
+            continue;
+          }
+          if (char === "[") depth += 1;
+          if (char === "]") {
+            depth -= 1;
+            if (depth === 0) break;
+          }
+        }
+        if (end < text.length) {
+          index = end + 1;
+          continue;
+        }
+      }
+    }
+    out += text[index];
+    index += 1;
+  }
+  return out;
 }
 
 // ── Segment parsing (mirrors client parseNarrationSegments indexing) ──


### PR DESCRIPTION
<!-- Target branch: `refactor` for this refactor-branch bugfix. -->
<!-- The default base in this UI may be `main`; this PR intentionally targets `refactor`. -->
<!-- See CONTRIBUTING.md § Branches. -->

## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #1149

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- Game segment edits on the refactor branch could leave dangling JSON fragments from unknown GM tags, polluting edited game history used by later turns.

## What changed

<!-- List the key changes in this PR -->

- Replaced the engine segment-edit unknown-tag regex with balanced, quote-aware bracket stripping.
- Added focused tests for nested JSON tags, Note preservation, quoted bracket handling, readable nested payload preservation, and the persisted segment-edit path.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Codex reproduced the issue before the fix with `pnpm exec vitest run src/engine/modes/game/state/segment-edits.test.ts`; the new tests failed because `}]` leaked from an unknown nested tag.
- Codex verified the original repro after the fix with `pnpm exec vitest run src/engine/modes/game/state/segment-edits.test.ts`; result: 1 test file passed, 4 tests passed.
- Codex addressed CodeRabbit's readable-payload follow-up by preserving kept `[Note: ...]` tags atomically, then reran the same targeted command; result: 1 test file passed, 4 tests passed.
- Codex ran `pnpm check`; result: passed, including architecture, frontend typecheck, Rust check, and docs.
- Codex ran the local proof gate against `scratch/bugfix-verification.json`; result: passed.
- Manual app click-through was not performed because this is engine-only segment edit string handling with direct unit coverage.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs or release metadata changes are needed for this engine-only bugfix.

## UI evidence (if applicable)

N/A - engine-only string handling; no visible UI state changed.
