### PR TITLE
Migrate storage JSON fields to typed values

### DIFF
--- a/src-tauri/src/commands/storage/commands/entities.rs
+++ b/src-tauri/src/commands/storage/commands/entities.rs
@@ -91,7 +91,7 @@ pub fn storage_create(
 ) -> Result<Value, AppError> {
     state
         .storage
-        .create(&entity, shared::with_entity_defaults(&entity, value))
+        .create(&entity, shared::with_entity_defaults(&entity, value)?)
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/storage/exports.rs
+++ b/src-tauri/src/commands/storage/exports.rs
@@ -128,7 +128,7 @@ pub(crate) fn import_character_embedded_lorebook(
                 "characterId": character_id,
                 "sourceCharacterId": character_id
             }),
-        ),
+        )?,
     )?;
     let lorebook_id = lorebook
         .get("id")
@@ -450,11 +450,7 @@ fn compatible_lorebook_export(lorebook: &Value, entries: &Value) -> Value {
 }
 
 fn character_data_value(character: &Value) -> Value {
-    match character.get("data") {
-        Some(Value::String(raw)) => serde_json::from_str(raw).unwrap_or_else(|_| json!({})),
-        Some(value) => value.clone(),
-        None => character.clone(),
-    }
+    character.get("data").cloned().unwrap_or_else(|| json!({}))
 }
 
 fn normalize_character_book_entry(entry: &Value, index: usize, lorebook_id: &str) -> Value {
@@ -510,7 +506,7 @@ fn patch_character_embedded_lorebook_pointer(
     state.storage.patch(
         "characters",
         character_id,
-        json!({ "data": serde_json::to_string(&data).unwrap_or_else(|_| "{}".to_string()) }),
+        json!({ "data": data }),
     )?;
     Ok(())
 }

--- a/src-tauri/src/commands/storage/imports/bulk_imports.rs
+++ b/src-tauri/src/commands/storage/imports/bulk_imports.rs
@@ -610,7 +610,7 @@ fn import_persona_payload(
     }
     state
         .storage
-        .create("personas", with_entity_defaults("personas", Value::Object(object)))
+        .create("personas", with_entity_defaults("personas", Value::Object(object))?)
         .map(|record| json!({ "success": true, "id": record.get("id").cloned().unwrap_or(Value::Null), "name": record.get("name").cloned().unwrap_or(Value::Null), "persona": record }))
 }
 

