### PR TITLE
Fix provider lookup fallback metadata

### DIFF
--- a/src-tauri/src/commands/storage/integrations/tts.rs
+++ b/src-tauri/src/commands/storage/integrations/tts.rs
@@ -197,9 +197,9 @@ async fn voices(state: &AppState) -> AppResult<Value> {
         ));
     }
     if source == "elevenlabs" {
-        return elevenlabs_voices(&config, &base)
+        return Ok(elevenlabs_voices(&config, &base)
             .await
-            .or_else(|_| Ok(fallback_voices(source)));
+            .unwrap_or_else(|error| fallback_voices_with_error(source, &error)));
     }
     if source == "pockettts" {
         return Ok(fallback_voices(source));
@@ -218,17 +218,49 @@ async fn voices(state: &AppState) -> AppResult<Value> {
         .await;
     match response {
         Ok(response) if response.status().is_success() => {
-            let data = response.json::<Value>().await.unwrap_or(Value::Null);
+            let data = match response.json::<Value>().await {
+                Ok(data) => data,
+                Err(error) => {
+                    return Ok(fallback_voices_with_error(
+                        source,
+                        &AppError::new("tts_response_error", error.to_string()),
+                    ));
+                }
+            };
             let parsed = parse_voice_options(&data);
             if parsed.is_empty() {
-                Ok(fallback_voices(source))
+                Ok(fallback_voices_with_error(
+                    source,
+                    &AppError::new("tts_provider_error", "TTS provider returned no voices"),
+                ))
             } else {
                 Ok(
-                    json!({ "voices": parsed.iter().filter_map(|voice| voice.get("id").cloned()).collect::<Vec<_>>(), "voiceOptions": parsed, "fromProvider": true, "source": source }),
+                    json!({ "voices": parsed.iter().filter_map(|voice| voice.get("id").cloned()).collect::<Vec<_>>(), "voiceOptions": parsed, "fromProvider": true, "fallback": false, "source": source }),
                 )
             }
         }
-        _ => Ok(fallback_voices(source)),
+        Ok(response) => {
+            let status = response.status();
+            let detail = response
+                .text()
+                .await
+                .unwrap_or_default()
+                .chars()
+                .take(300)
+                .collect::<String>();
+            Ok(fallback_voices_with_error(
+                source,
+                &AppError::with_details(
+                    "tts_provider_error",
+                    format!("TTS provider returned HTTP {status}"),
+                    json!({ "detail": detail }),
+                ),
+            ))
+        }
+        Err(error) => Ok(fallback_voices_with_error(
+            source,
+            &AppError::new("tts_provider_unreachable", error.to_string()),
+        )),
     }
 }
 
@@ -476,6 +508,17 @@ fn fallback_voices(source: &str) -> Value {
     }
 }
 
+fn fallback_voices_with_error(source: &str, error: &AppError) -> Value {
+    let mut response = fallback_voices(source);
+    response["fallback"] = json!(true);
+    response["providerError"] = json!(error.message.clone());
+    response["providerErrorCode"] = json!(error.code.clone());
+    if let Some(details) = error.details.clone() {
+        response["providerErrorDetails"] = details;
+    }
+    response
+}
+
 fn voice_options_response(
     source: &str,
     voices: &[&str],
@@ -496,6 +539,7 @@ fn voice_options_response(
         "voices": voices,
         "voiceOptions": options,
         "fromProvider": from_provider,
+        "fallback": !from_provider,
         "source": source
     })
 }
