### PR TITLE
feat: native AI-assisted Magic Rewrite for character, persona, and lorebook fields

### DIFF
--- a/packages/client/src/components/connections/ConnectionEditor.tsx
+++ b/packages/client/src/components/connections/ConnectionEditor.tsx
@@ -43,6 +43,7 @@ import {
   ImageIcon,
   RotateCcw,
   SlidersHorizontal,
+  Sparkles,
 } from "lucide-react";
 import { cn } from "../../lib/utils";
 import { showConfirmDialog } from "../../lib/app-dialogs";
@@ -149,6 +150,7 @@ export function ConnectionEditor() {
   const [localEnableCaching, setLocalEnableCaching] = useState(false);
   const [localCachingAtDepth, setLocalCachingAtDepth] = useState(DEFAULT_CACHING_AT_DEPTH);
   const [localDefaultForAgents, setLocalDefaultForAgents] = useState(false);
+  const [localDefaultForRewrite, setLocalDefaultForRewrite] = useState(false);
   const [localEmbeddingModel, setLocalEmbeddingModel] = useState("");
   const [localEmbeddingBaseUrl, setLocalEmbeddingBaseUrl] = useState("");
   const [localEmbeddingConnectionId, setLocalEmbeddingConnectionId] = useState("");
@@ -248,6 +250,7 @@ export function ConnectionEditor() {
     setLocalEnableCaching(c.enableCaching === "true" || c.enableCaching === true);
     setLocalCachingAtDepth(normalizeCachingAtDepth(c.cachingAtDepth));
     setLocalDefaultForAgents(c.defaultForAgents === "true" || c.defaultForAgents === true);
+    setLocalDefaultForRewrite(c.defaultForRewrite === "true" || c.defaultForRewrite === true);
     setLocalEmbeddingModel((c.embeddingModel as string) ?? "");
     setLocalEmbeddingBaseUrl((c.embeddingBaseUrl as string) ?? "");
     setLocalEmbeddingConnectionId((c.embeddingConnectionId as string) ?? "");
@@ -412,6 +415,7 @@ export function ConnectionEditor() {
       enableCaching: localEnableCaching,
       cachingAtDepth: localCachingAtDepth,
       defaultForAgents: localDefaultForAgents,
+      defaultForRewrite: localDefaultForRewrite,
       embeddingModel: localEmbeddingModel,
       embeddingBaseUrl: localEmbeddingBaseUrl,
       embeddingConnectionId: localEmbeddingConnectionId || null,
@@ -471,6 +475,7 @@ export function ConnectionEditor() {
     localEnableCaching,
     localCachingAtDepth,
     localDefaultForAgents,
+    localDefaultForRewrite,
     localEmbeddingModel,
     localEmbeddingBaseUrl,
     localEmbeddingConnectionId,
@@ -1724,6 +1729,32 @@ export function ConnectionEditor() {
               </p>
             )}
           </FieldGroup>
+
+          {/* ── Default for Magic Rewrite ── */}
+          {!isImageGenerationProvider && (
+            <FieldGroup
+              label="Default for Rewrite"
+              icon={<Sparkles size="0.875rem" className="text-violet-400" />}
+              help="When enabled, all Magic Rewrite text generations will use this connection. Otherwise the default chat connection will be used."
+            >
+              <label className="flex items-center gap-3 cursor-pointer select-none px-2 py-1">
+                <div className="relative">
+                  <input
+                    type="checkbox"
+                    checked={localDefaultForRewrite}
+                    onChange={(e) => {
+                      setLocalDefaultForRewrite(e.target.checked);
+                      markDirty();
+                    }}
+                    className="peer sr-only"
+                  />
+                  <div className="h-5 w-9 rounded-full bg-[var(--border)] transition-colors peer-checked:bg-violet-400/70" />
+                  <div className="absolute top-0.5 left-0.5 h-4 w-4 rounded-full bg-white shadow-sm transition-transform peer-checked:translate-x-4" />
+                </div>
+                <span className="text-sm">Use as default rewrite connection</span>
+              </label>
+            </FieldGroup>
+          )}
 
           {/* ── Claude (Subscription) — Fast Mode toggle ── */}
           {localProvider === "claude_subscription" && (

--- a/packages/client/src/components/connections/ConnectionEditor.tsx
+++ b/packages/client/src/components/connections/ConnectionEditor.tsx
@@ -415,7 +415,7 @@ export function ConnectionEditor() {
       enableCaching: localEnableCaching,
       cachingAtDepth: localCachingAtDepth,
       defaultForAgents: localDefaultForAgents,
-      defaultForRewrite: localDefaultForRewrite,
+      defaultForRewrite: isImageGenerationProvider ? false : localDefaultForRewrite,
       embeddingModel: localEmbeddingModel,
       embeddingBaseUrl: localEmbeddingBaseUrl,
       embeddingConnectionId: localEmbeddingConnectionId || null,
@@ -1735,7 +1735,7 @@ export function ConnectionEditor() {
             <FieldGroup
               label="Default for Rewrite"
               icon={<Sparkles size="0.875rem" className="text-violet-400" />}
-              help="When enabled, all Magic Rewrite text generations will use this connection. Otherwise the default chat connection will be used."
+              help="When enabled, all Magic Rewrite text generations will use this connection. Falls back to Default Chat and then Default Agent connections."
             >
               <label className="flex items-center gap-3 cursor-pointer select-none px-2 py-1">
                 <div className="relative">

--- a/packages/client/src/components/lorebooks/LorebookFormFields.tsx
+++ b/packages/client/src/components/lorebooks/LorebookFormFields.tsx
@@ -244,7 +244,7 @@ export function ExpandedContentModal({
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
+      if (e.key === "Escape" && !magicRewriteMode) {
         onChange(local);
         onCommit?.();
         onClose();
@@ -252,7 +252,7 @@ export function ExpandedContentModal({
     };
     document.addEventListener("keydown", handler);
     return () => document.removeEventListener("keydown", handler);
-  }, [onClose, onChange, onCommit, local]);
+  }, [onClose, onChange, onCommit, local, magicRewriteMode]);
 
   const handleClose = () => {
     onChange(local);

--- a/packages/client/src/components/lorebooks/LorebookFormFields.tsx
+++ b/packages/client/src/components/lorebooks/LorebookFormFields.tsx
@@ -4,10 +4,11 @@
 // and LorebookEntryRow (the per-entry inline drawer).
 // Extracted from LorebookEditor.tsx so styling stays consistent.
 // ──────────────────────────────────────────────
-import { useEffect, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
-import { FileText, Maximize2, ToggleLeft, ToggleRight, X } from "lucide-react";
+import { useCallback, useEffect, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
+import { FileText, Maximize2, Sparkles, ToggleLeft, ToggleRight, X } from "lucide-react";
 import { cn } from "../../lib/utils";
 import { HelpTooltip } from "../ui/HelpTooltip";
+import { MagicRewritePanel } from "../ui/MagicRewritePanel";
 
 export function FieldGroup({
   label,
@@ -233,6 +234,8 @@ export function ExpandedContentModal({
   placeholder?: string;
 }) {
   const [local, setLocal] = useState(value);
+  const [magicRewriteMode, setMagicRewriteMode] = useState(false);
+  const [magicRewriteResult, setMagicRewriteResult] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   useEffect(() => {
@@ -257,36 +260,87 @@ export function ExpandedContentModal({
     onClose();
   };
 
+  const handleMagicRewriteBack = () => {
+    setMagicRewriteMode(false);
+    setMagicRewriteResult("");
+  };
+
+  const handleMagicRewriteApply = () => {
+    if (!magicRewriteResult) return;
+    setLocal(magicRewriteResult);
+    setMagicRewriteMode(false);
+    setMagicRewriteResult("");
+    window.setTimeout(() => textareaRef.current?.focus(), 100);
+  };
+
+  const handleMagicRewriteResultChange = useCallback((next: string) => {
+    setMagicRewriteResult(next);
+  }, []);
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-6 max-md:pt-[max(1.5rem,env(safe-area-inset-top))]">
       <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={handleClose} />
-      <div className="relative flex h-[80vh] w-full max-w-3xl flex-col rounded-2xl border border-[var(--border)] bg-[var(--card)] shadow-2xl shadow-black/50">
+      <div className="relative flex h-[80vh] w-full max-w-5xl flex-col rounded-2xl border border-[var(--border)] bg-[var(--card)] shadow-2xl shadow-black/50">
         <div className="flex items-center justify-between border-b border-[var(--border)] px-4 py-3">
-          <h3 className="text-sm font-semibold">{title}</h3>
-          <button onClick={handleClose} className="rounded-lg p-1.5 hover:bg-[var(--accent)]">
-            <X size="1rem" />
-          </button>
+          <h3 className="text-sm font-semibold">{magicRewriteMode ? "✨ Magic Rewrite" : title}</h3>
+          <div className="flex items-center gap-2">
+            <button onClick={handleClose} className="rounded-lg p-1.5 hover:bg-[var(--accent)]">
+              <X size="1rem" />
+            </button>
+          </div>
         </div>
         <div className="flex-1 overflow-hidden p-4">
-          <textarea
-            ref={textareaRef}
-            value={local}
-            onChange={(e) => setLocal(e.target.value)}
-            onKeyDown={(e) => handleTextareaTabKeyDown(e, local, setLocal)}
-            className="h-full w-full resize-none rounded-lg bg-[var(--secondary)] p-4 text-sm text-[var(--foreground)] ring-1 ring-[var(--border)] placeholder:text-[var(--muted-foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
-            placeholder={placeholder}
-          />
+          {magicRewriteMode ? (
+            <MagicRewritePanel value={local} onResultChange={handleMagicRewriteResultChange} />
+          ) : (
+            <textarea
+              ref={textareaRef}
+              value={local}
+              onChange={(e) => setLocal(e.target.value)}
+              onKeyDown={(e) => handleTextareaTabKeyDown(e, local, setLocal)}
+              className="h-full w-full resize-none rounded-lg bg-[var(--secondary)] p-4 text-sm text-[var(--foreground)] ring-1 ring-[var(--border)] placeholder:text-[var(--muted-foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+              placeholder={placeholder}
+            />
+          )}
         </div>
         <div className="flex items-center justify-between border-t border-[var(--border)] px-4 py-2.5">
           <p className="text-[0.625rem] text-[var(--muted-foreground)]">
-            Changes auto-save on close. Press Escape to close.
+            {magicRewriteMode ? "Back returns to the editor without applying. Apply moves the preview into the editor." : "Changes auto-save on close. Press Escape to close."}
           </p>
-          <button
-            onClick={handleClose}
-            className="rounded-xl bg-gradient-to-r from-amber-400 to-orange-500 px-4 py-1.5 text-xs font-medium text-white shadow-md hover:shadow-lg active:scale-[0.98]"
-          >
-            Done
-          </button>
+          {magicRewriteMode ? (
+            <div className="flex items-center gap-2">
+              <button
+                onClick={handleMagicRewriteBack}
+                className="rounded-xl border border-[var(--border)] px-4 py-1.5 text-xs font-medium text-[var(--foreground)] hover:bg-[var(--accent)] active:scale-[0.98]"
+              >
+                Back
+              </button>
+              <button
+                onClick={handleMagicRewriteApply}
+                disabled={!magicRewriteResult}
+                className="rounded-xl bg-gradient-to-r from-violet-500 to-fuchsia-500 px-4 py-1.5 text-xs font-medium text-white shadow-md hover:shadow-lg active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                Apply
+              </button>
+            </div>
+          ) : (
+            <div className="flex items-center gap-2">
+              <button
+                onClick={() => setMagicRewriteMode(true)}
+                className="inline-flex items-center gap-1.5 rounded-lg border border-violet-400/30 bg-violet-500/10 px-3 py-1.5 text-xs font-medium text-violet-200 hover:bg-violet-500/20"
+                title="Open Magic Rewrite"
+              >
+                <Sparkles size="0.875rem" />
+                Rewrite
+              </button>
+              <button
+                onClick={handleClose}
+                className="rounded-xl bg-gradient-to-r from-amber-400 to-orange-500 px-4 py-1.5 text-xs font-medium text-white shadow-md hover:shadow-lg active:scale-[0.98]"
+              >
+                Done
+              </button>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/packages/client/src/components/ui/ExpandedTextarea.tsx
+++ b/packages/client/src/components/ui/ExpandedTextarea.tsx
@@ -1,10 +1,11 @@
 // ──────────────────────────────────────────────
 // Expanded Textarea — Fullscreen editing overlay
 // ──────────────────────────────────────────────
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { motion, AnimatePresence } from "framer-motion";
-import { Minimize2 } from "lucide-react";
+import { Minimize2, Sparkles } from "lucide-react";
+import { MagicRewritePanel } from "./MagicRewritePanel";
 
 interface ExpandedTextareaProps {
   open: boolean;
@@ -17,22 +18,53 @@ interface ExpandedTextareaProps {
 
 export function ExpandedTextarea({ open, onClose, title, value, onChange, placeholder }: ExpandedTextareaProps) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const [local, setLocal] = useState(value);
+  const [magicRewriteMode, setMagicRewriteMode] = useState(false);
+  const [magicRewriteResult, setMagicRewriteResult] = useState("");
+
+  // Sync parent value into local when prop changes
+  useEffect(() => {
+    setLocal(value);
+  }, [value]);
 
   useEffect(() => {
     if (!open) return;
     const handler = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
+      if (e.key === "Escape" && !magicRewriteMode) onClose();
     };
     document.addEventListener("keydown", handler);
     return () => document.removeEventListener("keydown", handler);
-  }, [open, onClose]);
+  }, [open, onClose, magicRewriteMode]);
 
   // Focus textarea when opened
   useEffect(() => {
-    if (open) {
+    if (open && !magicRewriteMode) {
       requestAnimationFrame(() => textareaRef.current?.focus());
     }
-  }, [open]);
+  }, [open, magicRewriteMode]);
+
+  const handleClose = () => {
+    onChange(local);
+    onClose();
+  };
+
+  const handleMagicRewriteResultChange = useCallback((next: string) => {
+    setMagicRewriteResult(next);
+  }, []);
+
+  const handleMagicRewriteApply = () => {
+    if (!magicRewriteResult) return;
+    setLocal(magicRewriteResult);
+    setMagicRewriteMode(false);
+    setMagicRewriteResult("");
+    onChange(magicRewriteResult);
+    requestAnimationFrame(() => textareaRef.current?.focus());
+  };
+
+  const handleMagicRewriteBack = () => {
+    setMagicRewriteMode(false);
+    setMagicRewriteResult("");
+  };
 
   return createPortal(
     <AnimatePresence>
@@ -46,11 +78,38 @@ export function ExpandedTextarea({ open, onClose, title, value, onChange, placeh
         >
           {/* Header */}
           <div className="flex shrink-0 items-center justify-between border-b border-[var(--border)] px-5 py-3">
-            <h2 className="text-sm font-semibold">{title}</h2>
+            <h2 className="text-sm font-semibold">{magicRewriteMode ? "✨ Magic Rewrite" : title}</h2>
             <div className="flex items-center gap-2">
-              <span className="text-[0.625rem] text-[var(--muted-foreground)]">{value.length} characters</span>
+              {!magicRewriteMode && (
+                <button
+                  onClick={() => setMagicRewriteMode(true)}
+                  className="flex items-center gap-1.5 rounded-lg border border-violet-400/30 bg-violet-500/10 px-2.5 py-1.5 text-xs font-medium text-violet-200 hover:bg-violet-500/20"
+                  title="Open Magic Rewrite"
+                >
+                  <Sparkles size="0.875rem" />
+                  Rewrite
+                </button>
+              )}
+              {magicRewriteMode && (
+                <button
+                  onClick={handleMagicRewriteBack}
+                  className="flex items-center gap-1.5 rounded-lg border border-[var(--border)] px-2.5 py-1.5 text-xs font-medium text-[var(--foreground)] hover:bg-[var(--accent)]"
+                >
+                  Back
+                </button>
+              )}
+              {magicRewriteMode && (
+                <button
+                  onClick={handleMagicRewriteApply}
+                  disabled={!magicRewriteResult}
+                  className="rounded-xl bg-gradient-to-r from-violet-500 to-fuchsia-500 px-3 py-1.5 text-xs font-medium text-white disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  Apply
+                </button>
+              )}
+              <span className="text-[0.625rem] text-[var(--muted-foreground)]">{local.length} characters</span>
               <button
-                onClick={onClose}
+                onClick={handleClose}
                 className="flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
               >
                 <Minimize2 size="0.875rem" />
@@ -59,15 +118,19 @@ export function ExpandedTextarea({ open, onClose, title, value, onChange, placeh
             </div>
           </div>
 
-          {/* Textarea */}
+          {/* Content */}
           <div className="flex-1 overflow-hidden p-4 md:p-6">
-            <textarea
-              ref={textareaRef}
-              value={value}
-              onChange={(e) => onChange(e.target.value)}
-              placeholder={placeholder}
-              className="h-full w-full resize-none rounded-xl border border-[var(--border)] bg-[var(--secondary)] p-5 text-sm leading-relaxed outline-none transition-colors placeholder:text-[var(--muted-foreground)]/40 focus:border-[var(--primary)]/40 focus:ring-1 focus:ring-[var(--primary)]/20"
-            />
+            {magicRewriteMode ? (
+              <MagicRewritePanel value={local} onResultChange={handleMagicRewriteResultChange} />
+            ) : (
+              <textarea
+                ref={textareaRef}
+                value={local}
+                onChange={(e) => setLocal(e.target.value)}
+                placeholder={placeholder}
+                className="h-full w-full resize-none rounded-xl border border-[var(--border)] bg-[var(--secondary)] p-5 text-sm leading-relaxed outline-none transition-colors placeholder:text-[var(--muted-foreground)]/40 focus:border-[var(--primary)]/40 focus:ring-1 focus:ring-[var(--primary)]/20"
+              />
+            )}
           </div>
         </motion.div>
       )}

--- a/packages/client/src/components/ui/ExpandedTextarea.tsx
+++ b/packages/client/src/components/ui/ExpandedTextarea.tsx
@@ -22,10 +22,14 @@ export function ExpandedTextarea({ open, onClose, title, value, onChange, placeh
   const [magicRewriteMode, setMagicRewriteMode] = useState(false);
   const [magicRewriteResult, setMagicRewriteResult] = useState("");
 
-  // Sync parent value into local when prop changes
+  // Sync parent value into local when prop changes; reset rewrite state on close
   useEffect(() => {
+    if (!open) {
+      setMagicRewriteMode(false);
+      setMagicRewriteResult("");
+    }
     setLocal(value);
-  }, [value]);
+  }, [value, open]);
 
   useEffect(() => {
     if (!open) return;

--- a/packages/client/src/components/ui/MagicRewritePanel.tsx
+++ b/packages/client/src/components/ui/MagicRewritePanel.tsx
@@ -90,7 +90,9 @@ export function MagicRewritePanel({
   value: string;
   onResultChange: (value: string) => void;
 }) {
-  const [instruction, setInstruction] = useState(() => window.localStorage.getItem(PROMPT_KEY) ?? "");
+  const [instruction, setInstruction] = useState(() => {
+    try { return window.localStorage.getItem(PROMPT_KEY) ?? ""; } catch { return ""; }
+  });
   const [characters, setCharacters] = useState<MinimalItem[]>([]);
   const [lorebooks, setLorebooks] = useState<MinimalItem[]>([]);
   const [characterId, setCharacterId] = useState("");
@@ -102,7 +104,7 @@ export function MagicRewritePanel({
   const [error, setError] = useState("");
 
   useEffect(() => {
-    const timer = window.setTimeout(() => window.localStorage.setItem(PROMPT_KEY, instruction), 300);
+    const timer = window.setTimeout(() => { try { window.localStorage.setItem(PROMPT_KEY, instruction); } catch { /* noop */ } }, 300);
     return () => window.clearTimeout(timer);
   }, [instruction]);
 

--- a/packages/client/src/components/ui/MagicRewritePanel.tsx
+++ b/packages/client/src/components/ui/MagicRewritePanel.tsx
@@ -1,0 +1,243 @@
+// ──────────────────────────────────────────────
+// Magic Rewrite Panel
+// ──────────────────────────────────────────────
+import { useEffect, useMemo, useState } from "react";
+import { Sparkles, Loader2 } from "lucide-react";
+import { api } from "../../lib/api-client";
+
+const PROMPT_KEY = "magic-rewrite-prompt";
+
+type MinimalItem = { id: string; name?: string; title?: string; content?: string; description?: string; data?: unknown };
+type ChatMessage = { role?: string; name?: string; content?: string | { text?: string }; characterId?: string; extra?: unknown };
+
+type RewriteResponse = { text: string };
+type DiffPart = { text: string; changed: boolean };
+type DiffResult =
+  | { skipped: true; before: string; after: string }
+  | { skipped: false; before: DiffPart[]; after: DiffPart[] };
+
+function readActiveChatId(): string | null {
+  try {
+    return window.localStorage.getItem("marinara-active-chat-id");
+  } catch {
+    return null;
+  }
+}
+
+function parseCardData(data: unknown): Record<string, unknown> | null {
+  if (!data) return null;
+  if (typeof data === "object") return data as Record<string, unknown>;
+  if (typeof data !== "string") return null;
+  try {
+    const parsed = JSON.parse(data) as unknown;
+    return parsed && typeof parsed === "object" ? parsed as Record<string, unknown> : null;
+  } catch {
+    return null;
+  }
+}
+
+function labelFor(item: MinimalItem, fallback: string): string {
+  const data = parseCardData(item.data);
+  return item.name || item.title || (typeof data?.name === "string" ? data.name : "") || fallback;
+}
+
+function textFromMessage(message: ChatMessage): string {
+  if (typeof message.content === "string") return message.content;
+  if (message.content && typeof message.content.text === "string") return message.content.text;
+  return "";
+}
+
+function diffWords(before: string, after: string): DiffResult {
+  const beforeWords = before.match(/\S+|\s+/g) ?? [];
+  const afterWords = after.match(/\S+|\s+/g) ?? [];
+  if (beforeWords.length + afterWords.length > 3000) {
+    return { before: before, after: after, skipped: true };
+  }
+
+  const dp = Array.from({ length: beforeWords.length + 1 }, () => new Uint16Array(afterWords.length + 1));
+  for (let i = 1; i <= beforeWords.length; i++) {
+    for (let j = 1; j <= afterWords.length; j++) {
+      dp[i][j] = beforeWords[i - 1] === afterWords[j - 1] ? dp[i - 1][j - 1] + 1 : Math.max(dp[i - 1][j], dp[i][j - 1]);
+    }
+  }
+
+  const deleted = new Uint8Array(beforeWords.length);
+  const added = new Uint8Array(afterWords.length);
+  let i = beforeWords.length;
+  let j = afterWords.length;
+  while (i > 0 || j > 0) {
+    if (i > 0 && j > 0 && beforeWords[i - 1] === afterWords[j - 1]) {
+      i--;
+      j--;
+    } else if (j > 0 && (i === 0 || dp[i][j - 1] >= dp[i - 1][j])) {
+      added[--j] = 1;
+    } else {
+      deleted[--i] = 1;
+    }
+  }
+
+  return {
+    skipped: false,
+    before: beforeWords.map((word, index) => ({ text: word, changed: deleted[index] === 1 })),
+    after: afterWords.map((word, index) => ({ text: word, changed: added[index] === 1 })),
+  };
+}
+
+export function MagicRewritePanel({
+  value,
+  onResultChange,
+}: {
+  value: string;
+  onResultChange: (value: string) => void;
+}) {
+  const [instruction, setInstruction] = useState(() => window.localStorage.getItem(PROMPT_KEY) ?? "");
+  const [characters, setCharacters] = useState<MinimalItem[]>([]);
+  const [lorebooks, setLorebooks] = useState<MinimalItem[]>([]);
+  const [characterId, setCharacterId] = useState("");
+  const [lorebookId, setLorebookId] = useState("");
+  const [includeChat, setIncludeChat] = useState(false);
+  const [chatLimit, setChatLimit] = useState(20);
+  const [result, setResult] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => window.localStorage.setItem(PROMPT_KEY, instruction), 300);
+    return () => window.clearTimeout(timer);
+  }, [instruction]);
+
+  useEffect(() => {
+    api.get<MinimalItem[]>("/characters").then(setCharacters).catch(() => setCharacters([]));
+    api.get<MinimalItem[]>("/lorebooks/").then(setLorebooks).catch(() => setLorebooks([]));
+  }, []);
+
+  const diff = useMemo(() => (result ? diffWords(value, result) : null), [value, result]);
+
+  useEffect(() => {
+    onResultChange(result);
+  }, [onResultChange, result]);
+
+  async function buildContext(): Promise<string> {
+    const sections: string[] = [];
+
+    if (characterId) {
+      const character = await api.get<Record<string, unknown>>(`/characters/${characterId}`);
+      sections.push(`[CHARACTER CARD]\n${JSON.stringify(character, null, 2)}`);
+    }
+
+    if (includeChat) {
+      const chatId = readActiveChatId();
+      if (chatId) {
+        const messages = await api.get<ChatMessage[]>(`/chats/${chatId}/messages?limit=${chatLimit}&skip=0`);
+        const lines = messages
+          .slice(-chatLimit)
+          .map((message) => `${message.name || message.role || "unknown"}: ${textFromMessage(message)}`)
+          .join("\n");
+        sections.push(`[CHAT HISTORY: last ${chatLimit} messages]\n${lines}`);
+      }
+    }
+
+    if (lorebookId) {
+      const entries = await api.get<MinimalItem[]>(`/lorebooks/${lorebookId}/entries`);
+      const lorebook = lorebooks.find((item) => item.id === lorebookId);
+      const lines = entries.map((entry, index) => `[${labelFor(entry, `Entry ${index + 1}`)}]\n${entry.content ?? entry.description ?? ""}`).join("\n\n");
+      sections.push(`[LOREBOOK${lorebook ? `: ${labelFor(lorebook, "")}` : ""}]\n${lines}`);
+    }
+
+    return sections.length > 0
+      ? `The following context is provided for reference. Use it to maintain consistency with the character, story, and world.\n\n${sections.join("\n\n---\n\n")}`
+      : "";
+  }
+
+  async function generate() {
+    setLoading(true);
+    setError("");
+    try {
+      const context = await buildContext();
+      const response = await api.post<RewriteResponse>("/magic-rewrite/generate", {
+        text: value,
+        instruction,
+        context,
+      });
+      setResult(response.text ?? "");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Magic Rewrite failed");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="flex h-full flex-col gap-4 overflow-hidden">
+      <div className="grid gap-4 lg:grid-cols-[minmax(0,3fr)_minmax(18rem,2fr)]">
+        <div className="flex min-w-0 flex-col">
+          <div className="mb-1.5 text-[0.65rem] font-semibold uppercase tracking-wide text-[var(--muted-foreground)]">Rewrite instructions</div>
+          <textarea
+            value={instruction}
+            onChange={(event) => setInstruction(event.target.value)}
+            placeholder='e.g. "Make this more vivid and dramatic..."'
+            className="min-h-0 flex-1 resize-none rounded-xl bg-[var(--secondary)] p-3 text-sm ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-violet-500/50"
+          />
+        </div>
+
+        <div className="space-y-3">
+          <div className="text-[0.65rem] font-semibold uppercase tracking-wide text-[var(--muted-foreground)]">Included Context</div>
+          <label className="block space-y-1 text-xs text-[var(--muted-foreground)]">
+            <span>Character Card</span>
+            <select value={characterId} onChange={(event) => setCharacterId(event.target.value)} className="w-full rounded-lg bg-[var(--secondary)] px-2 py-1.5 text-sm text-[var(--foreground)] ring-1 ring-[var(--border)]">
+              <option value="">— None —</option>
+              {characters.map((character, index) => <option key={character.id} value={character.id}>{labelFor(character, `Character ${index + 1}`)}</option>)}
+            </select>
+          </label>
+
+          <label className="block space-y-1 text-xs text-[var(--muted-foreground)]">
+            <span>Lorebook</span>
+            <select value={lorebookId} onChange={(event) => setLorebookId(event.target.value)} className="w-full rounded-lg bg-[var(--secondary)] px-2 py-1.5 text-sm text-[var(--foreground)] ring-1 ring-[var(--border)]">
+              <option value="">— None —</option>
+              {lorebooks.map((lorebook, index) => <option key={lorebook.id} value={lorebook.id}>{labelFor(lorebook, `Lorebook ${index + 1}`)}</option>)}
+            </select>
+          </label>
+
+          <label className="flex items-center gap-2 text-sm">
+            <input type="checkbox" checked={includeChat} onChange={(event) => setIncludeChat(event.target.checked)} />
+            Include Current Chat
+          </label>
+          <div className="flex items-center gap-2 text-xs text-[var(--muted-foreground)]">
+            <span>Last</span>
+            <input type="range" min={5} max={250} step={5} value={chatLimit} onChange={(event) => setChatLimit(Number(event.target.value))} className="flex-1" />
+            <span className="w-14 text-right">{chatLimit} msgs</span>
+          </div>
+
+          <button
+            onClick={generate}
+            disabled={loading}
+            className="inline-flex w-full items-center justify-center gap-2 rounded-xl border border-violet-400/40 bg-violet-500/10 px-4 py-2 text-sm font-medium text-violet-200 transition hover:bg-violet-500/20 disabled:cursor-wait disabled:opacity-60"
+          >
+            {loading ? <Loader2 size="1rem" className="animate-spin" /> : <Sparkles size="1rem" />}
+            {loading ? "Rewriting…" : "Generate Rewrite"}
+          </button>
+          {error && <p className="text-xs text-red-300">{error}</p>}
+        </div>
+      </div>
+
+      <div className="grid min-h-0 flex-1 gap-4 lg:grid-cols-2">
+        <div className="min-h-0 overflow-auto rounded-xl bg-[var(--secondary)] p-3 text-sm ring-1 ring-[var(--border)]">
+          <div className="mb-2 text-[0.65rem] font-semibold uppercase tracking-wide text-[var(--muted-foreground)]">Before</div>
+          <div className="whitespace-pre-wrap break-words font-sans">
+            {diff && !diff.skipped && Array.isArray(diff.before)
+              ? diff.before.map((part, index) => <span key={index} className={part.changed ? "bg-red-500/20 text-red-200 line-through" : undefined}>{part.text}</span>)
+              : value}
+          </div>
+        </div>
+        <div className="min-h-0 overflow-auto rounded-xl bg-[var(--secondary)] p-3 text-sm ring-1 ring-[var(--border)]">
+          <div className="mb-2 text-[0.65rem] font-semibold uppercase tracking-wide text-[var(--muted-foreground)]">After</div>
+          <div className="whitespace-pre-wrap break-words font-sans">
+            {diff && !diff.skipped && Array.isArray(diff.after)
+              ? diff.after.map((part, index) => <span key={index} className={part.changed ? "bg-emerald-500/20 text-emerald-200" : undefined}>{part.text}</span>)
+              : result || "Generated rewrite will appear here."}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -584,6 +584,11 @@ const COLUMN_MIGRATIONS: ColumnMigration[] = [
     definition: "TEXT NOT NULL DEFAULT 'false'",
   },
   {
+    table: "api_connections",
+    column: "default_for_rewrite",
+    definition: "TEXT NOT NULL DEFAULT 'false'",
+  },
+  {
     table: "chats",
     column: "folder_id",
     definition: "TEXT",

--- a/packages/server/src/db/schema/connections.ts
+++ b/packages/server/src/db/schema/connections.ts
@@ -37,6 +37,8 @@ export const apiConnections = sqliteTable("api_connections", {
   cachingAtDepth: integer("caching_at_depth").notNull().default(5),
   /** Whether this connection is the default for all agents (only one allowed) */
   defaultForAgents: text("default_for_agents").notNull().default("false"),
+  /** Whether this connection is the default for Magic Rewrite text generation (only one allowed) */
+  defaultForRewrite: text("default_for_rewrite").notNull().default("false"),
   /** Model to use for embedding generation (e.g. text-embedding-3-small) */
   embeddingModel: text("embedding_model"),
   /** Optional: separate base URL for the embedding backend (e.g. a second llama.cpp instance) */

--- a/packages/server/src/routes/index.ts
+++ b/packages/server/src/routes/index.ts
@@ -50,6 +50,7 @@ import { sidecarRoutes } from "./sidecar.routes.js";
 import { ttsRoutes } from "./tts.routes.js";
 import { promptOverridesRoutes } from "./prompt-overrides.routes.js";
 import { csrfDiagnosticsRoutes } from "./csrf-diagnostics.routes.js";
+import { magicRewriteRoutes } from "./magic-rewrite.routes.js";
 
 export async function registerRoutes(app: FastifyInstance) {
   await app.register(chatsRoutes, { prefix: "/api/chats" });
@@ -98,6 +99,7 @@ export async function registerRoutes(app: FastifyInstance) {
   await app.register(gameAssetsRoutes, { prefix: "/api/game-assets" });
   await app.register(ttsRoutes, { prefix: "/api/tts" });
   await app.register(promptOverridesRoutes, { prefix: "/api/prompt-overrides" });
+  await app.register(magicRewriteRoutes, { prefix: "/api/magic-rewrite" });
   await app.register(csrfDiagnosticsRoutes, { prefix: "/api/csrf" });
   if (process.env.MARINARA_LITE !== "true" && process.env.MARINARA_LITE !== "1") {
     await app.register(sidecarRoutes, { prefix: "/api/sidecar" });

--- a/packages/server/src/routes/magic-rewrite.routes.ts
+++ b/packages/server/src/routes/magic-rewrite.routes.ts
@@ -7,6 +7,7 @@ import { PROVIDERS } from "@marinara-engine/shared";
 import { createConnectionsStorage } from "../services/storage/connections.storage.js";
 import { createLLMProvider } from "../services/llm/provider-registry.js";
 import type { ChatMessage } from "../services/llm/base-provider.js";
+import { logger } from "../lib/logger.js";
 
 const magicRewriteSchema = z.object({
   text: z.string().default(""),
@@ -31,7 +32,11 @@ export async function magicRewriteRoutes(app: FastifyInstance) {
   const connections = createConnectionsStorage(app.db);
 
   app.post("/generate", async (req, reply) => {
-    const input = magicRewriteSchema.parse(req.body);
+    const result = magicRewriteSchema.safeParse(req.body);
+    if (!result.success) {
+      return reply.status(400).send({ error: "Invalid request", details: result.error.issues });
+    }
+    const input = result.data;
 
     const defaultRewriteConnection = await connections.getDefaultForRewrite();
     const fallbackDefault = defaultRewriteConnection ? null : await connections.getDefault();
@@ -89,9 +94,8 @@ export async function magicRewriteRoutes(app: FastifyInstance) {
 
       return { text: result.content?.trim() ?? "", finishReason: result.finishReason, usage: result.usage ?? null };
     } catch (error) {
-      app.log.error({ err: error }, "Magic Rewrite generation failed");
-      const message = error instanceof Error ? error.message : "Magic Rewrite generation failed";
-      return reply.status(500).send({ error: message });
+      logger.error(error, "Magic Rewrite generation failed");
+      return reply.status(500).send({ error: "Magic Rewrite generation failed" });
     }
   });
 }

--- a/packages/server/src/routes/magic-rewrite.routes.ts
+++ b/packages/server/src/routes/magic-rewrite.routes.ts
@@ -1,0 +1,97 @@
+// ──────────────────────────────────────────────
+// Routes: Magic Rewrite
+// ──────────────────────────────────────────────
+import type { FastifyInstance } from "fastify";
+import { z } from "zod";
+import { PROVIDERS } from "@marinara-engine/shared";
+import { createConnectionsStorage } from "../services/storage/connections.storage.js";
+import { createLLMProvider } from "../services/llm/provider-registry.js";
+import type { ChatMessage } from "../services/llm/base-provider.js";
+
+const magicRewriteSchema = z.object({
+  text: z.string().default(""),
+  instruction: z.string().default(""),
+  context: z.string().optional().default(""),
+});
+
+const REWRITE_SYSTEM_PROMPT = `You are a rewriting assistant for roleplay, fiction, and worldbuilding content.
+Rewrite or generate the requested text according to the user's instructions.
+Use any provided character, chat, and lorebook context only as reference for continuity.
+Return ONLY the rewritten text — no explanations, no markdown fences, no preamble.`;
+
+function resolveBaseUrl(conn: { provider: string; baseUrl: string | null }): string {
+  if (conn.baseUrl) return conn.baseUrl;
+  if (conn.provider === "claude_subscription") return "claude-agent-sdk://local";
+  if (conn.provider === "openai_chatgpt") return "openai-chatgpt://codex-auth";
+  const providerDef = PROVIDERS[conn.provider as keyof typeof PROVIDERS];
+  return providerDef?.defaultBaseUrl ?? "";
+}
+
+export async function magicRewriteRoutes(app: FastifyInstance) {
+  const connections = createConnectionsStorage(app.db);
+
+  app.post("/generate", async (req, reply) => {
+    const input = magicRewriteSchema.parse(req.body);
+
+    const defaultRewriteConnection = await connections.getDefaultForRewrite();
+    const fallbackDefault = defaultRewriteConnection ? null : await connections.getDefault();
+    const fallbackAgent = !defaultRewriteConnection && !fallbackDefault ? await connections.getDefaultForAgents() : null;
+    const conn = defaultRewriteConnection
+      ?? (fallbackDefault ? await connections.getWithKey(fallbackDefault.id) : null)
+      ?? fallbackAgent;
+
+    if (!conn) {
+      return reply.status(400).send({ error: "No default language model connection configured" });
+    }
+
+    if (conn.provider === "image_generation") {
+      return reply.status(400).send({ error: "Default connection is an image generation provider" });
+    }
+
+    const baseUrl = resolveBaseUrl(conn);
+    if (!baseUrl) {
+      return reply.status(400).send({ error: "No base URL configured for the default connection" });
+    }
+
+    const hasSourceText = input.text.trim().length > 0;
+    const instruction = input.instruction.trim() || (hasSourceText ? "Improve this text while preserving its meaning." : "Generate suitable content.");
+
+    const userParts = [
+      `Instruction:\n${instruction}`,
+      input.context.trim() ? `Reference context:\n${input.context.trim()}` : null,
+      hasSourceText ? `Text to rewrite:\n${input.text}` : "No source text was provided; generate new content from the instruction and context.",
+    ].filter(Boolean);
+
+    const messages: ChatMessage[] = [
+      { role: "system", content: REWRITE_SYSTEM_PROMPT },
+      { role: "user", content: userParts.join("\n\n---\n\n") },
+    ];
+
+    try {
+      const provider = createLLMProvider(
+        conn.provider,
+        baseUrl,
+        conn.apiKey,
+        conn.maxContext,
+        conn.openrouterProvider,
+        conn.maxTokensOverride,
+        conn.claudeFastMode === "true",
+      );
+
+      const result = await provider.chatComplete(messages, {
+        model: conn.model,
+        temperature: 0.7,
+        maxTokens: 4000,
+        stream: false,
+        enableCaching: conn.enableCaching === "true",
+        cachingAtDepth: conn.cachingAtDepth,
+      });
+
+      return { text: result.content?.trim() ?? "", finishReason: result.finishReason, usage: result.usage ?? null };
+    } catch (error) {
+      app.log.error({ err: error }, "Magic Rewrite generation failed");
+      const message = error instanceof Error ? error.message : "Magic Rewrite generation failed";
+      return reply.status(500).send({ error: message });
+    }
+  });
+}

--- a/packages/server/src/services/storage/connections.storage.ts
+++ b/packages/server/src/services/storage/connections.storage.ts
@@ -238,6 +238,7 @@ export function createConnectionsStorage(db: DB) {
         isDefault: "false",
         useForRandom: source.useForRandom,
         defaultForAgents: "false",
+        defaultForRewrite: "false",
         enableCaching: source.enableCaching,
         cachingAtDepth: source.cachingAtDepth,
         embeddingModel: source.embeddingModel,

--- a/packages/server/src/services/storage/connections.storage.ts
+++ b/packages/server/src/services/storage/connections.storage.ts
@@ -41,6 +41,14 @@ export function createConnectionsStorage(db: DB) {
       return { ...row, apiKey: decryptApiKey(row.apiKeyEncrypted) };
     },
 
+    /** Get the connection marked as default for Magic Rewrite (with decrypted key). */
+    async getDefaultForRewrite() {
+      const rows = await db.select().from(apiConnections).where(eq(apiConnections.defaultForRewrite, "true"));
+      const row = rows.find((candidate) => candidate.provider !== "image_generation");
+      if (!row) return null;
+      return { ...row, apiKey: decryptApiKey(row.apiKeyEncrypted) };
+    },
+
     async create(input: CreateConnectionInput) {
       const id = newId();
       const timestamp = now();
@@ -67,6 +75,18 @@ export function createConnectionsStorage(db: DB) {
           }
         }
       }
+      // If this is set as default for rewrite, unset other non-image defaults
+      if (input.defaultForRewrite) {
+        const existingDefaults = await db
+          .select()
+          .from(apiConnections)
+          .where(eq(apiConnections.defaultForRewrite, "true"));
+        for (const row of existingDefaults) {
+          if (row.provider !== "image_generation") {
+            await db.update(apiConnections).set({ defaultForRewrite: "false" }).where(eq(apiConnections.id, row.id));
+          }
+        }
+      }
       await db.insert(apiConnections).values({
         id,
         name: input.name,
@@ -78,6 +98,7 @@ export function createConnectionsStorage(db: DB) {
         isDefault: String(input.isDefault ?? false),
         useForRandom: String(input.useForRandom ?? false),
         defaultForAgents: String(input.defaultForAgents ?? false),
+        defaultForRewrite: String(input.defaultForRewrite ?? false),
         enableCaching: String(input.enableCaching ?? false),
         cachingAtDepth: input.cachingAtDepth ?? 5,
         maxParallelJobs: input.maxParallelJobs ?? 1,
@@ -139,6 +160,20 @@ export function createConnectionsStorage(db: DB) {
           }
         }
         updateFields.defaultForAgents = String(data.defaultForAgents);
+      }
+      if (data.defaultForRewrite !== undefined) {
+        if (data.defaultForRewrite) {
+          const existingDefaults = await db
+            .select()
+            .from(apiConnections)
+            .where(eq(apiConnections.defaultForRewrite, "true"));
+          for (const row of existingDefaults) {
+            if (row.provider !== "image_generation") {
+              await db.update(apiConnections).set({ defaultForRewrite: "false" }).where(eq(apiConnections.id, row.id));
+            }
+          }
+        }
+        updateFields.defaultForRewrite = String(data.defaultForRewrite);
       }
       if (data.enableCaching !== undefined) {
         updateFields.enableCaching = String(data.enableCaching);

--- a/packages/shared/src/schemas/connection.schema.ts
+++ b/packages/shared/src/schemas/connection.schema.ts
@@ -29,6 +29,7 @@ export const createConnectionSchema = z.object({
   isDefault: z.boolean().default(false),
   useForRandom: z.boolean().default(false),
   defaultForAgents: z.boolean().default(false),
+  defaultForRewrite: z.boolean().default(false),
   enableCaching: z.boolean().default(false),
   cachingAtDepth: z.number().int().min(0).default(5),
   embeddingModel: z.string().default(""),

--- a/packages/shared/src/types/connection.ts
+++ b/packages/shared/src/types/connection.ts
@@ -35,6 +35,8 @@ export interface APIConnection {
   useForRandom: boolean;
   /** Whether this connection is the default for all agents */
   defaultForAgents: boolean;
+  /** Whether this connection is the default for Magic Rewrite text generation */
+  defaultForRewrite: boolean;
   /** Whether provider-native prompt caching is enabled */
   enableCaching: boolean;
   /** Conversation message depth for Anthropic cache breakpoints */


### PR DESCRIPTION
<!-- Target branch: `staging`. The default base in this UI is `main` (release branch). -->
<!-- Change the base to `staging` before submitting unless this is a maintainer-approved mainline change. -->
<!-- See CONTRIBUTING.md § Branches. -->

## Linked issue

Closes #1183

## Why this change

Writing and maintaining long-form text entries — character descriptions, persona definitions, lorebook entries, system prompts — is one of the more tedious parts of setting up a roleplay session. Other RP platforms offer AI-assisted rewriting that lets users iteratively refine these fields with natural language instructions: "add more detail about their childhood," "convert to XML format," "make this more token-efficient."

Currently Marinara has no built-in mechanism for this. A Marinara app extension (`magic-rewrite-extension`) exists as a proof of concept, but it requires users to manually enter API keys because it cannot access the LLM connections already configured in the app. This PR ships the feature natively, reusing Marinara's existing connection infrastructure so users can leverage their configured endpoints with no additional credential management.

## What changed

- **`packages/shared/src/types/connection.ts`** + **`packages/shared/src/schemas/connection.schema.ts`**: add `defaultForRewrite` boolean field to the shared connection type and Zod create schema.
- **`packages/server/src/db/schema/connections.ts`** + **`packages/server/src/db/migrate.ts`**: add `default_for_rewrite` text column to the `api_connections` table with a migration entry.
- **`packages/server/src/services/storage/connections.storage.ts`**: add `getDefaultForRewrite()` method and mutual-exclusion enforcement in create/update — only one non-image-generation connection can hold the rewrite default at a time.
- **`packages/server/src/routes/magic-rewrite.routes.ts`**: new `POST /api/magic-rewrite/generate` route. Accepts `text`, `instruction`, and optional `context` (character, lorebook, chat history). Resolves connection via rewrite-specific → default chat → agent default chain. Uses `createLLMProvider()` and `chatComplete()` with a focused system prompt that returns only rewritten text.
- **`packages/client/src/components/ui/MagicRewritePanel.tsx`**: new panel component with instruction textarea, context selectors (character card, lorebook entries, chat history with configurable message count up to 250), generate button with loading spinner, and a word-level diff preview showing before/after with changed spans highlighted. Supports persistent instruction recall via `localStorage`.
- **`packages/client/src/components/lorebooks/LorebookFormFields.tsx`**: adds ✨ Rewrite button in the lorebook description editor modal (bottom-right, left of Done). Clicking it enters rewrite mode with Back/Apply controls.
- **`packages/client/src/components/ui/ExpandedTextarea.tsx`**: adds ✨ Rewrite button in the shared full-screen editor header. This automatically makes the feature available in the character editor, persona editor, and chat settings drawer — all of which use this shared component.
- **`packages/client/src/components/connections/ConnectionEditor.tsx`**: adds "Default for Rewrite" toggle beneath the existing "Default for Agents" toggle, with tooltip explaining the fallback behavior. Hidden for image-generation provider connections.

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Lorebook description editor: ✨ Rewrite button appears, generates rewrite using the default chat connection, diff preview renders correctly with line breaks in both before/after panes, Apply saves rewritten text back to the editor.
- Character editor: ✨ Rewrite button appears in the expand-textarea header for all text fields.
- Persona editor: ✨ Rewrite button appears in the expand-textarea header for all text fields.
- Connection settings: "Default for Rewrite" toggle works, mutual exclusion enforced (only one non-image connection can hold the flag).
- Fallback chain: with no rewrite-specific connection set, correctly falls through to the default chat connection, then agent default.
- Chat history context: messages slider configurable up to 250, context included in the generation request.
- Instruction persistence: rewrite instructions saved to and recalled from `localStorage`.
- Escape key does not close the modal while Magic Rewrite mode is active.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

<img width="743" height="325" alt="Screenshot 2026-05-24 222848" src="https://github.com/user-attachments/assets/9e052222-bb93-47a0-8f63-fd417c152cff" />

---
<img width="788" height="387" alt="Screenshot 2026-05-24 223102" src="https://github.com/user-attachments/assets/26436275-6f82-4bf5-b7a3-9de920dc6da2" />
----
<img width="2944" height="1697" alt="Screenshot 2026-05-24 223043" src="https://github.com/user-attachments/assets/d01c92e0-825a-427e-ae63-9d2905128010" />
