### PR TITLE
Restore character field prompt macros

### DIFF
--- a/src/engine/generation/prompt-assembly.test.ts
+++ b/src/engine/generation/prompt-assembly.test.ts
@@ -66,6 +66,21 @@ function storageWithCharacters(characters: Row[]): StorageGateway {
   };
 }
 
+function storageWithSectionsAndCharacters(sections: Row[], characters: Row[]): StorageGateway {
+  const base = storageWithSections(sections);
+  return {
+    ...base,
+    list: async <T,>(entity: string, options?: { filters?: Record<string, unknown> }) => {
+      if (entity === "characters") return characters as T[];
+      return base.list<T>(entity, options);
+    },
+    get: async <T,>(entity: string, id: string) => {
+      if (entity === "characters") return (characters.find((character) => character.id === id) as T) ?? null;
+      return base.get<T>(entity, id);
+    },
+  };
+}
+
 function storageWithLore(entries: Row[]): StorageGateway {
   return {
     ...storageWithSections([]),
@@ -87,6 +102,48 @@ const request = {
   strictRoleFormatting: true,
   singleUserMessage: false,
 };
+
+describe("assembleGenerationPrompt macro parity", () => {
+  it("resolves charSysInfo and charPostHistory from active character instruction fields", async () => {
+    const assembly = await assembleGenerationPrompt(
+      storageWithSectionsAndCharacters(
+        [
+          section({
+            id: "main",
+            name: "main",
+            role: "system",
+            content: "Sys={{charSysInfo}}\nPost={{charPostHistory}}",
+            sortOrder: 0,
+          }),
+        ],
+        [
+          {
+            id: "char-a",
+            data: {
+              name: "Aster",
+              description: "A roleplay card.",
+              system_prompt: "Always keep Aster's system guidance.",
+              post_history_instructions: "Always keep Aster's post-history guidance.",
+            },
+          },
+        ],
+      ),
+      {
+        chat: { id: "chat", mode: "roleplay", characterIds: ["char-a"] },
+        storedMessages: [],
+        connection: {},
+        request,
+        latestUserInput: "",
+      },
+    );
+
+    const prompt = assembly.messages.map((message) => message.content).join("\n\n");
+    expect(prompt).toContain("Sys=Always keep Aster's system guidance.");
+    expect(prompt).toContain("Post=Always keep Aster's post-history guidance.");
+    expect(prompt).not.toContain("{{charSysInfo}}");
+    expect(prompt).not.toContain("{{charPostHistory}}");
+  });
+});
 
 describe("assembleGenerationPrompt strict roles", () => {
   it("preserves preset chat history roles when history begins with an assistant greeting", async () => {

--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -533,6 +533,8 @@ function macroContext(input: {
       appearance: character.appearance,
       scenario: character.scenario,
       example: character.mesExample,
+      systemPrompt: character.systemPrompt,
+      postHistoryInstructions: character.postHistoryInstructions,
     })),
     variables: stringRecord(input.chat.promptVariables ?? input.chat.variableValues),
     lastInput: input.latestUserInput,
@@ -548,6 +550,8 @@ function macroContext(input: {
           appearance: first.appearance,
           scenario: first.scenario,
           example: first.mesExample,
+          systemPrompt: first.systemPrompt,
+          postHistoryInstructions: first.postHistoryInstructions,
         }
       : undefined,
     personaFields: input.persona

--- a/src/engine/shared/macros/macro-engine.test.ts
+++ b/src/engine/shared/macros/macro-engine.test.ts
@@ -160,6 +160,17 @@ describe("resolveMacros character instruction macros", () => {
     expect(resolved).toBe("");
   });
 
+  it("stops self-referential character field conditionals at a bounded depth", () => {
+    const ctx = conditionalContext({
+      characterFields: {
+        systemPrompt: "{{#if charSysInfo}}loop{{/if}}",
+      },
+    });
+
+    expect(resolveMacros("{{charSysInfo}}", ctx)).toBe("");
+    expect(resolveMacros("{{#if charSysInfo}}present{{else}}missing{{/if}}", ctx)).toBe("missing");
+  });
+
   it("preserves acyclic terminal character field values at the depth boundary", () => {
     const resolved = resolveMacros(
       "{{description}}",

--- a/src/engine/shared/macros/macro-engine.test.ts
+++ b/src/engine/shared/macros/macro-engine.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { formatZonedDate, formatZonedTime, getZonedWeekdayName } from "../time/timezone";
-import { resolveMacros, type MacroContext } from "./macro-engine";
+import { resolveMacros, SUPPORTED_MACROS, type MacroContext } from "./macro-engine";
 
 function baseContext(overrides: Partial<MacroContext> = {}): MacroContext {
   return {
@@ -34,22 +34,160 @@ function conditionalContext(overrides: Partial<MacroContext> = {}): MacroContext
       appearance: "mask and coat",
       scenario: "winter palace",
       example: "Observe carefully.",
+      systemPrompt: "Prioritize clinical precision.",
+      postHistoryInstructions: "Keep experiments consistent after chat history.",
     },
     characterProfiles: [
       {
         name: "Dottore",
         description: "Harbinger doctor",
         personality: "calculating",
+        systemPrompt: "Dottore system guidance",
+        postHistoryInstructions: "Dottore post-history guidance",
       },
       {
         name: "Pantalone",
         description: "Banker harbinger",
         personality: "polished",
+        systemPrompt: "Pantalone system guidance",
+        postHistoryInstructions: "Pantalone post-history guidance",
       },
     ],
     ...rest,
   });
 }
+
+describe("resolveMacros character instruction macros", () => {
+  it("advertises charSysInfo and charPostHistory in the supported macro reference", () => {
+    expect(SUPPORTED_MACROS.map((macro) => macro.syntax)).toEqual(
+      expect.arrayContaining(["{{charSysInfo}}", "{{charPostHistory}}"]),
+    );
+  });
+
+  it("resolves character instruction macros from the active character fields", () => {
+    const resolved = resolveMacros("Sys: {{charSysInfo}}\nPost: {{charPostHistory}}", conditionalContext());
+
+    expect(resolved).toBe(
+      "Sys: Prioritize clinical precision.\nPost: Keep experiments consistent after chat history.",
+    );
+  });
+
+  it("resolves nested macros inside active character instruction fields", () => {
+    const resolved = resolveMacros(
+      "Sys: {{charSysInfo}}\nPost: {{charPostHistory}}",
+      conditionalContext({
+        characterFields: {
+          description: "Harbinger doctor",
+          systemPrompt: "Guide {{char}} for {{user}} using {{description}}.",
+          postHistoryInstructions: "After history: {{charSysInfo}}",
+        },
+      }),
+    );
+
+    expect(resolved).toBe(
+      "Sys: Guide Dottore for Xel using Harbinger doctor.\nPost: After history: Guide Dottore for Xel using Harbinger doctor.",
+    );
+  });
+
+  it("expands character instruction macros per repeated group-chat profile", () => {
+    const resolved = resolveMacros(
+      [
+        "[",
+        "{{char}}",
+        "sys={{charSysInfo}}",
+        "post={{charPostHistory}}",
+        '{{#if charSysInfo contains "Pantalone"}}banker{{else}}other{{/if}}',
+        "]",
+      ].join("\n"),
+      conditionalContext(),
+    );
+
+    expect(resolved).toContain("Dottore\nsys=Dottore system guidance\npost=Dottore post-history guidance\nother");
+    expect(resolved).toContain(
+      "Pantalone\nsys=Pantalone system guidance\npost=Pantalone post-history guidance\nbanker",
+    );
+    expect(resolved).not.toContain("{{charSysInfo}}");
+    expect(resolved).not.toContain("{{charPostHistory}}");
+  });
+
+  it("resolves nested character instruction fields per repeated group-chat profile", () => {
+    const resolved = resolveMacros(
+      [
+        "[",
+        "{{char}}",
+        "sys={{charSysInfo}}",
+        "post={{charPostHistory}}",
+        '{{#if charPostHistory contains "Harbinger doctor"}}nested{{else}}miss{{/if}}',
+        "]",
+      ].join("\n"),
+      conditionalContext({
+        characterProfiles: [
+          {
+            name: "Dottore",
+            description: "Harbinger doctor",
+            systemPrompt: "Guide {{char}} for {{user}} using {{description}}.",
+            postHistoryInstructions: "After history: {{charSysInfo}}",
+          },
+          {
+            name: "Pantalone",
+            description: "Banker harbinger",
+            systemPrompt: "Guide {{char}} for {{user}} using {{description}}.",
+            postHistoryInstructions: "After history: {{charSysInfo}}",
+          },
+        ],
+      }),
+    );
+
+    expect(resolved).toContain(
+      "Dottore\nsys=Guide Dottore for Xel using Harbinger doctor.\npost=After history: Guide Dottore for Xel using Harbinger doctor.\nnested",
+    );
+    expect(resolved).toContain(
+      "Pantalone\nsys=Guide Pantalone for Xel using Banker harbinger.\npost=After history: Guide Pantalone for Xel using Banker harbinger.\nmiss",
+    );
+  });
+
+  it("stops recursive character instruction fields at a bounded depth", () => {
+    const resolved = resolveMacros(
+      "{{charSysInfo}}",
+      conditionalContext({
+        characterFields: {
+          systemPrompt: "{{charPostHistory}}",
+          postHistoryInstructions: "{{charSysInfo}}",
+        },
+      }),
+    );
+
+    expect(resolved).toBe("");
+  });
+
+  it("preserves acyclic terminal character field values at the depth boundary", () => {
+    const resolved = resolveMacros(
+      "{{description}}",
+      conditionalContext({
+        characterFields: {
+          description: "{{personality}}",
+          personality: "{{backstory}}",
+          backstory: "{{appearance}}",
+          appearance: "{{scenario}}",
+          scenario: "Terminal for {{char}} and {{user}}.",
+        },
+      }),
+    );
+
+    expect(resolved).toBe("Terminal for Dottore and Xel.");
+  });
+
+  it("does not evaluate unused character fields", () => {
+    const ctx = conditionalContext({
+      characterFields: {
+        description: "{{#if {{setvar::leaked::yes}}}}unused{{/if}}",
+      },
+    });
+
+    expect(resolveMacros("No character field macros here.", ctx)).toBe("No character field macros here.");
+    expect(ctx.variables.leaked).toBeUndefined();
+  });
+});
 
 describe("resolveMacros conditional blocks", () => {
   it("selects truthy and else branches from variables", () => {

--- a/src/engine/shared/macros/macro-engine.ts
+++ b/src/engine/shared/macros/macro-engine.ts
@@ -67,6 +67,10 @@ export interface ResolveMacroOptions {
   trimResult?: boolean;
 }
 
+interface MacroResolutionState {
+  characterFieldDepth: number;
+}
+
 export interface SupportedMacroDefinition {
   category: string;
   syntax: string;
@@ -210,13 +214,15 @@ function profileFromMacroContext(ctx: MacroContext): CharacterMacroProfile {
   };
 }
 
-function resolveContextCharacterFieldValue(ctx: MacroContext, field: CharacterFieldMacroName): string {
-  return resolveCharacterFieldValue(profileFromMacroContext(ctx), field, 0, ctx);
+function resolveContextCharacterFieldValue(ctx: MacroContext, field: CharacterFieldMacroName, depth = 0): string {
+  return resolveCharacterFieldValue(profileFromMacroContext(ctx), field, depth, ctx);
 }
 
-function resolveContextCharacterFieldOperand(ctx: MacroContext, field: CharacterFieldMacroName): string {
-  const value = resolveContextCharacterFieldValue(ctx, field);
-  return value.includes("{{") ? resolveMacros(value, ctx, { trimResult: false }) : value;
+function resolveContextCharacterFieldOperand(ctx: MacroContext, field: CharacterFieldMacroName, depth: number): string {
+  const value = resolveContextCharacterFieldValue(ctx, field, depth);
+  return value.includes("{{")
+    ? resolveMacrosWithState(value, ctx, { trimResult: false }, { characterFieldDepth: depth })
+    : value;
 }
 
 function macroContextForCharacterProfile(profile: CharacterMacroProfile, base?: MacroContext): MacroContext {
@@ -254,6 +260,7 @@ function resolveCharacterScopedMacros(
   const scoped = resolveConditionalBlocks(
     stripMacroComments(template),
     macroContextForCharacterProfile(profile, baseContext),
+    { characterFieldDepth: depth },
   );
   return scoped
     .replace(/\{\{char(?:Name)?\}\}/gi, profile.name)
@@ -396,12 +403,14 @@ function normalizeConditionKey(value: string): string {
   return value.trim().replace(/^@/, "").toLowerCase();
 }
 
-function resolveConditionalOperand(raw: string, ctx: MacroContext): string {
+function resolveConditionalOperand(raw: string, ctx: MacroContext, state: MacroResolutionState): string {
   const quoted = stripOuterQuotes(raw);
-  if (quoted !== null) return quoted.includes("{{") ? resolveMacros(quoted, ctx, { trimResult: false }) : quoted;
+  if (quoted !== null) {
+    return quoted.includes("{{") ? resolveMacrosWithState(quoted, ctx, { trimResult: false }, state) : quoted;
+  }
 
   const token = raw.trim();
-  if (token.includes("{{")) return resolveMacros(token, ctx, { trimResult: false });
+  if (token.includes("{{")) return resolveMacrosWithState(token, ctx, { trimResult: false }, state);
 
   const normalized = normalizeConditionKey(token);
   switch (normalized) {
@@ -422,21 +431,21 @@ function resolveConditionalOperand(raw: string, ctx: MacroContext): string {
     case "chatid":
       return ctx.chatId ?? "";
     case "description":
-      return resolveContextCharacterFieldOperand(ctx, "description");
+      return resolveContextCharacterFieldOperand(ctx, "description", state.characterFieldDepth);
     case "personality":
-      return resolveContextCharacterFieldOperand(ctx, "personality");
+      return resolveContextCharacterFieldOperand(ctx, "personality", state.characterFieldDepth);
     case "backstory":
-      return resolveContextCharacterFieldOperand(ctx, "backstory");
+      return resolveContextCharacterFieldOperand(ctx, "backstory", state.characterFieldDepth);
     case "appearance":
-      return resolveContextCharacterFieldOperand(ctx, "appearance");
+      return resolveContextCharacterFieldOperand(ctx, "appearance", state.characterFieldDepth);
     case "scenario":
-      return resolveContextCharacterFieldOperand(ctx, "scenario");
+      return resolveContextCharacterFieldOperand(ctx, "scenario", state.characterFieldDepth);
     case "example":
-      return resolveContextCharacterFieldOperand(ctx, "example");
+      return resolveContextCharacterFieldOperand(ctx, "example", state.characterFieldDepth);
     case "charsysinfo":
-      return resolveContextCharacterFieldOperand(ctx, "systemPrompt");
+      return resolveContextCharacterFieldOperand(ctx, "systemPrompt", state.characterFieldDepth);
     case "charposthistory":
-      return resolveContextCharacterFieldOperand(ctx, "postHistoryInstructions");
+      return resolveContextCharacterFieldOperand(ctx, "postHistoryInstructions", state.characterFieldDepth);
     default:
       if (/^var[:.]/i.test(token)) {
         const name = token.replace(/^var[:.]/i, "").trim();
@@ -481,11 +490,11 @@ function compareConditionValues(left: string, operator: string, right: string): 
   }
 }
 
-function evaluateCondition(condition: string, ctx: MacroContext): boolean {
+function evaluateCondition(condition: string, ctx: MacroContext, state: MacroResolutionState): boolean {
   const parsed = parseConditionExpression(condition);
-  const left = resolveConditionalOperand(parsed.left, ctx);
+  const left = resolveConditionalOperand(parsed.left, ctx, state);
   if (parsed.operator === "truthy") return left.trim().length > 0 && !/^(false|0|no|off|null|undefined)$/i.test(left);
-  const right = resolveConditionalOperand(parsed.right ?? "", ctx);
+  const right = resolveConditionalOperand(parsed.right ?? "", ctx, state);
   return compareConditionValues(left, parsed.operator, right);
 }
 
@@ -557,7 +566,11 @@ function findConditionalEnd(
   return null;
 }
 
-function resolveConditionalBlocks(input: string, ctx: MacroContext): string {
+function resolveConditionalBlocks(
+  input: string,
+  ctx: MacroContext,
+  state: MacroResolutionState = { characterFieldDepth: 0 },
+): string {
   let result = "";
   let index = 0;
 
@@ -581,10 +594,10 @@ function resolveConditionalBlocks(input: string, ctx: MacroContext): string {
     const truthy = input.slice(contentStart, blockEnd.elseStart ?? blockEnd.endStart);
     const falsy =
       blockEnd.elseStart === null ? "" : input.slice(blockEnd.elseEnd ?? blockEnd.endStart, blockEnd.endStart);
-    const selected = evaluateCondition(condition, ctx) ? truthy : falsy;
+    const selected = evaluateCondition(condition, ctx, state) ? truthy : falsy;
 
     result += input.slice(index, blockStart);
-    result += resolveConditionalBlocks(selected, ctx);
+    result += resolveConditionalBlocks(selected, ctx, state);
     index = blockEnd.endEnd;
   }
 
@@ -720,6 +733,15 @@ function pickWeightedRandomChoice(choices: string[]): string {
  *  - {{#if char == "Name"}}...{{else}}...{{/if}} - conditional block
  */
 export function resolveMacros(template: string, ctx: MacroContext, options: ResolveMacroOptions = {}): string {
+  return resolveMacrosWithState(template, ctx, options, { characterFieldDepth: 0 });
+}
+
+function resolveMacrosWithState(
+  template: string,
+  ctx: MacroContext,
+  options: ResolveMacroOptions,
+  state: MacroResolutionState,
+): string {
   let result = template;
   const personaText = [
     ctx.personaFields?.description,
@@ -736,23 +758,37 @@ export function resolveMacros(template: string, ctx: MacroContext, options: Reso
 
   // ── Multi-character bracket blocks — expand before global substitutions ──
   result = expandBracketedCharacterBlocks(result, ctx);
-  result = resolveConditionalBlocks(result, ctx);
+  result = resolveConditionalBlocks(result, ctx, state);
 
   // ── No-op & banned ──
   result = result.replace(/\{\{noop\}\}/gi, "");
   result = result.replace(/\{\{banned\s+"[^"]*"\}\}/gi, "");
 
   // ── Character field substitutions ──
-  result = result.replace(/\{\{description\}\}/gi, () => resolveContextCharacterFieldValue(ctx, "description"));
-  result = result.replace(/\{\{personality\}\}/gi, () => resolveContextCharacterFieldValue(ctx, "personality"));
-  result = result.replace(/\{\{backstory\}\}/gi, () => resolveContextCharacterFieldValue(ctx, "backstory"));
-  result = result.replace(/\{\{appearance\}\}/gi, () => resolveContextCharacterFieldValue(ctx, "appearance"));
-  result = result.replace(/\{\{scenario\}\}/gi, () => resolveContextCharacterFieldValue(ctx, "scenario"));
-  result = result.replace(/\{\{example\}\}/gi, () => resolveContextCharacterFieldValue(ctx, "example"));
-  result = result.replace(/\{\{charSysInfo\}\}/gi, () => resolveContextCharacterFieldValue(ctx, "systemPrompt"));
+  result = result.replace(/\{\{description\}\}/gi, () =>
+    resolveContextCharacterFieldValue(ctx, "description", state.characterFieldDepth),
+  );
+  result = result.replace(/\{\{personality\}\}/gi, () =>
+    resolveContextCharacterFieldValue(ctx, "personality", state.characterFieldDepth),
+  );
+  result = result.replace(/\{\{backstory\}\}/gi, () =>
+    resolveContextCharacterFieldValue(ctx, "backstory", state.characterFieldDepth),
+  );
+  result = result.replace(/\{\{appearance\}\}/gi, () =>
+    resolveContextCharacterFieldValue(ctx, "appearance", state.characterFieldDepth),
+  );
+  result = result.replace(/\{\{scenario\}\}/gi, () =>
+    resolveContextCharacterFieldValue(ctx, "scenario", state.characterFieldDepth),
+  );
+  result = result.replace(/\{\{example\}\}/gi, () =>
+    resolveContextCharacterFieldValue(ctx, "example", state.characterFieldDepth),
+  );
+  result = result.replace(/\{\{charSysInfo\}\}/gi, () =>
+    resolveContextCharacterFieldValue(ctx, "systemPrompt", state.characterFieldDepth),
+  );
   result = result.replace(
     /\{\{charPostHistory\}\}/gi,
-    () => resolveContextCharacterFieldValue(ctx, "postHistoryInstructions"),
+    () => resolveContextCharacterFieldValue(ctx, "postHistoryInstructions", state.characterFieldDepth),
   );
 
   // ── Static substitutions ──
@@ -791,7 +827,7 @@ export function resolveMacros(template: string, ctx: MacroContext, options: Reso
       .filter(Boolean);
     if (choices.length === 0) return "";
     const choice = pickWeightedRandomChoice(choices);
-    return resolveMacros(choice, ctx, { ...options, trimResult: false });
+    return resolveMacrosWithState(choice, ctx, { ...options, trimResult: false }, state);
   });
   result = result.replace(/\{\{random:(\d+):(\d+)\}\}/gi, (_, min, max) => {
     const lo = parseInt(min, 10);
@@ -820,11 +856,12 @@ export function resolveMacros(template: string, ctx: MacroContext, options: Reso
       case "getvar":
         return ctx.variables[name] ?? "";
       case "setvar":
-        ctx.variables[name] = resolveMacros(writeMatch?.[3] ?? "", ctx, { ...options, trimResult: false });
+        ctx.variables[name] = resolveMacrosWithState(writeMatch?.[3] ?? "", ctx, { ...options, trimResult: false }, state);
         return "";
       case "addvar":
         ctx.variables[name] =
-          (ctx.variables[name] ?? "") + resolveMacros(writeMatch?.[3] ?? "", ctx, { ...options, trimResult: false });
+          (ctx.variables[name] ?? "") +
+          resolveMacrosWithState(writeMatch?.[3] ?? "", ctx, { ...options, trimResult: false }, state);
         return "";
       case "incvar":
         ctx.variables[name] = String((parseInt(ctx.variables[name] ?? "0", 10) || 0) + 1);

--- a/src/engine/shared/macros/macro-engine.ts
+++ b/src/engine/shared/macros/macro-engine.ts
@@ -23,6 +23,8 @@ export interface MacroContext {
     appearance?: string;
     scenario?: string;
     example?: string;
+    systemPrompt?: string;
+    postHistoryInstructions?: string;
   }>;
   /** Custom variables from prompt toggle groups */
   variables: Record<string, string>;
@@ -42,6 +44,8 @@ export interface MacroContext {
     appearance?: string;
     scenario?: string;
     example?: string;
+    systemPrompt?: string;
+    postHistoryInstructions?: string;
   };
   /** Active persona card fields used by {{persona}} */
   personaFields?: {
@@ -70,7 +74,13 @@ export interface SupportedMacroDefinition {
 }
 
 const CHARACTER_MACRO_PATTERN =
-  /\{\{(?:char|charName|description|personality|backstory|appearance|scenario|example)\}\}|\{\{\s*#if\s+[^}]*\b(?:char|charName|character|speaker|description|personality|backstory|appearance|scenario|example)\b/i;
+  /\{\{(?:char|charName|description|personality|backstory|appearance|scenario|example|charSysInfo|charPostHistory)\}\}|\{\{\s*#if\s+[^}]*\b(?:char|charName|character|speaker|description|personality|backstory|appearance|scenario|example|charSysInfo|charPostHistory)\b/i;
+const CHARACTER_FIELD_MACRO_PATTERN =
+  /\{\{(?:description|personality|backstory|appearance|scenario|example|charSysInfo|charPostHistory)\}\}|\{\{\s*#if\s+[^}]*\b(?:description|personality|backstory|appearance|scenario|example|charSysInfo|charPostHistory)\b/i;
+const MAX_CHARACTER_FIELD_RESOLUTION_DEPTH = 4;
+
+type CharacterMacroProfile = NonNullable<MacroContext["characterProfiles"]>[number];
+type CharacterFieldMacroName = keyof NonNullable<MacroContext["characterFields"]>;
 
 export const SUPPORTED_MACROS: readonly SupportedMacroDefinition[] = [
   { category: "Identity", syntax: "{{user}}", description: "Current user or persona name" },
@@ -89,6 +99,12 @@ export const SUPPORTED_MACROS: readonly SupportedMacroDefinition[] = [
   { category: "Character", syntax: "{{appearance}}", description: "Current character appearance" },
   { category: "Character", syntax: "{{scenario}}", description: "Current character scenario" },
   { category: "Character", syntax: "{{example}}", description: "Current character example dialogue" },
+  { category: "Character", syntax: "{{charSysInfo}}", description: "Current character system prompt" },
+  {
+    category: "Character",
+    syntax: "{{charPostHistory}}",
+    description: "Current character post-history instructions",
+  },
   { category: "Context", syntax: "{{input}}", description: "Most recent user message" },
   { category: "Context", syntax: "{{model}}", description: "Current model name" },
   { category: "Context", syntax: "{{chatId}}", description: "Current chat ID" },
@@ -146,10 +162,64 @@ export const SUPPORTED_MACROS: readonly SupportedMacroDefinition[] = [
   },
 ];
 
-function macroContextForCharacterProfile(
-  profile: NonNullable<MacroContext["characterProfiles"]>[number],
-  base?: MacroContext,
-): MacroContext {
+function stripMacroComments(value: string): string {
+  return value.replace(/\{\{\/\/[^}]*\}\}/g, "");
+}
+
+function getCharacterFieldValue(profile: CharacterMacroProfile, field: CharacterFieldMacroName): string {
+  return stripMacroComments(profile[field] ?? "");
+}
+
+function resolveTerminalCharacterFieldValue(
+  value: string,
+  profile: CharacterMacroProfile,
+  baseContext?: MacroContext,
+): string {
+  if (CHARACTER_FIELD_MACRO_PATTERN.test(value)) return "";
+  return resolveConditionalBlocks(value, macroContextForCharacterProfile(profile, baseContext)).replace(
+    /\{\{char(?:Name)?\}\}/gi,
+    profile.name,
+  );
+}
+
+function resolveCharacterFieldValue(
+  profile: CharacterMacroProfile,
+  field: CharacterFieldMacroName,
+  depth: number,
+  baseContext?: MacroContext,
+): string {
+  const value = getCharacterFieldValue(profile, field);
+  if (!value) return "";
+  if (depth >= MAX_CHARACTER_FIELD_RESOLUTION_DEPTH) {
+    return resolveTerminalCharacterFieldValue(value, profile, baseContext);
+  }
+  return resolveCharacterScopedMacros(value, profile, baseContext, depth + 1);
+}
+
+function profileFromMacroContext(ctx: MacroContext): CharacterMacroProfile {
+  return {
+    name: ctx.char,
+    description: ctx.characterFields?.description ?? "",
+    personality: ctx.characterFields?.personality ?? "",
+    backstory: ctx.characterFields?.backstory ?? "",
+    appearance: ctx.characterFields?.appearance ?? "",
+    scenario: ctx.characterFields?.scenario ?? "",
+    example: ctx.characterFields?.example ?? "",
+    systemPrompt: ctx.characterFields?.systemPrompt ?? "",
+    postHistoryInstructions: ctx.characterFields?.postHistoryInstructions ?? "",
+  };
+}
+
+function resolveContextCharacterFieldValue(ctx: MacroContext, field: CharacterFieldMacroName): string {
+  return resolveCharacterFieldValue(profileFromMacroContext(ctx), field, 0, ctx);
+}
+
+function resolveContextCharacterFieldOperand(ctx: MacroContext, field: CharacterFieldMacroName): string {
+  const value = resolveContextCharacterFieldValue(ctx, field);
+  return value.includes("{{") ? resolveMacros(value, ctx, { trimResult: false }) : value;
+}
+
+function macroContextForCharacterProfile(profile: CharacterMacroProfile, base?: MacroContext): MacroContext {
   return {
     user: base?.user ?? "User",
     char: profile.name,
@@ -169,24 +239,34 @@ function macroContextForCharacterProfile(
       appearance: profile.appearance ?? "",
       scenario: profile.scenario ?? "",
       example: profile.example ?? "",
+      systemPrompt: profile.systemPrompt ?? "",
+      postHistoryInstructions: profile.postHistoryInstructions ?? "",
     },
   };
 }
 
 function resolveCharacterScopedMacros(
   template: string,
-  profile: NonNullable<MacroContext["characterProfiles"]>[number],
+  profile: CharacterMacroProfile,
   baseContext?: MacroContext,
+  depth = 0,
 ): string {
-  const scoped = resolveConditionalBlocks(template, macroContextForCharacterProfile(profile, baseContext));
+  const scoped = resolveConditionalBlocks(
+    stripMacroComments(template),
+    macroContextForCharacterProfile(profile, baseContext),
+  );
   return scoped
     .replace(/\{\{char(?:Name)?\}\}/gi, profile.name)
-    .replace(/\{\{description\}\}/gi, profile.description ?? "")
-    .replace(/\{\{personality\}\}/gi, profile.personality ?? "")
-    .replace(/\{\{backstory\}\}/gi, profile.backstory ?? "")
-    .replace(/\{\{appearance\}\}/gi, profile.appearance ?? "")
-    .replace(/\{\{scenario\}\}/gi, profile.scenario ?? "")
-    .replace(/\{\{example\}\}/gi, profile.example ?? "");
+    .replace(/\{\{description\}\}/gi, () => resolveCharacterFieldValue(profile, "description", depth, baseContext))
+    .replace(/\{\{personality\}\}/gi, () => resolveCharacterFieldValue(profile, "personality", depth, baseContext))
+    .replace(/\{\{backstory\}\}/gi, () => resolveCharacterFieldValue(profile, "backstory", depth, baseContext))
+    .replace(/\{\{appearance\}\}/gi, () => resolveCharacterFieldValue(profile, "appearance", depth, baseContext))
+    .replace(/\{\{scenario\}\}/gi, () => resolveCharacterFieldValue(profile, "scenario", depth, baseContext))
+    .replace(/\{\{example\}\}/gi, () => resolveCharacterFieldValue(profile, "example", depth, baseContext))
+    .replace(/\{\{charSysInfo\}\}/gi, () => resolveCharacterFieldValue(profile, "systemPrompt", depth, baseContext))
+    .replace(/\{\{charPostHistory\}\}/gi, () =>
+      resolveCharacterFieldValue(profile, "postHistoryInstructions", depth, baseContext),
+    );
 }
 
 function expandBracketedCharacterBlocks(template: string, ctx: MacroContext): string {
@@ -342,17 +422,21 @@ function resolveConditionalOperand(raw: string, ctx: MacroContext): string {
     case "chatid":
       return ctx.chatId ?? "";
     case "description":
-      return ctx.characterFields?.description ?? "";
+      return resolveContextCharacterFieldOperand(ctx, "description");
     case "personality":
-      return ctx.characterFields?.personality ?? "";
+      return resolveContextCharacterFieldOperand(ctx, "personality");
     case "backstory":
-      return ctx.characterFields?.backstory ?? "";
+      return resolveContextCharacterFieldOperand(ctx, "backstory");
     case "appearance":
-      return ctx.characterFields?.appearance ?? "";
+      return resolveContextCharacterFieldOperand(ctx, "appearance");
     case "scenario":
-      return ctx.characterFields?.scenario ?? "";
+      return resolveContextCharacterFieldOperand(ctx, "scenario");
     case "example":
-      return ctx.characterFields?.example ?? "";
+      return resolveContextCharacterFieldOperand(ctx, "example");
+    case "charsysinfo":
+      return resolveContextCharacterFieldOperand(ctx, "systemPrompt");
+    case "charposthistory":
+      return resolveContextCharacterFieldOperand(ctx, "postHistoryInstructions");
     default:
       if (/^var[:.]/i.test(token)) {
         const name = token.replace(/^var[:.]/i, "").trim();
@@ -658,17 +742,24 @@ export function resolveMacros(template: string, ctx: MacroContext, options: Reso
   result = result.replace(/\{\{noop\}\}/gi, "");
   result = result.replace(/\{\{banned\s+"[^"]*"\}\}/gi, "");
 
+  // ── Character field substitutions ──
+  result = result.replace(/\{\{description\}\}/gi, () => resolveContextCharacterFieldValue(ctx, "description"));
+  result = result.replace(/\{\{personality\}\}/gi, () => resolveContextCharacterFieldValue(ctx, "personality"));
+  result = result.replace(/\{\{backstory\}\}/gi, () => resolveContextCharacterFieldValue(ctx, "backstory"));
+  result = result.replace(/\{\{appearance\}\}/gi, () => resolveContextCharacterFieldValue(ctx, "appearance"));
+  result = result.replace(/\{\{scenario\}\}/gi, () => resolveContextCharacterFieldValue(ctx, "scenario"));
+  result = result.replace(/\{\{example\}\}/gi, () => resolveContextCharacterFieldValue(ctx, "example"));
+  result = result.replace(/\{\{charSysInfo\}\}/gi, () => resolveContextCharacterFieldValue(ctx, "systemPrompt"));
+  result = result.replace(
+    /\{\{charPostHistory\}\}/gi,
+    () => resolveContextCharacterFieldValue(ctx, "postHistoryInstructions"),
+  );
+
   // ── Static substitutions ──
   result = result.replace(/\{\{user(?:Name)?\}\}/gi, ctx.user);
   result = result.replace(/\{\{persona\}\}/gi, personaText);
   result = result.replace(/\{\{char(?:Name)?\}\}/gi, ctx.char);
   result = result.replace(/\{\{characters\}\}/gi, ctx.characters.join(", "));
-  result = result.replace(/\{\{description\}\}/gi, ctx.characterFields?.description ?? "");
-  result = result.replace(/\{\{personality\}\}/gi, ctx.characterFields?.personality ?? "");
-  result = result.replace(/\{\{backstory\}\}/gi, ctx.characterFields?.backstory ?? "");
-  result = result.replace(/\{\{appearance\}\}/gi, ctx.characterFields?.appearance ?? "");
-  result = result.replace(/\{\{scenario\}\}/gi, ctx.characterFields?.scenario ?? "");
-  result = result.replace(/\{\{example\}\}/gi, ctx.characterFields?.example ?? "");
   result = result.replace(/\{\{input\}\}/gi, ctx.lastInput ?? "");
   result = result.replace(/\{\{model\}\}/gi, ctx.model ?? "");
   result = result.replace(/\{\{chatId\}\}/gi, ctx.chatId ?? "");

--- a/src/features/catalog/agents/components/RegexScriptEditor.tsx
+++ b/src/features/catalog/agents/components/RegexScriptEditor.tsx
@@ -60,6 +60,8 @@ function createLiveTestMacroContext(input: string): MacroContext {
       appearance: "Character appearance",
       scenario: "Character scenario",
       example: "Character example",
+      systemPrompt: "Character system prompt",
+      postHistoryInstructions: "Character post-history instructions",
     },
     personaFields: {
       description: "Persona description",

--- a/src/features/modes/shared/chat-ui/hooks/use-chat-surface-data.ts
+++ b/src/features/modes/shared/chat-ui/hooks/use-chat-surface-data.ts
@@ -205,6 +205,8 @@ export function useChatSurfaceData({
           appearance: parsed.extensions?.appearance ?? "",
           scenario: parsed.scenario ?? "",
           example: parsed.mes_example ?? "",
+          systemPrompt: parsed.system_prompt ?? parsed.systemPrompt ?? "",
+          postHistoryInstructions: parsed.post_history_instructions ?? parsed.postHistoryInstructions ?? "",
           avatarUrl: character.avatarPath ?? null,
           nameColor: parsed.extensions?.nameColor || undefined,
           dialogueColor: parsed.extensions?.dialogueColor || undefined,

--- a/src/features/runtime/visuals/types.ts
+++ b/src/features/runtime/visuals/types.ts
@@ -10,6 +10,8 @@ export type CharacterMap = Map<
     appearance?: string;
     scenario?: string;
     example?: string;
+    systemPrompt?: string;
+    postHistoryInstructions?: string;
     avatarUrl: string | null;
     nameColor?: string;
     dialogueColor?: string;

--- a/src/shared/lib/chat-macros.test.ts
+++ b/src/shared/lib/chat-macros.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { parseCharacterMacroData, resolveMessageMacros } from "./chat-macros";
+
+describe("chat macro character instruction fields", () => {
+  it("plumbs parsed character instruction fields into message macro resolution", () => {
+    const character = parseCharacterMacroData({
+      id: "char-a",
+      data: {
+        name: "Aster",
+        system_prompt: "Display system guidance.",
+        post_history_instructions: "Display post-history guidance.",
+      },
+    });
+
+    expect(character).not.toBeNull();
+    expect(
+      resolveMessageMacros("{{char}}|{{charSysInfo}}|{{charPostHistory}}", {
+        primaryCharacter: character,
+        characters: character ? [character] : [],
+      }),
+    ).toBe("Aster|Display system guidance.|Display post-history guidance.");
+  });
+});

--- a/src/shared/lib/chat-macros.ts
+++ b/src/shared/lib/chat-macros.ts
@@ -9,6 +9,8 @@ export interface MacroCharacterData {
   appearance?: string;
   scenario?: string;
   example?: string;
+  systemPrompt?: string;
+  postHistoryInstructions?: string;
 }
 
 export interface MacroPersonaData {
@@ -83,6 +85,8 @@ export function parseCharacterMacroData(
       appearance: getString(extensions?.appearance),
       scenario: getString(data.scenario),
       example: getString(data.mes_example),
+      systemPrompt: getString(data.system_prompt) || getString(data.systemPrompt),
+      postHistoryInstructions: getString(data.post_history_instructions) || getString(data.postHistoryInstructions),
     };
   } catch {
     return { id: raw.id, name: "Unknown" };
@@ -172,6 +176,17 @@ export function buildMessageMacroContext({
     user: userName ?? persona?.name ?? "User",
     char: fallbackCharacter?.name ?? "Character",
     characters: characters.map((character) => character.name).filter((name) => name.trim().length > 0),
+    characterProfiles: characters.map((character) => ({
+      name: character.name,
+      description: character.description ?? "",
+      personality: character.personality ?? "",
+      backstory: character.backstory ?? "",
+      appearance: character.appearance ?? "",
+      scenario: character.scenario ?? "",
+      example: character.example ?? "",
+      systemPrompt: character.systemPrompt ?? "",
+      postHistoryInstructions: character.postHistoryInstructions ?? "",
+    })),
     variables,
     lastInput,
     characterFields: fallbackCharacter
@@ -182,6 +197,8 @@ export function buildMessageMacroContext({
           appearance: fallbackCharacter.appearance ?? "",
           scenario: fallbackCharacter.scenario ?? "",
           example: fallbackCharacter.example ?? "",
+          systemPrompt: fallbackCharacter.systemPrompt ?? "",
+          postHistoryInstructions: fallbackCharacter.postHistoryInstructions ?? "",
         }
       : undefined,
     personaFields: persona


### PR DESCRIPTION
## Linked issue

Closes #1335

## Why this change

- The refactor macro engine did not expose `{{charSysInfo}}` or `{{charPostHistory}}`, leaving legacy character system and post-history prompt fields unavailable in prompt/display macro expansion.
- Nested character-field macros also needed bounded resolution that preserves valid terminal values while still stopping recursive cycles.

## What changed

- Added `{{charSysInfo}}` and `{{charPostHistory}}` to the shared macro engine, supported macro list, active-character context, and grouped character expansion.
- Plumbed character `systemPrompt` and `postHistoryInstructions` through prompt assembly, shared chat macro helpers, chat surface character maps, runtime visual character maps, and regex script live-test context.
- Added regression coverage for direct, nested, grouped, recursive, and lazy character-field macro resolution.

## Refactor impact

Primary owner:

engine generation / shared macro engine

Impact areas reviewed:

- Engine prompt assembly character profile context
- Shared chat macro context used by mode chat/display surfaces
- Runtime visual character map typing
- Regex script editor macro live-test sample context
- Macro reference/help list through `SUPPORTED_MACROS`

Boundary notes:

- Engine macro behavior remains React/Tauri-free.
- Feature-layer changes only pass existing character fields into macro context.
- No raw Tauri, raw HTTP, remote runtime, storage, or Rust capability boundary changes.

Pressure points touched:

- Shared mode UI character data mapping
- Runtime visual character map shape
- Regex script live-test macro context

## Validation

- [x] `pnpm check` passes locally
- [x] `pnpm typecheck` passes locally
- [x] `pnpm build` passes locally
- [x] `pnpm check:architecture` passes locally
- [x] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

Agent-run local checks:

- `pnpm vitest run src/engine/shared/macros/macro-engine.test.ts`
- `pnpm vitest run src/engine/shared/macros/macro-engine.test.ts src/engine/generation/prompt-assembly.test.ts src/shared/lib/chat-macros.test.ts`
- `pnpm typecheck`
- `pnpm check:architecture`
- `git diff --check`
- `pnpm test`
- `pnpm lint`
- `pnpm build`
- `git diff --cached --check`

No native Tauri/manual prompt-preview QA was run; this is the remaining end-to-end app verification gap.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

No changelog file exists on this branch, so no changelog update was made.

## UI evidence

Not applicable: this does not change visible layout. The only UI-adjacent change updates macro live-test sample context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new character macros: `{{charSysInfo}}` for character system prompts and `{{charPostHistory}}` for character post-history instructions, enabling enhanced character-based prompt customization.

* **Tests**
  * Extended test coverage for the new character instruction macros, validating proper resolution, nested macro expansion, recursion handling, and conditional block support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1390?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->