### PR TITLE
[codex] Clear chat activity on deleted chats

### DIFF
--- a/src-tauri/src/commands/storage/chats.rs
+++ b/src-tauri/src/commands/storage/chats.rs
@@ -882,7 +882,7 @@ pub(crate) fn delete_chat_with_messages(state: &AppState, chat_id: &str) -> AppR
     state.storage.delete_messages_for_chats(&delete_id_set)?;
 
     for delete_id in &delete_ids {
-        state.storage.delete("chats", &delete_id)?;
+        state.storage.delete("chats", delete_id)?;
     }
     Ok(delete_ids)
 }

--- a/src-tauri/src/commands/storage/chats.rs
+++ b/src-tauri/src/commands/storage/chats.rs
@@ -712,16 +712,22 @@ pub(crate) fn delete_chat_group(state: &AppState, group_id: &str) -> AppResult<V
         _ => Vec::new(),
     };
     let mut deleted = 0;
+    let mut deleted_chat_ids = Vec::new();
     for chat in chats {
         if let Some(id) = chat.get("id").and_then(Value::as_str) {
             if is_protected_record("chats", id) {
                 continue;
             }
-            delete_chat_with_messages(state, id)?;
-            deleted += 1;
+            let chat_delete_ids = delete_chat_with_messages(state, id)?;
+            if chat_delete_ids.iter().any(|deleted_id| deleted_id == id) {
+                deleted += 1;
+            }
+            deleted_chat_ids.extend(chat_delete_ids);
         }
     }
-    Ok(json!({ "deleted": deleted }))
+    deleted_chat_ids.sort_unstable();
+    deleted_chat_ids.dedup();
+    Ok(json!({ "deleted": deleted, "deletedChatIds": deleted_chat_ids }))
 }
 
 pub(crate) fn branch_chat(state: &AppState, chat_id: &str, body: Value) -> AppResult<Value> {
@@ -853,14 +859,14 @@ pub(crate) fn branch_chat(state: &AppState, chat_id: &str, body: Value) -> AppRe
     Ok(new_chat)
 }
 
