### PR TITLE
Fix legacy chat branch group roots

### DIFF
--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -62,6 +62,7 @@ impl AppState {
         let backgrounds = AssetService::new(data_dir.join("backgrounds"))?;
         Self::seed_defaults(&storage, &game_assets, &backgrounds, default_data_roots)?;
         migrate_storage_json_fields(&storage)?;
+        migrate_legacy_chat_group_roots(&storage)?;
         migrate_local_media_references(&storage, &data_dir)?;
 
         Ok(Self {
@@ -218,6 +219,56 @@ fn migrate_collection_json_fields(storage: &FileStorage, collection: &str) -> Ap
     }
     if changed {
         storage.replace_all(collection, normalized_rows)?;
+    }
+    Ok(())
+}
+
+fn migrate_legacy_chat_group_roots(storage: &FileStorage) -> AppResult<()> {
+    let mut rows = storage.list("chats")?;
+    let referenced_group_ids: HashSet<String> = rows
+        .iter()
+        .filter_map(|row| {
+            row.get("groupId")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|group_id| !group_id.is_empty())
+                .map(ToOwned::to_owned)
+        })
+        .collect();
+    if referenced_group_ids.is_empty() {
+        return Ok(());
+    }
+
+    let mut changed = false;
+    for row in &mut rows {
+        let Some(object) = row.as_object_mut() else {
+            continue;
+        };
+        let Some(id) = object
+            .get("id")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|id| !id.is_empty())
+            .map(ToOwned::to_owned)
+        else {
+            continue;
+        };
+        if !referenced_group_ids.contains(&id) {
+            continue;
+        }
+        let has_group_id = object
+            .get("groupId")
+            .and_then(Value::as_str)
+            .is_some_and(|group_id| !group_id.trim().is_empty());
+        if has_group_id {
+            continue;
+        }
+        object.insert("groupId".to_string(), Value::String(id));
+        changed = true;
+    }
+
+    if changed {
+        storage.replace_all("chats", rows)?;
     }
     Ok(())
 }
@@ -780,6 +831,74 @@ mod tests {
         assert_ne!(background, old_asset_url);
         assert_eq!(background, "chat-1.webp");
         assert!(root.0.join("backgrounds/chat-1.webp").is_file());
+    }
+
+    #[test]
+    fn app_state_startup_enrolls_legacy_ungrouped_chat_roots() {
+        let root = temp_root("legacy-chat-root-groups");
+        let storage = FileStorage::new(root.0.join("data")).expect("storage should initialize");
+        for chat in [
+            json!({
+                "id": "root-1",
+                "mode": "roleplay",
+                "groupId": null,
+                "characterIds": [],
+                "metadata": {}
+            }),
+            json!({
+                "id": "branch-1",
+                "mode": "roleplay",
+                "groupId": "root-1",
+                "characterIds": [],
+                "metadata": {}
+            }),
+            json!({
+                "id": "unrelated-root",
+                "mode": "conversation",
+                "groupId": null,
+                "characterIds": [],
+                "metadata": {}
+            }),
+            json!({
+                "id": "already-grouped-root",
+                "mode": "roleplay",
+                "groupId": "existing-group",
+                "characterIds": [],
+                "metadata": {}
+            }),
+            json!({
+                "id": "existing-branch",
+                "mode": "roleplay",
+                "groupId": "already-grouped-root",
+                "characterIds": [],
+                "metadata": {}
+            }),
+        ] {
+            storage
+                .create("chats", chat)
+                .expect("chat row should be inserted");
+        }
+
+        let state = AppState::from_data_dir(&root.0, Vec::new()).expect("state should initialize");
+        let root_chat = state
+            .storage
+            .get("chats", "root-1")
+            .expect("root lookup should not fail")
+            .expect("root should still exist");
+        let unrelated = state
+            .storage
+            .get("chats", "unrelated-root")
+            .expect("unrelated lookup should not fail")
+            .expect("unrelated chat should still exist");
+        let already_grouped = state
+            .storage
+            .get("chats", "already-grouped-root")
+            .expect("grouped root lookup should not fail")
+            .expect("grouped root should still exist");
+
+        assert_eq!(root_chat["groupId"], "root-1");
+        assert_eq!(unrelated.get("groupId"), Some(&Value::Null));
+        assert_eq!(already_grouped["groupId"], "existing-group");
     }
 
     #[test]

