### PR TITLE
Fix pre-refactor data migration import gaps

### DIFF
--- a/src-tauri/src/commands/storage/imports/bulk_imports.rs
+++ b/src-tauri/src/commands/storage/imports/bulk_imports.rs
@@ -486,7 +486,7 @@ fn import_st_chat_text(
     chat.remove("id");
     chat.insert("name".to_string(), Value::String(chat_name));
     chat.entry("mode".to_string())
-        .or_insert(Value::String("chat".to_string()));
+        .or_insert(Value::String("conversation".to_string()));
     chat.entry("characterIds".to_string())
         .or_insert_with(|| json!([]));
     chat.entry("metadata".to_string())

--- a/src-tauri/src/commands/storage/imports/marinara.rs
+++ b/src-tauri/src/commands/storage/imports/marinara.rs
@@ -437,6 +437,18 @@ fn import_marinara_lorebook(
         &mut lorebook_data,
         &["tags", "characterIds", "personaIds"],
     );
+    // Pre-refactor also stored bool columns as TEXT (`"false"` / `"true"`).
+    // Refactor reads these directly, so `lorebook.isGlobal === "false"` is
+    // truthy and the editor shows every scoped lorebook as global.
+    normalize_legacy_text_bool_fields(
+        &mut lorebook_data,
+        &[
+            "isGlobal",
+            "enabled",
+            "recursiveScanning",
+            "excludeFromVectorization",
+        ],
+    );
     let mut lorebook = with_entity_defaults("lorebooks", lorebook_data.clone());
     if let Some(image) = data
         .get("avatar")

--- a/src-tauri/src/commands/storage/imports/marinara.rs
+++ b/src-tauri/src/commands/storage/imports/marinara.rs
@@ -430,6 +430,13 @@ fn import_marinara_lorebook(
     inherit_wrapper_timestamps(&mut lorebook_data, &data);
     remove_import_id(&mut lorebook_data);
     remove_fields(&mut lorebook_data, &["entries", "folders"]);
+    // Pre-refactor stored `tags`/`characterIds`/`personaIds` as TEXT columns
+    // (JSON-stringified arrays). Refactor expects real arrays — without this
+    // normalize step the lorebook editor crashes on `formTags.map is not a function`.
+    normalize_legacy_text_array_fields(
+        &mut lorebook_data,
+        &["tags", "characterIds", "personaIds"],
+    );
     let mut lorebook = with_entity_defaults("lorebooks", lorebook_data.clone());
     if let Some(image) = data
         .get("avatar")

--- a/src-tauri/src/commands/storage/profile/assets.rs
+++ b/src-tauri/src/commands/storage/profile/assets.rs
@@ -521,16 +521,29 @@ fn legacy_profile_asset_for_path(
     let relative = legacy_profile_asset_relative_path(value)?;
     // Profile imports stage the asset files under a temporary `staging_root`
     // and only move them into `state.data_dir` at install time, which happens
-    // AFTER row normalization. Check the staging dir too so legacy paths
-    // (e.g. `/api/avatars/file/<hash>.png`) get rewritten to the new relative
-    // form during the same pass, instead of being left as broken URLs.
-    let staged_present = staging_root
-        .map(|root| root.join(&relative).is_file())
+    // AFTER row normalization. Read from whichever location currently holds
+    // the file so legacy paths (e.g. `/api/avatars/file/<hash>.png`) get
+    // rewritten - and, for avatars, embedded as data URLs - during this pass
+    // instead of being left as broken URLs.
+    let staged_path = staging_root.map(|root| root.join(&relative));
+    let staged_present = staged_path
+        .as_ref()
+        .map(|path| path.is_file())
         .unwrap_or(false);
-    let absolute = state.data_dir.join(&relative);
-    if !staged_present && !absolute.is_file() {
+    let installed_path = state.data_dir.join(&relative);
+    let read_path = if staged_present {
+        staged_path
+            .as_ref()
+            .expect("staged_present implies staging_root is Some")
+            .clone()
+    } else if installed_path.is_file() {
+        installed_path.clone()
+    } else {
         return None;
-    }
+    };
+    // `absolute` is the post-install location stored on the row, so the
+    // reference stays valid after the staging transaction commits.
+    let absolute = installed_path;
     let filename = relative
         .file_name()
         .map(|value| value.to_string_lossy().to_string())
@@ -538,7 +551,10 @@ fn legacy_profile_asset_for_path(
     let kind = legacy_profile_asset_kind(&relative);
     let value = match kind {
         LegacyProfileAssetKind::Avatar | LegacyProfileAssetKind::FileDataUrl => {
-            data_url_from_file(&absolute)?
+            // Read from `read_path` (staging or installed, whichever holds the
+            // bytes right now) - avatars are inlined as data URLs at this
+            // point, so the bytes need to actually be available.
+            data_url_from_file(&read_path)?
         }
         LegacyProfileAssetKind::Background => managed_asset_url(
             "marinara-background:",

--- a/src-tauri/src/commands/storage/profile/assets.rs
+++ b/src-tauri/src/commands/storage/profile/assets.rs
@@ -12,6 +12,7 @@ const PROFILE_ASSET_DIRS: &[&str] = &[
     "avatars",
     "sprites",
     "backgrounds",
+    "gallery",
     "game-assets",
     "fonts",
     "knowledge-sources",

--- a/src-tauri/src/commands/storage/profile/assets.rs
+++ b/src-tauri/src/commands/storage/profile/assets.rs
@@ -75,6 +75,16 @@ impl RestoredProfileAssets {
         self.restored
     }
 
+    /// Path where staged assets live before `install()` moves them into the
+    /// live data dir. Callers that normalize legacy asset paths during the
+    /// pre-install window need this so they can find the assets that have
+    /// just been staged but are not yet at `state.data_dir`.
+    pub(super) fn staging_root(&self) -> Option<&Path> {
+        self.transaction
+            .as_ref()
+            .map(|transaction| transaction.staging_root.as_path())
+    }
+
     pub(super) fn install(&mut self) -> AppResult<()> {
         if let Some(transaction) = self.transaction.as_mut() {
             transaction.install()?;
@@ -428,11 +438,15 @@ fn profile_asset_manifest_path(asset: &Value, index: usize) -> AppResult<&str> {
         })
 }
 
-pub(super) fn normalize_legacy_profile_asset_paths(state: &AppState, value: &mut Value) {
+pub(super) fn normalize_legacy_profile_asset_paths(
+    state: &AppState,
+    staging_root: Option<&Path>,
+    value: &mut Value,
+) {
     match value {
         Value::Object(object) => {
             for nested in object.values_mut() {
-                normalize_legacy_profile_asset_paths(state, nested);
+                normalize_legacy_profile_asset_paths(state, staging_root, nested);
             }
             for field in [
                 "avatar",
@@ -449,7 +463,7 @@ pub(super) fn normalize_legacy_profile_asset_paths(state: &AppState, value: &mut
                 let Some(raw) = object.get(field).and_then(Value::as_str) else {
                     continue;
                 };
-                let Some(asset) = legacy_profile_asset_for_path(state, raw) else {
+                let Some(asset) = legacy_profile_asset_for_path(state, staging_root, raw) else {
                     continue;
                 };
                 object.insert(field.to_string(), Value::String(asset.value));
@@ -477,7 +491,7 @@ pub(super) fn normalize_legacy_profile_asset_paths(state: &AppState, value: &mut
         }
         Value::Array(items) => {
             for item in items {
-                normalize_legacy_profile_asset_paths(state, item);
+                normalize_legacy_profile_asset_paths(state, staging_root, item);
             }
         }
         Value::String(raw) => {
@@ -489,7 +503,7 @@ pub(super) fn normalize_legacy_profile_asset_paths(state: &AppState, value: &mut
                 return;
             }
             if let Ok(mut parsed) = serde_json::from_str::<Value>(raw) {
-                normalize_legacy_profile_asset_paths(state, &mut parsed);
+                normalize_legacy_profile_asset_paths(state, staging_root, &mut parsed);
                 if let Ok(serialized) = serde_json::to_string(&parsed) {
                     *raw = serialized;
                 }
@@ -499,10 +513,22 @@ pub(super) fn normalize_legacy_profile_asset_paths(state: &AppState, value: &mut
     }
 }
 
-fn legacy_profile_asset_for_path(state: &AppState, value: &str) -> Option<LegacyProfileAsset> {
+fn legacy_profile_asset_for_path(
+    state: &AppState,
+    staging_root: Option<&Path>,
+    value: &str,
+) -> Option<LegacyProfileAsset> {
     let relative = legacy_profile_asset_relative_path(value)?;
+    // Profile imports stage the asset files under a temporary `staging_root`
+    // and only move them into `state.data_dir` at install time, which happens
+    // AFTER row normalization. Check the staging dir too so legacy paths
+    // (e.g. `/api/avatars/file/<hash>.png`) get rewritten to the new relative
+    // form during the same pass, instead of being left as broken URLs.
+    let staged_present = staging_root
+        .map(|root| root.join(&relative).is_file())
+        .unwrap_or(false);
     let absolute = state.data_dir.join(&relative);
-    if !absolute.is_file() {
+    if !staged_present && !absolute.is_file() {
         return None;
     }
     let filename = relative

--- a/src-tauri/src/commands/storage/profile/legacy.rs
+++ b/src-tauri/src/commands/storage/profile/legacy.rs
@@ -2,7 +2,8 @@ use super::super::{
     game_state_snapshots,
     shared::{
         materialize_message_swipe_fields, non_negative_i64_value,
-        normalize_legacy_text_array_fields, string_array_from_value,
+        normalize_legacy_text_array_fields, normalize_legacy_text_bool_fields,
+        string_array_from_value,
     },
 };
 use super::assets::{normalize_legacy_profile_asset_paths, restore_legacy_profile_json_assets};
@@ -173,6 +174,18 @@ fn add_legacy_lorebook_links(rows: &mut [Value], tables: &Map<String, Value>) {
         normalize_legacy_text_array_fields(
             row,
             &["tags", "characterIds", "personaIds"],
+        );
+        // Pre-refactor also stored bool columns as TEXT (`"false"` / `"true"`).
+        // Without coercion, the frontend reads `lorebook.isGlobal === "false"`
+        // as truthy and renders every scoped lorebook as global in the editor.
+        normalize_legacy_text_bool_fields(
+            row,
+            &[
+                "isGlobal",
+                "enabled",
+                "recursiveScanning",
+                "excludeFromVectorization",
+            ],
         );
         let Some(object) = row.as_object_mut() else {
             continue;

--- a/src-tauri/src/commands/storage/profile/legacy.rs
+++ b/src-tauri/src/commands/storage/profile/legacy.rs
@@ -1,7 +1,8 @@
 use super::super::{
     game_state_snapshots,
     shared::{
-        materialize_message_swipe_fields, non_negative_i64_value, normalize_legacy_text_array_fields,
+        materialize_message_swipe_fields, non_negative_i64_value,
+        normalize_legacy_text_array_fields, string_array_from_value,
     },
 };
 use super::assets::{normalize_legacy_profile_asset_paths, restore_legacy_profile_json_assets};
@@ -146,39 +147,48 @@ fn add_legacy_lorebook_links(rows: &mut [Value], tables: &Map<String, Value>) {
         let Some(lorebook_id) = object.get("id").and_then(Value::as_str) else {
             continue;
         };
-        let mut character_ids =
+        let mut linked_character_ids =
             linked_ids(&character_links, "lorebookId", lorebook_id, "characterId");
-        let mut persona_ids = linked_ids(&persona_links, "lorebookId", lorebook_id, "personaId");
+        let mut linked_persona_ids =
+            linked_ids(&persona_links, "lorebookId", lorebook_id, "personaId");
         if let Some(character_id) = object
             .get("characterId")
             .and_then(Value::as_str)
             .filter(|value| !value.trim().is_empty())
         {
-            push_unique(&mut character_ids, character_id);
+            push_unique(&mut linked_character_ids, character_id);
         }
         if let Some(persona_id) = object
             .get("personaId")
             .and_then(Value::as_str)
             .filter(|value| !value.trim().is_empty())
         {
-            push_unique(&mut persona_ids, persona_id);
+            push_unique(&mut linked_persona_ids, persona_id);
         }
-        object
-            .entry("characterIds".to_string())
-            .or_insert_with(|| json!(character_ids));
-        object
-            .entry("personaIds".to_string())
-            .or_insert_with(|| json!(persona_ids));
-        // Pre-refactor stored `tags`/`characterIds`/`personaIds` as TEXT
-        // columns (JSON-stringified arrays). The refactor lorebook editor
-        // expects real arrays — without this normalize the editor crashes
-        // on `formTags.map is not a function`. The junction-table paths above
-        // emit real arrays; this catches any text-encoded values that came in
-        // directly on the lorebook row.
+        // Normalize first - pre-refactor stored `tags`/`characterIds`/`personaIds`
+        // as TEXT columns (JSON-stringified arrays). Without this the lorebook
+        // editor crashes on `formTags.map is not a function`, and the junction
+        // links computed above would be discarded by `or_insert_with` whenever
+        // the row carried a text-encoded `"[]"` placeholder.
         normalize_legacy_text_array_fields(
             row,
             &["tags", "characterIds", "personaIds"],
         );
+        let Some(object) = row.as_object_mut() else {
+            continue;
+        };
+        // Then union the (now array-shaped) row values with the link-table
+        // results so neither source is dropped.
+        let mut merged_character_ids = string_array_from_value(object.get("characterIds"));
+        for id in linked_character_ids {
+            push_unique(&mut merged_character_ids, &id);
+        }
+        object.insert("characterIds".to_string(), json!(merged_character_ids));
+        let mut merged_persona_ids = string_array_from_value(object.get("personaIds"));
+        for id in linked_persona_ids {
+            push_unique(&mut merged_persona_ids, &id);
+        }
+        object.insert("personaIds".to_string(), json!(merged_persona_ids));
     }
 }
 

--- a/src-tauri/src/commands/storage/profile/legacy.rs
+++ b/src-tauri/src/commands/storage/profile/legacy.rs
@@ -381,7 +381,7 @@ mod tests {
             ]),
         );
 
-        import_legacy_profile_tables_with_restored_assets(&state, &tables, 0, || Ok(()))
+        import_legacy_profile_tables_with_restored_assets(&state, &tables, 0, None, || Ok(()))
             .expect("legacy profile import should succeed");
 
         let ui = state
@@ -408,7 +408,7 @@ mod tests {
             ]),
         );
 
-        import_legacy_profile_tables_with_restored_assets(&state, &tables, 0, || Ok(()))
+        import_legacy_profile_tables_with_restored_assets(&state, &tables, 0, None, || Ok(()))
             .expect("legacy profile import should preserve malformed rows without matching ui");
 
         assert!(state

--- a/src-tauri/src/commands/storage/profile/legacy.rs
+++ b/src-tauri/src/commands/storage/profile/legacy.rs
@@ -1,6 +1,8 @@
 use super::super::{
     game_state_snapshots,
-    shared::{materialize_message_swipe_fields, non_negative_i64_value},
+    shared::{
+        materialize_message_swipe_fields, non_negative_i64_value, normalize_legacy_text_array_fields,
+    },
 };
 use super::assets::{normalize_legacy_profile_asset_paths, restore_legacy_profile_json_assets};
 use super::{finish_profile_import_assets, insert_profile_import_aliases};
@@ -161,6 +163,16 @@ fn add_legacy_lorebook_links(rows: &mut [Value], tables: &Map<String, Value>) {
         object
             .entry("personaIds".to_string())
             .or_insert_with(|| json!(persona_ids));
+        // Pre-refactor stored `tags`/`characterIds`/`personaIds` as TEXT
+        // columns (JSON-stringified arrays). The refactor lorebook editor
+        // expects real arrays — without this normalize the editor crashes
+        // on `formTags.map is not a function`. The junction-table paths above
+        // emit real arrays; this catches any text-encoded values that came in
+        // directly on the lorebook row.
+        normalize_legacy_text_array_fields(
+            row,
+            &["tags", "characterIds", "personaIds"],
+        );
     }
 }
 

--- a/src-tauri/src/commands/storage/profile/legacy.rs
+++ b/src-tauri/src/commands/storage/profile/legacy.rs
@@ -9,6 +9,7 @@ use super::{finish_profile_import_assets, insert_profile_import_aliases};
 use crate::state::AppState;
 use marinara_core::AppResult;
 use serde_json::{json, Map, Value};
+use std::path::Path;
 
 const LEGACY_PROFILE_TABLES: &[(&str, &str)] = &[
     ("characters", "characters"),
@@ -65,10 +66,14 @@ pub(super) fn import_legacy_profile_tables(
     let files = data.get("fileStorage").and_then(|value| value.get("files"));
     let mut restored_assets = restore_legacy_profile_json_assets(state, files)?;
     let restored_count = restored_assets.restored();
-    let result =
-        import_legacy_profile_tables_with_restored_assets(state, tables, restored_count, || {
-            restored_assets.install()
-        });
+    let staging_root = restored_assets.staging_root().map(Path::to_path_buf);
+    let result = import_legacy_profile_tables_with_restored_assets(
+        state,
+        tables,
+        restored_count,
+        staging_root.as_deref(),
+        || restored_assets.install(),
+    );
     finish_profile_import_assets(restored_assets, result)
 }
 
@@ -76,6 +81,7 @@ pub(super) fn import_legacy_profile_tables_with_restored_assets<F>(
     state: &AppState,
     tables: &Map<String, Value>,
     restored_assets: usize,
+    staging_root: Option<&Path>,
     install_assets: F,
 ) -> AppResult<Value>
 where
@@ -94,7 +100,7 @@ where
             _ => {}
         }
         for row in &mut rows {
-            normalize_legacy_profile_asset_paths(state, row);
+            normalize_legacy_profile_asset_paths(state, staging_root, row);
         }
         imported.insert((*collection).to_string(), json!(rows.len()));
         replacements.push((*collection, rows));

--- a/src-tauri/src/commands/storage/profile/zip_import.rs
+++ b/src-tauri/src/commands/storage/profile/zip_import.rs
@@ -53,10 +53,12 @@ pub(super) fn import_profile_zip(state: &AppState, path: &Path) -> AppResult<Val
         let mut restored_assets =
             restore_profile_zip_assets(state, &mut archive, &names, &profile_prefix, files)?;
         let restored_count = restored_assets.restored();
+        let staging_root = restored_assets.staging_root().map(Path::to_path_buf);
         let result = import_legacy_profile_tables_with_restored_assets(
             state,
             tables,
             restored_count,
+            staging_root.as_deref(),
             || restored_assets.install(),
         );
         finish_profile_import_assets(restored_assets, result)

--- a/src-tauri/src/commands/storage/shared.rs
+++ b/src-tauri/src/commands/storage/shared.rs
@@ -415,6 +415,38 @@ pub(crate) fn string_array_from_value(value: Option<&Value>) -> Vec<String> {
     }
 }
 
+/// Replace any text-encoded boolean field on a record object with a real
+/// JSON boolean. The pre-refactor server stored bool columns as TEXT
+/// (`"true"` / `"false"` strings); the refactor frontend reads these
+/// directly, so `lorebook.isGlobal === "false"` evaluates truthy and every
+/// scoped lorebook renders as a global one. Called from the migration
+/// import paths to bridge that schema gap.
+pub(crate) fn normalize_legacy_text_bool_fields(record: &mut Value, fields: &[&str]) {
+    let Some(object) = record.as_object_mut() else {
+        return;
+    };
+    for field in fields {
+        let Some(entry) = object.get_mut(*field) else {
+            continue;
+        };
+        if entry.is_boolean() {
+            continue;
+        }
+        let coerced = match entry.as_str().map(str::trim).map(str::to_ascii_lowercase) {
+            Some(raw) if raw == "true" || raw == "1" || raw == "yes" || raw == "on" => true,
+            Some(raw) if raw == "false" || raw == "0" || raw == "no" || raw == "off" => false,
+            _ => match entry.as_i64() {
+                Some(n) => n != 0,
+                None => match entry.as_f64() {
+                    Some(n) => n != 0.0,
+                    None => false,
+                },
+            },
+        };
+        *entry = Value::Bool(coerced);
+    }
+}
+
 /// Replace any text-encoded JSON-array field on a record object with a real
 /// JSON array. The pre-refactor server stored `tags`, `characterIds`,
 /// `personaIds`, etc. as TEXT columns (a JSON-stringified array); the

--- a/src-tauri/src/commands/storage/shared.rs
+++ b/src-tauri/src/commands/storage/shared.rs
@@ -432,12 +432,16 @@ pub(crate) fn normalize_legacy_text_array_fields(record: &mut Value, fields: &[&
         if entry.is_array() {
             continue;
         }
+        // String -> parse as JSON array, fall back to empty.
+        // Anything else (null, number, bool, object) -> empty array. Pre-refactor
+        // should only emit array or text-encoded array here; any other shape is a
+        // malformed legacy value that must not reach the editor as-is.
         if let Some(raw) = entry.as_str() {
             *entry = serde_json::from_str::<Value>(raw)
                 .ok()
                 .filter(Value::is_array)
                 .unwrap_or_else(|| json!([]));
-        } else if entry.is_null() {
+        } else {
             *entry = json!([]);
         }
     }

--- a/src-tauri/src/commands/storage/shared.rs
+++ b/src-tauri/src/commands/storage/shared.rs
@@ -415,6 +415,34 @@ pub(crate) fn string_array_from_value(value: Option<&Value>) -> Vec<String> {
     }
 }
 
+/// Replace any text-encoded JSON-array field on a record object with a real
+/// JSON array. The pre-refactor server stored `tags`, `characterIds`,
+/// `personaIds`, etc. as TEXT columns (a JSON-stringified array); the
+/// refactor expects an actual JSON array on every row, and the frontend
+/// crashes (`.map is not a function`) when it sees a string. Called from the
+/// migration import paths to bridge that schema gap.
+pub(crate) fn normalize_legacy_text_array_fields(record: &mut Value, fields: &[&str]) {
+    let Some(object) = record.as_object_mut() else {
+        return;
+    };
+    for field in fields {
+        let Some(entry) = object.get_mut(*field) else {
+            continue;
+        };
+        if entry.is_array() {
+            continue;
+        }
+        if let Some(raw) = entry.as_str() {
+            *entry = serde_json::from_str::<Value>(raw)
+                .ok()
+                .filter(Value::is_array)
+                .unwrap_or_else(|| json!([]));
+        } else if entry.is_null() {
+            *entry = json!([]);
+        }
+    }
+}
+
 #[derive(Clone)]
 pub(crate) struct UploadedFile {
     pub(crate) name: String,

--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -924,7 +924,9 @@ async function loadActivatedLore(
     await Promise.all(
       lorebooks.map(async (book) => {
         const id = readString(book.id);
-        return id ? storage.list<JsonRecord>(`lorebooks/${encodeURIComponent(id)}/entries`) : [];
+        // The refactor storage API has no path-style routes; use the
+        // dedicated capability that filters lorebook-entries by lorebookId.
+        return id ? storage.listLorebookEntries<JsonRecord>(id) : [];
       }),
     )
   ).flat();

--- a/src/features/catalog/lorebooks/components/ImportLorebookModal.tsx
+++ b/src/features/catalog/lorebooks/components/ImportLorebookModal.tsx
@@ -30,8 +30,13 @@ export function ImportLorebookModal({ open, onClose }: Props) {
         const text = await file.text();
         const json = JSON.parse(text) as Record<string, unknown>;
 
-        const isMarinaraLorebook = json.type === "marinara_lorebook" && json.version === 1;
-        const payload = isMarinaraLorebook
+        // Accept any `marinara_*` envelope so unsupported types route to the
+        // Marinara importer and surface a clear "Unknown Marinara import type"
+        // error instead of falling through to the permissive ST importer,
+        // which would silently create an empty lorebook.
+        const isMarinaraEnvelope =
+          json.version === 1 && typeof json.type === "string" && (json.type as string).startsWith("marinara_");
+        const payload = isMarinaraEnvelope
           ? {
               ...json,
               timestampOverrides: {
@@ -48,7 +53,7 @@ export function ImportLorebookModal({ open, onClose }: Props) {
               },
             };
 
-        const data = isMarinaraLorebook
+        const data = isMarinaraEnvelope
           ? await importApi.marinara<{ success: boolean; error?: string }>(payload)
           : await importApi.stLorebook<{ success: boolean; error?: string }>(payload);
         nextResults.push({

--- a/src/features/catalog/presets/components/ImportPresetModal.tsx
+++ b/src/features/catalog/presets/components/ImportPresetModal.tsx
@@ -31,8 +31,14 @@ export function ImportPresetModal({ open, onClose }: Props) {
         const text = await file.text();
         const json = JSON.parse(text);
 
-        // Detect Marinara native export format vs SillyTavern format
-        const isMarinara = json.type === "marinara_preset" && json.version === 1;
+        // Detect Marinara native export format vs SillyTavern format.
+        // Accept any `marinara_*` envelope so unsupported types (e.g.
+        // `marinara_chat_preset`, `marinara_memory_recall`) route to the
+        // Marinara importer and surface a clear "Unknown Marinara import type"
+        // error instead of falling through to the permissive ST importer,
+        // which would silently create an empty preset.
+        const isMarinara =
+          json.version === 1 && typeof json.type === "string" && (json.type as string).startsWith("marinara_");
         const payload = isMarinara
           ? {
               ...json,


### PR DESCRIPTION
## Why this change

Existing users on the pre-refactor `staging` branch cannot move their data into the Tauri refactor without hitting one of eight import or post-import gaps. The full-profile zip is rejected outright if the user has any chat images, every imported avatar lands as a broken URL, individual lorebook imports crash the editor on open, individual chat imports become unreachable, two of the seven pre-refactor envelope types silently create empty rows instead of erroring, every imported lorebook renders as `Global` even when it was scoped, and any roleplay-mode chat with an attached lorebook fails to assemble a prompt at all. This PR fixes all eight gaps as one coherent change because they share a single theme - the refactor's importers, modals, and runtime don't yet account for the schema and envelope shapes the production app actually ships.

Filed together at #1180.

## What changed

- **`src-tauri/src/commands/storage/profile/assets.rs`**: add `"gallery"` to `PROFILE_ASSET_DIRS`. The pre-refactor backup set includes a `gallery/` directory for chat-image attachments; without this the `safe_profile_asset_path` allow-list rejected the entire profile zip with `Invalid profile asset path` for any user with chat images. Also thread an optional `staging_root` through `normalize_legacy_profile_asset_paths` and `legacy_profile_asset_for_path`, and resolve the read path off the staging dir when the install transaction hasn't committed yet. PR #1153 / #1179's atomic asset transaction moves restored files into `state.data_dir` only at install time, so the previous existence check missed every just-restored avatar and the rows kept the unresolvable `/api/avatars/file/<hash>.png` URLs. Expose `RestoredProfileAssets::staging_root()` to support the same.
- **`src-tauri/src/commands/storage/profile/legacy.rs`**: read the staging root from `RestoredProfileAssets` and pass it through `import_legacy_profile_tables` / `import_legacy_profile_tables_with_restored_assets` into the per-row normalizer. Normalize legacy text-encoded array fields (`tags`, `characterIds`, `personaIds`) on lorebook rows then union them with the junction-table-derived link IDs, so neither source is dropped and the lorebook editor doesn't crash on `formTags.map is not a function`. Also normalize legacy text-encoded bool fields (`isGlobal`, `enabled`, `recursiveScanning`, `excludeFromVectorization`) on lorebook rows; pre-refactor stored these as `"true"` / `"false"` strings, which the frontend reads as truthy and renders every scoped lorebook as `Global`.
- **`src-tauri/src/commands/storage/profile/zip_import.rs`**: pass the staging root into the legacy branch alongside the `restored_assets` count.
- **`src-tauri/src/commands/storage/imports/bulk_imports.rs`**: default `import_st_chat_text` to `mode = "conversation"` instead of the bogus `"chat"`. The `ChatMode` enum is `conversation | roleplay | visual_novel | game`; the old default sat outside the enum, so imported chats never showed up in any mode sidebar.
- **`src-tauri/src/commands/storage/imports/marinara.rs`**: in `import_marinara_lorebook`, normalize legacy text-encoded array fields (`tags`, `characterIds`, `personaIds`) and bool fields (`isGlobal`, `enabled`, `recursiveScanning`, `excludeFromVectorization`) before writing the lorebook row, matching the legacy profile-zip path.
- **`src-tauri/src/commands/storage/shared.rs`**: add `normalize_legacy_text_array_fields` and `normalize_legacy_text_bool_fields` as the shared helpers both the marinara envelope path and the legacy profile-zip path use. The bool helper accepts `true|1|yes|on` and `false|0|no|off` as the truthy / falsy sets and coerces everything else (including malformed legacy values) to `false`.
- **`src/features/catalog/presets/components/ImportPresetModal.tsx`** + **`src/features/catalog/lorebooks/components/ImportLorebookModal.tsx`**: relax the strict-equality detection so any `marinara_*` envelope (not only the exactly-matched type) routes to the Marinara importer instead of the permissive SillyTavern fallback. Matches the pattern the persona and character modals already use. The Rust router then rejects unsupported envelope types (`marinara_chat_preset`, `marinara_memory_recall`) with the existing "Unknown Marinara import type" error - clear failure instead of silent empty-record success.
- **`src/engine/generation/prompt-assembly.ts`**: in `buildActivatedEntries`, use the `listLorebookEntries(lorebookId)` capability instead of calling `storage.list("lorebooks/<id>/entries")`. The path-style argument is a leftover from the pre-refactor HTTP API; the refactor storage layer rejects anything with a slash via `validate_collection_name`, so roleplay-mode chats with any attached lorebook surfaced `Invalid collection name: lorebooks/<id>/entries` the moment the user sent a message.

## Verification

- `pnpm check` and `cargo clippy --all-targets -- -D warnings` pass locally.
- Reproduced and verified every path in `pnpm tauri dev` against a snapshot of the current production tables (31 characters, 20 personas, 32 lorebooks / 1492 entries, 5 chats with 126 messages and 24 memories, 3 chat presets, 18 connections, 9 chat-image gallery attachments):
  - `chat-preset.marinara.json` and `memory-recall.marinara.json` now produce a clear "Unknown Marinara import type: <type>" error instead of creating empty preset / lorebook rows.
  - Individual character / persona / lorebook / preset `.marinara.json` files import cleanly; lorebooks open in the editor without the `formTags.map` crash.
  - SillyTavern `.jsonl` chat imports now appear under the conversation sidebar.
  - Full profile zip (49 MB, with the 9 chat-image attachments and all 51 character + persona avatars) imports end-to-end and every avatar resolves correctly post-install.
  - The lorebook list shows the correct `Global` count (5 of 32, matching the source) instead of marking every imported lorebook as global.
  - Roleplay-mode chats with one or more attached lorebooks send and receive without the `Invalid collection name` error; the prompt assembly fetches entries through the proper storage capability.
- Not yet exercised on macOS or Linux. The Rust changes are platform-agnostic but Tauri behavior should still be confirmed cross-platform before release.

## Linked issue

Closes #1180