### PR TITLE
Fix import rollback on failed writes

### DIFF
--- a/src-tauri/src/commands/storage/imports/bulk_imports.rs
+++ b/src-tauri/src/commands/storage/imports/bulk_imports.rs
@@ -531,52 +531,68 @@ fn import_st_chat_text(
         chat.entry("importedCharacterName".to_string())
             .or_insert(Value::String(character_name));
     }
-    let chat_record = state.storage.create("chats", Value::Object(chat))?;
-    let chat_id = chat_record
-        .get("id")
-        .and_then(Value::as_str)
-        .unwrap_or_default()
-        .to_string();
-    let mut imported = 0usize;
-    for row in parsed_rows {
-        if row
-            .get("is_system")
-            .and_then(Value::as_bool)
-            .unwrap_or(false)
-        {
-            continue;
+    let mut created_chat_id = None;
+    let mut created_message_ids = Vec::new();
+    let result = (|| -> AppResult<Value> {
+        let chat_record = state.storage.create("chats", Value::Object(chat))?;
+        let chat_id = created_record_id(&chat_record, "chat")?;
+        created_chat_id = Some(chat_id.clone());
+        let mut imported = 0usize;
+        for row in parsed_rows {
+            if row
+                .get("is_system")
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+            {
+                continue;
+            }
+            let content = row
+                .get("mes")
+                .or_else(|| row.get("content"))
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string();
+            if content.trim().is_empty() {
+                continue;
+            }
+            let role = if row.get("is_user").and_then(Value::as_bool).unwrap_or(false) {
+                "user"
+            } else {
+                "assistant"
+            };
+            let message = state.storage.create(
+                "messages",
+                json!({
+                    "chatId": chat_id,
+                    "role": role,
+                    "content": content,
+                    "characterId": Value::Null,
+                    "extra": {},
+                    "activeSwipeIndex": 0,
+                    "swipes": [{ "content": content }]
+                }),
+            )?;
+            created_message_ids.push(created_record_id(&message, "message")?);
+            imported += 1;
         }
-        let content = row
-            .get("mes")
-            .or_else(|| row.get("content"))
-            .and_then(Value::as_str)
-            .unwrap_or("")
-            .to_string();
-        if content.trim().is_empty() {
-            continue;
-        }
-        let role = if row.get("is_user").and_then(Value::as_bool).unwrap_or(false) {
-            "user"
-        } else {
-            "assistant"
-        };
-        state.storage.create(
+        Ok(
+            json!({ "success": true, "chatId": chat_id, "chat": chat_record, "messagesImported": imported }),
+        )
+    })();
+
+    result.map_err(|error| {
+        let mut rollback_errors = Vec::new();
+        rollback_created_records(
+            state,
             "messages",
-            json!({
-                "chatId": chat_id,
-                "role": role,
-                "content": content,
-                "characterId": Value::Null,
-                "extra": {},
-                "activeSwipeIndex": 0,
-                "swipes": [{ "content": content }]
-            }),
-        )?;
-        imported += 1;
-    }
-    Ok(
-        json!({ "success": true, "chatId": chat_id, "chat": chat_record, "messagesImported": imported }),
-    )
+            &created_message_ids,
+            &mut rollback_errors,
+        );
+        if let Some(chat_id) = created_chat_id.as_deref() {
+            rollback_created_records(state, "chats", &[chat_id.to_string()], &mut rollback_errors);
+        }
+        append_rollback_errors(error, "chat import", rollback_errors)
+    })
 }
 
 pub(super) fn import_st_chat(state: &AppState, body: Value) -> AppResult<Value> {
@@ -620,7 +636,11 @@ pub(super) fn import_st_chat_into_group(state: &AppState, body: Value) -> AppRes
         .map(|name| name.to_string_lossy().replace('_', " "))
         .filter(|name| !name.trim().is_empty())
         .unwrap_or_else(|| "Imported".to_string());
-    import_st_chat_text(state, &text, branch_name, Some(inherited))
+    import_st_chat_text(state, &text, branch_name, Some(inherited)).map_err(|error| {
+        let mut rollback_errors = Vec::new();
+        restore_record(state, "chats", &target, &mut rollback_errors);
+        append_rollback_errors(error, "chat branch import", rollback_errors)
+    })
 }
 
 fn import_persona_payload(
@@ -674,6 +694,7 @@ fn import_persona_avatar_file(
         path,
     )?;
     let modified = modified_at(path);
+    let avatar_path = stored.absolute_path.clone();
     let payload = json!({
         "name": name,
         "description": description,
@@ -682,7 +703,56 @@ fn import_persona_avatar_file(
         "avatarFilename": stored.filename,
         "importedModifiedAt": modified,
     });
-    import_persona_payload(state, payload, &file_stem(path))
+    import_persona_payload(state, payload, &file_stem(path)).map_err(|error| {
+        let mut rollback_errors = Vec::new();
+        rollback_managed_file_path(
+            state,
+            "avatars/personas",
+            &avatar_path,
+            &mut rollback_errors,
+        );
+        append_rollback_errors(error, "persona import", rollback_errors)
+    })
+}
+
+fn restore_record(
+    state: &AppState,
+    collection: &str,
+    original: &Value,
+    rollback_errors: &mut Vec<String>,
+) {
+    let Some(id) = original.get("id").and_then(Value::as_str) else {
+        rollback_errors.push(format!("{collection}: original record is missing an id"));
+        return;
+    };
+    let rows = match state.storage.list(collection) {
+        Ok(rows) => rows,
+        Err(error) => {
+            rollback_errors.push(format!("{collection}/{id}: {error}"));
+            return;
+        }
+    };
+    let mut replaced = false;
+    let restored = rows
+        .into_iter()
+        .map(|row| {
+            if row.get("id").and_then(Value::as_str) == Some(id) {
+                replaced = true;
+                original.clone()
+            } else {
+                row
+            }
+        })
+        .collect::<Vec<_>>();
+    if !replaced {
+        rollback_errors.push(format!(
+            "{collection}/{id}: record was not found for restore"
+        ));
+        return;
+    }
+    if let Err(error) = state.storage.replace_all(collection, restored) {
+        rollback_errors.push(format!("{collection}/{id}: {error}"));
+    }
 }
 
 fn copy_background_file(state: &AppState, path: &Path) -> AppResult<Value> {
@@ -935,6 +1005,7 @@ pub(super) fn run_st_bulk_import_channel(
 mod tests {
     use super::*;
     use crate::state::AppState;
+    use base64::engine::general_purpose;
     use std::path::{Path, PathBuf};
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -965,6 +1036,26 @@ mod tests {
             fs::create_dir_all(parent).expect("fixture parent should be created");
         }
         fs::write(path, bytes).expect("fixture file should be written");
+    }
+
+    fn corrupt_collection(state: &AppState, collection: &str) {
+        let collection_path = state
+            .storage
+            .root()
+            .join("collections")
+            .join(format!("{collection}.json"));
+        if let Some(parent) = collection_path.parent() {
+            fs::create_dir_all(parent).expect("collection parent should be created");
+        }
+        fs::write(collection_path, b"{not-json").expect("collection should be corruptible");
+    }
+
+    fn uploaded_jsonl_file(name: &str, text: &str) -> Value {
+        json!({
+            "name": name,
+            "type": "application/jsonl",
+            "base64": general_purpose::STANDARD.encode(text.as_bytes())
+        })
     }
 
     fn build_sillytavern_fixture(root: &Path) {
@@ -1025,6 +1116,158 @@ mod tests {
             .filter_map(|item| item.get("id").and_then(Value::as_str))
             .map(ToOwned::to_owned)
             .collect()
+    }
+
+    #[test]
+    fn import_st_chat_text_rolls_back_chat_when_message_write_fails() {
+        let app_root = temp_path("chat-rollback");
+        let state = AppState::from_data_dir(&app_root, Vec::new())
+            .expect("test app state should initialize");
+        corrupt_collection(&state, "messages");
+
+        let error = import_st_chat_text(
+            &state,
+            r#"{"character_name":"Bot","mes":"hello"}"#,
+            "Rollback Chat".to_string(),
+            None,
+        )
+        .expect_err("message storage failure should reject chat import");
+
+        assert_eq!(error.code, "invalid_input");
+        assert!(
+            state.storage.list("chats").unwrap().is_empty(),
+            "failed chat import must remove the created chat"
+        );
+
+        let _ = fs::remove_dir_all(app_root);
+    }
+
+    #[test]
+    fn import_st_chat_into_group_restores_target_when_branch_import_fails() {
+        let app_root = temp_path("branch-rollback");
+        let state = AppState::from_data_dir(&app_root, Vec::new())
+            .expect("test app state should initialize");
+        state
+            .storage
+            .create(
+                "chats",
+                json!({
+                    "id": "target-chat",
+                    "name": "Target Chat",
+                    "mode": "conversation",
+                    "metadata": {},
+                    "characterIds": []
+                }),
+            )
+            .expect("target chat should be created");
+        corrupt_collection(&state, "messages");
+
+        let error = import_st_chat_into_group(
+            &state,
+            json!({
+                "chatId": "target-chat",
+                "file": uploaded_jsonl_file(
+                    "branch.jsonl",
+                    r#"{"character_name":"Bot","mes":"hello"}"#
+                )
+            }),
+        )
+        .expect_err("message storage failure should reject branch import");
+
+        assert_eq!(error.code, "invalid_input");
+        let target = state
+            .storage
+            .get("chats", "target-chat")
+            .expect("target chat should be readable")
+            .expect("target chat should remain");
+        assert!(
+            target.get("groupId").is_none(),
+            "failed branch import must restore the target chat without a generated groupId"
+        );
+        assert_eq!(
+            state.storage.list("chats").unwrap().len(),
+            1,
+            "failed branch import must remove the created branch chat"
+        );
+
+        let _ = fs::remove_dir_all(app_root);
+    }
+
+    #[test]
+    fn import_st_chat_into_existing_group_preserves_group_id_when_branch_import_fails() {
+        let app_root = temp_path("branch-existing-group-rollback");
+        let state = AppState::from_data_dir(&app_root, Vec::new())
+            .expect("test app state should initialize");
+        state
+            .storage
+            .create(
+                "chats",
+                json!({
+                    "id": "target-chat",
+                    "name": "Target Chat",
+                    "mode": "conversation",
+                    "groupId": "existing-group",
+                    "metadata": {},
+                    "characterIds": []
+                }),
+            )
+            .expect("target chat should be created");
+        corrupt_collection(&state, "messages");
+
+        let error = import_st_chat_into_group(
+            &state,
+            json!({
+                "chatId": "target-chat",
+                "file": uploaded_jsonl_file(
+                    "branch.jsonl",
+                    r#"{"character_name":"Bot","mes":"hello"}"#
+                )
+            }),
+        )
+        .expect_err("message storage failure should reject branch import");
+
+        assert_eq!(error.code, "invalid_input");
+        let target = state
+            .storage
+            .get("chats", "target-chat")
+            .expect("target chat should be readable")
+            .expect("target chat should remain");
+        assert_eq!(
+            target.get("groupId").and_then(Value::as_str),
+            Some("existing-group"),
+            "failed branch import must preserve the existing group id"
+        );
+
+        let _ = fs::remove_dir_all(app_root);
+    }
+
+    #[test]
+    fn import_persona_avatar_file_rolls_back_avatar_when_persona_write_fails() {
+        let app_root = temp_path("persona-avatar-rollback");
+        let source_root = temp_path("persona-source");
+        fs::create_dir_all(&source_root).expect("source dir should be created");
+        let source = source_root.join("persona.png");
+        fs::write(&source, b"persona-avatar-bytes").expect("source fixture should be written");
+        let state = AppState::from_data_dir(&app_root, Vec::new())
+            .expect("test app state should initialize");
+        corrupt_collection(&state, "personas");
+
+        let error = import_persona_avatar_file(
+            &state,
+            &source,
+            "Persona".to_string(),
+            "description".to_string(),
+        )
+        .expect_err("persona storage failure should reject persona avatar import");
+
+        assert_eq!(error.code, "json_error");
+        assert!(
+            !app_root.join("avatars").join("personas").exists(),
+            "failed persona avatar import must remove the managed avatar file"
+        );
+
+        let _ = fs::remove_dir_all(app_root);
+        let _ = fs::remove_dir_all(source_root);
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/imports/rollback.rs
+++ b/src-tauri/src/commands/storage/imports/rollback.rs
@@ -1,0 +1,118 @@
+use super::*;
+
+pub(super) fn created_record_id(record: &Value, label: &str) -> AppResult<String> {
+    record
+        .get("id")
+        .and_then(Value::as_str)
+        .filter(|id| !id.trim().is_empty())
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| AppError::new("storage_error", format!("Created {label} is missing an id")))
+}
+
+pub(super) fn append_rollback_errors(
+    error: AppError,
+    context: &str,
+    rollback_errors: Vec<String>,
+) -> AppError {
+    if rollback_errors.is_empty() {
+        error
+    } else {
+        AppError::new(
+            "storage_rollback_failed",
+            format!(
+                "{error}; additionally failed to roll back {context}: {}",
+                rollback_errors.join("; ")
+            ),
+        )
+    }
+}
+
+pub(super) fn rollback_created_records(
+    state: &AppState,
+    collection: &str,
+    record_ids: &[String],
+    rollback_errors: &mut Vec<String>,
+) {
+    for record_id in record_ids.iter().rev() {
+        if let Err(error) = state.storage.delete(collection, record_id) {
+            rollback_errors.push(format!("{collection}/{record_id}: {error}"));
+        }
+    }
+}
+
+fn rollback_records_by_field(
+    state: &AppState,
+    collection: &str,
+    field: &str,
+    value: &str,
+    rollback_errors: &mut Vec<String>,
+) {
+    let mut filters = Map::new();
+    filters.insert(field.to_string(), Value::String(value.to_string()));
+    if let Err(error) = state.storage.delete_where(collection, &filters) {
+        rollback_errors.push(format!("{collection} where {field}={value}: {error}"));
+    }
+}
+
+pub(super) fn rollback_lorebook_tree(
+    state: &AppState,
+    lorebook_id: &str,
+    rollback_errors: &mut Vec<String>,
+) {
+    rollback_records_by_field(
+        state,
+        "lorebook-entries",
+        "lorebookId",
+        lorebook_id,
+        rollback_errors,
+    );
+    rollback_records_by_field(
+        state,
+        "lorebook-folders",
+        "lorebookId",
+        lorebook_id,
+        rollback_errors,
+    );
+    rollback_created_records(
+        state,
+        "lorebooks",
+        &[lorebook_id.to_string()],
+        rollback_errors,
+    );
+}
+
+pub(super) fn rollback_managed_file_path(
+    state: &AppState,
+    folder: &str,
+    absolute_path: &str,
+    rollback_errors: &mut Vec<String>,
+) {
+    let managed_dir = state.data_dir.join(folder);
+    let path = Path::new(absolute_path);
+    let Ok(managed_dir) = fs::canonicalize(&managed_dir) else {
+        return;
+    };
+    let path = match fs::canonicalize(path) {
+        Ok(path) => path,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return,
+        Err(error) => {
+            rollback_errors.push(format!("{absolute_path}: {error}"));
+            return;
+        }
+    };
+    if !path.starts_with(&managed_dir) {
+        rollback_errors.push(format!(
+            "{} is outside managed import folder {}",
+            path.display(),
+            managed_dir.display()
+        ));
+        return;
+    }
+    if path.is_file() {
+        if let Err(error) = fs::remove_file(&path) {
+            rollback_errors.push(format!("{}: {error}", path.display()));
+        } else if let Some(parent) = path.parent() {
+            let _ = fs::remove_dir(parent);
+        }
+    }
+}

--- a/src-tauri/src/commands/storage/imports/service.rs
+++ b/src-tauri/src/commands/storage/imports/service.rs
@@ -14,6 +14,8 @@ mod marinara;
 mod normalization;
 #[path = "payloads.rs"]
 mod payloads;
+#[path = "rollback.rs"]
+mod rollback;
 #[path = "st_preset.rs"]
 mod st_preset;
 #[path = "timestamps.rs"]
@@ -22,6 +24,7 @@ use access::*;
 use marinara::*;
 use normalization::*;
 use payloads::*;
+use rollback::*;
 use st_preset::*;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -35,25 +38,46 @@ fn create_lorebook_from_payload(
 ) -> AppResult<Value> {
     let (mut lorebook, entries) = normalize_lorebook(payload, fallback_name, character_id);
     apply_timestamp_overrides(&mut lorebook, &Value::Null, payload);
-    let record = state.storage.create("lorebooks", lorebook)?;
-    let lorebook_id = record
-        .get("id")
-        .and_then(Value::as_str)
-        .unwrap_or_default()
-        .to_string();
-    for (index, entry) in entries.iter().enumerate() {
-        state.storage.create(
+    let mut created_lorebook_id = None;
+    let mut created_entry_ids = Vec::new();
+    let result = (|| -> AppResult<Value> {
+        let record = state.storage.create("lorebooks", lorebook)?;
+        let lorebook_id = created_record_id(&record, "lorebook")?;
+        created_lorebook_id = Some(lorebook_id.clone());
+        for (index, entry) in entries.iter().enumerate() {
+            let entry = state.storage.create(
+                "lorebook-entries",
+                normalize_lorebook_entry(&lorebook_id, entry, index),
+            )?;
+            created_entry_ids.push(created_record_id(&entry, "lorebook entry")?);
+        }
+        Ok(json!({
+            "success": true,
+            "lorebookId": lorebook_id,
+            "name": record.get("name").cloned().unwrap_or(Value::Null),
+            "entriesImported": entries.len(),
+            "lorebook": record
+        }))
+    })();
+
+    result.map_err(|error| {
+        let mut rollback_errors = Vec::new();
+        rollback_created_records(
+            state,
             "lorebook-entries",
-            normalize_lorebook_entry(&lorebook_id, entry, index),
-        )?;
-    }
-    Ok(json!({
-        "success": true,
-        "lorebookId": lorebook_id,
-        "name": record.get("name").cloned().unwrap_or(Value::Null),
-        "entriesImported": entries.len(),
-        "lorebook": record
-    }))
+            &created_entry_ids,
+            &mut rollback_errors,
+        );
+        if let Some(lorebook_id) = created_lorebook_id.as_deref() {
+            rollback_created_records(
+                state,
+                "lorebooks",
+                &[lorebook_id.to_string()],
+                &mut rollback_errors,
+            );
+        }
+        append_rollback_errors(error, "lorebook import", rollback_errors)
+    })
 }
 
 fn patch_imported_character_lorebook_pointer(
@@ -131,67 +155,96 @@ fn import_st_character_payload(
     if let Some(avatar) =
         imported_avatar_reference(state, &payload, filename.as_deref(), trusted_avatar_source)?
     {
+        let avatar_absolute_path = avatar.absolute_path.clone();
         let object = record
             .as_object_mut()
             .expect("character import record should be an object");
         object.insert("avatarPath".to_string(), Value::String(avatar.asset_url));
         object.insert(
             "avatarFilePath".to_string(),
-            Value::String(avatar.absolute_path),
+            Value::String(avatar_absolute_path.clone()),
         );
         object.insert("avatarFilename".to_string(), Value::String(avatar.filename));
     }
     apply_timestamp_overrides(&mut record, body, &payload);
-    let character = state.storage.create("characters", record)?;
 
-    let import_embedded = body
-        .get("importEmbeddedLorebook")
+    let avatar_absolute_path = record
+        .get("avatarFilePath")
         .and_then(Value::as_str)
-        .map(|raw| raw != "false")
-        .unwrap_or_else(|| {
-            body.get("importEmbeddedLorebook")
-                .and_then(Value::as_bool)
-                .unwrap_or(true)
-        });
-    let embedded = embedded_lorebook(&payload);
-    let mut lorebook_result = Value::Null;
-    if import_embedded {
-        if let Some(book) = embedded.as_ref() {
-            let character_id = character.get("id").and_then(Value::as_str);
-            lorebook_result = create_lorebook_from_payload(
-                state,
-                book,
-                &format!("{name}'s Lorebook"),
-                character_id,
-            )?;
-            if let (Some(character_id), Some(lorebook_id)) = (
-                character_id,
-                lorebook_result.get("lorebookId").and_then(Value::as_str),
-            ) {
-                patch_imported_character_lorebook_pointer(
+        .map(ToOwned::to_owned);
+    let mut created_character_id = None;
+    let mut created_lorebook_id = None;
+    let result = (|| -> AppResult<Value> {
+        let character = state.storage.create("characters", record)?;
+        let character_id = created_record_id(&character, "character")?;
+        created_character_id = Some(character_id.clone());
+
+        let import_embedded = body
+            .get("importEmbeddedLorebook")
+            .and_then(Value::as_str)
+            .map(|raw| raw != "false")
+            .unwrap_or_else(|| {
+                body.get("importEmbeddedLorebook")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(true)
+            });
+        let embedded = embedded_lorebook(&payload);
+        let mut lorebook_result = Value::Null;
+        if import_embedded {
+            if let Some(book) = embedded.as_ref() {
+                lorebook_result = create_lorebook_from_payload(
                     state,
-                    character_id,
-                    lorebook_id,
-                    lorebook_entry_count(book),
+                    book,
+                    &format!("{name}'s Lorebook"),
+                    Some(&character_id),
                 )?;
+                if let Some(lorebook_id) = lorebook_result.get("lorebookId").and_then(Value::as_str)
+                {
+                    created_lorebook_id = Some(lorebook_id.to_string());
+                    patch_imported_character_lorebook_pointer(
+                        state,
+                        &character_id,
+                        lorebook_id,
+                        lorebook_entry_count(book),
+                    )?;
+                }
             }
         }
-    }
 
-    Ok(json!({
-        "success": true,
-        "characterId": character.get("id").cloned().unwrap_or(Value::Null),
-        "character": character,
-        "name": name,
-        "filename": filename,
-        "embeddedLorebook": {
-            "hasEmbeddedLorebook": embedded.as_ref().map(lorebook_entry_count).unwrap_or(0) > 0,
-            "entries": embedded.as_ref().map(lorebook_entry_count).unwrap_or(0),
-            "imported": lorebook_result.get("lorebookId").is_some(),
-            "skipped": embedded.is_some() && !import_embedded
-        },
-        "lorebook": lorebook_result
-    }))
+        Ok(json!({
+            "success": true,
+            "characterId": character.get("id").cloned().unwrap_or(Value::Null),
+            "character": character,
+            "name": name,
+            "filename": filename,
+            "embeddedLorebook": {
+                "hasEmbeddedLorebook": embedded.as_ref().map(lorebook_entry_count).unwrap_or(0) > 0,
+                "entries": embedded.as_ref().map(lorebook_entry_count).unwrap_or(0),
+                "imported": lorebook_result.get("lorebookId").is_some(),
+                "skipped": embedded.is_some() && !import_embedded
+            },
+            "lorebook": lorebook_result
+        }))
+    })();
+
+    result.map_err(|error| {
+        let mut rollback_errors = Vec::new();
+        if let Some(lorebook_id) = created_lorebook_id.as_deref() {
+            rollback_lorebook_tree(state, lorebook_id, &mut rollback_errors);
+        }
+        if let Some(character_id) = created_character_id.as_deref() {
+            rollback_created_records(
+                state,
+                "characters",
+                &[character_id.to_string()],
+                &mut rollback_errors,
+            );
+        }
+        if let Some(path) = avatar_absolute_path.as_deref() {
+            rollback_managed_file_path(state, "avatars/characters", path, &mut rollback_errors);
+        }
+        append_rollback_errors(error, "character import", rollback_errors)
+    })
 }
 
 fn strip_reserved_avatar_source_fields(payload: &mut Value) {
@@ -431,112 +484,5 @@ pub(crate) fn import_stream_channel(
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::state::AppState;
-    use std::time::{SystemTime, UNIX_EPOCH};
-
-    fn temp_path(label: &str) -> PathBuf {
-        let nonce = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("system clock should be after epoch")
-            .as_nanos();
-        std::env::temp_dir().join(format!(
-            "marinara-st-character-import-{label}-{}-{nonce}",
-            std::process::id()
-        ))
-    }
-
-    #[test]
-    fn import_st_character_ignores_untrusted_avatar_source_fields() {
-        let app_root = temp_path("app");
-        let source_root = temp_path("source");
-        fs::create_dir_all(&source_root).expect("source dir should be created");
-        let source = source_root.join("not-an-avatar.txt");
-        fs::write(&source, b"do not copy me").expect("source fixture should be written");
-        let state = AppState::from_data_dir(&app_root, Vec::new())
-            .expect("test app state should initialize");
-
-        let result = import_st_character(
-            &state,
-            json!({
-                "spec": "chara_card_v2",
-                "data": {
-                    "name": "Reserved Field Probe",
-                    "description": "Should not copy arbitrary files"
-                },
-                "_avatarSourcePath": source.to_string_lossy(),
-                "_avatarFileCopySourcePath": source.to_string_lossy()
-            }),
-        )
-        .expect("reserved avatar source fields should be ignored");
-
-        let character = result
-            .get("character")
-            .and_then(Value::as_object)
-            .expect("import should return a character record");
-        assert!(
-            character
-                .get("avatarFilePath")
-                .and_then(Value::as_str)
-                .is_none(),
-            "external payload fields must not create managed avatar file paths"
-        );
-        assert_eq!(character.get("avatarPath"), Some(&Value::Null));
-        assert!(
-            !app_root.join("avatars").join("characters").exists(),
-            "untrusted local file paths should not be copied into managed avatars"
-        );
-
-        let _ = fs::remove_dir_all(app_root);
-        let _ = fs::remove_dir_all(source_root);
-    }
-
-    #[test]
-    fn import_st_character_uses_trusted_avatar_source_path() {
-        let app_root = temp_path("app");
-        let source_root = temp_path("source");
-        fs::create_dir_all(&source_root).expect("source dir should be created");
-        let source = source_root.join("trusted-avatar.png");
-        fs::write(&source, b"trusted-avatar-bytes").expect("source fixture should be written");
-        let state = AppState::from_data_dir(&app_root, Vec::new())
-            .expect("test app state should initialize");
-
-        let result = import_st_character_payload(
-            &state,
-            json!({
-                "spec": "chara_card_v2",
-                "data": {
-                    "name": "Trusted Source",
-                    "description": "Trusted bulk import source path"
-                }
-            }),
-            Some("trusted-avatar.png".to_string()),
-            &Value::Null,
-            Some(&source),
-        )
-        .expect("trusted avatar source should import");
-
-        let character = result
-            .get("character")
-            .and_then(Value::as_object)
-            .expect("import should return a character record");
-        let avatar_file_path = character
-            .get("avatarFilePath")
-            .and_then(Value::as_str)
-            .expect("trusted source should create a managed avatar file");
-        assert!(
-            avatar_file_path.contains("avatars")
-                && avatar_file_path.contains("characters")
-                && avatar_file_path.ends_with("trusted-avatar.png"),
-            "managed avatar path should stay under the character avatar folder"
-        );
-        assert!(
-            Path::new(avatar_file_path).exists(),
-            "managed avatar file should exist"
-        );
-
-        let _ = fs::remove_dir_all(app_root);
-        let _ = fs::remove_dir_all(source_root);
-    }
-}
+#[path = "service_tests.rs"]
+mod tests;

--- a/src-tauri/src/commands/storage/imports/service_tests.rs
+++ b/src-tauri/src/commands/storage/imports/service_tests.rs
@@ -1,0 +1,189 @@
+use super::*;
+use crate::state::AppState;
+use base64::engine::general_purpose;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn temp_path(label: &str) -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock should be after epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "marinara-st-character-import-{label}-{}-{nonce}",
+        std::process::id()
+    ))
+}
+
+fn corrupt_collection(state: &AppState, collection: &str) {
+    let collection_path = state
+        .storage
+        .root()
+        .join("collections")
+        .join(format!("{collection}.json"));
+    if let Some(parent) = collection_path.parent() {
+        fs::create_dir_all(parent).expect("collection parent should be created");
+    }
+    fs::write(collection_path, b"{not-json").expect("collection should be corruptible");
+}
+
+#[test]
+fn create_lorebook_rolls_back_parent_when_entry_write_fails() {
+    let app_root = temp_path("lorebook-rollback");
+    let state =
+        AppState::from_data_dir(&app_root, Vec::new()).expect("test app state should initialize");
+    corrupt_collection(&state, "lorebook-entries");
+
+    let error = create_lorebook_from_payload(
+        &state,
+        &json!({
+            "name": "Rollback Lorebook",
+            "entries": [{ "content": "entry", "keys": ["rollback"] }]
+        }),
+        "Rollback Lorebook",
+        None,
+    )
+    .expect_err("entry storage failure should reject lorebook import");
+
+    assert_eq!(error.code, "json_error");
+    assert!(
+        state.storage.list("lorebooks").unwrap().is_empty(),
+        "failed lorebook import must remove the created parent row"
+    );
+
+    let _ = fs::remove_dir_all(app_root);
+}
+
+#[test]
+fn import_st_character_rolls_back_character_and_avatar_when_embedded_lorebook_fails() {
+    let app_root = temp_path("character-rollback");
+    let state =
+        AppState::from_data_dir(&app_root, Vec::new()).expect("test app state should initialize");
+    corrupt_collection(&state, "lorebook-entries");
+
+    let avatar = general_purpose::STANDARD.encode(b"avatar-bytes");
+    let error = import_st_character(
+        &state,
+        json!({
+            "spec": "chara_card_v2",
+            "data": {
+                "name": "Rollback Character",
+                "description": "Should be removed",
+                "character_book": {
+                    "name": "Embedded Book",
+                    "entries": [{ "content": "entry", "keys": ["rollback"] }]
+                }
+            },
+            "_avatarDataUrl": format!("data:image/png;base64,{avatar}")
+        }),
+    )
+    .expect_err("embedded lorebook storage failure should reject character import");
+
+    assert_eq!(error.code, "json_error");
+    assert!(
+        state.storage.list("characters").unwrap().is_empty(),
+        "failed embedded-lorebook import must remove the created character"
+    );
+    assert!(
+        state.storage.list("lorebooks").unwrap().is_empty(),
+        "failed embedded-lorebook import must remove the created lorebook"
+    );
+    assert!(
+        !app_root.join("avatars").join("characters").exists(),
+        "failed character import must remove the managed avatar file"
+    );
+
+    let _ = fs::remove_dir_all(app_root);
+}
+
+#[test]
+fn import_st_character_ignores_untrusted_avatar_source_fields() {
+    let app_root = temp_path("app");
+    let source_root = temp_path("source");
+    fs::create_dir_all(&source_root).expect("source dir should be created");
+    let source = source_root.join("not-an-avatar.txt");
+    fs::write(&source, b"do not copy me").expect("source fixture should be written");
+    let state =
+        AppState::from_data_dir(&app_root, Vec::new()).expect("test app state should initialize");
+
+    let result = import_st_character(
+        &state,
+        json!({
+            "spec": "chara_card_v2",
+            "data": {
+                "name": "Reserved Field Probe",
+                "description": "Should not copy arbitrary files"
+            },
+            "_avatarSourcePath": source.to_string_lossy(),
+            "_avatarFileCopySourcePath": source.to_string_lossy()
+        }),
+    )
+    .expect("reserved avatar source fields should be ignored");
+
+    let character = result
+        .get("character")
+        .and_then(Value::as_object)
+        .expect("import should return a character record");
+    assert!(
+        character
+            .get("avatarFilePath")
+            .and_then(Value::as_str)
+            .is_none(),
+        "external payload fields must not create managed avatar file paths"
+    );
+    assert_eq!(character.get("avatarPath"), Some(&Value::Null));
+    assert!(
+        !app_root.join("avatars").join("characters").exists(),
+        "untrusted local file paths should not be copied into managed avatars"
+    );
+
+    let _ = fs::remove_dir_all(app_root);
+    let _ = fs::remove_dir_all(source_root);
+}
+
+#[test]
+fn import_st_character_uses_trusted_avatar_source_path() {
+    let app_root = temp_path("app");
+    let source_root = temp_path("source");
+    fs::create_dir_all(&source_root).expect("source dir should be created");
+    let source = source_root.join("trusted-avatar.png");
+    fs::write(&source, b"trusted-avatar-bytes").expect("source fixture should be written");
+    let state =
+        AppState::from_data_dir(&app_root, Vec::new()).expect("test app state should initialize");
+
+    let result = import_st_character_payload(
+        &state,
+        json!({
+            "spec": "chara_card_v2",
+            "data": {
+                "name": "Trusted Source",
+                "description": "Trusted bulk import source path"
+            }
+        }),
+        Some("trusted-avatar.png".to_string()),
+        &Value::Null,
+        Some(&source),
+    )
+    .expect("trusted avatar source should import");
+
+    let character = result
+        .get("character")
+        .and_then(Value::as_object)
+        .expect("import should return a character record");
+    let avatar_file_path = character
+        .get("avatarFilePath")
+        .and_then(Value::as_str)
+        .expect("trusted source should create a managed avatar file");
+    assert!(
+        avatar_file_path.contains("avatars")
+            && avatar_file_path.contains("characters")
+            && avatar_file_path.ends_with("trusted-avatar.png"),
+        "managed avatar path should stay under the character avatar folder"
+    );
+    assert!(
+        Path::new(avatar_file_path).exists(),
+        "managed avatar file should exist"
+    );
+
+    let _ = fs::remove_dir_all(app_root);
+    let _ = fs::remove_dir_all(source_root);
+}


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

<!-- Every user-facing PR should reference a feature request or issue report when practical. -->

Closes #1250

## Why this change

<!-- What user problem, bug, refactor goal, or maintenance need does this solve? -->

- Failed direct/ST import paths could create storage rows, managed avatar files, or target chat patches before a later import write failed, leaving partial imported state behind.

## What changed

<!-- List the key changes in this PR. -->

- Added rollback helpers for imported storage rows, lorebook trees, and managed avatar files.
- Wrapped direct ST lorebook/character imports, ST chat/branch imports, and persona avatar import writes so later failures undo earlier writes.
- Moved ST character import tests out of the oversized service module and added failure-injection regression tests for the covered rollback paths.

## Refactor impact

Primary owner:

<!-- Examples: app shell, catalog, chat mode, roleplay mode, game mode, runtime generation, world-state, shared API, engine generation, Rust storage, imports, remote runtime. -->

Rust storage/imports

Impact areas reviewed:

- Tauri/Rust import paths
- FileStorage JSON collections
- Managed avatar files under `avatars/characters` and `avatars/personas`

Boundary notes:

<!-- Note engine/shared-api/feature/Rust/remote-runtime boundaries. Say "none" only if you checked. -->

- Stays inside Rust import/storage command code.
- No schema, dependency, auth, prompt-pipeline, remote-runtime, release, or UI changes.

Pressure points touched:

<!-- Mention ModeSurface, GameSurface, shared mode UI, src-tauri/src/lib.rs command registration, or import modules if touched. -->

- `src-tauri/src/commands/storage/imports/service.rs`
- `src-tauri/src/commands/storage/imports/bulk_imports.rs`
- New focused rollback/test modules under `src-tauri/src/commands/storage/imports/`

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app/runtime, step by step. If an AI agent filled this out, verify it yourself before ticking boxes. -->

- Codex machine verification: `cargo test storage_commands::imports` passed 14 Rust import tests, including failure-injection rows for lorebook parent rollback, character/avatar embedded-lorebook rollback, chat rollback, group branch target restoration, existing group preservation, and persona avatar rollback.
- Codex machine verification: `pnpm check` passed architecture, frontend TypeScript, Rust cargo check workspace, and docs checks.
- Codex proof gate: `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json` passed.
- Repo-doc mismatch: `pnpm db:push` is not present in this refactor worktree, so no DB push command was available to run.
- Manual human verification available but not required for the core claim: try a real failed direct import and failed ST bulk import in the Tauri app if you want end-to-end UI confidence beyond the Rust storage harness.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

<!-- Add before/after screenshots or recordings for visible UI changes. -->

N/A - non-UI Rust storage/import rollback fix. Machine proof is in the Rust import tests and proof ledger.
