### PR TITLE
Fix Rust clippy lifetime warning

### DIFF
--- a/src-tauri/src/commands/storage/commands/entities.rs
+++ b/src-tauri/src/commands/storage/commands/entities.rs
@@ -133,9 +133,9 @@ fn projection_fields(options: Option<&Value>) -> Option<Vec<String>> {
         })
 }
 
-fn projection_field_selections<'a>(
-    options: Option<&'a Value>,
-) -> &'a serde_json::Map<String, Value> {
+fn projection_field_selections(
+    options: Option<&Value>,
+) -> &serde_json::Map<String, Value> {
     if let Some(selections) = options
         .and_then(|value| value.get("fieldSelections"))
         .and_then(Value::as_object)


### PR DESCRIPTION
## Linked issue

Unblocks #1434

## Why this change

- The `Rust Capability Layer` CI job on #1434 fails on `refactor` because Rust 1.95 clippy now rejects an explicit lifetime in `projection_field_selections`.

## What changed

- Elided the needless lifetime in `projection_field_selections`.
- No behavior change.

## Refactor impact

Primary owner:

Rust storage

Impact areas reviewed:

- `src-tauri/src/commands/storage/commands/entities.rs`

Boundary notes:

- Rust-only clippy cleanup.
- No schema, storage behavior, provider, prompt, dependency, or frontend changes.

Pressure points touched:

- None.

## Validation

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Codex reproduced the CI blocker locally with `cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- -D warnings`; it failed with `clippy::needless_lifetimes` at `src-tauri/src/commands/storage/commands/entities.rs:136`.
- Codex verified the fix with `cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- -D warnings`: passed.
- Codex verified `cargo check --manifest-path src-tauri/Cargo.toml --workspace`: passed.
- Bunny review pass completed before opening the PR.
- `graphify update .` could not run because `graphify` is not available on PATH in this Codex session.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A: Rust clippy cleanup only.
