### PR TITLE
Fix character avatar path normalization

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3059,6 +3059,7 @@ dependencies = [
  "chrono",
  "criterion",
  "image",
+ "libc",
  "log",
  "marinara-assets",
  "marinara-core",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -42,6 +42,7 @@ buttplug = "10.0.2"
 buttplug_core = "10.0.2"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "webp"] }
+libc = "0.2"
 log = "0.4"
 pdf-extract = "0.10"
 png = "0.17"

--- a/src-tauri/src/commands/storage/commands/profile.rs
+++ b/src-tauri/src/commands/storage/commands/profile.rs
@@ -1,21 +1,201 @@
 use super::{exports, http, profile, prompts, shared};
 use crate::state::AppState;
+use base64::{engine::general_purpose, Engine as _};
 use marinara_core::AppError;
 use serde_json::{json, Value};
+use std::fs::{File, OpenOptions};
+use std::io::Read;
+use std::path::{Path, PathBuf};
 use tauri::State;
+
+const MAX_LOCAL_BINARY_BYTES: u64 = 25 * 1024 * 1024;
+const LOCAL_BINARY_ASSET_DIRS: &[&str] = &[
+    "avatars",
+    "backgrounds",
+    "fonts",
+    "gallery",
+    "game-assets",
+    "knowledge-sources",
+    "lorebooks/images",
+    "sprites",
+];
 
 #[tauri::command]
 pub async fn load_url_binary(
+    state: State<'_, AppState>,
     url: String,
     fallback_mime: Option<String>,
 ) -> Result<Value, AppError> {
-    http::http_binary(
-        &url,
-        fallback_mime
-            .as_deref()
-            .unwrap_or("application/octet-stream"),
-    )
-    .await
+    let fallback_mime = fallback_mime
+        .as_deref()
+        .unwrap_or("application/octet-stream");
+    load_url_binary_for_state(&state, &url, fallback_mime).await
+}
+
+pub(crate) async fn load_url_binary_for_state(
+    state: &AppState,
+    url: &str,
+    fallback_mime: &str,
+) -> Result<Value, AppError> {
+    if let Some(response) = load_local_asset_binary(state, url, fallback_mime)? {
+        return Ok(response);
+    }
+    http::http_binary(url, fallback_mime).await
+}
+
+fn load_local_asset_binary(
+    state: &AppState,
+    url: &str,
+    fallback_mime: &str,
+) -> Result<Option<Value>, AppError> {
+    let Some(path) = local_asset_path_from_url(url) else {
+        return Ok(None);
+    };
+    let canonical_path = std::fs::canonicalize(&path).map_err(|error| {
+        AppError::new(
+            "local_asset_not_found",
+            format!("Managed local asset could not be read: {error}"),
+        )
+    })?;
+    let data_dir = std::fs::canonicalize(&state.data_dir).map_err(AppError::from)?;
+    if !canonical_path.starts_with(&data_dir) {
+        return Err(AppError::invalid_input(
+            "Managed local asset URL is outside the app data directory",
+        ));
+    }
+    if !is_managed_local_binary_asset(&data_dir, &canonical_path) {
+        return Err(AppError::invalid_input(
+            "Managed local asset URL is outside allowed media directories",
+        ));
+    }
+
+    let file = open_local_binary_file(&path).map_err(AppError::from)?;
+    let metadata = file.metadata().map_err(AppError::from)?;
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        return Err(AppError::invalid_input(
+            "Managed local asset URL does not point to a file",
+        ));
+    }
+    if metadata.len() > MAX_LOCAL_BINARY_BYTES {
+        return Err(AppError::invalid_input("Local asset file is too large"));
+    }
+
+    let mut bytes = Vec::new();
+    let mut reader = file.take(MAX_LOCAL_BINARY_BYTES + 1);
+    reader.read_to_end(&mut bytes).map_err(AppError::from)?;
+    if bytes.len() as u64 > MAX_LOCAL_BINARY_BYTES {
+        return Err(AppError::invalid_input("Local asset file is too large"));
+    }
+
+    Ok(Some(json!({
+        "base64": general_purpose::STANDARD.encode(bytes),
+        "mimeType": local_binary_mime_type(&canonical_path, fallback_mime)
+    })))
+}
+
+fn open_local_binary_file(path: &Path) -> std::io::Result<File> {
+    let mut options = OpenOptions::new();
+    options.read(true);
+    configure_no_follow_open(&mut options);
+    options.open(path)
+}
+
+#[cfg(unix)]
+fn configure_no_follow_open(options: &mut OpenOptions) {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    options.custom_flags(libc::O_NOFOLLOW);
+}
+
+#[cfg(windows)]
+fn configure_no_follow_open(options: &mut OpenOptions) {
+    use std::os::windows::fs::OpenOptionsExt;
+
+    const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+    options.custom_flags(FILE_FLAG_OPEN_REPARSE_POINT);
+}
+
+#[cfg(not(any(unix, windows)))]
+fn configure_no_follow_open(_options: &mut OpenOptions) {}
+
+fn local_asset_path_from_url(url: &str) -> Option<PathBuf> {
+    let trimmed = url.trim();
+    let encoded = trimmed
+        .strip_prefix("asset://localhost/")
+        .or_else(|| trimmed.strip_prefix("http://asset.localhost/"))?;
+    let encoded = encoded
+        .split(['?', '#'])
+        .next()
+        .filter(|value| !value.is_empty())?;
+    Some(PathBuf::from(percent_decode(encoded)))
+}
+
+fn local_binary_mime_type(path: &Path, fallback_mime: &str) -> String {
+    match path
+        .extension()
+        .and_then(|value| value.to_str())
+        .unwrap_or("")
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "jpg" | "jpeg" => "image/jpeg",
+        "png" => "image/png",
+        "webp" => "image/webp",
+        "gif" => "image/gif",
+        "avif" => "image/avif",
+        "svg" => "image/svg+xml",
+        "bmp" => "image/bmp",
+        "mp3" => "audio/mpeg",
+        "wav" => "audio/wav",
+        "ogg" => "audio/ogg",
+        "webm" => "video/webm",
+        "mp4" => "video/mp4",
+        _ => fallback_mime,
+    }
+    .to_string()
+}
+
+fn is_managed_local_binary_asset(data_dir: &Path, path: &Path) -> bool {
+    LOCAL_BINARY_ASSET_DIRS.iter().any(|asset_dir| {
+        std::fs::canonicalize(data_dir.join(asset_dir))
+            .ok()
+            .is_some_and(|allowed_root| path.starts_with(allowed_root))
+    })
+}
+
+fn percent_decode(value: &str) -> String {
+    let bytes = value.as_bytes();
+    let mut output = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'%' if index + 2 < bytes.len() => {
+                if let (Some(hi), Some(lo)) =
+                    (hex_value(bytes[index + 1]), hex_value(bytes[index + 2]))
+                {
+                    output.push((hi << 4) | lo);
+                    index += 3;
+                } else {
+                    output.push(bytes[index]);
+                    index += 1;
+                }
+            }
+            byte => {
+                output.push(byte);
+                index += 1;
+            }
+        }
+    }
+    String::from_utf8_lossy(&output).to_string()
+}
+
+fn hex_value(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
 }
 
 #[tauri::command]
