### PR TITLE
Enroll source chat into its group when creating the first branch

### DIFF
--- a/src-tauri/src/commands/storage/chats.rs
+++ b/src-tauri/src/commands/storage/chats.rs
@@ -706,20 +706,34 @@ pub(crate) fn branch_chat(state: &AppState, chat_id: &str, body: Value) -> AppRe
         .and_then(Value::as_str)
         .unwrap_or("Chat")
         .to_string();
-    let group_id = object
+    let source_group_id = object
         .get("groupId")
         .and_then(Value::as_str)
-        .unwrap_or(chat_id)
-        .to_string();
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned);
+    let group_id = source_group_id
+        .clone()
+        .unwrap_or_else(|| chat_id.to_string());
     object.insert("id".to_string(), Value::String(new_chat_id.clone()));
     object.insert(
         "name".to_string(),
         Value::String(format!("{base_name} Branch")),
     );
-    object.insert("groupId".to_string(), Value::String(group_id));
+    object.insert("groupId".to_string(), Value::String(group_id.clone()));
     let source_has_tracker_snapshots =
         game_state_snapshots::latest_tracker_snapshot(state, chat_id)?.is_some();
     let mut new_chat = state.storage.create("chats", chat)?;
+    // The first branch turns the source chat into a group root. Enroll the
+    // source chat into the new group too, otherwise it keeps `groupId: null`
+    // and Manage Chat Files / the branch selector (which key off the active
+    // chat's groupId) cannot discover the branches when opened from the
+    // original chat. Mirrors the ST-chat-into-group import path.
+    if source_group_id.is_none() {
+        state
+            .storage
+            .patch("chats", chat_id, json!({ "groupId": group_id }))?;
+    }
     let up_to = body.get("upToMessageId").and_then(Value::as_str);
     let mut visible_tracker_target: Option<(String, i64)> = None;
     for mut message in messages_for_chat(state, chat_id)? {
@@ -1076,6 +1090,76 @@ mod tests {
             std::fs::remove_dir_all(&path).expect("stale temp chat delete dir should be removable");
         }
         AppState::from_data_dir(path, Vec::new()).expect("test app state should initialize")
+    }
+
+    #[test]
+    fn branch_chat_enrolls_ungrouped_source_chat_into_the_new_group() {
+        let state = test_state("branch-enroll-root");
+        state
+            .storage
+            .create(
+                "chats",
+                json!({
+                    "id": "root-1",
+                    "name": "New Roleplay",
+                    "mode": "roleplay",
+                    "characterIds": [],
+                    "metadata": {}
+                }),
+            )
+            .expect("source chat should be created");
+
+        let branch = branch_chat(&state, "root-1", json!({})).expect("branch should be created");
+
+        // The new branch joins a group keyed on the source chat id...
+        assert_eq!(branch["groupId"], "root-1");
+
+        // ...and the source/root chat is enrolled into that same group instead
+        // of keeping groupId: null, so Manage Chat Files finds the branches
+        // when opened from the original chat.
+        let source = state
+            .storage
+            .get("chats", "root-1")
+            .expect("source lookup should not fail")
+            .expect("source chat should still exist");
+        assert_eq!(source["groupId"], "root-1");
+
+        let mut filters = Map::new();
+        filters.insert("groupId".to_string(), Value::String("root-1".to_string()));
+        let group_members = state
+            .storage
+            .list_where("chats", &filters)
+            .expect("group listing should not fail");
+        assert_eq!(group_members.len(), 2);
+    }
+
+    #[test]
+    fn branch_chat_preserves_existing_group_without_repatching_source() {
+        let state = test_state("branch-existing-group");
+        state
+            .storage
+            .create(
+                "chats",
+                json!({
+                    "id": "root-1",
+                    "name": "Grouped Roleplay",
+                    "mode": "roleplay",
+                    "groupId": "existing-group",
+                    "characterIds": [],
+                    "metadata": {}
+                }),
+            )
+            .expect("source chat should be created");
+
+        let branch = branch_chat(&state, "root-1", json!({})).expect("branch should be created");
+
+        assert_eq!(branch["groupId"], "existing-group");
+        let source = state
+            .storage
+            .get("chats", "root-1")
+            .expect("source lookup should not fail")
+            .expect("source chat should still exist");
+        assert_eq!(source["groupId"], "existing-group");
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/chats.rs
+++ b/src-tauri/src/commands/storage/chats.rs
@@ -728,7 +728,12 @@ pub(crate) fn branch_chat(state: &AppState, chat_id: &str, body: Value) -> AppRe
     // source chat into the new group too, otherwise it keeps `groupId: null`
     // and Manage Chat Files / the branch selector (which key off the active
     // chat's groupId) cannot discover the branches when opened from the
-    // original chat. Mirrors the ST-chat-into-group import path.
+    // original chat. This mirrors the intent of the ST-chat-into-group import
+    // path (promote the root into the group); it does not copy that path's
+    // patch-then-rollback ordering. The branch is created first on purpose: if
+    // this enroll patch fails, the state is exactly the pre-fix one (branch
+    // grouped, root ungrouped) which a later branch attempt re-converges,
+    // rather than leaving a root enrolled in a group that has no branches.
     if source_group_id.is_none() {
         state
             .storage


### PR DESCRIPTION
## Why this change

After creating Roleplay branches, Manage Chat Files worked from a branch chat but the original/root chat still reported it was not part of a group and had no branches. `branch_chat` set the new branch's `groupId` to the source chat id, but left the source/root chat at `groupId: null`. The drawer and branch selector only fetch a group when the active chat has a `groupId`, so opening either from the original chat showed the no-group empty state even though branch records already pointed at that chat id.

## What changed

- `src-tauri/src/commands/storage/chats.rs`: when the source chat has no group, enroll it into the new group (keyed on its own id) alongside the branch, mirroring the intent of the ST-chat-into-group import path that already promotes the target chat to a group root. An empty-string `groupId` is now treated as ungrouped too. The branch is created first and the source enrolled after, on purpose: a failed enroll patch degrades to the pre-fix state rather than leaving a root in a branchless group.

## Verification

- `pnpm check` passes locally; `cargo test --lib` 176 passed / 0 failed, including two new regression tests: an ungrouped source chat gets enrolled and the group lists both chats, and an already-grouped source is not re-patched.
- `cargo clippy --workspace --all-targets -- -D warnings` clean.
- Verified on the real Tauri desktop shell (Playwright over WebView2 CDP, real `chat_branch` invoke through the real Rust runtime and real storage): branching an ungrouped roleplay chat enrolls the root, the branch joins the group, and `storage_list` filtered by `groupId` returns both the root and the branch. Seeded chats cleaned up afterward.

## Known caveat

This fixes branch discovery for chats branched after the change. Chats that were already branched while the root stayed ungrouped (the existing broken state in the report) are not retroactively patched; that migration is tracked in #1522.

## Follow-ups (deferred, not blocking)

- #1522: the Manage Chat / delete dialog counts the root as a branch (pre-existing, also affected ST-imported groups), and a one-time migration to repair already-branched chats whose root stayed ungrouped.

## Linked issue

Closes #1509

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved chat organization when branching conversations: branches now properly maintain group associations with their source chat, and ungrouped source chats are automatically enrolled in a new group with their branches.

* **Tests**
  * Added comprehensive test coverage for chat branching behavior with grouped and ungrouped source chats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1519?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->