### PR TITLE
Remove unused catalog exports

### DIFF
--- a/src/features/catalog/chats/lib/timeline-message.ts
+++ b/src/features/catalog/chats/lib/timeline-message.ts
@@ -1,7 +1,7 @@
 import type { StorageListOptions } from "../../../../engine/capabilities/storage";
 import type { Message } from "../../../../engine/contracts/types/chat";
 
-export const CHAT_MESSAGE_TIMELINE_FIELDS = [
+const CHAT_MESSAGE_TIMELINE_FIELDS = [
   "id",
   "chatId",
   "role",
@@ -17,7 +17,7 @@ export const CHAT_MESSAGE_TIMELINE_FIELDS = [
   "createdAt",
 ];
 
-export const CHAT_MESSAGE_TIMELINE_EXTRA_FIELDS = [
+const CHAT_MESSAGE_TIMELINE_EXTRA_FIELDS = [
   "displayText",
   "isGenerated",
   "tokenCount",

--- a/src/features/catalog/personas/lib/persona-editor-model.ts
+++ b/src/features/catalog/personas/lib/persona-editor-model.ts
@@ -7,14 +7,14 @@ export interface AltDescriptionEntry {
   active: boolean;
 }
 
-export interface PersonaStatBar {
+interface PersonaStatBar {
   name: string;
   value: number;
   max: number;
   color: string;
 }
 
-export interface PersonaRPGAttribute {
+interface PersonaRPGAttribute {
   name: string;
   value: number;
 }

--- a/src/features/catalog/personas/lib/persona-sprites-model.ts
+++ b/src/features/catalog/personas/lib/persona-sprites-model.ts
@@ -1,6 +1,6 @@
 export type PersonaSpriteCategory = "expressions" | "full-body";
 
-export const DEFAULT_PERSONA_SPRITE_EXPRESSIONS = [
+const DEFAULT_PERSONA_SPRITE_EXPRESSIONS = [
   "neutral",
   "happy",
   "sad",

--- a/src/features/catalog/personas/lib/personas-panel-model.ts
+++ b/src/features/catalog/personas/lib/personas-panel-model.ts
@@ -25,7 +25,7 @@ export function isPersonaActive(persona: PersonaPanelRow): boolean {
   return persona.isActive === true || persona.isActive === "true";
 }
 
-export function estimatePersonaTokens(persona: PersonaPanelRow): number {
+function estimatePersonaTokens(persona: PersonaPanelRow): number {
   const text = [persona.description, persona.personality, persona.scenario, persona.backstory, persona.appearance].join(
     "",
   );


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

No linked issue. Follow-up Knip cleanup requested after #1664.

## Why this change

- Removes unnecessary public export visibility from catalog helpers reported by a fresh Knip exports run.

## What changed

- Made chat timeline projection field lists file-local.
- Made persona editor stat helper interfaces file-local.
- Made persona sprite default expression list file-local.
- Made persona token-estimation helper file-local.

## Refactor impact

Primary owner:

Catalog feature helpers.

Impact areas reviewed:

- `src/features/catalog/chats/lib/timeline-message.ts`
- `src/features/catalog/personas/lib/persona-editor-model.ts`
- `src/features/catalog/personas/lib/persona-sprites-model.ts`
- `src/features/catalog/personas/lib/personas-panel-model.ts`

Boundary notes:

- Export visibility only; no engine, shared API, Rust, remote runtime, schema, storage, prompt pipeline, auth, provider transport, or migration behavior changed.
- Character catalog was not touched.

Pressure points touched:

- None.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Fresh baseline before edit: `pnpm exec knip --exports --no-config-hints --reporter compact --no-exit-code` reported 61 unused exports, 50 unused exported types, and 1 duplicate export.
- After edit: the same Knip command reported 58 unused exports, 49 unused exported types, and 1 duplicate export.
- Disappeared Knip rows:
  - `src/features/catalog/chats/lib/timeline-message.ts: CHAT_MESSAGE_TIMELINE_FIELDS, CHAT_MESSAGE_TIMELINE_EXTRA_FIELDS`
  - `src/features/catalog/personas/lib/persona-sprites-model.ts: DEFAULT_PERSONA_SPRITE_EXPRESSIONS`
  - `src/features/catalog/personas/lib/personas-panel-model.ts: estimatePersonaTokens`
  - `src/features/catalog/personas/lib/persona-editor-model.ts: PersonaStatBar, PersonaRPGAttribute`
- `pnpm typecheck` passed locally.
- `git diff --check` passed locally.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs or release-note changes needed for export visibility cleanup.

## UI evidence

N/A. This PR only changes TypeScript export visibility and has no visible UI behavior change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restricted access to internal constants and type interfaces across multiple modules by converting them from exported to non-exported. Changes improve code encapsulation and reduce public API surface area.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1665?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->