### PR TITLE
Harden SillyTavern bulk import

### DIFF
--- a/src-tauri/src/commands/storage/imports/bulk_imports.rs
+++ b/src-tauri/src/commands/storage/imports/bulk_imports.rs
@@ -59,6 +59,33 @@ fn imported_count(imported: &Value, key: &str) -> i64 {
     imported.get(key).and_then(Value::as_i64).unwrap_or(0)
 }
 
+fn push_import_error(errors: &mut Vec<Value>, item: impl AsRef<str>, error: AppError) {
+    errors.push(Value::String(format!(
+        "{}: {}",
+        item.as_ref(),
+        error.message
+    )));
+}
+
+fn push_path_import_error(errors: &mut Vec<Value>, path: &Path, error: AppError) {
+    push_import_error(errors, path.to_string_lossy(), error);
+}
+
+fn selected_path(
+    data_dir: &Path,
+    category: &str,
+    id: &str,
+    errors: &mut Vec<Value>,
+) -> Option<PathBuf> {
+    match path_from_id(data_dir, category, id) {
+        Ok(path) => Some(path),
+        Err(error) => {
+            push_import_error(errors, id, error);
+            None
+        }
+    }
+}
+
 fn bump_imported(imported: &mut Value, key: &str) {
     if let Some(value) = imported.get_mut(key) {
         *value = json!(value.as_i64().unwrap_or(0) + 1);
@@ -622,37 +649,28 @@ fn import_persona_file(state: &AppState, path: &Path) -> AppResult<Value> {
     import_persona_payload(state, payload, &fallback_name)
 }
 
-fn image_mime_from_path(path: &Path) -> &'static str {
-    match path
-        .extension()
-        .and_then(|ext| ext.to_str())
-        .map(|ext| ext.to_ascii_lowercase())
-        .as_deref()
-    {
-        Some("jpg") | Some("jpeg") => "image/jpeg",
-        Some("webp") => "image/webp",
-        _ => "image/png",
-    }
-}
-
 fn import_persona_avatar_file(
     state: &AppState,
     path: &Path,
     name: String,
     description: String,
 ) -> AppResult<Value> {
-    let bytes = fs::read(path)?;
-    let mime = image_mime_from_path(path);
-    let avatar = format!(
-        "data:{mime};base64,{}",
-        general_purpose::STANDARD.encode(bytes)
-    );
+    let stored = super::super::media_uploads::persist_image_file_copy(
+        state,
+        "avatars/personas",
+        &path
+            .file_name()
+            .map(|name| name.to_string_lossy().to_string())
+            .unwrap_or_else(|| file_stem(path)),
+        path,
+    )?;
     let modified = modified_at(path);
     let payload = json!({
         "name": name,
         "description": description,
-        "avatar": avatar,
-        "avatarPath": avatar,
+        "avatarPath": stored.asset_url,
+        "avatarFilePath": stored.absolute_path,
+        "avatarFilename": stored.filename,
         "importedModifiedAt": modified,
     });
     import_persona_payload(state, payload, &file_stem(path))
@@ -709,7 +727,9 @@ fn run_st_bulk_import_inner(
     let (persona_names, persona_descriptions) = read_st_persona_settings(&data_dir);
 
     for id in selected_ids(&options, "characters") {
-        let path = path_from_id(&data_dir, "characters", &id)?;
+        let Some(path) = selected_path(&data_dir, "characters", &id, &mut errors) else {
+            continue;
+        };
         progress.emit_item("Characters", &path, &imported)?;
         let filename = path
             .file_name()
@@ -717,7 +737,7 @@ fn run_st_bulk_import_inner(
             .unwrap_or_default();
         let result = fs::read(&path)
             .map_err(AppError::from)
-            .and_then(|bytes| parse_character_file(&filename, &bytes))
+            .and_then(|bytes| parse_character_file_from_path(&filename, &path, &bytes))
             .and_then(|payload| {
                 import_st_character_payload(
                     state,
@@ -728,16 +748,14 @@ fn run_st_bulk_import_inner(
             });
         match result {
             Ok(_) => bump_imported(&mut imported, "characters"),
-            Err(error) => errors.push(Value::String(format!(
-                "{}: {}",
-                path.to_string_lossy(),
-                error.message
-            ))),
+            Err(error) => push_path_import_error(&mut errors, &path, error),
         }
     }
 
     for id in selected_ids(&options, "lorebooks") {
-        let path = path_from_id(&data_dir, "lorebooks", &id)?;
+        let Some(path) = selected_path(&data_dir, "lorebooks", &id, &mut errors) else {
+            continue;
+        };
         progress.emit_item("Lorebooks", &path, &imported)?;
         let result = fs::read(&path)
             .map_err(AppError::from)
@@ -747,16 +765,14 @@ fn run_st_bulk_import_inner(
             });
         match result {
             Ok(_) => bump_imported(&mut imported, "lorebooks"),
-            Err(error) => errors.push(Value::String(format!(
-                "{}: {}",
-                path.to_string_lossy(),
-                error.message
-            ))),
+            Err(error) => push_path_import_error(&mut errors, &path, error),
         }
     }
 
     for id in selected_ids(&options, "presets") {
-        let path = path_from_id(&data_dir, "presets", &id)?;
+        let Some(path) = selected_path(&data_dir, "presets", &id, &mut errors) else {
+            continue;
+        };
         progress.emit_item("Presets", &path, &imported)?;
         let result = fs::read(&path)
             .map_err(AppError::from)
@@ -764,16 +780,14 @@ fn run_st_bulk_import_inner(
             .and_then(|payload| import_st_preset_payload(state, payload, Some(&file_stem(&path))));
         match result {
             Ok(_) => bump_imported(&mut imported, "presets"),
-            Err(error) => errors.push(Value::String(format!(
-                "{}: {}",
-                path.to_string_lossy(),
-                error.message
-            ))),
+            Err(error) => push_path_import_error(&mut errors, &path, error),
         }
     }
 
     for id in selected_ids(&options, "personas") {
-        let path = path_from_id(&data_dir, "personas", &id)?;
+        let Some(path) = selected_path(&data_dir, "personas", &id, &mut errors) else {
+            continue;
+        };
         progress.emit_item("Personas", &path, &imported)?;
         let is_media = path
             .extension()
@@ -807,29 +821,25 @@ fn run_st_bulk_import_inner(
         };
         match result {
             Ok(_) => bump_imported(&mut imported, "personas"),
-            Err(error) => errors.push(Value::String(format!(
-                "{}: {}",
-                path.to_string_lossy(),
-                error.message
-            ))),
+            Err(error) => push_path_import_error(&mut errors, &path, error),
         }
     }
 
     for id in selected_ids(&options, "backgrounds") {
-        let path = path_from_id(&data_dir, "backgrounds", &id)?;
+        let Some(path) = selected_path(&data_dir, "backgrounds", &id, &mut errors) else {
+            continue;
+        };
         progress.emit_item("Backgrounds", &path, &imported)?;
         match copy_background_file(state, &path) {
             Ok(_) => bump_imported(&mut imported, "backgrounds"),
-            Err(error) => errors.push(Value::String(format!(
-                "{}: {}",
-                path.to_string_lossy(),
-                error.message
-            ))),
+            Err(error) => push_path_import_error(&mut errors, &path, error),
         }
     }
 
     for id in selected_ids(&options, "chats") {
-        let path = path_from_id(&data_dir, "chats", &id)?;
+        let Some(path) = selected_path(&data_dir, "chats", &id, &mut errors) else {
+            continue;
+        };
         progress.emit_item("Chats", &path, &imported)?;
         let result = fs::read_to_string(&path)
             .map_err(AppError::from)
@@ -838,16 +848,14 @@ fn run_st_bulk_import_inner(
             });
         match result {
             Ok(_) => bump_imported(&mut imported, "chats"),
-            Err(error) => errors.push(Value::String(format!(
-                "{}: {}",
-                path.to_string_lossy(),
-                error.message
-            ))),
+            Err(error) => push_path_import_error(&mut errors, &path, error),
         }
     }
 
     for id in selected_ids(&options, "groupChats") {
-        let path = path_from_id(&data_dir, "groupChats", &id)?;
+        let Some(path) = selected_path(&data_dir, "groupChats", &id, &mut errors) else {
+            continue;
+        };
         progress.emit_item("Group chats", &path, &imported)?;
         let result = fs::read_to_string(&path)
             .map_err(AppError::from)
@@ -856,11 +864,7 @@ fn run_st_bulk_import_inner(
             });
         match result {
             Ok(_) => bump_imported(&mut imported, "groupChats"),
-            Err(error) => errors.push(Value::String(format!(
-                "{}: {}",
-                path.to_string_lossy(),
-                error.message
-            ))),
+            Err(error) => push_path_import_error(&mut errors, &path, error),
         }
     }
 
@@ -903,5 +907,167 @@ pub(super) fn run_st_bulk_import_channel(
                 "code": error.code
             }
         })),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::AppState;
+    use std::path::{Path, PathBuf};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_path(label: &str) -> PathBuf {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "marinara-st-bulk-import-{label}-{}-{nonce}",
+            std::process::id()
+        ))
+    }
+
+    fn write_json(path: &Path, value: &Value) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("fixture parent should be created");
+        }
+        fs::write(
+            path,
+            serde_json::to_vec(value).expect("fixture JSON should serialize"),
+        )
+        .expect("fixture JSON should be written");
+    }
+
+    fn write_bytes(path: &Path, bytes: &[u8]) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("fixture parent should be created");
+        }
+        fs::write(path, bytes).expect("fixture file should be written");
+    }
+
+    fn build_sillytavern_fixture(root: &Path) {
+        let data_dir = root.join("data").join("default-user");
+        for index in 0..80 {
+            write_json(
+                &data_dir
+                    .join("characters")
+                    .join(format!("character-{index:02}.json")),
+                &json!({
+                    "spec": "chara_card_v2",
+                    "data": {
+                        "name": format!("Character {index:02}"),
+                        "description": "Imported test character"
+                    }
+                }),
+            );
+        }
+        for index in 0..48 {
+            write_bytes(
+                &data_dir
+                    .join("backgrounds")
+                    .join(format!("background-{index:02}.png")),
+                b"background-bytes",
+            );
+        }
+        for index in 0..2 {
+            write_bytes(
+                &data_dir
+                    .join("User Avatars")
+                    .join(format!("persona-{index:02}.png")),
+                b"persona-avatar-bytes",
+            );
+        }
+    }
+
+    fn folder_access(root: &Path) -> (String, String) {
+        let listing = directory_listing(root.to_path_buf(), true)
+            .expect("fixture folder should receive an import token");
+        let path = listing
+            .get("path")
+            .and_then(Value::as_str)
+            .expect("listing should include canonical path")
+            .to_string();
+        let token = listing
+            .get("folderToken")
+            .and_then(Value::as_str)
+            .expect("listing should include folder token")
+            .to_string();
+        (path, token)
+    }
+
+    fn scan_ids(scan: &Value, key: &str) -> Vec<String> {
+        scan.get(key)
+            .and_then(Value::as_array)
+            .expect("scan category should be an array")
+            .iter()
+            .filter_map(|item| item.get("id").and_then(Value::as_str))
+            .map(ToOwned::to_owned)
+            .collect()
+    }
+
+    #[test]
+    fn run_st_bulk_import_continues_after_stale_selected_items() {
+        let app_root = temp_path("app");
+        let st_root = temp_path("source");
+        build_sillytavern_fixture(&st_root);
+        let state = AppState::from_data_dir(&app_root, Vec::new())
+            .expect("test app state should initialize");
+        let (folder_path, folder_token) = folder_access(&st_root);
+        let scan = scan_st_folder(json!({
+            "folderPath": folder_path,
+            "folderToken": folder_token,
+        }))
+        .expect("fixture scan should succeed");
+        let mut characters = scan_ids(&scan, "characters");
+        let mut backgrounds = scan_ids(&scan, "backgrounds");
+        let mut personas = scan_ids(&scan, "personas");
+        characters.push("characters:characters/missing.json".to_string());
+        backgrounds.push("backgrounds:backgrounds/missing.png".to_string());
+        personas.push("personas:User Avatars/missing.png".to_string());
+
+        let result = run_st_bulk_import(
+            &state,
+            json!({
+                "folderPath": folder_path,
+                "folderToken": folder_token,
+                "options": {
+                    "characters": characters,
+                    "backgrounds": backgrounds,
+                    "personas": personas,
+                }
+            }),
+        )
+        .expect("stale selected items should not abort the import");
+
+        assert_eq!(result["success"], Value::Bool(true));
+        assert_eq!(result["imported"]["characters"], json!(80));
+        assert_eq!(result["imported"]["backgrounds"], json!(48));
+        assert_eq!(result["imported"]["personas"], json!(2));
+        assert_eq!(result["errors"].as_array().map(Vec::len), Some(3));
+        let personas = state
+            .storage
+            .list("personas")
+            .expect("personas should be readable");
+        let persona = personas.first().expect("a persona should be imported");
+        let expected_asset_url_prefix = if cfg!(windows) {
+            "http://asset.localhost/"
+        } else {
+            "asset://localhost/"
+        };
+        assert!(
+            persona
+                .get("avatarPath")
+                .and_then(Value::as_str)
+                .is_some_and(|value| value.starts_with(expected_asset_url_prefix)),
+            "persona avatars should be stored as managed asset URLs"
+        );
+        assert!(
+            persona.get("avatar").and_then(Value::as_str).is_none(),
+            "persona imports should not duplicate avatar bytes into the avatar field"
+        );
+
+        let _ = fs::remove_dir_all(app_root);
+        let _ = fs::remove_dir_all(st_root);
     }
 }

