### PR TITLE
Fix dangling connection deletes

### DIFF
--- a/packages/server/src/routes/connections.routes.ts
+++ b/packages/server/src/routes/connections.routes.ts
@@ -10,8 +10,7 @@ import { buildGoogleVertexModelUrl, googleAuthHeadersForVertex } from "../servic
 import { resolveConnectionImageDefaults } from "../services/image/image-generation-defaults.js";
 import {
   deleteConnectionAndClearReferences,
-  hasConnectionReferences,
-  listConnectionReferences,
+  deleteConnectionIfUnreferenced,
 } from "../services/storage/connection-references.storage.js";
 import { isImageLocalUrlsEnabled, isProviderLocalUrlsEnabled } from "../config/runtime-config.js";
 import { logDebugOverride } from "../lib/logger.js";
@@ -226,15 +225,6 @@ export async function connectionsRoutes(app: FastifyInstance) {
 
   app.delete<{ Params: { id: string }; Querystring: { force?: string | boolean } }>("/:id", async (req, reply) => {
     const force = req.query.force === true || req.query.force === "true";
-    const references = await listConnectionReferences(app.db, req.params.id);
-
-    if (hasConnectionReferences(references) && !force) {
-      return reply.status(409).send({
-        error: "connection_in_use",
-        message: "Connection is still used by agents or chats. Repoint them first, or delete with force=true.",
-        references,
-      });
-    }
 
     if (force) {
       const clearedReferences = await deleteConnectionAndClearReferences(app.db, req.params.id);
@@ -246,7 +236,15 @@ export async function connectionsRoutes(app: FastifyInstance) {
       });
     }
 
-    await storage.remove(req.params.id);
+    const result = await deleteConnectionIfUnreferenced(app.db, req.params.id);
+    if (!result.deleted) {
+      return reply.status(409).send({
+        error: "connection_in_use",
+        message: "Connection is still used by agents or chats. Repoint them first, or delete with force=true.",
+        references: result.references,
+      });
+    }
+
     return reply.status(204).send();
   });
 

--- a/packages/server/src/routes/connections.routes.ts
+++ b/packages/server/src/routes/connections.routes.ts
@@ -8,6 +8,11 @@ import { createLLMProvider } from "../services/llm/provider-registry.js";
 import { fetchOpenAIChatGPTModels, getOpenAIChatGPTAuth } from "../services/llm/openai-chatgpt-auth.js";
 import { buildGoogleVertexModelUrl, googleAuthHeadersForVertex } from "../services/llm/providers/google.provider.js";
 import { resolveConnectionImageDefaults } from "../services/image/image-generation-defaults.js";
+import {
+  deleteConnectionAndClearReferences,
+  hasConnectionReferences,
+  listConnectionReferences,
+} from "../services/storage/connection-references.storage.js";
 import { isImageLocalUrlsEnabled, isProviderLocalUrlsEnabled } from "../config/runtime-config.js";
 import { logDebugOverride } from "../lib/logger.js";
 import { normalizeLoopbackUrl, safeFetch } from "../utils/security.js";
@@ -219,7 +224,28 @@ export async function connectionsRoutes(app: FastifyInstance) {
     return { success: true };
   });
 
