### PR TITLE
Remove unused game mechanics exports

### DIFF
--- a/src/engine/modes/game/mechanics/combat.service.ts
+++ b/src/engine/modes/game/mechanics/combat.service.ts
@@ -57,7 +57,7 @@ function applyNamedStatus(target: CombatantStats, effect: StatusEffect) {
   }
 }
 
-export interface InitiativeEntry {
+interface InitiativeEntry {
   id: string;
   name: string;
   roll: number;
@@ -65,7 +65,7 @@ export interface InitiativeEntry {
   total: number;
 }
 
-export interface AttackResult {
+interface AttackResult {
   attackerId: string;
   defenderId: string;
   attackRoll: number;
@@ -292,7 +292,7 @@ function chooseAutoSkill(
 // ── Functions ──
 
 /** Roll initiative for all combatants. Returns sorted order (highest first). */
-export function rollInitiative(combatants: CombatantStats[]): InitiativeEntry[] {
+function rollInitiative(combatants: CombatantStats[]): InitiativeEntry[] {
   const entries: InitiativeEntry[] = combatants.map((c) => {
     const speedMod = Math.floor(c.speed / 5);
     const roll = rollDice("1d20").total;
@@ -309,7 +309,7 @@ export function rollInitiative(combatants: CombatantStats[]): InitiativeEntry[] 
 }
 
 /** Calculate a single attack from attacker against defender. */
-export function resolveAttack(
+function resolveAttack(
   attacker: CombatantStats,
   defender: CombatantStats,
   difficulty: string = "normal",
@@ -415,7 +415,7 @@ export function resolveAttack(
 }
 
 /** Tick status effects: decrement turns, remove expired. Returns tick results. */
-export function tickStatusEffects(combatant: CombatantStats): {
+function tickStatusEffects(combatant: CombatantStats): {
   updated: CombatantStats;
   ticks: Array<{ effect: string; expired: boolean }>;
 } {

--- a/src/engine/modes/game/mechanics/dice.service.ts
+++ b/src/engine/modes/game/mechanics/dice.service.ts
@@ -1,14 +1,6 @@
 import type { DiceRollResult } from "../../../contracts/types/game";
 
-export const DICE_NOTATION_REGEX = /^(\d+)?d(\d+)([+-]\d+)?$/i;
-
-export function isDiceNotation(value: string): boolean {
-  const match = value.trim().match(DICE_NOTATION_REGEX);
-  if (!match) return false;
-  const count = parseInt(match[1] ?? "1", 10);
-  const sides = parseInt(match[2]!, 10);
-  return count >= 1 && sides >= 1;
-}
+const DICE_NOTATION_REGEX = /^(\d+)?d(\d+)([+-]\d+)?$/i;
 
 /**
  * Parse and roll dice using NdM notation (e.g. "2d6+3", "d20", "4d8-1").

--- a/src/engine/modes/game/mechanics/element-reactions.service.ts
+++ b/src/engine/modes/game/mechanics/element-reactions.service.ts
@@ -12,14 +12,14 @@ import type { StatusEffect } from "./status-effect.js";
 
 // ── Core types ──
 
-export interface ElementDefinition {
+interface ElementDefinition {
   id: string;
   name: string;
   emoji: string;
   color: string;
 }
 
-export interface ReactionRule {
+interface ReactionRule {
   /** Element already applied (aura) */
   trigger: string;
   /** Incoming element */

--- a/src/engine/modes/game/mechanics/encounter.service.ts
+++ b/src/engine/modes/game/mechanics/encounter.service.ts
@@ -8,7 +8,7 @@
 
 import { rollDice } from "./dice.service.js";
 
-export type EncounterType = "combat" | "social" | "trap" | "puzzle" | "merchant" | "event";
+type EncounterType = "combat" | "social" | "trap" | "puzzle" | "merchant" | "event";
 
 export interface EncounterRoll {
   triggered: boolean;
@@ -126,7 +126,7 @@ function pickEncounterType(): EncounterType {
 }
 
 /** Infer location danger from a location string. */
-export function inferLocationDanger(location: string): string {
+function inferLocationDanger(location: string): string {
   const lower = location.toLowerCase();
   if (/town|city|village|inn|tavern|market|home|palace|temple|church/.test(lower)) return "town";
   if (/road|path|trail|highway/.test(lower)) return "road";

--- a/src/engine/modes/game/mechanics/loot.service.ts
+++ b/src/engine/modes/game/mechanics/loot.service.ts
@@ -5,9 +5,9 @@
 // Difficulty and location affect rarity distribution.
 // ──────────────────────────────────────────────
 
-export type ItemRarity = "common" | "uncommon" | "rare" | "epic" | "legendary";
+type ItemRarity = "common" | "uncommon" | "rare" | "epic" | "legendary";
 
-export interface LootItem {
+interface LootItem {
   name: string;
   description: string;
   rarity: ItemRarity;
@@ -196,7 +196,7 @@ function pickRarity(difficulty: string): ItemRarity {
 }
 
 /** Generate a single loot drop based on difficulty. */
-export function generateLootDrop(difficulty: string = "normal"): LootDrop {
+function generateLootDrop(difficulty: string = "normal"): LootDrop {
   const targetRarity = pickRarity(difficulty);
 
   // Pick a random table

--- a/src/engine/modes/game/mechanics/morale.service.ts
+++ b/src/engine/modes/game/mechanics/morale.service.ts
@@ -8,12 +8,6 @@
 
 export type MoraleTier = "inspired" | "high" | "steady" | "low" | "broken";
 
-export interface MoraleState {
-  /** Morale value: 0-100 */
-  value: number;
-  tier: MoraleTier;
-}
-
 /** Event types that affect morale. */
 export type MoraleEvent =
   | "combat_victory"
@@ -83,33 +77,4 @@ export function applyMoraleEvent(
   const tier = getMoraleTier(newValue);
 
   return { value: newValue, tier, change: modifier, previousTier };
-}
-
-/** Get dice roll bonus/penalty from current morale tier. */
-export function moraleDiceModifier(tier: MoraleTier): number {
-  switch (tier) {
-    case "inspired":
-      return 2;
-    case "high":
-      return 1;
-    case "steady":
-      return 0;
-    case "low":
-      return -1;
-    case "broken":
-      return -2;
-  }
-}
-
-/** Format morale for GM context injection. */
-export function formatMoraleContext(state: MoraleState): string {
-  const tierDescriptions: Record<MoraleTier, string> = {
-    inspired: "The party is fired up and brimming with confidence. They believe they can overcome anything.",
-    high: "Spirits are high. The party moves with purpose and optimism.",
-    steady: "The party's morale is stable — neither particularly motivated nor discouraged.",
-    low: "Morale is flagging. Doubt and fatigue are setting in. The party is short-tempered.",
-    broken: "The party is demoralized. Fear and despair hang heavy. Arguments may break out.",
-  };
-
-  return `<party_morale>\nMorale: ${state.tier} (${state.value}/100)\n${tierDescriptions[state.tier]}\n</party_morale>`;
 }

--- a/src/engine/modes/game/mechanics/perception.service.ts
+++ b/src/engine/modes/game/mechanics/perception.service.ts
@@ -93,7 +93,7 @@ const SOCIAL_HINTS: Array<{ dc: number; text: (npcName: string) => string }> = [
 /**
  * Compute passive perception: 10 + perception modifier + wisdom modifier.
  */
-export function passivePerception(perceptionMod: number, wisdomScore: number): number {
+function passivePerception(perceptionMod: number, wisdomScore: number): number {
   const wisMod = Math.floor((wisdomScore - 10) / 2);
   return 10 + perceptionMod + wisMod;
 }

--- a/src/engine/modes/game/mechanics/reputation.service.ts
+++ b/src/engine/modes/game/mechanics/reputation.service.ts
@@ -36,7 +36,7 @@ const ACTION_MODIFIERS: Record<string, number> = {
 export type ReputationTier = "devoted" | "allied" | "friendly" | "neutral" | "unfriendly" | "hostile" | "enemy";
 
 /** Map reputation number to a named tier. */
-export function getReputationTier(reputation: number): ReputationTier {
+function getReputationTier(reputation: number): ReputationTier {
   if (reputation >= 80) return "devoted";
   if (reputation >= 50) return "allied";
   if (reputation >= 20) return "friendly";
@@ -106,7 +106,7 @@ function detectMilestone(npcName: string, oldReputation: number, newReputation: 
 }
 
 /** Apply a reputation change to an NPC. Returns the updated NPC. */
-export function applyReputationChange(
+function applyReputationChange(
   npc: GameNpc,
   action: string,
   customModifier?: number,
@@ -178,16 +178,4 @@ export function processReputationActions(
     changes,
     milestones,
   };
-}
-
-/** Get a summary of NPC relationships for prompt injection. */
-export function buildNpcRelationshipSummary(npcs: GameNpc[]): string {
-  if (npcs.length === 0) return "";
-
-  const lines = npcs.map((n) => {
-    const tier = getReputationTier(n.reputation);
-    return `- ${n.emoji} ${n.name}: ${tier} (${n.reputation}/100)${n.met ? "" : " [not yet met]"}`;
-  });
-
-  return lines.join("\n");
 }

--- a/src/engine/modes/game/mechanics/skill-check.service.ts
+++ b/src/engine/modes/game/mechanics/skill-check.service.ts
@@ -46,13 +46,6 @@ function d20(): number {
 }
 
 /**
- * Compute a D&D-style attribute modifier: floor((score - 10) / 2).
- */
-export function attributeModifier(score: number): number {
-  return Math.floor((score - 10) / 2);
-}
-
-/**
  * Map common skills to their governing attribute.
  * Falls back to "int" for unlisted skills.
  */


### PR DESCRIPTION
## Linked issue

N/A - mechanical Knip cleanup batch.

## Why this change

- Continues the `refactor` branch Knip cleanup by removing unnecessary public exports from game mechanics modules.
- Fresh source-of-truth command before editing: `pnpm exec knip --exports --no-config-hints --reporter compact --no-exit-code`.
- Fresh counts changed from `Unused exports (70)` / `Unused exported types (55)` to `Unused exports (62)` / `Unused exported types (50)`.

## What changed

- Removed public export visibility from game mechanics helpers/types that are only used inside their defining modules.
- Removed declarations that became true unused locals once their public export was removed:
  - `isDiceNotation`
  - `moraleDiceModifier`
  - `formatMoraleContext`
  - `buildNpcRelationshipSummary`
  - `attributeModifier`

## Refactor impact

Primary owner:

engine game mode mechanics

Impact areas reviewed:

- `src/engine/modes/game/mechanics`
- Fresh Knip output
- TypeScript project references
- Production Vite build/import graph

Boundary notes:

- No React, feature UI, shared API, Rust, storage, schema, prompt-pipeline, or contract files changed.
- This is a public export-surface cleanup only; runtime imports and remaining exported entrypoints are unchanged.

Pressure points touched:

- Game mechanics services only.
- No `GameSurface`, `ModeSurface`, command registration, or import modules touched.

## Validation

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Codex ran `pnpm exec knip --exports --no-config-hints --reporter compact --no-exit-code` after the cleanup and confirmed the selected mechanics rows no longer appear.
- Codex ran `pnpm typecheck` successfully.
- Codex ran `git diff --check` successfully.
- Codex ran `pnpm build` successfully.
- No browser/Tauri manual verification was run because this is a non-UI mechanical export cleanup.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs or release-note updates are needed for this mechanical export cleanup.

## UI evidence

N/A - no UI changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This release contains internal code refactoring with **no user-facing changes**. All game mechanics, features, and functionality remain unchanged and work as before.

* **Refactor**
  * Internal API reorganization for improved code structure and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1663?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->