### PR TITLE
Surface invalid combat action responses instead of advancing combat

### DIFF
--- a/src/engine/contracts/types/combat-encounter.ts
+++ b/src/engine/contracts/types/combat-encounter.ts
@@ -223,6 +223,12 @@ export interface EncounterActionRequest {
 /** Response from encounter action resolution. */
 export interface EncounterActionResponse {
   result: CombatActionResult;
+  /**
+   * True when the model output could not be parsed into a usable combat turn.
+   * The caller must surface a retryable error and leave combat state unchanged
+   * instead of treating `result` as a real turn.
+   */
+  invalid?: boolean;
 }
 
 /** Payload for summarizing an encounter. */

--- a/src/engine/modes/roleplay/encounter/encounter-service.test.ts
+++ b/src/engine/modes/roleplay/encounter/encounter-service.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import type { LlmGateway } from "../../../capabilities/llm";
+import type { StorageGateway } from "../../../capabilities/storage";
+import type { EncounterActionRequest } from "../../../contracts/types/combat-encounter";
+import { resolveRoleplayEncounterAction } from "./encounter-service";
+
+type JsonRecord = Record<string, unknown>;
+
+const CHAT: JsonRecord = {
+  id: "chat-1",
+  name: "Encounter",
+  mode: "roleplay",
+  personaId: null,
+  characterIds: [],
+  connectionId: "conn-1",
+  metadata: {},
+};
+
+/** Minimal storage that resolves the chat + a default connection and returns
+ *  empty collections for everything else, so the action path runs end to end. */
+function fakeStorage(): StorageGateway {
+  return {
+    list: async <T,>() => [] as T[],
+    get: async <T,>(entity: string, id: string) => {
+      if (entity === "chats" && id === "chat-1") return CHAT as T;
+      if (entity === "connections" && id === "conn-1") return { id: "conn-1", name: "Test" } as T;
+      return null as T | null;
+    },
+    create: async <T,>() => ({}) as T,
+    update: async <T,>() => ({}) as T,
+    delete: async () => ({ deleted: true }),
+    listChatMessages: async () => [],
+    createChatMessage: async <T,>() => ({}) as T,
+    updateChatMessage: async <T,>() => ({}) as T,
+    deleteChatMessage: async () => ({ deleted: true }),
+    patchChatMessageExtra: async <T,>() => ({}) as T,
+    addChatMessageSwipe: async <T,>() => ({}) as T,
+    patchChatMetadata: async <T,>() => ({}) as T,
+    patchChatSummaries: async <T,>() => ({}) as T,
+    listChatMemories: async () => [],
+    getWorldState: async <T,>() => null as T | null,
+    saveTrackerSnapshot: async <T,>() => ({}) as T,
+    listLorebookEntries: async () => [],
+    createLorebookEntries: async () => [],
+    promptFull: async <T,>() => null as T | null,
+  };
+}
+
+/** LlmGateway whose `complete` is fully controllable (resolve text or reject). */
+function fakeLlm(complete: () => Promise<string>): LlmGateway {
+  return {
+    complete,
+    // eslint-disable-next-line require-yield
+    stream: async function* () {
+      throw new Error("stream is not used in these tests");
+    },
+    listModels: async () => [],
+  };
+}
+
+const NARRATIVE = { tense: "present", person: "second", narration: "limited", pov: "" } as const;
+
+function actionRequest(): EncounterActionRequest {
+  return {
+    chatId: "chat-1",
+    connectionId: null,
+    action: "I swing my sword at the dummy.",
+    combatStats: {
+      party: [
+        { name: "Hero", hp: 20, maxHp: 24, attacks: [], items: [], statuses: [], isPlayer: true },
+      ],
+      enemies: [
+        { name: "Dummy", hp: 18, maxHp: 18, attacks: [], statuses: [], description: "", sprite: "" },
+      ],
+      environment: "a training hall",
+    },
+    playerActions: { attacks: [], items: [] },
+    encounterLog: [],
+    settings: { combatNarrative: NARRATIVE, summaryNarrative: NARRATIVE, historyDepth: 0 },
+    spellbookId: null,
+  };
+}
+
+describe("resolveRoleplayEncounterAction invalid-response handling (issue #1520)", () => {
+  it("flags invalid (and does not invent a turn) when the model output is not JSON", async () => {
+    const storage = fakeStorage();
+    const llm = fakeLlm(async () => "A13_MALFORMED_NON_JSON_RESPONSE");
+
+    const res = await resolveRoleplayEncounterAction({ storage, llm }, actionRequest());
+
+    // Caller must treat this as a retryable failure and leave combat unchanged;
+    // res.result is only a placeholder fallback and must not be applied.
+    expect(res.invalid).toBe(true);
+  });
+
+  it("flags invalid when the LLM call itself fails", async () => {
+    const storage = fakeStorage();
+    const llm = fakeLlm(async () => {
+      throw new Error("provider timeout");
+    });
+
+    const res = await resolveRoleplayEncounterAction({ storage, llm }, actionRequest());
+
+    expect(res.invalid).toBe(true);
+  });
+
+  it("resolves a real turn (not invalid) for a valid JSON action response", async () => {
+    const storage = fakeStorage();
+    const llm = fakeLlm(async () =>
+      JSON.stringify({
+        combatStats: {
+          party: [{ name: "Hero", hp: 20, maxHp: 24, isPlayer: true }],
+          enemies: [{ name: "Dummy", hp: 0, maxHp: 18 }],
+        },
+        narrative: "The dummy splinters.",
+        combatEnd: true,
+        result: "victory",
+      }),
+    );
+
+    const res = await resolveRoleplayEncounterAction({ storage, llm }, actionRequest());
+
+    expect(res.invalid).toBeFalsy();
+    expect(res.result.result).toBe("victory");
+    expect(res.result.narrative).toContain("dummy");
+  });
+
+  it("does not flag a present-but-partial JSON response (it is still a real turn)", async () => {
+    const storage = fakeStorage();
+    const llm = fakeLlm(async () => JSON.stringify({ narrative: "Something happened." }));
+
+    const res = await resolveRoleplayEncounterAction({ storage, llm }, actionRequest());
+
+    // A real record missing `result`/`combatStats` is sanitized from input,
+    // NOT treated as invalid — only a null parse (unparseable / LLM error) is.
+    expect(res.invalid).toBeFalsy();
+    expect(res.result).toBeDefined();
+  });
+});

--- a/src/engine/modes/roleplay/encounter/encounter-service.test.ts
+++ b/src/engine/modes/roleplay/encounter/encounter-service.test.ts
@@ -20,29 +20,29 @@ const CHAT: JsonRecord = {
  *  empty collections for everything else, so the action path runs end to end. */
 function fakeStorage(): StorageGateway {
   return {
-    list: async <T,>() => [] as T[],
-    get: async <T,>(entity: string, id: string) => {
+    list: async <T>() => [] as T[],
+    get: async <T>(entity: string, id: string) => {
       if (entity === "chats" && id === "chat-1") return CHAT as T;
       if (entity === "connections" && id === "conn-1") return { id: "conn-1", name: "Test" } as T;
       return null as T | null;
     },
-    create: async <T,>() => ({}) as T,
-    update: async <T,>() => ({}) as T,
+    create: async <T>() => ({}) as T,
+    update: async <T>() => ({}) as T,
     delete: async () => ({ deleted: true }),
     listChatMessages: async () => [],
-    createChatMessage: async <T,>() => ({}) as T,
-    updateChatMessage: async <T,>() => ({}) as T,
+    createChatMessage: async <T>() => ({}) as T,
+    updateChatMessage: async <T>() => ({}) as T,
     deleteChatMessage: async () => ({ deleted: true }),
-    patchChatMessageExtra: async <T,>() => ({}) as T,
-    addChatMessageSwipe: async <T,>() => ({}) as T,
-    patchChatMetadata: async <T,>() => ({}) as T,
-    patchChatSummaries: async <T,>() => ({}) as T,
+    patchChatMessageExtra: async <T>() => ({}) as T,
+    addChatMessageSwipe: async <T>() => ({}) as T,
+    patchChatMetadata: async <T>() => ({}) as T,
+    patchChatSummaries: async <T>() => ({}) as T,
     listChatMemories: async () => [],
-    getWorldState: async <T,>() => null as T | null,
-    saveTrackerSnapshot: async <T,>() => ({}) as T,
+    getWorldState: async <T>() => null as T | null,
+    saveTrackerSnapshot: async <T>() => ({}) as T,
     listLorebookEntries: async () => [],
     createLorebookEntries: async () => [],
-    promptFull: async <T,>() => null as T | null,
+    promptFull: async <T>() => null as T | null,
   };
 }
 
@@ -66,12 +66,8 @@ function actionRequest(): EncounterActionRequest {
     connectionId: null,
     action: "I swing my sword at the dummy.",
     combatStats: {
-      party: [
-        { name: "Hero", hp: 20, maxHp: 24, attacks: [], items: [], statuses: [], isPlayer: true },
-      ],
-      enemies: [
-        { name: "Dummy", hp: 18, maxHp: 18, attacks: [], statuses: [], description: "", sprite: "" },
-      ],
+      party: [{ name: "Hero", hp: 20, maxHp: 24, attacks: [], items: [], statuses: [], isPlayer: true }],
+      enemies: [{ name: "Dummy", hp: 18, maxHp: 18, attacks: [], statuses: [], description: "", sprite: "" }],
       environment: "a training hall",
     },
     playerActions: { attacks: [], items: [] },

--- a/src/engine/modes/roleplay/encounter/encounter-service.ts
+++ b/src/engine/modes/roleplay/encounter/encounter-service.ts
@@ -96,6 +96,15 @@ export async function resolveRoleplayEncounterAction(
     temperature: 0.8,
     maxTokens: ACTION_OUTPUT_TOKENS,
   });
+  // completeJsonObject returns null only when the model output was unparseable
+  // or the LLM call failed. In that case there is no real turn: synthesizing a
+  // deterministic fallback would silently advance combat (and can reach
+  // victory + summary writeback). Surface a recoverable invalid signal instead
+  // and leave combat state untouched. A present-but-partial response is still a
+  // real turn and continues through sanitizeCombatActionResult below.
+  if (parsed === null) {
+    return { result: fallback, invalid: true };
+  }
   const rawResult = recordValue(parsed?.result) ?? parsed;
   const result = sanitizeCombatActionResult(rawResult, input, fallback);
 

--- a/src/features/modes/roleplay/encounter/hooks/use-encounter.ts
+++ b/src/features/modes/roleplay/encounter/hooks/use-encounter.ts
@@ -155,6 +155,14 @@ export function useEncounter() {
           },
         );
 
+        // Model produced no usable combat turn (unparseable output or LLM
+        // error) — surface a retryable error and keep combat state unchanged.
+        if (res.invalid) {
+          store.setError("AI returned an invalid response. Try again.");
+          store.setProcessing(false);
+          return;
+        }
+
         const r = res.result;
 
         // Validate critical fields — AI may return malformed data


### PR DESCRIPTION
## Why this change

A malformed / non-JSON combat action response was silently treated as a successful turn. `completeJsonObject` returns `null` on unparseable output or an LLM error, but `resolveRoleplayEncounterAction` then ran `recordValue(parsed?.result) ?? parsed` (which is `null`) through `sanitizeCombatActionResult`, which rebuilds a fully valid-looking `CombatActionResult` from the deterministic fallback. The caller had no way to tell "sanitized a garbage response" from "a real turn", so it advanced party/enemy HP and the log, and could even reach victory + a summary writeback to the chat from a malformed reply.

## What changed

- `combat-encounter.ts`: add an optional `invalid?: boolean` to `EncounterActionResponse` (documented: the caller must surface a retryable error and leave combat unchanged).
- `encounter-service.ts`: when `completeJsonObject` returns `null`, return `{ result: fallback, invalid: true }` before the sanitize path runs. The fallback is returned only to satisfy the required `result` field; the caller must not apply it.
- `use-encounter.ts`: check `res.invalid` first and reuse the existing recoverable error path (`setError("AI returned an invalid response. Try again.")` + clear processing + early return), which runs before any `updateCombat`/`endCombat`/`generateSummary`, so combat state and the chat are untouched and the retry controls stay mounted. No new UI.

A present-but-partial response (a real record missing `result`/`combatStats`) is still a real turn and continues through the sanitizer unchanged, and the genuine empty-input `interrupted` branch stays reachable, because only a `null` parse flags invalid.

## Verification

- `pnpm exec tsc -b` clean; `pnpm check:architecture` clean (no new cross-layer import).
- New engine tests (`encounter-service.test.ts`) cover: malformed non-JSON output flags invalid, an LLM error flags invalid, a valid JSON turn resolves normally (not invalid), and a present-but-partial response is not flagged invalid.

## Risk / note

This also routes a transient LLM-call failure (timeout, 5xx) into the same retryable error instead of the previous silent fallback turn. That is the intended, more-correct behavior, but it does broaden the trigger beyond pure malformed JSON, so it is called out here. The hook + inline error rendering are covered by code reading; the engine root cause is covered by the unit tests.

## Linked issue

Closes #1520.