### PR TITLE
Fix bare speaker tag rendering

### DIFF
--- a/src/features/modes/shared/chat-ui/components/ChatMessage.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatMessage.tsx
@@ -169,8 +169,8 @@ interface ChatMessageProps {
 /** Regex to match a plain image URL as the entire content. */
 const IMAGE_URL_RE = /^https?:\/\/\S+\.(?:gif|png|jpe?g|webp)(?:\?[^\s]*)?$/i;
 
-/** Regex to match <speaker="name">dialogue</speaker> tags. */
-const SPEAKER_TAG_RE = /<speaker="([^"]*)">([\s\S]*?)<\/speaker>/g;
+/** Regex to match <speaker>dialogue</speaker> and <speaker="name">dialogue</speaker> tags. */
+const SPEAKER_TAG_RE = /<speaker(?:="([^"]*)")?>([\s\S]*?)<\/speaker>/g;
 const INLINE_MARKDOWN_CONTAINER_RE =
   /\*\*\*[\s\S]+?\*\*\*|\*\*[\s\S]+?\*\*|__[\s\S]+?__|(?<!\*)\*(?!\*)[\s\S]+?(?<!\*)\*(?!\*)|==[\s\S]+?==|~~[\s\S]+?~~|(?<![_\w])_[^_]+?_(?![_\w])/g;
 
@@ -203,9 +203,9 @@ function renderWithSpeakerTags(
     if (match.index > lastIndex) {
       nodes.push(...renderLine(text.slice(lastIndex, match.index), defaultDialogueColor));
     }
-    const speakerName = match[1]!;
+    const speakerName = match[1]?.trim() ?? "";
     const dialogue = match[2]!;
-    const speakerColor = speakerColorMap?.get(speakerName) ?? defaultDialogueColor;
+    const speakerColor = speakerName ? (speakerColorMap?.get(speakerName) ?? defaultDialogueColor) : defaultDialogueColor;
     // Render the dialogue content (without the tags) using the speaker's color
     nodes.push(<span key={`s${key++}`}>{renderLine(dialogue, speakerColor)}</span>);
     lastIndex = match.index + match[0].length;
@@ -497,7 +497,8 @@ function renderContent(
   // For HTML content, replace speaker tags with color-annotated spans (preserves per-character colors)
   const stripped = speakerColorMap
     ? normalized.replace(SPEAKER_TAG_RE, (_, name, dialogue) => {
-        const color = speakerColorMap.get(name as string);
+        const speakerName = typeof name === "string" ? name.trim() : "";
+        const color = speakerName ? speakerColorMap.get(speakerName) : undefined;
         return color ? `<span data-spk="${color}">${dialogue as string}</span>` : (dialogue as string);
       })
     : normalized.replace(SPEAKER_TAG_RE, "$2");


### PR DESCRIPTION
## What?

Fixes bare `<speaker>...</speaker>` wrappers rendering as literal text in the refactor chat message UI.

The shared `ChatMessage` speaker-tag renderer now accepts both bare and named speaker wrappers, so bare tags are stripped consistently while named speaker coloring still works.

Fixes #1126

## Why?

The pre-HTML detection path already treated the speaker name as optional, but the actual plain-text renderer only matched `<speaker="Name">...</speaker>`. That mismatch let existing or newly generated bare speaker tags leak into chat bubbles.

## How?

- Updated the shared speaker tag regex to match `<speaker>...</speaker>` and `<speaker="Name">...</speaker>`.
- Treated unnamed speaker tags as default-color dialogue.
- Kept named speaker color lookup intact for group/merged chat rendering.

## Machine Verification

- `pnpm exec vitest run --config scratch/vitest.issue-1126.config.ts`
  - Before fix on clean `upstream/refactor`: bare tag cases failed and leaked literal markup.
  - After fix: 5/5 passed.
  - Covered single bare wrapper, named wrapper regression, multiple bare wrappers, mixed bare/named wrappers, and negative control `<speakerish>...</speakerish>`.
- `pnpm check` passed:
  - architecture check
  - frontend typecheck
  - Rust `cargo check`
  - docs check
- `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json` passed.
- Bunny review passed before PR open.

## Evidence

![Issue 1126 before/after proof](https://gist.githubusercontent.com/cha1latte/e10fd7fcaa941533e64fce067277d0e6/raw/issue-1126-proof.svg)

Evidence URL verified with `curl.exe -I` returning `200 OK`.

## Manual Verification

None required for the core claim. The changed path was exercised directly with a component render harness against `ChatMessage`.

## Notes

Targeting `refactor` because this issue was requested for the refactor lane and the relevant renderer has moved from `packages/client/...` to `src/features/modes/shared/chat-ui/components/ChatMessage.tsx`.