-pub(crate) fn delete_chat_with_messages(state: &AppState, chat_id: &str) -> AppResult<()> {
+pub(crate) fn delete_chat_with_messages(state: &AppState, chat_id: &str) -> AppResult<Vec<String>> {
     if is_protected_record("chats", chat_id) {
         return Err(AppError::invalid_input(
             "Protected records cannot be deleted",
         ));
     }
     let Some(root_chat) = state.storage.get("chats", chat_id)? else {
-        return Ok(());
+        return Ok(Vec::new());
     };
     let owned_scene_chat_ids = scene_delete_scope(state, chat_id, &root_chat)?;
     clear_character_scene_memories(state, &owned_scene_chat_ids)?;
@@ -875,10 +881,10 @@ pub(crate) fn delete_chat_with_messages(state: &AppState, chat_id: &str) -> AppR
     let delete_id_set = delete_ids.iter().cloned().collect::<HashSet<_>>();
     state.storage.delete_messages_for_chats(&delete_id_set)?;
 
-    for delete_id in delete_ids {
+    for delete_id in &delete_ids {
         state.storage.delete("chats", &delete_id)?;
     }
-    Ok(())
+    Ok(delete_ids)
 }
 
 fn chat_game_state_is_bootstrap(chat: &Value) -> bool {
@@ -1124,6 +1130,80 @@ mod tests {
             std::fs::remove_dir_all(&path).expect("stale temp chat delete dir should be removable");
         }
         AppState::from_data_dir(path, Vec::new()).expect("test app state should initialize")
+    }
+
+    #[test]
+    fn delete_chat_group_reports_exact_deleted_chat_ids_including_scene_children() {
+        let state = test_state("group-delete-ids");
+        state
+            .storage
+            .create(
+                "chats",
+                json!({
+                    "id": "origin-chat",
+                    "name": "Origin",
+                    "groupId": "group-1",
+                    "metadata": { "activeSceneChatId": "scene-chat" }
+                }),
+            )
+            .expect("origin chat should be created");
+        state
+            .storage
+            .create(
+                "chats",
+                json!({
+                    "id": "scene-chat",
+                    "name": "Scene",
+                    "metadata": { "sceneOriginChatId": "origin-chat" }
+                }),
+            )
+            .expect("scene chat should be created");
+        state
+            .storage
+            .create(
+                "chats",
+                json!({
+                    "id": "sibling-chat",
+                    "name": "Sibling",
+                    "groupId": "group-1",
+                    "metadata": {}
+                }),
+            )
+            .expect("sibling chat should be created");
+        state
+            .storage
+            .create(
+                "chats",
+                json!({
+                    "id": "other-chat",
+                    "name": "Other",
+                    "groupId": "group-other",
+                    "metadata": {}
+                }),
+            )
+            .expect("other chat should be created");
+
+        let result = delete_chat_group(&state, "group-1").expect("group delete should succeed");
+        let deleted_chat_ids: Vec<&str> = result["deletedChatIds"]
+            .as_array()
+            .expect("deleted chat ids should be returned")
+            .iter()
+            .map(|id| id.as_str().expect("deleted chat id should be a string"))
+            .collect();
+
+        assert_eq!(result.get("deleted").and_then(Value::as_i64), Some(2));
+        assert_eq!(
+            deleted_chat_ids,
+            vec!["origin-chat", "scene-chat", "sibling-chat"]
+        );
+        assert!(state.storage.get("chats", "origin-chat").unwrap().is_none());
+        assert!(state.storage.get("chats", "scene-chat").unwrap().is_none());
+        assert!(state
+            .storage
+            .get("chats", "sibling-chat")
+            .unwrap()
+            .is_none());
+        assert!(state.storage.get("chats", "other-chat").unwrap().is_some());
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/commands/entities.rs
+++ b/src-tauri/src/commands/storage/commands/entities.rs
@@ -269,10 +269,11 @@ pub(crate) fn delete_entity(
     }
     if entity == "chats" {
         let existed = state.storage.get("chats", id)?.is_some();
+        let mut deleted_chat_ids = Vec::new();
         if existed {
-            chats::delete_chat_with_messages(state, id)?;
+            deleted_chat_ids = chats::delete_chat_with_messages(state, id)?;
         }
-        return Ok(json!({ "deleted": existed }));
+        return Ok(json!({ "deleted": existed, "deletedChatIds": deleted_chat_ids }));
     }
     if is_protected_record(entity, id) {
         return Err(AppError::invalid_input(
@@ -445,6 +446,47 @@ mod tests {
             .into_iter()
             .filter_map(|row| row.get("id").and_then(Value::as_str).map(str::to_string))
             .collect()
+    }
+
+    #[test]
+    fn deleting_chat_reports_cascade_deleted_chat_ids() {
+        let state = test_state("chat-delete-ids");
+        state
+            .storage
+            .create(
+                "chats",
+                json!({
+                    "id": "origin-chat",
+                    "name": "Origin",
+                    "metadata": { "activeSceneChatId": "scene-chat" }
+                }),
+            )
+            .expect("origin chat should be created");
+        state
+            .storage
+            .create(
+                "chats",
+                json!({
+                    "id": "scene-chat",
+                    "name": "Scene",
+                    "metadata": { "sceneOriginChatId": "origin-chat" }
+                }),
+            )
+            .expect("scene chat should be created");
+
+        let result = delete_entity(&state, "chats", "origin-chat", false)
+            .expect("chat delete should succeed");
+        let deleted_chat_ids: Vec<&str> = result["deletedChatIds"]
+            .as_array()
+            .expect("deleted chat ids should be returned")
+            .iter()
+            .map(|id| id.as_str().expect("deleted chat id should be a string"))
+            .collect();
+
+        assert_eq!(result.get("deleted").and_then(Value::as_bool), Some(true));
+        assert_eq!(deleted_chat_ids, vec!["origin-chat", "scene-chat"]);
+        assert!(state.storage.get("chats", "origin-chat").unwrap().is_none());
+        assert!(state.storage.get("chats", "scene-chat").unwrap().is_none());
     }
 
     #[test]

--- a/src/features/catalog/chats/hooks/use-chats.test.tsx
+++ b/src/features/catalog/chats/hooks/use-chats.test.tsx
@@ -1,0 +1,137 @@
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { clearChatActivity } from "../../../../engine/modes/chat/autonomous/autonomous.service";
+import { chatCommandApi } from "../../../../shared/api/chat-command-api";
+import { storageApi } from "../../../../shared/api/storage-api";
+import { chatKeys, useDeleteChat, useDeleteChatGroup } from "./use-chats";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock("../../../../shared/api/storage-api", () => ({
+  storageApi: {
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock("../../../../shared/api/chat-command-api", () => ({
+  chatCommandApi: {
+    groupDelete: vi.fn(),
+  },
+}));
+
+vi.mock("../../../../engine/modes/chat/autonomous/autonomous.service", () => ({
+  clearChatActivity: vi.fn(),
+}));
+
+const storageDeleteMock = vi.mocked(storageApi.delete);
+const groupDeleteMock = vi.mocked(chatCommandApi.groupDelete);
+const clearChatActivityMock = vi.mocked(clearChatActivity);
+
+describe("chat deletion mutations", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    queryClient = new QueryClient({
+      defaultOptions: {
+        mutations: { retry: false },
+        queries: { retry: false },
+      },
+    });
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    queryClient.clear();
+    storageDeleteMock.mockReset();
+    groupDeleteMock.mockReset();
+    clearChatActivityMock.mockReset();
+  });
+
+  async function renderMutation<TMutation>(useHook: () => TMutation): Promise<TMutation> {
+    let mutation: TMutation | undefined;
+
+    function Probe() {
+      mutation = useHook();
+      return null;
+    }
+
+    await act(async () => {
+      root.render(
+        createElement(QueryClientProvider, {
+          client: queryClient,
+          children: createElement(Probe),
+        }),
+      );
+    });
+
+    if (!mutation) {
+      throw new Error("Mutation hook did not render");
+    }
+
+    return mutation;
+  }
+
+  it("clears autonomous activity for every chat deleted by a chat delete", async () => {
+    const deleteChat = await renderMutation(useDeleteChat);
+    storageDeleteMock.mockResolvedValue({ deleted: true, deletedChatIds: ["chat-1", "scene-chat"] } as {
+      deleted: boolean;
+    });
+
+    await act(async () => {
+      await deleteChat.mutateAsync({ id: "chat-1", groupId: "group-1" });
+    });
+
+    expect(storageDeleteMock).toHaveBeenCalledWith("chats", "chat-1");
+    expect(clearChatActivityMock).toHaveBeenCalledTimes(2);
+    expect(clearChatActivityMock).toHaveBeenCalledWith("chat-1");
+    expect(clearChatActivityMock).toHaveBeenCalledWith("scene-chat");
+  });
+
+  it("keeps autonomous activity when chat deletion fails", async () => {
+    const deleteChat = await renderMutation(useDeleteChat);
+    storageDeleteMock.mockRejectedValue(new Error("delete failed"));
+    let caught: unknown;
+
+    await act(async () => {
+      try {
+        await deleteChat.mutateAsync("chat-1");
+      } catch (error) {
+        caught = error;
+      }
+    });
+
+    expect(caught).toBeInstanceOf(Error);
+    expect(clearChatActivityMock).not.toHaveBeenCalled();
+  });
+
+  it("clears backend-reported chat activity after deleting a chat group without relying on cache", async () => {
+    const deleteChatGroup = await renderMutation(useDeleteChatGroup);
+    groupDeleteMock.mockResolvedValue({ deleted: 2, deletedChatIds: ["chat-1", "chat-2", "scene-chat"] });
+    queryClient.setQueryData(chatKeys.list(), [
+      { id: "chat-other", groupId: "group-other" },
+    ]);
+
+    await act(async () => {
+      await deleteChatGroup.mutateAsync("group-1");
+    });
+
+    expect(groupDeleteMock).toHaveBeenCalledWith("group-1");
+    expect(clearChatActivityMock).toHaveBeenCalledTimes(3);
+    expect(clearChatActivityMock).toHaveBeenCalledWith("chat-1");
+    expect(clearChatActivityMock).toHaveBeenCalledWith("chat-2");
+    expect(clearChatActivityMock).toHaveBeenCalledWith("scene-chat");
+    expect(clearChatActivityMock).not.toHaveBeenCalledWith("chat-other");
+  });
+});

--- a/src/features/catalog/chats/hooks/use-chats.test.tsx
+++ b/src/features/catalog/chats/hooks/use-chats.test.tsx
@@ -134,4 +134,16 @@ describe("chat deletion mutations", () => {
     expect(clearChatActivityMock).toHaveBeenCalledWith("scene-chat");
     expect(clearChatActivityMock).not.toHaveBeenCalledWith("chat-other");
   });
+
+  it("does not crash when a chat group delete response omits deleted chat ids", async () => {
+    const deleteChatGroup = await renderMutation(useDeleteChatGroup);
+    groupDeleteMock.mockResolvedValue({ deleted: 1 } as Awaited<ReturnType<typeof chatCommandApi.groupDelete>>);
+
+    await act(async () => {
+      await deleteChatGroup.mutateAsync("group-1");
+    });
+
+    expect(groupDeleteMock).toHaveBeenCalledWith("group-1");
+    expect(clearChatActivityMock).not.toHaveBeenCalled();
+  });
 });

--- a/src/features/catalog/chats/hooks/use-chats.ts
+++ b/src/features/catalog/chats/hooks/use-chats.ts
@@ -592,7 +592,7 @@ export function useDeleteChatGroup() {
       return { previous, groupId };
     },
     onSuccess: (data) => {
-      for (const chatId of uniqueIds(data.deletedChatIds)) {
+      for (const chatId of uniqueIds(data.deletedChatIds ?? [])) {
         clearChatActivity(chatId);
       }
     },

--- a/src/features/catalog/chats/hooks/use-chats.ts
+++ b/src/features/catalog/chats/hooks/use-chats.ts
@@ -21,6 +21,7 @@ import {
   summariesPatchSchema,
 } from "../../../../engine/contracts/schemas/chat.schema";
 import { boolish } from "../../../../engine/generation/runtime-records";
+import { clearChatActivity } from "../../../../engine/modes/chat/autonomous/autonomous.service";
 import { backfillConversationSummaries } from "../../../../engine/modes/chat/core/summaries/auto-summary.service";
 import { appendChatSummaryEntryToMetadata } from "../../../../engine/shared/text/chat-summary-entries";
 import { chatCommandApi } from "../../../../shared/api/chat-command-api";
@@ -476,12 +477,21 @@ export function useChatGroup(groupId: string | null) {
 
 type DeleteChatInput = string | { id: string; groupId?: string | null };
 
+interface DeleteChatResult {
+  deleted: boolean;
+  deletedChatIds?: string[];
+}
+
 function getDeleteChatId(input: DeleteChatInput) {
   return typeof input === "string" ? input : input.id;
 }
 
 function getDeleteChatGroupId(input: DeleteChatInput) {
   return typeof input === "string" ? null : (input.groupId ?? null);
+}
+
+function uniqueIds(ids: Array<string | null | undefined>) {
+  return Array.from(new Set(ids.filter((id): id is string => typeof id === "string" && id.length > 0)));
 }
 
 export function useCreateChat() {
@@ -506,7 +516,8 @@ export function useCreateChat() {
 export function useDeleteChat() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (input: DeleteChatInput) => storageApi.delete("chats", getDeleteChatId(input)),
+    mutationFn: async (input: DeleteChatInput): Promise<DeleteChatResult> =>
+      (await storageApi.delete("chats", getDeleteChatId(input))) as DeleteChatResult,
     onMutate: async (input) => {
       const id = getDeleteChatId(input);
       const providedGroupId = getDeleteChatGroupId(input);
@@ -533,6 +544,11 @@ export function useDeleteChat() {
       }
 
       return { previous, previousSummaries, previousGroup, groupId };
+    },
+    onSuccess: (data, input) => {
+      for (const chatId of uniqueIds([getDeleteChatId(input), ...(data.deletedChatIds ?? [])])) {
+        clearChatActivity(chatId);
+      }
     },
     onError: (_err, _id, context) => {
       if (context?.previous) {
@@ -574,6 +590,11 @@ export function useDeleteChatGroup() {
       qc.setQueryData<Chat[]>(chatKeys.group(groupId), []);
 
       return { previous, groupId };
+    },
+    onSuccess: (data) => {
+      for (const chatId of uniqueIds(data.deletedChatIds)) {
+        clearChatActivity(chatId);
+      }
     },
     onError: (_err, _groupId, context) => {
       if (context?.previous) qc.setQueryData(chatKeys.list(), context.previous);

--- a/src/shared/api/chat-command-api.ts
+++ b/src/shared/api/chat-command-api.ts
@@ -1,5 +1,10 @@
 import { invokeTauri } from "./tauri-client";
 
+export interface ChatGroupDeleteResult {
+  deleted: number;
+  deletedChatIds: string[];
+}
+
 export const chatCommandApi = {
   messageCount: (chatId: string | null) => invokeTauri<{ count: number }>("chat_message_count", { chatId }),
   memoriesList: <T = unknown>(chatId: string | null) => invokeTauri<T>("chat_memories_list", { chatId }),
@@ -12,7 +17,7 @@ export const chatCommandApi = {
   notesList: <T = unknown>(chatId: string | null) => invokeTauri<T>("chat_notes_list", { chatId }),
   noteDelete: (chatId: string | null, noteId: string) => invokeTauri("chat_note_delete", { chatId, noteId }),
   notesClear: (chatId: string | null) => invokeTauri("chat_notes_clear", { chatId }),
-  groupDelete: (groupId: string) => invokeTauri("chat_group_delete", { groupId }),
+  groupDelete: (groupId: string) => invokeTauri<ChatGroupDeleteResult>("chat_group_delete", { groupId }),
   markAutonomousUnread: <T = unknown>(chatId: string, body: { characterId?: string | null; count?: number | null }) =>
     invokeTauri<T>("chat_autonomous_unread_mark", { chatId, body }),
   clearAutonomousUnread: <T = unknown>(chatId: string) => invokeTauri<T>("chat_autonomous_unread_clear", { chatId }),

--- a/src/shared/api/chat-command-api.ts
+++ b/src/shared/api/chat-command-api.ts
@@ -2,7 +2,7 @@ import { invokeTauri } from "./tauri-client";
 
 export interface ChatGroupDeleteResult {
   deleted: number;
-  deletedChatIds: string[];
+  deletedChatIds?: string[];
 }
 
 export const chatCommandApi = {


### PR DESCRIPTION
## Linked issue

No linked issue. This is a local Knip unused-export triage cleanup slice.

## Why this change

Chat deletion removed persisted chat records and cache state, but autonomous chat activity lived in an in-memory engine map keyed by chat id. Deleted chats, including cascade-deleted roleplay scene chats, could leave stale autonomous activity state behind until reload.

## What changed

- Return exact `deletedChatIds` from chat deletion commands, including scene-chat cascades.
- Clear autonomous chat activity from backend-reported deleted ids after successful single-chat and group-chat deletion.
- Keep group deletion tolerant of older or mixed-runtime responses that omit `deletedChatIds`.
- Add focused React Query hook tests and Rust command tests for deletion id reporting and cleanup behavior.

## Refactor impact

Primary owner:

Catalog chats, chat autonomous engine state, shared API chat command wrapper, and Rust storage chat deletion commands.

Impact areas reviewed:

- Catalog chat deletion hooks and optimistic cache rollback.
- Chat autonomous in-memory activity cleanup.
- Rust `storage_delete` and `chat_group_delete` command response contracts.
- Roleplay scene chat cascade deletion ids.
- Shared API typing for the group-delete command.

Boundary notes:

- Feature code still calls focused shared API/storage wrappers.
- Engine code remains React-free and does not import shared API adapters.
- Rust storage commands remain the source of truth for which chat ids were actually deleted.
- `chat_group_delete` is already routed through the embedded Tauri command and remote `/api/invoke` allowlist/dispatch path; the response shape change is shared by both.

Pressure points touched:

- None of the listed pressure points were touched: no ModeSurface, GameSurface, shared mode UI, `src-tauri/src/lib.rs` command registration, or import modules changed.

## Validation

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

Commands run locally:

- `pnpm vitest run src/features/catalog/chats/hooks/use-chats.test.tsx` passed.
- `cargo test --manifest-path src-tauri/Cargo.toml delete_chat_group_reports_exact_deleted_chat_ids_including_scene_children` passed.
- `cargo test --manifest-path src-tauri/Cargo.toml deleting_chat_reports_cascade_deleted_chat_ids` passed.
- `pnpm typecheck` passed.
- `pnpm check:architecture` passed.
- `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passed.
- `cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- -D warnings` passed after fixing the CI clippy finding.
- `pnpm exec eslint src/features/catalog/chats/hooks/use-chats.ts src/features/catalog/chats/hooks/use-chats.test.tsx src/shared/api/chat-command-api.ts` passed.
- `pnpm build` passed with the existing large chunk warning.
- `git diff --check` passed.

Manual app/Tauri QA was not run. Remote runtime was not smoke checked separately.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs or release note files were changed. This checkout has no `CHANGELOG.md`, and the change is internal cleanup/bugfix behavior rather than a documented workflow change.

## UI evidence

No visible UI changes; no screenshots or recordings added.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of chat deletion reporting to track all affected chat records when deleting groups or related chats.
  * Enhanced cleanup of chat activity data during deletion operations to ensure all affected chats are properly cleared.

* **Tests**
  * Added test coverage for multi-chat deletion and cascade delete scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1655?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->