@@ -519,15 +563,33 @@ async fn elevenlabs_voices(config: &Value, base: &str) -> AppResult<Value> {
         .await
         .map_err(|error| AppError::new("tts_provider_unreachable", error.to_string()))?;
     if !response.status().is_success() {
-        return Ok(fallback_voices("elevenlabs"));
+        let status = response.status();
+        let detail = response
+            .text()
+            .await
+            .unwrap_or_default()
+            .chars()
+            .take(300)
+            .collect::<String>();
+        return Err(AppError::with_details(
+            "tts_provider_error",
+            format!("TTS provider returned HTTP {status}"),
+            json!({ "detail": detail }),
+        ));
     }
-    let data = response.json::<Value>().await.unwrap_or(Value::Null);
+    let data = response
+        .json::<Value>()
+        .await
+        .map_err(|error| AppError::new("tts_response_error", error.to_string()))?;
     let parsed = parse_voice_options(&data);
     if parsed.is_empty() {
-        Ok(fallback_voices("elevenlabs"))
+        Err(AppError::new(
+            "tts_provider_error",
+            "TTS provider returned no voices",
+        ))
     } else {
         Ok(
-            json!({ "voices": parsed.iter().filter_map(|voice| voice.get("id").cloned()).collect::<Vec<_>>(), "voiceOptions": parsed, "fromProvider": true, "source": "elevenlabs" }),
+            json!({ "voices": parsed.iter().filter_map(|voice| voice.get("id").cloned()).collect::<Vec<_>>(), "voiceOptions": parsed, "fromProvider": true, "fallback": false, "source": "elevenlabs" }),
         )
     }
 }
@@ -772,6 +834,35 @@ mod tests {
         format!("http://{address}/v1")
     }
 
