### PR TITLE
Add haptics API wrapper

### DIFF
--- a/src/features/runtime/haptics/hooks/use-haptic.ts
+++ b/src/features/runtime/haptics/hooks/use-haptic.ts
@@ -2,7 +2,7 @@
 // Hook: Haptic Feedback (Buttplug.io / Intiface Central)
 // ──────────────────────────────────────────────
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { invokeTauri } from "../../../../shared/api/tauri-client";
+import { hapticsApi } from "../../../../shared/api/haptics-api";
 import type { HapticStatus, HapticDeviceCommand } from "../../../../engine/contracts/types/haptic";
 
 const HAPTIC_KEY = ["haptic", "status"] as const;
@@ -12,7 +12,7 @@ export const HAPTIC_INTIFACE_URL_STORAGE_KEY = "marinara_haptic_intiface_url";
 export function useHapticStatus() {
   return useQuery<HapticStatus>({
     queryKey: HAPTIC_KEY,
-    queryFn: () => invokeTauri<HapticStatus>("haptic_status"),
+    queryFn: () => hapticsApi.status(),
     refetchInterval: () => (document.hidden ? false : 15_000), // Pause while tab is hidden
   });
 }
@@ -21,7 +21,7 @@ export function useHapticStatus() {
 export function useHapticConnect() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (url?: string) => invokeTauri<HapticStatus>("haptic_connect", { body: url ? { url } : null }),
+    mutationFn: (url?: string) => hapticsApi.connect(url),
     onSuccess: () => qc.invalidateQueries({ queryKey: HAPTIC_KEY }),
   });
 }
@@ -30,7 +30,7 @@ export function useHapticConnect() {
 export function useHapticDisconnect() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: () => invokeTauri<HapticStatus>("haptic_disconnect"),
+    mutationFn: () => hapticsApi.disconnect(),
     onSuccess: () => qc.invalidateQueries({ queryKey: HAPTIC_KEY }),
   });
 }
@@ -39,7 +39,7 @@ export function useHapticDisconnect() {
 export function useHapticStartScan() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: () => invokeTauri("haptic_start_scan"),
+    mutationFn: () => hapticsApi.startScan(),
     onSuccess: () => qc.invalidateQueries({ queryKey: HAPTIC_KEY }),
   });
 }
@@ -48,7 +48,7 @@ export function useHapticStartScan() {
 export function useHapticStopScan() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: () => invokeTauri("haptic_stop_scan"),
+    mutationFn: () => hapticsApi.stopScan(),
     onSuccess: () => qc.invalidateQueries({ queryKey: HAPTIC_KEY }),
   });
 }
