### PR TITLE
Fix Tauri client test shell stub

### DIFF
--- a/src/shared/api/tauri-client.test.ts
+++ b/src/shared/api/tauri-client.test.ts
@@ -15,6 +15,7 @@ describe("invokeTauri remote runtime routing", () => {
     tauriInvoke.mockReset();
     fetchMock.mockReset();
     vi.stubGlobal("fetch", fetchMock);
+    vi.stubGlobal("__TAURI_INTERNALS__", {});
     useUIStore.setState({ remoteRuntimeUrl: "" });
   });
 


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #

## Why this change

- The `Frontend, Architecture, and Organization` CI lane was failing in `pnpm test` because `src/shared/api/tauri-client.test.ts` expected embedded Tauri fallback without simulating an embedded Tauri shell.
- Runtime code correctly fails closed when neither a valid remote runtime nor embedded Tauri IPC is available; the test needed to model the embedded shell before expecting the local invoke path.

## What changed

- Stub `__TAURI_INTERNALS__` in the Tauri client routing test setup so the embedded fallback test represents the Tauri app shell.
- No production runtime behavior changed.

## Refactor impact

Primary owner:

- Shared API

Impact areas reviewed:

- Remote runtime routing tests
- Embedded Tauri fallback test coverage

Boundary notes:

- Test-only change.
- No runtime code, schema, storage, dependency, UI, Rust, or release metadata changes.

Pressure points touched:

- `src/shared/api/tauri-client.test.ts`

## Validation

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Codex reproduced the pre-fix failure with `pnpm test -- src/shared/api/tauri-client.test.ts`: the fallback test rejected with `Remote Runtime URL is not configured`.
- Codex reran `pnpm test -- src/shared/api/tauri-client.test.ts` after the fix: 3 tests passed.
- Codex ran `pnpm test`: 17 test files and 67 tests passed.
- Codex ran `pnpm check`: architecture, frontend typecheck, Rust check, and docs check passed.
- Codex ran the Marinara proof gate on `scratch/tauri-ci-verification.json`: passed.
- Bunny review before PR: passed for focused test-only scope and unchanged runtime behavior.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A - test-only CI fix.
