### PR TITLE
Fix refactor TTS provider voice model hint

### DIFF
--- a/src-tauri/src/commands/storage/integrations/tts.rs
+++ b/src-tauri/src/commands/storage/integrations/tts.rs
@@ -420,6 +420,12 @@ fn configured_base_url(config: &Value) -> String {
     }
 }
 
+/// Builds the OpenAI-compatible voice discovery endpoint.
+///
+/// Nonblank model values are trimmed and sent as `model` so multi-model
+/// providers can return the right catalog. If URL parsing fails, return the
+/// raw legacy endpoint and let the provider request fail through the existing
+/// fallback path.
 fn openai_voices_url(base: &str, model: Option<&str>) -> String {
     let raw_url = format!("{base}/audio/voices");
     let Ok(mut url) = reqwest::Url::parse(&raw_url) else {

--- a/src-tauri/src/commands/storage/integrations/tts.rs
+++ b/src-tauri/src/commands/storage/integrations/tts.rs
@@ -208,7 +208,10 @@ async fn voices(state: &AppState) -> AppResult<Value> {
         .timeout(Duration::from_secs(10))
         .build()
         .map_err(|error| AppError::new("tts_client_error", error.to_string()))?
-        .get(format!("{base}/audio/voices"))
+        .get(openai_voices_url(
+            &base,
+            config.get("model").and_then(Value::as_str),
+        ))
         .headers(openai_headers(api_key)?)
         .send()
         .await;
@@ -415,6 +418,19 @@ fn configured_base_url(config: &Value) -> String {
         "pockettts" => "http://localhost:8000".to_string(),
         _ => "https://api.openai.com/v1".to_string(),
     }
+}
+
+fn openai_voices_url(base: &str, model: Option<&str>) -> String {
+    let raw_url = format!("{base}/audio/voices");
+    let Ok(mut url) = reqwest::Url::parse(&raw_url) else {
+        return raw_url;
+    };
+
+    if let Some(model) = model.map(str::trim).filter(|value| !value.is_empty()) {
+        url.query_pairs_mut().append_pair("model", model);
+    }
+
+    url.to_string()
 }
 
 fn normalized_model(source: &str, base: &str, configured: &str) -> String {
@@ -689,4 +705,110 @@ fn optional_bearer_headers(api_key: &str) -> AppResult<reqwest::header::HeaderMa
         );
     }
     Ok(headers)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::AppState;
+    use std::time::{SystemTime, UNIX_EPOCH};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    fn test_state(label: &str) -> AppState {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after epoch")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("marinara-tts-{label}-{nonce}"));
+        if path.exists() {
+            std::fs::remove_dir_all(&path).expect("stale temp TTS dir should be removable");
+        }
+        AppState::from_data_dir(path, Vec::new()).expect("test app state should initialize")
+    }
+
+    async fn serve_model_gated_voices(expected_model: &'static str) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("test voice server should bind");
+        let address = listener
+            .local_addr()
+            .expect("test voice server address should be readable");
+        tokio::spawn(async move {
+            let (mut stream, _) = listener
+                .accept()
+                .await
+                .expect("test voice server should accept one request");
+            let mut buffer = [0_u8; 2048];
+            let bytes = stream
+                .read(&mut buffer)
+                .await
+                .expect("test voice server should read request");
+            let request = String::from_utf8_lossy(&buffer[..bytes]);
+            let path = request.lines().next().unwrap_or_default();
+            let encoded_model = expected_model.replace('/', "%2F");
+            let has_model = path.contains(&format!("model={encoded_model}"));
+            let (status, body) = if has_model {
+                ("200 OK", r#"{"voices":["af_heart"]}"#)
+            } else {
+                ("400 Bad Request", r#"{"error":"missing model"}"#)
+            };
+            let response = format!(
+                "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream
+                .write_all(response.as_bytes())
+                .await
+                .expect("test voice server should write response");
+        });
+        format!("http://{address}/v1")
+    }
+
+    #[tokio::test]
+    async fn openai_compatible_voice_lookup_passes_configured_model() {
+        let state = test_state("openai-voices-model");
+        let model = "mlx-community/Kokoro-82M-bf16";
+        let base_url = serve_model_gated_voices(model).await;
+        state
+            .storage
+            .upsert_with_id(
+                "app-settings",
+                TTS_SETTINGS_KEY,
+                json!({
+                    "value": {
+                        "enabled": true,
+                        "source": "openai",
+                        "baseUrl": base_url,
+                        "apiKey": "",
+                        "model": model
+                    }
+                }),
+            )
+            .expect("TTS settings should be stored");
+
+        let result = voices(&state).await.expect("voice lookup should complete");
+
+        assert_eq!(result["fromProvider"], true);
+        assert_eq!(result["voices"], json!(["af_heart"]));
+    }
+
+    #[test]
+    fn openai_voices_url_encodes_configured_model() {
+        assert_eq!(
+            openai_voices_url(
+                "http://127.0.0.1:8081/v1",
+                Some(" mlx-community/Kokoro-82M-bf16 ")
+            ),
+            "http://127.0.0.1:8081/v1/audio/voices?model=mlx-community%2FKokoro-82M-bf16"
+        );
+    }
+
+    #[test]
+    fn openai_voices_url_omits_blank_model() {
+        assert_eq!(
+            openai_voices_url("http://127.0.0.1:8081/v1", Some("  ")),
+            "http://127.0.0.1:8081/v1/audio/voices"
+        );
+    }
 }


### PR DESCRIPTION
## Linked issue

Closes #1131

## Why this change

OpenAI-compatible TTS providers can host multiple voice models behind the same `baseUrl`. On the refactor branch, the native TTS voice lookup still requested `{baseUrl}/audio/voices` without passing the saved model, so model-specific providers such as mlx-audio could return the wrong catalog or reject the request and force Marinara back to the built-in OpenAI voice list.

This ports the staging PR's intended behavior into the refactor branch's Tauri/Rust TTS integration path.

## What changed

- Added `openai_voices_url()` in `src-tauri/src/commands/storage/integrations/tts.rs` to append the trimmed configured model as `?model=...` for OpenAI-compatible voice discovery.
- Kept blank model values as the legacy `{baseUrl}/audio/voices` request.
- Added Rust regression coverage for a local model-gated voice endpoint, encoded model IDs, and the blank-model negative control.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

Codex verification performed:

- Reproduced the refactor-branch failure before the production fix with `cargo test --manifest-path src-tauri/Cargo.toml openai_compatible_voice_lookup_passes_configured_model`; the local model-gated voice endpoint rejected the request without `?model=`, and Marinara returned `fromProvider: false`.
- Ran `cargo test --manifest-path src-tauri/Cargo.toml storage_commands::integrations::tts::tests`; all 3 TTS integration tests passed.
- Ran `pnpm check`; architecture, frontend typecheck, Rust cargo check, and docs check passed.
- Ran `git diff --check`; no whitespace errors.
- Ran the local Marinara proof gate against `scratch/bugfix-verification.json`; it passed.

Not manually verified against a real external OpenAI-compatible TTS server or api.openai.com from this environment.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs or version files changed.

## UI evidence (if applicable)

No UI code changed. This is a native TTS command/provider request change verified with a Rust integration harness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TTS voice lookup by properly handling model configuration parameters.

* **Tests**
  * Added comprehensive test coverage for TTS voice URL handling and model parameter encoding.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1207?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->