### PR TITLE
Fix inactive group chat characters

### DIFF
--- a/src/engine/contracts/types/chat.ts
+++ b/src/engine/contracts/types/chat.ts
@@ -165,6 +165,8 @@ export interface ChatMetadata {
   groupSpeakerColors?: boolean;
   /** Group individual mode response order: "sequential" or "smart" (agent-decided) */
   groupResponseOrder?: GroupResponseOrder;
+  /** Character IDs attached to this chat but muted/excluded from generation. */
+  inactiveCharacterIds?: string[];
   /** Characters with visible roleplay sprites enabled for this chat. */
   spriteCharacterIds?: string[];
   /** Which sprite file families the roleplay Expression Engine may display. */

--- a/src/engine/generation/active-characters.ts
+++ b/src/engine/generation/active-characters.ts
@@ -1,0 +1,32 @@
+import { parseRecord, readString, stringArray, type JsonRecord } from "./runtime-records";
+
+/** Character IDs muted for this chat. They remain attached to the chat, but are excluded from generation. */
+export function inactiveCharacterIds(chat: JsonRecord): Set<string> {
+  return new Set(
+    stringArray(parseRecord(chat.metadata).inactiveCharacterIds)
+      .map((id) => id.trim())
+      .filter(Boolean),
+  );
+}
+
+export function activeCharacterIds(chat: JsonRecord): string[] {
+  const inactiveIds = inactiveCharacterIds(chat);
+  return stringArray(chat.characterIds).filter((id) => !inactiveIds.has(id));
+}
+
+export function assertRequestedCharacterIsActive(chat: JsonRecord, characterId: unknown): void {
+  const requestedId = readString(characterId).trim();
+  if (!requestedId) return;
+  const allCharacterIds = stringArray(chat.characterIds);
+  if (!allCharacterIds.includes(requestedId)) return;
+  if (inactiveCharacterIds(chat).has(requestedId)) {
+    throw new Error("This character is inactive in this group chat. Mark them active before generating a reply.");
+  }
+}
+
+export function assertChatHasActiveCharacters(chat: JsonRecord): void {
+  const allCharacterIds = stringArray(chat.characterIds);
+  if (allCharacterIds.length > 0 && activeCharacterIds(chat).length === 0) {
+    throw new Error("At least one character must be active before generating a reply.");
+  }
+}

--- a/src/engine/generation/prompt-assembly.test.ts
+++ b/src/engine/generation/prompt-assembly.test.ts
@@ -295,6 +295,40 @@ describe("assembleGenerationPrompt lorebook game-state gates", () => {
   });
 });
 
