### PR TITLE
Fix Character Library mobile actions

### DIFF
--- a/src/features/catalog/characters/components/CharacterLibraryView.tsx
+++ b/src/features/catalog/characters/components/CharacterLibraryView.tsx
@@ -297,27 +297,27 @@ export function CharacterLibraryView() {
             </div>
           </div>
 
-          <div className="flex w-full items-center gap-1.5 overflow-x-auto pb-1 sm:flex-wrap sm:gap-2 sm:overflow-visible sm:pb-0 lg:w-auto lg:justify-end">
+          <div className="flex w-full min-w-0 flex-wrap items-center gap-1.5 pb-1 sm:gap-2 sm:pb-0 lg:w-auto lg:justify-end">
             <button
               onClick={() => openModal("create-character")}
-              className="inline-flex min-w-[6.1rem] shrink-0 items-center justify-center gap-1.5 rounded-2xl bg-[var(--secondary)] px-2.5 py-1.5 text-[0.8125rem] font-medium text-[var(--secondary-foreground)] ring-1 ring-[var(--border)] transition-all hover:bg-[var(--accent)] sm:min-w-[8rem] sm:px-3 sm:py-2 sm:text-sm"
+              className="inline-flex min-w-[5.25rem] flex-1 items-center justify-center gap-1.5 rounded-2xl bg-[var(--secondary)] px-2.5 py-1.5 text-[0.8125rem] font-medium text-[var(--secondary-foreground)] ring-1 ring-[var(--border)] transition-all hover:bg-[var(--accent)] sm:min-w-[8rem] sm:flex-none sm:px-3 sm:py-2 sm:text-sm"
             >
               <Plus size="0.8125rem" />
-              New
+              <span className="truncate">New</span>
             </button>
             <button
               onClick={() => openModal("import-character")}
-              className="inline-flex min-w-[6.1rem] shrink-0 items-center justify-center gap-1.5 rounded-2xl bg-[var(--secondary)] px-2.5 py-1.5 text-[0.8125rem] font-medium text-[var(--secondary-foreground)] ring-1 ring-[var(--border)] transition-all hover:bg-[var(--accent)] sm:min-w-[8rem] sm:px-3 sm:py-2 sm:text-sm"
+              className="inline-flex min-w-[5.25rem] flex-1 items-center justify-center gap-1.5 rounded-2xl bg-[var(--secondary)] px-2.5 py-1.5 text-[0.8125rem] font-medium text-[var(--secondary-foreground)] ring-1 ring-[var(--border)] transition-all hover:bg-[var(--accent)] sm:min-w-[8rem] sm:flex-none sm:px-3 sm:py-2 sm:text-sm"
             >
               <Download size="0.8125rem" />
-              Import
+              <span className="truncate">Import</span>
             </button>
             <button
               onClick={() => openModal("character-maker")}
-              className="inline-flex min-w-[6.35rem] shrink-0 items-center justify-center gap-1.5 rounded-2xl bg-gradient-to-r from-pink-400 to-rose-500 px-2.5 py-1.5 text-[0.8125rem] font-medium text-white shadow-lg shadow-pink-500/15 transition-all hover:shadow-pink-500/25 sm:min-w-[8rem] sm:px-3 sm:py-2 sm:text-sm"
+              className="inline-flex min-w-[6rem] flex-1 items-center justify-center gap-1.5 rounded-2xl bg-gradient-to-r from-pink-400 to-rose-500 px-2.5 py-1.5 text-[0.8125rem] font-medium text-white shadow-lg shadow-pink-500/15 transition-all hover:shadow-pink-500/25 sm:min-w-[8rem] sm:flex-none sm:px-3 sm:py-2 sm:text-sm"
             >
               <Sparkles size="0.8125rem" />
-              AI Maker
+              <span className="truncate">AI Maker</span>
             </button>
           </div>
         </div>


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #1226

## Why this change

- The Character Library mobile header clipped the `AI Maker` action offscreen at a 320px viewport, leaving the action row visually broken on narrow phones.

## What changed

- Changed the Character Library header actions from a fixed-width horizontal scroller to a compact wrapping/flexing row on mobile.
- Kept the existing larger tablet/desktop button widths and layout behavior.

## Refactor impact

Primary owner:

- Catalog resources: `src/features/catalog/characters/components/CharacterLibraryView.tsx`

Impact areas reviewed:

- Character Library full-page surface
- Mobile Characters panel path into the full library
- Current `refactor` mobile catalog action wrapping work

Boundary notes:

- UI-only catalog layout fix; no engine, shared API, Rust, storage, auth, prompt, or remote-runtime boundary changes.

Pressure points touched:

- None of the listed pressure points were touched. This stays inside the Character Library leaf component.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Codex reproduced the original issue at `320x568`: before fix, `AI Maker` measured `right: 340.8125px` in a `320px` viewport.
- Codex reran the original Playwright path after the fix and after rebasing onto current `upstream/refactor`: `AI Maker` measured `right: 307.25px` in a `320px` viewport, with no horizontal document/body overflow.
- Codex also checked adjacent mobile widths:
  - `375x667`: `AI Maker` fully visible, `right: 362.25px <= 375px`.
  - `390x844`: `AI Maker` fully visible, `right: 377.25px <= 390px`.
  - `280x568` stress case: row wraps instead of clipping, `AI Maker right: 267.25px <= 280px`.
- Codex ran `pnpm check` after the rebase; it passed architecture, frontend TypeScript, Rust `cargo check`, and docs.
- Codex ran `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json`; it passed.
- No human-only verification is blocking the core claim.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

Before:

![Before: AI Maker clipped offscreen](https://raw.githubusercontent.com/cha1latte/Marinara-Engine/evidence/issue-1226-character-library-toolbar/docs/evidence/issue-1226/before.png)

After:

![After: AI Maker visible at 320px](https://raw.githubusercontent.com/cha1latte/Marinara-Engine/evidence/issue-1226-character-library-toolbar/docs/evidence/issue-1226/after.png)
