### PR TITLE
Fix snapshot personaStats startup migration

### DIFF
--- a/src-tauri/src/commands/storage/shared.rs
+++ b/src-tauri/src/commands/storage/shared.rs
@@ -177,7 +177,8 @@ pub(crate) fn normalize_typed_json_fields(collection: &str, object: &mut Map<Str
         }
         "game-state-snapshots" => {
             normalize_json_array_fields(object, &["presentCharacters", "recentEvents"])?;
-            normalize_nullable_json_object_fields(object, &["playerStats", "personaStats", "metadata"])?;
+            normalize_nullable_json_object_fields(object, &["playerStats", "metadata"])?;
+            normalize_nullable_json_array_fields(object, &["personaStats"])?;
         }
         "game-checkpoints" => {
             normalize_nullable_json_object_fields(object, &["snapshot", "gameState", "metadata"])?;
@@ -220,6 +221,23 @@ fn normalize_json_array_fields(object: &mut Map<String, Value>, fields: &[&str])
     Ok(())
 }
 
+fn normalize_nullable_json_array_fields(
+    object: &mut Map<String, Value>,
+    fields: &[&str],
+) -> AppResult<()> {
+    for field in fields {
+        let Some(value) = object.get(*field) else {
+            continue;
+        };
+        if value.is_null() {
+            continue;
+        }
+        let normalized = normalize_json_field(value, Value::is_array, "array or null", field)?;
+        object.insert((*field).to_string(), normalized);
+    }
+    Ok(())
+}
+
 fn normalize_json_object_fields(object: &mut Map<String, Value>, fields: &[&str]) -> AppResult<()> {
     for field in fields {
         let Some(value) = object.get(*field) else { continue };
@@ -254,7 +272,7 @@ fn normalize_json_field(
         if raw.trim().is_empty() {
             return Ok(match expected {
                 "array" => json!([]),
-                "object or null" => Value::Null,
+                "array or null" | "object or null" => Value::Null,
                 _ => json!({}),
             });
         }
@@ -473,6 +491,51 @@ mod tests {
                 .expect_err("invalid character data should fail");
             assert_eq!(error.code, "invalid_input");
         }
+    }
+
+    #[test]
+    fn game_state_snapshot_normalizes_persona_stats_as_nullable_array() {
+        let mut row = json!({
+            "presentCharacters": "[{\"name\":\"Mari\"}]",
+            "recentEvents": "[\"arrived\"]",
+            "playerStats": "{\"status\":\"ready\"}",
+            "personaStats": "[{\"name\":\"Energy\",\"value\":5,\"max\":10}]",
+            "metadata": "{\"source\":\"qa\"}"
+        });
+        let object = row.as_object_mut().expect("row should be an object");
+
+        normalize_typed_json_fields("game-state-snapshots", object)
+            .expect("snapshot row should normalize");
+
+        assert!(object["presentCharacters"].is_array());
+        assert!(object["recentEvents"].is_array());
+        assert!(object["playerStats"].is_object());
+        assert!(object["personaStats"].is_array());
+        assert!(object["metadata"].is_object());
+
+        let mut null_row = json!({ "personaStats": null });
+        let null_object = null_row.as_object_mut().expect("row should be an object");
+        normalize_typed_json_fields("game-state-snapshots", null_object)
+            .expect("null personaStats should normalize");
+        assert!(null_object["personaStats"].is_null());
+
+        let mut empty_row = json!({ "personaStats": "  " });
+        let empty_object = empty_row.as_object_mut().expect("row should be an object");
+        normalize_typed_json_fields("game-state-snapshots", empty_object)
+            .expect("empty personaStats should normalize");
+        assert!(empty_object["personaStats"].is_null());
+    }
+
+    #[test]
+    fn game_state_snapshot_rejects_malformed_persona_stats_string() {
+        let mut row = json!({ "personaStats": "{\"not\":\"an array\"}" });
+        let object = row.as_object_mut().expect("row should be an object");
+
+        let error = normalize_typed_json_fields("game-state-snapshots", object)
+            .expect_err("object-shaped personaStats should fail");
+
+        assert_eq!(error.code, "invalid_input");
+        assert_eq!(error.message, "personaStats must be a JSON array or null");
     }
 
     #[test]

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -1,7 +1,7 @@
 use marinara_assets::AssetService;
 use marinara_core::{AppError, AppResult};
 use marinara_storage::FileStorage;
-use serde_json::{json, Value};
+use serde_json::{json, Map, Value};
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
@@ -196,6 +196,9 @@ fn migrate_collection_json_fields(storage: &FileStorage, collection: &str) -> Ap
                     }
                 }
             } else {
+                if collection == "game-state-snapshots" {
+                    repair_snapshot_persona_stats_for_startup(object);
+                }
                 normalize_typed_json_fields(collection, object)?;
             }
         }
