### PR TITLE
Fix refactor update check handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Marinara Engine is a local-first AI chat, roleplay, and game engine built as a Tauri desktop app. It combines a React interface, a TypeScript product engine, and Rust capability modules for local storage, managed assets, provider transport, integrations, and an optional hostable runtime.
 
 This repository is an active refactor branch. The app is usable from source, but public release packaging and end-user installation guides are still being rebuilt around the new architecture.
+The refactor build keeps an explicit in-app update check in Settings > Advanced. It checks Marinara Engine GitHub releases and opens the matching release page for manual install; signed Tauri auto-install artifacts are not configured on this branch yet.
 
 ## Screenshots
 

--- a/src-tauri/src/commands/storage.rs
+++ b/src-tauri/src/commands/storage.rs
@@ -62,6 +62,8 @@ pub(crate) mod shared;
 pub(crate) mod sprites;
 #[path = "storage/translation.rs"]
 pub(crate) mod translation;
+#[path = "storage/updates.rs"]
+pub(crate) mod updates;
 
 #[path = "storage/commands/agents.rs"]
 pub mod agent_commands;
@@ -87,3 +89,5 @@ pub mod mari_commands;
 pub mod media_commands;
 #[path = "storage/commands/profile.rs"]
 pub mod profile_commands;
+#[path = "storage/commands/updates.rs"]
+pub mod update_commands;

--- a/src-tauri/src/commands/storage/commands/updates.rs
+++ b/src-tauri/src/commands/storage/commands/updates.rs
@@ -1,0 +1,13 @@
+use super::updates;
+use marinara_core::AppError;
+use serde_json::Value;
+
+#[tauri::command]
+pub async fn update_check() -> Result<Value, AppError> {
+    updates::check_updates().await
+}
+
+#[tauri::command]
+pub fn update_apply(input: Option<Value>) -> Result<Value, AppError> {
+    updates::apply_update(input.unwrap_or(Value::Null))
+}

