### PR TITLE
feat: Agent Memory Enhancement 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Fixed mobile Conversation chats where optional toolbar actions could squeeze the message textarea down until it appeared missing on narrow phone viewports.
 - Added a stale client artifact cleanup step for the obsolete tracker data sidebar folder so installs, updates, checks, and builds are not tripped up by leftover local files after the tracker panel refactor.
 - Fixed Docker builds so the stale client artifact cleanup script is available before dependency install/build scripts run.
 - Fixed streaming Roleplay messages in Glued Side Panel avatar mode so the avatar frame keeps the selected scale and is revealed by the growing message instead of rescaling while tokens arrive.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 - Added a Marinara-specific AI agent workflow overlay, adapted from the Chai Agent Workflow Pack, covering proof discipline, bugfix/feature lanes, issue filing, PR gates, and risky-work claim boundaries.
 - Added a None option for Roleplay message avatars so messages can render without avatar attachments.
+- Added default starting values for numeric Game HUD widgets, with setup/editor clamps that keep start values within the configured max.
+- Added a prompt override editor for registered prompt templates, including conversation selfie overrides, collapsible settings, and draft preservation.
+- Added shared drag-and-drop image upload dropzones for character avatars, chat gallery images, and background imports.
 - Added a manual Game Mode combat start control with confirmation so players can trigger encounter setup when a scene should enter combat.
 - Added a General quote-format preference for straight or curly dialogue quotes and apostrophes, with editor/input formatting support across chat, presets, characters, and personas.
 - Added conditional prompt macros, macro comment blocks, and Macro Reference guidance so presets and character/persona cards can keep author-only notes or branch prompt text by speaker/character.
@@ -29,6 +32,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 - Removed the Conversation, Roleplay, and Game mode shortcuts from the topbar because the sidebar already owns mode navigation.
 - Widened the Glued Side Panel roleplay avatar presentation so the portrait strip has more visual presence.
+- Improved sprite wand cleanup with halo edge cleanup, clean/paint brush tools, unified brush controls, and better multi-pointer handling.
+- Polished Tracker Panel visual controls, thought bubbles, persona/tracker card styling, responsive world-state temperature display, and color preview restore/legacy tint behavior.
 - Improved Game Mode combat setup so encounter generation can run in the background after scene analysis, with debug logging and a wait state only when the player reaches combat before setup is ready.
 - Removed unreliable met/unmet status tracking from Game Mode NPC prompt context.
 - Improved Roleplay group chat Individual mode prompting so only the currently responding character card is included, other characters' prior messages are treated as user-side context, and the turn-owner instruction can be toggled.
@@ -45,9 +50,14 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 ### Fixed
 
 - Fixed mobile Conversation chats where optional toolbar actions could squeeze the message textarea down until it appeared missing on narrow phone viewports.
+- Fixed tracker character-card lookup so active-chat card aliases from title/comment text resolve tracker rows before out-of-chat fallback cards, keeping group-chat tracker portraits and color settings attached to the intended character.
+- Fixed character tracker refreshes preserving user-uploaded NPC portraits and portrait framing across agent updates, including first snapshot writes.
+- Fixed the Roleplay HUD temperature chip so it respects the shared Tracker Panel Celsius/Fahrenheit display setting.
 - Added a stale client artifact cleanup step for the obsolete tracker data sidebar folder so installs, updates, checks, and builds are not tripped up by leftover local files after the tracker panel refactor.
 - Fixed Docker builds so the stale client artifact cleanup script is available before dependency install/build scripts run.
 - Fixed streaming Roleplay messages in Glued Side Panel avatar mode so the avatar frame keeps the selected scale and is revealed by the growing message instead of rescaling while tokens arrive.
+- Fixed Quest Board state merges so tracker updates no longer revert quest progress or keep completed empty-objective quests.
+- Fixed profile export/import fallback handling for large assets so profile exports can recover cleanly when embedded asset payloads are too large.
 - Fixed Windows installer updates for existing shallow release checkouts by fetching the resolved release commit before checkout.
 - Fixed mobile Game Mode character and party controls so sheet actions stay compact, long character names can remain accessible, and crowded party rosters collapse into a scrollable mobile party picker.
 - Fixed mobile Game Mode choice prompts so large choice sets stay readable and scroll inside the available play area instead of squishing buttons or pushing custom input off-screen.
