### PR TITLE
[codex] Tighten PR template issue-link workflow

### DIFF
--- a/skills/marinara-agent-workflow/references/workflows/review-and-pr.md
+++ b/skills/marinara-agent-workflow/references/workflows/review-and-pr.md
@@ -19,11 +19,15 @@ Before push or PR creation:
 3. Confirm only intentional files will ship.
 4. Verify evidence exists for the PR claim.
 5. Confirm repo-defined docs/release notes are updated for user-facing changes when an appropriate source exists, or explicitly record why not needed.
-6. Draft external text exactly.
+6. If `.github/pull_request_template.md` exists, use it as the PR body, preserve its sections, and fill applicable placeholders.
+7. If the work came from or references a GitHub issue, fill the linked-issue field with a closing keyword such as `Closes #123` so GitHub links the PR to the issue.
+8. Draft external text exactly.
 
 Open new PRs as draft unless the user or target workflow says it should be ready for review. Never push directly to protected branches or force-push without explicit approval.
 
 ## After Push
+
+After creating a PR, re-read the submitted PR body and fix it immediately if the repo template sections or linked issue did not survive the creation path.
 
 Wait for required checks when available. Inspect unresolved inline review threads, not only PR-level summaries. Address clear in-scope feedback; ask before posting arbitrary external replies.
 

--- a/skills/marinara-agent-workflow/references/workflows/review-and-pr.md
+++ b/skills/marinara-agent-workflow/references/workflows/review-and-pr.md
@@ -20,14 +20,14 @@ Before push or PR creation:
 4. Verify evidence exists for the PR claim.
 5. Confirm repo-defined docs/release notes are updated for user-facing changes when an appropriate source exists, or explicitly record why not needed.
 6. If `.github/pull_request_template.md` exists, use it as the PR body, preserve its sections, and fill applicable placeholders.
-7. If the work came from or references a GitHub issue, fill the linked-issue field with a closing keyword such as `Closes #123` so GitHub links the PR to the issue.
+7. If the work came from or references a GitHub issue, put a GitHub closing keyword in the linked-issue field, such as `Closes #123`, so GitHub links the PR to the issue and automatically closes the issue when the PR merges. Do not use only a bare issue reference such as `#123` when merge-time auto-close is intended.
 8. Draft external text exactly.
 
 Open new PRs as draft unless the user or target workflow says it should be ready for review. Never push directly to protected branches or force-push without explicit approval.
 
 ## After Push
 
-After creating a PR, re-read the submitted PR body and fix it immediately if the repo template sections or linked issue did not survive the creation path.
+After creating a PR, re-read the submitted PR body and fix it immediately if the repo template sections or closing-keyword issue link did not survive the creation path.
 
 Wait for required checks when available. Inspect unresolved inline review threads, not only PR-level summaries. Address clear in-scope feedback; ask before posting arbitrary external replies.
 


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

N/A - workflow guidance follow-up from PR #1399.

## Why this change

- The PR shipping workflow already required drafting external PR text, and the PR template already had a `Linked issue` section, but the workflow did not explicitly require agents to load the template, preserve its sections, fill issue-link placeholders with auto-closing syntax, or verify the submitted body after creation.

## What changed

- Added a PR shipping gate to use `.github/pull_request_template.md` when it exists.
- Added a PR shipping gate to fill linked issue fields with a GitHub closing keyword such as `Closes #123` for issue-backed work, so GitHub links the PR and automatically closes the issue on merge.
- Clarified that a bare issue reference such as `#123` is not enough when merge-time auto-close is intended.
- Added an after-creation check to re-read the submitted PR body and fix missing template sections or closing-keyword issue linkage immediately.

## Refactor impact

Primary owner:

- Repo agent workflow guidance.

Impact areas reviewed:

- PR shipping gates.
- After-push/after-create PR workflow.
- Current PR template expectations.

Boundary notes:

- Docs/skill guidance only.
- No app, engine, shared API, Rust, or remote-runtime behavior changed.

Pressure points touched:

- `skills/marinara-agent-workflow/references/workflows/review-and-pr.md`

## Validation

<!-- Checkboxes intentionally left unchecked per template instruction until a human verifies them. -->

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

Agent-run local proof:

- `pnpm check:docs`

### Manual verification notes

- Read `.github/pull_request_template.md` and the review-and-PR workflow card.
- Confirmed this PR body preserves the template sections and explains why no linked issue is closed.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [x] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

Notes:

- Updated repo skill workflow guidance.
- No product docs, changelog, or release note changes needed for this process-only change.
- This PR does not restore old staging/package-workspace/release claims.

## UI evidence

N/A - no UI changes.