### PR TITLE
Fix assistant regenerate replay metadata

### DIFF
--- a/src/engine/generation/start-generation.test.ts
+++ b/src/engine/generation/start-generation.test.ts
@@ -43,6 +43,7 @@ function generationDepsForChat(options: {
   const initialMessages = options.initialMessages ?? [
     { id: "assistant-1", chatId: "chat-1", role: "assistant", content: "What now?" },
   ];
+  const messagesById = new Map(initialMessages.map((message) => [String(message.id), message]));
   const listChatMessages = vi.fn(async () =>
     listChatMessages.mock.calls.length > 1 && options.messagesAfterSave
       ? options.messagesAfterSave
@@ -59,10 +60,24 @@ function generationDepsForChat(options: {
     }
     return { id: "assistant-2", chatId: "chat-1", ...value };
   });
+  const addChatMessageSwipe = vi.fn(async (_chatId: string, messageId: string, content: string) => ({
+    ...messagesById.get(messageId),
+    content,
+    activeSwipeIndex: 1,
+    swipeCount: 2,
+  }));
+  const patchChatMessageExtra = vi.fn(async (messageId: string, patch: Record<string, unknown>) => ({
+    ...messagesById.get(messageId),
+    extra: {
+      ...((messagesById.get(messageId)?.extra as Record<string, unknown> | undefined) ?? {}),
+      ...patch,
+    },
+  }));
   const storage = {
     get: vi.fn(async (entity: string, id: string) => {
       if (entity === "chats" && id === "chat-1") return chat;
       if (entity === "connections" && id === "connection-1") return connection;
+      if (entity === "messages") return messagesById.get(id) ?? null;
       return null;
     }),
     list: vi.fn(async (entity: string) => {
@@ -72,6 +87,8 @@ function generationDepsForChat(options: {
     }),
     create: vi.fn(async (_entity: string, value: Record<string, unknown>) => value),
     createChatMessage,
+    addChatMessageSwipe,
+    patchChatMessageExtra,
     listChatMessages,
     listChatMemories: vi.fn(async () => []),
     listLorebookEntries: vi.fn(async () => []),
@@ -82,7 +99,7 @@ function generationDepsForChat(options: {
     llm: { stream } as Partial<LlmGateway> as LlmGateway,
     integrations: {} as GenerationEngineDeps["integrations"],
   };
-  return { deps, listChatMessages, streamedRequests };
+  return { deps, createChatMessage, addChatMessageSwipe, patchChatMessageExtra, listChatMessages, streamedRequests };
 }
 
 async function drainGeneration(stream: AsyncGenerator<unknown>) {
@@ -197,6 +214,128 @@ describe("startGeneration chat message loading", () => {
     expect(streamedRequests[0]).toMatchObject({
       messages: expect.arrayContaining([expect.objectContaining({ role: "user", content: "hello" })]),
     });
+  });
+});
+
+describe("startGeneration generation replay metadata", () => {
+  it("stores guided replay metadata on the generated assistant message", async () => {
+    const { deps, createChatMessage } = generationDepsForChat();
+
+    await drainGeneration(
+      startGeneration(deps, {
+        chatId: "chat-1",
+        userMessage: "hello",
+        generationGuide: "Keep the reply clipped.",
+        generationGuideSource: "guide",
+        impersonateBlockAgents: true,
+      }),
+    );
+
+    const assistantSave = createChatMessage.mock.calls.find(([, value]) => value.role === "assistant");
+    expect(assistantSave?.[1]).toMatchObject({
+      extra: {
+        generationReplay: {
+          generationGuide: "Keep the reply clipped.",
+          generationGuideSource: "guide",
+        },
+      },
+    });
+  });
+
+  it("updates the regenerated assistant target with replay metadata for the new active swipe", async () => {
+    const { deps, addChatMessageSwipe, patchChatMessageExtra } = generationDepsForChat({
+      initialMessages: [
+        { id: "user-1", chatId: "chat-1", role: "user", content: "hello" },
+        { id: "assistant-1", chatId: "chat-1", role: "assistant", content: "first reply", extra: {} },
+      ],
+    });
+
+    await drainGeneration(
+      startGeneration(deps, {
+        chatId: "chat-1",
+        regenerateMessageId: "assistant-1",
+        generationGuide: "Make this one colder.",
+        generationGuideSource: "guide",
+      }),
+    );
+
+    expect(addChatMessageSwipe).toHaveBeenCalledWith("chat-1", "assistant-1", "Done.");
+    expect(patchChatMessageExtra).toHaveBeenCalledWith("assistant-1", {
+      generationReplay: {
+        generationGuide: "Make this one colder.",
+        generationGuideSource: "guide",
+      },
+    });
+  });
+
+  it("applies stored assistant replay metadata for direct engine regenerates", async () => {
+    const { deps, streamedRequests } = generationDepsForChat({
+      initialMessages: [
+        { id: "user-1", chatId: "chat-1", role: "user", content: "hello" },
+        {
+          id: "assistant-1",
+          chatId: "chat-1",
+          role: "assistant",
+          content: "first reply",
+          extra: {
+            generationReplay: {
+              generationGuide: "Keep the reply clipped.",
+              generationGuideSource: "guide",
+            },
+          },
+        },
+      ],
+    });
+
+    await drainGeneration(startGeneration(deps, { chatId: "chat-1", regenerateMessageId: "assistant-1" }));
+
+    expect(streamedRequests[0]).toMatchObject({
+      messages: expect.arrayContaining([
+        expect.objectContaining({ role: "user", content: "Keep the reply clipped." }),
+      ]),
+    });
+  });
+
+  it("does not invent replay metadata for plain regenerates without stored replay", async () => {
+    const { deps, patchChatMessageExtra, streamedRequests } = generationDepsForChat({
+      initialMessages: [
+        { id: "user-1", chatId: "chat-1", role: "user", content: "hello" },
+        { id: "assistant-1", chatId: "chat-1", role: "assistant", content: "first reply", extra: {} },
+      ],
+    });
+
+    await drainGeneration(startGeneration(deps, { chatId: "chat-1", regenerateMessageId: "assistant-1" }));
+
+    expect(patchChatMessageExtra).not.toHaveBeenCalled();
+    expect((streamedRequests[0] as { messages: Array<{ content: string }> }).messages).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ content: "Keep the reply clipped." })]),
+    );
+  });
+
+  it("ignores stored replay metadata from a target outside the active chat", async () => {
+    const { deps, streamedRequests } = generationDepsForChat({
+      initialMessages: [
+        { id: "user-1", chatId: "chat-1", role: "user", content: "hello" },
+        {
+          id: "assistant-1",
+          chatId: "other-chat",
+          role: "assistant",
+          content: "first reply",
+          extra: {
+            generationReplay: {
+              generationGuide: "Wrong chat guide.",
+              generationGuideSource: "guide",
+            },
+          },
+        },
+      ],
+    });
+
+    await drainGeneration(startGeneration(deps, { chatId: "chat-1", regenerateMessageId: "assistant-1" }));
+
+    expect((streamedRequests[0] as { messages: Array<{ content: string }> }).messages).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ content: "Wrong chat guide." })]),
+    );
   });
 });
 

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -19,7 +19,11 @@ import {
   type PromptAttachment,
 } from "./generate-route-utils";
 import type { GenerationEvent } from "./generation-events";
