### PR TITLE
Harden legacy profile import against silent data loss and size limits

### DIFF
--- a/src-tauri/src/commands/storage/profile/legacy.rs
+++ b/src-tauri/src/commands/storage/profile/legacy.rs
@@ -99,6 +99,14 @@ where
     let mut imported_conversation_notes = 0usize;
     let mut imported_ooc_influences = 0usize;
     for (table, collection) in LEGACY_PROFILE_TABLES {
+        // A partial profile (an older backup, a hand-built export, or a file
+        // missing a table) must not wipe collections it does not carry.
+        // Skipping the replacement leaves the user's existing collection
+        // untouched; a table that is present but empty is still an explicit
+        // clear and falls through to a normal empty replacement.
+        if !tables.contains_key(*table) {
+            continue;
+        }
         let mut rows = table_rows(tables, table);
         match *collection {
             "app-settings" => normalize_legacy_app_settings(&mut rows),
@@ -107,6 +115,7 @@ where
                 unsupported_prompt_overrides = normalize_profile_prompt_overrides(&mut rows)
             }
             "lorebooks" => add_legacy_lorebook_links(&mut rows, tables),
+            "lorebook-entries" => normalize_legacy_lorebook_entries(&mut rows),
             "chats" => {
                 add_legacy_chat_memories(&mut rows, tables);
                 let counts = add_legacy_connected_notes(&mut rows, tables);
@@ -265,6 +274,45 @@ fn add_legacy_lorebook_links(rows: &mut [Value], tables: &Map<String, Value>) {
             push_unique(&mut merged_persona_ids, &id);
         }
         object.insert("personaIds".to_string(), json!(merged_persona_ids));
+    }
+}
+
+/// Pre-refactor stored lorebook-entry bool columns (`caseSensitive`,
+/// `constant`, `locked`, ...) as TEXT (`"true"` / `"false"`) and the
+/// multi-value filter columns as TEXT-encoded JSON arrays (`"[]"`). The
+/// refactor frontend reads these directly, so `"false"` evaluates truthy in
+/// the entry editor and the keyword scanner's raw-truthiness checks misread
+/// `constant` / `preventRecursion`; a string `"[]"` also crashes the editor on
+/// `.map`. Coerce them to native types, matching the treatment the
+/// character-card import path (`normalize_lorebook_entry`) already applies.
+/// `keys` / `secondaryKeys` are handled separately by the generic
+/// `normalize_typed_json_fields` pass.
+fn normalize_legacy_lorebook_entries(rows: &mut [Value]) {
+    for row in rows {
+        normalize_legacy_text_bool_fields(
+            row,
+            &[
+                "enabled",
+                "constant",
+                "selective",
+                "matchWholeWords",
+                "caseSensitive",
+                "useRegex",
+                "preventRecursion",
+                "locked",
+                "excludeFromVectorization",
+            ],
+        );
+        normalize_legacy_text_array_fields(
+            row,
+            &[
+                "characterFilterIds",
+                "characterTagFilters",
+                "generationTriggerFilters",
+                "additionalMatchingSources",
+                "activationConditions",
+            ],
+        );
     }
 }
 
