### PR TITLE
fix/avatar crop scaling

### DIFF
--- a/src/features/catalog/characters/components/CharacterAvatarImage.tsx
+++ b/src/features/catalog/characters/components/CharacterAvatarImage.tsx
@@ -1,0 +1,48 @@
+import type { AvatarCrop } from "../../../../shared/lib/utils";
+import { cn, getAvatarCropStyle, parseAvatarCropJson } from "../../../../shared/lib/utils";
+
+function isAvatarCrop(value: unknown): value is AvatarCrop {
+  return (
+    !!value &&
+    typeof value === "object" &&
+    Number.isFinite((value as AvatarCrop).srcX) &&
+    Number.isFinite((value as AvatarCrop).srcY) &&
+    Number.isFinite((value as AvatarCrop).srcWidth) &&
+    Number.isFinite((value as AvatarCrop).srcHeight) &&
+    (value as AvatarCrop).srcWidth > 0 &&
+    (value as AvatarCrop).srcHeight > 0 &&
+    (value as AvatarCrop).srcX >= 0 &&
+    (value as AvatarCrop).srcY >= 0 &&
+    (value as AvatarCrop).srcX + (value as AvatarCrop).srcWidth <= 1.001 &&
+    (value as AvatarCrop).srcY + (value as AvatarCrop).srcHeight <= 1.001
+  );
+}
+
+function resolveAvatarCrop(crop: unknown): AvatarCrop | null {
+  if (!crop) return null;
+  if (typeof crop === "string") return parseAvatarCropJson(crop);
+  return isAvatarCrop(crop) ? crop : null;
+}
+
+export function CharacterAvatarImage({
+  src,
+  alt,
+  crop,
+  className,
+}: {
+  src: string;
+  alt: string;
+  crop?: unknown;
+  className?: string;
+}) {
+  return (
+    <img
+      src={src}
+      alt={alt}
+      loading="lazy"
+      draggable={false}
+      className={cn("h-full w-full object-cover", className)}
+      style={getAvatarCropStyle(resolveAvatarCrop(crop))}
+    />
+  );
+}

