### PR TITLE
Fix conditional prompt macro parity

### DIFF
--- a/src/engine/shared/macros/macro-engine.test.ts
+++ b/src/engine/shared/macros/macro-engine.test.ts
@@ -58,6 +58,9 @@ describe("resolveMacros conditional blocks", () => {
     );
 
     expect(resolveMacros("{{#if off}}Enabled{{else}}Disabled{{/if}}", conditionalContext())).toBe("Disabled");
+    expect(resolveMacros("{{#if missingFlag}}Enabled{{else}}Disabled{{/if}}", conditionalContext())).toBe(
+      "Disabled",
+    );
   });
 
   it("supports legacy comparisons and aliases", () => {
@@ -180,5 +183,20 @@ describe("resolveMacros time macros", () => {
     // never the UTC Z stamp.
     expect(datetime).toMatch(/[+-]\d{2}:\d{2}$/);
     expect(datetime).not.toMatch(/Z$/);
+  });
+
+  it("uses the caller timezone inside grouped character conditional operands", () => {
+    const resolved = resolveMacros(
+      ["[", '{{#if "{{date}}" == "2026-05-26"}}{{char}}: local{{else}}{{char}}: host{{/if}}', "]"].join("\n"),
+      baseContext({
+        characters: ["Dottore", "Pantalone"],
+        characterProfiles: [{ name: "Dottore" }, { name: "Pantalone" }],
+        timeZone: "America/Los_Angeles",
+      }),
+    );
+
+    expect(resolved).toContain("Dottore: local");
+    expect(resolved).toContain("Pantalone: local");
+    expect(resolved).not.toContain("host");
   });
 });

