### PR TITLE
Narrow game asset helper exports

### DIFF
--- a/src/features/modes/game/components/game-asset-generation-payload.ts
+++ b/src/features/modes/game/components/game-asset-generation-payload.ts
@@ -31,7 +31,7 @@ export function normalizeSceneAssetNameForGeneration(value: string): string {
   return value.trim().toLowerCase().replace(/[_-]+/g, " ").replace(/\s+/g, " ");
 }
 
-export function getMissingBackgroundTag(
+function getMissingBackgroundTag(
   backgroundTag: string | undefined | null,
   manifest: AssetManifestMap,
 ): string | null {

--- a/src/features/modes/game/lib/game-asset-selection.ts
+++ b/src/features/modes/game/lib/game-asset-selection.ts
@@ -12,7 +12,7 @@ type AssetEntryWithPath = {
   path: string;
 };
 
-export function normalizeGameAssetFolderPath(path: string | null | undefined): string {
+function normalizeGameAssetFolderPath(path: string | null | undefined): string {
   return (path ?? "")
     .trim()
     .replace(/\\/g, "/")
@@ -20,7 +20,7 @@ export function normalizeGameAssetFolderPath(path: string | null | undefined): s
     .replace(/\/+/g, "/");
 }
 
-export function isGameAssetPathInFolder(path: string, folder: string): boolean {
+function isGameAssetPathInFolder(path: string, folder: string): boolean {
   const normalizedPath = normalizeGameAssetFolderPath(path);
   const normalizedFolder = normalizeGameAssetFolderPath(folder);
   if (!normalizedFolder) return true;
@@ -48,7 +48,7 @@ export function serializeGameAssetSelection(excludedFolders: Iterable<string>): 
   return folders.length > 0 ? { excludedFolders: folders } : null;
 }
 
-export function isGameAssetIncluded(path: string, excludedFolders: readonly string[]): boolean {
+function isGameAssetIncluded(path: string, excludedFolders: readonly string[]): boolean {
   return !excludedFolders.some((folder) => folder && isGameAssetPathInFolder(path, folder));
 }
 

--- a/src/features/modes/game/lib/game-audio-settings.ts
+++ b/src/features/modes/game/lib/game-audio-settings.ts
@@ -1,4 +1,4 @@
-export const DEFAULT_GAME_AUDIO_SETTINGS = {
+const DEFAULT_GAME_AUDIO_SETTINGS = {
   masterVolume: 50,
   musicVolume: 60,
   sfxVolume: 80,


### PR DESCRIPTION
## Linked issue

Refs #1566

## Why this change

- Narrows the Game Asset And Audio Helper Visibility Knip slice by making in-file-only game asset/audio helpers private.

## What changed

- Made the game asset folder normalization/inclusion helper functions private to `game-asset-selection.ts`.
- Made the missing-background tag helper private to `game-asset-generation-payload.ts`.
- Made the default game audio settings constant private while keeping the exported `GameAudioSettings` type and persisted settings shape unchanged.

## Refactor impact

Primary owner:

Game mode

Impact areas reviewed:

- Game asset selection helper exports
- Missing scene asset generation payload helper exports
- Game audio settings helper exports

Boundary notes:

- Feature-lane only; no engine contract cleanup, shared API changes, Rust validation changes, MIME/file type contract changes, upload validation changes, asset selection behavior changes, or persisted audio settings shape changes.

Pressure points touched:

- None

## Validation

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

Codex ran:

- `pnpm exec knip --exports --no-config-hints --reporter compact --no-exit-code`
  - Before: target rows were present.
  - After: target rows were removed; unused exports dropped from 85 to 82.
- `pnpm test -- src\engine\contracts\constants\game-assets.test.ts src\features\modes\game-assets\components\GameAssetsBrowserView.test.tsx`
- `pnpm typecheck`
- `pnpm check:architecture`
- `pnpm check:unused`
- `pnpm build`
- `pnpm check`
- `git diff --check`

No focused audio helper tests were present. `git diff --check` exited clean with only Windows line-ending warnings.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A. This is export visibility cleanup only; no visible UI behavior changed.
