### PR TITLE
Add refactor branch contributor and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,51 @@
+---
+name: Feature request
+about: Suggest an improvement or new feature for the refactor branch
+title: "[Feature]: "
+labels: "enhancement"
+assignees: ""
+---
+
+## What problem does this solve?
+
+<!-- Describe the pain point, missing workflow, or capability gap. -->
+
+## Proposed behavior
+
+<!-- What should Marinara Engine add or change? -->
+
+## Expected owner or impact area
+
+<!-- Check the areas you think are relevant. Leave uncertain items unchecked. -->
+
+- [ ] App shell, navigation, startup, or providers
+- [ ] Catalog resources: chats, characters, personas, lorebooks, presets, connections, agents, gallery, or knowledge
+- [ ] Chat mode
+- [ ] Roleplay mode
+- [ ] Game mode
+- [ ] Shared mode UI
+- [ ] Runtime systems: generation, world-state, visuals, tracker, or haptics
+- [ ] Professor Mari or shell tools
+- [ ] React-free engine behavior, contracts, agents, or capability ports
+- [ ] Shared API wrapper or remote runtime routing
+- [ ] Tauri/Rust storage, assets, LLM, integrations, security, imports, or HTTP runtime
+- [ ] Docs, contributor workflow, or templates
+
+## Refactor branch considerations
+
+<!-- Note any architecture expectations, remote-runtime needs, or risky pressure points. -->
+<!-- Examples: avoid broadening ModeSurface/GameSurface, keep engine React-free, use shared API wrappers instead of raw Tauri calls. -->
+
+## Alternatives considered
+
+<!-- Any other approaches you thought about? -->
+
+## Additional context
+
+<!-- Optional: mockups, related issues, logs, examples, or links. -->
+
+## Template check
+
+Please uncheck the box below before submitting so we know you read the template. It is intentionally pre-checked:
+
+- [x] I DID NOT read this template and provide the requested details.

--- a/.github/ISSUE_TEMPLATE/issue_report.md
+++ b/.github/ISSUE_TEMPLATE/issue_report.md
@@ -1,0 +1,70 @@
+---
+name: Issue report
+about: Report a bug, regression, or usability problem on the refactor branch
+title: "[Issue]: "
+labels: "bug"
+assignees: ""
+---
+
+## Summary
+
+<!-- What is wrong in one or two sentences? -->
+
+## Expected behavior
+
+<!-- What should have happened? -->
+
+## Actual behavior
+
+<!-- What happened instead? -->
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Impact area
+
+<!-- Check the areas you think are relevant. Leave uncertain items unchecked. -->
+
+- [ ] App shell, navigation, startup, or providers
+- [ ] Catalog resources
+- [ ] Chat mode
+- [ ] Roleplay mode
+- [ ] Game mode
+- [ ] Shared mode UI
+- [ ] Runtime systems: generation, world-state, visuals, tracker, or haptics
+- [ ] Professor Mari or shell tools
+- [ ] React-free engine behavior, contracts, agents, or capability ports
+- [ ] Shared API wrapper or remote runtime routing
+- [ ] Tauri/Rust storage, assets, LLM, integrations, security, imports, or HTTP runtime
+- [ ] Docs, contributor workflow, or templates
+
+## Environment
+
+- Branch or commit:
+- Run mode: (Tauri desktop / web shell only / remote runtime / Docker runtime)
+- OS + version:
+- Node + pnpm versions:
+- Rust version, if relevant:
+- Remote Runtime URL configured? (yes / no / not relevant)
+- Provider, model, or integration, if relevant:
+
+## Logs, screenshots, or video
+
+<!-- Paste relevant logs and add screenshots or recordings when possible. Redact secrets and API keys. -->
+
+## Regression notes
+
+<!-- Did this work before? If yes, include the last known good branch, commit, build, or date. -->
+
+## Additional context
+
+<!-- Optional: related issue links, temporary workaround, import file shape, affected data type, or edge case. -->
+
+## Template check
+
+Please uncheck the box below before submitting so we know you read the template. It is intentionally pre-checked:
+
+- [x] I DID NOT read this template and provide the requested details.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -50,7 +50,7 @@ Pressure points touched:
 - [ ] `pnpm build` passes locally
 - [ ] `pnpm check:architecture` passes locally
 - [ ] `pnpm check:docs` passes locally
