### PR TITLE
Fix Professor Mari action contract

### DIFF
--- a/src-tauri/src/commands/storage/mari.rs
+++ b/src-tauri/src/commands/storage/mari.rs
@@ -279,7 +279,16 @@ pub(crate) async fn professor_mari_prompt(state: &AppState, body: Value) -> AppR
     Ok(json!({
         "content": response.to_string(),
         "createdAt": chrono::Utc::now().to_rfc3339(),
+        "action": read_only_mari_action_contract(),
     }))
+}
+
+fn read_only_mari_action_contract() -> Value {
+    json!({
+        "type": "none",
+        "capability": "read_only",
+        "reason": "Professor Mari v1 can inspect the creative library but cannot create or edit records.",
+    })
 }
 
 fn autoagents_message_to_marinara(message: &ChatMessage) -> marinara_llm::LlmMessage {

--- a/src/engine/mari/mari-entry.ts
+++ b/src/engine/mari/mari-entry.ts
@@ -32,17 +32,67 @@ export type MariEntryRequest = {
   attachments?: MariAttachment[];
 };
 
+export const MARI_ACTION_ENTITIES = [
+  "characters",
+  "character-groups",
+  "personas",
+  "persona-groups",
+  "lorebooks",
+  "lorebook-entries",
+  "prompts",
+  "prompt-sections",
+  "prompt-groups",
+  "prompt-variables",
+] as const;
+
+export type MariActionEntity = (typeof MARI_ACTION_ENTITIES)[number];
+
+export type MariEntryAction =
+  | {
+      type: "none";
+      capability: "read_only";
+      reason: string;
+    }
+  | {
+      type: "create_record";
+      entity: MariActionEntity;
+      draft: Record<string, unknown>;
+      label?: string;
+      rationale?: string;
+    }
+  | {
+      type: "edit_record";
+      entity: MariActionEntity;
+      id: string;
+      patch: Record<string, unknown>;
+      label?: string;
+      rationale?: string;
+    };
+
+const MARI_READ_ONLY_REASON = "Professor Mari v1 can inspect the creative library but cannot create or edit records.";
+
+export const MARI_READ_ONLY_ACTION: MariEntryAction = {
+  type: "none",
+  capability: "read_only",
+  reason: MARI_READ_ONLY_REASON,
+};
+
 export type MariEntryResponse = {
   content: string;
   createdAt: string;
+  action: MariEntryAction;
+};
+
+export type MariGatewayResponse = Omit<MariEntryResponse, "action"> & {
+  action?: unknown;
 };
 
 export type MariGateway = {
-  prompt(input: MariEntryRequest): Promise<MariEntryResponse>;
+  prompt(input: MariEntryRequest): Promise<MariGatewayResponse>;
 };
 
 export async function runProfessorMariEntry(input: MariEntryRequest, gateway: MariGateway): Promise<MariEntryResponse> {
-  return gateway.prompt({
+  const response = await gateway.prompt({
     ...input,
     userMessage: input.userMessage.trim(),
     messages: input.messages.slice(),
@@ -50,4 +100,53 @@ export async function runProfessorMariEntry(input: MariEntryRequest, gateway: Ma
     connectionId: input.connectionId ?? null,
     persona: input.persona ?? null,
   });
+  return {
+    ...response,
+    action: normalizeMariEntryAction(response.action),
+  };
+}
+
+function normalizeMariEntryAction(value: unknown): MariEntryAction {
+  if (!isRecord(value)) return MARI_READ_ONLY_ACTION;
+  if (value.type === "none" && value.capability === "read_only") {
+    return {
+      type: "none",
+      capability: "read_only",
+      reason: typeof value.reason === "string" && value.reason.trim() ? value.reason : MARI_READ_ONLY_REASON,
+    };
+  }
+  if (value.type === "create_record" && isMariActionEntity(value.entity) && isRecord(value.draft)) {
+    return {
+      type: "create_record",
+      entity: value.entity,
+      draft: value.draft,
+      ...(typeof value.label === "string" ? { label: value.label } : {}),
+      ...(typeof value.rationale === "string" ? { rationale: value.rationale } : {}),
+    };
+  }
+  if (
+    value.type === "edit_record" &&
+    isMariActionEntity(value.entity) &&
+    typeof value.id === "string" &&
+    value.id.trim() &&
+    isRecord(value.patch)
+  ) {
+    return {
+      type: "edit_record",
+      entity: value.entity,
+      id: value.id,
+      patch: value.patch,
+      ...(typeof value.label === "string" ? { label: value.label } : {}),
+      ...(typeof value.rationale === "string" ? { rationale: value.rationale } : {}),
+    };
+  }
+  return MARI_READ_ONLY_ACTION;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isMariActionEntity(value: unknown): value is MariActionEntity {
+  return typeof value === "string" && MARI_ACTION_ENTITIES.includes(value as MariActionEntity);
 }

--- a/src/shared/api/mari-api.ts
+++ b/src/shared/api/mari-api.ts
@@ -1,9 +1,9 @@
-import type { MariEntryRequest, MariEntryResponse } from "../../engine/mari/mari-entry";
+import type { MariEntryRequest, MariGatewayResponse } from "../../engine/mari/mari-entry";
 import { invokeTauri } from "./tauri-client";
 
 export const mariApi = {
   prompt: (request: MariEntryRequest) =>
-    invokeTauri<MariEntryResponse>("professor_mari_prompt", {
+    invokeTauri<MariGatewayResponse>("professor_mari_prompt", {
       request,
     }),
 };


### PR DESCRIPTION
## What?

Adds an explicit Professor Mari action contract on the refactor branch. The response from `professor_mari_prompt` now includes an `action` field, and the TypeScript `runProfessorMariEntry` boundary normalizes that field before the shell UI consumes the response.

## Why?

Refs the old refactor issue: https://github.com/Pasta-Devs/Marinara-Engine-Refactor/issues/36

The previous path was implicitly read-only but only returned `content` and `createdAt`, so the UI boundary could not tell whether record create/edit support was intentionally absent or just missing from the response contract.

## How?

- Added `MariEntryAction` as a discriminated contract with a current `read_only` no-op action and guarded future `create_record` / `edit_record` shapes.
- Added runtime normalization for the Tauri gateway response so missing or malformed `action` values fall back to the read-only contract.
- Added the Rust response-side `action` field for Professor Mari with the same read-only reason.

## Testing?

Machine/Codex verification:

- `node scratch\issue-36-contract-proof.mjs before` reproduced the missing contract before the fix.
- `node scratch\issue-36-contract-proof.mjs after` passed after the fix and confirmed:
  - TypeScript response contract includes `action`.
  - The gateway normalizes the runtime action payload.
  - Action entities are validated before accepting create/edit actions.
  - Rust emits the read-only action field.
  - Rust does not register a create/edit mutation tool for Professor Mari.
- `$env:CARGO_TARGET_DIR='C:\tmp\me-refactor-issue-36-cargo-target'; pnpm check` passed:
  - `pnpm check:architecture`
  - `pnpm check:frontend`
  - `pnpm check:rust`
  - `pnpm check:docs`
- `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json` passed.
- Bunny review pass completed for the current diff.

Manual verification needed:

- None. This is a code contract change verified by the focused harness and full branch baseline.

## Screenshots

N/A. This is a non-UI contract fix.

## Anything Else?

The first direct `cargo check` against `src-tauri\target` hit Windows access-denied errors from stale/locked build output. Rerunning with a fresh `CARGO_TARGET_DIR` completed successfully, and the full `pnpm check` baseline passed with that target dir.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Professor Mari responses now explicitly indicate action capabilities, declaring whether operations are read-only, can create, or can edit content.

* **Improvements**
  * Improved response validation and normalization with automatic fallback to read-only mode for unsupported or malformed action payloads, ensuring robust handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1163?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->