### PR TITLE
Fix Chat Settings header hit targets

### DIFF
--- a/src/features/modes/shared/chat-ui/components/ChatSettingsDrawer.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatSettingsDrawer.tsx
@@ -6282,7 +6282,7 @@ function AdvancedParametersSection({
   };
 
   return (
-    <div className="relative border-b border-[var(--border)]">
+    <div className="border-b border-[var(--border)]">
       <ChatSettingsSectionHeader
         label="Advanced Parameters"
         icon={<Settings2 size="0.875rem" />}

--- a/src/features/modes/shared/chat-ui/components/ChatSettingsDrawer.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatSettingsDrawer.tsx
@@ -72,6 +72,7 @@ import { ChoiceSelectionModal } from "../../../../catalog/presets/index";
 import { SummariesEditorModal } from "./SummariesEditorModal";
 import {
   AgentCategorySection,
+  ChatSettingsSectionHeader,
   ChatSettingsSection as Section,
   PickerDropdown,
   SpriteRangeSlider,
@@ -6281,30 +6282,14 @@ function AdvancedParametersSection({
   };
 
   return (
-    <div className="border-b border-[var(--border)]">
-      <div className="flex w-full items-center gap-2 px-4 py-3 transition-colors hover:bg-[var(--accent)]/50">
-        <button
-          type="button"
-          onClick={() => setExpanded((o) => !o)}
-          aria-expanded={expanded}
-          className="flex min-w-0 flex-1 items-center gap-2 text-left"
-        >
-          <span className="text-[var(--muted-foreground)]">
-            <Settings2 size="0.875rem" />
-          </span>
-          <span className="flex-1 text-xs font-semibold">Advanced Parameters</span>
-          <ChevronDown
-            size="0.75rem"
-            className={cn("text-[var(--muted-foreground)] transition-transform", expanded && "rotate-180")}
-          />
-        </button>
-        <span className="shrink-0">
-          <HelpTooltip
-            text="Override generation parameters for this chat. Only change these if you know what you're doing."
-            side="left"
-          />
-        </span>
-      </div>
+    <div className="relative border-b border-[var(--border)]">
+      <ChatSettingsSectionHeader
+        label="Advanced Parameters"
+        icon={<Settings2 size="0.875rem" />}
+        help="Override generation parameters for this chat. Only change these if you know what you're doing."
+        expanded={expanded}
+        onToggle={() => setExpanded((o) => !o)}
+      />
       {expanded && (
         <div className="px-4 pb-3 space-y-3">
           {inheritedGenerationParametersPending ? (

--- a/src/features/modes/shared/chat-ui/components/settings/ChatSettingsSections.test.tsx
+++ b/src/features/modes/shared/chat-ui/components/settings/ChatSettingsSections.test.tsx
@@ -34,8 +34,10 @@ describe("ChatSettingsSection", () => {
     });
 
     const section = container.firstElementChild as HTMLElement;
-    const header = section.firstElementChild as HTMLElement;
+    const headerWrapper = section.firstElementChild as HTMLElement;
+    const header = headerWrapper.firstElementChild as HTMLElement;
 
+    expect(headerWrapper.className).toContain("relative");
     expect(header.tagName).toBe("BUTTON");
 
     act(() => {
@@ -55,8 +57,10 @@ describe("ChatSettingsSection", () => {
     });
 
     const helpButton = container.querySelector('button[aria-label="Show help"]') as HTMLButtonElement;
-    const header = container.firstElementChild?.firstElementChild as HTMLElement;
+    const headerWrapper = container.firstElementChild?.firstElementChild as HTMLElement;
+    const header = headerWrapper.firstElementChild as HTMLElement;
 
+    expect(headerWrapper.contains(helpButton)).toBe(true);
     expect(header.contains(helpButton)).toBe(false);
 
     act(() => {

--- a/src/features/modes/shared/chat-ui/components/settings/ChatSettingsSections.test.tsx
+++ b/src/features/modes/shared/chat-ui/components/settings/ChatSettingsSections.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ChatSettingsSection } from "./ChatSettingsSections";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("ChatSettingsSection", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("uses the visible header row as the toggle target", () => {
+    act(() => {
+      root.render(
+        <ChatSettingsSection label="Behavior">
+          <span>Expanded settings</span>
+        </ChatSettingsSection>,
+      );
+    });
+
+    const section = container.firstElementChild as HTMLElement;
+    const header = section.firstElementChild as HTMLElement;
+
+    expect(header.tagName).toBe("BUTTON");
+
+    act(() => {
+      header.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(container.textContent).toContain("Expanded settings");
+  });
+
+  it("keeps the help tooltip from toggling the section", () => {
+    act(() => {
+      root.render(
+        <ChatSettingsSection label="Behavior" help="Explain the setting.">
+          <span>Expanded settings</span>
+        </ChatSettingsSection>,
+      );
+    });
+
+    const helpButton = container.querySelector('button[aria-label="Show help"]') as HTMLButtonElement;
+    const header = container.firstElementChild?.firstElementChild as HTMLElement;
+
+    expect(header.contains(helpButton)).toBe(false);
+
+    act(() => {
+      helpButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(container.textContent).not.toContain("Expanded settings");
+  });
+});

--- a/src/features/modes/shared/chat-ui/components/settings/ChatSettingsSections.tsx
+++ b/src/features/modes/shared/chat-ui/components/settings/ChatSettingsSections.tsx
@@ -19,7 +19,7 @@ export function ChatSettingsSectionHeader({
   onToggle: () => void;
 }) {
   return (
-    <>
+    <div className="relative">
       <button
         type="button"
         onClick={onToggle}
@@ -46,7 +46,7 @@ export function ChatSettingsSectionHeader({
           <HelpTooltip text={help} side="left" />
         </span>
       )}
-    </>
+    </div>
   );
 }
 
@@ -66,7 +66,7 @@ export function ChatSettingsSection({
   const [open, setOpen] = useState(false);
 
   return (
-    <div className="relative border-b border-[var(--border)]">
+    <div className="border-b border-[var(--border)]">
       <ChatSettingsSectionHeader
         label={label}
         icon={icon}

--- a/src/features/modes/shared/chat-ui/components/settings/ChatSettingsSections.tsx
+++ b/src/features/modes/shared/chat-ui/components/settings/ChatSettingsSections.tsx
@@ -3,6 +3,53 @@ import { useEffect, useRef, useState, type ReactNode } from "react";
 import { HelpTooltip } from "../../../../../../shared/components/ui/HelpTooltip";
 import { cn } from "../../../../../../shared/lib/utils";
 
+export function ChatSettingsSectionHeader({
+  label,
+  icon,
+  count,
+  help,
+  expanded,
+  onToggle,
+}: {
+  label: string;
+  icon?: ReactNode;
+  count?: number;
+  help?: string;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <>
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={expanded}
+        className={cn(
+          "flex min-h-11 w-full min-w-0 items-center gap-2 px-4 py-3 text-left transition-colors hover:bg-[var(--accent)]/50",
+          help && "pr-12 max-md:pr-16",
+        )}
+      >
+        {icon && <span className="text-[var(--muted-foreground)]">{icon}</span>}
+        <span className="flex-1 truncate text-xs font-semibold">{label}</span>
+        {count != null && count > 0 && (
+          <span className="rounded-full bg-[var(--primary)]/15 px-1.5 py-0.5 text-[0.625rem] font-medium text-[var(--primary)]">
+            {count}
+          </span>
+        )}
+        <ChevronDown
+          size="0.75rem"
+          className={cn("text-[var(--muted-foreground)] transition-transform", expanded && "rotate-180")}
+        />
+      </button>
+      {help && (
+        <span className="absolute right-4 top-3 z-10 max-md:top-0">
+          <HelpTooltip text={help} side="left" />
+        </span>
+      )}
+    </>
+  );
+}
+
 export function ChatSettingsSection({
   label,
   icon,
@@ -19,27 +66,15 @@ export function ChatSettingsSection({
   const [open, setOpen] = useState(false);
 
   return (
-    <div className="border-b border-[var(--border)]">
-      <div className="flex items-center gap-2 px-4 py-3 transition-colors hover:bg-[var(--accent)]/50">
-        <button
-          type="button"
-          onClick={() => setOpen((o) => !o)}
-          className="flex min-w-0 flex-1 items-center gap-2 text-left"
-        >
-          {icon && <span className="text-[var(--muted-foreground)]">{icon}</span>}
-          <span className="flex-1 truncate text-xs font-semibold">{label}</span>
-          {count != null && count > 0 && (
-            <span className="rounded-full bg-[var(--primary)]/15 px-1.5 py-0.5 text-[0.625rem] font-medium text-[var(--primary)]">
-              {count}
-            </span>
-          )}
-          <ChevronDown
-            size="0.75rem"
-            className={cn("text-[var(--muted-foreground)] transition-transform", open && "rotate-180")}
-          />
-        </button>
-        {help && <HelpTooltip text={help} side="left" />}
-      </div>
+    <div className="relative border-b border-[var(--border)]">
+      <ChatSettingsSectionHeader
+        label={label}
+        icon={icon}
+        count={count}
+        help={help}
+        expanded={open}
+        onToggle={() => setOpen((o) => !o)}
+      />
       {open && <div className="px-6 py-3">{children}</div>}
     </div>
   );


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #1525

## Why this change

- Chat Settings drawer section headers looked full-row clickable, but only the inner label/chevron button toggled expansion. This made Conversation and Roleplay settings feel like they required precise chevron-line clicks.

## What changed

- Added a shared `ChatSettingsSectionHeader` row control so the visible header row is the actual toggle target.
- Reused that header for Advanced Parameters so it follows the same hit-target behavior as the shared drawer sections.
- Added jsdom regression coverage for full-row toggling and for keeping the help tooltip outside the toggle button.

## Refactor impact

Primary owner:

- Shared mode UI: `src/features/modes/shared/chat-ui`

Impact areas reviewed:

- Conversation Chat Settings drawer sections
- Roleplay Chat Settings drawer sections
- Advanced Parameters section
- Help tooltip interaction inside section headers

Boundary notes:

- Feature UI only. No engine, shared API, Rust, storage, provider, or remote-runtime boundary changes.

Pressure points touched:

- Shared mode UI via `ChatSettingsDrawer` and `ChatSettingsSections`

## Validation

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Reproduced the issue before the fix with `pnpm vitest run src/features/modes/shared/chat-ui/components/settings/ChatSettingsSections.test.tsx`; the regression test failed because the visible header row was a `DIV`, not the toggle button.
- Verified after the fix with `pnpm vitest run src/features/modes/shared/chat-ui/components/settings/ChatSettingsSections.test.tsx`.
- Ran `pnpm typecheck`.
- Ran `pnpm check:architecture`.
- Ran `git diff --check origin/refactor..HEAD`.
- Manual Tauri app drawer-click QA is still not covered in this branch.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs changes were made because this is a narrow interaction bugfix. This branch does not contain a `CHANGELOG.md`.

## UI evidence

Focused component regression coverage was added. No screenshots or recordings are attached; native/manual UI verification remains for a human pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured Advanced Parameters section header UI for improved component organization.

* **Tests**
  * Added comprehensive test coverage for settings section toggle behavior and help tooltip interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1564?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->