### PR TITLE
Fix Conversation impersonate quick reply persistence

### DIFF
--- a/src-tauri/src/commands/storage/commands/entities.rs
+++ b/src-tauri/src/commands/storage/commands/entities.rs
@@ -133,9 +133,9 @@ fn projection_fields(options: Option<&Value>) -> Option<Vec<String>> {
         })
 }
 
-fn projection_field_selections<'a>(
-    options: Option<&'a Value>,
-) -> &'a serde_json::Map<String, Value> {
+fn projection_field_selections(
+    options: Option<&Value>,
+) -> &serde_json::Map<String, Value> {
     if let Some(selections) = options
         .and_then(|value| value.get("fieldSelections"))
         .and_then(Value::as_object)

--- a/src/engine/generation/start-generation.test.ts
+++ b/src/engine/generation/start-generation.test.ts
@@ -517,10 +517,6 @@ describe("startGeneration generation replay metadata", () => {
           impersonateBlockAgents: true,
         },
       },
-      generationInfo: {
-        connectionId: "connection-1",
-        model: "test-model",
-      },
     });
     expect(createChatMessage.mock.calls.some(([, value]) => value.role === "assistant")).toBe(false);
     expect((streamedRequests[0] as { messages: Array<{ role: string; content: string }> }).messages).toEqual(

--- a/src/engine/generation/start-generation.test.ts
+++ b/src/engine/generation/start-generation.test.ts
@@ -484,6 +484,87 @@ describe("startGeneration chat summary fingerprint metadata", () => {
 });
 
 describe("startGeneration generation replay metadata", () => {
+  it("stores impersonate output as a generated user message with replay metadata", async () => {
+    const { deps, createChatMessage, streamedRequests } = generationDepsForChat({
+      chatPatch: {
+        characterIds: ["char-1"],
+        personaId: "persona-1",
+      },
+      characters: [{ id: "char-1", data: { name: "Marina" } }],
+      personas: [{ id: "persona-1", name: "Chai" }],
+    });
+
+    await drainGeneration(
+      startGeneration(deps, {
+        chatId: "chat-1",
+        userMessage: "a tiny answer",
+        impersonate: true,
+        impersonateBlockAgents: true,
+      }),
+    );
+
+    const userSave = createChatMessage.mock.calls.find(
+      ([, value]) => value.role === "user" && value.content === "Done.",
+    );
+    expect(userSave?.[1]).toMatchObject({
+      role: "user",
+      characterId: null,
+      content: "Done.",
+      extra: {
+        generationReplay: {
+          impersonate: true,
+          userMessage: "a tiny answer",
+          impersonateBlockAgents: true,
+        },
+      },
+      generationInfo: {
+        connectionId: "connection-1",
+        model: "test-model",
+      },
+    });
+    expect(createChatMessage.mock.calls.some(([, value]) => value.role === "assistant")).toBe(false);
+    expect((streamedRequests[0] as { messages: Array<{ role: string; content: string }> }).messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          role: "user",
+          content: expect.stringContaining("Direction:\na tiny answer"),
+        }),
+      ]),
+    );
+  });
+
+  it("adds swipes when regenerating an impersonated user message", async () => {
+    const { deps, createChatMessage, addChatMessageSwipe, patchChatMessageExtra } = generationDepsForChat({
+      initialMessages: [
+        {
+          id: "impersonate-1",
+          chatId: "chat-1",
+          role: "user",
+          content: "Original impersonation.",
+          extra: {
+            chatSummaryFingerprint: null,
+            generationReplay: {
+              impersonate: true,
+              userMessage: "a tiny answer",
+            },
+          },
+        },
+      ],
+    });
+
+    await drainGeneration(startGeneration(deps, { chatId: "chat-1", regenerateMessageId: "impersonate-1" }));
+
+    expect(createChatMessage).not.toHaveBeenCalled();
+    expect(addChatMessageSwipe).toHaveBeenCalledWith("chat-1", "impersonate-1", "Done.");
+    expect(patchChatMessageExtra).toHaveBeenCalledWith("impersonate-1", {
+      generationReplay: {
+        impersonate: true,
+        userMessage: "a tiny answer",
+      },
+      chatSummaryFingerprint: null,
+    });
+  });
+
   it("stores guided replay metadata on the generated assistant message", async () => {
     const { deps, createChatMessage } = generationDepsForChat();
 

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -580,13 +580,6 @@ async function saveAssistantMessage(args: {
 }): Promise<unknown | null> {
   const regenerateMessageId = readString(args.input.regenerateMessageId).trim();
   const generationReplay = buildGenerationReplay(args.input);
-  const generationInfo = {
-    connectionId: readString(args.connection.id) || null,
-    model: readString(args.connection.model) || null,
-    agentResults: args.agentResults.length,
-    notes: args.noteCount,
-    usage: args.usage ?? null,
-  };
 
   if (args.input.impersonate === true) {
     if (regenerateMessageId) {
@@ -606,7 +599,6 @@ async function saveAssistantMessage(args: {
         ...(generationReplay ? { generationReplay } : {}),
         chatSummaryFingerprint: args.chatSummaryFingerprint,
       },
-      generationInfo,
     });
   }
 
@@ -637,7 +629,13 @@ async function saveAssistantMessage(args: {
       ...(generationReplay ? { generationReplay } : {}),
       chatSummaryFingerprint: args.chatSummaryFingerprint,
     },
-    generationInfo,
+    generationInfo: {
+      connectionId: readString(args.connection.id) || null,
+      model: readString(args.connection.model) || null,
+      agentResults: args.agentResults.length,
+      notes: args.noteCount,
+      usage: args.usage ?? null,
+    },
   });
 }
 

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -33,6 +33,7 @@ import {
   applyGenerationReplayToRegenerateInput,
   buildGenerationReplay,
   normalizeGenerationReplay,
+  type GenerationReplay,
 } from "./generation-replay";
 import { assembleGenerationPrompt, chatSummaryForGeneration } from "./prompt-assembly";
 import type { GenerationCharacterContext, GenerationPersonaContext } from "./prompt-assembly";
@@ -584,9 +585,7 @@ async function saveAssistantMessage(args: {
   if (args.input.impersonate === true) {
     if (regenerateMessageId) {
       await args.storage.addChatMessageSwipe(args.input.chatId, regenerateMessageId, args.content);
-      const extraPatch: Record<string, unknown> = {};
-      if (generationReplay) extraPatch.generationReplay = generationReplay;
-      extraPatch.chatSummaryFingerprint = args.chatSummaryFingerprint;
+      const extraPatch = generationReplayExtraPatch(generationReplay, args.chatSummaryFingerprint);
       return args.storage.patchChatMessageExtra(regenerateMessageId, extraPatch);
     }
 
@@ -604,9 +603,7 @@ async function saveAssistantMessage(args: {
 
   if (regenerateMessageId) {
     await args.storage.addChatMessageSwipe(args.input.chatId, regenerateMessageId, args.content);
-    const extraPatch: Record<string, unknown> = {};
-    if (generationReplay) extraPatch.generationReplay = generationReplay;
-    extraPatch.chatSummaryFingerprint = args.chatSummaryFingerprint;
+    const extraPatch = generationReplayExtraPatch(generationReplay, args.chatSummaryFingerprint);
     return args.storage.patchChatMessageExtra(regenerateMessageId, extraPatch);
   }
 
@@ -637,6 +634,16 @@ async function saveAssistantMessage(args: {
       usage: args.usage ?? null,
     },
   });
+}
+
+function generationReplayExtraPatch(
+  generationReplay: GenerationReplay | null,
+  chatSummaryFingerprint: string | null,
+): Record<string, unknown> {
+  const extraPatch: Record<string, unknown> = {};
+  if (generationReplay) extraPatch.generationReplay = generationReplay;
+  extraPatch.chatSummaryFingerprint = chatSummaryFingerprint;
+  return extraPatch;
 }
 
 function savedGenerationEventType(input: StartGenerationInput): "assistant_message" | "user_message" {

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -584,9 +584,14 @@ async function saveAssistantMessage(args: {
 
   if (args.input.impersonate === true) {
     if (regenerateMessageId) {
-      await args.storage.addChatMessageSwipe(args.input.chatId, regenerateMessageId, args.content);
-      const extraPatch = generationReplayExtraPatch(generationReplay, args.chatSummaryFingerprint);
-      return args.storage.patchChatMessageExtra(regenerateMessageId, extraPatch);
+      return saveRegeneratedMessage({
+        storage: args.storage,
+        chatId: args.input.chatId,
+        messageId: regenerateMessageId,
+        content: args.content,
+        generationReplay,
+        chatSummaryFingerprint: args.chatSummaryFingerprint,
+      });
     }
 
     return args.storage.createChatMessage(args.input.chatId, {
@@ -602,9 +607,14 @@ async function saveAssistantMessage(args: {
   }
 
   if (regenerateMessageId) {
-    await args.storage.addChatMessageSwipe(args.input.chatId, regenerateMessageId, args.content);
-    const extraPatch = generationReplayExtraPatch(generationReplay, args.chatSummaryFingerprint);
-    return args.storage.patchChatMessageExtra(regenerateMessageId, extraPatch);
+    return saveRegeneratedMessage({
+      storage: args.storage,
+      chatId: args.input.chatId,
+      messageId: regenerateMessageId,
+      content: args.content,
+      generationReplay,
+      chatSummaryFingerprint: args.chatSummaryFingerprint,
+    });
   }
 
   const requestedCharacterId = readString(args.input.forCharacterId).trim();
@@ -634,6 +644,19 @@ async function saveAssistantMessage(args: {
       usage: args.usage ?? null,
     },
   });
+}
+
+async function saveRegeneratedMessage(args: {
+  storage: StorageGateway;
+  chatId: string;
+  messageId: string;
+  content: string;
+  generationReplay: GenerationReplay | null;
+  chatSummaryFingerprint: string | null;
+}): Promise<unknown | null> {
+  await args.storage.addChatMessageSwipe(args.chatId, args.messageId, args.content);
+  const extraPatch = generationReplayExtraPatch(args.generationReplay, args.chatSummaryFingerprint);
+  return args.storage.patchChatMessageExtra(args.messageId, extraPatch);
 }
 
 function generationReplayExtraPatch(

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -578,10 +578,38 @@ async function saveAssistantMessage(args: {
   attachments?: JsonRecord[];
   usage?: unknown;
 }): Promise<unknown | null> {
-  if (args.input.impersonate === true) return null;
-
   const regenerateMessageId = readString(args.input.regenerateMessageId).trim();
   const generationReplay = buildGenerationReplay(args.input);
+  const generationInfo = {
+    connectionId: readString(args.connection.id) || null,
+    model: readString(args.connection.model) || null,
+    agentResults: args.agentResults.length,
+    notes: args.noteCount,
+    usage: args.usage ?? null,
+  };
+
+  if (args.input.impersonate === true) {
+    if (regenerateMessageId) {
+      await args.storage.addChatMessageSwipe(args.input.chatId, regenerateMessageId, args.content);
+      const extraPatch: Record<string, unknown> = {};
+      if (generationReplay) extraPatch.generationReplay = generationReplay;
+      extraPatch.chatSummaryFingerprint = args.chatSummaryFingerprint;
+      return args.storage.patchChatMessageExtra(regenerateMessageId, extraPatch);
+    }
+
+    return args.storage.createChatMessage(args.input.chatId, {
+      role: "user",
+      characterId: null,
+      content: args.content,
+      extra: {
+        isGenerated: true,
+        ...(generationReplay ? { generationReplay } : {}),
+        chatSummaryFingerprint: args.chatSummaryFingerprint,
+      },
+      generationInfo,
+    });
+  }
+
   if (regenerateMessageId) {
     await args.storage.addChatMessageSwipe(args.input.chatId, regenerateMessageId, args.content);
     const extraPatch: Record<string, unknown> = {};
@@ -609,14 +637,12 @@ async function saveAssistantMessage(args: {
       ...(generationReplay ? { generationReplay } : {}),
       chatSummaryFingerprint: args.chatSummaryFingerprint,
     },
-    generationInfo: {
-      connectionId: readString(args.connection.id) || null,
-      model: readString(args.connection.model) || null,
-      agentResults: args.agentResults.length,
-      notes: args.noteCount,
-      usage: args.usage ?? null,
-    },
+    generationInfo,
   });
+}
+
+function savedGenerationEventType(input: StartGenerationInput): "assistant_message" | "user_message" {
+  return input.impersonate === true ? "user_message" : "assistant_message";
 }
 
 function messageId(saved: unknown): string | null {
@@ -1078,7 +1104,7 @@ export async function* startGeneration(
           attachments: connected.assistantAttachments,
           usage,
         });
-    if (saved) {
+    if (saved && input.impersonate !== true) {
       await mirrorSavedAssistantMessageToDiscord({
         deps,
         chat,
@@ -1087,11 +1113,11 @@ export async function* startGeneration(
         content: connected.displayContent,
         characters: assembly.characters,
       });
+      await persistTrackerSnapshotSafely(deps.storage, chatId, saved, allAgentResults, generationTrackerBaseline);
     }
-    if (saved) await persistTrackerSnapshotSafely(deps.storage, chatId, saved, allAgentResults, generationTrackerBaseline);
     await persistSecretPlotAgentMemorySafely(deps.storage, chatId, allAgentResults);
     await persistAgentResults(deps.storage, chatId, messageId(saved), allAgentResults);
-    if (saved) {
+    if (saved && input.impersonate !== true) {
       const autoLorebookResults = await runLorebookKeeperBackfill(
         deps,
         {
@@ -1106,7 +1132,7 @@ export async function* startGeneration(
         yield { type: "agent_result", data: result };
       }
     }
-    if (saved) yield { type: "assistant_message", data: saved };
+    if (saved) yield { type: savedGenerationEventType(input), data: saved };
     yield { type: "done", data: { transcript: visibleTranscript(generationMessages) } };
     return;
   }
@@ -1166,7 +1192,7 @@ export async function* startGeneration(
         attachments: connected.assistantAttachments,
         usage,
       });
-  if (saved) {
+  if (saved && input.impersonate !== true) {
     await mirrorSavedAssistantMessageToDiscord({
       deps,
       chat,
@@ -1176,7 +1202,7 @@ export async function* startGeneration(
       characters: assembly.characters,
     });
   }
-  if (saved) {
+  if (saved && input.impersonate !== true) {
     const autoLorebookResults = await runLorebookKeeperBackfill(
       deps,
       {
@@ -1191,7 +1217,7 @@ export async function* startGeneration(
       yield { type: "agent_result", data: result };
     }
   }
-  if (saved) yield { type: "assistant_message", data: saved };
+  if (saved) yield { type: savedGenerationEventType(input), data: saved };
   yield { type: "done" };
 }
 


### PR DESCRIPTION
## Linked issue

Closes #1432

## Why this change

- Conversation Impersonate quick replies generated text as the active persona, but the generated persona/user output was not persisted to chat storage.

## What changed

- Store impersonate generations as generated `role: "user"` chat messages with replay metadata.
- Preserve impersonated-user regenerate behavior by adding a new swipe to the target user message.
- Keep assistant-only side effects, including Discord mirroring, tracker snapshots, and auto lorebook backfill, limited to assistant message saves.
- Added focused generation tests for impersonate persistence and impersonated regenerate swipes.
- Fixed an existing Rust clippy lifetime warning that blocked the required Rust Capability Layer CI job on this PR.

## Refactor impact

Primary owner:

- engine generation

Impact areas reviewed:

- `startGeneration` save path for assistant, guided, and impersonate generations.
- Generation replay metadata.
- Regenerate swipe persistence.

Boundary notes:

- Engine generation change plus a Rust clippy-only cleanup in an existing storage command helper. No React, shared API, Rust storage schema, dependency, auth, or remote-runtime boundary changes.

Pressure points touched:

- Runtime generation persistence.
- Rust storage command helper signature only; no behavior/schema change.

## Validation

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Codex proof run:
- `pnpm exec vitest run src/engine/generation/start-generation.test.ts -t impersonate` passed after the fix.
- `pnpm exec vitest run src/engine/generation/start-generation.test.ts` passed with 33 tests.
- `pnpm check` passed, including architecture, frontend typecheck, Rust cargo check, and docs checks.
- `cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- -D warnings` passed after the CI-only Rust cleanup.
- `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json` passed.
- Graphify was run with `python -m graphify update .`; generated `graphify-out` cache/path churn was omitted from the PR because it was not portable reviewable evidence for this fix.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- N/A: this is an engine persistence bug. The proof asserts the generated impersonate output is persisted as a user message with replay metadata and does not create an assistant message.
