### PR TITLE
Fix refactor import rollback tests

### DIFF
--- a/src-tauri/src/commands/storage/imports/bulk_imports.rs
+++ b/src-tauri/src/commands/storage/imports/bulk_imports.rs
@@ -1003,6 +1003,7 @@ pub(super) fn run_st_bulk_import_channel(
 
 #[cfg(test)]
 mod tests {
+    use super::super::test_helpers::block_collection_file;
     use super::*;
     use crate::state::AppState;
     use base64::engine::general_purpose;
@@ -1036,18 +1037,6 @@ mod tests {
             fs::create_dir_all(parent).expect("fixture parent should be created");
         }
         fs::write(path, bytes).expect("fixture file should be written");
-    }
-
-    fn block_collection_file(state: &AppState, collection: &str) {
-        let collection_path = state
-            .storage
-            .root()
-            .join("collections")
-            .join(format!("{collection}.json"));
-        if let Some(parent) = collection_path.parent() {
-            fs::create_dir_all(parent).expect("collection parent should be created");
-        }
-        fs::create_dir(collection_path).expect("collection path should be blockable");
     }
 
     fn uploaded_jsonl_file(name: &str, text: &str) -> Value {

--- a/src-tauri/src/commands/storage/imports/bulk_imports.rs
+++ b/src-tauri/src/commands/storage/imports/bulk_imports.rs
@@ -1038,7 +1038,7 @@ mod tests {
         fs::write(path, bytes).expect("fixture file should be written");
     }
 
-    fn corrupt_collection(state: &AppState, collection: &str) {
+    fn block_collection_file(state: &AppState, collection: &str) {
         let collection_path = state
             .storage
             .root()
@@ -1047,7 +1047,7 @@ mod tests {
         if let Some(parent) = collection_path.parent() {
             fs::create_dir_all(parent).expect("collection parent should be created");
         }
-        fs::write(collection_path, b"{not-json").expect("collection should be corruptible");
+        fs::create_dir(collection_path).expect("collection path should be blockable");
     }
 
     fn uploaded_jsonl_file(name: &str, text: &str) -> Value {
@@ -1123,7 +1123,7 @@ mod tests {
         let app_root = temp_path("chat-rollback");
         let state = AppState::from_data_dir(&app_root, Vec::new())
             .expect("test app state should initialize");
-        corrupt_collection(&state, "messages");
+        block_collection_file(&state, "messages");
 
         let error = import_st_chat_text(
             &state,
@@ -1133,7 +1133,7 @@ mod tests {
         )
         .expect_err("message storage failure should reject chat import");
 
-        assert_eq!(error.code, "invalid_input");
+        assert_eq!(error.code, "io_error");
         assert!(
             state.storage.list("chats").unwrap().is_empty(),
             "failed chat import must remove the created chat"
@@ -1160,7 +1160,7 @@ mod tests {
                 }),
             )
             .expect("target chat should be created");
-        corrupt_collection(&state, "messages");
+        block_collection_file(&state, "messages");
 
         let error = import_st_chat_into_group(
             &state,
@@ -1174,7 +1174,7 @@ mod tests {
         )
         .expect_err("message storage failure should reject branch import");
 
-        assert_eq!(error.code, "invalid_input");
+        assert_eq!(error.code, "io_error");
         let target = state
             .storage
             .get("chats", "target-chat")
@@ -1212,7 +1212,7 @@ mod tests {
                 }),
             )
             .expect("target chat should be created");
-        corrupt_collection(&state, "messages");
+        block_collection_file(&state, "messages");
 
         let error = import_st_chat_into_group(
             &state,
@@ -1226,7 +1226,7 @@ mod tests {
         )
         .expect_err("message storage failure should reject branch import");
 
-        assert_eq!(error.code, "invalid_input");
+        assert_eq!(error.code, "io_error");
         let target = state
             .storage
             .get("chats", "target-chat")
@@ -1250,7 +1250,7 @@ mod tests {
         fs::write(&source, b"persona-avatar-bytes").expect("source fixture should be written");
         let state = AppState::from_data_dir(&app_root, Vec::new())
             .expect("test app state should initialize");
-        corrupt_collection(&state, "personas");
+        block_collection_file(&state, "personas");
 
         let error = import_persona_avatar_file(
             &state,
@@ -1260,7 +1260,7 @@ mod tests {
         )
         .expect_err("persona storage failure should reject persona avatar import");
 
-        assert_eq!(error.code, "json_error");
+        assert_eq!(error.code, "io_error");
         assert!(
             !app_root.join("avatars").join("personas").exists(),
             "failed persona avatar import must remove the managed avatar file"

--- a/src-tauri/src/commands/storage/imports/service.rs
+++ b/src-tauri/src/commands/storage/imports/service.rs
@@ -18,6 +18,9 @@ mod payloads;
 mod rollback;
 #[path = "st_preset.rs"]
 mod st_preset;
+#[cfg(test)]
+#[path = "test_helpers.rs"]
+mod test_helpers;
 #[path = "timestamps.rs"]
 mod timestamps;
 use access::*;

--- a/src-tauri/src/commands/storage/imports/service_tests.rs
+++ b/src-tauri/src/commands/storage/imports/service_tests.rs
@@ -1,5 +1,5 @@
+use super::test_helpers::block_collection_file;
 use super::*;
-use crate::state::AppState;
 use base64::engine::general_purpose;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -12,18 +12,6 @@ fn temp_path(label: &str) -> PathBuf {
         "marinara-st-character-import-{label}-{}-{nonce}",
         std::process::id()
     ))
-}
-
-fn block_collection_file(state: &AppState, collection: &str) {
-    let collection_path = state
-        .storage
-        .root()
-        .join("collections")
-        .join(format!("{collection}.json"));
-    if let Some(parent) = collection_path.parent() {
-        fs::create_dir_all(parent).expect("collection parent should be created");
-    }
-    fs::create_dir(collection_path).expect("collection path should be blockable");
 }
 
 #[test]

--- a/src-tauri/src/commands/storage/imports/service_tests.rs
+++ b/src-tauri/src/commands/storage/imports/service_tests.rs
@@ -14,7 +14,7 @@ fn temp_path(label: &str) -> PathBuf {
     ))
 }
 
-fn corrupt_collection(state: &AppState, collection: &str) {
+fn block_collection_file(state: &AppState, collection: &str) {
     let collection_path = state
         .storage
         .root()
@@ -23,7 +23,7 @@ fn corrupt_collection(state: &AppState, collection: &str) {
     if let Some(parent) = collection_path.parent() {
         fs::create_dir_all(parent).expect("collection parent should be created");
     }
-    fs::write(collection_path, b"{not-json").expect("collection should be corruptible");
+    fs::create_dir(collection_path).expect("collection path should be blockable");
 }
 
 #[test]
@@ -31,7 +31,7 @@ fn create_lorebook_rolls_back_parent_when_entry_write_fails() {
     let app_root = temp_path("lorebook-rollback");
     let state =
         AppState::from_data_dir(&app_root, Vec::new()).expect("test app state should initialize");
-    corrupt_collection(&state, "lorebook-entries");
+    block_collection_file(&state, "lorebook-entries");
 
     let error = create_lorebook_from_payload(
         &state,
@@ -44,7 +44,7 @@ fn create_lorebook_rolls_back_parent_when_entry_write_fails() {
     )
     .expect_err("entry storage failure should reject lorebook import");
 
-    assert_eq!(error.code, "json_error");
+    assert_eq!(error.code, "io_error");
     assert!(
         state.storage.list("lorebooks").unwrap().is_empty(),
         "failed lorebook import must remove the created parent row"
@@ -58,7 +58,7 @@ fn import_st_character_rolls_back_character_and_avatar_when_embedded_lorebook_fa
     let app_root = temp_path("character-rollback");
     let state =
         AppState::from_data_dir(&app_root, Vec::new()).expect("test app state should initialize");
-    corrupt_collection(&state, "lorebook-entries");
+    block_collection_file(&state, "lorebook-entries");
 
     let avatar = general_purpose::STANDARD.encode(b"avatar-bytes");
     let error = import_st_character(
@@ -78,7 +78,7 @@ fn import_st_character_rolls_back_character_and_avatar_when_embedded_lorebook_fa
     )
     .expect_err("embedded lorebook storage failure should reject character import");
 
-    assert_eq!(error.code, "json_error");
+    assert_eq!(error.code, "io_error");
     assert!(
         state.storage.list("characters").unwrap().is_empty(),
         "failed embedded-lorebook import must remove the created character"

--- a/src-tauri/src/commands/storage/imports/test_helpers.rs
+++ b/src-tauri/src/commands/storage/imports/test_helpers.rs
@@ -1,0 +1,14 @@
+use crate::state::AppState;
+use std::fs;
+
+pub(crate) fn block_collection_file(state: &AppState, collection: &str) {
+    let collection_path = state
+        .storage
+        .root()
+        .join("collections")
+        .join(format!("{collection}.json"));
+    if let Some(parent) = collection_path.parent() {
+        fs::create_dir_all(parent).expect("collection parent should be created");
+    }
+    fs::create_dir(collection_path).expect("collection path should be blockable");
+}


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

<!-- Every user-facing PR should reference a feature request or issue report when practical. -->

No linked issue; this unblocks the current `refactor` Rust Capability Layer CI failure.

## Why this change

<!-- What user problem, bug, refactor goal, or maintenance need does this solve? -->

- The `refactor` branch Rust Capability Layer is failing in import rollback tests because those tests still use corrupt JSON files to simulate write failures. Storage corruption recovery now correctly preserves and recreates corrupt collections, so those fixtures no longer fail writes and the imports can succeed.

## What changed

<!-- List the key changes in this PR. -->

- Updated import rollback test fixtures to block the target collection path with a directory, which exercises the intended durable write failure path.
- Updated expected error codes from recovered JSON parse failures to the resulting filesystem write errors.
- Covered the same harness correction for bulk import rollback tests and the related lorebook/character import rollback tests.

## Refactor impact

Primary owner:

<!-- Examples: app shell, catalog, chat mode, roleplay mode, game mode, runtime generation, world-state, shared API, engine generation, Rust storage, imports, remote runtime. -->

Rust storage / imports tests.

Impact areas reviewed:

- SillyTavern chat import rollback tests.
- SillyTavern branch import rollback tests.
- Persona avatar import rollback tests.
- Lorebook and embedded-lorebook import rollback tests.

Boundary notes:

<!-- Note engine/shared-api/feature/Rust/remote-runtime boundaries. Say "none" only if you checked. -->

- Test-only change. No runtime storage, import, shared API, client, or remote runtime behavior changes.

Pressure points touched:

<!-- Mention ModeSurface, GameSurface, shared mode UI, src-tauri/src/lib.rs command registration, or import modules if touched. -->

- `src-tauri/src/commands/storage/imports/bulk_imports.rs` test module.
- `src-tauri/src/commands/storage/imports/service_tests.rs` test module.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app/runtime, step by step. If an AI agent filled this out, verify it yourself before ticking boxes. -->

- Codex confirmed the current `refactor` push fails Rust Capability Layer in the import rollback tests.
- Codex ran `cargo test --manifest-path src-tauri\Cargo.toml storage_commands::imports::service::bulk_imports::tests`; it passed 5/5.
- Codex ran `cargo test --manifest-path src-tauri\Cargo.toml storage_commands::imports::service::tests`; it passed 4/4.
- Codex ran `cargo test --manifest-path src-tauri\Cargo.toml --workspace`; it passed.
- Codex ran `pnpm check`; it passed.
- Codex ran `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\ci-unblock-import-rollback-verification.json`; it passed.
- Local `cargo nextest` was unavailable in this worktree; GitHub CI installs nextest in the Rust Capability Layer job.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs or release metadata changes are needed; this is a test-only CI unblock.

## UI evidence

<!-- Add before/after screenshots or recordings for visible UI changes. -->

N/A - Rust test harness change only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved storage import rollback tests to simulate I/O failure scenarios and verify proper error handling, enhancing reliability of the import process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1320?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->