### PR TITLE
Fix invalid remote runtime URL fallback

### DIFF
--- a/src/shared/api/remote-runtime.ts
+++ b/src/shared/api/remote-runtime.ts
@@ -71,10 +71,13 @@ function normalizeRemoteRuntimeUrl(raw: string): RuntimeTarget | null {
 }
 
 export function remoteRuntimeTarget(): RuntimeTarget | null {
+  const raw = useUIStore.getState().remoteRuntimeUrl;
   try {
-    return normalizeRemoteRuntimeUrl(useUIStore.getState().remoteRuntimeUrl);
+    return normalizeRemoteRuntimeUrl(raw);
   } catch {
-    return null;
+    throw new ApiError("Invalid Remote Runtime URL. Check Settings and enter a valid runtime URL.", 400, {
+      code: "invalid_remote_runtime_url",
+    });
   }
 }
 

--- a/src/shared/api/tauri-client.test.ts
+++ b/src/shared/api/tauri-client.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useUIStore } from "../stores/ui.store";
+import { invokeTauri } from "./tauri-client";
+
+const tauriInvoke = vi.hoisted(() => vi.fn());
+const fetchMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: tauriInvoke,
+}));
+
+describe("invokeTauri remote runtime routing", () => {
+  beforeEach(() => {
+    tauriInvoke.mockReset();
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+    useUIStore.setState({ remoteRuntimeUrl: "" });
+  });
+
+  it("falls back to embedded Tauri when no remote runtime URL is configured", async () => {
+    tauriInvoke.mockResolvedValueOnce(["local-character"]);
+
+    await expect(invokeTauri("storage_list", { entity: "characters" })).resolves.toEqual(["local-character"]);
+
+    expect(tauriInvoke).toHaveBeenCalledWith("storage_list", { entity: "characters" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("routes supported commands to a valid configured remote runtime", async () => {
+    useUIStore.setState({ remoteRuntimeUrl: "https://remote.example/runtime///" });
+    fetchMock.mockResolvedValueOnce(new Response(JSON.stringify(["remote-character"]), { status: 200 }));
+
+    await expect(invokeTauri("storage_list", { entity: "characters" })).resolves.toEqual(["remote-character"]);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://remote.example/runtime/api/invoke",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ command: "storage_list", args: { entity: "characters" } }),
+      }),
+    );
+    expect(tauriInvoke).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when a configured remote runtime URL is malformed", async () => {
+    useUIStore.setState({ remoteRuntimeUrl: "http://[bad" });
+    tauriInvoke.mockResolvedValueOnce(["local-character"]);
+
+    await expect(invokeTauri("storage_list", { entity: "characters" })).rejects.toMatchObject({
+      message: "Invalid Remote Runtime URL. Check Settings and enter a valid runtime URL.",
+      status: 400,
+      details: { code: "invalid_remote_runtime_url" },
+    });
+
+    expect(tauriInvoke).not.toHaveBeenCalled();
+  });
+});

--- a/src/shared/api/tauri-client.test.ts
+++ b/src/shared/api/tauri-client.test.ts
@@ -54,5 +54,6 @@ describe("invokeTauri remote runtime routing", () => {
     });
 
     expect(tauriInvoke).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Fixes #1246

## Why this change

- A malformed configured Remote Runtime URL was treated the same as no remote URL, so supported shared Tauri commands could fall back to embedded/local Tauri instead of failing closed.

## What changed

- Preserve the distinction between blank remote runtime config and malformed configured remote runtime config.
- Throw a 400 `ApiError` with `invalid_remote_runtime_url` when parsing a configured Remote Runtime URL fails.
- Add focused regression coverage for blank embedded fallback, valid remote routing, and malformed configured URL fail-closed behavior.

## Refactor impact

Primary owner:

Shared API / remote runtime routing.

Impact areas reviewed:

- Shared Tauri client command routing.
- Remote runtime target parsing.
- Storage-backed `invokeTauri` command behavior.

Boundary notes:

- Blank Remote Runtime URL still uses embedded Tauri.
- Valid Remote Runtime URL still routes supported commands to `/api/invoke`.
- Malformed configured Remote Runtime URL now rejects before embedded/local fallback.

Pressure points touched:

- `src/shared/api/remote-runtime.ts`
- `src/shared/api/tauri-client.test.ts`

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Codex reproduced the original failure with `pnpm exec vitest run src/shared/api/tauri-client.test.ts`: before the fix, the malformed configured URL case resolved through the embedded Tauri mock instead of rejecting.
- Codex verified the fixed behavior with `pnpm exec vitest run src/shared/api/tauri-client.test.ts`: 3 tests passed.
- Edge cases covered by the targeted test:
  - Blank Remote Runtime URL still falls back to embedded Tauri for `storage_list`.
  - Valid Remote Runtime URL still routes supported `storage_list` to remote fetch.
  - Malformed configured Remote Runtime URL rejects with `invalid_remote_runtime_url` and does not call embedded invoke.
- Codex ran `pnpm check`; it passed `check:architecture`, `check:frontend`, `check:rust`, and `check:docs`.
- Codex ran the Marinara proof gate against `scratch/bugfix-verification.json`; it passed.
- Evidence: ![Issue #1246 targeted verification](https://gist.githubusercontent.com/cha1latte/cf9909136c6c35d8009c9420588dbd3b/raw/83be64bd1314da0be6ad7546ad11b34084195d5a/issue-1246-targeted-after.svg)
- Raw targeted output: https://gist.githubusercontent.com/cha1latte/cf9909136c6c35d8009c9420588dbd3b/raw/5c9c260093c2bec21547915f3499d45496185b34/issue-1246-targeted-after.txt

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs or release metadata changes are needed for this narrow shared API routing fix.

## UI evidence

N/A: this is shared runtime routing behavior, not a visible UI change. Non-UI verification evidence is embedded above.