-- [ ] `cargo check --manifest-path src-tauri/Cargo.toml` passes locally
+- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
 - [ ] Rust clippy/tests were run for Rust behavior changes
 - [ ] Browser or Tauri app manual verification completed
 - [ ] Playwright, screenshot, or recording evidence added for UI changes

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,76 @@
+<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
+<!-- Keep all checkboxes unchecked until a human has actually verified them. -->
+
+## Linked issue
+
+<!-- Every user-facing PR should reference a feature request or issue report when practical. -->
+
+Closes #
+
+## Why this change
+
+<!-- What user problem, bug, refactor goal, or maintenance need does this solve? -->
+
+-
+
+## What changed
+
+<!-- List the key changes in this PR. -->
+
+-
+
+## Refactor impact
+
+Primary owner:
+
+<!-- Examples: app shell, catalog, chat mode, roleplay mode, game mode, runtime generation, world-state, shared API, engine generation, Rust storage, imports, remote runtime. -->
+
+Impact areas reviewed:
+
+-
+
+Boundary notes:
+
+<!-- Note engine/shared-api/feature/Rust/remote-runtime boundaries. Say "none" only if you checked. -->
+
+-
+
+Pressure points touched:
+
+<!-- Mention ModeSurface, GameSurface, shared mode UI, src-tauri/src/lib.rs command registration, or import modules if touched. -->
+
+-
+
+## Validation
+
+<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
+
+- [ ] `pnpm check` passes locally
+- [ ] `pnpm typecheck` passes locally
+- [ ] `pnpm build` passes locally
+- [ ] `pnpm check:architecture` passes locally
+- [ ] `pnpm check:docs` passes locally
+- [ ] `cargo check --manifest-path src-tauri/Cargo.toml` passes locally
+- [ ] Rust clippy/tests were run for Rust behavior changes
+- [ ] Browser or Tauri app manual verification completed
+- [ ] Playwright, screenshot, or recording evidence added for UI changes
+- [ ] Remote runtime smoke checked when relevant
+
+### Manual verification notes
+
+<!-- Describe exactly what you tested in a real browser/app/runtime, step by step. If an AI agent filled this out, verify it yourself before ticking boxes. -->
+
+-
+
+## Docs and release impact
+
+- [ ] No docs changes needed
+- [ ] Updated `README.md`
+- [ ] Updated `CONTRIBUTING.md`
+- [ ] Updated `docs/developer/`
+- [ ] Updated repo skills or `AGENTS.md`
+- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims
+
+## UI evidence
+
+<!-- Add before/after screenshots or recordings for visible UI changes. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,7 @@ pnpm typecheck
 pnpm build
 pnpm check:architecture
 pnpm check:docs