--- a/src-tauri/src/commands/storage/updates.rs
+++ b/src-tauri/src/commands/storage/updates.rs
@@ -1,0 +1,309 @@
+use marinara_core::{AppError, AppResult};
+use serde::Deserialize;
+use serde_json::{json, Value};
+use std::cmp::Ordering;
+use std::time::Duration;
+
+const APP_VERSION: &str = env!("CARGO_PKG_VERSION");
+const GITHUB_REPO: &str = "Pasta-Devs/Marinara-Engine";
+const GITHUB_REPO_URL: &str = "https://github.com/Pasta-Devs/Marinara-Engine";
+const GITHUB_TAGS_API: &str =
+    "https://api.github.com/repos/Pasta-Devs/Marinara-Engine/git/matching-refs/tags/v";
+
+#[derive(Debug, Deserialize)]
+struct TagRef {
+    #[serde(default)]
+    r#ref: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubRelease {
+    html_url: Option<String>,
+    body: Option<String>,
+    published_at: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct ReleaseInfo {
+    latest_version: String,
+    release_tag: String,
+    release_url: String,
+    release_notes: String,
+    published_at: String,
+}
+
+fn normalize_tag(tag: &str) -> String {
+    tag.trim().trim_start_matches('v').to_string()
+}
+
+fn is_stable_version_tag(tag: &str) -> bool {
+    let Some(rest) = tag.trim().strip_prefix('v') else {
+        return false;
+    };
+    let parts: Vec<&str> = rest.split('.').collect();
+    parts.len() == 3
+        && parts
+            .iter()
+            .all(|part| !part.is_empty() && part.chars().all(|ch| ch.is_ascii_digit()))
+}
+
+fn parse_version(version: &str) -> Vec<u64> {
+    normalize_tag(version)
+        .split('.')
+        .map(|part| part.parse::<u64>().unwrap_or(0))
+        .collect()
+}
+
+fn compare_versions(left: &str, right: &str) -> Ordering {
+    let left = parse_version(left);
+    let right = parse_version(right);
+    for index in 0..left.len().max(right.len()) {
+        match left
+            .get(index)
+            .unwrap_or(&0)
+            .cmp(right.get(index).unwrap_or(&0))
+        {
+            Ordering::Equal => {}
+            ordering => return ordering,
+        }
+    }
+    Ordering::Equal
+}
+
+fn is_newer_version(current: &str, latest: &str) -> bool {
+    compare_versions(latest, current).is_gt()
+}
+
+fn platform_label() -> &'static str {
+    if cfg!(target_os = "windows") {
+        "windows"
+    } else if cfg!(target_os = "macos") {
+        "macos"
+    } else if cfg!(target_os = "linux") {
+        "linux"
+    } else if cfg!(target_os = "android") {
+        "android"
+    } else if cfg!(target_os = "ios") {
+        "ios"
+    } else {
+        "unknown"
+    }
+}
+
+fn manual_update_hint() -> &'static str {
+    "Download the latest Marinara Engine release asset for this platform, run the installer or replace the app bundle, then restart Marinara Engine."
+}
+
+fn release_payload(release: &ReleaseInfo) -> Value {
+    let version_update = is_newer_version(APP_VERSION, &release.latest_version);
+    json!({
+        "currentVersion": APP_VERSION,
+        "latestVersion": release.latest_version,
+        "releaseTag": release.release_tag,
+        "releaseUrl": release.release_url,
+        "releaseNotes": release.release_notes,
+        "publishedAt": release.published_at,
+        "updateAvailable": version_update,
+        "versionUpdate": version_update,
+        "installType": "tauri-desktop",
+        "serverPlatform": platform_label(),
+        "clientPlatform": "desktop",
+        "updateMechanism": "manual-release",
+        "tauriUpdaterConfigured": false,
+        "applyAvailable": false,
+        "applyUnavailableReason": "tauri-updater-not-configured",
+        "manualUpdateCommand": Value::Null,
+        "manualUpdateHint": manual_update_hint(),
+    })
+}
+
+fn fallback_release(tag: &str) -> ReleaseInfo {
+    ReleaseInfo {
+        latest_version: normalize_tag(tag),
+        release_tag: tag.to_string(),
+        release_url: format!("{GITHUB_REPO_URL}/releases/tag/{tag}"),
+        release_notes: String::new(),
+        published_at: String::new(),
+    }
+}
+
+async fn fetch_latest_release() -> AppResult<ReleaseInfo> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .map_err(|error| AppError::new("update_check_failed", error.to_string()))?;
+
+    let tags = client
+        .get(GITHUB_TAGS_API)
+        .header(reqwest::header::ACCEPT, "application/vnd.github.v3+json")
+        .header(
+            reqwest::header::USER_AGENT,
+            format!("MarinaraEngine/{APP_VERSION}"),
+        )
+        .send()
+        .await
+        .map_err(|error| AppError::new("update_check_failed", error.to_string()))?;
+
+    if !tags.status().is_success() {
+        return Err(AppError::new(
+            "update_check_failed",
+            format!("GitHub tags API returned {}", tags.status()),
+        ));
+    }
+
+    let refs = tags
+        .json::<Vec<TagRef>>()
+        .await
+        .map_err(|error| AppError::new("update_check_failed", error.to_string()))?;
+    let latest_tag = refs
+        .iter()
+        .filter_map(|entry| entry.r#ref.rsplit('/').next())
+        .filter(|tag| is_stable_version_tag(tag))
+        .max_by(|left, right| compare_versions(left, right))
+        .ok_or_else(|| {
+            AppError::new(
+                "update_check_failed",
+                "No stable vX.Y.Z tags were found on GitHub",
+            )
+        })?;
+
+    let release_url =
+        format!("https://api.github.com/repos/{GITHUB_REPO}/releases/tags/{latest_tag}");
+    let release = client
+        .get(release_url)
+        .header(reqwest::header::ACCEPT, "application/vnd.github.v3+json")
+        .header(
+            reqwest::header::USER_AGENT,
+            format!("MarinaraEngine/{APP_VERSION}"),
+        )
+        .send()
+        .await
+        .map_err(|error| AppError::new("update_check_failed", error.to_string()))?;
+
+    if !release.status().is_success() {
+        return Ok(fallback_release(latest_tag));
+    }
+
+    let release = release
+        .json::<GitHubRelease>()
+        .await
+        .map_err(|error| AppError::new("update_check_failed", error.to_string()))?;
+
+    Ok(ReleaseInfo {
+        latest_version: normalize_tag(latest_tag),
+        release_tag: latest_tag.to_string(),
+        release_url: release
+            .html_url
+            .unwrap_or_else(|| format!("{GITHUB_REPO_URL}/releases/tag/{latest_tag}")),
+        release_notes: release.body.unwrap_or_default(),
+        published_at: release.published_at.unwrap_or_default(),
+    })
+}
+
+pub async fn check_updates() -> AppResult<Value> {
+    let release = fetch_latest_release().await?;
+    Ok(release_payload(&release))
+}
+
+pub fn apply_update(input: Value) -> AppResult<Value> {
+    let body = input.as_object();
+    if body
+        .and_then(|object| object.get("confirm"))
+        .and_then(Value::as_bool)
+        != Some(true)
+    {
+        return Err(AppError::invalid_input(
+            "Must send { confirm: true } to continue to manual update instructions",
+        ));
+    }
+
+    let latest_version = body
+        .and_then(|object| object.get("latestVersion"))
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or(APP_VERSION);
+    let release_tag = body
+        .and_then(|object| object.get("releaseTag"))
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| format!("v{latest_version}"));
+    let release_url = body
+        .and_then(|object| object.get("releaseUrl"))
+        .and_then(Value::as_str)
+        .filter(|value| value.starts_with(GITHUB_REPO_URL))
+        .unwrap_or("https://github.com/Pasta-Devs/Marinara-Engine/releases/latest");
+
+    Ok(json!({
+        "status": "manual_update_required",
+        "message": "Automatic Tauri update installation is not configured for this build. Open the release page, install the latest asset, then restart Marinara Engine.",
+        "currentVersion": APP_VERSION,
+        "latestVersion": latest_version,
+        "releaseTag": release_tag,
+        "releaseUrl": release_url,
+        "installType": "tauri-desktop",
+        "serverPlatform": platform_label(),
+        "updateMechanism": "manual-release",
+        "tauriUpdaterConfigured": false,
+        "applyAvailable": false,
+        "applyUnavailableReason": "tauri-updater-not-configured",
+        "manualUpdateCommand": Value::Null,
+        "manualUpdateHint": manual_update_hint(),
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stable_tag_filter_excludes_prerelease_and_non_versions() {
+        assert!(is_stable_version_tag("v1.2.3"));
+        assert!(!is_stable_version_tag("v1.2.3-beta.1"));
+        assert!(!is_stable_version_tag("1.2.3"));
+        assert!(!is_stable_version_tag("v1.2"));
+        assert!(!is_stable_version_tag("v1.2.x"));
+    }
+
+    #[test]
+    fn version_comparison_handles_multi_digit_parts() {
+        assert!(is_newer_version("1.9.0", "1.10.0"));
+        assert!(!is_newer_version("1.10.0", "1.9.9"));
+        assert!(!is_newer_version("1.10.0", "1.10.0"));
+    }
+
+    #[test]
+    fn apply_update_rejects_unconfirmed_requests() {
+        let error = apply_update(json!({})).expect_err("unconfirmed apply should be rejected");
+        assert_eq!(error.code, "invalid_input");
+    }
+
+    #[test]
+    fn apply_update_returns_manual_release_handoff() {
+        let response = apply_update(json!({
+            "confirm": true,
+            "latestVersion": "1.6.2",
+            "releaseTag": "v1.6.2",
+            "releaseUrl": "https://github.com/Pasta-Devs/Marinara-Engine/releases/tag/v1.6.2"
+        }))
+        .expect("confirmed apply should return manual instructions");
+
+        assert_eq!(response["status"], "manual_update_required");
+        assert_eq!(response["applyAvailable"], false);
+        assert_eq!(response["releaseTag"], "v1.6.2");
+    }
+
+    #[test]
+    fn apply_update_uses_safe_release_url_fallback_for_untrusted_urls() {
+        let response = apply_update(json!({
+            "confirm": true,
+            "releaseUrl": "https://example.com/not-marinara"
+        }))
+        .expect("confirmed apply should return manual instructions");
+
+        assert_eq!(
+            response["releaseUrl"],
+            "https://github.com/Pasta-Devs/Marinara-Engine/releases/latest"
+        );
+    }
+}

--- a/src-tauri/src/commands/storage/updates.rs
+++ b/src-tauri/src/commands/storage/updates.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 const APP_VERSION: &str = env!("CARGO_PKG_VERSION");
 const GITHUB_REPO: &str = "Pasta-Devs/Marinara-Engine";
 const GITHUB_REPO_URL: &str = "https://github.com/Pasta-Devs/Marinara-Engine";
+const GITHUB_RELEASES_URL: &str = "https://github.com/Pasta-Devs/Marinara-Engine/releases/latest";
 const GITHUB_TAGS_API: &str =
     "https://api.github.com/repos/Pasta-Devs/Marinara-Engine/git/matching-refs/tags/v";
 
@@ -127,6 +128,18 @@ fn fallback_release(tag: &str) -> ReleaseInfo {
     }
 }
 
+fn is_trusted_release_url(value: &str) -> bool {
+    let Ok(url) = reqwest::Url::parse(value) else {
+        return false;
+    };
+
+    url.scheme() == "https"
+        && url.host_str() == Some("github.com")
+        && url
+            .path()
+            .starts_with("/Pasta-Devs/Marinara-Engine/releases/")
+}
+
 async fn fetch_latest_release() -> AppResult<ReleaseInfo> {
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(10))
@@ -231,8 +244,8 @@ pub fn apply_update(input: Value) -> AppResult<Value> {
     let release_url = body
         .and_then(|object| object.get("releaseUrl"))
         .and_then(Value::as_str)
-        .filter(|value| value.starts_with(GITHUB_REPO_URL))
-        .unwrap_or("https://github.com/Pasta-Devs/Marinara-Engine/releases/latest");
+        .filter(|value| is_trusted_release_url(value))
+        .unwrap_or(GITHUB_RELEASES_URL);
 
     Ok(json!({
         "status": "manual_update_required",
@@ -305,5 +318,16 @@ mod tests {
             response["releaseUrl"],
             "https://github.com/Pasta-Devs/Marinara-Engine/releases/latest"
         );
+    }
+
+    #[test]
+    fn apply_update_rejects_prefix_spoofed_release_urls() {
+        let response = apply_update(json!({
+            "confirm": true,
+            "releaseUrl": "https://github.com/Pasta-Devs/Marinara-Engine.evil.example/releases/tag/v9.9.9"
+        }))
+        .expect("confirmed apply should return manual instructions");
+
+        assert_eq!(response["releaseUrl"], GITHUB_RELEASES_URL);
     }
 }

--- a/src-tauri/src/http_dispatch.rs
+++ b/src-tauri/src/http_dispatch.rs
@@ -3,7 +3,7 @@ use crate::storage_commands::{
     admin, agents, avatars, backgrounds, backup, bot_browser, characters, chats, custom_tools,
     entity_commands, exports, fonts, game_assets, game_state_snapshots, generation, http, images,
     imports, integrations, knowledge, llm, lorebook_images, mari, profile, prompts, shared,
-    sprites, translation,
+    sprites, translation, updates,
 };
 use marinara_core::{AppError, AppResult};
 use serde::Deserialize;
@@ -542,6 +542,8 @@ pub async fn dispatch(state: &AppState, request: InvokeRequest) -> AppResult<Val
         }
         "llm_stream_cancel" => llm_stream_cancel(state, &args),
         "professor_mari_prompt" => mari::professor_mari_prompt(state, optional_value(&args, "request")).await,
+        "update_check" => updates::check_updates().await,
+        "update_apply" => updates::apply_update(optional_value(&args, "input")),
         _ => Err(AppError::new(
             "unsupported_command",
             format!("{command} is not exposed by the remote runtime"),
@@ -1359,5 +1361,33 @@ mod tests {
             .get("game-state-snapshots", "snapshot-message-1")
             .unwrap()
             .is_some());
+    }
+
+    #[tokio::test]
+    async fn dispatch_supports_remote_update_apply_manual_path() {
+        let state = test_state("update-apply");
+        let result = dispatch(
+            &state,
+            InvokeRequest {
+                command: "update_apply".to_string(),
+                args: Some(json!({
+                    "input": {
+                        "confirm": true,
+                        "latestVersion": "1.6.2",
+                        "releaseTag": "v1.6.2",
+                        "releaseUrl": "https://github.com/Pasta-Devs/Marinara-Engine/releases/tag/v1.6.2"
+                    }
+                })),
+            },
+        )
+        .await
+        .expect("remote update apply should dispatch into manual release instructions");
+
+        assert_eq!(result["status"], "manual_update_required");
+        assert_eq!(result["applyAvailable"], false);
+        assert_eq!(
+            result["applyUnavailableReason"],
+            "tauri-updater-not-configured"
+        );
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -203,6 +203,8 @@ pub fn run() {
             storage_commands::media_commands::llm_stream_cancel,
             storage_commands::media_commands::llm_list_models,
             storage_commands::mari_commands::professor_mari_prompt,
+            storage_commands::update_commands::update_check,
+            storage_commands::update_commands::update_apply,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/features/shell/settings/components/SettingsPanel.tsx
+++ b/src/features/shell/settings/components/SettingsPanel.tsx
@@ -20,6 +20,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { gameAssetsApi } from "../../../../shared/api/assets-api";
 import { importApi } from "../../../../shared/api/import-api";
 import { backupApi, profileApi, type ManagedBackup } from "../../../../shared/api/profile-api";
+import { updatesApi, type UpdateCheckResponse } from "../../../../shared/api/updates-api";
 import { backgroundsApi, fontsApi } from "../../../../shared/api/settings-assets-api";
 import { storageApi } from "../../../../shared/api/storage-api";
 import { triggerDownload } from "../../../../shared/api/download-payload";
@@ -3093,6 +3094,9 @@ function AdvancedSettings() {
   const [exportingProfile, setExportingProfile] = useState(false);
   const [downloadingBackupName, setDownloadingBackupName] = useState<string | null>(null);
   const [refreshingSpa, setRefreshingSpa] = useState(false);
+  const [checkingUpdates, setCheckingUpdates] = useState(false);
+  const [openingUpdate, setOpeningUpdate] = useState(false);
+  const [updateInfo, setUpdateInfo] = useState<UpdateCheckResponse | null>(null);
   const [adminSecret, setAdminSecret] = useState(() => localStorage.getItem(ADMIN_SECRET_STORAGE_KEY) ?? "");
   const [quickRepliesDrawerOpen, setQuickRepliesDrawerOpen] = useState(true);
   const queryClient = useQueryClient();
@@ -3167,6 +3171,38 @@ function AdvancedSettings() {
     } catch (err) {
       setRefreshingSpa(false);
       toast.error(err instanceof Error ? err.message : "Failed to refresh the app");
+    }
+  };
+
+  const handleCheckUpdates = async () => {
+    if (checkingUpdates) return;
+    setCheckingUpdates(true);
+    try {
+      const result = await updatesApi.check();
+      setUpdateInfo(result);
+      if (result.updateAvailable) {
+        toast.success(`Update ${result.releaseTag} is available.`);
+      } else {
+        toast.info("Marinara is up to date.");
+      }
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to check for updates");
+    } finally {
+      setCheckingUpdates(false);
+    }
+  };
+
+  const handleOpenUpdate = async () => {
+    if (!updateInfo || openingUpdate) return;
+    setOpeningUpdate(true);
+    try {
+      const result = await updatesApi.apply(updateInfo);
+      window.open(result.releaseUrl, "_blank", "noopener,noreferrer");
+      toast.info(result.message);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to open update");
+    } finally {
+      setOpeningUpdate(false);
     }
   };
 
@@ -3263,6 +3299,56 @@ function AdvancedSettings() {
             side="bottom"
             text="Manual refresh unregisters the active service worker and clears browser caches before reloading. Marinara's stored chats, settings, and other local app data stay intact."
           />
+        </div>
+
+        <div className="flex flex-col gap-2 rounded-lg bg-[var(--secondary)]/35 p-2.5 ring-1 ring-[var(--border)]">
+          <div className="flex items-center gap-1.5">
+            <span className="text-xs font-medium">App Updates</span>
+            <HelpTooltip text="Checks the Marinara Engine GitHub releases. This refactor build opens the release page for manual install because signed Tauri updater artifacts are not configured yet." />
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={() => void handleCheckUpdates()}
+              disabled={checkingUpdates}
+              className="flex items-center justify-center gap-1.5 rounded-lg bg-[var(--background)]/70 px-3 py-2 text-xs font-medium text-[var(--foreground)] ring-1 ring-[var(--border)] transition-all hover:bg-[var(--accent)] active:scale-95 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {checkingUpdates ? (
+                <>
+                  <Loader2 size="0.8125rem" className="animate-spin" />
+                  Checking...
+                </>
+              ) : (
+                <>
+                  <RefreshCw size="0.8125rem" />
+                  Check for Updates
+                </>
+              )}
+            </button>
+            <button
+              type="button"
+              onClick={() => void handleOpenUpdate()}
+              disabled={!updateInfo || openingUpdate}
+              className="flex items-center justify-center gap-1.5 rounded-lg bg-[var(--primary)] px-3 py-2 text-xs font-medium text-white transition-all hover:opacity-90 active:scale-95 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {openingUpdate ? (
+                <>
+                  <Loader2 size="0.8125rem" className="animate-spin" />
+                  Opening...
+                </>
+              ) : (
+                <>
+                  <Download size="0.8125rem" />
+                  Open Release
+                </>
+              )}
+            </button>
+          </div>
+          {updateInfo && (
+            <div className="text-[0.625rem] leading-relaxed text-[var(--muted-foreground)]">
+              Current {updateInfo.currentVersion}; latest {updateInfo.latestVersion}. {updateInfo.manualUpdateHint}
+            </div>
+          )}
         </div>
 
         <div className="flex flex-col gap-1.5 rounded-lg bg-[var(--secondary)]/35 p-2.5 ring-1 ring-[var(--border)]">

--- a/src/features/shell/settings/components/SettingsPanel.tsx
+++ b/src/features/shell/settings/components/SettingsPanel.tsx
@@ -3186,6 +3186,7 @@ function AdvancedSettings() {
         toast.info("Marinara is up to date.");
       }
     } catch (err) {
+      setUpdateInfo(null);
       toast.error(err instanceof Error ? err.message : "Failed to check for updates");
     } finally {
       setCheckingUpdates(false);
@@ -3193,7 +3194,7 @@ function AdvancedSettings() {
   };
 
   const handleOpenUpdate = async () => {
-    if (!updateInfo || openingUpdate) return;
+    if (!updateInfo || !updateInfo.updateAvailable || openingUpdate || checkingUpdates) return;
     setOpeningUpdate(true);
     try {
       const result = await updatesApi.apply(updateInfo);
@@ -3328,7 +3329,7 @@ function AdvancedSettings() {
             <button
               type="button"
               onClick={() => void handleOpenUpdate()}
-              disabled={!updateInfo || openingUpdate}
+              disabled={!updateInfo || !updateInfo.updateAvailable || openingUpdate || checkingUpdates}
               className="flex items-center justify-center gap-1.5 rounded-lg bg-[var(--primary)] px-3 py-2 text-xs font-medium text-white transition-all hover:opacity-90 active:scale-95 disabled:cursor-not-allowed disabled:opacity-50"
             >
               {openingUpdate ? (

--- a/src/shared/api/remote-runtime.ts
+++ b/src/shared/api/remote-runtime.ts
@@ -166,6 +166,8 @@ const REMOTE_COMMANDS = new Set([
   "llm_stream_cancel",
   "llm_list_models",
   "professor_mari_prompt",
+  "update_check",
+  "update_apply",
 ]);
 
 type RuntimeTarget = {

--- a/src/shared/api/updates-api.ts
+++ b/src/shared/api/updates-api.ts
@@ -1,0 +1,32 @@
+import { invokeTauri } from "./tauri-client";
+
+export type UpdateCheckResponse = {
+  currentVersion: string;
+  latestVersion: string;
+  releaseTag: string;
+  releaseUrl: string;
+  releaseNotes: string;
+  publishedAt: string;
+  updateAvailable: boolean;
+  versionUpdate: boolean;
+  installType: string;
+  serverPlatform: string;
+  clientPlatform?: string;
+  updateMechanism: "manual-release";
+  tauriUpdaterConfigured: boolean;
+  applyAvailable: boolean;
+  applyUnavailableReason: "tauri-updater-not-configured";
+  manualUpdateCommand: string | null;
+  manualUpdateHint: string;
+};
+
+export type UpdateApplyResponse = Omit<UpdateCheckResponse, "releaseNotes" | "publishedAt" | "updateAvailable" | "versionUpdate"> & {
+  status: "manual_update_required";
+  message: string;
+};
+
+export const updatesApi = {
+  check: () => invokeTauri<UpdateCheckResponse>("update_check"),
+  apply: (input: Pick<UpdateCheckResponse, "latestVersion" | "releaseTag" | "releaseUrl">) =>
+    invokeTauri<UpdateApplyResponse>("update_apply", { input: { ...input, confirm: true } }),
+};


### PR DESCRIPTION
## Linked issue

Closes #1348

## Why this change

- The refactor branch had no explicit replacement for the legacy update checker/apply routes, which could leave users without an in-app update path.
- This restores a bounded Tauri-era update surface without pretending signed automatic Tauri installs are configured.

## What changed

- Added `update_check` and `update_apply` Tauri commands plus remote-runtime `/api/invoke` dispatch.
- Added a typed client `updatesApi` and Settings > Advanced controls for checking releases and opening the release page.
- Added release/manual-update guardrails: stable `vX.Y.Z` tag filtering, confirm-required apply handoff, and official GitHub release URL fallback for untrusted URLs.
- Documented the refactor branch behavior in `README.md`.

## Refactor impact

Primary owner:

Rust/Tauri command surface and shared API.

Impact areas reviewed:

- App shell settings UI
- Shared API wrappers
- Tauri command registration
- Hostable remote runtime dispatch
- Release/distribution behavior

Boundary notes:

- `src-tauri/src/commands/storage/updates.rs` owns release lookup and the manual-update response.
- `src/shared/api/updates-api.ts` is the typed client wrapper; feature UI does not call `invokeTauri` directly.
- Remote runtime allowlisting is explicit for `update_check` and `update_apply`.
- Automatic Tauri install is intentionally not implemented because signed updater artifacts, a public key, and updater endpoints are not configured on this branch.

Pressure points touched:

- `src-tauri/src/lib.rs` command registration
- `src-tauri/src/http_dispatch.rs` remote runtime dispatch
- `src/features/shell/settings/components/SettingsPanel.tsx` Advanced settings
- `src/shared/api/remote-runtime.ts` command allowlist

## Validation

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Codex ran `node scratch\issue-1348-updates-surface-repro.mjs`; it passed and confirmed embedded command registration, remote dispatch, remote allowlist, and the typed client API are present.
- Codex ran `cargo test --manifest-path src-tauri\Cargo.toml updates::tests`; 5 tests passed, covering stable tag filtering, semver comparison, confirmed manual apply, unconfirmed apply rejection, and untrusted release URL fallback.
- Codex ran `cargo test --manifest-path src-tauri\Cargo.toml dispatch_supports_remote_update_apply_manual_path`; 1 test passed, covering remote `/api/invoke` dispatch into the manual update handoff.
- Codex ran `pnpm check` on the merged current `upstream/refactor` head; it passed.
- Codex ran the Marinara proof gate against `scratch\bugfix-verification.json`; it passed.
- Codex opened the Vite app in Playwright, navigated to Settings > Advanced, and confirmed the App Updates controls render.
- Manual limitation: signed Tauri automatic install was not tested because this branch does not configure updater signing/public-key/endpoints. This PR exposes a manual-release update handoff instead.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

Local Playwright verification confirmed Settings > Advanced renders the App Updates controls. No GitHub-hosted screenshot is attached because the captured evidence is local-only and should not be treated as reviewer-visible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "App Updates" in Settings > Advanced: check for updates, view current vs latest version, open the release page for manual installation, and receive toasts for check/apply results. Automatic in-app installation is not configured; manual update flow is used.

* **Documentation**
  * README updated to describe the Advanced settings update check and the manual-installation note.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1374?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->