### PR TITLE
feat(tts): split quoted dialogue from prose narration

### DIFF
--- a/src/engine/contracts/types/tts.ts
+++ b/src/engine/contracts/types/tts.ts
@@ -104,6 +104,8 @@ export const ttsConfigSchema = z.object({
   /** Plain text on write; masked "••••••" on read when a key is saved */
   apiKey: z.string().default(""),
   voice: z.string().default("alloy"),
+  narratorVoiceEnabled: z.boolean().default(false),
+  narratorVoice: z.string().default(""),
   model: z.string().default("tts-1"),
   /** 0.25 – 4.0 */
   speed: z.number().min(0.25).max(4.0).default(1.0),

--- a/src/features/modes/shared/chat-ui/components/ChatMessage.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatMessage.tsx
@@ -51,9 +51,8 @@ import {
   subscribeStreamingTTSActive,
 } from "../hooks/use-streaming-tts";
 import {
-  buildTTSMessageText,
+  buildTTSVoiceRequests,
   clientSidePlaybackRate,
-  resolveTTSVoiceForSpeaker,
 } from "../../../../../shared/lib/tts-dialogue";
 import { DIALOGUE_QUOTE_PATTERN_SOURCE, HTML_SAFE_DIALOGUE_QUOTE_PATTERN_SOURCE } from "../../../../../shared/lib/dialogue-quotes";
 import DOMPurify from "dompurify";
@@ -746,11 +745,16 @@ export const ChatMessage = memo(function ChatMessage({
   const { data: ttsConfig } = useTTSConfig();
   const ttsEnabled = ttsConfig?.enabled ?? false;
   const ttsSpeakerName = message.characterId ? characterMap?.get(message.characterId)?.name : undefined;
-  const ttsVoice = ttsConfig ? resolveTTSVoiceForSpeaker(ttsConfig, ttsSpeakerName, message.characterId) : "";
-  const ttsSpeakText =
-    ttsConfig && (ttsConfig.source !== "elevenlabs" || ttsVoice)
-      ? buildTTSMessageText(message.content, ttsConfig, ttsSpeakerName)
-      : "";
+  const ttsVoiceRequests = useMemo(
+    () =>
+      ttsConfig
+        ? buildTTSVoiceRequests(message.content, ttsConfig, ttsSpeakerName, message.characterId).filter((request) =>
+            request.text.trim(),
+          )
+        : [],
+    [message.characterId, message.content, ttsConfig, ttsSpeakerName],
+  );
+  const hasTTSContent = ttsVoiceRequests.length > 0;
   const [ttsState, setTTSState] = useState(ttsService.getState());
   const [ttsActiveId, setTTSActiveId] = useState<string | null>(ttsService.getActiveId());
   useEffect(
@@ -782,14 +786,12 @@ export const ChatMessage = memo(function ChatMessage({
     if (liveIsThis) {
       ttsService.stop();
     } else {
-      if (!ttsSpeakText) return;
-      void ttsService.speak(ttsSpeakText, message.id, {
-        speaker: ttsSpeakerName,
-        voice: ttsVoice,
+      if (!hasTTSContent) return;
+      void ttsService.speakSequence(ttsVoiceRequests, message.id, {
         playbackRate: clientSidePlaybackRate(ttsConfig),
       });
     }
-  }, [message.id, ttsSpeakText, ttsSpeakerName, ttsVoice, ttsConfig]);
+  }, [hasTTSContent, message.id, ttsConfig, ttsVoiceRequests]);
 
   const handlePauseResumeTTS = useCallback(() => {
     if (ttsService.getActiveId() !== message.id) return;
@@ -1849,7 +1851,7 @@ export const ChatMessage = memo(function ChatMessage({
                     title={
                       streamingTTSActive
                         ? "Stop streaming narration"
-                        : !ttsSpeakText
+                        : !hasTTSContent
                         ? "No dialogue to speak"
                         : isLoadingThis
                           ? "Loading…"
@@ -1858,7 +1860,7 @@ export const ChatMessage = memo(function ChatMessage({
                             : "Speak"
                     }
                     className={isSpeakingThis || streamingTTSActive ? "text-sky-400 hover:text-sky-300" : undefined}
-                    disabled={!streamingTTSActive && (!ttsSpeakText || (ttsBusy && !isSpeakingThis))}
+                    disabled={!streamingTTSActive && (!hasTTSContent || (ttsBusy && !isSpeakingThis))}
                     dark
                   />
                 </>
@@ -2258,7 +2260,7 @@ export const ChatMessage = memo(function ChatMessage({
                   title={
                     streamingTTSActive
                       ? "Stop streaming narration"
-                      : !ttsSpeakText
+                      : !hasTTSContent
                       ? "No dialogue to speak"
                       : isLoadingThis
                         ? "Loading…"
@@ -2267,7 +2269,7 @@ export const ChatMessage = memo(function ChatMessage({
                           : "Speak"
                   }
                   className={isSpeakingThis || streamingTTSActive ? "text-sky-500" : undefined}
-                  disabled={!streamingTTSActive && (!ttsSpeakText || (ttsBusy && !isSpeakingThis))}
+                  disabled={!streamingTTSActive && (!hasTTSContent || (ttsBusy && !isSpeakingThis))}
                 />
               </>
             )}

--- a/src/features/modes/shared/chat-ui/hooks/use-chat-tts-autoplay.ts
+++ b/src/features/modes/shared/chat-ui/hooks/use-chat-tts-autoplay.ts
@@ -1,10 +1,9 @@
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useTTSConfig } from "../../../../../shared/hooks/use-tts";
 import {
-  buildTTSMessageText,
+  buildTTSVoiceRequests,
   clientSidePlaybackRate,
   normalizeTTSCharacterName,
-  resolveTTSVoiceForSpeaker,
 } from "../../../../../shared/lib/tts-dialogue";
 import { ttsService } from "../../../../../shared/lib/tts-service";
 import { useChatStore } from "../../../../../shared/stores/chat.store";
@@ -108,14 +107,12 @@ export function useChatTtsAutoplay({ chatId, mode, messages, characterMap, isStr
         : lastMessage.characterId
           ? characterMap.get(lastMessage.characterId)?.name
           : undefined;
-    const text = buildTTSMessageText(lastMessage.content, config, fallbackSpeaker);
-    if (!text) return;
-    const voice = resolveTTSVoiceForSpeaker(config, fallbackSpeaker, lastMessage.characterId);
-    if (config.source === "elevenlabs" && !voice) return;
+    const requests = buildTTSVoiceRequests(lastMessage.content, config, fallbackSpeaker, lastMessage.characterId).filter(
+      (request) => request.text.trim().length > 0,
+    );
+    if (requests.length === 0) return;
 
-    void ttsService.speak(text, lastMessage.id, {
-      speaker: fallbackSpeaker,
-      voice,
+    void ttsService.speakSequence(requests, lastMessage.id, {
       playbackRate: clientSidePlaybackRate(config),
     });
   }, [characterMap, isStreaming]);

--- a/src/features/modes/shared/chat-ui/hooks/use-streaming-tts.test.tsx
+++ b/src/features/modes/shared/chat-ui/hooks/use-streaming-tts.test.tsx
@@ -14,6 +14,8 @@ const baseConfig: TTSConfig = {
   baseUrl: "https://api.openai.com/v1",
   apiKey: "",
   voice: "alloy",
+  narratorVoiceEnabled: false,
+  narratorVoice: "",
   model: "tts-1",
   speed: 1,
   elevenLabsStability: 0.5,
@@ -51,12 +53,20 @@ class MockAudio {
   }
 }
 
-function Harness({ enabled = true }: { enabled?: boolean }) {
+function Harness({
+  enabled = true,
+  config = baseConfig,
+  fallbackSpeaker = "Narrator",
+}: {
+  enabled?: boolean;
+  config?: TTSConfig;
+  fallbackSpeaker?: string;
+}) {
   useStreamingTTS({
     enabled,
     chatId: "chat-1",
-    ttsConfig: baseConfig,
-    fallbackSpeaker: "Narrator",
+    ttsConfig: config,
+    fallbackSpeaker,
   });
   return null;
 }
@@ -141,5 +151,44 @@ describe("useStreamingTTS", () => {
 
     await waitFor(() => expect(MockAudio.instances).toHaveLength(2));
     expect(MockAudio.instances[1]?.play).toHaveBeenCalledTimes(1);
+  });
+
+  it("routes streaming prose to narrator voice without emitting partial quoted dialogue", async () => {
+    const config: TTSConfig = {
+      ...baseConfig,
+      narratorVoiceEnabled: true,
+      narratorVoice: "nova",
+    };
+    act(() => {
+      root.render(<Harness config={config} fallbackSpeaker="Ada" />);
+    });
+
+    act(() => {
+      useChatStore.getState().setStreaming(true, "chat-1");
+      useChatStore.getState().appendStreamBuffer('She smiles. "Hello. How', "chat-1");
+    });
+
+    await waitFor(() => expect(ttsService.generateAudio).toHaveBeenCalledTimes(1));
+    expect(ttsService.generateAudio).toHaveBeenNthCalledWith(
+      1,
+      "She smiles.",
+      expect.objectContaining({ speaker: "Narrator", voice: "nova" }),
+    );
+
+    act(() => {
+      useChatStore.getState().appendStreamBuffer(' are you?" She nods.', "chat-1");
+    });
+
+    await waitFor(() => expect(ttsService.generateAudio).toHaveBeenCalledTimes(3));
+    expect(ttsService.generateAudio).toHaveBeenNthCalledWith(
+      2,
+      "Hello. How are you?",
+      expect.objectContaining({ speaker: "Ada", voice: "alloy" }),
+    );
+    expect(ttsService.generateAudio).toHaveBeenNthCalledWith(
+      3,
+      "She nods.",
+      expect.objectContaining({ speaker: "Narrator", voice: "nova" }),
+    );
   });
 });

--- a/src/features/shell/settings/components/settings/TTSConfigCard.tsx
+++ b/src/features/shell/settings/components/settings/TTSConfigCard.tsx
@@ -919,9 +919,15 @@ export function TTSConfigCard() {
                   label="Split quoted dialogue from narration"
                   checked={narratorVoiceEnabled}
                   onChange={(enabled) => {
-                    const nextNarratorVoice = narratorVoice || voice;
+                    const nextNarratorVoice = narratorVoice.trim() || voice.trim();
+                    if (enabled && !nextNarratorVoice) {
+                      setNarratorVoiceEnabled(false);
+                      mark({ narratorVoiceEnabled: false });
+                      return;
+                    }
+
                     setNarratorVoiceEnabled(enabled);
-                    if (enabled && !narratorVoice) setNarratorVoice(nextNarratorVoice);
+                    if (enabled && nextNarratorVoice !== narratorVoice) setNarratorVoice(nextNarratorVoice);
                     mark({
                       narratorVoiceEnabled: enabled,
                       narratorVoice: enabled ? nextNarratorVoice : narratorVoice,
@@ -934,6 +940,7 @@ export function TTSConfigCard() {
                       <input
                         value={narratorVoice}
                         list="pockettts-voices"
+                        aria-label="Narrator voice selection"
                         onChange={(e) => {
                           setNarratorVoice(e.target.value);
                           mark({ narratorVoice: e.target.value });
@@ -945,6 +952,7 @@ export function TTSConfigCard() {
                   ) : (
                     <select
                       value={narratorVoice}
+                      aria-label="Narrator voice selection"
                       onChange={(e) => {
                         setNarratorVoice(e.target.value);
                         mark({ narratorVoice: e.target.value });
@@ -953,7 +961,7 @@ export function TTSConfigCard() {
                       className={cn(INPUT_CLS, "cursor-pointer appearance-none")}
                     >
                       {source === "elevenlabs" && <option value="">Select narrator voice</option>}
-                      {fetchingVoices && <option value="">Loading voicesâ€¦</option>}
+                      {fetchingVoices && <option value="">Loading voices&hellip;</option>}
                       {!fetchingVoices && voiceOptions.length === 0 && <option value="">Save config to load voices</option>}
                       {voiceOptions.map((option) => (
                         <option key={option.id} value={option.id}>

--- a/src/features/shell/settings/components/settings/TTSConfigCard.tsx
+++ b/src/features/shell/settings/components/settings/TTSConfigCard.tsx
@@ -293,6 +293,8 @@ export function TTSConfigCard() {
   const [apiKey, setApiKey] = useState("");
   const [model, setModel] = useState("tts-1");
   const [voice, setVoice] = useState("alloy");
+  const [narratorVoiceEnabled, setNarratorVoiceEnabled] = useState(false);
+  const [narratorVoice, setNarratorVoice] = useState("");
   const [voiceMode, setVoiceMode] = useState<TTSVoiceMode>("single");
   const [voiceAssignments, setVoiceAssignments] = useState<TTSVoiceAssignment[]>([]);
   const [npcDefaultVoicesEnabled, setNpcDefaultVoicesEnabled] = useState(false);
@@ -335,6 +337,8 @@ export function TTSConfigCard() {
     setApiKey(savedConfig.apiKey); // masked value from server
     setModel(savedConfig.model);
     setVoice(savedConfig.voice);
+    setNarratorVoiceEnabled(savedConfig.narratorVoiceEnabled ?? false);
+    setNarratorVoice(savedConfig.narratorVoice ?? "");
     setVoiceMode(savedConfig.voiceMode ?? "single");
     setVoiceAssignments(savedConfig.voiceAssignments ?? []);
     setNpcDefaultVoicesEnabled(savedConfig.npcDefaultVoicesEnabled ?? false);
@@ -378,6 +382,8 @@ export function TTSConfigCard() {
     apiKey: apiKey === TTS_API_KEY_MASK ? TTS_API_KEY_MASK : apiKey,
     model,
     voice,
+    narratorVoiceEnabled,
+    narratorVoice,
     voiceMode,
     voiceAssignments,
     npcDefaultVoicesEnabled,
@@ -431,6 +437,8 @@ export function TTSConfigCard() {
     setApiKey(nextApiKey);
     setModel(defaults.model);
     setVoice(defaults.voice);
+    setNarratorVoiceEnabled(false);
+    setNarratorVoice(defaults.voice);
     setVoiceMode("single");
     setVoiceAssignments([]);
     setNpcDefaultVoicesEnabled(false);
@@ -443,6 +451,8 @@ export function TTSConfigCard() {
       apiKey: nextApiKey,
       model: defaults.model,
       voice: defaults.voice,
+      narratorVoiceEnabled: false,
+      narratorVoice: defaults.voice,
       voiceMode: "single",
       voiceAssignments: [],
       npcDefaultVoicesEnabled: false,
@@ -896,6 +906,63 @@ export function TTSConfigCard() {
                   Showing PocketTTS built-in voices. You can type a custom voice URL or path accepted by your server.
                 </p>
               )}
+            </FieldRow>
+          )}
+
+          {voiceMode === "single" && (
+            <FieldRow
+              label="Narrator Voice"
+              help="Use a separate voice for prose outside quotes while quoted dialogue keeps the character voice."
+            >
+              <div className="space-y-2 rounded-lg border border-[var(--border)] bg-[var(--secondary)]/40 p-2">
+                <ToggleRow
+                  label="Split quoted dialogue from narration"
+                  checked={narratorVoiceEnabled}
+                  onChange={(enabled) => {
+                    const nextNarratorVoice = narratorVoice || voice;
+                    setNarratorVoiceEnabled(enabled);
+                    if (enabled && !narratorVoice) setNarratorVoice(nextNarratorVoice);
+                    mark({
+                      narratorVoiceEnabled: enabled,
+                      narratorVoice: enabled ? nextNarratorVoice : narratorVoice,
+                    });
+                  }}
+                />
+                {narratorVoiceEnabled &&
+                  (source === "pockettts" ? (
+                    <>
+                      <input
+                        value={narratorVoice}
+                        list="pockettts-voices"
+                        onChange={(e) => {
+                          setNarratorVoice(e.target.value);
+                          mark({ narratorVoice: e.target.value });
+                        }}
+                        className={INPUT_CLS}
+                        placeholder={voice || "Narrator voice"}
+                      />
+                    </>
+                  ) : (
+                    <select
+                      value={narratorVoice}
+                      onChange={(e) => {
+                        setNarratorVoice(e.target.value);
+                        mark({ narratorVoice: e.target.value });
+                      }}
+                      disabled={fetchingVoices || voiceOptions.length === 0}
+                      className={cn(INPUT_CLS, "cursor-pointer appearance-none")}
+                    >
+                      {source === "elevenlabs" && <option value="">Select narrator voice</option>}
+                      {fetchingVoices && <option value="">Loading voicesâ€¦</option>}
+                      {!fetchingVoices && voiceOptions.length === 0 && <option value="">Save config to load voices</option>}
+                      {voiceOptions.map((option) => (
+                        <option key={option.id} value={option.id}>
+                          {option.name === option.id ? option.id : `${option.name} (${option.id})`}
+                        </option>
+                      ))}
+                    </select>
+                  ))}
+              </div>
             </FieldRow>
           )}
 

--- a/src/features/shell/settings/components/settings/TTSConfigCard.tsx
+++ b/src/features/shell/settings/components/settings/TTSConfigCard.tsx
@@ -428,6 +428,12 @@ export function TTSConfigCard() {
     }, 600);
   };
 
+  const handleNarratorVoiceChange = (value: string) => {
+    const nextNarratorVoice = value.trim();
+    setNarratorVoice(nextNarratorVoice);
+    mark({ narratorVoice: nextNarratorVoice });
+  };
+
   const handleSourceChange = (nextSource: TTSSource) => {
     const defaults = TTS_SOURCE_DEFAULTS[nextSource];
     const nextApiKey = apiKey === TTS_API_KEY_MASK ? "" : apiKey;
@@ -942,8 +948,7 @@ export function TTSConfigCard() {
                         list="pockettts-voices"
                         aria-label="Narrator voice selection"
                         onChange={(e) => {
-                          setNarratorVoice(e.target.value);
-                          mark({ narratorVoice: e.target.value });
+                          handleNarratorVoiceChange(e.target.value);
                         }}
                         className={INPUT_CLS}
                         placeholder={voice || "Narrator voice"}
@@ -954,8 +959,7 @@ export function TTSConfigCard() {
                       value={narratorVoice}
                       aria-label="Narrator voice selection"
                       onChange={(e) => {
-                        setNarratorVoice(e.target.value);
-                        mark({ narratorVoice: e.target.value });
+                        handleNarratorVoiceChange(e.target.value);
                       }}
                       disabled={fetchingVoices || voiceOptions.length === 0}
                       className={cn(INPUT_CLS, "cursor-pointer appearance-none")}

--- a/src/shared/lib/dialogue-quotes.ts
+++ b/src/shared/lib/dialogue-quotes.ts
@@ -1,4 +1,5 @@
 const DIALOGUE_QUOTE_PAIRS = [
+  ['""', '""'],
   ['"', '"'],
   ["\u201c", "\u201d"],
   ["\u00ab", "\u00bb"],
@@ -7,13 +8,13 @@ const DIALOGUE_QUOTE_PAIRS = [
 ] as const;
 
 export const DIALOGUE_QUOTE_PATTERN_SOURCE =
-  '"[^"]+"|\u201c[^\u201d]+\u201d|\u00ab[^\u00bb]+\u00bb|\u300c[^\u300d]+\u300d|\u300e[^\u300f]+\u300f';
+  '""[^"]+""|"[^"]+"|\u201c[^\u201d]+\u201d|\u00ab[^\u00bb]+\u00bb|\u300c[^\u300d]+\u300d|\u300e[^\u300f]+\u300f';
 
 export const DIALOGUE_QUOTE_CAPTURE_GROUP_PATTERN_SOURCE =
-  '"([^"]+)"|\u201c([^\u201d]+)\u201d|\u00ab([^\u00bb]+)\u00bb|\u300c([^\u300d]+)\u300d|\u300e([^\u300f]+)\u300f';
+  '""([^"]+)""|"([^"]+)"|\u201c([^\u201d]+)\u201d|\u00ab([^\u00bb]+)\u00bb|\u300c([^\u300d]+)\u300d|\u300e([^\u300f]+)\u300f';
 
 export const HTML_SAFE_DIALOGUE_QUOTE_PATTERN_SOURCE =
-  '"[^"<>]+"|\u201c[^\u201d<>]+\u201d|\u00ab[^\u00bb<>]+\u00bb|\u300c[^\u300d<>]+\u300d|\u300e[^\u300f<>]+\u300f';
+  '""[^"<>]+""|"[^"<>]+"|\u201c[^\u201d<>]+\u201d|\u00ab[^\u00bb<>]+\u00bb|\u300c[^\u300d<>]+\u300d|\u300e[^\u300f<>]+\u300f';
 
 export function stripSurroundingDialogueQuotes(content: string): string {
   if (content.length < 2) return content;

--- a/src/shared/lib/sentence-chunker.test.ts
+++ b/src/shared/lib/sentence-chunker.test.ts
@@ -36,4 +36,30 @@ describe("streaming TTS sentence chunker", () => {
     expect(extractNewSentences("Visible. <thought>still thinking. Hidden", unclosedState)).toBe("Visible.");
     expect(extractRemainder("Visible. <thought>still thinking. Hidden", unclosedState)).toBe("");
   });
+
+  it("waits for quoted dialogue to close before emitting mid-quote sentence punctuation", () => {
+    const state = createChunkerState();
+
+    expect(extractNewSentences('She says, "Hello. How are', state)).toBe("");
+    expect(extractNewSentences('She says, "Hello. How are you." Then nods.', state)).toBe(
+      'She says, "Hello. How are you." Then nods.',
+    );
+  });
+
+  it("treats doubled ASCII quotes as balanced dialogue delimiters", () => {
+    const state = createChunkerState();
+
+    expect(extractNewSentences('She says, ""Hello. How are', state)).toBe("");
+    expect(extractNewSentences('She says, ""Hello. How are you."" Then nods.', state)).toBe(
+      'She says, ""Hello. How are you."" Then nods.',
+    );
+  });
+
+  it("emits sentence ends after guillemet and Japanese quote closers", () => {
+    const state = createChunkerState();
+
+    expect(extractNewSentences("\u00abHello. How are you?\u00bb \u300cFine.\u300d", state)).toBe(
+      "\u00abHello. How are you?\u00bb \u300cFine.\u300d",
+    );
+  });
 });

--- a/src/shared/lib/sentence-chunker.test.ts
+++ b/src/shared/lib/sentence-chunker.test.ts
@@ -53,6 +53,9 @@ describe("streaming TTS sentence chunker", () => {
     expect(extractNewSentences('She says, ""Hello. How are you."" Then nods.', state)).toBe(
       'She says, ""Hello. How are you."" Then nods.',
     );
+
+    const terminalState = createChunkerState();
+    expect(extractNewSentences('She says, ""Hello.""', terminalState)).toBe('She says, ""Hello.""');
   });
 
   it("emits sentence ends after guillemet and Japanese quote closers", () => {

--- a/src/shared/lib/sentence-chunker.ts
+++ b/src/shared/lib/sentence-chunker.ts
@@ -1,4 +1,13 @@
-const SENTENCE_END_RE = /[.!?\u2026\u3002\uff01\uff1f]+(?:["'\u201d\u2019)\]}])?(?=\s|$)/gu;
+const SENTENCE_END_RE = /[.!?\u2026\u3002\uff01\uff1f]+(?:["'\u201d\u2019\u00bb\u300d\u300f)\]}])?(?=\s|$)/gu;
+
+const OPEN_QUOTES = new Set(['"', "\u201c", "\u00ab", "\u300c", "\u300e"]);
+const CLOSE_QUOTES_FOR: Record<string, string> = {
+  '"': '"',
+  "\u201c": "\u201d",
+  "\u00ab": "\u00bb",
+  "\u300c": "\u300d",
+  "\u300e": "\u300f",
+};
 
 const ABBREVIATIONS = new Set(["mr", "mrs", "ms", "dr", "st", "prof", "sr", "jr", "vs", "etc", "ie", "eg", "fig", "no"]);
 
@@ -69,7 +78,7 @@ function findUnclosedThinkingStart(tail: string): number | null {
 }
 
 function isEllipsisEndCandidate(matchText: string): boolean {
-  return /^\.{2,}["'\u201d\u2019)\]}]?$/.test(matchText);
+  return /^\.{2,}["'\u201d\u2019\u00bb\u300d\u300f)\]}]?$/.test(matchText);
 }
 
 function lastSentencePunctuationIndex(matchText: string): number {
@@ -82,6 +91,33 @@ function lastSentencePunctuationIndex(matchText: string): number {
     matchText.lastIndexOf("\uff01"),
     matchText.lastIndexOf("\uff1f"),
   );
+}
+
+function isInsideUnclosedQuote(text: string, pos: number): boolean {
+  let asciiOpen = false;
+  const pairStack: string[] = [];
+
+  for (let index = 0; index < pos; index += 1) {
+    const char = text[index]!;
+    if (char === '"' && text[index + 1] === '"') {
+      asciiOpen = !asciiOpen;
+      index += 1;
+      continue;
+    }
+    if (char === '"') {
+      asciiOpen = !asciiOpen;
+      continue;
+    }
+    if (OPEN_QUOTES.has(char)) {
+      pairStack.push(CLOSE_QUOTES_FOR[char]!);
+      continue;
+    }
+    if (pairStack.length > 0 && char === pairStack[pairStack.length - 1]) {
+      pairStack.pop();
+    }
+  }
+
+  return asciiOpen || pairStack.length > 0;
 }
 
 export function extractNewSentences(buffer: string, state: ChunkerState): string {
@@ -107,7 +143,10 @@ export function extractNewSentences(buffer: string, state: ChunkerState): string
     const punctuationIndex = punctuationOffset >= 0 ? localIndex + punctuationOffset : localIndex + matchText.length - 1;
     if (scannable[punctuationIndex] === "." && endsWithAbbreviation(scannable, punctuationIndex)) continue;
 
-    lastEnd = startAt + localIndex + matchText.length;
+    const absoluteEnd = startAt + localIndex + matchText.length;
+    if (isInsideUnclosedQuote(buffer, absoluteEnd)) continue;
+
+    lastEnd = absoluteEnd;
   }
 
   if (lastEnd === -1) return "";

--- a/src/shared/lib/sentence-chunker.ts
+++ b/src/shared/lib/sentence-chunker.ts
@@ -1,4 +1,4 @@
-const SENTENCE_END_RE = /[.!?\u2026\u3002\uff01\uff1f]+(?:["'\u201d\u2019\u00bb\u300d\u300f)\]}])?(?=\s|$)/gu;
+const SENTENCE_END_RE = /[.!?\u2026\u3002\uff01\uff1f]+(?:["'\u201d\u2019\u00bb\u300d\u300f)\]}]+)?(?=\s|$)/gu;
 
 const OPEN_QUOTES = new Set(['"', "\u201c", "\u00ab", "\u300c", "\u300e"]);
 const CLOSE_QUOTES_FOR: Record<string, string> = {
@@ -78,7 +78,7 @@ function findUnclosedThinkingStart(tail: string): number | null {
 }
 
 function isEllipsisEndCandidate(matchText: string): boolean {
-  return /^\.{2,}["'\u201d\u2019\u00bb\u300d\u300f)\]}]?$/.test(matchText);
+  return /^\.{2,}["'\u201d\u2019\u00bb\u300d\u300f)\]}]*$/.test(matchText);
 }
 
 function lastSentencePunctuationIndex(matchText: string): number {

--- a/src/shared/lib/tts-dialogue.test.ts
+++ b/src/shared/lib/tts-dialogue.test.ts
@@ -75,4 +75,16 @@ describe("TTS dialogue routing", () => {
       expect.objectContaining({ text: "Stay close.", speaker: "Ada", voice: "alloy" }),
     ]);
   });
+
+  it("does not treat a real fallback speaker named Narrator as synthetic narration", () => {
+    const requests = buildTTSVoiceRequests('"Line."', {
+      ...baseConfig,
+      narratorVoiceEnabled: true,
+      narratorVoice: "nova",
+    }, "Narrator");
+
+    expect(requests).toEqual([
+      expect.objectContaining({ text: "Line.", speaker: "Narrator", voice: "alloy" }),
+    ]);
+  });
 });

--- a/src/shared/lib/tts-dialogue.test.ts
+++ b/src/shared/lib/tts-dialogue.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import type { TTSConfig } from "../../engine/contracts/types/tts";
+import { buildTTSVoiceRequests } from "./tts-dialogue";
+
+const baseConfig: TTSConfig = {
+  enabled: true,
+  source: "openai",
+  baseUrl: "https://api.openai.com/v1",
+  apiKey: "",
+  voice: "alloy",
+  narratorVoiceEnabled: false,
+  narratorVoice: "",
+  model: "tts-1",
+  speed: 1,
+  elevenLabsStability: 0.5,
+  elevenLabsLanguageCode: "",
+  voiceMode: "single",
+  voiceAssignments: [],
+  npcDefaultVoicesEnabled: false,
+  npcDefaultMaleVoices: [],
+  npcDefaultFemaleVoices: [],
+  autoplayRP: true,
+  autoplayConvo: false,
+  autoplayGame: false,
+  autoplayStreaming: false,
+  dialogueOnly: false,
+  dialogueScope: "all",
+  dialogueCharacterName: "",
+};
+
+describe("TTS dialogue routing", () => {
+  it("routes prose to narrator voice and quoted dialogue to the fallback character", () => {
+    const requests = buildTTSVoiceRequests('She smiles. "Come here." Then waits.', {
+      ...baseConfig,
+      narratorVoiceEnabled: true,
+      narratorVoice: "nova",
+    }, "Ada");
+
+    expect(requests).toEqual([
+      expect.objectContaining({ text: "She smiles.", speaker: "Narrator", voice: "nova" }),
+      expect.objectContaining({ text: "Come here.", speaker: "Ada", voice: "alloy" }),
+      expect.objectContaining({ text: "Then waits.", speaker: "Narrator", voice: "nova" }),
+    ]);
+  });
+
+  it("keeps action-only chunks on narrator voice when narrator splitting is enabled", () => {
+    const requests = buildTTSVoiceRequests("She crosses the room without speaking.", {
+      ...baseConfig,
+      narratorVoiceEnabled: true,
+      narratorVoice: "nova",
+    }, "Ada");
+
+    expect(requests).toEqual([
+      expect.objectContaining({ text: "She crosses the room without speaking.", speaker: "Narrator", voice: "nova" }),
+    ]);
+  });
+
+  it("leaves single-voice playback unchanged when narrator splitting is disabled", () => {
+    const requests = buildTTSVoiceRequests('She smiles. "Come here."', baseConfig, "Ada");
+
+    expect(requests).toEqual([
+      expect.objectContaining({ text: "She smiles. \"Come here.\"", speaker: "Ada", voice: "alloy" }),
+    ]);
+  });
+
+  it("supports doubled ASCII quotes as dialogue delimiters", () => {
+    const requests = buildTTSVoiceRequests('She whispers, ""Stay close.""', {
+      ...baseConfig,
+      narratorVoiceEnabled: true,
+      narratorVoice: "nova",
+    }, "Ada");
+
+    expect(requests).toEqual([
+      expect.objectContaining({ text: "She whispers,", speaker: "Narrator", voice: "nova" }),
+      expect.objectContaining({ text: "Stay close.", speaker: "Ada", voice: "alloy" }),
+    ]);
+  });
+});

--- a/src/shared/lib/tts-dialogue.ts
+++ b/src/shared/lib/tts-dialogue.ts
@@ -1,5 +1,9 @@
 import type { TTSConfig } from "../../engine/contracts/types/tts";
-import { DIALOGUE_QUOTE_CAPTURE_GROUP_PATTERN_SOURCE, stripSurroundingDialogueQuotes } from "./dialogue-quotes";
+import {
+  DIALOGUE_QUOTE_CAPTURE_GROUP_PATTERN_SOURCE,
+  DIALOGUE_QUOTE_PATTERN_SOURCE,
+  stripSurroundingDialogueQuotes,
+} from "./dialogue-quotes";
 
 export function clientSidePlaybackRate(cfg: TTSConfig | null | undefined): number {
   if (!cfg || cfg.source !== "openai") return 1;
@@ -127,6 +131,8 @@ export function resolveTTSVoiceForSpeaker(
         | "source"
         | "voiceMode"
         | "voiceAssignments"
+        | "narratorVoiceEnabled"
+        | "narratorVoice"
         | "npcDefaultVoicesEnabled"
         | "npcDefaultMaleVoices"
         | "npcDefaultFemaleVoices"
@@ -137,6 +143,14 @@ export function resolveTTSVoiceForSpeaker(
   npcHint?: TTSNpcVoiceHint | null,
 ): string {
   const fallbackVoice = config.voice ?? "";
+  if (
+    config.narratorVoiceEnabled &&
+    normalizeTTSCharacterName(speaker) === "narrator" &&
+    (config.voiceMode ?? "single") === "single"
+  ) {
+    return config.narratorVoice || fallbackVoice;
+  }
+
   if (config.voiceMode === "per-character") {
     const assignments = Array.isArray(config.voiceAssignments) ? config.voiceAssignments : [];
     const normalizedSpeaker = normalizeTTSCharacterName(speaker);
@@ -262,6 +276,34 @@ export function buildTTSMessageText(text: string, config: TTSConfig, fallbackSpe
     .join("\n");
 }
 
+export function splitQuotedDialogueAndNarration(text: string, fallbackSpeaker?: string | null): TTSUtterance[] {
+  const quoteRe = new RegExp(DIALOGUE_QUOTE_PATTERN_SOURCE, "g");
+  const utterances: TTSUtterance[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = quoteRe.exec(text)) !== null) {
+    const narrationBefore = cleanTTSInputText(text.slice(lastIndex, match.index));
+    if (narrationBefore) {
+      utterances.push({ text: narrationBefore, speaker: "Narrator" });
+    }
+
+    const dialogue = cleanTTSInputText(stripSurroundingDialogueQuotes(match[0]));
+    if (dialogue) {
+      utterances.push({ text: dialogue, speaker: fallbackSpeaker || undefined });
+    }
+
+    lastIndex = match.index + match[0].length;
+  }
+
+  const narrationAfter = cleanTTSInputText(text.slice(lastIndex));
+  if (narrationAfter) {
+    utterances.push({ text: narrationAfter, speaker: "Narrator" });
+  }
+
+  return utterances;
+}
+
 export function buildTTSVoiceRequests(
   text: string,
   config: TTSConfig,
@@ -271,12 +313,19 @@ export function buildTTSVoiceRequests(
 ): TTSVoiceRequest[] {
   const hasSpeakerTags = /<speaker="[^"]*">/i.test(text);
   const shouldExtractUtterances = config.dialogueOnly || hasSpeakerTags;
+  const shouldAutoSplitForNarrator =
+    !hasSpeakerTags &&
+    !config.dialogueOnly &&
+    config.narratorVoiceEnabled &&
+    (config.voiceMode ?? "single") === "single";
   const utterances =
     hasSpeakerTags && !config.dialogueOnly
       ? extractSpeakerTaggedUtterances(text, config, fallbackSpeaker, true)
       : shouldExtractUtterances
         ? extractDialogueUtterances(text, config, fallbackSpeaker)
-        : [{ text: cleanTTSInputText(text), speaker: fallbackSpeaker || undefined } satisfies TTSUtterance];
+        : shouldAutoSplitForNarrator
+          ? splitQuotedDialogueAndNarration(text, fallbackSpeaker)
+          : [{ text: cleanTTSInputText(text), speaker: fallbackSpeaker || undefined } satisfies TTSUtterance];
 
   const fallbackSpeakerKey = normalizeTTSCharacterName(fallbackSpeaker);
   return utterances.flatMap((utterance) => {

--- a/src/shared/lib/tts-dialogue.ts
+++ b/src/shared/lib/tts-dialogue.ts
@@ -24,6 +24,12 @@ export interface TTSVoiceRequest extends TTSUtterance {
   voice?: string;
 }
 
+const TTS_NARRATOR_SPEAKER = "__tts_narrator__";
+
+function isSyntheticTTSNarrator(speaker?: string | null): boolean {
+  return speaker === TTS_NARRATOR_SPEAKER;
+}
+
 export function normalizeTTSCharacterName(value?: string | null): string {
   return (value ?? "").toLowerCase().replace(/[_-]+/g, " ").replace(/\s+/g, " ").trim();
 }
@@ -145,7 +151,7 @@ export function resolveTTSVoiceForSpeaker(
   const fallbackVoice = config.voice ?? "";
   if (
     config.narratorVoiceEnabled &&
-    normalizeTTSCharacterName(speaker) === "narrator" &&
+    isSyntheticTTSNarrator(speaker) &&
     (config.voiceMode ?? "single") === "single"
   ) {
     return config.narratorVoice || fallbackVoice;
@@ -285,7 +291,7 @@ export function splitQuotedDialogueAndNarration(text: string, fallbackSpeaker?: 
   while ((match = quoteRe.exec(text)) !== null) {
     const narrationBefore = cleanTTSInputText(text.slice(lastIndex, match.index));
     if (narrationBefore) {
-      utterances.push({ text: narrationBefore, speaker: "Narrator" });
+      utterances.push({ text: narrationBefore, speaker: TTS_NARRATOR_SPEAKER });
     }
 
     const dialogue = cleanTTSInputText(stripSurroundingDialogueQuotes(match[0]));
@@ -298,7 +304,7 @@ export function splitQuotedDialogueAndNarration(text: string, fallbackSpeaker?: 
 
   const narrationAfter = cleanTTSInputText(text.slice(lastIndex));
   if (narrationAfter) {
-    utterances.push({ text: narrationAfter, speaker: "Narrator" });
+    utterances.push({ text: narrationAfter, speaker: TTS_NARRATOR_SPEAKER });
   }
 
   return utterances;
@@ -330,17 +336,21 @@ export function buildTTSVoiceRequests(
   const fallbackSpeakerKey = normalizeTTSCharacterName(fallbackSpeaker);
   return utterances.flatMap((utterance) => {
     const speaker = utterance.speaker || fallbackSpeaker || undefined;
+    const isSyntheticNarrator = isSyntheticTTSNarrator(speaker);
     const speakerKey = normalizeTTSCharacterName(speaker);
-    const resolvedCharacterId = speaker
+    const resolvedCharacterId = isSyntheticNarrator
+      ? undefined
+      : speaker
       ? (resolveCharacterIdForSpeaker?.(speaker) ??
         (speakerKey && speakerKey === fallbackSpeakerKey ? fallbackCharacterId : undefined))
       : fallbackCharacterId;
     const voice = resolveTTSVoiceForSpeaker(config, speaker, resolvedCharacterId);
     if (config.source === "elevenlabs" && !voice) return [];
+    const requestSpeaker = isSyntheticNarrator ? "Narrator" : speaker;
 
     return splitTTSChunks(utterance.text).map((chunk) => ({
       text: chunk,
-      speaker,
+      speaker: requestSpeaker,
       tone: utterance.tone,
       voice,
     }));
@@ -405,7 +415,7 @@ function extractSpeakerTaggedUtterances(
   const addNarration = (value: string) => {
     if (!includeNarration) return;
     const spoken = cleanTTSInputText(value);
-    if (spoken) utterances.push({ text: spoken, speaker: "Narrator" });
+    if (spoken) utterances.push({ text: spoken, speaker: TTS_NARRATOR_SPEAKER });
   };
 
   while ((speakerTagMatch = speakerTagRe.exec(text)) !== null) {

--- a/src/shared/lib/tts-service.ts
+++ b/src/shared/lib/tts-service.ts
@@ -16,6 +16,13 @@ export interface TTSSpeakOptions {
   playbackRate?: number;
 }
 
+export interface TTSSpeakRequest {
+  text: string;
+  speaker?: string;
+  tone?: string;
+  voice?: string;
+}
+
 class TTSService {
   private audio: HTMLAudioElement | null = null;
   private currentObjectUrl: string | null = null;
@@ -135,6 +142,134 @@ class TTSService {
       this.lastError = error.message;
       this.setState("error");
       if (options.throwOnError) throw error;
+    }
+  }
+
+  async speakSequence(
+    requests: TTSSpeakRequest[],
+    id?: string,
+    options: Pick<TTSSpeakOptions, "signal" | "throwOnError" | "playbackRate"> = {},
+  ): Promise<void> {
+    const playableRequests = requests.filter((request) => request.text.trim().length > 0);
+    if (playableRequests.length === 0) return;
+
+    this.stop();
+    const sequence = ++this.sequence;
+    this.lastError = null;
+    this.setState("loading", id ?? null);
+
+    const abortController = new AbortController();
+    this.abortController = abortController;
+    const externalAbort = () => abortController.abort();
+    if (options.signal) {
+      if (options.signal.aborted) {
+        abortController.abort();
+      } else {
+        options.signal.addEventListener("abort", externalAbort, { once: true });
+      }
+    }
+
+    try {
+      for (const request of playableRequests) {
+        if (!this.isCurrentSequence(sequence)) return;
+        if (abortController.signal.aborted) {
+          this.setState("idle");
+          return;
+        }
+        this.setState("loading", id ?? null);
+
+        const blob = await this.generateAudio(request.text, {
+          speaker: request.speaker,
+          tone: request.tone,
+          voice: request.voice,
+          signal: abortController.signal,
+        });
+        if (!this.isCurrentSequence(sequence)) return;
+        if (abortController.signal.aborted) {
+          this.setState("idle");
+          return;
+        }
+
+        const objectUrl = URL.createObjectURL(blob);
+        if (!this.isCurrentSequence(sequence) || abortController.signal.aborted) {
+          URL.revokeObjectURL(objectUrl);
+          if (this.isCurrentSequence(sequence)) this.setState("idle");
+          return;
+        }
+
+        this.cleanup();
+        this.currentObjectUrl = objectUrl;
+        const audio = new Audio(objectUrl);
+        if (options.playbackRate && options.playbackRate > 0 && options.playbackRate !== 1) {
+          audio.playbackRate = options.playbackRate;
+        }
+        this.audio = audio;
+        this.setState("playing", id ?? null);
+
+        const playbackResult = await new Promise<"ended" | "aborted">((resolve, reject) => {
+          let onAbort: (() => void) | null = null;
+          const cleanupListeners = () => {
+            audio.onended = null;
+            audio.onerror = null;
+            if (onAbort) abortController.signal.removeEventListener("abort", onAbort);
+          };
+          audio.onended = () => {
+            cleanupListeners();
+            resolve("ended");
+          };
+          audio.onerror = () => {
+            cleanupListeners();
+            reject(new Error("TTS audio playback failed"));
+          };
+          onAbort = () => {
+            audio.pause();
+            cleanupListeners();
+            resolve("aborted");
+          };
+          if (abortController.signal.aborted) {
+            onAbort();
+            return;
+          }
+          abortController.signal.addEventListener("abort", onAbort, { once: true });
+          audio.play().catch((err: unknown) => {
+            cleanupListeners();
+            reject(err instanceof Error ? err : new Error("Browser blocked audio playback"));
+          });
+        });
+
+        if (!this.isCurrentSequence(sequence)) return;
+        if (playbackResult === "aborted") {
+          this.cleanup();
+          this.audio = null;
+          this.setState("idle");
+          return;
+        }
+        this.cleanup();
+        this.audio = null;
+      }
+
+      if (this.isCurrentSequence(sequence)) {
+        this.setState("idle");
+      }
+    } catch (err) {
+      if (!this.isCurrentSequence(sequence)) return;
+      if (err instanceof Error && err.name === "AbortError") {
+        this.setState("idle");
+        return;
+      }
+      const error = err instanceof Error ? err : new Error("TTS request failed");
+      this.lastError = error.message;
+      this.cleanup();
+      this.audio = null;
+      this.setState("error");
+      if (options.throwOnError) throw error;
+    } finally {
+      if (options.signal) {
+        options.signal.removeEventListener("abort", externalAbort);
+      }
+      if (this.abortController === abortController) {
+        this.abortController = null;
+      }
     }
   }
 


### PR DESCRIPTION
## Linked issue

Closes #1144
Ports #1143 to the refactor branch.

## Why this change

Users can configure a separate narrator voice, but unstructured roleplay replies without `<speaker>` tags were still spoken as one character-voice utterance. That meant prose narration and quoted dialogue could not use separate voices in normal roleplay output.

This adds quote-aware routing so prose outside quotes uses the narrator voice and quoted dialogue keeps the fallback character voice when narrator splitting is enabled.

## What changed

- Added `narratorVoiceEnabled` and `narratorVoice` TTS config fields.
- Added a TTS settings control to enable quote/prose splitting and choose the narrator voice.
- Added shared quote/prose splitting for unstructured TTS text.
- Updated speaker-icon playback and end-of-stream autoplay to use sequenced TTS requests.
- Made the streaming sentence chunker wait for balanced quoted spans before emitting mid-quote punctuation.
- Added regression coverage for narrator routing, streaming routing, doubled ASCII quotes, guillemets, and Japanese quote closers.

## Refactor impact

Primary owner:

shared TTS / chat playback

Impact areas reviewed:

- `src/shared/lib` TTS helpers, sentence chunker, and TTS service
- shared chat message speaker-button playback
- shared chat TTS autoplay hook
- shell TTS settings card
- TTS contract schema

Boundary notes:

- No server route, storage, Rust command, remote runtime, or provider API changes.
- Existing `dialogueOnly`, `<speaker>` tag, VN/Game speaker-line paths are intentionally left in their existing routing path.
- Per-character voice mode is not changed by narrator splitting.

Pressure points touched:

- shared mode UI: `ChatMessage`
- shared mode autoplay hook: `use-chat-tts-autoplay`
- settings UI: `TTSConfigCard`
- shared TTS service sequencing

## Validation

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

Codex verification run:

- `pnpm test -- src/shared/lib/tts-dialogue.test.ts src/shared/lib/sentence-chunker.test.ts src/features/modes/shared/chat-ui/hooks/use-streaming-tts.test.tsx` passed: 3 files, 13 tests.
- `pnpm check` passed.
- `pnpm build` passed.
- `pnpm lint` passed.
- Bunny review pass completed with no blocking findings.

Manual/provider smoke still recommended before marking ready:

- Configure TTS with one character voice and one narrator voice.
- Enable “Split quoted dialogue from narration.”
- Use a message with prose plus quoted dialogue and confirm the speaker icon plays prose with the narrator voice and quoted text with the character voice.
- Repeat with streaming TTS enabled to confirm the same routing during streamed playback.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

No screenshot attached. This adds a small TTS settings control and changes playback routing; local compile/build/tests passed, but real provider voice timbre still needs manual smoke verification.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Narrator voice option in single-voice TTS: toggle to split narration from quoted dialogue and choose a narrator voice in settings
  * Sequential TTS playback: multiple text segments speak in order for smoother narration and dialogue handling
  * UI/Autoplay updates: TTS play controls and autoplay now respect whether there is speakable TTS content

* **Bug Fixes**
  * Improved quote and sentence detection (including doubled ASCII quotes and additional quote styles) to avoid premature sentence emission

* **Tests**
  * Added tests covering narrator/dialogue routing, sentence-chunking, and streaming behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1255?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->