### PR TITLE
Generate the illustration on the Gallery Illustrate retry path

### DIFF
--- a/src/engine/generation/start-generation.test.ts
+++ b/src/engine/generation/start-generation.test.ts
@@ -2255,7 +2255,7 @@ describe("retryGenerationAgents lorebook keeper backfill", () => {
       initialMessages: messages,
     });
 
-    const results = await retryGenerationAgents(deps, {
+    const { results } = await retryGenerationAgents(deps, {
       chatId: "chat-1",
       agentTypes: ["lorebook-keeper"],
       options: { lorebookKeeperBackfill: true },
@@ -2306,7 +2306,7 @@ describe("retryGenerationAgents custom agent activation", () => {
       ],
     });
 
-    const results = await retryGenerationAgents(deps, {
+    const { results } = await retryGenerationAgents(deps, {
       chatId: "chat-1",
       agentTypes: ["custom-scene-scout"],
     });
@@ -2326,7 +2326,7 @@ describe("retryGenerationAgents custom agent activation", () => {
       ],
     });
 
-    const results = await retryGenerationAgents(deps, {
+    const { results } = await retryGenerationAgents(deps, {
       chatId: "chat-1",
       agentTypes: ["custom-scene-scout"],
       options: { bypassActivation: true },
@@ -2339,5 +2339,134 @@ describe("retryGenerationAgents custom agent activation", () => {
       success: true,
     });
     expect(streamedRequests).toHaveLength(1);
+  });
+});
+
+describe("retryGenerationAgents illustrator", () => {
+  const illustratorAgent = (settings: Record<string, unknown>) => ({
+    id: "illustrator-agent",
+    type: "illustrator",
+    name: "Illustrator",
+    enabled: true,
+    phase: "post_processing",
+    connectionId: null,
+    model: "agent-model",
+    promptTemplate: "Return JSON.",
+    settings: { runInterval: 1, ...settings },
+  });
+
+  const illustratorResponse = JSON.stringify({
+    shouldGenerate: true,
+    reason: "Manual illustrate marker",
+    prompt: "A11_MANUAL_ILLUSTRATE_PROMPT_MARKER",
+  });
+
+  it("generates an illustration and emits an illustration event when an image connection is configured", async () => {
+    const imageRequests: Record<string, unknown>[] = [];
+    const imageGenerate: IntegrationGateway["image"]["generate"] = async <T = unknown>(
+      input: Record<string, unknown>,
+    ): Promise<T> => {
+      imageRequests.push(input);
+      return {
+        base64: "generated-image",
+        mimeType: "image/png",
+        provider: "test-image-provider",
+        model: "test-image-model",
+      } as T;
+    };
+    const { deps, patchChatMessageExtra } = generationDepsForChat({
+      chatPatch: { mode: "roleplay" },
+      chatMetadata: { enableAgents: true },
+      agents: [illustratorAgent({ imageConnectionId: "image-conn" })],
+      streamResponses: [illustratorResponse],
+      integrations: { image: { generate: imageGenerate } },
+    });
+
+    const { results, events } = await retryGenerationAgents(deps, {
+      chatId: "chat-1",
+      agentTypes: ["illustrator"],
+      options: { bypassActivation: true, forMessageId: "assistant-1" },
+    });
+
+    expect(imageRequests).toHaveLength(1);
+    expect(results.some((result) => result.agentType === "illustrator" && result.type === "image_prompt")).toBe(true);
+    expect(deps.storage.create).toHaveBeenCalledWith(
+      "gallery",
+      expect.objectContaining({ chatId: "chat-1", kind: "illustration" }),
+    );
+    expect(patchChatMessageExtra).toHaveBeenCalledWith(
+      "assistant-1",
+      expect.objectContaining({
+        attachments: [expect.objectContaining({ type: "image", galleryId: "gallery-1" })],
+      }),
+    );
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "illustration", data: expect.objectContaining({ galleryId: "gallery-1" }) }),
+      ]),
+    );
+  });
+
+  it("emits an illustration_error and creates no gallery image when no image connection is configured", async () => {
+    const imageGenerate = vi.fn();
+    const { deps, patchChatMessageExtra } = generationDepsForChat({
+      chatPatch: { mode: "roleplay" },
+      chatMetadata: { enableAgents: true },
+      agents: [illustratorAgent({})],
+      streamResponses: [illustratorResponse],
+      integrations: { image: { generate: imageGenerate as unknown as IntegrationGateway["image"]["generate"] } },
+    });
+
+    const { events } = await retryGenerationAgents(deps, {
+      chatId: "chat-1",
+      agentTypes: ["illustrator"],
+      options: { bypassActivation: true, forMessageId: "assistant-1" },
+    });
+
+    expect(imageGenerate).not.toHaveBeenCalled();
+    expect(deps.storage.create).not.toHaveBeenCalledWith("gallery", expect.anything());
+    expect(patchChatMessageExtra).not.toHaveBeenCalledWith(
+      "assistant-1",
+      expect.objectContaining({ attachments: expect.anything() }),
+    );
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "illustration_error",
+          data: expect.objectContaining({
+            error: "No image generation connection configured for the Illustrator agent.",
+          }),
+        }),
+      ]),
+    );
+  });
+
+  it("returns the agent result with no illustration events for a non-illustrator retry", async () => {
+    const { deps } = generationDepsForChat({
+      chatMetadata: { enableAgents: true },
+      agents: [
+        {
+          id: "scene-scout",
+          type: "custom-scene-scout",
+          name: "Scene Scout",
+          enabled: true,
+          phase: "pre_generation",
+          connectionId: null,
+          model: "agent-model",
+          promptTemplate: "Watch the scene.",
+          settings: { resultType: "context_injection" },
+        },
+      ],
+      streamResponses: ["Scene note."],
+    });
+
+    const { results, events } = await retryGenerationAgents(deps, {
+      chatId: "chat-1",
+      agentTypes: ["custom-scene-scout"],
+      options: { bypassActivation: true, forMessageId: "assistant-1" },
+    });
+
+    expect(results.some((result) => result.agentType === "custom-scene-scout")).toBe(true);
+    expect(events).toEqual([]);
   });
 });

