### PR TITLE
Phase 1: AI sprite cleanup runtime discovery

### DIFF
--- a/src-tauri/resources/background-remover/README.md
+++ b/src-tauri/resources/background-remover/README.md
@@ -1,0 +1,16 @@
+Bundled background remover runtime placeholder.
+
+Packaged builds can place a prepared `backgroundremover` executable or portable Python
+runtime here without relying on system Python or PATH. Marinara checks these layouts
+before env vars, the app data `.venv`, and PATH:
+
+- `windows-x64/backgroundremover.exe`
+- `windows/backgroundremover.exe`
+- `linux-x64/backgroundremover`
+- `linux/backgroundremover`
+- `macos-arm64/backgroundremover`
+- `macos/backgroundremover`
+- `common/backgroundremover`
+
+Portable Python runtimes can use the same layout with `python`/`python.exe`; Marinara
+will run it as `python -m backgroundremover.cmd.cli`.

--- a/src-tauri/src/commands/storage/sprites.rs
+++ b/src-tauri/src/commands/storage/sprites.rs
@@ -1569,6 +1569,45 @@ fn background_remover_runtime_dir(state: &AppState) -> PathBuf {
     state.data_dir.join("background-remover")
 }
 
+fn bundled_background_remover_roots(state: &AppState) -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+    if let Some(resource_dir) = &state.resource_dir {
+        roots.push(resource_dir.join("resources").join("background-remover"));
+        roots.push(resource_dir.join("background-remover"));
+    }
+    roots.push(
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("resources")
+            .join("background-remover"),
+    );
+    roots
+}
+
+fn platform_runtime_dirs(root: &Path) -> Vec<PathBuf> {
+    let os = if cfg!(windows) {
+        "windows"
+    } else if cfg!(target_os = "macos") {
+        "macos"
+    } else if cfg!(target_os = "linux") {
+        "linux"
+    } else {
+        "unknown"
+    };
+    let arch = if cfg!(target_arch = "x86_64") {
+        "x64"
+    } else if cfg!(target_arch = "aarch64") {
+        "arm64"
+    } else {
+        "generic"
+    };
+    vec![
+        root.join(format!("{os}-{arch}")),
+        root.join(os),
+        root.join("common"),
+        root.to_path_buf(),
+    ]
+}
+
 fn executable_exists(path: &Path) -> bool {
     path.is_file()
 }
@@ -1613,7 +1652,46 @@ fn find_executable_on_path(name: &str) -> Option<PathBuf> {
     None
 }
 
+fn bundled_runtime_executable(dir: &Path, name: &str) -> Option<PathBuf> {
+    for executable in path_executable_names(name) {
+        for parent in [dir.to_path_buf(), dir.join("bin"), dir.join("Scripts")] {
+            let candidate = parent.join(&executable);
+            if executable_exists(&candidate) {
+                return Some(candidate);
+            }
+        }
+    }
+    None
+}
+
+fn resolve_bundled_backgroundremover_command(state: &AppState) -> Option<BackgroundRemoverCommand> {
+    for root in bundled_background_remover_roots(state) {
+        for dir in platform_runtime_dirs(&root) {
+            if let Some(command) = bundled_runtime_executable(&dir, "backgroundremover") {
+                return Some(BackgroundRemoverCommand {
+                    label: command.to_string_lossy().to_string(),
+                    command,
+                    args_prefix: Vec::new(),
+                    source: "bundled",
+                });
+            }
+            if let Some(command) = bundled_runtime_executable(&dir, "python") {
+                return Some(BackgroundRemoverCommand {
+                    label: format!("{} -m backgroundremover.cmd.cli", command.to_string_lossy()),
+                    command,
+                    args_prefix: vec!["-m".to_string(), "backgroundremover.cmd.cli".to_string()],
+                    source: "bundled",
+                });
+            }
+        }
+    }
+    None
+}
+
 fn resolve_backgroundremover_command(state: &AppState) -> Option<BackgroundRemoverCommand> {
+    if let Some(command) = resolve_bundled_backgroundremover_command(state) {
+        return Some(command);
+    }
     if let Ok(command) = env::var("BACKGROUNDREMOVER_COMMAND") {
         let command = command.trim();
         if !command.is_empty() {
@@ -1686,7 +1764,7 @@ fn background_remover_status(state: &AppState) -> Value {
         } else if command.is_some() {
             Value::Null
         } else {
-            Value::String("Install backgroundremover or set BACKGROUNDREMOVER_COMMAND/BACKGROUNDREMOVER_PYTHON to enable optional AI background cleanup.".to_string())
+            Value::String("No bundled backgroundremover runtime was found for this platform. Marinara will use built-in matte cleanup unless BACKGROUNDREMOVER_COMMAND/BACKGROUNDREMOVER_PYTHON or PATH provides backgroundremover.".to_string())
         }
     })
 }
