### PR TITLE
Stop the connections sidebar squishing during panel resize

### DIFF
--- a/src/app/shell/AppShell.tsx
+++ b/src/app/shell/AppShell.tsx
@@ -197,6 +197,7 @@ export function AppShell() {
   const rightPanelOpen = useUIStore((s) => s.rightPanelOpen);
   const rightPanelWidth = useUIStore((s) => s.rightPanelWidth);
   const setRightPanelWidth = useUIStore((s) => s.setRightPanelWidth);
+  const setRightPanelResizing = useUIStore((s) => s.setRightPanelResizing);
   const closeRightPanel = useUIStore((s) => s.closeRightPanel);
   const trackerPanelEnabled = useUIStore((s) => s.trackerPanelEnabled);
   const trackerPanelOpen = useUIStore((s) => s.trackerPanelOpen);
@@ -397,6 +398,7 @@ export function AppShell() {
       document.body.style.userSelect = "none";
       rightPanelDragWidthRef.current = rightPanelWidth;
       setRightPanelDragWidth(rightPanelWidth);
+      setRightPanelResizing(true);
 
       const onMove = (moveEvent: MouseEvent) => {
         const nextWidth = clampWidth(
@@ -414,6 +416,7 @@ export function AppShell() {
         setRightPanelWidth(rightPanelDragWidthRef.current ?? useUIStore.getState().rightPanelWidth);
         rightPanelDragWidthRef.current = null;
         setRightPanelDragWidth(null);
+        setRightPanelResizing(false);
         document.body.style.cursor = originalCursor;
         document.body.style.userSelect = originalUserSelect;
         window.removeEventListener("mousemove", onMove);
@@ -425,7 +428,7 @@ export function AppShell() {
       window.addEventListener("mouseup", finishResize);
       window.addEventListener("blur", finishResize);
     },
-    [isMobile, rightPanelWidth, setRightPanelWidth],
+    [isMobile, rightPanelWidth, setRightPanelWidth, setRightPanelResizing],
   );
 
   const adjustSidebarWidth = useCallback(

--- a/src/features/shell/connections/components/ConnectionsPanel.tsx
+++ b/src/features/shell/connections/components/ConnectionsPanel.tsx
@@ -94,7 +94,7 @@ function ConnectionRow({
     <div
       onClick={onClickRow}
       className={cn(
-        "group relative flex cursor-pointer items-center gap-3 rounded-xl p-2.5 transition-all hover:bg-[var(--sidebar-accent)]",
+        "group relative flex cursor-pointer items-center gap-3 rounded-xl p-2.5 transition-colors hover:bg-[var(--sidebar-accent)]",
         isSelected && `ring-1 ${colors.ring} bg-[var(--sidebar-accent)]/50`,
       )}
     >
@@ -208,11 +208,27 @@ function ConnectionFolderRow({
   onDelete: (folder: ConnectionFolder) => void;
 }) {
   const dragControls = useDragControls();
+  const isResizing = useUIStore((s) => s.rightPanelResizing);
   const [renaming, setRenaming] = useState(false);
   const [renameValue, setRenameValue] = useState(folder.name);
 
+  // While the right panel is being drag-resized, suppress framer-motion's
+  // per-item layout projection (which measures+animates on every width frame
+  // and causes the squish). `layout` is omitted from ReorderItemProps's public
+  // type even though the runtime forwards it, so it must go through a
+  // loosely-typed spread. Empty when not resizing -> default layout=true and
+  // drag-to-reorder are fully preserved.
+  const reorderLayoutProps = isResizing ? ({ layout: false } as Record<string, unknown>) : {};
+
   return (
-    <Reorder.Item value={folder.id} dragListener={false} dragControls={dragControls} as="div" className="flex flex-col">
+    <Reorder.Item
+      value={folder.id}
+      dragListener={false}
+      dragControls={dragControls}
+      as="div"
+      className="flex flex-col"
+      {...reorderLayoutProps}
+    >
       {/* Folder header */}
       <div
         onClick={() => onToggleCollapse(folder)}

--- a/src/features/shell/settings/components/settings/TTSConfigCard.tsx
+++ b/src/features/shell/settings/components/settings/TTSConfigCard.tsx
@@ -676,7 +676,7 @@ export function TTSConfigCard() {
   return (
     <div
       className={cn(
-        "rounded-xl border border-rose-400/20 bg-gradient-to-br from-rose-500/5 to-orange-500/5 p-3 transition-all",
+        "rounded-xl border border-rose-400/20 bg-gradient-to-br from-rose-500/5 to-orange-500/5 p-3 transition-colors",
         expanded && "border-rose-400/30",
       )}
     >

--- a/src/shared/stores/ui.store.test.ts
+++ b/src/shared/stores/ui.store.test.ts
@@ -2,6 +2,7 @@
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { useUIStore } from "./ui.store";
+import { partializeUiState } from "./ui/persistence";
 
 // Snapshot the pristine store state once at module load so each case starts clean.
 // The store does not expose a reset action, so we restore the captured initial
@@ -67,5 +68,28 @@ describe("useUIStore closeAgentDetail mobile panel reopen (issue #1554)", () => 
     const closed = useUIStore.getState();
     expect(closed.agentDetailId).toBe(null);
     expect(closed.rightPanelOpen).toBe(false);
+  });
+});
+
+describe("useUIStore right-panel resize flag (issue #1586)", () => {
+  beforeEach(() => {
+    useUIStore.setState(INITIAL_STATE, true);
+  });
+
+  it("defaults to not resizing", () => {
+    expect(useUIStore.getState().rightPanelResizing).toBe(false);
+  });
+
+  it("toggles rightPanelResizing through its setter", () => {
+    useUIStore.getState().setRightPanelResizing(true);
+    expect(useUIStore.getState().rightPanelResizing).toBe(true);
+    useUIStore.getState().setRightPanelResizing(false);
+    expect(useUIStore.getState().rightPanelResizing).toBe(false);
+  });
+
+  it("never persists the transient resize flag to storage", () => {
+    useUIStore.getState().setRightPanelResizing(true);
+    const persisted = partializeUiState(useUIStore.getState());
+    expect(Object.prototype.hasOwnProperty.call(persisted, "rightPanelResizing")).toBe(false);
   });
 });

--- a/src/shared/stores/ui.store.ts
+++ b/src/shared/stores/ui.store.ts
@@ -214,6 +214,7 @@ export const useUIStore = create<UIState>()(
       userStatus: "active" as UserStatus,
       userActivity: "",
       centerCompact: false,
+      rightPanelResizing: false,
 
       // Impersonate settings defaults
       impersonatePromptTemplate: "",
@@ -456,6 +457,7 @@ export const useUIStore = create<UIState>()(
       setTextStrokeWidth: (v) => set({ textStrokeWidth: Math.max(0, Math.min(5, v)) }),
       setTextStrokeColor: (v) => set({ textStrokeColor: v }),
       setCenterCompact: (v) => set({ centerCompact: v }),
+      setRightPanelResizing: (v) => set({ rightPanelResizing: v }),
       setVisualTheme: (v) => set({ visualTheme: v }),
       setConvoGradientField: (scheme, field, value) =>
         set((s) => ({

--- a/src/shared/stores/ui/model.ts
+++ b/src/shared/stores/ui/model.ts
@@ -496,6 +496,10 @@ export interface UIState {
   /** Transient: true when center content area is too narrow (overflow detected) */
   centerCompact: boolean;
 
+  /** Transient: true while the user is dragging a side-panel resizer; lets
+   * ConnectionsPanel suppress framer-motion Reorder layout animations during resize. */
+  rightPanelResizing: boolean;
+
   // Actions
   toggleSidebar: () => void;
   setSidebarOpen: (open: boolean) => void;
@@ -611,6 +615,7 @@ export interface UIState {
   setTextStrokeWidth: (v: number) => void;
   setTextStrokeColor: (v: string) => void;
   setCenterCompact: (v: boolean) => void;
+  setRightPanelResizing: (v: boolean) => void;
   setVisualTheme: (v: VisualTheme) => void;
   setConvoGradientField: (scheme: "dark" | "light", field: "from" | "to", value: string) => void;
   setConvoNotificationSound: (v: boolean) => void;


### PR DESCRIPTION
## Why this change

The connections right panel was the only right-side panel that lagged and squished while dragging the panel resizer. Two independent causes, both unique to it:

1. **`transition-all` on inner cards.** The `ConnectionRow` and `TTSConfigCard` root divs used `transition-all`, which animates `width`. Every connection card therefore ran a width transition on every resize frame.
2. **framer-motion `Reorder` layout animation.** `ConnectionsPanel` is the only right-side panel using `Reorder`. Each `Reorder.Item` defaults to `layout=true` and runs a layout-projection measure/animate on every width change, producing the squish/squash.

The AppShell `<aside>` already disables `transition-[width]` during drag, so the container was fine; the jank was entirely these two inner sources.

## What changed

- `ConnectionsPanel.tsx` / `TTSConfigCard.tsx`: swap the two `transition-all` root classes to `transition-colors`. The only animated effect on either element is a hover/expand color change, so behavior is preserved while the per-frame width animation is gone.
- `ui/model.ts` + `ui.store.ts`: add a transient `rightPanelResizing` flag and setter, beside the existing transient `centerCompact`. Intentionally **not** added to `partializeUiState`, so it is never persisted.
- `AppShell.tsx`: set the flag on right-panel drag start and clear it in the shared `finishResize` teardown (covering mouseup and the window-blur path).
- `ConnectionsPanel.tsx` (folder rows): read the flag and pass `layout=false` to `Reorder.Item` while resizing, suppressing the per-item layout projection. `layout` is omitted from `ReorderItemProps`'s public type even though the runtime forwards it, so it goes through a loosely-typed spread (commented). Drag-to-reorder is unchanged because the reorder measurement is independent of the layout flag.

## Verification

- `pnpm exec tsc -b` clean (validates the new store field and the typed-omit spread).
- New `ui.store.test.ts` cases pass: flag defaults to `false`, toggles via its setter, and is absent from `partializeUiState` (never persisted).
- Playwright boot repro: the app mounts with the new wiring and a `transition-colors` element does not animate `all`; no error from the new symbols.

## Manual

The perceived smoothness (framer-motion layout suppression) and drag-to-reorder-after-resize are visual/interaction behaviors not capturable by an assertion; verified by driving the connections panel in the browser tier. Worth a quick look on a real display.

## Risk

`layout={false}` is passed via a loosely-typed spread because framer-motion 12 omits `layout` from `ReorderItemProps` while still forwarding it at runtime; a future framer-motion major could change that forwarding (noted in a code comment). Mobile is unaffected (the resize gesture returns early on mobile, so the flag never sets).

## Linked issue

Closes #1586.