### PR TITLE
[codex] Add feature-layer focused coverage

### DIFF
--- a/graphify-out/.graphify_labels.json
+++ b/graphify-out/.graphify_labels.json
@@ -268,6 +268,7 @@
   "267": "Community 267",
   "268": "Community 268",
   "270": "Community 270",
+  "272": "Community 272",
   "273": "Community 273",
   "275": "Community 275",
   "276": "Community 276",

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,16 +1,16 @@
 # Graph Report - MarinaraEngine-Refactor  (2026-05-29)
 
 ## Corpus Check
-- 858 files · ~2,840,437 words
+- 858 files · ~2,840,886 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 10501 nodes · 22783 edges · 449 communities (415 shown, 34 thin omitted)
+- 10507 nodes · 22790 edges · 450 communities (416 shown, 34 thin omitted)
 - Extraction: 99% EXTRACTED · 1% INFERRED · 0% AMBIGUOUS · INFERRED: 280 edges (avg confidence: 0.8)
 - Token cost: 0 input · 0 output
 
 ## Graph Freshness
-- Built from commit: `5fb8c74a`
+- Built from commit: `73ecb92d`
 - Run `git rev-parse HEAD` and compare to check if the graph is stale.
 - Run `graphify update .` after code changes (no API cost).
 
@@ -278,6 +278,7 @@
 - [[_COMMUNITY_Community 267|Community 267]]
 - [[_COMMUNITY_Community 268|Community 268]]
 - [[_COMMUNITY_Community 270|Community 270]]
+- [[_COMMUNITY_Community 272|Community 272]]
 - [[_COMMUNITY_Community 273|Community 273]]
 - [[_COMMUNITY_Community 275|Community 275]]
 - [[_COMMUNITY_Community 276|Community 276]]
@@ -451,7 +452,7 @@
 - `MountOnceWhenOpened()` --calls--> `cn()`  [EXTRACTED]
   src/app/shell/AppShell.tsx → src/shared/lib/utils.ts
 
-## Communities (449 total, 34 thin omitted)
+## Communities (450 total, 34 thin omitted)
 
 ### Community 0 - "Community 0"
 Cohesion: 0.00
@@ -1318,8 +1319,8 @@ Cohesion: 0.20
 Nodes (9): codeowners, dependencies, documentation, domain, iot_class, issue_tracker, name, requirements (+1 more)
 
 ### Community 225 - "Community 225"
-Cohesion: 0.24
-Nodes (9): firstSearch, refreshButton, generic_marinara_import_directs_profile_exports_to_profile_import(), marinara_lorebook_import_remaps_nested_folders_and_entry_folders(), marinara_preset_import_remaps_nested_groups_and_section_groups(), parented_record_import_rolls_back_created_records_on_failure(), record_with_field(), test_state() (+1 more)
+Cohesion: 0.18
+Nodes (10): firstSearch, refreshButton, searchInput, generic_marinara_import_directs_profile_exports_to_profile_import(), marinara_lorebook_import_remaps_nested_folders_and_entry_folders(), marinara_preset_import_remaps_nested_groups_and_section_groups(), parented_record_import_rolls_back_created_records_on_failure(), record_with_field() (+2 more)
 
 ### Community 226 - "Community 226"
 Cohesion: 0.27
@@ -1484,6 +1485,10 @@ Nodes (7): DANGER_HINTS, ENVIRONMENTAL_HINTS, generatePerceptionHints(), passive
 ### Community 270 - "Community 270"
 Cohesion: 0.25
 Nodes (6): computeTooltipStyle(), GameTutorial(), GameTutorialProps, GameTutorialStep, Rect, STEPS
+
+### Community 272 - "Community 272"
+Cohesion: 0.00
+Nodes (3): firstFlush, firstPatch, mountPatcherHarness()
 
 ### Community 273 - "Community 273"
 Cohesion: 0.22
@@ -1962,7 +1967,7 @@ Cohesion: 0.32
 Nodes (7): child, findModernNode(), readNodeVersion(), repoRoot, runner, supportsVite(), viteBin
 
 ## Knowledge Gaps
-- **3237 isolated node(s):** `arrowParens`, `endOfLine`, `printWidth`, `semi`, `singleQuote` (+3232 more)
+- **3240 isolated node(s):** `arrowParens`, `endOfLine`, `printWidth`, `semi`, `singleQuote` (+3235 more)
   These have ≤1 connection - possible missing edges or undocumented components.
 - **34 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
 
@@ -1970,13 +1975,13 @@ Nodes (7): child, findModernNode(), readNodeVersion(), repoRoot, runner, support
 _Questions this graph is uniquely positioned to answer:_
 
 - **Why does `cn()` connect `Community 97` to `Community 128`, `Community 1`, `Community 2`, `Community 384`, `Community 129`, `Community 5`, `Community 257`, `Community 4`, `Community 265`, `Community 10`, `Community 11`, `Community 12`, `Community 137`, `Community 9`, `Community 145`, `Community 19`, `Community 23`, `Community 151`, `Community 409`, `Community 26`, `Community 30`, `Community 35`, `Community 164`, `Community 165`, `Community 39`, `Community 168`, `Community 167`, `Community 42`, `Community 43`, `Community 172`, `Community 45`, `Community 40`, `Community 47`, `Community 177`, `Community 50`, `Community 51`, `Community 52`, `Community 54`, `Community 57`, `Community 61`, `Community 191`, `Community 63`, `Community 65`, `Community 68`, `Community 197`, `Community 70`, `Community 71`, `Community 205`, `Community 208`, `Community 220`, `Community 96`, `Community 98`, `Community 100`, `Community 103`, `Community 104`, `Community 105`, `Community 108`, `Community 115`, `Community 371`, `Community 247`, `Community 249`, `Community 250`, `Community 124`, `Community 126`, `Community 383`?**
-  _High betweenness centrality (0.052) - this node is a cross-community bridge._
+  _High betweenness centrality (0.049) - this node is a cross-community bridge._
 - **Why does `useUIStore` connect `Community 247` to `Community 128`, `Community 1`, `Community 2`, `Community 129`, `Community 4`, `Community 5`, `Community 10`, `Community 11`, `Community 12`, `Community 145`, `Community 19`, `Community 20`, `Community 23`, `Community 151`, `Community 26`, `Community 29`, `Community 163`, `Community 39`, `Community 168`, `Community 40`, `Community 177`, `Community 50`, `Community 54`, `Community 183`, `Community 57`, `Community 186`, `Community 60`, `Community 191`, `Community 63`, `Community 71`, `Community 201`, `Community 205`, `Community 208`, `Community 81`, `Community 90`, `Community 220`, `Community 97`, `Community 98`, `Community 104`, `Community 105`, `Community 241`, `Community 114`, `Community 124`, `Community 383`?**
-  _High betweenness centrality (0.021) - this node is a cross-community bridge._
+  _High betweenness centrality (0.022) - this node is a cross-community bridge._
 - **Why does `storageApi` connect `Community 26` to `Community 128`, `Community 4`, `Community 5`, `Community 10`, `Community 11`, `Community 12`, `Community 19`, `Community 20`, `Community 30`, `Community 33`, `Community 35`, `Community 39`, `Community 40`, `Community 168`, `Community 172`, `Community 175`, `Community 180`, `Community 181`, `Community 191`, `Community 65`, `Community 198`, `Community 78`, `Community 208`, `Community 81`, `Community 220`, `Community 98`, `Community 101`, `Community 102`, `Community 104`, `Community 105`, `Community 241`, `Community 124`, `Community 383`?**
   _High betweenness centrality (0.012) - this node is a cross-community bridge._
 - **What connects `arrowParens`, `endOfLine`, `printWidth` to the rest of the system?**
