### PR TITLE
Normalize lorebook-entry fields at the generic storage boundary

### DIFF
--- a/src-tauri/src/commands/storage/shared.rs
+++ b/src-tauri/src/commands/storage/shared.rs
@@ -377,7 +377,40 @@ pub(crate) fn normalize_typed_json_fields(
             normalize_json_array_fields(object, &["tags", "characterIds", "personaIds"])?;
         }
         "lorebook-entries" => {
-            normalize_json_array_fields(object, &["keys", "secondaryKeys"])?;
+            // The generic storage boundary is the single contract every
+            // lorebook-entry write crosses (editor, bulk create, copy/move,
+            // tool-generated entries, remote runtime). Coerce every legacy-style
+            // shape - string booleans, JSON-string arrays, and JSON-string
+            // objects - to the native shape, or reject what cannot be coerced,
+            // so downstream UI/generation never has to guess the intended type.
+            normalize_json_array_fields(
+                object,
+                &[
+                    "keys",
+                    "secondaryKeys",
+                    "characterFilterIds",
+                    "characterTagFilters",
+                    "generationTriggerFilters",
+                    "additionalMatchingSources",
+                    "activationConditions",
+                ],
+            )?;
+            normalize_boolish_fields(
+                object,
+                &[
+                    "enabled",
+                    "constant",
+                    "selective",
+                    "matchWholeWords",
+                    "caseSensitive",
+                    "useRegex",
+                    "preventRecursion",
+                    "locked",
+                    "excludeFromVectorization",
+                ],
+            );
+            normalize_json_object_fields(object, &["relationships", "dynamicState"])?;
+            normalize_nullable_json_object_fields(object, &["schedule"])?;
         }
         "connections" => {
             normalize_nullable_json_object_fields(
@@ -1533,6 +1566,69 @@ mod tests {
         let Err(error) = result else {
             panic!("a non-svg-root document declared as SVG should be rejected");
         };
+        assert_eq!(error.code, "invalid_input");
+    }
+
+    #[test]
+    fn normalize_typed_lorebook_entry_coerces_legacy_string_fields() {
+        let Value::Object(mut object) = json!({
+            "enabled": "false",
+            "constant": "true",
+            "excludeFromVectorization": "1",
+            "keys": "[\"moon\"]",
+            "secondaryKeys": "[]",
+            "characterFilterIds": "[\"c1\"]",
+            "additionalMatchingSources": "[\"character_name\"]",
+            "relationships": "{}",
+            "schedule": null
+        }) else {
+            unreachable!("json! object literal");
+        };
+
+        normalize_typed_json_fields("lorebook-entries", &mut object)
+            .expect("legacy-style lorebook entry should normalize at the storage boundary");
+
+        assert_eq!(object["enabled"], json!(false));
+        assert_eq!(object["constant"], json!(true));
+        assert_eq!(object["excludeFromVectorization"], json!(true));
+        assert_eq!(object["keys"], json!(["moon"]));
+        assert_eq!(object["secondaryKeys"], json!([]));
+        assert_eq!(object["characterFilterIds"], json!(["c1"]));
+        assert_eq!(object["additionalMatchingSources"], json!(["character_name"]));
+        assert_eq!(object["relationships"], json!({}));
+        assert_eq!(object["schedule"], Value::Null);
+    }
+
+    #[test]
+    fn normalize_typed_lorebook_entry_keeps_native_row_unchanged() {
+        let Value::Object(mut object) = json!({
+            "enabled": true,
+            "constant": false,
+            "keys": ["sun"],
+            "secondaryKeys": [],
+            "additionalMatchingSources": ["character_name"],
+            "relationships": { "ally": "moon" },
+            "dynamicState": {},
+            "schedule": { "activeTimes": [], "activeDates": [], "activeLocations": [] }
+        }) else {
+            unreachable!("json! object literal");
+        };
+        let before = object.clone();
+
+        normalize_typed_json_fields("lorebook-entries", &mut object)
+            .expect("a native lorebook entry should pass through unchanged");
+
+        assert_eq!(object, before);
+    }
+
+    #[test]
+    fn normalize_typed_lorebook_entry_rejects_unparseable_array_field() {
+        let Value::Object(mut object) = json!({ "keys": "not json" }) else {
+            unreachable!("json! object literal");
+        };
+
+        let error = normalize_typed_json_fields("lorebook-entries", &mut object)
+            .expect_err("an unparseable array field must be rejected, not silently stored");
         assert_eq!(error.code, "invalid_input");
     }
 }

--- a/src-tauri/src/commands/storage/shared.rs
+++ b/src-tauri/src/commands/storage/shared.rs
@@ -409,8 +409,14 @@ pub(crate) fn normalize_typed_json_fields(
                     "excludeFromVectorization",
                 ],
             );
