### PR TITLE
Fix preset role history preservation

### DIFF
--- a/src/engine/generation/prompt-assembly.test.ts
+++ b/src/engine/generation/prompt-assembly.test.ts
@@ -71,6 +71,56 @@ const request = {
 };
 
 describe("assembleGenerationPrompt strict roles", () => {
+  it("preserves preset chat history roles when history begins with an assistant greeting", async () => {
+    const assembly = await assembleGenerationPrompt(
+      storageWithSections([
+        section({ id: "main", name: "main", role: "system", content: "Main rules.", sortOrder: 0 }),
+        section({
+          id: "history",
+          name: "chat_history",
+          role: "user",
+          markerConfig: { type: "chat_history" },
+          sortOrder: 1,
+        }),
+      ]),
+      {
+        chat: { id: "chat", mode: "roleplay" },
+        storedMessages: [
+          { role: "assistant", content: "Welcome back.", contextKind: "history" },
+          { role: "user", content: "I missed you.", contextKind: "history" },
+        ],
+        connection: {},
+        request,
+        latestUserInput: "I missed you.",
+      },
+    );
+
+    const history = assembly.messages.filter((message) => message.contextKind === "history");
+    expect(history.map((message) => [message.role, message.content])).toEqual([
+      ["assistant", "Welcome back."],
+      ["user", "I missed you."],
+    ]);
+  });
+
+  it("preserves fallback chat history roles when no preset is active", async () => {
+    const assembly = await assembleGenerationPrompt(storageWithSections([]), {
+      chat: { id: "chat", mode: "roleplay" },
+      storedMessages: [
+        { role: "assistant", content: "Welcome back.", contextKind: "history" },
+        { role: "user", content: "I missed you.", contextKind: "history" },
+      ],
+      connection: {},
+      request: { ...request, promptPresetId: "" },
+      latestUserInput: "I missed you.",
+    });
+
+    const history = assembly.messages.filter((message) => message.contextKind === "history");
+    expect(history.map((message) => [message.role, message.content])).toEqual([
+      ["assistant", "Welcome back."],
+      ["user", "I missed you."],
+    ]);
+  });
+
   it("merges post-history system sections into the preceding user-side message", async () => {
     const assembly = await assembleGenerationPrompt(
       storageWithSections([

--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -925,8 +925,8 @@ function enforceStrictRoles(messages: ChatMLMessage[]): ChatMLMessage[] {
       continue;
     }
 
-    result.push({ ...message, role: expectedRole });
-    expectedRole = expectedRole === "user" ? "assistant" : "user";
+    result.push({ ...message, role: effectiveRole });
+    expectedRole = effectiveRole === "user" ? "assistant" : "user";
   }
 
   return result;


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #1273

## Why this change

- Applying a prompt preset in roleplay could cause strict role formatting to rewrite real chat history turns into the alternating slot, which made an assistant greeting/user reply sequence become user/assistant instead of assistant/user.
- This is a clean replacement for #1315 after that PR's GitHub diff became polluted while avoiding a force-push.

## What changed

- Preserve the actual effective role when strict role formatting encounters a non-mergable role mismatch, instead of rewriting that message to the expected alternating role.
- Added regression coverage for preset chat history beginning with an assistant greeting, plus the no-preset fallback path.

## Refactor impact

Primary owner:

engine generation

Impact areas reviewed:

- `assembleGenerationPrompt` strict role formatting
- prompt preset `chat_history` marker insertion
- roleplay fallback prompt assembly

Boundary notes:

- Stays inside React-free engine generation code.
- No prompt wording, preset content, UI, storage, schema, dependency, provider, or Rust behavior changes.
- GitHub PR diff was checked to include only the two prompt assembly files.

Pressure points touched:

- `src/engine/generation/prompt-assembly.ts`

## Validation

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

Codex-run machine proof:

- Reproduced before fix with a Vitest regression row: assistant greeting followed by user reply was collapsed into one `user` history message.
- `pnpm exec vitest run src/engine/generation/prompt-assembly.test.ts --reporter=json --outputFile=scratch/issue-1273-vitest-clean.json` passed after the fix: 8 tests.
- `pnpm check` passed locally: architecture, frontend typecheck, Rust cargo check, docs.
- `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json` passed.
- Bunny review passed before opening: focused diff, direct regression proof, no scope expansion.

### Manual verification notes

- No manual verification required for the core claim; this is covered by engine-level regression tests and `pnpm check`.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs or release metadata changes needed; this is a narrow engine bugfix.

## UI evidence

N/A - no visible UI surface changed. The affected behavior is generated provider message role assembly.
