### PR TITLE
Restore TTS audio format config

### DIFF
--- a/src-tauri/src/commands/storage/integrations/tts.rs
+++ b/src-tauri/src/commands/storage/integrations/tts.rs
@@ -109,6 +109,7 @@ fn default_config() -> Value {
         "apiKey": "",
         "voice": "alloy",
         "model": "tts-1",
+        "audioFormat": "mp3",
         "speed": 1.0,
         "elevenLabsStability": 0.5,
         "elevenLabsLanguageCode": "",
@@ -311,6 +312,7 @@ async fn speak(state: &AppState, body: Value) -> AppResult<Value> {
         .and_then(Value::as_f64)
         .unwrap_or(1.0)
         .clamp(0.25, 4.0);
+    let audio_format = configured_audio_format(&config);
     let tone = body.get("tone").and_then(Value::as_str);
     let speaker = body.get("speaker").and_then(Value::as_str);
     let use_nano_gpt = is_nano_gpt_base_url(&base);
@@ -373,7 +375,7 @@ async fn speak(state: &AppState, body: Value) -> AppResult<Value> {
             "input": provider_text,
             "voice": if voice.trim().is_empty() { "alloy" } else { voice },
             "speed": speed,
-            "response_format": "mp3"
+            "response_format": audio_format
         });
         if let Some(instructions) = instructions {
             payload["instructions"] = json!(instructions);
@@ -450,6 +452,20 @@ fn configured_base_url(config: &Value) -> String {
         "elevenlabs" => "https://api.elevenlabs.io".to_string(),
         "pockettts" => "http://localhost:8000".to_string(),
         _ => "https://api.openai.com/v1".to_string(),
+    }
+}
+
+fn configured_audio_format(config: &Value) -> &'static str {
+    match config
+        .get("audioFormat")
+        .and_then(Value::as_str)
+        .unwrap_or("mp3")
+        .trim()
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "wav" => "wav",
+        _ => "mp3",
     }
 }
 
@@ -906,6 +922,50 @@ mod tests {
         format!("http://{address}")
     }
 
