### PR TITLE
Consolidate engine string reader helper

### DIFF
--- a/src/engine/generation/prompt-reviewer.ts
+++ b/src/engine/generation/prompt-reviewer.ts
@@ -1,5 +1,6 @@
 import type { LlmGateway } from "../capabilities/llm";
 import type { StorageGateway } from "../capabilities/storage";
+import { readString as stringValue } from "../shared/value-readers";
 
 export type PromptReviewInput = {
   presetId: string;
@@ -135,10 +136,6 @@ async function assemblePromptReviewView(storage: StorageGateway, presetId: strin
 function orderValue(section: JsonRecord): number {
   const value = section.sortOrder ?? section.order ?? section.injectionOrder;
   return typeof value === "number" && Number.isFinite(value) ? value : 0;
-}
-
-function stringValue(value: unknown): string {
-  return typeof value === "string" ? value : "";
 }
 
 function isRecord(value: unknown): value is JsonRecord {

--- a/src/engine/generation/runtime-records.test.ts
+++ b/src/engine/generation/runtime-records.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+import { readString } from "./runtime-records";
+
+describe("runtime record readers", () => {
+  it("keeps readString available from the generation runtime-records module", () => {
+    expect(readString("Nia")).toBe("Nia");
+    expect(readString(42, "fallback")).toBe("fallback");
+  });
+});

--- a/src/engine/generation/runtime-records.ts
+++ b/src/engine/generation/runtime-records.ts
@@ -1,3 +1,7 @@
+import { readString } from "../shared/value-readers";
+
+export { readString };
+
 export type JsonRecord = Record<string, unknown>;
 
 export function isRecord(value: unknown): value is JsonRecord {
@@ -31,10 +35,6 @@ export function parseArray(value: unknown): unknown[] {
 
 export function stringArray(value: unknown): string[] {
   return parseArray(value).filter((entry): entry is string => typeof entry === "string" && entry.trim().length > 0);
-}
-
-export function readString(value: unknown, fallback = ""): string {
-  return typeof value === "string" ? value : fallback;
 }
 
 export function readNumber(value: unknown, fallback = 0): number {

--- a/src/engine/modes/chat/core/summaries/auto-summary.service.ts
+++ b/src/engine/modes/chat/core/summaries/auto-summary.service.ts
@@ -3,6 +3,7 @@ import type { LlmGateway, LlmMessage } from "../../../../capabilities/llm";
 import type { StorageGateway } from "../../../../capabilities/storage";
 import type { BaseLLMProvider } from "../../../../generation-core/llm/base-provider.js";
 import { boolish } from "../../../../generation/runtime-records";
+import { readString as stringValue } from "../../../../shared/value-readers";
 import { stripConversationPromptTimestamps } from "./transcript-sanitize.js";
 
 export interface ConversationSummaryMessage {
@@ -76,11 +77,6 @@ function parseRecord(value: unknown): JsonRecord {
   }
   return value && typeof value === "object" && !Array.isArray(value) ? (value as JsonRecord) : {};
 }
-
-function stringValue(value: unknown): string {
-  return typeof value === "string" ? value : "";
-}
-
 
 function stringArray(value: unknown): string[] {
   if (Array.isArray(value)) return value.filter((item): item is string => typeof item === "string" && item.trim().length > 0);

--- a/src/engine/modes/chat/schedules/schedule.service.ts
+++ b/src/engine/modes/chat/schedules/schedule.service.ts
@@ -3,6 +3,7 @@ import type { StorageGateway } from "../../../capabilities/storage";
 import { parseJsonArray, parseJsonObject } from "../../../core/json";
 import { boolish } from "../../../generation/runtime-records";
 import type { BaseLLMProvider, ChatMessage } from "../../../generation-core/llm/base-provider.js";
+import { readString as stringValue } from "../../../shared/value-readers";
 
 // ── Types ──
 
@@ -763,10 +764,6 @@ function buildScheduleContinuityContext(args: {
   }
 
   return sections.join("\n").slice(0, SCHEDULE_CONTINUITY_MAX_CHARS);
-}
-
-function stringValue(value: unknown): string {
-  return typeof value === "string" ? value : "";
 }
 
 function numberOrNull(value: unknown): number | null {

--- a/src/engine/modes/roleplay/encounter/encounter-service.ts
+++ b/src/engine/modes/roleplay/encounter/encounter-service.ts
@@ -2,6 +2,7 @@ import type { LlmGateway, LlmMessage } from "../../../capabilities/llm";
 import type { StorageGateway } from "../../../capabilities/storage";
 import { parseJsonArray, parseJsonObject } from "../../../core/json";
 import { parseGameJsonish } from "../../../shared/parsing-jsonish";
+import { readString as stringValue } from "../../../shared/value-readers";
 import type { RPGStatsConfig } from "../../../contracts/types/character";
 import type { Chat, Message } from "../../../contracts/types/chat";
 import type { CombatActionResult, CombatAttack, CombatEnemy, CombatEnemyAction, CombatInitState, CombatItemEffect, CombatPartyAction, CombatPartyMember, CombatPlayerActions, CombatStatus, CombatStyleNotes, EncounterActionRequest, EncounterActionResponse, EncounterInitRequest, EncounterInitResponse, EncounterLogEntry, EncounterSummaryRequest, EncounterSummaryResponse, NarrativeStyle } from "../../../contracts/types/combat-encounter";
@@ -956,10 +957,6 @@ function arrayValue(value: unknown): unknown[] | null {
 
 function stringArray(value: unknown): string[] {
   return parseJsonArray<unknown>(value).filter((item): item is string => typeof item === "string" && item.trim().length > 0);
-}
-
-function stringValue(value: unknown, fallback = ""): string {
-  return typeof value === "string" ? value : fallback;
 }
 
 function numberValue(value: unknown, fallback: number): number {

--- a/src/engine/modes/roleplay/scene/scene-service.ts
+++ b/src/engine/modes/roleplay/scene/scene-service.ts
@@ -3,6 +3,7 @@ import type { StorageGateway } from "../../../capabilities/storage";
 import { parseJsonArray, parseJsonObject } from "../../../core/json";
 import { boolish } from "../../../generation/runtime-records";
 import { parseGameJsonish } from "../../../shared/parsing-jsonish";
+import { readString as stringValue } from "../../../shared/value-readers";
 import type { SceneAnalysis, SceneCreateRequest, SceneCreateResponse, SceneForkRequest, SceneForkResponse, SceneFullPlan, ScenePlanRequest, ScenePlanResponse } from "../../../contracts/types/scene";
 import {
   copyTrackerSnapshotsForRebasedMessages,
@@ -731,10 +732,6 @@ function parseObject(raw: string): JsonRecord {
 
 function stringArray(value: unknown): string[] {
   return parseJsonArray<string>(value).filter((item) => typeof item === "string" && item.trim().length > 0);
-}
-
-function stringValue(value: unknown): string {
-  return typeof value === "string" ? value : "";
 }
 
 function isRecord(value: unknown): value is JsonRecord {

--- a/src/engine/shared/value-readers.test.ts
+++ b/src/engine/shared/value-readers.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { readString as readRuntimeString } from "../generation/runtime-records";
+import { readString } from "./value-readers";
+
+describe("readString", () => {
+  it("returns string values without replacing empty strings", () => {
+    expect(readString("Nia")).toBe("Nia");
+    expect(readString("", "fallback")).toBe("");
+  });
+
+  it("returns the fallback for non-string values without coercion", () => {
+    expect(readString(null)).toBe("");
+    expect(readString(42, "fallback")).toBe("fallback");
+    expect(readString({ value: "Nia" }, "fallback")).toBe("fallback");
+  });
+
+  it("preserves the generation runtime-records readString export", () => {
+    expect(readRuntimeString("Nia")).toBe("Nia");
+    expect(readRuntimeString(42, "fallback")).toBe("fallback");
+  });
+});

--- a/src/engine/shared/value-readers.test.ts
+++ b/src/engine/shared/value-readers.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-import { readString as readRuntimeString } from "../generation/runtime-records";
 import { readString } from "./value-readers";
 
 describe("readString", () => {
@@ -14,8 +13,4 @@ describe("readString", () => {
     expect(readString({ value: "Nia" }, "fallback")).toBe("fallback");
   });
 
-  it("preserves the generation runtime-records readString export", () => {
-    expect(readRuntimeString("Nia")).toBe("Nia");
-    expect(readRuntimeString(42, "fallback")).toBe("fallback");
-  });
 });

--- a/src/engine/shared/value-readers.ts
+++ b/src/engine/shared/value-readers.ts
@@ -1,0 +1,3 @@
+export function readString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}


### PR DESCRIPTION
## Linked issue

No linked GitHub issue. This came from the local chore queue item `2026-05-27-engine-duplicate-helper-consolidation`.

## Why this change

- Consolidates repeated engine string-reader helpers into one pure lower-layer helper so chat, roleplay, and generation code do not keep duplicate `stringValue` implementations.

## What changed

- Added `src/engine/shared/value-readers.ts` with the shared `readString` helper.
- Re-exported `readString` from `src/engine/generation/runtime-records.ts` so existing generation imports keep working.
- Migrated prompt review, chat summaries, chat schedules, roleplay scenes, and roleplay encounters to the shared helper.
- Added focused tests for direct helper behavior and the existing `runtime-records` compatibility export.

## Refactor impact

Primary owner:

Engine shared primitive / generation compatibility.

Impact areas reviewed:

- `src/engine/shared`
- `src/engine/generation/runtime-records.ts`
- `src/engine/generation/prompt-reviewer.ts`
- `src/engine/modes/chat/core/summaries/auto-summary.service.ts`
- `src/engine/modes/chat/schedules/schedule.service.ts`
- `src/engine/modes/roleplay/scene/scene-service.ts`
- `src/engine/modes/roleplay/encounter/encounter-service.ts`

Boundary notes:

- Engine-only TypeScript cleanup.
- No React, shared API, Tauri, Rust, storage, provider transport, or remote-runtime boundary changes.
- `readString` stays in `src/engine/shared` as a pure deterministic helper. The generation re-export preserves existing import compatibility without moving ownership upward.

Pressure points touched:

- None. This does not touch `ModeSurface`, `GameSurface`, shared mode UI, `src-tauri/src/lib.rs`, or import modules.

## Validation

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Ran `pnpm test -- src/engine/shared/value-readers.test.ts src/engine/generation/runtime-records.test.ts` after rebasing onto current `origin/refactor`; 2 files passed, 3 tests passed.
- Ran `pnpm typecheck`; passed.
- Ran `pnpm check:architecture`; passed with no dependency violations and Rust structure check passed.
- Ran `pnpm build`; passed. Vite still reports existing dynamic-import and large-chunk warnings unrelated to this change.
- Ran `git diff --check origin/refactor...HEAD`; passed.
- No browser or Tauri manual verification was run because this is an engine-only helper cleanup with no visible UI, native, Rust, or remote-runtime behavior.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

No repo changelog file is present, and this cleanup is not user-facing or release-note-worthy. No docs changes were made.

## UI evidence

N/A. No UI behavior changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated duplicate string-reading logic across multiple modules into a shared utility for improved maintainability.

* **Tests**
  * Added comprehensive test coverage for the new shared utility and its re-exports.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1417?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->