### PR TITLE
Fix summary popover settings

### DIFF
--- a/src/features/catalog/chats/hooks/use-chats.ts
+++ b/src/features/catalog/chats/hooks/use-chats.ts
@@ -14,7 +14,15 @@ import { useChatStore } from "../../../../shared/stores/chat.store";
 import { ApiError } from "../../../../shared/api/api-errors";
 import { apiQueryRetryDelay, shouldRetryApiQuery } from "../../../../shared/api/query-retry";
 import { lorebookKeys } from "../../lorebooks/query-keys";
-import type { Chat, ChatMemoryChunk, ConversationNote, Message, MessageSwipe, DaySummaryEntry, WeekSummaryEntry } from "../../../../engine/contracts/types/chat";
+import type {
+  Chat,
+  ChatMemoryChunk,
+  ConversationNote,
+  Message,
+  MessageSwipe,
+  DaySummaryEntry,
+  WeekSummaryEntry,
+} from "../../../../engine/contracts/types/chat";
 
 export { chatKeys } from "../query-keys";
 
@@ -715,6 +723,57 @@ export function useUpdateMessageExtra(chatId: string | null) {
   });
 }
 
+export function useBulkSetMessagesHiddenFromAI(chatId: string | null) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ messageIds, hidden }: { messageIds: string[]; hidden: boolean }) => {
+      if (!chatId) throw new Error("Chat was not found.");
+      const uniqueIds = Array.from(new Set(messageIds.filter((id) => id.trim().length > 0)));
+      await Promise.all(
+        uniqueIds.map(async (messageId) => {
+          const message = await storageApi.get<Message>("messages", messageId);
+          if (!message || message.chatId !== chatId) return null;
+          return storageApi.patchChatMessageExtra<Message>(messageId, { hiddenFromAI: hidden, hiddenFromAi: hidden });
+        }),
+      );
+      return { updated: uniqueIds.length };
+    },
+    onMutate: async ({ messageIds, hidden }) => {
+      if (!chatId) return;
+      await qc.cancelQueries({ queryKey: chatKeys.messages(chatId) });
+      const previous = qc.getQueryData<InfiniteData<Message[]>>(chatKeys.messages(chatId));
+      const idSet = new Set(messageIds);
+      qc.setQueryData<InfiniteData<Message[]>>(chatKeys.messages(chatId), (old) => {
+        if (!old?.pages) return old;
+        return {
+          ...old,
+          pages: old.pages.map((page) =>
+            page.map((msg) => {
+              if (!idSet.has(msg.id)) return msg;
+              return {
+                ...msg,
+                extra: { ...parseRecord(msg.extra), hiddenFromAI: hidden, hiddenFromAi: hidden } as unknown as Message["extra"],
+              };
+            }),
+          ),
+        };
+      });
+      return { previous };
+    },
+    onError: (_err, _vars, context) => {
+      if (chatId && context?.previous) {
+        qc.setQueryData(chatKeys.messages(chatId), context.previous);
+      }
+    },
+    onSettled: () => {
+      if (chatId) {
+        qc.invalidateQueries({ queryKey: chatKeys.messages(chatId) });
+        qc.invalidateQueries({ queryKey: lorebookKeys.active(chatId) });
+      }
+    },
+  });
+}
+
 function replaceCachedMessage(
   old: InfiniteData<Message[]> | undefined,
   messageId: string,
@@ -784,6 +843,17 @@ function messageHiddenFromAi(message: Message) {
   return extra.hiddenFromAI === true || extra.hiddenFromAi === true;
 }
 
+export type GenerateSummaryInput = {
+  chatId: string;
+  contextSize?: number;
+  rangeStartIndex?: number;
+  rangeEndIndex?: number;
+};
+
+export type GenerateSummaryResult = {
+  summary: string;
+  messageIds: string[];
+};
 
 function compactTranscript(messages: Message[]) {
   return messages
@@ -805,7 +875,8 @@ async function resolveSummaryConnectionId(chat: Chat): Promise<string> {
   return connectionId;
 }
 
-async function generateLlmChatSummary(chatId: string, contextSize?: number): Promise<{ summary: string }> {
+async function generateLlmChatSummary(input: GenerateSummaryInput): Promise<GenerateSummaryResult> {
+  const { chatId, contextSize, rangeStartIndex, rangeEndIndex } = input;
   const [chat, allMessages] = await Promise.all([
     storageApi.get<Chat>("chats", chatId),
     storageApi.listChatMessages<Message>(chatId),
@@ -813,10 +884,20 @@ async function generateLlmChatSummary(chatId: string, contextSize?: number): Pro
   if (!chat) throw new Error("Chat was not found.");
   const storedContextSize = Number((chat.metadata as { summaryContextSize?: unknown } | null)?.summaryContextSize);
   const limit = Math.max(5, Math.min(200, Math.trunc(contextSize ?? (Number.isFinite(storedContextSize) ? storedContextSize : 50))));
-  const selected = allMessages
-    .filter((message) => !messageHiddenFromAi(message) && !!message.content?.trim())
-    .slice(-limit);
-  if (selected.length === 0) throw new Error("No non-hidden messages available for summary generation.");
+  const hasRange = Number.isInteger(rangeStartIndex) && Number.isInteger(rangeEndIndex);
+  const rangeLow = hasRange ? Math.max(1, Math.min(rangeStartIndex!, rangeEndIndex!)) : null;
+  const rangeHigh = hasRange ? Math.max(rangeStartIndex!, rangeEndIndex!) : null;
+  if (hasRange) {
+    if (!rangeLow || !rangeHigh || rangeHigh > allMessages.length) {
+      throw new Error("Summary range is outside this chat's message history.");
+    }
+    if (rangeHigh - rangeLow + 1 > 200) {
+      throw new Error("Summary ranges cannot include more than 200 messages.");
+    }
+  }
+  const sourceMessages = hasRange ? allMessages.slice(rangeLow! - 1, rangeHigh ?? undefined) : allMessages.slice(-limit);
+  const selected = sourceMessages.filter((message) => !messageHiddenFromAi(message) && !!message.content?.trim());
+  if (selected.length === 0) throw new Error("No non-hidden messages available for the requested summary.");
 
   const connectionId = await resolveSummaryConnectionId(chat);
   const transcript = compactTranscript(selected);
@@ -845,9 +926,11 @@ async function generateLlmChatSummary(chatId: string, contextSize?: number): Pro
     {
       content,
       origin: "manual",
-      sourceMode: "last",
-      title: "Summary of recent messages",
-      messageCount: selected.length,
+      sourceMode: hasRange ? "range" : "last",
+      title: hasRange ? `Summary messages ${rangeLow}-${rangeHigh}` : "Summary of recent messages",
+      messageCount: hasRange ? undefined : selected.length,
+      rangeStartIndex: rangeLow ?? undefined,
+      rangeEndIndex: rangeHigh ?? undefined,
       messageIds: selected.map((message) => message.id),
     },
     {
@@ -862,7 +945,7 @@ async function generateLlmChatSummary(chatId: string, contextSize?: number): Pro
     summaryEntries: appended.entries,
     summaryContextSize: limit,
   });
-  return { summary: appended.summary ?? content };
+  return { summary: appended.summary ?? content, messageIds: selected.map((message) => message.id) };
 }
 
 /** Peek at the assembled prompt for a chat */
@@ -977,8 +1060,7 @@ export function useBranchChat() {
 export function useGenerateSummary() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: ({ chatId, contextSize }: { chatId: string; contextSize?: number }) =>
-      generateLlmChatSummary(chatId, contextSize),
+    mutationFn: (input: GenerateSummaryInput) => generateLlmChatSummary(input),
     onSuccess: (_data, vars) => {
       qc.invalidateQueries({ queryKey: chatKeys.detail(vars.chatId) });
     },

--- a/src/features/modes/conversation/components/ConversationMessage.tsx
+++ b/src/features/modes/conversation/components/ConversationMessage.tsx
@@ -10,6 +10,7 @@ import {
   RefreshCw,
   Eye,
   EyeOff,
+  ChevronRight,
   ScrollText,
   Brain,
   X,
@@ -51,6 +52,41 @@ function nameColorStyle(color?: string): CSSProperties | undefined {
 
 /** Regex to detect a message that is just an image/GIF URL */
 const IMAGE_URL_RE = /^https?:\/\/\S+\.(?:gif|png|jpe?g|webp)(?:\?[^\s]*)?$/i;
+
+function HiddenFromAIConversationButton({
+  canCollapse,
+  isExpanded,
+  onToggle,
+}: {
+  canCollapse: boolean;
+  isExpanded: boolean;
+  onToggle: () => void;
+}) {
+  const className =
+    "inline-flex items-center gap-1 rounded px-1 py-0.5 text-[0.625rem] font-medium text-amber-500/80";
+  if (!canCollapse) {
+    return (
+      <span className={className} title="Hidden from AI">
+        <EyeOff size="0.7rem" />
+      </span>
+    );
+  }
+  return (
+    <button
+      type="button"
+      onClick={(event) => {
+        event.stopPropagation();
+        onToggle();
+      }}
+      className={`${className} transition-colors hover:bg-amber-500/10 hover:text-amber-400`}
+      title={isExpanded ? "Collapse hidden from AI message" : "Expand hidden from AI message"}
+      aria-label={isExpanded ? "Collapse hidden from AI message" : "Expand hidden from AI message"}
+    >
+      <ChevronRight size="0.7rem" className={cn("transition-transform", isExpanded && "rotate-90")} />
+      <EyeOff size="0.7rem" />
+    </button>
+  );
+}
 
 /** Highlight @mentions in a list of ReactNodes. Scans string nodes for @CharacterName and wraps matches in a styled span. */
 function highlightMentions(nodes: ReactNode[], names: string[], keyPrefix: string): ReactNode[] {
@@ -295,12 +331,14 @@ export const ConversationMessage = memo(function ConversationMessage({
   const [copied, setCopied] = useState(false);
   const [showThinking, setShowThinking] = useState(false);
   const [showGenerationReplay, setShowGenerationReplay] = useState(false);
+  const [manuallyExpandedHidden, setManuallyExpandedHidden] = useState(false);
   const [imageLightbox, setImageLightbox] = useState<{ url: string; prompt?: string | null } | null>(null);
   const editRef = useRef<HTMLTextAreaElement>(null);
   const hasInput = useChatStore((s) => s.currentInput.trim().length > 0);
   const guideGenerations = useUIStore((s) => s.guideGenerations);
   const chatFontSize = useUIStore((s) => s.chatFontSize);
   const showMessageNumbers = useUIStore((s) => s.showMessageNumbers);
+  const collapseHiddenMessages = useUIStore((s) => s.summaryPopoverSettings.collapseHiddenMessages);
   const messageTextStyle = useMemo<CSSProperties>(() => ({ fontSize: `${chatFontSize}px` }), [chatFontSize]);
   const isGuided = guideGenerations && hasInput;
   const regenerateButtonTitle = isGuided ? "Regenerate (guided)" : "Regenerate";
@@ -322,7 +360,17 @@ export const ConversationMessage = memo(function ConversationMessage({
     return typeof message.extra === "string" ? JSON.parse(message.extra) : message.extra;
   }, [message.extra]);
   const generationReplay = hasGenerationReplayDetails(extra.generationReplay) ? extra.generationReplay : null;
-  const isHiddenFromAI = extra.hiddenFromAI === true;
+  const isHiddenFromAI = extra.hiddenFromAI === true || extra.hiddenFromAi === true;
+  const isHiddenExpanded =
+    isHiddenFromAI && (!collapseHiddenMessages || manuallyExpandedHidden || editing || isStreaming === true);
+  const isHiddenCollapsed = isHiddenFromAI && collapseHiddenMessages && !isHiddenExpanded;
+  const hiddenFromAIHeader = isHiddenFromAI ? (
+    <HiddenFromAIConversationButton
+      canCollapse={collapseHiddenMessages}
+      isExpanded={isHiddenExpanded}
+      onToggle={() => setManuallyExpandedHidden((value) => !value)}
+    />
+  ) : null;
   // canRegenerate lets assistant messages retry; isUser messages need generationReplay
   // metadata from hasGenerationReplayDetails, such as /impersonate.
   const canRegenerate = !isUser || generationReplay !== null;
@@ -330,6 +378,14 @@ export const ConversationMessage = memo(function ConversationMessage({
   useEffect(() => {
     if (!generationReplay) setShowGenerationReplay(false);
   }, [generationReplay]);
+
+  useEffect(() => {
+    setManuallyExpandedHidden(false);
+  }, [message.id]);
+
+  useEffect(() => {
+    if (!isHiddenFromAI || !collapseHiddenMessages) setManuallyExpandedHidden(false);
+  }, [collapseHiddenMessages, isHiddenFromAI]);
 
   const scopedCharacterMap = useMemo(() => {
     if (!characterMap) return null;
@@ -601,6 +657,21 @@ export const ConversationMessage = memo(function ConversationMessage({
 
   // ── Render: grouped multi-speaker message (merged group chat) ──
   if (groupedSegments && !editing && !isUser) {
+    if (isHiddenCollapsed) {
+      return (
+        <div
+          className={cn(
+            "relative px-4 py-0.5 transition-colors hover:bg-[var(--secondary)]/30",
+            !noHoverGroup && "group",
+            isGrouped ? "mt-0" : "mt-3",
+          )}
+          data-message-id={message.id}
+          data-message-role={message.role}
+        >
+          <div className="ml-14 flex items-center gap-2 py-1">{hiddenFromAIHeader}</div>
+        </div>
+      );
+    }
     return (
       <div
         className={cn(
@@ -761,7 +832,7 @@ export const ConversationMessage = memo(function ConversationMessage({
         )}
 
         {/* Image attachments (selfies, illustrations) */}
-        {extra.attachments && extra.attachments.length > 0 && !IMAGE_URL_RE.test(renderedContent.trim()) && (
+        {!isHiddenCollapsed && extra.attachments && extra.attachments.length > 0 && !IMAGE_URL_RE.test(renderedContent.trim()) && (
           <div className="ml-14 mt-1.5 flex flex-col items-start gap-2">
             {extra.attachments.map((att: any, i: number) =>
               att.type === "image" || att.type?.startsWith("image/") ? (
@@ -974,6 +1045,7 @@ export const ConversationMessage = memo(function ConversationMessage({
         {/* Header — name + timestamp (only for first in group) */}
         {!isGrouped && (
           <div className="mari-message-meta flex items-baseline gap-2 mb-0.5">
+            {hiddenFromAIHeader}
             <span
               className="mari-message-name text-[0.9375rem] font-semibold leading-tight hover:underline cursor-default"
               style={nameColorStyle(nameColor)}
@@ -987,7 +1059,7 @@ export const ConversationMessage = memo(function ConversationMessage({
         )}
 
         {/* Message body */}
-        {editing ? (
+        {isHiddenCollapsed ? null : editing ? (
           <div className="space-y-2">
             <textarea
               ref={editRef}
@@ -1051,7 +1123,7 @@ export const ConversationMessage = memo(function ConversationMessage({
         )}
 
         {/* Translation */}
-        {(translatedText || isTranslating) && (
+        {!isHiddenCollapsed && (translatedText || isTranslating) && (
           <div className="mt-1.5 border-t border-[var(--border)] pt-1.5">
             {isTranslating ? (
               <span className="text-[0.75rem] italic text-[var(--muted-foreground)]">Translating…</span>
@@ -1064,7 +1136,7 @@ export const ConversationMessage = memo(function ConversationMessage({
         )}
 
         {/* Image attachments (selfies, illustrations) — skip when content is already an image URL */}
-        {extra.attachments && extra.attachments.length > 0 && !IMAGE_URL_RE.test(renderedContent.trim()) && (
+        {!isHiddenCollapsed && extra.attachments && extra.attachments.length > 0 && !IMAGE_URL_RE.test(renderedContent.trim()) && (
           <div className="mt-1.5 flex flex-col items-center gap-2">
             {extra.attachments.map((att: any, i: number) =>
               att.type === "image" || att.type?.startsWith("image/") ? (

--- a/src/features/modes/roleplay/components/ChatRoleplaySurface.tsx
+++ b/src/features/modes/roleplay/components/ChatRoleplaySurface.tsx
@@ -327,11 +327,13 @@ function SummaryButton({
   chatId,
   summary,
   summaryContextSize,
+  totalMessageCount,
   onContextSizeChange,
 }: {
   chatId: string | null;
   summary: string | null;
   summaryContextSize: number;
+  totalMessageCount: number;
   onContextSizeChange: (size: number) => void;
 }) {
   const [open, setOpen] = useState(false);
@@ -362,6 +364,7 @@ function SummaryButton({
             chatId={chatId}
             summary={summary}
             contextSize={summaryContextSize}
+            totalMessageCount={totalMessageCount}
             onContextSizeChange={onContextSizeChange}
             onClose={() => setOpen(false)}
           />
@@ -775,6 +778,7 @@ export function ChatRoleplaySurface({
                       chatId={chat?.id ?? null}
                       summary={chatMeta.summary ?? null}
                       summaryContextSize={summaryContextSize}
+                      totalMessageCount={totalMessageCount}
                       onContextSizeChange={onSummaryContextSizeChange}
                     />
                     <ActiveWorldInfoButton chatId={chat?.id ?? null} />
@@ -861,6 +865,7 @@ export function ChatRoleplaySurface({
                           chatId={chat?.id ?? null}
                           summary={chatMeta.summary ?? null}
                           summaryContextSize={summaryContextSize}
+                          totalMessageCount={totalMessageCount}
                           onContextSizeChange={onSummaryContextSizeChange}
                         />
                         <ActiveWorldInfoButton chatId={chat?.id ?? null} />
@@ -919,6 +924,7 @@ export function ChatRoleplaySurface({
                         chatId={chat?.id ?? null}
                         summary={chatMeta.summary ?? null}
                         summaryContextSize={summaryContextSize}
+                        totalMessageCount={totalMessageCount}
                         onContextSizeChange={onSummaryContextSizeChange}
                       />
                       <ActiveWorldInfoButton chatId={chat?.id ?? null} />

--- a/src/features/modes/shared/chat-ui/components/ChatMessage.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatMessage.tsx
@@ -21,8 +21,9 @@ import {
   X,
   Flag,
   Eye,
+  EyeOff,
+  ChevronRight,
   ScrollText,
-  Circle,
   Brain,
   Languages,
   Volume2,
@@ -75,6 +76,46 @@ const MESSAGE_ACTION_ICON_SIZE = "1em";
 const MESSAGE_SWIPE_ICON_SIZE = "1.15em";
 const normalizeEditableQuotes = (value: string) =>
   value.replace(/["\u201c\u201d\u201e\u201f]/g, '"').replace(/['\u2018\u2019\u201a\u201b]/g, "'");
+
+function HiddenFromAIBadge({
+  roleplay,
+  canCollapse,
+  isExpanded,
+  onToggle,
+}: {
+  roleplay?: boolean;
+  canCollapse: boolean;
+  isExpanded: boolean;
+  onToggle: () => void;
+}) {
+  const className = cn(
+    "inline-flex items-center gap-1 rounded px-1 py-0.5 text-[0.625rem] font-medium text-amber-500/80",
+    roleplay && "text-amber-200/60",
+    canCollapse && "transition-colors hover:bg-amber-500/10 hover:text-amber-400",
+  );
+  if (!canCollapse) {
+    return (
+      <span className={className} title="Hidden from AI">
+        <EyeOff size="0.7rem" />
+      </span>
+    );
+  }
+  return (
+    <button
+      type="button"
+      onClick={(event) => {
+        event.stopPropagation();
+        onToggle();
+      }}
+      className={className}
+      title={isExpanded ? "Collapse hidden from AI message" : "Expand hidden from AI message"}
+      aria-label={isExpanded ? "Collapse hidden from AI message" : "Expand hidden from AI message"}
+    >
+      <ChevronRight size="0.7rem" className={cn("transition-transform", isExpanded && "rotate-90")} />
+      <EyeOff size="0.7rem" />
+    </button>
+  );
+}
 
 /** Isolated edit textarea — uncontrolled to avoid React re-renders on every keystroke. */
 const EditTextarea = memo(function EditTextarea({
@@ -683,6 +724,7 @@ export const ChatMessage = memo(function ChatMessage({
     guideGenerations,
     boldDialogue,
     theme,
+    collapseHiddenMessages,
   } = useUIStore(
     useShallow((s) => ({
       chatFontSize: s.chatFontSize,
@@ -698,6 +740,7 @@ export const ChatMessage = memo(function ChatMessage({
       guideGenerations: s.guideGenerations,
       boldDialogue: s.boldDialogue ?? true,
       theme: s.theme,
+      collapseHiddenMessages: s.summaryPopoverSettings.collapseHiddenMessages,
     })),
   );
   const hasInput = useChatStore((s) => s.currentInput.trim().length > 0);
@@ -752,6 +795,7 @@ export const ChatMessage = memo(function ChatMessage({
   const [showThinking, setShowThinking] = useState(false);
   const [showGenerationReplay, setShowGenerationReplay] = useState(false);
   const [showActions, setShowActions] = useState(false);
+  const [manuallyExpandedHidden, setManuallyExpandedHidden] = useState(false);
   const [avatarLightbox, setAvatarLightbox] = useState<string | null>(null);
   const [avatarLightboxPrompt, setAvatarLightboxPrompt] = useState<string | null>(null);
   const scrollRestoreRef = useRef<{ el: HTMLElement; top: number } | null>(null);
@@ -877,9 +921,28 @@ export const ChatMessage = memo(function ChatMessage({
     return typeof message.extra === "string" ? JSON.parse(message.extra) : message.extra;
   }, [message.extra]);
   const isConversationStart = !!extra.isConversationStart;
-  const isHiddenFromAI = extra.hiddenFromAI === true;
+  const isHiddenFromAI = extra.hiddenFromAI === true || extra.hiddenFromAi === true;
   const thinking = extra.thinking as string | undefined;
   const generationReplay = hasGenerationReplayDetails(extra.generationReplay) ? extra.generationReplay : null;
+  const isHiddenExpanded =
+    isHiddenFromAI && (!collapseHiddenMessages || manuallyExpandedHidden || editing || !!isStreaming);
+  const isHiddenCollapsed = isHiddenFromAI && collapseHiddenMessages && !isHiddenExpanded;
+  const hiddenFromAIHeader = isHiddenFromAI ? (
+    <HiddenFromAIBadge
+      roleplay={isRoleplay}
+      canCollapse={collapseHiddenMessages}
+      isExpanded={isHiddenExpanded}
+      onToggle={() => setManuallyExpandedHidden((value) => !value)}
+    />
+  ) : null;
+
+  useEffect(() => {
+    setManuallyExpandedHidden(false);
+  }, [message.id]);
+
+  useEffect(() => {
+    if (!isHiddenFromAI || !collapseHiddenMessages) setManuallyExpandedHidden(false);
+  }, [collapseHiddenMessages, isHiddenFromAI]);
 
   useEffect(() => {
     if (!generationReplay) setShowGenerationReplay(false);
@@ -1284,7 +1347,7 @@ export const ChatMessage = memo(function ChatMessage({
       </div>
     ) : null
   ) : null;
-  const roleplayBubbleContent = editing ? (
+  const roleplayBubbleContent = isHiddenCollapsed ? null : editing ? (
     <EditTextarea
       initialContent={message.content}
       fontSize={chatFontSize}
@@ -1412,15 +1475,18 @@ export const ChatMessage = memo(function ChatMessage({
               )}
               <div className="mb-1 flex items-center gap-2 text-[0.625rem] font-semibold uppercase tracking-widest text-amber-400/70">
                 <span className="h-px flex-1 bg-amber-400/20" />
+                {hiddenFromAIHeader}
                 Narrator
                 <span className="h-px flex-1 bg-amber-400/20" />
               </div>
-              <div
-                className={cn("mari-message-content break-words italic", !isHtmlContent && "whitespace-pre-wrap")}
-                style={messageTextStyle}
-              >
-                {renderedContent}
-              </div>
+              {!isHiddenCollapsed && (
+                <div
+                  className={cn("mari-message-content break-words italic", !isHtmlContent && "whitespace-pre-wrap")}
+                  style={messageTextStyle}
+                >
+                  {renderedContent}
+                </div>
+              )}
             </div>
           </div>
         </div>
@@ -1551,6 +1617,7 @@ export const ChatMessage = memo(function ChatMessage({
             {/* Name + time (only if not grouped) */}
             {!isGrouped && (
               <div className={cn("flex items-baseline gap-2 px-1", isUser && "flex-row-reverse")}>
+                {hiddenFromAIHeader}
                 <span
                   className={cn(
                     "mari-message-name text-[0.75rem] font-bold tracking-tight",
@@ -1690,10 +1757,10 @@ export const ChatMessage = memo(function ChatMessage({
                       />
                     </div>
                   </div>
-                  <div className="min-w-0 flex-1 px-3 py-3">{roleplayBubbleContent}</div>
+                  {roleplayBubbleContent && <div className="min-w-0 flex-1 px-3 py-3">{roleplayBubbleContent}</div>}
                 </div>
               ) : (
-                <div className="px-4 py-3">{roleplayBubbleContent}</div>
+                roleplayBubbleContent ? <div className="px-4 py-3">{roleplayBubbleContent}</div> : null
               )}
             </div>
 
@@ -1784,7 +1851,11 @@ export const ChatMessage = memo(function ChatMessage({
               {onToggleHiddenFromAI && (
                 <ActionBtn
                   icon={
-                    isHiddenFromAI ? <Circle size={MESSAGE_ACTION_ICON_SIZE} /> : <X size={MESSAGE_ACTION_ICON_SIZE} />
+                    isHiddenFromAI ? (
+                      <Eye size={MESSAGE_ACTION_ICON_SIZE} />
+                    ) : (
+                      <EyeOff size={MESSAGE_ACTION_ICON_SIZE} />
+                    )
                   }
                   onClick={() => onToggleHiddenFromAI(message.id, isHiddenFromAI)}
                   title={isHiddenFromAI ? "Unhide from AI" : "Hide from AI"}
@@ -2034,15 +2105,18 @@ export const ChatMessage = memo(function ChatMessage({
         >
           {/* Name — only for first in group */}
           {!isGrouped && !isUser && (
-            <span
-              className={cn(
-                "mari-message-name px-3 text-[0.6875rem] font-semibold",
-                !msgNameColor && !isMergedGroup && "text-[var(--muted-foreground)]",
-              )}
-              style={!isMergedGroup ? nameColorStyle(msgNameColor) : undefined}
-            >
-              {isMergedGroup ? mergedNameElement : displayName}
-            </span>
+            <div className="flex items-center gap-2 px-3">
+              {hiddenFromAIHeader}
+              <span
+                className={cn(
+                  "mari-message-name text-[0.6875rem] font-semibold",
+                  !msgNameColor && !isMergedGroup && "text-[var(--muted-foreground)]",
+                )}
+                style={!isMergedGroup ? nameColorStyle(msgNameColor) : undefined}
+              >
+                {isMergedGroup ? mergedNameElement : displayName}
+              </span>
+            </div>
           )}
 
           {/* Conversation start marker */}
@@ -2071,7 +2145,7 @@ export const ChatMessage = memo(function ChatMessage({
             )}
             style={{ ...messageTextStyle, ...(boxBgColor ? { backgroundColor: boxBgColor } : {}) }}
           >
-            {editing ? (
+            {isHiddenCollapsed ? null : editing ? (
               <EditTextarea
                 initialContent={message.content}
                 fontSize={chatFontSize}

--- a/src/features/modes/shared/chat-ui/components/SummaryPopover.tsx
+++ b/src/features/modes/shared/chat-ui/components/SummaryPopover.tsx
@@ -4,31 +4,76 @@
 // ──────────────────────────────────────────────
 import { useState, useEffect, useRef, useCallback } from "react";
 import { createPortal } from "react-dom";
-import { useGenerateSummary, useUpdateChatMetadata } from "../../../../catalog/chats/index";
-import { ScrollText, Sparkles, X, Save, Loader2, Info } from "lucide-react";
+import { useBulkSetMessagesHiddenFromAI, useGenerateSummary, useUpdateChatMetadata } from "../../../../catalog/chats/index";
+import { Check, Info, Loader2, Save, ScrollText, Settings2, Sparkles, X } from "lucide-react";
 import { cn } from "../../../../../shared/lib/utils";
+import { useUIStore } from "../../../../../shared/stores/ui.store";
+import type { SummaryPopoverSourceMode } from "../../../../../shared/stores/ui.store";
 
 interface SummaryPopoverProps {
   chatId: string;
   summary: string | null;
   contextSize: number;
+  totalMessageCount: number;
   onContextSizeChange: (size: number) => void;
   onClose: () => void;
 }
 
-export function SummaryPopover({ chatId, summary, contextSize, onContextSizeChange, onClose }: SummaryPopoverProps) {
+const MIN_SUMMARY_MESSAGES = 5;
+const MAX_SUMMARY_MESSAGES = 200;
+
+function clampSummaryCount(value: number) {
+  return Math.max(MIN_SUMMARY_MESSAGES, Math.min(MAX_SUMMARY_MESSAGES, Math.round(value)));
+}
+
+function parsePositiveInteger(value: string): number | null {
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+export function SummaryPopover({
+  chatId,
+  summary,
+  contextSize,
+  totalMessageCount,
+  onContextSizeChange,
+  onClose,
+}: SummaryPopoverProps) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(summary ?? "");
-  const [localSize, setLocalSize] = useState(String(contextSize || ""));
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [errorText, setErrorText] = useState<string | null>(null);
+  const summaryPopoverSettings = useUIStore((s) => s.summaryPopoverSettings);
+  const setSummaryPopoverSettings = useUIStore((s) => s.setSummaryPopoverSettings);
+  const persistedContextSize = clampSummaryCount(summaryPopoverSettings.contextSize ?? contextSize ?? 50);
+  const [localSize, setLocalSize] = useState(String(persistedContextSize));
+  const [rangeStart, setRangeStart] = useState(String(summaryPopoverSettings.rangeStart ?? 1));
+  const [rangeEnd, setRangeEnd] = useState(String(summaryPopoverSettings.rangeEnd ?? Math.max(1, totalMessageCount)));
   const sizeInputFocused = useRef(false);
   const generateSummary = useGenerateSummary();
+  const bulkSetMessagesHiddenFromAI = useBulkSetMessagesHiddenFromAI(chatId);
   const updateMeta = useUpdateChatMetadata();
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
 
-  // Close on click outside — defer by one frame so the synthesised
-  // mousedown from the tap that *opened* the popover doesn't
-  // immediately close it on touch devices (Android / iPadOS).
+  const updateSourceMode = useCallback(
+    (sourceMode: SummaryPopoverSourceMode) => {
+      setSummaryPopoverSettings({ sourceMode });
+      setErrorText(null);
+    },
+    [setSummaryPopoverSettings],
+  );
+
+  const persistContextSize = useCallback(
+    (size: number) => {
+      const clamped = clampSummaryCount(size);
+      setLocalSize(String(clamped));
+      setSummaryPopoverSettings({ contextSize: clamped });
+      onContextSizeChange(clamped);
+    },
+    [onContextSizeChange, setSummaryPopoverSettings],
+  );
+
   useEffect(() => {
     const handler = (e: MouseEvent) => {
       if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
@@ -44,7 +89,6 @@ export function SummaryPopover({ chatId, summary, contextSize, onContextSizeChan
     };
   }, [onClose]);
 
-  // Close on Escape
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (e.key === "Escape") onClose();
@@ -53,36 +97,107 @@ export function SummaryPopover({ chatId, summary, contextSize, onContextSizeChan
     return () => document.removeEventListener("keydown", handler);
   }, [onClose]);
 
-  // Sync draft when summary changes (e.g. after generation)
   useEffect(() => {
     setDraft(summary ?? "");
   }, [summary]);
 
-  // Sync local size when contextSize prop changes externally
   useEffect(() => {
     if (!sizeInputFocused.current) {
-      setLocalSize(contextSize ? String(contextSize) : "");
+      setLocalSize(String(persistedContextSize));
     }
-  }, [contextSize]);
+  }, [persistedContextSize]);
 
-  // Focus textarea when entering edit mode
+  useEffect(() => {
+    if (summaryPopoverSettings.sourceMode !== "range") return;
+    const fallbackEnd = Math.max(1, totalMessageCount);
+    setRangeStart(String(summaryPopoverSettings.rangeStart ?? 1));
+    setRangeEnd(String(summaryPopoverSettings.rangeEnd ?? fallbackEnd));
+  }, [summaryPopoverSettings.rangeEnd, summaryPopoverSettings.rangeStart, summaryPopoverSettings.sourceMode, totalMessageCount]);
+
   useEffect(() => {
     if (editing) {
       setTimeout(() => textareaRef.current?.focus(), 50);
     }
   }, [editing]);
 
+  const normalizedLastSize = clampSummaryCount(parsePositiveInteger(localSize) ?? persistedContextSize);
+  const normalizedRangeStart = Math.max(1, Math.min(totalMessageCount || 1, parsePositiveInteger(rangeStart) ?? 1));
+  const normalizedRangeEnd = Math.max(
+    1,
+    Math.min(totalMessageCount || 1, parsePositiveInteger(rangeEnd) ?? (totalMessageCount || 1)),
+  );
+  const rangeLow = Math.min(normalizedRangeStart, normalizedRangeEnd);
+  const rangeHigh = Math.max(normalizedRangeStart, normalizedRangeEnd);
+  const selectedRangeCount = totalMessageCount > 0 ? rangeHigh - rangeLow + 1 : 0;
+  const rangeTooLarge = selectedRangeCount > MAX_SUMMARY_MESSAGES;
+  const sourceSummary =
+    summaryPopoverSettings.sourceMode === "range"
+      ? totalMessageCount > 0
+        ? `Messages ${rangeLow}-${rangeHigh} of ${totalMessageCount}`
+        : "No messages yet"
+      : totalMessageCount > 0
+        ? `Last ${Math.min(normalizedLastSize, totalMessageCount)} of ${totalMessageCount} messages`
+        : "No messages yet";
+
+  const maybeHideSummarizedMessages = useCallback(
+    (messageIds: string[]) => {
+      if (!summaryPopoverSettings.hideSummarizedMessages || messageIds.length === 0) return;
+      bulkSetMessagesHiddenFromAI.mutate({ messageIds, hidden: true });
+    },
+    [bulkSetMessagesHiddenFromAI, summaryPopoverSettings.hideSummarizedMessages],
+  );
+
   const handleGenerate = useCallback(() => {
+    setErrorText(null);
+    if (summaryPopoverSettings.sourceMode === "range") {
+      if (totalMessageCount === 0) {
+        setErrorText("No messages available for summary generation.");
+        return;
+      }
+      if (rangeTooLarge) {
+        setErrorText(`Choose ${MAX_SUMMARY_MESSAGES} messages or fewer.`);
+        return;
+      }
+      setSummaryPopoverSettings({ rangeStart: rangeLow, rangeEnd: rangeHigh });
+      generateSummary.mutate(
+        { chatId, contextSize: normalizedLastSize, rangeStartIndex: rangeLow, rangeEndIndex: rangeHigh },
+        {
+          onSuccess: (data) => {
+            setDraft(data.summary);
+            setEditing(false);
+            maybeHideSummarizedMessages(data.messageIds);
+          },
+          onError: (error) => setErrorText(error instanceof Error ? error.message : "Could not generate summary."),
+        },
+      );
+      return;
+    }
+
+    persistContextSize(normalizedLastSize);
     generateSummary.mutate(
-      { chatId, contextSize },
+      { chatId, contextSize: normalizedLastSize },
       {
         onSuccess: (data) => {
           setDraft(data.summary);
           setEditing(false);
+          maybeHideSummarizedMessages(data.messageIds);
         },
+        onError: (error) => setErrorText(error instanceof Error ? error.message : "Could not generate summary."),
       },
     );
-  }, [chatId, contextSize, generateSummary]);
+  }, [
+    chatId,
+    generateSummary,
+    maybeHideSummarizedMessages,
+    normalizedLastSize,
+    persistContextSize,
+    rangeHigh,
+    rangeLow,
+    rangeTooLarge,
+    setSummaryPopoverSettings,
+    summaryPopoverSettings.sourceMode,
+    totalMessageCount,
+  ]);
 
   const handleSave = useCallback(() => {
     updateMeta.mutate({ id: chatId, summary: draft || null });
@@ -90,7 +205,6 @@ export function SummaryPopover({ chatId, summary, contextSize, onContextSizeChan
   }, [chatId, draft, updateMeta]);
 
   const isGenerating = generateSummary.isPending;
-
   const isMobile = typeof window !== "undefined" && window.innerWidth < 768;
 
   const content = (
@@ -103,50 +217,32 @@ export function SummaryPopover({ chatId, summary, contextSize, onContextSizeChan
           : "absolute right-0 top-full z-[100] mt-1",
       )}
     >
-      {/* Mobile backdrop */}
       {isMobile && <div className="absolute inset-0 bg-black/30" onClick={onClose} />}
       <div
         className={cn(
           "rounded-xl border border-[var(--border)] bg-[var(--card)] shadow-2xl shadow-black/40",
-          isMobile ? "relative w-full max-w-sm max-h-[calc(100dvh-4rem)] overflow-y-auto" : "w-80",
+          isMobile ? "relative max-h-[calc(100dvh-4rem)] w-full max-w-sm overflow-y-auto" : "w-96",
         )}
       >
-        {/* Header */}
         <div className="flex items-center justify-between border-b border-[var(--border)] px-3 py-2">
           <div className="flex items-center gap-1.5 text-xs font-semibold">
             <ScrollText size="0.8125rem" className="text-amber-400" />
             Chat Summary
           </div>
           <div className="flex items-center gap-1">
-            <div
-              className="flex items-center gap-1 mr-1"
-              title="Context size — number of recent messages used for summary generation"
-            >
-              <input
-                type="number"
-                min={5}
-                max={200}
-                value={localSize}
-                onFocus={() => {
-                  sizeInputFocused.current = true;
-                }}
-                onChange={(e) => setLocalSize(e.target.value)}
-                onBlur={() => {
-                  sizeInputFocused.current = false;
-                  const parsed = parseInt(localSize);
-                  if (!localSize || isNaN(parsed)) {
-                    setLocalSize("50");
-                    onContextSizeChange(50);
-                  } else {
-                    const clamped = Math.max(5, Math.min(200, parsed));
-                    setLocalSize(String(clamped));
-                    onContextSizeChange(clamped);
-                  }
-                }}
-                className="w-12 rounded-md bg-[var(--secondary)] px-1.5 py-0.5 text-center text-[0.625rem] tabular-nums ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
-              />
-            </div>
             <button
+              type="button"
+              onClick={() => setSettingsOpen((open) => !open)}
+              className={cn(
+                "rounded-md p-1 text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]",
+                settingsOpen && "bg-[var(--accent)] text-[var(--foreground)]",
+              )}
+              title="Summary settings"
+            >
+              <Settings2 size="0.75rem" />
+            </button>
+            <button
+              type="button"
               onClick={handleGenerate}
               disabled={isGenerating}
               className={cn(
@@ -158,9 +254,10 @@ export function SummaryPopover({ chatId, summary, contextSize, onContextSizeChan
               title="Generate summary with AI"
             >
               {isGenerating ? <Loader2 size="0.6875rem" className="animate-spin" /> : <Sparkles size="0.6875rem" />}
-              {isGenerating ? "Generating…" : "Generate"}
+              {isGenerating ? "Generating..." : "Generate"}
             </button>
             <button
+              type="button"
               onClick={onClose}
               className="rounded-md p-1 text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
             >
@@ -169,8 +266,118 @@ export function SummaryPopover({ chatId, summary, contextSize, onContextSizeChan
           </div>
         </div>
 
-        {/* Body */}
+        {settingsOpen && (
+          <div className="space-y-3 border-b border-[var(--border)] px-3 py-3">
+            <div className="grid grid-cols-2 rounded-lg bg-[var(--secondary)] p-0.5 text-[0.6875rem] font-medium">
+              {(["last", "range"] as SummaryPopoverSourceMode[]).map((mode) => (
+                <button
+                  key={mode}
+                  type="button"
+                  onClick={() => updateSourceMode(mode)}
+                  className={cn(
+                    "rounded-md px-2 py-1 transition-colors",
+                    summaryPopoverSettings.sourceMode === mode
+                      ? "bg-[var(--card)] text-[var(--foreground)] shadow-sm"
+                      : "text-[var(--muted-foreground)] hover:text-[var(--foreground)]",
+                  )}
+                >
+                  {mode === "last" ? "Last" : "Range"}
+                </button>
+              ))}
+            </div>
+
+            {summaryPopoverSettings.sourceMode === "last" ? (
+              <label className="block space-y-1">
+                <span className="text-[0.625rem] font-medium text-[var(--muted-foreground)]">Messages</span>
+                <input
+                  type="number"
+                  min={MIN_SUMMARY_MESSAGES}
+                  max={MAX_SUMMARY_MESSAGES}
+                  value={localSize}
+                  onFocus={() => {
+                    sizeInputFocused.current = true;
+                  }}
+                  onChange={(e) => setLocalSize(e.target.value)}
+                  onBlur={() => {
+                    sizeInputFocused.current = false;
+                    persistContextSize(parsePositiveInteger(localSize) ?? 50);
+                  }}
+                  className="w-full rounded-md bg-[var(--secondary)] px-2 py-1 text-xs tabular-nums ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+                />
+              </label>
+            ) : (
+              <div className="space-y-1">
+                <div className="grid grid-cols-2 gap-2">
+                  <label className="block space-y-1">
+                    <span className="text-[0.625rem] font-medium text-[var(--muted-foreground)]">Start</span>
+                    <input
+                      type="number"
+                      min={1}
+                      max={Math.max(1, totalMessageCount)}
+                      value={rangeStart}
+                      onChange={(e) => setRangeStart(e.target.value)}
+                      onBlur={() => setSummaryPopoverSettings({ rangeStart: normalizedRangeStart })}
+                      className="w-full rounded-md bg-[var(--secondary)] px-2 py-1 text-xs tabular-nums ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+                    />
+                  </label>
+                  <label className="block space-y-1">
+                    <span className="text-[0.625rem] font-medium text-[var(--muted-foreground)]">End</span>
+                    <input
+                      type="number"
+                      min={1}
+                      max={Math.max(1, totalMessageCount)}
+                      value={rangeEnd}
+                      onChange={(e) => setRangeEnd(e.target.value)}
+                      onBlur={() => setSummaryPopoverSettings({ rangeEnd: normalizedRangeEnd })}
+                      className="w-full rounded-md bg-[var(--secondary)] px-2 py-1 text-xs tabular-nums ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+                    />
+                  </label>
+                </div>
+                {rangeTooLarge && (
+                  <p className="text-[0.625rem] leading-snug text-[var(--destructive)]">
+                    Choose {MAX_SUMMARY_MESSAGES} messages or fewer.
+                  </p>
+                )}
+              </div>
+            )}
+
+            <div className="space-y-2">
+              <label className="flex items-center gap-2 text-[0.6875rem] text-[var(--foreground)]/80">
+                <input
+                  type="checkbox"
+                  checked={summaryPopoverSettings.hideSummarizedMessages}
+                  onChange={(e) => setSummaryPopoverSettings({ hideSummarizedMessages: e.target.checked })}
+                  className="h-3.5 w-3.5 accent-amber-400"
+                />
+                Hide summarized messages from AI
+              </label>
+              <label className="flex items-center gap-2 text-[0.6875rem] text-[var(--foreground)]/80">
+                <input
+                  type="checkbox"
+                  checked={summaryPopoverSettings.collapseHiddenMessages}
+                  onChange={(e) => setSummaryPopoverSettings({ collapseHiddenMessages: e.target.checked })}
+                  className="h-3.5 w-3.5 accent-amber-400"
+                />
+                Collapse hidden messages
+              </label>
+            </div>
+
+            <p className="text-[0.625rem] leading-snug text-[var(--muted-foreground)]">{sourceSummary}</p>
+          </div>
+        )}
+
         <div className="max-h-72 overflow-y-auto p-3">
+          {errorText && (
+            <div className="mb-2 rounded-md border border-[var(--destructive)]/30 bg-[var(--destructive)]/10 px-2 py-1.5 text-[0.6875rem] text-[var(--destructive)]">
+              {errorText}
+            </div>
+          )}
+          {bulkSetMessagesHiddenFromAI.isSuccess && summaryPopoverSettings.hideSummarizedMessages && (
+            <div className="mb-2 flex items-center gap-1.5 rounded-md border border-amber-400/20 bg-amber-400/10 px-2 py-1.5 text-[0.6875rem] text-amber-300">
+              <Check size="0.6875rem" />
+              Summarized messages hidden from AI.
+            </div>
+          )}
           {editing ? (
             <div className="space-y-2">
               <textarea
@@ -179,10 +386,11 @@ export function SummaryPopover({ chatId, summary, contextSize, onContextSizeChan
                 onChange={(e) => setDraft(e.target.value)}
                 rows={6}
                 className="max-h-48 w-full resize-y rounded-lg bg-[var(--secondary)] p-2.5 text-xs ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
-                placeholder="Write or paste a summary of this chat…"
+                placeholder="Write or paste a summary of this chat..."
               />
               <div className="flex justify-end gap-1.5">
                 <button
+                  type="button"
                   onClick={() => {
                     setDraft(summary ?? "");
                     setEditing(false);
@@ -192,6 +400,7 @@ export function SummaryPopover({ chatId, summary, contextSize, onContextSizeChan
                   Cancel
                 </button>
                 <button
+                  type="button"
                   onClick={handleSave}
                   disabled={updateMeta.isPending}
                   className="flex items-center gap-1 rounded-lg bg-gradient-to-r from-amber-400 to-orange-500 px-2.5 py-1 text-[0.625rem] font-medium text-white shadow-sm transition-all hover:shadow-md active:scale-[0.98] disabled:opacity-50"
@@ -225,14 +434,11 @@ export function SummaryPopover({ chatId, summary, contextSize, onContextSizeChan
           )}
         </div>
 
-        {/* Info tip */}
         <div className="border-t border-[var(--border)] px-3 py-2">
           <p className="flex items-start gap-1.5 text-[0.625rem] leading-relaxed text-[var(--muted-foreground)]">
             <Info size="0.6875rem" className="mt-0.5 shrink-0 text-amber-400/70" />
             <span>
-              Use the Generate button above to update the summary manually. Add an{" "}
-              <strong className="font-medium text-[var(--foreground)]/70">Automated Chat Summary</strong> agent to the
-              chat if you&apos;d like it to be updated automatically every X messages.
+              Manual summaries append to rolling summary entries. Hidden messages are excluded from generated summaries.
             </span>
           </p>
         </div>

--- a/src/features/modes/shared/chat-ui/hooks/use-chat-surface-data.ts
+++ b/src/features/modes/shared/chat-ui/hooks/use-chat-surface-data.ts
@@ -1,6 +1,7 @@
 import { useEffect, useMemo } from "react";
 import {
   useChat,
+  useChatMessageCount,
   useChatMessages,
   type Chat,
   type ChatMode,
@@ -143,6 +144,7 @@ export function useChatSurfaceData({
     isFetchingNextPage,
     refetch: refetchMessages,
   } = useChatMessages(activeChatId, resolvedMessagePageSize, !!chat);
+  const { data: messageCountData } = useChatMessageCount(chat ? activeChatId : null);
 
   useEffect(() => {
     if (!(chatError instanceof ApiError) || chatError.status !== 404) return;
@@ -174,8 +176,11 @@ export function useChatSurfaceData({
     () => (msgData ? [...msgData.pages].reverse().flat() : undefined),
     [msgData],
   );
-  const totalMessageCount = messages?.length ?? 0;
   const loadedMessageCount = messages?.length ?? 0;
+  const totalMessageCount =
+    typeof messageCountData?.count === "number"
+      ? Math.max(messageCountData.count, loadedMessageCount)
+      : loadedMessageCount;
   const messageOffset = messages ? totalMessageCount - messages.length : 0;
   const messageIdByOrderIndex = useMemo(() => {
     const map = new Map<number, string>();

--- a/src/features/modes/shared/chat-ui/hooks/use-chat-timeline-actions.ts
+++ b/src/features/modes/shared/chat-ui/hooks/use-chat-timeline-actions.ts
@@ -469,7 +469,7 @@ export function useChatTimelineActions({
 
   const handleToggleHiddenFromAI = useCallback(
     (messageId: string, current: boolean) => {
-      updateMessageExtra.mutate({ messageId, extra: { hiddenFromAI: !current } });
+      updateMessageExtra.mutate({ messageId, extra: { hiddenFromAI: !current, hiddenFromAi: !current } });
     },
     [updateMessageExtra],
   );

--- a/src/shared/stores/ui.store.ts
+++ b/src/shared/stores/ui.store.ts
@@ -6,6 +6,7 @@ import { persist } from "zustand/middleware";
 import {
   DEFAULT_GAME_SETUP_LEARNED_OPTIONS,
   DEFAULT_GAME_SETUP_REMEMBERED_TEXT,
+  DEFAULT_SUMMARY_POPOVER_SETTINGS,
   RIGHT_PANEL_WIDTH_MAX,
   RIGHT_PANEL_WIDTH_MIN,
   ROLEPLAY_AVATAR_SCALE_MAX,
@@ -21,6 +22,7 @@ import {
   mobilePanelClosePatch,
   normalizeLearnedGameSetupOption,
   normalizeRememberedGameSetupText,
+  normalizeSummaryPopoverSettings,
   normalizeTrackerPanelSizeProfile,
   normalizeTrackerPanelSectionOrder,
   normalizeTrackerTemperatureUnit,
@@ -77,6 +79,8 @@ export type {
   HudPosition,
   Panel,
   RoleplayAvatarStyle,
+  SummaryPopoverSettings,
+  SummaryPopoverSourceMode,
   TrackerDataPanelSection,
   TrackerPanelCollapsedSections,
   TrackerPanelSectionOrder,
@@ -167,6 +171,7 @@ export const useUIStore = create<UIState>()(
       intuitiveSwipeNavigation: false,
       intuitiveSwipeRerollLatest: false,
       editLastMessageOnArrowUp: true,
+      summaryPopoverSettings: DEFAULT_SUMMARY_POPOVER_SETTINGS,
       narrationFontColor: "",
       narrationOpacity: 80,
       chatFontColor: "",
@@ -422,6 +427,13 @@ export const useUIStore = create<UIState>()(
       setIntuitiveSwipeNavigation: (v) => set({ intuitiveSwipeNavigation: v }),
       setIntuitiveSwipeRerollLatest: (v) => set({ intuitiveSwipeRerollLatest: v }),
       setEditLastMessageOnArrowUp: (v) => set({ editLastMessageOnArrowUp: v }),
+      setSummaryPopoverSettings: (settings) =>
+        set((state) => ({
+          summaryPopoverSettings: normalizeSummaryPopoverSettings({
+            ...state.summaryPopoverSettings,
+            ...settings,
+          }),
+        })),
       setNarrationFontColor: (v) => set({ narrationFontColor: v }),
       setNarrationOpacity: (v) => set({ narrationOpacity: Math.max(0, Math.min(100, v)) }),
       setChatFontColor: (v) => set({ chatFontColor: v }),

--- a/src/shared/stores/ui/model.ts
+++ b/src/shared/stores/ui/model.ts
@@ -27,9 +27,18 @@ export type EchoChamberSide = "top-left" | "top-right" | "bottom-left" | "bottom
 export type UserStatus = "active" | "idle" | "dnd";
 export type RoleplayAvatarStyle = "circles" | "rectangles" | "panel";
 export type GameDialogueDisplayMode = "classic" | "stacked";
+export type SummaryPopoverSourceMode = "last" | "range";
 export interface FloatingWidgetPosition {
   x: number;
   y: number;
+}
+export interface SummaryPopoverSettings {
+  sourceMode: SummaryPopoverSourceMode;
+  contextSize: number | null;
+  rangeStart: number | null;
+  rangeEnd: number | null;
+  hideSummarizedMessages: boolean;
+  collapseHiddenMessages: boolean;
 }
 export const APP_LANGUAGE_OPTIONS = [{ id: "en", label: "English" }] as const;
 export type AppLanguage = (typeof APP_LANGUAGE_OPTIONS)[number]["id"];
@@ -85,6 +94,14 @@ export const DEFAULT_GAME_SETUP_LEARNED_OPTIONS: GameSetupLearnedOptions = {
 export const DEFAULT_GAME_SETUP_REMEMBERED_TEXT: GameSetupRememberedText = {
   playerGoals: "",
   preferences: "",
+};
+export const DEFAULT_SUMMARY_POPOVER_SETTINGS: SummaryPopoverSettings = {
+  sourceMode: "last",
+  contextSize: null,
+  rangeStart: null,
+  rangeEnd: null,
+  hideSummarizedMessages: false,
+  collapseHiddenMessages: false,
 };
 
 export function clampImageDimension(value: number) {
@@ -150,6 +167,20 @@ export function normalizeTrackerPanelSectionOrder(value: unknown): TrackerPanelS
   }
 
   return order;
+}
+
+export function normalizeSummaryPopoverSettings(value: unknown): SummaryPopoverSettings {
+  const raw = typeof value === "object" && value !== null ? (value as Record<string, unknown>) : {};
+  const numberOrNull = (next: unknown) =>
+    typeof next === "number" && Number.isFinite(next) ? Math.round(next) : null;
+  return {
+    sourceMode: raw.sourceMode === "range" ? "range" : "last",
+    contextSize: numberOrNull(raw.contextSize),
+    rangeStart: numberOrNull(raw.rangeStart),
+    rangeEnd: numberOrNull(raw.rangeEnd),
+    hideSummarizedMessages: raw.hideSummarizedMessages === true || raw.hideSummarisedMessages === true,
+    collapseHiddenMessages: raw.collapseHiddenMessages === true,
+  };
 }
 
 export function normalizeLearnedGameSetupOption(value: unknown) {
@@ -336,6 +367,8 @@ export interface UIState {
   intuitiveSwipeRerollLatest: boolean;
   /** When true, pressing Up Arrow with an empty chat input opens the last user message for editing (Conversation/Roleplay). */
   editLastMessageOnArrowUp: boolean;
+  /** Persisted controls shown in the Chat Summary popover settings window. */
+  summaryPopoverSettings: SummaryPopoverSettings;
 
   // ── Text Appearance ──
   /** Color for narrator text in RP mode (empty = default amber) */
@@ -532,6 +565,7 @@ export interface UIState {
   setIntuitiveSwipeNavigation: (v: boolean) => void;
   setIntuitiveSwipeRerollLatest: (v: boolean) => void;
   setEditLastMessageOnArrowUp: (v: boolean) => void;
+  setSummaryPopoverSettings: (settings: Partial<SummaryPopoverSettings>) => void;
   setNarrationFontColor: (v: string) => void;
   setNarrationOpacity: (v: number) => void;
   setChatFontColor: (v: string) => void;

--- a/src/shared/stores/ui/persistence.ts
+++ b/src/shared/stores/ui/persistence.ts
@@ -2,13 +2,14 @@ import { createJSONStorage } from "zustand/middleware";
 import {
   normalizeTrackerPanelSectionOrder,
   normalizeTrackerPanelSizeProfile,
+  normalizeSummaryPopoverSettings,
   normalizeTrackerTemperatureUnit,
   normalizeTrackerThoughtBubbleDisplay,
 } from "./model";
 import type { UIState } from "./model";
 
 export const UI_STORE_NAME = "marinara-engine-ui-tauri";
-export const UI_STORE_VERSION = 3;
+export const UI_STORE_VERSION = 4;
 
 type PersistedUiState = Partial<UIState> & {
   trackerPanelWidth?: unknown;
@@ -111,6 +112,7 @@ export function partializeUiState(state: UIState) {
     intuitiveSwipeNavigation: state.intuitiveSwipeNavigation,
     intuitiveSwipeRerollLatest: state.intuitiveSwipeRerollLatest,
     editLastMessageOnArrowUp: state.editLastMessageOnArrowUp,
+    summaryPopoverSettings: state.summaryPopoverSettings,
     narrationFontColor: state.narrationFontColor,
     narrationOpacity: state.narrationOpacity,
     chatFontColor: state.chatFontColor,
@@ -169,6 +171,7 @@ export function migrateUiState(persistedState: unknown): Partial<UIState> {
   );
   persisted.trackerTemperatureUnit = normalizeTrackerTemperatureUnit(persisted.trackerTemperatureUnit);
   persisted.trackerPanelSectionOrder = normalizeTrackerPanelSectionOrder(persisted.trackerPanelSectionOrder);
+  persisted.summaryPopoverSettings = normalizeSummaryPopoverSettings(persisted.summaryPopoverSettings);
   persisted.userStatusManual = persisted.userStatusManual === "dnd" ? "dnd" : "active";
   persisted.userStatus = persisted.userStatusManual === "dnd" ? "dnd" : "active";
   delete persisted.trackerPanelWidth;


### PR DESCRIPTION
## Linked issue

Closes #1362

## Why this change

- The chat summary popover needed persistent controls for choosing summary source, hiding summarized messages from AI context, and collapsing hidden messages without crossing conversation/roleplay boundaries.
- Range summaries also need to use the full chat message count, not only the currently loaded paginated window, so selected ranges map to the intended message history.

## What changed

- Added persisted summary popover settings for source mode, context size, range bounds, hide-summarized behavior, and hidden-message collapse.
- Extended manual summary generation to support explicit message ranges and to return summarized message IDs for optional bulk hiding.
- Added hidden-message collapse controls to conversation and shared chat message UI.
- Updated hidden-from-AI writes and reads to handle both `hiddenFromAI` and legacy `hiddenFromAi`.
- Wired shared chat surface data to the existing chat message count query so range controls and message offsets use the full chat count.

## Refactor impact

Primary owner:

shared mode UI, catalog chat hooks, shared UI store

Impact areas reviewed:

- Conversation message rendering and hidden-message controls
- Roleplay summary toolbar and shared chat message rendering
- Shared chat surface count/offset consumers, including roleplay jump validation and game route loaded-vs-total checks
- UI store persistence and migration for summary popover settings

Boundary notes:

- Feature code continues to use catalog chat hooks and shared UI stores through existing feature/shared entrypoints.
- No engine imports from React, Zustand, Tauri, shared API adapters, or feature internals were added.
- No raw remote-runtime fetch or new raw feature-level Tauri call was added.

Pressure points touched:

- shared mode UI
- conversation message UI
- roleplay surface summary button
- shared UI store persistence

## Validation

- [x] `pnpm check` passes locally
- [x] `pnpm typecheck` passes locally
- [x] `pnpm build` passes locally
- [x] `pnpm check:architecture` passes locally
- [x] `pnpm check:docs` passes locally
- [x] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Agent-run verification completed: `git diff --check`, `pnpm typecheck`, `pnpm check:architecture`, and `pnpm build`.
- `pnpm build` completed with existing Vite chunk/dynamic-import warnings.
- Browser/Tauri manual verification was not completed.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

Not captured.