--- a/src/features/catalog/characters/components/CharacterLibraryView.tsx
+++ b/src/features/catalog/characters/components/CharacterLibraryView.tsx
@@ -3,8 +3,9 @@ import { ArrowLeft, ArrowUpDown, Download, MessageCircle, Pencil, Plus, Search, 
 import { useCharacters } from "../hooks/use-characters";
 import { useStartChatFromCharacter } from "../hooks/use-start-chat-from-character";
 import { getCharacterTitle } from "../../../../shared/lib/character-display";
-import { cn, getAvatarCropStyle, type AvatarCrop } from "../../../../shared/lib/utils";
+import { cn } from "../../../../shared/lib/utils";
 import { useUIStore } from "../../../../shared/stores/ui.store";
+import { CharacterAvatarImage } from "./CharacterAvatarImage";
 
 type CharacterData = Record<string, unknown> & {
   name?: string;
@@ -106,14 +107,10 @@ function CharacterLibraryDetailCard({
       <div className="overflow-hidden rounded-[1.5rem] border border-[var(--border)]/50 bg-[var(--background)]/70 shadow-[0_24px_70px_-40px_rgba(15,23,42,0.95)] sm:rounded-[2rem]">
         <div className="relative aspect-[4/3] overflow-hidden bg-gradient-to-br from-pink-400/25 via-rose-500/15 to-sky-400/15">
           {character.avatarPath ? (
-            <img
+            <CharacterAvatarImage
               src={character.avatarPath}
               alt={characterName || "Selected character"}
-              className="h-full w-full object-cover"
-              style={getAvatarCropStyle(
-                character.parsed.extensions?.avatarCrop as AvatarCrop
-                  | undefined,
-              )}
+              crop={character.parsed.extensions?.avatarCrop}
             />
           ) : (
             <div className="flex h-full w-full items-center justify-center text-white/85">
@@ -428,15 +425,11 @@ export function CharacterLibraryView() {
                     >
                       <div className="relative h-24 w-24 shrink-0 overflow-hidden bg-gradient-to-br from-pink-400/25 via-rose-500/15 to-sky-400/15 sm:h-auto sm:w-full sm:aspect-[4/3]">
                         {char.avatarPath ? (
-                          <img
+                          <CharacterAvatarImage
                             src={char.avatarPath}
                             alt={charName}
-                            loading="lazy"
-                            className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.03]"
-                            style={getAvatarCropStyle(
-                              char.parsed.extensions?.avatarCrop as AvatarCrop
-                                | undefined,
-                            )}
+                            crop={char.parsed.extensions?.avatarCrop}
+                            className="transition-transform duration-300 group-hover:scale-[1.03]"
                           />
                         ) : (
                           <div className="flex h-full w-full items-center justify-center text-white/85">

--- a/src/features/catalog/characters/components/CharactersPanel.tsx
+++ b/src/features/catalog/characters/components/CharactersPanel.tsx
@@ -48,8 +48,9 @@ import {
 } from "lucide-react";
 import { getCharacterTitle } from "../../../../shared/lib/character-display";
 import { useUIStore } from "../../../../shared/stores/ui.store";
-import { cn, getAvatarCropStyle, type AvatarCrop } from "../../../../shared/lib/utils";
+import { cn } from "../../../../shared/lib/utils";
 import { ExportFormatDialog, type ExportFormatChoice } from "../../../../shared/components/ui/ExportFormatDialog";
+import { CharacterAvatarImage } from "./CharacterAvatarImage";
 
 type CharacterRow = {
   id: string;
@@ -181,9 +182,17 @@ export function CharactersPanel() {
   }, [characters]) as ParsedCharacterRow[];
 
   const charMap = useMemo(() => {
-    const map = new Map<string, { name: string; comment?: string | null; avatarPath: string | null }>();
+    const map = new Map<
+      string,
+      { name: string; comment?: string | null; avatarPath: string | null; avatarCrop?: unknown }
+    >();
     for (const c of parsedCharacters) {
-      map.set(c.id, { name: c.parsed.name ?? "Unknown", comment: c.comment, avatarPath: c.avatarPath });
+      map.set(c.id, {
+        name: c.parsed.name ?? "Unknown",
+        comment: c.comment,
+        avatarPath: c.avatarPath,
+        avatarCrop: c.parsed.extensions?.avatarCrop,
+      });
     }
     return map;
   }, [parsedCharacters]);
@@ -944,13 +953,12 @@ export function CharactersPanel() {
                             }}
                             className="group/member flex cursor-pointer items-center gap-2 rounded-lg p-1.5 transition-all hover:bg-[var(--sidebar-accent)]"
                           >
-                            <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg overflow-hidden bg-gradient-to-br from-pink-400 to-rose-500 text-white">
+                            <div className="relative flex h-7 w-7 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-gradient-to-br from-pink-400 to-rose-500 text-white">
                               {member.avatarPath ? (
-                                <img
+                                <CharacterAvatarImage
                                   src={member.avatarPath}
                                   alt={member.name}
-                                  loading="lazy"
-                                  className="h-full w-full object-cover"
+                                  crop={member.avatarCrop}
                                 />
                               ) : (
                                 <User size="0.75rem" />
@@ -1120,14 +1128,10 @@ export function CharactersPanel() {
               <div className="relative flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-pink-400 to-rose-500 text-white shadow-sm">
                 {avatarUrl ? (
                   <div className="absolute inset-0 overflow-hidden rounded-xl">
-                    <img
+                    <CharacterAvatarImage
                       src={avatarUrl}
                       alt={charName}
-                      className="h-full w-full object-cover"
-                      style={getAvatarCropStyle(
-                        char.parsed.extensions?.avatarCrop as AvatarCrop
-                          | undefined,
-                      )}
+                      crop={char.parsed.extensions?.avatarCrop}
                     />
                   </div>
                 ) : (


### PR DESCRIPTION
Migrated from Pasta-Devs/Marinara-Engine-Refactor#55: https://github.com/Pasta-Devs/Marinara-Engine-Refactor/pull/55
Original author: @Promansis
Target base: Pasta-Devs/Marinara-Engine refactor
Source draft state: True
Port note: source updates/tracker/evidence files were omitted because the target refactor branch removed repo-local updates guidance.

---

## Linked issue

Fixes #1158

Original migrated source issue: Pasta-Devs/Marinara-Engine-Refactor#35.

## Why this change

Character library avatars should follow one explicit crop display contract. The old library and panel paths could pass a persisted JSON-string `avatarCrop` directly into the crop style helper, which produced invalid crop sizing and could render squished full-image avatars instead of the stored crop.

## What changed

- Added a shared `CharacterAvatarImage` helper in the React character feature.
- Swapped the character library detail/card avatars and Characters panel avatars to use the shared crop-aware image path.
- Preserved the normal uncropped `object-cover` fallback for missing or invalid crop data.
- Included group-member avatars in the Characters panel so nested member rows use the same crop contract.

## Validation

- [ ] `pnpm check`
- [ ] `pnpm build`
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml`
- [ ] `pnpm check:docs` when docs, skills, or repo guidance changed
- [ ] Ran `pnpm tauri dev` and tested the app path manually
- [ ] Verified the affected feature in the right mode(s): chat, roleplay, game, settings/providers, imports/exports, or assets

### Codex verification notes

- Vite + Playwright proof harness passed for the affected render path. It reproduced the old string-crop failure as 160x160 `object-fit: fill`, then verified the shared helper renders the same persisted string crop as 320x160 absolute crop geometry.
- Edge case verified: invalid persisted crop string falls back to uncropped `object-cover`.
- `pnpm check` passed locally: architecture, frontend typecheck, Rust cargo check, and docs check.
- `pnpm build` passed locally. Vite reported existing chunk-size/dynamic-import warnings.
- Marinara proof gate passed for `scratch/bugfix-verification.json`.
- Bunny review pass: no code blockers after PR wording/evidence update.

### Manual verification notes

No manual verification needed for the core claim. The local proof uses a Vite-served React harness importing the production `CharacterAvatarImage` helper because the browser-only dev app cannot list local Tauri storage rows without the Tauri runtime.

## Docs impact

- [ ] No docs changes needed
- [ ] Updated `docs/developer/*` or repo guidance as needed

## UI evidence

![Avatar crop proof](https://gist.githubusercontent.com/cha1latte/2c5a0792417e27e1d2bb88b159e051e5/raw/issue-1158-avatar-crop-proof.svg)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated character avatar rendering logic into a reusable component for improved code maintainability across character display views.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1169?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->