### PR TITLE
Fix Prompt Reviewer JSON handling

### DIFF
--- a/src/engine/generation/prompt-reviewer.test.ts
+++ b/src/engine/generation/prompt-reviewer.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest";
+import type { LlmGateway, LlmRequest } from "../capabilities/llm";
+import type { StorageGateway } from "../capabilities/storage";
+import { reviewPromptPreset, type PromptReviewEvent } from "./prompt-reviewer";
+
+function storageGateway(preset: Record<string, unknown> | null = { id: "preset-1", name: "Test Preset" }) {
+  return {
+    get: vi.fn(async (entity: string, id: string) => (entity === "prompts" && id === "preset-1" ? preset : null)),
+    promptFull: vi.fn(async () => ({
+      preset,
+      groups: [],
+      choiceBlocks: [],
+      sections: [
+        {
+          id: "section-1",
+          name: "System",
+          role: "system",
+          enabled: true,
+          content: "Stay in character.",
+        },
+      ],
+    })),
+    list: vi.fn(async () => []),
+  } as Partial<StorageGateway> as StorageGateway;
+}
+
+function llmGateway(response: string, requests: LlmRequest[] = []): LlmGateway {
+  return {
+    complete: vi.fn(async (request: LlmRequest) => {
+      requests.push(request);
+      return response;
+    }),
+    async *stream() {},
+    listModels: vi.fn(async () => []),
+  };
+}
+
+async function collectReviewEvents(storage: StorageGateway, llm: LlmGateway): Promise<PromptReviewEvent[]> {
+  const events: PromptReviewEvent[] = [];
+  for await (const event of reviewPromptPreset({ storage, llm }, { presetId: "preset-1", connectionId: "conn-1" })) {
+    events.push(event);
+  }
+  return events;
+}
+
+describe("reviewPromptPreset", () => {
+  it("requests JSON mode and emits normalized JSON for valid prompt reviews", async () => {
+    const review = {
+      overall_score: 8,
+      summary: "Clear and focused.",
+      sections: [{ area: "clarity", score: 8, findings: "Direct.", suggestions: ["Keep it concise."] }],
+      token_estimate: 1200,
+      warnings: [],
+      best_practices: ["Uses clear roles."],
+    };
+    const requests: LlmRequest[] = [];
+
+    const events = await collectReviewEvents(storageGateway(), llmGateway(JSON.stringify(review), requests));
+
+    const normalized = JSON.stringify(review, null, 2);
+    expect(events).toEqual([
+      { type: "token", data: normalized },
+      { type: "done", data: normalized },
+    ]);
+    expect(requests).toHaveLength(1);
+    expect(requests[0]).toMatchObject({
+      connectionId: "conn-1",
+      parameters: {
+        temperature: 0.7,
+        maxTokens: 8192,
+        responseFormat: "json_object",
+      },
+    });
+    expect(requests[0]?.messages.map((message) => message.content).join("\n")).toContain("Stay in character.");
+  });
+
+  it("emits a clear error event when the reviewer returns malformed JSON", async () => {
+    const events = await collectReviewEvents(storageGateway(), llmGateway("{ invalid json"));
+
+    expect(events).toEqual([
+      {
+        type: "error",
+        data: "Prompt Reviewer returned malformed JSON. Try again or use a model/provider with JSON mode support.",
+      },
+    ]);
+    expect(events.some((event) => event.type === "done")).toBe(false);
+  });
+
+  it("throws when the preset is missing", async () => {
+    await expect(collectReviewEvents(storageGateway(null), llmGateway("{}"))).rejects.toThrow(
+      "Prompt preset not found.",
+    );
+  });
+});

--- a/src/engine/generation/prompt-reviewer.test.ts
+++ b/src/engine/generation/prompt-reviewer.test.ts
@@ -86,6 +86,18 @@ describe("reviewPromptPreset", () => {
     expect(events.some((event) => event.type === "done")).toBe(false);
   });
 
