### PR TITLE
Surface legacy script custom tools as preserved-only with migration path

### DIFF
--- a/src-tauri/src/commands/storage/custom_tools.rs
+++ b/src-tauri/src/commands/storage/custom_tools.rs
@@ -39,6 +39,13 @@ pub(crate) async fn execute_custom_tool(state: &AppState, body: Value) -> AppRes
                 .ok_or_else(|| AppError::invalid_input(format!("Static result is missing for custom tool: {tool_name}")))?
         })),
         "webhook" => execute_webhook_tool(&tool, tool_name, arguments).await,
+        "script" => Err(AppError::with_details(
+            "custom_tool_script_unsupported",
+            format!(
+                "Custom tool '{tool_name}' uses the legacy script executionType, which the refactor desktop runtime does not execute. Open the tool in the editor and convert it to a Webhook (recommended) or a Static result."
+            ),
+            json!({ "executionType": "script", "migration": "convert-to-webhook-or-static" }),
+        )),
         other => Err(AppError::invalid_input(format!(
             "Unsupported custom tool execution type: {other}"
         ))),
@@ -101,4 +108,85 @@ async fn execute_webhook_tool(tool: &Value, tool_name: &str, arguments: Value) -
         "success": true,
         "result": text
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::AppState;
+    use serde_json::Map;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn test_state(label: &str) -> AppState {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after unix epoch")
+            .as_nanos();
+        let path = std::env::temp_dir()
+            .join(format!("marinara-custom-tools-{label}-{nonce}"));
+        if path.exists() {
+            std::fs::remove_dir_all(&path).expect("stale temp dir should be removable");
+        }
+        AppState::from_data_dir(path, Vec::new()).expect("test app state should initialize")
+    }
+
+    fn insert_tool(state: &AppState, row: Map<String, Value>) {
+        state
+            .storage
+            .create("custom-tools", Value::Object(row))
+            .expect("storage create should succeed");
+    }
+
+    #[tokio::test]
+    async fn script_execution_type_returns_actionable_error() {
+        let state = test_state("script-unsupported");
+        let mut row = Map::new();
+        row.insert("name".to_string(), json!("legacy_script_tool"));
+        row.insert("description".to_string(), json!("legacy"));
+        row.insert("executionType".to_string(), json!("script"));
+        row.insert("scriptBody".to_string(), json!("return 1 + 1;"));
+        row.insert("enabled".to_string(), json!(true));
+        insert_tool(&state, row);
+
+        let body = json!({ "toolName": "legacy_script_tool", "arguments": {} });
+        let result = execute_custom_tool(&state, body).await;
+        let error = result.expect_err("script tools must not execute in refactor runtime");
+        assert_eq!(error.code, "custom_tool_script_unsupported");
+        assert!(
+            error.message.contains("legacy_script_tool"),
+            "error should name the tool, got: {}",
+            error.message
+        );
+        assert!(
+            error.message.contains("legacy script") || error.message.contains("script executionType"),
+            "error should identify the legacy script issue, got: {}",
+            error.message
+        );
+        assert!(
+            error.message.contains("Webhook") || error.message.contains("webhook"),
+            "error should point at the webhook migration path, got: {}",
+            error.message
+        );
+    }
+
+    #[tokio::test]
+    async fn unknown_execution_type_still_rejected() {
+        let state = test_state("unknown-type");
+        let mut row = Map::new();
+        row.insert("name".to_string(), json!("alien_tool"));
+        row.insert("description".to_string(), json!("?"));
+        row.insert("executionType".to_string(), json!("quantum"));
+        row.insert("enabled".to_string(), json!(true));
+        insert_tool(&state, row);
+
+        let body = json!({ "toolName": "alien_tool", "arguments": {} });
+        let error = execute_custom_tool(&state, body)
+            .await
+            .expect_err("unknown executionType must reject");
+        assert!(
+            error.message.contains("Unsupported custom tool execution type"),
+            "unknown types must keep the generic message, got: {}",
+            error.message
+        );
+    }
 }