@@ -940,5 +988,135 @@ mod tests {
         assert_eq!(folder["id"], "folder-1");
         assert_eq!(folder["name"], "Provider Folder");
         assert_eq!(folder["collapsed"], true);
+    }
+
+    #[test]
+    fn legacy_lorebook_entries_coerce_text_bools_and_arrays() {
+        let state = test_state("lorebook-entry-coercion");
+        let mut tables = Map::new();
+        tables.insert(
+            "lorebook_entries".to_string(),
+            json!([
+                {
+                    "id": "entry-1",
+                    "lorebookId": "lore-1",
+                    "name": "NPC: Kafka",
+                    "keys": ["Kafka"],
+                    "secondaryKeys": [],
+                    "caseSensitive": "false",
+                    "constant": "false",
+                    "locked": "false",
+                    "preventRecursion": "false",
+                    "excludeFromVectorization": "false",
+                    "selective": "true",
+                    "enabled": "true",
+                    "matchWholeWords": true,
+                    "characterFilterIds": "[]",
+                    "characterTagFilters": "[]",
+                    "additionalMatchingSources": "[]",
+                    "activationConditions": "[]"
+                }
+            ]),
+        );
+
+        import_legacy_profile_tables_with_restored_assets(&state, &tables, 0, None, || Ok(()))
+            .expect("legacy lorebook-entry import should succeed");
+
+        let entry = state
+            .storage
+            .get("lorebook-entries", "entry-1")
+            .expect("entry lookup should not fail")
+            .expect("imported entry should be addressable by id");
+
+        for field in [
+            "caseSensitive",
+            "constant",
+            "locked",
+            "preventRecursion",
+            "excludeFromVectorization",
+            "selective",
+            "enabled",
+            "matchWholeWords",
+        ] {
+            assert!(
+                entry[field].is_boolean(),
+                "{field} should be a native boolean, got {:?}",
+                entry[field]
+            );
+        }
+        assert_eq!(entry["caseSensitive"], false);
+        assert_eq!(entry["constant"], false);
+        assert_eq!(entry["locked"], false);
+        assert_eq!(entry["preventRecursion"], false);
+        assert_eq!(entry["excludeFromVectorization"], false);
+        assert_eq!(entry["selective"], true);
+        assert_eq!(entry["enabled"], true);
+
+        for field in [
+            "characterFilterIds",
+            "characterTagFilters",
+            "additionalMatchingSources",
+            "activationConditions",
+        ] {
+            assert!(
+                entry[field].is_array(),
+                "{field} should be a native array, got {:?}",
+                entry[field]
+            );
+        }
+    }
+
+    #[test]
+    fn legacy_partial_profile_does_not_wipe_absent_collections() {
+        let state = test_state("partial-no-wipe");
+        state
+            .storage
+            .upsert_with_id(
+                "characters",
+                "char-1",
+                json!({ "name": "Keep Me", "data": { "name": "Keep Me" } }),
+            )
+            .expect("seeded character should write");
+        state
+            .storage
+            .upsert_with_id("lorebooks", "lore-1", json!({ "name": "Keep Me Too" }))
+            .expect("seeded lorebook should write");
+
+        let mut tables = Map::new();
+        tables.insert(
+            "chats".to_string(),
+            json!([
+                {
+                    "id": "chat-1",
+                    "name": "Imported Chat",
+                    "mode": "conversation",
+                    "metadata": {},
+                    "characterIds": []
+                }
+            ]),
+        );
+
+        import_legacy_profile_tables_with_restored_assets(&state, &tables, 0, None, || Ok(()))
+            .expect("partial legacy profile import should succeed");
+
+        // The table present in the file is replaced as expected...
+        let chat = state
+            .storage
+            .get("chats", "chat-1")
+            .expect("chat lookup should not fail")
+            .expect("imported chat should be present");
+        assert_eq!(chat["name"], "Imported Chat");
+
+        // ...but collections absent from the file are left untouched, not wiped.
+        assert!(state
+            .storage
+            .get("characters", "char-1")
+            .expect("character lookup should not fail")
+            .is_some());
+        assert!(state
+            .storage
+            .get("lorebooks", "lore-1")
+            .expect("lorebook lookup should not fail")
+            .is_some());
     }
 }

--- a/src-tauri/src/commands/storage/profile/legacy.rs
+++ b/src-tauri/src/commands/storage/profile/legacy.rs
@@ -11,7 +11,7 @@ use super::{
     finish_profile_import_assets, insert_profile_import_aliases, normalize_profile_prompt_overrides,
 };
 use crate::state::AppState;
-use marinara_core::AppResult;
+use marinara_core::{AppError, AppResult};
 use serde_json::{json, Map, Value};
 use std::collections::HashMap;
 use std::path::Path;
@@ -104,8 +104,17 @@ where
         // Skipping the replacement leaves the user's existing collection
         // untouched; a table that is present but empty is still an explicit
         // clear and falls through to a normal empty replacement.
