### PR TITLE
Fix memory recall provider embeddings

### DIFF
--- a/src-tauri/src/commands/storage/chats.rs
+++ b/src-tauri/src/commands/storage/chats.rs
@@ -54,6 +54,118 @@ fn lexical_memory_embedding(text: &str) -> Vec<f64> {
     vector
 }
 
+struct MemoryDraft {
+    content: String,
+    message_count: usize,
+    first_message_at: Value,
+    last_message_at: Value,
+}
+
+enum MemoryEmbeddingPlan {
+    Provider(prompts::EmbeddingTarget),
+    Lexical,
+}
+
+fn default_connection(state: &AppState) -> AppResult<Option<Value>> {
+    let connections = state.storage.list("connections")?;
+    Ok(connections
+        .iter()
+        .find(|connection| {
+            connection
+                .get("isDefault")
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+        })
+        .cloned()
+        .or_else(|| connections.into_iter().next()))
+}
+
+fn active_connection_for_chat(state: &AppState, chat: &Value) -> AppResult<Option<Value>> {
+    if let Some(connection_id) = chat
+        .get("connectionId")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        return get_required(state, "connections", connection_id).map(Some);
+    }
+    default_connection(state)
+}
+
+fn resolve_memory_embedding_plan(state: &AppState, chat: &Value) -> AppResult<MemoryEmbeddingPlan> {
+    let Some(connection) = active_connection_for_chat(state, chat)? else {
+        return Ok(MemoryEmbeddingPlan::Lexical);
+    };
+    match prompts::resolve_embedding_target_for_chat(state, chat, &connection)? {
+        Some(target) => Ok(MemoryEmbeddingPlan::Provider(target)),
+        None => Ok(MemoryEmbeddingPlan::Lexical),
+    }
+}
+
+async fn embed_memory_texts(
+    state: &AppState,
+    chat: &Value,
+    texts: &[String],
+) -> AppResult<(MemoryEmbeddingPlan, Vec<Vec<f64>>)> {
+    let plan = resolve_memory_embedding_plan(state, chat)?;
+    let embeddings = match &plan {
+        MemoryEmbeddingPlan::Provider(target) => {
+            prompts::embed_texts(&target.connection, &target.model, texts).await?
+        }
+        MemoryEmbeddingPlan::Lexical => texts
+            .iter()
+            .map(|content| lexical_memory_embedding(content))
+            .collect(),
+    };
+    Ok((plan, embeddings))
+}
+
+fn set_memory_embedding_fields(
+    memory: &mut Map<String, Value>,
+    embedding: Vec<f64>,
+    plan: &MemoryEmbeddingPlan,
+    updated_at: &str,
+) {
+    memory.insert("embedding".to_string(), json!(embedding));
+    memory.insert("hasEmbedding".to_string(), json!(true));
+    memory.insert("embeddingStatus".to_string(), json!("vectorized"));
+    memory.insert(
+        "embeddingUpdatedAt".to_string(),
+        Value::String(updated_at.to_string()),
+    );
+    match plan {
+        MemoryEmbeddingPlan::Provider(target) => {
+            memory.insert("embeddingSource".to_string(), json!("provider"));
+            memory.insert("embeddingModel".to_string(), json!(target.model));
+            memory.insert(
+                "embeddingConnectionId".to_string(),
+                json!(target.connection_id),
+            );
+            memory.insert(
+                "embeddingProvider".to_string(),
+                json!(target
+                    .connection
+                    .get("provider")
+                    .and_then(Value::as_str)
+                    .unwrap_or("openai")),
+            );
+        }
+        MemoryEmbeddingPlan::Lexical => {
+            memory.insert("embeddingSource".to_string(), json!("lexical"));
+            memory.remove("embeddingModel");
+            memory.remove("embeddingConnectionId");
+            memory.remove("embeddingProvider");
+        }
+    }
+}
+
+fn has_numeric_embedding(memory: &Map<String, Value>) -> bool {
+    memory
+        .get("embedding")
+        .and_then(Value::as_array)
+        .is_some_and(|items| items.iter().any(Value::is_number))
+}
+
 fn is_hidden_from_ai(message: &Value) -> bool {
     let extra = match message.get("extra") {
         Some(Value::Object(object)) => Some(object.clone()),
@@ -304,37 +416,67 @@ pub(crate) fn delete_chat_array_item(
     set_chat_array_field(state, chat_id, field, values)
 }
 
-pub(crate) fn refresh_chat_memories(state: &AppState, chat_id: &str) -> AppResult<Value> {
-    get_required(state, "chats", chat_id)?;
+pub(crate) async fn refresh_chat_memories(state: &AppState, chat_id: &str) -> AppResult<Value> {
+    let chat = get_required(state, "chats", chat_id)?;
     let visible_messages = messages_for_chat(state, chat_id)?
         .into_iter()
         .filter(|message| !is_hidden_from_ai(message) && !message_content(message).is_empty())
         .collect::<Vec<_>>();
     let now = now_iso();
-    let chunks = visible_messages
+    let drafts = visible_messages
         .chunks(MEMORY_CHUNK_SIZE)
         .map(|chunk| {
             let content = chunk
                 .iter()
                 .map(|message| {
-                    let role = message.get("role").and_then(Value::as_str).unwrap_or("message");
+                    let role = message
+                        .get("role")
+                        .and_then(Value::as_str)
+                        .unwrap_or("message");
                     format!("{role}: {}", message_content(message))
                 })
                 .collect::<Vec<_>>()
                 .join("\n");
-            let embedding = lexical_memory_embedding(&content);
-            json!({
-                "id": new_id(),
-                "chatId": chat_id,
-                "content": content,
-                "embedding": embedding,
-                "messageCount": chunk.len(),
-                "firstMessageAt": chunk.first().and_then(|message| message.get("createdAt")).cloned().unwrap_or(Value::Null),
-                "lastMessageAt": chunk.last().and_then(|message| message.get("createdAt")).cloned().unwrap_or(Value::Null),
-                "createdAt": now,
-                "hasEmbedding": true,
-                "embeddingStatus": "vectorized"
-            })
+            MemoryDraft {
+                content,
+                message_count: chunk.len(),
+                first_message_at: chunk
+                    .first()
+                    .and_then(|message| message.get("createdAt"))
+                    .cloned()
+                    .unwrap_or(Value::Null),
+                last_message_at: chunk
+                    .last()
+                    .and_then(|message| message.get("createdAt"))
+                    .cloned()
+                    .unwrap_or(Value::Null),
+            }
+        })
+        .collect::<Vec<_>>();
+    let texts = drafts
+        .iter()
+        .map(|draft| draft.content.clone())
+        .collect::<Vec<_>>();
+    let (plan, embeddings) = embed_memory_texts(state, &chat, &texts).await?;
+    let chunks = drafts
+        .into_iter()
+        .enumerate()
+        .map(|(index, draft)| {
+            let mut memory = Map::new();
+            memory.insert("id".to_string(), Value::String(new_id()));
+            memory.insert("chatId".to_string(), Value::String(chat_id.to_string()));
+            memory.insert("content".to_string(), Value::String(draft.content));
+            memory.insert("messageCount".to_string(), json!(draft.message_count));
+            memory.insert("firstMessageAt".to_string(), draft.first_message_at);
+            memory.insert("lastMessageAt".to_string(), draft.last_message_at);
+            memory.insert("createdAt".to_string(), Value::String(now.clone()));
+            set_memory_embedding_fields(
+                &mut memory,
+                embeddings.get(index).cloned().unwrap_or_default(),
+                &plan,
+                &now,
+            );
+            Value::Object(memory)
         })
         .collect::<Vec<_>>();
     state
@@ -363,12 +505,12 @@ pub(crate) fn export_chat_memories(state: &AppState, chat_id: &str) -> AppResult
     }))
 }
 
