### PR TITLE
Fix mobile onboarding and mobile chat controls

### DIFF
--- a/src/app/shell/AppShell.tsx
+++ b/src/app/shell/AppShell.tsx
@@ -651,6 +651,7 @@ export function AppShell() {
   }, [activeMobilePanel, isMobile]);
 
   useEffect(() => {
+    if (!hasCompletedOnboarding) return;
     syncMobilePanelInert();
     return () => {
       setInert(sidebarPanelRef.current, false);
@@ -659,10 +660,10 @@ export function AppShell() {
       setInert(headerRef.current, false);
       setInert(mainRef.current, false);
     };
-  }, [syncMobilePanelInert]);
+  }, [hasCompletedOnboarding, syncMobilePanelInert]);
 
   useEffect(() => {
-    if (!isMobile || !activeMobilePanel) return;
+    if (!hasCompletedOnboarding || !isMobile || !activeMobilePanel) return;
 
     const getPanel = () => {
       if (activeMobilePanel === "right") return mobileRightPanelRef.current;
@@ -732,7 +733,7 @@ export function AppShell() {
         previous.focus();
       }
     };
-  }, [activeMobilePanel, closeRightPanel, isMobile, setSidebarOpen, setTrackerPanelOpen]);
+  }, [activeMobilePanel, closeRightPanel, hasCompletedOnboarding, isMobile, setSidebarOpen, setTrackerPanelOpen]);
 
   const trackerPanelDesktop = (side: "left" | "right") =>
     trackerPanelVisible && trackerPanelSide === side ? (

--- a/src/app/shell/AppShell.tsx
+++ b/src/app/shell/AppShell.tsx
@@ -633,7 +633,7 @@ export function AppShell() {
           : null
     : null;
 
-  useEffect(() => {
+  const syncMobilePanelInert = useCallback(() => {
     if (!isMobile) {
       setInert(sidebarPanelRef.current, false);
       setInert(mobileTrackerPanelRef.current, false);
@@ -648,7 +648,10 @@ export function AppShell() {
     setInert(mobileRightPanelRef.current, activeMobilePanel !== "right");
     setInert(headerRef.current, activeMobilePanel !== null);
     setInert(mainRef.current, activeMobilePanel !== null);
+  }, [activeMobilePanel, isMobile]);
 
+  useEffect(() => {
+    syncMobilePanelInert();
     return () => {
       setInert(sidebarPanelRef.current, false);
       setInert(mobileTrackerPanelRef.current, false);
@@ -656,7 +659,7 @@ export function AppShell() {
       setInert(headerRef.current, false);
       setInert(mainRef.current, false);
     };
-  }, [activeMobilePanel, isMobile]);
+  }, [syncMobilePanelInert]);
 
   useEffect(() => {
     if (!isMobile || !activeMobilePanel) return;
@@ -1019,7 +1022,7 @@ export function AppShell() {
       {/* First-time onboarding tutorial */}
       {!hasCompletedOnboarding && (
         <Suspense fallback={null}>
-          <OnboardingTutorial />
+          <OnboardingTutorial onShellInertResync={syncMobilePanelInert} />
         </Suspense>
       )}
       <SpotifyMobileWidget />

--- a/src/app/shell/AppShell.tsx
+++ b/src/app/shell/AppShell.tsx
@@ -823,7 +823,11 @@ export function AppShell() {
           onOpenProfessorMari={() => setProfessorMariOpen(true)}
           onGoHome={() => setProfessorMariOpen(false)}
         />
-        <TopBar />
+        <TopBar
+          professorMariOpen={professorMariOpen}
+          onOpenProfessorMari={() => setProfessorMariOpen(true)}
+          onGoHome={() => setProfessorMariOpen(false)}
+        />
       </header>
 
       <div data-component="AppShellBody" className="relative flex min-h-0 flex-1 overflow-hidden">

--- a/src/app/shell/ChatSidebar.tsx
+++ b/src/app/shell/ChatSidebar.tsx
@@ -467,8 +467,9 @@ export function ChatSidebar({
   }, [activeChatId, chats, folders, updateFolderMut]);
 
   const handleNewChatFromTab = useCallback(() => {
+    if (window.innerWidth < 768) setSidebarOpen(false);
     startNewChat(activeTab);
-  }, [activeTab, startNewChat]);
+  }, [activeTab, setSidebarOpen, startNewChat]);
 
   // ── Folder handlers ──
   const handleCreateFolder = useCallback(() => {

--- a/src/app/shell/ChatTitleControls.tsx
+++ b/src/app/shell/ChatTitleControls.tsx
@@ -13,12 +13,14 @@ export function ChatTitleControls({
   onOpenProfessorMari,
   onGoHome,
   className,
+  hideProfessorOnNarrow = false,
   showDivider = true,
 }: {
   professorMariOpen?: boolean;
   onOpenProfessorMari?: () => void;
   onGoHome?: () => void;
   className?: string;
+  hideProfessorOnNarrow?: boolean;
   showDivider?: boolean;
 }) {
   const setActiveChatId = useChatStore((s) => s.setActiveChatId);
@@ -79,6 +81,7 @@ export function ChatTitleControls({
         onDoubleClick={stopChromeDrag}
         className={cn(
           "mari-titlebar-action relative rounded-md p-1 transition-all duration-200",
+          hideProfessorOnNarrow && "mari-titlebar-action-mobile-optional",
           professorMariOpen
             ? "mari-titlebar-action-active text-[color-mix(in_srgb,var(--primary)_54%,var(--muted-foreground))]"
             : "text-[var(--muted-foreground)] hover:text-[var(--primary)]",

--- a/src/app/shell/ChatTitleControls.tsx
+++ b/src/app/shell/ChatTitleControls.tsx
@@ -1,0 +1,103 @@
+import { Home, PanelLeft, PanelLeftClose } from "lucide-react";
+import type { MouseEvent as ReactMouseEvent } from "react";
+import { cn } from "../../shared/lib/utils";
+import { useChatStore } from "../../shared/stores/chat.store";
+import { useUIStore } from "../../shared/stores/ui.store";
+
+function stopChromeDrag(event: ReactMouseEvent<HTMLElement>) {
+  event.stopPropagation();
+}
+
+export function ChatTitleControls({
+  professorMariOpen = false,
+  onOpenProfessorMari,
+  onGoHome,
+  className,
+  showDivider = true,
+}: {
+  professorMariOpen?: boolean;
+  onOpenProfessorMari?: () => void;
+  onGoHome?: () => void;
+  className?: string;
+  showDivider?: boolean;
+}) {
+  const setActiveChatId = useChatStore((s) => s.setActiveChatId);
+  const sidebarOpen = useUIStore((s) => s.sidebarOpen);
+  const toggleSidebar = useUIStore((s) => s.toggleSidebar);
+  const closeAllDetails = useUIStore((s) => s.closeAllDetails);
+
+  const goHome = () => {
+    setActiveChatId(null);
+    closeAllDetails();
+    onGoHome?.();
+  };
+
+  const openProfessorMari = () => {
+    setActiveChatId(null);
+    closeAllDetails();
+    onOpenProfessorMari?.();
+  };
+
+  return (
+    <div className={cn("mari-chat-title-controls flex h-full shrink-0 items-center gap-1.5", className)}>
+      <button
+        type="button"
+        onClick={toggleSidebar}
+        onMouseDown={stopChromeDrag}
+        onDoubleClick={stopChromeDrag}
+        data-tour="sidebar-toggle"
+        className={cn(
+          "mari-titlebar-action relative rounded-md p-1.5 transition-all duration-200",
+          sidebarOpen
+            ? "mari-titlebar-action-active text-[color-mix(in_srgb,var(--primary)_54%,var(--muted-foreground))] [&>svg]:stroke-[2.3]"
+            : "text-[var(--muted-foreground)] hover:text-[var(--primary)]",
+        )}
+        title={sidebarOpen ? "Close chats" : "Open chats"}
+        aria-label={sidebarOpen ? "Close chats" : "Open chats"}
+        aria-pressed={sidebarOpen}
+      >
+        {sidebarOpen ? <PanelLeftClose size="0.875rem" /> : <PanelLeft size="0.875rem" />}
+        {sidebarOpen && (
+          <span className="absolute -bottom-0.5 left-1/2 h-0.5 w-3 -translate-x-1/2 rounded-full bg-gradient-to-r from-teal-500 to-cyan-500" />
+        )}
+      </button>
+      <button
+        type="button"
+        onClick={goHome}
+        onMouseDown={stopChromeDrag}
+        onDoubleClick={stopChromeDrag}
+        className="mari-titlebar-action rounded-md p-1.5 text-[var(--muted-foreground)] transition-all duration-200 hover:text-[var(--primary)]"
+        title="Home"
+        aria-label="Home"
+      >
+        <Home size="0.875rem" />
+      </button>
+      <button
+        type="button"
+        onClick={openProfessorMari}
+        onMouseDown={stopChromeDrag}
+        onDoubleClick={stopChromeDrag}
+        className={cn(
+          "mari-titlebar-action relative rounded-md p-1 transition-all duration-200",
+          professorMariOpen
+            ? "mari-titlebar-action-active text-[color-mix(in_srgb,var(--primary)_54%,var(--muted-foreground))]"
+            : "text-[var(--muted-foreground)] hover:text-[var(--primary)]",
+        )}
+        title="Professor Mari"
+        aria-label="Professor Mari"
+        aria-pressed={professorMariOpen}
+      >
+        <img
+          src="/sprites/mari/Mari_profile.png"
+          alt=""
+          className="h-[1.125rem] w-[1.125rem] rounded-md object-cover"
+          draggable={false}
+        />
+        {professorMariOpen && (
+          <span className="absolute -bottom-0.5 left-1/2 h-0.5 w-3 -translate-x-1/2 rounded-full bg-gradient-to-r from-teal-500 to-cyan-500" />
+        )}
+      </button>
+      {showDivider && <span className="mari-chat-title-divider" aria-hidden />}
+    </div>
+  );
+}

--- a/src/app/shell/TopBar.tsx
+++ b/src/app/shell/TopBar.tsx
@@ -2,15 +2,30 @@
 // Layout: Top Bar (polished, with hover glow)
 // ──────────────────────────────────────────────
 import { SpotifyMiniPlayer } from "../../features/shell/spotify/shell";
+import { ChatTitleControls } from "./ChatTitleControls";
 import { PanelNavButtons } from "./PanelNavButtons";
 
-export function TopBar() {
+export function TopBar({
+  professorMariOpen = false,
+  onOpenProfessorMari,
+  onGoHome,
+}: {
+  professorMariOpen?: boolean;
+  onOpenProfessorMari?: () => void;
+  onGoHome?: () => void;
+}) {
   return (
     <header
       data-component="TopBar"
       className="mari-topbar relative z-10 flex h-9 flex-shrink-0 items-center justify-between px-2 md:hidden"
     >
       <div className="flex min-w-0 shrink-0 items-center gap-1.5">
+        <ChatTitleControls
+          professorMariOpen={professorMariOpen}
+          onOpenProfessorMari={onOpenProfessorMari}
+          onGoHome={onGoHome}
+          showDivider={false}
+        />
         <SpotifyMiniPlayer />
       </div>
       <PanelNavButtons className="md:hidden" />

--- a/src/app/shell/TopBar.tsx
+++ b/src/app/shell/TopBar.tsx
@@ -24,6 +24,7 @@ export function TopBar({
           professorMariOpen={professorMariOpen}
           onOpenProfessorMari={onOpenProfessorMari}
           onGoHome={onGoHome}
+          hideProfessorOnNarrow
           showDivider={false}
         />
         <SpotifyMiniPlayer />

--- a/src/app/shell/WindowTitleBar.tsx
+++ b/src/app/shell/WindowTitleBar.tsx
@@ -1,9 +1,8 @@
 import { getCurrentWindow } from "@tauri-apps/api/window";
-import { Home, Maximize2, Minus, PanelLeft, PanelLeftClose, Square, X } from "lucide-react";
+import { Maximize2, Minus, Square, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState, type MouseEvent as ReactMouseEvent } from "react";
 import { cn } from "../../shared/lib/utils";
-import { useChatStore } from "../../shared/stores/chat.store";
-import { useUIStore } from "../../shared/stores/ui.store";
+import { ChatTitleControls } from "./ChatTitleControls";
 import { PanelNavButtons } from "./PanelNavButtons";
 
 type DesktopPlatform = "darwin" | "windows" | "linux";
@@ -41,10 +40,6 @@ export function WindowTitleBar({
   const platform = useMemo(inferDesktopPlatform, []);
   const [isMaximized, setIsMaximized] = useState(false);
   const appWindow = useMemo(() => (isTauriRuntime() ? getCurrentWindow() : null), []);
-  const setActiveChatId = useChatStore((s) => s.setActiveChatId);
-  const sidebarOpen = useUIStore((s) => s.sidebarOpen);
-  const toggleSidebar = useUIStore((s) => s.toggleSidebar);
-  const closeAllDetails = useUIStore((s) => s.closeAllDetails);
 
   const refreshMaximized = useCallback(() => {
     if (!appWindow) return;
@@ -96,16 +91,6 @@ export function WindowTitleBar({
   const toggleMaximizeFromDragRegion = useCallback(() => {
     runWindowAction("maximize");
   }, [runWindowAction]);
-  const goHome = useCallback(() => {
-    setActiveChatId(null);
-    closeAllDetails();
-    onGoHome?.();
-  }, [closeAllDetails, onGoHome, setActiveChatId]);
-  const openProfessorMari = useCallback(() => {
-    setActiveChatId(null);
-    closeAllDetails();
-    onOpenProfessorMari?.();
-  }, [closeAllDetails, onOpenProfessorMari, setActiveChatId]);
   const controlActions = platform === "darwin" ? (["close", "minimize", "maximize"] as const) : (["minimize", "maximize", "close"] as const);
   const controls = (
     <div
@@ -155,66 +140,12 @@ export function WindowTitleBar({
       onDoubleClick={toggleMaximizeFromDragRegion}
     >
       {platform === "darwin" && controls}
-      <div className="mari-chat-title-controls flex h-full shrink-0 items-center gap-1.5 pl-2.5 pr-0">
-        <button
-          type="button"
-          onClick={toggleSidebar}
-          onMouseDown={(event) => event.stopPropagation()}
-          onDoubleClick={(event) => event.stopPropagation()}
-          data-tour="sidebar-toggle"
-          className={cn(
-            "mari-titlebar-action relative rounded-md p-1.5 transition-all duration-200",
-            sidebarOpen
-              ? "mari-titlebar-action-active text-[color-mix(in_srgb,var(--primary)_54%,var(--muted-foreground))] [&>svg]:stroke-[2.3]"
-              : "text-[var(--muted-foreground)] hover:text-[var(--primary)]",
-          )}
-          title={sidebarOpen ? "Close chats" : "Open chats"}
-          aria-label={sidebarOpen ? "Close chats" : "Open chats"}
-          aria-pressed={sidebarOpen}
-        >
-          {sidebarOpen ? <PanelLeftClose size="0.875rem" /> : <PanelLeft size="0.875rem" />}
-          {sidebarOpen && (
-            <span className="absolute -bottom-0.5 left-1/2 h-0.5 w-3 -translate-x-1/2 rounded-full bg-gradient-to-r from-teal-500 to-cyan-500" />
-          )}
-        </button>
-        <button
-          type="button"
-          onClick={goHome}
-          onMouseDown={(event) => event.stopPropagation()}
-          onDoubleClick={(event) => event.stopPropagation()}
-          className="mari-titlebar-action rounded-md p-1.5 text-[var(--muted-foreground)] transition-all duration-200 hover:text-[var(--primary)]"
-          title="Home"
-          aria-label="Home"
-        >
-          <Home size="0.875rem" />
-        </button>
-        <button
-          type="button"
-          onClick={openProfessorMari}
-          onMouseDown={(event) => event.stopPropagation()}
-          onDoubleClick={(event) => event.stopPropagation()}
-          className={cn(
-            "mari-titlebar-action relative rounded-md p-1 transition-all duration-200",
-            professorMariOpen
-              ? "mari-titlebar-action-active text-[color-mix(in_srgb,var(--primary)_54%,var(--muted-foreground))]"
-              : "text-[var(--muted-foreground)] hover:text-[var(--primary)]",
-          )}
-          title="Professor Mari"
-          aria-label="Professor Mari"
-          aria-pressed={professorMariOpen}
-        >
-          <img
-            src="/sprites/mari/Mari_profile.png"
-            alt=""
-            className="h-[1.125rem] w-[1.125rem] rounded-md object-cover"
-            draggable={false}
-          />
-          {professorMariOpen && (
-            <span className="absolute -bottom-0.5 left-1/2 h-0.5 w-3 -translate-x-1/2 rounded-full bg-gradient-to-r from-teal-500 to-cyan-500" />
-          )}
-        </button>
-        <span className="mari-chat-title-divider" aria-hidden />
-      </div>
+      <ChatTitleControls
+        className="pl-2.5 pr-0"
+        professorMariOpen={professorMariOpen}
+        onOpenProfessorMari={onOpenProfessorMari}
+        onGoHome={onGoHome}
+      />
       <div
         className="mari-titlebar-content flex h-full min-w-0 flex-1 items-center"
       >

--- a/src/features/shell/onboarding/components/OnboardingTutorial.tsx
+++ b/src/features/shell/onboarding/components/OnboardingTutorial.tsx
@@ -166,8 +166,16 @@ function applyShellInertExceptTutorial(root: HTMLElement): () => void {
   };
 }
 
+function isVisibleTourTarget(element: Element) {
+  const rect = element.getBoundingClientRect();
+  if (rect.width <= 0 || rect.height <= 0) return false;
+  const style = window.getComputedStyle(element);
+  return style.display !== "none" && style.visibility !== "hidden";
+}
+
 function getTargetRect(target: string): Rect | null {
-  const el = document.querySelector(`[data-tour="${target}"]`);
+  const matches = Array.from(document.querySelectorAll(`[data-tour="${target}"]`));
+  const el = matches.find(isVisibleTourTarget) ?? matches[0];
   if (!el) return null;
   const r = el.getBoundingClientRect();
   return { top: r.top, left: r.left, width: r.width, height: r.height };

--- a/src/features/shell/onboarding/components/OnboardingTutorial.tsx
+++ b/src/features/shell/onboarding/components/OnboardingTutorial.tsx
@@ -24,6 +24,10 @@ interface TourStep {
   sprite?: { src: string; flip?: boolean };
 }
 
+interface OnboardingTutorialProps {
+  onShellInertResync: () => void;
+}
+
 const STEPS: TourStep[] = [
   {
     target: null,
@@ -118,20 +122,48 @@ function setInert(element: Element, inert: boolean) {
   (element as HTMLElement & { inert?: boolean }).inert = inert;
 }
 
-function setShellInertExceptTutorial(root: HTMLElement, inert: boolean) {
+interface InertSnapshot {
+  element: Element;
+  hadInertAttribute: boolean;
+  inertProperty: boolean;
+}
+
+function applyShellInertExceptTutorial(root: HTMLElement): () => void {
   const shell = root.closest('[data-component="AppShell"]');
-  if (!shell) return;
+  if (!shell) return () => {};
+
+  const snapshots: InertSnapshot[] = [];
+
+  const apply = (element: Element) => {
+    snapshots.push({
+      element,
+      hadInertAttribute: element.hasAttribute("inert"),
+      inertProperty: Boolean((element as HTMLElement & { inert?: boolean }).inert),
+    });
+    setInert(element, true);
+  };
 
   for (const child of Array.from(shell.children)) {
     if (!child.contains(root)) {
-      setInert(child, inert);
+      apply(child);
       continue;
     }
 
     for (const nestedChild of Array.from(child.children)) {
-      if (nestedChild !== root) setInert(nestedChild, inert);
+      if (nestedChild !== root) apply(nestedChild);
     }
   }
+
+  return () => {
+    for (const { element, hadInertAttribute, inertProperty } of snapshots) {
+      if (hadInertAttribute) {
+        element.setAttribute("inert", "");
+      } else {
+        element.removeAttribute("inert");
+      }
+      (element as HTMLElement & { inert?: boolean }).inert = inertProperty;
+    }
+  };
 }
 
 function getTargetRect(target: string): Rect | null {
@@ -343,13 +375,13 @@ function TourCardContent({
 
 // ─── Main component ───────────────────────────
 
-export function OnboardingTutorial() {
+export function OnboardingTutorial({ onShellInertResync }: OnboardingTutorialProps) {
   const hasCompleted = useUIStore((s) => s.hasCompletedOnboarding);
   if (hasCompleted) return null;
-  return <OnboardingTutorialInner />;
+  return <OnboardingTutorialInner onShellInertResync={onShellInertResync} />;
 }
 
-function OnboardingTutorialInner() {
+function OnboardingTutorialInner({ onShellInertResync }: OnboardingTutorialProps) {
   const setCompleted = useUIStore((s) => s.setHasCompletedOnboarding);
   const openRightPanel = useUIStore((s) => s.openRightPanel);
   const setSettingsTab = useUIStore((s) => s.setSettingsTab);
@@ -361,6 +393,8 @@ function OnboardingTutorialInner() {
   const prevStepRef = useRef(0);
   const rootRef = useRef<HTMLDivElement>(null);
   const previousFocusRef = useRef<HTMLElement | null>(null);
+  const onShellInertResyncRef = useRef(onShellInertResync);
+  onShellInertResyncRef.current = onShellInertResync;
 
   const currentStep = STEPS[step];
   const isLast = step === STEPS.length - 1;
@@ -439,7 +473,7 @@ function OnboardingTutorialInner() {
     if (!root) return;
 
     previousFocusRef.current = document.activeElement instanceof HTMLElement ? document.activeElement : null;
-    setShellInertExceptTutorial(root, true);
+    const restoreShellInert = applyShellInertExceptTutorial(root);
 
     const focusFirstControl = () => {
       if (!root.contains(document.activeElement)) {
@@ -491,7 +525,8 @@ function OnboardingTutorialInner() {
       window.cancelAnimationFrame(frame);
       document.removeEventListener("keydown", handleKeyDown, true);
       document.removeEventListener("focusin", handleFocusIn, true);
-      setShellInertExceptTutorial(root, false);
+      restoreShellInert();
+      onShellInertResyncRef.current();
       const previousFocus = previousFocusRef.current;
       if (previousFocus?.isConnected) previousFocus.focus();
     };

--- a/src/features/shell/onboarding/components/OnboardingTutorial.tsx
+++ b/src/features/shell/onboarding/components/OnboardingTutorial.tsx
@@ -133,8 +133,11 @@ function applyShellInertExceptTutorial(root: HTMLElement): () => void {
   if (!shell) return () => {};
 
   const snapshots: InertSnapshot[] = [];
+  const inertedElements = new Set<Element>();
 
   const apply = (element: Element) => {
+    if (inertedElements.has(element)) return;
+    inertedElements.add(element);
     snapshots.push({
       element,
       hadInertAttribute: element.hasAttribute("inert"),
@@ -143,18 +146,34 @@ function applyShellInertExceptTutorial(root: HTMLElement): () => void {
     setInert(element, true);
   };
 
-  for (const child of Array.from(shell.children)) {
-    if (!child.contains(root)) {
-      apply(child);
-      continue;
+  const applyOutsideRoot = (element: Element) => {
+    if (element === root || root.contains(element)) return;
+
+    if (element.contains(root)) {
+      for (const child of Array.from(element.children)) {
+        applyOutsideRoot(child);
+      }
+      return;
     }
 
-    for (const nestedChild of Array.from(child.children)) {
-      if (nestedChild !== root) apply(nestedChild);
-    }
+    apply(element);
+  };
+
+  for (const child of Array.from(shell.children)) {
+    applyOutsideRoot(child);
   }
 
+  const observer = new MutationObserver((mutations) => {
+    for (const mutation of mutations) {
+      for (const node of Array.from(mutation.addedNodes)) {
+        if (node instanceof Element) applyOutsideRoot(node);
+      }
+    }
+  });
+  observer.observe(shell, { childList: true, subtree: true });
+
   return () => {
+    observer.disconnect();
     for (const { element, hadInertAttribute, inertProperty } of snapshots) {
       if (hadInertAttribute) {
         element.setAttribute("inert", "");

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -713,6 +713,12 @@ body {
   transform: translateY(0) rotate(-8deg) scale(0.98);
 }
 
+@media (max-width: 380px) {
+  .mari-titlebar-action-mobile-optional {
+    display: none !important;
+  }
+}
+
 .mari-chat-title-divider {
   display: block;
   width: 1px;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -719,6 +719,26 @@ body {
   }
 }
 
+@media (max-width: 340px) {
+  .mari-topbar {
+    padding-left: 0.25rem;
+    padding-right: 0.25rem;
+  }
+
+  .mari-topbar .mari-chat-title-controls {
+    gap: 0.125rem;
+  }
+
+  .mari-topbar .mari-panel-nav {
+    gap: 0;
+  }
+
+  .mari-topbar .mari-chat-title-controls button,
+  .mari-topbar .mari-panel-nav button {
+    width: 1.625rem;
+  }
+}
+
 .mari-chat-title-divider {
   display: block;
   width: 1px;


### PR DESCRIPTION
## Summary
- Preserve existing AppShell inert state while the onboarding tutorial is mounted, then re-sync mobile panel inert state after onboarding unmounts.
- Track shell elements mounted while onboarding is open so later-added mobile panels/backdrops are also inerted and restored on cleanup.
- Keep AppShell mobile panel inert/focus effects from overriding onboarding while the tutorial is mounted.
- Reuse the desktop chat, Home, and Professor Mari controls in the mobile top bar so mobile users can reopen the chat sidebar from Roleplay.
- Keep the extra-narrow mobile top bar within the viewport while preserving the required chat/sidebar and panel controls.
- Close the mobile chat sidebar before starting a new chat so setup/connection gates mount in an interactive main surface.
- Prefer visible onboarding tour targets when desktop and mobile chrome both provide the same `data-tour` hook.

## Behavior changed
Skipping onboarding on mobile no longer leaves the chat sidebar or main app surfaces stuck in the wrong inert state. Mobile Roleplay now also has a visible Open chats control in the top bar; tapping it opens the full-width chat sidebar so users can switch between CONVO/RP/GM or create/select chats without relying on the Android back gesture.

Starting a new chat from the mobile sidebar now closes the sidebar first, so any setup or connection gate that appears in the main route is reachable instead of being inert underneath the sidebar dialog. On very narrow mobile widths, the optional Professor Mari top-bar button is hidden to prevent clipping; it remains visible at Pixel 7 Pro width and in the desktop titlebar.

## Primary files/modules touched
- `src/app/shell/AppShell.tsx`
- `src/app/shell/ChatSidebar.tsx`
- `src/app/shell/ChatTitleControls.tsx`
- `src/app/shell/TopBar.tsx`
- `src/app/shell/WindowTitleBar.tsx`
- `src/features/shell/onboarding/components/OnboardingTutorial.tsx`
- `src/styles/globals.css`

## Impact / dependent areas reviewed
- AppShell mobile panel inert and focus behavior.
- First-run onboarding modal inert/focus cleanup.
- Dynamic shell children mounted while onboarding is open.
- Mobile top app chrome layout and sidebar access.
- Mobile new-chat setup/connection gate flow from the sidebar.
- Desktop titlebar chat/Home/Professor Mari controls, now routed through the shared control component.
- Onboarding spotlight target lookup with duplicate desktop/mobile tour hooks.

## Verification
- `pnpm typecheck`
- `pnpm check:architecture`
- `pnpm build` passed; Vite reported existing chunk/dynamic-import warnings.
- Browser/Vite mobile viewport check: at 360px, AppChrome and TopBar `scrollWidth` both stayed at 360px, Professor Mari was hidden, and the visible top-bar controls fit within the viewport.
- Browser/Vite mobile viewport check: at 411px, Professor Mari was visible and AppChrome/TopBar still had no horizontal overflow.
- Browser/Vite mobile interaction check: with the mobile sidebar open, tapping New Conversation closed the sidebar, cleared `main` inert/`aria-hidden`, and left setup buttons without an inert ancestor.
- Android ADB/CDP targeted QA: replay tutorial, `Next -> Skip`, sidebar stays interactive, main/header stay inert, and RP tab tap works.
- Android ADB/CDP targeted QA: skip tutorial while sidebar is already open, sidebar stays interactive and background remains inert.
- Android ADB/CDP targeted QA: mobile top bar shows Open chats, Home, and Professor Mari controls; Open chats opens the full-width sidebar dialog; tapping CONVO activates the Conversation tab and exposes New Conversation.
- Android WebView/CDP targeted QA: while onboarding is open, a newly appended shell child outside the tutorial becomes inert; after Skip/cleanup it is restored.

## Docs / release notes
- Not updated: scoped mobile shell/onboarding bugfix, no repo changelog/release-note source found.

## Remaining risk
- Full mobile app QA sweep was not run. The latest setup-gate and narrow-topbar proof was Browser/Vite mobile viewport proof; native Android proof was focused on onboarding and sidebar access paths.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Sidebar automatically closes when creating a new chat on mobile devices for a smoother workflow
  * Enhanced responsive design optimizations for screens under 380px wide
  * Improved onboarding tutorial integration with better management of app interface interactions during the tutorial experience

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1190?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->