### PR TITLE
[codex] Wire mutation schemas at storage boundaries

### DIFF
--- a/src/engine/contracts/schemas/connection.schema.test.ts
+++ b/src/engine/contracts/schemas/connection.schema.test.ts
@@ -13,4 +13,10 @@ describe("connection schemas", () => {
 
     expect(parsed).toEqual({ folderId: null });
   });
+
+  it("rejects invalid connection folder ids", () => {
+    expect(() => updateConnectionSchema.parse({ folderId: 123 })).toThrow();
+    expect(() => updateConnectionSchema.parse({ folderId: {} })).toThrow();
+    expect(() => updateConnectionSchema.parse({ folderId: true })).toThrow();
+  });
 });

--- a/src/engine/contracts/schemas/connection.schema.test.ts
+++ b/src/engine/contracts/schemas/connection.schema.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { updateConnectionSchema } from "./connection.schema";
+
+describe("connection schemas", () => {
+  it("accepts partial connection folder updates", () => {
+    const parsed = updateConnectionSchema.parse({ folderId: "folder-1" });
+
+    expect(parsed).toEqual({ folderId: "folder-1" });
+  });
+
+  it("accepts clearing the connection folder", () => {
+    const parsed = updateConnectionSchema.parse({ folderId: null });
+
+    expect(parsed).toEqual({ folderId: null });
+  });
+});

--- a/src/engine/contracts/schemas/connection.schema.ts
+++ b/src/engine/contracts/schemas/connection.schema.ts
@@ -45,4 +45,16 @@ export const createConnectionSchema = z.object({
   maxParallelJobs: z.number().int().min(1).max(16).default(1),
 });
 
+export const updateConnectionSchema = createConnectionSchema
+  .extend({
+    folderId: z.string().nullable().optional(),
+    sortOrder: z.number().int().optional(),
+    enabled: z.boolean().optional(),
+    defaultParameters: z.record(z.unknown()).nullable().optional(),
+    capabilities: z.record(z.unknown()).nullable().optional(),
+    providerMetadata: z.record(z.unknown()).nullable().optional(),
+  })
+  .partial();
+
 export type CreateConnectionInput = z.infer<typeof createConnectionSchema>;
+export type UpdateConnectionInput = z.infer<typeof updateConnectionSchema>;

