### PR TITLE
Scope TypeScript no-undef in staged ESLint report

### DIFF
--- a/eslint.full-report.config.js
+++ b/eslint.full-report.config.js
@@ -11,4 +11,11 @@ export default [
       ...js.configs.recommended.rules,
     },
   },
+  {
+    name: "marinara/staged-typescript-name-resolution",
+    files: ["src/**/*.{ts,tsx}"],
+    rules: {
+      "no-undef": "off",
+    },
+  },
 ];


### PR DESCRIPTION
## Linked issue

Part of #1619

## Why this change

- Phase 1 of ESLint restoration needs the staged report to stop treating TypeScript and DOM/browser names as undefined globals.
- TypeScript already owns name resolution for TS/TSX source, so base ESLint `no-undef` is fake noise there and hides the actionable lint buckets.

## What changed

- Added a staged-report-only override in `eslint.full-report.config.js` that disables base `no-undef` for `src/**/*.{ts,tsx}`.
- Kept `@eslint/js` recommended rules enabled for the staged report and left the blocking `pnpm lint` architecture gate unchanged.

## Refactor impact

Primary owner:

Tooling / lint configuration

Impact areas reviewed:

- Staged ESLint full-report config
- Existing blocking `pnpm lint` behavior
- TypeScript name-resolution proof path

Boundary notes:

- No runtime behavior changed.
- No engine, shared API, feature, Rust, Tauri, or remote-runtime boundary changed.
- This only changes diagnostic output for the optional staged report command.

Pressure points touched:

- None. No ModeSurface, GameSurface, shared mode UI, command registration, or import workflow files touched.

## Validation

- [x] `pnpm check` passes locally
- [x] `pnpm typecheck` passes locally
- [x] `pnpm build` passes locally
- [x] `pnpm check:architecture` passes locally
- [x] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- `pnpm lint:eslint:full-report -- --output .eslint-reports/eslint-full-report-before-no-undef-scope.json` before the change reported 3,543 errors across 374 files, including `no-undef`: 2,467.
- `pnpm lint:eslint:full-report -- --output .eslint-reports/eslint-full-report-after-no-undef-scope.json` after the change reported 1,076 errors across 229 files, with `no-undef`: 0.
- Remaining top rules after the change: `no-unused-vars` 1,047; `no-useless-escape` 23; `require-yield` 2; `no-control-regex` 2; `no-redeclare` 2.
- `pnpm lint` passed.
- `pnpm typecheck` passed.
- `pnpm check:architecture` passed.
- `pnpm check:docs` passed.
- `pnpm check:unused` passed.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

No changelog update was made because this refactor checkout does not have a `CHANGELOG.md`, and the change is tooling-only with no runtime/user-facing behavior change.

## UI evidence

Not applicable; this is a config-only tooling change.