--- a/src-tauri/src/commands/storage/imports/marinara.rs
+++ b/src-tauri/src/commands/storage/imports/marinara.rs
@@ -92,11 +92,7 @@ pub(super) fn import_marinara_file(state: &AppState, body: Value) -> AppResult<V
 }
 
 fn data_string_name(record: &Value) -> Option<String> {
-    record
-        .get("data")
-        .and_then(|data| data.get("name"))
-        .and_then(Value::as_str)
-        .map(ToOwned::to_owned)
+    record.get("data").and_then(|data| data.get("name")).and_then(Value::as_str).map(ToOwned::to_owned)
 }
 
 fn data_image_string(value: Option<&Value>) -> Option<String> {
@@ -349,10 +345,7 @@ fn import_marinara_character(state: &AppState, data: Value) -> AppResult<Value> 
     remove_fields(&mut source, &["id", "sprites", "gallery", "metadata"]);
     if let Some(object) = source.as_object_mut() {
         if let Some(Value::String(raw)) = object.get("data") {
-            let parsed = serde_json::from_str::<Value>(raw)
-                .ok()
-                .filter(Value::is_object)
-                .unwrap_or_else(|| json!({}));
+            let parsed = serde_json::from_str::<Value>(raw).ok().filter(Value::is_object).unwrap_or_else(|| json!({}));
             object.insert("data".to_string(), parsed);
         }
     }

--- a/src-tauri/src/commands/storage/imports/marinara.rs
+++ b/src-tauri/src/commands/storage/imports/marinara.rs
@@ -94,13 +94,9 @@ pub(super) fn import_marinara_file(state: &AppState, body: Value) -> AppResult<V
 fn data_string_name(record: &Value) -> Option<String> {
     record
         .get("data")
+        .and_then(|data| data.get("name"))
         .and_then(Value::as_str)
-        .and_then(|raw| serde_json::from_str::<Value>(raw).ok())
-        .and_then(|data| {
-            data.get("name")
-                .and_then(Value::as_str)
-                .map(ToOwned::to_owned)
-        })
+        .map(ToOwned::to_owned)
 }
 
 fn data_image_string(value: Option<&Value>) -> Option<String> {
@@ -299,7 +295,7 @@ fn import_marinara_character(state: &AppState, data: Value) -> AppResult<Value> 
         let mut character_data = data.get("data").cloned().unwrap_or_else(|| json!({}));
         strip_stale_embedded_lorebook_pointer(&mut character_data);
         let mut record = json!({
-            "data": serde_json::to_string(&character_data)?,
+            "data": character_data,
             "comment": data
                 .get("metadata")
                 .and_then(|metadata| metadata.get("comment"))
@@ -351,7 +347,16 @@ fn import_marinara_character(state: &AppState, data: Value) -> AppResult<Value> 
 
     let mut source = data.clone();
     remove_fields(&mut source, &["id", "sprites", "gallery", "metadata"]);
-    let mut record_value = with_entity_defaults("characters", source.clone());
+    if let Some(object) = source.as_object_mut() {
+        if let Some(Value::String(raw)) = object.get("data") {
+            let parsed = serde_json::from_str::<Value>(raw)
+                .ok()
+                .filter(Value::is_object)
+                .unwrap_or_else(|| json!({}));
+            object.insert("data".to_string(), parsed);
+        }
+    }
+    let mut record_value = with_entity_defaults("characters", source.clone())?;
     if let Some(avatar) = data.get("avatar").and_then(Value::as_str) {
         if let Some(record) = record_value.as_object_mut() {
             record.insert("avatarPath".to_string(), Value::String(avatar.to_string()));
@@ -392,7 +397,7 @@ fn import_marinara_character(state: &AppState, data: Value) -> AppResult<Value> 
 fn import_marinara_persona(state: &AppState, data: Value) -> AppResult<Value> {
     let mut source = data.clone();
     remove_fields(&mut source, &["id", "metadata", "avatar", "sprites"]);
-    let mut record_value = with_entity_defaults("personas", source);
+    let mut record_value = with_entity_defaults("personas", source)?;
     if let Some(avatar) = data.get("avatar").and_then(Value::as_str) {
         if let Some(record) = record_value.as_object_mut() {
             record.insert("avatarPath".to_string(), Value::String(avatar.to_string()));
@@ -449,7 +454,7 @@ fn import_marinara_lorebook(
             "excludeFromVectorization",
         ],
     );
-    let mut lorebook = with_entity_defaults("lorebooks", lorebook_data.clone());
+    let mut lorebook = with_entity_defaults("lorebooks", lorebook_data.clone())?;
     if let Some(image) = data
         .get("avatar")
         .or_else(|| data.get("image"))
@@ -563,7 +568,7 @@ fn import_marinara_preset(
         &mut preset_data,
         &["sections", "groups", "choiceBlocks", "variables"],
     );
-    let mut record_value = with_entity_defaults("prompts", preset_data.clone());
+    let mut record_value = with_entity_defaults("prompts", preset_data.clone())?;
     let mut timestamp_payload = preset_data.clone();
     hydrate_metadata_timestamps(&mut timestamp_payload);
     apply_timestamp_overrides(&mut record_value, &Value::Null, &timestamp_payload);

--- a/src-tauri/src/commands/storage/imports/service.rs
+++ b/src-tauri/src/commands/storage/imports/service.rs
@@ -62,11 +62,7 @@ fn patch_imported_character_lorebook_pointer(
     entries_imported: usize,
 ) -> AppResult<()> {
     let character = get_required(state, "characters", character_id)?;
-    let mut data = character
-        .get("data")
-        .and_then(Value::as_str)
-        .and_then(|raw| serde_json::from_str::<Value>(raw).ok())
-        .unwrap_or_else(|| json!({}));
+    let mut data = character.get("data").cloned().unwrap_or_else(|| json!({}));
     let Some(data_object) = data.as_object_mut() else {
         return Ok(());
     };
@@ -93,7 +89,7 @@ fn patch_imported_character_lorebook_pointer(
     state.storage.patch(
         "characters",
         character_id,
-        json!({ "data": serde_json::to_string(&data).unwrap_or_else(|_| "{}".to_string()) }),
+        json!({ "data": data }),
     )?;
     Ok(())
 }
@@ -114,10 +110,8 @@ fn import_st_character_payload(
         .into_iter()
         .flat_map(|row| {
             row.get("data")
-                .and_then(Value::as_str)
-                .and_then(|raw| serde_json::from_str::<Value>(raw).ok())
-                .and_then(|data| data.get("tags").cloned())
-                .map(|tags| string_array(Some(&tags)))
+                .and_then(|data| data.get("tags"))
+                .map(|tags| string_array(Some(tags)))
                 .unwrap_or_default()
         })
         .collect();
@@ -128,7 +122,7 @@ fn import_st_character_payload(
         .unwrap_or("Imported Character")
         .to_string();
     let mut record = json!({
-        "data": serde_json::to_string(&data)?,
+        "data": data,
         "comment": data.get("creator_notes").and_then(Value::as_str).unwrap_or(""),
         "avatarPath": payload
             .get("_avatarDataUrl")

--- a/src-tauri/src/commands/storage/imports/st_preset.rs
+++ b/src-tauri/src/commands/storage/imports/st_preset.rs
@@ -288,7 +288,7 @@ pub(super) fn import_st_preset_payload(
                     "singleUserMessage": false
                 }
             }),
-        ),
+        )?,
     )?;
     let preset_id = preset
         .get("id")

--- a/src-tauri/src/commands/storage/profile.rs
+++ b/src-tauri/src/commands/storage/profile.rs
@@ -157,11 +157,12 @@ where
     let mut imported = Map::new();
     let mut replacements = Vec::new();
     for collection in PROFILE_COLLECTIONS {
-        let rows = collections
+        let mut rows = collections
             .get(*collection)
             .and_then(Value::as_array)
             .cloned()
             .unwrap_or_default();
+        normalize_profile_json_fields(collection, &mut rows)?;
         imported.insert((*collection).to_string(), json!(rows.len()));
         replacements.push((*collection, rows));
     }
@@ -171,6 +172,32 @@ where
     imported.insert("files".to_string(), json!(restored_assets));
     insert_profile_import_aliases(&mut imported);
     Ok(json!({ "success": true, "imported": imported }))
+}
+
+fn normalize_profile_json_fields(collection: &str, rows: &mut [Value]) -> AppResult<()> {
+    for row in rows {
+        let Some(object) = row.as_object_mut() else {
+            continue;
+        };
+        if collection == "characters" {
+            match object.get("data") {
+                Some(Value::Object(_)) => {}
+                Some(Value::String(raw)) => {
+                    let parsed = serde_json::from_str::<Value>(raw)
+                        .ok()
+                        .filter(Value::is_object)
+                        .unwrap_or_else(|| json!({}));
+                    object.insert("data".to_string(), parsed);
+                }
+                Some(_) | None => {
+                    object.insert("data".to_string(), json!({}));
+                }
+            }
+        } else {
+            normalize_typed_json_fields(collection, object)?;
+        }
+    }
+    Ok(())
 }
 
 fn finish_profile_import_assets(

--- a/src-tauri/src/commands/storage/profile/legacy.rs
+++ b/src-tauri/src/commands/storage/profile/legacy.rs
@@ -3,7 +3,7 @@ use super::super::{
     shared::{
         materialize_message_swipe_fields, non_negative_i64_value,
         normalize_legacy_text_array_fields, normalize_legacy_text_bool_fields,
-        string_array_from_value,
+        normalize_typed_json_fields, string_array_from_value,
     },
 };
 use super::assets::{normalize_legacy_profile_asset_paths, restore_legacy_profile_json_assets};
@@ -95,12 +95,14 @@ where
         let mut rows = table_rows(tables, table);
         match *collection {
             "app-settings" => normalize_legacy_app_settings(&mut rows),
+            "characters" => normalize_legacy_character_data(&mut rows),
             "lorebooks" => add_legacy_lorebook_links(&mut rows, tables),
             "chats" => add_legacy_chat_memories(&mut rows, tables),
             "messages" => add_legacy_message_swipes(&mut rows, tables),
             "game-state-snapshots" => normalize_legacy_game_state_snapshots(&mut rows),
             _ => {}
         }
+        normalize_legacy_profile_json_fields(collection, &mut rows)?;
         for row in &mut rows {
             normalize_legacy_profile_asset_paths(state, staging_root, row);
         }
@@ -121,6 +123,40 @@ fn table_rows(tables: &Map<String, Value>, table: &str) -> Vec<Value> {
         .and_then(Value::as_array)
         .cloned()
         .unwrap_or_default()
+}
+
+fn normalize_legacy_profile_json_fields(collection: &str, rows: &mut [Value]) -> AppResult<()> {
+    if collection == "characters" {
+        normalize_legacy_character_data(rows);
+        return Ok(());
+    }
+    for row in rows {
+        if let Some(object) = row.as_object_mut() {
+            normalize_typed_json_fields(collection, object)?;
+        }
+    }
+    Ok(())
+}
+
+fn normalize_legacy_character_data(rows: &mut [Value]) {
+    for row in rows {
+        let Some(object) = row.as_object_mut() else {
+            continue;
+        };
+        match object.get("data") {
+            Some(Value::Object(_)) => {}
+            Some(Value::String(raw)) => {
+                let parsed = serde_json::from_str::<Value>(raw)
+                    .ok()
+                    .filter(Value::is_object)
+                    .unwrap_or_else(|| json!({}));
+                object.insert("data".to_string(), parsed);
+            }
+            Some(_) | None => {
+                object.insert("data".to_string(), json!({}));
+            }
+        }
+    }
 }
 
 fn normalize_legacy_app_settings(rows: &mut [Value]) {

--- a/src-tauri/src/commands/storage/shared.rs
+++ b/src-tauri/src/commands/storage/shared.rs
@@ -170,7 +170,7 @@ pub(crate) fn normalize_typed_json_fields(collection: &str, object: &mut Map<Str
             normalize_json_array_fields(object, &["keys", "secondaryKeys"])?;
         }
         "connections" => {
-            normalize_json_object_fields(object, &["defaultParameters", "capabilities", "providerMetadata"])?;
+            normalize_nullable_json_object_fields(object, &["defaultParameters", "capabilities", "providerMetadata"])?;
         }
         "custom-tools" => {
             normalize_json_object_fields(object, &["parametersSchema"])?;

--- a/src-tauri/src/commands/storage/shared.rs
+++ b/src-tauri/src/commands/storage/shared.rs
@@ -131,31 +131,145 @@ pub(crate) fn swipe_index_value(message: &Value) -> i64 {
 
 pub(crate) fn normalize_character_data_for_storage(data: &Value) -> AppResult<Value> {
     match data {
-        Value::String(raw) => Ok(Value::String(raw.clone())),
-        Value::Object(_) => Ok(Value::String(serde_json::to_string(data)?)),
-        _ => Err(AppError::invalid_input(
-            "Character data must be an object or JSON string",
-        )),
+        Value::Object(_) => Ok(data.clone()),
+        _ => Err(AppError::invalid_input("Character data must be a JSON object")),
     }
 }
 
 pub(crate) fn normalize_update_patch(collection: &str, patch: Value) -> AppResult<Value> {
-    if collection != "characters" {
-        return Ok(patch);
-    }
-
     let mut object = ensure_object(patch)?;
-    if let Some(data) = object.get("data") {
-        object.insert(
-            "data".to_string(),
-            normalize_character_data_for_storage(data)?,
-        );
-    }
+    normalize_typed_json_fields(collection, &mut object)?;
     Ok(Value::Object(object))
 }
 
-pub(crate) fn with_entity_defaults(collection: &str, body: Value) -> Value {
-    let mut object = ensure_object(body).unwrap_or_default();
+pub(crate) fn normalize_typed_json_fields(collection: &str, object: &mut Map<String, Value>) -> AppResult<()> {
+    match collection {
+        "characters" => {
+            if let Some(data) = object.get("data") {
+                object.insert("data".to_string(), normalize_character_data_for_storage(data)?);
+            }
+        }
+        "chats" => {
+            normalize_json_array_fields(object, &["characterIds", "activeLorebookIds", "activeAgentIds", "activeToolIds", "memories"])?;
+            normalize_nullable_json_object_fields(object, &["metadata", "gameState"])?;
+        }
+        "messages" => {
+            normalize_json_array_fields(object, &["swipes", "images", "attachments"])?;
+            normalize_nullable_json_object_fields(object, &["extra"])?;
+        }
+        "character-groups" => {
+            normalize_json_array_fields(object, &["characterIds"])?;
+        }
+        "persona-groups" => {
+            normalize_json_array_fields(object, &["personaIds"])?;
+        }
+        "lorebooks" => {
+            normalize_json_array_fields(object, &["tags", "characterIds", "personaIds"])?;
+        }
+        "lorebook-entries" => {
+            normalize_json_array_fields(object, &["keys", "secondaryKeys"])?;
+        }
+        "connections" => {
+            normalize_json_object_fields(object, &["defaultParameters", "capabilities", "providerMetadata"])?;
+        }
+        "custom-tools" => {
+            normalize_json_object_fields(object, &["parametersSchema"])?;
+        }
+        "game-state-snapshots" => {
+            normalize_json_array_fields(object, &["presentCharacters", "recentEvents"])?;
+            normalize_nullable_json_object_fields(object, &["playerStats", "personaStats", "metadata"])?;
+        }
+        "game-checkpoints" => {
+            normalize_nullable_json_object_fields(object, &["snapshot", "gameState", "metadata"])?;
+        }
+        "chat-presets" => {
+            normalize_json_object_fields(object, &["parameters"])?;
+        }
+        "prompts" => {
+            normalize_json_array_fields(object, &["sectionOrder", "groupOrder", "variableOrder"])?;
+            normalize_json_object_fields(object, &["variableValues", "parameters", "defaultChoices"])?;
+            normalize_json_array_fields(object, &["variableGroups"])?;
+        }
+        "prompt-sections" => {
+            normalize_nullable_json_object_fields(object, &["markerConfig"])?;
+        }
+        "prompt-variables" => {
+            normalize_json_array_fields(object, &["options"])?;
+        }
+        "personas" => {
+            normalize_json_array_fields(object, &["tags", "altDescriptions", "savedStatusOptions"])?;
+            normalize_nullable_json_object_fields(object, &["avatarCrop", "personaStats"])?;
+        }
+        "agents" => {
+            normalize_json_object_fields(object, &["settings"])?;
+        }
+        "regex-scripts" => {
+            normalize_json_array_fields(object, &["placement", "trimStrings"])?;
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn normalize_json_array_fields(object: &mut Map<String, Value>, fields: &[&str]) -> AppResult<()> {
+    for field in fields {
+        let Some(value) = object.get(*field) else { continue };
+        let normalized = normalize_json_field(value, Value::is_array, "array", field)?;
+        object.insert((*field).to_string(), normalized);
+    }
+    Ok(())
+}
+
+fn normalize_json_object_fields(object: &mut Map<String, Value>, fields: &[&str]) -> AppResult<()> {
+    for field in fields {
+        let Some(value) = object.get(*field) else { continue };
+        let normalized = normalize_json_field(value, Value::is_object, "object", field)?;
+        object.insert((*field).to_string(), normalized);
+    }
+    Ok(())
+}
+
+fn normalize_nullable_json_object_fields(object: &mut Map<String, Value>, fields: &[&str]) -> AppResult<()> {
+    for field in fields {
+        let Some(value) = object.get(*field) else { continue };
+        if value.is_null() {
+            continue;
+        }
+        let normalized = normalize_json_field(value, Value::is_object, "object or null", field)?;
+        object.insert((*field).to_string(), normalized);
+    }
+    Ok(())
+}
+
+fn normalize_json_field(
+    value: &Value,
+    predicate: fn(&Value) -> bool,
+    expected: &str,
+    field: &str,
+) -> AppResult<Value> {
+    if predicate(value) {
+        return Ok(value.clone());
+    }
+    if let Some(raw) = value.as_str() {
+        if raw.trim().is_empty() {
+            return Ok(match expected {
+                "array" => json!([]),
+                "object or null" => Value::Null,
+                _ => json!({}),
+            });
+        }
+        let parsed: Value = serde_json::from_str(raw).map_err(|_| {
+            AppError::invalid_input(format!("{field} must be a JSON {expected}, not a JSON string"))
+        })?;
+        if predicate(&parsed) {
+            return Ok(parsed);
+        }
+    }
+    Err(AppError::invalid_input(format!("{field} must be a JSON {expected}")))
+}
+
+pub(crate) fn with_entity_defaults(collection: &str, body: Value) -> AppResult<Value> {
+    let mut object = ensure_object(body)?;
     match collection {
         "chats" => {
             object
@@ -174,12 +288,8 @@ pub(crate) fn with_entity_defaults(collection: &str, body: Value) -> Value {
                 .or_insert(Value::Bool(true));
         }
         "characters" => {
-            if let Some(data) = object.get_mut("data") {
-                if data.is_object() {
-                    *data = Value::String(
-                        serde_json::to_string(data).unwrap_or_else(|_| "{}".to_string()),
-                    );
-                }
+            if let Some(data) = object.get("data") {
+                normalize_character_data_for_storage(data)?;
             } else {
                 let mut data = Map::new();
                 let name = object
@@ -208,13 +318,7 @@ pub(crate) fn with_entity_defaults(collection: &str, body: Value) -> Value {
                 data.insert("alternate_greetings".to_string(), json!([]));
                 data.insert("extensions".to_string(), json!({ "altDescriptions": [] }));
                 data.insert("character_book".to_string(), Value::Null);
-                object.insert(
-                    "data".to_string(),
-                    Value::String(
-                        serde_json::to_string(&Value::Object(data))
-                            .unwrap_or_else(|_| "{}".to_string()),
-                    ),
-                );
+                object.insert("data".to_string(), Value::Object(data));
             }
             object
                 .entry("comment".to_string())
@@ -265,6 +369,7 @@ pub(crate) fn with_entity_defaults(collection: &str, body: Value) -> Value {
                 .or_insert(Value::Null);
         }
         "personas" => {
+            normalize_typed_json_fields(collection, &mut object)?;
             object
                 .entry("description".to_string())
                 .or_insert(Value::String(String::new()));
@@ -291,27 +396,52 @@ pub(crate) fn with_entity_defaults(collection: &str, body: Value) -> Value {
                 .or_insert(Value::Bool(false));
             object
                 .entry("tags".to_string())
-                .or_insert(Value::String("[]".to_string()));
+                .or_insert_with(|| json!([]));
+            object
+                .entry("altDescriptions".to_string())
+                .or_insert_with(|| json!([]));
+            object.entry("avatarCrop".to_string()).or_insert(Value::Null);
         }
         "prompts" => {
+            normalize_typed_json_fields(collection, &mut object)?;
             object
                 .entry("description".to_string())
                 .or_insert(Value::String(String::new()));
             object
+                .entry("sectionOrder".to_string())
+                .or_insert_with(|| json!([]));
+            object
+                .entry("groupOrder".to_string())
+                .or_insert_with(|| json!([]));
+            object
+                .entry("variableGroups".to_string())
+                .or_insert_with(|| json!([]));
+            object
+                .entry("variableValues".to_string())
+                .or_insert_with(|| json!({}));
+            object
                 .entry("parameters".to_string())
+                .or_insert_with(|| json!({}));
+            object
+                .entry("defaultChoices".to_string())
                 .or_insert_with(|| json!({}));
             object
                 .entry("isDefault".to_string())
                 .or_insert(Value::Bool(false));
         }
+        "prompt-sections" | "prompt-variables" => {
+            normalize_typed_json_fields(collection, &mut object)?;
+        }
         "agents" => {
+            normalize_typed_json_fields(collection, &mut object)?;
             object
                 .entry("enabled".to_string())
                 .or_insert(Value::Bool(true));
         }
         _ => {}
     }
-    Value::Object(object)
+    normalize_typed_json_fields(collection, &mut object)?;
+    Ok(Value::Object(object))
 }
 
 #[cfg(test)]
@@ -319,7 +449,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn character_update_patch_serializes_object_data() {
+    fn character_update_patch_preserves_object_data() {
         let patch = normalize_update_patch(
             "characters",
             json!({
@@ -331,29 +461,18 @@ mod tests {
         )
         .expect("patch should normalize");
 
-        let data = patch
-            .get("data")
-            .and_then(Value::as_str)
-            .expect("character data should be serialized");
-        let parsed: Value =
-            serde_json::from_str(data).expect("serialized data should be valid JSON");
-        assert_eq!(parsed["name"], "Professor Mari");
-        assert_eq!(parsed["tags"], json!(["guide"]));
+        assert_eq!(patch["data"]["name"], "Professor Mari");
+        assert_eq!(patch["data"]["tags"], json!(["guide"]));
     }
 
-    #[test]
-    fn character_update_patch_preserves_string_data() {
-        let raw = r#"{"name":"Professor Mari"}"#;
-        let patch = normalize_update_patch("characters", json!({ "data": raw }))
-            .expect("patch should normalize");
-        assert_eq!(patch["data"], raw);
-    }
 
     #[test]
     fn character_update_patch_rejects_invalid_data_shape() {
-        let error = normalize_update_patch("characters", json!({ "data": true }))
-            .expect_err("invalid character data should fail");
-        assert_eq!(error.code, "invalid_input");
+        for invalid in [json!(true), json!("{\"name\":\"Professor Mari\"}"), json!([]), Value::Null] {
+            let error = normalize_update_patch("characters", json!({ "data": invalid }))
+                .expect_err("invalid character data should fail");
+            assert_eq!(error.code, "invalid_input");
+        }
     }
 
     #[test]

--- a/src-tauri/src/http_dispatch.rs
+++ b/src-tauri/src/http_dispatch.rs
@@ -155,7 +155,7 @@ fn storage_create(state: &AppState, args: &Map<String, Value>) -> AppResult<Valu
     let entity = required_string(args, "entity")?;
     state.storage.create(
         entity,
-        shared::with_entity_defaults(entity, optional_value(args, "value")),
+        shared::with_entity_defaults(entity, optional_value(args, "value"))?,
     )
 }
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -1,6 +1,7 @@
 use marinara_assets::AssetService;
 use marinara_core::{AppError, AppResult};
 use marinara_storage::FileStorage;
+use serde_json::{json, Value};
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
@@ -8,6 +9,7 @@ use tauri::{AppHandle, Manager};
 use tokio::sync::watch;
 
 use crate::seed_defaults::seed_bundled_defaults;
+use crate::storage_commands::shared::normalize_typed_json_fields;
 
 #[derive(Clone)]
 pub struct AppState {
@@ -54,6 +56,7 @@ impl AppState {
         let game_assets = AssetService::new(data_dir.join("game-assets"))?;
         let backgrounds = AssetService::new(data_dir.join("backgrounds"))?;
         Self::seed_defaults(&storage, &game_assets, &backgrounds, default_data_roots)?;
+        migrate_storage_json_fields(&storage)?;
 
         Ok(Self {
             storage,
@@ -143,4 +146,64 @@ impl AppState {
             Ok(false)
         }
     }
+}
+
+fn migrate_storage_json_fields(storage: &FileStorage) -> AppResult<()> {
+    for collection in [
+        "characters",
+        "character-groups",
+        "personas",
+        "persona-groups",
+        "lorebooks",
+        "lorebook-entries",
+        "prompts",
+        "prompt-sections",
+        "prompt-variables",
+        "chat-presets",
+        "agents",
+        "connections",
+        "chats",
+        "messages",
+        "custom-tools",
+        "regex-scripts",
+        "game-state-snapshots",
+        "game-checkpoints",
+    ] {
+        migrate_collection_json_fields(storage, collection)?;
+    }
+    Ok(())
+}
+
+fn migrate_collection_json_fields(storage: &FileStorage, collection: &str) -> AppResult<()> {
+    let rows = storage.list(collection)?;
+    let mut changed = false;
+    let mut normalized_rows = Vec::with_capacity(rows.len());
+    for mut row in rows {
+        let before = row.clone();
+        if let Some(object) = row.as_object_mut() {
+            if collection == "characters" {
+                match object.get("data") {
+                    Some(Value::Object(_)) => {}
+                    Some(Value::String(raw)) => {
+                        let parsed = serde_json::from_str::<Value>(raw)
+                            .ok()
+                            .filter(Value::is_object)
+                            .unwrap_or_else(|| json!({}));
+                        object.insert("data".to_string(), parsed);
+                    }
+                    Some(_) | None => {
+                        object.insert("data".to_string(), json!({}));
+                    }
+                }
+            } else {
+                normalize_typed_json_fields(collection, object)?;
+            }
+        }
+        changed = changed || row != before;
+        normalized_rows.push(row);
+    }
+    if changed {
+        storage.replace_all(collection, normalized_rows)?;
+    }
+    Ok(())
 }

--- a/src/app/shell/ChatSidebar.tsx
+++ b/src/app/shell/ChatSidebar.tsx
@@ -158,25 +158,18 @@ export function ChatSidebar({
     >();
     if (!allCharacters) return map;
     for (const char of allCharacters as Array<{ id: string; data: unknown; avatarPath: string | null }>) {
-      try {
-        const parsed = typeof char.data === "string" ? JSON.parse(char.data) : char.data;
-        const record = parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : {};
-        const extensions =
-          record.extensions && typeof record.extensions === "object"
-            ? (record.extensions as Record<string, unknown>)
-            : {};
-        const name = typeof record.name === "string" && record.name.trim() ? record.name.trim() : "Unknown";
-        const conversationStatus =
-          typeof extensions.conversationStatus === "string" ? extensions.conversationStatus : undefined;
-        map.set(char.id, {
-          name,
-          avatarUrl: char.avatarPath ?? null,
-          avatarCrop: (extensions.avatarCrop as AvatarCropValue | undefined) ?? null,
-          conversationStatus,
-        });
-      } catch {
-        map.set(char.id, { name: "Unknown", avatarUrl: null });
-      }
+      const record = char.data && typeof char.data === "object" ? (char.data as Record<string, unknown>) : {};
+      const extensions =
+        record.extensions && typeof record.extensions === "object" ? (record.extensions as Record<string, unknown>) : {};
+      const name = typeof record.name === "string" && record.name.trim() ? record.name.trim() : "Unknown";
+      const conversationStatus =
+        typeof extensions.conversationStatus === "string" ? extensions.conversationStatus : undefined;
+      map.set(char.id, {
+        name,
+        avatarUrl: char.avatarPath ?? null,
+        avatarCrop: (extensions.avatarCrop as AvatarCropValue | undefined) ?? null,
+        conversationStatus,
+      });
     }
     return map;
   }, [allCharacters]);

--- a/src/engine/generation/generate-route-utils.ts
+++ b/src/engine/generation/generate-route-utils.ts
@@ -478,10 +478,10 @@ export function parseGameStateRow(row: Record<string, unknown>): GameState {
     location: row.location as string | null,
     weather: row.weather as string | null,
     temperature: row.temperature as string | null,
-    presentCharacters: JSON.parse((row.presentCharacters as string) ?? "[]"),
-    recentEvents: JSON.parse((row.recentEvents as string) ?? "[]"),
-    playerStats: row.playerStats ? JSON.parse(row.playerStats as string) : null,
-    personaStats: row.personaStats ? JSON.parse(row.personaStats as string) : null,
+    presentCharacters: Array.isArray(row.presentCharacters) ? row.presentCharacters : [],
+    recentEvents: Array.isArray(row.recentEvents) ? row.recentEvents : [],
+    playerStats: row.playerStats && typeof row.playerStats === "object" ? (row.playerStats as GameState["playerStats"]) : null,
+    personaStats: Array.isArray(row.personaStats) ? (row.personaStats as GameState["personaStats"]) : null,
     createdAt: row.createdAt as string,
   };
 }

--- a/src/features/catalog/agents/components/AgentEditor.tsx
+++ b/src/features/catalog/agents/components/AgentEditor.tsx
@@ -1876,7 +1876,7 @@ export function AgentEditor() {
                     tool={{
                       name: tool.name,
                       description: tool.description,
-                      parameters: JSON.parse(tool.parametersSchema || "{}"),
+                      parameters: tool.parametersSchema as unknown as ToolDefinition["parameters"],
                     }}
                     enabled={localEnabledTools.includes(tool.name)}
                     onToggle={(name) => {

--- a/src/features/catalog/agents/components/AgentsPanel.tsx
+++ b/src/features/catalog/agents/components/AgentsPanel.tsx
@@ -251,13 +251,7 @@ export function AgentsPanel() {
           <p className="text-[0.625rem] text-[var(--muted-foreground)] px-1 py-2">No regex scripts yet.</p>
         ) : (
           sortedRegexScripts.map((script) => {
-            const placements = (() => {
-              try {
-                return JSON.parse(script.placement) as string[];
-              } catch {
-                return [];
-              }
-            })();
+            const placements = Array.isArray(script.placement) ? script.placement : [];
             const enabled = script.enabled === "true";
             return (
               <div

--- a/src/features/catalog/agents/components/RegexScriptEditor.tsx
+++ b/src/features/catalog/agents/components/RegexScriptEditor.tsx
@@ -130,12 +130,16 @@ export function RegexScriptEditor() {
       setLocalFindRegex(dbRow.findRegex);
       setLocalReplaceString(dbRow.replaceString);
       try {
-        setLocalTrimStrings(JSON.parse(dbRow.trimStrings));
+        setLocalTrimStrings(Array.isArray(dbRow.trimStrings) ? dbRow.trimStrings : []);
       } catch {
         setLocalTrimStrings([]);
       }
       try {
-        setLocalPlacement(JSON.parse(dbRow.placement));
+        setLocalPlacement(
+          Array.isArray(dbRow.placement)
+            ? dbRow.placement.filter((value): value is RegexPlacement => value === "ai_output" || value === "user_input")
+            : [],
+        );
       } catch {
         setLocalPlacement(["ai_output"]);
       }

--- a/src/features/catalog/agents/components/ToolEditor.tsx
+++ b/src/features/catalog/agents/components/ToolEditor.tsx
@@ -76,25 +76,20 @@ export function ToolEditor() {
       setLocalExecType(dbTool.executionType === "webhook" ? "webhook" : "static");
       setLocalWebhookUrl(dbTool.webhookUrl ?? "");
       setLocalStaticResult(dbTool.staticResult ?? "");
-      // Parse params from schema
-      try {
-        const schema = JSON.parse(dbTool.parametersSchema || "{}");
-        const props = schema.properties ?? {};
-        const req: string[] = schema.required ?? [];
-        setLocalParams(
-          Object.entries(props).map(([name, p]) => {
-            const prop = p as { type?: string; description?: string };
-            return {
-              name,
-              type: prop.type ?? "string",
-              description: prop.description ?? "",
-              required: req.includes(name),
-            };
-          }),
-        );
-      } catch {
-        setLocalParams([]);
-      }
+      const schema = dbTool.parametersSchema ?? {};
+      const props = (schema.properties as Record<string, unknown> | undefined) ?? {};
+      const req: string[] = Array.isArray(schema.required) ? schema.required.filter((value): value is string => typeof value === "string") : [];
+      setLocalParams(
+        Object.entries(props).map(([name, p]) => {
+          const prop = p as { type?: string; description?: string };
+          return {
+            name,
+            type: prop.type ?? "string",
+            description: prop.description ?? "",
+            required: req.includes(name),
+          };
+        }),
+      );
     } else if (isNew) {
       setLocalName("");
       setLocalDesc("");

--- a/src/features/catalog/agents/hooks/use-custom-tools.ts
+++ b/src/features/catalog/agents/hooks/use-custom-tools.ts
@@ -9,7 +9,7 @@ export interface CustomToolRow {
   id: string;
   name: string;
   description: string;
-  parametersSchema: string;
+  parametersSchema: Record<string, unknown>;
   executionType: string;
   webhookUrl: string | null;
   staticResult: string | null;

--- a/src/features/catalog/agents/hooks/use-regex-scripts.ts
+++ b/src/features/catalog/agents/hooks/use-regex-scripts.ts
@@ -15,8 +15,8 @@ export interface RegexScriptRow {
   enabled: string;
   findRegex: string;
   replaceString: string;
-  trimStrings: string;
-  placement: string;
+  trimStrings: string[];
+  placement: string[];
   flags: string;
   promptOnly: string;
   order: number;

--- a/src/features/catalog/agents/regex-application.ts
+++ b/src/features/catalog/agents/regex-application.ts
@@ -16,14 +16,9 @@ interface ParsedRegexScript extends RegexScriptRow {
   trimList: string[];
 }
 
-function parseJsonArray<T extends string>(value: string, allowed?: Set<T>): T[] {
-  try {
-    const parsed = JSON.parse(value) as unknown;
-    if (!Array.isArray(parsed)) return [];
-    return parsed.filter((entry): entry is T => typeof entry === "string" && (!allowed || allowed.has(entry as T)));
-  } catch {
-    return allowed?.has(value as T) ? [value as T] : [];
-  }
+function parseJsonArray<T extends string>(value: unknown, allowed?: Set<T>): T[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((entry): entry is T => typeof entry === "string" && (!allowed || allowed.has(entry as T)));
 }
 
 function parseScript(row: RegexScriptRow): ParsedRegexScript {

--- a/src/features/catalog/characters/components/CharacterEditor.tsx
+++ b/src/features/catalog/characters/components/CharacterEditor.tsx
@@ -121,7 +121,7 @@ interface AltDescriptionEntry {
 
 interface ParsedCharacter {
   id: string;
-  data: string;
+  data: CharacterData;
   comment: string;
   avatarPath: string | null;
   spriteFolderPath: string | null;
@@ -224,18 +224,10 @@ export function CharacterEditor() {
 
     loadedCharacterIdRef.current = char.id;
 
-    try {
-      const parsed = typeof char.data === "string" ? JSON.parse(char.data) : char.data;
-      setFormData(parsed as CharacterData);
-      setCharacterComment(char.comment ?? "");
-      setAvatarPreview(char.avatarPath);
-      setDirtyState(false);
-    } catch {
-      setFormData(null);
-      setCharacterComment("");
-      setAvatarPreview(null);
-      setDirtyState(false);
-    }
+    setFormData(char.data ?? null);
+    setCharacterComment(char.comment ?? "");
+    setAvatarPreview(char.avatarPath);
+    setDirtyState(false);
   }, [rawCharacter, setDirtyState]);
 
   const updateField = useCallback(<K extends keyof CharacterData>(key: K, value: CharacterData[K]) => {
@@ -465,7 +457,7 @@ export function CharacterEditor() {
 
     const rpgStats = formData.extensions.rpgStats as RPGStatsConfig | undefined;
     const personaStats = rpgStats
-      ? JSON.stringify({
+      ? {
           enabled: !!rpgStats.enabled,
           bars: [
             { name: "Satiety", value: 100, max: 100, color: "#f59e0b" },
@@ -474,8 +466,8 @@ export function CharacterEditor() {
             { name: "Mood", value: 100, max: 100, color: "#ec4899" },
           ],
           rpgStats,
-        })
-      : "";
+        }
+      : null;
 
     try {
       const created = (await createPersona.mutateAsync({
@@ -493,8 +485,8 @@ export function CharacterEditor() {
           parseTrackerCardColorConfig(formData.extensions.trackerCardColors),
         ),
         personaStats,
-        altDescriptions: "[]",
-        tags: JSON.stringify(formData.tags ?? []),
+        altDescriptions: [],
+        tags: formData.tags ?? [],
       })) as { id?: string };
 
       const personaId = created?.id;

--- a/src/features/catalog/characters/components/CharacterLibraryView.tsx
+++ b/src/features/catalog/characters/components/CharacterLibraryView.tsx
@@ -24,7 +24,7 @@ type SortOption = "name-asc" | "name-desc" | "newest" | "oldest" | "favorites";
 
 type CharacterRow = {
   id: string;
-  data: string;
+  data: Partial<CharacterData>;
   comment?: string | null;
   avatarPath: string | null;
   createdAt: string;
@@ -38,12 +38,7 @@ type ParsedCharacterRow = CharacterRow & {
 };
 
 function parseCharacterRow(char: CharacterRow): ParsedCharacterRow {
-  try {
-    const parsed = typeof char.data === "string" ? JSON.parse(char.data) : char.data;
-    return { ...char, parsed: (parsed as ParsedCharacterRow["parsed"]) ?? {} };
-  } catch {
-    return { ...char, parsed: { name: "Unknown", description: "" } };
-  }
+  return { ...char, parsed: (char.data as ParsedCharacterRow["parsed"]) ?? {} };
 }
 
 function getText(value: unknown) {

--- a/src/features/catalog/characters/components/CharactersPanel.tsx
+++ b/src/features/catalog/characters/components/CharactersPanel.tsx
@@ -54,7 +54,7 @@ import { CharacterAvatarImage } from "./CharacterAvatarImage";
 
 type CharacterRow = {
   id: string;
-  data: string;
+  data: Record<string, any>;
   comment?: string | null;
   avatarPath: string | null;
   createdAt: string;
@@ -161,24 +161,17 @@ export function CharactersPanel() {
   const [selectedCharacterIds, setSelectedCharacterIds] = useState<Set<string>>(new Set());
   const [exportingSelected, setExportingSelected] = useState(false);
 
-  const chatCharacterIds: string[] = activeChat
-    ? ((typeof activeChat.characterIds === "string" ? JSON.parse(activeChat.characterIds) : activeChat.characterIds) ??
-      [])
-    : [];
+  const chatCharacterIds: string[] = activeChat ? (activeChat.characterIds ?? []) : [];
 
   const isConversation = (activeChat as unknown as { mode?: string })?.mode === "conversation";
 
-  // Parse character data and filter by search
+  // Character data is stored as raw JSON objects.
   const parsedCharacters = useMemo(() => {
     if (!characters) return [];
-    return (characters as CharacterRow[]).map((char) => {
-      try {
-        const parsed = typeof char.data === "string" ? JSON.parse(char.data) : char.data;
-        return { ...char, parsed };
-      } catch {
-        return { ...char, parsed: { name: "Unknown", description: "" } };
-      }
-    });
+    return (characters as CharacterRow[]).map((char) => ({
+      ...char,
+      parsed: char.data ?? { name: "Unknown", description: "" },
+    }));
   }, [characters]) as ParsedCharacterRow[];
 
   const charMap = useMemo(() => {
@@ -336,7 +329,7 @@ export function CharactersPanel() {
       ...g,
       memberIds: (() => {
         try {
-          return JSON.parse(g.characterIds);
+          return Array.isArray(g.characterIds) ? g.characterIds : [];
         } catch {
           return [];
         }
@@ -358,16 +351,12 @@ export function CharactersPanel() {
           const charList = (characters ?? []) as CharacterRow[];
           const char = charList.find((c) => c.id === charId);
           if (!char) return;
-          try {
-            const parsed = typeof char.data === "string" ? JSON.parse(char.data) : char.data;
-            const firstMes = (parsed as { first_mes?: string }).first_mes;
-            const altGreetings = (parsed as { alternate_greetings?: string[] }).alternate_greetings ?? [];
-            const name = (parsed as { name?: string }).name ?? "Unknown";
-            if (firstMes) {
-              setFirstMesConfirm({ charId, charName: name, message: firstMes, alternateGreetings: altGreetings });
-            }
-          } catch {
-            /* ignore */
+          const parsed = char.data;
+          const firstMes = (parsed as { first_mes?: string }).first_mes;
+          const altGreetings = (parsed as { alternate_greetings?: string[] }).alternate_greetings ?? [];
+          const name = (parsed as { name?: string }).name ?? "Unknown";
+          if (firstMes) {
+            setFirstMesConfirm({ charId, charName: name, message: firstMes, alternateGreetings: altGreetings });
           }
         },
       },
@@ -389,17 +378,13 @@ export function CharactersPanel() {
           for (const charId of newlyAdded) {
             const char = charList.find((c) => c.id === charId);
             if (!char) continue;
-            try {
-              const parsed = typeof char.data === "string" ? JSON.parse(char.data) : char.data;
-              const firstMes = (parsed as { first_mes?: string }).first_mes;
-              const altGreetings = (parsed as { alternate_greetings?: string[] }).alternate_greetings ?? [];
-              const name = (parsed as { name?: string }).name ?? "Unknown";
-              if (firstMes) {
-                setFirstMesConfirm({ charId, charName: name, message: firstMes, alternateGreetings: altGreetings });
-                break; // show one at a time
-              }
-            } catch {
-              /* ignore */
+            const parsed = char.data;
+            const firstMes = (parsed as { first_mes?: string }).first_mes;
+            const altGreetings = (parsed as { alternate_greetings?: string[] }).alternate_greetings ?? [];
+            const name = (parsed as { name?: string }).name ?? "Unknown";
+            if (firstMes) {
+              setFirstMesConfirm({ charId, charName: name, message: firstMes, alternateGreetings: altGreetings });
+              break; // show one at a time
             }
           }
         },

--- a/src/features/catalog/characters/hooks/use-characters.ts
+++ b/src/features/catalog/characters/hooks/use-characters.ts
@@ -391,11 +391,11 @@ export function useCreatePersona() {
       dialogueColor?: string;
       boxColor?: string;
       trackerCardColors?: string;
-      personaStats?: string;
-      altDescriptions?: string;
-      tags?: string;
-      savedStatusOptions?: string;
-      avatarCrop?: string;
+      personaStats?: unknown;
+      altDescriptions?: unknown[];
+      tags?: string[];
+      savedStatusOptions?: string[];
+      avatarCrop?: unknown;
     }) => storageApi.create("personas", data),
     onSuccess: () => qc.invalidateQueries({ queryKey: characterKeys.personas }),
   });
@@ -420,11 +420,11 @@ export function useUpdatePersona() {
       dialogueColor?: string;
       boxColor?: string;
       trackerCardColors?: string;
-      personaStats?: string;
-      altDescriptions?: string;
-      tags?: string;
-      savedStatusOptions?: string;
-      avatarCrop?: string;
+      personaStats?: unknown;
+      altDescriptions?: unknown[];
+      tags?: string[];
+      savedStatusOptions?: string[];
+      avatarCrop?: unknown;
     }) => storageApi.update("personas", id, data),
     onSuccess: (updatedPersona, variables) => {
       qc.setQueryData<unknown[] | undefined>(characterKeys.personas, (old) => {

--- a/src/features/catalog/lorebooks/components/LorebookEditor.tsx
+++ b/src/features/catalog/lorebooks/components/LorebookEditor.tsx
@@ -308,14 +308,10 @@ export function LorebookEditor() {
   const folders = useMemo(() => (rawFolders ?? []) as LorebookFolder[], [rawFolders]);
   const characters = useMemo(() => {
     if (!rawCharacters) return [] as Array<{ id: string; name: string; tags: string[] }>;
-    return (rawCharacters as Array<{ id: string; data: string | Record<string, unknown> }>).map((c) => {
-      try {
-        const parsed = typeof c.data === "string" ? JSON.parse(c.data) : c.data;
-        const tags = Array.isArray(parsed?.tags) ? parsed.tags.map(String).filter(Boolean) : [];
-        return { id: c.id, name: parsed?.name ?? "Unknown", tags };
-      } catch {
-        return { id: c.id, name: "Unknown", tags: [] };
-      }
+    return (rawCharacters as Array<{ id: string; data: Record<string, unknown> }>).map((c) => {
+      const parsed = c.data;
+      const tags = Array.isArray(parsed?.tags) ? parsed.tags.map(String).filter(Boolean) : [];
+      return { id: c.id, name: typeof parsed?.name === "string" ? parsed.name : "Unknown", tags };
     });
   }, [rawCharacters]);
   const characterTags = useMemo(

--- a/src/features/catalog/lorebooks/components/LorebooksPanel.tsx
+++ b/src/features/catalog/lorebooks/components/LorebooksPanel.tsx
@@ -100,13 +100,9 @@ export function LorebooksPanel() {
   const characterNameById = useMemo(() => {
     const map = new Map<string, string>();
     if (!rawCharacters) return map;
-    for (const c of rawCharacters as Array<{ id: string; data: string | Record<string, unknown> }>) {
-      try {
-        const d = typeof c.data === "string" ? JSON.parse(c.data) : c.data;
-        map.set(c.id, d?.name ?? "Unknown");
-      } catch {
-        map.set(c.id, "Unknown");
-      }
+    for (const c of rawCharacters as Array<{ id: string; data: Record<string, unknown> }>) {
+      const d = c.data;
+      map.set(c.id, typeof d?.name === "string" ? d.name : "Unknown");
     }
     return map;
   }, [rawCharacters]);

--- a/src/features/catalog/personas/components/PersonaEditor.tsx
+++ b/src/features/catalog/personas/components/PersonaEditor.tsx
@@ -105,10 +105,9 @@ interface PersonaFormData {
   dialogueColor: string;
   boxColor: string;
   trackerCardColors: TrackerCardColorConfig;
-  personaStats: string;
+  personaStats: PersonaStatsData | null;
   altDescriptions: AltDescriptionEntry[];
   tags: string[];
-  /** Avatar crop region parsed from the persona row's JSON-encoded `avatarCrop`. */
   avatarCrop: AvatarCrop | null;
 }
 
@@ -122,17 +121,16 @@ interface PersonaRow {
   backstory: string;
   appearance: string;
   avatarPath: string | null;
-  /** JSON-encoded AvatarCrop, or empty string when unset. */
-  avatarCrop?: string;
+  avatarCrop?: AvatarCrop | null;
   isActive: string | boolean;
   nameColor?: string;
   dialogueColor?: string;
   boxColor?: string;
   trackerCardColors?: string;
   [TRACKER_CARD_COLOR_PREVIEW_BASE_FIELD]?: string;
-  personaStats?: string;
-  altDescriptions?: string;
-  tags?: string;
+  personaStats?: Record<string, unknown> | string;
+  altDescriptions?: AltDescriptionEntry[];
+  tags?: string[];
 }
 
 export function PersonaEditor() {
@@ -183,47 +181,30 @@ export function PersonaEditor() {
 
     loadedPersonaIdRef.current = rawPersona.id;
 
-    let parsedAltDescs: AltDescriptionEntry[] = [];
-    try {
-      const raw = rawPersona.altDescriptions;
-      if (raw) parsedAltDescs = JSON.parse(raw);
-    } catch {
-      /* ignore */
-    }
+    const parsedAltDescs: AltDescriptionEntry[] = Array.isArray(rawPersona.altDescriptions) ? rawPersona.altDescriptions : [];
 
     let parsedAvatarCrop: AvatarCrop | null = null;
-    try {
-      const raw = rawPersona.avatarCrop;
-      if (raw) {
-        const obj = JSON.parse(raw);
-        // Defensive: malformed crop data is dropped so the editor falls back to defaults.
-        if (obj && typeof obj === "object") {
-          // Validate geometry — finite, positive, within normalized bounds.
-          // Anything malformed is dropped so the editor falls back to defaults
-          // instead of producing NaN transforms or an off-screen overlay.
-          if (
-            Number.isFinite(obj.srcX) &&
-            Number.isFinite(obj.srcY) &&
-            Number.isFinite(obj.srcWidth) &&
-            Number.isFinite(obj.srcHeight) &&
-            obj.srcWidth > 0 &&
-            obj.srcHeight > 0 &&
-            obj.srcX >= 0 &&
-            obj.srcY >= 0 &&
-            obj.srcX + obj.srcWidth <= 1.001 &&
-            obj.srcY + obj.srcHeight <= 1.001
-          ) {
-            parsedAvatarCrop = {
-              srcX: obj.srcX,
-              srcY: obj.srcY,
-              srcWidth: obj.srcWidth,
-              srcHeight: obj.srcHeight,
-            };
-          }
-        }
+    const obj = rawPersona.avatarCrop;
+    if (obj && typeof obj === "object") {
+      if (
+        Number.isFinite(obj.srcX) &&
+        Number.isFinite(obj.srcY) &&
+        Number.isFinite(obj.srcWidth) &&
+        Number.isFinite(obj.srcHeight) &&
+        obj.srcWidth > 0 &&
+        obj.srcHeight > 0 &&
+        obj.srcX >= 0 &&
+        obj.srcY >= 0 &&
+        obj.srcX + obj.srcWidth <= 1.001 &&
+        obj.srcY + obj.srcHeight <= 1.001
+      ) {
+        parsedAvatarCrop = {
+          srcX: obj.srcX,
+          srcY: obj.srcY,
+          srcWidth: obj.srcWidth,
+          srcHeight: obj.srcHeight,
+        };
       }
-    } catch {
-      /* ignore — empty / malformed crop just stays null */
     }
 
     const savedTrackerCardColors =
@@ -243,15 +224,12 @@ export function PersonaEditor() {
       dialogueColor: rawPersona.dialogueColor ?? "",
       boxColor: rawPersona.boxColor ?? "",
       trackerCardColors: parseTrackerCardColorConfig(savedTrackerCardColors),
-      personaStats: rawPersona.personaStats ?? "",
+      personaStats:
+        rawPersona.personaStats && typeof rawPersona.personaStats === "object"
+          ? (rawPersona.personaStats as unknown as PersonaStatsData)
+          : null,
       altDescriptions: parsedAltDescs,
-      tags: (() => {
-        try {
-          return rawPersona.tags ? JSON.parse(rawPersona.tags) : [];
-        } catch {
-          return [];
-        }
-      })(),
+      tags: Array.isArray(rawPersona.tags) ? rawPersona.tags : [],
       avatarCrop: parsedAvatarCrop,
     });
     setAvatarPreview(rawPersona.avatarPath);
@@ -271,11 +249,10 @@ export function PersonaEditor() {
       await updatePersona.mutateAsync({
         id: personaId,
         ...rest,
-        altDescriptions: JSON.stringify(altDescriptions),
-        tags: JSON.stringify(tags),
+        altDescriptions,
+        tags,
         trackerCardColors: serializeTrackerCardColorConfig(formData.trackerCardColors),
-        // Persist as JSON string; empty string means "no crop".
-        avatarCrop: avatarCrop ? JSON.stringify(avatarCrop) : "",
+        avatarCrop: avatarCrop ?? null,
       });
       setDirty(false);
     } finally {
@@ -1622,18 +1599,10 @@ function PersonaStatsTab({
   formData: PersonaFormData;
   updateField: <K extends keyof PersonaFormData>(key: K, value: PersonaFormData[K]) => void;
 }) {
-  const parsed: PersonaStatsData = formData.personaStats
-    ? (() => {
-        try {
-          return JSON.parse(formData.personaStats) as PersonaStatsData;
-        } catch {
-          return DEFAULT_PERSONA_STATS;
-        }
-      })()
-    : DEFAULT_PERSONA_STATS;
+  const parsed: PersonaStatsData = formData.personaStats ?? DEFAULT_PERSONA_STATS;
 
   const save = (next: PersonaStatsData) => {
-    updateField("personaStats", JSON.stringify(next));
+    updateField("personaStats", next);
   };
 
   const updateBar = (index: number, field: string, value: string | number) => {

--- a/src/features/catalog/personas/components/PersonasPanel.tsx
+++ b/src/features/catalog/personas/components/PersonasPanel.tsx
@@ -57,10 +57,10 @@ type PersonaRow = {
   avatarPath: string | null;
   isActive: string | boolean;
   createdAt: string;
-  tags?: string;
+  tags?: string[];
 };
 
-type PersonaGroupRow = { id: string; name: string; description: string; personaIds: string };
+type PersonaGroupRow = { id: string; name: string; description: string; personaIds: string[] };
 
 type SortOption = "name-asc" | "name-desc" | "newest" | "oldest" | "tokens";
 
@@ -137,13 +137,7 @@ export function PersonasPanel() {
 
   const rawList = useMemo(() => (personas as PersonaRow[] | undefined) ?? [], [personas]);
 
-  const parseTags = (p: PersonaRow): string[] => {
-    try {
-      return p.tags ? JSON.parse(p.tags) : [];
-    } catch {
-      return [];
-    }
-  };
+  const parseTags = (p: PersonaRow): string[] => (Array.isArray(p.tags) ? p.tags : []);
 
   const allTags = useMemo(() => {
     const tagSet = new Set<string>();
@@ -169,7 +163,7 @@ export function PersonasPanel() {
         const affected = rawList.filter((p) => parseTags(p).includes(tag));
         for (const p of affected) {
           const newTags = parseTags(p).filter((t) => t !== tag);
-          await updatePersona.mutateAsync({ id: p.id, tags: JSON.stringify(newTags) });
+          await updatePersona.mutateAsync({ id: p.id, tags: newTags });
         }
         if (activeTag === tag) setActiveTag(null);
       } catch {
@@ -190,11 +184,7 @@ export function PersonasPanel() {
     return (personaGroupsRaw as PersonaGroupRow[]).map((g) => ({
       ...g,
       memberIds: (() => {
-        try {
-          return JSON.parse(g.personaIds);
-        } catch {
-          return [];
-        }
+        return Array.isArray(g.personaIds) ? g.personaIds : [];
       })() as string[],
     }));
   }, [personaGroupsRaw]);

--- a/src/features/catalog/personas/hooks/use-personas.ts
+++ b/src/features/catalog/personas/hooks/use-personas.ts
@@ -29,7 +29,11 @@ export function useUpdatePersona() {
       scenario?: string;
       backstory?: string;
       appearance?: string;
-      tags?: string;
+      tags?: string[];
+      altDescriptions?: unknown[];
+      savedStatusOptions?: string[];
+      avatarCrop?: unknown;
+      personaStats?: unknown;
     }) => storageApi.update("personas", id, data),
     onSuccess: () => qc.invalidateQueries({ queryKey: personaKeys.list }),
   });

--- a/src/features/catalog/presets/components/ChoiceSelectionModal.tsx
+++ b/src/features/catalog/presets/components/ChoiceSelectionModal.tsx
@@ -53,12 +53,7 @@ export function ChoiceSelectionModal({
   const variables = useMemo<VariableData[]>(() => {
     if (!data?.choiceBlocks) return [];
     return (data.choiceBlocks as any[]).map((cb: any) => {
-      let opts: ChoiceOption[] = [];
-      try {
-        opts = typeof cb.options === "string" ? JSON.parse(cb.options) : (cb.options ?? []);
-      } catch {
-        /* empty */
-      }
+      const opts: ChoiceOption[] = Array.isArray(cb.options) ? cb.options : [];
       return {
         id: cb.id,
         variableName: cb.variableName ?? cb.variable_name ?? "unknown",
@@ -73,12 +68,7 @@ export function ChoiceSelectionModal({
   // Parse saved default choices from preset
   const defaultChoices = useMemo<Record<string, string | string[]>>(() => {
     if (!data?.preset) return {};
-    try {
-      const raw = (data.preset as any).defaultChoices ?? (data.preset as any).default_choices;
-      return typeof raw === "string" ? JSON.parse(raw) : (raw ?? {});
-    } catch {
-      return {};
-    }
+    return ((data.preset as any).defaultChoices ?? (data.preset as any).default_choices ?? {}) as Record<string, string | string[]>;
   }, [data?.preset]);
 
   // Base selections derived from existing choices / defaults / first option.

--- a/src/features/catalog/presets/components/PresetEditor.tsx
+++ b/src/features/catalog/presets/components/PresetEditor.tsx
@@ -194,11 +194,7 @@ export function PresetEditor() {
     setLocalDescription(p.description ?? "");
     setLocalWrapFormat((p.wrapFormat ?? "xml") as WrapFormat);
     setLocalAuthor(p.author ?? "");
-    try {
-      setLocalParams(typeof p.parameters === "string" ? JSON.parse(p.parameters) : (p.parameters ?? {}));
-    } catch {
-      setLocalParams({});
-    }
+    setLocalParams(p.parameters ?? {});
   }, [data]);
 
   const handleClose = useCallback(() => {
@@ -251,11 +247,7 @@ export function PresetEditor() {
   const sectionOrder = useMemo(() => {
     if (!data?.preset) return [];
     const p = data.preset as any;
-    try {
-      return typeof p.sectionOrder === "string" ? JSON.parse(p.sectionOrder) : (p.sectionOrder ?? []);
-    } catch {
-      return [];
-    }
+    return Array.isArray(p.sectionOrder) ? p.sectionOrder : [];
   }, [data]);
 
   const orderedSections = useMemo(() => {
@@ -268,15 +260,10 @@ export function PresetEditor() {
     return orderedSections.some((section: any) => {
       if (section.enabled !== "true" && section.enabled !== true) return false;
       if (section.isMarker !== "true" && section.isMarker !== true) return false;
-      try {
-        const config =
-          typeof section.markerConfig === "string" ? JSON.parse(section.markerConfig) : section.markerConfig;
-        return (
-          config?.type === "lorebook" || config?.type === "world_info_before" || config?.type === "world_info_after"
-        );
-      } catch {
-        return false;
-      }
+      const config = section.markerConfig;
+      return (
+        config?.type === "lorebook" || config?.type === "world_info_before" || config?.type === "world_info_after"
+      );
     });
   }, [orderedSections]);
   const parentChatHasLorebook = useMemo(() => {
@@ -697,7 +684,7 @@ function SectionsTab({
   const injectableAgents = useMemo(() => {
     if (!agentConfigs) return [];
     return (agentConfigs as AgentConfigRow[]).filter((a) => {
-      const settings = typeof a.settings === "string" ? JSON.parse(a.settings) : a.settings;
+      const settings = a.settings as unknown as Record<string, unknown>;
       return settings?.injectAsSection === true;
     });
   }, [agentConfigs]);
@@ -1229,10 +1216,7 @@ function SectionsTab({
                       {isMarker &&
                         section.markerConfig &&
                         (() => {
-                          const mc =
-                            typeof section.markerConfig === "string"
-                              ? JSON.parse(section.markerConfig)
-                              : section.markerConfig;
+                          const mc = section.markerConfig;
                           const isAgentMarker = mc.type === "agent_data";
                           return isAgentMarker ? (
                             <div className="space-y-2">
@@ -1570,13 +1554,9 @@ function VariableCard({
   canMoveDown: boolean;
   isReordering: boolean;
 }) {
-  // Parse options
-  let opts: Array<{ id: string; label: string; value: string }> = [];
-  try {
-    opts = typeof variable.options === "string" ? JSON.parse(variable.options) : (variable.options ?? []);
-  } catch {
-    /* empty */
-  }
+  const opts: Array<{ id: string; label: string; value: string }> = Array.isArray(variable.options)
+    ? variable.options
+    : [];
 
   const varName = variable.variableName ?? variable.variable_name ?? "";
   const question = variable.question ?? "";

--- a/src/features/catalog/presets/components/PresetsPanel.tsx
+++ b/src/features/catalog/presets/components/PresetsPanel.tsx
@@ -90,15 +90,7 @@ export function PresetsPanel() {
     );
   };
 
-  const getSectionCount = (preset: PresetRow) => {
-    try {
-      const order = preset.sectionOrder;
-      if (Array.isArray(order)) return order.length;
-      return JSON.parse(order ?? "[]").length;
-    } catch {
-      return 0;
-    }
-  };
+  const getSectionCount = (preset: PresetRow) => (Array.isArray(preset.sectionOrder) ? preset.sectionOrder.length : 0);
 
   const exitSelectionMode = () => {
     setSelectionMode(false);

--- a/src/features/catalog/presets/hooks/use-presets.ts
+++ b/src/features/catalog/presets/hooks/use-presets.ts
@@ -40,10 +40,7 @@ const promptOrderField: Record<PromptNestedKind, string> = {
 const presetOrderQueues = new Map<string, Promise<void>>();
 
 function parseOrderIds(value: unknown): string[] {
-  if (Array.isArray(value)) return value.filter((id): id is string => typeof id === "string");
-  if (typeof value !== "string" || !value.trim()) return [];
-  const parsed = JSON.parse(value) as unknown;
-  return Array.isArray(parsed) ? parsed.filter((id): id is string => typeof id === "string") : [];
+  return Array.isArray(value) ? value.filter((id): id is string => typeof id === "string") : [];
 }
 
 async function runPresetOrderUpdate<T>(presetId: string, task: () => Promise<T>): Promise<T> {
@@ -372,7 +369,7 @@ export function useReorderSections() {
       if (prev?.preset?.sectionOrder) {
         qc.setQueryData(presetKeys.full(presetId), {
           ...prev,
-          preset: { ...prev.preset, sectionOrder: JSON.stringify(sectionIds) },
+          preset: { ...prev.preset, sectionOrder: sectionIds },
         });
       }
       return { prev };

--- a/src/features/modes/conversation/components/ConversationInput.tsx
+++ b/src/features/modes/conversation/components/ConversationInput.tsx
@@ -1426,7 +1426,7 @@ export function ConversationInput({
       }
       await updatePersona.mutateAsync({
         id: activePersona.id,
-        savedStatusOptions: JSON.stringify(nextOptions.slice(0, SAVED_STATUS_LIMIT)),
+        savedStatusOptions: nextOptions.slice(0, SAVED_STATUS_LIMIT),
       });
     },
     [activePersona, updatePersona],

--- a/src/features/modes/conversation/hooks/autonomous/use-background-autonomous.ts
+++ b/src/features/modes/conversation/hooks/autonomous/use-background-autonomous.ts
@@ -31,7 +31,7 @@ interface RawChat {
 
 interface RawCharacter {
   id: string;
-  data?: string | { name?: string };
+  data?: { name?: string; extensions?: { avatarCrop?: AvatarCropValue | null } };
   avatarPath?: string | null;
 }
 
@@ -165,7 +165,7 @@ export function useBackgroundAutonomousPolling() {
                   // Find the triggering character's name
                   const charRow = await storageApi.get<RawCharacter>("characters", characterId);
                   if (charRow) {
-                    const data = typeof charRow.data === "string" ? JSON.parse(charRow.data) : charRow.data;
+                    const data = charRow.data;
                     if (data?.name) charName = data.name;
                     charAvatarCrop = data?.extensions?.avatarCrop ?? null;
                     charAvatar = charRow.avatarPath ?? null;

--- a/src/features/modes/router/components/RecentChats.tsx
+++ b/src/features/modes/router/components/RecentChats.tsx
@@ -39,17 +39,13 @@ export function RecentChats() {
       { name: string; avatarUrl: string | null; avatarCrop?: AvatarCropValue | null }
     >();
     if (!allCharacters) return map;
-    for (const char of allCharacters as Array<{ id: string; data: string; avatarPath: string | null }>) {
-      try {
-        const parsed = typeof char.data === "string" ? JSON.parse(char.data) : char.data;
-        map.set(char.id, {
-          name: parsed.name ?? "Unknown",
-          avatarUrl: char.avatarPath ?? null,
-          avatarCrop: parsed.extensions?.avatarCrop ?? null,
-        });
-      } catch {
-        map.set(char.id, { name: "Unknown", avatarUrl: null });
-      }
+    for (const char of allCharacters as Array<{ id: string; data: Record<string, any>; avatarPath: string | null }>) {
+      const parsed = char.data ?? {};
+      map.set(char.id, {
+        name: parsed.name ?? "Unknown",
+        avatarUrl: char.avatarPath ?? null,
+        avatarCrop: parsed.extensions?.avatarCrop ?? null,
+      });
     }
     return map;
   }, [allCharacters]);
@@ -91,7 +87,7 @@ function RecentChatChip({
 
   const charIds: string[] = useMemo(() => {
     if (!chat.characterIds) return [];
-    return typeof chat.characterIds === "string" ? JSON.parse(chat.characterIds) : chat.characterIds;
+    return chat.characterIds;
   }, [chat.characterIds]);
 
   const firstAvatar = useMemo(() => {

--- a/src/features/modes/shared/chat-ui/components/ChatSettingsDrawer.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatSettingsDrawer.tsx
@@ -322,7 +322,7 @@ export function ChatSettingsDrawer({
   const personas = useMemo(() => (allPersonas ?? []) as DrawerPersona[], [allPersonas]);
 
   const chatCharIds: string[] = useMemo(
-    () => (typeof chat.characterIds === "string" ? JSON.parse(chat.characterIds) : (chat.characterIds ?? [])),
+    () => chat.characterIds ?? [],
     [chat.characterIds],
   );
 
@@ -550,7 +550,7 @@ export function ChatSettingsDrawer({
     () =>
       (allCharacters ?? []) as Array<{
         id: string;
-        data: string;
+        data: unknown;
         comment?: string | null;
         avatarPath: string | null;
       }>,
@@ -561,7 +561,7 @@ export function ChatSettingsDrawer({
     () =>
       chatCharIds
         .map((characterId) => characters.find((character) => character.id === characterId))
-        .filter((character): character is { id: string; data: string; avatarPath: string | null } => !!character),
+        .filter((character): character is { id: string; data: unknown; avatarPath: string | null } => !!character),
     [chatCharIds, characters],
   );
 
@@ -616,7 +616,7 @@ export function ChatSettingsDrawer({
   }, [charInfoMap]);
 
   const getCharacterInfo = useCallback(
-    (c: { id?: string; data: string; comment?: string | null }) => {
+    (c: { id?: string; data: unknown; comment?: string | null }) => {
       if (c.id && charInfoMap.has(c.id)) return charInfoMap.get(c.id)!;
       return parseCharacterDisplayData(c);
     },
@@ -624,27 +624,22 @@ export function ChatSettingsDrawer({
   );
 
   const charName = useCallback(
-    (c: { id?: string; data: string; comment?: string | null }) => getCharacterInfo(c).name,
+    (c: { id?: string; data: unknown; comment?: string | null }) => getCharacterInfo(c).name,
     [getCharacterInfo],
   );
 
   const charTitle = useCallback(
-    (c: { id?: string; data: string; comment?: string | null }) => getCharacterTitle(getCharacterInfo(c)),
+    (c: { id?: string; data: unknown; comment?: string | null }) => getCharacterTitle(getCharacterInfo(c)),
     [getCharacterInfo],
   );
 
   const charAvatarCrop = useCallback((c: { data: unknown }) => {
-    try {
-      const parsed = typeof c.data === "string" ? JSON.parse(c.data) : c.data;
-      return (
-        ((parsed as { extensions?: { avatarCrop?: AvatarCrop | null } } | null)?.extensions?.avatarCrop as
-          | AvatarCrop
-          | null
-          | undefined) ?? null
-      );
-    } catch {
-      return null;
-    }
+    return (
+      ((c.data as { extensions?: { avatarCrop?: AvatarCrop | null } } | null)?.extensions?.avatarCrop as
+        | AvatarCrop
+        | null
+        | undefined) ?? null
+    );
   }, []);
 
   // ── First message confirm state ──
@@ -730,20 +725,16 @@ export function ChatSettingsDrawer({
             if (isConversation) return;
             const char = characters.find((c) => c.id === charId);
             if (!char) return;
-            try {
-              const parsed = typeof char.data === "string" ? JSON.parse(char.data) : char.data;
-              const firstMes = (parsed as { first_mes?: string }).first_mes;
-              const altGreetings = (parsed as { alternate_greetings?: string[] }).alternate_greetings ?? [];
-              if (firstMes) {
-                setFirstMesConfirm({
-                  charId,
-                  charName: charName(char),
-                  message: firstMes,
-                  alternateGreetings: altGreetings,
-                });
-              }
-            } catch {
-              /* ignore parse errors */
+            const parsed = char.data;
+            const firstMes = (parsed as { first_mes?: string }).first_mes;
+            const altGreetings = (parsed as { alternate_greetings?: string[] }).alternate_greetings ?? [];
+            if (firstMes) {
+              setFirstMesConfirm({
+                charId,
+                charName: charName(char),
+                message: firstMes,
+                alternateGreetings: altGreetings,
+              });
             }
           },
         },

--- a/src/features/modes/shared/chat-ui/components/ChatSetupWizard.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatSetupWizard.tsx
@@ -131,14 +131,8 @@ function formatPersonaLabel(persona: PersonaDisplayInfo): string {
 }
 
 function getCharacterAvatarCrop(character: { data: unknown }): AvatarCrop | null {
-  try {
-    const parsed = typeof character.data === "string" ? JSON.parse(character.data) : character.data;
-    return (parsed as { extensions?: { avatarCrop?: AvatarCrop | null } } | null)?.extensions?.avatarCrop ?? null;
-  } catch {
-    return null;
-  }
+  return (character.data as { extensions?: { avatarCrop?: AvatarCrop | null } } | null)?.extensions?.avatarCrop ?? null;
 }
-
 function CharacterAvatarImage({
   character,
   src,
@@ -330,7 +324,7 @@ function ConversationQuickSetup({ chat, onFinish }: ChatSetupWizardProps) {
 
   const characters = useMemo(
     () =>
-      (allCharacters ?? []) as Array<{ id: string; data: string; comment?: string | null; avatarPath: string | null }>,
+      (allCharacters ?? []) as Array<{ id: string; data: unknown; comment?: string | null; avatarPath: string | null }>,
     [allCharacters],
   );
   const personas = (allPersonas ?? []) as Array<{
@@ -371,7 +365,7 @@ function ConversationQuickSetup({ chat, onFinish }: ChatSetupWizardProps) {
   }, [metadata.chatParameters]);
 
   const chatCharIds: string[] = useMemo(() => {
-    return typeof chat.characterIds === "string" ? JSON.parse(chat.characterIds) : (chat.characterIds ?? []);
+    return chat.characterIds ?? [];
   }, [chat.characterIds]);
 
   const [search, setSearch] = useState("");
@@ -385,7 +379,7 @@ function ConversationQuickSetup({ chat, onFinish }: ChatSetupWizardProps) {
   }, [characters]);
 
   const getCharacterInfo = useCallback(
-    (c: { id?: string; data: string; comment?: string | null }) => {
+    (c: { id?: string; data: unknown; comment?: string | null }) => {
       if (c.id && charInfoMap.has(c.id)) return charInfoMap.get(c.id)!;
       return parseCharacterDisplayData(c);
     },
@@ -393,7 +387,7 @@ function ConversationQuickSetup({ chat, onFinish }: ChatSetupWizardProps) {
   );
 
   const charName = useCallback(
-    (c: { id?: string; data: string; comment?: string | null }) => getCharacterInfo(c).name,
+    (c: { id?: string; data: unknown; comment?: string | null }) => getCharacterInfo(c).name,
     [getCharacterInfo],
   );
 
@@ -872,7 +866,7 @@ function RoleplaySetupWizard({ chat, onFinish }: ChatSetupWizardProps) {
   }>;
   const characters = useMemo(
     () =>
-      (allCharacters ?? []) as Array<{ id: string; data: string; comment?: string | null; avatarPath: string | null }>,
+      (allCharacters ?? []) as Array<{ id: string; data: unknown; comment?: string | null; avatarPath: string | null }>,
     [allCharacters],
   );
   const connectionOptions = useMemo(
@@ -908,7 +902,7 @@ function RoleplaySetupWizard({ chat, onFinish }: ChatSetupWizardProps) {
   }, [metadata.chatParameters]);
 
   const chatCharIds: string[] = useMemo(() => {
-    return typeof chat.characterIds === "string" ? JSON.parse(chat.characterIds) : (chat.characterIds ?? []);
+    return chat.characterIds ?? [];
   }, [chat.characterIds]);
 
   const activeLorebookIds: string[] = useMemo(() => metadata.activeLorebookIds ?? [], [metadata.activeLorebookIds]);
@@ -923,7 +917,7 @@ function RoleplaySetupWizard({ chat, onFinish }: ChatSetupWizardProps) {
   }, [characters]);
 
   const charName = useCallback(
-    (c: { id?: string; data: string; comment?: string | null }) => {
+    (c: { id?: string; data: unknown; comment?: string | null }) => {
       if (c.id && charInfoMap.has(c.id)) return charInfoMap.get(c.id)!.name;
       return parseCharacterDisplayData(c).name;
     },
@@ -931,7 +925,7 @@ function RoleplaySetupWizard({ chat, onFinish }: ChatSetupWizardProps) {
   );
 
   const charTitle = useCallback(
-    (c: { id?: string; data: string; comment?: string | null }) => {
+    (c: { id?: string; data: unknown; comment?: string | null }) => {
       if (c.id && charInfoMap.has(c.id)) return getCharacterTitle(charInfoMap.get(c.id)!);
       return getCharacterTitle(parseCharacterDisplayData(c));
     },
@@ -1006,34 +1000,30 @@ function RoleplaySetupWizard({ chat, onFinish }: ChatSetupWizardProps) {
           onSuccess: () => {
             const char = characters.find((c) => c.id === charId);
             if (!char) return;
-            try {
-              const parsed = typeof char.data === "string" ? JSON.parse(char.data) : char.data;
-              const firstMes = (parsed as { first_mes?: string }).first_mes;
-              const altGreetings = (parsed as { alternate_greetings?: string[] }).alternate_greetings ?? [];
-              if (firstMes) {
-                createMessage
-                  .mutateAsync({ role: "assistant", content: firstMes, characterId: charId })
-                  .then(async (msg) => {
-                    if (msg?.id && altGreetings.length > 0) {
-                      for (const greeting of altGreetings) {
-                        if (greeting.trim()) {
-                          await invokeTauri("chat_message_add_swipe", {
-                            chatId: chat.id,
-                            messageId: msg.id,
-                            body: {
+            const parsed = char.data;
+            const firstMes = (parsed as { first_mes?: string }).first_mes;
+            const altGreetings = (parsed as { alternate_greetings?: string[] }).alternate_greetings ?? [];
+            if (firstMes) {
+              createMessage
+                .mutateAsync({ role: "assistant", content: firstMes, characterId: charId })
+                .then(async (msg) => {
+                  if (msg?.id && altGreetings.length > 0) {
+                    for (const greeting of altGreetings) {
+                      if (greeting.trim()) {
+                        await invokeTauri("chat_message_add_swipe", {
+                          chatId: chat.id,
+                          messageId: msg.id,
+                          body: {
                             content: greeting,
                             silent: true,
-                            },
-                          });
-                        }
+                          },
+                        });
                       }
-                      queryClient.invalidateQueries({ queryKey: chatKeys.messages(chat.id) });
                     }
-                  })
-                  .catch(() => {});
-              }
-            } catch {
-              /* ignore */
+                    queryClient.invalidateQueries({ queryKey: chatKeys.messages(chat.id) });
+                  }
+                })
+                .catch(() => {});
             }
           },
         });

--- a/src/features/modes/shared/chat-ui/components/QuickPersonaSwitcher.tsx
+++ b/src/features/modes/shared/chat-ui/components/QuickPersonaSwitcher.tsx
@@ -71,7 +71,7 @@ export function QuickPersonaSwitcher({ className }: { className?: string }) {
     for (const g of groupRows) {
       let memberIds: string[] = [];
       try {
-        memberIds = JSON.parse(g.personaIds);
+        memberIds = Array.isArray(g.personaIds) ? g.personaIds : [];
       } catch {
         memberIds = [];
       }

--- a/src/features/modes/shared/chat-ui/components/QuickSwitcherMobile.tsx
+++ b/src/features/modes/shared/chat-ui/components/QuickSwitcherMobile.tsx
@@ -77,7 +77,7 @@ export function QuickSwitcherMobile() {
     for (const g of groupRows) {
       let memberIds: string[] = [];
       try {
-        memberIds = JSON.parse(g.personaIds);
+        memberIds = Array.isArray(g.personaIds) ? g.personaIds : [];
       } catch {
         memberIds = [];
       }

--- a/src/features/modes/shared/chat-ui/hooks/use-chat-surface-data.ts
+++ b/src/features/modes/shared/chat-ui/hooks/use-chat-surface-data.ts
@@ -26,7 +26,7 @@ type UseChatSurfaceDataOptions = {
 
 type CharacterRow = {
   id: string;
-  data: string;
+  data: Record<string, any>;
   comment?: string | null;
   avatarPath: string | null;
 };
@@ -40,7 +40,7 @@ type PersonaRow = {
   scenario?: string;
   backstory?: string;
   appearance?: string;
-  altDescriptions?: string;
+  altDescriptions?: Array<{ active?: boolean; content?: string }>;
   avatarPath?: string | null;
   avatarCrop?: string;
   nameColor?: string;
@@ -62,9 +62,8 @@ function parseChatCharacterIds(chat: Chat | null | undefined): string[] {
   return Array.isArray(raw) ? raw.filter((id): id is string => typeof id === "string") : [];
 }
 
-function parseCharacterData(data: string): Record<string, any> {
-  const parsed = typeof data === "string" ? JSON.parse(data) : data;
-  return parsed && typeof parsed === "object" ? parsed : {};
+function parseCharacterData(data: Record<string, any>): Record<string, any> {
+  return data && typeof data === "object" ? data : {};
 }
 
 function buildPersonaInfo(
@@ -82,16 +81,11 @@ function buildPersonaInfo(
   if (!persona) return undefined;
 
   let description = persona.description ?? "";
-  if (persona.altDescriptions) {
-    try {
-      const altDescriptions = JSON.parse(persona.altDescriptions) as Array<{ active?: boolean; content?: string }>;
-      for (const altDescription of altDescriptions) {
-        if (altDescription?.active && typeof altDescription.content === "string" && altDescription.content.trim()) {
-          description = [description, altDescription.content.trim()].filter(Boolean).join("\n");
-        }
+  if (Array.isArray(persona.altDescriptions)) {
+    for (const altDescription of persona.altDescriptions) {
+      if (altDescription?.active && typeof altDescription.content === "string" && altDescription.content.trim()) {
+        description = [description, altDescription.content.trim()].filter(Boolean).join("\n");
       }
-    } catch {
-      /* ignore malformed persona alt-description JSON */
     }
   }
 

--- a/src/shared/lib/character-display.ts
+++ b/src/shared/lib/character-display.ts
@@ -146,12 +146,7 @@ export function getCharacterLookupTexts(character: CharacterDisplayInfo | null |
 export function parseCharacterDisplayData(raw: { data: unknown; comment?: string | null }): CharacterDisplayInfo {
   const comment = typeof raw.comment === "string" ? raw.comment.trim() : "";
 
-  try {
-    const parsed = typeof raw.data === "string" ? JSON.parse(raw.data) : raw.data;
-    const record = parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : null;
-    const name = typeof record?.name === "string" && record.name.trim() ? record.name.trim() : "Unknown";
-    return { name, comment };
-  } catch {
-    return { name: "Unknown", comment };
-  }
+  const record = raw.data && typeof raw.data === "object" ? (raw.data as Record<string, unknown>) : null;
+  const name = typeof record?.name === "string" && record.name.trim() ? record.name.trim() : "Unknown";
+  return { name, comment };
 }

--- a/src/shared/lib/chat-macros.ts
+++ b/src/shared/lib/chat-macros.ts
@@ -30,23 +30,14 @@ function getRecord(value: unknown): Record<string, unknown> | null {
 }
 
 function appendActiveAltDescriptions(description: string, altDescriptions: unknown): string {
-  try {
-    const parsed =
-      typeof altDescriptions === "string"
-        ? altDescriptions.trim()
-          ? (JSON.parse(altDescriptions) as Array<{ active?: boolean; content?: string }>)
-          : []
-        : Array.isArray(altDescriptions)
-          ? (altDescriptions as Array<{ active?: boolean; content?: string }>)
-          : [];
-    const activeDescriptions = parsed
-      .filter((item) => item?.active && typeof item.content === "string" && item.content.trim().length > 0)
-      .map((item) => item.content!.trim());
-    if (activeDescriptions.length === 0) return description;
-    return [description, ...activeDescriptions].filter((part) => part.trim().length > 0).join("\n");
-  } catch {
-    return description;
-  }
+  const parsed = Array.isArray(altDescriptions)
+    ? (altDescriptions as Array<{ active?: boolean; content?: string }>)
+    : [];
+  const activeDescriptions = parsed
+    .filter((item) => item?.active && typeof item.content === "string" && item.content.trim().length > 0)
+    .map((item) => item.content!.trim());
+  if (activeDescriptions.length === 0) return description;
+  return [description, ...activeDescriptions].filter((part) => part.trim().length > 0).join("\n");
 }
 
 export function getChatCharacterIds(chat: { characterIds?: unknown } | null | undefined): string[] {
@@ -77,8 +68,7 @@ export function parseCharacterMacroData(
   if (!raw) return null;
 
   try {
-    const parsed = typeof raw.data === "string" ? JSON.parse(raw.data) : raw.data;
-    const data = getRecord(parsed);
+    const data = getRecord(raw.data);
     if (!data) return { id: raw.id, name: "Unknown" };
     const extensions = getRecord(data.extensions);
     return {


### PR DESCRIPTION
## Summary
- migrate file-backed storage JSON-string fields to typed JSON values across characters, personas, prompts, chats/messages, groups, lorebooks, agents/tools/regex scripts, connections, and game snapshots/checkpoints
- normalize typed JSON fields on storage create/update plus startup/profile/legacy import migration
- update primary frontend access points to consume typed storage values without JSON-string conversion

## Verification
- cargo check --manifest-path src-tauri/Cargo.toml
- pnpm typecheck
- pnpm check:architecture

## Notes
- JSON.stringify/JSON.parse remain where they are true boundaries (imports/exports, localStorage, LLM/prompt payloads, editable JSON text). Storage-backed typed fields are migrated away from stringified JSON.