### PR TITLE
[codex] Harden provider connection errors

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3109,6 +3109,8 @@ name = "marinara-security"
 version = "0.1.0"
 dependencies = [
  "marinara-core",
+ "regex",
+ "serde_json",
  "url",
 ]
 

--- a/src-tauri/crates/llm/src/lib.rs
+++ b/src-tauri/crates/llm/src/lib.rs
@@ -1,6 +1,6 @@
 use futures_util::StreamExt;
 use marinara_core::{AppError, AppResult};
-use marinara_security::is_allowed_outbound_url;
+use marinara_security::{is_allowed_outbound_url, redact_sensitive_json, redact_sensitive_text};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::{
@@ -495,14 +495,15 @@ fn provider_error_text(details: &Value) -> Option<String> {
         details.get("message").and_then(Value::as_str),
         details.pointer("/error").and_then(Value::as_str),
     ]
-    .into_iter()
-    .flatten()
-    .map(str::trim)
-    .find(|message| !message.is_empty())
-    .map(|message| message.chars().take(500).collect())
+        .into_iter()
+        .flatten()
+        .map(str::trim)
+        .find(|message| !message.is_empty())
+        .map(|message| redact_sensitive_text(message).chars().take(500).collect())
 }
 
 fn provider_http_error(status: reqwest::StatusCode, details: Value) -> AppError {
+    let details = redact_sensitive_json(details);
     let message = provider_error_text(&details)
         .map(|detail| format!("Provider returned HTTP {status}: {detail}"))
         .unwrap_or_else(|| format!("Provider returned HTTP {status}"));
@@ -515,7 +516,7 @@ fn sanitize_provider_error_text(text: &str) -> String {
     if lower.contains("<html") || lower.contains("<!doctype") {
         return "Provider returned HTML instead of JSON".to_string();
     }
-    trimmed.chars().take(500).collect()
+    redact_sensitive_text(trimmed).chars().take(500).collect()
 }
 
 fn provider_error_details_from_text(text: &str) -> Value {
@@ -524,6 +525,7 @@ fn provider_error_details_from_text(text: &str) -> Value {
         return json!({});
     }
     serde_json::from_str::<Value>(trimmed)
+        .map(redact_sensitive_json)
         .unwrap_or_else(|_| json!({ "message": sanitize_provider_error_text(trimmed) }))
 }
 
@@ -582,16 +584,16 @@ fn string_value(value: Option<&Value>) -> Option<String> {
         .map(str::to_string)
 }
 
+fn openai_chatgpt_auth_missing_message(error: &std::io::Error) -> String {
+    format!(
+        "No Codex ChatGPT login found in the local Codex auth.json credential file ({error}). Run `codex login` on this host."
+    )
+}
+
 async fn load_openai_chatgpt_auth() -> AppResult<ChatGptAuth> {
     let path = codex_auth_file_path();
     let raw = fs::read_to_string(&path).map_err(|error| {
-        AppError::new(
-            "openai_chatgpt_auth_missing",
-            format!(
-                "No Codex ChatGPT login found at {} ({error}). Run `codex login` on this host.",
-                path.display()
-            ),
-        )
+        AppError::new("openai_chatgpt_auth_missing", openai_chatgpt_auth_missing_message(&error))
     })?;
     let mut auth_json: Value = serde_json::from_str(&raw)
         .map_err(|error| AppError::new("openai_chatgpt_auth_error", error.to_string()))?;
@@ -1009,7 +1011,7 @@ async fn complete_openai_responses_rich(request: LlmRequest) -> AppResult<LlmCom
         return Err(AppError::with_details(
             "llm_response_error",
             "Responses API result did not contain assistant text or tool calls",
-            json,
+            redact_sensitive_json(json),
         ));
     }
     Ok(LlmCompletion {
@@ -1122,7 +1124,7 @@ fn process_openai_responses_sse_block(
             return Err(AppError::with_details(
                 "llm_provider_error",
                 format!("Responses API stream event {event_type}"),
-                value,
+                redact_sensitive_json(value),
             ));
         }
         _ => {}
@@ -1705,7 +1707,7 @@ fn parse_claude_subscription_output(raw: &str, requested_model: &str) -> AppResu
             return Err(AppError::with_details(
                 "claude_subscription_empty",
                 format!("Claude Code returned no content ({diagnostic})."),
-                value,
+                redact_sensitive_json(value),
             ));
         }
     }
@@ -1734,7 +1736,7 @@ fn parse_claude_subscription_output(raw: &str, requested_model: &str) -> AppResu
         return Err(AppError::with_details(
             "claude_subscription_empty",
             format!("Claude Code returned no content ({diagnostic})."),
-            value,
+            redact_sensitive_json(value),
         ));
     }
     Ok(trimmed.to_string())
@@ -1810,19 +1812,19 @@ pub fn diagnose_claude_subscription_model(model: &str, fast_mode: bool) -> AppRe
             if stderr.trim().is_empty() {
                 "Claude Code routing diagnosis failed.".to_string()
             } else {
-                stderr.trim().to_string()
+                redact_sensitive_text(stderr.trim())
             },
-            json!({
+            redact_sensitive_json(json!({
                 "status": output.status.code(),
                 "stdout": stdout.chars().take(1000).collect::<String>(),
-            }),
+            })),
         ));
     }
     let value = parse_claude_subscription_json_output(&stdout).ok_or_else(|| {
         AppError::with_details(
             "claude_subscription_response_error",
             "Claude Code did not return diagnostic JSON.",
-            json!({ "stdout": stdout.chars().take(1000).collect::<String>() }),
+            redact_sensitive_json(json!({ "stdout": stdout.chars().take(1000).collect::<String>() })),
         )
     })?;
     let model_usage = value
@@ -1933,12 +1935,12 @@ async fn complete_claude_subscription(request: LlmRequest) -> AppResult<String> 
             if stderr.trim().is_empty() {
                 "Claude Code request failed.".to_string()
             } else {
-                stderr.trim().to_string()
+                redact_sensitive_text(stderr.trim())
             },
-            json!({
+            redact_sensitive_json(json!({
                 "status": output.status.code(),
                 "stdout": stdout.chars().take(1000).collect::<String>(),
-            }),
+            })),
         ));
     }
     parse_claude_subscription_output(&stdout, &request.connection.model)
@@ -2181,7 +2183,7 @@ fn process_anthropic_sse_block(
             return Err(AppError::with_details(
                 "llm_provider_error",
                 "Anthropic stream error",
-                error,
+                redact_sensitive_json(error),
             ));
         }
         _ => {}
@@ -2427,7 +2429,7 @@ fn process_google_sse_block(
         return Err(AppError::with_details(
             "llm_provider_error",
             "Gemini API stream error",
-            error.clone(),
+            redact_sensitive_json(error.clone()),
         ));
     }
     if let Some(usage) = value.get("usageMetadata") {
@@ -2507,7 +2509,7 @@ where
         AppError::with_details(
             "llm_response_error",
             "Provider response did not contain assistant text",
-            json,
+            redact_sensitive_json(json),
         )
     })
 }
@@ -2572,7 +2574,7 @@ async fn parse_json_response_rich(response: reqwest::Response) -> AppResult<LlmC
             AppError::with_details(
                 "llm_response_error",
                 "Provider response did not contain a completion choice",
-                json.clone(),
+                redact_sensitive_json(json.clone()),
             )
         })?;
     let message = choice.get("message").unwrap_or(choice);
