### PR TITLE
Surface failed agents in generation hot path

### DIFF
--- a/src/features/runtime/generation/hooks/use-generate.ts
+++ b/src/features/runtime/generation/hooks/use-generate.ts
@@ -893,8 +893,20 @@ export function useGenerate() {
     async (chatId: string, agentTypes?: string[], options?: Record<string, unknown>) => {
       try {
         await assertChatCanGenerate(queryClient, chatId);
-        useAgentStore.getState().setProcessing(true);
-        useAgentStore.getState().clearFailedAgentTypes();
+        const agentStore = useAgentStore.getState();
+        agentStore.setProcessing(true);
+        if (agentTypes && agentTypes.length > 0) {
+          // Targeted retry: clear only the entries for agents we're about to re-run, so
+          // prior-turn failures for agents that aren't being retried stay visible. If any
+          // of the retried agents fail again, addFailedAgentFailure in applyAgentResultEffects
+          // will repopulate them via the result loop below.
+          const retrySet = new Set(agentTypes);
+          const remaining = agentStore.failedAgentFailures.filter((failure) => !retrySet.has(failure.agentType));
+          agentStore.setFailedAgentFailures(remaining);
+        } else {
+          // Full retry: clear everything; the result loop repopulates anything still failing.
+          agentStore.clearFailedAgentTypes();
+        }
         const results = await retryGenerationAgents(
           { storage: storageApi, llm: llmApi, integrations: integrationGateway },
           { chatId, agentTypes, options },

--- a/src/features/runtime/generation/hooks/use-generate.ts
+++ b/src/features/runtime/generation/hooks/use-generate.ts
@@ -24,6 +24,7 @@ import { storageApi } from "../../../../shared/api/storage-api";
 import { integrationGateway } from "../../../../shared/api/integration-gateway";
 import { ApiError } from "../../../../shared/api/api-errors";
 import { useAgentStore, type PendingCardUpdate } from "../../../../shared/stores/agent.store";
+import { toAgentFailure } from "../../../../shared/lib/agent-failures";
 import { useChatStore } from "../../../../shared/stores/chat.store";
 import { useUIStore } from "../../../../shared/stores/ui.store";
 import { useGameStateStore } from "../../world-state/index";
@@ -672,7 +673,12 @@ async function applyAgentResultEffects(
   const agentStore = useAgentStore.getState();
   agentStore.addResult(result.agentId || result.agentType, result);
 
-  if (!result.success) return;
+  if (!result.success) {
+    agentStore.addFailedAgentFailure(
+      toAgentFailure({ agentType: result.agentType, agentName, error: result.error }),
+    );
+    return;
+  }
   const bubble = formatAgentBubble(result, agentName);
   if (bubble) agentStore.addThoughtBubble(result.agentType, agentName, bubble);
 
@@ -729,6 +735,7 @@ export async function runGenerationWithUi(
   chatStore.setGenerationPhase("Starting generation...");
   chatStore.setStreamBuffer("", chatId);
   chatStore.setThinkingBuffer("", chatId);
+  useAgentStore.getState().clearFailedAgentTypes();
   useAgentStore.getState().setProcessing(true);
 
   let received = "";
@@ -887,6 +894,7 @@ export function useGenerate() {
       try {
         await assertChatCanGenerate(queryClient, chatId);
         useAgentStore.getState().setProcessing(true);
+        useAgentStore.getState().clearFailedAgentTypes();
         const results = await retryGenerationAgents(
           { storage: storageApi, llm: llmApi, integrations: integrationGateway },
           { chatId, agentTypes, options },
@@ -895,7 +903,6 @@ export function useGenerate() {
           await applyAgentResultEffects(queryClient, chatId, result);
         }
         await refreshGameStateFromStorage(chatId);
-        useAgentStore.getState().clearFailedAgentTypes();
         await queryClient.invalidateQueries({ queryKey: ["agents"] });
         await queryClient.invalidateQueries({ queryKey: ["chats"] });
       } catch (error) {

--- a/src/shared/stores/agent.store.ts
+++ b/src/shared/stores/agent.store.ts
@@ -87,6 +87,7 @@ interface AgentState {
   clearDebugLog: () => void;
   setFailedAgentTypes: (types: string[]) => void;
   setFailedAgentFailures: (failures: AgentFailure[]) => void;
+  addFailedAgentFailure: (failure: AgentFailure) => void;
   clearFailedAgentTypes: () => void;
   addThoughtBubble: (agentId: string, agentName: string, content: string) => void;
   dismissThoughtBubble: (index: number) => void;
@@ -157,6 +158,15 @@ export const useAgentStore = create<AgentState>((set) => ({
     set({
       failedAgentTypes: failures.map((failure) => failure.agentType),
       failedAgentFailures: failures,
+    }),
+  addFailedAgentFailure: (failure) =>
+    set((s) => {
+      const withoutSameType = s.failedAgentFailures.filter((f) => f.agentType !== failure.agentType);
+      const failures = [...withoutSameType, failure];
+      return {
+        failedAgentFailures: failures,
+        failedAgentTypes: failures.map((f) => f.agentType),
+      };
     }),
   clearFailedAgentTypes: () => set({ failedAgentTypes: [], failedAgentFailures: [] }),
 


### PR DESCRIPTION
## Why this change

Closes #1192.

When an agent generation fails (provider 4xx, timeout, malformed output, anything that sets `result.success: false`), the failure is invisible in the UI. The existing empty-state panels render and no toast, badge, or retry surface appears. The store fields and UI consumers for failed agents already exist (`failedAgentTypes`, `failedAgentFailures`, the amber dot on the Agents nav button, `RoleplayHUDActionsMenu`'s retry block, `use-chat-timeline-actions` retry handler) but nothing in the per-turn hot path ever populated them. `applyAgentResultEffects` would `addResult` to the per-agent map, then short-circuit on `!result.success` before any failure surface was touched. The only caller of `clearFailedAgentTypes` was the `retryAgents` flow, so the arrays stayed empty in normal usage.

This wasn't a regression — the gap has been there since the failure-arrays plumbing was added. The #1191 avatar-bloat fix removed one common trigger for silent agent failures, but the silent-failure shape itself stays open for any future cause (rate limits, auth errors, timeouts, malformed output), so closing the gap now keeps the original report from drifting.

## What changed

- `src/shared/stores/agent.store.ts`: add `addFailedAgentFailure(failure)` action. Dedupes by `agentType` so the same agent failing again on a later turn or a re-retry replaces the prior entry instead of stacking.
- `src/features/runtime/generation/hooks/use-generate.ts`:
  - In `applyAgentResultEffects`, push the failure before the early return on `!result.success`. Uses `toAgentFailure` from `shared/lib/agent-failures.ts` so `reasonLabel` ("Context limit", "Timeout", "Rate limit", "Authentication", ...) is classified from the provider error string, which is what the retry block uses for human-readable copy.
  - In `runGenerationWithUi`, clear the failed-agent arrays at turn start so stale failures don't bleed across turns.
  - In `retryAgents`, replace the after-loop `clearFailedAgentTypes()` with a scoped clear at the top. If `agentTypes` is provided, only entries whose `agentType` is in that set are removed — the rest stay visible. If `agentTypes` is omitted (full retry), keep the existing full clear. This matters for the per-agent rerun buttons (illustrator/cyoa/lorebook-keeper/per-tracker) called from `GameSurface`, `CyoaChoices`, `ChatSettingsDrawer`, `SecretPlotPanel`, `ContextInjectionPanel`, and `use-tracker-rerun`: a successful targeted retry now leaves prior-turn failures for other agents visible instead of wiping them. The "Retry Failed Agents" all-button case (`use-chat-timeline-actions.ts:377`, passes the full `failedAgentTypes`) is functionally equivalent under either clear scope.

No UI work required — the existing consumers (`PanelNavButtons` badge, `RoleplayHUDActionsMenu` retry section, `use-chat-timeline-actions` `handleRetryFailedAgents`) all read from the store and react automatically.

## Verification

- `pnpm check` passes locally (architecture + frontend TS + cargo check + docs check).
- Browser fast path (`pnpm dev` + Vite at `localhost:1420`): injected synthetic failures via `useAgentStore.getState().addFailedAgentFailure(toAgentFailure({...}))` for `character-tracker` (prompt-too-long), `world-state` (timeout), and `illustrator` (rate limit). Confirmed dedupe by `agentType` works, `reasonLabel` resolves correctly ("Context limit", "Timeout", "Rate limit"), and the amber failed-agent dot lights up on the Agents nav button. Then simulated a targeted retry of `["illustrator"]`: the scoped-clear filter removed only the illustrator entry and the remaining two failures + the dot stayed visible. Untargeted retry (no `agentTypes`) clears everything as before. `clearFailedAgentTypes()` resets both arrays and the dot disappears.
- Not yet verified in `pnpm tauri dev`: the real end-to-end repro path (trigger an actual provider failure in the desktop shell and confirm the retry block + retry button work). Will run that pass before promoting this PR out of draft.

## Risk

- Touches the per-turn hot path in `applyAgentResultEffects`, which is shared by chat / roleplay / game modes. Only adds a store write on the already-existing failure short-circuit, so behavior for successful results is unchanged.
- `retryAgents` clear semantics changed from "always clear everything before the retry" to "scoped clear" when a targeted `agentTypes` list is supplied. This is a behavior change for the per-agent rerun buttons, but it's the intended one — without it, a successful targeted retry would hide prior-turn failures for agents that weren't even re-run.
- The dedupe-by-`agentType` in `addFailedAgentFailure` overwrites a prior entry of the same type. The current agent runtime is one-per-type per turn, so this is correct; if a future change ever fans out per-character trackers under a single type, the dedupe would need to switch to a composite key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced tracking of agent failures during content generation for more accurate error reporting
  * Improved retry mechanism with support for targeted retries of specific agents
  * Refined failure history management to preserve prior failures when retrying individual agents

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1193?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->