--- a/src/engine/shared/macros/macro-engine.test.ts
+++ b/src/engine/shared/macros/macro-engine.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import { resolveMacros, type MacroContext } from "./macro-engine";
+
+function macroContext(overrides: Partial<MacroContext> = {}): MacroContext {
+  return {
+    user: "Xel",
+    char: "Dottore",
+    characters: ["Dottore", "Pantalone"],
+    variables: {
+      mood: "ominous",
+      off: "false",
+      ...overrides.variables,
+    },
+    lastInput: "Tell me the plan.",
+    chatId: "chat-1",
+    model: "test-model",
+    characterFields: {
+      description: "Harbinger doctor",
+      personality: "calculating",
+      backstory: "Fatui research lead",
+      appearance: "mask and coat",
+      scenario: "winter palace",
+      example: "Observe carefully.",
+    },
+    characterProfiles: [
+      {
+        name: "Dottore",
+        description: "Harbinger doctor",
+        personality: "calculating",
+      },
+      {
+        name: "Pantalone",
+        description: "Banker harbinger",
+        personality: "polished",
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("resolveMacros conditional blocks", () => {
+  it("selects truthy and else branches from variables", () => {
+    expect(resolveMacros("{{#if mood}}Mood: {{mood}}{{else}}No mood{{/if}}", macroContext())).toBe(
+      "Mood: ominous",
+    );
+
+    expect(resolveMacros("{{#if off}}Enabled{{else}}Disabled{{/if}}", macroContext())).toBe("Disabled");
+  });
+
+  it("supports legacy comparisons and aliases", () => {
+    const ctx = macroContext();
+
+    expect(resolveMacros('{{#if character == "Dottore"}}Doctor{{else}}Other{{/if}}', ctx)).toBe("Doctor");
+    expect(resolveMacros("{{#if speaker != \u201cDottore\u201d}}Other{{else}}Same{{/if}}", ctx)).toBe("Same");
+    expect(resolveMacros('{{#if characters contains "Pantalone"}}Group{{else}}Solo{{/if}}', ctx)).toBe("Group");
+  });
+
+  it("supports nested macro operands in condition expressions", () => {
+    const ctx = macroContext({ variables: { target: "Dottore" } });
+
+    expect(resolveMacros('{{#if {{getvar::target}} == {{char}}}}Matched{{else}}Missed{{/if}}', ctx)).toBe("Matched");
+    expect(resolveMacros('{{#if "{{char}}" == "Dottore"}}Quoted{{else}}Missed{{/if}}', ctx)).toBe("Quoted");
+  });
+
+  it("only resolves macros and side effects from the selected branch", () => {
+    const ctx = macroContext();
+
+    expect(
+      resolveMacros("{{#if off}}{{setvar::selected::bad}}{{else}}{{setvar::selected::good}}{{/if}}{{getvar::selected}}", ctx),
+    ).toBe("good");
+    expect(ctx.variables.selected).toBe("good");
+  });
+
+  it("resolves nested conditional blocks", () => {
+    expect(
+      resolveMacros(
+        '{{#if mood}}{{#if char == "Dottore"}}{{user}} branch{{else}}Other char{{/if}}{{else}}No mood{{/if}}',
+        macroContext(),
+      ),
+    ).toBe("Xel branch");
+  });
+
+  it("does not treat unknown hash macros starting with if as conditional starts", () => {
+    expect(resolveMacros("{{#if mood}}Keep {{#iframe}}{{else}}No{{/if}}", macroContext())).toBe(
+      "Keep {{#iframe}}",
+    );
+  });
+
+  it("preserves malformed conditional openers and continues resolving later blocks", () => {
+    expect(
+      resolveMacros('{{#if mood}}Keep {{user}} {{#if char == "Dottore"}}Doctor{{else}}Other{{/if}}', macroContext()),
+    ).toBe(
+      "{{#if mood}}Keep Xel Doctor",
+    );
+  });
+
+  it("evaluates character conditionals per repeated group-chat profile", () => {
+    const resolved = resolveMacros(
+      [
+        "[",
+        '{{#if char == "Dottore"}}Doctor: {{description}}{{else}}{{char}} fallback{{/if}}',
+        "]",
+      ].join("\n"),
+      macroContext(),
+    );
+
+    expect(resolved).toContain("Doctor: Harbinger doctor");
+    expect(resolved).toContain("Pantalone fallback");
+    expect(resolved).not.toContain("Dottore fallback");
+  });
+});

--- a/src/engine/shared/macros/macro-engine.ts
+++ b/src/engine/shared/macros/macro-engine.ts
@@ -57,7 +57,7 @@ export interface SupportedMacroDefinition {
 }
 
 const CHARACTER_MACRO_PATTERN =
-  /\{\{(?:char|charName|description|personality|backstory|appearance|scenario|example)\}\}/i;
+  /\{\{(?:char|charName|description|personality|backstory|appearance|scenario|example)\}\}|\{\{\s*#if\s+[^}]*\b(?:char|charName|character|speaker|description|personality|backstory|appearance|scenario|example)\b/i;
 
 export const SUPPORTED_MACROS: readonly SupportedMacroDefinition[] = [
   { category: "Identity", syntax: "{{user}}", description: "Current user or persona name" },
@@ -119,6 +119,11 @@ export const SUPPORTED_MACROS: readonly SupportedMacroDefinition[] = [
     syntax: "{{lowercase}}...{{/lowercase}}",
     description: "Lowercase a wrapped block",
   },
+  {
+    category: "Formatting",
+    syntax: '{{#if char == "Name"}}...{{else}}...{{/if}}',
+    description: "Conditional block; supports ==, !=, contains, and straight or typographic quotes",
+  },
   { category: "Formatting", syntax: "{{noop}}", description: "No-op placeholder removed from output" },
   { category: "Formatting", syntax: "{{// comment}}", description: "Inline author comment removed from output" },
   {
@@ -128,11 +133,39 @@ export const SUPPORTED_MACROS: readonly SupportedMacroDefinition[] = [
   },
 ];
 
+function macroContextForCharacterProfile(
+  profile: NonNullable<MacroContext["characterProfiles"]>[number],
+  base?: MacroContext,
+): MacroContext {
+  return {
+    user: base?.user ?? "User",
+    char: profile.name,
+    characters: base?.characters ?? [profile.name],
+    characterProfiles: base?.characterProfiles ?? [profile],
+    variables: base?.variables ?? {},
+    lastInput: base?.lastInput,
+    chatId: base?.chatId,
+    model: base?.model,
+    agentData: base?.agentData,
+    personaFields: base?.personaFields,
+    characterFields: {
+      description: profile.description ?? "",
+      personality: profile.personality ?? "",
+      backstory: profile.backstory ?? "",
+      appearance: profile.appearance ?? "",
+      scenario: profile.scenario ?? "",
+      example: profile.example ?? "",
+    },
+  };
+}
+
 function resolveCharacterScopedMacros(
   template: string,
   profile: NonNullable<MacroContext["characterProfiles"]>[number],
+  baseContext?: MacroContext,
 ): string {
-  return template
+  const scoped = resolveConditionalBlocks(template, macroContextForCharacterProfile(profile, baseContext));
+  return scoped
     .replace(/\{\{char(?:Name)?\}\}/gi, profile.name)
     .replace(/\{\{description\}\}/gi, profile.description ?? "")
     .replace(/\{\{personality\}\}/gi, profile.personality ?? "")
@@ -179,7 +212,7 @@ function expandBracketedCharacterBlocks(template: string, ctx: MacroContext): st
     changed = true;
     expandedLines.push(
       ...profiles
-        .map((profile) => resolveCharacterScopedMacros(block, profile))
+        .map((profile) => resolveCharacterScopedMacros(block, profile, ctx))
         .join("\n")
         .split("\n"),
     );
@@ -242,6 +275,218 @@ function replaceBalancedMacros(
       result += "{{";
       index = start + 2;
     }
+  }
+
+  return result;
+}
+
+function quoteKind(value?: string): "single" | "double" | null {
+  if (!value) return null;
+  if (/["\u201c\u201d\u201e\u201f]/u.test(value)) return "double";
+  if (/['\u2018\u2019\u201a\u201b]/u.test(value)) return "single";
+  return null;
+}
+
+function stripOuterQuotes(value: string): string | null {
+  const trimmed = value.trim();
+  if (trimmed.length < 2) return null;
+  const openingKind = quoteKind(trimmed[0]);
+  if (!openingKind || quoteKind(trimmed.at(-1)) !== openingKind) return null;
+  return trimmed
+    .slice(1, -1)
+    .replace(/\\(["'\u2018\u2019\u201a\u201b\u201c\u201d\u201e\u201f\\])/g, "$1")
+    .replace(/\\n/g, "\n");
+}
+
+function normalizeConditionKey(value: string): string {
+  return value.trim().replace(/^@/, "").toLowerCase();
+}
+
+function resolveConditionalOperand(raw: string, ctx: MacroContext): string {
+  const quoted = stripOuterQuotes(raw);
+  if (quoted !== null) return quoted.includes("{{") ? resolveMacros(quoted, ctx, { trimResult: false }) : quoted;
+
+  const token = raw.trim();
+  if (token.includes("{{")) return resolveMacros(token, ctx, { trimResult: false });
+
+  const normalized = normalizeConditionKey(token);
+  switch (normalized) {
+    case "char":
+    case "charname":
+    case "character":
+    case "speaker":
+      return ctx.char;
+    case "user":
+    case "username":
+      return ctx.user;
+    case "characters":
+      return ctx.characters.join(", ");
+    case "input":
+      return ctx.lastInput ?? "";
+    case "model":
+      return ctx.model ?? "";
+    case "chatid":
+      return ctx.chatId ?? "";
+    case "description":
+      return ctx.characterFields?.description ?? "";
+    case "personality":
+      return ctx.characterFields?.personality ?? "";
+    case "backstory":
+      return ctx.characterFields?.backstory ?? "";
+    case "appearance":
+      return ctx.characterFields?.appearance ?? "";
+    case "scenario":
+      return ctx.characterFields?.scenario ?? "";
+    case "example":
+      return ctx.characterFields?.example ?? "";
+    default:
+      if (/^var[:.]/i.test(token)) {
+        const name = token.replace(/^var[:.]/i, "").trim();
+        return ctx.variables[name] ?? "";
+      }
+      return ctx.variables[token] ?? token;
+  }
+}
+
+function parseConditionExpression(condition: string): { left: string; operator: string; right?: string } {
+  const match = condition.match(
+    /^(.+?)\s*(==|!=|=|is\s+not|is|not\s+contains|not\s+includes|contains|includes)\s*(.+)$/i,
+  );
+  if (!match) return { left: condition.trim(), operator: "truthy" };
+  return {
+    left: match[1]?.trim() ?? "",
+    operator: (match[2] ?? "").toLowerCase().replace(/\s+/g, " "),
+    right: match[3]?.trim() ?? "",
+  };
+}
+
+function compareConditionValues(left: string, operator: string, right: string): boolean {
+  const leftNormalized = left.trim().toLowerCase();
+  const rightNormalized = right.trim().toLowerCase();
+  switch (operator) {
+    case "=":
+    case "==":
+    case "is":
+      return leftNormalized === rightNormalized;
+    case "!=":
+    case "is not":
+      return leftNormalized !== rightNormalized;
+    case "contains":
+    case "includes":
+      return leftNormalized.includes(rightNormalized);
+    case "not contains":
+    case "not includes":
+      return !leftNormalized.includes(rightNormalized);
+    default:
+      return false;
+  }
+}
+
+function evaluateCondition(condition: string, ctx: MacroContext): boolean {
+  const parsed = parseConditionExpression(condition);
+  const left = resolveConditionalOperand(parsed.left, ctx);
+  if (parsed.operator === "truthy") return left.trim().length > 0 && !/^(false|0|no|off|null|undefined)$/i.test(left);
+  const right = resolveConditionalOperand(parsed.right ?? "", ctx);
+  return compareConditionValues(left, parsed.operator, right);
+}
+
+function readConditionalTag(input: string, start: number): { body: string; end: number } | null {
+  if (input[start] !== "{" || input[start + 1] !== "{") return null;
+  const end = findBalancedMacroEnd(input, start);
+  if (end === -1) return null;
+  return { body: input.slice(start + 2, end - 2).trim(), end };
+}
+
+function findConditionalStart(
+  input: string,
+  fromIndex: number,
+): { index: number; end: number; condition: string } | null {
+  let start = input.indexOf("{{", fromIndex);
+  while (start !== -1) {
+    const tag = readConditionalTag(input, start);
+    if (tag) {
+      const match = tag.body.match(/^#if\b([\s\S]*)$/i);
+      if (match) {
+        return { index: start, end: tag.end, condition: (match[1] ?? "").trim() };
+      }
+      start = input.indexOf("{{", tag.end);
+      continue;
+    }
+    start = input.indexOf("{{", start + 2);
+  }
+
+  return null;
+}
+
+function findConditionalEnd(
+  input: string,
+  contentStart: number,
+): { elseStart: number | null; elseEnd: number | null; endStart: number; endEnd: number } | null {
+  let depth = 1;
+  let elseStart: number | null = null;
+  let elseEnd: number | null = null;
+
+  let start = input.indexOf("{{", contentStart);
+  while (start !== -1) {
+    const tag = readConditionalTag(input, start);
+    if (!tag) {
+      start = input.indexOf("{{", start + 2);
+      continue;
+    }
+
+    const body = tag.body.toLowerCase();
+    if (/^#if\b/.test(body)) {
+      depth += 1;
+      start = input.indexOf("{{", tag.end);
+      continue;
+    }
+    if (body === "/if") {
+      depth -= 1;
+      if (depth === 0) {
+        return { elseStart, elseEnd, endStart: start, endEnd: tag.end };
+      }
+      start = input.indexOf("{{", tag.end);
+      continue;
+    }
+    if (body === "else" && depth === 1 && elseStart === null) {
+      elseStart = start;
+      elseEnd = tag.end;
+    }
+    start = input.indexOf("{{", tag.end);
+  }
+
+  return null;
+}
+
+function resolveConditionalBlocks(input: string, ctx: MacroContext): string {
+  let result = "";
+  let index = 0;
+
+  while (index < input.length) {
+    const startMatch = findConditionalStart(input, index);
+    if (!startMatch) {
+      result += input.slice(index);
+      break;
+    }
+
+    const blockStart = startMatch.index;
+    const condition = startMatch.condition;
+    const contentStart = startMatch.end;
+    const blockEnd = findConditionalEnd(input, contentStart);
+    if (!blockEnd) {
+      result += input.slice(index, contentStart);
+      index = contentStart;
+      continue;
+    }
+
+    const truthy = input.slice(contentStart, blockEnd.elseStart ?? blockEnd.endStart);
+    const falsy =
+      blockEnd.elseStart === null ? "" : input.slice(blockEnd.elseEnd ?? blockEnd.endStart, blockEnd.endStart);
+    const selected = evaluateCondition(condition, ctx) ? truthy : falsy;
+
+    result += input.slice(index, blockStart);
+    result += resolveConditionalBlocks(selected, ctx);
+    index = blockEnd.endEnd;
   }
 
   return result;
@@ -373,6 +618,7 @@ function pickWeightedRandomChoice(choices: string[]): string {
  *  - {{banned "text"}} — content filter (removed for now)
  *  - {{uppercase}}...{{/uppercase}} — convert to uppercase
  *  - {{lowercase}}...{{/lowercase}} — convert to lowercase
+ *  - {{#if char == "Name"}}...{{else}}...{{/if}} - conditional block
  */
 export function resolveMacros(template: string, ctx: MacroContext, options: ResolveMacroOptions = {}): string {
   let result = template;
@@ -391,6 +637,7 @@ export function resolveMacros(template: string, ctx: MacroContext, options: Reso
 
   // ── Multi-character bracket blocks — expand before global substitutions ──
   result = expandBracketedCharacterBlocks(result, ctx);
+  result = resolveConditionalBlocks(result, ctx);
 
   // ── No-op & banned ──
   result = result.replace(/\{\{noop\}\}/gi, "");

--- a/src/engine/shared/macros/macro-engine.ts
+++ b/src/engine/shared/macros/macro-engine.ts
@@ -161,6 +161,7 @@ function macroContextForCharacterProfile(
     model: base?.model,
     agentData: base?.agentData,
     personaFields: base?.personaFields,
+    timeZone: base?.timeZone,
     characterFields: {
       description: profile.description ?? "",
       personality: profile.personality ?? "",
@@ -357,19 +358,20 @@ function resolveConditionalOperand(raw: string, ctx: MacroContext): string {
         const name = token.replace(/^var[:.]/i, "").trim();
         return ctx.variables[name] ?? "";
       }
-      return ctx.variables[token] ?? token;
+      return ctx.variables[token] ?? "";
   }
 }
 
 function parseConditionExpression(condition: string): { left: string; operator: string; right?: string } {
-  const match = condition.match(
-    /^(.+?)\s*(==|!=|=|is\s+not|is|not\s+contains|not\s+includes|contains|includes)\s*(.+)$/i,
-  );
-  if (!match) return { left: condition.trim(), operator: "truthy" };
+  const symbolicMatch = condition.match(/^(.+?)\s*(==|!=|=)\s*(.+)$/i);
+  const wordMatch =
+    symbolicMatch ??
+    condition.match(/^(.+?)\s+(is\s+not|not\s+contains|not\s+includes|contains|includes|is)\s+(.+)$/i);
+  if (!wordMatch) return { left: condition.trim(), operator: "truthy" };
   return {
-    left: match[1]?.trim() ?? "",
-    operator: (match[2] ?? "").toLowerCase().replace(/\s+/g, " "),
-    right: match[3]?.trim() ?? "",
+    left: wordMatch[1]?.trim() ?? "",
+    operator: (wordMatch[2] ?? "").toLowerCase().replace(/\s+/g, " "),
+    right: wordMatch[3]?.trim() ?? "",
   };
 }
 


### PR DESCRIPTION
## Linked issue

Closes #1326

## Why this change

- The refactor macro engine regressed from v1.6.1 by dropping conditional prompt block support, so prompt authors could not use `{{#if ...}}...{{else}}...{{/if}}` parity behavior.

## What changed

- Added conditional prompt block resolution for truthy checks, `==`, `!=`, `=`, `is`, `is not`, `contains`, `includes`, and negative contains/includes forms.
- Added straight and typographic quote handling, nested conditional block support, nested macro operands in condition expressions, and selected-branch-only macro side effects.
- Preserved malformed conditional openers while continuing to resolve later valid blocks.
- Evaluated character conditionals per profile inside grouped character bracket expansion.
- Addressed review findings by preserving caller `timeZone` in per-character macro contexts and making unset bare conditional identifiers evaluate falsy.
- Added focused macro engine tests covering normal, nested, malformed, timezone, missing-variable, and negative-control parser behavior.

## Refactor impact

Primary owner:

- `src/engine/shared/macros`

Impact areas reviewed:

- Prompt macro resolution used by generation and prompt assembly.
- Character-scoped group prompt expansion.
- Variable side effects inside selected conditional branches.
- Malformed conditional and unknown hash-macro parser failure paths.
- Caller timezone propagation into grouped character conditional operands.

Boundary notes:

- Engine-only deterministic macro behavior.
- No React, Zustand, shared API, Tauri/Rust, storage, provider, or remote-runtime boundary touched by the conditional macro fix.

Pressure points touched:

- Shared macro engine only.
- No ModeSurface, GameSurface, shared mode UI, Tauri command registration, or import modules touched by the conditional macro fix.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->

- [ ] `pnpm check` passes locally
- [x] `pnpm typecheck` passes locally
- [x] `pnpm build` passes locally
- [x] `pnpm check:architecture` passes locally
- [x] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app/runtime, step by step. If an AI agent filled this out, verify it yourself before ticking boxes. -->

Agent-run validation after addressing CodeRabbit comments:

- `pnpm vitest run src/engine/shared/macros/macro-engine.test.ts --pool threads --maxWorkers 1 --no-file-parallelism` passed: 1 file, 15 tests.
- `pnpm vitest run src/engine/generation/prompt-assembly.test.ts --pool threads --maxWorkers 1 --no-file-parallelism` passed: 1 file, 13 tests.
- `pnpm vitest run --pool threads --maxWorkers 1 --no-file-parallelism` passed: 21 files, 115 tests.
- `pnpm typecheck` passed.
- `pnpm check:architecture` passed.
- `pnpm build` passed. Vite emitted existing chunk/dynamic-import warnings, but exited successfully.
- `git diff --check` passed; Git reported CRLF normalization warnings only.

Not run:

- `pnpm check`, Rust checks, browser/Tauri manual QA, Playwright, and remote-runtime smoke. This patch is engine-only macro parsing with no Rust, UI, or remote-runtime boundary changes.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

- Active `refactor` branch has no `CHANGELOG.md`; no changelog entry was added.
- No developer docs change was made. The in-code supported macro catalog now lists conditional blocks.

## UI evidence

<!-- Add before/after screenshots or recordings for visible UI changes. -->

N/A; engine-only macro parser behavior.