### PR TITLE
Wire main-path tool calling into startGeneration

### DIFF
--- a/src/engine/generation/agent-runner.ts
+++ b/src/engine/generation/agent-runner.ts
@@ -1,4 +1,4 @@
-import { BUILT_IN_TOOLS, type AgentContext, type AgentResult } from "../contracts/types/agent";
+import { type AgentContext, type AgentResult } from "../contracts/types/agent";
 import type { IntegrationGateway } from "../capabilities/integrations";
 import type { LlmGateway, LlmMessage } from "../capabilities/llm";
 import type { StorageGateway } from "../capabilities/storage";
@@ -12,19 +12,26 @@ import type {
 } from "../generation-core/llm/base-provider";
 import { createAgentPipeline, type AgentInjection, type ResolvedAgent } from "../agents-runtime/pipeline/agent-pipeline";
 import type { AgentToolContext } from "../agents-runtime/executor/agent-executor";
-import { appendChatSummaryEntryToMetadata } from "../shared/text/chat-summary-entries";
 import type { GenerationCharacterContext, GenerationPersonaContext } from "./prompt-assembly";
 import {
   boolish,
   hiddenFromAi,
   isRecord,
-  newId,
-  nowIso,
   parseRecord,
-  readNumber,
   readString,
   type JsonRecord,
 } from "./runtime-records";
+import {
+  BUILT_IN_TOOL_MAP,
+  builtInToolDefinition,
+  customToolDefinition,
+  customToolExecutor,
+  executeBuiltInTool,
+  loadCustomTools,
+  normalizeToolCall,
+  stringifyToolResult,
+  type CustomToolRecord,
+} from "./tools-runtime";
 
 export interface GenerationAgentRuntimeInput {
   chat: JsonRecord;
@@ -99,33 +106,6 @@ function llmProvider(llm: LlmGateway, connectionId: string | null): BaseLLMProvi
   };
 }
 
-interface CustomToolRecord extends JsonRecord {
-  name: string;
-  description: string;
-  parametersSchema: unknown;
-  executionType: string;
-  webhookUrl: string | null;
-  staticResult: string | null;
-  enabled: string | boolean;
-}
-
-function normalizeToolCall(value: unknown): LLMToolCall | null {
-  if (!isRecord(value)) return null;
-  const rawFunction = isRecord(value.function) ? value.function : value;
-  const name = readString(rawFunction.name || value.name).trim();
-  if (!name) return null;
-  const args = readString(rawFunction.arguments || value.arguments, "{}");
-  return {
-    id: readString(value.id) || `tool-${name}-${Date.now().toString(36)}`,
-    name,
-    arguments: args,
-    function: {
-      name,
-      arguments: args,
-    },
-  };
-}
-
 function agentSettings(agent: JsonRecord): Record<string, unknown> {
   return parseRecord(agent.settings);
 }
@@ -187,335 +167,6 @@ function chatActiveToolIds(input: GenerationAgentRuntimeInput): Set<string> {
   return stringSet(chatMetadata(input).activeToolIds);
 }
 
-function parseToolParameters(value: unknown): unknown {
-  if (!value) return { type: "object", properties: {} };
-  if (typeof value === "string") {
-    try {
-      return JSON.parse(value);
-    } catch {
-      return { type: "object", properties: {} };
-    }
-  }
-  return value;
-}
-
-function customToolRecord(row: JsonRecord): CustomToolRecord | null {
-  const name = readString(row.name).trim();
-  if (!name || !boolish(row.enabled, false)) return null;
-  const executionType = readString(row.executionType, "static");
-  if (executionType !== "static" && executionType !== "webhook") return null;
-  return {
-    ...row,
-    name,
-    description: readString(row.description),
-    parametersSchema: parseToolParameters(row.parametersSchema),
-    executionType,
-    webhookUrl: readString(row.webhookUrl).trim() || null,
-    staticResult: readString(row.staticResult),
-    enabled: row.enabled as string | boolean,
-  };
-}
-
-async function loadCustomTools(storage: StorageGateway): Promise<Map<string, CustomToolRecord>> {
-  const tools = new Map<string, CustomToolRecord>();
-  for (const row of await storage.list<JsonRecord>("custom-tools")) {
-    const tool = customToolRecord(row);
-    if (tool) tools.set(tool.name, tool);
-  }
-  return tools;
-}
-
-function customToolDefinition(tool: CustomToolRecord): LLMToolDefinition {
-  return {
-    name: tool.name,
-    description: tool.description || `Run custom tool ${tool.name}.`,
-    parameters: tool.parametersSchema,
-  };
-}
-
-const BUILT_IN_TOOL_MAP = new Map(BUILT_IN_TOOLS.map((tool) => [tool.name, tool]));
-
-function builtInToolDefinition(name: string): LLMToolDefinition | null {
-  const tool = BUILT_IN_TOOL_MAP.get(name);
-  if (!tool) return null;
-  return {
-    name: tool.name,
-    description: tool.description,
-    parameters: tool.parameters,
-  };
-}
-
-function stringifyToolResult(value: unknown): string {
-  if (typeof value === "string") return value;
-  if (isRecord(value) && typeof value.result === "string") return value.result;
-  return JSON.stringify(value ?? null);
-}
-
-function toolArguments(call: LLMToolCall): JsonRecord {
-  const raw = call.function?.arguments || call.arguments || "{}";
-  if (typeof raw === "string") return parseRecord(raw);
-  return parseRecord(raw);
-}
-
-function stringArg(args: JsonRecord, key: string, fallback = ""): string {
-  return readString(args[key], fallback).trim();
-}
-
-function numberArg(args: JsonRecord, key: string, fallback: number): number {
-  return readNumber(args[key], fallback);
-}
-
-function stringArrayArg(args: JsonRecord, key: string): string[] {
-  const value = args[key];
-  if (!Array.isArray(value)) return [];
-  return value.map((item) => readString(item).trim()).filter(Boolean);
-}
-
-function toolError(message: string): never {
-  throw new Error(message);
-}
-
-function requireChatId(input: GenerationAgentRuntimeInput): string {
-  const chatId = readString(input.chat.id).trim();
-  if (!chatId) toolError("Tool requires a persisted chat id.");
-  return chatId;
-}
-
-async function updateChatMetadata(
-  storage: StorageGateway,
-  input: GenerationAgentRuntimeInput,
-  updater: (metadata: JsonRecord) => JsonRecord,
-): Promise<JsonRecord> {
-  const chatId = requireChatId(input);
-  const metadata = updater({ ...parseRecord(input.chat.metadata) });
-  await storage.update("chats", chatId, { metadata });
-  input.chat.metadata = metadata;
-  return metadata;
-}
-
-function rollDiceNotation(notation: string) {
-  const match = notation.trim().match(/^(\d*)d(\d+)([+-]\d+)?$/i);
-  if (!match) toolError("Dice notation must look like 1d20, 2d6, or 3d8+2.");
-  const count = Math.max(1, Math.min(100, Number(match[1] || "1")));
-  const sides = Math.max(2, Math.min(1000, Number(match[2])));
-  const modifier = Number(match[3] || "0");
-  const rolls = Array.from({ length: count }, () => Math.floor(Math.random() * sides) + 1);
-  return {
-    notation: `${count}d${sides}${modifier === 0 ? "" : modifier > 0 ? `+${modifier}` : modifier}`,
-    rolls,
-    modifier,
-    total: rolls.reduce((sum, value) => sum + value, 0) + modifier,
-  };
-}
-
-async function searchLorebookTool(storage: StorageGateway, input: GenerationAgentRuntimeInput, args: JsonRecord) {
-  const query = stringArg(args, "query").toLowerCase();
-  if (!query) toolError("query is required.");
-  const category = stringArg(args, "category").toLowerCase();
-  const tokens = query.split(/\s+/).filter((token) => token.length > 1);
-  const rows = await storage.list<JsonRecord>("lorebook-entries").catch(() => []);
-  const activated = input.activatedLorebookEntries.map((entry) => ({
-    id: entry.id,
-    name: entry.name,
-    content: entry.content,
-    tag: entry.tag,
-    source: "activated",
-  }));
-  const stored = rows.map((entry) => ({
-    id: readString(entry.id),
-    name: readString(entry.name || entry.comment || entry.title, "Lorebook entry"),
-    content: readString(entry.content),
-    tag: readString(entry.tag || entry.category || entry.position),
-    source: "stored",
-  }));
-  const seen = new Set<string>();
-  const scored = [...activated, ...stored]
-    .filter((entry) => {
-      if (!entry.id || seen.has(entry.id)) return false;
-      seen.add(entry.id);
-      if (category && !`${entry.name} ${entry.tag}`.toLowerCase().includes(category)) return false;
-      return true;
-    })
-    .map((entry) => {
-      const haystack = `${entry.name} ${entry.tag} ${entry.content}`.toLowerCase();
-      const score =
-        (haystack.includes(query) ? 10 : 0) +
-        tokens.reduce((sum, token) => sum + (haystack.includes(token) ? 1 : 0), 0);
-      return { ...entry, score };
-    })
-    .filter((entry) => entry.score > 0)
-    .sort((a, b) => b.score - a.score)
-    .slice(0, 8)
-    .map((entry) => ({
-      id: entry.id,
-      name: entry.name,
-      tag: entry.tag || null,
-      source: entry.source,
-      score: entry.score,
-      content: entry.content.slice(0, 4000),
-    }));
-  return { query, entries: scored };
-}
-
-async function executeBuiltInTool(
-  deps: Pick<AgentDeps, "storage" | "integrations">,
-  input: GenerationAgentRuntimeInput,
-  agent: JsonRecord,
-  call: LLMToolCall,
-): Promise<unknown> {
-  const { storage, integrations } = deps;
-  const toolName = call.function?.name || call.name;
-  const args = toolArguments(call);
-  const chatId = requireChatId(input);
-
-  switch (toolName) {
-    case "roll_dice": {
-      const notation = stringArg(args, "notation");
-      if (!notation) toolError("notation is required.");
-      return { ...rollDiceNotation(notation), reason: stringArg(args, "reason") || null };
-    }
-    case "update_game_state": {
-      const update = {
-        id: newId("game_state_update"),
-        createdAt: nowIso(),
-        type: stringArg(args, "type"),
-        target: stringArg(args, "target"),
-        key: stringArg(args, "key"),
-        value: stringArg(args, "value"),
-        description: stringArg(args, "description"),
-      };
-      if (!update.type || !update.target || !update.key) toolError("type, target, and key are required.");
-      const metadata = parseRecord(input.chat.metadata);
-      const updates = Array.isArray(metadata.agentGameStateUpdates) ? metadata.agentGameStateUpdates : [];
-      metadata.agentGameStateUpdates = [...updates, update].slice(-100);
-      const gameState = isRecord(input.chat.gameState) ? { ...input.chat.gameState } : {};
-      if (update.type === "location_change") gameState.location = update.value;
-      if (update.type === "time_advance") gameState.time = update.value;
-      await storage.update("chats", chatId, { metadata, gameState });
-      input.chat.metadata = metadata;
-      input.chat.gameState = gameState;
-      return { success: true, update, gameState };
-    }
-    case "set_expression": {
-      const characterName = stringArg(args, "characterName");
-      const expression = stringArg(args, "expression");
-      if (!characterName || !expression) toolError("characterName and expression are required.");
-      const metadata = await updateChatMetadata(storage, input, (current) => {
-        const expressions = parseRecord(current.agentExpressions);
-        expressions[characterName] = expression;
-        return { ...current, agentExpressions: expressions };
-      });
-      return { success: true, characterName, expression, expressions: metadata.agentExpressions };
-    }
-    case "trigger_event": {
-      const event = {
-        id: newId("agent_event"),
-        createdAt: nowIso(),
-        eventType: stringArg(args, "eventType"),
-        description: stringArg(args, "description"),
-        involvedCharacters: stringArrayArg(args, "involvedCharacters"),
-      };
-      if (!event.eventType || !event.description) toolError("eventType and description are required.");
-      await updateChatMetadata(storage, input, (current) => {
-        const events = Array.isArray(current.agentEvents) ? current.agentEvents : [];
-        return { ...current, agentEvents: [...events, event].slice(-100) };
-      });
-      return { success: true, event };
-    }
-    case "search_lorebook":
-      return searchLorebookTool(storage, input, args);
-    case "read_chat_summary":
-      return { summary: (input.chatSummary ?? readString(parseRecord(input.chat.metadata).summary)) || null };
-    case "append_chat_summary": {
-      const text = stringArg(args, "text");
-      if (!text) toolError("text is required.");
-      const now = nowIso();
-      const metadata = parseRecord(input.chat.metadata);
-      const appended = appendChatSummaryEntryToMetadata(
-        metadata,
-        {
-          content: text,
-          origin: "automated",
-          sourceMode: "agent",
-          title: "Agent memory",
-        },
-        { now, createId: () => newId("summary") },
-      );
-      metadata.summaryEntries = appended.entries;
-      metadata.summary = appended.summary;
-      await storage.update("chats", chatId, { metadata });
-      input.chat.metadata = metadata;
-      input.chatSummary = appended.summary;
-      return { success: true, entry: appended.entry, summary: appended.summary };
-    }
-    case "read_chat_variable": {
-      const key = stringArg(args, "key");
-      if (!key) toolError("key is required.");
-      const variables = parseRecord(parseRecord(input.chat.metadata).agentVariables);
-      return { key, value: typeof variables[key] === "string" ? variables[key] : null };
-    }
-    case "write_chat_variable": {
-      const key = stringArg(args, "key");
-      const value = stringArg(args, "value");
-      if (!key) toolError("key is required.");
-      await updateChatMetadata(storage, input, (current) => {
-        const variables = parseRecord(current.agentVariables);
-        variables[key] = value;
-        return { ...current, agentVariables: variables };
-      });
-      return { success: true, key, value };
-    }
-    case "spotify_get_current_playback":
-      return integrations.spotify.player({ agentId: spotifyAgentId(agent) });
-    case "spotify_get_playlists": {
-      const limit = Math.max(1, Math.min(50, Math.trunc(numberArg(args, "limit", 20))));
-      return integrations.spotify.playlists({ agentId: spotifyAgentId(agent), limit });
-    }
-    case "spotify_get_playlist_tracks": {
-      const playlistId = stringArg(args, "playlistId");
-      if (!playlistId) toolError("playlistId is required.");
-      const body: JsonRecord = {
-        agentId: spotifyAgentId(agent),
-        playlistId,
-        query: stringArg(args, "query"),
-        mood: stringArg(args, "mood"),
-        limit: Math.max(1, Math.min(80, Math.trunc(numberArg(args, "candidateLimit", numberArg(args, "limit", 50))))),
-      };
-      const offset = numberArg(args, "offset", Number.NaN);
-      if (Number.isFinite(offset)) body.offset = Math.max(0, Math.trunc(offset));
-      return integrations.spotify.playlistTracks(body);
-    }
-    case "spotify_search":
-      return integrations.spotify.searchTracks({
-        agentId: spotifyAgentId(agent),
-        query: stringArg(args, "query"),
-        limit: Math.max(1, Math.min(50, Math.trunc(numberArg(args, "limit", 10)))),
-      });
-    case "spotify_play": {
-      const uri = stringArg(args, "uri");
-      const uris = stringArrayArg(args, "uris");
-      if (!uri && uris.length === 0) toolError("uri or uris is required.");
-      const body: JsonRecord = { agentId: spotifyAgentId(agent) };
-      if (uris.length > 0) body.uris = uris;
-      else if (uri.startsWith("spotify:track:")) body.uri = uri;
-      else body.contextUri = uri;
-      return integrations.spotify.play(body);
-    }
-    case "spotify_set_volume":
-      return integrations.spotify.volume({
-        agentId: spotifyAgentId(agent),
-        volume: Math.max(0, Math.min(100, Math.trunc(numberArg(args, "volume", 50)))),
-      });
-    default:
-      return null;
-  }
-}
-
-function spotifyAgentId(agent: JsonRecord): string {
-  const settings = agentSettings(agent);
-  return readString(settings.spotifyAgentId).trim() || readString(agent.id).trim() || "spotify";
-}
-
 function buildAgentToolContext(
   deps: Pick<AgentDeps, "storage" | "integrations">,
   input: GenerationAgentRuntimeInput,
@@ -541,12 +192,7 @@ function buildAgentToolContext(
       if (BUILT_IN_TOOL_MAP.has(toolName)) {
         return stringifyToolResult(await executeBuiltInTool(deps, input, agent, call));
       }
-      return stringifyToolResult(
-        await deps.integrations.customTools.execute({
-          toolName,
-          arguments: toolArguments(call),
-        }),
-      );
+      return customToolExecutor(deps.integrations, call);
     },
   };
 }

