### PR TITLE
Fix mobile catalog action wrapping

### DIFF
--- a/src/features/catalog/characters/components/CharactersPanel.tsx
+++ b/src/features/catalog/characters/components/CharactersPanel.tsx
@@ -659,7 +659,7 @@ export function CharactersPanel() {
       )}
 
       {/* Actions */}
-      <div className="flex gap-2">
+      <div className="grid grid-cols-2 gap-2 md:grid-cols-4">
         <button
           onClick={() => openModal("create-character")}
           className="flex flex-1 items-center justify-center gap-1.5 rounded-xl bg-gradient-to-r from-pink-400 to-purple-500 px-3 py-2.5 text-xs font-medium text-white shadow-md shadow-pink-500/15 transition-all hover:shadow-lg hover:shadow-pink-500/25 active:scale-[0.98]"

--- a/src/features/catalog/personas/components/PersonasPanel.tsx
+++ b/src/features/catalog/personas/components/PersonasPanel.tsx
@@ -419,7 +419,7 @@ export function PersonasPanel() {
       )}
 
       {/* Actions */}
-      <div className="flex gap-2">
+      <div className="grid grid-cols-2 gap-2 md:grid-cols-4">
         <button
           onClick={handleCreate}
           className="flex flex-1 items-center justify-center gap-1.5 rounded-xl bg-gradient-to-r from-emerald-400 to-teal-500 px-3 py-2.5 text-xs font-medium text-white shadow-md shadow-emerald-400/15 transition-all hover:shadow-lg hover:shadow-emerald-400/25 active:scale-[0.98]"


### PR DESCRIPTION
## Linked issue

Closes #1225

## Why this change

- On 320px mobile viewports, the Characters and Personas catalog action rows could force the rightmost Select button offscreen.

## What changed

- Changed the Characters panel action row from a single flex row to a responsive grid that wraps into two columns on narrow mobile widths.
- Changed the Personas panel action row the same way so the shared catalog toolbar pattern behaves consistently.

## Refactor impact

Primary owner:

Catalog resources.

Impact areas reviewed:

- Characters catalog panel
- Personas catalog panel
- Mobile Tools/right-panel flow used to reach those panels

Boundary notes:

- UI-only feature code change under `src/features/catalog`.
- No engine, shared API, Rust, storage, schema, dependency, auth, remote-runtime, or prompt pipeline changes.

Pressure points touched:

- None.

## Validation

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Codex reproduced the original `320x568` mobile clipping with Playwright before the fix: Characters Select measured `right: 354px`, Personas Select measured `right: 355px`.
- Codex reran the original `320x568` Playwright flow after the fix on current `upstream/refactor`; all Characters and Personas action buttons measured within the viewport.
- Codex also ran adjacent viewport checks at `390x844` and `768x768`; all target action buttons stayed within the viewport.
- Codex ran `pnpm check` successfully on the updated refactor base.
- No human-only verification is currently blocking the core claim.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

Before, Characters at 320x568:

![Before Characters](https://raw.githubusercontent.com/cha1latte/Marinara-Engine/evidence/issue-1225-mobile-catalog-actions/docs/evidence/issue-1225/before-characters.png)

After, Characters at 320x568:

![After Characters](https://raw.githubusercontent.com/cha1latte/Marinara-Engine/evidence/issue-1225-mobile-catalog-actions/docs/evidence/issue-1225/after-characters.png)

Before, Personas at 320x568:

![Before Personas](https://raw.githubusercontent.com/cha1latte/Marinara-Engine/evidence/issue-1225-mobile-catalog-actions/docs/evidence/issue-1225/before-personas.png)

After, Personas at 320x568:

![After Personas](https://raw.githubusercontent.com/cha1latte/Marinara-Engine/evidence/issue-1225-mobile-catalog-actions/docs/evidence/issue-1225/after-personas.png)
