### PR TITLE
Add ComfyUI workflow JSON file import

### DIFF
--- a/src/features/shell/connections/components/ConnectionEditor.tsx
+++ b/src/features/shell/connections/components/ConnectionEditor.tsx
@@ -2,7 +2,7 @@
 // Full-Page Connection Editor
 // Click a connection → opens this editor (like presets/characters)
 // ──────────────────────────────────────────────
-import { useState, useCallback, useEffect, useLayoutEffect, useMemo, useRef } from "react";
+import { useState, useCallback, useEffect, useLayoutEffect, useMemo, useRef, type ChangeEvent } from "react";
 import { useUIStore } from "../../../../shared/stores/ui.store";
 import {
   useConnection,
@@ -40,6 +40,7 @@ import {
   ImageIcon,
   RotateCcw,
   SlidersHorizontal,
+  Upload,
 } from "lucide-react";
 import { cn } from "../../../../shared/lib/utils";
 import { showConfirmDialog } from "../../../../shared/lib/app-dialogs";
@@ -57,6 +58,7 @@ import { MODEL_LISTS, IMAGE_GENERATION_SOURCES, inferImageSource } from "../../.
 import { PROVIDERS, isTauriRuntimeProvider } from "../../../../engine/contracts/constants/providers";
 import type { APIProvider } from "../../../../engine/contracts/types/connection";
 import type { ImageDefaultsService, ImageGenerationDefaultsProfile } from "../../../../engine/contracts/types/image-generation-defaults";
+import { toast } from "sonner";
 
 /** Links where users can obtain API keys for each provider */
 const API_KEY_LINKS: Partial<Record<APIProvider, { label: string; url: string }>> = {
@@ -164,6 +166,7 @@ export function ConnectionEditor() {
   const modelTriggerRef = useRef<HTMLDivElement>(null);
   const modelSearchInputRef = useRef<HTMLInputElement>(null);
   const comfyWorkflowTextareaRef = useRef<HTMLTextAreaElement>(null);
+  const comfyWorkflowFileInputRef = useRef<HTMLInputElement>(null);
   const [dropdownRect, setDropdownRect] = useState<{ top: number; left: number; width: number; maxH: number } | null>(
     null,
   );
@@ -584,6 +587,32 @@ export function ConnectionEditor() {
     ta.focus();
     ta.setSelectionRange(pos, pos);
   }, [comfyWorkflowValidation]);
+
+  const handleImportComfyWorkflowFile = useCallback(
+    async (event: ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      event.target.value = "";
+      if (!file) return;
+
+      const isJsonFile =
+        file.type === "application/json" || file.name.trim().toLowerCase().endsWith(".json");
+      if (!isJsonFile) {
+        toast.error("Choose a .json workflow file.");
+        return;
+      }
+
+      try {
+        const workflowText = await file.text();
+        JSON.parse(workflowText);
+        setLocalComfyuiWorkflow(workflowText);
+        markDirty();
+        toast.success(`Imported ${file.name}`);
+      } catch (error) {
+        toast.error(error instanceof Error ? `Invalid workflow JSON: ${error.message}` : "Invalid workflow JSON.");
+      }
+    },
+    [markDirty],
+  );
 
   const providerDef = PROVIDERS[localProvider];
   const providerEntries = useMemo(
@@ -1206,6 +1235,23 @@ export function ConnectionEditor() {
                   : "Paste a custom ComfyUI workflow JSON (API format). Use placeholders like %prompt%, %negative_prompt%, %width%, %height%, %seed%, %model%, %steps%, %cfg%, %sampler%, %scheduler%, and %denoise%. Leave empty to use the built-in default txt2img workflow."
               }
             >
+              <div className="mb-2 flex flex-wrap items-center gap-2">
+                <input
+                  ref={comfyWorkflowFileInputRef}
+                  type="file"
+                  accept=".json,application/json"
+                  className="hidden"
+                  onChange={handleImportComfyWorkflowFile}
+                />
+                <button
+                  type="button"
+                  onClick={() => comfyWorkflowFileInputRef.current?.click()}
+                  className="inline-flex items-center gap-1.5 rounded-lg bg-[var(--secondary)] px-3 py-2 text-xs font-medium text-[var(--foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)] active:scale-[0.98]"
+                >
+                  <Upload size="0.8125rem" />
+                  Import JSON
+                </button>
+              </div>
               <textarea
                 ref={comfyWorkflowTextareaRef}
                 value={localComfyuiWorkflow}


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

<!-- Every user-facing PR should reference a feature request or issue report when practical. -->

Closes #1150

## Why this change

<!-- What user problem, bug, refactor goal, or maintenance need does this solve? -->

- Large ComfyUI API workflow JSON can be painful to paste into Marinara, especially on Android where clipboard size can make copying the whole workflow unreliable.

## What changed

<!-- List the key changes in this PR. -->

- Added an `Import JSON` button above the ComfyUI workflow text area in the connection editor.
- The picker accepts `.json` files, reads the selected workflow with the browser File API, validates JSON before replacing the text area, marks the editor dirty, and shows success/error toast feedback.
- Invalid JSON and non-JSON selections do not overwrite the existing workflow text.

## Refactor impact

Primary owner:

<!-- Examples: app shell, catalog, chat mode, roleplay mode, game mode, runtime generation, world-state, shared API, engine generation, Rust storage, imports, remote runtime. -->

Shell connections UI.

Impact areas reviewed:

- `src/features/shell/connections/components/ConnectionEditor.tsx`
- Existing ComfyUI workflow validation and save payload path

Boundary notes:

<!-- Note engine/shared-api/feature/Rust/remote-runtime boundaries. Say "none" only if you checked. -->

- Feature-only React UI change. No engine, shared API, Rust, remote runtime, storage schema, or dependency boundary changes.

Pressure points touched:

<!-- Mention ModeSurface, GameSurface, shared mode UI, src-tauri/src/lib.rs command registration, or import modules if touched. -->

- None. This stays inside the connection editor's existing ComfyUI workflow field.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app/runtime, step by step. If an AI agent filled this out, verify it yourself before ticking boxes. -->

- Codex ran `node scratch\issue-1150-verify-comfyui-import.mjs` against local Vite. The script opened the real Connection editor UI with mocked Tauri storage, created an image-generation connection, selected ComfyUI, imported a valid workflow JSON file, confirmed `%prompt%` appeared in the workflow text area, then imported invalid JSON and confirmed the existing workflow text was not overwritten.
- Codex ran `pnpm check` successfully after rebasing onto current `upstream/refactor`.
- Codex ran `pnpm build` successfully after rebasing onto current `upstream/refactor`. Vite reported existing chunk-size/dynamic-import warnings.
- Codex ran Bunny review before push: focused one-file diff, no schema/storage/dependency/auth/prompt-pipeline changes, invalid JSON negative control covered, and branch targets `refactor`.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

Docs/release notes: not changed; this is a focused UI affordance in an existing connection setting.

## UI evidence

<!-- Add before/after screenshots or recordings for visible UI changes. -->

Codex generated local Playwright screenshots:

- `scratch/issue-1150-before-import.png`
- `scratch/issue-1150-after-valid-import.png`
- `scratch/issue-1150-after-invalid-import.png`

These are local proof artifacts and are not attached to the PR body.
