### PR TITLE
Fix hostable remote runtime security gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ Health check:
 curl http://127.0.0.1:8787/health
 ```
 
+Non-loopback clients fail closed unless you configure access control. Use `BASIC_AUTH_USER` and
+`BASIC_AUTH_PASS`, `IP_ALLOWLIST`, or an explicit opt-in such as
+`ALLOW_UNAUTHENTICATED_PRIVATE_NETWORK=true` for trusted LAN/private-network access.
+Set `CORS_ORIGINS` or `CSRF_TRUSTED_ORIGINS` when the desktop client origin is not one of the
+runtime defaults.
+
 With Docker Compose:
 
 ```sh

--- a/docs/developer/run-build.html
+++ b/docs/developer/run-build.html
@@ -113,6 +113,16 @@
         <p>Override the bind address and data directory with:</p>
         <pre><code>MARINARA_SERVER_ADDR=0.0.0.0:8787
 MARINARA_DATA_DIR=/path/to/data</code></pre>
+        <p>
+          Non-loopback clients fail closed unless the runtime has explicit
+          access control. Configure <code>BASIC_AUTH_USER</code> and
+          <code>BASIC_AUTH_PASS</code>, <code>IP_ALLOWLIST</code>, or an
+          intentional compatibility opt-in such as
+          <code>ALLOW_UNAUTHENTICATED_PRIVATE_NETWORK=true</code> for trusted
+          LAN/private-network access. Set <code>CORS_ORIGINS</code> or
+          <code>CSRF_TRUSTED_ORIGINS</code> if your desktop client origin is not
+          one of the runtime defaults.
+        </p>
         <div class="callout">
           Remote-capable features must use the shared API HTTP pipeline:
           <code>src/shared/api</code> wrapper, <code>remote-runtime.ts</code>

--- a/src-tauri/src/http_server.rs
+++ b/src-tauri/src/http_server.rs
@@ -2,24 +2,38 @@ use crate::http_dispatch::{dispatch, InvokeRequest};
 use crate::state::AppState;
 use crate::storage_commands::{llm, lorebook_images};
 use axum::body::Body;
-use axum::extract::{Path, State};
-use axum::http::{header, StatusCode};
+use axum::extract::{ConnectInfo, Path, State};
+use axum::http::{header, HeaderMap, HeaderName, HeaderValue, Method, Request, StatusCode};
+use axum::middleware::{self, Next};
 use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::{Json, Router};
+use base64::{engine::general_purpose, Engine as _};
 use marinara_core::AppError;
 use serde::Deserialize;
 use serde_json::{json, Value};
 use std::convert::Infallible;
 use std::io::ErrorKind;
-use std::net::SocketAddr;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::path::{Path as FsPath, PathBuf};
 use std::time::Instant;
 use tokio::io::AsyncReadExt;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::{ReceiverStream, UnboundedReceiverStream};
