### PR TITLE
Align game asset MIME contracts

### DIFF
--- a/src-tauri/crates/assets/src/lib.rs
+++ b/src-tauri/crates/assets/src/lib.rs
@@ -615,7 +615,10 @@ fn sort_asset_rows(rows: &mut [Value]) {
 
 #[cfg(test)]
 mod tests {
-    use super::{ensure_upload_extension, AssetService};
+    use super::{
+        ensure_upload_extension, AssetService, AUDIO_EXTENSIONS, RASTER_IMAGE_EXTENSIONS,
+        SPRITE_IMAGE_EXTENSIONS,
+    };
     use std::fs;
     #[cfg(windows)]
     use std::io;
@@ -701,17 +704,20 @@ mod tests {
 
     #[test]
     fn accepts_client_advertised_game_asset_upload_extensions() {
-        for (category, filename) in [
-            ("music", "loop.webm"),
-            ("sfx", "hit.opus"),
-            ("ambient", "rain.flac"),
-            ("backgrounds", "scene.avif"),
-            ("sprites", "hero.svg"),
+        for (category, extensions) in [
+            ("music", AUDIO_EXTENSIONS),
+            ("sfx", AUDIO_EXTENSIONS),
+            ("ambient", AUDIO_EXTENSIONS),
+            ("backgrounds", RASTER_IMAGE_EXTENSIONS),
+            ("sprites", SPRITE_IMAGE_EXTENSIONS),
         ] {
-            assert!(
-                ensure_upload_extension(category, filename).is_ok(),
-                "{category} should accept {filename}"
-            );
+            for extension in extensions {
+                let filename = format!("asset.{extension}");
+                assert!(
+                    ensure_upload_extension(category, &filename).is_ok(),
+                    "{category} should accept {filename}"
+                );
+            }
         }
     }
 

--- a/src-tauri/crates/assets/src/lib.rs
+++ b/src-tauri/crates/assets/src/lib.rs
@@ -10,8 +10,10 @@ const MANAGED_GAME_ASSET_CATEGORIES: &[&str] =
     &["music", "sfx", "ambient", "sprites", "backgrounds"];
 const MAX_TEXT_ASSET_BYTES: usize = 1_000_000;
 const MAX_MEDIA_ASSET_BYTES: usize = 75 * 1024 * 1024;
-const IMAGE_EXTENSIONS: &[&str] = &["png", "jpg", "jpeg", "webp", "gif"];
-const AUDIO_EXTENSIONS: &[&str] = &["mp3", "ogg", "wav", "flac", "m4a", "aac", "opus"];
+const RASTER_IMAGE_EXTENSIONS: &[&str] = &["png", "jpg", "jpeg", "webp", "gif", "avif"];
+const SPRITE_IMAGE_EXTENSIONS: &[&str] = &["png", "jpg", "jpeg", "webp", "gif", "avif", "svg"];
+const AUDIO_EXTENSIONS: &[&str] =
+    &["mp3", "ogg", "wav", "flac", "m4a", "aac", "opus", "webm"];
 const TEXT_EXTENSIONS: &[&str] = &[
     "txt", "md", "markdown", "json", "jsonl", "yaml", "yml", "csv", "log",
 ];
@@ -474,7 +476,8 @@ fn ensure_upload_extension(category: &str, filename: &str) -> AppResult<()> {
         .unwrap_or_default();
     let allowed = match category {
         "music" | "sfx" | "ambient" => AUDIO_EXTENSIONS,
-        "sprites" | "backgrounds" => IMAGE_EXTENSIONS,
+        "sprites" => SPRITE_IMAGE_EXTENSIONS,
+        "backgrounds" => RASTER_IMAGE_EXTENSIONS,
         _ => &[],
     };
     if allowed.contains(&extension.as_str()) {
@@ -531,7 +534,7 @@ fn system_time_iso(value: Option<SystemTime>) -> String {
 }
 
 fn image_dimensions_for(path: &Path) -> (Option<u32>, Option<u32>) {
-    if !IMAGE_EXTENSIONS.contains(&path_extension(path).as_str()) {
+    if !RASTER_IMAGE_EXTENSIONS.contains(&path_extension(path).as_str()) {
         return (None, None);
     }
     image::image_dimensions(path)
@@ -612,7 +615,7 @@ fn sort_asset_rows(rows: &mut [Value]) {
 
 #[cfg(test)]
 mod tests {
-    use super::AssetService;
+    use super::{ensure_upload_extension, AssetService};
     use std::fs;
     #[cfg(windows)]
     use std::io;
@@ -694,5 +697,30 @@ mod tests {
         assert!(!outside.join("new.txt").exists());
 
         let _ = fs::remove_dir_all(sandbox);
+    }
+
+    #[test]
+    fn accepts_client_advertised_game_asset_upload_extensions() {
+        for (category, filename) in [
+            ("music", "loop.webm"),
+            ("sfx", "hit.opus"),
+            ("ambient", "rain.flac"),
+            ("backgrounds", "scene.avif"),
+            ("sprites", "hero.svg"),
+        ] {
+            assert!(
+                ensure_upload_extension(category, filename).is_ok(),
+                "{category} should accept {filename}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_svg_background_uploads() {
+        let error = ensure_upload_extension("backgrounds", "wall.svg")
+            .expect_err("background SVG uploads should stay sprite-only");
+
+        assert_eq!(error.code, "invalid_input");
+        assert!(error.message.contains("Can't upload .svg files to backgrounds"));
     }
 }

--- a/src/engine/contracts/constants/game-assets.test.ts
+++ b/src/engine/contracts/constants/game-assets.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { AUDIO_EXTS, AUDIO_MIME_MAP, GAME_ASSET_MIME_MAP, IMAGE_EXTS, IMAGE_MIME_MAP } from "./game-assets";
+
+describe("game asset MIME maps", () => {
+  it("covers every advertised image and audio extension", () => {
+    for (const extension of IMAGE_EXTS) {
+      expect(IMAGE_MIME_MAP[extension], `${extension} should have an image MIME type`).toBeTruthy();
+      expect(GAME_ASSET_MIME_MAP[extension], `${extension} should be present in the combined MIME map`).toBe(
+        IMAGE_MIME_MAP[extension],
+      );
+    }
+
+    for (const extension of AUDIO_EXTS) {
+      expect(AUDIO_MIME_MAP[extension], `${extension} should have an audio MIME type`).toBeTruthy();
+      expect(GAME_ASSET_MIME_MAP[extension], `${extension} should be present in the combined MIME map`).toBe(
+        AUDIO_MIME_MAP[extension],
+      );
+    }
+  });
+
+  it("keeps browser-preview MIME hints for WebM and Opus audio", () => {
+    expect(AUDIO_MIME_MAP[".webm"]).toBe("audio/webm");
+    expect(AUDIO_MIME_MAP[".opus"]).toBe("audio/ogg");
+  });
+});

--- a/src/engine/contracts/constants/game-assets.test.ts
+++ b/src/engine/contracts/constants/game-assets.test.ts
@@ -3,18 +3,24 @@ import { describe, expect, it } from "vitest";
 import { AUDIO_EXTS, AUDIO_MIME_MAP, GAME_ASSET_MIME_MAP, IMAGE_EXTS, IMAGE_MIME_MAP } from "./game-assets";
 
 describe("game asset MIME maps", () => {
-  it("covers every advertised image and audio extension", () => {
-    for (const extension of IMAGE_EXTS) {
-      expect(IMAGE_MIME_MAP[extension], `${extension} should have an image MIME type`).toBeTruthy();
+  function sorted(values: Iterable<string>) {
+    return Array.from(values).sort((left, right) => left.localeCompare(right));
+  }
+
+  it("keeps advertised extensions exactly aligned with MIME maps", () => {
+    expect(sorted(Object.keys(IMAGE_MIME_MAP))).toEqual(sorted(IMAGE_EXTS));
+    expect(sorted(Object.keys(AUDIO_MIME_MAP))).toEqual(sorted(AUDIO_EXTS));
+    expect(sorted(Object.keys(GAME_ASSET_MIME_MAP))).toEqual(sorted([...IMAGE_EXTS, ...AUDIO_EXTS]));
+
+    for (const extension of AUDIO_EXTS) {
       expect(GAME_ASSET_MIME_MAP[extension], `${extension} should be present in the combined MIME map`).toBe(
-        IMAGE_MIME_MAP[extension],
+        AUDIO_MIME_MAP[extension],
       );
     }
 
-    for (const extension of AUDIO_EXTS) {
-      expect(AUDIO_MIME_MAP[extension], `${extension} should have an audio MIME type`).toBeTruthy();
+    for (const extension of IMAGE_EXTS) {
       expect(GAME_ASSET_MIME_MAP[extension], `${extension} should be present in the combined MIME map`).toBe(
-        AUDIO_MIME_MAP[extension],
+        IMAGE_MIME_MAP[extension],
       );
     }
   });

--- a/src/engine/contracts/constants/game-assets.ts
+++ b/src/engine/contracts/constants/game-assets.ts
@@ -6,7 +6,16 @@
 export const IMAGE_EXTS: ReadonlySet<string> = new Set([".png", ".jpg", ".jpeg", ".gif", ".webp", ".avif", ".svg"]);
 
 /** Audio file extensions supported by the game-asset pipeline. */
-export const AUDIO_EXTS: ReadonlySet<string> = new Set([".mp3", ".ogg", ".wav", ".flac", ".m4a", ".aac", ".webm"]);
+export const AUDIO_EXTS: ReadonlySet<string> = new Set([
+  ".mp3",
+  ".ogg",
+  ".wav",
+  ".flac",
+  ".m4a",
+  ".aac",
+  ".webm",
+  ".opus",
+]);
 
 /** Text/code file extensions editable in the in-engine file browser. */
 export const TEXT_EXTS: ReadonlySet<string> = new Set([
@@ -31,6 +40,7 @@ export const AUDIO_MIME_MAP: Readonly<Record<string, string>> = {
   ".m4a": "audio/mp4",
   ".aac": "audio/aac",
   ".webm": "audio/webm",
+  ".opus": "audio/ogg",
 };
 
 /** MIME types for image responses (used by the server's file serving route). */

--- a/src/features/modes/game-assets/components/AudioPlayerModal.tsx
+++ b/src/features/modes/game-assets/components/AudioPlayerModal.tsx
@@ -2,7 +2,7 @@
 // File Browser — Audio player with format fallback
 // ──────────────────────────────────────────────
 import { useEffect, useState } from "react";
-import { AUDIO_MIME_MAP } from "../../../../engine/contracts/constants/game-assets";
+import { AUDIO_MIME_MAP, GAME_ASSET_MIME_MAP } from "../../../../engine/contracts/constants/game-assets";
 import { resolveGameAssetFileUrl } from "../../../../shared/api/local-file-api";
 
 /**
@@ -24,7 +24,7 @@ export function AudioPlayerModal({
 }) {
   const lastDot = name.lastIndexOf(".");
   const ext = lastDot >= 0 ? name.slice(lastDot).toLowerCase() : "";
-  const mime = AUDIO_MIME_MAP[ext] || "audio/mpeg";
+  const mime = GAME_ASSET_MIME_MAP[ext] ?? AUDIO_MIME_MAP[ext] ?? "audio/mpeg";
   const [playError, setPlayError] = useState(false);
   const [src, setSrc] = useState("");
 

--- a/src/features/modes/game-assets/components/AudioPlayerModal.tsx
+++ b/src/features/modes/game-assets/components/AudioPlayerModal.tsx
@@ -2,7 +2,7 @@
 // File Browser — Audio player with format fallback
 // ──────────────────────────────────────────────
 import { useEffect, useState } from "react";
-import { AUDIO_MIME_MAP, GAME_ASSET_MIME_MAP } from "../../../../engine/contracts/constants/game-assets";
+import { GAME_ASSET_MIME_MAP } from "../../../../engine/contracts/constants/game-assets";
 import { resolveGameAssetFileUrl } from "../../../../shared/api/local-file-api";
 
 /**
@@ -13,18 +13,10 @@ import { resolveGameAssetFileUrl } from "../../../../shared/api/local-file-api";
  * @param name - File name (used for extension detection and display)
  * @param onClose - Callback when modal should close
  */
-export function AudioPlayerModal({
-  path,
-  name,
-  onClose,
-}: {
-  path: string;
-  name: string;
-  onClose: () => void;
-}) {
+export function AudioPlayerModal({ path, name, onClose }: { path: string; name: string; onClose: () => void }) {
   const lastDot = name.lastIndexOf(".");
   const ext = lastDot >= 0 ? name.slice(lastDot).toLowerCase() : "";
-  const mime = GAME_ASSET_MIME_MAP[ext] ?? AUDIO_MIME_MAP[ext] ?? "audio/mpeg";
+  const mime = GAME_ASSET_MIME_MAP[ext] ?? "audio/mpeg";
   const [playError, setPlayError] = useState(false);
   const [src, setSrc] = useState("");
 
@@ -63,12 +55,7 @@ export function AudioPlayerModal({
         onClick={(e) => e.stopPropagation()}
       >
         <h3 className="mb-4 text-sm font-semibold text-(--foreground)">{name}</h3>
-        <audio
-          controls
-          className="w-full"
-          autoPlay
-          onError={() => setPlayError(true)}
-        >
+        <audio controls className="w-full" autoPlay onError={() => setPlayError(true)}>
           {src && <source src={src} type={mime} />}
           Your browser does not support the audio element.
         </audio>

--- a/src/features/shell/settings/components/SettingsPanel.tsx
+++ b/src/features/shell/settings/components/SettingsPanel.tsx
@@ -36,6 +36,7 @@ import {
 import { checkRemoteRuntimeHealth, type RemoteRuntimeHealthCheck } from "../../../../shared/api/remote-runtime";
 import React, { useRef, useState, useCallback, useEffect } from "react";
 import { toast } from "sonner";
+import { AUDIO_MIME_MAP, IMAGE_MIME_MAP } from "../../../../engine/contracts/constants/game-assets";
 import type { Theme } from "../../../../engine/contracts/types/theme";
 import {
   findDuplicateTheme,
@@ -244,36 +245,50 @@ const TRACKER_PANEL_CARD_OPTIONS: Record<TrackerDataPanelSection, { label: strin
   },
 };
 
+const GAME_AUDIO_ASSET_EXTENSIONS = Object.keys(AUDIO_MIME_MAP);
+const GAME_AUDIO_ASSET_MIME_TYPES = Array.from(new Set(Object.values(AUDIO_MIME_MAP)));
+const GAME_AUDIO_ASSET_ACCEPT = [...GAME_AUDIO_ASSET_MIME_TYPES, ...GAME_AUDIO_ASSET_EXTENSIONS].join(",");
+const GAME_RASTER_IMAGE_ASSET_EXTENSIONS = Object.keys(IMAGE_MIME_MAP).filter((extension) => extension !== ".svg");
+const GAME_SPRITE_IMAGE_ASSET_EXTENSIONS = Object.keys(IMAGE_MIME_MAP);
+const GAME_RASTER_IMAGE_ASSET_ACCEPT = [
+  ...new Set(GAME_RASTER_IMAGE_ASSET_EXTENSIONS.map((extension) => IMAGE_MIME_MAP[extension])),
+  ...GAME_RASTER_IMAGE_ASSET_EXTENSIONS,
+].join(",");
+const GAME_SPRITE_IMAGE_ASSET_ACCEPT = [
+  ...new Set(GAME_SPRITE_IMAGE_ASSET_EXTENSIONS.map((extension) => IMAGE_MIME_MAP[extension])),
+  ...GAME_SPRITE_IMAGE_ASSET_EXTENSIONS,
+].join(",");
+
 const GAME_ASSET_CATEGORIES = [
   {
     id: "music",
     label: "Music",
     defaultFolder: "exploration/fantasy/calm",
-    accept: "audio/*,.mp3,.ogg,.wav,.flac,.m4a,.aac,.webm",
+    accept: GAME_AUDIO_ASSET_ACCEPT,
   },
   {
     id: "ambient",
     label: "Ambient",
     defaultFolder: "nature",
-    accept: "audio/*,.mp3,.ogg,.wav,.flac,.m4a,.aac,.webm",
+    accept: GAME_AUDIO_ASSET_ACCEPT,
   },
   {
     id: "sfx",
     label: "Sound Effects",
     defaultFolder: "exploration",
-    accept: "audio/*,.mp3,.ogg,.wav,.flac,.m4a,.aac,.webm",
+    accept: GAME_AUDIO_ASSET_ACCEPT,
   },
   {
     id: "sprites",
     label: "Sprites",
     defaultFolder: "generic-fantasy",
-    accept: "image/*,.svg",
+    accept: GAME_SPRITE_IMAGE_ASSET_ACCEPT,
   },
   {
     id: "backgrounds",
     label: "Backgrounds",
     defaultFolder: "custom",
-    accept: "image/*",
+    accept: GAME_RASTER_IMAGE_ASSET_ACCEPT,
   },
 ] as const;
 
@@ -1251,8 +1266,8 @@ function GeneralSettings() {
 
         <p className="mt-2.5 text-[0.625rem] leading-relaxed text-[var(--muted-foreground)]">
           On desktop, folder buttons open the local app asset folders. Use upload to copy files into Marinara's managed
-          data directory. Audio supports MP3, OGG, WAV, FLAC, M4A, AAC, and WebM; images support PNG, JPG, GIF, WebP,
-          AVIF, and SVG for sprites. Music folders use state/genre/intensity, such as exploration/fantasy/calm.
+          data directory. Audio supports MP3, OGG, WAV, FLAC, M4A, AAC, WebM, and Opus; images support PNG, JPG, GIF,
+          WebP, AVIF, and SVG for sprites. Music folders use state/genre/intensity, such as exploration/fantasy/calm.
         </p>
       </div>
     </div>

--- a/src/shared/components/ui/ImageUploadDropzone.tsx
+++ b/src/shared/components/ui/ImageUploadDropzone.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState, type ChangeEvent, type DragEvent, type ReactNode } from "react";
 import { toast } from "sonner";
 
+import { IMAGE_MIME_MAP } from "../../../engine/contracts/constants/game-assets";
 import { MAX_IMAGE_UPLOAD_BYTES } from "../../api/file-payload";
 import { cn } from "../../lib/utils";
 
@@ -20,7 +21,12 @@ interface ImageUploadDropzoneProps {
   maxFileSizeBytes?: number;
 }
 
-const IMAGE_EXTENSION_PATTERN = /\.(avif|gif|jpe?g|png|webp)$/i;
+const UPLOAD_IMAGE_EXTENSIONS = Object.keys(IMAGE_MIME_MAP).filter((extension) => extension !== ".svg");
+const IMAGE_EXTENSION_PATTERN = new RegExp(
+  `(${UPLOAD_IMAGE_EXTENSIONS.map((extension) => extension.replace(".", "\\.")).join("|")})$`,
+  "i",
+);
+const DEFAULT_IMAGE_ACCEPT = ["image/*", ...UPLOAD_IMAGE_EXTENSIONS].join(",");
 const DEFAULT_MAX_IMAGE_FILES = 50;
 const DEFAULT_MAX_IMAGE_BYTES = MAX_IMAGE_UPLOAD_BYTES;
 
@@ -47,7 +53,7 @@ export function ImageUploadDropzone({
   pendingLabel = "Uploading...",
   dragLabel = "Drop images to upload",
   className,
-  accept = "image/*",
+  accept = DEFAULT_IMAGE_ACCEPT,
   multiple = true,
   disabled = false,
   ariaLabel,

--- a/src/shared/components/ui/ImageUploadDropzone.tsx
+++ b/src/shared/components/ui/ImageUploadDropzone.tsx
@@ -21,12 +21,15 @@ interface ImageUploadDropzoneProps {
   maxFileSizeBytes?: number;
 }
 
-const UPLOAD_IMAGE_EXTENSIONS = Object.keys(IMAGE_MIME_MAP).filter((extension) => extension !== ".svg");
+const UPLOAD_IMAGE_ENTRIES = Object.entries(IMAGE_MIME_MAP).filter(([extension]) => extension !== ".svg");
+const UPLOAD_IMAGE_EXTENSIONS = UPLOAD_IMAGE_ENTRIES.map(([extension]) => extension);
+const UPLOAD_IMAGE_MIME_TYPES = Array.from(new Set(UPLOAD_IMAGE_ENTRIES.map(([, mime]) => mime)));
+const UPLOAD_IMAGE_MIME_TYPE_SET = new Set(UPLOAD_IMAGE_MIME_TYPES);
 const IMAGE_EXTENSION_PATTERN = new RegExp(
   `(${UPLOAD_IMAGE_EXTENSIONS.map((extension) => extension.replace(".", "\\.")).join("|")})$`,
   "i",
 );
-const DEFAULT_IMAGE_ACCEPT = ["image/*", ...UPLOAD_IMAGE_EXTENSIONS].join(",");
+const DEFAULT_IMAGE_ACCEPT = [...UPLOAD_IMAGE_MIME_TYPES, ...UPLOAD_IMAGE_EXTENSIONS].join(",");
 const DEFAULT_MAX_IMAGE_FILES = 50;
 const DEFAULT_MAX_IMAGE_BYTES = MAX_IMAGE_UPLOAD_BYTES;
 
@@ -35,9 +38,10 @@ function isFileDrag(event: DragEvent<HTMLElement>) {
 }
 
 function getSupportedImageFiles(files: FileList | null) {
-  return Array.from(files ?? []).filter(
-    (file) => file.type.startsWith("image/") || IMAGE_EXTENSION_PATTERN.test(file.name),
-  );
+  return Array.from(files ?? []).filter((file) => {
+    const mimeType = file.type.trim().toLowerCase();
+    return (mimeType !== "" && UPLOAD_IMAGE_MIME_TYPE_SET.has(mimeType)) || IMAGE_EXTENSION_PATTERN.test(file.name);
+  });
 }
 
 function formatBytes(bytes: number) {


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

No linked issue.

## Why this change

- Game asset MIME and extension support drifted between the TypeScript constants, Settings file pickers, browser audio hints, shared image upload filtering, and the Rust managed-asset upload gate.
- The drift could make the UI advertise files that native upload rejected, or let drag/drop accept image MIME types that were not part of the intended raster upload contract.

## What changed

- Added Opus to the TypeScript game asset audio extension and MIME maps.
- Derived Settings game-asset file picker accept strings from the shared MIME maps.
- Updated managed game asset upload validation in Rust to accept WebM audio, Opus audio, AVIF backgrounds, and SVG sprites while keeping SVG rejected for backgrounds.
- Tightened the shared image upload dropzone to accept only known raster image MIME types or extensions by default.
- Switched the audio preview modal to use the combined game asset MIME map.
- Added focused TypeScript and Rust tests for the advertised file-type contracts and SVG-background negative path.

## Refactor impact

Primary owner:

Engine contracts, shared UI, shell settings, game asset UI, and Rust assets capability.

Impact areas reviewed:

- Managed game asset upload categories.
- Settings game-asset upload file picker copy and accept values.
- Generic image dropzone callers for backgrounds, chat gallery, and character gallery.
- Audio preview MIME hinting.
- Rust asset upload extension validation.

Boundary notes:

- React-free constants remain in `src/engine/contracts`.
- Shared and feature UI consume constants only; no raw Tauri or remote-runtime calls were added.
- Privileged upload enforcement remains in `src-tauri/crates/assets`.
- No shared API command shape or remote runtime allowlist changed.

Pressure points touched:

- `SettingsPanel` was touched only in its existing game-asset upload constants/copy.
- Did not touch `ModeSurface`, `GameSurface`, shared mode UI, `src-tauri/src/lib.rs`, or import modules.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->

- [x] `pnpm check` passes locally
- [x] `pnpm typecheck` passes locally
- [x] `pnpm build` passes locally
- [x] `pnpm check:architecture` passes locally
- [x] `pnpm check:docs` passes locally
- [x] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [x] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- `pnpm test -- src/engine/contracts/constants/game-assets.test.ts` passed.
- `cargo test --manifest-path src-tauri/Cargo.toml -p marinara-assets` passed.
- `pnpm build` passed; Vite reported the existing large-chunk warning.
- `pnpm check:architecture` passed.
- `pnpm check:unused` passed.
- `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passed.
- Bunny pass found no confirmed findings.
- Native Tauri upload and audio playback were not manually exercised.

## Docs and release impact

- No `CHANGELOG.md` exists in the repo.
- Settings copy was updated to mention Opus support.
- No developer docs, repo skills, or agent workflow changes were needed.

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

No screenshots or recordings added; this is a file-type contract and upload validation fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Opus audio format support for game assets

* **Improvements**
  * Enhanced file upload validation with category-specific format rules
  * Upload dialogs now dynamically display supported formats based on asset type
  * Improved file type detection accuracy for audio and image uploads

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1591?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->