--- a/src/engine/contracts/schemas/custom-tool.schema.ts
+++ b/src/engine/contracts/schemas/custom-tool.schema.ts
@@ -3,7 +3,12 @@
 // ──────────────────────────────────────────────
 import { z } from "zod";
 
-export const toolExecutionTypeSchema = z.enum(["webhook", "static"]);
+// "script" is a legacy executionType from the pre-refactor staging codebase.
+// The refactor does not execute script bodies (no JS sandbox in the Tauri runtime),
+// but the variant is recognized so legacy data round-trips intact through import,
+// storage, and the editor. See custom_tools.rs + ToolEditor.tsx for the surfaces
+// that explain the unsupported state to the user.
+export const toolExecutionTypeSchema = z.enum(["webhook", "static", "script"]);
 
 export const createCustomToolSchema = z.object({
   name: z
@@ -16,6 +21,7 @@ export const createCustomToolSchema = z.object({
   executionType: toolExecutionTypeSchema.default("static"),
   webhookUrl: z.string().url().nullable().default(null),
   staticResult: z.string().nullable().default(null),
+  scriptBody: z.string().nullable().default(null),
   enabled: z.boolean().default(true),
 });
 

--- a/src/engine/generation/main-tool-loop.test.ts
+++ b/src/engine/generation/main-tool-loop.test.ts
@@ -796,6 +796,39 @@ describe("row 10 — custom-tool name collision with built-in: built-in wins, no
     expect(noArgsCall!.arguments).toBe("{}");
   });
 
+  it("legacy script custom-tool (executionType=script) is filtered out of LLM toolDefs (refactor #1353)", async () => {
+    // A legacy profile import can leave script-type custom-tool rows on disk. The
+    // refactor desktop runtime has no JS sandbox; customToolRecord must drop them
+    // from the LLM-visible tool set so the AI never tries to invoke them. Use an
+    // open allowlist (activeToolIds: []) so the built-in tools keep the result
+    // non-empty even when the script tool is dropped.
+    const { deps } = makeStubDeps({
+      chatMetadata: { enableTools: true, activeToolIds: [] },
+      customTools: [
+        {
+          id: "ct-legacy",
+          name: "legacy_calc",
+          description: "old script tool",
+          parametersSchema: JSON.stringify({ type: "object", properties: {} }),
+          executionType: "script",
+          webhookUrl: null,
+          staticResult: null,
+          scriptBody: "return arguments.a + arguments.b;",
+          enabled: true,
+        },
+      ],
+      script: { turns: [[{ type: "token", text: "ok" }]] },
+    });
+    const built = await buildMainToolDefinitions({
+      chat: { id: "chat-1", metadata: { enableTools: true, activeToolIds: [] } },
+      storage: deps.storage,
+      integrations: deps.integrations,
+    });
+    expect(built).not.toBeNull();
+    const names = built!.toolDefs.map((tool) => tool.name);
+    expect(names).not.toContain("legacy_calc");
+  });
+
   it("usage is aggregated across multi-turn tool-call loops, not overwritten by the last turn", async () => {
     // Two-turn loop: turn 1 emits usage A + a tool call, turn 2 emits usage B
     // and resolves. Saved usage must reflect both turns' token counts.

--- a/src/engine/generation/tools-runtime.ts
+++ b/src/engine/generation/tools-runtime.ts
@@ -78,6 +78,10 @@ export function customToolRecord(row: JsonRecord): CustomToolRecord | null {
   const name = readString(row.name).trim();
   if (!name || !boolish(row.enabled, false)) return null;
   const executionType = readString(row.executionType, "static");
+  // Legacy "script" tools (from the pre-refactor staging codebase) are intentionally
+  // excluded from the LLM-visible tool set: the refactor has no JS sandbox and will
+  // not execute script bodies. The row is preserved on disk and surfaced read-only
+  // in ToolEditor for migration. See src/engine/contracts/schemas/custom-tool.schema.ts.
   if (executionType !== "static" && executionType !== "webhook") return null;
   return {
     ...row,

--- a/src/features/catalog/agents/components/ToolEditor.tsx
+++ b/src/features/catalog/agents/components/ToolEditor.tsx
@@ -25,6 +25,7 @@ import {
   Trash2,
   Plus,
   Minus,
+  ShieldAlert,
 } from "lucide-react";
 import { cn } from "../../../../shared/lib/utils";
 import { HelpTooltip } from "../../../../shared/components/ui/HelpTooltip";
@@ -33,6 +34,8 @@ const EXEC_TYPES = [
   { value: "static", label: "Static Result", icon: FileText, description: "Returns a fixed string when called." },
   { value: "webhook", label: "Webhook", icon: Globe, description: "Sends a POST request to an external URL." },
 ] as const;
+
+type ExecType = "static" | "webhook" | "script";
 
 // ═══════════════════════════════════════════════
 //  Main Editor
@@ -56,9 +59,10 @@ export function ToolEditor() {
   // ── Local state ──
   const [localName, setLocalName] = useState("");
   const [localDesc, setLocalDesc] = useState("");
-  const [localExecType, setLocalExecType] = useState<"static" | "webhook">("static");
+  const [localExecType, setLocalExecType] = useState<ExecType>("static");
   const [localWebhookUrl, setLocalWebhookUrl] = useState("");
   const [localStaticResult, setLocalStaticResult] = useState("");
+  const [localScriptBody, setLocalScriptBody] = useState("");
   const [localParams, setLocalParams] = useState<ParamDef[]>([]);
   const [dirty, setDirty] = useState(false);
   const setEditorDirty = useUIStore((s) => s.setEditorDirty);
@@ -73,9 +77,16 @@ export function ToolEditor() {
     if (dbTool) {
       setLocalName(dbTool.name);
       setLocalDesc(dbTool.description);
-      setLocalExecType(dbTool.executionType === "webhook" ? "webhook" : "static");
+      const execType: ExecType =
+        dbTool.executionType === "webhook"
+          ? "webhook"
+          : dbTool.executionType === "script"
+            ? "script"
+            : "static";
+      setLocalExecType(execType);
       setLocalWebhookUrl(dbTool.webhookUrl ?? "");
       setLocalStaticResult(dbTool.staticResult ?? "");
+      setLocalScriptBody(dbTool.scriptBody ?? "");
       const schema = dbTool.parametersSchema ?? {};
       const props = (schema.properties as Record<string, unknown> | undefined) ?? {};
       const req: string[] = Array.isArray(schema.required) ? schema.required.filter((value): value is string => typeof value === "string") : [];
@@ -96,6 +107,7 @@ export function ToolEditor() {
       setLocalExecType("static");
       setLocalWebhookUrl("");
       setLocalStaticResult("");
+      setLocalScriptBody("");
       setLocalParams([]);
     }
     setDirty(false);
@@ -156,6 +168,7 @@ export function ToolEditor() {
       executionType: localExecType,
       webhookUrl: localExecType === "webhook" ? localWebhookUrl || null : null,
       staticResult: localExecType === "static" ? localStaticResult || null : null,
+      scriptBody: localExecType === "script" ? localScriptBody || null : null,
       enabled: true,
     };
 
@@ -179,6 +192,7 @@ export function ToolEditor() {
     localExecType,
     localWebhookUrl,
     localStaticResult,
+    localScriptBody,
     dbTool,
     createTool,
     updateTool,
@@ -212,7 +226,13 @@ export function ToolEditor() {
   }
 
   const isPending = createTool.isPending || updateTool.isPending;
+  const isLegacyScript = localExecType === "script";
   const execMeta = EXEC_TYPES.find((e) => e.value === localExecType) ?? EXEC_TYPES[0];
+
+  const convertScriptTo = useCallback((target: "static" | "webhook") => {
+    setLocalExecType(target);
+    markDirty();
+  }, [markDirty]);
 
   return (
     <div className="flex flex-1 flex-col overflow-hidden bg-[var(--background)]">
@@ -312,6 +332,21 @@ export function ToolEditor() {
       {/* ── Body ── */}
       <div className="flex-1 overflow-y-auto p-6">
         <div className="mx-auto max-w-3xl space-y-6">
+          {/* Legacy script-tool banner */}
+          {isLegacyScript && (
+            <div className="flex items-start gap-3 rounded-xl border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-xs text-amber-200">
+              <ShieldAlert size="1rem" className="mt-0.5 shrink-0" />
+              <div className="space-y-1">
+                <p className="font-semibold">Legacy script tool — not executable in this build.</p>
+                <p className="text-amber-200/80">
+                  Script-body execution shipped only in the pre-refactor codebase. This tool's body is preserved
+                  read-only below so you can migrate it. The AI will not call this tool until you convert it to a
+                  Webhook (recommended — run the same logic on your own server) or a Static result.
+                </p>
+              </div>
+            </div>
+          )}
+
           {/* ── Name hint ── */}
           <p className="text-[0.625rem] text-[var(--muted-foreground)]">
             Tool name must be lowercase snake_case (e.g.{" "}
@@ -431,19 +466,27 @@ export function ToolEditor() {
           </FieldGroup>
 
           {/* ── Execution Type ── */}
-          <FieldGroup label="Execution Type" icon={<Wrench size="0.875rem" className="text-[var(--primary)]" />}>
+          <FieldGroup
+            label={isLegacyScript ? "Convert this tool" : "Execution Type"}
+            icon={<Wrench size="0.875rem" className="text-[var(--primary)]" />}
+          >
             <div className="grid grid-cols-2 gap-2">
               {EXEC_TYPES.map((et) => {
                 const isActive = localExecType === et.value;
                 const Icon = et.icon;
+                const label = isLegacyScript ? `Convert to ${et.label}` : et.label;
                 return (
                   <button
                     key={et.value}
                     type="button"
                     title={et.description}
                     onClick={() => {
-                      setLocalExecType(et.value);
-                      markDirty();
+                      if (isLegacyScript) {
+                        convertScriptTo(et.value);
+                      } else {
+                        setLocalExecType(et.value);
+                        markDirty();
+                      }
                     }}
                     className={cn(
                       "flex flex-col items-center gap-1.5 rounded-xl p-3 text-xs ring-1 transition-all",
@@ -453,13 +496,36 @@ export function ToolEditor() {
                     )}
                   >
                     <Icon size="1rem" />
-                    <span className="font-medium">{et.label}</span>
+                    <span className="font-medium">{label}</span>
                   </button>
                 );
               })}
             </div>
-            <p className="mt-1.5 text-[0.625rem] text-[var(--muted-foreground)]">{execMeta.description}</p>
+            {isLegacyScript ? (
+              <p className="mt-1.5 text-[0.625rem] text-[var(--muted-foreground)]">
+                Pick a supported execution type to make this tool callable again. The script body below is preserved
+                until you save the conversion.
+              </p>
+            ) : (
+              <p className="mt-1.5 text-[0.625rem] text-[var(--muted-foreground)]">{execMeta.description}</p>
+            )}
           </FieldGroup>
+
+          {/* ── Legacy script body (read-only) ── */}
+          {isLegacyScript && (
+            <FieldGroup label="Script Body (read-only)" icon={<Code2 size="0.875rem" className="text-[var(--primary)]" />}>
+              <textarea
+                value={localScriptBody}
+                readOnly
+                rows={Math.min(20, Math.max(5, localScriptBody.split("\n").length))}
+                className="w-full resize-y rounded-xl bg-[var(--secondary)]/60 px-4 py-3 font-mono text-xs leading-relaxed ring-1 ring-[var(--border)] text-[var(--muted-foreground)] focus:outline-none"
+              />
+              <p className="mt-1 text-[0.625rem] text-[var(--muted-foreground)]">
+                Copy this body into a webhook handler on your own server, then convert this tool to a Webhook
+                pointing at that handler. Direct script execution will not be re-added to the desktop runtime.
+              </p>
+            </FieldGroup>
+          )}
 
           {/* ── Execution Config ── */}
           {localExecType === "static" && (

--- a/src/features/catalog/agents/components/ToolEditor.tsx
+++ b/src/features/catalog/agents/components/ToolEditor.tsx
@@ -137,35 +137,38 @@ export function ToolEditor() {
     return { type: "object", properties, required };
   }, [localParams]);
 
-  const handleSave = useCallback(async () => {
-    if (!toolDetailId) return;
+  // Returns true on persisted save, false on any validation or mutation failure.
+  // Callers that auto-close on save (Save & close) must gate the close on this
+  // result so a failed save does not discard the user's unsaved edits.
+  const handleSave = useCallback(async (): Promise<boolean> => {
+    if (!toolDetailId) return false;
     setSaveError(null);
 
     if (!localName.trim()) {
       setSaveError("Tool name is required.");
-      return;
+      return false;
     }
     if (!/^[a-z][a-z0-9_]*$/.test(localName)) {
       setSaveError("Tool name must be lowercase snake_case (e.g. my_tool).");
-      return;
+      return false;
     }
     if (!localDesc.trim()) {
       setSaveError("Description is required.");
-      return;
+      return false;
     }
     if (localExecType === "script") {
       setSaveError(
         "Pick \"Convert to Webhook\" or \"Convert to Static Result\" before saving — legacy script tools cannot run in this build.",
       );
-      return;
+      return false;
     }
     if (localExecType === "static" && !localStaticResult.trim()) {
       setSaveError("Static result is required for a static custom tool.");
-      return;
+      return false;
     }
     if (localExecType === "webhook" && !localWebhookUrl.trim()) {
       setSaveError("Webhook URL is required for a webhook custom tool.");
-      return;
+      return false;
     }
     const payload = {
       name: localName,
@@ -191,8 +194,10 @@ export function ToolEditor() {
       setDirty(false);
       setSavedFlash(true);
       setTimeout(() => setSavedFlash(false), 1500);
+      return true;
     } catch (err) {
       setSaveError(err instanceof Error ? err.message : "Failed to save tool");
+      return false;
     }
   }, [
     toolDetailId,
@@ -319,8 +324,8 @@ export function ToolEditor() {
             </button>
             <button
               onClick={async () => {
-                await handleSave();
-                closeToolDetail();
+                const saved = await handleSave();
+                if (saved) closeToolDetail();
               }}
               className="rounded-lg bg-amber-500/20 px-3 py-1 hover:bg-amber-500/30"
             >

--- a/src/features/catalog/agents/components/ToolEditor.tsx
+++ b/src/features/catalog/agents/components/ToolEditor.tsx
@@ -153,6 +153,12 @@ export function ToolEditor() {
       setSaveError("Description is required.");
       return;
     }
+    if (localExecType === "script") {
+      setSaveError(
+        "Pick \"Convert to Webhook\" or \"Convert to Static Result\" before saving — legacy script tools cannot run in this build.",
+      );
+      return;
+    }
     if (localExecType === "static" && !localStaticResult.trim()) {
       setSaveError("Static result is required for a static custom tool.");
       return;
@@ -168,7 +174,10 @@ export function ToolEditor() {
       executionType: localExecType,
       webhookUrl: localExecType === "webhook" ? localWebhookUrl || null : null,
       staticResult: localExecType === "static" ? localStaticResult || null : null,
-      scriptBody: localExecType === "script" ? localScriptBody || null : null,
+      // Script tools are blocked by the guard above; converting to webhook/static
+      // intentionally clears the preserved script body since the tool is no longer
+      // a legacy script row.
+      scriptBody: null,
       enabled: true,
     };
 
@@ -216,6 +225,14 @@ export function ToolEditor() {
     closeToolDetail();
   };
 
+  const convertScriptTo = useCallback(
+    (target: "static" | "webhook") => {
+      setLocalExecType(target);
+      markDirty();
+    },
+    [markDirty],
+  );
+
   // ── Not found ──
   if (!toolDetailId || (!dbTool && !isNew)) {
     return (
@@ -228,11 +245,6 @@ export function ToolEditor() {
   const isPending = createTool.isPending || updateTool.isPending;
   const isLegacyScript = localExecType === "script";
   const execMeta = EXEC_TYPES.find((e) => e.value === localExecType) ?? EXEC_TYPES[0];
-
-  const convertScriptTo = useCallback((target: "static" | "webhook") => {
-    setLocalExecType(target);
-    markDirty();
-  }, [markDirty]);
 
   return (
     <div className="flex flex-1 flex-col overflow-hidden bg-[var(--background)]">

--- a/src/features/catalog/agents/hooks/use-custom-tools.ts
+++ b/src/features/catalog/agents/hooks/use-custom-tools.ts
@@ -13,6 +13,7 @@ export interface CustomToolRow {
   executionType: string;
   webhookUrl: string | null;
   staticResult: string | null;
+  scriptBody: string | null;
   enabled: string;
   createdAt: string;
   updatedAt: string;
@@ -29,6 +30,7 @@ export function isCustomToolSelectable(tool: CustomToolRow, _capabilities?: Cust
   if (!enabled) return false;
   if (tool.executionType === "static") return !!tool.staticResult?.trim();
   if (tool.executionType === "webhook") return !!tool.webhookUrl?.trim();
+  // executionType === "script" is preserved legacy data; refactor has no JS sandbox.
   return false;
 }
 


### PR DESCRIPTION
## Why this change

Issue #1353 reports that the refactor cannot run legacy custom tools with `executionType: "script"` + a stored `scriptBody`, while the pre-refactor staging codebase did execute them (gated by `CUSTOM_TOOL_SCRIPT_ENABLED` env var, default off, sandboxed via `node:vm`). The refactor has no Node `vm` equivalent in the Tauri runtime, and embedding a JS engine would re-introduce arbitrary-code-execution risk that even staging shipped disabled-by-default.

The real bug today is worse than "cannot run". On a clean read of the code:

- `customToolRecord` in `src/engine/generation/tools-runtime.ts` silently filters script tools out of the LLM-visible tool set, so the AI never sees them.
- `ToolEditor` coerces `executionType === "script"` to `"static"` on load, omits `scriptBody` from the save payload, and has no banner — so opening a legacy script tool and pressing Save **destroys the `scriptBody` field** with no warning.
- The Rust executor returns a generic `"Unsupported custom tool execution type: script"` with no migration guidance.

This PR implements the "migration-aware preserve + clear error" outcome named in the issue's expected behavior. It does **not** add a sandboxed script execution path.

## What changed

- `src/engine/contracts/schemas/custom-tool.schema.ts`: extend `toolExecutionTypeSchema` to `webhook | static | script`; add nullable `scriptBody` field so legacy data round-trips intact through any future schema-validating layer. Comment pins intent.
- `src/engine/generation/tools-runtime.ts`: add an explanatory comment to the existing static/webhook filter in `customToolRecord` so future readers do not accidentally re-admit script tools.
- `src/features/catalog/agents/hooks/use-custom-tools.ts`: add `scriptBody: string | null` to `CustomToolRow`; `isCustomToolSelectable` already returns false for script tools, now with a comment noting why.
- `src/features/catalog/agents/components/ToolEditor.tsx`: expand the local execution-type union to include `"script"`; load `dbTool.scriptBody` into local state; render an amber `ShieldAlert` banner when the loaded tool is a legacy script; show the script body in a read-only textarea; swap the execution-type picker into a `"Convert to Static / Convert to Webhook"` pair when the user is editing a legacy script tool; preserve `scriptBody` in the save payload while the tool is still in legacy state and clear it once the user picks a supported execution type.
- `src-tauri/src/commands/storage/custom_tools.rs`: replace the generic "Unsupported `{other}`" branch with an explicit `"script"` case returning `custom_tool_script_unsupported` + a message naming the tool and pointing at the webhook migration path. Generic unknown types still fall through to the original error string. Adds two `#[tokio::test]` cases covering both branches.
- `src/engine/generation/main-tool-loop.test.ts`: add a regression test proving a `executionType: "script"` custom tool with `enabled: true` never appears in `buildMainToolDefinitions().toolDefs`.

## Verification

- `pnpm check:architecture` → green (boundary guard + Rust structure).
- `pnpm check:frontend` (`tsc -b`) → green.
- `pnpm check:docs` → green.
- `pnpm test` (vitest) → 24 files / 156 tests pass, including the new row in `main-tool-loop.test.ts`.
- `pnpm check:rust:clippy` (`-D warnings`) → green.
- `cargo test -p marinara-engine` → 118/118 pass, including the two new `custom_tools::tests` cases.
- **End-to-end Playwright spec against the real Tauri shell (WebView2 CDP)** drove the full migration flow: seeded a legacy script-tool row via `storage_create` with `executionType: "script"` + `scriptBody`; opened it through the agents panel in the real ToolEditor; asserted the amber legacy banner, the read-only `scriptBody` textarea with the exact seeded body, and both `Convert to ...` buttons; clicked Convert to Webhook, filled a URL, saved, then re-read the row via `storage_get` and confirmed the post-save shape (`executionType: "webhook"`, `webhookUrl` preserved, `scriptBody: null`). No fatal pageerrors. Cleanup ran via `storage_delete` in `afterEach`.
- Manually re-read the diff against the in-repo `marinara-architecture-guard`, `marinara-mode-separation`, and `marinara-bugfix-discipline` skills. Schema in engine/contracts, hook in features, Rust in commands/storage. No cross-boundary imports. No mode-flag patches. No catch-and-ignore. Custom tools are mode-agnostic, so mode-separation is not engaged.

The unrelated `marinara-assets::tests::rejects_paths_that_escape_root_through_symlinked_directory` fails on this Windows host (no `SeCreateSymbolicLinkPrivilege`); confirmed identical failure on a clean checkout of `refactor` HEAD without this PR's changes.

## Known caveat: legacy profile import already preserves script-tool rows

The Rust storage layer for `custom-tools` is schemaless, so `import_legacy_profile_tables` in `src-tauri/src/commands/storage/profile/legacy.rs` already round-trips script-type rows intact today. This PR does not change the import path. What it adds is the surface that lets the user *see* the preserved data and migrate it; before this PR, the data was on disk but invisible (and destroyed on next save).

## Follow-ups (not in this PR)

- Optionally have the `useCustomToolCapabilities` hook drive the banner copy (today the banner is unconditional for script tools — it does not check the capability flag because `scriptExecutionEnabled` is hard-coded `false` in `custom_tool_capabilities()` and there is no realistic future where it becomes true on the refactor desktop runtime).
- Optionally expose the `custom_tool_script_unsupported` error structurally to the chat UI so the user sees the same migration hint when the AI tries to call a script tool via name (currently filtered out before reaching the executor; the executor error is only reachable through the direct `custom_tool_execute` invoke path).

## Linked issue

Closes #1353

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for viewing legacy script-based custom tools with read-only script content display.
  * Introduced conversion interface to help migrate script tools to webhook or static execution modes with clear guidance.

* **Bug Fixes**
  * Script-based custom tools are now explicitly rejected during execution with actionable migration instructions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1400?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->