### PR TITLE
Fix scoped lorebook tool search

### DIFF
--- a/src/engine/generation/main-tool-loop.test.ts
+++ b/src/engine/generation/main-tool-loop.test.ts
@@ -6,6 +6,7 @@ import { startGeneration, type GenerationEngineDeps } from "./start-generation";
 import {
   buildMainToolDefinitions,
   executeMainToolCall,
+  searchLorebookTool,
   normalizeToolCall,
   type CustomToolRecord,
 } from "./tools-runtime";
@@ -706,6 +707,8 @@ describe("row 10 — custom-tool name collision with built-in: built-in wins, no
       input: {
         chat: { id: "chat-1", metadata: {} },
         activatedLorebookEntries: [],
+        characters: [],
+        persona: null,
         chatSummary: null,
       },
       customTools,
@@ -750,6 +753,8 @@ describe("row 10 — custom-tool name collision with built-in: built-in wins, no
       input: {
         chat: { id: "chat-1", metadata: {} },
         activatedLorebookEntries: [],
+        characters: [],
+        persona: null,
         chatSummary: null,
       },
       customTools: new Map(),
@@ -855,5 +860,90 @@ describe("row 10 — custom-tool name collision with built-in: built-in wins, no
     expect(generationInfo.usage.promptTokens).toBe(250);
     expect(generationInfo.usage.completionTokens).toBe(50);
     expect(generationInfo.usage.totalTokens).toBe(300);
+  });
+});
+
+describe("search_lorebook active context", () => {
+  it("does not return disabled, disabled-folder, or unrelated stored lorebook entries", async () => {
+    const storage = {
+      list: vi.fn(async (entity: string, options?: { filters?: Record<string, unknown> }) => {
+        if (entity === "lorebooks") {
+          return [
+            { id: "active-book", name: "Active book", enabled: true, isGlobal: true },
+            { id: "disabled-book", name: "Disabled book", enabled: false, isGlobal: true },
+            { id: "other-character-book", name: "Other character", enabled: true, characterId: "other-character" },
+          ];
+        }
+        if (entity === "lorebook-folders") {
+          if (options?.filters?.lorebookId === "active-book") {
+            return [{ id: "disabled-folder", lorebookId: "active-book", enabled: false }];
+          }
+          return [];
+        }
+        return [];
+      }),
+      listLorebookEntries: vi.fn(async (lorebookId: string) => {
+        if (lorebookId === "active-book") {
+          return [
+            {
+              id: "allowed-entry",
+              lorebookId,
+              name: "Allowed",
+              content: "moonstone archive visible",
+              enabled: true,
+              keys: [],
+            },
+            {
+              id: "disabled-folder-entry",
+              lorebookId,
+              name: "Disabled folder",
+              content: "moonstone archive hidden by folder",
+              enabled: true,
+              folderId: "disabled-folder",
+              keys: [],
+            },
+          ];
+        }
+        if (lorebookId === "disabled-book") {
+          return [
+            {
+              id: "disabled-book-entry",
+              lorebookId,
+              name: "Disabled book",
+              content: "moonstone archive hidden by book",
+              enabled: true,
+              keys: [],
+            },
+          ];
+        }
+        if (lorebookId === "other-character-book") {
+          return [
+            {
+              id: "other-character-entry",
+              lorebookId,
+              name: "Other character",
+              content: "moonstone archive hidden by character scope",
+              enabled: true,
+              keys: [],
+            },
+          ];
+        }
+        return [];
+      }),
+    } as unknown as StorageGateway;
+
+    const result = await searchLorebookTool(
+      storage,
+      {
+        chat: { id: "chat-1", mode: "conversation", metadata: {} },
+        activatedLorebookEntries: [],
+        characters: [{ id: "character-1", name: "Hero", description: "", tags: [] }],
+        persona: null,
+        chatSummary: null,
+      },
+      { query: "moonstone archive" },
+    );
+
+    expect(result.entries.map((entry) => entry.id)).toEqual(["allowed-entry"]);
   });
 });

--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -1695,7 +1695,7 @@ export function normalizeLorebookEntry(entry: JsonRecord): LorebookEntry {
   };
 }
 
