### PR TITLE
Remove unused runtime visuals exports

### DIFF
--- a/src/features/runtime/visuals/components/SpriteOverlay.tsx
+++ b/src/features/runtime/visuals/components/SpriteOverlay.tsx
@@ -49,7 +49,7 @@ interface CharacterExpressionState {
 }
 
 /** Simple keyword-based expression detection from message text. */
-export function detectExpression(text: string): string {
+function detectExpression(text: string): string {
   const lower = text.toLowerCase();
   const patterns: [string, RegExp][] = [
     ["angry", /\b(anger|angry|furious|rage|yells?|shouts?|snarls?|growls?|seeth)/i],

--- a/src/features/runtime/visuals/sprite-display-modes.ts
+++ b/src/features/runtime/visuals/sprite-display-modes.ts
@@ -1,4 +1,4 @@
-export const SPRITE_DISPLAY_MODES = ["expressions", "full-body"] as const;
+const SPRITE_DISPLAY_MODES = ["expressions", "full-body"] as const;
 
 export type SpriteDisplayMode = (typeof SPRITE_DISPLAY_MODES)[number];
 


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

N/A

## Why this change

- Continue the Knip unused-export cleanup from a fresh `upstream/refactor` baseline after PR #1614 merged.
- Remove only public export markers that Knip still reports as unused in the runtime visuals owner lane.

## What changed

- Made `detectExpression` local to `SpriteOverlay.tsx`.
- Made `SPRITE_DISPLAY_MODES` local to `sprite-display-modes.ts` while keeping the exported `SpriteDisplayMode` type derived from it.

## Refactor impact

Primary owner:

- Runtime visuals (`src/features/runtime/visuals`).

Impact areas reviewed:

- Fresh Knip report before the slice showed `73` unused exports and `60` unused exported types.
- Fresh Knip report after the slice showed `71` unused exports and `60` unused exported types.
- Confirmed `detectExpression` and `SPRITE_DISPLAY_MODES` disappeared from the Knip unused-export report.
- `rg` confirmed both symbols are only used locally in their owner files.

Boundary notes:

- Feature-lane-only cleanup.
- No engine, shared API, Rust, storage, schema, dependency, or prompt-pipeline behavior changed.
- Runtime behavior is intended to be unchanged; this removes unnecessary public exports only.

Pressure points touched:

- None.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Codex ran `pnpm exec knip --exports --no-config-hints --reporter compact --no-exit-code`; the targeted rows for `detectExpression` and `SPRITE_DISPLAY_MODES` are gone.
- Codex ran `pnpm typecheck`; it passed.
- Codex ran `git diff --check`; it passed.
- `pnpm build` was not run because this slice only removes public export markers and did not affect build/import behavior.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A; no visible UI behavior changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored internal sprite handling by making previously exported APIs private module implementations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1659?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->