### PR TITLE
Narrow runtime tracker exports

### DIFF
--- a/src/features/runtime/tracker/components/tracker-persona-profile-style.ts
+++ b/src/features/runtime/tracker/components/tracker-persona-profile-style.ts
@@ -5,7 +5,7 @@ import { visibleText } from "./tracker-display.helpers";
 import { type TrackerProfileColors, getTrackerProfilePalette } from "./tracker-profile-colors";
 import { withTrackerProfileStyle } from "./tracker-profile-style-vars";
 
-export function getPersonaProfileColors(persona: Persona | null): TrackerProfileColors {
+function getPersonaProfileColors(persona: Persona | null): TrackerProfileColors {
   return {
     dialogueColor: persona?.dialogueColor,
     nameColor: persona?.nameColor,

--- a/src/features/runtime/tracker/components/tracker-world.helpers.ts
+++ b/src/features/runtime/tracker/components/tracker-world.helpers.ts
@@ -25,24 +25,24 @@ export {
 
 export const WORLD_GRID_BASE_CLASS = "grid-cols-[2.5rem_2.5rem_minmax(0,1fr)]";
 export const WORLD_FREEFORM_DATE_GRID_BASE_CLASS = "grid-cols-[minmax(3.8rem,4.45rem)_2.5rem_minmax(0,1fr)]";
-export const WORLD_GRID_BALANCED_CLASS =
+const WORLD_GRID_BALANCED_CLASS =
   "@min-[380px]:grid-cols-[2.5rem_2.5rem_minmax(6.25rem,1fr)_minmax(7.5rem,1.35fr)]";
-export const WORLD_GRID_FORECAST_HEAVY_CLASS =
+const WORLD_GRID_FORECAST_HEAVY_CLASS =
   "@min-[380px]:grid-cols-[2.5rem_2.5rem_minmax(7rem,1.05fr)_minmax(7.25rem,1.2fr)]";
-export const WORLD_GRID_LOCATION_HEAVY_CLASS =
+const WORLD_GRID_LOCATION_HEAVY_CLASS =
   "@min-[380px]:grid-cols-[2.5rem_2.5rem_minmax(7rem,0.95fr)_minmax(9rem,1.45fr)]";
-export const WORLD_FREEFORM_DATE_GRID_BALANCED_CLASS =
+const WORLD_FREEFORM_DATE_GRID_BALANCED_CLASS =
   "@min-[380px]:grid-cols-[minmax(4.1rem,4.7rem)_2.5rem_minmax(5rem,0.86fr)_minmax(7.25rem,1.35fr)]";
-export const WORLD_FREEFORM_DATE_GRID_FORECAST_HEAVY_CLASS =
+const WORLD_FREEFORM_DATE_GRID_FORECAST_HEAVY_CLASS =
   "@min-[380px]:grid-cols-[minmax(4.1rem,4.7rem)_2.5rem_minmax(5.75rem,1fr)_minmax(6.75rem,1.1fr)]";
-export const WORLD_FREEFORM_DATE_GRID_LOCATION_HEAVY_CLASS =
+const WORLD_FREEFORM_DATE_GRID_LOCATION_HEAVY_CLASS =
   "@min-[380px]:grid-cols-[minmax(4.1rem,4.7rem)_2.5rem_minmax(5rem,0.75fr)_minmax(8.25rem,1.45fr)]";
 
 type WorldDashboardGridClassOptions = {
   hasFreeformDate?: boolean;
 };
 
-export function getWorldTileTextNeed(value: string | null | undefined, fallback: string) {
+function getWorldTileTextNeed(value: string | null | undefined, fallback: string) {
   const text = visibleText(value, fallback).replace(/\s+/g, " ");
   const longestWord = text.split(" ").reduce((longest, word) => Math.max(longest, word.length), 0);
   return text.length + longestWord * 0.7;

--- a/src/features/runtime/tracker/hooks/use-tracker-panel-model.ts
+++ b/src/features/runtime/tracker/hooks/use-tracker-panel-model.ts
@@ -51,7 +51,7 @@ function useTrackerSpriteMessages(chatId: string | null, enabled: boolean) {
   });
 }
 
-export interface TrackerSpriteLookup {
+interface TrackerSpriteLookup {
   knownIds: Set<string>;
   idByName: Map<string, string>;
   pictureById: Record<string, string>;

--- a/src/features/runtime/world-state/hooks/use-world-state-patcher.ts
+++ b/src/features/runtime/world-state/hooks/use-world-state-patcher.ts
@@ -441,7 +441,7 @@ export function patchGameStateField<K extends GameStatePatchField>(
   queuePatch(chatId, field, value, target);
 }
 
-export function patchPlayerStatsField<K extends keyof PlayerStats>(chatId: string, field: K, value: PlayerStats[K]) {
+function patchPlayerStatsField<K extends keyof PlayerStats>(chatId: string, field: K, value: PlayerStats[K]) {
   const current = getCurrentGameStateForChat(chatId)?.playerStats ?? createEmptyPlayerStats();
   const nextPlayerStats: PlayerStats = { ...current, [field]: value };
   patchGameStateField(chatId, "playerStats", nextPlayerStats);

--- a/src/features/runtime/world-state/lib/tracker-state-edits.ts
+++ b/src/features/runtime/world-state/lib/tracker-state-edits.ts
@@ -24,7 +24,7 @@ export function appendTrackerListItem<T>(items: readonly T[], item: T): T[] {
   return [...items, item];
 }
 
-export function mergeChangedTrackerFields<T extends object>(
+function mergeChangedTrackerFields<T extends object>(
   previous: T | undefined,
   latest: T | undefined,
   next: T,
@@ -178,7 +178,7 @@ function questObjectiveKey(item: QuestObjective | undefined) {
   return item?.text?.trim() || null;
 }
 
-export function makeManualTrackerId() {
+function makeManualTrackerId() {
   const id =
     typeof globalThis.crypto?.randomUUID === "function"
       ? globalThis.crypto.randomUUID()
@@ -377,7 +377,7 @@ export function createManualInventoryItem(options: Partial<InventoryItem> = {}):
   };
 }
 
-export function createManualQuestObjective(options: Partial<QuestProgress["objectives"][number]> = {}) {
+function createManualQuestObjective(options: Partial<QuestProgress["objectives"][number]> = {}) {
   return {
     text: options.text ?? "New objective",
     completed: options.completed ?? false,
@@ -448,7 +448,7 @@ export function addQuestObjective(
   };
 }
 
-export function replaceQuestObjective(
+function replaceQuestObjective(
   quest: QuestProgress,
   index: number,
   objective: QuestProgress["objectives"][number],

--- a/src/features/runtime/world-state/lib/world-state-display.ts
+++ b/src/features/runtime/world-state/lib/world-state-display.ts
@@ -1,8 +1,8 @@
 import type { WorldTemperatureUnit } from "../types";
 
-export const WORLD_MONTH_LABELS = ["JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"];
+const WORLD_MONTH_LABELS = ["JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"];
 
-export const WORLD_MONTH_ALIASES: Record<string, number> = {
+const WORLD_MONTH_ALIASES: Record<string, number> = {
   jan: 0,
   january: 0,
   feb: 1,


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

N/A - Knip cleanup slice on `refactor`.

## Why this change

- Continue the Knip export cleanup for the `src/features/runtime` tracker/world-state slice by removing unnecessary public exports while preserving runtime behavior.

## What changed

- Made Knip-reported tracker persona/world helper exports internal where they are only used within their modules.
- Made the tracker sprite lookup type internal to the tracker panel model module.
- Made Knip-reported world-state patcher, tracker edit, and date-display helpers internal while leaving their implementation unchanged.

## Refactor impact

Primary owner:

- `src/features/runtime`

Impact areas reviewed:

- Tracker panel helpers and model exports.
- World-state patcher and tracker-state edit helpers.
- World-state display date parsing helpers.

Boundary notes:

- Stayed within `src/features/runtime`.
- Did not touch character catalog or `src/engine/contracts/**`.
- No runtime wrapper, Rust, remote-runtime, schema, dependency, or storage changes.

Pressure points touched:

- None. No ModeSurface, GameSurface, command registration, or import modules touched.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- `pnpm install`
- `pnpm exec knip --exports --no-config-hints --reporter compact --no-exit-code`
  - Before: requested runtime targets were present in the Knip report.
  - After: requested runtime targets were removed from the Knip report; unrelated remaining rows were left untouched.
- `pnpm typecheck`
- Bunny pass on the current diff: no blocking findings. This is export-surface-only cleanup with no behavior changes, so no browser/UI proof was needed.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs or release-note changes were made.

## UI evidence

N/A - no visible UI behavior change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code cleanup and API surface reduction across tracker and world-state modules. No changes to user-facing functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1613?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->