### PR TITLE
Validate uploaded image bytes instead of trusting declared MIME type

### DIFF
--- a/src-tauri/src/commands/storage/shared.rs
+++ b/src-tauri/src/commands/storage/shared.rs
@@ -1501,6 +1501,40 @@ mod tests {
         assert_eq!(error.code, "invalid_input");
         assert!(error.message.contains("Only image uploads"));
     }
+
+    #[test]
+    fn decode_uploaded_image_file_accepts_svg_with_prolog_doctype_and_comment() {
+        let svg = "\u{feff}<?xml version=\"1.0\"?>\n<!-- a logo -->\n<!DOCTYPE svg>\n<svg xmlns=\"http://www.w3.org/2000/svg\"/>";
+        let uploaded = decode_uploaded_image_file(&json!({
+            "file": {
+                "name": "logo.svg",
+                "type": "image/svg+xml",
+                "size": svg.len(),
+                "base64": general_purpose::STANDARD.encode(svg)
+            }
+        }))
+        .expect("an SVG with BOM, prolog, comment and doctype should be accepted");
+        assert_eq!(uploaded.content_type, "image/svg+xml");
+    }
+
+    #[test]
+    fn decode_uploaded_image_file_rejects_svg_substring_not_at_root() {
+        // `<svg` appears, but the document root is `<html>`, not `<svg>`.
+        let html = "<html><body><svg></svg></body></html>";
+        let result = decode_uploaded_image_file(&json!({
+            "file": {
+                "name": "sneaky.svg",
+                "type": "image/svg+xml",
+                "size": html.len(),
+                "base64": general_purpose::STANDARD.encode(html)
+            }
+        }));
+
+        let Err(error) = result else {
+            panic!("a non-svg-root document declared as SVG should be rejected");
+        };
+        assert_eq!(error.code, "invalid_input");
+    }
 }
 
 pub(crate) fn duplicate_record(state: &AppState, collection: &str, id: &str) -> AppResult<Value> {
@@ -1646,6 +1680,48 @@ fn image_upload_invalid_type_error() -> AppError {
     AppError::invalid_input("Only image uploads are allowed")
 }
 
+/// True when the decoded bytes are a UTF-8 XML document whose first element is
+/// `<svg>`. Skips a UTF-8 BOM, leading whitespace, the `<?xml ...?>` prolog, XML
+/// comments, and `<!DOCTYPE ...>`/declarations, then requires the first start
+/// tag to be `svg`. This rejects a non-SVG document that merely contains the
+/// `<svg` substring somewhere inside it.
+fn bytes_have_svg_root(bytes: &[u8]) -> bool {
+    let Ok(text) = std::str::from_utf8(bytes) else {
+        return false;
+    };
+    let mut rest = text.trim_start_matches('\u{feff}').trim_start();
+    loop {
+        if let Some(after) = rest.strip_prefix("<?") {
+            let Some(end) = after.find("?>") else {
+                return false;
+            };
+            rest = after[end + 2..].trim_start();
+        } else if let Some(after) = rest.strip_prefix("<!--") {
+            let Some(end) = after.find("-->") else {
+                return false;
+            };
+            rest = after[end + 3..].trim_start();
+        } else if rest.starts_with("<!") {
+            // DOCTYPE or other declaration.
+            let Some(end) = rest.find('>') else {
+                return false;
+            };
+            rest = rest[end + 1..].trim_start();
+        } else {
+            break;
+        }
+    }
+    let Some(after) = rest
+        .get(..4)
+        .filter(|head| head.eq_ignore_ascii_case("<svg"))
+        .map(|_| &rest[4..])
+    else {
+        return false;
+    };
+    // The tag name must end here (delimiter), not be a prefix like `<svguard`.
+    after.is_empty() || after.starts_with(['>', '/']) || after.starts_with(char::is_whitespace)
+}
+
 pub(crate) fn decode_uploaded_file_value(file: &Value) -> AppResult<UploadedFile> {
     let name = file
         .get("name")
@@ -1714,12 +1790,11 @@ pub(crate) fn decode_uploaded_image_file(body: &Value) -> AppResult<UploadedFile
     // them, rejecting arbitrary bytes masquerading as an image.
     if content_type.eq_ignore_ascii_case("image/svg+xml") {
         // SVG is an accepted upload type but is XML text with no binary magic,
-        // so `image::guess_format` cannot recognize it. Require a recognizable
-        // SVG root instead, which still rejects non-SVG bytes declared as SVG.
-        let looks_like_svg = std::str::from_utf8(&uploaded.bytes)
-            .map(|text| text.to_ascii_lowercase().contains("<svg"))
-            .unwrap_or(false);
-        if !looks_like_svg {
+        // so `image::guess_format` cannot recognize it. Require an `<svg>` ROOT
+        // element (not just the substring anywhere), which still rejects non-SVG
+        // bytes declared as SVG, including a document that merely embeds `<svg`
+        // inside another root element.
+        if !bytes_have_svg_root(&uploaded.bytes) {
             return Err(image_upload_invalid_type_error());
         }
     } else {

--- a/src-tauri/src/commands/storage/shared.rs
+++ b/src-tauri/src/commands/storage/shared.rs
@@ -1467,6 +1467,40 @@ mod tests {
         assert_eq!(uploaded.content_type, "image/png");
         assert!(!uploaded.bytes.is_empty());
     }
+
+    #[test]
+    fn decode_uploaded_image_file_accepts_svg_with_root_element() {
+        let svg = "<?xml version=\"1.0\"?><svg xmlns=\"http://www.w3.org/2000/svg\"></svg>";
+        let uploaded = decode_uploaded_image_file(&json!({
+            "file": {
+                "name": "logo.svg",
+                "type": "image/svg+xml",
+                "size": svg.len(),
+                "base64": general_purpose::STANDARD.encode(svg)
+            }
+        }))
+        .expect("a real SVG payload should be accepted");
+        assert_eq!(uploaded.content_type, "image/svg+xml");
+    }
+
+    #[test]
+    fn decode_uploaded_image_file_rejects_svg_typed_non_svg_bytes() {
+        // `bm9wZQ==` decodes to "nope" - declared image/svg+xml but not SVG.
+        let result = decode_uploaded_image_file(&json!({
+            "file": {
+                "name": "fake.svg",
+                "type": "image/svg+xml",
+                "size": 4,
+                "base64": "bm9wZQ=="
+            }
+        }));
+
+        let Err(error) = result else {
+            panic!("svg-typed payload without an svg root should be rejected");
+        };
+        assert_eq!(error.code, "invalid_input");
+        assert!(error.message.contains("Only image uploads"));
+    }
 }
 
 pub(crate) fn duplicate_record(state: &AppState, collection: &str, id: &str) -> AppResult<Value> {
@@ -1676,11 +1710,23 @@ pub(crate) fn decode_uploaded_image_file(body: &Value) -> AppResult<UploadedFile
         return Err(image_upload_too_large_error());
     }
     // The declared `image/*` content type is caller-controlled; validate that
-    // the decoded bytes actually carry a recognized image signature before
-    // storing or serving them. A magic-byte check rejects arbitrary bytes
-    // masquerading as an image while still accepting every real image format,
-    // including ones whose decoder feature is not compiled in (e.g. GIF).
-    image::guess_format(&uploaded.bytes).map_err(|_| image_upload_invalid_type_error())?;
+    // the decoded bytes actually carry image content before storing or serving
+    // them, rejecting arbitrary bytes masquerading as an image.
+    if content_type.eq_ignore_ascii_case("image/svg+xml") {
+        // SVG is an accepted upload type but is XML text with no binary magic,
+        // so `image::guess_format` cannot recognize it. Require a recognizable
+        // SVG root instead, which still rejects non-SVG bytes declared as SVG.
+        let looks_like_svg = std::str::from_utf8(&uploaded.bytes)
+            .map(|text| text.to_ascii_lowercase().contains("<svg"))
+            .unwrap_or(false);
+        if !looks_like_svg {
+            return Err(image_upload_invalid_type_error());
+        }
+    } else {
+        // A magic-byte check accepts every real raster image format, including
+        // ones whose decoder feature is not compiled in (e.g. GIF).
+        image::guess_format(&uploaded.bytes).map_err(|_| image_upload_invalid_type_error())?;
+    }
     Ok(uploaded)
 }
 

--- a/src-tauri/src/commands/storage/shared.rs
+++ b/src-tauri/src/commands/storage/shared.rs
@@ -1430,6 +1430,43 @@ mod tests {
         assert_eq!(error.code, "invalid_input");
         assert!(error.message.contains("Only image uploads"));
     }
+
+    #[test]
+    fn decode_uploaded_image_file_rejects_declared_image_with_non_image_bytes() {
+        // `bm9wZQ==` decodes to "nope" - a valid `image/png` content type but
+        // bytes that are not actually an image.
+        let result = decode_uploaded_image_file(&json!({
+            "file": {
+                "name": "fake.png",
+                "type": "image/png",
+                "size": 4,
+                "base64": "bm9wZQ=="
+            }
+        }));
+
+        let Err(error) = result else {
+            panic!("image-typed payload with non-image bytes should be rejected");
+        };
+        assert_eq!(error.code, "invalid_input");
+        assert!(error.message.contains("Only image uploads"));
+    }
+
+    #[test]
+    fn decode_uploaded_image_file_accepts_valid_png_bytes() {
+        // A real 1x1 PNG so the magic-byte check passes.
+        let png_base64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==";
+        let uploaded = decode_uploaded_image_file(&json!({
+            "file": {
+                "name": "pixel.png",
+                "type": "image/png",
+                "size": 70,
+                "base64": png_base64
+            }
+        }))
+        .expect("a real PNG payload should be accepted");
+        assert_eq!(uploaded.content_type, "image/png");
+        assert!(!uploaded.bytes.is_empty());
+    }
 }
 
 pub(crate) fn duplicate_record(state: &AppState, collection: &str, id: &str) -> AppResult<Value> {
@@ -1638,6 +1675,12 @@ pub(crate) fn decode_uploaded_image_file(body: &Value) -> AppResult<UploadedFile
     if uploaded.bytes.len() > MAX_IMAGE_UPLOAD_BYTES {
         return Err(image_upload_too_large_error());
     }
+    // The declared `image/*` content type is caller-controlled; validate that
+    // the decoded bytes actually carry a recognized image signature before
+    // storing or serving them. A magic-byte check rejects arbitrary bytes
+    // masquerading as an image while still accepting every real image format,
+    // including ones whose decoder feature is not compiled in (e.g. GIF).
+    image::guess_format(&uploaded.bytes).map_err(|_| image_upload_invalid_type_error())?;
     Ok(uploaded)
 }
 

--- a/src-tauri/src/http_dispatch.rs
+++ b/src-tauri/src/http_dispatch.rs
@@ -1258,7 +1258,9 @@ mod tests {
     }
 
     fn upload_body(name: &str) -> Value {
-        let bytes = [137_u8, 80, 78, 71];
+        // Full 8-byte PNG signature so the image-byte validation in
+        // decode_uploaded_image_file recognizes the fixture as a real image.
+        let bytes = [137_u8, 80, 78, 71, 13, 10, 26, 10];
         json!({
             "file": {
                 "name": name,


### PR DESCRIPTION
## Why this change

`decode_uploaded_image_file` (shared upload decoder) already rejects empty payloads, oversized payloads, and non-image declared content types, but it still trusted a declared `image/*` MIME type without validating the decoded bytes. A caller could declare `image/png` and send arbitrary non-image bytes, which passed the decoder and were stored / later served as an image.

## What changed

- `src-tauri/src/commands/storage/shared.rs`: after decoding (and after the existing size checks), validate the decoded bytes. For raster types, `image::guess_format` rejects bytes that match no recognized image signature (accepting every real raster format, including ones whose decoder feature is not compiled in, e.g. GIF). SVG is an accepted upload type (`image/svg+xml`, in `IMAGE_EXTS`, reachable via `accept="image/*"`) but is XML text with no binary magic, so it is special-cased to require a recognizable `<svg` root instead, which still rejects non-SVG bytes declared as SVG.
- `src-tauri/src/http_dispatch.rs`: the shared upload test fixture emitted only the 4-byte PNG prefix; emit the full 8-byte PNG signature so it is recognized as a real image.
- Tests: declared-`image/png` with non-image bytes is rejected; a real 1x1 PNG is accepted; a real SVG is accepted; svg-typed non-SVG bytes are rejected.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` clean.
- Full Rust test suite green, including the three `dispatch_supports_remote_*_upload` tests (fixture fixed) and the `decode_uploaded_image_*` suite (6 tests).

The end-user trigger (uploading through an image/background path) reaches this decoder via the native file picker, which the automated tiers don't drive; the decoder's byte-level behavior is fully covered by the tests.

## Linked issue

Closes #1534.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened image upload validation to properly distinguish between SVG and raster image formats using format-specific detection methods.

* **Tests**
  * Expanded test coverage for image upload validation scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1636?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->