### PR TITLE
Make profile imports atomic with rollback

### DIFF
--- a/src-tauri/crates/storage/src/lib.rs
+++ b/src-tauri/crates/storage/src/lib.rs
@@ -1,9 +1,12 @@
 use marinara_core::{ensure_object, new_id, now_iso, AppError, AppResult};
 use marinara_security::validate_collection_name;
 use serde_json::{json, Map, Value};
+use std::collections::HashSet;
 use std::fs;
+use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 #[derive(Clone)]
 pub struct FileStorage {
@@ -167,6 +170,14 @@ impl FileStorage {
         self.write_collection(collection, &rows)
     }
 
+    pub fn replace_all_many(&self, replacements: Vec<(&str, Vec<Value>)>) -> AppResult<()> {
+        let _guard = self
+            .lock
+            .lock()
+            .map_err(|_| AppError::new("lock_error", "Storage lock poisoned"))?;
+        self.replace_all_many_locked(replacements)
+    }
+
     pub fn clear_all(&self) -> AppResult<()> {
         let _guard = self
             .lock
@@ -216,6 +227,175 @@ impl FileStorage {
         fs::rename(tmp, path)?;
         Ok(())
     }
+
+    fn replace_all_many_locked(&self, replacements: Vec<(&str, Vec<Value>)>) -> AppResult<()> {
+        let transaction_id = storage_transaction_id();
+        let mut pending = Vec::new();
+        let mut seen_paths = HashSet::new();
+        let prepare_result = (|| -> AppResult<()> {
+            for (index, (collection, rows)) in replacements.iter().enumerate() {
+                let path = self.collection_path(collection)?;
+                if !seen_paths.insert(path.clone()) {
+                    return Err(AppError::invalid_input(format!(
+                        "Duplicate collection replacement: {collection}"
+                    )));
+                }
+                let existed = path_exists_no_follow(&path)?;
+                if let Some(parent) = path.parent() {
+                    fs::create_dir_all(parent)?;
+                }
+                let tmp = collection_transaction_path(&path, &transaction_id, index, "tmp")?;
+                let backup = collection_transaction_path(&path, &transaction_id, index, "backup")?;
+                pending.push(PendingCollectionReplacement {
+                    path,
+                    tmp,
+                    backup,
+                    existed,
+                });
+                let item = pending
+                    .last()
+                    .expect("pending collection replacement should exist");
+                fs::write(&item.tmp, serde_json::to_vec_pretty(rows)?)?;
+            }
+            Ok(())
+        })();
+        if let Err(error) = prepare_result {
+            cleanup_pending_collection_temps(&pending);
+            return Err(error);
+        }
+
+        let mut backed_up = Vec::new();
+        let mut installed = Vec::new();
+        let result = (|| -> AppResult<()> {
+            for (index, item) in pending.iter().enumerate() {
+                if !item.existed {
+                    continue;
+                }
+                fs::rename(&item.path, &item.backup)?;
+                backed_up.push(index);
+            }
+            for (index, item) in pending.iter().enumerate() {
+                fs::rename(&item.tmp, &item.path)?;
+                installed.push(index);
+            }
+            Ok(())
+        })();
+
+        if let Err(error) = result {
+            if let Err(rollback_error) =
+                rollback_collection_replacements(&pending, &backed_up, &installed)
+            {
+                cleanup_pending_collection_temps(&pending);
+                return Err(AppError::new(
+                    "storage_rollback_failed",
+                    format!(
+                        "{error}; additionally failed to roll back collection import: {rollback_error}"
+                    ),
+                ));
+            }
+            cleanup_pending_collection_transaction_files(&pending);
+            return Err(error);
+        }
+
+        cleanup_pending_collection_transaction_files(&pending);
+        Ok(())
+    }
+}
+
+struct PendingCollectionReplacement {
+    path: PathBuf,
+    tmp: PathBuf,
+    backup: PathBuf,
+    existed: bool,
+}
+
+fn rollback_collection_replacements(
+    pending: &[PendingCollectionReplacement],
+    backed_up: &[usize],
+    installed: &[usize],
+) -> AppResult<()> {
+    let mut first_error = None;
+    for index in installed.iter().rev() {
+        if let Err(error) = remove_path_if_exists(&pending[*index].path) {
+            first_error.get_or_insert(error);
+        }
+    }
+    for index in backed_up.iter().rev() {
+        let item = &pending[*index];
+        match path_exists_no_follow(&item.backup) {
+            Ok(true) => {}
+            Ok(false) => continue,
+            Err(error) => {
+                first_error.get_or_insert(error);
+                continue;
+            }
+        }
+        if let Err(error) = fs::rename(&item.backup, &item.path) {
+            first_error.get_or_insert(AppError::from(error));
+        }
+    }
+    if let Some(error) = first_error {
+        return Err(error);
+    }
+    Ok(())
+}
+
+fn cleanup_pending_collection_temps(pending: &[PendingCollectionReplacement]) {
+    for item in pending {
+        let _ = remove_path_if_exists(&item.tmp);
+    }
+}
+
+fn cleanup_pending_collection_transaction_files(pending: &[PendingCollectionReplacement]) {
+    for item in pending {
+        let _ = remove_path_if_exists(&item.tmp);
+        let _ = remove_path_if_exists(&item.backup);
+    }
+}
+
+fn collection_transaction_path(
+    path: &Path,
+    transaction_id: &str,
+    index: usize,
+    kind: &str,
+) -> AppResult<PathBuf> {
+    let file_name = path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .ok_or_else(|| AppError::invalid_input("Invalid collection path"))?;
+    Ok(path.with_file_name(format!(
+        "{file_name}.profile-import-{transaction_id}-{index}.{kind}"
+    )))
+}
+
+fn storage_transaction_id() -> String {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
+    format!("{}-{nonce}", std::process::id())
+}
+
+fn path_exists_no_follow(path: &Path) -> AppResult<bool> {
+    match fs::symlink_metadata(path) {
+        Ok(_) => Ok(true),
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn remove_path_if_exists(path: &Path) -> AppResult<()> {
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error.into()),
+    };
+    if metadata.is_dir() {
+        fs::remove_dir_all(path)?;
+    } else {
+        fs::remove_file(path)?;
+    }
+    Ok(())
 }
 
 pub fn record_id(value: &Value) -> Option<&str> {
@@ -240,4 +420,88 @@ pub fn merge_object_field(
     }
     object.insert("updatedAt".to_string(), Value::String(now_iso()));
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_storage_root(test_name: &str) -> PathBuf {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after epoch")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "marinara-storage-{test_name}-{}-{nonce}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&path).expect("temporary storage root should be created");
+        path
+    }
+
+    #[test]
+    fn replace_all_many_updates_multiple_collections() {
+        let root = temp_storage_root("replace-many");
+        let storage = FileStorage::new(&root).unwrap();
+
+        storage
+            .replace_all_many(vec![
+                ("characters", vec![json!({ "id": "character-1" })]),
+                ("personas", vec![json!({ "id": "persona-1" })]),
+            ])
+            .unwrap();
+
+        assert_eq!(storage.list("characters").unwrap()[0]["id"], "character-1");
+        assert_eq!(storage.list("personas").unwrap()[0]["id"], "persona-1");
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn replace_all_many_rejects_invalid_collection_before_replacing_anything() {
+        let root = temp_storage_root("replace-many-invalid");
+        let storage = FileStorage::new(&root).unwrap();
+        storage
+            .replace_all("characters", vec![json!({ "id": "old-character" })])
+            .unwrap();
+
+        let error = storage
+            .replace_all_many(vec![
+                ("characters", vec![json!({ "id": "new-character" })]),
+                ("../bad", vec![json!({ "id": "bad" })]),
+            ])
+            .expect_err("invalid collection should reject the batch");
+
+        assert_eq!(error.code, "invalid_input");
+        assert_eq!(
+            storage.list("characters").unwrap()[0]["id"],
+            "old-character"
+        );
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn replace_all_many_rejects_duplicate_collections_before_replacing_anything() {
+        let root = temp_storage_root("replace-many-duplicate");
+        let storage = FileStorage::new(&root).unwrap();
+        storage
+            .replace_all("characters", vec![json!({ "id": "old-character" })])
+            .unwrap();
+
+        let error = storage
+            .replace_all_many(vec![
+                ("characters", vec![json!({ "id": "new-character" })]),
+                ("characters", vec![json!({ "id": "duplicate-character" })]),
+            ])
+            .expect_err("duplicate collection should reject the batch");
+
+        assert_eq!(error.code, "invalid_input");
+        assert_eq!(
+            storage.list("characters").unwrap()[0]["id"],
+            "old-character"
+        );
+
+        fs::remove_dir_all(root).unwrap();
+    }
 }

--- a/src-tauri/src/commands/storage/profile.rs
+++ b/src-tauri/src/commands/storage/profile.rs
@@ -5,7 +5,7 @@ mod legacy;
 #[path = "profile/zip_import.rs"]
 mod zip_import;
 
-use self::assets::{profile_assets, restore_profile_assets};
+use self::assets::{profile_assets, restore_profile_assets, RestoredProfileAssets};
 use self::legacy::import_legacy_profile_tables;
 use self::zip_import::import_profile_zip;
 use super::shared::*;
@@ -137,7 +137,11 @@ fn import_profile_collections(
     collections: &Map<String, Value>,
 ) -> AppResult<Value> {
     let restored_assets = restore_profile_assets(state, data.get("assets"))?;
-    import_profile_collections_with_restored_assets(state, collections, restored_assets)
+    let restored_count = restored_assets.restored();
+    finish_profile_import_assets(
+        restored_assets,
+        import_profile_collections_with_restored_assets(state, collections, restored_count),
+    )
 }
 
 pub(super) fn import_profile_collections_with_restored_assets(
@@ -146,18 +150,43 @@ pub(super) fn import_profile_collections_with_restored_assets(
     restored_assets: usize,
 ) -> AppResult<Value> {
     let mut imported = Map::new();
+    let mut replacements = Vec::new();
     for collection in PROFILE_COLLECTIONS {
         let rows = collections
             .get(*collection)
             .and_then(Value::as_array)
             .cloned()
             .unwrap_or_default();
-        state.storage.replace_all(collection, rows.clone())?;
         imported.insert((*collection).to_string(), json!(rows.len()));
+        replacements.push((*collection, rows));
     }
+    state.storage.replace_all_many(replacements)?;
     imported.insert("files".to_string(), json!(restored_assets));
     insert_profile_import_aliases(&mut imported);
     Ok(json!({ "success": true, "imported": imported }))
+}
+
+fn finish_profile_import_assets(
+    restored_assets: RestoredProfileAssets,
+    result: AppResult<Value>,
+) -> AppResult<Value> {
+    match result {
+        Ok(value) => {
+            restored_assets.commit();
+            Ok(value)
+        }
+        Err(error) => {
+            if let Err(rollback_error) = restored_assets.rollback() {
+                return Err(AppError::new(
+                    "profile_import_rollback_failed",
+                    format!(
+                        "{error}; additionally failed to roll back profile assets: {rollback_error}"
+                    ),
+                ));
+            }
+            Err(error)
+        }
+    }
 }
 
 fn insert_profile_import_aliases(imported: &mut Map<String, Value>) {

--- a/src-tauri/src/commands/storage/profile/assets.rs
+++ b/src-tauri/src/commands/storage/profile/assets.rs
@@ -6,6 +6,7 @@ use serde_json::{json, Value};
 use std::fs::{self, File};
 use std::io::{Read, Seek, Write};
 use std::path::{Component, Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 const PROFILE_ASSET_DIRS: &[&str] = &[
     "avatars",
@@ -54,6 +55,174 @@ struct ProfileAssetRestore {
     source: ProfileAssetSource,
 }
 
+pub(super) struct RestoredProfileAssets {
+    restored: usize,
+    transaction: Option<ProfileAssetTransaction>,
+}
+
+struct ProfileAssetTransaction {
+    data_dir: PathBuf,
+    staging_root: PathBuf,
+    backup_root: PathBuf,
+    backed_up: Vec<&'static str>,
+    installed: Vec<&'static str>,
+    finished: bool,
+}
+
+impl RestoredProfileAssets {
+    pub(super) fn restored(&self) -> usize {
+        self.restored
+    }
+
+    pub(super) fn commit(mut self) {
+        if let Some(transaction) = self.transaction.take() {
+            transaction.commit();
+        }
+    }
+
+    pub(super) fn rollback(mut self) -> AppResult<()> {
+        if let Some(mut transaction) = self.transaction.take() {
+            transaction.rollback()?;
+        }
+        Ok(())
+    }
+}
+
+impl Drop for RestoredProfileAssets {
+    fn drop(&mut self) {
+        if let Some(mut transaction) = self.transaction.take() {
+            let _ = transaction.rollback();
+        }
+    }
+}
+
+impl ProfileAssetTransaction {
+    fn new(data_dir: &Path) -> AppResult<Self> {
+        fs::create_dir_all(data_dir)?;
+        let staging_root = create_profile_import_temp_dir(data_dir, "staging")?;
+        let backup_root = match create_profile_import_temp_dir(data_dir, "backup") {
+            Ok(path) => path,
+            Err(error) => {
+                let _ = remove_path_if_exists(&staging_root);
+                return Err(error);
+            }
+        };
+        Ok(Self {
+            data_dir: data_dir.to_path_buf(),
+            staging_root,
+            backup_root,
+            backed_up: Vec::new(),
+            installed: Vec::new(),
+            finished: false,
+        })
+    }
+
+    fn stage_bytes(&self, relative: &Path, bytes: &[u8]) -> AppResult<()> {
+        write_profile_asset_in_root(&self.staging_root, relative, bytes)
+    }
+
+    fn install(&mut self) -> AppResult<()> {
+        if let Err(error) = self.install_inner() {
+            return match self.rollback() {
+                Ok(()) => Err(error),
+                Err(rollback_error) => Err(AppError::new(
+                    "profile_asset_rollback_failed",
+                    format!(
+                        "{error}; additionally failed to roll back profile assets: {rollback_error}"
+                    ),
+                )),
+            };
+        }
+        Ok(())
+    }
+
+    fn install_inner(&mut self) -> AppResult<()> {
+        for dir in PROFILE_ASSET_DIRS {
+            let target = self.data_dir.join(dir);
+            if !path_exists_no_follow(&target)? {
+                continue;
+            }
+            let backup = self.backup_root.join(dir);
+            if let Some(parent) = backup.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            fs::rename(&target, &backup)?;
+            self.backed_up.push(*dir);
+        }
+
+        for dir in PROFILE_ASSET_DIRS {
+            let source = self.staging_root.join(dir);
+            if !path_exists_no_follow(&source)? {
+                continue;
+            }
+            let target = self.data_dir.join(dir);
+            if let Some(parent) = target.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            fs::rename(&source, &target)?;
+            self.installed.push(*dir);
+        }
+
+        remove_path_if_exists(&self.staging_root)?;
+        Ok(())
+    }
+
+    fn commit(mut self) {
+        self.finished = true;
+        let _ = remove_path_if_exists(&self.staging_root);
+        let _ = remove_path_if_exists(&self.backup_root);
+    }
+
+    fn rollback(&mut self) -> AppResult<()> {
+        if self.finished {
+            return Ok(());
+        }
+        self.finished = true;
+        let mut first_error = None;
+        for dir in self.installed.iter().rev() {
+            let target = self.data_dir.join(dir);
+            if let Err(error) = remove_path_if_exists(&target) {
+                first_error.get_or_insert(error);
+            }
+        }
+        for dir in self.backed_up.iter().rev() {
+            let backup = self.backup_root.join(dir);
+            match path_exists_no_follow(&backup) {
+                Ok(true) => {}
+                Ok(false) => continue,
+                Err(error) => {
+                    first_error.get_or_insert(error);
+                    continue;
+                }
+            }
+            let target = self.data_dir.join(dir);
+            if let Some(parent) = target.parent() {
+                if let Err(error) = fs::create_dir_all(parent) {
+                    first_error.get_or_insert(AppError::from(error));
+                    continue;
+                }
+            }
+            if let Err(error) = fs::rename(&backup, &target) {
+                first_error.get_or_insert(AppError::from(error));
+            }
+        }
+        let _ = remove_path_if_exists(&self.staging_root);
+        if let Some(error) = first_error {
+            return Err(error);
+        }
+        let _ = remove_path_if_exists(&self.backup_root);
+        Ok(())
+    }
+}
+
+impl Drop for ProfileAssetTransaction {
+    fn drop(&mut self) {
+        if !self.finished {
+            let _ = self.rollback();
+        }
+    }
+}
+
 pub(super) fn profile_assets(state: &AppState) -> AppResult<Vec<Value>> {
     let mut assets = Vec::new();
     for dir in PROFILE_ASSET_DIRS {
@@ -92,14 +261,14 @@ fn collect_profile_assets(root: &Path, relative: &Path, assets: &mut Vec<Value>)
 pub(super) fn restore_profile_assets(
     state: &AppState,
     raw_assets: Option<&Value>,
-) -> AppResult<usize> {
+) -> AppResult<RestoredProfileAssets> {
     restore_profile_json_assets(state, raw_assets, false)
 }
 
 pub(super) fn restore_legacy_profile_json_assets(
     state: &AppState,
     raw_assets: Option<&Value>,
-) -> AppResult<usize> {
+) -> AppResult<RestoredProfileAssets> {
     restore_profile_json_assets(state, raw_assets, true)
 }
 
@@ -107,7 +276,7 @@ fn restore_profile_json_assets(
     state: &AppState,
     raw_assets: Option<&Value>,
     allow_legacy_data_field: bool,
-) -> AppResult<usize> {
+) -> AppResult<RestoredProfileAssets> {
     restore_profile_json_assets_in_root(&state.data_dir, raw_assets, allow_legacy_data_field)
 }
 
@@ -115,28 +284,30 @@ fn restore_profile_json_assets_in_root(
     data_dir: &Path,
     raw_assets: Option<&Value>,
     allow_legacy_data_field: bool,
-) -> AppResult<usize> {
+) -> AppResult<RestoredProfileAssets> {
     let assets = decoded_profile_json_assets(raw_assets, allow_legacy_data_field)?;
-    clear_profile_asset_dirs(data_dir)?;
     let restored = assets.len();
+    let mut transaction = ProfileAssetTransaction::new(data_dir)?;
     for (relative, bytes) in assets {
-        write_profile_asset_in_root(data_dir, &relative, &bytes)?;
+        transaction.stage_bytes(&relative, &bytes)?;
     }
-    Ok(restored)
+    transaction.install()?;
+    Ok(RestoredProfileAssets {
+        restored,
+        transaction: Some(transaction),
+    })
 }
 
 fn decoded_profile_json_assets(
     raw_assets: Option<&Value>,
     allow_legacy_data_field: bool,
 ) -> AppResult<Vec<(PathBuf, Vec<u8>)>> {
-    let Some(assets) = raw_assets.and_then(Value::as_array) else {
+    let Some(assets) = profile_asset_manifest(raw_assets)? else {
         return Ok(Vec::new());
     };
     let mut decoded = Vec::new();
-    for asset in assets {
-        let Some(path) = asset.get("path").and_then(Value::as_str) else {
-            continue;
-        };
+    for (index, asset) in assets.iter().enumerate() {
+        let path = profile_asset_manifest_path(asset, index)?;
         if is_legacy_cleanup_backup_asset_path(path) {
             continue;
         }
@@ -150,7 +321,9 @@ fn decoded_profile_json_assets(
             asset.get("base64").and_then(Value::as_str)
         };
         let Some(raw_data) = raw_data else {
-            continue;
+            return Err(AppError::invalid_input(format!(
+                "Profile asset {path} is missing base64 data"
+            )));
         };
         let bytes = decode_profile_asset_data(raw_data)?;
         decoded.push((relative, bytes));
@@ -164,17 +337,17 @@ pub(super) fn restore_profile_zip_assets<R: Read + Seek>(
     names: &[String],
     profile_prefix: &str,
     raw_assets: Option<&Value>,
-) -> AppResult<usize> {
+) -> AppResult<RestoredProfileAssets> {
     let assets = decoded_profile_zip_assets(raw_assets, names, profile_prefix)?;
-    clear_profile_asset_dirs(&state.data_dir)?;
     let restored = assets.len();
+    let mut transaction = ProfileAssetTransaction::new(&state.data_dir)?;
     for asset in assets {
         match asset.source {
             ProfileAssetSource::Bytes(bytes) => {
-                write_profile_asset_in_root(&state.data_dir, &asset.relative, &bytes)?;
+                transaction.stage_bytes(&asset.relative, &bytes)?;
             }
             ProfileAssetSource::ZipEntry(entry_name) => {
-                let target = state.data_dir.join(asset.relative);
+                let target = transaction.staging_root.join(asset.relative);
                 if let Some(parent) = target.parent() {
                     fs::create_dir_all(parent)?;
                 }
@@ -189,7 +362,11 @@ pub(super) fn restore_profile_zip_assets<R: Read + Seek>(
             }
         }
     }
-    Ok(restored)
+    transaction.install()?;
+    Ok(RestoredProfileAssets {
+        restored,
+        transaction: Some(transaction),
+    })
 }
 
 fn decoded_profile_zip_assets(
@@ -197,14 +374,12 @@ fn decoded_profile_zip_assets(
     names: &[String],
     profile_prefix: &str,
 ) -> AppResult<Vec<ProfileAssetRestore>> {
-    let Some(assets) = raw_assets.and_then(Value::as_array) else {
+    let Some(assets) = profile_asset_manifest(raw_assets)? else {
         return Ok(Vec::new());
     };
     let mut decoded = Vec::new();
-    for asset in assets {
-        let Some(path) = asset.get("path").and_then(Value::as_str) else {
-            continue;
-        };
+    for (index, asset) in assets.iter().enumerate() {
+        let path = profile_asset_manifest_path(asset, index)?;
         if is_legacy_cleanup_backup_asset_path(path) {
             continue;
         }
@@ -218,11 +393,33 @@ fn decoded_profile_zip_assets(
         } else if let Some(entry_name) = zip_asset_entry_name(names, profile_prefix, path) {
             ProfileAssetSource::ZipEntry(entry_name)
         } else {
-            continue;
+            return Err(AppError::invalid_input(format!(
+                "Profile ZIP is missing asset file: {path}"
+            )));
         };
         decoded.push(ProfileAssetRestore { relative, source });
     }
     Ok(decoded)
+}
+
+fn profile_asset_manifest(raw_assets: Option<&Value>) -> AppResult<Option<&Vec<Value>>> {
+    match raw_assets {
+        None => Ok(None),
+        Some(Value::Array(assets)) => Ok(Some(assets)),
+        Some(_) => Err(AppError::invalid_input(
+            "Profile assets manifest must be an array",
+        )),
+    }
+}
+
+fn profile_asset_manifest_path(asset: &Value, index: usize) -> AppResult<&str> {
+    asset
+        .get("path")
+        .and_then(Value::as_str)
+        .filter(|path| !path.trim().is_empty())
+        .ok_or_else(|| {
+            AppError::invalid_input(format!("Profile asset entry {index} is missing path"))
+        })
 }
 
 pub(super) fn normalize_legacy_profile_asset_paths(state: &AppState, value: &mut Value) {
@@ -431,18 +628,46 @@ fn write_profile_asset_in_root(data_dir: &Path, relative: &Path, bytes: &[u8]) -
     Ok(())
 }
 
-fn clear_profile_asset_dirs(data_dir: &Path) -> AppResult<()> {
-    for dir in PROFILE_ASSET_DIRS {
-        let path = data_dir.join(dir);
-        if !path.exists() {
-            continue;
+fn create_profile_import_temp_dir(data_dir: &Path, kind: &str) -> AppResult<PathBuf> {
+    for attempt in 0..100 {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_nanos())
+            .unwrap_or_default();
+        let path = data_dir.join(format!(
+            ".profile-import-{kind}-{}-{nonce}-{attempt}",
+            std::process::id()
+        ));
+        match fs::create_dir(&path) {
+            Ok(()) => return Ok(path),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(error.into()),
         }
-        let metadata = fs::symlink_metadata(&path)?;
-        if metadata.is_dir() {
-            fs::remove_dir_all(path)?;
-        } else {
-            fs::remove_file(path)?;
-        }
+    }
+    Err(AppError::new(
+        "profile_import_temp_error",
+        "Could not create a unique profile import staging directory",
+    ))
+}
+
+fn path_exists_no_follow(path: &Path) -> AppResult<bool> {
+    match fs::symlink_metadata(path) {
+        Ok(_) => Ok(true),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn remove_path_if_exists(path: &Path) -> AppResult<()> {
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error.into()),
+    };
+    if metadata.is_dir() {
+        fs::remove_dir_all(path)?;
+    } else {
+        fs::remove_file(path)?;
     }
     Ok(())
 }
@@ -603,7 +828,7 @@ mod tests {
         let restored =
             restore_profile_json_assets_in_root(&data_dir, Some(&assets), false).unwrap();
 
-        assert_eq!(restored, 2);
+        assert_eq!(restored.restored(), 2);
         assert_eq!(
             fs::read(data_dir.join("avatars/new.png")).unwrap(),
             b"new avatar"
@@ -624,6 +849,7 @@ mod tests {
             b"keep"
         );
 
+        restored.commit();
         fs::remove_dir_all(data_dir).unwrap();
     }
 
@@ -646,6 +872,57 @@ mod tests {
             fs::read(data_dir.join("avatars/stale.png")).unwrap(),
             b"stale"
         );
+
+        fs::remove_dir_all(data_dir).unwrap();
+    }
+
+    #[test]
+    fn profile_asset_restore_rolls_back_when_import_fails_later() {
+        let data_dir = temp_data_dir("rollback-assets");
+        fs::create_dir_all(data_dir.join("avatars")).unwrap();
+        fs::write(data_dir.join("avatars/stale.png"), b"stale").unwrap();
+        let assets = json!([
+            {
+                "path": "avatars/new.png",
+                "base64": general_purpose::STANDARD.encode(b"new avatar"),
+            }
+        ]);
+
+        let restored =
+            restore_profile_json_assets_in_root(&data_dir, Some(&assets), false).unwrap();
+        assert_eq!(
+            fs::read(data_dir.join("avatars/new.png")).unwrap(),
+            b"new avatar"
+        );
+        assert!(!data_dir.join("avatars/stale.png").exists());
+
+        restored.rollback().unwrap();
+
+        assert_eq!(
+            fs::read(data_dir.join("avatars/stale.png")).unwrap(),
+            b"stale"
+        );
+        assert!(!data_dir.join("avatars/new.png").exists());
+
+        fs::remove_dir_all(data_dir).unwrap();
+    }
+
+    #[test]
+    fn unfinished_profile_asset_transaction_cleans_staging_on_drop() {
+        let data_dir = temp_data_dir("drop-cleans-staging");
+        let staging_root;
+        let backup_root;
+        {
+            let transaction = ProfileAssetTransaction::new(&data_dir).unwrap();
+            staging_root = transaction.staging_root.clone();
+            backup_root = transaction.backup_root.clone();
+            transaction
+                .stage_bytes(Path::new("avatars/staged.png"), b"staged")
+                .unwrap();
+        }
+
+        assert!(!staging_root.exists());
+        assert!(!backup_root.exists());
 
         fs::remove_dir_all(data_dir).unwrap();
     }
@@ -700,5 +977,40 @@ mod tests {
             }
             ProfileAssetSource::Bytes(_) => panic!("zip manifest should resolve to an entry"),
         }
+    }
+
+    #[test]
+    fn profile_json_assets_reject_manifest_entries_without_payload() {
+        let assets = json!([
+            {
+                "path": "avatars/missing-data.png",
+            }
+        ]);
+
+        let error = match decoded_profile_json_assets(Some(&assets), false) {
+            Ok(_) => panic!("missing JSON asset payload should reject the import"),
+            Err(error) => error,
+        };
+
+        assert_eq!(error.code, "invalid_input");
+        assert!(error.message.contains("missing-data.png"));
+    }
+
+    #[test]
+    fn profile_zip_assets_reject_manifest_entries_without_matching_file() {
+        let assets = json!([
+            {
+                "path": "avatars/missing-from-zip.png",
+            }
+        ]);
+        let names = Vec::new();
+
+        let error = match decoded_profile_zip_assets(Some(&assets), &names, "") {
+            Ok(_) => panic!("missing ZIP asset entry should reject the import"),
+            Err(error) => error,
+        };
+
+        assert_eq!(error.code, "invalid_input");
+        assert!(error.message.contains("missing-from-zip.png"));
     }
 }

--- a/src-tauri/src/commands/storage/profile/legacy.rs
+++ b/src-tauri/src/commands/storage/profile/legacy.rs
@@ -3,7 +3,7 @@ use super::super::{
     shared::{materialize_message_swipe_fields, non_negative_i64_value},
 };
 use super::assets::{normalize_legacy_profile_asset_paths, restore_legacy_profile_json_assets};
-use super::insert_profile_import_aliases;
+use super::{finish_profile_import_assets, insert_profile_import_aliases};
 use crate::state::AppState;
 use marinara_core::AppResult;
 use serde_json::{json, Map, Value};
@@ -62,7 +62,11 @@ pub(super) fn import_legacy_profile_tables(
 ) -> AppResult<Value> {
     let files = data.get("fileStorage").and_then(|value| value.get("files"));
     let restored_assets = restore_legacy_profile_json_assets(state, files)?;
-    import_legacy_profile_tables_with_restored_assets(state, tables, restored_assets)
+    let restored_count = restored_assets.restored();
+    finish_profile_import_assets(
+        restored_assets,
+        import_legacy_profile_tables_with_restored_assets(state, tables, restored_count),
+    )
 }
 
 pub(super) fn import_legacy_profile_tables_with_restored_assets(
@@ -71,6 +75,7 @@ pub(super) fn import_legacy_profile_tables_with_restored_assets(
     restored_assets: usize,
 ) -> AppResult<Value> {
     let mut imported = Map::new();
+    let mut replacements = Vec::new();
     for (table, collection) in LEGACY_PROFILE_TABLES {
         let mut rows = table_rows(tables, table);
         match *collection {
@@ -83,9 +88,10 @@ pub(super) fn import_legacy_profile_tables_with_restored_assets(
         for row in &mut rows {
             normalize_legacy_profile_asset_paths(state, row);
         }
-        state.storage.replace_all(collection, rows.clone())?;
         imported.insert((*collection).to_string(), json!(rows.len()));
+        replacements.push((*collection, rows));
     }
+    state.storage.replace_all_many(replacements)?;
     imported.insert("files".to_string(), json!(restored_assets));
     insert_profile_import_aliases(&mut imported);
     Ok(json!({ "success": true, "imported": imported }))

--- a/src-tauri/src/commands/storage/profile/zip_import.rs
+++ b/src-tauri/src/commands/storage/profile/zip_import.rs
@@ -1,6 +1,6 @@
 use super::assets::{normalize_zip_entry_name, restore_profile_zip_assets};
 use super::{
-    import_profile_collections_with_restored_assets,
+    finish_profile_import_assets, import_profile_collections_with_restored_assets,
     legacy::import_legacy_profile_tables_with_restored_assets,
 };
 use crate::state::AppState;
@@ -32,7 +32,11 @@ pub(super) fn import_profile_zip(state: &AppState, path: &Path) -> AppResult<Val
     if let Some(collections) = data.get("collections").and_then(Value::as_object) {
         let restored_assets =
             restore_profile_zip_assets(state, &mut archive, &names, &profile_prefix, files)?;
-        import_profile_collections_with_restored_assets(state, collections, restored_assets)
+        let restored_count = restored_assets.restored();
+        finish_profile_import_assets(
+            restored_assets,
+            import_profile_collections_with_restored_assets(state, collections, restored_count),
+        )
     } else {
         let tables = data
             .get("fileStorage")
@@ -45,7 +49,11 @@ pub(super) fn import_profile_zip(state: &AppState, path: &Path) -> AppResult<Val
             })?;
         let restored_assets =
             restore_profile_zip_assets(state, &mut archive, &names, &profile_prefix, files)?;
-        import_legacy_profile_tables_with_restored_assets(state, tables, restored_assets)
+        let restored_count = restored_assets.restored();
+        finish_profile_import_assets(
+            restored_assets,
+            import_legacy_profile_tables_with_restored_assets(state, tables, restored_count),
+        )
     }
 }
 


### PR DESCRIPTION
## Linked issue

No linked issue; PR requested directly.

## Why this change

Profile imports replace both persisted collections and managed asset directories. Before this branch, a failure partway through import could leave the profile in a mixed state, with some new data installed and old data already removed.

## What changed

- Added atomic multi-collection replacement in the Rust storage crate with rollback on install failure.
- Staged profile assets into temporary import directories, backed up existing managed asset directories, and commit or roll back the asset transaction with the collection import result.
- Tightened profile asset manifest validation so missing JSON payloads or missing ZIP asset entries fail before replacing existing assets.
- Covered JSON, ZIP, and legacy profile import paths through the same rollback-aware finishing flow.

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

Local validation run:

- `git diff --check origin/refactor...HEAD` passed with no whitespace errors.
- `cargo check --manifest-path src-tauri/Cargo.toml` passed.
- `cargo test --manifest-path src-tauri/Cargo.toml --workspace` passed.
- `pnpm check:architecture` passed.

### Manual verification notes

- Not run: native Tauri app profile import through Settings and the file picker.
- Not run: container runtime.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

Changelog: this is release-note-worthy import/storage behavior, but this `refactor` branch does not contain `CHANGELOG.md`, so no changelog file was updated.

## UI evidence (if applicable)

N/A; Rust storage/profile import behavior only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Profile imports now use atomic batch processing, ensuring all collections and assets are imported together with automatic error recovery.
  * Enhanced error handling prevents partial imports from leaving the application in an inconsistent state.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1153?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->