-  _3270 weakly-connected nodes found - possible documentation gaps or missing edges._
+  _3273 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Community 0` be split into smaller, more focused modules?**
   _Cohesion score 0.004395604395604396 - nodes in this community are weakly interconnected._
 - **Should `Community 1` be split into smaller, more focused modules?**

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,16 +1,16 @@
 # Graph Report - MarinaraEngine-Refactor  (2026-05-29)
 
 ## Corpus Check
-- 856 files · ~2,839,266 words
+- 858 files · ~2,840,437 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 10485 nodes · 22752 edges · 449 communities (415 shown, 34 thin omitted)
+- 10501 nodes · 22783 edges · 449 communities (415 shown, 34 thin omitted)
 - Extraction: 99% EXTRACTED · 1% INFERRED · 0% AMBIGUOUS · INFERRED: 280 edges (avg confidence: 0.8)
 - Token cost: 0 input · 0 output
 
 ## Graph Freshness
-- Built from commit: `004bad7d`
+- Built from commit: `5fb8c74a`
 - Run `git rev-parse HEAD` and compare to check if the graph is stale.
 - Run `graphify update .` after code changes (no API cost).
 
@@ -670,8 +670,8 @@ Cohesion: 0.13
 Nodes (41): parseJsonObject(), TrackerSnapshotMessageRebase, abandonRoleplayScene(), analyzeScene(), appendSceneMemory(), buildForkContinuityMessage(), buildSceneConversationContext(), characterData() (+33 more)
 
 ### Community 54 - "Community 54"
-Cohesion: 0.10
-Nodes (22): knowledgeSourcesApi, AgentEditor(), CUSTOM_AGENT_RESULT_TYPE_OPTIONS, CustomAgentResultType, getDisplayedSpotifyRedirectUri(), PHASE_META, ToolCard(), useCreateAgent() (+14 more)
+Cohesion: 0.09
+Nodes (24): knowledgeSourcesApi, AgentEditor(), CUSTOM_AGENT_RESULT_TYPE_OPTIONS, CustomAgentResultType, getDisplayedSpotifyRedirectUri(), PHASE_META, ToolCard(), useCreateAgent() (+16 more)
 
 ### Community 55 - "Community 55"
 Cohesion: 0.09
@@ -1114,8 +1114,8 @@ Cohesion: 0.17
 Nodes (9): invalid_profile_asset_payload_does_not_clear_existing_assets(), path_exists_no_follow(), profile_asset_restore_replaces_managed_asset_dirs(), profile_asset_restore_rolls_back_when_import_fails_later(), ProfileAssetTransaction, remove_path_if_exists(), restore_profile_json_assets_in_root(), RestoredProfileAssets (+1 more)
 
 ### Community 170 - "Community 170"
-Cohesion: 0.20
-Nodes (15): BinaryPayload, binaryStringToBlob(), botBrowserAssetUrl(), botBrowserBlob(), botBrowserGet(), botBrowserPost(), fetchBotBrowserAssetBlob(), ImportCharacterResult (+7 more)
+Cohesion: 0.13
+Nodes (18): BinaryPayload, binaryStringToBlob(), botBrowserAssetUrl(), botBrowserBlob(), botBrowserGet(), botBrowserPost(), fetchBotBrowserAssetBlob(), ImportCharacterResult (+10 more)
 
 ### Community 171 - "Community 171"
 Cohesion: 0.13
@@ -1318,8 +1318,8 @@ Cohesion: 0.20
 Nodes (9): codeowners, dependencies, documentation, domain, iot_class, issue_tracker, name, requirements (+1 more)
 
 ### Community 225 - "Community 225"
-Cohesion: 0.44
-Nodes (7): generic_marinara_import_directs_profile_exports_to_profile_import(), marinara_lorebook_import_remaps_nested_folders_and_entry_folders(), marinara_preset_import_remaps_nested_groups_and_section_groups(), parented_record_import_rolls_back_created_records_on_failure(), record_with_field(), test_state(), test_string()
+Cohesion: 0.24
+Nodes (9): firstSearch, refreshButton, generic_marinara_import_directs_profile_exports_to_profile_import(), marinara_lorebook_import_remaps_nested_folders_and_entry_folders(), marinara_preset_import_remaps_nested_groups_and_section_groups(), parented_record_import_rolls_back_created_records_on_failure(), record_with_field(), test_state() (+1 more)
 
 ### Community 226 - "Community 226"
 Cohesion: 0.27
@@ -1358,8 +1358,8 @@ Cohesion: 0.44
 Nodes (7): execute_custom_tool(), execute_webhook_tool(), insert_tool(), script_execution_type_returns_actionable_error(), string_bool(), test_state(), unknown_execution_type_still_rejected()
 
 ### Community 237 - "Community 237"
-Cohesion: 0.32
-Nodes (7): coerceGameStateTextFields(), coerceGameStateTextValue(), coerceGameStateTextValueInner(), GAME_STATE_TEXT_FIELDS, GAME_STATE_TEXT_OBJECT_KEYS, GameStateTextField, normalizeGameState()
+Cohesion: 0.18
+Nodes (9): coerceGameStateTextFields(), coerceGameStateTextValue(), coerceGameStateTextValueInner(), GAME_STATE_TEXT_FIELDS, GAME_STATE_TEXT_OBJECT_KEYS, GameStateTextField, patchMock, resetPatcherState() (+1 more)
 
 ### Community 238 - "Community 238"
 Cohesion: 0.18
@@ -1962,7 +1962,7 @@ Cohesion: 0.32
 Nodes (7): child, findModernNode(), readNodeVersion(), repoRoot, runner, supportsVite(), viteBin
 
 ## Knowledge Gaps
-- **3230 isolated node(s):** `arrowParens`, `endOfLine`, `printWidth`, `semi`, `singleQuote` (+3225 more)
+- **3237 isolated node(s):** `arrowParens`, `endOfLine`, `printWidth`, `semi`, `singleQuote` (+3232 more)
   These have ≤1 connection - possible missing edges or undocumented components.
 - **34 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
 
@@ -1970,13 +1970,13 @@ Nodes (7): child, findModernNode(), readNodeVersion(), repoRoot, runner, support
 _Questions this graph is uniquely positioned to answer:_
 
 - **Why does `cn()` connect `Community 97` to `Community 128`, `Community 1`, `Community 2`, `Community 384`, `Community 129`, `Community 5`, `Community 257`, `Community 4`, `Community 265`, `Community 10`, `Community 11`, `Community 12`, `Community 137`, `Community 9`, `Community 145`, `Community 19`, `Community 23`, `Community 151`, `Community 409`, `Community 26`, `Community 30`, `Community 35`, `Community 164`, `Community 165`, `Community 39`, `Community 168`, `Community 167`, `Community 42`, `Community 43`, `Community 172`, `Community 45`, `Community 40`, `Community 47`, `Community 177`, `Community 50`, `Community 51`, `Community 52`, `Community 54`, `Community 57`, `Community 61`, `Community 191`, `Community 63`, `Community 65`, `Community 68`, `Community 197`, `Community 70`, `Community 71`, `Community 205`, `Community 208`, `Community 220`, `Community 96`, `Community 98`, `Community 100`, `Community 103`, `Community 104`, `Community 105`, `Community 108`, `Community 115`, `Community 371`, `Community 247`, `Community 249`, `Community 250`, `Community 124`, `Community 126`, `Community 383`?**
-  _High betweenness centrality (0.054) - this node is a cross-community bridge._
+  _High betweenness centrality (0.052) - this node is a cross-community bridge._
 - **Why does `useUIStore` connect `Community 247` to `Community 128`, `Community 1`, `Community 2`, `Community 129`, `Community 4`, `Community 5`, `Community 10`, `Community 11`, `Community 12`, `Community 145`, `Community 19`, `Community 20`, `Community 23`, `Community 151`, `Community 26`, `Community 29`, `Community 163`, `Community 39`, `Community 168`, `Community 40`, `Community 177`, `Community 50`, `Community 54`, `Community 183`, `Community 57`, `Community 186`, `Community 60`, `Community 191`, `Community 63`, `Community 71`, `Community 201`, `Community 205`, `Community 208`, `Community 81`, `Community 90`, `Community 220`, `Community 97`, `Community 98`, `Community 104`, `Community 105`, `Community 241`, `Community 114`, `Community 124`, `Community 383`?**
-  _High betweenness centrality (0.018) - this node is a cross-community bridge._
+  _High betweenness centrality (0.021) - this node is a cross-community bridge._
 - **Why does `storageApi` connect `Community 26` to `Community 128`, `Community 4`, `Community 5`, `Community 10`, `Community 11`, `Community 12`, `Community 19`, `Community 20`, `Community 30`, `Community 33`, `Community 35`, `Community 39`, `Community 40`, `Community 168`, `Community 172`, `Community 175`, `Community 180`, `Community 181`, `Community 191`, `Community 65`, `Community 198`, `Community 78`, `Community 208`, `Community 81`, `Community 220`, `Community 98`, `Community 101`, `Community 102`, `Community 104`, `Community 105`, `Community 241`, `Community 124`, `Community 383`?**
   _High betweenness centrality (0.012) - this node is a cross-community bridge._
 - **What connects `arrowParens`, `endOfLine`, `printWidth` to the rest of the system?**
-  _3263 weakly-connected nodes found - possible documentation gaps or missing edges._
+  _3270 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Community 0` be split into smaller, more focused modules?**
   _Cohesion score 0.004395604395604396 - nodes in this community are weakly interconnected._
 - **Should `Community 1` be split into smaller, more focused modules?**

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -50047,7 +50047,7 @@
       "label": "LoginModal()",
       "file_type": "code",
       "source_file": "src/features/shell/bot-browser/components/BotBrowserView.tsx",
-      "source_location": "L2222",
+      "source_location": "L2258",
       "id": "components_botbrowserview_loginmodal",
       "community": 50,
       "norm_label": "loginmodal()"
@@ -50056,7 +50056,7 @@
       "label": "BotBrowserAssetImage()",
       "file_type": "code",
       "source_file": "src/features/shell/bot-browser/components/BotBrowserView.tsx",
-      "source_location": "L2459",
+      "source_location": "L2495",
       "id": "components_botbrowserview_botbrowserassetimage",
       "community": 50,
       "norm_label": "botbrowserassetimage()"
@@ -50065,7 +50065,7 @@
       "label": "CardTile()",
       "file_type": "code",
       "source_file": "src/features/shell/bot-browser/components/BotBrowserView.tsx",
-      "source_location": "L2501",
+      "source_location": "L2537",
       "id": "components_botbrowserview_cardtile",
       "community": 259,
       "norm_label": "cardtile()"
@@ -50074,7 +50074,7 @@
       "label": "DetailView()",
       "file_type": "code",
       "source_file": "src/features/shell/bot-browser/components/BotBrowserView.tsx",
-      "source_location": "L2564",
+      "source_location": "L2600",
       "id": "components_botbrowserview_detailview",
       "community": 259,
       "norm_label": "detailview()"
@@ -50083,7 +50083,7 @@
       "label": "buildCharacterCardPng()",
       "file_type": "code",
       "source_file": "src/features/shell/bot-browser/components/BotBrowserView.tsx",
-      "source_location": "L2831",
+      "source_location": "L2867",
       "id": "components_botbrowserview_buildcharactercardpng",
       "community": 170,
       "norm_label": "buildcharactercardpng()"
@@ -50092,7 +50092,7 @@
       "label": "crc32()",
       "file_type": "code",
       "source_file": "src/features/shell/bot-browser/components/BotBrowserView.tsx",
-      "source_location": "L2938",
+      "source_location": "L2974",
       "id": "components_botbrowserview_crc32",
       "community": 170,
       "norm_label": "crc32()"
@@ -50101,7 +50101,7 @@
       "label": "DefSection()",
       "file_type": "code",
       "source_file": "src/features/shell/bot-browser/components/BotBrowserView.tsx",
-      "source_location": "L2958",
+      "source_location": "L2994",
       "id": "components_botbrowserview_defsection",
       "community": 50,
       "norm_label": "defsection()"
@@ -60640,7 +60640,7 @@
       "label": "flushGameStatePatchOnUnload()",
       "file_type": "code",
       "source_file": "src/features/runtime/world-state/hooks/use-world-state-patcher.ts",
-      "source_location": "L375",
+      "source_location": "L380",
       "id": "hooks_use_world_state_patcher_flushgamestatepatchonunload",
       "community": 102,
       "norm_label": "flushgamestatepatchonunload()"
@@ -60649,7 +60649,7 @@
       "label": "retainBeforeUnloadFlush()",
       "file_type": "code",
       "source_file": "src/features/runtime/world-state/hooks/use-world-state-patcher.ts",
-      "source_location": "L401",
+      "source_location": "L406",
       "id": "hooks_use_world_state_patcher_retainbeforeunloadflush",
       "community": 102,
       "norm_label": "retainbeforeunloadflush()"
@@ -60658,7 +60658,7 @@
       "label": "patchGameStateField()",
       "file_type": "code",
       "source_file": "src/features/runtime/world-state/hooks/use-world-state-patcher.ts",
-      "source_location": "L422",
+      "source_location": "L427",
       "id": "hooks_use_world_state_patcher_patchgamestatefield",
       "community": 102,
       "norm_label": "patchgamestatefield()"
@@ -60667,7 +60667,7 @@
       "label": "patchPlayerStatsField()",
       "file_type": "code",
       "source_file": "src/features/runtime/world-state/hooks/use-world-state-patcher.ts",
