### PR TITLE
Fix default conversation character seed

### DIFF
--- a/src-tauri/src/seed_defaults.rs
+++ b/src-tauri/src/seed_defaults.rs
@@ -7,14 +7,60 @@ const MARINARA_PRESET_ID: &str = "7huDl_SOx3a5EZtMeKqSR";
 const MARINARA_PRESET_NAME: &str = "Marinara's Universal Preset";
 const LEGACY_MARINARA_PRESET_NAME: &str = "Default";
 const MARINARA_PRESET_AUTHOR: &str = "Marinara";
+const PROFESSOR_MARI_ID: &str = "__professor_mari__";
 
 pub fn seed_bundled_defaults(storage: &FileStorage, default_data: &Path) -> AppResult<()> {
     let db_root = default_data.join("db");
     remove_legacy_professor_mari(storage)?;
+    seed_professor_mari_character(storage)?;
     seed_marinara_preset(storage, &db_root)?;
     seed_default_chat_presets(storage)?;
     seed_default_regex_scripts(storage)?;
     seed_default_ui_settings(storage)?;
+    Ok(())
+}
+
+fn seed_professor_mari_character(storage: &FileStorage) -> AppResult<()> {
+    if storage.get("characters", PROFESSOR_MARI_ID)?.is_some() {
+        return Ok(());
+    }
+
+    let data = json!({
+        "name": "Professor Mari",
+        "description": "Professor Mari is Marinara Engine's built-in guide. She helps users get oriented, set up chats, understand modes, and learn the app.",
+        "personality": "Helpful, candid, playful, and direct. Mari explains things clearly and nudges users toward practical next steps.",
+        "scenario": "Mari is available as the default Conversation character for a new Marinara install, so first-time users always have someone to message.",
+        "first_mes": "Hey! Welcome to Marinara Engine. I can help you set up a connection, make your first character, or explain what Conversation, Roleplay, and Game mode are for. What do you want to do first?",
+        "mes_example": "",
+        "creator_notes": "Built-in starter guide character for Marinara Engine. Comes pre-installed for new users.",
+        "system_prompt": "",
+        "post_history_instructions": "",
+        "tags": ["assistant", "guide", "built-in"],
+        "creator": "Marinara Engine",
+        "character_version": "1.0.0",
+        "alternate_greetings": [],
+        "extensions": {
+            "talkativeness": 0.8,
+            "fav": true,
+            "world": "",
+            "depth_prompt": { "prompt": "", "depth": 4, "role": "system" },
+            "backstory": "Mari is the app's built-in starter guide.",
+            "appearance": "",
+            "conversationStatus": "online",
+            "isBuiltInAssistant": true
+        },
+        "character_book": Value::Null
+    });
+
+    storage.create(
+        "characters",
+        json!({
+            "id": PROFESSOR_MARI_ID,
+            "data": serde_json::to_string(&data)?,
+            "comment": "Built-in guide",
+            "avatarPath": Value::Null
+        }),
+    )?;
     Ok(())
 }
 