+    async fn serve_openai_speech(expected_format: &'static str) -> String {
+        const AUDIO_BYTES: &[u8] = b"fake-audio";
+
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("test TTS server should bind");
+        let address = listener
+            .local_addr()
+            .expect("test TTS server address should be readable");
+        tokio::spawn(async move {
+            let (mut stream, _) = listener
+                .accept()
+                .await
+                .expect("test TTS server should accept one request");
+            let mut buffer = [0_u8; 8192];
+            let bytes = stream
+                .read(&mut buffer)
+                .await
+                .expect("test TTS server should read request");
+            let request = String::from_utf8_lossy(&buffer[..bytes]);
+            assert!(request.starts_with("POST /v1/audio/speech "));
+            assert!(request.contains(&format!(r#""response_format":"{expected_format}""#)));
+
+            let content_type = if expected_format == "wav" {
+                "audio/wav"
+            } else {
+                "audio/mpeg"
+            };
+            let header = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                AUDIO_BYTES.len()
+            );
+            stream
+                .write_all(header.as_bytes())
+                .await
+                .expect("test TTS server should write response header");
+            stream
+                .write_all(AUDIO_BYTES)
+                .await
+                .expect("test TTS server should write response body");
+        });
+        format!("http://{address}/v1")
+    }
+
     #[tokio::test]
     async fn openai_compatible_voice_lookup_passes_configured_model() {
         let state = test_state("openai-voices-model");
@@ -1023,6 +1083,72 @@ mod tests {
             .expect("TTS speak should return provider audio");
 
         assert_eq!(result["contentType"], "audio/wav");
+        assert!(result["audioBase64"]
+            .as_str()
+            .is_some_and(|audio| !audio.is_empty()));
+    }
+
+    #[tokio::test]
+    async fn openai_compatible_speak_uses_configured_audio_format() {
+        let state = test_state("openai-speak-audio-format");
+        let base_url = serve_openai_speech("wav").await;
+        state
+            .storage
+            .upsert_with_id(
+                "app-settings",
+                TTS_SETTINGS_KEY,
+                json!({
+                    "value": {
+                        "enabled": true,
+                        "source": "openai",
+                        "baseUrl": base_url,
+                        "apiKey": "",
+                        "model": "tts-1",
+                        "voice": "alloy",
+                        "audioFormat": "wav"
+                    }
+                }),
+            )
+            .expect("TTS settings should be stored");
+
+        let result = speak(&state, json!({ "text": "Hello as wav." }))
+            .await
+            .expect("TTS speak should return provider audio");
+
+        assert_eq!(result["contentType"], "audio/wav");
+        assert!(result["audioBase64"]
+            .as_str()
+            .is_some_and(|audio| !audio.is_empty()));
+    }
+
+    #[tokio::test]
+    async fn openai_compatible_speak_rejects_invalid_audio_format_config() {
+        let state = test_state("openai-speak-invalid-audio-format");
+        let base_url = serve_openai_speech("mp3").await;
+        state
+            .storage
+            .upsert_with_id(
+                "app-settings",
+                TTS_SETTINGS_KEY,
+                json!({
+                    "value": {
+                        "enabled": true,
+                        "source": "openai",
+                        "baseUrl": base_url,
+                        "apiKey": "",
+                        "model": "tts-1",
+                        "voice": "alloy",
+                        "audioFormat": "flac"
+                    }
+                }),
+            )
+            .expect("TTS settings should be stored");
+
+        let result = speak(&state, json!({ "text": "Hello as fallback mp3." }))
+            .await
+            .expect("TTS speak should return provider audio");
+
+        assert_eq!(result["contentType"], "audio/mpeg");
         assert!(result["audioBase64"]
             .as_str()
             .is_some_and(|audio| !audio.is_empty()));

--- a/src/engine/contracts/types/tts.ts
+++ b/src/engine/contracts/types/tts.ts
@@ -12,6 +12,9 @@ export type TTSDialogueScope = z.infer<typeof ttsDialogueScopeSchema>;
 export const ttsVoiceModeSchema = z.enum(["single", "per-character"]);
 export type TTSVoiceMode = z.infer<typeof ttsVoiceModeSchema>;
 
+export const ttsAudioFormatSchema = z.enum(["mp3", "wav"]);
+export type TTSAudioFormat = z.infer<typeof ttsAudioFormatSchema>;
+
 export const ttsVoiceAssignmentSchema = z.object({
   characterId: z.string().default(""),
   characterName: z.string().default(""),
@@ -107,6 +110,7 @@ export const ttsConfigSchema = z.object({
   narratorVoiceEnabled: z.boolean().default(false),
   narratorVoice: z.string().default(""),
   model: z.string().default("tts-1"),
+  audioFormat: ttsAudioFormatSchema.default("mp3"),
   /** 0.25 – 4.0 */
   speed: z.number().min(0.25).max(4.0).default(1.0),
   /** ElevenLabs only: 0.0 = more expressive/creative, 1.0 = more stable/robust */

--- a/src/features/modes/shared/chat-ui/hooks/use-streaming-tts.test.tsx
+++ b/src/features/modes/shared/chat-ui/hooks/use-streaming-tts.test.tsx
@@ -17,6 +17,7 @@ const baseConfig: TTSConfig = {
   narratorVoiceEnabled: false,
   narratorVoice: "",
   model: "tts-1",
+  audioFormat: "mp3",
   speed: 1,
   elevenLabsStability: 0.5,
   elevenLabsLanguageCode: "",

--- a/src/features/shell/settings/components/settings/TTSConfigCard.tsx
+++ b/src/features/shell/settings/components/settings/TTSConfigCard.tsx
@@ -23,7 +23,13 @@ import { useCharacters } from "../../../../catalog/characters/index";
 import { ttsService } from "../../../../../shared/lib/tts-service";
 import { clientSidePlaybackRate } from "../../../../../shared/lib/tts-dialogue";
 import { parseCharacterDisplayData } from "../../../../../shared/lib/character-display";
-import type { TTSConfig, TTSSource, TTSVoiceAssignment, TTSVoiceMode } from "../../../../../engine/contracts/types/tts";
+import type {
+  TTSAudioFormat,
+  TTSConfig,
+  TTSSource,
+  TTSVoiceAssignment,
+  TTSVoiceMode,
+} from "../../../../../engine/contracts/types/tts";
 import { ELEVENLABS_TTS_LANGUAGE_OPTIONS, TTS_API_KEY_MASK } from "../../../../../engine/contracts/types/tts";
 import { HelpTooltip } from "../../../../../shared/components/ui/HelpTooltip";
 
@@ -75,6 +81,11 @@ const TTS_SOURCE_OPTIONS: Array<{ value: TTSSource; label: string }> = [
   { value: "openai", label: "OpenAI-compatible" },
   { value: "elevenlabs", label: "ElevenLabs" },
   { value: "pockettts", label: "PocketTTS" },
+];
+
+const TTS_AUDIO_FORMAT_OPTIONS: Array<{ value: TTSAudioFormat; label: string }> = [
+  { value: "mp3", label: "MP3" },
+  { value: "wav", label: "WAV" },
 ];
 
 const ELEVENLABS_TTS_MODELS = [
@@ -292,6 +303,7 @@ export function TTSConfigCard() {
   const [baseUrl, setBaseUrl] = useState("https://api.openai.com/v1");
   const [apiKey, setApiKey] = useState("");
   const [model, setModel] = useState("tts-1");
+  const [audioFormat, setAudioFormat] = useState<TTSAudioFormat>("mp3");
   const [voice, setVoice] = useState("alloy");
   const [narratorVoiceEnabled, setNarratorVoiceEnabled] = useState(false);
   const [narratorVoice, setNarratorVoice] = useState("");
@@ -336,6 +348,7 @@ export function TTSConfigCard() {
     setBaseUrl(savedConfig.baseUrl);
     setApiKey(savedConfig.apiKey); // masked value from server
     setModel(savedConfig.model);
+    setAudioFormat(savedConfig.audioFormat ?? "mp3");
     setVoice(savedConfig.voice);
     setNarratorVoiceEnabled(savedConfig.narratorVoiceEnabled ?? false);
     setNarratorVoice(savedConfig.narratorVoice ?? "");
@@ -381,6 +394,7 @@ export function TTSConfigCard() {
     baseUrl,
     apiKey: apiKey === TTS_API_KEY_MASK ? TTS_API_KEY_MASK : apiKey,
     model,
+    audioFormat,
     voice,
     narratorVoiceEnabled,
     narratorVoice,
@@ -442,6 +456,7 @@ export function TTSConfigCard() {
     setBaseUrl(defaults.baseUrl);
     setApiKey(nextApiKey);
     setModel(defaults.model);
+    setAudioFormat("mp3");
     setVoice(defaults.voice);
     setNarratorVoiceEnabled(false);
     setNarratorVoice(defaults.voice);
@@ -456,6 +471,7 @@ export function TTSConfigCard() {
       baseUrl: defaults.baseUrl,
       apiKey: nextApiKey,
       model: defaults.model,
+      audioFormat: "mp3",
       voice: defaults.voice,
       narratorVoiceEnabled: false,
       narratorVoice: defaults.voice,
@@ -812,6 +828,26 @@ export function TTSConfigCard() {
               </>
             )}
           </FieldRow>
+
+          {source === "openai" && (
+            <FieldRow label="Audio Format" help="Output container for OpenAI-compatible TTS providers that support it.">
+              <select
+                value={audioFormat}
+                onChange={(e) => {
+                  const nextFormat = e.target.value as TTSAudioFormat;
+                  setAudioFormat(nextFormat);
+                  mark({ audioFormat: nextFormat });
+                }}
+                className={cn(INPUT_CLS, "cursor-pointer appearance-none")}
+              >
+                {TTS_AUDIO_FORMAT_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </FieldRow>
+          )}
 
           {/* Voice assignment mode */}
           <FieldRow

--- a/src/shared/lib/tts-dialogue.test.ts
+++ b/src/shared/lib/tts-dialogue.test.ts
@@ -11,6 +11,7 @@ const baseConfig: TTSConfig = {
   narratorVoiceEnabled: false,
   narratorVoice: "",
   model: "tts-1",
+  audioFormat: "mp3",
   speed: 1,
   elevenLabsStability: 0.5,
   elevenLabsLanguageCode: "",


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

<!-- Every user-facing PR should reference a feature request or issue report when practical. -->

Closes #1360

## Why this change

<!-- What user problem, bug, refactor goal, or maintenance need does this solve? -->

- Refactor TTS config dropped the legacy `audioFormat` option, so imported OpenAI-compatible TTS settings could not preserve `mp3`/`wav` and native requests always sent `response_format: "mp3"`.

## What changed

<!-- List the key changes in this PR. -->

- Restored `audioFormat` to the shared TTS contract with legacy `mp3`/`wav` values and an `mp3` default.
- Added the OpenAI-compatible TTS Audio Format selector to the settings card load/save payload.
- Restored the Rust default config field and sends the configured format in OpenAI-compatible TTS requests, falling back to `mp3` for invalid values.
- Added Rust request-body coverage for configured `wav` and invalid-format fallback.

## Refactor impact

Primary owner:

<!-- Examples: app shell, catalog, chat mode, roleplay mode, game mode, runtime generation, world-state, shared API, engine generation, Rust storage, imports, remote runtime. -->

Rust storage / shared API

Impact areas reviewed:

- Shared TTS contract schema
- TTS settings card
- Native TTS config defaults
- Native OpenAI-compatible TTS request payload
- Existing TTS config test fixtures

Boundary notes:

<!-- Note engine/shared-api/feature/Rust/remote-runtime boundaries. Say "none" only if you checked. -->

- Shared contract and feature UI now preserve the legacy `audioFormat` field.
- Rust native TTS honors only the legacy `mp3`/`wav` formats for OpenAI-compatible requests and falls back to `mp3` for unsupported persisted values.
- ElevenLabs output format, PocketTTS server-specific output controls, and new formats beyond `mp3`/`wav` are intentionally out of scope.

Pressure points touched:

<!-- Mention ModeSurface, GameSurface, shared mode UI, src-tauri/src/lib.rs command registration, or import modules if touched. -->

- TTS settings card
- Native TTS storage/integration command path

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app/runtime, step by step. If an AI agent filled this out, verify it yourself before ticking boxes. -->

- Codex proof:
  - `node scratch\issue-1360-tts-audio-format-proof.mjs` passes.
  - `cargo test --manifest-path src-tauri\Cargo.toml openai_compatible_speak_uses_configured_audio_format --workspace` passes.
  - `cargo test --manifest-path src-tauri\Cargo.toml openai_compatible_speak_rejects_invalid_audio_format_config --workspace` passes.
  - `pnpm check` passes.
  - `git diff --check upstream/refactor...HEAD` passes.
  - `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json` passes.
- Manual UI verification still needed before ticking the UI boxes: open Settings/Connections TTS in the browser or Tauri app, choose OpenAI-compatible TTS, confirm the Audio Format select is visible, and confirm saving `wav` persists.
- Codex attempted local browser smoke for the settings UI, but the shell-launched Playwright browser hit `spawn EPERM`; MCP browser navigation confirmed the app shell loads at `http://localhost:1420/`, but the available MCP toolset did not include a click/action primitive to open the settings panel.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs or release metadata changes needed; this restores an existing legacy config option.

## UI evidence

<!-- Add before/after screenshots or recordings for visible UI changes. -->

N/A for request-path proof. Manual browser/Tauri UI verification is listed above because local browser interaction was blocked after app-shell load.
