### PR TITLE
Add TypeScript ESLint staged report rules

### DIFF
--- a/eslint.full-report.config.js
+++ b/eslint.full-report.config.js
@@ -1,20 +1,43 @@
 import js from "@eslint/js";
+import tseslint from "typescript-eslint";
 
 import baseConfig from "./eslint.config.js";
+
+const sourceFiles = ["src/**/*.{js,jsx,mjs,cjs,ts,tsx}"];
+const tsSourceFiles = ["src/**/*.{ts,tsx}"];
+const stagedTypeScriptRecommendedConfigs = tseslint.configs.recommended.slice(1).map((config) => ({
+  ...config,
+  name: `marinara/staged-${config.name}`,
+  files: tsSourceFiles,
+}));
 
 export default [
   ...baseConfig,
   {
     name: "marinara/staged-js-recommended-report",
-    files: ["src/**/*.{js,jsx,mjs,cjs,ts,tsx}"],
+    files: sourceFiles,
     rules: {
       ...js.configs.recommended.rules,
     },
   },
+  ...stagedTypeScriptRecommendedConfigs,
   {
-    name: "marinara/staged-typescript-name-resolution",
-    files: ["src/**/*.{ts,tsx}"],
+    name: "marinara/staged-typescript-pragmatic-relaxations",
+    files: tsSourceFiles,
     rules: {
+      "@typescript-eslint/no-empty-object-type": "off",
+      "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/no-unused-vars": [
+        "warn",
+        {
+          argsIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+          destructuredArrayIgnorePattern: "^_",
+          ignoreRestSiblings: true,
+          varsIgnorePattern: "^_",
+        },
+      ],
+      "no-empty-pattern": "off",
       "no-undef": "off",
     },
   },


### PR DESCRIPTION
## Linked issue

Part of #1619

## Why this change

- Phase 2 restores TypeScript ESLint recommended diagnostics in the staged full-report path without changing the blocking architecture lint gate.
- The previous staged report still had a huge base `no-unused-vars` bucket that treated TypeScript syntax poorly; TypeScript ESLint gives cleaner signal.

## What changed

- Layered `typescript-eslint` recommended rule configs over `src/**/*.{ts,tsx}` in `eslint.full-report.config.js`.
- Kept the existing architecture config as the base layer.
- Kept pragmatic Phase 2 relaxations for report-only triage: `@typescript-eslint/no-explicit-any` off, `@typescript-eslint/no-empty-object-type` off, `no-empty-pattern` off, `no-undef` off for TS/TSX, and `@typescript-eslint/no-unused-vars` warning-level with `_` ignore patterns.

## Refactor impact

Primary owner:

Tooling / lint configuration

Impact areas reviewed:

- Staged ESLint full-report config
- Existing blocking `pnpm lint` behavior
- TypeScript ESLint recommended rule composition
- Knip visibility for the report config

Boundary notes:

- No runtime behavior changed.
- No engine, shared API, feature, Rust, Tauri, or remote-runtime boundary changed.
- This only changes diagnostic output for the optional staged report command.

Pressure points touched:

- None. No ModeSurface, GameSurface, shared mode UI, command registration, or import workflow files touched.

## Validation

- [x] `pnpm check` passes locally
- [x] `pnpm typecheck` passes locally
- [x] `pnpm build` passes locally
- [x] `pnpm check:architecture` passes locally
- [x] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- `pnpm lint:eslint:full-report -- --output .eslint-reports/eslint-full-report-before-ts-recommended.json` before the change reported 1,076 errors, 0 warnings across 229 files. Rule counts: `no-unused-vars` 1,047; `no-useless-escape` 23; `require-yield` 2; `no-control-regex` 2; `no-redeclare` 2.
- `pnpm lint:eslint:full-report -- --output .eslint-reports/eslint-full-report-after-ts-recommended.json` after the change reported 28 errors, 0 warnings across 10 files. Rule counts: `no-useless-escape` 23; `require-yield` 2; `no-control-regex` 2; `prefer-const` 1.
- `pnpm lint` passed.
- `pnpm typecheck` passed.
- `pnpm check:architecture` passed.
- `pnpm check:docs` passed.
- `pnpm check:unused` passed.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

No changelog update was made because this refactor checkout does not have a `CHANGELOG.md`, and the change is tooling-only with no runtime/user-facing behavior change.

## UI evidence

Not applicable; this is a config-only tooling change.