-        if !tables.contains_key(*table) {
+        let Some(table_value) = tables.get(*table) else {
             continue;
+        };
+        // A present-but-non-array table is malformed (e.g. `"characters": {}`).
+        // `table_rows` would coerce it to an empty array, which silently clears
+        // the collection - the same data loss the absent-key skip above guards
+        // against. Reject the import instead so nothing is replaced.
+        if !table_value.is_array() {
+            return Err(AppError::invalid_input(format!(
+                "Legacy profile table `{table}` must be a JSON array"
+            )));
         }
         let mut rows = table_rows(tables, table);
         match *collection {
@@ -1117,6 +1126,35 @@ mod tests {
             .storage
             .get("lorebooks", "lore-1")
             .expect("lorebook lookup should not fail")
+            .is_some());
+    }
+
+    #[test]
+    fn legacy_present_but_malformed_table_is_rejected_without_wiping() {
+        let state = test_state("malformed-table-no-wipe");
+        state
+            .storage
+            .upsert_with_id(
+                "characters",
+                "char-1",
+                json!({ "name": "Keep Me", "data": { "name": "Keep Me" } }),
+            )
+            .expect("seeded character should write");
+
+        let mut tables = Map::new();
+        // Object instead of array: malformed, must not be treated as a clear.
+        tables.insert("characters".to_string(), json!({}));
+
+        let error =
+            import_legacy_profile_tables_with_restored_assets(&state, &tables, 0, None, || Ok(()))
+                .expect_err("a present-but-non-array table should be rejected");
+        assert_eq!(error.code, "invalid_input");
+
+        // The rejected import must not have wiped the existing collection.
+        assert!(state
+            .storage
+            .get("characters", "char-1")
+            .expect("character lookup should not fail")
             .is_some());
     }
 }

--- a/src-tauri/src/commands/storage/profile/zip_import.rs
+++ b/src-tauri/src/commands/storage/profile/zip_import.rs
@@ -7,11 +7,16 @@ use crate::state::AppState;
 use marinara_core::{AppError, AppResult};
 use serde_json::Value;
 use std::fs::File;
-use std::io::Read;
+use std::io::{BufReader, Read};
 use std::path::Path;
 
 const PROFILE_JSON_ENTRY: &str = "marinara-profile.json";
