### PR TITLE
Add staged ESLint full report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ dist
 dist-ssr
 *.local
 *.tsbuildinfo
+.eslint-reports/
 
 # Local environment and app/runtime data
 .env

--- a/eslint.full-report.config.js
+++ b/eslint.full-report.config.js
@@ -1,0 +1,14 @@
+import js from "@eslint/js";
+
+import baseConfig from "./eslint.config.js";
+
+export default [
+  ...baseConfig,
+  {
+    name: "marinara/staged-js-recommended-report",
+    files: ["src/**/*.{js,jsx,mjs,cjs,ts,tsx}"],
+    rules: {
+      ...js.configs.recommended.rules,
+    },
+  },
+];

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint": "pnpm lint:eslint",
     "lint:all": "pnpm lint:eslint && pnpm format:check && pnpm lint:design",
     "lint:eslint": "eslint .",
+    "lint:eslint:full-report": "node scripts/eslint-full-report.mjs",
     "lint:design": "impeccable detect --fast src",
     "lint:design:report": "pnpm lint:design || test $? -eq 2",
     "check:architecture": "depcruise src --config .dependency-cruiser.cjs && node scripts/check-rust-structure.mjs",
@@ -57,6 +58,7 @@
     "zustand": "^5.0.12"
   },
   "devDependencies": {
+    "@eslint/js": "^9.39.4",
     "@lhci/cli": "^0.15.1",
     "@playwright/test": "^1.60.0",
     "@size-limit/preset-app": "^12.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
         specifier: ^5.0.12
         version: 5.0.13(@types/react@19.2.14)(react@19.2.6)
     devDependencies:
+      '@eslint/js':
+        specifier: ^9.39.4
+        version: 9.39.4
       '@lhci/cli':
         specifier: ^0.15.1
         version: 0.15.1

--- a/scripts/eslint-full-report.mjs
+++ b/scripts/eslint-full-report.mjs
@@ -2,6 +2,8 @@ import { ESLint } from "eslint";
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 
+import fullReportConfig from "../eslint.full-report.config.js";
+
 const args = process.argv.slice(2);
 const outputIndex = args.indexOf("--output");
 
@@ -14,7 +16,8 @@ const outputPath = path.resolve(process.cwd(), outputFile);
 
 const eslint = new ESLint({
   errorOnUnmatchedPattern: false,
-  overrideConfigFile: "eslint.full-report.config.js",
+  overrideConfig: fullReportConfig,
+  overrideConfigFile: true,
 });
 
 const results = await eslint.lintFiles(["."]);

--- a/scripts/eslint-full-report.mjs
+++ b/scripts/eslint-full-report.mjs
@@ -1,0 +1,58 @@
+import { ESLint } from "eslint";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+const args = process.argv.slice(2);
+const outputIndex = args.indexOf("--output");
+
+if (outputIndex !== -1 && !args[outputIndex + 1]) {
+  throw new Error("Missing value for --output");
+}
+
+const outputFile = outputIndex === -1 ? "scratch/eslint-full-report.json" : args[outputIndex + 1];
+const outputPath = path.resolve(process.cwd(), outputFile);
+
+const eslint = new ESLint({
+  errorOnUnmatchedPattern: false,
+  overrideConfigFile: "eslint.full-report.config.js",
+});
+
+const results = await eslint.lintFiles(["."]);
+const formatter = await eslint.loadFormatter("json");
+const report = await formatter.format(results);
+
+await mkdir(path.dirname(outputPath), { recursive: true });
+await writeFile(outputPath, report);
+
+const ruleCounts = new Map();
+let filesWithMessages = 0;
+let errorCount = 0;
+let warningCount = 0;
+
+for (const result of results) {
+  errorCount += result.errorCount;
+  warningCount += result.warningCount;
+
+  if (result.messages.length === 0) {
+    continue;
+  }
+
+  filesWithMessages += 1;
+
+  for (const message of result.messages) {
+    const ruleId = message.ruleId ?? "fatal-or-parser-error";
+    ruleCounts.set(ruleId, (ruleCounts.get(ruleId) ?? 0) + 1);
+  }
+}
+
+const topRules = [...ruleCounts.entries()].sort(([, left], [, right]) => right - left).slice(0, 10);
+
+console.log(`ESLint full report written to ${path.relative(process.cwd(), outputPath)}`);
+console.log(`${errorCount} errors, ${warningCount} warnings across ${filesWithMessages} files.`);
+
+if (topRules.length > 0) {
+  console.log("Top rules:");
+  for (const [ruleId, count] of topRules) {
+    console.log(`- ${ruleId}: ${count}`);
+  }
+}

--- a/scripts/eslint-full-report.mjs
+++ b/scripts/eslint-full-report.mjs
@@ -9,7 +9,7 @@ if (outputIndex !== -1 && !args[outputIndex + 1]) {
   throw new Error("Missing value for --output");
 }
 
-const outputFile = outputIndex === -1 ? "scratch/eslint-full-report.json" : args[outputIndex + 1];
+const outputFile = outputIndex === -1 ? ".eslint-reports/eslint-full-report.json" : args[outputIndex + 1];
 const outputPath = path.resolve(process.cwd(), outputFile);
 
 const eslint = new ESLint({


### PR DESCRIPTION
## Linked issue

Part of #1619

## Why this change

- Restore a reproducible ESLint recommended-rule report path for the refactor branch without making the known noisy findings CI-blocking.
- Preserve the existing architecture-focused lint gate as the blocking `pnpm lint` behavior while the broader rule buckets are classified.

## What changed

- Added `eslint.full-report.config.js` to layer `@eslint/js` recommended rules over the current architecture ESLint config for source files.
- Added `scripts/eslint-full-report.mjs` and `pnpm lint:eslint:full-report` to write a JSON report and print rule-count summaries.
- Made the report config a static import from the report script so Knip sees it as used while ESLint still uses the report-only config object.
- Defaulted generated reports to `.eslint-reports/eslint-full-report.json` and ignored that directory in the repo so clean clones do not need local `scratch/` setup.
- Added `@eslint/js` as a direct dev dependency so the staged config import is stable under pnpm.

## Refactor impact

Primary owner:

Tooling / lint configuration

Impact areas reviewed:

- Existing architecture lint config and `pnpm lint` gate
- Package scripts and lint dependency metadata
- Report output shape for staged ESLint restoration work
- Knip unused-file reporting for the new report config

Boundary notes:

- No runtime behavior changed.
- No engine, shared API, feature, Rust, Tauri, or remote-runtime boundary changed.
- The report config composes the existing architecture config instead of replacing it.

Pressure points touched:

- None. No ModeSurface, GameSurface, shared mode UI, command registration, or import workflow files touched.

## Validation

- [x] `pnpm check` passes locally
- [x] `pnpm typecheck` passes locally
- [x] `pnpm build` passes locally
- [x] `pnpm check:architecture` passes locally
- [x] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- `pnpm exec eslint . --format json --output-file scratch/eslint-current-refactor-2026-05-30-phase0.json` passed with 0 errors and 0 warnings.
- `pnpm lint:eslint:full-report` wrote `.eslint-reports/eslint-full-report.json` and exited successfully: 3,525 errors, 0 warnings across 373 files.
- `git check-ignore -v .eslint-reports\eslint-full-report.json` confirmed the default report output is ignored by repo `.gitignore`.
- Top staged report rules: `no-undef` 2,449; `no-unused-vars` 1,047; `no-useless-escape` 23; `require-yield` 2; `no-control-regex` 2; `no-redeclare` 2.
- `pnpm lint` passed.
- `pnpm typecheck` passed.
- `pnpm check:architecture` passed.
- `pnpm check:docs` passed.
- `pnpm check:unused` passed after making `eslint.full-report.config.js` a static import from the report script.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

No changelog update was made because this refactor checkout does not have a `CHANGELOG.md`, and the change is tooling-only with no runtime/user-facing behavior change.

## UI evidence

Not applicable; this is a config-only tooling change.