-      "source_location": "L439",
+      "source_location": "L444",
       "id": "hooks_use_world_state_patcher_patchplayerstatsfield",
       "community": 102,
       "norm_label": "patchplayerstatsfield()"
@@ -60676,7 +60676,7 @@
       "label": "useGameStatePatcher()",
       "file_type": "code",
       "source_file": "src/features/runtime/world-state/hooks/use-world-state-patcher.ts",
-      "source_location": "L445",
+      "source_location": "L450",
       "id": "hooks_use_world_state_patcher_usegamestatepatcher",
       "community": 151,
       "norm_label": "usegamestatepatcher()"
@@ -94390,7 +94390,7 @@
       "label": "resetPatcherState()",
       "file_type": "code",
       "source_file": "src/features/runtime/world-state/hooks/use-world-state-patcher.test.ts",
-      "source_location": "L45",
+      "source_location": "L55",
       "id": "hooks_use_world_state_patcher_test_resetpatcherstate",
       "community": 237,
       "norm_label": "resetpatcherstate()"
@@ -94426,7 +94426,7 @@
       "label": "flushSearchTimer()",
       "file_type": "code",
       "source_file": "src/features/shell/bot-browser/components/BotBrowserView.test.tsx",
-      "source_location": "L77",
+      "source_location": "L84",
       "id": "components_botbrowserview_test_flushsearchtimer",
       "community": 170,
       "norm_label": "flushsearchtimer()"
@@ -94435,7 +94435,7 @@
       "label": "retryButton",
       "file_type": "code",
       "source_file": "src/features/shell/bot-browser/components/BotBrowserView.test.tsx",
-      "source_location": "L139",
+      "source_location": "L146",
       "id": "components_botbrowserview_test_retrybutton",
       "community": 170,
       "norm_label": "retrybutton"
@@ -94444,7 +94444,7 @@
       "label": "searchCallCount()",
       "file_type": "code",
       "source_file": "src/features/shell/bot-browser/components/BotBrowserView.test.tsx",
-      "source_location": "L73",
+      "source_location": "L74",
       "id": "components_botbrowserview_test_searchcallcount",
       "community": 170,
       "norm_label": "searchcallcount()"
@@ -94453,7 +94453,7 @@
       "label": "textPath",
       "file_type": "code",
       "source_file": "src/features/shell/bot-browser/components/BotBrowserView.test.tsx",
-      "source_location": "L100",
+      "source_location": "L107",
       "id": "components_botbrowserview_test_textpath",
       "community": 170,
       "norm_label": "textpath"
@@ -94480,7 +94480,7 @@
       "label": "firstSearch",
       "file_type": "code",
       "source_file": "src/features/shell/bot-browser/components/BotBrowserView.test.tsx",
-      "source_location": "L156",
+      "source_location": "L163",
       "id": "components_botbrowserview_test_firstsearch",
       "community": 225,
       "norm_label": "firstsearch"
@@ -94489,7 +94489,7 @@
       "label": "refreshButton",
       "file_type": "code",
       "source_file": "src/features/shell/bot-browser/components/BotBrowserView.test.tsx",
-      "source_location": "L179",
+      "source_location": "L186",
       "id": "components_botbrowserview_test_refreshbutton",
       "community": 225,
       "norm_label": "refreshbutton"
@@ -94499,18 +94499,72 @@
       "file_type": "code",
       "source_file": "src/features/runtime/world-state/hooks/use-world-state-patcher.test.ts",
       "source_location": "L196",
-      "id": "hooks_use_world_state_patcher_test_container",
       "community": 54,
-      "norm_label": "container"
+      "norm_label": "container",
+      "id": "hooks_use_world_state_patcher_test_container"
     },
     {
       "label": "Harness()",
       "file_type": "code",
       "source_file": "src/features/runtime/world-state/hooks/use-world-state-patcher.test.ts",
       "source_location": "L214",
-      "id": "hooks_use_world_state_patcher_test_harness",
       "community": 54,
-      "norm_label": "harness()"
+      "norm_label": "harness()",
+      "id": "hooks_use_world_state_patcher_test_harness"
+    },
+    {
+      "label": "searchInput",
+      "file_type": "code",
+      "source_file": "src/features/shell/bot-browser/components/BotBrowserView.test.tsx",
+      "source_location": "L237",
+      "id": "components_botbrowserview_test_searchinput",
+      "community": 225,
+      "norm_label": "searchinput"
+    },
+    {
+      "label": "setInputValue()",
+      "file_type": "code",
+      "source_file": "src/features/shell/bot-browser/components/BotBrowserView.test.tsx",
+      "source_location": "L78",
+      "id": "components_botbrowserview_test_setinputvalue",
+      "community": 225,
+      "norm_label": "setinputvalue()"
+    },
+    {
+      "label": "deferred()",
+      "file_type": "code",
+      "source_file": "src/features/runtime/world-state/hooks/use-world-state-patcher.test.ts",
+      "source_location": "L45",
+      "id": "hooks_use_world_state_patcher_test_deferred",
+      "community": 272,
+      "norm_label": "deferred()"
+    },
+    {
+      "label": "firstFlush",
+      "file_type": "code",
+      "source_file": "src/features/runtime/world-state/hooks/use-world-state-patcher.test.ts",
+      "source_location": "L185",
+      "id": "hooks_use_world_state_patcher_test_firstflush",
+      "community": 272,
+      "norm_label": "firstflush"
+    },
+    {
+      "label": "firstPatch",
+      "file_type": "code",
+      "source_file": "src/features/runtime/world-state/hooks/use-world-state-patcher.test.ts",
+      "source_location": "L172",
+      "id": "hooks_use_world_state_patcher_test_firstpatch",
+      "community": 272,
+      "norm_label": "firstpatch"
+    },
+    {
+      "label": "mountPatcherHarness()",
+      "file_type": "code",
+      "source_file": "src/features/runtime/world-state/hooks/use-world-state-patcher.test.ts",
+      "source_location": "L62",
+      "id": "hooks_use_world_state_patcher_test_mountpatcherharness",
+      "community": 272,
+      "norm_label": "mountpatcherharness()"
     }
   ],
   "links": [
@@ -335535,8 +335589,79 @@
       "source": "src_features_shell_bot_browser_components_botbrowserview_test_tsx",
       "target": "components_botbrowserview_test_refreshbutton",
       "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "src/features/runtime/world-state/hooks/use-world-state-patcher.test.ts",
+      "source_location": "L68",
+      "weight": 1.0,
+      "source": "hooks_use_world_state_patcher_test_mountpatcherharness",
+      "target": "hooks_use_world_state_patcher_usegamestatepatcher",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "src/features/runtime/world-state/hooks/use-world-state-patcher.test.ts",
+      "source_location": "L45",
+      "weight": 1.0,
+      "source": "src_features_runtime_world_state_hooks_use_world_state_patcher_test_ts",
+      "target": "hooks_use_world_state_patcher_test_deferred",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "src/features/runtime/world-state/hooks/use-world-state-patcher.test.ts",
+      "source_location": "L185",
+      "weight": 1.0,
+      "source": "src_features_runtime_world_state_hooks_use_world_state_patcher_test_ts",
+      "target": "hooks_use_world_state_patcher_test_firstflush",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "src/features/runtime/world-state/hooks/use-world-state-patcher.test.ts",
+      "source_location": "L172",
+      "weight": 1.0,
+      "source": "src_features_runtime_world_state_hooks_use_world_state_patcher_test_ts",
+      "target": "hooks_use_world_state_patcher_test_firstpatch",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "src/features/runtime/world-state/hooks/use-world-state-patcher.test.ts",
+      "source_location": "L62",
+      "weight": 1.0,
+      "source": "src_features_runtime_world_state_hooks_use_world_state_patcher_test_ts",
+      "target": "hooks_use_world_state_patcher_test_mountpatcherharness",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "src/features/shell/bot-browser/components/BotBrowserView.test.tsx",
+      "source_location": "L237",
+      "weight": 1.0,
+      "source": "src_features_shell_bot_browser_components_botbrowserview_test_tsx",
+      "target": "components_botbrowserview_test_searchinput",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "src/features/shell/bot-browser/components/BotBrowserView.test.tsx",
+      "source_location": "L78",
+      "weight": 1.0,
+      "source": "src_features_shell_bot_browser_components_botbrowserview_test_tsx",
+      "target": "components_botbrowserview_test_setinputvalue",
+      "confidence_score": 1.0
     }
   ],
   "hyperedges": [],
-  "built_at_commit": "5fb8c74a0c2419c492f5c3e367e4433afce4009f"
+  "built_at_commit": "73ecb92ddc7d941848c831f346b1483504091e3d"
 }

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -50047,7 +50047,7 @@
       "label": "LoginModal()",
       "file_type": "code",
       "source_file": "src/features/shell/bot-browser/components/BotBrowserView.tsx",
-      "source_location": "L2215",
+      "source_location": "L2222",
       "id": "components_botbrowserview_loginmodal",
       "community": 50,
       "norm_label": "loginmodal()"
@@ -50056,7 +50056,7 @@
       "label": "BotBrowserAssetImage()",
       "file_type": "code",
       "source_file": "src/features/shell/bot-browser/components/BotBrowserView.tsx",
-      "source_location": "L2452",
+      "source_location": "L2459",
       "id": "components_botbrowserview_botbrowserassetimage",
       "community": 50,
       "norm_label": "botbrowserassetimage()"
@@ -50065,7 +50065,7 @@
       "label": "CardTile()",
       "file_type": "code",
       "source_file": "src/features/shell/bot-browser/components/BotBrowserView.tsx",
-      "source_location": "L2494",
+      "source_location": "L2501",
       "id": "components_botbrowserview_cardtile",
       "community": 259,
       "norm_label": "cardtile()"
@@ -50074,7 +50074,7 @@
       "label": "DetailView()",
       "file_type": "code",
       "source_file": "src/features/shell/bot-browser/components/BotBrowserView.tsx",
-      "source_location": "L2557",
+      "source_location": "L2564",
       "id": "components_botbrowserview_detailview",
       "community": 259,
       "norm_label": "detailview()"
@@ -50083,7 +50083,7 @@
       "label": "buildCharacterCardPng()",
       "file_type": "code",
       "source_file": "src/features/shell/bot-browser/components/BotBrowserView.tsx",
-      "source_location": "L2824",
+      "source_location": "L2831",
       "id": "components_botbrowserview_buildcharactercardpng",
       "community": 170,
       "norm_label": "buildcharactercardpng()"
@@ -50092,7 +50092,7 @@
       "label": "crc32()",
       "file_type": "code",
       "source_file": "src/features/shell/bot-browser/components/BotBrowserView.tsx",
