### PR TITLE
Fix automated summary source hiding

### DIFF
--- a/src/engine/generation/agent-runner.ts
+++ b/src/engine/generation/agent-runner.ts
@@ -79,6 +79,7 @@ export interface GenerationAgentRuntimeInput {
   signal?: AbortSignal;
   agentTypes?: Set<string>;
   bypassCustomAgentActivation?: boolean;
+  hideAutomatedSummarySourceMessages?: boolean;
   regenerateMessageId?: string | null;
   agentInjectionOverrides?: AgentInjection[];
 }

--- a/src/engine/generation/main-tool-loop.test.ts
+++ b/src/engine/generation/main-tool-loop.test.ts
@@ -5,6 +5,7 @@ import type { StorageGateway } from "../capabilities/storage";
 import { startGeneration, type GenerationEngineDeps } from "./start-generation";
 import {
   buildMainToolDefinitions,
+  executeBuiltInTool,
   executeMainToolCall,
   searchLorebookTool,
   normalizeToolCall,
@@ -397,6 +398,110 @@ describe("row 6 — agent-only tool names filtered from main toolDefs", () => {
     expect(names).not.toContain("append_chat_summary");
     expect(names).not.toContain("read_chat_variable");
     expect(names).not.toContain("write_chat_variable");
+  });
+});
+
+describe("append_chat_summary source message hiding", () => {
+  it("records and hides recent visible source messages when automated summary hiding is enabled", async () => {
+    const { deps, storage, update } = makeStubDeps({
+      chatMetadata: {},
+      initialMessages: [],
+      script: { turns: [] },
+    });
+    const patchChatMessageExtra = storage.patchChatMessageExtra as ReturnType<typeof vi.fn>;
+
+    const result = await executeBuiltInTool(
+      deps,
+      {
+        chat: { id: "chat-1", metadata: {} },
+        storedMessages: [
+          { id: "visible-1", role: "user", content: "First." },
+          { id: "hidden-1", role: "assistant", content: "Hidden.", extra: { hiddenFromAI: true } },
+          { id: "visible-2", role: "assistant", content: "Second." },
+        ],
+        activatedLorebookEntries: [],
+        chatSummary: null,
+        hideAutomatedSummarySourceMessages: true,
+      },
+      { id: "agent-a", name: "Summary Agent" },
+      normalizeToolCall({
+        function: {
+          name: "append_chat_summary",
+          arguments: JSON.stringify({ text: "The visible exchange was summarized." }),
+        },
+      })!,
+    );
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        success: true,
+        hiddenMessageIds: ["visible-1", "visible-2"],
+        entry: expect.objectContaining({
+          messageCount: 2,
+          messageIds: ["visible-1", "visible-2"],
+        }),
+      }),
+    );
+    expect(patchChatMessageExtra).toHaveBeenCalledTimes(2);
+    expect(patchChatMessageExtra).toHaveBeenNthCalledWith(1, "visible-1", {
+      hiddenFromAI: true,
+      hiddenFromAi: true,
+    });
+    expect(patchChatMessageExtra).toHaveBeenNthCalledWith(2, "visible-2", {
+      hiddenFromAI: true,
+      hiddenFromAi: true,
+    });
+    expect(update).toHaveBeenCalledWith(
+      "chats",
+      "chat-1",
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          summaryEntries: [
+            expect.objectContaining({
+              origin: "automated",
+              sourceMode: "agent",
+              messageIds: ["visible-1", "visible-2"],
+            }),
+          ],
+        }),
+      }),
+    );
+  });
+
+  it("records source messages without hiding them when automated summary hiding is disabled", async () => {
+    const { deps, storage } = makeStubDeps({
+      chatMetadata: {},
+      initialMessages: [],
+      script: { turns: [] },
+    });
+    const patchChatMessageExtra = storage.patchChatMessageExtra as ReturnType<typeof vi.fn>;
+
+    const result = await executeBuiltInTool(
+      deps,
+      {
+        chat: { id: "chat-1", metadata: {} },
+        storedMessages: [{ id: "visible-1", role: "user", content: "First." }],
+        activatedLorebookEntries: [],
+        chatSummary: null,
+        hideAutomatedSummarySourceMessages: false,
+      },
+      { id: "agent-a", name: "Summary Agent" },
+      normalizeToolCall({
+        function: {
+          name: "append_chat_summary",
+          arguments: JSON.stringify({ text: "The visible exchange was summarized." }),
+        },
+      })!,
+    );
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        success: true,
+        hiddenMessageIds: [],
+        entry: expect.objectContaining({ messageIds: ["visible-1"] }),
+      }),
+    );
+    expect(patchChatMessageExtra).not.toHaveBeenCalled();
   });
 });
 

