### PR TITLE
Fix roleplay background metadata sync

### DIFF
--- a/src/features/modes/shared/chat-ui/hooks/use-chat-metadata-sync.test.tsx
+++ b/src/features/modes/shared/chat-ui/hooks/use-chat-metadata-sync.test.tsx
@@ -134,6 +134,24 @@ describe("useChatMetadataSync", () => {
     expect(catalogMocks.mutate).not.toHaveBeenCalled();
   });
 
+  it("cancels a pending write when metadata catches up before the debounce fires", () => {
+    act(() => {
+      root.render(<Harness chatId="chat-with-caught-up-change" background="old-background.png" />);
+    });
+
+    act(() => {
+      useUIStore.getState().setChatBackground("https://media.local/new-background.png");
+    });
+    act(() => {
+      root.render(<Harness chatId="chat-with-caught-up-change" background="https://media.local/new-background.png" />);
+    });
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(catalogMocks.mutate).not.toHaveBeenCalled();
+  });
+
   it("keeps pending background writes isolated per chat", () => {
     act(() => {
       root.render(<Harness chatId="first-chat" background="first-saved.png" />);

--- a/src/features/modes/shared/chat-ui/hooks/use-chat-metadata-sync.test.tsx
+++ b/src/features/modes/shared/chat-ui/hooks/use-chat-metadata-sync.test.tsx
@@ -1,0 +1,165 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Chat } from "../../../../../engine/contracts/types/chat";
+import { useUIStore } from "../../../../../shared/stores/ui.store";
+import { useChatMetadataSync } from "./use-chat-metadata-sync";
+
+const catalogMocks = vi.hoisted(() => ({
+  mutate: vi.fn(),
+}));
+
+vi.mock("../../../../catalog/chats/index", () => ({
+  useUpdateChatMetadata: () => ({ mutate: catalogMocks.mutate }),
+}));
+
+type HarnessProps = {
+  chatId: string;
+  background: string | null;
+};
+
+function Harness({ chatId, background }: HarnessProps) {
+  useChatMetadataSync({
+    chat: { id: chatId } as Chat,
+    chatMeta: { background },
+    messages: [],
+    messagePageCount: 1,
+  });
+  return null;
+}
+
+describe("useChatMetadataSync", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    catalogMocks.mutate.mockReset();
+    useUIStore.getState().setChatBackground(null);
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    useUIStore.getState().setChatBackground(null);
+  });
+
+  it("clears a stale chat background when the active chat metadata hydrates to no background", () => {
+    act(() => {
+      root.render(<Harness chatId="chat-with-background" background="old-background.png" />);
+    });
+    expect(useUIStore.getState().chatBackground).toBe("marinara-background:old-background.png");
+
+    act(() => {
+      root.render(<Harness chatId="chat-without-background" background="old-background.png" />);
+    });
+    expect(useUIStore.getState().chatBackground).toBe("marinara-background:old-background.png");
+
+    act(() => {
+      root.render(<Harness chatId="chat-without-background" background={null} />);
+    });
+
+    expect(useUIStore.getState().chatBackground).toBeNull();
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(catalogMocks.mutate).not.toHaveBeenCalled();
+  });
+
+  it("restores a chat background when the active chat metadata hydrates with a background", () => {
+    act(() => {
+      root.render(<Harness chatId="chat-with-delayed-background" background={null} />);
+    });
+    expect(useUIStore.getState().chatBackground).toBeNull();
+
+    act(() => {
+      root.render(<Harness chatId="chat-with-delayed-background" background="new-background.png" />);
+    });
+
+    expect(useUIStore.getState().chatBackground).toBe("marinara-background:new-background.png");
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(catalogMocks.mutate).not.toHaveBeenCalled();
+  });
+
+  it("does not clobber a local background change when stale metadata refreshes before persistence", () => {
+    act(() => {
+      root.render(<Harness chatId="chat-with-local-change" background="persisted-background.png" />);
+    });
+    expect(useUIStore.getState().chatBackground).toBe("marinara-background:persisted-background.png");
+
+    act(() => {
+      useUIStore.getState().setChatBackground("https://media.local/new-background.png");
+    });
+
+    act(() => {
+      root.render(<Harness chatId="chat-with-local-change" background="stale-background.png" />);
+    });
+
+    expect(useUIStore.getState().chatBackground).toBe("https://media.local/new-background.png");
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(catalogMocks.mutate).toHaveBeenCalledWith({
+      id: "chat-with-local-change",
+      background: "https://media.local/new-background.png",
+    });
+  });
+
+  it("cancels a pending write when the active chat background returns to the saved value", () => {
+    act(() => {
+      root.render(<Harness chatId="chat-with-reverted-change" background="saved-background.png" />);
+    });
+
+    act(() => {
+      useUIStore.getState().setChatBackground("https://media.local/temporary-background.png");
+    });
+    act(() => {
+      useUIStore.getState().setChatBackground("marinara-background:saved-background.png");
+    });
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(catalogMocks.mutate).not.toHaveBeenCalled();
+  });
+
+  it("keeps pending background writes isolated per chat", () => {
+    act(() => {
+      root.render(<Harness chatId="first-chat" background="first-saved.png" />);
+    });
+    act(() => {
+      useUIStore.getState().setChatBackground("https://media.local/first-new.png");
+    });
+
+    act(() => {
+      root.render(<Harness chatId="second-chat" background="second-saved.png" />);
+    });
+    act(() => {
+      useUIStore.getState().setChatBackground("https://media.local/second-new.png");
+    });
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(catalogMocks.mutate).toHaveBeenCalledTimes(2);
+    expect(catalogMocks.mutate).toHaveBeenCalledWith({
+      id: "first-chat",
+      background: "https://media.local/first-new.png",
+    });
+    expect(catalogMocks.mutate).toHaveBeenCalledWith({
+      id: "second-chat",
+      background: "https://media.local/second-new.png",
+    });
+  });
+});