--- a/src-tauri/src/commands/storage/imports/payloads.rs
+++ b/src-tauri/src/commands/storage/imports/payloads.rs
@@ -254,6 +254,25 @@ pub(super) fn parse_character_file(filename: &str, bytes: &[u8]) -> AppResult<Va
     })
 }
 
+pub(super) fn parse_character_file_from_path(
+    filename: &str,
+    source_path: &Path,
+    bytes: &[u8],
+) -> AppResult<Value> {
+    if filename.to_ascii_lowercase().ends_with(".png") {
+        let mut payload = extract_chara_from_png(bytes)?;
+        let object = payload.as_object_mut().ok_or_else(|| {
+            AppError::invalid_input("Embedded character data must be a JSON object")
+        })?;
+        object.insert(
+            "_avatarFileCopySourcePath".to_string(),
+            Value::String(source_path.to_string_lossy().to_string()),
+        );
+        return Ok(payload);
+    }
+    parse_character_file(filename, bytes)
+}
+
 pub(super) fn import_payload(body: Value) -> AppResult<Value> {
     if body.get("file").is_some() {
         let (_name, _content_type, bytes) = decode_uploaded_file(&body)?;

--- a/src-tauri/src/commands/storage/imports/service.rs
+++ b/src-tauri/src/commands/storage/imports/service.rs
@@ -1,5 +1,6 @@
 use super::super::media_uploads::{
-    decode_image_payload, extension_for_image_mime, safe_filename, unique_file_path,
+    decode_image_payload, extension_for_image_mime, persist_image_bytes, persist_image_file_copy,
+    safe_filename, unique_file_path,
 };
 use super::super::shared::*;
 use super::super::*;
@@ -17,13 +18,13 @@ mod payloads;
 mod st_preset;
 #[path = "timestamps.rs"]
 mod timestamps;
-use std::collections::HashMap;
-use std::path::{Path, PathBuf};
 use access::*;
 use marinara::*;
 use normalization::*;
 use payloads::*;
 use st_preset::*;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 use timestamps::{apply_timestamp_overrides, timestamp_overrides_from_value};
 
 fn create_lorebook_from_payload(
@@ -130,13 +131,20 @@ fn import_st_character_payload(
     let mut record = json!({
         "data": serde_json::to_string(&data)?,
         "comment": data.get("creator_notes").and_then(Value::as_str).unwrap_or(""),
-        "avatarPath": payload
-            .get("_avatarDataUrl")
-            .and_then(Value::as_str)
-            .map(|value| Value::String(value.to_string()))
-            .unwrap_or(Value::Null),
+        "avatarPath": null,
         "format": payload.get("spec").and_then(Value::as_str).unwrap_or("chara_card_v2"),
     });
+    if let Some(avatar) = imported_avatar_reference(state, &payload, filename.as_deref())? {
+        let object = record
+            .as_object_mut()
+            .expect("character import record should be an object");
+        object.insert("avatarPath".to_string(), Value::String(avatar.asset_url));
+        object.insert(
+            "avatarFilePath".to_string(),
+            Value::String(avatar.absolute_path),
+        );
+        object.insert("avatarFilename".to_string(), Value::String(avatar.filename));
+    }
     apply_timestamp_overrides(&mut record, body, &payload);
     let character = state.storage.create("characters", record)?;
 
@@ -187,6 +195,64 @@ fn import_st_character_payload(
             "skipped": embedded.is_some() && !import_embedded
         },
         "lorebook": lorebook_result
+    }))
+}
+
+struct ImportedAvatarReference {
+    asset_url: String,
+    absolute_path: String,
+    filename: String,
+}
+
+fn imported_avatar_reference(
+    state: &AppState,
+    payload: &Value,
+    filename: Option<&str>,
+) -> AppResult<Option<ImportedAvatarReference>> {
+    if let Some(path) = payload
+        .get("_avatarSourcePath")
+        .or_else(|| payload.get("_avatarFileCopySourcePath"))
+        .and_then(Value::as_str)
+        .filter(|path| !path.trim().is_empty())
+    {
+        let source = PathBuf::from(path);
+        let filename_hint = source
+            .file_name()
+            .and_then(|value| value.to_str())
+            .or(filename)
+            .unwrap_or("avatar.png");
+        let stored = persist_image_file_copy(state, "avatars/characters", filename_hint, &source)?;
+        return Ok(Some(ImportedAvatarReference {
+            asset_url: stored.asset_url,
+            absolute_path: stored.absolute_path,
+            filename: stored.filename,
+        }));
+    }
+    let Some(value) = payload.get("_avatarDataUrl").and_then(Value::as_str) else {
+        return Ok(None);
+    };
+    if !value.starts_with("data:image/") {
+        return Ok(None);
+    }
+    let (mime, bytes) = decode_image_payload(value, "avatar")?;
+    let fallback = payload
+        .get("data")
+        .and_then(|data| data.get("name"))
+        .or_else(|| payload.get("name"))
+        .and_then(Value::as_str)
+        .or(filename)
+        .unwrap_or("avatar");
+    let stored = persist_image_bytes(
+        state,
+        "avatars/characters",
+        &safe_filename(fallback),
+        &bytes,
+        &mime,
+    )?;
+    Ok(Some(ImportedAvatarReference {
+        asset_url: stored.asset_url,
+        absolute_path: stored.absolute_path,
+        filename: stored.filename,
     }))
 }
 

