### PR TITLE
game: ignore blank turn sends

### DIFF
--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -121,7 +121,7 @@ const DEFAULT_LOREBOOK_KEEPER_RUN_INTERVAL = BUILT_IN_AGENT_RUN_INTERVAL_DEFAULT
 const CONTINUE_ASSISTANT_RESPONSE_INSTRUCTION =
   "[Generation instruction: continue from the latest assistant message. Do not repeat or summarize the previous response; pick up naturally from where it stopped.]";
 
-function inputUserMessage(input: StartGenerationInput): string {
+export function inputUserMessage(input: StartGenerationInput): string {
   return readString(input.message) || readString(input.userMessage);
 }
 

--- a/src/engine/modes/game/turn/game-turn.service.test.ts
+++ b/src/engine/modes/game/turn/game-turn.service.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { GenerationEngineDeps, StartGenerationInput } from "../../../generation/start-generation";
+import { startGeneration } from "../../../generation/start-generation";
+import { startGameTurnGeneration } from "./game-turn.service";
+
+vi.mock("../../../generation/start-generation", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../generation/start-generation")>();
+  return {
+    ...actual,
+    startGeneration: vi.fn(async function* (_deps: GenerationEngineDeps, input: StartGenerationInput) {
+      yield { type: "phase" as const, data: input.generationGuideSource };
+    }),
+  };
+});
+
+function gameDeps() {
+  const storageGet = vi.fn(async () => ({
+    id: "chat-1",
+    mode: "game",
+    metadata: { gameSessionStatus: "active" },
+  }));
+  return {
+    deps: {
+      storage: { get: storageGet },
+      llm: {},
+      integrations: {},
+    } as unknown as GenerationEngineDeps,
+    storageGet,
+  };
+}
+
+async function drain(stream: AsyncGenerator<unknown>) {
+  const events: unknown[] = [];
+  for await (const event of stream) events.push(event);
+  return events;
+}
+
+describe("startGameTurnGeneration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("no-ops explicit whitespace-only player turns before storage or model work", async () => {
+    const { deps, storageGet } = gameDeps();
+
+    const events = await drain(startGameTurnGeneration(deps, { chatId: "chat-1", kind: "turn", userMessage: " \n\t " }));
+
+    expect(events).toEqual([]);
+    expect(storageGet).not.toHaveBeenCalled();
+    expect(startGeneration).not.toHaveBeenCalled();
+  });
+
+  it("still allows passive game turn retries when no player message was supplied", async () => {
+    const { deps, storageGet } = gameDeps();
+
+    const events = await drain(startGameTurnGeneration(deps, { chatId: "chat-1", kind: "turn" }));
+
+    expect(events).toEqual([{ type: "phase", data: "game_turn" }]);
+    expect(storageGet).toHaveBeenCalledWith("chats", "chat-1");
+    expect(startGeneration).toHaveBeenCalledWith(
+      deps,
+      expect.objectContaining({ chatId: "chat-1", kind: "turn", generationGuideSource: "game_turn" }),
+      undefined,
+    );
+  });
+
+  it("allows attachment-only player turns", async () => {
+    const { deps } = gameDeps();
+
+    const events = await drain(
+      startGameTurnGeneration(deps, {
+        chatId: "chat-1",
+        kind: "turn",
+        userMessage: " ",
+        attachments: [{ type: "image/png", data: "data:image/png;base64,abc" }],
+      }),
+    );
+
+    expect(events).toEqual([{ type: "phase", data: "game_turn" }]);
+    expect(startGeneration).toHaveBeenCalledWith(
+      deps,
+      expect.objectContaining({ chatId: "chat-1", kind: "turn", generationGuideSource: "game_turn" }),
+      undefined,
+    );
+  });
+});

--- a/src/engine/modes/game/turn/game-turn.service.ts
+++ b/src/engine/modes/game/turn/game-turn.service.ts
@@ -1,5 +1,5 @@
 import type { GenerationEngineDeps, StartGenerationInput } from "../../../generation/start-generation";
