### PR TITLE
Restore group turn prompt toggle

### DIFF
--- a/src/engine/contracts/types/chat.ts
+++ b/src/engine/contracts/types/chat.ts
@@ -167,6 +167,8 @@ export interface ChatMetadata {
   groupResponseOrder?: GroupResponseOrder;
   /** Character IDs attached to this chat but muted/excluded from generation. */
   inactiveCharacterIds?: string[];
+  /** When true/omitted, individual group turns append a responding-character instruction to the prompt. */
+  groupTurnPromptEnabled?: boolean;
   /** Characters with visible roleplay sprites enabled for this chat. */
   spriteCharacterIds?: string[];
   /** Which sprite file families the roleplay Expression Engine may display. */

--- a/src/engine/generation/start-generation.test.ts
+++ b/src/engine/generation/start-generation.test.ts
@@ -423,6 +423,35 @@ describe("startGeneration Discord mirror", () => {
   });
 });
 
+describe("startGeneration group turn prompt toggle", () => {
+  it("keeps target character instructions enabled by default for non-conversation group chats", async () => {
+    const { deps, streamedRequests } = generationDepsForChat({
+      chatPatch: { mode: "roleplay", characterIds: ["char-1", "char-2"] },
+      characters: [{ id: "char-1", data: { name: "Marina" } }],
+    });
+
+    await drainGeneration(startGeneration(deps, { chatId: "chat-1", forCharacterId: "char-1", impersonateBlockAgents: true }));
+
+    expect((streamedRequests[0] as { messages: Array<{ content: string }> }).messages).toEqual(
+      expect.arrayContaining([expect.objectContaining({ content: "[Generation instruction: respond as Marina.]" })]),
+    );
+  });
+
+  it("omits target character instructions when non-conversation group turn prompts are disabled", async () => {
+    const { deps, streamedRequests } = generationDepsForChat({
+      chatPatch: { mode: "roleplay", characterIds: ["char-1", "char-2"] },
+      chatMetadata: { groupTurnPromptEnabled: false },
+      characters: [{ id: "char-1", data: { name: "Marina" } }],
+    });
+
+    await drainGeneration(startGeneration(deps, { chatId: "chat-1", forCharacterId: "char-1", impersonateBlockAgents: true }));
+
+    expect((streamedRequests[0] as { messages: Array<{ content: string }> }).messages).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ content: "[Generation instruction: respond as Marina.]" })]),
+    );
+  });
+});
+
 describe("retryGenerationAgents lorebook keeper backfill", () => {
   it("uses run interval and read-behind settings to backfill only unprocessed batch anchors", async () => {
     const messages = Array.from({ length: 40 }, (_, index) => ({

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -351,6 +351,7 @@ function withImageAttachments(messages: LlmMessage[], images: string[]): LlmMess
 
 function directiveMessages(
   input: StartGenerationInput,
+  chat: JsonRecord,
   characters: GenerationCharacterContext[],
   prepared: PreparedUserInput,
   options: { continueAssistantResponse?: boolean } = {},
@@ -370,7 +371,9 @@ function directiveMessages(
   }
 
   const forCharacterId = readString(input.forCharacterId).trim();
-  if (forCharacterId) {
+  const isNonConversationGroup = readString(chat.mode || chat.chatMode) !== "conversation" && stringArray(chat.characterIds).length > 1;
+  const addGroupTurnPrompt = !isNonConversationGroup || parseRecord(chat.metadata).groupTurnPromptEnabled !== false;
+  if (forCharacterId && addGroupTurnPrompt) {
     const character = characters.find((candidate) => candidate.id === forCharacterId);
     messages.push({
       role: "user",
@@ -921,7 +924,7 @@ export async function* startGeneration(
     prompt = withImageAttachments(
       [
         ...assembly.messages,
-        ...directiveMessages(input, assembly.characters, preparedUserInput, { continueAssistantResponse }),
+        ...directiveMessages(input, chat, assembly.characters, preparedUserInput, { continueAssistantResponse }),
       ],
       preparedUserInput.images,
     );
@@ -1014,7 +1017,7 @@ export async function* startGeneration(
   }
 
   prompt = withImageAttachments(
-    [...(prompt ?? []), ...directiveMessages(input, assembly.characters, preparedUserInput, { continueAssistantResponse })],
+    [...(prompt ?? []), ...directiveMessages(input, chat, assembly.characters, preparedUserInput, { continueAssistantResponse })],
     preparedUserInput.images,
   );
   yield { type: "phase", data: "Calling model..." };

--- a/src/features/modes/shared/chat-ui/components/ChatSettingsDrawer.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatSettingsDrawer.tsx
@@ -2778,6 +2778,44 @@ export function ChatSettingsDrawer({
                         ? "An AI agent decides which characters should respond based on the scene context."
                         : "Characters respond one by one in their listed order."}
                   </p>
+                  <button
+                    onClick={() =>
+                      updateMeta.mutate({
+                        id: chat.id,
+                        groupTurnPromptEnabled: metadata.groupTurnPromptEnabled === false,
+                      })
+                    }
+                    className={cn(
+                      "flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left transition-all",
+                      metadata.groupTurnPromptEnabled !== false
+                        ? "bg-[var(--primary)]/10 ring-1 ring-[var(--primary)]/30"
+                        : "bg-[var(--secondary)] hover:bg-[var(--accent)]",
+                    )}
+                  >
+                    <div className="min-w-0 flex-1">
+                      <span className="text-[0.6875rem] font-medium">Add Turn To Prompt</span>
+                      <p className="mt-0.5 text-[0.625rem] leading-relaxed text-[var(--muted-foreground)]">
+                        {metadata.groupTurnPromptEnabled !== false
+                          ? "Each individual turn includes a short responding-character instruction."
+                          : "Individual turns rely on context without adding a turn instruction."}
+                      </p>
+                    </div>
+                    <div
+                      className={cn(
+                        "ml-3 h-5 w-9 shrink-0 rounded-full p-0.5 transition-colors",
+                        metadata.groupTurnPromptEnabled !== false
+                          ? "bg-[var(--primary)]"
+                          : "bg-[var(--muted-foreground)]/50",
+                      )}
+                    >
+                      <div
+                        className={cn(
+                          "h-4 w-4 rounded-full bg-white shadow-sm transition-transform",
+                          metadata.groupTurnPromptEnabled !== false && "translate-x-3.5",
+                        )}
+                      />
+                    </div>
+                  </button>
                 </div>
               )}
 


### PR DESCRIPTION
## What?
- Restore the chat metadata field for the legacy group-turn prompt toggle.
- Add the Group Chat settings toggle back for non-conversation individual group chats.
- Honor `groupTurnPromptEnabled: false` by omitting the target-character prompt instruction for non-conversation group turns.

## Why?
Issue #1358 reported that refactor preserved manual targeted replies but lost the legacy chat-level control over whether individual group turns inject the strict responding-character instruction.

Closes #1358

## How?
- Added `groupTurnPromptEnabled` to `ChatMetadata`.
- Reintroduced the “Add Turn To Prompt” toggle in `ChatSettingsDrawer`, defaulting to enabled when unset.
- Passed chat metadata into generation directive assembly so non-conversation group chats can suppress the target-character instruction when the toggle is off.
- Added regression tests for default enabled behavior and disabled behavior.

## Testing?
- `pnpm install --frozen-lockfile`
- `pnpm vitest run src/engine/generation/start-generation.test.ts`
- `pnpm typecheck`
- `pnpm check:architecture`
- `pnpm build`

## Screenshots (optional)
Not captured; this restores a small settings-drawer toggle and prompt behavior.

## Anything Else?
`pnpm install --frozen-lockfile` still warns about `unrs-resolver` on this branch because #1394 handles that repo tooling cleanup separately.