### PR TITLE
Normalize chat preset boolean flags

### DIFF
--- a/src-tauri/src/commands/storage/shared.rs
+++ b/src-tauri/src/commands/storage/shared.rs
@@ -398,6 +398,7 @@ pub(crate) fn normalize_typed_json_fields(
         }
         "chat-presets" => {
             normalize_json_object_fields(object, &["parameters"])?;
+            normalize_boolish_fields(object, &["isDefault", "default", "isActive", "active"]);
         }
         "prompts" => {
             normalize_json_array_fields(object, &["sectionOrder", "groupOrder", "variableOrder"])?;
@@ -468,6 +469,27 @@ fn normalize_json_object_fields(object: &mut Map<String, Value>, fields: &[&str]
         object.insert((*field).to_string(), normalized);
     }
     Ok(())
+}
+
+fn normalize_boolish_fields(object: &mut Map<String, Value>, fields: &[&str]) {
+    for field in fields {
+        let Some(value) = object.get_mut(*field) else {
+            continue;
+        };
+        if value.is_boolean() {
+            continue;
+        }
+        let normalized = match value.as_str().map(str::trim).map(str::to_ascii_lowercase) {
+            Some(raw) if raw == "true" || raw == "1" || raw == "yes" || raw == "on" => true,
+            Some(raw) if raw == "false" || raw == "0" || raw == "no" || raw == "off" => false,
+            _ => value
+                .as_i64()
+                .map(|number| number != 0)
+                .or_else(|| value.as_f64().map(|number| !number.is_nan() && number != 0.0))
+                .unwrap_or(false),
+        };
+        *value = Value::Bool(normalized);
+    }
 }
 
 fn normalize_nullable_json_object_fields(
@@ -1121,6 +1143,28 @@ mod tests {
         let mut record = json!("scalar");
         normalize_legacy_text_bool_fields(&mut record, &["flag"]);
         assert_eq!(record, json!("scalar"));
+    }
+
+    #[test]
+    fn chat_preset_defaults_normalize_boolish_flags() {
+        let row = with_entity_defaults(
+            "chat-presets",
+            json!({
+                "name": "Imported Preset",
+                "mode": "roleplay",
+                "parameters": {},
+                "isDefault": "false",
+                "default": "0",
+                "isActive": "true",
+                "active": "yes"
+            }),
+        )
+        .expect("chat preset defaults should normalize");
+
+        assert_eq!(row["isDefault"], json!(false));
+        assert_eq!(row["default"], json!(false));
+        assert_eq!(row["isActive"], json!(true));
+        assert_eq!(row["active"], json!(true));
     }
 
     #[test]

--- a/src/app/shell/useStartNewChat.ts
+++ b/src/app/shell/useStartNewChat.ts
@@ -2,8 +2,12 @@ import { useCallback } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { CHAT_MODES } from "../../engine/contracts/constants/chat-modes";
 import type { ChatMode } from "../../engine/contracts/types/chat";
-import type { ChatPreset } from "../../engine/contracts/types/chat-preset";
-import { chatPresetKeys, useApplyChatPreset } from "../../features/catalog/chat-presets/index";
+import {
+  chatPresetKeys,
+  findUserStarredChatPreset,
+  listChatPresets,
+  useApplyChatPreset,
+} from "../../features/catalog/chat-presets/index";
 import { useCreateChat } from "../../features/catalog/chats/index";
 import { connectionKeys } from "../../features/catalog/connections/index";
 import { storageApi } from "../../shared/api/storage-api";
@@ -45,14 +49,11 @@ export function useStartNewChat() {
       const presets = presetMode
         ? await queryClient.fetchQuery({
             queryKey: chatPresetKeys.list(null),
-            queryFn: () => storageApi.list<ChatPreset>("chat-presets"),
+            queryFn: () => listChatPresets(null),
             staleTime: 60_000,
           })
         : [];
-      const starred =
-        presetMode && presets
-          ? (presets.find((preset) => preset.mode === presetMode && preset.isActive && !preset.isDefault) ?? null)
-          : null;
+      const starred = findUserStarredChatPreset(presets, presetMode);
 
       createChat.mutate(
         {

--- a/src/engine/contracts/types/chat-preset.ts
+++ b/src/engine/contracts/types/chat-preset.ts
@@ -32,8 +32,12 @@ export interface ChatPreset {
   mode: ChatMode;
   /** True for the built-in "Default" preset (cannot be deleted, renamed, or saved into). */
   isDefault: boolean;
+  /** Legacy/default alias mirrored by imported rows and storage migrations. */
+  default?: boolean;
   /** True for the preset currently used as the starting state for new chats of this mode. */
   isActive: boolean;
+  /** Legacy/active alias mirrored by imported rows and storage migrations. */
+  active?: boolean;
   /** Bundled chat settings (JSON). */
   settings: ChatPresetSettings;
   createdAt: string;

--- a/src/features/catalog/characters/hooks/use-start-chat-from-character.ts
+++ b/src/features/catalog/characters/hooks/use-start-chat-from-character.ts
@@ -4,7 +4,7 @@ import { storageApi } from "../../../../shared/api/storage-api";
 import { filterLanguageGenerationConnections } from "../../../../shared/lib/connection-filters";
 import { useChatStore } from "../../../../shared/stores/chat.store";
 import { chatKeys, useCreateChat } from "../../chats/index";
-import { useApplyChatPreset, useChatPresets } from "../../chat-presets/index";
+import { findUserStarredChatPreset, useApplyChatPreset, useChatPresets } from "../../chat-presets/index";
 import { useConnections } from "../../connections/index";
 
 type ChatMode = "roleplay" | "conversation";
@@ -28,9 +28,7 @@ export function useStartChatFromCharacter() {
     ({ characterId, characterName, mode, firstMessage, alternateGreetings }: StartChatFromCharacterOptions) => {
       const label = mode === "conversation" ? "Conversation" : "Roleplay";
       const presetMode = mode === "conversation" ? "conversation" : "roleplay";
-      const starred = (chatPresetsData ?? []).find(
-        (preset) => preset.mode === presetMode && preset.isActive && !preset.isDefault,
-      );
+      const starred = findUserStarredChatPreset(chatPresetsData, presetMode);
       const connectionRows = filterLanguageGenerationConnections(
         (connections ?? []) as Array<{ id: string; provider?: string }>,
       ).filter((connection) => !!connection.id);

--- a/src/features/catalog/chat-presets/hooks/use-chat-presets.test.ts
+++ b/src/features/catalog/chat-presets/hooks/use-chat-presets.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { normalizeChatPresetFlags, sanitizeChatPresetSettings } from "./use-chat-presets";
+import { findUserStarredChatPreset, normalizeChatPresetFlags, sanitizeChatPresetSettings } from "./use-chat-presets";
 
 describe("sanitizeChatPresetSettings", () => {
   it("removes chat-specific summary metadata from saved presets", () => {
@@ -56,5 +56,49 @@ describe("normalizeChatPresetFlags", () => {
 
     expect(preset.isDefault).toBe(true);
     expect(preset.isActive).toBe(false);
+  });
+});
+
+describe("findUserStarredChatPreset", () => {
+  it("normalizes imported text boolean flags before choosing the starred preset", () => {
+    const starred = findUserStarredChatPreset(
+      [
+        {
+          id: "default-preset",
+          name: "Default",
+          mode: "roleplay",
+          isDefault: "true" as unknown as boolean,
+          isActive: "true" as unknown as boolean,
+          settings: {},
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+        },
+        {
+          id: "inactive-preset",
+          name: "Inactive",
+          mode: "roleplay",
+          isDefault: "false" as unknown as boolean,
+          isActive: "false" as unknown as boolean,
+          settings: {},
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+        },
+        {
+          id: "starred-preset",
+          name: "Starred",
+          mode: "roleplay",
+          isDefault: "false" as unknown as boolean,
+          isActive: "true" as unknown as boolean,
+          settings: {},
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+        },
+      ],
+      "roleplay",
+    );
+
+    expect(starred?.id).toBe("starred-preset");
+    expect(starred?.isDefault).toBe(false);
+    expect(starred?.isActive).toBe(true);
   });
 });

--- a/src/features/catalog/chat-presets/hooks/use-chat-presets.test.ts
+++ b/src/features/catalog/chat-presets/hooks/use-chat-presets.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { sanitizeChatPresetSettings } from "./use-chat-presets";
+import { normalizeChatPresetFlags, sanitizeChatPresetSettings } from "./use-chat-presets";
 
 describe("sanitizeChatPresetSettings", () => {
   it("removes chat-specific summary metadata from saved presets", () => {
@@ -20,5 +20,41 @@ describe("sanitizeChatPresetSettings", () => {
       promptPresetId: "prompt",
       metadata: { enableAgents: true },
     });
+  });
+});
+
+describe("normalizeChatPresetFlags", () => {
+  it("coerces imported text boolean flags before UI code reads them", () => {
+    const preset = normalizeChatPresetFlags({
+      id: "preset-1",
+      name: "Named Preset",
+      mode: "roleplay",
+      isDefault: "false" as unknown as boolean,
+      isActive: "true" as unknown as boolean,
+      settings: {},
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    });
+
+    expect(preset.isDefault).toBe(false);
+    expect(preset.isActive).toBe(true);
+  });
+
+  it("uses legacy default and active aliases when canonical flags are missing", () => {
+    const preset = normalizeChatPresetFlags({
+      id: "preset-2",
+      name: "Legacy Preset",
+      mode: "conversation",
+      isDefault: undefined as unknown as boolean,
+      isActive: undefined as unknown as boolean,
+      default: "1" as unknown as boolean,
+      active: "0" as unknown as boolean,
+      settings: {},
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    });
+
+    expect(preset.isDefault).toBe(true);
+    expect(preset.isActive).toBe(false);
   });
 });

--- a/src/features/catalog/chat-presets/hooks/use-chat-presets.ts
+++ b/src/features/catalog/chat-presets/hooks/use-chat-presets.ts
@@ -32,6 +32,23 @@ export function normalizeChatPresetFlags<T extends RawChatPreset>(preset: T): T 
   };
 }
 
+export async function listChatPresets(mode?: ChatMode | null): Promise<ChatPreset[]> {
+  const presets = (await storageApi.list<RawChatPreset>("chat-presets")).map(normalizeChatPresetFlags);
+  return mode ? presets.filter((preset) => preset.mode === mode) : presets;
+}
+
+export function findUserStarredChatPreset(
+  presets: readonly RawChatPreset[] | null | undefined,
+  mode: ChatMode | null,
+): ChatPreset | null {
+  if (!mode) return null;
+  return (
+    presets
+      ?.map(normalizeChatPresetFlags)
+      .find((preset) => preset.mode === mode && preset.isActive && !preset.isDefault) ?? null
+  );
+}
+
 export function sanitizeChatPresetSettings(settings: ChatPresetSettings | null | undefined): ChatPresetSettings {
   const clean: ChatPresetSettings = {};
   if (!settings) return clean;
@@ -69,10 +86,7 @@ async function setOnlyActivePreset(id: string): Promise<ChatPreset> {
 export function useChatPresets(mode?: ChatMode | null) {
   return useQuery({
     queryKey: chatPresetKeys.list(mode ?? null),
-    queryFn: async () => {
-      const presets = (await storageApi.list<RawChatPreset>("chat-presets")).map(normalizeChatPresetFlags);
-      return mode ? presets.filter((preset) => preset.mode === mode) : presets;
-    },
+    queryFn: () => listChatPresets(mode),
     staleTime: 60_000,
     refetchOnWindowFocus: false,
   });

--- a/src/features/catalog/chat-presets/hooks/use-chat-presets.ts
+++ b/src/features/catalog/chat-presets/hooks/use-chat-presets.ts
@@ -4,6 +4,7 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { chatPresetKeys } from "../query-keys";
 import { chatPresetSettingsSchema } from "../../../../engine/contracts/schemas/chat-preset.schema";
+import { boolish } from "../../../../engine/generation/runtime-records";
 import { storageApi } from "../../../../shared/api/storage-api";
 import { storageCommandsApi } from "../../../../shared/api/storage-commands-api";
 import { chatKeys } from "../../chats/query-keys";
@@ -17,6 +18,19 @@ import {
 export { chatPresetKeys } from "../query-keys";
 
 const EXCLUDED_METADATA_KEYS = new Set<string>(CHAT_PRESET_EXCLUDED_METADATA_KEYS);
+
+type RawChatPreset = ChatPreset & {
+  default?: unknown;
+  active?: unknown;
+};
+
+export function normalizeChatPresetFlags<T extends RawChatPreset>(preset: T): T & ChatPreset {
+  return {
+    ...preset,
+    isDefault: boolish(preset.isDefault ?? preset.default, false),
+    isActive: boolish(preset.isActive ?? preset.active, false),
+  };
+}
 
 export function sanitizeChatPresetSettings(settings: ChatPresetSettings | null | undefined): ChatPresetSettings {
   const clean: ChatPresetSettings = {};
@@ -36,9 +50,9 @@ export function sanitizeChatPresetSettings(settings: ChatPresetSettings | null |
 }
 
 async function setOnlyActivePreset(id: string): Promise<ChatPreset> {
-  const selected = await storageApi.get<ChatPreset>("chat-presets", id);
+  const selected = await storageApi.get<RawChatPreset>("chat-presets", id);
   if (!selected) throw new Error(`Chat preset ${id} was not found`);
-  const presets = await storageApi.list<ChatPreset>("chat-presets");
+  const presets = (await storageApi.list<RawChatPreset>("chat-presets")).map(normalizeChatPresetFlags);
   await Promise.all(
     presets
       .filter((preset) => preset.mode === selected.mode)
@@ -49,14 +63,14 @@ async function setOnlyActivePreset(id: string): Promise<ChatPreset> {
         }),
       ),
   );
-  return { ...selected, isActive: true, active: true } as ChatPreset;
+  return { ...normalizeChatPresetFlags(selected), isActive: true, active: true } as ChatPreset;
 }
 
 export function useChatPresets(mode?: ChatMode | null) {
   return useQuery({
     queryKey: chatPresetKeys.list(mode ?? null),
     queryFn: async () => {
-      const presets = await storageApi.list<ChatPreset>("chat-presets");
+      const presets = (await storageApi.list<RawChatPreset>("chat-presets")).map(normalizeChatPresetFlags);
       return mode ? presets.filter((preset) => preset.mode === mode) : presets;
     },
     staleTime: 60_000,

--- a/src/features/modes/shared/chat-ui/components/ChatSettingsDrawer.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatSettingsDrawer.tsx
@@ -1324,8 +1324,10 @@ function ChatSettingsDrawerInner({
       const match = presetList.find((p) => p.id === appliedPresetId);
       if (match) return match;
     }
-    return presetList.find((p) => p.isDefault) ?? null;
+    return presetList.find((p) => isEnabledFlag(p.isDefault ?? p.default, false)) ?? null;
   }, [presetList, appliedPresetId]);
+  const selectedChatPresetIsDefault = isEnabledFlag(selectedChatPreset?.isDefault ?? selectedChatPreset?.default, false);
+  const selectedChatPresetIsActive = isEnabledFlag(selectedChatPreset?.isActive ?? selectedChatPreset?.active, false);
   const [renamingPreset, setRenamingPreset] = useState(false);
   const [renamePresetVal, setRenamePresetVal] = useState("");
   const presetFileInputRef = useRef<HTMLInputElement | null>(null);
@@ -1533,23 +1535,23 @@ function ChatSettingsDrawerInner({
   };
 
   const handleToggleDefaultPreset = () => {
-    if (!selectedChatPreset || selectedChatPreset.isActive) return;
+    if (!selectedChatPreset || isEnabledFlag(selectedChatPreset.isActive ?? selectedChatPreset.active, false)) return;
     setActiveChatPreset.mutate(selectedChatPreset.id);
   };
 
   const handleSaveIntoPreset = () => {
-    if (!selectedChatPreset || selectedChatPreset.isDefault) return;
+    if (!selectedChatPreset || isEnabledFlag(selectedChatPreset.isDefault ?? selectedChatPreset.default, false)) return;
     saveChatPreset.mutate({ id: selectedChatPreset.id, settings: snapshotCurrentPresetSettings() });
   };
 
   const handleStartRenamePreset = () => {
-    if (!selectedChatPreset || selectedChatPreset.isDefault) return;
+    if (!selectedChatPreset || isEnabledFlag(selectedChatPreset.isDefault ?? selectedChatPreset.default, false)) return;
     setRenamePresetVal(selectedChatPreset.name);
     setRenamingPreset(true);
   };
 
   const handleCommitRenamePreset = () => {
-    if (!selectedChatPreset || selectedChatPreset.isDefault) {
+    if (!selectedChatPreset || isEnabledFlag(selectedChatPreset.isDefault ?? selectedChatPreset.default, false)) {
       setRenamingPreset(false);
       return;
     }
@@ -1589,7 +1591,7 @@ function ChatSettingsDrawerInner({
   };
 
   const handleDeletePreset = async () => {
-    if (!selectedChatPreset || selectedChatPreset.isDefault) return;
+    if (!selectedChatPreset || isEnabledFlag(selectedChatPreset.isDefault ?? selectedChatPreset.default, false)) return;
     const ok = await showConfirmDialog({
       title: "Delete Preset",
       message: `Delete preset "${selectedChatPreset.name}"? This cannot be undone.`,
@@ -1598,7 +1600,7 @@ function ChatSettingsDrawerInner({
     });
     if (!ok) return;
     const wasApplied = selectedChatPreset.id === appliedPresetId;
-    const defaultPreset = presetList.find((p) => p.isDefault);
+    const defaultPreset = presetList.find((p) => isEnabledFlag(p.isDefault ?? p.default, false));
     deleteChatPreset.mutate(selectedChatPreset.id, {
       onSuccess: () => {
         // If the chat was using the preset we just deleted, fall back to the
@@ -1750,34 +1752,34 @@ function ChatSettingsDrawerInner({
                   {presetList.length === 0 && <option value="">Loading…</option>}
                   {presetList.map((p) => (
                     <option key={p.id} value={p.id}>
-                      {p.isDefault ? "Default" : p.name}
+                      {isEnabledFlag(p.isDefault ?? p.default, false) ? "Default" : p.name}
                     </option>
                   ))}
                 </select>
               )}
               <button
                 onClick={handleToggleDefaultPreset}
-                disabled={!selectedChatPreset || selectedChatPreset.isActive || setActiveChatPreset.isPending}
+                disabled={!selectedChatPreset || selectedChatPresetIsActive || setActiveChatPreset.isPending}
                 title={
                   !selectedChatPreset
                     ? "Select a preset to mark it as default"
-                    : selectedChatPreset.isActive
+                    : selectedChatPresetIsActive
                       ? "This preset is the default for new chats in this mode"
                       : "Mark this preset as default for new chats in this mode"
                 }
-                aria-pressed={!!selectedChatPreset?.isActive}
-                aria-label={selectedChatPreset?.isActive ? "Default preset" : "Mark as default preset"}
+                aria-pressed={selectedChatPresetIsActive}
+                aria-label={selectedChatPresetIsActive ? "Default preset" : "Mark as default preset"}
                 className={cn(
                   "shrink-0 flex items-center justify-center rounded-md p-1.5 transition-colors disabled:cursor-not-allowed",
-                  selectedChatPreset?.isActive
+                  selectedChatPresetIsActive
                     ? "text-yellow-400 disabled:opacity-100"
                     : "text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-yellow-400 disabled:opacity-40",
                 )}
               >
                 <Star
                   size="0.875rem"
-                  fill={selectedChatPreset?.isActive ? "currentColor" : "none"}
-                  strokeWidth={selectedChatPreset?.isActive ? 1.5 : 2}
+                  fill={selectedChatPresetIsActive ? "currentColor" : "none"}
+                  strokeWidth={selectedChatPresetIsActive ? 1.5 : 2}
                 />
               </button>
               <HelpTooltip
@@ -1793,9 +1795,9 @@ function ChatSettingsDrawerInner({
             <div className="flex items-center gap-1">
               <button
                 onClick={handleSaveIntoPreset}
-                disabled={!selectedChatPreset || selectedChatPreset.isDefault}
+                disabled={!selectedChatPreset || selectedChatPresetIsDefault}
                 title={
-                  selectedChatPreset?.isDefault
+                  selectedChatPresetIsDefault
                     ? "Cannot save into the Default preset"
                     : "Save current chat settings into this preset"
                 }
@@ -1805,8 +1807,8 @@ function ChatSettingsDrawerInner({
               </button>
               <button
                 onClick={handleStartRenamePreset}
-                disabled={!selectedChatPreset || selectedChatPreset.isDefault}
-                title={selectedChatPreset?.isDefault ? "Cannot rename the Default preset" : "Rename preset"}
+                disabled={!selectedChatPreset || selectedChatPresetIsDefault}
+                title={selectedChatPresetIsDefault ? "Cannot rename the Default preset" : "Rename preset"}
                 className="flex-1 flex items-center justify-center rounded-md p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] disabled:cursor-not-allowed disabled:opacity-40"
               >
                 <Pencil size="0.875rem" />
@@ -1837,8 +1839,8 @@ function ChatSettingsDrawerInner({
               </button>
               <button
                 onClick={handleDeletePreset}
-                disabled={!selectedChatPreset || selectedChatPreset.isDefault}
-                title={selectedChatPreset?.isDefault ? "Cannot delete the Default preset" : "Delete preset"}
+                disabled={!selectedChatPreset || selectedChatPresetIsDefault}
+                title={selectedChatPresetIsDefault ? "Cannot delete the Default preset" : "Delete preset"}
                 className="flex-1 flex items-center justify-center rounded-md p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--destructive)]/15 hover:text-[var(--destructive)] disabled:cursor-not-allowed disabled:opacity-40"
               >
                 <Trash2 size="0.875rem" />

--- a/src/features/modes/shared/chat-ui/components/ChatSetupWizard.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatSetupWizard.tsx
@@ -30,6 +30,7 @@ import { useUpdateChat, useUpdateChatMetadata, useCreateMessage, chatKeys } from
 import { useChatPresets, useApplyChatPreset } from "../../../../catalog/chat-presets/index";
 import { useUIStore } from "../../../../../shared/stores/ui.store";
 import { useChatStore } from "../../../../../shared/stores/chat.store";
+import { boolish } from "../../../../../engine/generation/runtime-records";
 import { generateConversationSchedules } from "../../../../../engine/modes/chat/schedules/schedule.service";
 import { llmApi } from "../../../../../shared/api/llm-api";
 import { storageApi } from "../../../../../shared/api/storage-api";
@@ -1084,8 +1085,8 @@ function RoleplaySetupWizard({ chat, onFinish }: ChatSetupWizardProps) {
     if (chatPresetList.length === 0) return;
     const appliedId = (metadata.appliedChatPresetId as string | undefined) ?? null;
     const applied = appliedId ? chatPresetList.find((p) => p.id === appliedId) : null;
-    const starred = chatPresetList.find((p) => p.isActive);
-    const fallback = chatPresetList.find((p) => p.isDefault);
+    const starred = chatPresetList.find((p) => boolish(p.isActive ?? p.active, false));
+    const fallback = chatPresetList.find((p) => boolish(p.isDefault ?? p.default, false));
     const pick = applied ?? starred ?? fallback;
     if (pick) setShortcutPresetId(pick.id);
   }, [chatPresetList, shortcutPresetId, metadata.appliedChatPresetId]);
@@ -1474,7 +1475,7 @@ function RoleplaySetupWizard({ chat, onFinish }: ChatSetupWizardProps) {
                     {chatPresetList.length === 0 && <option value="">Loading…</option>}
                     {chatPresetList.map((p) => (
                       <option key={p.id} value={p.id}>
-                        {p.isDefault ? "Default" : p.name}
+                        {boolish(p.isDefault ?? p.default, false) ? "Default" : p.name}
                       </option>
                     ))}
                   </select>

--- a/src/features/modes/shared/chat-ui/components/NewChatConnectionGate.tsx
+++ b/src/features/modes/shared/chat-ui/components/NewChatConnectionGate.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { BookOpen, Loader2, MessageCircle, Plug, Settings, X } from "lucide-react";
 import { useCreateChat } from "../../../../catalog/chats/index";
-import { useApplyChatPreset, useChatPresets } from "../../../../catalog/chat-presets/index";
+import { findUserStarredChatPreset, useApplyChatPreset, useChatPresets } from "../../../../catalog/chat-presets/index";
 import { useConnections } from "../../../../catalog/connections/index";
 import { filterLanguageGenerationConnections } from "../../../../../shared/lib/connection-filters";
 import { cn } from "../../../../../shared/lib/utils";
@@ -59,9 +59,7 @@ export function NewChatConnectionGate({ mode, onClose }: NewChatConnectionGatePr
     const label = MODE_META[mode].label;
     const presets = chatPresetsData ?? [];
     const presetMode = mode === "conversation" || mode === "roleplay" ? mode : null;
-    const starred = presetMode
-      ? (presets.find((preset) => preset.mode === presetMode && preset.isActive && !preset.isDefault) ?? null)
-      : null;
+    const starred = findUserStarredChatPreset(presets, presetMode);
     createChat.mutate(
       {
         name: `New ${label}`,


### PR DESCRIPTION
## Linked issue

Closes #1523

## Why this change

- Imported or legacy chat-settings preset rows can store boolean flags as strings such as `"false"`.
- The Chat Settings drawer and setup wizard used those raw truthy values, so every preset could render as `Default` and default/active selection logic could choose the wrong row.

## What changed

- Normalized `isDefault`, `default`, `isActive`, and `active` at the Rust storage typed-field boundary for `chat-presets`.
- Normalized chat preset flags again in `useChatPresets` so UI code gets booleans even before older rows are rewritten.
- Updated Chat Settings drawer and Roleplay setup wizard preset selection/rendering to use boolish flag checks.
- Added Rust and Vitest coverage for text boolean coercion and legacy alias handling.

## Refactor impact

Primary owner:

Rust storage normalization; catalog chat preset hook; shared mode chat UI.

Impact areas reviewed:

- Chat Settings drawer preset dropdown, default/star controls, save/rename/delete guards.
- Roleplay setup wizard preset defaulting/dropdown labels.
- Storage/import boundary for chat preset boolean-ish fields.

Boundary notes:

- Storage normalization stays in `src-tauri` shared storage typed-field handling.
- Feature UI continues to use catalog hooks and existing storage API wrappers.
- No raw Tauri invoke, remote runtime, HTTP dispatch, or engine-to-React boundary changes.

Pressure points touched:

- `src-tauri/src/commands/storage/shared.rs` typed JSON/flag normalization.
- `src/features/catalog/chat-presets/hooks/use-chat-presets.ts` catalog hook normalization.
- `src/features/modes/shared/chat-ui/components/ChatSettingsDrawer.tsx` shared mode UI.
- `src/features/modes/shared/chat-ui/components/ChatSetupWizard.tsx` shared mode UI.

## Validation

- [ ] `pnpm check` passes locally
- [x] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [x] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [x] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [x] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- `cargo test --manifest-path src-tauri/Cargo.toml chat_preset_defaults_normalize_boolish_flags`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `pnpm exec vitest run src/features/catalog/chat-presets/hooks/use-chat-presets.test.ts`
- `pnpm typecheck`
- `pnpm check:architecture`
- `git diff --check`
- Browser/Tauri manual UI verification was not run; behavior is covered by storage/hook tests and typecheck.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

Not added. The visible change is corrected dropdown/default-control behavior for legacy/imported preset flags, covered by focused hook/storage tests.