### PR TITLE
[codex] Use shared Professor Mari contracts

### DIFF
--- a/src/features/shell/mari/components/ProfessorMariSurface.tsx
+++ b/src/features/shell/mari/components/ProfessorMariSurface.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Check, ChevronUp, CircleUser, FileText, Link, Plus, Send, X } from "lucide-react";
-import { runProfessorMariEntry, type MariMessage } from "../../../../engine/mari/mari-entry";
+import { runProfessorMariEntry, type MariAttachment, type MariMessage } from "../../../../engine/mari/mari-entry";
 import {
   compactProfessorMariHistory,
   EMPTY_MARI_COMPACTION,
+  PROFESSOR_MARI_CHAT_ID,
   isMariResetCommand,
   mariContextMessages,
   type MariCompactionState,
@@ -32,13 +33,7 @@ const MARI_INPUT_PLACEHOLDER = "Message @Professor Mari, /reset to reset the con
 const MARI_ATTACHMENT_CLIENT_TEXT_BYTES = 64 * 1024;
 const MARI_IMAGE_ATTACHMENT_EXTENSIONS = new Set(["avif", "gif", "jpeg", "jpg", "png", "webp"]);
 
-type MariAttachment = {
-  id: string;
-  name: string;
-  type: string;
-  size: number;
-  content: string;
-};
+type ClientMariAttachment = MariAttachment & { id: string };
 
 type MariConnection = {
   id: string;
@@ -90,7 +85,7 @@ function getDayKey(value: string) {
 function toConversationMessage(message: MariMessage): Message {
   return {
     id: message.id,
-    chatId: "professor-mari",
+    chatId: PROFESSOR_MARI_CHAT_ID,
     role: message.role,
     characterId: message.role === "assistant" ? MARI_CHARACTER_ID : null,
     content: message.content,
@@ -116,7 +111,7 @@ export function ProfessorMariSurface() {
   const [historyLoaded, setHistoryLoaded] = useState(false);
   const [compaction, setCompaction] = useState<MariCompactionState>(EMPTY_MARI_COMPACTION);
   const [draft, setDraft] = useState("");
-  const [attachments, setAttachments] = useState<MariAttachment[]>([]);
+  const [attachments, setAttachments] = useState<ClientMariAttachment[]>([]);
   const [selectedConnectionId, setSelectedConnectionId] = useState<string | null>(null);
   const [preferencesLoaded, setPreferencesLoaded] = useState(false);
   const [selectedPersonaId, setSelectedPersonaId] = useState<string | null>(null);
@@ -300,7 +295,7 @@ export function ProfessorMariSurface() {
     const nextAttachments = await Promise.all(
       Array.from(files).map(
         (file) =>
-          new Promise<MariAttachment>((resolve, reject) => {
+          new Promise<ClientMariAttachment>((resolve, reject) => {
             const finish = (content: string) =>
               resolve({
                 id: newId("mari-file"),


### PR DESCRIPTION
## Linked issue

No linked issue; this is an internal Knip unused-export cleanup slice from local triage.

## Why this change

- Professor Mari's shell surface duplicated the engine-owned chat id and attachment contract shape, leaving the UI vulnerable to drift from `src/engine/mari`.

## What changed

- Import `PROFESSOR_MARI_CHAT_ID` from the engine Mari history contract for shell transcript message mapping.
- Import the shared `MariAttachment` request contract from the engine Mari entrypoint.
- Keep a shell-only `ClientMariAttachment` refinement so input-tray attachments still require a stable id for React keys and remove-by-id behavior.

## Refactor impact

Primary owner:

- `features/shell/mari`

Impact areas reviewed:

- Professor Mari shell surface
- `engine/mari` request/history contracts
- Shared chat message mapping used by the shell surface

Boundary notes:

- Feature UI now consumes the existing engine Mari contracts directly.
- No shared API, Rust, storage command, provider transport, or remote runtime behavior changed.

Pressure points touched:

- None. This does not touch ModeSurface, GameSurface, shared mode UI internals, Tauri command registration, or import modules.

## Validation

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Ran `git diff --check origin/refactor...HEAD`; no whitespace errors.
- Ran `pnpm typecheck`; passed.
- Ran `pnpm check:architecture`; passed with no dependency violations and Rust structure check passed.
- Did not run Tauri/manual UI verification because this is a type/import cleanup with no intended runtime UI behavior change.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs or release-note update was made because this is internal contract-drift cleanup and the repo has no `CHANGELOG.md`.

## UI evidence

No screenshots or recordings. There is no intended visible UI change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved attachment handling consistency in chat functionality to ensure proper ID retention and display.
  * Enhanced chat history reliability by using standardized chat identifiers across the application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1661?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->