### PR TITLE
Normalize boolish persisted config flags

### DIFF
--- a/src/engine/generation/context.ts
+++ b/src/engine/generation/context.ts
@@ -1,10 +1,11 @@
 import type { StorageGateway } from "../capabilities/storage";
-import { isRecord, parseRecord, readString, type JsonRecord } from "./runtime-records";
+import { boolish, isRecord, parseRecord, readString, type JsonRecord } from "./runtime-records";
 
 export function requireRecord(value: unknown, label: string): JsonRecord {
   if (isRecord(value)) return value;
   throw new Error(`${label} was not found`);
 }
+
 
 export async function resolveGenerationConnection(
   storage: StorageGateway,
@@ -19,7 +20,8 @@ export async function resolveGenerationConnection(
 
   const connections = await storage.list<JsonRecord>("connections");
   const selected =
-    connections.find((connection) => connection.isDefault === true || connection.default === true) ?? connections[0];
+    connections.find((connection) => boolish(connection.isDefault, false) || boolish(connection.default, false)) ??
+    connections[0];
   if (!selected) throw new Error("No LLM connection is configured");
   return selected;
 }

--- a/src/engine/modes/chat/core/summaries/auto-summary.service.ts
+++ b/src/engine/modes/chat/core/summaries/auto-summary.service.ts
@@ -2,6 +2,7 @@ import type { DaySummaryEntry, WeekSummaryEntry } from "../../../../contracts/ty
 import type { LlmGateway, LlmMessage } from "../../../../capabilities/llm";
 import type { StorageGateway } from "../../../../capabilities/storage";
 import type { BaseLLMProvider } from "../../../../generation-core/llm/base-provider.js";
+import { boolish } from "../../../../generation/runtime-records";
 import { stripConversationPromptTimestamps } from "./transcript-sanitize.js";
 
 export interface ConversationSummaryMessage {
@@ -80,6 +81,7 @@ function stringValue(value: unknown): string {
   return typeof value === "string" ? value : "";
 }
 
+
 function stringArray(value: unknown): string[] {
   if (Array.isArray(value)) return value.filter((item): item is string => typeof item === "string" && item.trim().length > 0);
   if (typeof value === "string") {
@@ -155,7 +157,9 @@ async function resolveSummaryConnection(
     return connection;
   }
   const connections = await storage.list<JsonRecord>("connections");
-  const selected = connections.find((connection) => connection.isDefault === true || connection.default === true) ?? connections[0];
+  const selected =
+    connections.find((connection) => boolish(connection.isDefault, false) || boolish(connection.default, false)) ??
+    connections[0];
   if (!selected) throw new Error("No API connection configured for this chat");
   return selected;
 }

--- a/src/engine/modes/chat/schedules/schedule.service.ts
+++ b/src/engine/modes/chat/schedules/schedule.service.ts
@@ -1,6 +1,7 @@
 import type { LlmGateway, LlmMessage } from "../../../capabilities/llm";
 import type { StorageGateway } from "../../../capabilities/storage";
 import { parseJsonArray, parseJsonObject } from "../../../core/json";
+import { boolish } from "../../../generation/runtime-records";
 import type { BaseLLMProvider, ChatMessage } from "../../../generation-core/llm/base-provider.js";
 
 // ── Types ──
@@ -543,10 +544,11 @@ function toLlmMessage(message: ChatMessage): LlmMessage {
   return { role, content: String(message.content ?? ""), name: message.name };
 }
 
+
 async function resolveScheduleConnection(storage: StorageGateway, chatConnectionId: string): Promise<JsonRecord> {
   const connections = await storage.list<JsonRecord>("connections");
   if (chatConnectionId === "random") {
-    const pool = connections.filter((connection) => connection.useForRandom === true);
+    const pool = connections.filter((connection) => boolish(connection.useForRandom, false));
     const selected = pool[Math.floor(Math.random() * pool.length)];
     if (!selected) throw new Error("No connections marked for the random pool");
     return selected;
@@ -557,7 +559,8 @@ async function resolveScheduleConnection(storage: StorageGateway, chatConnection
     return connection;
   }
   const selected =
-    connections.find((connection) => connection.isDefault === true || connection.default === true) ?? connections[0];
+    connections.find((connection) => boolish(connection.isDefault, false) || boolish(connection.default, false)) ??
+    connections[0];
   if (!selected) throw new Error("No connection configured");
   return selected;
 }

--- a/src/engine/modes/roleplay/scene/scene-service.ts
+++ b/src/engine/modes/roleplay/scene/scene-service.ts
@@ -1,6 +1,7 @@
 import type { LlmGateway } from "../../../capabilities/llm";
 import type { StorageGateway } from "../../../capabilities/storage";
 import { parseJsonArray, parseJsonObject } from "../../../core/json";
+import { boolish } from "../../../generation/runtime-records";
 import { parseGameJsonish } from "../../../shared/parsing-jsonish";
 import type { SceneAnalysis, SceneCreateRequest, SceneCreateResponse, SceneForkRequest, SceneForkResponse, SceneFullPlan, ScenePlanRequest, ScenePlanResponse } from "../../../contracts/types/scene";
 import {
@@ -587,6 +588,7 @@ function buildForkContinuityMessage(sceneMeta: JsonRecord): string | null {
   return ["Hidden continuity carried from the original scene branch.", "", ...lines].join("\n");
 }
 
+
 async function resolveConnectionId(
   storage: StorageGateway,
   chat: JsonRecord,
@@ -596,14 +598,15 @@ async function resolveConnectionId(
   const chatConnectionId = stringValue(chat.connectionId).trim();
   const connections = await storage.list<JsonRecord>("connections");
   if (chatConnectionId === "random") {
-    const pool = connections.filter((connection) => connection.useForRandom === true);
+    const pool = connections.filter((connection) => boolish(connection.useForRandom, false));
     const selected = pool[Math.floor(Math.random() * pool.length)];
     if (!selected?.id) throw new Error("No connections marked for the random pool");
     return stringValue(selected.id);
   }
   if (chatConnectionId) return chatConnectionId;
   const selected =
-    connections.find((connection) => connection.isDefault === true || connection.default === true) ?? connections[0];
+    connections.find((connection) => boolish(connection.isDefault, false) || boolish(connection.default, false)) ??
+    connections[0];
   const id = stringValue(selected?.id);
   if (!id) throw new Error("No connection configured");
   return id;

--- a/src/features/catalog/chats/hooks/use-chats.ts
+++ b/src/features/catalog/chats/hooks/use-chats.ts
@@ -4,6 +4,7 @@
 import { useQuery, useInfiniteQuery, useMutation, useQueryClient, type InfiniteData } from "@tanstack/react-query";
 import { chatKeys } from "../query-keys";
 import { previewGenerationPrompt } from "../../../../engine/generation/prompt-preview";
+import { boolish } from "../../../../engine/generation/runtime-records";
 import { backfillConversationSummaries } from "../../../../engine/modes/chat/core/summaries/auto-summary.service";
 import { appendChatSummaryEntryToMetadata } from "../../../../engine/shared/text/chat-summary-entries";
 import { llmApi } from "../../../../shared/api/llm-api";
@@ -699,6 +700,7 @@ function messageHiddenFromAi(message: Message) {
   return extra.hiddenFromAI === true || extra.hiddenFromAi === true;
 }
 
+
 function compactTranscript(messages: Message[]) {
   return messages
     .map((message, index) => {
@@ -712,7 +714,8 @@ async function resolveSummaryConnectionId(chat: Chat): Promise<string> {
   if (typeof chat.connectionId === "string" && chat.connectionId.trim()) return chat.connectionId.trim();
   const connections = await storageApi.list<Record<string, unknown>>("connections");
   const selected =
-    connections.find((connection) => connection.isDefault === true || connection.default === true) ?? connections[0];
+    connections.find((connection) => boolish(connection.isDefault, false) || boolish(connection.default, false)) ??
+    connections[0];
   const connectionId = typeof selected?.id === "string" ? selected.id.trim() : "";
   if (!connectionId) throw new Error("No API connection configured for summary generation.");
   return connectionId;

--- a/src/features/catalog/presets/components/PresetsPanel.tsx
+++ b/src/features/catalog/presets/components/PresetsPanel.tsx
@@ -13,6 +13,7 @@ import { showConfirmDialog } from "../../../../shared/lib/app-dialogs";
 import { ChoiceSelectionModal } from "./ChoiceSelectionModal";
 import { Plus, Download, FileText, Trash2, Check, Copy, Search, Code2, Hash, Star } from "lucide-react";
 import { cn } from "../../../../shared/lib/utils";
+import { boolish } from "../../../../engine/generation/runtime-records";
 
 type PresetRow = {
   id: string;
@@ -23,6 +24,7 @@ type PresetRow = {
   author?: string;
   sectionOrder?: string | string[];
 };
+
 
 export function PresetsPanel() {
   const { data: presets, isLoading } = usePresets();
@@ -277,7 +279,7 @@ export function PresetsPanel() {
           const isBulkSelected = selectedPresetIds.has(preset.id);
           const sectionCount = getSectionCount(preset);
           const wrapFormat = (preset.wrapFormat ?? "xml") as string;
-          const isDefault = preset.isDefault === "true";
+          const isDefault = boolish(preset.isDefault ?? (preset as PresetRow & { default?: unknown }).default, false);
 
           return (
             <div

--- a/src/features/catalog/presets/hooks/use-presets.ts
+++ b/src/features/catalog/presets/hooks/use-presets.ts
@@ -3,6 +3,7 @@
 // ──────────────────────────────────────────────
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { previewGenerationPrompt } from "../../../../engine/generation/prompt-preview";
+import { boolish } from "../../../../engine/generation/runtime-records";
 import { storageApi } from "../../../../shared/api/storage-api";
 import { storageCommandsApi } from "../../../../shared/api/storage-commands-api";
 import type { PromptPreset, PromptGroup, PromptSection, ChoiceBlock, GenerationParameters, ChatMLMessage } from "../../../../engine/contracts/types/prompt";
@@ -169,7 +170,13 @@ export function useDefaultPreset() {
     queryKey: presetKeys.default(),
     queryFn: async () => {
       const presets = await storageApi.list<PromptPreset>("prompts");
-      return presets.find((preset) => (preset as PromptPreset & { default?: boolean }).isDefault || (preset as PromptPreset & { default?: boolean }).default) ?? null;
+      return (
+        presets.find(
+          (preset) =>
+            boolish((preset as PromptPreset & { default?: unknown }).isDefault, false) ||
+            boolish((preset as PromptPreset & { default?: unknown }).default, false),
+        ) ?? null
+      );
     },
     staleTime: 5 * 60_000,
   });

--- a/src/features/modes/shared/chat-ui/components/ChatSettingsDrawer.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatSettingsDrawer.tsx
@@ -128,6 +128,7 @@ import { LIMITS } from "../../../../../engine/contracts/constants/defaults";
 import { DEFAULT_IMPERSONATE_PROMPT } from "../../../../../engine/contracts/constants/impersonate";
 import { BUILT_IN_AGENTS, BUILT_IN_TOOLS, DEFAULT_AGENT_CONTEXT_SIZE, DEFAULT_AGENT_TOOLS, DEFAULT_AGENT_MAX_TOKENS, MAX_AGENT_MAX_TOKENS, MIN_AGENT_MAX_TOKENS, getDefaultBuiltInAgentSettings } from "../../../../../engine/contracts/types/agent";
 import { estimateAgentLoadCost, AGENT_COST_HIGH_CALLS, AGENT_COST_HIGH_TOKENS } from "../../../../../engine/shared/scoring/agent-cost";
+import { boolish as isEnabledFlag } from "../../../../../engine/generation/runtime-records";
 import type { CharacterGroup } from "../../../../../engine/contracts/types/character";
 import type { Chat } from "../../../../../engine/contracts/types/chat";
 import type { Lorebook } from "../../../../../engine/contracts/types/lorebook";
@@ -253,9 +254,6 @@ function normalizeSpriteDisplayValue(value: unknown, fallback: number, min: numb
   return Math.max(min, Math.min(max, numeric));
 }
 
-function isEnabledFlag(value: unknown): boolean {
-  return value === true || value === "true" || value === "1";
-}
 
 function normalizeNonNegativeInteger(value: unknown, fallback: number, max: number): number {
   if (typeof value !== "number" || !Number.isFinite(value)) return fallback;

--- a/src/features/modes/shared/chat-ui/components/QuickConnectionSwitcher.tsx
+++ b/src/features/modes/shared/chat-ui/components/QuickConnectionSwitcher.tsx
@@ -8,6 +8,8 @@ import { useUpdateChat, useChat } from "../../../../catalog/chats/index";
 import { useChatStore } from "../../../../../shared/stores/chat.store";
 import { filterLanguageGenerationConnections } from "../../../../../shared/lib/connection-filters";
 import { cn } from "../../../../../shared/lib/utils";
+import { boolish as isRandomPoolEnabled } from "../../../../../engine/generation/runtime-records";
+
 
 export function QuickConnectionSwitcher({ className }: { className?: string }) {
   const [open, setOpen] = useState(false);
@@ -23,7 +25,7 @@ export function QuickConnectionSwitcher({ className }: { className?: string }) {
   const isRandom = activeConnectionId === "random";
 
   const sorted = filterLanguageGenerationConnections(
-    (connections ?? []) as Array<{ id: string; name: string; provider?: string; useForRandom?: string }>,
+    (connections ?? []) as Array<{ id: string; name: string; provider?: string; useForRandom?: string | boolean | null }>,
   ).sort((a, b) => (a.name || "").localeCompare(b.name || ""));
 
   const handleSwitch = useCallback(
@@ -120,7 +122,7 @@ export function QuickConnectionSwitcher({ className }: { className?: string }) {
           </div>
           <div className="overflow-y-auto p-1">
             {sorted.map((conn) => {
-              const inPool = conn.useForRandom === "true";
+              const inPool = isRandomPoolEnabled(conn.useForRandom);
               const isActive = activeConnectionId === conn.id;
               if (isRandom) {
                 return (

--- a/src/features/modes/shared/chat-ui/components/QuickSwitcherMobile.tsx
+++ b/src/features/modes/shared/chat-ui/components/QuickSwitcherMobile.tsx
@@ -11,6 +11,7 @@ import { useUpdateChat, useChat } from "../../../../catalog/chats/index";
 import { useChatStore } from "../../../../../shared/stores/chat.store";
 import { filterLanguageGenerationConnections } from "../../../../../shared/lib/connection-filters";
 import { cn, getAvatarCropStyle, parseAvatarCropJson } from "../../../../../shared/lib/utils";
+import { boolish as isRandomPoolEnabled } from "../../../../../engine/generation/runtime-records";
 
 interface Persona {
   id: string;
@@ -35,6 +36,7 @@ interface ParsedGroup {
   members: Persona[];
 }
 
+
 export function QuickSwitcherMobile() {
   const [open, setOpen] = useState(false);
   const [tab, setTab] = useState<"connections" | "personas">("connections");
@@ -54,7 +56,7 @@ export function QuickSwitcherMobile() {
   const isRandom = activeConnectionId === "random";
 
   const sortedConnections = filterLanguageGenerationConnections(
-    (connections ?? []) as Array<{ id: string; name: string; provider?: string; useForRandom?: string }>,
+    (connections ?? []) as Array<{ id: string; name: string; provider?: string; useForRandom?: string | boolean | null }>,
   ).sort((a, b) => (a.name || "").localeCompare(b.name || ""));
 
   const sortedPersonas = ((rawPersonas ?? []) as Persona[])
@@ -290,7 +292,7 @@ export function QuickSwitcherMobile() {
                 </button>
                 <div className="mx-2 my-1 h-px bg-[var(--border)]" />
                 {sortedConnections.map((conn) => {
-                  const inPool = conn.useForRandom === "true";
+                  const inPool = isRandomPoolEnabled(conn.useForRandom);
                   const isActive = activeConnectionId === conn.id;
                   if (isRandom) {
                     return (

--- a/src/features/shell/connections/components/ConnectionsPanel.tsx
+++ b/src/features/shell/connections/components/ConnectionsPanel.tsx
@@ -38,6 +38,7 @@ import {
   Pencil,
 } from "lucide-react";
 import { cn } from "../../../../shared/lib/utils";
+import { boolish } from "../../../../engine/generation/runtime-records";
 import { TTSConfigCard } from "../../../shell/settings/index";
 
 /** Provider → gradient color pair for connection icons. */
@@ -64,9 +65,10 @@ type ConnectionRowData = {
   name: string;
   provider: string;
   model: string;
-  useForRandom?: string;
+  useForRandom?: string | boolean | null;
   folderId?: string | null;
 };
+
 
 function ConnectionRow({
   conn,
@@ -86,7 +88,7 @@ function ConnectionRow({
   const updateConnection = useUpdateConnection();
   const openConnectionDetail = useUIStore((s) => s.openConnectionDetail);
 
-  const inRandomPool = conn.useForRandom === "true";
+  const inRandomPool = boolish(conn.useForRandom, false);
   const colors = PROVIDER_COLORS[conn.provider] ?? DEFAULT_COLOR;
 
   return (


### PR DESCRIPTION
Migrated from Pasta-Devs/Marinara-Engine-Refactor#17: https://github.com/Pasta-Devs/Marinara-Engine-Refactor/pull/17
Original author: @Promansis
Target base: Pasta-Devs/Marinara-Engine refactor
Source draft state: False
Verification after port: `pnpm typecheck`
Port note: source updates/ tracker/evidence files were omitted because the target refactor branch removed repo-local updates guidance.

---

## Summary

- Normalize persisted boolish reads for connection random-pool membership across connection UI, quick switchers, and dependent random/default connection resolvers.
- Normalize prompt preset default reads so boolean defaults show the default badge and are found by default preset lookup.
- Record local bug ownership/status for the two boolean configuration issues.

## Root Cause

Some persisted configuration readers only treated string `"true"` as enabled, while current writers and engine contracts use boolean `true`. That made UI state and resolver state diverge for random-pool membership and prompt preset defaults.

## Validation

- `pnpm typecheck`
- `git diff --check`
- Searched for remaining strict `useForRandom`, `isDefault`, and `default` equality checks in `src/features` and `src/engine`.
