### PR TITLE
Add React Hooks staged report rules

### DIFF
--- a/eslint.full-report.config.js
+++ b/eslint.full-report.config.js
@@ -22,6 +22,14 @@ export default [
   },
   ...stagedTypeScriptRecommendedConfigs,
   {
+    name: "marinara/staged-react-hooks-report",
+    files: tsSourceFiles,
+    rules: {
+      "react-hooks/rules-of-hooks": "error",
+      "react-hooks/exhaustive-deps": "warn",
+    },
+  },
+  {
     name: "marinara/staged-typescript-pragmatic-relaxations",
     files: tsSourceFiles,
     rules: {


### PR DESCRIPTION
## Linked issue

Part of #1619

## Why this change

- Continues the ESLint restoration plan by surfacing React Hooks diagnostics in the optional full-report path after the TypeScript recommended cleanup reduced the baseline.

## What changed

- Adds a staged React Hooks report override for `react-hooks/rules-of-hooks` and `react-hooks/exhaustive-deps` in `eslint.full-report.config.js`.
- Leaves the normal blocking `pnpm lint` path unchanged.

## Refactor impact

Primary owner:

tooling / ESLint reporting

Impact areas reviewed:

- ESLint full-report config layering
- Existing React Hooks plugin registration in the base ESLint config
- Normal lint/typecheck/architecture/docs/unused gates

Boundary notes:

- No product runtime, engine, shared API, Rust, or remote runtime behavior changed.
- The change is limited to the optional staged ESLint report config.

Pressure points touched:

- none

## Validation

- [x] `pnpm check` passes locally
- [x] `pnpm typecheck` passes locally
- [x] `pnpm build` passes locally
- [x] `pnpm check:architecture` passes locally
- [x] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- `pnpm lint:eslint:full-report -- --output .eslint-reports/eslint-full-report-before-react-hooks.json` before the change: 28 errors, 0 warnings across 10 files.
- `pnpm lint:eslint:full-report -- --output .eslint-reports/eslint-full-report-after-react-hooks.json` after the change: 28 errors, 25 warnings across 20 files; `react-hooks/exhaustive-deps` reports 25 warnings and `react-hooks/rules-of-hooks` reports 0 errors.
- `pnpm lint`
- `pnpm typecheck`
- `pnpm check:architecture`
- `pnpm check:docs`
- `pnpm check:unused`

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

No changelog update: this is report-only tooling configuration, and this branch does not currently have a `CHANGELOG.md` file.

## UI evidence

N/A; no visible UI changes.