### PR TITLE
[codex] Move persona hooks to catalog personas

### DIFF
--- a/docs/developer/architecture.html
+++ b/docs/developer/architecture.html
@@ -287,14 +287,14 @@ flowchart TB
             <tr>
               <td><code>catalog/characters</code></td>
               <td>Character library hooks, groups, sprites, start-chat helpers, and character shell surfaces.</td>
-              <td>Current public callers also use this package for persona data hooks and persona groups.</td>
+              <td>Persona data hooks and persona groups live behind <code>catalog/personas</code>.</td>
             </tr>
             <tr>
               <td><code>catalog/personas</code></td>
-              <td>Persona panel/editor/modals and persona query-key file.</td>
+              <td>Persona panel/editor/modals, persona data hooks, persona groups, and persona query keys.</td>
               <td>
-                This package currently has no <code>index.ts</code>; most shared persona hook consumers import from
-                <code>catalog/characters/index.ts</code>.
+                Public persona data callers import from <code>catalog/personas/index.ts</code>. App-shell lazy UI
+                entrypoints keep using <code>catalog/personas/shell.ts</code>.
               </td>
             </tr>
             <tr>

--- a/docs/developer/modules.html
+++ b/docs/developer/modules.html
@@ -99,10 +99,10 @@
             </tr>
             <tr>
               <td><code>features/catalog/personas</code></td>
-              <td>Persona panel/editor/modals, imports, and query keys.</td>
+              <td>Persona panel/editor/modals, imports, data hooks, and query keys.</td>
               <td>
-                Storage API, avatar API, persona contracts. Current shared persona data hooks are exported from
-                <code>features/catalog/characters/index.ts</code>.
+                Storage API, avatar API, persona contracts. Shared persona data hooks are exported from
+                <code>features/catalog/personas/index.ts</code>.
               </td>
             </tr>
             <tr>

--- a/src/features/catalog/characters/components/CharacterEditor.test.tsx
+++ b/src/features/catalog/characters/components/CharacterEditor.test.tsx
@@ -11,7 +11,7 @@ import { useUIStore } from "../../../../shared/stores/ui.store";
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
 // ── Mocks ──
-// The editor pulls every character data-hook from this barrel. We only need
+// The editor pulls every character data-hook from this module. We only need
 // useCharacter to feed it a deliberately malformed card (no `extensions` key);
 // the rest are stubbed to inert no-ops so the component mounts without touching
 // the Tauri storage layer.
@@ -30,8 +30,6 @@ vi.mock("../hooks/use-characters", () => {
     useUploadAvatar: noopMutation,
     useDeleteCharacter: noopMutation,
     useDuplicateCharacter: noopMutation,
-    useCreatePersona: noopMutation,
-    useUploadPersonaAvatar: noopMutation,
     useCharacterSprites: emptyQuery,
     useCharacterGalleryImages: emptyQuery,
     useUploadCharacterGalleryImage: noopMutation,
@@ -49,6 +47,18 @@ vi.mock("../hooks/use-characters", () => {
       list: (id: string) => ["sprites", id],
       capabilities: () => ["sprites", "capabilities"],
     },
+  };
+});
+
+vi.mock("../../personas/index", () => {
+  const noopMutation = () => ({
+    mutate: vi.fn(),
+    mutateAsync: vi.fn().mockResolvedValue(undefined),
+    isPending: false,
+  });
+  return {
+    useCreatePersona: noopMutation,
+    useUploadPersonaAvatar: noopMutation,
   };
 });
 

