### PR TITLE
Fix game gallery session aggregation

### DIFF
--- a/src/features/catalog/gallery/hooks/use-gallery.test.ts
+++ b/src/features/catalog/gallery/hooks/use-gallery.test.ts
@@ -68,6 +68,7 @@ describe("game gallery scope", () => {
     const sessions = [
       chat({ id: "session-1", mode: "game", groupId: "game-1", metadata: metadata({ gameId: "game-1" }) }),
       active,
+      chat({ id: "other-game-session", mode: "game", groupId: "game-2", metadata: metadata({ gameId: "game-2" }) }),
       chat({ id: "conversation-1", mode: "conversation", groupId: "game-1" }),
     ];
 

--- a/src/features/catalog/gallery/hooks/use-gallery.test.ts
+++ b/src/features/catalog/gallery/hooks/use-gallery.test.ts
@@ -1,6 +1,44 @@
 import { describe, expect, it } from "vitest";
 
-import { chatGalleryUploadFailureError } from "./use-gallery";
+import {
+  chatGalleryUploadFailureError,
+  getGalleryChatIds,
+  getGameGalleryScopeId,
+  listGalleryImagesForChatIds,
+} from "./use-gallery";
+import type { Chat, ChatMetadata } from "../../../../engine/contracts/types/chat";
+
+function metadata(overrides: Partial<ChatMetadata> = {}): ChatMetadata {
+  return {
+    summary: null,
+    tags: [],
+    enableAgents: true,
+    agentOverrides: {},
+    activeAgentIds: [],
+    activeToolIds: [],
+    presetChoices: {},
+    ...overrides,
+  };
+}
+
+function chat(overrides: Partial<Chat> & Pick<Chat, "id" | "mode">): Chat {
+  return {
+    id: overrides.id,
+    name: overrides.name ?? overrides.id,
+    mode: overrides.mode,
+    characterIds: overrides.characterIds ?? [],
+    groupId: overrides.groupId ?? null,
+    personaId: overrides.personaId ?? null,
+    promptPresetId: overrides.promptPresetId ?? null,
+    connectionId: overrides.connectionId ?? null,
+    connectedChatId: overrides.connectedChatId ?? null,
+    folderId: overrides.folderId ?? null,
+    sortOrder: overrides.sortOrder ?? 0,
+    createdAt: overrides.createdAt ?? "2026-05-27T00:00:00.000Z",
+    updatedAt: overrides.updatedAt ?? "2026-05-27T00:00:00.000Z",
+    metadata: overrides.metadata ?? metadata(),
+  };
+}
 
 describe("chatGalleryUploadFailureError", () => {
   it("preserves the underlying remote error for single-file uploads", () => {
@@ -13,5 +51,54 @@ describe("chatGalleryUploadFailureError", () => {
     expect(chatGalleryUploadFailureError(2, [new Error("nope")]).message).toBe(
       "One chat gallery image failed to upload.",
     );
+  });
+});
+
+describe("game gallery scope", () => {
+  it("prefers metadata gameId over groupId for game chats", () => {
+    expect(
+      getGameGalleryScopeId(
+        chat({ id: "session-2", mode: "game", groupId: "fallback-game", metadata: metadata({ gameId: "game-1" }) }),
+      ),
+    ).toBe("game-1");
+  });
+
+  it("aggregates only game sessions in the same scope and keeps the active chat included", () => {
+    const active = chat({ id: "session-2", mode: "game", groupId: "game-1", metadata: metadata({ gameId: "game-1" }) });
+    const sessions = [
+      chat({ id: "session-1", mode: "game", groupId: "game-1", metadata: metadata({ gameId: "game-1" }) }),
+      active,
+      chat({ id: "conversation-1", mode: "conversation", groupId: "game-1" }),
+    ];
+
+    expect(getGalleryChatIds(active, sessions)).toEqual(["session-1", "session-2"]);
+    expect(getGalleryChatIds(active, [])).toEqual(["session-2"]);
+  });
+
+  it("does not aggregate non-game chats or game chats without a scope id", () => {
+    const sessions = [chat({ id: "session-1", mode: "game", groupId: "game-1" })];
+
+    expect(getGalleryChatIds(chat({ id: "conversation-1", mode: "conversation", groupId: "game-1" }), sessions)).toEqual([
+      "conversation-1",
+    ]);
+    expect(getGalleryChatIds(chat({ id: "solo", mode: "game" }), sessions)).toEqual(["solo"]);
+  });
+
+  it("lists gallery rows for every scoped chat id and sorts newest first", async () => {
+    const calls: string[] = [];
+    const images = await listGalleryImagesForChatIds(["session-1", "session-2"], async (chatId) => {
+      calls.push(chatId);
+      return [
+        {
+          id: `${chatId}-image`,
+          chatId,
+          url: `data:image/png;base64,${chatId}`,
+          createdAt: chatId === "session-1" ? "2026-05-27T00:00:00.000Z" : "2026-05-27T01:00:00.000Z",
+        },
+      ];
+    });
+
+    expect(calls).toEqual(["session-1", "session-2"]);
+    expect(images.map((image) => image.id)).toEqual(["session-2-image", "session-1-image"]);
   });
 });

--- a/src/features/catalog/gallery/hooks/use-gallery.ts
+++ b/src/features/catalog/gallery/hooks/use-gallery.ts
@@ -2,13 +2,57 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { galleryKeys } from "../query-keys";
 import { galleryApi } from "../../../../shared/api/image-generation-api";
 import { storageApi } from "../../../../shared/api/storage-api";
+import type { Chat } from "../../../../engine/contracts/types/chat";
 import type { ChatImage } from "../../../../shared/types/gallery";
 
-export function useGalleryImages(chatId: string | null) {
+function imageCreatedAt(image: ChatImage) {
+  const timestamp = typeof image.createdAt === "string" ? Date.parse(image.createdAt) : NaN;
+  return Number.isFinite(timestamp) ? timestamp : 0;
+}
+
+export function getGameGalleryScopeId(chat: Chat | null): string | null {
+  if (!chat || chat.mode !== "game") return null;
+  const metadataGameId =
+    typeof chat.metadata?.gameId === "string" && chat.metadata.gameId.trim() ? chat.metadata.gameId.trim() : null;
+  return metadataGameId ?? chat.groupId ?? null;
+}
+
+export function getGalleryChatIds(chat: Chat | null, gameSessions: readonly Chat[] = []): string[] {
+  if (!chat) return [];
+  const gameId = getGameGalleryScopeId(chat);
+  if (!gameId) return [chat.id];
+
+  const sessionIds = gameSessions
+    .filter((session) => session.mode === "game")
+    .map((session) => session.id)
+    .filter(Boolean);
+
+  return Array.from(new Set([...sessionIds, chat.id]));
+}
+
+export async function listGalleryImagesForChatIds(
+  galleryChatIds: readonly string[],
+  listByChatId: (chatId: string) => Promise<ChatImage[]> = (chatId) =>
+    storageApi.list<ChatImage>("gallery", { filters: { chatId } }),
+): Promise<ChatImage[]> {
+  const batches = await Promise.all(galleryChatIds.map((chatId) => listByChatId(chatId)));
+  return batches.flat().sort((a, b) => imageCreatedAt(b) - imageCreatedAt(a));
+}
+
+export function useGalleryImages(chat: Chat | null) {
+  const gameId = getGameGalleryScopeId(chat);
+  const gameSessions = useQuery({
+    queryKey: galleryKeys.gameSessions(gameId),
+    queryFn: () => storageApi.list<Chat>("chats", { filters: { groupId: gameId } }),
+    enabled: !!gameId,
+    retry: false,
+  });
+  const galleryChatIds = getGalleryChatIds(chat, gameSessions.data ?? []);
+
   return useQuery({
-    queryKey: galleryKeys.images(chatId),
-    queryFn: () => storageApi.list<ChatImage>("gallery", { filters: { chatId } }),
-    enabled: !!chatId,
+    queryKey: galleryKeys.images(chat?.id ?? null, galleryChatIds),
+    queryFn: () => listGalleryImagesForChatIds(galleryChatIds),
+    enabled: !!chat?.id && galleryChatIds.length > 0 && (!gameId || gameSessions.isSuccess || gameSessions.isError),
     retry: false,
   });
 }

--- a/src/features/catalog/gallery/hooks/use-gallery.ts
+++ b/src/features/catalog/gallery/hooks/use-gallery.ts
@@ -23,7 +23,7 @@ export function getGalleryChatIds(chat: Chat | null, gameSessions: readonly Chat
   if (!gameId) return [chat.id];
 
   const sessionIds = gameSessions
-    .filter((session) => session.mode === "game")
+    .filter((session) => session.mode === "game" && getGameGalleryScopeId(session) === gameId)
     .map((session) => session.id)
     .filter(Boolean);
 

--- a/src/features/catalog/gallery/query-keys.ts
+++ b/src/features/catalog/gallery/query-keys.ts
@@ -1,4 +1,8 @@
 export const galleryKeys = {
   all: ["gallery"] as const,
-  images: (chatId: string | null) => [...galleryKeys.all, "images", chatId] as const,
+  images: (chatId: string | null, scopeChatIds?: readonly string[]) =>
+    scopeChatIds
+      ? ([...galleryKeys.all, "images", chatId, "scope", scopeChatIds] as const)
+      : ([...galleryKeys.all, "images", chatId] as const),
+  gameSessions: (gameId: string | null) => [...galleryKeys.all, "game-sessions", gameId] as const,
 };

--- a/src/features/modes/game/components/GameSurface.tsx
+++ b/src/features/modes/game/components/GameSurface.tsx
@@ -46,6 +46,7 @@ import {
   useUpdateChatMetadata,
   useUpdateMessage,
 } from "../../../catalog/chats/index";
+import { galleryKeys } from "../../../catalog/gallery/query-keys";
 import { useConnections } from "../../../catalog/connections/index";
 import { useGameGeneration } from "../hooks/use-game-generation";
 import { useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -3793,7 +3794,7 @@ export function GameSurface({
 
   const installGeneratedIllustration = useCallback(
     async (illustration: { tag: string; segment?: number }) => {
-      void queryClient.invalidateQueries({ queryKey: ["gallery", activeChatId] });
+      void queryClient.invalidateQueries({ queryKey: galleryKeys.images(activeChatId) });
       await fetchManifest();
       if (illustration.segment !== undefined && illustration.segment > 0) {
         setPendingSegmentEffects((previous) => {

--- a/src/features/modes/shared/chat-ui/components/ChatGallery.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatGallery.tsx
@@ -25,9 +25,10 @@ import { useGalleryStore } from "../../../../../shared/stores/gallery.store";
 import { ImageUploadDropzone } from "../../../../../shared/components/ui/ImageUploadDropzone";
 import { ImagePromptPanel } from "./ImagePromptPanel";
 import type { ChatImage } from "../../../../../shared/types/gallery";
+import type { Chat } from "../../../../../engine/contracts/types/chat";
 
 interface ChatGalleryProps {
-  chatId: string;
+  chat: Chat;
   /** Manually trigger the Illustrator agent */
   onIllustrate?: () => void | Promise<void>;
 }
@@ -45,10 +46,10 @@ function formatIllustrateError(error: unknown) {
   return "Illustration failed. Check your text and image generation settings.";
 }
 
-export function ChatGallery({ chatId, onIllustrate }: ChatGalleryProps) {
-  const { data: images, isLoading } = useGalleryImages(chatId);
-  const upload = useUploadGalleryImage(chatId);
-  const remove = useDeleteGalleryImage(chatId);
+export function ChatGallery({ chat, onIllustrate }: ChatGalleryProps) {
+  const { data: images, isLoading } = useGalleryImages(chat);
+  const upload = useUploadGalleryImage(chat.id);
+  const remove = useDeleteGalleryImage(chat.id);
   const [lightbox, setLightbox] = useState<ChatImage | null>(null);
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
   const [illustratePending, setIllustratePending] = useState(false);

--- a/src/features/modes/shared/chat-ui/components/ChatGalleryDrawer.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatGalleryDrawer.tsx
@@ -37,7 +37,7 @@ export function ChatGalleryDrawer({ chat, open, onClose, onIllustrate }: ChatGal
         </div>
 
         <div className="flex-1 overflow-y-auto">
-          <ChatGallery chatId={chat.id} onIllustrate={onIllustrate} />
+          <ChatGallery chat={chat} onIllustrate={onIllustrate} />
         </div>
       </div>
     </>


### PR DESCRIPTION
## Linked issue

Closes #1366

## Why this change

- Refactor chat gallery listing only queried gallery rows for the active chat ID, so Game Mode galleries lost legacy images from earlier/later session chats in the same game.

## What changed

- Resolve game gallery scope from `Chat.metadata.gameId` with `groupId` fallback.
- List gallery rows for every game session chat in that scope, while keeping non-game galleries scoped to the active chat.
- Pass the full chat object into the gallery drawer/grid so the hook can distinguish game vs non-game scope.
- Keep game illustration invalidation aligned with the gallery query key.
- Added unit coverage for game gallery scope selection, negative controls, and multi-chat gallery fetch fan-out.

## Refactor impact

Primary owner:

- Game mode

Impact areas reviewed:

- Catalog gallery hook/query keys
- Shared chat gallery drawer/grid
- Game illustration/gallery invalidation

Boundary notes:

- No storage schema, Rust command, dependency, remote runtime, auth, prompt assembly, or import/export behavior changed.
- Uses existing generic `storageApi.list` calls for chats and gallery rows.

Pressure points touched:

- Game gallery drawer via shared `ChatGallery`
- GameSurface generated-illustration gallery invalidation

## Validation

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Codex proof: `node scratch\issue-1366-gallery-scope-proof.mjs` failed before the fix and passes after the fix.
- Codex proof: `pnpm exec vitest run src/features/catalog/gallery/hooks/use-gallery.test.ts` passed.
- Codex proof: `pnpm check` passed locally.
- Codex proof: `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json` passed with compatibility rows and negative controls.
- Manual follow-up: open a game with multiple session chats containing gallery images and confirm the Game Mode gallery shows images from all sessions while ordinary chat galleries remain per-chat.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- Not attached. This fix is covered by scope/fan-out unit proof and `pnpm check`; no browser screenshot was captured.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Gallery now displays images from related game sessions within the same game scope, providing a unified view across game chats instead of just the current chat.
  * Images are consistently sorted by creation time with newest first.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1381?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->