### PR TITLE
Preserve JSONL message roles and character ids

### DIFF
--- a/src-tauri/src/commands/storage/imports/bulk_imports.rs
+++ b/src-tauri/src/commands/storage/imports/bulk_imports.rs
@@ -505,6 +505,7 @@ fn import_st_chat_text(
     inherited: Option<Value>,
 ) -> AppResult<Value> {
     let mut character_name = String::new();
+    let mut character_ids = Vec::new();
     let mut parsed_rows = Vec::new();
     for line in text.lines().map(str::trim).filter(|line| !line.is_empty()) {
         let parsed = match parse_json_text(line) {
@@ -516,6 +517,16 @@ fn import_st_chat_text(
                 character_name = name.to_string();
             }
         }
+        if let Some(character_id) = parsed
+            .get("characterId")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            if !character_ids.iter().any(|id| id == character_id) {
+                character_ids.push(character_id.to_string());
+            }
+        }
         parsed_rows.push(parsed);
     }
     let mut chat = ensure_object(inherited.unwrap_or_else(|| json!({})))?;
@@ -523,8 +534,18 @@ fn import_st_chat_text(
     chat.insert("name".to_string(), Value::String(chat_name));
     chat.entry("mode".to_string())
         .or_insert(Value::String("conversation".to_string()));
-    chat.entry("characterIds".to_string())
-        .or_insert_with(|| json!([]));
+    if character_ids.is_empty() {
+        chat.entry("characterIds".to_string())
+            .or_insert_with(|| json!([]));
+    } else {
+        let mut merged_character_ids = shared::string_array_from_value(chat.get("characterIds"));
+        for character_id in character_ids {
+            if !merged_character_ids.iter().any(|id| id == &character_id) {
+                merged_character_ids.push(character_id);
+            }
+        }
+        chat.insert("characterIds".to_string(), json!(merged_character_ids));
+    }
     chat.entry("metadata".to_string())
         .or_insert_with(|| json!({}));
     if !character_name.is_empty() {
@@ -560,13 +581,20 @@ fn import_st_chat_text(
             } else {
                 "assistant"
             };
+            let character_id = row
+                .get("characterId")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(|value| Value::String(value.to_string()))
+                .unwrap_or(Value::Null);
             let message = state.storage.create(
                 "messages",
                 json!({
                     "chatId": chat_id,
                     "role": role,
                     "content": content,
-                    "characterId": Value::Null,
+                    "characterId": character_id,
                     "extra": {},
                     "activeSwipeIndex": 0,
                     "swipes": [{ "content": content }]
@@ -1137,6 +1165,90 @@ mod tests {
         assert!(
             state.storage.list("chats").unwrap().is_empty(),
             "failed chat import must remove the created chat"
+        );
+
+        let _ = fs::remove_dir_all(app_root);
+    }
+
+    #[test]
+    fn import_st_chat_text_preserves_marinara_jsonl_character_ids() {
+        let app_root = temp_path("chat-character-ids");
+        let state = AppState::from_data_dir(&app_root, Vec::new())
+            .expect("test app state should initialize");
+
+        let result = import_st_chat_text(
+            &state,
+            r#"{"role":"assistant","characterId":"char-a","content":"hello"}"#,
+            "Imported Chat".to_string(),
+            None,
+        )
+        .expect("chat import should succeed");
+
+        let chat_id = result
+            .get("chatId")
+            .and_then(Value::as_str)
+            .expect("import result should include chat id");
+        let chat = state
+            .storage
+            .get("chats", chat_id)
+            .expect("chat should be readable")
+            .expect("chat should exist");
+        assert_eq!(
+            shared::string_array_from_value(chat.get("characterIds")),
+            vec!["char-a".to_string()],
+            "chat should link character ids from Marinara JSONL rows"
+        );
+
+        let messages = state
+            .storage
+            .list("messages")
+            .expect("messages should list");
+        assert_eq!(messages.len(), 1);
+        assert_eq!(
+            messages[0].get("characterId").and_then(Value::as_str),
+            Some("char-a"),
+            "message should retain its row-level character id"
+        );
+
+        let _ = fs::remove_dir_all(app_root);
+    }
+
+    #[test]
+    fn import_st_chat_text_does_not_link_character_name_only_rows() {
+        let app_root = temp_path("chat-character-name-only");
+        let state = AppState::from_data_dir(&app_root, Vec::new())
+            .expect("test app state should initialize");
+
+        let result = import_st_chat_text(
+            &state,
+            r#"{"character_name":"Bot","mes":"hello"}"#,
+            "Imported Chat".to_string(),
+            None,
+        )
+        .expect("chat import should succeed");
+
+        let chat_id = result
+            .get("chatId")
+            .and_then(Value::as_str)
+            .expect("import result should include chat id");
+        let chat = state
+            .storage
+            .get("chats", chat_id)
+            .expect("chat should be readable")
+            .expect("chat should exist");
+        assert!(
+            shared::string_array_from_value(chat.get("characterIds")).is_empty(),
+            "ST character_name alone is not a stable local character link"
+        );
+
+        let messages = state
+            .storage
+            .list("messages")
+            .expect("messages should list");
+        assert_eq!(messages.len(), 1);
+        assert!(
+            messages[0].get("characterId").is_none_or(Value::is_null),
+            "ST character_name alone should keep transcript messages unlinked"
         );
 
         let _ = fs::remove_dir_all(app_root);

--- a/src-tauri/src/commands/storage/imports/bulk_imports.rs
+++ b/src-tauri/src/commands/storage/imports/bulk_imports.rs
@@ -43,6 +43,17 @@ fn selected_import_total(options: &Value) -> usize {
     .sum()
 }
 
+fn imported_jsonl_message_role(row: &Value) -> &'static str {
+    match row.get("role").and_then(Value::as_str).map(str::trim) {
+        Some("user") => "user",
+        Some("assistant") => "assistant",
+        Some("system") => "system",
+        Some("narrator") => "narrator",
+        _ if row.get("is_user").and_then(Value::as_bool).unwrap_or(false) => "user",
+        _ => "assistant",
+    }
+}
+
 fn empty_import_counts() -> Value {
     json!({
         "characters": 0,
@@ -576,11 +587,7 @@ fn import_st_chat_text(
             if content.trim().is_empty() {
                 continue;
             }
-            let role = if row.get("is_user").and_then(Value::as_bool).unwrap_or(false) {
-                "user"
-            } else {
-                "assistant"
-            };
+            let role = imported_jsonl_message_role(&row);
             let character_id = row
                 .get("characterId")
                 .and_then(Value::as_str)
@@ -1208,6 +1215,83 @@ mod tests {
             messages[0].get("characterId").and_then(Value::as_str),
             Some("char-a"),
             "message should retain its row-level character id"
+        );
+
+        let _ = fs::remove_dir_all(app_root);
+    }
+
+    #[test]
+    fn import_st_chat_text_preserves_marinara_jsonl_roles() {
+        let app_root = temp_path("chat-message-roles");
+        let state = AppState::from_data_dir(&app_root, Vec::new())
+            .expect("test app state should initialize");
+
+        import_st_chat_text(
+            &state,
+            concat!(
+                r#"{"role":"user","content":"hello"}"#,
+                "\n",
+                r#"{"role":"assistant","content":"hi"}"#,
+                "\n",
+                r#"{"role":"system","content":"note"}"#,
+                "\n",
+                r#"{"role":"narrator","content":"scene"}"#,
+            ),
+            "Imported Chat".to_string(),
+            None,
+        )
+        .expect("chat import should succeed");
+
+        let roles = state
+            .storage
+            .list("messages")
+            .expect("messages should list")
+            .into_iter()
+            .map(|message| {
+                message
+                    .get("role")
+                    .and_then(Value::as_str)
+                    .expect("message should include a role")
+                    .to_string()
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            roles,
+            vec![
+                "user".to_string(),
+                "assistant".to_string(),
+                "system".to_string(),
+                "narrator".to_string()
+            ],
+            "Marinara JSONL roles should round-trip without ST is_user flags"
+        );
+
+        let _ = fs::remove_dir_all(app_root);
+    }
+
+    #[test]
+    fn import_st_chat_text_falls_back_for_unknown_marinara_jsonl_roles() {
+        let app_root = temp_path("chat-unknown-message-role");
+        let state = AppState::from_data_dir(&app_root, Vec::new())
+            .expect("test app state should initialize");
+
+        import_st_chat_text(
+            &state,
+            r#"{"role":"tool","content":"internal"}"#,
+            "Imported Chat".to_string(),
+            None,
+        )
+        .expect("chat import should succeed");
+
+        let messages = state
+            .storage
+            .list("messages")
+            .expect("messages should list");
+        assert_eq!(messages.len(), 1);
+        assert_eq!(
+            messages[0].get("role").and_then(Value::as_str),
+            Some("assistant"),
+            "unknown JSONL roles should not be persisted verbatim"
         );
 
         let _ = fs::remove_dir_all(app_root);


### PR DESCRIPTION
## Linked issue

Closes #1524

## Why this change

Marinara JSONL chat export writes stored message rows as-is, including each row's `role` and `characterId`, but the JSONL/ST importer discarded that local context. Imported Marinara JSONL user rows could become assistant messages because the importer only looked at ST's `is_user` flag, and imported messages always lost `characterId`.

## What changed

- The JSONL/ST chat importer now preserves supported explicit Marinara JSONL roles: `user`, `assistant`, `system`, and `narrator`.
- ST-style rows without an explicit role still use the existing `is_user` fallback and default assistant behavior.
- Unknown role strings are not persisted verbatim; they fall back to assistant.
- Non-empty row-level `characterId` strings are preserved on imported messages.
- Imported chats collect those explicit row-level character IDs into `characterIds`, preserving existing inherited chat links when present.
- Plain SillyTavern `character_name` rows remain transcript-only and are not guessed into local character links.
- Added importer tests for Marinara JSONL roles, unknown role fallback, character IDs, and the ST `character_name` negative control.

## Refactor impact

Primary owner:

- Rust storage imports.

Impact areas reviewed:

- ST/JSONL chat import behavior.
- Marinara JSONL export shape, which already serializes message rows with `role` and `characterId`.
- Chat/message persistence fields used by chat and roleplay message rendering and avatar resolution.

Boundary notes:

- Rust import capability only; no React feature imports, engine coupling, shared API routing, or remote-runtime allowlist changes.
- The fix avoids name-based matching because `character_name` is not a stable local character identity.

Pressure points touched:

- `src-tauri/src/commands/storage/imports/bulk_imports.rs`

## Validation

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [x] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [x] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml import_st_chat_text`
- `cargo fmt --manifest-path src-tauri/Cargo.toml --check` was attempted, but the repository currently has unrelated rustfmt drift in other files. The touched importer hunks were manually aligned and `git diff --check` passes.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

Not applicable; this is Rust import behavior.
