### PR TITLE
[codex] Wire roleplay direct-message commands

### DIFF
--- a/src/engine/generation/connected-commands.test.ts
+++ b/src/engine/generation/connected-commands.test.ts
@@ -188,6 +188,34 @@ describe("persistConnectedCommandTags roleplay direct messages", () => {
     });
   });
 
+  it("suppresses the source assistant message when a direct-message command has no visible roleplay text", async () => {
+    const roleplay = {
+      id: "roleplay-1",
+      mode: "roleplay",
+      metadata: { roleplayDmCommandsEnabled: true },
+      notes: [],
+    };
+    const chats = new Map<string, Row>([
+      ["roleplay-1", roleplay],
+      ["conversation-mira", { id: "conversation-mira", mode: "conversation", name: "Mira", characterIds: ["char-mira"] }],
+    ]);
+    const storage = storageWithChats(chats, { characters: [mira] });
+
+    const result = await persistConnectedCommandTags(
+      storage,
+      roleplay,
+      '[dm: character="Mira", message="I found the key."]',
+    );
+
+    expect(result.displayContent).toBe("");
+    expect(result.executedCommands).toEqual(["dm"]);
+    expect(result.suppressAssistantMessage).toBe(true);
+    expect(storage.createChatMessage).toHaveBeenCalledWith(
+      "conversation-mira",
+      expect.objectContaining({ content: "I found the key." }),
+    );
+  });
+
   it("leaves direct-message tags visible when the roleplay setting is disabled", async () => {
     const roleplay = {
       id: "roleplay-1",

--- a/src/engine/generation/connected-commands.test.ts
+++ b/src/engine/generation/connected-commands.test.ts
@@ -4,11 +4,21 @@ import { consumePendingConnectedInfluences, persistConnectedCommandTags } from "
 
 type Row = Record<string, unknown>;
 
-function storageWithChats(chats: Map<string, Row>): StorageGateway {
+function storageWithChats(chats: Map<string, Row>, entities: Record<string, Row[]> = {}): StorageGateway {
   return {
-    list: vi.fn(async () => []),
+    list: vi.fn(async (entity: string) => {
+      if (entity === "chats") return Array.from(chats.values()) as never;
+      return (entities[entity] ?? []) as never;
+    }),
     get: vi.fn(async (entity: string, id: string) => (entity === "chats" ? ((chats.get(id) as never) ?? null) : null)),
-    create: vi.fn(async (_entity: string, value: Record<string, unknown>) => value as never),
+    create: vi.fn(async (entity: string, value: Record<string, unknown>) => {
+      if (entity === "chats") {
+        const row = { ...value, id: value.id ?? `chat-${chats.size + 1}` };
+        chats.set(String(row.id), row);
+        return row as never;
+      }
+      return value as never;
+    }),
     update: vi.fn(async (entity: string, id: string, patch: Record<string, unknown>) => {
       if (entity === "chats") {
         const next = { ...(chats.get(id) ?? { id }), ...patch };
@@ -93,6 +103,178 @@ describe("persistConnectedCommandTags connected notes", () => {
     expect(notes[0]?.consumed).toBeUndefined();
     expect(notes[1]).toMatchObject({ consumed: true });
     expect(typeof notes[1]?.consumedAt).toBe("string");
+  });
+});
+
+describe("persistConnectedCommandTags roleplay direct messages", () => {
+  const mira = { id: "char-mira", name: "Mira", data: { name: "Mira" } };
+
+  it("posts roleplay direct-message commands to an existing conversation chat when enabled", async () => {
+    const roleplay = {
+      id: "roleplay-1",
+      mode: "roleplay",
+      metadata: { roleplayDmCommandsEnabled: true },
+      notes: [],
+    };
+    const chats = new Map<string, Row>([
+      ["roleplay-1", roleplay],
+      ["conversation-mira", { id: "conversation-mira", mode: "conversation", name: "Mira", characterIds: ["char-mira"] }],
+    ]);
+    const storage = storageWithChats(chats, { characters: [mira] });
+
+    const result = await persistConnectedCommandTags(
+      storage,
+      roleplay,
+      'She looks away. [dm: character="Mira", message="[12:01] Meet me outside."]',
+    );
+
+    expect(result.displayContent).toBe("She looks away.");
+    expect(result.executedCommands).toEqual(["dm"]);
+    expect(storage.createChatMessage).toHaveBeenCalledWith(
+      "conversation-mira",
+      expect.objectContaining({
+        chatId: "conversation-mira",
+        role: "assistant",
+        characterId: "char-mira",
+        content: "Meet me outside.",
+      }),
+    );
+    expect(result.events).toContainEqual({
+      type: "ooc_posted",
+      data: { chatId: "conversation-mira", chatName: "Mira", count: 1, createdChat: false },
+    });
+  });
+
+  it("creates a conversation DM chat when the target character has no existing conversation", async () => {
+    const roleplay = {
+      id: "roleplay-1",
+      mode: "roleplay",
+      folderId: "folder-1",
+      metadata: { roleplayDmCommandsEnabled: true },
+      notes: [],
+    };
+    const chats = new Map<string, Row>([["roleplay-1", roleplay]]);
+    const storage = storageWithChats(chats, { characters: [mira] });
+
+    const result = await persistConnectedCommandTags(
+      storage,
+      roleplay,
+      'She keeps narrating. [dm: character="Mira", message="I found the key."]',
+    );
+
+    expect(result.displayContent).toBe("She keeps narrating.");
+    expect(storage.create).toHaveBeenCalledWith(
+      "chats",
+      expect.objectContaining({
+        name: "Mira",
+        mode: "conversation",
+        characterIds: ["char-mira"],
+        folderId: "folder-1",
+        metadata: {},
+      }),
+    );
+    expect(storage.createChatMessage).toHaveBeenCalledWith(
+      "chat-2",
+      expect.objectContaining({
+        chatId: "chat-2",
+        role: "assistant",
+        characterId: "char-mira",
+        content: "I found the key.",
+      }),
+    );
+    expect(result.events).toContainEqual({
+      type: "ooc_posted",
+      data: { chatId: "chat-2", chatName: "Mira", count: 1, createdChat: true },
+    });
+  });
+
+  it("leaves direct-message tags visible when the roleplay setting is disabled", async () => {
+    const roleplay = {
+      id: "roleplay-1",
+      mode: "roleplay",
+      metadata: { roleplayDmCommandsEnabled: false },
+      notes: [],
+    };
+    const storage = storageWithChats(new Map<string, Row>([["roleplay-1", roleplay]]), { characters: [mira] });
+    const content = 'Visible. [dm: character="Mira", message="Do not route this."]';
+
+    const result = await persistConnectedCommandTags(storage, roleplay, content);
+
+    expect(result.displayContent).toBe(content);
+    expect(result.executedCommands).toEqual([]);
+    expect(storage.createChatMessage).not.toHaveBeenCalled();
+  });
+
+  it("does not enable direct-message commands outside roleplay mode", async () => {
+    const conversation = {
+      id: "conversation-1",
+      mode: "conversation",
+      metadata: { roleplayDmCommandsEnabled: true },
+      notes: [],
+    };
+    const storage = storageWithChats(new Map<string, Row>([["conversation-1", conversation]]), { characters: [mira] });
+    const content = 'Visible. [dm: character="Mira", message="Do not route this."]';
+
+    const result = await persistConnectedCommandTags(storage, conversation, content);
+
+    expect(result.displayContent).toBe(content);
+    expect(result.executedCommands).toEqual([]);
+    expect(storage.createChatMessage).not.toHaveBeenCalled();
+  });
+
+  it("emits command_error when a roleplay direct-message target character cannot be found", async () => {
+    const roleplay = {
+      id: "roleplay-1",
+      mode: "roleplay",
+      metadata: { roleplayDmCommandsEnabled: true },
+      notes: [],
+    };
+    const storage = storageWithChats(new Map<string, Row>([["roleplay-1", roleplay]]), { characters: [] });
+
+    const result = await persistConnectedCommandTags(
+      storage,
+      roleplay,
+      'Visible. [dm: character="Missing", message="This should not vanish silently."]',
+    );
+
+    expect(result.displayContent).toBe("Visible.");
+    expect(result.executedCommands).toEqual([]);
+    expect(result.events).toContainEqual({
+      type: "command_error",
+      data: {
+        command: "dm",
+        error: 'No character named "Missing" was found for the direct-message command.',
+      },
+    });
+    expect(storage.createChatMessage).not.toHaveBeenCalled();
+  });
+
+  it("emits command_error when a new direct-message conversation cannot be resolved", async () => {
+    const roleplay = {
+      id: "roleplay-1",
+      mode: "roleplay",
+      metadata: { roleplayDmCommandsEnabled: true },
+      notes: [],
+    };
+    const storage = storageWithChats(new Map<string, Row>([["roleplay-1", roleplay]]), { characters: [mira] });
+    storage.create = vi.fn(async () => ({ name: "Mira", mode: "conversation", characterIds: ["char-mira"] }) as never);
+
+    const result = await persistConnectedCommandTags(
+      storage,
+      roleplay,
+      'Visible. [dm: character="Mira", message="This should report failure."]',
+    );
+
+    expect(result.displayContent).toBe("Visible.");
+    expect(result.executedCommands).toEqual([]);
+    expect(result.events).toContainEqual({
+      type: "command_error",
+      data: {
+        command: "dm",
+        error: "Could not resolve a conversation for the direct-message command.",
+      },
+    });
+    expect(storage.createChatMessage).not.toHaveBeenCalled();
   });
 });
 

--- a/src/engine/generation/connected-commands.test.ts
+++ b/src/engine/generation/connected-commands.test.ts
@@ -277,6 +277,58 @@ describe("persistConnectedCommandTags roleplay direct messages", () => {
     expect(storage.createChatMessage).not.toHaveBeenCalled();
   });
 
+  it("suppresses the source assistant message when a failed direct-message command has no visible text", async () => {
+    const roleplay = {
+      id: "roleplay-1",
+      mode: "roleplay",
+      metadata: { roleplayDmCommandsEnabled: true },
+      notes: [],
+    };
+    const storage = storageWithChats(new Map<string, Row>([["roleplay-1", roleplay]]), { characters: [] });
+
+    const result = await persistConnectedCommandTags(
+      storage,
+      roleplay,
+      '[dm: character="Missing", message="This should not force a blank source turn."]',
+    );
+
+    expect(result.displayContent).toBe("");
+    expect(result.executedCommands).toEqual([]);
+    expect(result.suppressAssistantMessage).toBe(true);
+    expect(result.events).toContainEqual({
+      type: "command_error",
+      data: {
+        command: "dm",
+        error: 'No character named "Missing" was found for the direct-message command.',
+      },
+    });
+    expect(storage.createChatMessage).not.toHaveBeenCalled();
+  });
+
+  it("reports malformed direct-message commands and suppresses an empty source turn", async () => {
+    const roleplay = {
+      id: "roleplay-1",
+      mode: "roleplay",
+      metadata: { roleplayDmCommandsEnabled: true },
+      notes: [],
+    };
+    const storage = storageWithChats(new Map<string, Row>([["roleplay-1", roleplay]]), { characters: [mira] });
+
+    const result = await persistConnectedCommandTags(storage, roleplay, '[dm: character="Mira"]');
+
+    expect(result.displayContent).toBe("");
+    expect(result.executedCommands).toEqual([]);
+    expect(result.suppressAssistantMessage).toBe(true);
+    expect(result.events).toContainEqual({
+      type: "command_error",
+      data: {
+        command: "dm",
+        error: "Direct-message command must include both character and message.",
+      },
+    });
+    expect(storage.createChatMessage).not.toHaveBeenCalled();
+  });
+
   it("emits command_error when a new direct-message conversation cannot be resolved", async () => {
     const roleplay = {
       id: "roleplay-1",

--- a/src/engine/generation/connected-commands.ts
+++ b/src/engine/generation/connected-commands.ts
@@ -836,7 +836,7 @@ async function executeCommand(
         type: "ooc_posted",
         data: { chatId: targetChatId, chatName: targetChatName, count: 1, createdChat },
       });
-      return { name: "dm" };
+      return { name: "dm", suppressSourceMessage: !visibleContent.trim() };
     }
     case "schedule_update":
       return (await applyScheduleUpdate(storage, chat, command)) ? { name: "schedule_update" } : null;

--- a/src/engine/generation/connected-commands.ts
+++ b/src/engine/generation/connected-commands.ts
@@ -102,14 +102,37 @@ function roleplayDirectMessageCommandsEnabled(chat: JsonRecord): boolean {
 function parseConnectedCommands(chat: JsonRecord, content: string): {
   cleanContent: string;
   commands: CharacterCommand[];
+  parseEvents: ConnectedCommandEvent[];
+  strippedHiddenContent: boolean;
 } {
-  if (!roleplayDirectMessageCommandsEnabled(chat)) return parseCharacterCommands(content);
+  if (!roleplayDirectMessageCommandsEnabled(chat)) {
+    const parsed = parseCharacterCommands(content);
+    return {
+      ...parsed,
+      parseEvents: [],
+      strippedHiddenContent: parsed.cleanContent !== content,
+    };
+  }
 
   const directMessages = parseDirectMessageCommands(content);
   const parsed = parseCharacterCommands(directMessages.cleanContent);
+  const parseEvents: ConnectedCommandEvent[] =
+    directMessages.invalidCommands > 0
+      ? [
+          {
+            type: "command_error",
+            data: {
+              command: "dm",
+              error: "Direct-message command must include both character and message.",
+            },
+          },
+        ]
+      : [];
   return {
     cleanContent: parsed.cleanContent,
     commands: [...parsed.commands, ...directMessages.commands],
+    parseEvents,
+    strippedHiddenContent: directMessages.cleanContent !== content || parsed.cleanContent !== directMessages.cleanContent,
   };
 }
 
@@ -874,7 +897,7 @@ export async function persistConnectedCommandTags(
   const pendingNoteWrites: Array<{ chatId: string; note: JsonRecord }> = [];
   const parsed = parseConnectedCommands(chat, content);
   const executedCommands: string[] = [];
-  const events: ConnectedCommandEvent[] = [];
+  const events: ConnectedCommandEvent[] = [...parsed.parseEvents];
   const assistantAttachments: JsonRecord[] = [];
   let suppressAssistantMessage = false;
 
@@ -911,12 +934,16 @@ export async function persistConnectedCommandTags(
     await persistNoteWrites(storage, chat, pendingNoteWrites);
   }
 
+  const hasVisibleSourceOutput = parsed.cleanContent.trim().length > 0 || assistantAttachments.length > 0;
+  const suppressEmptyHiddenCommandSource =
+    !hasVisibleSourceOutput && parsed.strippedHiddenContent && content.trim().length > 0;
+
   return {
     displayContent: parsed.cleanContent,
     createdNotes,
     executedCommands,
     events,
     assistantAttachments,
-    suppressAssistantMessage,
+    suppressAssistantMessage: suppressAssistantMessage || suppressEmptyHiddenCommandSource,
   };
 }

--- a/src/engine/generation/connected-commands.ts
+++ b/src/engine/generation/connected-commands.ts
@@ -3,6 +3,7 @@ import type { IntegrationGateway } from "../capabilities/integrations";
 import type { LlmGateway } from "../capabilities/llm";
 import {
   parseCharacterCommands,
+  parseDirectMessageCommands,
   type CharacterCommand,
   type CreateCharacterCommand,
   type CreateLorebookCommand,
@@ -91,6 +92,25 @@ async function findConversationChatByTarget(
       return id === normalized || name.includes(normalized);
     }) ?? null
   );
+}
+
+function roleplayDirectMessageCommandsEnabled(chat: JsonRecord): boolean {
+  const mode = readString(chat.mode || chat.chatMode);
+  return mode === "roleplay" && boolish(parseRecord(chat.metadata).roleplayDmCommandsEnabled, false);
+}
+
+function parseConnectedCommands(chat: JsonRecord, content: string): {
+  cleanContent: string;
+  commands: CharacterCommand[];
+} {
+  if (!roleplayDirectMessageCommandsEnabled(chat)) return parseCharacterCommands(content);
+
+  const directMessages = parseDirectMessageCommands(content);
+  const parsed = parseCharacterCommands(directMessages.cleanContent);
+  return {
+    cleanContent: parsed.cleanContent,
+    commands: [...parsed.commands, ...directMessages.commands],
+  };
 }
 
 function messageDefaults(chatId: string, value: Record<string, unknown>): Record<string, unknown> {
@@ -773,23 +793,49 @@ async function executeCommand(
     }
     case "dm": {
       const character = await findByName(storage, "characters", command.character);
-      const targetChat = character?.id
-        ? (await storage.list<JsonRecord>("chats")).find((candidate) => {
-            const ids = stringArray(candidate.characterIds);
-            return readString(candidate.mode) === "conversation" && ids.includes(readString(character.id));
-          })
-        : null;
-      const targetChatId = readString(targetChat?.id);
-      if (!targetChatId) return null;
+      const characterId = readString(character?.id);
+      if (!character || !characterId) {
+        eventsPushCommandError(
+          events,
+          command.type,
+          `No character named "${command.character}" was found for the direct-message command.`,
+        );
+        return null;
+      }
+      let targetChat =
+        (await storage.list<JsonRecord>("chats")).find((candidate) => {
+          const ids = stringArray(candidate.characterIds);
+          return readString(candidate.mode) === "conversation" && ids.includes(characterId);
+        }) ?? null;
+      const createdChat = !targetChat;
+      if (!targetChat) {
+        const characterName = nameOf(character) || command.character;
+        targetChat = await storage.create<JsonRecord>("chats", {
+          name: characterName,
+          mode: "conversation",
+          characterIds: [characterId],
+          folderId: chat.folderId ?? null,
+          metadata: {},
+        });
+      }
+      const targetChatId = readString(targetChat.id);
+      if (!targetChatId) {
+        eventsPushCommandError(events, command.type, "Could not resolve a conversation for the direct-message command.");
+        return null;
+      }
+      const targetChatName = readString(targetChat.name) || nameOf(character) || command.character;
       await storage.createChatMessage(
         targetChatId,
         messageDefaults(targetChatId, {
           role: "assistant",
-          characterId: readString(character?.id) || null,
+          characterId,
           content: command.message,
         }),
       );
-      events.push({ type: "ooc_posted", data: { chatId: targetChatId, count: 1 } });
+      events.push({
+        type: "ooc_posted",
+        data: { chatId: targetChatId, chatName: targetChatName, count: 1, createdChat },
+      });
       return { name: "dm" };
     }
     case "schedule_update":
@@ -826,7 +872,7 @@ export async function persistConnectedCommandTags(
 ): Promise<ConnectedCommandResult> {
   const createdNotes: JsonRecord[] = [];
   const pendingNoteWrites: Array<{ chatId: string; note: JsonRecord }> = [];
-  const parsed = parseCharacterCommands(content);
+  const parsed = parseConnectedCommands(chat, content);
   const executedCommands: string[] = [];
   const events: ConnectedCommandEvent[] = [];
   const assistantAttachments: JsonRecord[] = [];

--- a/src/engine/generation/prompt-assembly.test.ts
+++ b/src/engine/generation/prompt-assembly.test.ts
@@ -1171,6 +1171,47 @@ describe("assembleGenerationPrompt connected conversation notes", () => {
     expect(joined).toContain("- Let the next scene reveal the locked lab door.");
     expect(joined).not.toContain("This one was already spent.");
   });
+
+  it("injects roleplay direct-message command guidance only when enabled", async () => {
+    const enabled = await assembleGenerationPrompt(storageWithSections([]), {
+      chat: {
+        id: "roleplay-1",
+        mode: "roleplay",
+        metadata: { roleplayDmCommandsEnabled: true },
+      },
+      storedMessages: [{ role: "user", content: "What happens?", contextKind: "history" }],
+      connection: {},
+      request: { ...request, promptPresetId: "", strictRoleFormatting: false },
+      latestUserInput: "What happens?",
+    });
+    const disabled = await assembleGenerationPrompt(storageWithSections([]), {
+      chat: {
+        id: "roleplay-2",
+        mode: "roleplay",
+        metadata: { roleplayDmCommandsEnabled: false },
+      },
+      storedMessages: [{ role: "user", content: "What happens?", contextKind: "history" }],
+      connection: {},
+      request: { ...request, promptPresetId: "", strictRoleFormatting: false },
+      latestUserInput: "What happens?",
+    });
+    const conversation = await assembleGenerationPrompt(storageWithSections([]), {
+      chat: {
+        id: "conversation-1",
+        mode: "conversation",
+        metadata: { roleplayDmCommandsEnabled: true },
+      },
+      storedMessages: [{ role: "user", content: "What happens?", contextKind: "history" }],
+      connection: {},
+      request: { ...request, promptPresetId: "", strictRoleFormatting: false },
+      latestUserInput: "What happens?",
+    });
+
+    expect(promptText(enabled)).toContain("<direct_message_commands>");
+    expect(promptText(enabled)).toContain('[dm: character="Character Name" message="Message text"]');
+    expect(promptText(disabled)).not.toContain("<direct_message_commands>");
+    expect(promptText(conversation)).not.toContain("<direct_message_commands>");
+  });
 });
 
 describe("assembleGenerationPrompt game character sheets", () => {

--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -1429,6 +1429,25 @@ function buildConnectedConversationBlocks(chat: JsonRecord): ChatMLMessage[] {
   return blocks;
 }
 
+function buildRoleplayDirectMessageCommandReminder(chat: JsonRecord): ChatMLMessage[] {
+  const mode = readString(chat.mode || chat.chatMode, "conversation");
+  const meta = parseRecord(chat.metadata);
+  if (mode !== "roleplay" || !boolish(meta.roleplayDmCommandsEnabled, false)) return [];
+  return [
+    {
+      role: "system",
+      contextKind: "prompt",
+      content: [
+        "<direct_message_commands>",
+        'If a roleplay character naturally texts or privately messages the user outside the current scene, append one hidden command after the visible response: [dm: character="Character Name" message="Message text"].',
+        "Use the exact character name and only use this for in-world private messages, not normal spoken dialogue or narration.",
+        "Do not mention the command in visible text.",
+        "</direct_message_commands>",
+      ].join("\n"),
+    },
+  ];
+}
+
 function insertBeforeLastUser(messages: ChatMLMessage[], blocks: ChatMLMessage[]): void {
   if (blocks.length === 0) return;
   const insertAt = messages.map((message) => message.role).lastIndexOf("user");
@@ -2233,7 +2252,10 @@ export async function assembleGenerationPrompt(
     });
   }
 
-  insertBeforeLastUser(messages, buildConnectedConversationBlocks(input.chat));
+  insertBeforeLastUser(messages, [
+    ...buildConnectedConversationBlocks(input.chat),
+    ...buildRoleplayDirectMessageCommandReminder(input.chat),
+  ]);
 
   const authorNotesEntry = authorNotesDepthEntry(input.chat);
   messages = injectAtDepth(

--- a/src/engine/modes/chat/commands/character-commands.test.ts
+++ b/src/engine/modes/chat/commands/character-commands.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseCharacterCommands } from "./character-commands";
+import { parseCharacterCommands, parseDirectMessageCommands } from "./character-commands";
 
 describe("parseCharacterCommands", () => {
   it("parses assistant numeric params with literal decimal points", () => {
@@ -25,5 +25,22 @@ describe("parseCharacterCommands", () => {
     expect(commands[0]).toMatchObject({ type: "create_character", name: "Ada" });
     expect(commands[0]).not.toHaveProperty("talkativeness");
     expect(commands[0]).not.toHaveProperty("depthPromptDepth");
+  });
+});
+
+describe("parseDirectMessageCommands", () => {
+  it("parses roleplay direct messages and strips transcript timestamps", () => {
+    const result = parseDirectMessageCommands(
+      'She checks her phone. [dm: character="Mira", message="[12:01] Meet me outside."]',
+    );
+
+    expect(result.cleanContent).toBe("She checks her phone.");
+    expect(result.commands).toEqual([
+      {
+        type: "dm",
+        character: "Mira",
+        message: "Meet me outside.",
+      },
+    ]);
   });
 });

--- a/src/engine/modes/chat/commands/character-commands.test.ts
+++ b/src/engine/modes/chat/commands/character-commands.test.ts
@@ -42,5 +42,14 @@ describe("parseDirectMessageCommands", () => {
         message: "Meet me outside.",
       },
     ]);
+    expect(result.invalidCommands).toBe(0);
+  });
+
+  it("counts malformed direct-message commands that were stripped from output", () => {
+    const result = parseDirectMessageCommands('[dm: character="Mira"]');
+
+    expect(result.cleanContent).toBe("");
+    expect(result.commands).toEqual([]);
+    expect(result.invalidCommands).toBe(1);
   });
 });

--- a/src/engine/modes/chat/commands/character-commands.ts
+++ b/src/engine/modes/chat/commands/character-commands.ts
@@ -799,8 +799,10 @@ export function parseCharacterCommands(content: string): {
 export function parseDirectMessageCommands(content: string): {
   cleanContent: string;
   commands: DirectMessageCommand[];
+  invalidCommands: number;
 } {
   const commands: DirectMessageCommand[] = [];
+  let invalidCommands = 0;
 
   for (const match of content.matchAll(DIRECT_MESSAGE_RE)) {
     const params = match[1]!;
@@ -809,6 +811,8 @@ export function parseDirectMessageCommands(content: string): {
     const cleanMessage = message ? stripConversationPromptTimestamps(message.trim()) : "";
     if (character && cleanMessage) {
       commands.push({ type: "dm", character, message: cleanMessage });
+    } else {
+      invalidCommands += 1;
     }
   }
 
@@ -817,7 +821,7 @@ export function parseDirectMessageCommands(content: string): {
     .replace(/\n{3,}/g, "\n\n")
     .trim();
 
-  return { cleanContent, commands };
+  return { cleanContent, commands, invalidCommands };
 }
 
 /**

--- a/src/features/runtime/generation/hooks/use-generate.ts
+++ b/src/features/runtime/generation/hooks/use-generate.ts
@@ -1205,8 +1205,11 @@ export async function runGenerationWithUi(
         case "ooc_posted": {
           const data = parseMaybeRecord(event.data);
           const count = typeof data.count === "number" ? data.count : 1;
-          toast(`${count} message${count === 1 ? "" : "s"} posted.`);
+          const targetChatId = readString(data.chatId).trim();
+          const target = readString(data.chatName).trim();
+          toast(`${count} message${count === 1 ? "" : "s"} posted${target ? ` to ${target}` : ""}.`);
           scheduleChatQueryRefresh(queryClient, chatId);
+          if (targetChatId && targetChatId !== chatId) scheduleChatQueryRefresh(queryClient, targetChatId);
           break;
         }
         case "selfie": {


### PR DESCRIPTION
## Linked issue

No linked issue.

## Why this change

- Knip triage found the roleplay `[dm: character="Name" message="text"]` parser, chat metadata toggle, and settings UI already existed, but the parser was not wired into generation.
- The feature had an exposed settings surface without runtime behavior, and the existing `dm` executor could only post into an already-existing conversation.

## What changed

- Gate direct-message command parsing to roleplay chats with `metadata.roleplayDmCommandsEnabled === true`.
- Strip successful hidden `[dm:]` tags from roleplay output and post the message into the matching Conversation DM.
- Create a Conversation DM for the target character when none exists yet.
- Emit `command_error` events when parsed DM commands cannot find a character or resolve a target conversation, instead of silently losing the hidden command.
- Suppress the source roleplay assistant save when a successful DM command leaves no visible source text.
- Add a roleplay-only prompt reminder for the hidden DM command when the setting is enabled.
- Refresh the target chat cache and include the target name in the OOC-posted toast.

## Refactor impact

Primary owner:

- Engine generation and roleplay command post-processing.

Impact areas reviewed:

- Roleplay generation prompt assembly.
- Connected command parsing/execution.
- Conversation DM chat creation and message writes.
- Runtime generation event handling and chat cache invalidation.
- Sibling mode gating for conversation/game so `[dm:]` does not become a general command.

Boundary notes:

- Product behavior stays in `src/engine`.
- React runtime handling stays in `src/features/runtime`.
- No shared API, Tauri, Rust, or remote-runtime boundary changes.

Pressure points touched:

- `persistConnectedCommandTags` in engine generation.
- `assembleGenerationPrompt` prompt insertion.
- Runtime generation event handling for `ooc_posted`.

## Validation

<!-- Checkboxes intentionally left for human verification per the repo template. Agent-run checks are listed below. -->

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Agent-run: `pnpm vitest run src/engine/generation/connected-commands.test.ts src/engine/modes/chat/commands/character-commands.test.ts src/engine/generation/prompt-assembly.test.ts` passed with 71 tests.
- Agent-run: `pnpm typecheck` passed.
- Agent-run: `pnpm check:architecture` passed.
- Agent-run: `pnpm build` passed with the existing Vite large chunk warning.
- Agent-run: `git diff --check origin/refactor...HEAD` passed.
- Not run: native Tauri/manual model QA. Model obedience to the hidden `[dm:]` reminder still needs in-app spot-checking.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs or release files changed. No active changelog/changeset file was found for this slice.

## UI evidence

No screenshots or recordings. This change uses the existing settings UI and changes generation/runtime behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added direct message command support for roleplay mode, allowing characters to send private messages when enabled. Automatically creates new conversation chats as needed and provides enhanced notifications showing destination chat details for posted messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1653?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->