### PR TITLE
Fix Discord mirror webhook sends

### DIFF
--- a/src-tauri/src/commands/storage/commands/integrations.rs
+++ b/src-tauri/src/commands/storage/commands/integrations.rs
@@ -36,6 +36,11 @@ pub async fn translate_text_command(
 }
 
 #[tauri::command]
+pub async fn discord_webhook_send(body: Value) -> Result<Value, AppError> {
+    integrations::discord_webhook_send(body).await
+}
+
+#[tauri::command]
 pub async fn haptic_status() -> Result<Value, AppError> {
     integrations::haptic_call(&["status"], Value::Null).await
 }

--- a/src-tauri/src/commands/storage/integrations.rs
+++ b/src-tauri/src/commands/storage/integrations.rs
@@ -3,6 +3,8 @@ use super::*;
 
 #[path = "integrations/haptic.rs"]
 mod haptic;
+#[path = "integrations/discord.rs"]
+mod discord;
 #[path = "integrations/spotify.rs"]
 mod spotify;
 #[path = "integrations/spotify_callback.rs"]
@@ -31,4 +33,8 @@ pub(crate) async fn spotify_call(
 
 pub(crate) async fn haptic_call(rest: &[&str], body: Value) -> AppResult<Value> {
     haptic::haptic_call(rest, body).await
+}
+
+pub(crate) async fn discord_webhook_send(body: Value) -> AppResult<Value> {
+    discord::discord_webhook_send(body).await
 }

--- a/src-tauri/src/commands/storage/integrations/discord.rs
+++ b/src-tauri/src/commands/storage/integrations/discord.rs
@@ -1,0 +1,125 @@
+use crate::storage_commands::shared::required_string;
+use marinara_core::{AppError, AppResult};
+use marinara_security::is_allowed_outbound_url;
+use serde_json::{json, Map, Value};
+use std::time::Duration;
+
+const DISCORD_CONTENT_LIMIT: usize = 2_000;
+const DISCORD_USERNAME_LIMIT: usize = 80;
+
+pub(crate) async fn discord_webhook_send(body: Value) -> AppResult<Value> {
+    let webhook_url = required_string(&body, "webhookUrl")?.trim();
+    if !is_valid_discord_webhook_url(webhook_url) || !is_allowed_outbound_url(webhook_url, false) {
+        return Err(AppError::invalid_input("Invalid Discord webhook URL"));
+    }
+
+    let content = required_string(&body, "content")?.trim();
+    let mut payload = Map::new();
+    payload.insert(
+        "content".to_string(),
+        Value::String(truncate_for_discord(content, DISCORD_CONTENT_LIMIT)),
+    );
+
+    if let Some(username) = optional_trimmed_string(&body, "username") {
+        payload.insert(
+            "username".to_string(),
+            Value::String(truncate_chars(&username, DISCORD_USERNAME_LIMIT)),
+        );
+    }
+    if let Some(avatar_url) = optional_trimmed_string(&body, "avatarUrl") {
+        if !is_allowed_outbound_url(&avatar_url, false) {
+            return Err(AppError::invalid_input("Invalid Discord avatar URL"));
+        }
+        payload.insert("avatar_url".to_string(), Value::String(avatar_url));
+    }
+
+    let response = reqwest::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .build()
+        .map_err(|error| AppError::new("discord_webhook_client_error", error.to_string()))?
+        .post(webhook_url)
+        .json(&Value::Object(payload))
+        .send()
+        .await
+        .map_err(|error| AppError::new("discord_webhook_request_error", error.to_string()))?;
+
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        return Err(AppError::with_details(
+            "discord_webhook_failed",
+            format!("Discord webhook returned HTTP {status}"),
+            json!({ "body": body.chars().take(500).collect::<String>() }),
+        ));
+    }
+
+    Ok(json!({ "success": true }))
+}
+
+fn optional_trimmed_string(body: &Value, key: &str) -> Option<String> {
+    body.get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn truncate_for_discord(value: &str, limit: usize) -> String {
+    if value.chars().count() <= limit {
+        return value.to_string();
+    }
+    let prefix = value.chars().take(limit.saturating_sub(3)).collect::<String>();
+    format!("{prefix}...")
+}
+
+fn truncate_chars(value: &str, limit: usize) -> String {
+    value.chars().take(limit).collect()
+}
+
+fn is_valid_discord_webhook_url(raw: &str) -> bool {
+    let trimmed = raw.trim();
+    let Some(rest) = trimmed
+        .strip_prefix("https://discord.com/api/webhooks/")
+        .or_else(|| trimmed.strip_prefix("https://discordapp.com/api/webhooks/"))
+    else {
+        return false;
+    };
+    let mut parts = rest.split('/');
+    let id = parts.next().unwrap_or_default();
+    let token = parts.next().unwrap_or_default();
+    if parts.next().is_some() {
+        return false;
+    }
+    !id.is_empty()
+        && id.chars().all(|character| character.is_ascii_digit())
+        && !token.is_empty()
+        && token
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || character == '_' || character == '-')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validates_legacy_discord_webhook_shapes() {
+        assert!(is_valid_discord_webhook_url(
+            "https://discord.com/api/webhooks/123456789/token_AB-12"
+        ));
+        assert!(is_valid_discord_webhook_url(
+            "https://discordapp.com/api/webhooks/123456789/token_AB-12"
+        ));
+        assert!(!is_valid_discord_webhook_url("http://discord.com/api/webhooks/123/token"));
+        assert!(!is_valid_discord_webhook_url("https://example.com/api/webhooks/123/token"));
+        assert!(!is_valid_discord_webhook_url("https://discord.com/api/webhooks/notnumeric/token"));
+    }
+
+    #[test]
+    fn truncates_content_with_ellipsis_inside_discord_limit() {
+        let value = "x".repeat(DISCORD_CONTENT_LIMIT + 20);
+        let truncated = truncate_for_discord(&value, DISCORD_CONTENT_LIMIT);
+        assert_eq!(truncated.chars().count(), DISCORD_CONTENT_LIMIT);
+        assert!(truncated.ends_with("..."));
+    }
+}

