### PR TITLE
Narrow chat helper export surface

### DIFF
--- a/src/features/catalog/chats/hooks/use-chats.ts
+++ b/src/features/catalog/chats/hooks/use-chats.ts
@@ -84,7 +84,7 @@ function findCachedMessage(data: InfiniteData<Message[]> | undefined, messageId:
   return null;
 }
 
-export function rememberRecentMessageContentEdit(
+function rememberRecentMessageContentEdit(
   chatId: string,
   messageId: string,
   content: string,
@@ -99,7 +99,7 @@ export function rememberRecentMessageContentEdit(
   });
 }
 
-export function forgetRecentMessageContentEdit(chatId: string, messageId: string) {
+function forgetRecentMessageContentEdit(chatId: string, messageId: string) {
   const edit = recentMessageContentEdits.get(messageId);
   if (edit?.chatId === chatId) {
     recentMessageContentEdits.delete(messageId);
@@ -113,32 +113,6 @@ export function preserveRecentMessageContentEdit(chatId: string, message: Messag
   if (edit.activeSwipeIndex !== null && edit.activeSwipeIndex !== (message.activeSwipeIndex ?? 0)) return message;
   if (message.content === edit.content) return message;
   return { ...message, content: edit.content };
-}
-
-export function applyRecentMessageContentEditsToData(
-  chatId: string,
-  data: InfiniteData<Message[]> | undefined,
-): InfiniteData<Message[]> | undefined {
-  if (!data?.pages || recentMessageContentEdits.size === 0) return data;
-  let changed = false;
-  const pages = data.pages.map((page) =>
-    page.map((message) => {
-      const next = preserveRecentMessageContentEdit(chatId, message);
-      if (next !== message) changed = true;
-      return next;
-    }),
-  );
-  return changed ? { ...data, pages } : data;
-}
-
-export interface ConversationSummaryBackfillResult {
-  generatedDays: string[];
-  consolidatedWeeks: string[];
-  failedDays: Array<{ date: string; error: string }>;
-  failedWeeks: Array<{ weekKey: string; error: string }>;
-  missingDayCount: number;
-  processedDayCount: number;
-  remainingMissingDayCount: number;
 }
 
 const CHAT_SUMMARY_FIELDS = [

--- a/src/features/catalog/chats/lib/chat-transcript-export.ts
+++ b/src/features/catalog/chats/lib/chat-transcript-export.ts
@@ -4,7 +4,7 @@ import type { StoredZipFile } from "../../../../shared/lib/zip";
 export type ChatTranscriptExportFormat = "jsonl" | "text";
 export type BulkChatExportFormat = ChatTranscriptExportFormat | "native";
 
-export function getChatNameForExport(chat: Chat) {
+function getChatNameForExport(chat: Chat) {
   const metadata = chat.metadata;
   if (metadata && typeof metadata === "object" && "branchName" in metadata) {
     const branchName = (metadata as { branchName?: unknown }).branchName;


### PR DESCRIPTION
## Summary

- keep chat transcript name resolution private to the transcript export module
- keep recent-message edit cache helpers private to the chat hook module
- remove unused feature-local chat summary/edit helper exports

## Verification

- `pnpm exec knip --exports --no-config-hints --reporter compact --no-exit-code`
- `pnpm test -- src/features/catalog/chats/lib/chat-transcript-export.test.ts`
- `pnpm typecheck`
- `pnpm check:architecture`
- `pnpm check:unused`
- `pnpm build`
- `pnpm check`
- `git diff --check`

## Notes

This stays in the `src/features` chat lane. Larger unused chat hooks remain separate follow-up candidates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal chat management utilities by streamlining the public API surface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1608?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->