@@ -1698,6 +1776,10 @@ fn cleanup_engine_status(state: &AppState) -> Value {
         .get("installed")
         .and_then(Value::as_bool)
         .unwrap_or(false);
+    let background_remover_reason = background_remover
+        .get("reason")
+        .cloned()
+        .unwrap_or(Value::Null);
     let forced_background_remover = engine == "backgroundremover";
     let installed = !forced_background_remover || background_remover_installed;
     json!({
@@ -1706,20 +1788,32 @@ fn cleanup_engine_status(state: &AppState) -> Value {
         "command": background_remover.get("command").cloned().unwrap_or(Value::Null),
         "source": if background_remover_installed {
             background_remover.get("source").cloned().unwrap_or(Value::Null)
+        } else if installed {
+            json!("builtin")
         } else {
-            json!("local")
+            Value::Null
         },
         "runtimeDir": background_remover_runtime_dir(state).to_string_lossy(),
         "reason": if installed {
-            if background_remover_installed {
+            if engine == "builtin" {
+                background_remover_reason.clone().as_str().map_or_else(|| {
+                    Value::String("Built-in matte cleanup is forced by SPRITE_BACKGROUND_REMOVAL_ENGINE".to_string())
+                }, |_| background_remover_reason.clone())
+            } else if background_remover_installed {
                 Value::Null
+            } else if background_remover_reason
+                .as_str()
+                .map(|reason| reason.contains("disabled"))
+                .unwrap_or(false)
+            {
+                background_remover_reason.clone()
             } else {
-                Value::String("Using built-in matte cleanup; optional backgroundremover is not installed.".to_string())
+                Value::String("Using built-in matte cleanup; no bundled or external backgroundremover runtime is available.".to_string())
             }
         } else {
-            background_remover.get("reason").cloned().unwrap_or_else(|| {
+            background_remover_reason.as_str().map_or_else(|| {
                 Value::String("backgroundremover is required but unavailable.".to_string())
-            })
+            }, |_| background_remover_reason.clone())
         }
     })
 }
@@ -1748,7 +1842,7 @@ fn try_remove_background_with_backgroundremover(
         if required || engine == "backgroundremover" {
             return Err(AppError::new(
                 "backgroundremover_unavailable",
-                "backgroundremover is not installed. Install it or set BACKGROUNDREMOVER_COMMAND/BACKGROUNDREMOVER_PYTHON.",
+                "backgroundremover is not available. Add a bundled runtime or set BACKGROUNDREMOVER_COMMAND/BACKGROUNDREMOVER_PYTHON.",
             ));
         }
         return Ok(None);
@@ -1844,4 +1938,140 @@ fn validate_safe_segment(value: &str, label: &str) -> AppResult<()> {
 
 fn image_error(error: image::ImageError) -> AppError {
     AppError::new("image_processing_error", error.to_string())
+}
+
+#[cfg(test)]
+mod background_remover_runtime_tests {
+    use super::*;
+    use std::fs;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn temp_path(label: &str) -> PathBuf {
+        env::temp_dir().join(format!("marinara-bgrem-{label}-{}", now_millis()))
+    }
+
+    fn test_state(data_dir: PathBuf, resource_dir: Option<PathBuf>) -> AppState {
+        AppState::from_data_dir_with_resource_dir(data_dir, Vec::new(), resource_dir)
+            .expect("test state should initialize")
+    }
+
+    #[test]
+    fn bundled_backgroundremover_is_preferred_before_env_and_path() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|error| error.into_inner());
+        let old_command = env::var_os("BACKGROUNDREMOVER_COMMAND");
+        env::set_var("BACKGROUNDREMOVER_COMMAND", "external-backgroundremover");
+
+        let root = temp_path("bundled");
+        let data_dir = root.join("data");
+        let resource_dir = root.join("resources-root");
+        let bundled_dir = resource_dir
+            .join("resources")
+            .join("background-remover")
+            .join(
+                platform_runtime_dirs(Path::new(""))
+                    .into_iter()
+                    .next()
+                    .expect("platform dir"),
+            );
+        fs::create_dir_all(&bundled_dir).expect("runtime dir");
+        let command_path = bundled_dir.join(if cfg!(windows) {
+            "backgroundremover.exe"
+        } else {
+            "backgroundremover"
+        });
+        fs::write(&command_path, b"fake").expect("fake command");
+
+        let state = test_state(data_dir, Some(resource_dir));
+        let command = resolve_backgroundremover_command(&state).expect("bundled runtime");
+
+        assert_eq!(command.source, "bundled");
+        assert_eq!(command.command, command_path);
+
+        if let Some(value) = old_command {
+            env::set_var("BACKGROUNDREMOVER_COMMAND", value);
+        } else {
+            env::remove_var("BACKGROUNDREMOVER_COMMAND");
+        }
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn builtin_fallback_reports_builtin_source() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|error| error.into_inner());
+        let old_engine = env::var_os("SPRITE_BACKGROUND_REMOVAL_ENGINE");
+        env::set_var("SPRITE_BACKGROUND_REMOVAL_ENGINE", "builtin");
+
+        let root = temp_path("builtin");
+        let state = test_state(root.join("data"), Some(root.join("resources-root")));
+        let status = cleanup_engine_status(&state);
+
+        assert_eq!(
+            status.get("source").and_then(Value::as_str),
+            Some("builtin")
+        );
+        assert!(status
+            .get("reason")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .contains("Built-in matte cleanup is forced"));
+
+        if let Some(value) = old_engine {
+            env::set_var("SPRITE_BACKGROUND_REMOVAL_ENGINE", value);
+        } else {
+            env::remove_var("SPRITE_BACKGROUND_REMOVAL_ENGINE");
+        }
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn forced_backgroundremover_unavailable_does_not_claim_builtin_source() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|error| error.into_inner());
+        let old_engine = env::var_os("SPRITE_BACKGROUND_REMOVAL_ENGINE");
+        let old_command = env::var_os("BACKGROUNDREMOVER_COMMAND");
+        let old_python = env::var_os("BACKGROUNDREMOVER_PYTHON");
+        let old_path = env::var_os("PATH");
+        env::set_var("SPRITE_BACKGROUND_REMOVAL_ENGINE", "backgroundremover");
+        env::remove_var("BACKGROUNDREMOVER_COMMAND");
+        env::remove_var("BACKGROUNDREMOVER_PYTHON");
+        env::set_var("PATH", "");
+
+        let root = temp_path("required-missing");
+        let state = test_state(root.join("data"), Some(root.join("resources-root")));
+        let status = cleanup_engine_status(&state);
+
+        assert_eq!(
+            status.get("installed").and_then(Value::as_bool),
+            Some(false)
+        );
+        assert_eq!(status.get("source").and_then(Value::as_str), None);
+        assert!(status
+            .get("reason")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .contains("No bundled backgroundremover runtime"));
+
+        if let Some(value) = old_engine {
+            env::set_var("SPRITE_BACKGROUND_REMOVAL_ENGINE", value);
+        } else {
+            env::remove_var("SPRITE_BACKGROUND_REMOVAL_ENGINE");
+        }
+        if let Some(value) = old_command {
+            env::set_var("BACKGROUNDREMOVER_COMMAND", value);
+        } else {
+            env::remove_var("BACKGROUNDREMOVER_COMMAND");
+        }
+        if let Some(value) = old_python {
+            env::set_var("BACKGROUNDREMOVER_PYTHON", value);
+        } else {
+            env::remove_var("BACKGROUNDREMOVER_PYTHON");
+        }
+        if let Some(value) = old_path {
+            env::set_var("PATH", value);
+        } else {
+            env::remove_var("PATH");
+        }
+        let _ = fs::remove_dir_all(root);
+    }
 }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -15,6 +15,7 @@ pub struct AppState {
     pub game_assets: AssetService,
     pub backgrounds: AssetService,
     pub data_dir: PathBuf,
+    pub resource_dir: Option<PathBuf>,
     llm_stream_cancellations: Arc<Mutex<LlmStreamCancellations>>,
 }
 
