### PR TITLE
Remove unused roleplay exports

### DIFF
--- a/src/features/modes/roleplay/components/RoleplayHUDWidgetShell.tsx
+++ b/src/features/modes/roleplay/components/RoleplayHUDWidgetShell.tsx
@@ -32,7 +32,7 @@ export function TrackerPanelToggleButton({ onToggle }: { onToggle: () => void })
 
 type WidgetPopoverPlacement = "bottom" | "right" | "left";
 
-export function getWidgetPopoverPlacement(layout: HudPosition): WidgetPopoverPlacement {
+function getWidgetPopoverPlacement(layout: HudPosition): WidgetPopoverPlacement {
   return layout === "left" ? "right" : layout === "right" ? "left" : "bottom";
 }
 

--- a/src/features/modes/roleplay/hooks/use-agent-injection-review.ts
+++ b/src/features/modes/roleplay/hooks/use-agent-injection-review.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import { useChatStore } from "../../../../shared/stores/chat.store";
 import { useGenerate } from "../../../runtime/generation/index";
 
-export type AgentInjectionReviewItem = {
+type AgentInjectionReviewItem = {
   agentType: string;
   agentName: string;
   text: string;


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

<!-- Every user-facing PR should reference a feature request or issue report when practical. -->

N/A - Knip cleanup slice from the fresh `refactor` unused exports report.

## Why this change

<!-- What user problem, bug, refactor goal, or maintenance need does this solve? -->

- Removes two roleplay public exports that Knip reports as unused while keeping the implementation local to each module.

## What changed

<!-- List the key changes in this PR. -->

- Made `getWidgetPopoverPlacement` private inside `RoleplayHUDWidgetShell.tsx`.
- Made `AgentInjectionReviewItem` private inside `use-agent-injection-review.ts`.

## Refactor impact

Primary owner:

<!-- Examples: app shell, catalog, chat mode, roleplay mode, game mode, runtime generation, world-state, shared API, engine generation, Rust storage, imports, remote runtime. -->

Roleplay mode.

Impact areas reviewed:

- Roleplay HUD widget popover placement.
- Roleplay agent injection review hook typing.

Boundary notes:

<!-- Note engine/shared-api/feature/Rust/remote-runtime boundaries. Say "none" only if you checked. -->

- Feature-only cleanup under `src/features/modes/roleplay`.
- No engine, shared API, Rust, storage, schema, dependency, or remote-runtime boundaries touched.

Pressure points touched:

<!-- Mention ModeSurface, GameSurface, shared mode UI, src-tauri/src/lib.rs command registration, or import modules if touched. -->

- None.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app/runtime, step by step. If an AI agent filled this out, verify it yourself before ticking boxes. -->

- Codex ran `pnpm exec knip --exports --no-config-hints --reporter compact --no-exit-code`.
  - Before: `Unused exports (71)`, `Unused exported types (60)`.
  - After: `Unused exports (70)`, `Unused exported types (59)`.
  - Removed rows: `getWidgetPopoverPlacement` and `AgentInjectionReviewItem`.
- Codex ran `pnpm typecheck`.
- Codex ran `git diff --check`.
- Codex ran Bunny pre-PR review on the current diff.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs or release-note changes expected for this internal export visibility cleanup.

## UI evidence

<!-- Add before/after screenshots or recordings for visible UI changes. -->

N/A - no visible UI behavior changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code structure improvements with no impact to user-facing functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1660?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->