-            normalize_json_object_fields(object, &["relationships", "dynamicState"])?;
-            normalize_nullable_json_object_fields(object, &["schedule"])?;
+            // Use the nullable object normalizer so a stored entry that already
+            // carries `null` (e.g. round-tripped through a copy/duplicate) is
+            // left untouched rather than rejected, while a JSON-string object is
+            // still parsed and a malformed value still rejected.
+            normalize_nullable_json_object_fields(
+                object,
+                &["relationships", "dynamicState", "schedule"],
+            )?;
         }
         "connections" => {
             normalize_nullable_json_object_fields(
@@ -1619,6 +1625,25 @@ mod tests {
             .expect("a native lorebook entry should pass through unchanged");
 
         assert_eq!(object, before);
+    }
+
+    #[test]
+    fn normalize_typed_lorebook_entry_allows_null_object_fields() {
+        // A copy/duplicate round-trips a stored entry through this arm; a null
+        // relationships/dynamicState/schedule must pass through, not be rejected.
+        let Value::Object(mut object) = json!({
+            "relationships": null,
+            "dynamicState": null,
+            "schedule": null
+        }) else {
+            unreachable!("json! object literal");
+        };
+
+        normalize_typed_json_fields("lorebook-entries", &mut object)
+            .expect("null object fields should round-trip, not reject");
+        assert_eq!(object["relationships"], Value::Null);
+        assert_eq!(object["dynamicState"], Value::Null);
+        assert_eq!(object["schedule"], Value::Null);
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/shared.rs
+++ b/src-tauri/src/commands/storage/shared.rs
@@ -1656,6 +1656,17 @@ mod tests {
             .expect_err("an unparseable array field must be rejected, not silently stored");
         assert_eq!(error.code, "invalid_input");
     }
+
+    #[test]
+    fn normalize_typed_lorebook_entry_rejects_unparseable_object_field() {
+        let Value::Object(mut object) = json!({ "relationships": "not json" }) else {
+            unreachable!("json! object literal");
+        };
+
+        let error = normalize_typed_json_fields("lorebook-entries", &mut object)
+            .expect_err("an unparseable object field must be rejected, not silently stored");
+        assert_eq!(error.code, "invalid_input");
+    }
 }
 
 pub(crate) fn duplicate_record(state: &AppState, collection: &str, id: &str) -> AppResult<Value> {


### PR DESCRIPTION
## Why this change

Follow-up to #1571 (related to but not a duplicate of #1513). #1513 fixed legacy lorebook-entry **import** normalization, but the generic storage write boundary stayed loosely typed: the `lorebook-entries` arm of `normalize_typed_json_fields` only normalized `keys` and `secondaryKeys`. Any caller that bypassed the legacy import path (the editor, bulk create, copy/move/reorder, tool-generated entries, remote runtime) could still hand `enabled: "false"`, `constant: "true"`, `keys: "[\"moon\"]"`, or a JSON-string object across the boundary and rely on downstream UI/generation to guess the intended shape.

`normalize_typed_json_fields` is the single contract both write paths cross: `storage_create` through `with_entity_defaults`, and `storage_update` through `normalize_update_patch`. Strengthening that one arm closes the gap for every generic caller at once.

## What changed

- `src-tauri/src/commands/storage/shared.rs`: extend the `lorebook-entries` arm to normalize the full native record shape:
  - the nine boolean flags (`enabled`, `constant`, `selective`, `matchWholeWords`, `caseSensitive`, `useRegex`, `preventRecursion`, `locked`, `excludeFromVectorization`) via the existing `normalize_boolish_fields`,
  - the remaining array fields (`characterFilterIds`, `characterTagFilters`, `generationTriggerFilters`, `additionalMatchingSources`, `activationConditions`) alongside `keys`/`secondaryKeys`,
  - the `relationships`/`dynamicState` objects and the nullable `schedule` object.
  - Values that cannot be coerced are rejected rather than stored, matching the existing array-field contract.
- Added three tests: legacy-string coercion (positive), native row passes through unchanged (negative control), and an unparseable array field is rejected.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` clean.
- New tests plus the existing lorebook (19) and normalization (31) suites pass; the legacy import path (which also calls this function) is unaffected because its rows are already coerced before reaching it and the new object/schedule fields are absent on legacy rows.

The end-user write paths reach this boundary through generic `storage_create`/`storage_update`, fully covered by the new unit tests against the real normalization function.

## Known caveat: numeric fields

Numeric lorebook-entry fields (`probability`, `scanDepth`, `position`, `depth`, `order`, `sticky`, `cooldown`, `delay`, `ephemeral`, `groupWeight`) are intentionally left untouched. There is no numeric-coercion primitive at this boundary today and the legacy contract never covered them, so adding one is out of scope for this fix. If a malformed numeric caller ever appears it warrants a dedicated follow-up with its own primitive.

## Linked issue

Closes #1571.