+describe("assembleGenerationPrompt inactive chat characters", () => {
+  it("excludes inactive chat characters from character prompt context", async () => {
+    const assembly = await assembleGenerationPrompt(
+      storageWithCharacters([
+        {
+          id: "char-active",
+          data: { name: "Aster", description: "ACTIVE CARD SHOULD APPEAR" },
+        },
+        {
+          id: "char-inactive",
+          data: { name: "Briar", description: "INACTIVE CARD SHOULD NOT APPEAR" },
+        },
+      ]),
+      {
+        chat: {
+          id: "group-chat",
+          mode: "roleplay",
+          characterIds: ["char-active", "char-inactive"],
+          metadata: { inactiveCharacterIds: ["char-inactive"] },
+        },
+        storedMessages: [{ role: "user", content: "Who is here?", contextKind: "history" }],
+        connection: {},
+        request: { ...request, promptPresetId: "" },
+        latestUserInput: "Who is here?",
+      },
+    );
+
+    const prompt = assembly.messages.map((message) => message.content).join("\n\n");
+    expect(assembly.characters.map((character) => character.id)).toEqual(["char-active"]);
+    expect(prompt).toContain("ACTIVE CARD SHOULD APPEAR");
+    expect(prompt).not.toContain("INACTIVE CARD SHOULD NOT APPEAR");
+  });
+});
+
 describe("assembleGenerationPrompt conversation scene awareness gates", () => {
   it("does not inject prior scene summaries when conversation cross-chat awareness and memory recall are off", async () => {
     const assembly = await assembleGenerationPrompt(storageWithSections([]), {

--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -10,6 +10,7 @@ import { resolveMacros, type MacroContext } from "../shared/macros/macro-engine"
 import { normalizeUserTimeZone } from "../shared/time/timezone";
 import type { GameActiveState, GameCampaignPlan, GameMap, GameNpc, HudWidget, SessionSummary } from "../contracts/types/game";
 import { buildGmFormatReminder, buildGmSystemPrompt, type GmPromptContext } from "../modes/game/prompts/gm-prompts";
+import { activeCharacterIds } from "./active-characters";
 import { buildGenerationPromptPresetCandidates } from "./prompt-preset-selection";
 import {
   bySortOrder,
@@ -174,7 +175,7 @@ function isRpgStats(value: unknown): GenerationPersonaContext["rpgStats"] | unde
 }
 
 async function loadCharacters(storage: StorageGateway, chat: JsonRecord): Promise<GenerationCharacterContext[]> {
-  const ids = stringArray(chat.characterIds);
+  const ids = activeCharacterIds(chat);
   const rows = await Promise.all(ids.map((id) => storage.get<JsonRecord>("characters", id)));
   return rows.filter(isRecord).map(loadCharacterContext);
 }

--- a/src/engine/generation/start-generation.test.ts
+++ b/src/engine/generation/start-generation.test.ts
@@ -132,6 +132,20 @@ describe("startGeneration concluded roleplay guard", () => {
     await expect(retryGenerationAgents(deps, { chatId: "chat-1" })).rejects.toThrow("This scene is concluded.");
   });
 
+  it("rejects manual replies for inactive group characters before saving user messages", async () => {
+    const { deps, createChatMessage } = depsForChat({
+      id: "chat-1",
+      mode: "roleplay",
+      characterIds: ["char-active", "char-muted"],
+      metadata: { inactiveCharacterIds: ["char-muted"] },
+    });
+
+    const stream = startGeneration(deps, { chatId: "chat-1", forCharacterId: "char-muted" });
+
+    await expect(stream.next()).rejects.toThrow("This character is inactive");
+    expect(createChatMessage).not.toHaveBeenCalled();
+  });
+
   it("does not block non-roleplay chats that have concluded scene metadata", async () => {
     const { deps } = depsForChat({
       id: "chat-1",

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -5,6 +5,7 @@ import type { IntegrationGateway } from "../capabilities/integrations";
 import type { LlmGateway, LlmMessage } from "../capabilities/llm";
 import type { StorageGateway } from "../capabilities/storage";
 import type { GenerationGuideSource } from "../shared/text/generation-guide";
+import { activeCharacterIds, assertChatHasActiveCharacters, assertRequestedCharacterIsActive } from "./active-characters";
 import { createGenerationAgentRuntime } from "./agent-runner";
 import { persistConnectedCommandTags } from "./connected-commands";
 import { llmParameters, loadChatMessages, requireRecord, resolveGenerationConnection } from "./context";
@@ -103,12 +104,14 @@ function inputAttachments(input: StartGenerationInput): PromptAttachment[] {
   return Array.isArray(input.attachments) ? input.attachments.filter(isRecord).map((attachment) => attachment as PromptAttachment) : [];
 }
 
-function assertChatCanGenerate(chat: JsonRecord) {
+function assertChatCanGenerate(chat: JsonRecord, input?: { forCharacterId?: unknown }) {
   const mode = readString(chat.mode || chat.chatMode);
   const metadata = parseRecord(chat.metadata);
   if (mode === "roleplay" && metadata.sceneStatus === "concluded") {
     throw new Error("This scene is concluded. Convert or reopen it before sending new messages.");
   }
+  assertChatHasActiveCharacters(chat);
+  assertRequestedCharacterIsActive(chat, input?.forCharacterId);
 }
 
 function imageAttachmentNotes(attachments: PromptAttachment[]): string {
@@ -385,7 +388,7 @@ async function saveAssistantMessage(args: {
   }
 
   const requestedCharacterId = readString(args.input.forCharacterId).trim();
-  const chatCharacterIdList = stringArray(args.chat.characterIds);
+  const chatCharacterIdList = activeCharacterIds(args.chat);
   const chatCharacterIds = new Set(chatCharacterIdList);
   const characterId =
     requestedCharacterId && (chatCharacterIds.size === 0 || chatCharacterIds.has(requestedCharacterId))
@@ -709,8 +712,8 @@ export async function* startGeneration(
   const chatId = readString(input.chatId).trim();
   if (!chatId) throw new Error("chatId is required");
   const chat = requireRecord(await deps.storage.get("chats", chatId), "Chat");
-  assertChatCanGenerate(chat);
   input = await inputWithStoredGenerationReplay(deps.storage, chatId, input);
+  assertChatCanGenerate(chat, input);
 
   yield { type: "phase", data: "Saving message..." };
   const preparedUserInput = await prepareUserInput(deps.storage, input);

--- a/src/features/modes/conversation/components/ConversationView.tsx
+++ b/src/features/modes/conversation/components/ConversationView.tsx
@@ -316,7 +316,6 @@ export function ConversationView({
   pageCount,
   totalMessageCount,
   characterMap,
-  characterNames,
   personaInfo,
   chatMeta,
   chatName,
@@ -350,13 +349,25 @@ export function ConversationView({
   const streamingCharacterId = useChatStore((s) => s.streamingCharacterId);
   const typingCharacterName = useChatStore((s) => s.typingCharacterName);
   const delayedCharacterInfo = useChatStore((s) => s.delayedCharacterInfo);
+  const inactiveCharacterIdSet = useMemo(
+    () => new Set(Array.isArray(chatMeta.inactiveCharacterIds) ? chatMeta.inactiveCharacterIds : []),
+    [chatMeta.inactiveCharacterIds],
+  );
+  const activeChatCharIds = useMemo(
+    () => chatCharIds.filter((id) => !inactiveCharacterIdSet.has(id)),
+    [chatCharIds, inactiveCharacterIdSet],
+  );
+  const activeCharacterNames = useMemo(
+    () => activeChatCharIds.map((id) => characterMap.get(id)?.name).filter((name): name is string => !!name),
+    [activeChatCharIds, characterMap],
+  );
   const liveTypingName = useMemo(() => {
     if (typingCharacterName) return typingCharacterName;
     if (streamingCharacterId) return characterMap.get(streamingCharacterId)?.name ?? "Character";
-    if (chatCharIds.length === 1) return characterMap.get(chatCharIds[0]!)?.name ?? "Character";
-    if (characterNames.length > 0) return characterNames.join(", ");
+    if (activeChatCharIds.length === 1) return characterMap.get(activeChatCharIds[0]!)?.name ?? "Character";
+    if (activeCharacterNames.length > 0) return activeCharacterNames.join(", ");
     return "Character";
-  }, [characterMap, characterNames, chatCharIds, streamingCharacterId, typingCharacterName]);
+  }, [activeCharacterNames, activeChatCharIds, characterMap, streamingCharacterId, typingCharacterName]);
   const liveTypingVerb = liveTypingName.includes(",") || liveTypingName.includes(" & ") ? "are" : "is";
   const showTypingIndicator =
     isStreaming && !delayedCharacterInfo && (!regenerateMessageId || (!streamBuffer && !thinkingBuffer));
@@ -724,7 +735,7 @@ export function ConversationView({
       }
       void showConversationLocalNotification({
         enabled: uiState.conversationBrowserNotifications,
-        characterName: getAssistantNotificationName(newAssistantMessage, characterMap, characterNames),
+        characterName: getAssistantNotificationName(newAssistantMessage, characterMap, activeCharacterNames),
         tag: `marinara-conversation-${chatId}`,
       });
     }
@@ -775,7 +786,7 @@ export function ConversationView({
     // No cleanup return here — timers are managed via staggerTimersRef and
     // must survive effect re-runs caused by query refetches. Cleanup on
     // unmount is handled by a separate effect below.
-  }, [characterMap, characterNames, chatId, renderedItems]);
+  }, [activeCharacterNames, characterMap, chatId, renderedItems]);
 
   // Clean up stagger timers on unmount only (empty deps = unmount cleanup)
   useEffect(() => {
@@ -1117,17 +1128,17 @@ export function ConversationView({
       {/* ── Input area ── */}
       <ConversationInput
         key={chatId}
-        characterNames={characterNames}
+        characterNames={activeCharacterNames}
         groupResponseOrder={
-          chatMeta.groupResponseOrder === "manual"
-            ? "manual"
-            : chatCharIds.length > 1
-              ? (chatMeta.groupResponseOrder ?? "sequential")
-              : undefined
+          activeChatCharIds.length > 1
+            ? chatMeta.groupResponseOrder === "manual"
+              ? "manual"
+              : (chatMeta.groupResponseOrder ?? "sequential")
+            : undefined
         }
         chatCharacters={
-          chatCharIds.length > 1
-            ? chatCharIds
+          activeChatCharIds.length > 1
+            ? activeChatCharIds
                 .filter((id) => characterMap.has(id))
                 .map((id) => {
                   const info = characterMap.get(id)!;

--- a/src/features/modes/roleplay/components/ChatRoleplaySurface.tsx
+++ b/src/features/modes/roleplay/components/ChatRoleplaySurface.tsx
@@ -6,6 +6,7 @@ import {
   useLayoutEffect,
   useRef,
   useState,
+  useMemo,
   type ComponentProps,
   type ReactNode,
   type RefObject,
@@ -596,7 +597,6 @@ export function ChatRoleplaySurface({
   enabledAgentTypes,
   chatCharIds,
   characterMap,
-  characterNames,
   personaInfo,
   messages,
   msgPayload,
@@ -705,6 +705,18 @@ export function ChatRoleplaySurface({
       };
   const hideEchoChamberOnMobile =
     sidebarOpen || rightPanelOpen || settingsOpen || filesOpen || galleryOpen || wizardOpen;
+  const inactiveCharacterIdSet = useMemo(
+    () => new Set(Array.isArray(chatMeta.inactiveCharacterIds) ? chatMeta.inactiveCharacterIds : []),
+    [chatMeta.inactiveCharacterIds],
+  );
+  const activeChatCharIds = useMemo(
+    () => chatCharIds.filter((id) => !inactiveCharacterIdSet.has(id)),
+    [chatCharIds, inactiveCharacterIdSet],
+  );
+  const activeCharacterNames = useMemo(
+    () => activeChatCharIds.map((id) => characterMap.get(id)?.name).filter((name): name is string => !!name),
+    [activeChatCharIds, characterMap],
+  );
 
   return (
     <div data-component="ChatArea.Roleplay" className="flex flex-1 overflow-hidden">
@@ -1110,13 +1122,13 @@ export function ChatRoleplaySurface({
                   <ChatInput
                     key={activeChatId}
                     mode={isRoleplay ? "roleplay" : "conversation"}
-                    characterNames={characterNames}
+                    characterNames={activeCharacterNames}
                     groupResponseOrder={
-                      chatCharIds.length > 1 && groupChatMode === "individual"
+                      activeChatCharIds.length > 1 && groupChatMode === "individual"
                         ? (chatMeta.groupResponseOrder ?? "sequential")
                         : undefined
                     }
-                    chatCharacters={chatCharIds
+                    chatCharacters={activeChatCharIds
                       .filter((id) => characterMap.has(id))
                       .map((id) => {
                         const info = characterMap.get(id)!;

--- a/src/features/modes/shared/chat-ui/components/ChatSettingsDrawer.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatSettingsDrawer.tsx
@@ -397,6 +397,18 @@ export function ChatSettingsDrawer({
       ? Math.max(0, Math.floor(metadata.lorebookTokenBudget))
       : LIMITS.DEFAULT_LOREBOOK_TOKEN_BUDGET;
   const activeAgentIds = useMemo<string[]>(() => metadata.activeAgentIds ?? [], [metadata.activeAgentIds]);
+  const inactiveCharacterIds = useMemo<string[]>(
+    () =>
+      Array.isArray(metadata.inactiveCharacterIds)
+        ? metadata.inactiveCharacterIds.filter((id: unknown): id is string => typeof id === "string" && id.trim().length > 0)
+        : [],
+    [metadata.inactiveCharacterIds],
+  );
+  const inactiveCharacterIdSet = useMemo(() => new Set(inactiveCharacterIds), [inactiveCharacterIds]);
+  const activeChatCharacterCount = useMemo(
+    () => chatCharIds.filter((id) => !inactiveCharacterIdSet.has(id)).length,
+    [chatCharIds, inactiveCharacterIdSet],
+  );
   const activeToolIds: string[] = metadata.activeToolIds ?? [];
   const gameLorebookKeeperLorebook = gameLorebookKeeperLorebookId
     ? ((lorebooks ?? []) as Array<{ id: string; name: string }>).find(
@@ -705,6 +717,10 @@ export function ChatSettingsDrawer({
           onSuccess: () => syncGamePartyMetadata(current),
         },
       );
+      const nextInactiveCharacterIds = inactiveCharacterIds.filter((id) => id !== charId);
+      if (nextInactiveCharacterIds.length !== inactiveCharacterIds.length) {
+        updateMeta.mutate({ id: chat.id, inactiveCharacterIds: nextInactiveCharacterIds });
+      }
       if (spriteCharacterIds.includes(charId)) {
         const nextSpritePlacements = { ...normalizeSpritePlacements(metadata.spritePlacements) };
         delete nextSpritePlacements[charId];
@@ -740,6 +756,18 @@ export function ChatSettingsDrawer({
         },
       );
     }
+  };
+
+  const toggleCharacterGenerationActive = (charId: string) => {
+    const isInactive = inactiveCharacterIdSet.has(charId);
+    if (!isInactive && activeChatCharacterCount <= 1) {
+      toast.info("At least one character must stay active.");
+      return;
+    }
+    const next = isInactive
+      ? inactiveCharacterIds.filter((id) => id !== charId)
+      : Array.from(new Set([...inactiveCharacterIds, charId]));
+    updateMeta.mutate({ id: chat.id, inactiveCharacterIds: next });
   };
 
   const toggleSprite = (charId: string) => {
@@ -2333,6 +2361,8 @@ export function ChatSettingsDrawer({
                     if (!c) return null;
                     const name = charName(c);
                     const title = charTitle(c);
+                    const isInactive = inactiveCharacterIdSet.has(c.id);
+                    const canDeactivate = !isInactive && activeChatCharacterCount <= 1;
                     return (
                       <div key={c.id}>
                         {dropIdx === i && dragIdx !== null && dragIdx !== i && (
@@ -2347,7 +2377,10 @@ export function ChatSettingsDrawer({
                           }}
                           onDragEnd={handleCharDragEnd}
                           className={cn(
-                            "flex items-center gap-2 rounded-lg bg-[var(--primary)]/10 px-2 py-2 ring-1 ring-[var(--primary)]/30 transition-opacity",
+                            "flex items-center gap-2 rounded-lg px-2 py-2 ring-1 transition-opacity",
+                            isInactive
+                              ? "bg-[var(--secondary)] text-[var(--muted-foreground)] ring-[var(--border)]"
+                              : "bg-[var(--primary)]/10 ring-[var(--primary)]/30",
                             dragIdx === i && "opacity-40",
                           )}
                         >
@@ -2388,6 +2421,27 @@ export function ChatSettingsDrawer({
                                 </span>
                               )}
                             </div>
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => toggleCharacterGenerationActive(c.id)}
+                            disabled={canDeactivate}
+                            className={cn(
+                              "rounded-md px-2 py-1 text-[0.625rem] font-medium transition-colors",
+                              isInactive
+                                ? "bg-[var(--muted)] text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+                                : "bg-emerald-500/10 text-emerald-500 hover:bg-emerald-500/15",
+                              canDeactivate && "cursor-not-allowed opacity-50",
+                            )}
+                            title={
+                              isInactive
+                                ? "Mark active for generation"
+                                : canDeactivate
+                                  ? "At least one character must stay active"
+                                  : "Mark inactive for generation"
+                            }
+                          >
+                            {isInactive ? "Inactive" : "Active"}
                           </button>
                           <button
                             onClick={() => toggleCharacter(c.id)}


### PR DESCRIPTION
## Summary
- Add per-chat inactive character tracking for group chats.
- Exclude inactive characters from generation prompt context, reply target pickers, mention suggestions, and fallback assistant attribution.
- Guard direct/manual generation requests so inactive characters cannot be selected until reactivated.

Fixes #1357

## Proof

Core claim:

- Group chats can keep characters attached while marking individual characters inactive, and inactive characters are excluded from generation.

Verification run:

- `pnpm typecheck`
- `pnpm exec vitest run src/engine/generation/prompt-assembly.test.ts src/engine/generation/start-generation.test.ts`
- `pnpm check:architecture`

Evidence:

- Added prompt assembly coverage proving inactive character cards are excluded from assembled context.
- Added start-generation coverage proving manual/direct replies for inactive characters fail before saving messages.
- Architecture check passed with no dependency violations.

Risk coverage:

- Positive rows: active group members remain in prompt context; inactive IDs persist in chat metadata while characters stay attached to the chat.
- Negative controls: inactive character card text does not appear in prompt context; inactive manual target is rejected.
- Untested/manual blockers: no browser UI pass was run for the settings drawer toggle.

Manual verification requested:

- In a group chat, toggle one character to Inactive in Chat Settings, confirm the input picker only offers active characters, then toggle back to Active.

## Notes
- Docs/release notes not updated: this is a narrow parity/QoL behavior fix without a durable architecture change.
