### PR TITLE
feat(magic-rewrite): V1 — AI-assisted text rewriting for editors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Fixed mobile Conversation chats where optional toolbar actions could squeeze the message textarea down until it appeared missing on narrow phone viewports.
 - Added a stale client artifact cleanup step for the obsolete tracker data sidebar folder so installs, updates, checks, and builds are not tripped up by leftover local files after the tracker panel refactor.
 - Fixed Docker builds so the stale client artifact cleanup script is available before dependency install/build scripts run.
 - Fixed streaming Roleplay messages in Glued Side Panel avatar mode so the avatar frame keeps the selected scale and is revealed by the growing message instead of rescaling while tokens arrive.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 - Added a Marinara-specific AI agent workflow overlay, adapted from the Chai Agent Workflow Pack, covering proof discipline, bugfix/feature lanes, issue filing, PR gates, and risky-work claim boundaries.
 - Added a None option for Roleplay message avatars so messages can render without avatar attachments.
+- Added default starting values for numeric Game HUD widgets, with setup/editor clamps that keep start values within the configured max.
+- Added a prompt override editor for registered prompt templates, including conversation selfie overrides, collapsible settings, and draft preservation.
+- Added shared drag-and-drop image upload dropzones for character avatars, chat gallery images, and background imports.
 - Added a manual Game Mode combat start control with confirmation so players can trigger encounter setup when a scene should enter combat.
 - Added a General quote-format preference for straight or curly dialogue quotes and apostrophes, with editor/input formatting support across chat, presets, characters, and personas.
 - Added conditional prompt macros, macro comment blocks, and Macro Reference guidance so presets and character/persona cards can keep author-only notes or branch prompt text by speaker/character.
@@ -29,6 +32,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 - Removed the Conversation, Roleplay, and Game mode shortcuts from the topbar because the sidebar already owns mode navigation.
 - Widened the Glued Side Panel roleplay avatar presentation so the portrait strip has more visual presence.
+- Improved sprite wand cleanup with halo edge cleanup, clean/paint brush tools, unified brush controls, and better multi-pointer handling.
+- Polished Tracker Panel visual controls, thought bubbles, persona/tracker card styling, responsive world-state temperature display, and color preview restore/legacy tint behavior.
 - Improved Game Mode combat setup so encounter generation can run in the background after scene analysis, with debug logging and a wait state only when the player reaches combat before setup is ready.
 - Removed unreliable met/unmet status tracking from Game Mode NPC prompt context.
 - Improved Roleplay group chat Individual mode prompting so only the currently responding character card is included, other characters' prior messages are treated as user-side context, and the turn-owner instruction can be toggled.
@@ -45,9 +50,14 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 ### Fixed
 
 - Fixed mobile Conversation chats where optional toolbar actions could squeeze the message textarea down until it appeared missing on narrow phone viewports.
+- Fixed tracker character-card lookup so active-chat card aliases from title/comment text resolve tracker rows before out-of-chat fallback cards, keeping group-chat tracker portraits and color settings attached to the intended character.
+- Fixed character tracker refreshes preserving user-uploaded NPC portraits and portrait framing across agent updates, including first snapshot writes.
+- Fixed the Roleplay HUD temperature chip so it respects the shared Tracker Panel Celsius/Fahrenheit display setting.
 - Added a stale client artifact cleanup step for the obsolete tracker data sidebar folder so installs, updates, checks, and builds are not tripped up by leftover local files after the tracker panel refactor.
 - Fixed Docker builds so the stale client artifact cleanup script is available before dependency install/build scripts run.
 - Fixed streaming Roleplay messages in Glued Side Panel avatar mode so the avatar frame keeps the selected scale and is revealed by the growing message instead of rescaling while tokens arrive.
+- Fixed Quest Board state merges so tracker updates no longer revert quest progress or keep completed empty-objective quests.
+- Fixed profile export/import fallback handling for large assets so profile exports can recover cleanly when embedded asset payloads are too large.
 - Fixed Windows installer updates for existing shallow release checkouts by fetching the resolved release commit before checkout.
 - Fixed mobile Game Mode character and party controls so sheet actions stay compact, long character names can remain accessible, and crowded party rosters collapse into a scrollable mobile party picker.
 - Fixed mobile Game Mode choice prompts so large choice sets stay readable and scroll inside the available play area instead of squishing buttons or pushing custom input off-screen.
