### PR TITLE
Fix refactor gallery upload failure handling

### DIFF
--- a/src/features/catalog/gallery/hooks/use-gallery.test.ts
+++ b/src/features/catalog/gallery/hooks/use-gallery.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { chatGalleryUploadFailureError } from "./use-gallery";
+
+describe("chatGalleryUploadFailureError", () => {
+  it("preserves the underlying remote error for single-file uploads", () => {
+    const remoteError = new Error("chat_gallery_upload is not exposed by the remote runtime");
+
+    expect(chatGalleryUploadFailureError(1, [remoteError])).toBe(remoteError);
+  });
+
+  it("keeps a batch summary for multi-file partial failures", () => {
+    expect(chatGalleryUploadFailureError(2, [new Error("nope")]).message).toBe(
+      "One chat gallery image failed to upload.",
+    );
+  });
+});

--- a/src/features/catalog/gallery/hooks/use-gallery.ts
+++ b/src/features/catalog/gallery/hooks/use-gallery.ts
@@ -13,28 +13,35 @@ export function useGalleryImages(chatId: string | null) {
   });
 }
 
+export function chatGalleryUploadFailureError(fileCount: number, failures: unknown[]): Error {
+  if (fileCount === 1 && failures[0] instanceof Error) {
+    return failures[0];
+  }
+
+  const failedCount = failures.length;
+  return new Error(
+    failedCount === 1 ? "One chat gallery image failed to upload." : `${failedCount} chat gallery images failed to upload.`,
+  );
+}
+
 export function useUploadGalleryImage(chatId: string | null) {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (files: File[]) => {
       if (!chatId) return [];
       const uploaded: ChatImage[] = [];
-      let failedCount = 0;
+      const failures: unknown[] = [];
 
       for (const file of files) {
         try {
           uploaded.push(await galleryApi.uploadChat<ChatImage>(chatId, file));
-        } catch {
-          failedCount += 1;
+        } catch (error) {
+          failures.push(error);
         }
       }
 
-      if (failedCount > 0) {
-        throw new Error(
-          failedCount === 1
-            ? "One chat gallery image failed to upload."
-            : `${failedCount} chat gallery images failed to upload.`,
-        );
+      if (failures.length > 0) {
+        throw chatGalleryUploadFailureError(files.length, failures);
       }
 
       return uploaded;

--- a/src/shared/api/file-payload.test.ts
+++ b/src/shared/api/file-payload.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { fileToUploadPayload, IMAGE_UPLOAD_SIZE_ERROR, MAX_IMAGE_UPLOAD_BYTES } from "./file-payload";
+
+function fakeFile(size: number, bytes = [0x89, 0x50, 0x4e, 0x47]) {
+  let arrayBufferCalls = 0;
+  const file = {
+    name: "upload.png",
+    type: "image/png",
+    size,
+    async arrayBuffer() {
+      arrayBufferCalls += 1;
+      return new Uint8Array(bytes).buffer;
+    },
+  } as File;
+
+  return {
+    file,
+    arrayBufferCalls: () => arrayBufferCalls,
+  };
+}
+
+describe("fileToUploadPayload", () => {
+  it("rejects oversized uploads before reading bytes", async () => {
+    const upload = fakeFile(MAX_IMAGE_UPLOAD_BYTES + 1);
+
+    await expect(
+      fileToUploadPayload(upload.file, {
+        maxBytes: MAX_IMAGE_UPLOAD_BYTES,
+        tooLargeMessage: IMAGE_UPLOAD_SIZE_ERROR,
+      }),
+    ).rejects.toThrow(IMAGE_UPLOAD_SIZE_ERROR);
+    expect(upload.arrayBufferCalls()).toBe(0);
+  });
+
+  it("encodes files within the configured size limit", async () => {
+    const upload = fakeFile(4);
+
+    await expect(
+      fileToUploadPayload(upload.file, {
+        maxBytes: MAX_IMAGE_UPLOAD_BYTES,
+        tooLargeMessage: IMAGE_UPLOAD_SIZE_ERROR,
+      }),
+    ).resolves.toMatchObject({
+      name: "upload.png",
+      type: "image/png",
+      size: 4,
+      base64: "iVBORw==",
+    });
+    expect(upload.arrayBufferCalls()).toBe(1);
+  });
+});

--- a/src/shared/api/file-payload.ts
+++ b/src/shared/api/file-payload.ts
@@ -5,7 +5,19 @@ export interface UploadFilePayload {
   base64: string;
 }
 
-export async function fileToUploadPayload(file: File): Promise<UploadFilePayload> {
+export const MAX_IMAGE_UPLOAD_BYTES = 20 * 1024 * 1024;
+export const IMAGE_UPLOAD_SIZE_ERROR = "Image uploads must be 20 MB or smaller";
+
+interface FilePayloadOptions {
+  maxBytes?: number;
+  tooLargeMessage?: string;
+}
+
+export async function fileToUploadPayload(file: File, options: FilePayloadOptions = {}): Promise<UploadFilePayload> {
+  if (options.maxBytes !== undefined && file.size > options.maxBytes) {
+    throw new Error(options.tooLargeMessage ?? `Uploads must be ${options.maxBytes} bytes or smaller`);
+  }
+
   const buffer = await file.arrayBuffer();
   const bytes = new Uint8Array(buffer);
   let binary = "";

--- a/src/shared/api/image-generation-api.ts
+++ b/src/shared/api/image-generation-api.ts
@@ -1,5 +1,5 @@
 import { invokeTauri } from "./tauri-client";
-import { fileToUploadPayload } from "./file-payload";
+import { fileToUploadPayload, IMAGE_UPLOAD_SIZE_ERROR, MAX_IMAGE_UPLOAD_BYTES } from "./file-payload";
 
 export const spriteApi = {
   capabilities: <T = unknown>() => invokeTauri<T>("sprite_capabilities_command"),
@@ -31,11 +31,17 @@ export const imageGenerationApi = {
 
 export const galleryApi = {
   uploadCharacter: async <T = unknown>(characterId: string, file: File) => {
-    const payload = await fileToUploadPayload(file);
+    const payload = await fileToUploadPayload(file, {
+      maxBytes: MAX_IMAGE_UPLOAD_BYTES,
+      tooLargeMessage: IMAGE_UPLOAD_SIZE_ERROR,
+    });
     return invokeTauri<T>("character_gallery_upload", { characterId, body: { file: payload } });
   },
   uploadChat: async <T = unknown>(chatId: string, file: File) => {
-    const payload = await fileToUploadPayload(file);
+    const payload = await fileToUploadPayload(file, {
+      maxBytes: MAX_IMAGE_UPLOAD_BYTES,
+      tooLargeMessage: IMAGE_UPLOAD_SIZE_ERROR,
+    });
     return invokeTauri<T>("chat_gallery_upload", { chatId, body: { file: payload } });
   },
 };

--- a/src/shared/api/settings-assets-api.ts
+++ b/src/shared/api/settings-assets-api.ts
@@ -1,4 +1,4 @@
-import { fileToUploadPayload } from "./file-payload";
+import { fileToUploadPayload, IMAGE_UPLOAD_SIZE_ERROR, MAX_IMAGE_UPLOAD_BYTES } from "./file-payload";
 import { invokeTauri } from "./tauri-client";
 
 export const fontsApi = {
@@ -11,7 +11,10 @@ export const backgroundsApi = {
   list: <T = unknown>() => invokeTauri<T>("backgrounds_list"),
   tags: <T = unknown>() => invokeTauri<T>("backgrounds_tags"),
   upload: async <T = unknown>(file: File) => {
-    const payload = await fileToUploadPayload(file);
+    const payload = await fileToUploadPayload(file, {
+      maxBytes: MAX_IMAGE_UPLOAD_BYTES,
+      tooLargeMessage: IMAGE_UPLOAD_SIZE_ERROR,
+    });
     return invokeTauri<T>("background_upload", { body: { file: payload } });
   },
   delete: <T = unknown>(filename: string) => invokeTauri<T>("background_delete", { filename }),

--- a/src/shared/components/ui/ImageUploadDropzone.tsx
+++ b/src/shared/components/ui/ImageUploadDropzone.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState, type ChangeEvent, type DragEvent, type ReactNode } from "react";
 import { toast } from "sonner";
 
+import { MAX_IMAGE_UPLOAD_BYTES } from "../../api/file-payload";
 import { cn } from "../../lib/utils";
 
 interface ImageUploadDropzoneProps {
@@ -21,7 +22,7 @@ interface ImageUploadDropzoneProps {
 
 const IMAGE_EXTENSION_PATTERN = /\.(avif|gif|jpe?g|png|webp)$/i;
 const DEFAULT_MAX_IMAGE_FILES = 50;
-const DEFAULT_MAX_IMAGE_BYTES = 20 * 1024 * 1024;
+const DEFAULT_MAX_IMAGE_BYTES = MAX_IMAGE_UPLOAD_BYTES;
 
 function isFileDrag(event: DragEvent<HTMLElement>) {
   return Array.from(event.dataTransfer.types).some((type) => type.toLowerCase() === "files");


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #1232

## Why this change

- Refactor chat gallery uploads need to fail clearly in remote-runtime/browser flows instead of leaving the gallery unchanged with an unhelpful message.
- Xel's audit note also called out oversized upload preflight before renderer/base64 work; the shared payload path still lacked that API-boundary guard even though the dropzone and Rust decoder had size checks.

## What changed

- Preserve the underlying single-file chat gallery upload error, so an older/unsupported remote runtime can surface the actual `chat_gallery_upload is not exposed by the remote runtime` message.
- Add an opt-in max-byte preflight to `fileToUploadPayload()` and apply the 20 MB image limit to chat gallery, character gallery, and background upload API wrappers before `arrayBuffer()`/base64 conversion.
- Reuse the shared image-upload size constant in the dropzone so UI validation and API-boundary validation stay aligned.
- Add focused Vitest coverage for oversized preflight, valid image encoding, single-file remote error preservation, and multi-file batch summary behavior.

## Refactor impact

Primary owner:

- Shared API and catalog/gallery upload hooks.

Impact areas reviewed:

- Chat gallery upload error handling
- Character gallery upload payload creation
- Background upload payload creation
- Shared image upload dropzone size limit
- Remote-runtime command support in current `refactor`

Boundary notes:

- The fix stays in shared API and feature hook boundaries; engine and Rust storage code are unchanged.
- Current `refactor` already allowlists and dispatches `chat_gallery_upload`; this PR covers the remaining compatibility/error visibility path plus the payload preflight requested in the issue comment.
- No schema, version, dependency, auth, storage migration, or prompt-pipeline changes.

Pressure points touched:

- Shared mode UI chat gallery
- Shared API file payload conversion
- Shared image upload dropzone

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Codex ran `pnpm exec vitest run src\shared\api\file-payload.test.ts src\features\catalog\gallery\hooks\use-gallery.test.ts`: 2 files / 4 tests passed.
- Codex re-ran the scratch before/after repro with `pnpm exec vitest run --config scratch\vitest.issue-1232.config.ts`: 1 file / 1 test passed after the fix.
- Codex ran `pnpm check:frontend`: passed.
- Codex ran `pnpm check:architecture`: dependency-cruiser passed and Rust structure check passed.
- Codex ran `pnpm check:docs`: checked 40 docs and repo guidance files.
- Codex attempted full `pnpm check`, but local verification timed out in the Rust phase after Cargo dependency compilation hit sandbox machine resource failures.
- GitHub CI supplied the full baseline for PR #1270: Frontend, Architecture, and Organization passed; Rust Capability Layer passed; Browser Smoke and Performance passed; Auto-label passed; Pull Request template check skipped as expected.
- CodeRabbit current-head status is successful and `reviewThreads` is empty.
- Verification proof gist: https://gist.github.com/cha1latte/9548e2a75aab5005c07a7763b8e62035

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs or release metadata changes needed; this is a narrow upload error/preflight fix.

## UI evidence

No layout change. The user-facing path is covered by unit proof that single-file remote upload errors preserve the underlying unsupported-command message; the proof gist above includes the command results.