-use tower_http::cors::{Any, CorsLayer};
+use tower_http::cors::{AllowOrigin, CorsLayer};
+
+const CSRF_HEADER_NAME: &str = "x-marinara-csrf";
+const CSRF_HEADER_VALUE: &str = "1";
+const DEFAULT_CORS_ORIGINS: [&str; 7] = [
+    "http://localhost:1420",
+    "http://127.0.0.1:1420",
+    "http://localhost:5173",
+    "http://127.0.0.1:5173",
+    "tauri://localhost",
+    "http://tauri.localhost",
+    "https://tauri.localhost",
+];
 
 #[derive(Clone)]
 pub struct HttpState {
@@ -35,10 +49,17 @@ pub struct LlmStreamRequest {
 
 pub async fn serve(state: AppState, addr: SocketAddr) -> Result<(), std::io::Error> {
     let listener = tokio::net::TcpListener::bind(addr).await?;
-    axum::serve(listener, router(state)).await
+    axum::serve(
+        listener,
+        router(state).into_make_service_with_connect_info::<SocketAddr>(),
+    )
+    .await
 }
 
 pub fn router(state: AppState) -> Router {
+    let security = SecurityConfig::from_env();
+    let cors_security = security.clone();
+    let middleware_security = security.clone();
     Router::new()
         .route("/health", get(health))
         .route("/api/invoke", post(invoke))
@@ -47,10 +68,25 @@ pub fn router(state: AppState) -> Router {
         .route("/api/llm/stream/:stream_id/cancel", post(llm_stream_cancel))
         .layer(
             CorsLayer::new()
-                .allow_origin(Any)
-                .allow_methods(Any)
-                .allow_headers(Any),
+                .allow_origin(AllowOrigin::predicate(move |origin, _parts| {
+                    origin
+                        .to_str()
+                        .ok()
+                        .is_some_and(|value| cors_security.is_cors_origin_allowed(value))
+                }))
+                .allow_methods([Method::GET, Method::POST, Method::OPTIONS])
+                .allow_headers([
+                    header::AUTHORIZATION,
+                    header::CONTENT_TYPE,
+                    header::ACCEPT,
+                    HeaderName::from_static(CSRF_HEADER_NAME),
+                ])
+                .allow_credentials(true),
         )
+        .layer(middleware::from_fn_with_state(
+            middleware_security,
+            security_middleware,
+        ))
         .with_state(HttpState { app: state })
 }
 
@@ -248,5 +284,709 @@ impl IntoResponse for HttpError {
             "details": self.0.details,
         });
         (status, Json(payload)).into_response()
+    }
+}
+
+#[derive(Debug, Clone)]
+struct SecurityConfig {
+    cors_wildcard: bool,
+    cors_origins: Vec<String>,
+    basic_auth: Option<BasicAuthConfig>,
+    basic_auth_realm: String,
+    ip_allowlist: Option<Vec<CidrEntry>>,
+    trusted_private_networks: Vec<CidrEntry>,
+    allow_unauthenticated_private_network: bool,
+    allow_unauthenticated_remote: bool,
+    bypass_tailscale: bool,
+    bypass_docker: bool,
+    require_auth_for_docker_proxy: bool,
+    csrf_trusted_origins: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct BasicAuthConfig {
+    expected_header: Vec<u8>,
+}
+
+#[derive(Debug, Clone)]
+struct CidrEntry {
+    network: IpAddr,
+    prefix: u8,
+}
+
+#[derive(Debug)]
+struct SecurityRejection {
+    status: StatusCode,
+    code: &'static str,
+    message: String,
+    www_authenticate: Option<String>,
+}
+
+async fn security_middleware(
+    State(security): State<SecurityConfig>,
+    request: Request<Body>,
+    next: Next,
+) -> Response {
+    match security.evaluate_request(&request) {
+        Ok(()) => {
+            let mut response = next.run(request).await;
+            apply_security_headers(response.headers_mut());
+            response
+        }
+        Err(rejection) => rejection.into_response(&security),
+    }
+}
+
+impl SecurityConfig {
+    fn from_env() -> Self {
+        let cors_origins = parse_origin_list("CORS_ORIGINS").unwrap_or_else(|| {
+            DEFAULT_CORS_ORIGINS
+                .iter()
+                .map(|value| value.to_string())
+                .collect()
+        });
+        let cors_wildcard = cors_origins.iter().any(|origin| origin == "*");
+        let csrf_trusted_origins = parse_origin_list("CSRF_TRUSTED_ORIGINS").unwrap_or_default();
+        let user = env_value("BASIC_AUTH_USER");
+        let pass = env_value("BASIC_AUTH_PASS");
+        let basic_auth_realm =
+            env_value("BASIC_AUTH_REALM").unwrap_or_else(|| "Marinara Engine".to_string());
+        let basic_auth = match (user, pass) {
+            (Some(user), Some(pass)) => Some(BasicAuthConfig {
+                expected_header: format!(
+                    "Basic {}",
+                    general_purpose::STANDARD.encode(format!("{user}:{pass}"))
+                )
+                .into_bytes(),
+            }),
+            _ => None,
+        };
+
+        Self {
+            cors_wildcard,
+            cors_origins,
+            basic_auth,
+            basic_auth_realm,
+            ip_allowlist: if env_flag_disabled("IP_ALLOWLIST_ENABLED") {
+                None
+            } else {
+                parse_cidr_list("IP_ALLOWLIST")
+            },
+            trusted_private_networks: parse_cidr_list("TRUSTED_PRIVATE_NETWORKS")
+                .unwrap_or_else(default_private_networks),
+            allow_unauthenticated_private_network: env_flag_enabled(
+                "ALLOW_UNAUTHENTICATED_PRIVATE_NETWORK",
+            ),
+            allow_unauthenticated_remote: env_flag_enabled("ALLOW_UNAUTHENTICATED_REMOTE"),
+            bypass_tailscale: !env_flag_disabled("BYPASS_AUTH_TAILSCALE"),
+            bypass_docker: !env_flag_disabled("BYPASS_AUTH_DOCKER"),
+            require_auth_for_docker_proxy: env_flag_enabled("REQUIRE_AUTH_FOR_DOCKER_PROXY"),
+            csrf_trusted_origins,
+        }
+    }
+
+    fn evaluate_request(&self, request: &Request<Body>) -> Result<(), SecurityRejection> {
+        let path = request.uri().path();
+        let method = request.method();
+        if method == Method::OPTIONS || path == "/health" {
+            return Ok(());
+        }
+
+        let ip = remote_ip(request);
+        self.enforce_ip_allowlist(ip)?;
+        self.enforce_basic_auth(ip, request.headers())?;
+        self.enforce_csrf(method, path, request.headers())?;
+        Ok(())
+    }
+
+    fn enforce_ip_allowlist(&self, ip: IpAddr) -> Result<(), SecurityRejection> {
+        let Some(allowlist) = &self.ip_allowlist else {
+            return Ok(());
+        };
+        if is_loopback(ip) || self.is_trusted_interface_ip(ip) || cidr_list_contains(allowlist, ip)
+        {
+            Ok(())
+        } else {
+            Err(SecurityRejection::forbidden(
+                "ip_not_allowed",
+                "Client IP is not allowed to access this runtime",
+            ))
+        }
+    }
+
+    fn enforce_basic_auth(&self, ip: IpAddr, headers: &HeaderMap) -> Result<(), SecurityRejection> {
+        if is_loopback(ip) || self.is_trusted_interface_ip(ip) || self.is_ip_allowlisted(ip) {
+            return Ok(());
+        }
+
+        let Some(config) = &self.basic_auth else {
+            if self.allow_unauthenticated_remote {
+                return Ok(());
+            }
+            if self.allow_unauthenticated_private_network
+                && cidr_list_contains(&self.trusted_private_networks, ip)
+            {
+                return Ok(());
+            }
+            return Err(SecurityRejection::forbidden(
+                "remote_auth_required",
+                "Non-loopback access requires BASIC_AUTH_USER and BASIC_AUTH_PASS, IP_ALLOWLIST, or an explicit unauthenticated remote opt-in",
+            ));
+        };
+
+        let Some(header_value) = headers.get(header::AUTHORIZATION) else {
+            return Err(SecurityRejection::challenge("Authentication required"));
+        };
+        let Ok(provided) = header_value.to_str() else {
+            return Err(SecurityRejection::challenge("Authentication required"));
+        };
+        if constant_time_eq(provided.as_bytes(), &config.expected_header) {
+            Ok(())
+        } else {
+            Err(SecurityRejection::challenge("Authentication required"))
+        }
+    }
+
+    fn enforce_csrf(
+        &self,
+        method: &Method,
+        path: &str,
+        headers: &HeaderMap,
+    ) -> Result<(), SecurityRejection> {
+        if !is_unsafe_method(method) || !path.starts_with("/api/") {
+            return Ok(());
+        }
+
+        let origin = first_header(headers, header::ORIGIN);
+        let referer = first_header(headers, header::REFERER);
+        let sec_fetch_site = first_header(headers, HeaderName::from_static("sec-fetch-site"));
+        let browser_signal_present =
+            origin.is_some() || referer.is_some() || sec_fetch_site.is_some();
+
+        if let Some(site) = sec_fetch_site.as_deref().map(str::to_ascii_lowercase) {
+            let safe_fetch_site = matches!(site.as_str(), "same-origin" | "same-site" | "none");
+            if !safe_fetch_site
+                && !origin
+                    .as_deref()
+                    .is_some_and(|value| self.is_origin_trusted(value))
+            {
+                return Err(SecurityRejection::forbidden(
+                    "csrf_cross_site",
+                    "Cross-site unsafe requests are not allowed",
+                ));
+            }
+        }
+
+        if let Some(origin) = origin.as_deref() {
+            if !self.is_origin_trusted(origin) {
+                return Err(SecurityRejection::forbidden(
+                    "csrf_origin_not_trusted",
+                    format!("Origin '{origin}' is not trusted for remote runtime requests"),
+                ));
+            }
+        } else if let Some(referer) = referer.as_deref() {
+            if !self.is_origin_trusted(referer) {
+                return Err(SecurityRejection::forbidden(
+                    "csrf_referer_not_trusted",
+                    format!("Referer '{referer}' is not trusted for remote runtime requests"),
+                ));
+            }
+        }
+
+        if browser_signal_present
+            && first_header(headers, HeaderName::from_static(CSRF_HEADER_NAME)).as_deref()
+                != Some(CSRF_HEADER_VALUE)
+        {
+            return Err(SecurityRejection::forbidden(
+                "csrf_missing_header",
+                format!("Missing {CSRF_HEADER_NAME} header"),
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn is_ip_allowlisted(&self, ip: IpAddr) -> bool {
+        self.ip_allowlist
+            .as_ref()
+            .is_some_and(|entries| cidr_list_contains(entries, ip))
+    }
+
+    fn is_trusted_interface_ip(&self, ip: IpAddr) -> bool {
+        (self.bypass_tailscale
+            && parse_cidr("100.64.0.0/10").is_some_and(|entry| cidr_contains(&entry, ip)))
+            || (self.bypass_docker
+                && !self.require_auth_for_docker_proxy
+                && parse_cidr("172.16.0.0/12").is_some_and(|entry| cidr_contains(&entry, ip)))
+    }
+
+    fn is_cors_origin_allowed(&self, origin: &str) -> bool {
+        self.cors_wildcard || self.cors_origins.iter().any(|allowed| allowed == origin)
+    }
+
+    fn is_origin_trusted(&self, origin_or_referer: &str) -> bool {
+        let Some(origin) = normalize_origin(origin_or_referer) else {
+            return false;
+        };
+        self.is_cors_origin_allowed(&origin)
+            || self.csrf_trusted_origins.iter().any(|trusted| {
+                trusted == "*" || normalize_origin(trusted).as_deref() == Some(origin.as_str())
+            })
+    }
+}
+
+impl SecurityRejection {
+    fn forbidden(code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::FORBIDDEN,
+            code,
+            message: message.into(),
+            www_authenticate: None,
+        }
+    }
+
+    fn challenge(message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::UNAUTHORIZED,
+            code: "authentication_required",
+            message: message.into(),
+            www_authenticate: None,
+        }
+    }
+
+    fn into_response(mut self, security: &SecurityConfig) -> Response {
+        if self.status == StatusCode::UNAUTHORIZED {
+            self.www_authenticate = Some(format!(
+                "Basic realm=\"{}\", charset=\"UTF-8\"",
+                security
+                    .basic_auth_realm
+                    .replace('\\', "\\\\")
+                    .replace('"', "\\\"")
+            ));
+        }
+        let mut response = (
+            self.status,
+            Json(json!({
+                "code": self.code,
+                "message": self.message,
+            })),
+        )
+            .into_response();
+        if let Some(value) = self.www_authenticate {
+            if let Ok(header_value) = HeaderValue::from_str(&value) {
+                response
+                    .headers_mut()
+                    .insert(header::WWW_AUTHENTICATE, header_value);
+            }
+        }
+        apply_security_headers(response.headers_mut());
+        response
+    }
+}
+
+fn apply_security_headers(headers: &mut HeaderMap) {
+    headers.insert(
+        header::X_CONTENT_TYPE_OPTIONS,
+        HeaderValue::from_static("nosniff"),
+    );
+    headers.insert(
+        HeaderName::from_static("referrer-policy"),
+        HeaderValue::from_static("strict-origin-when-cross-origin"),
+    );
+    headers.insert(
+        HeaderName::from_static("x-frame-options"),
+        HeaderValue::from_static("DENY"),
+    );
+    headers.insert(
+        HeaderName::from_static("x-permitted-cross-domain-policies"),
+        HeaderValue::from_static("none"),
+    );
+    headers.insert(
+        HeaderName::from_static("origin-agent-cluster"),
+        HeaderValue::from_static("?1"),
+    );
+    headers.insert(
+        HeaderName::from_static("permissions-policy"),
+        HeaderValue::from_static(
+            "camera=(), microphone=(), geolocation=(), payment=(), usb=(), serial=(), xr-spatial-tracking=()",
+        ),
+    );
+}
+
+fn remote_ip(request: &Request<Body>) -> IpAddr {
+    request
+        .extensions()
+        .get::<ConnectInfo<SocketAddr>>()
+        .map(|ConnectInfo(addr)| addr.ip())
+        .unwrap_or(IpAddr::V4(Ipv4Addr::LOCALHOST))
+}
+
+fn env_value(key: &str) -> Option<String> {
+    std::env::var(key)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn env_flag_enabled(key: &str) -> bool {
+    env_value(key).is_some_and(|value| {
+        matches!(
+            value.to_ascii_lowercase().as_str(),
+            "1" | "true" | "yes" | "on"
+        )
+    })
+}
+
+fn env_flag_disabled(key: &str) -> bool {
+    env_value(key).is_some_and(|value| {
+        matches!(
+            value.to_ascii_lowercase().as_str(),
+            "0" | "false" | "no" | "off"
+        )
+    })
+}
+
+fn parse_origin_list(key: &str) -> Option<Vec<String>> {
+    let values: Vec<String> = env_value(key)?
+        .split(',')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|value| value.to_string())
+        .collect();
+    if values.is_empty() {
+        None
+    } else {
+        Some(values)
+    }
+}
+
+fn parse_cidr_list(key: &str) -> Option<Vec<CidrEntry>> {
+    let entries: Vec<CidrEntry> = env_value(key)?
+        .split(',')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .filter_map(parse_cidr)
+        .collect();
+    if entries.is_empty() {
+        None
+    } else {
+        Some(entries)
+    }
+}
+
+fn default_private_networks() -> Vec<CidrEntry> {
+    [
+        "10.0.0.0/8",
+        "172.16.0.0/12",
+        "192.168.0.0/16",
+        "169.254.0.0/16",
+        "100.64.0.0/10",
+        "fc00::/7",
+        "fe80::/10",
+    ]
+    .iter()
+    .filter_map(|entry| parse_cidr(entry))
+    .collect()
+}
+
+fn parse_cidr(raw: &str) -> Option<CidrEntry> {
+    let (addr, prefix) = raw
+        .split_once('/')
+        .map_or((raw, None), |(addr, prefix)| (addr, Some(prefix)));
+    let network: IpAddr = addr.parse().ok()?;
+    let max_prefix = match network {
+        IpAddr::V4(_) => 32,
+        IpAddr::V6(_) => 128,
+    };
+    let prefix = match prefix {
+        Some(value) => value.parse::<u8>().ok()?,
+        None => max_prefix,
+    };
+    if prefix > max_prefix {
+        return None;
+    }
+    Some(CidrEntry { network, prefix })
+}
+
+fn cidr_list_contains(entries: &[CidrEntry], ip: IpAddr) -> bool {
+    entries.iter().any(|entry| cidr_contains(entry, ip))
+}
+
+fn cidr_contains(entry: &CidrEntry, ip: IpAddr) -> bool {
+    match (entry.network, ip) {
+        (IpAddr::V4(network), IpAddr::V4(candidate)) => {
+            masked_v4(network, entry.prefix) == masked_v4(candidate, entry.prefix)
+        }
+        (IpAddr::V6(network), IpAddr::V6(candidate)) => {
+            masked_v6(network, entry.prefix) == masked_v6(candidate, entry.prefix)
+        }
+        _ => false,
+    }
+}
+
+fn masked_v4(ip: Ipv4Addr, prefix: u8) -> u32 {
+    let value = u32::from(ip);
+    if prefix == 0 {
+        0
+    } else {
+        value & (!0u32 << (32 - prefix))
+    }
+}
+
+fn masked_v6(ip: Ipv6Addr, prefix: u8) -> u128 {
+    let value = u128::from(ip);
+    if prefix == 0 {
+        0
+    } else {
+        value & (!0u128 << (128 - prefix))
+    }
+}
+
+fn is_loopback(ip: IpAddr) -> bool {
+    ip.is_loopback()
+}
+
+fn is_unsafe_method(method: &Method) -> bool {
+    matches!(
+        *method,
+        Method::POST | Method::PUT | Method::PATCH | Method::DELETE
+    )
+}
+
+fn first_header(headers: &HeaderMap, name: HeaderName) -> Option<String> {
+    headers
+        .get(name)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.split(',').next())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|value| value.to_string())
+}
+
+fn normalize_origin(value: &str) -> Option<String> {
+    let parsed = reqwest::Url::parse(value).ok()?;
+    let scheme = parsed.scheme();
+    let host = parsed.host_str()?;
+    let port = parsed
+        .port()
+        .map(|port| format!(":{port}"))
+        .unwrap_or_default();
+    Some(format!("{scheme}://{host}{port}"))
+}
+
+fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
+    if left.len() != right.len() {
+        return false;
+    }
+    left.iter()
+        .zip(right.iter())
+        .fold(0u8, |acc, (left, right)| acc | (left ^ right))
+        == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_security() -> SecurityConfig {
+        SecurityConfig {
+            cors_wildcard: false,
+            cors_origins: DEFAULT_CORS_ORIGINS
+                .iter()
+                .map(|value| value.to_string())
+                .collect(),
+            basic_auth: None,
+            basic_auth_realm: "Marinara Engine".to_string(),
+            ip_allowlist: None,
+            trusted_private_networks: default_private_networks(),
+            allow_unauthenticated_private_network: false,
+            allow_unauthenticated_remote: false,
+            bypass_tailscale: false,
+            bypass_docker: false,
+            require_auth_for_docker_proxy: true,
+            csrf_trusted_origins: Vec::new(),
+        }
+    }
+
+    fn request(method: Method, path: &str, ip: IpAddr, headers: &[(&str, &str)]) -> Request<Body> {
+        let mut builder = Request::builder().method(method).uri(path);
+        for (name, value) in headers {
+            builder = builder.header(*name, *value);
+        }
+        let mut request = builder.body(Body::empty()).expect("request should build");
+        request
+            .extensions_mut()
+            .insert(ConnectInfo(SocketAddr::new(ip, 54321)));
+        request
+    }
+
+    fn basic_auth(user: &str, pass: &str) -> BasicAuthConfig {
+        BasicAuthConfig {
+            expected_header: format!(
+                "Basic {}",
+                general_purpose::STANDARD.encode(format!("{user}:{pass}"))
+            )
+            .into_bytes(),
+        }
+    }
+
+    #[test]
+    fn hostable_security_allows_loopback_without_auth() {
+        let security = test_security();
+        let request = request(
+            Method::POST,
+            "/api/invoke",
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            &[],
+        );
+
+        assert!(security.evaluate_request(&request).is_ok());
+    }
+
+    #[test]
+    fn hostable_security_fails_closed_for_non_loopback_without_auth() {
+        let security = test_security();
+        let request = request(
+            Method::POST,
+            "/api/invoke",
+            IpAddr::V4(Ipv4Addr::new(203, 0, 113, 10)),
+            &[],
+        );
+
+        let rejection = security
+            .evaluate_request(&request)
+            .expect_err("public remote IP should require auth");
+        assert_eq!(rejection.status, StatusCode::FORBIDDEN);
+        assert_eq!(rejection.code, "remote_auth_required");
+    }
+
+    #[test]
+    fn hostable_security_requires_basic_auth_when_configured() {
+        let mut security = test_security();
+        security.basic_auth = Some(basic_auth("user", "pass"));
+        let ip = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 10));
+
+        let missing = request(Method::POST, "/api/invoke", ip, &[]);
+        assert_eq!(
+            security
+                .evaluate_request(&missing)
+                .expect_err("missing auth should challenge")
+                .status,
+            StatusCode::UNAUTHORIZED
+        );
+
+        let wrong = request(
+            Method::POST,
+            "/api/invoke",
+            ip,
+            &[("authorization", "Basic bm90OnRoZS1wYXNz")],
+        );
+        assert_eq!(
+            security
+                .evaluate_request(&wrong)
+                .expect_err("wrong auth should challenge")
+                .status,
+            StatusCode::UNAUTHORIZED
+        );
+
+        let correct = request(
+            Method::POST,
+            "/api/invoke",
+            ip,
+            &[("authorization", "Basic dXNlcjpwYXNz")],
+        );
+        assert!(security.evaluate_request(&correct).is_ok());
+    }
+
+    #[test]
+    fn hostable_security_enforces_ip_allowlist_with_negative_control() {
+        let mut security = test_security();
+        security.ip_allowlist = Some(vec![parse_cidr("192.168.1.5").unwrap()]);
+
+        let denied = request(
+            Method::POST,
+            "/api/invoke",
+            IpAddr::V4(Ipv4Addr::new(192, 168, 1, 6)),
+            &[],
+        );
+        let allowed = request(
+            Method::POST,
+            "/api/invoke",
+            IpAddr::V4(Ipv4Addr::new(192, 168, 1, 5)),
+            &[],
+        );
+
+        assert_eq!(
+            security
+                .evaluate_request(&denied)
+                .expect_err("nearby IP should not match the allowlist")
+                .code,
+            "ip_not_allowed"
+        );
+        assert!(security.evaluate_request(&allowed).is_ok());
+    }
+
+    #[test]
+    fn hostable_security_requires_csrf_header_for_trusted_browser_origins() {
+        let security = test_security();
+        let ip = IpAddr::V4(Ipv4Addr::LOCALHOST);
+
+        let missing = request(
+            Method::POST,
+            "/api/invoke",
+            ip,
+            &[("origin", "http://localhost:1420")],
+        );
+        assert_eq!(
+            security
+                .evaluate_request(&missing)
+                .expect_err("browser-origin unsafe request should need CSRF proof")
+                .code,
+            "csrf_missing_header"
+        );
+
+        let present = request(
+            Method::POST,
+            "/api/invoke",
+            ip,
+            &[
+                ("origin", "http://localhost:1420"),
+                (CSRF_HEADER_NAME, CSRF_HEADER_VALUE),
+            ],
+        );
+        assert!(security.evaluate_request(&present).is_ok());
+    }
+
+    #[test]
+    fn hostable_security_rejects_untrusted_origin_with_negative_control() {
+        let security = test_security();
+        let request = request(
+            Method::POST,
+            "/api/invoke",
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            &[
+                ("origin", "https://evil.example"),
+                (CSRF_HEADER_NAME, CSRF_HEADER_VALUE),
+            ],
+        );
+
+        let rejection = security
+            .evaluate_request(&request)
+            .expect_err("untrusted browser origin should not pass with only the header");
+        assert_eq!(rejection.status, StatusCode::FORBIDDEN);
+        assert_eq!(rejection.code, "csrf_origin_not_trusted");
+    }
+
+    #[test]
+    fn hostable_security_adds_core_security_headers() {
+        let mut headers = HeaderMap::new();
+        apply_security_headers(&mut headers);
+
+        assert_eq!(
+            headers.get(header::X_CONTENT_TYPE_OPTIONS).unwrap(),
+            "nosniff"
+        );
+        assert_eq!(headers.get("x-frame-options").unwrap(), "DENY");
+        assert!(headers.get("permissions-policy").is_some());
     }
 }

