### PR TITLE
Fall back when recent chat avatar fails

### DIFF
--- a/src/features/modes/router/components/RecentChats.tsx
+++ b/src/features/modes/router/components/RecentChats.tsx
@@ -2,7 +2,7 @@
 // Chat: Recent Chats — shows 3 most recently
 // interacted chats on the homepage (compact row)
 // ──────────────────────────────────────────────
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { MessageSquare, BookOpen } from "lucide-react";
 import { useRecentChatSummaries, type ChatListItem } from "../../../catalog/chats/index";
 import { characterAvatarUrl, useCharacterSummariesByIds } from "../../../catalog/characters/index";
@@ -105,19 +105,8 @@ function RecentChatChip({
     >
       {/* Small avatar with mode dot */}
       <div className="relative flex-shrink-0">
-        {firstAvatar?.avatarUrl ? (
-          <span className="relative block h-5 w-5 overflow-hidden rounded-md">
-            <img
-              src={firstAvatar.avatarUrl}
-              alt={firstAvatar.name}
-              className="h-full w-full object-cover"
-              style={getAvatarCropStyle(firstAvatar.avatarCrop)}
-            />
-          </span>
-        ) : firstAvatar ? (
-          <div className="flex h-5 w-5 items-center justify-center rounded-md bg-[var(--secondary)] text-[0.5rem] font-bold text-[var(--muted-foreground)]">
-            {firstAvatar.name[0]}
-          </div>
+        {firstAvatar ? (
+          <RecentChatAvatar avatar={firstAvatar} />
         ) : (
           <div
             className="flex h-5 w-5 items-center justify-center rounded-md text-white"
@@ -140,5 +129,37 @@ function RecentChatChip({
       {/* Chat name only */}
       <span className="truncate text-[0.625rem] font-medium text-[var(--foreground)]">{chat.name}</span>
     </button>
+  );
+}
+
+function RecentChatAvatar({
+  avatar,
+}: {
+  avatar: { name: string; avatarUrl: string | null; avatarCrop?: AvatarCropValue | null };
+}) {
+  const [imageFailed, setImageFailed] = useState(false);
+
+  useEffect(() => {
+    setImageFailed(false);
+  }, [avatar.avatarUrl]);
+
+  if (!avatar.avatarUrl || imageFailed) {
+    return (
+      <div className="flex h-5 w-5 items-center justify-center rounded-md bg-[var(--secondary)] text-[0.5rem] font-bold text-[var(--muted-foreground)]">
+        {avatar.name[0]}
+      </div>
+    );
+  }
+
+  return (
+    <span className="relative block h-5 w-5 overflow-hidden rounded-md">
+      <img
+        src={avatar.avatarUrl}
+        alt={avatar.name}
+        className="h-full w-full object-cover"
+        style={getAvatarCropStyle(avatar.avatarCrop)}
+        onError={() => setImageFailed(true)}
+      />
+    </span>
   );
 }


### PR DESCRIPTION
## Linked issue

Closes #1604

## Why this change

Recent chat chips rendered a broken image fragment when a character had a persisted avatar URL but the asset file returned 404. The no-avatar initial fallback already existed, but the component only used it when `avatarUrl` was missing, not when image loading failed.

## What changed

- Added a focused `RecentChatAvatar` renderer for recent-chat chips.
- Tracks image load failure and swaps to the existing name-initial fallback.
- Resets the failed state when the avatar URL changes so newly resolved avatars can render normally.

## Refactor impact

Primary owner:

- Mode router UI / recent chat home surface.

Impact areas reviewed:

- Recent chat chip avatar rendering.
- Character avatar URL resolution remains unchanged.
- Avatar persistence and Tauri asset serving are not changed by this PR.

Boundary notes:

- Feature UI only; no engine, shared API, Rust, or remote-runtime boundary changes.

Pressure points touched:

- `src/features/modes/router/components/RecentChats.tsx`

## Validation

- [ ] `pnpm check` passes locally
- [x] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- `pnpm typecheck`
- Code-path review: a truthy avatar URL still renders `<img>`, `onError` sets the failed state, and the component reuses the same initial fallback used for no-avatar characters. The failed state resets when `avatar.avatarUrl` changes.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

Not captured. This is a narrow broken-image fallback in the recent-chat chip and was verified by typecheck plus code-path review.
