### PR TITLE
Enforce React Hooks lint rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -57,6 +57,8 @@ export default tseslint.config(
       ],
     },
     rules: {
+      "react-hooks/rules-of-hooks": "error",
+      "react-hooks/exhaustive-deps": "warn",
       "no-restricted-imports": [
         "error",
         {

--- a/eslint.full-report.config.js
+++ b/eslint.full-report.config.js
@@ -22,14 +22,6 @@ export default [
   },
   ...stagedTypeScriptRecommendedConfigs,
   {
-    name: "marinara/staged-react-hooks-report",
-    files: tsSourceFiles,
-    rules: {
-      "react-hooks/rules-of-hooks": "error",
-      "react-hooks/exhaustive-deps": "warn",
-    },
-  },
-  {
     name: "marinara/staged-typescript-pragmatic-relaxations",
     files: tsSourceFiles,
     rules: {


### PR DESCRIPTION
## Linked issue

Part of #1619

## Why this change

- React Hooks findings are now clean after the non-GameSurface and GameSurface cleanup slices, so the useful hooks signal can move from staged report-only coverage into normal lint.

## What changed

- Enables `react-hooks/rules-of-hooks` as an error in the main ESLint config.
- Enables `react-hooks/exhaustive-deps` as a warning in the main ESLint config.
- Removes the now-redundant staged React Hooks report block from the full-report config; full reports still inherit the normal hooks rules through the base config.

## Refactor impact

Primary owner:

Tooling / ESLint config

Impact areas reviewed:

- Normal `pnpm lint` ESLint path
- Staged `pnpm lint:eslint:full-report` path
- Architecture/docs validation gates for config-only changes

Boundary notes:

- No app, feature, engine, shared API, Rust, Tauri command, or remote runtime behavior changed.
- Existing architecture/import lint rules stay in place.
- React Hooks rules now run as part of normal source lint for `src/**/*.{ts,tsx}`.

Pressure points touched:

- None; only root ESLint config files changed.

## Validation

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- `pnpm lint`
- `pnpm lint:eslint:full-report -- --output .eslint-reports/eslint-full-report-before-hooks-gate.json`: 0 errors, 0 warnings across 0 files before the gate change.
- `pnpm lint:eslint:full-report -- --output .eslint-reports/eslint-full-report-after-hooks-gate.json`: 0 errors, 0 warnings across 0 files after moving hooks into normal lint.
- `pnpm typecheck`
- `pnpm check:architecture`
- `pnpm check:docs`
- `git diff --check` passed with existing CRLF warnings for the touched JS config files.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

No changelog update: this repo branch currently has no `CHANGELOG.md`, and this is tooling-only lint enforcement.

## UI evidence

N/A; no visible UI changes.