### PR TITLE
Fix character import drag-and-drop handling

### DIFF
--- a/src/features/catalog/characters/components/ImportCharacterModal.tsx
+++ b/src/features/catalog/characters/components/ImportCharacterModal.tsx
@@ -267,6 +267,7 @@ export function ImportCharacterModal({ open, onClose }: Props) {
     const { files, error } = extractDroppedFiles(e);
     if (error) {
       setDropError(error);
+      setPendingLorebookChoice(null);
       setStatus("idle");
       setResults([]);
       return;

--- a/src/features/catalog/characters/components/ImportCharacterModal.tsx
+++ b/src/features/catalog/characters/components/ImportCharacterModal.tsx
@@ -34,9 +34,11 @@ const TAG_IMPORT_OPTIONS: Array<{ value: TagImportMode; label: string; descripti
 
 export function ImportCharacterModal({ open, onClose }: Props) {
   const fileRef = useRef<HTMLInputElement>(null);
+  const dragDepthRef = useRef(0);
   const [status, setStatus] = useState<"idle" | "loading" | "done">("idle");
   const [results, setResults] = useState<ImportResultRow[]>([]);
   const [dragOver, setDragOver] = useState(false);
+  const [dropError, setDropError] = useState<string | null>(null);
   const [pendingLorebookChoice, setPendingLorebookChoice] = useState<{
     files: File[];
     previews: EmbeddedLorebookImportPreview[];
@@ -50,11 +52,47 @@ export function ImportCharacterModal({ open, onClose }: Props) {
     return head[0] === 0x50 && head[1] === 0x4b;
   };
 
+  const extractDroppedFiles = (event: React.DragEvent<HTMLElement>) => {
+    const items = Array.from(event.dataTransfer.items ?? []);
+    if (items.length > 0) {
+      const files: File[] = [];
+
+      for (const item of items) {
+        if (item.kind !== "file") {
+          return {
+            files: [] as File[],
+            error: "Drop supported character files here. Folders and other items are not supported.",
+          };
+        }
+
+        const file = item.getAsFile();
+        if (!file) {
+          return {
+            files: [] as File[],
+            error: "Folders are not supported here. Drop supported character files instead.",
+          };
+        }
+
+        files.push(file);
+      }
+
+      return files.length > 0
+        ? { files, error: null }
+        : { files: [] as File[], error: "Drop supported character files here." };
+    }
+
+    const files = Array.from(event.dataTransfer.files ?? []);
+    return files.length > 0
+      ? { files, error: null }
+      : { files: [] as File[], error: "Drop supported character files here." };
+  };
+
   const handleFiles = async (files: File[], importEmbeddedLorebook?: boolean) => {
     if (files.length === 0) return;
     setStatus("loading");
     setResults([]);
     setPendingLorebookChoice(null);
+    setDropError(null);
 
     try {
       const stCharacterFiles: File[] = [];
@@ -220,10 +258,45 @@ export function ImportCharacterModal({ open, onClose }: Props) {
     }
   };
 
-  const handleDrop = (e: React.DragEvent) => {
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
+    e.stopPropagation();
+    dragDepthRef.current = 0;
     setDragOver(false);
-    handleFiles(Array.from(e.dataTransfer.files));
+
+    const { files, error } = extractDroppedFiles(e);
+    if (error) {
+      setDropError(error);
+      setStatus("idle");
+      setResults([]);
+      return;
+    }
+
+    void handleFiles(files);
+  };
+
+  const handleDragEnter = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    dragDepthRef.current += 1;
+    setDropError(null);
+    setDragOver(true);
+  };
+
+  const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    e.dataTransfer.dropEffect = "copy";
+    setDragOver(true);
+  };
+
+  const handleDragLeave = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    dragDepthRef.current = Math.max(0, dragDepthRef.current - 1);
+    if (dragDepthRef.current === 0) {
+      setDragOver(false);
+    }
   };
 
   const reset = () => {
@@ -231,6 +304,9 @@ export function ImportCharacterModal({ open, onClose }: Props) {
     setResults([]);
     setPendingLorebookChoice(null);
     setTagImportMode("all");
+    setDropError(null);
+    dragDepthRef.current = 0;
+    setDragOver(false);
   };
 
   return (
@@ -326,11 +402,9 @@ export function ImportCharacterModal({ open, onClose }: Props) {
         {/* Drop zone */}
         <div
           onDrop={handleDrop}
-          onDragOver={(e) => {
-            e.preventDefault();
-            setDragOver(true);
-          }}
-          onDragLeave={() => setDragOver(false)}
+          onDragEnter={handleDragEnter}
+          onDragOver={handleDragOver}
+          onDragLeave={handleDragLeave}
           onClick={() => fileRef.current?.click()}
           className={`flex cursor-pointer flex-col items-center gap-3 rounded-xl border-2 border-dashed p-8 transition-all ${
             dragOver
@@ -363,6 +437,12 @@ export function ImportCharacterModal({ open, onClose }: Props) {
             </span>
           </div>
         </div>
+
+        {dropError && (
+          <div className="rounded-lg border border-[var(--destructive)]/30 bg-[var(--destructive)]/10 p-3 text-xs text-[var(--destructive)]">
+            {dropError}
+          </div>
+        )}
 
         <input
           ref={fileRef}


### PR DESCRIPTION
Migrated from Pasta-Devs/Marinara-Engine-Refactor PR 51: https://github.com/Pasta-Devs/Marinara-Engine-Refactor/pull/51
Original author: @Promansis
Target base: Pasta-Devs/Marinara-Engine `refactor`
Source issue: Pasta-Devs/Marinara-Engine-Refactor issue 38

Note: this intentionally references the refactor-repo issue. It does not close Pasta-Devs/Marinara-Engine issue 38, which is an unrelated Windows `cp` installer issue.

---

## Why this change

- The Import Character modal could lose drag hover state when dragged items crossed nested drop-zone elements.
- Folder-like or unsupported drops could fail without a clear rejection.

## What changed

- React UI owner: `src/features/catalog/characters/components/ImportCharacterModal.tsx`.
- Track drag depth for stable enter/leave handling.
- Stop propagation on drop-zone drag events and set a copy drop effect for supported file drops.
- Inspect `DataTransferItem`s so unsupported or folder-like drops show a clear error instead of silently doing nothing.
- Clear any pending embedded-lorebook prompt when an invalid drop is rejected.

## Validation

Codex local verification:
- `pnpm check` passed from `D:\dev\Marinara-Engine-pr-1166-refactor` with `TEMP`/`TMP` pointed at `scratch\codex-temp` because `C:` had no free temp space.
- `node scratch\pr1166-dnd-smoke.mjs` passed against local Vite at `http://127.0.0.1:5178`:
  - opened the Import Character modal
  - confirmed nested drag enter/leave keeps the drag highlight active
  - confirmed unsupported non-file drops show a clear rejection
  - confirmed folder-like drops show a clear rejection
  - confirmed a supported `.json` drop enters the import path

GitHub verification:
- CI / Frontend, Architecture, and Organization: pass
- CI / Rust Capability Layer: pass
- CI / Browser Smoke and Performance: pass
- Pull Request Triage / Auto-label: pass

## Manual verification notes

- Tauri desktop native OS drag/drop was not manually exercised. The local browser smoke verifies the React drop-zone handler path; GitHub browser smoke and CI are green.

## Docs impact

- No docs changes needed.

## UI evidence

- Local screenshots were captured by `scratch\pr1166-dnd-smoke.mjs` for the modal, folder rejection, and supported-drop state. They are not embedded here because they are local proof artifacts, not GitHub-hosted attachments.