--- a/src/engine/generation/agent-runner.ts
+++ b/src/engine/generation/agent-runner.ts
@@ -182,7 +182,7 @@ function buildAgentToolContext(
     .filter((tool): tool is LLMToolDefinition => !!tool);
   const selectedCustomTools = selectedNames
     .map((name) => customTools.get(name))
-    .filter((tool): tool is CustomToolRecord => !!tool);
+    .filter((tool): tool is CustomToolRecord => !!tool && !BUILT_IN_TOOL_MAP.has(tool.name));
   if (selectedBuiltIns.length === 0 && selectedCustomTools.length === 0) return undefined;
 
   return {

--- a/src/engine/generation/generation-events.ts
+++ b/src/engine/generation/generation-events.ts
@@ -2,6 +2,8 @@ export type GenerationEvent =
   | { type: "phase"; data: string }
   | { type: "thinking"; data: string }
   | { type: "token"; data: string }
+  | { type: "tool_call"; data: { id?: string; name: string; arguments: string } }
+  | { type: "tool_result"; data: { toolCallId?: string; name: string; result: string; success: boolean } }
   | { type: "user_message"; data: unknown }
   | { type: "assistant_message"; data: unknown }
   | { type: "agent_result"; data: unknown }

--- a/src/engine/generation/main-tool-loop.test.ts
+++ b/src/engine/generation/main-tool-loop.test.ts
@@ -1,0 +1,727 @@
+import { describe, expect, it, vi } from "vitest";
+import type { IntegrationGateway } from "../capabilities/integrations";
+import type { LlmChunk, LlmGateway, LlmRequest } from "../capabilities/llm";
+import type { StorageGateway } from "../capabilities/storage";
+import { startGeneration, type GenerationEngineDeps } from "./start-generation";
+import {
+  buildMainToolDefinitions,
+  executeMainToolCall,
+  type CustomToolRecord,
+} from "./tools-runtime";
+
+// ──────────────────────────────────────────────
+// Stub builders
+// ──────────────────────────────────────────────
+
+interface StubChatOptions {
+  chatMetadata?: Record<string, unknown>;
+  initialMessages?: Array<Record<string, unknown>>;
+  customTools?: Array<Record<string, unknown>>;
+}
+
+interface LlmScript {
+  // Each turn yields the chunks for one stream() invocation.
+  turns: Array<LlmChunk[]>;
+}
+
+function makeStubDeps(
+  options: StubChatOptions & {
+    script: LlmScript;
+    customToolExecuteImpl?: (input: { toolName: string; arguments: unknown }) => Promise<unknown>;
+  },
+) {
+  const chat: Record<string, unknown> = {
+    id: "chat-1",
+    mode: "conversation",
+    connectionId: "connection-1",
+    characterIds: [],
+    metadata: options.chatMetadata ?? {},
+  };
+  const connection = {
+    id: "connection-1",
+    model: "test-model",
+    defaultParameters: {},
+  };
+  const customTools = options.customTools ?? [];
+  const initialMessages =
+    options.initialMessages ?? [{ id: "assistant-1", chatId: "chat-1", role: "assistant", content: "What now?" }];
+
+  const messagesById = new Map(initialMessages.map((message) => [String(message.id), message]));
+  const allMessages = [...initialMessages];
+
+  const streamedRequests: LlmRequest[] = [];
+  let turnIndex = 0;
+  const stream: LlmGateway["stream"] = vi.fn(async function* (request) {
+    streamedRequests.push(request);
+    const chunks = options.script.turns[turnIndex] ?? [];
+    turnIndex++;
+    for (const chunk of chunks) {
+      yield chunk;
+    }
+  });
+
+  const createChatMessage = vi.fn(async (_chatId: string, value: Record<string, unknown>) => {
+    if (value.role === "user") {
+      const saved = { id: "user-1", chatId: "chat-1", ...value };
+      allMessages.push(saved);
+      messagesById.set("user-1", saved);
+      return saved;
+    }
+    const saved = { id: "assistant-2", chatId: "chat-1", ...value };
+    allMessages.push(saved);
+    messagesById.set("assistant-2", saved);
+    return saved;
+  });
+
+  const listChatMessages = vi.fn(async () => [...allMessages]);
+  const updates: Array<{ entity: string; id: string; patch: Record<string, unknown> }> = [];
+  const update = vi.fn(async (entity: string, id: string, patch: Record<string, unknown>) => {
+    updates.push({ entity, id, patch });
+    if (entity === "chats" && id === "chat-1") {
+      Object.assign(chat, patch);
+    }
+    return { id, ...patch };
+  });
+  const customToolsExecute = vi.fn(
+    options.customToolExecuteImpl ?? (async () => ({ ok: true })),
+  );
+
+  const storage: StorageGateway = {
+    get: vi.fn(async (entity: string, id: string) => {
+      if (entity === "chats" && id === "chat-1") return chat;
+      if (entity === "connections" && id === "connection-1") return connection;
+      if (entity === "messages") return messagesById.get(id) ?? null;
+      return null;
+    }),
+    list: vi.fn(async (entity: string) => {
+      if (entity === "custom-tools") return customTools;
+      return [];
+    }),
+    create: vi.fn(async (_entity: string, value: Record<string, unknown>) => value),
+    update,
+    delete: vi.fn(async () => ({ deleted: true })),
+    listChatMessages,
+    createChatMessage,
+    updateChatMessage: vi.fn(async (id: string, value: Record<string, unknown>) => ({ id, ...value })),
+    deleteChatMessage: vi.fn(async () => ({ deleted: true })),
+    patchChatMessageExtra: vi.fn(async (id: string, patch: Record<string, unknown>) => ({ id, ...patch })),
+    addChatMessageSwipe: vi.fn(async () => ({})),
+    patchChatMetadata: vi.fn(async () => ({})),
+    patchChatSummaries: vi.fn(async () => ({})),
+    listChatMemories: vi.fn(async () => []),
+    getWorldState: vi.fn(async () => null),
+    saveTrackerSnapshot: vi.fn(async (_chatId: string, snapshot: Record<string, unknown>) => snapshot),
+    listLorebookEntries: vi.fn(async () => []),
+    createLorebookEntries: vi.fn(async () => []),
+    promptFull: vi.fn(async () => null),
+  } as StorageGateway;
+
+  const integrations: IntegrationGateway = {
+    customTools: { execute: customToolsExecute },
+    spotify: {
+      player: vi.fn(),
+      playlists: vi.fn(),
+      playlistTracks: vi.fn(),
+      searchTracks: vi.fn(),
+      playTrack: vi.fn(),
+      play: vi.fn(),
+      volume: vi.fn(),
+    },
+    haptic: { command: vi.fn(), stopAll: vi.fn() },
+    image: { generate: vi.fn() },
+  } as IntegrationGateway;
+
+  const llm: LlmGateway = {
+    stream,
+    complete: vi.fn(async () => ""),
+    listModels: vi.fn(async () => []),
+  };
+
+  const deps: GenerationEngineDeps = { storage, llm, integrations };
+  return {
+    deps,
+    chat,
+    storage,
+    integrations,
+    streamedRequests,
+    createChatMessage,
+    customToolsExecute,
+    update,
+    updates,
+    allMessages,
+  };
+}
+
+type CollectedEvent = { type: string; data: unknown };
+
+async function collectEvents(
+  gen: AsyncGenerator<{ type: string; data?: unknown }>,
+): Promise<CollectedEvent[]> {
+  const events: CollectedEvent[] = [];
+  for await (const event of gen) {
+    events.push({ type: event.type, data: event.data });
+  }
+  return events;
+}
+
+function toolCallChunk(name: string, args: Record<string, unknown> = {}, id = `call-${name}`): LlmChunk {
+  return {
+    type: "tool_call",
+    data: {
+      id,
+      function: { name, arguments: JSON.stringify(args) },
+    },
+  };
+}
+
+// ──────────────────────────────────────────────
+// Row 1 — Spotify excluded from main path
+// ──────────────────────────────────────────────
+
+describe("row 1 — Spotify tool excluded from main path", () => {
+  it("does NOT include spotify_play in toolDefs even when actively requested", async () => {
+    const { deps } = makeStubDeps({
+      chatMetadata: { enableTools: true, activeToolIds: ["spotify_play"] },
+      script: { turns: [[{ type: "token", text: "no spotify here" }]] },
+    });
+    const built = await buildMainToolDefinitions({
+      chat: {
+        id: "chat-1",
+        metadata: { enableTools: true, activeToolIds: ["spotify_play"] },
+      },
+      storage: deps.storage,
+      integrations: deps.integrations,
+    });
+    // activeToolIds contained only a Spotify tool, which is filtered → null
+    expect(built).toBeNull();
+  });
+
+  it("filters all spotify_* names out when activeToolIds is empty", async () => {
+    const { deps } = makeStubDeps({
+      chatMetadata: { enableTools: true, activeToolIds: [] },
+      script: { turns: [[{ type: "token", text: "ok" }]] },
+    });
+    const built = await buildMainToolDefinitions({
+      chat: { id: "chat-1", metadata: { enableTools: true, activeToolIds: [] } },
+      storage: deps.storage,
+      integrations: deps.integrations,
+    });
+    expect(built).not.toBeNull();
+    const names = built!.toolDefs.map((tool) => tool.name);
+    expect(names.filter((name) => name.startsWith("spotify_"))).toEqual([]);
+  });
+});
+
+// ──────────────────────────────────────────────
+// Row 2 — Infinite tool loop terminates at MAX_MAIN_TOOL_ITERATIONS = 8
+// ──────────────────────────────────────────────
+
+describe("row 2 — infinite tool loop terminates at MAX_MAIN_TOOL_ITERATIONS = 8", () => {
+  it("stops after 8 stream calls and emits the iteration-cap phase event", async () => {
+    // 10 turns of repeated roll_dice — should cap at 8.
+    const turn: LlmChunk[] = [
+      { type: "token", text: "rolling..." },
+      toolCallChunk("roll_dice", { notation: "1d6" }),
+    ];
+    const turns: LlmChunk[][] = Array.from({ length: 10 }, () => turn);
+    const { deps, streamedRequests } = makeStubDeps({
+      chatMetadata: { enableTools: true, activeToolIds: ["roll_dice"] },
+      script: { turns },
+    });
+
+    const events = await collectEvents(
+      startGeneration(deps, {
+        chatId: "chat-1",
+        userMessage: "fight!",
+        impersonateBlockAgents: true,
+      }),
+    );
+
+    expect(streamedRequests).toHaveLength(8);
+    const phaseEvents = events.filter((event) => event.type === "phase");
+    const capPhase = phaseEvents.find(
+      (event) =>
+        typeof event.data === "string" && event.data.includes("Tool-call iteration limit (8)"),
+    );
+    expect(capPhase).toBeTruthy();
+  });
+});
+
+// ──────────────────────────────────────────────
+// Row 3 — Custom-tool failure surfaces as success: false, doesn't escape loop
+// ──────────────────────────────────────────────
+
+describe("row 3 — custom-tool failure surfaces as success: false and does not escape the loop", () => {
+  it("emits tool_result with success: false on executor throw, then continues", async () => {
+    const turns: LlmChunk[][] = [
+      [{ type: "token", text: "trying custom..." }, toolCallChunk("my_tool", { x: 1 })],
+      [{ type: "token", text: "done." }],
+    ];
+    const { deps } = makeStubDeps({
+      chatMetadata: { enableTools: true, activeToolIds: ["my_tool"] },
+      customTools: [
+        {
+          id: "ct-1",
+          name: "my_tool",
+          description: "Broken webhook",
+          parametersSchema: JSON.stringify({ type: "object", properties: {} }),
+          executionType: "webhook",
+          webhookUrl: "https://invalid.example/none",
+          staticResult: null,
+          enabled: true,
+        },
+      ],
+      script: { turns },
+      customToolExecuteImpl: async () => {
+        throw new Error("webhook unreachable");
+      },
+    });
+
+    const events = await collectEvents(
+      startGeneration(deps, {
+        chatId: "chat-1",
+        userMessage: "do it",
+        impersonateBlockAgents: true,
+      }),
+    );
+
+    const toolResultEvents = events.filter((event) => event.type === "tool_result");
+    expect(toolResultEvents).toHaveLength(1);
+    const result = toolResultEvents[0]!.data as { success: boolean; result: string; name: string };
+    expect(result.success).toBe(false);
+    expect(result.name).toBe("my_tool");
+    expect(result.result.length).toBeGreaterThan(0);
+
+    const doneEvent = events.find((event) => event.type === "done");
+    expect(doneEvent).toBeTruthy();
+  });
+});
+
+// ──────────────────────────────────────────────
+// Row 4 — Tool turns NOT persisted as chat messages
+// ──────────────────────────────────────────────
+
+describe("row 4 — tool-call/tool-result turns are NOT persisted as chat messages", () => {
+  it("only persists role=user and role=assistant; never role=tool", async () => {
+    const turns: LlmChunk[][] = [
+      [{ type: "token", text: "rolling..." }, toolCallChunk("roll_dice", { notation: "1d4" })],
+      [{ type: "token", text: "you rolled. final answer." }],
+    ];
+    const { deps, createChatMessage } = makeStubDeps({
+      chatMetadata: { enableTools: true, activeToolIds: ["roll_dice"] },
+      script: { turns },
+    });
+
+    await collectEvents(
+      startGeneration(deps, {
+        chatId: "chat-1",
+        userMessage: "roll",
+        impersonateBlockAgents: true,
+      }),
+    );
+
+    const calls = createChatMessage.mock.calls;
+    const persistedRoles = calls.map(([, value]) => (value as { role: string }).role);
+    expect(persistedRoles).toEqual(["user", "assistant"]);
+    expect(persistedRoles).not.toContain("tool");
+    const assistantCall = calls.find(([, value]) => (value as { role: string }).role === "assistant");
+    expect((assistantCall![1] as { content: string }).content).toBe("rolling...you rolled. final answer.");
+  });
+});
+
+// ──────────────────────────────────────────────
+// Row 5 — enableTools: false produces tools-undefined request + zero tool events
+// ──────────────────────────────────────────────
+
+describe("row 5 — enableTools: false → tools field is undefined and no tool events fire", () => {
+  it("LlmRequest.tools is undefined and stream contains no tool_call / tool_result events", async () => {
+    const turns: LlmChunk[][] = [
+      [
+        { type: "token", text: "hello" },
+        // Even if the model emits a tool_call chunk, with mainTools=null it must NOT propagate
+        toolCallChunk("roll_dice", { notation: "1d6" }),
+      ],
+    ];
+    const { deps, streamedRequests } = makeStubDeps({
+      chatMetadata: { enableTools: false },
+      script: { turns },
+    });
+    const events = await collectEvents(
+      startGeneration(deps, {
+        chatId: "chat-1",
+        userMessage: "hi",
+        impersonateBlockAgents: true,
+      }),
+    );
+
+    expect(streamedRequests).toHaveLength(1);
+    expect(streamedRequests[0]!.tools).toBeUndefined();
+    expect(events.find((event) => event.type === "tool_call")).toBeUndefined();
+    expect(events.find((event) => event.type === "tool_result")).toBeUndefined();
+  });
+});
+
+// ──────────────────────────────────────────────
+// Row 6 — Agent-only tools filtered from main toolDefs
+// ──────────────────────────────────────────────
+
+describe("row 6 — agent-only tool names filtered from main toolDefs", () => {
+  it("returns null when only agent-only tools are requested", async () => {
+    const { deps } = makeStubDeps({
+      chatMetadata: { enableTools: true, activeToolIds: ["read_chat_summary"] },
+      script: { turns: [[{ type: "token", text: "ok" }]] },
+    });
+    const built = await buildMainToolDefinitions({
+      chat: { id: "chat-1", metadata: { enableTools: true, activeToolIds: ["read_chat_summary"] } },
+      storage: deps.storage,
+      integrations: deps.integrations,
+    });
+    expect(built).toBeNull();
+  });
+
+  it("with activeToolIds: [] all four agent-only names are excluded", async () => {
+    const { deps } = makeStubDeps({
+      chatMetadata: { enableTools: true, activeToolIds: [] },
+      script: { turns: [[{ type: "token", text: "ok" }]] },
+    });
+    const built = await buildMainToolDefinitions({
+      chat: { id: "chat-1", metadata: { enableTools: true, activeToolIds: [] } },
+      storage: deps.storage,
+      integrations: deps.integrations,
+    });
+    expect(built).not.toBeNull();
+    const names = built!.toolDefs.map((tool) => tool.name);
+    expect(names).not.toContain("read_chat_summary");
+    expect(names).not.toContain("append_chat_summary");
+    expect(names).not.toContain("read_chat_variable");
+    expect(names).not.toContain("write_chat_variable");
+  });
+});
+
+// ──────────────────────────────────────────────
+// Row 7 — activeToolIds: [] + enableTools: true exposes all built-ins minus agent-only minus spotify, plus customs
+// ──────────────────────────────────────────────
+
+describe("row 7 — empty activeToolIds with enableTools: true exposes the expected set", () => {
+  it("includes all built-ins except agent-only + spotify, and includes enabled customs", async () => {
+    const { deps } = makeStubDeps({
+      chatMetadata: { enableTools: true, activeToolIds: [] },
+      customTools: [
+        {
+          id: "ct-1",
+          name: "weather_lookup",
+          description: "Returns the weather.",
+          parametersSchema: JSON.stringify({ type: "object", properties: {} }),
+          executionType: "static",
+          webhookUrl: null,
+          staticResult: "sunny",
+          enabled: true,
+        },
+        {
+          id: "ct-2",
+          name: "disabled_one",
+          description: "Should not appear",
+          parametersSchema: JSON.stringify({ type: "object", properties: {} }),
+          executionType: "static",
+          webhookUrl: null,
+          staticResult: "x",
+          enabled: false,
+        },
+      ],
+      script: { turns: [[{ type: "token", text: "ok" }]] },
+    });
+    const built = await buildMainToolDefinitions({
+      chat: { id: "chat-1", metadata: { enableTools: true, activeToolIds: [] } },
+      storage: deps.storage,
+      integrations: deps.integrations,
+    });
+    expect(built).not.toBeNull();
+    const names = new Set(built!.toolDefs.map((tool) => tool.name));
+    // Expected built-ins on the main path:
+    expect(names).toContain("roll_dice");
+    expect(names).toContain("update_game_state");
+    expect(names).toContain("set_expression");
+    expect(names).toContain("trigger_event");
+    expect(names).toContain("search_lorebook");
+    // Agent-only must be absent:
+    for (const agentOnly of [
+      "read_chat_summary",
+      "append_chat_summary",
+      "read_chat_variable",
+      "write_chat_variable",
+    ]) {
+      expect(names.has(agentOnly)).toBe(false);
+    }
+    // Spotify must be absent on the main path:
+    for (const spotify of [
+      "spotify_get_current_playback",
+      "spotify_get_playlists",
+      "spotify_get_playlist_tracks",
+      "spotify_search",
+      "spotify_play",
+      "spotify_set_volume",
+    ]) {
+      expect(names.has(spotify)).toBe(false);
+    }
+    // Enabled custom appears, disabled custom does not:
+    expect(names.has("weather_lookup")).toBe(true);
+    expect(names.has("disabled_one")).toBe(false);
+  });
+});
+
+// ──────────────────────────────────────────────
+// Row 8 — Mid-loop abort propagates cleanly, no orphan tool_call without tool_result
+// ──────────────────────────────────────────────
+
+describe("row 8 — mid-loop abort propagates cleanly", () => {
+  it("aborting between turns terminates the loop with matched tool_call/tool_result pairs only", async () => {
+    const controller = new AbortController();
+
+    // Stub stream so that the FIRST turn yields a tool_call and the SECOND turn,
+    // when entered, throws an AbortError because the signal has been triggered
+    // by the consumer's executeMainToolCall path. We simulate the signal-triggered
+    // pre-yield by checking signal.aborted at the top of each stream() call.
+    let callCount = 0;
+    const turns: LlmChunk[][] = [
+      [{ type: "token", text: "rolling..." }, toolCallChunk("roll_dice", { notation: "1d4" })],
+      [{ type: "token", text: "should-never-reach" }],
+    ];
+
+    const stubChat: Record<string, unknown> = {
+      id: "chat-1",
+      mode: "conversation",
+      connectionId: "connection-1",
+      characterIds: [],
+      metadata: { enableTools: true, activeToolIds: ["roll_dice"] },
+    };
+    const connection = { id: "connection-1", model: "test-model", defaultParameters: {} };
+    const allMessages: Array<Record<string, unknown>> = [
+      { id: "assistant-1", chatId: "chat-1", role: "assistant", content: "?" },
+    ];
+    const messagesById = new Map(allMessages.map((message) => [String(message.id), message]));
+
+    const createChatMessage = vi.fn(async (_chatId: string, value: Record<string, unknown>) => {
+      const id = value.role === "user" ? "user-1" : "assistant-2";
+      const saved = { id, chatId: "chat-1", ...value };
+      allMessages.push(saved);
+      messagesById.set(id, saved);
+      return saved;
+    });
+    const stream: LlmGateway["stream"] = vi.fn(async function* (_request, signal) {
+      callCount++;
+      if (signal?.aborted) {
+        throw Object.assign(new Error("aborted"), { name: "AbortError" });
+      }
+      // After yielding the first turn, abort BEFORE we even enter the second.
+      const chunks = turns[callCount - 1] ?? [];
+      for (const chunk of chunks) {
+        yield chunk;
+      }
+      // Trigger abort once the first turn has fully yielded its chunks.
+      if (callCount === 1) controller.abort();
+    });
+    const storage: StorageGateway = {
+      get: vi.fn(async (entity: string, id: string) => {
+        if (entity === "chats" && id === "chat-1") return stubChat;
+        if (entity === "connections" && id === "connection-1") return connection;
+        if (entity === "messages") return messagesById.get(id) ?? null;
+        return null;
+      }),
+      list: vi.fn(async () => []),
+      create: vi.fn(async (_entity: string, value: Record<string, unknown>) => value),
+      update: vi.fn(async () => ({})),
+      delete: vi.fn(async () => ({ deleted: true })),
+      listChatMessages: vi.fn(async () => [...allMessages]),
+      createChatMessage,
+      updateChatMessage: vi.fn(async () => ({})),
+      deleteChatMessage: vi.fn(async () => ({ deleted: true })),
+      patchChatMessageExtra: vi.fn(async () => ({})),
+      addChatMessageSwipe: vi.fn(async () => ({})),
+      patchChatMetadata: vi.fn(async () => ({})),
+      patchChatSummaries: vi.fn(async () => ({})),
+      listChatMemories: vi.fn(async () => []),
+      getWorldState: vi.fn(async () => null),
+      saveTrackerSnapshot: vi.fn(async (_chatId: string, snapshot: Record<string, unknown>) => snapshot),
+      listLorebookEntries: vi.fn(async () => []),
+      createLorebookEntries: vi.fn(async () => []),
+      promptFull: vi.fn(async () => null),
+    } as StorageGateway;
+    const integrations: IntegrationGateway = {
+      customTools: { execute: vi.fn(async () => ({})) },
+      spotify: {
+        player: vi.fn(),
+        playlists: vi.fn(),
+        playlistTracks: vi.fn(),
+        searchTracks: vi.fn(),
+        playTrack: vi.fn(),
+        play: vi.fn(),
+        volume: vi.fn(),
+      },
+      haptic: { command: vi.fn(), stopAll: vi.fn() },
+      image: { generate: vi.fn() },
+    } as IntegrationGateway;
+    const llm: LlmGateway = {
+      stream,
+      complete: vi.fn(async () => ""),
+      listModels: vi.fn(async () => []),
+    };
+    const deps: GenerationEngineDeps = { storage, llm, integrations };
+
+    const events: CollectedEvent[] = [];
+    let threw: unknown = null;
+    try {
+      for await (const event of startGeneration(
+        deps,
+        { chatId: "chat-1", userMessage: "roll", impersonateBlockAgents: true },
+        controller.signal,
+      )) {
+        events.push({ type: event.type, data: event.data });
+      }
+    } catch (err) {
+      threw = err;
+    }
+
+    // Every emitted tool_call must have a matching tool_result by id.
+    const toolCalls = events.filter((event) => event.type === "tool_call");
+    const toolResults = events.filter((event) => event.type === "tool_result");
+    expect(toolCalls.length).toBe(toolResults.length);
+    const callIds = new Set(
+      toolCalls.map((event) => (event.data as { id: string }).id),
+    );
+    for (const result of toolResults) {
+      expect(callIds.has((result.data as { toolCallId: string }).toolCallId)).toBe(true);
+    }
+    // Aborts may surface as a thrown error from the second stream() call — that's fine.
+    // What matters is no orphan tool_call without a tool_result.
+    expect(callCount).toBeGreaterThanOrEqual(1);
+    // Suppress unused-binding warning on `threw` (recorded for diagnostic clarity).
+    expect(threw === null || threw instanceof Error).toBe(true);
+  });
+});
+
+// ──────────────────────────────────────────────
+// Row 9 — Branch B (directMessages) tool loop matches Branch A behavior
+// ──────────────────────────────────────────────
+
+describe("row 9 — Branch B (directMessages) tool loop matches Branch A behavior", () => {
+  it("directMessages path runs the same multi-turn tool loop and caps at 8 iterations", async () => {
+    // 10 turns of repeated roll_dice with directMessages — should also cap at 8.
+    const turn: LlmChunk[] = [
+      { type: "token", text: "x" },
+      toolCallChunk("roll_dice", { notation: "1d6" }),
+    ];
+    const turns: LlmChunk[][] = Array.from({ length: 10 }, () => turn);
+    const { deps, streamedRequests } = makeStubDeps({
+      chatMetadata: { enableTools: true, activeToolIds: ["roll_dice"] },
+      script: { turns },
+    });
+    const events = await collectEvents(
+      startGeneration(deps, {
+        chatId: "chat-1",
+        messages: [{ role: "user", content: "direct prompt" }],
+        impersonate: true,
+      }),
+    );
+    expect(streamedRequests).toHaveLength(8);
+    const capPhase = events.find(
+      (event) =>
+        event.type === "phase" &&
+        typeof event.data === "string" &&
+        event.data.includes("Tool-call iteration limit (8)"),
+    );
+    expect(capPhase).toBeTruthy();
+
+    // Tool definitions were also passed on the directMessages stream.
+    expect(streamedRequests[0]!.tools).toBeDefined();
+    expect(streamedRequests[0]!.tools!.map((tool) => tool.name)).toContain("roll_dice");
+  });
+});
+
+// ──────────────────────────────────────────────
+// Row 10 — Custom-tool name collision with built-in: built-in wins, no duplicate
+// ──────────────────────────────────────────────
+
+describe("row 10 — custom-tool name collision with built-in: built-in wins, no duplicate", () => {
+  it("toolDefs contains exactly one roll_dice entry when a custom roll_dice is also enabled", async () => {
+    const { deps } = makeStubDeps({
+      chatMetadata: { enableTools: true, activeToolIds: [] },
+      customTools: [
+        {
+          id: "ct-collide",
+          name: "roll_dice",
+          description: "fake roll_dice",
+          parametersSchema: JSON.stringify({ type: "object", properties: {} }),
+          executionType: "static",
+          webhookUrl: null,
+          staticResult: "fake",
+          enabled: true,
+        },
+      ],
+      script: { turns: [[{ type: "token", text: "ok" }]] },
+    });
+    const built = await buildMainToolDefinitions({
+      chat: { id: "chat-1", metadata: { enableTools: true, activeToolIds: [] } },
+      storage: deps.storage,
+      integrations: deps.integrations,
+    });
+    expect(built).not.toBeNull();
+    const rollDiceEntries = built!.toolDefs.filter((tool) => tool.name === "roll_dice");
+    expect(rollDiceEntries).toHaveLength(1);
+    // And the entry retained is the built-in (its description starts with "Roll dice using ...")
+    expect(rollDiceEntries[0]!.description).toMatch(/Roll dice/i);
+  });
+
+  it("executeMainToolCall dispatches to the built-in (not custom) on name collision", async () => {
+    const customTools = new Map<string, CustomToolRecord>([
+      [
+        "roll_dice",
+        {
+          id: "ct-collide",
+          name: "roll_dice",
+          description: "fake",
+          parametersSchema: { type: "object", properties: {} },
+          executionType: "static",
+          webhookUrl: null,
+          staticResult: "fake",
+          enabled: true,
+        } as CustomToolRecord,
+      ],
+    ]);
+    const customExecute = vi.fn(async () => ({ from: "custom" }));
+    const storage = {
+      get: vi.fn(async () => null),
+      list: vi.fn(async () => []),
+      update: vi.fn(async () => ({})),
+    } as unknown as StorageGateway;
+    const integrations = {
+      customTools: { execute: customExecute },
+      spotify: {} as IntegrationGateway["spotify"],
+      haptic: {} as IntegrationGateway["haptic"],
+      image: {} as IntegrationGateway["image"],
+    } as IntegrationGateway;
+
+    const result = await executeMainToolCall({
+      deps: { storage, integrations },
+      input: {
+        chat: { id: "chat-1", metadata: {} },
+        activatedLorebookEntries: [],
+        chatSummary: null,
+      },
+      customTools,
+      call: {
+        id: "call-1",
+        name: "roll_dice",
+        arguments: JSON.stringify({ notation: "1d6" }),
+        function: { name: "roll_dice", arguments: JSON.stringify({ notation: "1d6" }) },
+      },
+    });
+
+    // Custom executor was NOT called — built-in handled it.
+    expect(customExecute).not.toHaveBeenCalled();
+    // The built-in roll_dice returns a JSON-stringified object with notation/rolls/total/reason.
+    const parsed = JSON.parse(result) as { notation: string; rolls: number[]; total: number };
+    expect(parsed.notation).toMatch(/^1d6/);
+    expect(parsed.rolls).toHaveLength(1);
+    expect(typeof parsed.total).toBe("number");
+  });
+});

--- a/src/engine/generation/main-tool-loop.test.ts
+++ b/src/engine/generation/main-tool-loop.test.ts
@@ -6,6 +6,7 @@ import { startGeneration, type GenerationEngineDeps } from "./start-generation";
 import {
   buildMainToolDefinitions,
   executeMainToolCall,
+  normalizeToolCall,
   type CustomToolRecord,
 } from "./tools-runtime";
 
@@ -708,6 +709,7 @@ describe("row 10 — custom-tool name collision with built-in: built-in wins, no
         chatSummary: null,
       },
       customTools,
+      allowedToolNames: new Set(["roll_dice"]),
       call: {
         id: "call-1",
         name: "roll_dice",
@@ -723,5 +725,104 @@ describe("row 10 — custom-tool name collision with built-in: built-in wins, no
     expect(parsed.notation).toMatch(/^1d6/);
     expect(parsed.rolls).toHaveLength(1);
     expect(typeof parsed.total).toBe("number");
+  });
+
+  it("executeMainToolCall rejects tools that were filtered out of toolDefs (allowlist enforcement)", async () => {
+    // The model hallucinates a call to spotify_play, which buildMainToolDefinitions
+    // had filtered out. executeMainToolCall must reject it without dispatching.
+    const customExecute = vi.fn(async () => ({ ok: true }));
+    const storage = {
+      get: vi.fn(async () => null),
+      list: vi.fn(async () => []),
+      update: vi.fn(async () => ({})),
+    } as unknown as StorageGateway;
+    const integrations = {
+      customTools: { execute: customExecute },
+      spotify: {
+        player: vi.fn(async () => ({ playing: true })),
+      } as unknown as IntegrationGateway["spotify"],
+      haptic: {} as IntegrationGateway["haptic"],
+      image: {} as IntegrationGateway["image"],
+    } as IntegrationGateway;
+
+    const result = await executeMainToolCall({
+      deps: { storage, integrations },
+      input: {
+        chat: { id: "chat-1", metadata: {} },
+        activatedLorebookEntries: [],
+        chatSummary: null,
+      },
+      customTools: new Map(),
+      allowedToolNames: new Set(["roll_dice"]), // spotify_play NOT in allowlist
+      call: {
+        id: "call-1",
+        name: "spotify_play",
+        arguments: JSON.stringify({ uri: "spotify:track:abc" }),
+        function: { name: "spotify_play", arguments: JSON.stringify({ uri: "spotify:track:abc" }) },
+      },
+    });
+
+    expect(customExecute).not.toHaveBeenCalled();
+    expect((integrations.spotify as unknown as { player: ReturnType<typeof vi.fn> }).player).not.toHaveBeenCalled();
+    const parsed = JSON.parse(result) as { error: string };
+    expect(parsed.error).toContain("Tool not enabled for this chat");
+    expect(parsed.error).toContain("spotify_play");
+  });
+
+  it("normalizeToolCall preserves object-form arguments instead of coercing to '{}'", async () => {
+    // Some providers emit pre-parsed arguments as an object rather than a JSON string.
+    // The pre-fix readString coercion would collapse the object to "{}", silently
+    // erasing required fields and failing downstream tool execution.
+    const objectArgsCall = normalizeToolCall({
+      id: "call-obj",
+      function: { name: "roll_dice", arguments: { notation: "2d6", reason: "perception" } },
+    });
+    expect(objectArgsCall).not.toBeNull();
+    const parsed = JSON.parse(objectArgsCall!.arguments) as { notation: string; reason: string };
+    expect(parsed.notation).toBe("2d6");
+    expect(parsed.reason).toBe("perception");
+
+    // String form still passes through unchanged.
+    const stringArgsCall = normalizeToolCall({
+      id: "call-str",
+      function: { name: "roll_dice", arguments: JSON.stringify({ notation: "1d20" }) },
+    });
+    expect(stringArgsCall).not.toBeNull();
+    expect(stringArgsCall!.arguments).toBe(JSON.stringify({ notation: "1d20" }));
+
+    // Missing arguments fall back to empty object literal.
+    const noArgsCall = normalizeToolCall({ id: "call-none", function: { name: "roll_dice" } });
+    expect(noArgsCall).not.toBeNull();
+    expect(noArgsCall!.arguments).toBe("{}");
+  });
+
+  it("usage is aggregated across multi-turn tool-call loops, not overwritten by the last turn", async () => {
+    // Two-turn loop: turn 1 emits usage A + a tool call, turn 2 emits usage B
+    // and resolves. Saved usage must reflect both turns' token counts.
+    const { deps, createChatMessage } = makeStubDeps({
+      chatMetadata: { enableTools: true, activeToolIds: ["roll_dice"] },
+      script: {
+        turns: [
+          [
+            { type: "token", text: "thinking..." },
+            toolCallChunk("roll_dice", { notation: "1d6" }, "c1"),
+            { type: "usage", data: { promptTokens: 100, completionTokens: 20, totalTokens: 120 } },
+          ],
+          [
+            { type: "token", text: " result is 4." },
+            { type: "usage", data: { promptTokens: 150, completionTokens: 30, totalTokens: 180 } },
+          ],
+        ],
+      },
+    });
+
+    await collectEvents(startGeneration(deps, { chatId: "chat-1", message: "go" }));
+
+    const assistantCall = createChatMessage.mock.calls.find(([, body]) => (body as Record<string, unknown>).role === "assistant");
+    expect(assistantCall).toBeDefined();
+    const generationInfo = (assistantCall![1] as { generationInfo: { usage: Record<string, number> } }).generationInfo;
+    expect(generationInfo.usage.promptTokens).toBe(250);
+    expect(generationInfo.usage.completionTokens).toBe(50);
+    expect(generationInfo.usage.totalTokens).toBe(300);
   });
 });

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -991,7 +991,7 @@ async function* streamMainGenerationLoop(args: {
 }): AsyncGenerator<GenerationEvent, { content: string; usage: unknown }> {
   const { deps, connection, input, baseMessages, mainTools, toolRuntimeInput, signal } = args;
   let content = "";
-  let usage: unknown = null;
+  const usages: unknown[] = [];
   const conversation: LlmMessage[] = [...baseMessages];
   let iteration = 0;
 
@@ -1018,8 +1018,8 @@ async function* streamMainGenerationLoop(args: {
       } else if (chunk.type === "tool_call") {
         const normalized = normalizeToolCall(chunk.data);
         if (normalized) pendingToolCalls.push(normalized);
-      } else if (chunk.type === "usage") {
-        usage = chunk.data ?? null;
+      } else if (chunk.type === "usage" && chunk.data != null) {
+        usages.push(chunk.data);
       }
     }
 
@@ -1051,6 +1051,7 @@ async function* streamMainGenerationLoop(args: {
           deps: { storage: deps.storage, integrations: deps.integrations },
           input: toolRuntimeInput,
           customTools: mainTools.customTools,
+          allowedToolNames: mainTools.allowedToolNames,
           call,
         });
       } catch (err) {
@@ -1070,5 +1071,38 @@ async function* streamMainGenerationLoop(args: {
     }
   }
 
-  return { content, usage };
+  return { content, usage: mergeUsages(usages) };
+}
+
+/**
+ * Aggregate per-turn usage records across a multi-turn tool-call loop.
+ *
+ * Each LLM turn (every iteration of `streamMainGenerationLoop`) emits its own
+ * `usage` chunk. When the loop runs once with no tool calls, behavior is
+ * byte-identical to the pre-loop world — the single record is returned as-is.
+ * When the loop iterates 2+ times, numeric leaf fields (prompt/completion/total
+ * tokens, cached/reasoning/cost breakdowns) are summed so downstream
+ * `generationInfo.usage` reflects total cost, not just the final turn's slice.
+ *
+ * Falls back to the latest non-null entry when usages have heterogeneous shapes
+ * (different providers, different keys) so we never silently report wrong-typed
+ * data.
+ */
+function mergeUsages(usages: unknown[]): unknown {
+  if (usages.length === 0) return null;
+  if (usages.length === 1) return usages[0];
+  const records = usages.filter(isRecord);
+  if (records.length === 0) return usages[usages.length - 1] ?? null;
+  const merged: Record<string, unknown> = {};
+  for (const record of records) {
+    for (const [key, value] of Object.entries(record)) {
+      if (typeof value === "number" && Number.isFinite(value)) {
+        const prev = merged[key];
+        merged[key] = typeof prev === "number" && Number.isFinite(prev) ? prev + value : value;
+      } else if (!(key in merged)) {
+        merged[key] = value;
+      }
+    }
+  }
+  return merged;
 }

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -7,6 +7,14 @@ import type { StorageGateway } from "../capabilities/storage";
 import type { GenerationGuideSource } from "../shared/text/generation-guide";
 import { createGenerationAgentRuntime } from "./agent-runner";
 import { persistConnectedCommandTags } from "./connected-commands";
