### PR TITLE
Avoid duplicate chat message loads in startGeneration

### DIFF
--- a/src/engine/generation/start-generation.test.ts
+++ b/src/engine/generation/start-generation.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import type { LlmGateway } from "../capabilities/llm";
 import type { StorageGateway } from "../capabilities/storage";
 import { retryGenerationAgents, startGeneration, type GenerationEngineDeps } from "./start-generation";
 
@@ -17,6 +18,67 @@ function depsForChat(chat: Record<string, unknown>) {
     integrations: {} as GenerationEngineDeps["integrations"],
   };
   return { deps, get, createChatMessage };
+}
+
+function generationDepsForChat(options: {
+  savedUserMessage?: unknown;
+  messagesAfterSave?: Record<string, unknown>[];
+} = {}) {
+  const chat = {
+    id: "chat-1",
+    mode: "conversation",
+    connectionId: "connection-1",
+    characterIds: [],
+    metadata: {},
+  };
+  const connection = {
+    id: "connection-1",
+    model: "test-model",
+    defaultParameters: {},
+  };
+  const initialMessages = [{ id: "assistant-1", chatId: "chat-1", role: "assistant", content: "What now?" }];
+  const listChatMessages = vi.fn(async () =>
+    listChatMessages.mock.calls.length > 1 && options.messagesAfterSave
+      ? options.messagesAfterSave
+      : initialMessages,
+  );
+  const streamedRequests: unknown[] = [];
+  const stream: LlmGateway["stream"] = vi.fn(async function* (request) {
+    streamedRequests.push(request);
+    yield { type: "token" as const, text: "Done." };
+  });
+  const createChatMessage = vi.fn(async (_chatId: string, value: Record<string, unknown>) => {
+    if (value.role === "user") {
+      return options.savedUserMessage ?? { id: "user-1", chatId: "chat-1", ...value };
+    }
+    return { id: "assistant-2", chatId: "chat-1", ...value };
+  });
+  const storage = {
+    get: vi.fn(async (entity: string, id: string) => {
+      if (entity === "chats" && id === "chat-1") return chat;
+      if (entity === "connections" && id === "connection-1") return connection;
+      return null;
+    }),
+    list: vi.fn(async () => []),
+    create: vi.fn(async (_entity: string, value: Record<string, unknown>) => value),
+    createChatMessage,
+    listChatMessages,
+    listChatMemories: vi.fn(async () => []),
+    listLorebookEntries: vi.fn(async () => []),
+    saveTrackerSnapshot: vi.fn(async (_chatId: string, snapshot: Record<string, unknown>) => snapshot),
+  } as Partial<StorageGateway> as StorageGateway;
+  const deps: GenerationEngineDeps = {
+    storage,
+    llm: { stream } as Partial<LlmGateway> as LlmGateway,
+    integrations: {} as GenerationEngineDeps["integrations"],
+  };
+  return { deps, listChatMessages, streamedRequests };
+}
+
+async function drainGeneration(stream: AsyncGenerator<unknown>) {
+  for await (const _event of stream) {
+    // Exhaust the generator so storage and LLM calls finish.
+  }
 }
 
 describe("startGeneration concluded roleplay guard", () => {
@@ -57,5 +119,73 @@ describe("startGeneration concluded roleplay guard", () => {
       value: { type: "phase", data: "Saving message..." },
     });
     await stream.return(undefined);
+  });
+});
+
+describe("startGeneration chat message loading", () => {
+  it("reuses the pre-commit messages and appends the saved user message for normal sends", async () => {
+    const { deps, listChatMessages, streamedRequests } = generationDepsForChat();
+
+    await drainGeneration(
+      startGeneration(deps, {
+        chatId: "chat-1",
+        userMessage: "hello",
+        impersonateBlockAgents: true,
+      }),
+    );
+
+    expect(listChatMessages).toHaveBeenCalledTimes(1);
+    expect(streamedRequests).toHaveLength(1);
+    expect(streamedRequests[0]).toMatchObject({
+      messages: expect.arrayContaining([expect.objectContaining({ role: "user", content: "hello" })]),
+    });
+  });
+
+  it("reloads messages after saving when the storage adapter does not return a saved message record", async () => {
+    const { deps, listChatMessages, streamedRequests } = generationDepsForChat({
+      savedUserMessage: "user-1",
+      messagesAfterSave: [
+        { id: "assistant-1", chatId: "chat-1", role: "assistant", content: "What now?" },
+        { id: "user-1", chatId: "chat-1", role: "user", content: "hello" },
+      ],
+    });
+
+    await drainGeneration(
+      startGeneration(deps, {
+        chatId: "chat-1",
+        userMessage: "hello",
+        impersonateBlockAgents: true,
+      }),
+    );
+
+    expect(listChatMessages).toHaveBeenCalledTimes(2);
+    expect(streamedRequests).toHaveLength(1);
+    expect(streamedRequests[0]).toMatchObject({
+      messages: expect.arrayContaining([expect.objectContaining({ role: "user", content: "hello" })]),
+    });
+  });
+
+  it("reloads messages after saving when the saved message record is incomplete", async () => {
+    const { deps, listChatMessages, streamedRequests } = generationDepsForChat({
+      savedUserMessage: { id: "user-1" },
+      messagesAfterSave: [
+        { id: "assistant-1", chatId: "chat-1", role: "assistant", content: "What now?" },
+        { id: "user-1", chatId: "chat-1", role: "user", content: "hello" },
+      ],
+    });
+
+    await drainGeneration(
+      startGeneration(deps, {
+        chatId: "chat-1",
+        userMessage: "hello",
+        impersonateBlockAgents: true,
+      }),
+    );
+
+    expect(listChatMessages).toHaveBeenCalledTimes(2);
+    expect(streamedRequests).toHaveLength(1);
+    expect(streamedRequests[0]).toMatchObject({
+      messages: expect.arrayContaining([expect.objectContaining({ role: "user", content: "hello" })]),
+    });
   });
 });

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -150,6 +150,15 @@ async function saveUserMessage(
   });
 }
 
