### PR TITLE
Fix refactor workflow docs references

### DIFF
--- a/docs/developer/run-build.html
+++ b/docs/developer/run-build.html
@@ -127,7 +127,7 @@ MARINARA_DATA_DIR=/path/to/data</code></pre>
         <p>The compose service exposes:</p>
         <pre><code>http://127.0.0.1:8787</code></pre>
         <p>To build directly from GitHub, use Docker's remote git context:</p>
-        <pre><code>docker build -t marinara-engine-server https://github.com/Pasta-Devs/Marinara-Engine-Refactor.git#main
+        <pre><code>docker build -t marinara-engine-server https://github.com/Pasta-Devs/Marinara-Engine.git#refactor
 docker run --rm -p 8787:8787 -v marinara-server-data:/data marinara-engine-server</code></pre>
 
         <h2>Checks</h2>

--- a/skills/marinara-agent-workflow/references/marinara-overrides.md
+++ b/skills/marinara-agent-workflow/references/marinara-overrides.md
@@ -41,9 +41,9 @@ Do not treat missing pack automation as a blocker. Treat it as a reason to make 
 
 ## Branches And PR Targets
 
-The source pack has Marinara assumptions about `Pasta-Devs/Marinara-Engine`, `staging`, and team-branch workflow. This checkout is `Pasta-Devs/Marinara-Engine-Refactor` on `main`.
+The source pack has Marinara assumptions about legacy `staging` and team-branch workflow. This checkout is `Pasta-Devs/Marinara-Engine` on the `refactor` branch unless the current task says otherwise.
 
-Always verify `git status --short --branch`, `git branch --show-current`, and `git remote -v` before shipping. Do not assume `staging`, fork workflow, or team-branch workflow unless the current repo and user request confirm it.
+Always verify `git status --short --branch`, `git branch --show-current`, and `git remote -v` before shipping. Do not assume `staging`, `main`, fork workflow, or team-branch workflow unless the current repo and user request confirm it.
 
 Never push directly to protected branches or force-push without explicit approval.
 

--- a/skills/marinara-agent-workflow/references/source-map.md
+++ b/skills/marinara-agent-workflow/references/source-map.md
@@ -14,7 +14,7 @@ This map explains how source files connect to this repo-local skill.
 - `workflows/vault-capture.md` -> `references/workflows/durable-notes.md`
 - `REFACTOR_HANDOFF.md` -> `references/workflows/refactor-handoff.md`
 
-These cards are source-derived but rewritten where needed so they do not assume a root `CHANGELOG.md`, `.agents/automation` helpers, `staging`, issue templates, labels, Obsidian vaults, or the original `Pasta-Devs/Marinara-Engine` repo.
+These cards are source-derived but rewritten where needed so they do not assume a root `CHANGELOG.md`, `.agents/automation` helpers, legacy `staging` workflow, issue templates, labels, or Obsidian vaults.
 
 ## Imported As Templates
 
@@ -44,5 +44,5 @@ The JSON and PR proof templates are kept source-shaped. `status-snippets.md` is 
 - Repo instruction authority: `AGENTS.md`.
 - Architecture docs: `docs/developer/architecture.html`, `modules.html`, and `impact-areas.html`.
 - Durable bug/work tracking: GitHub issues and PRs, not repo-local update files.
-- Current checkout during import: `Pasta-Devs/Marinara-Engine-Refactor`, branch `main`.
+- Current refactor workflow target: `Pasta-Devs/Marinara-Engine`, branch `refactor`.
 - No root `CHANGELOG.md`, no `.agents/automation/scripts`, and no `.github/ISSUE_TEMPLATE` directory were present during import.


### PR DESCRIPTION
## What?

Updates stale refactor workflow references so docs point at `Pasta-Devs/Marinara-Engine` branch `refactor` instead of the retired standalone `Pasta-Devs/Marinara-Engine-Refactor` repo on `main`.

Fixes #1152

## Why?

The refactor workflow now lives in the main Marinara Engine repo on the `refactor` branch. Leaving the old repo/branch in developer docs and workflow references can send contributors and agents to the wrong checkout.

## How?

- Changed the Docker remote git context example in `docs/developer/run-build.html` to `https://github.com/Pasta-Devs/Marinara-Engine.git#refactor`.
- Updated `skills/marinara-agent-workflow/references/marinara-overrides.md` so the branch guidance names the current repo/branch and still tells agents to verify the live checkout before shipping.
- Updated `skills/marinara-agent-workflow/references/source-map.md` so the local repo assumptions describe the current refactor workflow target.

## Testing?

Machine/Codex verification:

- Reproduced the stale references with targeted `rg` before the fix.
- `rg -n 'Marinara-Engine-Refactor|github\.com/Pasta-Devs/Marinara-Engine\.git#main|branch `main`|branch main|#main' docs skills .github README.md AGENTS.md package.json scripts` returned no matches after the fix.
- Positive-control `rg` confirmed the touched files now reference `Pasta-Devs/Marinara-Engine` / `refactor`.
- `pnpm check:docs` passed: checked 40 docs and repo guidance files.
- `pnpm check` passed: architecture, frontend, Rust, and docs checks.
- `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json` passed.
- Bunny review pass: passed for the current diff before opening the PR.

Manual verification needed: none. This is a docs-only stale-reference fix with no app UI state.

## Screenshots

N/A; docs/workflow text only.

## Anything Else?

Target base is `refactor` per the issue and request. Draft PR opened for normal review flow; no runtime, schema, dependency, release, prompt, or storage files changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Docker build instructions for the remote runtime setup with new repository references.
  * Updated workflow configuration and source map documentation with revised repository checkout and branch information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1174?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->