--- a/src-tauri/src/http_server.rs
+++ b/src-tauri/src/http_server.rs
@@ -378,8 +378,8 @@ impl SecurityConfig {
                 "ALLOW_UNAUTHENTICATED_PRIVATE_NETWORK",
             ),
             allow_unauthenticated_remote: env_flag_enabled("ALLOW_UNAUTHENTICATED_REMOTE"),
-            bypass_tailscale: !env_flag_disabled("BYPASS_AUTH_TAILSCALE"),
-            bypass_docker: !env_flag_disabled("BYPASS_AUTH_DOCKER"),
+            bypass_tailscale: env_flag_enabled("BYPASS_AUTH_TAILSCALE"),
+            bypass_docker: env_flag_enabled("BYPASS_AUTH_DOCKER"),
             require_auth_for_docker_proxy: env_flag_enabled("REQUIRE_AUTH_FOR_DOCKER_PROXY"),
             csrf_trusted_origins,
         }
@@ -415,11 +415,14 @@ impl SecurityConfig {
     }
 
     fn enforce_basic_auth(&self, ip: IpAddr, headers: &HeaderMap) -> Result<(), SecurityRejection> {
-        if is_loopback(ip) || self.is_trusted_interface_ip(ip) || self.is_ip_allowlisted(ip) {
+        if is_loopback(ip) || self.is_trusted_interface_ip(ip) {
             return Ok(());
         }
 
         let Some(config) = &self.basic_auth else {
+            if self.is_ip_allowlisted(ip) {
+                return Ok(());
+            }
             if self.allow_unauthenticated_remote {
                 return Ok(());
             }
@@ -899,6 +902,33 @@ mod tests {
     }
 
     #[test]
+    fn hostable_security_requires_basic_auth_for_allowlisted_ip_when_auth_is_configured() {
+        let mut security = test_security();
+        security.basic_auth = Some(basic_auth("user", "pass"));
+        security.ip_allowlist = Some(vec![parse_cidr("192.168.1.5").unwrap()]);
+        let ip = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 5));
+
+        let missing = request(Method::POST, "/api/invoke", ip, &[]);
+        assert_eq!(
+            security
+                .evaluate_request(&missing)
+                .expect_err(
+                    "allowlisted IP should still authenticate when Basic Auth is configured"
+                )
+                .status,
+            StatusCode::UNAUTHORIZED
+        );
+
+        let correct = request(
+            Method::POST,
+            "/api/invoke",
+            ip,
+            &[("authorization", "Basic dXNlcjpwYXNz")],
+        );
+        assert!(security.evaluate_request(&correct).is_ok());
+    }
+
+    #[test]
     fn hostable_security_enforces_ip_allowlist_with_negative_control() {
         let mut security = test_security();
         security.ip_allowlist = Some(vec![parse_cidr("192.168.1.5").unwrap()]);
@@ -924,6 +954,27 @@ mod tests {
             "ip_not_allowed"
         );
         assert!(security.evaluate_request(&allowed).is_ok());
+    }
+
+    #[test]
+    fn hostable_security_requires_explicit_trusted_interface_bypass() {
+        let mut security = test_security();
+        let tailscale = request(
+            Method::POST,
+            "/api/invoke",
+            IpAddr::V4(Ipv4Addr::new(100, 64, 0, 2)),
+            &[],
+        );
+        assert_eq!(
+            security
+                .evaluate_request(&tailscale)
+                .expect_err("trusted-interface bypass should fail closed by default")
+                .code,
+            "remote_auth_required"
+        );
+
+        security.bypass_tailscale = true;
+        assert!(security.evaluate_request(&tailscale).is_ok());
     }
 
     #[test]

--- a/src/shared/api/remote-runtime.ts
+++ b/src/shared/api/remote-runtime.ts
@@ -88,8 +88,8 @@ export function isRemoteCommand(command: string): boolean {
 function remoteHeaders(target: RuntimeTarget, extra?: HeadersInit): HeadersInit {
   return {
     ...(target.authorization ? { Authorization: target.authorization } : {}),
-    "X-Marinara-CSRF": "1",
     ...extra,
+    "X-Marinara-CSRF": "1",
   };
 }
 

--- a/src/shared/api/remote-runtime.ts
+++ b/src/shared/api/remote-runtime.ts
@@ -88,6 +88,7 @@ export function isRemoteCommand(command: string): boolean {
 function remoteHeaders(target: RuntimeTarget, extra?: HeadersInit): HeadersInit {
   return {
     ...(target.authorization ? { Authorization: target.authorization } : {}),
+    "X-Marinara-CSRF": "1",
     ...extra,
   };
 }


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #1345

## Why this change

- The refactor hostable Rust runtime exposed remote API routes with permissive CORS and without the legacy server-side remote access gates. That left remote access dependent on client behavior instead of server enforcement.

## What changed

- Added hostable runtime security middleware for CORS allowlisted origins, Basic Auth, IP allowlist checks, CSRF/origin checks, and security headers.
- Updated the remote runtime client to send `X-Marinara-CSRF: 1` on remote API calls.
- Documented the remote runtime access-control expectations in README and developer docs.
- Added focused Rust coverage for allowed and denied remote-access rows, including should-not-match negative controls.

## Refactor impact

Primary owner:

Remote runtime / Rust hostable server

Impact areas reviewed:

- Shared API wrapper or remote runtime routing
- Tauri/Rust HTTP runtime, security, and remote access docs

Boundary notes:

- This PR only gates the hostable Rust HTTP runtime. It does not add TLS termination, serve the React UI from `marinara-server`, or add new admin-only API routes.

Pressure points touched:

- `src-tauri/src/http_server.rs`
- `src/shared/api/remote-runtime.ts`
- Remote runtime docs

## Validation

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Codex ran `node scratch/issue-1345-hostable-security-repro.mjs --expect-fixed`.
- Codex ran `cargo test --manifest-path src-tauri/Cargo.toml hostable_security --lib`.
- Codex ran `pnpm check`.
- Codex ran `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json`.
- Manually verify a configured desktop client can still use a remote runtime with the intended `CORS_ORIGINS` / `CSRF_TRUSTED_ORIGINS` settings for the target deployment.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A, backend remote runtime security change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Remote runtime now enforces stricter access control by default, with support for IP allowlisting, optional Basic Authentication, and CSRF protection.

* **Documentation**
  * Updated security configuration guidance for remote runtime setup, including environment variable options for authentication and access control.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1370?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->