### PR TITLE
Port TTS speed fallback to refactor

### DIFF
--- a/src/features/modes/shared/chat-ui/components/ChatMessage.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatMessage.tsx
@@ -45,7 +45,11 @@ import { useTranslate } from "../../../../../shared/hooks/use-translate";
 import { storageApi } from "../../../../../shared/api/storage-api";
 import { ttsService } from "../../../../../shared/lib/tts-service";
 import { useTTSConfig } from "../../../../../shared/hooks/use-tts";
-import { buildTTSMessageText, resolveTTSVoiceForSpeaker } from "../../../../../shared/lib/tts-dialogue";
+import {
+  buildTTSMessageText,
+  clientSidePlaybackRate,
+  resolveTTSVoiceForSpeaker,
+} from "../../../../../shared/lib/tts-dialogue";
 import { DIALOGUE_QUOTE_PATTERN_SOURCE, HTML_SAFE_DIALOGUE_QUOTE_PATTERN_SOURCE } from "../../../../../shared/lib/dialogue-quotes";
 import DOMPurify from "dompurify";
 import type { CharacterMap, MessageSelectionToggle, PersonaInfo } from "../types";
@@ -765,9 +769,13 @@ export const ChatMessage = memo(function ChatMessage({
       ttsService.stop();
     } else {
       if (!ttsSpeakText) return;
-      void ttsService.speak(ttsSpeakText, message.id, { speaker: ttsSpeakerName, voice: ttsVoice });
+      void ttsService.speak(ttsSpeakText, message.id, {
+        speaker: ttsSpeakerName,
+        voice: ttsVoice,
+        playbackRate: clientSidePlaybackRate(ttsConfig),
+      });
     }
-  }, [message.id, ttsSpeakText, ttsSpeakerName, ttsVoice]);
+  }, [message.id, ttsSpeakText, ttsSpeakerName, ttsVoice, ttsConfig]);
 
   const handlePauseResumeTTS = useCallback(() => {
     if (ttsService.getActiveId() !== message.id) return;

--- a/src/features/modes/shared/chat-ui/hooks/use-chat-tts-autoplay.ts
+++ b/src/features/modes/shared/chat-ui/hooks/use-chat-tts-autoplay.ts
@@ -1,6 +1,10 @@
 import { useEffect, useRef } from "react";
 import { useTTSConfig } from "../../../../../shared/hooks/use-tts";
-import { buildTTSMessageText, resolveTTSVoiceForSpeaker } from "../../../../../shared/lib/tts-dialogue";
+import {
+  buildTTSMessageText,
+  clientSidePlaybackRate,
+  resolveTTSVoiceForSpeaker,
+} from "../../../../../shared/lib/tts-dialogue";
 import { ttsService } from "../../../../../shared/lib/tts-service";
 import type { CharacterMap, MessageWithSwipes } from "../types";
 
@@ -53,6 +57,10 @@ export function useChatTtsAutoplay({ mode, messages, characterMap, isStreaming }
     const voice = resolveTTSVoiceForSpeaker(config, fallbackSpeaker, lastMessage.characterId);
     if (config.source === "elevenlabs" && !voice) return;
 
-    void ttsService.speak(text, lastMessage.id, { speaker: fallbackSpeaker, voice });
+    void ttsService.speak(text, lastMessage.id, {
+      speaker: fallbackSpeaker,
+      voice,
+      playbackRate: clientSidePlaybackRate(config),
+    });
   }, [characterMap, isStreaming]);
 }

--- a/src/features/shell/settings/components/settings/TTSConfigCard.tsx
+++ b/src/features/shell/settings/components/settings/TTSConfigCard.tsx
@@ -21,6 +21,7 @@ import { toast } from "sonner";
 import { useTTSConfig, useUpdateTTSConfig, useTTSVoices } from "../../../../../shared/hooks/use-tts";
 import { useCharacters } from "../../../../catalog/characters/index";
 import { ttsService } from "../../../../../shared/lib/tts-service";
+import { clientSidePlaybackRate } from "../../../../../shared/lib/tts-dialogue";
 import { parseCharacterDisplayData } from "../../../../../shared/lib/character-display";
 import type { TTSConfig, TTSSource, TTSVoiceAssignment, TTSVoiceMode } from "../../../../../engine/contracts/types/tts";
 import { ELEVENLABS_TTS_LANGUAGE_OPTIONS, TTS_API_KEY_MASK } from "../../../../../engine/contracts/types/tts";
@@ -475,6 +476,7 @@ export function TTSConfigCard() {
         await ttsService.speak("Hello! This is a preview of the text to speech voice.", "tts-preview", {
           throwOnError: true,
           voice: previewVoice,
+          playbackRate: clientSidePlaybackRate(payload),
         });
       } catch (error) {
         const message = error instanceof Error ? error.message : "TTS preview failed.";

--- a/src/shared/lib/tts-dialogue.ts
+++ b/src/shared/lib/tts-dialogue.ts
@@ -1,6 +1,15 @@
 import type { TTSConfig } from "../../engine/contracts/types/tts";
 import { DIALOGUE_QUOTE_CAPTURE_GROUP_PATTERN_SOURCE, stripSurroundingDialogueQuotes } from "./dialogue-quotes";
 
+export function clientSidePlaybackRate(cfg: TTSConfig | null | undefined): number {
+  if (!cfg || cfg.source !== "openai") return 1;
+
+  const baseUrl = (cfg.baseUrl || "").toLowerCase();
+  if (baseUrl.includes("api.openai.com")) return 1;
+
+  return Number.isFinite(cfg.speed) && cfg.speed > 0 ? cfg.speed : 1;
+}
+
 export interface TTSUtterance {
   text: string;
   speaker?: string;

--- a/src/shared/lib/tts-service.ts
+++ b/src/shared/lib/tts-service.ts
@@ -13,6 +13,7 @@ export interface TTSSpeakOptions {
   voice?: string;
   signal?: AbortSignal;
   throwOnError?: boolean;
+  playbackRate?: number;
 }
 
 class TTSService {
@@ -108,6 +109,9 @@ class TTSService {
     this.currentObjectUrl = objectUrl;
 
     const audio = new Audio(objectUrl);
+    if (options.playbackRate && options.playbackRate > 0 && options.playbackRate !== 1) {
+      audio.playbackRate = options.playbackRate;
+    }
     this.audio = audio;
 
     audio.onended = () => {


### PR DESCRIPTION
## What?
Ports the local OpenAI-compatible TTS speed fallback from #1141 onto the refactor branch layout.

This keeps OpenAI cloud and non-OpenAI providers at the provider-owned speed behavior, while local OpenAI-compatible TTS servers apply the configured speed slider through the browser audio element.

## Why?
#1141 targets staging, but the same fix needs to land on refactor. A straight retarget conflicts because the TTS call sites moved in the refactor branch.

## How?
- Added `clientSidePlaybackRate()` in the shared TTS dialogue helpers.
- Applied non-default playback rates inside `ttsService.speak()`.
- Passed the computed playback rate from chat autoplay, per-message speak, and settings preview.

## Testing?
- `pnpm check` passed.
- Scratch Vitest proof passed: 1 file, 4 tests.
- Bunny pass completed for the focused refactor diff.

## Screenshots
N/A, non-visual TTS playback behavior.

## Anything Else?
Source PR: #1141.

Manual verification to consider: test the speed slider against a real local OpenAI-compatible TTS server, since Codex verified the client-side playback path but did not play audio through a real local TTS provider.
