### PR TITLE
Narrow shared runtime type exports

### DIFF
--- a/src/shared/api/remote-runtime.ts
+++ b/src/shared/api/remote-runtime.ts
@@ -180,7 +180,7 @@ export type RuntimeTarget = {
   authorization?: string;
 };
 
-export type RemoteRuntimeHealthPayload = {
+type RemoteRuntimeHealthPayload = {
   ok?: boolean;
   runtime?: string;
   writable?: boolean;

--- a/src/shared/api/translation-api.ts
+++ b/src/shared/api/translation-api.ts
@@ -1,6 +1,6 @@
 import { invokeTauri } from "./tauri-client";
 
-export type TranslationProvider = "ai" | "deeplx" | "deepl" | "google";
+type TranslationProvider = "ai" | "deeplx" | "deepl" | "google";
 
 export interface TranslateTextInput {
   text: string;

--- a/src/shared/components/ui/ImagePromptReviewModal.tsx
+++ b/src/shared/components/ui/ImagePromptReviewModal.tsx
@@ -3,7 +3,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Modal } from "./Modal";
 import { cn } from "../../lib/utils";
 
-export type ImagePromptReviewKind = "background" | "illustration" | "portrait" | "sprite" | "avatar" | "selfie";
+type ImagePromptReviewKind = "background" | "illustration" | "portrait" | "sprite" | "avatar" | "selfie";
 
 export type ImagePromptReviewItem = {
   id: string;

--- a/src/shared/lib/tts-service.ts
+++ b/src/shared/lib/tts-service.ts
@@ -3,11 +3,11 @@
 // ──────────────────────────────────────────────
 import { ttsApi } from "../api/tts-api";
 
-export type TTSState = "idle" | "loading" | "playing" | "paused" | "error";
+type TTSState = "idle" | "loading" | "playing" | "paused" | "error";
 
 type StateListener = (state: TTSState, activeId: string | null) => void;
 
-export interface TTSSpeakOptions {
+interface TTSSpeakOptions {
   speaker?: string;
   tone?: string;
   voice?: string;
@@ -16,7 +16,7 @@ export interface TTSSpeakOptions {
   playbackRate?: number;
 }
 
-export interface TTSSpeakRequest {
+interface TTSSpeakRequest {
   text: string;
   speaker?: string;
   tone?: string;

--- a/src/shared/stores/dialog.store.ts
+++ b/src/shared/stores/dialog.store.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 
-export type AppDialogTone = "default" | "destructive";
+type AppDialogTone = "default" | "destructive";
 
 type AppDialogCommon = {
   title?: string;

--- a/src/shared/stores/translation.store.ts
+++ b/src/shared/stores/translation.store.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 
 // ── Translation config (set from chat metadata) ──
-export interface TranslationConfig {
+interface TranslationConfig {
   provider: "ai" | "deeplx" | "deepl" | "google";
   targetLanguage: string;
   connectionId?: string;


### PR DESCRIPTION
## Linked issue

Refs #1566

## Why this change

Narrow Knip's shared runtime unused exported type surface for the Shared API / Store Type Cleanup slice.

## What changed

- Privatized Knip-reported unused exported shared types in `src/shared/api`.
- Privatized Knip-reported unused exported shared types in `src/shared/components`, `src/shared/lib`, and `src/shared/stores`.
- Kept runtime payload shapes, persisted settings, store state shape, and API behavior unchanged.

## Refactor impact

Primary owner:

Shared API / shared runtime type surface.

Impact areas reviewed:

- `src/shared/api`
- `src/shared/components`
- `src/shared/lib`
- `src/shared/stores`

Boundary notes:

- This PR only removes unused exported type names from the shared lane.
- It does not broaden into engine contract cleanup.
- No wire payloads, persisted settings, runtime store state shapes, or runtime API behavior changed.

Pressure points touched:

- Remote runtime health typing
- Translation request/config typing
- Image prompt review item typing
- TTS service request/options/state typing
- Dialog and translation store typing

## Validation

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

Codex ran:

- `pnpm exec knip --exports --no-config-hints --reporter compact --no-exit-code` before editing and confirmed the target shared rows existed.
- `pnpm exec knip --exports --no-config-hints --reporter compact --no-exit-code` after editing; the target shared unused exported type rows were removed from the report.
- Focused test search for these target modules; no focused test files were present.
- `pnpm typecheck`
- `pnpm check:architecture`
- `pnpm check:unused`
- `pnpm build`
- `pnpm check`
- `git diff --check`

`pnpm build` passed with the existing Vite large-chunk warning. The first `pnpm check` attempt timed out at the command timeout limit, then passed when rerun with a longer timeout.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs or release changes are needed for this type-export cleanup.

## UI evidence

N/A. Type export visibility cleanup only; no UI behavior changed.