+import type { LLMToolCall } from "../generation-core/llm/base-provider";
+import {
+  buildMainToolDefinitions,
+  executeMainToolCall,
+  normalizeToolCall,
+  type MainToolDefinitions,
+  type ToolRuntimeInput,
+} from "./tools-runtime";
 import { llmParameters, loadChatMessages, requireRecord, resolveGenerationConnection } from "./context";
 import {
   appendReadableAttachmentsToContent,
@@ -798,26 +806,29 @@ export async function* startGeneration(
 
     const parallelAgents = runtime?.runParallel() ?? Promise.resolve<AgentResult[]>([]);
     yield { type: "phase", data: "Calling model..." };
-    let content = "";
-    let usage: unknown = null;
-    for await (const chunk of deps.llm.stream(
-      {
-        connectionId: readString(connection.id) || input.connectionId,
-        model: readString(connection.model) || undefined,
-        messages: [...prompt, generationGuide(input)].filter((message): message is LlmMessage => !!message),
-        parameters: llmParameters(connection, input),
-      },
+    const mainTools = await buildMainToolDefinitions({
+      chat: chatForGeneration,
+      storage: deps.storage,
+      integrations: deps.integrations,
+    });
+    const toolRuntimeInput: ToolRuntimeInput = {
+      chat: chatForGeneration,
+      activatedLorebookEntries: assembly.activatedLorebookEntries,
+      chatSummary: assembly.chatSummary,
+    };
+    const baseMessages: LlmMessage[] = [...prompt, generationGuide(input)].filter(
+      (message): message is LlmMessage => !!message,
+    );
+    const { content: streamedContent, usage } = yield* streamMainGenerationLoop({
+      deps,
+      connection,
+      input,
+      baseMessages,
+      mainTools,
+      toolRuntimeInput,
       signal,
-    )) {
-      if (chunk.type === "token" && chunk.text) {
-        content += chunk.text;
-        yield { type: "token", data: chunk.text };
-      } else if (chunk.type === "thinking" && chunk.text) {
-        yield { type: "thinking", data: chunk.text };
-      } else if (chunk.type === "usage") {
-        usage = chunk.data ?? null;
-      }
-    }
+    });
+    let content = streamedContent;
 
     const parallelResults = await parallelAgents;
     const postResults = runtime ? await runtime.runPost(content) : [];
@@ -875,26 +886,29 @@ export async function* startGeneration(
     preparedUserInput.images,
   );
   yield { type: "phase", data: "Calling model..." };
-  let content = "";
-  let usage: unknown = null;
-  for await (const chunk of deps.llm.stream(
-    {
-      connectionId: readString(connection.id) || input.connectionId,
-      model: readString(connection.model) || undefined,
-      messages: [...(prompt ?? []), generationGuide(input)].filter((message): message is LlmMessage => !!message),
-      parameters: llmParameters(connection, input),
-    },
+  const mainToolsDirect = await buildMainToolDefinitions({
+    chat: chatForGeneration,
+    storage: deps.storage,
+    integrations: deps.integrations,
+  });
+  const toolRuntimeInputDirect: ToolRuntimeInput = {
+    chat: chatForGeneration,
+    activatedLorebookEntries: assembly.activatedLorebookEntries,
+    chatSummary: assembly.chatSummary,
+  };
+  const baseMessagesDirect: LlmMessage[] = [...(prompt ?? []), generationGuide(input)].filter(
+    (message): message is LlmMessage => !!message,
+  );
+  const { content: streamedContentDirect, usage } = yield* streamMainGenerationLoop({
+    deps,
+    connection,
+    input,
+    baseMessages: baseMessagesDirect,
+    mainTools: mainToolsDirect,
+    toolRuntimeInput: toolRuntimeInputDirect,
     signal,
-  )) {
-    if (chunk.type === "token" && chunk.text) {
-      content += chunk.text;
-      yield { type: "token", data: chunk.text };
-    } else if (chunk.type === "thinking" && chunk.text) {
-      yield { type: "thinking", data: chunk.text };
-    } else if (chunk.type === "usage") {
-      usage = chunk.data ?? null;
-    }
-  }
+  });
+  let content = streamedContentDirect;
   content = await applyRuntimeRegexScripts(deps.storage, "ai_output", content);
   const connected = await persistConnectedCommandTags(
     deps.storage,
@@ -940,4 +954,121 @@ export async function* startGeneration(
 function generationGuide(input: StartGenerationInput): LlmMessage | null {
   const guide = readString(input.generationGuide).trim();
   return guide ? { role: "user", content: guide } : null;
+}
+
+/**
+ * Cap on the number of stream → tool-execute → re-stream iterations the main
+ * generation loop will perform before forcing a final turn. Picked defensively
+ * to cover realistic multi-step flows (e.g. Spotify-style 4-hop sequences,
+ * combat-style dice + state-update interleaves) while preventing runaway loops
+ * from broken models that always emit a tool call.
+ */
+const MAX_MAIN_TOOL_ITERATIONS = 8;
+
+/**
+ * Multi-turn main-character streaming loop.
+ *
+ * Streams from the LLM, collects any `tool_call` chunks, executes them via
+ * `executeMainToolCall`, appends the assistant turn + tool results to the
+ * conversation, and re-streams until the model produces a turn with no tool
+ * calls (or the iteration cap is hit).
+ *
+ * Mode-blind by construction: this helper reads no chat-mode flag. The only
+ * gate on the tool loop is `mainTools !== null`, which the caller derives from
+ * `chat.metadata.enableTools` via `buildMainToolDefinitions`.
+ *
+ * Tool-result messages are conversation-internal — they are NOT persisted as
+ * chat messages. Only the final accumulated text reaches `saveAssistantMessage`.
+ */
+async function* streamMainGenerationLoop(args: {
+  deps: GenerationEngineDeps;
+  connection: JsonRecord;
+  input: StartGenerationInput;
+  baseMessages: LlmMessage[];
+  mainTools: MainToolDefinitions | null;
+  toolRuntimeInput: ToolRuntimeInput;
+  signal: AbortSignal | undefined;
+}): AsyncGenerator<GenerationEvent, { content: string; usage: unknown }> {
+  const { deps, connection, input, baseMessages, mainTools, toolRuntimeInput, signal } = args;
+  let content = "";
+  let usage: unknown = null;
+  const conversation: LlmMessage[] = [...baseMessages];
+  let iteration = 0;
+
+  while (true) {
+    iteration++;
+    const pendingToolCalls: LLMToolCall[] = [];
+    let turnContent = "";
+
+    for await (const chunk of deps.llm.stream(
+      {
+        connectionId: readString(connection.id) || input.connectionId,
+        model: readString(connection.model) || undefined,
+        messages: conversation,
+        parameters: llmParameters(connection, input),
+        tools: mainTools?.toolDefs,
+      },
+      signal,
+    )) {
+      if (chunk.type === "token" && chunk.text) {
+        turnContent += chunk.text;
+        yield { type: "token", data: chunk.text };
+      } else if (chunk.type === "thinking" && chunk.text) {
+        yield { type: "thinking", data: chunk.text };
+      } else if (chunk.type === "tool_call") {
+        const normalized = normalizeToolCall(chunk.data);
+        if (normalized) pendingToolCalls.push(normalized);
+      } else if (chunk.type === "usage") {
+        usage = chunk.data ?? null;
+      }
+    }
+
+    content += turnContent;
+
+    if (!mainTools || pendingToolCalls.length === 0) break;
+    if (iteration >= MAX_MAIN_TOOL_ITERATIONS) {
+      yield {
+        type: "phase",
+        data: `Tool-call iteration limit (${MAX_MAIN_TOOL_ITERATIONS}) reached; finishing without further tool calls.`,
+      };
+      break;
+    }
+
+    conversation.push({
+      role: "assistant",
+      content: turnContent,
+      tool_calls: pendingToolCalls,
+    });
+
+    for (const call of pendingToolCalls) {
+      const toolName = call.function?.name || call.name;
+      const toolArgs = call.function?.arguments || call.arguments || "{}";
+      yield { type: "tool_call", data: { id: call.id, name: toolName, arguments: toolArgs } };
+      let resultText: string;
+      let success = true;
+      try {
+        resultText = await executeMainToolCall({
+          deps: { storage: deps.storage, integrations: deps.integrations },
+          input: toolRuntimeInput,
+          customTools: mainTools.customTools,
+          call,
+        });
+      } catch (err) {
+        success = false;
+        resultText = err instanceof Error ? err.message : String(err);
+      }
+      yield {
+        type: "tool_result",
+        data: { toolCallId: call.id, name: toolName, result: resultText, success },
+      };
+      conversation.push({
+        role: "tool",
+        content: resultText,
+        tool_call_id: call.id,
+        name: toolName,
+      });
+    }
+  }
+
+  return { content, usage };
 }

--- a/src/engine/generation/tools-runtime.ts
+++ b/src/engine/generation/tools-runtime.ts
@@ -505,8 +505,11 @@ export interface ExecuteMainToolCallArgs {
  *
  * The synthetic main-agent record matters only for Spotify tools, which are
  * filtered out of `buildMainToolDefinitions` by default. If a future change
- * lifts that exclusion, `spotifyAgentId` falls back to the string `"main"`,
- * which the Spotify gateway treats as "use default credentials".
+ * lifts that exclusion, the caller MUST also supply a real Spotify-agent id
+ * (or refactor `spotifyAgentId` to fall back to `""`); the synthetic `"main"`
+ * literal here will NOT resolve to default credentials — the Spotify gateway
+ * calls `get_required(state, "agents", "main")`, which returns 404 unless an
+ * agent with that literal id exists.
  */
 export async function executeMainToolCall(args: ExecuteMainToolCallArgs): Promise<string> {
   const name = args.call.function?.name || args.call.name;

--- a/src/engine/generation/tools-runtime.ts
+++ b/src/engine/generation/tools-runtime.ts
@@ -49,7 +49,8 @@ export function normalizeToolCall(value: unknown): LLMToolCall | null {
   const rawFunction = isRecord(value.function) ? value.function : value;
   const name = readString(rawFunction.name || value.name).trim();
   if (!name) return null;
-  const args = readString(rawFunction.arguments || value.arguments, "{}");
+  const rawArgs = rawFunction.arguments ?? value.arguments;
+  const args = typeof rawArgs === "string" ? rawArgs : JSON.stringify(rawArgs ?? {});
   return {
     id: readString(value.id) || `tool-${name}-${Date.now().toString(36)}`,
     name,
@@ -443,6 +444,13 @@ export interface BuildMainToolDefinitionsArgs {
 export interface MainToolDefinitions {
   toolDefs: LlmToolDefinition[];
   customTools: Map<string, CustomToolRecord>;
+  /**
+   * Set of tool names that survived the filter and were actually advertised to
+   * the model. `executeMainToolCall` enforces this allowlist at dispatch time
+   * so a hallucinated or injected call to a filtered-out tool (Spotify,
+   * agent-only, inactive, name-collided custom) cannot reach execution.
+   */
+  allowedToolNames: Set<string>;
 }
 
 /**
@@ -477,22 +485,29 @@ export async function buildMainToolDefinitions(
     if (!filter(tool.name)) continue;
     builtIns.push({ name: tool.name, description: tool.description, parameters: tool.parameters });
   }
-  const customTools = await loadCustomTools(args.storage);
+  const loadedCustomTools = await loadCustomTools(args.storage);
+  const customTools = new Map<string, CustomToolRecord>();
   const customs: LlmToolDefinition[] = [];
-  for (const tool of customTools.values()) {
+  for (const tool of loadedCustomTools.values()) {
     if (!filter(tool.name)) continue;
     // Dedupe: built-in wins on name collision. Matches staging behavior.
     if (BUILT_IN_TOOL_MAP.has(tool.name)) continue;
+    customTools.set(tool.name, tool);
     customs.push(customToolDefinition(tool));
   }
   if (builtIns.length === 0 && customs.length === 0) return null;
-  return { toolDefs: [...builtIns, ...customs], customTools };
+  const allowedToolNames = new Set<string>([
+    ...builtIns.map((tool) => tool.name),
+    ...customTools.keys(),
+  ]);
+  return { toolDefs: [...builtIns, ...customs], customTools, allowedToolNames };
 }
 
 export interface ExecuteMainToolCallArgs {
   deps: ToolDeps;
   input: ToolRuntimeInput;
   customTools: Map<string, CustomToolRecord>;
+  allowedToolNames: Set<string>;
   call: LLMToolCall;
 }
 
@@ -513,6 +528,9 @@ export interface ExecuteMainToolCallArgs {
  */
 export async function executeMainToolCall(args: ExecuteMainToolCallArgs): Promise<string> {
   const name = args.call.function?.name || args.call.name;
+  if (!args.allowedToolNames.has(name)) {
+    return stringifyToolResult({ error: `Tool not enabled for this chat: ${name}` });
+  }
   if (BUILT_IN_TOOL_MAP.has(name)) {
     const syntheticMainAgent: JsonRecord = { id: "main", type: "main", name: "Main Generation" };
     return stringifyToolResult(await executeBuiltInTool(args.deps, args.input, syntheticMainAgent, args.call));

--- a/src/engine/generation/tools-runtime.ts
+++ b/src/engine/generation/tools-runtime.ts
@@ -1,0 +1,526 @@
+import { BUILT_IN_TOOLS, DEFAULT_AGENT_TOOLS, type ToolDefinition } from "../contracts/types/agent";
+import type { IntegrationGateway } from "../capabilities/integrations";
+import type { LlmToolDefinition } from "../capabilities/llm";
+import type { StorageGateway } from "../capabilities/storage";
+import type { LLMToolCall, LLMToolDefinition } from "../generation-core/llm/base-provider";
+import { appendChatSummaryEntryToMetadata } from "../shared/text/chat-summary-entries";
+import {
+  boolish,
+  isRecord,
+  newId,
+  nowIso,
+  parseRecord,
+  readNumber,
+  readString,
+  type JsonRecord,
+} from "./runtime-records";
+
+/**
+ * Narrow input shape consumed by tool runtime helpers.
+ *
+ * `GenerationAgentRuntimeInput` (in `agent-runner.ts`) extends this shape
+ * structurally, so existing agent-path callers pass without change. The main
+ * generation path constructs this directly from the chat record + assembly
+ * output.
+ */
+export interface ToolRuntimeInput {
+  chat: JsonRecord;
+  activatedLorebookEntries: Array<{ id: string; name: string; content: string; tag: string }>;
+  chatSummary: string | null;
+}
+
+export interface CustomToolRecord extends JsonRecord {
+  name: string;
+  description: string;
+  parametersSchema: unknown;
+  executionType: string;
+  webhookUrl: string | null;
+  staticResult: string | null;
+  enabled: string | boolean;
+}
+
+interface ToolDeps {
+  storage: StorageGateway;
+  integrations: IntegrationGateway;
+}
+
+export function normalizeToolCall(value: unknown): LLMToolCall | null {
+  if (!isRecord(value)) return null;
+  const rawFunction = isRecord(value.function) ? value.function : value;
+  const name = readString(rawFunction.name || value.name).trim();
+  if (!name) return null;
+  const args = readString(rawFunction.arguments || value.arguments, "{}");
+  return {
+    id: readString(value.id) || `tool-${name}-${Date.now().toString(36)}`,
+    name,
+    arguments: args,
+    function: {
+      name,
+      arguments: args,
+    },
+  };
+}
+
+export function parseToolParameters(value: unknown): unknown {
+  if (!value) return { type: "object", properties: {} };
+  if (typeof value === "string") {
+    try {
+      return JSON.parse(value);
+    } catch {
+      return { type: "object", properties: {} };
+    }
+  }
+  return value;
+}
+
+export function customToolRecord(row: JsonRecord): CustomToolRecord | null {
+  const name = readString(row.name).trim();
+  if (!name || !boolish(row.enabled, false)) return null;
+  const executionType = readString(row.executionType, "static");
+  if (executionType !== "static" && executionType !== "webhook") return null;
+  return {
+    ...row,
+    name,
+    description: readString(row.description),
+    parametersSchema: parseToolParameters(row.parametersSchema),
+    executionType,
+    webhookUrl: readString(row.webhookUrl).trim() || null,
+    staticResult: readString(row.staticResult),
+    enabled: row.enabled as string | boolean,
+  };
+}
+
+export async function loadCustomTools(storage: StorageGateway): Promise<Map<string, CustomToolRecord>> {
+  const tools = new Map<string, CustomToolRecord>();
+  for (const row of await storage.list<JsonRecord>("custom-tools")) {
+    const tool = customToolRecord(row);
+    if (tool) tools.set(tool.name, tool);
+  }
+  return tools;
+}
+
+export function customToolDefinition(tool: CustomToolRecord): LLMToolDefinition {
+  return {
+    name: tool.name,
+    description: tool.description || `Run custom tool ${tool.name}.`,
+    parameters: tool.parametersSchema,
+  };
+}
+
+export const BUILT_IN_TOOL_MAP: Map<string, ToolDefinition> = new Map(
+  BUILT_IN_TOOLS.map((tool) => [tool.name, tool]),
+);
+
+export function builtInToolDefinition(name: string): LLMToolDefinition | null {
+  const tool = BUILT_IN_TOOL_MAP.get(name);
+  if (!tool) return null;
+  return {
+    name: tool.name,
+    description: tool.description,
+    parameters: tool.parameters,
+  };
+}
+
+export function stringifyToolResult(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (isRecord(value) && typeof value.result === "string") return value.result;
+  return JSON.stringify(value ?? null);
+}
+
+export function toolArguments(call: LLMToolCall): JsonRecord {
+  const raw = call.function?.arguments || call.arguments || "{}";
+  if (typeof raw === "string") return parseRecord(raw);
+  return parseRecord(raw);
+}
+
+export function stringArg(args: JsonRecord, key: string, fallback = ""): string {
+  return readString(args[key], fallback).trim();
+}
+
+export function numberArg(args: JsonRecord, key: string, fallback: number): number {
+  return readNumber(args[key], fallback);
+}
+
+export function stringArrayArg(args: JsonRecord, key: string): string[] {
+  const value = args[key];
+  if (!Array.isArray(value)) return [];
+  return value.map((item) => readString(item).trim()).filter(Boolean);
+}
+
+export function toolError(message: string): never {
+  throw new Error(message);
+}
+
+export function requireChatId(input: ToolRuntimeInput): string {
+  const chatId = readString(input.chat.id).trim();
+  if (!chatId) toolError("Tool requires a persisted chat id.");
+  return chatId;
+}
+
+export async function updateChatMetadata(
+  storage: StorageGateway,
+  input: ToolRuntimeInput,
+  updater: (metadata: JsonRecord) => JsonRecord,
+): Promise<JsonRecord> {
+  const chatId = requireChatId(input);
+  const metadata = updater({ ...parseRecord(input.chat.metadata) });
+  await storage.update("chats", chatId, { metadata });
+  input.chat.metadata = metadata;
+  return metadata;
+}
+
+export function rollDiceNotation(notation: string) {
+  const match = notation.trim().match(/^(\d*)d(\d+)([+-]\d+)?$/i);
+  if (!match) toolError("Dice notation must look like 1d20, 2d6, or 3d8+2.");
+  const count = Math.max(1, Math.min(100, Number(match[1] || "1")));
+  const sides = Math.max(2, Math.min(1000, Number(match[2])));
+  const modifier = Number(match[3] || "0");
+  const rolls = Array.from({ length: count }, () => Math.floor(Math.random() * sides) + 1);
+  return {
+    notation: `${count}d${sides}${modifier === 0 ? "" : modifier > 0 ? `+${modifier}` : modifier}`,
+    rolls,
+    modifier,
+    total: rolls.reduce((sum, value) => sum + value, 0) + modifier,
+  };
+}
+
+export async function searchLorebookTool(storage: StorageGateway, input: ToolRuntimeInput, args: JsonRecord) {
+  const query = stringArg(args, "query").toLowerCase();
+  if (!query) toolError("query is required.");
+  const category = stringArg(args, "category").toLowerCase();
+  const tokens = query.split(/\s+/).filter((token) => token.length > 1);
+  const rows = await storage.list<JsonRecord>("lorebook-entries").catch(() => []);
+  const activated = input.activatedLorebookEntries.map((entry) => ({
+    id: entry.id,
+    name: entry.name,
+    content: entry.content,
+    tag: entry.tag,
+    source: "activated",
+  }));
+  const stored = rows.map((entry) => ({
+    id: readString(entry.id),
+    name: readString(entry.name || entry.comment || entry.title, "Lorebook entry"),
+    content: readString(entry.content),
+    tag: readString(entry.tag || entry.category || entry.position),
+    source: "stored",
+  }));
+  const seen = new Set<string>();
+  const scored = [...activated, ...stored]
+    .filter((entry) => {
+      if (!entry.id || seen.has(entry.id)) return false;
+      seen.add(entry.id);
+      if (category && !`${entry.name} ${entry.tag}`.toLowerCase().includes(category)) return false;
+      return true;
+    })
+    .map((entry) => {
+      const haystack = `${entry.name} ${entry.tag} ${entry.content}`.toLowerCase();
+      const score =
+        (haystack.includes(query) ? 10 : 0) +
+        tokens.reduce((sum, token) => sum + (haystack.includes(token) ? 1 : 0), 0);
+      return { ...entry, score };
+    })
+    .filter((entry) => entry.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 8)
+    .map((entry) => ({
+      id: entry.id,
+      name: entry.name,
+      tag: entry.tag || null,
+      source: entry.source,
+      score: entry.score,
+      content: entry.content.slice(0, 4000),
+    }));
+  return { query, entries: scored };
+}
+
+export async function executeBuiltInTool(
+  deps: ToolDeps,
+  input: ToolRuntimeInput,
+  agent: JsonRecord,
+  call: LLMToolCall,
+): Promise<unknown> {
+  const { storage, integrations } = deps;
+  const toolName = call.function?.name || call.name;
+  const args = toolArguments(call);
+  const chatId = requireChatId(input);
+
+  switch (toolName) {
+    case "roll_dice": {
+      const notation = stringArg(args, "notation");
+      if (!notation) toolError("notation is required.");
+      return { ...rollDiceNotation(notation), reason: stringArg(args, "reason") || null };
+    }
+    case "update_game_state": {
+      const update = {
+        id: newId("game_state_update"),
+        createdAt: nowIso(),
+        type: stringArg(args, "type"),
+        target: stringArg(args, "target"),
+        key: stringArg(args, "key"),
+        value: stringArg(args, "value"),
+        description: stringArg(args, "description"),
+      };
+      if (!update.type || !update.target || !update.key) toolError("type, target, and key are required.");
+      const metadata = parseRecord(input.chat.metadata);
+      const updates = Array.isArray(metadata.agentGameStateUpdates) ? metadata.agentGameStateUpdates : [];
+      metadata.agentGameStateUpdates = [...updates, update].slice(-100);
+      const gameState = isRecord(input.chat.gameState) ? { ...input.chat.gameState } : {};
+      if (update.type === "location_change") gameState.location = update.value;
+      if (update.type === "time_advance") gameState.time = update.value;
+      await storage.update("chats", chatId, { metadata, gameState });
+      input.chat.metadata = metadata;
+      input.chat.gameState = gameState;
+      return { success: true, update, gameState };
+    }
+    case "set_expression": {
+      const characterName = stringArg(args, "characterName");
+      const expression = stringArg(args, "expression");
+      if (!characterName || !expression) toolError("characterName and expression are required.");
+      const metadata = await updateChatMetadata(storage, input, (current) => {
+        const expressions = parseRecord(current.agentExpressions);
+        expressions[characterName] = expression;
+        return { ...current, agentExpressions: expressions };
+      });
+      return { success: true, characterName, expression, expressions: metadata.agentExpressions };
+    }
+    case "trigger_event": {
+      const event = {
+        id: newId("agent_event"),
+        createdAt: nowIso(),
+        eventType: stringArg(args, "eventType"),
+        description: stringArg(args, "description"),
+        involvedCharacters: stringArrayArg(args, "involvedCharacters"),
+      };
+      if (!event.eventType || !event.description) toolError("eventType and description are required.");
+      await updateChatMetadata(storage, input, (current) => {
+        const events = Array.isArray(current.agentEvents) ? current.agentEvents : [];
+        return { ...current, agentEvents: [...events, event].slice(-100) };
+      });
+      return { success: true, event };
+    }
+    case "search_lorebook":
+      return searchLorebookTool(storage, input, args);
+    case "read_chat_summary":
+      return { summary: (input.chatSummary ?? readString(parseRecord(input.chat.metadata).summary)) || null };
+    case "append_chat_summary": {
+      const text = stringArg(args, "text");
+      if (!text) toolError("text is required.");
+      const now = nowIso();
+      const metadata = parseRecord(input.chat.metadata);
+      const appended = appendChatSummaryEntryToMetadata(
+        metadata,
+        {
+          content: text,
+          origin: "automated",
+          sourceMode: "agent",
+          title: "Agent memory",
+        },
+        { now, createId: () => newId("summary") },
+      );
+      metadata.summaryEntries = appended.entries;
+      metadata.summary = appended.summary;
+      await storage.update("chats", chatId, { metadata });
+      input.chat.metadata = metadata;
+      input.chatSummary = appended.summary;
+      return { success: true, entry: appended.entry, summary: appended.summary };
+    }
+    case "read_chat_variable": {
+      const key = stringArg(args, "key");
+      if (!key) toolError("key is required.");
+      const variables = parseRecord(parseRecord(input.chat.metadata).agentVariables);
+      return { key, value: typeof variables[key] === "string" ? variables[key] : null };
+    }
+    case "write_chat_variable": {
+      const key = stringArg(args, "key");
+      const value = stringArg(args, "value");
+      if (!key) toolError("key is required.");
+      await updateChatMetadata(storage, input, (current) => {
+        const variables = parseRecord(current.agentVariables);
+        variables[key] = value;
+        return { ...current, agentVariables: variables };
+      });
+      return { success: true, key, value };
+    }
+    case "spotify_get_current_playback":
+      return integrations.spotify.player({ agentId: spotifyAgentId(agent) });
+    case "spotify_get_playlists": {
+      const limit = Math.max(1, Math.min(50, Math.trunc(numberArg(args, "limit", 20))));
+      return integrations.spotify.playlists({ agentId: spotifyAgentId(agent), limit });
+    }
+    case "spotify_get_playlist_tracks": {
+      const playlistId = stringArg(args, "playlistId");
+      if (!playlistId) toolError("playlistId is required.");
+      const body: JsonRecord = {
+        agentId: spotifyAgentId(agent),
+        playlistId,
+        query: stringArg(args, "query"),
+        mood: stringArg(args, "mood"),
+        limit: Math.max(1, Math.min(80, Math.trunc(numberArg(args, "candidateLimit", numberArg(args, "limit", 50))))),
+      };
+      const offset = numberArg(args, "offset", Number.NaN);
+      if (Number.isFinite(offset)) body.offset = Math.max(0, Math.trunc(offset));
+      return integrations.spotify.playlistTracks(body);
+    }
+    case "spotify_search":
+      return integrations.spotify.searchTracks({
+        agentId: spotifyAgentId(agent),
+        query: stringArg(args, "query"),
+        limit: Math.max(1, Math.min(50, Math.trunc(numberArg(args, "limit", 10)))),
+      });
+    case "spotify_play": {
+      const uri = stringArg(args, "uri");
+      const uris = stringArrayArg(args, "uris");
+      if (!uri && uris.length === 0) toolError("uri or uris is required.");
+      const body: JsonRecord = { agentId: spotifyAgentId(agent) };
+      if (uris.length > 0) body.uris = uris;
+      else if (uri.startsWith("spotify:track:")) body.uri = uri;
+      else body.contextUri = uri;
+      return integrations.spotify.play(body);
+    }
+    case "spotify_set_volume":
+      return integrations.spotify.volume({
+        agentId: spotifyAgentId(agent),
+        volume: Math.max(0, Math.min(100, Math.trunc(numberArg(args, "volume", 50)))),
+      });
+    default:
+      return null;
+  }
+}
+
+export function spotifyAgentId(agent: JsonRecord): string {
+  const settings = parseRecord(agent.settings);
+  return readString(settings.spotifyAgentId).trim() || readString(agent.id).trim() || "spotify";
+}
+
+/**
+ * Trivial wrapper around the custom-tools integration. Extracted so the main
+ * generation path and the agent path execute custom tools through identical
+ * code.
+ */
+export async function customToolExecutor(integrations: IntegrationGateway, call: LLMToolCall): Promise<string> {
+  const name = call.function?.name || call.name;
+  return stringifyToolResult(
+    await integrations.customTools.execute({
+      toolName: name,
+      arguments: toolArguments(call),
+    }),
+  );
+}
+
+// ──────────────────────────────────────────────
+// Main-path metadata gating (mode-neutral)
+// ──────────────────────────────────────────────
+
+export function chatToolsEnabledFor(chat: JsonRecord): boolean {
+  return boolish(parseRecord(chat.metadata).enableTools, false);
+}
+
+export function chatActiveToolIdsFor(chat: JsonRecord): Set<string> {
+  const value = parseRecord(chat.metadata).activeToolIds;
+  if (!Array.isArray(value)) return new Set();
+  return new Set(value.map((item) => readString(item).trim()).filter(Boolean));
+}
+
+// ──────────────────────────────────────────────
+// Main-path public API
+// ──────────────────────────────────────────────
+
+const AGENT_ONLY_TOOL_NAMES = new Set([
+  "read_chat_summary",
+  "append_chat_summary",
+  "read_chat_variable",
+  "write_chat_variable",
+]);
+const SPOTIFY_TOOL_NAMES = new Set(DEFAULT_AGENT_TOOLS.spotify);
+
+export interface BuildMainToolDefinitionsArgs {
+  chat: JsonRecord;
+  storage: StorageGateway;
+  integrations: IntegrationGateway;
+  includeSpotify?: boolean;
+}
+
+export interface MainToolDefinitions {
+  toolDefs: LlmToolDefinition[];
+  customTools: Map<string, CustomToolRecord>;
+}
+
+/**
+ * Build the tool-definition set exposed to the main character LLM call.
+ *
+ * Returns `null` when chat-level tools are disabled or when the filtered set is
+ * empty. The result is mode-neutral — it reads `chat.metadata.enableTools` and
+ * `chat.metadata.activeToolIds` and never branches on `chat.mode`.
+ *
+ * Filtering rules:
+ *  - Agent-only tools (`read_chat_summary`, `append_chat_summary`,
+ *    `read_chat_variable`, `write_chat_variable`) are excluded from the main
+ *    path; they remain exposed to agents via `buildAgentToolContext`.
+ *  - Spotify tools are excluded unless `includeSpotify: true` is requested
+ *    (default `false` — see design §4).
+ *  - Custom tools whose name collides with a built-in are dropped; the built-in
+ *    wins. Mirrors staging `generate.routes.ts:5984-5990`.
+ */
+export async function buildMainToolDefinitions(
+  args: BuildMainToolDefinitionsArgs,
+): Promise<MainToolDefinitions | null> {
+  if (!chatToolsEnabledFor(args.chat)) return null;
+  const activeIds = chatActiveToolIdsFor(args.chat);
+  const filter = (name: string): boolean => {
+    if (AGENT_ONLY_TOOL_NAMES.has(name)) return false;
+    if (!args.includeSpotify && SPOTIFY_TOOL_NAMES.has(name)) return false;
+    if (activeIds.size === 0) return true;
+    return activeIds.has(name);
+  };
+  const builtIns: LlmToolDefinition[] = [];
+  for (const tool of BUILT_IN_TOOLS) {
+    if (!filter(tool.name)) continue;
+    builtIns.push({ name: tool.name, description: tool.description, parameters: tool.parameters });
+  }
+  const customTools = await loadCustomTools(args.storage);
+  const customs: LlmToolDefinition[] = [];
+  for (const tool of customTools.values()) {
+    if (!filter(tool.name)) continue;
+    // Dedupe: built-in wins on name collision. Matches staging behavior.
+    if (BUILT_IN_TOOL_MAP.has(tool.name)) continue;
+    customs.push(customToolDefinition(tool));
+  }
+  if (builtIns.length === 0 && customs.length === 0) return null;
+  return { toolDefs: [...builtIns, ...customs], customTools };
+}
+
+export interface ExecuteMainToolCallArgs {
+  deps: ToolDeps;
+  input: ToolRuntimeInput;
+  customTools: Map<string, CustomToolRecord>;
+  call: LLMToolCall;
+}
+
+/**
+ * Execute a single tool call from the main character LLM stream.
+ *
+ * Dispatches on tool name only — built-in first (synthetic main-agent record),
+ * then custom tools, then a sentinel error for unknown tools. Errors thrown by
+ * the underlying executor propagate to the caller (no swallowing).
+ *
+ * The synthetic main-agent record matters only for Spotify tools, which are
+ * filtered out of `buildMainToolDefinitions` by default. If a future change
+ * lifts that exclusion, `spotifyAgentId` falls back to the string `"main"`,
+ * which the Spotify gateway treats as "use default credentials".
+ */
+export async function executeMainToolCall(args: ExecuteMainToolCallArgs): Promise<string> {
+  const name = args.call.function?.name || args.call.name;
+  if (BUILT_IN_TOOL_MAP.has(name)) {
+    const syntheticMainAgent: JsonRecord = { id: "main", type: "main", name: "Main Generation" };
+    return stringifyToolResult(await executeBuiltInTool(args.deps, args.input, syntheticMainAgent, args.call));
+  }
+  if (args.customTools.has(name)) {
+    return stringifyToolResult(
+      await args.deps.integrations.customTools.execute({
+        toolName: name,
+        arguments: toolArguments(args.call),
+      }),
+    );
+  }
+  return stringifyToolResult({ error: `Unknown tool: ${name}` });
+}


### PR DESCRIPTION
## Why this change

Closes #1340.

The refactor's `startGeneration` (`src/engine/generation/start-generation.ts`) never passed `tools` to `deps.llm.stream(...)` and never handled `tool_call` chunks coming back, so the per-chat `enableTools` + `activeToolIds` settings persisted by `ChatSettingsDrawer` were dead settings for the main character LLM call across every mode (chat / roleplay / game / conversation). All tool plumbing already existed scoped per-agent in `agent-runner.ts`, but was unreachable from the main character path. This was a regression versus the v1.6.x server build, where the main generation route resolved built-in + custom tools and ran a multi-turn tool-execution loop.

The audit comment on #1340 asked to verify that transport, command handling, and prompt assembly all agree on conversation-mode tool behavior. They did not: the UI claimed tools available, storage persisted `enableTools` / `activeToolIds`, and the transport / prompt-assembly layer ignored both. This change restores agreement across all three layers, mode-neutrally.

## What changed

- **New module** `src/engine/generation/tools-runtime.ts` — extracts the shared tool helpers (built-in tool map, custom-tool loader, `executeBuiltInTool`, normalization, dice / lorebook helpers) from `agent-runner.ts` and adds a mode-neutral public API (`buildMainToolDefinitions`, `executeMainToolCall`, `chatToolsEnabledFor`, `chatActiveToolIdsFor`). All extracted helpers are byte-identical to their previous behavior; the new API is additive.
- **`src/engine/generation/agent-runner.ts`** — deletes the moved functions and re-imports them from `./tools-runtime`. Agent-path behavior is unchanged.
- **`src/engine/generation/start-generation.ts`** — adds a single `streamMainGenerationLoop` helper called by both LLM branches (agents-enabled and directMessages). Each iteration streams from the model, collects `tool_call` chunks, executes them via `executeMainToolCall`, appends the results back into the conversation, and re-streams. Iteration is capped at `MAX_MAIN_TOOL_ITERATIONS = 8` with a visible `phase` event on cap-hit.
- **`src/engine/generation/generation-events.ts`** — two new variants `tool_call` and `tool_result` so downstream consumers can observe the loop. No UI rendering is added in this PR — that is intentionally left for a follow-up.

### Design choices

- **Mode-neutral by construction.** The loop activates iff `chat.metadata.enableTools` is true and `buildMainToolDefinitions` returns at least one usable tool. There is no read of `chat.mode` anywhere in the new path. The change therefore restores parity uniformly across chat / roleplay / game / conversation; #1340 is framed as conversation-mode but the surface is broader.
- **Agent-only tools filtered out of the main toolset.** `read_chat_summary`, `append_chat_summary`, `read_chat_variable`, and `write_chat_variable` are inter-agent coordination primitives — they should not be exposed to the main character, matching the legacy server's `agentOnlyToolNames` set.
- **Spotify tools filtered out of the main toolset.** The Spotify integration is owned by the Spotify agent; routing it through the main character would conflate ownership and would also require a synthetic agent id with no Spotify credentials, which would just fail at execution time anyway. Agents that already have Spotify in their `enabledTools` continue to receive it via the unchanged agent path.
- **Custom-vs-built-in name collision** — de-duplicated with the built-in winning. Matches the legacy `generate.routes.ts:5984-5990` behavior.
- **Tool turns are conversation-internal only.** Tool-call and tool-result messages are appended to the in-memory `conversation: LlmMessage[]` array between iterations but never flow into `saveAssistantMessage`; only the final accumulated assistant content is persisted, matching legacy.

## Verification

- `pnpm check` passes locally (`check:architecture`, `check:frontend`, `check:rust`, `check:docs`).
- `pnpm test` passes (22 files / 128 tests including the new `main-tool-loop.test.ts` with 13 deterministic tests covering all ten rows of the implementation's risk matrix: Spotify filter, infinite-loop cap, custom-tool execution failure surfacing, non-persistence of tool turns, `enableTools: false` byte-identical baseline, agent-only filter, `activeToolIds: []` semantics, mid-loop abort with no orphan tool-call events, Branch B parity with Branch A, and custom-vs-built-in name collision).
- `cargo clippy --workspace --all-targets -- -D warnings` passes.
- The verification is fully deterministic against stubbed `deps.llm.stream` / `deps.integrations.customTools.execute` / `deps.storage`; no real network, no flaky asserts.
- I have not yet driven this end-to-end through the desktop shell against a live tool-capable provider. Reviewer judgement welcome on whether a manual end-to-end pass is required before promoting from draft.

## Known caveat: streaming downgrade on some providers when tools are enabled

The `marinara-llm` crate's streaming router (`src-tauri/crates/llm/src/lib.rs:95-119`) only takes the true streaming path (`stream_openai_compatible`) when `request.tools.is_empty()` for any provider that is not `openai_chatgpt`, OpenAI Responses, Anthropic, Google, Google Vertex, or Claude subscription. Once tools are non-empty, those other providers fall through to `complete_rich`, which is a single non-streaming request that emits all tokens at once at the end of the turn.

This is a pre-existing limitation of the LLM crate, not introduced by this PR — but this PR is the first commit that makes the user-facing `enableTools` setting actually reach the streaming router. As a result, enabling tools on chats backed by OpenRouter, raw OpenAI Chat Completions (non-Responses), Mistral, Groq, KoboldCpp, llama.cpp, Together, etc. will silently drop token-by-token streaming for those chats. Tool calls themselves still work; only the streaming UX changes.

Tracking as a follow-up: extend `stream_openai_compatible` to support the OpenAI Chat Completions streaming-tool-delta path so the affected providers retain streaming UX with tools enabled.

## Follow-ups (deferred, not blocking this PR)

- Extend `stream_openai_compatible` with tool-call streaming for non-Responses-API providers (per the caveat above).
- UI rendering for the new `tool_call` / `tool_result` events in the chat surface. This PR keeps the events as runtime signal only.
- Abort-signal propagation into long-running custom-tool webhooks. Currently the loop honors abort at the next `deps.llm.stream` iteration boundary; a 30s+ webhook would still complete before the loop cancels. Matches existing agent-runner behavior.
- Type unification: `customToolDefinition` returns `LLMToolDefinition` (from `generation-core/llm/base-provider`) while `buildMainToolDefinitions` packs the result into `LlmToolDefinition[]` (from `capabilities/llm`). Structurally identical so typecheck passes, but worth consolidating in a future cleanup.
- Documenting the in-place mutation contract of `updateChatMetadata` (pre-existing in `agent-runner.ts`, now reachable from a second call site).
- If `includeSpotify: false` is ever lifted from `buildMainToolDefinitions`, the caller must supply a real Spotify-agent id (or `spotifyAgentId` must be refactored to fall back to `""` so `find_by_field(... "type", "spotify")` is reached) — the synthetic `"main"` literal will NOT resolve to default credentials. See the updated comment on `executeMainToolCall` for context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `tool_call` and `tool_result` event types for improved tool execution visibility.
  * Implemented multi-turn tool execution loops with iteration caps to enhance conversation flow.

* **Refactor**
  * Reorganized tool runtime logic to improve maintainability and separation of concerns.

* **Tests**
  * Added comprehensive test suite for tool loop behavior, filtering, and error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1389?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->