### PR TITLE
Fix refactor web-shell runtime setup error

### DIFF
--- a/src/shared/api/tauri-client.ts
+++ b/src/shared/api/tauri-client.ts
@@ -15,9 +15,24 @@ function normalize(error: unknown): ApiError {
   return new ApiError(String(error ?? "Tauri command failed"), 500, error);
 }
 
+function hasEmbeddedTauriIpc(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    Boolean((window as unknown as { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__)
+  );
+}
+
 export async function invokeTauri<T>(command: string, args?: Record<string, unknown>): Promise<T> {
-  if (remoteRuntimeTarget() && isRemoteCommand(command)) {
+  const runtimeTarget = remoteRuntimeTarget();
+  const remoteCommand = isRemoteCommand(command);
+  if (runtimeTarget && remoteCommand) {
     return invokeRemote<T>(command, args);
+  }
+  if (!hasEmbeddedTauriIpc()) {
+    throw new ApiError(
+      remoteCommand ? "Remote Runtime URL is not configured" : "This action requires the Tauri app shell",
+      400,
+    );
   }
   try {
     return await invoke<T>(command, args);


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #1233

## Why this change

- In the plain Vite web shell, creating an Image Generation connection with no Remote Runtime URL configured fell through to embedded Tauri IPC and showed a raw `Cannot read properties of undefined (reading 'invoke')` error.
- Users need a setup error that tells them they need a Remote Runtime URL or the Tauri shell, not a JavaScript implementation error.

## What changed

- Added an embedded Tauri IPC availability guard in `src/shared/api/tauri-client.ts`.
- Remote-capable commands now fail with `Remote Runtime URL is not configured` when neither remote runtime nor Tauri IPC is available.
- Tauri-only commands now fail with `This action requires the Tauri app shell` instead of leaking the raw IPC TypeError.

## Refactor impact

Primary owner:

shared API / remote runtime boundary

Impact areas reviewed:

- Vite browser shell with no Remote Runtime URL
- Embedded Tauri IPC path
- Configured Remote Runtime URL path for remote-capable commands

Boundary notes:

- The fix stays in the shared API runtime wrapper.
- It does not change `REMOTE_COMMANDS`, remote HTTP payloads, Rust commands, storage schemas, or provider behavior.
- The configured-but-invalid Remote Runtime URL fail-closed behavior is intentionally out of scope here and tracked separately by #1246.

Pressure points touched:

- `src/shared/api/tauri-client.ts`

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Codex reproduced the pre-fix runtime bug with `pnpm exec vitest run --config scratch\vitest.issue-1233.config.ts --reporter verbose`: before the fix, the missing-runtime `storage_create` row failed because it returned status 500 with the raw `Cannot read properties of undefined` message.
- Codex verified the fixed runtime rows with `pnpm exec vitest run --config scratch\vitest.issue-1233.config.ts --reporter verbose`: 4 tests passed for missing remote runtime, Tauri-only browser error, embedded Tauri IPC, and configured remote runtime HTTP routing.
- Codex verified the actual UI flow with Playwright against `pnpm dev -- --host 127.0.0.1 --port 5176`: Connections -> Add Connection -> Image Generation -> Create now shows `Remote Runtime URL is not configured`, and the page text does not contain the raw TypeError.
- Codex ran `pnpm check`: passed architecture, frontend typecheck, Rust cargo check, and docs.
- Codex ran `pnpm build`: passed Vite production build; only existing chunk/dynamic-import warnings were reported.
- Codex ran the local proof gate: `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json` passed.
- Bunny review pass: passed before opening this PR.
- No human-only verification blockers remain for the core claim.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs or release metadata changes were needed.

## UI evidence

Before, from the linked issue:

![Before: raw Tauri invoke error](https://raw.githubusercontent.com/cha1latte/Marinara-Engine/issue-evidence/image-generation-refactor-20260526/refactor-no-remote-create-connection-error.png)

After, from Codex Playwright verification:

![After: clear Remote Runtime URL setup error](https://raw.githubusercontent.com/cha1latte/Marinara-Engine/issue-evidence/issue-1233-runtime-error/issue-evidence/issue-1233-runtime-error/after.png)
