### PR TITLE
Normalize legacy activeQuests shapes in one shared quest-merge helper

### DIFF
--- a/src/engine/generation/tracker-snapshots.ts
+++ b/src/engine/generation/tracker-snapshots.ts
@@ -5,21 +5,17 @@ import type {
   CustomTrackerField,
   GameState,
   InventoryItem,
-  PlayerStats,
   PresentCharacter,
-  QuestProgress,
-  RPGAttributes,
 } from "../contracts/types/game-state";
 import { preserveTrackerCharacterUiFields } from "./generate-route-utils";
+import { boolish, isRecord, nowIso, parseRecord, readNonNegativeInteger, readString } from "./runtime-records";
 import {
-  boolish,
-  isRecord,
-  nowIso,
-  parseRecord,
-  readNonNegativeInteger,
-  readNumber,
-  readString,
-} from "./runtime-records";
+  applyQuestUpdatesToPlayerStats,
+  clonePlayerStats,
+  parseCustomTrackerField,
+  parseInventoryItem,
+  parseStat,
+} from "../shared/game-state/player-stats";
 
 export interface TrackerSnapshotTurnTarget {
   messageId: string;
@@ -60,18 +56,6 @@ type TrackerStatePatch = Partial<
   >
 >;
 
-type QuestObjective = QuestProgress["objectives"][number];
-type QuestUpdateAction = "create" | "update" | "complete" | "fail";
-type RpgAttributeKey = keyof RPGAttributes;
-
-const RPG_ATTRIBUTE_KEYS: RpgAttributeKey[] = ["str", "dex", "con", "int", "wis", "cha"];
-
-interface NormalizedQuestUpdate {
-  action: QuestUpdateAction;
-  questName: string;
-  objectives?: QuestObjective[];
-}
-
 function readNullableString(value: unknown): string | null {
   if (value === null || value === undefined) return null;
   if (typeof value === "string") {
@@ -80,101 +64,6 @@ function readNullableString(value: unknown): string | null {
   }
   if (typeof value === "number" || typeof value === "bigint") return String(value);
   return null;
-}
-
-function parseStat(value: unknown): CharacterStat | null {
-  const record = parseRecord(value);
-  const name = readString(record.name).trim();
-  if (!name) return null;
-  const max = Math.max(1, readNumber(record.max, 100));
-  const valueNumber = Math.min(max, Math.max(0, readNumber(record.value, max)));
-  const color = readString(record.color).trim() || "#8b5cf6";
-  return { name, value: valueNumber, max, color };
-}
-
-function parseInventoryItem(value: unknown): InventoryItem | null {
-  const record = parseRecord(value);
-  const name = readString(record.name).trim();
-  if (!name) return null;
-  return {
-    name,
-    description: readString(record.description).trim(),
-    quantity: Math.max(0, readNumber(record.quantity, 1)),
-    location: readString(record.location).trim() || "on_person",
-  };
-}
-
-function parseQuestObjective(value: unknown): { text: string; completed: boolean } | null {
-  if (typeof value === "string") {
-    const text = value.trim();
-    return text ? { text, completed: false } : null;
-  }
-  const record = parseRecord(value);
-  const text = firstString(record.text, record.description, record.objective, record.name, record.title);
-  if (!text) return null;
-  const status = readString(record.status ?? record.done)
-    .trim()
-    .toLowerCase();
-  return {
-    text,
-    completed: boolish(record.completed, status === "complete" || status === "completed" || status === "done"),
-  };
-}
-
-function firstString(...values: unknown[]): string | undefined {
-  for (const value of values) {
-    const text = readString(value).trim();
-    if (text) return text;
-  }
-  return undefined;
-}
-
-function parseQuest(value: unknown): QuestProgress | null {
-  const record = parseRecord(value);
-  const name = readString(record.name).trim() || readString(record.questName).trim();
-  if (!name) return null;
-  const questEntryId = readString(record.questEntryId).trim() || name;
-  const objectives = Array.isArray(record.objectives)
-    ? record.objectives
-        .map(parseQuestObjective)
-        .filter((objective): objective is { text: string; completed: boolean } => !!objective)
-    : [];
-  return {
-    questEntryId,
-    name,
-    currentStage: Math.max(0, readNonNegativeInteger(record.currentStage, 0)),
-    objectives,
-    completed: boolish(record.completed, false),
-  };
-}
-
-function parseCustomTrackerField(value: unknown): CustomTrackerField | null {
-  const record = parseRecord(value);
-  const name = readString(record.name).trim();
-  if (!name) return null;
-  return { name, value: readString(record.value).trim() };
-}
-
-function parseRpgAttributes(value: unknown): RPGAttributes | null {
-  const record = parseRecord(value);
-  if (!RPG_ATTRIBUTE_KEYS.some((key) => Object.prototype.hasOwnProperty.call(record, key))) return null;
-  return {
-    str: readNumber(record.str, 10),
-    dex: readNumber(record.dex, 10),
-    con: readNumber(record.con, 10),
-    int: readNumber(record.int, 10),
-    wis: readNumber(record.wis, 10),
-    cha: readNumber(record.cha, 10),
-  };
-}
-
-function parseSkills(value: unknown): Record<string, number> {
-  const record = parseRecord(value);
-  return Object.fromEntries(
-    Object.entries(record)
-      .map(([key, skillValue]) => [key.trim(), readNumber(skillValue, Number.NaN)] as const)
-      .filter(([key, skillValue]) => key.length > 0 && Number.isFinite(skillValue)),
-  );
 }
 
 function parseManualOverrides(value: unknown): Record<string, string> | null {
@@ -223,121 +112,6 @@ function parsePresentCharacter(value: unknown): PresentCharacter | null {
       : [],
     thoughts: readNullableString(record.thoughts),
   };
-}
-
-function clonePlayerStats(value: unknown): PlayerStats {
-  const record = parseRecord(value);
-  return {
-    stats: Array.isArray(record.stats)
-      ? record.stats.map(parseStat).filter((stat): stat is CharacterStat => !!stat)
-      : [],
-    attributes: parseRpgAttributes(record.attributes),
-    skills: parseSkills(record.skills),
-    inventory: Array.isArray(record.inventory)
-      ? record.inventory.map(parseInventoryItem).filter((item): item is InventoryItem => !!item)
-      : [],
-    activeQuests: Array.isArray(record.activeQuests)
-      ? record.activeQuests.map(parseQuest).filter((quest): quest is QuestProgress => !!quest)
-      : [],
-    customTrackerFields: Array.isArray(record.customTrackerFields)
-      ? record.customTrackerFields.map(parseCustomTrackerField).filter((field): field is CustomTrackerField => !!field)
-      : undefined,
-    status: readString(record.status),
-  };
-}
-
-function normalizeQuestAction(value: unknown): QuestUpdateAction | null {
-  const normalized = readString(value).trim().toLowerCase();
-  if (normalized === "completed") return "complete";
-  if (normalized === "failed") return "fail";
-  return normalized === "create" || normalized === "update" || normalized === "complete" || normalized === "fail"
-    ? normalized
-    : null;
-}
-
-function collectQuestObjectives(value: unknown, depth = 0): QuestObjective[] {
-  if (value == null || depth > 5) return [];
-  if (Array.isArray(value)) return value.flatMap((entry) => collectQuestObjectives(entry, depth + 1));
-  const direct = parseQuestObjective(value);
-  if (direct) return [direct];
-  const record = parseRecord(value);
-  if (!Object.keys(record).length) return [];
-  for (const key of ["objectives", "tasks", "steps", "items", "subtasks", "children", "goals"]) {
-    if (record[key] === undefined) continue;
-    const nested = collectQuestObjectives(record[key], depth + 1);
-    if (nested.length) return nested;
-  }
-  return Object.values(record).flatMap((entry) => collectQuestObjectives(entry, depth + 1));
-}
-
-function normalizeQuestUpdate(value: unknown): NormalizedQuestUpdate | null {
-  const record = parseRecord(value);
-  const action = normalizeQuestAction(record.action);
-  const questName = firstString(record.questName, record.name, record.title, record.questEntryId);
-  if (!action || !questName) return null;
-  const objectives = record.objectives === undefined ? undefined : collectQuestObjectives(record.objectives);
-  return {
-    action,
-    questName,
-    ...(objectives !== undefined ? { objectives } : {}),
-  };
-}
-
-function cloneQuest(quest: QuestProgress): QuestProgress {
-  return {
-    ...quest,
-    objectives: quest.objectives.map((objective) => ({ ...objective })),
-  };
-}
-
-function applyQuestUpdatesToPlayerStats(
-  value: unknown,
-  updatesValue: unknown,
-): { playerStats: PlayerStats; changed: boolean } {
-  const updates = Array.isArray(updatesValue)
-    ? updatesValue.map(normalizeQuestUpdate).filter((update): update is NormalizedQuestUpdate => !!update)
-    : [];
-  const playerStats = clonePlayerStats(value);
-  const rawActiveQuestsJson = JSON.stringify(playerStats.activeQuests);
-  const quests = playerStats.activeQuests.map(cloneQuest);
-
-  for (const update of updates) {
-    let index = quests.findIndex((quest) => quest.questEntryId === update.questName);
-    if (index === -1) {
-      index = quests.findIndex((quest) => quest.name === update.questName);
-    }
-    if (update.action === "create" && index === -1) {
-      quests.push({
-        questEntryId: update.questName,
-        name: update.questName,
-        currentStage: 0,
-        objectives: update.objectives ?? [],
-        completed: false,
-      });
-    } else if (index !== -1) {
-      if (update.action === "update") {
-        if (update.objectives !== undefined) quests[index]!.objectives = update.objectives;
-      } else if (update.action === "complete") {
-        quests[index]!.completed = true;
-        if (update.objectives !== undefined) quests[index]!.objectives = update.objectives;
-      } else if (update.action === "fail") {
-        quests.splice(index, 1);
-      }
-    }
-  }
-
-  for (let index = quests.length - 1; index >= 0; index -= 1) {
-    const quest = quests[index]!;
-    if (
-      quest.completed &&
-      (quest.objectives.length === 0 || quest.objectives.every((objective) => objective.completed))
-    ) {
-      quests.splice(index, 1);
-    }
-  }
-
-  playerStats.activeQuests = quests;
-  return { playerStats, changed: JSON.stringify(quests) !== rawActiveQuestsJson };
 }
 
 function normalizeGameState(value: unknown, chatId: string, target: TrackerSnapshotTurnTarget): GameState {

--- a/src/engine/shared/game-state/player-stats.test.ts
+++ b/src/engine/shared/game-state/player-stats.test.ts
@@ -6,10 +6,7 @@ describe("normalizeActiveQuestCollection", () => {
     const quests = normalizeActiveQuestCollection({
       "quest-rescue": {
         name: "Rescue the Mayor",
-        objectives: [
-          { description: "Find the cell", status: "done" },
-          { text: "Open the gate" },
-        ],
+        objectives: [{ description: "Find the cell", status: "done" }, { text: "Open the gate" }],
       },
       "quest-loot": {
         questEntryId: "loot-1",
@@ -45,10 +42,7 @@ describe("normalizeActiveQuestCollection", () => {
 
   it("flattens grouped containers and wrapper collections", () => {
     const grouped = normalizeActiveQuestCollection({
-      groups: [
-        { quests: [{ name: "Quest A" }, { name: "Quest B" }] },
-        { quests: [{ name: "Quest C" }] },
-      ],
+      groups: [{ quests: [{ name: "Quest A" }, { name: "Quest B" }] }, { quests: [{ name: "Quest C" }] }],
     });
     expect(grouped.map((quest) => quest.name)).toEqual(["Quest A", "Quest B", "Quest C"]);
 
@@ -80,16 +74,13 @@ describe("normalizeActiveQuestCollection", () => {
 
   it("recovers nested objectives carried under a wrapper key during quest updates", () => {
     // collectQuestObjectives (used by quest updates) digs through nested objective wrappers.
-    const { playerStats } = applyQuestUpdatesToPlayerStats(
-      { activeQuests: [] },
-      [
-        {
-          action: "create",
-          questName: "Nested",
-          objectives: { tasks: [{ text: "Step one" }, { description: "Step two", status: "completed" }] },
-        },
-      ],
-    );
+    const { playerStats } = applyQuestUpdatesToPlayerStats({ activeQuests: [] }, [
+      {
+        action: "create",
+        questName: "Nested",
+        objectives: { tasks: [{ text: "Step one" }, { description: "Step two", status: "completed" }] },
+      },
+    ]);
     const quest = playerStats.activeQuests.find((entry) => entry.name === "Nested");
     expect(quest?.objectives).toEqual([
       { text: "Step one", completed: false },
@@ -128,9 +119,7 @@ describe("applyQuestUpdatesToPlayerStats", () => {
   it("auto-removes a completed quest whose objectives are all done (or empty)", () => {
     const { playerStats, changed } = applyQuestUpdatesToPlayerStats(
       {
-        activeQuests: [
-          { questEntryId: "q1", name: "Finish me", objectives: [{ text: "do it", completed: true }] },
-        ],
+        activeQuests: [{ questEntryId: "q1", name: "Finish me", objectives: [{ text: "do it", completed: true }] }],
       },
       [{ action: "complete", questName: "q1" }],
     );
@@ -174,26 +163,23 @@ describe("applyQuestUpdatesToPlayerStats", () => {
     expect(byName.playerStats.activeQuests[0]?.objectives).toEqual([{ text: "named", completed: false }]);
 
     // "completed" alias -> complete (and auto-remove because objectives empty).
-    const completedAlias = applyQuestUpdatesToPlayerStats(
-      { activeQuests: [{ questEntryId: "qid", name: "Done" }] },
-      [{ action: "completed", questName: "qid" }],
-    );
+    const completedAlias = applyQuestUpdatesToPlayerStats({ activeQuests: [{ questEntryId: "qid", name: "Done" }] }, [
+      { action: "completed", questName: "qid" },
+    ]);
     expect(completedAlias.playerStats.activeQuests).toHaveLength(0);
     expect(completedAlias.changed).toBe(true);
 
     // "failed" alias -> fail (removes the quest).
-    const failedAlias = applyQuestUpdatesToPlayerStats(
-      { activeQuests: [{ questEntryId: "qid", name: "Doomed" }] },
-      [{ action: "failed", questName: "qid" }],
-    );
+    const failedAlias = applyQuestUpdatesToPlayerStats({ activeQuests: [{ questEntryId: "qid", name: "Doomed" }] }, [
+      { action: "failed", questName: "qid" },
+    ]);
     expect(failedAlias.playerStats.activeQuests).toHaveLength(0);
     expect(failedAlias.changed).toBe(true);
 
     // create when no match exists.
-    const created = applyQuestUpdatesToPlayerStats(
-      { activeQuests: [] },
-      [{ action: "create", questName: "Brand New", objectives: [{ text: "begin" }] }],
-    );
+    const created = applyQuestUpdatesToPlayerStats({ activeQuests: [] }, [
+      { action: "create", questName: "Brand New", objectives: [{ text: "begin" }] },
+    ]);
     expect(created.playerStats.activeQuests).toHaveLength(1);
     expect(created.playerStats.activeQuests[0]).toMatchObject({
       questEntryId: "Brand New",
@@ -236,9 +222,7 @@ describe("applyQuestUpdatesToPlayerStats", () => {
 
   it("reports changed=false for a no-op on already-array quests", () => {
     const original = {
-      activeQuests: [
-        { questEntryId: "q1", name: "Stable", currentStage: 0, objectives: [], completed: false },
-      ],
+      activeQuests: [{ questEntryId: "q1", name: "Stable", currentStage: 0, objectives: [], completed: false }],
     };
     const { changed } = applyQuestUpdatesToPlayerStats(original, []);
     expect(changed).toBe(false);

--- a/src/engine/shared/game-state/player-stats.test.ts
+++ b/src/engine/shared/game-state/player-stats.test.ts
@@ -113,6 +113,16 @@ describe("normalizeActiveQuestCollection", () => {
     });
     expect(quests.map((quest) => quest.name)).toEqual(["Real Quest"]);
   });
+
+  it("does not promote a non-quest keyed record to a phantom quest named after its key", () => {
+    const quests = normalizeActiveQuestCollection({
+      "find-the-key": { name: "Find the Key", objectives: ["search"] },
+      "ui-flags": { collapsed: true, sortOrder: 2 },
+    });
+    // The real quest is kept; the unrelated config-shaped record is dropped, not
+    // turned into a quest named "ui-flags".
+    expect(quests.map((quest) => quest.name)).toEqual(["Find the Key"]);
+  });
 });
 
 describe("applyQuestUpdatesToPlayerStats", () => {

--- a/src/engine/shared/game-state/player-stats.test.ts
+++ b/src/engine/shared/game-state/player-stats.test.ts
@@ -96,6 +96,32 @@ describe("normalizeActiveQuestCollection", () => {
       { text: "Step two", completed: true },
     ]);
   });
+
+  it("recovers a quest's non-array objectives wrapper during collection normalization", () => {
+    const [quest] = normalizeActiveQuestCollection([
+      { name: "Wrapped", objectives: { tasks: [{ text: "a" }, { text: "b" }] } },
+    ]);
+    expect(quest?.objectives).toEqual([
+      { text: "a", completed: false },
+      { text: "b", completed: false },
+    ]);
+  });
+
+  it("aggregates quests across all nested wrapper keys, not just the first", () => {
+    const quests = normalizeActiveQuestCollection({
+      quests: [{ name: "From quests" }],
+      groups: [{ quests: [{ name: "From groups" }] }],
+    });
+    expect(quests.map((quest) => quest.name)).toEqual(["From quests", "From groups"]);
+  });
+
+  it("does not let a present-but-empty wrapper key swallow sibling keyed quests", () => {
+    const quests = normalizeActiveQuestCollection({
+      quests: [],
+      "real-quest-id": { name: "Real Quest" },
+    });
+    expect(quests.map((quest) => quest.name)).toEqual(["Real Quest"]);
+  });
 });
 
 describe("applyQuestUpdatesToPlayerStats", () => {

--- a/src/engine/shared/game-state/player-stats.test.ts
+++ b/src/engine/shared/game-state/player-stats.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from "vitest";
+import { applyQuestUpdatesToPlayerStats, normalizeActiveQuestCollection } from "./player-stats";
+
+describe("normalizeActiveQuestCollection", () => {
+  it("normalizes a keyed quest map into an array using the map key as the entry id", () => {
+    const quests = normalizeActiveQuestCollection({
+      "quest-rescue": {
+        name: "Rescue the Mayor",
+        objectives: [
+          { description: "Find the cell", status: "done" },
+          { text: "Open the gate" },
+        ],
+      },
+      "quest-loot": {
+        questEntryId: "loot-1",
+        name: "Loot the Vault",
+      },
+    });
+
+    expect(quests).toHaveLength(2);
+    const rescue = quests.find((quest) => quest.name === "Rescue the Mayor");
+    expect(rescue).toBeDefined();
+    // Named keyed entry derives its questEntryId from the quest name (no explicit id given).
+    expect(rescue?.questEntryId).toBe("Rescue the Mayor");
+    expect(rescue?.objectives).toEqual([
+      { text: "Find the cell", completed: true },
+      { text: "Open the gate", completed: false },
+    ]);
+
+    const loot = quests.find((quest) => quest.name === "Loot the Vault");
+    // Explicit questEntryId wins.
+    expect(loot?.questEntryId).toBe("loot-1");
+  });
+
+  it("uses the map key as the quest name when a keyed entry has no name", () => {
+    const quests = normalizeActiveQuestCollection({
+      "Find the Relic": { objectives: [{ text: "search ruins" }] },
+    });
+    expect(quests).toHaveLength(1);
+    // fallbackName (the map key) fills in both the name and the derived questEntryId.
+    expect(quests[0]?.name).toBe("Find the Relic");
+    expect(quests[0]?.questEntryId).toBe("Find the Relic");
+    expect(quests[0]?.objectives).toEqual([{ text: "search ruins", completed: false }]);
+  });
+
+  it("flattens grouped containers and wrapper collections", () => {
+    const grouped = normalizeActiveQuestCollection({
+      groups: [
+        { quests: [{ name: "Quest A" }, { name: "Quest B" }] },
+        { quests: [{ name: "Quest C" }] },
+      ],
+    });
+    expect(grouped.map((quest) => quest.name)).toEqual(["Quest A", "Quest B", "Quest C"]);
+
+    const items = normalizeActiveQuestCollection({ items: [{ name: "Quest D" }] });
+    expect(items.map((quest) => quest.name)).toEqual(["Quest D"]);
+
+    const wrapped = normalizeActiveQuestCollection({ activeQuests: [{ name: "Quest E" }] });
+    expect(wrapped.map((quest) => quest.name)).toEqual(["Quest E"]);
+  });
+
+  it("normalizes object-shaped and nested objectives", () => {
+    const [quest] = normalizeActiveQuestCollection([
+      {
+        name: "Investigate",
+        objectives: [{ description: "Search the desk", status: "done" }, { text: "Read the letter" }],
+      },
+    ]);
+    expect(quest?.objectives).toEqual([
+      { text: "Search the desk", completed: true },
+      { text: "Read the letter", completed: false },
+    ]);
+  });
+
+  it("returns an empty array for non-collection / null values", () => {
+    expect(normalizeActiveQuestCollection(null)).toEqual([]);
+    expect(normalizeActiveQuestCollection(undefined)).toEqual([]);
+    expect(normalizeActiveQuestCollection(42)).toEqual([]);
+  });
+
+  it("recovers nested objectives carried under a wrapper key during quest updates", () => {
+    // collectQuestObjectives (used by quest updates) digs through nested objective wrappers.
+    const { playerStats } = applyQuestUpdatesToPlayerStats(
+      { activeQuests: [] },
+      [
+        {
+          action: "create",
+          questName: "Nested",
+          objectives: { tasks: [{ text: "Step one" }, { description: "Step two", status: "completed" }] },
+        },
+      ],
+    );
+    const quest = playerStats.activeQuests.find((entry) => entry.name === "Nested");
+    expect(quest?.objectives).toEqual([
+      { text: "Step one", completed: false },
+      { text: "Step two", completed: true },
+    ]);
+  });
+});
+
+describe("applyQuestUpdatesToPlayerStats", () => {
+  it("auto-removes a completed quest whose objectives are all done (or empty)", () => {
+    const { playerStats, changed } = applyQuestUpdatesToPlayerStats(
+      {
+        activeQuests: [
+          { questEntryId: "q1", name: "Finish me", objectives: [{ text: "do it", completed: true }] },
+        ],
+      },
+      [{ action: "complete", questName: "q1" }],
+    );
+    expect(changed).toBe(true);
+    expect(playerStats.activeQuests).toHaveLength(0);
+  });
+
+  it("keeps a completed quest that still has an incomplete objective", () => {
+    const { playerStats } = applyQuestUpdatesToPlayerStats(
+      {
+        activeQuests: [
+          {
+            questEntryId: "q1",
+            name: "Half done",
+            objectives: [
+              { text: "a", completed: true },
+              { text: "b", completed: false },
+            ],
+          },
+        ],
+      },
+      [{ action: "complete", questName: "q1" }],
+    );
+    expect(playerStats.activeQuests).toHaveLength(1);
+    expect(playerStats.activeQuests[0]?.completed).toBe(true);
+  });
+
+  it("matches by questEntryId and by name, and accepts string action aliases", () => {
+    // Match by questEntryId.
+    const byId = applyQuestUpdatesToPlayerStats(
+      { activeQuests: [{ questEntryId: "qid", name: "Quest Display Name" }] },
+      [{ action: "update", questName: "qid", objectives: [{ text: "new objective" }] }],
+    );
+    expect(byId.playerStats.activeQuests[0]?.objectives).toEqual([{ text: "new objective", completed: false }]);
+
+    // Match by name.
+    const byName = applyQuestUpdatesToPlayerStats(
+      { activeQuests: [{ questEntryId: "qid", name: "Quest Display Name" }] },
+      [{ action: "update", questName: "Quest Display Name", objectives: [{ text: "named" }] }],
+    );
+    expect(byName.playerStats.activeQuests[0]?.objectives).toEqual([{ text: "named", completed: false }]);
+
+    // "completed" alias -> complete (and auto-remove because objectives empty).
+    const completedAlias = applyQuestUpdatesToPlayerStats(
+      { activeQuests: [{ questEntryId: "qid", name: "Done" }] },
+      [{ action: "completed", questName: "qid" }],
+    );
+    expect(completedAlias.playerStats.activeQuests).toHaveLength(0);
+    expect(completedAlias.changed).toBe(true);
+
+    // "failed" alias -> fail (removes the quest).
+    const failedAlias = applyQuestUpdatesToPlayerStats(
+      { activeQuests: [{ questEntryId: "qid", name: "Doomed" }] },
+      [{ action: "failed", questName: "qid" }],
+    );
+    expect(failedAlias.playerStats.activeQuests).toHaveLength(0);
+    expect(failedAlias.changed).toBe(true);
+
+    // create when no match exists.
+    const created = applyQuestUpdatesToPlayerStats(
+      { activeQuests: [] },
+      [{ action: "create", questName: "Brand New", objectives: [{ text: "begin" }] }],
+    );
+    expect(created.playerStats.activeQuests).toHaveLength(1);
+    expect(created.playerStats.activeQuests[0]).toMatchObject({
+      questEntryId: "Brand New",
+      name: "Brand New",
+      completed: false,
+      objectives: [{ text: "begin", completed: false }],
+    });
+  });
+
+  it("normalizes a keyed quest collection before merging updates (matched by name)", () => {
+    const { playerStats, changed } = applyQuestUpdatesToPlayerStats(
+      {
+        activeQuests: {
+          "quest-1": { name: "Keyed Quest", objectives: [{ text: "step" }] },
+        },
+      },
+      [{ action: "update", questName: "Keyed Quest", objectives: [{ text: "updated step" }] }],
+    );
+    // The non-array keyed map was normalized to a single quest, then matched by name and updated.
+    expect(changed).toBe(true);
+    expect(playerStats.activeQuests).toHaveLength(1);
+    expect(playerStats.activeQuests[0]?.name).toBe("Keyed Quest");
+    expect(playerStats.activeQuests[0]?.objectives).toEqual([{ text: "updated step", completed: false }]);
+  });
+
+  it("matches updates against a nameless keyed quest by the map key (questEntryId fallback)", () => {
+    const { playerStats } = applyQuestUpdatesToPlayerStats(
+      {
+        activeQuests: {
+          "quest-key": { objectives: [{ text: "step" }] },
+        },
+      },
+      [{ action: "update", questName: "quest-key", objectives: [{ text: "updated step" }] }],
+    );
+    // Nameless keyed entry takes the map key as both name and questEntryId, so the update matches.
+    expect(playerStats.activeQuests).toHaveLength(1);
+    expect(playerStats.activeQuests[0]?.questEntryId).toBe("quest-key");
+    expect(playerStats.activeQuests[0]?.objectives).toEqual([{ text: "updated step", completed: false }]);
+  });
+
+  it("reports changed=false for a no-op on already-array quests", () => {
+    const original = {
+      activeQuests: [
+        { questEntryId: "q1", name: "Stable", currentStage: 0, objectives: [], completed: false },
+      ],
+    };
+    const { changed } = applyQuestUpdatesToPlayerStats(original, []);
+    expect(changed).toBe(false);
+  });
+});

--- a/src/engine/shared/game-state/player-stats.ts
+++ b/src/engine/shared/game-state/player-stats.ts
@@ -53,9 +53,10 @@ export function parseQuest(value: unknown, fallbackName?: string): QuestProgress
   const name = readString(record.name).trim() || readString(record.questName).trim() || readString(fallbackName).trim();
   if (!name) return null;
   const questEntryId = readString(record.questEntryId).trim() || name;
-  const objectives = Array.isArray(record.objectives)
-    ? record.objectives.map(parseQuestObjective).filter((objective): objective is { text: string; completed: boolean } => !!objective)
-    : [];
+  // Route objectives through collectQuestObjectives so non-array wrappers
+  // (e.g. `{ tasks: [...] }`) and object-shaped objectives are recovered, the
+  // same way the quest-update path does, rather than dropped.
+  const objectives = record.objectives === undefined ? [] : collectQuestObjectives(record.objectives);
   return {
     questEntryId,
     name,
@@ -79,16 +80,26 @@ export function normalizeActiveQuestCollection(value: unknown, depth = 0): Quest
   }
   if (!isRecord(value)) return [];
 
-  for (const key of NESTED_QUEST_KEYS) {
-    if (value[key] !== undefined) {
-      return normalizeActiveQuestCollection(value[key], depth + 1);
-    }
-  }
+  // Aggregate quests across ALL nested wrapper keys, not just the first present
+  // one, so a container carrying several (e.g. both `quests` and `groups`) does
+  // not silently drop siblings, and a present-but-empty wrapper does not swallow
+  // keyed quests alongside it. Only treat the wrapper branch as taken when it
+  // actually yields quests; otherwise fall through to single-quest / keyed-entry
+  // parsing below.
+  const nested = NESTED_QUEST_KEYS.flatMap((key) =>
+    value[key] === undefined ? [] : normalizeActiveQuestCollection(value[key], depth + 1),
+  );
+  if (nested.length > 0) return nested;
 
   const single = parseQuest(value);
   if (single) return [single];
 
+  const nestedKeys = NESTED_QUEST_KEYS as readonly string[];
   return Object.entries(value).flatMap(([key, entry]) => {
+    // Wrapper keys were already handled by the aggregate above; skip them here
+    // so a present-but-empty wrapper (e.g. `quests: []`) is not misread as a
+    // keyed quest entry named after the wrapper key.
+    if (nestedKeys.includes(key)) return [];
     const quest = parseQuest(entry, key);
     return quest ? [quest] : normalizeActiveQuestCollection(entry, depth + 1);
   });

--- a/src/engine/shared/game-state/player-stats.ts
+++ b/src/engine/shared/game-state/player-stats.ts
@@ -1,0 +1,256 @@
+import type {
+  CharacterStat,
+  CustomTrackerField,
+  InventoryItem,
+  PlayerStats,
+  QuestProgress,
+  RPGAttributes,
+} from "../../contracts/types/game-state";
+import { boolish, isRecord, parseRecord, readNonNegativeInteger, readNumber, readString } from "../../generation/runtime-records";
+
+export type QuestObjective = QuestProgress["objectives"][number];
+export type QuestUpdateAction = "create" | "update" | "complete" | "fail";
+
+export interface NormalizedQuestUpdate {
+  action: QuestUpdateAction;
+  questName: string;
+  objectives?: QuestObjective[];
+}
+
+type RpgAttributeKey = keyof RPGAttributes;
+
+const RPG_ATTRIBUTE_KEYS: RpgAttributeKey[] = ["str", "dex", "con", "int", "wis", "cha"];
+
+/**
+ * Keys that wrap a nested collection of quests rather than a single quest. When an
+ * `activeQuests` value is a record carrying one of these, recurse into it instead of
+ * trying to read the wrapper itself as a quest.
+ */
+const NESTED_QUEST_KEYS = ["quests", "activeQuests", "groups", "items", "children"] as const;
+
+export function parseQuestObjective(value: unknown): { text: string; completed: boolean } | null {
+  if (typeof value === "string") {
+    const text = value.trim();
+    return text ? { text, completed: false } : null;
+  }
+  const record = parseRecord(value);
+  const text = firstString(record.text, record.description, record.objective, record.name, record.title);
+  if (!text) return null;
+  const status = readString(record.status ?? record.done).trim().toLowerCase();
+  return { text, completed: boolish(record.completed, status === "complete" || status === "completed" || status === "done") };
+}
+
+export function firstString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    const text = readString(value).trim();
+    if (text) return text;
+  }
+  return undefined;
+}
+
+export function parseQuest(value: unknown, fallbackName?: string): QuestProgress | null {
+  const record = parseRecord(value);
+  const name = readString(record.name).trim() || readString(record.questName).trim() || readString(fallbackName).trim();
+  if (!name) return null;
+  const questEntryId = readString(record.questEntryId).trim() || name;
+  const objectives = Array.isArray(record.objectives)
+    ? record.objectives.map(parseQuestObjective).filter((objective): objective is { text: string; completed: boolean } => !!objective)
+    : [];
+  return {
+    questEntryId,
+    name,
+    currentStage: Math.max(0, readNonNegativeInteger(record.currentStage, 0)),
+    objectives,
+    completed: boolish(record.completed, false),
+  };
+}
+
+/**
+ * Normalize an arbitrary `activeQuests` value into a flat `QuestProgress[]`.
+ *
+ * Restores legacy tolerance for non-array shapes that some imported saves and older
+ * agents produce: plain arrays, keyed quest maps (`{ questId: quest }`), grouped
+ * containers (`{ quests: [...] }`, `{ groups: [...] }`), and nested collections.
+ */
+export function normalizeActiveQuestCollection(value: unknown, depth = 0): QuestProgress[] {
+  if (value == null || depth > 5) return [];
+  if (Array.isArray(value)) {
+    return value.flatMap((entry) => normalizeActiveQuestCollection(entry, depth + 1));
+  }
+  if (!isRecord(value)) return [];
+
+  for (const key of NESTED_QUEST_KEYS) {
+    if (value[key] !== undefined) {
+      return normalizeActiveQuestCollection(value[key], depth + 1);
+    }
+  }
+
+  const single = parseQuest(value);
+  if (single) return [single];
+
+  return Object.entries(value).flatMap(([key, entry]) => {
+    const quest = parseQuest(entry, key);
+    return quest ? [quest] : normalizeActiveQuestCollection(entry, depth + 1);
+  });
+}
+
+export function parseStat(value: unknown): CharacterStat | null {
+  const record = parseRecord(value);
+  const name = readString(record.name).trim();
+  if (!name) return null;
+  const max = Math.max(1, readNumber(record.max, 100));
+  const valueNumber = Math.min(max, Math.max(0, readNumber(record.value, max)));
+  const color = readString(record.color).trim() || "#8b5cf6";
+  return { name, value: valueNumber, max, color };
+}
+
+export function parseInventoryItem(value: unknown): InventoryItem | null {
+  const record = parseRecord(value);
+  const name = readString(record.name).trim();
+  if (!name) return null;
+  return {
+    name,
+    description: readString(record.description).trim(),
+    quantity: Math.max(0, readNumber(record.quantity, 1)),
+    location: readString(record.location).trim() || "on_person",
+  };
+}
+
+export function parseCustomTrackerField(value: unknown): CustomTrackerField | null {
+  const record = parseRecord(value);
+  const name = readString(record.name).trim();
+  if (!name) return null;
+  return { name, value: readString(record.value).trim() };
+}
+
+function parseRpgAttributes(value: unknown): RPGAttributes | null {
+  const record = parseRecord(value);
+  if (!RPG_ATTRIBUTE_KEYS.some((key) => Object.prototype.hasOwnProperty.call(record, key))) return null;
+  return {
+    str: readNumber(record.str, 10),
+    dex: readNumber(record.dex, 10),
+    con: readNumber(record.con, 10),
+    int: readNumber(record.int, 10),
+    wis: readNumber(record.wis, 10),
+    cha: readNumber(record.cha, 10),
+  };
+}
+
+function parseSkills(value: unknown): Record<string, number> {
+  const record = parseRecord(value);
+  return Object.fromEntries(
+    Object.entries(record)
+      .map(([key, skillValue]) => [key.trim(), readNumber(skillValue, Number.NaN)] as const)
+      .filter(([key, skillValue]) => key.length > 0 && Number.isFinite(skillValue)),
+  );
+}
+
+export function clonePlayerStats(value: unknown): PlayerStats {
+  const record = parseRecord(value);
+  return {
+    stats: Array.isArray(record.stats) ? record.stats.map(parseStat).filter((stat): stat is CharacterStat => !!stat) : [],
+    attributes: parseRpgAttributes(record.attributes),
+    skills: parseSkills(record.skills),
+    inventory: Array.isArray(record.inventory)
+      ? record.inventory.map(parseInventoryItem).filter((item): item is InventoryItem => !!item)
+      : [],
+    activeQuests: normalizeActiveQuestCollection(record.activeQuests),
+    customTrackerFields: Array.isArray(record.customTrackerFields)
+      ? record.customTrackerFields
+          .map(parseCustomTrackerField)
+          .filter((field): field is CustomTrackerField => !!field)
+      : undefined,
+    status: readString(record.status),
+  };
+}
+
+export function normalizeQuestAction(value: unknown): QuestUpdateAction | null {
+  const normalized = readString(value).trim().toLowerCase();
+  if (normalized === "completed") return "complete";
+  if (normalized === "failed") return "fail";
+  return normalized === "create" || normalized === "update" || normalized === "complete" || normalized === "fail"
+    ? normalized
+    : null;
+}
+
+export function collectQuestObjectives(value: unknown, depth = 0): QuestObjective[] {
+  if (value == null || depth > 5) return [];
+  if (Array.isArray(value)) return value.flatMap((entry) => collectQuestObjectives(entry, depth + 1));
+  const direct = parseQuestObjective(value);
+  if (direct) return [direct];
+  const record = parseRecord(value);
+  if (!Object.keys(record).length) return [];
+  for (const key of ["objectives", "tasks", "steps", "items", "subtasks", "children", "goals"]) {
+    if (record[key] === undefined) continue;
+    const nested = collectQuestObjectives(record[key], depth + 1);
+    if (nested.length) return nested;
+  }
+  return Object.values(record).flatMap((entry) => collectQuestObjectives(entry, depth + 1));
+}
+
+export function normalizeQuestUpdate(value: unknown): NormalizedQuestUpdate | null {
+  const record = parseRecord(value);
+  const action = normalizeQuestAction(record.action);
+  const questName = firstString(record.questName, record.name, record.title, record.questEntryId);
+  if (!action || !questName) return null;
+  const objectives = record.objectives === undefined ? undefined : collectQuestObjectives(record.objectives);
+  return {
+    action,
+    questName,
+    ...(objectives !== undefined ? { objectives } : {}),
+  };
+}
+
+export function cloneQuest(quest: QuestProgress): QuestProgress {
+  return {
+    ...quest,
+    objectives: quest.objectives.map((objective) => ({ ...objective })),
+  };
+}
+
+export function applyQuestUpdatesToPlayerStats(
+  value: unknown,
+  updatesValue: unknown,
+): { playerStats: PlayerStats; changed: boolean } {
+  const updates = Array.isArray(updatesValue)
+    ? updatesValue.map(normalizeQuestUpdate).filter((update): update is NormalizedQuestUpdate => !!update)
+    : [];
+  const playerStats = clonePlayerStats(value);
+  const rawActiveQuestsJson = JSON.stringify(playerStats.activeQuests);
+  const quests = playerStats.activeQuests.map(cloneQuest);
+
+  for (const update of updates) {
+    let index = quests.findIndex((quest) => quest.questEntryId === update.questName);
+    if (index === -1) {
+      index = quests.findIndex((quest) => quest.name === update.questName);
+    }
+    if (update.action === "create" && index === -1) {
+      quests.push({
+        questEntryId: update.questName,
+        name: update.questName,
+        currentStage: 0,
+        objectives: update.objectives ?? [],
+        completed: false,
+      });
+    } else if (index !== -1) {
+      if (update.action === "update") {
+        if (update.objectives !== undefined) quests[index]!.objectives = update.objectives;
+      } else if (update.action === "complete") {
+        quests[index]!.completed = true;
+        if (update.objectives !== undefined) quests[index]!.objectives = update.objectives;
+      } else if (update.action === "fail") {
+        quests.splice(index, 1);
+      }
+    }
+  }
+
+  for (let index = quests.length - 1; index >= 0; index -= 1) {
+    const quest = quests[index]!;
+    if (quest.completed && (quest.objectives.length === 0 || quest.objectives.every((objective) => objective.completed))) {
+      quests.splice(index, 1);
+    }
+  }
+
+  playerStats.activeQuests = quests;
+  return { playerStats, changed: JSON.stringify(quests) !== rawActiveQuestsJson };
+}

--- a/src/engine/shared/game-state/player-stats.ts
+++ b/src/engine/shared/game-state/player-stats.ts
@@ -6,7 +6,14 @@ import type {
   QuestProgress,
   RPGAttributes,
 } from "../../contracts/types/game-state";
-import { boolish, isRecord, parseRecord, readNonNegativeInteger, readNumber, readString } from "../../generation/runtime-records";
+import {
+  boolish,
+  isRecord,
+  parseRecord,
+  readNonNegativeInteger,
+  readNumber,
+  readString,
+} from "../../generation/runtime-records";
 
 export type QuestObjective = QuestProgress["objectives"][number];
 export type QuestUpdateAction = "create" | "update" | "complete" | "fail";
@@ -36,8 +43,13 @@ export function parseQuestObjective(value: unknown): { text: string; completed: 
   const record = parseRecord(value);
   const text = firstString(record.text, record.description, record.objective, record.name, record.title);
   if (!text) return null;
-  const status = readString(record.status ?? record.done).trim().toLowerCase();
-  return { text, completed: boolish(record.completed, status === "complete" || status === "completed" || status === "done") };
+  const status = readString(record.status ?? record.done)
+    .trim()
+    .toLowerCase();
+  return {
+    text,
+    completed: boolish(record.completed, status === "complete" || status === "completed" || status === "done"),
+  };
 }
 
 export function firstString(...values: unknown[]): string | undefined {
@@ -159,7 +171,9 @@ function parseSkills(value: unknown): Record<string, number> {
 export function clonePlayerStats(value: unknown): PlayerStats {
   const record = parseRecord(value);
   return {
-    stats: Array.isArray(record.stats) ? record.stats.map(parseStat).filter((stat): stat is CharacterStat => !!stat) : [],
+    stats: Array.isArray(record.stats)
+      ? record.stats.map(parseStat).filter((stat): stat is CharacterStat => !!stat)
+      : [],
     attributes: parseRpgAttributes(record.attributes),
     skills: parseSkills(record.skills),
     inventory: Array.isArray(record.inventory)
@@ -167,9 +181,7 @@ export function clonePlayerStats(value: unknown): PlayerStats {
       : [],
     activeQuests: normalizeActiveQuestCollection(record.activeQuests),
     customTrackerFields: Array.isArray(record.customTrackerFields)
-      ? record.customTrackerFields
-          .map(parseCustomTrackerField)
-          .filter((field): field is CustomTrackerField => !!field)
+      ? record.customTrackerFields.map(parseCustomTrackerField).filter((field): field is CustomTrackerField => !!field)
       : undefined,
     status: readString(record.status),
   };
@@ -257,7 +269,10 @@ export function applyQuestUpdatesToPlayerStats(
 
   for (let index = quests.length - 1; index >= 0; index -= 1) {
     const quest = quests[index]!;
-    if (quest.completed && (quest.objectives.length === 0 || quest.objectives.every((objective) => objective.completed))) {
+    if (
+      quest.completed &&
+      (quest.objectives.length === 0 || quest.objectives.every((objective) => objective.completed))
+    ) {
       quests.splice(index, 1);
     }
   }

--- a/src/engine/shared/game-state/player-stats.ts
+++ b/src/engine/shared/game-state/player-stats.ts
@@ -60,9 +60,24 @@ export function firstString(...values: unknown[]): string | undefined {
   return undefined;
 }
 
+/** A keyed-map entry only earns the map key as its name when it actually looks
+ *  like a quest. Prevents an arbitrary non-quest record from being promoted to
+ *  a phantom quest named after its key (matches the legacy behavior). */
+function looksLikeQuestRecord(record: Record<string, unknown>): boolean {
+  return (
+    record.questEntryId !== undefined ||
+    record.objectives !== undefined ||
+    record.currentStage !== undefined ||
+    record.completed !== undefined
+  );
+}
+
 export function parseQuest(value: unknown, fallbackName?: string): QuestProgress | null {
   const record = parseRecord(value);
-  const name = readString(record.name).trim() || readString(record.questName).trim() || readString(fallbackName).trim();
+  let name = readString(record.name).trim() || readString(record.questName).trim();
+  if (!name && looksLikeQuestRecord(record)) {
+    name = readString(fallbackName).trim();
+  }
   if (!name) return null;
   const questEntryId = readString(record.questEntryId).trim() || name;
   // Route objectives through collectQuestObjectives so non-array wrappers

--- a/src/features/runtime/generation/hooks/use-generate.ts
+++ b/src/features/runtime/generation/hooks/use-generate.ts
@@ -45,6 +45,7 @@ import {
   type GenerationReplay,
 } from "../../../../engine/generation/generation-replay";
 import { readNonNegativeInteger } from "../../../../engine/generation/runtime-records";
+import { applyQuestUpdatesToPlayerStats } from "../../../../engine/shared/game-state/player-stats";
 import type { AgentDebugEntry } from "../../../../engine/contracts/types/agent";
 import type { IntegrationGateway } from "../../../../engine/capabilities/integrations";
 
@@ -580,45 +581,16 @@ async function applyBackgroundChoice(chatId: string, chosen: unknown) {
 }
 
 function applyQuestUpdates(rawData: unknown) {
-  const data = parseMaybeRecord(rawData);
-  const updates = Array.isArray(data.updates) ? data.updates.map(parseMaybeRecord) : [];
-  if (updates.length === 0) return;
-
   const current = useGameStateStore.getState().current;
-  const existingPlayerStats = parseMaybeRecord(current?.playerStats);
-  const quests = Array.isArray(existingPlayerStats.activeQuests)
-    ? [...existingPlayerStats.activeQuests.map(parseMaybeRecord)]
-    : [];
-
-  for (const update of updates) {
-    const questName = readString(update.questName).trim();
-    if (!questName) continue;
-    const action = readString(update.action, "update");
-    const index = quests.findIndex((quest) => readString(quest.name) === questName);
-    if (action === "create" && index === -1) {
-      quests.push({
-        questEntryId: questName,
-        name: questName,
-        currentStage: 0,
-        objectives: Array.isArray(update.objectives) ? update.objectives : [],
-        completed: false,
-      });
-    } else if (index !== -1) {
-      if (action === "fail") {
-        quests.splice(index, 1);
-      } else {
-        quests[index] = {
-          ...quests[index],
-          ...(Array.isArray(update.objectives) ? { objectives: update.objectives } : {}),
-          ...(action === "complete" ? { completed: true } : {}),
-        };
-      }
-    }
-  }
+  const { playerStats, changed } = applyQuestUpdatesToPlayerStats(
+    current?.playerStats,
+    parseMaybeRecord(rawData).updates,
+  );
+  if (!changed) return;
 
   useGameStateStore.getState().setGameState({
     ...(current ?? ({} as never)),
-    playerStats: { ...existingPlayerStats, activeQuests: quests },
+    playerStats,
   } as never);
 }
 


### PR DESCRIPTION
## Why this change

Two quest-merge code paths existed and neither restored the pre-rewrite tolerance for non-array `activeQuests` shapes (keyed quest maps, grouped containers, nested collections):

- The **engine tracker-snapshot** path (`tracker-snapshots.ts`) normalized objectives and auto-removed completed quests, but `clonePlayerStats` dropped any keyed/grouped `activeQuests` to `[]`.
- The **UI optimistic Quest Board** path (`use-generate.ts applyQuestUpdates`) was an entirely separate, simpler merge: it matched quests by `name` only, passed objectives through raw, did no completed-removal, and also dropped non-array shapes.

So legacy/imported saves silently lost quests, and the optimistic and persisted merges diverged.

## What changed

- New `src/engine/shared/game-state/player-stats.ts` (mode-neutral deterministic helper) owns player-stats normalization, including the new `normalizeActiveQuestCollection`: handles plain arrays, keyed quest maps (`{ questId: quest }`), grouped/wrapper containers (`{ quests | groups | items | activeQuests | children: [...] }`), and nested collections, depth-guarded.
- `tracker-snapshots.ts` and the UI Quest Board path now both call the same `applyQuestUpdatesToPlayerStats`, so optimistic and persisted merges are byte-identical (match by `questEntryId` then `name`, normalized objectives, completed-empty-objective removal).
- Consolidating the helper removed ~70 lines of player-stats parsing (`parseStat`/`parseInventoryItem`/`parseCustomTrackerField`/`clonePlayerStats`/…) that had been duplicated across the two files. Dependency direction stays one-way (`tracker-snapshots → player-stats`, `use-generate → player-stats`); no import cycle.

## Verification

- `pnpm check` passes (architecture + frontend tsc + cargo check + docs).
- New `player-stats.test.ts` (12 tests) covers keyed maps, grouped containers, object- and nested-shaped objectives, completed-empty-objective removal, create/update/fail matching by id and name, and the changed-flag semantics.
- Adjacent engine suites (`src/engine/generation`, `src/engine/shared`, 229 tests) green.

## Risk / behavior note

The UI optimistic path now matches by `questEntryId | name` (was name-only) and auto-removes completed-empty quests, matching the persisted path. This is the intended parity but is a visible delta: a completed quest that the optimistic UI previously kept on screen until the next storage refresh now disappears immediately. Worth a quick look in `pnpm tauri dev` against a real imported save before merge.

## Linked issue

Closes #1530.