### PR TITLE
Fix lorebook game-state gates

### DIFF
--- a/src/engine/generation-core/lorebooks/keyword-scanner.ts
+++ b/src/engine/generation-core/lorebooks/keyword-scanner.ts
@@ -70,9 +70,10 @@ export interface GameStateForScanning {
  */
 export function evaluateConditions(conditions: ActivationCondition[], gameState: GameStateForScanning | null): boolean {
   if (conditions.length === 0) return true;
-  if (!gameState) return true; // No game state = conditions pass (permissive)
+  if (!gameState) return false;
 
   for (const condition of conditions) {
+    if (!hasGameStateValue(gameState, condition.field)) return false;
     const fieldValue = String(gameState[condition.field] ?? "");
 
     switch (condition.operator) {
@@ -100,31 +101,55 @@ export function evaluateConditions(conditions: ActivationCondition[], gameState:
   return true;
 }
 
+function hasGameStateValue(gameState: GameStateForScanning, field: string): boolean {
+  const value = gameState[field];
+  return value !== undefined && value !== null && String(value).trim().length > 0;
+}
+
+function scheduleValues(values: string[] | undefined): string[] {
+  return Array.isArray(values) ? values : [];
+}
+
+function hasScheduleGate(schedule: LorebookSchedule): boolean {
+  return (
+    scheduleValues(schedule.activeTimes).length > 0 ||
+    scheduleValues(schedule.activeDates).length > 0 ||
+    scheduleValues(schedule.activeLocations).length > 0
+  );
+}
+
 /**
  * Evaluate schedule conditions against game state.
  */
 function evaluateSchedule(schedule: LorebookSchedule | null, gameState: GameStateForScanning | null): boolean {
   if (!schedule) return true;
-  if (!gameState) return true;
+  if (!hasScheduleGate(schedule)) return true;
+  if (!gameState) return false;
 
   // Check active times
-  if (schedule.activeTimes.length > 0 && gameState.time) {
+  const activeTimes = scheduleValues(schedule.activeTimes);
+  if (activeTimes.length > 0) {
+    if (!hasGameStateValue(gameState, "time")) return false;
     const currentTime = String(gameState.time).toLowerCase();
-    const matches = schedule.activeTimes.some((t) => currentTime.includes(t.toLowerCase()));
+    const matches = activeTimes.some((t) => currentTime.includes(t.toLowerCase()));
     if (!matches) return false;
   }
 
   // Check active dates
-  if (schedule.activeDates.length > 0 && gameState.date) {
+  const activeDates = scheduleValues(schedule.activeDates);
+  if (activeDates.length > 0) {
+    if (!hasGameStateValue(gameState, "date")) return false;
     const currentDate = String(gameState.date).toLowerCase();
-    const matches = schedule.activeDates.some((d) => currentDate.includes(d.toLowerCase()));
+    const matches = activeDates.some((d) => currentDate.includes(d.toLowerCase()));
     if (!matches) return false;
   }
 
   // Check active locations
-  if (schedule.activeLocations.length > 0 && gameState.location) {
+  const activeLocations = scheduleValues(schedule.activeLocations);
+  if (activeLocations.length > 0) {
+    if (!hasGameStateValue(gameState, "location")) return false;
     const currentLoc = String(gameState.location).toLowerCase();
-    const matches = schedule.activeLocations.some((l) => currentLoc.includes(l.toLowerCase()));
+    const matches = activeLocations.some((l) => currentLoc.includes(l.toLowerCase()));
     if (!matches) return false;
   }
 

--- a/src/engine/generation/prompt-assembly.test.ts
+++ b/src/engine/generation/prompt-assembly.test.ts
@@ -48,6 +48,20 @@ function storageWithSections(sections: Row[]): StorageGateway {
   };
 }
 
+function storageWithLore(entries: Row[]): StorageGateway {
+  return {
+    ...storageWithSections([]),
+    list: async <T,>(entity: string) => {
+      if (entity === "lorebooks") return [{ id: "lorebook", enabled: true, isGlobal: true }] as T[];
+      if (entity === "regex-scripts") return [] as T[];
+      if (entity === "personas") return [] as T[];
+      if (entity === "prompts") return [] as T[];
+      return [] as T[];
+    },
+    listLorebookEntries: async <T,>() => entries as T[],
+  };
+}
+
 const request = {
   ...DEFAULT_GENERATION_PARAMS,
   promptPresetId: "preset",
@@ -119,5 +133,96 @@ describe("assembleGenerationPrompt strict roles", () => {
     expect(finalMessage?.role).toBe("user");
     expect(finalMessage?.content).toMatch(/What happens next\?/);
     expect(finalMessage?.content).toMatch(/<style_note>\s*Keep the response concise\.\s*<\/style_note>/);
+  });
+});
+
+describe("assembleGenerationPrompt lorebook game-state gates", () => {
+  const gatedEntry = {
+    id: "entry-1",
+    lorebookId: "lorebook",
+    name: "Moonlit grove only",
+    content: "This lore should only appear in the moonlit grove.",
+    keys: ["moonlit"],
+    enabled: true,
+    activationConditions: [{ field: "location", operator: "equals", value: "moonlit grove" }],
+    schedule: {
+      activeTimes: ["midnight"],
+      activeDates: [],
+      activeLocations: ["moonlit grove"],
+    },
+  };
+
+  it("does not activate lorebook entries when visible game state fails their gates", async () => {
+    const assembly = await assembleGenerationPrompt(storageWithLore([gatedEntry]), {
+      chat: {
+        id: "chat",
+        mode: "roleplay",
+        gameState: { location: "sunny market", time: "noon" },
+      },
+      storedMessages: [{ role: "user", content: "Tell me about the moonlit path.", contextKind: "history" }],
+      connection: {},
+      request: { ...request, promptPresetId: "" },
+      latestUserInput: "Tell me about the moonlit path.",
+    });
+
+    expect(assembly.activatedLorebookEntries).toHaveLength(0);
+  });
+
+  it("does not activate lorebook entries with game-state gates when game state is unavailable", async () => {
+    const assembly = await assembleGenerationPrompt(storageWithLore([gatedEntry]), {
+      chat: {
+        id: "chat",
+        mode: "roleplay",
+      },
+      storedMessages: [{ role: "user", content: "Tell me about the moonlit path.", contextKind: "history" }],
+      connection: {},
+      request: { ...request, promptPresetId: "" },
+      latestUserInput: "Tell me about the moonlit path.",
+    });
+
+    expect(assembly.activatedLorebookEntries).toHaveLength(0);
+  });
+
+  it("activates lorebook entries when visible game state satisfies their gates", async () => {
+    const assembly = await assembleGenerationPrompt(storageWithLore([gatedEntry]), {
+      chat: {
+        id: "chat",
+        mode: "roleplay",
+        gameState: { location: "moonlit grove", time: "midnight" },
+      },
+      storedMessages: [{ role: "user", content: "Tell me about the moonlit path.", contextKind: "history" }],
+      connection: {},
+      request: { ...request, promptPresetId: "" },
+      latestUserInput: "Tell me about the moonlit path.",
+    });
+
+    expect(assembly.activatedLorebookEntries.map((entry) => entry.name)).toEqual(["Moonlit grove only"]);
+  });
+
+  it("keeps ungated lorebook entries active when game state is unavailable", async () => {
+    const assembly = await assembleGenerationPrompt(
+      storageWithLore([
+        {
+          id: "entry-2",
+          lorebookId: "lorebook",
+          name: "Ungated moonlit lore",
+          content: "This lore only needs the keyword.",
+          keys: ["moonlit"],
+          enabled: true,
+        },
+      ]),
+      {
+        chat: {
+          id: "chat",
+          mode: "roleplay",
+        },
+        storedMessages: [{ role: "user", content: "Tell me about the moonlit path.", contextKind: "history" }],
+        connection: {},
+        request: { ...request, promptPresetId: "" },
+        latestUserInput: "Tell me about the moonlit path.",
+      },
+    );
+
+    expect(assembly.activatedLorebookEntries.map((entry) => entry.name)).toEqual(["Ungated moonlit lore"]);
   });
 });

--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -1027,13 +1027,15 @@ async function loadActivatedLore(
   const entries = rows.map(normalizeLorebookEntry).filter((entry) => entry.enabled && entry.content.trim());
   const activeCharacterIds = characters.map((character) => character.id);
   const activeCharacterTags = characters.flatMap((character) => character.tags);
+  const meta = parseRecord(chat.metadata);
+  const gameState = parseRecord(chat.gameState ?? meta.gameState);
   return scanForActivatedEntries(
     storedMessages.filter((message) => !hiddenFromAi(message)).map((message) => ({
       role: readString(message.role, "user"),
       content: readString(message.content),
     })),
     entries,
-    { activeCharacterIds, activeCharacterTags, generationTriggers: ["chat", readString(chat.mode)] },
+    { activeCharacterIds, activeCharacterTags, generationTriggers: ["chat", readString(chat.mode)], gameState },
   );
 }
 


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #1249

## Why this change

- Lorebook entries with game-state activation conditions or schedules could activate during prompt assembly even when the visible game state did not satisfy their gates.
- The scanner also treated missing game state as a pass for configured gates, which could leak conditional lore into the assembled prompt.

## What changed

- Pass the chat's visible game state into lorebook scanning during prompt assembly.
- Make configured activation conditions and schedules fail closed when required game-state data is unavailable.
- Added prompt assembly regression coverage for mismatched game state, unavailable game state, matching game state, and ungated lore compatibility.

## Refactor impact

Primary owner:

- Engine generation

Impact areas reviewed:

- Prompt assembly
- Lorebook keyword scanning
- Roleplay/chat generation lore injection behavior

Boundary notes:

- No schema, storage, dependency, prompt preset, UI, or Rust behavior changes.
- Ungated lore still activates without game state; only entries with game-state gates fail closed when the required state is unavailable or does not match.

Pressure points touched:

- `src/engine/generation/prompt-assembly.ts`
- `src/engine/generation-core/lorebooks/keyword-scanner.ts`

## Validation

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Codex reproduced the bug before the fix with `pnpm test -- src/engine/generation/prompt-assembly.test.ts`; the new mismatch row failed because the gated entry activated.
- Codex reran `pnpm test -- src/engine/generation/prompt-assembly.test.ts` after the fix: 6 tests passed.
- Codex ran `pnpm check`: architecture, frontend typecheck, Rust check, and docs check passed.
- Codex ran the Marinara proof gate on `scratch/bugfix-verification.json`: passed.
- Bunny review before PR: passed for focused scope, proof quality, and no schema/version/dependency expansion.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A - this is non-UI prompt assembly behavior. The proof is the focused prompt assembly regression plus `pnpm check`.