-      "source_location": "L2931",
+      "source_location": "L2938",
       "id": "components_botbrowserview_crc32",
       "community": 170,
       "norm_label": "crc32()"
@@ -50101,7 +50101,7 @@
       "label": "DefSection()",
       "file_type": "code",
       "source_file": "src/features/shell/bot-browser/components/BotBrowserView.tsx",
-      "source_location": "L2951",
+      "source_location": "L2958",
       "id": "components_botbrowserview_defsection",
       "community": 50,
       "norm_label": "defsection()"
@@ -60613,7 +60613,7 @@
       "label": "queuePatch()",
       "file_type": "code",
       "source_file": "src/features/runtime/world-state/hooks/use-world-state-patcher.ts",
-      "source_location": "L217",
+      "source_location": "L224",
       "id": "hooks_use_world_state_patcher_queuepatch",
       "community": 102,
       "norm_label": "queuepatch()"
@@ -60622,7 +60622,7 @@
       "label": "flushGameStatePatch()",
       "file_type": "code",
       "source_file": "src/features/runtime/world-state/hooks/use-world-state-patcher.ts",
-      "source_location": "L250",
+      "source_location": "L257",
       "id": "hooks_use_world_state_patcher_flushgamestatepatch",
       "community": 102,
       "norm_label": "flushgamestatepatch()"
@@ -60631,7 +60631,7 @@
       "label": "discardPendingGameStatePatch()",
       "file_type": "code",
       "source_file": "src/features/runtime/world-state/hooks/use-world-state-patcher.ts",
-      "source_location": "L334",
+      "source_location": "L341",
       "id": "hooks_use_world_state_patcher_discardpendinggamestatepatch",
       "community": 102,
       "norm_label": "discardpendinggamestatepatch()"
@@ -60640,7 +60640,7 @@
       "label": "flushGameStatePatchOnUnload()",
       "file_type": "code",
       "source_file": "src/features/runtime/world-state/hooks/use-world-state-patcher.ts",
-      "source_location": "L368",
+      "source_location": "L375",
       "id": "hooks_use_world_state_patcher_flushgamestatepatchonunload",
       "community": 102,
       "norm_label": "flushgamestatepatchonunload()"
@@ -60649,7 +60649,7 @@
       "label": "retainBeforeUnloadFlush()",
       "file_type": "code",
       "source_file": "src/features/runtime/world-state/hooks/use-world-state-patcher.ts",
-      "source_location": "L394",
+      "source_location": "L401",
       "id": "hooks_use_world_state_patcher_retainbeforeunloadflush",
       "community": 102,
       "norm_label": "retainbeforeunloadflush()"
@@ -60658,7 +60658,7 @@
       "label": "patchGameStateField()",
       "file_type": "code",
       "source_file": "src/features/runtime/world-state/hooks/use-world-state-patcher.ts",
-      "source_location": "L415",
+      "source_location": "L422",
       "id": "hooks_use_world_state_patcher_patchgamestatefield",
       "community": 102,
       "norm_label": "patchgamestatefield()"
@@ -60667,7 +60667,7 @@
       "label": "patchPlayerStatsField()",
       "file_type": "code",
       "source_file": "src/features/runtime/world-state/hooks/use-world-state-patcher.ts",
-      "source_location": "L432",
+      "source_location": "L439",
       "id": "hooks_use_world_state_patcher_patchplayerstatsfield",
       "community": 102,
       "norm_label": "patchplayerstatsfield()"
@@ -60676,7 +60676,7 @@
       "label": "useGameStatePatcher()",
       "file_type": "code",
       "source_file": "src/features/runtime/world-state/hooks/use-world-state-patcher.ts",
-      "source_location": "L438",
+      "source_location": "L445",
       "id": "hooks_use_world_state_patcher_usegamestatepatcher",
       "community": 151,
       "norm_label": "usegamestatepatcher()"
@@ -94367,6 +94367,150 @@
       "id": "capabilities_storage_addchatmessageswipeoptions",
       "community": 52,
       "norm_label": "addchatmessageswipeoptions"