+function savedUserMessageForTimeline(saved: unknown, chatId: string): JsonRecord | null {
+  if (!isRecord(saved)) return null;
+  if (!readString(saved.id).trim()) return null;
+  if (readString(saved.chatId).trim() !== chatId) return null;
+  if (readString(saved.role).trim() !== "user") return null;
+  if (!readString(saved.content).trim()) return null;
+  return saved;
+}
+
 function requestMessages(input: StartGenerationInput): LlmMessage[] | null {
   if (!Array.isArray(input.messages) || input.messages.length === 0) return null;
   return input.messages
@@ -501,13 +510,23 @@ export async function* startGeneration(
 
   yield { type: "phase", data: "Saving message..." };
   const preparedUserInput = await prepareUserInput(deps.storage, input);
-  if (shouldSaveUserMessage(input, preparedUserInput)) {
-    await commitVisibleTrackerSnapshotSafely(deps.storage, chatId, await loadChatMessages(deps.storage, chatId));
+  const savesUserMessage = shouldSaveUserMessage(input, preparedUserInput);
+  let storedMessages: JsonRecord[] | null = null;
+  if (savesUserMessage) {
+    storedMessages = await loadChatMessages(deps.storage, chatId);
+    await commitVisibleTrackerSnapshotSafely(deps.storage, chatId, storedMessages);
   }
   const savedUserMessage = await saveUserMessage(deps.storage, input, preparedUserInput);
   if (savedUserMessage) yield { type: "user_message", data: savedUserMessage };
   const connection = await resolveGenerationConnection(deps.storage, chat, input);
-  const storedMessages = await loadChatMessages(deps.storage, chatId);
+  if (savesUserMessage) {
+    const savedTimelineMessage = savedUserMessageForTimeline(savedUserMessage, chatId);
+    storedMessages = savedTimelineMessage
+      ? [...(storedMessages ?? []), savedTimelineMessage]
+      : await loadChatMessages(deps.storage, chatId);
+  } else {
+    storedMessages = await loadChatMessages(deps.storage, chatId);
+  }
   const generationMessages = messagesBeforeRegenerationTarget(storedMessages, input.regenerateMessageId);
   const generationTrackerBaseline = await selectGenerationTrackerBaseline(
     deps.storage,


### PR DESCRIPTION
## Summary

- Reuse the pre-commit chat message list in `startGeneration` after a normal user-message save by appending the returned saved message record.
- Reload messages instead when the storage adapter returns a non-record or incomplete saved-message shape.
- Add focused generation tests for reuse, non-record fallback, and incomplete-record fallback.

Fixes #1189

## Impact

- Owner: TypeScript engine generation lifecycle.
- Affected paths: shared generation startup for conversation, roleplay, game, and background/autonomous generation.
- No React, shared API, Rust, native, or storage command changes.

## Verification

- `pnpm test src/engine/generation/start-generation.test.ts`
- `pnpm typecheck`
- `pnpm check:architecture`

## Changelog

Not updated. This repo currently has no `CHANGELOG.md`, and the change is an internal generation-path cleanup with no user-facing behavior change.

## Remaining Risk

The optimized path still assumes no out-of-band same-chat message is inserted between the pre-save load and the saved user message append. Existing UI/background callers mostly gate generation per chat, and malformed saved-message returns still reload, so this is treated as low residual risk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced message persistence validation with automatic fallback to reload messages when saved records are incomplete or missing.

* **Tests**
  * Added test suite covering message-loading scenarios including successful message reuse, incomplete record handling, and missing record fallback cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1197?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->