### PR TITLE
[codex] Restore Illustrator run interval parity

### DIFF
--- a/src/engine/contracts/types/agent.ts
+++ b/src/engine/contracts/types/agent.ts
@@ -490,6 +490,7 @@ export const BUILT_IN_AGENTS: BuiltInAgentMeta[] = [
 
 export const BUILT_IN_AGENT_RUN_INTERVAL_DEFAULTS: Readonly<Record<string, number>> = {
   director: 5,
+  illustrator: 5,
   "lorebook-keeper": 8,
   "card-evolution-auditor": 8,
   "chat-summary": 5,

--- a/src/engine/generation/agent-runner.test.ts
+++ b/src/engine/generation/agent-runner.test.ts
@@ -4,9 +4,9 @@ import type { LlmGateway } from "../capabilities/llm";
 import type { StorageGateway } from "../capabilities/storage";
 import { createGenerationAgentRuntime } from "./agent-runner";
 
-function storage(rows: Record<string, unknown>[]): StorageGateway {
+function storage(rows: Record<string, unknown>[], collections: Record<string, Record<string, unknown>[]> = {}): StorageGateway {
   return {
-    list: async <T,>(entity: string) => (entity === "agents" ? rows : []) as T[],
+    list: async <T,>(entity: string) => (entity === "agents" ? rows : (collections[entity] ?? [])) as T[],
     get: async <T,>() => null as T | null,
     create: async <T,>() => ({}) as T,
     update: async <T,>() => ({}) as T,
@@ -40,14 +40,14 @@ const llm: LlmGateway = {
   },
 };
 
-function countingLlm(calls: unknown[]): LlmGateway {
+function countingLlm(calls: unknown[], responseText = "ok"): LlmGateway {
   return {
     async *stream(request) {
       calls.push(request);
-      yield { type: "token", text: "ok" };
+      yield { type: "token", text: responseText };
     },
     async complete() {
-      return "ok";
+      return responseText;
     },
     async listModels() {
       return [];
@@ -56,6 +56,18 @@ function countingLlm(calls: unknown[]): LlmGateway {
 }
 
 const integrations = {} as IntegrationGateway;
+
+const illustratorDrawData = {
+  shouldGenerate: true,
+  reason: "Important visual beat",
+  prompt: "moonlit tavern confrontation",
+};
+const illustratorDrawResponse = JSON.stringify(illustratorDrawData);
+const illustratorNoDrawData = {
+  shouldGenerate: false,
+  reason: "No major visual change",
+  prompt: "",
+};
 
 describe("createGenerationAgentRuntime", () => {
   it("runs chat-scoped active agents even when the legacy enable flag is absent", async () => {
@@ -339,6 +351,374 @@ describe("createGenerationAgentRuntime", () => {
         text: "ok",
       },
     ]);
+    expect(calls).toHaveLength(1);
+  });
+
+  it("skips automatic Illustrator runs until the assistant-message interval has elapsed", async () => {
+    const calls: unknown[] = [];
+    const runtime = await createGenerationAgentRuntime(
+      {
+        storage: storage(
+          [
+            {
+              id: "agent-a",
+              type: "illustrator",
+              name: "Illustrator",
+              enabled: true,
+              phase: "post_processing",
+              connectionId: null,
+              promptTemplate: "Decide whether to draw this scene.",
+              settings: { runInterval: 5 },
+            },
+          ],
+          {
+            "agent-runs": [
+              {
+                chatId: "chat-a",
+                agentType: "illustrator",
+                resultType: "image_prompt",
+                resultData: illustratorDrawData,
+                messageId: "assistant-1",
+                success: true,
+                createdAt: "2026-01-01T00:00:00.000Z",
+              },
+            ],
+          },
+        ),
+        llm: countingLlm(calls),
+        integrations,
+      },
+      {
+        chat: { id: "chat-a", metadata: { enableAgents: true } },
+        connection: { id: "chat-connection", model: "chat-model" },
+        storedMessages: [
+          { id: "assistant-1", role: "assistant", content: "First illustrated reply." },
+          { id: "assistant-2", role: "assistant", content: "Second reply." },
+          { id: "assistant-3", role: "assistant", content: "Third reply." },
+        ],
+        characters: [],
+        persona: null,
+        activatedLorebookEntries: [],
+        chatSummary: null,
+      },
+    );
+
+    expect(runtime.preResults).toEqual([]);
+    expect(await runtime.runParallel()).toEqual([]);
+    expect(await runtime.runPost("response")).toEqual([]);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("uses legacy type fields on persisted Illustrator runs when gating automatic intervals", async () => {
+    const calls: unknown[] = [];
+    const runtime = await createGenerationAgentRuntime(
+      {
+        storage: storage(
+          [
+            {
+              id: "agent-a",
+              type: "illustrator",
+              name: "Illustrator",
+              enabled: true,
+              phase: "post_processing",
+              connectionId: null,
+              promptTemplate: "Decide whether to draw this scene.",
+              settings: { runInterval: 5 },
+            },
+          ],
+          {
+            "agent-runs": [
+              {
+                chatId: "chat-a",
+                type: "illustrator",
+                resultType: "image_prompt",
+                resultData: illustratorDrawData,
+                messageId: "assistant-1",
+                success: true,
+                createdAt: "2026-01-01T00:00:00.000Z",
+              },
+            ],
+          },
+        ),
+        llm: countingLlm(calls),
+        integrations,
+      },
+      {
+        chat: { id: "chat-a", metadata: { enableAgents: true } },
+        connection: { id: "chat-connection", model: "chat-model" },
+        storedMessages: [
+          { id: "assistant-1", role: "assistant", content: "First illustrated reply." },
+          { id: "assistant-2", role: "assistant", content: "Second reply." },
+          { id: "assistant-3", role: "assistant", content: "Third reply." },
+        ],
+        characters: [],
+        persona: null,
+        activatedLorebookEntries: [],
+        chatSummary: null,
+      },
+    );
+
+    expect(await runtime.runPost("response")).toEqual([]);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("does not let no-draw Illustrator decisions reset the automatic run interval", async () => {
+    const calls: unknown[] = [];
+    const runtime = await createGenerationAgentRuntime(
+      {
+        storage: storage(
+          [
+            {
+              id: "agent-a",
+              type: "illustrator",
+              name: "Illustrator",
+              enabled: true,
+              phase: "post_processing",
+              connectionId: null,
+              promptTemplate: "Decide whether to draw this scene.",
+              settings: { runInterval: 5 },
+            },
+          ],
+          {
+            "agent-runs": [
+              {
+                chatId: "chat-a",
+                agentType: "illustrator",
+                resultType: "image_prompt",
+                resultData: illustratorDrawData,
+                messageId: "assistant-1",
+                success: true,
+                createdAt: "2026-01-01T00:00:00.000Z",
+              },
+              {
+                chatId: "chat-a",
+                agentType: "illustrator",
+                resultType: "image_prompt",
+                resultData: illustratorNoDrawData,
+                messageId: "assistant-4",
+                success: true,
+                createdAt: "2026-01-01T00:04:00.000Z",
+              },
+            ],
+          },
+        ),
+        llm: countingLlm(calls, illustratorDrawResponse),
+        integrations,
+      },
+      {
+        chat: { id: "chat-a", metadata: { enableAgents: true } },
+        connection: { id: "chat-connection", model: "chat-model" },
+        storedMessages: [
+          { id: "assistant-1", role: "assistant", content: "First illustrated reply." },
+          { id: "assistant-2", role: "assistant", content: "Second reply." },
+          { id: "assistant-3", role: "assistant", content: "Third reply." },
+          { id: "assistant-4", role: "assistant", content: "Fourth reply with no new image." },
+          { id: "assistant-5", role: "assistant", content: "Fifth reply." },
+        ],
+        characters: [],
+        persona: null,
+        activatedLorebookEntries: [],
+        chatSummary: null,
+      },
+    );
+
+    const results = await runtime.runPost("response");
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      agentId: "agent-a",
+      agentType: "illustrator",
+      success: true,
+      data: illustratorDrawData,
+    });
+    expect(calls).toHaveLength(1);
+  });
+
+  it("chooses the latest transcript-position Illustrator run over a newer retry of an older message", async () => {
+    const calls: unknown[] = [];
+    const runtime = await createGenerationAgentRuntime(
+      {
+        storage: storage(
+          [
+            {
+              id: "agent-a",
+              type: "illustrator",
+              name: "Illustrator",
+              enabled: true,
+              phase: "post_processing",
+              connectionId: null,
+              promptTemplate: "Decide whether to draw this scene.",
+              settings: { runInterval: 5 },
+            },
+          ],
+          {
+            "agent-runs": [
+              {
+                chatId: "chat-a",
+                agentType: "illustrator",
+                resultType: "image_prompt",
+                resultData: illustratorDrawData,
+                messageId: "assistant-5",
+                success: true,
+                createdAt: "2026-01-01T00:05:00.000Z",
+              },
+              {
+                chatId: "chat-a",
+                agentType: "illustrator",
+                resultType: "image_prompt",
+                resultData: illustratorDrawData,
+                messageId: "assistant-1",
+                success: true,
+                createdAt: "2026-01-01T00:10:00.000Z",
+              },
+            ],
+          },
+        ),
+        llm: countingLlm(calls),
+        integrations,
+      },
+      {
+        chat: { id: "chat-a", metadata: { enableAgents: true } },
+        connection: { id: "chat-connection", model: "chat-model" },
+        storedMessages: [
+          { id: "assistant-1", role: "assistant", content: "First illustrated reply." },
+          { id: "assistant-2", role: "assistant", content: "Second reply." },
+          { id: "assistant-3", role: "assistant", content: "Third reply." },
+          { id: "assistant-4", role: "assistant", content: "Fourth reply." },
+          { id: "assistant-5", role: "assistant", content: "Fifth illustrated reply." },
+          { id: "assistant-6", role: "assistant", content: "Sixth reply." },
+          { id: "assistant-7", role: "assistant", content: "Seventh reply." },
+        ],
+        characters: [],
+        persona: null,
+        activatedLorebookEntries: [],
+        chatSummary: null,
+      },
+    );
+
+    expect(await runtime.runPost("response")).toEqual([]);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("runs automatic Illustrator when the assistant-message interval has elapsed", async () => {
+    const calls: unknown[] = [];
+    const runtime = await createGenerationAgentRuntime(
+      {
+        storage: storage(
+          [
+            {
+              id: "agent-a",
+              type: "illustrator",
+              name: "Illustrator",
+              enabled: true,
+              phase: "post_processing",
+              connectionId: null,
+              promptTemplate: "Decide whether to draw this scene.",
+              settings: { runInterval: 5 },
+            },
+          ],
+          {
+            "agent-runs": [
+              {
+                chatId: "chat-a",
+                agentType: "illustrator",
+                resultType: "image_prompt",
+                resultData: illustratorDrawData,
+                messageId: "assistant-1",
+                success: true,
+                createdAt: "2026-01-01T00:00:00.000Z",
+              },
+            ],
+          },
+        ),
+        llm: countingLlm(calls, illustratorDrawResponse),
+        integrations,
+      },
+      {
+        chat: { id: "chat-a", metadata: { enableAgents: true } },
+        connection: { id: "chat-connection", model: "chat-model" },
+        storedMessages: [
+          { id: "assistant-1", role: "assistant", content: "First illustrated reply." },
+          { id: "assistant-2", role: "assistant", content: "Second reply." },
+          { id: "assistant-3", role: "assistant", content: "Third reply." },
+          { id: "assistant-4", role: "assistant", content: "Fourth reply." },
+          { id: "assistant-5", role: "assistant", content: "Fifth reply." },
+        ],
+        characters: [],
+        persona: null,
+        activatedLorebookEntries: [],
+        chatSummary: null,
+      },
+    );
+
+    const results = await runtime.runPost("response");
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      agentId: "agent-a",
+      agentType: "illustrator",
+      success: true,
+    });
+    expect(calls).toHaveLength(1);
+  });
+
+  it("lets explicit Illustrator retries bypass the automatic run interval", async () => {
+    const calls: unknown[] = [];
+    const runtime = await createGenerationAgentRuntime(
+      {
+        storage: storage(
+          [
+            {
+              id: "agent-a",
+              type: "illustrator",
+              name: "Illustrator",
+              enabled: true,
+              phase: "post_processing",
+              connectionId: null,
+              promptTemplate: "Decide whether to draw this scene.",
+              settings: { runInterval: 5 },
+            },
+          ],
+          {
+            "agent-runs": [
+              {
+                chatId: "chat-a",
+                agentType: "illustrator",
+                resultType: "image_prompt",
+                resultData: illustratorDrawData,
+                messageId: "assistant-1",
+                success: true,
+                createdAt: "2026-01-01T00:00:00.000Z",
+              },
+            ],
+          },
+        ),
+        llm: countingLlm(calls, illustratorDrawResponse),
+        integrations,
+      },
+      {
+        chat: { id: "chat-a", metadata: { enableAgents: true } },
+        connection: { id: "chat-connection", model: "chat-model" },
+        storedMessages: [
+          { id: "assistant-1", role: "assistant", content: "First illustrated reply." },
+          { id: "assistant-2", role: "assistant", content: "Second reply." },
+        ],
+        characters: [],
+        persona: null,
+        activatedLorebookEntries: [],
+        chatSummary: null,
+        agentTypes: new Set(["illustrator"]),
+      },
+    );
+
+    const results = await runtime.runPost("response");
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      agentId: "agent-a",
+      agentType: "illustrator",
+      success: true,
+    });
     expect(calls).toHaveLength(1);
   });
 });

--- a/src/engine/generation/agent-runner.ts
+++ b/src/engine/generation/agent-runner.ts
@@ -1,4 +1,10 @@
-import { BUILT_IN_AGENTS, BUILT_IN_TOOLS, type AgentContext, type AgentResult } from "../contracts/types/agent";
+import {
+  BUILT_IN_AGENTS,
+  BUILT_IN_AGENT_RUN_INTERVAL_DEFAULTS,
+  BUILT_IN_TOOLS,
+  type AgentContext,
+  type AgentResult,
+} from "../contracts/types/agent";
 import type { IntegrationGateway } from "../capabilities/integrations";
 import type { LlmGateway, LlmMessage } from "../capabilities/llm";
 import type { StorageGateway } from "../capabilities/storage";
@@ -62,6 +68,8 @@ interface ResolvedAgentsResult {
 }
 
 const BUILT_IN_AGENT_TYPES = new Set(BUILT_IN_AGENTS.map((agent) => agent.id));
+const ILLUSTRATOR_AGENT_TYPE = "illustrator";
+const MAX_ASSISTANT_RUN_INTERVAL = 100;
 
 function llmProvider(llm: LlmGateway, connectionId: string | null): BaseLLMProvider {
   return {
@@ -200,6 +208,92 @@ function activationScanMessages(input: GenerationAgentRuntimeInput): ActivationS
 function isBuiltInAgent(agent: JsonRecord): boolean {
   const type = readString(agent.type || agent.agentType).trim();
   return BUILT_IN_AGENT_TYPES.has(type);
+}
+
+function positiveInteger(value: unknown, fallback: number, max: number): number {
+  const parsed = typeof value === "number" ? value : typeof value === "string" ? Number(value) : Number.NaN;
+  if (!Number.isFinite(parsed) || parsed < 1) return fallback;
+  return Math.max(1, Math.min(max, Math.floor(parsed)));
+}
+
+function automaticAssistantIntervalAgentType(input: GenerationAgentRuntimeInput, type: string): string | null {
+  if (input.agentTypes && input.agentTypes.size > 0) return null;
+  return type === ILLUSTRATOR_AGENT_TYPE ? type : null;
+}
+
+function runAgentType(run: JsonRecord): string {
+  return readString(run.agentType || run.type).trim();
+}
+
+function illustratorRunCountsTowardInterval(run: JsonRecord): boolean {
+  const resultType = readString(run.resultType).trim();
+  if (resultType && resultType !== "image_prompt") return false;
+  const data = parseRecord(run.resultData);
+  if (boolish(data.parseError, false)) return false;
+  if (data.shouldGenerate !== true) return false;
+  return readString(data.prompt).trim().length > 0;
+}
+
+function messageIndexById(input: GenerationAgentRuntimeInput): Map<string, number> {
+  const indexes = new Map<string, number>();
+  input.storedMessages.forEach((message, index) => {
+    const id = readString(message.id).trim();
+    if (id) indexes.set(id, index);
+  });
+  return indexes;
+}
+
+function intervalAnchorRun(
+  runs: JsonRecord[],
+  input: GenerationAgentRuntimeInput,
+  chatId: string,
+  agentType: string,
+): JsonRecord | null {
+  const indexes = messageIndexById(input);
+  return (
+    runs
+      .filter((run) => readString(run.chatId).trim() === chatId)
+      .filter((run) => runAgentType(run) === agentType)
+      .filter((run) => boolish(run.success, false))
+      .filter((run) => agentType !== ILLUSTRATOR_AGENT_TYPE || illustratorRunCountsTowardInterval(run))
+      .map((run) => ({ run, messageIndex: indexes.get(readString(run.messageId).trim()) ?? -1 }))
+      .filter((entry) => entry.messageIndex >= 0)
+      .sort((a, b) => b.messageIndex - a.messageIndex || readString(b.run.createdAt).localeCompare(readString(a.run.createdAt)))[0]
+      ?.run ?? null
+  );
+}
+
+function assistantMessagesSinceRun(input: GenerationAgentRuntimeInput, messageId: string): number | null {
+  const index = input.storedMessages.findIndex((message) => readString(message.id).trim() === messageId);
+  if (index < 0) return null;
+  return input.storedMessages
+    .slice(index + 1)
+    .filter((message) => !hiddenFromAi(message))
+    .filter((message) => readString(message.role).trim() === "assistant").length;
+}
+
+async function automaticAssistantIntervalAllowsRun(
+  storage: StorageGateway,
+  input: GenerationAgentRuntimeInput,
+  agentType: string,
+  settings: Record<string, unknown>,
+): Promise<boolean> {
+  const fallback = positiveInteger(
+    BUILT_IN_AGENT_RUN_INTERVAL_DEFAULTS[agentType],
+    agentType === ILLUSTRATOR_AGENT_TYPE ? 5 : 1,
+    MAX_ASSISTANT_RUN_INTERVAL,
+  );
+  const runInterval = positiveInteger(settings.runInterval, fallback, MAX_ASSISTANT_RUN_INTERVAL);
+  if (runInterval <= 1) return true;
+  const chatId = readString(input.chat.id).trim();
+  if (!chatId) return true;
+  const lastRun = intervalAnchorRun(await storage.list<JsonRecord>("agent-runs"), input, chatId, agentType);
+  if (!lastRun) return true;
+  const messageId = readString(lastRun.messageId).trim();
+  if (!messageId) return true;
+  const assistantMessagesSince = assistantMessagesSinceRun(input, messageId);
+  if (assistantMessagesSince === null) return true;
+  return assistantMessagesSince + 1 >= runInterval;
 }
 
 function parseToolParameters(value: unknown): unknown {
@@ -611,10 +705,18 @@ async function resolveAgents(deps: AgentDeps, input: GenerationAgentRuntimeInput
   const resolved: ResolvedAgent[] = [];
   const skippedResults: AgentResult[] = [];
   for (const agent of rows) {
+    const type = readString(agent.type || agent.agentType) || "agent";
     const settings = agentSettings(agent);
     if (!input.bypassCustomAgentActivation && !isBuiltInAgent(agent)) {
       const activation = matchCustomAgentActivation(settings, activationMessages);
       if (activation.configured && !activation.matched) continue;
+    }
+    const assistantIntervalAgentType = automaticAssistantIntervalAgentType(input, type);
+    if (
+      assistantIntervalAgentType &&
+      !(await automaticAssistantIntervalAllowsRun(deps.storage, input, assistantIntervalAgentType, settings))
+    ) {
+      continue;
     }
     const requestedConnectionId = readString(agent.connectionId).trim();
     const fallbackConnectionId = readString(input.connection.id).trim() || null;
@@ -635,7 +737,7 @@ async function resolveAgents(deps: AgentDeps, input: GenerationAgentRuntimeInput
     customTools ??= await loadCustomTools(deps.storage);
     resolved.push({
       id: readString(agent.id) || readString(agent.type) || "agent",
-      type: readString(agent.type || agent.agentType) || "agent",
+      type,
       name: readString(agent.name) || readString(agent.type) || "Agent",
       phase: normalizePhase(agent),
       promptTemplate: readString(agent.promptTemplate),

--- a/src/engine/generation/start-generation.test.ts
+++ b/src/engine/generation/start-generation.test.ts
@@ -108,6 +108,12 @@ async function drainGeneration(stream: AsyncGenerator<unknown>) {
   }
 }
 
+const illustratorDrawData = {
+  shouldGenerate: true,
+  reason: "Important visual beat",
+  prompt: "moonlit tavern confrontation",
+};
+
 describe("startGeneration concluded roleplay guard", () => {
   it("rejects concluded roleplay scenes before saving user messages", async () => {
     const { deps, createChatMessage } = depsForChat({
@@ -336,6 +342,50 @@ describe("startGeneration generation replay metadata", () => {
     expect((streamedRequests[0] as { messages: Array<{ content: string }> }).messages).not.toEqual(
       expect.arrayContaining([expect.objectContaining({ content: "Wrong chat guide." })]),
     );
+  });
+});
+
+describe("startGeneration automatic Illustrator cadence", () => {
+  it("counts the pending assistant response when enforcing the run interval", async () => {
+    const messages = Array.from({ length: 5 }, (_, index) => ({
+      id: `assistant-${index + 1}`,
+      chatId: "chat-1",
+      role: "assistant",
+      content: `Assistant message ${index + 1}`,
+    }));
+    const { deps, streamedRequests } = generationDepsForChat({
+      chatMetadata: { enableAgents: true },
+      agents: [
+        {
+          id: "illustrator-agent",
+          type: "illustrator",
+          name: "Illustrator",
+          enabled: true,
+          phase: "post_processing",
+          connectionId: null,
+          model: "agent-model",
+          promptTemplate: "Return JSON.",
+          settings: { runInterval: 5 },
+        },
+      ],
+      agentRuns: [
+        {
+          id: "run-1",
+          chatId: "chat-1",
+          messageId: "assistant-1",
+          agentType: "illustrator",
+          resultType: "image_prompt",
+          resultData: illustratorDrawData,
+          success: true,
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      ],
+      initialMessages: messages,
+    });
+
+    await drainGeneration(startGeneration(deps, { chatId: "chat-1", userMessage: "continue" }));
+
+    expect(streamedRequests).toHaveLength(2);
   });
 });
 

--- a/src/features/catalog/agents/components/AgentEditor.tsx
+++ b/src/features/catalog/agents/components/AgentEditor.tsx
@@ -324,8 +324,9 @@ export function AgentEditor() {
   // Lorebook Keeper agent — run interval setting
   const isLorebookKeeperAgent = agentDetailId === "lorebook-keeper" || dbConfig?.type === "lorebook-keeper";
 
-  // Narrative Director agent — run interval setting
+  // Narrative Director / Illustrator agent cadence
   const isDirectorAgent = agentDetailId === "director" || dbConfig?.type === "director";
+  const isIllustratorAgent = agentDetailId === "illustrator" || dbConfig?.type === "illustrator";
 
   // Chat Summary agent — uses "Triggers After" instead of context size
   const isChatSummaryAgent = agentDetailId === "chat-summary" || dbConfig?.type === "chat-summary";
@@ -1276,12 +1277,16 @@ export function AgentEditor() {
             </FieldGroup>
           )}
 
-          {/* ── Run Interval (Narrative Director) ── */}
-          {isDirectorAgent && (
+          {/* Run Interval (Narrative Director / Illustrator) */}
+          {(isDirectorAgent || isIllustratorAgent) && (
             <FieldGroup
               label="Run Interval"
               icon={<Clock size="0.875rem" className="text-[var(--primary)]" />}
-              help="How many assistant messages between each Narrative Director intervention. Higher values make the director less aggressive. Set to 1 to run every message."
+              help={
+                isIllustratorAgent
+                  ? "How many assistant messages between allowed Illustrator image generations. Set to 1 to allow it every message."
+                  : "How many assistant messages between each Narrative Director intervention. Higher values make the director less aggressive. Set to 1 to run every message."
+              }
             >
               <div className="flex items-center gap-3">
                 <input
@@ -1300,7 +1305,9 @@ export function AgentEditor() {
                 <span className="text-[0.6875rem] text-[var(--muted-foreground)]">messages</span>
               </div>
               <p className="mt-1 text-[0.625rem] text-[var(--muted-foreground)]">
-                The director only jumps in once every N assistant messages instead of steering every reply. Default: 5.
+                {isIllustratorAgent
+                  ? "The Illustrator can only create a new image once every N assistant messages. If it decides not to draw, the timer does not reset. Default: 5."
+                  : "The director only jumps in once every N assistant messages instead of steering every reply. Default: 5."}
               </p>
             </FieldGroup>
           )}

--- a/src/shared/lib/agent-cadence.test.ts
+++ b/src/shared/lib/agent-cadence.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { getDefaultBuiltInAgentSettings } from "../../engine/contracts/types/agent";
+import { getAgentRunIntervalMeta } from "./agent-cadence";
+
+describe("agent cadence metadata", () => {
+  it("exposes Illustrator assistant-message run interval parity", () => {
+    expect(getDefaultBuiltInAgentSettings("illustrator")).toMatchObject({ runInterval: 5 });
+    expect(getAgentRunIntervalMeta("illustrator", true)).toEqual({
+      label: "Run Interval",
+      unit: "assistant messages",
+      help: "How many assistant messages should pass before the Illustrator is allowed to create another image.",
+      defaultValue: 5,
+      max: 100,
+    });
+  });
+});

--- a/src/shared/lib/agent-cadence.ts
+++ b/src/shared/lib/agent-cadence.ts
@@ -18,6 +18,14 @@ export function getAgentRunIntervalMeta(agentType: string, isBuiltIn = true): Ag
         defaultValue: 5,
         max: 100,
       };
+    case "illustrator":
+      return {
+        label: "Run Interval",
+        unit: "assistant messages",
+        help: "How many assistant messages should pass before the Illustrator is allowed to create another image.",
+        defaultValue: 5,
+        max: 100,
+      };
     case "lorebook-keeper":
       return {
         label: "Run Interval",


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #1329

## Why this change

- Restores v1.6.1 parity for the built-in Illustrator agent cadence. The refactor had defaulted/treated Illustrator like an every-turn post-processing agent unless manually constrained, so chats could request image prompts much more often than the live version.

## What changed

- Restored the built-in Illustrator `runInterval` default to 5 messages.
- Exposed Run Interval in the Agent Editor for Illustrator with Illustrator-specific helper copy.
- Gated automatic Illustrator post-processing by assistant-message cadence.
- Kept explicit Illustrator retries immediate, so manual retry actions still bypass the interval.
- Treated only successful draw decisions as cadence anchors.
- Supported legacy imported `agent-runs.type` rows as well as `agentType`.
- Anchored cadence by transcript position instead of retry timestamp so older-message retries cannot move cadence backward.

## Refactor impact

Primary owner:

- Engine generation, catalog agent editor, shared agent cadence metadata.

Impact areas reviewed:

- Automatic post-generation agent resolution.
- Illustrator retry behavior.
- Legacy agent-run storage shape compatibility.
- Agent Editor cadence controls.
- Upstream `refactor` merge conflict areas: tool-runtime extraction and Discord mirror tests.

Boundary notes:

- Engine cadence logic stays in `src/engine` and does not import React, Tauri, feature internals, or shared API adapters.
- React UI changes stay in `src/features/catalog/agents/components/AgentEditor.tsx`.
- Shared cadence display metadata stays in `src/shared/lib/agent-cadence.ts`.
- No raw Tauri or remote-runtime fetch wiring was added.

Pressure points touched:

- `src/engine/generation/agent-runner.ts`
- `src/engine/generation/start-generation.test.ts`
- `src/features/catalog/agents/components/AgentEditor.tsx`
- `src/shared/lib/agent-cadence.ts`
- `src/engine/contracts/types/agent.ts`

## Validation

<!-- Checkboxes intentionally left unchecked per template instruction until a human verifies them. -->

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

Agent-run local proof:

- `pnpm test src/engine/generation/agent-runner.test.ts src/engine/generation/start-generation.test.ts src/shared/lib/agent-cadence.test.ts`
- `pnpm typecheck`
- `pnpm check:architecture`
- `cargo check --manifest-path src-tauri/Cargo.toml`

### Manual verification notes

- Launched the native app through the Tauri dev path.
- Opened Agents -> Illustrator.
- Verified Run Interval is visible for Illustrator.
- Verified the value defaults to `5`.
- Verified the unit displays as `messages`.
- Verified the helper copy is Illustrator-specific.
- Live image-provider generation was not exercised.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

Notes:

- No changelog file exists in this checkout, so no changelog update was made.
- No docs or repo skill changes were required for this narrow parity fix.
- This PR does not restore old staging/package-workspace/release claims.

## UI evidence

- Visible UI changed in the Agent Editor, but no public screenshot/recording was attached.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Illustrator agent now supports configurable Run Interval setting to control how frequently it runs based on assistant message cadence.

* **UI Enhancements**
  * Run Interval field expanded in the agent editor to include Illustrator agent alongside Narrative Director, with contextual help text.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1399?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->