### PR TITLE
Fix Lorebook Keeper backfill cadence

### DIFF
--- a/src/engine/generation/agent-runner.ts
+++ b/src/engine/generation/agent-runner.ts
@@ -583,6 +583,7 @@ async function resolveAgents(deps: AgentDeps, input: GenerationAgentRuntimeInput
     .filter((agent) => {
       const type = readString(agent.type || agent.agentType);
       const id = readString(agent.id);
+      if ((!input.agentTypes || input.agentTypes.size === 0) && type === "lorebook-keeper") return false;
       if (scopedAgentIds.size > 0 && !scopedAgentIds.has(type) && !scopedAgentIds.has(id)) return false;
       if (!input.agentTypes || input.agentTypes.size === 0) return true;
       return input.agentTypes.has(type);

--- a/src/engine/generation/start-generation.test.ts
+++ b/src/engine/generation/start-generation.test.ts
@@ -23,20 +23,26 @@ function depsForChat(chat: Record<string, unknown>) {
 function generationDepsForChat(options: {
   savedUserMessage?: unknown;
   messagesAfterSave?: Record<string, unknown>[];
+  chatMetadata?: Record<string, unknown>;
+  agents?: Record<string, unknown>[];
+  agentRuns?: Record<string, unknown>[];
+  initialMessages?: Record<string, unknown>[];
 } = {}) {
   const chat = {
     id: "chat-1",
     mode: "conversation",
     connectionId: "connection-1",
     characterIds: [],
-    metadata: {},
+    metadata: options.chatMetadata ?? {},
   };
   const connection = {
     id: "connection-1",
     model: "test-model",
     defaultParameters: {},
   };
-  const initialMessages = [{ id: "assistant-1", chatId: "chat-1", role: "assistant", content: "What now?" }];
+  const initialMessages = options.initialMessages ?? [
+    { id: "assistant-1", chatId: "chat-1", role: "assistant", content: "What now?" },
+  ];
   const listChatMessages = vi.fn(async () =>
     listChatMessages.mock.calls.length > 1 && options.messagesAfterSave
       ? options.messagesAfterSave
@@ -59,7 +65,11 @@ function generationDepsForChat(options: {
       if (entity === "connections" && id === "connection-1") return connection;
       return null;
     }),
-    list: vi.fn(async () => []),
+    list: vi.fn(async (entity: string) => {
+      if (entity === "agents") return options.agents ?? [];
+      if (entity === "agent-runs") return options.agentRuns ?? [];
+      return [];
+    }),
     create: vi.fn(async (_entity: string, value: Record<string, unknown>) => value),
     createChatMessage,
     listChatMessages,
@@ -187,5 +197,68 @@ describe("startGeneration chat message loading", () => {
     expect(streamedRequests[0]).toMatchObject({
       messages: expect.arrayContaining([expect.objectContaining({ role: "user", content: "hello" })]),
     });
+  });
+});
+
+describe("retryGenerationAgents lorebook keeper backfill", () => {
+  it("uses run interval and read-behind settings to backfill only unprocessed batch anchors", async () => {
+    const messages = Array.from({ length: 40 }, (_, index) => ({
+      id: `assistant-${index + 1}`,
+      chatId: "chat-1",
+      role: "assistant",
+      content: `Assistant message ${index + 1}`,
+    }));
+    const { deps, streamedRequests } = generationDepsForChat({
+      chatMetadata: {
+        enableAgents: true,
+        activeAgentIds: ["lorebook-keeper"],
+        lorebookKeeperReadBehindMessages: 10,
+      },
+      agents: [
+        {
+          id: "lorebook-agent",
+          type: "lorebook-keeper",
+          name: "Lorebook Keeper",
+          enabled: true,
+          phase: "post_processing",
+          connectionId: null,
+          model: "agent-model",
+          promptTemplate: "Return JSON.",
+          settings: { runInterval: 10, contextSize: 15 },
+        },
+      ],
+      agentRuns: [
+        {
+          id: "run-10",
+          chatId: "chat-1",
+          messageId: "assistant-10",
+          agentType: "lorebook-keeper",
+          success: true,
+        },
+      ],
+      initialMessages: messages,
+    });
+
+    const results = await retryGenerationAgents(deps, {
+      chatId: "chat-1",
+      agentTypes: ["lorebook-keeper"],
+      options: { lorebookKeeperBackfill: true },
+    });
+
+    expect(results).toHaveLength(2);
+    expect(streamedRequests).toHaveLength(2);
+    expect(streamedRequests.map((request) => (request as { messages: Array<{ content: string }> }).messages.at(-1)?.content)).toEqual([
+      expect.stringContaining("Assistant message 20"),
+      expect.stringContaining("Assistant message 30"),
+    ]);
+    const promptTexts = streamedRequests.map((request) =>
+      (request as { messages: Array<{ content: string }> }).messages.map((message) => message.content).join("\n"),
+    );
+    expect(promptTexts[0]).toContain("Assistant message 19");
+    expect(promptTexts[0]).toContain("Assistant message 20");
+    expect(promptTexts[0]).not.toContain("Assistant message 31");
+    expect(promptTexts[1]).toContain("Assistant message 29");
+    expect(promptTexts[1]).toContain("Assistant message 30");
+    expect(promptTexts[1]).not.toContain("Assistant message 31");
   });
 });

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -1,4 +1,4 @@
-import type { AgentResult } from "../contracts/types/agent";
+import { BUILT_IN_AGENT_RUN_INTERVAL_DEFAULTS, type AgentResult } from "../contracts/types/agent";
 import type { GameState } from "../contracts/types/game-state";
 import type { EventGateway } from "../capabilities/events";
 import type { IntegrationGateway } from "../capabilities/integrations";
@@ -23,7 +23,7 @@ import { buildGenerationReplay } from "./generation-replay";
 import { assembleGenerationPrompt } from "./prompt-assembly";
 import type { GenerationCharacterContext } from "./prompt-assembly";
 import { applyRuntimeRegexScripts } from "./regex-runtime";
-import { hiddenFromAi, isRecord, nowIso, parseRecord, readString, stringArray, type JsonRecord } from "./runtime-records";
+import { boolish, hiddenFromAi, isRecord, nowIso, parseRecord, readString, stringArray, type JsonRecord } from "./runtime-records";
 import {
   commitTrackerSnapshotForTarget,
   createTrackerSnapshotReadContext,
@@ -75,6 +75,9 @@ interface PreparedUserInput {
   images: string[];
   mentionedCharacterNames: string[];
 }
+
+const LOREBOOK_KEEPER_AGENT_TYPE = "lorebook-keeper";
+const DEFAULT_LOREBOOK_KEEPER_RUN_INTERVAL = BUILT_IN_AGENT_RUN_INTERVAL_DEFAULTS[LOREBOOK_KEEPER_AGENT_TYPE] ?? 8;
 
 const CONTINUE_ASSISTANT_RESPONSE_INSTRUCTION =
   "[Generation instruction: continue from the latest assistant message. Do not repeat or summarize the previous response; pick up naturally from where it stopped.]";
@@ -383,6 +386,108 @@ function targetAssistantMessage(messages: JsonRecord[], options: Record<string, 
   return [...messages].reverse().find((message) => readString(message.role) === "assistant") ?? null;
 }
 
+function messageIndex(messages: JsonRecord[], target: JsonRecord | null): number {
+  const id = readString(target?.id).trim();
+  if (!id) return -1;
+  return messages.findIndex((message) => readString(message.id).trim() === id);
+}
+
+function messagesBeforeTarget(messages: JsonRecord[], target: JsonRecord | null): JsonRecord[] {
+  const index = messageIndex(messages, target);
+  return index >= 0 ? messages.slice(0, index) : messages;
+}
+
+function positiveInteger(value: unknown, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
+  return Math.max(1, Math.trunc(value));
+}
+
+function nonNegativeInteger(value: unknown, fallback = 0): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
+  return Math.max(0, Math.trunc(value));
+}
+
+function lorebookKeeperReadBehind(chat: JsonRecord): number {
+  return nonNegativeInteger(parseRecord(chat.metadata).lorebookKeeperReadBehindMessages, 0);
+}
+
+function agentType(agent: JsonRecord): string {
+  return readString(agent.type || agent.agentType).trim();
+}
+
+function agentSettings(agent: JsonRecord): JsonRecord {
+  return parseRecord(agent.settings);
+}
+
+function lorebookKeeperRunInterval(agent: JsonRecord | null): number {
+  return positiveInteger(agent ? agentSettings(agent).runInterval : null, DEFAULT_LOREBOOK_KEEPER_RUN_INTERVAL);
+}
+
+function chatActiveAgentIds(chat: JsonRecord): Set<string> {
+  return new Set(stringArray(parseRecord(chat.metadata).activeAgentIds).map((id) => id.trim()).filter(Boolean));
+}
+
+function chatHasLorebookKeeperEnabled(chat: JsonRecord, agent: JsonRecord): boolean {
+  if (!boolish(agent.enabled, false) || agentType(agent) !== LOREBOOK_KEEPER_AGENT_TYPE) return false;
+  const activeAgentIds = chatActiveAgentIds(chat);
+  if (activeAgentIds.size > 0) {
+    const id = readString(agent.id).trim();
+    return activeAgentIds.has(LOREBOOK_KEEPER_AGENT_TYPE) || (id ? activeAgentIds.has(id) : false);
+  }
+  return boolish(parseRecord(chat.metadata).enableAgents, false);
+}
+
+async function lorebookKeeperAgent(storage: StorageGateway, chat: JsonRecord): Promise<JsonRecord | null> {
+  const agents = await storage.list<JsonRecord>("agents").catch(() => []);
+  return agents.find((agent) => chatHasLorebookKeeperEnabled(chat, agent)) ?? null;
+}
+
+async function successfulLorebookKeeperMessageIds(storage: StorageGateway, chatId: string): Promise<Set<string>> {
+  const runs = await storage.list<JsonRecord>("agent-runs").catch(() => []);
+  return new Set(
+    runs
+      .filter((run) => readString(run.chatId).trim() === chatId)
+      .filter((run) => readString(run.agentType).trim() === LOREBOOK_KEEPER_AGENT_TYPE)
+      .filter((run) => boolish(run.success, false))
+      .map((run) => readString(run.messageId).trim())
+      .filter(Boolean),
+  );
+}
+
+interface LorebookKeeperTarget {
+  message: JsonRecord;
+}
+
+function lorebookKeeperBackfillTargets(
+  storedMessages: JsonRecord[],
+  processedMessageIds: Set<string>,
+  options: { readBehind: number; runInterval: number },
+): LorebookKeeperTarget[] {
+  const assistantMessages = storedMessages
+    .filter((message) => !hiddenFromAi(message))
+    .filter((message) => readString(message.role).trim() === "assistant")
+    .filter((message) => readString(message.id).trim() && readString(message.content).trim());
+  const eligibleCount = Math.max(0, assistantMessages.length - options.readBehind);
+  const targets: LorebookKeeperTarget[] = [];
+
+  for (let ordinal = options.runInterval; ordinal <= eligibleCount; ordinal += options.runInterval) {
+    const message = assistantMessages[ordinal - 1]!;
+    const id = readString(message.id).trim();
+    if (processedMessageIds.has(id)) continue;
+    targets.push({ message });
+  }
+
+  return targets;
+}
+
+function isLorebookKeeperBackfill(input: RetryAgentsInput): boolean {
+  return (
+    input.options?.lorebookKeeperBackfill === true &&
+    Array.isArray(input.agentTypes) &&
+    input.agentTypes.some((type) => readString(type).trim() === LOREBOOK_KEEPER_AGENT_TYPE)
+  );
+}
+
 async function commitVisibleTrackerSnapshotSafely(
   storage: StorageGateway,
   chatId: string,
@@ -421,21 +526,18 @@ async function selectGenerationTrackerBaseline(
   });
 }
 
-export async function retryGenerationAgents(
-  deps: GenerationEngineDeps,
-  input: RetryAgentsInput,
-  signal?: AbortSignal,
-): Promise<AgentResult[]> {
+async function runGenerationAgentsForTarget(args: {
+  deps: GenerationEngineDeps;
+  input: RetryAgentsInput;
+  chat: JsonRecord;
+  connection: JsonRecord;
+  storedMessages: JsonRecord[];
+  target: JsonRecord | null;
+  agentTypes: Set<string>;
+  signal?: AbortSignal;
+}): Promise<AgentResult[]> {
+  const { deps, input, chat, connection, storedMessages, target, agentTypes, signal } = args;
   const chatId = readString(input.chatId).trim();
-  if (!chatId) throw new Error("chatId is required");
-  const agentTypes = Array.isArray(input.agentTypes)
-    ? new Set(input.agentTypes.map((type) => readString(type).trim()).filter(Boolean))
-    : new Set<string>();
-  const chat = requireRecord(await deps.storage.get("chats", chatId), "Chat");
-  assertChatCanGenerate(chat);
-  const connection = await resolveGenerationConnection(deps.storage, chat, input);
-  const storedMessages = await loadChatMessages(deps.storage, chatId);
-  const target = targetAssistantMessage(storedMessages, input.options);
   const targetTrackerTarget = trackerSnapshotTargetFromMessage(target);
   const trackerReadContext = await createTrackerSnapshotReadContext(deps.storage, chatId);
   const retryBaseline = await selectTrackerSnapshotForGeneration(
@@ -459,9 +561,10 @@ export async function retryGenerationAgents(
     trackerReadContext,
   );
   const chatForAgents = targetSnapshot ?? retryBaseline ? { ...chat, gameState: targetSnapshot ?? retryBaseline } : chat;
+  const contextMessages = messagesBeforeTarget(storedMessages, target);
   const assembly = await assembleGenerationPrompt(deps.storage, {
     chat: chatForAgents,
-    storedMessages,
+    storedMessages: contextMessages,
     connection,
     request: input,
     latestUserInput: "",
@@ -472,7 +575,7 @@ export async function retryGenerationAgents(
     {
       chat: chatForAgents,
       connection,
-      storedMessages,
+      storedMessages: contextMessages,
       characters: assembly.characters,
       persona: assembly.persona,
       activatedLorebookEntries: assembly.activatedLorebookEntries,
@@ -496,6 +599,68 @@ export async function retryGenerationAgents(
   }
   await persistAgentResults(deps.storage, chatId, target ? readString(target.id) || null : null, finalResults);
   return finalResults;
+}
+
+async function runLorebookKeeperBackfill(
+  deps: GenerationEngineDeps,
+  input: RetryAgentsInput,
+  args: {
+    chat: JsonRecord;
+    connection: JsonRecord;
+    storedMessages?: JsonRecord[];
+    signal?: AbortSignal;
+  },
+): Promise<AgentResult[]> {
+  const chatId = readString(input.chatId).trim();
+  const agent = await lorebookKeeperAgent(deps.storage, args.chat);
+  if (!agent) return [];
+
+  const storedMessages = args.storedMessages ?? (await loadChatMessages(deps.storage, chatId));
+  const processedMessageIds = await successfulLorebookKeeperMessageIds(deps.storage, chatId);
+  const targets = lorebookKeeperBackfillTargets(storedMessages, processedMessageIds, {
+    readBehind: lorebookKeeperReadBehind(args.chat),
+    runInterval: lorebookKeeperRunInterval(agent),
+  });
+  const agentTypes = new Set([LOREBOOK_KEEPER_AGENT_TYPE]);
+  const allResults: AgentResult[] = [];
+
+  for (const target of targets) {
+    allResults.push(
+      ...(await runGenerationAgentsForTarget({
+        deps,
+        input,
+        chat: args.chat,
+        connection: args.connection,
+        storedMessages,
+        target: target.message,
+        agentTypes,
+        signal: args.signal,
+      })),
+    );
+  }
+
+  return allResults;
+}
+
+export async function retryGenerationAgents(
+  deps: GenerationEngineDeps,
+  input: RetryAgentsInput,
+  signal?: AbortSignal,
+): Promise<AgentResult[]> {
+  const chatId = readString(input.chatId).trim();
+  if (!chatId) throw new Error("chatId is required");
+  const agentTypes = Array.isArray(input.agentTypes)
+    ? new Set(input.agentTypes.map((type) => readString(type).trim()).filter(Boolean))
+    : new Set<string>();
+  const chat = requireRecord(await deps.storage.get("chats", chatId), "Chat");
+  assertChatCanGenerate(chat);
+  const connection = await resolveGenerationConnection(deps.storage, chat, input);
+  const storedMessages = await loadChatMessages(deps.storage, chatId);
+  if (isLorebookKeeperBackfill(input)) {
+    return runLorebookKeeperBackfill(deps, input, { chat, connection, storedMessages, signal });
+  }
+  const target = targetAssistantMessage(storedMessages, input.options);
+  return runGenerationAgentsForTarget({ deps, input, chat, connection, storedMessages, target, agentTypes, signal });
 }
 
 export async function* startGeneration(
@@ -644,6 +809,21 @@ export async function* startGeneration(
         });
     if (saved) await persistTrackerSnapshotSafely(deps.storage, chatId, saved, allAgentResults, generationTrackerBaseline);
     await persistAgentResults(deps.storage, chatId, messageId(saved), allAgentResults);
+    if (saved) {
+      const autoLorebookResults = await runLorebookKeeperBackfill(
+        deps,
+        {
+          chatId,
+          connectionId: readString(connection.id) || input.connectionId || null,
+          agentTypes: [LOREBOOK_KEEPER_AGENT_TYPE],
+          options: { lorebookKeeperBackfill: true },
+        },
+        { chat, connection, signal },
+      );
+      for (const result of autoLorebookResults) {
+        yield { type: "agent_result", data: result };
+      }
+    }
     if (saved) yield { type: "assistant_message", data: saved };
     yield { type: "done", data: { transcript: visibleTranscript(generationMessages) } };
     return;
@@ -697,6 +877,21 @@ export async function* startGeneration(
         attachments: connected.assistantAttachments,
         usage,
       });
+  if (saved) {
+    const autoLorebookResults = await runLorebookKeeperBackfill(
+      deps,
+      {
+        chatId,
+        connectionId: readString(connection.id) || input.connectionId || null,
+        agentTypes: [LOREBOOK_KEEPER_AGENT_TYPE],
+        options: { lorebookKeeperBackfill: true },
+      },
+      { chat, connection, signal },
+    );
+    for (const result of autoLorebookResults) {
+      yield { type: "agent_result", data: result };
+    }
+  }
   if (saved) yield { type: "assistant_message", data: saved };
   yield { type: "done" };
 }


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #1211

## Why this change

- Lorebook Keeper's refactor path passed a `lorebookKeeperBackfill` option from the UI, but the generation engine ignored it and only retried the latest assistant message.
- Automatic generation also ran Lorebook Keeper through the normal post-processing agent path, which cannot honor read-behind because the target assistant message has not been saved yet.

## What changed

- Route normal automatic Lorebook Keeper work through a post-save backfill pass so run interval, read-behind, processed-message history, and target-scoped context are all applied.
- Make manual Backfill Unprocessed select unprocessed interval anchors instead of the latest assistant message only.
- Reuse the targeted retry runtime with message history sliced before each selected assistant target, so the agent context window batches around the intended target.
- Skip Lorebook Keeper from the normal automatic agent runtime; targeted retries still run it directly.
- Added focused regression coverage for run interval, read-behind exclusion, already-processed anchors, and target-scoped prompt context.

## Refactor impact

Primary owner:

- Engine generation

Impact areas reviewed:

- `startGeneration` automatic post-save agent flow
- `retryGenerationAgents` targeted retry/backfill flow
- Agent resolution for normal automatic runs
- Agent-run persistence via `agent-runs.messageId`

Boundary notes:

- Change stays inside engine generation and tests. No React feature code, shared API wrapper, Rust command, schema, dependency, or prompt-template changes.

Pressure points touched:

- Engine generation runtime only; no ModeSurface/GameSurface/shared mode UI/Rust command registration/import modules touched.

## Validation

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Codex ran `pnpm exec vitest run src/engine/generation/agent-runner.test.ts src/engine/generation/start-generation.test.ts` and the focused repro passed.
- Codex ran `pnpm check`, covering architecture, TypeScript, Rust workspace `cargo check`, and docs checks.
- Codex ran `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json`; the proof gate passed.
- No browser/Tauri manual verification was performed because this is engine generation logic with no visible UI change.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A - engine generation logic only.