--- a/src/features/catalog/characters/components/CharacterEditor.tsx
+++ b/src/features/catalog/characters/components/CharacterEditor.tsx
@@ -13,8 +13,6 @@ import {
   useUploadAvatar,
   useDeleteCharacter,
   useDuplicateCharacter,
-  useCreatePersona,
-  useUploadPersonaAvatar,
   useCharacterSprites,
   useCharacterGalleryImages,
   useUploadCharacterGalleryImage,
@@ -32,6 +30,7 @@ import {
   type CharacterGalleryImage,
   type SpriteInfo,
 } from "../hooks/use-characters";
+import { useCreatePersona, useUploadPersonaAvatar } from "../../personas/index";
 import { useUIStore } from "../../../../shared/stores/ui.store";
 import { lorebookKeys, useLorebook } from "../../lorebooks/index";
 import { useStartChatFromCharacter } from "../hooks/use-start-chat-from-character";

--- a/src/features/catalog/characters/hooks/use-characters.ts
+++ b/src/features/catalog/characters/hooks/use-characters.ts
@@ -1,5 +1,5 @@
 // ──────────────────────────────────────────────
-// React Query: Character, Group & Persona hooks
+// React Query: Character & Group hooks
 // ──────────────────────────────────────────────
 import { useMemo } from "react";
 import { useQuery, useQueries, useMutation, useQueryClient, type QueryClient } from "@tanstack/react-query";
@@ -15,7 +15,6 @@ import { ApiError } from "../../../../shared/api/api-errors";
 import { storageApi } from "../../../../shared/api/storage-api";
 import { storageCommandsApi } from "../../../../shared/api/storage-commands-api";
 import { galleryApi, spriteApi } from "../../../../shared/api/image-generation-api";
-import { personaApi } from "../../../../shared/api/persona-api";
 import type { CharacterCardVersion } from "../../../../engine/contracts/types/character";
 import type { SpriteCapabilities, SpriteCleanupEngine } from "../../../../shared/types/sprite-capabilities";
 
@@ -40,21 +39,6 @@ export type CharacterSummary = {
   updatedAt?: string;
 };
 
-export type PersonaSummary = {
-  id: string;
-  name?: string;
-  comment?: string | null;
-  description?: string;
-  tags?: string[];
-  avatarPath?: string | null;
-  avatarCrop?: unknown;
-  isActive?: string | boolean;
-  createdAt?: string;
-  nameColor?: string;
-  dialogueColor?: string;
-  boxColor?: string;
-};
-
 const CHARACTER_LIST_FIELDS = ["id", "data", "comment", "avatarFilePath", "avatarFilename", "createdAt", "updatedAt"];
 
 const CHARACTER_SUMMARY_OPTIONS = {
@@ -66,24 +50,6 @@ const CHARACTER_LIST_OPTIONS = {
 };
 const CHARACTER_SUMMARY_BY_ID_CONCURRENCY = 8;
 const EMPTY_CHARACTER_SUMMARIES: CharacterSummary[] = [];
-
-const PERSONA_SUMMARY_OPTIONS = {
-  fields: [
-    "id",
-    "name",
-    "comment",
-    "description",
-    "tags",
-    "avatarPath",
-    "avatarCrop",
-    "isActive",
-    "active",
-    "createdAt",
-    "nameColor",
-    "dialogueColor",
-    "boxColor",
-  ],
-};
 
 function isCharacterListRecord(value: unknown): value is CharacterListRecord & { id: string } {
   return Boolean(
@@ -590,164 +556,6 @@ export function useDeleteCharacterGalleryImage(characterId: string) {
   });
 }
 
-// ── Personas ──
-
-export function usePersonas(enabled = true) {
-  return useQuery({
-    queryKey: characterKeys.personas,
-    queryFn: () => storageApi.list<unknown>("personas"),
-    enabled,
-    staleTime: 5 * 60_000,
-    refetchOnWindowFocus: false,
-  });
-}
-
-export function usePersonaSummaries(enabled = true) {
-  return useQuery({
-    queryKey: characterKeys.personaSummaries,
-    queryFn: () => storageApi.list<PersonaSummary>("personas", PERSONA_SUMMARY_OPTIONS),
-    enabled,
-    staleTime: 5 * 60_000,
-    refetchOnWindowFocus: false,
-  });
-}
-
-export function usePersona(id: string | null, enabled = true) {
-  return useQuery({
-    queryKey: characterKeys.personaDetail(id ?? ""),
-    queryFn: () => storageApi.get("personas", id!),
-    enabled: enabled && !!id,
-    staleTime: 5 * 60_000,
-    refetchOnWindowFocus: false,
-  });
-}
-
-export function useActivePersona(enabled = true) {
-  return useQuery({
-    queryKey: characterKeys.activePersona,
-    queryFn: async () => {
-      const personas = await storageApi.list<PersonaSummary & { active?: string | boolean }>(
-        "personas",
-        PERSONA_SUMMARY_OPTIONS,
-      );
-      return (
-        personas.find(
-          (persona) =>
-            persona.isActive === true ||
-            persona.isActive === "true" ||
-            persona.active === true ||
-            persona.active === "true",
-        ) ?? null
-      );
-    },
-    enabled,
-    staleTime: 5 * 60_000,
-    refetchOnWindowFocus: false,
-  });
-}
-
-export function useCreatePersona() {
-  const qc = useQueryClient();
-  return useMutation({
-    mutationFn: (data: {
-      name: string;
-      description?: string;
-      comment?: string;
-      personality?: string;
-      scenario?: string;
-      backstory?: string;
-      appearance?: string;
-      nameColor?: string;
-      dialogueColor?: string;
-      boxColor?: string;
-      trackerCardColors?: string;
-      personaStats?: unknown;
-      altDescriptions?: unknown[];
-      tags?: string[];
-      savedStatusOptions?: string[];
-      avatarCrop?: unknown;
-    }) => storageApi.create("personas", data),
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: characterKeys.personas });
-      qc.invalidateQueries({ queryKey: characterKeys.personaSummaries });
-    },
-  });
-}
-
-export function useUpdatePersona() {
-  const qc = useQueryClient();
-  return useMutation({
-    mutationFn: ({
-      id,
-      ...data
-    }: {
-      id: string;
-      name?: string;
-      comment?: string;
-      description?: string;
-      personality?: string;
-      scenario?: string;
-      backstory?: string;
-      appearance?: string;
-      nameColor?: string;
-      dialogueColor?: string;
-      boxColor?: string;
-      trackerCardColors?: string;
-      personaStats?: unknown;
-      altDescriptions?: unknown[];
-      tags?: string[];
-      savedStatusOptions?: string[];
-      avatarCrop?: unknown;
-    }) => storageApi.update("personas", id, data),
-    onSuccess: (updatedPersona, variables) => {
-      qc.setQueryData(characterKeys.personaDetail(variables.id), updatedPersona);
-      qc.setQueryData<unknown[] | undefined>(characterKeys.personas, (old) => {
-        if (!Array.isArray(old)) return old;
-        const updatedId = (updatedPersona as { id?: string } | null)?.id ?? variables.id;
-        if (!updatedId) return old;
-
-        return old.map((p) => {
-          const row = p as Record<string, unknown> & { id?: string };
-          if (row?.id !== updatedId) return p;
-          if (!updatedPersona || typeof updatedPersona !== "object") return p;
-          return { ...row, ...(updatedPersona as Record<string, unknown>) };
-        });
-      });
-
-      qc.invalidateQueries({ queryKey: characterKeys.personas });
-      qc.invalidateQueries({ queryKey: characterKeys.personaSummaries });
-      qc.invalidateQueries({ queryKey: characterKeys.personaDetail(variables.id) });
-    },
-  });
-}
-
-export function useDeletePersona() {
-  const qc = useQueryClient();
-  return useMutation({
-    mutationFn: (id: string) => storageApi.delete("personas", id),
-    onSuccess: (_data, id) => {
-      qc.removeQueries({ queryKey: characterKeys.personaDetail(id) });
-      qc.removeQueries({ queryKey: characterKeys.personaSummaryDetail(id) });
-      qc.invalidateQueries({ queryKey: characterKeys.personas });
-      qc.invalidateQueries({ queryKey: characterKeys.personaSummaries });
-    },
-  });
-}
-
-export function useUploadPersonaAvatar() {
-  const qc = useQueryClient();
-  return useMutation({
-    mutationFn: ({ id, avatar, filename }: { id: string; avatar: string; filename?: string }) =>
-      personaApi.uploadAvatar(id, avatar, filename),
-    onSuccess: (_data, variables) => {
-      qc.invalidateQueries({ queryKey: characterKeys.personas });
-      qc.invalidateQueries({ queryKey: characterKeys.personaSummaries });
-      qc.invalidateQueries({ queryKey: characterKeys.personaDetail(variables.id) });
-      qc.invalidateQueries({ queryKey: characterKeys.personaSummaryDetail(variables.id) });
-    },
-  });
-}
-
 // ── Character Groups ──
 
 export function useCharacterGroups() {
@@ -780,15 +588,5 @@ export function useDeleteGroup() {
   return useMutation({
     mutationFn: (id: string) => storageApi.delete("character-groups", id),
     onSuccess: () => qc.invalidateQueries({ queryKey: characterKeys.groups }),
-  });
-}
-
-// ── Persona Groups ──
-
-export function usePersonaGroups(enabled = true) {
-  return useQuery({
-    queryKey: characterKeys.personaGroups,
-    queryFn: () => storageApi.list<unknown>("persona-groups"),
-    enabled,
   });
 }

--- a/src/features/catalog/characters/query-keys.ts
+++ b/src/features/catalog/characters/query-keys.ts
@@ -8,14 +8,7 @@ export const characterKeys = {
   detail: (id: string) => [...characterKeys.all, "detail", id] as const,
   versions: (id: string) => [...characterKeys.detail(id), "versions"] as const,
   gallery: (id: string) => [...characterKeys.all, "gallery", id] as const,
-  personas: ["personas"] as const,
-  personaSummaries: ["personas", "summaries"] as const,
-  personaSummaryDetail: (id: string) => ["personas", "summaries", id] as const,
-  personaDetail: (id: string) => [...characterKeys.personas, "detail", id] as const,
-  activePersona: ["personas", "active"] as const,
   groups: ["character-groups"] as const,
-  personaGroups: ["persona-groups"] as const,
-  personaGroupDetail: (id: string) => ["persona-groups", "detail", id] as const,
 };
 
 export const spriteKeys = {

--- a/src/features/catalog/lorebooks/components/LorebookEditor.tsx
+++ b/src/features/catalog/lorebooks/components/LorebookEditor.tsx
@@ -35,7 +35,8 @@ import {
   useBulkUnvectorizeLorebookEntries,
   lorebookKeys,
 } from "../hooks/use-lorebooks";
-import { useCharacterSummaries, useCharacterSummariesByIds, usePersonaSummaries } from "../../characters/index";
+import { useCharacterSummaries, useCharacterSummariesByIds } from "../../characters/index";
+import { usePersonaSummaries } from "../../personas/index";
 import { useConnections } from "../../connections/index";
 import { showConfirmDialog } from "../../../../shared/lib/app-dialogs";
 import { useUIStore } from "../../../../shared/stores/ui.store";

--- a/src/features/catalog/lorebooks/components/LorebooksPanel.tsx
+++ b/src/features/catalog/lorebooks/components/LorebooksPanel.tsx
@@ -28,7 +28,8 @@ import {
 import { useUIStore } from "../../../../shared/stores/ui.store";
 import { useChatStore } from "../../../../shared/stores/chat.store";
 import { useLorebooks, useDeleteLorebook, useUpdateLorebook, useUploadLorebookImage } from "../hooks/use-lorebooks";
-import { useCharacterSummariesByIds, usePersonaSummaries } from "../../characters/index";
+import { useCharacterSummariesByIds } from "../../characters/index";
+import { usePersonaSummaries } from "../../personas/index";
 import type { Lorebook, LorebookCategory } from "../../../../engine/contracts/types/lorebook";
 import { showConfirmDialog } from "../../../../shared/lib/app-dialogs";
 import { cn } from "../../../../shared/lib/utils";

--- a/src/features/catalog/personas/components/CreatePersonaModal.tsx
+++ b/src/features/catalog/personas/components/CreatePersonaModal.tsx
@@ -3,7 +3,7 @@
 // ──────────────────────────────────────────────
 import { useState } from "react";
 import { Modal } from "../../../../shared/components/ui/Modal";
-import { useCreatePersona } from "../../characters/index";
+import { useCreatePersona } from "../hooks/use-personas";
 import { useUIStore } from "../../../../shared/stores/ui.store";
 import { Loader2, User } from "lucide-react";
 import { toast } from "sonner";

--- a/src/features/catalog/personas/components/ImportPersonaModal.tsx
+++ b/src/features/catalog/personas/components/ImportPersonaModal.tsx
@@ -5,7 +5,7 @@ import { useState, useRef } from "react";
 import { Modal } from "../../../../shared/components/ui/Modal";
 import { Download, FileJson, CheckCircle, XCircle, Loader2 } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
-import { characterKeys } from "../../characters/index";
+import { personaKeys } from "../query-keys";
 import { importApi } from "../../../../shared/api/import-api";
 import { storageApi } from "../../../../shared/api/storage-api";
 
@@ -126,7 +126,7 @@ export function ImportPersonaModal({ open, onClose }: Props) {
     setResults(nextResults);
     setStatus("done");
     if (nextResults.some((result) => result.success)) {
-      qc.invalidateQueries({ queryKey: characterKeys.personas });
+      qc.invalidateQueries({ queryKey: personaKeys.list });
     }
   };
 

--- a/src/features/catalog/personas/components/PersonaEditor.tsx
+++ b/src/features/catalog/personas/components/PersonaEditor.tsx
@@ -6,7 +6,7 @@
 // ──────────────────────────────────────────────
 import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { toast } from "sonner";
-import { usePersona, useUpdatePersona, useUploadPersonaAvatar, useDeletePersona } from "../../characters/index";
+import { usePersona, useUpdatePersona, useUploadPersonaAvatar, useDeletePersona } from "../hooks/use-personas";
 import { useConnections } from "../../connections/index";
 import { useUIStore } from "../../../../shared/stores/ui.store";
 import {

--- a/src/features/catalog/personas/components/PersonaMakerModal.tsx
+++ b/src/features/catalog/personas/components/PersonaMakerModal.tsx
@@ -5,7 +5,7 @@
 import { useState, useRef, useCallback } from "react";
 import { Modal } from "../../../../shared/components/ui/Modal";
 import { useConnections } from "../../connections/index";
-import { useCreatePersona } from "../../characters/index";
+import { useCreatePersona } from "../hooks/use-personas";
 import { useUIStore } from "../../../../shared/stores/ui.store";
 import { Sparkles, Loader2, Wand2, CheckCircle, AlertCircle, ChevronDown, User, Save } from "lucide-react";
 import { ProfessorMariWorkingWindow } from "../../../../shared/components/ui/ProfessorMariWorkingWindow";

--- a/src/features/catalog/personas/components/PersonasPanel.tsx
+++ b/src/features/catalog/personas/components/PersonasPanel.tsx
@@ -13,8 +13,8 @@ import {
   useDeletePersonaGroup,
   useUpdatePersona,
   useDuplicatePersona,
+  usePersonaSummaries,
 } from "../hooks/use-personas";
-import { usePersonaSummaries } from "../../characters/index";
 import { useUIStore } from "../../../../shared/stores/ui.store";
 import {
   Plus,

--- a/src/features/catalog/personas/hooks/use-personas.test.tsx
+++ b/src/features/catalog/personas/hooks/use-personas.test.tsx
@@ -1,0 +1,156 @@
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { personaApi } from "../../../../shared/api/persona-api";
+import { storageApi } from "../../../../shared/api/storage-api";
+import { storageCommandsApi } from "../../../../shared/api/storage-commands-api";
+import { personaKeys } from "../query-keys";
+import { useDeletePersona, useUpdatePersona, useUploadPersonaAvatar } from "./use-personas";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock("../../../../shared/api/storage-api", () => ({
+  storageApi: {
+    create: vi.fn(),
+    delete: vi.fn(),
+    get: vi.fn(),
+    list: vi.fn(),
+    update: vi.fn(),
+  },
+}));
+
+vi.mock("../../../../shared/api/persona-api", () => ({
+  personaApi: {
+    activate: vi.fn(),
+    uploadAvatar: vi.fn(),
+  },
+}));
+
+vi.mock("../../../../shared/api/storage-commands-api", () => ({
+  storageCommandsApi: {
+    duplicate: vi.fn(),
+  },
+}));
+
+const storageDeleteMock = vi.mocked(storageApi.delete);
+const storageUpdateMock = vi.mocked(storageApi.update);
+const uploadAvatarMock = vi.mocked(personaApi.uploadAvatar);
+const duplicateMock = vi.mocked(storageCommandsApi.duplicate);
+
+describe("persona mutations", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    queryClient = new QueryClient({
+      defaultOptions: {
+        mutations: { retry: false },
+        queries: { retry: false },
+      },
+    });
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    queryClient.clear();
+    storageDeleteMock.mockReset();
+    storageUpdateMock.mockReset();
+    uploadAvatarMock.mockReset();
+    duplicateMock.mockReset();
+  });
+
+  async function renderMutation<TMutation>(useHook: () => TMutation): Promise<TMutation> {
+    let mutation: TMutation | undefined;
+
+    function Probe() {
+      mutation = useHook();
+      return null;
+    }
+
+    await act(async () => {
+      root.render(
+        createElement(QueryClientProvider, {
+          client: queryClient,
+          children: createElement(Probe),
+        }),
+      );
+    });
+
+    if (!mutation) {
+      throw new Error("Mutation hook did not render");
+    }
+
+    return mutation;
+  }
+
+  function primeActivePersonaCache() {
+    queryClient.setQueryData(personaKeys.active, {
+      id: "persona-1",
+      isActive: true,
+      name: "Current Persona",
+    });
+
+    expect(queryClient.getQueryState(personaKeys.active)?.isInvalidated).toBe(false);
+  }
+
+  function expectActivePersonaInvalidated() {
+    expect(queryClient.getQueryState(personaKeys.active)?.isInvalidated).toBe(true);
+  }
+
+  it("invalidates the active persona cache after updating a persona", async () => {
+    const updatePersona = await renderMutation(useUpdatePersona);
+    primeActivePersonaCache();
+    storageUpdateMock.mockResolvedValue({
+      id: "persona-1",
+      isActive: true,
+      name: "Updated Persona",
+    });
+
+    await act(async () => {
+      await updatePersona.mutateAsync({ id: "persona-1", name: "Updated Persona" });
+    });
+
+    expect(storageUpdateMock).toHaveBeenCalledWith("personas", "persona-1", { name: "Updated Persona" });
+    expectActivePersonaInvalidated();
+  });
+
+  it("invalidates the active persona cache after deleting a persona", async () => {
+    const deletePersona = await renderMutation(useDeletePersona);
+    primeActivePersonaCache();
+    storageDeleteMock.mockResolvedValue({ deleted: true });
+
+    await act(async () => {
+      await deletePersona.mutateAsync("persona-1");
+    });
+
+    expect(storageDeleteMock).toHaveBeenCalledWith("personas", "persona-1");
+    expectActivePersonaInvalidated();
+  });
+
+  it("invalidates the active persona cache after uploading a persona avatar", async () => {
+    const uploadPersonaAvatar = await renderMutation(useUploadPersonaAvatar);
+    primeActivePersonaCache();
+    uploadAvatarMock.mockResolvedValue({ id: "persona-1", avatarPath: "avatars/persona-1.png" });
+
+    await act(async () => {
+      await uploadPersonaAvatar.mutateAsync({
+        id: "persona-1",
+        avatar: "data:image/png;base64,avatar",
+        filename: "persona-1.png",
+      });
+    });
+
+    expect(uploadAvatarMock).toHaveBeenCalledWith("persona-1", "data:image/png;base64,avatar", "persona-1.png");
+    expectActivePersonaInvalidated();
+  });
+});

--- a/src/features/catalog/personas/hooks/use-personas.ts
+++ b/src/features/catalog/personas/hooks/use-personas.ts
@@ -164,6 +164,7 @@ export function useUpdatePersona() {
       qc.invalidateQueries({ queryKey: personaKeys.list });
       qc.invalidateQueries({ queryKey: personaKeys.summaries });
       qc.invalidateQueries({ queryKey: personaKeys.detail(variables.id) });
+      qc.invalidateQueries({ queryKey: personaKeys.active });
     },
   });
 }
