### PR TITLE
Narrow game mode exports

### DIFF
--- a/src/features/modes/game/api/game-api.ts
+++ b/src/features/modes/game/api/game-api.ts
@@ -204,8 +204,6 @@ type GameJsonRepairContext = {
   applyBody: Record<string, unknown>;
 };
 
-const EMPTY_JOURNAL: Journal = createJournal();
-
 function newId(prefix = ""): string {
   const id =
     typeof crypto !== "undefined" && "randomUUID" in crypto
@@ -2351,8 +2349,4 @@ export async function applyGameJsonRepair(request: JsonRepairRequest, rawJson: s
     default:
       throw new Error("Unsupported game JSON repair request.");
   }
-}
-
-export function getEmptyJournal(): Journal {
-  return { ...EMPTY_JOURNAL, entries: [], quests: [], locations: [], npcLog: [], inventoryLog: [] };
 }

--- a/src/features/modes/game/components/GameQteOverlay.tsx
+++ b/src/features/modes/game/components/GameQteOverlay.tsx
@@ -158,25 +158,3 @@ export function GameQteOverlay({ actions, timerSeconds, onSelect, onTimeout, onD
     </div>
   );
 }
-
-// ── Tag Parser ──
-
-/** Parse [qte: action1 | action2, timer: 5s] from narration content. */
-export function parseQteTag(content: string): { actions: string[]; timer: number; cleanContent: string } | null {
-  const regex = /\[qte:\s*(.+?),\s*timer:\s*(\d+)s?\]/i;
-  const match = content.match(regex);
-  if (!match) return null;
-
-  const actionsRaw = match[1]!;
-  const timer = parseInt(match[2]!, 10);
-
-  const actions = actionsRaw
-    .split("|")
-    .map((a) => a.trim().replace(/^["']|["']$/g, ""))
-    .filter((a) => a.length > 0);
-
-  if (actions.length === 0 || isNaN(timer)) return null;
-
-  const cleanContent = content.replace(regex, "").trim();
-  return { actions, timer, cleanContent };
-}

--- a/src/features/modes/game/components/game-asset-generation-payload.ts
+++ b/src/features/modes/game/components/game-asset-generation-payload.ts
@@ -2,7 +2,7 @@ import { resolveAssetTag } from "../lib/asset-fuzzy-match";
 
 type AssetManifestMap = Record<string, { path: string }> | null;
 
-export type SceneAssetNpcAvatarCandidate = {
+type SceneAssetNpcAvatarCandidate = {
   name: string;
   description: string;
   avatarUrl?: string | null;

--- a/src/features/modes/game/hooks/use-game.ts
+++ b/src/features/modes/game/hooks/use-game.ts
@@ -343,25 +343,6 @@ export function useRecruitPartyMember() {
   });
 }
 
-export function useRegeneratePartyCard() {
-  const qc = useQueryClient();
-
-  return useMutation({
-    mutationFn: (data: { chatId: string; characterName: string; characterId?: string; connectionId?: string }) =>
-      gameApi.upsertPartyCard(data),
-    onSuccess: (res, variables) => {
-      publishSessionChat(qc, res.sessionChat);
-      qc.invalidateQueries({ queryKey: chatKeys.detail(variables.chatId) });
-      qc.invalidateQueries({ queryKey: chatKeys.list() });
-      toast.success(`${res.characterName}'s sheet was regenerated.`);
-    },
-    onError: (err) => {
-      console.error("[regeneratePartyCard] Error:", err);
-      toast.error(err.message || "Failed to regenerate party sheet.");
-    },
-  });
-}
-
 export function useRemovePartyMember() {
   const qc = useQueryClient();
 
@@ -492,15 +473,6 @@ export function useUpdateGameWidgets() {
 }
 
 // ── Queries ──
-
-export function useGameSessions(gameId: string | null) {
-  return useQuery({
-    queryKey: gameKeys.sessions(gameId ?? ""),
-    queryFn: () => gameApi.gameSessions(gameId!),
-    enabled: !!gameId,
-    staleTime: 2 * 60_000,
-  });
-}
 
 // ── Sync hook — reads chat metadata and updates game store ──
 
@@ -643,27 +615,6 @@ export function useCombatRound() {
   });
 }
 
-export function useCombatLoot() {
-  return useMutation({
-    mutationFn: async (data: { chatId: string; enemyCount: number }) => {
-      const res = await gameApi.combatLoot(data);
-
-      return {
-        drops: (res.drops ?? [])
-          .filter((drop): drop is NonNullable<(typeof res.drops)[number]> => !!drop?.item?.name)
-          .map((drop) => ({ name: drop.item!.name!, quantity: drop.quantity ?? undefined })),
-      };
-    },
-  });
-}
-
-export function useLootGenerate() {
-  return useMutation({
-    mutationFn: (data: { chatId: string; count?: number }) =>
-      gameApi.lootGenerate(data),
-  });
-}
-
 export function useAdvanceTime() {
   const qc = useQueryClient();
   return useMutation({
@@ -740,15 +691,6 @@ export function useJournalEntry() {
       publishSessionChat(qc, res.sessionChat);
       qc.invalidateQueries({ queryKey: [...gameKeys.all, "journal", variables.chatId] });
     },
-  });
-}
-
-export function useGameJournal(chatId: string | null) {
-  return useQuery({
-    queryKey: [...gameKeys.all, "journal", chatId],
-    queryFn: () => gameApi.getJournal(chatId!),
-    enabled: !!chatId,
-    staleTime: 30_000,
   });
 }
 

--- a/src/features/modes/game/lib/game-audio.ts
+++ b/src/features/modes/game/lib/game-audio.ts
@@ -30,7 +30,7 @@ interface LoopingAudioLayer {
   stop: () => void;
 }
 
-export interface OneShotAudioLayer {
+interface OneShotAudioLayer {
   ready: Promise<void>;
   setVolume: (volume: number) => void;
   setMuted: (muted: boolean) => void;

--- a/src/features/modes/game/lib/game-tag-parser.ts
+++ b/src/features/modes/game/lib/game-tag-parser.ts
@@ -15,7 +15,7 @@ export interface CombatEncounterTag {
   allies?: string[] | null;
 }
 
-export interface SkillCheckTag {
+interface SkillCheckTag {
   skill: string;
   dc: number;
   advantage?: boolean;


### PR DESCRIPTION
﻿## Linked issue

N/A - Knip cleanup slice on `refactor`.

## Why this change

- Continues the fresh Knip export cleanup after the merged runtime tracker/world-state slice by narrowing unused public exports in the game mode owner lane.

## What changed

- Deleted unused exported helpers from `src/features/modes/game/api/game-api.ts`, `src/features/modes/game/components/GameQteOverlay.tsx`, and `src/features/modes/game/hooks/use-game.ts`.
- Made unused exported types internal in `src/features/modes/game/components/game-asset-generation-payload.ts`, `src/features/modes/game/lib/game-audio.ts`, and `src/features/modes/game/lib/game-tag-parser.ts`.

## Refactor impact

Primary owner:

game mode

Impact areas reviewed:

- Game API helper exports
- Game QTE overlay helper exports
- Game React Query hook exports
- Game asset generation payload types
- Game audio layer types
- Game tag parser types

Boundary notes:

- Stayed within `src/features/modes/game`.
- Did not touch character catalog.
- Did not touch `src/engine/contracts/**`.
- No runtime wrapper, Rust, remote runtime, schema, dependency, or storage changes.

Pressure points touched:

- None. This did not touch ModeSurface, GameSurface, shared mode UI, Tauri command registration, or import modules.

## Validation

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- `pnpm install` completed with the lockfile already up to date.
- Fresh pre-slice Knip report: `Unused exports (75)`, `Unused exported types (62)`.
- Post-slice `pnpm exec knip --exports --no-config-hints --reporter compact --no-exit-code`: `Unused exports (72)`, `Unused exported types (59)`.
- `pnpm typecheck` passed.
- `git diff --check` passed.
- `pnpm build` was not run because this slice did not unexpectedly touch build or import behavior.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A - public export cleanup only; no visible UI behavior change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated game mode internal APIs by removing unused helper functions and query hooks
  * Removed deprecated utility helpers for journal and QTE parsing
  * Simplified React Query hook structure by removing unused party and loot-related hooks
  * Reduced internal type exports to streamline the public API surface
  * Added new combat round mutation hook to replace removed combat-related functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1614?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->