### PR TITLE
Fix Stability SD3 legacy aliases

### DIFF
--- a/src/engine/contracts/constants/model-lists.ts
+++ b/src/engine/contracts/constants/model-lists.ts
@@ -517,6 +517,9 @@ const IMAGE_GEN_MODELS: KnownModel[] = [
   // Stability AI
   { id: "stable-image-core", name: "Stable Image Core", context: 0, maxOutput: 0 },
   { id: "stable-image-ultra", name: "Stable Image Ultra", context: 0, maxOutput: 0 },
+  { id: "sd3-large", name: "Stable Diffusion 3 Large (legacy alias)", context: 0, maxOutput: 0 },
+  { id: "sd3-large-turbo", name: "SD3 Large Turbo (legacy alias)", context: 0, maxOutput: 0 },
+  { id: "sd3-medium", name: "Stable Diffusion 3 Medium (legacy alias)", context: 0, maxOutput: 0 },
   { id: "sd3.5-large", name: "Stable Diffusion 3.5 Large", context: 0, maxOutput: 0 },
   { id: "sd3.5-large-turbo", name: "SD3.5 Large Turbo", context: 0, maxOutput: 0 },
   { id: "sd3.5-medium", name: "Stable Diffusion 3.5 Medium", context: 0, maxOutput: 0 },


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #1352

## Why this change

Refactor dropped the legacy Stability SD3 image model aliases that are still present on staging. Saved image-generation connections that use `sd3-large`, `sd3-large-turbo`, or `sd3-medium` should continue to show and resolve through the shared image model catalog.

## What changed

- Restored the three legacy Stability SD3 aliases to `IMAGE_GEN_MODELS`.
- Kept the change scoped to catalog parity only; provider routing already treats `sd3*` model IDs as Stability.

## Refactor impact

Primary owner:

Catalog / engine contracts

Impact areas reviewed:

- Shared image-generation model catalog
- Stability image source inference path

Boundary notes:

- No provider API behavior, schema, storage, Rust, remote runtime, or dependency changes.
- Live Stability generation was not attempted because this PR only restores static catalog aliases and does not require provider credentials.

Pressure points touched:

- `src/engine/contracts/constants/model-lists.ts`

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Codex ran `node scratch/issue-1352-model-alias-proof.mjs` before the fix and reproduced the missing `sd3-large`, `sd3-large-turbo`, and `sd3-medium` aliases.
- Codex reran `node scratch/issue-1352-model-alias-proof.mjs` after the fix; it passed and confirmed those aliases are present while `sd3-large-unlisted` is not.
- Codex ran `pnpm check`; it passed.
- Codex ran `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json`; it passed.
- Bunny pass: focused one-file catalog diff, refactor base, no schema/dependency/server logging changes, proof includes a negative control.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A: this is a static catalog parity fix with no visible UI layout change. The scratch proof verifies the model catalog contents directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three new Stable Diffusion 3 image-generation models: `sd3-large`, `sd3-large-turbo`, and `sd3-medium`. These models expand the platform's image generation capabilities with optimized options for various use cases. Users now have access to distinct performance and quality trade-offs, enabling more flexible and versatile image generation workflows suited to different needs and constraints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1378?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->