### PR TITLE
Narrow lorebook form helper exports

### DIFF
--- a/src/features/catalog/lorebooks/components/LorebookFormFields.tsx
+++ b/src/features/catalog/lorebooks/components/LorebookFormFields.tsx
@@ -158,7 +158,7 @@ export function NumberField({
   );
 }
 
-export function insertTabAtSelection(
+function insertTabAtSelection(
   element: HTMLTextAreaElement,
   value: string,
   applyValue: (nextValue: string) => void,
@@ -173,7 +173,7 @@ export function insertTabAtSelection(
   });
 }
 
-export function handleTextareaTabKeyDown(
+function handleTextareaTabKeyDown(
   event: ReactKeyboardEvent<HTMLTextAreaElement>,
   value: string,
   applyValue: (nextValue: string) => void,
@@ -246,7 +246,7 @@ export function ExpandableTextarea({
 }
 
 /** Fullscreen modal editor for lorebook entry fields. */
-export function ExpandedContentModal({
+function ExpandedContentModal({
   title,
   value,
   onChange,


### PR DESCRIPTION
## Linked issue

Refs #1566

## Why this change

- Implements the Lorebook Form Helper Visibility Knip slice from the restore cleanup queue.

## What changed

- Removed public exports from `insertTabAtSelection`, `handleTextareaTabKeyDown`, and `ExpandedContentModal`.
- Kept the helpers/components local to `LorebookFormFields.tsx` with runtime behavior unchanged.

## Refactor impact

Primary owner:

catalog/lorebooks (`src/features`)

Impact areas reviewed:

- `src/features/catalog/lorebooks/components/LorebookFormFields.tsx`
- Knip export report
- Focused lorebook/component tests: none present

Boundary notes:

- Feature-lane only.
- No engine contract cleanup.
- No lorebook storage, schema, query hook, import, or export behavior touched.

Pressure points touched:

- None.

## Validation

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Codex ran `pnpm exec knip --exports --no-config-hints --reporter compact --no-exit-code`; the target `LorebookFormFields.tsx` row was present before the change and absent after the change.
- Codex ran `pnpm typecheck`.
- Codex ran `pnpm check:architecture`.
- Codex ran `pnpm check:unused`.
- Codex ran `pnpm build`.
- Codex ran `pnpm check`.
- Codex ran `git diff --check`.
- No focused lorebook/component tests were present to run.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs or release notes changed.

## UI evidence

N/A. This is an export-visibility cleanup with no intended UI behavior change.
