### PR TITLE
Harden pnpm install policy

### DIFF
--- a/.puppeteerrc.cjs
+++ b/.puppeteerrc.cjs
@@ -1,0 +1,5 @@
+// Impeccable depends on Puppeteer, but Marinara uses explicit Playwright/LHCI
+// browser install steps. Keep Puppeteer's install hook from downloading Chrome.
+module.exports = {
+  skipDownload: true,
+};

--- a/package.json
+++ b/package.json
@@ -87,14 +87,6 @@
     "vite": "^7.3.2",
     "vitest": "^4.1.7"
   },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild"
-    ],
-    "ignoredBuiltDependencies": [
-      "unrs-resolver"
-    ]
-  },
   "size-limit": [
     {
       "path": "dist/assets/*.js",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,14 +1,11 @@
 # Install-time supply-chain guardrails. The root package is included by pnpm
 # when no workspace package globs are specified.
 minimumReleaseAge: 1440
-minimumReleaseAgeIgnoreMissingTime: false
 trustPolicy: no-downgrade
 blockExoticSubdeps: true
 strictDepBuilds: true
 
-onlyBuiltDependencies:
-  - esbuild
-  - puppeteer@24.43.1
-
-ignoredBuiltDependencies:
-  - unrs-resolver
+allowBuilds:
+  esbuild: true
+  puppeteer@24.43.1: true
+  unrs-resolver: false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,14 @@
+# Install-time supply-chain guardrails. The root package is included by pnpm
+# when no workspace package globs are specified.
+minimumReleaseAge: 1440
+minimumReleaseAgeIgnoreMissingTime: false
+trustPolicy: no-downgrade
+blockExoticSubdeps: true
+strictDepBuilds: true
+
+onlyBuiltDependencies:
+  - esbuild
+  - puppeteer@24.43.1
+
+ignoredBuiltDependencies:
+  - unrs-resolver


### PR DESCRIPTION
## Linked issue

N/A - Discord follow-up / focused supply-chain hardening pass.

## Why this change

- Add focused install-time supply-chain guardrails to the refactor branch without changing dependency versions, CI workflow shape, Rust policy, or runtime behavior.
- Keep dependency lifecycle scripts explicit so new install-time scripts block until reviewed.

## What changed

- Added root `pnpm-workspace.yaml` as the canonical pnpm policy file.
- Moved the existing pnpm build-script policy out of `package.json`.
- Enabled `minimumReleaseAge`, missing publish-time blocking, `trustPolicy: no-downgrade`, `blockExoticSubdeps`, and `strictDepBuilds`.
- Added a root Puppeteer config so the allowlisted Puppeteer postinstall runs without downloading browsers.

## Refactor impact

Primary owner:

Tooling / dependency installation policy

Impact areas reviewed:

- pnpm install policy
- Existing package lock behavior
- CI install entrypoints that already use `pnpm install --frozen-lockfile`
- Impeccable/Puppeteer install-script behavior

Boundary notes:

- No app, feature, engine, shared API, Rust, Tauri command, storage, remote runtime, or prompt-assembly behavior changed.
- No dependencies were added, removed, or upgraded.
- `pnpm-lock.yaml` was unchanged.

Pressure points touched:

- None. No ModeSurface, GameSurface, shared mode UI, command registration, or import modules touched.

## Validation

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

Codex verification from a clean worktree based on `upstream/refactor`:

- `pnpm install --frozen-lockfile` passed with no lockfile changes.
- `pnpm ignored-builds` reported `None`.
- `pnpm --dir scratch\pnpm-strict-negative install` failed as expected with `ERR_PNPM_IGNORED_BUILDS` for an unapproved local postinstall script.
- `pnpm --dir scratch\pnpm-strict-positive install` passed when the same local package was explicitly allowlisted.
- `pnpm rebuild puppeteer` ran Puppeteer's postinstall and reported: `Skipping downloading browsers as instructed.`
- `pnpm check:line-endings` passed.
- `pnpm check:architecture` passed.
- `pnpm typecheck` passed.
- `pnpm check:docs` passed.
- `pnpm lint` passed with 0 errors and 4 existing warnings.
- `git diff --check` passed.
- `pnpm check` passed.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs or release files were changed. This PR only changes install-time package-manager policy.

## UI evidence

N/A - no visible UI changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined build configuration to optimize dependency handling and reduce unnecessary downloads.
  * Added security guardrails for supply-chain integrity across project dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1672?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->