@@ -177,6 +178,7 @@ export function useDeletePersona() {
       qc.removeQueries({ queryKey: personaKeys.summaryDetail(id) });
       qc.invalidateQueries({ queryKey: personaKeys.list });
       qc.invalidateQueries({ queryKey: personaKeys.summaries });
+      qc.invalidateQueries({ queryKey: personaKeys.active });
     },
   });
 }
@@ -214,6 +216,7 @@ export function useUploadPersonaAvatar() {
       qc.invalidateQueries({ queryKey: personaKeys.summaries });
       qc.invalidateQueries({ queryKey: personaKeys.detail(variables.id) });
       qc.invalidateQueries({ queryKey: personaKeys.summaryDetail(variables.id) });
+      qc.invalidateQueries({ queryKey: personaKeys.active });
     },
   });
 }

--- a/src/features/catalog/personas/hooks/use-personas.ts
+++ b/src/features/catalog/personas/hooks/use-personas.ts
@@ -4,6 +4,123 @@ import { personaApi } from "../../../../shared/api/persona-api";
 import { storageApi } from "../../../../shared/api/storage-api";
 import { storageCommandsApi } from "../../../../shared/api/storage-commands-api";
 
+export { personaKeys } from "../query-keys";
+
+export type PersonaSummary = {
+  id: string;
+  name?: string;
+  comment?: string | null;
+  description?: string;
+  tags?: string[];
+  avatarPath?: string | null;
+  avatarCrop?: unknown;
+  isActive?: string | boolean;
+  createdAt?: string;
+  nameColor?: string;
+  dialogueColor?: string;
+  boxColor?: string;
+};
+
+const PERSONA_SUMMARY_OPTIONS = {
+  fields: [
+    "id",
+    "name",
+    "comment",
+    "description",
+    "tags",
+    "avatarPath",
+    "avatarCrop",
+    "isActive",
+    "active",
+    "createdAt",
+    "nameColor",
+    "dialogueColor",
+    "boxColor",
+  ],
+};
+
+export function usePersonas(enabled = true) {
+  return useQuery({
+    queryKey: personaKeys.list,
+    queryFn: () => storageApi.list<unknown>("personas"),
+    enabled,
+    staleTime: 5 * 60_000,
+    refetchOnWindowFocus: false,
+  });
+}
+
+export function usePersonaSummaries(enabled = true) {
+  return useQuery({
+    queryKey: personaKeys.summaries,
+    queryFn: () => storageApi.list<PersonaSummary>("personas", PERSONA_SUMMARY_OPTIONS),
+    enabled,
+    staleTime: 5 * 60_000,
+    refetchOnWindowFocus: false,
+  });
+}
+
+export function usePersona(id: string | null, enabled = true) {
+  return useQuery({
+    queryKey: personaKeys.detail(id ?? ""),
+    queryFn: () => storageApi.get("personas", id!),
+    enabled: enabled && !!id,
+    staleTime: 5 * 60_000,
+    refetchOnWindowFocus: false,
+  });
+}
+
+export function useActivePersona(enabled = true) {
+  return useQuery({
+    queryKey: personaKeys.active,
+    queryFn: async () => {
+      const personas = await storageApi.list<PersonaSummary & { active?: string | boolean }>(
+        "personas",
+        PERSONA_SUMMARY_OPTIONS,
+      );
+      return (
+        personas.find(
+          (persona) =>
+            persona.isActive === true ||
+            persona.isActive === "true" ||
+            persona.active === true ||
+            persona.active === "true",
+        ) ?? null
+      );
+    },
+    enabled,
+    staleTime: 5 * 60_000,
+    refetchOnWindowFocus: false,
+  });
+}
+
+export function useCreatePersona() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: {
+      name: string;
+      description?: string;
+      comment?: string;
+      personality?: string;
+      scenario?: string;
+      backstory?: string;
+      appearance?: string;
+      nameColor?: string;
+      dialogueColor?: string;
+      boxColor?: string;
+      trackerCardColors?: string;
+      personaStats?: unknown;
+      altDescriptions?: unknown[];
+      tags?: string[];
+      savedStatusOptions?: string[];
+      avatarCrop?: unknown;
+    }) => storageApi.create("personas", data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: personaKeys.list });
+      qc.invalidateQueries({ queryKey: personaKeys.summaries });
+    },
+  });
+}
+
 export function useUpdatePersona() {
   const qc = useQueryClient();
   return useMutation({
@@ -19,13 +136,35 @@ export function useUpdatePersona() {
       scenario?: string;
       backstory?: string;
       appearance?: string;
+      nameColor?: string;
+      dialogueColor?: string;
+      boxColor?: string;
+      trackerCardColors?: string;
       tags?: string[];
       altDescriptions?: unknown[];
       savedStatusOptions?: string[];
       avatarCrop?: unknown;
       personaStats?: unknown;
     }) => storageApi.update("personas", id, data),
-    onSuccess: () => qc.invalidateQueries({ queryKey: personaKeys.list }),
+    onSuccess: (updatedPersona, variables) => {
+      qc.setQueryData(personaKeys.detail(variables.id), updatedPersona);
+      qc.setQueryData<unknown[] | undefined>(personaKeys.list, (old) => {
+        if (!Array.isArray(old)) return old;
+        const updatedId = (updatedPersona as { id?: string } | null)?.id ?? variables.id;
+        if (!updatedId) return old;
+
+        return old.map((persona) => {
+          const row = persona as Record<string, unknown> & { id?: string };
+          if (row?.id !== updatedId) return persona;
+          if (!updatedPersona || typeof updatedPersona !== "object") return persona;
+          return { ...row, ...(updatedPersona as Record<string, unknown>) };
+        });
+      });
+
+      qc.invalidateQueries({ queryKey: personaKeys.list });
+      qc.invalidateQueries({ queryKey: personaKeys.summaries });
+      qc.invalidateQueries({ queryKey: personaKeys.detail(variables.id) });
+    },
   });
 }
 
