### PR TITLE
Fix persona avatar path normalization

### DIFF
--- a/src/features/catalog/personas/hooks/use-personas.test.tsx
+++ b/src/features/catalog/personas/hooks/use-personas.test.tsx
@@ -262,6 +262,7 @@ describe("persona hooks", () => {
   it("invalidates the active persona cache after updating a persona", async () => {
     const updatePersona = await renderMutation(useUpdatePersona);
     primeActivePersonaCache();
+    queryClient.setQueryData(personaKeys.summaryDetail("persona-1"), { id: "persona-1", name: "Current Persona" });
     storageUpdateMock.mockResolvedValue({
       id: "persona-1",
       isActive: true,
@@ -274,6 +275,7 @@ describe("persona hooks", () => {
 
     expect(storageUpdateMock).toHaveBeenCalledWith("personas", "persona-1", { name: "Updated Persona" });
     expectActivePersonaInvalidated();
+    expect(queryClient.getQueryState(personaKeys.summaryDetail("persona-1"))?.isInvalidated).toBe(true);
   });
 
   it("normalizes managed avatar paths in persona update cache writes", async () => {

--- a/src/features/catalog/personas/hooks/use-personas.test.tsx
+++ b/src/features/catalog/personas/hooks/use-personas.test.tsx
@@ -1,14 +1,23 @@
 // @vitest-environment jsdom
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { convertFileSrc } from "@tauri-apps/api/core";
 import { act, createElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { personaApi } from "../../../../shared/api/persona-api";
+import { remoteRuntimeTarget } from "../../../../shared/api/remote-runtime";
 import { storageApi } from "../../../../shared/api/storage-api";
 import { storageCommandsApi } from "../../../../shared/api/storage-commands-api";
 import { personaKeys } from "../query-keys";
-import { useDeletePersona, useUpdatePersona, useUploadPersonaAvatar } from "./use-personas";
+import {
+  useDeletePersona,
+  usePersona,
+  usePersonaSummaries,
+  usePersonas,
+  useUpdatePersona,
+  useUploadPersonaAvatar,
+} from "./use-personas";
 
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -20,6 +29,17 @@ vi.mock("../../../../shared/api/storage-api", () => ({
     list: vi.fn(),
     update: vi.fn(),
   },
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  convertFileSrc: vi.fn(),
+  invoke: vi.fn(),
+}));
+
+vi.mock("../../../../shared/api/remote-runtime", () => ({
+  invokeRemote: vi.fn(),
+  isRemoteCommand: vi.fn(),
+  remoteRuntimeTarget: vi.fn(),
 }));
 
 vi.mock("../../../../shared/api/persona-api", () => ({
@@ -35,12 +55,16 @@ vi.mock("../../../../shared/api/storage-commands-api", () => ({
   },
 }));
 
+const convertFileSrcMock = vi.mocked(convertFileSrc);
+const remoteRuntimeTargetMock = vi.mocked(remoteRuntimeTarget);
+const storageGetMock = vi.mocked(storageApi.get);
+const storageListMock = vi.mocked(storageApi.list);
 const storageDeleteMock = vi.mocked(storageApi.delete);
 const storageUpdateMock = vi.mocked(storageApi.update);
 const uploadAvatarMock = vi.mocked(personaApi.uploadAvatar);
 const duplicateMock = vi.mocked(storageCommandsApi.duplicate);
 
-describe("persona mutations", () => {
+describe("persona hooks", () => {
   let container: HTMLDivElement;
   let root: Root;
   let queryClient: QueryClient;
@@ -55,6 +79,13 @@ describe("persona mutations", () => {
         queries: { retry: false },
       },
     });
+    storageListMock.mockResolvedValue([]);
+    storageGetMock.mockResolvedValue(null);
+    remoteRuntimeTargetMock.mockReturnValue(null);
+    convertFileSrcMock.mockImplementation((path) => `asset://localhost/${encodeURIComponent(path)}`);
+    (window as unknown as { __TAURI_INTERNALS__?: { convertFileSrc?: unknown } }).__TAURI_INTERNALS__ = {
+      convertFileSrc: vi.fn(),
+    };
   });
 
   afterEach(() => {
@@ -63,17 +94,22 @@ describe("persona mutations", () => {
     });
     container.remove();
     queryClient.clear();
+    storageGetMock.mockReset();
+    storageListMock.mockReset();
     storageDeleteMock.mockReset();
     storageUpdateMock.mockReset();
     uploadAvatarMock.mockReset();
     duplicateMock.mockReset();
+    convertFileSrcMock.mockReset();
+    remoteRuntimeTargetMock.mockReset();
+    delete (window as unknown as { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
   });
 
-  async function renderMutation<TMutation>(useHook: () => TMutation): Promise<TMutation> {
-    let mutation: TMutation | undefined;
+  async function renderHook<THook>(useHook: () => THook): Promise<() => THook> {
+    let hook: THook | undefined;
 
     function Probe() {
-      mutation = useHook();
+      hook = useHook();
       return null;
     }
 
@@ -86,11 +122,20 @@ describe("persona mutations", () => {
       );
     });
 
-    if (!mutation) {
-      throw new Error("Mutation hook did not render");
+    if (!hook) {
+      throw new Error("Hook did not render");
     }
 
-    return mutation;
+    return () => {
+      if (!hook) {
+        throw new Error("Hook did not render");
+      }
+      return hook;
+    };
+  }
+
+  async function renderMutation<TMutation>(useHook: () => TMutation): Promise<TMutation> {
+    return (await renderHook(useHook))();
   }
 
   function primeActivePersonaCache() {
@@ -107,6 +152,113 @@ describe("persona mutations", () => {
     expect(queryClient.getQueryState(personaKeys.active)?.isInvalidated).toBe(true);
   }
 
+  it("projects persona summaries with file-backed avatar fields", async () => {
+    storageListMock.mockResolvedValue([
+      {
+        id: "persona-1",
+        name: "Current Persona",
+        avatarPath: "data:image/png;base64,large-avatar",
+        avatarFilePath: "C:\\Marinara\\avatars\\personas\\Current.png",
+        avatarFilename: "Current.png",
+        isActive: true,
+      },
+    ]);
+
+    const getSummaries = await renderHook(usePersonaSummaries);
+
+    await vi.waitFor(() =>
+      expect(getSummaries().data).toEqual([
+        {
+          id: "persona-1",
+          name: "Current Persona",
+          avatarPath: "asset://localhost/C%3A%5CMarinara%5Cavatars%5Cpersonas%5CCurrent.png",
+          avatarFilePath: "C:\\Marinara\\avatars\\personas\\Current.png",
+          avatarFilename: "Current.png",
+          isActive: true,
+        },
+      ]),
+    );
+
+    expect(storageListMock).toHaveBeenCalledWith("personas", {
+      fields: [
+        "id",
+        "name",
+        "comment",
+        "description",
+        "tags",
+        "avatarPath",
+        "avatarFilePath",
+        "avatarFilename",
+        "avatarCrop",
+        "isActive",
+        "active",
+        "createdAt",
+        "nameColor",
+        "dialogueColor",
+        "boxColor",
+      ],
+    });
+    expect(convertFileSrcMock).toHaveBeenCalledWith("C:\\Marinara\\avatars\\personas\\Current.png");
+  });
+
+  it("normalizes managed avatar paths from full persona reads", async () => {
+    storageListMock.mockResolvedValue([
+      {
+        id: "persona-1",
+        name: "Current Persona",
+        avatarPath: "data:image/png;base64,large-avatar",
+        avatarFilePath: "C:\\Marinara\\avatars\\personas\\Current.png",
+        avatarFilename: "Current.png",
+        personality: "Helpful",
+      },
+    ]);
+
+    const getPersonas = await renderHook(usePersonas);
+
+    await vi.waitFor(() =>
+      expect(getPersonas().data).toEqual([
+        {
+          id: "persona-1",
+          name: "Current Persona",
+          avatarPath: "asset://localhost/C%3A%5CMarinara%5Cavatars%5Cpersonas%5CCurrent.png",
+          avatarFilePath: "C:\\Marinara\\avatars\\personas\\Current.png",
+          avatarFilename: "Current.png",
+          personality: "Helpful",
+        },
+      ]),
+    );
+
+    expect(storageListMock).toHaveBeenCalledWith("personas");
+    expect(convertFileSrcMock).toHaveBeenCalledWith("C:\\Marinara\\avatars\\personas\\Current.png");
+  });
+
+  it("normalizes managed avatar paths from persona detail reads", async () => {
+    storageGetMock.mockResolvedValue({
+      id: "persona-1",
+      name: "Current Persona",
+      avatarPath: "data:image/png;base64,large-avatar",
+      avatarFilePath: "C:\\Marinara\\avatars\\personas\\Current.png",
+      avatarFilename: "Current.png",
+      description: "Detail row",
+    });
+
+    const getPersona = await renderHook(() => usePersona("persona-1"));
+
+    await vi.waitFor(() =>
+      expect(getPersona().data).toEqual({
+        id: "persona-1",
+        name: "Current Persona",
+        avatarPath: "asset://localhost/C%3A%5CMarinara%5Cavatars%5Cpersonas%5CCurrent.png",
+        avatarFilePath: "C:\\Marinara\\avatars\\personas\\Current.png",
+        avatarFilename: "Current.png",
+        description: "Detail row",
+      }),
+    );
+
+    expect(storageGetMock).toHaveBeenCalledWith("personas", "persona-1");
+    expect(convertFileSrcMock).toHaveBeenCalledWith("C:\\Marinara\\avatars\\personas\\Current.png");
+  });
+
   it("invalidates the active persona cache after updating a persona", async () => {
     const updatePersona = await renderMutation(useUpdatePersona);
     primeActivePersonaCache();
@@ -122,6 +274,38 @@ describe("persona mutations", () => {
 
     expect(storageUpdateMock).toHaveBeenCalledWith("personas", "persona-1", { name: "Updated Persona" });
     expectActivePersonaInvalidated();
+  });
+
+  it("normalizes managed avatar paths in persona update cache writes", async () => {
+    const updatePersona = await renderMutation(useUpdatePersona);
+    queryClient.setQueryData(personaKeys.list, [
+      {
+        id: "persona-1",
+        name: "Current Persona",
+        avatarPath: "data:image/png;base64,old-avatar",
+      },
+    ]);
+    storageUpdateMock.mockResolvedValue({
+      id: "persona-1",
+      name: "Updated Persona",
+      avatarPath: "data:image/png;base64,large-avatar",
+      avatarFilePath: "C:\\Marinara\\avatars\\personas\\Updated.png",
+      avatarFilename: "Updated.png",
+    });
+
+    await act(async () => {
+      await updatePersona.mutateAsync({ id: "persona-1", name: "Updated Persona" });
+    });
+
+    const expectedPersona = {
+      id: "persona-1",
+      name: "Updated Persona",
+      avatarPath: "asset://localhost/C%3A%5CMarinara%5Cavatars%5Cpersonas%5CUpdated.png",
+      avatarFilePath: "C:\\Marinara\\avatars\\personas\\Updated.png",
+      avatarFilename: "Updated.png",
+    };
+    expect(queryClient.getQueryData(personaKeys.detail("persona-1"))).toEqual(expectedPersona);
+    expect(queryClient.getQueryData(personaKeys.list)).toEqual([expectedPersona]);
   });
 
   it("invalidates the active persona cache after deleting a persona", async () => {

--- a/src/features/catalog/personas/hooks/use-personas.ts
+++ b/src/features/catalog/personas/hooks/use-personas.ts
@@ -188,6 +188,7 @@ export function useUpdatePersona() {
       qc.invalidateQueries({ queryKey: personaKeys.list });
       qc.invalidateQueries({ queryKey: personaKeys.summaries });
       qc.invalidateQueries({ queryKey: personaKeys.detail(variables.id) });
+      qc.invalidateQueries({ queryKey: personaKeys.summaryDetail(variables.id) });
       qc.invalidateQueries({ queryKey: personaKeys.active });
     },
   });

--- a/src/features/catalog/personas/hooks/use-personas.ts
+++ b/src/features/catalog/personas/hooks/use-personas.ts
@@ -3,6 +3,7 @@ import { personaKeys } from "../query-keys";
 import { personaApi } from "../../../../shared/api/persona-api";
 import { storageApi } from "../../../../shared/api/storage-api";
 import { storageCommandsApi } from "../../../../shared/api/storage-commands-api";
+import { personaAvatarUrl, type PersonaAvatarSource } from "../lib/persona-avatar-url";
 
 export { personaKeys } from "../query-keys";
 
@@ -13,8 +14,11 @@ export type PersonaSummary = {
   description?: string;
   tags?: string[];
   avatarPath?: string | null;
+  avatarFilePath?: string | null;
+  avatarFilename?: string | null;
   avatarCrop?: unknown;
   isActive?: string | boolean;
+  active?: string | boolean;
   createdAt?: string;
   nameColor?: string;
   dialogueColor?: string;
@@ -29,6 +33,8 @@ const PERSONA_SUMMARY_OPTIONS = {
     "description",
     "tags",
     "avatarPath",
+    "avatarFilePath",
+    "avatarFilename",
     "avatarCrop",
     "isActive",
     "active",
@@ -39,10 +45,41 @@ const PERSONA_SUMMARY_OPTIONS = {
   ],
 };
 
+function personaIsActive(persona: PersonaSummary): boolean {
+  return (
+    persona.isActive === true || persona.isActive === "true" || persona.active === true || persona.active === "true"
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function normalizePersonaAvatarFields<T>(persona: T): T {
+  if (!isRecord(persona)) return persona;
+  const avatarPath = personaAvatarUrl(persona as PersonaAvatarSource);
+  if (avatarPath === ((persona.avatarPath as string | null | undefined) ?? null)) return persona;
+  return { ...persona, avatarPath } as T;
+}
+
+async function listPersonas(): Promise<unknown[]> {
+  const personas = await storageApi.list<unknown>("personas");
+  return personas.map(normalizePersonaAvatarFields);
+}
+
+async function getPersona(id: string): Promise<unknown> {
+  return normalizePersonaAvatarFields(await storageApi.get<unknown>("personas", id));
+}
+
+async function listPersonaSummaries(): Promise<PersonaSummary[]> {
+  const personas = await storageApi.list<PersonaSummary>("personas", PERSONA_SUMMARY_OPTIONS);
+  return personas.map(normalizePersonaAvatarFields);
+}
+
 export function usePersonas(enabled = true) {
   return useQuery({
     queryKey: personaKeys.list,
-    queryFn: () => storageApi.list<unknown>("personas"),
+    queryFn: listPersonas,
     enabled,
     staleTime: 5 * 60_000,
     refetchOnWindowFocus: false,
@@ -52,7 +89,7 @@ export function usePersonas(enabled = true) {
 export function usePersonaSummaries(enabled = true) {
   return useQuery({
     queryKey: personaKeys.summaries,
-    queryFn: () => storageApi.list<PersonaSummary>("personas", PERSONA_SUMMARY_OPTIONS),
+    queryFn: listPersonaSummaries,
     enabled,
     staleTime: 5 * 60_000,
     refetchOnWindowFocus: false,
@@ -62,7 +99,7 @@ export function usePersonaSummaries(enabled = true) {
 export function usePersona(id: string | null, enabled = true) {
   return useQuery({
     queryKey: personaKeys.detail(id ?? ""),
-    queryFn: () => storageApi.get("personas", id!),
+    queryFn: () => getPersona(id!),
     enabled: enabled && !!id,
     staleTime: 5 * 60_000,
     refetchOnWindowFocus: false,
@@ -72,21 +109,7 @@ export function usePersona(id: string | null, enabled = true) {
 export function useActivePersona(enabled = true) {
   return useQuery({
     queryKey: personaKeys.active,
-    queryFn: async () => {
-      const personas = await storageApi.list<PersonaSummary & { active?: string | boolean }>(
-        "personas",
-        PERSONA_SUMMARY_OPTIONS,
-      );
-      return (
-        personas.find(
-          (persona) =>
-            persona.isActive === true ||
-            persona.isActive === "true" ||
-            persona.active === true ||
-            persona.active === "true",
-        ) ?? null
-      );
-    },
+    queryFn: async () => (await listPersonaSummaries()).find(personaIsActive) ?? null,
     enabled,
     staleTime: 5 * 60_000,
     refetchOnWindowFocus: false,
@@ -147,17 +170,18 @@ export function useUpdatePersona() {
       personaStats?: unknown;
     }) => storageApi.update("personas", id, data),
     onSuccess: (updatedPersona, variables) => {
-      qc.setQueryData(personaKeys.detail(variables.id), updatedPersona);
+      const normalizedPersona = normalizePersonaAvatarFields(updatedPersona);
+      qc.setQueryData(personaKeys.detail(variables.id), normalizedPersona);
       qc.setQueryData<unknown[] | undefined>(personaKeys.list, (old) => {
         if (!Array.isArray(old)) return old;
-        const updatedId = (updatedPersona as { id?: string } | null)?.id ?? variables.id;
+        const updatedId = (normalizedPersona as { id?: string } | null)?.id ?? variables.id;
         if (!updatedId) return old;
 
         return old.map((persona) => {
           const row = persona as Record<string, unknown> & { id?: string };
           if (row?.id !== updatedId) return persona;
-          if (!updatedPersona || typeof updatedPersona !== "object") return persona;
-          return { ...row, ...(updatedPersona as Record<string, unknown>) };
+          if (!normalizedPersona || typeof normalizedPersona !== "object") return persona;
+          return { ...row, ...(normalizedPersona as Record<string, unknown>) };
         });
       });
 

--- a/src/features/catalog/personas/index.ts
+++ b/src/features/catalog/personas/index.ts
@@ -1,2 +1,3 @@
 export * from "./query-keys";
 export * from "./hooks/use-personas";
+export * from "./lib/persona-avatar-url";

--- a/src/features/catalog/personas/lib/persona-avatar-url.ts
+++ b/src/features/catalog/personas/lib/persona-avatar-url.ts
@@ -1,0 +1,12 @@
+import { avatarFileUrlFromPath } from "../../../../shared/api/local-file-api";
+
+export type PersonaAvatarSource = {
+  avatarPath?: string | null;
+  avatarFilePath?: string | null;
+  avatarFilename?: string | null;
+};
+
+export function personaAvatarUrl(source: PersonaAvatarSource | null | undefined): string | null {
+  if (!source) return null;
+  return avatarFileUrlFromPath(source.avatarFilename, source.avatarFilePath) ?? source.avatarPath ?? null;
+}


### PR DESCRIPTION
## Summary

- Normalize persona avatar records through the catalog/personas hook layer.
- Prefer managed avatar file fields (`avatarFilePath`/`avatarFilename`) when constructing UI-safe avatar URLs.
- Cover summary, list, detail, active-persona, and update-cache paths with targeted tests.

## Root Cause

Panels consuming persona records could receive raw `avatarPath` payloads even when the row also had managed avatar file fields. That left some UI paths rendering the heavy or unsafe avatar payload directly instead of the managed file URL, which could crash panels using `avatarPath`.

## Validation

- `pnpm test -- src/features/catalog/personas/hooks/use-personas.test.tsx src/shared/api/local-file-api.test.ts`
- `pnpm typecheck`
- `pnpm check:architecture`
- `pnpm build`

## Notes

- No changelog update: this repo does not currently have a `CHANGELOG.md` file.
- Native Tauri panel click-through with real profile data is still a useful manual QA follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Avatar paths for personas are now consistently normalized across queries and updates, ensuring reliable avatar display.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1657?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->