### PR TITLE
Fix legacy HUD starting values

### DIFF
--- a/src/engine/contracts/types/game.ts
+++ b/src/engine/contracts/types/game.ts
@@ -448,6 +448,9 @@ export interface HudWidget {
 /** Type-specific widget config. */
 export interface HudWidgetConfig {
   // progress_bar / gauge / relationship_meter
+  /** Initial value used when the widget is created for a new session. */
+  startingValue?: number;
+  /** Current value shown at runtime. */
   value?: number;
   max?: number;
   milestones?: WidgetMilestone[];

--- a/src/features/modes/game/components/GameWidgetPanel.tsx
+++ b/src/features/modes/game/components/GameWidgetPanel.tsx
@@ -68,12 +68,20 @@ function formatWidgetTypeLabel(type: HudWidget["type"]) {
     .join(" ");
 }
 
+function isNumericWidgetType(type: HudWidget["type"]) {
+  return type === "progress_bar" || type === "gauge" || type === "relationship_meter";
+}
+
+function getNumericWidgetValue(widget: HudWidget) {
+  return widget.config.value ?? widget.config.startingValue ?? 0;
+}
+
 function describeWidget(widget: HudWidget) {
   switch (widget.type) {
     case "progress_bar":
     case "gauge":
     case "relationship_meter":
-      return `${widget.config.value ?? 0} / ${widget.config.max ?? 100}`;
+      return `${getNumericWidgetValue(widget)} / ${widget.config.max ?? 100}`;
     case "counter":
       return `${widget.config.count ?? 0} tracked`;
     case "stat_block": {
@@ -95,7 +103,12 @@ function describeWidget(widget: HudWidget) {
 
 function createWidgetEditorDraft(widget: HudWidget): WidgetEditorDraft {
   return {
-    value: widget.config.value != null ? String(widget.config.value) : "",
+    value:
+      widget.config.value != null
+        ? String(widget.config.value)
+        : widget.config.startingValue != null
+          ? String(widget.config.startingValue)
+          : "",
     max: widget.config.max != null ? String(widget.config.max) : "",
     count: widget.config.count != null ? String(widget.config.count) : "",
     seconds: widget.config.seconds != null ? String(widget.config.seconds) : "",
@@ -130,23 +143,31 @@ function coerceStatValue(rawValue: string, fallback: number | string) {
   return /^-?\d+(?:\.\d+)?$/.test(trimmed) ? Number(trimmed) : trimmed;
 }
 
-function buildUpdatedWidgetConfig(widget: HudWidget, draft: WidgetEditorDraft): HudWidget["config"] {
+function buildUpdatedWidgetConfig(
+  widget: HudWidget,
+  draft: WidgetEditorDraft,
+  options?: { syncStartingValue?: boolean },
+): HudWidget["config"] {
   const nextConfig = { ...widget.config };
 
   switch (widget.type) {
     case "progress_bar":
     case "gauge":
     case "relationship_meter":
-      nextConfig.value = parseNumberDraft(
-        draft.value,
-        typeof widget.config.value === "number" ? widget.config.value : 0,
-        {
-          min: 0,
-        },
-      );
       nextConfig.max = parseNumberDraft(draft.max, typeof widget.config.max === "number" ? widget.config.max : 100, {
         min: 1,
       });
+      nextConfig.value = parseNumberDraft(
+        draft.value,
+        getNumericWidgetValue(widget),
+        {
+          min: 0,
+          max: nextConfig.max,
+        },
+      );
+      if (options?.syncStartingValue) {
+        nextConfig.startingValue = nextConfig.value;
+      }
       return nextConfig;
     case "counter":
       nextConfig.count = parseNumberDraft(
@@ -463,6 +484,8 @@ function WidgetEditorModal({
   allowStructureEdit = false,
   description = "Adjust this widget manually when the model misses an update.",
   saveLabel = "Save Changes",
+  numericValueLabel = "Current value",
+  syncStartingValue = false,
 }: {
   widget: HudWidget | null;
   open: boolean;
@@ -472,6 +495,8 @@ function WidgetEditorModal({
   allowStructureEdit?: boolean;
   description?: string;
   saveLabel?: string;
+  numericValueLabel?: string;
+  syncStartingValue?: boolean;
 }) {
   const [draft, setDraft] = useState<WidgetEditorDraft>(EMPTY_WIDGET_DRAFT);
 
@@ -483,8 +508,8 @@ function WidgetEditorModal({
 
   const handleSave = useCallback(() => {
     if (!widget) return;
-    void onSave(buildUpdatedWidgetConfig(widget, draft));
-  }, [draft, onSave, widget]);
+    void onSave(buildUpdatedWidgetConfig(widget, draft, { syncStartingValue }));
+  }, [draft, onSave, syncStartingValue, widget]);
 
   if (!open || !widget || typeof document === "undefined") return null;
 
@@ -495,10 +520,10 @@ function WidgetEditorModal({
       <div className="space-y-4">
         <p className="text-sm text-[var(--muted-foreground)]">{description}</p>
 
-        {(widget.type === "progress_bar" || widget.type === "gauge" || widget.type === "relationship_meter") && (
+        {isNumericWidgetType(widget.type) && (
           <div className="grid gap-3 sm:grid-cols-2">
             <label className="space-y-1.5">
-              <span className="text-xs font-medium text-[var(--muted-foreground)]">Current value</span>
+              <span className="text-xs font-medium text-[var(--muted-foreground)]">{numericValueLabel}</span>
               <input
                 type="number"
                 value={draft.value}
@@ -759,6 +784,8 @@ export function GameWidgetSessionPrepModal({
             startingLabel: "Starting Game...",
             editorDescription:
               "Adjust the starting values, or reshape stat blocks before the first game turn uses them.",
+            numericValueLabel: "Starting value",
+            syncStartingValue: true,
           }
         : {
             title: "Prepare Next Session Widgets",
@@ -772,6 +799,8 @@ export function GameWidgetSessionPrepModal({
             startingLabel: "Starting Session...",
             editorDescription:
               "Adjust the values that should carry forward, or reshape stat blocks for the next session.",
+            numericValueLabel: "Current value",
+            syncStartingValue: false,
           },
     [mode],
   );
@@ -899,6 +928,8 @@ export function GameWidgetSessionPrepModal({
         allowStructureEdit
         description={copy.editorDescription}
         saveLabel="Update Widget"
+        numericValueLabel={copy.numericValueLabel}
+        syncStartingValue={copy.syncStartingValue}
       />
     </>
   );
@@ -907,7 +938,8 @@ export function GameWidgetSessionPrepModal({
 // ── Widget Implementations ──
 
 function ProgressBarWidget({ widget }: { widget: HudWidget }) {
-  const { value = 0, max = 100, dangerBelow } = widget.config;
+  const { max = 100, dangerBelow } = widget.config;
+  const value = getNumericWidgetValue(widget);
   const pct = Math.max(0, Math.min(100, (value / Math.max(1, max)) * 100));
   const accent = widget.accent ?? "#a78bfa";
   const isDanger = dangerBelow != null && value < dangerBelow;
@@ -934,7 +966,8 @@ function ProgressBarWidget({ widget }: { widget: HudWidget }) {
 }
 
 function GaugeWidget({ widget }: { widget: HudWidget }) {
-  const { value = 0, max = 100, dangerBelow } = widget.config;
+  const { max = 100, dangerBelow } = widget.config;
+  const value = getNumericWidgetValue(widget);
   const pct = Math.max(0, Math.min(100, (value / Math.max(1, max)) * 100));
   const accent = widget.accent ?? "#22c55e";
   const isDanger = dangerBelow != null && value < dangerBelow;
@@ -966,7 +999,8 @@ function GaugeWidget({ widget }: { widget: HudWidget }) {
 }
 
 function RelationshipMeterWidget({ widget }: { widget: HudWidget }) {
-  const { value = 0, max = 100 } = widget.config;
+  const { max = 100 } = widget.config;
+  const value = getNumericWidgetValue(widget);
   const milestones = Array.isArray(widget.config.milestones) ? widget.config.milestones : [];
   const pct = Math.max(0, Math.min(100, (value / Math.max(1, max)) * 100));
   const accent = widget.accent ?? "#ec4899";

--- a/src/features/modes/game/hooks/use-game.ts
+++ b/src/features/modes/game/hooks/use-game.ts
@@ -500,8 +500,35 @@ export function useGameSessions(gameId: string | null) {
 
 // ── Sync hook — reads chat metadata and updates game store ──
 
+function isNumericHudWidgetType(type: HudWidget["type"]) {
+  return type === "progress_bar" || type === "gauge" || type === "relationship_meter";
+}
+
+function finiteNumber(value: unknown): number | null {
+  const raw = typeof value === "string" && value.trim() ? Number(value.trim()) : value;
+  return typeof raw === "number" && Number.isFinite(raw) ? raw : null;
+}
+
 function normalizeHudWidgets(widgets: readonly HudWidget[]): HudWidget[] {
   return widgets.map((w) => {
+    if (isNumericHudWidgetType(w.type)) {
+      const max = Math.max(1, finiteNumber(w.config.max) ?? 100);
+      const value = finiteNumber(w.config.value) ?? finiteNumber(w.config.startingValue) ?? 0;
+      const startingValue = finiteNumber(w.config.startingValue) ?? value;
+
+      if (w.config.max !== max || w.config.value !== value || w.config.startingValue !== startingValue) {
+        return {
+          ...w,
+          config: {
+            ...w.config,
+            max,
+            startingValue,
+            value,
+          },
+        };
+      }
+    }
+
     if (w.type === "inventory_grid" && !w.config.contents && Array.isArray((w.config as any).items)) {
       const items = (w.config as any).items as Array<{ name: string; slot?: string | number; quantity?: number }>;
       return {


### PR DESCRIPTION
## Linked issue

Closes #1365

## Why this change

- Refactor Game HUD widgets lost the legacy `startingValue` path used by numeric widgets, so older/imported configs could render or edit as empty/default instead of using their intended initial values.

## What changed

- Restored `startingValue` on the shared HUD widget config contract.
- Hydrate numeric HUD widgets from `value ?? startingValue ?? 0` during game-state sync, while preserving current runtime `value` when present.
- Updated numeric widget display and editing to fall back to `startingValue`, and to sync edited starting values during initial session prep.

## Refactor impact

Primary owner:

- Game mode

Impact areas reviewed:

- HUD widget contract
- Game metadata sync
- HUD widget panel/editor

Boundary notes:

- No server, Rust, storage schema, dependency, remote runtime, or prompt assembly boundaries touched.

Pressure points touched:

- Game HUD widget rendering/editing and game-state metadata hydration.

## Validation

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Codex proof: `node scratch\issue-1365-starting-value-proof.mjs` failed before the fix and passes after the fix.
- Codex proof: `pnpm check` passed locally.
- Codex proof: `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json` passed with legacy compatibility rows and negative controls.
- Manual follow-up: try a legacy/imported game HUD with numeric widgets that only have `startingValue`, then confirm the first session shows the starting value and editing Review Starting Widgets preserves it.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- Not attached. This fix is covered by source/row compatibility proof and `pnpm check`; no browser screenshot was captured.