@@ -82,6 +92,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 - Added explicit Illustrator try-again controls when image generation fails, including a toast action and a persistent Roleplay HUD retry button. ([#797](https://github.com/Pasta-Devs/Marinara-Engine/issues/797))
 - Added Local Model sidecar as a first-class embedding source, including an Embedding Connection option, lorebook vectorization support, and a stable `/api/sidecar/v1/embeddings` endpoint. ([#780](https://github.com/Pasta-Devs/Marinara-Engine/issues/780))
 - Added opt-in Turn Data Access settings for custom post-processing agents so they can receive current-turn pre-generation injections and parallel agent results without exposing that data to existing agents by default. ([#778](https://github.com/Pasta-Devs/Marinara-Engine/issues/778))
+- Added Memory Recall export/import for moving chat recall data between profiles or installs.
+- Added weighted random macro choices for SillyTavern-style random prompt variants.
 - Added a native Appearance background blur slider for Roleplay and Game mode backgrounds. ([#763](https://github.com/Pasta-Devs/Marinara-Engine/issues/763))
 - Added excluded-tag filtering for the character browser, including `-tag:"tag name"` search syntax and exclude toggles in the character tag picker. ([#702](https://github.com/Pasta-Devs/Marinara-Engine/issues/702))
 - Added a server-side autonomous conversation scheduler so enabled characters can generate restrained scheduled messages while the browser poller is absent, with client-presence checks to avoid duplicate client/server generations. ([#698](https://github.com/Pasta-Devs/Marinara-Engine/issues/698))
@@ -125,6 +137,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 - Fixed Game Mode asset generation prompt review, NPC portrait matching, sprite recovery, Professor-name avatar matching, and command-prompt regeneration replay.
 - Fixed Game Session Log flicker, deletion offsets, manual deletion persistence, and dice-roll dismissal when advancing dialogue.
 - Fixed Game Mode weather, storm ambience, sun overlay behavior, CYOA live updates, skill checks, inventory notifications, combat voice audio, mobile party access, tracker refreshes, and tracker edit persistence.
+- Fixed CJK Google font shard loading and scene-summary max-token overrides.
+- Fixed manual chat file deletion persistence and regenerate replay for command prompts.
 - Fixed Conversation disconnection aborts on Docker, markdown block preservation, hidden-message regeneration crashes, Up Arrow recall behavior, role editing, DM schedule inheritance, random connection schedule generation, and connected-chat placeholder branch names.
 - Fixed character avatar uploads preserving unsaved drafts, chat folder click targets, drag reorder behavior, text selection while dragging, folder storage atomicity, and Professor Mari continuation after tool/fetch work.
 - Fixed OpenAI ChatGPT request shape and SSE parsing, compressed provider JSON decoding (`gzip`, raw `gzip`, and Brotli), Gemini gzip decoding, provider identity handling, NovelAI V4 prompt/model handling, ComfyUI numeric workflow placeholders, Horde image endpoints, and Pygmalion avatar content-type fallback.
@@ -155,6 +169,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 - Per-connection max parallel agent job controls, allowing agent-heavy chats to split same-connection work across multiple LLM calls.
 - Editable Game Session History map JSON in the current-session spoiler section.
 - Markdown rendering and live preview for Game journal notes.
+- Tracker Data Sidebar for viewing and editing live tracker data from the side panel.
 - `/emote name="Character" expression="expression"` for listing and manually switching roleplay sprite expressions.
 - Duplicate action for individual prompt preset blocks.
 - Close controls for Game mode choice prompts and quick-time event windows.

--- a/packages/client/src/components/chat/ConversationInput.tsx
+++ b/packages/client/src/components/chat/ConversationInput.tsx
@@ -1569,7 +1569,7 @@ export function ConversationInput({
         onDragLeave={handleDragLeave}
         onDrop={handleDrop}
         className={cn(
-          "relative flex items-center gap-1 rounded-2xl border-2 bg-[var(--card)] px-2 py-1.5 transition-all duration-200 sm:gap-2 sm:px-4 sm:py-2.5 dark:bg-black/40",
+          "relative flex flex-wrap items-end gap-1 rounded-2xl border-2 bg-[var(--card)] px-2 py-1.5 transition-all duration-200 sm:flex-nowrap sm:items-center sm:gap-2 sm:px-4 sm:py-2.5 dark:bg-black/40",
           isDragging ? "border-blue-400/50 bg-blue-500/10 shadow-lg shadow-blue-500/10" : "border-[var(--border)]",
         )}
       >
@@ -1588,7 +1588,7 @@ export function ConversationInput({
         <button
           onClick={() => fileInputRef.current?.click()}
           className={cn(
-            "flex h-11 w-11 items-center justify-center rounded-xl transition-all active:scale-90 sm:h-8 sm:w-8",
+            "order-2 flex h-11 w-11 items-center justify-center rounded-xl transition-all active:scale-90 sm:order-none sm:h-8 sm:w-8",
             attachments.length
               ? "bg-foreground/10 text-foreground/75"
               : "text-foreground/40 hover:bg-foreground/10 hover:text-foreground/70",
@@ -1601,7 +1601,7 @@ export function ConversationInput({
         {/* Quick Switchers — desktop: inline, mobile: chevron */}
         <QuickConnectionSwitcher className="hidden sm:flex" />
         <QuickPersonaSwitcher className="hidden sm:flex" />
-        <div className="sm:hidden">
+        <div className="order-2 sm:hidden">
           <QuickSwitcherMobile />
         </div>
 
@@ -1624,11 +1624,11 @@ export function ConversationInput({
           onInput={handleInput}
           onKeyDown={handleKeyDown}
           onPaste={handlePaste}
-          className="max-h-[12.5rem] min-w-0 flex-1 resize-none bg-transparent py-0 text-[1rem] leading-normal text-[var(--foreground)] outline-none placeholder:text-foreground/30"
+          className="order-1 max-h-[12.5rem] min-w-0 basis-full flex-1 resize-none bg-transparent py-0 text-[1rem] leading-normal text-[var(--foreground)] outline-none placeholder:text-foreground/30 sm:order-none sm:basis-auto"
         />
 
         {/* Right actions */}
-        <div className="flex shrink-0 items-center gap-0.5">
+        <div className="order-2 ml-auto flex min-w-0 flex-1 flex-nowrap items-center justify-end gap-0.5 sm:order-none sm:flex-none sm:shrink-0">
           <div className="relative">
             <button
               ref={gifButtonRef}

--- a/packages/client/src/components/chat/RoleplayHUD.tsx
+++ b/packages/client/src/components/chat/RoleplayHUD.tsx
@@ -29,6 +29,12 @@ import { useAgentConfigs, useCustomAgentRuns, type AgentConfigRow } from "../../
 import { useChat } from "../../hooks/use-chats";
 import { discardPendingGameStatePatch, useGameStatePatcher } from "../../hooks/use-game-state-patcher";
 import { useUIStore } from "../../stores/ui.store";
+import {
+  getTemperatureColor,
+  getTemperatureGaugeDisplay,
+  getTemperatureKeywordHint,
+  parseTemperatureValue,
+} from "../../features/tracker-panel/lib/world-state-display";
 import type {
   GameState,
   PresentCharacter,
@@ -38,7 +44,7 @@ import type {
   CustomTrackerField,
   Message,
 } from "@marinara-engine/shared";
-import type { HudPosition } from "../../stores/ui.store";
+import type { HudPosition, TrackerTemperatureUnit } from "../../stores/ui.store";
 
 const ACTIONS_DROPDOWN_WIDTH_PX = 288;
 
@@ -142,6 +148,7 @@ export function RoleplayHUD({
   const trackerPanelEnabled = useUIStore((s) => s.trackerPanelEnabled);
   const trackerPanelOpen = useUIStore((s) => s.trackerPanelOpen);
   const trackerPanelHideHudWidgets = useUIStore((s) => s.trackerPanelHideHudWidgets);
+  const trackerTemperatureUnit = useUIStore((s) => s.trackerTemperatureUnit);
   const toggleTrackerPanel = useUIStore((s) => s.toggleTrackerPanel);
 
   const isTrackerBusy = isAgentProcessing || isStreaming || gameStateRefreshing;
@@ -269,6 +276,7 @@ export function RoleplayHUD({
               time={time ?? ""}
               weather={weather ?? ""}
               temperature={temperature ?? ""}
+              trackerTemperatureUnit={trackerTemperatureUnit}
               onSaveLocation={(v) => patchField("location", v)}
               onSaveDate={(v) => patchField("date", v)}
               onSaveTime={(v) => patchField("time", v)}
@@ -334,6 +342,7 @@ export function RoleplayHUD({
               time={time ?? ""}
               weather={weather ?? ""}
               temperature={temperature ?? ""}
+              trackerTemperatureUnit={trackerTemperatureUnit}
               onSaveLocation={(v) => patchField("location", v)}
               onSaveDate={(v) => patchField("date", v)}
               onSaveTime={(v) => patchField("time", v)}
@@ -1264,6 +1273,7 @@ function CombinedWorldWidget({
   time,
   weather,
   temperature,
+  trackerTemperatureUnit,
   onSaveLocation,
   onSaveDate,
   onSaveTime,
@@ -1278,6 +1288,7 @@ function CombinedWorldWidget({
   time: string;
   weather: string;
   temperature: string;
+  trackerTemperatureUnit: TrackerTemperatureUnit;
   onSaveLocation: (v: string) => void;
   onSaveDate: (v: string) => void;
   onSaveTime: (v: string) => void;
@@ -1291,18 +1302,10 @@ function CombinedWorldWidget({
   const buttonRef = useRef<HTMLButtonElement>(null);
   const weatherEmoji = weather ? getWeatherEmoji(weather) : "🌤️";
   const pinColor = getLocationPinColor(location);
-  const tempNumeric = temperature ? parseTemperature(temperature) : null;
+  const temperatureDisplay = getTemperatureGaugeDisplay(temperature, trackerTemperatureUnit);
+  const tempNumeric = temperature ? parseTemperatureValue(temperature) : null;
   const temp = tempNumeric ?? (temperature ? getTemperatureKeywordHint(temperature) : null);
-  const tempColor =
-    temp !== null
-      ? temp < 0
-        ? "text-blue-400"
-        : temp < 15
-          ? "text-sky-400"
-          : temp < 30
-            ? "text-amber-400"
-            : "text-red-400"
-      : "text-rose-400/50";
+  const tempColor = getTemperatureColor(temperature);
 
   // Dynamic calendar: show day number
   const dateParts = date ? parseDateLabel(date) : { day: null, month: null };
@@ -1313,10 +1316,9 @@ function CombinedWorldWidget({
   const hourAngle = hour >= 0 ? (hour % 12) * 30 + minute * 0.5 : 0;
   const minuteAngle = minute * 6;
 
-  // Thermometer fill fraction (clamp -20..50°C → 0..1)
-  const tempFill = temp !== null ? Math.max(0, Math.min(1, (temp + 20) / 70)) : 0.3;
-  const tempFillColor =
-    temp !== null ? (temp < 0 ? "#60a5fa" : temp < 15 ? "#38bdf8" : temp < 30 ? "#fbbf24" : "#f87171") : "#fb7185";
+  const tempFill =
+    temperatureDisplay.percent == null ? 0.3 : Math.max(0, Math.min(1, temperatureDisplay.percent / 100));
+  const tempFillColor = temperatureDisplay.color;
 
   return (
     <div className="relative">
@@ -1462,7 +1464,7 @@ function CombinedWorldWidget({
         </svg>
         {tempNumeric !== null && (
           <span className={cn("text-[0.5rem] md:text-[0.5625rem] font-bold leading-none shrink-0", tempColor)}>
-            {tempNumeric}°
+            {temperatureDisplay.label}
           </span>
         )}
       </button>
@@ -1565,26 +1567,6 @@ function getWeatherEmoji(weather: string): string {
   if (w.includes("hot") || w.includes("swelter")) return "🥵";
   if (w.includes("cold") || w.includes("freez")) return "🥶";
   return "🌤️";
-}
-
-function parseTemperature(temp: string): number | null {
-  const m = temp.match(/-?\d+(\.\d+)?/);
-  if (!m) return null;
-  const num = parseFloat(m[0]!);
-  if (/°?\s*f/i.test(temp)) return Math.round((num - 32) * (5 / 9));
-  return Math.round(num);
-}
-
-/** Map descriptive temperature words to a numeric-equivalent hint (°C). */
-function getTemperatureKeywordHint(text: string): number | null {
-  const t = text.toLowerCase();
-  if (/\b(freez|frigid|arctic|glacial|sub-?zero|blizzard)/.test(t)) return -10;
-  if (/\b(cold|chill|frost|wintry|icy|bitter|nipp)/.test(t)) return 2;
-  if (/\b(cool|brisk|crisp|refresh)/.test(t)) return 12;
-  if (/\b(mild|pleasant|comfort|temperate|fair)/.test(t)) return 20;
-  if (/\b(warm|balmy|toasty|muggy|humid|stuffy|sultry)/.test(t)) return 28;
-  if (/\b(hot|swelter|blaz|scorch|burn|heat|boil|sear|bak)/.test(t)) return 38;
-  return null;
 }
 
 /** Categorise location text into a colour for the map-pin icon. */

--- a/packages/client/src/components/lorebooks/LorebookFormFields.tsx
+++ b/packages/client/src/components/lorebooks/LorebookFormFields.tsx
@@ -4,10 +4,11 @@
 // and LorebookEntryRow (the per-entry inline drawer).
 // Extracted from LorebookEditor.tsx so styling stays consistent.
 // ──────────────────────────────────────────────
-import { useEffect, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
-import { FileText, Maximize2, ToggleLeft, ToggleRight, X } from "lucide-react";
+import { useCallback, useEffect, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
+import { FileText, Maximize2, Sparkles, ToggleLeft, ToggleRight, X } from "lucide-react";
 import { cn } from "../../lib/utils";
 import { HelpTooltip } from "../ui/HelpTooltip";
+import { MagicRewritePanel } from "../ui/MagicRewritePanel";
 
 export function FieldGroup({
   label,
@@ -233,6 +234,8 @@ export function ExpandedContentModal({
   placeholder?: string;
 }) {
   const [local, setLocal] = useState(value);
+  const [magicRewriteMode, setMagicRewriteMode] = useState(false);
+  const [magicRewriteResult, setMagicRewriteResult] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   useEffect(() => {
@@ -241,7 +244,7 @@ export function ExpandedContentModal({
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
+      if (e.key === "Escape" && !magicRewriteMode) {
         onChange(local);
         onCommit?.();
         onClose();
@@ -249,7 +252,7 @@ export function ExpandedContentModal({
     };
     document.addEventListener("keydown", handler);
     return () => document.removeEventListener("keydown", handler);
-  }, [onClose, onChange, onCommit, local]);
+  }, [onClose, onChange, onCommit, local, magicRewriteMode]);
 
   const handleClose = () => {
     onChange(local);
@@ -257,36 +260,87 @@ export function ExpandedContentModal({
     onClose();
   };
 
+  const handleMagicRewriteBack = () => {
+    setMagicRewriteMode(false);
+    setMagicRewriteResult("");
+  };
+
+  const handleMagicRewriteApply = () => {
+    if (!magicRewriteResult) return;
+    setLocal(magicRewriteResult);
+    setMagicRewriteMode(false);
+    setMagicRewriteResult("");
+    window.setTimeout(() => textareaRef.current?.focus(), 100);
+  };
+
+  const handleMagicRewriteResultChange = useCallback((next: string) => {
+    setMagicRewriteResult(next);
+  }, []);
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-6 max-md:pt-[max(1.5rem,env(safe-area-inset-top))]">
       <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={handleClose} />
-      <div className="relative flex h-[80vh] w-full max-w-3xl flex-col rounded-2xl border border-[var(--border)] bg-[var(--card)] shadow-2xl shadow-black/50">
+      <div className="relative flex h-[80vh] w-full max-w-5xl flex-col rounded-2xl border border-[var(--border)] bg-[var(--card)] shadow-2xl shadow-black/50">
         <div className="flex items-center justify-between border-b border-[var(--border)] px-4 py-3">
-          <h3 className="text-sm font-semibold">{title}</h3>
-          <button onClick={handleClose} className="rounded-lg p-1.5 hover:bg-[var(--accent)]">
-            <X size="1rem" />
-          </button>
+          <h3 className="text-sm font-semibold">{magicRewriteMode ? "✨ Magic Rewrite" : title}</h3>
+          <div className="flex items-center gap-2">
+            <button onClick={handleClose} className="rounded-lg p-1.5 hover:bg-[var(--accent)]">
+              <X size="1rem" />
+            </button>
+          </div>
         </div>
         <div className="flex-1 overflow-hidden p-4">
-          <textarea
-            ref={textareaRef}
-            value={local}
-            onChange={(e) => setLocal(e.target.value)}
-            onKeyDown={(e) => handleTextareaTabKeyDown(e, local, setLocal)}
-            className="h-full w-full resize-none rounded-lg bg-[var(--secondary)] p-4 text-sm text-[var(--foreground)] ring-1 ring-[var(--border)] placeholder:text-[var(--muted-foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
-            placeholder={placeholder}
-          />
+          {magicRewriteMode ? (
+            <MagicRewritePanel value={local} onResultChange={handleMagicRewriteResultChange} />
+          ) : (
+            <textarea
+              ref={textareaRef}
+              value={local}
+              onChange={(e) => setLocal(e.target.value)}
+              onKeyDown={(e) => handleTextareaTabKeyDown(e, local, setLocal)}
+              className="h-full w-full resize-none rounded-lg bg-[var(--secondary)] p-4 text-sm text-[var(--foreground)] ring-1 ring-[var(--border)] placeholder:text-[var(--muted-foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+              placeholder={placeholder}
+            />
+          )}
         </div>
         <div className="flex items-center justify-between border-t border-[var(--border)] px-4 py-2.5">
           <p className="text-[0.625rem] text-[var(--muted-foreground)]">
-            Changes auto-save on close. Press Escape to close.
+            {magicRewriteMode ? "Back returns to the editor without applying. Apply moves the preview into the editor." : "Changes auto-save on close. Press Escape to close."}
           </p>
-          <button
-            onClick={handleClose}
-            className="rounded-xl bg-gradient-to-r from-amber-400 to-orange-500 px-4 py-1.5 text-xs font-medium text-white shadow-md hover:shadow-lg active:scale-[0.98]"
-          >
-            Done
-          </button>
+          {magicRewriteMode ? (
+            <div className="flex items-center gap-2">
+              <button
+                onClick={handleMagicRewriteBack}
+                className="rounded-xl border border-[var(--border)] px-4 py-1.5 text-xs font-medium text-[var(--foreground)] hover:bg-[var(--accent)] active:scale-[0.98]"
+              >
+                Back
+              </button>
+              <button
+                onClick={handleMagicRewriteApply}
+                disabled={!magicRewriteResult}
+                className="rounded-xl bg-gradient-to-r from-violet-500 to-fuchsia-500 px-4 py-1.5 text-xs font-medium text-white shadow-md hover:shadow-lg active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                Apply
+              </button>
+            </div>
+          ) : (
+            <div className="flex items-center gap-2">
+              <button
+                onClick={() => setMagicRewriteMode(true)}
+                className="inline-flex items-center gap-1.5 rounded-lg border border-violet-400/30 bg-violet-500/10 px-3 py-1.5 text-xs font-medium text-violet-200 hover:bg-violet-500/20"
+                title="Open Magic Rewrite"
+              >
+                <Sparkles size="0.875rem" />
+                Rewrite
+              </button>
+              <button
+                onClick={handleClose}
+                className="rounded-xl bg-gradient-to-r from-amber-400 to-orange-500 px-4 py-1.5 text-xs font-medium text-white shadow-md hover:shadow-lg active:scale-[0.98]"
+              >
+                Done
+              </button>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -631,7 +631,7 @@ function TrackerPanelAppearanceDrawer({
           <div className="mt-2 flex min-h-8 items-center justify-between gap-2">
             <span className="inline-flex items-center gap-1 text-[0.6875rem] font-medium">
               Temperature unit
-              <HelpTooltip text="Only changes the Tracker Panel display. It does not rewrite the saved world-state temperature or affect the older HUD widgets." />
+              <HelpTooltip text="Changes Tracker Panel and roleplay HUD temperature displays without rewriting the saved world-state temperature." />
             </span>
             <button
               type="button"

--- a/packages/client/src/components/panels/settings/TrackerCardColorSettings.tsx
+++ b/packages/client/src/components/panels/settings/TrackerCardColorSettings.tsx
@@ -23,6 +23,8 @@ import {
 } from "../../../lib/tracker-card-colors";
 import { useTrackerGameState } from "../../../features/tracker-panel/hooks/use-tracker-game-state";
 import {
+  addAliasLookups,
+  addExactNameLookups,
   normalizeLookupText,
   normalizeMaybeJsonStringArray,
 } from "../../../features/tracker-panel/lib/tracker-metadata";
@@ -234,14 +236,21 @@ export function TrackerCardColorSettings() {
       : [];
     const charactersById = new Map(characterRows.map((character) => [character.id, character]));
     const idByLookupText = new Map<string, string>();
+    const activeChatCharacterIds = normalizeMaybeJsonStringArray(
+      (activeChat as { characterIds?: unknown } | null | undefined)?.characterIds,
+    );
+    const activeChatCharacterIdSet = new Set(activeChatCharacterIds);
+    const displayRows = characterRows.map((character) => ({
+      character,
+      display: parseCharacterDisplayData(character),
+    }));
+    const chatDisplayRows = displayRows.filter(({ character }) => activeChatCharacterIdSet.has(character.id));
+    const fallbackDisplayRows = displayRows.filter(({ character }) => !activeChatCharacterIdSet.has(character.id));
 
-    for (const character of characterRows) {
-      const display = parseCharacterDisplayData(character);
-      const nameKey = normalizeLookupText(display.name);
-      const commentKey = normalizeLookupText(display.comment);
-      if (nameKey && !idByLookupText.has(nameKey)) idByLookupText.set(nameKey, character.id);
-      if (commentKey && !idByLookupText.has(commentKey)) idByLookupText.set(commentKey, character.id);
-    }
+    addExactNameLookups(chatDisplayRows, idByLookupText);
+    addAliasLookups(chatDisplayRows, idByLookupText);
+    addExactNameLookups(fallbackDisplayRows, idByLookupText);
+    addAliasLookups(fallbackDisplayRows, idByLookupText);
 
     const nextTargets: TrackerCardColorTarget[] = [];
     const chatPersonaId =
@@ -278,9 +287,6 @@ export function TrackerCardColorSettings() {
     }
 
     const presentCharacterIds = new Set<string>();
-    const activeChatCharacterIds = normalizeMaybeJsonStringArray(
-      (activeChat as { characterIds?: unknown } | null | undefined)?.characterIds,
-    );
     for (const id of activeChatCharacterIds) {
       if (charactersById.has(id)) presentCharacterIds.add(id);
     }

--- a/packages/client/src/components/ui/ExpandedTextarea.tsx
+++ b/packages/client/src/components/ui/ExpandedTextarea.tsx
@@ -1,10 +1,11 @@
 // ──────────────────────────────────────────────
 // Expanded Textarea — Fullscreen editing overlay
 // ──────────────────────────────────────────────
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { motion, AnimatePresence } from "framer-motion";
-import { Minimize2 } from "lucide-react";
+import { Minimize2, Sparkles } from "lucide-react";
+import { MagicRewritePanel } from "./MagicRewritePanel";
 
 interface ExpandedTextareaProps {
   open: boolean;
@@ -17,22 +18,57 @@ interface ExpandedTextareaProps {
 
 export function ExpandedTextarea({ open, onClose, title, value, onChange, placeholder }: ExpandedTextareaProps) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const [local, setLocal] = useState(value);
+  const [magicRewriteMode, setMagicRewriteMode] = useState(false);
+  const [magicRewriteResult, setMagicRewriteResult] = useState("");
+
+  // Sync parent value into local when prop changes; reset rewrite state on close
+  useEffect(() => {
+    if (!open) {
+      setMagicRewriteMode(false);
+      setMagicRewriteResult("");
+    }
+    setLocal(value);
+  }, [value, open]);
 
   useEffect(() => {
     if (!open) return;
     const handler = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
+      if (e.key === "Escape" && !magicRewriteMode) onClose();
     };
     document.addEventListener("keydown", handler);
     return () => document.removeEventListener("keydown", handler);
-  }, [open, onClose]);
+  }, [open, onClose, magicRewriteMode]);
 
   // Focus textarea when opened
   useEffect(() => {
-    if (open) {
+    if (open && !magicRewriteMode) {
       requestAnimationFrame(() => textareaRef.current?.focus());
     }
-  }, [open]);
+  }, [open, magicRewriteMode]);
+
+  const handleClose = () => {
+    onChange(local);
+    onClose();
+  };
+
+  const handleMagicRewriteResultChange = useCallback((next: string) => {
+    setMagicRewriteResult(next);
+  }, []);
+
+  const handleMagicRewriteApply = () => {
+    if (!magicRewriteResult) return;
+    setLocal(magicRewriteResult);
+    setMagicRewriteMode(false);
+    setMagicRewriteResult("");
+    onChange(magicRewriteResult);
+    requestAnimationFrame(() => textareaRef.current?.focus());
+  };
+
+  const handleMagicRewriteBack = () => {
+    setMagicRewriteMode(false);
+    setMagicRewriteResult("");
+  };
 
   return createPortal(
     <AnimatePresence>
@@ -46,11 +82,38 @@ export function ExpandedTextarea({ open, onClose, title, value, onChange, placeh
         >
           {/* Header */}
           <div className="flex shrink-0 items-center justify-between border-b border-[var(--border)] px-5 py-3">
-            <h2 className="text-sm font-semibold">{title}</h2>
+            <h2 className="text-sm font-semibold">{magicRewriteMode ? "✨ Magic Rewrite" : title}</h2>
             <div className="flex items-center gap-2">
-              <span className="text-[0.625rem] text-[var(--muted-foreground)]">{value.length} characters</span>
+              {!magicRewriteMode && (
+                <button
+                  onClick={() => setMagicRewriteMode(true)}
+                  className="flex items-center gap-1.5 rounded-lg border border-violet-400/30 bg-violet-500/10 px-2.5 py-1.5 text-xs font-medium text-violet-200 hover:bg-violet-500/20"
+                  title="Open Magic Rewrite"
+                >
+                  <Sparkles size="0.875rem" />
+                  Rewrite
+                </button>
+              )}
+              {magicRewriteMode && (
+                <button
+                  onClick={handleMagicRewriteBack}
+                  className="flex items-center gap-1.5 rounded-lg border border-[var(--border)] px-2.5 py-1.5 text-xs font-medium text-[var(--foreground)] hover:bg-[var(--accent)]"
+                >
+                  Back
+                </button>
+              )}
+              {magicRewriteMode && (
+                <button
+                  onClick={handleMagicRewriteApply}
+                  disabled={!magicRewriteResult}
+                  className="rounded-xl bg-gradient-to-r from-violet-500 to-fuchsia-500 px-3 py-1.5 text-xs font-medium text-white disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  Apply
+                </button>
+              )}
+              <span className="text-[0.625rem] text-[var(--muted-foreground)]">{local.length} characters</span>
               <button
-                onClick={onClose}
+                onClick={handleClose}
                 className="flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
               >
                 <Minimize2 size="0.875rem" />
@@ -59,15 +122,19 @@ export function ExpandedTextarea({ open, onClose, title, value, onChange, placeh
             </div>
           </div>
 
-          {/* Textarea */}
+          {/* Content */}
           <div className="flex-1 overflow-hidden p-4 md:p-6">
-            <textarea
-              ref={textareaRef}
-              value={value}
-              onChange={(e) => onChange(e.target.value)}
-              placeholder={placeholder}
-              className="h-full w-full resize-none rounded-xl border border-[var(--border)] bg-[var(--secondary)] p-5 text-sm leading-relaxed outline-none transition-colors placeholder:text-[var(--muted-foreground)]/40 focus:border-[var(--primary)]/40 focus:ring-1 focus:ring-[var(--primary)]/20"
-            />
+            {magicRewriteMode ? (
+              <MagicRewritePanel value={local} onResultChange={handleMagicRewriteResultChange} />
+            ) : (
+              <textarea
+                ref={textareaRef}
+                value={local}
+                onChange={(e) => setLocal(e.target.value)}
+                placeholder={placeholder}
+                className="h-full w-full resize-none rounded-xl border border-[var(--border)] bg-[var(--secondary)] p-5 text-sm leading-relaxed outline-none transition-colors placeholder:text-[var(--muted-foreground)]/40 focus:border-[var(--primary)]/40 focus:ring-1 focus:ring-[var(--primary)]/20"
+              />
+            )}
           </div>
         </motion.div>
       )}

--- a/packages/client/src/components/ui/MagicRewritePanel.tsx
+++ b/packages/client/src/components/ui/MagicRewritePanel.tsx
@@ -1,0 +1,148 @@
+// ──────────────────────────────────────────────
+// Magic Rewrite Panel
+//
+// Instruction + generate + before/after diff view.
+// Context selectors and chat-history inclusion are
+// intentionally omitted for V1 — follow-up PRs will
+// add richer context controls once the basic workflow
+// has landed.
+// ──────────────────────────────────────────────
+import { useEffect, useMemo, useState } from "react";
+import { Sparkles, Loader2 } from "lucide-react";
+import { HelpTooltip } from "./HelpTooltip";
+import { api } from "../../lib/api-client";
+
+const PROMPT_KEY = "magic-rewrite-prompt";
+
+type RewriteResponse = { text: string };
+type DiffPart = { text: string; changed: boolean };
+type DiffResult =
+  | { skipped: true; before: string; after: string }
+  | { skipped: false; before: DiffPart[]; after: DiffPart[] };
+
+function diffWords(before: string, after: string): DiffResult {
+  const beforeWords = before.match(/\S+|\s+/g) ?? [];
+  const afterWords = after.match(/\S+|\s+/g) ?? [];
+  if (beforeWords.length + afterWords.length > 3000) {
+    return { before, after, skipped: true };
+  }
+
+  const dp = Array.from({ length: beforeWords.length + 1 }, () => new Uint16Array(afterWords.length + 1));
+  for (let i = 1; i <= beforeWords.length; i++) {
+    for (let j = 1; j <= afterWords.length; j++) {
+      dp[i][j] = beforeWords[i - 1] === afterWords[j - 1] ? dp[i - 1][j - 1] + 1 : Math.max(dp[i - 1][j], dp[i][j - 1]);
+    }
+  }
+
+  const deleted = new Uint8Array(beforeWords.length);
+  const added = new Uint8Array(afterWords.length);
+  let i = beforeWords.length;
+  let j = afterWords.length;
+  while (i > 0 || j > 0) {
+    if (i > 0 && j > 0 && beforeWords[i - 1] === afterWords[j - 1]) {
+      i--;
+      j--;
+    } else if (j > 0 && (i === 0 || dp[i][j - 1] >= dp[i - 1][j])) {
+      added[--j] = 1;
+    } else {
+      deleted[--i] = 1;
+    }
+  }
+
+  return {
+    skipped: false,
+    before: beforeWords.map((word, index) => ({ text: word, changed: deleted[index] === 1 })),
+    after: afterWords.map((word, index) => ({ text: word, changed: added[index] === 1 })),
+  };
+}
+
+export function MagicRewritePanel({
+  value,
+  onResultChange,
+}: {
+  value: string;
+  onResultChange: (value: string) => void;
+}) {
+  const [instruction, setInstruction] = useState(() => {
+    try { return window.localStorage.getItem(PROMPT_KEY) ?? ""; } catch { return ""; }
+  });
+  const [result, setResult] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => { try { window.localStorage.setItem(PROMPT_KEY, instruction); } catch { /* noop */ } }, 300);
+    return () => window.clearTimeout(timer);
+  }, [instruction]);
+
+  const diff = useMemo(() => (result ? diffWords(value, result) : null), [value, result]);
+
+  useEffect(() => {
+    onResultChange(result);
+  }, [onResultChange, result]);
+
+  async function generate() {
+    setLoading(true);
+    setError("");
+    try {
+      const response = await api.post<RewriteResponse>("/magic-rewrite/generate", {
+        text: value,
+        instruction,
+      });
+      setResult(response.text ?? "");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Magic Rewrite failed");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="flex h-full flex-col gap-4 overflow-hidden">
+      <div className="grid gap-4 lg:grid-cols-[minmax(0,3fr)_minmax(12rem,1fr)]">
+        <div className="flex min-w-0 flex-col">
+          <div className="mb-1.5 text-[0.65rem] font-semibold uppercase tracking-wide text-[var(--muted-foreground)]">Rewrite instructions{" "}<HelpTooltip text="Uses your default agent connection." /></div>
+          <textarea
+            value={instruction}
+            onChange={(event) => setInstruction(event.target.value)}
+            placeholder='e.g. "Make this more vivid and dramatic..."'
+            className="min-h-0 flex-1 resize-none rounded-xl bg-[var(--secondary)] p-3 text-sm ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-violet-500/50"
+          />
+        </div>
+
+        <div className="flex min-h-0 flex-col">
+          {error && <p className="mb-3 text-xs text-red-300">{error}</p>}
+          <div className="mt-auto">
+            <button
+              onClick={generate}
+              disabled={loading}
+              className="inline-flex w-full items-center justify-center gap-2 rounded-xl border border-violet-400/40 bg-violet-500/10 px-4 py-2 text-sm font-medium text-violet-200 transition hover:bg-violet-500/20 disabled:cursor-wait disabled:opacity-60"
+            >
+              {loading ? <Loader2 size="1rem" className="animate-spin" /> : <Sparkles size="1rem" />}
+              {loading ? "Rewriting…" : "Generate Rewrite"}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid min-h-0 flex-1 gap-4 lg:grid-cols-2">
+        <div className="min-h-0 overflow-auto rounded-xl bg-[var(--secondary)] p-3 text-sm ring-1 ring-[var(--border)]">
+          <div className="mb-2 text-[0.65rem] font-semibold uppercase tracking-wide text-[var(--muted-foreground)]">Before</div>
+          <div className="whitespace-pre-wrap break-words font-sans">
+            {diff && !diff.skipped && Array.isArray(diff.before)
+              ? diff.before.map((part, index) => <span key={index} className={part.changed ? "bg-red-500/20 text-red-200 line-through" : undefined}>{part.text}</span>)
+              : value}
+          </div>
+        </div>
+        <div className="min-h-0 overflow-auto rounded-xl bg-[var(--secondary)] p-3 text-sm ring-1 ring-[var(--border)]">
+          <div className="mb-2 text-[0.65rem] font-semibold uppercase tracking-wide text-[var(--muted-foreground)]">After</div>
+          <div className="whitespace-pre-wrap break-words font-sans">
+            {diff && !diff.skipped && Array.isArray(diff.after)
+              ? diff.after.map((part, index) => <span key={index} className={part.changed ? "bg-emerald-500/20 text-emerald-200" : undefined}>{part.text}</span>)
+              : result || "Generated rewrite will appear here."}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/client/src/features/tracker-panel/hooks/use-tracker-sprite-lookup.ts
+++ b/packages/client/src/features/tracker-panel/hooks/use-tracker-sprite-lookup.ts
@@ -4,7 +4,7 @@ import { useCharacters } from "../../../hooks/use-characters";
 import { parseCharacterDisplayData } from "../../../lib/character-display";
 import type { TrackerSpriteLookup } from "../tracker-panel.types";
 import { isSpriteLookupCharacterId } from "../lib/sprite-expressions";
-import { normalizeLookupText } from "../lib/tracker-metadata";
+import { addAliasLookups, addExactNameLookups, normalizeLookupText } from "../lib/tracker-metadata";
 import { getCharacterProfileColors } from "../lib/tracker-profile-style";
 
 interface UseTrackerSpriteLookupOptions {
@@ -29,16 +29,21 @@ export function useTrackerSpriteLookup({ enabled, chatCharacterIds }: UseTracker
     const idByName = new Map<string, string>();
     const pictureById: Record<string, string> = {};
     const profileColorsById: TrackerSpriteLookup["profileColorsById"] = {};
+    const displayRows = orderedRows.map((character) => ({
+      character,
+      display: parseCharacterDisplayData(character),
+    }));
+    const chatDisplayRows = displayRows.filter(({ character }) => chatIdSet.has(character.id));
+    const fallbackDisplayRows = displayRows.filter(({ character }) => !chatIdSet.has(character.id));
     for (const character of orderedRows) {
       if (character.avatarPath) pictureById[character.id] = character.avatarPath;
       const profileColors = getCharacterProfileColors(character.data);
       if (profileColors) profileColorsById[character.id] = profileColors;
-      const display = parseCharacterDisplayData(character);
-      const nameKey = normalizeLookupText(display.name);
-      if (nameKey && !idByName.has(nameKey)) idByName.set(nameKey, character.id);
-      const commentKey = normalizeLookupText(display.comment);
-      if (commentKey && !idByName.has(commentKey)) idByName.set(commentKey, character.id);
     }
+    addExactNameLookups(chatDisplayRows, idByName);
+    addAliasLookups(chatDisplayRows, idByName);
+    addExactNameLookups(fallbackDisplayRows, idByName);
+    addAliasLookups(fallbackDisplayRows, idByName);
     return { knownIds, idByName, pictureById, profileColorsById };
   }, [charactersData, chatCharacterIds]);
 

--- a/packages/client/src/features/tracker-panel/lib/tracker-metadata.ts
+++ b/packages/client/src/features/tracker-panel/lib/tracker-metadata.ts
@@ -1,3 +1,10 @@
+import { getCharacterLookupAliases, type CharacterDisplayInfo } from "../../../lib/character-display";
+
+export interface CharacterLookupDisplayRow {
+  character: { id: string };
+  display: CharacterDisplayInfo;
+}
+
 export function parseMetadataRecord(raw: unknown): Record<string, unknown> {
   if (!raw) return {};
   if (typeof raw === "string") {
@@ -50,4 +57,28 @@ export function normalizeMaybeJsonStringArray(value: unknown): string[] {
 
 export function normalizeLookupText(value: string | null | undefined) {
   return (value ?? "").trim().toLowerCase();
+}
+
+export function addExactNameLookups(
+  candidates: readonly CharacterLookupDisplayRow[],
+  idByLookupText: Map<string, string>,
+) {
+  for (const { character, display } of candidates) {
+    const nameKey = normalizeLookupText(display.name);
+    if (nameKey && !idByLookupText.has(nameKey)) idByLookupText.set(nameKey, character.id);
+  }
+}
+
+export function addAliasLookups(
+  candidates: readonly CharacterLookupDisplayRow[],
+  idByLookupText: Map<string, string>,
+) {
+  for (const { character, display } of candidates) {
+    const nameKey = normalizeLookupText(display.name);
+    for (const alias of getCharacterLookupAliases(display)) {
+      const aliasKey = normalizeLookupText(alias);
+      if (aliasKey === nameKey) continue;
+      if (aliasKey && !idByLookupText.has(aliasKey)) idByLookupText.set(aliasKey, character.id);
+    }
+  }
 }

--- a/packages/client/src/lib/character-display.ts
+++ b/packages/client/src/lib/character-display.ts
@@ -3,9 +3,49 @@ export interface CharacterDisplayInfo {
   comment?: string | null;
 }
 
+const LOOKUP_ALIAS_SEPARATOR = /\s+(?:-|\/|\||:|\u2013|\u2014)\s+/;
+const LOOKUP_ALIAS_PARENS = /\(([^)]{1,96})\)|\[([^\]]{1,96})\]/g;
+const LOOKUP_ALIAS_EDGE_PUNCTUATION = /^[\s"'([{]+|[\s"')\]}.,:;]+$/g;
+
+function addLookupAlias(aliases: string[], seen: Set<string>, value: string | null | undefined) {
+  const alias = (value ?? "").replace(/\s+/g, " ").replace(LOOKUP_ALIAS_EDGE_PUNCTUATION, "").trim();
+  if (!alias || alias.length > 96) return;
+  const key = alias.toLowerCase();
+  if (seen.has(key)) return;
+  seen.add(key);
+  aliases.push(alias);
+}
+
+function addLeadingLookupAlias(aliases: string[], seen: Set<string>, value: string | null | undefined) {
+  const [leadingAlias] = (value ?? "").split(LOOKUP_ALIAS_SEPARATOR);
+  addLookupAlias(aliases, seen, leadingAlias);
+}
+
 export function getCharacterTitle(character: CharacterDisplayInfo | null | undefined): string | null {
   const title = typeof character?.comment === "string" ? character.comment.trim() : "";
   return title || null;
+}
+
+export function getCharacterLookupAliases(character: CharacterDisplayInfo | null | undefined): string[] {
+  const aliases: string[] = [];
+  const seen = new Set<string>();
+
+  addLookupAlias(aliases, seen, character?.name);
+
+  const title = getCharacterTitle(character);
+  if (!title) return aliases;
+
+  addLookupAlias(aliases, seen, title);
+
+  for (const match of title.matchAll(LOOKUP_ALIAS_PARENS)) {
+    addLookupAlias(aliases, seen, match[1] ?? match[2]);
+  }
+
+  const withoutParenthetical = title.replace(LOOKUP_ALIAS_PARENS, " ");
+  addLookupAlias(aliases, seen, withoutParenthetical);
+  addLeadingLookupAlias(aliases, seen, withoutParenthetical);
+
+  return aliases;
 }
 
 export function parseCharacterDisplayData(raw: { data: unknown; comment?: string | null }): CharacterDisplayInfo {

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -8891,10 +8891,14 @@ export async function generateRoutes(app: FastifyInstance) {
                 const ctData = result.data as Record<string, unknown>;
                 const chars = (ctData.presentCharacters as any[]) ?? [];
                 const snapBeforeUpdate = await gameStateStore.getByMessage(messageId, targetSwipeIndex);
-                const oldChars: any[] = snapBeforeUpdate?.presentCharacters
-                  ? typeof snapBeforeUpdate.presentCharacters === "string"
-                    ? JSON.parse(snapBeforeUpdate.presentCharacters)
-                    : snapBeforeUpdate.presentCharacters
+                const previousCharacterSnapshot =
+                  snapBeforeUpdate ??
+                  baseGameStateSnapshot ??
+                  (allowLatestGameStateFallback ? await gameStateStore.getLatest(input.chatId) : null);
+                const oldChars: any[] = previousCharacterSnapshot?.presentCharacters
+                  ? typeof previousCharacterSnapshot.presentCharacters === "string"
+                    ? JSON.parse(previousCharacterSnapshot.presentCharacters)
+                    : previousCharacterSnapshot.presentCharacters
                   : [];
                 preserveTrackerCharacterUiFields(chars, oldChars);
 

--- a/packages/server/src/routes/generate/generate-route-utils.ts
+++ b/packages/server/src/routes/generate/generate-route-utils.ts
@@ -565,14 +565,31 @@ export function wrapFields(
   return parts;
 }
 
+function trackerCharacterIdKey(character: Record<string, unknown>) {
+  return typeof character.characterId === "string" ? character.characterId.trim().toLowerCase() : "";
+}
+
+function trackerCharacterNameKey(character: Record<string, unknown>) {
+  return typeof character.name === "string" ? character.name.trim().toLowerCase() : "";
+}
+
 function trackerCharacterKey(character: Record<string, unknown>) {
-  const id = typeof character.characterId === "string" ? character.characterId.trim().toLowerCase() : "";
-  const name = typeof character.name === "string" ? character.name.trim().toLowerCase() : "";
-  return id || name || null;
+  return trackerCharacterIdKey(character) || trackerCharacterNameKey(character) || null;
+}
+
+function isNpcTrackerAvatarPath(value: unknown): value is string {
+  return typeof value === "string" && value.trim().startsWith("/api/avatars/npc/");
 }
 
 export function isManualTrackerCharacterId(value: unknown): boolean {
   return typeof value === "string" && value.trim().startsWith("manual-");
+}
+
+function canUseManualTrackerNameFallback(character: Record<string, unknown>) {
+  const id = trackerCharacterIdKey(character);
+  if (!id || isManualTrackerCharacterId(id)) return true;
+  const name = trackerCharacterNameKey(character);
+  return !!name && id === name;
 }
 
 export function preserveTrackerCharacterUiFields(
@@ -580,17 +597,36 @@ export function preserveTrackerCharacterUiFields(
   previousCharacters: Array<Record<string, unknown>>,
 ): void {
   const previousByKey = new Map<string, Record<string, unknown>>();
+  const previousManualByName = new Map<string, Record<string, unknown>>();
+  const previousNameCounts = new Map<string, number>();
   for (const character of previousCharacters) {
     const key = trackerCharacterKey(character);
     if (key) previousByKey.set(key, character);
+    const name = trackerCharacterNameKey(character);
+    if (name) previousNameCounts.set(name, (previousNameCounts.get(name) ?? 0) + 1);
+    if (name && isManualTrackerCharacterId(character.characterId)) {
+      previousManualByName.set(name, character);
+    }
   }
 
   for (const character of nextCharacters) {
     const key = trackerCharacterKey(character);
-    const previous = key ? previousByKey.get(key) : null;
+    const name = trackerCharacterNameKey(character);
+    const previous =
+      (key ? previousByKey.get(key) : null) ??
+      (name && previousNameCounts.get(name) === 1 && canUseManualTrackerNameFallback(character)
+        ? previousManualByName.get(name)
+        : null);
     const previousPortraitFocusX = previous?.portraitFocusX;
     const previousPortraitFocusY = previous?.portraitFocusY;
     const previousPortraitZoom = previous?.portraitZoom;
+    const previousAvatarPath = previous?.avatarPath;
+    if (
+      (typeof character.avatarPath !== "string" || !character.avatarPath.trim()) &&
+      isNpcTrackerAvatarPath(previousAvatarPath)
+    ) {
+      character.avatarPath = previousAvatarPath.trim();
+    }
     if (
       (typeof character.portraitFocusX !== "number" || !Number.isFinite(character.portraitFocusX)) &&
       typeof previousPortraitFocusX === "number" &&

--- a/packages/server/src/routes/index.ts
+++ b/packages/server/src/routes/index.ts
@@ -50,6 +50,7 @@ import { sidecarRoutes } from "./sidecar.routes.js";
 import { ttsRoutes } from "./tts.routes.js";
 import { promptOverridesRoutes } from "./prompt-overrides.routes.js";
 import { csrfDiagnosticsRoutes } from "./csrf-diagnostics.routes.js";
+import { magicRewriteRoutes } from "./magic-rewrite.routes.js";
 
 export async function registerRoutes(app: FastifyInstance) {
   await app.register(chatsRoutes, { prefix: "/api/chats" });
@@ -99,6 +100,7 @@ export async function registerRoutes(app: FastifyInstance) {
   await app.register(ttsRoutes, { prefix: "/api/tts" });
   await app.register(promptOverridesRoutes, { prefix: "/api/prompt-overrides" });
   await app.register(csrfDiagnosticsRoutes, { prefix: "/api/csrf" });
+  await app.register(magicRewriteRoutes, { prefix: "/api/magic-rewrite" });
   if (process.env.MARINARA_LITE !== "true" && process.env.MARINARA_LITE !== "1") {
     await app.register(sidecarRoutes, { prefix: "/api/sidecar" });
   }

--- a/packages/server/src/routes/magic-rewrite.routes.ts
+++ b/packages/server/src/routes/magic-rewrite.routes.ts
@@ -1,0 +1,101 @@
+// ──────────────────────────────────────────────
+// Routes: Magic Rewrite
+//
+// Generates AI-assisted rewrites of editor text
+// using the user's instruction. Falls back through
+// the existing default chat/agent connections.
+// ──────────────────────────────────────────────
+import type { FastifyInstance } from "fastify";
+import { z } from "zod";
+import { PROVIDERS } from "@marinara-engine/shared";
+import { createConnectionsStorage } from "../services/storage/connections.storage.js";
+import { createLLMProvider } from "../services/llm/provider-registry.js";
+import type { ChatMessage } from "../services/llm/base-provider.js";
+import { logger } from "../lib/logger.js";
+
+const magicRewriteSchema = z.object({
+  text: z.string().default(""),
+  instruction: z.string().default(""),
+});
+
+const REWRITE_SYSTEM_PROMPT = `You are a rewriting assistant for roleplay, fiction, and worldbuilding content.
+Rewrite or generate the requested text according to the user's instructions.
+Return ONLY the rewritten text — no explanations, no markdown fences, no preamble.`;
+
+function resolveBaseUrl(conn: { provider: string; baseUrl: string | null }): string {
+  if (conn.baseUrl) return conn.baseUrl;
+  if (conn.provider === "claude_subscription") return "claude-agent-sdk://local";
+  if (conn.provider === "openai_chatgpt") return "openai-chatgpt://codex-auth";
+  const providerDef = PROVIDERS[conn.provider as keyof typeof PROVIDERS];
+  return providerDef?.defaultBaseUrl ?? "";
+}
+
+export async function magicRewriteRoutes(app: FastifyInstance) {
+  const connections = createConnectionsStorage(app.db);
+
+  app.post("/generate", async (req, reply) => {
+    const parsed = magicRewriteSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return reply.status(400).send({ error: "Invalid request", details: parsed.error.issues });
+    }
+    const input = parsed.data;
+
+    // Resolve connection: default chat → default agent
+    const defaultChat = await connections.getDefault();
+    const conn = defaultChat
+      ? await connections.getWithKey(defaultChat.id)
+      : await connections.getDefaultForAgents();
+
+    if (!conn) {
+      return reply.status(400).send({ error: "No default agent connection configured" });
+    }
+
+    if (conn.provider === "image_generation") {
+      return reply.status(400).send({ error: "Default connection is an image generation provider" });
+    }
+
+    const baseUrl = resolveBaseUrl(conn);
+    if (!baseUrl) {
+      return reply.status(400).send({ error: "No base URL configured for the default connection" });
+    }
+
+    const hasSourceText = input.text.trim().length > 0;
+    const instruction = input.instruction.trim() || (hasSourceText ? "Improve this text while preserving its meaning." : "Generate suitable content.");
+
+    const messages: ChatMessage[] = [
+      { role: "system", content: REWRITE_SYSTEM_PROMPT },
+      {
+        role: "user",
+        content: hasSourceText
+          ? `Instruction:\n${instruction}\n\n---\n\nText to rewrite:\n${input.text}`
+          : `Instruction:\n${instruction}\n\n---\n\nNo source text was provided; generate new content from the instruction.`,
+      },
+    ];
+
+    try {
+      const provider = createLLMProvider(
+        conn.provider,
+        baseUrl,
+        conn.apiKey,
+        conn.maxContext,
+        conn.openrouterProvider,
+        conn.maxTokensOverride,
+        conn.claudeFastMode === "true",
+      );
+
+      const result = await provider.chatComplete(messages, {
+        model: conn.model,
+        temperature: 0.7,
+        maxTokens: 4000,
+        stream: false,
+        enableCaching: conn.enableCaching === "true",
+        cachingAtDepth: conn.cachingAtDepth,
+      });
+
+      return { text: result.content?.trim() ?? "", finishReason: result.finishReason, usage: result.usage ?? null };
+    } catch (error) {
+      logger.error(error, "Magic Rewrite generation failed");
+      return reply.status(500).send({ error: "Magic Rewrite generation failed" });
+    }
+  });
+}


### PR DESCRIPTION
<!-- Target branch: `staging`. The default base in this UI is `main` (release branch). -->
<!-- Change the base to `staging` before submitting unless this is a maintainer-approved mainline change. -->
<!-- See CONTRIBUTING.md § Branches. -->

## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #1183

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

Writing and maintaining long-form text entries — character descriptions, persona definitions, lorebook entries — is tedious. Other RP platforms offer AI-assisted rewriting with natural language instructions ("add more detail about their childhood," "convert to XML format," "make this more token-efficient"). Currently Marinara has no built-in mechanism for this. A third-party extension exists as a proof of concept but requires users to manually enter API keys. This PR ships the feature natively, reusing Marinara's existing connection infrastructure.

## What changed

<!-- List the key changes in this PR -->

- **`packages/server/src/routes/magic-rewrite.routes.ts`** (new): `POST /api/magic-rewrite/generate` — accepts `text` and `instruction`, resolves an LLM connection through the existing default → default agent fallback chain, returns rewritten text. No new DB columns, no migrations.
- **`packages/client/src/components/ui/MagicRewritePanel.tsx`** (new): Instruction textarea, generate button, word-level LCS diff view (green additions, red deletions). Falls back to plain text for inputs over 3 000 words. Includes `HelpTooltip` noting agent connection usage.
- **`packages/client/src/components/ui/ExpandedTextarea.tsx`** (modified): Rewrite button in fullscreen editor header, Apply/Back controls. Escape key suppressed during rewrite mode.
- **`packages/client/src/components/lorebooks/LorebookFormFields.tsx`** (modified): Same rewrite integration in lorebook expanded content modal. Modal widened to `max-w-5xl`.
- **`packages/server/src/routes/index.ts`** (modified): Registered magic-rewrite routes under `/api/magic-rewrite`.

### Intentionally omitted (follow-up PRs)

Per maintainer feedback on #1184, V1 is scoped to the core rewrite flow:
- Rewrite-specific default connection selection (`defaultForRewrite` flag)
- DB migration / schema changes
- Connection editor toggle UI
- Character card / lorebook context injection
- Chat history context selection

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

-

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

<img width="2101" height="1331" alt="Screenshot 2026-05-25 193644" src="https://github.com/user-attachments/assets/395567c1-8651-47c7-b6f3-19274d5c0f4d" />