@@ -33,7 +172,12 @@ export function useDeletePersona() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (id: string) => storageApi.delete("personas", id),
-    onSuccess: () => qc.invalidateQueries({ queryKey: personaKeys.list }),
+    onSuccess: (_data, id) => {
+      qc.removeQueries({ queryKey: personaKeys.detail(id) });
+      qc.removeQueries({ queryKey: personaKeys.summaryDetail(id) });
+      qc.invalidateQueries({ queryKey: personaKeys.list });
+      qc.invalidateQueries({ queryKey: personaKeys.summaries });
+    },
   });
 }
 
@@ -41,7 +185,10 @@ export function useDuplicatePersona() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (id: string) => storageCommandsApi.duplicate("personas", id),
-    onSuccess: () => qc.invalidateQueries({ queryKey: personaKeys.list }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: personaKeys.list });
+      qc.invalidateQueries({ queryKey: personaKeys.summaries });
+    },
   });
 }
 
@@ -49,7 +196,11 @@ export function useActivatePersona() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (id: string) => personaApi.activate(id),
-    onSuccess: () => qc.invalidateQueries({ queryKey: personaKeys.list }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: personaKeys.list });
+      qc.invalidateQueries({ queryKey: personaKeys.summaries });
+      qc.invalidateQueries({ queryKey: personaKeys.active });
+    },
   });
 }
 
