### PR TITLE
Preflight upload sizes before reading whole files into memory

### DIFF
--- a/src/engine/contracts/constants/defaults.ts
+++ b/src/engine/contracts/constants/defaults.ts
@@ -42,6 +42,7 @@ export const MAX_FILE_SIZES = {
   LOREBOOK_JSON: 10 * 1024 * 1024, // 10 MB
   PRESET_JSON: 2 * 1024 * 1024, // 2 MB
   CHAT_JSONL: 50 * 1024 * 1024, // 50 MB
+  GAME_ASSET: 50 * 1024 * 1024, // 50 MB (matches the Settings game-asset upload gate; under the 75 MB Rust server ceiling)
 } as const;
 
 /** Limits for various entities. */

--- a/src/features/modes/game/components/GameInput.tsx
+++ b/src/features/modes/game/components/GameInput.tsx
@@ -9,6 +9,7 @@ import { SpeechToTextButton } from "../../../../shared/components/ui/SpeechToTex
 import { useUIStore } from "../../../../shared/stores/ui.store";
 import { useChatStore } from "../../../../shared/stores/chat.store";
 import { translateDraftText } from "../../../../shared/lib/draft-translation";
+import { MAX_FILE_SIZES } from "../../../../engine/contracts/constants/defaults";
 import type { DiceRollResult } from "../../../../engine/contracts/types/game";
 import {
   CHAT_INPUT_ICON_BUTTON_ACTIVE_CLASS,
@@ -257,7 +258,8 @@ export function GameInput({
     const files = e.target.files;
     if (!files?.length) return;
     for (const file of Array.from(files)) {
-      if (file.size > 20 * 1024 * 1024) continue;
+      // Skip oversized files before reading them into a data URL.
+      if (file.size > MAX_FILE_SIZES.IMAGE_UPLOAD) continue;
       const reader = new FileReader();
       reader.onload = () => {
         setAttachments((prev) => [...prev, { type: file.type, data: reader.result as string, name: file.name }]);

--- a/src/shared/api/assets-api.ts
+++ b/src/shared/api/assets-api.ts
@@ -1,4 +1,5 @@
-import { fileToUploadPayload } from "./file-payload";
+import { fileToUploadPayload, GAME_ASSET_SIZE_ERROR } from "./file-payload";
+import { MAX_FILE_SIZES } from "../../engine/contracts/constants/defaults";
 import { invokeTauri } from "./tauri-client";
 
 interface GameAssetFileInfo {
@@ -29,7 +30,10 @@ async function uploadGameAsset({
     body: {
       category,
       subcategory: subcategory ?? "",
-      file: await fileToUploadPayload(file),
+      file: await fileToUploadPayload(file, {
+        maxBytes: MAX_FILE_SIZES.GAME_ASSET,
+        tooLargeMessage: GAME_ASSET_SIZE_ERROR,
+      }),
     },
   });
 }

--- a/src/shared/api/file-payload.test.ts
+++ b/src/shared/api/file-payload.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "vitest";
 
 import { MAX_FILE_SIZES } from "../../engine/contracts/constants/defaults";
-import { fileToUploadPayload, IMAGE_UPLOAD_SIZE_ERROR, MAX_IMAGE_UPLOAD_BYTES } from "./file-payload";
+import {
+  fileToUploadPayload,
+  formDataToJson,
+  IMAGE_UPLOAD_SIZE_ERROR,
+  MAX_IMAGE_UPLOAD_BYTES,
+} from "./file-payload";
 
 function fakeFile(size: number, bytes = [0x89, 0x50, 0x4e, 0x47]) {
   let arrayBufferCalls = 0;
@@ -57,5 +62,65 @@ describe("fileToUploadPayload", () => {
       base64: "iVBORw==",
     });
     expect(upload.arrayBufferCalls()).toBe(1);
+  });
+});
+
+// formDataToJson checks `value instanceof File`, so it needs a real File. Build
+// one with a spied arrayBuffer and an overridden size, then feed it through a
+// minimal `entries()`-bearing stand-in so FormData never clones away the spy.
+function fakeFormBody(size: number, extraFields: Record<string, string> = {}) {
+  let arrayBufferCalls = 0;
+  const file = new File([new Uint8Array([0x89, 0x50, 0x4e, 0x47])], "upload.png", {
+    type: "image/png",
+  });
+  Object.defineProperty(file, "size", { value: size, configurable: true });
+  Object.defineProperty(file, "arrayBuffer", {
+    configurable: true,
+    value: async () => {
+      arrayBufferCalls += 1;
+      return new Uint8Array([0x89, 0x50, 0x4e, 0x47]).buffer;
+    },
+  });
+  const entries: Array<[string, FormDataEntryValue]> = [
+    ["file", file],
+    ...Object.entries(extraFields),
+  ];
+  const body = { entries: () => entries[Symbol.iterator]() } as unknown as FormData;
+  return { body, arrayBufferCalls: () => arrayBufferCalls };
+}
+
+describe("formDataToJson", () => {
+  it("rejects an oversized File entry before reading its bytes", async () => {
+    const form = fakeFormBody(MAX_IMAGE_UPLOAD_BYTES + 1, { chatId: "chat-1" });
+
+    await expect(
+      formDataToJson(form.body, {
+        maxBytes: MAX_IMAGE_UPLOAD_BYTES,
+        tooLargeMessage: IMAGE_UPLOAD_SIZE_ERROR,
+      }),
+    ).rejects.toThrow(IMAGE_UPLOAD_SIZE_ERROR);
+    expect(form.arrayBufferCalls()).toBe(0);
+  });
+
+  it("encodes a File within the limit and preserves string fields", async () => {
+    const form = fakeFormBody(4, { chatId: "chat-1" });
+
+    const result = await formDataToJson(form.body, {
+      maxBytes: MAX_IMAGE_UPLOAD_BYTES,
+      tooLargeMessage: IMAGE_UPLOAD_SIZE_ERROR,
+    });
+
+    expect(result.chatId).toBe("chat-1");
+    expect(result.file).toMatchObject({ name: "upload.png", size: 4, base64: "iVBORw==" });
+    expect(form.arrayBufferCalls()).toBe(1);
+  });
+
+  it("still reads files when no size limit is supplied (back-compat)", async () => {
+    const form = fakeFormBody(MAX_IMAGE_UPLOAD_BYTES + 1);
+
+    await expect(formDataToJson(form.body)).resolves.toMatchObject({
+      file: { name: "upload.png" },
+    });
+    expect(form.arrayBufferCalls()).toBe(1);
   });
 });

--- a/src/shared/api/file-payload.test.ts
+++ b/src/shared/api/file-payload.test.ts
@@ -1,12 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { MAX_FILE_SIZES } from "../../engine/contracts/constants/defaults";
-import {
-  fileToUploadPayload,
-  formDataToJson,
-  IMAGE_UPLOAD_SIZE_ERROR,
-  MAX_IMAGE_UPLOAD_BYTES,
-} from "./file-payload";
+import { fileToUploadPayload, formDataToJson, IMAGE_UPLOAD_SIZE_ERROR, MAX_IMAGE_UPLOAD_BYTES } from "./file-payload";
 
 function fakeFile(size: number, bytes = [0x89, 0x50, 0x4e, 0x47]) {
   let arrayBufferCalls = 0;
@@ -81,10 +76,7 @@ function fakeFormBody(size: number, extraFields: Record<string, string> = {}) {
       return new Uint8Array([0x89, 0x50, 0x4e, 0x47]).buffer;
     },
   });
-  const entries: Array<[string, FormDataEntryValue]> = [
-    ["file", file],
-    ...Object.entries(extraFields),
-  ];
+  const entries: Array<[string, FormDataEntryValue]> = [["file", file], ...Object.entries(extraFields)];
   const body = { entries: () => entries[Symbol.iterator]() } as unknown as FormData;
   return { body, arrayBufferCalls: () => arrayBufferCalls };
 }

