### PR TITLE
Restore practical Knip export contracts

### DIFF
--- a/src/engine/capabilities/assets.ts
+++ b/src/engine/capabilities/assets.ts
@@ -1,9 +1,0 @@
-export interface AssetGateway {
-  list(path?: string): Promise<unknown[]>;
-  readText(path: string): Promise<string>;
-  writeText(path: string, content: string): Promise<void>;
-  remove(path: string): Promise<void>;
-  copy(path: string, targetFolder: string): Promise<unknown>;
-  move(path: string, targetFolder: string): Promise<unknown>;
-  openFolder(path?: string): Promise<void>;
-}

--- a/src/features/modes/conversation/components/ConversationInput.tsx
+++ b/src/features/modes/conversation/components/ConversationInput.tsx
@@ -39,7 +39,7 @@ import { createInputMacroResolverForChat, isPromptPreviewMacro } from "../../../
 import { parseChatMetadata } from "../../../../shared/lib/chat-display";
 import { formatTextQuotes } from "../../../../shared/lib/dialogue-quotes";
 import { cn, getAvatarCropStyle, type AvatarCropValue } from "../../../../shared/lib/utils";
-import { loadUrlBlob } from "../../../../shared/lib/url-blob";
+import { blobToDataUrl, loadUrlBlob } from "../../../../shared/lib/url-blob";
 import { prepareImageAttachment } from "../../../../shared/lib/chat-attachment-images";
 import { translateDraftText } from "../../../../shared/lib/draft-translation";
 import {
@@ -146,15 +146,6 @@ function parseSavedStatusOptions(value: PersonaStatusRow["savedStatusOptions"]):
     byKey.set(normalized.toLowerCase(), normalized);
   }
   return [...byKey.values()].slice(0, SAVED_STATUS_LIMIT);