@@ -148,4 +328,161 @@ pub async fn lorebook_vectorize(
     body: Value,
 ) -> Result<Value, AppError> {
     prompts::vectorize_lorebook(&state, &id, body).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage_commands::media_uploads::file_path_asset_url;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    struct TempRoot(PathBuf);
+
+    impl Drop for TempRoot {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn temp_root(test_name: &str) -> TempRoot {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after epoch")
+            .as_nanos();
+        TempRoot(std::env::temp_dir().join(format!("marinara-profile-command-{test_name}-{nonce}")))
+    }
+
+    #[cfg(unix)]
+    fn symlink_file(source: &Path, target: &Path) -> bool {
+        std::os::unix::fs::symlink(source, target).expect("file symlink should be created");
+        true
+    }
+
+    #[cfg(windows)]
+    fn symlink_file(source: &Path, target: &Path) -> bool {
+        match std::os::windows::fs::symlink_file(source, target) {
+            Ok(()) => true,
+            Err(error)
+                if error.kind() == std::io::ErrorKind::PermissionDenied
+                    || error.raw_os_error() == Some(1314) =>
+            {
+                false
+            }
+            Err(error) => panic!("file symlink should be created: {error}"),
+        }
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    fn symlink_file(_source: &Path, _target: &Path) -> bool {
+        false
+    }
+
+    #[test]
+    fn local_asset_binary_reads_managed_app_data_asset_urls() {
+        let root = temp_root("local-asset");
+        let state =
+            AppState::from_data_dir(&root.0, Vec::new()).expect("test state should initialize");
+        let avatar_dir = state.data_dir.join("avatars").join("characters");
+        std::fs::create_dir_all(&avatar_dir).expect("avatar dir should be created");
+        let avatar_path = avatar_dir.join("Avatar One.png");
+        std::fs::write(&avatar_path, b"avatar-bytes").expect("avatar should be written");
+
+        let response = load_local_asset_binary(
+            &state,
+            &file_path_asset_url(&avatar_path),
+            "application/octet-stream",
+        )
+        .expect("managed local asset should load")
+        .expect("asset url should be handled locally");
+
+        let base64 = response
+            .get("base64")
+            .and_then(Value::as_str)
+            .expect("response should include base64");
+        let bytes = general_purpose::STANDARD
+            .decode(base64)
+            .expect("base64 should decode");
+        assert_eq!(bytes, b"avatar-bytes");
+        assert_eq!(
+            response.get("mimeType"),
+            Some(&Value::String("image/png".into()))
+        );
+    }
+
+    #[test]
+    fn local_asset_binary_rejects_asset_urls_outside_app_data() {
+        let root = temp_root("local-asset-state");
+        let state =
+            AppState::from_data_dir(&root.0, Vec::new()).expect("test state should initialize");
+        let outside = temp_root("local-asset-outside");
+        std::fs::create_dir_all(&outside.0).expect("outside dir should be created");
+        let outside_path = outside.0.join("Outside.png");
+        std::fs::write(&outside_path, b"outside").expect("outside asset should be written");
+
+        let result = load_local_asset_binary(
+            &state,
+            &file_path_asset_url(&outside_path),
+            "application/octet-stream",
+        );
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn local_asset_binary_rejects_symlinked_asset_files() {
+        let root = temp_root("local-asset-symlink");
+        let state =
+            AppState::from_data_dir(&root.0, Vec::new()).expect("test state should initialize");
+        let avatar_dir = state.data_dir.join("avatars").join("characters");
+        std::fs::create_dir_all(&avatar_dir).expect("avatar dir should be created");
+        let target_path = avatar_dir.join("Target.png");
+        std::fs::write(&target_path, b"avatar-bytes").expect("target avatar should be written");
+        let symlink_path = avatar_dir.join("Alias.png");
+        if !symlink_file(&target_path, &symlink_path) {
+            return;
+        }
+
+        let result = load_local_asset_binary(
+            &state,
+            &file_path_asset_url(&symlink_path),
+            "application/octet-stream",
+        );
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn local_asset_binary_rejects_non_media_files_inside_app_data() {
+        let root = temp_root("local-asset-data");
+        let state =
+            AppState::from_data_dir(&root.0, Vec::new()).expect("test state should initialize");
+        let collection_dir = state.data_dir.join("data").join("collections");
+        std::fs::create_dir_all(&collection_dir).expect("collection dir should be created");
+        let collection_path = collection_dir.join("characters.json");
+        std::fs::write(&collection_path, b"[]").expect("collection should be written");
+
+        let result = load_local_asset_binary(
+            &state,
+            &file_path_asset_url(&collection_path),
+            "application/octet-stream",
+        );
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn local_asset_binary_ignores_non_asset_urls() {
+        let root = temp_root("remote-url");
+        let state =
+            AppState::from_data_dir(&root.0, Vec::new()).expect("test state should initialize");
+
+        let response = load_local_asset_binary(
+            &state,
+            "https://example.com/avatar.png",
+            "application/octet-stream",
+        )
+        .expect("non-local urls should not error");
+
+        assert!(response.is_none());
+    }
 }

--- a/src-tauri/src/http_dispatch.rs
+++ b/src-tauri/src/http_dispatch.rs
@@ -2,8 +2,8 @@ use crate::state::AppState;
 use crate::storage_commands::{
     admin, agents, avatars, backgrounds, backup, bot_browser, characters, chats, custom_tools,
     entity_commands, exports, fonts, game_assets, game_state_snapshots, generation, http, images,
-    imports, integrations, knowledge, llm, lorebook_images, mari, profile, prompts, shared,
-    sprites, translation, updates,
+    imports, integrations, knowledge, llm, lorebook_images, mari, profile, profile_commands,
+    prompts, shared, sprites, translation, updates,
 };
 use marinara_core::{AppError, AppResult};
 use serde::Deserialize;
@@ -79,7 +79,7 @@ pub async fn dispatch(state: &AppState, request: InvokeRequest) -> AppResult<Val
     let command = request.command.as_str();
     let args = args_object(request.args)?;
     match command {
-        "load_url_binary" => load_url_binary(&args).await,
+        "load_url_binary" => load_url_binary(state, &args).await,
         "profile_export" => profile::profile_snapshot(state),
         "profile_import" => profile::profile_call(
             state,
@@ -717,8 +717,9 @@ pub async fn dispatch(state: &AppState, request: InvokeRequest) -> AppResult<Val
     }
 }
 
-async fn load_url_binary(args: &Map<String, Value>) -> AppResult<Value> {
-    http::http_binary(
+async fn load_url_binary(state: &AppState, args: &Map<String, Value>) -> AppResult<Value> {
+    profile_commands::load_url_binary_for_state(
+        state,
         required_string(args, "url")?,
         optional_string(args, "fallbackMime")
             .as_deref()
@@ -1248,6 +1249,7 @@ fn message_cursor(row: &Value) -> (&str, &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::storage_commands::media_uploads::file_path_asset_url;
     use base64::{engine::general_purpose, Engine as _};
     use std::collections::BTreeSet;
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -1366,6 +1368,41 @@ mod tests {
 
         assert_eq!(remote_allowlist, expected_remote);
         assert_eq!(dispatch_commands, remote_allowlist);
+    }
+
+    #[tokio::test]
+    async fn dispatch_load_url_binary_reads_managed_asset_urls() {
+        let state = test_state("load-url-binary-local-asset");
+        let avatar_dir = state.data_dir.join("avatars").join("characters");
+        std::fs::create_dir_all(&avatar_dir).expect("avatar dir should be created");
+        let avatar_path = avatar_dir.join("Avatar One.png");
+        std::fs::write(&avatar_path, b"avatar-bytes").expect("avatar should be written");
+
+        let result = dispatch(
+            &state,
+            InvokeRequest {
+                command: "load_url_binary".to_string(),
+                args: Some(json!({
+                    "url": file_path_asset_url(&avatar_path),
+                    "fallbackMime": "application/octet-stream"
+                })),
+            },
+        )
+        .await
+        .expect("remote load_url_binary should load managed local assets");
+
+        let base64 = result
+            .get("base64")
+            .and_then(Value::as_str)
+            .expect("response should include base64");
+        let bytes = general_purpose::STANDARD
+            .decode(base64)
+            .expect("base64 should decode");
+        assert_eq!(bytes, b"avatar-bytes");
+        assert_eq!(
+            result.get("mimeType"),
+            Some(&Value::String("image/png".into()))
+        );
     }
 
     #[tokio::test]

--- a/src/features/catalog/characters/hooks/use-characters.test.ts
+++ b/src/features/catalog/characters/hooks/use-characters.test.ts
@@ -1,15 +1,20 @@
 // @vitest-environment jsdom
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { convertFileSrc } from "@tauri-apps/api/core";
 import { act, createElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { updateCharacterSchema } from "../../../../engine/contracts/schemas/character.schema";
+import { remoteRuntimeTarget } from "../../../../shared/api/remote-runtime";
 import { storageApi } from "../../../../shared/api/storage-api";
 import {
   cacheCharacterListRecordFromResult,
   characterKeys,
   removeCachedCharacterRecord,
+  useCharacter,
+  useCharacterSummaries,
+  useCharactersByIds,
   useCharacters,
 } from "./use-characters";
 
@@ -17,10 +22,25 @@ import {
 
 vi.mock("../../../../shared/api/storage-api", () => ({
   storageApi: {
+    get: vi.fn(),
     list: vi.fn(),
   },
 }));
 
+vi.mock("@tauri-apps/api/core", () => ({
+  convertFileSrc: vi.fn(),
+  invoke: vi.fn(),
+}));
+
+vi.mock("../../../../shared/api/remote-runtime", () => ({
+  invokeRemote: vi.fn(),
+  isRemoteCommand: vi.fn(),
+  remoteRuntimeTarget: vi.fn(),
+}));
+
+const convertFileSrcMock = vi.mocked(convertFileSrc);
+const remoteRuntimeTargetMock = vi.mocked(remoteRuntimeTarget);
+const storageGetMock = vi.mocked(storageApi.get);
 const storageListMock = vi.mocked(storageApi.list);
 
 function characterRecord(id: string, name: string) {
@@ -30,11 +50,6 @@ function characterRecord(id: string, name: string) {
     avatarPath: null,
     comment: null,
   };
-}
-
-function UseCharactersProbe() {
-  useCharacters(true);
-  return null;
 }
 
 describe("character list query", () => {
@@ -52,6 +67,12 @@ describe("character list query", () => {
       },
     });
     storageListMock.mockResolvedValue([]);
+    storageGetMock.mockResolvedValue(null);
+    remoteRuntimeTargetMock.mockReturnValue(null);
+    convertFileSrcMock.mockImplementation((path) => `asset://localhost/${encodeURIComponent(path)}`);
+    (window as unknown as { __TAURI_INTERNALS__?: { convertFileSrc?: unknown } }).__TAURI_INTERNALS__ = {
+      convertFileSrc: vi.fn(),
+    };
   });
 
   afterEach(() => {
@@ -60,24 +81,217 @@ describe("character list query", () => {
     });
     container.remove();
     queryClient.clear();
+    storageGetMock.mockReset();
     storageListMock.mockReset();
+    convertFileSrcMock.mockReset();
+    remoteRuntimeTargetMock.mockReset();
+    delete (window as unknown as { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
   });
 
-  it("projects full character list reads without embedded avatar payloads", async () => {
+  async function renderHook<THook>(useHook: () => THook): Promise<() => THook> {
+    let hook: THook | undefined;
+
+    function Probe() {
+      hook = useHook();
+      return null;
+    }
+
     await act(async () => {
       root.render(
         createElement(QueryClientProvider, {
           client: queryClient,
-          children: createElement(UseCharactersProbe),
+          children: createElement(Probe),
         }),
       );
     });
 
+    if (!hook) {
+      throw new Error("Hook did not render");
+    }
+
+    return () => {
+      if (!hook) {
+        throw new Error("Hook did not render");
+      }
+      return hook;
+    };
+  }
+
+  it("requests list fields needed for managed and legacy avatar paths", async () => {
+    await renderHook(() => useCharacters(true));
+
     await vi.waitFor(() => {
       expect(storageListMock).toHaveBeenCalledWith("characters", {
-        fields: ["id", "data", "comment", "avatarFilePath", "avatarFilename", "createdAt", "updatedAt"],
+        fields: ["id", "data", "comment", "avatarPath", "avatarFilePath", "avatarFilename", "createdAt", "updatedAt"],
       });
     });
+  });
+
+  it("normalizes managed avatar paths from character summaries", async () => {
+    storageListMock.mockResolvedValue([
+      {
+        id: "char-1",
+        data: { name: "Managed Character" },
+        avatarFilePath: "C:\\Marinara\\avatars\\characters\\Managed.png",
+        avatarFilename: "Managed.png",
+      },
+    ]);
+
+    const getSummaries = await renderHook(useCharacterSummaries);
+
+    await vi.waitFor(() =>
+      expect(getSummaries().data).toEqual([
+        {
+          id: "char-1",
+          data: { name: "Managed Character" },
+          avatarPath: "asset://localhost/C%3A%5CMarinara%5Cavatars%5Ccharacters%5CManaged.png",
+          avatarFilePath: "C:\\Marinara\\avatars\\characters\\Managed.png",
+          avatarFilename: "Managed.png",
+        },
+      ]),
+    );
+  });
+
+  it("normalizes managed avatar paths from full character list reads", async () => {
+    storageListMock.mockResolvedValue([
+      {
+        id: "char-1",
+        data: { name: "Managed Character" },
+        avatarPath: "data:image/png;base64,large-avatar",
+        avatarFilePath: "C:\\Marinara\\avatars\\characters\\Managed.png",
+        avatarFilename: "Managed.png",
+      },
+    ]);
+
+    const getCharacters = await renderHook(() => useCharacters(true));
+
+    await vi.waitFor(() =>
+      expect(getCharacters().data).toEqual([
+        {
+          id: "char-1",
+          data: { name: "Managed Character" },
+          avatarPath: "asset://localhost/C%3A%5CMarinara%5Cavatars%5Ccharacters%5CManaged.png",
+          avatarFilePath: "C:\\Marinara\\avatars\\characters\\Managed.png",
+          avatarFilename: "Managed.png",
+        },
+      ]),
+    );
+  });
+
+  it("normalizes managed avatar paths to remote runtime asset urls", async () => {
+    remoteRuntimeTargetMock.mockReturnValue({ baseUrl: "http://runtime.local" });
+    storageListMock.mockResolvedValue([
+      {
+        id: "char-1",
+        data: { name: "Managed Character" },
+        avatarFilePath: "C:\\Marinara\\avatars\\characters\\Managed Avatar.png",
+        avatarFilename: "Managed Avatar.png",
+      },
+    ]);
+
+    const getCharacters = await renderHook(() => useCharacters(true));
+
+    await vi.waitFor(() =>
+      expect(getCharacters().data).toEqual([
+        {
+          id: "char-1",
+          data: { name: "Managed Character" },
+          avatarPath: "http://runtime.local/api/assets/avatar/Managed%20Avatar.png",
+          avatarFilePath: "C:\\Marinara\\avatars\\characters\\Managed Avatar.png",
+          avatarFilename: "Managed Avatar.png",
+        },
+      ]),
+    );
+    expect(convertFileSrcMock).not.toHaveBeenCalled();
+  });
+
+  it("preserves legacy avatar paths from full character list reads", async () => {
+    storageListMock.mockResolvedValue([
+      {
+        id: "char-1",
+        data: { name: "Legacy Character" },
+        avatarPath: "data:image/png;base64,legacy-avatar",
+      },
+    ]);
+
+    const getCharacters = await renderHook(() => useCharacters(true));
+
+    await vi.waitFor(() =>
+      expect(getCharacters().data).toEqual([
+        {
+          id: "char-1",
+          data: { name: "Legacy Character" },
+          avatarPath: "data:image/png;base64,legacy-avatar",
+        },
+      ]),
+    );
+  });
+
+  it("normalizes missing avatar paths to null from full character list reads", async () => {
+    storageListMock.mockResolvedValue([
+      {
+        id: "char-1",
+        data: { name: "No Avatar Character" },
+      },
+    ]);
+
+    const getCharacters = await renderHook(() => useCharacters(true));
+
+    await vi.waitFor(() =>
+      expect(getCharacters().data).toEqual([
+        {
+          id: "char-1",
+          data: { name: "No Avatar Character" },
+          avatarPath: null,
+        },
+      ]),
+    );
+  });
+
+  it("normalizes managed avatar paths from character detail reads", async () => {
+    storageGetMock.mockResolvedValue({
+      id: "char-1",
+      data: { name: "Managed Character" },
+      avatarPath: "data:image/png;base64,large-avatar",
+      avatarFilePath: "C:\\Marinara\\avatars\\characters\\Managed.png",
+      avatarFilename: "Managed.png",
+    });
+
+    const getCharacter = await renderHook(() => useCharacter("char-1"));
+
+    await vi.waitFor(() =>
+      expect(getCharacter().data).toEqual({
+        id: "char-1",
+        data: { name: "Managed Character" },
+        avatarPath: "asset://localhost/C%3A%5CMarinara%5Cavatars%5Ccharacters%5CManaged.png",
+        avatarFilePath: "C:\\Marinara\\avatars\\characters\\Managed.png",
+        avatarFilename: "Managed.png",
+      }),
+    );
+  });
+
+  it("normalizes managed avatar paths from character reads by id", async () => {
+    storageGetMock.mockResolvedValue({
+      id: "char-1",
+      data: { name: "Managed Character" },
+      avatarPath: "data:image/png;base64,large-avatar",
+      avatarFilePath: "C:\\Marinara\\avatars\\characters\\Managed.png",
+      avatarFilename: "Managed.png",
+    });
+
+    const getCharacters = await renderHook(() => useCharactersByIds(["char-1"]));
+
+    await vi.waitFor(() =>
+      expect(getCharacters().data).toEqual([
+        {
+          id: "char-1",
+          data: { name: "Managed Character" },
+          avatarPath: "asset://localhost/C%3A%5CMarinara%5Cavatars%5Ccharacters%5CManaged.png",
+          avatarFilePath: "C:\\Marinara\\avatars\\characters\\Managed.png",
+          avatarFilename: "Managed.png",
+        },
+      ]),
+    );
   });
 });
 
@@ -96,6 +310,37 @@ describe("character query cache helpers", () => {
     expect(queryClient.getQueryData(characterKeys.summaries())).toEqual([created, existing]);
     expect(queryClient.getQueryData(characterKeys.detail(created.id))).toEqual(created);
     expect(queryClient.getQueryData(characterKeys.summaryDetail(created.id))).toEqual(created);
+  });
+
+  it("normalizes managed avatar paths in character cache writes", () => {
+    const queryClient = new QueryClient();
+    remoteRuntimeTargetMock.mockReturnValue(null);
+    convertFileSrcMock.mockImplementation((path) => `asset://localhost/${encodeURIComponent(path)}`);
+    (window as unknown as { __TAURI_INTERNALS__?: { convertFileSrc?: unknown } }).__TAURI_INTERNALS__ = {
+      convertFileSrc: vi.fn(),
+    };
+    const created = {
+      id: "char-created",
+      data: { name: "Created Character" },
+      avatarPath: "data:image/png;base64,large-avatar",
+      avatarFilePath: "C:\\Marinara\\avatars\\characters\\Created.png",
+      avatarFilename: "Created.png",
+      comment: null,
+    };
+    const expected = {
+      ...created,
+      avatarPath: "asset://localhost/C%3A%5CMarinara%5Cavatars%5Ccharacters%5CCreated.png",
+    };
+
+    queryClient.setQueryData(characterKeys.list(), []);
+    queryClient.setQueryData(characterKeys.summaries(), []);
+
+    expect(cacheCharacterListRecordFromResult(queryClient, { character: created })).toBe(true);
+
+    expect(queryClient.getQueryData(characterKeys.list())).toEqual([expected]);
+    expect(queryClient.getQueryData(characterKeys.summaries())).toEqual([expected]);
+    expect(queryClient.getQueryData(characterKeys.detail(created.id))).toEqual(expected);
+    expect(queryClient.getQueryData(characterKeys.summaryDetail(created.id))).toEqual(expected);
   });
 
   it("removes deleted characters from list and summary caches", () => {

--- a/src/features/catalog/characters/hooks/use-characters.ts
+++ b/src/features/catalog/characters/hooks/use-characters.ts
@@ -17,6 +17,7 @@ import { storageCommandsApi } from "../../../../shared/api/storage-commands-api"
 import { galleryApi, spriteApi } from "../../../../shared/api/image-generation-api";
 import type { CharacterCardVersion } from "../../../../engine/contracts/types/character";
 import type { SpriteCapabilities, SpriteCleanupEngine } from "../../../../shared/types/sprite-capabilities";
+import { characterAvatarUrl, type CharacterAvatarSource } from "../lib/character-avatar-url";
 
 export { characterKeys, spriteKeys } from "../query-keys";
 
@@ -39,7 +40,16 @@ export type CharacterSummary = {
   updatedAt?: string;
 };
 
-const CHARACTER_LIST_FIELDS = ["id", "data", "comment", "avatarFilePath", "avatarFilename", "createdAt", "updatedAt"];
+const CHARACTER_LIST_FIELDS = [
+  "id",
+  "data",
+  "comment",
+  "avatarPath",
+  "avatarFilePath",
+  "avatarFilename",
+  "createdAt",
+  "updatedAt",
+];
 
 const CHARACTER_SUMMARY_OPTIONS = {
   fields: CHARACTER_LIST_FIELDS,
@@ -61,16 +71,39 @@ function isPresent<T>(value: T | null | undefined): value is NonNullable<T> {
   return value != null;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function normalizeCharacterAvatarFields<T>(character: T): T {
+  if (!isRecord(character)) return character;
+  const avatarPath = characterAvatarUrl(character as CharacterAvatarSource);
+  const hasAvatarPath = Object.prototype.hasOwnProperty.call(character, "avatarPath");
+  const currentAvatarPath = character.avatarPath as string | null | undefined;
+  if (hasAvatarPath && currentAvatarPath === avatarPath) return character;
+  return { ...character, avatarPath } as T;
+}
+
 function normalizeSearchQuery(search: string | null | undefined): string {
   return search?.trim() ?? "";
 }
 
-function listCharacterSummaries(search?: string): Promise<CharacterSummary[]> {
+async function listCharacters(): Promise<unknown[]> {
+  const characters = await storageApi.list<unknown>("characters", CHARACTER_LIST_OPTIONS);
+  return characters.map(normalizeCharacterAvatarFields);
+}
+
+async function listCharacterSummaries(search?: string): Promise<CharacterSummary[]> {
   const query = normalizeSearchQuery(search);
-  return storageApi.list<CharacterSummary>("characters", {
+  const characters = await storageApi.list<CharacterSummary>("characters", {
     ...CHARACTER_SUMMARY_OPTIONS,
     ...(query ? { search: query } : {}),
   });
+  return characters.map(normalizeCharacterAvatarFields);
+}
+
+async function getCharacter(id: string): Promise<unknown> {
+  return normalizeCharacterAvatarFields(await storageApi.get<unknown>("characters", id));
 }
 
 async function listCharacterSummariesByIds(ids: string[]): Promise<CharacterSummary[]> {
@@ -83,7 +116,9 @@ async function listCharacterSummariesByIds(ids: string[]): Promise<CharacterSumm
         const index = nextIndex;
         nextIndex += 1;
         try {
-          results[index] = await storageApi.get<CharacterSummary>("characters", ids[index]!, CHARACTER_SUMMARY_OPTIONS);
+          results[index] = normalizeCharacterAvatarFields(
+            await storageApi.get<CharacterSummary>("characters", ids[index]!, CHARACTER_SUMMARY_OPTIONS),
+          );
         } catch (error) {
           if (error instanceof ApiError && error.status === 404) {
             results[index] = null;
@@ -143,7 +178,7 @@ export function cacheCharacterListRecordFromResult(
   result: unknown,
 ): boolean {
   if (!result || typeof result !== "object" || Array.isArray(result)) return false;
-  const record = (result as { character?: unknown }).character;
+  const record = normalizeCharacterAvatarFields((result as { character?: unknown }).character);
   if (!isCharacterListRecord(record)) return false;
 
   const updatedList = upsertCharacterCollectionRecord(queryClient, characterKeys.list(), record);
@@ -199,7 +234,7 @@ function invalidateCharacterRecordQueries(
 export function useCharacters(enabled = true) {
   return useQuery({
     queryKey: characterKeys.list(),
-    queryFn: () => storageApi.list<unknown>("characters", CHARACTER_LIST_OPTIONS),
+    queryFn: listCharacters,
     enabled,
     staleTime: 5 * 60_000,
     refetchOnWindowFocus: false,
@@ -220,7 +255,7 @@ export function useCharacterSummaries(enabled = true, search?: string) {
 export function useCharacter(id: string | null) {
   return useQuery({
     queryKey: characterKeys.detail(id ?? ""),
-    queryFn: () => storageApi.get("characters", id!),
+    queryFn: () => getCharacter(id!),
     enabled: !!id,
     staleTime: 5 * 60_000,
     refetchOnWindowFocus: false,
@@ -232,7 +267,7 @@ export function useCharactersByIds(ids: string[], enabled = true) {
   const queries = useQueries({
     queries: uniqueIds.map((id) => ({
       queryKey: characterKeys.detail(id),
-      queryFn: () => storageApi.get("characters", id),
+      queryFn: () => getCharacter(id),
       enabled: enabled && !!id,
       staleTime: 5 * 60_000,
       refetchOnWindowFocus: false,

--- a/src/features/catalog/personas/hooks/use-personas.test.tsx
+++ b/src/features/catalog/personas/hooks/use-personas.test.tsx
@@ -232,6 +232,27 @@ describe("persona hooks", () => {
     expect(convertFileSrcMock).toHaveBeenCalledWith("C:\\Marinara\\avatars\\personas\\Current.png");
   });
 
+  it("normalizes missing avatar paths to null from full persona reads", async () => {
+    storageListMock.mockResolvedValue([
+      {
+        id: "persona-1",
+        name: "No Avatar Persona",
+      },
+    ]);
+
+    const getPersonas = await renderHook(usePersonas);
+
+    await vi.waitFor(() =>
+      expect(getPersonas().data).toEqual([
+        {
+          id: "persona-1",
+          name: "No Avatar Persona",
+          avatarPath: null,
+        },
+      ]),
+    );
+  });
+
   it("normalizes managed avatar paths from persona detail reads", async () => {
     storageGetMock.mockResolvedValue({
       id: "persona-1",

--- a/src/features/catalog/personas/hooks/use-personas.ts
+++ b/src/features/catalog/personas/hooks/use-personas.ts
@@ -58,7 +58,9 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 function normalizePersonaAvatarFields<T>(persona: T): T {
   if (!isRecord(persona)) return persona;
   const avatarPath = personaAvatarUrl(persona as PersonaAvatarSource);
-  if (avatarPath === ((persona.avatarPath as string | null | undefined) ?? null)) return persona;
+  const hasAvatarPath = Object.prototype.hasOwnProperty.call(persona, "avatarPath");
+  const currentAvatarPath = persona.avatarPath as string | null | undefined;
+  if (hasAvatarPath && currentAvatarPath === avatarPath) return persona;
   return { ...persona, avatarPath } as T;
 }
 


### PR DESCRIPTION
## Summary

- Normalize character avatar records through the catalog/characters hook layer.
- Request `avatarPath` in character list projections so legacy inline-only avatars are still available to panels, while managed avatars continue to prefer `avatarFilePath`/`avatarFilename`.
- Keep character and persona normalized rows consistent by writing `avatarPath: null` when no avatar fields are present.
- Allow managed local avatar/media asset URLs to be converted through `load_url_binary` in both desktop Tauri and remote-runtime dispatch paths, while restricting local binary reads to managed media roots and reading through a no-follow file handle.
- Cover summary, list, detail, by-id, cache-write, legacy list-avatar, remote-runtime avatar URL, null-avatar normalization, dispatcher parity, and local asset binary failure paths with targeted tests.

## Root Cause

The persona fix normalized avatar data at the persona hook boundary, but character hooks could still return either a missing `avatarPath` for projected managed-avatar rows or the raw embedded avatar payload from detail/by-id reads. Panels that directly used `character.avatarPath` could still render the unsafe payload or miss the managed URL.

The first character-list patch also omitted `avatarPath` from the list projection. That kept managed avatars small, but it meant legacy inline-only character rows had no display avatar in list consumers. The list projection now requests `avatarPath`; the existing storage projection keeps legacy `avatarPath` while omitting redundant managed embedded payloads when managed avatar file fields are present.

After character avatar paths were normalized, workflows that convert the current avatar URL into a data URL, such as avatar generation references and import-as-persona paths, could receive managed local asset URLs. The existing binary loader only supported remote HTTP(S) URLs, and the remote runtime dispatcher still bypassed the new local loader, so those local managed assets still failed until `load_url_binary` shared one implementation across desktop and remote dispatch.

## Validation

- `cargo test --manifest-path src-tauri/Cargo.toml local_asset_binary --lib`
- `cargo test --manifest-path src-tauri/Cargo.toml dispatch_load_url_binary --lib`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `pnpm test -- src/features/catalog/characters/hooks/use-characters.test.ts src/features/catalog/personas/hooks/use-personas.test.tsx`
- `pnpm test -- src/features/catalog/characters/hooks/use-characters.test.ts src/features/catalog/personas/hooks/use-personas.test.tsx src/shared/lib/url-blob.test.ts src/shared/api/url-binary-api.test.ts`
- `pnpm typecheck`
- `pnpm check:architecture`
- `pnpm build`

## Notes

- No changelog entry: no changelog, changeset, or release-notes file was found in the repo.
- Native Tauri panel click-through with real profile data is still useful manual QA.