### PR TITLE
Fix Spotify auth browser launch

### DIFF
--- a/src-tauri/src/commands/storage/commands/integrations.rs
+++ b/src-tauri/src/commands/storage/commands/integrations.rs
@@ -99,7 +99,15 @@ pub async fn spotify_authorize(
     state: State<'_, AppState>,
     input: Value,
 ) -> Result<Value, AppError> {
-    spotify_direct(state, "POST", &["authorize"], input).await
+    let response = spotify_direct(state, "POST", &["authorize"], input).await?;
+    let auth_url = response
+        .get("authUrl")
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| AppError::new("spotify_authorize_failed", "Authorize request did not return an auth URL"))?;
+    tauri_plugin_opener::open_url(auth_url, None::<&str>)
+        .map_err(|error| AppError::new("spotify_authorize_open_failed", error.to_string()))?;
+    Ok(response)
 }
 
 #[tauri::command]

--- a/src/features/catalog/agents/components/AgentEditor.tsx
+++ b/src/features/catalog/agents/components/AgentEditor.tsx
@@ -1346,7 +1346,6 @@ export function AgentEditor() {
                         if (!data.authUrl) {
                           throw new Error(data.error ?? "Authorize request did not return an auth URL");
                         }
-                        window.open(data.authUrl, "_blank", "width=500,height=700");
                         // Clear any existing poll before starting a new one
                         if (spotifyPollRef.current) clearInterval(spotifyPollRef.current);
                         if (spotifyTimeoutRef.current) clearTimeout(spotifyTimeoutRef.current);


### PR DESCRIPTION
## Linked issue

Closes #1204

## Why this change

- Spotify OAuth generated an authorization URL, but the Agent Editor tried to open it with `window.open` after awaiting the Tauri command. In the Tauri desktop flow this no longer reliably opened an external browser, leaving users unable to authenticate.

## What changed

- Moved the browser-opening side effect into the embedded `spotify_authorize` Tauri command using `tauri_plugin_opener::open_url`.
- Kept the React feature path on the typed `spotifyApi.authorize` wrapper and removed the post-await `window.open` call.
- Preserved the returned `authUrl` contract so the caller can still validate that authorization started.

## Refactor impact

Primary owner:

Rust storage/integrations Tauri command boundary.

Impact areas reviewed:

- Spotify OAuth settings flow in `AgentEditor`.
- Shared Spotify API wrapper.
- Embedded Tauri integration command wrapper.
- Spotify Rust integration auth URL generation and callback listener.
- Remote runtime command allowlist.

Boundary notes:

- Feature code still calls `src/shared/api/integration-utility-api.ts`.
- No raw `invokeTauri` call was added to React feature code.
- Native opener behavior now lives at the embedded Tauri boundary.
- The shared Spotify helper still builds auth state and the OAuth URL.
- `spotify_authorize` is not remote-runtime allowlisted, so this remains desktop-only OAuth behavior.

Pressure points touched:

- Tauri opener behavior.
- Spotify OAuth.
- No `ModeSurface`, `GameSurface`, shared mode UI, command registration, or import modules touched.

## Validation

- [x] `pnpm check` passes locally
- [x] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [x] `pnpm check:architecture` passes locally
- [x] `pnpm check:docs` passes locally
- [x] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [x] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Ran `pnpm check` locally.
- Ran `pnpm check:architecture` locally.
- Manually restarted the Tauri app, entered a valid Spotify client ID, clicked the Spotify connect/authenticate button, confirmed the browser opened, completed Spotify OAuth, and confirmed connected-account playlists loaded.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

Manual Tauri verification completed. No screenshot added because the visible result is an external Spotify OAuth browser launch and connected-account state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in Spotify authorization flow with better error messages for failed authorization attempts.

* **Refactor**
  * Streamlined Spotify authorization flow by moving URL handling from client to backend for improved reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1205?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->