### PR TITLE
Restore UI parity controls

### DIFF
--- a/src/features/modes/game/components/DirectionEngine.tsx
+++ b/src/features/modes/game/components/DirectionEngine.tsx
@@ -5,12 +5,20 @@
 // Each direction maps to a CSS-driven effect applied as a layer
 // over the game viewport.
 // ──────────────────────────────────────────────
-import { useEffect, useLayoutEffect, useRef, useState, useCallback } from "react";
+import { useEffect, useLayoutEffect, useRef, useState, useCallback, type CSSProperties } from "react";
 import type { DirectionCommand } from "../../../../engine/contracts/types/game";
 import { resolveManagedLocalAssetUrl } from "../../../../shared/api/local-file-api";
 
 /** Cross-fading background layer — renders two stacked layers and transitions between them. */
-function CrossfadeBackground({ url }: { url?: string }) {
+function getBackgroundBlurStyle(blurPx: number): Pick<CSSProperties, "filter" | "transform"> {
+  if (blurPx <= 0) return {};
+  return {
+    filter: `blur(${blurPx}px)`,
+    transform: `scale(${Math.min(1.08, 1 + blurPx * 0.0025)})`,
+  };
+}
+
+function CrossfadeBackground({ url, blurPx = 0 }: { url?: string; blurPx?: number }) {
   const [resolvedUrl, setResolvedUrl] = useState<string | null>(url ?? null);
   const [layers, setLayers] = useState<{ front: string | null; back: string | null; fading: boolean }>({
     front: url ?? null,
@@ -18,6 +26,7 @@ function CrossfadeBackground({ url }: { url?: string }) {
     fading: false,
   });
   const timerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const backgroundBlurStyle = getBackgroundBlurStyle(blurPx);
 
   useEffect(() => {
     let cancelled = false;
@@ -57,7 +66,8 @@ function CrossfadeBackground({ url }: { url?: string }) {
           style={{
             backgroundImage: `url(${layers.back})`,
             opacity: layers.fading ? 0 : 1,
-            transition: "opacity 700ms ease-in-out",
+            transition: "opacity 700ms ease-in-out, filter 180ms ease-out, transform 180ms ease-out",
+            ...backgroundBlurStyle,
           }}
         />
       )}
@@ -68,7 +78,8 @@ function CrossfadeBackground({ url }: { url?: string }) {
           style={{
             backgroundImage: `url(${layers.front})`,
             opacity: layers.fading ? 1 : 1,
-            transition: "opacity 700ms ease-in-out",
+            transition: "opacity 700ms ease-in-out, filter 180ms ease-out, transform 180ms ease-out",
+            ...backgroundBlurStyle,
           }}
         />
       )}
@@ -82,6 +93,8 @@ interface DirectionEngineProps {
   directions: DirectionCommand[];
   /** Background image URL — rendered inside the effect scope so shake/blur affects it. */
   backgroundUrl?: string;
+  /** Persistent user-configured background blur, in px. */
+  backgroundBlurPx?: number;
   /** Called when active effects start or all finish playing. */
   onPlayingChange?: (playing: boolean) => void;
   children: React.ReactNode;
@@ -100,7 +113,13 @@ const FADE_OUT_MS = 600;
 
 let effectCounter = 0;
 
-export function DirectionEngine({ directions, backgroundUrl, onPlayingChange, children }: DirectionEngineProps) {
+export function DirectionEngine({
+  directions,
+  backgroundUrl,
+  backgroundBlurPx = 0,
+  onPlayingChange,
+  children,
+}: DirectionEngineProps) {
   const [activeEffects, setActiveEffects] = useState<ActiveEffect[]>([]);
   const processedRef = useRef<string>("");
 
@@ -178,7 +197,7 @@ export function DirectionEngine({ directions, backgroundUrl, onPlayingChange, ch
     <div className="relative h-full w-full overflow-hidden">
       {/* Scene visual layer. Transform/filter effects live here so HUD widgets remain stable. */}
       <div className="absolute inset-0 z-0 h-full w-full" style={buildVisualStyle(bgEffects)}>
-        <CrossfadeBackground url={backgroundUrl} />
+        <CrossfadeBackground url={backgroundUrl} blurPx={backgroundBlurPx} />
       </div>
 
       {/* Background/all overlay effects */}

--- a/src/features/modes/game/components/GameSurface.tsx
+++ b/src/features/modes/game/components/GameSurface.tsx
@@ -1652,6 +1652,7 @@ export function GameSurface({
   const gameTutorialDisabled = useUIStore((s) => s.gameTutorialDisabled);
   const setGameTutorialDisabled = useUIStore((s) => s.setGameTutorialDisabled);
   const gameFullBodySpriteScale = useUIStore((s) => s.gameFullBodySpriteScale);
+  const chatBackgroundBlur = useUIStore((s) => s.chatBackgroundBlur);
   const gameMiddleMouseNav = useUIStore((s) => s.gameMiddleMouseNav);
   const messagesPerPage = useUIStore((s) => s.messagesPerPage);
   const openGameAssetsBrowser = useUIStore((s) => s.openGameAssetsBrowser);
@@ -7499,6 +7500,7 @@ export function GameSurface({
         <DirectionEngine
           directions={activeDirections}
           backgroundUrl={displayedBackground ?? undefined}
+          backgroundBlurPx={chatBackgroundBlur}
           onPlayingChange={(playing) => {
             setDirectionsPlaying(playing);
             // When intro cinematic finishes, clear the flag

--- a/src/features/modes/roleplay/components/ChatRoleplaySurface.tsx
+++ b/src/features/modes/roleplay/components/ChatRoleplaySurface.tsx
@@ -7,8 +7,8 @@ import {
   useRef,
   useState,
   useMemo,
-  type ComponentProps,
   type CSSProperties,
+  type ComponentProps,
   type ReactNode,
   type RefObject,
 } from "react";
@@ -104,6 +104,15 @@ function WeatherEffectsConnected() {
   );
 }
 
+function getBackgroundBlurStyle(blurPx: number): Pick<CSSProperties, "filter" | "transform"> {
+  const safeBlurPx = Math.max(0, Math.min(24, Number.isFinite(blurPx) ? blurPx : 0));
+  if (safeBlurPx <= 0) return {};
+  return {
+    filter: `blur(${safeBlurPx}px)`,
+    transform: `scale(${1 + safeBlurPx / 120})`,
+  };
+}
+
 function CrossfadeBackground({
   url,
   className,
@@ -118,14 +127,7 @@ function CrossfadeBackground({
   const [bgB, setBgB] = useState<string | null>(null);
   const [aActive, setAActive] = useState(true);
   const activeSlot = useRef<"a" | "b">("a");
-  const safeBlurPx = Math.max(0, Math.min(24, Number.isFinite(blurPx) ? blurPx : 0));
-  const blurStyle: CSSProperties =
-    safeBlurPx > 0
-      ? {
-          filter: `blur(${safeBlurPx}px)`,
-          transform: `scale(${1 + safeBlurPx / 120})`,
-        }
-      : {};
+  const backgroundBlurStyle = getBackgroundBlurStyle(blurPx);
 
   useEffect(() => {
     let cancelled = false;
@@ -167,14 +169,24 @@ function CrossfadeBackground({
           "mari-background absolute inset-0 bg-cover bg-center bg-no-repeat transition-opacity duration-700 ease-in-out",
           className,
         )}
-        style={{ ...blurStyle, backgroundImage: bgA ? `url(${bgA})` : "none", opacity: aActive ? 1 : 0 }}
+        style={{
+          backgroundImage: bgA ? `url(${bgA})` : "none",
+          opacity: aActive ? 1 : 0,
+          transition: "opacity 700ms ease-in-out, filter 180ms ease-out, transform 180ms ease-out",
+          ...backgroundBlurStyle,
+        }}
       />
       <div
         className={cn(
           "mari-background absolute inset-0 bg-cover bg-center bg-no-repeat transition-opacity duration-700 ease-in-out",
           className,
         )}
-        style={{ ...blurStyle, backgroundImage: bgB ? `url(${bgB})` : "none", opacity: aActive ? 0 : 1 }}
+        style={{
+          backgroundImage: bgB ? `url(${bgB})` : "none",
+          opacity: aActive ? 0 : 1,
+          transition: "opacity 700ms ease-in-out, filter 180ms ease-out, transform 180ms ease-out",
+          ...backgroundBlurStyle,
+        }}
       />
     </>
   );

--- a/src/features/modes/shared/chat-ui/components/ChatMessage.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatMessage.tsx
@@ -1337,6 +1337,8 @@ export const ChatMessage = memo(function ChatMessage({
   const hideRoleplayAvatar = isRoleplay && roleplayAvatarStyle === "none";
   const showRoleplayAvatarPanel = isRoleplay && roleplayAvatarStyle === "panel" && !isGrouped;
   const showCompactAvatar = !isGrouped && !showRoleplayAvatarPanel && !hideRoleplayAvatar;
+  const showMessageNumberInNameRow =
+    (showRoleplayAvatarPanel || hideRoleplayAvatar) && (showActions || showMessageNumbers) && messageIndex != null;
   const roleplayAvatarPanelTail = showRoleplayAvatarPanel ? (
     isMergedGroup && mergedAvatars.length > 0 ? (
       <div className="rpg-avatar-panel-tail absolute inset-0 pointer-events-none overflow-hidden">
@@ -1656,7 +1658,7 @@ export const ChatMessage = memo(function ChatMessage({
                     {genLabel}
                   </span>
                 )}
-                {showRoleplayAvatarPanel && (showActions || showMessageNumbers) && messageIndex != null && (
+                {showMessageNumberInNameRow && (
                   <span className="text-[0.5625rem] font-medium text-white/25 select-none">#{messageIndex}</span>
                 )}
               </div>

--- a/src/features/shell/settings/components/SettingsPanel.tsx
+++ b/src/features/shell/settings/components/SettingsPanel.tsx
@@ -3,6 +3,8 @@
 // ──────────────────────────────────────────────
 import {
   APP_LANGUAGE_OPTIONS,
+  CHAT_BACKGROUND_BLUR_MAX,
+  CHAT_BACKGROUND_BLUR_MIN,
   TRACKER_DATA_PANEL_SECTIONS,
   getTrackerPanelWidthForProfile,
   useUIStore,
@@ -154,7 +156,7 @@ const ROLEPLAY_AVATAR_STYLE_OPTIONS: Array<{ id: RoleplayAvatarStyle; label: str
   {
     id: "none",
     label: "None",
-    desc: "Hide roleplay message avatars for the cleanest reading layout.",
+    desc: "Hide message avatars and remove the reserved avatar gutter.",
   },
   {
     id: "circles",
@@ -1240,8 +1242,8 @@ function AppearanceSettings() {
   const visualTheme = useUIStore((s) => s.visualTheme);
   const setVisualTheme = useUIStore((s) => s.setVisualTheme);
   const chatBackground = useUIStore((s) => s.chatBackground);
-  const setChatBackgroundRaw = useUIStore((s) => s.setChatBackground);
   const chatBackgroundBlur = useUIStore((s) => s.chatBackgroundBlur);
+  const setChatBackgroundRaw = useUIStore((s) => s.setChatBackground);
   const setChatBackgroundBlur = useUIStore((s) => s.setChatBackgroundBlur);
   const activeChatId = useChatStore((s) => s.activeChatId);
   const updateMeta = useUpdateChatMetadata();
@@ -1674,8 +1676,8 @@ function AppearanceSettings() {
                 {opt.id === "none" ? (
                   <div className="flex h-14 items-center px-3">
                     <div className="flex-1 rounded-2xl bg-black/25 px-3 py-2">
-                      <div className="h-1.5 w-16 rounded-full bg-white/20" />
-                      <div className="mt-1.5 h-1.5 w-24 rounded-full bg-white/12" />
+                      <div className="h-1.5 w-14 rounded-full bg-white/20" />
+                      <div className="mt-1.5 h-1.5 w-20 rounded-full bg-white/12" />
                     </div>
                   </div>
                 ) : opt.id === "circles" ? (
@@ -1717,7 +1719,11 @@ function AppearanceSettings() {
         <div className="rounded-lg border border-[var(--border)] bg-[var(--secondary)]/45 p-3">
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
             <div className="flex h-20 w-full shrink-0 items-end justify-center gap-3 overflow-hidden rounded-md bg-black/30 ring-1 ring-[var(--border)]/70 sm:w-28">
-              {roleplayAvatarStyle !== "none" && (
+              {roleplayAvatarStyle === "none" ? (
+                <div className="mb-4 rounded-full bg-white/10 px-2 py-1 text-[0.5625rem] uppercase tracking-wide text-white/45">
+                  No avatars
+                </div>
+              ) : (
                 <div
                   className={cn(
                     "mb-2 border border-white/20 bg-gradient-to-b from-rose-300/85 via-fuchsia-300/65 to-slate-900/90 shadow-lg transition-all",
@@ -2031,23 +2037,23 @@ function AppearanceSettings() {
           )}
         </div>
         <BackgroundPicker selected={chatBackground} onSelect={setChatBackground} />
-        <label className="flex flex-col gap-1 rounded-lg border border-[var(--border)] bg-[var(--secondary)]/35 p-3">
+        <label className="flex flex-col gap-1 rounded-lg bg-[var(--secondary)]/35 p-3 ring-1 ring-[var(--border)]">
           <span className="text-[0.6875rem] font-medium inline-flex items-center gap-1">
             Background Blur
-            <HelpTooltip text="Softens the selected roleplay background image behind the chat. Set to 0px for a sharp background." />
+            <HelpTooltip text="Blurs Roleplay and Game background images. Set to Off for a sharp background." />
           </span>
           <div className="flex items-center gap-3">
             <input
               type="range"
-              min={0}
-              max={24}
+              min={CHAT_BACKGROUND_BLUR_MIN}
+              max={CHAT_BACKGROUND_BLUR_MAX}
               step={1}
               value={chatBackgroundBlur}
               onChange={(e) => setChatBackgroundBlur(Number(e.target.value))}
               className="flex-1 accent-[var(--primary)]"
             />
-            <span className="w-10 text-right text-xs tabular-nums text-[var(--muted-foreground)]">
-              {chatBackgroundBlur}px
+            <span className="w-12 text-right text-xs tabular-nums text-[var(--muted-foreground)]">
+              {chatBackgroundBlur === 0 ? "Off" : `${chatBackgroundBlur}px`}
             </span>
           </div>
         </label>

--- a/src/shared/stores/ui.store.ts
+++ b/src/shared/stores/ui.store.ts
@@ -18,11 +18,13 @@ import {
   SIDEBAR_WIDTH_MIN,
   TRACKER_DATA_PANEL_SECTIONS,
   CLEARED_DETAIL_IDS,
+  clampChatBackgroundBlur,
   clampImageDimension,
   mergeLearnedGameSetupOptions,
   mobilePanelClosePatch,
   normalizeLearnedGameSetupOption,
   normalizeRememberedGameSetupText,
+  normalizeRoleplayAvatarStyle,
   normalizeSummaryPopoverSettings,
   normalizeTrackerPanelSizeProfile,
   normalizeTrackerPanelSectionOrder,
@@ -68,6 +70,8 @@ export {
   TRACKER_PANEL_WIDTH_MAX,
   TRACKER_PANEL_WIDTH_MIN,
   TRACKER_TEMPERATURE_UNITS,
+  CHAT_BACKGROUND_BLUR_MAX,
+  CHAT_BACKGROUND_BLUR_MIN,
   getTrackerPanelWidthForProfile,
 } from "./ui/model";
 export type {
@@ -290,8 +294,7 @@ export const useUIStore = create<UIState>()(
       closeModal: () => set({ modal: null }),
       setTheme: (theme) => set({ theme }),
       setChatBackground: (url) => set({ chatBackground: url }),
-      setChatBackgroundBlur: (v) =>
-        set({ chatBackgroundBlur: Math.max(0, Math.min(24, Math.round(Number.isFinite(v) ? v : 0))) }),
+      setChatBackgroundBlur: (v) => set({ chatBackgroundBlur: clampChatBackgroundBlur(v) }),
       openCharacterDetail: (id) =>
         set(openDetailRouteState({ characterDetailId: id })),
       closeCharacterDetail: () => set({ characterDetailId: null, editorDirty: false }),
@@ -448,7 +451,7 @@ export const useUIStore = create<UIState>()(
       setNarrationOpacity: (v) => set({ narrationOpacity: Math.max(0, Math.min(100, v)) }),
       setChatFontColor: (v) => set({ chatFontColor: v }),
       setChatFontOpacity: (v) => set({ chatFontOpacity: Math.max(0, Math.min(100, v)) }),
-      setRoleplayAvatarStyle: (v) => set({ roleplayAvatarStyle: v }),
+      setRoleplayAvatarStyle: (v) => set({ roleplayAvatarStyle: normalizeRoleplayAvatarStyle(v) }),
       setRoleplayAvatarScale: (v) =>
         set({ roleplayAvatarScale: Math.max(ROLEPLAY_AVATAR_SCALE_MIN, Math.min(ROLEPLAY_AVATAR_SCALE_MAX, v)) }),
       setRoleplaySpriteScale: (v) =>

--- a/src/shared/stores/ui/model.ts
+++ b/src/shared/stores/ui/model.ts
@@ -85,6 +85,8 @@ export const ROLEPLAY_AVATAR_SCALE_MIN = 0.75;
 export const ROLEPLAY_AVATAR_SCALE_MAX = 2.5;
 export const ROLEPLAY_SPRITE_SCALE_MIN = 0.5;
 export const ROLEPLAY_SPRITE_SCALE_MAX = 1.75;
+export const CHAT_BACKGROUND_BLUR_MIN = 0;
+export const CHAT_BACKGROUND_BLUR_MAX = 24;
 
 export const DEFAULT_GAME_SETUP_LEARNED_OPTIONS: GameSetupLearnedOptions = {
   genres: [],
@@ -110,6 +112,15 @@ export const DEFAULT_SUMMARY_POPOVER_SETTINGS: SummaryPopoverSettings = {
 export function clampImageDimension(value: number) {
   const rounded = Number.isFinite(value) ? Math.round(value) : 0;
   return Math.max(IMAGE_DIMENSION_MIN, Math.min(IMAGE_DIMENSION_MAX, rounded));
+}
+
+export function clampChatBackgroundBlur(value: unknown) {
+  const rounded = typeof value === "number" && Number.isFinite(value) ? Math.round(value) : CHAT_BACKGROUND_BLUR_MIN;
+  return Math.max(CHAT_BACKGROUND_BLUR_MIN, Math.min(CHAT_BACKGROUND_BLUR_MAX, rounded));
+}
+
+export function normalizeRoleplayAvatarStyle(value: unknown): RoleplayAvatarStyle {
+  return value === "none" || value === "circles" || value === "rectangles" || value === "panel" ? value : "circles";
 }
 
 export function clampTrackerPanelWidth(value: unknown) {

--- a/src/shared/stores/ui/persistence.ts
+++ b/src/shared/stores/ui/persistence.ts
@@ -1,6 +1,8 @@
 import { createJSONStorage } from "zustand/middleware";
 import { normalizeQuoteFormat } from "../../lib/dialogue-quotes";
 import {
+  clampChatBackgroundBlur,
+  normalizeRoleplayAvatarStyle,
   normalizeTrackerPanelSectionOrder,
   normalizeTrackerPanelSizeProfile,
   normalizeSummaryPopoverSettings,
@@ -10,7 +12,7 @@ import {
 import type { UIState } from "./model";
 
 export const UI_STORE_NAME = "marinara-engine-ui-tauri";
-export const UI_STORE_VERSION = 4;
+export const UI_STORE_VERSION = 5;
 
 type PersistedUiState = Partial<UIState> & {
   trackerPanelWidth?: unknown;
@@ -177,6 +179,8 @@ export function migrateUiState(persistedState: unknown): Partial<UIState> {
   persisted.trackerPanelSectionOrder = normalizeTrackerPanelSectionOrder(persisted.trackerPanelSectionOrder);
   persisted.summaryPopoverSettings = normalizeSummaryPopoverSettings(persisted.summaryPopoverSettings);
   persisted.quoteFormat = normalizeQuoteFormat(persisted.quoteFormat);
+  persisted.chatBackgroundBlur = clampChatBackgroundBlur(persisted.chatBackgroundBlur);
+  persisted.roleplayAvatarStyle = normalizeRoleplayAvatarStyle(persisted.roleplayAvatarStyle);
   persisted.userStatusManual = persisted.userStatusManual === "dnd" ? "dnd" : "active";
   persisted.userStatus = persisted.userStatusManual === "dnd" ? "dnd" : "active";
   delete persisted.trackerPanelWidth;


### PR DESCRIPTION
## Linked issue

Fixes #1337
Fixes #1334
Fixes #1324

## Why this change

- Restores small UI parity controls that existed or were requested before the refactor: chat background blur, copying stored guidance back into `/guided`, and hiding Roleplay message avatars entirely.

## What changed

- Applies the persisted chat background blur setting to Roleplay and Game background layers.
- Keeps the Appearance panel background blur slider wired to the shared UI store with normalized persisted values.
- Adds a `None` Roleplay avatar style that hides compact avatars and the grouped-message gutter.
- Keeps stored generation guidance copyable as a ready-to-paste `/guided ...` command.

## Refactor impact

Primary owner:

- Roleplay mode, Game mode, shared mode UI, app shell settings, UI store persistence.

Impact areas reviewed:

- Roleplay background rendering, Game `DirectionEngine` background rendering, Roleplay message avatar layout, generation replay details modal, Appearance settings, UI store migration/partialization.

Boundary notes:

- UI behavior stays in `src/features`; persisted settings stay in `src/shared/stores`; no engine, Tauri, or raw runtime API boundaries were changed.

Pressure points touched:

- `GameSurface`, `DirectionEngine`, `ChatRoleplaySurface`, shared `ChatMessage`, `GenerationReplayDetailsModal`, `SettingsPanel`, UI store model/persistence.

## Validation

- [x] `pnpm check` passes locally
- [x] `pnpm typecheck` passes locally
- [x] `pnpm build` passes locally
- [x] `pnpm check:architecture` passes locally
- [x] `pnpm check:docs` passes locally
- [x] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Local automated checks run: `pnpm typecheck`, `pnpm check:architecture`, `pnpm check:docs`, `pnpm build`, `pnpm lint`, `pnpm check`, `pnpm test`.
- `pnpm test` passed with existing `act(...)` warnings in `use-streaming-tts.test.tsx`.
- `pnpm build` passed with existing Vite dynamic-import/chunk-size warnings.
- `pnpm perf:size` was attempted twice but could not complete locally because headless Chrome/Node failed with Windows paging-file and out-of-memory errors before producing size results.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- No screenshot or recording added; this is a narrow parity restoration and was covered with local build/type/architecture/test checks.

## What?

This PR restores the missing background blur, `/guided` copy, and no-avatar UI affordances on the refactor branch.

## Why?

These controls are small user-facing parity gaps and should remain available after the refactor without changing engine or runtime boundaries.

## How?

The change reuses the shared UI store for persisted settings, keeps UI rendering in feature components, normalizes persisted values during UI state migration, and avoids adding new backend or engine dependencies.

## Testing?

See the Validation section above.

## Screenshots (optional)

Not added.

## Anything Else?

`pnpm perf:size` appears locally environment-blocked by Chrome/paging-file exhaustion, not by this diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable background blur effect for game scenes with adjustable range
  * Enhanced Settings panel with new Chat Background Blur control (displays "Off" when disabled)

* **Improvements**
  * Refined roleplay message numbering display logic
  * Updated roleplay avatar style "none" preview with descriptive label
  * Improved help text and validation for blur-related settings

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1413?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->