### PR TITLE
[codex] Restore haptic controls

### DIFF
--- a/src-tauri/src/commands/storage/integrations/haptic.rs
+++ b/src-tauri/src/commands/storage/integrations/haptic.rs
@@ -143,25 +143,26 @@ async fn stop_all() -> AppResult<Value> {
 async fn command(body: Value) -> AppResult<Value> {
     let now = now_millis();
     let mut runtime = runtime().lock().await;
-    if now.saturating_sub(runtime.last_command_at) < MIN_COMMAND_INTERVAL_MS {
-        return Err(AppError::new(
-            "rate_limited",
-            "Haptic commands are rate limited",
-        ));
-    }
-    runtime.last_command_at = now;
-    let client = runtime
+    if !runtime
         .client
         .as_ref()
-        .filter(|client| client.connected())
-        .ok_or_else(|| AppError::invalid_input("Not connected to Intiface Central"))?;
-    let targets = command_targets(client, &body)?;
+        .is_some_and(ButtplugClient::connected)
+    {
+        return Err(AppError::invalid_input("Not connected to Intiface Central"));
+    }
     let action = normalize_action(body.get("action")).ok_or_else(|| {
         AppError::invalid_input(format!(
             "Unknown haptic action: {}",
             body.get("action").and_then(Value::as_str).unwrap_or("")
         ))
     })?;
+    enforce_command_rate_limit(&mut runtime, now, action)?;
+    let client = runtime
+        .client
+        .as_ref()
+        .filter(|client| client.connected())
+        .ok_or_else(|| AppError::invalid_input("Not connected to Intiface Central"))?;
+    let targets = command_targets(client, &body)?;
     let intensity = clamp_unit(body.get("intensity"), 0.5);
     let duration = clamp_duration(body.get("duration"));
 
@@ -178,6 +179,24 @@ async fn command(body: Value) -> AppResult<Value> {
         });
     }
     Ok(json!({ "ok": true }))
+}
+
+fn enforce_command_rate_limit(
+    runtime: &mut HapticRuntime,
+    now: u128,
+    action: &'static str,
+) -> AppResult<()> {
+    if action == "stop" {
+        return Ok(());
+    }
+    if now.saturating_sub(runtime.last_command_at) < MIN_COMMAND_INTERVAL_MS {
+        return Err(AppError::new(
+            "rate_limited",
+            "Haptic commands are rate limited",
+        ));
+    }
+    runtime.last_command_at = now;
+    Ok(())
 }
 
 fn status_value(runtime: &HapticRuntime) -> Value {
@@ -346,5 +365,35 @@ fn output_command_for_action(
             Some(ClientDeviceOutputCommand::Vibrate(value))
         }
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stop_commands_bypass_rate_limit() {
+        let mut runtime = HapticRuntime {
+            last_command_at: 1_000,
+            ..HapticRuntime::default()
+        };
+
+        assert!(enforce_command_rate_limit(&mut runtime, 1_050, "stop").is_ok());
+        assert_eq!(runtime.last_command_at, 1_000);
+    }
+
+    #[test]
+    fn non_stop_commands_keep_rate_limit() {
+        let mut runtime = HapticRuntime {
+            last_command_at: 1_000,
+            ..HapticRuntime::default()
+        };
+
+        assert!(enforce_command_rate_limit(&mut runtime, 1_050, "vibrate").is_err());
+        assert_eq!(runtime.last_command_at, 1_000);
+
+        assert!(enforce_command_rate_limit(&mut runtime, 1_250, "vibrate").is_ok());
+        assert_eq!(runtime.last_command_at, 1_250);
     }
 }

--- a/src/features/modes/shared/chat-ui/components/settings/HapticConnectionPanel.test.tsx
+++ b/src/features/modes/shared/chat-ui/components/settings/HapticConnectionPanel.test.tsx
@@ -34,8 +34,10 @@ vi.mock("../../../../../runtime/haptics/index", () => ({
   useHapticStopScan: hapticHookMocks.useHapticStopScan,
 }));
 
