### PR TITLE
Restore Tauri opener link wiring

### DIFF
--- a/src/features/shell/settings/components/SettingsPanel.tsx
+++ b/src/features/shell/settings/components/SettingsPanel.tsx
@@ -19,6 +19,7 @@ import { cn } from "../../../../shared/lib/utils";
 import { useExtensions, useCreateExtension, useDeleteExtension, useUpdateExtension } from "../hooks/use-extensions";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { gameAssetsApi } from "../../../../shared/api/assets-api";
+import { openExternalUrl } from "../../../../shared/api/external-link-api";
 import { importApi } from "../../../../shared/api/import-api";
 import { backupApi, profileApi, type ManagedBackup } from "../../../../shared/api/profile-api";
 import { updatesApi, type UpdateCheckResponse } from "../../../../shared/api/updates-api";
@@ -3367,7 +3368,7 @@ function AdvancedSettings() {
     setOpeningUpdate(true);
     try {
       const result = await updatesApi.apply(updateInfo);
-      window.open(result.releaseUrl, "_blank", "noopener,noreferrer");
+      await openExternalUrl(result.releaseUrl);
       toast.info(result.message);
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Failed to open update");

--- a/src/features/shell/settings/components/SettingsPanel.tsx
+++ b/src/features/shell/settings/components/SettingsPanel.tsx
@@ -3368,8 +3368,14 @@ function AdvancedSettings() {
     setOpeningUpdate(true);
     try {
       const result = await updatesApi.apply(updateInfo);
-      await openExternalUrl(result.releaseUrl);
-      toast.info(result.message);
+      try {
+        await openExternalUrl(result.releaseUrl);
+        toast.info(result.message);
+      } catch (openErr) {
+        toast.error(openErr instanceof Error ? openErr.message : "Failed to open update", {
+          description: result.message,
+        });
+      }
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Failed to open update");
     } finally {

--- a/src/features/shell/spotify/components/SpotifyMiniPlayer.tsx
+++ b/src/features/shell/spotify/components/SpotifyMiniPlayer.tsx
@@ -30,6 +30,7 @@ import {
 } from "react";
 import { toast } from "sonner";
 import { ApiError } from "../../../../shared/api/api-errors";
+import { openExternalUrl } from "../../../../shared/api/external-link-api";
 import { spotifyApi } from "../../../../shared/api/integration-utility-api";
 import {
   SPOTIFY_SCENE_TRACK_CHANGE_EVENT,
@@ -598,7 +599,11 @@ export function SpotifyMiniPlayer({ mobile = false }: { mobile?: boolean }) {
         action: result.playlistUrl
           ? {
               label: "Open playlist",
-              onClick: () => window.open(result.playlistUrl!, "_blank", "noopener,noreferrer"),
+              onClick: () => {
+                void openExternalUrl(result.playlistUrl!).catch((error) => {
+                  toast.error(error instanceof Error ? error.message : "Failed to open playlist");
+                });
+              },
             }
           : undefined,
       });

--- a/src/shared/api/external-link-api.test.ts
+++ b/src/shared/api/external-link-api.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { openExternalUrl } from "./external-link-api";
+
+const openUrlMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@tauri-apps/plugin-opener", () => ({
+  openUrl: openUrlMock,
+}));
+
+describe("openExternalUrl", () => {
+  beforeEach(() => {
+    openUrlMock.mockReset();
+    vi.unstubAllGlobals();
+    vi.stubGlobal("__TAURI__", undefined);
+    vi.stubGlobal("__TAURI_INTERNALS__", undefined);
+  });
+
+  it("opens links with the browser fallback outside embedded Tauri", async () => {
+    const windowOpen = vi.fn(() => ({})) as unknown as typeof window.open;
+    vi.stubGlobal("open", windowOpen);
+
+    await openExternalUrl("https://example.com/docs");
+
+    expect(windowOpen).toHaveBeenCalledWith("https://example.com/docs", "_blank", "noopener,noreferrer");
+    expect(openUrlMock).not.toHaveBeenCalled();
+  });
+
+  it("uses the Tauri opener plugin in embedded Tauri", async () => {
+    const windowOpen = vi.fn(() => ({})) as unknown as typeof window.open;
+    vi.stubGlobal("open", windowOpen);
+    vi.stubGlobal("__TAURI_INTERNALS__", {});
+
+    await openExternalUrl("https://example.com/native");
+
+    expect(openUrlMock).toHaveBeenCalledWith("https://example.com/native");
+    expect(windowOpen).not.toHaveBeenCalled();
+  });
+
+  it("rejects unsupported URL protocols", async () => {
+    const windowOpen = vi.fn(() => ({})) as unknown as typeof window.open;
+    vi.stubGlobal("open", windowOpen);
+
+    await expect(openExternalUrl("javascript:alert(1)")).rejects.toThrow("Unsupported external URL protocol");
+
+    expect(windowOpen).not.toHaveBeenCalled();
+    expect(openUrlMock).not.toHaveBeenCalled();
+  });
+
+  it("reports empty and malformed URLs with stable errors", async () => {
+    const windowOpen = vi.fn(() => ({})) as unknown as typeof window.open;
+    vi.stubGlobal("open", windowOpen);
+
+    await expect(openExternalUrl("")).rejects.toThrow("External URL is empty.");
+    await expect(openExternalUrl("not a url")).rejects.toThrow("External URL is invalid.");
+
+    expect(windowOpen).not.toHaveBeenCalled();
+    expect(openUrlMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/shared/api/external-link-api.test.ts
+++ b/src/shared/api/external-link-api.test.ts
@@ -17,12 +17,37 @@ describe("openExternalUrl", () => {
   });
 
   it("opens links with the browser fallback outside embedded Tauri", async () => {
-    const windowOpen = vi.fn(() => ({})) as unknown as typeof window.open;
+    const openedWindow = { opener: {}, location: { href: "" } } as unknown as Window;
+    const windowOpen = vi.fn(() => openedWindow) as unknown as typeof window.open;
     vi.stubGlobal("open", windowOpen);
 
     await openExternalUrl("https://example.com/docs");
 
-    expect(windowOpen).toHaveBeenCalledWith("https://example.com/docs", "_blank", "noopener,noreferrer");
+    expect(windowOpen).toHaveBeenCalledWith("about:blank", "_blank");
+    expect(openedWindow.opener).toBeNull();
+    expect(openedWindow.location.href).toBe("https://example.com/docs");
+    expect(openUrlMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects blocked browser popups outside embedded Tauri", async () => {
+    const windowOpen = vi.fn(() => null) as unknown as typeof window.open;
+    vi.stubGlobal("open", windowOpen);
+
+    await expect(openExternalUrl("https://example.com/docs")).rejects.toThrow(
+      "The browser blocked the external URL popup.",
+    );
+
+    expect(windowOpen).toHaveBeenCalledWith("about:blank", "_blank");
+    expect(openUrlMock).not.toHaveBeenCalled();
+  });
+
+  it("opens external-handler protocols without treating null as a blocked popup", async () => {
+    const windowOpen = vi.fn(() => null) as unknown as typeof window.open;
+    vi.stubGlobal("open", windowOpen);
+
+    await openExternalUrl("mailto:mari@example.com");
+
+    expect(windowOpen).toHaveBeenCalledWith("mailto:mari@example.com", "_blank", "noopener,noreferrer");
     expect(openUrlMock).not.toHaveBeenCalled();
   });
 

--- a/src/shared/api/external-link-api.test.ts
+++ b/src/shared/api/external-link-api.test.ts
@@ -17,7 +17,15 @@ describe("openExternalUrl", () => {
   });
 
   it("opens links with the browser fallback outside embedded Tauri", async () => {
-    const openedWindow = { opener: {}, location: { href: "" } } as unknown as Window;
+    const openedLink = { href: "", rel: "", target: "", click: vi.fn() };
+    const appendLink = vi.fn();
+    const openedWindow = {
+      opener: {},
+      document: {
+        body: { append: appendLink },
+        createElement: vi.fn(() => openedLink),
+      },
+    } as unknown as Window;
     const windowOpen = vi.fn(() => openedWindow) as unknown as typeof window.open;
     vi.stubGlobal("open", windowOpen);
 
@@ -25,7 +33,12 @@ describe("openExternalUrl", () => {
 
     expect(windowOpen).toHaveBeenCalledWith("about:blank", "_blank");
     expect(openedWindow.opener).toBeNull();
-    expect(openedWindow.location.href).toBe("https://example.com/docs");
+    expect(openedWindow.document.createElement).toHaveBeenCalledWith("a");
+    expect(openedLink.href).toBe("https://example.com/docs");
+    expect(openedLink.rel).toBe("noreferrer");
+    expect(openedLink.target).toBe("_self");
+    expect(appendLink).toHaveBeenCalledWith(openedLink);
+    expect(openedLink.click).toHaveBeenCalled();
     expect(openUrlMock).not.toHaveBeenCalled();
   });
 

--- a/src/shared/api/external-link-api.ts
+++ b/src/shared/api/external-link-api.ts
@@ -1,0 +1,47 @@
+type TauriOpenerApi = typeof import("@tauri-apps/plugin-opener");
+
+const EXTERNAL_URL_PROTOCOLS = new Set(["http:", "https:", "mailto:", "tel:"]);
+
+function hasEmbeddedTauriRuntime(): boolean {
+  if (typeof window === "undefined") return false;
+  const tauriWindow = window as unknown as { __TAURI__?: unknown; __TAURI_INTERNALS__?: unknown };
+  return Boolean(tauriWindow.__TAURI__ || tauriWindow.__TAURI_INTERNALS__);
+}
+
+function normalizeExternalUrl(rawUrl: string | URL): string {
+  const value = rawUrl instanceof URL ? rawUrl.toString() : rawUrl.trim();
+  if (!value) throw new Error("External URL is empty.");
+
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error("External URL is invalid.");
+  }
+
+  if (!EXTERNAL_URL_PROTOCOLS.has(url.protocol)) {
+    throw new Error(`Unsupported external URL protocol: ${url.protocol || "unknown"}`);
+  }
+  return url.toString();
+}
+
+function openExternalUrlInBrowser(url: string): void {
+  if (typeof window === "undefined") {
+    throw new Error("External URLs can only be opened in a browser or Tauri runtime.");
+  }
+  window.open(url, "_blank", "noopener,noreferrer");
+}
+
+async function getTauriOpenerApi(): Promise<TauriOpenerApi> {
+  return import("@tauri-apps/plugin-opener");
+}
+
+export async function openExternalUrl(rawUrl: string | URL): Promise<void> {
+  const url = normalizeExternalUrl(rawUrl);
+  if (!hasEmbeddedTauriRuntime()) {
+    openExternalUrlInBrowser(url);
+    return;
+  }
+  const { openUrl } = await getTauriOpenerApi();
+  await openUrl(url);
+}

--- a/src/shared/api/external-link-api.ts
+++ b/src/shared/api/external-link-api.ts
@@ -38,13 +38,19 @@ function openExternalUrlInBrowser(url: string): void {
   }
 
   // `noopener` can force a null return even when the popup succeeds, so open a
-  // detectable blank page and sever the opener before navigating.
+  // detectable blank page, sever the opener, then navigate with noreferrer.
   const opened = window.open("about:blank", "_blank");
   if (opened == null) {
     throw new Error("The browser blocked the external URL popup.");
   }
   opened.opener = null;
-  opened.location.href = url;
+
+  const link = opened.document.createElement("a");
+  link.href = url;
+  link.rel = "noreferrer";
+  link.target = "_self";
+  opened.document.body.append(link);
+  link.click();
 }
 
 async function getTauriOpenerApi(): Promise<TauriOpenerApi> {

--- a/src/shared/api/external-link-api.ts
+++ b/src/shared/api/external-link-api.ts
@@ -1,6 +1,7 @@
 type TauriOpenerApi = typeof import("@tauri-apps/plugin-opener");
 
 const EXTERNAL_URL_PROTOCOLS = new Set(["http:", "https:", "mailto:", "tel:"]);
+const BROWSER_POPUP_PROTOCOLS = new Set(["http:", "https:"]);
 
 function hasEmbeddedTauriRuntime(): boolean {
   if (typeof window === "undefined") return false;
@@ -29,7 +30,21 @@ function openExternalUrlInBrowser(url: string): void {
   if (typeof window === "undefined") {
     throw new Error("External URLs can only be opened in a browser or Tauri runtime.");
   }
-  window.open(url, "_blank", "noopener,noreferrer");
+
+  const parsedUrl = new URL(url);
+  if (!BROWSER_POPUP_PROTOCOLS.has(parsedUrl.protocol)) {
+    window.open(url, "_blank", "noopener,noreferrer");
+    return;
+  }
+
+  // `noopener` can force a null return even when the popup succeeds, so open a
+  // detectable blank page and sever the opener before navigating.
+  const opened = window.open("about:blank", "_blank");
+  if (opened == null) {
+    throw new Error("The browser blocked the external URL popup.");
+  }
+  opened.opener = null;
+  opened.location.href = url;
 }
 
 async function getTauriOpenerApi(): Promise<TauriOpenerApi> {

--- a/src/shared/api/integration-utility-api.ts
+++ b/src/shared/api/integration-utility-api.ts
@@ -1,4 +1,5 @@
 import { fileToUploadPayload } from "./file-payload";
+import { openExternalUrl } from "./external-link-api";
 import { remoteRuntimeTarget } from "./remote-runtime";
 import { invokeTauri } from "./tauri-client";
 export { ttsApi } from "./tts-api";
@@ -51,7 +52,7 @@ export const spotifyApi = {
     const shouldOpenClientSide = Boolean(remoteRuntimeTarget());
     const response = await invokeTauri<SpotifyAuthorizeResponse>("spotify_authorize", { input });
     if (shouldOpenClientSide && response.authUrl) {
-      window.open(response.authUrl, "_blank", "noopener,noreferrer");
+      await openExternalUrl(response.authUrl);
     }
     return response;
   },


### PR DESCRIPTION
## Linked issue

Follow-up to #1496.

## Why this change

- After the Knip unused-file cleanup, the full Knip report still flagged `@tauri-apps/plugin-opener` as unused even though the Rust plugin is installed and permissioned.
- The practical restore path is to wire external URL flows through the existing Tauri opener binding instead of deleting the dependency.

## What changed

- Added a focused `src/shared/api/external-link-api.ts` wrapper for external URL opening.
- The wrapper validates `http:`, `https:`, `mailto:`, and `tel:` URLs, uses `@tauri-apps/plugin-opener` in embedded Tauri, and preserves browser `window.open` behavior outside Tauri.
- Routed Spotify authorization, Spotify playlist opening, and manual update release opening through the wrapper.
- Preserved the manual-update handoff text if the release page fails to open.
- Added focused unit coverage for browser fallback, embedded Tauri opener usage, unsupported protocols, and empty/malformed URLs.

## Refactor impact

Primary owner:

Shared API runtime adapter, with shell Settings and Spotify callers.

Impact areas reviewed:

- Settings update handoff flow
- Spotify authorization and playlist external links
- Tauri opener plugin permission surface
- Browser/hosted fallback behavior
- Knip dependency report for `@tauri-apps/plugin-opener`

Boundary notes:

- Feature code calls a focused shared API wrapper instead of importing the Tauri plugin directly.
- No engine, Rust command, remote-runtime allowlist, or HTTP dispatch changes.
- Native opener capability already exists in `src-tauri/capabilities/default.json` via `opener:default`.

Pressure points touched:

- None of `ModeSurface`, `GameSurface`, command registration, or import modules were touched.

## Validation

- [x] `pnpm check` passes locally
- [x] `pnpm typecheck` passes locally
- [x] `pnpm build` passes locally
- [x] `pnpm check:architecture` passes locally
- [x] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

Automated checks run locally:

- `pnpm test -- src/shared/api/external-link-api.test.ts` passed.
- `pnpm typecheck` passed.
- `pnpm lint:eslint` passed.
- `pnpm check:unused` passed.
- `pnpm build` passed with the existing large chunk warning.
- `git diff origin/refactor...HEAD --check` passed.
- `pnpm exec knip --reporter compact --no-exit-code --no-config-hints` no longer reports `@tauri-apps/plugin-opener` as unused.

Manual/native gap:

- Native Tauri click-through QA for the actual OS opener handoff was not run.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs were changed; this restores an existing dependency wiring path without changing documented setup or architecture guidance.

## UI evidence

No screenshots included; this changes external-link handling, not visible layout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * External links (app updates, Spotify playlists, authorization URLs) now provide improved error handling with user-friendly error messages when opening fails.

* **Tests**
  * Added test coverage for external link functionality, validating correct behavior in web browser and embedded application environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1563?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->