### PR TITLE
Remove unreferenced feature hook exports

### DIFF
--- a/src/features/catalog/agents/hooks/use-agents.ts
+++ b/src/features/catalog/agents/hooks/use-agents.ts
@@ -9,7 +9,6 @@ import { storageApi } from "../../../../shared/api/storage-api";
 
 export const agentKeys = {
   all: ["agents"] as const,
-  detail: (id: string) => ["agents", id] as const,
   customRuns: (chatId: string) => ["agents", "runs", "custom", chatId] as const,
 };
 
@@ -50,15 +49,6 @@ export function useAgentConfigs(enabled = true) {
     queryKey: agentKeys.all,
     queryFn: () => storageApi.list<AgentConfigRow>("agents"),
     enabled,
-    staleTime: 5 * 60_000,
-  });
-}
-
-export function useAgentConfig(id: string | null) {
-  return useQuery({
-    queryKey: agentKeys.detail(id ?? ""),
-    queryFn: () => storageApi.get<AgentConfigRow>("agents", id!),
-    enabled: !!id,
     staleTime: 5 * 60_000,
   });
 }
@@ -113,16 +103,6 @@ export function useUpdateAgentRunData() {
       storageApi.update("agent-runs", id, { resultData }),
     onSuccess: (_data, variables) => {
       qc.invalidateQueries({ queryKey: agentKeys.customRuns(variables.chatId) });
-    },
-  });
-}
-
-export function useToggleAgent() {
-  const qc = useQueryClient();
-  return useMutation({
-    mutationFn: (agentType: string) => agentApi.toggleByType(agentType),
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: agentKeys.all });
     },
   });
 }

--- a/src/features/catalog/agents/hooks/use-custom-tools.ts
+++ b/src/features/catalog/agents/hooks/use-custom-tools.ts
@@ -38,7 +38,6 @@ export function isCustomToolSelectable(tool: CustomToolRow, _capabilities?: Cust
 
 const toolKeys = {
   all: ["custom-tools"] as const,
-  detail: (id: string) => ["custom-tools", id] as const,
   capabilities: ["custom-tools", "capabilities"] as const,
 };
 
@@ -46,14 +45,6 @@ export function useCustomTools() {
   return useQuery({
     queryKey: toolKeys.all,
     queryFn: () => storageApi.list<CustomToolRow>("custom-tools"),
-  });
-}
-
-export function useCustomTool(id: string | null) {
-  return useQuery({
-    queryKey: toolKeys.detail(id ?? ""),
-    queryFn: () => storageApi.get<CustomToolRow>("custom-tools", id!),
-    enabled: !!id,
   });
 }
 

--- a/src/features/catalog/agents/hooks/use-regex-scripts.ts
+++ b/src/features/catalog/agents/hooks/use-regex-scripts.ts
@@ -7,7 +7,6 @@ import { storageApi } from "../../../../shared/api/storage-api";
 
 const regexKeys = {
   all: ["regex-scripts"] as const,
-  detail: (id: string) => ["regex-scripts", id] as const,
 };
 
 export interface RegexScriptRow {
@@ -31,14 +30,6 @@ export function useRegexScripts() {
   return useQuery({
     queryKey: regexKeys.all,
     queryFn: () => storageApi.list<RegexScriptRow>("regex-scripts"),
-  });
-}
-
-export function useRegexScript(id: string | null) {
-  return useQuery({
-    queryKey: regexKeys.detail(id ?? ""),
-    queryFn: () => storageApi.get<RegexScriptRow>("regex-scripts", id!),
-    enabled: !!id,
   });
 }
 

--- a/src/features/catalog/chat-presets/hooks/use-chat-presets.ts
+++ b/src/features/catalog/chat-presets/hooks/use-chat-presets.ts
@@ -3,10 +3,7 @@
 // ──────────────────────────────────────────────
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { chatPresetKeys } from "../query-keys";
-import {
-  chatPresetSettingsSchema,
-  createChatPresetSchema,
-} from "../../../../engine/contracts/schemas/chat-preset.schema";
+import { chatPresetSettingsSchema } from "../../../../engine/contracts/schemas/chat-preset.schema";
 import { storageApi } from "../../../../shared/api/storage-api";
 import { storageCommandsApi } from "../../../../shared/api/storage-commands-api";
 import { chatKeys } from "../../chats/query-keys";
@@ -64,43 +61,6 @@ export function useChatPresets(mode?: ChatMode | null) {
     },
     staleTime: 60_000,
     refetchOnWindowFocus: false,
-  });
-}
-
-export function useActiveChatPreset(mode: ChatMode | null) {
-  return useQuery({
-    queryKey: mode ? chatPresetKeys.active(mode) : chatPresetKeys.all,
-    queryFn: async () => {
-      const presets = await storageApi.list<ChatPreset>("chat-presets");
-      return (
-        presets.find(
-          (preset) =>
-            preset.mode === mode &&
-            ((preset as ChatPreset & { isActive?: boolean; active?: boolean }).isActive ||
-              (preset as ChatPreset & { isActive?: boolean; active?: boolean }).active),
-        ) ??
-        presets.find((preset) => preset.mode === mode) ??
-        null
-      );
-    },
-    enabled: !!mode,
-    staleTime: 60_000,
-    refetchOnWindowFocus: false,
-  });
-}
-
-export function useCreateChatPreset() {
-  const qc = useQueryClient();
-  return useMutation({
-    mutationFn: (data: { name: string; mode: ChatMode; settings?: ChatPresetSettings }) =>
-      storageApi.create<ChatPreset>(
-        "chat-presets",
-        createChatPresetSchema.parse({
-          ...data,
-          settings: sanitizeChatPresetSettings(data.settings),
-        }),
-      ),
-    onSuccess: () => qc.invalidateQueries({ queryKey: chatPresetKeys.all }),
   });
 }
 

