### PR TITLE
Propagate user timezone into generation prompt assembly

### DIFF
--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -488,10 +488,27 @@ function markerConfig(section: PromptSectionRecord): MarkerConfig | null {
   return null;
 }
 
+function resolveLiveHostTimeZone(): string | undefined {
+  try {
+    return normalizeUserTimeZone(Intl.DateTimeFormat().resolvedOptions().timeZone);
+  } catch {
+    return undefined;
+  }
+}
+
 function resolvePromptTimeZone(chat: JsonRecord, request: JsonRecord): string | undefined {
+  // Preference order: persisted per-chat override → caller-supplied input →
+  // live host resolution. The live fallback guarantees that every
+  // startGeneration entry point (chat hook, game-turn service, background
+  // autonomous chats, prompt-preview UI, future callers) resolves prompt-time
+  // macros in the user's local zone even when the caller forgot to plumb
+  // `userTimeZone` through the input contract. Engine code runs in the user's
+  // Tauri webview, so `Intl` always reflects the user's OS.
   const persisted = normalizeUserTimeZone(parseRecord(chat.metadata).promptTimeZone);
   if (persisted) return persisted;
-  return normalizeUserTimeZone(request.userTimeZone);
+  const fromInput = normalizeUserTimeZone(request.userTimeZone);
+  if (fromInput) return fromInput;
+  return resolveLiveHostTimeZone();
 }
 
 function macroContext(input: {

--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -7,6 +7,7 @@ import { wrapContent } from "../generation-core/prompt/format-engine";
 import { mergeAdjacentMessages, squashLeadingSystemMessages } from "../generation-core/prompt/merger";
 import { applyRegexScriptsToPromptMessages } from "../generation-core/regex/regex-application";
 import { resolveMacros, type MacroContext } from "../shared/macros/macro-engine";
+import { normalizeUserTimeZone } from "../shared/time/timezone";
 import type { GameActiveState, GameCampaignPlan, GameMap, GameNpc, HudWidget, SessionSummary } from "../contracts/types/game";
 import { buildGmFormatReminder, buildGmSystemPrompt, type GmPromptContext } from "../modes/game/prompts/gm-prompts";
 import { buildGenerationPromptPresetCandidates } from "./prompt-preset-selection";
@@ -487,6 +488,12 @@ function markerConfig(section: PromptSectionRecord): MarkerConfig | null {
   return null;
 }
 
+function resolvePromptTimeZone(chat: JsonRecord, request: JsonRecord): string | undefined {
+  const persisted = normalizeUserTimeZone(parseRecord(chat.metadata).promptTimeZone);
+  if (persisted) return persisted;
+  return normalizeUserTimeZone(request.userTimeZone);
+}
+
 function macroContext(input: {
   chat: JsonRecord;
   connection: JsonRecord;
@@ -494,6 +501,7 @@ function macroContext(input: {
   persona: GenerationPersonaContext | null;
   latestUserInput: string;
   agentData?: Record<string, string>;
+  request: JsonRecord;
 }): MacroContext {
   const first = input.characters[0];
   return {
@@ -514,6 +522,7 @@ function macroContext(input: {
     chatId: readString(input.chat.id),
     model: readString(input.connection.model),
     agentData: input.agentData,
+    timeZone: resolvePromptTimeZone(input.chat, input.request),
     characterFields: first
       ? {
           description: first.description,
@@ -1125,6 +1134,7 @@ export async function assembleGenerationPrompt(
     persona,
     latestUserInput: input.latestUserInput,
     agentData: input.agentData,
+    request: input.request,
   });
   const agentData = input.agentData ?? {};
   let messages: ChatMLMessage[] = [];

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -57,6 +57,13 @@ export interface StartGenerationInput extends JsonRecord {
   forCharacterId?: string | null;
   mentionedCharacterNames?: string[];
   attachments?: PromptAttachment[];
+  /**
+   * IANA timezone resolved on the client (e.g. via
+   * `Intl.DateTimeFormat().resolvedOptions().timeZone`). When set, prompt-time
+   * macros like {{date}} and {{time}} resolve in this zone instead of UTC.
+   * A persisted per-chat `metadata.promptTimeZone` takes precedence.
+   */
+  userTimeZone?: string;
   debugMode?: boolean;
   debugSink?: AgentContext["debugSink"];
 }

--- a/src/engine/shared/macros/macro-engine.test.ts
+++ b/src/engine/shared/macros/macro-engine.test.ts
@@ -57,4 +57,15 @@ describe("resolveMacros time macros", () => {
     expect(resolveMacros("{{time}}", ctx)).toBe(formatZonedTime(fixed));
     expect(resolveMacros("{{weekday}}", ctx)).toBe(getZonedWeekdayName(fixed));
   });
+
+  it("{{datetime}} also falls back to host-local rather than UTC when no timezone is provided", () => {
+    const ctx = baseContext();
+    const datetime = resolveMacros("{{datetime}}", ctx);
+    // Pre-fix-pass 2 this returned `Date.toISOString()` (UTC, ends in `Z`),
+    // splitting {{datetime}} away from {{date}}/{{time}} for any caller that
+    // skipped the input plumbing. Post-fix it emits a numeric offset and
+    // never the UTC Z stamp.
+    expect(datetime).toMatch(/[+-]\d{2}:\d{2}$/);
+    expect(datetime).not.toMatch(/Z$/);
+  });
 });

--- a/src/engine/shared/macros/macro-engine.test.ts
+++ b/src/engine/shared/macros/macro-engine.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveMacros, type MacroContext } from "./macro-engine";
+import { formatZonedDate, formatZonedTime, getZonedWeekdayName } from "../time/timezone";
+
+function baseContext(overrides: Partial<MacroContext> = {}): MacroContext {
+  return {
+    user: "User",
+    char: "Char",
+    characters: ["Char"],
+    variables: {},
+    ...overrides,
+  };
+}
+
+describe("resolveMacros time macros", () => {
+  // Use a moment that lands on different calendar days in UTC vs. Pacific time:
+  // 2026-05-27T05:30:00Z is 2026-05-26 22:30 in America/Los_Angeles.
+  const fixed = new Date("2026-05-27T05:30:00Z");
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(fixed);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("{{date}} honors caller-provided IANA timezone", () => {
+    const ctx = baseContext({ timeZone: "America/Los_Angeles" });
+    expect(resolveMacros("{{date}}", ctx)).toBe("2026-05-26");
+  });
+
+  it("{{time}} honors caller-provided IANA timezone", () => {
+    const ctx = baseContext({ timeZone: "America/Los_Angeles" });
+    expect(resolveMacros("{{time}}", ctx)).toBe("22:30");
+  });
+
+  it("{{weekday}} honors caller-provided IANA timezone", () => {
+    // 2026-05-26 in LA is a Tuesday; UTC instant lands on Wednesday.
+    const ctx = baseContext({ timeZone: "America/Los_Angeles" });
+    expect(resolveMacros("{{weekday}}", ctx)).toBe("Tuesday");
+  });
+
+  it("{{datetime}} produces a zoned offset rather than a UTC Z stamp", () => {
+    const ctx = baseContext({ timeZone: "America/Los_Angeles" });
+    const datetime = resolveMacros("{{datetime}}", ctx);
+    expect(datetime.startsWith("2026-05-26T22:30:")).toBe(true);
+    expect(datetime).not.toMatch(/Z$/);
+  });
+
+  it("falls back to host-local resolution when no timezone is provided", () => {
+    const ctx = baseContext();
+    // Without a timezone we must match the helper's host-local rendering;
+    // do not assume UTC.
+    expect(resolveMacros("{{date}}", ctx)).toBe(formatZonedDate(fixed));
+    expect(resolveMacros("{{time}}", ctx)).toBe(formatZonedTime(fixed));
+    expect(resolveMacros("{{weekday}}", ctx)).toBe(getZonedWeekdayName(fixed));
+  });
+});

--- a/src/engine/shared/macros/macro-engine.ts
+++ b/src/engine/shared/macros/macro-engine.ts
@@ -2,6 +2,13 @@
 // Macro Engine — {{user}}, {{char}}, {{date}}, etc.
 // ──────────────────────────────────────────────
 
+import {
+  formatZonedDate,
+  formatZonedIsoDateTime,
+  formatZonedTime,
+  getZonedWeekdayName,
+} from "../time/timezone";
+
 export interface MacroContext {
   user: string;
   char: string;
@@ -44,6 +51,12 @@ export interface MacroContext {
     appearance?: string;
     scenario?: string;
   };
+  /**
+   * IANA timezone (e.g. "America/Los_Angeles") used to resolve {{date}},
+   * {{time}}, {{datetime}}, {{isotime}}, and {{weekday}}. When unset, macros
+   * fall back to the host machine's local timezone.
+   */
+  timeZone?: string;
 }
 
 export interface ResolveMacroOptions {
@@ -417,12 +430,15 @@ export function resolveMacros(template: string, ctx: MacroContext, options: Reso
   });
 
   // ── Date/time ──
+  // Resolve in the caller-provided IANA timezone so prompts reflect the user's
+  // local frame rather than UTC. Falls back to the host machine's local zone.
   const now = new Date();
-  result = result.replace(/\{\{date\}\}/gi, now.toISOString().slice(0, 10));
-  result = result.replace(/\{\{time\}\}/gi, now.toTimeString().slice(0, 5));
-  result = result.replace(/\{\{datetime\}\}/gi, now.toISOString());
-  result = result.replace(/\{\{isotime\}\}/gi, now.toISOString());
-  result = result.replace(/\{\{weekday\}\}/gi, now.toLocaleDateString("en-US", { weekday: "long" }));
+  const tz = ctx.timeZone;
+  result = result.replace(/\{\{date\}\}/gi, formatZonedDate(now, tz));
+  result = result.replace(/\{\{time\}\}/gi, formatZonedTime(now, tz));
+  result = result.replace(/\{\{datetime\}\}/gi, formatZonedIsoDateTime(now, tz));
+  result = result.replace(/\{\{isotime\}\}/gi, formatZonedIsoDateTime(now, tz));
+  result = result.replace(/\{\{weekday\}\}/gi, getZonedWeekdayName(now, tz));
 
   // ── Random values ──
   result = result.replace(/\{\{random\}\}/gi, () => String(Math.floor(Math.random() * 101)));

--- a/src/engine/shared/time/timezone.ts
+++ b/src/engine/shared/time/timezone.ts
@@ -71,9 +71,13 @@ export function formatZonedTime(date: Date, timeZone?: string): string {
 }
 
 export function formatZonedIsoDateTime(date: Date, timeZone?: string): string {
-  if (!timeZone) return date.toISOString();
+  // Keep the no-zone fallback consistent with formatZonedDate and
+  // formatZonedTime, which delegate to Intl with `timeZone: undefined` (i.e.
+  // host-local). Falling back to `date.toISOString()` here would resolve in
+  // UTC, splitting {{datetime}} away from {{date}}/{{time}} for any caller
+  // that doesn't explicitly thread a zone.
   const parts = getZonedDateParts(date, timeZone);
-  const offsetMinutes = zonedOffsetMinutes(date, timeZone);
+  const offsetMinutes = timeZone ? zonedOffsetMinutes(date, timeZone) : -date.getTimezoneOffset();
   const sign = offsetMinutes >= 0 ? "+" : "-";
   const absMinutes = Math.abs(offsetMinutes);
   const offsetHours = String(Math.floor(absMinutes / 60)).padStart(2, "0");

--- a/src/engine/shared/time/timezone.ts
+++ b/src/engine/shared/time/timezone.ts
@@ -1,0 +1,118 @@
+// ──────────────────────────────────────────────
+// Zoned-time helpers for prompt assembly
+//
+// Refactor parity with the pre-rewrite generation flow, which propagated the
+// user's IANA timezone (`userTimeZone`) from the client into every prompt so
+// {{date}} / {{time}} / {{datetime}} / {{weekday}} resolve in the user's local
+// frame rather than UTC. A per-chat `promptTimeZone` override may take
+// precedence over the live browser value when persisted on chat metadata.
+// ──────────────────────────────────────────────
+
+const MAX_TIMEZONE_LENGTH = 100;
+
+export function normalizeUserTimeZone(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const timeZone = value.trim();
+  if (!timeZone || timeZone.length > MAX_TIMEZONE_LENGTH) return undefined;
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone }).format(new Date());
+    return timeZone;
+  } catch {
+    return undefined;
+  }
+}
+
+interface ZonedDateParts {
+  year: string;
+  month: string;
+  day: string;
+  hour: string;
+  minute: string;
+  second: string;
+  weekday: string;
+}
+
+function readPart(parts: Intl.DateTimeFormatPart[], type: Intl.DateTimeFormatPartTypes): string {
+  return parts.find((part) => part.type === type)?.value ?? "";
+}
+
+export function getZonedDateParts(date: Date, timeZone?: string): ZonedDateParts {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    hourCycle: "h23",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    weekday: "long",
+  }).formatToParts(date);
+  const hour = readPart(parts, "hour");
+  return {
+    year: readPart(parts, "year"),
+    month: readPart(parts, "month"),
+    day: readPart(parts, "day"),
+    hour: hour === "24" ? "00" : hour,
+    minute: readPart(parts, "minute"),
+    second: readPart(parts, "second"),
+    weekday: readPart(parts, "weekday"),
+  };
+}
+
+export function formatZonedDate(date: Date, timeZone?: string): string {
+  const parts = getZonedDateParts(date, timeZone);
+  return `${parts.year}-${parts.month}-${parts.day}`;
+}
+
+export function formatZonedTime(date: Date, timeZone?: string): string {
+  const parts = getZonedDateParts(date, timeZone);
+  return `${parts.hour}:${parts.minute}`;
+}
+
+export function formatZonedIsoDateTime(date: Date, timeZone?: string): string {
+  if (!timeZone) return date.toISOString();
+  const parts = getZonedDateParts(date, timeZone);
+  const offsetMinutes = zonedOffsetMinutes(date, timeZone);
+  const sign = offsetMinutes >= 0 ? "+" : "-";
+  const absMinutes = Math.abs(offsetMinutes);
+  const offsetHours = String(Math.floor(absMinutes / 60)).padStart(2, "0");
+  const offsetMins = String(absMinutes % 60).padStart(2, "0");
+  return `${parts.year}-${parts.month}-${parts.day}T${parts.hour}:${parts.minute}:${parts.second}${sign}${offsetHours}:${offsetMins}`;
+}
+
+export function getZonedWeekdayName(date: Date, timeZone?: string): string {
+  return getZonedDateParts(date, timeZone).weekday;
+}
+
+function zonedOffsetMinutes(date: Date, timeZone: string): number {
+  const utcParts = new Intl.DateTimeFormat("en-US", {
+    timeZone: "UTC",
+    hourCycle: "h23",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  }).formatToParts(date);
+  const localParts = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    hourCycle: "h23",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  }).formatToParts(date);
+  const toEpochMinutes = (parts: Intl.DateTimeFormatPart[]) => {
+    const year = Number(readPart(parts, "year"));
+    const month = Number(readPart(parts, "month"));
+    const day = Number(readPart(parts, "day"));
+    const hour = Number(readPart(parts, "hour"));
+    const minute = Number(readPart(parts, "minute"));
+    return Date.UTC(year, month - 1, day, hour === 24 ? 0 : hour, minute) / 60_000;
+  };
+  return toEpochMinutes(localParts) - toEpochMinutes(utcParts);
+}

