### PR TITLE
Project remaining useCharacters list payload

### DIFF
--- a/src/features/catalog/characters/hooks/use-characters.test.ts
+++ b/src/features/catalog/characters/hooks/use-characters.test.ts
@@ -1,7 +1,27 @@
-import { QueryClient } from "@tanstack/react-query";
-import { describe, expect, it } from "vitest";
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { updateCharacterSchema } from "../../../../engine/contracts/schemas/character.schema";
-import { cacheCharacterListRecordFromResult, characterKeys, removeCachedCharacterRecord } from "./use-characters";
+import { storageApi } from "../../../../shared/api/storage-api";
+import {
+  cacheCharacterListRecordFromResult,
+  characterKeys,
+  removeCachedCharacterRecord,
+  useCharacters,
+} from "./use-characters";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock("../../../../shared/api/storage-api", () => ({
+  storageApi: {
+    list: vi.fn(),
+  },
+}));
+
+const storageListMock = vi.mocked(storageApi.list);
 
 function characterRecord(id: string, name: string) {
   return {
@@ -11,6 +31,55 @@ function characterRecord(id: string, name: string) {
     comment: null,
   };
 }
+
+function UseCharactersProbe() {
+  useCharacters(true);
+  return null;
+}
+
+describe("character list query", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+      },
+    });
+    storageListMock.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    queryClient.clear();
+    storageListMock.mockReset();
+  });
+
+  it("projects full character list reads without embedded avatar payloads", async () => {
+    await act(async () => {
+      root.render(
+        createElement(QueryClientProvider, {
+          client: queryClient,
+          children: createElement(UseCharactersProbe),
+        }),
+      );
+    });
+
+    await vi.waitFor(() => {
+      expect(storageListMock).toHaveBeenCalledWith("characters", {
+        fields: ["id", "data", "comment", "avatarFilePath", "avatarFilename", "createdAt", "updatedAt"],
+      });
+    });
+  });
+});
 
 describe("character query cache helpers", () => {
   it("updates character list and summary caches from a created or imported character result", () => {

--- a/src/features/catalog/characters/hooks/use-characters.ts
+++ b/src/features/catalog/characters/hooks/use-characters.ts
@@ -55,12 +55,14 @@ export type PersonaSummary = {
   boxColor?: string;
 };
 
+const CHARACTER_LIST_FIELDS = ["id", "data", "comment", "avatarFilePath", "avatarFilename", "createdAt", "updatedAt"];
+
 const CHARACTER_SUMMARY_OPTIONS = {
-  fields: ["id", "data", "comment", "avatarFilePath", "avatarFilename", "createdAt", "updatedAt"],
+  fields: CHARACTER_LIST_FIELDS,
   fieldSelections: { data: ["name", "creator", "creator_notes", "character_version", "tags", "extensions"] },
 };
 const CHARACTER_LIST_OPTIONS = {
-  fields: ["id", "data", "comment", "avatarFilePath", "avatarFilename", "createdAt", "updatedAt"],
+  fields: CHARACTER_LIST_FIELDS,
 };
 const CHARACTER_SUMMARY_BY_ID_CONCURRENCY = 8;
 const EMPTY_CHARACTER_SUMMARIES: CharacterSummary[] = [];

--- a/src/features/catalog/characters/hooks/use-characters.ts
+++ b/src/features/catalog/characters/hooks/use-characters.ts
@@ -59,6 +59,9 @@ const CHARACTER_SUMMARY_OPTIONS = {
   fields: ["id", "data", "comment", "avatarFilePath", "avatarFilename", "createdAt", "updatedAt"],
   fieldSelections: { data: ["name", "creator", "creator_notes", "character_version", "tags", "extensions"] },
 };
+const CHARACTER_LIST_OPTIONS = {
+  fields: ["id", "data", "comment", "avatarFilePath", "avatarFilename", "createdAt", "updatedAt"],
+};
 const CHARACTER_SUMMARY_BY_ID_CONCURRENCY = 8;
 const EMPTY_CHARACTER_SUMMARIES: CharacterSummary[] = [];
 
@@ -228,7 +231,7 @@ function invalidateCharacterRecordQueries(
 export function useCharacters(enabled = true) {
   return useQuery({
     queryKey: characterKeys.list(),
-    queryFn: () => storageApi.list<unknown>("characters"),
+    queryFn: () => storageApi.list<unknown>("characters", CHARACTER_LIST_OPTIONS),
     enabled,
     staleTime: 5 * 60_000,
     refetchOnWindowFocus: false,


### PR DESCRIPTION
## Linked issue

Closes #1582
Related: #1643

## Why this change

- Xel's #1582 follow-up comment noted that `useCharacters()` still called `storageApi.list("characters")` without a projection after the earlier partial fix.
- #1643 moved the active library/panel paths to `useCharacterSummaries()`, but the exported full-list hook still allowed future callers to fetch embedded avatar payloads by accident.

## What changed

- Added a full-list projection for `useCharacters()` that keeps full `data` while omitting embedded `avatarPath` from list rows.
- Added a regression test that mounts the hook and asserts the projected `storageApi.list("characters", ...)` call.

## Refactor impact

Primary owner:

- catalog

Impact areas reviewed:

- Character library/panel call sites already use `useCharacterSummaries()` after #1643.
- Raw unprojected `storageApi.list("characters")` grep now returns no matches.

Boundary notes:

- Feature hook change only. It continues to use the focused shared `storageApi` wrapper; no engine, Rust, or remote-runtime boundary changes.

Pressure points touched:

- none

## Validation

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- `pnpm typecheck`
- `pnpm exec vitest run src/features/catalog/characters/hooks/use-characters.test.ts`
- `pnpm check:architecture`
- `pnpm build`
- `git diff --check`
- `rg -n -F 'storageApi.list("characters"' src src-tauri` returned no matches.
- `rg -n "useCharacters\\(" src/features src/app src/shared -g "*.ts" -g "*.tsx"` only found the hook definition and its regression test.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- No visible UI change; this narrows the character list payload for the remaining full-list hook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized the character list query to fetch only essential fields, reducing payload size and improving performance. Unnecessary embedded data is now excluded from character list requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1647?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->