### PR TITLE
Fix game narration truncation display

### DIFF
--- a/src/features/modes/game/components/GameNarration.tsx
+++ b/src/features/modes/game/components/GameNarration.tsx
@@ -2482,10 +2482,11 @@ export function GameNarration({
   const getSegmentStartVisibleChars = useCallback(
     (index: number) => {
       const segment = segments[index];
-      if (!segment || !gameInstantTextReveal || directionsActive || scenePreparing) return 0;
-      return effectDisplayLength(segment.content);
+      if (!segment || directionsActive || scenePreparing) return 0;
+      if (!isStreaming || gameInstantTextReveal) return effectDisplayLength(segment.content);
+      return 0;
     },
-    [segments, gameInstantTextReveal, directionsActive, scenePreparing],
+    [segments, directionsActive, scenePreparing, isStreaming, gameInstantTextReveal],
   );
 
   useEffect(() => {
@@ -2851,7 +2852,7 @@ export function GameNarration({
     tw.pos = visibleChars;
 
     if (tw.pos >= dispLen) return;
-    if (gameInstantTextReveal || gameTextSpeed >= 100) {
+    if (!isStreaming || gameInstantTextReveal || gameTextSpeed >= 100) {
       // Instant
       tw.pos = dispLen;
       setVisibleChars(dispLen);
@@ -2873,7 +2874,7 @@ export function GameNarration({
     }, TICK_MS);
     return () => clearInterval(interval);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [active, gameInstantTextReveal, gameTextSpeed, directionsActive, scenePreparing, logsOpen]); // visibleChars intentionally excluded — managed internally
+  }, [active, isStreaming, gameInstantTextReveal, gameTextSpeed, directionsActive, scenePreparing, logsOpen]); // visibleChars intentionally excluded — managed internally
 
   const assetManifest = useGameAssetStore((s) => s.manifest);
 


### PR DESCRIPTION
## Summary

Fixes #1593.

Completed game narration turns now reveal the active segment in full instead of leaving the typewriter partially advanced after generation or regeneration finishes. Streaming turns still type out normally, and instant-reveal settings continue to work.

## Root Cause

`GameNarration` initialized and advanced visible character count from the same typewriter path for both active streaming and already-completed assistant turns. After a completed generation, the visible narration could remain at a partial prefix and look like the model output was cut off.

## Validation

- `pnpm typecheck`

