### PR TITLE
Add mobile Tracker dock states

### DIFF
--- a/src/app/shell/AppShell.tsx
+++ b/src/app/shell/AppShell.tsx
@@ -34,6 +34,8 @@ import {
   type CSSProperties,
   type KeyboardEvent as ReactKeyboardEvent,
   type MouseEvent as ReactMouseEvent,
+  type PointerEvent as ReactPointerEvent,
+  type TouchEvent as ReactTouchEvent,
 } from "react";
 
 const ModeSurface = lazy(() =>
@@ -72,6 +74,10 @@ const TRACKER_PANEL_DESKTOP_EXIT_EASE = [0.4, 0, 1, 1] as const;
 const TRACKER_PANEL_TOGGLE_SELECTOR = '[data-tracker-panel-toggle="roleplay-hud"]';
 const TRACKER_PANEL_ANCHOR_SELECTOR = '[data-tracker-panel-anchor="roleplay-hud"]';
 const TOP_BAR_SELECTOR = '[data-component="TopBar"]';
+const MOBILE_TRACKER_GESTURE_LOCK_PX = 18;
+const MOBILE_TRACKER_SNAP_PX = 44;
+const MOBILE_TRACKER_DEEP_SNAP_PX = 132;
+const MOBILE_TRACKER_DOCK_STATES = ["collapsed", "compact", "expanded"] as const;
 const FOCUSABLE_SELECTOR = [
   "a[href]",
   "button:not([disabled])",
@@ -80,6 +86,54 @@ const FOCUSABLE_SELECTOR = [
   "select:not([disabled])",
   "[tabindex]:not([tabindex='-1'])",
 ].join(",");
+
+type MobileTrackerDockView = (typeof MOBILE_TRACKER_DOCK_STATES)[number];
+
+interface MobileTrackerDragState {
+  cancelled: boolean;
+  locked: boolean;
+  pointerId: number;
+  side: "left" | "right";
+  startClientX: number;
+  startClientY: number;
+  startDockView: MobileTrackerDockView;
+}
+
+function getMobileTrackerDockWidthPx(view: MobileTrackerDockView, viewportWidth: number) {
+  const rootFontSize =
+    typeof window === "undefined"
+      ? 16
+      : Number.parseFloat(window.getComputedStyle(document.documentElement).fontSize) || 16;
+  const rem = (value: number) => value * rootFontSize;
+
+  if (view === "collapsed") return rem(1.375);
+  if (view === "expanded") {
+    return viewportWidth <= 380
+      ? clampWidth(viewportWidth * 0.58, rem(12.5), rem(17))
+      : clampWidth(viewportWidth * 0.58, rem(13.5), rem(18));
+  }
+
+  return viewportWidth <= 380
+    ? clampWidth(viewportWidth * 0.4, rem(8.5), rem(14.5))
+    : clampWidth(viewportWidth * 0.38, rem(8.75), rem(15));
+}
+
+function getMobileTrackerDockStateIndex(view: MobileTrackerDockView) {
+  return Math.max(0, MOBILE_TRACKER_DOCK_STATES.indexOf(view));
+}
+
+function resolveMobileTrackerDockView(startDockView: MobileTrackerDockView, signedDelta: number): MobileTrackerDockView {
+  const startIndex = getMobileTrackerDockStateIndex(startDockView);
+  if (signedDelta >= MOBILE_TRACKER_DEEP_SNAP_PX) return "expanded";
+  if (signedDelta <= -MOBILE_TRACKER_DEEP_SNAP_PX) return "collapsed";
+  if (signedDelta >= MOBILE_TRACKER_SNAP_PX) {
+    return MOBILE_TRACKER_DOCK_STATES[Math.min(MOBILE_TRACKER_DOCK_STATES.length - 1, startIndex + 1)]!;
+  }
+  if (signedDelta <= -MOBILE_TRACKER_SNAP_PX) {
+    return MOBILE_TRACKER_DOCK_STATES[Math.max(0, startIndex - 1)]!;
+  }
+  return startDockView;
+}
 
 function getFocusableElements(root: HTMLElement) {
   return Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter((element) => {
@@ -157,13 +211,19 @@ export function AppShell() {
   const trackerPanelSide = useUIStore((s) => s.trackerPanelSide);
   const trackerPanelHideHudWidgets = useUIStore((s) => s.trackerPanelHideHudWidgets);
   const trackerPanelSizeProfile = useUIStore((s) => s.trackerPanelSizeProfile);
-  const setTrackerPanelOpen = useUIStore((s) => s.setTrackerPanelOpen);
   const [sidebarDragWidth, setSidebarDragWidth] = useState<number | null>(null);
   const [rightPanelDragWidth, setRightPanelDragWidth] = useState<number | null>(null);
   const [activeChatSidebarTab, setActiveChatSidebarTab] = useState<ChatSidebarTab>("conversation");
   const [professorMariOpen, setProfessorMariOpen] = useState(false);
+  const [mobileTrackerDockView, setMobileTrackerDockView] = useState<MobileTrackerDockView>("compact");
+  const [mobileTrackerDragOffset, setMobileTrackerDragOffset] = useState(0);
+  const [mobileTrackerDragging, setMobileTrackerDragging] = useState(false);
   const sidebarDragWidthRef = useRef<number | null>(null);
   const rightPanelDragWidthRef = useRef<number | null>(null);
+  const mobileTrackerDockViewRef = useRef<MobileTrackerDockView>("compact");
+  const mobileTrackerDragStateRef = useRef<MobileTrackerDragState | null>(null);
+  const mobileTrackerSuppressClickRef = useRef(false);
+  const mobileTrackerWasVisibleRef = useRef(false);
   const headerRef = useRef<HTMLElement>(null);
   const liveSidebarWidth = sidebarDragWidth ?? sidebarWidth;
   const liveRightPanelWidth = rightPanelDragWidth ?? rightPanelWidth;
@@ -177,6 +237,10 @@ export function AppShell() {
     mq.addEventListener("change", handler);
     return () => mq.removeEventListener("change", handler);
   }, []);
+
+  useEffect(() => {
+    mobileTrackerDockViewRef.current = mobileTrackerDockView;
+  }, [mobileTrackerDockView]);
 
   // Auto-close right panel when viewport is too narrow for comfort
   useEffect(() => {
@@ -623,15 +687,235 @@ export function AppShell() {
     !isMobile && trackerPanelAnchoredForMotion && trackerPanelHideHudWidgets && trackerPanelSurfaceAvailable
       ? trackerPanelWidth + TRACKER_PANEL_HUD_GAP
       : 0;
+  const trackerPanelMobileDockVisible = isMobile && trackerPanelVisible && !sidebarOpen && !rightPanelOpen;
   const activeMobilePanel = isMobile
     ? rightPanelOpen
       ? "right"
-      : trackerPanelVisible
-        ? "tracker"
-        : sidebarOpen
-          ? "sidebar"
-          : null
+      : sidebarOpen
+        ? "sidebar"
+        : null
     : null;
+
+  useEffect(() => {
+    if (trackerPanelMobileDockVisible && !mobileTrackerWasVisibleRef.current) {
+      setMobileTrackerDockView("compact");
+      setMobileTrackerDragOffset(0);
+      setMobileTrackerDragging(false);
+    }
+    if (!trackerPanelMobileDockVisible) {
+      mobileTrackerDragStateRef.current = null;
+      setMobileTrackerDragOffset(0);
+      setMobileTrackerDragging(false);
+    }
+    mobileTrackerWasVisibleRef.current = trackerPanelMobileDockVisible;
+  }, [trackerPanelMobileDockVisible]);
+
+  const updateMobileTrackerDrag = useCallback(
+    (pointerId: number, clientX: number, clientY: number, capturePointer: () => void, preventDefault: () => void) => {
+      const dragState = mobileTrackerDragStateRef.current;
+      if (!dragState || dragState.pointerId !== pointerId || dragState.cancelled) return;
+
+      const dx = clientX - dragState.startClientX;
+      const dy = clientY - dragState.startClientY;
+      const absDx = Math.abs(dx);
+      const absDy = Math.abs(dy);
+
+      if (!dragState.locked) {
+        if (absDy > 10 && absDy > absDx * 1.15) {
+          dragState.cancelled = true;
+          mobileTrackerDragStateRef.current = dragState;
+          return;
+        }
+        if (absDx < MOBILE_TRACKER_GESTURE_LOCK_PX || absDx < absDy * 1.1) return;
+
+        dragState.locked = true;
+        mobileTrackerDragStateRef.current = dragState;
+        capturePointer();
+        setMobileTrackerDragging(true);
+      }
+
+      const signedDelta = dx * (dragState.side === "left" ? 1 : -1);
+      const viewportWidth = typeof window === "undefined" ? 411 : window.innerWidth;
+      const baseWidth = getMobileTrackerDockWidthPx(dragState.startDockView, viewportWidth);
+      const minOffset = getMobileTrackerDockWidthPx("collapsed", viewportWidth) - baseWidth;
+      const maxOffset = getMobileTrackerDockWidthPx("expanded", viewportWidth) - baseWidth;
+      setMobileTrackerDragOffset(clampWidth(signedDelta, minOffset, maxOffset));
+      preventDefault();
+    },
+    [],
+  );
+
+  const finishMobileTrackerDragAt = useCallback((pointerId: number, clientX: number, releasePointer?: () => void) => {
+    const dragState = mobileTrackerDragStateRef.current;
+    if (!dragState || dragState.pointerId !== pointerId) return;
+
+    const signedDelta = (clientX - dragState.startClientX) * (dragState.side === "left" ? 1 : -1);
+    if (dragState.locked) {
+      setMobileTrackerDockView(resolveMobileTrackerDockView(dragState.startDockView, signedDelta));
+      mobileTrackerSuppressClickRef.current = true;
+      window.setTimeout(() => {
+        mobileTrackerSuppressClickRef.current = false;
+      }, 220);
+    }
+
+    releasePointer?.();
+    mobileTrackerDragStateRef.current = null;
+    setMobileTrackerDragOffset(0);
+    setMobileTrackerDragging(false);
+  }, []);
+
+  const finishMobileTrackerDrag = useCallback(
+    (event: ReactPointerEvent<HTMLElement>) => {
+      finishMobileTrackerDragAt(event.pointerId, event.clientX, () => {
+        if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+          event.currentTarget.releasePointerCapture(event.pointerId);
+        }
+      });
+    },
+    [finishMobileTrackerDragAt],
+  );
+
+  const handleMobileTrackerPointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLElement>) => {
+      if (!trackerPanelMobileDockVisible || !isMobile) return;
+      if (event.pointerType === "mouse" && event.button !== 0) return;
+
+      const target = event.target instanceof HTMLElement ? event.target : null;
+      const gripTarget = target?.closest("[data-mobile-tracker-grip]");
+      const interactiveTarget = target?.closest(
+        "a[href],button,input,textarea,select,[contenteditable='true'],[role='button']",
+      );
+      if (interactiveTarget && !gripTarget) return;
+
+      mobileTrackerDragStateRef.current = {
+        cancelled: false,
+        locked: false,
+        pointerId: event.pointerId,
+        side: trackerPanelSide,
+        startClientX: event.clientX,
+        startClientY: event.clientY,
+        startDockView: mobileTrackerDockViewRef.current,
+      };
+    },
+    [isMobile, trackerPanelMobileDockVisible, trackerPanelSide],
+  );
+
+  const handleMobileTrackerPointerMove = useCallback(
+    (event: ReactPointerEvent<HTMLElement>) => {
+      updateMobileTrackerDrag(
+        event.pointerId,
+        event.clientX,
+        event.clientY,
+        () => event.currentTarget.setPointerCapture(event.pointerId),
+        () => event.preventDefault(),
+      );
+    },
+    [updateMobileTrackerDrag],
+  );
+
+  const handleMobileTrackerPointerCancel = useCallback((event: ReactPointerEvent<HTMLElement>) => {
+    const dragState = mobileTrackerDragStateRef.current;
+    if (!dragState || dragState.pointerId !== event.pointerId) return;
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+    mobileTrackerDragStateRef.current = null;
+    setMobileTrackerDragOffset(0);
+    setMobileTrackerDragging(false);
+  }, []);
+
+  const handleMobileTrackerTouchStart = useCallback(
+    (event: ReactTouchEvent<HTMLElement>) => {
+      if (!trackerPanelMobileDockVisible || !isMobile) return;
+
+      const target = event.target instanceof HTMLElement ? event.target : null;
+      const gripTarget = target?.closest("[data-mobile-tracker-grip]");
+      const interactiveTarget = target?.closest(
+        "a[href],button,input,textarea,select,[contenteditable='true'],[role='button']",
+      );
+      if (interactiveTarget && !gripTarget) return;
+
+      const touch = event.touches[0];
+      if (!touch) return;
+      mobileTrackerDragStateRef.current = {
+        cancelled: false,
+        locked: false,
+        pointerId: touch.identifier,
+        side: trackerPanelSide,
+        startClientX: touch.clientX,
+        startClientY: touch.clientY,
+        startDockView: mobileTrackerDockViewRef.current,
+      };
+    },
+    [isMobile, trackerPanelMobileDockVisible, trackerPanelSide],
+  );
+
+  const handleMobileTrackerTouchMove = useCallback(
+    (event: ReactTouchEvent<HTMLElement>) => {
+      const dragState = mobileTrackerDragStateRef.current;
+      if (!dragState) return;
+      const touch = Array.from(event.touches).find((candidate) => candidate.identifier === dragState.pointerId);
+      if (!touch) return;
+      updateMobileTrackerDrag(
+        touch.identifier,
+        touch.clientX,
+        touch.clientY,
+        () => {},
+        () => event.preventDefault(),
+      );
+    },
+    [updateMobileTrackerDrag],
+  );
+
+  const handleMobileTrackerTouchEnd = useCallback(
+    (event: ReactTouchEvent<HTMLElement>) => {
+      const dragState = mobileTrackerDragStateRef.current;
+      if (!dragState) return;
+      const touch = Array.from(event.changedTouches).find((candidate) => candidate.identifier === dragState.pointerId);
+      if (!touch) return;
+      finishMobileTrackerDragAt(touch.identifier, touch.clientX);
+    },
+    [finishMobileTrackerDragAt],
+  );
+
+  const stepMobileTrackerDockView = useCallback((direction: -1 | 1) => {
+    setMobileTrackerDockView((current) => {
+      const nextIndex = Math.max(
+        0,
+        Math.min(MOBILE_TRACKER_DOCK_STATES.length - 1, getMobileTrackerDockStateIndex(current) + direction),
+      );
+      return MOBILE_TRACKER_DOCK_STATES[nextIndex]!;
+    });
+  }, []);
+
+  const handleMobileTrackerGripClick = useCallback(() => {
+    if (mobileTrackerSuppressClickRef.current) return;
+    setMobileTrackerDockView((current) =>
+      current === "collapsed" ? "compact" : current === "compact" ? "expanded" : "compact",
+    );
+  }, []);
+
+  const handleMobileTrackerGripKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLButtonElement>) => {
+      const expandKey = trackerPanelSide === "left" ? "ArrowRight" : "ArrowLeft";
+      const collapseKey = trackerPanelSide === "left" ? "ArrowLeft" : "ArrowRight";
+
+      if (event.key === expandKey) {
+        event.preventDefault();
+        stepMobileTrackerDockView(1);
+      } else if (event.key === collapseKey) {
+        event.preventDefault();
+        stepMobileTrackerDockView(-1);
+      } else if (event.key === "Home") {
+        event.preventDefault();
+        setMobileTrackerDockView("collapsed");
+      } else if (event.key === "End") {
+        event.preventDefault();
+        setMobileTrackerDockView("expanded");
+      }
+    },
+    [stepMobileTrackerDockView, trackerPanelSide],
+  );
 
   const syncMobilePanelInert = useCallback(() => {
     if (!isMobile) {
@@ -644,7 +928,7 @@ export function AppShell() {
     }
 
     setInert(sidebarPanelRef.current, activeMobilePanel !== "sidebar");
-    setInert(mobileTrackerPanelRef.current, activeMobilePanel !== "tracker");
+    setInert(mobileTrackerPanelRef.current, activeMobilePanel === "sidebar" || activeMobilePanel === "right");
     setInert(mobileRightPanelRef.current, activeMobilePanel !== "right");
     setInert(headerRef.current, activeMobilePanel !== null);
     setInert(mainRef.current, activeMobilePanel !== null);
@@ -667,7 +951,6 @@ export function AppShell() {
 
     const getPanel = () => {
       if (activeMobilePanel === "right") return mobileRightPanelRef.current;
-      if (activeMobilePanel === "tracker") return mobileTrackerPanelRef.current;
       return sidebarPanelRef.current;
     };
 
@@ -691,7 +974,6 @@ export function AppShell() {
       if (event.key === "Escape") {
         event.preventDefault();
         if (activeMobilePanel === "right") closeRightPanel();
-        else if (activeMobilePanel === "tracker") setTrackerPanelOpen(false);
         else setSidebarOpen(false);
         return;
       }
@@ -733,7 +1015,7 @@ export function AppShell() {
         previous.focus();
       }
     };
-  }, [activeMobilePanel, closeRightPanel, hasCompletedOnboarding, isMobile, setSidebarOpen, setTrackerPanelOpen]);
+  }, [activeMobilePanel, closeRightPanel, hasCompletedOnboarding, isMobile, setSidebarOpen]);
 
   const trackerPanelDesktop = (side: "left" | "right") =>
     trackerPanelVisible && trackerPanelSide === side ? (
@@ -793,6 +1075,76 @@ export function AppShell() {
         </div>
       </motion.aside>
     ) : null;
+  const trackerPanelMobile = (side: "left" | "right") =>
+    trackerPanelMobileDockVisible && trackerPanelSide === side ? (
+      <motion.aside
+        ref={mobileTrackerPanelRef}
+        key={`mobile-tracker-${side}`}
+        initial={{ x: side === "left" ? -18 : 18, opacity: 0 }}
+        animate={{ x: 0, opacity: 1 }}
+        exit={{ x: side === "left" ? -14 : 14, opacity: 0 }}
+        transition={{ duration: 0.18, ease: TRACKER_PANEL_DESKTOP_EASE }}
+        data-component="TrackerDataSidebarMobile"
+        data-mobile-tracker-panel="dock"
+        data-mobile-tracker-side={side}
+        data-mobile-tracker-view={mobileTrackerDockView}
+        data-mobile-tracker-dragging={mobileTrackerDragging ? true : undefined}
+        aria-label="Tracker data panel"
+        onPointerDown={handleMobileTrackerPointerDown}
+        onPointerMove={handleMobileTrackerPointerMove}
+        onPointerUp={finishMobileTrackerDrag}
+        onPointerCancel={handleMobileTrackerPointerCancel}
+        onLostPointerCapture={handleMobileTrackerPointerCancel}
+        onTouchStart={handleMobileTrackerTouchStart}
+        onTouchMove={handleMobileTrackerTouchMove}
+        onTouchEnd={handleMobileTrackerTouchEnd}
+        onTouchCancel={handleMobileTrackerTouchEnd}
+        className={cn(
+          "mari-tracker-panel mari-tracker-panel-mobile relative z-20 min-h-0 flex-shrink-0 overflow-hidden shadow-2xl",
+          side === "left" ? "border-r" : "border-l",
+        )}
+        style={
+          {
+            "--mobile-tracker-drag-offset": `${mobileTrackerDragOffset}px`,
+          } as CSSProperties
+        }
+      >
+        <button
+          type="button"
+          data-mobile-tracker-grip
+          onClick={handleMobileTrackerGripClick}
+          onKeyDown={handleMobileTrackerGripKeyDown}
+          aria-label={
+            mobileTrackerDockView === "collapsed"
+              ? "Open tracker panel"
+              : mobileTrackerDockView === "compact"
+                ? "Expand tracker panel"
+                : "Return tracker panel to compact view"
+          }
+          title={
+            mobileTrackerDockView === "collapsed"
+              ? "Open tracker panel"
+              : mobileTrackerDockView === "compact"
+                ? "Expand tracker panel"
+                : "Return tracker panel to compact view"
+          }
+          className="mari-tracker-panel-mobile-grip"
+        >
+          <span aria-hidden="true" className="mari-tracker-panel-mobile-grip__mark" />
+        </button>
+        {mobileTrackerDockView !== "collapsed" && (
+          <div className="mari-tracker-panel-mobile-content">
+            <Suspense fallback={<SidePanelFallback />}>
+              <TrackerDataSidebar
+                fillHeight
+                presentation="mobileDock"
+                mobileDockView={mobileTrackerDockView === "expanded" ? "expanded" : "compact"}
+              />
+            </Suspense>
+          </div>
+        )}
+      </motion.aside>
+    ) : null;
 
   return (
     <div
@@ -831,7 +1183,12 @@ export function AppShell() {
         />
       </header>
 
-      <div data-component="AppShellBody" className="relative flex min-h-0 flex-1 overflow-hidden">
+      <div
+        data-component="AppShellBody"
+        data-mobile-tracker-docked={trackerPanelMobileDockVisible ? trackerPanelSide : undefined}
+        data-mobile-tracker-view={trackerPanelMobileDockVisible ? mobileTrackerDockView : undefined}
+        className="relative flex min-h-0 flex-1 overflow-hidden"
+      >
       {/* Mobile sidebar backdrop */}
       {sidebarOpen && (
         <div
@@ -881,6 +1238,7 @@ export function AppShell() {
       )}
 
       <AnimatePresence initial={false}>{!isMobile && trackerPanelSurfaceAvailable && trackerPanelDesktop("left")}</AnimatePresence>
+      <AnimatePresence initial={false}>{trackerPanelMobile("left")}</AnimatePresence>
 
       {/* Center content */}
       <main
@@ -921,43 +1279,7 @@ export function AppShell() {
       </main>
 
       <AnimatePresence initial={false}>{!isMobile && trackerPanelSurfaceAvailable && trackerPanelDesktop("right")}</AnimatePresence>
-
-      {/* Mobile tracker panel backdrop */}
-      {trackerPanelVisible && (
-        <div
-          className="fixed inset-0 z-40 bg-black/50 backdrop-blur-sm md:hidden"
-          onClick={() => setTrackerPanelOpen(false)}
-        />
-      )}
-
-      {/* Mobile tracker panel */}
-      {isMobile && (
-        <AnimatePresence mode="wait">
-          {trackerPanelVisible && (
-            <motion.aside
-              ref={mobileTrackerPanelRef}
-              key="mobile-tracker"
-              initial={{ x: trackerPanelSide === "left" ? "-100%" : "100%" }}
-              animate={{ x: 0 }}
-              exit={{ x: trackerPanelSide === "left" ? "-100%" : "100%" }}
-              transition={{ type: "spring", damping: 28, stiffness: 350 }}
-              data-component="TrackerDataSidebarMobile"
-              aria-label="Tracker data panel"
-              aria-modal="true"
-              role="dialog"
-              tabIndex={-1}
-              className={cn(
-                "mari-tracker-panel fixed! inset-y-0 z-50 w-[calc(100vw-0.5rem)] max-w-[24rem] overflow-hidden bg-[var(--background)]/65 pt-[env(safe-area-inset-top)] shadow-2xl backdrop-blur-xl",
-                trackerPanelSide === "left" ? "left-0" : "right-0",
-              )}
-            >
-              <Suspense fallback={<SidePanelFallback />}>
-                <TrackerDataSidebar fillHeight />
-              </Suspense>
-            </motion.aside>
-          )}
-        </AnimatePresence>
-      )}
+      <AnimatePresence initial={false}>{trackerPanelMobile("right")}</AnimatePresence>
 
       {/* Mobile right panel backdrop */}
       {rightPanelOpen && (

--- a/src/app/shell/PanelNavButtons.tsx
+++ b/src/app/shell/PanelNavButtons.tsx
@@ -1,6 +1,8 @@
 import { BookOpen, Bot, FileText, Link, Settings, Sparkles, User, Users } from "lucide-react";
 import type { MouseEvent as ReactMouseEvent } from "react";
+import { TrackerPanelIcon } from "../../shared/components/ui/TrackerPanelIcon";
 import { useAgentStore } from "../../shared/stores/agent.store";
+import { useChatStore } from "../../shared/stores/chat.store";
 import { useUIStore } from "../../shared/stores/ui.store";
 import { cn } from "../../shared/lib/utils";
 
@@ -20,10 +22,29 @@ function stopTitlebarDrag(event: ReactMouseEvent<HTMLElement>) {
 }
 
 export function PanelNavButtons({ className }: { className?: string }) {
+  const activeChatMode = useChatStore((s) => s.activeChat?.mode ?? null);
+  const closeRightPanel = useUIStore((s) => s.closeRightPanel);
+  const setSidebarOpen = useUIStore((s) => s.setSidebarOpen);
+  const setTrackerPanelOpen = useUIStore((s) => s.setTrackerPanelOpen);
+  const trackerPanelEnabled = useUIStore((s) => s.trackerPanelEnabled);
+  const trackerPanelOpen = useUIStore((s) => s.trackerPanelOpen);
   const toggleRightPanel = useUIStore((s) => s.toggleRightPanel);
   const rightPanel = useUIStore((s) => s.rightPanel);
   const rightPanelOpen = useUIStore((s) => s.rightPanelOpen);
   const failedAgentCount = useAgentStore((s) => s.failedAgentTypes.length);
+  const showMobileTrackerButton =
+    trackerPanelEnabled && (activeChatMode === "roleplay" || activeChatMode === "visual_novel");
+  const trackerLabel = trackerPanelOpen ? "Hide Tracker Panel" : "Show Tracker Panel";
+  const toggleTrackerPanel = () => {
+    if (trackerPanelOpen) {
+      setTrackerPanelOpen(false);
+      return;
+    }
+
+    closeRightPanel();
+    setSidebarOpen(false);
+    setTrackerPanelOpen(true);
+  };
 
   return (
     <nav
@@ -33,6 +54,28 @@ export function PanelNavButtons({ className }: { className?: string }) {
       onMouseDown={stopTitlebarDrag}
       onDoubleClick={stopTitlebarDrag}
     >
+      {showMobileTrackerButton && (
+        <button
+          type="button"
+          onClick={toggleTrackerPanel}
+          onMouseDown={stopTitlebarDrag}
+          onDoubleClick={stopTitlebarDrag}
+          className={cn(
+            "mari-titlebar-action relative rounded-md p-1.5 transition-all duration-200 md:hidden",
+            trackerPanelOpen
+              ? "mari-titlebar-action-active text-[color-mix(in_srgb,var(--primary)_72%,var(--y2k-pink))]"
+              : "text-[var(--muted-foreground)] hover:text-[var(--primary)]",
+          )}
+          title={trackerLabel}
+          aria-label={trackerLabel}
+          aria-pressed={trackerPanelOpen}
+        >
+          <TrackerPanelIcon size="0.95rem" strokeWidth={2} />
+          {trackerPanelOpen && (
+            <span className="absolute -bottom-0.5 left-1/2 h-0.5 w-3 -translate-x-1/2 rounded-full bg-gradient-to-r from-pink-500 to-cyan-400" />
+          )}
+        </button>
+      )}
       {RIGHT_PANEL_BUTTONS.map(({ panel, icon: Icon, label, activeClass, hoverClass, underlineClass }) => {
         const isActive = rightPanelOpen && rightPanel === panel;
         return (

--- a/src/features/modes/roleplay/components/RoleplayHUD.tsx
+++ b/src/features/modes/roleplay/components/RoleplayHUD.tsx
@@ -150,7 +150,17 @@ export function RoleplayHUD({
   const trackerPanelOpen = useUIStore((s) => s.trackerPanelOpen);
   const trackerPanelHideHudWidgets = useUIStore((s) => s.trackerPanelHideHudWidgets);
   const trackerTemperatureUnit = useUIStore((s) => s.trackerTemperatureUnit);
-  const toggleTrackerPanel = useUIStore((s) => s.toggleTrackerPanel);
+  const closeRightPanel = useUIStore((s) => s.closeRightPanel);
+  const setSidebarOpen = useUIStore((s) => s.setSidebarOpen);
+  const setTrackerPanelOpen = useUIStore((s) => s.setTrackerPanelOpen);
+
+  const openTrackerPanel = useCallback(() => {
+    if (typeof window !== "undefined" && window.innerWidth < 768) {
+      closeRightPanel();
+      setSidebarOpen(false);
+    }
+    setTrackerPanelOpen(true);
+  }, [closeRightPanel, setSidebarOpen, setTrackerPanelOpen]);
 
   const isTrackerBusy = isAgentProcessing || isStreaming || gameStateRefreshing;
   const showHudTrackerWidgets = !gameStateRefreshing && !(trackerPanelEnabled && trackerPanelHideHudWidgets);
@@ -259,7 +269,7 @@ export function RoleplayHUD({
         mobileCompact && "flex-1 min-w-0",
       )}
     >
-      {trackerPanelEnabled && !trackerPanelOpen && <TrackerPanelToggleButton onToggle={toggleTrackerPanel} />}
+      {trackerPanelEnabled && !trackerPanelOpen && <TrackerPanelToggleButton onToggle={openTrackerPanel} />}
 
       {/* Actions (Agents + Clear) */}
       <ActionsGroup

--- a/src/features/modes/shared/chat-ui/components/ChatInput.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatInput.tsx
@@ -145,6 +145,7 @@ export const ChatInput = memo(function ChatInput({
   const [charPickerOpen, setCharPickerOpen] = useState(false);
   const charPickerBtnRef = useRef<HTMLButtonElement>(null);
   const charPickerMenuRef = useRef<HTMLDivElement>(null);
+  const inputContainerRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const emojiButtonRef = useRef<HTMLButtonElement>(null);
   const inputBarRef = useRef<HTMLDivElement>(null);
@@ -1025,6 +1026,41 @@ export const ChatInput = memo(function ChatInput({
     if (hasInput && feedback) setFeedback(null);
   }, [hasInput, feedback]);
 
+  useEffect(() => {
+    if (mode !== "roleplay") return;
+    const inputContainer = inputContainerRef.current;
+    if (!inputContainer) return;
+
+    const scope =
+      inputContainer.closest<HTMLElement>('[data-component="AppShellBody"]') ?? document.documentElement;
+    const reserveProperty = "--mobile-docked-composer-height";
+    let frame = 0;
+
+    const updateReserve = () => {
+      if (frame) cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(() => {
+        frame = 0;
+        const height = Math.ceil(inputContainer.getBoundingClientRect().height);
+        if (height > 0) scope.style.setProperty(reserveProperty, `${height}px`);
+      });
+    };
+
+    updateReserve();
+
+    const resizeObserver = typeof ResizeObserver === "undefined" ? null : new ResizeObserver(updateReserve);
+    resizeObserver?.observe(inputContainer);
+    window.addEventListener("resize", updateReserve);
+    window.visualViewport?.addEventListener("resize", updateReserve);
+
+    return () => {
+      if (frame) cancelAnimationFrame(frame);
+      resizeObserver?.disconnect();
+      window.removeEventListener("resize", updateReserve);
+      window.visualViewport?.removeEventListener("resize", updateReserve);
+      scope.style.removeProperty(reserveProperty);
+    };
+  }, [mode]);
+
   const _isRP = mode === "roleplay";
   void _isRP;
 
@@ -1162,7 +1198,7 @@ export const ChatInput = memo(function ChatInput({
   );
 
   return (
-    <div className="mari-chat-input chat-input-container px-3 pb-3">
+    <div ref={inputContainerRef} className="mari-chat-input chat-input-container px-3 pb-3">
       {/* Slash command autocomplete popup */}
       {completions.length > 0 && (
         <div className="mb-2 max-h-[min(18rem,45dvh)] overflow-y-auto rounded-xl border border-foreground/10 bg-[var(--card)] shadow-xl backdrop-blur-xl [-webkit-overflow-scrolling:touch]">
@@ -1237,7 +1273,7 @@ export const ChatInput = memo(function ChatInput({
         onDragLeave={handleDragLeave}
         onDrop={handleDrop}
         className={cn(
-          "mari-chat-input-box relative flex items-center gap-1.5 rounded-2xl border-2 px-2.5 py-2.5 transition-all duration-200 sm:gap-2 sm:px-4",
+          "mari-chat-input-box relative flex flex-wrap items-center gap-1.5 gap-y-2 rounded-2xl border-2 px-2.5 py-2.5 transition-all duration-200 sm:flex-nowrap sm:gap-2 sm:px-4",
           "bg-[var(--card)]",
           isDragging
             ? "border-blue-400/50 bg-blue-500/10 shadow-lg shadow-blue-500/10"
@@ -1255,25 +1291,24 @@ export const ChatInput = memo(function ChatInput({
           className="hidden"
           onChange={handleFileUpload}
         />
-        <button
-          onClick={() => fileInputRef.current?.click()}
-          disabled={!activeChatId}
-          className={cn(
-            "rounded-lg p-1.5 transition-all active:scale-90",
-            attachments.length
-              ? "text-blue-400 hover:bg-foreground/10"
-              : "text-foreground/40 hover:bg-foreground/10 hover:text-foreground/70",
-          )}
-          title="Attach files"
-        >
-          <Paperclip size="1rem" />
-        </button>
 
-        {/* Quick Switchers — desktop: inline, mobile: chevron */}
-        <QuickConnectionSwitcher className="hidden sm:flex" />
-        <QuickPersonaSwitcher className="hidden sm:flex" />
-        <div className="sm:hidden">
-          <QuickSwitcherMobile />
+        {/* Quick Switchers — desktop: inline, mobile: wrapped controls */}
+        <div className="hidden items-center gap-1.5 sm:flex">
+          <button
+            onClick={() => fileInputRef.current?.click()}
+            disabled={!activeChatId}
+            className={cn(
+              "rounded-lg p-1.5 transition-all active:scale-90",
+              attachments.length
+                ? "text-blue-400 hover:bg-foreground/10"
+                : "text-foreground/40 hover:bg-foreground/10 hover:text-foreground/70",
+            )}
+            title="Attach files"
+          >
+            <Paperclip size="1rem" />
+          </button>
+          <QuickConnectionSwitcher />
+          <QuickPersonaSwitcher />
         </div>
 
         {/* Text input */}
@@ -1295,9 +1330,27 @@ export const ChatInput = memo(function ChatInput({
           rows={1}
           spellCheck
           autoCorrect="on"
-          className="mari-chat-input-textarea max-h-[12.5rem] min-w-0 flex-1 resize-none bg-transparent py-0 text-sm leading-normal text-foreground/90 placeholder:text-foreground/30 outline-none disabled:cursor-not-allowed disabled:opacity-40"
+          className="mari-chat-input-textarea max-h-[12.5rem] min-w-0 basis-full resize-none bg-transparent py-0 text-sm leading-normal text-foreground/90 placeholder:text-foreground/30 outline-none disabled:cursor-not-allowed disabled:opacity-40 sm:flex-1 sm:basis-auto"
         />
 
+        <div className="flex items-center gap-1.5 sm:hidden">
+          <button
+            onClick={() => fileInputRef.current?.click()}
+            disabled={!activeChatId}
+            className={cn(
+              "rounded-lg p-1.5 transition-all active:scale-90",
+              attachments.length
+                ? "text-blue-400 hover:bg-foreground/10"
+                : "text-foreground/40 hover:bg-foreground/10 hover:text-foreground/70",
+            )}
+            title="Attach files"
+          >
+            <Paperclip size="1rem" />
+          </button>
+          <QuickSwitcherMobile />
+        </div>
+
+        <div className="ml-auto flex shrink-0 items-center gap-0.5 sm:ml-0">
         {/* Emoji picker */}
         <div className="relative hidden sm:block">
           <button
@@ -1398,6 +1451,7 @@ export const ChatInput = memo(function ChatInput({
             <Send size="0.9375rem" className={cn(hasInput && "translate-x-[1px]")} />
           )}
         </button>
+        </div>
       </div>
 
       {/* Character picker dropdown (portal) */}

--- a/src/features/runtime/tracker/components/FeaturedCharacterFields.tsx
+++ b/src/features/runtime/tracker/components/FeaturedCharacterFields.tsx
@@ -9,7 +9,8 @@ import { InlineEdit, TRACKER_PROFILE_FIELD_TILE_CLASS } from "./tracker-data-sid
 import { StatList as TrackerStatList } from "./tracker-data-sidebar.stats";
 import "./TrackerProfileFields.css";
 
-const FEATURED_FIELD_LIST_CLASS = "relative z-[1] grid h-full min-h-0 grid-cols-1 gap-1 overflow-hidden p-1";
+const FEATURED_FIELD_LIST_CLASS =
+  "tracker-featured-field-list relative z-[1] grid h-full min-h-0 grid-cols-1 gap-1 overflow-hidden p-1";
 const FEATURED_FIELD_ICON_CLASS = "tracker-featured-field-icon";
 type FeaturedFieldTone = "mood" | "appearance" | "outfit";
 const FEATURED_FIELD_ICON_TONE_CLASS = {

--- a/src/features/runtime/tracker/components/FeaturedCharacterTrackerCard.tsx
+++ b/src/features/runtime/tracker/components/FeaturedCharacterTrackerCard.tsx
@@ -52,7 +52,7 @@ const FEATURED_CARD_CLASS = cn(
   "group/character mx-1 hover:border-[var(--primary)]/30",
 );
 const FEATURED_COCKPIT_SHELF_CLASS = cn(
-  "pointer-events-none absolute inset-x-0 top-5 z-0 h-[9rem] overflow-hidden border-b border-[color-mix(in_srgb,var(--tracker-profile-dialogue-border)_42%,transparent)] shadow-[inset_0_9px_16px_color-mix(in_srgb,var(--background)_18%,transparent),inset_0_-10px_18px_color-mix(in_srgb,var(--background)_38%,transparent)] @min-[380px]:h-[10.5rem]",
+  "tracker-profile-cockpit-shelf pointer-events-none absolute inset-x-0 top-5 z-0 h-[9rem] overflow-hidden border-b border-[color-mix(in_srgb,var(--tracker-profile-dialogue-border)_42%,transparent)] shadow-[inset_0_9px_16px_color-mix(in_srgb,var(--background)_18%,transparent),inset_0_-10px_18px_color-mix(in_srgb,var(--background)_38%,transparent)] @min-[380px]:h-[10.5rem]",
   TRACKER_PROFILE_MATERIAL_PANEL_CLASS,
 );
 const FEATURED_REMOVE_BUTTON_CLASS =
@@ -65,7 +65,7 @@ const FEATURED_DETAILS_FIELDS_CLASS = "relative min-h-0 flex-1 overflow-hidden";
 const FEATURED_DOCKED_THOUGHT_CLASS = "mx-0 mb-0.5 mt-0 shrink-0";
 const FEATURED_DOCKED_THOUGHT_SURFACE_CLASS =
   "scrollbar-hide overflow-hidden";
-const FEATURED_STAT_BAND_CLASS = "order-3 col-span-full mt-0 rounded-b-[5px]";
+const FEATURED_STAT_BAND_CLASS = "tracker-featured-stat-band order-3 col-span-full mt-0 rounded-b-[5px]";
 const FEATURED_CUSTOM_FIELD_LIST_CLASS =
   "relative z-[1] mx-1 mb-1 mt-1 grid gap-px border-t border-[var(--tracker-profile-rule)] pt-0.5 text-[0.625rem]";
 const FEATURED_CUSTOM_FIELD_ROW_CLASS =

--- a/src/features/runtime/tracker/components/PersonaTrackerPanel.tsx
+++ b/src/features/runtime/tracker/components/PersonaTrackerPanel.tsx
@@ -57,24 +57,24 @@ import { PersonaPortraitStage } from "./PersonaPortraitStage";
 
 const PERSONA_COCKPIT_SHELF_CLASS =
   cn(
-    "pointer-events-none absolute inset-x-0 top-5 z-0 h-[9rem] overflow-hidden border-b border-[color-mix(in_srgb,var(--tracker-profile-dialogue-border)_46%,transparent)] shadow-[inset_0_10px_18px_color-mix(in_srgb,var(--background)_20%,transparent),inset_0_-12px_22px_color-mix(in_srgb,var(--background)_44%,transparent)] @min-[380px]:h-[10.5rem]",
+    "tracker-profile-cockpit-shelf pointer-events-none absolute inset-x-0 top-5 z-0 h-[9rem] overflow-hidden border-b border-[color-mix(in_srgb,var(--tracker-profile-dialogue-border)_46%,transparent)] shadow-[inset_0_10px_18px_color-mix(in_srgb,var(--background)_20%,transparent),inset_0_-12px_22px_color-mix(in_srgb,var(--background)_44%,transparent)] @min-[380px]:h-[10.5rem]",
     TRACKER_PROFILE_MATERIAL_PANEL_CLASS,
   );
 const PERSONA_STAT_COLUMN_CLASS =
   "relative z-[1] flex min-w-0 flex-col overflow-hidden border-[color-mix(in_srgb,var(--tracker-profile-dialogue-border)_52%,transparent)]";
 const PERSONA_STAT_SHELF_CLASS =
-  "group/statbox relative min-h-0 min-w-0 flex-1 overflow-y-auto px-1.5 py-1.5";
+  "group/statbox tracker-persona-stat-shelf relative min-h-0 min-w-0 flex-1 overflow-y-auto px-1.5 py-1.5";
 const PERSONA_LOWER_DECK_CLASS =
   cn(
-    "relative z-[1] order-3 col-span-2 flex flex-col gap-1 border-t border-[color-mix(in_srgb,var(--tracker-profile-dialogue-border)_50%,transparent)] px-1 py-1",
+    "tracker-profile-lower-deck relative z-[1] order-3 col-span-2 flex flex-col gap-1 border-t border-[color-mix(in_srgb,var(--tracker-profile-dialogue-border)_50%,transparent)] px-1 py-1",
     TRACKER_PROFILE_MATERIAL_PANEL_CLASS,
   );
 const PERSONA_STATUS_STRIP_CLASS =
   cn(TRACKER_PROFILE_STATUS_STRIP_CLASS, "mx-0.5 items-center px-1.5 py-[0.1875rem]");
 const PERSONA_INVENTORY_HEADER_CLASS =
-  "relative mx-0.5 flex min-h-6 items-center gap-1 overflow-hidden px-0.5 text-[0.625rem] leading-3";
+  "tracker-persona-inventory-header relative mx-0.5 flex min-h-6 items-center gap-1 overflow-hidden px-0.5 text-[0.625rem] leading-3";
 const PERSONA_INVENTORY_SHELF_CLASS =
-  cn(TRACKER_PROFILE_EMPTY_SURFACE_CLASS, "min-h-0 flex-1");
+  cn(TRACKER_PROFILE_EMPTY_SURFACE_CLASS, "tracker-persona-inventory-shelf min-h-0 flex-1");
 
 interface PersonaPortraitPendingSave {
   id: string;
@@ -410,7 +410,7 @@ export function PersonaInventoryPanel({
                     onSave={onSaveStatus}
                     placeholder="Status"
                     className={cn(
-                      "relative z-[1] min-h-5 flex-1 rounded-[2px] px-0.5 py-0 text-[0.6875rem] font-medium leading-[0.875rem] text-[color-mix(in_srgb,var(--tracker-profile-text)_86%,var(--primary)_14%)] hover:bg-[var(--accent)]/18",
+                      "tracker-profile-status-edit relative z-[1] min-h-5 flex-1 rounded-[2px] px-0.5 py-0 text-[0.6875rem] font-medium leading-[0.875rem] text-[color-mix(in_srgb,var(--tracker-profile-text)_86%,var(--primary)_14%)] hover:bg-[var(--accent)]/18",
                       trackerPanelSizeProfile === "compact" && "h-5",
                     )}
                     title={`${personaName} status`}

--- a/src/features/runtime/tracker/components/TrackerDataSidebar.tsx
+++ b/src/features/runtime/tracker/components/TrackerDataSidebar.tsx
@@ -6,7 +6,18 @@ import { TrackerSkeleton } from "./TrackerSkeleton";
 import { TrackerSectionList } from "./TrackerSectionList";
 import { TrackerSidebarHeader } from "./TrackerSidebarHeader";
 
-export function TrackerDataSidebar({ fillHeight = false }: { fillHeight?: boolean } = {}) {
+export type TrackerDataSidebarPresentation = "standard" | "mobileDock";
+export type TrackerMobileDockView = "compact" | "expanded";
+
+export function TrackerDataSidebar({
+  fillHeight = false,
+  mobileDockView = "compact",
+  presentation = "standard",
+}: {
+  fillHeight?: boolean;
+  mobileDockView?: TrackerMobileDockView;
+  presentation?: TrackerDataSidebarPresentation;
+} = {}) {
   const [deleteMode, setDeleteMode] = useState(false);
   const [addMode, setAddMode] = useState(false);
   const model = useTrackerPanelModel();
@@ -15,6 +26,8 @@ export function TrackerDataSidebar({ fillHeight = false }: { fillHeight?: boolea
     <section
       data-component="TrackerDataSidebar"
       data-tracker-size-profile={model.trackerPanelSizeProfile}
+      data-tracker-presentation={presentation}
+      data-tracker-mobile-dock-view={presentation === "mobileDock" ? mobileDockView : undefined}
       className={cn(
         "@container relative flex flex-col overflow-hidden bg-[color-mix(in_srgb,var(--background)_8%,transparent)] backdrop-blur-sm",
         fillHeight ? "h-full" : "min-h-0",
@@ -31,11 +44,25 @@ export function TrackerDataSidebar({ fillHeight = false }: { fillHeight?: boolea
         onSetDeleteMode={setDeleteMode}
         onSetSide={model.setTrackerPanelSide}
         onSetSizeProfile={model.setTrackerPanelSizeProfile}
+        presentation={presentation}
         onClose={() => model.setTrackerPanelOpen(false)}
       />
 
-      <div className={cn("relative z-10", fillHeight && "min-h-0 flex-1 overflow-y-auto")}>
-        {model.showTrackerSections ? <TrackerSectionList model={model} deleteMode={deleteMode} addMode={addMode} /> : null}
+      <div
+        className={cn(
+          "relative z-10",
+          fillHeight && "mari-tracker-panel-scroll min-h-0 flex-1 overscroll-contain overflow-y-auto",
+        )}
+      >
+        {model.showTrackerSections ? (
+          <TrackerSectionList
+            model={model}
+            deleteMode={deleteMode}
+            addMode={addMode}
+            mobileDockView={mobileDockView}
+            presentation={presentation}
+          />
+        ) : null}
 
         {!model.activeChatId ? (
           <EmptySection>Select a chat to view tracker data.</EmptySection>

--- a/src/features/runtime/tracker/components/TrackerSectionList.tsx
+++ b/src/features/runtime/tracker/components/TrackerSectionList.tsx
@@ -16,14 +16,21 @@ import { CharacterTrackerPanel } from "./CharacterTrackerPanel";
 import { QuestTrackerPanel } from "./QuestTrackerPanel";
 import { CustomTrackerPanel } from "./CustomTrackerPanel";
 
+type TrackerDataSidebarPresentation = "standard" | "mobileDock";
+type TrackerMobileDockView = "compact" | "expanded";
+
 export function TrackerSectionList({
   addMode,
   deleteMode,
+  mobileDockView = "compact",
   model,
+  presentation = "standard",
 }: {
   addMode: boolean;
   deleteMode: boolean;
+  mobileDockView?: TrackerMobileDockView;
   model: TrackerPanelModel;
+  presentation?: TrackerDataSidebarPresentation;
 }) {
   const {
     activeChatId,
@@ -58,6 +65,12 @@ export function TrackerSectionList({
     trackerTemperatureUnit,
     orderedTrackerSections,
   } = model;
+  const effectiveTrackerPanelSizeProfile =
+    presentation === "mobileDock"
+      ? mobileDockView === "expanded"
+        ? "standard"
+        : "compact"
+      : trackerPanelSizeProfile;
   const { rerunTracker, trackerRetryBusy } = useTrackerRerun({
     activeChatId,
     enabledAgentTypes,
@@ -142,7 +155,7 @@ export function TrackerSectionList({
           <WorldStatePanel
             key="world"
             state={gameState}
-            trackerPanelSizeProfile={trackerPanelSizeProfile}
+            trackerPanelSizeProfile={effectiveTrackerPanelSizeProfile}
             trackerTemperatureUnit={trackerTemperatureUnit}
             action={renderRerunAction("world")}
             onSaveField={patchField}
@@ -162,7 +175,7 @@ export function TrackerSectionList({
                 : undefined
             }
             trackerPanelSide={trackerPanelSide}
-            trackerPanelSizeProfile={trackerPanelSizeProfile}
+            trackerPanelSizeProfile={effectiveTrackerPanelSizeProfile}
             personaStats={personaStats}
             inventory={inventory}
             action={renderRerunAction("persona")}
@@ -191,7 +204,7 @@ export function TrackerSectionList({
             characterProfileColors={characterSpriteLookup.profileColorsById}
             resolveSpriteCharacterId={resolveSpriteCharacterId}
             trackerPanelSide={trackerPanelSide}
-            trackerPanelSizeProfile={trackerPanelSizeProfile}
+            trackerPanelSizeProfile={effectiveTrackerPanelSizeProfile}
             thoughtBubbleDisplay={trackerPanelThoughtBubbleDisplay}
             dockedThoughtsAlwaysVisible={trackerPanelDockedThoughtsAlwaysVisible}
             action={renderCharacterHeaderAction()}

--- a/src/features/runtime/tracker/components/TrackerSidebarHeader.css
+++ b/src/features/runtime/tracker/components/TrackerSidebarHeader.css
@@ -158,3 +158,36 @@
 .tracker-sidebar-header__side-icon--active {
   color: var(--primary);
 }
+
+@media (max-width: 767px), (pointer: coarse) {
+  .tracker-sidebar-header {
+    height: 2.375rem;
+    gap: 0.375rem;
+    padding-right: 0.375rem;
+    padding-left: 0.375rem;
+  }
+
+  .tracker-sidebar-header__control-group {
+    gap: 0.375rem;
+  }
+
+  .tracker-sidebar-header__close,
+  .tracker-sidebar-header__mode-button,
+  .tracker-sidebar-header__size-button {
+    width: 2rem;
+    height: 2rem;
+  }
+
+  .tracker-sidebar-header__side-switch {
+    width: 3.25rem;
+    height: 2rem;
+  }
+
+  .tracker-sidebar-header__side-switch-knob {
+    width: 1.5rem;
+  }
+
+  .tracker-sidebar-header__side-switch-knob--right {
+    transform: translateX(1.5rem);
+  }
+}

--- a/src/features/runtime/tracker/components/TrackerSidebarHeader.tsx
+++ b/src/features/runtime/tracker/components/TrackerSidebarHeader.tsx
@@ -5,6 +5,8 @@ import type { TrackerPanelSide, TrackerPanelSizeProfile } from "../../../../shar
 import { cn } from "../../../../shared/lib/utils";
 import "./TrackerSidebarHeader.css";
 
+type TrackerDataSidebarPresentation = "standard" | "mobileDock";
+
 const TRACKER_PANEL_SIZE_SEQUENCE: TrackerPanelSizeProfile[] = ["compact", "standard", "expanded"];
 const TRACKER_PANEL_SIZE_LABELS: Record<TrackerPanelSizeProfile, string> = {
   compact: "Compact",
@@ -21,6 +23,7 @@ export function TrackerSidebarHeader({
   onSetDeleteMode,
   onSetSide,
   onSetSizeProfile,
+  presentation = "standard",
   onClose,
 }: {
   trackerPanelSide: TrackerPanelSide;
@@ -31,8 +34,10 @@ export function TrackerSidebarHeader({
   onSetDeleteMode: (enabled: boolean) => void;
   onSetSide: (side: TrackerPanelSide) => void;
   onSetSizeProfile: (profile: TrackerPanelSizeProfile) => void;
+  presentation?: TrackerDataSidebarPresentation;
   onClose: () => void;
 }) {
+  const showSizeButton = presentation !== "mobileDock";
   const sizeIndex = Math.max(0, TRACKER_PANEL_SIZE_SEQUENCE.indexOf(sizeProfile));
   const nextSizeProfile = TRACKER_PANEL_SIZE_SEQUENCE[(sizeIndex + 1) % TRACKER_PANEL_SIZE_SEQUENCE.length]!;
   const sizeLabel = TRACKER_PANEL_SIZE_LABELS[sizeProfile];
@@ -93,15 +98,17 @@ export function TrackerSidebarHeader({
       >
         <Trash2 size="0.75rem" />
       </button>
-      <button
-        type="button"
-        onClick={() => onSetSizeProfile(nextSizeProfile)}
-        title={sizeTitle}
-        aria-label={sizeTitle}
-        className="tracker-sidebar-header__size-button"
-      >
-        <TrackerSizeTierIcon sizeProfile={sizeProfile} />
-      </button>
+      {showSizeButton && (
+        <button
+          type="button"
+          onClick={() => onSetSizeProfile(nextSizeProfile)}
+          title={sizeTitle}
+          aria-label={sizeTitle}
+          className="tracker-sidebar-header__size-button"
+        >
+          <TrackerSizeTierIcon sizeProfile={sizeProfile} />
+        </button>
+      )}
       <button
         type="button"
         onClick={() => onSetSide(trackerPanelSide === "left" ? "right" : "left")}
@@ -138,7 +145,7 @@ export function TrackerSidebarHeader({
   );
 
   return (
-    <div className="tracker-sidebar-header">
+    <div className="tracker-sidebar-header" data-tracker-sidebar-presentation={presentation}>
       <div className="tracker-sidebar-header__rule" />
       {trackerPanelSide === "left" ? outerHeaderControls : closePanelButton}
       <div className="min-w-0 flex-1" />

--- a/src/features/runtime/tracker/components/tracker-data-sidebar.constants.ts
+++ b/src/features/runtime/tracker/components/tracker-data-sidebar.constants.ts
@@ -10,9 +10,9 @@ export const TRACKER_PROFILE_PORTRAIT_COLUMN_RIGHT_CLASS =
 export const TRACKER_PROFILE_PORTRAIT_COLUMN_LEFT_CLASS =
   "grid-cols-[clamp(5.25rem,38cqw,6.75rem)_minmax(0,1fr)] @min-[380px]:grid-cols-[9.25rem_minmax(0,1fr)]";
 export const TRACKER_PROFILE_PORTRAIT_FRAME_STAGE_CLASS =
-  "h-[9rem] min-h-[9rem] @min-[380px]:h-[10.5rem] @min-[380px]:min-h-[10.5rem]";
+  "tracker-profile-portrait-frame-stage h-[9rem] min-h-[9rem] @min-[380px]:h-[10.5rem] @min-[380px]:min-h-[10.5rem]";
 export const TRACKER_PROFILE_PORTRAIT_FRAME_STAGE_MAX_CLASS =
-  "h-[9rem] max-h-[9rem] @min-[380px]:h-[10.5rem] @min-[380px]:max-h-[10.5rem]";
+  "tracker-profile-portrait-frame-stage tracker-profile-portrait-frame-stage--max h-[9rem] max-h-[9rem] @min-[380px]:h-[10.5rem] @min-[380px]:max-h-[10.5rem]";
 export const TRACKER_PROFILE_PORTRAIT_MEDIA_STAGE_REM = 7.75;
 export const TRACKER_PROFILE_PORTRAIT_ROOMY_MEDIA_STAGE_REM = 9.25;
 

--- a/src/features/runtime/tracker/components/tracker-data-sidebar.controls.tsx
+++ b/src/features/runtime/tracker/components/tracker-data-sidebar.controls.tsx
@@ -463,6 +463,7 @@ export function SectionHeader({
 
   return (
     <div
+      data-tracker-section-header
       role={collapsible ? "button" : undefined}
       tabIndex={collapsible ? 0 : undefined}
       aria-expanded={collapsible ? !collapsed : undefined}
@@ -494,6 +495,7 @@ export function SectionHeader({
         {icon}
       </span>
       <span
+        data-tracker-section-title
         className={cn(
           "min-w-0 flex-1 truncate font-semibold uppercase tracking-[0.08em] text-[var(--foreground)]/62",
           TRACKER_TEXT_MICRO,
@@ -502,7 +504,11 @@ export function SectionHeader({
         {title}
       </span>
       {(badge !== undefined && badge !== null) || action || addAction ? (
-        <div className="ml-0.5 flex shrink-0 items-center gap-0.5" onClick={(event) => event.stopPropagation()}>
+        <div
+          data-tracker-section-actions
+          className="ml-0.5 flex shrink-0 items-center gap-0.5"
+          onClick={(event) => event.stopPropagation()}
+        >
           {badge !== undefined && badge !== null && (
             <span
               className="shrink-0 rounded-sm border border-[var(--border)]/26 bg-[var(--background)]/16 px-1 py-0.5 text-[0.5625rem] font-semibold uppercase leading-none tabular-nums text-[var(--foreground)]/62"

--- a/src/features/runtime/tracker/lib/tracker-profile-layout.ts
+++ b/src/features/runtime/tracker/lib/tracker-profile-layout.ts
@@ -6,11 +6,11 @@ import {
 
 export type TrackerProfileSide = "left" | "right";
 
-export const TRACKER_PROFILE_GRID_CLASS = "relative z-[1] grid gap-y-0 gap-x-0";
+export const TRACKER_PROFILE_GRID_CLASS = "tracker-profile-grid relative z-[1] grid gap-y-0 gap-x-0";
 
 export const TRACKER_PROFILE_GRID_CLASS_BY_PORTRAIT_SIDE = {
-  left: TRACKER_PROFILE_PORTRAIT_COLUMN_LEFT_CLASS,
-  right: TRACKER_PROFILE_PORTRAIT_COLUMN_RIGHT_CLASS,
+  left: `tracker-profile-grid--portrait-left ${TRACKER_PROFILE_PORTRAIT_COLUMN_LEFT_CLASS}`,
+  right: `tracker-profile-grid--portrait-right ${TRACKER_PROFILE_PORTRAIT_COLUMN_RIGHT_CLASS}`,
 } satisfies Record<TrackerProfileSide, string>;
 
 export const TRACKER_PROFILE_ORDER_CLASS_BY_SIDE = {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1250,6 +1250,484 @@ summary[class*="cursor-pointer"],
   background-clip: padding-box;
 }
 
+.mari-tracker-panel-mobile {
+  --tracker-mobile-collapsed-width: 1.375rem;
+  --tracker-mobile-compact-width: clamp(8.75rem, 38vw, 15rem);
+  --tracker-mobile-expanded-width: clamp(13.5rem, 58vw, 18rem);
+  --tracker-mobile-dock-base-width: var(--tracker-mobile-compact-width);
+  --mobile-tracker-drag-offset: 0px;
+  --tracker-mobile-profile-stage: clamp(5.85rem, 25vw, 6.7rem);
+  --tracker-mobile-profile-portrait-column: clamp(4.15rem, 16.5vw, 4.7rem);
+
+  width: max(
+    var(--tracker-mobile-collapsed-width),
+    calc(var(--tracker-mobile-dock-base-width) + var(--mobile-tracker-drag-offset))
+  );
+  border-color: color-mix(in srgb, var(--border) 48%, transparent);
+  background: color-mix(in srgb, var(--background) 94%, var(--card) 6%);
+  box-shadow:
+    0 1rem 2rem rgb(0 0 0 / 30%),
+    inset 0 1px 0 color-mix(in srgb, var(--foreground) 8%, transparent);
+  touch-action: pan-y;
+  transition:
+    width 180ms cubic-bezier(0.16, 1, 0.3, 1),
+    border-color 180ms ease,
+    background-color 180ms ease;
+}
+
+[data-theme="light"] .mari-tracker-panel-mobile {
+  background: color-mix(in srgb, var(--background) 96%, var(--card) 4%);
+}
+
+.mari-tracker-panel-mobile[data-mobile-tracker-dragging="true"] {
+  transition: none;
+}
+
+.mari-tracker-panel-mobile[data-mobile-tracker-view="collapsed"] {
+  --tracker-mobile-dock-base-width: var(--tracker-mobile-collapsed-width);
+
+  border-color: color-mix(in srgb, var(--primary) 34%, var(--border) 66%);
+  background:
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--primary) 12%, transparent),
+      color-mix(in srgb, var(--background) 88%, var(--card) 12%)
+    );
+}
+
+.mari-tracker-panel-mobile[data-mobile-tracker-view="expanded"] {
+  --tracker-mobile-dock-base-width: var(--tracker-mobile-expanded-width);
+  --tracker-mobile-profile-stage: clamp(6.75rem, 30vw, 8rem);
+  --tracker-mobile-profile-portrait-column: clamp(5rem, 23vw, 6.5rem);
+}
+
+@media (max-width: 380px) {
+  .mari-tracker-panel-mobile {
+    --tracker-mobile-compact-width: clamp(8.5rem, 40vw, 14.5rem);
+    --tracker-mobile-expanded-width: clamp(12.5rem, 58vw, 17rem);
+  }
+}
+
+.mari-tracker-panel-mobile-content {
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+}
+
+.mari-tracker-panel-mobile-grip {
+  position: absolute;
+  top: 2.35rem;
+  bottom: 0.55rem;
+  z-index: 40;
+  display: flex;
+  width: 0.875rem;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid color-mix(in srgb, var(--primary) 24%, transparent);
+  background:
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--background) 84%, transparent),
+      color-mix(in srgb, var(--primary) 10%, transparent)
+    );
+  color: color-mix(in srgb, var(--primary) 74%, var(--foreground) 26%);
+  opacity: 0.7;
+  touch-action: none;
+  transition:
+    opacity 160ms ease,
+    border-color 160ms ease,
+    background-color 160ms ease;
+}
+
+.mari-tracker-panel-mobile-grip:hover,
+.mari-tracker-panel-mobile-grip:focus-visible {
+  border-color: color-mix(in srgb, var(--primary) 48%, transparent);
+  opacity: 1;
+  outline: none;
+}
+
+.mari-tracker-panel-mobile[data-mobile-tracker-side="left"] .mari-tracker-panel-mobile-grip {
+  right: 0;
+  border-top-left-radius: 999px;
+  border-bottom-left-radius: 999px;
+  border-right: 0;
+}
+
+.mari-tracker-panel-mobile[data-mobile-tracker-side="right"] .mari-tracker-panel-mobile-grip {
+  left: 0;
+  border-top-right-radius: 999px;
+  border-bottom-right-radius: 999px;
+  border-left: 0;
+}
+
+.mari-tracker-panel-mobile[data-mobile-tracker-view="collapsed"] .mari-tracker-panel-mobile-grip {
+  inset: 0;
+  width: 100%;
+  border: 0;
+  border-radius: 0;
+  background:
+    radial-gradient(circle at 50% 20%, color-mix(in srgb, var(--primary) 28%, transparent), transparent 44%),
+    color-mix(in srgb, var(--background) 82%, var(--card) 18%);
+  opacity: 1;
+}
+
+.mari-tracker-panel-mobile-grip__mark {
+  position: relative;
+  display: block;
+  width: 0.125rem;
+  height: 2.7rem;
+  border-radius: 999px;
+  background: currentcolor;
+  box-shadow:
+    0 -0.55rem 0 color-mix(in srgb, currentColor 54%, transparent),
+    0 0.55rem 0 color-mix(in srgb, currentColor 54%, transparent);
+  opacity: 0.8;
+}
+
+.mari-tracker-panel-mobile [data-component="TrackerDataSidebar"] {
+  background: color-mix(in srgb, var(--background) 12%, transparent);
+  -webkit-backdrop-filter: none;
+  backdrop-filter: none;
+}
+
+.mari-tracker-panel-mobile .tracker-sidebar-header {
+  height: 2rem;
+  gap: 0.25rem;
+  background: color-mix(in srgb, var(--background) 82%, var(--card) 18%);
+  padding-right: 0.25rem;
+  padding-left: 0.25rem;
+  box-shadow:
+    0 1px 0 color-mix(in srgb, var(--border) 40%, transparent),
+    0 6px 10px color-mix(in srgb, var(--background) 26%, transparent);
+}
+
+.mari-tracker-panel-mobile .tracker-sidebar-header__control-group {
+  gap: 0.25rem;
+}
+
+.mari-tracker-panel-mobile .tracker-sidebar-header__close,
+.mari-tracker-panel-mobile .tracker-sidebar-header__mode-button {
+  width: 1.625rem;
+  height: 1.625rem;
+  border-radius: 0.3125rem;
+}
+
+.mari-tracker-panel-mobile .tracker-sidebar-header__side-switch {
+  width: 2.75rem;
+  height: 1.625rem;
+}
+
+.mari-tracker-panel-mobile .tracker-sidebar-header__side-switch-knob {
+  width: 1.175rem;
+}
+
+.mari-tracker-panel-mobile .tracker-sidebar-header__side-switch-knob--right {
+  transform: translateX(1.325rem);
+}
+
+.mari-tracker-panel-mobile [data-tracker-section-header] {
+  min-height: 1.625rem;
+  gap: 0.25rem;
+  padding: 0.1875rem 0.375rem;
+  background: color-mix(in srgb, var(--background) 48%, transparent);
+}
+
+.mari-tracker-panel-mobile [data-tracker-section-title] {
+  font-size: 0.5625rem;
+  line-height: 0.65rem;
+  letter-spacing: 0.055em;
+  opacity: 0.72;
+}
+
+.mari-tracker-panel-mobile [data-tracker-section-actions] {
+  gap: 0.25rem;
+}
+
+.mari-tracker-panel-mobile .tracker-world-tile-shell {
+  min-height: 2.55rem;
+  border-radius: 0.25rem;
+}
+
+.mari-tracker-panel-mobile .tracker-world-edit-hint {
+  opacity: 0;
+}
+
+.mari-tracker-panel-mobile .tracker-profile-card-frame,
+.mari-tracker-panel-mobile .tracker-profile-card-surface,
+.mari-tracker-panel-mobile .tracker-compact-character-card {
+  border-radius: 0.3125rem;
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, var(--foreground) 5%, transparent),
+    inset 0 -1px 0 color-mix(in srgb, var(--background) 26%, transparent);
+}
+
+.mari-tracker-panel-mobile .tracker-profile-grid--portrait-right {
+  grid-template-columns: minmax(0, 1fr) minmax(4.25rem, var(--tracker-mobile-profile-portrait-column)) !important;
+}
+
+.mari-tracker-panel-mobile .tracker-profile-grid--portrait-left {
+  grid-template-columns: minmax(4.25rem, var(--tracker-mobile-profile-portrait-column)) minmax(0, 1fr) !important;
+}
+
+.mari-tracker-panel-mobile .tracker-profile-portrait-frame-stage {
+  height: var(--tracker-mobile-profile-stage) !important;
+  min-height: var(--tracker-mobile-profile-stage) !important;
+}
+
+.mari-tracker-panel-mobile .tracker-profile-portrait-frame-stage--max {
+  max-height: var(--tracker-mobile-profile-stage) !important;
+}
+
+.mari-tracker-panel-mobile .tracker-profile-cockpit-shelf {
+  top: 1.25rem !important;
+  height: var(--tracker-mobile-profile-stage) !important;
+}
+
+.mari-tracker-panel-mobile .tracker-profile-nameplate {
+  height: 1.25rem;
+  min-height: 1.25rem;
+  border-top-left-radius: 0.3125rem;
+  border-top-right-radius: 0.3125rem;
+}
+
+.mari-tracker-panel-mobile .tracker-profile-nameplate-edit,
+.mari-tracker-panel-mobile .tracker-profile-nameplate-preview {
+  font-size: 0.6875rem;
+  line-height: 1.25rem;
+}
+
+.mari-tracker-panel-mobile .tracker-profile-nameplate-clasp {
+  transform: scale(0.86);
+  transform-origin: center;
+}
+
+.mari-tracker-panel-mobile .tracker-profile-lower-deck,
+.mari-tracker-panel-mobile .tracker-featured-stat-band {
+  gap: 0.25rem;
+  padding: 0.3125rem !important;
+}
+
+.mari-tracker-panel-mobile .tracker-profile-status-strip {
+  margin-right: 0 !important;
+  margin-left: 0 !important;
+  gap: 0.25rem;
+  border-radius: 0.25rem;
+  padding: 0.1875rem 0.375rem !important;
+  font-size: 0.625rem;
+  line-height: 0.75rem;
+}
+
+.mari-tracker-panel-mobile .tracker-profile-status-strip > svg {
+  width: 0.75rem;
+  height: 0.75rem;
+  margin-top: 0 !important;
+}
+
+.mari-tracker-panel-mobile .tracker-profile-status-edit {
+  min-height: 1.125rem !important;
+  font-size: 0.625rem;
+  line-height: 0.75rem;
+}
+
+.mari-tracker-panel-mobile .tracker-persona-stat-shelf {
+  padding: 0.375rem !important;
+}
+
+.mari-tracker-panel-mobile .tracker-persona-inventory-header {
+  min-height: 1.125rem;
+  margin-right: 0;
+  margin-left: 0;
+  font-size: 0.5625rem;
+  line-height: 0.75rem;
+}
+
+.mari-tracker-panel-mobile .tracker-persona-inventory-shelf {
+  border-radius: 0.25rem;
+  font-size: 0.5625rem;
+  line-height: 0.75rem;
+}
+
+.mari-tracker-panel-mobile .tracker-featured-field-list {
+  gap: 0.1875rem;
+  padding: 0.25rem;
+}
+
+.mari-tracker-panel-mobile .tracker-featured-field-list .tracker-profile-field-tile {
+  min-height: 1.45rem;
+  align-items: center;
+}
+
+.mari-tracker-panel-mobile .tracker-profile-field-tile {
+  grid-template-columns: 0.875rem minmax(0, 1fr);
+  gap: 0.1875rem;
+  padding: 0.1875rem;
+}
+
+.mari-tracker-panel-mobile .tracker-featured-field-icon {
+  width: 0.875rem;
+  height: 0.875rem;
+}
+
+.mari-tracker-panel-mobile .tracker-featured-field-list .line-clamp-2,
+.mari-tracker-panel-mobile .tracker-featured-field-list .line-clamp-3,
+.mari-tracker-panel-mobile .tracker-featured-field-list .line-clamp-4 {
+  display: block;
+  overflow: hidden;
+  line-height: 0.75rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  -webkit-box-orient: initial;
+  -webkit-line-clamp: unset;
+}
+
+.mari-tracker-panel-mobile[data-mobile-tracker-view="expanded"] .tracker-profile-status-strip {
+  padding: 0.25rem 0.5rem !important;
+  font-size: 0.6875rem;
+  line-height: 0.875rem;
+}
+
+.mari-tracker-panel-mobile[data-mobile-tracker-view="expanded"] .tracker-profile-status-edit {
+  min-height: 1.55rem !important;
+  font-size: 0.6875rem;
+  line-height: 0.875rem;
+}
+
+.mari-tracker-panel-mobile[data-mobile-tracker-view="expanded"] .tracker-featured-field-list {
+  gap: 0.3125rem;
+  padding: 0.375rem;
+}
+
+.mari-tracker-panel-mobile[data-mobile-tracker-view="expanded"] .tracker-featured-field-list .line-clamp-2,
+.mari-tracker-panel-mobile[data-mobile-tracker-view="expanded"] .tracker-featured-field-list .line-clamp-3,
+.mari-tracker-panel-mobile[data-mobile-tracker-view="expanded"] .tracker-featured-field-list .line-clamp-4 {
+  display: -webkit-box;
+  overflow: hidden;
+  line-height: 1.15;
+  white-space: normal;
+  -webkit-box-orient: vertical;
+}
+
+.mari-tracker-panel-mobile[data-mobile-tracker-view="expanded"] .tracker-featured-field-list .line-clamp-2 {
+  -webkit-line-clamp: 2;
+}
+
+.mari-tracker-panel-mobile[data-mobile-tracker-view="expanded"] .tracker-featured-field-list .line-clamp-3 {
+  -webkit-line-clamp: 3;
+}
+
+.mari-tracker-panel-mobile[data-mobile-tracker-view="expanded"] .tracker-featured-field-list .line-clamp-4 {
+  -webkit-line-clamp: 4;
+}
+
+.mari-tracker-panel-mobile .tracker-profile-empty-surface {
+  font-size: 0.625rem;
+  line-height: 0.8rem;
+}
+
+.mari-tracker-panel-mobile .tracker-portrait-view-controls,
+.mari-tracker-panel-mobile .tracker-portrait-upload-button {
+  opacity: 0.78;
+}
+
+.mari-tracker-panel-mobile .tracker-portrait-view-controls {
+  bottom: 0.1875rem;
+  left: 0.1875rem;
+  gap: 0.0625rem;
+  padding: 0.0625rem;
+}
+
+.mari-tracker-panel-mobile .tracker-portrait-view-button {
+  width: 1rem;
+  height: 1rem;
+}
+
+.mari-tracker-panel-mobile .tracker-portrait-upload-button {
+  right: 0.1875rem;
+  bottom: 0.1875rem;
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+[data-mobile-tracker-docked] {
+  --mobile-docked-composer-height: calc(5.75rem + env(safe-area-inset-bottom));
+  --mobile-docked-composer-clearance: calc(
+    var(--mobile-docked-composer-height) - env(safe-area-inset-bottom) + 0.25rem
+  );
+}
+
+[data-mobile-tracker-docked] .mari-tracker-panel-mobile {
+  margin-bottom: var(--mobile-docked-composer-clearance);
+}
+
+[data-mobile-tracker-docked] .rpg-chat-messages-mobile {
+  height: calc(100% - var(--mobile-docked-composer-clearance));
+  padding-right: 0.25rem !important;
+  padding-left: 0.25rem !important;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem !important;
+  scroll-padding-bottom: 0.5rem;
+}
+
+[data-mobile-tracker-docked] .mari-message {
+  --roleplay-avatar-scale: 0.62 !important;
+  gap: 0.35rem;
+  margin-bottom: 0.75rem;
+  padding-right: 0;
+  padding-left: 0;
+}
+
+[data-mobile-tracker-view="collapsed"] .rpg-chat-messages-mobile {
+  padding-right: 0.5rem !important;
+  padding-left: 0.5rem !important;
+}
+
+[data-mobile-tracker-view="collapsed"] .mari-message {
+  --roleplay-avatar-scale: 0.72 !important;
+  gap: 0.5rem;
+}
+
+[data-mobile-tracker-docked] .mari-message-body {
+  width: 100%;
+  max-width: 100% !important;
+}
+
+[data-mobile-tracker-docked] .mari-message-bubble > .px-4 {
+  padding: 0.7rem 0.85rem;
+}
+
+[data-mobile-tracker-docked] .mari-message-bubble .min-w-0.flex-1 {
+  padding-right: 0.625rem !important;
+  padding-left: 0.625rem !important;
+}
+
+[data-mobile-tracker-docked] .chat-input-container {
+  position: fixed;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 45;
+  width: 100vw;
+  padding: 0.25rem 0.5rem calc(0.25rem + env(safe-area-inset-bottom)) !important;
+  background:
+    linear-gradient(180deg, transparent 0%, color-mix(in srgb, var(--background) 76%, transparent) 30%),
+    color-mix(in srgb, var(--background) 82%, transparent);
+  -webkit-backdrop-filter: blur(10px);
+  backdrop-filter: blur(10px);
+}
+
+[data-mobile-tracker-docked] .chat-input-container .mari-chat-input-box {
+  row-gap: 0.35rem;
+  padding: 0.5rem 0.625rem !important;
+}
+
+[data-mobile-tracker-docked] .chat-input-container .mari-chat-input-textarea {
+  max-height: 3.5rem !important;
+}
+
+[data-mobile-tracker-docked] .chat-input-container .rounded-2xl {
+  border-radius: 1.375rem;
+}
+
 /* ─────────────────────────────────────────────
    8. GLASS / FROSTED PANELS
    ───────────────────────────────────────────── */


### PR DESCRIPTION
## Summary
- Reworks the Roleplay mobile Tracker panel from a modal overlay into a split dock beside the chat.
- Adds collapsed, compact, and expanded mobile dock states with swipe/tap/keyboard controls on the tracker grip.
- Lets the Roleplay composer span the full bottom width while reserving message-list clearance so input cannot overlap chat content.
- Tunes compact/expanded Tracker presentation for mobile density, including profile card sizing, header controls, section spacing, and collapsed chat breathing room.

Refs #1195. This PR is the first implementation slice; the issue remains open for follow-up validation and polish.

## Impact / Areas Reviewed
- Roleplay mobile shell layout and panel inert/focus behavior.
- Shared chat input mobile wrapping and fixed composer clearance.
- Tracker runtime sidebar/header/section presentation only.
- No engine, storage, provider, prompt, generation, Tauri, or Rust behavior changed.

## Verification
- `pnpm build`
- `pnpm check:architecture`
- `git diff --check origin/refactor...HEAD`
- Pixel/WebView manual pass using the already-running Android app:
  - compact dock rendered beside chat
  - swipe inward collapsed to rail
  - tap rail restored compact
  - swipe outward expanded inspect view
  - composer/message overlap measured at `0px` in tested states

## Changelog
Relevant user-facing UI change, but this branch has no `CHANGELOG.md`; no changelog entry added.

## Remaining Risk
- Light theme not separately verified.
- Right-side docking behavior still needs a focused manual pass.
- Smaller/narrower Android viewports still need tuning proof.
- Gesture discoverability may need another UX pass after real use.