### PR TITLE
Fix scene fork continuity visibility

### DIFF
--- a/src/engine/modes/roleplay/scene/scene-service.test.ts
+++ b/src/engine/modes/roleplay/scene/scene-service.test.ts
@@ -282,3 +282,82 @@ describe("forkRoleplayScene folderId inheritance", () => {
     expect(payloads[0]?.folderId).toBe("folder-xyz");
   });
 });
+
+describe("forkRoleplayScene continuity", () => {
+  it("stores cloned scene continuity as prompt-visible hidden context", async () => {
+    const storage = recordingStorage({
+      "scene-1": {
+        id: "scene-1",
+        name: "Scene: Continuity",
+        mode: "roleplay",
+        characterIds: ["char-a"],
+        folderId: null,
+        groupId: null,
+        personaId: null,
+        promptPresetId: null,
+        connectionId: null,
+        metadata: {
+          sceneOriginChatId: "origin-x",
+          sceneStatus: "active",
+          sceneConversationContext: "user: The origin user remembers the old promise.",
+          sceneRelationshipHistory: "They trust each other after the archive rescue.",
+          sceneScenario: "A midnight meeting in the observatory.",
+        },
+      },
+    });
+
+    const input: SceneForkRequest = {
+      sceneChatId: "scene-1",
+      mode: "clone",
+      includePreSceneSummary: true,
+      includeParticipationGuide: false,
+    };
+
+    await forkRoleplayScene(storage.gateway, input);
+
+    expect(storage.chatMessages).toHaveLength(1);
+    expect(storage.chatMessages[0]).toMatchObject({
+      role: "narrator",
+      extra: {
+        hiddenFromUser: true,
+        isSceneContinuity: true,
+      },
+    });
+    expect((storage.chatMessages[0]?.extra as JsonRecord).hiddenFromAi).toBeUndefined();
+    expect(storage.chatMessages[0]?.content).toContain("The origin user remembers the old promise.");
+    expect(storage.chatMessages[0]?.content).toContain("They trust each other after the archive rescue.");
+    expect(storage.chatMessages[0]?.content).toContain("A midnight meeting in the observatory.");
+  });
+
+  it("does not create continuity context when pre-scene summary carryover is disabled", async () => {
+    const storage = recordingStorage({
+      "scene-1": {
+        id: "scene-1",
+        name: "Scene: No Continuity",
+        mode: "roleplay",
+        characterIds: ["char-a"],
+        folderId: null,
+        groupId: null,
+        personaId: null,
+        promptPresetId: null,
+        connectionId: null,
+        metadata: {
+          sceneOriginChatId: "origin-x",
+          sceneStatus: "active",
+          sceneConversationContext: "user: This should not be copied.",
+        },
+      },
+    });
+
+    const input: SceneForkRequest = {
+      sceneChatId: "scene-1",
+      mode: "clone",
+      includePreSceneSummary: false,
+      includeParticipationGuide: false,
+    };
+
+    await forkRoleplayScene(storage.gateway, input);
+
+    expect(storage.chatMessages).toHaveLength(0);
+  });
+});

--- a/src/engine/modes/roleplay/scene/scene-service.ts
+++ b/src/engine/modes/roleplay/scene/scene-service.ts
@@ -260,7 +260,7 @@ export async function forkRoleplayScene(
       await createChatMessage(storage, forkChatId, {
         role: "narrator",
         content: continuity,
-        extra: { hiddenFromAi: true, isSceneContinuity: true },
+        extra: { hiddenFromUser: true, isSceneContinuity: true },
       });
     }
   }


### PR DESCRIPTION
## Linked issue

Closes #1517

## Why this change

- Scene clone/convert created a continuity message, but marked it hidden from AI, so future generation prompts dropped the origin/scene context that the fork was meant to preserve.

## What changed

- Stores fork continuity as `hiddenFromUser` instead of `hiddenFromAi`, keeping it out of the visible transcript while allowing prompt assembly to include it.
- Adds focused engine tests for the prompt-visible continuity shape and the disabled carryover negative control.

## Refactor impact

Primary owner:

roleplay mode engine scene service

Impact areas reviewed:

- `forkRoleplayScene(...)`
- fork continuity message metadata
- prompt hidden-from-AI semantics
- Roleplay surface `hiddenFromUser` transcript filtering

Boundary notes:

- Engine-only behavior change; no React imports, shared API, Rust, or remote-runtime boundaries changed.
- The existing UI-hidden context contract is used instead of adding prompt-assembly exceptions or compatibility branches.

Pressure points touched:

- `src/engine/modes/roleplay/scene/scene-service.ts`
- `src/engine/modes/roleplay/scene/scene-service.test.ts`

## Validation

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Agent-ran checks:
- `pnpm exec vitest run src/engine/modes/roleplay/scene/scene-service.test.ts` passed.
- `pnpm typecheck` passed.
- `pnpm check:architecture` passed.
- Manual generation prompt snapshot repro was not run.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

Docs/release notes: not needed; this is a narrow bug fix to existing scene fork continuity behavior.

## UI evidence

Not applicable; engine continuity metadata behavior validated by tests above.