--- a/src-tauri/src/http_dispatch.rs
+++ b/src-tauri/src/http_dispatch.rs
@@ -271,6 +271,7 @@ pub async fn dispatch(state: &AppState, request: InvokeRequest) -> AppResult<Val
         "tts_voices" => integrations::tts_call(state, "GET", &["voices"], Value::Null).await,
         "tts_speak" => integrations::tts_call(state, "POST", &["speak"], optional_value(&args, "input")).await,
         "translate_text_command" => translation::translate_text(state, optional_value(&args, "input")).await,
+        "discord_webhook_send" => integrations::discord_webhook_send(optional_value(&args, "body")).await,
         "spotify_status" => spotify_direct(state, "POST", &["status"], optional_value(&args, "body")).await,
         "spotify_authorize" => spotify_direct(state, "POST", &["authorize"], optional_value(&args, "input")).await,
         "spotify_exchange" => {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -86,6 +86,7 @@ pub fn run() {
             storage_commands::integration_commands::tts_voices,
             storage_commands::integration_commands::tts_speak,
             storage_commands::integration_commands::translate_text_command,
+            storage_commands::integration_commands::discord_webhook_send,
             storage_commands::integration_commands::haptic_status,
             storage_commands::integration_commands::haptic_connect,
             storage_commands::integration_commands::haptic_disconnect,

--- a/src/engine/capabilities/integrations.ts
+++ b/src/engine/capabilities/integrations.ts
@@ -21,9 +21,19 @@ export interface ImageGenerationGateway {
   generate<T = unknown>(input: Record<string, unknown>): Promise<T>;
 }
 
+export interface DiscordGateway {
+  mirrorMessage<T = unknown>(input: {
+    webhookUrl: string;
+    content: string;
+    username?: string | null;
+    avatarUrl?: string | null;
+  }): Promise<T>;
+}
+
 export interface IntegrationGateway {
   spotify: SpotifyGateway;
   haptic: HapticGateway;
   customTools: CustomToolsGateway;
   image: ImageGenerationGateway;
+  discord?: DiscordGateway;
 }

--- a/src/engine/generation/start-generation.test.ts
+++ b/src/engine/generation/start-generation.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it, vi } from "vitest";
+import type { DiscordGateway } from "../capabilities/integrations";
 import type { LlmGateway } from "../capabilities/llm";
 import type { StorageGateway } from "../capabilities/storage";
 import { retryGenerationAgents, startGeneration, type GenerationEngineDeps } from "./start-generation";
+
+function mockDiscordMirror() {
+  return vi.fn(<T = unknown>(_input: Parameters<DiscordGateway["mirrorMessage"]>[0]): Promise<T> => {
+    return Promise.resolve({ success: true } as T);
+  });
+}
 
 function depsForChat(chat: Record<string, unknown>) {
   const get = vi.fn(async (entity: string, id: string) => (entity === "chats" && id === "chat-1" ? chat : null));
@@ -23,7 +30,10 @@ function depsForChat(chat: Record<string, unknown>) {
 function generationDepsForChat(options: {
   savedUserMessage?: unknown;
   messagesAfterSave?: Record<string, unknown>[];
+  chatPatch?: Record<string, unknown>;
   chatMetadata?: Record<string, unknown>;
+  characters?: Record<string, unknown>[];
+  personas?: Record<string, unknown>[];
   agents?: Record<string, unknown>[];
   agentRuns?: Record<string, unknown>[];
   initialMessages?: Record<string, unknown>[];
@@ -34,6 +44,7 @@ function generationDepsForChat(options: {
     connectionId: "connection-1",
     characterIds: [],
     metadata: options.chatMetadata ?? {},
+    ...(options.chatPatch ?? {}),
   };
   const connection = {
     id: "connection-1",
@@ -77,10 +88,13 @@ function generationDepsForChat(options: {
     get: vi.fn(async (entity: string, id: string) => {
       if (entity === "chats" && id === "chat-1") return chat;
       if (entity === "connections" && id === "connection-1") return connection;
+      if (entity === "characters") return options.characters?.find((character) => character.id === id) ?? null;
+      if (entity === "personas") return options.personas?.find((persona) => persona.id === id) ?? null;
       if (entity === "messages") return messagesById.get(id) ?? null;
       return null;
     }),
     list: vi.fn(async (entity: string) => {
+      if (entity === "personas") return options.personas ?? [];
       if (entity === "agents") return options.agents ?? [];
       if (entity === "agent-runs") return options.agentRuns ?? [];
       return [];
@@ -336,6 +350,62 @@ describe("startGeneration generation replay metadata", () => {
     expect((streamedRequests[0] as { messages: Array<{ content: string }> }).messages).not.toEqual(
       expect.arrayContaining([expect.objectContaining({ content: "Wrong chat guide." })]),
     );
+  });
+});
+
+describe("startGeneration Discord mirror", () => {
+  it("mirrors saved user and assistant messages when a chat has a Discord webhook", async () => {
+    const mirrorMessage = mockDiscordMirror();
+    const webhookUrl = "https://discord.com/api/webhooks/123456789/test-token";
+    const { deps } = generationDepsForChat({
+      chatPatch: { characterIds: ["char-1"], personaId: "persona-1" },
+      chatMetadata: { discordWebhookUrl: webhookUrl },
+      characters: [{ id: "char-1", data: { name: "Marina" } }],
+      personas: [{ id: "persona-1", name: "Natalie" }],
+    });
+    deps.integrations = {
+      ...deps.integrations,
+      discord: { mirrorMessage: mirrorMessage as DiscordGateway["mirrorMessage"] },
+    };
+
+    await drainGeneration(
+      startGeneration(deps, {
+        chatId: "chat-1",
+        userMessage: "hello",
+        impersonateBlockAgents: true,
+      }),
+    );
+
+    expect(mirrorMessage).toHaveBeenCalledTimes(2);
+    expect(mirrorMessage).toHaveBeenNthCalledWith(1, {
+      webhookUrl,
+      content: "hello",
+      username: "Natalie",
+    });
+    expect(mirrorMessage).toHaveBeenNthCalledWith(2, {
+      webhookUrl,
+      content: "Done.",
+      username: "Marina",
+    });
+  });
+
+  it("does not mirror regenerations", async () => {
+    const mirrorMessage = mockDiscordMirror();
+    const { deps } = generationDepsForChat({
+      chatMetadata: { discordWebhookUrl: "https://discord.com/api/webhooks/123456789/test-token" },
+      initialMessages: [
+        { id: "user-1", chatId: "chat-1", role: "user", content: "hello" },
+        { id: "assistant-1", chatId: "chat-1", role: "assistant", content: "first reply", extra: {} },
+      ],
+    });
+    deps.integrations = {
+      ...deps.integrations,
+      discord: { mirrorMessage: mirrorMessage as DiscordGateway["mirrorMessage"] },
+    };
+
+    await drainGeneration(startGeneration(deps, { chatId: "chat-1", regenerateMessageId: "assistant-1" }));
+
+    expect(mirrorMessage).not.toHaveBeenCalled();
   });
 });
 

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -25,7 +25,7 @@ import {
   normalizeGenerationReplay,
 } from "./generation-replay";
 import { assembleGenerationPrompt } from "./prompt-assembly";
-import type { GenerationCharacterContext } from "./prompt-assembly";
+import type { GenerationCharacterContext, GenerationPersonaContext } from "./prompt-assembly";
 import { applyRuntimeRegexScripts } from "./regex-runtime";
 import { boolish, hiddenFromAi, isRecord, nowIso, parseRecord, readString, stringArray, type JsonRecord } from "./runtime-records";
 import {
@@ -173,6 +173,119 @@ function savedUserMessageForTimeline(saved: unknown, chatId: string): JsonRecord
   if (readString(saved.role).trim() !== "user") return null;
   if (!readString(saved.content).trim()) return null;
   return saved;
+}
+
+function discordWebhookUrl(chat: JsonRecord): string {
+  return readString(parseRecord(chat.metadata).discordWebhookUrl).trim();
+}
+
+function limitedDiscordName(value: string | null | undefined, fallback: string): string {
+  const trimmed = readString(value).trim() || fallback;
+  return [...trimmed].slice(0, 80).join("");
+}
+
+async function characterNameById(
+  storage: StorageGateway,
+  characters: GenerationCharacterContext[],
+  characterId: string,
+): Promise<string | null> {
+  const known = characters.find((character) => character.id === characterId);
+  if (known?.name) return known.name;
+  const row = await storage.get<JsonRecord>("characters", characterId).catch(() => null);
+  if (!isRecord(row)) return null;
+  return readString(parseRecord(row.data).name).trim() || readString(row.name).trim() || null;
+}
+
+async function assistantDiscordName(args: {
+  storage: StorageGateway;
+  chat: JsonRecord;
+  saved: unknown;
+  characters: GenerationCharacterContext[];
+}): Promise<string> {
+  const mode = readString(args.chat.mode || args.chat.chatMode).trim();
+  const metadata = parseRecord(args.chat.metadata);
+  if (mode === "game") {
+    const gmCharacterId = readString(metadata.gameGmCharacterId).trim();
+    if (readString(metadata.gameGmMode).trim() === "character" && gmCharacterId) {
+      return limitedDiscordName(await characterNameById(args.storage, args.characters, gmCharacterId), "Narrator");
+    }
+    return "Narrator";
+  }
+
+  const characterId = isRecord(args.saved) ? readString(args.saved.characterId).trim() : "";
+  if (characterId) {
+    return limitedDiscordName(await characterNameById(args.storage, args.characters, characterId), "Character");
+  }
+  return limitedDiscordName(args.characters.length === 1 ? args.characters[0]?.name : null, "Assistant");
+}
+
+function mirrorDiscordMessage(args: {
+  integrations: IntegrationGateway;
+  chat: JsonRecord;
+  content: string;
+  username: string;
+  avatarUrl?: string | null;
+}): void {
+  const webhookUrl = discordWebhookUrl(args.chat);
+  const content = args.content.trim();
+  if (!webhookUrl || !content) return;
+  if (!args.integrations.discord) {
+    console.warn("[generation] Discord mirror skipped: integration gateway unavailable");
+    return;
+  }
+  const payload: {
+    webhookUrl: string;
+    content: string;
+    username: string;
+    avatarUrl?: string;
+  } = {
+    webhookUrl,
+    content,
+    username: limitedDiscordName(args.username, "Marinara"),
+  };
+  if (args.avatarUrl) payload.avatarUrl = args.avatarUrl;
+  void args.integrations.discord.mirrorMessage(payload).catch((error) => {
+    console.warn("[generation] Discord mirror failed", error);
+  });
+}
+
+function mirrorSavedUserMessageToDiscord(args: {
+  deps: GenerationEngineDeps;
+  chat: JsonRecord;
+  input: StartGenerationInput;
+  prepared: PreparedUserInput;
+  persona: GenerationPersonaContext | null;
+}): void {
+  if (!shouldSaveUserMessage(args.input, args.prepared)) return;
+  mirrorDiscordMessage({
+    integrations: args.deps.integrations,
+    chat: args.chat,
+    content: args.prepared.content || inputUserMessage(args.input),
+    username: limitedDiscordName(args.persona?.name, "User"),
+  });
+}
+
+async function mirrorSavedAssistantMessageToDiscord(args: {
+  deps: GenerationEngineDeps;
+  chat: JsonRecord;
+  input: StartGenerationInput;
+  saved: unknown;
+  content: string;
+  characters: GenerationCharacterContext[];
+}): Promise<void> {
+  if (args.input.impersonate === true || readString(args.input.regenerateMessageId).trim()) return;
+  const username = await assistantDiscordName({
+    storage: args.deps.storage,
+    chat: args.chat,
+    saved: args.saved,
+    characters: args.characters,
+  });
+  mirrorDiscordMessage({
+    integrations: args.deps.integrations,
+    chat: args.chat,
+    content: args.content,
+    username,
+  });
 }
 
 async function inputWithStoredGenerationReplay(
@@ -753,6 +866,7 @@ export async function* startGeneration(
     request: input,
     latestUserInput: preparedUserInput.content || inputUserMessage(input),
   });
+  mirrorSavedUserMessageToDiscord({ deps, chat, input, prepared: preparedUserInput, persona: assembly.persona });
 
   if (!directMessages) {
     const agentsEnabled = input.impersonateBlockAgents !== true;
@@ -848,6 +962,16 @@ export async function* startGeneration(
           attachments: connected.assistantAttachments,
           usage,
         });
+    if (saved) {
+      await mirrorSavedAssistantMessageToDiscord({
+        deps,
+        chat,
+        input,
+        saved,
+        content: connected.displayContent,
+        characters: assembly.characters,
+      });
+    }
     if (saved) await persistTrackerSnapshotSafely(deps.storage, chatId, saved, allAgentResults, generationTrackerBaseline);
     await persistAgentResults(deps.storage, chatId, messageId(saved), allAgentResults);
     if (saved) {
@@ -918,6 +1042,16 @@ export async function* startGeneration(
         attachments: connected.assistantAttachments,
         usage,
       });
+  if (saved) {
+    await mirrorSavedAssistantMessageToDiscord({
+      deps,
+      chat,
+      input,
+      saved,
+      content: connected.displayContent,
+      characters: assembly.characters,
+    });
+  }
   if (saved) {
     const autoLorebookResults = await runLorebookKeeperBackfill(
       deps,

--- a/src/features/modes/game/api/game-api.ts
+++ b/src/features/modes/game/api/game-api.ts
@@ -5,6 +5,7 @@ import type { RPGAttributes } from "../../../../engine/contracts/types/game-stat
 import { ApiError, type JsonRepairRequest } from "../../../../shared/api/api-errors";
 import { gameAssetsApi } from "../../../../shared/api/assets-api";
 import { imageGenerationApi } from "../../../../shared/api/image-generation-api";
+import { integrationGateway } from "../../../../shared/api/integration-gateway";
 import { spotifyApi } from "../../../../shared/api/integration-utility-api";
 import { llmApi } from "../../../../shared/api/llm-api";
 import { storageApi } from "../../../../shared/api/storage-api";
@@ -163,6 +164,23 @@ function asRecord(value: unknown): Record<string, unknown> {
 
 function chatMeta(chat: Chat | null | undefined): Record<string, unknown> {
   return asRecord(chat?.metadata);
+}
+
+function discordWebhookUrl(meta: Record<string, unknown>): string {
+  return typeof meta.discordWebhookUrl === "string" ? meta.discordWebhookUrl.trim() : "";
+}
+
+function mirrorGameMessageToDiscord(meta: Record<string, unknown>, content: string, username: string): void {
+  const webhookUrl = discordWebhookUrl(meta);
+  const trimmed = content.trim();
+  if (!webhookUrl || !trimmed) return;
+  if (!integrationGateway.discord) {
+    console.warn("[game] Discord mirror skipped: integration gateway unavailable");
+    return;
+  }
+  void integrationGateway.discord.mirrorMessage({ webhookUrl, content: trimmed, username }).catch((error) => {
+    console.warn("[game] Discord mirror failed", error);
+  });
 }
 
 async function getChat(chatId: string): Promise<Chat> {
@@ -518,6 +536,7 @@ function gameCarryoverPatch(meta: Record<string, unknown>) {
     "gameSessionLorebookId",
     "gameSessionLorebookEntryCount",
     "gameJournal",
+    "discordWebhookUrl",
   ];
   return Object.fromEntries(keys.filter((key) => key in meta).map((key) => [key, meta[key]]));
 }
@@ -954,6 +973,7 @@ export const gameApi = {
         content: `[session-recap]\n${recap.trim()}`,
         extra: { hiddenFromAi: false, isSessionRecap: true },
       });
+      mirrorGameMessageToDiscord(chatMeta(sessionChat), recap.trim(), "Narrator");
     }
     return { sessionChat, sessionNumber, recap };
   },
@@ -1425,6 +1445,7 @@ export const gameApi = {
       swipes: [{ content: `[party-turn]\n${clean}` }],
       activeSwipeIndex: 0,
     });
+    mirrorGameMessageToDiscord(meta, clean, "Party");
     return { raw: clean };
   },
 

--- a/src/shared/api/integration-gateway.ts
+++ b/src/shared/api/integration-gateway.ts
@@ -28,4 +28,12 @@ export const integrationGateway: IntegrationGateway = {
   image: {
     generate: <T = unknown>(input: Record<string, unknown>) => imageGenerationApi.generate<T>(input),
   },
+  discord: {
+    mirrorMessage: <T = unknown>(input: {
+      webhookUrl: string;
+      content: string;
+      username?: string | null;
+      avatarUrl?: string | null;
+    }) => invokeTauri<T>("discord_webhook_send", { body: input }),
+  },
 };

--- a/src/shared/api/remote-runtime.ts
+++ b/src/shared/api/remote-runtime.ts
@@ -58,6 +58,7 @@ const REMOTE_COMMANDS = new Set([
   "tts_voices",
   "tts_speak",
   "translate_text_command",
+  "discord_webhook_send",
   "spotify_status",
   "spotify_authorize",
   "spotify_exchange",


### PR DESCRIPTION
## What?
- Add Discord webhook sending support for the refactor build.
- Mirror Discord-enabled generation chats by sending saved user messages and assistant replies.
- Mirror Discord-enabled game recaps and party turns.

## Why?
Issue #1359 reported that Discord Mirror settings persisted the webhook URL but no refactor send path existed, so mirrors never posted messages.

Closes #1359

## How?
- Added an optional engine Discord gateway and wired it through the shared integration gateway.
- Added a Tauri/remote `discord_webhook_send` command backed by a Rust webhook sender with URL validation, payload truncation, and Discord error handling.
- Kept mirroring fire-and-forget so webhook failures warn instead of blocking generation or game flow.

## Testing?
- `pnpm vitest run src/engine/generation/start-generation.test.ts`
- `pnpm typecheck`
- `pnpm check:architecture`
- `cargo test --manifest-path src-tauri/Cargo.toml discord`
- `pnpm build`

## Screenshots (optional)
Not applicable; this is webhook plumbing without UI changes.

## Anything Else?
No real Discord webhook/manual Tauri post was run; coverage is automated unit/build verification.