@@ -206,4 +209,126 @@ fn migrate_collection_json_fields(storage: &FileStorage, collection: &str) -> Ap
         storage.replace_all(collection, normalized_rows)?;
     }
     Ok(())
+}
+
+fn repair_snapshot_persona_stats_for_startup(object: &mut Map<String, Value>) {
+    let Some(value) = object.get("personaStats") else {
+        return;
+    };
+    if value.is_null() || value.is_array() {
+        return;
+    }
+
+    let (next, repaired_invalid) = match value.as_str() {
+        Some(raw) if raw.trim().is_empty() => (Value::Null, false),
+        Some(raw) => match serde_json::from_str::<Value>(raw) {
+            Ok(parsed) if parsed.is_array() => (parsed, false),
+            Ok(parsed) if parsed.is_null() => (Value::Null, false),
+            Ok(_) | Err(_) => (Value::Null, true),
+        },
+        None => (Value::Null, true),
+    };
+
+    if repaired_invalid {
+        let row_id = object
+            .get("id")
+            .and_then(Value::as_str)
+            .unwrap_or("<unknown>");
+        log::trace!(
+            "repairing game-state-snapshots row id={row_id} personaStats to null because it is not a JSON array or null"
+        );
+    }
+
+    object.insert("personaStats".to_string(), next);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    struct TempRoot(PathBuf);
+
+    impl Drop for TempRoot {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn temp_root(test_name: &str) -> TempRoot {
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock should be after epoch")
+            .as_nanos();
+        TempRoot(std::env::temp_dir().join(format!("marinara-state-{test_name}-{suffix}")))
+    }
+
+    #[test]
+    fn app_state_startup_accepts_snapshot_persona_stats_arrays() {
+        let root = temp_root("snapshot-persona-stats");
+        let storage = FileStorage::new(root.0.join("data")).expect("storage should initialize");
+        storage
+            .create(
+                "game-state-snapshots",
+                json!({
+                    "kind": "tracker",
+                    "chatId": "chat-1",
+                    "messageId": "message-1",
+                    "presentCharacters": [],
+                    "recentEvents": [],
+                    "playerStats": null,
+                    "personaStats": [{ "name": "Energy", "value": 5, "max": 10 }],
+                    "metadata": null
+                }),
+            )
+            .expect("snapshot should be inserted");
+
+        let state = AppState::from_data_dir(&root.0, Vec::new()).expect("state should initialize");
+        let rows = state
+            .storage
+            .list("game-state-snapshots")
+            .expect("snapshots should list");
+
+        assert_eq!(rows.len(), 1);
+        assert!(rows[0]["personaStats"].is_array());
+    }
+
+    #[test]
+    fn app_state_startup_repairs_malformed_snapshot_persona_stats_to_null() {
+        let root = temp_root("snapshot-persona-stats-repair");
+        let storage = FileStorage::new(root.0.join("data")).expect("storage should initialize");
+        for (id, persona_stats) in [
+            ("bad-string", json!("{\"not\":\"an array\"}")),
+            ("bad-object", json!({ "not": "an array" })),
+        ] {
+            storage
+                .create(
+                    "game-state-snapshots",
+                    json!({
+                        "id": id,
+                        "kind": "tracker",
+                        "chatId": "chat-1",
+                        "messageId": "message-1",
+                        "presentCharacters": [],
+                        "recentEvents": [],
+                        "playerStats": null,
+                        "personaStats": persona_stats,
+                        "metadata": null
+                    }),
+                )
+                .expect("snapshot should be inserted");
+        }
+
+        let state = AppState::from_data_dir(&root.0, Vec::new()).expect("state should initialize");
+        let rows = state
+            .storage
+            .list("game-state-snapshots")
+            .expect("snapshots should list");
+
+        assert_eq!(rows.len(), 2);
+        for row in rows {
+            assert!(row["personaStats"].is_null());
+        }
+    }
 }


### PR DESCRIPTION
## Linked issue

Closes #1239

## Why this change

- Existing refactor save data can contain `game-state-snapshots.personaStats` as an array, matching tracker snapshot readers/writers.
- Startup storage migration was treating snapshot `personaStats` as object/null, so valid saves could fail app initialization with `invalid_input`.
- A malformed old snapshot row should not brick startup when the frontend already treats non-array snapshot `personaStats` as `null`.

## What changed

- Normalize `game-state-snapshots.personaStats` as a nullable JSON array while keeping `playerStats` and `metadata` as nullable objects.
- Add startup-only repair for malformed snapshot `personaStats`, coercing bad non-array values to `null` before strict storage normalization runs.
- Add Rust coverage for valid array/null/empty snapshot values, strict API rejection of malformed snapshot values, and startup repair of malformed saved rows.

## Refactor impact

Primary owner:

Rust storage startup migration and storage shape normalization.

Impact areas reviewed:

- Tauri `AppState` startup storage migration
- Shared Rust storage normalization contracts
- Tracker snapshot storage writer/reader shape
- Roleplay/Game world-state consumers that expect snapshot `personaStats` as array/null

Boundary notes:

- Rust storage-only change; no React, Zustand, Tauri JS API, feature internals, or engine imports added.
- Strict create/update validation stays in the shared storage normalizer; startup repair is limited to persisted old `game-state-snapshots` rows.

Pressure points touched:

- `src-tauri/src/state.rs` startup migration
- `src-tauri/src/commands/storage/shared.rs` typed JSON normalization

## Validation

- [x] `pnpm check` passes locally
- [x] `pnpm typecheck` passes locally
- [x] `pnpm build` passes locally
- [x] `pnpm check:architecture` passes locally
- [x] `pnpm check:docs` passes locally
- [x] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [x] Rust clippy/tests were run for Rust behavior changes
- [x] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [x] Remote runtime smoke checked when relevant

### Manual verification notes

- `cargo test --manifest-path src-tauri\Cargo.toml persona_stats` passed.
- `cargo check --manifest-path src-tauri\Cargo.toml` passed.
- `git diff --check origin/refactor...HEAD` passed.
- `rustfmt --edition 2021 --check src-tauri/src/state.rs` passed.
- Tauri desktop was launched with local test save data; the app opened and loaded existing roleplay/tracker data. QA process was closed afterward.
- Known existing gap: `cargo fmt --manifest-path src-tauri\Cargo.toml --check` still fails repo-wide on unrelated pre-existing Rust formatting drift, so this PR avoids a broad formatting-only sweep.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs changes needed: this is a storage migration compatibility fix with no user-facing settings or documented workflow changes.

## UI evidence

No UI screenshots added. The relevant proof is startup/data migration behavior plus Rust storage tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced game state snapshot data handling with improved validation for player statistics and metadata. Malformed data values are now properly converted to null instead of potentially causing errors.

* **Tests**
  * Added tests for game state snapshot data normalization and repair scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1240?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->