### PR TITLE
Restore chat summary fingerprint metadata

### DIFF
--- a/src/engine/contracts/types/chat.ts
+++ b/src/engine/contracts/types/chat.ts
@@ -392,6 +392,8 @@ export interface MessageExtra {
    * saved with this assistant message — reused when regenerating that swipe unless refreshed.
    */
   contextInjections?: Array<{ agentType: string; agentName?: string; text: string }> | null;
+  /** Fingerprint of the chat summary text used in the generation prompt. */
+  chatSummaryFingerprint?: string | null;
   /**
    * Hidden command-generation options needed to make swipes/regenerations replay
    * the same slash-command or guided-regenerate prompt behavior.

--- a/src/engine/generation/prompt-assembly.test.ts
+++ b/src/engine/generation/prompt-assembly.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { StorageGateway } from "../capabilities/storage";
 import { DEFAULT_GENERATION_PARAMS } from "../contracts/constants/defaults";
+import { fingerprintChatSummary } from "../shared/text/chat-summary-fingerprint";
 import { assembleGenerationPrompt } from "./prompt-assembly";
 
 type Row = Record<string, unknown>;
@@ -45,6 +46,17 @@ function storageWithSections(sections: Row[]): StorageGateway {
     listLorebookEntries: async () => [],
     createLorebookEntries: async () => [],
     promptFull: async <T,>() => null as T | null,
+  };
+}
+
+function storageWithSectionsAndRegex(sections: Row[], regexScripts: Row[]): StorageGateway {
+  const base = storageWithSections(sections);
+  return {
+    ...base,
+    list: async <T,>(entity: string, options?: { filters?: Record<string, unknown> }) => {
+      if (entity === "regex-scripts") return regexScripts as T[];
+      return base.list<T>(entity, options);
+    },
   };
 }
 
@@ -383,6 +395,51 @@ describe("assembleGenerationPrompt inactive chat characters", () => {
     expect(assembly.characters.map((character) => character.id)).toEqual(["char-active"]);
     expect(prompt).toContain("ACTIVE CARD SHOULD APPEAR");
     expect(prompt).not.toContain("INACTIVE CARD SHOULD NOT APPEAR");
+  });
+});
+
+describe("assembleGenerationPrompt chat summary fingerprints", () => {
+  it("fingerprints the current summary even when prompt regex scripts transform the final prompt text", async () => {
+    const summary = "The user met Nia at the market.";
+    const assembly = await assembleGenerationPrompt(
+      storageWithSectionsAndRegex(
+        [
+          section({
+            id: "summary",
+            name: "Summary",
+            role: "system",
+            markerConfig: { type: "chat_summary" },
+            sortOrder: 0,
+          }),
+        ],
+        [
+          {
+            enabled: true,
+            promptOnly: true,
+            placement: ["ai_output"],
+            findRegex: "Nia at the market",
+            replaceString: "Nia near the docks",
+          },
+        ],
+      ),
+      {
+        chat: {
+          id: "conversation-chat",
+          mode: "conversation",
+          characterIds: [],
+          metadata: { summary },
+        },
+        storedMessages: [],
+        connection: {},
+        request,
+        latestUserInput: "hello",
+      },
+    );
+
+    const prompt = assembly.messages.map((message) => message.content).join("\n\n");
+    expect(prompt).toContain("The user met Nia near the docks.");
+    expect(prompt).not.toContain(summary);
+    expect(assembly.chatSummaryFingerprint).toBe(fingerprintChatSummary(summary));
   });
 });
 

--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -713,7 +713,7 @@ function buildRoleplayScenePromptBlock(
   return parts.join("\n\n");
 }
 
-function chatSummary(chat: JsonRecord): string | null {
+export function chatSummaryForGeneration(chat: JsonRecord): string | null {
   const meta = parseRecord(chat.metadata);
   const mode = readString(chat.mode || chat.chatMode, "conversation");
   const includeSceneSummary = mode !== "conversation" || meta.crossChatAwareness !== false;
@@ -1139,7 +1139,7 @@ export async function assembleGenerationPrompt(
   const persona = await loadPersona(storage, input.chat);
   const activated = await loadActivatedLore(storage, input.chat, characters, persona, input.storedMessages);
   const processedLore = processActivatedEntries(activated, readNumber(input.request.lorebookTokenBudget, 0));
-  const summary = chatSummary(input.chat);
+  const summary = chatSummaryForGeneration(input.chat);
   const memoryRecallBlock = await buildMemoryRecallBlock(
     storage,
     input.chat,

--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -10,6 +10,7 @@ import { resolveMacros, type MacroContext } from "../shared/macros/macro-engine"
 import { normalizeUserTimeZone } from "../shared/time/timezone";
 import type { GameActiveState, GameCampaignPlan, GameMap, GameNpc, HudWidget, SessionSummary } from "../contracts/types/game";
 import { buildGmFormatReminder, buildGmSystemPrompt, type GmPromptContext } from "../modes/game/prompts/gm-prompts";
+import { fingerprintChatSummary } from "../shared/text/chat-summary-fingerprint";
 import { activeCharacterIds } from "./active-characters";
 import { buildGenerationPromptPresetCandidates } from "./prompt-preset-selection";
 import {
@@ -70,6 +71,7 @@ export interface PromptAssemblyResult {
     constant: boolean;
   }>;
   chatSummary: string | null;
+  chatSummaryFingerprint: string | null;
 }
 
 export interface PromptAssemblyInput {
@@ -1260,6 +1262,7 @@ export async function assembleGenerationPrompt(
   if (!strictRoleFormatting && boolish(input.request.squashSystemMessages, false)) {
     messages = squashLeadingSystemMessages(messages);
   }
+  const summaryFingerprint = fingerprintChatSummary(summary);
 
   return {
     messages,
@@ -1267,5 +1270,6 @@ export async function assembleGenerationPrompt(
     persona,
     activatedLorebookEntries: activated.map(loreForEvent),
     chatSummary: summary,
+    chatSummaryFingerprint: summaryFingerprint,
   };
 }

--- a/src/engine/generation/start-generation.test.ts
+++ b/src/engine/generation/start-generation.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { DiscordGateway } from "../capabilities/integrations";
 import type { LlmGateway } from "../capabilities/llm";
 import type { StorageGateway } from "../capabilities/storage";
+import { fingerprintChatSummary } from "../shared/text/chat-summary-fingerprint";
 import { retryGenerationAgents, startGeneration, type GenerationEngineDeps } from "./start-generation";
 
 function mockDiscordMirror() {
@@ -245,6 +246,59 @@ describe("startGeneration chat message loading", () => {
   });
 });
 
+describe("startGeneration chat summary fingerprint metadata", () => {
+  it("stores the chat summary fingerprint on generated assistant messages when summary context is injected", async () => {
+    const { deps, createChatMessage, streamedRequests } = generationDepsForChat({
+      chatMetadata: { summary: "The user met Nia at the market." },
+    });
+
+    await drainGeneration(
+      startGeneration(deps, {
+        chatId: "chat-1",
+        userMessage: "hello",
+        impersonateBlockAgents: true,
+      }),
+    );
+
+    expect(
+      (streamedRequests[0] as { messages: Array<{ content: string }> }).messages
+        .map((message) => message.content)
+        .join("\n"),
+    ).toContain("The user met Nia at the market.");
+    const assistantSave = createChatMessage.mock.calls.find(([, value]) => value.role === "assistant");
+    expect(assistantSave?.[1]).toMatchObject({
+      extra: {
+        chatSummaryFingerprint: fingerprintChatSummary("The user met Nia at the market."),
+      },
+    });
+  });
+
+  it("stamps the current summary fingerprint when direct request messages bypass assembled summary context", async () => {
+    const { deps, createChatMessage, streamedRequests } = generationDepsForChat({
+      chatMetadata: { summary: "This summary should not be injected." },
+    });
+
+    await drainGeneration(
+      startGeneration(deps, {
+        chatId: "chat-1",
+        messages: [{ role: "user", content: "Direct prompt" }],
+        impersonateBlockAgents: true,
+      }),
+    );
+
+    expect(
+      (streamedRequests[0] as { messages: Array<{ content: string }> }).messages
+        .map((message) => message.content)
+        .join("\n"),
+    ).not.toContain("This summary should not be injected.");
+    const assistantSave = createChatMessage.mock.calls.find(([, value]) => value.role === "assistant");
+    const assistantExtra = (assistantSave?.[1] as { extra?: Record<string, unknown> } | undefined)?.extra ?? {};
+    expect(assistantExtra).toMatchObject({
+      chatSummaryFingerprint: fingerprintChatSummary("This summary should not be injected."),
+    });
+  });
+});
+
 describe("startGeneration generation replay metadata", () => {
   it("stores guided replay metadata on the generated assistant message", async () => {
     const { deps, createChatMessage } = generationDepsForChat();
@@ -293,6 +347,7 @@ describe("startGeneration generation replay metadata", () => {
         generationGuide: "Make this one colder.",
         generationGuideSource: "guide",
       },
+      chatSummaryFingerprint: null,
     });
   });
 
@@ -334,10 +389,29 @@ describe("startGeneration generation replay metadata", () => {
 
     await drainGeneration(startGeneration(deps, { chatId: "chat-1", regenerateMessageId: "assistant-1" }));
 
-    expect(patchChatMessageExtra).not.toHaveBeenCalled();
+    expect(patchChatMessageExtra).toHaveBeenCalledWith("assistant-1", { chatSummaryFingerprint: null });
     expect((streamedRequests[0] as { messages: Array<{ content: string }> }).messages).not.toEqual(
       expect.arrayContaining([expect.objectContaining({ content: "Keep the reply clipped." })]),
     );
+  });
+
+  it("clears stale summary fingerprints on regenerates when the current summary is empty", async () => {
+    const { deps, patchChatMessageExtra } = generationDepsForChat({
+      initialMessages: [
+        { id: "user-1", chatId: "chat-1", role: "user", content: "hello" },
+        {
+          id: "assistant-1",
+          chatId: "chat-1",
+          role: "assistant",
+          content: "first reply",
+          extra: { chatSummaryFingerprint: "stale-fingerprint" },
+        },
+      ],
+    });
+
+    await drainGeneration(startGeneration(deps, { chatId: "chat-1", regenerateMessageId: "assistant-1" }));
+
+    expect(patchChatMessageExtra).toHaveBeenCalledWith("assistant-1", { chatSummaryFingerprint: null });
   });
 
   it("ignores stored replay metadata from a target outside the active chat", async () => {

--- a/src/engine/generation/start-generation.test.ts
+++ b/src/engine/generation/start-generation.test.ts
@@ -361,6 +361,7 @@ describe("startGeneration generation replay metadata", () => {
           role: "assistant",
           content: "first reply",
           extra: {
+            chatSummaryFingerprint: null,
             generationReplay: {
               generationGuide: "Keep the reply clipped.",
               generationGuideSource: "guide",
@@ -376,6 +377,37 @@ describe("startGeneration generation replay metadata", () => {
       messages: expect.arrayContaining([
         expect.objectContaining({ role: "user", content: "Keep the reply clipped." }),
       ]),
+    });
+  });
+
+  it("skips stored assistant replay metadata when the summary fingerprint is stale", async () => {
+    const { deps, patchChatMessageExtra, streamedRequests } = generationDepsForChat({
+      chatMetadata: { summary: "Current summary." },
+      initialMessages: [
+        { id: "user-1", chatId: "chat-1", role: "user", content: "hello" },
+        {
+          id: "assistant-1",
+          chatId: "chat-1",
+          role: "assistant",
+          content: "first reply",
+          extra: {
+            chatSummaryFingerprint: fingerprintChatSummary("Old summary."),
+            generationReplay: {
+              generationGuide: "Keep the reply clipped.",
+              generationGuideSource: "guide",
+            },
+          },
+        },
+      ],
+    });
+
+    await drainGeneration(startGeneration(deps, { chatId: "chat-1", regenerateMessageId: "assistant-1" }));
+
+    expect((streamedRequests[0] as { messages: Array<{ content: string }> }).messages).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ content: "Keep the reply clipped." })]),
+    );
+    expect(patchChatMessageExtra).toHaveBeenCalledWith("assistant-1", {
+      chatSummaryFingerprint: fingerprintChatSummary("Current summary."),
     });
   });
 

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -498,6 +498,7 @@ async function saveAssistantMessage(args: {
   content: string;
   agentResults: AgentResult[];
   noteCount: number;
+  chatSummaryFingerprint: string | null;
   attachments?: JsonRecord[];
   usage?: unknown;
 }): Promise<unknown | null> {
@@ -506,9 +507,11 @@ async function saveAssistantMessage(args: {
   const regenerateMessageId = readString(args.input.regenerateMessageId).trim();
   const generationReplay = buildGenerationReplay(args.input);
   if (regenerateMessageId) {
-    const saved = await args.storage.addChatMessageSwipe(args.input.chatId, regenerateMessageId, args.content);
-    if (!generationReplay) return saved;
-    return args.storage.patchChatMessageExtra(regenerateMessageId, { generationReplay });
+    await args.storage.addChatMessageSwipe(args.input.chatId, regenerateMessageId, args.content);
+    const extraPatch: Record<string, unknown> = {};
+    if (generationReplay) extraPatch.generationReplay = generationReplay;
+    extraPatch.chatSummaryFingerprint = args.chatSummaryFingerprint;
+    return args.storage.patchChatMessageExtra(regenerateMessageId, extraPatch);
   }
 
   const requestedCharacterId = readString(args.input.forCharacterId).trim();
@@ -528,6 +531,7 @@ async function saveAssistantMessage(args: {
     extra: {
       ...(args.attachments?.length ? { attachments: args.attachments } : {}),
       ...(generationReplay ? { generationReplay } : {}),
+      chatSummaryFingerprint: args.chatSummaryFingerprint,
     },
     generationInfo: {
       connectionId: readString(args.connection.id) || null,
@@ -981,6 +985,7 @@ export async function* startGeneration(
           content: connected.displayContent,
           agentResults: allAgentResults,
           noteCount: connected.createdNotes.length + connected.executedCommands.length,
+          chatSummaryFingerprint: assembly.chatSummaryFingerprint,
           attachments: connected.assistantAttachments,
           usage,
         });
@@ -1064,6 +1069,7 @@ export async function* startGeneration(
         content: connected.displayContent,
         agentResults: [],
         noteCount: connected.createdNotes.length + connected.executedCommands.length,
+        chatSummaryFingerprint: assembly.chatSummaryFingerprint,
         attachments: connected.assistantAttachments,
         usage,
       });

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -33,8 +33,9 @@ import {
   buildGenerationReplay,
   normalizeGenerationReplay,
 } from "./generation-replay";
-import { assembleGenerationPrompt } from "./prompt-assembly";
+import { assembleGenerationPrompt, chatSummaryForGeneration } from "./prompt-assembly";
 import type { GenerationCharacterContext, GenerationPersonaContext } from "./prompt-assembly";
+import { chatSummaryFingerprintMatches, fingerprintChatSummary } from "../shared/text/chat-summary-fingerprint";
 import { applyRuntimeRegexScripts } from "./regex-runtime";
 import { boolish, hiddenFromAi, isRecord, nowIso, parseRecord, readString, stringArray, type JsonRecord } from "./runtime-records";
 import {
@@ -301,6 +302,7 @@ async function mirrorSavedAssistantMessageToDiscord(args: {
 
 async function inputWithStoredGenerationReplay(
   storage: StorageGateway,
+  chat: JsonRecord,
   chatId: string,
   input: StartGenerationInput,
 ): Promise<StartGenerationInput> {
@@ -310,8 +312,11 @@ async function inputWithStoredGenerationReplay(
   const target = await storage.get("messages", regenerateMessageId).catch(() => null);
   if (!isRecord(target) || readString(target.chatId).trim() !== chatId) return input;
 
-  const replay = normalizeGenerationReplay(parseRecord(target.extra).generationReplay);
+  const targetExtra = parseRecord(target.extra);
+  const replay = normalizeGenerationReplay(targetExtra.generationReplay);
   if (!replay) return input;
+  const currentFingerprint = fingerprintChatSummary(chatSummaryForGeneration(chat));
+  if (!chatSummaryFingerprintMatches(targetExtra, currentFingerprint)) return input;
 
   const nextInput = { ...input };
   applyGenerationReplayToRegenerateInput(nextInput, replay);
@@ -845,7 +850,7 @@ export async function* startGeneration(
   const chatId = readString(input.chatId).trim();
   if (!chatId) throw new Error("chatId is required");
   const chat = requireRecord(await deps.storage.get("chats", chatId), "Chat");
-  input = await inputWithStoredGenerationReplay(deps.storage, chatId, input);
+  input = await inputWithStoredGenerationReplay(deps.storage, chat, chatId, input);
   assertChatCanGenerate(chat, input);
 
   yield { type: "phase", data: "Saving message..." };

--- a/src/engine/shared/text/chat-summary-fingerprint.test.ts
+++ b/src/engine/shared/text/chat-summary-fingerprint.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { chatSummaryFingerprintMatches, fingerprintChatSummary } from "./chat-summary-fingerprint";
+
+describe("chat summary fingerprints", () => {
+  it("matches the legacy v1.6.1 whitespace normalization and base36 hash format", () => {
+    expect(fingerprintChatSummary("The user met Nia at the market.")).toBe("176fv69");
+    expect(fingerprintChatSummary("  The\nuser\tmet  Nia at the market.  ")).toBe("176fv69");
+  });
+
+  it("uses legacy stale-summary matching semantics", () => {
+    const current = fingerprintChatSummary("The user met Nia at the market.");
+
+    expect(chatSummaryFingerprintMatches({ chatSummaryFingerprint: current }, current)).toBe(true);
+    expect(chatSummaryFingerprintMatches({ chatSummaryFingerprint: "different" }, current)).toBe(false);
+    expect(chatSummaryFingerprintMatches({}, current)).toBe(false);
+  });
+});

--- a/src/engine/shared/text/chat-summary-fingerprint.ts
+++ b/src/engine/shared/text/chat-summary-fingerprint.ts
@@ -1,0 +1,22 @@
+function normalizeChatSummaryFingerprint(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function fingerprintChatSummary(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.replace(/\s+/g, " ").trim();
+  if (!normalized) return null;
+
+  let hash = 5381;
+  for (let i = 0; i < normalized.length; i += 1) {
+    hash = (hash * 33) ^ normalized.charCodeAt(i);
+  }
+  return (hash >>> 0).toString(36);
+}
+
+export function chatSummaryFingerprintMatches(extra: Record<string, unknown>, current: string | null): boolean {
+  if (!Object.prototype.hasOwnProperty.call(extra, "chatSummaryFingerprint")) return false;
+  return normalizeChatSummaryFingerprint(extra.chatSummaryFingerprint) === current;
+}

--- a/src/features/catalog/chats/types.ts
+++ b/src/features/catalog/chats/types.ts
@@ -35,6 +35,7 @@ export interface MessageExtra {
   thinking?: string | null;
   hiddenFromUser?: boolean;
   hiddenFromAI?: boolean;
+  chatSummaryFingerprint?: string | null;
   isConversationStart?: boolean;
   personaSnapshot?: {
     name?: string | null;


### PR DESCRIPTION
## Summary
- Restores legacy-compatible chat summary fingerprint metadata on generated assistant messages and regenerations.
- Gates stored generation replay reuse against the current chat summary fingerprint so stale replay guidance is not applied after summary changes.
- Adds focused coverage for legacy hash normalization, regex-transformed prompt summaries, direct prompt saves, stale regenerate clearing, and stale replay rejection.

Closes #1355.

## Impact
- Primary area: TypeScript engine generation and prompt assembly metadata.
- Persisted message extra shape now includes `chatSummaryFingerprint?: string | null` in engine and catalog chat types.
- Reviewed dependent paths: assistant message creation, regenerate swipes, stored generation replay, direct engine messages, prompt regex transforms, and shared generation mode impact.

## Verification
- `pnpm vitest run src/engine/shared/text/chat-summary-fingerprint.test.ts src/engine/generation/start-generation.test.ts src/engine/generation/prompt-assembly.test.ts`
- `pnpm typecheck`
- `pnpm check:architecture`
- `git diff --check`
- `pnpm build`

## Remaining Risk
- No native Tauri/provider manual QA was run; this is engine metadata and replay behavior covered by focused unit tests and build/type gates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added message regeneration context validation to ensure generated messages remain accurate when chat history changes. Message metadata now stores a summary fingerprint for improved regeneration reliability.

* **Tests**
  * Added comprehensive tests for message regeneration validation and context integrity checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1402?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->