### PR TITLE
Fix remote message delete tracker cleanup

### DIFF
--- a/src-tauri/src/commands/storage/commands/entities.rs
+++ b/src-tauri/src/commands/storage/commands/entities.rs
@@ -211,33 +211,35 @@ pub async fn storage_delete(
     force: Option<bool>,
 ) -> Result<Value, AppError> {
     let state = state.inner().clone();
-    tauri::async_runtime::spawn_blocking(move || storage_delete_inner(&state, entity, id, force))
-        .await
-        .map_err(|error| AppError::new("task_join_error", error.to_string()))?
+    tauri::async_runtime::spawn_blocking(move || {
+        delete_entity(&state, &entity, &id, force.unwrap_or(false))
+    })
+    .await
+    .map_err(|error| AppError::new("task_join_error", error.to_string()))?
 }
 
-fn storage_delete_inner(
+pub(crate) fn delete_entity(
     state: &AppState,
-    entity: String,
-    id: String,
-    force: Option<bool>,
+    entity: &str,
+    id: &str,
+    force: bool,
 ) -> Result<Value, AppError> {
     if entity == "connections" {
-        return crate::connection_refs::delete_connection(state, &id, force.unwrap_or(false));
+        return crate::connection_refs::delete_connection(state, id, force);
     }
     if entity == "chats" {
-        let existed = state.storage.get("chats", &id)?.is_some();
+        let existed = state.storage.get("chats", id)?.is_some();
         if existed {
-            chats::delete_chat_with_messages(state, &id)?;
+            chats::delete_chat_with_messages(state, id)?;
         }
         return Ok(json!({ "deleted": existed }));
     }
-    if is_protected_record(&entity, &id) {
+    if is_protected_record(entity, id) {
         return Err(AppError::invalid_input(
             "Protected records cannot be deleted",
         ));
     }
-    let existing = owned_record_for_delete(state, &entity, &id)?;
+    let existing = owned_record_for_delete(state, entity, id)?;
     let message_chat_id = if entity == "messages" {
         existing
             .as_ref()
@@ -247,13 +249,13 @@ fn storage_delete_inner(
     } else {
         None
     };
-    let deleted = state.storage.delete(&entity, &id)?;
+    let deleted = state.storage.delete(entity, id)?;
     if deleted {
         if let Some(record) = existing.as_ref() {
-            remove_owned_media(state, &entity, record);
+            remove_owned_media(state, entity, record);
         }
         if let Some(chat_id) = message_chat_id {
-            game_state_snapshots::delete_tracker_snapshots_for_message(state, &chat_id, &id)?;
+            game_state_snapshots::delete_tracker_snapshots_for_message(state, &chat_id, id)?;
             game_state_snapshots::sync_chat_game_state_to_visible_tracker(state, &chat_id)?;
         }
     }

--- a/src-tauri/src/http_dispatch.rs
+++ b/src-tauri/src/http_dispatch.rs
@@ -1,8 +1,6 @@
-use crate::builtins::is_protected_record;
 use crate::state::AppState;
 use crate::storage_commands::{
-    avatars, backgrounds, chats, generation, images, imports, llm, lorebook_images, profile,
-    shared, sprites,
+    backgrounds, chats, entity_commands, generation, images, imports, llm, profile, shared, sprites,
 };
 use marinara_core::{AppError, AppResult};
 use serde::Deserialize;
@@ -223,33 +221,12 @@ fn storage_update(state: &AppState, args: &Map<String, Value>) -> AppResult<Valu
 fn storage_delete(state: &AppState, args: &Map<String, Value>) -> AppResult<Value> {
     let entity = required_string(args, "entity")?;
     let id = required_string(args, "id")?;
-    if entity == "connections" {
-        return crate::connection_refs::delete_connection(
-            state,
-            id,
-            args.get("force").and_then(Value::as_bool).unwrap_or(false),
-        );
-    }
-    if entity == "chats" {
-        let existed = state.storage.get("chats", id)?.is_some();
-        if existed {
-            chats::delete_chat_with_messages(state, id)?;
-        }
-        return Ok(json!({ "deleted": existed }));
-    }
-    if is_protected_record(entity, id) {
-        return Err(AppError::invalid_input(
-            "Protected records cannot be deleted",
-        ));
-    }
-    let existing = media_owned_record(state, entity, id)?;
-    let deleted = state.storage.delete(entity, id)?;
-    if deleted {
-        if let Some(record) = existing.as_ref() {
-            remove_owned_media(state, entity, record);
-        }
-    }
-    Ok(json!({ "deleted": deleted }))
+    entity_commands::delete_entity(
+        state,
+        entity,
+        id,
+        args.get("force").and_then(Value::as_bool).unwrap_or(false),
+    )
 }
 
 fn storage_duplicate(state: &AppState, args: &Map<String, Value>) -> AppResult<Value> {
@@ -384,21 +361,6 @@ async fn sprite_generate_sheet_preview(
 
 fn llm_stream_cancel(state: &AppState, args: &Map<String, Value>) -> AppResult<Value> {
     llm::llm_stream_cancel(state, required_string(args, "streamId")?)
-}
-
-fn media_owned_record(state: &AppState, entity: &str, id: &str) -> AppResult<Option<Value>> {
-    match entity {
-        "characters" | "personas" | "lorebooks" => state.storage.get(entity, id),
-        _ => Ok(None),
-    }
-}
-
-fn remove_owned_media(state: &AppState, entity: &str, record: &Value) {
-    match entity {
-        "characters" | "personas" => avatars::remove_avatar_file(state, entity, record),
-        "lorebooks" => lorebook_images::remove_lorebook_image_file(state, record),
-        _ => {}
-    }
 }
 
 fn compare_json_values(left: Option<&Value>, right: Option<&Value>) -> std::cmp::Ordering {
@@ -604,5 +566,128 @@ mod tests {
             result.get("originalName").and_then(Value::as_str),
             Some("background.png")
         );
+    }
+
+    #[tokio::test]
+    async fn dispatch_storage_delete_message_cleans_tracker_snapshots() {
+        let state = test_state("message-delete-tracker-cleanup");
+        state
+            .storage
+            .create(
+                "chats",
+                json!({
+                    "id": "chat-1",
+                    "name": "Tracker chat",
+                    "gameState": { "kind": "tracker", "chatId": "chat-1", "messageId": "message-2", "swipeIndex": 0 }
+                }),
+            )
+            .unwrap();
+        for (message_id, created_at) in [
+            ("message-1", "2026-05-26T10:00:00Z"),
+            ("message-2", "2026-05-26T10:01:00Z"),
+        ] {
+            state
+                .storage
+                .create(
+                    "messages",
+                    json!({
+                        "id": message_id,
+                        "chatId": "chat-1",
+                        "role": "assistant",
+                        "content": "turn",
+                        "createdAt": created_at
+                    }),
+                )
+                .unwrap();
+            state
+                .storage
+                .create(
+                    "game-state-snapshots",
+                    json!({
+                        "id": format!("snapshot-{message_id}"),
+                        "kind": "tracker",
+                        "chatId": "chat-1",
+                        "messageId": message_id,
+                        "swipeIndex": 0,
+                        "createdAt": created_at,
+                        "location": message_id
+                    }),
+                )
+                .unwrap();
+        }
+
+        let result = dispatch(
+            &state,
+            InvokeRequest {
+                command: "storage_delete".to_string(),
+                args: Some(json!({ "entity": "messages", "id": "message-2" })),
+            },
+        )
+        .await
+        .expect("remote message delete should dispatch");
+
+        assert_eq!(result["deleted"], true);
+        assert!(state
+            .storage
+            .get("messages", "message-2")
+            .unwrap()
+            .is_none());
+        assert!(state
+            .storage
+            .get("game-state-snapshots", "snapshot-message-2")
+            .unwrap()
+            .is_none());
+        assert!(state
+            .storage
+            .get("game-state-snapshots", "snapshot-message-1")
+            .unwrap()
+            .is_some());
+        let chat = state.storage.get("chats", "chat-1").unwrap().unwrap();
+        assert_eq!(
+            chat["gameState"].get("messageId").and_then(Value::as_str),
+            Some("message-1")
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_storage_delete_non_message_keeps_tracker_snapshots() {
+        let state = test_state("non-message-delete-tracker-control");
+        state
+            .storage
+            .create(
+                "personas",
+                json!({ "id": "persona-1", "name": "Keep tracker snapshots" }),
+            )
+            .unwrap();
+        state
+            .storage
+            .create(
+                "game-state-snapshots",
+                json!({
+                    "id": "snapshot-message-1",
+                    "kind": "tracker",
+                    "chatId": "chat-1",
+                    "messageId": "message-1",
+                    "swipeIndex": 0
+                }),
+            )
+            .unwrap();
+
+        let result = dispatch(
+            &state,
+            InvokeRequest {
+                command: "storage_delete".to_string(),
+                args: Some(json!({ "entity": "personas", "id": "persona-1" })),
+            },
+        )
+        .await
+        .expect("remote non-message delete should dispatch");
+
+        assert_eq!(result["deleted"], true);
+        assert!(state
+            .storage
+            .get("game-state-snapshots", "snapshot-message-1")
+            .unwrap()
+            .is_some());
     }
 }


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #1247

## Why this change

- Remote `/api/invoke` `storage_delete` had drifted from embedded Tauri `storage_delete` for message records, so deleting a message through the remote runtime could leave tracker snapshots and stale `chats.gameState` behind.

## What changed

- Exposed the embedded storage-delete owner as a shared `delete_entity` helper.
- Routed HTTP `storage_delete` through that helper instead of maintaining a second generic delete implementation.
- Added dispatcher regression coverage for remote message deletion cleanup and a non-message negative control.

## Refactor impact

Primary owner:

- Rust storage / remote runtime

Impact areas reviewed:

- Remote runtime `/api/invoke`
- Embedded Tauri storage commands
- Tracker snapshot cleanup
- Chat `gameState` synchronization

Boundary notes:

- The HTTP dispatcher now calls the storage command owner for delete semantics, so embedded and remote delete paths cannot drift on protected records, chat cascades, media cleanup, message tracker cleanup, or forced connection deletion.

Pressure points touched:

- `src-tauri/src/commands/storage/commands/entities.rs`
- `src-tauri/src/http_dispatch.rs`

## Validation

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Codex proof: `cargo test dispatch_storage_delete` failed before the fix because `snapshot-message-2` survived remote message deletion, then passed after the fix with the message cleanup test and non-message negative control.
- Codex proof: `pnpm check` passed after rebasing onto current `upstream/refactor`; it ran architecture, frontend typecheck, Rust workspace check, and docs checks.
- Codex proof: `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json` passed with a storage/cross-entrypoint risk matrix.
- Manual verification not required for the core claim; this is backend/runtime storage semantics covered by the dispatcher harness.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A: no visible UI changed. The proof is the Rust dispatcher harness for remote runtime storage deletion.
