### PR TITLE
Fix import rollback test fixtures

### DIFF
--- a/src-tauri/src/commands/storage/imports/bulk_imports.rs
+++ b/src-tauri/src/commands/storage/imports/bulk_imports.rs
@@ -1038,7 +1038,7 @@ mod tests {
         fs::write(path, bytes).expect("fixture file should be written");
     }
 
-    fn corrupt_collection(state: &AppState, collection: &str) {
+    fn block_collection_writes(state: &AppState, collection: &str) {
         let collection_path = state
             .storage
             .root()
@@ -1047,7 +1047,7 @@ mod tests {
         if let Some(parent) = collection_path.parent() {
             fs::create_dir_all(parent).expect("collection parent should be created");
         }
-        fs::write(collection_path, b"{not-json").expect("collection should be corruptible");
+        fs::create_dir(collection_path).expect("collection path should block file writes");
     }
 
     fn uploaded_jsonl_file(name: &str, text: &str) -> Value {
@@ -1123,7 +1123,7 @@ mod tests {
         let app_root = temp_path("chat-rollback");
         let state = AppState::from_data_dir(&app_root, Vec::new())
             .expect("test app state should initialize");
-        corrupt_collection(&state, "messages");
+        block_collection_writes(&state, "messages");
 
         let error = import_st_chat_text(
             &state,
@@ -1133,7 +1133,7 @@ mod tests {
         )
         .expect_err("message storage failure should reject chat import");
 
-        assert_eq!(error.code, "invalid_input");
+        assert_eq!(error.code, "io_error");
         assert!(
             state.storage.list("chats").unwrap().is_empty(),
             "failed chat import must remove the created chat"
@@ -1160,7 +1160,7 @@ mod tests {
                 }),
             )
             .expect("target chat should be created");
-        corrupt_collection(&state, "messages");
+        block_collection_writes(&state, "messages");
 
         let error = import_st_chat_into_group(
             &state,
@@ -1174,7 +1174,7 @@ mod tests {
         )
         .expect_err("message storage failure should reject branch import");
 
-        assert_eq!(error.code, "invalid_input");
+        assert_eq!(error.code, "io_error");
         let target = state
             .storage
             .get("chats", "target-chat")
@@ -1212,7 +1212,7 @@ mod tests {
                 }),
             )
             .expect("target chat should be created");
-        corrupt_collection(&state, "messages");
+        block_collection_writes(&state, "messages");
 
         let error = import_st_chat_into_group(
             &state,
@@ -1226,7 +1226,7 @@ mod tests {
         )
         .expect_err("message storage failure should reject branch import");
 
-        assert_eq!(error.code, "invalid_input");
+        assert_eq!(error.code, "io_error");
         let target = state
             .storage
             .get("chats", "target-chat")
@@ -1250,7 +1250,7 @@ mod tests {
         fs::write(&source, b"persona-avatar-bytes").expect("source fixture should be written");
         let state = AppState::from_data_dir(&app_root, Vec::new())
             .expect("test app state should initialize");
-        corrupt_collection(&state, "personas");
+        block_collection_writes(&state, "personas");
 
         let error = import_persona_avatar_file(
             &state,
@@ -1260,7 +1260,7 @@ mod tests {
         )
         .expect_err("persona storage failure should reject persona avatar import");
 
-        assert_eq!(error.code, "json_error");
+        assert_eq!(error.code, "io_error");
         assert!(
             !app_root.join("avatars").join("personas").exists(),
             "failed persona avatar import must remove the managed avatar file"

--- a/src-tauri/src/commands/storage/imports/service_tests.rs
+++ b/src-tauri/src/commands/storage/imports/service_tests.rs
@@ -14,7 +14,7 @@ fn temp_path(label: &str) -> PathBuf {
     ))
 }
 
-fn corrupt_collection(state: &AppState, collection: &str) {
+fn block_collection_writes(state: &AppState, collection: &str) {
     let collection_path = state
         .storage
         .root()
@@ -23,7 +23,7 @@ fn corrupt_collection(state: &AppState, collection: &str) {
     if let Some(parent) = collection_path.parent() {
         fs::create_dir_all(parent).expect("collection parent should be created");
     }
-    fs::write(collection_path, b"{not-json").expect("collection should be corruptible");
+    fs::create_dir(collection_path).expect("collection path should block file writes");
 }
 
 #[test]
@@ -31,7 +31,7 @@ fn create_lorebook_rolls_back_parent_when_entry_write_fails() {
     let app_root = temp_path("lorebook-rollback");
     let state =
         AppState::from_data_dir(&app_root, Vec::new()).expect("test app state should initialize");
-    corrupt_collection(&state, "lorebook-entries");
+    block_collection_writes(&state, "lorebook-entries");
 
     let error = create_lorebook_from_payload(
         &state,
@@ -44,7 +44,7 @@ fn create_lorebook_rolls_back_parent_when_entry_write_fails() {
     )
     .expect_err("entry storage failure should reject lorebook import");
 
-    assert_eq!(error.code, "json_error");
+    assert_eq!(error.code, "io_error");
     assert!(
         state.storage.list("lorebooks").unwrap().is_empty(),
         "failed lorebook import must remove the created parent row"
@@ -58,7 +58,7 @@ fn import_st_character_rolls_back_character_and_avatar_when_embedded_lorebook_fa
     let app_root = temp_path("character-rollback");
     let state =
         AppState::from_data_dir(&app_root, Vec::new()).expect("test app state should initialize");
-    corrupt_collection(&state, "lorebook-entries");
+    block_collection_writes(&state, "lorebook-entries");
 
     let avatar = general_purpose::STANDARD.encode(b"avatar-bytes");
     let error = import_st_character(
@@ -78,7 +78,7 @@ fn import_st_character_rolls_back_character_and_avatar_when_embedded_lorebook_fa
     )
     .expect_err("embedded lorebook storage failure should reject character import");
 
-    assert_eq!(error.code, "json_error");
+    assert_eq!(error.code, "io_error");
     assert!(
         state.storage.list("characters").unwrap().is_empty(),
         "failed embedded-lorebook import must remove the created character"


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

No linked issue. This unblocks the current `refactor` Rust CI failure.

## Why this change

- Rust import rollback tests were using malformed collection JSON as a write-failure fixture.
- Storage now intentionally recovers corrupt collection files, so those tests no longer triggered rollback and instead imported successfully.

## What changed

- Updated rollback tests to block writes by placing a directory at the target collection file path.
- Updated expected error codes from JSON parse errors to `io_error`, matching the actual write-blocked failure being tested.
- Left production storage/import behavior unchanged.

## Refactor impact

Primary owner:

Rust storage/import tests

Impact areas reviewed:

- SillyTavern chat import rollback tests
- Persona avatar import rollback tests
- Embedded lorebook rollback tests
- Storage corrupt collection recovery tests

Boundary notes:

- Test-only change under `src-tauri/src/commands/storage/imports`.
- No production storage, import, UI, API, schema, dependency, or release metadata changes.

Pressure points touched:

- Import rollback coverage in `bulk_imports.rs` and `service_tests.rs`

## Validation

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

Codex-run machine proof:

- `cargo test --manifest-path src-tauri/Cargo.toml --workspace storage_commands::imports::service::bulk_imports::tests -- --nocapture` passed.
- `cargo test --manifest-path src-tauri/Cargo.toml --workspace storage_commands::imports::service::tests -- --nocapture` passed.
- `cargo test --manifest-path src-tauri/Cargo.toml --workspace` passed.
- `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passed.
- `cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- -D warnings` passed.
- `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\rust-ci-verification.json` passed.
- Bunny review passed before opening: test-only diff, production behavior untouched, direct coverage for the failing CI rows.

### Manual verification notes

- No manual verification required; this is a Rust test-fixture/CI unblocker with no user-facing runtime change.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs or release metadata changes needed.

## UI evidence

N/A - no UI changed.
