### PR TITLE
Triage non-GameSurface hook dependency warnings

### DIFF
--- a/src/app/shell/AppShell.tsx
+++ b/src/app/shell/AppShell.tsx
@@ -758,13 +758,19 @@ export function AppShell() {
 
   useEffect(() => {
     if (!hasCompletedOnboarding) return;
+    const sidebarPanel = sidebarPanelRef.current;
+    const mobileTrackerPanel = mobileTrackerPanelRef.current;
+    const mobileRightPanel = mobileRightPanelRef.current;
+    const header = headerRef.current;
+    const main = mainRef.current;
+
     syncMobilePanelInert();
     return () => {
-      setInert(sidebarPanelRef.current, false);
-      setInert(mobileTrackerPanelRef.current, false);
-      setInert(mobileRightPanelRef.current, false);
-      setInert(headerRef.current, false);
-      setInert(mainRef.current, false);
+      setInert(sidebarPanel, false);
+      setInert(mobileTrackerPanel, false);
+      setInert(mobileRightPanel, false);
+      setInert(header, false);
+      setInert(main, false);
     };
   }, [hasCompletedOnboarding, syncMobilePanelInert]);
 

--- a/src/app/shell/ChatSidebar.tsx
+++ b/src/app/shell/ChatSidebar.tsx
@@ -490,7 +490,7 @@ export function ChatSidebar({
       }, 200);
       return () => clearTimeout(timer);
     }
