### PR TITLE
Fix lorebook prompt activation settings

### DIFF
--- a/src/engine/generation-core/lorebooks/prompt-injector.ts
+++ b/src/engine/generation-core/lorebooks/prompt-injector.ts
@@ -112,11 +112,41 @@ export function injectAtDepth(
  * Uses a rough estimate of 4 characters per token.
  */
 export function applyTokenBudget(activatedEntries: ActivatedEntry[], tokenBudget: number): ActivatedEntry[] {
-  if (tokenBudget <= 0) return activatedEntries;
+  return applyTokenBudgetWithSkipped(activatedEntries, tokenBudget).includedEntries;
+}
+
+export interface BudgetSkippedActivatedEntry {
+  activatedEntry: ActivatedEntry;
+  estimatedTokens: number;
+  usedTokensBefore: number;
+}
+
+/**
+ * Apply the same budget ordering as applyTokenBudget, while preserving the
+ * entries that were dropped so callers can surface budget diagnostics.
+ */
+export function applyTokenBudgetWithSkipped(
+  activatedEntries: ActivatedEntry[],
+  tokenBudget: number,
+): {
+  includedEntries: ActivatedEntry[];
+  skippedEntries: BudgetSkippedActivatedEntry[];
+  totalTokensEstimate: number;
+} {
+  if (tokenBudget <= 0) {
+    const totalChars = activatedEntries.reduce((sum, entry) => sum + entry.entry.content.length, 0);
+    return {
+      includedEntries: activatedEntries,
+      skippedEntries: [],
+      totalTokensEstimate: Math.ceil(totalChars / 4),
+    };
+  }
 
   const CHARS_PER_TOKEN = 4;
   let totalTokens = 0;
-  const result: ActivatedEntry[] = [];
+  let budgetExhausted = false;
+  const includedEntries: ActivatedEntry[] = [];
+  const skippedEntries: BudgetSkippedActivatedEntry[] = [];
 
   // Sort: constant entries first, then by order
   const sorted = [...activatedEntries].sort((a, b) => {
@@ -126,16 +156,21 @@ export function applyTokenBudget(activatedEntries: ActivatedEntry[], tokenBudget
   });
 
   for (const entry of sorted) {
-    const entryTokens = Math.ceil(entry.entry.content.length / CHARS_PER_TOKEN);
-    if (totalTokens + entryTokens > tokenBudget) {
-      // Budget exhausted — skip remaining entries
-      break;
+    const estimatedTokens = Math.ceil(entry.entry.content.length / CHARS_PER_TOKEN);
+    if (budgetExhausted || totalTokens + estimatedTokens > tokenBudget) {
+      budgetExhausted = true;
+      skippedEntries.push({ activatedEntry: entry, estimatedTokens, usedTokensBefore: totalTokens });
+      continue;
     }
-    totalTokens += entryTokens;
-    result.push(entry);
+    totalTokens += estimatedTokens;
+    includedEntries.push(entry);
   }
 
-  return result;
+  return {
+    includedEntries,
+    skippedEntries,
+    totalTokensEstimate: totalTokens,
+  };
 }
 
 /**
@@ -149,27 +184,27 @@ export function processActivatedEntries(
   worldInfoAfter: string;
   depthEntries: Array<{ content: string; role: LorebookRole; depth: number; order: number }>;
   includedEntries: ActivatedEntry[];
+  skippedEntries: BudgetSkippedActivatedEntry[];
   totalEntries: number;
   totalTokensEstimate: number;
 } {
   // Apply budget
-  const budgeted = applyTokenBudget(activatedEntries, tokenBudget);
+  const budgeted = applyTokenBudgetWithSkipped(activatedEntries, tokenBudget);
+  const includedEntries = budgeted.includedEntries;
 
   // Build blocks
-  const { before, after } = buildWorldInfoBlocks(budgeted);
+  const { before, after } = buildWorldInfoBlocks(includedEntries);
 
   // Get depth entries
-  const depthEntries = getDepthInjectedEntries(budgeted);
-
-  // Estimate tokens
-  const totalChars = budgeted.reduce((sum, a) => sum + a.entry.content.length, 0);
+  const depthEntries = getDepthInjectedEntries(includedEntries);
 
   return {
     worldInfoBefore: before,
     worldInfoAfter: after,
     depthEntries,
-    includedEntries: budgeted,
-    totalEntries: budgeted.length,
-    totalTokensEstimate: Math.ceil(totalChars / 4),
+    includedEntries,
+    skippedEntries: budgeted.skippedEntries,
+    totalEntries: includedEntries.length,
+    totalTokensEstimate: budgeted.totalTokensEstimate,
   };
 }

--- a/src/engine/generation-core/lorebooks/prompt-injector.ts
+++ b/src/engine/generation-core/lorebooks/prompt-injector.ts
@@ -148,6 +148,7 @@ export function processActivatedEntries(
   worldInfoBefore: string;
   worldInfoAfter: string;
   depthEntries: Array<{ content: string; role: LorebookRole; depth: number; order: number }>;
+  includedEntries: ActivatedEntry[];
   totalEntries: number;
   totalTokensEstimate: number;
 } {
@@ -167,6 +168,7 @@ export function processActivatedEntries(
     worldInfoBefore: before,
     worldInfoAfter: after,
     depthEntries,
+    includedEntries: budgeted,
     totalEntries: budgeted.length,
     totalTokensEstimate: Math.ceil(totalChars / 4),
   };

--- a/src/engine/generation/active-lorebooks.ts
+++ b/src/engine/generation/active-lorebooks.ts
@@ -1,6 +1,6 @@
 import type { StorageGateway } from "../capabilities/storage";
 import { loadChatMessages, requireRecord, resolveGenerationConnection } from "./context";
-import { assembleGenerationPrompt } from "./prompt-assembly";
+import { assembleGenerationPrompt, type BudgetSkippedLorebookEntry } from "./prompt-assembly";
 
 export interface ActiveLorebookScanResult {
   entries: Array<{
@@ -12,7 +12,7 @@ export interface ActiveLorebookScanResult {
     order: number;
     constant: boolean;
   }>;
-  budgetSkippedEntries: [];
+  budgetSkippedEntries: BudgetSkippedLorebookEntry[];
   totalTokens: number;
   totalEntries: number;
 }
@@ -42,7 +42,7 @@ export async function scanActiveLorebookEntries(
   }));
   return {
     entries,
-    budgetSkippedEntries: [],
+    budgetSkippedEntries: assembly.budgetSkippedLorebookEntries,
     totalTokens: Math.ceil(entries.reduce((sum, entry) => sum + entry.content.length, 0) / 4),
     totalEntries: entries.length,
   };

--- a/src/engine/generation/prompt-assembly.test.ts
+++ b/src/engine/generation/prompt-assembly.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { StorageGateway } from "../capabilities/storage";
 import { DEFAULT_GENERATION_PARAMS } from "../contracts/constants/defaults";
 import { fingerprintChatSummary } from "../shared/text/chat-summary-fingerprint";
+import { scanActiveLorebookEntries } from "./active-lorebooks";
 import { assembleGenerationPrompt } from "./prompt-assembly";
 
 type Row = Record<string, unknown>;
@@ -1336,6 +1337,36 @@ describe("assembleGenerationPrompt lorebook activation settings", () => {
     expect(promptText(assembly)).toContain("LQA_RECURSIVE_CHILD_CONTENT_SHOULD_APPEAR");
   });
 
+  it("caps malformed lorebook recursion depth to the schema maximum", async () => {
+    const chainEntries = Array.from({ length: 12 }, (_, index) => ({
+      id: `entry-recursive-cap-${index}`,
+      lorebookId: "lorebook",
+      name: `Recursive cap ${index}`,
+      content: `LQA_RECURSION_CAP_CONTENT_${index}${index < 11 ? ` LQA_CAP_KEY_${index + 1}` : ""}`,
+      keys: [`LQA_CAP_KEY_${index}`],
+      enabled: true,
+      order: index,
+    }));
+    const assembly = await assembleGenerationPrompt(
+      storageWithLore(
+        chainEntries,
+        [{ id: "lorebook", enabled: true, isGlobal: true, recursiveScanning: true, maxRecursionDepth: 99 }],
+      ),
+      {
+        chat: { id: "chat", mode: "roleplay" },
+        storedMessages: [{ role: "user", content: "Trigger LQA_CAP_KEY_0.", contextKind: "history" }],
+        connection: {},
+        request: { ...request, promptPresetId: "" },
+        latestUserInput: "Trigger LQA_CAP_KEY_0.",
+      },
+    );
+
+    expect(assembly.activatedLorebookEntries.map((entry) => entry.name)).toEqual(
+      Array.from({ length: 11 }, (_, index) => `Recursive cap ${index}`),
+    );
+    expect(promptText(assembly)).not.toContain("LQA_RECURSION_CAP_CONTENT_11");
+  });
+
   it("applies chat metadata lorebook token budget during prompt injection", async () => {
     const assembly = await assembleGenerationPrompt(
       storageWithLore([
@@ -1358,7 +1389,57 @@ describe("assembleGenerationPrompt lorebook activation settings", () => {
     );
 
     expect(assembly.activatedLorebookEntries).toHaveLength(0);
+    expect(assembly.budgetSkippedLorebookEntries).toMatchObject([
+      {
+        id: "entry-chat-budget",
+        blockedBy: "chat",
+        chatBudget: 1,
+        chatUsedTokens: 0,
+      },
+    ]);
     expect(promptText(assembly)).not.toContain("LQA_CHAT_BUDGET_CONTENT_SHOULD_NOT_APPEAR");
+  });
+
+  it("returns budget skipped lorebook entries for active-world-info scans", async () => {
+    const baseStorage = storageWithLore(
+      [
+        {
+          id: "entry-active-scan-budget",
+          lorebookId: "lorebook",
+          name: "Active scan budgeted entry",
+          content: "LQA_ACTIVE_SCAN_BUDGET_CONTENT_SHOULD_NOT_APPEAR",
+          enabled: true,
+          constant: true,
+        },
+      ],
+      [{ id: "lorebook", name: "Budget test book", enabled: true, isGlobal: true }],
+    );
+    const storage: StorageGateway = {
+      ...baseStorage,
+      get: async <T>(entity: string, id: string) => {
+        if (entity === "chats" && id === "chat") {
+          return { id: "chat", mode: "roleplay", metadata: { lorebookTokenBudget: 1 } } as T;
+        }
+        return baseStorage.get<T>(entity, id);
+      },
+      list: async <T>(entity: string, options?: { filters?: Record<string, unknown> }) => {
+        if (entity === "connections") return [{}] as T[];
+        return baseStorage.list<T>(entity, options);
+      },
+      listChatMessages: async () => [],
+    };
+
+    const scan = await scanActiveLorebookEntries(storage, "chat");
+
+    expect(scan.entries).toHaveLength(0);
+    expect(scan.budgetSkippedEntries).toMatchObject([
+      {
+        id: "entry-active-scan-budget",
+        lorebookName: "Budget test book",
+        blockedBy: "chat",
+        chatBudget: 1,
+      },
+    ]);
   });
 
   it("applies per-lorebook token budgets before prompt injection", async () => {
@@ -1386,6 +1467,14 @@ describe("assembleGenerationPrompt lorebook activation settings", () => {
     );
 
     expect(assembly.activatedLorebookEntries).toHaveLength(0);
+    expect(assembly.budgetSkippedLorebookEntries).toMatchObject([
+      {
+        id: "entry-book-budget",
+        blockedBy: "lorebook",
+        lorebookBudget: 1,
+        lorebookUsedTokens: 0,
+      },
+    ]);
     expect(promptText(assembly)).not.toContain("LQA_LOREBOOK_BUDGET_CONTENT_SHOULD_NOT_APPEAR");
   });
 });

--- a/src/engine/generation/prompt-assembly.test.ts
+++ b/src/engine/generation/prompt-assembly.test.ts
@@ -151,11 +151,15 @@ function storageWithSectionsAndCharacters(sections: Row[], characters: Row[]): S
 function storageWithLore(
   entries: Row[],
   lorebooks: Row[] = [{ id: "lorebook", enabled: true, isGlobal: true }],
+  folders: Row[] = [],
 ): StorageGateway {
   return {
     ...storageWithSections([]),
-    list: async <T>(entity: string) => {
+    list: async <T>(entity: string, options?: { filters?: Record<string, unknown> }) => {
       if (entity === "lorebooks") return lorebooks as T[];
+      if (entity === "lorebook-folders") {
+        return folders.filter((folder) => folder.lorebookId === options?.filters?.lorebookId) as T[];
+      }
       if (entity === "regex-scripts") return [] as T[];
       if (entity === "personas") return [] as T[];
       if (entity === "prompts") return [] as T[];
@@ -164,6 +168,10 @@ function storageWithLore(
     listLorebookEntries: async <T>(lorebookId: string) =>
       entries.filter((entry) => !entry.lorebookId || entry.lorebookId === lorebookId) as T[],
   };
+}
+
+function promptText(assembly: Awaited<ReturnType<typeof assembleGenerationPrompt>>): string {
+  return assembly.messages.map((message) => message.content).join("\n\n");
 }
 
 const request = {
@@ -1136,6 +1144,249 @@ describe("assembleGenerationPrompt game character sheets", () => {
     const joined = assembly.messages.map((message) => message.content).join("\n\n");
     expect(joined).toContain("RPG Attributes: Strength: 8, Dexterity: 16");
     expect(joined).toContain("RPG HP: 18/24");
+  });
+});
+
+describe("assembleGenerationPrompt lorebook activation settings", () => {
+  it("skips entries inside disabled lorebook folders", async () => {
+    const assembly = await assembleGenerationPrompt(
+      storageWithLore(
+        [
+          {
+            id: "entry-disabled-folder",
+            lorebookId: "lorebook",
+            folderId: "folder-disabled",
+            name: "Disabled folder entry",
+            content: "LQA_DISABLED_FOLDER_CONTENT_SHOULD_NOT_APPEAR",
+            enabled: true,
+            constant: true,
+          },
+        ],
+        [{ id: "lorebook", enabled: true, isGlobal: true }],
+        [{ id: "folder-disabled", lorebookId: "lorebook", enabled: false }],
+      ),
+      {
+        chat: { id: "chat", mode: "roleplay" },
+        storedMessages: [],
+        connection: {},
+        request: { ...request, promptPresetId: "" },
+        latestUserInput: "",
+      },
+    );
+
+    expect(assembly.activatedLorebookEntries).toHaveLength(0);
+    expect(promptText(assembly)).not.toContain("LQA_DISABLED_FOLDER_CONTENT_SHOULD_NOT_APPEAR");
+  });
+
+  it("activates chat-scoped lorebooks without activeLorebookIds metadata", async () => {
+    const assembly = await assembleGenerationPrompt(
+      storageWithLore(
+        [
+          {
+            id: "entry-chat-scoped",
+            lorebookId: "chat-book",
+            name: "Chat scoped entry",
+            content: "LQA_CHAT_SCOPED_CONTENT_SHOULD_APPEAR",
+            enabled: true,
+            constant: true,
+          },
+        ],
+        [{ id: "chat-book", enabled: true, isGlobal: false, chatId: "chat" }],
+      ),
+      {
+        chat: { id: "chat", mode: "roleplay", metadata: {} },
+        storedMessages: [],
+        connection: {},
+        request: { ...request, promptPresetId: "" },
+        latestUserInput: "",
+      },
+    );
+
+    expect(assembly.activatedLorebookEntries.map((entry) => entry.name)).toEqual(["Chat scoped entry"]);
+    expect(promptText(assembly)).toContain("LQA_CHAT_SCOPED_CONTENT_SHOULD_APPEAR");
+  });
+
+  it("uses character and persona additional matching sources during activation", async () => {
+    const baseStorage = storageWithLore([
+      {
+        id: "entry-character-source",
+        lorebookId: "lorebook",
+        name: "Character source entry",
+        content: "LQA_ADDITIONAL_CHARACTER_SOURCE_CONTENT",
+        keys: ["LQA_CHAR_SOURCE_KEY"],
+        additionalMatchingSources: ["character_description"],
+        enabled: true,
+        order: 0,
+      },
+      {
+        id: "entry-persona-source",
+        lorebookId: "lorebook",
+        name: "Persona source entry",
+        content: "LQA_ADDITIONAL_PERSONA_SOURCE_CONTENT",
+        keys: ["LQA_PERSONA_SOURCE_KEY"],
+        additionalMatchingSources: ["persona_description"],
+        enabled: true,
+        order: 1,
+      },
+    ]);
+    const storage: StorageGateway = {
+      ...baseStorage,
+      get: async <T>(entity: string, id: string) => {
+        if (entity === "characters" && id === "char-a") {
+          return {
+            id: "char-a",
+            data: { name: "Aster", description: "Character detail with LQA_CHAR_SOURCE_KEY." },
+          } as T;
+        }
+        if (entity === "personas" && id === "persona-1") {
+          return {
+            id: "persona-1",
+            data: { name: "Mari", description: "Persona detail with LQA_PERSONA_SOURCE_KEY." },
+          } as T;
+        }
+        return baseStorage.get<T>(entity, id);
+      },
+    };
+
+    const assembly = await assembleGenerationPrompt(storage, {
+      chat: { id: "chat", mode: "roleplay", characterIds: ["char-a"], personaId: "persona-1" },
+      storedMessages: [{ role: "user", content: "No lorebook keys are in chat history.", contextKind: "history" }],
+      connection: {},
+      request: { ...request, promptPresetId: "" },
+      latestUserInput: "No lorebook keys are in chat history.",
+    });
+
+    expect(assembly.activatedLorebookEntries.map((entry) => entry.name)).toEqual([
+      "Character source entry",
+      "Persona source entry",
+    ]);
+    expect(promptText(assembly)).toContain("LQA_ADDITIONAL_CHARACTER_SOURCE_CONTENT");
+    expect(promptText(assembly)).toContain("LQA_ADDITIONAL_PERSONA_SOURCE_CONTENT");
+  });
+
+  it("applies lorebook-level scan depth to entries without an override", async () => {
+    const assembly = await assembleGenerationPrompt(
+      storageWithLore(
+        [
+          {
+            id: "entry-scan-depth",
+            lorebookId: "lorebook",
+            name: "Scan depth entry",
+            content: "LQA_SCAN_DEPTH_CONTENT_SHOULD_NOT_APPEAR",
+            keys: ["LQA_OLD_KEY"],
+            enabled: true,
+          },
+        ],
+        [{ id: "lorebook", enabled: true, isGlobal: true, scanDepth: 1 }],
+      ),
+      {
+        chat: { id: "chat", mode: "roleplay" },
+        storedMessages: [
+          { role: "user", content: "Older message has LQA_OLD_KEY.", contextKind: "history" },
+          { role: "assistant", content: "Latest message has no trigger.", contextKind: "history" },
+        ],
+        connection: {},
+        request: { ...request, promptPresetId: "" },
+        latestUserInput: "",
+      },
+    );
+
+    expect(assembly.activatedLorebookEntries).toHaveLength(0);
+    expect(promptText(assembly)).not.toContain("LQA_SCAN_DEPTH_CONTENT_SHOULD_NOT_APPEAR");
+  });
+
+  it("recursively scans activated lorebook content when the lorebook enables recursion", async () => {
+    const assembly = await assembleGenerationPrompt(
+      storageWithLore(
+        [
+          {
+            id: "entry-recursive-parent",
+            lorebookId: "lorebook",
+            name: "Recursive parent",
+            content: "LQA_RECURSIVE_PARENT_CONTENT mentions LQA_CHILD_KEY.",
+            keys: ["LQA_PARENT_KEY"],
+            enabled: true,
+            order: 0,
+          },
+          {
+            id: "entry-recursive-child",
+            lorebookId: "lorebook",
+            name: "Recursive child",
+            content: "LQA_RECURSIVE_CHILD_CONTENT_SHOULD_APPEAR",
+            keys: ["LQA_CHILD_KEY"],
+            enabled: true,
+            order: 1,
+          },
+        ],
+        [{ id: "lorebook", enabled: true, isGlobal: true, recursiveScanning: true, maxRecursionDepth: 3 }],
+      ),
+      {
+        chat: { id: "chat", mode: "roleplay" },
+        storedMessages: [{ role: "user", content: "Trigger LQA_PARENT_KEY.", contextKind: "history" }],
+        connection: {},
+        request: { ...request, promptPresetId: "" },
+        latestUserInput: "Trigger LQA_PARENT_KEY.",
+      },
+    );
+
+    expect(assembly.activatedLorebookEntries.map((entry) => entry.name)).toEqual([
+      "Recursive parent",
+      "Recursive child",
+    ]);
+    expect(promptText(assembly)).toContain("LQA_RECURSIVE_CHILD_CONTENT_SHOULD_APPEAR");
+  });
+
+  it("applies chat metadata lorebook token budget during prompt injection", async () => {
+    const assembly = await assembleGenerationPrompt(
+      storageWithLore([
+        {
+          id: "entry-chat-budget",
+          lorebookId: "lorebook",
+          name: "Chat budgeted entry",
+          content: "LQA_CHAT_BUDGET_CONTENT_SHOULD_NOT_APPEAR",
+          enabled: true,
+          constant: true,
+        },
+      ]),
+      {
+        chat: { id: "chat", mode: "roleplay", metadata: { lorebookTokenBudget: 1 } },
+        storedMessages: [],
+        connection: {},
+        request: { ...request, promptPresetId: "" },
+        latestUserInput: "",
+      },
+    );
+
+    expect(assembly.activatedLorebookEntries).toHaveLength(0);
+    expect(promptText(assembly)).not.toContain("LQA_CHAT_BUDGET_CONTENT_SHOULD_NOT_APPEAR");
+  });
+
+  it("applies per-lorebook token budgets before prompt injection", async () => {
+    const assembly = await assembleGenerationPrompt(
+      storageWithLore(
+        [
+          {
+            id: "entry-book-budget",
+            lorebookId: "lorebook",
+            name: "Book budgeted entry",
+            content: "LQA_LOREBOOK_BUDGET_CONTENT_SHOULD_NOT_APPEAR",
+            enabled: true,
+            constant: true,
+          },
+        ],
+        [{ id: "lorebook", enabled: true, isGlobal: true, tokenBudget: 1 }],
+      ),
+      {
+        chat: { id: "chat", mode: "roleplay", metadata: { lorebookTokenBudget: 0 } },
+        storedMessages: [],
+        connection: {},
+        request: { ...request, promptPresetId: "" },
+        latestUserInput: "",
+      },
+    );
+
+    expect(assembly.activatedLorebookEntries).toHaveLength(0);
+    expect(promptText(assembly)).not.toContain("LQA_LOREBOOK_BUDGET_CONTENT_SHOULD_NOT_APPEAR");
   });
 });
 

--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -3,7 +3,12 @@ import type { ChatMLMessage, MarkerConfig, WrapFormat } from "../contracts/types
 import type { CharacterData } from "../contracts/types/character";
 import type { StorageGateway } from "../capabilities/storage";
 import { getCharacterDescriptionWithExtensions } from "../generation-core/prompt/character-description-extensions";
-import { applyTokenBudget, injectAtDepth, processActivatedEntries } from "../generation-core/lorebooks/prompt-injector";
+import {
+  applyTokenBudgetWithSkipped,
+  injectAtDepth,
+  processActivatedEntries,
+  type BudgetSkippedActivatedEntry,
+} from "../generation-core/lorebooks/prompt-injector";
 import {
   recursiveScan,
   scanForActivatedEntries,
@@ -84,6 +89,20 @@ export interface GenerationPersonaContext {
   };
 }
 
+export interface BudgetSkippedLorebookEntry {
+  id: string;
+  name: string;
+  lorebookId: string;
+  lorebookName: string;
+  matchedKeys: string[];
+  estimatedTokens: number;
+  lorebookBudget: number;
+  lorebookUsedTokens: number;
+  chatBudget: number;
+  chatUsedTokens: number;
+  blockedBy: "lorebook" | "chat" | "both";
+}
+
 export interface PromptAssemblyResult {
   messages: ChatMLMessage[];
   previewMessages: ChatMLMessage[];
@@ -102,6 +121,7 @@ export interface PromptAssemblyResult {
     order: number;
     constant: boolean;
   }>;
+  budgetSkippedLorebookEntries: BudgetSkippedLorebookEntry[];
   chatSummary: string | null;
   chatSummaryFingerprint: string | null;
 }
@@ -1611,12 +1631,37 @@ function nonNegativeInteger(value: unknown, fallback = 0): number {
   return Math.max(0, Math.floor(readNumber(value, fallback)));
 }
 
+const MAX_LOREBOOK_RECURSION_DEPTH = 10;
+
+interface LoadedLorebookBudgetSkippedEntry {
+  activatedEntry: ActivatedEntry;
+  lorebookName: string;
+  lorebookBudget: number;
+  lorebookUsedTokens: number;
+  estimatedTokens: number;
+}
+
+interface ScannedLorebookEntries {
+  activatedEntries: ActivatedEntry[];
+  budgetSkippedEntries: LoadedLorebookBudgetSkippedEntry[];
+}
+
+interface LoadedActivatedLore {
+  activatedEntries: ActivatedEntry[];
+  budgetSkippedEntries: LoadedLorebookBudgetSkippedEntry[];
+  lorebookNamesById: Map<string, string>;
+}
+
 function resolveLorebookTokenBudget(chat: JsonRecord, request: JsonRecord): number {
   const meta = parseRecord(chat.metadata);
   return nonNegativeInteger(
     request.lorebookTokenBudget,
     readNumber(meta.lorebookTokenBudget, LIMITS.DEFAULT_LOREBOOK_TOKEN_BUDGET),
   );
+}
+
+function resolveLorebookRecursionDepth(lorebook: JsonRecord): number {
+  return Math.min(MAX_LOREBOOK_RECURSION_DEPTH, Math.max(1, nonNegativeInteger(lorebook.maxRecursionDepth, 3)));
 }
 
 async function loadLorebookEntriesForActivation(
@@ -1652,11 +1697,24 @@ function scanLorebookEntries(
   entries: LorebookEntry[],
   lorebook: JsonRecord,
   options: ScanOptions,
-): ActivatedEntry[] {
+): ScannedLorebookEntries {
   const activated = boolish(lorebook.recursiveScanning, false)
-    ? recursiveScan(messages, entries, options, Math.max(1, Math.floor(readNumber(lorebook.maxRecursionDepth, 3))))
+    ? recursiveScan(messages, entries, options, resolveLorebookRecursionDepth(lorebook))
     : scanForActivatedEntries(messages, entries, options);
-  return applyTokenBudget(activated, nonNegativeInteger(lorebook.tokenBudget, 0));
+  const lorebookId = readString(lorebook.id);
+  const lorebookName = readString(lorebook.name, lorebookId || "Lorebook");
+  const lorebookBudget = nonNegativeInteger(lorebook.tokenBudget, 0);
+  const budgeted = applyTokenBudgetWithSkipped(activated, lorebookBudget);
+  return {
+    activatedEntries: budgeted.includedEntries,
+    budgetSkippedEntries: budgeted.skippedEntries.map((skipped) => ({
+      activatedEntry: skipped.activatedEntry,
+      lorebookName,
+      lorebookBudget,
+      lorebookUsedTokens: skipped.usedTokensBefore,
+      estimatedTokens: skipped.estimatedTokens,
+    })),
+  };
 }
 
 async function loadActivatedLore(
@@ -1665,7 +1723,7 @@ async function loadActivatedLore(
   characters: GenerationCharacterContext[],
   persona: GenerationPersonaContext | null,
   storedMessages: JsonRecord[],
-): Promise<ActivatedEntry[]> {
+): Promise<LoadedActivatedLore> {
   const lorebooks = (await storage.list<JsonRecord>("lorebooks")).filter((book) =>
     lorebookAppliesToContext(book, chat, characters, persona),
   );
@@ -1687,16 +1745,24 @@ async function loadActivatedLore(
     gameState,
     additionalMatchingSourceText: buildAdditionalMatchingSourceText(characters, persona),
   };
-  const activated = (
-    await Promise.all(
-      lorebooks.map(async (book) =>
-        scanLorebookEntries(messages, await loadLorebookEntriesForActivation(storage, book), book, options),
-      ),
-    )
-  )
-    .flat()
-    .sort((a, b) => a.injectionOrder - b.injectionOrder);
-  return activated;
+  const lorebookNamesById = new Map(
+    lorebooks.map((book) => {
+      const id = readString(book.id);
+      return [id, readString(book.name, id || "Lorebook")] as const;
+    }),
+  );
+  const scanned = await Promise.all(
+    lorebooks.map(async (book) =>
+      scanLorebookEntries(messages, await loadLorebookEntriesForActivation(storage, book), book, options),
+    ),
+  );
+  return {
+    activatedEntries: scanned
+      .flatMap((result) => result.activatedEntries)
+      .sort((a, b) => a.injectionOrder - b.injectionOrder),
+    budgetSkippedEntries: scanned.flatMap((result) => result.budgetSkippedEntries),
+    lorebookNamesById,
+  };
 }
 
 function loreForEvent(entry: ActivatedEntry) {
@@ -1709,6 +1775,47 @@ function loreForEvent(entry: ActivatedEntry) {
     matchedKeys: entry.matchedKeys,
     order: entry.entry.order,
     constant: entry.entry.constant,
+  };
+}
+
+function budgetSkippedLoreForEvent(
+  skipped: BudgetSkippedActivatedEntry,
+  lorebookNamesById: Map<string, string>,
+  chatBudget: number,
+): BudgetSkippedLorebookEntry {
+  const entry = skipped.activatedEntry.entry;
+  return {
+    id: entry.id,
+    name: entry.name,
+    lorebookId: entry.lorebookId,
+    lorebookName: lorebookNamesById.get(entry.lorebookId) ?? entry.lorebookId,
+    matchedKeys: skipped.activatedEntry.matchedKeys,
+    estimatedTokens: skipped.estimatedTokens,
+    lorebookBudget: 0,
+    lorebookUsedTokens: 0,
+    chatBudget,
+    chatUsedTokens: skipped.usedTokensBefore,
+    blockedBy: "chat",
+  };
+}
+
+function lorebookBudgetSkippedLoreForEvent(
+  skipped: LoadedLorebookBudgetSkippedEntry,
+  chatBudget: number,
+): BudgetSkippedLorebookEntry {
+  const entry = skipped.activatedEntry.entry;
+  return {
+    id: entry.id,
+    name: entry.name,
+    lorebookId: entry.lorebookId,
+    lorebookName: skipped.lorebookName,
+    matchedKeys: skipped.activatedEntry.matchedKeys,
+    estimatedTokens: skipped.estimatedTokens,
+    lorebookBudget: skipped.lorebookBudget,
+    lorebookUsedTokens: skipped.lorebookUsedTokens,
+    chatBudget,
+    chatUsedTokens: 0,
+    blockedBy: "lorebook",
   };
 }
 
@@ -1757,8 +1864,15 @@ export async function assembleGenerationPrompt(
 ): Promise<PromptAssemblyResult> {
   const characters = await loadCharacters(storage, input.chat);
   const persona = await loadPersona(storage, input.chat);
-  const activated = await loadActivatedLore(storage, input.chat, characters, persona, input.storedMessages);
-  const processedLore = processActivatedEntries(activated, resolveLorebookTokenBudget(input.chat, input.request));
+  const loadedLore = await loadActivatedLore(storage, input.chat, characters, persona, input.storedMessages);
+  const lorebookTokenBudget = resolveLorebookTokenBudget(input.chat, input.request);
+  const processedLore = processActivatedEntries(loadedLore.activatedEntries, lorebookTokenBudget);
+  const budgetSkippedLorebookEntries = [
+    ...loadedLore.budgetSkippedEntries.map((entry) => lorebookBudgetSkippedLoreForEvent(entry, lorebookTokenBudget)),
+    ...processedLore.skippedEntries.map((entry) =>
+      budgetSkippedLoreForEvent(entry, loadedLore.lorebookNamesById, lorebookTokenBudget),
+    ),
+  ];
   const summary = chatSummaryForGeneration(input.chat);
   const memoryRecallBlock = await buildMemoryRecallBlock(
     storage,
@@ -1939,6 +2053,7 @@ export async function assembleGenerationPrompt(
     characters,
     persona,
     activatedLorebookEntries: processedLore.includedEntries.map(loreForEvent),
+    budgetSkippedLorebookEntries,
     chatSummary: summary,
     chatSummaryFingerprint: summaryFingerprint,
   };

--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -1,10 +1,16 @@
-import type { LorebookEntry } from "../contracts/types/lorebook";
+import type { LorebookEntry, LorebookMatchingSource } from "../contracts/types/lorebook";
 import type { ChatMLMessage, MarkerConfig, WrapFormat } from "../contracts/types/prompt";
 import type { CharacterData } from "../contracts/types/character";
 import type { StorageGateway } from "../capabilities/storage";
 import { getCharacterDescriptionWithExtensions } from "../generation-core/prompt/character-description-extensions";
-import { injectAtDepth, processActivatedEntries } from "../generation-core/lorebooks/prompt-injector";
-import { scanForActivatedEntries, type ActivatedEntry } from "../generation-core/lorebooks/keyword-scanner";
+import { applyTokenBudget, injectAtDepth, processActivatedEntries } from "../generation-core/lorebooks/prompt-injector";
+import {
+  recursiveScan,
+  scanForActivatedEntries,
+  type ActivatedEntry,
+  type ScanMessage,
+  type ScanOptions,
+} from "../generation-core/lorebooks/keyword-scanner";
 import { resolveGameLorebookScopeExclusions } from "../generation-core/lorebooks/game-lorebook-scope";
 import { wrapContent } from "../generation-core/prompt/format-engine";
 import { mergeAdjacentMessages, squashLeadingSystemMessages } from "../generation-core/prompt/merger";
@@ -32,6 +38,7 @@ import {
   type StoredGenerationParameters,
 } from "./generate-route-utils";
 import { buildGenerationPromptPresetCandidates } from "./prompt-preset-selection";
+import { LIMITS } from "../contracts/constants/defaults";
 import {
   bySortOrder,
   boolish,
@@ -68,6 +75,7 @@ export interface GenerationPersonaContext {
   backstory?: string;
   appearance?: string;
   scenario?: string;
+  tags: string[];
   personaStats?: { enabled: boolean; bars: Array<{ name: string; value: number; max: number; color: string }> };
   rpgStats?: {
     enabled: boolean;
@@ -223,6 +231,7 @@ function loadPersonaContext(record: JsonRecord): GenerationPersonaContext {
     backstory: field(data, "backstory") || undefined,
     appearance: field(data, "appearance") || undefined,
     scenario: field(data, "scenario") || undefined,
+    tags: stringArray(data.tags ?? record.tags),
     personaStats: isPersonaStats(data.personaStats),
     rpgStats: isRpgStats(data.rpgStats),
   };
@@ -1521,7 +1530,7 @@ export function normalizeLorebookEntry(entry: JsonRecord): LorebookEntry {
     tag: readString(entry.tag),
     relationships: stringRecord(entry.relationships),
     dynamicState: parseRecord(entry.dynamicState),
-    scanDepth: readNumber(entry.scanDepth, 0),
+    scanDepth: entry.scanDepth == null ? null : readNumber(entry.scanDepth, 0),
     sticky: entry.sticky == null ? null : readNumber(entry.sticky, 0),
     cooldown: entry.cooldown == null ? null : readNumber(entry.cooldown, 0),
     delay: entry.delay == null ? null : readNumber(entry.delay, 0),
@@ -1571,7 +1580,83 @@ function lorebookAppliesToContext(
     const personaIds = stringArray(lorebook.personaIds);
     if (personaIds.includes(personaId) || readString(lorebook.personaId) === personaId) return true;
   }
+  const chatScopedId = readString(lorebook.chatId).trim();
+  if (chatScopedId && chatScopedId === readString(chat.id).trim()) return true;
   return stringArray(meta.activeLorebookIds ?? chat.activeLorebookIds).includes(lorebookId);
+}
+
+function joinMatchingSourceParts(parts: Array<string | undefined>): string {
+  return parts
+    .map((part) => part?.trim() ?? "")
+    .filter(Boolean)
+    .join("\n");
+}
+
+function buildAdditionalMatchingSourceText(
+  characters: GenerationCharacterContext[],
+  persona: GenerationPersonaContext | null,
+): Partial<Record<LorebookMatchingSource, string>> {
+  return {
+    character_name: joinMatchingSourceParts(characters.map((character) => character.name)),
+    character_description: joinMatchingSourceParts(characters.map((character) => character.description)),
+    character_personality: joinMatchingSourceParts(characters.map((character) => character.personality)),
+    character_scenario: joinMatchingSourceParts(characters.map((character) => character.scenario)),
+    character_tags: joinMatchingSourceParts(characters.flatMap((character) => character.tags)),
+    persona_description: persona?.description ?? "",
+    persona_tags: joinMatchingSourceParts(persona?.tags ?? []),
+  };
+}
+
+function nonNegativeInteger(value: unknown, fallback = 0): number {
+  return Math.max(0, Math.floor(readNumber(value, fallback)));
+}
+
+function resolveLorebookTokenBudget(chat: JsonRecord, request: JsonRecord): number {
+  const meta = parseRecord(chat.metadata);
+  return nonNegativeInteger(
+    request.lorebookTokenBudget,
+    readNumber(meta.lorebookTokenBudget, LIMITS.DEFAULT_LOREBOOK_TOKEN_BUDGET),
+  );
+}
+
+async function loadLorebookEntriesForActivation(
+  storage: StorageGateway,
+  lorebook: JsonRecord,
+): Promise<LorebookEntry[]> {
+  const id = readString(lorebook.id);
+  if (!id) return [];
+  const [rows, folders] = await Promise.all([
+    storage.listLorebookEntries<JsonRecord>(id),
+    storage.list<JsonRecord>("lorebook-folders", { filters: { lorebookId: id } }),
+  ]);
+  const disabledFolderIds = new Set(
+    folders
+      .filter((folder) => !boolish(folder.enabled, true))
+      .map((folder) => readString(folder.id))
+      .filter(Boolean),
+  );
+  const defaultScanDepth = nonNegativeInteger(lorebook.scanDepth, 0);
+  const excludeFromVectorization = boolish(lorebook.excludeFromVectorization, false);
+  return rows
+    .map((row) => normalizeLorebookEntry(excludeFromVectorization ? { ...row, excludeFromVectorization: true } : row))
+    .map((entry) => ({
+      ...entry,
+      scanDepth: entry.scanDepth == null ? defaultScanDepth : entry.scanDepth,
+    }))
+    .filter((entry) => entry.enabled && entry.content.trim())
+    .filter((entry) => !entry.folderId || !disabledFolderIds.has(entry.folderId));
+}
+
+function scanLorebookEntries(
+  messages: ScanMessage[],
+  entries: LorebookEntry[],
+  lorebook: JsonRecord,
+  options: ScanOptions,
+): ActivatedEntry[] {
+  const activated = boolish(lorebook.recursiveScanning, false)
+    ? recursiveScan(messages, entries, options, Math.max(1, Math.floor(readNumber(lorebook.maxRecursionDepth, 3))))
+    : scanForActivatedEntries(messages, entries, options);
+  return applyTokenBudget(activated, nonNegativeInteger(lorebook.tokenBudget, 0));
 }
 
 async function loadActivatedLore(
@@ -1584,34 +1669,34 @@ async function loadActivatedLore(
   const lorebooks = (await storage.list<JsonRecord>("lorebooks")).filter((book) =>
     lorebookAppliesToContext(book, chat, characters, persona),
   );
-  const rows = (
-    await Promise.all(
-      lorebooks.map(async (book) => {
-        const id = readString(book.id);
-        // The refactor storage API has no path-style routes; use the
-        // dedicated capability that filters lorebook-entries by lorebookId.
-        if (!id) return [];
-        const rows = await storage.listLorebookEntries<JsonRecord>(id);
-        if (!boolish(book.excludeFromVectorization, false)) return rows;
-        return rows.map((entry) => ({ ...entry, excludeFromVectorization: true }));
-      }),
-    )
-  ).flat();
-  const entries = rows.map(normalizeLorebookEntry).filter((entry) => entry.enabled && entry.content.trim());
   const activeCharacterIds = characters.map((character) => character.id);
   const activeCharacterTags = characters.flatMap((character) => character.tags);
   const meta = parseRecord(chat.metadata);
   const gameState = parseRecord(chat.gameState ?? meta.gameState);
-  return scanForActivatedEntries(
-    storedMessages
-      .filter((message) => !hiddenFromAi(message))
-      .map((message) => ({
-        role: readString(message.role, "user"),
-        content: readString(message.content),
-      })),
-    entries,
-    { activeCharacterIds, activeCharacterTags, generationTriggers: ["chat", readString(chat.mode)], gameState },
-  );
+  const messages = storedMessages
+    .filter((message) => !hiddenFromAi(message))
+    .map((message) => ({
+      role: readString(message.role, "user"),
+      content: readString(message.content),
+    }));
+  const generationTriggers = ["chat", readString(chat.mode || chat.chatMode)].filter(Boolean);
+  const options: ScanOptions = {
+    activeCharacterIds,
+    activeCharacterTags,
+    generationTriggers,
+    gameState,
+    additionalMatchingSourceText: buildAdditionalMatchingSourceText(characters, persona),
+  };
+  const activated = (
+    await Promise.all(
+      lorebooks.map(async (book) =>
+        scanLorebookEntries(messages, await loadLorebookEntriesForActivation(storage, book), book, options),
+      ),
+    )
+  )
+    .flat()
+    .sort((a, b) => a.injectionOrder - b.injectionOrder);
+  return activated;
 }
 
 function loreForEvent(entry: ActivatedEntry) {
@@ -1673,7 +1758,7 @@ export async function assembleGenerationPrompt(
   const characters = await loadCharacters(storage, input.chat);
   const persona = await loadPersona(storage, input.chat);
   const activated = await loadActivatedLore(storage, input.chat, characters, persona, input.storedMessages);
-  const processedLore = processActivatedEntries(activated, readNumber(input.request.lorebookTokenBudget, 0));
+  const processedLore = processActivatedEntries(activated, resolveLorebookTokenBudget(input.chat, input.request));
   const summary = chatSummaryForGeneration(input.chat);
   const memoryRecallBlock = await buildMemoryRecallBlock(
     storage,
@@ -1853,7 +1938,7 @@ export async function assembleGenerationPrompt(
     wrapFormat,
     characters,
     persona,
-    activatedLorebookEntries: activated.map(loreForEvent),
+    activatedLorebookEntries: processedLore.includedEntries.map(loreForEvent),
     chatSummary: summary,
     chatSummaryFingerprint: summaryFingerprint,
   };


### PR DESCRIPTION
## Linked issue

Closes #1543
Closes #1544
Closes #1545
Closes #1546
Closes #1547

## Why this change

- Lorebook editor/chat settings saved several activation controls that prompt assembly did not honor, so prompt preview/generation could disagree with the UI and inject the wrong world-info entries.
- Follow-up failure-path review found two hardening gaps: malformed recursion depth could bypass the schema max in prompt assembly, and budget-skipped active lore could be hidden from the active-world-info preview.

## What changed

- Prompt assembly now skips entries inside disabled lorebook folders.
- Chat-scoped lorebooks now apply when `lorebook.chatId` matches the current chat, even when the book is not pinned in `activeLorebookIds`.
- Character/persona additional matching sources are passed into lorebook scanning.
- Lorebook-level `scanDepth` is inherited by entries without an entry-level override, and recursive lorebooks use `recursiveScan` with the schema max depth cap.
- Per-lorebook and chat-level lorebook token budgets are applied before active prompt output.
- Active-world-info scans now surface budget-skipped lore entries instead of silently reporting no active lore.
- Added focused prompt-assembly regression tests for the covered issue rows and failpath fixes.

## Refactor impact

Primary owner:

engine generation / generation-core lorebooks

Impact areas reviewed:

- Prompt assembly active lorebook selection and injection.
- Active lorebook preview output, which is backed by prompt assembly.
- Existing lorebook folder update invalidation in `useUpdateLorebookFolder`.
- Chat, roleplay, and game shared prompt assembly paths.
- Agent/tool consumers of `activatedLorebookEntries`.

Boundary notes:

- Engine-only behavior change. No shared API, Rust command, storage schema, import/export, or remote runtime boundary changes.
- Catalog UI already invalidates active lorebook scans when folder enabled state changes, so no feature-layer patch was needed for #1543.

Pressure points touched:

- None. No ModeSurface, GameSurface, shared mode UI, src-tauri registry, or import modules touched.

## Validation

- [ ] `pnpm check` passes locally
- [x] `pnpm typecheck` passes locally
- [x] `pnpm build` passes locally
- [x] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [x] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Reproduced before fix with focused Vitest rows: `pnpm exec vitest run src/engine/generation/prompt-assembly.test.ts -t "lorebook activation settings"` failed 7/7 expected rows.
- Verified after initial fix:
  - `pnpm exec vitest run src/engine/generation/prompt-assembly.test.ts -t "lorebook activation settings"` passed.
  - `pnpm exec vitest run src/engine/generation/prompt-assembly.test.ts` passed.
  - `pnpm exec vitest run src/engine/generation-core/lorebooks/keyword-scanner.test.ts src/engine/generation/start-generation.test.ts src/engine/generation/runtime-records.test.ts src/engine/generation/prompt-overrides.test.ts src/engine/generation/prompt-assembly.test.ts src/engine/generation/main-tool-loop.test.ts src/engine/generation/generate-route-utils.test.ts src/engine/generation/connected-commands.test.ts src/engine/generation/agent-runner.test.ts` passed.
  - `pnpm typecheck` passed.
  - `pnpm check:architecture` passed.
  - `pnpm build` passed with the existing Vite large-chunk warning.
- Verified after failpath fixes:
  - `pnpm exec vitest run src/engine/generation/prompt-assembly.test.ts` passed, 50 tests.
  - `pnpm exec vitest run src/engine/generation-core/lorebooks/keyword-scanner.test.ts src/engine/generation/start-generation.test.ts src/engine/generation/runtime-records.test.ts src/engine/generation/prompt-overrides.test.ts src/engine/generation/prompt-assembly.test.ts src/engine/generation/main-tool-loop.test.ts src/engine/generation/generate-route-utils.test.ts src/engine/generation/connected-commands.test.ts src/engine/generation/agent-runner.test.ts` passed, 173 tests.
  - `pnpm typecheck` passed.
  - `pnpm check:architecture` passed.
  - `pnpm build` passed with the existing Vite large-chunk warning.
- Fanout failpath review fixed the confirmed recursion-depth and budget-skipped-preview findings.
- Fanout Bunny review returned no confirmed findings after those fixes.
- Native Tauri QA passed after the follow-up request:
  - Reused the already-running `Marinara Engine QA` window launched through `pnpm tauri dev --no-watch --config scratch\tauri-qa.config.json` against `http://localhost:1420`.
  - WebView2 CDP confirmed the React root mounted and Tauri internals were present in the native WebView.
  - Exercised focused lorebook prompt scenarios inside the native WebView: disabled-folder suppression, chat-scoped lorebook activation, character additional matching source activation, recursion-depth clamping, and active-world-info budget-skipped telemetry.
  - Saved local QA screenshots at `scratch/tauri-qa-lorebook-activation.png` and `scratch/tauri-window-lorebook-activation.png`.
- #1548 remains separate because timing persistence needs per-chat runtime state writeback, not just prompt assembly scanning.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

No `CHANGELOG.md` exists on this branch. No docs changes were made because this fixes existing prompt behavior without changing the public setup or architecture docs.

## UI evidence

Native Tauri QA evidence was captured from the already-running QA window after the engine prompt scenarios passed. Local artifacts: scratch/tauri-qa-lorebook-activation.png and scratch/tauri-window-lorebook-activation.png.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced lorebook entry management to properly track and distinguish entries skipped due to token budget constraints during prompt assembly.

* **Tests**
  * Expanded test coverage for lorebook activation settings, token budget enforcement, and recursive scanning behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1565?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->