### PR TITLE
Fix Conversation provider page errors

### DIFF
--- a/src/features/modes/conversation/components/ConversationInput.tsx
+++ b/src/features/modes/conversation/components/ConversationInput.tsx
@@ -760,13 +760,17 @@ export function ConversationInput({
       return;
     }
 
-    await generate({
-      chatId: activeChatId,
-      connectionId: null,
-      userMessage: message,
-      ...(pendingAttachments.length ? { attachments: pendingAttachments } : {}),
-      ...(mentioned.length ? { mentionedCharacterNames: mentioned } : {}),
-    });
+    try {
+      await generate({
+        chatId: activeChatId,
+        connectionId: null,
+        userMessage: message,
+        ...(pendingAttachments.length ? { attachments: pendingAttachments } : {}),
+        ...(mentioned.length ? { mentionedCharacterNames: mentioned } : {}),
+      });
+    } catch {
+      // useGenerate owns provider-failure UI feedback; aborts are an expected Stop generating path.
+    }
   }, [
     activeChatId,
     attachments,


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #1433

## Why this change

- Conversation send failures from provider errors and expected cancellation were escaping the input handler as unhandled browser `pageerror` events after the provider/cancel fixes.

## What changed

- Catch `generate(...)` rejections from the Conversation main Send/Enter path after `useGenerate` has already handled provider-failure UI feedback and Stop generating cleanup.

## Refactor impact

Primary owner:

- chat mode

Impact areas reviewed:

- Conversation input send path
- Runtime generation error/cancel handling contract
- Shared chat input behavior for the analogous guarded send path

Boundary notes:

- UI-only fix in `src/features`; no `src/engine`, `src/shared/api`, or `src-tauri` boundary changes.

Pressure points touched:

- Conversation mode input surface only.

## Validation

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Focused Playwright proof against `http://127.0.0.1:5173`, remote runtime `http://127.0.0.1:8787`, and fake OpenAI provider `http://127.0.0.1:8899/v1` covered provider 500, 429, malformed JSON, slow stream Stop generating, and timeout Stop generating. Result: `pageErrors: []`.
- Reviewer-visible JSON proof: https://gist.github.com/cha1latte/7c1581b2031caac9b7f74a0c4c488794
- Local proof artifacts: `scratch/conversation-qa-2026-05-27T19-37-43-201Z/console-errors-new.json` reproduced the original `Error: [object Object]` and `AbortError: signal is aborted without reason`; `scratch/issue-1433-provider-pageerrors-2026-05-27T20-01-36-949Z/result.json` verifies the fixed path.
- `pnpm check` passed locally after rebasing onto current `upstream/refactor`.
- `pnpm build` passed locally after rebasing onto current `upstream/refactor`.
- `graphify update .` was attempted but could not run because `graphify` is not installed/on PATH in this environment.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- No visible UI layout change. The relevant UI evidence is the browser event proof above showing the provider/cancel flow no longer emits unhandled `pageerror` events.
