### PR TITLE
Fix message edit persistence

### DIFF
--- a/src-tauri/crates/storage/src/lib.rs
+++ b/src-tauri/crates/storage/src/lib.rs
@@ -177,6 +177,19 @@ impl FileStorage {
     }
 
     pub fn patch(&self, collection: &str, id: &str, patch: Value) -> AppResult<Value> {
+        self.patch_with(collection, id, patch, |_, _| Ok(()))
+    }
+
+    pub fn patch_with<F>(
+        &self,
+        collection: &str,
+        id: &str,
+        patch: Value,
+        mut after_patch: F,
+    ) -> AppResult<Value>
+    where
+        F: FnMut(&mut Map<String, Value>, &Map<String, Value>) -> AppResult<()>,
+    {
         let _guard = self
             .lock
             .write()
@@ -191,9 +204,10 @@ impl FileStorage {
             let Some(object) = row.as_object_mut() else {
                 return Err(AppError::invalid_input("Stored record is not an object"));
             };
-            for (key, value) in patch {
-                object.insert(key, value);
+            for (key, value) in &patch {
+                object.insert(key.clone(), value.clone());
             }
+            after_patch(object, &patch)?;
             object.insert("updatedAt".to_string(), Value::String(now_iso()));
             found = Some(Value::Object(object.clone()));
             break;

--- a/src-tauri/src/commands/storage/commands/entities.rs
+++ b/src-tauri/src/commands/storage/commands/entities.rs
@@ -243,11 +243,12 @@ fn storage_update_inner(
     id: String,
     patch: Value,
 ) -> Result<Value, AppError> {
-    state.storage.patch(
-        &entity,
-        &id,
-        shared::normalize_update_patch(&entity, patch)?,
-    )
+    let normalized_patch = if entity == "messages" {
+        shared::normalize_message_update_patch(state, &id, patch)?
+    } else {
+        shared::normalize_update_patch(&entity, patch)?
+    };
+    state.storage.patch(&entity, &id, normalized_patch)
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/storage/commands/entities.rs
+++ b/src-tauri/src/commands/storage/commands/entities.rs
@@ -133,9 +133,7 @@ fn projection_fields(options: Option<&Value>) -> Option<Vec<String>> {
         })
 }
 
-fn projection_field_selections(
-    options: Option<&Value>,
-) -> &serde_json::Map<String, Value> {
+fn projection_field_selections(options: Option<&Value>) -> &serde_json::Map<String, Value> {
     if let Some(selections) = options
         .and_then(|value| value.get("fieldSelections"))
         .and_then(Value::as_object)
@@ -243,12 +241,14 @@ fn storage_update_inner(
     id: String,
     patch: Value,
 ) -> Result<Value, AppError> {
-    let normalized_patch = if entity == "messages" {
-        shared::normalize_message_update_patch(state, &id, patch)?
-    } else {
-        shared::normalize_update_patch(&entity, patch)?
-    };
-    state.storage.patch(&entity, &id, normalized_patch)
+    if entity == "messages" {
+        return shared::patch_message_update(state, &id, patch);
+    }
+    state.storage.patch(
+        &entity,
+        &id,
+        shared::normalize_update_patch(&entity, patch)?,
+    )
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/storage/shared.rs
+++ b/src-tauri/src/commands/storage/shared.rs
@@ -144,43 +144,45 @@ pub(crate) fn normalize_update_patch(collection: &str, patch: Value) -> AppResul
     Ok(Value::Object(object))
 }
 
-pub(crate) fn normalize_message_update_patch(
+pub(crate) fn patch_message_update(
     state: &AppState,
     message_id: &str,
     patch: Value,
 ) -> AppResult<Value> {
-    let mut normalized = normalize_update_patch("messages", patch)?;
-    let Some(object) = normalized.as_object_mut() else {
-        return Ok(normalized);
-    };
-    if object.contains_key("swipes") {
-        return Ok(normalized);
+    let normalized = normalize_update_patch("messages", patch)?;
+    state
+        .storage
+        .patch_with("messages", message_id, normalized, |message, patch| {
+            sync_message_patch_content_to_active_swipe(message, patch);
+            Ok(())
+        })
+}
+
+pub(crate) fn sync_message_patch_content_to_active_swipe(
+    message: &mut Map<String, Value>,
+    patch: &Map<String, Value>,
+) {
+    if patch.contains_key("swipes") {
+        return;
     }
-    let Some(content) = object
+    let Some(content) = patch
         .get("content")
         .and_then(Value::as_str)
         .map(ToOwned::to_owned)
     else {
-        return Ok(normalized);
+        return;
     };
-    let Some(mut existing) = state.storage.get("messages", message_id)? else {
-        return Ok(normalized);
-    };
-    let active_index = object
+    let active_index = patch
         .get("activeSwipeIndex")
-        .or_else(|| existing.get("activeSwipeIndex"))
+        .or_else(|| message.get("activeSwipeIndex"))
         .and_then(Value::as_u64)
         .map(|value| value as usize)
         .unwrap_or(0);
-    let Some(swipes) = existing
-        .as_object_mut()
-        .and_then(|existing_object| existing_object.get_mut("swipes"))
-        .and_then(Value::as_array_mut)
-    else {
-        return Ok(normalized);
+    let Some(swipes) = message.get_mut("swipes").and_then(Value::as_array_mut) else {
+        return;
     };
     if swipes.is_empty() {
-        return Ok(normalized);
+        return;
     }
     let active_index = active_index.min(swipes.len().saturating_sub(1));
     match swipes.get_mut(active_index) {
@@ -190,10 +192,8 @@ pub(crate) fn normalize_message_update_patch(
         Some(swipe) => {
             *swipe = json!({ "content": content });
         }
-        None => return Ok(normalized),
+        None => {}
     }
-    object.insert("swipes".to_string(), Value::Array(swipes.clone()));
-    Ok(normalized)
 }
 
 pub(crate) fn normalize_typed_json_fields(
@@ -638,16 +638,9 @@ mod tests {
             )
             .expect("message should be created");
 
-        let patch = normalize_message_update_patch(
-            &state,
-            "message-1",
-            json!({ "content": "edited active" }),
-        )
-        .expect("patch should normalize");
-        let mut updated = state
-            .storage
-            .patch("messages", "message-1", patch)
-            .expect("message should update");
+        let mut updated =
+            patch_message_update(&state, "message-1", json!({ "content": "edited active" }))
+                .expect("message should update");
         materialize_message_swipe_fields(&mut updated);
 
         assert_eq!(updated["content"], json!("edited active"));
@@ -674,18 +667,9 @@ mod tests {
             )
             .expect("message should be created");
 
-        let patch = normalize_message_update_patch(
-            &state,
-            "message-1",
-            json!({ "content": "edited legacy" }),
-        )
-        .expect("patch should normalize");
-
-        assert!(patch.get("swipes").is_none());
-        let mut updated = state
-            .storage
-            .patch("messages", "message-1", patch)
-            .expect("message should update");
+        let mut updated =
+            patch_message_update(&state, "message-1", json!({ "content": "edited legacy" }))
+                .expect("message should update");
         materialize_message_swipe_fields(&mut updated);
 
         assert_eq!(updated["content"], json!("edited legacy"));

--- a/src-tauri/src/commands/storage/shared.rs
+++ b/src-tauri/src/commands/storage/shared.rs
@@ -144,6 +144,58 @@ pub(crate) fn normalize_update_patch(collection: &str, patch: Value) -> AppResul
     Ok(Value::Object(object))
 }
 
+pub(crate) fn normalize_message_update_patch(
+    state: &AppState,
+    message_id: &str,
+    patch: Value,
+) -> AppResult<Value> {
+    let mut normalized = normalize_update_patch("messages", patch)?;
+    let Some(object) = normalized.as_object_mut() else {
+        return Ok(normalized);
+    };
+    if object.contains_key("swipes") {
+        return Ok(normalized);
+    }
+    let Some(content) = object
+        .get("content")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+    else {
+        return Ok(normalized);
+    };
+    let Some(mut existing) = state.storage.get("messages", message_id)? else {
+        return Ok(normalized);
+    };
+    let active_index = object
+        .get("activeSwipeIndex")
+        .or_else(|| existing.get("activeSwipeIndex"))
+        .and_then(Value::as_u64)
+        .map(|value| value as usize)
+        .unwrap_or(0);
+    let Some(swipes) = existing
+        .as_object_mut()
+        .and_then(|existing_object| existing_object.get_mut("swipes"))
+        .and_then(Value::as_array_mut)
+    else {
+        return Ok(normalized);
+    };
+    if swipes.is_empty() {
+        return Ok(normalized);
+    }
+    let active_index = active_index.min(swipes.len().saturating_sub(1));
+    match swipes.get_mut(active_index) {
+        Some(Value::Object(swipe)) => {
+            swipe.insert("content".to_string(), Value::String(content));
+        }
+        Some(swipe) => {
+            *swipe = json!({ "content": content });
+        }
+        None => return Ok(normalized),
+    }
+    object.insert("swipes".to_string(), Value::Array(swipes.clone()));
+    Ok(normalized)
+}
+
 pub(crate) fn normalize_typed_json_fields(
     collection: &str,
     object: &mut Map<String, Value>,
@@ -510,6 +562,24 @@ pub(crate) fn with_entity_defaults(collection: &str, body: Value) -> AppResult<V
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    struct TempRoot(PathBuf);
+
+    impl Drop for TempRoot {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn temp_root(test_name: &str) -> TempRoot {
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock should be after epoch")
+            .as_nanos();
+        TempRoot(std::env::temp_dir().join(format!("marinara-storage-{test_name}-{suffix}")))
+    }
 
     #[test]
     fn character_update_patch_preserves_object_data() {
@@ -540,6 +610,86 @@ mod tests {
                 .expect_err("invalid character data should fail");
             assert_eq!(error.code, "invalid_input");
         }
+    }
+
+    #[test]
+    fn message_content_update_patch_updates_active_swipe_content() {
+        let root = temp_root("message-edit-active-swipe");
+        let state = AppState::from_data_dir(&root.0, Vec::new()).expect("state should initialize");
+        state
+            .storage
+            .create(
+                "messages",
+                with_entity_defaults(
+                    "messages",
+                    json!({
+                        "id": "message-1",
+                        "chatId": "chat-1",
+                        "role": "user",
+                        "content": "original active",
+                        "activeSwipeIndex": 1,
+                        "swipes": [
+                            { "content": "first swipe" },
+                            { "content": "original active" }
+                        ]
+                    }),
+                )
+                .expect("message defaults should apply"),
+            )
+            .expect("message should be created");
+
+        let patch = normalize_message_update_patch(
+            &state,
+            "message-1",
+            json!({ "content": "edited active" }),
+        )
+        .expect("patch should normalize");
+        let mut updated = state
+            .storage
+            .patch("messages", "message-1", patch)
+            .expect("message should update");
+        materialize_message_swipe_fields(&mut updated);
+
+        assert_eq!(updated["content"], json!("edited active"));
+        assert_eq!(updated["activeSwipeIndex"], json!(1));
+        assert_eq!(updated["swipes"][0]["content"], json!("first swipe"));
+        assert_eq!(updated["swipes"][1]["content"], json!("edited active"));
+    }
+
+    #[test]
+    fn message_content_update_patch_does_not_invent_missing_swipes() {
+        let root = temp_root("message-edit-no-swipes");
+        let state = AppState::from_data_dir(&root.0, Vec::new()).expect("state should initialize");
+        state
+            .storage
+            .create(
+                "messages",
+                json!({
+                    "id": "message-1",
+                    "chatId": "chat-1",
+                    "role": "user",
+                    "content": "legacy content",
+                    "extra": {}
+                }),
+            )
+            .expect("message should be created");
+
+        let patch = normalize_message_update_patch(
+            &state,
+            "message-1",
+            json!({ "content": "edited legacy" }),
+        )
+        .expect("patch should normalize");
+
+        assert!(patch.get("swipes").is_none());
+        let mut updated = state
+            .storage
+            .patch("messages", "message-1", patch)
+            .expect("message should update");
+        materialize_message_swipe_fields(&mut updated);
+
+        assert_eq!(updated["content"], json!("edited legacy"));
+        assert!(updated.get("swipes").is_none());
     }
 
     #[test]

--- a/src-tauri/src/http_dispatch.rs
+++ b/src-tauri/src/http_dispatch.rs
@@ -802,12 +802,14 @@ fn storage_create(state: &AppState, args: &Map<String, Value>) -> AppResult<Valu
 fn storage_update(state: &AppState, args: &Map<String, Value>) -> AppResult<Value> {
     let entity = required_string(args, "entity")?;
     let id = required_string(args, "id")?;
-    let normalized_patch = if entity == "messages" {
-        shared::normalize_message_update_patch(state, id, optional_value(args, "patch"))?
-    } else {
-        shared::normalize_update_patch(entity, optional_value(args, "patch"))?
-    };
-    state.storage.patch(entity, id, normalized_patch)
+    if entity == "messages" {
+        return shared::patch_message_update(state, id, optional_value(args, "patch"));
+    }
+    state.storage.patch(
+        entity,
+        id,
+        shared::normalize_update_patch(entity, optional_value(args, "patch"))?,
+    )
 }
 
 fn storage_delete(state: &AppState, args: &Map<String, Value>) -> AppResult<Value> {

--- a/src-tauri/src/http_dispatch.rs
+++ b/src-tauri/src/http_dispatch.rs
@@ -802,11 +802,12 @@ fn storage_create(state: &AppState, args: &Map<String, Value>) -> AppResult<Valu
 fn storage_update(state: &AppState, args: &Map<String, Value>) -> AppResult<Value> {
     let entity = required_string(args, "entity")?;
     let id = required_string(args, "id")?;
-    state.storage.patch(
-        entity,
-        id,
-        shared::normalize_update_patch(entity, optional_value(args, "patch"))?,
-    )
+    let normalized_patch = if entity == "messages" {
+        shared::normalize_message_update_patch(state, id, optional_value(args, "patch"))?
+    } else {
+        shared::normalize_update_patch(entity, optional_value(args, "patch"))?
+    };
+    state.storage.patch(entity, id, normalized_patch)
 }
 
 fn storage_delete(state: &AppState, args: &Map<String, Value>) -> AppResult<Value> {


### PR DESCRIPTION
## Linked issue

Closes #1430

## Why this change

- Conversation message edits were saved as a `messages.content` patch, but message readback materializes `content` from the active swipe. That left the edited top-level content overwritten by stale swipe content on reload/list/read.

## What changed

- Added a storage-layer `patch_with` hook so message edits can apply the base patch and active-swipe content synchronization under one storage write lock.
- Route message updates through the same atomic helper in both embedded Tauri storage commands and the remote runtime HTTP dispatch path.
- Add Rust coverage for active-swipe edit persistence and a legacy no-swipes negative row.

## Refactor impact

Primary owner:

Rust storage

Impact areas reviewed:

- Embedded `storage_update`
- Remote runtime `/api/invoke` `storage_update`
- Message materialization from active swipes
- Legacy message rows without swipes
- Storage patch locking behavior for the message edit path

Boundary notes:

- Kept the fix in Rust storage/shared dispatch; no React, engine, or shared API boundary changes.
- Non-message entity updates still use the existing generic update normalization.

Pressure points touched:

- Rust storage command update path
- Remote runtime dispatch update path
- `FileStorage::patch_with` shared storage primitive

## Validation

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Reproduced before fix with `node scratch\issue-1430-storage-repro.mjs`: after `storage_update`, both `storage_get` and `storage_list` still returned `message actions baseline` from the stale active swipe.
- Verified after final CodeRabbit follow-up with `node scratch\issue-1430-storage-repro.mjs --expect-fixed` against a freshly restarted local remote runtime: `storage_get`, `storage_list`, and active swipe content all returned `message actions edited`.
- Ran `cargo test --manifest-path src-tauri/Cargo.toml message_content_update_patch --lib` after the atomic storage follow-up: passed.
- Ran `cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- -D warnings` after the atomic storage follow-up: passed.
- Ran `pnpm check` after the atomic storage follow-up: passed.
- Ran `graphify update .`; the command completed, but the generated `graphify-out` cache/report diff was reverted from this PR because it rewrote stale generated output unrelated to the narrow storage fix.
- Ran Bunny/maintainer pass: diff is two commits, four source files, no unrelated working-tree files, no server `console.*`, `git diff --check` passed, and `scratch/bugfix-verification.json` proof gate passed locally.
- Addressed CodeRabbit's read-then-write concurrency concern by moving active-swipe synchronization into `FileStorage::patch_with`; the original inline thread is now outdated.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- Not applicable; this is a storage persistence bug with runtime command proof rather than a visible UI rendering change.