+    },
+    {
+      "label": "gameState()",
+      "file_type": "code",
+      "source_file": "src/features/runtime/world-state/hooks/use-world-state-patcher.test.ts",
+      "source_location": "L25",
+      "id": "hooks_use_world_state_patcher_test_gamestate",
+      "community": 237,
+      "norm_label": "gamestate()"
+    },
+    {
+      "label": "patchMock",
+      "file_type": "code",
+      "source_file": "src/features/runtime/world-state/hooks/use-world-state-patcher.test.ts",
+      "source_location": "L23",
+      "id": "hooks_use_world_state_patcher_test_patchmock",
+      "community": 237,
+      "norm_label": "patchmock"
+    },
+    {
+      "label": "resetPatcherState()",
+      "file_type": "code",
+      "source_file": "src/features/runtime/world-state/hooks/use-world-state-patcher.test.ts",
+      "source_location": "L45",
+      "id": "hooks_use_world_state_patcher_test_resetpatcherstate",
+      "community": 237,
+      "norm_label": "resetpatcherstate()"
+    },
+    {
+      "label": "use-world-state-patcher.test.ts",
+      "file_type": "code",
+      "source_file": "src/features/runtime/world-state/hooks/use-world-state-patcher.test.ts",
+      "source_location": "L1",
+      "id": "src_features_runtime_world_state_hooks_use_world_state_patcher_test_ts",
+      "community": 237,
+      "norm_label": "use-world-state-patcher.test.ts"
+    },
+    {
+      "label": "botBrowserGetMock",
+      "file_type": "code",
+      "source_file": "src/features/shell/bot-browser/components/BotBrowserView.test.tsx",
+      "source_location": "L41",
+      "id": "components_botbrowserview_test_botbrowsergetmock",
+      "community": 170,
+      "norm_label": "botbrowsergetmock"
+    },
+    {
+      "label": "chubSearchResult()",
+      "file_type": "code",
+      "source_file": "src/features/shell/bot-browser/components/BotBrowserView.test.tsx",
+      "source_location": "L53",
+      "id": "components_botbrowserview_test_chubsearchresult",
+      "community": 170,
+      "norm_label": "chubsearchresult()"
+    },
+    {
+      "label": "flushSearchTimer()",
+      "file_type": "code",
+      "source_file": "src/features/shell/bot-browser/components/BotBrowserView.test.tsx",
+      "source_location": "L77",
+      "id": "components_botbrowserview_test_flushsearchtimer",
+      "community": 170,
+      "norm_label": "flushsearchtimer()"
+    },
+    {
+      "label": "retryButton",
+      "file_type": "code",
+      "source_file": "src/features/shell/bot-browser/components/BotBrowserView.test.tsx",
+      "source_location": "L139",
+      "id": "components_botbrowserview_test_retrybutton",
+      "community": 170,
+      "norm_label": "retrybutton"
+    },
+    {
+      "label": "searchCallCount()",
+      "file_type": "code",
+      "source_file": "src/features/shell/bot-browser/components/BotBrowserView.test.tsx",
+      "source_location": "L73",
+      "id": "components_botbrowserview_test_searchcallcount",
+      "community": 170,
+      "norm_label": "searchcallcount()"
+    },
+    {
+      "label": "textPath",
+      "file_type": "code",
+      "source_file": "src/features/shell/bot-browser/components/BotBrowserView.test.tsx",
+      "source_location": "L100",
+      "id": "components_botbrowserview_test_textpath",
+      "community": 170,
+      "norm_label": "textpath"
+    },
+    {
+      "label": "BotBrowserView.test.tsx",
+      "file_type": "code",
+      "source_file": "src/features/shell/bot-browser/components/BotBrowserView.test.tsx",
+      "source_location": "L1",
+      "id": "src_features_shell_bot_browser_components_botbrowserview_test_tsx",
+      "community": 170,
+      "norm_label": "botbrowserview.test.tsx"
+    },
+    {
+      "label": "deferred()",
+      "file_type": "code",
+      "source_file": "src/features/shell/bot-browser/components/BotBrowserView.test.tsx",
+      "source_location": "L43",
+      "id": "components_botbrowserview_test_deferred",
+      "community": 225,
+      "norm_label": "deferred()"
+    },
+    {
+      "label": "firstSearch",
+      "file_type": "code",
+      "source_file": "src/features/shell/bot-browser/components/BotBrowserView.test.tsx",
+      "source_location": "L156",
+      "id": "components_botbrowserview_test_firstsearch",
+      "community": 225,
+      "norm_label": "firstsearch"
+    },
+    {
+      "label": "refreshButton",
+      "file_type": "code",
+      "source_file": "src/features/shell/bot-browser/components/BotBrowserView.test.tsx",
+      "source_location": "L179",
+      "id": "components_botbrowserview_test_refreshbutton",
+      "community": 225,
+      "norm_label": "refreshbutton"
+    },
+    {
+      "label": "container",
+      "file_type": "code",
+      "source_file": "src/features/runtime/world-state/hooks/use-world-state-patcher.test.ts",
+      "source_location": "L196",
+      "id": "hooks_use_world_state_patcher_test_container",
+      "community": 54,
+      "norm_label": "container"
+    },
+    {
+      "label": "Harness()",
+      "file_type": "code",
+      "source_file": "src/features/runtime/world-state/hooks/use-world-state-patcher.test.ts",
+      "source_location": "L214",
+      "id": "hooks_use_world_state_patcher_test_harness",
+      "community": 54,
+      "norm_label": "harness()"
     }
   ],
   "links": [
@@ -335064,8 +335208,335 @@
       "source": "storage_chats_message_swipes_respects_legacy_silent_flag_for_inactive_swipes",
       "target": "storage_chats_test_state",
       "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "src/features/runtime/world-state/hooks/use-world-state-patcher.test.ts",
+      "source_location": "L37",
+      "weight": 1.0,
+      "source": "hooks_use_world_state_patcher_test_resetpatcherstate",
+      "target": "hooks_use_world_state_patcher_discardpendinggamestatepatch",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "src/features/runtime/world-state/hooks/use-world-state-patcher.test.ts",
+      "source_location": "L3",
+      "weight": 1.0,
+      "source": "src_features_runtime_world_state_hooks_use_world_state_patcher_test_ts",
+      "target": "api_world_state_api_worldstateapi",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "src/features/runtime/world-state/hooks/use-world-state-patcher.test.ts",
+      "source_location": "L5",
+      "weight": 1.0,
+      "source": "src_features_runtime_world_state_hooks_use_world_state_patcher_test_ts",
+      "target": "hooks_use_world_state_patcher_discardpendinggamestatepatch",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "src/features/runtime/world-state/hooks/use-world-state-patcher.test.ts",
+      "source_location": "L5",
+      "weight": 1.0,
+      "source": "src_features_runtime_world_state_hooks_use_world_state_patcher_test_ts",
+      "target": "hooks_use_world_state_patcher_flushgamestatepatch",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "src/features/runtime/world-state/hooks/use-world-state-patcher.test.ts",
+      "source_location": "L5",
+      "weight": 1.0,
+      "source": "src_features_runtime_world_state_hooks_use_world_state_patcher_test_ts",
+      "target": "hooks_use_world_state_patcher_patchgamestatefield",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "src/features/runtime/world-state/hooks/use-world-state-patcher.test.ts",
+      "source_location": "L16",
+      "weight": 1.0,
+      "source": "src_features_runtime_world_state_hooks_use_world_state_patcher_test_ts",
+      "target": "hooks_use_world_state_patcher_test_gamestate",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "src/features/runtime/world-state/hooks/use-world-state-patcher.test.ts",
+      "source_location": "L14",
+      "weight": 1.0,
+      "source": "src_features_runtime_world_state_hooks_use_world_state_patcher_test_ts",
+      "target": "hooks_use_world_state_patcher_test_patchmock",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "src/features/runtime/world-state/hooks/use-world-state-patcher.test.ts",
+      "source_location": "L36",
+      "weight": 1.0,
+      "source": "src_features_runtime_world_state_hooks_use_world_state_patcher_test_ts",
+      "target": "hooks_use_world_state_patcher_test_resetpatcherstate",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "src/features/runtime/world-state/hooks/use-world-state-patcher.test.ts",
+      "source_location": "L2",
+      "weight": 1.0,
+      "source": "src_features_runtime_world_state_hooks_use_world_state_patcher_test_ts",
+      "target": "src_engine_contracts_types_game_state_ts",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "src/features/runtime/world-state/hooks/use-world-state-patcher.test.ts",
+      "source_location": "L3",
+      "weight": 1.0,
+      "source": "src_features_runtime_world_state_hooks_use_world_state_patcher_test_ts",
+      "target": "src_features_runtime_world_state_api_world_state_api_ts",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "src/features/runtime/world-state/hooks/use-world-state-patcher.test.ts",
+      "source_location": "L5",
+      "weight": 1.0,
+      "source": "src_features_runtime_world_state_hooks_use_world_state_patcher_test_ts",
+      "target": "src_features_runtime_world_state_hooks_use_world_state_patcher_ts",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "src/features/runtime/world-state/hooks/use-world-state-patcher.test.ts",
+      "source_location": "L4",
+      "weight": 1.0,
+      "source": "src_features_runtime_world_state_hooks_use_world_state_patcher_test_ts",
+      "target": "src_features_runtime_world_state_stores_world_state_store_ts",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "src/features/runtime/world-state/hooks/use-world-state-patcher.test.ts",
+      "source_location": "L4",
+      "weight": 1.0,
+      "source": "src_features_runtime_world_state_hooks_use_world_state_patcher_test_ts",
+      "target": "stores_world_state_store_usegamestatestore",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "src/features/runtime/world-state/hooks/use-world-state-patcher.test.ts",
+      "source_location": "L2",
+      "weight": 1.0,
+      "source": "src_features_runtime_world_state_hooks_use_world_state_patcher_test_ts",
+      "target": "types_game_state_gamestate",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "src/features/shell/bot-browser/components/BotBrowserView.test.tsx",
+      "source_location": "L8",
+      "weight": 1.0,
+      "source": "src_features_shell_bot_browser_components_botbrowserview_test_tsx",
+      "target": "api_bot_browser_api_botbrowserget",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "src/features/shell/bot-browser/components/BotBrowserView.test.tsx",
+      "source_location": "L7",
+      "weight": 1.0,
+      "source": "src_features_shell_bot_browser_components_botbrowserview_test_tsx",
+      "target": "components_botbrowserview_botbrowserview",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "src/features/shell/bot-browser/components/BotBrowserView.test.tsx",
+      "source_location": "L41",
+      "weight": 1.0,
+      "source": "src_features_shell_bot_browser_components_botbrowserview_test_tsx",
+      "target": "components_botbrowserview_test_botbrowsergetmock",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "src/features/shell/bot-browser/components/BotBrowserView.test.tsx",
+      "source_location": "L43",
+      "weight": 1.0,
+      "source": "src_features_shell_bot_browser_components_botbrowserview_test_tsx",
+      "target": "components_botbrowserview_test_chubsearchresult",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "src/features/shell/bot-browser/components/BotBrowserView.test.tsx",
+      "source_location": "L67",
+      "weight": 1.0,
+      "source": "src_features_shell_bot_browser_components_botbrowserview_test_tsx",
+      "target": "components_botbrowserview_test_flushsearchtimer",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "src/features/shell/bot-browser/components/BotBrowserView.test.tsx",
+      "source_location": "L129",
+      "weight": 1.0,
+      "source": "src_features_shell_bot_browser_components_botbrowserview_test_tsx",
+      "target": "components_botbrowserview_test_retrybutton",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "src/features/shell/bot-browser/components/BotBrowserView.test.tsx",
+      "source_location": "L63",
+      "weight": 1.0,
+      "source": "src_features_shell_bot_browser_components_botbrowserview_test_tsx",
+      "target": "components_botbrowserview_test_searchcallcount",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "src/features/shell/bot-browser/components/BotBrowserView.test.tsx",
+      "source_location": "L90",
+      "weight": 1.0,
+      "source": "src_features_shell_bot_browser_components_botbrowserview_test_tsx",
+      "target": "components_botbrowserview_test_textpath",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "src/features/shell/bot-browser/components/BotBrowserView.test.tsx",
+      "source_location": "L8",
+      "weight": 1.0,
+      "source": "src_features_shell_bot_browser_components_botbrowserview_test_tsx",
+      "target": "src_features_shell_bot_browser_api_bot_browser_api_ts",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "src/features/shell/bot-browser/components/BotBrowserView.test.tsx",
+      "source_location": "L7",
+      "weight": 1.0,
+      "source": "src_features_shell_bot_browser_components_botbrowserview_test_tsx",
+      "target": "src_features_shell_bot_browser_components_botbrowserview_tsx",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "src/features/runtime/world-state/hooks/use-world-state-patcher.test.ts",
+      "source_location": "L215",
+      "weight": 1.0,
+      "source": "hooks_use_world_state_patcher_test_harness",
+      "target": "hooks_use_world_state_patcher_usegamestatepatcher"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "src/features/runtime/world-state/hooks/use-world-state-patcher.test.ts",
+      "source_location": "L196",
+      "weight": 1.0,
+      "source": "src_features_runtime_world_state_hooks_use_world_state_patcher_test_ts",
+      "target": "hooks_use_world_state_patcher_test_container",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "src/features/runtime/world-state/hooks/use-world-state-patcher.test.ts",
+      "source_location": "L214",
+      "weight": 1.0,
+      "source": "src_features_runtime_world_state_hooks_use_world_state_patcher_test_ts",
+      "target": "hooks_use_world_state_patcher_test_harness",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "src/features/runtime/world-state/hooks/use-world-state-patcher.test.ts",
+      "source_location": "L7",
+      "weight": 1.0,
+      "source": "src_features_runtime_world_state_hooks_use_world_state_patcher_test_ts",
+      "target": "hooks_use_world_state_patcher_usegamestatepatcher",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "src/features/shell/bot-browser/components/BotBrowserView.test.tsx",
+      "source_location": "L43",
+      "weight": 1.0,
+      "source": "src_features_shell_bot_browser_components_botbrowserview_test_tsx",
+      "target": "components_botbrowserview_test_deferred",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "src/features/shell/bot-browser/components/BotBrowserView.test.tsx",
+      "source_location": "L156",
+      "weight": 1.0,
+      "source": "src_features_shell_bot_browser_components_botbrowserview_test_tsx",
+      "target": "components_botbrowserview_test_firstsearch",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "src/features/shell/bot-browser/components/BotBrowserView.test.tsx",
+      "source_location": "L179",
+      "weight": 1.0,
+      "source": "src_features_shell_bot_browser_components_botbrowserview_test_tsx",
+      "target": "components_botbrowserview_test_refreshbutton",
+      "confidence_score": 1.0
     }
   ],
   "hyperedges": [],
-  "built_at_commit": "004bad7db29d8ffe7fea1dbc4be21cb7e6bd0c87"
+  "built_at_commit": "5fb8c74a0c2419c492f5c3e367e4433afce4009f"
 }

--- a/graphify-out/manifest.json
+++ b/graphify-out/manifest.json
@@ -1685,8 +1685,8 @@
     "semantic_hash": ""
   },
   "src/features/shell/bot-browser/components/BotBrowserView.tsx": {
-    "mtime": 1779997003.588245,
-    "ast_hash": "10c54f659dd931af4b7e43474e4ac438",
+    "mtime": 1780030430.9810927,
+    "ast_hash": "23be5953868e4c0301ae870a023f2e69",
     "semantic_hash": ""
   },
   "src/features/shell/bot-browser/api/bot-browser-api.ts": {
@@ -2495,8 +2495,8 @@
     "semantic_hash": ""
   },
   "src/features/runtime/world-state/hooks/use-world-state-patcher.ts": {
-    "mtime": 1779835633.8596742,
-    "ast_hash": "a4b403cba5c2830f3bf439bcb53b1b2a",
+    "mtime": 1780030442.4052184,
+    "ast_hash": "0ce1082ee7e5b865e153e2e9834f833e",
     "semantic_hash": ""
   },
   "src/features/runtime/world-state/lib/tracker-state-display.ts": {
@@ -5827,6 +5827,16 @@
   "src/features/modes/shared/chat-ui/components/settings/ChatSettingsSections.tsx": {
     "mtime": 1780006516.2087274,
     "ast_hash": "4000a7a3fb055f60377c8a70d8c92a19",
+    "semantic_hash": ""
+  },
+  "src/features/runtime/world-state/hooks/use-world-state-patcher.test.ts": {
+    "mtime": 1780030556.0531025,
+    "ast_hash": "db75c67904d14d42ecd0f5b1cc946910",
+    "semantic_hash": ""
+  },
+  "src/features/shell/bot-browser/components/BotBrowserView.test.tsx": {
+    "mtime": 1780030508.6452873,
+    "ast_hash": "81c9d45138ccdb7f06e43454f7b39126",
     "semantic_hash": ""
   }
 }

