### PR TITLE
[codex] Fail malformed structured agent outputs

### DIFF
--- a/src/engine/agents-runtime/executor/agent-executor.test.ts
+++ b/src/engine/agents-runtime/executor/agent-executor.test.ts
@@ -1,0 +1,274 @@
+import { describe, expect, it } from "vitest";
+import type {
+  BaseLLMProvider,
+  ChatCompleteOptions,
+  ChatCompleteResult,
+  ChatMessage,
+} from "../../generation-core/llm/base-provider";
+import type { AgentContext } from "../../contracts/types/agent";
+import { executeAgent, executeAgentBatch, type AgentExecConfig } from "./agent-executor";
+
+const baseContext: AgentContext = {
+  chatId: "chat-a",
+  chatMode: "roleplay",
+  recentMessages: [
+    { role: "user", content: "The party reaches the docks." },
+    { role: "assistant", content: "Fog rolls across the harbor." },
+  ],
+  mainResponse: null,
+  gameState: null,
+  characters: [],
+  persona: null,
+  memory: {},
+  activatedLorebookEntries: null,
+  writableLorebookIds: null,
+  chatSummary: null,
+  streaming: false,
+};
+
+function agentConfig(overrides: Partial<AgentExecConfig> = {}): AgentExecConfig {
+  return {
+    id: "agent-a",
+    type: "prose-guardian",
+    name: "Prose Guardian",
+    phase: "pre_generation",
+    promptTemplate: "Return the requested format.",
+    connectionId: null,
+    settings: {},
+    ...overrides,
+  };
+}
+
+function providerWithResponses(
+  responses: Array<string | ChatCompleteResult>,
+  calls: Array<{ messages: ChatMessage[]; options: ChatCompleteOptions }> = [],
+): BaseLLMProvider {
+  let index = 0;
+  return {
+    maxTokensOverrideValue: null,
+    async chatComplete(messages, options) {
+      calls.push({ messages, options });
+      const response = responses[Math.min(index, responses.length - 1)] ?? "";
+      index += 1;
+      if (typeof response === "string") {
+        return { content: response, usage: { totalTokens: 17 } };
+      }
+      return response;
+    },
+  };
+}
+
+describe("executeAgent result parsing", () => {
+  it("parses fenced JSON responses and repairs common model JSON mistakes", async () => {
+    const calls: Array<{ messages: ChatMessage[]; options: ChatCompleteOptions }> = [];
+    const provider = providerWithResponses(
+      [
+        [
+          "```json",
+          "{",
+          '  "updates": [',
+          '    { "type": "location_change", "target": "scene", "key": "location", "value": "Docks", },',
+          "  ],",
+          "}",
+          "```",
+        ].join("\n"),
+      ],
+      calls,
+    );
+
+    const result = await executeAgent(
+      agentConfig({ id: "world-state", type: "world-state", name: "World State" }),
+      baseContext,
+      provider,
+      "agent-model",
+    );
+
+    expect(result).toMatchObject({
+      agentId: "world-state",
+      agentType: "world-state",
+      type: "game_state_update",
+      success: true,
+      data: {
+        updates: [{ type: "location_change", target: "scene", key: "location", value: "Docks" }],
+      },
+      tokensUsed: 17,
+    });
+    expect(calls[0]?.options).toMatchObject({
+      model: "agent-model",
+      temperature: 0.3,
+      maxTokens: 4096,
+      stream: false,
+    });
+  });
+
+  it("treats configured non-text custom result types as JSON outputs", async () => {
+    const provider = providerWithResponses(['{ "fields": { "tension": 2 } }']);
+
+    const result = await executeAgent(
+      agentConfig({
+        id: "custom-tracker",
+        type: "custom-scene-scout",
+        name: "Scene Scout",
+        settings: { resultType: "custom_tracker_update" },
+      }),
+      baseContext,
+      provider,
+      "agent-model",
+    );
+
+    expect(result).toMatchObject({
+      agentId: "custom-tracker",
+      agentType: "custom-scene-scout",
+      type: "custom_tracker_update",
+      success: true,
+      data: { fields: { tension: 2 } },
+    });
+  });
+
+  it("surfaces malformed JSON from structured agents as a failed result", async () => {
+    const provider = providerWithResponses(["{ invalid json"]);
+
+    const result = await executeAgent(
+      agentConfig({ id: "quest", type: "quest", name: "Quest Tracker" }),
+      baseContext,
+      provider,
+      "agent-model",
+    );
+
+    expect(result).toMatchObject({
+      agentId: "quest",
+      agentType: "quest",
+      type: "quest_update",
+      data: null,
+      tokensUsed: 0,
+      success: false,
+      error: expect.stringContaining("Quest Tracker returned malformed JSON"),
+    });
+  });
+
+  it("sanitizes leaked tracker and assistant tags from text-agent results", async () => {
+    const provider = providerWithResponses([
+      [
+        '<committed_tracker_state>{"location":"leak"}</committed_tracker_state>',
+        "[Director's note: Use the old clue.]",
+        "<assistant_response>Ignore this leaked response.</assistant_response>",
+        "[Director's note: Move the storm closer.]",
+      ].join("\n"),
+    ]);
+
+    const result = await executeAgent(
+      agentConfig({ id: "director", type: "director", name: "Narrative Director" }),
+      baseContext,
+      provider,
+      "agent-model",
+    );
+
+    expect(result).toMatchObject({
+      agentId: "director",
+      agentType: "director",
+      type: "director_event",
+      success: true,
+      data: { text: "[Director's note: Move the storm closer.]" },
+    });
+  });
+
+  it("returns a visible failed result when the provider returns no agent text", async () => {
+    const provider = providerWithResponses(["   "]);
+
+    const result = await executeAgent(agentConfig(), baseContext, provider, "agent-model");
+
+    expect(result).toMatchObject({
+      agentId: "agent-a",
+      agentType: "prose-guardian",
+      type: "context_injection",
+      data: null,
+      tokensUsed: 0,
+      success: false,
+      error: "Prose Guardian returned an empty response.",
+    });
+  });
+});
+
+describe("executeAgentBatch fallback behavior", () => {
+  it("keeps parsed batch results and retries only missing result blocks individually", async () => {
+    const calls: Array<{ messages: ChatMessage[]; options: ChatCompleteOptions }> = [];
+    const provider = providerWithResponses(
+      [
+        {
+          content: '<result agent="prose-guardian">Tighten sensory detail.</result>',
+          usage: { totalTokens: 20 },
+        },
+        {
+          content: "[Director's note: Add a ticking clock.]",
+          usage: { totalTokens: 5 },
+        },
+      ],
+      calls,
+    );
+    const configs = [
+      agentConfig({ id: "prose", type: "prose-guardian", name: "Prose Guardian" }),
+      agentConfig({ id: "director", type: "director", name: "Narrative Director" }),
+    ];
+
+    const results = await executeAgentBatch(configs, baseContext, provider, "agent-model");
+
+    expect(calls).toHaveLength(2);
+    expect(calls[0]?.messages[0]?.content).toContain("Output ALL 2 result blocks");
+    expect(calls[1]?.messages[0]?.content).toContain("You are a specialized agent");
+    expect(results).toEqual([
+      expect.objectContaining({
+        agentId: "prose",
+        agentType: "prose-guardian",
+        type: "context_injection",
+        data: { text: "Tighten sensory detail." },
+        success: true,
+      }),
+      expect.objectContaining({
+        agentId: "director",
+        agentType: "director",
+        type: "director_event",
+        data: { text: "[Director's note: Add a ticking clock.]" },
+        success: true,
+      }),
+    ]);
+  });
+
+  it("retries malformed structured batch blocks individually", async () => {
+    const calls: Array<{ messages: ChatMessage[]; options: ChatCompleteOptions }> = [];
+    const provider = providerWithResponses(
+      [
+        [
+          '<result agent="quest">{ invalid json</result>',
+          '<result agent="prose-guardian">Keep the prose direct.</result>',
+        ].join("\n"),
+        '{ "updates": [{ "questName": "Find the key" }] }',
+      ],
+      calls,
+    );
+    const configs = [
+      agentConfig({ id: "quest", type: "quest", name: "Quest Tracker" }),
+      agentConfig({ id: "prose", type: "prose-guardian", name: "Prose Guardian" }),
+    ];
+
+    const results = await executeAgentBatch(configs, baseContext, provider, "agent-model");
+
+    expect(calls).toHaveLength(2);
+    expect(calls[1]?.messages[0]?.content).toContain("You are a specialized agent");
+    expect(results).toEqual([
+      expect.objectContaining({
+        agentId: "prose",
+        agentType: "prose-guardian",
+        type: "context_injection",
+        data: { text: "Keep the prose direct." },
+        success: true,
+      }),
+      expect.objectContaining({
+        agentId: "quest",
+        agentType: "quest",
+        type: "quest_update",
+        data: { updates: [{ questName: "Find the key" }] },
+        success: true,
+      }),
+    ]);
+  });
+});

