### PR TITLE
Fix bulk sprite folder imports

### DIFF
--- a/src-tauri/src/commands/storage/commands/media.rs
+++ b/src-tauri/src/commands/storage/commands/media.rs
@@ -50,6 +50,15 @@ pub fn sprite_upload(
 }
 
 #[tauri::command]
+pub fn sprite_upload_bulk(
+    state: State<'_, AppState>,
+    character_id: String,
+    body: Value,
+) -> Result<Value, AppError> {
+    sprites::upload_sprites(&state, &character_id, body)
+}
+
+#[tauri::command]
 pub fn sprite_delete(
     state: State<'_, AppState>,
     character_id: String,

--- a/src-tauri/src/commands/storage/sprites.rs
+++ b/src-tauri/src/commands/storage/sprites.rs
@@ -303,6 +303,63 @@ pub(crate) fn upload_sprite(state: &AppState, character_id: &str, body: Value) -
     sprite_info_from_path(&path)
 }
 
+pub(crate) fn upload_sprites(state: &AppState, character_id: &str, body: Value) -> AppResult<Value> {
+    validate_safe_segment(character_id, "character ID")?;
+    let uploads = body
+        .get("sprites")
+        .and_then(Value::as_array)
+        .filter(|items| !items.is_empty())
+        .ok_or_else(|| AppError::invalid_input("At least one sprite is required"))?;
+    let dir = sprites_dir(state, character_id);
+    fs::create_dir_all(&dir)?;
+    let mut imported = 0usize;
+    let mut failed = Vec::new();
+
+    for item in uploads {
+        let raw_expression = item.get("expression").and_then(Value::as_str).unwrap_or("");
+        let expression = normalize_sprite_expression(raw_expression);
+        if expression.is_empty() {
+            failed.push(json!({
+                "expression": raw_expression,
+                "error": "Expression label is required"
+            }));
+            continue;
+        }
+        let Some(image) = item.get("image").and_then(Value::as_str) else {
+            failed.push(json!({
+                "expression": expression,
+                "error": "No image data provided"
+            }));
+            continue;
+        };
+        let (bytes, ext) = match decode_image_value(image) {
+            Ok(value) => value,
+            Err(error) => {
+                failed.push(json!({
+                    "expression": expression,
+                    "error": error.message
+                }));
+                continue;
+            }
+        };
+        let filename = format!("{expression}.{ext}");
+        match fs::write(dir.join(&filename), bytes) {
+            Ok(_) => imported += 1,
+            Err(error) => failed.push(json!({
+                "expression": expression,
+                "filename": filename,
+                "error": error.to_string()
+            })),
+        }
+    }
+
+    Ok(json!({
+        "imported": imported,
+        "failed": failed,
+        "sprites": list_sprites(state, character_id)?
+    }))
+}
+
 pub(crate) fn clean_saved_sprites(
     state: &AppState,
     character_id: &str,
@@ -1938,6 +1995,76 @@ fn validate_safe_segment(value: &str, label: &str) -> AppResult<()> {
 
 fn image_error(error: image::ImageError) -> AppError {
     AppError::new("image_processing_error", error.to_string())
+}
+
+#[cfg(test)]
+mod sprite_upload_tests {
+    use super::*;
+    use std::fs;
+
+    fn test_state(label: &str) -> (AppState, PathBuf) {
+        let root = env::temp_dir().join(format!("marinara-sprite-upload-{label}-{}", now_millis()));
+        let data_dir = root.join("data");
+        let state = AppState::from_data_dir_with_resource_dir(data_dir, Vec::new(), None)
+            .expect("test state should initialize");
+        (state, root)
+    }
+
+    #[test]
+    fn bulk_upload_reports_partial_failures_and_returns_refreshed_list() {
+        let (state, root) = test_state("bulk");
+        let result = upload_sprites(
+            &state,
+            "character-1",
+            json!({
+                "sprites": [
+                    { "expression": "Happy Face", "image": "data:image/png;base64,aGVsbG8=" },
+                    { "expression": "missing-image" },
+                    { "expression": "bad-image", "image": "not base64!" }
+                ]
+            }),
+        )
+        .expect("bulk upload should keep partial failures in the result");
+
+        assert_eq!(result.get("imported").and_then(Value::as_u64), Some(1));
+        assert_eq!(
+            result
+                .get("failed")
+                .and_then(Value::as_array)
+                .map(Vec::len),
+            Some(2)
+        );
+        let sprites = result
+            .get("sprites")
+            .and_then(Value::as_array)
+            .expect("sprites list should be returned");
+        assert_eq!(sprites.len(), 1);
+        assert_eq!(
+            sprites[0].get("expression").and_then(Value::as_str),
+            Some("happy_face")
+        );
+        assert_eq!(
+            sprites[0].get("filename").and_then(Value::as_str),
+            Some("happy_face.png")
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn bulk_upload_rejects_unsafe_character_id() {
+        let (state, root) = test_state("unsafe-id");
+        let error = upload_sprites(
+            &state,
+            "../character-1",
+            json!({ "sprites": [{ "expression": "happy", "image": "data:image/png;base64,aGVsbG8=" }] }),
+        )
+        .expect_err("unsafe character IDs should be rejected");
+
+        assert_eq!(error.code, "invalid_input");
+
+        let _ = fs::remove_dir_all(root);
+    }
 }
 
 #[cfg(test)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -173,6 +173,7 @@ pub fn run() {
             storage_commands::media_commands::sprite_cleanup,
             storage_commands::media_commands::sprite_list,
             storage_commands::media_commands::sprite_upload,
+            storage_commands::media_commands::sprite_upload_bulk,
             storage_commands::media_commands::sprite_delete,
             storage_commands::media_commands::sprite_cleanup_saved,
             storage_commands::media_commands::sprite_cleanup_restore,

--- a/src/features/catalog/characters/components/CharacterEditor.tsx
+++ b/src/features/catalog/characters/components/CharacterEditor.tsx
@@ -2147,13 +2147,13 @@ function SpritesTab({
   const cleanupEngineReason =
     spriteCapabilities?.cleanupEngine?.reason ?? "Sprite cleanup is not available.";
 
-  const normalizeExpressionForCategory = (raw: string) => {
+  const normalizeExpressionForCategory = (raw: string, forCategory: SpriteCategory = category) => {
     const cleaned = raw
       .trim()
       .toLowerCase()
       .replace(/[^a-z0-9_-]/g, "_");
     if (!cleaned) return "";
-    if (category === "full-body") {
+    if (forCategory === "full-body") {
       return cleaned.startsWith("full_") ? cleaned : `full_${cleaned}`;
     }
     return cleaned.replace(/^full_/, "");
@@ -2208,13 +2208,14 @@ function SpritesTab({
     setFolderProgress({ done: 0, total: imageFiles.length });
     try {
       const uploads: Array<{ expression: string; image: string }> = [];
+      const folderCategory = category;
       let skipped = 0;
 
       for (let i = 0; i < imageFiles.length; i++) {
         const file = imageFiles[i]!;
         // Derive expression name from filename (strip extension, lowercase, sanitize)
         const expression = file.name.replace(/\.[^.]+$/, "").trim();
-        const normalized = normalizeExpressionForCategory(expression);
+        const normalized = normalizeExpressionForCategory(expression, folderCategory);
         if (!normalized) {
           skipped += 1;
           setFolderProgress({ done: i + 1, total: imageFiles.length });

--- a/src/features/catalog/characters/components/CharacterEditor.tsx
+++ b/src/features/catalog/characters/components/CharacterEditor.tsx
@@ -20,6 +20,7 @@ import {
   useUploadCharacterGalleryImage,
   useDeleteCharacterGalleryImage,
   useUploadSprite,
+  useUploadSprites,
   useDeleteSprite,
   useCleanupSavedSprites,
   useRestoreSpriteCleanupPoint,
@@ -2101,6 +2102,7 @@ function SpritesTab({
   const { data: sprites, isLoading } = useCharacterSprites(characterId);
   const { data: spriteCapabilities } = useSpriteCapabilities();
   const uploadSprite = useUploadSprite();
+  const uploadSprites = useUploadSprites();
   const deleteSprite = useDeleteSprite();
   const cleanupSavedSprites = useCleanupSavedSprites();
   const restoreSpriteCleanupPoint = useRestoreSpriteCleanupPoint();
@@ -2204,30 +2206,55 @@ function SpritesTab({
     if (imageFiles.length === 0) return;
 
     setFolderProgress({ done: 0, total: imageFiles.length });
+    try {
+      const uploads: Array<{ expression: string; image: string }> = [];
+      let skipped = 0;
 
-    for (let i = 0; i < imageFiles.length; i++) {
-      const file = imageFiles[i]!;
-      // Derive expression name from filename (strip extension, lowercase, sanitize)
-      const expression = file.name.replace(/\.[^.]+$/, "").trim();
-      const normalized = normalizeExpressionForCategory(expression);
-      if (!normalized) continue;
+      for (let i = 0; i < imageFiles.length; i++) {
+        const file = imageFiles[i]!;
+        // Derive expression name from filename (strip extension, lowercase, sanitize)
+        const expression = file.name.replace(/\.[^.]+$/, "").trim();
+        const normalized = normalizeExpressionForCategory(expression);
+        if (!normalized) {
+          skipped += 1;
+          setFolderProgress({ done: i + 1, total: imageFiles.length });
+          continue;
+        }
 
-      const dataUrl = await new Promise<string>((resolve) => {
-        const reader = new FileReader();
-        reader.onload = () => resolve(reader.result as string);
-        reader.readAsDataURL(file);
-      });
+        const dataUrl = await new Promise<string>((resolve, reject) => {
+          const reader = new FileReader();
+          reader.onload = () => resolve(reader.result as string);
+          reader.onerror = () => reject(reader.error ?? new Error(`Failed to read ${file.name}`));
+          reader.readAsDataURL(file);
+        }).catch(() => {
+          skipped += 1;
+          return null;
+        });
 
-      try {
-        await uploadSprite.mutateAsync({ characterId, expression: normalized, image: dataUrl });
-      } catch {
-        // Skip failed uploads, continue with the rest
+        if (dataUrl) {
+          uploads.push({ expression: normalized, image: dataUrl });
+        }
+        setFolderProgress({ done: i + 1, total: imageFiles.length });
       }
-      setFolderProgress({ done: i + 1, total: imageFiles.length });
-    }
 
-    setFolderProgress(null);
-    e.target.value = "";
+      if (uploads.length > 0) {
+        const result = await uploadSprites.mutateAsync({ characterId, sprites: uploads });
+        if (result.failed.length > 0 || skipped > 0) {
+          toast.warning(
+            `${result.failed.length + skipped} sprite${result.failed.length + skipped === 1 ? "" : "s"} could not be imported.`,
+          );
+        } else {
+          toast.success(`Imported ${result.imported} sprite${result.imported === 1 ? "" : "s"}.`);
+        }
+      } else if (skipped > 0) {
+        toast.error("No sprites could be imported.");
+      }
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to import sprites.");
+    } finally {
+      setFolderProgress(null);
+      e.target.value = "";
+    }
   };
 
   const handleDeleteSingleSprite = useCallback(async () => {

--- a/src/features/catalog/characters/hooks/use-characters.ts
+++ b/src/features/catalog/characters/hooks/use-characters.ts
@@ -130,6 +130,17 @@ export interface SpriteInfo {
   url: string;
 }
 
+export interface SpriteUploadItem {
+  expression: string;
+  image: string;
+}
+
+export interface SpriteBulkUploadResult {
+  imported: number;
+  failed: Array<{ expression: string; filename?: string; error: string }>;
+  sprites: SpriteInfo[];
+}
+
 export interface SpriteCleanupResult {
   processed: number;
   failed: Array<{ expression: string; error: string }>;
@@ -184,6 +195,17 @@ export function useUploadSprite() {
       spriteApi.upload<SpriteInfo>(characterId, { expression, image }),
     onSuccess: (_data, variables) => {
       qc.invalidateQueries({ queryKey: spriteKeys.list(variables.characterId) });
+    },
+  });
+}
+
+export function useUploadSprites() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ characterId, sprites }: { characterId: string; sprites: SpriteUploadItem[] }) =>
+      spriteApi.bulkUpload<SpriteBulkUploadResult>(characterId, { sprites }),
+    onSuccess: (data, variables) => {
+      qc.setQueryData(spriteKeys.list(variables.characterId), data.sprites);
     },
   });
 }

--- a/src/features/catalog/personas/components/PersonaEditor.tsx
+++ b/src/features/catalog/personas/components/PersonaEditor.tsx
@@ -718,13 +718,13 @@ function PersonaSpritesTab({
   const cleanupEngineReason =
     spriteCapabilities?.cleanupEngine?.reason ?? "Sprite cleanup is not available.";
 
-  const normalizeExpressionForCategory = (raw: string) => {
+  const normalizeExpressionForCategory = (raw: string, forCategory: SpriteCategory = category) => {
     const cleaned = raw
       .trim()
       .toLowerCase()
       .replace(/[^a-z0-9_-]/g, "_");
     if (!cleaned) return "";
-    if (category === "full-body") {
+    if (forCategory === "full-body") {
       return cleaned.startsWith("full_") ? cleaned : `full_${cleaned}`;
     }
     return cleaned.replace(/^full_/, "");
@@ -771,11 +771,12 @@ function PersonaSpritesTab({
     setFolderProgress({ done: 0, total: imageFiles.length });
     try {
       const uploads: Array<{ expression: string; image: string }> = [];
+      const folderCategory = category;
       let skipped = 0;
       for (let i = 0; i < imageFiles.length; i++) {
         const file = imageFiles[i]!;
         const expression = file.name.replace(/\.[^.]+$/, "").trim();
-        const normalized = normalizeExpressionForCategory(expression);
+        const normalized = normalizeExpressionForCategory(expression, folderCategory);
         if (!normalized) {
           skipped += 1;
           setFolderProgress({ done: i + 1, total: imageFiles.length });

--- a/src/features/catalog/personas/components/PersonaEditor.tsx
+++ b/src/features/catalog/personas/components/PersonaEditor.tsx
@@ -53,6 +53,7 @@ import {
 import {
   useCharacterSprites,
   useUploadSprite,
+  useUploadSprites,
   useDeleteSprite,
   useCleanupSavedSprites,
   useRestoreSpriteCleanupPoint,
@@ -672,6 +673,7 @@ function PersonaSpritesTab({
   const { data: sprites, isLoading } = useCharacterSprites(personaId);
   const { data: spriteCapabilities } = useSpriteCapabilities();
   const uploadSprite = useUploadSprite();
+  const uploadSprites = useUploadSprites();
   const deleteSprite = useDeleteSprite();
   const cleanupSavedSprites = useCleanupSavedSprites();
   const restoreSpriteCleanupPoint = useRestoreSpriteCleanupPoint();
@@ -767,25 +769,50 @@ function PersonaSpritesTab({
     if (imageFiles.length === 0) return;
 
     setFolderProgress({ done: 0, total: imageFiles.length });
-    for (let i = 0; i < imageFiles.length; i++) {
-      const file = imageFiles[i]!;
-      const expression = file.name.replace(/\.[^.]+$/, "").trim();
-      const normalized = normalizeExpressionForCategory(expression);
-      if (!normalized) continue;
-      const dataUrl = await new Promise<string>((resolve) => {
-        const reader = new FileReader();
-        reader.onload = () => resolve(reader.result as string);
-        reader.readAsDataURL(file);
-      });
-      try {
-        await uploadSprite.mutateAsync({ characterId: personaId, expression: normalized, image: dataUrl });
-      } catch {
-        /* skip */
+    try {
+      const uploads: Array<{ expression: string; image: string }> = [];
+      let skipped = 0;
+      for (let i = 0; i < imageFiles.length; i++) {
+        const file = imageFiles[i]!;
+        const expression = file.name.replace(/\.[^.]+$/, "").trim();
+        const normalized = normalizeExpressionForCategory(expression);
+        if (!normalized) {
+          skipped += 1;
+          setFolderProgress({ done: i + 1, total: imageFiles.length });
+          continue;
+        }
+        const dataUrl = await new Promise<string>((resolve, reject) => {
+          const reader = new FileReader();
+          reader.onload = () => resolve(reader.result as string);
+          reader.onerror = () => reject(reader.error ?? new Error(`Failed to read ${file.name}`));
+          reader.readAsDataURL(file);
+        }).catch(() => {
+          skipped += 1;
+          return null;
+        });
+        if (dataUrl) {
+          uploads.push({ expression: normalized, image: dataUrl });
+        }
+        setFolderProgress({ done: i + 1, total: imageFiles.length });
       }
-      setFolderProgress({ done: i + 1, total: imageFiles.length });
+      if (uploads.length > 0) {
+        const result = await uploadSprites.mutateAsync({ characterId: personaId, sprites: uploads });
+        if (result.failed.length > 0 || skipped > 0) {
+          toast.warning(
+            `${result.failed.length + skipped} sprite${result.failed.length + skipped === 1 ? "" : "s"} could not be imported.`,
+          );
+        } else {
+          toast.success(`Imported ${result.imported} sprite${result.imported === 1 ? "" : "s"}.`);
+        }
+      } else if (skipped > 0) {
+        toast.error("No sprites could be imported.");
+      }
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to import sprites.");
+    } finally {
+      setFolderProgress(null);
+      e.target.value = "";
     }
-    setFolderProgress(null);
-    e.target.value = "";
   };
 
   const handleDeleteSingleSprite = useCallback(async () => {

--- a/src/shared/api/image-generation-api.ts
+++ b/src/shared/api/image-generation-api.ts
@@ -11,6 +11,8 @@ export const spriteApi = {
   list: <T = unknown>(characterId: string) => invokeTauri<T>("sprite_list", { characterId }),
   upload: <T = unknown>(characterId: string, body: Record<string, unknown>) =>
     invokeTauri<T>("sprite_upload", { characterId, body }),
+  bulkUpload: <T = unknown>(characterId: string, body: Record<string, unknown>) =>
+    invokeTauri<T>("sprite_upload_bulk", { characterId, body }),
   delete: <T = unknown>(characterId: string, expression: string) =>
     invokeTauri<T>("sprite_delete", { characterId, expression }),
   cleanupSaved: <T = unknown>(characterId: string, body: Record<string, unknown>) =>


### PR DESCRIPTION
## What?

Fixes #1185.

Adds a bulk sprite upload path for folder imports:

- adds `sprite_upload_bulk` in Tauri storage commands
- adds `spriteApi.bulkUpload` and `useUploadSprites`
- updates character and persona folder uploads to prepare the selected files, call the bulk mutation once, and update the sprite query cache from the returned list
- keeps the existing single-sprite upload path and its normal invalidation behavior unchanged

## Why?

Folder sprite imports were using the single-upload mutation inside the file loop. That meant every successful file upload invalidated and refetched the full sprite list while the folder was still importing, and the Rust single-upload response also read the saved file back for each item.

## How?

The new Rust bulk helper validates the character/persona sprite ID, writes each valid image payload, records per-file failures without aborting the whole batch, then returns one final `list_sprites` result. The editors use that final list to set the `spriteKeys.list(characterId)` cache once instead of invalidating it after every file.

Out of scope for this PR:

- native folder-token import with Rust-side folder scanning/progress events
- changing `sprite_list` away from base64 data URLs
- changing runtime sprite consumers outside the editor upload cache path

## Testing?

Machine verification:

- `node scratch\issue-1185-bulk-sprite-proof.mjs` passed
- `cargo test --manifest-path src-tauri/Cargo.toml sprite_upload_tests` passed
- `pnpm check` passed
- `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json` passed
- Bunny pass completed before opening this PR

Proof report:

- Gist: https://gist.github.com/cha1latte/5b636d9e399aeb8c28295905847024f3
- Raw verification output: https://gist.githubusercontent.com/cha1latte/5b636d9e399aeb8c28295905847024f3/raw/f2a82c384005483639ab0baa2686b05ada789fd6/issue-1185-verification-output.json

Manual verification:

- Runtime timing with real 10/50/100+ sprite folders in the Tauri app would quantify the performance improvement. This PR does not claim a numeric speedup; it verifies the repeated per-file list refresh path is removed.

## Screenshots

N/A. This is a storage/cache behavior fix. The proof gist above includes the raw command output from the verification run.

## Anything Else?

Targets `refactor` because the issue references the refactor-branch source layout and the request was to ship this to refactor.
