### PR TITLE
Clean up Rust dependency checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,10 +61,10 @@ jobs:
       - run: cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- -D warnings
       - run: cargo nextest run --manifest-path src-tauri/Cargo.toml --workspace
       - name: Rust dependency policy report
-        run: cargo deny --manifest-path src-tauri/Cargo.toml check
+        run: cargo deny --manifest-path src-tauri/Cargo.toml check --config deny.toml
         continue-on-error: true
       - name: Unused Rust dependency report
-        run: cargo machete --manifest-path src-tauri/Cargo.toml
+        run: cargo machete src-tauri
         continue-on-error: true
 
   smoke:

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,40 @@
+[graph]
+all-features = true
+
+[advisories]
+version = 2
+yanked = "warn"
+unmaintained = "workspace"
+ignore = []
+
+[bans]
+multiple-versions = "warn"
+wildcards = "allow"
+highlight = "all"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []
+
+[licenses]
+version = 2
+confidence-threshold = 0.8
+unused-allowed-license = "allow"
+private = { ignore = true }
+allow = [
+  "0BSD",
+  "Apache-2.0",
+  "Apache-2.0 WITH LLVM-exception",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "CDLA-Permissive-2.0",
+  "ISC",
+  "MIT",
+  "MIT-0",
+  "MPL-2.0",
+  "Unicode-3.0",
+  "Unlicense",
+  "Zlib",
+]

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "check:rust:clippy": "cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- -D warnings",
     "check:rust:test": "cargo test --manifest-path src-tauri/Cargo.toml --workspace",
     "check:rust:nextest": "cargo nextest run --manifest-path src-tauri/Cargo.toml --workspace",
-    "check:rust:deny": "cargo deny --manifest-path src-tauri/Cargo.toml check",
-    "check:rust:deps": "cargo machete --manifest-path src-tauri/Cargo.toml",
+    "check:rust:deny": "cargo deny --manifest-path src-tauri/Cargo.toml check --config deny.toml",
+    "check:rust:deps": "cargo machete src-tauri",
     "check:docs": "node scripts/check-docs.mjs",
     "check:unused": "knip",
     "check": "pnpm check:architecture && pnpm check:frontend && pnpm check:rust && pnpm check:docs",
@@ -83,6 +83,9 @@
   "pnpm": {
     "onlyBuiltDependencies": [
       "esbuild"
+    ],
+    "ignoredBuiltDependencies": [
+      "unrs-resolver"
     ]
   },
   "size-limit": [

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3034,7 +3034,6 @@ dependencies = [
  "image",
  "marinara-core",
  "marinara-security",
- "marinara-storage",
  "serde_json",
 ]
 
@@ -3063,7 +3062,6 @@ dependencies = [
  "log",
  "marinara-assets",
  "marinara-core",
- "marinara-integrations",
  "marinara-llm",
  "marinara-security",
  "marinara-storage",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,6 +4,7 @@ version = "1.6.1"
 description = "Marinara Engine"
 authors = ["you"]
 edition = "2021"
+publish = false
 default-run = "marinara-engine"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -60,7 +61,6 @@ marinara-core = { path = "crates/core" }
 marinara-security = { path = "crates/security" }
 marinara-storage = { path = "crates/storage" }
 marinara-assets = { path = "crates/assets" }
-marinara-integrations = { path = "crates/integrations" }
 marinara-llm = { path = "crates/llm" }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]

--- a/src-tauri/crates/assets/Cargo.toml
+++ b/src-tauri/crates/assets/Cargo.toml
@@ -2,6 +2,7 @@
 name = "marinara-assets"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [lib]
 path = "src/lib.rs"
@@ -12,5 +13,4 @@ chrono = { version = "0.4", default-features = false, features = ["clock", "std"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "webp"] }
 marinara-core = { path = "../core" }
 marinara-security = { path = "../security" }
-marinara-storage = { path = "../storage" }
 serde_json = "1"

--- a/src-tauri/crates/core/Cargo.toml
+++ b/src-tauri/crates/core/Cargo.toml
@@ -2,6 +2,7 @@
 name = "marinara-core"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [lib]
 path = "src/lib.rs"

--- a/src-tauri/crates/integrations/Cargo.toml
+++ b/src-tauri/crates/integrations/Cargo.toml
@@ -2,6 +2,7 @@
 name = "marinara-integrations"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [lib]
 path = "src/lib.rs"

--- a/src-tauri/crates/llm/Cargo.toml
+++ b/src-tauri/crates/llm/Cargo.toml
@@ -2,6 +2,7 @@
 name = "marinara-llm"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [lib]
 path = "src/lib.rs"

--- a/src-tauri/crates/security/Cargo.toml
+++ b/src-tauri/crates/security/Cargo.toml
@@ -2,6 +2,7 @@
 name = "marinara-security"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [lib]
 path = "src/lib.rs"

--- a/src-tauri/crates/storage/Cargo.toml
+++ b/src-tauri/crates/storage/Cargo.toml
@@ -2,6 +2,7 @@
 name = "marinara-storage"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [lib]
 path = "src/lib.rs"


### PR DESCRIPTION
## What?
- Fix the repo Rust dependency-check scripts so `cargo-machete` uses its supported path invocation.
- Add an explicit `cargo-deny` policy and wire local scripts/CI to use it.
- Remove two unused Rust path dependencies reported by `cargo-machete`.
- Mark private Rust workspace crates as unpublished and explicitly ignore the safe-to-ignore `unrs-resolver` pnpm build script.

## Why?
Issue #1394 reported that the Rust dependency tooling was failing because repo scripts relied on unsupported/default tool behavior instead of project-owned configuration.

Closes #1394

## How?
- Changed `check:rust:deps` and the CI report step from `cargo machete --manifest-path ...` to `cargo machete src-tauri`.
- Changed `check:rust:deny` and CI to pass `check --config deny.toml`.
- Added `deny.toml` with repo-owned advisory, ban, license, and source policy.
- Removed `marinara-integrations` from the root Tauri crate and `marinara-storage` from `marinara-assets`, then let `Cargo.lock` update.

## Testing?
- `pnpm install --frozen-lockfile`
- `cargo check --manifest-path src-tauri/Cargo.toml --workspace`
- `pnpm check:docs`
- `PATH="/e/TEMP/opencode/cargo-tools/bin:$PATH" pnpm check:rust:deny`
- `PATH="/e/TEMP/opencode/cargo-tools/bin:$PATH" pnpm check:rust:deps`
- `pnpm check:architecture`

## Screenshots (optional)
Not applicable; this is repo tooling/config cleanup.

## Anything Else?
`cargo-deny` still reports duplicate dependency warnings, but the configured policy exits successfully so the report is usable without blocking normal checks.