### PR TITLE
Triage GameSurface hook dependency warnings

### DIFF
--- a/src/features/modes/game/components/GameSurface.tsx
+++ b/src/features/modes/game/components/GameSurface.tsx
@@ -1671,6 +1671,10 @@ export function GameSurface({
 }: GameSurfaceProps) {
   // Sync game metadata → store
   useSyncGameState(activeChatId, chatMeta);
+  const chatMetaRef = useRef(chatMeta);
+  useEffect(() => {
+    chatMetaRef.current = chatMeta;
+  }, [chatMeta]);
 
   const {
     gameState,
@@ -2355,7 +2359,7 @@ export function GameSurface({
 
       const inventoryPersist =
         updated !== previousInventory
-          ? persistGameMetadata(activeChatId, { gameInventory: updated }, chatMeta).catch(() => null)
+          ? persistGameMetadata(activeChatId, { gameInventory: updated }, chatMetaRef.current).catch(() => null)
           : Promise.resolve(null);
 
       if (updated !== previousInventory) {
@@ -2995,7 +2999,7 @@ export function GameSurface({
         persistGameMetadata(
           activeChatId,
           { gameRecentSpotifyTracks: recentSpotifyTrackHistoryRef.current },
-          chatMeta,
+          chatMetaRef.current,
         ).catch(() => {});
         await queryClient.invalidateQueries({ queryKey: ["spotify", "player"] });
       } catch (error) {
@@ -3201,7 +3205,7 @@ export function GameSurface({
           recentMusicHistoryRef.current = appendRecentMusic(recentMusicHistoryRef.current, state.currentMusic);
           patch.gameRecentMusic = recentMusicHistoryRef.current;
         }
-        persistGameMetadata(activeChatId, patch, chatMeta).catch(() => {});
+        persistGameMetadata(activeChatId, patch, chatMetaRef.current).catch(() => {});
       }, 1500);
     });
     return () => {
@@ -3218,7 +3222,7 @@ export function GameSurface({
             gameSceneAmbient: currentAmbient,
             gameRecentMusic: recentMusicHistoryRef.current,
           },
-          chatMeta,
+          chatMetaRef.current,
         ).catch(() => {});
       }
     };
@@ -3240,7 +3244,7 @@ export function GameSurface({
     if (!snapshot || !snapshot.party?.length || !snapshot.enemies?.length) return;
     if (chatMeta.gameActiveState !== "combat") {
       // Stale snapshot — combat ended but the metadata write didn't land. Clear it.
-      persistGameMetadata(activeChatId, { gameCombatState: null }, chatMeta).catch(() => {});
+      persistGameMetadata(activeChatId, { gameCombatState: null }, chatMetaRef.current).catch(() => {});
       return;
     }
     // Runtime validation: the snapshot is JSON-deserialized from chat metadata that
@@ -3255,7 +3259,7 @@ export function GameSurface({
         "[game-surface] Discarding combat snapshot — failed Combatant schema validation. " +
           "Likely written by an older client version.",
       );
-      persistGameMetadata(activeChatId, { gameCombatState: null }, chatMeta).catch(() => {});
+      persistGameMetadata(activeChatId, { gameCombatState: null }, chatMetaRef.current).catch(() => {});
       return;
     }
     setCombatParty(rawParty);
@@ -3306,7 +3310,7 @@ export function GameSurface({
       // keepalive flush below or the lifecycle wipes in `clearCombatSnapshot`. A
       // silent failure here means the user keeps fighting believing state is saved,
       // then loses progress on refresh — the operator needs to see this in console.
-      persistGameMetadata(activeChatId, { gameCombatState: snapshot }, chatMeta).catch((err: unknown) =>
+      persistGameMetadata(activeChatId, { gameCombatState: snapshot }, chatMetaRef.current).catch((err: unknown) =>
         console.error("[game-surface] combat snapshot persist failed", err),
       );
       combatPendingSnapshotRef.current = null;
@@ -3390,7 +3394,7 @@ export function GameSurface({
             gameNarrationIndex: index,
             gameNarrationMessageId: narrationProgressMessageId,
           },
-          chatMeta,
+          chatMetaRef.current,
         ).catch(() => {});
       }, 500);
     },
@@ -3410,7 +3414,7 @@ export function GameSurface({
                 gameNarrationIndex: saved.index,
                 gameNarrationMessageId: saved.messageId,
               },
-              chatMeta,
+              chatMetaRef.current,
             ).catch(() => {});
           }
         } catch {
@@ -5457,7 +5461,7 @@ export function GameSurface({
         next.set(`${messageId}:${segmentIndex}`, payload);
         return next;
       });
-      persistGameMetadata(activeChatId, { [key]: payload }, chatMeta).catch(() => {});
+      persistGameMetadata(activeChatId, { [key]: payload }, chatMetaRef.current).catch(() => {});
 
       if (payload.readableContent) {
         upsertReadableJournalEntry({
@@ -5480,7 +5484,7 @@ export function GameSurface({
         next.add(`${messageId}:${segmentIndex}`);
         return next;
       });
-      persistGameMetadata(activeChatId, { [key]: true }, chatMeta).catch(() => {});
+      persistGameMetadata(activeChatId, { [key]: true }, chatMetaRef.current).catch(() => {});
     },
     [activeChatId],
   );
@@ -6832,7 +6836,6 @@ export function GameSurface({
     gameSnapshot?.time,
     gameSnapshot?.weather,
     generateMap,
-    generateMap.isPending,
     handleJsonRepairError,
     isStreaming,
     latestNarrationText,

--- a/src/features/modes/game/components/GameSurface.tsx
+++ b/src/features/modes/game/components/GameSurface.tsx
@@ -981,26 +981,8 @@ import type { Chat, Message } from "../../../../engine/contracts/types/chat";
 import type { SessionSummary, Combatant, GameCombatStateSnapshot } from "../../../../engine/contracts/types/game";
 import type { CharacterMap, PersonaInfo } from "../../shared/chat-ui/types";
 
-function metadataRecord(value: unknown): Record<string, unknown> {
-  if (typeof value === "string") {
-    try {
-      const parsed = JSON.parse(value);
-      return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : {};
-    } catch {
-      return {};
-    }
-  }
-  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
-}
-
-async function persistGameMetadata(
-  chatId: string,
-  patch: Record<string, unknown>,
-  fallbackMetadata?: Record<string, unknown>,
-) {
-  const latest = await storageApi.get<Chat>("chats", chatId);
-  const metadata = latest ? metadataRecord(latest.metadata) : (fallbackMetadata ?? {});
-  return storageApi.update<Chat>("chats", chatId, { metadata: { ...metadata, ...patch } });
+async function persistGameMetadata(chatId: string, patch: Record<string, unknown>) {
+  return storageApi.patchChatMetadata<Chat>(chatId, patch);
 }
 
 /** Typewriter component for the intro screen — reveals text character-by-character. */
@@ -1671,10 +1653,6 @@ export function GameSurface({
 }: GameSurfaceProps) {
   // Sync game metadata → store
   useSyncGameState(activeChatId, chatMeta);
-  const chatMetaRef = useRef(chatMeta);
-  useEffect(() => {
-    chatMetaRef.current = chatMeta;
-  }, [chatMeta]);
 
   const {
     gameState,
@@ -2359,7 +2337,7 @@ export function GameSurface({
 
       const inventoryPersist =
         updated !== previousInventory
-          ? persistGameMetadata(activeChatId, { gameInventory: updated }, chatMetaRef.current).catch(() => null)
+          ? persistGameMetadata(activeChatId, { gameInventory: updated }).catch(() => null)
           : Promise.resolve(null);
 
       if (updated !== previousInventory) {
@@ -2996,11 +2974,9 @@ export function GameSurface({
           recentSpotifyTrackHistoryRef.current,
           track.uri,
         );
-        persistGameMetadata(
-          activeChatId,
-          { gameRecentSpotifyTracks: recentSpotifyTrackHistoryRef.current },
-          chatMetaRef.current,
-        ).catch(() => {});
+        persistGameMetadata(activeChatId, { gameRecentSpotifyTracks: recentSpotifyTrackHistoryRef.current }).catch(
+          () => {},
+        );
         await queryClient.invalidateQueries({ queryKey: ["spotify", "player"] });
       } catch (error) {
         console.warn("[spotify/game] Failed to play scene track:", error);
@@ -3205,7 +3181,7 @@ export function GameSurface({
           recentMusicHistoryRef.current = appendRecentMusic(recentMusicHistoryRef.current, state.currentMusic);
           patch.gameRecentMusic = recentMusicHistoryRef.current;
         }
-        persistGameMetadata(activeChatId, patch, chatMetaRef.current).catch(() => {});
+        persistGameMetadata(activeChatId, patch).catch(() => {});
       }, 1500);
     });
     return () => {
@@ -3214,16 +3190,12 @@ export function GameSurface({
       if (scenePersistTimer.current) {
         clearTimeout(scenePersistTimer.current);
         const { currentBackground, currentMusic, currentAmbient } = useGameAssetStore.getState();
-        persistGameMetadata(
-          activeChatId,
-          {
-            gameSceneBackground: currentBackground,
-            gameSceneMusic: currentMusic,
-            gameSceneAmbient: currentAmbient,
-            gameRecentMusic: recentMusicHistoryRef.current,
-          },
-          chatMetaRef.current,
-        ).catch(() => {});
+        persistGameMetadata(activeChatId, {
+          gameSceneBackground: currentBackground,
+          gameSceneMusic: currentMusic,
+          gameSceneAmbient: currentAmbient,
+          gameRecentMusic: recentMusicHistoryRef.current,
+        }).catch(() => {});
       }
     };
   }, [activeChatId]);
@@ -3244,7 +3216,7 @@ export function GameSurface({
     if (!snapshot || !snapshot.party?.length || !snapshot.enemies?.length) return;
     if (chatMeta.gameActiveState !== "combat") {
       // Stale snapshot — combat ended but the metadata write didn't land. Clear it.
-      persistGameMetadata(activeChatId, { gameCombatState: null }, chatMetaRef.current).catch(() => {});
+      persistGameMetadata(activeChatId, { gameCombatState: null }).catch(() => {});
       return;
     }
     // Runtime validation: the snapshot is JSON-deserialized from chat metadata that
@@ -3259,7 +3231,7 @@ export function GameSurface({
         "[game-surface] Discarding combat snapshot — failed Combatant schema validation. " +
           "Likely written by an older client version.",
       );
-      persistGameMetadata(activeChatId, { gameCombatState: null }, chatMetaRef.current).catch(() => {});
+      persistGameMetadata(activeChatId, { gameCombatState: null }).catch(() => {});
       return;
     }
     setCombatParty(rawParty);
@@ -3310,7 +3282,7 @@ export function GameSurface({
       // keepalive flush below or the lifecycle wipes in `clearCombatSnapshot`. A
       // silent failure here means the user keeps fighting believing state is saved,
       // then loses progress on refresh — the operator needs to see this in console.
-      persistGameMetadata(activeChatId, { gameCombatState: snapshot }, chatMetaRef.current).catch((err: unknown) =>
+      persistGameMetadata(activeChatId, { gameCombatState: snapshot }).catch((err: unknown) =>
         console.error("[game-surface] combat snapshot persist failed", err),
       );
       combatPendingSnapshotRef.current = null;
@@ -3394,7 +3366,6 @@ export function GameSurface({
             gameNarrationIndex: index,
             gameNarrationMessageId: narrationProgressMessageId,
           },
-          chatMetaRef.current,
         ).catch(() => {});
       }, 500);
     },
@@ -3414,7 +3385,6 @@ export function GameSurface({
                 gameNarrationIndex: saved.index,
                 gameNarrationMessageId: saved.messageId,
               },
-              chatMetaRef.current,
             ).catch(() => {});
           }
         } catch {
@@ -3556,9 +3526,7 @@ export function GameSurface({
     } catch {
       /* ignore */
     }
-    persistGameMetadata(activeChatId, { gameNarrationIndex: 0, gameNarrationMessageId: msg.id }, chatMeta).catch(
-      () => {},
-    );
+    persistGameMetadata(activeChatId, { gameNarrationIndex: 0, gameNarrationMessageId: msg.id }).catch(() => {});
 
     const tags = parseGmTags(msg.content);
     const mapUpdateCommands = parseMapUpdateCommands(msg.content);
@@ -5461,7 +5429,7 @@ export function GameSurface({
         next.set(`${messageId}:${segmentIndex}`, payload);
         return next;
       });
-      persistGameMetadata(activeChatId, { [key]: payload }, chatMetaRef.current).catch(() => {});
+      persistGameMetadata(activeChatId, { [key]: payload }).catch(() => {});
 
       if (payload.readableContent) {
         upsertReadableJournalEntry({
@@ -5484,7 +5452,7 @@ export function GameSurface({
         next.add(`${messageId}:${segmentIndex}`);
         return next;
       });
-      persistGameMetadata(activeChatId, { [key]: true }, chatMetaRef.current).catch(() => {});
+      persistGameMetadata(activeChatId, { [key]: true }).catch(() => {});
     },
     [activeChatId],
   );


### PR DESCRIPTION
## Linked issue

Part of #1619

## Why this change

- Clears the remaining `react-hooks/exhaustive-deps` warnings in `GameSurface`, the broad game-mode pressure point intentionally left out of PR #1630.

## What changed

- Routes GameSurface metadata persistence through `storageApi.patchChatMetadata` so delayed callbacks patch the latest stored metadata instead of carrying a render-time fallback object.
- Updates inventory, Spotify scene track, scene asset, combat snapshot, narration progress, and segment edit/delete persistence paths to use that focused helper.
- Removes the redundant `generateMap.isPending` dependency where the mutation object is already tracked.

## Refactor impact

Primary owner:

Game mode UI / `GameSurface` hook hygiene

Impact areas reviewed:

- Game inventory persistence and journal side effects
- Spotify scene music persistence
- Scene asset background/music/ambient persistence
- Combat snapshot restore/persist cleanup paths
- Narration segment progress persistence
- Game segment edit/delete metadata writes
- Map generation callback dependencies

Boundary notes:

- No engine, Rust, Tauri command, or remote runtime behavior changed.
- Uses the existing focused shared storage API wrapper instead of a local metadata merge fallback.
- Game mode remains the only concrete mode touched; shared mode UI and sibling chat/roleplay owners are not modified.

Pressure points touched:

- `GameSurface` only. This PR keeps the change localized to the known broad game UI orchestrator and does not extract or move behavior.

## Validation

- [x] `pnpm check` passes locally
- [x] `pnpm typecheck` passes locally
- [x] `pnpm build` passes locally
- [x] `pnpm check:architecture` passes locally
- [x] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Failure-path review checked persisted metadata, chat switch/unmount cleanup, delayed timers, segment edit/delete writes, map-generation dependencies, and mode boundaries.
- Bunny review found the metadata fallback ref could be cleaner and safer as a direct stored-metadata patch; fixed in follow-up commit `b5af3be5`.
- `pnpm lint:eslint:full-report -- --output .eslint-reports/eslint-full-report-before-gamesurface-hooks.json` before the change: 0 errors, 25 warnings across 10 files.
- `pnpm lint:eslint:full-report -- --output .eslint-reports/eslint-full-report-after-gamesurface-hooks-bunny.json` after the Bunny fix: 0 errors, 15 warnings across 9 files; `GameSurface` has 0 remaining warnings. The 15 remaining warnings are the non-GameSurface slice already covered by PR #1630.
- `pnpm lint`
- `pnpm typecheck`
- `pnpm check:architecture`
- `pnpm check:docs`
- `pnpm check:unused`
- `pnpm build` passed; Vite emitted the existing large-chunk warning.
- `pnpm test` passed: 80 files, 496 tests.
- `git diff --check` passed with the existing CRLF warning for the touched file.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

No changelog update: this is internal hook-lint cleanup, and this branch does not currently have a `CHANGELOG.md` file.

## UI evidence

N/A; no visible UI changes and no manual app QA was run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined the game metadata persistence system to improve reliability when saving inventory changes, music history, combat snapshots, and narration progress.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1631?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->