### PR TITLE
Fix Game whitespace-only turns

### DIFF
--- a/src/engine/modes/game/turn/game-turn.service.test.ts
+++ b/src/engine/modes/game/turn/game-turn.service.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { IntegrationGateway } from "../../../capabilities/integrations";
 import type { LlmGateway } from "../../../capabilities/llm";
 import type { StorageGateway } from "../../../capabilities/storage";
+import type { PromptAttachment } from "../../../generation/generate-route-utils";
 import { startGameTurnGeneration } from "./game-turn.service";
 
 function depsForGameChat() {
@@ -70,6 +71,7 @@ describe("startGameTurnGeneration", () => {
 
   it("keeps attachment-only player turns eligible for generation", async () => {
     const { deps, listChatMessages } = depsForGameChat();
+    const textAttachment: PromptAttachment = { type: "text/plain", data: "note" };
 
     await expect(() =>
       drain(
@@ -78,7 +80,7 @@ describe("startGameTurnGeneration", () => {
           connectionId: "connection-1",
           kind: "turn",
           userMessage: " ",
-          attachments: [{ type: "text/plain", data: "note" }],
+          attachments: [textAttachment],
         }),
       ),
     ).rejects.toThrow("listChatMessages should not be called");

--- a/src/engine/modes/game/turn/game-turn.service.test.ts
+++ b/src/engine/modes/game/turn/game-turn.service.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from "vitest";
+import type { IntegrationGateway } from "../../../capabilities/integrations";
+import type { LlmGateway } from "../../../capabilities/llm";
+import type { StorageGateway } from "../../../capabilities/storage";
+import { startGameTurnGeneration } from "./game-turn.service";
+
+function depsForGameChat() {
+  const get = vi.fn(async (entity: string, id: string) => {
+    if (entity === "chats" && id === "chat-1") {
+      return {
+        id: "chat-1",
+        mode: "game",
+        connectionId: "connection-1",
+        characterIds: ["char-1"],
+        metadata: { gameSessionStatus: "active" },
+      };
+    }
+    if (entity === "connections" && id === "connection-1") {
+      return { id: "connection-1", model: "test-model", defaultParameters: {} };
+    }
+    return null;
+  });
+  const listChatMessages = vi.fn(async () => {
+    throw new Error("listChatMessages should not be called");
+  });
+  const createChatMessage = vi.fn(async () => {
+    throw new Error("createChatMessage should not be called");
+  });
+  const stream = vi.fn(async function* () {
+    throw new Error("llm.stream should not be called");
+  });
+
+  return {
+    deps: {
+      storage: { get, listChatMessages, createChatMessage } as Partial<StorageGateway> as StorageGateway,
+      llm: { stream } as Partial<LlmGateway> as LlmGateway,
+      integrations: {} as Partial<IntegrationGateway> as IntegrationGateway,
+    },
+    get,
+    listChatMessages,
+    createChatMessage,
+    stream,
+  };
+}
+
+async function drain(stream: AsyncGenerator<unknown>) {
+  for await (const _event of stream) {
+    // Exhaust the generator so attempted side effects become visible.
+  }
+}
+
+describe("startGameTurnGeneration", () => {
+  it("does not start generation for a whitespace-only player turn", async () => {
+    const { deps, get, listChatMessages, createChatMessage, stream } = depsForGameChat();
+
+    await drain(
+      startGameTurnGeneration(deps, {
+        chatId: "chat-1",
+        connectionId: "connection-1",
+        kind: "turn",
+        userMessage: "   \n  ",
+      }),
+    );
+
+    expect(get).toHaveBeenCalledWith("chats", "chat-1");
+    expect(listChatMessages).not.toHaveBeenCalled();
+    expect(createChatMessage).not.toHaveBeenCalled();
+    expect(stream).not.toHaveBeenCalled();
+  });
+
+  it("keeps attachment-only player turns eligible for generation", async () => {
+    const { deps, listChatMessages } = depsForGameChat();
+
+    await expect(() =>
+      drain(
+        startGameTurnGeneration(deps, {
+          chatId: "chat-1",
+          connectionId: "connection-1",
+          kind: "turn",
+          userMessage: " ",
+          attachments: [{ type: "text/plain", data: "note" }],
+        }),
+      ),
+    ).rejects.toThrow("listChatMessages should not be called");
+    expect(listChatMessages).toHaveBeenCalled();
+  });
+});

--- a/src/engine/modes/game/turn/game-turn.service.ts
+++ b/src/engine/modes/game/turn/game-turn.service.ts
@@ -37,6 +37,12 @@ function assertGameChat(chat: JsonRecord, kind: GameTurnKind): void {
   }
 }
 
+function hasPlayerTurnInput(input: StartGameTurnInput): boolean {
+  const text = readString(input.message).trim() || readString(input.userMessage).trim();
+  const attachments = Array.isArray(input.attachments) ? input.attachments : [];
+  return !!text || attachments.length > 0;
+}
+
 export async function* startGameTurnGeneration(
   deps: GenerationEngineDeps,
   input: StartGameTurnInput,
@@ -49,6 +55,7 @@ export async function* startGameTurnGeneration(
   if (!isRecord(rawChat)) throw new Error("Chat was not found.");
   const chat = rawChat;
   assertGameChat(chat, input.kind);
+  if (input.kind === "turn" && !hasPlayerTurnInput(input)) return;
 
   const generationInput: StartGenerationInput = {
     ...input,

--- a/src/features/modes/game/components/GameSurface.tsx
+++ b/src/features/modes/game/components/GameSurface.tsx
@@ -4552,12 +4552,15 @@ export function GameSurface({
   const sendMessage = useCallback(
     (message: string, attachments?: Array<{ type: string; data: string }>) => {
       if ((chatMeta.gameSessionStatus as string) === "concluded") return;
+      const trimmedMessage = message.trim();
+      const hasAttachments = !!attachments?.length;
+      if (!trimmedMessage && !hasAttachments) return;
       generateGameTurn({
         chatId: activeChatId,
         connectionId: null,
         kind: "turn",
-        userMessage: formatTextQuotes(message, quoteFormat),
-        ...(attachments?.length ? { attachments } : {}),
+        userMessage: formatTextQuotes(trimmedMessage, quoteFormat),
+        ...(hasAttachments ? { attachments } : {}),
       });
     },
     [activeChatId, chatMeta.gameSessionStatus, generateGameTurn, quoteFormat],


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #1449

## Why this change

- Game mode could accept a whitespace-only player turn and persist/generate extra messages instead of treating the send as a no-op.

## What changed

- Trim Game turn text at the Game surface send boundary and no-op empty text when there are no attachments.
- Add a React-free Game turn service guard so `kind: "turn"` requests with no player text and no attachments do not enter generation.
- Add a focused regression test for whitespace-only Game turns and attachment-only turns.

## Refactor impact

Primary owner:

Game mode / engine generation.

Impact areas reviewed:

- Game input send path
- Game turn generation service
- Remote runtime QA core flow

Boundary notes:

- UI stays in `src/features`.
- Product turn validation lives in `src/engine`.
- No storage schema, shared API, Rust runtime, dependency, or provider protocol changes.

Pressure points touched:

- `GameSurface`
- Game turn generation service

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

Codex verification run:

- `pnpm exec vitest run src/engine/modes/game/turn/game-turn.service.test.ts` passed.
- `MARINARA_QA_ONLY_BLOCKS=core-flow MARINARA_QA_OUT_DIR=scratch/game-qa-fix-1449-before node scratch/game-qa-runner.mjs` reproduced the original whitespace failure.
- `MARINARA_QA_ONLY_BLOCKS=core-flow MARINARA_QA_OUT_DIR=scratch/game-qa-fix-1449-after-2 node scratch/game-qa-runner.mjs` passed with `bugs: 0`.
- `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\game-qa-fix-1449-after-2\ledger.json` passed.
- `pnpm check` passed.

Non-blocking tooling limitation:

- `graphify update .` timed out twice, including a longer retry.
- `graphify update . --no-cluster` also timed out.
- Orphaned Graphify/Python processes were stopped after each timeout.

Evidence note:

- Before/after screenshots are local-only because GitHub gist upload rejected PNG binaries.
- The core claim is still covered by the targeted browser QA ledger, proof gate, local unit test, `pnpm check`, and passing GitHub CI.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

Local evidence paths:

- Before: `scratch/game-qa-fix-1449-before/core-flow-whitespace-created-message.png`
- After: `scratch/game-qa-fix-1449-after-2/core-flow-after-reload.png`

These screenshots are not GitHub-renderable from the PR body; the automated browser QA and CI results above are the reviewer-visible proof for the core fix.
