### PR TITLE
[codex] Restore agent activity UI

### DIFF
--- a/src/features/catalog/agents/activity.ts
+++ b/src/features/catalog/agents/activity.ts
@@ -1,0 +1,2 @@
+export { AgentThoughtBubbles } from "./components/AgentThoughtBubbles";
+export { ContinuityIssueChecklist } from "./components/ContinuityIssueChecklist";

--- a/src/features/catalog/agents/components/AgentThoughtBubbles.tsx
+++ b/src/features/catalog/agents/components/AgentThoughtBubbles.tsx
@@ -23,6 +23,15 @@ export function AgentThoughtBubbles({ enabledAgentTypes }: { enabledAgentTypes?:
     .map((bubble, index) => ({ bubble, storeIndex: index }))
     .filter(({ bubble }) => !enabledAgentTypes || enabledAgentTypes.has(bubble.agentId));
   const showProcessing = isProcessing && (!enabledAgentTypes || enabledAgentTypes.size > 0);
+  const handleClearVisibleBubbles = () => {
+    if (!enabledAgentTypes) {
+      clearThoughtBubbles();
+      return;
+    }
+    for (const { storeIndex } of [...thoughtBubbles].reverse()) {
+      dismissThoughtBubble(storeIndex);
+    }
+  };
 
   if (thoughtBubbles.length === 0 && !showProcessing) return null;
 
@@ -60,7 +69,7 @@ export function AgentThoughtBubbles({ enabledAgentTypes }: { enabledAgentTypes?:
         </button>
         {thoughtBubbles.length > 0 && (
           <button
-            onClick={clearThoughtBubbles}
+            onClick={handleClearVisibleBubbles}
             className="rounded p-0.5 text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
             title="Dismiss all"
           >

--- a/src/features/catalog/agents/components/AgentThoughtBubbles.tsx
+++ b/src/features/catalog/agents/components/AgentThoughtBubbles.tsx
@@ -9,6 +9,7 @@ import { AnimatePresence, motion } from "framer-motion";
 import { Sparkles, ChevronDown, ChevronUp, X } from "lucide-react";
 import { useAgentStore } from "../../../../shared/stores/agent.store";
 import { cn } from "../../../../shared/lib/utils";
+import { ContinuityIssueChecklist } from "./ContinuityIssueChecklist";
 
 export function AgentThoughtBubbles({ enabledAgentTypes }: { enabledAgentTypes?: Set<string> }) {
   const allThoughtBubbles = useAgentStore((s) => s.thoughtBubbles);
@@ -18,11 +19,12 @@ export function AgentThoughtBubbles({ enabledAgentTypes }: { enabledAgentTypes?:
   const [collapsed, setCollapsed] = useState(false);
 
   // Filter bubbles to only agents active in the current chat
-  const thoughtBubbles = enabledAgentTypes
-    ? allThoughtBubbles.filter((b) => enabledAgentTypes.has(b.agentId))
-    : allThoughtBubbles;
+  const thoughtBubbles = allThoughtBubbles
+    .map((bubble, index) => ({ bubble, storeIndex: index }))
+    .filter(({ bubble }) => !enabledAgentTypes || enabledAgentTypes.has(bubble.agentId));
+  const showProcessing = isProcessing && (!enabledAgentTypes || enabledAgentTypes.size > 0);
 
-  if (thoughtBubbles.length === 0 && !isProcessing) return null;
+  if (thoughtBubbles.length === 0 && !showProcessing) return null;
 
   return (
     <motion.div
@@ -77,7 +79,7 @@ export function AgentThoughtBubbles({ enabledAgentTypes }: { enabledAgentTypes?:
             className="overflow-hidden rounded-b-lg border border-t-0 border-[var(--border)] bg-[var(--card)] shadow-lg shadow-black/20"
           >
             <div className="max-h-48 overflow-y-auto p-2 flex flex-col gap-1.5">
-              {thoughtBubbles.map((bubble, i) => (
+              {thoughtBubbles.map(({ bubble, storeIndex }) => (
                 <motion.div
                   key={`${bubble.agentId}-${bubble.timestamp}`}
                   initial={{ opacity: 0, x: 20 }}
@@ -86,16 +88,20 @@ export function AgentThoughtBubbles({ enabledAgentTypes }: { enabledAgentTypes?:
                   className="relative rounded-md bg-[var(--primary)]/8 p-2 text-xs"
                 >
                   <button
-                    onClick={() => dismissThoughtBubble(i)}
+                    onClick={() => dismissThoughtBubble(storeIndex)}
                     className="absolute right-1 top-1 rounded text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
                   >
                     <X size="0.75rem" />
                   </button>
                   <div className="pr-4">
                     <span className="font-semibold text-[var(--primary)]">{bubble.agentName}</span>
-                    <p className="mt-0.5 whitespace-pre-wrap text-[var(--muted-foreground)] leading-relaxed">
-                      {bubble.content}
-                    </p>
+                    {bubble.agentId === "continuity" ? (
+                      <ContinuityIssueChecklist content={bubble.content} />
+                    ) : (
+                      <p className="mt-0.5 whitespace-pre-wrap text-[var(--muted-foreground)] leading-relaxed">
+                        {bubble.content}
+                      </p>
+                    )}
                   </div>
                 </motion.div>
               ))}

--- a/src/features/modes/conversation/components/ChatConversationSurface.tsx
+++ b/src/features/modes/conversation/components/ChatConversationSurface.tsx
@@ -1,6 +1,7 @@
 import type { ComponentProps } from "react";
 import type { Message, SpriteSide } from "../../../../engine/contracts/types/chat";
 import { ConversationView } from "./ConversationView";
+import { AgentThoughtBubbles } from "../../../catalog/agents/activity";
 import { ChatCommonOverlays } from "../../shared/chat-ui/index";
 import type { CharacterMap, MessageSelectionToggle, PeekPromptData, PersonaInfo } from "../../shared/chat-ui/types";
 
@@ -32,6 +33,7 @@ type ConversationSurfaceProps = {
   personaInfo?: PersonaInfo;
   chatMeta: Record<string, any>;
   chatCharIds: string[];
+  enabledAgentTypes?: Set<string>;
   connectedChatName?: string;
   sceneInfo?: SceneInfo;
   settingsOpen: boolean;
@@ -96,6 +98,7 @@ export function ChatConversationSurface({
   personaInfo,
   chatMeta,
   chatCharIds,
+  enabledAgentTypes,
   connectedChatName,
   sceneInfo,
   settingsOpen,
@@ -221,6 +224,7 @@ export function ChatConversationSurface({
         onSelectAllAboveSelection={onSelectAllAboveSelection}
         onSelectAllBelowSelection={onSelectAllBelowSelection}
       />
+      <AgentThoughtBubbles enabledAgentTypes={enabledAgentTypes} />
     </div>
   );
 }

--- a/src/features/modes/conversation/components/ConversationModeRoute.tsx
+++ b/src/features/modes/conversation/components/ConversationModeRoute.tsx
@@ -40,7 +40,7 @@ export function ConversationModeRoute({ activeChatId }: ConversationModeRoutePro
 
   const overlays = useChatOverlays(activeChatId);
   const spriteState = useSpriteMetadataState({ chat: data.chat, chatMeta: data.chatMeta, messages: data.messages });
-  const { enabledAgentTypes, agentThoughtBubbleTypes } = useMemo(() => {
+  const { agentsEnabled, enabledAgentTypes, agentThoughtBubbleTypes } = useMemo(() => {
     const activeAgentIds = Array.isArray(data.chatMeta.activeAgentIds)
       ? data.chatMeta.activeAgentIds.filter((id): id is string => typeof id === "string" && id.trim().length > 0)
       : [];
@@ -48,6 +48,7 @@ export function ConversationModeRoute({ activeChatId }: ConversationModeRoutePro
     for (const id of activeAgentIds) set.add(id.trim());
     const agentsEnabled = Boolean(data.chatMeta.enableAgents) || activeAgentIds.length > 0;
     return {
+      agentsEnabled,
       enabledAgentTypes: agentsEnabled ? set : new Set<string>(),
       agentThoughtBubbleTypes: agentsEnabled && activeAgentIds.length === 0 ? undefined : set,
     };
@@ -57,7 +58,7 @@ export function ConversationModeRoute({ activeChatId }: ConversationModeRoutePro
     messages: data.messages,
     messageIdByOrderIndex: data.messageIdByOrderIndex,
     enabledAgentTypes,
-    refreshWorldStateOnTimelineChange: Boolean(data.chatMeta.enableAgents),
+    refreshWorldStateOnTimelineChange: agentsEnabled,
   });
   const shortcutsBlocked =
     overlays.settingsOpen ||

--- a/src/features/modes/conversation/components/ConversationModeRoute.tsx
+++ b/src/features/modes/conversation/components/ConversationModeRoute.tsx
@@ -40,12 +40,17 @@ export function ConversationModeRoute({ activeChatId }: ConversationModeRoutePro
 
   const overlays = useChatOverlays(activeChatId);
   const spriteState = useSpriteMetadataState({ chat: data.chat, chatMeta: data.chatMeta, messages: data.messages });
-  const enabledAgentTypes = useMemo(() => {
+  const { enabledAgentTypes, agentThoughtBubbleTypes } = useMemo(() => {
+    const activeAgentIds = Array.isArray(data.chatMeta.activeAgentIds)
+      ? data.chatMeta.activeAgentIds.filter((id): id is string => typeof id === "string" && id.trim().length > 0)
+      : [];
     const set = new Set<string>();
-    if (!data.chatMeta.enableAgents) return set;
-    const activeAgentIds: string[] = Array.isArray(data.chatMeta.activeAgentIds) ? data.chatMeta.activeAgentIds : [];
-    for (const id of activeAgentIds) set.add(id);
-    return set;
+    for (const id of activeAgentIds) set.add(id.trim());
+    const agentsEnabled = Boolean(data.chatMeta.enableAgents) || activeAgentIds.length > 0;
+    return {
+      enabledAgentTypes: agentsEnabled ? set : new Set<string>(),
+      agentThoughtBubbleTypes: agentsEnabled && activeAgentIds.length === 0 ? undefined : set,
+    };
   }, [data.chatMeta.activeAgentIds, data.chatMeta.enableAgents]);
   const timeline = useChatTimelineActions({
     activeChatId,
@@ -125,6 +130,7 @@ export function ConversationModeRoute({ activeChatId }: ConversationModeRoutePro
         personaInfo={data.personaInfo}
         chatMeta={data.chatMeta}
         chatCharIds={data.chatCharIds}
+        enabledAgentTypes={agentThoughtBubbleTypes}
         connectedChatName={data.connectedChatName}
         sceneInfo={sceneInfo}
         settingsOpen={overlays.settingsOpen}

--- a/src/features/modes/roleplay/components/RoleplayHUDActionsMenu.tsx
+++ b/src/features/modes/roleplay/components/RoleplayHUDActionsMenu.tsx
@@ -20,6 +20,7 @@ import {
   toAgentFailure,
   type AgentFailure,
 } from "../../../../shared/lib/agent-failures";
+import { ContinuityIssueChecklist } from "../../../catalog/agents/activity";
 import { ContextInjectionPanel } from "./ContextInjectionPanel";
 
 const SecretPlotPanel = lazy(async () =>
@@ -197,7 +198,11 @@ export function RoleplayHUDActionsMenu({
                     </button>
                     <div className="pr-4">
                       <span className="font-semibold text-foreground/75">{bubble.agentName}</span>
-                      <p className="mt-0.5 whitespace-pre-wrap text-white/50 leading-relaxed">{bubble.content}</p>
+                      {bubble.agentId === "continuity" ? (
+                        <ContinuityIssueChecklist content={bubble.content} compact />
+                      ) : (
+                        <p className="mt-0.5 whitespace-pre-wrap text-white/50 leading-relaxed">{bubble.content}</p>
+                      )}
                     </div>
                   </div>
                 ))}


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Refs #1496

## Why this change

- Restores and properly wires the orphaned agent activity UI slice identified during the Knip triage, without closing the broader issue because additional orphaned files remain.

## What changed

- Added a catalog agents activity public entrypoint for the restored components.
- Wired `AgentThoughtBubbles` into conversation mode so active agent work can surface during chat generation.
- Reused `ContinuityIssueChecklist` for continuity bubbles in conversation and roleplay agent activity surfaces.
- Fixed filtered thought-bubble dismissal to dismiss the original store entry instead of the filtered-array index.
- Aligned conversation agent gating so explicit `activeAgentIds` also keep timeline world-state refresh active for tracker-agent paths.

## Refactor impact

Primary owner:

catalog agents UI, conversation mode UI, roleplay mode HUD activity

Impact areas reviewed:

- Catalog agent component public entrypoint and private component imports
- Conversation mode agent thought bubble rendering and timeline refresh gating
- Roleplay HUD activity rendering for continuity bubbles
- Shared chat timeline action gating for tracker refresh
- Architecture dependency direction between modes and catalog

Boundary notes:

- Feature-layer UI only; no engine, shared API, Rust, storage, or remote-runtime boundary changes.
- Conversation and roleplay remain separate mode owners; shared restored UI is imported through the catalog agents public activity entrypoint.
- No raw Tauri invoke or remote-runtime fetch added.

Pressure points touched:

- Shared mode UI is only consumed through existing conversation surface and timeline hooks.
- Did not touch `ModeSurface`, `GameSurface`, `src-tauri/src/lib.rs`, or import modules.

## Validation

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- `pnpm typecheck` passed locally.
- `pnpm lint:eslint` passed locally.
- `pnpm check:architecture` passed locally.
- `pnpm build` passed locally; Vite still reports the existing large-chunk warning.
- `pnpm exec knip --reporter compact --no-exit-code --no-config-hints` reports 11 unused files remaining, down from the previous 13-file slice target.
- `git diff --check origin/refactor...HEAD` passed.
- No Tauri/manual UI pass was run in this slice.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs or release files were changed; this restores existing UI wiring and does not change public commands, architecture guidance, or release packaging claims.

## UI evidence

Not added; no browser, screenshot, recording, or native Tauri UI pass was run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent thought bubbles now display continuity issues in a dedicated checklist format
  * Enhanced filtering and enabling logic for agent visibility in conversations
  * Added support for selective agent type configuration in the conversation surface

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1527?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->