### PR TITLE
[codex] Restore upload size constant wiring

### DIFF
--- a/src/engine/contracts/constants/defaults.ts
+++ b/src/engine/contracts/constants/defaults.ts
@@ -36,6 +36,7 @@ export const DEFAULT_GENERATION_PARAMS: GenerationParameters = {
 export const MAX_FILE_SIZES = {
   AVATAR: 10 * 1024 * 1024, // 10 MB
   BACKGROUND: 20 * 1024 * 1024, // 20 MB
+  IMAGE_UPLOAD: 20 * 1024 * 1024, // 20 MB
   SPRITE: 10 * 1024 * 1024, // 10 MB
   CHARACTER_JSON: 5 * 1024 * 1024, // 5 MB
   LOREBOOK_JSON: 10 * 1024 * 1024, // 10 MB

--- a/src/shared/api/file-payload.test.ts
+++ b/src/shared/api/file-payload.test.ts
@@ -23,10 +23,10 @@ function fakeFile(size: number, bytes = [0x89, 0x50, 0x4e, 0x47]) {
 
 describe("fileToUploadPayload", () => {
   it("keeps the image upload limit and message tied to the shared upload constants", () => {
-    const expectedMib = MAX_FILE_SIZES.BACKGROUND / (1024 * 1024);
+    const expectedMib = MAX_FILE_SIZES.IMAGE_UPLOAD / (1024 * 1024);
     const expectedSize = Number.isInteger(expectedMib) ? expectedMib.toString() : expectedMib.toFixed(1);
 
-    expect(MAX_IMAGE_UPLOAD_BYTES).toBe(MAX_FILE_SIZES.BACKGROUND);
+    expect(MAX_IMAGE_UPLOAD_BYTES).toBe(MAX_FILE_SIZES.IMAGE_UPLOAD);
     expect(IMAGE_UPLOAD_SIZE_ERROR).toBe(`Image uploads must be ${expectedSize} MB or smaller`);
   });
 

--- a/src/shared/api/file-payload.test.ts
+++ b/src/shared/api/file-payload.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { MAX_FILE_SIZES } from "../../engine/contracts/constants/defaults";
 import { fileToUploadPayload, IMAGE_UPLOAD_SIZE_ERROR, MAX_IMAGE_UPLOAD_BYTES } from "./file-payload";
 
 function fakeFile(size: number, bytes = [0x89, 0x50, 0x4e, 0x47]) {
@@ -21,6 +22,14 @@ function fakeFile(size: number, bytes = [0x89, 0x50, 0x4e, 0x47]) {
 }
 
 describe("fileToUploadPayload", () => {
+  it("keeps the image upload limit and message tied to the shared upload constants", () => {
+    const expectedMib = MAX_FILE_SIZES.BACKGROUND / (1024 * 1024);
+    const expectedSize = Number.isInteger(expectedMib) ? expectedMib.toString() : expectedMib.toFixed(1);
+
+    expect(MAX_IMAGE_UPLOAD_BYTES).toBe(MAX_FILE_SIZES.BACKGROUND);
+    expect(IMAGE_UPLOAD_SIZE_ERROR).toBe(`Image uploads must be ${expectedSize} MB or smaller`);
+  });
+
   it("rejects oversized uploads before reading bytes", async () => {
     const upload = fakeFile(MAX_IMAGE_UPLOAD_BYTES + 1);
 

--- a/src/shared/api/file-payload.ts
+++ b/src/shared/api/file-payload.ts
@@ -12,7 +12,7 @@ function formatUploadSize(bytes: number) {
   return `${Number.isInteger(mib) ? mib.toString() : mib.toFixed(1)} MB`;
 }
 
-export const MAX_IMAGE_UPLOAD_BYTES = MAX_FILE_SIZES.BACKGROUND;
+export const MAX_IMAGE_UPLOAD_BYTES = MAX_FILE_SIZES.IMAGE_UPLOAD;
 export const IMAGE_UPLOAD_SIZE_ERROR = `Image uploads must be ${formatUploadSize(MAX_IMAGE_UPLOAD_BYTES)} or smaller`;
 
 interface FilePayloadOptions {

--- a/src/shared/api/file-payload.ts
+++ b/src/shared/api/file-payload.ts
@@ -1,3 +1,5 @@
+import { MAX_FILE_SIZES } from "../../engine/contracts/constants/defaults";
+
 export interface UploadFilePayload {
   name: string;
   type: string;
@@ -5,7 +7,7 @@ export interface UploadFilePayload {
   base64: string;
 }
 
-export const MAX_IMAGE_UPLOAD_BYTES = 20 * 1024 * 1024;
+export const MAX_IMAGE_UPLOAD_BYTES = MAX_FILE_SIZES.BACKGROUND;
 export const IMAGE_UPLOAD_SIZE_ERROR = "Image uploads must be 20 MB or smaller";
 
 interface FilePayloadOptions {

--- a/src/shared/api/file-payload.ts
+++ b/src/shared/api/file-payload.ts
@@ -7,8 +7,13 @@ export interface UploadFilePayload {
   base64: string;
 }
 
+function formatUploadSize(bytes: number) {
+  const mib = bytes / (1024 * 1024);
+  return `${Number.isInteger(mib) ? mib.toString() : mib.toFixed(1)} MB`;
+}
+
 export const MAX_IMAGE_UPLOAD_BYTES = MAX_FILE_SIZES.BACKGROUND;
-export const IMAGE_UPLOAD_SIZE_ERROR = "Image uploads must be 20 MB or smaller";
+export const IMAGE_UPLOAD_SIZE_ERROR = `Image uploads must be ${formatUploadSize(MAX_IMAGE_UPLOAD_BYTES)} or smaller`;
 
 interface FilePayloadOptions {
   maxBytes?: number;


### PR DESCRIPTION
## Linked issue

Refs #1566

## Why this change

Restore the orphaned upload-size constant wiring from the Knip follow-up queue so frontend image upload validation is driven by the shared engine constants instead of duplicated literals.

This keeps the user-facing error message and the actual upload limit tied together, while avoiding a hidden coupling between generic image uploads and the background-specific size key.

## What changed

- Added a dedicated `MAX_FILE_SIZES.IMAGE_UPLOAD` constant for shared image upload validation.
- Re-exported `MAX_IMAGE_UPLOAD_BYTES` from the shared API file-payload adapter using that constant.
- Derived `IMAGE_UPLOAD_SIZE_ERROR` from the same byte limit instead of hardcoding `20 MB` in the message.
- Added a focused test that locks the limit and message to the shared constant.

## Refactor impact

Primary owner:

Shared API wrapper / engine contracts.

Impact areas reviewed:

- Shared API file payload conversion.
- Settings background image upload callers.
- Gallery/image-generation upload callers.
- Shared `ImageUploadDropzone` usage.
- Rust-side image upload enforcement for matching current limits.

Boundary notes:

- Engine stays React-free; the shared API imports only the engine contract constants.
- No feature layer imports from engine internals were added.
- No Rust command or remote-runtime route changed.

Pressure points touched:

None; this is limited to engine constants and shared API upload payload handling.

## Validation

- [x] `pnpm check` passes locally
- [x] `pnpm typecheck` passes locally
- [x] `pnpm build` passes locally
- [x] `pnpm check:architecture` passes locally
- [x] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

AI-run validation:

- `pnpm test -- src/shared/api/file-payload.test.ts`
- `pnpm typecheck`
- `pnpm lint:eslint`
- `pnpm check:architecture`
- `pnpm check:unused`
- `pnpm build`
- `git diff --check`

No browser or Tauri manual pass was run because this slice only restores shared validation constants and unit-level coverage.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs changes needed: this is internal shared validation wiring, not a workflow, architecture, or user-facing documentation change.

## UI evidence

No UI evidence added; no visible UI layout or flow changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation tests to ensure image upload size constants remain consistent across the application.

* **Chores**
  * Consolidated image upload size configuration to a centralized source for improved code maintainability and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1589?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->