+  it("emits a clear error event when the reviewer returns non-object JSON", async () => {
+    const events = await collectReviewEvents(storageGateway(), llmGateway("null"));
+
+    expect(events).toEqual([
+      {
+        type: "error",
+        data: "Prompt Reviewer returned malformed JSON. Try again or use a model/provider with JSON mode support.",
+      },
+    ]);
+    expect(events.some((event) => event.type === "done")).toBe(false);
+  });
+
   it("throws when the preset is missing", async () => {
     await expect(collectReviewEvents(storageGateway(null), llmGateway("{}"))).rejects.toThrow(
       "Prompt preset not found.",

--- a/src/engine/generation/prompt-reviewer.ts
+++ b/src/engine/generation/prompt-reviewer.ts
@@ -42,6 +42,16 @@ Review areas:
 Be specific and actionable. Reference exact sections when possible.`;
 
 type JsonRecord = Record<string, unknown>;
+const MALFORMED_REVIEW_JSON_MESSAGE =
+  "Prompt Reviewer returned malformed JSON. Try again or use a model/provider with JSON mode support.";
+
+function normalizePromptReviewJson(raw: string): string | null {
+  try {
+    return JSON.stringify(JSON.parse(raw), null, 2);
+  } catch {
+    return null;
+  }
+}
 
 export async function* reviewPromptPreset(
   capabilities: { storage: StorageGateway; llm: LlmGateway },
@@ -73,12 +83,18 @@ export async function* reviewPromptPreset(
         { role: "system", content: PROMPT_REVIEWER_SYSTEM_PROMPT },
         { role: "user", content: userPrompt },
       ],
-      parameters: { temperature: 0.7, maxTokens: 8192 },
+      // JSON mode reduces malformed output, but the client still validates the result.
+      parameters: { temperature: 0.7, maxTokens: 8192, responseFormat: "json_object" },
     },
     signal,
   );
-  yield { type: "token", data: raw };
-  yield { type: "done", data: raw };
+  const normalized = normalizePromptReviewJson(raw);
+  if (!normalized) {
+    yield { type: "error", data: MALFORMED_REVIEW_JSON_MESSAGE };
+    return;
+  }
+  yield { type: "token", data: normalized };
+  yield { type: "done", data: normalized };
 }
 
 async function assemblePromptReviewView(storage: StorageGateway, presetId: string): Promise<string> {

--- a/src/engine/generation/prompt-reviewer.ts
+++ b/src/engine/generation/prompt-reviewer.ts
@@ -47,7 +47,9 @@ const MALFORMED_REVIEW_JSON_MESSAGE =
 
 function normalizePromptReviewJson(raw: string): string | null {
   try {
-    return JSON.stringify(JSON.parse(raw), null, 2);
+    const parsed = JSON.parse(raw);
+    if (!isRecord(parsed)) return null;
+    return JSON.stringify(parsed, null, 2);
   } catch {
     return null;
   }


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #1561

## Why this change

- Prompt Reviewer output is consumed as JSON, but the engine was only asking for JSON in prose and emitted the raw provider response as a successful review.
- GPT 5.5 can return malformed JSON for that path, leaving the preset editor with an invalid review payload instead of a clear contract failure.

## What changed

- `reviewPromptPreset` now sends `parameters.responseFormat = "json_object"` through the existing LLM gateway request.
- Prompt Reviewer responses are parsed before success; valid compact JSON objects are emitted as normalized pretty JSON, and malformed or degenerate JSON emits a clear `error` event without a `done` event.
- Added focused unit coverage for JSON-mode request shape, valid JSON normalization, malformed-response failure, non-object JSON failure, and missing preset behavior.

## Refactor impact

Primary owner:

- engine generation

Impact areas reviewed:

- Preset editor AI Review event contract
- Existing LLM request parameter plumbing for `responseFormat`
- Prompt Reviewer missing-preset behavior

Boundary notes:

- Product behavior stays in `src/engine`; no React, shared API, Rust transport, storage, schema, dependency, or UI layout changes.
- `PromptReviewEvent` shape is unchanged, and the existing ReviewTab error path remains the consumer surface.
- This intentionally uses existing JSON-mode plumbing rather than adding `json_schema` structured outputs.

Pressure points touched:

- None.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Codex ran `pnpm test src/engine/generation/prompt-reviewer.test.ts`: passed, 1 file and 4 tests.
- Codex ran `pnpm typecheck`: passed.
- Codex ran `pnpm check`: passed, including line endings, architecture, frontend/typecheck, Rust check, and docs.
- Codex ran Bunny on the current diff before opening this PR: pass.
- Codex ran `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json`: passed.
- Manual limitation: live GPT 5.5 provider verification requires real provider credentials and was not run. The local proof covers the request shape and malformed-response handling.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A - engine-level contract fix with focused unit coverage; no UI layout change.
