### PR TITLE
[codex] Fix Rust structure line counting

### DIFF
--- a/scripts/check-rust-structure.mjs
+++ b/scripts/check-rust-structure.mjs
@@ -36,10 +36,19 @@ const checks = [
 
 const failures = [];
 
+function countLogicalLines(source) {
+  if (source.length === 0) {
+    return 0;
+  }
+
+  // Do not count a normal terminal newline as an extra blank line.
+  return source.replace(/\r?\n$/, "").split(/\r?\n/).length;
+}
+
 for (const check of checks) {
   const absolutePath = resolve(root, check.path);
   const source = readFileSync(absolutePath, "utf8");
-  const lines = source.split(/\r?\n/).length;
+  const lines = countLogicalLines(source);
 
   if (lines > check.maxLines) {
     failures.push(


### PR DESCRIPTION
## Linked issue

None - local chore/tooling fix, no public issue.

## Why this change

- `scripts/check-rust-structure.mjs` counted a normal terminal newline as an extra logical line, so a Rust module with exactly the configured line limit could fail as one line over.

## What changed

- Added a focused logical line counter that ignores one terminal newline before applying configured max-line limits.
- Preserved real over-limit failures, including intentional trailing blank logical lines and 751-line files.

## Refactor impact

Primary owner:

- Architecture check tooling: `scripts/check-rust-structure.mjs`

Impact areas reviewed:

- Architecture/import-rule validation path.
- Rust import module structure gate.

Boundary notes:

- No product, React feature, engine, shared API, Tauri runtime, or Rust behavior changed.
- Forbidden-pattern checks are unchanged.

Pressure points touched:

- `scripts/check-rust-structure.mjs` only. No Rust import modules were edited.

## Validation

- [x] `pnpm check` passes locally
- [x] `pnpm typecheck` passes locally
- [x] `pnpm build` passes locally
- [x] `pnpm check:architecture` passes locally
- [x] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

Automated/local proof run before opening this draft:

- Reproduced the bug with a scratch fixture: 750 logical lines plus a terminal newline failed as 751 before the fix.
- Verified the fixed path: 750 LF lines plus terminal newline passes.
- Verified CRLF handling: 750 CRLF lines plus terminal newline passes.
- Verified no-terminal-newline handling: 750 lines without terminal newline passes.
- Verified negative controls: 750 lines plus an intentional trailing blank logical line still fails as 751, and 751 CRLF lines still fails.
- Ran `pnpm check:architecture`; dependency-cruiser passed and Rust structure check passed.
- Ran `git diff --check`; no whitespace errors were reported. Git emitted only the local LF/CRLF conversion warning for the touched script.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

Docs/release notes: not needed; this is an internal architecture-check tooling fix with no user-facing app behavior change.

## UI evidence

Not applicable; no UI behavior changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the accuracy of structure validation for internal checks by refining line-counting logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1252?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->