### PR TITLE
[codex] Optimize character summary and search paths

### DIFF
--- a/src-tauri/src/commands/storage/commands/entities.rs
+++ b/src-tauri/src/commands/storage/commands/entities.rs
@@ -521,6 +521,7 @@ mod tests {
                         "description": "Frost archive keeper",
                         "personality": "Dry humor",
                         "tags": ["Mage"],
+                        "favorite_color": "violet",
                         "extensions": { "fav": true }
                     }
                 }),
@@ -589,5 +590,20 @@ mod tests {
                 .is_empty(),
             "search should not match embedded avatar payload text"
         );
+
+        let full_data_result = storage_list_inner(
+            &state,
+            "characters".to_string(),
+            Some(json!({
+                "fields": ["id", "data"],
+                "search": "frost archive"
+            })),
+        )
+        .expect("full data search list should succeed");
+        let full_data_rows = full_data_result
+            .as_array()
+            .expect("storage_list returns an array");
+        assert_eq!(full_data_rows.len(), 1);
+        assert_eq!(full_data_rows[0]["data"]["favorite_color"], "violet");
     }
 }

--- a/src-tauri/src/commands/storage/commands/entities.rs
+++ b/src-tauri/src/commands/storage/commands/entities.rs
@@ -53,6 +53,22 @@ fn storage_list_inner(
         }
         (_, _)
             if empty_filters
+                && has_search
+                && projection_fields
+                    .as_ref()
+                    .is_some_and(|fields| !fields.is_empty()) =>
+        {
+            let search_projection_fields = shared::search_projection_fields(options.as_ref());
+            let search_projection_field_selections =
+                shared::search_projection_field_selections(options.as_ref());
+            state.storage.list_projected(
+                &entity,
+                &search_projection_fields,
+                &search_projection_field_selections,
+            )?
+        }
+        (_, _)
+            if empty_filters
                 && !has_search
                 && projection_fields
                     .as_ref()
@@ -484,6 +500,94 @@ mod tests {
         assert_eq!(
             ids_for_lorebook(&state, "lorebook-folders", "book-keep"),
             vec!["folder-keep".to_string()]
+        );
+    }
+
+    #[test]
+    fn storage_list_searches_projected_character_fields_without_returning_avatar_payloads() {
+        let state = test_state("character-search-projection");
+        state
+            .storage
+            .create(
+                "characters",
+                json!({
+                    "id": "char-match",
+                    "comment": "summary",
+                    "avatarPath": "data:image/png;base64,large-avatar",
+                    "avatarFilePath": "C:\\Marinara\\avatars\\characters\\match.png",
+                    "avatarFilename": "match.png",
+                    "data": {
+                        "name": "Rina",
+                        "description": "Frost archive keeper",
+                        "personality": "Dry humor",
+                        "tags": ["Mage"],
+                        "extensions": { "fav": true }
+                    }
+                }),
+            )
+            .expect("matching character should be created");
+        state
+            .storage
+            .create(
+                "characters",
+                json!({
+                    "id": "char-avatar-only",
+                    "avatarPath": "data:image/png;base64,frost-hidden-in-avatar",
+                    "data": {
+                        "name": "Mira",
+                        "description": "No matching text",
+                        "tags": []
+                    }
+                }),
+            )
+            .expect("non-matching character should be created");
+
+        let result = storage_list_inner(
+            &state,
+            "characters".to_string(),
+            Some(json!({
+                "fields": ["id", "data", "comment", "avatarFilePath", "avatarFilename"],
+                "fieldSelections": { "data": ["name", "tags", "extensions"] },
+                "search": "frost archive"
+            })),
+        )
+        .expect("search list should succeed");
+        let rows = result.as_array().expect("storage_list returns an array");
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0]["id"], "char-match");
+        assert_eq!(
+            rows[0],
+            json!({
+                "id": "char-match",
+                "data": {
+                    "name": "Rina",
+                    "tags": ["Mage"],
+                    "extensions": { "fav": true }
+                },
+                "comment": "summary",
+                "avatarFilePath": "C:\\Marinara\\avatars\\characters\\match.png",
+                "avatarFilename": "match.png"
+            })
+        );
+
+        let avatar_payload_result = storage_list_inner(
+            &state,
+            "characters".to_string(),
+            Some(json!({
+                "fields": ["id", "data", "comment", "avatarFilePath", "avatarFilename"],
+                "fieldSelections": { "data": ["name", "tags", "extensions"] },
+                "search": "frost-hidden-in-avatar"
+            })),
+        )
+        .expect("avatar payload search should succeed");
+
+        assert!(
+            avatar_payload_result
+                .as_array()
+                .expect("storage_list returns an array")
+                .is_empty(),
+            "search should not match embedded avatar payload text"
         );
     }
 }