@@ -58,14 +209,20 @@ export function useUploadPersonaAvatar() {
   return useMutation({
     mutationFn: ({ id, avatar, filename }: { id: string; avatar: string; filename?: string }) =>
       personaApi.uploadAvatar(id, avatar, filename),
-    onSuccess: () => qc.invalidateQueries({ queryKey: personaKeys.list }),
+    onSuccess: (_data, variables) => {
+      qc.invalidateQueries({ queryKey: personaKeys.list });
+      qc.invalidateQueries({ queryKey: personaKeys.summaries });
+      qc.invalidateQueries({ queryKey: personaKeys.detail(variables.id) });
+      qc.invalidateQueries({ queryKey: personaKeys.summaryDetail(variables.id) });
+    },
   });
 }
 
-export function usePersonaGroups() {
+export function usePersonaGroups(enabled = true) {
   return useQuery({
     queryKey: personaKeys.groups,
     queryFn: () => storageApi.list<unknown>("persona-groups"),
+    enabled,
   });
 }
 

--- a/src/features/catalog/personas/index.ts
+++ b/src/features/catalog/personas/index.ts
@@ -1,0 +1,2 @@
+export * from "./query-keys";
+export * from "./hooks/use-personas";

--- a/src/features/catalog/personas/query-keys.test.ts
+++ b/src/features/catalog/personas/query-keys.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { personaKeys } from "./query-keys";
+
+describe("personaKeys", () => {
+  it("preserves the legacy persona cache key values", () => {
+    expect(personaKeys.list).toEqual(["personas"]);
+    expect(personaKeys.summaries).toEqual(["personas", "summaries"]);
+    expect(personaKeys.summaryDetail("persona-1")).toEqual(["personas", "summaries", "persona-1"]);
+    expect(personaKeys.detail("persona-1")).toEqual(["personas", "detail", "persona-1"]);
+    expect(personaKeys.active).toEqual(["personas", "active"]);
+    expect(personaKeys.groups).toEqual(["persona-groups"]);
+    expect(personaKeys.groupDetail("group-1")).toEqual(["persona-groups", "detail", "group-1"]);
+  });
+});

--- a/src/features/catalog/personas/query-keys.ts
+++ b/src/features/catalog/personas/query-keys.ts
@@ -1,4 +1,9 @@
 export const personaKeys = {
   list: ["personas"] as const,
+  summaries: ["personas", "summaries"] as const,
+  summaryDetail: (id: string) => ["personas", "summaries", id] as const,
+  detail: (id: string) => [...personaKeys.list, "detail", id] as const,
+  active: ["personas", "active"] as const,
   groups: ["persona-groups"] as const,
+  groupDetail: (id: string) => ["persona-groups", "detail", id] as const,
 };

--- a/src/features/modes/conversation/components/ConversationInput.tsx
+++ b/src/features/modes/conversation/components/ConversationInput.tsx
@@ -34,7 +34,8 @@ import {
   useChat,
   chatKeys,
 } from "../../../catalog/chats/index";
-import { characterKeys, useActivePersona, usePersona, useUpdatePersona } from "../../../catalog/characters/index";
+import { characterKeys } from "../../../catalog/characters/index";
+import { personaKeys, useActivePersona, usePersona, useUpdatePersona } from "../../../catalog/personas/index";
 import {
   matchSlashCommand,
   getSlashCompletions,
@@ -561,7 +562,7 @@ export function ConversationInput({
     if (isStreaming) {
       const activeChatData = useChatStore.getState().activeChat;
       const cachedCharacters = qc.getQueryData<Array<{ id: string; data: unknown }>>(characterKeys.list());
-      const cachedPersonas = qc.getQueryData<Array<Record<string, unknown>>>(characterKeys.personas);
+      const cachedPersonas = qc.getQueryData<Array<Record<string, unknown>>>(personaKeys.list);
       const resolveInputMacros = createInputMacroResolverForChat(activeChatData, cachedCharacters, cachedPersonas, raw);
       // First pass: resolve macros against raw input, so {{input}} uses the pre-translation text.
       let message = applyToUserInput(raw, { resolveMacros: resolveInputMacros });
@@ -666,7 +667,7 @@ export function ConversationInput({
 
     const activeChat = useChatStore.getState().activeChat;
     const cachedCharacters = qc.getQueryData<Array<{ id: string; data: unknown }>>(characterKeys.list());
-    const cachedPersonas = qc.getQueryData<Array<Record<string, unknown>>>(characterKeys.personas);
+    const cachedPersonas = qc.getQueryData<Array<Record<string, unknown>>>(personaKeys.list);
     const resolveInputMacros = createInputMacroResolverForChat(activeChat, cachedCharacters, cachedPersonas, raw);
     // First pass: resolve macros against raw input, so {{input}} uses the pre-translation text.
     let message = applyToUserInput(raw, { resolveMacros: resolveInputMacros });
@@ -864,7 +865,7 @@ export function ConversationInput({
 
     const activeChatData = useChatStore.getState().activeChat;
     const cachedCharacters = qc.getQueryData<Array<{ id: string; data: unknown }>>(characterKeys.list());
-    const cachedPersonas = qc.getQueryData<Array<Record<string, unknown>>>(characterKeys.personas);
+    const cachedPersonas = qc.getQueryData<Array<Record<string, unknown>>>(personaKeys.list);
     const resolveInputMacros = createInputMacroResolverForChat(activeChatData, cachedCharacters, cachedPersonas, raw);
     let message = applyToUserInput(raw, { resolveMacros: resolveInputMacros });
 

--- a/src/features/modes/game/components/GameSetupWizard.tsx
+++ b/src/features/modes/game/components/GameSetupWizard.tsx
@@ -36,9 +36,9 @@ import {
   characterAvatarUrl,
   useCharacterSummaries,
   useCharacterSummariesByIds,
-  usePersonas,
   type CharacterSummary,
 } from "../../../catalog/characters/index";
+import { usePersonas } from "../../../catalog/personas/index";
 import { useLorebooks } from "../../../catalog/lorebooks/index";
 import { useGameAssetStore } from "../stores/game-asset.store";
 import { useUIStore } from "../../../../shared/stores/ui.store";

--- a/src/features/modes/shared/chat-ui/components/ChatInput.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatInput.tsx
@@ -24,6 +24,7 @@ import { useGenerate } from "../../../../runtime/generation/index";
 import { useApplyRegex } from "../../../../catalog/agents/regex-application";
 import { useCreateMessage, useDeleteMessage, useUpdateMessageExtra, chatKeys } from "../../../../catalog/chats/index";
 import { characterKeys } from "../../../../catalog/characters/index";
+import { personaKeys } from "../../../../catalog/personas/index";
 import type { Message } from "../../../../../engine/contracts/types/chat";
 import { buildGuidedGenerationInstructionMessage } from "../../../../../engine/shared/text/generation-guide";
 import {
@@ -566,7 +567,7 @@ export const ChatInput = memo(function ChatInput({
     }
 
     const cachedCharacters = qc.getQueryData<Array<{ id: string; data: unknown }>>(characterKeys.list());
-    const cachedPersonas = qc.getQueryData<Array<Record<string, unknown>>>(characterKeys.personas);
+    const cachedPersonas = qc.getQueryData<Array<Record<string, unknown>>>(personaKeys.list);
     const resolveInputMacros = createInputMacroResolverForChat(chat, cachedCharacters, cachedPersonas, normalized);
     let message = applyToUserInput(normalized, { resolveMacros: resolveInputMacros });
 
@@ -744,7 +745,7 @@ export const ChatInput = memo(function ChatInput({
     const normalized = formatTextQuotes(raw.trim(), quoteFormat);
     const chat = useChatStore.getState().activeChat;
     const cachedCharacters = qc.getQueryData<Array<{ id: string; data: unknown }>>(characterKeys.list());
-    const cachedPersonas = qc.getQueryData<Array<Record<string, unknown>>>(characterKeys.personas);
+    const cachedPersonas = qc.getQueryData<Array<Record<string, unknown>>>(personaKeys.list);
     const resolveInputMacros = createInputMacroResolverForChat(chat, cachedCharacters, cachedPersonas, normalized);
     let message = applyToUserInput(normalized, { resolveMacros: resolveInputMacros });
 

--- a/src/features/modes/shared/chat-ui/components/ChatSettingsDrawer.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatSettingsDrawer.tsx
@@ -81,10 +81,10 @@ import {
   characterAvatarUrl,
   useCharacterSummaries,
   useCharacterSummariesByIds,
-  usePersonaSummaries,
   useCharacterGroups,
   type SpriteInfo,
 } from "../../../../catalog/characters/index";
+import { usePersonaSummaries } from "../../../../catalog/personas/index";
 import { useLorebooks } from "../../../../catalog/lorebooks/index";
 import { usePresetFull, usePresetSummaries } from "../../../../catalog/presets/index";
 import { useConnections, useSaveConnectionDefaults } from "../../../../catalog/connections/index";

--- a/src/features/modes/shared/chat-ui/components/ChatSetupWizard.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatSetupWizard.tsx
@@ -28,8 +28,8 @@ import {
   characterAvatarUrl,
   useCharacterSummaries,
   useCharacterSummariesByIds,
-  usePersonaSummaries,
 } from "../../../../catalog/characters/index";
+import { usePersonaSummaries } from "../../../../catalog/personas/index";
 import { useLorebooks } from "../../../../catalog/lorebooks/index";
 import { useUpdateChat, useUpdateChatMetadata, useCreateMessage, chatKeys } from "../../../../catalog/chats/index";
 import { useChatPresets, useApplyChatPreset } from "../../../../catalog/chat-presets/index";

--- a/src/features/modes/shared/chat-ui/components/QuickPersonaSwitcher.tsx
+++ b/src/features/modes/shared/chat-ui/components/QuickPersonaSwitcher.tsx
@@ -4,7 +4,7 @@
 // ──────────────────────────────────────────────
 import { useState, useRef, useCallback, useEffect, useMemo } from "react";
 import { ChevronDown, ChevronRight, FolderOpen, Folder } from "lucide-react";
-import { usePersona, usePersonaGroups, usePersonaSummaries } from "../../../../catalog/characters/index";
+import { usePersona, usePersonaGroups, usePersonaSummaries } from "../../../../catalog/personas/index";
 import { useUpdateChat, useChat } from "../../../../catalog/chats/index";
 import { useChatStore } from "../../../../../shared/stores/chat.store";
 import { cn, getAvatarCropStyle, parseAvatarCropJson } from "../../../../../shared/lib/utils";

--- a/src/features/modes/shared/chat-ui/components/QuickSwitcherMobile.tsx
+++ b/src/features/modes/shared/chat-ui/components/QuickSwitcherMobile.tsx
@@ -6,7 +6,7 @@
 import { useState, useRef, useCallback, useEffect, useMemo } from "react";
 import { ChevronUp, ChevronDown, ChevronRight, Link, CircleUser, FolderOpen, Folder, Check } from "lucide-react";
 import { useConnections, useUpdateConnection } from "../../../../catalog/connections/index";
-import { usePersonaGroups, usePersonaSummaries } from "../../../../catalog/characters/index";
+import { usePersonaGroups, usePersonaSummaries } from "../../../../catalog/personas/index";
 import { useUpdateChat, useChat } from "../../../../catalog/chats/index";
 import { useChatStore } from "../../../../../shared/stores/chat.store";
 import { filterLanguageGenerationConnections } from "../../../../../shared/lib/connection-filters";

--- a/src/features/modes/shared/chat-ui/hooks/use-chat-surface-data.ts
+++ b/src/features/modes/shared/chat-ui/hooks/use-chat-surface-data.ts
@@ -8,10 +8,9 @@ import {
 } from "../../../../catalog/chats/index";
 import {
   characterAvatarUrl,
-  useActivePersona,
   useCharactersByIds,
-  usePersona,
 } from "../../../../catalog/characters/index";
+import { useActivePersona, usePersona } from "../../../../catalog/personas/index";
 import { ApiError } from "../../../../../shared/api/api-errors";
 import { getConnectedChatDisplayName, parseChatMetadata } from "../../../../../shared/lib/chat-display";
 import { parseCharacterDisplayData } from "../../../../../shared/lib/character-display";

--- a/src/features/runtime/tracker/components/PersonaTrackerPanel.tsx
+++ b/src/features/runtime/tracker/components/PersonaTrackerPanel.tsx
@@ -4,12 +4,8 @@ import { HeartPulse, Package, Sparkles } from "lucide-react";
 import type { CharacterStat, InventoryItem } from "../../../../engine/contracts/types/game-state";
 import type { Persona } from "../../../../engine/contracts/types/persona";
 import type { TrackerPanelSide, TrackerPanelSizeProfile } from "../../../../shared/stores/ui.store";
-import {
-  characterKeys,
-  useCharacterSprites,
-  useUpdatePersona,
-  type SpriteInfo,
-} from "../../../catalog/characters/index";
+import { useCharacterSprites, type SpriteInfo } from "../../../catalog/characters/index";
+import { personaKeys, useUpdatePersona } from "../../../catalog/personas/index";
 import {
   getTrackerCardPortraitView,
   parseTrackerCardColorConfig,
@@ -167,7 +163,7 @@ export function PersonaInventoryPanel({
       ? personaPortraitFocusOverride
       : personaSavedPortraitFocus;
   const flushPersonaPortraitPendingSave = (pendingSave: PersonaPortraitPendingSave) => {
-    const cachedPersonas = queryClient.getQueryData<unknown[] | undefined>(characterKeys.personas);
+    const cachedPersonas = queryClient.getQueryData<unknown[] | undefined>(personaKeys.list);
     const cachedPersona = Array.isArray(cachedPersonas)
       ? cachedPersonas.find((candidate) => isRecord(candidate) && candidate.id === pendingSave.id)
       : null;

--- a/src/features/runtime/tracker/hooks/use-tracker-panel-model.ts
+++ b/src/features/runtime/tracker/hooks/use-tracker-panel-model.ts
@@ -19,7 +19,8 @@ import type {
   TrackerThoughtBubbleDisplay,
 } from "../../../../shared/stores/ui.store";
 import { chatKeys, preserveRecentMessageContentEdit, useChat } from "../../../catalog/chats/index";
-import { characterAvatarUrl, useCharacterSummaries, usePersonas } from "../../../catalog/characters/index";
+import { characterAvatarUrl, useCharacterSummaries } from "../../../catalog/characters/index";
+import { usePersonas } from "../../../catalog/personas/index";
 import { useTrackerStateController } from "../../world-state/index";
 import { TRACKER_SECTION_AGENT_TYPES, type TrackerPanelSection } from "../../world-state/index";
 import type { TrackerStateController } from "../../world-state/types";

--- a/src/features/shell/imports/components/STBulkImportModal.tsx
+++ b/src/features/shell/imports/components/STBulkImportModal.tsx
@@ -28,7 +28,8 @@ import { cn } from "../../../../shared/lib/utils";
 import { ApiError } from "../../../../shared/api/api-errors";
 import { importApi } from "../../../../shared/api/import-api";
 import { remoteRuntimeTarget } from "../../../../shared/api/remote-runtime";
-import { characterKeys, invalidateCharacterCollectionQueries } from "../../../catalog/characters/index";
+import { invalidateCharacterCollectionQueries } from "../../../catalog/characters/index";
+import { personaKeys } from "../../../catalog/personas/index";
 import { chatKeys } from "../../../catalog/chats/index";
 import { lorebookKeys } from "../../../catalog/lorebooks/index";
 import { presetKeys } from "../../../catalog/presets/index";
@@ -370,7 +371,7 @@ export function STBulkImportModal({ open, onClose }: Props) {
           qc.invalidateQueries({ queryKey: presetKeys.all });
         }
         if (hasImported(data.imported, "personas")) {
-          qc.invalidateQueries({ queryKey: characterKeys.personas });
+          qc.invalidateQueries({ queryKey: personaKeys.list });
         }
         if (hasImported(data.imported, "backgrounds")) {
           qc.invalidateQueries({ queryKey: ["backgrounds"] });

--- a/src/features/shell/mari/components/ProfessorMariSurface.tsx
+++ b/src/features/shell/mari/components/ProfessorMariSurface.tsx
@@ -11,7 +11,7 @@ import {
 import { llmApi } from "../../../../shared/api/llm-api";
 import { mariApi, type ProfessorMariPreferences } from "../../../../shared/api/mari-api";
 import { useConnections } from "../../../catalog/connections/index";
-import { usePersonaSummaries } from "../../../catalog/characters/index";
+import { usePersonaSummaries } from "../../../catalog/personas/index";
 import { ConversationMessage } from "../../../modes/conversation/message-shell";
 import type { CharacterMap, PersonaInfo } from "../../../modes/shared/chat-ui/types";
 import type { Message } from "../../../../engine/contracts/types/chat";

--- a/src/features/shell/settings/hooks/tracker-card-color-manager.test.ts
+++ b/src/features/shell/settings/hooks/tracker-card-color-manager.test.ts
@@ -2,6 +2,7 @@ import { QueryClient } from "@tanstack/react-query";
 import { describe, expect, it } from "vitest";
 import type { Persona } from "../../../../engine/contracts/types/persona";
 import { characterKeys } from "../../../catalog/characters/index";
+import { personaKeys } from "../../../catalog/personas/index";
 import {
   resolveTrackerCardColorTargets,
   updateCachedTrackerCardColorTargetConfig,
@@ -52,7 +53,7 @@ describe("tracker card color manager", () => {
   it("patches persona tracker card color cache previews and clears the preview base on save", () => {
     const queryClient = new QueryClient();
     const target = makeTarget("persona", "persona-1");
-    queryClient.setQueryData(characterKeys.personas, [
+    queryClient.setQueryData(personaKeys.list, [
       {
         id: "persona-1",
         trackerCardColors: "old",
@@ -63,17 +64,17 @@ describe("tracker card color manager", () => {
 
     updateCachedTrackerCardColorTargetConfig(queryClient, target, "preview", "saved");
 
-    expect(queryClient.getQueryData<Record<string, unknown>[]>(characterKeys.personas)?.[0]).toMatchObject({
+    expect(queryClient.getQueryData<Record<string, unknown>[]>(personaKeys.list)?.[0]).toMatchObject({
       trackerCardColors: "preview",
       [TRACKER_CARD_COLOR_PREVIEW_BASE_FIELD]: "saved",
     });
-    expect(queryClient.getQueryData<Record<string, unknown>[]>(characterKeys.personas)?.[1]?.trackerCardColors).toBe(
+    expect(queryClient.getQueryData<Record<string, unknown>[]>(personaKeys.list)?.[1]?.trackerCardColors).toBe(
       "untouched",
     );
 
     updateCachedTrackerCardColorTargetConfig(queryClient, target, "saved");
 
-    const savedPersona = queryClient.getQueryData<Record<string, unknown>[]>(characterKeys.personas)?.[0];
+    const savedPersona = queryClient.getQueryData<Record<string, unknown>[]>(personaKeys.list)?.[0];
     expect(savedPersona?.trackerCardColors).toBe("saved");
     expect(savedPersona).not.toHaveProperty(TRACKER_CARD_COLOR_PREVIEW_BASE_FIELD);
   });

--- a/src/features/shell/settings/hooks/tracker-card-color-manager.ts
+++ b/src/features/shell/settings/hooks/tracker-card-color-manager.ts
@@ -2,6 +2,7 @@ import type { QueryClient } from "@tanstack/react-query";
 import type { PresentCharacter } from "../../../../engine/contracts/types/game-state";
 import type { Persona, TrackerCardColorConfig } from "../../../../engine/contracts/types/persona";
 import { characterKeys } from "../../../catalog/characters/index";
+import { personaKeys } from "../../../catalog/personas/index";
 import { parseCharacterDisplayData } from "../../../../shared/lib/character-display";
 import {
   cleanTrackerCardColorConfig,
@@ -149,7 +150,7 @@ export function updateCachedTrackerCardColorTargetConfig(
   previewBaseSerializedConfig?: string,
 ) {
   if (target.kind === "persona") {
-    queryClient.setQueryData<unknown[] | undefined>(characterKeys.personas, (old) => {
+    queryClient.setQueryData<unknown[] | undefined>(personaKeys.list, (old) => {
       if (!Array.isArray(old)) return old;
 
       return old.map((persona) => {

--- a/src/features/shell/settings/hooks/use-tracker-card-color-manager.ts
+++ b/src/features/shell/settings/hooks/use-tracker-card-color-manager.ts
@@ -1,12 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import type { TrackerCardColorConfig } from "../../../../engine/contracts/types/persona";
-import {
-  useCharacterSummaries,
-  usePersonas,
-  useUpdateCharacter,
-  useUpdatePersona,
-} from "../../../catalog/characters/index";
+import { useCharacterSummaries, useUpdateCharacter } from "../../../catalog/characters/index";
+import { usePersonas, useUpdatePersona } from "../../../catalog/personas/index";
 import { storageApi } from "../../../../shared/api/storage-api";
 import { useChat } from "../../../catalog/chats/index";
 import { useTrackerStateController } from "../../../runtime/world-state/index";


### PR DESCRIPTION
## Linked issue

No linked GitHub issue. This follows the architecture ownership remediation work for persona catalog ownership.

## Why this change

- Move persona data ownership out of `catalog/characters` and behind the existing `catalog/personas` feature boundary.
- Preserve existing TanStack Query cache keys so the ownership cleanup does not split or invalidate active persona caches unexpectedly.

## What changed

- Added `src/features/catalog/personas/index.ts` as the public persona data entrypoint.
- Moved public persona hooks, summary type, and persona query keys behind `catalog/personas`.
- Removed persona-owned hooks and persona key members from `catalog/characters`.
- Updated callers across shell, lorebooks, shared chat UI, conversation input, game setup, and runtime tracker to import persona hooks/keys from `catalog/personas`.
- Added focused cache-key and active-persona invalidation regression tests for persona query behavior.
- Updated developer architecture/module docs to reflect the new persona ownership boundary.

## Refactor impact

Primary owner:

`features/catalog/personas`

Impact areas reviewed:

- `features/catalog/personas` hook/query-key ownership and persona UI components
- `features/catalog/characters` character hooks, query keys, and import-as-persona workflow
- Shared chat UI persona selectors and cached persona reads
- Conversation input persona update/cache reads
- Runtime tracker persona cache/update paths
- Shell settings/imports/Mari persona consumers
- Lorebook and game setup persona summary/list consumers

Boundary notes:

- Feature/catalog-only ownership cleanup.
- No engine, shared API adapter, Rust, Tauri command, or remote runtime routing changes.
- Existing `storageApi`, `personaApi`, and `storageCommandsApi` usage remains in the catalog feature layer.
- Existing persona cache key strings are preserved and covered by a focused test.

Pressure points touched:

- Shared mode UI imports only; no shared mode UI behavior moved.
- Runtime tracker cache helper imports now use `personaKeys.list`.
- Active persona cache now invalidates after persona update/delete/avatar upload.
- No `ModeSurface`, `GameSurface`, `src-tauri/src/lib.rs`, or command registration changes.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->

- [ ] `pnpm check` passes locally
- [x] `pnpm typecheck` passes locally
- [x] `pnpm build` passes locally
- [x] `pnpm check:architecture` passes locally
- [x] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

Automated validation run:

- Bunny follow-up commit `c1e526aa` addressed the active persona cache invalidation review finding for update/delete/avatar upload.
- `pnpm test -- src/features/catalog/personas/query-keys.test.ts src/features/catalog/personas/hooks/use-personas.test.tsx src/features/shell/settings/hooks/tracker-card-color-manager.test.ts src/features/catalog/characters/components/CharacterEditor.test.tsx` passed, 4 files / 8 tests.
- `pnpm typecheck` passed.
- `pnpm check:architecture` passed.
- `pnpm check:docs` passed.
- `pnpm build` passed. Vite emitted the existing large-chunk warning, but the build completed successfully.
- `git diff --check origin/refactor...HEAD -- . ':(exclude)graphify-out/**'` passed.

No browser or native Tauri manual QA was run; this is an import/cache ownership cleanup with no intended visible UI behavior change.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [x] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

Docs note: `docs/developer/architecture.html` and `docs/developer/modules.html` were updated. No `CHANGELOG.md` is present in this checkout, and this change is not release-visible behavior.

## UI evidence

Not applicable; no visible UI change intended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Reorganized persona-related data hooks and utilities into the personas module. All persona features remain fully functional.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1652?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