--- a/src/shared/api/file-payload.ts
+++ b/src/shared/api/file-payload.ts
@@ -15,7 +15,10 @@ function formatUploadSize(bytes: number) {
 export const MAX_IMAGE_UPLOAD_BYTES = MAX_FILE_SIZES.IMAGE_UPLOAD;
 export const IMAGE_UPLOAD_SIZE_ERROR = `Image uploads must be ${formatUploadSize(MAX_IMAGE_UPLOAD_BYTES)} or smaller`;
 
-interface FilePayloadOptions {
+export const CHAT_IMPORT_SIZE_ERROR = `Chat imports must be ${formatUploadSize(MAX_FILE_SIZES.CHAT_JSONL)} or smaller`;
+export const GAME_ASSET_SIZE_ERROR = `Game assets must be ${formatUploadSize(MAX_FILE_SIZES.GAME_ASSET)} or smaller`;
+
+export interface FilePayloadOptions {
   maxBytes?: number;
   tooLargeMessage?: string;
 }
@@ -37,7 +40,10 @@ export async function fileToUploadPayload(file: File, options: FilePayloadOption
   };
 }
 
-export async function formDataToJson(body: FormData): Promise<Record<string, unknown>> {
+export async function formDataToJson(
+  body: FormData,
+  options: FilePayloadOptions = {},
+): Promise<Record<string, unknown>> {
   const entries: Record<string, unknown> = {};
   const appendEntry = (key: string, value: unknown) => {
     const existing = entries[key];
@@ -50,7 +56,9 @@ export async function formDataToJson(body: FormData): Promise<Record<string, unk
     }
   };
   for (const [key, value] of body.entries()) {
-    appendEntry(key, value instanceof File ? await fileToUploadPayload(value) : value);
+    // Pass the caller's size limit down so a File entry is rejected before its
+    // bytes are read into memory, rather than after.
+    appendEntry(key, value instanceof File ? await fileToUploadPayload(value, options) : value);
   }
   return entries;
 }

--- a/src/shared/api/import-api.ts
+++ b/src/shared/api/import-api.ts
@@ -1,4 +1,5 @@
-import { formDataToJson } from "./file-payload";
+import { formDataToJson, CHAT_IMPORT_SIZE_ERROR, type FilePayloadOptions } from "./file-payload";
+import { MAX_FILE_SIZES } from "../../engine/contracts/constants/defaults";
 import { Channel } from "@tauri-apps/api/core";
 import { invokeTauri } from "./tauri-client";
 import { remoteRuntimeTarget } from "./remote-runtime";
@@ -8,7 +9,15 @@ export interface ImportFilePayload {
   fields?: Record<string, string | number | boolean | null | undefined>;
 }
 
-async function filePayload(payload: ImportFilePayload | File): Promise<Record<string, unknown>> {
+const CHAT_IMPORT_LIMIT: FilePayloadOptions = {
+  maxBytes: MAX_FILE_SIZES.CHAT_JSONL,
+  tooLargeMessage: CHAT_IMPORT_SIZE_ERROR,
+};
+
+async function filePayload(
+  payload: ImportFilePayload | File,
+  options?: FilePayloadOptions,
+): Promise<Record<string, unknown>> {
   const file = payload instanceof File ? payload : payload.file;
   const fields = payload instanceof File ? undefined : payload.fields;
   const formData = new FormData();
@@ -16,14 +25,17 @@ async function filePayload(payload: ImportFilePayload | File): Promise<Record<st
     if (value !== null && value !== undefined) formData.append(key, String(value));
   }
   formData.append("file", file, file.name);
-  return formDataToJson(formData);
+  return formDataToJson(formData, options);
 }
 
-async function filesPayload(payload: File[] | FormData): Promise<Record<string, unknown>> {
-  if (payload instanceof FormData) return formDataToJson(payload);
+async function filesPayload(
+  payload: File[] | FormData,
+  options?: FilePayloadOptions,
+): Promise<Record<string, unknown>> {
+  if (payload instanceof FormData) return formDataToJson(payload, options);
   const form = new FormData();
   payload.forEach((file) => form.append("files", file, file.name));
-  return formDataToJson(form);
+  return formDataToJson(form, options);
 }
 
 export const importApi = {
@@ -40,10 +52,11 @@ export const importApi = {
   },
   stCharacterInspect: async <T>(payload: File[] | FormData) =>
     invokeTauri<T>("import_st_character_inspect", { body: await filesPayload(payload) }),
-  stChat: async <T>(file: File) => invokeTauri<T>("import_st_chat", { body: await filePayload(file) }),
+  stChat: async <T>(file: File) =>
+    invokeTauri<T>("import_st_chat", { body: await filePayload(file, CHAT_IMPORT_LIMIT) }),
   stChatIntoGroup: async <T>(chatId: string, file: File) =>
     invokeTauri<T>("import_st_chat_into_group", {
-      body: await filePayload({ file, fields: { chatId } }),
+      body: await filePayload({ file, fields: { chatId } }, CHAT_IMPORT_LIMIT),
     }),
   stPreset: <T>(payload: unknown) => invokeTauri<T>("import_st_preset", { payload }),
   stLorebook: <T>(payload: unknown) => invokeTauri<T>("import_st_lorebook", { payload }),


### PR DESCRIPTION
## Why this change

`fileToUploadPayload` already short-circuits oversized files before `file.arrayBuffer()` when given a `maxBytes`, but several callers invoked it (or `FileReader`) with no limit, so the entire file was read and base64-encoded before any size check ran:

- `formDataToJson` is the funnel for every import-api file path but passed no limit, so chat imports read the whole file first.
- `uploadGameAsset` read the whole asset before sending; the API layer never enforced a limit (only one of its two callers, the Settings panel, had an inline UI check).
- `GameInput.handleFileUpload` carried an inline `20 * 1024 * 1024` magic number before `FileReader.readAsDataURL`.

## What changed

- `file-payload.ts`: `formDataToJson` gains an optional `FilePayloadOptions` (`maxBytes`/`tooLargeMessage`) and threads it to `fileToUploadPayload`, so a File entry is rejected before its bytes are read. Exported `FilePayloadOptions` + two message constants.
- `import-api.ts`: `filePayload`/`filesPayload` accept and forward the options; the chat import paths (`stChat`, `stChatIntoGroup`) pass the `CHAT_JSONL` (50 MB) limit.
- `assets-api.ts`: `uploadGameAsset` preflights against a new `MAX_FILE_SIZES.GAME_ASSET` (50 MB), matching the existing Settings upload gate and staying under the 75 MB Rust `MAX_MEDIA_ASSET_BYTES` server ceiling.
- `GameInput.tsx`: replace the inline 20 MB magic number with `MAX_FILE_SIZES.IMAGE_UPLOAD` (same value, now named).

## Verification

- `pnpm exec tsc -b` clean.
- New `file-payload.test.ts` cases prove `formDataToJson` rejects an oversized File before `arrayBuffer` is called, encodes a within-limit file while preserving string fields, and stays backward-compatible with no limit.
- Full `src/shared/api` suite (92 tests) green.

The end-user upload triggers (game-asset upload, ST chat import) run through the native file picker, which the automated tiers don't drive; the size-preflight behavior they depend on is covered by the unit tests against `formDataToJson`/`fileToUploadPayload`.

## Follow-ups (deferred, not blocking this PR)

The two remaining named import paths are intentionally left uncapped here because choosing a safe whole-file limit needs a maintainer decision, and a wrong value would reject valid imports:

- **`stCharacterFile` / `stCharacterBatch` / `stCharacterInspect`** accept PNG character cards as well as JSON. The declared `CHARACTER_JSON` limit (5 MB) is too small for PNG cards, and the Rust `import_st_character` path enforces no whole-file cap, so applying 5 MB would reject valid cards.
- **`marinaraFile`** uploads a `.marinara` ZIP. The Rust side caps `data.json` at 5 MB and the avatar at 20 MB *per entry after unzip*; the whole-package size has no server cap, so a tight whole-file limit would reject valid packages.

The mechanism to cap them (`formDataToJson` `maxBytes`) is now in place, so the follow-up is a one-line change per caller once the intended limits are chosen.

## Linked issue

Closes #1538.