@@ -2605,13 +2607,13 @@ async fn parse_json_response_rich(response: reqwest::Response) -> AppResult<LlmC
             return Err(AppError::with_details(
                 "llm_response_error",
                 "Provider returned reasoning but no final assistant text. Increase Max Output Tokens or lower Reasoning Effort in this connection's generation controls.",
-                json,
+                redact_sensitive_json(json),
             ));
         }
         return Err(AppError::with_details(
             "llm_response_error",
             "Provider response did not contain assistant text or tool calls",
-            json,
+            redact_sensitive_json(json),
         ));
     }
     Ok(LlmCompletion {
@@ -2761,6 +2763,17 @@ mod tests {
     }
 
     #[test]
+    fn openai_chatgpt_missing_auth_message_hides_local_path() {
+        let error = std::io::Error::new(std::io::ErrorKind::NotFound, "missing");
+        let message = openai_chatgpt_auth_missing_message(&error);
+
+        assert!(message.contains("local Codex auth.json credential file"));
+        assert!(!message.contains(":\\"));
+        assert!(!message.contains("/Users/"));
+        assert!(!message.contains("/home/"));
+    }
+
+    #[test]
     fn google_vertex_default_base_uses_aiplatform_endpoint() {
         assert_eq!(
             base_url("google_vertex", ""),
@@ -2819,6 +2832,22 @@ mod tests {
 
         assert_eq!(error.code, "llm_provider_error");
         assert!(error.message.contains("error code: 1033"));
+    }
+
+    #[test]
+    fn provider_http_error_redacts_sensitive_error_body() {
+        let details = provider_error_details_from_text(
+            r#"{"error":{"message":"Invalid API key sk-test-secret"},"api_key":"sk-test-secret","usage":{"input_tokens":12}}"#,
+        );
+        let error = provider_http_error(reqwest::StatusCode::UNAUTHORIZED, details);
+
+        assert_eq!(error.code, "llm_provider_error");
+        assert!(error.message.contains("[REDACTED]"));
+        assert!(!error.message.contains("sk-test-secret"));
+        let details = error.details.expect("provider details should be attached");
+        assert_eq!(details["api_key"], "[REDACTED]");
+        assert_eq!(details["usage"]["input_tokens"], 12);
+        assert!(!details.to_string().contains("sk-test-secret"));
     }
 
     #[test]

--- a/src-tauri/crates/llm/src/lib.rs
+++ b/src-tauri/crates/llm/src/lib.rs
@@ -848,7 +848,9 @@ async fn stream_openai_compatible(
     let mut buffer = String::new();
     let mut tool_calls = OpenAiToolCallAccumulator::default();
     while let Some(chunk) = stream.next().await {
-        let chunk = chunk.map_err(|error| AppError::new("llm_stream_error", error.to_string()))?;
+        let chunk = chunk.map_err(|error| {
+            AppError::new("llm_stream_error", provider_transport_error_message(error))
+        })?;
         buffer.push_str(&String::from_utf8_lossy(&chunk));
         while let Some(block) = take_sse_block(&mut buffer) {
             process_openai_sse_block(&block, emit, &mut tool_calls)?;
@@ -1059,7 +1061,9 @@ async fn stream_openai_responses(
     let mut stream = response.bytes_stream();
     let mut buffer = String::new();
     while let Some(chunk) = stream.next().await {
-        let chunk = chunk.map_err(|error| AppError::new("llm_stream_error", error.to_string()))?;
+        let chunk = chunk.map_err(|error| {
+            AppError::new("llm_stream_error", provider_transport_error_message(error))
+        })?;
         buffer.push_str(&String::from_utf8_lossy(&chunk));
         while let Some(block) = take_sse_block(&mut buffer) {
             process_openai_responses_sse_block(&block, emit)?;
@@ -2083,7 +2087,9 @@ async fn stream_anthropic(
     let mut stream = response.bytes_stream();
     let mut buffer = String::new();
     while let Some(chunk) = stream.next().await {
-        let chunk = chunk.map_err(|error| AppError::new("llm_stream_error", error.to_string()))?;
+        let chunk = chunk.map_err(|error| {
+            AppError::new("llm_stream_error", provider_transport_error_message(error))
+        })?;
         buffer.push_str(&String::from_utf8_lossy(&chunk));
         while let Some(block) = take_sse_block(&mut buffer) {
             process_anthropic_sse_block(&block, emit)?;
@@ -2403,7 +2409,9 @@ async fn stream_google(
     let mut stream = response.bytes_stream();
     let mut buffer = String::new();
     while let Some(chunk) = stream.next().await {
-        let chunk = chunk.map_err(|error| AppError::new("llm_stream_error", error.to_string()))?;
+        let chunk = chunk.map_err(|error| {
+            AppError::new("llm_stream_error", provider_transport_error_message(error))
+        })?;
         buffer.push_str(&String::from_utf8_lossy(&chunk));
         while let Some(block) = take_sse_block(&mut buffer) {
             process_google_sse_block(&block, emit)?;
@@ -2477,7 +2485,9 @@ async fn read_error_response_details(response: reqwest::Response) -> AppResult<V
     let text = response
         .text()
         .await
-        .map_err(|error| AppError::new("llm_response_error", error.to_string()))?;
+        .map_err(|error| {
+            AppError::new("llm_response_error", provider_transport_error_message(error))
+        })?;
     Ok(provider_error_details_from_text(&text))
 }
 
@@ -2488,7 +2498,9 @@ async fn read_json_response(
     let text = response
         .text()
         .await
-        .map_err(|error| AppError::new("llm_response_error", error.to_string()))?;
+        .map_err(|error| {
+            AppError::new("llm_response_error", provider_transport_error_message(error))
+        })?;
     if !status.is_success() {
         return Ok((status, provider_error_details_from_text(&text)));
     }

--- a/src-tauri/crates/llm/src/lib.rs
+++ b/src-tauri/crates/llm/src/lib.rs
@@ -311,9 +311,14 @@ fn ensure_url_allowed(url: &str) -> AppResult<()> {
         Ok(())
     } else {
         Err(AppError::invalid_input(format!(
-            "Outbound URL is not allowed: {url}"
+            "Outbound URL is not allowed: {}",
+            redact_sensitive_text(url)
         )))
     }
+}
+
+fn provider_transport_error_message(error: impl std::fmt::Display) -> String {
+    redact_sensitive_text(&error.to_string())
 }
 
 fn should_use_openai_responses(request: &LlmRequest) -> bool {
@@ -781,7 +786,7 @@ async fn complete_openai_compatible_rich(request: LlmRequest) -> AppResult<LlmCo
     let response = req
         .send()
         .await
-        .map_err(|error| AppError::new("llm_network_error", error.to_string()))?;
+        .map_err(|error| AppError::new("llm_network_error", provider_transport_error_message(error)))?;
     parse_json_response_rich(response).await
 }
 
@@ -832,7 +837,7 @@ async fn stream_openai_compatible(
     let response = req
         .send()
         .await
-        .map_err(|error| AppError::new("llm_network_error", error.to_string()))?;
+        .map_err(|error| AppError::new("llm_network_error", provider_transport_error_message(error)))?;
     let status = response.status();
     if !status.is_success() {
         let error_body = response.json::<Value>().await.unwrap_or_else(|_| json!({}));
@@ -979,7 +984,7 @@ async fn openai_responses_request(
     };
     req.send()
         .await
-        .map_err(|error| AppError::new("llm_network_error", error.to_string()))
+        .map_err(|error| AppError::new("llm_network_error", provider_transport_error_message(error)))
 }
 
 async fn complete_openai_responses_rich(request: LlmRequest) -> AppResult<LlmCompletion> {
@@ -2043,7 +2048,7 @@ async fn anthropic_request(
         .json(body)
         .send()
         .await
-        .map_err(|error| AppError::new("llm_network_error", error.to_string()))
+        .map_err(|error| AppError::new("llm_network_error", provider_transport_error_message(error)))
 }
 
 async fn complete_anthropic(request: LlmRequest) -> AppResult<String> {
@@ -2349,7 +2354,7 @@ async fn complete_google(request: LlmRequest) -> AppResult<String> {
         .json(&body)
         .send()
         .await
-        .map_err(|error| AppError::new("llm_network_error", error.to_string()))?;
+        .map_err(|error| AppError::new("llm_network_error", provider_transport_error_message(error)))?;
     parse_json_response(response, |json| {
         json.get("candidates")
             .and_then(Value::as_array)
@@ -2388,7 +2393,7 @@ async fn stream_google(
         .json(&body)
         .send()
         .await
-        .map_err(|error| AppError::new("llm_network_error", error.to_string()))?;
+        .map_err(|error| AppError::new("llm_network_error", provider_transport_error_message(error)))?;
     let status = response.status();
     if !status.is_success() {
         let error_body = read_error_response_details(response).await?;
@@ -2771,6 +2776,16 @@ mod tests {
         assert!(!message.contains(":\\"));
         assert!(!message.contains("/Users/"));
         assert!(!message.contains("/home/"));
+    }
+
+    #[test]
+    fn ensure_url_allowed_redacts_query_secret() {
+        let error = ensure_url_allowed("ftp://example.test/models?key=sk-test-secret")
+            .expect_err("disallowed URL should fail");
+
+        assert_eq!(error.code, "invalid_input");
+        assert!(error.message.contains("[REDACTED]"));
+        assert!(!error.message.contains("sk-test-secret"));
     }
 
     #[test]

--- a/src-tauri/crates/security/Cargo.toml
+++ b/src-tauri/crates/security/Cargo.toml
@@ -9,4 +9,6 @@ path = "src/lib.rs"
 
 [dependencies]
 marinara-core = { path = "../core" }
+regex = "1"
+serde_json = "1"
 url = "2"

--- a/src-tauri/crates/security/src/lib.rs
+++ b/src-tauri/crates/security/src/lib.rs
@@ -319,6 +319,25 @@ mod tests {
     }
 
     #[test]
+    fn redact_sensitive_text_redacts_payment_and_retrieval_urls() {
+        let redacted = redact_sensitive_text(
+            "See https://billing.example.test/invoice/retrieve?token=secret for details.",
+        );
+
+        assert!(redacted.contains("[REDACTED_URL]"));
+        assert!(!redacted.contains("billing.example.test"));
+        assert!(!redacted.contains("secret"));
+    }
+
+    #[test]
+    fn redact_sensitive_text_redacts_standalone_bearer_tokens() {
+        let redacted = redact_sensitive_text("rejected credential Bearer abc123DEF456._-");
+
+        assert!(redacted.contains("Bearer [REDACTED]"));
+        assert!(!redacted.contains("abc123DEF456"));
+    }
+
+    #[test]
     fn redact_sensitive_json_redacts_secret_keys_without_hiding_usage_tokens() {
         let redacted = redact_sensitive_json(json!({
             "api_key": "sk-test-secret",

--- a/src-tauri/crates/security/src/lib.rs
+++ b/src-tauri/crates/security/src/lib.rs
@@ -1,6 +1,12 @@
 use marinara_core::{AppError, AppResult};
+use regex::{Captures, Regex};
+use serde_json::Value;
 use std::path::{Component, Path, PathBuf};
+use std::sync::OnceLock;
 use url::Url;
+
+const REDACTED: &str = "[REDACTED]";
+const REDACTED_URL: &str = "[REDACTED_URL]";
 
 pub fn validate_collection_name(name: &str) -> AppResult<()> {
     let valid = !name.is_empty()
@@ -87,4 +93,241 @@ pub fn is_allowed_outbound_url(raw: &str, allow_local: bool) -> bool {
         return false;
     };
     !matches!(host, "localhost" | "127.0.0.1" | "::1")
+}
+
+fn sensitive_pair_regex() -> &'static Regex {
+    static REGEX: OnceLock<Regex> = OnceLock::new();
+    REGEX.get_or_init(|| {
+        Regex::new(
+            r#"(?ix)
+            \b
+            (?P<label>
+                api[_\s-]?key |
+                access[_\s-]?token |
+                refresh[_\s-]?token |
+                id[_\s-]?token |
+                auth(?:orization)? |
+                authorization |
+                password |
+                secret |
+                credential |
+                cookie |
+                session[_\s-]?(?:id|token)
+            )
+            \b
+            (?P<sep>\s*[:=]\s*["']?)
+            (?P<value>(?:Bearer\s+)?[^"',\s}\]\)]+)
+            "#,
+        )
+        .expect("sensitive pair regex should compile")
+    })
+}
+
+fn sensitive_query_regex() -> &'static Regex {
+    static REGEX: OnceLock<Regex> = OnceLock::new();
+    REGEX.get_or_init(|| {
+        Regex::new(
+            r#"(?i)(?P<prefix>[?&](?:api[_-]?key|key|access[_-]?token|refresh[_-]?token|id[_-]?token|token|password|secret|credential|authorization)=)(?P<value>[^&#\s"'<>]+)"#,
+        )
+        .expect("sensitive query regex should compile")
+    })
+}
+
+fn sensitive_phrase_regex() -> &'static Regex {
+    static REGEX: OnceLock<Regex> = OnceLock::new();
+    REGEX.get_or_init(|| {
+        Regex::new(
+            r#"(?ix)
+            \b
+            (?P<label>
+                api[_\s-]?key |
+                access[_\s-]?token |
+                refresh[_\s-]?token |
+                id[_\s-]?token |
+                credential |
+                secret |
+                session[_\s-]?(?:id|token)
+            )
+            \b
+            \s+
+            (?P<value>[A-Za-z0-9._-]{4,})
+            "#,
+        )
+        .expect("sensitive phrase regex should compile")
+    })
+}
+
+fn bearer_regex() -> &'static Regex {
+    static REGEX: OnceLock<Regex> = OnceLock::new();
+    REGEX.get_or_init(|| {
+        Regex::new(r#"(?i)\bBearer\s+[A-Za-z0-9._~+/=-]{4,}"#)
+            .expect("bearer regex should compile")
+    })
+}
+
+fn provider_key_regex() -> &'static Regex {
+    static REGEX: OnceLock<Regex> = OnceLock::new();
+    REGEX.get_or_init(|| {
+        Regex::new(
+            r#"(?ix)
+            \b(?:
+                sk-[A-Za-z0-9._-]{3,} |
+                xai-[A-Za-z0-9._-]{3,} |
+                orp_[A-Za-z0-9._-]{3,} |
+                pplx-[A-Za-z0-9._-]{3,} |
+                gsk_[A-Za-z0-9._-]{3,} |
+                hf_[A-Za-z0-9._-]{3,} |
+                gh[opsu]_[A-Za-z0-9._-]{3,} |
+                AIza[A-Za-z0-9_-]{8,} |
+                [A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}
+            )\b
+            "#,
+        )
+        .expect("provider key regex should compile")
+    })
+}
+
+fn sensitive_url_regex() -> &'static Regex {
+    static REGEX: OnceLock<Regex> = OnceLock::new();
+    REGEX.get_or_init(|| {
+        Regex::new(r#"(?i)https?://[^\s"'<>)]*(?:payment|billing|checkout|invoice|retriev)[^\s"'<>)]*"#)
+            .expect("sensitive URL regex should compile")
+    })
+}
+
+fn is_sensitive_json_key(key: &str) -> bool {
+    let normalized: String = key
+        .chars()
+        .filter(|character| character.is_ascii_alphanumeric())
+        .flat_map(|character| character.to_lowercase())
+        .collect();
+    matches!(
+        normalized.as_str(),
+        "apikey"
+            | "authorization"
+            | "cookie"
+            | "credential"
+            | "credentials"
+            | "password"
+            | "secret"
+            | "sessionid"
+            | "sessiontoken"
+            | "token"
+    ) || normalized.ends_with("apikey")
+        || normalized.ends_with("token")
+        || normalized.ends_with("secret")
+        || normalized.ends_with("password")
+        || normalized.contains("credential")
+}
+
+fn looks_sensitive_fragment(value: &str) -> bool {
+    let trimmed = value.trim_matches(|character: char| !character.is_ascii_alphanumeric());
+    trimmed.len() >= 4
+        && (trimmed.chars().any(|character| character.is_ascii_digit())
+            || trimmed.chars().any(|character| matches!(character, '-' | '_' | '.'))
+            || trimmed.len() >= 16)
+}
+
+pub fn redact_sensitive_text(text: &str) -> String {
+    let mut output = text.to_string();
+    output = sensitive_url_regex()
+        .replace_all(&output, REDACTED_URL)
+        .into_owned();
+    output = sensitive_query_regex()
+        .replace_all(&output, |captures: &Captures| {
+            format!("{}{}", &captures["prefix"], REDACTED)
+        })
+        .into_owned();
+    output = sensitive_pair_regex()
+        .replace_all(&output, |captures: &Captures| {
+            format!("{}{}{}", &captures["label"], &captures["sep"], REDACTED)
+        })
+        .into_owned();
+    output = sensitive_phrase_regex()
+        .replace_all(&output, |captures: &Captures| {
+            let value = &captures["value"];
+            if looks_sensitive_fragment(value) {
+                format!("{} {}", &captures["label"], REDACTED)
+            } else {
+                captures
+                    .get(0)
+                    .map(|matched| matched.as_str().to_string())
+                    .unwrap_or_default()
+            }
+        })
+        .into_owned();
+    output = bearer_regex()
+        .replace_all(&output, |_captures: &Captures| format!("Bearer {REDACTED}"))
+        .into_owned();
+    provider_key_regex()
+        .replace_all(&output, REDACTED)
+        .into_owned()
+}
+
+pub fn redact_sensitive_json(value: Value) -> Value {
+    match value {
+        Value::Object(map) => Value::Object(
+            map.into_iter()
+                .map(|(key, value)| {
+                    let next_value = if is_sensitive_json_key(&key) {
+                        Value::String(REDACTED.to_string())
+                    } else {
+                        redact_sensitive_json(value)
+                    };
+                    (key, next_value)
+                })
+                .collect(),
+        ),
+        Value::Array(values) => Value::Array(values.into_iter().map(redact_sensitive_json).collect()),
+        Value::String(value) => Value::String(redact_sensitive_text(&value)),
+        other => other,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn redact_sensitive_text_removes_provider_keys_and_query_values() {
+        let redacted = redact_sensitive_text(
+            "OpenAI rejected api_key=sk-test-secret at https://api.example.test/v1?key=AIzaSecretValue123",
+        );
+
+        assert!(redacted.contains("[REDACTED]"));
+        assert!(!redacted.contains("sk-test-secret"));
+        assert!(!redacted.contains("AIzaSecretValue123"));
+    }
+
+    #[test]
+    fn redact_sensitive_text_keeps_non_secret_session_and_token_counts() {
+        let redacted =
+            redact_sensitive_text("Invalid session. API key is invalid. usage input_tokens=12 output_tokens=3.");
+
+        assert_eq!(
+            redacted,
+            "Invalid session. API key is invalid. usage input_tokens=12 output_tokens=3."
+        );
+    }
+
+    #[test]
+    fn redact_sensitive_text_removes_unprefixed_api_key_fragments() {
+        let redacted = redact_sensitive_text("Invalid API key abc123 for this request.");
+
+        assert_eq!(redacted, "Invalid API key [REDACTED] for this request.");
+    }
+
+    #[test]
+    fn redact_sensitive_json_redacts_secret_keys_without_hiding_usage_tokens() {
+        let redacted = redact_sensitive_json(json!({
+            "api_key": "sk-test-secret",
+            "error": { "message": "Authorization: Bearer sk-test-secret" },
+            "usage": { "input_tokens": 12, "output_tokens": 3 }
+        }));
+
+        assert_eq!(redacted["api_key"], "[REDACTED]");
+        assert_eq!(redacted["usage"]["input_tokens"], 12);
+        assert!(!redacted.to_string().contains("sk-test-secret"));
+    }
 }

--- a/src-tauri/src/commands/storage/images/providers.rs
+++ b/src-tauri/src/commands/storage/images/providers.rs
@@ -411,7 +411,7 @@ fn http_client(timeout_secs: u64) -> AppResult<reqwest::Client> {
     reqwest::Client::builder()
         .timeout(Duration::from_secs(timeout_secs))
         .build()
-        .map_err(|error| AppError::new("image_client_error", error.to_string()))
+        .map_err(|error| AppError::new("image_client_error", image_transport_error_message(error)))
 }
 
 fn bearer(request: reqwest::RequestBuilder, api_key: &str) -> reqwest::RequestBuilder {
@@ -424,10 +424,9 @@ fn bearer(request: reqwest::RequestBuilder, api_key: &str) -> reqwest::RequestBu
 
 async fn response_json(response: reqwest::Response, provider: &str) -> AppResult<Value> {
     let status = response.status();
-    let text = response
-        .text()
-        .await
-        .map_err(|error| AppError::new("image_response_error", error.to_string()))?;
+    let text = response.text().await.map_err(|error| {
+        AppError::new("image_response_error", image_transport_error_message(error))
+    })?;
     if !status.is_success() {
         return Err(AppError::new(
             "image_provider_error",
@@ -456,10 +455,9 @@ async fn image_response_base64(
         .and_then(|value| value.to_str().ok())
         .unwrap_or("image/png")
         .to_string();
-    let bytes = response
-        .bytes()
-        .await
-        .map_err(|error| AppError::new("image_response_error", error.to_string()))?;
+    let bytes = response.bytes().await.map_err(|error| {
+        AppError::new("image_response_error", image_transport_error_message(error))
+    })?;
     if !status.is_success() {
         let text = String::from_utf8_lossy(&bytes);
         return Err(AppError::new(
@@ -482,6 +480,10 @@ fn sanitize_error(text: &str) -> String {
         .chars()
         .take(300)
         .collect()
+}
+
+fn image_transport_error_message(error: impl std::fmt::Display) -> String {
+    sanitize_error(&error.to_string())
 }
 
 fn strip_data_url(value: &str) -> (&str, &str) {
@@ -595,7 +597,9 @@ async fn response_bytes(
     let bytes = response
         .bytes()
         .await
-        .map_err(|error| AppError::new("image_response_error", error.to_string()))?
+        .map_err(|error| {
+            AppError::new("image_response_error", image_transport_error_message(error))
+        })?
         .to_vec();
     if !status.is_success() {
         let text = String::from_utf8_lossy(&bytes);
@@ -611,11 +615,9 @@ async fn response_bytes(
 }
 
 async fn fetch_image_url(client: &reqwest::Client, url: &str) -> AppResult<(String, String)> {
-    let response = client
-        .get(url)
-        .send()
-        .await
-        .map_err(|error| AppError::new("image_network_error", error.to_string()))?;
+    let response = client.get(url).send().await.map_err(|error| {
+        AppError::new("image_network_error", image_transport_error_message(error))
+    })?;
     image_response_base64(response, "image URL").await
 }
 
@@ -697,7 +699,9 @@ async fn generate_openai_compatible_image(
         )
         .send()
         .await
-        .map_err(|error| AppError::new("image_network_error", error.to_string()))?;
+        .map_err(|error| {
+            AppError::new("image_network_error", image_transport_error_message(error))
+        })?;
         let json = response_json(response, source).await?;
         return parse_image_json(&client, &json).await.ok_or_else(|| {
             AppError::new(
@@ -740,7 +744,7 @@ async fn generate_openai_compatible_image(
     )
     .send()
     .await
-    .map_err(|error| AppError::new("image_network_error", error.to_string()))?;
+    .map_err(|error| AppError::new("image_network_error", image_transport_error_message(error)))?;
     let json = response_json(response, source).await?;
     parse_image_json(&client, &json).await.ok_or_else(|| {
         AppError::new(
@@ -853,7 +857,7 @@ async fn generate_xai(
     )
     .send()
     .await
-    .map_err(|error| AppError::new("image_network_error", error.to_string()))?;
+    .map_err(|error| AppError::new("image_network_error", image_transport_error_message(error)))?;
     let json = response_json(response, "xai").await?;
     parse_image_json(&client, &json)
         .await
@@ -986,7 +990,7 @@ async fn generate_nanogpt_image(
     )
     .send()
     .await
-    .map_err(|error| AppError::new("image_network_error", error.to_string()))?;
+    .map_err(|error| AppError::new("image_network_error", image_transport_error_message(error)))?;
     let json = response_json(response, "nanogpt").await?;
     parse_image_json(&client, &json)
         .await
@@ -1032,7 +1036,7 @@ async fn generate_together_image(
     )
     .send()
     .await
-    .map_err(|error| AppError::new("image_network_error", error.to_string()))?;
+    .map_err(|error| AppError::new("image_network_error", image_transport_error_message(error)))?;
     let json = response_json(response, "togetherai").await?;
     parse_image_json(&client, &json)
         .await
@@ -1082,7 +1086,7 @@ async fn generate_chat_image(
     )
     .send()
     .await
-    .map_err(|error| AppError::new("image_network_error", error.to_string()))?;
+    .map_err(|error| AppError::new("image_network_error", image_transport_error_message(error)))?;
     let json = response_json(response, &source).await?;
     parse_image_json(&client, &json).await.ok_or_else(|| {
         AppError::new(
@@ -1151,7 +1155,9 @@ async fn generate_google_image(
             .json(&payload)
             .send()
             .await
-            .map_err(|error| AppError::new("image_network_error", error.to_string()))?;
+            .map_err(|error| {
+                AppError::new("image_network_error", image_transport_error_message(error))
+            })?;
         let json = response_json(response, GOOGLE_IMAGE_PROVIDER).await?;
         return parse_google_predict_image(&json).ok_or_else(|| {
             AppError::new(
@@ -1190,7 +1196,9 @@ async fn generate_google_image(
         .json(&payload)
         .send()
         .await
-        .map_err(|error| AppError::new("image_network_error", error.to_string()))?;
+        .map_err(|error| {
+            AppError::new("image_network_error", image_transport_error_message(error))
+        })?;
     let json = response_json(response, GOOGLE_IMAGE_PROVIDER).await?;
     parse_google_generate_content_image(&json).ok_or_else(|| {
         // No inline image part — surface why (e.g. a SAFETY block or a text-only reply)
@@ -1555,7 +1563,9 @@ async fn upload_comfy_reference_image(base: &str, reference: &str) -> AppResult<
         .multipart(form)
         .send()
         .await
-        .map_err(|error| AppError::new("image_network_error", error.to_string()))?;
+        .map_err(|error| {
+            AppError::new("image_network_error", image_transport_error_message(error))
+        })?;
     let json = response_json(response, "comfyui").await?;
     json.get("name")
         .and_then(Value::as_str)
@@ -1636,7 +1646,7 @@ async fn generate_stability(
     )
     .send()
     .await
-    .map_err(|error| AppError::new("image_network_error", error.to_string()))?;
+    .map_err(|error| AppError::new("image_network_error", image_transport_error_message(error)))?;
     image_response_base64(response, "stability").await
 }
 
@@ -1684,7 +1694,7 @@ async fn generate_stability_v1(
     )
     .send()
     .await
-    .map_err(|error| AppError::new("image_network_error", error.to_string()))?;
+    .map_err(|error| AppError::new("image_network_error", image_transport_error_message(error)))?;
     let json = response_json(response, "stability").await?;
     let base64 = json
         .get("artifacts")
@@ -1864,7 +1874,9 @@ async fn generate_automatic1111(
         .json(&payload)
         .send()
         .await
-        .map_err(|error| AppError::new("image_network_error", error.to_string()))?;
+        .map_err(|error| {
+            AppError::new("image_network_error", image_transport_error_message(error))
+        })?;
     let json = response_json(response, "automatic1111").await?;
     let image = json
         .get("images")
@@ -1920,10 +1932,9 @@ async fn generate_horde(
         },
     );
     let submit = response_json(
-        request
-            .send()
-            .await
-            .map_err(|error| AppError::new("image_network_error", error.to_string()))?,
+        request.send().await.map_err(|error| {
+            AppError::new("image_network_error", image_transport_error_message(error))
+        })?,
         "horde",
     )
     .await?;
@@ -1952,7 +1963,9 @@ async fn generate_horde(
                 )
                 .send()
                 .await
-                .map_err(|error| AppError::new("image_network_error", error.to_string()))?,
+                .map_err(|error| {
+                    AppError::new("image_network_error", image_transport_error_message(error))
+                })?,
             "horde",
         )
         .await?;
@@ -2044,7 +2057,9 @@ async fn generate_comfyui(
             .json(&json!({ "prompt": prompt_json }))
             .send()
             .await
-            .map_err(|error| AppError::new("image_network_error", error.to_string()))?,
+            .map_err(|error| {
+                AppError::new("image_network_error", image_transport_error_message(error))
+            })?,
         "comfyui",
     )
     .await?;
@@ -2060,7 +2075,9 @@ async fn generate_comfyui(
                 .get(format!("{base}/history/{prompt_id}"))
                 .send()
                 .await
-                .map_err(|error| AppError::new("image_network_error", error.to_string()))?,
+                .map_err(|error| {
+                    AppError::new("image_network_error", image_transport_error_message(error))
+                })?,
             "comfyui",
         )
         .await?;
@@ -2282,7 +2299,9 @@ async fn generate_runpod_comfyui(
         )
         .send()
         .await
-        .map_err(|error| AppError::new("image_network_error", error.to_string()))?,
+        .map_err(|error| {
+            AppError::new("image_network_error", image_transport_error_message(error))
+        })?,
         "runpod",
     )
     .await?;
@@ -2301,7 +2320,9 @@ async fn generate_runpod_comfyui(
             )
             .send()
             .await
-            .map_err(|error| AppError::new("image_network_error", error.to_string()))?,
+            .map_err(|error| {
+                AppError::new("image_network_error", image_transport_error_message(error))
+            })?,
             "runpod",
         )
         .await?;
@@ -2467,7 +2488,7 @@ async fn generate_novelai(
     )
     .send()
     .await
-    .map_err(|error| AppError::new("image_network_error", error.to_string()))?;
+    .map_err(|error| AppError::new("image_network_error", image_transport_error_message(error)))?;
     let (bytes, content_type) = response_bytes(response, "novelai").await?;
     parse_novelai_image_response(&client, bytes, &content_type).await
 }

--- a/src-tauri/src/commands/storage/images/providers.rs
+++ b/src-tauri/src/commands/storage/images/providers.rs
@@ -1,4 +1,5 @@
 use super::*;
+use marinara_security::redact_sensitive_text;
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::io::{Cursor, Read};
@@ -473,7 +474,8 @@ async fn image_response_base64(
 }
 
 fn sanitize_error(text: &str) -> String {
-    text.replace(['\n', '\r', '\t'], " ")
+    redact_sensitive_text(text)
+        .replace(['\n', '\r', '\t'], " ")
         .split_whitespace()
         .collect::<Vec<_>>()
         .join(" ")
@@ -2614,6 +2616,18 @@ fn find_comfyui_image<'a>(history: &'a Value, prompt_id: &str) -> Option<&'a Val
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn image_provider_error_sanitizer_redacts_secrets() {
+        let sanitized = sanitize_error(
+            r#"{"error":"bad key sk-test-secret","payment":"https://pay.example.test/retrieve/session"}"#,
+        );
+
+        assert!(sanitized.contains("[REDACTED]"));
+        assert!(sanitized.contains("[REDACTED_URL]"));
+        assert!(!sanitized.contains("sk-test-secret"));
+        assert!(!sanitized.contains("retrieve/session"));
+    }
 
     #[test]
     fn comfy_reference_name_tokens_collect_default_and_indexed_slots() {

--- a/src-tauri/src/commands/storage/integrations/discord.rs
+++ b/src-tauri/src/commands/storage/integrations/discord.rs
@@ -1,6 +1,6 @@
 use crate::storage_commands::shared::required_string;
 use marinara_core::{AppError, AppResult};
-use marinara_security::is_allowed_outbound_url;
+use marinara_security::{is_allowed_outbound_url, redact_sensitive_text};
 use serde_json::{json, Map, Value};
 use std::time::Duration;
 
@@ -49,7 +49,7 @@ pub(crate) async fn discord_webhook_send(body: Value) -> AppResult<Value> {
         return Err(AppError::with_details(
             "discord_webhook_failed",
             format!("Discord webhook returned HTTP {status}"),
-            json!({ "body": body.chars().take(500).collect::<String>() }),
+            json!({ "body": redact_sensitive_text(&body).chars().take(500).collect::<String>() }),
         ));
     }
 

--- a/src-tauri/src/commands/storage/integrations/discord.rs
+++ b/src-tauri/src/commands/storage/integrations/discord.rs
@@ -41,7 +41,12 @@ pub(crate) async fn discord_webhook_send(body: Value) -> AppResult<Value> {
         .json(&Value::Object(payload))
         .send()
         .await
-        .map_err(|error| AppError::new("discord_webhook_request_error", error.to_string()))?;
+        .map_err(|error| {
+            AppError::new(
+                "discord_webhook_request_error",
+                redact_sensitive_text(&error.to_string()),
+            )
+        })?;
 
     let status = response.status();
     if !status.is_success() {

--- a/src-tauri/src/commands/storage/integrations/tts.rs
+++ b/src-tauri/src/commands/storage/integrations/tts.rs
@@ -421,10 +421,7 @@ async fn speak(state: &AppState, body: Value) -> AppResult<Value> {
         ));
     }
     if !is_allowed_audio_content_type(&content_type) {
-        let detail = String::from_utf8_lossy(&bytes)
-            .chars()
-            .take(500)
-            .collect::<String>();
+        let detail = provider_error_detail(&String::from_utf8_lossy(&bytes), 500);
         return Err(AppError::with_details(
             "tts_provider_error",
             "TTS provider returned a non-audio response",

--- a/src-tauri/src/commands/storage/integrations/tts.rs
+++ b/src-tauri/src/commands/storage/integrations/tts.rs
@@ -1,6 +1,7 @@
 use super::super::images::percent_encode_component;
 use super::super::shared::*;
 use super::super::*;
+use marinara_security::redact_sensitive_text;
 
 const TTS_SETTINGS_KEY: &str = "tts";
 const TTS_API_KEY_MASK: &str = "\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}";
@@ -33,6 +34,13 @@ const POCKET_TTS_VOICES: &[&str] = &[
     "stuart_bell",
     "vera",
 ];
+
+fn provider_error_detail(text: &str, max_chars: usize) -> String {
+    redact_sensitive_text(text)
+        .chars()
+        .take(max_chars)
+        .collect()
+}
 
 const NANOGPT_ELEVENLABS_VOICES: &[&str] = &[
     "Adam",
@@ -242,13 +250,8 @@ async fn voices(state: &AppState) -> AppResult<Value> {
         }
         Ok(response) => {
             let status = response.status();
-            let detail = response
-                .text()
-                .await
-                .unwrap_or_default()
-                .chars()
-                .take(300)
-                .collect::<String>();
+            let raw_detail = response.text().await.unwrap_or_default();
+            let detail = provider_error_detail(&raw_detail, 300);
             Ok(fallback_voices_with_error(
                 source,
                 &AppError::with_details(
@@ -410,10 +413,7 @@ async fn speak(state: &AppState, body: Value) -> AppResult<Value> {
         .await
         .map_err(|error| AppError::new("tts_response_error", error.to_string()))?;
     if !status.is_success() {
-        let detail = String::from_utf8_lossy(&bytes)
-            .chars()
-            .take(500)
-            .collect::<String>();
+        let detail = provider_error_detail(&String::from_utf8_lossy(&bytes), 500);
         return Err(AppError::with_details(
             "tts_provider_error",
             format!("TTS provider returned HTTP {status}"),
@@ -593,13 +593,8 @@ async fn elevenlabs_voices(config: &Value, base: &str) -> AppResult<Value> {
         .map_err(|error| AppError::new("tts_provider_unreachable", error.to_string()))?;
     if !response.status().is_success() {
         let status = response.status();
-        let detail = response
-            .text()
-            .await
-            .unwrap_or_default()
-            .chars()
-            .take(300)
-            .collect::<String>();
+        let raw_detail = response.text().await.unwrap_or_default();
+        let detail = provider_error_detail(&raw_detail, 300);
         return Err(AppError::with_details(
             "tts_provider_error",
             format!("TTS provider returned HTTP {status}"),
@@ -968,7 +963,8 @@ mod tests {
     #[tokio::test]
     async fn openai_voice_lookup_marks_fallback_when_provider_fails() {
         let state = test_state("openai-voices-provider-error");
-        let base_url = serve_voice_failure("401 Unauthorized", r#"{"error":"bad key"}"#).await;
+        let base_url =
+            serve_voice_failure("401 Unauthorized", r#"{"error":"bad key sk-test-secret"}"#).await;
         state
             .storage
             .upsert_with_id(
@@ -995,6 +991,7 @@ mod tests {
         assert!(result["providerError"]
             .as_str()
             .is_some_and(|message| message.contains("TTS provider returned HTTP")));
+        assert!(!result.to_string().contains("sk-test-secret"));
         assert_eq!(result["voices"], json!(OPENAI_FALLBACK_VOICES));
     }
 

--- a/src-tauri/src/commands/storage/llm.rs
+++ b/src-tauri/src/commands/storage/llm.rs
@@ -379,9 +379,10 @@ pub(crate) async fn connection_auth_check(state: &AppState, id: &str) -> AppResu
         .and_then(Value::as_str)
         .map(str::to_string);
     match check_connection_without_generation(&connection).await {
-        Ok(message) => Ok(json!({
-            "success": true,
-            "message": message,
+        Ok(outcome) => Ok(json!({
+            "success": !outcome.warning,
+            "warning": outcome.warning,
+            "message": outcome.message,
             "latencyMs": started.elapsed().as_millis(),
             "modelName": model_name,
         })),
@@ -422,40 +423,72 @@ pub(crate) async fn connection_diagnose_claude_subscription(
     marinara_llm::diagnose_claude_subscription_model(model, fast_mode)
 }
 
-async fn check_connection_without_generation(connection: &Value) -> AppResult<String> {
+#[derive(Debug)]
+struct ConnectionCheckOutcome {
+    message: String,
+    warning: bool,
+}
+
+impl ConnectionCheckOutcome {
+    fn success(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            warning: false,
+        }
+    }
+
+    fn warning(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            warning: true,
+        }
+    }
+}
+
+async fn check_connection_without_generation(
+    connection: &Value,
+) -> AppResult<ConnectionCheckOutcome> {
     let provider = connection
         .get("provider")
         .and_then(Value::as_str)
         .unwrap_or("openai");
     match provider {
-        "openai_chatgpt" => marinara_llm::check_openai_chatgpt_auth().await,
-        "claude_subscription" => marinara_llm::check_claude_subscription_available(),
-        "openrouter" => check_openrouter_key(connection).await,
+        "openai_chatgpt" => marinara_llm::check_openai_chatgpt_auth()
+            .await
+            .map(ConnectionCheckOutcome::success),
+        "claude_subscription" => {
+            marinara_llm::check_claude_subscription_available().map(ConnectionCheckOutcome::success)
+        }
+        "openrouter" => check_openrouter_key(connection)
+            .await
+            .map(ConnectionCheckOutcome::success),
         "nanogpt" => check_nanogpt_connection(connection).await,
-        "image_generation" => check_image_generation_connection(connection).await,
+        "image_generation" => check_image_generation_connection(connection)
+            .await
+            .map(ConnectionCheckOutcome::success),
         _ => {
             let models = fetch_provider_models(connection).await?;
             if models.is_empty() {
-                Ok("Connection successful.".to_string())
+                Ok(ConnectionCheckOutcome::success("Connection successful."))
             } else {
-                Ok(format!(
+                Ok(ConnectionCheckOutcome::success(format!(
                     "Connection successful. {} model{} available.",
                     models.len(),
                     if models.len() == 1 { "" } else { "s" }
-                ))
+                )))
             }
         }
     }
 }
 
-async fn check_nanogpt_connection(connection: &Value) -> AppResult<String> {
+async fn check_nanogpt_connection(connection: &Value) -> AppResult<ConnectionCheckOutcome> {
     let _api_key = connection_api_key(connection)?;
     let models = fetch_provider_models(connection).await?;
     let count = models.len();
     let suffix = if count == 1 { "" } else { "s" };
-    Ok(format!(
+    Ok(ConnectionCheckOutcome::warning(format!(
         "NanoGPT model list is reachable ({count} model{suffix} available), but this does not verify generation auth/payment. Use Send Test Message to verify the saved key can generate."
-    ))
+    )))
 }
 
 async fn check_openrouter_key(connection: &Value) -> AppResult<String> {
@@ -1395,7 +1428,7 @@ mod tests {
     async fn nanogpt_connection_test_labels_model_lookup_as_generation_unverified() {
         let base_url = serve_model_failure("200 OK", r#"{"data":[{"id":"model-a"}]}"#).await;
 
-        let message = check_connection_without_generation(&json!({
+        let outcome = check_connection_without_generation(&json!({
             "provider": "nanogpt",
             "baseUrl": base_url,
             "apiKey": "sk-test-key",
@@ -1404,7 +1437,39 @@ mod tests {
         .await
         .expect("NanoGPT model lookup should remain usable");
 
-        assert!(message.contains("does not verify generation auth/payment"));
+        assert!(outcome.warning);
+        assert!(outcome
+            .message
+            .contains("does not verify generation auth/payment"));
+    }
+
+    #[tokio::test]
+    async fn nanogpt_connection_auth_check_returns_warning_state() {
+        let state = test_state("nanogpt-warning");
+        let base_url = serve_model_failure("200 OK", r#"{"data":[{"id":"model-a"}]}"#).await;
+        state
+            .storage
+            .upsert_with_id(
+                "connections",
+                "nanogpt-warning",
+                json!({
+                    "provider": "nanogpt",
+                    "baseUrl": base_url,
+                    "apiKey": "sk-test-key",
+                    "model": "model-a"
+                }),
+            )
+            .expect("connection should be stored");
+
+        let result = connection_auth_check(&state, "nanogpt-warning")
+            .await
+            .expect("NanoGPT connection check should return model-list result");
+
+        assert_eq!(result["success"], false);
+        assert_eq!(result["warning"], true);
+        assert!(result["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("does not verify generation auth/payment")));
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/storage/llm.rs
+++ b/src-tauri/src/commands/storage/llm.rs
@@ -605,10 +605,12 @@ async fn send_connection_test_request(
     request: reqwest::RequestBuilder,
     label: &str,
 ) -> AppResult<Value> {
-    let response = request
-        .send()
-        .await
-        .map_err(|error| AppError::new("connection_network_error", error.to_string()))?;
+    let response = request.send().await.map_err(|error| {
+        AppError::new(
+            "connection_network_error",
+            provider_transport_error_message(error),
+        )
+    })?;
     let status = response.status();
     let text = response
         .text()
@@ -815,10 +817,12 @@ async fn fetch_provider_models(connection: &Value) -> AppResult<Vec<Value>> {
     } else if !api_key.is_empty() && provider != "google" {
         request = request.bearer_auth(api_key);
     }
-    let response = request
-        .send()
-        .await
-        .map_err(|error| AppError::new("models_network_error", error.to_string()))?;
+    let response = request.send().await.map_err(|error| {
+        AppError::new(
+            "models_network_error",
+            provider_transport_error_message(error),
+        )
+    })?;
     let status = response.status();
     let text = response
         .text()
@@ -849,7 +853,12 @@ async fn fetch_ollama_models(connection: &Value) -> AppResult<Vec<Value>> {
         .get(url)
         .send()
         .await
-        .map_err(|error| AppError::new("models_network_error", error.to_string()))?
+        .map_err(|error| {
+            AppError::new(
+                "models_network_error",
+                provider_transport_error_message(error),
+            )
+        })?
         .json::<Value>()
         .await
         .map_err(|error| AppError::new("models_json_error", error.to_string()))?;
@@ -986,10 +995,12 @@ where
     {
         request = request.bearer_auth(api_key.trim());
     }
-    let response = request
-        .send()
-        .await
-        .map_err(|error| AppError::new("models_network_error", error.to_string()))?;
+    let response = request.send().await.map_err(|error| {
+        AppError::new(
+            "models_network_error",
+            provider_transport_error_message(error),
+        )
+    })?;
     let status = response.status();
     let text = response
         .text()
@@ -1195,9 +1206,14 @@ fn ensure_model_url_allowed(url: &str) -> AppResult<()> {
         Ok(())
     } else {
         Err(AppError::invalid_input(format!(
-            "Outbound model URL is not allowed: {url}"
+            "Outbound model URL is not allowed: {}",
+            redact_sensitive_text(url)
         )))
     }
+}
+
+fn provider_transport_error_message(error: impl std::fmt::Display) -> String {
+    redact_sensitive_text(&error.to_string())
 }
 
 fn sanitize_provider_body(body: &str) -> String {
@@ -1305,6 +1321,17 @@ mod tests {
             })),
             "https://home.linkapi.ai"
         );
+    }
+
+    #[test]
+    fn model_url_rejection_redacts_query_secret() {
+        let error =
+            ensure_model_url_allowed("ftp://example.test/v1beta/models?key=AIzaSecretValue123")
+                .expect_err("disallowed model URL should fail");
+
+        assert_eq!(error.code, "invalid_input");
+        assert!(error.message.contains("[REDACTED]"));
+        assert!(!error.message.contains("AIzaSecretValue123"));
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/storage/llm.rs
+++ b/src-tauri/src/commands/storage/llm.rs
@@ -1,7 +1,7 @@
 use super::prompts;
 use super::shared::*;
 use super::*;
-use marinara_security::is_allowed_outbound_url;
+use marinara_security::{is_allowed_outbound_url, redact_sensitive_text};
 
 pub(crate) fn resolve_llm_connection_for_request(
     state: &AppState,
@@ -431,6 +431,7 @@ async fn check_connection_without_generation(connection: &Value) -> AppResult<St
         "openai_chatgpt" => marinara_llm::check_openai_chatgpt_auth().await,
         "claude_subscription" => marinara_llm::check_claude_subscription_available(),
         "openrouter" => check_openrouter_key(connection).await,
+        "nanogpt" => check_nanogpt_connection(connection).await,
         "image_generation" => check_image_generation_connection(connection).await,
         _ => {
             let models = fetch_provider_models(connection).await?;
@@ -445,6 +446,16 @@ async fn check_connection_without_generation(connection: &Value) -> AppResult<St
             }
         }
     }
+}
+
+async fn check_nanogpt_connection(connection: &Value) -> AppResult<String> {
+    let _api_key = connection_api_key(connection)?;
+    let models = fetch_provider_models(connection).await?;
+    let count = models.len();
+    let suffix = if count == 1 { "" } else { "s" };
+    Ok(format!(
+        "NanoGPT model list is reachable ({count} model{suffix} available), but this does not verify generation auth/payment. Use Send Test Message to verify the saved key can generate."
+    ))
 }
 
 async fn check_openrouter_key(connection: &Value) -> AppResult<String> {
@@ -1170,6 +1181,7 @@ fn provider_default_base_url(provider: &str) -> &'static str {
         }
         "openrouter" => "https://openrouter.ai/api/v1",
         "xai" => "https://api.x.ai/v1",
+        "nanogpt" => "https://nano-gpt.com/api/v1",
         "ollama" => "http://127.0.0.1:11434",
         "mistral" => "https://api.mistral.ai/v1",
         "cohere" => "https://api.cohere.ai/v2",
@@ -1189,10 +1201,11 @@ fn ensure_model_url_allowed(url: &str) -> AppResult<()> {
 }
 
 fn sanitize_provider_body(body: &str) -> String {
-    if body.contains("<html") || body.contains("<!DOCTYPE") {
+    let lower = body.to_ascii_lowercase();
+    if lower.contains("<html") || lower.contains("<!doctype") {
         "Provider returned HTML instead of JSON".to_string()
     } else {
-        body.chars().take(300).collect()
+        redact_sensitive_text(body).chars().take(300).collect()
     }
 }
 
@@ -1297,8 +1310,11 @@ mod tests {
     #[tokio::test]
     async fn connection_models_marks_fallback_when_provider_lookup_fails() {
         let state = test_state("provider-error");
-        let base_url =
-            serve_model_failure("500 Internal Server Error", r#"{"error":"bad key"}"#).await;
+        let base_url = serve_model_failure(
+            "500 Internal Server Error",
+            r#"{"error":"bad key sk-test-secret","api_key":"sk-test-secret"}"#,
+        )
+        .await;
         state
             .storage
             .upsert_with_id(
@@ -1322,9 +1338,46 @@ mod tests {
         assert!(result["providerError"]
             .as_str()
             .is_some_and(|message| message.contains("Provider returned HTTP")));
+        assert!(!result["providerError"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("sk-test-secret"));
         assert!(result["models"]
             .as_array()
             .is_some_and(|models| models.iter().any(|model| model["id"] == "gpt-custom")));
+    }
+
+    #[tokio::test]
+    async fn nanogpt_connection_test_requires_api_key_before_model_lookup() {
+        let base_url = serve_model_failure("200 OK", r#"{"data":[{"id":"model-a"}]}"#).await;
+
+        let error = check_connection_without_generation(&json!({
+            "provider": "nanogpt",
+            "baseUrl": base_url,
+            "apiKey": "",
+            "model": "model-a"
+        }))
+        .await
+        .expect_err("NanoGPT test should reject missing generation credentials");
+
+        assert_eq!(error.code, "invalid_input");
+        assert!(error.message.contains("API key is required"));
+    }
+
+    #[tokio::test]
+    async fn nanogpt_connection_test_labels_model_lookup_as_generation_unverified() {
+        let base_url = serve_model_failure("200 OK", r#"{"data":[{"id":"model-a"}]}"#).await;
+
+        let message = check_connection_without_generation(&json!({
+            "provider": "nanogpt",
+            "baseUrl": base_url,
+            "apiKey": "sk-test-key",
+            "model": "model-a"
+        }))
+        .await
+        .expect("NanoGPT model lookup should remain usable");
+
+        assert!(message.contains("does not verify generation auth/payment"));
     }
 
     #[tokio::test]

--- a/src/engine/contracts/types/connection.ts
+++ b/src/engine/contracts/types/connection.ts
@@ -104,7 +104,10 @@ export interface ModelCapabilities {
 /** Test result for a connection. */
 export interface ConnectionTestResult {
   success: boolean;
+  warning?: boolean;
   message: string;
   latencyMs: number;
   modelName: string | null;
+  code?: string;
+  details?: unknown;
 }

--- a/src/features/catalog/connections/types.ts
+++ b/src/features/catalog/connections/types.ts
@@ -24,7 +24,11 @@ export interface ConnectionRow {
 
 export interface ConnectionTestResult {
   success: boolean;
-  latencyMs?: number;
+  warning?: boolean;
+  message: string;
+  latencyMs: number;
+  modelName?: string | null;
+  code?: string;
   error?: string;
   details?: unknown;
 }

--- a/src/features/shell/connections/components/ConnectionEditor.tsx
+++ b/src/features/shell/connections/components/ConnectionEditor.tsx
@@ -195,7 +195,12 @@ export function ConnectionEditor() {
   const [imageDefaultsExpanded, setImageDefaultsExpanded] = useState(false);
 
   // Test results
-  const [testResult, setTestResult] = useState<{ success: boolean; message: string; latencyMs: number } | null>(null);
+  const [testResult, setTestResult] = useState<{
+    success: boolean;
+    warning?: boolean;
+    message: string;
+    latencyMs: number;
+  } | null>(null);
   const [msgResult, setMsgResult] = useState<{
     success: boolean;
     response: string;
@@ -572,7 +577,7 @@ export function ConnectionEditor() {
     }
     setTestResult(null);
     testConnection.mutate(connectionDetailId, {
-      onSuccess: (data) => setTestResult(data as { success: boolean; message: string; latencyMs: number }),
+      onSuccess: (data) => setTestResult(data),
       onError: (err) =>
         setTestResult({ success: false, message: err instanceof Error ? err.message : "Failed", latencyMs: 0 }),
     });
@@ -1973,7 +1978,12 @@ export function ConnectionEditor() {
 
             {/* Connection test result */}
             {testResult && (
-              <TestResultCard label="Connection Test" success={testResult.success} latencyMs={testResult.latencyMs}>
+              <TestResultCard
+                label="Connection Test"
+                success={testResult.success}
+                warning={testResult.warning}
+                latencyMs={testResult.latencyMs}
+              >
                 {testResult.message}
               </TestResultCard>
             )}
@@ -2157,29 +2167,45 @@ function ClaudeSubscriptionAuthHelp() {
 function TestResultCard({
   label,
   success,
+  warning = false,
   latencyMs,
   children,
 }: {
   label: string;
   success: boolean;
+  warning?: boolean;
   latencyMs: number;
   children: React.ReactNode;
 }) {
+  const tone = warning ? "warning" : success ? "success" : "error";
+  const isSuccess = tone === "success";
+  const isWarning = tone === "warning";
+  const statusLabel = isWarning ? "Warning" : isSuccess ? "Success" : "Failed";
+
   return (
     <div
       className={cn(
         "rounded-lg border p-3",
-        success ? "border-emerald-400/20 bg-emerald-400/5" : "border-[var(--destructive)]/20 bg-[var(--destructive)]/5",
+        isWarning
+          ? "border-amber-400/25 bg-amber-400/5"
+          : isSuccess
+            ? "border-emerald-400/20 bg-emerald-400/5"
+            : "border-[var(--destructive)]/20 bg-[var(--destructive)]/5",
       )}
     >
       <div className="flex items-center gap-2 text-xs font-medium">
-        {success ? (
+        {isSuccess ? (
           <Check size="0.8125rem" className="text-emerald-400" />
         ) : (
-          <AlertCircle size="0.8125rem" className="text-[var(--destructive)]" />
+          <AlertCircle
+            size="0.8125rem"
+            className={isWarning ? "text-amber-300" : "text-[var(--destructive)]"}
+          />
         )}
-        <span className={success ? "text-emerald-400" : "text-[var(--destructive)]"}>
-          {label}: {success ? "Success" : "Failed"}
+        <span
+          className={isWarning ? "text-amber-300" : isSuccess ? "text-emerald-400" : "text-[var(--destructive)]"}
+        >
+          {label}: {statusLabel}
         </span>
         <span className="ml-auto text-[0.625rem] text-[var(--muted-foreground)]">{latencyMs}ms</span>
       </div>

--- a/src/features/shell/connections/components/ConnectionEditor.tsx
+++ b/src/features/shell/connections/components/ConnectionEditor.tsx
@@ -455,8 +455,8 @@ export function ConnectionEditor() {
     closeConnectionDetail();
   }, [dirty, closeConnectionDetail]);
 
-  const handleSave = useCallback(async () => {
-    if (!connectionDetailId) return;
+  const handleSave = useCallback(async (): Promise<boolean> => {
+    if (!connectionDetailId) return false;
     setSaveError(null);
     const payload: Record<string, unknown> = {
       id: connectionDetailId,
@@ -511,8 +511,10 @@ export function ConnectionEditor() {
       setDirty(false);
       setSavedFlash(true);
       setTimeout(() => setSavedFlash(false), 1500);
+      return true;
     } catch (err) {
       setSaveError(err instanceof Error ? err.message : "Failed to save connection");
+      return false;
     }
   }, [
     connectionDetailId,
@@ -568,12 +570,8 @@ export function ConnectionEditor() {
   const handleTestConnection = useCallback(async () => {
     if (!connectionDetailId) return;
     // Save first if dirty, and wait for it to complete
-    if (dirty) {
-      try {
-        await handleSave();
-      } catch {
-        return;
-      }
+    if (dirty && !(await handleSave())) {
+      return;
     }
     setTestResult(null);
     testConnection.mutate(connectionDetailId, {
@@ -585,12 +583,8 @@ export function ConnectionEditor() {
 
   const handleTestMessage = useCallback(async () => {
     if (!connectionDetailId) return;
-    if (dirty) {
-      try {
-        await handleSave();
-      } catch {
-        return;
-      }
+    if (dirty && !(await handleSave())) {
+      return;
     }
     setMsgResult(null);
     testMessage.mutate(connectionDetailId, {
@@ -608,12 +602,8 @@ export function ConnectionEditor() {
 
   const handleDiagnoseClaudeSubscription = useCallback(async () => {
     if (!connectionDetailId) return;
-    if (dirty) {
-      try {
-        await handleSave();
-      } catch {
-        return;
-      }
+    if (dirty && !(await handleSave())) {
+      return;
     }
     setClaudeDiagResult(null);
     diagnoseClaudeSubscription.mutate(connectionDetailId, {
@@ -634,12 +624,8 @@ export function ConnectionEditor() {
 
   const handleTestImage = useCallback(async () => {
     if (!connectionDetailId) return;
-    if (dirty) {
-      try {
-        await handleSave();
-      } catch {
-        return;
-      }
+    if (dirty && !(await handleSave())) {
+      return;
     }
     setImgTestResult(null);
     testImageGeneration.mutate(connectionDetailId, {
@@ -670,12 +656,8 @@ export function ConnectionEditor() {
     if (!connectionDetailId) return;
     setFetchError(null);
     // Save first if dirty so native provider calls use the latest baseUrl/apiKey/provider.
-    if (dirty) {
-      try {
-        await handleSave();
-      } catch {
-        return;
-      }
+    if (dirty && !(await handleSave())) {
+      return;
     }
     fetchModels.mutate(connectionDetailId, {
       onSuccess: (data) => {
@@ -849,8 +831,9 @@ export function ConnectionEditor() {
             </button>
             <button
               onClick={async () => {
-                await handleSave();
-                closeConnectionDetail();
+                if (await handleSave()) {
+                  closeConnectionDetail();
+                }
               }}
               className="rounded-lg bg-amber-500/20 px-3 py-1 hover:bg-amber-500/30"
             >

--- a/src/features/shell/connections/components/ConnectionEditor.tsx
+++ b/src/features/shell/connections/components/ConnectionEditor.tsx
@@ -101,6 +101,7 @@ const MAX_PARALLEL_JOBS = 16;
 const OPENAI_CHATGPT_SETUP_STEPS = [
   { label: "Install Codex CLI", command: "npm i -g @openai/codex" },
   { label: "Sign in once", command: "codex login" },
+  { label: "Codex creates a local auth.json credential file that Marinara reads automatically." },
   { label: "API Key and Base URL are not required - leave them blank." },
 ] as const;
 
@@ -993,7 +994,7 @@ export function ConnectionEditor() {
               {isClaudeSubscriptionProvider
                 ? "Authentication is read from your local Claude Code session."
                 : usesLocalChatGptAuth
-                  ? "Authentication is read from your local codex login session."
+                  ? "Authentication is read from your local Codex auth.json credential file; this field stays locked."
                   : "Your key is encrypted at rest. Leave blank when editing to keep the existing key."}
             </p>
             {!usesLocalAuthProvider && API_KEY_LINKS[localProvider] && (
@@ -1047,7 +1048,8 @@ export function ConnectionEditor() {
               </p>
             ) : usesLocalChatGptAuth ? (
               <p className="mt-1.5 text-[0.625rem] text-[var(--muted-foreground)]">
-                Marinara sends requests to the ChatGPT Codex endpoint automatically using your local Codex auth.
+                Marinara sends requests to the ChatGPT Codex endpoint automatically using your local Codex auth; this
+                endpoint field stays locked.
               </p>
             ) : providerDef?.defaultBaseUrl && !localBaseUrl ? (
               <p className="mt-1 text-[0.625rem] text-[var(--muted-foreground)]">
@@ -1946,7 +1948,9 @@ export function ConnectionEditor() {
                 ? "verifies your local Claude Code command is available."
                 : usesLocalChatGptAuth
                   ? "verifies your local Codex ChatGPT login."
-                  : "verifies your API key works."}
+                  : localProvider === "nanogpt"
+                    ? "checks NanoGPT's model list only. Use Send Test Message to verify generation auth and account balance."
+                    : "verifies your API key works."}
               {localProvider !== "image_generation" && (
                 <>
                   {" "}
@@ -2103,8 +2107,9 @@ function OpenAiChatGptAuthHelp() {
             })}
           </ol>
           <p className="mt-2">
-            Marinara reads the local Codex auth file and refreshes the ChatGPT session when possible. Embeddings are not
-            available on this provider; configure a separate connection for embedding work.
+            Marinara reads the local Codex <code className="rounded bg-[var(--secondary)] px-1">auth.json</code>{" "}
+            credential file and refreshes the ChatGPT session when possible. Embeddings are not available on this
+            provider; configure a separate connection for embedding work.
           </p>
         </div>
       </div>


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #1567
Closes #1568
Closes #1569

## Why this change

Provider and connection-test failures could surface upstream error text without a Marinara-owned final redaction pass. NanoGPT could also show a green connection-test success for a model-list lookup even though generation auth/payment was still unverified. The OpenAI ChatGPT setup UI also needed clearer local credential-file guidance.

## What changed

- Added shared Rust redaction helpers for provider error text and JSON details, covering API keys, auth tokens, bearer values, sensitive query params, payment/retrieval URLs, and common provider key prefixes.
- Applied redaction to LLM provider HTTP errors, malformed response details, stream error events, Claude subscription diagnostics, connection model lookup errors, image provider errors, TTS provider errors, and Discord webhook response details.
- Redacted provider transport URL/network errors so query-string credentials such as Google `?key=...` values are not echoed back.
- Changed NanoGPT connection tests to require a saved API key, label model-list reachability as generation/payment-unverified, and return/render the result as a warning instead of success.
- Updated OpenAI ChatGPT connection helper text to explain the local Codex `auth.json` credential-file flow and locked fields.

## Refactor impact

Primary owner:

Rust provider transport/security plus Connections shell UI.

Impact areas reviewed:

- Rust `marinara-security` redaction helpers and consumers.
- Rust LLM provider transport and connection-test command paths.
- Image provider, TTS, and Discord integration failure-body surfaces.
- Connections catalog/shell result types and warning-card rendering.
- Hostable/runtime boundary shape for existing connection commands; no new command was added.

Boundary notes:

- Redaction lives in `src-tauri/crates/security` and is reused by privileged Rust provider/integration boundaries.
- React UI changes stay in `src/features/shell/connections`; shared result typing stays in existing connection contract/type owners.
- No engine-to-Tauri or feature raw-invoke boundary was added.
- Remote runtime allowlists/dispatch were not changed because the existing connection commands and DTO shape are reused.

Pressure points touched:

- No ModeSurface, GameSurface, shared mode UI, `src-tauri/src/lib.rs` registration, or import workflow changes.
- Existing broad provider command files were touched only at the relevant error and connection-test surfaces.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->

- [x] `pnpm check` passes locally
- [x] `pnpm typecheck` passes locally
- [x] `pnpm build` passes locally
- [x] `pnpm check:architecture` passes locally
- [x] `pnpm check:docs` passes locally
- [x] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [x] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

Commands and checks run locally:

- `cargo test --manifest-path src-tauri/Cargo.toml -p marinara-security -p marinara-llm`
- `cargo test --manifest-path src-tauri/Cargo.toml nanogpt_connection`
- `cargo test --manifest-path src-tauri/Cargo.toml connection_models_marks_fallback_when_provider_lookup_fails`
- `cargo test --manifest-path src-tauri/Cargo.toml image_provider_error_sanitizer_redacts_secrets`
- `cargo test --manifest-path src-tauri/Cargo.toml openai_voice_lookup_marks_fallback_when_provider_fails`
- `cargo test --manifest-path src-tauri/Cargo.toml -p marinara-llm openai_chatgpt_missing_auth_message_hides_local_path`
- `cargo test --manifest-path src-tauri/Cargo.toml -p marinara-llm ensure_url_allowed_redacts_query_secret`
- `cargo test --manifest-path src-tauri/Cargo.toml model_url_rejection_redacts_query_secret`
- `cargo test --manifest-path src-tauri/Cargo.toml -p marinara-llm provider_http_error_redacts_sensitive_error_body`
- `pnpm typecheck`
- `cargo check --manifest-path src-tauri/Cargo.toml --workspace`
- `pnpm check:architecture`
- `pnpm build`
- `git diff --check origin/refactor...HEAD -- . ':(exclude)graphify-out/**'`

Native Tauri QA:

- Ran the native WebDriver smoke against a current debug Tauri executable built from this branch; verified React mounted in the native window with title `Marinara Engine`.
- In the native Connections UI, created a temporary NanoGPT connection pointed at a local fake model-list endpoint, clicked `Test Connection`, and observed `Connection Test: Warning` plus the “does not verify generation auth/payment” copy. The card did not show `Connection Test: Success`.
- Deleted the temporary connection after the QA pass.

Proof gaps:

- No real NanoGPT account/payment or live provider credentials were used.
- Remote runtime smoke was not run because this change reuses existing command routing and the focused risk was provider error/result handling.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs files were changed; this is covered by existing issue reports and does not change run commands, architecture ownership, or contributor workflow.

## UI evidence

Local native WebDriver screenshot evidence was captured for the NanoGPT warning card during Tauri QA. No screenshot artifact is committed in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Connection tests now display warning states separately from failures, providing clearer diagnostic feedback.

* **Bug Fixes**
  * Improved redaction of sensitive information (API credentials, tokens, file paths) from error messages and diagnostic logs across all integrated providers.
  * Enhanced error handling to prevent credential leaks in connection validation and model retrieval responses.

* **Improvements**
  * Connection status UI now visually distinguishes between warnings and failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1581?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->