-import { buildGenerationReplay } from "./generation-replay";
+import {
+  applyGenerationReplayToRegenerateInput,
+  buildGenerationReplay,
+  normalizeGenerationReplay,
+} from "./generation-replay";
 import { assembleGenerationPrompt } from "./prompt-assembly";
 import type { GenerationCharacterContext } from "./prompt-assembly";
 import { applyRuntimeRegexScripts } from "./regex-runtime";
@@ -162,6 +166,25 @@ function savedUserMessageForTimeline(saved: unknown, chatId: string): JsonRecord
   if (readString(saved.role).trim() !== "user") return null;
   if (!readString(saved.content).trim()) return null;
   return saved;
+}
+
+async function inputWithStoredGenerationReplay(
+  storage: StorageGateway,
+  chatId: string,
+  input: StartGenerationInput,
+): Promise<StartGenerationInput> {
+  const regenerateMessageId = readString(input.regenerateMessageId).trim();
+  if (!regenerateMessageId) return input;
+
+  const target = await storage.get("messages", regenerateMessageId).catch(() => null);
+  if (!isRecord(target) || readString(target.chatId).trim() !== chatId) return input;
+
+  const replay = normalizeGenerationReplay(parseRecord(target.extra).generationReplay);
+  if (!replay) return input;
+
+  const nextInput = { ...input };
+  applyGenerationReplayToRegenerateInput(nextInput, replay);
+  return nextInput;
 }
 
 function requestMessages(input: StartGenerationInput): LlmMessage[] | null {
@@ -347,8 +370,11 @@ async function saveAssistantMessage(args: {
   if (args.input.impersonate === true) return null;
 
   const regenerateMessageId = readString(args.input.regenerateMessageId).trim();
+  const generationReplay = buildGenerationReplay(args.input);
   if (regenerateMessageId) {
-    return args.storage.addChatMessageSwipe(args.input.chatId, regenerateMessageId, args.content);
+    const saved = await args.storage.addChatMessageSwipe(args.input.chatId, regenerateMessageId, args.content);
+    if (!generationReplay) return saved;
+    return args.storage.patchChatMessageExtra(regenerateMessageId, { generationReplay });
   }
 
   const requestedCharacterId = readString(args.input.forCharacterId).trim();
@@ -365,7 +391,10 @@ async function saveAssistantMessage(args: {
     role: "assistant",
     characterId,
     content: args.content,
-    extra: args.attachments?.length ? { attachments: args.attachments } : {},
+    extra: {
+      ...(args.attachments?.length ? { attachments: args.attachments } : {}),
+      ...(generationReplay ? { generationReplay } : {}),
+    },
     generationInfo: {
       connectionId: readString(args.connection.id) || null,
       model: readString(args.connection.model) || null,
@@ -674,6 +703,7 @@ export async function* startGeneration(
   if (!chatId) throw new Error("chatId is required");
   const chat = requireRecord(await deps.storage.get("chats", chatId), "Chat");
   assertChatCanGenerate(chat);
+  input = await inputWithStoredGenerationReplay(deps.storage, chatId, input);
 
   yield { type: "phase", data: "Saving message..." };
   const preparedUserInput = await prepareUserInput(deps.storage, input);


### PR DESCRIPTION
## Linked issue

Closes #1248

## Why this change

- Assistant regeneration on the `refactor` branch could lose the replay payload that shaped the original assistant response.
- The generation path built replay data, but the regenerate path expects to read it from the assistant target, so guided regenerates and direct engine regenerates could drift.

## What changed

- Rehydrates stored assistant replay payloads before engine-level regenerate requests run.
- Stores replay payloads on newly generated assistant messages.
- Updates the regenerated assistant target when a new guided replay swipe becomes active.
- Adds focused regression coverage for positive replay rows and negative controls.

## Refactor impact

Primary owner:

engine generation

Impact areas reviewed:

- runtime generation regenerate wrapper
- assistant message extra contract
- direct engine regenerate path
- refactor branch PR template/base expectations

Boundary notes:

- Product behavior stays in `src/engine`.
- No React, shared API adapter, Rust storage, schema, dependency, version, or release metadata changes.

Pressure points touched:

- `src/engine/generation/start-generation.ts`

## Validation

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Codex ran `pnpm exec vitest run src/engine/generation/start-generation.test.ts --reporter=json --outputFile=scratch/issue-1248-vitest-after.json`.
- Codex ran `pnpm typecheck`.
- Codex ran `pnpm check`, covering architecture, frontend/typecheck, Rust `cargo check`, and docs checks.
- Codex ran `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json`.
- Bunny review passed before opening the PR.
- No browser/Tauri manual verification was run because this is an engine replay-contract fix with focused harness coverage.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs or release files changed.

## UI evidence

N/A: no visible UI changes.
