### PR TITLE
Fix concluded scene message actions

### DIFF
--- a/src/features/modes/shared/chat-ui/components/ChatMessage.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatMessage.tsx
@@ -2014,21 +2014,32 @@ export const ChatMessage = memo(function ChatMessage({
                 className={translatedText ? "text-blue-400/80 hover:text-blue-300" : undefined}
                 dark
               />
-              <ActionBtn icon={<Pencil size={MESSAGE_ACTION_ICON_SIZE} />} onClick={startEditing} title="Edit" dark />
-              <ActionBtn
-                icon={<RefreshCw size={MESSAGE_ACTION_ICON_SIZE} />}
-                onClick={() => onRegenerate?.(message.id)}
-                title={regenerateButtonTitle}
-                className={regenerateGuidedClass}
-                dark
-              />
-              <ActionBtn
-                icon={<Flag size={MESSAGE_ACTION_ICON_SIZE} />}
-                onClick={() => onToggleConversationStart?.(message.id, isConversationStart)}
-                title={isConversationStart ? "Remove conversation start" : "Mark as new start"}
-                className={isConversationStart ? "text-amber-400/80 hover:text-amber-300" : undefined}
-                dark
-              />
+              {onEdit && (
+                <ActionBtn
+                  icon={<Pencil size={MESSAGE_ACTION_ICON_SIZE} />}
+                  onClick={startEditing}
+                  title="Edit"
+                  dark
+                />
+              )}
+              {onRegenerate && (
+                <ActionBtn
+                  icon={<RefreshCw size={MESSAGE_ACTION_ICON_SIZE} />}
+                  onClick={() => onRegenerate(message.id)}
+                  title={regenerateButtonTitle}
+                  className={regenerateGuidedClass}
+                  dark
+                />
+              )}
+              {onToggleConversationStart && (
+                <ActionBtn
+                  icon={<Flag size={MESSAGE_ACTION_ICON_SIZE} />}
+                  onClick={() => onToggleConversationStart(message.id, isConversationStart)}
+                  title={isConversationStart ? "Remove conversation start" : "Mark as new start"}
+                  className={isConversationStart ? "text-amber-400/80 hover:text-amber-300" : undefined}
+                  dark
+                />
+              )}
               {onToggleHiddenFromAI && (
                 <ActionBtn
                   icon={
@@ -2091,13 +2102,15 @@ export const ChatMessage = memo(function ChatMessage({
                   dark
                 />
               )}
-              <ActionBtn
-                icon={<Trash2 size={MESSAGE_ACTION_ICON_SIZE} />}
-                onClick={() => onDelete?.(message.id)}
-                title="Delete"
-                className="hover:text-red-400"
-                dark
-              />
+              {onDelete && (
+                <ActionBtn
+                  icon={<Trash2 size={MESSAGE_ACTION_ICON_SIZE} />}
+                  onClick={() => onDelete(message.id)}
+                  title="Delete"
+                  className="hover:text-red-400"
+                  dark
+                />
+              )}
               {ttsEnabled && (
                 <>
                   {isSpeakingThis && !isLoadingThis && (
@@ -2459,19 +2472,25 @@ export const ChatMessage = memo(function ChatMessage({
               title={translatedText ? "Hide translation" : "Translate"}
               className={translatedText ? "text-blue-500" : undefined}
             />
-            <ActionBtn icon={<Pencil size={MESSAGE_ACTION_ICON_SIZE} />} onClick={startEditing} title="Edit" />
-            <ActionBtn
-              icon={<RefreshCw size={MESSAGE_ACTION_ICON_SIZE} />}
-              onClick={() => onRegenerate?.(message.id)}
-              title={regenerateButtonTitle}
-              className={regenerateGuidedClass}
-            />
-            <ActionBtn
-              icon={<Flag size={MESSAGE_ACTION_ICON_SIZE} />}
-              onClick={() => onToggleConversationStart?.(message.id, isConversationStart)}
-              title={isConversationStart ? "Remove conversation start" : "Mark as new start"}
-              className={isConversationStart ? "text-amber-500" : undefined}
-            />
+            {onEdit && (
+              <ActionBtn icon={<Pencil size={MESSAGE_ACTION_ICON_SIZE} />} onClick={startEditing} title="Edit" />
+            )}
+            {onRegenerate && (
+              <ActionBtn
+                icon={<RefreshCw size={MESSAGE_ACTION_ICON_SIZE} />}
+                onClick={() => onRegenerate(message.id)}
+                title={regenerateButtonTitle}
+                className={regenerateGuidedClass}
+              />
+            )}
+            {onToggleConversationStart && (
+              <ActionBtn
+                icon={<Flag size={MESSAGE_ACTION_ICON_SIZE} />}
+                onClick={() => onToggleConversationStart(message.id, isConversationStart)}
+                title={isConversationStart ? "Remove conversation start" : "Mark as new start"}
+                className={isConversationStart ? "text-amber-500" : undefined}
+              />
+            )}
             {isLastAssistantMessage && !isUser && (
               <ActionBtn
                 icon={<Search size={MESSAGE_ACTION_ICON_SIZE} />}
@@ -2514,12 +2533,14 @@ export const ChatMessage = memo(function ChatMessage({
                 disabled={isCloneSceneFromHereDisabled}
               />
             )}
-            <ActionBtn
-              icon={<Trash2 size={MESSAGE_ACTION_ICON_SIZE} />}
-              onClick={() => onDelete?.(message.id)}
-              title="Delete"
-              className="hover:text-[var(--destructive)]"
-            />
+            {onDelete && (
+              <ActionBtn
+                icon={<Trash2 size={MESSAGE_ACTION_ICON_SIZE} />}
+                onClick={() => onDelete(message.id)}
+                title="Delete"
+                className="hover:text-[var(--destructive)]"
+              />
+            )}
             {ttsEnabled && (
               <>
                 {isSpeakingThis && !isLoadingThis && (


### PR DESCRIPTION
## Linked issue

Closes #1516

## Why this change

- Concluded Roleplay scenes are read-only, but message rows still displayed enabled-looking mutation actions after the scene ended.

## What changed

- Hides message mutation actions when their owning surface does not provide a handler.
- Leaves non-mutating/read actions like copy, translate, prompt peek, replay details, thoughts, and TTS available.

## Refactor impact

Primary owner:

shared mode UI, Roleplay mode caller contract

Impact areas reviewed:

- `ChatRoleplaySurface` concluded-scene `messageActions` contract
- shared `ChatMessage` roleplay action rendering
- conversation/texting message action rendering

Boundary notes:

- No engine, shared API, Rust, or remote-runtime boundaries changed.
- The Roleplay surface still owns concluded-scene read-only state; `ChatMessage` now respects absent handler capability before rendering mutation buttons.

Pressure points touched:

- shared mode UI: `src/features/modes/shared/chat-ui/components/ChatMessage.tsx`

## Validation

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Agent-ran checks:
- `pnpm exec vitest run src/features/modes/shared/chat-ui/components/ChatMessage.test.ts` passed.
- `pnpm typecheck` passed.
- `pnpm check:architecture` passed.
- Manual browser/Tauri repro was not run.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

Docs/release notes: not needed; this is a narrow bug fix to existing concluded-scene read-only UI behavior.

## UI evidence

Not captured; validated by code path and checks above.