--- a/src/engine/generation/start-generation.test.ts
+++ b/src/engine/generation/start-generation.test.ts
@@ -2407,6 +2407,44 @@ describe("retryGenerationAgents illustrator", () => {
     );
   });
 
+  it("generates an illustration via the latest-assistant fallback when no forMessageId is passed", async () => {
+    // The real Illustrate button calls retryAgents(chatId, ["illustrator"]) with
+    // no options, so the target resolves via targetAssistantMessage's
+    // latest-assistant branch rather than forMessageId.
+    const imageRequests: Record<string, unknown>[] = [];
+    const imageGenerate: IntegrationGateway["image"]["generate"] = async <T = unknown>(
+      input: Record<string, unknown>,
+    ): Promise<T> => {
+      imageRequests.push(input);
+      return {
+        base64: "generated-image",
+        mimeType: "image/png",
+        provider: "test-image-provider",
+        model: "test-image-model",
+      } as T;
+    };
+    const { deps } = generationDepsForChat({
+      chatPatch: { mode: "roleplay" },
+      chatMetadata: { enableAgents: true },
+      agents: [illustratorAgent({ imageConnectionId: "image-conn" })],
+      streamResponses: [illustratorResponse],
+      integrations: { image: { generate: imageGenerate } },
+    });
+
+    const { events } = await retryGenerationAgents(deps, {
+      chatId: "chat-1",
+      agentTypes: ["illustrator"],
+      options: { bypassActivation: true },
+    });
+
+    expect(imageRequests).toHaveLength(1);
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "illustration", data: expect.objectContaining({ galleryId: "gallery-1" }) }),
+      ]),
+    );
+  });
+
   it("emits an illustration_error and creates no gallery image when no image connection is configured", async () => {
     const imageGenerate = vi.fn();
     const { deps, patchChatMessageExtra } = generationDepsForChat({

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -2053,7 +2053,10 @@ export async function retryGenerationAgents(
   const connection = await resolveGenerationConnection(deps.storage, chat, input);
   const storedMessages = await loadChatMessages(deps.storage, chatId);
   if (isLorebookKeeperBackfill(input)) {
-    return { results: await runLorebookKeeperBackfill(deps, input, { chat, connection, storedMessages, signal }), events: [] };
+    return {
+      results: await runLorebookKeeperBackfill(deps, input, { chat, connection, storedMessages, signal }),
+      events: [],
+    };
   }
   const target = targetAssistantMessage(storedMessages, input.options);
   return runGenerationAgentsForTarget({ deps, input, chat, connection, storedMessages, target, agentTypes, signal });

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -120,6 +120,7 @@ export interface RetryAgentsInput extends JsonRecord {
   connectionId?: string | null;
   agentTypes?: string[];
   hideAutomatedSummarySourceMessages?: boolean;
+  imagePromptSettings?: StartGenerationInput["imagePromptSettings"];
   options?: Record<string, unknown>;
 }
 
@@ -1904,7 +1905,7 @@ async function runGenerationAgentsForTarget(args: {
   target: JsonRecord | null;
   agentTypes: Set<string>;
   signal?: AbortSignal;
-}): Promise<AgentResult[]> {
+}): Promise<{ results: AgentResult[]; events: GenerationEvent[] }> {
   const { deps, input, chat, connection, storedMessages, target, agentTypes, signal } = args;
   const chatId = readString(input.chatId).trim();
   const targetTrackerTarget = trackerSnapshotTargetFromMessage(target);
@@ -1972,7 +1973,26 @@ async function runGenerationAgentsForTarget(args: {
   }
   await persistSecretPlotAgentMemorySafely(deps.storage, chatId, finalResults);
   await persistAgentResults(deps.storage, chatId, target ? readString(target.id) || null : null, finalResults);
-  return finalResults;
+
+  const events: GenerationEvent[] = [];
+  const hasIllustrationRequest = finalResults.some((result) => illustratorPromptData(result) !== null);
+  if (target && hasIllustrationRequest) {
+    const illustration = await generateIllustrationAttachments({
+      deps,
+      chat: chatForAgents,
+      results: finalResults,
+      imagePromptSettings: input.imagePromptSettings,
+      signal,
+    });
+    events.push(...illustration.events);
+    await appendSavedMessageAttachments({
+      storage: deps.storage,
+      saved: target,
+      attachments: illustration.attachments,
+    });
+  }
+
+  return { results: finalResults, events };
 }
 
 async function runLorebookKeeperBackfill(
@@ -2000,16 +2020,18 @@ async function runLorebookKeeperBackfill(
 
   for (const target of targets) {
     allResults.push(
-      ...(await runGenerationAgentsForTarget({
-        deps,
-        input,
-        chat: args.chat,
-        connection: args.connection,
-        storedMessages,
-        target: target.message,
-        agentTypes,
-        signal: args.signal,
-      })),
+      ...(
+        await runGenerationAgentsForTarget({
+          deps,
+          input,
+          chat: args.chat,
+          connection: args.connection,
+          storedMessages,
+          target: target.message,
+          agentTypes,
+          signal: args.signal,
+        })
+      ).results,
     );
   }
 
@@ -2020,7 +2042,7 @@ export async function retryGenerationAgents(
   deps: GenerationEngineDeps,
   input: RetryAgentsInput,
   signal?: AbortSignal,
-): Promise<AgentResult[]> {
+): Promise<{ results: AgentResult[]; events: GenerationEvent[] }> {
   const chatId = readString(input.chatId).trim();
   if (!chatId) throw new Error("chatId is required");
   const agentTypes = Array.isArray(input.agentTypes)
@@ -2031,7 +2053,7 @@ export async function retryGenerationAgents(
   const connection = await resolveGenerationConnection(deps.storage, chat, input);
   const storedMessages = await loadChatMessages(deps.storage, chatId);
   if (isLorebookKeeperBackfill(input)) {
-    return runLorebookKeeperBackfill(deps, input, { chat, connection, storedMessages, signal });
+    return { results: await runLorebookKeeperBackfill(deps, input, { chat, connection, storedMessages, signal }), events: [] };
   }
   const target = targetAssistantMessage(storedMessages, input.options);
   return runGenerationAgentsForTarget({ deps, input, chat, connection, storedMessages, target, agentTypes, signal });

--- a/src/features/runtime/generation/hooks/use-generate.ts
+++ b/src/features/runtime/generation/hooks/use-generate.ts
@@ -1425,12 +1425,16 @@ export function useGenerate() {
           // Full retry: clear everything; the result loop repopulates anything still failing.
           agentStore.clearFailedAgentTypes();
         }
-        const results = await retryGenerationAgents(
+        const { results, events } = await retryGenerationAgents(
           { storage: storageApi, llm: llmApi, integrations: integrationGateway, visuals: visualAssetsApi },
           {
             chatId,
             agentTypes,
             hideAutomatedSummarySourceMessages: useUIStore.getState().summaryPopoverSettings.hideSummarizedMessages,
+            imagePromptSettings: {
+              includeAppearances: useUIStore.getState().imagePromptIncludeAppearances,
+              format: useUIStore.getState().imagePromptFormat,
+            },
             options: { ...(options ?? {}), bypassActivation: options?.bypassActivation ?? true },
           },
         );
@@ -1453,6 +1457,18 @@ export function useGenerate() {
         }
         if (failedRetries.length > 0) {
           toast.error(formatAgentFailuresToast(failedRetries), { duration: 10_000 });
+        }
+        for (const event of events) {
+          if (event.type === "illustration") {
+            toast("Illustration generated.");
+            scheduleChatQueryRefresh(queryClient, chatId);
+            runDeferredGenerationWork("gallery refresh", () =>
+              queryClient.invalidateQueries({ queryKey: ["gallery", "images", chatId] }),
+            );
+          } else if (event.type === "illustration_error") {
+            const data = parseMaybeRecord(event.data);
+            toast.error(readString(data.error, "Illustration generation failed."));
+          }
         }
         runDeferredGenerationWork("agent retry refresh", async () => {
           await refreshGameStateFromStorage(chatId);

--- a/src/features/runtime/generation/hooks/use-generate.ts
+++ b/src/features/runtime/generation/hooks/use-generate.ts
@@ -1461,7 +1461,8 @@ export function useGenerate() {
         for (const event of events) {
           if (event.type === "illustration") {
             toast("Illustration generated.");
-            scheduleChatQueryRefresh(queryClient, chatId);
+            // The chat-query refresh is fired unconditionally after this loop;
+            // here we only need the illustration-specific gallery invalidate.
             runDeferredGenerationWork("gallery refresh", () =>
               queryClient.invalidateQueries({ queryKey: ["gallery", "images", chatId] }),
             );


### PR DESCRIPTION
## Why this change

The Gallery "Illustrate" button routes through `retryAgents → retryGenerationAgents → runGenerationAgentsForTarget`, which ran the illustrator agent and persisted its `image_prompt` result but **never called `generateIllustrationAttachments`**. Only the normal `startGeneration` path did. So a successful illustrator prompt on the retry path was a silent no-op: the agent run was recorded, but no image was generated, no gallery row was written, no attachment was added, and no error surfaced.

## What changed

- `start-generation.ts`: `runGenerationAgentsForTarget` now runs the existing `generateIllustrationAttachments` helper when the target message has an illustrator prompt, appends its attachments via the existing `appendSavedMessageAttachments`, and surfaces its `illustration` / `illustration_error` events. `runGenerationAgentsForTarget` and `retryGenerationAgents` return `{ results, events }` instead of `AgentResult[]`; the internal lorebook-keeper-backfill caller reads `.results`. `RetryAgentsInput` gains `imagePromptSettings`.
- `use-generate.ts`: the `retryAgents` consumer destructures `{ results, events }`, threads `imagePromptSettings` (matching the `startGeneration` call site), and handles the `illustration` / `illustration_error` events identically to the streaming switch (toast + `["gallery","images",chatId]` invalidation).
- The reused helper and its error text ("No image generation connection configured for the Illustrator agent.") are unchanged; no helper duplication.

Callers of the changed return shape, all updated: `use-generate.ts` (production), the internal `runLorebookKeeperBackfill`, and the existing `retryGenerationAgents` test assertions.

## Verification

- `pnpm exec tsc -b` clean; `pnpm check:architecture` clean (events flow out as plain `GenerationEvent` data; no React/Tauri import added to engine).
- New engine tests on the retry path: a successful illustrator result invokes image generation + writes the gallery row + patches the attachment + emits `illustration`; a missing connection emits `illustration_error`; a non-illustrator retry returns results with no events. `start-generation.test.ts` (56 tests) and the full `src/engine/generation` suite (192 tests) green.

## Manual

The user-visible Gallery Illustrate flow runs through real `invoke()` (image-gen provider + gallery storage), so a `pnpm tauri dev` pass is the UI-level confirmation. The Illustrate button passes no `AbortSignal` on this path, so a slow provider can't be cancelled mid-illustration (pre-existing retry behavior, not changed here).

## Linked issue

Closes #1514.