--- a/src/features/modes/shared/chat-ui/hooks/use-chat-metadata-sync.ts
+++ b/src/features/modes/shared/chat-ui/hooks/use-chat-metadata-sync.ts
@@ -115,7 +115,7 @@ export function useChatMetadataSync({ chat, chatMeta, messages, messagePageCount
     }
     scheduleBackgroundPersist(chatId, nextBackground);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [chatBackground, chat?.id]);
+  }, [chatBackground, chat?.id, chatMeta.background]);
 
   useEffect(() => {
     return () => {

--- a/src/features/modes/shared/chat-ui/hooks/use-chat-metadata-sync.ts
+++ b/src/features/modes/shared/chat-ui/hooks/use-chat-metadata-sync.ts
@@ -55,12 +55,34 @@ export function useChatMetadataSync({ chat, chatMeta, messages, messagePageCount
   useEffect(() => {
     if (!chat?.id) return;
     const restoredUrl = chatBackgroundMetadataToUrl(chatMeta.background);
-    restoredChatBackgroundRef.current = { chatId: chat.id, url: restoredUrl, isSyncing: true };
-    useUIStore.getState().setChatBackground(restoredUrl);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [chat?.id]);
+    const previousRestore = restoredChatBackgroundRef.current;
+    const currentBackground = useUIStore.getState().chatBackground;
+    const chatChanged = previousRestore.chatId !== chat.id;
+    const metadataCaughtUpToLocalChange = currentBackground === restoredUrl;
+    const backgroundStillAtLastRestore = currentBackground === previousRestore.url;
 
-  const bgPersistTimer = useRef<ReturnType<typeof setTimeout>>(null);
+    if (!chatChanged && !metadataCaughtUpToLocalChange && !backgroundStillAtLastRestore) return;
+
+    const needsUiRestore = currentBackground !== restoredUrl;
+    restoredChatBackgroundRef.current = { chatId: chat.id, url: restoredUrl, isSyncing: needsUiRestore };
+    if (needsUiRestore) useUIStore.getState().setChatBackground(restoredUrl);
+  }, [chat?.id, chatMeta.background]);
+
+  const bgPersistTimers = useRef(new Map<string, ReturnType<typeof setTimeout>>());
+  const clearBackgroundPersistTimer = (chatId: string) => {
+    const timer = bgPersistTimers.current.get(chatId);
+    if (!timer) return;
+    clearTimeout(timer);
+    bgPersistTimers.current.delete(chatId);
+  };
+  const scheduleBackgroundPersist = (chatId: string, background: string | null) => {
+    clearBackgroundPersistTimer(chatId);
+    const timer = setTimeout(() => {
+      bgPersistTimers.current.delete(chatId);
+      updateMeta.mutate({ id: chatId, background });
+    }, 500);
+    bgPersistTimers.current.set(chatId, timer);
+  };
   useEffect(() => {
     if (!chat?.id) return;
     const chatId = chat.id;
@@ -78,26 +100,27 @@ export function useChatMetadataSync({ chat, chatMeta, messages, messagePageCount
     }
 
     if (!chatBackground) {
-      if (savedBackground === null) return;
-      if (bgPersistTimer.current) clearTimeout(bgPersistTimer.current);
-      bgPersistTimer.current = setTimeout(() => {
-        updateMeta.mutate({ id: chatId, background: null });
-      }, 500);
+      if (savedBackground === null) {
+        clearBackgroundPersistTimer(chatId);
+        return;
+      }
+      scheduleBackgroundPersist(chatId, null);
       return;
     }
 
     const nextBackground = chatBackgroundUrlToMetadata(chatBackground);
-    if (nextBackground === savedBackground) return;
-    if (bgPersistTimer.current) clearTimeout(bgPersistTimer.current);
-    bgPersistTimer.current = setTimeout(() => {
-      updateMeta.mutate({ id: chatId, background: nextBackground });
-    }, 500);
+    if (nextBackground === savedBackground) {
+      clearBackgroundPersistTimer(chatId);
+      return;
+    }
+    scheduleBackgroundPersist(chatId, nextBackground);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [chatBackground, chat?.id]);
 
   useEffect(() => {
     return () => {
-      if (bgPersistTimer.current) clearTimeout(bgPersistTimer.current);
+      for (const timer of bgPersistTimers.current.values()) clearTimeout(timer);
+      bgPersistTimers.current.clear();
     };
   }, []);
 


### PR DESCRIPTION
## Linked issue

Closes #1508

## Why this change

- Roleplay could keep showing the previous chat background after switching to a chat or branch whose metadata has no background.
- The live metadata restore path only ran on chat id changes, so delayed metadata hydration could leave the UI store stuck on the previous background until reload.

## What changed

- Restore chat background UI state when the active chat's background metadata safely changes, not only when the chat id changes.
- Preserve local pending background changes when stale metadata refreshes arrive.
- Track background persistence debounce timers per chat so one chat's pending write does not cancel another chat's write.
- Added focused hook coverage for stale-null hydration, delayed background hydration, stale metadata refreshes, reverted changes, caught-up metadata, and two-chat debounce isolation.

## Refactor impact

Primary owner:

- Shared mode UI: `src/features/modes/shared/chat-ui/hooks/use-chat-metadata-sync.ts`

Impact areas reviewed:

- Roleplay mode background restore path from issue #1508.
- Shared hook consumers in Conversation, Roleplay, and Game mode routes.
- UI-store background state and chat metadata persistence debounce behavior.

Boundary notes:

- No engine, shared API, Tauri/Rust, storage schema, provider, or remote-runtime boundary changes.
- The fix stays inside shared mode UI and uses the existing catalog metadata mutation hook.

Pressure points touched:

- Shared mode UI metadata hook. No `ModeSurface`, `GameSurface`, `src-tauri/src/lib.rs`, or import module changes.

## Validation

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

Automated validation run locally:

- `pnpm vitest run src/features/modes/shared/chat-ui/hooks/use-chat-metadata-sync.test.tsx` passed, 6 tests.
- `pnpm typecheck` passed.
- `pnpm check:architecture` passed.
- `git diff --check origin/refactor...HEAD -- . ':(exclude)graphify-out/**'` passed.

Manual native Tauri branch-switch QA is still needed for the exact issue reproduction.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

Notes: no `CHANGELOG.md` exists on this checkout; no docs were changed because this is a narrow UI state bugfix.

## UI evidence

No new screenshots attached. The original issue includes local repro screenshots; this PR adds focused hook regression coverage and still needs a native manual UI confirmation pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for chat background synchronization behaviors.

* **Bug Fixes**
  * Improved chat background persistence to better handle metadata updates and prevent local changes from being lost during synchronization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1542?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->