### PR TITLE
Narrow feature hook export surface

### DIFF
--- a/src/features/catalog/chats/hooks/use-chat-folders.ts
+++ b/src/features/catalog/chats/hooks/use-chat-folders.ts
@@ -6,7 +6,7 @@ import { storageApi } from "../../../../shared/api/storage-api";
 import type { ChatFolder } from "../../../../engine/contracts/types/chat";
 import { chatKeys } from "./use-chats";
 
-export const folderKeys = {
+const folderKeys = {
   all: ["chat-folders"] as const,
   list: () => [...folderKeys.all, "list"] as const,
 };

--- a/src/features/catalog/connections/hooks/use-connection-folders.ts
+++ b/src/features/catalog/connections/hooks/use-connection-folders.ts
@@ -6,7 +6,7 @@ import { storageApi } from "../../../../shared/api/storage-api";
 import type { ConnectionFolder } from "../../../../engine/contracts/types/connection";
 import { connectionKeys } from "./use-connections";
 
-export const connectionFolderKeys = {
+const connectionFolderKeys = {
   all: ["connection-folders"] as const,
   list: () => [...connectionFolderKeys.all, "list"] as const,
 };

--- a/src/features/catalog/personas/hooks/use-personas.ts
+++ b/src/features/catalog/personas/hooks/use-personas.ts
@@ -4,8 +4,6 @@ import { personaApi } from "../../../../shared/api/persona-api";
 import { storageApi } from "../../../../shared/api/storage-api";
 import { storageCommandsApi } from "../../../../shared/api/storage-commands-api";
 
-export { personaKeys } from "../query-keys";
-
 export function usePersonas() {
   return useQuery({
     queryKey: personaKeys.list,

--- a/src/features/modes/game-assets/hooks/use-game-assets.ts
+++ b/src/features/modes/game-assets/hooks/use-game-assets.ts
@@ -31,7 +31,7 @@ export interface TreeNode {
 }
 
 /** TanStack Query key factory for game-assets queries. */
-export const gameAssetKeys = {
+const gameAssetKeys = {
   all: ["game-assets"] as const,
   tree: () => [...gameAssetKeys.all, "tree"] as const,
   content: (path: string) => [...gameAssetKeys.all, "content", path] as const,

--- a/src/features/shell/settings/hooks/use-extensions.ts
+++ b/src/features/shell/settings/hooks/use-extensions.ts
@@ -6,7 +6,7 @@ import { storageApi } from "../../../../shared/api/storage-api";
 import type { CreateExtensionInput, UpdateExtensionInput } from "../../../../engine/contracts/schemas/extension.schema";
 import type { InstalledExtension } from "../../../../engine/contracts/types/extension";
 
-export const extensionKeys = {
+const extensionKeys = {
   all: ["extensions"] as const,
   list: () => [...extensionKeys.all, "list"] as const,
 };

--- a/src/features/shell/settings/hooks/use-prompt-overrides.ts
+++ b/src/features/shell/settings/hooks/use-prompt-overrides.ts
@@ -1,22 +1,13 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { promptOverridesApi } from "../api/prompt-overrides-api";
 import type {
-  PromptOverrideDefault,
   PromptOverrideDetail,
-  PromptOverrideRow,
   PromptOverrideSummary,
-  PromptOverrideVariable,
 } from "../../../../engine/generation/prompt-overrides";
 
-export type {
-  PromptOverrideDefault,
-  PromptOverrideDetail,
-  PromptOverrideRow,
-  PromptOverrideSummary,
-  PromptOverrideVariable,
-};
+export type { PromptOverrideDetail, PromptOverrideSummary };
 
-export const promptOverrideKeys = {
+const promptOverrideKeys = {
   all: ["prompt-overrides"] as const,
   list: () => [...promptOverrideKeys.all, "list"] as const,
   detail: (key: string) => [...promptOverrideKeys.all, "detail", key] as const,

--- a/src/features/shell/settings/hooks/use-themes.ts
+++ b/src/features/shell/settings/hooks/use-themes.ts
@@ -6,7 +6,7 @@ import { storageApi } from "../../../../shared/api/storage-api";
 import type { CreateThemeInput, UpdateThemeInput } from "../../../../engine/contracts/schemas/theme.schema";
 import type { Theme } from "../../../../engine/contracts/types/theme";
 
-export const themeKeys = {
+const themeKeys = {
   all: ["themes"] as const,
   list: () => [...themeKeys.all, "list"] as const,
 };


### PR DESCRIPTION
Linked issue: Refs #1566

Why: Continue the practical Knip restore/classification queue by narrowing feature-owned hook exports that are implementation-only.

What changed:
- Made several React Query key factories private to their hook modules.
- Removed the unused `personaKeys` re-export from persona hooks.
- Narrowed prompt override hook type re-exports to the types consumed by feature UI.

Validation:
- pnpm exec knip --exports --no-config-hints --reporter compact --no-exit-code
- pnpm typecheck
- pnpm check:architecture
- pnpm check:unused
- pnpm build
- pnpm check
- git diff --check

UI evidence: N/A, export-surface-only cleanup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code reorganization: Query and configuration keys have been made module-private to reduce public API surface and improve encapsulation. No changes to user-facing functionality or behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1597?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->