@@ -56,13 +56,13 @@ export function useHapticStopScan() {
 /** Send a manual command to a device. */
 export function useHapticCommand() {
   return useMutation({
-    mutationFn: (command: HapticDeviceCommand) => invokeTauri("haptic_command", { command }),
+    mutationFn: (command: HapticDeviceCommand) => hapticsApi.command(command),
   });
 }
 
 /** Stop all devices. */
 export function useHapticStopAll() {
   return useMutation({
-    mutationFn: () => invokeTauri("haptic_stop_all"),
+    mutationFn: () => hapticsApi.stopAll(),
   });
 }

--- a/src/shared/api/haptics-api.test.ts
+++ b/src/shared/api/haptics-api.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { hapticsApi } from "./haptics-api";
+import { invokeTauri } from "./tauri-client";
+
+vi.mock("./tauri-client", () => ({
+  invokeTauri: vi.fn(),
+}));
+
+describe("hapticsApi", () => {
+  const invokeMock = vi.mocked(invokeTauri);
+
+  beforeEach(() => {
+    invokeMock.mockReset();
+  });
+
+  it("keeps haptic connection commands behind a focused API wrapper", async () => {
+    await hapticsApi.status();
+    await hapticsApi.connect("ws://127.0.0.1:12345");
+    await hapticsApi.connect();
+    await hapticsApi.disconnect();
+
+    expect(invokeMock).toHaveBeenNthCalledWith(1, "haptic_status");
+    expect(invokeMock).toHaveBeenNthCalledWith(2, "haptic_connect", {
+      body: { url: "ws://127.0.0.1:12345" },
+    });
+    expect(invokeMock).toHaveBeenNthCalledWith(3, "haptic_connect", { body: null });
+    expect(invokeMock).toHaveBeenNthCalledWith(4, "haptic_disconnect");
+  });
+
+  it("passes scan and device commands through without reshaping payloads", async () => {
+    const command = {
+      deviceIndex: "all",
+      action: "vibrate",
+      intensity: 0.45,
+      duration: 1.5,
+    } as const;
+
+    await hapticsApi.startScan();
+    await hapticsApi.stopScan();
+    await hapticsApi.command(command);
+    await hapticsApi.stopAll();
+
+    expect(invokeMock).toHaveBeenNthCalledWith(1, "haptic_start_scan");
+    expect(invokeMock).toHaveBeenNthCalledWith(2, "haptic_stop_scan");
+    expect(invokeMock).toHaveBeenNthCalledWith(3, "haptic_command", { command });
+    expect(invokeMock).toHaveBeenNthCalledWith(4, "haptic_stop_all");
+  });
+});

--- a/src/shared/api/haptics-api.ts
+++ b/src/shared/api/haptics-api.ts
@@ -1,0 +1,13 @@
+import type { HapticDeviceCommand, HapticStatus } from "../../engine/contracts/types/haptic";
+import { invokeTauri } from "./tauri-client";
+
+export const hapticsApi = {
+  status: () => invokeTauri<HapticStatus>("haptic_status"),
+  connect: (url?: string) => invokeTauri<HapticStatus>("haptic_connect", { body: url ? { url } : null }),
+  disconnect: () => invokeTauri<HapticStatus>("haptic_disconnect"),
+  startScan: <T = unknown>() => invokeTauri<T>("haptic_start_scan"),
+  stopScan: <T = unknown>() => invokeTauri<T>("haptic_stop_scan"),
+  command: <T = unknown>(command: HapticDeviceCommand | Record<string, unknown>) =>
+    invokeTauri<T>("haptic_command", { command }),
+  stopAll: <T = unknown>() => invokeTauri<T>("haptic_stop_all"),
+};

--- a/src/shared/api/integration-gateway.ts
+++ b/src/shared/api/integration-gateway.ts
@@ -1,4 +1,5 @@
 import type { IntegrationGateway } from "../../engine/capabilities/integrations";
+import { hapticsApi } from "./haptics-api";
 import { imageGenerationApi } from "./image-generation-api";
 import { spotifyApi } from "./integration-utility-api";
 import { invokeTauri } from "./tauri-client";
@@ -18,8 +19,8 @@ export const integrationGateway: IntegrationGateway = {
     volume: <T = unknown>(input: Record<string, unknown>) => spotifyApi.volume(input) as Promise<T>,
   },
   haptic: {
-    command: <T = unknown>(input: Record<string, unknown>) => invokeTauri<T>("haptic_command", { command: input }),
-    stopAll: <T = unknown>() => invokeTauri<T>("haptic_stop_all"),
+    command: <T = unknown>(input: Record<string, unknown>) => hapticsApi.command<T>(input),
+    stopAll: <T = unknown>() => hapticsApi.stopAll<T>(),
   },
   customTools: {
     execute: <T = unknown>(input: { toolName: string; arguments: unknown }) =>

--- a/src/shared/api/tauri-client.test.ts
+++ b/src/shared/api/tauri-client.test.ts
@@ -45,18 +45,26 @@ describe("invokeTauri remote runtime routing", () => {
     expect(tauriInvoke).not.toHaveBeenCalled();
   });
 
-  it("keeps local-only haptic commands on embedded Tauri when remote runtime is configured", async () => {
+  it.each([
+    ["haptic_status", undefined],
+    ["haptic_connect", { body: { url: "ws://127.0.0.1:12345" } }],
+    ["haptic_disconnect", undefined],
+    ["haptic_start_scan", undefined],
+    ["haptic_stop_scan", undefined],
+    ["haptic_command", { command: { deviceIndex: "all", action: "stop" } }],
+    ["haptic_stop_all", undefined],
+  ])("keeps local-only %s on embedded Tauri when remote runtime is configured", async (command, args) => {
     useUIStore.setState({ remoteRuntimeUrl: "https://remote.example/runtime" });
     tauriInvoke.mockResolvedValueOnce({ connected: false, serverUrl: null, scanning: false, devices: [] });
 
-    await expect(invokeTauri("haptic_status")).resolves.toEqual({
+    await expect(invokeTauri(command, args)).resolves.toEqual({
       connected: false,
       serverUrl: null,
       scanning: false,
       devices: [],
     });
 
-    expect(tauriInvoke).toHaveBeenCalledWith("haptic_status", undefined);
+    expect(tauriInvoke).toHaveBeenCalledWith(command, args);
     expect(fetchMock).not.toHaveBeenCalled();
   });
 

--- a/src/shared/api/tauri-client.test.ts
+++ b/src/shared/api/tauri-client.test.ts
@@ -45,6 +45,21 @@ describe("invokeTauri remote runtime routing", () => {
     expect(tauriInvoke).not.toHaveBeenCalled();
   });
 
+  it("keeps local-only haptic commands on embedded Tauri when remote runtime is configured", async () => {
+    useUIStore.setState({ remoteRuntimeUrl: "https://remote.example/runtime" });
+    tauriInvoke.mockResolvedValueOnce({ connected: false, serverUrl: null, scanning: false, devices: [] });
+
+    await expect(invokeTauri("haptic_status")).resolves.toEqual({
+      connected: false,
+      serverUrl: null,
+      scanning: false,
+      devices: [],
+    });
+
+    expect(tauriInvoke).toHaveBeenCalledWith("haptic_status", undefined);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("preserves Retry-After metadata from remote runtime 429 responses", async () => {
     useUIStore.setState({ remoteRuntimeUrl: "https://remote.example/runtime" });
     fetchMock.mockResolvedValueOnce(


### PR DESCRIPTION
## Linked issue

Refs #1457

## Why this change

Feature/runtime haptics were still calling raw Tauri commands directly. This moves those calls behind a focused shared API wrapper so feature code uses the same boundary pattern as the rest of the refactor lane.

## What changed

- Added `src/shared/api/haptics-api.ts` for haptic status, connection, scan, command, stop-scan, and stop-all calls.
- Updated runtime haptics hooks to call `hapticsApi` instead of importing `invokeTauri` directly.
- Updated the integration gateway haptic port to reuse the wrapper.
- Added wrapper payload tests and widened the local-only routing regression test to cover the full haptic command family.

## Refactor impact

- Primary owner area: shared API adapter / runtime haptics.
- Impact areas reviewed: runtime haptics hooks, integration gateway haptic port, remote runtime routing, Tauri haptic command names and payloads.
- Boundary notes: feature code no longer imports `tauri-client`; `hapticsApi` owns raw invoke calls; haptic commands remain desktop-native/local-only and are not added to the remote runtime allowlist; engine code continues using the integration port through `integrationGateway`.
- Pressure points touched: none of the listed generation, mode, storage, provider, or import/export pressure points.

## Validation

- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] `cargo check --manifest-path src-tauri/Cargo.toml`
- [x] `pnpm check:architecture`
- [x] Targeted/unit tests: `pnpm exec vitest run src/shared/api/haptics-api.test.ts src/shared/api/tauri-client.test.ts`
- [ ] Manual QA / app-path check completed
- [x] Not run; explained below

## Manual verification notes

Run locally before opening this draft:

- `pnpm exec vitest run src/shared/api/haptics-api.test.ts src/shared/api/tauri-client.test.ts` - 2 files, 13 tests passed.
- `pnpm typecheck` - passed.
- `pnpm check:architecture` - passed.
- `git diff --check` - passed.
- Graphify update skipped per Xel override until tracked Graphify output churn is fixed.
- Native Intiface/manual device QA was not run; this branch is intended to preserve behavior through adapter-only routing changes.

Test intent gate: added tests are intentional. `haptics-api.test.ts` pins the wrapper command names and payload shape; the widened `tauri-client.test.ts` negative control keeps every haptic command local-only under remote runtime configuration.

## Docs and release impact

No changelog update made: this repository has no `CHANGELOG.md`, and the change is an internal adapter migration with no intended user-visible behavior change.

No documentation update needed for the same reason.

## UI evidence

No UI evidence attached; this branch does not intentionally change visible UI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for haptics API operations and local command routing behavior.

* **Chores**
  * Refactored internal haptics operations to use a centralized API abstraction layer for improved code organization and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1456?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->