### PR TITLE
fix: Centralize agent debug mode diagnostics [Issue #1157]

### DIFF
--- a/src/engine/agents-runtime/debug.test.ts
+++ b/src/engine/agents-runtime/debug.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AgentContext } from "../contracts/types/agent";
+import { createAgentRuntimeDebug } from "./debug";
+
+const baseContext: AgentContext = {
+  chatId: "chat-1",
+  chatMode: "roleplay",
+  recentMessages: [],
+  mainResponse: null,
+  gameState: null,
+  characters: [],
+  persona: null,
+  memory: {},
+  activatedLorebookEntries: [],
+  writableLorebookIds: null,
+  chatSummary: null,
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("createAgentRuntimeDebug", () => {
+  it("does not emit console or structured debug entries unless debug mode is enabled", () => {
+    const sink = vi.fn();
+    const consoleDebug = vi.spyOn(console, "debug").mockImplementation(() => undefined);
+    const logger = createAgentRuntimeDebug({ ...baseContext, debugMode: false, debugSink: sink });
+
+    logger.debug("hidden");
+    logger.emit({ level: "debug", phase: "pre_generation", message: "hidden" });
+
+    expect(logger.enabled).toBe(false);
+    expect(logger.isLevelEnabled("debug")).toBe(false);
+    expect(consoleDebug).not.toHaveBeenCalled();
+    expect(sink).not.toHaveBeenCalled();
+  });
+
+  it("emits console and structured debug entries when debug mode is enabled", () => {
+    const sink = vi.fn();
+    const consoleDebug = vi.spyOn(console, "debug").mockImplementation(() => undefined);
+    const logger = createAgentRuntimeDebug({ ...baseContext, debugMode: true, debugSink: sink });
+
+    logger.debug("visible");
+    logger.emit({ level: "debug", phase: "pre_generation", message: "visible" });
+
+    expect(logger.enabled).toBe(true);
+    expect(logger.isLevelEnabled("debug")).toBe(true);
+    expect(consoleDebug).toHaveBeenCalledWith("visible");
+    expect(sink).toHaveBeenCalledWith(
+      expect.objectContaining({
+        level: "debug",
+        phase: "pre_generation",
+        message: "visible",
+        timestamp: expect.any(Number),
+      }),
+    );
+  });
+});

--- a/src/engine/agents-runtime/debug.ts
+++ b/src/engine/agents-runtime/debug.ts
@@ -1,0 +1,50 @@
+import type { AgentContext, AgentDebugEntry } from "../contracts/types/agent";
+
+export type AgentRuntimeDebugEntry = Omit<AgentDebugEntry, "timestamp"> & { timestamp?: number };
+
+export interface AgentRuntimeDebugLogger {
+  enabled: boolean;
+  debug: (...args: unknown[]) => void;
+  info: (...args: unknown[]) => void;
+  warn: (...args: unknown[]) => void;
+  error: (...args: unknown[]) => void;
+  isLevelEnabled: (_level: string) => boolean;
+  emit: (entry: AgentRuntimeDebugEntry) => void;
+}
+
+type ConsoleLevel = "debug" | "info" | "warn" | "error";
+
+function writeConsole(level: ConsoleLevel, args: unknown[]) {
+  if (typeof console === "undefined") return;
+  const target = typeof console[level] === "function" ? console[level] : console.log;
+  if (typeof target === "function") target.apply(console, args);
+}
+
+export function isAgentRuntimeDebugEnabled(context: Pick<AgentContext, "debugMode">): boolean {
+  return context.debugMode === true;
+}
+
+export function createAgentRuntimeDebug(context: AgentContext): AgentRuntimeDebugLogger {
+  const enabled = isAgentRuntimeDebugEnabled(context);
+
+  const log = (level: ConsoleLevel, args: unknown[]) => {
+    if (!enabled) return;
+    writeConsole(level, args);
+  };
+
+  return {
+    enabled,
+    debug: (...args: unknown[]) => log("debug", args),
+    info: (...args: unknown[]) => log("info", args),
+    warn: (...args: unknown[]) => log("warn", args),
+    error: (...args: unknown[]) => log("error", args),
+    isLevelEnabled: () => enabled,
+    emit: (entry: AgentRuntimeDebugEntry) => {
+      if (!enabled) return;
+      context.debugSink?.({
+        ...entry,
+        timestamp: entry.timestamp ?? Date.now(),
+      });
+    },
+  };
+}

--- a/src/engine/agents-runtime/executor/agent-executor.ts
+++ b/src/engine/agents-runtime/executor/agent-executor.ts
@@ -7,18 +7,11 @@ import type {
   LLMToolCall,
   LLMToolDefinition,
 } from "../../generation-core/llm/base-provider.js";
-import type { AgentResult, AgentContext, AgentResultType, AgentDebugEntry } from "../../contracts/types/agent";
+import type { AgentResult, AgentContext, AgentResultType } from "../../contracts/types/agent";
 import { getDefaultAgentPrompt } from "../../contracts/constants/agent-prompts";
 import { DEFAULT_AGENT_CONTEXT_SIZE, DEFAULT_AGENT_MAX_TOKENS, MAX_AGENT_MAX_TOKENS, MIN_AGENT_MAX_TOKENS } from "../../contracts/types/agent";
+import { createAgentRuntimeDebug, type AgentRuntimeDebugEntry } from "../debug.js";
 import { stripAvatarPathsReplacer } from "../strip-avatar-paths";
-
-type Logger = {
-  debug: (...args: unknown[]) => void;
-  info: (...args: unknown[]) => void;
-  warn: (...args: unknown[]) => void;
-  error: (...args: unknown[]) => void;
-  isLevelEnabled: (level: string) => boolean;
-};
 
 const MAX_AGENT_CONTEXT_MESSAGES = 200;
 const EXPRESSION_AGENT_RECENT_CONTEXT_MESSAGES = 2;
@@ -55,34 +48,6 @@ export function normalizeAgentContextSize(value: unknown, fallback = DEFAULT_AGE
     typeof value === "number" ? value : typeof value === "string" && value.trim() ? Number(value) : fallback;
   if (!Number.isFinite(parsed) || parsed < 1) return fallback;
   return Math.max(1, Math.min(MAX_AGENT_CONTEXT_MESSAGES, Math.trunc(parsed)));
-}
-
-function createLogger(enabled: boolean): Logger {
-  const log = (level: "debug" | "info" | "warn" | "error", args: unknown[]) => {
-    if (!enabled) return;
-    const target =
-      typeof console !== "undefined" && typeof console[level] === "function"
-        ? console[level]
-        : typeof console !== "undefined" && typeof console.log === "function"
-          ? console.log
-          : undefined;
-    target?.(...args);
-  };
-
-  return {
-    debug: (...args: unknown[]) => log("debug", args),
-    info: (...args: unknown[]) => log("info", args),
-    warn: (...args: unknown[]) => log("warn", args),
-    error: (...args: unknown[]) => log("error", args),
-    isLevelEnabled: () => enabled,
-  };
-}
-
-function emitDebug(context: AgentContext, entry: Omit<AgentDebugEntry, "timestamp"> & { timestamp?: number }) {
-  context.debugSink?.({
-    ...entry,
-    timestamp: entry.timestamp ?? Date.now(),
-  });
 }
 
 function redactSensitiveValue(value: unknown): unknown {
@@ -147,8 +112,8 @@ export async function executeAgent(
   toolContext?: AgentToolContext,
 ): Promise<AgentResult> {
   const startTime = Date.now();
-  const logger = createLogger(context.debugMode === true);
-  const emit = (entry: Omit<AgentDebugEntry, "timestamp"> & { timestamp?: number }) => emitDebug(context, entry);
+  const logger = createAgentRuntimeDebug(context);
+  const emit = (entry: AgentRuntimeDebugEntry) => logger.emit(entry);
 
   try {
     const template = config.promptTemplate || getDefaultAgentPrompt(config.type);
@@ -273,9 +238,9 @@ async function executeAgentWithTools(
   const MAX_TOOL_ROUNDS = 5;
   const loopMessages = [...initialMessages];
   let totalTokens = 0;
-  const logger = createLogger(context.debugMode === true);
+  const logger = createAgentRuntimeDebug(context);
   const debugAgentsEnabled = logger.isLevelEnabled("debug");
-  const emit = (entry: Omit<AgentDebugEntry, "timestamp"> & { timestamp?: number }) => emitDebug(context, entry);
+  const emit = (entry: AgentRuntimeDebugEntry) => logger.emit(entry);
 
   for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
     const result = await provider.chatComplete(loopMessages, {
@@ -392,8 +357,8 @@ export async function executeAgentBatch(
   model: string,
 ): Promise<AgentResult[]> {
   if (configs.length === 0) return [];
-  const logger = createLogger(context.debugMode === true);
-  const emit = (entry: Omit<AgentDebugEntry, "timestamp"> & { timestamp?: number }) => emitDebug(context, entry);
+  const logger = createAgentRuntimeDebug(context);
+  const emit = (entry: AgentRuntimeDebugEntry) => logger.emit(entry);
   const isolatedConfigs = configs.filter(shouldRunAgentIndividually);
   if (isolatedConfigs.length === configs.length) {
     logger.info(

--- a/src/engine/agents-runtime/knowledge/knowledge-router.ts
+++ b/src/engine/agents-runtime/knowledge/knowledge-router.ts
@@ -1,6 +1,7 @@
 import type { AgentContext, AgentResult } from "../../contracts/types/agent";
 import type { LorebookEntry } from "../../contracts/types/lorebook";
 import type { BaseLLMProvider } from "../../generation-core/llm/base-provider.js";
+import { createAgentRuntimeDebug } from "../debug.js";
 import { executeAgent, type AgentExecConfig } from "../executor/agent-executor.js";
 import { stripAvatarPathsReplacer } from "../strip-avatar-paths.js";
 import {
@@ -261,17 +262,7 @@ export async function executeKnowledgeRouter(
   options: KnowledgeRouterCandidateOptions = {},
 ): Promise<AgentResult> {
   const startTime = Date.now();
-  const logger = {
-    debug: (...args: unknown[]) => {
-      if (baseContext.debugMode === true) console.debug(...args);
-    },
-    warn: (...args: unknown[]) => {
-      if (baseContext.debugMode === true) console.warn(...args);
-    },
-    error: (...args: unknown[]) => {
-      if (baseContext.debugMode === true) console.error(...args);
-    },
-  };
+  const logger = createAgentRuntimeDebug(baseContext);
 
   // Empty input → no work, no LLM call.
   if (entries.length === 0) {
@@ -304,6 +295,12 @@ export async function executeKnowledgeRouter(
       candidates.length,
       routerEntries.length,
     );
+    logger.emit({
+      level: "warn",
+      phase: config.phase,
+      message: "knowledge-router-truncated",
+      args: [candidates.length, routerEntries.length],
+    });
   }
 
   const catalog = buildCatalog(candidates);
@@ -324,6 +321,12 @@ export async function executeKnowledgeRouter(
     // can serialize a stack-aware payload via its err-first signature.
     const err = new Error(result.error ?? "unknown error");
     logger.error(err, "[knowledge-router] agent execution failed");
+    logger.emit({
+      level: "error",
+      phase: config.phase,
+      message: "knowledge-router-error",
+      args: [result.error ?? "unknown error"],
+    });
     return result;
   }
 
@@ -345,6 +348,12 @@ export async function executeKnowledgeRouter(
 
   if (selectedEntries.length === 0) {
     logger.debug("[knowledge-router] no entries selected from %d candidates", candidates.length);
+    logger.emit({
+      level: "debug",
+      phase: config.phase,
+      message: "knowledge-router-empty",
+      args: [candidates.length],
+    });
     return {
       ...result,
       type: "context_injection",
@@ -362,6 +371,12 @@ export async function executeKnowledgeRouter(
     dedupedIds.length,
     dedupedIds.length - selectedEntries.length,
   );
+  logger.emit({
+    level: "debug",
+    phase: config.phase,
+    message: "knowledge-router-selected",
+    args: [selectedEntries.length, candidates.length, selectedIds.length, dedupedIds.length],
+  });
 
   return {
     ...result,

--- a/src/engine/agents-runtime/pipeline/agent-pipeline.ts
+++ b/src/engine/agents-runtime/pipeline/agent-pipeline.ts
@@ -1,5 +1,6 @@
-import type { AgentContext, AgentDebugEntry, AgentResult } from "../../contracts/types/agent";
+import type { AgentContext, AgentResult } from "../../contracts/types/agent";
 import type { BaseLLMProvider } from "../../generation-core/llm/base-provider.js";
+import { createAgentRuntimeDebug } from "../debug.js";
 import {
   executeAgent,
   executeAgentBatch,
@@ -7,27 +8,6 @@ import {
   type AgentExecConfig,
   type AgentToolContext,
 } from "../executor/agent-executor.js";
-
-function createLogger(enabled: boolean) {
-  return {
-    debug: (...args: unknown[]) => {
-      if (enabled) console.debug(...args);
-    },
-    warn: (...args: unknown[]) => {
-      if (enabled) console.warn(...args);
-    },
-    error: (...args: unknown[]) => {
-      if (enabled) console.error(...args);
-    },
-  };
-}
-
-function emitDebug(context: AgentContext, entry: Omit<AgentDebugEntry, "timestamp"> & { timestamp?: number }) {
-  context.debugSink?.({
-    ...entry,
-    timestamp: entry.timestamp ?? Date.now(),
-  });
-}
 
 /** A fully resolved agent ready for execution. */
 export interface ResolvedAgent extends AgentExecConfig {
@@ -159,8 +139,8 @@ async function executeGroup(
   context: AgentContext,
   onResult?: AgentResultCallback,
 ): Promise<AgentResult[]> {
-  const logger = createLogger(context.debugMode === true);
-  emitDebug(context, {
+  const logger = createAgentRuntimeDebug(context);
+  logger.emit({
     level: "debug",
     phase: group.agents[0]?.phase ?? "unknown",
     message: "group-start",
@@ -230,9 +210,9 @@ async function executePhase(
   const phaseAgents = agents.filter((a) => a.phase === phase);
   if (phaseAgents.length === 0) return [];
 
-  const logger = createLogger(context.debugMode === true);
+  const logger = createAgentRuntimeDebug(context);
   const groups = groupByProviderModel(phaseAgents).flatMap(splitGroupForParallelJobs);
-  emitDebug(context, {
+  logger.emit({
     level: "debug",
     phase,
     message: "phase-groups",
@@ -273,7 +253,7 @@ async function executePhase(
           String(entry.reason),
         );
       }
-      emitDebug(context, {
+      logger.emit({
         level: "error",
         phase,
         message: "group-error",

--- a/src/engine/contracts/types/agent.ts
+++ b/src/engine/contracts/types/agent.ts
@@ -161,7 +161,7 @@ export interface AgentContext {
   } | null;
   /** The agent's own persistent memory (key-value) */
   memory: Record<string, unknown>;
-  /** Optional sink for structured runtime debug entries. */
+  /** Optional sink for structured runtime debug entries when debugMode is enabled. */
   debugSink?: (entry: Omit<AgentDebugEntry, "timestamp"> & { timestamp?: number }) => void;
   /** Lorebook entries activated for this generation (read context) */
   activatedLorebookEntries: Array<{ id: string; name: string; content: string; tag: string }> | null;
@@ -175,7 +175,7 @@ export interface AgentContext {
   parallelResults?: AgentResult[];
   /** Whether internal agent LLM calls should use transport streaming. */
   streaming?: boolean;
-  /** Whether agent runtime logging should emit to the console. */
+  /** Whether agent runtime diagnostics should emit to the debug sink and console. */
   debugMode?: boolean;
   /** Abort signal — when triggered, agent execution should stop. Typed as `any` to avoid DOM/Node lib dependency. */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/features/shell/settings/components/SettingsPanel.tsx
+++ b/src/features/shell/settings/components/SettingsPanel.tsx
@@ -3430,7 +3430,7 @@ function AdvancedSettings() {
         label="Debug mode"
         checked={debugMode}
         onChange={setDebugMode}
-        help="Shows the in-app agent debug panel with prompt, response, tool, and result details for troubleshooting."
+        help="Shows the in-app agent debug panel and emits agent runtime diagnostics to the console for troubleshooting."
       />
 
       {/* ── Profile Export ── */}


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #1157

## Why this change

- Debug Mode's user-facing contract and runtime behavior had drifted between in-app panel diagnostics and scattered console logging helpers.
- Agent runtime diagnostics should have one engine-owned path so console output and structured debug panel entries are gated consistently by Debug Mode.

## What changed

- Added a small `src/engine/agents-runtime/debug.ts` helper that owns agent runtime diagnostic gating.
- Routed agent executor, pipeline, and knowledge-router debug output through the shared helper.
- Added focused tests proving Debug Mode off emits neither console nor structured debug entries, and Debug Mode on emits both.
- Updated the `AgentContext` comments and settings copy so the documented contract matches the implementation.

## Refactor impact

Primary owner:

engine agent runtime

Impact areas reviewed:

- Agent executor diagnostics
- Agent pipeline diagnostics
- Knowledge-router diagnostics
- `AgentContext` debug contract
- Settings Debug Mode copy
- Runtime generation hook wiring for `debugMode` / `debugSink`

Boundary notes:

- Behavior remains inside `src/engine/agents-runtime`.
- React settings code only updates user-facing copy.
- No shared API, Tauri, Rust, storage, or remote-runtime boundary changes.
- Engine code still depends only on engine contracts and engine-local helpers.

Pressure points touched:

- None of `ModeSurface`, `GameSurface`, shared mode UI, `src-tauri/src/lib.rs`, or import modules were touched.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- In Settings, confirm Debug mode copy says it shows the in-app agent debug panel and emits console diagnostics.
- With Debug mode off, run a generation path that uses agents and confirm the Agent Debug panel does not appear.
- With Debug mode on, run the same generation path and confirm the Agent Debug panel appears with prompt/response/tool/result details.
- With Debug mode on, confirm browser/Tauri console receives agent runtime diagnostic output.
- Toggle Debug mode off again, run another agent generation, and confirm new agent diagnostics stop appearing in both the panel and console.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

Notes:

- No docs changes needed; the user-facing Debug Mode settings copy was updated in place.
- This PR does not restore old staging/package-workspace/release claims.

## UI evidence

- No before/after screenshots or recordings added.
