### PR TITLE
Fix tauri client fallback test setup

### DIFF
--- a/src/shared/api/tauri-client.test.ts
+++ b/src/shared/api/tauri-client.test.ts
@@ -5,6 +5,7 @@ import { invokeTauri } from "./tauri-client";
 
 const tauriInvoke = vi.hoisted(() => vi.fn());
 const fetchMock = vi.hoisted(() => vi.fn());
+const tauriInternals = {};
 
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: tauriInvoke,
@@ -15,10 +16,12 @@ describe("invokeTauri remote runtime routing", () => {
     tauriInvoke.mockReset();
     fetchMock.mockReset();
     vi.stubGlobal("fetch", fetchMock);
+    delete (window as unknown as { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
     useUIStore.setState({ remoteRuntimeUrl: "" });
   });
 
   it("falls back to embedded Tauri when no remote runtime URL is configured", async () => {
+    (window as unknown as { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = tauriInternals;
     tauriInvoke.mockResolvedValueOnce(["local-character"]);
 
     await expect(invokeTauri("storage_list", { entity: "characters" })).resolves.toEqual(["local-character"]);


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

<!-- Every user-facing PR should reference a feature request or issue report when practical. -->

No standalone issue. Unblocks the current `refactor` CI failure seen on #1300.

## Why this change

<!-- What user problem, bug, refactor goal, or maintenance need does this solve? -->

- Current `refactor` CI fails in `src/shared/api/tauri-client.test.ts` because the embedded-Tauri fallback test mocks `@tauri-apps/api/core.invoke` but does not simulate the Tauri IPC marker that production code now requires before falling back to embedded Tauri.

## What changed

<!-- List the key changes in this PR. -->

- Clears the mocked Tauri IPC marker before each remote-runtime routing test.
- Sets the mocked Tauri IPC marker only in the fallback test that expects embedded Tauri invocation.
- Leaves production remote-runtime and Tauri shell behavior unchanged.

## Refactor impact

Primary owner:

<!-- Examples: app shell, catalog, chat mode, roleplay mode, game mode, runtime generation, world-state, shared API, engine generation, Rust storage, imports, remote runtime. -->

Shared API / remote runtime test coverage.

Impact areas reviewed:

- `src/shared/api/tauri-client.test.ts`
- `src/shared/api/tauri-client.ts`
- `src/shared/api/remote-runtime.ts`

Boundary notes:

<!-- Note engine/shared-api/feature/Rust/remote-runtime boundaries. Say "none" only if you checked. -->

- Test-only change. No production routing, storage, schema, dependency, release metadata, or UI behavior changes.

Pressure points touched:

<!-- Mention ModeSurface, GameSurface, shared mode UI, src-tauri/src/lib.rs command registration, or import modules if touched. -->

- None; this only updates the remote-runtime unit test setup.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app/runtime, step by step. If an AI agent filled this out, verify it yourself before ticking boxes. -->

- Codex reproduced the failure before the fix with `pnpm exec vitest run src/shared/api/tauri-client.test.ts`; report saved at `scratch/remote-runtime-before.json`.
- Codex verified the targeted file after the fix with `pnpm exec vitest run src/shared/api/tauri-client.test.ts`; report saved at `scratch/remote-runtime-after.json`.
- Codex ran `pnpm test`; 17 test files and 67 tests passed.
- Codex ran `pnpm check`; architecture, frontend typecheck, Rust check, and docs check passed.
- Codex ran `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch/bugfix-verification.json`; the proof gate passed.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs or release metadata changes are needed for this test-only CI fix.

## UI evidence

<!-- Add before/after screenshots or recordings for visible UI changes. -->

N/A. This is a test-only CI fix, not a visible UI change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test setup and teardown procedures for improved test isolation and reliability.

---

**Note:** This release includes internal testing improvements with no user-facing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1303?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->