### PR TITLE
Add URL binary API wrapper

### DIFF
--- a/src/shared/api/tauri-client.test.ts
+++ b/src/shared/api/tauri-client.test.ts
@@ -69,12 +69,13 @@ describe("invokeTauri remote runtime routing", () => {
   });
 
   it.each([
+    ["load_url_binary", { url: "https://example.com/image.png", fallbackMime: "image/png" }],
     ["tts_config", undefined],
     ["tts_update_config", { config: { enabled: true } }],
     ["tts_voices", undefined],
     ["tts_speak", { input: { text: "hello" } }],
     ["translate_text_command", { input: { text: "bonjour", provider: "google", targetLanguage: "en" } }],
-  ])("routes remote-capable integration command %s to the configured remote runtime", async (command, args) => {
+  ])("routes remote-capable shared command %s to the configured remote runtime", async (command, args) => {
     useUIStore.setState({ remoteRuntimeUrl: "https://remote.example/runtime" });
     fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), { status: 200 }));
 

--- a/src/shared/api/url-binary-api.test.ts
+++ b/src/shared/api/url-binary-api.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+import { invokeTauri } from "./tauri-client";
+import { urlBinaryApi } from "./url-binary-api";
+
+vi.mock("./tauri-client", () => ({
+  invokeTauri: vi.fn(),
+}));
+
+const invokeMock = vi.mocked(invokeTauri);
+
+describe("urlBinaryApi", () => {
+  it("loads URL binary data through the load_url_binary command", async () => {
+    invokeMock.mockResolvedValueOnce({ base64: "aGVsbG8=", mimeType: "image/png" });
+
+    const blob = await urlBinaryApi.load("https://example.com/image.png", "application/octet-stream");
+
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.type).toBe("image/png");
+    expect(await blob.text()).toBe("hello");
+    expect(invokeMock).toHaveBeenCalledWith("load_url_binary", {
+      url: "https://example.com/image.png",
+      fallbackMime: "application/octet-stream",
+    });
+  });
+
+  it("uses the fallback MIME type when the response MIME type is missing", async () => {
+    invokeMock.mockResolvedValueOnce({ base64: "YXVkaW8=", mimeType: "" });
+
+    const blob = await urlBinaryApi.load("https://example.com/audio", "audio/mpeg");
+
+    expect(blob.type).toBe("audio/mpeg");
+  });
+
+  it.each([null, "bytes", 42, false])("rejects malformed binary responses before reading fields", async (response) => {
+    invokeMock.mockResolvedValueOnce(response);
+
+    await expect(urlBinaryApi.load("https://example.com/file")).rejects.toThrow(
+      "URL binary request returned an invalid response",
+    );
+  });
+
+  it("rejects object responses without base64 data using the response error message", async () => {
+    invokeMock.mockResolvedValueOnce({ error: "Remote file is too large" });
+
+    await expect(urlBinaryApi.load("https://example.com/file")).rejects.toThrow("Remote file is too large");
+  });
+});

--- a/src/shared/api/url-binary-api.test.ts
+++ b/src/shared/api/url-binary-api.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { invokeTauri } from "./tauri-client";
 import { urlBinaryApi } from "./url-binary-api";
 
