### PR TITLE
Fix scene memory cleanup on chat delete

### DIFF
--- a/src-tauri/src/commands/storage/chats.rs
+++ b/src-tauri/src/commands/storage/chats.rs
@@ -586,13 +586,30 @@ pub(crate) fn delete_chat_with_messages(state: &AppState, chat_id: &str) -> AppR
             "Built-in Professor Mari cannot be deleted",
         ));
     }
-    game_state_snapshots::delete_tracker_snapshots_for_chat(state, chat_id)?;
-    for message in messages_for_chat(state, chat_id)? {
-        if let Some(id) = message.get("id").and_then(Value::as_str) {
-            state.storage.delete("messages", id)?;
+    let Some(root_chat) = state.storage.get("chats", chat_id)? else {
+        return Ok(());
+    };
+    let (scene_memory_ids, owned_scene_chat_ids) = scene_delete_scope(state, chat_id, &root_chat)?;
+    clear_character_scene_memories(state, &scene_memory_ids)?;
+    clear_deleted_scene_references(state, chat_id, &scene_memory_ids)?;
+
+    let mut delete_ids = owned_scene_chat_ids
+        .iter()
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    delete_ids.push(chat_id);
+    delete_ids.sort_unstable();
+    delete_ids.dedup();
+
+    for delete_id in delete_ids {
+        game_state_snapshots::delete_tracker_snapshots_for_chat(state, delete_id)?;
+        for message in messages_for_chat(state, delete_id)? {
+            if let Some(id) = message.get("id").and_then(Value::as_str) {
+                state.storage.delete("messages", id)?;
+            }
         }
+        state.storage.delete("chats", delete_id)?;
     }
-    state.storage.delete("chats", chat_id)?;
     Ok(())
 }
 
@@ -604,4 +621,353 @@ fn chat_game_state_is_bootstrap(chat: &Value) -> bool {
         .map(str::trim)
         .unwrap_or_default()
         .is_empty()
+}
+
+fn scene_delete_scope(
+    state: &AppState,
+    chat_id: &str,
+    root_chat: &Value,
+) -> AppResult<(Vec<String>, Vec<String>)> {
+    let mut memory_ids = std::collections::BTreeSet::new();
+    let mut delete_ids = std::collections::BTreeSet::new();
+
+    let meta = metadata_map(root_chat);
+    if meta
+        .get("sceneOriginChatId")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .is_some_and(|origin_id| !origin_id.is_empty())
+    {
+        memory_ids.insert(chat_id.to_string());
+        delete_ids.insert(chat_id.to_string());
+    }
+    insert_scene_memory_id(&mut memory_ids, meta.get("activeSceneChatId"));
+    insert_owned_scene_chat_id(
+        state,
+        &mut delete_ids,
+        chat_id,
+        meta.get("activeSceneChatId"),
+    )?;
+    if let Some(history) = meta.get("roleplaySceneHistory").and_then(Value::as_array) {
+        for entry in history {
+            insert_scene_memory_id(&mut memory_ids, entry.get("sceneChatId"));
+            insert_owned_scene_chat_id(state, &mut delete_ids, chat_id, entry.get("sceneChatId"))?;
+        }
+    }
+
+    for chat in state.storage.list("chats")? {
+        let meta = metadata_map(&chat);
+        if meta
+            .get("sceneOriginChatId")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            == Some(chat_id)
+        {
+            if let Some(id) = chat.get("id").and_then(Value::as_str) {
+                memory_ids.insert(id.to_string());
+                delete_ids.insert(id.to_string());
+            }
+        }
+    }
+
+    Ok((
+        memory_ids.into_iter().collect(),
+        delete_ids.into_iter().collect(),
+    ))
+}
+
+fn insert_scene_memory_id(ids: &mut std::collections::BTreeSet<String>, value: Option<&Value>) {
+    if let Some(id) = value
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+    {
+        ids.insert(id.to_string());
+    }
+}
+
+fn insert_owned_scene_chat_id(
+    state: &AppState,
+    ids: &mut std::collections::BTreeSet<String>,
+    origin_chat_id: &str,
+    value: Option<&Value>,
+) -> AppResult<()> {
+    let Some(id) = value
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+    else {
+        return Ok(());
+    };
+    let Some(chat) = state.storage.get("chats", id)? else {
+        return Ok(());
+    };
+    let meta = metadata_map(&chat);
+    if meta
+        .get("sceneOriginChatId")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        == Some(origin_chat_id)
+    {
+        ids.insert(id.to_string());
+    }
+    Ok(())
+}
+
+fn clear_character_scene_memories(state: &AppState, scene_chat_ids: &[String]) -> AppResult<()> {
+    if scene_chat_ids.is_empty() {
+        return Ok(());
+    }
+    let scene_ids = scene_chat_ids
+        .iter()
+        .map(String::as_str)
+        .collect::<std::collections::BTreeSet<_>>();
+    for character in state.storage.list("characters")? {
+        let Some(character_id) = character.get("id").and_then(Value::as_str) else {
+            continue;
+        };
+        let mut data = object_or_parse(character.get("data"));
+        let mut extensions = object_or_parse(data.get("extensions"));
+        let Some(memories) = extensions
+            .get("characterMemories")
+            .and_then(Value::as_array)
+        else {
+            continue;
+        };
+        let retained = memories
+            .iter()
+            .filter(|memory| {
+                memory
+                    .get("sceneChatId")
+                    .and_then(Value::as_str)
+                    .is_none_or(|scene_chat_id| !scene_ids.contains(scene_chat_id))
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        if retained.len() == memories.len() {
+            continue;
+        }
+        extensions.insert("characterMemories".to_string(), Value::Array(retained));
+        data.insert("extensions".to_string(), Value::Object(extensions));
+        state
+            .storage
+            .patch("characters", character_id, json!({ "data": data }))?;
+    }
+    Ok(())
+}
+
+fn clear_deleted_scene_references(
+    state: &AppState,
+    deleted_chat_id: &str,
+    scene_chat_ids: &[String],
+) -> AppResult<()> {
+    if scene_chat_ids.is_empty() {
+        return Ok(());
+    }
+    let scene_ids = scene_chat_ids
+        .iter()
+        .map(String::as_str)
+        .collect::<std::collections::BTreeSet<_>>();
+    for scene_id in scene_chat_ids {
+        let Some(scene_chat) = state.storage.get("chats", scene_id)? else {
+            continue;
+        };
+        let origin_id = metadata_map(&scene_chat)
+            .get("sceneOriginChatId")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|id| !id.is_empty() && *id != deleted_chat_id)
+            .map(str::to_string);
+        let Some(origin_id) = origin_id else {
+            continue;
+        };
+        let Some(origin_chat) = state.storage.get("chats", &origin_id)? else {
+            continue;
+        };
+        let mut meta = metadata_map(&origin_chat);
+        if meta
+            .get("activeSceneChatId")
+            .and_then(Value::as_str)
+            .is_some_and(|id| scene_ids.contains(id))
+        {
+            meta.insert("activeSceneChatId".to_string(), Value::Null);
+        }
+        if let Some(history) = meta.get("roleplaySceneHistory").and_then(Value::as_array) {
+            let retained = history
+                .iter()
+                .filter(|entry| {
+                    entry
+                        .get("sceneChatId")
+                        .and_then(Value::as_str)
+                        .is_none_or(|scene_chat_id| !scene_ids.contains(scene_chat_id))
+                })
+                .cloned()
+                .collect::<Vec<_>>();
+            if retained.len() != history.len() {
+                meta.insert("roleplaySceneHistory".to_string(), Value::Array(retained));
+                if meta
+                    .get("lastRoleplaySceneSummary")
+                    .is_some_and(|summary| !summary.is_null())
+                    && meta
+                        .get("roleplaySceneHistory")
+                        .and_then(Value::as_array)
+                        .is_none_or(Vec::is_empty)
+                {
+                    meta.insert("lastRoleplaySceneSummary".to_string(), Value::Null);
+                }
+            }
+        }
+        state.storage.patch(
+            "chats",
+            &origin_id,
+            json!({ "metadata": meta, "connectedChatId": Value::Null }),
+        )?;
+    }
+    Ok(())
+}
+
+fn object_or_parse(value: Option<&Value>) -> Map<String, Value> {
+    match value {
+        Some(Value::Object(object)) => object.clone(),
+        Some(Value::String(raw)) => serde_json::from_str::<Value>(raw)
+            .ok()
+            .and_then(|value| value.as_object().cloned())
+            .unwrap_or_default(),
+        _ => Map::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::AppState;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn test_state(label: &str) -> AppState {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after unix epoch")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("marinara-chat-delete-{label}-{nonce}"));
+        if path.exists() {
+            std::fs::remove_dir_all(&path).expect("stale temp chat delete dir should be removable");
+        }
+        AppState::from_data_dir(path, Vec::new()).expect("test app state should initialize")
+    }
+
+    #[test]
+    fn delete_origin_chat_removes_scene_chats_and_character_scene_memories() {
+        let state = test_state("origin-scene-memory");
+        state
+            .storage
+            .create(
+                "chats",
+                json!({
+                    "id": "origin-chat",
+                    "name": "Origin",
+                    "metadata": {
+                        "roleplaySceneHistory": [
+                            { "sceneChatId": "scene-chat", "summary": "The moonlit duel happened." },
+                            { "sceneChatId": "linked-non-scene-chat", "summary": "Corrupted non-scene reference." }
+                        ],
+                        "lastRoleplaySceneSummary": "The moonlit duel happened."
+                    },
+                    "connectedChatId": "linked-non-scene-chat"
+                }),
+            )
+            .unwrap();
+        state
+            .storage
+            .create(
+                "chats",
+                json!({
+                    "id": "scene-chat",
+                    "name": "Scene: Moonlit duel",
+                    "metadata": { "sceneOriginChatId": "origin-chat", "sceneStatus": "concluded" },
+                    "characterIds": ["char-a"]
+                }),
+            )
+            .unwrap();
+        state
+            .storage
+            .create(
+                "chats",
+                json!({
+                    "id": "linked-non-scene-chat",
+                    "name": "Linked non-scene chat",
+                    "metadata": {}
+                }),
+            )
+            .unwrap();
+        state
+            .storage
+            .create(
+                "messages",
+                json!({ "id": "origin-message", "chatId": "origin-chat", "content": "start" }),
+            )
+            .unwrap();
+        state
+            .storage
+            .create(
+                "messages",
+                json!({ "id": "scene-message", "chatId": "scene-chat", "content": "duel" }),
+            )
+            .unwrap();
+        state
+            .storage
+            .create(
+                "characters",
+                json!({
+                    "id": "char-a",
+                    "data": {
+                        "extensions": {
+                            "characterMemories": [
+                                { "sceneChatId": "scene-chat", "summary": "The moonlit duel happened." },
+                                { "sceneChatId": "other-scene", "summary": "Keep this unrelated memory." },
+                                { "summary": "Keep this older unscoped memory." }
+                            ]
+                        }
+                    }
+                }),
+            )
+            .unwrap();
+
+        delete_chat_with_messages(&state, "origin-chat").unwrap();
+
+        assert!(state.storage.get("chats", "origin-chat").unwrap().is_none());
+        assert!(state.storage.get("chats", "scene-chat").unwrap().is_none());
+        assert!(state
+            .storage
+            .get("chats", "linked-non-scene-chat")
+            .unwrap()
+            .is_some());
+        assert!(state
+            .storage
+            .get("messages", "origin-message")
+            .unwrap()
+            .is_none());
+        assert!(state
+            .storage
+            .get("messages", "scene-message")
+            .unwrap()
+            .is_none());
+        let character = state.storage.get("characters", "char-a").unwrap().unwrap();
+        let memories = character["data"]["extensions"]["characterMemories"]
+            .as_array()
+            .expect("character memories should remain an array");
+        assert_eq!(memories.len(), 2);
+        assert!(memories
+            .iter()
+            .all(|memory| memory.get("sceneChatId").and_then(Value::as_str) != Some("scene-chat")));
+        assert!(
+            memories
+                .iter()
+                .any(|memory| memory.get("sceneChatId").and_then(Value::as_str)
+                    == Some("other-scene"))
+        );
+        assert!(memories
+            .iter()
+            .any(|memory| memory.get("summary").and_then(Value::as_str)
+                == Some("Keep this older unscoped memory.")));
+    }
 }

--- a/src-tauri/src/commands/storage/chats.rs
+++ b/src-tauri/src/commands/storage/chats.rs
@@ -589,9 +589,9 @@ pub(crate) fn delete_chat_with_messages(state: &AppState, chat_id: &str) -> AppR
     let Some(root_chat) = state.storage.get("chats", chat_id)? else {
         return Ok(());
     };
-    let (scene_memory_ids, owned_scene_chat_ids) = scene_delete_scope(state, chat_id, &root_chat)?;
-    clear_character_scene_memories(state, &scene_memory_ids)?;
-    clear_deleted_scene_references(state, chat_id, &scene_memory_ids)?;
+    let owned_scene_chat_ids = scene_delete_scope(state, chat_id, &root_chat)?;
+    clear_character_scene_memories(state, &owned_scene_chat_ids)?;
+    clear_deleted_scene_references(state, chat_id, &owned_scene_chat_ids)?;
 
     let mut delete_ids = owned_scene_chat_ids
         .iter()
@@ -627,8 +627,7 @@ fn scene_delete_scope(
     state: &AppState,
     chat_id: &str,
     root_chat: &Value,
-) -> AppResult<(Vec<String>, Vec<String>)> {
-    let mut memory_ids = std::collections::BTreeSet::new();
+) -> AppResult<Vec<String>> {
     let mut delete_ids = std::collections::BTreeSet::new();
 
     let meta = metadata_map(root_chat);
@@ -638,10 +637,8 @@ fn scene_delete_scope(
         .map(str::trim)
         .is_some_and(|origin_id| !origin_id.is_empty())
     {
-        memory_ids.insert(chat_id.to_string());
         delete_ids.insert(chat_id.to_string());
     }
-    insert_scene_memory_id(&mut memory_ids, meta.get("activeSceneChatId"));
     insert_owned_scene_chat_id(
         state,
         &mut delete_ids,
@@ -650,8 +647,8 @@ fn scene_delete_scope(
     )?;
     if let Some(history) = meta.get("roleplaySceneHistory").and_then(Value::as_array) {
         for entry in history {
-            insert_scene_memory_id(&mut memory_ids, entry.get("sceneChatId"));
-            insert_owned_scene_chat_id(state, &mut delete_ids, chat_id, entry.get("sceneChatId"))?;
+            let record = object_or_parse(Some(entry));
+            insert_owned_scene_chat_id(state, &mut delete_ids, chat_id, record.get("sceneChatId"))?;
         }
     }
 
@@ -664,26 +661,12 @@ fn scene_delete_scope(
             == Some(chat_id)
         {
             if let Some(id) = chat.get("id").and_then(Value::as_str) {
-                memory_ids.insert(id.to_string());
                 delete_ids.insert(id.to_string());
             }
         }
     }
 
-    Ok((
-        memory_ids.into_iter().collect(),
-        delete_ids.into_iter().collect(),
-    ))
-}
-
-fn insert_scene_memory_id(ids: &mut std::collections::BTreeSet<String>, value: Option<&Value>) {
-    if let Some(id) = value
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|id| !id.is_empty())
-    {
-        ids.insert(id.to_string());
-    }
+    Ok(delete_ids.into_iter().collect())
 }
 
 fn insert_owned_scene_chat_id(
@@ -737,7 +720,7 @@ fn clear_character_scene_memories(state: &AppState, scene_chat_ids: &[String]) -
         let retained = memories
             .iter()
             .filter(|memory| {
-                memory
+                object_or_parse(Some(memory))
                     .get("sceneChatId")
                     .and_then(Value::as_str)
                     .is_none_or(|scene_chat_id| !scene_ids.contains(scene_chat_id))
@@ -791,12 +774,13 @@ fn clear_deleted_scene_references(
             .is_some_and(|id| scene_ids.contains(id))
         {
             meta.insert("activeSceneChatId".to_string(), Value::Null);
+            meta.insert("sceneBusyCharIds".to_string(), Value::Null);
         }
         if let Some(history) = meta.get("roleplaySceneHistory").and_then(Value::as_array) {
             let retained = history
                 .iter()
                 .filter(|entry| {
-                    entry
+                    object_or_parse(Some(entry))
                         .get("sceneChatId")
                         .and_then(Value::as_str)
                         .is_none_or(|scene_chat_id| !scene_ids.contains(scene_chat_id))
@@ -804,24 +788,34 @@ fn clear_deleted_scene_references(
                 .cloned()
                 .collect::<Vec<_>>();
             if retained.len() != history.len() {
+                let next_summary = retained
+                    .last()
+                    .and_then(|entry| {
+                        object_or_parse(Some(entry))
+                            .get("summary")
+                            .and_then(Value::as_str)
+                            .map(str::to_string)
+                    })
+                    .filter(|summary| !summary.trim().is_empty());
                 meta.insert("roleplaySceneHistory".to_string(), Value::Array(retained));
-                if meta
-                    .get("lastRoleplaySceneSummary")
-                    .is_some_and(|summary| !summary.is_null())
-                    && meta
-                        .get("roleplaySceneHistory")
-                        .and_then(Value::as_array)
-                        .is_none_or(Vec::is_empty)
-                {
-                    meta.insert("lastRoleplaySceneSummary".to_string(), Value::Null);
-                }
+                meta.insert(
+                    "lastRoleplaySceneSummary".to_string(),
+                    next_summary.map(Value::String).unwrap_or(Value::Null),
+                );
             }
         }
-        state.storage.patch(
-            "chats",
-            &origin_id,
-            json!({ "metadata": meta, "connectedChatId": Value::Null }),
-        )?;
+        let mut patch = Map::new();
+        patch.insert("metadata".to_string(), Value::Object(meta));
+        if origin_chat
+            .get("connectedChatId")
+            .and_then(Value::as_str)
+            .is_some_and(|id| scene_ids.contains(id))
+        {
+            patch.insert("connectedChatId".to_string(), Value::Null);
+        }
+        state
+            .storage
+            .patch("chats", &origin_id, Value::Object(patch))?;
     }
     Ok(())
 }
@@ -922,7 +916,7 @@ mod tests {
                     "data": {
                         "extensions": {
                             "characterMemories": [
-                                { "sceneChatId": "scene-chat", "summary": "The moonlit duel happened." },
+                                "{\"sceneChatId\":\"scene-chat\",\"summary\":\"The moonlit duel happened.\"}",
                                 { "sceneChatId": "other-scene", "summary": "Keep this unrelated memory." },
                                 { "summary": "Keep this older unscoped memory." }
                             ]
@@ -956,18 +950,121 @@ mod tests {
             .as_array()
             .expect("character memories should remain an array");
         assert_eq!(memories.len(), 2);
-        assert!(memories
-            .iter()
-            .all(|memory| memory.get("sceneChatId").and_then(Value::as_str) != Some("scene-chat")));
-        assert!(
-            memories
-                .iter()
-                .any(|memory| memory.get("sceneChatId").and_then(Value::as_str)
-                    == Some("other-scene"))
-        );
+        assert!(memories.iter().all(|memory| object_or_parse(Some(memory))
+            .get("sceneChatId")
+            .and_then(Value::as_str)
+            != Some("scene-chat")));
+        assert!(memories.iter().any(|memory| object_or_parse(Some(memory))
+            .get("sceneChatId")
+            .and_then(Value::as_str)
+            == Some("other-scene")));
         assert!(memories
             .iter()
             .any(|memory| memory.get("summary").and_then(Value::as_str)
                 == Some("Keep this older unscoped memory.")));
+    }
+
+    #[test]
+    fn delete_scene_chat_prunes_origin_scene_state_without_breaking_unrelated_link() {
+        let state = test_state("scene-origin-reference");
+        state
+            .storage
+            .create(
+                "chats",
+                json!({
+                    "id": "origin-chat",
+                    "name": "Origin",
+                    "metadata": {
+                        "activeSceneChatId": "scene-chat",
+                        "sceneBusyCharIds": ["char-a"],
+                        "roleplaySceneHistory": [
+                            { "sceneChatId": "other-scene", "summary": "Keep this other scene." },
+                            "{\"sceneChatId\":\"scene-chat\",\"summary\":\"Remove this deleted scene.\"}"
+                        ],
+                        "lastRoleplaySceneSummary": "Remove this deleted scene."
+                    },
+                    "connectedChatId": "linked-non-scene-chat"
+                }),
+            )
+            .unwrap();
+        state
+            .storage
+            .create(
+                "chats",
+                json!({
+                    "id": "scene-chat",
+                    "name": "Scene: Moonlit duel",
+                    "metadata": { "sceneOriginChatId": "origin-chat", "sceneStatus": "concluded" },
+                    "characterIds": ["char-a"]
+                }),
+            )
+            .unwrap();
+        state
+            .storage
+            .create(
+                "chats",
+                json!({
+                    "id": "linked-non-scene-chat",
+                    "name": "Linked non-scene chat",
+                    "metadata": {}
+                }),
+            )
+            .unwrap();
+        state
+            .storage
+            .create(
+                "characters",
+                json!({
+                    "id": "char-a",
+                    "data": {
+                        "extensions": {
+                            "characterMemories": [
+                                "{\"sceneChatId\":\"scene-chat\",\"summary\":\"Remove this deleted scene.\"}",
+                                { "sceneChatId": "other-scene", "summary": "Keep this other scene." }
+                            ]
+                        }
+                    }
+                }),
+            )
+            .unwrap();
+
+        delete_chat_with_messages(&state, "scene-chat").unwrap();
+
+        assert!(state.storage.get("chats", "scene-chat").unwrap().is_none());
+        let origin = state.storage.get("chats", "origin-chat").unwrap().unwrap();
+        assert_eq!(
+            origin.get("connectedChatId").and_then(Value::as_str),
+            Some("linked-non-scene-chat")
+        );
+        let meta = metadata_map(&origin);
+        assert!(meta.get("activeSceneChatId").is_some_and(Value::is_null));
+        assert!(meta.get("sceneBusyCharIds").is_some_and(Value::is_null));
+        assert_eq!(
+            meta.get("lastRoleplaySceneSummary").and_then(Value::as_str),
+            Some("Keep this other scene.")
+        );
+        let history = meta
+            .get("roleplaySceneHistory")
+            .and_then(Value::as_array)
+            .expect("origin scene history should remain an array");
+        assert_eq!(history.len(), 1);
+        assert_eq!(
+            object_or_parse(history.first())
+                .get("sceneChatId")
+                .and_then(Value::as_str),
+            Some("other-scene")
+        );
+
+        let character = state.storage.get("characters", "char-a").unwrap().unwrap();
+        let memories = character["data"]["extensions"]["characterMemories"]
+            .as_array()
+            .expect("character memories should remain an array");
+        assert_eq!(memories.len(), 1);
+        assert_eq!(
+            object_or_parse(memories.first())
+                .get("sceneChatId")
+                .and_then(Value::as_str),
+            Some("other-scene")
+        );
     }
 }

--- a/src-tauri/src/commands/storage/commands/entities.rs
+++ b/src-tauri/src/commands/storage/commands/entities.rs
@@ -1,4 +1,4 @@
-use super::{avatars, game_state_snapshots, lorebook_images, shared};
+use super::{avatars, chats, game_state_snapshots, lorebook_images, shared};
 use crate::builtins::is_protected_record;
 use crate::state::AppState;
 use marinara_core::AppError;
@@ -117,6 +117,13 @@ pub fn storage_delete(
 ) -> Result<Value, AppError> {
     if entity == "connections" {
         return crate::connection_refs::delete_connection(&state, &id, force.unwrap_or(false));
+    }
+    if entity == "chats" {
+        let existed = state.storage.get("chats", &id)?.is_some();
+        if existed {
+            chats::delete_chat_with_messages(&state, &id)?;
+        }
+        return Ok(json!({ "deleted": existed }));
     }
     if is_protected_record(&entity, &id) {
         return Err(AppError::invalid_input(

--- a/src-tauri/src/http_dispatch.rs
+++ b/src-tauri/src/http_dispatch.rs
@@ -179,6 +179,13 @@ fn storage_delete(state: &AppState, args: &Map<String, Value>) -> AppResult<Valu
             args.get("force").and_then(Value::as_bool).unwrap_or(false),
         );
     }
+    if entity == "chats" {
+        let existed = state.storage.get("chats", id)?.is_some();
+        if existed {
+            chats::delete_chat_with_messages(state, id)?;
+        }
+        return Ok(json!({ "deleted": existed }));
+    }
     if is_protected_record(entity, id) {
         return Err(AppError::invalid_input(
             "Built-in Professor Mari cannot be deleted",


### PR DESCRIPTION
## What?

Fixes #1182.

Deleting a chat now uses the chat-aware cleanup path instead of the raw storage delete path. When the deleted chat owns roleplay scenes, Marinara removes the owned scene child chats, their messages, tracker snapshots, and the matching character-level scene memories.

## Why?

Concluded roleplay scenes write continuity into both the origin chat metadata and each character's `extensions.characterMemories`. Deleting the origin conversation previously removed only the origin chat row, leaving scene chats and character memories available for later conversations with the same character.

## How?

- Routes `storage_delete(entity = "chats")` through `delete_chat_with_messages` for both Tauri and HTTP runtime entrypoints.
- Extends `delete_chat_with_messages` to discover scene IDs from owned scene rows and origin metadata, then clean up scene chat rows/messages and matching character memories.
- Keeps the destructive boundary narrow: non-scene linked chats are not deleted, and unrelated character memories are preserved.

## Testing?

Machine verification:

- `cargo test --manifest-path src-tauri\Cargo.toml storage_commands::chats::tests`
  - Before fix: failed because `scene-chat` still existed after deleting `origin-chat`.
  - After fix: passed; the owned scene chat/messages were deleted, matching character memories were removed, unrelated memories stayed, stringified scene-memory records were parsed, direct scene deletion pruned origin scene state, and a linked non-scene chat stayed.
- `pnpm check`
  - Passed architecture checks, frontend typecheck, Rust check, and docs validation.
- `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json`
  - Passed.
- Bunny review
  - Passed after tightening the helper to no-op when the target chat row is already missing.
- CodeRabbit follow-up
  - Addressed current-head comments by limiting cleanup to validated owned scene IDs, parsing stringified history/memory entries, refreshing `lastRoleplaySceneSummary` after pruning, clearing `sceneBusyCharIds`, and preserving unrelated `connectedChatId` links.

Manual verification:

- None required for the core claim. If manually testing destructive chat deletion against real app data, first back up `<Marinara app data>/data/collections/chats.json`, `messages.json`, `characters.json`, and `game-state-snapshots.json` when present to a separate folder outside the app data directory.

## Screenshots

N/A. This is a storage cleanup bug verified by a targeted Rust harness and `pnpm check`.

## Anything Else?

Base branch: `refactor`.

Out of scope: changing scene conclusion behavior, memory recall ranking, prompt assembly, or ordinary linked-chat deletion.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat deletion to properly handle scene-related chats and associated data. When deleting a chat that's part of a roleplay scene, the system now correctly cleans up linked scene chats, character memories, and scene references, preventing orphaned data and broken connections.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1198?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->