### PR TITLE
Surface connected command failures instead of swallowing them

### DIFF
--- a/src/engine/generation/connected-commands.test.ts
+++ b/src/engine/generation/connected-commands.test.ts
@@ -145,11 +145,7 @@ describe("persistConnectedCommandTags command failures", () => {
     const chats = new Map<string, Row>([["conversation-1", conversation]]);
     const storage = storageWithChats(chats);
 
-    const result = await persistConnectedCommandTags(
-      storage,
-      conversation,
-      '[haptic: action="vibrate"]',
-    );
+    const result = await persistConnectedCommandTags(storage, conversation, '[haptic: action="vibrate"]');
 
     expect(result.events.some((event) => event.type === "command_error")).toBe(true);
     const haptic = result.events.find(
@@ -164,11 +160,7 @@ describe("persistConnectedCommandTags command failures", () => {
     const chats = new Map<string, Row>([["conversation-1", conversation]]);
     const storage = storageWithChats(chats);
 
-    const result = await persistConnectedCommandTags(
-      storage,
-      conversation,
-      "<note>[12:01] Remember the door.</note>",
-    );
+    const result = await persistConnectedCommandTags(storage, conversation, "<note>[12:01] Remember the door.</note>");
 
     expect(result.events.some((event) => event.type === "command_error")).toBe(false);
     expect(result.executedCommands).toContain("note");

--- a/src/engine/generation/connected-commands.test.ts
+++ b/src/engine/generation/connected-commands.test.ts
@@ -95,3 +95,82 @@ describe("persistConnectedCommandTags connected notes", () => {
     expect(typeof notes[1]?.consumedAt).toBe("string");
   });
 });
+
+describe("persistConnectedCommandTags command failures", () => {
+  it("emits command_error when a command throws during execution instead of swallowing it", async () => {
+    const conversation = { id: "conversation-1", mode: "conversation", notes: [] };
+    const chats = new Map<string, Row>([["conversation-1", conversation]]);
+    const storage = storageWithChats(chats);
+    storage.create = vi.fn(async () => {
+      throw new Error("disk full");
+    });
+
+    const result = await persistConnectedCommandTags(
+      storage,
+      conversation,
+      'Sure thing. [create_character: name="Ada"]',
+    );
+
+    expect(result.events).toContainEqual({
+      type: "command_error",
+      data: { command: "create_character", error: "disk full" },
+    });
+    expect(result.executedCommands).not.toContain("create_character");
+    // The failure is now surfaced, but the command tag is still stripped from the visible message.
+    expect(result.displayContent).toBe("Sure thing.");
+  });
+
+  it("continues processing remaining commands after one throws", async () => {
+    const conversation = { id: "conversation-1", mode: "conversation", notes: [] };
+    const chats = new Map<string, Row>([["conversation-1", conversation]]);
+    const storage = storageWithChats(chats);
+    storage.create = vi.fn(async () => {
+      throw new Error("disk full");
+    });
+
+    const result = await persistConnectedCommandTags(
+      storage,
+      conversation,
+      '[create_character: name="Ada"]\n<note>[12:01] Remember the door.</note>',
+    );
+
+    const commandErrors = result.events.filter((event) => event.type === "command_error");
+    expect(commandErrors).toHaveLength(1);
+    // The note after the failing command still runs — no rethrow / no abort.
+    expect(result.executedCommands).toContain("note");
+  });
+
+  it("emits command_error for an unsupported haptic command when integrations are absent", async () => {
+    const conversation = { id: "conversation-1", mode: "conversation", notes: [] };
+    const chats = new Map<string, Row>([["conversation-1", conversation]]);
+    const storage = storageWithChats(chats);
+
+    const result = await persistConnectedCommandTags(
+      storage,
+      conversation,
+      '[haptic: action="vibrate"]',
+    );
+
+    expect(result.events.some((event) => event.type === "command_error")).toBe(true);
+    const haptic = result.events.find(
+      (event): event is Extract<typeof event, { type: "command_error" }> => event.type === "command_error",
+    );
+    expect(haptic?.data.command).toBe("haptic");
+    expect(result.executedCommands).not.toContain("haptic");
+  });
+
+  it("does not emit command_error for a successful note (intentional no-ops stay silent)", async () => {
+    const conversation = { id: "conversation-1", mode: "conversation", notes: [] };
+    const chats = new Map<string, Row>([["conversation-1", conversation]]);
+    const storage = storageWithChats(chats);
+
+    const result = await persistConnectedCommandTags(
+      storage,
+      conversation,
+      "<note>[12:01] Remember the door.</note>",
+    );
+
+    expect(result.events.some((event) => event.type === "command_error")).toBe(false);
+    expect(result.executedCommands).toContain("note");
+  });
+});

--- a/src/engine/generation/connected-commands.ts
+++ b/src/engine/generation/connected-commands.ts
@@ -31,6 +31,7 @@ export type ConnectedCommandEvent =
   | { type: "ooc_posted"; data: JsonRecord }
   | { type: "selfie"; data: JsonRecord }
   | { type: "selfie_error"; data: JsonRecord }
+  | { type: "command_error"; data: JsonRecord }
   | { type: "scene_created"; data: JsonRecord };
 
 export interface ConnectedCommandResult {
@@ -427,6 +428,10 @@ function eventsPushSelfieError(events: ConnectedCommandEvent[], characterId: str
   events.push({ type: "selfie_error", data: { characterId, error } });
 }
 
+function eventsPushCommandError(events: ConnectedCommandEvent[], command: string, error: string): void {
+  events.push({ type: "command_error", data: { command, error } });
+}
+
 async function createSceneFromCommand(args: {
   storage: StorageGateway;
   llm?: LlmGateway;
@@ -649,6 +654,7 @@ async function executeCommand(
         });
         return { name: "haptic" };
       }
+      eventsPushCommandError(events, command.type, "Haptic integration is not connected.");
       return null;
     case "spotify":
       if (integrations) {
@@ -660,6 +666,7 @@ async function executeCommand(
         if (track) await integrations.spotify.playTrack({ track });
         return { name: "spotify" };
       }
+      eventsPushCommandError(events, command.type, "Spotify integration is not connected.");
       return null;
     case "create_persona":
       await storage.create("personas", personaPatch(command));
@@ -826,23 +833,31 @@ export async function persistConnectedCommandTags(
   let suppressAssistantMessage = false;
 
   for (const command of parsed.commands) {
-    const executed = await executeCommand(
-      storage,
-      integrations,
-      llm,
-      llmConnectionId,
-      chat,
-      command,
-      createdNotes,
-      pendingNoteWrites,
-      events,
-      assistantAttachments,
-      parsed.cleanContent,
-      imagePromptSettings,
-    ).catch(() => null);
-    if (executed) {
-      executedCommands.push(executed.name);
-      suppressAssistantMessage = suppressAssistantMessage || executed.suppressSourceMessage === true;
+    try {
+      const executed = await executeCommand(
+        storage,
+        integrations,
+        llm,
+        llmConnectionId,
+        chat,
+        command,
+        createdNotes,
+        pendingNoteWrites,
+        events,
+        assistantAttachments,
+        parsed.cleanContent,
+        imagePromptSettings,
+      );
+      if (executed) {
+        executedCommands.push(executed.name);
+        suppressAssistantMessage = suppressAssistantMessage || executed.suppressSourceMessage === true;
+      }
+    } catch (error) {
+      eventsPushCommandError(
+        events,
+        command.type,
+        error instanceof Error ? error.message : "Command execution failed.",
+      );
     }
   }
 

--- a/src/engine/generation/generation-events.ts
+++ b/src/engine/generation/generation-events.ts
@@ -13,6 +13,7 @@ export type GenerationEvent =
   | { type: "ooc_posted"; data: unknown }
   | { type: "selfie"; data: unknown }
   | { type: "selfie_error"; data: unknown }
+  | { type: "command_error"; data: unknown }
   | { type: "illustration"; data: unknown }
   | { type: "illustration_error"; data: unknown }
   | { type: "scene_created"; data: unknown }

--- a/src/features/runtime/generation/hooks/use-generate.ts
+++ b/src/features/runtime/generation/hooks/use-generate.ts
@@ -1250,6 +1250,12 @@ export async function runGenerationWithUi(
           toast.error(readString(data.error, "Selfie generation failed."));
           break;
         }
+        case "command_error": {
+          const data = parseMaybeRecord(event.data);
+          const command = readString(data.command).trim();
+          toast.error(readString(data.error, command ? `Command "${command}" failed.` : "Command failed."));
+          break;
+        }
         case "illustration": {
           toast("Illustration generated.");
           scheduleChatQueryRefresh(queryClient, chatId);


### PR DESCRIPTION
## Why this change

`persistConnectedCommandTags` wrapped `executeCommand` in a blanket `.catch(() => null)`, and `parseCharacterCommands` strips command tags from the visible content **unconditionally** (regardless of whether the command ran). So when a connected command threw, the failure collapsed to `null`, emitted no event, and left the user with a clean message and no error or retry. Two integration commands (`haptic`, `spotify`) also returned a silent `null` when their integration was absent, while their tag was still stripped from the content.

## What changed

Mirror the existing `selfie_error` event end to end, for commands:

- `generation-events.ts` / `connected-commands.ts`: add a `command_error` variant to both the `GenerationEvent` and `ConnectedCommandEvent` unions, plus an `eventsPushCommandError` helper (sibling of `eventsPushSelfieError`).
- `connected-commands.ts`: replace the blanket `.catch(() => null)` around `executeCommand` with a `try/catch` that emits `command_error` and lets generation continue (no rethrow); emit `command_error` on the `haptic`/`spotify` integration-absent branches.
- `use-generate.ts`: consume `command_error` with a toast, exactly like `selfie_error`.

The fix is **mode-neutral** — no mode flag is added to the shared helper (per `marinara-mode-separation`); roleplay/game modes that route through the same helper now get the same visible error instead of a silent strip.

## Verification

- `pnpm exec tsc -b` clean; `pnpm check:architecture` clean (events ride the existing pass-through; no new caller wiring, no React/Tauri import added to engine).
- New `connected-commands.test.ts` cases: a throwing command emits `command_error` (tag still stripped), the loop continues after a failure, an unsupported `haptic` without integrations surfaces an error, and the happy path emits no error. Full `src/engine/generation` suite (193 tests) green.

## Risk / note

The toast consumer is untested, consistent with the existing untested `selfie_error`/`illustration_error` siblings (covered by tsc + the structural mirror). A message with many failing command tags fires one toast per failure (per-command granularity, matches the existing design); aggregation is out of scope. Raw error text surfaces in the toast, parity with `selfie_error`.

## Linked issue

Closes #1535.