--- a/src/app/shell/ChatSidebar.tsx
+++ b/src/app/shell/ChatSidebar.tsx
@@ -1234,9 +1234,9 @@ export function ChatSidebar({
                 <AlertTriangle size="1.125rem" className="text-[var(--destructive)]" />
               </div>
               <p className="text-sm text-[var(--muted-foreground)]">
-                This conversation has{" "}
-                <strong className="text-[var(--foreground)]">{deleteTarget.branchCount} branches</strong>. What would
-                you like to delete?
+                This group contains{" "}
+                <strong className="text-[var(--foreground)]">{deleteTarget.branchCount} chats</strong>. What would you
+                like to delete?
               </p>
             </div>
             <div className="flex flex-col gap-2">
@@ -1249,7 +1249,7 @@ export function ChatSidebar({
                 className="flex w-full items-center justify-center gap-1.5 rounded-xl bg-[var(--secondary)] px-3 py-2.5 text-xs font-medium ring-1 ring-[var(--border)] transition-all hover:bg-[var(--accent)] active:scale-[0.98]"
               >
                 <Trash2 size="0.8125rem" />
-                Delete This Branch Only
+                Delete This Chat Only
               </button>
               <button
                 onClick={() => {
@@ -1262,7 +1262,7 @@ export function ChatSidebar({
                 className="flex w-full items-center justify-center gap-1.5 rounded-xl bg-[var(--destructive)]/10 px-3 py-2.5 text-xs font-medium text-[var(--destructive)] ring-1 ring-[var(--destructive)]/20 transition-all hover:bg-[var(--destructive)]/20 active:scale-[0.98]"
               >
                 <Trash2 size="0.8125rem" />
-                Delete All {deleteTarget.branchCount} Branches
+                Delete Entire Group
               </button>
             </div>
           </div>

--- a/src/features/modes/shared/chat-ui/components/ChatFilesDrawer.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatFilesDrawer.tsx
@@ -341,15 +341,15 @@ export function ChatFilesDrawer({ chat, open, onClose }: ChatFilesDrawerProps) {
           </div>
         </div>
 
-        {/* Delete all branches */}
+        {/* Delete entire group */}
         <div className="border-t border-[var(--border)] px-4 py-3">
           <button
             onClick={async () => {
               if (
                 !(await showConfirmDialog({
-                  title: "Delete All Branches",
-                  message: `Delete all ${chatFiles.length} branches? This cannot be undone.`,
-                  confirmLabel: "Delete All",
+                  title: "Delete Entire Group",
+                  message: `Delete all ${chatFiles.length} chats in this group? This cannot be undone.`,
+                  confirmLabel: "Delete Group",
                   tone: "destructive",
                 }))
               ) {
@@ -363,7 +363,7 @@ export function ChatFilesDrawer({ chat, open, onClose }: ChatFilesDrawerProps) {
             className="flex w-full items-center justify-center gap-1.5 rounded-xl bg-[var(--destructive)]/10 px-3 py-2 text-xs font-medium text-[var(--destructive)] ring-1 ring-[var(--destructive)]/20 transition-all hover:bg-[var(--destructive)]/20 active:scale-[0.98] disabled:opacity-50"
           >
             <Trash2 size="0.8125rem" />
-            Delete All Branches
+            Delete Entire Group
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Linked issue

Closes #1522

## Why this change

- Branch group delete actions intentionally delete every chat in the group, including the original/root chat, but the UI still described the root-inclusive count as branches.
- Existing profiles could still have legacy branch groups where child chats point at the root chat id while the root chat keeps `groupId: null`, leaving Manage Chat Files unable to find the group from the root.

## What changed

- Reworded the app sidebar delete dialog and Manage Chat Files delete action to say group/chats instead of implying the original chat survives as a non-branch.
- Added a startup storage migration that enrolls legacy ungrouped root chats when another chat already references the root id as `groupId`.
- Added a startup migration test covering the positive root repair and negative controls for unrelated null roots and already-grouped roots.

## Refactor impact

Primary owner:

Rust storage startup migration; app shell chat sidebar; shared mode chat UI.

Impact areas reviewed:

- Chat/roleplay/conversation branch group listing and deletion labels.
- Startup storage migration path for existing user chat rows.
- Delete semantics in `delete_chat_group` were reviewed and intentionally left unchanged.

Boundary notes:

- Product deletion behavior remains in existing chat storage commands.
- React changes are copy-only and continue using existing hooks/API wrappers.
- No engine, raw Tauri invoke, remote runtime, or HTTP dispatch changes.

Pressure points touched:

- `src-tauri/src/state.rs` startup migration.
- `src/app/shell/ChatSidebar.tsx` delete dialog copy.
- `src/features/modes/shared/chat-ui/components/ChatFilesDrawer.tsx` delete group copy.

## Validation

- [ ] `pnpm check` passes locally
- [x] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [x] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [x] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [x] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- `cargo test --manifest-path src-tauri/Cargo.toml app_state_startup_enrolls_legacy_ungrouped_chat_roots`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `pnpm typecheck`
- `pnpm check:architecture`
- `git diff --check`
- Browser/Tauri manual UI verification was not run; UI changes are copy-only.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

Not added. The UI changes are wording-only in existing delete dialogs/buttons.