-cargo check --manifest-path src-tauri/Cargo.toml
+cargo check --manifest-path src-tauri/Cargo.toml --workspace
 pnpm check
 ```
 
@@ -102,12 +102,12 @@ Use these as a guide:
 
 - TypeScript, React, feature, or engine changes: `pnpm typecheck`.
 - Import graph, dependency boundaries, or bundling changes: `pnpm check:architecture` and usually `pnpm build`.
-- Rust commands, capability crates, provider transport, storage, imports, assets, native integrations, or hostable runtime changes: `cargo check --manifest-path src-tauri/Cargo.toml`.
+- Rust commands, capability crates, provider transport, storage, imports, assets, native integrations, or hostable runtime changes: `cargo check --manifest-path src-tauri/Cargo.toml --workspace`.
 - Docs, templates, skills, or agent guidance: `pnpm check:docs`.
 - Visible UI behavior: run the app and manually verify the workflow. Use Playwright or screenshots when the change is visual or flow-sensitive.
 - Remote runtime behavior: run `marinara-server`, check `/health`, configure the app's Remote Runtime URL, and exercise the supported shared API path when practical.
 
-CI also runs lint, tests, build, size checks, Rust clippy, Rust tests, and browser smoke checks. Local validation should still describe exactly what was run and what remains unverified.
+CI also runs lint, tests, build, size checks, Rust clippy, Rust tests, and the Browser Smoke and Performance job. Local validation should still describe exactly what was run and what remains unverified.
 
 ## Pull Requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,133 @@
+# Contributing to Marinara Engine
+
+Marinara Engine is currently being rebuilt on the `refactor` branch as a local-first Tauri desktop app with a React UI, a React-free TypeScript product engine, and Rust capability modules. Use this guide with `README.md`, `AGENTS.md`, and the developer docs under `docs/developer/`.
+
+## Branches
+
+Current development targets `refactor`.
+
+- Base feature, bug fix, and documentation branches on `refactor`.
+- Open pull requests against `refactor`.
+- Do not target `main` unless a maintainer explicitly asks for a mainline or release change.
+- Keep PRs focused. Separate architecture moves, product behavior, UI polish, and docs-only work when they can be reviewed independently.
+
+## Development Setup
+
+Prerequisites:
+
+- Node.js 22 or newer.
+- pnpm through the repo-pinned `packageManager`.
+- Rust stable toolchain.
+- Tauri v2 platform prerequisites for your OS.
+
+Typical local setup:
+
+```sh
+git clone https://github.com/Pasta-Devs/Marinara-Engine.git
+cd Marinara-Engine
+git checkout refactor
+pnpm install
+pnpm tauri dev
+```
+
+Useful commands:
+
+```sh
+pnpm tauri dev
+pnpm dev
+pnpm build
+pnpm tauri build
+cargo run --manifest-path src-tauri/Cargo.toml --bin marinara-server
+docker compose up --build
+```
+
+- `pnpm tauri dev` is the normal desktop development command.
+- `pnpm dev` runs the web shell only. Tauri-only capabilities will not all work there.
+- `marinara-server` runs the hostable Rust HTTP runtime. It hosts the Rust API only, not the React UI.
+- `docker compose up --build` builds and starts the remote Rust runtime container.
+
+## Current Source Shape
+
+The refactor branch is layered by ownership:
+
+- `src/app` owns React bootstrap, app shell, providers, and startup effects.
+- `src/features` owns user-facing React workflows.
+- `src/features/shell` owns settings, imports, onboarding, Professor Mari, and integrations surfaces.
+- `src/features/modes` owns chat, roleplay, game, shared transcript UI, and the mode router.
+- `src/features/runtime` owns shared runtime systems such as generation, world-state, visuals, tracker, and haptics.
+- `src/features/catalog` owns resource-library UI and hooks for chats, characters, personas, lorebooks, presets, connections, agents, gallery, and knowledge sources.
+- `src/shared` owns feature-neutral frontend components, hooks, stores, types, and browser helpers.
+- `src/shared/api` owns typed adapters for embedded Tauri commands and the optional remote Rust runtime.
+- `src/engine` owns React-free product behavior, contracts, generation, agents, capability ports, and mode engines.
+- `src-tauri` owns the Tauri host, command facades, HTTP server and dispatch, and Rust capability crates for core, storage, assets, LLM, integrations, and security.
+
+This ownership map follows the current refactor actual-state design. Keep contributor guidance consistent with the developer docs and architecture diagrams when those change.
+
+## Architecture Rules
+
+Start each change by naming the owner: app shell, catalog, runtime system, concrete mode, shared UI/helper, engine service, shared API adapter, Tauri command, hostable HTTP route, or Rust capability crate.
+
+Hard boundaries:
+
+- Product behavior belongs in `src/engine`; React UI belongs in `src/features`; runtime wrappers belong in `src/shared/api`; privileged or hostable capabilities belong in `src-tauri`.
+- Engine code must not import React, Zustand stores, `@tauri-apps/api`, feature internals, or concrete `src/shared/api` adapters.
+- New or touched feature code should use focused shared API wrappers, not raw `invokeTauri` imports or raw remote-runtime `fetch`.
+- Remote-capable behavior must use the explicit path through `src/shared/api`, `remote-runtime.ts`, `src-tauri/src/http_server.rs`, and `src-tauri/src/http_dispatch.rs`.
+- Chat, roleplay, and game remain separate mode owners. Put reusable mode UI in shared mode UI, not in another concrete mode.
+- `src/shared` must stay feature-neutral and must not import from `src/features` or `src/app`.
+- Tauri commands should stay thin. Durable behavior belongs in focused Rust modules or crates.
+
+Known pressure points:
+
+- `src/features/modes/router/components/ModeSurface.tsx` is still broad. Avoid adding unrelated orchestration there when a mode, runtime, or catalog owner fits better.
+- `src/features/modes/game/components/GameSurface.tsx` is the largest UI orchestrator. Prefer extracting focused game-owned helpers or controllers when adding substantial behavior.
+- Some shared mode UI files are large. Keep them mode-neutral rather than using them as a place for concrete chat, roleplay, or game rules.
+- `src-tauri/src/lib.rs` still has a broad command registration list. Add commands deliberately and keep implementation outside the registry.
+- Import workflows are split, but dense modules remain. Trace storage, asset, security, and payload paths before changing imports.
+
+## Validation
+
+Run checks that match the change. `pnpm check` is the baseline combined check.
+
+```sh
+pnpm typecheck
+pnpm build
+pnpm check:architecture
+pnpm check:docs
+cargo check --manifest-path src-tauri/Cargo.toml
+pnpm check
+```
+
+Use these as a guide:
+
+- TypeScript, React, feature, or engine changes: `pnpm typecheck`.
+- Import graph, dependency boundaries, or bundling changes: `pnpm check:architecture` and usually `pnpm build`.
+- Rust commands, capability crates, provider transport, storage, imports, assets, native integrations, or hostable runtime changes: `cargo check --manifest-path src-tauri/Cargo.toml`.
+- Docs, templates, skills, or agent guidance: `pnpm check:docs`.
+- Visible UI behavior: run the app and manually verify the workflow. Use Playwright or screenshots when the change is visual or flow-sensitive.
+- Remote runtime behavior: run `marinara-server`, check `/health`, configure the app's Remote Runtime URL, and exercise the supported shared API path when practical.
+
+CI also runs lint, tests, build, size checks, Rust clippy, Rust tests, and browser smoke checks. Local validation should still describe exactly what was run and what remains unverified.
+
+## Pull Requests
+
+Every PR should include:
+
+- The user problem, bug, or maintenance goal.
+- The primary owner and impact area.
+- The files or modules touched.
+- Boundary notes for engine, shared API, feature layers, Rust commands, and remote runtime when relevant.
+- Manual verification notes for user-facing behavior.
+- Screenshots or recordings for visible UI changes.
+- Any remaining risk, follow-up work, or proof gaps.
+
+Leave PR template checkboxes unchecked until a human has actually verified each item. If an AI agent drafts a PR body, treat the checkboxes as a to-do list, not as proof.
+
+## Docs And Release Notes
+
+Keep docs accurate for the refactor branch:
+
+- Update `README.md` and `docs/developer/` when run commands, architecture, source ownership, or validation changes.
+- Update `AGENTS.md` or repo skills only when contributor or agent workflow rules change.
+- Do not restore old `staging`, package-workspace, installer, release, screenshot, or changelog claims unless they are true for the refactor branch.
+- Public release packaging, installation pages, final screenshots, release notes, and license metadata are still being rebuilt around the new architecture.

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ pnpm typecheck
 pnpm build
 pnpm check:architecture
 pnpm check:docs
-cargo check --manifest-path src-tauri/Cargo.toml
+cargo check --manifest-path src-tauri/Cargo.toml --workspace
 ```
 
 The combined check is:

--- a/docs/developer/impact-areas.html
+++ b/docs/developer/impact-areas.html
@@ -175,7 +175,7 @@ flowchart LR
           <tbody>
             <tr><th>Touching</th><td>Professor Mari shell entry, standalone chat surface, connection/persona context, attachments, read-only creative library tool, native tool calling, or Mari provider errors.</td></tr>
             <tr><th>Review</th><td>App shell routing, <code>features/shell/mari</code>, <code>engine/mari</code>, <code>shared/api/mari-api</code>, Rust Mari command, LLM connection support, storage snapshot scope.</td></tr>
-            <tr><th>Verify</th><td><code>pnpm typecheck</code>; add <code>cargo check --manifest-path src-tauri/Cargo.toml</code> when the command, AutoAgents bridge, storage snapshot, or provider transport changed.</td></tr>
+            <tr><th>Verify</th><td><code>pnpm typecheck</code>; add <code>cargo check --manifest-path src-tauri/Cargo.toml --workspace</code> when the command, AutoAgents bridge, storage snapshot, or provider transport changed.</td></tr>
           </tbody>
         </table>
 
@@ -203,7 +203,7 @@ flowchart LR
           <tbody>
             <tr><th>Touching</th><td>Entity CRUD, profile import/export, avatar/background/gallery files, game assets, bulk imports, local file URLs.</td></tr>
             <tr><th>Review</th><td>DTO shapes, filename/path validation, atomic writes, frontend adapter response shapes, progress channels.</td></tr>
-            <tr><th>Verify</th><td><code>cargo check --manifest-path src-tauri/Cargo.toml</code>; run TypeScript checks if adapter contracts changed.</td></tr>
+            <tr><th>Verify</th><td><code>cargo check --manifest-path src-tauri/Cargo.toml --workspace</code>; run TypeScript checks if adapter contracts changed.</td></tr>
           </tbody>
         </table>
 
@@ -268,7 +268,7 @@ flowchart LR
           <tbody>
             <tr><th>Touching</th><td><code>invokeTauri</code>, <code>remote-runtime.ts</code>, <code>llm-api</code> streaming, <code>http_server.rs</code>, <code>http_dispatch.rs</code>, <code>local-file-api</code>, Tauri plugins, file dialogs, managed asset URLs, imports/uploads, native window/titlebar behavior, opener behavior, haptics, Spotify OAuth, TTS, or Docker/server build files.</td></tr>
             <tr><th>Review</th><td>Does the feature require desktop-only native access, or can it safely run through the hostable runtime data directory and JSON/SSE HTTP contract? Is the command allowlisted in <code>remote-runtime.ts</code> and handled explicitly in <code>http_dispatch.rs</code> or a dedicated route? Does the feature avoid raw server filesystem paths and silent no-op fallbacks?</td></tr>