-  }, [activeChatId, chats, folders, updateFolderMut]);
+  }, [activeChatId, chats, folders, onActiveTabChange, updateFolderMut]);
 
   const handleNewChatFromTab = useCallback(() => {
     if (window.innerWidth < 768) setSidebarOpen(false);

--- a/src/features/catalog/lorebooks/components/LorebookEditor.tsx
+++ b/src/features/catalog/lorebooks/components/LorebookEditor.tsx
@@ -2177,9 +2177,10 @@ function VectorizeSection({
   const excludedCount = excludeFromVectorization
     ? entries.length
     : entries.filter((entry) => readBoolFlag(entry.excludeFromVectorization)).length;
-  const vectorizableEntries = excludeFromVectorization
-    ? []
-    : entries.filter((entry) => !readBoolFlag(entry.excludeFromVectorization));
+  const vectorizableEntries = useMemo(
+    () => (excludeFromVectorization ? [] : entries.filter((entry) => !readBoolFlag(entry.excludeFromVectorization))),
+    [entries, excludeFromVectorization],
+  );
   const vectorizableEntryCount = vectorizableEntries.length;
   const vectorizedCount = vectorizableEntries.filter(
     (entry) => Array.isArray(entry.embedding) && entry.embedding.length > 0,

--- a/src/features/modes/conversation/hooks/autonomous/use-autonomous-messaging.ts
+++ b/src/features/modes/conversation/hooks/autonomous/use-autonomous-messaging.ts
@@ -72,61 +72,64 @@ export function useAutonomousMessaging(
     });
   }, [chatId]);
 
-  async function triggerAutonomousGeneration(characterId: string, poll: () => Promise<void>) {
-    if (!chatId) return;
-    generatingRef.current = true;
-    const startedAt = markGenerationInProgress(chatId);
-    let produced = false;
-    let shouldSchedulePoll = true;
-    try {
-      produced = await generate({
-        chatId,
-        connectionId: null,
-      });
-      if (produced) {
-        recordAssistantActivityState(chatId, characterId);
-        await qc.invalidateQueries({ queryKey: chatKeys.list() });
-        await qc.invalidateQueries({ queryKey: chatKeys.messages(chatId) });
-        onAutonomousMessageRef.current?.(characterId);
-      }
-    } catch {
-      // Autonomous generation is opportunistic; keep polling after failures.
-    } finally {
-      clearGenerationInProgress(chatId, startedAt);
-      generatingRef.current = false;
-    }
-
-    if (produced && exchangesEnabled) {
+  const triggerAutonomousGeneration = useCallback(
+    async (characterId: string, poll: () => Promise<void>) => {
+      if (!chatId) return;
+      generatingRef.current = true;
+      const startedAt = markGenerationInProgress(chatId);
+      let produced = false;
+      let shouldSchedulePoll = true;
       try {
-        const exchange = await checkConversationCharacterExchange(storageApi, {
+        produced = await generate({
           chatId,
-          lastSpeakerCharId: characterId,
+          connectionId: null,
         });
-        const nextCharacterId = exchange.characterIds[0];
-        if (exchange.shouldTrigger && nextCharacterId) {
-          shouldSchedulePoll = false;
-          clearTimeout(busyTimerRef.current);
-          busyTimerRef.current = setTimeout(
-            () => {
-              if (!useChatStore.getState().abortControllers.has(chatId)) {
-                void triggerAutonomousGeneration(nextCharacterId, poll);
-              } else {
-                schedulePoll(poll);
-              }
-            },
-            2_000 + Math.random() * 3_000,
-          );
+        if (produced) {
+          recordAssistantActivityState(chatId, characterId);
+          await qc.invalidateQueries({ queryKey: chatKeys.list() });
+          await qc.invalidateQueries({ queryKey: chatKeys.messages(chatId) });
+          onAutonomousMessageRef.current?.(characterId);
         }
       } catch {
-        // Exchange checks are best-effort.
+        // Autonomous generation is opportunistic; keep polling after failures.
+      } finally {
+        clearGenerationInProgress(chatId, startedAt);
+        generatingRef.current = false;
       }
-    }
 
-    if (!produced) {
-      recordAssistantActivityState(chatId);
-    }
-    if (shouldSchedulePoll) schedulePoll(poll);
-  }
+      if (produced && exchangesEnabled) {
+        try {
+          const exchange = await checkConversationCharacterExchange(storageApi, {
+            chatId,
+            lastSpeakerCharId: characterId,
+          });
+          const nextCharacterId = exchange.characterIds[0];
+          if (exchange.shouldTrigger && nextCharacterId) {
+            shouldSchedulePoll = false;
+            clearTimeout(busyTimerRef.current);
+            busyTimerRef.current = setTimeout(
+              () => {
+                if (!useChatStore.getState().abortControllers.has(chatId)) {
+                  void triggerAutonomousGeneration(nextCharacterId, poll);
+                } else {
+                  schedulePoll(poll);
+                }
+              },
+              2_000 + Math.random() * 3_000,
+            );
+          }
+        } catch {
+          // Exchange checks are best-effort.
+        }
+      }
+
+      if (!produced) {
+        recordAssistantActivityState(chatId);
+      }
+      if (shouldSchedulePoll) schedulePoll(poll);
+    },
+    [chatId, exchangesEnabled, generate, qc, schedulePoll],
+  );
 
   useEffect(() => {
     if (!chatId || !autonomousEnabled) return;
@@ -177,7 +180,7 @@ export function useAutonomousMessaging(
       clearTimeout(pollTimerRef.current);
       clearTimeout(busyTimerRef.current);
     };
-  }, [autonomousEnabled, chatId, exchangesEnabled, generate, qc, schedulePoll]);
+  }, [autonomousEnabled, chatId, exchangesEnabled, qc, schedulePoll, triggerAutonomousGeneration]);
 
   return {
     recordUserActivity,

--- a/src/features/modes/game/components/GameConversationView.tsx
+++ b/src/features/modes/game/components/GameConversationView.tsx
@@ -37,19 +37,14 @@ export function GameConversationView({ activeChatId }: GameConversationViewProps
     messageIdByOrderIndex: data.messageIdByOrderIndex,
     refreshWorldStateOnTimelineChange: true,
   });
+  const { fetchNextPage, hasNextPage, isFetchingNextPage, loadedMessageCount, totalMessageCount } = data;
 
   useEffect(() => {
-    if (data.loadedMessageCount <= 0) return;
-    if (data.totalMessageCount <= data.loadedMessageCount) return;
-    if (!data.hasNextPage || data.isFetchingNextPage) return;
-    void data.fetchNextPage();
-  }, [
-    data.fetchNextPage,
-    data.hasNextPage,
-    data.isFetchingNextPage,
-    data.loadedMessageCount,
-    data.totalMessageCount,
-  ]);
+    if (loadedMessageCount <= 0) return;
+    if (totalMessageCount <= loadedMessageCount) return;
+    if (!hasNextPage || isFetchingNextPage) return;
+    void fetchNextPage();
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage, loadedMessageCount, totalMessageCount]);
 
   if (!data.chat) return <div className="flex flex-1 overflow-hidden" />;
 

--- a/src/features/modes/game/components/GameNodeMap.tsx
+++ b/src/features/modes/game/components/GameNodeMap.tsx
@@ -2,7 +2,7 @@
 // Game: Node Map (dungeons/interiors)
 // ──────────────────────────────────────────────
 import { Check, Pencil, X } from "lucide-react";
-import { useEffect, useState, useCallback, type ReactNode } from "react";
+import { useEffect, useState, useCallback, useMemo, type ReactNode } from "react";
 import { cn } from "../../../../shared/lib/utils";
 import type { GameMap } from "../../../../engine/contracts/types/game";
 
@@ -35,12 +35,14 @@ export function GameNodeMap({
   topLeftAction,
   topRightAction,
 }: GameNodeMapProps) {
-  const nodes = map.nodes || [];
-  const edges = map.edges || [];
+  const nodes = useMemo(() => map.nodes ?? [], [map.nodes]);
+  const edges = useMemo(() => map.edges ?? [], [map.edges]);
   const currentNodeId = showPartyPosition && typeof map.partyPosition === "string" ? map.partyPosition : null;
   const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null);
   const [editorOpen, setEditorOpen] = useState(false);
-  const [editingNodeId, setEditingNodeId] = useState<string | null>(selectedNodeId ?? currentNodeId ?? nodes[0]?.id ?? null);
+  const [editingNodeId, setEditingNodeId] = useState<string | null>(
+    selectedNodeId ?? currentNodeId ?? nodes[0]?.id ?? null,
+  );
   const [draftEmoji, setDraftEmoji] = useState("");
   const [draftLabel, setDraftLabel] = useState("");
   const [editorError, setEditorError] = useState<string | null>(null);

--- a/src/features/modes/roleplay/components/RoleplayModeRoute.tsx
+++ b/src/features/modes/roleplay/components/RoleplayModeRoute.tsx
@@ -61,6 +61,10 @@ function resolveExpressionAvatarSpriteUrl(sprites: Map<string, string> | undefin
   return sprites?.get(normalizedExpression) ?? null;
 }
 
+function combineSpriteQueryData(results: Array<{ data: SpriteInfo[] | undefined }>): Array<SpriteInfo[] | undefined> {
+  return results.map((query) => query.data);
+}
+
 export function RoleplayModeRoute({ activeChatId, fallbackChatMode = "roleplay" }: RoleplayModeRouteProps) {
   const messagesPerPage = useUIStore((state) => state.messagesPerPage);
   const centerCompact = useUIStore((state) => state.centerCompact);
@@ -186,20 +190,21 @@ export function RoleplayModeRoute({ activeChatId, fallbackChatMode = "roleplay" 
         : data.chatCharIds;
     return Array.from(new Set(configuredIds.filter((id) => typeof id === "string" && id.trim())));
   }, [data.chatCharIds, spriteState.spriteCharacterIds]);
-  const expressionAvatarSpriteQueries = useQueries({
+  const expressionAvatarSpriteData = useQueries({
     queries: expressionAvatarCharacterIds.map((characterId) => ({
       queryKey: spriteKeys.list(characterId),
       queryFn: () => spriteApi.list<SpriteInfo[]>(characterId),
       enabled: expressionAvatarsEnabled,
       staleTime: 5 * 60_000,
     })),
+    combine: combineSpriteQueryData,
   });
   const expressionAvatarSpriteMap = useMemo(() => {
     const map = new Map<string, Map<string, string>>();
     if (!expressionAvatarsEnabled) return map;
     for (let index = 0; index < expressionAvatarCharacterIds.length; index += 1) {
       const characterId = expressionAvatarCharacterIds[index]!;
-      const sprites = expressionAvatarSpriteQueries[index]?.data;
+      const sprites = expressionAvatarSpriteData[index];
       if (!Array.isArray(sprites) || sprites.length === 0) continue;
       const byExpression = new Map<string, string>();
       for (const sprite of sprites) {
@@ -210,7 +215,7 @@ export function RoleplayModeRoute({ activeChatId, fallbackChatMode = "roleplay" 
       if (byExpression.size > 0) map.set(characterId, byExpression);
     }
     return map;
-  }, [expressionAvatarCharacterIds, expressionAvatarSpriteQueries, expressionAvatarsEnabled]);
+  }, [expressionAvatarCharacterIds, expressionAvatarSpriteData, expressionAvatarsEnabled]);
   const expressionAvatarResolver = useMemo<ExpressionAvatarResolver | undefined>(() => {
     if (!expressionAvatarsEnabled) return undefined;
     return (message: MessageWithSwipes, characterId: string) => {

--- a/src/features/modes/roleplay/components/RoleplayModeRoute.tsx
+++ b/src/features/modes/roleplay/components/RoleplayModeRoute.tsx
@@ -175,7 +175,10 @@ export function RoleplayModeRoute({ activeChatId, fallbackChatMode = "roleplay" 
   const isSceneChat = data.chatMeta.sceneStatus === "active" || Boolean(data.chatMeta.sceneOriginChatId);
   const isRoleplay = data.chatMode === "roleplay";
   const expressionAvatarsEnabled =
-    isRoleplay && data.chatMeta.expressionAvatarsEnabled === true && expressionAgentEnabled && data.chatCharIds.length > 0;
+    isRoleplay &&
+    data.chatMeta.expressionAvatarsEnabled === true &&
+    expressionAgentEnabled &&
+    data.chatCharIds.length > 0;
   const expressionAvatarCharacterIds = useMemo(() => {
     const configuredIds =
       spriteState.spriteCharacterIds.length > 0
@@ -183,7 +186,6 @@ export function RoleplayModeRoute({ activeChatId, fallbackChatMode = "roleplay" 
         : data.chatCharIds;
     return Array.from(new Set(configuredIds.filter((id) => typeof id === "string" && id.trim())));
   }, [data.chatCharIds, spriteState.spriteCharacterIds]);
-  const expressionAvatarCharacterIdsKey = expressionAvatarCharacterIds.join("\u0000");
   const expressionAvatarSpriteQueries = useQueries({
     queries: expressionAvatarCharacterIds.map((characterId) => ({
       queryKey: spriteKeys.list(characterId),
@@ -192,13 +194,6 @@ export function RoleplayModeRoute({ activeChatId, fallbackChatMode = "roleplay" 
       staleTime: 5 * 60_000,
     })),
   });
-  const expressionAvatarSpriteDataVersion = useMemo(
-    () =>
-      expressionAvatarSpriteQueries
-        .map((query, index) => `${expressionAvatarCharacterIds[index] ?? ""}:${query.dataUpdatedAt}`)
-        .join("\u0000"),
-    [expressionAvatarCharacterIdsKey, expressionAvatarSpriteQueries],
-  );
   const expressionAvatarSpriteMap = useMemo(() => {
     const map = new Map<string, Map<string, string>>();
     if (!expressionAvatarsEnabled) return map;
@@ -215,7 +210,7 @@ export function RoleplayModeRoute({ activeChatId, fallbackChatMode = "roleplay" 
       if (byExpression.size > 0) map.set(characterId, byExpression);
     }
     return map;
-  }, [expressionAvatarCharacterIdsKey, expressionAvatarSpriteDataVersion, expressionAvatarsEnabled]);
+  }, [expressionAvatarCharacterIds, expressionAvatarSpriteQueries, expressionAvatarsEnabled]);
   const expressionAvatarResolver = useMemo<ExpressionAvatarResolver | undefined>(() => {
     if (!expressionAvatarsEnabled) return undefined;
     return (message: MessageWithSwipes, characterId: string) => {
@@ -348,7 +343,10 @@ export function RoleplayModeRoute({ activeChatId, fallbackChatMode = "roleplay" 
         />
       )}
       {pendingNewChatMode && (
-        <NewChatConnectionGate mode={pendingNewChatMode} onClose={() => useChatStore.getState().setPendingNewChatMode(null)} />
+        <NewChatConnectionGate
+          mode={pendingNewChatMode}
+          onClose={() => useChatStore.getState().setPendingNewChatMode(null)}
+        />
       )}
     </>
   );

--- a/src/features/modes/shared/chat-ui/hooks/use-chat-metadata-sync.ts
+++ b/src/features/modes/shared/chat-ui/hooks/use-chat-metadata-sync.ts
@@ -118,9 +118,10 @@ export function useChatMetadataSync({ chat, chatMeta, messages, messagePageCount
   }, [chatBackground, chat?.id, chatMeta.background]);
 
   useEffect(() => {
+    const timers = bgPersistTimers.current;
     return () => {
-      for (const timer of bgPersistTimers.current.values()) clearTimeout(timer);
-      bgPersistTimers.current.clear();
+      for (const timer of timers.values()) clearTimeout(timer);
+      timers.clear();
     };
   }, []);
 

--- a/src/features/runtime/visuals/components/SpriteOverlay.tsx
+++ b/src/features/runtime/visuals/components/SpriteOverlay.tsx
@@ -90,9 +90,10 @@ export function SpriteOverlay({
   spriteOpacity = 1,
 }: SpriteOverlayProps) {
   const stageRef = useRef<HTMLDivElement>(null);
-  const resolvedSpriteDisplayModes = useMemo(() => normalizeSpriteDisplayModes(spriteDisplayModes), [spriteDisplayModes]);
-  const characterIdsKey = characterIds.join("\u0000");
-
+  const resolvedSpriteDisplayModes = useMemo(
+    () => normalizeSpriteDisplayModes(spriteDisplayModes),
+    [spriteDisplayModes],
+  );
   // Subscribe to agent expression results
   const expressionResult = useAgentStore((s) => s.lastResults.get("expression"));
   // Track which agent result we already applied so we don't re-fire for stale results
@@ -208,15 +209,18 @@ export function SpriteOverlay({
       const nextKeys = Object.keys(newStates);
       if (prevKeys.length !== nextKeys.length) return newStates;
       for (const key of nextKeys) {
-        if (prev[key]?.expression !== newStates[key]?.expression || prev[key]?.transition !== newStates[key]?.transition) {
+        if (
+          prev[key]?.expression !== newStates[key]?.expression ||
+          prev[key]?.transition !== newStates[key]?.transition
+        ) {
           return newStates;
         }
       }
       return prev;
     });
-  }, [messages, characterIdsKey, expressionResult, spriteExpressions, fullBodyOnly]);
+  }, [messages, characterIds, expressionResult, spriteExpressions, fullBodyOnly]);
 
-  const visibleChars = useMemo(() => characterIds.slice(0, 3), [characterIdsKey]);
+  const visibleChars = useMemo(() => characterIds.slice(0, 3), [characterIds]);
   const resolvedPlacements = useMemo(() => {
     const placements: Record<string, SpritePlacement> = {};
     for (const [index, charId] of visibleChars.entries()) {
@@ -412,7 +416,8 @@ function CharacterSprite({
       : spriteCount === 2
         ? "h-[min(82vh,calc(60vh*var(--game-sprite-scale)))] max-w-[min(90vw,calc(64vw*var(--game-sprite-scale)))] md:h-[min(86vh,calc(56vh*var(--game-sprite-scale)))] md:max-w-[min(52vw,calc(34vw*var(--game-sprite-scale)))]"
         : "h-[min(86vh,calc(64vh*var(--game-sprite-scale)))] max-w-[min(96vw,calc(86vw*var(--game-sprite-scale)))] md:h-[min(90vh,calc(62vh*var(--game-sprite-scale)))] md:max-w-[min(70vw,calc(44vw*var(--game-sprite-scale)))]";
-  const fullBodyLayout = fullBodyOnly || (spriteDisplayModes.includes("full-body") && !spriteDisplayModes.includes("expressions"));
+  const fullBodyLayout =
+    fullBodyOnly || (spriteDisplayModes.includes("full-body") && !spriteDisplayModes.includes("expressions"));
   const sizeClass = fullBodyLayout ? fullBodySizeClass : standardSizeClass;
   const spriteScaleStyle = useMemo<CSSProperties>(
     () =>


### PR DESCRIPTION
## Linked issue

Part of #1619

## Why this change

- Continues the React Hooks `exhaustive-deps` triage by clearing the lower-risk warnings outside the broad `GameSurface` component.

## What changed

- Captures app-shell and shared metadata refs before cleanup functions use them.
- Makes chat sidebar, autonomous conversation polling, game conversation pagination, game node-map, lorebook vectorization, roleplay expression-avatar, and sprite overlay hook dependencies explicit.
- Stabilizes roleplay expression-avatar sprite query data so the sprite map does not recompute just because `useQueries` returned a fresh result array.
- Leaves the remaining `GameSurface` hook warnings for a separate focused branch because that component is a known broad pressure point.

## Refactor impact

Primary owner:

React UI hook hygiene across app shell, catalog, chat, roleplay, game, shared mode UI, and runtime visuals

Impact areas reviewed:

- App shell mobile panel inert cleanup
- Chat sidebar active-tab sync
- Conversation autonomous polling and exchange chaining
- Lorebook vectorization entry memoization
- Game conversation pagination and node map editing state
- Roleplay expression-avatar sprite lookup
- Shared chat metadata background persist cleanup
- Runtime sprite expression fallback and visible sprite selection

Boundary notes:

- No engine, shared API, Rust, Tauri command, or remote runtime behavior changed.
- Mode ownership stays intact: chat/autonomous behavior remains in conversation hooks, roleplay expression avatars stay in roleplay route code, and game UI fixes stay in game components.

Pressure points touched:

- `GameSurface` intentionally not touched; its 10 remaining hook warnings stay isolated for the next slice.
- Shared mode UI touched narrowly in `use-chat-metadata-sync.ts` for cleanup ref capture only.

## Validation

- [x] `pnpm check` passes locally
- [x] `pnpm typecheck` passes locally
- [x] `pnpm build` passes locally
- [x] `pnpm check:architecture` passes locally
- [x] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Verified CodeRabbit nitpick on `RoleplayModeRoute`: still valid; fixed in commit `e1b0c068`.
- `pnpm lint:eslint:full-report -- --output .eslint-reports/eslint-full-report-before-hooks-deps.json` before the change: 0 errors, 25 warnings across 10 files.
- `pnpm lint:eslint:full-report -- --output .eslint-reports/eslint-full-report-after-hooks-deps-slice-coderabbit.json` after the latest fix: 0 errors, 10 warnings across 1 file; all remaining warnings are `react-hooks/exhaustive-deps` in `GameSurface`.
- `pnpm lint`
- `pnpm typecheck`
- `pnpm check:architecture`
- `pnpm check:docs`
- `pnpm check:unused`
- `pnpm test` passed: 78 files, 489 tests.
- `pnpm build` passed; Vite emitted the existing large-chunk warning.
- `git diff --check` passed with the existing CRLF warning for the touched file.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

No changelog update: this is internal hook-lint cleanup, and this branch does not currently have a `CHANGELOG.md` file.

## UI evidence

N/A; no visible UI changes and no manual app QA was run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized internal React hooks and component logic across the application for improved performance and maintainability.
  * Enhanced memoization in several components to reduce unnecessary re-renders and improve responsiveness.
  * Improved cleanup routines and dependency tracking in effect hooks to ensure more reliable and predictable component behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1630?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->