@@ -82,6 +92,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 - Added explicit Illustrator try-again controls when image generation fails, including a toast action and a persistent Roleplay HUD retry button. ([#797](https://github.com/Pasta-Devs/Marinara-Engine/issues/797))
 - Added Local Model sidecar as a first-class embedding source, including an Embedding Connection option, lorebook vectorization support, and a stable `/api/sidecar/v1/embeddings` endpoint. ([#780](https://github.com/Pasta-Devs/Marinara-Engine/issues/780))
 - Added opt-in Turn Data Access settings for custom post-processing agents so they can receive current-turn pre-generation injections and parallel agent results without exposing that data to existing agents by default. ([#778](https://github.com/Pasta-Devs/Marinara-Engine/issues/778))
+- Added Memory Recall export/import for moving chat recall data between profiles or installs.
+- Added weighted random macro choices for SillyTavern-style random prompt variants.
 - Added a native Appearance background blur slider for Roleplay and Game mode backgrounds. ([#763](https://github.com/Pasta-Devs/Marinara-Engine/issues/763))
 - Added excluded-tag filtering for the character browser, including `-tag:"tag name"` search syntax and exclude toggles in the character tag picker. ([#702](https://github.com/Pasta-Devs/Marinara-Engine/issues/702))
 - Added a server-side autonomous conversation scheduler so enabled characters can generate restrained scheduled messages while the browser poller is absent, with client-presence checks to avoid duplicate client/server generations. ([#698](https://github.com/Pasta-Devs/Marinara-Engine/issues/698))
@@ -125,6 +137,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 - Fixed Game Mode asset generation prompt review, NPC portrait matching, sprite recovery, Professor-name avatar matching, and command-prompt regeneration replay.
 - Fixed Game Session Log flicker, deletion offsets, manual deletion persistence, and dice-roll dismissal when advancing dialogue.
 - Fixed Game Mode weather, storm ambience, sun overlay behavior, CYOA live updates, skill checks, inventory notifications, combat voice audio, mobile party access, tracker refreshes, and tracker edit persistence.
+- Fixed CJK Google font shard loading and scene-summary max-token overrides.
+- Fixed manual chat file deletion persistence and regenerate replay for command prompts.
 - Fixed Conversation disconnection aborts on Docker, markdown block preservation, hidden-message regeneration crashes, Up Arrow recall behavior, role editing, DM schedule inheritance, random connection schedule generation, and connected-chat placeholder branch names.
 - Fixed character avatar uploads preserving unsaved drafts, chat folder click targets, drag reorder behavior, text selection while dragging, folder storage atomicity, and Professor Mari continuation after tool/fetch work.
 - Fixed OpenAI ChatGPT request shape and SSE parsing, compressed provider JSON decoding (`gzip`, raw `gzip`, and Brotli), Gemini gzip decoding, provider identity handling, NovelAI V4 prompt/model handling, ComfyUI numeric workflow placeholders, Horde image endpoints, and Pygmalion avatar content-type fallback.
@@ -155,6 +169,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 - Per-connection max parallel agent job controls, allowing agent-heavy chats to split same-connection work across multiple LLM calls.
 - Editable Game Session History map JSON in the current-session spoiler section.
 - Markdown rendering and live preview for Game journal notes.
+- Tracker Data Sidebar for viewing and editing live tracker data from the side panel.
 - `/emote name="Character" expression="expression"` for listing and manually switching roleplay sprite expressions.
 - Duplicate action for individual prompt preset blocks.
 - Close controls for Game mode choice prompts and quick-time event windows.

--- a/packages/client/src/components/chat/ConversationInput.tsx
+++ b/packages/client/src/components/chat/ConversationInput.tsx
@@ -1569,7 +1569,7 @@ export function ConversationInput({
         onDragLeave={handleDragLeave}
         onDrop={handleDrop}
         className={cn(
-          "relative flex items-center gap-1 rounded-2xl border-2 bg-[var(--card)] px-2 py-1.5 transition-all duration-200 sm:gap-2 sm:px-4 sm:py-2.5 dark:bg-black/40",
+          "relative flex flex-wrap items-end gap-1 rounded-2xl border-2 bg-[var(--card)] px-2 py-1.5 transition-all duration-200 sm:flex-nowrap sm:items-center sm:gap-2 sm:px-4 sm:py-2.5 dark:bg-black/40",
           isDragging ? "border-blue-400/50 bg-blue-500/10 shadow-lg shadow-blue-500/10" : "border-[var(--border)]",
         )}
       >
@@ -1588,7 +1588,7 @@ export function ConversationInput({
         <button
           onClick={() => fileInputRef.current?.click()}
           className={cn(
-            "flex h-11 w-11 items-center justify-center rounded-xl transition-all active:scale-90 sm:h-8 sm:w-8",
+            "order-2 flex h-11 w-11 items-center justify-center rounded-xl transition-all active:scale-90 sm:order-none sm:h-8 sm:w-8",
             attachments.length
               ? "bg-foreground/10 text-foreground/75"
               : "text-foreground/40 hover:bg-foreground/10 hover:text-foreground/70",
@@ -1601,7 +1601,7 @@ export function ConversationInput({
         {/* Quick Switchers — desktop: inline, mobile: chevron */}
         <QuickConnectionSwitcher className="hidden sm:flex" />
         <QuickPersonaSwitcher className="hidden sm:flex" />
-        <div className="sm:hidden">
+        <div className="order-2 sm:hidden">
           <QuickSwitcherMobile />
         </div>
 
@@ -1624,11 +1624,11 @@ export function ConversationInput({
           onInput={handleInput}
           onKeyDown={handleKeyDown}
           onPaste={handlePaste}
-          className="max-h-[12.5rem] min-w-0 flex-1 resize-none bg-transparent py-0 text-[1rem] leading-normal text-[var(--foreground)] outline-none placeholder:text-foreground/30"
+          className="order-1 max-h-[12.5rem] min-w-0 basis-full flex-1 resize-none bg-transparent py-0 text-[1rem] leading-normal text-[var(--foreground)] outline-none placeholder:text-foreground/30 sm:order-none sm:basis-auto"
         />
 
         {/* Right actions */}
-        <div className="flex shrink-0 items-center gap-0.5">
+        <div className="order-2 ml-auto flex min-w-0 flex-1 flex-nowrap items-center justify-end gap-0.5 sm:order-none sm:flex-none sm:shrink-0">
           <div className="relative">
             <button
               ref={gifButtonRef}

--- a/packages/client/src/components/chat/RoleplayHUD.tsx
+++ b/packages/client/src/components/chat/RoleplayHUD.tsx
@@ -29,6 +29,12 @@ import { useAgentConfigs, useCustomAgentRuns, type AgentConfigRow } from "../../
 import { useChat } from "../../hooks/use-chats";
 import { discardPendingGameStatePatch, useGameStatePatcher } from "../../hooks/use-game-state-patcher";
 import { useUIStore } from "../../stores/ui.store";
+import {
+  getTemperatureColor,
+  getTemperatureGaugeDisplay,
+  getTemperatureKeywordHint,
+  parseTemperatureValue,
+} from "../../features/tracker-panel/lib/world-state-display";
 import type {
   GameState,
   PresentCharacter,
@@ -38,7 +44,7 @@ import type {
   CustomTrackerField,
   Message,
 } from "@marinara-engine/shared";
-import type { HudPosition } from "../../stores/ui.store";
+import type { HudPosition, TrackerTemperatureUnit } from "../../stores/ui.store";
 
 const ACTIONS_DROPDOWN_WIDTH_PX = 288;
 
@@ -142,6 +148,7 @@ export function RoleplayHUD({
   const trackerPanelEnabled = useUIStore((s) => s.trackerPanelEnabled);
   const trackerPanelOpen = useUIStore((s) => s.trackerPanelOpen);
   const trackerPanelHideHudWidgets = useUIStore((s) => s.trackerPanelHideHudWidgets);
+  const trackerTemperatureUnit = useUIStore((s) => s.trackerTemperatureUnit);
   const toggleTrackerPanel = useUIStore((s) => s.toggleTrackerPanel);
 
   const isTrackerBusy = isAgentProcessing || isStreaming || gameStateRefreshing;
@@ -269,6 +276,7 @@ export function RoleplayHUD({
               time={time ?? ""}
               weather={weather ?? ""}
               temperature={temperature ?? ""}
+              trackerTemperatureUnit={trackerTemperatureUnit}
               onSaveLocation={(v) => patchField("location", v)}
               onSaveDate={(v) => patchField("date", v)}
               onSaveTime={(v) => patchField("time", v)}
@@ -334,6 +342,7 @@ export function RoleplayHUD({
               time={time ?? ""}
               weather={weather ?? ""}
               temperature={temperature ?? ""}
+              trackerTemperatureUnit={trackerTemperatureUnit}
               onSaveLocation={(v) => patchField("location", v)}
               onSaveDate={(v) => patchField("date", v)}
               onSaveTime={(v) => patchField("time", v)}
@@ -1264,6 +1273,7 @@ function CombinedWorldWidget({
   time,
   weather,
   temperature,
+  trackerTemperatureUnit,
   onSaveLocation,
   onSaveDate,
   onSaveTime,
@@ -1278,6 +1288,7 @@ function CombinedWorldWidget({
   time: string;
   weather: string;
   temperature: string;
+  trackerTemperatureUnit: TrackerTemperatureUnit;
   onSaveLocation: (v: string) => void;
   onSaveDate: (v: string) => void;
   onSaveTime: (v: string) => void;
@@ -1291,18 +1302,10 @@ function CombinedWorldWidget({
   const buttonRef = useRef<HTMLButtonElement>(null);
   const weatherEmoji = weather ? getWeatherEmoji(weather) : "🌤️";
   const pinColor = getLocationPinColor(location);
-  const tempNumeric = temperature ? parseTemperature(temperature) : null;
+  const temperatureDisplay = getTemperatureGaugeDisplay(temperature, trackerTemperatureUnit);
+  const tempNumeric = temperature ? parseTemperatureValue(temperature) : null;
   const temp = tempNumeric ?? (temperature ? getTemperatureKeywordHint(temperature) : null);
-  const tempColor =
-    temp !== null
-      ? temp < 0
-        ? "text-blue-400"
-        : temp < 15
-          ? "text-sky-400"
-          : temp < 30
-            ? "text-amber-400"
-            : "text-red-400"
-      : "text-rose-400/50";
+  const tempColor = getTemperatureColor(temperature);
 
   // Dynamic calendar: show day number
   const dateParts = date ? parseDateLabel(date) : { day: null, month: null };
@@ -1313,10 +1316,9 @@ function CombinedWorldWidget({
   const hourAngle = hour >= 0 ? (hour % 12) * 30 + minute * 0.5 : 0;
   const minuteAngle = minute * 6;
 
-  // Thermometer fill fraction (clamp -20..50°C → 0..1)
-  const tempFill = temp !== null ? Math.max(0, Math.min(1, (temp + 20) / 70)) : 0.3;
-  const tempFillColor =
-    temp !== null ? (temp < 0 ? "#60a5fa" : temp < 15 ? "#38bdf8" : temp < 30 ? "#fbbf24" : "#f87171") : "#fb7185";
+  const tempFill =
+    temperatureDisplay.percent == null ? 0.3 : Math.max(0, Math.min(1, temperatureDisplay.percent / 100));
+  const tempFillColor = temperatureDisplay.color;
 
   return (
     <div className="relative">
@@ -1462,7 +1464,7 @@ function CombinedWorldWidget({
         </svg>
         {tempNumeric !== null && (
           <span className={cn("text-[0.5rem] md:text-[0.5625rem] font-bold leading-none shrink-0", tempColor)}>
-            {tempNumeric}°
+            {temperatureDisplay.label}
           </span>
         )}
       </button>
@@ -1565,26 +1567,6 @@ function getWeatherEmoji(weather: string): string {
   if (w.includes("hot") || w.includes("swelter")) return "🥵";
   if (w.includes("cold") || w.includes("freez")) return "🥶";
   return "🌤️";
-}
-
-function parseTemperature(temp: string): number | null {
-  const m = temp.match(/-?\d+(\.\d+)?/);
-  if (!m) return null;
-  const num = parseFloat(m[0]!);
-  if (/°?\s*f/i.test(temp)) return Math.round((num - 32) * (5 / 9));
-  return Math.round(num);
-}
-
-/** Map descriptive temperature words to a numeric-equivalent hint (°C). */
-function getTemperatureKeywordHint(text: string): number | null {
-  const t = text.toLowerCase();
-  if (/\b(freez|frigid|arctic|glacial|sub-?zero|blizzard)/.test(t)) return -10;
-  if (/\b(cold|chill|frost|wintry|icy|bitter|nipp)/.test(t)) return 2;
-  if (/\b(cool|brisk|crisp|refresh)/.test(t)) return 12;
-  if (/\b(mild|pleasant|comfort|temperate|fair)/.test(t)) return 20;
-  if (/\b(warm|balmy|toasty|muggy|humid|stuffy|sultry)/.test(t)) return 28;
-  if (/\b(hot|swelter|blaz|scorch|burn|heat|boil|sear|bak)/.test(t)) return 38;
-  return null;
 }
 
 /** Categorise location text into a colour for the map-pin icon. */

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -631,7 +631,7 @@ function TrackerPanelAppearanceDrawer({
           <div className="mt-2 flex min-h-8 items-center justify-between gap-2">
             <span className="inline-flex items-center gap-1 text-[0.6875rem] font-medium">
               Temperature unit
-              <HelpTooltip text="Only changes the Tracker Panel display. It does not rewrite the saved world-state temperature or affect the older HUD widgets." />
+              <HelpTooltip text="Changes Tracker Panel and roleplay HUD temperature displays without rewriting the saved world-state temperature." />
             </span>
             <button
               type="button"

--- a/packages/client/src/components/panels/settings/TrackerCardColorSettings.tsx
+++ b/packages/client/src/components/panels/settings/TrackerCardColorSettings.tsx
@@ -23,6 +23,8 @@ import {
 } from "../../../lib/tracker-card-colors";
 import { useTrackerGameState } from "../../../features/tracker-panel/hooks/use-tracker-game-state";
 import {
+  addAliasLookups,
+  addExactNameLookups,
   normalizeLookupText,
   normalizeMaybeJsonStringArray,
 } from "../../../features/tracker-panel/lib/tracker-metadata";
@@ -234,14 +236,21 @@ export function TrackerCardColorSettings() {
       : [];
     const charactersById = new Map(characterRows.map((character) => [character.id, character]));
     const idByLookupText = new Map<string, string>();
+    const activeChatCharacterIds = normalizeMaybeJsonStringArray(
+      (activeChat as { characterIds?: unknown } | null | undefined)?.characterIds,
+    );
+    const activeChatCharacterIdSet = new Set(activeChatCharacterIds);
+    const displayRows = characterRows.map((character) => ({
+      character,
+      display: parseCharacterDisplayData(character),
+    }));
+    const chatDisplayRows = displayRows.filter(({ character }) => activeChatCharacterIdSet.has(character.id));
+    const fallbackDisplayRows = displayRows.filter(({ character }) => !activeChatCharacterIdSet.has(character.id));
 
-    for (const character of characterRows) {
-      const display = parseCharacterDisplayData(character);
-      const nameKey = normalizeLookupText(display.name);
-      const commentKey = normalizeLookupText(display.comment);
-      if (nameKey && !idByLookupText.has(nameKey)) idByLookupText.set(nameKey, character.id);
-      if (commentKey && !idByLookupText.has(commentKey)) idByLookupText.set(commentKey, character.id);
-    }
+    addExactNameLookups(chatDisplayRows, idByLookupText);
+    addAliasLookups(chatDisplayRows, idByLookupText);
+    addExactNameLookups(fallbackDisplayRows, idByLookupText);
+    addAliasLookups(fallbackDisplayRows, idByLookupText);
 
     const nextTargets: TrackerCardColorTarget[] = [];
     const chatPersonaId =
@@ -278,9 +287,6 @@ export function TrackerCardColorSettings() {
     }
 
     const presentCharacterIds = new Set<string>();
-    const activeChatCharacterIds = normalizeMaybeJsonStringArray(
-      (activeChat as { characterIds?: unknown } | null | undefined)?.characterIds,
-    );
     for (const id of activeChatCharacterIds) {
       if (charactersById.has(id)) presentCharacterIds.add(id);
     }

--- a/packages/client/src/features/tracker-panel/hooks/use-tracker-sprite-lookup.ts
+++ b/packages/client/src/features/tracker-panel/hooks/use-tracker-sprite-lookup.ts
@@ -4,7 +4,7 @@ import { useCharacters } from "../../../hooks/use-characters";
 import { parseCharacterDisplayData } from "../../../lib/character-display";
 import type { TrackerSpriteLookup } from "../tracker-panel.types";
 import { isSpriteLookupCharacterId } from "../lib/sprite-expressions";
-import { normalizeLookupText } from "../lib/tracker-metadata";
+import { addAliasLookups, addExactNameLookups, normalizeLookupText } from "../lib/tracker-metadata";
 import { getCharacterProfileColors } from "../lib/tracker-profile-style";
 
 interface UseTrackerSpriteLookupOptions {
@@ -29,16 +29,21 @@ export function useTrackerSpriteLookup({ enabled, chatCharacterIds }: UseTracker
     const idByName = new Map<string, string>();
     const pictureById: Record<string, string> = {};
     const profileColorsById: TrackerSpriteLookup["profileColorsById"] = {};
+    const displayRows = orderedRows.map((character) => ({
+      character,
+      display: parseCharacterDisplayData(character),
+    }));
+    const chatDisplayRows = displayRows.filter(({ character }) => chatIdSet.has(character.id));
+    const fallbackDisplayRows = displayRows.filter(({ character }) => !chatIdSet.has(character.id));
     for (const character of orderedRows) {
       if (character.avatarPath) pictureById[character.id] = character.avatarPath;
       const profileColors = getCharacterProfileColors(character.data);
       if (profileColors) profileColorsById[character.id] = profileColors;
-      const display = parseCharacterDisplayData(character);
-      const nameKey = normalizeLookupText(display.name);
-      if (nameKey && !idByName.has(nameKey)) idByName.set(nameKey, character.id);
-      const commentKey = normalizeLookupText(display.comment);
-      if (commentKey && !idByName.has(commentKey)) idByName.set(commentKey, character.id);
     }
+    addExactNameLookups(chatDisplayRows, idByName);
+    addAliasLookups(chatDisplayRows, idByName);
+    addExactNameLookups(fallbackDisplayRows, idByName);
+    addAliasLookups(fallbackDisplayRows, idByName);
     return { knownIds, idByName, pictureById, profileColorsById };
   }, [charactersData, chatCharacterIds]);
 

--- a/packages/client/src/features/tracker-panel/lib/tracker-metadata.ts
+++ b/packages/client/src/features/tracker-panel/lib/tracker-metadata.ts
@@ -1,3 +1,10 @@
+import { getCharacterLookupAliases, type CharacterDisplayInfo } from "../../../lib/character-display";
+
+export interface CharacterLookupDisplayRow {
+  character: { id: string };
+  display: CharacterDisplayInfo;
+}
+
 export function parseMetadataRecord(raw: unknown): Record<string, unknown> {
   if (!raw) return {};
   if (typeof raw === "string") {
@@ -50,4 +57,28 @@ export function normalizeMaybeJsonStringArray(value: unknown): string[] {
 
 export function normalizeLookupText(value: string | null | undefined) {
   return (value ?? "").trim().toLowerCase();
+}
+
+export function addExactNameLookups(
+  candidates: readonly CharacterLookupDisplayRow[],
+  idByLookupText: Map<string, string>,
+) {
+  for (const { character, display } of candidates) {
+    const nameKey = normalizeLookupText(display.name);
+    if (nameKey && !idByLookupText.has(nameKey)) idByLookupText.set(nameKey, character.id);
+  }
+}
+
+export function addAliasLookups(
+  candidates: readonly CharacterLookupDisplayRow[],
+  idByLookupText: Map<string, string>,
+) {
+  for (const { character, display } of candidates) {
+    const nameKey = normalizeLookupText(display.name);
+    for (const alias of getCharacterLookupAliases(display)) {
+      const aliasKey = normalizeLookupText(alias);
+      if (aliasKey === nameKey) continue;
+      if (aliasKey && !idByLookupText.has(aliasKey)) idByLookupText.set(aliasKey, character.id);
+    }
+  }
 }

--- a/packages/client/src/lib/character-display.ts
+++ b/packages/client/src/lib/character-display.ts
@@ -3,9 +3,49 @@ export interface CharacterDisplayInfo {
   comment?: string | null;
 }
 
+const LOOKUP_ALIAS_SEPARATOR = /\s+(?:-|\/|\||:|\u2013|\u2014)\s+/;
+const LOOKUP_ALIAS_PARENS = /\(([^)]{1,96})\)|\[([^\]]{1,96})\]/g;
+const LOOKUP_ALIAS_EDGE_PUNCTUATION = /^[\s"'([{]+|[\s"')\]}.,:;]+$/g;
+
+function addLookupAlias(aliases: string[], seen: Set<string>, value: string | null | undefined) {
+  const alias = (value ?? "").replace(/\s+/g, " ").replace(LOOKUP_ALIAS_EDGE_PUNCTUATION, "").trim();
+  if (!alias || alias.length > 96) return;
+  const key = alias.toLowerCase();
+  if (seen.has(key)) return;
+  seen.add(key);
+  aliases.push(alias);
+}
+
+function addLeadingLookupAlias(aliases: string[], seen: Set<string>, value: string | null | undefined) {
+  const [leadingAlias] = (value ?? "").split(LOOKUP_ALIAS_SEPARATOR);
+  addLookupAlias(aliases, seen, leadingAlias);
+}
+
 export function getCharacterTitle(character: CharacterDisplayInfo | null | undefined): string | null {
   const title = typeof character?.comment === "string" ? character.comment.trim() : "";
   return title || null;
+}
+
+export function getCharacterLookupAliases(character: CharacterDisplayInfo | null | undefined): string[] {
+  const aliases: string[] = [];
+  const seen = new Set<string>();
+
+  addLookupAlias(aliases, seen, character?.name);
+
+  const title = getCharacterTitle(character);
+  if (!title) return aliases;
+
+  addLookupAlias(aliases, seen, title);
+
+  for (const match of title.matchAll(LOOKUP_ALIAS_PARENS)) {
+    addLookupAlias(aliases, seen, match[1] ?? match[2]);
+  }
+
+  const withoutParenthetical = title.replace(LOOKUP_ALIAS_PARENS, " ");
+  addLookupAlias(aliases, seen, withoutParenthetical);
+  addLeadingLookupAlias(aliases, seen, withoutParenthetical);
+
+  return aliases;
 }
 
 export function parseCharacterDisplayData(raw: { data: unknown; comment?: string | null }): CharacterDisplayInfo {

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -304,9 +304,19 @@ const CREATE_TABLES: string[] = [
     id TEXT PRIMARY KEY NOT NULL,
     agent_config_id TEXT NOT NULL REFERENCES agent_configs(id),
     chat_id TEXT NOT NULL,
+    character_id TEXT,
+    memory_type TEXT NOT NULL DEFAULT 'legacy_kv',
     key TEXT NOT NULL,
     value TEXT NOT NULL DEFAULT '',
-    updated_at TEXT NOT NULL
+    title TEXT,
+    content TEXT NOT NULL DEFAULT '',
+    metadata TEXT NOT NULL DEFAULT '{}',
+    embedding TEXT,
+    content_hash TEXT,
+    enabled TEXT NOT NULL DEFAULT 'true',
+    created_at TEXT NOT NULL DEFAULT '',
+    updated_at TEXT NOT NULL,
+    deleted_at TEXT
   )`,
   `CREATE TABLE IF NOT EXISTS custom_tools (
     id TEXT PRIMARY KEY NOT NULL,
@@ -674,6 +684,56 @@ const COLUMN_MIGRATIONS: ColumnMigration[] = [
     definition: "TEXT NOT NULL DEFAULT ''",
   },
   {
+    table: "agent_memory",
+    column: "character_id",
+    definition: "TEXT",
+  },
+  {
+    table: "agent_memory",
+    column: "memory_type",
+    definition: "TEXT NOT NULL DEFAULT 'legacy_kv'",
+  },
+  {
+    table: "agent_memory",
+    column: "title",
+    definition: "TEXT",
+  },
+  {
+    table: "agent_memory",
+    column: "content",
+    definition: "TEXT NOT NULL DEFAULT ''",
+  },
+  {
+    table: "agent_memory",
+    column: "metadata",
+    definition: "TEXT NOT NULL DEFAULT '{}'",
+  },
+  {
+    table: "agent_memory",
+    column: "embedding",
+    definition: "TEXT",
+  },
+  {
+    table: "agent_memory",
+    column: "content_hash",
+    definition: "TEXT",
+  },
+  {
+    table: "agent_memory",
+    column: "enabled",
+    definition: "TEXT NOT NULL DEFAULT 'true'",
+  },
+  {
+    table: "agent_memory",
+    column: "created_at",
+    definition: "TEXT NOT NULL DEFAULT ''",
+  },
+  {
+    table: "agent_memory",
+    column: "deleted_at",
+    definition: "TEXT",
+  },
+  {
     table: "lorebook_entries",
     column: "folder_id",
     definition: "TEXT",
@@ -872,6 +932,11 @@ export async function runMigrations(db: DB) {
     sql.raw(
       `CREATE INDEX IF NOT EXISTS idx_character_card_versions ON character_card_versions(character_id, created_at DESC)`,
     ),
+  );
+  await db.run(sql.raw(`CREATE INDEX IF NOT EXISTS idx_agent_memory_chat ON agent_memory(chat_id, updated_at DESC)`));
+  await db.run(sql.raw(`CREATE INDEX IF NOT EXISTS idx_agent_memory_deleted ON agent_memory(deleted_at) WHERE deleted_at IS NULL`));
+  await db.run(
+    sql.raw(`CREATE INDEX IF NOT EXISTS idx_agent_memory_character_type ON agent_memory(character_id, memory_type)`),
   );
   await db.run(sql.raw(`CREATE INDEX IF NOT EXISTS idx_custom_themes_active ON custom_themes(is_active)`));
   await db.run(sql.raw(`CREATE INDEX IF NOT EXISTS idx_chat_presets_mode_active ON chat_presets(mode, is_active)`));

--- a/packages/server/src/db/schema/agents.ts
+++ b/packages/server/src/db/schema/agents.ts
@@ -42,7 +42,17 @@ export const agentMemory = sqliteTable("agent_memory", {
     .notNull()
     .references(() => agentConfigs.id),
   chatId: text("chat_id").notNull(),
+  characterId: text("character_id"),
+  memoryType: text("memory_type").notNull().default("legacy_kv"),
   key: text("key").notNull(),
   value: text("value").notNull().default(""),
+  title: text("title"),
+  content: text("content").notNull().default(""),
+  metadata: text("metadata").notNull().default("{}"),
+  embedding: text("embedding"),
+  contentHash: text("content_hash"),
+  enabled: text("enabled").notNull().default("true"),
+  createdAt: text("created_at").notNull().default(""),
   updatedAt: text("updated_at").notNull(),
+  deletedAt: text("deleted_at"),
 });

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -8891,10 +8891,14 @@ export async function generateRoutes(app: FastifyInstance) {
                 const ctData = result.data as Record<string, unknown>;
                 const chars = (ctData.presentCharacters as any[]) ?? [];
                 const snapBeforeUpdate = await gameStateStore.getByMessage(messageId, targetSwipeIndex);
-                const oldChars: any[] = snapBeforeUpdate?.presentCharacters
-                  ? typeof snapBeforeUpdate.presentCharacters === "string"
-                    ? JSON.parse(snapBeforeUpdate.presentCharacters)
-                    : snapBeforeUpdate.presentCharacters
+                const previousCharacterSnapshot =
+                  snapBeforeUpdate ??
+                  baseGameStateSnapshot ??
+                  (allowLatestGameStateFallback ? await gameStateStore.getLatest(input.chatId) : null);
+                const oldChars: any[] = previousCharacterSnapshot?.presentCharacters
+                  ? typeof previousCharacterSnapshot.presentCharacters === "string"
+                    ? JSON.parse(previousCharacterSnapshot.presentCharacters)
+                    : previousCharacterSnapshot.presentCharacters
                   : [];
                 preserveTrackerCharacterUiFields(chars, oldChars);
 

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -216,6 +216,7 @@ import {
   normalizeSecretPlotSceneDirections,
   normalizeStringArray,
 } from "./generate/agent-normalizers.js";
+import { persistSecretPlotMemory } from "./generate/secret-plot-memory.js";
 import {
   buildGenerationPromptPresetCandidates,
   type PromptPresetCandidateSource,
@@ -4030,11 +4031,21 @@ export async function generateRoutes(app: FastifyInstance) {
             }
           }
 
+          const runtimePhase = cfg.type === "secret-plot-driver" ? "pre_generation" : (cfg.phase as string);
+          if (cfg.type === "secret-plot-driver" && cfg.phase !== runtimePhase) {
+            logger.warn(
+              "[secret-plot-driver] Stored phase %s is stale for chat %s; running as %s",
+              cfg.phase,
+              input.chatId,
+              runtimePhase,
+            );
+          }
+
           resolvedAgents.push({
             id: cfg.id,
             type: cfg.type,
             name: cfg.name,
-            phase: cfg.phase as string,
+            phase: runtimePhase,
             promptTemplate: cfg.promptTemplate as string,
             connectionId: effectiveConnectionId,
             settings,
@@ -5855,8 +5866,25 @@ export async function generateRoutes(app: FastifyInstance) {
         // navigated away), a write error must NOT crash the agent pipeline —
         // otherwise Promise.allSettled in executePhase silently drops the
         // entire group's results, causing agents to appear as "not triggered".
+        const secretPlotMemoryWrites: Promise<void>[] = [];
         const sendAgentEvent = (result: AgentResult) => {
           if (shouldDeferSpotifyAgentEvent(result)) return;
+          if (result.success && result.type === "secret_plot" && result.data && typeof result.data === "object") {
+            const agentConfigId =
+              resolvedAgents.find((agent) => agent.type === "secret-plot-driver")?.id ?? result.agentId ?? null;
+            secretPlotMemoryWrites.push(
+              persistSecretPlotMemory({
+                agentsStore,
+                agentConfigId,
+                chatId: input.chatId,
+                plotData: result.data as Record<string, unknown>,
+                clearMissingSceneDirections: true,
+                source: "generation",
+              }).catch((err) => {
+                logger.error(err, "[secret-plot-driver] Failed to persist state from generation");
+              }),
+            );
+          }
           trySendSseEvent(reply, {
             type: "agent_result",
             data: {
@@ -6087,6 +6115,14 @@ export async function generateRoutes(app: FastifyInstance) {
             logger.debug("[spotify] Omitted unavailable Spotify tools from main generation");
           }
         }
+        const agentMemoryToolNames = new Set([
+          "save_agent_memory",
+          "search_agent_memory",
+          "list_agent_memory",
+          "delete_agent_memory",
+        ]);
+        const mainGenerationToolDefs = toolDefs?.filter((td) => !agentMemoryToolNames.has(td.function.name));
+        const mainResolvedToolNames = new Set((mainGenerationToolDefs ?? []).map((td) => td.function.name));
         const searchLorebookForTools = async (query: string, category?: string | null) => {
           const entries = await lorebooksStore.listActiveEntries({
             chatId: input.chatId,
@@ -6130,6 +6166,9 @@ export async function generateRoutes(app: FastifyInstance) {
         };
         const baseToolExecutionContext = {
           gameState: gameState ? (gameState as unknown as Record<string, unknown>) : undefined,
+          chatId: input.chatId,
+          activeCharacters: charInfo.map((character) => ({ id: character.id, name: character.name })),
+          agentMemory: agentsStore,
           customTools: customToolDefs,
           spotify: spotifyCreds,
           spotifyRepeatAfterPlay: gameSpotifyMusicEnabled ? ("track" as const) : undefined,
@@ -6190,6 +6229,11 @@ export async function generateRoutes(app: FastifyInstance) {
               }
               const results = await executeToolCalls([call], {
                 ...baseToolExecutionContext,
+                agentConfigId: agent.id,
+                agentMemoryScope:
+                  typeof agentSettings.memoryScope === "string" && agentSettings.memoryScope.trim()
+                    ? agentSettings.memoryScope.trim()
+                    : null,
               });
               const result = results[0]?.result ?? "Tool execution failed";
               if (agent.type === "spotify" && call.function.name === "spotify_play") {
@@ -6493,6 +6537,25 @@ export async function generateRoutes(app: FastifyInstance) {
             logger.warn(`[pre-gen] Non-critical agent(s) failed (${failedNames}) — continuing generation`);
           }
 
+          // Secret Plot Driver stores structured state for both the UI panel and
+          // the next prompt. Persist from the completed pre-gen result before any
+          // later branch can return early.
+          const plotResult = preGenResults.find((r) => r.type === "secret_plot");
+          if (plotResult?.success && plotResult.data && typeof plotResult.data === "object") {
+            try {
+              await persistSecretPlotMemory({
+                agentsStore,
+                agentConfigId: secretPlotAgent?.id ?? plotResult.agentId,
+                chatId: input.chatId,
+                plotData: plotResult.data as Record<string, unknown>,
+                clearMissingSceneDirections: true,
+                source: "pre_generation",
+              });
+            } catch (persistErr) {
+              logger.error(persistErr, "[secret-plot-driver] Failed to persist state from pre_generation");
+            }
+          }
+
           const shouldReviewWriterAgentOutputs =
             (chatMode === "roleplay" || chatMode === "visual_novel") &&
             chatMeta.reviewWriterAgentOutputs === true &&
@@ -6517,50 +6580,8 @@ export async function generateRoutes(app: FastifyInstance) {
             return;
           }
 
-          // ── Secret Plot Driver: persist fresh state + build injection ──
-          const plotResult = preGenResults.find((r) => r.type === "secret_plot");
-          if (plotResult?.success && plotResult.data && typeof plotResult.data === "object") {
-            const plotData = plotResult.data as Record<string, unknown>;
-            const agentConfigId = secretPlotAgent?.id ?? plotResult.agentId;
-
-            // Persist to agent memory so swipes/regens read from it
-            try {
-              if (plotData.overarchingArc) {
-                await agentsStore.setMemory(agentConfigId, input.chatId, "overarchingArc", plotData.overarchingArc);
-              }
-              if (plotData.sceneDirections) {
-                const allDirections = normalizeSecretPlotSceneDirections(plotData.sceneDirections);
-                const active = allDirections.filter((d) => !d.fulfilled);
-                const justFulfilled = allDirections.filter((d) => d.fulfilled).map((d) => d.direction);
-                await agentsStore.setMemory(agentConfigId, input.chatId, "sceneDirections", active);
-
-                // Keep a rolling window of recently fulfilled directions so the agent doesn't repeat them
-                if (justFulfilled.length > 0) {
-                  const mem = await agentsStore.getMemory(agentConfigId, input.chatId);
-                  const prev = normalizeStringArray(mem.recentlyFulfilled);
-                  const merged = [...prev, ...justFulfilled].slice(-10); // keep last 10
-                  await agentsStore.setMemory(agentConfigId, input.chatId, "recentlyFulfilled", merged);
-                }
-              } else {
-                // Agent didn't return new directions — clear stale ones so fulfilled
-                // directions from the previous turn aren't re-injected into the prompt
-                await agentsStore.setMemory(agentConfigId, input.chatId, "sceneDirections", []);
-              }
-              if (plotData.pacing) {
-                await agentsStore.setMemory(agentConfigId, input.chatId, "pacing", plotData.pacing);
-              }
-              await agentsStore.setMemory(
-                agentConfigId,
-                input.chatId,
-                "staleDetected",
-                plotData.staleDetected ?? false,
-              );
-              logger.debug(
-                `[secret-plot-driver] Persisted pre-gen state — arc: ${plotData.overarchingArc ? "updated" : "unchanged"}, directions: ${Array.isArray(plotData.sceneDirections) ? (plotData.sceneDirections as any[]).filter((d: any) => !d.fulfilled).length : 0} active, pacing: ${plotData.pacing ?? "unknown"}`,
-              );
-            } catch (persistErr) {
-              logger.error(persistErr, "[secret-plot-driver] Failed to persist state");
-            }
+          if (secretPlotMemoryWrites.length > 0) {
+            await Promise.all(secretPlotMemoryWrites);
           }
 
           const runtimeHandledPreGen = splitRuntimeHandledAgentInjections(
@@ -7286,7 +7307,7 @@ export async function generateRoutes(app: FastifyInstance) {
           const fitPromptForSend = (candidateMessages: ChatMessage[]): ChatMessage[] => {
             const fit = fitMessagesToContext(
               candidateMessages,
-              { maxContext: effectiveMaxContext, maxTokens, tools: toolDefs },
+              { maxContext: effectiveMaxContext, maxTokens, tools: mainGenerationToolDefs },
               connectionMaxContext,
             );
             finalPromptSent = fit.messages;
@@ -7443,7 +7464,7 @@ export async function generateRoutes(app: FastifyInstance) {
                     topK: providerTopK,
                     frequencyPenalty: frequencyPenalty || undefined,
                     presencePenalty: presencePenalty || undefined,
-                    tools: toolDefs,
+                    tools: mainGenerationToolDefs,
                     enableCaching: conn.enableCaching === "true",
                     cachingAtDepth: conn.cachingAtDepth ?? 5,
                     enableThinking,
@@ -7512,16 +7533,16 @@ export async function generateRoutes(app: FastifyInstance) {
                 });
 
                 const permittedToolCalls = result.toolCalls.filter((call) =>
-                  chatResolvedToolNames.has(call.function.name),
+                  mainResolvedToolNames.has(call.function.name),
                 );
                 const deniedToolResults = result.toolCalls
-                  .filter((call) => !chatResolvedToolNames.has(call.function.name))
+                  .filter((call) => !mainResolvedToolNames.has(call.function.name))
                   .map((call) => ({
                     toolCallId: call.id,
                     name: call.function.name,
                     result: JSON.stringify({
                       error: `Tool not allowed in this context: ${call.function.name}`,
-                      allowed: Array.from(chatResolvedToolNames),
+                      allowed: Array.from(mainResolvedToolNames),
                     }),
                     success: false,
                   }));

--- a/packages/server/src/routes/generate/generate-route-utils.ts
+++ b/packages/server/src/routes/generate/generate-route-utils.ts
@@ -565,14 +565,31 @@ export function wrapFields(
   return parts;
 }
 
+function trackerCharacterIdKey(character: Record<string, unknown>) {
+  return typeof character.characterId === "string" ? character.characterId.trim().toLowerCase() : "";
+}
+
+function trackerCharacterNameKey(character: Record<string, unknown>) {
+  return typeof character.name === "string" ? character.name.trim().toLowerCase() : "";
+}
+
 function trackerCharacterKey(character: Record<string, unknown>) {
-  const id = typeof character.characterId === "string" ? character.characterId.trim().toLowerCase() : "";
-  const name = typeof character.name === "string" ? character.name.trim().toLowerCase() : "";
-  return id || name || null;
+  return trackerCharacterIdKey(character) || trackerCharacterNameKey(character) || null;
+}
+
+function isNpcTrackerAvatarPath(value: unknown): value is string {
+  return typeof value === "string" && value.trim().startsWith("/api/avatars/npc/");
 }
 
 export function isManualTrackerCharacterId(value: unknown): boolean {
   return typeof value === "string" && value.trim().startsWith("manual-");
+}
+
+function canUseManualTrackerNameFallback(character: Record<string, unknown>) {
+  const id = trackerCharacterIdKey(character);
+  if (!id || isManualTrackerCharacterId(id)) return true;
+  const name = trackerCharacterNameKey(character);
+  return !!name && id === name;
 }
 
 export function preserveTrackerCharacterUiFields(
@@ -580,17 +597,36 @@ export function preserveTrackerCharacterUiFields(
   previousCharacters: Array<Record<string, unknown>>,
 ): void {
   const previousByKey = new Map<string, Record<string, unknown>>();
+  const previousManualByName = new Map<string, Record<string, unknown>>();
+  const previousNameCounts = new Map<string, number>();
   for (const character of previousCharacters) {
     const key = trackerCharacterKey(character);
     if (key) previousByKey.set(key, character);
+    const name = trackerCharacterNameKey(character);
+    if (name) previousNameCounts.set(name, (previousNameCounts.get(name) ?? 0) + 1);
+    if (name && isManualTrackerCharacterId(character.characterId)) {
+      previousManualByName.set(name, character);
+    }
   }
 
   for (const character of nextCharacters) {
     const key = trackerCharacterKey(character);
-    const previous = key ? previousByKey.get(key) : null;
+    const name = trackerCharacterNameKey(character);
+    const previous =
+      (key ? previousByKey.get(key) : null) ??
+      (name && previousNameCounts.get(name) === 1 && canUseManualTrackerNameFallback(character)
+        ? previousManualByName.get(name)
+        : null);
     const previousPortraitFocusX = previous?.portraitFocusX;
     const previousPortraitFocusY = previous?.portraitFocusY;
     const previousPortraitZoom = previous?.portraitZoom;
+    const previousAvatarPath = previous?.avatarPath;
+    if (
+      (typeof character.avatarPath !== "string" || !character.avatarPath.trim()) &&
+      isNpcTrackerAvatarPath(previousAvatarPath)
+    ) {
+      character.avatarPath = previousAvatarPath.trim();
+    }
     if (
       (typeof character.portraitFocusX !== "number" || !Number.isFinite(character.portraitFocusX)) &&
       typeof previousPortraitFocusX === "number" &&

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -65,11 +65,8 @@ import {
   normalizeSpriteDisplayModes,
   validateSpriteExpressionEntries,
 } from "./expression-agent-utils.js";
-import {
-  normalizeContextInjections,
-  normalizeSecretPlotSceneDirections,
-  normalizeStringArray,
-} from "./agent-normalizers.js";
+import { normalizeContextInjections } from "./agent-normalizers.js";
+import { persistSecretPlotMemory } from "./secret-plot-memory.js";
 import { executeToolCalls, type MetadataPatchInput } from "../../services/tools/tool-executor.js";
 
 type PersonaContext = {
@@ -1564,39 +1561,21 @@ async function applyRetryResultEffects(args: {
     }
 
     if (result.success && result.type === "secret_plot" && result.data && typeof result.data === "object") {
+      const agentConfigId =
+        resolvedAgents.find((entry) => entry.resolved.type === "secret-plot-driver")?.resolved.id ??
+        result.agentId ??
+        null;
       try {
-        const plotData = result.data as Record<string, unknown>;
-        const agentConfigId =
-          resolvedAgents.find((entry) => entry.resolved.type === "secret-plot-driver")?.resolved.id ?? null;
-        if (agentConfigId) {
-          // Turn-only re-run should preserve long-running arc memory while refreshing
-          // per-turn guidance (scene directions/pacing/stale flags).
-          if (secretPlotRerollMode !== "turn_only" && plotData.overarchingArc !== undefined) {
-            await agentsStore.setMemory(agentConfigId, chatId, "overarchingArc", plotData.overarchingArc ?? null);
-          }
-          if (plotData.sceneDirections !== undefined) {
-            const allDirections = normalizeSecretPlotSceneDirections(plotData.sceneDirections);
-            const active = allDirections.filter((d) => !d.fulfilled);
-            const justFulfilled = allDirections.filter((d) => d.fulfilled).map((d) => d.direction);
-            await agentsStore.setMemory(agentConfigId, chatId, "sceneDirections", active);
-            if (justFulfilled.length > 0) {
-              const mem = await agentsStore.getMemory(agentConfigId, chatId);
-              const prev = normalizeStringArray(mem.recentlyFulfilled);
-              await agentsStore.setMemory(
-                agentConfigId,
-                chatId,
-                "recentlyFulfilled",
-                [...prev, ...justFulfilled].slice(-10),
-              );
-            }
-          }
-          if (plotData.pacing !== undefined) {
-            await agentsStore.setMemory(agentConfigId, chatId, "pacing", plotData.pacing ?? null);
-          }
-          await agentsStore.setMemory(agentConfigId, chatId, "staleDetected", plotData.staleDetected === true);
-        }
-      } catch {
-        // Non-critical patching failure.
+        await persistSecretPlotMemory({
+          agentsStore,
+          agentConfigId,
+          chatId,
+          plotData: result.data as Record<string, unknown>,
+          preserveOverarchingArc: secretPlotRerollMode === "turn_only",
+          source: "retry_agents",
+        });
+      } catch (err) {
+        logger.error(err, "[secret-plot-driver] Failed to persist state from retry_agents");
       }
     }
 

--- a/packages/server/src/routes/generate/secret-plot-memory.ts
+++ b/packages/server/src/routes/generate/secret-plot-memory.ts
@@ -1,0 +1,64 @@
+import { logger } from "../../lib/logger.js";
+import { createAgentsStorage } from "../../services/storage/agents.storage.js";
+import { normalizeSecretPlotSceneDirections, normalizeStringArray } from "./agent-normalizers.js";
+
+type AgentsStore = ReturnType<typeof createAgentsStorage>;
+
+export async function persistSecretPlotMemory(args: {
+  agentsStore: AgentsStore;
+  agentConfigId: string | null | undefined;
+  chatId: string;
+  plotData: Record<string, unknown>;
+  preserveOverarchingArc?: boolean;
+  clearMissingSceneDirections?: boolean;
+  source: string;
+}) {
+  const {
+    agentsStore,
+    agentConfigId,
+    chatId,
+    plotData,
+    preserveOverarchingArc = false,
+    clearMissingSceneDirections = false,
+    source,
+  } = args;
+
+  if (!agentConfigId) {
+    logger.warn("[secret-plot-driver] Could not persist state from %s: missing agent config id", source);
+    return;
+  }
+
+  let activeDirections = 0;
+  if (!preserveOverarchingArc && plotData.overarchingArc !== undefined) {
+    await agentsStore.setMemory(agentConfigId, chatId, "overarchingArc", plotData.overarchingArc ?? null);
+  }
+
+  if (plotData.sceneDirections !== undefined) {
+    const allDirections = normalizeSecretPlotSceneDirections(plotData.sceneDirections);
+    const active = allDirections.filter((direction) => !direction.fulfilled);
+    const justFulfilled = allDirections.filter((direction) => direction.fulfilled).map((direction) => direction.direction);
+    activeDirections = active.length;
+    await agentsStore.setMemory(agentConfigId, chatId, "sceneDirections", active);
+
+    if (justFulfilled.length > 0) {
+      const mem = await agentsStore.getMemory(agentConfigId, chatId);
+      const prev = normalizeStringArray(mem.recentlyFulfilled);
+      await agentsStore.setMemory(agentConfigId, chatId, "recentlyFulfilled", [...prev, ...justFulfilled].slice(-10));
+    }
+  } else if (clearMissingSceneDirections) {
+    await agentsStore.setMemory(agentConfigId, chatId, "sceneDirections", []);
+  }
+
+  if (plotData.pacing !== undefined) {
+    await agentsStore.setMemory(agentConfigId, chatId, "pacing", plotData.pacing ?? null);
+  }
+  await agentsStore.setMemory(agentConfigId, chatId, "staleDetected", plotData.staleDetected === true);
+
+  logger.info(
+    "[secret-plot-driver] Persisted state from %s: arc=%s directions=%d pacing=%s",
+    source,
+    plotData.overarchingArc !== undefined && !preserveOverarchingArc ? "updated" : "unchanged",
+    activeDirections,
+    String(plotData.pacing ?? "unknown"),
+  );
+}

--- a/packages/server/src/services/storage/agents.storage.ts
+++ b/packages/server/src/services/storage/agents.storage.ts
@@ -1,7 +1,8 @@
 // ──────────────────────────────────────────────
 // Storage: Agent Configs, Runs & Memory
 // ──────────────────────────────────────────────
-import { eq, and, desc } from "drizzle-orm";
+import { eq, and, desc, isNull, ne, sql } from "drizzle-orm";
+import { createHash } from "node:crypto";
 import type { DB } from "../../db/connection.js";
 import { agentConfigs, agentRuns, agentMemory } from "../../db/schema/index.js";
 import { newId, now } from "../../utils/id-generator.js";
@@ -13,9 +14,61 @@ import {
 } from "@marinara-engine/shared";
 
 const BUILTIN_AGENT_ID_PREFIX = "builtin:";
+const SECRET_PLOT_MEMORY_TYPE = "secret_plot_internal";
 const BUILT_IN_AGENT_TYPES = new Set(BUILT_IN_AGENTS.map((agent) => agent.id));
 type AgentRunRow = typeof agentRuns.$inferSelect;
 type AgentConfigRow = typeof agentConfigs.$inferSelect;
+type AgentMemoryRow = typeof agentMemory.$inferSelect;
+
+export interface AgentMemoryRecord {
+  id: string;
+  agentConfigId: string;
+  chatId: string;
+  characterId: string | null;
+  memoryScope: string | null;
+  memoryType: string;
+  key: string;
+  value: string;
+  title: string | null;
+  content: string;
+  metadata: Record<string, unknown>;
+  embedding: number[] | null;
+  contentHash: string | null;
+  enabled: boolean;
+  createdAt: string;
+  updatedAt: string;
+  deletedAt: string | null;
+}
+
+export interface AgentMemoryFilters {
+  chatId?: string | null;
+  characterId?: string | null;
+  agentConfigId?: string | null;
+  memoryScope?: string | null;
+  memoryType?: string | null;
+  includeInternal?: boolean;
+  includeDeleted?: boolean;
+  includeDisabled?: boolean;
+}
+
+export interface SaveAgentMemoryInput {
+  recordId?: string | null;
+  agentConfigId: string;
+  chatId: string;
+  characterId?: string | null;
+  memoryScope?: string | null;
+  memoryType?: string | null;
+  key?: string | null;
+  title?: string | null;
+  content: string;
+  metadata?: Record<string, unknown> | null;
+  embedding?: number[] | null;
+  enabled?: boolean;
+}
+
+export function hashAgentMemoryContent(content: string): string {
+  return createHash("sha256").update(content).digest("hex");
+}
 
 function isBuiltInAgentType(type: string): boolean {
   return BUILT_IN_AGENT_TYPES.has(type);
@@ -29,6 +82,79 @@ function getBuiltinAgentType(agentConfigId: string): string | null {
   if (!agentConfigId.startsWith(BUILTIN_AGENT_ID_PREFIX)) return null;
   const agentType = agentConfigId.slice(BUILTIN_AGENT_ID_PREFIX.length).trim();
   return agentType.length > 0 ? agentType : null;
+}
+
+function parseJsonObject(value: string | null | undefined): Record<string, unknown> {
+  if (!value) return {};
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : {};
+  } catch {
+    return {};
+  }
+}
+
+function parseEmbedding(value: string | null | undefined): number[] | null {
+  if (!value) return null;
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) && parsed.every((entry) => typeof entry === "number") ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function stringifyMetadata(value: Record<string, unknown> | null | undefined): string {
+  return JSON.stringify(value ?? {});
+}
+
+function normalizeMemoryScope(value: unknown): string | null {
+  const trimmed = typeof value === "string" ? value.trim() : "";
+  return trimmed ? trimmed : null;
+}
+
+function memoryContentFromValue(value: unknown): string {
+  return typeof value === "string" ? value : JSON.stringify(value);
+}
+
+function normalizeMemoryRow(row: AgentMemoryRow): AgentMemoryRecord {
+  const metadata = parseJsonObject(row.metadata);
+  const content = row.content || row.value || "";
+  return {
+    id: row.id,
+    agentConfigId: row.agentConfigId,
+    chatId: row.chatId,
+    characterId: row.characterId ?? null,
+    memoryScope: normalizeMemoryScope(metadata.memoryScope),
+    memoryType: row.memoryType || "legacy_kv",
+    key: row.key,
+    value: row.value,
+    title: row.title ?? null,
+    content,
+    metadata,
+    embedding: parseEmbedding(row.embedding),
+    contentHash: row.contentHash ?? null,
+    enabled: row.enabled !== "false",
+    createdAt: row.createdAt || row.updatedAt,
+    updatedAt: row.updatedAt,
+    deletedAt: row.deletedAt ?? null,
+  };
+}
+
+function isInternalMemoryType(memoryType: string): boolean {
+  return memoryType.endsWith("_internal") || memoryType === "internal" || memoryType === "legacy_kv";
+}
+
+function recordMatchesFilters(record: AgentMemoryRecord, filters: AgentMemoryFilters): boolean {
+  if (!filters.includeDeleted && record.deletedAt) return false;
+  if (!filters.includeDisabled && !record.enabled) return false;
+  if (!filters.includeInternal && isInternalMemoryType(record.memoryType)) return false;
+  if (filters.chatId !== undefined && record.chatId !== filters.chatId) return false;
+  if (filters.characterId !== undefined && record.characterId !== filters.characterId) return false;
+  if (filters.agentConfigId !== undefined && record.agentConfigId !== filters.agentConfigId) return false;
+  if (filters.memoryScope !== undefined && record.memoryScope !== filters.memoryScope) return false;
+  if (filters.memoryType && record.memoryType !== filters.memoryType) return false;
+  return true;
 }
 
 function keepLatestConfigPerType<T extends { type: string }>(rows: T[]): T[] {
@@ -139,6 +265,60 @@ export function createAgentsStorage(db: DB) {
     if (!builtinType) return agentConfigId;
     const config = await ensureBuiltinConfig(builtinType);
     return config?.id ?? agentConfigId;
+  }
+
+  async function resolveAgentMemoryType(agentConfigId: string) {
+    const builtinType = getBuiltinAgentType(agentConfigId);
+    if (builtinType === "secret-plot-driver") return SECRET_PLOT_MEMORY_TYPE;
+    const config = await getById(agentConfigId);
+    return config?.type === "secret-plot-driver" ? SECRET_PLOT_MEMORY_TYPE : "internal";
+  }
+
+  async function listAgentMemoryRecords(filters: AgentMemoryFilters = {}, limit = 50): Promise<AgentMemoryRecord[]> {
+    const resolvedFilters = { ...filters };
+    if (resolvedFilters.agentConfigId) {
+      resolvedFilters.agentConfigId = await resolveAgentConfigId(resolvedFilters.agentConfigId);
+    }
+    if (resolvedFilters.chatId === null || resolvedFilters.agentConfigId === null) return [];
+    const conditions = [];
+    if (resolvedFilters.chatId !== undefined) conditions.push(eq(agentMemory.chatId, resolvedFilters.chatId));
+    if (resolvedFilters.characterId !== undefined) {
+      conditions.push(
+        resolvedFilters.characterId === null ? isNull(agentMemory.characterId) : eq(agentMemory.characterId, resolvedFilters.characterId),
+      );
+    }
+    if (resolvedFilters.agentConfigId !== undefined) {
+      conditions.push(eq(agentMemory.agentConfigId, resolvedFilters.agentConfigId));
+    }
+    if (resolvedFilters.memoryType) conditions.push(eq(agentMemory.memoryType, resolvedFilters.memoryType));
+    if (resolvedFilters.memoryScope !== undefined) {
+      conditions.push(
+        resolvedFilters.memoryScope === null
+          ? sql`(json_type(${agentMemory.metadata}, '$.memoryScope') IS NULL OR json_type(${agentMemory.metadata}, '$.memoryScope') <> 'text' OR trim(coalesce(cast(json_extract(${agentMemory.metadata}, '$.memoryScope') AS TEXT), '')) = '')`
+          : sql`(json_type(${agentMemory.metadata}, '$.memoryScope') = 'text' AND trim(cast(json_extract(${agentMemory.metadata}, '$.memoryScope') AS TEXT)) = ${resolvedFilters.memoryScope})`,
+      );
+    }
+    if (!resolvedFilters.includeDeleted) conditions.push(isNull(agentMemory.deletedAt));
+    if (!resolvedFilters.includeDisabled) conditions.push(eq(agentMemory.enabled, "true"));
+    if (!resolvedFilters.includeInternal) {
+      conditions.push(
+        ne(agentMemory.memoryType, "internal"),
+        ne(agentMemory.memoryType, "legacy_kv"),
+        sql`${agentMemory.memoryType} NOT LIKE ${"%\\_internal"} ESCAPE '\\'`,
+      );
+    }
+
+    const normalizedLimit = Math.max(1, Math.min(limit, 100));
+    const rows = await db
+      .select()
+      .from(agentMemory)
+      .where(conditions.length > 0 ? and(...conditions) : undefined)
+      .orderBy(desc(agentMemory.updatedAt))
+      .limit(normalizedLimit);
+    return rows
+      .map(normalizeMemoryRow)
+      .filter((record) => recordMatchesFilters(record, resolvedFilters))
+      .slice(0, normalizedLimit);
   }
 
   return {
@@ -347,6 +527,8 @@ export function createAgentsStorage(db: DB) {
     async setMemory(agentConfigId: string, chatId: string, key: string, value: unknown) {
       const resolvedAgentConfigId = await resolveAgentConfigId(agentConfigId);
       const stringValue = typeof value === "string" ? value : JSON.stringify(value);
+      const content = memoryContentFromValue(value);
+      const memoryType = await resolveAgentMemoryType(resolvedAgentConfigId);
       const existing = await db
         .select()
         .from(agentMemory)
@@ -361,16 +543,34 @@ export function createAgentsStorage(db: DB) {
       if (existing.length > 0) {
         await db
           .update(agentMemory)
-          .set({ value: stringValue, updatedAt: now() })
+          .set({
+            value: stringValue,
+            memoryType,
+            content,
+            metadata: stringifyMetadata({ rawValue: value }),
+            contentHash: hashAgentMemoryContent(content),
+            enabled: "true",
+            deletedAt: null,
+            updatedAt: now(),
+          })
           .where(eq(agentMemory.id, existing[0]!.id));
       } else {
+        const timestamp = now();
         await db.insert(agentMemory).values({
           id: newId(),
           agentConfigId: resolvedAgentConfigId,
           chatId,
+          characterId: null,
+          memoryType,
           key,
           value: stringValue,
-          updatedAt: now(),
+          title: key,
+          content,
+          metadata: stringifyMetadata({ rawValue: value }),
+          contentHash: hashAgentMemoryContent(content),
+          enabled: "true",
+          createdAt: timestamp,
+          updatedAt: timestamp,
         });
       }
     },
@@ -392,22 +592,42 @@ export function createAgentsStorage(db: DB) {
           .where(and(eq(agentMemory.agentConfigId, resolvedAgentConfigId), eq(agentMemory.chatId, chatId)));
         const existingByKey = new Map(existingRows.map((row) => [row.key, row]));
         const timestamp = now();
+        const memoryType = await resolveAgentMemoryType(resolvedAgentConfigId);
         const inserts: (typeof agentMemory.$inferInsert)[] = [];
 
         for (const entry of entries) {
+          const rawValue = values[entry.key];
+          const content = memoryContentFromValue(rawValue);
           const existing = existingByKey.get(entry.key);
           if (existing) {
             await tx
               .update(agentMemory)
-              .set({ value: entry.value, updatedAt: timestamp })
+              .set({
+                value: entry.value,
+                memoryType,
+                content,
+                metadata: stringifyMetadata({ rawValue }),
+                contentHash: hashAgentMemoryContent(content),
+                enabled: "true",
+                deletedAt: null,
+                updatedAt: timestamp,
+              })
               .where(eq(agentMemory.id, existing.id));
           } else {
             inserts.push({
               id: newId(),
               agentConfigId: resolvedAgentConfigId,
               chatId,
+              characterId: null,
+              memoryType,
               key: entry.key,
               value: entry.value,
+              title: entry.key,
+              content,
+              metadata: stringifyMetadata({ rawValue }),
+              contentHash: hashAgentMemoryContent(content),
+              enabled: "true",
+              createdAt: timestamp,
               updatedAt: timestamp,
             });
           }
@@ -417,6 +637,137 @@ export function createAgentsStorage(db: DB) {
           await tx.insert(agentMemory).values(inserts);
         }
       });
+    },
+
+    async saveAgentMemory(input: SaveAgentMemoryInput): Promise<AgentMemoryRecord> {
+      const resolvedAgentConfigId = await resolveAgentConfigId(input.agentConfigId);
+      const timestamp = now();
+      const memoryType = (input.memoryType ?? "general").trim() || "general";
+      const content = input.content.trim();
+      const memoryScope = normalizeMemoryScope(input.memoryScope);
+      const scopedMetadata = { ...(input.metadata ?? {}) };
+      delete scopedMetadata.memoryScope;
+      if (memoryScope) scopedMetadata.memoryScope = memoryScope;
+      const metadata = stringifyMetadata(scopedMetadata);
+      const embedding = input.embedding ? JSON.stringify(input.embedding) : null;
+      const contentHash = hashAgentMemoryContent(content);
+
+      if (input.recordId) {
+        const rows = await db.select().from(agentMemory).where(eq(agentMemory.id, input.recordId));
+        if (rows[0]) {
+          await db
+            .update(agentMemory)
+            .set({
+              agentConfigId: resolvedAgentConfigId,
+              chatId: input.chatId,
+              characterId: input.characterId ?? null,
+              memoryType,
+              key: input.key?.trim() || input.recordId,
+              value: content,
+              title: input.title?.trim() || null,
+              content,
+              metadata,
+              embedding,
+              contentHash,
+              enabled: String(input.enabled ?? true),
+              deletedAt: null,
+              updatedAt: timestamp,
+            })
+            .where(eq(agentMemory.id, input.recordId));
+          const updatedRows = await db.select().from(agentMemory).where(eq(agentMemory.id, input.recordId));
+          if (updatedRows[0]) return normalizeMemoryRow(updatedRows[0]);
+          throw new Error(`Agent memory record disappeared after update: ${input.recordId}`);
+        }
+      }
+
+      const stableKey = input.key?.trim();
+      if (stableKey) {
+        const existing = memoryScope
+          ? await db
+              .select()
+              .from(agentMemory)
+              .where(and(eq(agentMemory.chatId, input.chatId), eq(agentMemory.key, stableKey)))
+          : await db
+              .select()
+              .from(agentMemory)
+              .where(
+                and(
+                  eq(agentMemory.agentConfigId, resolvedAgentConfigId),
+                  eq(agentMemory.chatId, input.chatId),
+                  eq(agentMemory.key, stableKey),
+                ),
+              );
+        const matched = existing
+          .map(normalizeMemoryRow)
+          .find(
+            (record) =>
+              record.memoryType === memoryType &&
+              (record.characterId ?? null) === (input.characterId ?? null) &&
+              (!memoryScope || record.memoryScope === memoryScope),
+          );
+        if (matched) {
+          await db
+            .update(agentMemory)
+            .set({
+              value: content,
+              title: input.title?.trim() || null,
+              content,
+              metadata,
+              embedding,
+              contentHash,
+              enabled: String(input.enabled ?? true),
+              deletedAt: null,
+              updatedAt: timestamp,
+            })
+            .where(eq(agentMemory.id, matched.id));
+          const rows = await db.select().from(agentMemory).where(eq(agentMemory.id, matched.id));
+          if (rows[0]) return normalizeMemoryRow(rows[0]);
+          throw new Error(`Agent memory record disappeared after stable-key update: ${matched.id}`);
+        }
+      }
+
+      const id = input.recordId?.trim() || newId();
+      await db.insert(agentMemory).values({
+        id,
+        agentConfigId: resolvedAgentConfigId,
+        chatId: input.chatId,
+        characterId: input.characterId ?? null,
+        memoryType,
+        key: stableKey || id,
+        value: content,
+        title: input.title?.trim() || null,
+        content,
+        metadata,
+        embedding,
+        contentHash,
+        enabled: String(input.enabled ?? true),
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      });
+      const rows = await db.select().from(agentMemory).where(eq(agentMemory.id, id));
+      return normalizeMemoryRow(rows[0]!);
+    },
+
+    async listAgentMemory(filters: AgentMemoryFilters = {}, limit = 50): Promise<AgentMemoryRecord[]> {
+      return listAgentMemoryRecords(filters, limit);
+    },
+
+    async getAgentMemoryRecord(id: string): Promise<AgentMemoryRecord | null> {
+      const rows = await db.select().from(agentMemory).where(eq(agentMemory.id, id));
+      return rows[0] ? normalizeMemoryRow(rows[0]) : null;
+    },
+
+    async softDeleteAgentMemory(id: string): Promise<AgentMemoryRecord | null> {
+      const timestamp = now();
+      await db
+        .update(agentMemory)
+        .set({ enabled: "false", deletedAt: timestamp, updatedAt: timestamp })
+        .where(eq(agentMemory.id, id));
+      return this.getAgentMemoryRecord(id);
+    },
+
+    async searchAgentMemoryCandidates(filters: AgentMemoryFilters = {}, limit = 100): Promise<AgentMemoryRecord[]> {
+      return listAgentMemoryRecords(filters, limit);
     },
 
     /** Delete echo chamber message runs for a specific chat. */

--- a/packages/server/src/services/tools/tool-executor.ts
+++ b/packages/server/src/services/tools/tool-executor.ts
@@ -9,6 +9,8 @@ import { safeFetch } from "../../utils/security.js";
 import { logger } from "../../lib/logger.js";
 import { normalizeSpotifySearchQuery } from "../spotify/spotify.service.js";
 import { appendChatSummaryEntryToMetadata } from "@marinara-engine/shared";
+import { localEmbed } from "../local-embedder.js";
+import type { AgentMemoryRecord } from "../storage/agents.storage.js";
 
 export interface ToolExecutionResult {
   toolCallId: string;
@@ -35,6 +37,51 @@ export type LorebookSearchFn = (
 /** Spotify API credentials injected from the route layer. */
 export interface SpotifyCredentials {
   accessToken: string;
+}
+
+export interface AgentMemoryStore {
+  saveAgentMemory(input: {
+    recordId?: string | null;
+    agentConfigId: string;
+    chatId: string;
+    characterId?: string | null;
+    memoryScope?: string | null;
+    memoryType?: string | null;
+    key?: string | null;
+    title?: string | null;
+    content: string;
+    metadata?: Record<string, unknown> | null;
+    embedding?: number[] | null;
+    enabled?: boolean;
+  }): Promise<AgentMemoryRecord>;
+  listAgentMemory(
+    filters?: {
+      chatId?: string | null;
+      characterId?: string | null;
+      agentConfigId?: string | null;
+      memoryScope?: string | null;
+      memoryType?: string | null;
+      includeInternal?: boolean;
+      includeDeleted?: boolean;
+      includeDisabled?: boolean;
+    },
+    limit?: number,
+  ): Promise<AgentMemoryRecord[]>;
+  getAgentMemoryRecord(id: string): Promise<AgentMemoryRecord | null>;
+  softDeleteAgentMemory(id: string): Promise<AgentMemoryRecord | null>;
+  searchAgentMemoryCandidates(
+    filters?: {
+      chatId?: string | null;
+      characterId?: string | null;
+      agentConfigId?: string | null;
+      memoryScope?: string | null;
+      memoryType?: string | null;
+      includeInternal?: boolean;
+      includeDeleted?: boolean;
+      includeDisabled?: boolean;
+    },
+    limit?: number,
+  ): Promise<AgentMemoryRecord[]>;
 }
 
 export type MetadataPatch = Record<string, unknown>;
@@ -123,12 +170,17 @@ const SPOTIFY_MOOD_EXPANSIONS: Array<[RegExp, string[]]> = [
 
 export interface ToolExecutionContext {
   gameState?: Record<string, unknown>;
+  chatId?: string;
+  agentConfigId?: string;
+  agentMemoryScope?: string | null;
+  activeCharacters?: Array<{ id: string; name: string }>;
   chatMeta?: Record<string, unknown>;
   onUpdateMetadata?: (patch: MetadataPatchInput) => Promise<MetadataPatch>;
   customTools?: CustomToolDef[];
   searchLorebook?: LorebookSearchFn;
   spotify?: SpotifyCredentials;
   spotifyRepeatAfterPlay?: "off" | "track" | "context";
+  agentMemory?: AgentMemoryStore;
 }
 
 /**
@@ -190,6 +242,14 @@ async function executeSingleTool(
       return readChatSummary(context?.chatMeta);
     case "append_chat_summary":
       return appendChatSummary(args, context);
+    case "save_agent_memory":
+      return saveAgentMemory(args, context);
+    case "search_agent_memory":
+      return searchAgentMemory(args, context);
+    case "list_agent_memory":
+      return listAgentMemory(args, context);
+    case "delete_agent_memory":
+      return deleteAgentMemory(args, context);
     case "read_chat_variable":
       return readChatVariable(args, context?.chatMeta);
     case "write_chat_variable":
@@ -220,6 +280,10 @@ async function executeSingleTool(
           "search_lorebook",
           "read_chat_summary",
           "append_chat_summary",
+          "save_agent_memory",
+          "search_agent_memory",
+          "list_agent_memory",
+          "delete_agent_memory",
           "read_chat_variable",
           "write_chat_variable",
           "spotify_get_current_playback",
@@ -485,6 +549,260 @@ async function appendChatSummary(
     return { summary: result.summary, summaryEntries: result.entries };
   });
   return { summary: typeof updated.summary === "string" ? updated.summary : sanitizedText };
+}
+
+type AgentMemoryOwnership = {
+  chatId: string;
+  agentConfigId: string;
+  characterId?: string;
+  memoryScope?: string | null;
+};
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function asBoolean(value: unknown): boolean {
+  return value === true || value === "true";
+}
+
+function asLimit(value: unknown, fallback: number, max: number): number {
+  const parsed = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.max(1, Math.min(Math.floor(parsed), max));
+}
+
+function asMetadata(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function resolveCharacterId(args: Record<string, unknown>, context?: ToolExecutionContext): string | undefined {
+  const requestedName = asString(args.characterName);
+  if (!requestedName) return undefined;
+  const match = context?.activeCharacters?.find((character) => character.name.toLowerCase() === requestedName.toLowerCase());
+  if (!match) {
+    throw new Error(`Unknown active character for agent memory: ${requestedName}`);
+  }
+  return match.id;
+}
+
+function resolveAgentMemoryOwnership(
+  args: Record<string, unknown>,
+  context?: ToolExecutionContext,
+): AgentMemoryOwnership {
+  if (!context?.agentMemory) {
+    throw new Error("Agent memory storage is not available in this context");
+  }
+  if (!context.chatId) {
+    throw new Error("Agent memory tools require a current chat");
+  }
+  if (!context.agentConfigId) {
+    throw new Error("Agent memory tools require an executing agent identity");
+  }
+  return {
+    chatId: context.chatId,
+    agentConfigId: context.agentConfigId,
+    characterId: resolveCharacterId(args, context),
+    memoryScope: asString(context.agentMemoryScope),
+  };
+}
+
+function scopedAgentMemoryFilters(ownership: AgentMemoryOwnership): {
+  agentConfigId?: string;
+  memoryScope?: string;
+} {
+  return ownership.memoryScope
+    ? { memoryScope: ownership.memoryScope }
+    : { agentConfigId: ownership.agentConfigId };
+}
+
+function canAccessAgentMemoryRecord(record: AgentMemoryRecord, ownership: AgentMemoryOwnership): boolean {
+  if (record.chatId !== ownership.chatId) return false;
+  if (ownership.memoryScope) return record.memoryScope === ownership.memoryScope;
+  return record.agentConfigId === ownership.agentConfigId;
+}
+
+function publicAgentMemoryRecord(record: AgentMemoryRecord, includeContent = true): Record<string, unknown> {
+  return {
+    id: record.id,
+    memoryType: record.memoryType,
+    key: record.key,
+    title: record.title,
+    ...(includeContent ? { content: record.content } : {}),
+    metadata: record.metadata,
+    ownership: {
+      chat: Boolean(record.chatId),
+      character: Boolean(record.characterId),
+      agent: Boolean(record.agentConfigId),
+    },
+    enabled: record.enabled,
+    createdAt: record.createdAt,
+    updatedAt: record.updatedAt,
+  };
+}
+
+async function saveAgentMemory(
+  args: Record<string, unknown>,
+  context?: ToolExecutionContext,
+): Promise<Record<string, unknown>> {
+  const content = asString(args.content);
+  if (!content) return { error: "save_agent_memory requires non-empty content" };
+  const ownership = resolveAgentMemoryOwnership(args, context);
+  const semanticIndex = asBoolean(args.semanticIndex);
+  const recordId = asString(args.recordId);
+  if (recordId) {
+    const existing = await context!.agentMemory!.getAgentMemoryRecord(recordId);
+    if (existing && !canAccessAgentMemoryRecord(existing, ownership)) {
+      return { saved: false, error: "Agent memory record is not owned by the executing agent in this chat" };
+    }
+  }
+  let embedding: number[] | null = null;
+
+  if (semanticIndex) {
+    const vectors = await localEmbed([content]);
+    embedding = vectors?.[0] ?? null;
+  }
+
+  const record = await context!.agentMemory!.saveAgentMemory({
+    recordId,
+    agentConfigId: ownership.agentConfigId,
+    chatId: ownership.chatId,
+    characterId: ownership.characterId ?? null,
+    memoryScope: ownership.memoryScope,
+    memoryType: asString(args.memoryType) ?? "general",
+    key: asString(args.key),
+    title: asString(args.title),
+    content,
+    metadata: asMetadata(args.metadata),
+    embedding,
+  });
+
+  return {
+    saved: true,
+    semanticIndexed: Boolean(embedding),
+    record: publicAgentMemoryRecord(record),
+    note: semanticIndex && !embedding ? "Semantic indexing was requested, but the local embedder is unavailable." : undefined,
+  };
+}
+
+function literalScore(record: AgentMemoryRecord, query: string): number {
+  const q = query.toLowerCase();
+  const haystack = [record.title, record.content, record.memoryType, record.key].filter(Boolean).join("\n").toLowerCase();
+  return haystack.includes(q) ? 1 : 0;
+}
+
+function fuzzyScore(record: AgentMemoryRecord, query: string): number {
+  const tokens = query.toLowerCase().split(/\W+/).filter((token) => token.length >= 2);
+  if (tokens.length === 0) return 0;
+  const haystack = [record.title, record.content, record.memoryType, record.key].filter(Boolean).join(" ").toLowerCase();
+  const matches = tokens.filter((token) => haystack.includes(token)).length;
+  return matches / tokens.length;
+}
+
+function cosineSimilarity(a: number[], b: number[]): number {
+  if (a.length === 0 || a.length !== b.length) return 0;
+  let dot = 0;
+  let aMag = 0;
+  let bMag = 0;
+  for (let i = 0; i < a.length; i += 1) {
+    dot += a[i]! * b[i]!;
+    aMag += a[i]! * a[i]!;
+    bMag += b[i]! * b[i]!;
+  }
+  if (aMag === 0 || bMag === 0) return 0;
+  return dot / (Math.sqrt(aMag) * Math.sqrt(bMag));
+}
+
+async function searchAgentMemory(
+  args: Record<string, unknown>,
+  context?: ToolExecutionContext,
+): Promise<Record<string, unknown>> {
+  const query = asString(args.query);
+  if (!query) return { error: "search_agent_memory requires non-empty query" };
+  const ownership = resolveAgentMemoryOwnership(args, context);
+  const mode = asString(args.mode) ?? "literal";
+  const limit = asLimit(args.limit, 10, 50);
+  const candidates = await context!.agentMemory!.searchAgentMemoryCandidates(
+    {
+      chatId: ownership.chatId,
+      ...scopedAgentMemoryFilters(ownership),
+      characterId: ownership.characterId,
+      memoryType: asString(args.memoryType),
+      includeInternal: false,
+    },
+    100,
+  );
+
+  let scored: Array<{ record: AgentMemoryRecord; score: number }> = [];
+  if (mode === "semantic") {
+    const vectors = await localEmbed([query]);
+    const queryVector = vectors?.[0] ?? null;
+    if (!queryVector) {
+      return { query, mode, results: [], count: 0, error: "Semantic search is unavailable because embeddings are not available." };
+    }
+    scored = candidates
+      .filter((record) => record.embedding)
+      .map((record) => ({ record, score: cosineSimilarity(queryVector, record.embedding!) }))
+      .filter((entry) => entry.score > 0);
+    if (scored.length === 0) {
+      return { query, mode, results: [], count: 0, note: "No semantically indexed agent memory records matched." };
+    }
+  } else if (mode === "fuzzy") {
+    scored = candidates
+      .map((record) => ({ record, score: fuzzyScore(record, query) }))
+      .filter((entry) => entry.score > 0);
+  } else {
+    scored = candidates
+      .map((record) => ({ record, score: literalScore(record, query) }))
+      .filter((entry) => entry.score > 0);
+  }
+
+  const results = scored
+    .sort((a, b) => b.score - a.score || b.record.updatedAt.localeCompare(a.record.updatedAt))
+    .slice(0, limit)
+    .map((entry) => ({ ...publicAgentMemoryRecord(entry.record), score: entry.score }));
+
+  return { query, mode, results, count: results.length };
+}
+
+async function listAgentMemory(
+  args: Record<string, unknown>,
+  context?: ToolExecutionContext,
+): Promise<Record<string, unknown>> {
+  const ownership = resolveAgentMemoryOwnership(args, context);
+  const limit = asLimit(args.limit, 20, 100);
+  const records = await context!.agentMemory!.listAgentMemory(
+    {
+      chatId: ownership.chatId,
+      ...scopedAgentMemoryFilters(ownership),
+      characterId: ownership.characterId,
+      memoryType: asString(args.memoryType),
+      includeInternal: false,
+    },
+    limit,
+  );
+  const includeContent = args.includeContent !== false;
+  return { records: records.map((record) => publicAgentMemoryRecord(record, includeContent)), count: records.length };
+}
+
+async function deleteAgentMemory(
+  args: Record<string, unknown>,
+  context?: ToolExecutionContext,
+): Promise<Record<string, unknown>> {
+  const recordId = asString(args.recordId);
+  if (!recordId) return { error: "delete_agent_memory requires recordId" };
+  const ownership = resolveAgentMemoryOwnership(args, context);
+  const record = await context!.agentMemory!.getAgentMemoryRecord(recordId);
+  if (!record || record.deletedAt || !record.enabled) return { deleted: false, error: "Agent memory record not found" };
+  if (!canAccessAgentMemoryRecord(record, ownership)) {
+    return { deleted: false, error: "Agent memory record is not owned by the executing agent in this chat" };
+  }
+  if (ownership.characterId !== undefined && record.characterId !== ownership.characterId) {
+    return { deleted: false, error: "Agent memory record is not owned by the selected character" };
+  }
+  const deleted = await context!.agentMemory!.softDeleteAgentMemory(recordId);
+  return { deleted: Boolean(deleted?.deletedAt), recordId };
 }
 
 async function writeChatVariable(

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -779,6 +779,96 @@ export const BUILT_IN_TOOLS: ToolDefinition[] = [
     },
   },
   {
+    name: "save_agent_memory",
+    description:
+      "Save a durable agent memory record for the current chat and executing agent. Use for stable facts, plans, decisions, promises, or significant continuity details.",
+    parameters: {
+      type: "object",
+      properties: {
+        content: {
+          type: "string",
+          description: "The durable memory text to store. Keep it concise and self-contained.",
+        },
+        title: { type: "string", description: "Optional short human-readable title." },
+        memoryType: {
+          type: "string",
+          description:
+            "Category for this memory, such as general, continuity, planning, preference, or a custom agent-specific type.",
+        },
+        key: {
+          type: "string",
+          description: "Optional stable key for updating the same memory again instead of creating duplicates.",
+        },
+        characterName: {
+          type: "string",
+          description: "Optional active character name when the memory belongs to a specific character.",
+        },
+        metadata: {
+          type: "object",
+          description: "Optional structured JSON details for the agent. Do not include raw database IDs.",
+        },
+        semanticIndex: {
+          type: "boolean",
+          description: "Whether to request semantic indexing for this record if local embeddings are available.",
+        },
+        recordId: {
+          type: "string",
+          description: "Optional record ID returned by an earlier save/list/search when intentionally updating it.",
+        },
+      },
+      required: ["content"],
+    },
+  },
+  {
+    name: "search_agent_memory",
+    description:
+      "Search durable agent memory records owned by the current chat and executing agent using literal, fuzzy, or semantic matching.",
+    parameters: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "Search query." },
+        mode: {
+          type: "string",
+          description: "Search mode.",
+          enum: ["literal", "fuzzy", "semantic"],
+        },
+        memoryType: { type: "string", description: "Optional memory type filter." },
+        characterName: { type: "string", description: "Optional active character name filter." },
+        limit: { type: "number", description: "Maximum number of results to return." },
+      },
+      required: ["query"],
+    },
+  },
+  {
+    name: "list_agent_memory",
+    description: "List durable agent memory records owned by the current chat and executing agent.",
+    parameters: {
+      type: "object",
+      properties: {
+        memoryType: { type: "string", description: "Optional memory type filter." },
+        characterName: { type: "string", description: "Optional active character name filter." },
+        includeContent: { type: "boolean", description: "Whether to include full memory content in the response." },
+        limit: { type: "number", description: "Maximum number of records to return." },
+      },
+      required: [],
+    },
+  },
+  {
+    name: "delete_agent_memory",
+    description: "Delete a durable agent memory record by ID if it belongs to the current chat and executing agent.",
+    parameters: {
+      type: "object",
+      properties: {
+        recordId: {
+          type: "string",
+          description: "Record ID returned by save_agent_memory, search_agent_memory, or list_agent_memory.",
+        },
+        characterName: { type: "string", description: "Optional active character name ownership check." },
+      },
+      required: ["recordId"],
+    },
+  },
+  {
     name: "read_chat_variable",
     description:
       "Read a chat-wide string variable by key. Use this for agent-private state or coordination with other agents in the same chat.",


### PR DESCRIPTION
## Linked issue

Closes #589

## Why this change

Agents currently have only narrow per-agent key/value memory, which works for internal state like the secret plot driver but does not give built-in or custom agents a clear way to save, search, list, and delete durable memory records. This change adds an owner-aware agent memory surface that keeps current secret plot behavior working while making explicit agent-authored memory available through built-in tools.

Examples of how this expanded memory agent functionality can be used are: custom memories saving and retrieval, persistent custom trackers, etc

## What changed

*Key Changes*

- Expanded `agent_memory` storage to support typed records with title, content, metadata, optional embeddings, ownership fields, timestamps, and soft deletion.
- Added built-in tools for `save_agent_memory`, `search_agent_memory`, `list_agent_memory`, and `delete_agent_memory`.

*Secondary Changes*

- Added server-side ownership resolution from the current chat, executing agent config, and active character list, without accepting raw internal IDs from tool callers.
- Added literal, fuzzy, and optional semantic search behavior; semantic search returns a clear unavailable result when embeddings are not available.
- Updated existing agent memory compatibility so current key/value use, including secret plot state, continues through the enhanced storage model.
- Added `settings.memoryScope` as an explicit opt-in for multi-agent cooperation, so writer/retriever custom agents can share records without making all agent memory chat-global.

## Validation

- [x] `pnpm check`
- [x] Manual verification completed (describe below)
- [x] playwright testing to cover regression and new test (playtest files not included in the PR)

### Manual verification notes

- UI verification was performed ensuring that agent activity was logged correctly. 
- A Playwright suite exercised save, search, list, delete, and semantic-unavailable behavior through deterministic API/tool execution (playwright files not included as not part of repo testing strategy).
- Follow-up local session verification confirmed the writer/retriever custom agents can be configured with the same `memoryScope` and that existing writer-owned `character_memory` records can be tagged with `metadata.memoryScope` for shared retrieval. The patch preserves per-agent isolation when `memoryScope` is absent.
- No regression testing was performed on agent memory functionality used by Secret Plot agent confirming both writing and reading ot its generations.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

Not applicable. This change adds server/storage/tool behavior and does not introduce a user-facing UI surface.
