### PR TITLE
Fix Game QA console errors

### DIFF
--- a/src/features/modes/game/components/GameSurface.tsx
+++ b/src/features/modes/game/components/GameSurface.tsx
@@ -4384,14 +4384,18 @@ export function GameSurface({
 
   const retryGeneration = useCallback(() => {
     setGenerationFailed(false);
-    generateGameTurn({ chatId: activeChatId, connectionId: null, kind: "turn" });
+    void generateGameTurn({ chatId: activeChatId, connectionId: null, kind: "turn" }).catch(() => {
+      // Generation UI already shows the recoverable error state.
+    });
   }, [activeChatId, generateGameTurn]);
 
   const generateInitialGameTurn = useCallback(() => {
-    generateGameTurn({
+    void generateGameTurn({
       chatId: activeChatId,
       connectionId: null,
       kind: "start",
+    }).catch(() => {
+      // Generation UI already shows the recoverable error state.
     });
   }, [activeChatId, generateGameTurn]);
 
@@ -4555,12 +4559,14 @@ export function GameSurface({
       const trimmedMessage = message.trim();
       const hasAttachments = !!attachments?.length;
       if (!trimmedMessage && !hasAttachments) return;
-      generateGameTurn({
+      void generateGameTurn({
         chatId: activeChatId,
         connectionId: null,
         kind: "turn",
         userMessage: formatTextQuotes(trimmedMessage, quoteFormat),
         ...(hasAttachments ? { attachments } : {}),
+      }).catch(() => {
+        // Generation UI already shows the recoverable error state.
       });
     },
     [activeChatId, chatMeta.gameSessionStatus, generateGameTurn, quoteFormat],

--- a/src/features/modes/shared/chat-ui/components/ChatSettingsDrawer.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatSettingsDrawer.tsx
@@ -6129,25 +6129,29 @@ function AdvancedParametersSection({
 
   return (
     <div className="border-b border-[var(--border)]">
-      <button
-        onClick={() => setExpanded((o) => !o)}
-        className="flex w-full items-center gap-2 px-4 py-3 text-left transition-colors hover:bg-[var(--accent)]/50"
-      >
-        <span className="text-[var(--muted-foreground)]">
-          <Settings2 size="0.875rem" />
-        </span>
-        <span className="flex-1 text-xs font-semibold">Advanced Parameters</span>
-        <span onClick={(e) => e.stopPropagation()}>
+      <div className="flex w-full items-center gap-2 px-4 py-3 transition-colors hover:bg-[var(--accent)]/50">
+        <button
+          type="button"
+          onClick={() => setExpanded((o) => !o)}
+          aria-expanded={expanded}
+          className="flex min-w-0 flex-1 items-center gap-2 text-left"
+        >
+          <span className="text-[var(--muted-foreground)]">
+            <Settings2 size="0.875rem" />
+          </span>
+          <span className="flex-1 text-xs font-semibold">Advanced Parameters</span>
+          <ChevronDown
+            size="0.75rem"
+            className={cn("text-[var(--muted-foreground)] transition-transform", expanded && "rotate-180")}
+          />
+        </button>
+        <span className="shrink-0">
           <HelpTooltip
             text="Override generation parameters for this chat. Only change these if you know what you're doing."
             side="left"
           />
         </span>
-        <ChevronDown
-          size="0.75rem"
-          className={cn("text-[var(--muted-foreground)] transition-transform", expanded && "rotate-180")}
-        />
-      </button>
+      </div>
       {expanded && (
         <div className="px-4 pb-3 space-y-3">
           <GenerationParametersFields


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #1452
Closes #1453

## Why this change

- The post-#1449 Game QA sweep found two confirmed console failures: provider/runtime recovery rows emitted uncaught `pageerror` events, and opening the Game settings drawer emitted React's nested `<button>` validation error from Advanced Parameters.

## What changed

- Catch fire-and-forget `generateGameTurn(...)` rejections in Game setup/retry/send callbacks after the generation UI has already rendered the recoverable toast/error state.
- Split the Advanced Parameters drawer header so the collapsible header button no longer contains `HelpTooltip`'s own button.

## Refactor impact

Primary owner:

Game mode / shared mode UI

Impact areas reviewed:

- Game turn generation UI boundary
- Game settings drawer
- Shared chat settings Advanced Parameters section

Boundary notes:

- No engine, storage schema, provider protocol, prompt assembly, remote runtime, or Rust changes.
- The Game generation contract is unchanged; this only handles rejected UI promises that were already surfaced to the user by `runGenerationWithUi`.

Pressure points touched:

- `GameSurface`
- `ChatSettingsDrawer`

## Validation

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Codex ran the focused Game QA subset against the web shell + remote runtime:
  - `MARINARA_QA_OUT_DIR=scratch/game-qa-console-fix-focused MARINARA_QA_ONLY_BLOCKS=core-flow,game-systems,failure-recovery node scratch\game-qa-runner.mjs`
  - The rerun passed the provider 500, provider 429, malformed provider, timeout, runtime offline mid-turn, deleted active game id, and stale active game id recovery rows.
  - `scratch/game-qa-console-fix-focused/console.json` contained no `pageerror` entries and no non-intentional React/error console entries after the fix.
- Codex ran `pnpm check`, which passed.
- Codex ran `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch/bugfix-verification.json`, which passed.
- `graphify update .` was attempted but timed out after about 10 minutes in this shell; no Graphify output is included in this PR.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

No GitHub-renderable screenshots are attached. The proof for this bug is the before/after console audit:

- Before: `scratch/game-qa-post-1449-full-clean/console.json`
- After: `scratch/game-qa-console-fix-focused/console.json`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved error handling in game turn generation workflows to prevent unhandled promise rejections while maintaining existing error states.
  * Enhanced Advanced Parameters section with proper button semantics and improved tooltip accessibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1454?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->