### PR TITLE
Fix legacy profile settings import

### DIFF
--- a/src-tauri/src/commands/storage/imports/marinara.rs
+++ b/src-tauri/src/commands/storage/imports/marinara.rs
@@ -1,5 +1,8 @@
 use super::*;
 
+const PROFILE_IMPORT_GUIDANCE: &str =
+    "Full profile exports must be imported with Import Profile in Settings -> Import. Use Import Profile (JSON/ZIP) instead.";
+
 pub(super) fn import_marinara_file(state: &AppState, body: Value) -> AppResult<Value> {
     let uploaded = decode_uploaded_file_value(
         body.get("file")
@@ -12,6 +15,9 @@ pub(super) fn import_marinara_file(state: &AppState, body: Value) -> AppResult<V
     }
 
     let names = read_zip_entry_names(&uploaded.bytes)?;
+    if zip_entry_name_case_insensitive(&names, "marinara-profile.json").is_some() {
+        return Err(AppError::invalid_input(PROFILE_IMPORT_GUIDANCE));
+    }
     const MAX_PACKAGE_ENTRIES: usize = 8;
     const MAX_DATA_JSON_BYTES: usize = 5 * 1024 * 1024;
     const MAX_AVATAR_BYTES: usize = 20 * 1024 * 1024;
@@ -678,8 +684,46 @@ pub(super) fn import_marinara_envelope(state: &AppState, envelope: Value) -> App
         "marinara_persona" => import_marinara_persona(state, data),
         "marinara_lorebook" => import_marinara_lorebook(state, object, data),
         "marinara_preset" => import_marinara_preset(state, object, data),
+        "marinara_profile" => Err(AppError::invalid_input(PROFILE_IMPORT_GUIDANCE)),
         _ => Err(AppError::invalid_input(format!(
             "Unknown Marinara import type: {import_type}"
         ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::AppState;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn test_state(label: &str) -> AppState {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after epoch")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("marinara-import-{label}-{nonce}"));
+        if path.exists() {
+            std::fs::remove_dir_all(&path).expect("stale temp import dir should be removable");
+        }
+        AppState::from_data_dir(path, Vec::new()).expect("test app state should initialize")
+    }
+
+    #[test]
+    fn generic_marinara_import_directs_profile_exports_to_profile_import() {
+        let state = test_state("profile-envelope");
+        let error = import_marinara_envelope(
+            &state,
+            json!({
+                "type": "marinara_profile",
+                "version": 1,
+                "data": { "collections": {} }
+            }),
+        )
+        .expect_err("profile export should not go through generic Marinara import");
+
+        assert_eq!(error.code, "invalid_input");
+        assert!(error.message.contains("Import Profile"));
+        assert!(!error.message.contains("Unknown Marinara import type"));
     }
 }

--- a/src-tauri/src/commands/storage/profile.rs
+++ b/src-tauri/src/commands/storage/profile.rs
@@ -176,3 +176,64 @@ fn profile_collections(state: &AppState) -> AppResult<Map<String, Value>> {
     }
     Ok(collections)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::AppState;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn test_state(label: &str) -> AppState {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after epoch")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("marinara-profile-import-{label}-{nonce}"));
+        if path.exists() {
+            std::fs::remove_dir_all(&path).expect("stale temp profile dir should be removable");
+        }
+        AppState::from_data_dir(path, Vec::new()).expect("test app state should initialize")
+    }
+
+    #[test]
+    fn profile_import_legacy_file_storage_app_settings_key_sets_ui_id() {
+        let state = test_state("legacy-file-storage-app-settings");
+        state
+            .storage
+            .upsert_with_id(
+                "app-settings",
+                "ui",
+                json!({ "value": { "theme": "seeded" } }),
+            )
+            .expect("seeded ui settings should write");
+
+        import_profile(
+            &state,
+            json!({
+                "type": "marinara_profile",
+                "version": 1,
+                "data": {
+                    "fileStorage": {
+                        "tables": {
+                            "app_settings": [
+                                {
+                                    "key": "ui",
+                                    "value": { "theme": "imported" }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }),
+        )
+        .expect("legacy file-storage profile import should succeed");
+
+        let ui = state
+            .storage
+            .get("app-settings", "ui")
+            .expect("ui settings lookup should not fail")
+            .expect("imported ui settings should be addressable by id");
+        assert_eq!(ui["id"], "ui");
+        assert_eq!(ui["value"]["theme"], "imported");
+    }
+}

--- a/src-tauri/src/commands/storage/profile/legacy.rs
+++ b/src-tauri/src/commands/storage/profile/legacy.rs
@@ -74,6 +74,7 @@ pub(super) fn import_legacy_profile_tables_with_restored_assets(
     for (table, collection) in LEGACY_PROFILE_TABLES {
         let mut rows = table_rows(tables, table);
         match *collection {
+            "app-settings" => normalize_legacy_app_settings(&mut rows),
             "lorebooks" => add_legacy_lorebook_links(&mut rows, tables),
             "chats" => add_legacy_chat_memories(&mut rows, tables),
             "messages" => add_legacy_message_swipes(&mut rows, tables),
@@ -97,6 +98,21 @@ fn table_rows(tables: &Map<String, Value>, table: &str) -> Vec<Value> {
         .and_then(Value::as_array)
         .cloned()
         .unwrap_or_default()
+}
+
+fn normalize_legacy_app_settings(rows: &mut [Value]) {
+    for row in rows {
+        let Some(object) = row.as_object_mut() else {
+            continue;
+        };
+        let legacy_key = trimmed_string(object.get("key"));
+        if trimmed_string(object.get("id")).is_none() {
+            if let Some(key) = legacy_key {
+                object.insert("id".to_string(), Value::String(key));
+            }
+        }
+        object.remove("key");
+    }
 }
 
 fn add_legacy_lorebook_links(rows: &mut [Value], tables: &Map<String, Value>) {
@@ -296,6 +312,80 @@ fn diagnostic_string(value: Option<&Value>) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::state::AppState;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn test_state(label: &str) -> AppState {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after epoch")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("marinara-profile-legacy-{label}-{nonce}"));
+        if path.exists() {
+            std::fs::remove_dir_all(&path).expect("stale temp profile dir should be removable");
+        }
+        AppState::from_data_dir(path, Vec::new()).expect("test app state should initialize")
+    }
+
+    #[test]
+    fn legacy_app_settings_key_rows_import_as_settings_ids() {
+        let state = test_state("app-settings-key");
+        state
+            .storage
+            .upsert_with_id(
+                "app-settings",
+                "ui",
+                json!({ "value": { "theme": "seeded" } }),
+            )
+            .expect("seeded ui settings should write");
+        let mut tables = Map::new();
+        tables.insert(
+            "app_settings".to_string(),
+            json!([
+                {
+                    "key": "ui",
+                    "value": { "theme": "imported" },
+                    "updatedAt": "2026-05-24T00:00:00Z"
+                }
+            ]),
+        );
+
+        import_legacy_profile_tables_with_restored_assets(&state, &tables, 0)
+            .expect("legacy profile import should succeed");
+
+        let ui = state
+            .storage
+            .get("app-settings", "ui")
+            .expect("ui settings lookup should not fail")
+            .expect("imported ui settings should be addressable by id");
+        assert_eq!(ui["id"], "ui");
+        assert_eq!(ui["value"]["theme"], "imported");
+        assert!(!ui.as_object().unwrap().contains_key("key"));
+    }
+
+    #[test]
+    fn legacy_app_settings_blank_key_does_not_create_ui_id() {
+        let state = test_state("app-settings-blank-key");
+        let mut tables = Map::new();
+        tables.insert(
+            "app_settings".to_string(),
+            json!([
+                {
+                    "key": "  ",
+                    "value": { "theme": "not-ui" }
+                }
+            ]),
+        );
+
+        import_legacy_profile_tables_with_restored_assets(&state, &tables, 0)
+            .expect("legacy profile import should preserve malformed rows without matching ui");
+
+        assert!(state
+            .storage
+            .get("app-settings", "ui")
+            .expect("ui settings lookup should not fail")
+            .is_none());
+    }
 
     #[test]
     fn legacy_game_state_snapshot_maps_sqlite_field_names_to_tracker_rows() {


### PR DESCRIPTION
## What?

Fixes legacy full-profile imports on the refactor branch so `data.fileStorage.tables.app_settings` rows with `key: "ui"` are restored as `app-settings` records with `id: "ui"`.

Also recognizes `marinara_profile` exports in the generic Marinara importer and returns guidance to use Settings -> Import Profile instead of the low-level unknown import type message.

Fixes #1124

## Why?

A fresh Docker/file-storage instance can already have seeded synced UI settings before a full profile import runs. Legacy profile exports store that row under `app_settings.key`, while refactor storage reads settings by `id`; without normalization, imported UI settings are not addressable through the storage API.

## How?

- Normalizes legacy `app_settings.key` into `app-settings.id` during legacy profile table import.
- Removes the stale legacy `key` field after normalization.
- Adds a should-not-match guard so blank legacy keys do not create `id: "ui"`.
- Adds profile-export guidance for generic `.json` Marinara imports and profile ZIPs selected through the single-file importer.

## Machine Verification

- Before fix: `cargo test --manifest-path src-tauri/Cargo.toml legacy_app_settings_key_rows_import_as_settings_ids` failed because imported UI settings were not addressable by id.
- Before fix: `cargo test --manifest-path src-tauri/Cargo.toml generic_marinara_import_directs_profile_exports_to_profile_import` failed because the generic importer did not direct profile exports to Import Profile.
- After fix: `cargo test --manifest-path src-tauri/Cargo.toml profile` passed, 12 tests.
- After fix: `pnpm check` passed.
- Proof gate: `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json` passed.
- Bunny: pre-PR Bunny review passed for the current diff.

## Manual Verification

None required for the core claim; the storage/import behavior is covered by route-level and helper-level Rust regression tests plus `pnpm check`.

## Notes

This PR targets `refactor` as requested. The exact old duplicate-primary-key insert path from the issue body has been replaced on `refactor`; the matching broken branch behavior was legacy `app_settings.key` rows not being normalized into id-based app settings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Marinara profile imports now validate against full profile exports and direct users to the correct "Import Profile" feature in Settings
  * Improved legacy profile data migration with proper normalization of settings during imports

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1177?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->