-function lorebookAppliesToContext(
+export function lorebookAppliesToContext(
   lorebook: JsonRecord,
   chat: JsonRecord,
   characters: GenerationCharacterContext[],
@@ -1782,7 +1782,7 @@ function resolveLorebookRecursionDepth(lorebook: JsonRecord): number {
   return Math.min(MAX_LOREBOOK_RECURSION_DEPTH, Math.max(1, nonNegativeInteger(lorebook.maxRecursionDepth, 3)));
 }
 
-async function loadLorebookEntriesForActivation(
+export async function loadLorebookEntriesForActivation(
   storage: StorageGateway,
   lorebook: JsonRecord,
 ): Promise<LorebookEntry[]> {

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -2193,6 +2193,8 @@ export async function* startGeneration(
     const toolRuntimeInput: ToolRuntimeInput = {
       chat: chatForGeneration,
       activatedLorebookEntries: assembly.activatedLorebookEntries,
+      characters: assembly.characters,
+      persona: assembly.persona,
       chatSummary: assembly.chatSummary,
     };
     const baseMessages: LlmMessage[] = [...prompt, generationGuide(input)].filter(
@@ -2358,6 +2360,8 @@ export async function* startGeneration(
   const toolRuntimeInputDirect: ToolRuntimeInput = {
     chat: chatForGeneration,
     activatedLorebookEntries: assembly.activatedLorebookEntries,
+    characters: assembly.characters,
+    persona: assembly.persona,
     chatSummary: assembly.chatSummary,
   };
   const baseMessagesDirect: LlmMessage[] = [...(prompt ?? []), generationGuide(input)].filter(

--- a/src/engine/generation/tools-runtime.ts
+++ b/src/engine/generation/tools-runtime.ts
@@ -2,8 +2,16 @@ import { BUILT_IN_TOOLS, DEFAULT_AGENT_TOOLS, type ToolDefinition } from "../con
 import type { IntegrationGateway } from "../capabilities/integrations";
 import type { LlmToolDefinition } from "../capabilities/llm";
 import type { StorageGateway } from "../capabilities/storage";
+import type { LorebookEntry } from "../contracts/types/lorebook";
 import type { LLMToolCall, LLMToolDefinition } from "../generation-core/llm/base-provider";
+import { lorebookEntryPassesContextFilters } from "../generation-core/lorebooks/keyword-scanner";
 import { appendChatSummaryEntryToMetadata } from "../shared/text/chat-summary-entries";
+import {
+  loadLorebookEntriesForActivation,
+  lorebookAppliesToContext,
+  type GenerationCharacterContext,
+  type GenerationPersonaContext,
+} from "./prompt-assembly";
 import {
   boolish,
   isRecord,
@@ -26,6 +34,8 @@ import {
 export interface ToolRuntimeInput {
   chat: JsonRecord;
   activatedLorebookEntries: Array<{ id: string; name: string; content: string; tag: string }>;
+  characters: GenerationCharacterContext[];
+  persona: GenerationPersonaContext | null;
   chatSummary: string | null;
 }
 
@@ -187,12 +197,33 @@ export function rollDiceNotation(notation: string) {
   };
 }
 
+function lorebookToolEntryPassesContext(entry: LorebookEntry, input: ToolRuntimeInput): boolean {
+  return lorebookEntryPassesContextFilters(entry, {
+    activeCharacterIds: input.characters.map((character) => character.id),
+    activeCharacterTags: input.characters.flatMap((character) => character.tags),
+    generationTriggers: ["chat", readString(input.chat.mode || input.chat.chatMode)].filter(Boolean),
+  });
+}
+
+async function loadSearchableStoredLorebookEntries(
+  storage: StorageGateway,
+  input: ToolRuntimeInput,
+): Promise<LorebookEntry[]> {
+  const lorebooks = (await storage.list<JsonRecord>("lorebooks")).filter((book) =>
+    lorebookAppliesToContext(book, input.chat, input.characters, input.persona),
+  );
+  const entries = await Promise.all(
+    lorebooks.map((book) => loadLorebookEntriesForActivation(storage, book)),
+  );
+  return entries.flat().filter((entry) => lorebookToolEntryPassesContext(entry, input));
+}
+
 export async function searchLorebookTool(storage: StorageGateway, input: ToolRuntimeInput, args: JsonRecord) {
   const query = stringArg(args, "query").toLowerCase();
   if (!query) toolError("query is required.");
   const category = stringArg(args, "category").toLowerCase();
   const tokens = query.split(/\s+/).filter((token) => token.length > 1);
-  const rows = await storage.list<JsonRecord>("lorebook-entries").catch(() => []);
+  const rows = await loadSearchableStoredLorebookEntries(storage, input);
   const activated = input.activatedLorebookEntries.map((entry) => ({
     id: entry.id,
     name: entry.name,
@@ -201,10 +232,10 @@ export async function searchLorebookTool(storage: StorageGateway, input: ToolRun
     source: "activated",
   }));
   const stored = rows.map((entry) => ({
-    id: readString(entry.id),
-    name: readString(entry.name || entry.comment || entry.title, "Lorebook entry"),
-    content: readString(entry.content),
-    tag: readString(entry.tag || entry.category || entry.position),
+    id: entry.id,
+    name: entry.name || "Lorebook entry",
+    content: entry.content,
+    tag: entry.tag || String(entry.position),
     source: "stored",
   }));
   const seen = new Set<string>();


### PR DESCRIPTION
## Summary
- Scope built-in search_lorebook stored-entry fallback to lorebooks active for the current chat context
- Reuse prompt assembly lorebook/folder filtering for disabled books and disabled folders
- Add regression coverage for disabled, disabled-folder, and unrelated character-scoped entries

Fixes #1549

## Verification
- pnpm exec vitest run src/engine/generation/main-tool-loop.test.ts
- pnpm typecheck
- pnpm check:architecture