@@ -48,10 +94,8 @@ fn seed_marinara_preset(storage: &FileStorage, db_root: &Path) -> AppResult<()> 
 }
 
 fn remove_legacy_professor_mari(storage: &FileStorage) -> AppResult<()> {
-    for id in ["__professor_mari__", "professor-mari"] {
-        if storage.get("characters", id)?.is_some() {
-            storage.delete("characters", id)?;
-        }
+    if storage.get("characters", "professor-mari")?.is_some() {
+        storage.delete("characters", "professor-mari")?;
     }
     if storage.get("chats", "__professor_mari_chat__")?.is_some() {
         storage.delete("chats", "__professor_mari_chat__")?;
@@ -243,5 +287,55 @@ fn is_truthy(value: Option<&Value>) -> bool {
         Some(Value::Bool(value)) => *value,
         Some(Value::String(value)) => value == "true",
         _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    struct TempRoot(PathBuf);
+
+    impl Drop for TempRoot {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn temp_storage() -> (FileStorage, TempRoot) {
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock should be after epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("marinara-seed-test-{suffix}"));
+        let storage = FileStorage::new(root.join("data")).expect("storage should initialize");
+        (storage, TempRoot(root))
+    }
+
+    #[test]
+    fn seeds_professor_mari_as_default_character() {
+        let (storage, root) = temp_storage();
+
+        seed_bundled_defaults(&storage, &root.0.join("missing-default-data"))
+            .expect("defaults should seed");
+
+        let character = storage
+            .get("characters", PROFESSOR_MARI_ID)
+            .expect("character lookup should succeed")
+            .expect("Professor Mari should be seeded");
+        let data = character
+            .get("data")
+            .and_then(Value::as_str)
+            .and_then(|raw| serde_json::from_str::<Value>(raw).ok())
+            .expect("character data should be stored as JSON");
+
+        assert_eq!(data["name"], "Professor Mari");
+        assert_eq!(
+            data.pointer("/extensions/isBuiltInAssistant")
+                .and_then(Value::as_bool),
+            Some(true)
+        );
     }
 }

--- a/src-tauri/src/seed_defaults.rs
+++ b/src-tauri/src/seed_defaults.rs
@@ -11,8 +11,8 @@ const PROFESSOR_MARI_ID: &str = "__professor_mari__";
 
 pub fn seed_bundled_defaults(storage: &FileStorage, default_data: &Path) -> AppResult<()> {
     let db_root = default_data.join("db");
-    remove_legacy_professor_mari(storage)?;
     seed_professor_mari_character(storage)?;
+    remove_legacy_professor_mari(storage)?;
     seed_marinara_preset(storage, &db_root)?;
     seed_default_chat_presets(storage)?;
     seed_default_regex_scripts(storage)?;
@@ -337,5 +337,35 @@ mod tests {
                 .and_then(Value::as_bool),
             Some(true)
         );
+    }
+
+    #[test]
+    fn preserves_canonical_professor_mari_while_removing_legacy_id() {
+        let (storage, root) = temp_storage();
+
+        seed_professor_mari_character(&storage).expect("canonical seed should succeed");
+        storage
+            .create(
+                "characters",
+                json!({
+                    "id": "professor-mari",
+                    "data": "{}",
+                    "comment": "",
+                    "avatarPath": Value::Null
+                }),
+            )
+            .expect("legacy row should be inserted");
+
+        seed_bundled_defaults(&storage, &root.0.join("missing-default-data"))
+            .expect("defaults should seed");
+
+        assert!(storage
+            .get("characters", PROFESSOR_MARI_ID)
+            .expect("canonical lookup should succeed")
+            .is_some());
+        assert!(storage
+            .get("characters", "professor-mari")
+            .expect("legacy lookup should succeed")
+            .is_none());
     }
 }


### PR DESCRIPTION
Migrated from Pasta-Devs/Marinara-Engine-Refactor#30: https://github.com/Pasta-Devs/Marinara-Engine-Refactor/pull/30
Original author: @cha1latte
Target base: Pasta-Devs/Marinara-Engine refactor
Source draft state: False
Verification after port: `cargo check --manifest-path src-tauri/Cargo.toml`
Port note: source updates/ tracker/evidence files were omitted because the target refactor branch removed repo-local updates guidance.

---

## Summary

Fixes the Discord-sourced setup blocker where fresh Conversation setup had no selectable Professor Mari/default character, leaving the new-chat flow unable to reach `Characters: 1`.

The default seeding path now creates the built-in `__professor_mari__` character when missing, and the legacy cleanup no longer deletes that active default character id on startup.

## Proof

Before fix, the controlled setup repro had no selectable Professor Mari result and kept **Start Chatting** disabled:

![Before: Professor Mari unavailable](https://raw.githubusercontent.com/cha1latte/Marinara-Engine-Refactor/ca40798aa18c512c4c84df3c195b012647ca4103/updates/evidence/default-character-conversation-setup/conversation-default-before.png)

After fix, Professor Mari appears, can be selected, and the setup flow creates a chat with exactly one character:

![After: Professor Mari selected](https://raw.githubusercontent.com/cha1latte/Marinara-Engine-Refactor/ca40798aa18c512c4c84df3c195b012647ca4103/updates/evidence/default-character-conversation-setup/conversation-default-after.png)

## Validation

- [ ] `CARGO_INCREMENTAL=0 cargo test --manifest-path src-tauri/Cargo.toml seeds_professor_mari_as_default_character`
- [ ] `CARGO_INCREMENTAL=0 pnpm check`
- [ ] Fresh Conversation setup can select Professor Mari/default character
- [ ] Brand-new chat reaches `Characters: 1`
- [ ] Existing chat setup/settings behavior remains in scope for manual smoke verification in real Tauri

## Scope Notes

No remote runtime, sync server, browser hosting, auth, Docker, SSE, `/api/invoke`, AI background remover, drag-and-drop, schema, version, or prompt-pipeline changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Professor Mari is now bundled as a built-in assistant and automatically initialized when launching the app.

* **Bug Fixes**
  * Enhanced cleanup of legacy character data to remove outdated entries more effectively.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1165?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->