### PR TITLE
fix: restore refactor app version metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "marinara-engine",
   "private": true,
-  "version": "0.1.0",
+  "version": "1.6.1",
   "type": "module",
   "packageManager": "pnpm@10.33.2",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3050,7 +3050,7 @@ dependencies = [
 
 [[package]]
 name = "marinara-engine"
-version = "0.1.0"
+version = "1.6.1"
 dependencies = [
  "autoagents",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marinara-engine"
-version = "0.1.0"
+version = "1.6.1"
 description = "Marinara Engine"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/crates/llm/src/lib.rs
+++ b/src-tauri/crates/llm/src/lib.rs
@@ -13,7 +13,7 @@ use std::{
 const OPENAI_CHATGPT_CODEX_BASE_URL: &str = "https://chatgpt.com/backend-api/codex";
 const OPENAI_CHATGPT_REFRESH_URL: &str = "https://auth.openai.com/oauth/token";
 const OPENAI_CHATGPT_CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
-const APP_VERSION: &str = "0.1.0";
+const APP_VERSION: &str = "1.6.1";
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct LlmMessage {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Marinara Engine",
-  "version": "0.1.0",
+  "version": "1.6.1",
   "identifier": "com.marinara-engine.app",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/engine/contracts/constants/defaults.ts
+++ b/src/engine/contracts/constants/defaults.ts
@@ -4,7 +4,7 @@
 import type { GenerationParameters } from "../types/prompt.js";
 
 /** App version — single source of truth. */
-export const APP_VERSION = "1.6.0";
+export const APP_VERSION = "1.6.1";
 
 /** Stable ID for the default OpenRouter free‑tier connection. */
 export const DEFAULT_CONNECTION_ID = "__default_openrouter__";


### PR DESCRIPTION
## Linked issue

Closes #1367

## Why this change

- The refactor branch had app/package version fields reset to scaffold defaults (`0.1.0`), while the release/audit baseline for the current app identity is `1.6.1`.
- Keeping these fields downgraded can confuse app package identity, Tauri bundle identity, and release trust.

## What changed

- Restored the root `package.json` version to `1.6.1`.
- Restored the Tauri app bundle version in `src-tauri/tauri.conf.json` to `1.6.1`.
- Restored the root Tauri Rust package version in `src-tauri/Cargo.toml` to `1.6.1`.
- Refreshed the corresponding `marinara-engine` package entry in `src-tauri/Cargo.lock`.
- Updated the UI `APP_VERSION` constant to `1.6.1` so the app renders the same version as `package.json`.
- Updated the LLM request `APP_VERSION` constant to `1.6.1` so outbound version headers/user agent match the app version.

## Refactor impact

Primary owner:

- Release/app shell metadata

Impact areas reviewed:

- Root package release metadata
- Tauri app bundle version
- Tauri Rust package metadata and lock metadata
- Displayed app version
- LLM request version headers/user agent

Boundary notes:

- This PR intentionally does not change internal Rust crate package versions such as `marinara-core`; the scratch proof keeps `src-tauri/crates/core/Cargo.toml` at `0.1.0` as a should-not-match row.
- No storage behavior, migration behavior, provider payload behavior, or UI flow behavior changed.

Pressure points touched:

- Version truth only; no ModeSurface behavior, GameSurface behavior, shared mode UI flow, command registration, import modules, or remote runtime routing code touched.

## Validation

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Codex reproduced the issue with `node scratch/issue-1367-version-check.mjs 1.6.1 0.1.0`: before the fix, `package.json`, `src-tauri/tauri.conf.json`, and `src-tauri/Cargo.toml` reported `0.1.0` instead of `1.6.1`.
- Codex reran `node scratch/issue-1367-version-check.mjs 1.6.1 0.1.0` after the CodeRabbit follow-up: all app/package/UI/header version rows passed, and the internal crate negative control remained `0.1.0`.
- Codex ran `cargo check --manifest-path src-tauri/Cargo.toml --workspace`; it passed and checked `marinara-engine v1.6.1`.
- Codex ran `pnpm check`; it passed after `pnpm install --frozen-lockfile` installed already-locked dependencies in the clean worktree.
- Codex ran `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch/bugfix-verification.json`; it passed.
- `pnpm version:check` was not run because the current refactor `package.json` has no `version:check` script.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

No visual UI change. This is version-truth-only; the proof is command output from the version checker, Cargo, `pnpm check`, and the proof gate.
