### PR TITLE
Narrow character catalog hook exports

### DIFF
--- a/src/features/catalog/characters/hooks/use-characters.ts
+++ b/src/features/catalog/characters/hooks/use-characters.ts
@@ -7,10 +7,8 @@ import { characterKeys, spriteKeys } from "../query-keys";
 import {
   createCharacterSchema,
   createGroupSchema,
-  createPersonaGroupSchema,
   updateCharacterSchema,
   updateGroupSchema,
-  updatePersonaGroupSchema,
 } from "../../../../engine/contracts/schemas/character.schema";
 import { characterApi } from "../../../../shared/api/character-api";
 import { storageApi } from "../../../../shared/api/storage-api";
@@ -89,7 +87,7 @@ function listCharacterSummaries(): Promise<CharacterSummary[]> {
   return storageApi.list<CharacterSummary>("characters", CHARACTER_SUMMARY_OPTIONS);
 }
 
-export function upsertCharacterListRecord(current: unknown[] | undefined, record: unknown): unknown[] | undefined {
+function upsertCharacterListRecord(current: unknown[] | undefined, record: unknown): unknown[] | undefined {
   if (!isCharacterListRecord(record)) return current;
   if (!Array.isArray(current)) return current;
 
@@ -101,7 +99,7 @@ export function upsertCharacterListRecord(current: unknown[] | undefined, record
   );
 }
 
-export function removeCharacterListRecord(current: unknown[] | undefined, id: string): unknown[] | undefined {
+function removeCharacterListRecord(current: unknown[] | undefined, id: string): unknown[] | undefined {
   if (!Array.isArray(current)) return current;
   return current.filter((item) => !isCharacterListRecord(item) || item.id !== id);
 }
@@ -564,25 +562,6 @@ export function usePersonaSummaries(enabled = true) {
   });
 }
 