-import { startGeneration } from "../../../generation/start-generation";
+import { inputUserMessage, startGeneration } from "../../../generation/start-generation";
 import { isRecord, parseRecord, readString, type JsonRecord } from "../../../generation/runtime-records";
 
 export type GameTurnKind = "start" | "turn" | "retry";
@@ -24,6 +24,15 @@ function gameGuideSourceFor(kind: GameTurnKind): "game_start" | "game_turn" | "g
   return "game_turn";
 }
 
+function hasExplicitBlankUserMessage(input: StartGameTurnInput): boolean {
+  if (input.message == null && input.userMessage == null) return false;
+  return !inputUserMessage(input).trim();
+}
+
+function hasAttachments(input: StartGameTurnInput): boolean {
+  return Array.isArray(input.attachments) && input.attachments.length > 0;
+}
+
 function assertGameChat(chat: JsonRecord, kind: GameTurnKind): void {
   const mode = readString(chat.mode || chat.chatMode);
   if (mode !== "game") {
@@ -44,6 +53,7 @@ export async function* startGameTurnGeneration(
 ) {
   const chatId = readString(input.chatId).trim();
   if (!chatId) throw new Error("chatId is required");
+  if (input.kind === "turn" && hasExplicitBlankUserMessage(input) && !hasAttachments(input)) return;
 
   const rawChat = await deps.storage.get("chats", chatId);
   if (!isRecord(rawChat)) throw new Error("Chat was not found.");

--- a/src/features/modes/game/components/GameSurface.tsx
+++ b/src/features/modes/game/components/GameSurface.tsx
@@ -6729,6 +6729,7 @@ export function GameSurface({
       options?: { commitPendingMove?: boolean },
     ) => {
       if (!sessionInteractive) return;
+      if (!message.trim() && !attachments?.length) return;
       audioManager.unlock();
       // Commit a pending interrupt: persist the truncated GM message before generating
       // so the server-side prompt build doesn't see segments the player never read. We


### PR DESCRIPTION
## Linked issue

Closes #1449

## Why this change

Whitespace-only input in Game mode could reach the Game turn generation path and create persisted messages instead of behaving like an empty send.

## What changed

- Added a Game turn engine guard that no-ops explicit blank player turns before storage/model work.
- Added a GameSurface callback guard so blank sends do not commit interrupt/map side effects.
- Added focused Game turn tests for whitespace-only, passive no-message, and attachment-only turn behavior.
- Refreshed Graphify output after the code change.

## Refactor impact

Primary owner:

Game mode / game turn engine.

Impact areas reviewed:

- Game mode send flow.
- Engine generation entrypoint for Game turns.
- Attachment-only Game turns.
- Passive Game turn retry/continue path with omitted user message.

Boundary notes:

- Engine stays React-free.
- Feature UI only adds a mode-owned callback guard.
- No shared API, Rust, or remote-runtime routing changes.

Pressure points touched:

- GameSurface.
- Game turn generation service.

## Validation

- [x] `pnpm check` passes locally
- [x] `pnpm typecheck` passes locally
- [x] `pnpm build` passes locally
- [x] `pnpm check:architecture` passes locally
- [x] `pnpm check:docs` passes locally
- [x] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [x] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [x] Remote runtime smoke checked when relevant

### Manual verification notes

- Ran `pnpm test -- src/engine/modes/game/turn/game-turn.service.test.ts`; Vitest completed with 44 files / 267 tests passing under repo config.
- Ran `graphify update .` after code changes.
- No browser/manual runtime pass was performed.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs changes needed for this narrow bug fix; repo guidance unchanged.

## UI evidence

No screenshots or recordings attached. Unit coverage proves the core no-persist/no-model path for explicit whitespace-only Game turns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Empty or whitespace-only game turns are now prevented from being submitted, preventing unnecessary processing.
  * Game turns cannot be sent without either message content or attachments, ensuring all submissions are meaningful.

* **Tests**
  * Added comprehensive test suite covering game turn submission validation for empty messages, whitespace-only messages, and attachment-only scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1450?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->