### PR TITLE
Surface game journal load and save failures with retry

### DIFF
--- a/src/features/modes/game/components/GameJournal.test.tsx
+++ b/src/features/modes/game/components/GameJournal.test.tsx
@@ -1,0 +1,175 @@
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GameJournal } from "./GameJournal";
+import { gameApi } from "../api/game-api";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+// ──────────────────────────────────────────────
+// Seam under test: GameJournal must turn a rejected getJournal/updateNotes
+// into a retryable error surface instead of a stuck "Loading..."/"Saving..."
+// spinner. Mock the feature api + the heavy chats-index barrel + render-only
+// helpers so the component mounts in jsdom.
+// ──────────────────────────────────────────────
+vi.mock("../api/game-api", () => ({
+  gameApi: {
+    getJournal: vi.fn(),
+    updateNotes: vi.fn(),
+  },
+}));
+
+vi.mock("../../../catalog/chats/index", () => ({
+  chatKeys: { detail: (id: string) => ["chats", id] },
+}));
+
+vi.mock("../../../../shared/lib/markdown", () => ({
+  applyInlineMarkdown: (text: string) => text,
+  renderMarkdownBlocks: (text: string) => text,
+}));
+
+vi.mock("./AnimatedText", () => ({
+  AnimatedText: ({ text }: { text: string }) => text,
+}));
+
+vi.mock("../../../../shared/stores/chat.store", () => ({
+  useChatStore: Object.assign(() => null, {
+    getState: () => ({ activeChatId: null, setActiveChat: vi.fn() }),
+  }),
+}));
+
+const getJournalMock = vi.mocked(gameApi.getJournal);
+const updateNotesMock = vi.mocked(gameApi.updateNotes);
+
+const VALID_JOURNAL = {
+  journal: { entries: [], quests: [], locations: [], npcLog: [], inventoryLog: [] },
+  playerNotes: "remember the locked door",
+};
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe("GameJournal load/save failure UI (issue #1536)", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    queryClient.clear();
+    vi.clearAllMocks();
+  });
+
+  function render() {
+    return act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <GameJournal chatId="chat-1" onClose={vi.fn()} />
+        </QueryClientProvider>,
+      );
+    });
+  }
+
+  function retryButton() {
+    return Array.from(container.querySelectorAll("button")).find((b) => b.textContent?.includes("Retry"));
+  }
+
+  it("renders a retryable error panel (not a stuck spinner) when getJournal fails", async () => {
+    getJournalMock.mockRejectedValue(new Error("journal blew up"));
+
+    await render();
+    await flush();
+
+    expect(container.textContent).toContain("Couldn't load the journal.");
+    expect(container.textContent).toContain("journal blew up");
+    expect(container.textContent).not.toContain("Loading journal...");
+    expect(retryButton()).toBeTruthy();
+  });
+
+  it("retries the load and shows the journal when getJournal succeeds on retry", async () => {
+    getJournalMock.mockRejectedValueOnce(new Error("journal blew up")).mockResolvedValueOnce(VALID_JOURNAL as never);
+
+    await render();
+    await flush();
+    expect(retryButton()).toBeTruthy();
+
+    await act(async () => {
+      retryButton()!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flush();
+
+    expect(getJournalMock).toHaveBeenCalledTimes(2);
+    expect(container.textContent).not.toContain("Couldn't load the journal.");
+    // Journal panel chrome rendered.
+    expect(container.textContent).toContain("Adventure Journal");
+  });
+
+  it("surfaces a save failure with retry instead of a stuck 'Saving...'", async () => {
+    vi.useFakeTimers();
+    try {
+      getJournalMock.mockResolvedValue(VALID_JOURNAL as never);
+      updateNotesMock.mockRejectedValue(new Error("save blew up"));
+
+      await act(async () => {
+        root.render(
+          <QueryClientProvider client={queryClient}>
+            <GameJournal chatId="chat-1" onClose={vi.fn()} />
+          </QueryClientProvider>,
+        );
+      });
+      // Flush the resolved getJournal microtasks under fake timers.
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      // Switch to the Notes tab.
+      const notesTab = Array.from(container.querySelectorAll("button")).find((b) =>
+        b.textContent?.includes("Notes"),
+      );
+      await act(async () => {
+        notesTab!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+
+      // Type into the notes textarea, then let the 800ms debounce fire.
+      const textarea = container.querySelector("textarea");
+      expect(textarea).toBeTruthy();
+      // Use the native value setter so React's controlled-input value tracker
+      // registers the change and fires onChange.
+      const nativeValueSetter = Object.getOwnPropertyDescriptor(
+        HTMLTextAreaElement.prototype,
+        "value",
+      )!.set!;
+      await act(async () => {
+        nativeValueSetter.call(textarea, "a new clue");
+        textarea!.dispatchEvent(new Event("input", { bubbles: true }));
+      });
+      await act(async () => {
+        vi.advanceTimersByTime(800);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(container.textContent).toContain("Save failed");
+      expect(container.textContent).not.toContain("Saving...");
+      expect(retryButton()).toBeTruthy();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/features/modes/game/components/GameJournal.test.tsx
+++ b/src/features/modes/game/components/GameJournal.test.tsx
@@ -139,9 +139,7 @@ describe("GameJournal load/save failure UI (issue #1536)", () => {
       });
 
       // Switch to the Notes tab.
-      const notesTab = Array.from(container.querySelectorAll("button")).find((b) =>
-        b.textContent?.includes("Notes"),
-      );
+      const notesTab = Array.from(container.querySelectorAll("button")).find((b) => b.textContent?.includes("Notes"));
       await act(async () => {
         notesTab!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
       });
@@ -151,10 +149,7 @@ describe("GameJournal load/save failure UI (issue #1536)", () => {
       expect(textarea).toBeTruthy();
       // Use the native value setter so React's controlled-input value tracker
       // registers the change and fires onChange.
-      const nativeValueSetter = Object.getOwnPropertyDescriptor(
-        HTMLTextAreaElement.prototype,
-        "value",
-      )!.set!;
+      const nativeValueSetter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value")!.set!;
       await act(async () => {
         nativeValueSetter.call(textarea, "a new clue");
         textarea!.dispatchEvent(new Event("input", { bubbles: true }));
@@ -168,6 +163,19 @@ describe("GameJournal load/save failure UI (issue #1536)", () => {
       expect(container.textContent).toContain("Save failed");
       expect(container.textContent).not.toContain("Saving...");
       expect(retryButton()).toBeTruthy();
+
+      // Retry: the next save succeeds, so the failure clears back to "Saved".
+      updateNotesMock.mockResolvedValueOnce({
+        sessionChat: { id: "chat-1" },
+      } as never);
+      await act(async () => {
+        retryButton()!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(updateNotesMock).toHaveBeenCalledTimes(2);
+      expect(container.textContent).not.toContain("Save failed");
+      expect(container.textContent).toContain("Saved");
     } finally {
       vi.useRealTimers();
     }

--- a/src/features/modes/game/components/GameJournal.tsx
+++ b/src/features/modes/game/components/GameJournal.tsx
@@ -191,7 +191,12 @@ export function GameJournal({
       .getJournal(chatId)
       .then((res) => {
         setJournal(res.journal as Journal);
-        if (res.playerNotes) setPlayerNotes(res.playerNotes);
+        if (res.playerNotes) {
+          setPlayerNotes(res.playerNotes);
+          // Keep the retry-save ref a faithful mirror of the persisted notes
+          // from first load, not just whatever the user last typed.
+          latestNotesRef.current = res.playerNotes;
+        }
       })
       .catch((err) => {
         setLoadError(err instanceof Error ? err.message : "Failed to load journal");
@@ -227,6 +232,10 @@ export function GameJournal({
       setPlayerNotes(text);
       latestNotesRef.current = text;
       setNotesSaved(false);
+      // Clear a stale failure as soon as the user edits, so the pill returns to
+      // "Saving..." for the fresh, not-yet-attempted content instead of lingering
+      // on the red "Save failed" for the full debounce window.
+      setSaveError(null);
       if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
       saveTimerRef.current = setTimeout(() => saveNotes(text), 800);
     },

--- a/src/features/modes/game/components/GameJournal.tsx
+++ b/src/features/modes/game/components/GameJournal.tsx
@@ -178,23 +178,33 @@ export function GameJournal({
   const [activeTab, setActiveTab] = useState<TabId>("all");
   const [playerNotes, setPlayerNotes] = useState("");
   const [notesSaved, setNotesSaved] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
   const [removingNpcName, setRemovingNpcName] = useState<string | null>(null);
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const latestNotesRef = useRef("");
   const queryClient = useQueryClient();
 
-  useEffect(() => {
+  const loadJournal = useCallback(() => {
+    setLoadError(null);
     gameApi
       .getJournal(chatId)
       .then((res) => {
         setJournal(res.journal as Journal);
         if (res.playerNotes) setPlayerNotes(res.playerNotes);
       })
-      .catch(() => {});
+      .catch((err) => {
+        setLoadError(err instanceof Error ? err.message : "Failed to load journal");
+      });
   }, [chatId]);
+
+  useEffect(() => {
+    loadJournal();
+  }, [loadJournal]);
 
   const saveNotes = useCallback(
     (text: string) => {
+      setSaveError(null);
       gameApi
         .updateNotes(chatId, text)
         .then((res) => {
@@ -203,8 +213,11 @@ export function GameJournal({
             useChatStore.getState().setActiveChat(res.sessionChat);
           }
           setNotesSaved(true);
+          setSaveError(null);
         })
-        .catch(() => {});
+        .catch((err) => {
+          setSaveError(err instanceof Error ? err.message : "Failed to save notes");
+        });
     },
     [chatId, queryClient],
   );
@@ -263,6 +276,33 @@ export function GameJournal({
       ),
     [journal?.entries, trackedNpcNames],
   );
+
+  if (!journal && loadError) {
+    return (
+      <div className="absolute inset-0 z-40 flex items-center justify-center bg-black/70 p-6 backdrop-blur-sm">
+        <div className="flex max-w-sm flex-col items-center gap-3 text-center">
+          <p className="text-sm font-medium text-white/90">Couldn&apos;t load the journal.</p>
+          <p className="text-xs text-white/50">{loadError}</p>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={loadJournal}
+              className="rounded-lg bg-white/10 px-3 py-1.5 text-xs font-medium text-white/90 transition-colors hover:bg-white/20"
+            >
+              Retry
+            </button>
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-lg px-3 py-1.5 text-xs text-white/60 transition-colors hover:bg-white/10 hover:text-white"
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   if (!journal) {
     return (
@@ -327,7 +367,15 @@ export function GameJournal({
         {activeTab === "locations" && <LocationsView locations={journal.locations} />}
         {activeTab === "inventory" && <InventoryView items={journal.inventoryLog} />}
         {activeTab === "library" && <LibraryView entries={visibleEntries.filter((e) => e.type === "note")} />}
-        {activeTab === "notes" && <NotesView notes={playerNotes} onChange={handleNotesChange} saved={notesSaved} />}
+        {activeTab === "notes" && (
+          <NotesView
+            notes={playerNotes}
+            onChange={handleNotesChange}
+            saved={notesSaved}
+            saveError={saveError}
+            onRetrySave={() => saveNotes(latestNotesRef.current || playerNotes)}
+          />
+        )}
       </div>
     </div>
   );
@@ -612,18 +660,45 @@ function LibraryView({ entries }: { entries: JournalEntry[] }) {
   );
 }
 
-function NotesView({ notes, onChange, saved }: { notes: string; onChange: (text: string) => void; saved: boolean }) {
+function NotesView({
+  notes,
+  onChange,
+  saved,
+  saveError,
+  onRetrySave,
+}: {
+  notes: string;
+  onChange: (text: string) => void;
+  saved: boolean;
+  saveError?: string | null;
+  onRetrySave?: () => void;
+}) {
   return (
     <div className="flex h-full flex-col gap-2">
       <div className="flex items-center justify-between">
         <p className="text-[0.625rem] text-white/40">
           Your personal notes — visible to the Game Master and party members.
         </p>
-        <span
-          className={cn("text-[0.5625rem] transition-opacity", saved ? "text-emerald-400/60" : "text-amber-400/60")}
-        >
-          {saved ? "Saved" : "Saving..."}
-        </span>
+        <div className="flex items-center gap-1.5">
+          <span
+            className={cn(
+              "text-[0.5625rem] transition-opacity",
+              saveError ? "text-red-400/80" : saved ? "text-emerald-400/60" : "text-amber-400/60",
+            )}
+            title={saveError ?? undefined}
+          >
+            {saveError ? "Save failed" : saved ? "Saved" : "Saving..."}
+          </span>
+          {saveError && onRetrySave && (
+            <button
+              type="button"
+              onClick={onRetrySave}
+              className="rounded text-[0.5625rem] text-white/60 underline-offset-2 transition-colors hover:text-white/90 hover:underline"
+            >
+              Retry
+            </button>
+          )}
+        </div>
       </div>
       <div className="grid min-h-0 flex-1 gap-2 md:grid-cols-2">
         <textarea


### PR DESCRIPTION
## Why this change

`GameJournal` swallowed both of its async failures in empty `.catch(() => {})` blocks:

- When `getJournal` rejected, `setJournal` never ran, so the panel stayed stuck on the **"Loading journal..."** spinner forever, with no error and no way out.
- When `updateNotes` rejected, `setNotesSaved(true)` never ran, so the notes status pill stayed on the amber **"Saving..."** indefinitely, implying an in-flight save that had actually failed.

(Note: the issue body references a `useGameJournal` hook, but no such hook exists. The component uses local state, so the fix uses local state.)

## What changed

`src/features/modes/game/components/GameJournal.tsx`:
- Track `loadError` / `saveError` in local state.
- The load runs through a `loadJournal` callback so it can be retried; on failure it records the error.
- The render guard now shows a retryable error panel (underlying message + a **Retry** that re-runs the load + a **Close**) before falling through to the plain loading state.
- `saveNotes` records its failure and clears it on success; `NotesView` shows a red **"Save failed"** with a **Retry** control instead of a stuck "Saving...".

## Verification

- `pnpm exec tsc -b` clean.
- New jsdom component test (`GameJournal.test.tsx`) covers: the load-error panel renders (not a stuck spinner), a successful load retry shows the journal, and a save failure surfaces "Save failed" + Retry.

## Risk / note

This is Game-mode-owned UI; the underlying `gameApi.getJournal`/`updateNotes` are unchanged. The unmount-flush effect still calls `saveNotes` on unmount; on failure it sets error state on an unmounting component (benign React warning at most). The error panel's exact styling is verified by render, not pixel comparison.

## Linked issue

Closes #1536.