--- a/graphify-out/manifest.json
+++ b/graphify-out/manifest.json
@@ -1685,8 +1685,8 @@
     "semantic_hash": ""
   },
   "src/features/shell/bot-browser/components/BotBrowserView.tsx": {
-    "mtime": 1780030430.9810927,
-    "ast_hash": "23be5953868e4c0301ae870a023f2e69",
+    "mtime": 1780031292.0609622,
+    "ast_hash": "4262b597969862c87c59d13fd4226b12",
     "semantic_hash": ""
   },
   "src/features/shell/bot-browser/api/bot-browser-api.ts": {
@@ -2495,8 +2495,8 @@
     "semantic_hash": ""
   },
   "src/features/runtime/world-state/hooks/use-world-state-patcher.ts": {
-    "mtime": 1780030442.4052184,
-    "ast_hash": "0ce1082ee7e5b865e153e2e9834f833e",
+    "mtime": 1780031235.791033,
+    "ast_hash": "4dde3019d4181219bfa7ed92cac07da8",
     "semantic_hash": ""
   },
   "src/features/runtime/world-state/lib/tracker-state-display.ts": {
@@ -5830,13 +5830,13 @@
     "semantic_hash": ""
   },
   "src/features/runtime/world-state/hooks/use-world-state-patcher.test.ts": {
-    "mtime": 1780030556.0531025,
-    "ast_hash": "db75c67904d14d42ecd0f5b1cc946910",
+    "mtime": 1780031316.7370615,
+    "ast_hash": "4ee943cf28aae14987fdee207840fe71",
     "semantic_hash": ""
   },
   "src/features/shell/bot-browser/components/BotBrowserView.test.tsx": {
-    "mtime": 1780030508.6452873,
-    "ast_hash": "81c9d45138ccdb7f06e43454f7b39126",
+    "mtime": 1780031311.330896,
+    "ast_hash": "f84ddc90fcfab6f07afa4bd243c79527",
     "semantic_hash": ""
   }
 }

--- a/src/features/runtime/world-state/hooks/use-world-state-patcher.test.ts
+++ b/src/features/runtime/world-state/hooks/use-world-state-patcher.test.ts
@@ -1,5 +1,5 @@
 import { act, createElement } from "react";
-import { createRoot, type Root } from "react-dom/client";
+import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { GameState } from "../../../../engine/contracts/types/game-state";
 import { worldStateApi } from "../api/world-state-api";
@@ -42,11 +42,43 @@ function gameState(overrides: Partial<GameState> = {}): GameState {
   };
 }
 
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
+}
+
 async function resetPatcherState() {
   await discardPendingGameStatePatch();
   useGameStateStore.getState().reset();
   window.localStorage.clear();
   patchMock.mockReset();
+}
+
+async function mountPatcherHarness(registrationId: string) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  function Harness() {
+    useGameStatePatcher("chat-1", registrationId);
+    return null;
+  }
+
+  await act(async () => {
+    root.render(createElement(Harness));
+  });
+
+  return () => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  };
 }
 
 beforeEach(async () => {
@@ -136,6 +168,58 @@ describe("world-state patcher", () => {
     });
   });
 