+    async fn serve_voice_failure(status: &'static str, body: &'static str) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("test voice server should bind");
+        let address = listener
+            .local_addr()
+            .expect("test voice server address should be readable");
+        tokio::spawn(async move {
+            let (mut stream, _) = listener
+                .accept()
+                .await
+                .expect("test voice server should accept one request");
+            let mut buffer = [0_u8; 2048];
+            let _ = stream
+                .read(&mut buffer)
+                .await
+                .expect("test voice server should read request");
+            let response = format!(
+                "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream
+                .write_all(response.as_bytes())
+                .await
+                .expect("test voice server should write response");
+        });
+        format!("http://{address}/v1")
+    }
+
     async fn serve_pockettts_audio() -> String {
         const WAV_BYTES: &[u8] = &[
             82, 73, 70, 70, 38, 0, 0, 0, 87, 65, 86, 69, 102, 109, 116, 32, 16, 0, 0, 0, 1, 0, 1,
@@ -840,7 +931,71 @@ mod tests {
         let result = voices(&state).await.expect("voice lookup should complete");
 
         assert_eq!(result["fromProvider"], true);
+        assert_eq!(result["fallback"], false);
+        assert!(result.get("providerError").is_none());
         assert_eq!(result["voices"], json!(["af_heart"]));
+    }
+
+    #[tokio::test]
+    async fn openai_voice_lookup_marks_fallback_when_provider_fails() {
+        let state = test_state("openai-voices-provider-error");
+        let base_url = serve_voice_failure("401 Unauthorized", r#"{"error":"bad key"}"#).await;
+        state
+            .storage
+            .upsert_with_id(
+                "app-settings",
+                TTS_SETTINGS_KEY,
+                json!({
+                    "value": {
+                        "enabled": true,
+                        "source": "openai",
+                        "baseUrl": base_url,
+                        "apiKey": "bad-key",
+                        "model": "tts-1"
+                    }
+                }),
+            )
+            .expect("TTS settings should be stored");
+
+        let result = voices(&state)
+            .await
+            .expect("voice lookup should return fallback metadata");
+
+        assert_eq!(result["fromProvider"], false);
+        assert_eq!(result["fallback"], true);
+        assert!(result["providerError"]
+            .as_str()
+            .is_some_and(|message| message.contains("TTS provider returned HTTP")));
+        assert_eq!(result["voices"], json!(OPENAI_FALLBACK_VOICES));
+    }
+
+    #[tokio::test]
+    async fn disabled_voice_lookup_uses_fallback_without_provider_error() {
+        let state = test_state("openai-voices-disabled");
+        state
+            .storage
+            .upsert_with_id(
+                "app-settings",
+                TTS_SETTINGS_KEY,
+                json!({
+                    "value": {
+                        "enabled": false,
+                        "source": "openai",
+                        "apiKey": "bad-key",
+                        "model": "tts-1"
+                    }
+                }),
+            )
+            .expect("TTS settings should be stored");
+
+        let result = voices(&state)
+            .await
+            .expect("disabled voice lookup should use fallback");
+
+        assert_eq!(result["fromProvider"], false);
+        assert_eq!(result["fallback"], true);
+        assert!(result.get("providerError").is_none());
+        assert_eq!(result["voices"], json!(OPENAI_FALLBACK_VOICES));
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/storage/llm.rs
+++ b/src-tauri/src/commands/storage/llm.rs
@@ -139,7 +139,22 @@ pub(crate) fn llm_stream_cancel(state: &AppState, stream_id: &str) -> AppResult<
     Ok(json!({ "cancelled": state.cancel_llm_stream(stream_id)? }))
 }
 
+struct ModelLookupResult {
+    models: Vec<Value>,
+    from_provider: bool,
+    fallback: bool,
+    provider_error: Option<AppError>,
+}
+
 pub(crate) async fn llm_models(state: &AppState, connection_id: Option<&str>) -> AppResult<Value> {
+    let lookup = lookup_llm_models(state, connection_id).await?;
+    Ok(Value::Array(lookup.models))
+}
+
+async fn lookup_llm_models(
+    state: &AppState,
+    connection_id: Option<&str>,
+) -> AppResult<ModelLookupResult> {
     let connection = connection_id
         .and_then(|id| state.storage.get("connections", id).ok().flatten())
         .or_else(|| {
@@ -154,11 +169,25 @@ pub(crate) async fn llm_models(state: &AppState, connection_id: Option<&str>) ->
         .and_then(|value| value.get("provider"))
         .and_then(Value::as_str)
         .unwrap_or("openai");
+    let mut from_provider = false;
+    let mut fallback = false;
+    let mut provider_error = None;
     let mut models = match connection.as_ref() {
-        Some(connection) => fetch_provider_models(connection)
-            .await
-            .unwrap_or_else(|_| provider_model_catalog(provider)),
-        None => provider_model_catalog(provider),
+        Some(connection) => match fetch_provider_models(connection).await {
+            Ok(models) => {
+                from_provider = true;
+                models
+            }
+            Err(error) => {
+                fallback = true;
+                provider_error = Some(error);
+                provider_model_catalog(provider)
+            }
+        },
+        None => {
+            fallback = true;
+            provider_model_catalog(provider)
+        }
     };
     if let Some(connection) = connection.as_ref() {
         for key in ["model", "embeddingModel", "imageModel"] {
@@ -171,7 +200,30 @@ pub(crate) async fn llm_models(state: &AppState, connection_id: Option<&str>) ->
             }
         }
     }
-    Ok(Value::Array(models))
+    if fallback {
+        for model in &mut models {
+            if let Some(object) = model.as_object_mut() {
+                object.insert("fromProvider".to_string(), Value::Bool(false));
+                object.insert("fallback".to_string(), Value::Bool(true));
+                if let Some(error) = provider_error.as_ref() {
+                    object.insert(
+                        "providerError".to_string(),
+                        Value::String(error.message.clone()),
+                    );
+                    object.insert(
+                        "providerErrorCode".to_string(),
+                        Value::String(error.code.clone()),
+                    );
+                }
+            }
+        }
+    }
+    Ok(ModelLookupResult {
+        models,
+        from_provider,
+        fallback,
+        provider_error,
+    })
 }
 pub(crate) fn llm_connection_from_value(value: &Value) -> AppResult<marinara_llm::LlmConnection> {
     let provider = value
@@ -232,8 +284,17 @@ pub(crate) fn llm_connection_from_value(value: &Value) -> AppResult<marinara_llm
 }
 
 pub(crate) async fn connection_models(state: &AppState, id: &str) -> AppResult<Value> {
-    let models = llm_models(state, Some(id)).await?;
-    Ok(json!({ "models": models }))
+    let lookup = lookup_llm_models(state, Some(id)).await?;
+    let mut response = json!({
+        "models": lookup.models,
+        "fromProvider": lookup.from_provider,
+        "fallback": lookup.fallback
+    });
+    if let Some(error) = lookup.provider_error {
+        response["providerError"] = json!(error.message);
+        response["providerErrorCode"] = json!(error.code);
+    }
+    Ok(response)
 }
 
 pub(crate) async fn connection_auth_check(state: &AppState, id: &str) -> AppResult<Value> {
@@ -983,5 +1044,116 @@ fn sanitize_provider_body(body: &str) -> String {
         "Provider returned HTML instead of JSON".to_string()
     } else {
         body.chars().take(300).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::AppState;
+    use std::time::{SystemTime, UNIX_EPOCH};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    fn test_state(label: &str) -> AppState {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after epoch")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("marinara-llm-{label}-{nonce}"));
+        if path.exists() {
+            std::fs::remove_dir_all(&path).expect("stale temp LLM dir should be removable");
+        }
+        AppState::from_data_dir(path, Vec::new()).expect("test app state should initialize")
+    }
+
+    async fn serve_model_failure(status: &'static str, body: &'static str) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("test model server should bind");
+        let address = listener
+            .local_addr()
+            .expect("test model server address should be readable");
+        tokio::spawn(async move {
+            let (mut stream, _) = listener
+                .accept()
+                .await
+                .expect("test model server should accept one request");
+            let mut buffer = [0_u8; 2048];
+            let _ = stream
+                .read(&mut buffer)
+                .await
+                .expect("test model server should read request");
+            let response = format!(
+                "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream
+                .write_all(response.as_bytes())
+                .await
+                .expect("test model server should write response");
+        });
+        format!("http://{address}/v1")
+    }
+
+    #[tokio::test]
+    async fn connection_models_marks_fallback_when_provider_lookup_fails() {
+        let state = test_state("provider-error");
+        let base_url =
+            serve_model_failure("500 Internal Server Error", r#"{"error":"bad key"}"#).await;
+        state
+            .storage
+            .upsert_with_id(
+                "connections",
+                "bad-openai",
+                json!({
+                    "provider": "openai",
+                    "baseUrl": base_url,
+                    "apiKey": "bad-key",
+                    "model": "gpt-custom"
+                }),
+            )
+            .expect("connection should be stored");
+
+        let result = connection_models(&state, "bad-openai")
+            .await
+            .expect("model lookup should return fallback metadata");
+
+        assert_eq!(result["fromProvider"], false);
+        assert_eq!(result["fallback"], true);
+        assert!(result["providerError"]
+            .as_str()
+            .is_some_and(|message| message.contains("Provider returned HTTP")));
+        assert!(result["models"]
+            .as_array()
+            .is_some_and(|models| models.iter().any(|model| model["id"] == "gpt-custom")));
+    }
+
+    #[tokio::test]
+    async fn connection_models_keep_provider_success_distinct_from_fallback() {
+        let state = test_state("provider-success");
+        let base_url = serve_model_failure("200 OK", r#"{"data":[{"id":"live-model"}]}"#).await;
+        state
+            .storage
+            .upsert_with_id(
+                "connections",
+                "good-openai",
+                json!({
+                    "provider": "openai",
+                    "baseUrl": base_url,
+                    "apiKey": "valid-key",
+                    "model": "live-model"
+                }),
+            )
+            .expect("connection should be stored");
+
+        let result = connection_models(&state, "good-openai")
+            .await
+            .expect("model lookup should return provider metadata");
+
+        assert_eq!(result["fromProvider"], true);
+        assert_eq!(result["fallback"], false);
+        assert!(result.get("providerError").is_none());
+        assert_eq!(result["models"][0]["id"], "live-model");
     }
 }

--- a/src/engine/contracts/types/tts.ts
+++ b/src/engine/contracts/types/tts.ts
@@ -145,5 +145,10 @@ export interface TTSVoicesResponse {
   }>;
   /** True when the list came from the provider; false = local fallback or no provider voices */
   fromProvider: boolean;
+  /** True when Marinara is showing a local fallback voice catalog. */
+  fallback?: boolean;
+  /** Present when a live provider lookup failed and Marinara returned fallback voices. */
+  providerError?: string;
+  providerErrorCode?: string;
   source: TTSSource;
 }

--- a/src/engine/contracts/types/tts.ts
+++ b/src/engine/contracts/types/tts.ts
@@ -149,6 +149,7 @@ export interface TTSVoicesResponse {
   fallback?: boolean;
   /** Present when a live provider lookup failed and Marinara returned fallback voices. */
   providerError?: string;
+  /** Machine-readable error classification when providerError is present. */
   providerErrorCode?: string;
   source: TTSSource;
 }

--- a/src/features/catalog/connections/hooks/use-connections.ts
+++ b/src/features/catalog/connections/hooks/use-connections.ts
@@ -103,7 +103,7 @@ export function useFetchModels() {
     mutationFn: (id: string) =>
       invokeTauri<{
         models: Array<{ id: string; name: string; fallback?: boolean; fromProvider?: boolean; providerError?: string }>;
-        fromProvider?: boolean;
+        fromProvider: boolean;
         fallback?: boolean;
         providerError?: string;
         providerErrorCode?: string;

--- a/src/features/catalog/connections/hooks/use-connections.ts
+++ b/src/features/catalog/connections/hooks/use-connections.ts
@@ -100,7 +100,14 @@ export function useTestImageGeneration() {
 
 export function useFetchModels() {
   return useMutation({
-    mutationFn: (id: string) => invokeTauri<{ models: Array<{ id: string; name: string }> }>("connection_models", { id }),
+    mutationFn: (id: string) =>
+      invokeTauri<{
+        models: Array<{ id: string; name: string; fallback?: boolean; fromProvider?: boolean; providerError?: string }>;
+        fromProvider?: boolean;
+        fallback?: boolean;
+        providerError?: string;
+        providerErrorCode?: string;
+      }>("connection_models", { id }),
   });
 }
 

--- a/src/features/shell/connections/components/ConnectionEditor.tsx
+++ b/src/features/shell/connections/components/ConnectionEditor.tsx
@@ -77,6 +77,21 @@ const MAX_CACHING_AT_DEPTH = 100;
 const DEFAULT_MAX_PARALLEL_JOBS = 1;
 const MAX_PARALLEL_JOBS = 16;
 
+type RemoteModel = {
+  id: string;
+  name: string;
+  fallback?: boolean;
+  fromProvider?: boolean;
+  providerError?: string;
+};
+
+type ModelLookupResponse = {
+  models: RemoteModel[];
+  fromProvider?: boolean;
+  fallback?: boolean;
+  providerError?: string;
+};
+
 function normalizeCachingAtDepth(value: unknown): number {
   if (typeof value !== "number" || !Number.isFinite(value) || value < 0) return DEFAULT_CACHING_AT_DEPTH;
   return Math.min(MAX_CACHING_AT_DEPTH, Math.floor(value));
@@ -208,7 +223,7 @@ export function ConnectionEditor() {
   }, [showModelDropdown]);
 
   // Remote models fetched from provider API
-  const [remoteModels, setRemoteModels] = useState<Array<{ id: string; name: string }>>([]);
+  const [remoteModels, setRemoteModels] = useState<RemoteModel[]>([]);
   const [fetchError, setFetchError] = useState<string | null>(null);
 
   // Populate from the stored connection record.
@@ -333,7 +348,7 @@ export function ConnectionEditor() {
     const knownIds = new Set(providerModels.map((m) => m.id));
     const uniqueRemote = remoteModels
       .filter((m) => !knownIds.has(m.id))
-      .map((m) => ({ id: m.id, name: m.name, context: 0, maxOutput: 0, isRemote: true as const }));
+      .map((m) => ({ id: m.id, name: m.name, context: 0, maxOutput: 0, isRemote: true as const, fallback: m.fallback }));
     const known = providerModels.map((m) => ({ ...m, isRemote: false as const }));
     return [...known, ...uniqueRemote];
   }, [providerModels, remoteModels]);
@@ -556,8 +571,21 @@ export function ConnectionEditor() {
     }
     fetchModels.mutate(connectionDetailId, {
       onSuccess: (data) => {
-        const result = data as { models: Array<{ id: string; name: string }> };
-        setRemoteModels(result.models);
+        const result = data as ModelLookupResponse;
+        const fallback = result.fallback === true;
+        setRemoteModels(
+          result.models.map((model) => ({
+            ...model,
+            fallback: model.fallback ?? fallback,
+            fromProvider: model.fromProvider ?? result.fromProvider,
+            providerError: model.providerError ?? result.providerError,
+          })),
+        );
+        setFetchError(
+          result.providerError
+            ? `Provider lookup failed: ${result.providerError}. Showing fallback models.`
+            : null,
+        );
         setShowModelDropdown(true);
         requestAnimationFrame(() => {
           modelSearchInputRef.current?.focus();
@@ -1126,7 +1154,7 @@ export function ConnectionEditor() {
                                     <span className="text-[0.625rem] text-[var(--muted-foreground)]">{m.id}</span>
                                   </div>
                                   <span className="shrink-0 rounded-md bg-sky-400/10 px-1.5 py-0.5 text-[0.5625rem] font-medium text-sky-400">
-                                    API
+                                    {m.fallback ? "Fallback" : "API"}
                                   </span>
                                 </button>
                               ))}
@@ -1170,7 +1198,7 @@ export function ConnectionEditor() {
                               <span className="text-sm font-medium">{m.name}</span>
                               {m.isRemote && (
                                 <span className="rounded-md bg-sky-400/10 px-1.5 py-0.5 text-[0.5625rem] font-medium text-sky-400">
-                                  API
+                                  {m.fallback ? "Fallback" : "API"}
                                 </span>
                               )}
                               {localModel === m.id && <Check size="0.75rem" className="text-sky-400" />}

--- a/src/features/shell/settings/components/settings/TTSConfigCard.tsx
+++ b/src/features/shell/settings/components/settings/TTSConfigCard.tsx
@@ -509,6 +509,7 @@ export function TTSConfigCard() {
   const voiceOptions: VoiceOption[] =
     voicesData?.voiceOptions ?? voices.map((voiceId): VoiceOption => ({ id: voiceId, name: voiceId }));
   const voicesFromProvider = voicesData?.fromProvider ?? false;
+  const voicesProviderError = voicesData?.providerError;
   const elevenLabsMatchedMaleVoiceOptions = useMemo(
     () =>
       voiceOptions.filter((option) => isElevenLabsVoiceForGender(option, "male", ELEVENLABS_DEFAULT_MALE_VOICE_NAMES)),
@@ -897,6 +898,11 @@ export function TTSConfigCard() {
                   <RefreshCw size="0.75rem" className={cn(fetchingVoices && "animate-spin")} />
                 </button>
               </div>
+              {voicesProviderError && !fetchingVoices && (
+                <p className="text-[0.625rem] text-[var(--destructive)]">
+                  Provider voice lookup failed: {voicesProviderError}. Showing fallback voices.
+                </p>
+              )}
               {!voicesFromProvider && source === "openai" && voices.length > 0 && (
                 <p className="text-[0.625rem] text-[var(--muted-foreground)]">
                   Showing OpenAI built-in voices — save & enable to load from your provider

--- a/src/features/shell/settings/components/settings/TTSConfigCard.tsx
+++ b/src/features/shell/settings/components/settings/TTSConfigCard.tsx
@@ -987,6 +987,11 @@ export function TTSConfigCard() {
           {voiceMode === "per-character" && (
             <FieldRow label="Character Voices" help="Assign voices to specific characters from your Characters tab.">
               <div className="space-y-2 rounded-lg border border-[var(--border)] bg-[var(--secondary)]/40 p-2">
+                {voicesProviderError && !fetchingVoices && (
+                  <p className="text-[0.625rem] text-[var(--destructive)]">
+                    Provider voice lookup failed: {voicesProviderError}. Showing fallback voices.
+                  </p>
+                )}
                 <div className="grid gap-2 text-[0.625rem] font-semibold uppercase tracking-wide text-[var(--muted-foreground)] sm:grid-cols-[minmax(0,1.1fr)_minmax(0,1fr)_auto]">
                   <span>Character</span>
                   <span>Voice</span>


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #1251

## Why this change

- Live LLM model lookup and TTS voice lookup failures were being collapsed into fallback/default catalogs with no error metadata.
- That made bad API keys, bad endpoints, provider outages, and parse failures look like successful provider catalog loads.

## What changed

- LLM model lookup now returns fallback metadata and provider error details through `connection_models`, while keeping `llm_list_models` array-compatible and annotating fallback model rows.
- TTS voice lookup now marks fallback voice catalogs with `fallback: true` and includes `providerError` / `providerErrorCode` when a live provider request fails or returns unusable data.
- The connection model picker and TTS settings card now surface provider lookup failures while still showing fallback choices.
- Added Rust regression coverage for provider-failure and should-not-match success/disabled-fallback rows.

## Refactor impact

Primary owner:

Rust storage / shared API / shell settings

Impact areas reviewed:

- Tauri commands for LLM model lookup and TTS voice lookup
- Shared TTS voice response contract
- Connection model picker
- TTS settings voice picker

Boundary notes:

- `connection_models` remains backward-compatible for callers that only read `models`.
- `llm_list_models` remains an array response; fallback rows are annotated instead of changing the command shape.
- `tts_voices` preserves existing `voices`, `voiceOptions`, `fromProvider`, and `source` fields while adding optional fallback/error metadata.

Pressure points touched:

- `src-tauri/src/commands/storage/llm.rs`
- `src-tauri/src/commands/storage/integrations/tts.rs`
- Shell settings/components that consume these lookup responses

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Codex reproduced the pre-fix failure by adding focused Rust regression tests and running `cargo test marks_fallback`; the LLM and TTS fallback metadata assertions failed before the production patch.
- Codex verified the fix with `cargo test marks_fallback`; both provider-failure tests passed.
- Codex verified edge controls with `cargo test lookup`; TTS provider success stayed `fromProvider=true`/`fallback=false`, failed lookup returned `providerError`, and disabled TTS fallback had no provider error.
- Codex verified LLM positive and negative rows with `cargo test connection_models`; provider failure returned fallback/error metadata, while provider success stayed distinct from fallback.
- Codex ran `pnpm check`; architecture, frontend typecheck, Rust check, and docs check passed.
- Codex ran the local proof gate against `scratch/bugfix-verification.json`; it passed.
- Browser/Tauri click-through was not run. The core native command behavior is covered by Rust harnesses; the UI change is conditional rendering of the new response fields and was covered by TypeScript via `pnpm check`.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs, release metadata, schema, or dependency declarations changed.

## UI evidence

No screenshot attached. This is a native command contract/error-state fix with small settings UI conditional copy. The changed UI paths typecheck under `pnpm check`; the provider failure behavior is covered by Rust command harnesses.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced error transparency when voice and model providers fail—system now displays warning messages while seamlessly showing fallback options.
  
* **Improvements**
  * UI now clearly distinguishes between fallback voices/models and those from live providers.
  * Richer error context captured when external providers become unavailable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1310?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->