### PR TITLE
Remove unused shared gameplay helper exports

### DIFF
--- a/src/engine/shared/game-state/game-state-text.ts
+++ b/src/engine/shared/game-state/game-state-text.ts
@@ -17,11 +17,11 @@ const GAME_STATE_TEXT_OBJECT_KEYS = [
   "type",
 ] as const;
 
-export const GAME_STATE_TEXT_FIELDS = ["date", "time", "location", "weather", "temperature"] as const;
+const GAME_STATE_TEXT_FIELDS = ["date", "time", "location", "weather", "temperature"] as const;
 
 export type GameStateTextField = (typeof GAME_STATE_TEXT_FIELDS)[number];
 
-export function coerceGameStateTextValue(value: unknown): string | null {
+function coerceGameStateTextValue(value: unknown): string | null {
   return coerceGameStateTextValueInner(value, new WeakSet<object>());
 }
 

--- a/src/engine/shared/game-state/player-stats.ts
+++ b/src/engine/shared/game-state/player-stats.ts
@@ -15,10 +15,10 @@ import {
   readString,
 } from "../../generation/runtime-records";
 
-export type QuestObjective = QuestProgress["objectives"][number];
-export type QuestUpdateAction = "create" | "update" | "complete" | "fail";
+type QuestObjective = QuestProgress["objectives"][number];
+type QuestUpdateAction = "create" | "update" | "complete" | "fail";
 
-export interface NormalizedQuestUpdate {
+interface NormalizedQuestUpdate {
   action: QuestUpdateAction;
   questName: string;
   objectives?: QuestObjective[];
@@ -35,7 +35,7 @@ const RPG_ATTRIBUTE_KEYS: RpgAttributeKey[] = ["str", "dex", "con", "int", "wis"
  */
 const NESTED_QUEST_KEYS = ["quests", "activeQuests", "groups", "items", "children"] as const;
 
-export function parseQuestObjective(value: unknown): { text: string; completed: boolean } | null {
+function parseQuestObjective(value: unknown): { text: string; completed: boolean } | null {
   if (typeof value === "string") {
     const text = value.trim();
     return text ? { text, completed: false } : null;
@@ -52,7 +52,7 @@ export function parseQuestObjective(value: unknown): { text: string; completed: 
   };
 }
 
-export function firstString(...values: unknown[]): string | undefined {
+function firstString(...values: unknown[]): string | undefined {
   for (const value of values) {
     const text = readString(value).trim();
     if (text) return text;
@@ -72,7 +72,7 @@ function looksLikeQuestRecord(record: Record<string, unknown>): boolean {
   );
 }
 
-export function parseQuest(value: unknown, fallbackName?: string): QuestProgress | null {
+function parseQuest(value: unknown, fallbackName?: string): QuestProgress | null {
   const record = parseRecord(value);
   let name = readString(record.name).trim() || readString(record.questName).trim();
   if (!name && looksLikeQuestRecord(record)) {
@@ -202,7 +202,7 @@ export function clonePlayerStats(value: unknown): PlayerStats {
   };
 }
 
-export function normalizeQuestAction(value: unknown): QuestUpdateAction | null {
+function normalizeQuestAction(value: unknown): QuestUpdateAction | null {
   const normalized = readString(value).trim().toLowerCase();
   if (normalized === "completed") return "complete";
   if (normalized === "failed") return "fail";
@@ -211,7 +211,7 @@ export function normalizeQuestAction(value: unknown): QuestUpdateAction | null {
     : null;
 }
 
-export function collectQuestObjectives(value: unknown, depth = 0): QuestObjective[] {
+function collectQuestObjectives(value: unknown, depth = 0): QuestObjective[] {
   if (value == null || depth > 5) return [];
   if (Array.isArray(value)) return value.flatMap((entry) => collectQuestObjectives(entry, depth + 1));
   const direct = parseQuestObjective(value);
@@ -226,7 +226,7 @@ export function collectQuestObjectives(value: unknown, depth = 0): QuestObjectiv
   return Object.values(record).flatMap((entry) => collectQuestObjectives(entry, depth + 1));
 }
 
-export function normalizeQuestUpdate(value: unknown): NormalizedQuestUpdate | null {
+function normalizeQuestUpdate(value: unknown): NormalizedQuestUpdate | null {
   const record = parseRecord(value);
   const action = normalizeQuestAction(record.action);
   const questName = firstString(record.questName, record.name, record.title, record.questEntryId);
@@ -239,7 +239,7 @@ export function normalizeQuestUpdate(value: unknown): NormalizedQuestUpdate | nu
   };
 }
 
-export function cloneQuest(quest: QuestProgress): QuestProgress {
+function cloneQuest(quest: QuestProgress): QuestProgress {
   return {
     ...quest,
     objectives: quest.objectives.map((objective) => ({ ...objective })),

--- a/src/engine/shared/scoring/skill-check-format.ts
+++ b/src/engine/shared/scoring/skill-check-format.ts
@@ -1,6 +1,6 @@
 import type { SkillCheckResult } from "../../contracts/types/game.js";
 
-export function getSkillCheckOutcomeLabel(
+function getSkillCheckOutcomeLabel(
   result: Pick<SkillCheckResult, "success" | "criticalSuccess" | "criticalFailure">,
 ): string {
   if (result.criticalSuccess) return "Critical success";
@@ -8,7 +8,7 @@ export function getSkillCheckOutcomeLabel(
   return result.success ? "Success" : "Failure";
 }
 
-export function getSkillCheckOutcomeKey(
+function getSkillCheckOutcomeKey(
   result: Pick<SkillCheckResult, "success" | "criticalSuccess" | "criticalFailure">,
 ): string {
   if (result.criticalSuccess) return "critical_success";


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

N/A - mechanical Knip cleanup on `refactor`.

## Why this change

Remove unnecessary public exports from `src/engine/shared` gameplay helper modules so the fresh Knip unused-export report continues shrinking without changing runtime behavior.

## What changed

- Made unused `game-state-text` helper exports file-local.
- Made unused `player-stats` quest parsing/update helper exports and internal types file-local.
- Made unused `skill-check-format` outcome helper exports file-local.

## Refactor impact

Primary owner:

engine shared

Impact areas reviewed:

- `src/engine/shared/game-state/game-state-text.ts`
- `src/engine/shared/game-state/player-stats.ts`
- `src/engine/shared/scoring/skill-check-format.ts`

Boundary notes:

- Export visibility only; no runtime logic changed.
- No `src/engine/contracts/**`, storage, schema, migration, installer, prompt-pipeline, or cross-boundary files touched.
- `rg` found no outside imports for the removed public symbols.

Pressure points touched:

- None.

## Validation

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Fresh source-of-truth report before edits: `pnpm exec knip --exports --no-config-hints --reporter compact --no-exit-code` reported `Unused exports (64)`, `Unused exported types (51)`, and `Duplicate exports (1)`.
- After edits: the same Knip command reported `Unused exports (61)`, `Unused exported types (50)`, and `Duplicate exports (1)`.
- Disappeared Knip rows:
  - `src/engine/shared/game-state/game-state-text.ts`: `GAME_STATE_TEXT_FIELDS`, `coerceGameStateTextValue`
  - `src/engine/shared/game-state/player-stats.ts`: `parseQuestObjective`, `firstString`, `parseQuest`, `normalizeQuestAction`, `collectQuestObjectives`, `normalizeQuestUpdate`, `cloneQuest`
  - `src/engine/shared/game-state/player-stats.ts` exported types: `QuestObjective`, `QuestUpdateAction`, `NormalizedQuestUpdate`
  - `src/engine/shared/scoring/skill-check-format.ts`: `getSkillCheckOutcomeLabel`, `getSkillCheckOutcomeKey`
- `pnpm typecheck` passed locally.
- `git diff --check` passed locally.
- Bunny review passed before opening this PR.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A - no UI changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization by consolidating quest-related helpers and skill check formatting utilities within their modules, reducing the public API surface while maintaining all user-facing functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1664?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->