-}
-
-function readFileAsDataUrl(file: Blob): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = () => resolve(reader.result as string);
-    reader.onerror = () => reject(reader.error ?? new Error("Failed to read file"));
-    reader.readAsDataURL(file);
-  });
 }
 
 interface ConversationInputProps {
@@ -434,7 +425,7 @@ export function ConversationInput({
         }
 
         try {
-          const data = await readFileAsDataUrl(file);
+          const data = await blobToDataUrl(file, "Failed to read file");
           appendAttachmentForChat(originChatId, { type: inferAttachmentType(file), data, name: displayName });
         } catch {
           toast.error(`Failed to read ${displayName}`);

--- a/src/features/modes/conversation/components/ConversationInput.tsx
+++ b/src/features/modes/conversation/components/ConversationInput.tsx
@@ -35,7 +35,7 @@ import {
   type SlashCommand,
   type SlashCommandContext,
 } from "../../../../shared/lib/slash-commands";
-import { isPromptPreviewMacro, resolveInputMacrosForChat } from "../../../../shared/lib/chat-macros";
+import { createInputMacroResolverForChat, isPromptPreviewMacro } from "../../../../shared/lib/chat-macros";
 import { parseChatMetadata } from "../../../../shared/lib/chat-display";
 import { formatTextQuotes } from "../../../../shared/lib/dialogue-quotes";
 import { cn, getAvatarCropStyle, type AvatarCropValue } from "../../../../shared/lib/utils";
@@ -556,8 +556,7 @@ export function ConversationInput({
       const activeChatData = useChatStore.getState().activeChat;
       const cachedCharacters = qc.getQueryData<Array<{ id: string; data: unknown }>>(characterKeys.list());
       const cachedPersonas = qc.getQueryData<Array<Record<string, unknown>>>(characterKeys.personas);
-      const resolveInputMacros = (template: string) =>
-        resolveInputMacrosForChat(template, activeChatData, cachedCharacters, cachedPersonas, raw);
+      const resolveInputMacros = createInputMacroResolverForChat(activeChatData, cachedCharacters, cachedPersonas, raw);
       // First pass: resolve macros against raw input, so {{input}} uses the pre-translation text.
       let message = applyToUserInput(raw, { resolveMacros: resolveInputMacros });
       // Input translation for streaming path too
@@ -662,8 +661,7 @@ export function ConversationInput({
     const activeChat = useChatStore.getState().activeChat;
     const cachedCharacters = qc.getQueryData<Array<{ id: string; data: unknown }>>(characterKeys.list());
     const cachedPersonas = qc.getQueryData<Array<Record<string, unknown>>>(characterKeys.personas);
-    const resolveInputMacros = (template: string) =>
-      resolveInputMacrosForChat(template, activeChat, cachedCharacters, cachedPersonas, raw);
+    const resolveInputMacros = createInputMacroResolverForChat(activeChat, cachedCharacters, cachedPersonas, raw);
     // First pass: resolve macros against raw input, so {{input}} uses the pre-translation text.
     let message = applyToUserInput(raw, { resolveMacros: resolveInputMacros });
 
@@ -861,8 +859,7 @@ export function ConversationInput({
     const activeChatData = useChatStore.getState().activeChat;
     const cachedCharacters = qc.getQueryData<Array<{ id: string; data: unknown }>>(characterKeys.list());
     const cachedPersonas = qc.getQueryData<Array<Record<string, unknown>>>(characterKeys.personas);
-    const resolveInputMacros = (template: string) =>
-      resolveInputMacrosForChat(template, activeChatData, cachedCharacters, cachedPersonas, raw);
+    const resolveInputMacros = createInputMacroResolverForChat(activeChatData, cachedCharacters, cachedPersonas, raw);
     let message = applyToUserInput(raw, { resolveMacros: resolveInputMacros });
 
     const chatMeta = parseChatMetadata(activeChatData?.metadata);

--- a/src/features/modes/conversation/components/ConversationInput.tsx
+++ b/src/features/modes/conversation/components/ConversationInput.tsx
@@ -35,7 +35,7 @@ import {
   type SlashCommand,
   type SlashCommandContext,
 } from "../../../../shared/lib/slash-commands";
-import { createInputMacroResolverForChat, isPromptPreviewMacro } from "../../../../shared/lib/chat-macros";
+import { isPromptPreviewMacro, resolveInputMacrosForChat } from "../../../../shared/lib/chat-macros";
 import { parseChatMetadata } from "../../../../shared/lib/chat-display";
 import { formatTextQuotes } from "../../../../shared/lib/dialogue-quotes";
 import { cn, getAvatarCropStyle, type AvatarCropValue } from "../../../../shared/lib/utils";
@@ -556,7 +556,8 @@ export function ConversationInput({
       const activeChatData = useChatStore.getState().activeChat;
       const cachedCharacters = qc.getQueryData<Array<{ id: string; data: unknown }>>(characterKeys.list());
       const cachedPersonas = qc.getQueryData<Array<Record<string, unknown>>>(characterKeys.personas);
-      const resolveInputMacros = createInputMacroResolverForChat(activeChatData, cachedCharacters, cachedPersonas, raw);
+      const resolveInputMacros = (template: string) =>
+        resolveInputMacrosForChat(template, activeChatData, cachedCharacters, cachedPersonas, raw);
       // First pass: resolve macros against raw input, so {{input}} uses the pre-translation text.
       let message = applyToUserInput(raw, { resolveMacros: resolveInputMacros });
       // Input translation for streaming path too
@@ -661,7 +662,8 @@ export function ConversationInput({
     const activeChat = useChatStore.getState().activeChat;
     const cachedCharacters = qc.getQueryData<Array<{ id: string; data: unknown }>>(characterKeys.list());
     const cachedPersonas = qc.getQueryData<Array<Record<string, unknown>>>(characterKeys.personas);
-    const resolveInputMacros = createInputMacroResolverForChat(activeChat, cachedCharacters, cachedPersonas, raw);
+    const resolveInputMacros = (template: string) =>
+      resolveInputMacrosForChat(template, activeChat, cachedCharacters, cachedPersonas, raw);
     // First pass: resolve macros against raw input, so {{input}} uses the pre-translation text.
     let message = applyToUserInput(raw, { resolveMacros: resolveInputMacros });
 
@@ -859,7 +861,8 @@ export function ConversationInput({
     const activeChatData = useChatStore.getState().activeChat;
     const cachedCharacters = qc.getQueryData<Array<{ id: string; data: unknown }>>(characterKeys.list());
     const cachedPersonas = qc.getQueryData<Array<Record<string, unknown>>>(characterKeys.personas);
-    const resolveInputMacros = createInputMacroResolverForChat(activeChatData, cachedCharacters, cachedPersonas, raw);
+    const resolveInputMacros = (template: string) =>
+      resolveInputMacrosForChat(template, activeChatData, cachedCharacters, cachedPersonas, raw);
     let message = applyToUserInput(raw, { resolveMacros: resolveInputMacros });
 
     const chatMeta = parseChatMetadata(activeChatData?.metadata);

--- a/src/features/modes/shared/chat-ui/components/ChatInput.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatInput.tsx
@@ -36,6 +36,7 @@ import { createInputMacroResolverForChat, isPromptPreviewMacro } from "../../../
 import { parseChatMetadata } from "../../../../../shared/lib/chat-display";
 import { formatTextQuotes } from "../../../../../shared/lib/dialogue-quotes";
 import { cn, getAvatarCropStyle, type AvatarCropValue } from "../../../../../shared/lib/utils";
+import { blobToDataUrl } from "../../../../../shared/lib/url-blob";
 import { prepareImageAttachment } from "../../../../../shared/lib/chat-attachment-images";
 import { translateDraftText } from "../../../../../shared/lib/draft-translation";
 import { EmojiPicker } from "../../../../../shared/components/ui/EmojiPicker";
@@ -106,15 +107,6 @@ function isSupportedChatAttachment(file: File): boolean {
     return true;
   }
   return TEXT_ATTACHMENT_EXTENSIONS.has(getFileExtension(file.name));
-}
-
-function readFileAsDataUrl(file: Blob): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = () => resolve(reader.result as string);
-    reader.onerror = () => reject(reader.error ?? new Error("Failed to read file"));
-    reader.readAsDataURL(file);
-  });
 }
 
 interface ChatInputProps {
@@ -387,7 +379,7 @@ export const ChatInput = memo(function ChatInput({
         }
 
         try {
-          const data = await readFileAsDataUrl(file);
+          const data = await blobToDataUrl(file, "Failed to read file");
           appendAttachmentForChat(originChatId, { type: inferAttachmentType(file), data, name: displayName });
         } catch {
           toast.error(`Failed to read ${displayName}`);

--- a/src/features/modes/shared/chat-ui/components/ChatInput.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatInput.tsx
@@ -32,7 +32,7 @@ import {
   type SlashCommand,
   type SlashCommandContext,
 } from "../../../../../shared/lib/slash-commands";
-import { isPromptPreviewMacro, resolveInputMacrosForChat } from "../../../../../shared/lib/chat-macros";
+import { createInputMacroResolverForChat, isPromptPreviewMacro } from "../../../../../shared/lib/chat-macros";
 import { parseChatMetadata } from "../../../../../shared/lib/chat-display";
 import { formatTextQuotes } from "../../../../../shared/lib/dialogue-quotes";
 import { cn, getAvatarCropStyle, type AvatarCropValue } from "../../../../../shared/lib/utils";
@@ -567,8 +567,7 @@ export const ChatInput = memo(function ChatInput({
 
     const cachedCharacters = qc.getQueryData<Array<{ id: string; data: unknown }>>(characterKeys.list());
     const cachedPersonas = qc.getQueryData<Array<Record<string, unknown>>>(characterKeys.personas);
-    const resolveInputMacros = (template: string) =>
-      resolveInputMacrosForChat(template, chat, cachedCharacters, cachedPersonas, normalized);
+    const resolveInputMacros = createInputMacroResolverForChat(chat, cachedCharacters, cachedPersonas, normalized);
     let message = applyToUserInput(normalized, { resolveMacros: resolveInputMacros });
 
     // Input translation: translate user's message before sending
@@ -746,8 +745,7 @@ export const ChatInput = memo(function ChatInput({
     const chat = useChatStore.getState().activeChat;
     const cachedCharacters = qc.getQueryData<Array<{ id: string; data: unknown }>>(characterKeys.list());
     const cachedPersonas = qc.getQueryData<Array<Record<string, unknown>>>(characterKeys.personas);
-    const resolveInputMacros = (template: string) =>
-      resolveInputMacrosForChat(template, chat, cachedCharacters, cachedPersonas, normalized);
+    const resolveInputMacros = createInputMacroResolverForChat(chat, cachedCharacters, cachedPersonas, normalized);
     let message = applyToUserInput(normalized, { resolveMacros: resolveInputMacros });
 
     const chatMeta = parseChatMetadata(chat?.metadata);

--- a/src/features/modes/shared/chat-ui/components/ChatInput.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatInput.tsx
@@ -32,7 +32,7 @@ import {
   type SlashCommand,
   type SlashCommandContext,
 } from "../../../../../shared/lib/slash-commands";
-import { createInputMacroResolverForChat, isPromptPreviewMacro } from "../../../../../shared/lib/chat-macros";
+import { isPromptPreviewMacro, resolveInputMacrosForChat } from "../../../../../shared/lib/chat-macros";
 import { parseChatMetadata } from "../../../../../shared/lib/chat-display";
 import { formatTextQuotes } from "../../../../../shared/lib/dialogue-quotes";
 import { cn, getAvatarCropStyle, type AvatarCropValue } from "../../../../../shared/lib/utils";
@@ -567,7 +567,8 @@ export const ChatInput = memo(function ChatInput({
 
     const cachedCharacters = qc.getQueryData<Array<{ id: string; data: unknown }>>(characterKeys.list());
     const cachedPersonas = qc.getQueryData<Array<Record<string, unknown>>>(characterKeys.personas);
-    const resolveInputMacros = createInputMacroResolverForChat(chat, cachedCharacters, cachedPersonas, normalized);
+    const resolveInputMacros = (template: string) =>
+      resolveInputMacrosForChat(template, chat, cachedCharacters, cachedPersonas, normalized);
     let message = applyToUserInput(normalized, { resolveMacros: resolveInputMacros });
 
     // Input translation: translate user's message before sending
@@ -745,7 +746,8 @@ export const ChatInput = memo(function ChatInput({
     const chat = useChatStore.getState().activeChat;
     const cachedCharacters = qc.getQueryData<Array<{ id: string; data: unknown }>>(characterKeys.list());
     const cachedPersonas = qc.getQueryData<Array<Record<string, unknown>>>(characterKeys.personas);
-    const resolveInputMacros = createInputMacroResolverForChat(chat, cachedCharacters, cachedPersonas, normalized);
+    const resolveInputMacros = (template: string) =>
+      resolveInputMacrosForChat(template, chat, cachedCharacters, cachedPersonas, normalized);
     let message = applyToUserInput(normalized, { resolveMacros: resolveInputMacros });
 
     const chatMeta = parseChatMetadata(chat?.metadata);

--- a/src/features/runtime/generation/hooks/use-generate.ts
+++ b/src/features/runtime/generation/hooks/use-generate.ts
@@ -26,7 +26,7 @@ import { ApiError } from "../../../../shared/api/api-errors";
 import { visualAssetsApi } from "../../../../shared/api/visual-assets-api";
 import { requestImagePromptReview } from "../../../../shared/components/ui/ImagePromptReviewHost";
 import { useAgentStore, type PendingCardUpdate } from "../../../../shared/stores/agent.store";
-import { toAgentFailure } from "../../../../shared/lib/agent-failures";
+import { formatAgentFailuresToast, toAgentFailure } from "../../../../shared/lib/agent-failures";
 import { useChatStore } from "../../../../shared/stores/chat.store";
 import { useUIStore } from "../../../../shared/stores/ui.store";
 import { useGameStateStore } from "../../world-state/index";
@@ -1371,6 +1371,19 @@ export function useGenerate() {
           runDeferredGenerationWork("agent retry result effects", () =>
             applyAgentResultEffects(queryClient, chatId, result),
           );
+        }
+        const failedRetries = results
+          .filter((result) => !result.success)
+          .map((result) => {
+            const data = parseMaybeRecord(result.data);
+            return toAgentFailure({
+              agentType: result.agentType,
+              agentName: readString(data.agentName).trim() || result.agentType,
+              error: result.error,
+            });
+          });
+        if (failedRetries.length > 0) {
+          toast.error(formatAgentFailuresToast(failedRetries), { duration: 10_000 });
         }
         runDeferredGenerationWork("agent retry refresh", async () => {
           await refreshGameStateFromStorage(chatId);

--- a/src/features/runtime/generation/hooks/use-generate.ts
+++ b/src/features/runtime/generation/hooks/use-generate.ts
@@ -1375,10 +1375,15 @@ export function useGenerate() {
         const failedRetries = results
           .filter((result) => !result.success)
           .map((result) => {
+            const resultRecord = parseMaybeRecord(result);
             const data = parseMaybeRecord(result.data);
             return toAgentFailure({
               agentType: result.agentType,
-              agentName: readString(data.agentName).trim() || result.agentType,
+              agentName:
+                readString(resultRecord.agentName).trim() ||
+                readString(resultRecord.name).trim() ||
+                readString(data.agentName).trim() ||
+                result.agentType,
               error: result.error,
             });
           });

--- a/src/features/runtime/tracker/components/tracker-metadata.helpers.ts
+++ b/src/features/runtime/tracker/components/tracker-metadata.helpers.ts
@@ -11,24 +11,6 @@ export function parseMetadataRecord(raw: unknown): Record<string, unknown> {
   return typeof raw === "object" ? (raw as Record<string, unknown>) : {};
 }
 
-export function normalizeStringArray(value: unknown): string[] {
-  return Array.isArray(value)
-    ? value.filter((item): item is string => typeof item === "string" && item.length > 0)
-    : [];
-}
-
-export function normalizeMaybeJsonStringArray(value: unknown): string[] {
-  if (Array.isArray(value)) return normalizeStringArray(value);
-  if (typeof value !== "string") return [];
-  const trimmed = value.trim();
-  if (!trimmed) return [];
-  try {
-    return normalizeStringArray(JSON.parse(trimmed));
-  } catch {
-    return [trimmed];
-  }
-}
-
 export function normalizeLookupText(value: string | null | undefined) {
   return (value ?? "").trim().toLowerCase();
 }

--- a/src/features/runtime/tracker/hooks/use-featured-character-cards.ts
+++ b/src/features/runtime/tracker/hooks/use-featured-character-cards.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useUpdateChatMetadata } from "../../../catalog/chats/index";
+import { normalizeStringArray } from "../../../../shared/lib/tracker-metadata";
 import { TRACKER_FEATURED_CHARACTER_META_KEY } from "../components/tracker-data-sidebar.constants";
-import { normalizeStringArray } from "../components/tracker-metadata.helpers";
 
 function getFeaturedCharacterCardValues(cards: Set<string>) {
   return Array.from(cards);

--- a/src/features/runtime/tracker/hooks/use-tracker-panel-model.ts
+++ b/src/features/runtime/tracker/hooks/use-tracker-panel-model.ts
@@ -5,7 +5,11 @@ import type { PresentCharacter } from "../../../../engine/contracts/types/game-s
 import type { Persona } from "../../../../engine/contracts/types/persona";
 import { storageApi } from "../../../../shared/api/storage-api";
 import { parseCharacterDisplayData } from "../../../../shared/lib/character-display";
-import { addAliasLookups, addExactNameLookups } from "../../../../shared/lib/tracker-metadata";
+import {
+  addAliasLookups,
+  addExactNameLookups,
+  normalizeMaybeJsonStringArray,
+} from "../../../../shared/lib/tracker-metadata";
 import { useChatStore } from "../../../../shared/stores/chat.store";
 import { useUIStore } from "../../../../shared/stores/ui.store";
 import type { TrackerPanelSizeProfile, TrackerPanelSide, TrackerTemperatureUnit, TrackerThoughtBubbleDisplay } from "../../../../shared/stores/ui.store";
@@ -23,7 +27,6 @@ import type { TrackerProfileColors } from "../components/tracker-profile-colors"
 import {
   getLatestSpriteExpressionsFromMessages,
   normalizeLookupText,
-  normalizeMaybeJsonStringArray,
   normalizeSpriteExpressionMap,
   parseMetadataRecord,
 } from "../components/tracker-metadata.helpers";

--- a/src/features/shell/bot-browser/components/BotBrowserView.tsx
+++ b/src/features/shell/bot-browser/components/BotBrowserView.tsx
@@ -39,6 +39,7 @@ import { toast } from "sonner";
 import { cn } from "../../../../shared/lib/utils";
 import {
   confirmEmbeddedLorebookImport,
+  hasLorebookEntries,
   readEmbeddedLorebookFromCharacterPayload,
 } from "../../../../shared/lib/character-import";
 import {
@@ -163,13 +164,6 @@ const STAT_ICONS = {
   message: MessageSquare,
   hash: Hash,
 };
-
-function hasLorebookEntries(value: unknown): boolean {
-  if (!value || typeof value !== "object") return false;
-  const entries = (value as Record<string, unknown>).entries;
-  if (Array.isArray(entries)) return entries.length > 0;
-  return !!entries && typeof entries === "object" && Object.keys(entries).length > 0;
-}
 
 function attachEmbeddedLorebookToCharacterJson(raw: Record<string, unknown>, embeddedLorebook: unknown) {
   if (!hasLorebookEntries(embeddedLorebook)) return raw;

--- a/src/features/shell/settings/components/ProfileImportSection.test.tsx
+++ b/src/features/shell/settings/components/ProfileImportSection.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useUIStore } from "../../../../shared/stores/ui.store";
+import { ProfileImportSection } from "./ProfileImportSection";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+  open: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+vi.mock("../../../../shared/lib/app-dialogs", () => ({
+  showConfirmDialog: vi.fn(),
+}));
+
+vi.mock("../../../../shared/api/profile-api", () => ({
+  profileApi: {
+    importProfile: vi.fn(),
+    importProfileFile: vi.fn(),
+  },
+}));
+
+const toastError = vi.mocked(await import("sonner")).toast.error;
+
+describe("ProfileImportSection", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    useUIStore.setState({ remoteRuntimeUrl: "" });
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("renders with an invalid remote runtime URL and reports the click-time error", async () => {
+    useUIStore.setState({ remoteRuntimeUrl: "http://[bad" });
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={new QueryClient()}>
+          <ProfileImportSection />
+        </QueryClientProvider>,
+      );
+    });
+
+    const button = container.querySelector("button");
+    expect(button?.textContent).toContain("Import Profile (JSON)");
+
+    await act(async () => {
+      button?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(toastError).toHaveBeenCalledWith("Invalid Remote Runtime URL. Check Settings and enter a valid runtime URL.");
+  });
+});

--- a/src/features/shell/settings/components/ProfileImportSection.test.tsx
+++ b/src/features/shell/settings/components/ProfileImportSection.test.tsx
@@ -32,6 +32,20 @@ vi.mock("../../../../shared/api/profile-api", () => ({
 }));
 
 const toastError = vi.mocked(await import("sonner")).toast.error;
+const toastSuccess = vi.mocked(await import("sonner")).toast.success;
+const importProfile = (await import("../../../../shared/api/profile-api")).profileApi
+  .importProfile as unknown as ReturnType<typeof vi.fn>;
+const showConfirmDialog = vi.mocked(await import("../../../../shared/lib/app-dialogs")).showConfirmDialog;
+
+async function changeProfileFileInput(input: HTMLInputElement, file: File) {
+  Object.defineProperty(input, "files", {
+    configurable: true,
+    value: [file],
+  });
+  await act(async () => {
+    input.dispatchEvent(new Event("change", { bubbles: true }));
+  });
+}
 
 describe("ProfileImportSection", () => {
   let container: HTMLDivElement;
@@ -68,6 +82,59 @@ describe("ProfileImportSection", () => {
       button?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
 
-    expect(toastError).toHaveBeenCalledWith("Invalid Remote Runtime URL. Check Settings and enter a valid runtime URL.");
+    expect(toastError).toHaveBeenCalledWith(
+      "Invalid Remote Runtime URL. Check Settings and enter a valid runtime URL.",
+    );
+  });
+
+  it("imports a remote profile JSON file through the shared profile API", async () => {
+    useUIStore.setState({ remoteRuntimeUrl: "http://localhost:4111" });
+    showConfirmDialog.mockResolvedValue(true);
+    importProfile.mockResolvedValue({ success: true, imported: { characters: 1 } });
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={new QueryClient()}>
+          <ProfileImportSection />
+        </QueryClientProvider>,
+      );
+    });
+
+    const input = container.querySelector<HTMLInputElement>('input[type="file"]');
+    expect(input).toBeTruthy();
+
+    await changeProfileFileInput(
+      input!,
+      new File([JSON.stringify({ version: 1, characters: [] })], "profile.json", { type: "application/json" }),
+    );
+
+    await vi.waitFor(() => {
+      expect(importProfile).toHaveBeenCalledWith({ version: 1, characters: [] });
+    });
+    expect(showConfirmDialog).toHaveBeenCalledWith(expect.objectContaining({ title: "Import Profile" }));
+    expect(toastSuccess).toHaveBeenCalledWith("Imported: 1 characters");
+  });
+
+  it("reports a SyntaxError toast when a remote profile JSON file cannot be parsed", async () => {
+    useUIStore.setState({ remoteRuntimeUrl: "http://localhost:4111" });
+    showConfirmDialog.mockResolvedValue(true);
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={new QueryClient()}>
+          <ProfileImportSection />
+        </QueryClientProvider>,
+      );
+    });
+
+    const input = container.querySelector<HTMLInputElement>('input[type="file"]');
+    expect(input).toBeTruthy();
+
+    await changeProfileFileInput(input!, new File(["{"], "profile.json", { type: "application/json" }));
+
+    await vi.waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith("Import failed. Make sure this is a valid profile JSON file.");
+    });
+    expect(importProfile).not.toHaveBeenCalled();
   });
 });

--- a/src/features/shell/settings/components/ProfileImportSection.tsx
+++ b/src/features/shell/settings/components/ProfileImportSection.tsx
@@ -7,6 +7,7 @@ import { profileApi } from "../../../../shared/api/profile-api";
 import { remoteRuntimeTarget } from "../../../../shared/api/remote-runtime";
 import { showConfirmDialog } from "../../../../shared/lib/app-dialogs";
 import { cn } from "../../../../shared/lib/utils";
+import { useUIStore } from "../../../../shared/stores/ui.store";
 
 type ProfileImportStats = {
   characters?: number;
@@ -92,12 +93,13 @@ function formatProfileImportSkippedStats(stats?: ProfileImportStats) {
 export function ProfileImportSection() {
   const qc = useQueryClient();
   const remoteProfileInputRef = useRef<HTMLInputElement>(null);
+  const remoteRuntimeUrl = useUIStore((state) => state.remoteRuntimeUrl);
   const [profileImportProgress, setProfileImportProgress] = useState<ProfileImportProgressState | null>(null);
   const profileImportBusy =
     profileImportProgress?.status === "reading" ||
     profileImportProgress?.status === "starting" ||
     profileImportProgress?.status === "running";
-  const isRemoteRuntime = Boolean(remoteRuntimeTarget());
+  const isRemoteRuntime = remoteRuntimeUrl.trim().length > 0;
 
   useEffect(() => {
     if (!profileImportBusy) return;
@@ -174,9 +176,10 @@ export function ProfileImportSection() {
   };
 
   const showProfileImportError = (err: unknown, startedAt: number) => {
+    const expectedProfileFile = isRemoteRuntime ? "profile JSON file" : "profile JSON or ZIP file";
     const message =
       err instanceof SyntaxError
-        ? "Import failed. Make sure this is a valid profile JSON or ZIP file."
+        ? `Import failed. Make sure this is a valid ${expectedProfileFile}.`
         : `Import failed: ${err instanceof Error ? err.message : "local import error"}`;
     setProfileImportProgress({
       status: "error",
@@ -192,7 +195,13 @@ export function ProfileImportSection() {
 
   const handleProfileImport = async () => {
     if (profileImportBusy) return;
-    if (remoteRuntimeTarget()) {
+    if (isRemoteRuntime) {
+      try {
+        remoteRuntimeTarget();
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "Invalid Remote Runtime URL");
+        return;
+      }
       remoteProfileInputRef.current?.click();
       return;
     }

--- a/src/features/shell/settings/components/ProfileImportSection.tsx
+++ b/src/features/shell/settings/components/ProfileImportSection.tsx
@@ -1,7 +1,7 @@
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { useQueryClient } from "@tanstack/react-query";
 import { AlertTriangle, Check, Download, Loader2 } from "lucide-react";
-import { useEffect, useState } from "react";
+import { type ChangeEvent, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { profileApi } from "../../../../shared/api/profile-api";
 import { remoteRuntimeTarget } from "../../../../shared/api/remote-runtime";
@@ -31,6 +31,13 @@ type ProfileImportProgressState = {
   elapsedSeconds: number;
   imported?: ProfileImportStats;
   error?: string;
+};
+
+type ProfileImportResult = {
+  success?: boolean;
+  error?: string;
+  message?: string;
+  imported?: ProfileImportStats;
 };
 
 function formatProfileImportDuration(seconds: number) {
@@ -84,11 +91,13 @@ function formatProfileImportSkippedStats(stats?: ProfileImportStats) {
 
 export function ProfileImportSection() {
   const qc = useQueryClient();
+  const remoteProfileInputRef = useRef<HTMLInputElement>(null);
   const [profileImportProgress, setProfileImportProgress] = useState<ProfileImportProgressState | null>(null);
   const profileImportBusy =
     profileImportProgress?.status === "reading" ||
     profileImportProgress?.status === "starting" ||
     profileImportProgress?.status === "running";
+  const isRemoteRuntime = Boolean(remoteRuntimeTarget());
 
   useEffect(() => {
     if (!profileImportBusy) return;
@@ -102,8 +111,91 @@ export function ProfileImportSection() {
     return () => window.clearInterval(timer);
   }, [profileImportBusy]);
 
+  const finishProfileImport = (data: ProfileImportResult, startedAt: number) => {
+    if (data?.success === false) throw new Error(data.error ?? data.message ?? "Unknown error");
+    qc.invalidateQueries();
+    const imported = data?.imported;
+    const summary = formatProfileImportStats(imported);
+    const skippedSummary = formatProfileImportSkippedStats(imported);
+    setProfileImportProgress((current) => {
+      const totalItems = Math.max(1, current?.totalItems ?? 1);
+      return {
+        status: "success",
+        label: "Profile import complete",
+        completedItems: totalItems,
+        totalItems,
+        startedAt,
+        elapsedSeconds: Math.floor((Date.now() - startedAt) / 1000),
+        imported,
+      };
+    });
+    toast.success(
+      [summary ? `Imported: ${summary}` : "Profile imported.", skippedSummary ? `Skipped: ${skippedSummary}.` : ""]
+        .filter(Boolean)
+        .join(" "),
+    );
+  };
+
+  const runConfirmedProfileImport = async (startedAt: number, importProfile: () => Promise<ProfileImportResult>) => {
+    const confirmed = await showConfirmDialog({
+      title: "Import Profile",
+      message:
+        "Importing a profile replaces data from the selected file and may remove existing collections, depending on the export format. This cannot be undone. Continue?",
+      confirmLabel: "Import",
+      cancelLabel: "Cancel",
+      tone: "destructive",
+    });
+    if (!confirmed) {
+      setProfileImportProgress(null);
+      return;
+    }
+    setProfileImportProgress((current) =>
+      current
+        ? {
+            ...current,
+            status: "starting",
+            label: "Reading profile file",
+            elapsedSeconds: Math.floor((Date.now() - startedAt) / 1000),
+          }
+        : current,
+    );
+    setProfileImportProgress((current) =>
+      current
+        ? {
+            ...current,
+            status: "running",
+            label: "Importing profile",
+            totalItems: Math.max(1, current.totalItems),
+            elapsedSeconds: Math.floor((Date.now() - startedAt) / 1000),
+          }
+        : current,
+    );
+    finishProfileImport(await importProfile(), startedAt);
+  };
+
+  const showProfileImportError = (err: unknown, startedAt: number) => {
+    const message =
+      err instanceof SyntaxError
+        ? "Import failed. Make sure this is a valid profile JSON or ZIP file."
+        : `Import failed: ${err instanceof Error ? err.message : "local import error"}`;
+    setProfileImportProgress({
+      status: "error",
+      label: "Profile import failed",
+      completedItems: 0,
+      totalItems: 1,
+      startedAt,
+      elapsedSeconds: Math.floor((Date.now() - startedAt) / 1000),
+      error: message.replace(/^Import failed:\s*/, ""),
+    });
+    toast.error(message);
+  };
+
   const handleProfileImport = async () => {
     if (profileImportBusy) return;
+    if (remoteRuntimeTarget()) {
+      remoteProfileInputRef.current?.click();
+      return;
+    }
     const startedAt = Date.now();
     setProfileImportProgress({
       status: "reading",
@@ -114,9 +206,6 @@ export function ProfileImportSection() {
       elapsedSeconds: 0,
     });
     try {
-      if (remoteRuntimeTarget()) {
-        throw new Error("Profile import from a local file path is not available while Remote Runtime is configured.");
-      }
       const selected = await openDialog({
         multiple: false,
         filters: [{ name: "Marinara Profile", extensions: ["json", "zip"] }],
@@ -125,87 +214,44 @@ export function ProfileImportSection() {
         setProfileImportProgress(null);
         return;
       }
-      const confirmed = await showConfirmDialog({
-        title: "Import Profile",
-        message:
-          "Importing a profile replaces data from the selected file and may remove existing collections, depending on the export format. This cannot be undone. Continue?",
-        confirmLabel: "Import",
-        cancelLabel: "Cancel",
-        tone: "destructive",
-      });
-      if (!confirmed) {
-        setProfileImportProgress(null);
-        return;
-      }
-      setProfileImportProgress((current) =>
-        current
-          ? {
-              ...current,
-              status: "starting",
-              label: "Reading profile file",
-              elapsedSeconds: Math.floor((Date.now() - startedAt) / 1000),
-            }
-          : current,
-      );
-      setProfileImportProgress((current) =>
-        current
-          ? {
-              ...current,
-              status: "running",
-              label: "Importing profile",
-              totalItems: Math.max(1, current.totalItems),
-              elapsedSeconds: Math.floor((Date.now() - startedAt) / 1000),
-            }
-          : current,
-      );
-      const data = await profileApi.importProfileFile<{
-        success?: boolean;
-        error?: string;
-        message?: string;
-        imported?: ProfileImportStats;
-      }>(selected);
-      if (data?.success === false) throw new Error(data.error ?? data.message ?? "Unknown error");
-      qc.invalidateQueries();
-      const imported = data?.imported;
-      const summary = formatProfileImportStats(imported);
-      const skippedSummary = formatProfileImportSkippedStats(imported);
-      setProfileImportProgress((current) => {
-        const totalItems = Math.max(1, current?.totalItems ?? 1);
-        return {
-          status: "success",
-          label: "Profile import complete",
-          completedItems: totalItems,
-          totalItems,
-          startedAt,
-          elapsedSeconds: Math.floor((Date.now() - startedAt) / 1000),
-          imported,
-        };
-      });
-      toast.success(
-        [summary ? `Imported: ${summary}` : "Profile imported.", skippedSummary ? `Skipped: ${skippedSummary}.` : ""]
-          .filter(Boolean)
-          .join(" "),
-      );
+      await runConfirmedProfileImport(startedAt, () => profileApi.importProfileFile<ProfileImportResult>(selected));
     } catch (err) {
-      const message =
-        err instanceof SyntaxError
-          ? "Import failed. Make sure this is a valid profile JSON or ZIP file."
-          : `Import failed: ${err instanceof Error ? err.message : "local import error"}`;
-      setProfileImportProgress({
-        status: "error",
-        label: "Profile import failed",
-        completedItems: 0,
-        totalItems: 1,
-        startedAt,
-        elapsedSeconds: Math.floor((Date.now() - startedAt) / 1000),
-        error: message.replace(/^Import failed:\s*/, ""),
+      showProfileImportError(err, startedAt);
+    }
+  };
+
+  const handleRemoteProfileFileChange = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.currentTarget.files?.[0] ?? null;
+    event.currentTarget.value = "";
+    if (!file || profileImportBusy) return;
+    const startedAt = Date.now();
+    setProfileImportProgress({
+      status: "reading",
+      label: "Selecting profile file",
+      completedItems: 0,
+      totalItems: 1,
+      startedAt,
+      elapsedSeconds: 0,
+    });
+    try {
+      await runConfirmedProfileImport(startedAt, async () => {
+        const envelope = JSON.parse(await file.text()) as unknown;
+        return profileApi.importProfile<ProfileImportResult>(envelope);
       });
-      toast.error(message);
+    } catch (err) {
+      showProfileImportError(err, startedAt);
     }
   };
 
   return (
     <>
+      <input
+        ref={remoteProfileInputRef}
+        type="file"
+        accept=".json,application/json"
+        className="hidden"
+        onChange={(event) => void handleRemoteProfileFileChange(event)}
+      />
       <button
         type="button"
         onClick={() => void handleProfileImport()}
@@ -216,7 +262,11 @@ export function ProfileImportSection() {
         )}
       >
         {profileImportBusy ? <Loader2 size="1rem" className="animate-spin" /> : <Download size="1rem" />}
-        {profileImportBusy ? "Importing Profile..." : "Import Profile (JSON/ZIP)"}
+        {profileImportBusy
+          ? "Importing Profile..."
+          : isRemoteRuntime
+            ? "Import Profile (JSON)"
+            : "Import Profile (JSON/ZIP)"}
       </button>
 
       {profileImportProgress && (

--- a/src/features/shell/settings/components/SettingsPanel.tsx
+++ b/src/features/shell/settings/components/SettingsPanel.tsx
@@ -16,6 +16,7 @@ import {
   type VisualTheme,
 } from "../../../../shared/stores/ui.store";
 import { cn } from "../../../../shared/lib/utils";
+import { QUOTE_FORMATS } from "../../../../shared/lib/dialogue-quotes";
 import { useExtensions, useCreateExtension, useDeleteExtension, useUpdateExtension } from "../hooks/use-extensions";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { gameAssetsApi } from "../../../../shared/api/assets-api";
@@ -195,10 +196,15 @@ const GAME_DIALOGUE_DISPLAY_OPTIONS: Array<{ id: GameDialogueDisplayMode; label:
   },
 ];
 
-const QUOTE_FORMAT_OPTIONS: Array<{ id: QuoteFormat; label: string; sample: string }> = [
-  { id: "straight", label: "Straight", sample: '"Hello", it\'s me.' },
-  { id: "typographic", label: "Typographic", sample: "\u201cHello,\u201d it\u2019s me." },
-];
+const QUOTE_FORMAT_OPTION_COPY = {
+  straight: { label: "Straight", sample: '"Hello", it\'s me.' },
+  typographic: { label: "Typographic", sample: "\u201cHello,\u201d it\u2019s me." },
+} satisfies Record<QuoteFormat, { label: string; sample: string }>;
+
+const QUOTE_FORMAT_OPTIONS: Array<{ id: QuoteFormat; label: string; sample: string }> = QUOTE_FORMATS.map((id) => ({
+  id,
+  ...QUOTE_FORMAT_OPTION_COPY[id],
+}));
 
 const TRACKER_PANEL_SIZE_PROFILE_OPTIONS: Array<{ id: TrackerPanelSizeProfile; label: string; desc: string }> = [
   { id: "compact", label: "Compact", desc: `${getTrackerPanelWidthForProfile("compact")} px` },

--- a/src/shared/api/assets-api.ts
+++ b/src/shared/api/assets-api.ts
@@ -1,8 +1,7 @@
-import type { AssetGateway } from "../../engine/capabilities/assets";
 import { fileToUploadPayload } from "./file-payload";
 import { invokeTauri } from "./tauri-client";
 
-export interface GameAssetFileInfo {
+interface GameAssetFileInfo {
   name: string;
   size: number;
   width?: number;
@@ -59,17 +58,6 @@ const gameAssetCommands = {
   copyBulk: (paths: string[], targetFolder: string) =>
     invokeTauri<BulkOperationResult & { targetFolder: string }>("game_assets_copy_bulk", { paths, targetFolder }),
   deleteBulk: (paths: string[]) => invokeTauri<BulkOperationResult>("game_assets_delete_bulk", { paths }),
-};
-
-export const assetsApi: AssetGateway = {
-  list: gameAssetCommands.list,
-  readText: (path: string) =>
-    gameAssetCommands.readText<{ content?: unknown }>(path).then((value) => String(value.content ?? "")),
-  writeText: gameAssetCommands.writeText,
-  remove: gameAssetCommands.deleteFile,
-  copy: gameAssetCommands.copy,
-  move: gameAssetCommands.move,
-  openFolder: gameAssetCommands.openFolder,
 };
 
 export const gameAssetsApi = {

--- a/src/shared/api/integration-utility-api.ts
+++ b/src/shared/api/integration-utility-api.ts
@@ -4,7 +4,7 @@ import { remoteRuntimeTarget } from "./remote-runtime";
 import { invokeTauri } from "./tauri-client";
 export { ttsApi } from "./tts-api";
 
-export interface GifSearchResult {
+interface GifSearchResult {
   id: string;
   title: string;
   preview: string;

--- a/src/shared/api/local-file-api.ts
+++ b/src/shared/api/local-file-api.ts
@@ -4,7 +4,7 @@ import { remoteRuntimeTarget } from "./remote-runtime";
 
 export const USER_BACKGROUND_URL_PREFIX = "marinara-background:";
 export const GAME_ASSET_URL_PREFIX = "marinara-game-asset:";
-export const LOREBOOK_IMAGE_URL_PREFIX = "marinara-lorebook-image:";
+const LOREBOOK_IMAGE_URL_PREFIX = "marinara-lorebook-image:";
 
 type PathResponse = { path?: string | null };
 
@@ -21,7 +21,7 @@ function canConvertFileSrc(): boolean {
     .__TAURI_INTERNALS__?.convertFileSrc;
 }
 
-export function encodeLocalAssetPath(path: string): string {
+function encodeLocalAssetPath(path: string): string {
   return encodeURIComponent(path.replace(/\\/g, "/"));
 }
 
@@ -41,20 +41,7 @@ export function gameAssetUrl(path: string): string {
   return `${GAME_ASSET_URL_PREFIX}${encodeLocalAssetPath(path)}`;
 }
 
-export function lorebookImageUrl(filename: string): string {
-  return `${LOREBOOK_IMAGE_URL_PREFIX}${encodeLocalAssetPath(filename)}`;
-}
-
-export function isManagedLocalAssetUrl(url: string | null | undefined): boolean {
-  return (
-    !!url &&
-    (url.startsWith(USER_BACKGROUND_URL_PREFIX) ||
-      url.startsWith(GAME_ASSET_URL_PREFIX) ||
-      url.startsWith(LOREBOOK_IMAGE_URL_PREFIX))
-  );
-}
-
-export function filePathToAssetUrl(path: string | null | undefined): string {
+function filePathToAssetUrl(path: string | null | undefined): string {
   if (!path) return "";
   if (path.startsWith("asset:") || path.startsWith("http://asset.localhost")) return path;
   if (hasScheme(path) && !isAbsoluteFilesystemPath(path)) return path;
@@ -106,14 +93,14 @@ export async function resolveGameAssetFileUrl(path: string): Promise<string> {
   return filePathToAssetUrl(response.path ?? "");
 }
 
-export async function resolveBackgroundFileUrl(filename: string): Promise<string> {
+async function resolveBackgroundFileUrl(filename: string): Promise<string> {
   const remoteUrl = remoteManagedAssetUrl("background", filename);
   if (remoteUrl) return remoteUrl;
   const response = await invokeTauri<PathResponse>("background_file_path", { filename });
   return filePathToAssetUrl(response.path ?? "");
 }
 
-export async function resolveLorebookImageFileUrl(filename: string): Promise<string> {
+async function resolveLorebookImageFileUrl(filename: string): Promise<string> {
   const remoteUrl = remoteManagedAssetUrl("lorebook", filename);
   if (remoteUrl) return remoteUrl;
   const response = await invokeTauri<PathResponse>("lorebook_image_file_path", { filename });

--- a/src/shared/api/profile-api.ts
+++ b/src/shared/api/profile-api.ts
@@ -3,16 +3,16 @@ import { ApiError } from "./api-errors";
 import { downloadPayloadFromApiValue, type DownloadPayload } from "./download-payload";
 import { remoteRuntimeTarget } from "./remote-runtime";
 
-export async function exportProfile(): Promise<DownloadPayload> {
+async function exportProfile(): Promise<DownloadPayload> {
   const value = await invokeTauri("profile_export");
   return downloadPayloadFromApiValue(value, "marinara-profile.json", "application/json");
 }
 
-export async function importProfile<T>(envelope: unknown): Promise<T> {
+async function importProfile<T>(envelope: unknown): Promise<T> {
   return invokeTauri<T>("profile_import", { envelope });
 }
 
-export async function importProfileFile<T>(path: string): Promise<T> {
+async function importProfileFile<T>(path: string): Promise<T> {
   if (remoteRuntimeTarget()) {
     throw new ApiError(
       "Profile import from a local file path is not available while Remote Runtime is configured.",
@@ -29,19 +29,19 @@ export type ManagedBackup = {
   path?: string;
 };
 
-export async function createBackup(): Promise<{ success: boolean; backupName: string }> {
+async function createBackup(): Promise<{ success: boolean; backupName: string }> {
   return invokeTauri("backup_create");
 }
 
-export async function listBackups(): Promise<ManagedBackup[]> {
+async function listBackups(): Promise<ManagedBackup[]> {
   return invokeTauri("backup_list");
 }
 
-export async function deleteBackup(name: string): Promise<{ success: boolean; deleted: boolean }> {
+async function deleteBackup(name: string): Promise<{ success: boolean; deleted: boolean }> {
   return invokeTauri("backup_delete", { name });
 }
 
-export async function downloadBackup(name?: string): Promise<DownloadPayload> {
+async function downloadBackup(name?: string): Promise<DownloadPayload> {
   const value = await invokeTauri("backup_download", name ? { name } : undefined);
   return downloadPayloadFromApiValue(value, "marinara-backup.zip", "application/zip");
 }

--- a/src/shared/components/ui/SpriteFrameEditor.tsx
+++ b/src/shared/components/ui/SpriteFrameEditor.tsx
@@ -1,12 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { Crop, Loader2, RotateCcw, X } from "lucide-react";
-
-interface SpriteFrameAdjustments {
-  top: number;
-  bottom: number;
-  left: number;
-  right: number;
-}
+import { cropSpriteDataUrl, type SpriteFrameAdjustments } from "../../lib/sprite-frame-crop";
 
 type SpriteFrameAdjustmentKey = keyof SpriteFrameAdjustments;
 
@@ -35,47 +29,8 @@ const FRAME_CONTROLS: Array<{ key: SpriteFrameAdjustmentKey; label: string }> = 
 const MAX_SINGLE_EDGE_CROP = 80;
 const MAX_PAIR_CROP = 90;
 
-function percentToPixels(size: number, value: number): number {
-  return Math.round((size * value) / 100);
-}
-
 function clampPercent(value: number): number {
   return Math.max(0, Math.min(MAX_SINGLE_EDGE_CROP, Number.isFinite(value) ? value : 0));
-}
-
-export function cropSpriteDataUrl(dataUrl: string, frame: SpriteFrameAdjustments): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const image = new Image();
-    image.onload = () => {
-      const width = image.naturalWidth;
-      const height = image.naturalHeight;
-      const cropLeft = percentToPixels(width, frame.left);
-      const cropRight = percentToPixels(width, frame.right);
-      const cropTop = percentToPixels(height, frame.top);
-      const cropBottom = percentToPixels(height, frame.bottom);
-      const outputWidth = width - cropLeft - cropRight;
-      const outputHeight = height - cropTop - cropBottom;
-
-      if (outputWidth <= 0 || outputHeight <= 0) {
-        reject(new Error("Frame settings leave no usable sprite area"));
-        return;
-      }
-
-      const canvas = document.createElement("canvas");
-      canvas.width = outputWidth;
-      canvas.height = outputHeight;
-      const ctx = canvas.getContext("2d");
-      if (!ctx) {
-        reject(new Error("Canvas is unavailable"));
-        return;
-      }
-
-      ctx.drawImage(image, cropLeft, cropTop, outputWidth, outputHeight, 0, 0, outputWidth, outputHeight);
-      resolve(canvas.toDataURL("image/png"));
-    };
-    image.onerror = () => reject(new Error("Sprite image could not be loaded"));
-    image.src = dataUrl;
-  });
 }
 
 export function SpriteFrameEditor({ imageUrl, label, applying = false, onApply, onClose }: SpriteFrameEditorProps) {

--- a/src/shared/components/ui/SpriteGenerationModal.tsx
+++ b/src/shared/components/ui/SpriteGenerationModal.tsx
@@ -7,6 +7,7 @@ import { useState, useRef, useMemo, useCallback, useEffect } from "react";
 import { X, Loader2, Check, ImagePlus, Sparkles, ArrowLeft, Crop, RotateCcw } from "lucide-react";
 import { Modal } from "./Modal";
 import { cn } from "../../lib/utils";
+import { cropSpriteDataUrl, type SpriteFrameAdjustments } from "../../lib/sprite-frame-crop";
 import { useUIStore } from "../../stores/ui.store";
 import { spriteApi } from "../../api/image-generation-api";
 import { ImagePromptReviewModal, type ImagePromptOverride, type ImagePromptReviewItem } from "./ImagePromptReviewModal";
@@ -90,13 +91,6 @@ interface SliceAdjustments {
 }
 
 type NumericSliceAdjustmentKey = Exclude<keyof SliceAdjustments, "colCuts" | "rowCuts">;
-
-interface SpriteFrameAdjustments {
-  top: number;
-  bottom: number;
-  left: number;
-  right: number;
-}
 
 type SpriteFrameAdjustmentKey = keyof SpriteFrameAdjustments;
 
@@ -390,41 +384,6 @@ function percentToPixels(size: number, value: number): number {
 
 function clampPercent(value: number): number {
   return Math.max(0, Math.min(80, Number.isFinite(value) ? value : 0));
-}
-
-function cropSpriteDataUrl(dataUrl: string, frame: SpriteFrameAdjustments): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const image = new Image();
-    image.onload = () => {
-      const width = image.naturalWidth;
-      const height = image.naturalHeight;
-      const cropLeft = percentToPixels(width, frame.left);
-      const cropRight = percentToPixels(width, frame.right);
-      const cropTop = percentToPixels(height, frame.top);
-      const cropBottom = percentToPixels(height, frame.bottom);
-      const outputWidth = width - cropLeft - cropRight;
-      const outputHeight = height - cropTop - cropBottom;
-
-      if (outputWidth <= 0 || outputHeight <= 0) {
-        reject(new Error("Frame settings leave no usable sprite area"));
-        return;
-      }
-
-      const canvas = document.createElement("canvas");
-      canvas.width = outputWidth;
-      canvas.height = outputHeight;
-      const ctx = canvas.getContext("2d");
-      if (!ctx) {
-        reject(new Error("Canvas is unavailable"));
-        return;
-      }
-
-      ctx.drawImage(image, cropLeft, cropTop, outputWidth, outputHeight, 0, 0, outputWidth, outputHeight);
-      resolve(canvas.toDataURL("image/png"));
-    };
-    image.onerror = () => reject(new Error("Sprite image could not be loaded"));
-    image.src = dataUrl;
-  });
 }
 
 function clampBoundaries(boundaries: number[], minSpan: number): number[] {

--- a/src/shared/hooks/use-tts.ts
+++ b/src/shared/hooks/use-tts.ts
@@ -2,7 +2,7 @@
 // Hook: TTS Config & Voices
 // ──────────────────────────────────────────────
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { ttsApi } from "../api/tts-api";
+import { ttsApi } from "../api/integration-utility-api";
 import type { TTSConfig, TTSSource } from "../../engine/contracts/types/tts";
 import { TTS_API_KEY_MASK } from "../../engine/contracts/types/tts";
 

--- a/src/shared/lib/agent-cadence.ts
+++ b/src/shared/lib/agent-cadence.ts
@@ -6,7 +6,7 @@ export type AgentRunIntervalMeta = {
   max: number;
 };
 
-export const EVERY_RUN_LABEL = "Every run";
+const EVERY_RUN_LABEL = "Every run";
 
 export function getAgentRunIntervalMeta(agentType: string, isBuiltIn = true): AgentRunIntervalMeta | null {
   switch (agentType) {

--- a/src/shared/lib/backgrounds.ts
+++ b/src/shared/lib/backgrounds.ts
@@ -46,7 +46,3 @@ export function chatBackgroundUrlToMetadata(url: string | null): string | null {
 
   return url;
 }
-
-export function isManagedChatBackgroundUrl(url: string | null): boolean {
-  return !!url && (url.startsWith(USER_BACKGROUND_URL_PREFIX) || url.startsWith(GAME_ASSET_URL_PREFIX));
-}

--- a/src/shared/lib/character-import.ts
+++ b/src/shared/lib/character-import.ts
@@ -9,7 +9,7 @@ export interface EmbeddedLorebookImportPreview {
   error?: string;
 }
 
-export function countLorebookEntries(value: unknown): number {
+function countLorebookEntries(value: unknown): number {
   if (!value || typeof value !== "object") return 0;
   const entries = (value as Record<string, unknown>).entries;
   if (Array.isArray(entries)) return entries.length;

--- a/src/shared/lib/chat-macros.test.ts
+++ b/src/shared/lib/chat-macros.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { parseCharacterMacroData, resolveInputMacrosForChat, resolveMessageMacros } from "./chat-macros";
+import {
+  createInputMacroResolverForChat,
+  parseCharacterMacroData,
+  resolveInputMacrosForChat,
+  resolveMessageMacros,
+} from "./chat-macros";
 
 describe("chat macro character instruction fields", () => {
   it("plumbs parsed character instruction fields into message macro resolution", () => {
@@ -34,5 +39,25 @@ describe("chat macro character instruction fields", () => {
     );
 
     expect(resolved).toBe("Mika|Basil|Basil, Aster|hello there|Pilot persona");
+  });
+
+  it("keeps a per-submit input resolver stable if source rows change later", () => {
+    const characterData = { name: "Aster", description: "Original character" };
+    const persona = { id: "persona-a", name: "Mika", description: "Original persona" };
+    const resolveInputMacros = createInputMacroResolverForChat(
+      { characterIds: ["char-a"], personaId: "persona-a" },
+      [{ id: "char-a", data: characterData }],
+      [persona],
+      "hello there",
+    );
+
+    characterData.name = "Changed";
+    characterData.description = "Changed character";
+    persona.name = "Changed";
+    persona.description = "Changed persona";
+
+    expect(resolveInputMacros("{{user}}|{{char}}|{{description}}|{{persona}}|{{input}}")).toBe(
+      "Mika|Aster|Original character|Original persona|hello there",
+    );
   });
 });

--- a/src/shared/lib/chat-macros.test.ts
+++ b/src/shared/lib/chat-macros.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseCharacterMacroData, resolveMessageMacros } from "./chat-macros";
+import { parseCharacterMacroData, resolveInputMacrosForChat, resolveMessageMacros } from "./chat-macros";
 
 describe("chat macro character instruction fields", () => {
   it("plumbs parsed character instruction fields into message macro resolution", () => {
@@ -19,5 +19,20 @@ describe("chat macro character instruction fields", () => {
         characters: character ? [character] : [],
       }),
     ).toBe("Aster|Display system guidance.|Display post-history guidance.");
+  });
+
+  it("resolves input macros from chat character and persona rows", () => {
+    const resolved = resolveInputMacrosForChat(
+      "{{user}}|{{char}}|{{characters}}|{{input}}|{{persona}}",
+      { characterIds: JSON.stringify(["char-b", "char-a"]), personaId: "persona-a" },
+      [
+        { id: "char-a", data: { name: "Aster" } },
+        { id: "char-b", data: { name: "Basil" } },
+      ],
+      [{ id: "persona-a", name: "Mika", description: "Pilot persona" }],
+      "hello there",
+    );
+
+    expect(resolved).toBe("Mika|Basil|Basil, Aster|hello there|Pilot persona");
   });
 });

--- a/src/shared/lib/chat-macros.ts
+++ b/src/shared/lib/chat-macros.ts
@@ -239,7 +239,7 @@ export function resolveInputMacrosForChat(
   return createInputMacroResolverForChat(chat, characters, personas, lastInput)(template);
 }
 
-function createInputMacroResolverForChat(
+export function createInputMacroResolverForChat(
   chat: { characterIds?: unknown; personaId?: string | null; mode?: string | null } | null | undefined,
   characters: Array<{ id: string; data: unknown }> | undefined,
   personas: Array<Record<string, unknown>> | undefined,

--- a/src/shared/lib/chat-macros.ts
+++ b/src/shared/lib/chat-macros.ts
@@ -93,7 +93,7 @@ export function parseCharacterMacroData(
   }
 }
 
-export function parsePersonaMacroData(raw: Record<string, unknown> | null | undefined): MacroPersonaData | null {
+function parsePersonaMacroData(raw: Record<string, unknown> | null | undefined): MacroPersonaData | null {
   if (!raw) return null;
 
   return {
@@ -107,7 +107,7 @@ export function parsePersonaMacroData(raw: Record<string, unknown> | null | unde
   };
 }
 
-export function selectChatCharacters(
+function selectChatCharacters(
   chat: { characterIds?: unknown } | null | undefined,
   characters: Array<{ id: string; data: unknown }> | undefined,
 ): MacroCharacterData[] {
@@ -123,7 +123,7 @@ export function selectChatCharacters(
   return chatCharacterIds.map((id) => byId.get(id)).filter((value): value is MacroCharacterData => !!value);
 }
 
-export function selectActivePersona(
+function selectActivePersona(
   chat: { personaId?: string | null; mode?: string | null } | null | undefined,
   personas: Array<Record<string, unknown>> | undefined,
 ): MacroPersonaData | undefined {
@@ -239,7 +239,7 @@ export function resolveInputMacrosForChat(
   return createInputMacroResolverForChat(chat, characters, personas, lastInput)(template);
 }
 
-export function createInputMacroResolverForChat(
+function createInputMacroResolverForChat(
   chat: { characterIds?: unknown; personaId?: string | null; mode?: string | null } | null | undefined,
   characters: Array<{ id: string; data: unknown }> | undefined,
   personas: Array<Record<string, unknown>> | undefined,

--- a/src/shared/lib/connection-filters.ts
+++ b/src/shared/lib/connection-filters.ts
@@ -2,7 +2,7 @@ export type ConnectionProviderLike = {
   provider?: string | null;
 };
 
-export function isLanguageGenerationConnection(connection: ConnectionProviderLike): boolean {
+function isLanguageGenerationConnection(connection: ConnectionProviderLike): boolean {
   return connection.provider !== "image_generation";
 }
 

--- a/src/shared/lib/local-notifications.ts
+++ b/src/shared/lib/local-notifications.ts
@@ -54,7 +54,7 @@ export async function requestLocalNotificationPermission(): Promise<LocalNotific
   return requestBrowserNotificationPermission();
 }
 
-export function isAppFocusedForNotifications(): boolean {
+function isAppFocusedForNotifications(): boolean {
   if (typeof document === "undefined") return true;
   return document.visibilityState === "visible" && document.hasFocus();
 }

--- a/src/shared/lib/sprite-frame-crop.test.ts
+++ b/src/shared/lib/sprite-frame-crop.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { cropSpriteDataUrl, type SpriteFrameAdjustments } from "./sprite-frame-crop";
+
+const VALID_FRAME: SpriteFrameAdjustments = {
+  top: 0,
+  bottom: 0,
+  left: 0,
+  right: 0,
+};
+
+describe("cropSpriteDataUrl", () => {
+  it("rejects frame percentages outside the supported range before loading an image", async () => {
+    await expect(cropSpriteDataUrl("data:image/png;base64,", { ...VALID_FRAME, left: -1 })).rejects.toThrow(
+      "Frame settings must use percentages between 0 and 100",
+    );
+    await expect(cropSpriteDataUrl("data:image/png;base64,", { ...VALID_FRAME, top: Number.NaN })).rejects.toThrow(
+      "Frame settings must use percentages between 0 and 100",
+    );
+  });
+
+  it("rejects percentage ranges that leave no usable crop area before loading an image", async () => {
+    await expect(cropSpriteDataUrl("data:image/png;base64,", { ...VALID_FRAME, left: 40, right: 60 })).rejects.toThrow(
+      "Frame settings must use percentage ranges that leave a usable sprite area",
+    );
+    await expect(cropSpriteDataUrl("data:image/png;base64,", { ...VALID_FRAME, top: 100 })).rejects.toThrow(
+      "Frame settings must use percentage ranges that leave a usable sprite area",
+    );
+  });
+});

--- a/src/shared/lib/sprite-frame-crop.ts
+++ b/src/shared/lib/sprite-frame-crop.ts
@@ -1,0 +1,45 @@
+export interface SpriteFrameAdjustments {
+  top: number;
+  bottom: number;
+  left: number;
+  right: number;
+}
+
+function percentToPixels(size: number, value: number): number {
+  return Math.round((size * value) / 100);
+}
+
+export function cropSpriteDataUrl(dataUrl: string, frame: SpriteFrameAdjustments): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const image = new Image();
+    image.onload = () => {
+      const width = image.naturalWidth;
+      const height = image.naturalHeight;
+      const cropLeft = percentToPixels(width, frame.left);
+      const cropRight = percentToPixels(width, frame.right);
+      const cropTop = percentToPixels(height, frame.top);
+      const cropBottom = percentToPixels(height, frame.bottom);
+      const outputWidth = width - cropLeft - cropRight;
+      const outputHeight = height - cropTop - cropBottom;
+
+      if (outputWidth <= 0 || outputHeight <= 0) {
+        reject(new Error("Frame settings leave no usable sprite area"));
+        return;
+      }
+
+      const canvas = document.createElement("canvas");
+      canvas.width = outputWidth;
+      canvas.height = outputHeight;
+      const ctx = canvas.getContext("2d");
+      if (!ctx) {
+        reject(new Error("Canvas is unavailable"));
+        return;
+      }
+
+      ctx.drawImage(image, cropLeft, cropTop, outputWidth, outputHeight, 0, 0, outputWidth, outputHeight);
+      resolve(canvas.toDataURL("image/png"));
+    };
+    image.onerror = () => reject(new Error("Sprite image could not be loaded"));
+    image.src = dataUrl;
+  });
+}

--- a/src/shared/lib/sprite-frame-crop.ts
+++ b/src/shared/lib/sprite-frame-crop.ts
@@ -9,8 +9,25 @@ function percentToPixels(size: number, value: number): number {
   return Math.round((size * value) / 100);
 }
 
+function validateFrameAdjustments(frame: SpriteFrameAdjustments): Error | null {
+  const edges = [frame.top, frame.bottom, frame.left, frame.right];
+  if (edges.some((value) => !Number.isFinite(value) || value < 0 || value > 100)) {
+    return new Error("Frame settings must use percentages between 0 and 100");
+  }
+  if (frame.left + frame.right >= 100 || frame.top + frame.bottom >= 100) {
+    return new Error("Frame settings must use percentage ranges that leave a usable sprite area");
+  }
+  return null;
+}
+
 export function cropSpriteDataUrl(dataUrl: string, frame: SpriteFrameAdjustments): Promise<string> {
   return new Promise((resolve, reject) => {
+    const frameError = validateFrameAdjustments(frame);
+    if (frameError) {
+      reject(frameError);
+      return;
+    }
+
     const image = new Image();
     image.onload = () => {
       const width = image.naturalWidth;

--- a/src/shared/lib/tracker-card-colors.ts
+++ b/src/shared/lib/tracker-card-colors.ts
@@ -4,14 +4,14 @@ import type {
   TrackerCardPortraitStageBackground,
 } from "../../engine/contracts/types/persona";
 
-export const DEFAULT_TRACKER_CARD_COLOR_MODE: TrackerCardColorMode = "chat";
-export const DEFAULT_TRACKER_CARD_PORTRAIT_STAGE_BACKGROUND: TrackerCardPortraitStageBackground = "ambient";
-export const DEFAULT_TRACKER_CARD_PORTRAIT_FOCUS_X = 50;
-export const DEFAULT_TRACKER_CARD_PORTRAIT_FOCUS_Y = 36;
-export const MAX_TRACKER_CARD_PORTRAIT_FOCUS_Y = 140;
-export const DEFAULT_TRACKER_CARD_PORTRAIT_ZOOM = 1;
-export const MIN_TRACKER_CARD_PORTRAIT_ZOOM = 0.75;
-export const MAX_TRACKER_CARD_PORTRAIT_ZOOM = 2.35;
+const DEFAULT_TRACKER_CARD_COLOR_MODE: TrackerCardColorMode = "chat";
+const DEFAULT_TRACKER_CARD_PORTRAIT_STAGE_BACKGROUND: TrackerCardPortraitStageBackground = "ambient";
+const DEFAULT_TRACKER_CARD_PORTRAIT_FOCUS_X = 50;
+const DEFAULT_TRACKER_CARD_PORTRAIT_FOCUS_Y = 36;
+const MAX_TRACKER_CARD_PORTRAIT_FOCUS_Y = 140;
+const DEFAULT_TRACKER_CARD_PORTRAIT_ZOOM = 1;
+const MIN_TRACKER_CARD_PORTRAIT_ZOOM = 0.75;
+const MAX_TRACKER_CARD_PORTRAIT_ZOOM = 2.35;
 export const TRACKER_CARD_COLOR_PREVIEW_BASE_FIELD = "__trackerCardColorPreviewBase";
 const DEFAULT_TRACKER_CARD_SURFACE = "var(--card)";
 const TRACKER_CARD_FIXED_TINT_INTENSITY = 100;
@@ -36,7 +36,7 @@ export interface TrackerCardPaintEnabled {
   surfaceEnabled: boolean;
 }
 
-export interface TrackerCardPortraitStageVars {
+interface TrackerCardPortraitStageVars {
   base: string;
   veil: string;
   light: string;
@@ -51,7 +51,7 @@ export interface TrackerCardPortraitStageVars {
   bottomRuleOpacity: string;
 }
 
-export interface TrackerCardPortraitStagePalette {
+interface TrackerCardPortraitStagePalette {
   background: TrackerCardPortraitStageBackground;
   displaySolid: string;
   accent: string;
@@ -311,7 +311,7 @@ export interface TrackerCardSkinFinish {
   tintOpacity: string;
 }
 
-export const TRACKER_CARD_FINISH_DEFAULTS: Record<TrackerCardColorMode, TrackerCardFinish> = {
+const TRACKER_CARD_FINISH_DEFAULTS: Record<TrackerCardColorMode, TrackerCardFinish> = {
   default: {
     tintIntensity: TRACKER_CARD_FIXED_TINT_INTENSITY,
     materialBrightness: DEFAULT_TRACKER_CARD_MATERIAL_BRIGHTNESS,
@@ -332,13 +332,13 @@ export const TRACKER_CARD_FINISH_DEFAULTS: Record<TrackerCardColorMode, TrackerC
   },
 };
 
-export const TRACKER_CARD_PAINT_OPACITY_DEFAULTS: TrackerCardPaintOpacity = {
+const TRACKER_CARD_PAINT_OPACITY_DEFAULTS: TrackerCardPaintOpacity = {
   nameColorOpacity: 100,
   dialogueColorOpacity: 100,
   boxColorOpacity: 100,
 };
 
-export const TRACKER_CARD_PAINT_ENABLED_DEFAULTS: TrackerCardPaintEnabled = {
+const TRACKER_CARD_PAINT_ENABLED_DEFAULTS: TrackerCardPaintEnabled = {
   displayEnabled: true,
   accentEnabled: true,
   surfaceEnabled: true,
@@ -382,7 +382,7 @@ export function normalizeTrackerCardColorMode(value: unknown): TrackerCardColorM
   return value === "default" || value === "chat" || value === "custom" ? value : DEFAULT_TRACKER_CARD_COLOR_MODE;
 }
 
-export function normalizeTrackerCardPortraitStageBackground(value: unknown): TrackerCardPortraitStageBackground {
+function normalizeTrackerCardPortraitStageBackground(value: unknown): TrackerCardPortraitStageBackground {
   return value === "ambient" || value === "spotlight" || value === "soft" || value === "plain"
     ? value
     : DEFAULT_TRACKER_CARD_PORTRAIT_STAGE_BACKGROUND;
@@ -644,7 +644,7 @@ function applyOpacityToLinearGradientStop(stop: string, paintOpacity: number) {
   return [`color-mix(in srgb, ${color} ${paintOpacity}%, transparent)`, ...positions].join(" ");
 }
 
-export function applyTrackerCardPaintOpacity(value: string, opacity: number) {
+function applyTrackerCardPaintOpacity(value: string, opacity: number) {
   const paintOpacity = Math.max(0, Math.min(100, Math.round(opacity)));
   if (paintOpacity >= 100) return value;
 
@@ -1147,7 +1147,7 @@ export function getTrackerCardStyleVars({
   };
 }
 
-export function getTrackerCardPortraitStageVars({
+function getTrackerCardPortraitStageVars({
   background,
   displaySolid,
   accent,

--- a/src/shared/lib/tts-audio-cache.ts
+++ b/src/shared/lib/tts-audio-cache.ts
@@ -117,7 +117,7 @@ async function putPersistentBlob(key: string, blob: Blob): Promise<void> {
   }
 }
 
-export async function getCachedTTSAudioBlob(key: string): Promise<Blob | null> {
+async function getCachedTTSAudioBlob(key: string): Promise<Blob | null> {
   const memoryHit = memoryCache.get(key);
   if (memoryHit) {
     rememberInMemory(key, memoryHit);

--- a/src/shared/lib/tts-dialogue.ts
+++ b/src/shared/lib/tts-dialogue.ts
@@ -14,13 +14,16 @@ export function clientSidePlaybackRate(cfg: TTSConfig | null | undefined): numbe
   return Number.isFinite(cfg.speed) && cfg.speed > 0 ? cfg.speed : 1;
 }
 
-export interface TTSUtterance {
+interface TTSUtterance {
   text: string;
   speaker?: string;
   tone?: string;
 }
 
-export interface TTSVoiceRequest extends TTSUtterance {
+export interface TTSVoiceRequest {
+  text: string;
+  speaker?: string;
+  tone?: string;
   voice?: string;
 }
 
@@ -34,7 +37,7 @@ export function normalizeTTSCharacterName(value?: string | null): string {
   return (value ?? "").toLowerCase().replace(/[_-]+/g, " ").replace(/\s+/g, " ").trim();
 }
 
-export function normalizeTTSCharacterBaseName(value?: string | null): string {
+function normalizeTTSCharacterBaseName(value?: string | null): string {
   let normalized = normalizeTTSCharacterName(value);
   let previous = "";
   while (normalized && normalized !== previous) {
@@ -54,7 +57,7 @@ export function ttsConfigMatchesSpeaker(
   return true;
 }
 
-export type TTSNpcVoiceGender = "male" | "female" | "unknown";
+type TTSNpcVoiceGender = "male" | "female" | "unknown";
 
 export interface TTSNpcVoiceHint {
   name: string;
@@ -79,7 +82,7 @@ function stableTTSIndex(seed: string, length: number): number {
   return Math.abs(hash) % length;
 }
 
-export function inferTTSNpcVoiceGender(hint?: TTSNpcVoiceHint | null): TTSNpcVoiceGender {
+function inferTTSNpcVoiceGender(hint?: TTSNpcVoiceHint | null): TTSNpcVoiceGender {
   const explicitText = [hint?.gender, hint?.pronouns].filter(Boolean).join(" ");
   if (/\b(she|her|hers|female|feminine|woman|girl)\b/i.test(explicitText)) return "female";
   if (/\b(he|him|his|male|masculine|man|boy)\b/i.test(explicitText)) return "male";
@@ -186,7 +189,7 @@ export function resolveTTSVoiceForSpeaker(
   return fallbackVoice;
 }
 
-export function cleanTTSInputText(value: string): string {
+function cleanTTSInputText(value: string): string {
   return value
     .replace(/\{(shake|shout|whisper|glow|pulse|wave|flicker|drip|bounce|tremble|glitch|expand):([^}]+)\}/gi, "$2")
     .replace(/\[[a-z_]+:[^\]]*\]/gi, "")
@@ -275,14 +278,7 @@ export function splitTTSChunks(value: string): string[] {
     .flatMap((chunk) => splitCleanTTSInputIntoChunks(chunk));
 }
 
-export function buildTTSMessageText(text: string, config: TTSConfig, fallbackSpeaker?: string | null): string {
-  if (!config.dialogueOnly) return cleanTTSInputText(text);
-  return extractDialogueUtterances(text, config, fallbackSpeaker)
-    .map((utterance) => utterance.text)
-    .join("\n");
-}
-
-export function splitQuotedDialogueAndNarration(text: string, fallbackSpeaker?: string | null): TTSUtterance[] {
+function splitQuotedDialogueAndNarration(text: string, fallbackSpeaker?: string | null): TTSUtterance[] {
   const quoteRe = new RegExp(DIALOGUE_QUOTE_PATTERN_SOURCE, "g");
   const utterances: TTSUtterance[] = [];
   let lastIndex = 0;
@@ -357,7 +353,7 @@ export function buildTTSVoiceRequests(
   });
 }
 
-export function extractDialogueUtterances(
+function extractDialogueUtterances(
   text: string,
   config: Pick<TTSConfig, "dialogueScope" | "dialogueCharacterName">,
   fallbackSpeaker?: string | null,

--- a/src/shared/lib/tts-service.ts
+++ b/src/shared/lib/tts-service.ts
@@ -1,7 +1,7 @@
 // ──────────────────────────────────────────────
 // TTS Service — Server-proxied audio playback
 // ──────────────────────────────────────────────
-import { ttsApi } from "../api/tts-api";
+import { ttsApi } from "../api/integration-utility-api";
 
 export type TTSState = "idle" | "loading" | "playing" | "paused" | "error";
 


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Refs #1566

## Why this change

- Continue the practical Knip restoration work by wiring useful shared helpers back into real call sites and narrowing exports that are implementation-only.
- Reduce false public API surface while preserving behavior across profile import, chat input, sprite cropping, tracker metadata, TTS, and retry feedback paths.

## What changed

- Restored remote-runtime JSON profile import through `profileApi.importProfile`, while keeping native JSON/ZIP import on the local file-path command.
- Added invalid Remote Runtime URL protection for profile import UI and JSON-only copy for remote import parse errors.
- Reused shared helpers for chat input attachments, chat macros, sprite frame crop, tracker metadata normalization, lorebook entry detection, quote format options, and agent retry failure toasts.
- Narrowed implementation-only exports in local asset helpers, tracker card color helpers, TTS dialogue helpers, local notifications, connection filters, TTS cache, and related utility modules.
- Removed the unused generic asset gateway facade while keeping the focused `gameAssetsApi` and visual asset APIs.
- Added focused tests for profile import remote URL handling, chat macro input resolution, and shared blob/data URL handling.

## Refactor impact

Primary owner:

Shared frontend helpers/API, shell settings profile import, chat input UI, runtime generation/tracker helpers.

Impact areas reviewed:

- Settings profile import native and remote-runtime entrypoints.
- Chat and shared chat UI input handling, regex macro resolution, translation pass, and attachment reads.
- Runtime generation retry feedback, tracker metadata normalization, sprite frame crop UI, TTS service/hook imports, and local asset URL helpers.
- Shared API export surface and Knip-reported public helpers.

Boundary notes:

- Feature code continues to call shared wrappers/helpers; no raw Tauri or remote-runtime fetches were added.
- Remote profile import uses the existing `profile_import` shared API/HTTP dispatch path; local JSON/ZIP import stays on `profile_import_file`.
- No Rust command registration or Rust capability implementation changed.
- Engine asset capability removal only deletes an unused port/facade with no remaining callers.

Pressure points touched:

- Shared mode UI chat input was touched for macro and attachment helper wiring.
- Settings import UI was touched for native/remote profile import behavior.
- No `ModeSurface`, `GameSurface`, or `src-tauri/src/lib.rs` command registration changes.

## Validation

- [x] `pnpm check` passes locally
- [x] `pnpm typecheck` passes locally
- [x] `pnpm build` passes locally
- [x] `pnpm check:architecture` passes locally
- [x] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

Commands run after rebasing onto current `origin/refactor`:

- `pnpm test src/features/shell/settings/components/ProfileImportSection.test.tsx --run`
- `pnpm test src/shared/lib/chat-macros.test.ts --run`
- `pnpm test src/shared/lib/url-blob.test.ts --run`
- `pnpm typecheck`
- `pnpm check:architecture`
- `pnpm lint:eslint`
- `pnpm check:unused`
- `pnpm build` passed with the existing large-chunk warning
- `git diff --check`
- `pnpm exec knip --exports --no-config-hints` for export-count snapshot; targeted restored/narrowed helpers were not reported

Not manually verified in the native app: Tauri file dialog import flow and remote runtime smoke.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

No changelog update was made because this checkout has no `CHANGELOG.md`; the branch is mostly internal refactor/export restoration with focused behavior restored for remote JSON profile import.

## UI evidence

No screenshots or recordings added. The profile import UI behavior is covered by a focused jsdom component test; native file dialog and remote runtime behavior still need human/manual app QA.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error notifications when agent retries fail—users now see formatted error messages via toast alerts.
  * Enhanced profile import error handling with context-aware messaging and better file validation feedback.

* **Refactor**
  * Reorganized internal API structure to consolidate asset and profile operations into shared objects for improved maintainability.
  * Moved sprite-frame cropping logic to shared utilities for reuse across components.

* **Tests**
  * Added test coverage for profile import validation with invalid Remote Runtime URLs.
  * Expanded chat macro tests to verify macro resolution and resolver stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1579?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->