### PR TITLE
Strip avatarPath from agent gameState serialization

### DIFF
--- a/src/engine/agents-runtime/executor/agent-executor.ts
+++ b/src/engine/agents-runtime/executor/agent-executor.ts
@@ -1087,7 +1087,14 @@ function buildAgentExtras(context: AgentContext, agentTypes: string[] = []): str
 
   if (context.gameState) {
     parts.push(`<current_game_state>`);
-    parts.push(JSON.stringify(context.gameState));
+    // Strip presentCharacters[].avatarPath before serialization: it is a UI display
+    // field (image path or inline data URL) the model never reads, and a single
+    // inlined data: URL can be megabytes of base64 - imported pre-refactor chats
+    // ship with full data URLs in this field and were blowing past 1M-token
+    // provider ceilings (issue #1188).
+    parts.push(
+      JSON.stringify(context.gameState, (key, value) => (key === "avatarPath" ? undefined : value)),
+    );
     parts.push(`</current_game_state>`);
   }
 

--- a/src/engine/agents-runtime/executor/agent-executor.ts
+++ b/src/engine/agents-runtime/executor/agent-executor.ts
@@ -10,6 +10,7 @@ import type {
 import type { AgentResult, AgentContext, AgentResultType } from "../../contracts/types/agent";
 import { getDefaultAgentPrompt } from "../../contracts/constants/agent-prompts";
 import { DEFAULT_AGENT_CONTEXT_SIZE, DEFAULT_AGENT_MAX_TOKENS, MAX_AGENT_MAX_TOKENS, MIN_AGENT_MAX_TOKENS } from "../../contracts/types/agent";
+import { stripAvatarPathsReplacer } from "../strip-avatar-paths";
 const isDebugAgentsEnabled = () => false;
 const logger = {
   debug: (..._args: unknown[]) => {},
@@ -926,7 +927,7 @@ function buildAgentMessages(
         if (gs.playerStats) trackerSummary.playerStats = gs.playerStats;
         if (gs.personaStats?.length) trackerSummary.personaStats = gs.personaStats;
         if (Object.keys(trackerSummary).length > 0) {
-          content += `\n\n<committed_tracker_state>\n${JSON.stringify(trackerSummary)}\n</committed_tracker_state>`;
+          content += `\n\n<committed_tracker_state>\n${JSON.stringify(trackerSummary, stripAvatarPathsReplacer)}\n</committed_tracker_state>`;
         }
       }
 
@@ -1087,14 +1088,7 @@ function buildAgentExtras(context: AgentContext, agentTypes: string[] = []): str
 
   if (context.gameState) {
     parts.push(`<current_game_state>`);
-    // Strip presentCharacters[].avatarPath before serialization: it is a UI display
-    // field (image path or inline data URL) the model never reads, and a single
-    // inlined data: URL can be megabytes of base64 - imported pre-refactor chats
-    // ship with full data URLs in this field and were blowing past 1M-token
-    // provider ceilings (issue #1188).
-    parts.push(
-      JSON.stringify(context.gameState, (key, value) => (key === "avatarPath" ? undefined : value)),
-    );
+    parts.push(JSON.stringify(context.gameState, stripAvatarPathsReplacer));
     parts.push(`</current_game_state>`);
   }
 

--- a/src/engine/agents-runtime/knowledge/knowledge-router.ts
+++ b/src/engine/agents-runtime/knowledge/knowledge-router.ts
@@ -2,6 +2,7 @@ import type { AgentContext, AgentResult } from "../../contracts/types/agent";
 import type { LorebookEntry } from "../../contracts/types/lorebook";
 import type { BaseLLMProvider } from "../../generation-core/llm/base-provider.js";
 import { executeAgent, type AgentExecConfig } from "../executor/agent-executor.js";
+import { stripAvatarPathsReplacer } from "../strip-avatar-paths.js";
 import {
   scanForActivatedEntries,
   type ScanMessage,
@@ -159,7 +160,7 @@ export function buildKnowledgeRouterQuery(context: AgentContext): string {
     .map((message) => message.content.trim())
     .filter(Boolean);
   if (context.chatSummary?.trim()) parts.unshift(context.chatSummary.trim());
-  if (context.gameState) parts.push(JSON.stringify(context.gameState));
+  if (context.gameState) parts.push(JSON.stringify(context.gameState, stripAvatarPathsReplacer));
   return parts.join("\n\n");
 }
 

--- a/src/engine/agents-runtime/strip-avatar-paths.ts
+++ b/src/engine/agents-runtime/strip-avatar-paths.ts
@@ -1,0 +1,20 @@
+/**
+ * JSON.stringify replacer that drops `avatarPath` from any object in the tree.
+ *
+ * `presentCharacters[].avatarPath` is a UI display field (image path or inline
+ * data URL) the model never reads. Imported pre-refactor chats can ship full
+ * base64 data URLs in this field (the legacy backup format inlines avatars
+ * rather than referencing asset paths), and a single inlined avatar can be
+ * megabytes of base64. Serialized verbatim into agent prompts that already
+ * carry the bulk of chat context, this pushes turns past 1M-token provider
+ * ceilings and every tracker agent returns HTTP 400 "prompt is too long"
+ * (issue #1188).
+ *
+ * Use this replacer at every site that serializes `gameState` or anything
+ * containing `presentCharacters` into a prompt:
+ *
+ *   JSON.stringify(value, stripAvatarPathsReplacer)
+ */
+export function stripAvatarPathsReplacer(key: string, value: unknown): unknown {
+  return key === "avatarPath" ? undefined : value;
+}


### PR DESCRIPTION
## Why this change

Imported pre-refactor chats can carry full base64 image data URLs in `gameState.presentCharacters[].avatarPath` - the legacy backup format inlines avatars rather than referencing asset paths. Three sites in the agents-runtime layer serialize `gameState` (or a tracker summary built from it) into agent prompts, each of which can pick up a megabyte+ of base64 per present character.

On 1M-token providers (e.g. Gemini) the agent prompt blew past the ceiling and every tracker agent failed with:

```
Provider returned HTTP 400 Bad Request: prompt is too long: 2188040 tokens > 1000000 maximum
```

`applyAgentResultEffects` in `src/features/runtime/generation/hooks/use-generate.ts` short-circuits on `!result.success`, so the failures never reached the bubble / tracker handlers and the user-visible symptom was both panels stuck on their empty states ("No tracker data yet" and "No agent activity yet") with no error indication, even though the main chat reply itself succeeded.

## What changed

New named helper `stripAvatarPathsReplacer` at `src/engine/agents-runtime/strip-avatar-paths.ts` - a `JSON.stringify` replacer that drops any `avatarPath` key from the serialized tree. `avatarPath` is a UI display field (image path or data URL the tracker panel renders); the model never reads it. Every other model-relevant field on each present character (`name`, `mood`, `appearance`, `outfit`, `stats`, `thoughts`, `customFields`, etc.) is preserved as before.

The helper is now applied at all three sites that serialize `gameState` or a tracker summary built from it into a prompt:

1. `buildAgentExtras` `<current_game_state>` block at `src/engine/agents-runtime/executor/agent-executor.ts` - the original site identified in #1188.
2. `buildAgentMessages` `<committed_tracker_state>` block at `src/engine/agents-runtime/executor/agent-executor.ts` - attaches a tracker summary to the last 3 assistant messages and assigns `gs.presentCharacters` whole; structured-output agents would inherit the avatarPath data URLs from history regardless of whether `<current_game_state>` is included.
3. `buildKnowledgeRouterQuery` at `src/engine/agents-runtime/knowledge/knowledge-router.ts` - serializes `context.gameState` verbatim into the router query; latent until the knowledge router is enabled on an imported chat.

Co-locating the rule in a named helper makes it findable by symbol search and keeps future serialization sites a one-import-and-pass-the-replacer change rather than rediscovering the rule per-site.

## Verification

- `pnpm check:frontend`, `pnpm check:architecture`, `pnpm check:docs` all pass locally (595 modules, 2120 dependencies cruised).
- Manually verified in `pnpm tauri dev` on Windows against an imported pre-refactor profile (the exact repro from the issue: roleplay chat with `activeAgentIds: ["world-state", "quest", "character-tracker", "persona-stats"]`). Before the fix: all four agent results returned `success: false` with the prompt-too-long error and both side panels stayed empty. After the fix: all four agents complete normally, the agent activity panel shows the four thought bubbles, and the tracker panel populates with world / character / quest / persona data. Re-verified after the helper extraction; behavior unchanged.

## Out of scope

A second, separate UX bug is visible in passing: when every agent in a turn fails, the user sees only the empty-state panels - the failure surface (`setFailedAgentFailures` / `failedAgentTypes` in `agent.store.ts`) is defined but never called from `applyAgentResultEffects`, so genuine agent failures are silent. That made this bug much harder to spot than it should have been. Filed as #1192 to track separately; intentionally left out of this PR to keep the diff focused on the actual root cause.

Fixes #1188.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Optimized agent prompt serialization to exclude avatar path data, reducing unnecessary data transmission and improving performance when using legacy imported chats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1191?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->