### PR TITLE
Remove unused chat hook exports

### DIFF
--- a/src/features/catalog/chats/hooks/use-chats.ts
+++ b/src/features/catalog/chats/hooks/use-chats.ts
@@ -44,7 +44,6 @@ import type {
   ChatMemoryChunk,
   ConversationNote,
   Message,
-  MessageSwipe,
   DaySummaryEntry,
   WeekSummaryEntry,
 } from "../../../../engine/contracts/types/chat";
@@ -240,19 +239,6 @@ function patchAffectsActiveLorebooks(patch: Record<string, unknown>): boolean {
     "gameLorebookKeeperEnabled",
     "gameLorebookKeeperLorebookId",
   ].some((key) => Object.prototype.hasOwnProperty.call(patch, key));
-}
-
-export function useChats() {
-  return useQuery({
-    queryKey: chatKeys.list(),
-    queryFn: () => storageApi.list<Chat>("chats"),
-    staleTime: 10_000,
-    refetchOnMount: false,
-    refetchOnWindowFocus: false,
-    refetchOnReconnect: true,
-    retry: (failureCount, error) => shouldRetryApiQuery(failureCount, error, { maxRetries: 10 }),
-    retryDelay: (attempt, error) => apiQueryRetryDelay(attempt, error, { baseDelayMs: 750, maxDelayMs: 5_000 }),
-  });
 }
 
 export function useChatSummaries() {
@@ -659,20 +645,6 @@ export function useUpdateChatMetadata() {
       }
       setChatCacheRecord(qc, id, (chat) => applyChatMetadataPatch(chat, metadata));
       if (patchAffectsActiveLorebooks(metadata)) qc.invalidateQueries({ queryKey: lorebookKeys.active(id) });
-    },
-  });
-}
-
-export function useMarkAutonomousUnread() {
-  const qc = useQueryClient();
-  return useMutation({
-    mutationFn: ({ chatId, characterId, count }: { chatId: string; characterId?: string | null; count?: number }) =>
-      chatCommandApi.markAutonomousUnread<Chat>(chatId, { characterId: characterId ?? null, count }),
-    onSuccess: (data, vars) => {
-      if (data) {
-        qc.setQueryData(chatKeys.detail(vars.chatId), data);
-      }
-      qc.invalidateQueries({ queryKey: chatKeys.list() });
     },
   });
 }
@@ -1267,15 +1239,6 @@ export function useGenerateSummary() {
     onSuccess: (_data, vars) => {
       qc.invalidateQueries({ queryKey: chatKeys.detail(vars.chatId) });
     },
-  });
-}
-
-/** Fetch swipes for a message */
-export function useSwipes(chatId: string | null, messageId: string | null) {
-  return useQuery({
-    queryKey: [...chatKeys.all, "swipes", messageId ?? ""],
-    queryFn: () => chatCommandApi.swipes<MessageSwipe[]>(chatId, messageId),
-    enabled: !!chatId && !!messageId,
   });
 }
 


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

<!-- Every user-facing PR should reference a feature request or issue report when practical. -->

Closes #1566

## Why this change

<!-- What user problem, bug, refactor goal, or maintenance need does this solve? -->

- Removes the remaining unused chat hook exports from the Knip restore cleanup slice.

## What changed

<!-- List the key changes in this PR. -->

- Removed the unused exported `useChats`, `useMarkAutonomousUnread`, and `useSwipes` hooks from `src/features/catalog/chats/hooks/use-chats.ts`.
- Removed the now-unused `MessageSwipe` type import from the same file.

## Refactor impact

Primary owner:

<!-- Examples: app shell, catalog, chat mode, roleplay mode, game mode, runtime generation, world-state, shared API, engine generation, Rust storage, imports, remote runtime. -->

catalog chat hooks (`src/features`)

Impact areas reviewed:

- Confirmed no imports/call sites remain for `useChats`, `useMarkAutonomousUnread`, or `useSwipes`.
- Confirmed the target Knip row existed before the change and is gone after the change.

Boundary notes:

<!-- Note engine/shared-api/feature/Rust/remote-runtime boundaries. Say "none" only if you checked. -->

- Feature-lane export cleanup only.
- No engine contract, storage, autonomous behavior, chat summary generation, or chat command API changes.

Pressure points touched:

<!-- Mention ModeSurface, GameSurface, shared mode UI, src-tauri/src/lib.rs command registration, or import modules if touched. -->

- None.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app/runtime, step by step. If an AI agent filled this out, verify it yourself before ticking boxes. -->

- Codex ran `pnpm exec knip --exports --no-config-hints --reporter compact --no-exit-code` before editing and confirmed the target row: `src/features/catalog/chats/hooks/use-chats.ts: useChats, useMarkAutonomousUnread, useSwipes`.
- Codex confirmed no imports/call sites remained for the three target hooks before removing them.
- Codex reran `pnpm exec knip --exports --no-config-hints --reporter compact --no-exit-code` after the change; the target row is gone.
- No focused chat hook tests exist for this file or these removed hooks in the current tree.
- Codex ran `pnpm typecheck`.
- Codex ran `pnpm check:architecture`.
- Codex ran `pnpm check:unused`.
- Codex ran `pnpm build`; it passed with the existing Vite large-chunk warning.
- Codex ran `pnpm check`.
- Codex ran `git diff --check`; Git repeated a line-ending notice for the touched file, with no whitespace errors.
- Bunny review passed before opening the PR.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

<!-- Add before/after screenshots or recordings for visible UI changes. -->

N/A - no visible UI behavior changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored internal chat functionality to improve codebase maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1609?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->