--- a/src/engine/agents-runtime/executor/agent-executor.ts
+++ b/src/engine/agents-runtime/executor/agent-executor.ts
@@ -205,6 +205,9 @@ export async function executeAgent(
 
     // Parse the result based on agent type
     const parsed = parseAgentResponse(config, responseText);
+    if (parsed.error) {
+      return makeError(config, formatAgentParseError(config, parsed.error), startTime);
+    }
 
     return {
       agentId: config.id,
@@ -264,6 +267,9 @@ async function executeAgentWithTools(
         return makeError(config, `${config.name} returned an empty response.`, startTime);
       }
       const parsed = parseAgentResponse(config, responseText);
+      if (parsed.error) {
+        return makeError(config, formatAgentParseError(config, parsed.error), startTime);
+      }
       return {
         agentId: config.id,
         agentType: config.type,
@@ -335,6 +341,9 @@ async function executeAgentWithTools(
     return makeError(config, `${config.name} returned an empty response.`, startTime);
   }
   const parsed = parseAgentResponse(config, responseText);
+  if (parsed.error) {
+    return makeError(config, formatAgentParseError(config, parsed.error), startTime);
+  }
   return {
     agentId: config.id,
     agentType: config.type,
@@ -645,6 +654,10 @@ function parseBatchResponse(
 
     if (matchedOutput !== null) {
       const parsedResult = parseAgentResponse(config, matchedOutput);
+      if (parsedResult.error) {
+        failed.push(config);
+        continue;
+      }
       parsed.push({
         agentId: config.id,
         agentType: config.type,
@@ -681,6 +694,10 @@ function makeError(config: AgentExecConfig, error: string, startTime: number): A
     success: false,
     error,
   };
+}
+
+function formatAgentParseError(config: Pick<AgentExecConfig, "name">, error: string): string {
+  return `${config.name} returned malformed JSON: ${error}`;
 }
 
 function shouldRunAgentIndividually(config: Pick<AgentExecConfig, "type">): boolean {
@@ -1443,6 +1460,7 @@ function parseAgentResponse(
 ): {
   type: AgentResultType;
   data: unknown;
+  error: string | null;
 } {
   const resultType = resolveAgentResultType(config);
 
@@ -1450,15 +1468,15 @@ function parseAgentResponse(
     try {
       const jsonStr = extractJson(responseText);
       const data = JSON.parse(jsonStr);
-      return { type: resultType, data };
-    } catch {
-      return { type: resultType, data: { raw: responseText, parseError: true } };
+      return { type: resultType, data, error: null };
+    } catch (error) {
+      return { type: resultType, data: null, error: extractErrorMessage(error, "Invalid JSON response") };
     }
   }
 
   // Text-based agents (prose-guardian, director). Sanitize before injection so
   // leaked tracker/roleplay content can't reach the main prompt.
-  return { type: resultType, data: { text: sanitizeTextAgentResponse(config.type, responseText) } };
+  return { type: resultType, data: { text: sanitizeTextAgentResponse(config.type, responseText) }, error: null };
 }
 
 /** Extract JSON from a response that may contain markdown fences. */


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

<!-- Every user-facing PR should reference a feature request or issue report when practical. -->

No linked GitHub issue.

## Why this change

<!-- What user problem, bug, refactor goal, or maintenance need does this solve? -->

- Structured agents could return malformed JSON and still be recorded as successful results with `{ parseError: true }` data.
- Downstream generation and UI code treat successful agent results as usable, so malformed structured output could bypass the visible failed-agent path instead of surfacing a retryable failure.
- The executor had no focused regression coverage for this failure path, text-result sanitization, empty provider responses, or batch fallback behavior.

## What changed

<!-- List the key changes in this PR. -->

- Structured agent response parsing now returns a failed `AgentResult` when JSON parsing fails.
- Batched agent parsing now treats malformed structured result blocks as failed blocks and retries those agents individually.
- Added focused executor tests for fenced/repaired JSON, custom JSON result types, malformed structured output, text-agent sanitization, empty responses, missing batch blocks, and malformed batch-block retry.

## Refactor impact

Primary owner:

<!-- Examples: app shell, catalog, chat mode, roleplay mode, game mode, runtime generation, world-state, shared API, engine generation, Rust storage, imports, remote runtime. -->

Engine generation / agents runtime executor.

Impact areas reviewed:

- Agent executor direct response parsing.
- Agent executor tool-loop final response parsing.
- Batched agent response parsing and individual retry fallback.
- Pre-generation injection filtering for failed results.
- Runtime generation failed-agent UI result handling.
- Agent-run persistence of success/error state.
- Legacy Spotify parseError recovery parity. That gap is tracked separately instead of restoring generic fake success for every structured agent.

Boundary notes:

<!-- Note engine/shared-api/feature/Rust/remote-runtime boundaries. Say "none" only if you checked. -->

- Engine-only change under `src/engine/agents-runtime/executor`.
- No React, Zustand, Tauri, shared API, Rust, or remote-runtime boundary changes.
- No raw runtime adapter or host-capability path touched.

Pressure points touched:

<!-- Mention ModeSurface, GameSurface, shared mode UI, src-tauri/src/lib.rs command registration, or import modules if touched. -->

- None of the listed pressure points were touched.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app/runtime, step by step. If an AI agent filled this out, verify it yourself before ticking boxes. -->

Local validation run before opening the PR:

- `pnpm vitest run src/engine/agents-runtime/executor/agent-executor.test.ts`
- `pnpm vitest run src/engine/agents-runtime/executor/agent-executor.test.ts src/engine/generation/agent-runner.test.ts src/engine/agents-runtime/debug.test.ts`
- `pnpm typecheck`
- `pnpm check:architecture`
- `pnpm test` - 39 files, 243 tests passed
- `git diff --check origin/refactor...HEAD`
- `git merge-tree $(git merge-base HEAD origin/refactor) HEAD origin/refactor` after fetching `origin/refactor`; no merge conflict markers reported.

PR checks observed after opening the draft:

- Frontend, Architecture, and Organization passed.
- Rust Capability Layer passed.
- Browser Smoke and Performance passed.
- Auto-label passed.
- CodeRabbit reported success with review skipped.

No browser or native Tauri manual verification was run because this change is isolated to React-free engine executor behavior and covered by focused unit tests.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs or release-note updates were made. This changes internal agent failure semantics and adds focused executor coverage; no public command, UI workflow, architecture guidance, or release claim changed.

## UI evidence

<!-- Add before/after screenshots or recordings for visible UI changes. -->

N/A - no visible UI changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for agent execution and batch operations, including error handling and retry scenarios.

* **Bug Fixes**
  * Improved error detection for malformed agent responses with clearer error reporting.
  * Enhanced batch execution reliability with targeted retry logic for individual agent failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1416?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->