+  it("does not reconcile an older in-flight patch over a newer same-target optimistic edit", async () => {
+    const firstPatch = deferred<GameState>();
+    useGameStateStore.getState().setGameState(
+      gameState({
+        messageId: "assistant-2",
+        swipeIndex: 3,
+        location: "Town",
+      }),
+    );
+    patchMock
+      .mockImplementationOnce(() => firstPatch.promise)
+      .mockResolvedValueOnce(gameState({ messageId: "assistant-2", swipeIndex: 3, location: "Forest" }));
+
+    patchGameStateField("chat-1", "location", "Library");
+    const firstFlush = flushGameStatePatch("chat-1");
+
+    await vi.waitFor(() => {
+      expect(patchMock).toHaveBeenCalledTimes(1);
+    });
+
+    patchGameStateField("chat-1", "location", "Forest");
+    expect(useGameStateStore.getState().current).toMatchObject({
+      messageId: "assistant-2",
+      swipeIndex: 3,
+      location: "Forest",
+    });
+
+    firstPatch.resolve(gameState({ messageId: "assistant-2", swipeIndex: 3, location: "Library" }));
+    await firstFlush;
+
+    expect(useGameStateStore.getState().current).toMatchObject({
+      messageId: "assistant-2",
+      swipeIndex: 3,
+      location: "Forest",
+    });
+
+    await flushGameStatePatch("chat-1");
+
+    expect(patchMock).toHaveBeenCalledTimes(2);
+    expect(patchMock).toHaveBeenNthCalledWith(
+      2,
+      "chat-1",
+      {
+        location: "Forest",
+        manual: true,
+        messageId: "assistant-2",
+        swipeIndex: 3,
+      },
+      { signal: expect.any(AbortSignal) },
+    );
+  });
+
   it("keeps a failed patch queued and retries the same payload on the next flush", async () => {
     useGameStateStore.getState().setGameState(gameState({ messageId: "assistant-3", swipeIndex: 1 }));
     patchMock
@@ -192,9 +276,7 @@ describe("world-state patcher", () => {
   });
 
   it("restores and flushes a durable pending patch when the patcher hook mounts", async () => {
-    let root: Root | null = null;
-    const container = document.createElement("div");
-    document.body.appendChild(container);
+    let cleanup: (() => void) | null = null;
     patchMock.mockResolvedValueOnce(gameState({ messageId: "assistant-5", swipeIndex: 2, weather: "Fog" }));
     window.localStorage.setItem(
       PATCH_QUEUE_STORAGE_KEY,
@@ -211,16 +293,8 @@ describe("world-state patcher", () => {
       ]),
     );
 
-    function Harness() {
-      useGameStatePatcher("chat-1", "restore-test");
-      return null;
-    }
-
     try {
-      root = createRoot(container);
-      await act(async () => {
-        root!.render(createElement(Harness));
-      });
+      cleanup = await mountPatcherHarness("restore-test");
 
       await vi.waitFor(() => {
         expect(patchMock).toHaveBeenCalledWith(
@@ -235,13 +309,44 @@ describe("world-state patcher", () => {
         );
       });
       expect(window.localStorage.getItem(PATCH_QUEUE_STORAGE_KEY)).toBeNull();
+
+      cleanup();
+      cleanup = null;
+      await resetPatcherState();
+
+      patchMock.mockResolvedValueOnce(gameState({ messageId: "assistant-6", swipeIndex: 0, location: "Cave" }));
+      window.localStorage.setItem(
+        PATCH_QUEUE_STORAGE_KEY,
+        JSON.stringify([
+          [
+            "chat-1\u0000assistant-6\u00000",
+            {
+              chatId: "chat-1",
+              target: { messageId: "assistant-6", swipeIndex: 0 },
+              fields: { location: "Cave" },
+              revision: 1,
+            },
+          ],
+        ]),
+      );
+
+      cleanup = await mountPatcherHarness("restore-test-after-reset");
+
+      await vi.waitFor(() => {
+        expect(patchMock).toHaveBeenCalledWith(
+          "chat-1",
+          {
+            manual: true,
+            messageId: "assistant-6",
+            swipeIndex: 0,
+            location: "Cave",
+          },
+          { signal: expect.any(AbortSignal) },
+        );
+      });
+      expect(window.localStorage.getItem(PATCH_QUEUE_STORAGE_KEY)).toBeNull();
     } finally {
-      if (root) {
-        act(() => {
-          root!.unmount();
-        });
-      }
-      container.remove();
+      cleanup?.();
     }
   });
 });

--- a/src/features/runtime/world-state/hooks/use-world-state-patcher.test.ts
+++ b/src/features/runtime/world-state/hooks/use-world-state-patcher.test.ts
@@ -1,0 +1,247 @@
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { GameState } from "../../../../engine/contracts/types/game-state";
+import { worldStateApi } from "../api/world-state-api";
+import { useGameStateStore } from "../stores/world-state.store";
+import {
+  discardPendingGameStatePatch,
+  flushGameStatePatch,
+  patchGameStateField,
+  useGameStatePatcher,
+} from "./use-world-state-patcher";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock("../api/world-state-api", () => ({
+  worldStateApi: {
+    patch: vi.fn(),
+  },
+}));
+
+const PATCH_QUEUE_STORAGE_KEY = "marinara:pending-game-state-patches:v1";
+const patchMock = vi.mocked(worldStateApi.patch);
+
+function gameState(overrides: Partial<GameState> = {}): GameState {
+  return {
+    id: "state-1",
+    chatId: "chat-1",
+    messageId: "assistant-1",
+    swipeIndex: 0,
+    date: null,
+    time: null,
+    location: null,
+    weather: null,
+    temperature: null,
+    presentCharacters: [],
+    recentEvents: [],
+    playerStats: null,
+    personaStats: null,
+    createdAt: "2026-05-29T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+async function resetPatcherState() {
+  await discardPendingGameStatePatch();
+  useGameStateStore.getState().reset();
+  window.localStorage.clear();
+  patchMock.mockReset();
+}
+
+beforeEach(async () => {
+  await resetPatcherState();
+});
+
+afterEach(async () => {
+  await resetPatcherState();
+});
+
+describe("world-state patcher", () => {
+  it("optimistically updates the visible state and flushes a coalesced manual patch for the original target", async () => {
+    useGameStateStore.getState().setGameState(
+      gameState({
+        messageId: "assistant-2",
+        swipeIndex: 3,
+        location: "Old road",
+        weather: "Clear",
+      }),
+    );
+    patchMock.mockResolvedValueOnce(gameState({ location: "Library", weather: "Rain" }));
+
+    patchGameStateField("chat-1", "location", "Library");
+    patchGameStateField("chat-1", "weather", "Rain");
+
+    expect(useGameStateStore.getState().current).toMatchObject({
+      chatId: "chat-1",
+      messageId: "assistant-2",
+      swipeIndex: 3,
+      location: "Library",
+      weather: "Rain",
+    });
+
+    await flushGameStatePatch("chat-1");
+
+    expect(patchMock).toHaveBeenCalledTimes(1);
+    expect(patchMock).toHaveBeenCalledWith(
+      "chat-1",
+      {
+        location: "Library",
+        manual: true,
+        messageId: "assistant-2",
+        swipeIndex: 3,
+        weather: "Rain",
+      },
+      { signal: expect.any(AbortSignal) },
+    );
+    expect(window.localStorage.getItem(PATCH_QUEUE_STORAGE_KEY)).toBeNull();
+  });
+
+  it("does not overwrite the visible state when a queued patch flushes for an older same-chat target", async () => {
+    useGameStateStore.getState().setGameState(
+      gameState({
+        messageId: "assistant-2",
+        swipeIndex: 3,
+        location: "Old road",
+      }),
+    );
+    patchMock.mockResolvedValueOnce(gameState({ messageId: "assistant-2", swipeIndex: 3, location: "Library" }));
+
+    patchGameStateField("chat-1", "location", "Library");
+    useGameStateStore.getState().setGameState(
+      gameState({
+        messageId: "assistant-4",
+        swipeIndex: 0,
+        location: "New target",
+      }),
+    );
+
+    await flushGameStatePatch("chat-1");
+
+    expect(patchMock).toHaveBeenCalledWith(
+      "chat-1",
+      {
+        location: "Library",
+        manual: true,
+        messageId: "assistant-2",
+        swipeIndex: 3,
+      },
+      { signal: expect.any(AbortSignal) },
+    );
+    expect(useGameStateStore.getState().current).toMatchObject({
+      chatId: "chat-1",
+      messageId: "assistant-4",
+      swipeIndex: 0,
+      location: "New target",
+    });
+  });
+
+  it("keeps a failed patch queued and retries the same payload on the next flush", async () => {
+    useGameStateStore.getState().setGameState(gameState({ messageId: "assistant-3", swipeIndex: 1 }));
+    patchMock
+      .mockRejectedValueOnce(new Error("storage offline"))
+      .mockResolvedValueOnce(gameState({ messageId: "assistant-3", swipeIndex: 1, temperature: "Cold" }));
+
+    patchGameStateField("chat-1", "temperature", "Cold");
+
+    await expect(flushGameStatePatch("chat-1")).rejects.toThrow("Failed to flush 1 game-state patch.");
+    expect(window.localStorage.getItem(PATCH_QUEUE_STORAGE_KEY)).not.toBeNull();
+
+    await flushGameStatePatch("chat-1");
+
+    expect(patchMock).toHaveBeenCalledTimes(2);
+    expect(patchMock).toHaveBeenNthCalledWith(
+      2,
+      "chat-1",
+      {
+        manual: true,
+        messageId: "assistant-3",
+        swipeIndex: 1,
+        temperature: "Cold",
+      },
+      { signal: expect.any(AbortSignal) },
+    );
+    expect(window.localStorage.getItem(PATCH_QUEUE_STORAGE_KEY)).toBeNull();
+  });
+
+  it("does not update or queue manual patches while the current chat state is refreshing", async () => {
+    useGameStateStore.getState().setGameState(gameState({ location: "Town" }));
+    useGameStateStore.getState().setRefreshingChat("chat-1");
+
+    patchGameStateField("chat-1", "location", "Forest");
+    await flushGameStatePatch("chat-1");
+
+    expect(useGameStateStore.getState().current).toMatchObject({ location: "Town" });
+    expect(patchMock).not.toHaveBeenCalled();
+    expect(window.localStorage.getItem(PATCH_QUEUE_STORAGE_KEY)).toBeNull();
+  });
+
+  it("does not queue manual patches for a refreshing non-visible chat", async () => {
+    useGameStateStore.getState().setGameState(gameState({ chatId: "chat-1", location: "Town" }));
+    useGameStateStore.getState().setRefreshingChat("chat-2");
+
+    patchGameStateField("chat-2", "location", "Forest");
+    await flushGameStatePatch("chat-2");
+
+    expect(useGameStateStore.getState().current).toMatchObject({
+      chatId: "chat-1",
+      location: "Town",
+    });
+    expect(patchMock).not.toHaveBeenCalled();
+    expect(window.localStorage.getItem(PATCH_QUEUE_STORAGE_KEY)).toBeNull();
+  });
+
+  it("restores and flushes a durable pending patch when the patcher hook mounts", async () => {
+    let root: Root | null = null;
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    patchMock.mockResolvedValueOnce(gameState({ messageId: "assistant-5", swipeIndex: 2, weather: "Fog" }));
+    window.localStorage.setItem(
+      PATCH_QUEUE_STORAGE_KEY,
+      JSON.stringify([
+        [
+          "chat-1\u0000assistant-5\u00002",
+          {
+            chatId: "chat-1",
+            target: { messageId: "assistant-5", swipeIndex: 2 },
+            fields: { weather: "Fog" },
+            revision: 1,
+          },
+        ],
+      ]),
+    );
+
+    function Harness() {
+      useGameStatePatcher("chat-1", "restore-test");
+      return null;
+    }
+
+    try {
+      root = createRoot(container);
+      await act(async () => {
+        root!.render(createElement(Harness));
+      });
+
+      await vi.waitFor(() => {
+        expect(patchMock).toHaveBeenCalledWith(
+          "chat-1",
+          {
+            manual: true,
+            messageId: "assistant-5",
+            swipeIndex: 2,
+            weather: "Fog",
+          },
+          { signal: expect.any(AbortSignal) },
+        );
+      });
+      expect(window.localStorage.getItem(PATCH_QUEUE_STORAGE_KEY)).toBeNull();
+    } finally {
+      if (root) {
+        act(() => {
+          root!.unmount();
+        });
+      }
+      container.remove();
+    }
+  });
+});

--- a/src/features/runtime/world-state/hooks/use-world-state-patcher.ts
+++ b/src/features/runtime/world-state/hooks/use-world-state-patcher.ts
@@ -319,8 +319,8 @@ export async function flushGameStatePatch(chatId?: string) {
       if (durable?.revision === queuedSnapshot.revision) {
         durablePatches.delete(key);
         persistPendingPatches();
+        reconcileVisibleGameState(queuedSnapshot.chatId, payload);
       }
-      reconcileVisibleGameState(queuedSnapshot.chatId, payload);
     } catch (error) {
       if (!inFlightEntry.canceled) errors.push(error);
     }
@@ -370,6 +370,11 @@ export async function discardPendingGameStatePatch(chatId?: string) {
     .map((key) => inFlightPatches.get(key)?.promise)
     .filter((promise): promise is Promise<void> => Boolean(promise));
   await Promise.allSettled(inFlightSettles);
+
+  if (!chatId) {
+    restoredStoredPatches = false;
+    nextPatchRevision = 1;
+  }
 }
 
 function flushGameStatePatchOnUnload() {

--- a/src/features/runtime/world-state/hooks/use-world-state-patcher.ts
+++ b/src/features/runtime/world-state/hooks/use-world-state-patcher.ts
@@ -206,6 +206,13 @@ function reconcileVisibleGameState(chatId: string, payload: GameStatePatch & Gam
   const store = useGameStateStore.getState();
   const current = store.current;
   if (current?.chatId !== chatId) return;
+  if (
+    payload.messageId &&
+    (current.messageId !== payload.messageId ||
+      (payload.swipeIndex !== undefined && current.swipeIndex !== payload.swipeIndex))
+  ) {
+    return;
+  }
 
   store.setGameState({
     ...current,
@@ -418,7 +425,7 @@ export function patchGameStateField<K extends GameStatePatchField>(
   value: GameStatePatchValue[K],
 ) {
   const store = useGameStateStore.getState();
-  if (store.isRefreshing) return;
+  if (store.refreshingChatId === chatId) return;
   const prev = getCurrentGameStateForChat(chatId);
   const target = getPatchTarget(prev);
   const nextState = {

--- a/src/features/shell/bot-browser/components/BotBrowserView.test.tsx
+++ b/src/features/shell/bot-browser/components/BotBrowserView.test.tsx
@@ -1,0 +1,205 @@
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { BotBrowserView } from "./BotBrowserView";
+import { botBrowserGet } from "../api/bot-browser-api";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock("../api/bot-browser-api", () => ({
+  botBrowserAssetUrl: (path: string) => `tauri-api:/bot-browser/${path}`,
+  botBrowserBlob: vi.fn(),
+  botBrowserGet: vi.fn(),
+  botBrowserPost: vi.fn(),
+  fetchBotBrowserAssetBlob: vi.fn(),
+  importStCharacter: vi.fn(),
+  resolveBotBrowserAssetUrl: vi.fn(async (src: string) => src),
+}));
+
+vi.mock("../../../catalog/characters/index", () => ({
+  cacheCharacterListRecordFromResult: vi.fn(() => false),
+  invalidateCharacterCollectionQueries: vi.fn(),
+}));
+
+vi.mock("../../../catalog/lorebooks/index", () => ({
+  lorebookKeys: {
+    all: ["lorebooks"],
+  },
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    info: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+const botBrowserGetMock = vi.mocked(botBrowserGet);
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
+}
+
+function chubSearchResult() {
+  return {
+    data: {
+      nodes: [
+        {
+          fullPath: "marinara/retry-bot",
+          name: "Retry Bot",
+          tagline: "Recovered result",
+          topics: ["test"],
+          starCount: 12,
+          nChats: 34,
+          nTokens: 567,
+          nsfw: false,
+        },
+      ],
+      cursor: null,
+    },
+  };
+}
+
+function searchCallCount() {
+  return botBrowserGetMock.mock.calls.filter(([path]) => String(path).startsWith("chub/search?")).length;
+}
+
+async function flushSearchTimer() {
+  await act(async () => {
+    vi.runOnlyPendingTimers();
+  });
+}
+
+describe("BotBrowserView provider error UI", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    window.localStorage.clear();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+      },
+    });
+    botBrowserGetMock.mockImplementation(async (path) => {
+      const textPath = String(path);
+      if (textPath.endsWith("/session") || textPath === "pygmalion/session" || textPath === "chartavern/session") {
+        return { active: false };
+      }
+      if (textPath.startsWith("chub/search?")) {
+        return searchCallCount() === 1 ? Promise.reject(new Error("Chub provider unavailable")) : chubSearchResult();
+      }
+      return {};
+    });
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    queryClient.clear();
+    botBrowserGetMock.mockReset();
+    window.localStorage.clear();
+    vi.useRealTimers();
+  });
+
+  it("shows provider search failures as retryable errors instead of an empty result state", async () => {
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <BotBrowserView />
+        </QueryClientProvider>,
+      );
+    });
+
+    await flushSearchTimer();
+
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain("Chub provider unavailable");
+    });
+    expect(container.textContent).toContain("Retry");
+    expect(container.textContent).not.toContain("No characters found");
+
+    const retryButton = Array.from(container.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("Retry"),
+    );
+    expect(retryButton).toBeTruthy();
+
+    await act(async () => {
+      retryButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain("Retry Bot");
+    });
+    expect(searchCallCount()).toBe(2);
+    expect(container.textContent).not.toContain("Chub provider unavailable");
+  });
+
+  it("keeps newer search results visible when an older provider request fails late", async () => {
+    const firstSearch = deferred<ReturnType<typeof chubSearchResult>>();
+    botBrowserGetMock.mockImplementation(async (path) => {
+      const textPath = String(path);
+      if (textPath.endsWith("/session") || textPath === "pygmalion/session" || textPath === "chartavern/session") {
+        return { active: false };
+      }
+      if (textPath.startsWith("chub/search?")) {
+        return searchCallCount() === 1 ? firstSearch.promise : chubSearchResult();
+      }
+      return {};
+    });
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <BotBrowserView />
+        </QueryClientProvider>,
+      );
+    });
+
+    await flushSearchTimer();
+    expect(searchCallCount()).toBe(1);
+
+    const refreshButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.getAttribute("title") === "Refresh",
+    );
+    expect(refreshButton).toBeTruthy();
+
+    await act(async () => {
+      refreshButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain("Retry Bot");
+    });
+
+    await act(async () => {
+      firstSearch.reject(new Error("late provider failure"));
+      await Promise.resolve();
+    });
+
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain("Retry Bot");
+    });
+    expect(container.textContent).not.toContain("late provider failure");
+    expect(Array.from(container.querySelectorAll("button")).some((button) => button.textContent?.trim() === "Retry")).toBe(
+      false,
+    );
+  });
+});