--- a/src-tauri/src/commands/storage/shared.rs
+++ b/src-tauri/src/commands/storage/shared.rs
@@ -1731,6 +1731,71 @@ fn empty_projection_field_selections() -> &'static serde_json::Map<String, Value
     EMPTY.get_or_init(serde_json::Map::new)
 }
 
+pub(crate) fn search_projection_fields(options: Option<&Value>) -> Vec<String> {
+    let mut fields = projection_fields(options).unwrap_or_default();
+    for field in [
+        "id",
+        "name",
+        "comment",
+        "content",
+        "swipes",
+        "data",
+        "sortOrder",
+        "order",
+        "createdAt",
+        "updatedAt",
+    ] {
+        if !fields.iter().any(|existing| existing == field) {
+            fields.push(field.to_string());
+        }
+    }
+    if let Some(order_by) = options
+        .and_then(|value| value.get("orderBy"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        if !fields.iter().any(|existing| existing == order_by) {
+            fields.push(order_by.to_string());
+        }
+    }
+    fields
+}
+
+pub(crate) fn search_projection_field_selections(
+    options: Option<&Value>,
+) -> serde_json::Map<String, Value> {
+    let mut selections = projection_field_selections(options).clone();
+    let mut data_fields = selections
+        .get("data")
+        .and_then(string_array_from_json)
+        .unwrap_or_default();
+    for field in [
+        "name",
+        "creator",
+        "creator_notes",
+        "tags",
+        "description",
+        "personality",
+        "scenario",
+        "first_mes",
+        "mes_example",
+        "system_prompt",
+        "post_history_instructions",
+        "alternate_greetings",
+        "extensions",
+    ] {
+        if !data_fields.iter().any(|existing| existing == field) {
+            data_fields.push(field.to_string());
+        }
+    }
+    selections.insert(
+        "data".to_string(),
+        Value::Array(data_fields.into_iter().map(Value::String).collect()),
+    );
+    selections
+}
+
 pub(crate) fn apply_storage_search(rows: &mut Vec<Value>, options: Option<&Value>) {
     let Some(query) = storage_search_query(options) else {
         return;

--- a/src-tauri/src/commands/storage/shared.rs
+++ b/src-tauri/src/commands/storage/shared.rs
@@ -1731,6 +1731,29 @@ fn empty_projection_field_selections() -> &'static serde_json::Map<String, Value
     EMPTY.get_or_init(serde_json::Map::new)
 }
 
+/// Character data subfields added to projected rows so storage search can
+/// match card metadata and prompt text without returning embedded avatars.
+const CHARACTER_DATA_SEARCH_FIELDS: &[&str] = &[
+    "name",
+    "creator",
+    "creator_notes",
+    "tags",
+    "description",
+    "personality",
+    "scenario",
+    "first_mes",
+    "mes_example",
+    "system_prompt",
+    "post_history_instructions",
+    "alternate_greetings",
+    "extensions",
+];
+
+/// Expands top-level projection fields for searchable list queries.
+///
+/// The returned field set preserves the caller's requested projection, then
+/// adds fields searched by `apply_storage_search` plus default/orderBy sort
+/// fields needed before the final caller-facing projection is applied.
 pub(crate) fn search_projection_fields(options: Option<&Value>) -> Vec<String> {
     let mut fields = projection_fields(options).unwrap_or_default();
     for field in [
@@ -1762,6 +1785,10 @@ pub(crate) fn search_projection_fields(options: Option<&Value>) -> Vec<String> {
     fields
 }
 
+/// Expands nested projection selections for searchable character data.
+///
+/// When callers request a subset of `data`, this adds the character fields that
+/// search needs for matching, then final projection narrows the response again.
 pub(crate) fn search_projection_field_selections(
     options: Option<&Value>,
 ) -> serde_json::Map<String, Value> {
@@ -1769,6 +1796,9 @@ pub(crate) fn search_projection_field_selections(
     let original_fields = projection_fields(options).unwrap_or_default();
     let original_requests_data = original_fields.iter().any(|field| field == "data");
     let original_data_fields = selections.get("data").and_then(string_array_from_json);
+    // Preserve explicit full-data projections. If the caller requested `data`
+    // and `original_data_fields` is absent or empty, returning the original
+    // `selections` lets storage return complete data for search and response.
     if original_requests_data
         && original_data_fields
             .as_ref()
@@ -1778,21 +1808,7 @@ pub(crate) fn search_projection_field_selections(
     }
 
     let mut data_fields = original_data_fields.unwrap_or_default();
-    for field in [
-        "name",
-        "creator",
-        "creator_notes",
-        "tags",
-        "description",
-        "personality",
-        "scenario",
-        "first_mes",
-        "mes_example",
-        "system_prompt",
-        "post_history_instructions",
-        "alternate_greetings",
-        "extensions",
-    ] {
+    for field in CHARACTER_DATA_SEARCH_FIELDS {
         if !data_fields.iter().any(|existing| existing == field) {
             data_fields.push(field.to_string());
         }

--- a/src-tauri/src/commands/storage/shared.rs
+++ b/src-tauri/src/commands/storage/shared.rs
@@ -1766,10 +1766,18 @@ pub(crate) fn search_projection_field_selections(
     options: Option<&Value>,
 ) -> serde_json::Map<String, Value> {
     let mut selections = projection_field_selections(options).clone();
-    let mut data_fields = selections
-        .get("data")
-        .and_then(string_array_from_json)
-        .unwrap_or_default();
+    let original_fields = projection_fields(options).unwrap_or_default();
+    let original_requests_data = original_fields.iter().any(|field| field == "data");
+    let original_data_fields = selections.get("data").and_then(string_array_from_json);
+    if original_requests_data
+        && original_data_fields
+            .as_ref()
+            .is_none_or(|fields| fields.is_empty())
+    {
+        return selections;
+    }
+
+    let mut data_fields = original_data_fields.unwrap_or_default();
     for field in [
         "name",
         "creator",

--- a/src-tauri/src/http_dispatch.rs
+++ b/src-tauri/src/http_dispatch.rs
@@ -879,6 +879,22 @@ fn storage_list(state: &AppState, args: &Map<String, Value>) -> AppResult<Value>
         }
         (_, _)
             if empty_filters
+                && has_search
+                && projection_fields
+                    .as_ref()
+                    .is_some_and(|fields| !fields.is_empty()) =>
+        {
+            let search_projection_fields = shared::search_projection_fields(options);
+            let search_projection_field_selections =
+                shared::search_projection_field_selections(options);
+            state.storage.list_projected(
+                entity,
+                &search_projection_fields,
+                &search_projection_field_selections,
+            )?
+        }
+        (_, _)
+            if empty_filters
                 && !has_search
                 && projection_fields
                     .as_ref()

--- a/src/features/catalog/characters/components/ImportCharacterModal.tsx
+++ b/src/features/catalog/characters/components/ImportCharacterModal.tsx
@@ -8,7 +8,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import {
   cacheCharacterListRecordFromResult,
   invalidateCharacterCollectionQueries,
-  useCharacters,
+  useCharacterSummaries,
   useDeleteCharacter,
   useUpdateCharacter,
 } from "../hooks/use-characters";
@@ -77,7 +77,7 @@ function characterDisplayName(row: CharacterRow | null | undefined): string {
 
 export function ImportCharacterModal({ open, onClose }: Props) {
   const fileRef = useRef<HTMLInputElement>(null);
-  const { data: rawCharacters } = useCharacters(open);
+  const { data: rawCharacters } = useCharacterSummaries(open);
   const updateCharacter = useUpdateCharacter();
   const deleteCharacter = useDeleteCharacter();
   const [status, setStatus] = useState<"idle" | "loading" | "done">("idle");
@@ -96,7 +96,9 @@ export function ImportCharacterModal({ open, onClose }: Props) {
 
   const updateImportedCharacterInPlace = async (imported: unknown, importedName: string) => {
     if (!targetCharacterId) throw new Error("Choose a character to update.");
-    const target = characters.find((character) => character.id === targetCharacterId);
+    const target = await storageApi.get<CharacterRow>("characters", targetCharacterId, {
+      fields: ["id", "data", "comment", "avatarPath"],
+    });
     if (!target?.id) throw new Error("Target character not found.");
     const importedRow =
       imported && typeof imported === "object" && !Array.isArray(imported) ? (imported as CharacterRow) : null;

--- a/src/features/catalog/characters/hooks/use-characters.ts
+++ b/src/features/catalog/characters/hooks/use-characters.ts
@@ -56,7 +56,7 @@ export type PersonaSummary = {
 };
 
 const CHARACTER_SUMMARY_OPTIONS = {
-  fields: ["id", "data", "comment", "avatarPath", "avatarFilePath", "avatarFilename", "createdAt", "updatedAt"],
+  fields: ["id", "data", "comment", "avatarFilePath", "avatarFilename", "createdAt", "updatedAt"],
   fieldSelections: { data: ["name", "creator", "creator_notes", "character_version", "tags", "extensions"] },
 };
 const CHARACTER_SUMMARY_BY_ID_CONCURRENCY = 8;

--- a/src/features/runtime/generation/hooks/use-generate.ts
+++ b/src/features/runtime/generation/hooks/use-generate.ts
@@ -370,7 +370,10 @@ async function characterNameRowsById(queryClient: QueryClient, characterIds: str
           fields: ["id", "data"],
           fieldSelections: { data: ["name"] },
         })
-        .catch(() => null),
+        .catch((error) => {
+          console.warn("[generation] character name lookup failed", error);
+          return null;
+        }),
     ),
   );
   addCharacterRowsById(rowsById, fetchedRows);

--- a/src/features/runtime/generation/hooks/use-generate.ts
+++ b/src/features/runtime/generation/hooks/use-generate.ts
@@ -346,6 +346,37 @@ function characterNameFromRow(row: Record<string, unknown> | undefined, fallback
   return readString(data.name).trim() || readString(row?.name).trim() || fallback;
 }
 
+function addCharacterRowsById(target: Map<string, Record<string, unknown>>, rows: unknown): void {
+  if (!Array.isArray(rows)) return;
+  for (const row of rows) {
+    if (!isRecord(row)) continue;
+    const id = readString(row.id).trim();
+    if (id && !target.has(id)) target.set(id, row);
+  }
+}
+
+async function characterNameRowsById(queryClient: QueryClient, characterIds: string[]) {
+  const rowsById = new Map<string, Record<string, unknown>>();
+  addCharacterRowsById(rowsById, queryClient.getQueryData(characterKeys.list()));
+  addCharacterRowsById(rowsById, queryClient.getQueryData(characterKeys.summaries()));
+
+  const missingIds = characterIds.filter((id) => !rowsById.has(id));
+  if (missingIds.length === 0) return rowsById;
+
+  const fetchedRows = await Promise.all(
+    missingIds.map((id) =>
+      storageApi
+        .get<Record<string, unknown>>("characters", id, {
+          fields: ["id", "data"],
+          fieldSelections: { data: ["name"] },
+        })
+        .catch(() => null),
+    ),
+  );
+  addCharacterRowsById(rowsById, fetchedRows);
+  return rowsById;
+}
+
 async function buildPendingCardUpdates(
   queryClient: ReturnType<typeof useQueryClient>,
   chatId: string,
@@ -370,16 +401,6 @@ async function buildPendingCardUpdates(
   if (chatCharacterIds.length === 0) return [];
   const chatCharacterIdSet = new Set(chatCharacterIds);
 
-  let characters = queryClient.getQueryData<Record<string, unknown>[]>(characterKeys.list());
-  if (!characters) {
-    try {
-      characters = (await storageApi.list("characters")) as Record<string, unknown>[];
-      queryClient.setQueryData(characterKeys.list(), characters);
-    } catch {
-      characters = [];
-    }
-  }
-
   const groupedUpdates = new Map<string, CharacterCardFieldUpdate[]>();
   for (const update of updates) {
     if (!chatCharacterIdSet.has(update.characterId)) continue;
@@ -387,11 +408,12 @@ async function buildPendingCardUpdates(
   }
   if (groupedUpdates.size === 0) return [];
 
+  const charactersById = await characterNameRowsById(queryClient, chatCharacterIds);
   const timestamp = Date.now();
   return chatCharacterIds.flatMap((characterId, index) => {
     const grouped = groupedUpdates.get(characterId);
     if (!grouped?.length) return [];
-    const row = characters.find((character) => readString(character.id) === characterId);
+    const row = charactersById.get(characterId);
     return [
       {
         id: `card-update-${characterId}-${timestamp}-${index}`,

--- a/src/features/runtime/tracker/hooks/use-tracker-panel-model.ts
+++ b/src/features/runtime/tracker/hooks/use-tracker-panel-model.ts
@@ -14,7 +14,7 @@ import { useChatStore } from "../../../../shared/stores/chat.store";
 import { useUIStore } from "../../../../shared/stores/ui.store";
 import type { TrackerPanelSizeProfile, TrackerPanelSide, TrackerTemperatureUnit, TrackerThoughtBubbleDisplay } from "../../../../shared/stores/ui.store";
 import { chatKeys, preserveRecentMessageContentEdit, useChat } from "../../../catalog/chats/index";
-import { useCharacters, usePersonas } from "../../../catalog/characters/index";
+import { characterAvatarUrl, useCharacterSummaries, usePersonas } from "../../../catalog/characters/index";
 import { useTrackerStateController } from "../../world-state/index";
 import {
   TRACKER_SECTION_AGENT_TYPES,
@@ -144,13 +144,20 @@ export function useTrackerPanelModel(): TrackerPanelModel {
   const personaDataLookupEnabled = !!activeChatId && personaTrackerEnabled;
   const agentConfigLookupEnabled = !!activeChatId && characterTrackerEnabled;
   const { data: messageData } = useTrackerSpriteMessages(activeChatId, spriteExpressionLookupEnabled);
-  const { data: charactersData } = useCharacters(characterDataLookupEnabled);
+  const { data: charactersData } = useCharacterSummaries(characterDataLookupEnabled);
   const { data: personasData } = usePersonas(personaDataLookupEnabled);
 
   const characterSpriteLookup = useMemo(() => {
     const rows = (
       Array.isArray(charactersData)
-        ? (charactersData as Array<{ id: string; data: unknown; comment?: string | null; avatarPath?: string | null }>)
+        ? (charactersData as Array<{
+            id: string;
+            data: unknown;
+            comment?: string | null;
+            avatarPath?: string | null;
+            avatarFilePath?: string | null;
+            avatarFilename?: string | null;
+          }>)
         : []
     ).filter((character) => typeof character.id === "string" && character.id.length > 0);
     const chatIdSet = new Set(chatCharacterIds);
@@ -165,7 +172,8 @@ export function useTrackerPanelModel(): TrackerPanelModel {
     const pictureById: Record<string, string> = {};
     const profileColorsById: Record<string, TrackerProfileColors> = {};
     for (const { character } of displayRows) {
-      if (character.avatarPath) pictureById[character.id] = character.avatarPath;
+      const avatarUrl = characterAvatarUrl(character);
+      if (avatarUrl) pictureById[character.id] = avatarUrl;
       const profileColors = getCharacterProfileColors(character.data);
       if (profileColors) profileColorsById[character.id] = profileColors;
     }

--- a/src/features/shell/bot-browser/components/BotBrowserPanel.tsx
+++ b/src/features/shell/bot-browser/components/BotBrowserPanel.tsx
@@ -2,8 +2,9 @@
 // Panel: Browser (sidebar — shows imported characters)
 // ──────────────────────────────────────────────
 import { useState, useMemo, useCallback } from "react";
-import { useCharacters } from "../../../catalog/characters/index";
+import { characterAvatarUrl, useCharacterSummaries } from "../../../catalog/characters/index";
 import { useStartChatFromCharacter } from "../../../catalog/characters/index";
+import { storageApi } from "../../../../shared/api/storage-api";
 import { useUIStore } from "../../../../shared/stores/ui.store";
 import { Search, User, Globe, Wand2, MessageCircle } from "lucide-react";
 import { cn, getAvatarCropStyle } from "../../../../shared/lib/utils";
@@ -16,7 +17,15 @@ type CharacterData = Record<string, unknown> & {
   extensions?: Record<string, unknown>;
 };
 
-type CharacterRow = { id: string; data: unknown; avatarPath: string | null; createdAt: string; updatedAt: string };
+type CharacterRow = {
+  id: string;
+  data: unknown;
+  avatarPath?: string | null;
+  avatarFilePath?: string | null;
+  avatarFilename?: string | null;
+  createdAt?: string;
+  updatedAt?: string;
+};
 
 function parseCharacterData(data: unknown): CharacterData | null {
   if (typeof data === "string") {
@@ -31,7 +40,7 @@ function parseCharacterData(data: unknown): CharacterData | null {
 }
 
 export function BotBrowserPanel() {
-  const { data: characters, isLoading } = useCharacters();
+  const { data: characters, isLoading } = useCharacterSummaries();
   const openCharacterDetail = useUIStore((s) => s.openCharacterDetail);
   const openBotBrowser = useUIStore((s) => s.openBotBrowser);
   const botBrowserOpen = useUIStore((s) => s.botBrowserOpen);
@@ -54,7 +63,12 @@ export function BotBrowserPanel() {
       const d = parseCharacterData(c.data);
       if (!d) return acc;
       if (d.extensions?.botBrowserSource) {
-        acc.push({ id: c.id, name: d.name ?? "Unnamed", avatarPath: c.avatarPath, createdAt: c.createdAt });
+        acc.push({
+          id: c.id,
+          name: d.name ?? "Unnamed",
+          avatarPath: characterAvatarUrl(c),
+          createdAt: c.createdAt ?? "",
+        });
       }
       return acc;
     }, []);
@@ -67,17 +81,22 @@ export function BotBrowserPanel() {
   }, [parsed, search]);
 
   const getCharacterGreeting = useCallback(
-    (charId: string): { firstMes?: string; altGreetings: string[] } => {
-      const raw = (characters as CharacterRow[] | undefined)?.find((c) => c.id === charId);
+    async (charId: string): Promise<{ firstMes?: string; altGreetings: string[] }> => {
+      const raw = await storageApi.get<CharacterRow>("characters", charId, {
+        fields: ["id", "data"],
+        fieldSelections: { data: ["first_mes", "alternate_greetings"] },
+      });
       if (!raw) return { altGreetings: [] };
       const d = parseCharacterData(raw.data);
       if (!d) return { altGreetings: [] };
       return {
         firstMes: d.first_mes,
-        altGreetings: Array.isArray(d.alternate_greetings) ? d.alternate_greetings.filter((g): g is string => typeof g === "string") : [],
+        altGreetings: Array.isArray(d.alternate_greetings)
+          ? d.alternate_greetings.filter((g): g is string => typeof g === "string")
+          : [],
       };
     },
-    [characters],
+    [],
   );
 
   return (
@@ -123,15 +142,20 @@ export function BotBrowserPanel() {
               onClick={() => openCharacterDetail(char.id)}
               onContextMenu={(e) => {
                 e.preventDefault();
-                const greeting = getCharacterGreeting(char.id);
-                setContextMenu({
-                  x: e.clientX,
-                  y: e.clientY,
-                  charId: char.id,
-                  charName: char.name,
-                  firstMes: greeting.firstMes,
-                  altGreetings: greeting.altGreetings,
-                });
+                const x = e.clientX;
+                const y = e.clientY;
+                void getCharacterGreeting(char.id)
+                  .catch((): { firstMes?: string; altGreetings: string[] } => ({ altGreetings: [] }))
+                  .then((greeting) => {
+                    setContextMenu({
+                      x,
+                      y,
+                      charId: char.id,
+                      charName: char.name,
+                      firstMes: greeting.firstMes,
+                      altGreetings: greeting.altGreetings,
+                    });
+                  });
               }}
               className="group flex items-center gap-2.5 rounded-xl p-2 text-left transition-all hover:bg-[var(--sidebar-accent)]"
             >

--- a/src/features/shell/bot-browser/components/BotBrowserPanel.tsx
+++ b/src/features/shell/bot-browser/components/BotBrowserPanel.tsx
@@ -9,6 +9,7 @@ import { useUIStore } from "../../../../shared/stores/ui.store";
 import { Search, User, Globe, Wand2, MessageCircle } from "lucide-react";
 import { cn, getAvatarCropStyle } from "../../../../shared/lib/utils";
 import { ContextMenu, type ContextMenuItem } from "../../../../shared/components/ui/ContextMenu";
+import { toast } from "sonner";
 
 type CharacterData = Record<string, unknown> & {
   name?: string;
@@ -145,7 +146,6 @@ export function BotBrowserPanel() {
                 const x = e.clientX;
                 const y = e.clientY;
                 void getCharacterGreeting(char.id)
-                  .catch((): { firstMes?: string; altGreetings: string[] } => ({ altGreetings: [] }))
                   .then((greeting) => {
                     setContextMenu({
                       x,
@@ -154,6 +154,16 @@ export function BotBrowserPanel() {
                       charName: char.name,
                       firstMes: greeting.firstMes,
                       altGreetings: greeting.altGreetings,
+                    });
+                  })
+                  .catch(() => {
+                    toast.error("Could not load character greetings.");
+                    setContextMenu({
+                      x,
+                      y,
+                      charId: char.id,
+                      charName: char.name,
+                      altGreetings: [],
                     });
                   });
               }}

--- a/src/features/shell/settings/components/settings/TTSConfigCard.tsx
+++ b/src/features/shell/settings/components/settings/TTSConfigCard.tsx
@@ -19,7 +19,7 @@ import {
 import { cn } from "../../../../../shared/lib/utils";
 import { toast } from "sonner";
 import { useTTSConfig, useUpdateTTSConfig, useTTSVoices } from "../../../../../shared/hooks/use-tts";
-import { useCharacters } from "../../../../catalog/characters/index";
+import { useCharacterSummaries } from "../../../../catalog/characters/index";
 import { ttsService } from "../../../../../shared/lib/tts-service";
 import { clientSidePlaybackRate } from "../../../../../shared/lib/tts-dialogue";
 import { parseCharacterDisplayData } from "../../../../../shared/lib/character-display";
@@ -293,7 +293,7 @@ function NpcDefaultVoicePool({
 export function TTSConfigCard() {
   const { data: savedConfig, isLoading } = useTTSConfig();
   const updateConfig = useUpdateTTSConfig();
-  const { data: characters } = useCharacters();
+  const { data: characters } = useCharacterSummaries();
 
   // Local draft state
   const [enabled, setEnabled] = useState(false);

--- a/src/features/shell/settings/hooks/tracker-card-color-manager.ts
+++ b/src/features/shell/settings/hooks/tracker-card-color-manager.ts
@@ -165,7 +165,7 @@ export function updateCachedTrackerCardColorTargetConfig(
     return;
   }
 
-  queryClient.setQueryData<unknown[] | undefined>(characterKeys.list(), (old) => {
+  const patchCharacterCache = (old: unknown[] | undefined) => {
     if (!Array.isArray(old)) return old;
 
     return old.map((character) => {
@@ -175,7 +175,10 @@ export function updateCachedTrackerCardColorTargetConfig(
         data: patchCharacterDataTrackerCardColors(character.data, serializedConfig, previewBaseSerializedConfig),
       };
     });
-  });
+  };
+
+  queryClient.setQueryData<unknown[] | undefined>(characterKeys.list(), patchCharacterCache);
+  queryClient.setQueryData<unknown[] | undefined>(characterKeys.summaries(), patchCharacterCache);
 }
 
 export function resolvePresentCharacterId(

--- a/src/features/shell/settings/hooks/use-tracker-card-color-manager.ts
+++ b/src/features/shell/settings/hooks/use-tracker-card-color-manager.ts
@@ -2,12 +2,12 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import type { TrackerCardColorConfig } from "../../../../engine/contracts/types/persona";
 import {
-  characterKeys,
-  useCharacters,
+  useCharacterSummaries,
   usePersonas,
   useUpdateCharacter,
   useUpdatePersona,
 } from "../../../catalog/characters/index";
+import { storageApi } from "../../../../shared/api/storage-api";
 import { useChat } from "../../../catalog/chats/index";
 import { useTrackerStateController } from "../../../runtime/world-state/index";
 import { useChatStore } from "../../../../shared/stores/chat.store";
@@ -20,7 +20,6 @@ import {
 import {
   getCharacterExtensions,
   getTargetSavedConfig,
-  isRecord,
   mergeTrackerCardPortraitFields,
   parseCharacterData,
   resolveTrackerCardColorTargets,
@@ -43,7 +42,7 @@ export function useTrackerCardColorManager() {
     shouldLoadTargets,
   );
   const { data: personasData } = usePersonas(shouldLoadTargets);
-  const { data: charactersData } = useCharacters(shouldLoadTargets);
+  const { data: charactersData } = useCharacterSummaries(shouldLoadTargets);
   const updatePersona = useUpdatePersona();
   const updateCharacter = useUpdateCharacter();
   const [selectedTargetKey, setSelectedTargetKey] = useState("");
@@ -176,14 +175,12 @@ export function useTrackerCardColorManager() {
         return;
       }
 
-      if (!target.characterData) return;
-
-      const latestCharacterData =
-        queryClient
-          .getQueryData<unknown[] | undefined>(characterKeys.list())
-          ?.map((character) => (isRecord(character) && character.id === target.id ? character : null))
-          .find((character): character is Record<string, unknown> => !!character)?.data ?? target.characterData;
-      const characterData = parseCharacterData(latestCharacterData) ?? target.characterData;
+      const latestCharacter = await storageApi.get<Record<string, unknown>>("characters", target.id, {
+        fields: ["id", "data"],
+      });
+      if (!latestCharacter) throw new Error("Character target was not found.");
+      const characterData = parseCharacterData(latestCharacter.data);
+      if (!characterData) throw new Error("Character target data could not be read.");
       const nextExtensions: Record<string, unknown> = {
         ...getCharacterExtensions(characterData),
         trackerCardColors: serializedConfig,
@@ -198,7 +195,7 @@ export function useTrackerCardColorManager() {
         },
       });
     },
-    [queryClient, updateCharacter, updatePersona],
+    [updateCharacter, updatePersona],
   );
 
   const handleChange = useCallback(


### PR DESCRIPTION
## Linked issue

Closes #1582
Closes #1585
Related #1583
Related #1584

## Why this change

- Character summary/list paths still had a few full-record fetches or `avatarPath` payload exposure points after the broader refactor work.
- Character search needed to work against projected storage rows without pulling embedded avatar payloads back into list/search responses.
- Some follow-up consumers needed full character data only at action time, not during initial list rendering.

## What changed

- Removed `avatarPath` from character summary list options while keeping managed avatar file references.
- Moved remaining summary-capable `useCharacters()` consumers to `useCharacterSummaries()` and added targeted full-record fetches only where needed.
- Removed the direct full `storageApi.list("characters")` fallback from generation card-update naming.
- Added projected-search support for embedded Tauri storage and hostable HTTP dispatch while preserving explicit full-`data` projections.
- Added Rust regression coverage for projected character search matching card text, excluding avatar payload text, and preserving full `data` when requested.
- Ran failpath and Bunny passes; fixed Bunny findings around full-data projection and quiet fallback handling.

## Refactor impact

Primary owner:

- Catalog character data hooks, Rust storage list/search, runtime generation, shell/settings character consumers.

Impact areas reviewed:

- Character library/panels and pickers using summary rows.
- Bot Browser greeting context menu.
- TTS character voice assignments.
- Tracker sprite/color character lookup paths.
- Generation pending card-update name lookup.
- Embedded Tauri and hostable HTTP storage list dispatch.

Boundary notes:

- Feature code continues through existing storage API wrappers; no new raw Tauri or raw remote-runtime calls.
- Rust storage command and HTTP dispatch paths mirror the same projected-search behavior.
- Engine code was not changed.

Pressure points touched:

- `src-tauri/src/commands/storage/commands/entities.rs`
- `src-tauri/src/http_dispatch.rs`
- `src/features/runtime/generation/hooks/use-generate.ts`
- Shell/settings panels that consume character summaries.

## Validation

- [x] `pnpm check` passes locally
- [x] `pnpm typecheck` passes locally
- [x] `pnpm build` passes locally
- [x] `pnpm check:architecture` passes locally
- [x] `pnpm check:docs` passes locally
- [x] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [x] Rust clippy/tests were run for Rust behavior changes
- [x] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- `pnpm typecheck` passed.
- `pnpm check:architecture` passed.
- `pnpm exec vitest run src/features/catalog/characters/hooks/use-characters.test.ts src/shared/api/local-file-api.test.ts` passed.
- `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passed.
- `cargo test --manifest-path src-tauri/Cargo.toml storage_list_searches_projected_character_fields_without_returning_avatar_payloads` passed.
- `cargo test --manifest-path src-tauri/Cargo.toml apply_storage_search` passed.
- `git diff --check` passed.
- Native Tauri QA launched `Marinara Engine QA`; character summary IPC returned 5 rows with `avatarPathCount: 0`, projected search matched a non-returned description field with `returnedAvatarPathCount: 0`, and visible character-panel search narrowed `A5` from 5 characters to 1 with no console/page errors.
- Native Bot Browser and Settings panels opened with no console/page errors.
- `cargo fmt --manifest-path src-tauri/Cargo.toml --check` was attempted and reported existing rustfmt drift in storage files, including untouched `exports.rs`; no unrelated formatter churn was included.
- Remote runtime smoke was not manually launched; HTTP dispatch was code-reviewed and covered by matching Rust path logic.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- Native QA screenshots were captured locally under `scratch/native-tauri-*.png`; not committed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimized character data loading and search performance by implementing targeted field selection across character listing and import workflows, reducing unnecessary data transfers.
  * Improved data fetching efficiency for character summaries to load only required fields when displaying character lists.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1643?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->