-const MAX_PROFILE_JSON_BYTES: usize = 128 * 1024 * 1024;
+// Heavy real-world profiles inline their chat/message tables (and large
+// fields like `chats.memories`) into marinara-profile.json, so the file scales
+// with history size and can reach hundreds of MB. Keep a generous sanity cap
+// to guard against a pathological multi-GB entry while still allowing real
+// migrations through.
+const MAX_PROFILE_JSON_BYTES: u64 = 1024 * 1024 * 1024;
 
 pub(super) fn import_profile_zip(state: &AppState, path: &Path) -> AppResult<Value> {
     let file = File::open(path)?;
@@ -104,13 +109,99 @@ fn read_profile_zip_json<R: Read + std::io::Seek>(
     let entry = archive.by_name(entry_name).map_err(|error| {
         AppError::invalid_input(format!("Could not read marinara-profile.json: {error}"))
     })?;
-    let mut raw = Vec::new();
-    let mut limited = entry.take(MAX_PROFILE_JSON_BYTES as u64);
-    limited.read_to_end(&mut raw)?;
-    if raw.len() == MAX_PROFILE_JSON_BYTES {
+    // Reject early on the declared uncompressed size so a pathological entry
+    // never starts streaming. The `.take` below still bounds the read in case
+    // the zip header understates the real size.
+    if entry.size() > MAX_PROFILE_JSON_BYTES {
         return Err(AppError::invalid_input(
             "marinara-profile.json in profile ZIP is too large",
         ));
     }
-    Ok(serde_json::from_slice(&raw)?)
+    // Stream the parse straight off the zip entry instead of buffering the
+    // whole file into a Vec first. serde still materializes the Value tree, but
+    // dropping the intermediate byte buffer keeps peak memory lower on the
+    // hundreds-of-MB profiles this path has to handle.
+    let reader = BufReader::new(entry.take(MAX_PROFILE_JSON_BYTES));
+    Ok(serde_json::from_reader(reader)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::AppState;
+    use serde_json::json;
+    use std::io::Write;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+    use zip::write::SimpleFileOptions;
+
+    fn nonce() -> u128 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after unix epoch")
+            .as_nanos()
+    }
+
+    fn test_state(label: &str) -> AppState {
+        let path = std::env::temp_dir().join(format!("marinara-zip-import-{label}-{}", nonce()));
+        if path.exists() {
+            std::fs::remove_dir_all(&path).expect("stale temp dir should be removable");
+        }
+        AppState::from_data_dir(path, Vec::new()).expect("test app state should initialize")
+    }
+
+    fn write_profile_zip(label: &str, profile_json: &str) -> PathBuf {
+        let zip_path =
+            std::env::temp_dir().join(format!("marinara-zip-import-{label}-{}.zip", nonce()));
+        let file = File::create(&zip_path).expect("zip file should be creatable");
+        let mut writer = zip::ZipWriter::new(file);
+        writer
+            .start_file(
+                PROFILE_JSON_ENTRY,
+                SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored),
+            )
+            .expect("zip entry should start");
+        writer
+            .write_all(profile_json.as_bytes())
+            .expect("zip entry should write");
+        writer.finish().expect("zip should finalize");
+        zip_path
+    }
+
+    #[test]
+    fn import_profile_zip_streams_legacy_tables_from_entry() {
+        let state = test_state("legacy-stream");
+        let profile_json = json!({
+            "type": "marinara_profile",
+            "data": {
+                "fileStorage": {
+                    "tables": {
+                        "chats": [
+                            {
+                                "id": "chat-1",
+                                "name": "Imported Chat",
+                                "mode": "conversation",
+                                "metadata": {},
+                                "characterIds": []
+                            }
+                        ]
+                    }
+                }
+            }
+        })
+        .to_string();
+        let zip_path = write_profile_zip("legacy-stream", &profile_json);
+
+        let result = import_profile_zip(&state, &zip_path).expect("zip import should succeed");
+        assert_eq!(result["success"], true);
+
+        let chat = state
+            .storage
+            .get("chats", "chat-1")
+            .expect("chat lookup should not fail")
+            .expect("imported chat should be present");
+        assert_eq!(chat["name"], "Imported Chat");
+
+        let _ = std::fs::remove_file(&zip_path);
+    }
 }

--- a/src/features/shell/settings/components/ProfileImportSection.tsx
+++ b/src/features/shell/settings/components/ProfileImportSection.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { profileApi } from "../../../../shared/api/profile-api";
 import { remoteRuntimeTarget } from "../../../../shared/api/remote-runtime";
+import { showConfirmDialog } from "../../../../shared/lib/app-dialogs";
 import { cn } from "../../../../shared/lib/utils";
 
 type ProfileImportStats = {
@@ -121,6 +122,18 @@ export function ProfileImportSection() {
         filters: [{ name: "Marinara Profile", extensions: ["json", "zip"] }],
       });
       if (typeof selected !== "string" || !selected.trim()) {
+        setProfileImportProgress(null);
+        return;
+      }
+      const confirmed = await showConfirmDialog({
+        title: "Import Profile",
+        message:
+          "Importing a profile replaces the collections contained in the file (for example characters, chats, lorebooks, and personas). Collections not present in the file are left untouched. This cannot be undone. Continue?",
+        confirmLabel: "Import",
+        cancelLabel: "Cancel",
+        tone: "destructive",
+      });
+      if (!confirmed) {
         setProfileImportProgress(null);
         return;
       }

--- a/src/features/shell/settings/components/ProfileImportSection.tsx
+++ b/src/features/shell/settings/components/ProfileImportSection.tsx
@@ -128,7 +128,7 @@ export function ProfileImportSection() {
       const confirmed = await showConfirmDialog({
         title: "Import Profile",
         message:
-          "Importing a profile replaces the collections contained in the file (for example characters, chats, lorebooks, and personas). Collections not present in the file are left untouched. This cannot be undone. Continue?",
+          "Importing a profile replaces data from the selected file and may remove existing collections, depending on the export format. This cannot be undone. Continue?",
         confirmLabel: "Import",
         cancelLabel: "Cancel",
         tone: "destructive",


### PR DESCRIPTION
## Why this change

Three issues from the Heavy Data / Legacy / Import smoke test (#1484) all live in the profile import path:

- **#1513** Legacy import left several lorebook-entry fields as TEXT instead of native types. `caseSensitive`, `constant`, `locked`, `preventRecursion`, `excludeFromVectorization`, `selective` and `enabled` came through as `"true"`/`"false"` strings, and the filter columns (`characterFilterIds`, `characterTagFilters`, `additionalMatchingSources`, `activationConditions`) as `"[]"` strings. The refactor reads these directly, so the entry editor showed the wrong toggle state (a string `"false"` is truthy in JS) and `keyword-scanner.ts` raw-truthiness checks could mis-treat entries as constant or suppress recursion.
- **#1512** A legacy import rebuilt replacements for the full fixed table list, so any collection absent from the file was wiped to empty. There was also no confirmation before the destructive replace.
- **#1511** `marinara-profile.json` was capped at 128MB, but heavy profiles inline their chat/message tables (and large fields like `chats.memories`), so a real heavy dataset could never be read.

## What changed

- `src-tauri/src/commands/storage/profile/legacy.rs`: coerce lorebook-entry bool/array fields to native types during import (matching the field set `normalize_lorebook_entry` produces); only replace collections whose table key is present in the file, so a partial file no longer wipes collections it omits (a present-but-empty table is still an explicit clear).
- `src-tauri/src/commands/storage/profile/zip_import.rs`: stream the parse with `serde_json::from_reader` off the zip entry instead of buffering the whole file into a `Vec`, reject early on the declared uncompressed size (with `.take` as the hard backstop against an understated header), and raise the sanity cap to 1 GiB.
- `src/features/shell/settings/components/ProfileImportSection.tsx`: add a destructive confirmation dialog before import.

## Verification

- `pnpm check` (architecture, frontend, rust, docs) passes locally.
- `cargo test --lib` 176 passed / 0 failed, including 3 new regression tests: lorebook-entry bool/array coercion, partial-profile no-wipe, and a streaming zip import. The Rust fixes are exercised at the command-function level against the real storage backend.
- `cargo clippy --workspace --all-targets -- -D warnings` clean; `tsc -b` clean.

Live `pnpm tauri dev` note: the only live path for these fixes is the real profile import, which `replace_all`s the running app's actual storage, so it is not safe to drive automatically against real data. The behavior is covered by the unit tests above (real storage layer on temp dirs). The 1 GiB boundary on a genuinely >128MB profile and the confirm dialog through the native file picker remain a recommended manual pass on a backed-up profile.

## Follow-ups (deferred, not blocking)

- `keyword-scanner.ts` still uses raw truthiness for `constant` / `preventRecursion` / `caseSensitive`. Root-caused here at the import boundary (stored data is now native), but defensive coercion in the scanner could be a separate hardening.
- The skip-absent fix covers the legacy table import path. The modern `data.collections` import path has the same full-replace behavior and is tracked separately in #1521.
- #1511 notes that `chats.memories` is stored inline on the chat row and can reach tens of MB on its own. Moving large inline fields out of `marinara-profile.json` is a larger format change left for later.

## Linked issues

Closes #1511
Closes #1512
Closes #1513

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Profile imports now require user confirmation before proceeding, with a warning that imported data will replace existing collections.

* **Bug Fixes**
  * Fixed profile imports to preserve existing collections when imported files omit certain data.
  * Corrected type handling for legacy profile data during import.

* **Performance Improvements**
  * Increased maximum profile file size limit to 1 GiB and optimized import process to stream data instead of loading entire files into memory.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1518?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->