### PR TITLE
Fix pre-alpha platform build failures

### DIFF
--- a/.github/workflows/prealpha-platform-builds.yml
+++ b/.github/workflows/prealpha-platform-builds.yml
@@ -271,7 +271,8 @@ jobs:
           NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
           MARINARA_ANDROID_APPLICATION_ID: ${{ env.PREALPHA_ANDROID_APPLICATION_ID }}
           MARINARA_ANDROID_APP_NAME: ${{ env.PREALPHA_ANDROID_APP_NAME }}
-        run: pnpm tauri android build --debug --apk --ci --config "${{ env.PREALPHA_CONFIG }}"
+        # Keep Android on the generated source package from tauri.conf.json; Gradle applies the pre-alpha app id/name.
+        run: pnpm tauri android build --debug --apk --ci
 
       - name: Collect Android release assets
         shell: bash

--- a/docs/developer/run-build.html
+++ b/docs/developer/run-build.html
@@ -155,7 +155,7 @@
             <tr>
               <td>Android universal debug APK</td>
               <td>Experimental pre-alpha test build</td>
-              <td><code>pnpm tauri android build --debug --apk --ci --config src-tauri/tauri.prealpha.conf.json</code></td>
+              <td><code>pnpm tauri android build --debug --apk --ci</code> with Gradle-provided pre-alpha app id/name overrides</td>
               <td>Debug-signed APK on the GitHub pre-release using <code>com.marinara_engine.prealpha</code>.</td>
             </tr>
             <tr>

--- a/scripts/run-tauri.mjs
+++ b/scripts/run-tauri.mjs
@@ -6,9 +6,10 @@ const cargoHome = process.env.CARGO_HOME || (process.env.HOME ? join(process.env
 const cargoBin = cargoHome ? join(cargoHome, "bin") : "";
 
 const env = { ...process.env };
+const pathKey = Object.keys(env).find((key) => key.toLowerCase() === "path") || "PATH";
 
 if (cargoBin && existsSync(cargoBin)) {
-  env.PATH = [cargoBin, env.PATH].filter(Boolean).join(delimiter);
+  env[pathKey] = [cargoBin, env[pathKey]].filter(Boolean).join(delimiter);
 }
 
 const tauriBin = process.platform === "win32" ? "tauri.cmd" : "tauri";


### PR DESCRIPTION
## Linked issue

Follow-up to #1368 / #1369 and failed workflow run https://github.com/Pasta-Devs/Marinara-Engine/actions/runs/26486279463.

## Why this change

- The first manual pre-alpha workflow run failed on Android because the pre-alpha Tauri config changed the bundle identifier, causing Tauri Android to look for a generated Java/Kotlin source package that does not exist.
- The Windows desktop job failed because `scripts/run-tauri.mjs` rewrote `PATH` using only the uppercase `PATH` key; Windows runners may expose the inherited path as `Path`, which hid `node_modules/.bin/tauri.cmd` from the spawned process.

## What changed

- Android pre-alpha CI build now runs `pnpm tauri android build --debug --apk --ci` without the desktop pre-alpha config override.
- Android still applies the pre-alpha app id and app name through the existing Gradle environment overrides.
- `scripts/run-tauri.mjs` now preserves the existing path environment variable case-insensitively before prepending Cargo's bin directory.
- Developer docs now describe the Android build as using Gradle-provided pre-alpha identity overrides.

## Refactor impact

Primary owner:

- CI/release distribution

Impact areas reviewed:

- Pre-alpha GitHub Actions desktop build path
- Pre-alpha GitHub Actions Android build path
- Cross-platform Tauri CLI wrapper
- Developer build docs

Boundary notes:

- No React feature, engine, shared API, or Rust runtime behavior changed.
- Android app identity remains isolated via Gradle environment variables for the pre-alpha workflow.
- Desktop still uses `src-tauri/tauri.prealpha.conf.json` for the pre-alpha product name and identifier.

Pressure points touched:

- Tauri CLI invocation wrapper
- Android generated-project package assumptions
- Pre-alpha release workflow

## Validation

- [ ] `pnpm check` passes locally
- [x] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [x] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Reviewed failed run/job logs for Android and Windows failures.
- Parsed `.github/workflows/prealpha-platform-builds.yml` with PyYAML/BaseLoader.
- Ran `node --check scripts/run-tauri.mjs`.
- Ran `pnpm tauri --version` successfully through the wrapper on Windows.
- Ran `git diff --check`.
- Did not run the full platform packaging workflow locally; this needs another GitHub-hosted workflow dispatch after merge.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [x] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A — CI/docs/script fix only.