@@ -31,12 +32,21 @@ impl AppState {
             .app_data_dir()
             .map_err(|error| AppError::new("data_dir_error", error.to_string()))?;
         let default_data_roots = Self::default_data_roots(app);
-        Self::from_data_dir(data_dir, default_data_roots)
+        let resource_dir = app.path().resource_dir().ok();
+        Self::from_data_dir_with_resource_dir(data_dir, default_data_roots, resource_dir)
     }
 
     pub fn from_data_dir(
         data_dir: impl Into<PathBuf>,
         default_data_roots: Vec<PathBuf>,
+    ) -> AppResult<Self> {
+        Self::from_data_dir_with_resource_dir(data_dir, default_data_roots, None)
+    }
+
+    pub fn from_data_dir_with_resource_dir(
+        data_dir: impl Into<PathBuf>,
+        default_data_roots: Vec<PathBuf>,
+        resource_dir: Option<PathBuf>,
     ) -> AppResult<Self> {
         let data_dir = data_dir.into();
         std::fs::create_dir_all(&data_dir)?;
@@ -50,6 +60,7 @@ impl AppState {
             game_assets,
             backgrounds,
             data_dir,
+            resource_dir,
             llm_stream_cancellations: Arc::new(Mutex::new(LlmStreamCancellations::default())),
         })
     }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -33,7 +33,11 @@
   "bundle": {
     "active": true,
     "targets": "all",
-    "resources": ["resources/default-data/**/*", "resources/platform-assets/**/*"],
+    "resources": [
+      "resources/default-data/**/*",
+      "resources/platform-assets/**/*",
+      "resources/background-remover/**/*"
+    ],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/src/features/catalog/characters/components/CharacterEditor.tsx
+++ b/src/features/catalog/characters/components/CharacterEditor.tsx
@@ -2143,7 +2143,7 @@ function SpritesTab({
   const backgroundCleanupReason = spriteCapabilities?.reason ?? "Background cleanup is unavailable on this platform.";
   const cleanupEngineUnavailable = spriteCapabilities?.cleanupEngine?.installed === false;
   const cleanupEngineReason =
-    spriteCapabilities?.cleanupEngine?.reason ?? "Built-in sprite cleanup is not available.";
+    spriteCapabilities?.cleanupEngine?.reason ?? "Sprite cleanup is not available.";
 
   const normalizeExpressionForCategory = (raw: string) => {
     const cleaned = raw
@@ -2299,7 +2299,7 @@ function SpritesTab({
     if (
       !(await showConfirmDialog({
         title: "Clean Sprite Backgrounds",
-        message: `Run built-in cleanup on ${visibleSprites.length} saved ${modeLabel} sprite${visibleSprites.length === 1 ? "" : "s"} at strength ${savedCleanupStrength}? Marinara will keep a restore point in case the cleanup looks wrong.`,
+        message: `Run background cleanup on ${visibleSprites.length} saved ${modeLabel} sprite${visibleSprites.length === 1 ? "" : "s"} at strength ${savedCleanupStrength}? Marinara will keep a restore point in case the cleanup looks wrong.`,
         confirmLabel: "Clean",
       }))
     ) {
@@ -2312,7 +2312,7 @@ function SpritesTab({
         characterId,
         expressions: visibleSprites.map((sprite) => sprite.expression),
         cleanupStrength: savedCleanupStrength,
-        engine: "builtin",
+        engine: "auto",
       });
 
       if (result.processed > 0) {
@@ -2485,7 +2485,7 @@ function SpritesTab({
                   ? backgroundCleanupReason
                   : cleanupEngineUnavailable
                     ? cleanupEngineReason
-                    : "Run built-in cleanup on the currently visible saved sprites"
+                    : "Run background cleanup on the currently visible saved sprites"
               }
             >
               {cleaningSprites ? <Loader2 size="0.8125rem" className="animate-spin" /> : <Eraser size="0.8125rem" />}

--- a/src/features/catalog/personas/components/PersonaEditor.tsx
+++ b/src/features/catalog/personas/components/PersonaEditor.tsx
@@ -714,7 +714,7 @@ function PersonaSpritesTab({
   const backgroundCleanupReason = spriteCapabilities?.reason ?? "Background cleanup is unavailable on this platform.";
   const cleanupEngineUnavailable = spriteCapabilities?.cleanupEngine?.installed === false;
   const cleanupEngineReason =
-    spriteCapabilities?.cleanupEngine?.reason ?? "Built-in sprite cleanup is not available.";
+    spriteCapabilities?.cleanupEngine?.reason ?? "Sprite cleanup is not available.";
 
   const normalizeExpressionForCategory = (raw: string) => {
     const cleaned = raw
@@ -861,7 +861,7 @@ function PersonaSpritesTab({
     if (
       !(await showConfirmDialog({
         title: "Clean Sprite Backgrounds",
-        message: `Run built-in cleanup on ${visibleSprites.length} saved ${modeLabel} sprite${visibleSprites.length === 1 ? "" : "s"} at strength ${savedCleanupStrength}? Marinara will keep a restore point in case the cleanup looks wrong.`,
+        message: `Run background cleanup on ${visibleSprites.length} saved ${modeLabel} sprite${visibleSprites.length === 1 ? "" : "s"} at strength ${savedCleanupStrength}? Marinara will keep a restore point in case the cleanup looks wrong.`,
         confirmLabel: "Clean",
       }))
     ) {
@@ -874,7 +874,7 @@ function PersonaSpritesTab({
         characterId: personaId,
         expressions: visibleSprites.map((sprite) => sprite.expression),
         cleanupStrength: savedCleanupStrength,
-        engine: "builtin",
+        engine: "auto",
       });
 
       if (result.processed > 0) {
@@ -1049,7 +1049,7 @@ function PersonaSpritesTab({
                   ? backgroundCleanupReason
                   : cleanupEngineUnavailable
                     ? cleanupEngineReason
-                    : "Run built-in cleanup on the currently visible saved sprites"
+                    : "Run background cleanup on the currently visible saved sprites"
               }
             >
               {cleaningSprites ? <Loader2 size="0.8125rem" className="animate-spin" /> : <Eraser size="0.8125rem" />}

--- a/src/shared/components/ui/SpriteGenerationModal.tsx
+++ b/src/shared/components/ui/SpriteGenerationModal.tsx
@@ -540,7 +540,7 @@ export function SpriteGenerationModal({
   const spriteGenerationReason = spriteCapabilities?.reason ?? "Sprite generation is unavailable on this platform.";
   const cleanupEngineUnavailable = spriteCapabilities?.cleanupEngine?.installed === false;
   const cleanupEngineReason =
-    spriteCapabilities?.cleanupEngine?.reason ?? "Built-in sprite cleanup is not available.";
+    spriteCapabilities?.cleanupEngine?.reason ?? "Sprite cleanup is not available.";
   const existingPortraitExpressions = useMemo(() => {
     const seen = new Set<string>();
     const names: string[] = [];
@@ -982,7 +982,7 @@ export function SpriteGenerationModal({
     try {
       const result = await spriteApi.cleanup<{ cells: Array<{ expression: string; base64: string }> }>({
         cleanupStrength,
-        engine: "builtin",
+        engine: "auto",
         cells: cells.map((cell) => ({
           expression: cell.expression,
           base64: cell.rawDataUrl,
@@ -1898,7 +1898,7 @@ export function SpriteGenerationModal({
                         onClick={handleApplyCleanup}
                         disabled={cleanupApplying || cleanupEngineUnavailable || cells.length === 0}
                         className="rounded-lg bg-[var(--primary)] px-2.5 py-1 text-[0.6875rem] font-medium text-white transition-colors hover:opacity-90 disabled:opacity-50"
-                        title={cleanupEngineUnavailable ? cleanupEngineReason : "Run built-in cleanup"}
+                        title={cleanupEngineUnavailable ? cleanupEngineReason : "Run background cleanup"}
                       >
                         {cleanupApplying ? "Applying..." : cleanupApplied ? "Reapply Cleanup" : "Apply Cleanup"}
                       </button>

--- a/src/shared/types/sprite-capabilities.ts
+++ b/src/shared/types/sprite-capabilities.ts
@@ -1,4 +1,4 @@
-export type SpriteCleanupEngine = "auto" | "builtin";
+export type SpriteCleanupEngine = "auto" | "builtin" | "backgroundremover";
 
 export interface SpriteCapabilities {
   imageProcessingAvailable: boolean;
@@ -9,7 +9,7 @@ export interface SpriteCapabilities {
     engine: SpriteCleanupEngine;
     installed: boolean;
     command: string | null;
-    source: "env" | "local" | "path" | null;
+    source: "bundled" | "env" | "local" | "path" | "builtin" | null;
     runtimeDir: string;
     reason: string | null;
   };


### PR DESCRIPTION
## What?

Phase 1 plumbing for bundled/app-managed AI sprite background cleanup on the refactor branch.

This adds the runtime discovery and status path: sprite cleanup now prefers `resources/background-remover/...` packaged runtimes before env vars, app-data `.venv`, or PATH. Generated and saved sprite cleanup now request `engine: "auto"` so an app-managed AI cleanup runtime can be used when one exists, with built-in matte cleanup still available as fallback.

## Why?

Refs https://github.com/Pasta-Devs/Marinara-Engine-Refactor/issues/24

The refactor code still only discovered externally installed `backgroundremover`/Python runtimes, and UI cleanup paths forced built-in cleanup. That meant a packaged AI cleanup runtime would not be used even if a later packaging/runtime phase provided one.

## Verification

- `cargo test --manifest-path src-tauri\Cargo.toml background_remover_runtime_tests`
  - bundled runtime is preferred before env/PATH
  - forced built-in cleanup reports `source: "builtin"`
  - forced AI cleanup with no runtime reports unavailable and does not claim built-in source
- `pnpm check`
- `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json`
- GitHub CI passed on PR #1172:
  - Frontend, Architecture, and Organization
  - Rust Capability Layer
  - Browser Smoke and Performance

## Manual verification needed

- None for this Phase 1 discovery/status plumbing.

## Follow-up architecture/release decision

This PR does not bundle the actual third-party runtime binary/dependency payload. Phase 2 needs an architecture/release decision: should AI sprite cleanup runtime be app-managed first-run download or bundled into installers?

That decision should cover hosting, checksums/signatures, platform matrix, update cleanup, license/security review, model files, and installer size.