--- a/src/engine/generation/main-tool-loop.test.ts
+++ b/src/engine/generation/main-tool-loop.test.ts
@@ -420,6 +420,8 @@ describe("append_chat_summary source message hiding", () => {
           { id: "visible-2", role: "assistant", content: "Second." },
         ],
         activatedLorebookEntries: [],
+        characters: [],
+        persona: null,
         chatSummary: null,
         hideAutomatedSummarySourceMessages: true,
       },
@@ -482,6 +484,8 @@ describe("append_chat_summary source message hiding", () => {
         chat: { id: "chat-1", metadata: {} },
         storedMessages: [{ id: "visible-1", role: "user", content: "First." }],
         activatedLorebookEntries: [],
+        characters: [],
+        persona: null,
         chatSummary: null,
         hideAutomatedSummarySourceMessages: false,
       },
@@ -502,6 +506,76 @@ describe("append_chat_summary source message hiding", () => {
       }),
     );
     expect(patchChatMessageExtra).not.toHaveBeenCalled();
+  });
+
+  it("keeps successful hidden ids and persists metadata after partial hide failures settle", async () => {
+    const { deps, storage, update } = makeStubDeps({
+      chatMetadata: {},
+      initialMessages: [],
+      script: { turns: [] },
+    });
+    const patchChatMessageExtra = storage.patchChatMessageExtra as ReturnType<typeof vi.fn>;
+    patchChatMessageExtra.mockImplementation(async (id: string, patch: Record<string, unknown>) => {
+      if (id === "visible-2") throw new Error("patch failed");
+      return { id, ...patch };
+    });
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    try {
+      const result = await executeBuiltInTool(
+        deps,
+        {
+          chat: { id: "chat-1", metadata: {} },
+          storedMessages: [
+            { id: "visible-1", role: "user", content: "First." },
+            { id: "visible-2", role: "assistant", content: "Second." },
+          ],
+          activatedLorebookEntries: [],
+          characters: [],
+          persona: null,
+          chatSummary: null,
+          hideAutomatedSummarySourceMessages: true,
+        },
+        { id: "agent-a", name: "Summary Agent" },
+        normalizeToolCall({
+          function: {
+            name: "append_chat_summary",
+            arguments: JSON.stringify({ text: "The visible exchange was summarized." }),
+          },
+        })!,
+      );
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          success: true,
+          hiddenMessageIds: ["visible-1"],
+        }),
+      );
+      expect(patchChatMessageExtra).toHaveBeenCalledTimes(2);
+      expect(consoleWarn).toHaveBeenCalledWith(
+        "[tools-runtime] Failed to hide automated summary source message",
+        expect.objectContaining({ messageId: "visible-2" }),
+      );
+      expect(update).toHaveBeenCalledWith(
+        "chats",
+        "chat-1",
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            summaryEntries: [
+              expect.objectContaining({
+                messageCount: 2,
+                messageIds: ["visible-1", "visible-2"],
+              }),
+            ],
+          }),
+        }),
+      );
+      const updateOrder = update.mock.invocationCallOrder[0] ?? 0;
+      const patchOrders = patchChatMessageExtra.mock.invocationCallOrder;
+      expect(Math.max(...patchOrders)).toBeLessThan(updateOrder);
+    } finally {
+      consoleWarn.mockRestore();
+    }
   });
 });
 

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -103,6 +103,7 @@ export interface StartGenerationInput extends JsonRecord {
   };
   debugMode?: boolean;
   debugSink?: AgentContext["debugSink"];
