### PR TITLE
Fix character import drag-and-drop handling [Issue #1161]

### DIFF
--- a/src/engine/agents-runtime/debug.test.ts
+++ b/src/engine/agents-runtime/debug.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AgentContext } from "../contracts/types/agent";
+import { createAgentRuntimeDebug } from "./debug";
+
+const baseContext: AgentContext = {
+  chatId: "chat-1",
+  chatMode: "roleplay",
+  recentMessages: [],
+  mainResponse: null,
+  gameState: null,
+  characters: [],
+  persona: null,
+  memory: {},
+  activatedLorebookEntries: [],
+  writableLorebookIds: null,
+  chatSummary: null,
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("createAgentRuntimeDebug", () => {
+  it("does not emit console or structured debug entries unless debug mode is enabled", () => {
+    const sink = vi.fn();
+    const consoleDebug = vi.spyOn(console, "debug").mockImplementation(() => undefined);
+    const logger = createAgentRuntimeDebug({ ...baseContext, debugMode: false, debugSink: sink });
+
+    logger.debug("hidden");
+    logger.emit({ level: "debug", phase: "pre_generation", message: "hidden" });
+
+    expect(logger.enabled).toBe(false);
+    expect(logger.isLevelEnabled("debug")).toBe(false);
+    expect(consoleDebug).not.toHaveBeenCalled();
+    expect(sink).not.toHaveBeenCalled();
+  });
+
+  it("emits console and structured debug entries when debug mode is enabled", () => {
+    const sink = vi.fn();
+    const consoleDebug = vi.spyOn(console, "debug").mockImplementation(() => undefined);
+    const logger = createAgentRuntimeDebug({ ...baseContext, debugMode: true, debugSink: sink });
+
+    logger.debug("visible");
+    logger.emit({ level: "debug", phase: "pre_generation", message: "visible" });
+
+    expect(logger.enabled).toBe(true);
+    expect(logger.isLevelEnabled("debug")).toBe(true);
+    expect(consoleDebug).toHaveBeenCalledWith("visible");
+    expect(sink).toHaveBeenCalledWith(
+      expect.objectContaining({
+        level: "debug",
+        phase: "pre_generation",
+        message: "visible",
+        timestamp: expect.any(Number),
+      }),
+    );
+  });
+});

--- a/src/engine/agents-runtime/debug.ts
+++ b/src/engine/agents-runtime/debug.ts
@@ -1,0 +1,50 @@
+import type { AgentContext, AgentDebugEntry } from "../contracts/types/agent";
+
+export type AgentRuntimeDebugEntry = Omit<AgentDebugEntry, "timestamp"> & { timestamp?: number };
+
+export interface AgentRuntimeDebugLogger {
+  enabled: boolean;
+  debug: (...args: unknown[]) => void;
+  info: (...args: unknown[]) => void;
+  warn: (...args: unknown[]) => void;
+  error: (...args: unknown[]) => void;
+  isLevelEnabled: (_level: string) => boolean;
+  emit: (entry: AgentRuntimeDebugEntry) => void;
+}
+
+type ConsoleLevel = "debug" | "info" | "warn" | "error";
+
+function writeConsole(level: ConsoleLevel, args: unknown[]) {
+  if (typeof console === "undefined") return;
+  const target = typeof console[level] === "function" ? console[level] : console.log;
+  if (typeof target === "function") target.apply(console, args);
+}
+
+export function isAgentRuntimeDebugEnabled(context: Pick<AgentContext, "debugMode">): boolean {
+  return context.debugMode === true;
+}
+
+export function createAgentRuntimeDebug(context: AgentContext): AgentRuntimeDebugLogger {
+  const enabled = isAgentRuntimeDebugEnabled(context);
+
+  const log = (level: ConsoleLevel, args: unknown[]) => {
+    if (!enabled) return;
+    writeConsole(level, args);
+  };
+
+  return {
+    enabled,
+    debug: (...args: unknown[]) => log("debug", args),
+    info: (...args: unknown[]) => log("info", args),
+    warn: (...args: unknown[]) => log("warn", args),
+    error: (...args: unknown[]) => log("error", args),
+    isLevelEnabled: () => enabled,
+    emit: (entry: AgentRuntimeDebugEntry) => {
+      if (!enabled) return;
+      context.debugSink?.({
+        ...entry,
+        timestamp: entry.timestamp ?? Date.now(),
+      });
+    },
+  };
+}

--- a/src/engine/agents-runtime/executor/agent-executor.ts
+++ b/src/engine/agents-runtime/executor/agent-executor.ts
@@ -7,18 +7,11 @@ import type {
   LLMToolCall,
   LLMToolDefinition,
 } from "../../generation-core/llm/base-provider.js";
-import type { AgentResult, AgentContext, AgentResultType, AgentDebugEntry } from "../../contracts/types/agent";
+import type { AgentResult, AgentContext, AgentResultType } from "../../contracts/types/agent";
 import { getDefaultAgentPrompt } from "../../contracts/constants/agent-prompts";
 import { DEFAULT_AGENT_CONTEXT_SIZE, DEFAULT_AGENT_MAX_TOKENS, MAX_AGENT_MAX_TOKENS, MIN_AGENT_MAX_TOKENS } from "../../contracts/types/agent";
+import { createAgentRuntimeDebug, type AgentRuntimeDebugEntry } from "../debug.js";
 import { stripAvatarPathsReplacer } from "../strip-avatar-paths";
-
-type Logger = {
-  debug: (...args: unknown[]) => void;
-  info: (...args: unknown[]) => void;
-  warn: (...args: unknown[]) => void;
-  error: (...args: unknown[]) => void;
-  isLevelEnabled: (level: string) => boolean;
-};
 
 const MAX_AGENT_CONTEXT_MESSAGES = 200;
 const EXPRESSION_AGENT_RECENT_CONTEXT_MESSAGES = 2;
@@ -55,34 +48,6 @@ export function normalizeAgentContextSize(value: unknown, fallback = DEFAULT_AGE
     typeof value === "number" ? value : typeof value === "string" && value.trim() ? Number(value) : fallback;
   if (!Number.isFinite(parsed) || parsed < 1) return fallback;
   return Math.max(1, Math.min(MAX_AGENT_CONTEXT_MESSAGES, Math.trunc(parsed)));
-}
-
-function createLogger(enabled: boolean): Logger {
-  const log = (level: "debug" | "info" | "warn" | "error", args: unknown[]) => {
-    if (!enabled) return;
-    const target =
-      typeof console !== "undefined" && typeof console[level] === "function"
-        ? console[level]
-        : typeof console !== "undefined" && typeof console.log === "function"
-          ? console.log
-          : undefined;
-    target?.(...args);
-  };
-
-  return {
-    debug: (...args: unknown[]) => log("debug", args),
-    info: (...args: unknown[]) => log("info", args),
-    warn: (...args: unknown[]) => log("warn", args),
-    error: (...args: unknown[]) => log("error", args),
-    isLevelEnabled: () => enabled,
-  };
-}
-
-function emitDebug(context: AgentContext, entry: Omit<AgentDebugEntry, "timestamp"> & { timestamp?: number }) {
-  context.debugSink?.({
-    ...entry,
-    timestamp: entry.timestamp ?? Date.now(),
-  });
 }
 
 function redactSensitiveValue(value: unknown): unknown {
@@ -147,8 +112,8 @@ export async function executeAgent(
   toolContext?: AgentToolContext,
 ): Promise<AgentResult> {
   const startTime = Date.now();
-  const logger = createLogger(context.debugMode === true);
-  const emit = (entry: Omit<AgentDebugEntry, "timestamp"> & { timestamp?: number }) => emitDebug(context, entry);
+  const logger = createAgentRuntimeDebug(context);
+  const emit = (entry: AgentRuntimeDebugEntry) => logger.emit(entry);
 
   try {
     const template = config.promptTemplate || getDefaultAgentPrompt(config.type);
@@ -273,9 +238,9 @@ async function executeAgentWithTools(
   const MAX_TOOL_ROUNDS = 5;
   const loopMessages = [...initialMessages];
   let totalTokens = 0;
-  const logger = createLogger(context.debugMode === true);
+  const logger = createAgentRuntimeDebug(context);
   const debugAgentsEnabled = logger.isLevelEnabled("debug");
-  const emit = (entry: Omit<AgentDebugEntry, "timestamp"> & { timestamp?: number }) => emitDebug(context, entry);
+  const emit = (entry: AgentRuntimeDebugEntry) => logger.emit(entry);
 
   for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
     const result = await provider.chatComplete(loopMessages, {
@@ -392,8 +357,8 @@ export async function executeAgentBatch(
   model: string,
 ): Promise<AgentResult[]> {
   if (configs.length === 0) return [];
-  const logger = createLogger(context.debugMode === true);
-  const emit = (entry: Omit<AgentDebugEntry, "timestamp"> & { timestamp?: number }) => emitDebug(context, entry);
+  const logger = createAgentRuntimeDebug(context);
+  const emit = (entry: AgentRuntimeDebugEntry) => logger.emit(entry);
   const isolatedConfigs = configs.filter(shouldRunAgentIndividually);
   if (isolatedConfigs.length === configs.length) {
     logger.info(

--- a/src/engine/agents-runtime/knowledge/knowledge-router.ts
+++ b/src/engine/agents-runtime/knowledge/knowledge-router.ts
@@ -1,6 +1,7 @@
 import type { AgentContext, AgentResult } from "../../contracts/types/agent";
 import type { LorebookEntry } from "../../contracts/types/lorebook";
 import type { BaseLLMProvider } from "../../generation-core/llm/base-provider.js";
+import { createAgentRuntimeDebug } from "../debug.js";
 import { executeAgent, type AgentExecConfig } from "../executor/agent-executor.js";
 import { stripAvatarPathsReplacer } from "../strip-avatar-paths.js";
 import {
@@ -261,17 +262,7 @@ export async function executeKnowledgeRouter(
   options: KnowledgeRouterCandidateOptions = {},
 ): Promise<AgentResult> {
   const startTime = Date.now();
-  const logger = {
-    debug: (...args: unknown[]) => {
-      if (baseContext.debugMode === true) console.debug(...args);
-    },
-    warn: (...args: unknown[]) => {
-      if (baseContext.debugMode === true) console.warn(...args);
-    },
-    error: (...args: unknown[]) => {
-      if (baseContext.debugMode === true) console.error(...args);
-    },
-  };
+  const logger = createAgentRuntimeDebug(baseContext);
 
   // Empty input → no work, no LLM call.
   if (entries.length === 0) {
@@ -304,6 +295,12 @@ export async function executeKnowledgeRouter(
       candidates.length,
       routerEntries.length,
     );
+    logger.emit({
+      level: "warn",
+      phase: config.phase,
+      message: "knowledge-router-truncated",
+      args: [candidates.length, routerEntries.length],
+    });
   }
 
   const catalog = buildCatalog(candidates);
@@ -324,6 +321,12 @@ export async function executeKnowledgeRouter(
     // can serialize a stack-aware payload via its err-first signature.
     const err = new Error(result.error ?? "unknown error");
     logger.error(err, "[knowledge-router] agent execution failed");
+    logger.emit({
+      level: "error",
+      phase: config.phase,
+      message: "knowledge-router-error",
+      args: [result.error ?? "unknown error"],
+    });
     return result;
   }
 
@@ -345,6 +348,12 @@ export async function executeKnowledgeRouter(
 
   if (selectedEntries.length === 0) {
     logger.debug("[knowledge-router] no entries selected from %d candidates", candidates.length);
+    logger.emit({
+      level: "debug",
+      phase: config.phase,
+      message: "knowledge-router-empty",
+      args: [candidates.length],
+    });
     return {
       ...result,
       type: "context_injection",
@@ -362,6 +371,12 @@ export async function executeKnowledgeRouter(
     dedupedIds.length,
     dedupedIds.length - selectedEntries.length,
   );
+  logger.emit({
+    level: "debug",
+    phase: config.phase,
+    message: "knowledge-router-selected",
+    args: [selectedEntries.length, candidates.length, selectedIds.length, dedupedIds.length],
+  });
 
   return {
     ...result,

--- a/src/engine/agents-runtime/pipeline/agent-pipeline.ts
+++ b/src/engine/agents-runtime/pipeline/agent-pipeline.ts
@@ -1,5 +1,6 @@
-import type { AgentContext, AgentDebugEntry, AgentResult } from "../../contracts/types/agent";
+import type { AgentContext, AgentResult } from "../../contracts/types/agent";
 import type { BaseLLMProvider } from "../../generation-core/llm/base-provider.js";
+import { createAgentRuntimeDebug } from "../debug.js";
 import {
   executeAgent,
   executeAgentBatch,
@@ -7,27 +8,6 @@ import {
   type AgentExecConfig,
   type AgentToolContext,
 } from "../executor/agent-executor.js";
-
-function createLogger(enabled: boolean) {
-  return {
-    debug: (...args: unknown[]) => {
-      if (enabled) console.debug(...args);
-    },
-    warn: (...args: unknown[]) => {
-      if (enabled) console.warn(...args);
-    },
-    error: (...args: unknown[]) => {
-      if (enabled) console.error(...args);
-    },
-  };
-}
-
-function emitDebug(context: AgentContext, entry: Omit<AgentDebugEntry, "timestamp"> & { timestamp?: number }) {
-  context.debugSink?.({
-    ...entry,
-    timestamp: entry.timestamp ?? Date.now(),
-  });
-}
 
 /** A fully resolved agent ready for execution. */
 export interface ResolvedAgent extends AgentExecConfig {
@@ -159,8 +139,8 @@ async function executeGroup(
   context: AgentContext,
   onResult?: AgentResultCallback,
 ): Promise<AgentResult[]> {
-  const logger = createLogger(context.debugMode === true);
-  emitDebug(context, {
+  const logger = createAgentRuntimeDebug(context);
+  logger.emit({
     level: "debug",
     phase: group.agents[0]?.phase ?? "unknown",
     message: "group-start",
@@ -230,9 +210,9 @@ async function executePhase(
   const phaseAgents = agents.filter((a) => a.phase === phase);
   if (phaseAgents.length === 0) return [];
 
-  const logger = createLogger(context.debugMode === true);
+  const logger = createAgentRuntimeDebug(context);
   const groups = groupByProviderModel(phaseAgents).flatMap(splitGroupForParallelJobs);
-  emitDebug(context, {
+  logger.emit({
     level: "debug",
     phase,
     message: "phase-groups",
@@ -273,7 +253,7 @@ async function executePhase(
           String(entry.reason),
         );
       }
-      emitDebug(context, {
+      logger.emit({
         level: "error",
         phase,
         message: "group-error",

--- a/src/engine/contracts/types/agent.ts
+++ b/src/engine/contracts/types/agent.ts
@@ -161,7 +161,7 @@ export interface AgentContext {
   } | null;
   /** The agent's own persistent memory (key-value) */
   memory: Record<string, unknown>;
-  /** Optional sink for structured runtime debug entries. */
+  /** Optional sink for structured runtime debug entries when debugMode is enabled. */
   debugSink?: (entry: Omit<AgentDebugEntry, "timestamp"> & { timestamp?: number }) => void;
   /** Lorebook entries activated for this generation (read context) */
   activatedLorebookEntries: Array<{ id: string; name: string; content: string; tag: string }> | null;
@@ -175,7 +175,7 @@ export interface AgentContext {
   parallelResults?: AgentResult[];
   /** Whether internal agent LLM calls should use transport streaming. */
   streaming?: boolean;
-  /** Whether agent runtime logging should emit to the console. */
+  /** Whether agent runtime diagnostics should emit to the debug sink and console. */
   debugMode?: boolean;
   /** Abort signal — when triggered, agent execution should stop. Typed as `any` to avoid DOM/Node lib dependency. */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/features/catalog/characters/components/ImportCharacterModal.tsx
+++ b/src/features/catalog/characters/components/ImportCharacterModal.tsx
@@ -12,6 +12,11 @@ import {
   inspectCharacterFilesForEmbeddedLorebooks,
   type EmbeddedLorebookImportPreview,
 } from "../../../../shared/lib/character-import";
+import {
+  CHARACTER_IMPORT_UNSUPPORTED_FILE_MESSAGE,
+  extractDroppedCharacterImportFiles,
+  isSupportedCharacterImportFilename,
+} from "../lib/import-drop";
 
 interface Props {
   open: boolean;
@@ -34,7 +39,6 @@ const TAG_IMPORT_OPTIONS: Array<{ value: TagImportMode; label: string; descripti
 
 export function ImportCharacterModal({ open, onClose }: Props) {
   const fileRef = useRef<HTMLInputElement>(null);
-  const dragDepthRef = useRef(0);
   const [status, setStatus] = useState<"idle" | "loading" | "done">("idle");
   const [results, setResults] = useState<ImportResultRow[]>([]);
   const [dragOver, setDragOver] = useState(false);
@@ -52,41 +56,6 @@ export function ImportCharacterModal({ open, onClose }: Props) {
     return head[0] === 0x50 && head[1] === 0x4b;
   };
 
-  const extractDroppedFiles = (event: React.DragEvent<HTMLElement>) => {
-    const items = Array.from(event.dataTransfer.items ?? []);
-    if (items.length > 0) {
-      const files: File[] = [];
-
-      for (const item of items) {
-        if (item.kind !== "file") {
-          return {
-            files: [] as File[],
-            error: "Drop supported character files here. Folders and other items are not supported.",
-          };
-        }
-
-        const file = item.getAsFile();
-        if (!file) {
-          return {
-            files: [] as File[],
-            error: "Folders are not supported here. Drop supported character files instead.",
-          };
-        }
-
-        files.push(file);
-      }
-
-      return files.length > 0
-        ? { files, error: null }
-        : { files: [] as File[], error: "Drop supported character files here." };
-    }
-
-    const files = Array.from(event.dataTransfer.files ?? []);
-    return files.length > 0
-      ? { files, error: null }
-      : { files: [] as File[], error: "Drop supported character files here." };
-  };
-
   const handleFiles = async (files: File[], importEmbeddedLorebook?: boolean) => {
     if (files.length === 0) return;
     setStatus("loading");
@@ -98,6 +67,7 @@ export function ImportCharacterModal({ open, onClose }: Props) {
       const stCharacterFiles: File[] = [];
       const marinaraPayloads: Array<{ file: File; payload: Record<string, unknown> }> = [];
       const marinaraPackages: File[] = [];
+      const nextResults: ImportResultRow[] = [];
 
       for (const file of files) {
         const lower = file.name.toLowerCase();
@@ -113,8 +83,27 @@ export function ImportCharacterModal({ open, onClose }: Props) {
           continue;
         }
 
+        if (!isSupportedCharacterImportFilename(file.name)) {
+          nextResults.push({
+            filename: file.name,
+            success: false,
+            message: CHARACTER_IMPORT_UNSUPPORTED_FILE_MESSAGE,
+          });
+          continue;
+        }
+
         const text = await file.text();
-        const json = JSON.parse(text) as Record<string, unknown>;
+        let json: Record<string, unknown>;
+        try {
+          json = JSON.parse(text) as Record<string, unknown>;
+        } catch (error) {
+          nextResults.push({
+            filename: file.name,
+            success: false,
+            message: error instanceof Error ? error.message : "Invalid JSON file",
+          });
+          continue;
+        }
         const isMarinaraEnvelope =
           json.version === 1 && typeof json.type === "string" && (json.type as string).startsWith("marinara_");
 
@@ -123,6 +112,13 @@ export function ImportCharacterModal({ open, onClose }: Props) {
         } else {
           stCharacterFiles.push(file);
         }
+      }
+
+      const hasImportableFiles = stCharacterFiles.length > 0 || marinaraPayloads.length > 0 || marinaraPackages.length > 0;
+      if (!hasImportableFiles) {
+        setResults(nextResults);
+        setStatus("done");
+        return;
       }
 
       if (stCharacterFiles.length > 0 && importEmbeddedLorebook === undefined) {
@@ -134,7 +130,6 @@ export function ImportCharacterModal({ open, onClose }: Props) {
         }
       }
 
-      const nextResults: ImportResultRow[] = [];
       let importedLorebook = false;
       let importedCharacterMissingCacheRecord = false;
 
@@ -280,10 +275,9 @@ export function ImportCharacterModal({ open, onClose }: Props) {
   const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
     e.stopPropagation();
-    dragDepthRef.current = 0;
     setDragOver(false);
 
-    const { files, error } = extractDroppedFiles(e);
+    const { files, error } = extractDroppedCharacterImportFiles(e.dataTransfer);
     if (error) {
       setDropError(error);
       setPendingLorebookChoice(null);
@@ -298,7 +292,6 @@ export function ImportCharacterModal({ open, onClose }: Props) {
   const handleDragEnter = (e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
     e.stopPropagation();
-    dragDepthRef.current += 1;
     setDropError(null);
     setDragOver(true);
   };
@@ -313,10 +306,9 @@ export function ImportCharacterModal({ open, onClose }: Props) {
   const handleDragLeave = (e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
     e.stopPropagation();
-    dragDepthRef.current = Math.max(0, dragDepthRef.current - 1);
-    if (dragDepthRef.current === 0) {
-      setDragOver(false);
-    }
+    const nextTarget = e.relatedTarget;
+    if (nextTarget instanceof Node && e.currentTarget.contains(nextTarget)) return;
+    setDragOver(false);
   };
 
   const reset = () => {
@@ -325,7 +317,6 @@ export function ImportCharacterModal({ open, onClose }: Props) {
     setPendingLorebookChoice(null);
     setTagImportMode("all");
     setDropError(null);
-    dragDepthRef.current = 0;
     setDragOver(false);
   };
 

--- a/src/features/catalog/characters/lib/import-drop.test.ts
+++ b/src/features/catalog/characters/lib/import-drop.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { extractDroppedCharacterImportFiles, isSupportedCharacterImportFilename } from "./import-drop";
+
+function file(name: string): File {
+  return new File(["{}"], name, { type: "application/json" });
+}
+
+function fileItem(sourceFile: File, entry: { isDirectory?: boolean } | null = { isDirectory: false }) {
+  return {
+    kind: "file",
+    getAsFile: () => sourceFile,
+    webkitGetAsEntry: () => entry,
+  };
+}
+
+describe("character import drop handling", () => {
+  it("extracts browser file items without losing supported files", () => {
+    const first = file("rina.json");
+    const second = file("card.png");
+
+    expect(
+      extractDroppedCharacterImportFiles({
+        items: [fileItem(first), fileItem(second)],
+      }),
+    ).toEqual({ files: [first, second], error: null });
+  });
+
+  it("rejects dropped folders with a clear error", () => {
+    const result = extractDroppedCharacterImportFiles({
+      items: [fileItem(file("folder"), { isDirectory: true })],
+    });
+
+    expect(result.files).toEqual([]);
+    expect(result.error).toBe("Folders are not supported here. Drop supported character files instead.");
+  });
+
+  it("rejects non-file drag items instead of starting an import", () => {
+    const result = extractDroppedCharacterImportFiles({
+      items: [
+        {
+          kind: "string",
+          getAsFile: () => null,
+        },
+      ],
+    });
+
+    expect(result.files).toEqual([]);
+    expect(result.error).toBe("Drop supported character files here. Folders and other items are not supported.");
+  });
+
+  it("falls back to FileList drops when DataTransferItemList is empty", () => {
+    const dropped = file("renamed.marinara");
+
+    expect(
+      extractDroppedCharacterImportFiles({
+        items: [],
+        files: [dropped],
+      }),
+    ).toEqual({ files: [dropped], error: null });
+  });
+
+  it("identifies supported character import filenames case-insensitively", () => {
+    expect(isSupportedCharacterImportFilename("rina.JSON")).toBe(true);
+    expect(isSupportedCharacterImportFilename("card.PNG")).toBe(true);
+    expect(isSupportedCharacterImportFilename("bundle.charx")).toBe(true);
+    expect(isSupportedCharacterImportFilename("native.marinara")).toBe(true);
+    expect(isSupportedCharacterImportFilename("notes.txt")).toBe(false);
+  });
+});

--- a/src/features/catalog/characters/lib/import-drop.ts
+++ b/src/features/catalog/characters/lib/import-drop.ts
@@ -1,0 +1,70 @@
+export const CHARACTER_IMPORT_UNSUPPORTED_FILE_MESSAGE =
+  "Unsupported file type. Drop JSON, PNG character cards, CharX, or Marinara exports.";
+
+const EMPTY_DROP_ERROR = "Drop supported character files here.";
+const FOLDER_DROP_ERROR = "Folders are not supported here. Drop supported character files instead.";
+const UNSUPPORTED_DROP_ERROR = "Drop supported character files here. Folders and other items are not supported.";
+
+const SUPPORTED_CHARACTER_IMPORT_EXTENSIONS = [".json", ".png", ".charx", ".marinara"] as const;
+
+interface DroppedEntryLike {
+  isDirectory?: boolean;
+}
+
+interface DroppedItemLike {
+  kind: string;
+  getAsFile(): File | null;
+  webkitGetAsEntry?: () => DroppedEntryLike | null;
+}
+
+interface DropDataTransferLike {
+  items?: ArrayLike<DroppedItemLike> | null;
+  files?: ArrayLike<File> | null;
+}
+
+export interface DroppedCharacterImportFiles {
+  files: File[];
+  error: string | null;
+}
+
+export function isSupportedCharacterImportFilename(filename: string): boolean {
+  const lower = filename.toLowerCase();
+  return SUPPORTED_CHARACTER_IMPORT_EXTENSIONS.some((extension) => lower.endsWith(extension));
+}
+
+export function extractDroppedCharacterImportFiles(dataTransfer: DropDataTransferLike): DroppedCharacterImportFiles {
+  const items = Array.from(dataTransfer.items ?? []);
+  if (items.length > 0) {
+    const files: File[] = [];
+    let hasFolder = false;
+    let hasUnsupportedItem = false;
+
+    for (const item of items) {
+      if (item.kind !== "file") {
+        hasUnsupportedItem = true;
+        continue;
+      }
+
+      const entry = item.webkitGetAsEntry?.() ?? null;
+      if (entry?.isDirectory) {
+        hasFolder = true;
+        continue;
+      }
+
+      const file = item.getAsFile();
+      if (!file) {
+        hasFolder = true;
+        continue;
+      }
+
+      files.push(file);
+    }
+
+    if (hasFolder) return { files: [], error: FOLDER_DROP_ERROR };
+    if (hasUnsupportedItem) return { files: [], error: UNSUPPORTED_DROP_ERROR };
+    return files.length > 0 ? { files, error: null } : { files: [], error: EMPTY_DROP_ERROR };
+  }
+
+  const files = Array.from(dataTransfer.files ?? []);
+  return files.length > 0 ? { files, error: null } : { files: [], error: EMPTY_DROP_ERROR };
+}

--- a/src/features/shell/settings/components/SettingsPanel.tsx
+++ b/src/features/shell/settings/components/SettingsPanel.tsx
@@ -3430,7 +3430,7 @@ function AdvancedSettings() {
         label="Debug mode"
         checked={debugMode}
         onChange={setDebugMode}
-        help="Shows the in-app agent debug panel with prompt, response, tool, and result details for troubleshooting."
+        help="Shows the in-app agent debug panel and emits agent runtime diagnostics to the console for troubleshooting."
       />
 
       {/* ── Profile Export ── */}


### PR DESCRIPTION
## Linked issue

Closes #1161

## Why this change

- Character import drag-and-drop could behave inconsistently when users dropped folders, non-file drag items, unsupported files, or moved across nested drop-zone elements.
- Unsupported filenames could flow into JSON parsing and fail the whole drop instead of producing a clear per-file failure.

## What changed

- Added a focused character import drop extraction helper with explicit folder and non-file rejection.
- Switched the modal drop path to use that helper and preserve browser FileList fallback behavior.
- Kept drag highlight stable when moving across nested drop-zone children.
- Added per-file failures for unsupported filenames and invalid JSON.
- Added Vitest coverage for file item extraction, folder rejection, non-file rejection, FileList fallback, and supported filename detection.

## Refactor impact

Primary owner:

catalog characters

Impact areas reviewed:

- Character import modal drag-and-drop UI
- Character import file filtering before shared import API calls
- Tauri window drag-drop config

Boundary notes:

- Feature-only change under `src/features/catalog/characters`.
- Shared import API, Rust import commands, engine code, remote runtime, chat/roleplay/game mode owners unchanged.
- `src-tauri/tauri.conf.json` already has `dragDropEnabled: false`, so browser drop events remain UI-owned.

Pressure points touched:

- Character import module

## Validation

- [x] `pnpm check` passes locally
- [x] `pnpm typecheck` passes locally
- [x] `pnpm build` passes locally
- [x] `pnpm check:architecture` passes locally
- [x] `pnpm check:docs` passes locally
- [x] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [x] Rust clippy/tests were run for Rust behavior changes
- [x] Browser or Tauri app manual verification completed
- [x] Playwright, screenshot, or recording evidence added for UI changes
- [x] Remote runtime smoke checked when relevant

Additional validation:

- [x] `pnpm test -- src/features/catalog/characters/lib/import-drop.test.ts` passes locally

### Manual verification notes

- Not manually verified in Tauri/browser. Recommended manual check: open character import modal, drop a supported `.json`/`.png`, drop a folder, drop an unsupported file, and move the drag cursor across nested text/icons inside the drop zone. Expected: supported files import or show normal import errors, folders/non-file drags show clear errors, unsupported files show per-file failure, and drag highlight remains stable until leaving the drop zone.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

No screenshot or recording added. Logic covered by focused helper tests; manual drag-drop pass still recommended.