--- a/src/features/catalog/chats/hooks/use-chat-folders.ts
+++ b/src/features/catalog/chats/hooks/use-chat-folders.ts
@@ -76,17 +76,3 @@ export function useMoveChat() {
     onSuccess: () => qc.invalidateQueries({ queryKey: chatKeys.list() }),
   });
 }
-
-export function useReorderChats() {
-  const qc = useQueryClient();
-  return useMutation({
-    mutationFn: async (data: { orderedChatIds: string[]; folderId: string | null }) => {
-      await Promise.all(
-        data.orderedChatIds.map((id, index) =>
-          storageApi.update("chats", id, { sortOrder: index, order: index, folderId: data.folderId }),
-        ),
-      );
-    },
-    onSuccess: () => qc.invalidateQueries({ queryKey: chatKeys.list() }),
-  });
-}

--- a/src/features/catalog/personas/hooks/use-personas.ts
+++ b/src/features/catalog/personas/hooks/use-personas.ts
@@ -4,15 +4,6 @@ import { personaApi } from "../../../../shared/api/persona-api";
 import { storageApi } from "../../../../shared/api/storage-api";
 import { storageCommandsApi } from "../../../../shared/api/storage-commands-api";
 
-export function usePersonas() {
-  return useQuery({
-    queryKey: personaKeys.list,
-    queryFn: () => storageApi.list<unknown>("personas"),
-    staleTime: 5 * 60_000,
-    refetchOnWindowFocus: false,
-  });
-}
-
 export function useUpdatePersona() {
   const qc = useQueryClient();
   return useMutation({


### PR DESCRIPTION
## Linked issue

Refs #1566

## Why this change

- Continue the Knip restore follow-up by trimming feature-owned React Query hooks that no current feature imports.

## What changed

- Removed unreferenced agent, custom tool, regex script, chat preset, chat folder, and persona hook exports.
- Removed the now-unused per-record query-key helpers and `createChatPresetSchema` import that only supported those deleted exports.

## Refactor impact

Primary owner:

- `src/features`

Impact areas reviewed:

- Catalog agent hooks
- Catalog custom tool hooks
- Catalog regex script hooks
- Catalog chat preset hooks
- Catalog chat folder hooks
- Catalog persona hooks

Boundary notes:

- This stays inside feature-owned hook modules.
- No engine contract, shared API, Rust, storage, or remote-runtime boundary changes.

Pressure points touched:

- None. No ModeSurface, GameSurface, shared mode UI, command registration, or import modules touched.

## Validation

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Codex ran `pnpm exec knip --exports --no-config-hints --reporter compact --no-exit-code`; unused exports dropped from 95 to 89 and unused exported types stayed at 71.
- Codex ran `pnpm typecheck`.
- Codex ran `pnpm check:architecture`.
- Codex ran `pnpm check:unused`.
- Codex ran `pnpm build`.
- Codex ran `pnpm check`, including `cargo check --manifest-path src-tauri/Cargo.toml --workspace`.
- Codex ran `git diff --check`.
- Browser/Tauri manual verification was not run because this is deletion-only cleanup of unreferenced hook exports with no reachable UI call sites.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A - no visible UI behavior changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal data fetching patterns across catalog features including agents, custom tools, regex scripts, chat presets, chat folders, and personas.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1599?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->