+  hideAutomatedSummarySourceMessages?: boolean;
   agentInjectionOverrides?: AgentInjectionOverride[];
 }
 
@@ -118,6 +119,7 @@ export interface RetryAgentsInput extends JsonRecord {
   chatId: string;
   connectionId?: string | null;
   agentTypes?: string[];
+  hideAutomatedSummarySourceMessages?: boolean;
   options?: Record<string, unknown>;
 }
 
@@ -1949,6 +1951,7 @@ async function runGenerationAgentsForTarget(args: {
       chatSummary: assembly.chatSummary,
       agentTypes,
       bypassCustomAgentActivation: retryBypassesCustomAgentActivation(input),
+      hideAutomatedSummarySourceMessages: input.hideAutomatedSummarySourceMessages === true,
       signal,
       regenerateMessageId: readString(input.regenerateMessageId).trim() || null,
     },
@@ -2132,6 +2135,7 @@ export async function* startGeneration(
             chatSummary: assembly.chatSummary,
             debugMode: input.debugMode === true,
             debugSink: input.debugSink,
+            hideAutomatedSummarySourceMessages: input.hideAutomatedSummarySourceMessages === true,
             signal,
             regenerateMessageId: readString(input.regenerateMessageId).trim() || null,
             agentInjectionOverrides,
@@ -2192,10 +2196,12 @@ export async function* startGeneration(
     });
     const toolRuntimeInput: ToolRuntimeInput = {
       chat: chatForGeneration,
+      storedMessages: generationMessages,
       activatedLorebookEntries: assembly.activatedLorebookEntries,
       characters: assembly.characters,
       persona: assembly.persona,
       chatSummary: assembly.chatSummary,
+      hideAutomatedSummarySourceMessages: input.hideAutomatedSummarySourceMessages === true,
     };
     const baseMessages: LlmMessage[] = [...prompt, generationGuide(input)].filter(
       (message): message is LlmMessage => !!message,
@@ -2359,10 +2365,12 @@ export async function* startGeneration(
   });
   const toolRuntimeInputDirect: ToolRuntimeInput = {
     chat: chatForGeneration,
+    storedMessages: generationMessages,
     activatedLorebookEntries: assembly.activatedLorebookEntries,
     characters: assembly.characters,
     persona: assembly.persona,
     chatSummary: assembly.chatSummary,
+    hideAutomatedSummarySourceMessages: input.hideAutomatedSummarySourceMessages === true,
   };
   const baseMessagesDirect: LlmMessage[] = [...(prompt ?? []), generationGuide(input)].filter(
     (message): message is LlmMessage => !!message,

--- a/src/engine/generation/tools-runtime.ts
+++ b/src/engine/generation/tools-runtime.ts
@@ -33,10 +33,12 @@ import {
  */
 export interface ToolRuntimeInput {
   chat: JsonRecord;
+  storedMessages?: JsonRecord[];
   activatedLorebookEntries: Array<{ id: string; name: string; content: string; tag: string }>;
   characters: GenerationCharacterContext[];
   persona: GenerationPersonaContext | null;
   chatSummary: string | null;
+  hideAutomatedSummarySourceMessages?: boolean;
 }
 
 export interface CustomToolRecord extends JsonRecord {
@@ -168,6 +170,33 @@ export function requireChatId(input: ToolRuntimeInput): string {
   const chatId = readString(input.chat.id).trim();
   if (!chatId) toolError("Tool requires a persisted chat id.");
   return chatId;
+}
+
+function automatedSummarySourceMessageIds(input: ToolRuntimeInput): string[] {
+  const seen = new Set<string>();
+  return (input.storedMessages ?? [])
+    .filter((message) => !hiddenFromAiRecord(message))
+    .slice(-60)
+    .map((message) => readString(message.id).trim())
+    .filter((id) => {
+      if (!id || seen.has(id)) return false;
+      seen.add(id);
+      return true;
+    });
+}
+
+function hiddenFromAiRecord(message: JsonRecord): boolean {
+  const extra = parseRecord(message.extra);
+  return boolish(extra.hiddenFromAI ?? extra.hiddenFromAi, false);
+}
+
+async function hideSummarySourceMessages(storage: StorageGateway, messageIds: string[]): Promise<string[]> {
+  const hiddenIds: string[] = [];
+  for (const messageId of messageIds) {
+    await storage.patchChatMessageExtra(messageId, { hiddenFromAI: true, hiddenFromAi: true });
+    hiddenIds.push(messageId);
+  }
+  return hiddenIds;
 }
 
 export async function updateChatMetadata(
@@ -341,6 +370,7 @@ export async function executeBuiltInTool(
       if (!text) toolError("text is required.");
       const now = nowIso();
       const metadata = parseRecord(input.chat.metadata);
+      const sourceMessageIds = automatedSummarySourceMessageIds(input);
       const appended = appendChatSummaryEntryToMetadata(
         metadata,
         {
@@ -348,15 +378,20 @@ export async function executeBuiltInTool(
           origin: "automated",
           sourceMode: "agent",
           title: "Agent memory",
+          messageCount: sourceMessageIds.length || undefined,
+          messageIds: sourceMessageIds.length > 0 ? sourceMessageIds : undefined,
         },
         { now, createId: () => newId("summary") },
       );
       metadata.summaryEntries = appended.entries;
       metadata.summary = appended.summary;
       await storage.update("chats", chatId, { metadata });
+      const hiddenMessageIds = input.hideAutomatedSummarySourceMessages
+        ? await hideSummarySourceMessages(storage, sourceMessageIds)
+        : [];
       input.chat.metadata = metadata;
       input.chatSummary = appended.summary;
-      return { success: true, entry: appended.entry, summary: appended.summary };
+      return { success: true, entry: appended.entry, summary: appended.summary, hiddenMessageIds };
     }
     case "read_chat_variable": {
       const key = stringArg(args, "key");

--- a/src/engine/generation/tools-runtime.ts
+++ b/src/engine/generation/tools-runtime.ts
@@ -191,10 +191,23 @@ function hiddenFromAiRecord(message: JsonRecord): boolean {
 }
 
 async function hideSummarySourceMessages(storage: StorageGateway, messageIds: string[]): Promise<string[]> {
+  const results = await Promise.allSettled(
+    messageIds.map((messageId) =>
+      storage.patchChatMessageExtra(messageId, { hiddenFromAI: true, hiddenFromAi: true }),
+    ),
+  );
   const hiddenIds: string[] = [];
-  for (const messageId of messageIds) {
-    await storage.patchChatMessageExtra(messageId, { hiddenFromAI: true, hiddenFromAi: true });
-    hiddenIds.push(messageId);
+  for (const [index, result] of results.entries()) {
+    const messageId = messageIds[index];
+    if (!messageId) continue;
+    if (result.status === "fulfilled") {
+      hiddenIds.push(messageId);
+    } else {
+      console.warn("[tools-runtime] Failed to hide automated summary source message", {
+        messageId,
+        error: result.reason,
+      });
+    }
   }
   return hiddenIds;
 }
@@ -383,14 +396,14 @@ export async function executeBuiltInTool(
         },
         { now, createId: () => newId("summary") },
       );
-      metadata.summaryEntries = appended.entries;
-      metadata.summary = appended.summary;
-      await storage.update("chats", chatId, { metadata });
       const hiddenMessageIds = input.hideAutomatedSummarySourceMessages
         ? await hideSummarySourceMessages(storage, sourceMessageIds)
         : [];
+      metadata.summaryEntries = appended.entries;
+      metadata.summary = appended.summary;
       input.chat.metadata = metadata;
       input.chatSummary = appended.summary;
+      await storage.update("chats", chatId, { metadata });
       return { success: true, entry: appended.entry, summary: appended.summary, hiddenMessageIds };
     }
     case "read_chat_variable": {

--- a/src/features/modes/conversation/hooks/autonomous/use-background-autonomous.ts
+++ b/src/features/modes/conversation/hooks/autonomous/use-background-autonomous.ts
@@ -138,6 +138,8 @@ export function useBackgroundAutonomousPolling() {
                     chatId: chat.id,
                     connectionId: null,
                     streaming: useUIStore.getState().enableStreaming,
+                    hideAutomatedSummarySourceMessages:
+                      useUIStore.getState().summaryPopoverSettings.hideSummarizedMessages,
                   },
                 )) {
                   if ((_event as { type: string }).type === "token") receivedTokens = true;

--- a/src/features/runtime/generation/hooks/use-generate.ts
+++ b/src/features/runtime/generation/hooks/use-generate.ts
@@ -1356,6 +1356,8 @@ export function useGenerate() {
                 includeAppearances: useUIStore.getState().imagePromptIncludeAppearances,
                 format: useUIStore.getState().imagePromptFormat,
               },
+              hideAutomatedSummarySourceMessages:
+                useUIStore.getState().summaryPopoverSettings.hideSummarizedMessages,
               debugMode: useUIStore.getState().debugMode,
               debugSink: enqueueAgentDebugEntry,
             },
@@ -1401,7 +1403,13 @@ export function useGenerate() {
         }
         const results = await retryGenerationAgents(
           { storage: storageApi, llm: llmApi, integrations: integrationGateway, visuals: visualAssetsApi },
-          { chatId, agentTypes, options: { ...(options ?? {}), bypassActivation: options?.bypassActivation ?? true } },
+          {
+            chatId,
+            agentTypes,
+            hideAutomatedSummarySourceMessages:
+              useUIStore.getState().summaryPopoverSettings.hideSummarizedMessages,
+            options: { ...(options ?? {}), bypassActivation: options?.bypassActivation ?? true },
+          },
         );
         const failedRetries: AgentFailure[] = [];
         for (const rawResult of results) {


### PR DESCRIPTION
## Linked issue

Closes #1526

## Why this change

Automated chat summaries appended rolling summary entries but did not mark the source messages hidden when users enabled `Hide summarized messages from AI`. Manual last-N and range summaries already honored that setting, so automated summaries behaved inconsistently.

## What changed

- Pass the persisted hide-summarized-messages preference into generation and agent retry paths.
- Record visible source message IDs on automated `append_chat_summary` entries.
- Hide those known source messages via `hiddenFromAI` / `hiddenFromAi` when the preference is enabled.
- Added focused coverage for enabled and disabled hiding behavior.

## Refactor impact

Primary owner:

engine generation / runtime generation

Impact areas reviewed:

- Chat mode automated summaries
- Roleplay mode automated summaries
- Shared mode UI hidden-message collapse behavior
- Engine generation tool runtime

Boundary notes:

- UI settings are passed into the engine as plain generation input data.
- Engine code does not import React, Zustand, Tauri APIs, feature internals, or shared API adapters.
- No Rust, storage schema, or remote-runtime routing changes.

Pressure points touched:

- Runtime generation hook
- Background autonomous generation hook
- Engine agent/tool runtime

## Validation

- [ ] `pnpm check` passes locally
- [x] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [x] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Ran `pnpm exec vitest run src/engine/generation/main-tool-loop.test.ts`.
- Ran `pnpm typecheck`.
- Ran `pnpm check:architecture`.
- No browser/Tauri manual verification performed.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

No visible UI changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented option to hide messages used as sources for automated summaries; summarized source messages can now be hidden from chat display based on user preference.

* **Tests**
  * Added test coverage for automated summary source message hiding, including message visibility patching, metadata updates, and summary entry tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1574?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->