### PR TITLE
feat(tts): stream autoplay audio per sentence

### DIFF
--- a/src-tauri/src/commands/storage/integrations/tts.rs
+++ b/src-tauri/src/commands/storage/integrations/tts.rs
@@ -772,6 +772,50 @@ mod tests {
         format!("http://{address}/v1")
     }
 
+    async fn serve_pockettts_audio() -> String {
+        const WAV_BYTES: &[u8] = &[
+            82, 73, 70, 70, 38, 0, 0, 0, 87, 65, 86, 69, 102, 109, 116, 32, 16, 0, 0, 0, 1, 0,
+            1, 0, 64, 31, 0, 0, 64, 31, 0, 0, 1, 0, 8, 0, 100, 97, 116, 97, 2, 0, 0, 0, 128,
+            128,
+        ];
+
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("test TTS server should bind");
+        let address = listener
+            .local_addr()
+            .expect("test TTS server address should be readable");
+        tokio::spawn(async move {
+            let (mut stream, _) = listener
+                .accept()
+                .await
+                .expect("test TTS server should accept one request");
+            let mut buffer = [0_u8; 8192];
+            let bytes = stream
+                .read(&mut buffer)
+                .await
+                .expect("test TTS server should read request");
+            let request = String::from_utf8_lossy(&buffer[..bytes]);
+            assert!(request.starts_with("POST /tts "));
+            assert!(request.contains("name=\"text\""));
+            assert!(request.contains("name=\"voice_url\""));
+
+            let header = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: audio/wav\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                WAV_BYTES.len()
+            );
+            stream
+                .write_all(header.as_bytes())
+                .await
+                .expect("test TTS server should write response header");
+            stream
+                .write_all(WAV_BYTES)
+                .await
+                .expect("test TTS server should write response body");
+        });
+        format!("http://{address}")
+    }
+
     #[tokio::test]
     async fn openai_compatible_voice_lookup_passes_configured_model() {
         let state = test_state("openai-voices-model");
@@ -798,6 +842,34 @@ mod tests {
 
         assert_eq!(result["fromProvider"], true);
         assert_eq!(result["voices"], json!(["af_heart"]));
+    }
+
+    #[tokio::test]
+    async fn pockettts_speak_returns_provider_audio() {
+        let state = test_state("pockettts-speak");
+        let base_url = serve_pockettts_audio().await;
+        state
+            .storage
+            .upsert_with_id(
+                "app-settings",
+                TTS_SETTINGS_KEY,
+                json!({
+                    "value": {
+                        "enabled": true,
+                        "source": "pockettts",
+                        "baseUrl": base_url,
+                        "voice": "alba"
+                    }
+                }),
+            )
+            .expect("TTS settings should be stored");
+
+        let result = speak(&state, json!({ "text": "Hello from streaming TTS." }))
+            .await
+            .expect("TTS speak should return provider audio");
+
+        assert_eq!(result["contentType"], "audio/wav");
+        assert!(result["audioBase64"].as_str().is_some_and(|audio| !audio.is_empty()));
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/integrations/tts.rs
+++ b/src-tauri/src/commands/storage/integrations/tts.rs
@@ -120,6 +120,7 @@ fn default_config() -> Value {
         "autoplayRP": false,
         "autoplayConvo": false,
         "autoplayGame": false,
+        "autoplayStreaming": false,
         "dialogueOnly": false,
         "dialogueScope": "all",
         "dialogueCharacterName": ""

--- a/src/engine/contracts/types/tts.ts
+++ b/src/engine/contracts/types/tts.ts
@@ -119,6 +119,7 @@ export const ttsConfigSchema = z.object({
   autoplayRP: z.boolean().default(false),
   autoplayConvo: z.boolean().default(false),
   autoplayGame: z.boolean().default(false),
+  autoplayStreaming: z.boolean().default(false),
   dialogueOnly: z.boolean().default(false),
   dialogueScope: ttsDialogueScopeSchema.default("all"),
   dialogueCharacterName: z.string().default(""),

--- a/src/features/modes/conversation/components/ConversationModeRoute.tsx
+++ b/src/features/modes/conversation/components/ConversationModeRoute.tsx
@@ -72,6 +72,7 @@ export function ConversationModeRoute({ activeChatId }: ConversationModeRoutePro
     onRegenerate: timeline.handleRegenerate,
   });
   useChatTtsAutoplay({
+    chatId: activeChatId,
     mode: "conversation",
     messages: data.messages,
     characterMap: data.characterMap,

--- a/src/features/modes/roleplay/components/RoleplayModeRoute.tsx
+++ b/src/features/modes/roleplay/components/RoleplayModeRoute.tsx
@@ -109,6 +109,7 @@ export function RoleplayModeRoute({ activeChatId, fallbackChatMode = "roleplay" 
     onRegenerate: timeline.handleRegenerate,
   });
   useChatTtsAutoplay({
+    chatId: activeChatId,
     mode: data.chatMode === "visual_novel" ? "visual_novel" : "roleplay",
     messages: data.messages,
     characterMap: data.characterMap,

--- a/src/features/modes/shared/chat-ui/components/ChatMessage.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatMessage.tsx
@@ -46,6 +46,11 @@ import { storageApi } from "../../../../../shared/api/storage-api";
 import { ttsService } from "../../../../../shared/lib/tts-service";
 import { useTTSConfig } from "../../../../../shared/hooks/use-tts";
 import {
+  isStreamingTTSActive,
+  stopStreamingTTS,
+  subscribeStreamingTTSActive,
+} from "../hooks/use-streaming-tts";
+import {
   buildTTSMessageText,
   clientSidePlaybackRate,
   resolveTTSVoiceForSpeaker,
@@ -760,8 +765,14 @@ export const ChatMessage = memo(function ChatMessage({
   const isSpeakingThis = ttsActiveId === message.id;
   const isLoadingThis = isSpeakingThis && ttsState === "loading";
   const isPausedThis = isSpeakingThis && ttsState === "paused";
+  const [streamingTTSActive, setStreamingTTSActive] = useState<boolean>(() => isStreamingTTSActive());
+  useEffect(() => subscribeStreamingTTSActive(setStreamingTTSActive), []);
 
   const handleSpeak = useCallback(() => {
+    if (isStreamingTTSActive()) {
+      stopStreamingTTS();
+      return;
+    }
     // Read directly from the singleton so we never act on stale React state
     const liveState = ttsService.getState();
     const liveActiveId = ttsService.getActiveId();
@@ -1828,7 +1839,7 @@ export const ChatMessage = memo(function ChatMessage({
                     icon={
                       isLoadingThis ? (
                         <Loader2 size={MESSAGE_ACTION_ICON_SIZE} className="animate-spin" />
-                      ) : isSpeakingThis ? (
+                      ) : isSpeakingThis || streamingTTSActive ? (
                         <VolumeX size={MESSAGE_ACTION_ICON_SIZE} />
                       ) : (
                         <Volume2 size={MESSAGE_ACTION_ICON_SIZE} />
@@ -1836,7 +1847,9 @@ export const ChatMessage = memo(function ChatMessage({
                     }
                     onClick={handleSpeak}
                     title={
-                      !ttsSpeakText
+                      streamingTTSActive
+                        ? "Stop streaming narration"
+                        : !ttsSpeakText
                         ? "No dialogue to speak"
                         : isLoadingThis
                           ? "Loading…"
@@ -1844,8 +1857,8 @@ export const ChatMessage = memo(function ChatMessage({
                             ? "Stop speaking"
                             : "Speak"
                     }
-                    className={isSpeakingThis ? "text-sky-400 hover:text-sky-300" : undefined}
-                    disabled={!ttsSpeakText || (ttsBusy && !isSpeakingThis)}
+                    className={isSpeakingThis || streamingTTSActive ? "text-sky-400 hover:text-sky-300" : undefined}
+                    disabled={!streamingTTSActive && (!ttsSpeakText || (ttsBusy && !isSpeakingThis))}
                     dark
                   />
                 </>
@@ -2235,7 +2248,7 @@ export const ChatMessage = memo(function ChatMessage({
                   icon={
                     isLoadingThis ? (
                       <Loader2 size={MESSAGE_ACTION_ICON_SIZE} className="animate-spin" />
-                    ) : isSpeakingThis ? (
+                    ) : isSpeakingThis || streamingTTSActive ? (
                       <VolumeX size={MESSAGE_ACTION_ICON_SIZE} />
                     ) : (
                       <Volume2 size={MESSAGE_ACTION_ICON_SIZE} />
@@ -2243,7 +2256,9 @@ export const ChatMessage = memo(function ChatMessage({
                   }
                   onClick={handleSpeak}
                   title={
-                    !ttsSpeakText
+                    streamingTTSActive
+                      ? "Stop streaming narration"
+                      : !ttsSpeakText
                       ? "No dialogue to speak"
                       : isLoadingThis
                         ? "Loading…"
@@ -2251,8 +2266,8 @@ export const ChatMessage = memo(function ChatMessage({
                           ? "Stop speaking"
                           : "Speak"
                   }
-                  className={isSpeakingThis ? "text-sky-500" : undefined}
-                  disabled={!ttsSpeakText || (ttsBusy && !isSpeakingThis)}
+                  className={isSpeakingThis || streamingTTSActive ? "text-sky-500" : undefined}
+                  disabled={!streamingTTSActive && (!ttsSpeakText || (ttsBusy && !isSpeakingThis))}
                 />
               </>
             )}

--- a/src/features/modes/shared/chat-ui/hooks/use-chat-tts-autoplay.ts
+++ b/src/features/modes/shared/chat-ui/hooks/use-chat-tts-autoplay.ts
@@ -1,24 +1,41 @@
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useTTSConfig } from "../../../../../shared/hooks/use-tts";
 import {
   buildTTSMessageText,
   clientSidePlaybackRate,
+  normalizeTTSCharacterName,
   resolveTTSVoiceForSpeaker,
 } from "../../../../../shared/lib/tts-dialogue";
 import { ttsService } from "../../../../../shared/lib/tts-service";
+import { useChatStore } from "../../../../../shared/stores/chat.store";
 import type { CharacterMap, MessageWithSwipes } from "../types";
+import { useStreamingTTS } from "./use-streaming-tts";
 
 type ChatTtsAutoplayMode = "conversation" | "roleplay" | "visual_novel";
 
 type UseChatTtsAutoplayOptions = {
+  chatId: string | null;
   mode: ChatTtsAutoplayMode;
   messages: MessageWithSwipes[] | undefined;
   characterMap: CharacterMap;
   isStreaming: boolean;
 };
 
-export function useChatTtsAutoplay({ mode, messages, characterMap, isStreaming }: UseChatTtsAutoplayOptions) {
+function findLastAssistantMessage(messages: MessageWithSwipes[] | undefined): MessageWithSwipes | undefined {
+  const messageList = messages ?? [];
+  for (let index = messageList.length - 1; index >= 0; index -= 1) {
+    const candidate = messageList[index];
+    if (candidate.role === "assistant" || candidate.role === "narrator") {
+      return candidate;
+    }
+  }
+  return undefined;
+}
+
+export function useChatTtsAutoplay({ chatId, mode, messages, characterMap, isStreaming }: UseChatTtsAutoplayOptions) {
   const { data: ttsConfig } = useTTSConfig();
+  const streamingCharacterId = useChatStore((state) => state.streamingCharacterId);
+  const typingCharacterName = useChatStore((state) => state.typingCharacterName);
   const ttsConfigRef = useRef(ttsConfig);
   ttsConfigRef.current = ttsConfig;
   const messagesRef = useRef(messages);
@@ -26,6 +43,46 @@ export function useChatTtsAutoplay({ mode, messages, characterMap, isStreaming }
   const modeRef = useRef(mode);
   modeRef.current = mode;
   const prevIsStreamingRef = useRef(false);
+  const streamingTTSEnabled = Boolean(
+    ttsConfig?.enabled &&
+      ttsConfig.autoplayStreaming &&
+      (mode === "roleplay" || mode === "visual_novel" ? ttsConfig.autoplayRP : ttsConfig.autoplayConvo),
+  );
+  const fallbackTTSMessage = findLastAssistantMessage(messages);
+  const streamingFallbackCharacterId =
+    streamingCharacterId && characterMap.has(streamingCharacterId) ? streamingCharacterId : fallbackTTSMessage?.characterId;
+  const streamingFallbackSpeaker =
+    (streamingFallbackCharacterId ? characterMap.get(streamingFallbackCharacterId)?.name : undefined) ??
+    typingCharacterName ??
+    (fallbackTTSMessage?.role === "narrator"
+      ? "Narrator"
+      : fallbackTTSMessage?.characterId
+        ? characterMap.get(fallbackTTSMessage.characterId)?.name
+        : undefined);
+  const characterNameLookup = useMemo(() => {
+    const lookup = new Map<string, string>();
+    for (const [characterId, character] of characterMap) {
+      lookup.set(normalizeTTSCharacterName(character.name), characterId);
+    }
+    return lookup;
+  }, [characterMap]);
+  const resolveCharacterIdForSpeaker = useCallback(
+    (speaker?: string | null) => {
+      const normalizedSpeaker = normalizeTTSCharacterName(speaker);
+      if (!normalizedSpeaker) return null;
+      return characterNameLookup.get(normalizedSpeaker) ?? null;
+    },
+    [characterNameLookup],
+  );
+
+  useStreamingTTS({
+    enabled: streamingTTSEnabled,
+    chatId,
+    ttsConfig,
+    fallbackSpeaker: streamingFallbackSpeaker,
+    fallbackCharacterId: streamingFallbackCharacterId,
+    resolveCharacterIdForSpeaker,
+  });
 
   useEffect(() => {
     const wasStreaming = prevIsStreamingRef.current;
@@ -39,19 +96,18 @@ export function useChatTtsAutoplay({ mode, messages, characterMap, isStreaming }
     const shouldAutoplay =
       currentMode === "roleplay" || currentMode === "visual_novel" ? config.autoplayRP : config.autoplayConvo;
     if (!shouldAutoplay) return;
+    if (config.autoplayStreaming) return;
 
     const messageList = messagesRef.current ?? [];
-    let lastMessage: (typeof messageList)[number] | undefined;
-    for (let index = messageList.length - 1; index >= 0; index -= 1) {
-      const candidate = messageList[index];
-      if (candidate.role === "assistant" || candidate.role === "narrator") {
-        lastMessage = candidate;
-        break;
-      }
-    }
+    const lastMessage = findLastAssistantMessage(messageList);
     if (!lastMessage?.content) return;
 
-    const fallbackSpeaker = lastMessage.characterId ? characterMap.get(lastMessage.characterId)?.name : undefined;
+    const fallbackSpeaker =
+      lastMessage.role === "narrator"
+        ? "Narrator"
+        : lastMessage.characterId
+          ? characterMap.get(lastMessage.characterId)?.name
+          : undefined;
     const text = buildTTSMessageText(lastMessage.content, config, fallbackSpeaker);
     if (!text) return;
     const voice = resolveTTSVoiceForSpeaker(config, fallbackSpeaker, lastMessage.characterId);

--- a/src/features/modes/shared/chat-ui/hooks/use-streaming-tts.test.tsx
+++ b/src/features/modes/shared/chat-ui/hooks/use-streaming-tts.test.tsx
@@ -1,0 +1,145 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { TTSConfig } from "../../../../../engine/contracts/types/tts";
+import { useChatStore } from "../../../../../shared/stores/chat.store";
+import { ttsService } from "../../../../../shared/lib/tts-service";
+import { useStreamingTTS } from "./use-streaming-tts";
+
+const baseConfig: TTSConfig = {
+  enabled: true,
+  source: "openai",
+  baseUrl: "https://api.openai.com/v1",
+  apiKey: "",
+  voice: "alloy",
+  model: "tts-1",
+  speed: 1,
+  elevenLabsStability: 0.5,
+  elevenLabsLanguageCode: "",
+  voiceMode: "single",
+  voiceAssignments: [],
+  npcDefaultVoicesEnabled: false,
+  npcDefaultMaleVoices: [],
+  npcDefaultFemaleVoices: [],
+  autoplayRP: true,
+  autoplayConvo: false,
+  autoplayGame: false,
+  autoplayStreaming: true,
+  dialogueOnly: false,
+  dialogueScope: "all",
+  dialogueCharacterName: "",
+};
+
+class MockAudio {
+  static instances: MockAudio[] = [];
+
+  onended: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  playbackRate = 1;
+  paused = false;
+  play = vi.fn(() => Promise.resolve());
+  pause = vi.fn(() => {
+    this.paused = true;
+  });
+  src = "";
+
+  constructor(src: string) {
+    this.src = src;
+    MockAudio.instances.push(this);
+  }
+}
+
+function Harness({ enabled = true }: { enabled?: boolean }) {
+  useStreamingTTS({
+    enabled,
+    chatId: "chat-1",
+    ttsConfig: baseConfig,
+    fallbackSpeaker: "Narrator",
+  });
+  return null;
+}
+
+async function waitFor(expectation: () => void): Promise<void> {
+  const startedAt = Date.now();
+  let lastError: unknown;
+  while (Date.now() - startedAt < 1000) {
+    try {
+      expectation();
+      return;
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+  }
+  throw lastError;
+}
+
+describe("useStreamingTTS", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let objectUrlIndex = 0;
+
+  beforeEach(() => {
+    vi.spyOn(ttsService, "generateAudio").mockImplementation(async (text) => new Blob([text], { type: "audio/mpeg" }));
+    vi.spyOn(URL, "createObjectURL").mockImplementation(() => `blob:tts-${++objectUrlIndex}`);
+    vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => undefined);
+    vi.stubGlobal("Audio", MockAudio);
+    MockAudio.instances = [];
+    objectUrlIndex = 0;
+    useChatStore.getState().reset();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    useChatStore.getState().reset();
+  });
+
+  it("fetches completed sentences as the stream grows and plays them sequentially", async () => {
+    act(() => {
+      root.render(<Harness />);
+    });
+
+    act(() => {
+      useChatStore.getState().setStreaming(true, "chat-1");
+      useChatStore.getState().appendStreamBuffer("First sentence. Second", "chat-1");
+    });
+
+    await waitFor(() => expect(ttsService.generateAudio).toHaveBeenCalledTimes(1));
+    expect(ttsService.generateAudio).toHaveBeenNthCalledWith(
+      1,
+      "First sentence.",
+      expect.objectContaining({ speaker: "Narrator" }),
+    );
+    await waitFor(() => expect(MockAudio.instances).toHaveLength(1));
+    expect(MockAudio.instances[0]?.play).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      useChatStore.getState().appendStreamBuffer(" sentence.", "chat-1");
+    });
+
+    await waitFor(() => expect(ttsService.generateAudio).toHaveBeenCalledTimes(2));
+    expect(ttsService.generateAudio).toHaveBeenNthCalledWith(
+      2,
+      "Second sentence.",
+      expect.objectContaining({ speaker: "Narrator" }),
+    );
+    expect(MockAudio.instances).toHaveLength(1);
+
+    act(() => {
+      MockAudio.instances[0]?.onended?.();
+    });
+
+    await waitFor(() => expect(MockAudio.instances).toHaveLength(2));
+    expect(MockAudio.instances[1]?.play).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/modes/shared/chat-ui/hooks/use-streaming-tts.ts
+++ b/src/features/modes/shared/chat-ui/hooks/use-streaming-tts.ts
@@ -1,0 +1,272 @@
+import { useEffect, useRef } from "react";
+import type { TTSConfig } from "../../../../../engine/contracts/types/tts";
+import { useChatStore } from "../../../../../shared/stores/chat.store";
+import { ttsService } from "../../../../../shared/lib/tts-service";
+import { buildTTSVoiceRequests, clientSidePlaybackRate } from "../../../../../shared/lib/tts-dialogue";
+import { createChunkerState, extractNewSentences, extractRemainder } from "../../../../../shared/lib/sentence-chunker";
+
+interface UseStreamingTTSOptions {
+  enabled: boolean;
+  chatId: string | null;
+  ttsConfig: TTSConfig | undefined;
+  fallbackSpeaker?: string | null;
+  fallbackCharacterId?: string | null;
+  resolveCharacterIdForSpeaker?: (speaker?: string | null) => string | null | undefined;
+}
+
+type StreamingTTSActiveListener = (active: boolean) => void;
+
+let activeStopHandler: (() => void) | null = null;
+const activeListeners = new Set<StreamingTTSActiveListener>();
+
+function notifyActiveChange(): void {
+  const active = activeStopHandler !== null;
+  for (const listener of activeListeners) {
+    listener(active);
+  }
+}
+
+export function stopStreamingTTS(): void {
+  activeStopHandler?.();
+}
+
+export function isStreamingTTSActive(): boolean {
+  return activeStopHandler !== null;
+}
+
+export function subscribeStreamingTTSActive(listener: StreamingTTSActiveListener): () => void {
+  activeListeners.add(listener);
+  return () => {
+    activeListeners.delete(listener);
+  };
+}
+
+interface StreamingTTSSession {
+  chatId: string;
+  chunker: ReturnType<typeof createChunkerState>;
+  chain: Promise<void>;
+  abort: AbortController;
+  externalSignal: AbortSignal | null;
+  externalAbortListener: (() => void) | null;
+  objectUrls: Set<string>;
+  audios: Set<HTMLAudioElement>;
+}
+
+export function useStreamingTTS({
+  enabled,
+  chatId,
+  ttsConfig,
+  fallbackSpeaker,
+  fallbackCharacterId,
+  resolveCharacterIdForSpeaker,
+}: UseStreamingTTSOptions): void {
+  const sessionRef = useRef<StreamingTTSSession | null>(null);
+  const isStreamingRef = useRef(false);
+  const enabledRef = useRef(enabled);
+  const configRef = useRef(ttsConfig);
+  const fallbackSpeakerRef = useRef(fallbackSpeaker);
+  const fallbackCharacterIdRef = useRef(fallbackCharacterId);
+  const resolveCharacterIdRef = useRef(resolveCharacterIdForSpeaker);
+
+  enabledRef.current = enabled;
+  configRef.current = ttsConfig;
+  fallbackSpeakerRef.current = fallbackSpeaker;
+  fallbackCharacterIdRef.current = fallbackCharacterId;
+  resolveCharacterIdRef.current = resolveCharacterIdForSpeaker;
+
+  useEffect(() => {
+    if (!enabled || !chatId) {
+      stopStreamingTTS();
+    }
+  }, [enabled, chatId]);
+
+  useEffect(() => {
+    const stopSession = (): void => {
+      const session = sessionRef.current;
+      if (!session) return;
+      sessionRef.current = null;
+      if (activeStopHandler === stopSession) {
+        activeStopHandler = null;
+        notifyActiveChange();
+      }
+      if (session.externalSignal && session.externalAbortListener) {
+        session.externalSignal.removeEventListener("abort", session.externalAbortListener);
+      }
+      session.abort.abort();
+      for (const audio of session.audios) {
+        audio.pause();
+        audio.onended = null;
+        audio.onerror = null;
+        audio.src = "";
+      }
+      session.audios.clear();
+      for (const objectUrl of session.objectUrls) {
+        URL.revokeObjectURL(objectUrl);
+      }
+      session.objectUrls.clear();
+    };
+
+    const finishSessionAfterQueue = (session: StreamingTTSSession): void => {
+      session.chain = session.chain.then(() => {
+        if (sessionRef.current !== session) return;
+        if (session.externalSignal && session.externalAbortListener) {
+          session.externalSignal.removeEventListener("abort", session.externalAbortListener);
+        }
+        sessionRef.current = null;
+        if (activeStopHandler === stopSession) {
+          activeStopHandler = null;
+          notifyActiveChange();
+        }
+      });
+    };
+
+    const pushText = (text: string): void => {
+      const session = sessionRef.current;
+      const config = configRef.current;
+      if (!session || !config || !text.trim()) return;
+
+      const requests = buildTTSVoiceRequests(
+        text,
+        config,
+        fallbackSpeakerRef.current,
+        fallbackCharacterIdRef.current,
+        resolveCharacterIdRef.current,
+      ).filter((request) => request.text.trim().length > 0);
+
+      const playbackRate = clientSidePlaybackRate(config);
+      for (const request of requests) {
+        const fetchPromise = ttsService
+          .generateAudio(request.text, {
+            speaker: request.speaker,
+            tone: request.tone,
+            voice: request.voice,
+            signal: session.abort.signal,
+          })
+          .catch((error: unknown) => {
+            if (error instanceof Error && error.name === "AbortError") return null;
+            console.warn("[streaming-tts] fetch failed:", error);
+            return null;
+          });
+
+        session.chain = session.chain.then(async () => {
+          if (sessionRef.current !== session) return;
+          const blob = await fetchPromise;
+          if (!blob || sessionRef.current !== session) return;
+
+          const objectUrl = URL.createObjectURL(blob);
+          session.objectUrls.add(objectUrl);
+
+          const audio = new Audio(objectUrl);
+          if (playbackRate > 0 && playbackRate !== 1) {
+            audio.playbackRate = playbackRate;
+          }
+          session.audios.add(audio);
+
+          let onAbort: (() => void) | null = null;
+          try {
+            await audio.play();
+          } catch (error) {
+            if (sessionRef.current === session) {
+              console.warn("[streaming-tts] play() rejected:", error);
+            }
+            session.audios.delete(audio);
+            URL.revokeObjectURL(objectUrl);
+            session.objectUrls.delete(objectUrl);
+            return;
+          }
+
+          await new Promise<void>((resolve) => {
+            const cleanup = () => {
+              if (onAbort) session.abort.signal.removeEventListener("abort", onAbort);
+              audio.onended = null;
+              audio.onerror = null;
+              resolve();
+            };
+            audio.onended = cleanup;
+            audio.onerror = cleanup;
+            onAbort = () => {
+              audio.pause();
+              cleanup();
+            };
+            if (session.abort.signal.aborted) {
+              onAbort();
+            } else {
+              session.abort.signal.addEventListener("abort", onAbort, { once: true });
+            }
+          });
+
+          session.audios.delete(audio);
+          URL.revokeObjectURL(objectUrl);
+          session.objectUrls.delete(objectUrl);
+        });
+      }
+    };
+
+    const unsubscribe = useChatStore.subscribe((state) => {
+      const streamingThisChat = state.isStreaming && state.streamingChatId === chatId;
+      const wasStreaming = isStreamingRef.current;
+      isStreamingRef.current = streamingThisChat;
+
+      if (!enabledRef.current || !chatId) {
+        stopSession();
+        return;
+      }
+
+      const buffer = state.streamBuffers.get(chatId) ?? state.streamBuffer ?? "";
+
+      if (streamingThisChat && !wasStreaming) {
+        stopSession();
+        const externalController = state.abortControllers.get(chatId) ?? null;
+        const chunker = createChunkerState();
+        chunker.cursor = buffer.length;
+
+        const session: StreamingTTSSession = {
+          chatId,
+          chunker,
+          chain: Promise.resolve(),
+          abort: new AbortController(),
+          externalSignal: externalController?.signal ?? null,
+          externalAbortListener: null,
+          objectUrls: new Set(),
+          audios: new Set(),
+        };
+        sessionRef.current = session;
+        activeStopHandler = stopSession;
+        notifyActiveChange();
+
+        if (session.externalSignal && !session.externalSignal.aborted) {
+          const listener = () => {
+            if (sessionRef.current === session) stopSession();
+          };
+          session.externalAbortListener = listener;
+          session.externalSignal.addEventListener("abort", listener, { once: true });
+        }
+      }
+
+      if (!streamingThisChat && wasStreaming) {
+        const session = sessionRef.current;
+        if (!session) return;
+        if (session.externalSignal?.aborted) {
+          stopSession();
+          return;
+        }
+        const tail = extractRemainder(buffer, session.chunker);
+        if (tail) pushText(tail);
+        finishSessionAfterQueue(session);
+        return;
+      }
+
+      if (streamingThisChat) {
+        const session = sessionRef.current;
+        if (!session) return;
+        const newSentences = extractNewSentences(buffer, session.chunker);
+        if (newSentences) pushText(newSentences);
+      }
+    });
+
+    return () => {
+      unsubscribe();
+      stopSession();
+    };
+  }, [chatId]);
+}

--- a/src/features/modes/shared/chat-ui/index.ts
+++ b/src/features/modes/shared/chat-ui/index.ts
@@ -21,4 +21,5 @@ export * from "./hooks/use-chat-surface-data";
 export * from "./hooks/use-chat-timeline-actions";
 export * from "./hooks/use-chat-transcript-shortcuts";
 export * from "./hooks/use-chat-tts-autoplay";
+export * from "./hooks/use-streaming-tts";
 export * from "./hooks/use-sprite-metadata-state";

--- a/src/features/shell/settings/components/settings/TTSConfigCard.tsx
+++ b/src/features/shell/settings/components/settings/TTSConfigCard.tsx
@@ -304,6 +304,7 @@ export function TTSConfigCard() {
   const [autoplayRP, setAutoplayRP] = useState(false);
   const [autoplayConvo, setAutoplayConvo] = useState(false);
   const [autoplayGame, setAutoplayGame] = useState(false);
+  const [autoplayStreaming, setAutoplayStreaming] = useState(false);
   const [dialogueOnly, setDialogueOnly] = useState(false);
 
   const [expanded, setExpanded] = useState(false);
@@ -345,6 +346,7 @@ export function TTSConfigCard() {
     setAutoplayRP(savedConfig.autoplayRP);
     setAutoplayConvo(savedConfig.autoplayConvo);
     setAutoplayGame(savedConfig.autoplayGame);
+    setAutoplayStreaming(savedConfig.autoplayStreaming ?? false);
     setDialogueOnly(savedConfig.dialogueOnly ?? false);
     setSaveStatus("idle");
   }, [savedConfig]);
@@ -387,6 +389,7 @@ export function TTSConfigCard() {
     autoplayRP,
     autoplayConvo,
     autoplayGame,
+    autoplayStreaming,
     dialogueOnly,
     dialogueScope: "all",
     dialogueCharacterName: "",
@@ -1112,6 +1115,14 @@ export function TTSConfigCard() {
               onChange={(v) => {
                 setAutoplayGame(v);
                 mark({ autoplayGame: v });
+              }}
+            />
+            <ToggleRow
+              label="Stream as the model generates"
+              checked={autoplayStreaming}
+              onChange={(v) => {
+                setAutoplayStreaming(v);
+                mark({ autoplayStreaming: v });
               }}
             />
             <ToggleRow

--- a/src/shared/lib/sentence-chunker.test.ts
+++ b/src/shared/lib/sentence-chunker.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { createChunkerState, extractNewSentences, extractRemainder } from "./sentence-chunker";
+
+describe("streaming TTS sentence chunker", () => {
+  it("emits completed sentences and flushes the remaining tail", () => {
+    const state = createChunkerState();
+
+    expect(extractNewSentences("Hello there", state)).toBe("");
+    expect(extractNewSentences("Hello there. How are", state)).toBe("Hello there.");
+    expect(extractRemainder("Hello there. How are you", state)).toBe("How are you");
+  });
+
+  it("does not treat ellipses or common abbreviations as sentence boundaries", () => {
+    const state = createChunkerState();
+
+    expect(extractNewSentences("But tell me... what did Dr. Vale say? Fine.", state)).toBe(
+      "But tell me... what did Dr. Vale say? Fine.",
+    );
+  });
+
+  it("does not replay content after a stream buffer rewind", () => {
+    const state = createChunkerState();
+
+    expect(extractNewSentences("First sentence. Second sentence.", state)).toBe("First sentence. Second sentence.");
+    expect(extractNewSentences("First sentence. Cleaned", state)).toBe("");
+    expect(extractNewSentences("First sentence. Cleaned ending.", state)).toBe("");
+  });
+
+  it("strips closed thinking blocks and pauses at unclosed ones", () => {
+    const state = createChunkerState();
+
+    expect(extractNewSentences("Visible. <thought type=\"cot\">secret.</thought> Spoken.", state)).toBe(
+      "Visible. Spoken.",
+    );
+    const unclosedState = createChunkerState();
+    expect(extractNewSentences("Visible. <thought>still thinking. Hidden", unclosedState)).toBe("Visible.");
+    expect(extractRemainder("Visible. <thought>still thinking. Hidden", unclosedState)).toBe("");
+  });
+});

--- a/src/shared/lib/sentence-chunker.ts
+++ b/src/shared/lib/sentence-chunker.ts
@@ -1,0 +1,140 @@
+const SENTENCE_END_RE = /[.!?\u2026\u3002\uff01\uff1f]+(?:["'\u201d\u2019)\]}])?(?=\s|$)/gu;
+
+const ABBREVIATIONS = new Set(["mr", "mrs", "ms", "dr", "st", "prof", "sr", "jr", "vs", "etc", "ie", "eg", "fig", "no"]);
+
+const THINKING_BLOCK_RE = /<(think|thinking|thought)\b[^>]*>[\s\S]*?<\/\1>/gi;
+const SPECIAL_THINKING_BLOCK_RES = [
+  { open: /<\|think\|>/i, close: /<\|\/think\|>/i },
+  { open: /<\|channel>thought\b/i, close: /<channel\|>/i },
+];
+const THINKING_OPEN_TAG_RE = /<(think|thinking|thought)\b[^>]*>/i;
+
+export interface ChunkerState {
+  cursor: number;
+  highWaterMark: number;
+}
+
+export function createChunkerState(): ChunkerState {
+  return { cursor: 0, highWaterMark: 0 };
+}
+
+function endsWithAbbreviation(text: string, periodIndex: number): boolean {
+  let start = periodIndex;
+  while (start > 0 && /[A-Za-z]/.test(text[start - 1]!)) start -= 1;
+  const token = text.slice(start, periodIndex).toLowerCase();
+  return token.length > 0 && ABBREVIATIONS.has(token);
+}
+
+function stripClosedThinkingBlocks(text: string): string {
+  let output = text.replace(THINKING_BLOCK_RE, "");
+  for (const { open, close } of SPECIAL_THINKING_BLOCK_RES) {
+    let openMatch = output.match(open);
+    while (openMatch && openMatch.index !== undefined) {
+      const rest = output.slice(openMatch.index + openMatch[0].length);
+      const closeMatch = rest.match(close);
+      if (!closeMatch || closeMatch.index === undefined) break;
+      const blockEnd = openMatch.index + openMatch[0].length + closeMatch.index + closeMatch[0].length;
+      output = output.slice(0, openMatch.index) + output.slice(blockEnd);
+      openMatch = output.match(open);
+    }
+  }
+  return output.replace(/\s+/g, " ");
+}
+
+function maskClosedThinkingBlocks(text: string): string {
+  let masked = text.replace(THINKING_BLOCK_RE, (match) => " ".repeat(match.length));
+  for (const { open, close } of SPECIAL_THINKING_BLOCK_RES) {
+    let openMatch = masked.match(open);
+    while (openMatch && openMatch.index !== undefined) {
+      const rest = masked.slice(openMatch.index + openMatch[0].length);
+      const closeMatch = rest.match(close);
+      if (!closeMatch || closeMatch.index === undefined) break;
+      const blockLength = openMatch[0].length + closeMatch.index + closeMatch[0].length;
+      masked = masked.slice(0, openMatch.index) + " ".repeat(blockLength) + masked.slice(openMatch.index + blockLength);
+      openMatch = masked.match(open);
+    }
+  }
+  return masked;
+}
+
+function findUnclosedThinkingStart(tail: string): number | null {
+  const masked = maskClosedThinkingBlocks(tail);
+  const xmlMatch = masked.match(THINKING_OPEN_TAG_RE);
+  if (xmlMatch && xmlMatch.index !== undefined) return xmlMatch.index;
+  for (const { open } of SPECIAL_THINKING_BLOCK_RES) {
+    const specialMatch = masked.match(open);
+    if (specialMatch && specialMatch.index !== undefined) return specialMatch.index;
+  }
+  return null;
+}
+
+function isEllipsisEndCandidate(matchText: string): boolean {
+  return /^\.{2,}["'\u201d\u2019)\]}]?$/.test(matchText);
+}
+
+function lastSentencePunctuationIndex(matchText: string): number {
+  return Math.max(
+    matchText.lastIndexOf("."),
+    matchText.lastIndexOf("!"),
+    matchText.lastIndexOf("?"),
+    matchText.lastIndexOf("\u2026"),
+    matchText.lastIndexOf("\u3002"),
+    matchText.lastIndexOf("\uff01"),
+    matchText.lastIndexOf("\uff1f"),
+  );
+}
+
+export function extractNewSentences(buffer: string, state: ChunkerState): string {
+  if (buffer.length < state.cursor) {
+    state.cursor = buffer.length;
+  }
+
+  const startAt = Math.max(state.cursor, state.highWaterMark);
+  if (startAt >= buffer.length) return "";
+
+  const tail = buffer.slice(startAt);
+  const unclosedThinkingStart = findUnclosedThinkingStart(tail);
+  const scannable = unclosedThinkingStart === null ? tail : tail.slice(0, unclosedThinkingStart);
+
+  let lastEnd = -1;
+  SENTENCE_END_RE.lastIndex = 0;
+  for (const match of scannable.matchAll(SENTENCE_END_RE)) {
+    const matchText = match[0];
+    if (isEllipsisEndCandidate(matchText)) continue;
+
+    const localIndex = match.index ?? 0;
+    const punctuationOffset = lastSentencePunctuationIndex(matchText);
+    const punctuationIndex = punctuationOffset >= 0 ? localIndex + punctuationOffset : localIndex + matchText.length - 1;
+    if (scannable[punctuationIndex] === "." && endsWithAbbreviation(scannable, punctuationIndex)) continue;
+
+    lastEnd = startAt + localIndex + matchText.length;
+  }
+
+  if (lastEnd === -1) return "";
+
+  const cleanSlice = stripClosedThinkingBlocks(buffer.slice(startAt, lastEnd)).trim();
+  state.cursor = lastEnd;
+  state.highWaterMark = lastEnd;
+  return cleanSlice;
+}
+
+export function extractRemainder(buffer: string, state: ChunkerState): string {
+  if (buffer.length < state.cursor) {
+    state.cursor = buffer.length;
+  }
+
+  const startAt = Math.max(state.cursor, state.highWaterMark);
+  if (startAt >= buffer.length) {
+    state.cursor = buffer.length;
+    state.highWaterMark = buffer.length;
+    return "";
+  }
+
+  const tail = buffer.slice(startAt);
+  const unclosedThinkingStart = findUnclosedThinkingStart(tail);
+  const usableTail = unclosedThinkingStart === null ? tail : tail.slice(0, unclosedThinkingStart);
+  const remainder = stripClosedThinkingBlocks(usableTail).trim();
+  state.cursor = buffer.length;
+  state.highWaterMark = buffer.length;
+  return remainder;
+}

--- a/src/shared/lib/tts-dialogue.ts
+++ b/src/shared/lib/tts-dialogue.ts
@@ -16,6 +16,10 @@ export interface TTSUtterance {
   tone?: string;
 }
 
+export interface TTSVoiceRequest extends TTSUtterance {
+  voice?: string;
+}
+
 export function normalizeTTSCharacterName(value?: string | null): string {
   return (value ?? "").toLowerCase().replace(/[_-]+/g, " ").replace(/\s+/g, " ").trim();
 }
@@ -258,22 +262,49 @@ export function buildTTSMessageText(text: string, config: TTSConfig, fallbackSpe
     .join("\n");
 }
 
+export function buildTTSVoiceRequests(
+  text: string,
+  config: TTSConfig,
+  fallbackSpeaker?: string | null,
+  fallbackCharacterId?: string | null,
+  resolveCharacterIdForSpeaker?: (speaker?: string | null) => string | null | undefined,
+): TTSVoiceRequest[] {
+  const hasSpeakerTags = /<speaker="[^"]*">/i.test(text);
+  const shouldExtractUtterances = config.dialogueOnly || hasSpeakerTags;
+  const utterances =
+    hasSpeakerTags && !config.dialogueOnly
+      ? extractSpeakerTaggedUtterances(text, config, fallbackSpeaker, true)
+      : shouldExtractUtterances
+        ? extractDialogueUtterances(text, config, fallbackSpeaker)
+        : [{ text: cleanTTSInputText(text), speaker: fallbackSpeaker || undefined } satisfies TTSUtterance];
+
+  const fallbackSpeakerKey = normalizeTTSCharacterName(fallbackSpeaker);
+  return utterances.flatMap((utterance) => {
+    const speaker = utterance.speaker || fallbackSpeaker || undefined;
+    const speakerKey = normalizeTTSCharacterName(speaker);
+    const resolvedCharacterId = speaker
+      ? (resolveCharacterIdForSpeaker?.(speaker) ??
+        (speakerKey && speakerKey === fallbackSpeakerKey ? fallbackCharacterId : undefined))
+      : fallbackCharacterId;
+    const voice = resolveTTSVoiceForSpeaker(config, speaker, resolvedCharacterId);
+    if (config.source === "elevenlabs" && !voice) return [];
+
+    return splitTTSChunks(utterance.text).map((chunk) => ({
+      text: chunk,
+      speaker,
+      tone: utterance.tone,
+      voice,
+    }));
+  });
+}
+
 export function extractDialogueUtterances(
   text: string,
   config: Pick<TTSConfig, "dialogueScope" | "dialogueCharacterName">,
   fallbackSpeaker?: string | null,
 ): TTSUtterance[] {
   const utterances: TTSUtterance[] = [];
-
-  const speakerTagRe = /<speaker="([^"]*)">([\s\S]*?)<\/speaker>/gi;
-  let speakerTagMatch: RegExpExecArray | null;
-  while ((speakerTagMatch = speakerTagRe.exec(text)) !== null) {
-    const speaker = speakerTagMatch[1]?.trim() || fallbackSpeaker || undefined;
-    const spoken = cleanTTSInputText(speakerTagMatch[2] ?? "");
-    if (spoken && ttsConfigMatchesSpeaker(config, speaker)) {
-      utterances.push({ text: spoken, speaker });
-    }
-  }
+  utterances.push(...extractSpeakerTaggedUtterances(text, config, fallbackSpeaker, false));
 
   const vnLineRe = /^\s*(?:Dialogue\s*)?\[([^\]]+)\]\s*(?:\[([^\]]+)\])?\s*(?:\[([^\]]+)\])?\s*:\s*(.+)$/i;
   for (const rawLine of text.split(/\r?\n/)) {
@@ -309,6 +340,38 @@ export function extractDialogueUtterances(
   }
 
   return dedupeUtterances(utterances);
+}
+
+function extractSpeakerTaggedUtterances(
+  text: string,
+  config: Pick<TTSConfig, "dialogueScope" | "dialogueCharacterName">,
+  fallbackSpeaker?: string | null,
+  includeNarration = false,
+): TTSUtterance[] {
+  const utterances: TTSUtterance[] = [];
+  const speakerTagRe = /<speaker="([^"]*)">([\s\S]*?)<\/speaker>/gi;
+  let speakerTagMatch: RegExpExecArray | null;
+  let lastIndex = 0;
+
+  const addNarration = (value: string) => {
+    if (!includeNarration) return;
+    const spoken = cleanTTSInputText(value);
+    if (spoken) utterances.push({ text: spoken, speaker: "Narrator" });
+  };
+
+  while ((speakerTagMatch = speakerTagRe.exec(text)) !== null) {
+    addNarration(text.slice(lastIndex, speakerTagMatch.index));
+
+    const speaker = speakerTagMatch[1]?.trim() || fallbackSpeaker || undefined;
+    const spoken = cleanTTSInputText(stripSurroundingDialogueQuotes((speakerTagMatch[2] ?? "").trim()));
+    if (spoken && ttsConfigMatchesSpeaker(config, speaker)) {
+      utterances.push({ text: spoken, speaker });
+    }
+    lastIndex = speakerTagRe.lastIndex;
+  }
+
+  addNarration(text.slice(lastIndex));
+  return utterances;
 }
 
 function dedupeUtterances(utterances: TTSUtterance[]): TTSUtterance[] {


### PR DESCRIPTION
## Linked issue

Closes #1142

## Why this change

- TTS autoplay currently waits until the model finishes generating before requesting and playing audio. This adds an opt-in streaming autoplay path so conversation, roleplay, and visual novel replies can begin speaking completed sentences while generation is still in progress.

## What changed

- Added a default-off `autoplayStreaming` TTS setting and surfaced it in the TTS settings card.
- Added a sentence chunker that emits completed sentences, strips closed thinking blocks, pauses at unclosed thinking blocks, and avoids replay after stream-buffer rewrites.
- Added a shared streaming TTS hook that watches active chat stream buffers, requests audio per completed sentence, and plays fetched audio sequentially.
- Wired streaming TTS into conversation, roleplay, and visual novel autoplay while suppressing final-message autoplay when streaming is enabled to avoid duplicate playback.
- Updated message speaker controls so they can stop an active streaming narration queue.
- Kept game-mode TTS behavior out of scope.

## Refactor impact

Primary owner:

Shared mode UI / TTS configuration

Impact areas reviewed:

- Engine TTS config contract
- Rust TTS default storage config
- Shell settings TTS card
- Shared chat TTS autoplay hook
- Conversation and roleplay route wiring
- Shared TTS dialogue parsing helpers

Boundary notes:

- Engine contract change is limited to a default-off config field.
- Rust change is limited to the default stored TTS config.
- Streaming playback stays in shared chat UI hooks and uses the existing client-side `ttsService.generateAudio` path.
- No provider voices endpoint, remote runtime, schema, dependency, or prompt-pipeline changes.
- Game mode remains untouched.

Pressure points touched:

- Shared mode UI: `use-chat-tts-autoplay`, `use-streaming-tts`, `ChatMessage`
- Conversation and roleplay route call sites
- TTS settings card
- No `ModeSurface`, `GameSurface`, or `src-tauri/src/lib.rs` command-registration changes

## Validation

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Codex ran `pnpm test -- src/shared/lib/sentence-chunker.test.ts`; 4 tests passed.
- Codex ran `pnpm typecheck`; passed.
- Codex ran `pnpm check`; passed, including architecture, frontend, Rust, and docs checks.
- Codex ran `pnpm build`; passed. Vite emitted existing chunk/import warnings.
- Codex ran `cargo check --manifest-path src-tauri/Cargo.toml --workspace`; passed.
- Codex ran a Playwright app-shell smoke against this worktree's Vite server at `http://127.0.0.1:4174`; the app loaded as `Marinara Engine` with no console warnings/errors captured.
- True provider-audio verification is still pending. Before marking ready, manually enable TTS + autoplay + "Stream as the model generates", send a long conversation/RP reply, confirm audio starts before completion, confirm no duplicate final playback, stop mid-stream from a speaker icon, test regenerate while streaming, and disable the streaming toggle to confirm final autoplay still works.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs or release metadata changed. This is an opt-in TTS setting on the refactor branch.

## UI evidence

No GitHub-renderable UI evidence is attached yet. Codex did run a local Playwright app-shell smoke on this worktree's Vite server with no console warnings/errors, but real provider-audio behavior still needs manual verification before ready-for-review.
