### PR TITLE
Fix Chibi Professor Mari setting

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -4,6 +4,7 @@ import { AppShell } from "./shell/AppShell";
 import { ModalRenderer } from "./shell/ModalRenderer";
 import { CustomThemeInjector } from "./providers/CustomThemeInjector";
 import { AppDialogRenderer } from "../shared/components/ui/AppDialogRenderer";
+import { ChibiProfessorMariEasterEgg } from "../shared/components/ui/ChibiProfessorMariEasterEgg";
 import { fontsApi } from "../shared/api/settings-assets-api";
 import { fontFileUrlFromPath } from "../shared/api/local-file-api";
 import { useUIStore } from "../shared/stores/ui.store";
@@ -120,6 +121,7 @@ export function App() {
       <AppShell />
       <ModalRenderer />
       <AppDialogRenderer />
+      <ChibiProfessorMariEasterEgg />
       <Toaster
         position="bottom-right"
         theme={theme}

--- a/src/features/shell/settings/components/SettingsPanel.tsx
+++ b/src/features/shell/settings/components/SettingsPanel.tsx
@@ -730,6 +730,8 @@ function GeneralSettings() {
   const setSpeechToTextEnabled = useUIStore((s) => s.setSpeechToTextEnabled);
   const spotifyPlayerEnabled = useUIStore((s) => s.spotifyPlayerEnabled);
   const setSpotifyPlayerEnabled = useUIStore((s) => s.setSpotifyPlayerEnabled);
+  const chibiProfessorMariEnabled = useUIStore((s) => s.chibiProfessorMariEnabled);
+  const setChibiProfessorMariEnabled = useUIStore((s) => s.setChibiProfessorMariEnabled);
   const intuitiveSwipeNavigation = useUIStore((s) => s.intuitiveSwipeNavigation);
   const setIntuitiveSwipeNavigation = useUIStore((s) => s.setIntuitiveSwipeNavigation);
   const intuitiveSwipeRerollLatest = useUIStore((s) => s.intuitiveSwipeRerollLatest);
@@ -841,6 +843,13 @@ function GeneralSettings() {
         checked={spotifyPlayerEnabled}
         onChange={setSpotifyPlayerEnabled}
         help="Shows a compact Spotify player in the top bar on desktop and as a draggable floating widget on mobile. Requires the Spotify DJ agent to be connected."
+      />
+
+      <ToggleSetting
+        label="Chibi Professor Mari visits"
+        checked={chibiProfessorMariEnabled}
+        onChange={setChibiProfessorMariEnabled}
+        help="Allows the rare Chibi Professor Mari scroll toast to appear. Turn this off to prevent the easter egg from registering while you use the app."
       />
 
       {/* Streaming Speed */}

--- a/src/shared/components/ui/ChibiProfessorMariEasterEgg.tsx
+++ b/src/shared/components/ui/ChibiProfessorMariEasterEgg.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import { toast } from "sonner";
+import { useUIStore } from "../../stores/ui.store";
 
 const CHIBI_PROFESSOR_MARI_IMAGE = "/sprites/mari/chibi-professor-mari.png";
 const CHIBI_PROFESSOR_MARI_SEEN_KEY = "marinara:chibi-professor-mari-toast-seen";
@@ -51,7 +52,11 @@ function showChibiProfessorMariToast() {
 }
 
 export function ChibiProfessorMariEasterEgg() {
+  const enabled = useUIStore((state) => state.chibiProfessorMariEnabled);
+
   useEffect(() => {
+    if (!enabled) return;
+
     let seen = hasSeenChibiProfessorMari();
     let lastRollAt = 0;
 
@@ -74,7 +79,7 @@ export function ChibiProfessorMariEasterEgg() {
     return () => {
       document.removeEventListener("scroll", handleScroll, scrollOptions);
     };
-  }, []);
+  }, [enabled]);
 
   return null;
 }

--- a/src/shared/stores/ui.store.ts
+++ b/src/shared/stores/ui.store.ts
@@ -161,6 +161,7 @@ export const useUIStore = create<UIState>()(
       trimIncompleteModelOutput: false,
       speechToTextEnabled: false,
       spotifyPlayerEnabled: false,
+      chibiProfessorMariEnabled: true,
       remoteRuntimeUrl: "",
       spotifyMobileWidgetCollapsed: true,
       spotifyMobileWidgetPosition: { x: 16, y: 96 },
@@ -410,6 +411,7 @@ export const useUIStore = create<UIState>()(
       setTrimIncompleteModelOutput: (v) => set({ trimIncompleteModelOutput: v }),
       setSpeechToTextEnabled: (v) => set({ speechToTextEnabled: v }),
       setSpotifyPlayerEnabled: (v) => set({ spotifyPlayerEnabled: v }),
+      setChibiProfessorMariEnabled: (v) => set({ chibiProfessorMariEnabled: v }),
       setRemoteRuntimeUrl: (v) => set({ remoteRuntimeUrl: v.trim() }),
       setSpotifyMobileWidgetCollapsed: (v) => set({ spotifyMobileWidgetCollapsed: v }),
       setSpotifyMobileWidgetPosition: (position) =>

--- a/src/shared/stores/ui/model.ts
+++ b/src/shared/stores/ui/model.ts
@@ -324,6 +324,8 @@ export interface UIState {
   speechToTextEnabled: boolean;
   /** When true, show the global Spotify mini player in the app chrome. */
   spotifyPlayerEnabled: boolean;
+  /** When true, allow the rare Chibi Professor Mari scroll toast to register. */
+  chibiProfessorMariEnabled: boolean;
   /** Optional remote Rust runtime URL. Blank uses the embedded Tauri backend. */
   remoteRuntimeUrl: string;
   /** Mobile Spotify widget collapsed state. */
@@ -526,6 +528,7 @@ export interface UIState {
   setTrimIncompleteModelOutput: (v: boolean) => void;
   setSpeechToTextEnabled: (v: boolean) => void;
   setSpotifyPlayerEnabled: (v: boolean) => void;
+  setChibiProfessorMariEnabled: (v: boolean) => void;
   setRemoteRuntimeUrl: (v: string) => void;
   setSpotifyMobileWidgetCollapsed: (v: boolean) => void;
   setSpotifyMobileWidgetPosition: (position: FloatingWidgetPosition) => void;

--- a/src/shared/stores/ui/persistence.ts
+++ b/src/shared/stores/ui/persistence.ts
@@ -105,6 +105,7 @@ export function partializeUiState(state: UIState) {
     trimIncompleteModelOutput: state.trimIncompleteModelOutput,
     speechToTextEnabled: state.speechToTextEnabled,
     spotifyPlayerEnabled: state.spotifyPlayerEnabled,
+    chibiProfessorMariEnabled: state.chibiProfessorMariEnabled,
     remoteRuntimeUrl: state.remoteRuntimeUrl,
     spotifyMobileWidgetCollapsed: state.spotifyMobileWidgetCollapsed,
     spotifyMobileWidgetPosition: state.spotifyMobileWidgetPosition,


### PR DESCRIPTION
## Linked issue

Closes #1361

## Why this change

- Restores the v1.6.1-style persistent setting for disabling/enabling rare Chibi Professor Mari visits.
- Prevents the scroll easter egg from registering when the user has disabled it.

## What changed

- Added persisted `chibiProfessorMariEnabled` UI state with a default of `true`.
- Added a General settings toggle for Chibi Professor Mari visits.
- Mounted the existing easter-egg component at the app shell level and gated its scroll listener by the persisted setting.

## Refactor impact

Primary owner:

- App shell and shared UI state.

Impact areas reviewed:

- App startup composition, General settings, UI store model/defaults/persistence, and Chibi Professor Mari toast listener.

Boundary notes:

- UI-only change. No engine, shared API, Tauri, Rust, or remote-runtime boundary changes.

Pressure points touched:

- `src/app/App.tsx`
- `src/features/shell/settings/components/SettingsPanel.tsx`
- `src/shared/components/ui/ChibiProfessorMariEasterEgg.tsx`
- `src/shared/stores/ui.*`

## Validation

- [ ] `pnpm check` passes locally
- [x] `pnpm typecheck` passes locally
- [x] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Not manually verified in the running app. Code proof: when `chibiProfessorMariEnabled` is false, `ChibiProfessorMariEasterEgg` returns before registering the document scroll listener; toggling it back to true re-registers through the effect dependency.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- None captured.