--- a/src/engine/contracts/schemas/lorebook.schema.test.ts
+++ b/src/engine/contracts/schemas/lorebook.schema.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { createLorebookSchema, updateLorebookEntrySchema, updateLorebookSchema } from "./lorebook.schema";
+import {
+  createLorebookEntrySchema,
+  createLorebookFolderSchema,
+  createLorebookSchema,
+  updateLorebookEntrySchema,
+  updateLorebookFolderSchema,
+  updateLorebookSchema,
+} from "./lorebook.schema";
 
 describe("lorebook schemas", () => {
   it("defaults new lorebooks to vectorization enabled", () => {
@@ -18,6 +25,46 @@ describe("lorebook schemas", () => {
     const parsed = updateLorebookEntrySchema.parse({ lorebookId: "lorebook-next" });
 
     expect(parsed).toEqual({ lorebookId: "lorebook-next" });
+  });
+
+  it("accepts display-order and embedding patches without filling defaults", () => {
+    const parsed = updateLorebookEntrySchema.parse({ sortOrder: 4, order: 4, embedding: null });
+
+    expect(parsed).toEqual({ sortOrder: 4, order: 4, embedding: null });
+  });
+
+  it("accepts copied entry storage metadata without timestamps or ids", () => {
+    const parsed = createLorebookEntrySchema.parse({
+      id: "entry-original",
+      lorebookId: "lorebook-copy",
+      name: "Copied",
+      sortOrder: 2,
+      embedding: [0.1, 0.2],
+      createdAt: "old",
+      updatedAt: "old",
+    });
+
+    expect(parsed).toMatchObject({
+      lorebookId: "lorebook-copy",
+      name: "Copied",
+      sortOrder: 2,
+      embedding: [0.1, 0.2],
+    });
+    expect(parsed).not.toHaveProperty("id");
+    expect(parsed).not.toHaveProperty("createdAt");
+    expect(parsed).not.toHaveProperty("updatedAt");
+  });
+
+  it("accepts folder sort-order patches without filling defaults", () => {
+    const parsed = updateLorebookFolderSchema.parse({ order: 1, sortOrder: 1 });
+
+    expect(parsed).toEqual({ order: 1, sortOrder: 1 });
+  });
+
+  it("requires folder creates to carry their parent lorebook id", () => {
+    const parsed = createLorebookFolderSchema.parse({ lorebookId: "lorebook-1", name: "Locations" });
+
+    expect(parsed.lorebookId).toBe("lorebook-1");
   });
 
   it("accepts game-session lorebook metadata", () => {

--- a/src/engine/contracts/schemas/lorebook.schema.test.ts
+++ b/src/engine/contracts/schemas/lorebook.schema.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { createLorebookSchema, updateLorebookSchema } from "./lorebook.schema";
+import { createLorebookSchema, updateLorebookEntrySchema, updateLorebookSchema } from "./lorebook.schema";
 
 describe("lorebook schemas", () => {
   it("defaults new lorebooks to vectorization enabled", () => {
@@ -12,5 +12,22 @@ describe("lorebook schemas", () => {
     const parsed = updateLorebookSchema.parse({ excludeFromVectorization: true });
 
     expect(parsed.excludeFromVectorization).toBe(true);
+  });
+
+  it("accepts moving an entry between lorebooks as a narrow patch", () => {
+    const parsed = updateLorebookEntrySchema.parse({ lorebookId: "lorebook-next" });
+
+    expect(parsed).toEqual({ lorebookId: "lorebook-next" });
+  });
+
+  it("accepts game-session lorebook metadata", () => {
+    const parsed = createLorebookSchema.parse({
+      name: "Game Session Lore",
+      category: "game",
+      generatedBy: "game-session",
+    });
+
+    expect(parsed.category).toBe("game");
+    expect(parsed.generatedBy).toBe("game-session");
   });
 });

--- a/src/engine/contracts/schemas/lorebook.schema.test.ts
+++ b/src/engine/contracts/schemas/lorebook.schema.test.ts
@@ -33,7 +33,7 @@ describe("lorebook schemas", () => {
     expect(parsed).toEqual({ sortOrder: 4, order: 4, embedding: null });
   });
 
-  it("accepts copied entry storage metadata without timestamps or ids", () => {
+  it("strips system-managed fields from copied entries", () => {
     const parsed = createLorebookEntrySchema.parse({
       id: "entry-original",
       lorebookId: "lorebook-copy",
@@ -65,6 +65,23 @@ describe("lorebook schemas", () => {
     const parsed = createLorebookFolderSchema.parse({ lorebookId: "lorebook-1", name: "Locations" });
 
     expect(parsed.lorebookId).toBe("lorebook-1");
+  });
+
+  it("rejects invalid lorebook category and generatedBy values", () => {
+    expect(() => createLorebookSchema.parse({ name: "Invalid", category: "invalid-category" })).toThrow();
+    expect(() => createLorebookSchema.parse({ name: "Invalid", generatedBy: "unknown-maker" })).toThrow();
+  });
+
+  it("rejects malformed lorebook entry metadata", () => {
+    expect(() => updateLorebookEntrySchema.parse({ embedding: "not-an-array" })).toThrow();
+    expect(() => updateLorebookEntrySchema.parse({ embedding: [1, "2"] })).toThrow();
+    expect(() => updateLorebookEntrySchema.parse({ sortOrder: 1.5 })).toThrow();
+    expect(() => createLorebookEntrySchema.parse({ lorebookId: "book", name: "" })).toThrow();
+  });
+
+  it("rejects folder creates without a valid lorebook id", () => {
+    expect(() => createLorebookFolderSchema.parse({ name: "Missing Parent" })).toThrow();
+    expect(() => createLorebookFolderSchema.parse({ lorebookId: 123, name: "Bad Parent" })).toThrow();
   });
 
   it("accepts game-session lorebook metadata", () => {

--- a/src/engine/contracts/schemas/lorebook.schema.ts
+++ b/src/engine/contracts/schemas/lorebook.schema.ts
@@ -3,7 +3,9 @@
 // ──────────────────────────────────────────────
 import { z } from "zod";
 
-export const lorebookCategorySchema = z.enum(["world", "character", "npc", "spellbook", "uncategorized"]);
+export const lorebookCategorySchema = z.enum(["world", "character", "npc", "spellbook", "game", "uncategorized"]);
+
+export const lorebookGeneratedBySchema = z.enum(["user", "agent", "import", "lorebook-maker", "game-session"]);
 
 export const selectiveLogicSchema = z.enum(["and", "or", "not"]);
 
@@ -69,7 +71,7 @@ export const createLorebookSchema = z.object({
   enabled: z.boolean().default(true),
   excludeFromVectorization: z.boolean().default(false),
   tags: z.array(z.string()).default([]),
-  generatedBy: z.enum(["user", "agent", "import", "lorebook-maker"]).nullable().default(null),
+  generatedBy: lorebookGeneratedBySchema.nullable().default(null),
   sourceAgentId: z.string().nullable().default(null),
 });
 
@@ -92,7 +94,7 @@ export const updateLorebookSchema = z
     enabled: z.boolean().optional(),
     excludeFromVectorization: z.boolean().optional(),
     tags: z.array(z.string()).optional(),
-    generatedBy: z.enum(["user", "agent", "import", "lorebook-maker"]).nullable().optional(),
+    generatedBy: lorebookGeneratedBySchema.nullable().optional(),
     sourceAgentId: z.string().nullable().optional(),
   })
   .superRefine((value, ctx) => {
@@ -172,6 +174,7 @@ export const createLorebookEntrySchema = z.object({
 });
 
 export const updateLorebookEntrySchema = z.object({
+  lorebookId: z.string().optional(),
   name: z.string().min(1).max(200).optional(),
   content: z.string().optional(),
   description: z.string().optional(),

--- a/src/engine/contracts/schemas/lorebook.schema.ts
+++ b/src/engine/contracts/schemas/lorebook.schema.ts
@@ -47,6 +47,7 @@ export const createLorebookFolderSchema = z.object({
   enabled: z.boolean().default(true),
   parentFolderId: z.string().nullable().default(null),
   order: z.number().int().default(0),
+  /** Legacy storage/display fallback. Writers should keep this aligned with order until persisted rows migrate. */
   sortOrder: z.number().int().optional(),
 });
 
@@ -55,6 +56,7 @@ export const updateLorebookFolderSchema = z.object({
   enabled: z.boolean().optional(),
   parentFolderId: z.string().nullable().optional(),
   order: z.number().int().optional(),
+  /** Legacy storage/display fallback. Writers should keep this aligned with order until persisted rows migrate. */
   sortOrder: z.number().int().optional(),
 });
 
@@ -159,6 +161,7 @@ export const createLorebookEntrySchema = z.object({
   position: z.number().int().min(0).max(2).default(0),
   depth: z.number().int().min(0).default(4),
   order: z.number().int().default(100),
+  /** Legacy storage/display fallback. Writers should keep this aligned with order until persisted rows migrate. */
   sortOrder: z.number().int().optional(),
   role: z.enum(["system", "user", "assistant"]).default("system"),
   sticky: z.number().nullable().default(null),
@@ -206,6 +209,7 @@ export const updateLorebookEntrySchema = z.object({
   position: z.number().int().min(0).max(2).optional(),
   depth: z.number().int().min(0).optional(),
   order: z.number().int().optional(),
+  /** Legacy storage/display fallback. Writers should keep this aligned with order until persisted rows migrate. */
   sortOrder: z.number().int().optional(),
   role: z.enum(["system", "user", "assistant"]).optional(),
   sticky: z.number().nullable().optional(),

--- a/src/engine/contracts/schemas/lorebook.schema.ts
+++ b/src/engine/contracts/schemas/lorebook.schema.ts
@@ -33,6 +33,8 @@ export const lorebookScheduleSchema = z.object({
   activeLocations: z.array(z.string()).default([]),
 });
 
+const lorebookEmbeddingSchema = z.array(z.number()).nullable();
+
 // ──────────────────────────────────────────────
 // Folders — collapsible containers for entries
 // `parentFolderId` is reserved for a future nested-folder PR; v1 enforces
@@ -40,10 +42,12 @@ export const lorebookScheduleSchema = z.object({
 // rejects non-null values.
 // ──────────────────────────────────────────────
 export const createLorebookFolderSchema = z.object({
+  lorebookId: z.string(),
   name: z.string().min(1).max(200),
   enabled: z.boolean().default(true),
   parentFolderId: z.string().nullable().default(null),
   order: z.number().int().default(0),
+  sortOrder: z.number().int().optional(),
 });
 
 export const updateLorebookFolderSchema = z.object({
@@ -51,6 +55,7 @@ export const updateLorebookFolderSchema = z.object({
   enabled: z.boolean().optional(),
   parentFolderId: z.string().nullable().optional(),
   order: z.number().int().optional(),
+  sortOrder: z.number().int().optional(),
 });
 
 export const createLorebookSchema = z.object({
@@ -154,6 +159,7 @@ export const createLorebookEntrySchema = z.object({
   position: z.number().int().min(0).max(2).default(0),
   depth: z.number().int().min(0).default(4),
   order: z.number().int().default(100),
+  sortOrder: z.number().int().optional(),
   role: z.enum(["system", "user", "assistant"]).default("system"),
   sticky: z.number().nullable().default(null),
   cooldown: z.number().nullable().default(null),
@@ -171,6 +177,7 @@ export const createLorebookEntrySchema = z.object({
   activationConditions: z.array(activationConditionSchema).default([]),
   schedule: lorebookScheduleSchema.nullable().default(null),
   excludeFromVectorization: z.boolean().default(false),
+  embedding: lorebookEmbeddingSchema.optional(),
 });
 
 export const updateLorebookEntrySchema = z.object({
@@ -199,6 +206,7 @@ export const updateLorebookEntrySchema = z.object({
   position: z.number().int().min(0).max(2).optional(),
   depth: z.number().int().min(0).optional(),
   order: z.number().int().optional(),
+  sortOrder: z.number().int().optional(),
   role: z.enum(["system", "user", "assistant"]).optional(),
   sticky: z.number().nullable().optional(),
   cooldown: z.number().nullable().optional(),
@@ -215,6 +223,7 @@ export const updateLorebookEntrySchema = z.object({
   activationConditions: z.array(activationConditionSchema).optional(),
   schedule: lorebookScheduleSchema.nullable().optional(),
   excludeFromVectorization: z.boolean().optional(),
+  embedding: lorebookEmbeddingSchema.optional(),
 });
 
 export type CreateLorebookInput = z.input<typeof createLorebookSchema>;

--- a/src/engine/contracts/schemas/prompt.schema.test.ts
+++ b/src/engine/contracts/schemas/prompt.schema.test.ts
@@ -11,6 +11,22 @@ describe("prompt schemas", () => {
   it("accepts default preset flag updates", () => {
     const parsed = updatePromptPresetSchema.parse({ isDefault: true, default: true });
 
-    expect(parsed).toEqual({ isDefault: true, default: true });
+    expect(parsed).toEqual({ isDefault: true });
+  });
+
+  it("normalizes the legacy default flag to isDefault", () => {
+    const parsed = updatePromptPresetSchema.parse({ default: true });
+
+    expect(parsed).toEqual({ isDefault: true });
+  });
+
+  it("rejects conflicting default preset flags", () => {
+    expect(() => updatePromptPresetSchema.parse({ isDefault: false, default: true })).toThrow();
+  });
+
+  it("rejects malformed preset update fields", () => {
+    expect(() => updatePromptPresetSchema.parse({ variableOrder: "not-array" })).toThrow();
+    expect(() => updatePromptPresetSchema.parse({ variableOrder: [123] })).toThrow();
+    expect(() => updatePromptPresetSchema.parse({ isDefault: "yes" })).toThrow();
   });
 });

--- a/src/engine/contracts/schemas/prompt.schema.test.ts
+++ b/src/engine/contracts/schemas/prompt.schema.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { updatePromptPresetSchema } from "./prompt.schema";
+
+describe("prompt schemas", () => {
+  it("accepts preset variable order updates", () => {
+    const parsed = updatePromptPresetSchema.parse({ variableOrder: ["choice-a", "choice-b"] });
+
+    expect(parsed).toEqual({ variableOrder: ["choice-a", "choice-b"] });
+  });
+
+  it("accepts default preset flag updates", () => {
+    const parsed = updatePromptPresetSchema.parse({ isDefault: true, default: true });
+
+    expect(parsed).toEqual({ isDefault: true, default: true });
+  });
+});

--- a/src/engine/contracts/schemas/prompt.schema.ts
+++ b/src/engine/contracts/schemas/prompt.schema.ts
@@ -134,10 +134,13 @@ export const updatePromptPresetSchema = z.object({
   description: z.string().optional(),
   sectionOrder: z.array(z.string()).optional(),
   groupOrder: z.array(z.string()).optional(),
+  variableOrder: z.array(z.string()).optional(),
   variableGroups: z.array(promptVariableGroupSchema).optional(),
   variableValues: z.record(z.string()).optional(),
   parameters: generationParametersSchema.partial().optional(),
   wrapFormat: wrapFormatSchema.optional(),
+  isDefault: z.boolean().optional(),
+  default: z.boolean().optional(),
   author: z.string().optional(),
   defaultChoices: z.record(z.union([z.string(), z.array(z.string())])).optional(),
 });

--- a/src/engine/contracts/schemas/prompt.schema.ts
+++ b/src/engine/contracts/schemas/prompt.schema.ts
@@ -129,21 +129,35 @@ export const createPromptPresetSchema = z.object({
   author: z.string().default(""),
 });
 
-export const updatePromptPresetSchema = z.object({
-  name: z.string().min(1).max(200).optional(),
-  description: z.string().optional(),
-  sectionOrder: z.array(z.string()).optional(),
-  groupOrder: z.array(z.string()).optional(),
-  variableOrder: z.array(z.string()).optional(),
-  variableGroups: z.array(promptVariableGroupSchema).optional(),
-  variableValues: z.record(z.string()).optional(),
-  parameters: generationParametersSchema.partial().optional(),
-  wrapFormat: wrapFormatSchema.optional(),
-  isDefault: z.boolean().optional(),
-  default: z.boolean().optional(),
-  author: z.string().optional(),
-  defaultChoices: z.record(z.union([z.string(), z.array(z.string())])).optional(),
-});
+export const updatePromptPresetSchema = z
+  .object({
+    name: z.string().min(1).max(200).optional(),
+    description: z.string().optional(),
+    sectionOrder: z.array(z.string()).optional(),
+    groupOrder: z.array(z.string()).optional(),
+    variableOrder: z.array(z.string()).optional(),
+    variableGroups: z.array(promptVariableGroupSchema).optional(),
+    variableValues: z.record(z.string()).optional(),
+    parameters: generationParametersSchema.partial().optional(),
+    wrapFormat: wrapFormatSchema.optional(),
+    isDefault: z.boolean().optional(),
+    default: z.boolean().optional(),
+    author: z.string().optional(),
+    defaultChoices: z.record(z.union([z.string(), z.array(z.string())])).optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (value.isDefault !== undefined && value.default !== undefined && value.isDefault !== value.default) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["default"],
+        message: "default must match isDefault when both flags are provided.",
+      });
+    }
+  })
+  .transform(({ default: legacyDefault, ...value }) => ({
+    ...value,
+    ...(value.isDefault === undefined && legacyDefault !== undefined ? { isDefault: legacyDefault } : {}),
+  }));
 
 // ── Sections ──
 

--- a/src/engine/contracts/schemas/regex.schema.test.ts
+++ b/src/engine/contracts/schemas/regex.schema.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { updateRegexScriptSchema } from "./regex.schema";
+
+describe("regex schemas", () => {
+  it("accepts reorder patches without filling defaults", () => {
+    const parsed = updateRegexScriptSchema.parse({ order: 2, sortOrder: 2 });
+
+    expect(parsed).toEqual({ order: 2, sortOrder: 2 });
+  });
+});

--- a/src/engine/contracts/schemas/regex.schema.test.ts
+++ b/src/engine/contracts/schemas/regex.schema.test.ts
@@ -7,4 +7,12 @@ describe("regex schemas", () => {
 
     expect(parsed).toEqual({ order: 2, sortOrder: 2 });
   });
+
+  it("rejects malformed reorder fields", () => {
+    for (const value of [1.5, "2", null, {}, []]) {
+      expect(updateRegexScriptSchema.safeParse({ order: value }).success).toBe(false);
+      expect(updateRegexScriptSchema.safeParse({ sortOrder: value }).success).toBe(false);
+    }
+    expect(() => updateRegexScriptSchema.parse({ sortOrder: Number.NaN })).toThrow();
+  });
 });

--- a/src/engine/contracts/schemas/regex.schema.ts
+++ b/src/engine/contracts/schemas/regex.schema.ts
@@ -19,7 +19,9 @@ export const createRegexScriptSchema = z.object({
   maxDepth: z.number().int().nullable().default(null),
 });
 
-export const updateRegexScriptSchema = createRegexScriptSchema.partial();
+export const updateRegexScriptSchema = createRegexScriptSchema.partial().extend({
+  sortOrder: z.number().int().optional(),
+});
 export const reorderRegexScriptsSchema = z.object({
   scriptIds: z.array(z.string().min(1)),
 });

--- a/src/engine/contracts/schemas/theme.schema.test.ts
+++ b/src/engine/contracts/schemas/theme.schema.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { updateThemeSchema } from "./theme.schema";
+
+describe("theme schemas", () => {
+  it("accepts active theme flag updates", () => {
+    const parsed = updateThemeSchema.parse({ isActive: true, active: true });
+
+    expect(parsed).toEqual({ isActive: true, active: true });
+  });
+});

--- a/src/engine/contracts/schemas/theme.schema.test.ts
+++ b/src/engine/contracts/schemas/theme.schema.test.ts
@@ -7,4 +7,12 @@ describe("theme schemas", () => {
 
     expect(parsed).toEqual({ isActive: true, active: true });
   });
+
+  it("rejects non-boolean active flags", () => {
+    for (const value of ["true", 1, null, [], {}]) {
+      expect(updateThemeSchema.safeParse({ isActive: value }).success).toBe(false);
+      expect(updateThemeSchema.safeParse({ active: value }).success).toBe(false);
+    }
+    expect(() => updateThemeSchema.parse({ isActive: "true" })).toThrow();
+  });
 });

--- a/src/engine/contracts/schemas/theme.schema.ts
+++ b/src/engine/contracts/schemas/theme.schema.ts
@@ -13,8 +13,10 @@ export const updateThemeSchema = z
   .object({
     name: z.string().min(1).max(200).optional(),
     css: z.string().optional(),
+    isActive: z.boolean().optional(),
+    active: z.boolean().optional(),
   })
-  .refine((value) => value.name !== undefined || value.css !== undefined, {
+  .refine((value) => Object.keys(value).length > 0, {
     message: "Must update at least one field",
   });
 

--- a/src/engine/contracts/types/lorebook.ts
+++ b/src/engine/contracts/types/lorebook.ts
@@ -3,7 +3,7 @@
 // ──────────────────────────────────────────────
 
 /** Top-level lorebook categories. */
-export type LorebookCategory = "world" | "character" | "npc" | "spellbook" | "uncategorized";
+export type LorebookCategory = "world" | "character" | "npc" | "spellbook" | "game" | "uncategorized";
 
 /** Selective logic operators. */
 export type SelectiveLogic = "and" | "or" | "not";
@@ -59,7 +59,7 @@ export interface Lorebook {
   /** Tags for organizing/filtering lorebooks */
   tags: string[];
   /** Agent/generation origin tracking */
-  generatedBy: "user" | "agent" | "import" | null;
+  generatedBy: "user" | "agent" | "import" | "lorebook-maker" | "game-session" | null;
   sourceAgentId: string | null;
   createdAt: string;
   updatedAt: string;

--- a/src/features/catalog/agents/components/EditAgentModal.tsx
+++ b/src/features/catalog/agents/components/EditAgentModal.tsx
@@ -4,6 +4,10 @@
 import { useState, useEffect } from "react";
 import { Modal } from "../../../../shared/components/ui/Modal";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  createAgentConfigSchema,
+  updateAgentConfigSchema,
+} from "../../../../engine/contracts/schemas/agent.schema";
 import { storageApi } from "../../../../shared/api/storage-api";
 import { useConnections } from "../../connections/index";
 import { Loader2, Sparkles, Save } from "lucide-react";
@@ -63,7 +67,8 @@ export function EditAgentModal({ open, onClose, agent }: Props) {
 
   // Update existing config
   const updateAgent = useMutation({
-    mutationFn: ({ id, data }: { id: string; data: Record<string, unknown> }) => storageApi.update("agents", id, data),
+    mutationFn: ({ id, data }: { id: string; data: Record<string, unknown> }) =>
+      storageApi.update("agents", id, updateAgentConfigSchema.parse(data)),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["agents"] });
       onClose();
@@ -72,7 +77,7 @@ export function EditAgentModal({ open, onClose, agent }: Props) {
 
   // Create config if agent has never been persisted
   const createAgent = useMutation({
-    mutationFn: (data: Record<string, unknown>) => storageApi.create("agents", data),
+    mutationFn: (data: Record<string, unknown>) => storageApi.create("agents", createAgentConfigSchema.parse(data)),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["agents"] });
       onClose();

--- a/src/features/catalog/agents/hooks/use-agents.ts
+++ b/src/features/catalog/agents/hooks/use-agents.ts
@@ -2,7 +2,10 @@
 // Hooks: Agent Configs (React Query)
 // ──────────────────────────────────────────────
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { createAgentConfigSchema } from "../../../../engine/contracts/schemas/agent.schema";
+import {
+  createAgentConfigSchema,
+  updateAgentConfigSchema,
+} from "../../../../engine/contracts/schemas/agent.schema";
 import { BUILT_IN_AGENTS } from "../../../../engine/contracts/types/agent";
 import { agentApi } from "../../../../shared/api/agent-api";
 import { storageApi } from "../../../../shared/api/storage-api";
@@ -44,6 +47,15 @@ export interface AgentRunRow {
 
 const builtInAgentTypes = new Set(BUILT_IN_AGENTS.map((agent) => agent.id));
 
+function normalizeAgentUpdatePayload(data: Record<string, unknown>): Record<string, unknown> {
+  const nested = data.data;
+  const patch =
+    Object.keys(data).length === 1 && nested && typeof nested === "object" && !Array.isArray(nested)
+      ? (nested as Record<string, unknown>)
+      : data;
+  return updateAgentConfigSchema.parse(patch);
+}
+
 export function useAgentConfigs(enabled = true) {
   return useQuery({
     queryKey: agentKeys.all,
@@ -68,7 +80,8 @@ export function useCustomAgentRuns(chatId: string | null, enabled = true) {
 export function useUpdateAgent() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: ({ id, ...data }: { id: string } & Record<string, unknown>) => storageApi.update("agents", id, data),
+    mutationFn: ({ id, ...data }: { id: string } & Record<string, unknown>) =>
+      storageApi.update("agents", id, normalizeAgentUpdatePayload(data)),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: agentKeys.all });
     },
@@ -79,7 +92,7 @@ export function useUpdateAgentByType() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: ({ agentType, ...data }: { agentType: string } & Record<string, unknown>) =>
-      agentApi.patchByType(agentType, data),
+      agentApi.patchByType(agentType, updateAgentConfigSchema.parse(data)),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: agentKeys.all });
     },

--- a/src/features/catalog/agents/hooks/use-custom-tools.ts
+++ b/src/features/catalog/agents/hooks/use-custom-tools.ts
@@ -2,7 +2,10 @@
 // Hooks: Custom Tools (React Query)
 // ──────────────────────────────────────────────
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { createCustomToolSchema } from "../../../../engine/contracts/schemas/custom-tool.schema";
+import {
+  createCustomToolSchema,
+  updateCustomToolSchema,
+} from "../../../../engine/contracts/schemas/custom-tool.schema";
 import { customToolApi } from "../../../../shared/api/custom-tool-api";
 import { storageApi } from "../../../../shared/api/storage-api";
 
@@ -70,7 +73,7 @@ export function useUpdateCustomTool() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: ({ id, ...data }: { id: string } & Record<string, unknown>) =>
-      storageApi.update("custom-tools", id, data),
+      storageApi.update("custom-tools", id, updateCustomToolSchema.parse(data)),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: toolKeys.all });
     },

--- a/src/features/catalog/agents/hooks/use-regex-scripts.ts
+++ b/src/features/catalog/agents/hooks/use-regex-scripts.ts
@@ -2,7 +2,11 @@
 // Hooks: Regex Scripts (React Query)
 // ──────────────────────────────────────────────
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { createRegexScriptSchema, reorderRegexScriptsSchema } from "../../../../engine/contracts/schemas/regex.schema";
+import {
+  createRegexScriptSchema,
+  reorderRegexScriptsSchema,
+  updateRegexScriptSchema,
+} from "../../../../engine/contracts/schemas/regex.schema";
 import { storageApi } from "../../../../shared/api/storage-api";
 
 const regexKeys = {
@@ -50,7 +54,7 @@ export function useUpdateRegexScript() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: ({ id, ...data }: { id: string } & Record<string, unknown>) =>
-      storageApi.update<RegexScriptRow>("regex-scripts", id, data),
+      storageApi.update<RegexScriptRow>("regex-scripts", id, updateRegexScriptSchema.parse(data)),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: regexKeys.all });
     },

--- a/src/features/catalog/agents/hooks/use-regex-scripts.ts
+++ b/src/features/catalog/agents/hooks/use-regex-scripts.ts
@@ -68,7 +68,7 @@ export function useReorderRegexScripts() {
       const payload = reorderRegexScriptsSchema.parse({ scriptIds });
       await Promise.all(
         payload.scriptIds.map((id, index) =>
-          storageApi.update("regex-scripts", id, { sortOrder: index, order: index }),
+          storageApi.update("regex-scripts", id, updateRegexScriptSchema.parse({ sortOrder: index, order: index })),
         ),
       );
       return storageApi.list<RegexScriptRow>("regex-scripts");

--- a/src/features/catalog/connections/hooks/use-connection-folders.ts
+++ b/src/features/catalog/connections/hooks/use-connection-folders.ts
@@ -2,6 +2,7 @@
 // React Query: Connection Folder hooks
 // ──────────────────────────────────────────────
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { updateConnectionSchema } from "../../../../engine/contracts/schemas/connection.schema";
 import { storageApi } from "../../../../shared/api/storage-api";
 import type { ConnectionFolder } from "../../../../engine/contracts/types/connection";
 import { connectionKeys } from "./use-connections";
@@ -72,7 +73,7 @@ export function useMoveConnection() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (data: { connectionId: string; folderId: string | null }) =>
-      storageApi.update("connections", data.connectionId, { folderId: data.folderId }),
+      storageApi.update("connections", data.connectionId, updateConnectionSchema.parse({ folderId: data.folderId })),
     onSuccess: () => qc.invalidateQueries({ queryKey: connectionKeys.list() }),
   });
 }

--- a/src/features/catalog/connections/hooks/use-connections.ts
+++ b/src/features/catalog/connections/hooks/use-connections.ts
@@ -6,6 +6,7 @@ import { connectionKeys } from "../query-keys";
 import {
   createConnectionSchema,
   type CreateConnectionInput,
+  updateConnectionSchema,
 } from "../../../../engine/contracts/schemas/connection.schema";
 import { connectionCommandApi } from "../../../../shared/api/connection-command-api";
 import { storageApi } from "../../../../shared/api/storage-api";
@@ -58,7 +59,7 @@ export function useUpdateConnection() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: ({ id, ...data }: { id: string } & Record<string, unknown>) =>
-      storageApi.update("connections", id, data),
+      storageApi.update("connections", id, updateConnectionSchema.parse(data)),
     onSuccess: (_data, variables) => {
       qc.invalidateQueries({ queryKey: connectionKeys.list() });
       qc.invalidateQueries({ queryKey: connectionKeys.detail(variables.id) });

--- a/src/features/catalog/lorebooks/components/CreateLorebookModal.tsx
+++ b/src/features/catalog/lorebooks/components/CreateLorebookModal.tsx
@@ -19,7 +19,7 @@ export function CreateLorebookModal({ open, onClose }: Props) {
 
   const createLorebook = useMutation({
     mutationFn: (data: { name: string; description: string }) =>
-      storageApi.create("lorebooks", createLorebookSchema.parse(data)),
+      storageApi.create("lorebooks", { ...createLorebookSchema.parse(data), entries: [] }),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["lorebooks"] });
       onClose();

--- a/src/features/catalog/lorebooks/components/CreateLorebookModal.tsx
+++ b/src/features/catalog/lorebooks/components/CreateLorebookModal.tsx
@@ -4,6 +4,7 @@
 import { useState } from "react";
 import { Modal } from "../../../../shared/components/ui/Modal";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { createLorebookSchema } from "../../../../engine/contracts/schemas/lorebook.schema";
 import { storageApi } from "../../../../shared/api/storage-api";
 import { Loader2, BookOpen, AlertCircle } from "lucide-react";
 
@@ -18,7 +19,7 @@ export function CreateLorebookModal({ open, onClose }: Props) {
 
   const createLorebook = useMutation({
     mutationFn: (data: { name: string; description: string }) =>
-      storageApi.create("lorebooks", { ...data, entries: [] }),
+      storageApi.create("lorebooks", createLorebookSchema.parse(data)),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["lorebooks"] });
       onClose();

--- a/src/features/catalog/lorebooks/components/LorebookMakerModal.tsx
+++ b/src/features/catalog/lorebooks/components/LorebookMakerModal.tsx
@@ -220,9 +220,8 @@ export function LorebookMakerModal({ open, onClose }: Props) {
           order: e.order ?? 100,
         }));
 
-        await Promise.all(
-          entriesToCreate.map((entry) => storageApi.create("lorebook-entries", createLorebookEntrySchema.parse(entry))),
-        );
+        const validatedEntries = entriesToCreate.map((entry) => createLorebookEntrySchema.parse(entry));
+        await Promise.all(validatedEntries.map((entry) => storageApi.create("lorebook-entries", entry)));
         // Invalidate so entries appear immediately
         qc.invalidateQueries({ queryKey: lorebookKeys.entries(lbId) });
       }

--- a/src/features/catalog/lorebooks/components/LorebookMakerModal.tsx
+++ b/src/features/catalog/lorebooks/components/LorebookMakerModal.tsx
@@ -9,6 +9,10 @@ import { useConnections } from "../../connections/index";
 import { useLorebooks, useCreateLorebook, lorebookKeys } from "../hooks/use-lorebooks";
 import { useUIStore } from "../../../../shared/stores/ui.store";
 import { Loader2, Wand2, CheckCircle, AlertCircle, ChevronDown, BookOpen, Plus } from "lucide-react";
+import {
+  createLorebookEntrySchema,
+  lorebookCategorySchema,
+} from "../../../../engine/contracts/schemas/lorebook.schema";
 import type { Lorebook } from "../../../../engine/contracts/types/lorebook";
 import { ProfessorMariWorkingWindow } from "../../../../shared/components/ui/ProfessorMariWorkingWindow";
 import { generateLorebookMaker } from "../../../../engine/generation/makers";
@@ -41,6 +45,11 @@ type GeneratedData = {
     order?: number;
   }>;
 };
+
+function normalizeGeneratedLorebookCategory(category: unknown) {
+  const parsed = lorebookCategorySchema.safeParse(category);
+  return parsed.success ? parsed.data : "world";
+}
 
 export function LorebookMakerModal({ open, onClose }: Props) {
   const { data: rawConnections } = useConnections();
@@ -193,7 +202,7 @@ export function LorebookMakerModal({ open, onClose }: Props) {
       const result = await createLorebook.mutateAsync({
         name: generated.lorebook_name || "AI Generated Lorebook",
         description: generated.lorebook_description || "",
-        category: (generated.category as "world") || "world",
+        category: normalizeGeneratedLorebookCategory(generated.category),
         generatedBy: "lorebook-maker",
       });
 
@@ -211,7 +220,9 @@ export function LorebookMakerModal({ open, onClose }: Props) {
           order: e.order ?? 100,
         }));
 
-        await Promise.all(entriesToCreate.map((entry) => storageApi.create("lorebook-entries", entry)));
+        await Promise.all(
+          entriesToCreate.map((entry) => storageApi.create("lorebook-entries", createLorebookEntrySchema.parse(entry))),
+        );
         // Invalidate so entries appear immediately
         qc.invalidateQueries({ queryKey: lorebookKeys.entries(lbId) });
       }

--- a/src/features/catalog/lorebooks/components/LorebooksPanel.tsx
+++ b/src/features/catalog/lorebooks/components/LorebooksPanel.tsx
@@ -24,6 +24,7 @@ import {
   Trash2,
   Zap,
   Camera,
+  Gamepad2,
 } from "lucide-react";
 import { useUIStore } from "../../../../shared/stores/ui.store";
 import { useChatStore } from "../../../../shared/stores/chat.store";
@@ -45,6 +46,7 @@ const CATEGORIES: Array<{ id: LorebookCategory | "all" | "active"; label: string
   { id: "character", label: "Character", icon: Users },
   { id: "npc", label: "NPC", icon: UserRound },
   { id: "spellbook", label: "Spellbook", icon: Wand2 },
+  { id: "game", label: "Game", icon: Gamepad2 },
   { id: "uncategorized", label: "Other", icon: BookOpen },
 ];
 
@@ -53,6 +55,7 @@ const CATEGORY_COLORS: Record<string, string> = {
   character: "from-violet-400 to-purple-500",
   npc: "from-rose-400 to-pink-500",
   spellbook: "from-blue-400 to-indigo-500",
+  game: "from-cyan-400 to-sky-500",
   uncategorized: "from-amber-400 to-orange-500",
   all: "from-amber-400 to-orange-500",
 };
@@ -625,7 +628,10 @@ export function LorebooksPanel() {
           {activeCategory === "all" && grouped
             ? // Grouped view
               Array.from(grouped.entries()).map(([category, books]) => {
-                const catMeta = CATEGORIES.find((c) => c.id === category) ?? CATEGORIES[5];
+                const catMeta =
+                  CATEGORIES.find((c) => c.id === category) ??
+                  CATEGORIES.find((c) => c.id === "uncategorized") ??
+                  CATEGORIES[0];
                 const CatIcon = catMeta.icon;
                 return (
                   <div key={category} className="mb-2">

--- a/src/features/catalog/lorebooks/hooks/use-lorebooks.ts
+++ b/src/features/catalog/lorebooks/hooks/use-lorebooks.ts
@@ -4,6 +4,14 @@
 import { useQuery, useQueries, useMutation, useQueryClient } from "@tanstack/react-query";
 import { lorebookKeys } from "../query-keys";
 import { scanActiveLorebookEntries } from "../../../../engine/generation/active-lorebooks";
+import {
+  createLorebookEntrySchema,
+  createLorebookFolderSchema,
+  createLorebookSchema,
+  updateLorebookEntrySchema,
+  updateLorebookFolderSchema,
+  updateLorebookSchema,
+} from "../../../../engine/contracts/schemas/lorebook.schema";
 import { storageApi } from "../../../../shared/api/storage-api";
 import { ApiError } from "../../../../shared/api/api-errors";
 import { lorebookCommandApi } from "../../../../shared/api/lorebook-command-api";
@@ -31,7 +39,11 @@ async function transferLorebookEntries(
     if (!entry || entry.lorebookId !== sourceLorebookId) continue;
     if (operation === "move") {
       created.push(
-        await storageApi.update<LorebookEntry>("lorebook-entries", entryId, { lorebookId: targetLorebookId }),
+        await storageApi.update<LorebookEntry>(
+          "lorebook-entries",
+          entryId,
+          updateLorebookEntrySchema.parse({ lorebookId: targetLorebookId }),
+        ),
       );
     } else {
       const copy = { ...(entry as unknown as Record<string, unknown>) };
@@ -138,7 +150,8 @@ export function useLorebook(id: string | null) {
 export function useCreateLorebook() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (data: Record<string, unknown>) => storageApi.create<Lorebook>("lorebooks", data),
+    mutationFn: (data: Record<string, unknown>) =>
+      storageApi.create<Lorebook>("lorebooks", createLorebookSchema.parse(data)),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: lorebookKeys.all });
     },
@@ -149,7 +162,7 @@ export function useUpdateLorebook() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: ({ id, ...data }: { id: string } & Record<string, unknown>) =>
-      storageApi.update<Lorebook>("lorebooks", id, data),
+      storageApi.update<Lorebook>("lorebooks", id, updateLorebookSchema.parse(data)),
     onSuccess: (_data, variables) => {
       qc.invalidateQueries({ queryKey: lorebookKeys.all });
       qc.invalidateQueries({ queryKey: lorebookKeys.list() });
@@ -251,7 +264,7 @@ export function useCreateLorebookEntry() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: ({ lorebookId, ...data }: { lorebookId: string } & Record<string, unknown>) =>
-      storageApi.create<LorebookEntry>("lorebook-entries", { ...data, lorebookId }),
+      storageApi.create<LorebookEntry>("lorebook-entries", createLorebookEntrySchema.parse({ ...data, lorebookId })),
     onSuccess: (_data, variables) => {
       qc.invalidateQueries({ queryKey: lorebookKeys.entries(variables.lorebookId) });
       qc.invalidateQueries({ queryKey: lorebookKeys.active() });
@@ -263,7 +276,7 @@ export function useUpdateLorebookEntry() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: ({ lorebookId, entryId, ...data }: { lorebookId: string; entryId: string } & Record<string, unknown>) =>
-      storageApi.update<LorebookEntry>("lorebook-entries", entryId, data),
+      storageApi.update<LorebookEntry>("lorebook-entries", entryId, updateLorebookEntrySchema.parse(data)),
     onSuccess: (_data, variables) => {
       qc.invalidateQueries({ queryKey: lorebookKeys.entries(variables.lorebookId) });
       qc.invalidateQueries({ queryKey: lorebookKeys.entry(variables.entryId) });
@@ -357,7 +370,10 @@ export function useCreateLorebookFolder() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: ({ lorebookId, ...data }: { lorebookId: string } & Record<string, unknown>) =>
-      storageApi.create<LorebookFolder>("lorebook-folders", { ...data, lorebookId }),
+      storageApi.create<LorebookFolder>("lorebook-folders", {
+        ...createLorebookFolderSchema.parse(data),
+        lorebookId,
+      }),
     onSuccess: (_data, variables) => {
       qc.invalidateQueries({ queryKey: lorebookKeys.folders(variables.lorebookId) });
     },
@@ -374,7 +390,8 @@ export function useUpdateLorebookFolder() {
     }: {
       lorebookId: string;
       folderId: string;
-    } & Record<string, unknown>) => storageApi.update<LorebookFolder>("lorebook-folders", folderId, data),
+    } & Record<string, unknown>) =>
+      storageApi.update<LorebookFolder>("lorebook-folders", folderId, updateLorebookFolderSchema.parse(data)),
     onSuccess: (_data, variables) => {
       qc.invalidateQueries({ queryKey: lorebookKeys.folders(variables.lorebookId) });
       // Toggling folder.enabled changes which entries activate during scan

--- a/src/features/catalog/lorebooks/hooks/use-lorebooks.ts
+++ b/src/features/catalog/lorebooks/hooks/use-lorebooks.ts
@@ -49,10 +49,13 @@ async function transferLorebookEntries(
       const copy = { ...(entry as unknown as Record<string, unknown>) };
       delete copy.id;
       created.push(
-        await storageApi.create<LorebookEntry>("lorebook-entries", {
-          ...copy,
-          lorebookId: targetLorebookId,
-        }),
+        await storageApi.create<LorebookEntry>(
+          "lorebook-entries",
+          createLorebookEntrySchema.parse({
+            ...copy,
+            lorebookId: targetLorebookId,
+          }),
+        ),
       );
     }
   }
@@ -75,7 +78,7 @@ async function reorderLorebookEntries(
     entryIds.map((entryId, index) => {
       const patch: Record<string, unknown> = { order: index, sortOrder: index };
       if (folderId !== undefined) patch.folderId = folderId;
-      return storageApi.update("lorebook-entries", entryId, patch);
+      return storageApi.update("lorebook-entries", entryId, updateLorebookEntrySchema.parse(patch));
     }),
   );
   return storageApi.list<LorebookEntry>("lorebook-entries", { filters: { lorebookId } });
@@ -84,10 +87,14 @@ async function reorderLorebookEntries(
 async function reorderLorebookFolders(lorebookId: string, folderIds: string[]): Promise<LorebookFolder[]> {
   await Promise.all(
     folderIds.map((folderId, index) =>
-      storageApi.update("lorebook-folders", folderId, {
-        order: index,
-        sortOrder: index,
-      }),
+      storageApi.update(
+        "lorebook-folders",
+        folderId,
+        updateLorebookFolderSchema.parse({
+          order: index,
+          sortOrder: index,
+        }),
+      ),
     ),
   );
   return storageApi.list<LorebookFolder>("lorebook-folders", { filters: { lorebookId } });
@@ -109,9 +116,13 @@ async function bulkUnvectorizeLorebookEntries(
   const targets = entries.filter((entry) => Array.isArray(entry.embedding) && entry.embedding.length > 0);
   await Promise.all(
     targets.map((entry) =>
-      storageApi.update<LorebookEntry>("lorebook-entries", entry.id, {
-        embedding: null,
-      }),
+      storageApi.update<LorebookEntry>(
+        "lorebook-entries",
+        entry.id,
+        updateLorebookEntrySchema.parse({
+          embedding: null,
+        }),
+      ),
     ),
   );
   return { lorebookId, requested: requestedIds.length || entries.length, cleared: targets.length };
@@ -370,10 +381,7 @@ export function useCreateLorebookFolder() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: ({ lorebookId, ...data }: { lorebookId: string } & Record<string, unknown>) =>
-      storageApi.create<LorebookFolder>("lorebook-folders", {
-        ...createLorebookFolderSchema.parse(data),
-        lorebookId,
-      }),
+      storageApi.create<LorebookFolder>("lorebook-folders", createLorebookFolderSchema.parse({ ...data, lorebookId })),
     onSuccess: (_data, variables) => {
       qc.invalidateQueries({ queryKey: lorebookKeys.folders(variables.lorebookId) });
     },

--- a/src/features/catalog/lorebooks/lib/lorebook-keeper-updates.ts
+++ b/src/features/catalog/lorebooks/lib/lorebook-keeper-updates.ts
@@ -1,4 +1,8 @@
 import type { QueryClient } from "@tanstack/react-query";
+import {
+  createLorebookEntrySchema,
+  updateLorebookEntrySchema,
+} from "../../../../engine/contracts/schemas/lorebook.schema";
 import type { Chat } from "../../../../engine/contracts/types/chat";
 import type { Lorebook, LorebookEntry } from "../../../../engine/contracts/types/lorebook";
 import { storageApi } from "../../../../shared/api/storage-api";
@@ -200,14 +204,20 @@ function appendLoreFacts(existingContent: string, update: PendingLorebookUpdate)
 
 export async function applyLorebookKeeperUpdate(update: PendingLorebookUpdate): Promise<void> {
   if (update.action === "create") {
-    await storageApi.create<LorebookEntry>("lorebook-entries", entryDefaults(update.lorebookId, update));
+    await storageApi.create<LorebookEntry>(
+      "lorebook-entries",
+      createLorebookEntrySchema.parse(entryDefaults(update.lorebookId, update)),
+    );
     return;
   }
 
   const existing = await findExistingEntry(update);
   if (!existing) {
     if (update.action === "delete") return;
-    await storageApi.create<LorebookEntry>("lorebook-entries", entryDefaults(update.lorebookId, update));
+    await storageApi.create<LorebookEntry>(
+      "lorebook-entries",
+      createLorebookEntrySchema.parse(entryDefaults(update.lorebookId, update)),
+    );
     return;
   }
 
@@ -228,6 +238,6 @@ export async function applyLorebookKeeperUpdate(update: PendingLorebookUpdate): 
   if (update.tag && update.tag !== existing.tag) patch.tag = update.tag;
   if (Object.keys(patch).length > 0) {
     patch.embedding = null;
-    await storageApi.update<LorebookEntry>("lorebook-entries", existing.id, patch);
+    await storageApi.update<LorebookEntry>("lorebook-entries", existing.id, updateLorebookEntrySchema.parse(patch));
   }
 }

--- a/src/features/catalog/lorebooks/types.ts
+++ b/src/features/catalog/lorebooks/types.ts
@@ -1,4 +1,4 @@
-export type LorebookCategory = "world" | "character" | "npc" | "spellbook" | "uncategorized";
+export type LorebookCategory = "world" | "character" | "npc" | "spellbook" | "game" | "uncategorized";
 
 export interface Lorebook {
   id: string;

--- a/src/features/catalog/presets/components/CreatePresetModal.tsx
+++ b/src/features/catalog/presets/components/CreatePresetModal.tsx
@@ -4,6 +4,7 @@
 import { useState } from "react";
 import { Modal } from "../../../../shared/components/ui/Modal";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { createPromptPresetSchema } from "../../../../engine/contracts/schemas/prompt.schema";
 import { storageApi } from "../../../../shared/api/storage-api";
 import { useUIStore } from "../../../../shared/stores/ui.store";
 import { Loader2, FileText } from "lucide-react";
@@ -31,7 +32,7 @@ export function CreatePresetModal({ open, onClose }: Props) {
   const [description, setDescription] = useState("");
 
   const createPreset = useMutation({
-    mutationFn: (data: Record<string, unknown>) => storageApi.create("prompts", data),
+    mutationFn: (data: Record<string, unknown>) => storageApi.create("prompts", createPromptPresetSchema.parse(data)),
     onSuccess: () => qc.invalidateQueries({ queryKey: ["presets"] }),
   });
 

--- a/src/features/catalog/presets/hooks/use-presets.ts
+++ b/src/features/catalog/presets/hooks/use-presets.ts
@@ -205,10 +205,12 @@ export function useDefaultPreset() {
     queryFn: async () => {
       const presets = await storageApi.list<PromptPreset>("prompts");
       return (
-        presets.find(
-          (preset) =>
-            boolish((preset as PromptPreset & { default?: unknown }).isDefault, false) ||
-            boolish((preset as PromptPreset & { default?: unknown }).default, false),
+        presets.find((preset) =>
+          boolish(
+            (preset as PromptPreset & { default?: unknown }).isDefault ??
+              (preset as PromptPreset & { default?: unknown }).default,
+            false,
+          ),
         ) ?? null
       );
     },

--- a/src/features/catalog/presets/hooks/use-presets.ts
+++ b/src/features/catalog/presets/hooks/use-presets.ts
@@ -2,6 +2,15 @@
 // React Query: Preset, Group, Section & Choice hooks
 // ──────────────────────────────────────────────
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  createChoiceBlockSchema,
+  createPromptGroupSchema,
+  createPromptSectionSchema,
+  updateChoiceBlockSchema,
+  updatePromptGroupSchema,
+  updatePromptPresetSchema,
+  updatePromptSectionSchema,
+} from "../../../../engine/contracts/schemas/prompt.schema";
 import { boolish } from "../../../../engine/generation/runtime-records";
 import { storageApi } from "../../../../shared/api/storage-api";
 import { storageCommandsApi } from "../../../../shared/api/storage-commands-api";
@@ -68,12 +77,35 @@ async function listPromptNested<T>(presetId: string, kind: PromptNestedKind): Pr
   return storageApi.list<T>(promptNestedEntity[kind], { filters: { presetId } });
 }
 
+function parsePromptNestedCreate(kind: PromptNestedKind, presetId: string, data: Record<string, unknown>) {
+  const payload = { ...data, presetId };
+  switch (kind) {
+    case "groups":
+      return createPromptGroupSchema.parse(payload);
+    case "sections":
+      return createPromptSectionSchema.parse(payload);
+    case "variables":
+      return createChoiceBlockSchema.parse(payload);
+  }
+}
+
+function parsePromptNestedUpdate(kind: PromptNestedKind, data: Record<string, unknown>) {
+  switch (kind) {
+    case "groups":
+      return updatePromptGroupSchema.parse(data);
+    case "sections":
+      return updatePromptSectionSchema.parse(data);
+    case "variables":
+      return updateChoiceBlockSchema.parse(data);
+  }
+}
+
 async function createPromptNested<T>(
   presetId: string,
   kind: PromptNestedKind,
   data: Record<string, unknown>,
 ): Promise<T> {
-  const created = await storageApi.create<T>(promptNestedEntity[kind], { ...data, presetId });
+  const created = await storageApi.create<T>(promptNestedEntity[kind], parsePromptNestedCreate(kind, presetId, data));
   const newId = (created as Record<string, unknown>).id as string | undefined;
   if (newId) {
     await runPresetOrderUpdate(presetId, async () => {
@@ -88,9 +120,13 @@ async function createPromptNested<T>(
         currentOrder = [];
       }
       if (!currentOrder.includes(newId)) {
-        await storageApi.update("prompts", presetId, {
-          [orderField]: [...currentOrder, newId],
-        });
+        await storageApi.update(
+          "prompts",
+          presetId,
+          updatePromptPresetSchema.parse({
+            [orderField]: [...currentOrder, newId],
+          }),
+        );
       }
     });
   }
@@ -98,7 +134,7 @@ async function createPromptNested<T>(
 }
 
 async function updatePromptNested<T>(kind: PromptNestedKind, id: string, data: Record<string, unknown>): Promise<T> {
-  return storageApi.update<T>(promptNestedEntity[kind], id, data);
+  return storageApi.update<T>(promptNestedEntity[kind], id, parsePromptNestedUpdate(kind, data));
 }
 
 async function deletePromptNested(kind: PromptNestedKind, id: string) {
@@ -115,9 +151,13 @@ async function reorderPromptNested<T>(presetId: string, kind: PromptNestedKind, 
       }),
     ),
   );
-  await storageApi.update("prompts", presetId, {
-    [promptOrderField[kind]]: ids,
-  });
+  await storageApi.update(
+    "prompts",
+    presetId,
+    updatePromptPresetSchema.parse({
+      [promptOrderField[kind]]: ids,
+    }),
+  );
   return listPromptNested<T>(presetId, kind);
 }
 
@@ -180,7 +220,7 @@ export function useUpdatePreset() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: ({ id, ...data }: { id: string } & Record<string, unknown>) =>
-      storageApi.update<PromptPreset>("prompts", id, data),
+      storageApi.update<PromptPreset>("prompts", id, updatePromptPresetSchema.parse(data)),
     onSuccess: (_data, variables) => {
       qc.invalidateQueries({ queryKey: presetKeys.list() });
       qc.invalidateQueries({ queryKey: presetKeys.full(variables.id) });
@@ -217,10 +257,14 @@ export function useSetDefaultPreset() {
       await Promise.all(
         prompts.map(async (prompt) => {
           const isDefault = prompt.id === id;
-          const updated = await storageApi.update<PromptPreset>("prompts", prompt.id, {
-            isDefault,
-            default: isDefault,
-          });
+          const updated = await storageApi.update<PromptPreset>(
+            "prompts",
+            prompt.id,
+            updatePromptPresetSchema.parse({
+              isDefault,
+              default: isDefault,
+            }),
+          );
           if (isDefault) selected = updated;
         }),
       );

--- a/src/features/modes/game/api/game-api.ts
+++ b/src/features/modes/game/api/game-api.ts
@@ -28,6 +28,10 @@ import { integrationGateway } from "../../../../shared/api/integration-gateway";
 import { spotifyApi } from "../../../../shared/api/integration-utility-api";
 import { llmApi } from "../../../../shared/api/llm-api";
 import { storageApi } from "../../../../shared/api/storage-api";
+import {
+  createLorebookEntrySchema,
+  createLorebookSchema,
+} from "../../../../engine/contracts/schemas/lorebook.schema";
 import { resolveCombatRound } from "../../../../engine/modes/game/mechanics/combat.service";
 import { rollDice as rollGameDice } from "../../../../engine/modes/game/mechanics/dice.service";
 import {
@@ -1629,32 +1633,37 @@ export const gameApi = {
         },
       }));
     const entries = Array.isArray(parsed.entries) && parsed.entries.length ? parsed.entries : fallbackEntries;
-    const lorebook = await storageApi.create<{ id: string }>("lorebooks", {
-      name: `Game Session ${data.sessionNumber} Lore`,
-      description: "Generated from local game session state.",
-      category: "game",
-      chatId: data.chatId,
-      enabled: true,
-      generatedBy: "game-session",
-    });
+    const lorebook = await storageApi.create<{ id: string }>(
+      "lorebooks",
+      createLorebookSchema.parse({
+        name: `Game Session ${data.sessionNumber} Lore`,
+        description: "Generated from local game session state.",
+        category: "game",
+        chatId: data.chatId,
+        enabled: true,
+        generatedBy: "game-session",
+      }),
+    );
     let entryCount = 0;
     for (const [index, rawEntry] of entries.entries()) {
       const entry = asRecord(rawEntry);
-      await storageApi.create("lorebook-entries", {
-        lorebookId: lorebook.id,
-        name: typeof entry.name === "string" ? entry.name : "Session Lore",
-        content: typeof entry.content === "string" ? entry.content : "",
-        keys: Array.isArray(entry.keys) ? entry.keys : [`session ${data.sessionNumber}`],
-        secondaryKeys: [],
-        enabled: true,
-        constant: false,
-        selective: false,
-        order: index,
-        sortOrder: index,
-        position: 0,
-        role: "system",
-        excludeFromVectorization: false,
-      });
+      await storageApi.create(
+        "lorebook-entries",
+        createLorebookEntrySchema.parse({
+          lorebookId: lorebook.id,
+          name: typeof entry.name === "string" ? entry.name : "Session Lore",
+          content: typeof entry.content === "string" ? entry.content : "",
+          keys: Array.isArray(entry.keys) ? entry.keys : [`session ${data.sessionNumber}`],
+          secondaryKeys: [],
+          enabled: true,
+          constant: false,
+          selective: false,
+          order: index,
+          position: 0,
+          role: "system",
+          excludeFromVectorization: false,
+        }),
+      );
       entryCount += 1;
     }
     const sessionChat = await patchChatMetadata(data.chatId, {

--- a/src/features/shell/settings/hooks/use-extensions.ts
+++ b/src/features/shell/settings/hooks/use-extensions.ts
@@ -3,7 +3,12 @@
 // ──────────────────────────────────────────────
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { storageApi } from "../../../../shared/api/storage-api";
-import type { CreateExtensionInput, UpdateExtensionInput } from "../../../../engine/contracts/schemas/extension.schema";
+import {
+  createExtensionSchema,
+  updateExtensionSchema,
+  type CreateExtensionInput,
+  type UpdateExtensionInput,
+} from "../../../../engine/contracts/schemas/extension.schema";
 import type { InstalledExtension } from "../../../../engine/contracts/types/extension";
 
 const extensionKeys = {
@@ -26,7 +31,7 @@ export function useCreateExtension() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (data: CreateExtensionInput) =>
-      storageApi.create<InstalledExtension>("extensions", data as Record<string, unknown>),
+      storageApi.create<InstalledExtension>("extensions", createExtensionSchema.parse(data)),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: extensionKeys.all });
     },
@@ -37,7 +42,7 @@ export function useUpdateExtension() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: ({ id, ...data }: { id: string } & UpdateExtensionInput) =>
-      storageApi.update<InstalledExtension>("extensions", id, data as Record<string, unknown>),
+      storageApi.update<InstalledExtension>("extensions", id, updateExtensionSchema.parse(data)),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: extensionKeys.all });
     },

--- a/src/features/shell/settings/hooks/use-themes.ts
+++ b/src/features/shell/settings/hooks/use-themes.ts
@@ -3,7 +3,13 @@
 // ──────────────────────────────────────────────
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { storageApi } from "../../../../shared/api/storage-api";
-import type { CreateThemeInput, UpdateThemeInput } from "../../../../engine/contracts/schemas/theme.schema";
+import {
+  createThemeSchema,
+  setActiveThemeSchema,
+  updateThemeSchema,
+  type CreateThemeInput,
+  type UpdateThemeInput,
+} from "../../../../engine/contracts/schemas/theme.schema";
 import type { Theme } from "../../../../engine/contracts/types/theme";
 
 const themeKeys = {
@@ -28,7 +34,7 @@ export function useThemes() {
 export function useCreateTheme() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (data: CreateThemeInput) => storageApi.create<Theme>("themes", data as Record<string, unknown>),
+    mutationFn: (data: CreateThemeInput) => storageApi.create<Theme>("themes", createThemeSchema.parse(data)),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: themeKeys.all });
     },
@@ -39,7 +45,7 @@ export function useUpdateTheme() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: ({ id, ...data }: { id: string } & UpdateThemeInput) =>
-      storageApi.update<Theme>("themes", id, data as Record<string, unknown>),
+      storageApi.update<Theme>("themes", id, updateThemeSchema.parse(data)),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: themeKeys.all });
     },
@@ -60,19 +66,22 @@ export function useSetActiveTheme() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: async (id: string | null): Promise<Theme | null> => {
+      const payload = setActiveThemeSchema.parse({ id });
       const themes = await storageApi.list<Theme>("themes");
       let selected: Theme | null = null;
       await Promise.all(
         themes.flatMap((theme) => {
-          const isActive = !!id && theme.id === id;
+          const isActive = !!payload.id && theme.id === payload.id;
           const currentlyActive = !!(theme.isActive || theme.active);
           if (currentlyActive === isActive) {
             if (isActive) selected = theme;
             return [];
           }
-          return storageApi.update<Theme>("themes", theme.id, { isActive, active: isActive }).then((updated) => {
-            if (isActive) selected = updated;
-          });
+          return storageApi
+            .update<Theme>("themes", theme.id, updateThemeSchema.parse({ isActive, active: isActive }))
+            .then((updated) => {
+              if (isActive) selected = updated;
+            });
         }),
       );
       return selected;


### PR DESCRIPTION
## Linked issue

None. This follows the unused-export cleanup triage for mutation schemas.

## Why this change

- Several exported mutation schemas existed but were not consistently used at the feature/storage write boundary.
- Wiring them in keeps create/update payload contracts explicit instead of leaving validation behavior split across callers.
- The branch preserves current lorebook helper behavior by allowing existing storage metadata patches such as ordering and embedding clears.

## What changed

- Routed theme, extension, lorebook, prompt preset, agent, custom tool, regex script, and connection mutation payloads through their contract schemas before `storageApi` writes.
- Expanded schema coverage for behavior-compatible update patches, including connection folder moves, prompt defaults/order fields, lorebook game metadata, lorebook entry/folder ordering, embedding clears, and regex reorder metadata.
- Added focused schema tests for narrow update patches so default-filled create schemas do not accidentally overwrite partial updates.

## Refactor impact

Primary owner:

Engine contracts and catalog/shell feature mutation hooks.

Impact areas reviewed:

- Settings theme and extension mutations.
- Catalog agents, custom tools, regex scripts, connections, lorebooks, lorebook folders/entries, and prompt presets.
- Game-session lorebook creation and generated lorebook metadata.
- Lorebook Keeper, copy/move/reorder, unvectorize, and generated-entry helper paths.

Boundary notes:

- Engine schemas remain React-free contract code.
- Feature hooks/components parse payloads before calling the shared `storageApi` wrapper.
- No Rust storage, Tauri command registration, or remote runtime route changes.

Pressure points touched:

- Catalog and shell mutation hooks/components.
- Game-session lorebook API helper.
- No `ModeSurface`, `GameSurface`, `src-tauri/src/lib.rs` command registration, or import modules touched.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->

- [x] `pnpm check` passes locally
- [x] `pnpm typecheck` passes locally
- [x] `pnpm build` passes locally
- [x] `pnpm check:architecture` passes locally
- [x] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

Automated validation run after rebasing onto current `origin/refactor`:

- `pnpm test -- src/engine/contracts/schemas/connection.schema.test.ts src/engine/contracts/schemas/prompt.schema.test.ts src/engine/contracts/schemas/theme.schema.test.ts src/engine/contracts/schemas/lorebook.schema.test.ts src/engine/contracts/schemas/regex.schema.test.ts` passed: 5 files, 14 tests.
- `pnpm typecheck` passed.
- `pnpm check:architecture` passed.
- `pnpm check:line-endings` passed.
- `git diff origin/refactor...HEAD --check` passed.
- `pnpm build` passed with the existing Vite large-chunk warning.

Native Tauri manual CRUD QA was not run.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

Code-only contract-boundary cleanup; no docs or release-note updates were made.

## UI evidence

No screenshots or recordings. This change does not intentionally alter visible layout; it changes mutation validation behavior at storage boundaries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Game" category for lorebooks
  * Added support for ordering and embedding management in lorebook entries and folders
  * Added variable ordering and default status management for prompt presets
  * Added reordering capability for regex scripts
  * Added active status tracking for themes
  * Enhanced connection folder management

* **Improvements**
  * Improved data validation across lorebooks, connections, presets, and themes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1654?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->