### PR TITLE
[codex] Wire lorebook timing and skill check history

### DIFF
--- a/src-tauri/crates/storage/src/lib.rs
+++ b/src-tauri/crates/storage/src/lib.rs
@@ -165,6 +165,44 @@ impl FileStorage {
         self.patch_with(collection, id, patch, |_, _| Ok(()))
     }
 
+    pub fn patch_if<F>(&self, collection: &str, id: &str, mut patch_row: F) -> AppResult<Option<Value>>
+    where
+        F: FnMut(&mut Map<String, Value>) -> AppResult<bool>,
+    {
+        let _guard = self
+            .lock
+            .write()
+            .map_err(|_| AppError::new("lock_error", "Storage lock poisoned"))?;
+        let mut rows = self.read_collection(collection)?;
+        let mut found = false;
+        let mut patched = None;
+        for row in &mut rows {
+            if row.get("id").and_then(Value::as_str) != Some(id) {
+                continue;
+            }
+            found = true;
+            let Some(object) = row.as_object_mut() else {
+                return Err(AppError::invalid_input("Stored record is not an object"));
+            };
+            if !patch_row(object)? {
+                return Ok(None);
+            }
+            object.insert("updatedAt".to_string(), Value::String(now_iso()));
+            patched = Some(Value::Object(object.clone()));
+            break;
+        }
+        if !found {
+            return Err(AppError::not_found(format!(
+                "{collection}/{id} was not found"
+            )));
+        }
+        let Some(record) = patched else {
+            return Ok(None);
+        };
+        self.write_collection(collection, &rows)?;
+        Ok(Some(record))
+    }
+
     pub fn patch_with<F>(
         &self,
         collection: &str,

--- a/src-tauri/src/commands/storage/chats.rs
+++ b/src-tauri/src/commands/storage/chats.rs
@@ -298,6 +298,35 @@ pub(crate) fn message_swipes(
     Ok(updated)
 }
 
+pub(crate) fn update_message_content_if_unchanged(
+    state: &AppState,
+    chat_id: &str,
+    message_id: &str,
+    expected_content: &str,
+    content: &str,
+) -> AppResult<Value> {
+    let content = collapse_excess_blank_lines(content);
+    let updated = state.storage.patch_if("messages", message_id, |message| {
+        let current_chat_id = message.get("chatId").and_then(Value::as_str).unwrap_or("");
+        if current_chat_id != chat_id {
+            return Ok(false);
+        }
+        let current_content = message.get("content").and_then(Value::as_str).unwrap_or("");
+        if current_content != expected_content {
+            return Ok(false);
+        }
+        message.insert("content".to_string(), Value::String(content.clone()));
+        let mut patch = Map::new();
+        patch.insert("content".to_string(), Value::String(content.clone()));
+        sync_message_patch_content_to_active_swipe(message, &patch);
+        Ok(true)
+    })?;
+    Ok(match updated {
+        Some(message) => json!({ "updated": true, "message": message }),
+        None => json!({ "updated": false }),
+    })
+}
+
 pub(crate) fn set_active_swipe(
     state: &AppState,
     _chat_id: &str,
@@ -1165,6 +1194,45 @@ mod tests {
             .expect("source lookup should not fail")
             .expect("source chat should still exist");
         assert_eq!(source["groupId"], "existing-group");
+    }
+
+    #[test]
+    fn update_message_content_if_unchanged_updates_only_matching_content() {
+        let state = test_state("conditional-content");
+        state
+            .storage
+            .create(
+                "messages",
+                json!({
+                    "id": "message-1",
+                    "chatId": "chat-1",
+                    "role": "assistant",
+                    "content": "first",
+                    "activeSwipeIndex": 0,
+                    "swipes": [{ "content": "first" }]
+                }),
+            )
+            .expect("message should be created");
+
+        let stale =
+            update_message_content_if_unchanged(&state, "chat-1", "message-1", "stale", "second")
+                .expect("stale conditional update should not fail");
+        assert_eq!(stale["updated"], false);
+        let unchanged = state
+            .storage
+            .get("messages", "message-1")
+            .expect("message lookup should not fail")
+            .expect("message should still exist");
+        assert_eq!(unchanged["content"], "first");
+        assert_eq!(unchanged["swipes"][0]["content"], "first");
+
+        let updated =
+            update_message_content_if_unchanged(&state, "chat-1", "message-1", "first", "second")
+                .expect("matching conditional update should not fail");
+        assert_eq!(updated["updated"], true);
+        let message = updated["message"].clone();
+        assert_eq!(message["content"], "second");
+        assert_eq!(message["swipes"][0]["content"], "second");
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/commands/chats.rs
+++ b/src-tauri/src/commands/storage/commands/chats.rs
@@ -136,6 +136,23 @@ pub fn chat_message_add_swipe(
 }
 
 #[tauri::command]
+pub fn chat_message_update_content_if_unchanged(
+    state: State<'_, AppState>,
+    chat_id: String,
+    message_id: String,
+    expected_content: String,
+    content: String,
+) -> Result<Value, AppError> {
+    chats::update_message_content_if_unchanged(
+        &state,
+        &chat_id,
+        &message_id,
+        &expected_content,
+        &content,
+    )
+}
+
+#[tauri::command]
 pub async fn chat_message_set_active_swipe(
     state: State<'_, AppState>,
     chat_id: String,

--- a/src-tauri/src/http_dispatch.rs
+++ b/src-tauri/src/http_dispatch.rs
@@ -512,6 +512,9 @@ pub async fn dispatch(state: &AppState, request: InvokeRequest) -> AppResult<Val
         "storage_delete" => storage_delete(state, &args),
         "storage_duplicate" => storage_duplicate(state, &args),
         "chat_message_add_swipe" => chat_message_add_swipe(state, &args),
+        "chat_message_update_content_if_unchanged" => {
+            chat_message_update_content_if_unchanged(state, &args)
+        }
         "chat_message_set_active_swipe" => chat_message_set_active_swipe(state, &args),
         "chat_message_delete_swipe" => chat_message_delete_swipe(state, &args),
         "chat_autonomous_unread_mark" => chat_autonomous_unread_mark(state, &args),
@@ -1027,6 +1030,19 @@ fn chat_message_add_swipe(state: &AppState, args: &Map<String, Value>) -> AppRes
         required_string(args, "chatId")?,
         required_string(args, "messageId")?,
         optional_value(args, "body"),
+    )
+}
+
+fn chat_message_update_content_if_unchanged(
+    state: &AppState,
+    args: &Map<String, Value>,
+) -> AppResult<Value> {
+    chats::update_message_content_if_unchanged(
+        state,
+        required_string(args, "chatId")?,
+        required_string(args, "messageId")?,
+        required_string(args, "expectedContent")?,
+        required_string(args, "content")?,
     )
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -215,6 +215,7 @@ pub fn run() {
             storage_commands::chat_commands::chat_branch,
             storage_commands::chat_commands::chat_message_swipes,
             storage_commands::chat_commands::chat_message_add_swipe,
+            storage_commands::chat_commands::chat_message_update_content_if_unchanged,
             storage_commands::chat_commands::chat_message_set_active_swipe,
             storage_commands::chat_commands::chat_message_delete_swipe,
             storage_commands::chat_commands::chat_connect,

--- a/src/engine/capabilities/storage.ts
+++ b/src/engine/capabilities/storage.ts
@@ -64,6 +64,12 @@ export interface StorageGateway {
   listChatMessages<T = unknown>(chatId: string, options?: Omit<StorageListOptions, "filters">): Promise<T[]>;
   createChatMessage<T = unknown>(chatId: string, value: Record<string, unknown>): Promise<T>;
   updateChatMessage<T = unknown>(messageId: string, patch: Record<string, unknown>): Promise<T>;
+  updateChatMessageContentIfUnchanged?<T = unknown>(
+    chatId: string,
+    messageId: string,
+    expectedContent: string,
+    content: string,
+  ): Promise<{ updated: boolean; message?: T }>;
   deleteChatMessage(messageId: string): Promise<{ deleted: boolean }>;
   patchChatMessageExtra<T = unknown>(messageId: string, patch: Record<string, unknown>): Promise<T>;
   addChatMessageSwipe<T = unknown>(

--- a/src/engine/generation/prompt-assembly.test.ts
+++ b/src/engine/generation/prompt-assembly.test.ts
@@ -1474,6 +1474,39 @@ describe("assembleGenerationPrompt lorebook activation settings", () => {
     expect(promptText(assembly)).not.toContain("LQA_CHAT_BUDGET_CONTENT_SHOULD_NOT_APPEAR");
   });
 
+  it("does not advance timing state for entries skipped by the chat lorebook budget", async () => {
+    const assembly = await assembleGenerationPrompt(
+      storageWithLore([
+        {
+          id: "entry-budgeted-cooldown",
+          lorebookId: "lorebook",
+          name: "Budgeted cooldown entry",
+          content: "LQA_CHAT_BUDGET_TIMING_CONTENT_SHOULD_NOT_APPEAR",
+          enabled: true,
+          constant: true,
+          cooldown: 3,
+        },
+      ]),
+      {
+        chat: { id: "chat", mode: "roleplay", metadata: { lorebookTokenBudget: 1 } },
+        storedMessages: [],
+        connection: {},
+        request: { ...request, promptPresetId: "" },
+        latestUserInput: "",
+      },
+    );
+
+    expect(assembly.activatedLorebookEntries).toHaveLength(0);
+    expect(assembly.budgetSkippedLorebookEntries).toMatchObject([
+      {
+        id: "entry-budgeted-cooldown",
+        blockedBy: "chat",
+        chatBudget: 1,
+      },
+    ]);
+    expect(assembly.lorebookTimingStates).toBeNull();
+  });
+
   it("returns budget skipped lorebook entries for active-world-info scans", async () => {
     const baseStorage = storageWithLore(
       [

--- a/src/engine/generation/prompt-assembly.test.ts
+++ b/src/engine/generation/prompt-assembly.test.ts
@@ -1551,6 +1551,87 @@ describe("assembleGenerationPrompt lorebook activation settings", () => {
     ]);
     expect(promptText(assembly)).not.toContain("LQA_LOREBOOK_BUDGET_CONTENT_SHOULD_NOT_APPEAR");
   });
+
+  it("returns next timing state when a delayed lorebook entry is still waiting", async () => {
+    const assembly = await assembleGenerationPrompt(
+      storageWithLore([
+        {
+          id: "entry-delay",
+          lorebookId: "lorebook",
+          name: "Delayed moonlit lore",
+          content: "LQA_DELAYED_CONTENT_SHOULD_NOT_APPEAR_YET",
+          keys: ["moonlit"],
+          enabled: true,
+          delay: 1,
+        },
+      ]),
+      {
+        chat: { id: "chat", mode: "roleplay", metadata: {} },
+        storedMessages: [{ role: "user", content: "Tell me about the moonlit path.", contextKind: "history" }],
+        connection: {},
+        request: { ...request, promptPresetId: "" },
+        latestUserInput: "Tell me about the moonlit path.",
+      },
+    );
+
+    expect(assembly.activatedLorebookEntries).toHaveLength(0);
+    expect(promptText(assembly)).not.toContain("LQA_DELAYED_CONTENT_SHOULD_NOT_APPEAR_YET");
+    expect(assembly.lorebookTimingStates).toEqual({
+      "entry-delay": {
+        lastActivatedAt: null,
+        stickyCount: 0,
+        cooldownRemaining: 0,
+        delayRemaining: 0,
+      },
+    });
+  });
+
+  it("uses persisted sticky timing state when scanning active lore", async () => {
+    const assembly = await assembleGenerationPrompt(
+      storageWithLore([
+        {
+          id: "entry-sticky",
+          lorebookId: "lorebook",
+          name: "Sticky moonlit lore",
+          content: "LQA_STICKY_CONTENT_FROM_PRIOR_TRIGGER",
+          keys: ["moonlit"],
+          enabled: true,
+          sticky: 2,
+        },
+      ]),
+      {
+        chat: {
+          id: "chat",
+          mode: "roleplay",
+          metadata: {
+            entryTimingStates: {
+              "entry-sticky": {
+                lastActivatedAt: 1,
+                stickyCount: 2,
+                cooldownRemaining: 0,
+                delayRemaining: 0,
+              },
+            },
+          },
+        },
+        storedMessages: [{ role: "user", content: "No keyword in this turn.", contextKind: "history" }],
+        connection: {},
+        request: { ...request, promptPresetId: "" },
+        latestUserInput: "No keyword in this turn.",
+      },
+    );
+
+    expect(assembly.activatedLorebookEntries.map((entry) => entry.name)).toEqual(["Sticky moonlit lore"]);
+    expect(promptText(assembly)).toContain("LQA_STICKY_CONTENT_FROM_PRIOR_TRIGGER");
+    expect(assembly.lorebookTimingStates).toEqual({
+      "entry-sticky": {
+        lastActivatedAt: 1,
+        stickyCount: 1,
+        cooldownRemaining: 0,
+        delayRemaining: 0,
+      },
+    });
+  });
 });
 
 describe("assembleGenerationPrompt lorebook game-state gates", () => {

--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -1,4 +1,4 @@
-import type { LorebookEntry, LorebookMatchingSource } from "../contracts/types/lorebook";
+import type { LorebookEntry, LorebookEntryTimingState, LorebookMatchingSource } from "../contracts/types/lorebook";
 import type { ChatMLMessage, MarkerConfig, WrapFormat } from "../contracts/types/prompt";
 import type { CharacterData } from "../contracts/types/character";
 import type { StorageGateway } from "../capabilities/storage";
@@ -12,7 +12,9 @@ import {
 import {
   recursiveScan,
   scanForActivatedEntries,
+  updateTimingStatesForScan,
   type ActivatedEntry,
+  type EntryTimingState,
   type ScanMessage,
   type ScanOptions,
 } from "../generation-core/lorebooks/keyword-scanner";
@@ -121,6 +123,7 @@ export interface PromptAssemblyResult {
     order: number;
     constant: boolean;
   }>;
+  lorebookTimingStates: Record<string, LorebookEntryTimingState> | null;
   budgetSkippedLorebookEntries: BudgetSkippedLorebookEntry[];
   chatSummary: string | null;
   chatSummaryFingerprint: string | null;
@@ -1762,12 +1765,14 @@ interface LoadedLorebookBudgetSkippedEntry {
 interface ScannedLorebookEntries {
   activatedEntries: ActivatedEntry[];
   budgetSkippedEntries: LoadedLorebookBudgetSkippedEntry[];
+  entriesForTiming: LorebookEntry[];
 }
 
 interface LoadedActivatedLore {
   activatedEntries: ActivatedEntry[];
   budgetSkippedEntries: LoadedLorebookBudgetSkippedEntry[];
   lorebookNamesById: Map<string, string>;
+  timingStates: Record<string, LorebookEntryTimingState> | null;
 }
 
 function resolveLorebookTokenBudget(chat: JsonRecord, request: JsonRecord): number {
@@ -1780,6 +1785,73 @@ function resolveLorebookTokenBudget(chat: JsonRecord, request: JsonRecord): numb
 
 function resolveLorebookRecursionDepth(lorebook: JsonRecord): number {
   return Math.min(MAX_LOREBOOK_RECURSION_DEPTH, Math.max(1, nonNegativeInteger(lorebook.maxRecursionDepth, 3)));
+}
+
+function normalizeLorebookTimingState(value: unknown): EntryTimingState | null {
+  if (!isRecord(value)) return null;
+  const stickyCount = readNumber(value.stickyCount, Number.NaN);
+  const cooldownRemaining = readNumber(value.cooldownRemaining, Number.NaN);
+  const delayRemaining = readNumber(value.delayRemaining, Number.NaN);
+  if (![stickyCount, cooldownRemaining, delayRemaining].every(Number.isFinite)) return null;
+  const lastActivatedAt =
+    value.lastActivatedAt === null || value.lastActivatedAt === undefined
+      ? null
+      : readNumber(value.lastActivatedAt, Number.NaN);
+  if (lastActivatedAt !== null && !Number.isFinite(lastActivatedAt)) return null;
+  return {
+    lastActivatedAt: lastActivatedAt === null ? null : Math.max(0, Math.trunc(lastActivatedAt)),
+    stickyCount: Math.max(0, Math.trunc(stickyCount)),
+    cooldownRemaining: Math.max(0, Math.trunc(cooldownRemaining)),
+    delayRemaining: Math.max(0, Math.trunc(delayRemaining)),
+  };
+}
+
+function lorebookTimingStateMap(value: unknown): Map<string, EntryTimingState> {
+  const states = new Map<string, EntryTimingState>();
+  for (const [entryId, state] of Object.entries(parseRecord(value))) {
+    const normalizedId = entryId.trim();
+    const normalizedState = normalizeLorebookTimingState(state);
+    if (normalizedId && normalizedState) states.set(normalizedId, normalizedState);
+  }
+  return states;
+}
+
+function serializeLorebookTimingStates(
+  states: Map<string, EntryTimingState>,
+): Record<string, LorebookEntryTimingState> {
+  return Object.fromEntries(
+    [...states.entries()]
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([entryId, state]) => [
+        entryId,
+        {
+          lastActivatedAt: state.lastActivatedAt,
+          stickyCount: state.stickyCount,
+          cooldownRemaining: state.cooldownRemaining,
+          delayRemaining: state.delayRemaining,
+        },
+      ]),
+  );
+}
+
+function lorebookTimingStatesChanged(
+  previous: Map<string, EntryTimingState>,
+  next: Map<string, EntryTimingState>,
+): boolean {
+  if (previous.size !== next.size) return true;
+  for (const [entryId, previousState] of previous) {
+    const nextState = next.get(entryId);
+    if (!nextState) return true;
+    if (
+      previousState.lastActivatedAt !== nextState.lastActivatedAt ||
+      previousState.stickyCount !== nextState.stickyCount ||
+      previousState.cooldownRemaining !== nextState.cooldownRemaining ||
+      previousState.delayRemaining !== nextState.delayRemaining
+    ) {
+      return true;
+    }
+  }
+  return false;
 }
 
 export async function loadLorebookEntriesForActivation(
@@ -1832,6 +1904,7 @@ function scanLorebookEntries(
       lorebookUsedTokens: skipped.usedTokensBefore,
       estimatedTokens: skipped.estimatedTokens,
     })),
+    entriesForTiming: entries,
   };
 }
 
@@ -1849,6 +1922,7 @@ async function loadActivatedLore(
   const activeCharacterTags = characters.flatMap((character) => character.tags);
   const meta = parseRecord(chat.metadata);
   const gameState = parseRecord(chat.gameState ?? meta.gameState);
+  const previousTimingStates = lorebookTimingStateMap(meta.entryTimingStates);
   const messages = storedMessages
     .filter((message) => !hiddenFromAi(message))
     .map((message) => ({
@@ -1861,6 +1935,8 @@ async function loadActivatedLore(
     activeCharacterTags,
     generationTriggers,
     gameState,
+    timingStates: previousTimingStates,
+    currentMessageIndex: messages.length,
     additionalMatchingSourceText: buildAdditionalMatchingSourceText(characters, persona),
   };
   const lorebookNamesById = new Map(
@@ -1874,12 +1950,21 @@ async function loadActivatedLore(
       scanLorebookEntries(messages, await loadLorebookEntriesForActivation(storage, book), book, options),
     ),
   );
+  const nextTimingStates = updateTimingStatesForScan(
+    scanned.flatMap((result) => result.entriesForTiming),
+    scanned.flatMap((result) => result.activatedEntries),
+    previousTimingStates,
+    messages.length,
+  );
   return {
     activatedEntries: scanned
       .flatMap((result) => result.activatedEntries)
       .sort((a, b) => a.injectionOrder - b.injectionOrder),
     budgetSkippedEntries: scanned.flatMap((result) => result.budgetSkippedEntries),
     lorebookNamesById,
+    timingStates: lorebookTimingStatesChanged(previousTimingStates, nextTimingStates)
+      ? serializeLorebookTimingStates(nextTimingStates)
+      : null,
   };
 }
 
@@ -2188,6 +2273,7 @@ export async function assembleGenerationPrompt(
     characters,
     persona,
     activatedLorebookEntries: processedLore.includedEntries.map(loreForEvent),
+    lorebookTimingStates: loadedLore.timingStates,
     budgetSkippedLorebookEntries,
     chatSummary: summary,
     chatSummaryFingerprint: summaryFingerprint,

--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -1771,8 +1771,10 @@ interface ScannedLorebookEntries {
 interface LoadedActivatedLore {
   activatedEntries: ActivatedEntry[];
   budgetSkippedEntries: LoadedLorebookBudgetSkippedEntry[];
+  entriesForTiming: LorebookEntry[];
+  previousTimingStates: Map<string, EntryTimingState>;
   lorebookNamesById: Map<string, string>;
-  timingStates: Record<string, LorebookEntryTimingState> | null;
+  currentMessageIndex: number;
 }
 
 function resolveLorebookTokenBudget(chat: JsonRecord, request: JsonRecord): number {
@@ -1950,21 +1952,15 @@ async function loadActivatedLore(
       scanLorebookEntries(messages, await loadLorebookEntriesForActivation(storage, book), book, options),
     ),
   );
-  const nextTimingStates = updateTimingStatesForScan(
-    scanned.flatMap((result) => result.entriesForTiming),
-    scanned.flatMap((result) => result.activatedEntries),
-    previousTimingStates,
-    messages.length,
-  );
   return {
     activatedEntries: scanned
       .flatMap((result) => result.activatedEntries)
       .sort((a, b) => a.injectionOrder - b.injectionOrder),
     budgetSkippedEntries: scanned.flatMap((result) => result.budgetSkippedEntries),
+    entriesForTiming: scanned.flatMap((result) => result.entriesForTiming),
+    previousTimingStates,
     lorebookNamesById,
-    timingStates: lorebookTimingStatesChanged(previousTimingStates, nextTimingStates)
-      ? serializeLorebookTimingStates(nextTimingStates)
-      : null,
+    currentMessageIndex: messages.length,
   };
 }
 
@@ -2070,6 +2066,15 @@ export async function assembleGenerationPrompt(
   const loadedLore = await loadActivatedLore(storage, input.chat, characters, persona, input.storedMessages);
   const lorebookTokenBudget = resolveLorebookTokenBudget(input.chat, input.request);
   const processedLore = processActivatedEntries(loadedLore.activatedEntries, lorebookTokenBudget);
+  const nextLorebookTimingStates = updateTimingStatesForScan(
+    loadedLore.entriesForTiming,
+    processedLore.includedEntries,
+    loadedLore.previousTimingStates,
+    loadedLore.currentMessageIndex,
+  );
+  const lorebookTimingStates = lorebookTimingStatesChanged(loadedLore.previousTimingStates, nextLorebookTimingStates)
+    ? serializeLorebookTimingStates(nextLorebookTimingStates)
+    : null;
   const budgetSkippedLorebookEntries = [
     ...loadedLore.budgetSkippedEntries.map((entry) => lorebookBudgetSkippedLoreForEvent(entry, lorebookTokenBudget)),
     ...processedLore.skippedEntries.map((entry) =>
@@ -2273,7 +2278,7 @@ export async function assembleGenerationPrompt(
     characters,
     persona,
     activatedLorebookEntries: processedLore.includedEntries.map(loreForEvent),
-    lorebookTimingStates: loadedLore.timingStates,
+    lorebookTimingStates,
     budgetSkippedLorebookEntries,
     chatSummary: summary,
     chatSummaryFingerprint: summaryFingerprint,

--- a/src/engine/generation/start-generation.test.ts
+++ b/src/engine/generation/start-generation.test.ts
@@ -44,6 +44,9 @@ function generationDepsForChat(
     prompts?: Record<string, unknown>[];
     promptSections?: Record<string, unknown>[];
     promptVariables?: Record<string, unknown>[];
+    lorebooks?: Record<string, unknown>[];
+    lorebookEntries?: Record<string, unknown>[];
+    lorebookFolders?: Record<string, unknown>[];
     completeResponse?: string;
     streamResponses?: string[];
     integrations?: Partial<IntegrationGateway>;
@@ -120,6 +123,13 @@ function generationDepsForChat(
     messagesById.set(messageId, updated);
     return updated;
   });
+  const patchChatMetadata = vi.fn(async (_chatId: string, patch: Record<string, unknown>) => {
+    chat.metadata = {
+      ...((chat.metadata ?? {}) as Record<string, unknown>),
+      ...patch,
+    };
+    return chat;
+  });
   const storage = {
     get: vi.fn(async (entity: string, id: string) => {
       if (entity === "chats" && id === "chat-1") return chat;
@@ -135,6 +145,12 @@ function generationDepsForChat(
       if (entity === "agents") return options.agents ?? [];
       if (entity === "agent-runs") return options.agentRuns ?? [];
       if (entity === "prompts") return options.prompts ?? [];
+      if (entity === "lorebooks") return options.lorebooks ?? [];
+      if (entity === "lorebook-folders") {
+        return (options.lorebookFolders ?? []).filter(
+          (folder) => folder.lorebookId === listOptions?.filters?.lorebookId,
+        );
+      }
       if (entity === "prompt-sections") {
         return (options.promptSections ?? []).filter((section) => section.presetId === listOptions?.filters?.presetId);
       }
@@ -152,9 +168,12 @@ function generationDepsForChat(
     createChatMessage,
     addChatMessageSwipe,
     patchChatMessageExtra,
+    patchChatMetadata,
     listChatMessages,
     listChatMemories: vi.fn(async () => []),
-    listLorebookEntries: vi.fn(async () => []),
+    listLorebookEntries: vi.fn(async (lorebookId: string) =>
+      (options.lorebookEntries ?? []).filter((entry) => !entry.lorebookId || entry.lorebookId === lorebookId),
+    ),
     saveTrackerSnapshot: vi.fn(async (_chatId: string, snapshot: Record<string, unknown>) => snapshot),
   } as Partial<StorageGateway> as StorageGateway;
   const deps: GenerationEngineDeps = {
@@ -168,6 +187,7 @@ function generationDepsForChat(
     createChatMessage,
     addChatMessageSwipe,
     patchChatMessageExtra,
+    patchChatMetadata,
     listChatMessages,
     streamedRequests,
     completedRequests,
@@ -355,6 +375,80 @@ describe("startGeneration chat message loading", () => {
     expect(streamedRequests[0]).toMatchObject({
       messages: expect.arrayContaining([expect.objectContaining({ role: "user", content: "hello" })]),
     });
+  });
+
+  it("persists lorebook timing state after a successful generated turn", async () => {
+    const { deps, patchChatMetadata } = generationDepsForChat({
+      chatPatch: { mode: "roleplay" },
+      lorebooks: [{ id: "lorebook", enabled: true, isGlobal: true }],
+      lorebookEntries: [
+        {
+          id: "entry-delay",
+          lorebookId: "lorebook",
+          name: "Delayed moonlit lore",
+          content: "Delayed content",
+          keys: ["moonlit"],
+          enabled: true,
+          delay: 1,
+        },
+      ],
+    });
+
+    await drainGeneration(
+      startGeneration(deps, {
+        chatId: "chat-1",
+        userMessage: "moonlit path",
+        impersonateBlockAgents: true,
+      }),
+    );
+
+    expect(patchChatMetadata).toHaveBeenCalledWith("chat-1", {
+      entryTimingStates: {
+        "entry-delay": {
+          lastActivatedAt: null,
+          stickyCount: 0,
+          cooldownRemaining: 0,
+          delayRemaining: 0,
+        },
+      },
+    });
+  });
+
+  it("persists lorebook timing state before yielding the saved generated message", async () => {
+    const { deps, patchChatMetadata } = generationDepsForChat({
+      chatPatch: { mode: "roleplay" },
+      lorebooks: [{ id: "lorebook", enabled: true, isGlobal: true }],
+      lorebookEntries: [
+        {
+          id: "entry-delay",
+          lorebookId: "lorebook",
+          name: "Delayed moonlit lore",
+          content: "Delayed content",
+          keys: ["moonlit"],
+          enabled: true,
+          delay: 1,
+        },
+      ],
+    });
+
+    for await (const event of startGeneration(deps, {
+      chatId: "chat-1",
+      userMessage: "moonlit path",
+      impersonateBlockAgents: true,
+    })) {
+      if ((event as { type?: string }).type !== "assistant_message") continue;
+      expect(patchChatMetadata).toHaveBeenCalledWith("chat-1", {
+        entryTimingStates: {
+          "entry-delay": {
+            lastActivatedAt: null,
+            stickyCount: 0,
+            cooldownRemaining: 0,
+            delayRemaining: 0,
+          },
+        },
+      });
+      break;
+    }
   });
 
   it("uses the chat context message limit when assembling roleplay history", async () => {

--- a/src/engine/generation/start-generation.test.ts
+++ b/src/engine/generation/start-generation.test.ts
@@ -451,6 +451,44 @@ describe("startGeneration chat message loading", () => {
     }
   });
 
+  it("persists lorebook timing state for direct request message saves", async () => {
+    const { deps, patchChatMetadata } = generationDepsForChat({
+      chatPatch: { mode: "roleplay" },
+      initialMessages: [{ id: "user-1", chatId: "chat-1", role: "user", content: "moonlit path" }],
+      lorebooks: [{ id: "lorebook", enabled: true, isGlobal: true }],
+      lorebookEntries: [
+        {
+          id: "entry-delay",
+          lorebookId: "lorebook",
+          name: "Delayed moonlit lore",
+          content: "Delayed content",
+          keys: ["moonlit"],
+          enabled: true,
+          delay: 1,
+        },
+      ],
+    });
+
+    await drainGeneration(
+      startGeneration(deps, {
+        chatId: "chat-1",
+        messages: [{ role: "user", content: "Direct prompt" }],
+        impersonateBlockAgents: true,
+      }),
+    );
+
+    expect(patchChatMetadata).toHaveBeenCalledWith("chat-1", {
+      entryTimingStates: {
+        "entry-delay": {
+          lastActivatedAt: null,
+          stickyCount: 0,
+          cooldownRemaining: 0,
+          delayRemaining: 0,
+        },
+      },
+    });
+  });
+
   it("uses the chat context message limit when assembling roleplay history", async () => {
     const { deps, listChatMessages, streamedRequests } = generationDepsForChat({
       chatPatch: { mode: "roleplay" },

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -1262,6 +1262,19 @@ async function persistTrackerSnapshotSafely(
   }
 }
 
+async function persistLorebookTimingStatesSafely(
+  storage: StorageGateway,
+  chatId: string,
+  timingStates: Record<string, unknown> | null,
+): Promise<void> {
+  if (!timingStates) return;
+  try {
+    await storage.patchChatMetadata(chatId, { entryTimingStates: timingStates });
+  } catch (error) {
+    console.warn("[generation] lorebook timing state persist failed", error);
+  }
+}
+
 function cloneSerializableValue<T>(value: T): T {
   try {
     return JSON.parse(JSON.stringify(value)) as T;
@@ -2260,6 +2273,10 @@ export async function* startGeneration(
           contextInjections: runtime?.preInjections ?? null,
         });
     let latestSaved = saved;
+    if (saved) {
+      await persistLorebookTimingStatesSafely(deps.storage, chatId, assembly.lorebookTimingStates);
+    }
+    throwIfAborted(signal);
     if (saved && input.impersonate !== true) {
       await mirrorSavedAssistantMessageToDiscord({
         deps,

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -2440,6 +2440,10 @@ export async function* startGeneration(
         usage,
         promptSnapshot: promptSnapshotDirect,
       });
+  if (saved) {
+    await persistLorebookTimingStatesSafely(deps.storage, chatId, assembly.lorebookTimingStates);
+  }
+  throwIfAborted(signal);
   if (saved && input.impersonate !== true) {
     await mirrorSavedAssistantMessageToDiscord({
       deps,

--- a/src/features/modes/game/api/game-api.test.ts
+++ b/src/features/modes/game/api/game-api.test.ts
@@ -569,6 +569,102 @@ describe("gameApi.concludeSession summary normalization", () => {
   });
 });
 
+describe("gameApi.skillCheck history serialization", () => {
+  beforeEach(() => {
+    Object.values(storageApiMock).forEach((fn) => fn.mockReset());
+  });
+
+  function mockSkillCheckChat(messageContent: string) {
+    const chat = {
+      id: "chat-game",
+      mode: "game",
+      metadata: {
+        gameCharacterCards: [
+          {
+            name: "Mira",
+            rpgStats: {
+              attributes: [{ name: "WIS", value: 14 }],
+            },
+          },
+        ],
+      },
+    } as unknown as Chat;
+    const message = {
+      id: "message-1",
+      chatId: "chat-game",
+      role: "assistant",
+      content: messageContent,
+    };
+    storageApiMock.get.mockImplementation(async (entity: string, id: string) => {
+      if (entity === "chats" && id === chat.id) return chat;
+      if (entity === "messages" && id === message.id) return message;
+      return null;
+    });
+    storageApiMock.updateChatMessage.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...message,
+      ...patch,
+    }));
+  }
+
+  it("replaces the unresolved skill_check tag with the resolved result tag", async () => {
+    mockSkillCheckChat(`Try it.\n[skill_check: skill="Perception" dc="15"]\nThen listen.`);
+
+    const res = await gameApi.skillCheck({
+      chatId: "chat-game",
+      skill: "Perception",
+      dc: 15,
+      preRolledD20: 12,
+      messageId: "message-1",
+    });
+
+    expect(res.result.total).toBe(14);
+    expect(res.updatedContent).toContain(`[skill_check: skill="Perception"`);
+    expect(res.updatedContent).toContain(`rolls="12"`);
+    expect(res.updatedContent).toContain(`modifier="2"`);
+    expect(res.updatedContent).toContain(`total="14"`);
+    expect(res.updatedContent).toContain(`result="failure"`);
+    expect(storageApiMock.updateChatMessage).toHaveBeenCalledWith("message-1", { content: res.updatedContent });
+  });
+
+  it("does not rewrite already resolved skill_check tags", async () => {
+    mockSkillCheckChat(
+      `[skill_check: skill="Perception" dc="15" rolls="12" used="12" modifier="2" total="14" RESULT="failure" mode="normal"]`,
+    );
+
+    const res = await gameApi.skillCheck({
+      chatId: "chat-game",
+      skill: "Perception",
+      dc: 15,
+      preRolledD20: 12,
+      messageId: "message-1",
+    });
+
+    expect(res.updatedContent).toBeUndefined();
+    expect(storageApiMock.updateChatMessage).not.toHaveBeenCalled();
+  });
+
+  it("still returns the resolved skill check if history persistence fails", async () => {
+    mockSkillCheckChat(`[skill_check: skill="Perception" dc="15"]`);
+    storageApiMock.updateChatMessage.mockRejectedValueOnce(new Error("storage offline"));
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      const res = await gameApi.skillCheck({
+        chatId: "chat-game",
+        skill: "Perception",
+        dc: 15,
+        preRolledD20: 12,
+        messageId: "message-1",
+      });
+
+      expect(res.result.total).toBe(14);
+      expect(res.updatedContent).toBeUndefined();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+});
+
 describe("gameApi.partyTurn prompt wiring", () => {
   beforeEach(() => {
     Object.values(storageApiMock).forEach((fn) => fn.mockReset());

--- a/src/features/modes/game/api/game-api.test.ts
+++ b/src/features/modes/game/api/game-api.test.ts
@@ -11,6 +11,7 @@ const storageApiMock = vi.hoisted(() => ({
   listChatMessages: vi.fn(),
   createChatMessage: vi.fn(),
   updateChatMessage: vi.fn(),
+  updateChatMessageContentIfUnchanged: vi.fn(),
   deleteChatMessage: vi.fn(),
   patchChatMessageExtra: vi.fn(),
   addChatMessageSwipe: vi.fn(),
@@ -589,7 +590,7 @@ describe("gameApi.skillCheck history serialization", () => {
         ],
       },
     } as unknown as Chat;
-    const message = {
+    let message = {
       id: "message-1",
       chatId: messageChatId,
       role: "assistant",
@@ -600,10 +601,15 @@ describe("gameApi.skillCheck history serialization", () => {
       if (entity === "messages" && id === message.id) return message;
       return null;
     });
-    storageApiMock.updateChatMessage.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
-      ...message,
-      ...patch,
-    }));
+    storageApiMock.updateChatMessageContentIfUnchanged.mockImplementation(
+      async (chatId: string, id: string, expectedContent: string, content: string) => {
+        if (id !== message.id || chatId !== message.chatId || message.content !== expectedContent) {
+          return { updated: false, message };
+        }
+        message = { ...message, content };
+        return { updated: true, message };
+      },
+    );
   }
 
   it("replaces the unresolved skill_check tag with the resolved result tag", async () => {
@@ -623,7 +629,63 @@ describe("gameApi.skillCheck history serialization", () => {
     expect(res.updatedContent).toContain(`modifier="2"`);
     expect(res.updatedContent).toContain(`total="14"`);
     expect(res.updatedContent).toContain(`result="failure"`);
-    expect(storageApiMock.updateChatMessage).toHaveBeenCalledWith("message-1", { content: res.updatedContent });
+    expect(storageApiMock.updateChatMessageContentIfUnchanged).toHaveBeenCalledWith(
+      "chat-game",
+      "message-1",
+      `Try it.\n[skill_check: skill="Perception" dc="15"]\nThen listen.`,
+      res.updatedContent,
+    );
+    expect(storageApiMock.updateChatMessage).not.toHaveBeenCalled();
+  });
+
+  it("retries a skill_check history rewrite after a conditional content conflict", async () => {
+    const chat = {
+      id: "chat-game",
+      mode: "game",
+      metadata: {
+        gameCharacterCards: [
+          {
+            name: "Mira",
+            rpgStats: {
+              attributes: [{ name: "WIS", value: 14 }],
+            },
+          },
+        ],
+      },
+    } as unknown as Chat;
+    const contents = [
+      `Original.\n[skill_check: skill="Perception" dc="15"]`,
+      `Concurrent edit.\n[skill_check: skill="Perception" dc="15"]`,
+    ];
+    let messageReadCount = 0;
+    storageApiMock.get.mockImplementation(async (entity: string, id: string) => {
+      if (entity === "chats" && id === chat.id) return chat;
+      if (entity === "messages" && id === "message-1") {
+        const content = contents[Math.min(messageReadCount, contents.length - 1)];
+        messageReadCount += 1;
+        return { id: "message-1", chatId: "chat-game", role: "assistant", content };
+      }
+      return null;
+    });
+    storageApiMock.updateChatMessageContentIfUnchanged
+      .mockResolvedValueOnce({ updated: false })
+      .mockImplementationOnce(async (_chatId: string, _id: string, _expectedContent: string, content: string) => ({
+        updated: true,
+        message: { id: "message-1", chatId: "chat-game", role: "assistant", content },
+      }));
+
+    const res = await gameApi.skillCheck({
+      chatId: "chat-game",
+      skill: "Perception",
+      dc: 15,
+      preRolledD20: 12,
+      messageId: "message-1",
+    });
+
+    expect(res.result.total).toBe(14);
+    expect(res.updatedContent).toContain("Concurrent edit.");
+    expect(res.updatedContent).toContain(`result="failure"`);
+    expect(storageApiMock.updateChatMessageContentIfUnchanged).toHaveBeenCalledTimes(2);
   });
 
   it("does not rewrite already resolved skill_check tags", async () => {
@@ -657,11 +719,12 @@ describe("gameApi.skillCheck history serialization", () => {
     expect(res.result.total).toBe(14);
     expect(res.updatedContent).toBeUndefined();
     expect(storageApiMock.updateChatMessage).not.toHaveBeenCalled();
+    expect(storageApiMock.updateChatMessageContentIfUnchanged).not.toHaveBeenCalled();
   });
 
   it("still returns the resolved skill check if history persistence fails", async () => {
     mockSkillCheckChat(`[skill_check: skill="Perception" dc="15"]`);
-    storageApiMock.updateChatMessage.mockRejectedValueOnce(new Error("storage offline"));
+    storageApiMock.updateChatMessageContentIfUnchanged.mockRejectedValueOnce(new Error("storage offline"));
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     try {

--- a/src/features/modes/game/api/game-api.test.ts
+++ b/src/features/modes/game/api/game-api.test.ts
@@ -574,7 +574,7 @@ describe("gameApi.skillCheck history serialization", () => {
     Object.values(storageApiMock).forEach((fn) => fn.mockReset());
   });
 
-  function mockSkillCheckChat(messageContent: string) {
+  function mockSkillCheckChat(messageContent: string, messageChatId = "chat-game") {
     const chat = {
       id: "chat-game",
       mode: "game",
@@ -591,7 +591,7 @@ describe("gameApi.skillCheck history serialization", () => {
     } as unknown as Chat;
     const message = {
       id: "message-1",
-      chatId: "chat-game",
+      chatId: messageChatId,
       role: "assistant",
       content: messageContent,
     };
@@ -639,6 +639,22 @@ describe("gameApi.skillCheck history serialization", () => {
       messageId: "message-1",
     });
 
+    expect(res.updatedContent).toBeUndefined();
+    expect(storageApiMock.updateChatMessage).not.toHaveBeenCalled();
+  });
+
+  it("does not rewrite a skill_check tag on a message from another chat", async () => {
+    mockSkillCheckChat(`[skill_check: skill="Perception" dc="15"]`, "other-chat");
+
+    const res = await gameApi.skillCheck({
+      chatId: "chat-game",
+      skill: "Perception",
+      dc: 15,
+      preRolledD20: 12,
+      messageId: "message-1",
+    });
+
+    expect(res.result.total).toBe(14);
     expect(res.updatedContent).toBeUndefined();
     expect(storageApiMock.updateChatMessage).not.toHaveBeenCalled();
   });

--- a/src/features/modes/game/api/game-api.ts
+++ b/src/features/modes/game/api/game-api.ts
@@ -1046,6 +1046,8 @@ function replaceFirstUnresolvedSkillCheckTag(content: string, resolvedTag: strin
   });
 }
 
+const SKILL_CHECK_HISTORY_PERSIST_ATTEMPTS = 3;
+
 async function persistResolvedSkillCheckTag(
   chatId: string,
   messageId: string | undefined,
@@ -1054,14 +1056,24 @@ async function persistResolvedSkillCheckTag(
   const id = typeof messageId === "string" ? messageId.trim() : "";
   if (!id) return undefined;
   try {
-    const message = await storageApi.get<ChatMessage>("messages", id);
-    if (typeof message?.chatId !== "string" || message.chatId !== chatId) return undefined;
-    const content = typeof message?.content === "string" ? message.content : "";
-    if (!content) return undefined;
-    const updatedContent = replaceFirstUnresolvedSkillCheckTag(content, serializeResolvedSkillCheckTag(result));
-    if (updatedContent === content) return undefined;
-    await storageApi.updateChatMessage<ChatMessage>(id, { content: updatedContent });
-    return updatedContent;
+    const conditionalUpdate = storageApi.updateChatMessageContentIfUnchanged;
+    if (typeof conditionalUpdate !== "function") {
+      throw new Error("Conditional chat message content update is unavailable");
+    }
+    const resolvedTag = serializeResolvedSkillCheckTag(result);
+    for (let attempt = 0; attempt < SKILL_CHECK_HISTORY_PERSIST_ATTEMPTS; attempt += 1) {
+      const message = await storageApi.get<ChatMessage>("messages", id);
+      if (typeof message?.chatId !== "string" || message.chatId !== chatId) return undefined;
+      const content = typeof message?.content === "string" ? message.content : "";
+      if (!content) return undefined;
+      const updatedContent = replaceFirstUnresolvedSkillCheckTag(content, resolvedTag);
+      if (updatedContent === content) return undefined;
+      const update = await conditionalUpdate<ChatMessage>(chatId, id, content, updatedContent);
+      if (update.updated) {
+        return typeof update.message?.content === "string" ? update.message.content : updatedContent;
+      }
+    }
+    return undefined;
   } catch (error) {
     console.warn("[game] skill check history persist failed", error);
     return undefined;

--- a/src/features/modes/game/api/game-api.ts
+++ b/src/features/modes/game/api/game-api.ts
@@ -1047,6 +1047,7 @@ function replaceFirstUnresolvedSkillCheckTag(content: string, resolvedTag: strin
 }
 
 async function persistResolvedSkillCheckTag(
+  chatId: string,
   messageId: string | undefined,
   result: SkillCheckResult,
 ): Promise<string | undefined> {
@@ -1054,6 +1055,7 @@ async function persistResolvedSkillCheckTag(
   if (!id) return undefined;
   try {
     const message = await storageApi.get<ChatMessage>("messages", id);
+    if (typeof message?.chatId !== "string" || message.chatId !== chatId) return undefined;
     const content = typeof message?.content === "string" ? message.content : "";
     if (!content) return undefined;
     const updatedContent = replaceFirstUnresolvedSkillCheckTag(content, serializeResolvedSkillCheckTag(result));
@@ -1749,7 +1751,7 @@ export const gameApi = {
     });
     return {
       result,
-      updatedContent: await persistResolvedSkillCheckTag(data.messageId, result),
+      updatedContent: await persistResolvedSkillCheckTag(data.chatId, data.messageId, result),
     };
   },
 

--- a/src/features/modes/game/api/game-api.ts
+++ b/src/features/modes/game/api/game-api.ts
@@ -18,6 +18,7 @@ import type {
   HudWidget,
   PartyArc,
   SessionSummary,
+  SkillCheckResult,
 } from "../../../../engine/contracts/types/game";
 import type { RPGAttributes } from "../../../../engine/contracts/types/game-state";
 import { ApiError, type JsonRepairRequest } from "../../../../shared/api/api-errors";
@@ -44,6 +45,7 @@ import {
   mapSheetAttributesToRPG,
   resolveSkillCheck,
 } from "../../../../engine/modes/game/mechanics/skill-check.service";
+import { serializeResolvedSkillCheckTag } from "../../../../engine/shared/scoring/skill-check-format";
 import {
   applyMoraleEvent,
   getMoraleTier,
@@ -1034,6 +1036,36 @@ function playerAttributes(meta: Record<string, unknown>): Partial<RPGAttributes>
   return mapSheetAttributesToRPG(Array.isArray(rpgStats.attributes) ? (rpgStats.attributes as any[]) : undefined);
 }
 
+function replaceFirstUnresolvedSkillCheckTag(content: string, resolvedTag: string): string {
+  let replaced = false;
+  return content.replace(/\[skill_check:\s*([^\]]+)\]/gi, (fullTag, body: string) => {
+    if (replaced) return fullTag;
+    if (/\bresult\s*=/i.test(body)) return fullTag;
+    replaced = true;
+    return resolvedTag;
+  });
+}
+
+async function persistResolvedSkillCheckTag(
+  messageId: string | undefined,
+  result: SkillCheckResult,
+): Promise<string | undefined> {
+  const id = typeof messageId === "string" ? messageId.trim() : "";
+  if (!id) return undefined;
+  try {
+    const message = await storageApi.get<ChatMessage>("messages", id);
+    const content = typeof message?.content === "string" ? message.content : "";
+    if (!content) return undefined;
+    const updatedContent = replaceFirstUnresolvedSkillCheckTag(content, serializeResolvedSkillCheckTag(result));
+    if (updatedContent === content) return undefined;
+    await storageApi.updateChatMessage<ChatMessage>(id, { content: updatedContent });
+    return updatedContent;
+  } catch (error) {
+    console.warn("[game] skill check history persist failed", error);
+    return undefined;
+  }
+}
+
 function generatedAssetSlug(value: string): string {
   const slug = value
     .trim()
@@ -1700,22 +1732,24 @@ export const gameApi = {
     disadvantage?: boolean;
     preRolledD20?: number;
     skillModifier?: number;
+    messageId?: string;
   }) {
     const meta = chatMeta(await getChat(data.chatId));
     const attrs = playerAttributes(meta);
     const attr = getGoverningAttribute(data.skill);
     const attrScore = Number(attrs[attr] ?? 10);
+    const result = resolveSkillCheck({
+      skill: data.skill,
+      dc: data.dc,
+      skillModifier: Number(data.skillModifier ?? 0),
+      attributeModifier: Math.floor((attrScore - 10) / 2),
+      advantage: data.advantage,
+      disadvantage: data.disadvantage,
+      preRolledD20: data.preRolledD20,
+    });
     return {
-      result: resolveSkillCheck({
-        skill: data.skill,
-        dc: data.dc,
-        skillModifier: Number(data.skillModifier ?? 0),
-        attributeModifier: Math.floor((attrScore - 10) / 2),
-        advantage: data.advantage,
-        disadvantage: data.disadvantage,
-        preRolledD20: data.preRolledD20,
-      }),
-      updatedContent: undefined as string | undefined,
+      result,
+      updatedContent: await persistResolvedSkillCheckTag(data.messageId, result),
     };
   },
 

--- a/src/shared/api/remote-runtime.ts
+++ b/src/shared/api/remote-runtime.ts
@@ -108,6 +108,7 @@ const REMOTE_COMMANDS = new Set([
   "storage_delete",
   "storage_duplicate",
   "chat_message_add_swipe",
+  "chat_message_update_content_if_unchanged",
   "chat_message_set_active_swipe",
   "chat_message_delete_swipe",
   "chat_autonomous_unread_mark",

--- a/src/shared/api/storage-api.test.ts
+++ b/src/shared/api/storage-api.test.ts
@@ -64,4 +64,39 @@ describe("storageApi typed JSON read normalization", () => {
       },
     });
   });
+
+  it("routes conditional message-content updates through the storage command", async () => {
+    invokeMock.mockResolvedValueOnce({
+      updated: true,
+      message: {
+        id: "message-1",
+        chatId: "chat-1",
+        content: "next",
+        extra: '{"thinking":"still hidden"}',
+      },
+    });
+
+    const result = await storageApi.updateChatMessageContentIfUnchanged?.(
+      "chat-1",
+      "message-1",
+      "first\n\n\nsecond",
+      "next\n\n\nline",
+    );
+
+    expect(invokeMock).toHaveBeenCalledWith("chat_message_update_content_if_unchanged", {
+      chatId: "chat-1",
+      messageId: "message-1",
+      expectedContent: "first\n\n\nsecond",
+      content: "next\n\nline",
+    });
+    expect(result).toEqual({
+      updated: true,
+      message: {
+        id: "message-1",
+        chatId: "chat-1",
+        content: "next",
+        extra: { thinking: "still hidden" },
+      },
+    });
+  });
 });

--- a/src/shared/api/storage-api.ts
+++ b/src/shared/api/storage-api.ts
@@ -185,6 +185,19 @@ export const storageApi: StorageGateway = {
     }),
   createChatMessage: (chatId, value) => storageApi.create("messages", chatMessageDefaults(chatId, value)),
   updateChatMessage: (messageId, patch) => storageApi.update("messages", messageId, normalizeMessageWrite(patch)),
+  updateChatMessageContentIfUnchanged: async (chatId, messageId, expectedContent, content) => {
+    const result = (await invokeTauri("chat_message_update_content_if_unchanged", {
+      chatId,
+      messageId,
+      expectedContent,
+      content: collapseExcessBlankLines(content),
+    })) as { updated?: boolean; message?: unknown } | null;
+    const message = result?.message ? normalizeStorageReadResult("messages", result.message) : undefined;
+    return {
+      updated: result?.updated === true,
+      ...(message === undefined ? {} : { message }),
+    } as never;
+  },
   deleteChatMessage: (messageId) => storageApi.delete("messages", messageId),
   patchChatMessageExtra: async (messageId, patch) => {
     const message = await storageApi.get<Record<string, unknown>>("messages", messageId);


### PR DESCRIPTION
## Linked issue

No linked issue.

## Why this change

- Lorebook entry timing state and resolved game skill checks had engine/runtime helpers available, but the app paths were not carrying those results through persistence. That meant delayed/sticky lorebook timing could be lost between generated turns, and game skill-check history could keep unresolved tags instead of the resolved roll result.
- Review found three follow-up risks: timing state advanced before the final chat-wide lorebook budget, direct `input.messages` generations did not persist lorebook timing after save, and skill-check history rewrites used a blind read-modify-write on message content.

## What changed

- Wires lorebook timing state through prompt assembly and generation persistence after successful assistant message saves.
- Computes next lorebook timing state from the post-chat-budget included entries so budget-skipped lore does not burn cooldown/sticky/delay state.
- Persists lorebook timing state in the direct request-message save path after a successful assistant message save.
- Persists resolved game skill-check tags back into the source message history when a message id is provided.
- Keeps already-resolved skill-check tags unchanged and treats history persistence as best-effort so roll results still return if storage update fails.
- Guards skill-check history rewrites by chat id to avoid cross-chat message mutation.
- Adds a focused conditional chat-message content update through the shared storage API, embedded Tauri command, and hostable HTTP dispatch so skill-check history rewrites can retry without clobbering concurrent content changes.

## Refactor impact

Primary owner:

Engine generation, game mode API, shared storage API, and Rust storage command routing.

Impact areas reviewed:

- Prompt assembly lorebook scan/timing path.
- Generation assistant-message save flow, including direct request-message saves.
- Game mode skill-check API and history mutation path.
- Shared storage API wrapper and remote-runtime allowlist.
- Embedded Tauri command registration and hostable HTTP dispatch.
- Game hooks/surface callers, skill-check tag parser/serializer, segment edits, and storage API contracts.

Boundary notes:

- Engine generation remains React-free and uses engine contracts/helpers only.
- Feature game API continues to call focused shared storage API wrappers rather than raw Tauri or remote-runtime fetch.
- The new conditional content update is owned by the storage API boundary and is explicitly routed through Tauri command registration, `remote-runtime.ts`, and `http_dispatch.rs`.
- Rust storage keeps the atomic compare/update under the storage write lock; game-specific tag serialization remains in TypeScript game API code.

Pressure points touched:

- Prompt assembly timing-state output.
- `startGeneration` post-save metadata persistence in normal and direct-message branches.
- Game API skill-check history persistence.
- Shared storage API and Rust storage command routing.
- `GameSurface` was reviewed as a dependent caller but not modified.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->

- [x] `pnpm check` passes locally
- [x] `pnpm typecheck` passes locally
- [x] `pnpm build` passes locally
- [x] `pnpm check:architecture` passes locally
- [x] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Rebased onto current `origin/refactor` before initial push.
- Ran `pnpm exec vitest run src/engine/generation/prompt-assembly.test.ts src/engine/generation/start-generation.test.ts src/features/modes/game/api/game-api.test.ts src/shared/api/storage-api.test.ts` after review fixes: 4 files passed, 135 tests passed.
- Ran `cargo test --manifest-path src-tauri/Cargo.toml update_message_content_if_unchanged_updates_only_matching_content`: passed.
- Ran `pnpm typecheck`: passed.
- Ran `cargo check --manifest-path src-tauri/Cargo.toml --workspace`: passed.
- Ran `pnpm check:architecture`: passed.
- Ran `pnpm check:unused`: passed.
- Ran `pnpm format:check`: passed.
- Ran `pnpm build`: passed with the existing Vite large-chunk warning.
- Ran `git diff --check`: passed.
- No native Tauri/manual game UI pass was run.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

No changelog file is present in this repo. No docs updates were made because this wires existing runtime/history behavior and adds a narrow storage command for that path rather than changing setup, architecture guidance, or user-facing documentation.

## UI evidence

Not a visual UI change; no screenshots or recordings added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Lorebook entries now maintain and persist timing states across conversation turns, properly tracking delays, cooldowns, and sticky effects.
* Skill check results in game mode are now automatically recorded and saved in chat history for reference and persistence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1651?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->