--- a/src/features/runtime/generation/hooks/use-generate.ts
+++ b/src/features/runtime/generation/hooks/use-generate.ts
@@ -66,6 +66,14 @@ function readString(value: unknown, fallback = ""): string {
   return typeof value === "string" ? value : fallback;
 }
 
+function resolveUserTimeZone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone ?? "";
+  } catch {
+    return "";
+  }
+}
+
 function streamRevealChunkLength(speed: number, pendingLength: number): number {
   if (pendingLength <= 0) return 0;
   if (speed >= 100) return pendingLength;
@@ -955,6 +963,7 @@ export function useGenerate() {
             { storage: storageApi, llm: llmApi, integrations: integrationGateway },
             {
               ...streamArgs,
+              userTimeZone: resolveUserTimeZone(),
               debugMode: useUIStore.getState().debugMode,
               debugSink: (entry: Omit<AgentDebugEntry, "timestamp"> & { timestamp?: number }) =>
                 useAgentStore.getState().addDebugEntry(entry),

--- a/src/features/runtime/generation/hooks/use-generate.ts
+++ b/src/features/runtime/generation/hooks/use-generate.ts
@@ -67,11 +67,11 @@ function readString(value: unknown, fallback = ""): string {
 }
 
 function resolveUserTimeZone(): string {
-  try {
-    return Intl.DateTimeFormat().resolvedOptions().timeZone ?? "";
-  } catch {
-    return "";
-  }
+  // Engine has its own live-host fallback in resolvePromptTimeZone, so this is
+  // explicit-intent plumbing rather than a load-bearing source of truth.
+  // Kept so non-default callers (e.g. remote runtime in future) can override
+  // via the `userTimeZone` input field.
+  return Intl.DateTimeFormat().resolvedOptions().timeZone;
 }
 
 function streamRevealChunkLength(speed: number, pendingLength: number): number {


### PR DESCRIPTION
## Why this change

Closes #1356.

The legacy generation flow shipped the browser's resolved IANA timezone (`userTimeZone`) into prompt assembly so prompt-time macros (`{{date}}`, `{{time}}`, `{{datetime}}`, `{{isotime}}`, `{{weekday}}`) and any prompt code relying on local date context resolved in the user's local frame. The refactor's macro engine resolves `{{date}}` / `{{datetime}}` / `{{isotime}}` from `Date.prototype.toISOString` and so produces UTC, which silently drifts a calendar day for users west of UTC late at night and east of UTC early in the morning. No timezone string flows from the UI into the engine at all today.

## What changed

- `src/engine/shared/time/timezone.ts` (new): IANA-tz normalizer plus zoned-parts/date/time/weekday/ISO-with-offset helpers built on `Intl.DateTimeFormat`. The normalizer trims, length-caps to 100, and probes the value via `Intl.DateTimeFormat` so invalid strings drop quietly to `undefined`.
- `src/engine/shared/macros/macro-engine.ts`: adds `MacroContext.timeZone?: string` and routes `{{date}} / {{time}} / {{datetime}} / {{isotime}} / {{weekday}}` through the new helpers. All helpers fall back to the host machine's local zone via `Intl` when no zone is provided, so a caller that skips the input plumbing never lands in UTC.
- `src/engine/generation/start-generation.ts`: adds `userTimeZone?: string` to `StartGenerationInput`.
- `src/engine/generation/prompt-assembly.ts`: `resolvePromptTimeZone` resolves in preference order **persisted `chat.metadata.promptTimeZone` → caller-supplied `request.userTimeZone` → live `Intl.DateTimeFormat().resolvedOptions().timeZone`**. The live fallback is the load-bearing piece — engine code runs in the user's Tauri webview, so `Intl` always reflects the user's OS. This means every `startGeneration` entry point (the chat hook here, the game-turn service, the background-autonomous chat hook, and `previewGenerationPrompt`) resolves macros in the user's local frame without per-callsite plumbing.
- `src/features/runtime/generation/hooks/use-generate.ts`: resolves the live browser timezone via `Intl.DateTimeFormat().resolvedOptions().timeZone` and threads it into the `startGeneration` input. With the engine-side fallback in place this is explicit-intent rather than load-bearing; it stays for clarity and to keep an override surface for future non-default callers (e.g. remote runtime).

Two commits:

1. **Propagate user timezone into generation prompt assembly** — initial fix, plumbed tz through the chat-message generation path.
2. **Address review: centralize timezone fallback so all generation paths inherit** — moves the live-host fallback into `resolvePromptTimeZone` so game-mode and background-autonomous callers (which build their own `startGeneration` args without `userTimeZone`) and the prompt-preview UI all pick up the fix automatically. Also fixes `formatZonedIsoDateTime(date, undefined)` returning UTC (it now matches the host-local behavior of the other helpers) and extends the macro-engine fallback test with a `{{datetime}}` assertion.

## Verification

- `pnpm check` ✅ (architecture / dependency-cruiser, frontend `tsc -b`, `cargo check`, docs)
- `pnpm test` ✅ (21 suites / 106 tests, including 6 Vitest specs for the macro engine that pin both the zoned-tz case and the host-local fallback)
- Browser-tier repro spec exercised against `pnpm dev` confirms RED → GREEN: pre-fix the macro engine returned `2026-05-27` (UTC) for an instant that is `2026-05-26` in LA-local; post-fix it returns the LA-local date.
- Smoked end-to-end in `pnpm tauri dev`: `{{date}}` / `{{time}}` / `{{weekday}}` now render in the user's local zone in real chat output, and a chat reply that includes those macros resolves correctly under normal usage.

## Risks called out

- **Default macro behavior shift**: previous `{{date}}` returned UTC, new default returns host-local. This is the bug being fixed, but it does change observable output for any preset that depended on the old UTC behavior. Couldn't find such a preset in the repo.
- **`chat.metadata.promptTimeZone` precedence**: persisted overrides on legacy chats win over the live browser value. Intentional — matches the legacy server's `chatMeta.promptTimeZone ?? input.userTimeZone` order. Normalization rejects invalid stored strings so they fall through to the live host zone rather than producing UTC.
- **Mode parity**: change is in mode-neutral prompt assembly + macro engine + engine-level fallback, so chat / roleplay / game / preview / background-autonomous all pick up the same fix in one path.