### PR TITLE
Polish mobile top bar and chat sidebar

### DIFF
--- a/src/app/shell/AppShell.tsx
+++ b/src/app/shell/AppShell.tsx
@@ -818,7 +818,7 @@ export function AppShell() {
         ref={headerRef}
         data-component="AppChrome"
         aria-hidden={activeMobilePanel ? true : undefined}
-        className="mari-app-chrome relative z-40 flex shrink-0 flex-col overflow-hidden"
+        className="mari-app-chrome relative z-40 flex shrink-0 flex-col overflow-visible"
       >
         <WindowTitleBar
           professorMariOpen={professorMariOpen}

--- a/src/app/shell/ChatSidebar.tsx
+++ b/src/app/shell/ChatSidebar.tsx
@@ -25,6 +25,7 @@ import {
   Tag,
   Pencil,
   Download,
+  X,
 } from "lucide-react";
 import {
   useBulkExportChats,
@@ -819,12 +820,12 @@ export function ChatSidebar({
         <div className="absolute inset-x-0 bottom-0 h-px bg-[var(--border)]/30" />
         <h2 className="retro-glow-text truncate text-sm font-bold tracking-tight">✧ Chats</h2>
         <button
-          onClick={handleNewChatFromTab}
-          className="rounded-lg p-1.5 text-[var(--muted-foreground)] transition-all hover:bg-[var(--sidebar-accent)] hover:text-[var(--primary)] active:scale-90"
-          title={`New ${activeTab === "conversation" ? "Conversation" : activeTab === "game" ? "Game" : "Roleplay"}`}
-          aria-label={`New ${activeTab === "conversation" ? "Conversation" : activeTab === "game" ? "Game" : "Roleplay"}`}
+          onClick={() => setSidebarOpen(false)}
+          className="rounded-lg p-1.5 text-[var(--muted-foreground)] transition-all hover:bg-[var(--sidebar-accent)] hover:text-[var(--primary)] active:scale-90 md:hidden"
+          title="Back to chat"
+          aria-label="Back to chat"
         >
-          <Plus size="1rem" />
+          <X size="1rem" />
         </button>
       </div>
 
@@ -891,6 +892,65 @@ export function ChatSidebar({
               className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[var(--muted-foreground)]"
             />
           </div>
+
+          {creatingFolder ? (
+            <div className="flex items-center gap-1.5 rounded-lg bg-[var(--secondary)] px-2.5 py-2 ring-1 ring-[var(--primary)]/20">
+              <FolderPlus size="0.75rem" className="text-[var(--muted-foreground)]" />
+              <input
+                autoFocus
+                placeholder="Folder name..."
+                value={newFolderName}
+                onChange={(e) => setNewFolderName(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") handleCreateFolder();
+                  if (e.key === "Escape") {
+                    setCreatingFolder(false);
+                    setNewFolderName("");
+                  }
+                }}
+                onBlur={() => {
+                  if (newFolderName.trim()) handleCreateFolder();
+                  else {
+                    setCreatingFolder(false);
+                    setNewFolderName("");
+                  }
+                }}
+                className="min-w-0 flex-1 bg-transparent text-xs text-[var(--foreground)] outline-none placeholder:text-[var(--muted-foreground)]"
+              />
+            </div>
+          ) : (
+            <div className="grid grid-cols-2 gap-1.5">
+              <button
+                onClick={handleNewChatFromTab}
+                className="flex min-h-9 items-center justify-center gap-1.5 rounded-lg bg-[var(--primary)]/15 px-2.5 text-[0.72rem] font-semibold text-[var(--primary)] transition-all hover:bg-[var(--primary)]/25 active:scale-[0.98]"
+              >
+                <Plus size="0.8rem" />
+                New {activeTab === "conversation" ? "chat" : activeTab === "game" ? "game" : "RP"}
+              </button>
+              <button
+                onClick={() => setCreatingFolder(true)}
+                className="flex min-h-9 items-center justify-center gap-1.5 rounded-lg bg-[var(--secondary)] px-2.5 text-[0.72rem] font-semibold text-[var(--muted-foreground)] transition-all hover:bg-[var(--sidebar-accent)]/50 hover:text-[var(--foreground)] active:scale-[0.98]"
+              >
+                <FolderPlus size="0.8rem" />
+                Folder
+              </button>
+            </div>
+          )}
+
+          {displayChats.length > 0 && (
+            <button
+              onClick={() => (multiSelectMode ? exitMultiSelect() : setMultiSelectMode(true))}
+              className={cn(
+                "flex min-h-8 items-center justify-center gap-1.5 rounded-lg px-2.5 text-[0.6875rem] font-medium transition-all",
+                multiSelectMode
+                  ? "bg-[var(--primary)]/15 text-[var(--primary)]"
+                  : "bg-[var(--secondary)]/65 text-[var(--muted-foreground)] hover:bg-[var(--sidebar-accent)]/40 hover:text-[var(--foreground)]",
+              )}
+            >
+              <CheckSquare size="0.75rem" />
+              {multiSelectMode ? "Cancel selection" : "Select chats"}
+            </button>
+          )}
 
           {allTags.length > 0 && (
             <div className="flex max-w-full flex-wrap items-center gap-1">
@@ -1004,58 +1064,6 @@ export function ChatSidebar({
         )}
 
         <div className="stagger-children flex flex-col gap-0.5">
-          {/* New folder */}
-          {creatingFolder ? (
-            <div className="flex items-center gap-1.5 rounded-lg px-2.5 py-1.5">
-              <FolderPlus size="0.75rem" className="text-[var(--muted-foreground)]" />
-              <input
-                autoFocus
-                placeholder="Folder name..."
-                value={newFolderName}
-                onChange={(e) => setNewFolderName(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") handleCreateFolder();
-                  if (e.key === "Escape") {
-                    setCreatingFolder(false);
-                    setNewFolderName("");
-                  }
-                }}
-                onBlur={() => {
-                  if (newFolderName.trim()) handleCreateFolder();
-                  else {
-                    setCreatingFolder(false);
-                    setNewFolderName("");
-                  }
-                }}
-                className="flex-1 bg-transparent text-xs text-[var(--foreground)] outline-none placeholder:text-[var(--muted-foreground)]"
-              />
-            </div>
-          ) : (
-            <div className="flex items-center gap-1">
-              <button
-                onClick={() => setCreatingFolder(true)}
-                className="flex flex-1 items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-[0.6875rem] text-[var(--muted-foreground)] transition-all hover:bg-[var(--sidebar-accent)]/40 hover:text-[var(--foreground)]"
-              >
-                <FolderPlus size="0.75rem" />
-                New Folder
-              </button>
-              {displayChats.length > 0 && (
-                <button
-                  onClick={() => (multiSelectMode ? exitMultiSelect() : setMultiSelectMode(true))}
-                  className={cn(
-                    "flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-[0.6875rem] transition-all",
-                    multiSelectMode
-                      ? "bg-[var(--primary)]/15 text-[var(--primary)]"
-                      : "text-[var(--muted-foreground)] hover:bg-[var(--sidebar-accent)]/40 hover:text-[var(--foreground)]",
-                  )}
-                >
-                  <CheckSquare size="0.75rem" />
-                  {multiSelectMode ? "Cancel" : "Select"}
-                </button>
-              )}
-            </div>
-          )}
-
           {/* Folders (drag-to-reorder) */}
           {localFolderOrder.length > 0 && (
             <Reorder.Group

--- a/src/app/shell/ChatTitleControls.tsx
+++ b/src/app/shell/ChatTitleControls.tsx
@@ -1,4 +1,4 @@
-import { Home, PanelLeft, PanelLeftClose } from "lucide-react";
+import { PanelLeft, PanelLeftClose } from "lucide-react";
 import type { MouseEvent as ReactMouseEvent } from "react";
 import { cn } from "../../shared/lib/utils";
 import { useChatStore } from "../../shared/stores/chat.store";
@@ -14,6 +14,7 @@ export function ChatTitleControls({
   onGoHome,
   className,
   hideProfessorOnNarrow = false,
+  hideHome = false,
   showDivider = true,
 }: {
   professorMariOpen?: boolean;
@@ -21,6 +22,7 @@ export function ChatTitleControls({
   onGoHome?: () => void;
   className?: string;
   hideProfessorOnNarrow?: boolean;
+  hideHome?: boolean;
   showDivider?: boolean;
 }) {
   const setActiveChatId = useChatStore((s) => s.setActiveChatId);
@@ -63,17 +65,19 @@ export function ChatTitleControls({
           <span className="absolute -bottom-0.5 left-1/2 h-0.5 w-3 -translate-x-1/2 rounded-full bg-gradient-to-r from-teal-500 to-cyan-500" />
         )}
       </button>
-      <button
-        type="button"
-        onClick={goHome}
-        onMouseDown={stopChromeDrag}
-        onDoubleClick={stopChromeDrag}
-        className="mari-titlebar-action rounded-md p-1.5 text-[var(--muted-foreground)] transition-all duration-200 hover:text-[var(--primary)]"
-        title="Home"
-        aria-label="Home"
-      >
-        <Home size="0.875rem" />
-      </button>
+      {!hideHome && (
+        <button
+          type="button"
+          onClick={goHome}
+          onMouseDown={stopChromeDrag}
+          onDoubleClick={stopChromeDrag}
+          className="mari-titlebar-action rounded-md p-1.5 text-[var(--muted-foreground)] transition-all duration-200 hover:text-[var(--primary)]"
+          title="Home"
+          aria-label="Home"
+        >
+          <img src="/favicon.png" alt="" className="h-[0.95rem] w-[0.95rem] rounded-[0.2rem] object-cover" draggable={false} />
+        </button>
+      )}
       <button
         type="button"
         onClick={openProfessorMari}

--- a/src/app/shell/PanelNavButtons.tsx
+++ b/src/app/shell/PanelNavButtons.tsx
@@ -4,7 +4,7 @@ import { useAgentStore } from "../../shared/stores/agent.store";
 import { useUIStore } from "../../shared/stores/ui.store";
 import { cn } from "../../shared/lib/utils";
 
-const RIGHT_PANEL_BUTTONS = [
+export const RIGHT_PANEL_BUTTONS = [
   { panel: "bot-browser" as const, icon: Bot, label: "Browser", activeClass: "text-cyan-500", hoverClass: "hover:text-cyan-300", underlineClass: "from-cyan-500 to-blue-500" },
   { panel: "characters" as const, icon: Users, label: "Characters", activeClass: "text-rose-500", hoverClass: "hover:text-rose-300", underlineClass: "from-pink-500 to-rose-500" },
   { panel: "lorebooks" as const, icon: BookOpen, label: "Lorebooks", activeClass: "text-amber-500", hoverClass: "hover:text-amber-300", underlineClass: "from-amber-500 to-orange-500" },

--- a/src/app/shell/TopBar.tsx
+++ b/src/app/shell/TopBar.tsx
@@ -1,9 +1,12 @@
 // ──────────────────────────────────────────────
-// Layout: Top Bar (polished, with hover glow)
+// Layout: Mobile App Top Bar
 // ──────────────────────────────────────────────
-import { SpotifyMiniPlayer } from "../../features/shell/spotify/shell";
-import { ChatTitleControls } from "./ChatTitleControls";
-import { PanelNavButtons } from "./PanelNavButtons";
+import { Bot, ChevronDown, Menu, Sparkles, X } from "lucide-react";
+import { useEffect, useState } from "react";
+import { useChatStore } from "../../shared/stores/chat.store";
+import { useUIStore } from "../../shared/stores/ui.store";
+import { cn } from "../../shared/lib/utils";
+import { RIGHT_PANEL_BUTTONS } from "./PanelNavButtons";
 
 export function TopBar({
   professorMariOpen = false,
@@ -14,22 +17,179 @@ export function TopBar({
   onOpenProfessorMari?: () => void;
   onGoHome?: () => void;
 }) {
+  const [toolsOpen, setToolsOpen] = useState(false);
+  const activeChatId = useChatStore((s) => s.activeChatId);
+  const setActiveChatId = useChatStore((s) => s.setActiveChatId);
+  const sidebarOpen = useUIStore((s) => s.sidebarOpen);
+  const setSidebarOpen = useUIStore((s) => s.setSidebarOpen);
+  const rightPanel = useUIStore((s) => s.rightPanel);
+  const rightPanelOpen = useUIStore((s) => s.rightPanelOpen);
+  const openRightPanel = useUIStore((s) => s.openRightPanel);
+  const closeRightPanel = useUIStore((s) => s.closeRightPanel);
+  const setTrackerPanelOpen = useUIStore((s) => s.setTrackerPanelOpen);
+  const closeAllDetails = useUIStore((s) => s.closeAllDetails);
+  const hasOpenSurface = useUIStore((s) =>
+    Boolean(
+      s.characterDetailId ||
+        s.lorebookDetailId ||
+        s.presetDetailId ||
+        s.connectionDetailId ||
+        s.agentDetailId ||
+        s.toolDetailId ||
+        s.personaDetailId ||
+        s.regexDetailId ||
+        s.characterLibraryOpen ||
+        s.botBrowserOpen ||
+        s.gameAssetsBrowserOpen ||
+        s.rightPanelOpen,
+    ),
+  );
+
+  useEffect(() => {
+    if (!toolsOpen) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setToolsOpen(false);
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [toolsOpen]);
+
+  const openChats = () => {
+    closeRightPanel();
+    setTrackerPanelOpen(false);
+    setSidebarOpen(true);
+    setToolsOpen(false);
+  };
+
+  const goHome = () => {
+    setActiveChatId(null);
+    closeAllDetails();
+    closeRightPanel();
+    setSidebarOpen(false);
+    setTrackerPanelOpen(false);
+    setToolsOpen(false);
+    onGoHome?.();
+  };
+
+  const openProfessorMari = () => {
+    setActiveChatId(null);
+    closeAllDetails();
+    closeRightPanel();
+    setSidebarOpen(false);
+    setTrackerPanelOpen(false);
+    setToolsOpen(false);
+    onOpenProfessorMari?.();
+  };
+
+  const isHomeSurface = !professorMariOpen && !activeChatId && !hasOpenSurface;
+
   return (
     <header
       data-component="TopBar"
-      className="mari-topbar relative z-10 flex h-9 flex-shrink-0 items-center justify-between px-2 md:hidden"
+      className="mari-topbar relative z-30 flex h-[3.25rem] flex-shrink-0 items-center gap-2 px-2.5 pb-1 md:hidden"
     >
-      <div className="flex min-w-0 shrink-0 items-center gap-1.5">
-        <ChatTitleControls
-          professorMariOpen={professorMariOpen}
-          onOpenProfessorMari={onOpenProfessorMari}
-          onGoHome={onGoHome}
-          hideProfessorOnNarrow
-          showDivider={false}
+      <button
+        type="button"
+        onClick={openChats}
+        className={cn(
+          "mari-mobile-topbar-button shrink-0",
+          sidebarOpen && "mari-mobile-topbar-button-active text-[var(--primary)]",
+        )}
+        title="Open chats"
+        aria-label="Open chats"
+        aria-pressed={sidebarOpen}
+      >
+        <Menu size="1.05rem" aria-hidden />
+      </button>
+
+      <button
+        type="button"
+        onClick={goHome}
+        className="mari-mobile-topbar-title mari-mobile-topbar-home"
+        title="Home"
+        aria-label="Home"
+        aria-current={isHomeSurface ? "page" : undefined}
+      >
+        <span className="mari-mobile-home-mark" aria-hidden>
+          <img src="/favicon.png" alt="" draggable={false} />
+        </span>
+      </button>
+
+      <button
+        type="button"
+        onClick={openProfessorMari}
+        className={cn(
+          "mari-mobile-topbar-button shrink-0 max-[360px]:hidden",
+          professorMariOpen && "mari-mobile-topbar-button-active text-[var(--primary)]",
+        )}
+        title="Professor Mari"
+        aria-label="Professor Mari"
+        aria-pressed={professorMariOpen}
+      >
+        <img
+          src="/sprites/mari/Mari_profile.png"
+          alt=""
+          className="h-[1.15rem] w-[1.15rem] rounded-md object-cover"
+          draggable={false}
         />
-        <SpotifyMiniPlayer />
+      </button>
+
+      <div className="relative shrink-0">
+        <button
+          type="button"
+          onClick={() => setToolsOpen((open) => !open)}
+          className={cn("mari-mobile-topbar-tools", toolsOpen && "mari-mobile-topbar-button-active")}
+          title={toolsOpen ? "Close tools" : "Open tools"}
+          aria-label={toolsOpen ? "Close tools" : "Open tools"}
+          aria-expanded={toolsOpen}
+        >
+          {toolsOpen ? <X size="1rem" aria-hidden /> : <Sparkles size="1rem" aria-hidden />}
+          <span className="max-[340px]:hidden">Tools</span>
+          <ChevronDown size="0.75rem" aria-hidden className={cn("transition-transform", toolsOpen && "rotate-180")} />
+        </button>
+
+        {toolsOpen && (
+          <div className="mari-mobile-tools-menu" role="menu" aria-label="Tools and panels">
+            <button
+              type="button"
+              onClick={() => {
+                setSidebarOpen(false);
+                setTrackerPanelOpen(false);
+                openRightPanel("bot-browser");
+                setToolsOpen(false);
+              }}
+              className="mari-mobile-tools-item"
+              role="menuitem"
+            >
+              <Bot size="0.95rem" aria-hidden />
+              Browser
+            </button>
+            {RIGHT_PANEL_BUTTONS.filter(({ panel }) => panel !== "bot-browser").map(({ panel, icon: Icon, label }) => {
+              const isActive = rightPanelOpen && rightPanel === panel;
+              return (
+                <button
+                  key={panel}
+                  type="button"
+                  onClick={() => {
+                    setSidebarOpen(false);
+                    setTrackerPanelOpen(false);
+                    openRightPanel(panel);
+                    setToolsOpen(false);
+                  }}
+                  className={cn("mari-mobile-tools-item", isActive && "mari-mobile-tools-item-active")}
+                  role="menuitem"
+                  aria-current={isActive ? "page" : undefined}
+                >
+                  <Icon size="0.95rem" aria-hidden />
+                  <span className="truncate">{label}</span>
+                </button>
+              );
+            })}
+          </div>
+        )}
       </div>
-      <PanelNavButtons className="md:hidden" />
     </header>
   );
 }

--- a/src/app/shell/WindowTitleBar.tsx
+++ b/src/app/shell/WindowTitleBar.tsx
@@ -2,6 +2,8 @@ import { getCurrentWindow } from "@tauri-apps/api/window";
 import { Maximize2, Minus, Square, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState, type MouseEvent as ReactMouseEvent } from "react";
 import { cn } from "../../shared/lib/utils";
+import { useChatStore } from "../../shared/stores/chat.store";
+import { useUIStore } from "../../shared/stores/ui.store";
 import { ChatTitleControls } from "./ChatTitleControls";
 import { PanelNavButtons } from "./PanelNavButtons";
 
@@ -40,6 +42,25 @@ export function WindowTitleBar({
   const platform = useMemo(inferDesktopPlatform, []);
   const [isMaximized, setIsMaximized] = useState(false);
   const appWindow = useMemo(() => (isTauriRuntime() ? getCurrentWindow() : null), []);
+  const activeChatId = useChatStore((s) => s.activeChatId);
+  const setActiveChatId = useChatStore((s) => s.setActiveChatId);
+  const closeAllDetails = useUIStore((s) => s.closeAllDetails);
+  const hasOpenSurface = useUIStore((s) =>
+    Boolean(
+      s.characterDetailId ||
+        s.lorebookDetailId ||
+        s.presetDetailId ||
+        s.connectionDetailId ||
+        s.agentDetailId ||
+        s.toolDetailId ||
+        s.personaDetailId ||
+        s.regexDetailId ||
+        s.characterLibraryOpen ||
+        s.botBrowserOpen ||
+        s.gameAssetsBrowserOpen ||
+        s.rightPanelOpen,
+    ),
+  );
 
   const refreshMaximized = useCallback(() => {
     if (!appWindow) return;
@@ -91,6 +112,14 @@ export function WindowTitleBar({
   const toggleMaximizeFromDragRegion = useCallback(() => {
     runWindowAction("maximize");
   }, [runWindowAction]);
+
+  const goHome = useCallback(() => {
+    setActiveChatId(null);
+    closeAllDetails();
+    onGoHome?.();
+  }, [closeAllDetails, onGoHome, setActiveChatId]);
+
+  const isHomeSurface = !professorMariOpen && !activeChatId && !hasOpenSurface;
   const controlActions = platform === "darwin" ? (["close", "minimize", "maximize"] as const) : (["minimize", "maximize", "close"] as const);
   const controls = (
     <div
@@ -145,18 +174,36 @@ export function WindowTitleBar({
         professorMariOpen={professorMariOpen}
         onOpenProfessorMari={onOpenProfessorMari}
         onGoHome={onGoHome}
+        hideHome
       />
       <div
         className="mari-titlebar-content flex h-full min-w-0 flex-1 items-center"
       >
         <div
-          className="mari-title-drag-region flex h-full min-w-0 flex-1 items-center justify-start pl-2 pr-3"
+          className="mari-title-drag-region flex h-full min-w-0 flex-1 items-center justify-start pl-0.5 pr-3"
           onMouseDown={startWindowDrag}
           onDoubleClick={toggleMaximizeFromDragRegion}
         >
-          <div data-tauri-drag-region className="mari-title-brand mari-title-brand-compact min-w-0" aria-label="Marinara Engine">
-            <img data-tauri-drag-region className="mari-title-icon" src="/favicon.png" alt="" draggable={false} />
-          </div>
+          <button
+            type="button"
+            className={cn(
+              "mari-titlebar-action mari-title-home-button relative rounded-md p-1.5 transition-all duration-200",
+              isHomeSurface
+                ? "mari-titlebar-action-active text-[color-mix(in_srgb,var(--primary)_54%,var(--muted-foreground))]"
+                : "text-[var(--muted-foreground)] hover:text-[var(--primary)]",
+            )}
+            onClick={goHome}
+            onMouseDown={(event) => event.stopPropagation()}
+            onDoubleClick={(event) => event.stopPropagation()}
+            title="Home"
+            aria-label="Home"
+            aria-current={isHomeSurface ? "page" : undefined}
+          >
+            <img className="mari-title-icon" src="/favicon.png" alt="" draggable={false} />
+            {isHomeSurface && (
+              <span className="absolute -bottom-0.5 left-1/2 h-0.5 w-3 -translate-x-1/2 rounded-full bg-gradient-to-r from-teal-500 to-cyan-500" />
+            )}
+          </button>
         </div>
         <div
           className="mari-window-actions flex h-full shrink-0 items-center gap-2"

--- a/src/app/shell/WindowTitleBar.tsx
+++ b/src/app/shell/WindowTitleBar.tsx
@@ -154,14 +154,8 @@ export function WindowTitleBar({
           onMouseDown={startWindowDrag}
           onDoubleClick={toggleMaximizeFromDragRegion}
         >
-          <div data-tauri-drag-region className="mari-title-brand min-w-0">
-            <span className="mari-title-word mari-title-word-marinara">
-              Marinara
-            </span>
+          <div data-tauri-drag-region className="mari-title-brand mari-title-brand-compact min-w-0" aria-label="Marinara Engine">
             <img data-tauri-drag-region className="mari-title-icon" src="/favicon.png" alt="" draggable={false} />
-            <span className="mari-title-word mari-title-word-engine">
-              Engine
-            </span>
           </div>
         </div>
         <div

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -696,12 +696,14 @@ body {
   drop-shadow(0 0 0.28rem currentColor);
 }
 
-.mari-titlebar-action svg {
+.mari-titlebar-action svg,
+.mari-titlebar-action img {
   transform-origin: 50% 56%;
   transition: transform 220ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 
-.mari-titlebar-action:hover svg {
+.mari-titlebar-action:hover svg,
+.mari-titlebar-action:hover img {
   transform: translateY(-1px) rotate(-8deg) scale(1.12);
 }
 
@@ -709,8 +711,19 @@ body {
   filter: drop-shadow(0 0 0.12rem currentColor);
 }
 
-.mari-titlebar-action:active svg {
+.mari-titlebar-action:active svg,
+.mari-titlebar-action:active img {
   transform: translateY(0) rotate(-8deg) scale(0.98);
+}
+
+.mari-title-home-button {
+  -webkit-app-region: no-drag;
+  display: inline-flex;
+  width: 2.125rem;
+  height: 1.875rem;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
 }
 
 .mari-mobile-topbar-button,
@@ -1081,9 +1094,10 @@ body {
   color: color-mix(in srgb, var(--y2k-blue) 82%, var(--foreground));
 }
 
-.mari-title-brand-compact .mari-title-icon {
-  width: 1.25rem;
-  height: 1.25rem;
+.mari-title-brand-compact .mari-title-icon,
+.mari-title-home-button .mari-title-icon {
+  width: 1.125rem;
+  height: 1.125rem;
 }
 
 @media (max-width: 767px) {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -713,6 +713,184 @@ body {
   transform: translateY(0) rotate(-8deg) scale(0.98);
 }
 
+.mari-mobile-topbar-button,
+.mari-mobile-topbar-tools {
+  display: inline-flex;
+  min-width: 2.55rem;
+  height: 2.55rem;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  border: 1px solid color-mix(in srgb, var(--border) 38%, transparent);
+  border-radius: 0.95rem;
+  background: color-mix(in srgb, var(--card) 78%, var(--background));
+  color: var(--muted-foreground);
+  box-shadow: none;
+  transition:
+    background-color 160ms cubic-bezier(0.16, 1, 0.3, 1),
+    border-color 160ms cubic-bezier(0.16, 1, 0.3, 1),
+    color 160ms cubic-bezier(0.16, 1, 0.3, 1),
+    transform 180ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.mari-mobile-topbar-tools {
+  min-width: 4.95rem;
+  padding: 0 0.65rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
+
+.mari-mobile-topbar-button:hover,
+.mari-mobile-topbar-tools:hover,
+.mari-mobile-topbar-button-active {
+  border-color: color-mix(in srgb, var(--primary) 42%, transparent);
+  background: color-mix(in srgb, var(--primary) 15%, var(--card));
+  color: var(--primary);
+}
+
+.mari-mobile-topbar-button:active,
+.mari-mobile-topbar-tools:active {
+  transform: scale(0.97);
+}
+
+.mari-mobile-topbar-button:focus-visible,
+.mari-mobile-topbar-tools:focus-visible,
+.mari-mobile-tools-item:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--primary) 72%, transparent);
+  outline-offset: 2px;
+}
+
+.mari-mobile-topbar-button img {
+  width: 1.8rem;
+  height: 1.8rem;
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--primary) 22%, transparent);
+}
+
+.mari-mobile-topbar-button svg,
+.mari-mobile-topbar-tools svg,
+.mari-mobile-tools-item svg {
+  flex: 0 0 auto;
+}
+
+.mari-mobile-topbar-title {
+  display: inline-flex;
+  min-width: 0;
+  height: 2.55rem;
+  flex: 1 1 auto;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 0.55rem;
+  overflow: hidden;
+  border: 1px solid transparent;
+  border-radius: 0.95rem;
+  background: transparent;
+  padding: 0 0.45rem;
+  text-align: left;
+  box-shadow: none;
+  transition:
+    background-color 160ms cubic-bezier(0.16, 1, 0.3, 1),
+    border-color 160ms cubic-bezier(0.16, 1, 0.3, 1),
+    transform 180ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.mari-mobile-topbar-title:hover {
+  border-color: color-mix(in srgb, var(--border) 30%, transparent);
+  background: color-mix(in srgb, var(--card) 54%, transparent);
+}
+
+.mari-mobile-topbar-title:active {
+  transform: scale(0.985);
+}
+
+.mari-mobile-topbar-title:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--primary) 72%, transparent);
+  outline-offset: 2px;
+}
+
+.mari-mobile-topbar-home {
+  width: 2.55rem;
+  min-width: 2.55rem;
+  flex: 0 0 2.55rem;
+  margin-right: auto;
+  justify-content: center;
+  border-color: color-mix(in srgb, var(--border) 38%, transparent);
+  background: color-mix(in srgb, var(--card) 78%, var(--background));
+  padding: 0;
+}
+
+.mari-mobile-topbar-home:hover,
+.mari-mobile-topbar-home[aria-current="page"] {
+  border-color: color-mix(in srgb, var(--primary) 36%, transparent);
+  background: color-mix(in srgb, var(--primary) 13%, var(--card));
+}
+
+.mari-mobile-home-mark {
+  display: inline-flex;
+  width: 2rem;
+  height: 2rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: 0.45rem;
+}
+
+.mari-mobile-home-mark img {
+  width: 1.8rem;
+  height: 1.8rem;
+  border-radius: 0.25rem;
+  filter: drop-shadow(0 0 0.25rem color-mix(in srgb, var(--primary) 24%, transparent));
+}
+
+.mari-mobile-tools-menu {
+  position: absolute;
+  top: calc(100% + 1.05rem);
+  right: 0;
+  z-index: 70;
+  display: grid;
+  width: min(20rem, calc(100vw - 1rem));
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.45rem;
+  padding: 0.6rem;
+  border: 1px solid color-mix(in srgb, var(--border) 55%, transparent);
+  border-radius: 1.15rem;
+  background: color-mix(in srgb, var(--card) 96%, var(--background));
+  box-shadow:
+    0 1rem 2.5rem color-mix(in srgb, var(--background) 82%, transparent),
+    inset 0 1px color-mix(in srgb, var(--foreground) 9%, transparent);
+}
+
+.mari-mobile-tools-item {
+  display: inline-flex;
+  min-width: 0;
+  min-height: 2.6rem;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 0.55rem;
+  border: 1px solid color-mix(in srgb, var(--border) 34%, transparent);
+  border-radius: 0.85rem;
+  background: color-mix(in srgb, var(--secondary) 66%, transparent);
+  color: var(--foreground);
+  padding: 0 0.7rem;
+  font-size: 0.75rem;
+  font-weight: 650;
+  box-shadow: none;
+  transition:
+    background-color 160ms cubic-bezier(0.16, 1, 0.3, 1),
+    border-color 160ms cubic-bezier(0.16, 1, 0.3, 1),
+    transform 180ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.mari-mobile-tools-item:hover,
+.mari-mobile-tools-item-active {
+  border-color: color-mix(in srgb, var(--primary) 36%, transparent);
+  background: color-mix(in srgb, var(--primary) 14%, var(--secondary));
+  color: var(--primary);
+}
+
+.mari-mobile-tools-item:active {
+  transform: scale(0.98);
+}
+
 @media (max-width: 380px) {
   .mari-titlebar-action-mobile-optional {
     display: none !important;
@@ -901,6 +1079,11 @@ body {
 
 .mari-title-word-engine {
   color: color-mix(in srgb, var(--y2k-blue) 82%, var(--foreground));
+}
+
+.mari-title-brand-compact .mari-title-icon {
+  width: 1.25rem;
+  height: 1.25rem;
 }
 
 @media (max-width: 767px) {


### PR DESCRIPTION
## Summary

- Reworked the mobile top bar into a stable icon-based layout for chats, home, Professor Mari, and Tools.
- Added a clear mobile sidebar close button.
- Moved New Chat and New Folder actions under the sidebar filters so the chat list starts cleanly.
- Simplified desktop title branding to an icon.
- Made the mobile Tools dropdown a consistent grid.

## Verification

- `pnpm typecheck`
- `pnpm build`

## Notes

- `pnpm build` passes with existing Vite chunk-size and dynamic import warnings.
- `src-tauri/Cargo.toml` has an unrelated local modification and was not included in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mobile-optimized top navigation bar with quick-access buttons and tools dropdown menu.
  * Redesigned folder creation workflow with streamlined input and action buttons.

* **UI Improvements**
  * Updated sidebar with "back to chat" button for easier mobile navigation.
  * Refreshed multi-select toggle styling and controls layout.
  * Compact branding display in window title bar.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1237?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->