--- a/src-tauri/src/commands/storage/media_uploads.rs
+++ b/src-tauri/src/commands/storage/media_uploads.rs
@@ -7,6 +7,12 @@ pub(crate) struct StoredImageUpload {
     pub(crate) filename: String,
 }
 
+pub(crate) struct StoredManagedImage {
+    pub(crate) asset_url: String,
+    pub(crate) absolute_path: String,
+    pub(crate) filename: String,
+}
+
 pub(crate) fn persist_image_upload(
     state: &AppState,
     folder: &str,
@@ -48,6 +54,117 @@ pub(crate) fn persist_image_upload(
             .map(|value| value.to_string_lossy().to_string())
             .unwrap_or(filename),
     })
+}
+
+pub(crate) fn persist_image_file_copy(
+    state: &AppState,
+    folder: &str,
+    filename_hint: &str,
+    source_path: &Path,
+) -> AppResult<StoredManagedImage> {
+    let ext = source_path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .and_then(extension_from_filename)
+        .unwrap_or("png");
+    let dir = state.data_dir.join(folder);
+    fs::create_dir_all(&dir)?;
+    let filename = managed_image_filename(filename_hint, ext);
+    let target = unique_file_path(&dir.join(filename))?;
+    fs::copy(source_path, &target)?;
+    stored_managed_image(target)
+}
+
+pub(crate) fn persist_image_bytes(
+    state: &AppState,
+    folder: &str,
+    filename_hint: &str,
+    bytes: &[u8],
+    mime: &str,
+) -> AppResult<StoredManagedImage> {
+    let ext = extension_for_image_mime(mime).unwrap_or("png");
+    let dir = state.data_dir.join(folder);
+    fs::create_dir_all(&dir)?;
+    let filename = managed_image_filename(filename_hint, ext);
+    let target = unique_file_path(&dir.join(filename))?;
+    fs::write(&target, bytes)?;
+    stored_managed_image(target)
+}
+
+fn stored_managed_image(target: PathBuf) -> AppResult<StoredManagedImage> {
+    let filename = target
+        .file_name()
+        .map(|value| value.to_string_lossy().to_string())
+        .ok_or_else(|| AppError::invalid_input("Managed image path is missing a filename"))?;
+    Ok(StoredManagedImage {
+        asset_url: file_path_asset_url(&target),
+        absolute_path: target.to_string_lossy().to_string(),
+        filename,
+    })
+}
+
+fn managed_image_filename(filename_hint: &str, fallback_ext: &str) -> String {
+    let filename = safe_filename(filename_hint);
+    if Path::new(&filename).extension().is_some() {
+        filename
+    } else {
+        format!("{filename}.{fallback_ext}")
+    }
+}
+
+pub(crate) fn file_path_asset_url(path: &Path) -> String {
+    let encoded = percent_encode_asset_path(&path.to_string_lossy());
+    if cfg!(windows) {
+        format!("http://asset.localhost/{encoded}")
+    } else {
+        format!("asset://localhost/{encoded}")
+    }
+}
+
+fn percent_encode_asset_path(value: &str) -> String {
+    let mut encoded = String::new();
+    for byte in value.as_bytes() {
+        match *byte {
+            b'A'..=b'Z'
+            | b'a'..=b'z'
+            | b'0'..=b'9'
+            | b'-'
+            | b'_'
+            | b'.'
+            | b'!'
+            | b'~'
+            | b'*'
+            | b'\''
+            | b'('
+            | b')' => encoded.push(*byte as char),
+            _ => encoded.push_str(&format!("%{byte:02X}")),
+        }
+    }
+    encoded
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn file_path_asset_url_matches_tauri_encoding_on_windows() {
+        let path = Path::new(r"C:\Users\Mari\My Avatar.png");
+
+        let url = file_path_asset_url(path);
+
+        if cfg!(windows) {
+            assert_eq!(
+                url,
+                "http://asset.localhost/C%3A%5CUsers%5CMari%5CMy%20Avatar.png"
+            );
+        } else {
+            assert_eq!(
+                url,
+                "asset://localhost/C%3A%5CUsers%5CMari%5CMy%20Avatar.png"
+            );
+        }
+    }
 }
 
 pub(crate) fn remove_managed_record_file(


### PR DESCRIPTION
## What?
Harden SillyTavern bulk imports so stale selected items are reported as per-item warnings instead of aborting the whole run. The importer now also stores imported character/persona avatar images as managed local asset files instead of embedding large image data URLs into storage records.

## Why?
Bulk imports from realistic SillyTavern folders can contain many characters, backgrounds, personas, and large PNG character cards. A single missing selected file should not fail the whole import, and large inline avatar payloads can bloat storage enough to make otherwise ordinary imports fragile.

## How?
- Added a selected-item resolver that converts stale or invalid selected IDs into `errors` entries and continues with the remaining import queue.
- Reused the same per-item warning path across characters, lorebooks, presets, personas, backgrounds, chats, and group chats.
- Added managed image persistence helpers for copying image files or decoded image bytes into app-owned avatar folders and returning Tauri asset URLs plus file metadata.
- Added a path-aware character parse path for bulk PNG imports so character card avatars can be copied to managed storage rather than re-encoded into character records.
- Updated persona avatar imports to store managed asset references and avoid duplicating image bytes into the `avatar` field.

## Testing?
- `cargo test --manifest-path "src-tauri/Cargo.toml" run_st_bulk_import_continues_after_stale_selected_items`
- `cargo test --manifest-path "src-tauri/Cargo.toml" file_path_asset_url_matches_tauri_encoding_on_windows`
- `cargo check --manifest-path "src-tauri/Cargo.toml"`

## Screenshots (optional)
Not applicable; this is Rust storage/import behavior with no UI changes.

## Anything Else?
A live UI import against a full external SillyTavern folder was not run in this PR. The regression fixture covers the reported shape: many selected characters/backgrounds/personas plus stale selected items and managed avatar storage.