-pub(crate) fn import_chat_memories(
+pub(crate) async fn import_chat_memories(
     state: &AppState,
     chat_id: &str,
     body: Value,
 ) -> AppResult<Value> {
-    get_required(state, "chats", chat_id)?;
+    let chat = get_required(state, "chats", chat_id)?;
     let incoming = body
         .get("data")
         .and_then(|data| data.get("chunks"))
@@ -393,6 +535,7 @@ pub(crate) fn import_chat_memories(
     let now = now_iso();
     let mut imported = 0usize;
     let mut skipped = 0usize;
+    let mut pending_embeddings = Vec::new();
     for value in incoming {
         let Some(content) = value.get("content").and_then(Value::as_str).map(str::trim) else {
             skipped += 1;
@@ -420,25 +563,31 @@ pub(crate) fn import_chat_memories(
         memory
             .entry("messageCount".to_string())
             .or_insert_with(|| json!(1));
-        let has_embedding = memory
-            .get("embedding")
-            .and_then(Value::as_array)
-            .is_some_and(|items| items.iter().any(Value::is_number));
-        if !has_embedding {
-            memory.insert(
-                "embedding".to_string(),
-                Value::Array(
-                    lexical_memory_embedding(content)
-                        .into_iter()
-                        .map(|value| json!(value))
-                        .collect(),
-                ),
-            );
+        if has_numeric_embedding(&memory) {
+            memory.insert("hasEmbedding".to_string(), json!(true));
+            memory.insert("embeddingStatus".to_string(), json!("vectorized"));
+        } else {
+            pending_embeddings.push((memories.len(), content.to_string()));
+            memory.insert("hasEmbedding".to_string(), json!(false));
+            memory.insert("embeddingStatus".to_string(), json!("pending"));
         }
-        memory.insert("hasEmbedding".to_string(), json!(true));
-        memory.insert("embeddingStatus".to_string(), json!("vectorized"));
         memories.push(Value::Object(memory));
         imported += 1;
+    }
+    if !pending_embeddings.is_empty() {
+        let texts = pending_embeddings
+            .iter()
+            .map(|(_, content)| content.clone())
+            .collect::<Vec<_>>();
+        let (plan, embeddings) = embed_memory_texts(state, &chat, &texts).await?;
+        for ((memory_index, _), embedding) in pending_embeddings.into_iter().zip(embeddings) {
+            if let Some(object) = memories
+                .get_mut(memory_index)
+                .and_then(Value::as_object_mut)
+            {
+                set_memory_embedding_fields(object, embedding, &plan, &now);
+            }
+        }
     }
     set_chat_array_field(state, chat_id, "memories", memories)?;
     Ok(json!({ "imported": imported, "skipped": skipped }))
@@ -839,6 +988,8 @@ mod tests {
     use super::*;
     use crate::state::AppState;
     use std::time::{SystemTime, UNIX_EPOCH};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
 
     fn test_state(label: &str) -> AppState {
         let nonce = SystemTime::now()
@@ -850,6 +1001,103 @@ mod tests {
             std::fs::remove_dir_all(&path).expect("stale temp chat delete dir should be removable");
         }
         AppState::from_data_dir(path, Vec::new()).expect("test app state should initialize")
+    }
+
+    async fn serve_embedding_response(body: &'static str) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("test embedding server should bind");
+        let address = listener
+            .local_addr()
+            .expect("test embedding server address should be readable");
+        tokio::spawn(async move {
+            let (mut stream, _) = listener
+                .accept()
+                .await
+                .expect("test embedding server should accept one request");
+            let mut buffer = [0_u8; 4096];
+            let _ = stream
+                .read(&mut buffer)
+                .await
+                .expect("test embedding server should read request");
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream
+                .write_all(response.as_bytes())
+                .await
+                .expect("test embedding server should write response");
+        });
+        format!("http://{address}/v1")
+    }
+
+    #[tokio::test]
+    async fn refresh_chat_memories_uses_configured_provider_embeddings() {
+        let state = test_state("provider-memory-embedding");
+        let base_url =
+            serve_embedding_response(r#"{"data":[{"embedding":[0.25,0.75,0.5]}]}"#).await;
+        state
+            .storage
+            .create(
+                "connections",
+                json!({
+                    "id": "embedding-connection",
+                    "provider": "custom",
+                    "baseUrl": base_url,
+                    "model": "chat-model",
+                    "embeddingModel": "memory-embedding-model"
+                }),
+            )
+            .unwrap();
+        state
+            .storage
+            .create(
+                "chats",
+                json!({
+                    "id": "memory-chat",
+                    "name": "Memory chat",
+                    "mode": "conversation",
+                    "connectionId": "embedding-connection"
+                }),
+            )
+            .unwrap();
+        for index in 1..=5 {
+            state
+                .storage
+                .create(
+                    "messages",
+                    json!({
+                        "id": format!("message-{index}"),
+                        "chatId": "memory-chat",
+                        "role": if index % 2 == 0 { "assistant" } else { "user" },
+                        "content": format!("Memory setup line {index}."),
+                        "createdAt": format!("2026-05-27T00:0{index}:00.000Z")
+                    }),
+                )
+                .unwrap();
+        }
+
+        let result = refresh_chat_memories(&state, "memory-chat")
+            .await
+            .expect("memory refresh should vectorize with provider");
+        let chunk = result["chunks"][0]
+            .as_object()
+            .expect("refresh should return memory chunk");
+
+        assert_eq!(chunk.get("embedding"), Some(&json!([0.25, 0.75, 0.5])));
+        assert_eq!(
+            chunk.get("embeddingSource").and_then(Value::as_str),
+            Some("provider")
+        );
+        assert_eq!(
+            chunk.get("embeddingModel").and_then(Value::as_str),
+            Some("memory-embedding-model")
+        );
+        assert_eq!(
+            chunk.get("embeddingConnectionId").and_then(Value::as_str),
+            Some("embedding-connection")
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/commands/chats.rs
+++ b/src-tauri/src/commands/storage/commands/chats.rs
@@ -24,11 +24,11 @@ pub fn chat_memories_clear(state: State<'_, AppState>, chat_id: String) -> Resul
 }
 
 #[tauri::command]
-pub fn chat_memories_refresh(
+pub async fn chat_memories_refresh(
     state: State<'_, AppState>,
     chat_id: String,
 ) -> Result<Value, AppError> {
-    chats::refresh_chat_memories(&state, &chat_id)
+    chats::refresh_chat_memories(&state, &chat_id).await
 }
 
 #[tauri::command]
@@ -40,12 +40,12 @@ pub fn chat_memories_export(
 }
 
 #[tauri::command]
-pub fn chat_memories_import(
+pub async fn chat_memories_import(
     state: State<'_, AppState>,
     chat_id: String,
     body: Value,
 ) -> Result<Value, AppError> {
-    chats::import_chat_memories(&state, &chat_id, body)
+    chats::import_chat_memories(&state, &chat_id, body).await
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/storage/commands/media.rs
+++ b/src-tauri/src/commands/storage/commands/media.rs
@@ -223,6 +223,11 @@ pub async fn llm_complete(state: State<'_, AppState>, request: Value) -> Result<
 }
 
 #[tauri::command]
+pub async fn llm_embed(state: State<'_, AppState>, request: Value) -> Result<Value, AppError> {
+    llm::llm_embed(&state, request).await
+}
+
+#[tauri::command]
 pub async fn llm_stream_channel(
     state: State<'_, AppState>,
     stream_id: String,

--- a/src-tauri/src/commands/storage/llm.rs
+++ b/src-tauri/src/commands/storage/llm.rs
@@ -101,6 +101,46 @@ pub(crate) async fn llm_complete(state: &AppState, body: Value) -> AppResult<Val
     Ok(Value::String(content))
 }
 
+pub(crate) async fn llm_embed(state: &AppState, body: Value) -> AppResult<Value> {
+    let texts = body
+        .get("texts")
+        .and_then(Value::as_array)
+        .ok_or_else(|| AppError::invalid_input("texts is required"))?
+        .iter()
+        .map(|value| {
+            value
+                .as_str()
+                .map(ToOwned::to_owned)
+                .ok_or_else(|| AppError::invalid_input("texts must contain strings"))
+        })
+        .collect::<AppResult<Vec<_>>>()?;
+    if texts.is_empty() {
+        return Ok(json!({ "embeddings": [] }));
+    }
+    let mut connection = resolve_llm_connection_for_request(state, &body)?;
+    if let Some(model) = body
+        .get("model")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        if let Some(object) = connection.as_object_mut() {
+            object.insert(
+                "embeddingModel".to_string(),
+                Value::String(model.to_string()),
+            );
+        }
+    }
+    let target = super::prompts::resolve_embedding_target(state, &connection)?
+        .ok_or_else(|| AppError::invalid_input("Embedding model is required"))?;
+    let embeddings = super::prompts::embed_texts(&target.connection, &target.model, &texts).await?;
+    Ok(json!({
+        "embeddings": embeddings,
+        "model": target.model,
+        "connectionId": target.connection_id
+    }))
+}
+
 pub(crate) async fn llm_stream_channel(
     state: &AppState,
     stream_id: String,

--- a/src-tauri/src/commands/storage/prompts.rs
+++ b/src-tauri/src/commands/storage/prompts.rs
@@ -2,6 +2,12 @@ use super::shared::*;
 use super::*;
 use marinara_security::is_allowed_outbound_url;
 
+pub(crate) struct EmbeddingTarget {
+    pub(crate) connection: Value,
+    pub(crate) connection_id: String,
+    pub(crate) model: String,
+}
+
 pub(crate) async fn vectorize_lorebook(
     state: &AppState,
     lorebook_id: &str,
@@ -124,7 +130,94 @@ fn lorebook_entry_embedding_text(entry: &Value) -> String {
     .join("\n")
 }
 
-async fn embed_text(connection: &Value, model: &str, text: &str) -> AppResult<Vec<f64>> {
+pub(crate) fn resolve_embedding_target(
+    state: &AppState,
+    active_connection: &Value,
+) -> AppResult<Option<EmbeddingTarget>> {
+    let active_connection_id = active_connection
+        .get("id")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .trim()
+        .to_string();
+    let embedding_connection_id = active_connection
+        .get("embeddingConnectionId")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let mut embedding_connection = match embedding_connection_id {
+        Some(id) => get_required(state, "connections", id)?,
+        None => active_connection.clone(),
+    };
+    let embedding_model = embedding_connection
+        .get("embeddingModel")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .or_else(|| {
+            active_connection
+                .get("embeddingModel")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+        })
+        .map(str::to_string);
+    let Some(model) = embedding_model else {
+        return Ok(None);
+    };
+    let connection_id = embedding_connection
+        .get("id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .unwrap_or(active_connection_id);
+    if let Some(object) = embedding_connection.as_object_mut() {
+        object.insert("model".to_string(), Value::String(model.clone()));
+    }
+    Ok(Some(EmbeddingTarget {
+        connection: embedding_connection,
+        connection_id,
+        model,
+    }))
+}
+
+pub(crate) fn resolve_embedding_target_for_chat(
+    state: &AppState,
+    chat: &Value,
+    active_connection: &Value,
+) -> AppResult<Option<EmbeddingTarget>> {
+    let mut connection = active_connection.clone();
+    let metadata = metadata_map(chat);
+    if let Some(embedding_connection_id) = metadata
+        .get("embeddingConnectionId")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        if let Some(object) = connection.as_object_mut() {
+            object.insert(
+                "embeddingConnectionId".to_string(),
+                Value::String(embedding_connection_id.to_string()),
+            );
+        }
+    }
+    resolve_embedding_target(state, &connection)
+}
+
+pub(crate) async fn embed_texts(
+    connection: &Value,
+    model: &str,
+    texts: &[String],
+) -> AppResult<Vec<Vec<f64>>> {
+    let mut embeddings = Vec::with_capacity(texts.len());
+    for text in texts {
+        embeddings.push(embed_text(connection, model, text).await?);
+    }
+    Ok(embeddings)
+}
+
+pub(crate) async fn embed_text(connection: &Value, model: &str, text: &str) -> AppResult<Vec<f64>> {
     let provider = connection
         .get("provider")
         .and_then(Value::as_str)
@@ -248,10 +341,17 @@ fn json_embedding_array(value: &Value) -> Option<Vec<f64>> {
 
 fn embedding_base_url(connection: &Value, fallback: &str) -> String {
     connection
-        .get("baseUrl")
+        .get("embeddingBaseUrl")
         .and_then(Value::as_str)
         .map(str::trim)
         .filter(|value| !value.is_empty())
+        .or_else(|| {
+            connection
+                .get("baseUrl")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+        })
         .unwrap_or(fallback)
         .trim_end_matches('/')
         .to_string()

--- a/src-tauri/src/http_dispatch.rs
+++ b/src-tauri/src/http_dispatch.rs
@@ -393,13 +393,18 @@ pub async fn dispatch(state: &AppState, request: InvokeRequest) -> AppResult<Val
             "memories",
             Vec::new(),
         ),
-        "chat_memories_refresh" => chats::refresh_chat_memories(state, required_string(&args, "chatId")?),
+        "chat_memories_refresh" => {
+            chats::refresh_chat_memories(state, required_string(&args, "chatId")?).await
+        }
         "chat_memories_export" => chats::export_chat_memories(state, required_string(&args, "chatId")?),
-        "chat_memories_import" => chats::import_chat_memories(
-            state,
-            required_string(&args, "chatId")?,
-            optional_value(&args, "body"),
-        ),
+        "chat_memories_import" => {
+            chats::import_chat_memories(
+                state,
+                required_string(&args, "chatId")?,
+                optional_value(&args, "body"),
+            )
+            .await
+        }
         "chat_notes_list" => {
             chats::chat_array_field(state, required_string(&args, "chatId")?, "notes")
         }
@@ -538,6 +543,7 @@ pub async fn dispatch(state: &AppState, request: InvokeRequest) -> AppResult<Val
             optional_value(&args, "body"),
         ),
         "llm_complete" => llm::llm_complete(state, optional_value(&args, "request")).await,
+        "llm_embed" => llm::llm_embed(state, optional_value(&args, "request")).await,
         "llm_list_models" => {
             llm::llm_models(state, optional_string(&args, "connectionId").as_deref()).await
         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -200,6 +200,7 @@ pub fn run() {
             storage_commands::media_commands::npc_avatar_upload,
             storage_commands::media_commands::lorebook_image_upload,
             storage_commands::media_commands::llm_complete,
+            storage_commands::media_commands::llm_embed,
             storage_commands::media_commands::llm_stream_channel,
             storage_commands::media_commands::llm_stream_cancel,
             storage_commands::media_commands::llm_list_models,

--- a/src/engine/capabilities/llm.ts
+++ b/src/engine/capabilities/llm.ts
@@ -22,6 +22,13 @@ export interface LlmRequest {
   tools?: LlmToolDefinition[];
 }
 
+export interface LlmEmbedRequest {
+  connectionId?: string | null;
+  connection?: Record<string, unknown> | null;
+  model?: string | null;
+  texts: string[];
+}
+
 export interface LlmChunk {
   type: "start" | "token" | "thinking" | "tool_call" | "usage" | "done" | "error";
   text?: string;
@@ -31,6 +38,7 @@ export interface LlmChunk {
 }
 
 export interface LlmGateway {
+  embed(request: LlmEmbedRequest, signal?: AbortSignal): Promise<number[][] | null>;
   complete(request: LlmRequest, signal?: AbortSignal): Promise<string>;
   stream(request: LlmRequest, signal?: AbortSignal): AsyncGenerator<LlmChunk>;
   listModels(connectionId?: string | null): Promise<Array<{ id: string; name?: string; provider?: string }>>;

--- a/src/engine/contracts/types/chat.ts
+++ b/src/engine/contracts/types/chat.ts
@@ -123,8 +123,18 @@ export interface ChatMemoryChunk {
   createdAt: string;
   /** False when chunking succeeded but embedding generation was unavailable. */
   hasEmbedding: boolean;
-  /** Local lexical recall vector used by the Tauri prompt assembler. */
+  /** Recall vector generated from the configured embedding source, or lexical when no embedding model is configured. */
   embedding?: number[] | null;
+  /** Origin for the stored recall vector. */
+  embeddingSource?: "provider" | "lexical" | null;
+  /** Provider embedding model used when embeddingSource is provider. */
+  embeddingModel?: string | null;
+  /** Connection used when embeddingSource is provider. */
+  embeddingConnectionId?: string | null;
+  /** Provider name used when embeddingSource is provider. */
+  embeddingProvider?: string | null;
+  /** Last time the recall vector was rebuilt. */
+  embeddingUpdatedAt?: string | null;
   /** Current vectorization state for display. */
   embeddingStatus?: "vectorized" | "pending" | "unavailable";
 }

--- a/src/engine/generation/agent-runner.test.ts
+++ b/src/engine/generation/agent-runner.test.ts
@@ -29,6 +29,9 @@ function storage(rows: Record<string, unknown>[], collections: Record<string, Re
 }
 
 const llm: LlmGateway = {
+  async embed() {
+    return null;
+  },
   async *stream() {
     yield { type: "token", text: "ok" };
   },
@@ -42,6 +45,9 @@ const llm: LlmGateway = {
 
 function countingLlm(calls: unknown[], responseText = "ok"): LlmGateway {
   return {
+    async embed() {
+      return null;
+    },
     async *stream(request) {
       calls.push(request);
       yield { type: "token", text: responseText };

--- a/src/engine/generation/main-tool-loop.test.ts
+++ b/src/engine/generation/main-tool-loop.test.ts
@@ -133,6 +133,7 @@ function makeStubDeps(
   } as IntegrationGateway;
 
   const llm: LlmGateway = {
+    embed: vi.fn(async () => null),
     stream,
     complete: vi.fn(async () => ""),
     listModels: vi.fn(async () => []),
@@ -562,6 +563,7 @@ describe("row 8 — mid-loop abort propagates cleanly", () => {
       image: { generate: vi.fn() },
     } as IntegrationGateway;
     const llm: LlmGateway = {
+      embed: vi.fn(async () => null),
       stream,
       complete: vi.fn(async () => ""),
       listModels: vi.fn(async () => []),

--- a/src/engine/generation/prompt-assembly.test.ts
+++ b/src/engine/generation/prompt-assembly.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import type { LlmEmbedRequest, LlmGateway } from "../capabilities/llm";
 import type { StorageGateway } from "../capabilities/storage";
 import { DEFAULT_GENERATION_PARAMS } from "../contracts/constants/defaults";
 import { fingerprintChatSummary } from "../shared/text/chat-summary-fingerprint";
@@ -106,6 +107,20 @@ function storageWithLore(entries: Row[]): StorageGateway {
     listLorebookEntries: async <T,>() => entries as T[],
   };
 }
+
+function storageWithMemories(memories: Row[]): StorageGateway {
+  return {
+    ...storageWithSections([]),
+    listChatMemories: async <T,>() => memories as T[],
+  };
+}
+
+const providerMemoryLlm: LlmGateway = {
+  embed: async () => [[1, 0, 0]],
+  complete: async () => "",
+  stream: async function* () {},
+  listModels: async () => [],
+};
 
 const request = {
   ...DEFAULT_GENERATION_PARAMS,
@@ -570,6 +585,81 @@ describe("assembleGenerationPrompt conversation scene awareness gates", () => {
     const prompt = assembly.messages.map((message) => message.content).join("\n\n");
     expect(prompt).toContain("A normal conversation card.");
     expect(prompt).not.toContain("HIDDEN CHARACTER SCENE MEMORY SHOULD NOT BE IN CONVO PROMPT");
+    expect(prompt).not.toContain("<memories>");
+  });
+});
+
+describe("assembleGenerationPrompt memory recall embeddings", () => {
+  it("uses provider query embeddings for provider-vectorized memories", async () => {
+    const embedRequests: LlmEmbedRequest[] = [];
+    const llm: LlmGateway = {
+      ...providerMemoryLlm,
+      embed: async (embedRequest) => {
+        embedRequests.push(embedRequest);
+        return [[1, 0, 0]];
+      },
+    };
+    const assembly = await assembleGenerationPrompt(
+      storageWithMemories([
+        {
+          id: "memory-semantic",
+          chatId: "conversation-chat",
+          content: "assistant: Orchard passphrase silverleaf.",
+          embedding: [1, 0, 0],
+          embeddingSource: "provider",
+          embeddingModel: "embedding-model",
+          embeddingConnectionId: "embedding-connection",
+        },
+        {
+          id: "memory-other",
+          chatId: "conversation-chat",
+          content: "assistant: Harbor chimes midnight.",
+          embedding: [0, 1, 0],
+          embeddingSource: "provider",
+          embeddingModel: "embedding-model",
+          embeddingConnectionId: "embedding-connection",
+        },
+      ]),
+      {
+        chat: { id: "conversation-chat", mode: "conversation" },
+        storedMessages: [{ role: "user", content: "What was the secret word?", contextKind: "history" }],
+        connection: { id: "connection-1", embeddingModel: "embedding-model" },
+        request: { ...request, promptPresetId: "" },
+        latestUserInput: "What was the secret word?",
+        llm,
+      },
+    );
+
+    const prompt = assembly.messages.map((message) => message.content).join("\n\n");
+    expect(embedRequests).toEqual([{ connectionId: "embedding-connection", model: "embedding-model", texts: ["What was the secret word?"] }]);
+    expect(prompt).toContain("<memories>");
+    expect(prompt).toContain("silverleaf");
+    expect(prompt).not.toContain("Harbor chimes");
+  });
+
+  it("does not compare provider memories with lexical vectors when provider query embedding is unavailable", async () => {
+    const assembly = await assembleGenerationPrompt(
+      storageWithMemories([
+        {
+          id: "memory-semantic",
+          chatId: "conversation-chat",
+          content: "assistant: The orchard gate password is silverleaf.",
+          embedding: [1, 0, 0],
+          embeddingSource: "provider",
+          embeddingModel: "embedding-model",
+        },
+      ]),
+      {
+        chat: { id: "conversation-chat", mode: "conversation" },
+        storedMessages: [{ role: "user", content: "silverleaf?", contextKind: "history" }],
+        connection: { id: "connection-1", embeddingModel: "embedding-model" },
+        request: { ...request, promptPresetId: "" },
+        latestUserInput: "silverleaf?",
+        llm: { ...providerMemoryLlm, embed: async () => null },
+      },
+    );
+
+    const prompt = assembly.messages.map((message) => message.content).join("\n\n");
     expect(prompt).not.toContain("<memories>");
   });
 });

--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -1,5 +1,6 @@
 import type { LorebookEntry } from "../contracts/types/lorebook";
 import type { ChatMLMessage, MarkerConfig, WrapFormat } from "../contracts/types/prompt";
+import type { LlmEmbedRequest, LlmGateway } from "../capabilities/llm";
 import type { StorageGateway } from "../capabilities/storage";
 import { injectAtDepth, processActivatedEntries } from "../generation-core/lorebooks/prompt-injector";
 import { scanForActivatedEntries, type ActivatedEntry } from "../generation-core/lorebooks/keyword-scanner";
@@ -80,6 +81,7 @@ export interface PromptAssemblyInput {
   connection: JsonRecord;
   request: JsonRecord;
   latestUserInput: string;
+  llm?: LlmGateway | null;
   agentData?: Record<string, string>;
 }
 
@@ -776,7 +778,71 @@ function cosineSimilarity(a: number[], b: number[]): number {
 function memoryVector(memory: JsonRecord): number[] | null {
   if (!Array.isArray(memory.embedding)) return null;
   const vector = memory.embedding.filter((value): value is number => typeof value === "number" && Number.isFinite(value));
-  return vector.length === MEMORY_EMBEDDING_DIMS ? vector : null;
+  return vector.length > 0 ? vector : null;
+}
+
+function memoryUsesProviderEmbedding(memory: JsonRecord): boolean {
+  const vector = memoryVector(memory);
+  return (
+    readString(memory.embeddingSource) === "provider" ||
+    !!readString(memory.embeddingModel) ||
+    (!!vector && vector.length !== MEMORY_EMBEDDING_DIMS)
+  );
+}
+
+function providerMemoryEmbeddingKey(memory: JsonRecord, connection: JsonRecord): string {
+  const connectionId = readString(memory.embeddingConnectionId).trim() || readString(connection.id).trim() || "inline";
+  const model = readString(memory.embeddingModel).trim() || readString(connection.embeddingModel).trim();
+  return `${connectionId}\u0000${model}`;
+}
+
+function providerMemoryEmbeddingRequest(
+  memory: JsonRecord,
+  connection: JsonRecord,
+  latestUserInput: string,
+): LlmEmbedRequest | null {
+  const connectionId = readString(memory.embeddingConnectionId).trim() || readString(connection.id).trim();
+  if (!connectionId) return null;
+  const model = readString(memory.embeddingModel).trim();
+  return {
+    connectionId,
+    ...(model ? { model } : {}),
+    texts: [latestUserInput],
+  };
+}
+
+async function queryProviderMemoryEmbeddings(
+  llm: LlmGateway | null | undefined,
+  connection: JsonRecord,
+  latestUserInput: string,
+  memories: JsonRecord[],
+): Promise<Map<string, number[]>> {
+  const providerMemories = memories.filter(memoryUsesProviderEmbedding);
+  const queryEmbeddings = new Map<string, number[]>();
+  if (!llm || providerMemories.length === 0) return queryEmbeddings;
+
+  const requests = new Map<string, LlmEmbedRequest>();
+  for (const memory of providerMemories) {
+    const key = providerMemoryEmbeddingKey(memory, connection);
+    if (!requests.has(key)) {
+      const request = providerMemoryEmbeddingRequest(memory, connection, latestUserInput);
+      if (request) requests.set(key, request);
+    }
+  }
+
+  await Promise.all(
+    Array.from(requests.entries()).map(async ([key, request]) => {
+      const embeddings = await llm.embed(request).catch((error) => {
+        console.warn("[memory-recall] provider embedding unavailable", error);
+        return null;
+      });
+      const queryEmbedding = embeddings?.[0];
+      if (Array.isArray(queryEmbedding) && queryEmbedding.length > 0) {
+        queryEmbeddings.set(key, queryEmbedding);
+      }
+    }),
+  );
+  return queryEmbeddings;
 }
 
 function truncateRecalledMemory(content: string, tokenBudget: number): string {
@@ -821,7 +887,9 @@ function memoryRecallEnabled(chat: JsonRecord): boolean {
 async function buildMemoryRecallBlock(
   storage: StorageGateway,
   chat: JsonRecord,
+  connection: JsonRecord,
   latestUserInput: string,
+  llm?: LlmGateway | null,
   maxContext?: number,
 ): Promise<string | null> {
   if (!memoryRecallEnabled(chat) || !latestUserInput.trim()) return null;
@@ -836,13 +904,20 @@ async function buildMemoryRecallBlock(
   }
   if (memories.length === 0) return null;
 
-  const queryVector = lexicalMemoryEmbedding(latestUserInput);
+  const providerQueryVectors = await queryProviderMemoryEmbeddings(llm, connection, latestUserInput, memories);
+  const lexicalQueryVector = lexicalMemoryEmbedding(latestUserInput);
   const queryTokens = new Set(latestUserInput.toLowerCase().match(/[a-z0-9]{2,}/g) ?? []);
   const recalled = memories
     .map((memory) => {
       const content = readString(memory.content).trim();
       if (!content) return null;
-      const vector = memoryVector(memory) ?? lexicalMemoryEmbedding(content);
+      const storedVector = memoryVector(memory);
+      const usesProvider = memoryUsesProviderEmbedding(memory);
+      const providerQueryVector = usesProvider ? providerQueryVectors.get(providerMemoryEmbeddingKey(memory, connection)) : null;
+      if (usesProvider && (!providerQueryVector || !storedVector || storedVector.length !== providerQueryVector.length)) return null;
+      const vector = storedVector ?? lexicalMemoryEmbedding(content);
+      const queryVector = usesProvider ? providerQueryVector! : lexicalQueryVector;
+      if (storedVector && storedVector.length !== queryVector.length) return null;
       const haystack = content.toLowerCase();
       const lexicalScore = Array.from(queryTokens).reduce((score, token) => score + (haystack.includes(token) ? 1 : 0), 0);
       const similarity = cosineSimilarity(queryVector, vector) + Math.min(0.2, lexicalScore * 0.025);
@@ -1143,7 +1218,9 @@ export async function assembleGenerationPrompt(
   const memoryRecallBlock = await buildMemoryRecallBlock(
     storage,
     input.chat,
+    input.connection,
     input.latestUserInput,
+    input.llm,
     readNumber(input.connection.maxContext, 0) || undefined,
   );
   const defaultPrompt = await loadDefaultPromptId(storage);

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -746,6 +746,7 @@ async function runGenerationAgentsForTarget(args: {
     connection,
     request: input,
     latestUserInput: "",
+    llm: deps.llm,
   });
   const results: AgentResult[] = [];
   const runtime = await createGenerationAgentRuntime(
@@ -893,6 +894,7 @@ export async function* startGeneration(
     connection,
     request: input,
     latestUserInput: preparedUserInput.content || inputUserMessage(input),
+    llm: deps.llm,
   });
   mirrorSavedUserMessageToDiscord({ deps, chat, input, prepared: preparedUserInput, persona: assembly.persona });
 
@@ -928,6 +930,7 @@ export async function* startGeneration(
       connection,
       request: input,
       latestUserInput: preparedUserInput.content || inputUserMessage(input),
+      llm: deps.llm,
       agentData: runtime?.agentData,
     });
     prompt = withImageAttachments(

--- a/src/engine/mari/mari-history.test.ts
+++ b/src/engine/mari/mari-history.test.ts
@@ -43,6 +43,7 @@ describe("Professor Mari history", () => {
       message(index + 1, `Long turn ${index + 1}. ${"detail ".repeat(80)}`),
     );
     const llm: LlmGateway = {
+      embed: async () => null,
       complete: async () => "Compacted notes about the earlier conversation.",
       stream: async function* () {},
       listModels: async () => [],

--- a/src/features/modes/shared/chat-ui/components/ChatSettingsDrawer.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatSettingsDrawer.tsx
@@ -4715,7 +4715,7 @@ export function ChatSettingsDrawer({
             <Section
               label="Memory Recall"
               icon={<Brain size="0.875rem" />}
-              help="When enabled, relevant fragments from this chat are recalled with local lexical matching and injected into the prompt as memories."
+              help="When enabled, relevant fragments from this chat are recalled with the configured embedding model, or local lexical matching when no embedding model is configured, and injected into the prompt as memories."
             >
               {renderMemoryRecallControls(true)}
             </Section>
@@ -5017,7 +5017,7 @@ export function ChatSettingsDrawer({
             <Section
               label="Memory Recall"
               icon={<Brain size="0.875rem" />}
-              help="When enabled, relevant fragments from this chat are recalled with local lexical matching and injected into the prompt as memories."
+              help="When enabled, relevant fragments from this chat are recalled with the configured embedding model, or local lexical matching when no embedding model is configured, and injected into the prompt as memories."
             >
               {renderMemoryRecallControls(metadata.sceneStatus === "active")}
             </Section>
@@ -5649,6 +5649,16 @@ function estimateMemoryTokens(memories: ChatMemoryChunk[]): number {
   return Math.ceil(text.length / 4);
 }
 
+function memoryEmbeddingLabel(memory: ChatMemoryChunk): string {
+  if (!memory.hasEmbedding) {
+    return memory.embeddingStatus === "unavailable" ? "Embedding unavailable" : "Waiting for vector";
+  }
+  if (memory.embeddingSource === "provider") {
+    return memory.embeddingModel ? `Provider vector: ${memory.embeddingModel}` : "Provider vector";
+  }
+  return "Lexical vector";
+}
+
 const MEMORY_CONTENT_CLASS =
   "max-h-56 overflow-y-auto whitespace-pre-wrap rounded-lg bg-[var(--secondary)]/50 px-3 py-2 text-[0.6875rem] leading-relaxed text-[var(--foreground)]";
 
@@ -5807,13 +5817,7 @@ function MemoryRecallMemoriesModal({ chatId, open, onClose }: { chatId: string; 
                     </div>
                     <div className="mt-0.5 flex flex-wrap gap-x-2 gap-y-0.5">
                       <span>{memory.messageCount} messages</span>
-                      <span>
-                        {memory.hasEmbedding
-                          ? "Vectorized"
-                          : memory.embeddingStatus === "unavailable"
-                            ? "Embedding unavailable"
-                            : "Waiting for vector"}
-                      </span>
+                      <span>{memoryEmbeddingLabel(memory)}</span>
                       <span>Created {formatMemoryDate(memory.createdAt)}</span>
                     </div>
                   </div>

--- a/src/shared/api/llm-api.ts
+++ b/src/shared/api/llm-api.ts
@@ -9,6 +9,16 @@ function createStreamId(): string {
 }
 
 export const llmApi: LlmGateway = {
+  embed: async (request) => {
+    const result = await invokeTauri<{ embeddings?: unknown }>("llm_embed", {
+      request,
+    });
+    return Array.isArray(result.embeddings)
+      ? result.embeddings.filter((embedding): embedding is number[] =>
+          Array.isArray(embedding) && embedding.every((value) => typeof value === "number" && Number.isFinite(value)),
+        )
+      : [];
+  },
   complete: (request: LlmRequest) =>
     invokeTauri("llm_complete", {
       request,

--- a/src/shared/api/remote-runtime.ts
+++ b/src/shared/api/remote-runtime.ts
@@ -164,6 +164,7 @@ const REMOTE_COMMANDS = new Set([
   "npc_avatar_upload",
   "lorebook_image_upload",
   "llm_complete",
+  "llm_embed",
   "llm_stream_cancel",
   "llm_list_models",
   "professor_mari_prompt",


### PR DESCRIPTION
## Linked issue

Closes #1363

## Why this change

Memory Recall regressed during the refactor: chat memory refresh/import generated local lexical vectors only, while legacy staging could use configured provider or local-sidecar embeddings. Prompt assembly also queried memory recall with lexical vectors, so provider-vectorized memories could not be compared in the right vector space.

## What changed

- Restore provider-backed Memory Recall embeddings for chat memory refresh/import when an embedding model or embedding connection is configured.
- Keep lexical vectors as the fallback when no embedding model is configured.
- Store memory embedding metadata (`embeddingSource`, model, connection, provider, updated-at) so recall knows which vector space each memory uses.
- Add an `llm_embed` runtime command through the shared API, embedded Tauri command list, and remote-runtime allowlist/dispatch path.
- Update prompt assembly to query provider embeddings through `LlmGateway`, compare provider memories only against matching provider query vectors, and skip mismatched/unavailable provider vectors instead of mixing lexical and provider spaces.
- Update Memory Recall UI copy/labels so provider vectors are visible.

## Refactor impact

Primary owner:

Rust storage/provider transport, engine generation/prompt assembly, shared API runtime adapter, remote runtime dispatch, and shared chat settings UI.

Impact areas reviewed:

- Chat Memory Recall refresh/import and generation recall.
- Active roleplay-scene recall path through shared prompt assembly.
- Game state and game memory paths were checked for accidental ownership bleed; no game orchestration changed.
- Remote runtime command allowlist and Rust dispatch were checked for parity with embedded Tauri command registration.

Boundary notes:

- Engine code receives embeddings through `LlmGateway`; it does not import Tauri, shared API adapters, React, or feature internals.
- Feature UI continues to use existing chat hooks/shared API paths; no new raw remote-runtime fetch was added.
- Provider credentials stay server-side when query embeddings are requested by connection id.

Pressure points touched:

- `src-tauri/src/lib.rs` command registration.
- `src-tauri/src/http_dispatch.rs` remote invoke dispatch.
- `src/shared/api/remote-runtime.ts` allowlist.
- `src/features/modes/shared/chat-ui/components/ChatSettingsDrawer.tsx` Memory Recall labels/copy.

## Validation

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

Agent-run validation on the rebased branch:

- `pnpm check`
- `pnpm build`
- `pnpm test -- src/engine/generation/prompt-assembly.test.ts src/engine/generation/agent-runner.test.ts src/engine/generation/main-tool-loop.test.ts`
- `cargo test --manifest-path src-tauri/Cargo.toml refresh_chat_memories_uses_configured_provider_embeddings`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- -D warnings`

No browser/Tauri manual verification or remote-runtime live smoke was performed.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs were changed. This restores existing legacy behavior rather than adding a new documented feature.

## UI evidence

No screenshots added. UI change is limited to Memory Recall text/labels showing provider vs lexical vector source.