-            <tr><th>Verify</th><td><code>pnpm typecheck</code>, <code>pnpm build</code>, <code>cargo check --manifest-path src-tauri/Cargo.toml</code>, and an HTTP smoke check when practical: run <code>marinara-server</code>, hit <code>/health</code>, then exercise the supported shared API path from Settings &gt; Advanced &gt; Remote Runtime URL.</td></tr>
+            <tr><th>Verify</th><td><code>pnpm typecheck</code>, <code>pnpm build</code>, <code>cargo check --manifest-path src-tauri/Cargo.toml --workspace</code>, and an HTTP smoke check when practical: run <code>marinara-server</code>, hit <code>/health</code>, then exercise the supported shared API path from Settings &gt; Advanced &gt; Remote Runtime URL.</td></tr>
             <tr><th>Decision</th><td>If remote behavior cannot be equivalent, keep the feature desktop-only and document that limit instead of adding silent fallbacks.</td></tr>
           </tbody>
         </table>

--- a/docs/developer/run-build.html
+++ b/docs/developer/run-build.html
@@ -148,7 +148,7 @@ docker run --rm -p 8787:8787 -v marinara-server-data:/data marinara-engine-serve
               <td>Imports, build output, frontend bundling, or production behavior changed.</td>
             </tr>
             <tr>
-              <td><code>cargo check --manifest-path src-tauri/Cargo.toml</code></td>
+              <td><code>cargo check --manifest-path src-tauri/Cargo.toml --workspace</code></td>
               <td>Rust commands, capability crates, provider transport, storage, assets, or integrations changed.</td>
             </tr>
             <tr>

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint .",
     "check:architecture": "depcruise src --config .dependency-cruiser.cjs && node scripts/check-rust-structure.mjs",
     "check:frontend": "tsc -b",
-    "check:rust": "cargo check --manifest-path src-tauri/Cargo.toml",
+    "check:rust": "cargo check --manifest-path src-tauri/Cargo.toml --workspace",
     "check:rust:clippy": "cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- -D warnings",
     "check:rust:test": "cargo test --manifest-path src-tauri/Cargo.toml --workspace",
     "check:rust:nextest": "cargo nextest run --manifest-path src-tauri/Cargo.toml --workspace",


### PR DESCRIPTION
## Linked issue

No linked issue; docs/template recovery for the refactor branch.

## Why this change

- Adds contributor and GitHub templates that match the current refactor branch architecture and PR target.

## What changed

- Added refactor-scoped `CONTRIBUTING.md`.
- Added feature request and issue report templates.
- Added a pull request template for PRs targeting `refactor`.

## Refactor impact

Primary owner:

Docs and contributor workflow.

Impact areas reviewed:

- Current refactor branch ownership map from `Docs/UML/Refactor/refactor-actual-state.puml`
- `README.md`
- Developer architecture, run/build, modules, and impact-area docs
- Existing CI config

Boundary notes:

- No runtime/product boundary changes.
- Guidance now names the current `src/app`, `src/features`, `src/engine`, `src/shared/api`, and `src-tauri` ownership model.

Pressure points touched:

- No source pressure points touched.
- Templates now call out `ModeSurface`, `GameSurface`, shared mode UI, command registration, and import modules as review prompts.

## Validation

- [x] `pnpm check` passes locally
- [x] `pnpm typecheck` passes locally
- [x] `pnpm build` passes locally
- [x] `pnpm check:architecture` passes locally
- [x] `pnpm check:docs` passes locally
- [x] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Ran `pnpm check:docs`.
- Ran `pnpm check:rust`, now backed by `cargo check --manifest-path src-tauri/Cargo.toml --workspace`.
- Ran `pnpm check`.
- Ran `pnpm build`.

## Docs and release impact

- [ ] No docs changes needed
- [x] Updated `README.md`
- [x] Updated `CONTRIBUTING.md`
- [x] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

Not applicable; docs/template-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added GitHub issue templates for feature requests and bug reports with structured sections and metadata
  * Added pull request template with required sections for issue linking, changes, and validation steps
  * Added contributing guide outlining development workflow, setup instructions, and contribution requirements

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1199?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->