@@ -9,6 +9,10 @@ vi.mock("./tauri-client", () => ({
 const invokeMock = vi.mocked(invokeTauri);
 
 describe("urlBinaryApi", () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+  });
+
   it("loads URL binary data through the load_url_binary command", async () => {
     invokeMock.mockResolvedValueOnce({ base64: "aGVsbG8=", mimeType: "image/png" });
 
@@ -31,7 +35,7 @@ describe("urlBinaryApi", () => {
     expect(blob.type).toBe("audio/mpeg");
   });
 
-  it.each([null, "bytes", 42, false])("rejects malformed binary responses before reading fields", async (response) => {
+  it.each([null, "bytes", 42, false, []])("rejects malformed binary responses before reading fields", async (response) => {
     invokeMock.mockResolvedValueOnce(response);
 
     await expect(urlBinaryApi.load("https://example.com/file")).rejects.toThrow(
@@ -43,5 +47,13 @@ describe("urlBinaryApi", () => {
     invokeMock.mockResolvedValueOnce({ error: "Remote file is too large" });
 
     await expect(urlBinaryApi.load("https://example.com/file")).rejects.toThrow("Remote file is too large");
+  });
+
+  it("rejects invalid base64 data with a URL binary error", async () => {
+    invokeMock.mockResolvedValueOnce({ base64: "not base64!", mimeType: "image/png" });
+
+    await expect(urlBinaryApi.load("https://example.com/file")).rejects.toThrow(
+      "URL binary request returned invalid base64 data.",
+    );
   });
 });

--- a/src/shared/api/url-binary-api.ts
+++ b/src/shared/api/url-binary-api.ts
@@ -8,7 +8,7 @@ interface UrlBinaryResponse {
 }
 
 function isUrlBinaryResponse(value: unknown): value is UrlBinaryResponse {
-  return typeof value === "object" && value !== null;
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function optionalString(value: unknown): string | undefined {
@@ -23,7 +23,12 @@ function binaryFailureMessage(response: unknown): string {
 }
 
 function base64ToBytes(base64: string): Uint8Array {
-  const binary = atob(base64);
+  let binary: string;
+  try {
+    binary = atob(base64);
+  } catch {
+    throw new Error("URL binary request returned invalid base64 data.");
+  }
   const bytes = new Uint8Array(binary.length);
   for (let index = 0; index < binary.length; index += 1) {
     bytes[index] = binary.charCodeAt(index);

--- a/src/shared/api/url-binary-api.ts
+++ b/src/shared/api/url-binary-api.ts
@@ -1,0 +1,55 @@
+import { invokeTauri } from "./tauri-client";
+
+interface UrlBinaryResponse {
+  base64?: string;
+  mimeType?: string;
+  message?: string;
+  error?: string;
+}
+
+function isUrlBinaryResponse(value: unknown): value is UrlBinaryResponse {
+  return typeof value === "object" && value !== null;
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function binaryFailureMessage(response: unknown): string {
+  if (!isUrlBinaryResponse(response)) {
+    return `URL binary request returned an invalid response: ${String(response)}`;
+  }
+  return optionalString(response.error) ?? optionalString(response.message) ?? "URL binary request did not return base64 data.";
+}
+
+function base64ToBytes(base64: string): Uint8Array {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes;
+}
+
+function bytesToArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  const buffer = new ArrayBuffer(bytes.byteLength);
+  new Uint8Array(buffer).set(bytes);
+  return buffer;
+}
+
+function base64ToBlob(base64: string, mimeType: string): Blob {
+  return new Blob([bytesToArrayBuffer(base64ToBytes(base64))], { type: mimeType });
+}
+
+export const urlBinaryApi = {
+  load: async (url: string, fallbackMimeType = "application/octet-stream"): Promise<Blob> => {
+    const response = await invokeTauri<unknown>("load_url_binary", {
+      url,
+      fallbackMime: fallbackMimeType,
+    });
+    if (!isUrlBinaryResponse(response) || typeof response.base64 !== "string") {
+      throw new Error(binaryFailureMessage(response));
+    }
+    return base64ToBlob(response.base64, optionalString(response.mimeType) ?? fallbackMimeType);
+  },
+};

--- a/src/shared/lib/url-blob.test.ts
+++ b/src/shared/lib/url-blob.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { urlBinaryApi } from "../api/url-binary-api";
+import { loadUrlArrayBuffer, loadUrlBlob, urlToDataUrl } from "./url-blob";
+
+vi.mock("../api/url-binary-api", () => ({
+  urlBinaryApi: {
+    load: vi.fn(),
+  },
+}));
+
+const loadMock = vi.mocked(urlBinaryApi.load);
+
+describe("url-blob", () => {
+  beforeEach(() => {
+    loadMock.mockReset();
+  });
+
+  it("loads data URLs locally without calling the binary API", async () => {
+    const blob = await loadUrlBlob("data:text/plain;base64,aGVsbG8=");
+
+    expect(blob.type).toBe("text/plain");
+    expect(await blob.text()).toBe("hello");
+    expect(loadMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-GET binary loads before calling the binary API", async () => {
+    await expect(
+      loadUrlBlob("https://example.com/file.png", {
+        init: { method: "POST" },
+        errorMessage: "Custom load failure",
+      }),
+    ).rejects.toThrow("Custom load failure");
+
+    expect(loadMock).not.toHaveBeenCalled();
+  });
+
+  it("loads remote URLs through the URL binary API", async () => {
+    loadMock.mockResolvedValueOnce(new Blob(["image-bytes"], { type: "image/png" }));
+
+    const blob = await loadUrlBlob("https://example.com/file.png");
+
+    expect(blob.type).toBe("image/png");
+    expect(await blob.text()).toBe("image-bytes");
+    expect(loadMock).toHaveBeenCalledWith("https://example.com/file.png", "application/octet-stream");
+  });
+
+  it("uses caller error copy when a remote binary load fails", async () => {
+    loadMock.mockRejectedValueOnce(new Error("Remote file is too large"));
+
+    await expect(
+      loadUrlBlob("https://example.com/file.png", {
+        errorMessage: "Could not attach image",
+      }),
+    ).rejects.toThrow("Could not attach image");
+  });
+
+  it("converts loaded URL blobs to array buffers", async () => {
+    loadMock.mockResolvedValueOnce(new Blob(["audio"], { type: "audio/mpeg" }));
+
+    const buffer = await loadUrlArrayBuffer("https://example.com/file.mp3");
+
+    expect(new TextDecoder().decode(buffer)).toBe("audio");
+  });
+
+  it("returns existing data URLs without calling the binary API", async () => {
+    const url = "data:image/png;base64,aW1hZ2U=";
+
+    await expect(urlToDataUrl(url)).resolves.toBe(url);
+
+    expect(loadMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/shared/lib/url-blob.ts
+++ b/src/shared/lib/url-blob.ts
@@ -1,9 +1,4 @@
-import { invokeTauri } from "../api/tauri-client";
-
-type BinaryLoadResponse = {
-  base64?: string;
-  mimeType?: string;
-};
+import { urlBinaryApi } from "../api/url-binary-api";
 
 function base64ToBytes(base64: string): Uint8Array {
   const binary = atob(base64);
@@ -31,12 +26,7 @@ function blobToArrayBuffer(blob: Blob): Promise<ArrayBuffer> {
 }
 
 async function loadRemoteBlob(url: string, fallbackMimeType: string): Promise<Blob> {
-  const response = await invokeTauri<BinaryLoadResponse>("load_url_binary", {
-    url,
-    fallbackMime: fallbackMimeType,
-  });
-  const base64 = response.base64 ?? "";
-  return new Blob([bytesToArrayBuffer(base64ToBytes(base64))], { type: response.mimeType ?? fallbackMimeType });
+  return urlBinaryApi.load(url, fallbackMimeType);
 }
 
 export async function loadUrlBlob(


### PR DESCRIPTION
## Linked issue

Part of #1457

## Why this change

`src/shared/lib/url-blob.ts` still called `invokeTauri("load_url_binary")` directly. That kept the URL-binary command name, payload shape, response decoding, and malformed-response behavior inside a broad shared utility instead of a focused shared API wrapper.

This slice moves that command contract into `src/shared/api`, where remote-capable Tauri command wrappers belong, and adds failure-path coverage for the binary response contract.

## What changed

- Added `src/shared/api/url-binary-api.ts` for the `load_url_binary` command.
- Updated `src/shared/lib/url-blob.ts` to call `urlBinaryApi.load(...)` instead of raw `invokeTauri`.
- Added wrapper tests for command payloads, fallback MIME behavior, malformed responses, command error messages, and invalid base64 data.
- Added `url-blob` tests for data URLs, non-GET rejection, remote wrapper calls, caller error copy, array-buffer conversion, and `urlToDataUrl` passthrough.
- Added remote-runtime routing coverage for `load_url_binary` in the shared `invokeTauri` routing test.

## Refactor impact

Primary owner:

Shared API wrapper / frontend shared URL helper.

Impact areas reviewed:

- `src/shared/api/url-binary-api.ts`
- `src/shared/lib/url-blob.ts`
- `src/shared/api/tauri-client.test.ts`
- Existing Rust command and HTTP dispatch contract for `load_url_binary`
- Current callers of `loadUrlBlob`, `loadUrlArrayBuffer`, and `urlToDataUrl`

Boundary notes:

- Feature and shared utility callers now depend on a focused shared API wrapper instead of importing `tauri-client.ts` directly.
- `load_url_binary` was already remote-capable through `remote-runtime.ts` and `src-tauri/src/http_dispatch.rs`; this PR adds frontend routing coverage for that expectation.
- No Rust command behavior changed.

Pressure points touched:

- Shared binary URL loading used by bot browser asset loads, avatar/sprite URL conversion, GIF attachment loading, and game audio loading.

## Validation

- [x] `pnpm check` passes locally
- [x] `pnpm typecheck` passes locally
- [x] `pnpm build` passes locally
- [x] `pnpm check:architecture` passes locally
- [x] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

Agent-run local proof:

- `pnpm vitest run src/shared/api/url-binary-api.test.ts src/shared/lib/url-blob.test.ts src/shared/api/tauri-client.test.ts` passed.
- `pnpm check` passed, including architecture, frontend typecheck, Rust check, and docs.
- `pnpm test` passed: 49 test files, 315 tests.
- `git diff --check` passed.

Not run:

- Native Tauri manual QA; this slice changes TypeScript wrapper/test behavior and leaves the Rust command path unchanged.
- Graphify update; skipped per local instruction unless explicitly requested.
- Remote runtime live smoke; routing is covered by unit test, but no live remote runtime was launched.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs changes were made. This is an internal shared API wrapper migration slice with test coverage and no user-facing copy change.

## UI evidence

No UI screenshots. There is no visible UI change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for URL binary data loading functionality, including validation of payload responses, error handling, and MIME type fallback behavior.

* **Refactor**
  * Improved internal code organization for URL binary data handling with dedicated API abstraction layer.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1460?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->