-function pendingMutation(mutate: ReturnType<typeof vi.fn>) {
-  return { mutate, isPending: false, isError: false };
+type MutationOptions = { onError?: (error: unknown) => void };
+
+function pendingMutation(mutate: ReturnType<typeof vi.fn>, overrides: Record<string, unknown> = {}) {
+  return { mutate, isPending: false, isError: false, error: null, ...overrides };
 }
 
 describe("HapticConnectionPanel", () => {
@@ -100,7 +102,10 @@ describe("HapticConnectionPanel", () => {
 
     expect(hapticHookMocks.stopScanMutate).toHaveBeenCalledTimes(1);
     expect(hapticHookMocks.stopAllMutate).toHaveBeenCalledTimes(1);
-    expect(hapticHookMocks.commandMutate).toHaveBeenCalledWith({ deviceIndex: 2, action: "stop" });
+    expect(hapticHookMocks.commandMutate).toHaveBeenCalledWith(
+      { deviceIndex: 2, action: "stop" },
+      expect.objectContaining({ onError: expect.any(Function) }),
+    );
   });
 
   it("starts scanning when no scan is active", () => {
@@ -121,5 +126,16 @@ describe("HapticConnectionPanel", () => {
     expect(hapticHookMocks.startScanMutate).toHaveBeenCalledTimes(1);
     expect(hapticHookMocks.stopScanMutate).not.toHaveBeenCalled();
     expect(container.textContent).not.toContain("Stop all");
+  });
+
+  it("shows restored haptic action failures", () => {
+    hapticHookMocks.stopAllMutate.mockImplementation((_variables: unknown, options?: MutationOptions) => {
+      options?.onError?.(new Error("Intiface Central rejected stop all"));
+    });
+
+    renderPanel();
+    clickButton("Stop all");
+
+    expect(container.textContent).toContain("Haptic action failed - Intiface Central rejected stop all");
   });
 });

--- a/src/features/modes/shared/chat-ui/components/settings/HapticConnectionPanel.test.tsx
+++ b/src/features/modes/shared/chat-ui/components/settings/HapticConnectionPanel.test.tsx
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { HapticConnectionPanel } from "./HapticConnectionPanel";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const hapticHookMocks = vi.hoisted(() => ({
+  commandMutate: vi.fn(),
+  connectMutate: vi.fn(),
+  disconnectMutate: vi.fn(),
+  startScanMutate: vi.fn(),
+  stopAllMutate: vi.fn(),
+  stopScanMutate: vi.fn(),
+  useHapticCommand: vi.fn(),
+  useHapticConnect: vi.fn(),
+  useHapticDisconnect: vi.fn(),
+  useHapticStartScan: vi.fn(),
+  useHapticStatus: vi.fn(),
+  useHapticStopAll: vi.fn(),
+  useHapticStopScan: vi.fn(),
+}));
+
+vi.mock("../../../../../runtime/haptics/index", () => ({
+  HAPTIC_INTIFACE_URL_STORAGE_KEY: "marinara_haptic_intiface_url",
+  useHapticCommand: hapticHookMocks.useHapticCommand,
+  useHapticConnect: hapticHookMocks.useHapticConnect,
+  useHapticDisconnect: hapticHookMocks.useHapticDisconnect,
+  useHapticStartScan: hapticHookMocks.useHapticStartScan,
+  useHapticStatus: hapticHookMocks.useHapticStatus,
+  useHapticStopAll: hapticHookMocks.useHapticStopAll,
+  useHapticStopScan: hapticHookMocks.useHapticStopScan,
+}));
+
+function pendingMutation(mutate: ReturnType<typeof vi.fn>) {
+  return { mutate, isPending: false, isError: false };
+}
+
+describe("HapticConnectionPanel", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.localStorage.clear();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    hapticHookMocks.useHapticStatus.mockReturnValue({
+      data: {
+        connected: true,
+        devices: [{ index: 2, name: "Lovense Edge", capabilities: ["vibrate", "rotate"] }],
+        scanning: true,
+        serverUrl: "ws://127.0.0.1:12345",
+        defaultServerUrl: "ws://127.0.0.1:12345",
+      },
+      isLoading: false,
+    });
+    hapticHookMocks.useHapticConnect.mockReturnValue(pendingMutation(hapticHookMocks.connectMutate));
+    hapticHookMocks.useHapticDisconnect.mockReturnValue(pendingMutation(hapticHookMocks.disconnectMutate));
+    hapticHookMocks.useHapticStartScan.mockReturnValue(pendingMutation(hapticHookMocks.startScanMutate));
+    hapticHookMocks.useHapticStopScan.mockReturnValue(pendingMutation(hapticHookMocks.stopScanMutate));
+    hapticHookMocks.useHapticCommand.mockReturnValue(pendingMutation(hapticHookMocks.commandMutate));
+    hapticHookMocks.useHapticStopAll.mockReturnValue(pendingMutation(hapticHookMocks.stopAllMutate));
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  function renderPanel() {
+    act(() => {
+      root.render(<HapticConnectionPanel onIntifaceUrlChange={vi.fn()} />);
+    });
+  }
+
+  function clickButton(label: string) {
+    const button = Array.from(container.querySelectorAll("button")).find(
+      (candidate) => candidate.textContent?.trim() === label,
+    );
+    expect(button).toBeTruthy();
+
+    act(() => {
+      button!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+  }
+
+  it("routes restored stop controls through haptic mutations", () => {
+    renderPanel();
+
+    clickButton("Stop scan");
+    clickButton("Stop all");
+    clickButton("Stop");
+
+    expect(hapticHookMocks.stopScanMutate).toHaveBeenCalledTimes(1);
+    expect(hapticHookMocks.stopAllMutate).toHaveBeenCalledTimes(1);
+    expect(hapticHookMocks.commandMutate).toHaveBeenCalledWith({ deviceIndex: 2, action: "stop" });
+  });
+
+  it("starts scanning when no scan is active", () => {
+    hapticHookMocks.useHapticStatus.mockReturnValue({
+      data: {
+        connected: true,
+        devices: [],
+        scanning: false,
+        serverUrl: "ws://127.0.0.1:12345",
+        defaultServerUrl: "ws://127.0.0.1:12345",
+      },
+      isLoading: false,
+    });
+
+    renderPanel();
+    clickButton("Scan for devices");
+
+    expect(hapticHookMocks.startScanMutate).toHaveBeenCalledTimes(1);
+    expect(hapticHookMocks.stopScanMutate).not.toHaveBeenCalled();
+    expect(container.textContent).not.toContain("Stop all");
+  });
+});

--- a/src/features/modes/shared/chat-ui/components/settings/HapticConnectionPanel.tsx
+++ b/src/features/modes/shared/chat-ui/components/settings/HapticConnectionPanel.tsx
@@ -32,6 +32,7 @@ export function HapticConnectionPanel({
     () => savedIntifaceUrl ?? localStorage.getItem(HAPTIC_INTIFACE_URL_STORAGE_KEY) ?? "",
   );
   const [autoConnectAttempted, setAutoConnectAttempted] = useState(false);
+  const [hapticActionError, setHapticActionError] = useState<unknown>(null);
 
   useEffect(() => {
     setIntifaceUrl(savedIntifaceUrl ?? localStorage.getItem(HAPTIC_INTIFACE_URL_STORAGE_KEY) ?? "");
@@ -49,6 +50,14 @@ export function HapticConnectionPanel({
     }
     return trimmed;
   }, [intifaceUrl, onIntifaceUrlChange, savedIntifaceUrl]);
+
+  const clearHapticActionError = useCallback(() => {
+    setHapticActionError(null);
+  }, []);
+
+  const handleHapticActionError = useCallback((error: unknown) => {
+    setHapticActionError(() => error);
+  }, []);
 
   useEffect(() => {
     if (autoConnectAttempted || isLoading || !status || status.connected || connect.isPending) return;
@@ -72,6 +81,8 @@ export function HapticConnectionPanel({
   const activeServerUrl = status?.serverUrl ?? defaultServerUrl;
   const scanActionPending = startScan.isPending || stopScan.isPending;
   const stopActionPending = command.isPending || stopAll.isPending;
+  const hapticActionErrorMessage =
+    hapticActionError instanceof Error ? hapticActionError.message : "The haptic action failed.";
 
   return (
     <div className="space-y-1.5 px-1">
@@ -135,7 +146,10 @@ export function HapticConnectionPanel({
               {devices.length > 0 && (
                 <button
                   type="button"
-                  onClick={() => stopAll.mutate()}
+                  onClick={() => {
+                    clearHapticActionError();
+                    stopAll.mutate(undefined, { onError: handleHapticActionError });
+                  }}
                   disabled={stopActionPending}
                   className="text-[0.625rem] font-medium text-[var(--muted-foreground)] hover:text-[var(--primary)] hover:underline disabled:opacity-50"
                 >
@@ -145,10 +159,11 @@ export function HapticConnectionPanel({
               <button
                 type="button"
                 onClick={() => {
+                  clearHapticActionError();
                   if (scanning) {
-                    stopScan.mutate();
+                    stopScan.mutate(undefined, { onError: handleHapticActionError });
                   } else {
-                    startScan.mutate();
+                    startScan.mutate(undefined, { onError: handleHapticActionError });
                   }
                 }}
                 disabled={scanActionPending}
@@ -158,6 +173,9 @@ export function HapticConnectionPanel({
               </button>
             </div>
           </div>
+          {hapticActionError !== null && (
+            <p className="px-1 text-[0.625rem] text-red-400">Haptic action failed - {hapticActionErrorMessage}</p>
+          )}
           {devices.map((device) => (
             <div
               key={device.index}
@@ -170,7 +188,13 @@ export function HapticConnectionPanel({
               </span>
               <button
                 type="button"
-                onClick={() => command.mutate({ deviceIndex: device.index, action: "stop" })}
+                onClick={() => {
+                  clearHapticActionError();
+                  command.mutate(
+                    { deviceIndex: device.index, action: "stop" },
+                    { onError: handleHapticActionError },
+                  );
+                }}
                 disabled={stopActionPending}
                 className="text-[0.5625rem] font-medium text-[var(--muted-foreground)] hover:text-[var(--primary)] hover:underline disabled:opacity-50"
               >

--- a/src/features/modes/shared/chat-ui/components/settings/HapticConnectionPanel.tsx
+++ b/src/features/modes/shared/chat-ui/components/settings/HapticConnectionPanel.tsx
@@ -3,10 +3,13 @@ import { Vibrate } from "lucide-react";
 import { cn } from "../../../../../../shared/lib/utils";
 import {
   HAPTIC_INTIFACE_URL_STORAGE_KEY,
+  useHapticCommand,
   useHapticConnect,
   useHapticDisconnect,
   useHapticStartScan,
   useHapticStatus,
+  useHapticStopAll,
+  useHapticStopScan,
 } from "../../../../../runtime/haptics/index";
 
 interface HapticConnectionPanelProps {
@@ -22,6 +25,9 @@ export function HapticConnectionPanel({
   const connect = useHapticConnect();
   const disconnect = useHapticDisconnect();
   const startScan = useHapticStartScan();
+  const stopScan = useHapticStopScan();
+  const command = useHapticCommand();
+  const stopAll = useHapticStopAll();
   const [intifaceUrl, setIntifaceUrl] = useState(
     () => savedIntifaceUrl ?? localStorage.getItem(HAPTIC_INTIFACE_URL_STORAGE_KEY) ?? "",
   );
@@ -64,6 +70,8 @@ export function HapticConnectionPanel({
   const scanning = status?.scanning ?? false;
   const defaultServerUrl = status?.defaultServerUrl ?? "ws://127.0.0.1:12345";
   const activeServerUrl = status?.serverUrl ?? defaultServerUrl;
+  const scanActionPending = startScan.isPending || stopScan.isPending;
+  const stopActionPending = command.isPending || stopAll.isPending;
 
   return (
     <div className="space-y-1.5 px-1">
@@ -123,24 +131,51 @@ export function HapticConnectionPanel({
             <span className="text-[0.625rem] text-[var(--muted-foreground)]">
               {devices.length === 0 ? "No devices found" : `${devices.length} device${devices.length !== 1 ? "s" : ""}`}
             </span>
-            <button
-              onClick={() => startScan.mutate()}
-              disabled={scanning || startScan.isPending}
-              className="text-[0.625rem] font-medium text-[var(--primary)] hover:underline disabled:opacity-50"
-            >
-              {scanning ? "Scanning..." : "Scan for devices"}
-            </button>
+            <div className="flex items-center gap-2">
+              {devices.length > 0 && (
+                <button
+                  type="button"
+                  onClick={() => stopAll.mutate()}
+                  disabled={stopActionPending}
+                  className="text-[0.625rem] font-medium text-[var(--muted-foreground)] hover:text-[var(--primary)] hover:underline disabled:opacity-50"
+                >
+                  Stop all
+                </button>
+              )}
+              <button
+                type="button"
+                onClick={() => {
+                  if (scanning) {
+                    stopScan.mutate();
+                  } else {
+                    startScan.mutate();
+                  }
+                }}
+                disabled={scanActionPending}
+                className="text-[0.625rem] font-medium text-[var(--primary)] hover:underline disabled:opacity-50"
+              >
+                {scanning ? "Stop scan" : "Scan for devices"}
+              </button>
+            </div>
           </div>
           {devices.map((device) => (
             <div
               key={device.index}
-              className="flex items-center gap-1.5 rounded-md bg-[var(--accent)]/50 px-2.5 py-1.5"
+              className="flex min-w-0 items-center gap-1.5 rounded-md bg-[var(--accent)]/50 px-2.5 py-1.5"
             >
               <Vibrate size="0.625rem" className="text-[var(--primary)]" />
-              <span className="text-[0.625rem] font-medium">{device.name}</span>
-              <span className="text-[0.5rem] text-[var(--muted-foreground)]">
+              <span className="min-w-0 flex-1 truncate text-[0.625rem] font-medium">{device.name}</span>
+              <span className="min-w-0 flex-1 truncate text-[0.5rem] text-[var(--muted-foreground)]">
                 {device.capabilities.join(", ")}
               </span>
+              <button
+                type="button"
+                onClick={() => command.mutate({ deviceIndex: device.index, action: "stop" })}
+                disabled={stopActionPending}
+                className="text-[0.5625rem] font-medium text-[var(--muted-foreground)] hover:text-[var(--primary)] hover:underline disabled:opacity-50"
+              >
+                Stop
+              </button>
             </div>
           ))}
         </div>


### PR DESCRIPTION
## Linked issue

Part of #1566

## Why this change

- Restores the practical haptic control wiring surfaced by the Knip restore pass so connected Intiface devices can be scanned, stopped individually, and stopped as a group from the chat settings panel.
- Hardens the failure path so haptic action errors are shown instead of disappearing silently.
- Fixes the native command path so manual stop commands are not blocked by the normal haptic command rate limit.

## What changed

- Restored `Stop scan`, `Stop all`, and per-device `Stop` controls in the haptic settings panel.
- Added panel-level action error state that clears on retry and displays the most recent haptic action failure.
- Added component coverage for restored scan/stop routing and haptic action failure display.
- Updated the Rust haptic command handler so `action: "stop"` bypasses the command throttle while non-stop commands remain rate-limited.
- Added Rust unit coverage for stop-vs-non-stop rate-limit behavior.

## Refactor impact

Primary owner:

- Shared mode UI haptic settings and Rust haptic integration command handling.

Impact areas reviewed:

- `features/modes/shared/chat-ui` haptic settings panel behavior.
- `features/runtime/haptics` hook contracts.
- `src/shared/api/haptics-api.ts` command wrapper contract.
- `src-tauri/src/commands/storage/integrations/haptic.rs` native haptic command behavior.

Boundary notes:

- UI remains in `src/features`; it uses the existing runtime haptics hooks and focused shared API wrapper.
- No engine imports or raw Tauri calls were added from feature code.
- Rust owns the privileged Intiface command behavior and rate-limit enforcement.
- Haptic commands remain local-only in the existing Tauri path; no remote-runtime allowlist changes were made.

Pressure points touched:

- Shared mode UI settings component.
- Rust integrations command implementation.

## Validation

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

Commands run locally:

- `pnpm test -- src/features/modes/shared/chat-ui/components/settings/HapticConnectionPanel.test.tsx`
- `pnpm test -- src/shared/api/haptics-api.test.ts`
- `cargo test --manifest-path src-tauri/Cargo.toml haptic --lib`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `pnpm typecheck`
- `pnpm lint:eslint`
- `pnpm check:architecture`
- `pnpm check:unused`
- `pnpm build`
- `git diff --check`

Manual Tauri + real Intiface device QA was not run.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs changes were made; this is a focused restore/failure-path hardening slice for existing haptic controls.

## UI evidence

No screenshots or recordings added; native Intiface device QA remains manual.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Stop all" button to simultaneously control multiple haptic devices.
  * Added ability to cancel device scanning with "Stop scan" toggle.
  * Improved error messaging for failed haptic actions with centralized feedback.

* **Tests**
  * Added comprehensive test suite for haptic connection controls.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1588?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->