-  app.delete<{ Params: { id: string } }>("/:id", async (req, reply) => {
+  app.delete<{ Params: { id: string }; Querystring: { force?: string | boolean } }>("/:id", async (req, reply) => {
+    const force = req.query.force === true || req.query.force === "true";
+    const references = await listConnectionReferences(app.db, req.params.id);
+
+    if (hasConnectionReferences(references) && !force) {
+      return reply.status(409).send({
+        error: "connection_in_use",
+        message: "Connection is still used by agents or chats. Repoint them first, or delete with force=true.",
+        references,
+      });
+    }
+
+    if (force) {
+      const clearedReferences = await deleteConnectionAndClearReferences(app.db, req.params.id);
+      return reply.send({
+        success: true,
+        warning:
+          "Connection deleted. Agents and chats that referenced it were cleared and will use their configured fallback connection.",
+        clearedReferences,
+      });
+    }
+
     await storage.remove(req.params.id);
     return reply.status(204).send();
   });

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -3967,7 +3967,7 @@ export async function generateRoutes(app: FastifyInstance) {
 
         const agentConnectionWarnings: AgentConnectionWarning[] = [];
         const skippedLocalSidecarAgents: string[] = [];
-        const danglingConnectionAgents: string[] = [];
+        const danglingConnectionAgents = new Set<string>();
         const defaultAgentConnectionAgents: string[] = [];
         let responseOrchestratorSelectorAgent: ResolvedAgent | null = null;
         let responseOrchestratorSelectorUnavailable = false;
@@ -4010,7 +4010,7 @@ export async function generateRoutes(app: FastifyInstance) {
             } else {
               const agentConn = await connections.getWithKey(effectiveConnectionId);
               if (!agentConn) {
-                danglingConnectionAgents.push(cfg.name ?? cfg.type);
+                danglingConnectionAgents.add(cfg.name ?? cfg.type);
                 logger.warn(
                   "[generate] Skipping agent %s for chat %s because connection %s no longer exists",
                   cfg.type,
@@ -4055,9 +4055,6 @@ export async function generateRoutes(app: FastifyInstance) {
         }
         if (skippedLocalSidecarAgents.length > 0) {
           agentConnectionWarnings.push(buildLocalSidecarUnavailableWarning(skippedLocalSidecarAgents));
-        }
-        if (danglingConnectionAgents.length > 0) {
-          agentConnectionWarnings.push(buildDanglingAgentConnectionWarning(danglingConnectionAgents));
         }
 
         // Built-in agents with no DB row → use defaults only if explicitly in the per-chat list
@@ -4168,7 +4165,7 @@ export async function generateRoutes(app: FastifyInstance) {
                     const agentConn = await connections.getWithKey(effectiveConnectionId);
                     if (!agentConn) {
                       responseOrchestratorSelectorUnavailable = true;
-                      agentConnectionWarnings.push(buildDanglingAgentConnectionWarning(["Response Orchestrator"]));
+                      danglingConnectionAgents.add("Response Orchestrator");
                       logger.warn(
                         "[group-smart] Skipping Response Orchestrator for chat %s because connection %s no longer exists",
                         input.chatId,
@@ -4217,6 +4214,9 @@ export async function generateRoutes(app: FastifyInstance) {
         }
 
         if (defaultAgentConn && defaultAgentConnectionAgents.length > 0) {
+          if (danglingConnectionAgents.size > 0) {
+            agentConnectionWarnings.push(buildDanglingAgentConnectionWarning(Array.from(danglingConnectionAgents)));
+          }
           agentConnectionWarnings.push(
             buildDefaultAgentConnectionWarning({
               agentNames: defaultAgentConnectionAgents,
@@ -4224,6 +4224,8 @@ export async function generateRoutes(app: FastifyInstance) {
               model: defaultAgentConn.model,
             }),
           );
+        } else if (danglingConnectionAgents.size > 0) {
+          agentConnectionWarnings.push(buildDanglingAgentConnectionWarning(Array.from(danglingConnectionAgents)));
         }
 
         logger.info(

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -206,6 +206,7 @@ import { fingerprintChatSummary } from "../services/prompt/chat-summary-fingerpr
 import { sendSseEvent, startSseReply, trySendSseEvent } from "./generate/sse.js";
 import {
   buildDefaultAgentConnectionWarning,
+  buildDanglingAgentConnectionWarning,
   buildLocalSidecarUnavailableWarning,
   isLocalSidecarConnectionId,
   resolveAgentConnectionId,
@@ -3966,6 +3967,7 @@ export async function generateRoutes(app: FastifyInstance) {
 
         const agentConnectionWarnings: AgentConnectionWarning[] = [];
         const skippedLocalSidecarAgents: string[] = [];
+        const danglingConnectionAgents: string[] = [];
         const defaultAgentConnectionAgents: string[] = [];
         let responseOrchestratorSelectorAgent: ResolvedAgent | null = null;
         let responseOrchestratorSelectorUnavailable = false;
@@ -4007,25 +4009,33 @@ export async function generateRoutes(app: FastifyInstance) {
               agentMaxParallelJobs = cached.maxParallelJobs;
             } else {
               const agentConn = await connections.getWithKey(effectiveConnectionId);
-              if (agentConn) {
-                const agentBaseUrl = resolveBaseUrl(agentConn);
-                if (agentBaseUrl) {
-                  agentProvider = createLLMProvider(
-                    agentConn.provider,
-                    agentBaseUrl,
-                    agentConn.apiKey,
-                    agentConn.maxContext,
-                    agentConn.openrouterProvider,
-                    agentConn.maxTokensOverride,
-                  );
-                  agentModel = agentConn.model;
-                  agentMaxParallelJobs = Number(agentConn.maxParallelJobs) || 1;
-                  agentProviderCache.set(effectiveConnectionId, {
-                    provider: agentProvider,
-                    model: agentModel,
-                    maxParallelJobs: agentMaxParallelJobs,
-                  });
-                }
+              if (!agentConn) {
+                danglingConnectionAgents.push(cfg.name ?? cfg.type);
+                logger.warn(
+                  "[generate] Skipping agent %s for chat %s because connection %s no longer exists",
+                  cfg.type,
+                  input.chatId,
+                  effectiveConnectionId,
+                );
+                continue;
+              }
+              const agentBaseUrl = resolveBaseUrl(agentConn);
+              if (agentBaseUrl) {
+                agentProvider = createLLMProvider(
+                  agentConn.provider,
+                  agentBaseUrl,
+                  agentConn.apiKey,
+                  agentConn.maxContext,
+                  agentConn.openrouterProvider,
+                  agentConn.maxTokensOverride,
+                );
+                agentModel = agentConn.model;
+                agentMaxParallelJobs = Number(agentConn.maxParallelJobs) || 1;
+                agentProviderCache.set(effectiveConnectionId, {
+                  provider: agentProvider,
+                  model: agentModel,
+                  maxParallelJobs: agentMaxParallelJobs,
+                });
               }
             }
           }
@@ -4045,6 +4055,9 @@ export async function generateRoutes(app: FastifyInstance) {
         }
         if (skippedLocalSidecarAgents.length > 0) {
           agentConnectionWarnings.push(buildLocalSidecarUnavailableWarning(skippedLocalSidecarAgents));
+        }
+        if (danglingConnectionAgents.length > 0) {
+          agentConnectionWarnings.push(buildDanglingAgentConnectionWarning(danglingConnectionAgents));
         }
 
         // Built-in agents with no DB row → use defaults only if explicitly in the per-chat list
@@ -4153,7 +4166,15 @@ export async function generateRoutes(app: FastifyInstance) {
                     agentMaxParallelJobs = cached.maxParallelJobs;
                   } else {
                     const agentConn = await connections.getWithKey(effectiveConnectionId);
-                    if (agentConn) {
+                    if (!agentConn) {
+                      responseOrchestratorSelectorUnavailable = true;
+                      agentConnectionWarnings.push(buildDanglingAgentConnectionWarning(["Response Orchestrator"]));
+                      logger.warn(
+                        "[group-smart] Skipping Response Orchestrator for chat %s because connection %s no longer exists",
+                        input.chatId,
+                        effectiveConnectionId,
+                      );
+                    } else {
                       const agentBaseUrl = resolveBaseUrl(agentConn);
                       if (agentBaseUrl) {
                         agentProvider = createLLMProvider(
@@ -4176,18 +4197,20 @@ export async function generateRoutes(app: FastifyInstance) {
                   }
                 }
 
-                responseOrchestratorSelectorAgent = {
-                  id: "id" in cfg ? String(cfg.id) : "builtin:response-orchestrator",
-                  type: "response-orchestrator",
-                  name: "name" in cfg ? String(cfg.name) : "Response Orchestrator",
-                  phase: "phase" in cfg ? String(cfg.phase) : "pre_generation",
-                  promptTemplate: "promptTemplate" in cfg ? String(cfg.promptTemplate ?? "") : "",
-                  connectionId: effectiveConnectionId,
-                  settings,
-                  provider: agentProvider,
-                  model: agentModel,
-                  maxParallelJobs: agentMaxParallelJobs,
-                };
+                if (!responseOrchestratorSelectorUnavailable) {
+                  responseOrchestratorSelectorAgent = {
+                    id: "id" in cfg ? String(cfg.id) : "builtin:response-orchestrator",
+                    type: "response-orchestrator",
+                    name: "name" in cfg ? String(cfg.name) : "Response Orchestrator",
+                    phase: "phase" in cfg ? String(cfg.phase) : "pre_generation",
+                    promptTemplate: "promptTemplate" in cfg ? String(cfg.promptTemplate ?? "") : "",
+                    connectionId: effectiveConnectionId,
+                    settings,
+                    provider: agentProvider,
+                    model: agentModel,
+                    maxParallelJobs: agentMaxParallelJobs,
+                  };
+                }
               }
             }
           }

--- a/packages/server/src/routes/generate/agent-connection-guards.ts
+++ b/packages/server/src/routes/generate/agent-connection-guards.ts
@@ -1,7 +1,7 @@
 import { LOCAL_SIDECAR_CONNECTION_ID } from "@marinara-engine/shared";
 
 export type AgentConnectionWarning = {
-  code: "local_sidecar_unavailable" | "default_agent_connection_active";
+  code: "local_sidecar_unavailable" | "default_agent_connection_active" | "dangling_agent_connection";
   severity: "warning";
   message: string;
   agentNames: string[];
@@ -62,5 +62,19 @@ export function buildDefaultAgentConnectionWarning(args: {
     connectionName: args.connectionName,
     model: args.model,
     message: `${agentList} ${noun} using the default agent connection "${args.connectionName}" (${args.model}). If this is a paid API model, agent calls may bill that provider.`,
+  };
+}
+
+export function buildDanglingAgentConnectionWarning(agentNames: string[]): AgentConnectionWarning {
+  const normalizedNames = agentNames.length > 0 ? agentNames : ["Agent"];
+  const agentList = formatAgentNameList(normalizedNames);
+  const noun = normalizedNames.length === 1 ? "this agent" : "these agents";
+
+  return {
+    code: "dangling_agent_connection",
+    severity: "warning",
+    agentNames: normalizedNames,
+    fallbackPrevented: true,
+    message: `${agentList} requested a connection that no longer exists. Marinara skipped ${noun} instead of falling back to the chat connection.`,
   };
 }

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -537,7 +537,7 @@ async function resolveRetryAgents(args: {
   const chatConnectionMaxParallelJobs = Number(conn.maxParallelJobs) || 1;
   const resolvedAgents: ResolvedRetryAgent[] = [];
   const skippedLocalSidecarAgents: string[] = [];
-  const danglingConnectionAgents: string[] = [];
+  const danglingConnectionAgents = new Set<string>();
   const defaultAgentConnectionAgents: string[] = [];
   const defaultAgentConn = await conns.getDefaultForAgents();
   const defaultAgentConnection = defaultAgentConn
@@ -593,7 +593,7 @@ async function resolveRetryAgents(args: {
       } else {
         const agentConn = await conns.getWithKey(effectiveConnectionId);
         if (!agentConn) {
-          danglingConnectionAgents.push(cfg.name ?? cfg.type);
+          danglingConnectionAgents.add(cfg.name ?? cfg.type);
           logger.warn(
             "[retry-agents] Skipping agent %s because connection %s no longer exists",
             cfg.type,
@@ -640,8 +640,8 @@ async function resolveRetryAgents(args: {
   if (skippedLocalSidecarAgents.length > 0) {
     warnings.push(buildLocalSidecarUnavailableWarning(skippedLocalSidecarAgents));
   }
-  if (danglingConnectionAgents.length > 0) {
-    warnings.push(buildDanglingAgentConnectionWarning(danglingConnectionAgents));
+  if (danglingConnectionAgents.size > 0) {
+    warnings.push(buildDanglingAgentConnectionWarning(Array.from(danglingConnectionAgents)));
   }
 
   for (const builtIn of builtInFallbackConfigs) {

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -55,6 +55,7 @@ import { filterGameInternalAgentIds } from "../../services/lorebook/game-loreboo
 import { sendSseEvent, startSseReply } from "./sse.js";
 import {
   buildDefaultAgentConnectionWarning,
+  buildDanglingAgentConnectionWarning,
   buildLocalSidecarUnavailableWarning,
   isLocalSidecarConnectionId,
   resolveAgentConnectionId,
@@ -536,6 +537,7 @@ async function resolveRetryAgents(args: {
   const chatConnectionMaxParallelJobs = Number(conn.maxParallelJobs) || 1;
   const resolvedAgents: ResolvedRetryAgent[] = [];
   const skippedLocalSidecarAgents: string[] = [];
+  const danglingConnectionAgents: string[] = [];
   const defaultAgentConnectionAgents: string[] = [];
   const defaultAgentConn = await conns.getDefaultForAgents();
   const defaultAgentConnection = defaultAgentConn
@@ -590,20 +592,27 @@ async function resolveRetryAgents(args: {
         defaultAgentConnectionAgents.push(cfg.name ?? cfg.type);
       } else {
         const agentConn = await conns.getWithKey(effectiveConnectionId);
-        if (agentConn) {
-          const agentBaseUrl = resolveBaseUrl(agentConn);
-          if (agentBaseUrl) {
-            agentProvider = createLLMProvider(
-              agentConn.provider,
-              agentBaseUrl,
-              agentConn.apiKey,
-              agentConn.maxContext,
-              agentConn.openrouterProvider,
-              agentConn.maxTokensOverride,
-            );
-            agentModel = agentConn.model;
-            agentMaxParallelJobs = Number(agentConn.maxParallelJobs) || 1;
-          }
+        if (!agentConn) {
+          danglingConnectionAgents.push(cfg.name ?? cfg.type);
+          logger.warn(
+            "[retry-agents] Skipping agent %s because connection %s no longer exists",
+            cfg.type,
+            effectiveConnectionId,
+          );
+          continue;
+        }
+        const agentBaseUrl = resolveBaseUrl(agentConn);
+        if (agentBaseUrl) {
+          agentProvider = createLLMProvider(
+            agentConn.provider,
+            agentBaseUrl,
+            agentConn.apiKey,
+            agentConn.maxContext,
+            agentConn.openrouterProvider,
+            agentConn.maxTokensOverride,
+          );
+          agentModel = agentConn.model;
+          agentMaxParallelJobs = Number(agentConn.maxParallelJobs) || 1;
         }
       }
     }
@@ -627,8 +636,13 @@ async function resolveRetryAgents(args: {
     });
   }
 
-  const warnings =
-    skippedLocalSidecarAgents.length > 0 ? [buildLocalSidecarUnavailableWarning(skippedLocalSidecarAgents)] : [];
+  const warnings: AgentConnectionWarning[] = [];
+  if (skippedLocalSidecarAgents.length > 0) {
+    warnings.push(buildLocalSidecarUnavailableWarning(skippedLocalSidecarAgents));
+  }
+  if (danglingConnectionAgents.length > 0) {
+    warnings.push(buildDanglingAgentConnectionWarning(danglingConnectionAgents));
+  }
 
   for (const builtIn of builtInFallbackConfigs) {
     const builtInProvider = defaultAgentConnection ?? {

--- a/packages/server/src/services/storage/connection-references.storage.ts
+++ b/packages/server/src/services/storage/connection-references.storage.ts
@@ -30,6 +30,32 @@ export async function listConnectionReferences(db: DB, connectionId: string): Pr
   };
 }
 
+export async function deleteConnectionIfUnreferenced(
+  db: DB,
+  connectionId: string,
+): Promise<{ deleted: true; references: ConnectionReferences } | { deleted: false; references: ConnectionReferences }> {
+  return db.transaction(async (tx) => {
+    const [agentRows, chatRows] = await Promise.all([
+      tx
+        .select({ id: agentConfigs.id, name: agentConfigs.name, type: agentConfigs.type })
+        .from(agentConfigs)
+        .where(eq(agentConfigs.connectionId, connectionId)),
+      tx
+        .select({ id: chats.id, name: chats.name, mode: chats.mode })
+        .from(chats)
+        .where(eq(chats.connectionId, connectionId)),
+    ]);
+    const references = { agents: agentRows, chats: chatRows };
+
+    if (hasConnectionReferences(references)) {
+      return { deleted: false, references };
+    }
+
+    await tx.delete(apiConnections).where(eq(apiConnections.id, connectionId));
+    return { deleted: true, references };
+  });
+}
+
 export async function deleteConnectionAndClearReferences(db: DB, connectionId: string): Promise<ConnectionReferences> {
   const references = await listConnectionReferences(db, connectionId);
   const timestamp = now();

--- a/packages/server/src/services/storage/connection-references.storage.ts
+++ b/packages/server/src/services/storage/connection-references.storage.ts
@@ -1,0 +1,47 @@
+import { eq } from "drizzle-orm";
+import type { DB } from "../../db/connection.js";
+import { agentConfigs, apiConnections, chats } from "../../db/schema/index.js";
+import { now } from "../../utils/id-generator.js";
+
+export type ConnectionReferences = {
+  agents: Array<{ id: string; name: string; type: string }>;
+  chats: Array<{ id: string; name: string; mode: string }>;
+};
+
+export function hasConnectionReferences(references: ConnectionReferences): boolean {
+  return references.agents.length > 0 || references.chats.length > 0;
+}
+
+export async function listConnectionReferences(db: DB, connectionId: string): Promise<ConnectionReferences> {
+  const [agentRows, chatRows] = await Promise.all([
+    db
+      .select({ id: agentConfigs.id, name: agentConfigs.name, type: agentConfigs.type })
+      .from(agentConfigs)
+      .where(eq(agentConfigs.connectionId, connectionId)),
+    db
+      .select({ id: chats.id, name: chats.name, mode: chats.mode })
+      .from(chats)
+      .where(eq(chats.connectionId, connectionId)),
+  ]);
+
+  return {
+    agents: agentRows,
+    chats: chatRows,
+  };
+}
+
+export async function deleteConnectionAndClearReferences(db: DB, connectionId: string): Promise<ConnectionReferences> {
+  const references = await listConnectionReferences(db, connectionId);
+  const timestamp = now();
+
+  await db.transaction(async (tx) => {
+    await tx
+      .update(agentConfigs)
+      .set({ connectionId: null, updatedAt: timestamp })
+      .where(eq(agentConfigs.connectionId, connectionId));
+    await tx.update(chats).set({ connectionId: null, updatedAt: timestamp }).where(eq(chats.connectionId, connectionId));
+    await tx.delete(apiConnections).where(eq(apiConnections.id, connectionId));
+  });
+
+  return references;
+}


### PR DESCRIPTION
<!-- Target branch: `staging`. The default base in this UI is `main` (release branch). -->
<!-- Change the base to `staging` before submitting unless this is a maintainer-approved mainline change. -->
<!-- See CONTRIBUTING.md § Branches. -->

## Linked issue

Closes #1129

## Why this change

Deleting a connection that is still referenced by agents or chats left dead `connectionId` values behind. During generation/retry, those dead agent references could silently fall through to the chat connection, which could route agent calls to a provider the user thought they had moved away from.

This is the staging-port equivalent of the behavior already merged to the `refactor` branch in #1130.

## What changed

- Added a server-side connection reference helper for `agent_configs.connection_id` and `chats.connection_id`.
- Changed `DELETE /api/connections/:id` to return `409 connection_in_use` with referencing agents/chats unless `?force=true` is supplied.
- Changed forced connection delete to clear referencing agent/chat `connectionId` values before deleting the connection.
- Added a `dangling_agent_connection` warning and skip path in normal generation, smart Response Orchestrator resolution, and retry-agent resolution so missing agent connections no longer silently use the chat connection.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

Codex-run proof:

- Before fix: `packages\server\node_modules\.bin\tsx.cmd scratch\issue-1129-repro.ts` reproduced the bug: delete returned `204`, connection lookup returned `404`, and the agent/chat still stored the deleted ID.
- After fix: `packages\server\node_modules\.bin\tsx.cmd scratch\issue-1129-repro.ts --expect-fixed` passed: referenced delete returns `409 connection_in_use`, lists the agent/chat references, and leaves the connection intact.
- Edge: `packages\server\node_modules\.bin\tsx.cmd scratch\issue-1129-repro.ts --expect-force` passed: `?force=true` clears the agent/chat references and deletes the connection.
- Edge: `packages\server\node_modules\.bin\tsx.cmd scratch\issue-1129-repro.ts --expect-no-refs` passed: unreferenced delete still returns `204` and removes the connection.
- Edge: `packages\server\node_modules\.bin\tsx.cmd scratch\issue-1129-runtime-warning.ts` passed: retry-agent resolution emits `dangling_agent_connection` and skips the missing-connection agent without emitting an `agent_result`.
- `pnpm check` passed locally.
- `pnpm --filter @marinara-engine/server test` passed locally: 51 tests.
- `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json` passed.
- Bunny review pass completed before opening the PR.

### Manual verification notes

- No browser-only verification is required for the core claim; the changed behavior is server API/storage/runtime resolution and was exercised with Fastify/file-storage scratch harnesses.
- Optional human spot-check: in the app, assign an agent to a connection, try deleting that connection from Settings → Connections, and confirm the delete surfaces the server conflict instead of removing the connection.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs, schema, dependency, version, or release metadata changes.

## UI evidence (if applicable)

N/A - backend API/storage/runtime fix with command proof above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to force-delete connections while clearing all references; API now returns conflict error with reference list when deletion would affect dependent agents/chats.
  * Improved detection and handling of misconfigured agents with unavailable connections; system now skips these agents with informative warnings instead of failing silently.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1206?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->