--- a/src/features/shell/bot-browser/components/BotBrowserView.test.tsx
+++ b/src/features/shell/bot-browser/components/BotBrowserView.test.tsx
@@ -50,14 +50,15 @@ function deferred<T>() {
   return { promise, resolve, reject };
 }
 
-function chubSearchResult() {
+function chubSearchResult(name = "Retry Bot") {
+  const pathName = name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
   return {
     data: {
       nodes: [
         {
-          fullPath: "marinara/retry-bot",
-          name: "Retry Bot",
-          tagline: "Recovered result",
+          fullPath: `marinara/${pathName}`,
+          name,
+          tagline: `${name} result`,
           topics: ["test"],
           starCount: 12,
           nChats: 34,
@@ -72,6 +73,12 @@ function chubSearchResult() {
 
 function searchCallCount() {
   return botBrowserGetMock.mock.calls.filter(([path]) => String(path).startsWith("chub/search?")).length;
+}
+
+function setInputValue(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")?.set;
+  setter?.call(input, value);
+  input.dispatchEvent(new Event("input", { bubbles: true }));
 }
 
 async function flushSearchTimer() {
@@ -201,5 +208,53 @@ describe("BotBrowserView provider error UI", () => {
     expect(Array.from(container.querySelectorAll("button")).some((button) => button.textContent?.trim() === "Retry")).toBe(
       false,
     );
+  });
+
+  it("does not paint older results during the debounce gap after search criteria changes", async () => {
+    const firstSearch = deferred<ReturnType<typeof chubSearchResult>>();
+    botBrowserGetMock.mockImplementation(async (path) => {
+      const textPath = String(path);
+      if (textPath.endsWith("/session") || textPath === "pygmalion/session" || textPath === "chartavern/session") {
+        return { active: false };
+      }
+      if (textPath.startsWith("chub/search?")) {
+        return searchCallCount() === 1 ? firstSearch.promise : chubSearchResult("New Query Bot");
+      }
+      return {};
+    });
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <BotBrowserView />
+        </QueryClientProvider>,
+      );
+    });
+
+    await flushSearchTimer();
+    expect(searchCallCount()).toBe(1);
+
+    const searchInput = container.querySelector<HTMLInputElement>('input[placeholder="Search characters..."]');
+    expect(searchInput).toBeTruthy();
+
+    await act(async () => {
+      setInputValue(searchInput!, "new query");
+    });
+    expect(searchInput!.value).toBe("new query");
+
+    await act(async () => {
+      firstSearch.resolve(chubSearchResult("Old Query Bot"));
+      await firstSearch.promise;
+    });
+
+    expect(container.textContent).not.toContain("Old Query Bot");
+    expect(searchCallCount()).toBe(1);
+
+    await flushSearchTimer();
+
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain("New Query Bot");
+    });
+    expect(container.textContent).not.toContain("Old Query Bot");
   });
 });

--- a/src/features/shell/bot-browser/components/BotBrowserView.tsx
+++ b/src/features/shell/bot-browser/components/BotBrowserView.tsx
@@ -1202,6 +1202,7 @@ export function BotBrowserView() {
   }, []);
   const searchTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const searchRequestIdRef = useRef(0);
+  const searchCriteriaKeyRef = useRef("");
 
   // ── Check auth sessions on mount — sync persisted state with server ──
   useEffect(() => {
@@ -1308,9 +1309,43 @@ export function BotBrowserView() {
     };
   }, [sourceId]);
 
+  const searchCriteriaKey = useMemo(
+    () =>
+      JSON.stringify({
+        providerId: provider.id,
+        query,
+        page,
+        sort,
+        nsfw,
+        includeTags,
+        excludeTags,
+        sortAsc,
+        minTokens,
+        maxTokens,
+        features,
+        extraToggles,
+      }),
+    [
+      provider.id,
+      query,
+      page,
+      sort,
+      nsfw,
+      includeTags,
+      excludeTags,
+      sortAsc,
+      minTokens,
+      maxTokens,
+      features,
+      extraToggles,
+    ],
+  );
+  searchCriteriaKeyRef.current = searchCriteriaKey;
+
   const doSearch = useCallback(async () => {
     const requestId = searchRequestIdRef.current + 1;
     searchRequestIdRef.current = requestId;
+    const requestCriteriaKey = searchCriteriaKey;
     setLoading(true);
     setError(null);
     try {
@@ -1328,15 +1363,15 @@ export function BotBrowserView() {
         extraToggles,
       });
 
-      if (searchRequestIdRef.current !== requestId) return;
+      if (searchRequestIdRef.current !== requestId || searchCriteriaKeyRef.current !== requestCriteriaKey) return;
       setResults(result.cards);
       setTotalCount(result.totalCount);
     } catch (err) {
-      if (searchRequestIdRef.current !== requestId) return;
+      if (searchRequestIdRef.current !== requestId || searchCriteriaKeyRef.current !== requestCriteriaKey) return;
       setError(err instanceof Error ? err.message : "Search failed");
       setResults([]);
     } finally {
-      if (searchRequestIdRef.current === requestId) {
+      if (searchRequestIdRef.current === requestId && searchCriteriaKeyRef.current === requestCriteriaKey) {
         setLoading(false);
       }
     }
@@ -1353,6 +1388,7 @@ export function BotBrowserView() {
     maxTokens,
     features,
     extraToggles,
+    searchCriteriaKey,
   ]);
 
   useEffect(() => {

--- a/src/features/shell/bot-browser/components/BotBrowserView.tsx
+++ b/src/features/shell/bot-browser/components/BotBrowserView.tsx
@@ -1201,6 +1201,7 @@ export function BotBrowserView() {
     setPersistLogin("chartavern", val);
   }, []);
   const searchTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const searchRequestIdRef = useRef(0);
 
   // ── Check auth sessions on mount — sync persisted state with server ──
   useEffect(() => {
@@ -1308,6 +1309,8 @@ export function BotBrowserView() {
   }, [sourceId]);
 
   const doSearch = useCallback(async () => {
+    const requestId = searchRequestIdRef.current + 1;
+    searchRequestIdRef.current = requestId;
     setLoading(true);
     setError(null);
     try {
@@ -1325,13 +1328,17 @@ export function BotBrowserView() {
         extraToggles,
       });
 
+      if (searchRequestIdRef.current !== requestId) return;
       setResults(result.cards);
       setTotalCount(result.totalCount);
     } catch (err) {
+      if (searchRequestIdRef.current !== requestId) return;
       setError(err instanceof Error ? err.message : "Search failed");
       setResults([]);
     } finally {
-      setLoading(false);
+      if (searchRequestIdRef.current === requestId) {
+        setLoading(false);
+      }
     }
   }, [
     provider,


### PR DESCRIPTION
## Linked issue

No linked GitHub issue; selected from the local feature-layer focused-test gaps chore.

## Why this change

- Adds focused regression coverage around two feature-layer areas that had meaningful failure-path gaps: Bot Browser provider search state and runtime world-state manual patching.
- Fixes async edge cases found during failpath/Bunny review so stale provider results and stale world-state flushes do not overwrite newer user-visible state.

## What changed

- Added Bot Browser jsdom coverage for retryable provider failures, stale late failures after a newer refresh succeeds, and stale results resolving during the search debounce gap.
- Added world-state patcher coverage for optimistic/manual patch coalescing, same-chat target preservation, failed durable retry, refresh suppression, durable restore-on-mount, and concurrent same-target in-flight flushes.
- Updated Bot Browser search handling to validate both request generation and captured search criteria before applying results/errors/loading state.
- Updated world-state patch reconciliation so completed older same-target writes only reconcile visible state when that completed patch is still the latest durable revision.
- Refreshed Graphify output after source changes.

## Refactor impact

Primary owner:

- `features/shell/bot-browser` and `features/runtime/world-state`

Impact areas reviewed:

- Bot Browser search loading/error/empty/retry states
- World-state patch queue, optimistic visible state, durable localStorage restore, and refresh suppression
- Feature-layer dependency boundaries and generated Graphify map

Boundary notes:

- Feature/runtime-only TypeScript changes.
- No engine, shared API, Rust, Tauri command, or remote-runtime boundary changes.
- No raw Tauri invoke or raw remote-runtime fetch additions.

Pressure points touched:

- None of the known pressure points were touched: `ModeSurface`, `GameSurface`, shared mode UI, `src-tauri/src/lib.rs`, and import modules are unchanged.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->

- [x] `pnpm check` passes locally
- [x] `pnpm typecheck` passes locally
- [x] `pnpm build` passes locally
- [x] `pnpm check:architecture` passes locally
- [x] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- `pnpm exec vitest run src/features/runtime/world-state/hooks/use-world-state-patcher.test.ts src/features/shell/bot-browser/components/BotBrowserView.test.tsx` passed: 2 files / 10 tests.
- `pnpm typecheck` passed.
- `pnpm check:architecture` passed.
- `git diff --check origin/refactor...HEAD -- . ':(exclude)graphify-out/**'` was clean.
- `graphify update .` completed after the source changes.
- Native Tauri/manual Bot Browser UI verification was not run.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs changes were made because this PR changes focused feature/runtime behavior and regression tests, not contributor commands, architecture guidance, or public documentation.

## UI evidence

Not added. This PR has jsdom regression coverage for the visible Bot Browser state transitions, but no screenshot or Tauri/manual UI pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved game state patch handling to prevent stale state from being applied.
  * Enhanced bot browser search to discard outdated results and prevent display of stale data during searches.
  * Added safeguards against race conditions in async operations.

* **Tests**
  * Added comprehensive test coverage for game state patching and bot browser search behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1494?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->