### PR TITLE
[codex] fix character cache churn

### DIFF
--- a/src/features/catalog/characters/components/ImportCharacterModal.tsx
+++ b/src/features/catalog/characters/components/ImportCharacterModal.tsx
@@ -5,7 +5,7 @@ import { useState, useRef } from "react";
 import { Modal } from "../../../../shared/components/ui/Modal";
 import { Download, FileJson, Image, CheckCircle, XCircle, Loader2, BookOpen } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
-import { characterKeys } from "../hooks/use-characters";
+import { cacheCharacterListRecordFromResult, characterKeys } from "../hooks/use-characters";
 import { lorebookKeys } from "../../lorebooks/index";
 import { importApi } from "../../../../shared/api/import-api";
 import {
@@ -98,6 +98,7 @@ export function ImportCharacterModal({ open, onClose }: Props) {
 
       const nextResults: ImportResultRow[] = [];
       let importedLorebook = false;
+      let importedCharacterMissingCacheRecord = false;
 
       if (stCharacterFiles.length > 0) {
         const form = new FormData();
@@ -130,6 +131,10 @@ export function ImportCharacterModal({ open, onClose }: Props) {
 
         for (const result of batchResult.results) {
           if (result.lorebook?.lorebookId) importedLorebook = true;
+          if (result.success) {
+            const cached = cacheCharacterListRecordFromResult(qc, result);
+            if (!cached) importedCharacterMissingCacheRecord = true;
+          }
           nextResults.push({
             filename: result.filename,
             success: result.success,
@@ -152,6 +157,7 @@ export function ImportCharacterModal({ open, onClose }: Props) {
             success: boolean;
             name?: string;
             error?: string;
+            character?: unknown;
           }>({
             ...item.payload,
             timestampOverrides: {
@@ -160,6 +166,10 @@ export function ImportCharacterModal({ open, onClose }: Props) {
             },
           });
 
+          if (result.success) {
+            const cached = cacheCharacterListRecordFromResult(qc, result);
+            if (!cached) importedCharacterMissingCacheRecord = true;
+          }
           nextResults.push({
             filename: item.file.name,
             success: result.success,
@@ -176,7 +186,12 @@ export function ImportCharacterModal({ open, onClose }: Props) {
 
       for (const file of marinaraPackages) {
         try {
-          const result = await importApi.marinaraFile<{ success: boolean; name?: string; error?: string }>({
+          const result = await importApi.marinaraFile<{
+            success: boolean;
+            name?: string;
+            error?: string;
+            character?: unknown;
+          }>({
             file,
             fields: {
               timestampOverrides: JSON.stringify({
@@ -185,6 +200,10 @@ export function ImportCharacterModal({ open, onClose }: Props) {
               }),
             },
           });
+          if (result.success) {
+            const cached = cacheCharacterListRecordFromResult(qc, result);
+            if (!cached) importedCharacterMissingCacheRecord = true;
+          }
           nextResults.push({
             filename: file.name,
             success: result.success,
@@ -202,7 +221,7 @@ export function ImportCharacterModal({ open, onClose }: Props) {
       setResults(nextResults);
       setStatus("done");
 
-      if (nextResults.some((result) => result.success)) {
+      if (importedCharacterMissingCacheRecord) {
         qc.invalidateQueries({ queryKey: characterKeys.list() });
       }
       if (importedLorebook) {

--- a/src/features/catalog/characters/hooks/use-characters.ts
+++ b/src/features/catalog/characters/hooks/use-characters.ts
@@ -1,7 +1,7 @@
 // ──────────────────────────────────────────────
 // React Query: Character, Group & Persona hooks
 // ──────────────────────────────────────────────
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useQuery, useMutation, useQueryClient, type QueryClient } from "@tanstack/react-query";
 import { characterKeys, spriteKeys } from "../query-keys";
 import { storageApi } from "../../../../shared/api/storage-api";
 import { invokeTauri } from "../../../../shared/api/tauri-client";
@@ -10,6 +10,51 @@ import type { CharacterCardVersion } from "../../../../engine/contracts/types/ch
 import type { SpriteCapabilities, SpriteCleanupEngine } from "../../../../shared/types/sprite-capabilities";
 
 export { characterKeys, spriteKeys } from "../query-keys";
+
+type CharacterListRecord = Record<string, unknown> & { id?: string };
+
+function isCharacterListRecord(value: unknown): value is CharacterListRecord & { id: string } {
+  return Boolean(
+    value &&
+      typeof value === "object" &&
+      !Array.isArray(value) &&
+      typeof (value as { id?: unknown }).id === "string",
+  );
+}
+
+export function upsertCharacterListRecord(current: unknown[] | undefined, record: unknown): unknown[] | undefined {
+  if (!isCharacterListRecord(record)) return current;
+  if (!Array.isArray(current)) return current;
+
+  const existingIndex = current.findIndex((item) => isCharacterListRecord(item) && item.id === record.id);
+  if (existingIndex === -1) return [record, ...current];
+
+  return current.map((item, index) =>
+    index === existingIndex && isCharacterListRecord(item) ? { ...item, ...record } : item,
+  );
+}
+
+export function removeCharacterListRecord(current: unknown[] | undefined, id: string): unknown[] | undefined {
+  if (!Array.isArray(current)) return current;
+  return current.filter((item) => !isCharacterListRecord(item) || item.id !== id);
+}
+
+export function cacheCharacterListRecordFromResult(
+  queryClient: Pick<QueryClient, "getQueryData" | "setQueryData">,
+  result: unknown,
+): boolean {
+  if (!result || typeof result !== "object" || Array.isArray(result)) return false;
+  const record = (result as { character?: unknown }).character;
+  if (!isCharacterListRecord(record)) return false;
+
+  const current = queryClient.getQueryData<unknown[] | undefined>(characterKeys.list());
+  if (!Array.isArray(current)) return false;
+
+  queryClient.setQueryData<unknown[] | undefined>(characterKeys.list(), (value) =>
+    upsertCharacterListRecord(value, record),
+  );
+  return true;
+}
 
 // ── Characters ──
 
@@ -35,7 +80,10 @@ export function useCreateCharacter() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (data: Record<string, unknown>) => storageApi.create("characters", data),
-    onSuccess: () => qc.invalidateQueries({ queryKey: characterKeys.list() }),
+    onSuccess: (character) => {
+      const updated = cacheCharacterListRecordFromResult(qc, { character });
+      if (!updated) qc.invalidateQueries({ queryKey: characterKeys.list() });
+    },
   });
 }
 
@@ -110,7 +158,20 @@ export function useDeleteCharacter() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (id: string) => storageApi.delete("characters", id),
-    onSuccess: () => qc.invalidateQueries({ queryKey: characterKeys.list() }),
+    onSuccess: (result, id) => {
+      if (result?.deleted !== true) {
+        qc.invalidateQueries({ queryKey: characterKeys.list() });
+        return;
+      }
+
+      const current = qc.getQueryData<unknown[] | undefined>(characterKeys.list());
+      if (!Array.isArray(current)) {
+        qc.invalidateQueries({ queryKey: characterKeys.list() });
+        return;
+      }
+
+      qc.setQueryData<unknown[] | undefined>(characterKeys.list(), (value) => removeCharacterListRecord(value, id));
+    },
   });
 }
 
@@ -118,7 +179,10 @@ export function useDuplicateCharacter() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (id: string) => invokeTauri("storage_duplicate", { entity: "characters", id }),
-    onSuccess: () => qc.invalidateQueries({ queryKey: characterKeys.list() }),
+    onSuccess: (character) => {
+      const updated = cacheCharacterListRecordFromResult(qc, { character });
+      if (!updated) qc.invalidateQueries({ queryKey: characterKeys.list() });
+    },
   });
 }
 

--- a/src/features/shell/bot-browser/api/bot-browser-api.ts
+++ b/src/features/shell/bot-browser/api/bot-browser-api.ts
@@ -7,6 +7,7 @@ const TAURI_ASSET_PREFIX = "tauri-api:";
 export interface ImportCharacterResult {
   success?: boolean;
   name?: string;
+  character?: unknown;
   lorebook?: unknown;
   error?: string;
 }

--- a/src/features/shell/bot-browser/components/BotBrowserView.tsx
+++ b/src/features/shell/bot-browser/components/BotBrowserView.tsx
@@ -28,7 +28,7 @@ import {
   Cookie,
 } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
-import { characterKeys } from "../../../catalog/characters/index";
+import { cacheCharacterListRecordFromResult, characterKeys } from "../../../catalog/characters/index";
 import { lorebookKeys } from "../../../catalog/lorebooks/index";
 import { parsePngCharacterCard } from "../../../../shared/lib/png-parser";
 import { useUIStore } from "../../../../shared/stores/ui.store";
@@ -1397,7 +1397,8 @@ export function BotBrowserView() {
         });
         if (data.success) {
           toast.success(`Imported "${data.name ?? "character"}" successfully!`);
-          qc.invalidateQueries({ queryKey: characterKeys.list() });
+          const cached = cacheCharacterListRecordFromResult(qc, data);
+          if (!cached) qc.invalidateQueries({ queryKey: characterKeys.list() });
           if (data.lorebook) qc.invalidateQueries({ queryKey: lorebookKeys.all });
         } else throw new Error(data.error ?? "Import failed");
       } else {
@@ -1443,7 +1444,8 @@ export function BotBrowserView() {
         const data = await importStCharacter(v2);
         if (data.success) {
           toast.success(`Imported "${data.name ?? card.name}" successfully!`);
-          qc.invalidateQueries({ queryKey: characterKeys.list() });
+          const cached = cacheCharacterListRecordFromResult(qc, data);
+          if (!cached) qc.invalidateQueries({ queryKey: characterKeys.list() });
           if (data.lorebook) qc.invalidateQueries({ queryKey: lorebookKeys.all });
         } else throw new Error(data.error ?? "Import failed");
       }


### PR DESCRIPTION
Migrated from Pasta-Devs/Marinara-Engine-Refactor#54: https://github.com/Pasta-Devs/Marinara-Engine-Refactor/pull/54
Original author: @Promansis
Target base: Pasta-Devs/Marinara-Engine refactor
Source draft state: True
Verification after port: `pnpm typecheck`
Port note: source updates/ tracker/evidence files were omitted because the target refactor branch removed repo-local updates guidance.

---

Closes #39

## Why this change

Character import and delete paths were refreshing the full character list even when the mutation response already contained enough data to patch the React Query cache. That caused avoidable refetch churn in the character UI.

## What changed

- Added small character-list cache helpers in the character feature hook owner.
- Updated create, duplicate, delete, and import flows to patch the list cache directly when the response contains a usable character record.
- Kept a single invalidation fallback when a successful import does not return enough data to patch the cache safely.
- Recorded the issue ownership update in the local updates file.

## Validation

- [ ] `pnpm typecheck`
- [ ] `pnpm check`
- [ ] Ran `pnpm tauri dev` and tested the app path manually
- [ ] Verified the affected feature in the right mode(s): imports/exports

### Manual verification notes

Codex verification:
- `pnpm check` passed on PR head in an isolated worktree.
- A local no-commit merge of current `upstream/refactor` into the PR head merged cleanly.
- `pnpm check` passed after that local merge proof.
- GitHub CI is green.
- CodeRabbit status is green with no actionable inline review threads.

Manual follow-up:
- Live desktop smoke for import/delete refetch observation has not been run.

## Docs impact

- [ ] No docs changes needed

## UI evidence

N/A. Cache behavior change; no reviewer-visible UI screenshot captured.