-export function usePersonaSummariesByIds(ids: string[], enabled = true) {
-  const uniqueIds = Array.from(new Set(ids.map((id) => id.trim()).filter(Boolean)));
-  const queries = useQueries({
-    queries: uniqueIds.map((id) => ({
-      queryKey: characterKeys.personaSummaryDetail(id),
-      queryFn: () => storageApi.get<PersonaSummary>("personas", id, PERSONA_SUMMARY_OPTIONS),
-      enabled: enabled && !!id,
-      staleTime: 5 * 60_000,
-      refetchOnWindowFocus: false,
-    })),
-  });
-
-  return {
-    data: queries.map((query) => query.data).filter(Boolean),
-    isLoading: queries.some((query) => query.isLoading),
-    isFetching: queries.some((query) => query.isFetching),
-  };
-}
-
 export function usePersona(id: string | null, enabled = true) {
   return useQuery({
     queryKey: characterKeys.personaDetail(id ?? ""),
@@ -705,29 +684,6 @@ export function useDeletePersona() {
   });
 }
 
-export function useDuplicatePersona() {
-  const qc = useQueryClient();
-  return useMutation({
-    mutationFn: (id: string) => storageCommandsApi.duplicate("personas", id),
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: characterKeys.personas });
-      qc.invalidateQueries({ queryKey: characterKeys.personaSummaries });
-    },
-  });
-}
-
-export function useActivatePersona() {
-  const qc = useQueryClient();
-  return useMutation({
-    mutationFn: (id: string) => personaApi.activate(id),
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: characterKeys.personas });
-      qc.invalidateQueries({ queryKey: characterKeys.personaSummaries });
-      qc.invalidateQueries({ queryKey: characterKeys.activePersona });
-    },
-  });
-}
-
 export function useUploadPersonaAvatar() {
   const qc = useQueryClient();
   return useMutation({
@@ -748,14 +704,6 @@ export function useCharacterGroups() {
   return useQuery({
     queryKey: characterKeys.groups,
     queryFn: () => storageApi.list<unknown>("character-groups"),
-  });
-}
-
-export function useCharacterGroup(id: string | null) {
-  return useQuery({
-    queryKey: characterKeys.groupDetail(id ?? ""),
-    queryFn: () => storageApi.get("character-groups", id!),
-    enabled: !!id,
   });
 }
 
@@ -792,31 +740,5 @@ export function usePersonaGroups(enabled = true) {
     queryKey: characterKeys.personaGroups,
     queryFn: () => storageApi.list<unknown>("persona-groups"),
     enabled,
-  });
-}
-
-export function useCreatePersonaGroup() {
-  const qc = useQueryClient();
-  return useMutation({
-    mutationFn: (data: { name: string; description?: string; personaIds?: string[] }) =>
-      storageApi.create("persona-groups", createPersonaGroupSchema.parse(data)),
-    onSuccess: () => qc.invalidateQueries({ queryKey: characterKeys.personaGroups }),
-  });
-}
-
-export function useUpdatePersonaGroup() {
-  const qc = useQueryClient();
-  return useMutation({
-    mutationFn: ({ id, ...data }: { id: string; name?: string; description?: string; personaIds?: string[] }) =>
-      storageApi.update("persona-groups", id, updatePersonaGroupSchema.parse(data)),
-    onSuccess: () => qc.invalidateQueries({ queryKey: characterKeys.personaGroups }),
-  });
-}
-
-export function useDeletePersonaGroup() {
-  const qc = useQueryClient();
-  return useMutation({
-    mutationFn: (id: string) => storageApi.delete("persona-groups", id),
-    onSuccess: () => qc.invalidateQueries({ queryKey: characterKeys.personaGroups }),
   });
 }

--- a/src/features/catalog/characters/query-keys.ts
+++ b/src/features/catalog/characters/query-keys.ts
@@ -12,7 +12,6 @@ export const characterKeys = {
   personaDetail: (id: string) => [...characterKeys.personas, "detail", id] as const,
   activePersona: ["personas", "active"] as const,
   groups: ["character-groups"] as const,
-  groupDetail: (id: string) => ["character-groups", "detail", id] as const,
   personaGroups: ["persona-groups"] as const,
   personaGroupDetail: (id: string) => ["persona-groups", "detail", id] as const,
 };


### PR DESCRIPTION
## Linked issue

Refs #1566

## Why this change

- Continue the Knip restore follow-up by trimming character-catalog hook exports that no current feature imports.

## What changed

- Made character-list cache helpers private because they are only used inside the character hook module.
- Removed unreferenced persona summary-by-id, persona duplicate/activate, character group detail, and persona group mutation hook exports from the character catalog hook module.
- Removed the orphaned `characterKeys.groupDetail` query-key helper.
- Left the separate `src/features/catalog/personas` hooks intact; those are the active persona panel hooks.

## Refactor impact

Primary owner:

- `src/features`

Impact areas reviewed:

- Catalog character hooks
- Catalog character query keys
- Existing persona panel hook imports
- Character hook cache helper tests

Boundary notes:

- This stays inside feature-owned catalog character modules.
- No shared API, Rust, storage, remote-runtime, or visible UI boundary changes.
- Engine contract schemas were not edited; any schema exports now reported by Knip remain in the separate engine contract lane.

Pressure points touched:

- None. No ModeSurface, GameSurface, shared mode UI, command registration, or import modules touched.

## Validation

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Codex ran `pnpm exec knip --exports --no-config-hints --reporter compact --no-exit-code`; `src/features/catalog/characters/hooks/use-characters.ts` no longer appears in the unused export report and the headline unused export count dropped from 88 to 87.
- Codex ran `pnpm test -- src/features/catalog/characters/hooks/use-characters.test.ts`.
- Codex ran `pnpm typecheck`.
- Codex ran `pnpm check:architecture`.
- Codex ran `pnpm check:unused`.
- Codex ran `pnpm build`.
- Codex ran `pnpm check`, including `cargo check --manifest-path src-tauri/Cargo.toml --workspace`.
- Codex ran `git diff --check`.
- Browser/Tauri manual verification was not run because this is deletion-only cleanup of unreferenced hook exports with no reachable UI call sites.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A - no visible UI behavior changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined character group management APIs
  * Reorganized internal query structure for character group operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1606?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->