### PR TITLE
fix: enlarge mobile close and help targets

### DIFF
--- a/src/app/shell/RightPanel.tsx
+++ b/src/app/shell/RightPanel.tsx
@@ -85,10 +85,12 @@ export function RightPanel() {
           <h2 className="text-sm font-semibold text-[var(--foreground)]">{config.title}</h2>
         </div>
         <button
+          type="button"
           onClick={close}
-          className="rounded-lg p-1.5 text-[var(--muted-foreground)] transition-all hover:bg-[var(--accent)] hover:text-[var(--primary)] active:scale-90"
+          aria-label={`Close ${config.title}`}
+          className="flex min-h-8 min-w-8 items-center justify-center rounded-lg text-[var(--muted-foreground)] transition-all hover:bg-[var(--accent)] hover:text-[var(--primary)] active:scale-90 max-md:min-h-11 max-md:min-w-11"
         >
-          <X size="0.875rem" />
+          <X size="0.875rem" aria-hidden="true" />
         </button>
       </div>
 

--- a/src/features/modes/shared/chat-ui/components/NewChatConnectionGate.tsx
+++ b/src/features/modes/shared/chat-ui/components/NewChatConnectionGate.tsx
@@ -102,10 +102,12 @@ export function NewChatConnectionGate({ mode, onClose }: NewChatConnectionGatePr
               </div>
             </div>
             <button
+              type="button"
               onClick={onClose}
-              className="rounded-md p-1 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--secondary)] hover:text-[var(--foreground)]"
+              aria-label="Close setup"
+              className="flex min-h-8 min-w-8 items-center justify-center rounded-lg text-[var(--muted-foreground)] transition-colors hover:bg-[var(--secondary)] hover:text-[var(--foreground)] max-md:min-h-11 max-md:min-w-11"
             >
-              <X size="0.875rem" />
+              <X size="0.875rem" aria-hidden="true" />
             </button>
           </div>
 

--- a/src/shared/components/ui/HelpTooltip.tsx
+++ b/src/shared/components/ui/HelpTooltip.tsx
@@ -92,7 +92,7 @@ export function HelpTooltip({
       <button
         type="button"
         aria-label="Show help"
-        className="inline-flex cursor-help items-center rounded-full text-[var(--muted-foreground)] opacity-50 transition-opacity hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--primary)]/40"
+        className="inline-flex h-5 w-5 shrink-0 cursor-help items-center justify-center rounded-full text-[var(--muted-foreground)] opacity-50 transition-opacity hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--primary)]/40 max-md:h-11 max-md:w-11"
         onMouseEnter={() => setShow(true)}
         onPointerDown={(event) => {
           event.preventDefault();


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #1228

## Why this change

Mobile icon-only controls in the new-chat connection gate and settings panel were smaller than comfortable touch targets. The original 320px repro measured the gate close button at 23.38px, the settings panel close button at 27.63px, and settings help buttons at 12.75px.

## What changed

- Increased the new-chat gate close button and right-panel close button hit boxes on mobile while keeping the icon size visually compact.
- Increased shared `HelpTooltip` button boxes on mobile so settings help controls expose a comfortable touch target.
- Added explicit accessible labels/hidden icon semantics to the close icon buttons touched by this fix.

## Refactor impact

Primary owner:

Shared mode UI and app shell.

Impact areas reviewed:

- New chat connection gate
- Right panel header
- Shared help tooltip component used by settings rows

Boundary notes:

- React UI only. No engine, shared API, Rust storage, remote runtime, schema, dependency, or prompt-pipeline behavior changed.

Pressure points touched:

- Shared mode UI: `NewChatConnectionGate`
- App shell: `RightPanel`
- Shared UI primitive: `HelpTooltip`

## Validation

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Codex Playwright repro at 320x568:
  - Before: new-chat close `23.38x23.38`, settings close `27.63x27.63`, smallest settings help button `12.75x12.75`.
  - After: new-chat close `46.75x46.75`, settings close `46.75x46.75`, smallest settings help button `46.75x46.75`.
- Codex Playwright edge case at 390x844:
  - After: new-chat close `46.75x46.75`, settings close `46.75x46.75`, smallest settings help button `46.75x46.75`.
- Codex desktop smoke at 1024x768:
  - Desktop remains compact: new-chat close and right-panel close `34x34`; help buttons `21.25x21.25`.
- `pnpm typecheck` passed locally after rebasing onto current `upstream/refactor`.
- `pnpm check:docs` passed locally.
- Full `pnpm check` was attempted locally. `check:architecture` and `check:frontend` passed, but `check:rust` could not complete on this machine because Cargo exhausted local Windows disk/paging resources while compiling Tauri dependencies. This PR does not touch Rust; CI should be treated as the Rust/full-check source of truth before ready/merge.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

New chat gate before:

![New chat gate before](https://raw.githubusercontent.com/cha1latte/Marinara-Engine/evidence/issue-1228-touch-targets/docs/evidence/issue-1228-touch-targets/before-newchat-gate.png)

New chat gate after:

![New chat gate after](https://raw.githubusercontent.com/cha1latte/Marinara-Engine/evidence/issue-1228-touch-targets/docs/evidence/issue-1228-touch-targets/after-newchat-gate.png)

Settings before:

![Settings before](https://raw.githubusercontent.com/cha1latte/Marinara-Engine/evidence/issue-1228-touch-targets/docs/evidence/issue-1228-touch-targets/before-settings.png)

Settings after:

![Settings after](https://raw.githubusercontent.com/cha1latte/Marinara-Engine/evidence/issue-1228-touch-targets/docs/evidence/issue-1228-touch-targets/after-settings.png)
