### PR TITLE
Fix conversation group reply targeting

### DIFF
--- a/src/engine/generation/prompt-assembly.test.ts
+++ b/src/engine/generation/prompt-assembly.test.ts
@@ -1071,6 +1071,58 @@ describe("assembleGenerationPrompt strict roles", () => {
     ]);
   });
 
+  it("keeps all conversation cards visible while scoping history to the responding character", async () => {
+    const assembly = await assembleGenerationPrompt(
+      storageWithSectionsAndCharacters(
+        [
+          section({
+            id: "character",
+            name: "Characters",
+            role: "system",
+            markerConfig: { type: "character" },
+            sortOrder: 0,
+          }),
+          section({
+            id: "history",
+            name: "chat_history",
+            role: "user",
+            markerConfig: { type: "chat_history" },
+            sortOrder: 1,
+          }),
+        ],
+        [
+          { id: "char-a", name: "Aster", description: "ASTER CARD" },
+          { id: "char-b", name: "Briar", description: "BRIAR CARD" },
+        ],
+      ),
+      {
+        chat: {
+          id: "chat",
+          mode: "conversation",
+          characterIds: ["char-a", "char-b"],
+        },
+        storedMessages: [
+          { role: "assistant", characterId: "char-a", content: "Aster opened.", contextKind: "history" },
+          { role: "assistant", characterId: "char-b", content: "Briar replied.", contextKind: "history" },
+          { role: "user", content: "User follows up.", contextKind: "history" },
+        ],
+        connection: {},
+        request: { ...request, forCharacterId: "char-b" },
+        latestUserInput: "User follows up.",
+      },
+    );
+
+    const prompt = promptText(assembly);
+    expect(prompt).toContain("ASTER CARD");
+    expect(prompt).toContain("BRIAR CARD");
+    expect(prompt).toContain("Respond only as Briar");
+    expect(assembly.messages.filter((message) => message.contextKind === "history")).toMatchObject([
+      { role: "user", content: "Aster opened." },
+      { role: "assistant", content: "Briar replied." },
+      { role: "user", content: "User follows up." },
+    ]);
+  });
+
   it("excludes stored reasoning from history by default", async () => {
     const assembly = await assembleGenerationPrompt(storageWithSections([]), {
       chat: { id: "chat", mode: "roleplay", metadata: {} },

--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -1537,6 +1537,17 @@ function scopedIndividualGroupTarget(
   return characters.some((character) => character.id === requestedCharacterId) ? requestedCharacterId : null;
 }
 
+function scopedConversationGroupTarget(
+  input: PromptAssemblyInput,
+  characters: GenerationCharacterContext[],
+): string | null {
+  const chatMode = readString(input.chat.mode || input.chat.chatMode);
+  if (chatMode !== "conversation" || characters.length <= 1 || input.request.impersonate === true) return null;
+  const requestedCharacterId = readString(input.request.forCharacterId).trim();
+  if (!requestedCharacterId) return null;
+  return characters.some((character) => character.id === requestedCharacterId) ? requestedCharacterId : null;
+}
+
 function promptCharactersForGeneration(
   input: PromptAssemblyInput,
   characters: GenerationCharacterContext[],
@@ -1558,6 +1569,23 @@ function individualGroupTurnPromptMessage(
   return {
     role: "system",
     content: `Respond only as ${name}`,
+    contextKind: "prompt",
+    displayName: "Turn",
+  };
+}
+
+function conversationGroupTurnPromptMessage(
+  input: PromptAssemblyInput,
+  characters: GenerationCharacterContext[],
+): ChatMLMessage | null {
+  const targetId = scopedConversationGroupTarget(input, characters);
+  if (!targetId) return null;
+  if (parseRecord(input.chat.metadata).groupTurnPromptEnabled === false) return null;
+  const character = characters.find((candidate) => candidate.id === targetId);
+  const name = character?.name.trim() || "the requested character";
+  return {
+    role: "system",
+    content: `Respond only as ${name}. Use the other attached character cards and recent messages as context, but do not speak as another character in this turn.`,
     contextKind: "prompt",
     displayName: "Turn",
   };
@@ -2266,7 +2294,8 @@ export async function assembleGenerationPrompt(
   applyRegexScriptsToPromptMessages(messages, regexScripts, {
     resolveMacros: (value) => resolveMacros(value, macros, { trimResult: false }),
   });
-  const turnPrompt = individualGroupTurnPromptMessage(input, characters);
+  const turnPrompt =
+    individualGroupTurnPromptMessage(input, characters) ?? conversationGroupTurnPromptMessage(input, characters);
   if (turnPrompt) {
     messages.push(turnPrompt);
   }
@@ -2279,6 +2308,10 @@ export async function assembleGenerationPrompt(
   const individualGroupTarget = scopedIndividualGroupTarget(input, characters);
   if (individualGroupTarget) {
     messages = scopeIndividualGroupHistoryRoles(messages, individualGroupTarget);
+  }
+  const conversationGroupTarget = scopedConversationGroupTarget(input, characters);
+  if (conversationGroupTarget) {
+    messages = scopeIndividualGroupHistoryRoles(messages, conversationGroupTarget);
   }
   const previewMessages = previewMessagesForPrompt(messages);
   const shouldEnforceStrictRoles =

--- a/src/engine/generation/start-generation.test.ts
+++ b/src/engine/generation/start-generation.test.ts
@@ -2458,6 +2458,120 @@ describe("startGeneration group turn prompt toggle", () => {
     const assistantSave = createChatMessage.mock.calls.find(([, value]) => value.role === "assistant");
     expect(assistantSave?.[1]).toMatchObject({ characterId: "char-b" });
   });
+
+  it("targets an @mentioned conversation character and saves the reply under that character", async () => {
+    const { deps, createChatMessage, streamedRequests } = generationDepsForChat({
+      chatPatch: {
+        mode: "conversation",
+        promptPresetId: "preset",
+        characterIds: ["char-a", "char-b"],
+      },
+      chatMetadata: { groupResponseOrder: "sequential" },
+      characters: [
+        { id: "char-a", data: { name: "Aster", description: "ASTER CARD" } },
+        { id: "char-b", data: { name: "Briar", description: "BRIAR CARD" } },
+      ],
+      prompts: [{ id: "preset", wrapFormat: "xml" }],
+      promptSections: [
+        {
+          id: "character",
+          presetId: "preset",
+          name: "Characters",
+          role: "system",
+          markerConfig: { type: "character" },
+          enabled: true,
+          sortOrder: 0,
+        },
+        {
+          id: "history",
+          presetId: "preset",
+          name: "History",
+          role: "user",
+          markerConfig: { type: "chat_history" },
+          enabled: true,
+          sortOrder: 1,
+        },
+      ],
+    });
+
+    await drainGeneration(
+      startGeneration(deps, {
+        chatId: "chat-1",
+        userMessage: "@Briar, what do you think?",
+        mentionedCharacterNames: ["Briar"],
+        impersonateBlockAgents: true,
+      }),
+    );
+
+    const promptText = (streamedRequests[0] as { messages: Array<{ content: string }> }).messages
+      .map((message) => message.content)
+      .join("\n");
+    expect(promptText).toContain("ASTER CARD");
+    expect(promptText).toContain("BRIAR CARD");
+    expect(promptText).toContain("Respond only as Briar");
+    const assistantSave = createChatMessage.mock.calls.find(([, value]) => value.role === "assistant");
+    expect(assistantSave?.[1]).toMatchObject({ characterId: "char-b" });
+  });
+
+  it("continues conversation group replies sequentially after the previous speaker", async () => {
+    const { deps, createChatMessage, streamedRequests } = generationDepsForChat({
+      chatPatch: {
+        mode: "conversation",
+        promptPresetId: "preset",
+        characterIds: ["char-a", "char-b"],
+      },
+      chatMetadata: { groupResponseOrder: "sequential" },
+      characters: [
+        { id: "char-a", data: { name: "Aster", description: "ASTER CARD" } },
+        { id: "char-b", data: { name: "Briar", description: "BRIAR CARD" } },
+      ],
+      prompts: [{ id: "preset", wrapFormat: "xml" }],
+      promptSections: [
+        {
+          id: "character",
+          presetId: "preset",
+          name: "Characters",
+          role: "system",
+          markerConfig: { type: "character" },
+          enabled: true,
+          sortOrder: 0,
+        },
+        {
+          id: "history",
+          presetId: "preset",
+          name: "History",
+          role: "user",
+          markerConfig: { type: "chat_history" },
+          enabled: true,
+          sortOrder: 1,
+        },
+      ],
+      initialMessages: [
+        {
+          id: "assistant-a",
+          chatId: "chat-1",
+          role: "assistant",
+          characterId: "char-a",
+          content: "Aster answered last.",
+        },
+      ],
+    });
+
+    await drainGeneration(
+      startGeneration(deps, {
+        chatId: "chat-1",
+        userMessage: "Carry on.",
+        impersonateBlockAgents: true,
+      }),
+    );
+
+    const promptText = (streamedRequests[0] as { messages: Array<{ content: string }> }).messages
+      .map((message) => message.content)
+      .join("\n");
+    expect(promptText).toContain("Respond only as Briar");
+    const assistantSave = createChatMessage.mock.calls.find(([, value]) => value.role === "assistant");
+    expect(assistantSave?.[1]).toMatchObject({ characterId: "char-b" });
+  });
 });
 
 describe("retryGenerationAgents lorebook keeper backfill", () => {

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -926,6 +926,17 @@ function roleplayIndividualGroupCharacterIds(chat: JsonRecord): string[] {
   return readString(parseRecord(chat.metadata).groupChatMode, "merged") === "individual" ? ids : [];
 }
 
+function conversationGroupCharacterIds(chat: JsonRecord): string[] {
+  if (readString(chat.mode || chat.chatMode) !== "conversation") return [];
+  const ids = activeCharacterIds(chat);
+  return ids.length > 1 ? ids : [];
+}
+
+function targetedGroupCharacterIds(chat: JsonRecord): string[] {
+  const roleplayIds = roleplayIndividualGroupCharacterIds(chat);
+  return roleplayIds.length > 0 ? roleplayIds : conversationGroupCharacterIds(chat);
+}
+
 function lastVisibleAssistantCharacterId(messages: JsonRecord[], activeIds: string[]): string | null {
   const active = new Set(activeIds);
   for (let index = messages.length - 1; index >= 0; index -= 1) {
@@ -938,7 +949,7 @@ function lastVisibleAssistantCharacterId(messages: JsonRecord[], activeIds: stri
   return null;
 }
 
-function sequentialRoleplayGroupTarget(messages: JsonRecord[], activeIds: string[]): string | null {
+function sequentialGroupTarget(messages: JsonRecord[], activeIds: string[]): string | null {
   if (activeIds.length === 0) return null;
   const lastCharacterId = lastVisibleAssistantCharacterId(messages, activeIds);
   if (!lastCharacterId) return activeIds[0] ?? null;
@@ -946,7 +957,7 @@ function sequentialRoleplayGroupTarget(messages: JsonRecord[], activeIds: string
   return activeIds[(index + 1) % activeIds.length] ?? activeIds[0] ?? null;
 }
 
-function explicitRoleplayGroupTarget(
+function explicitGroupTarget(
   input: StartGenerationInput,
   storedMessages: JsonRecord[],
   activeIds: string[],
@@ -962,7 +973,7 @@ function explicitRoleplayGroupTarget(
   return active.has(targetCharacterId) ? targetCharacterId : null;
 }
 
-function continuationRoleplayGroupTarget(args: {
+function continuationGroupTarget(args: {
   input: StartGenerationInput;
   latestUserInput: string;
   storedMessages: JsonRecord[];
@@ -1081,11 +1092,13 @@ async function smartRoleplayGroupTarget(args: {
     mentionedNames: args.mentionedNames,
   });
   if (mentionedIds.length > 0) return mentionedIds[0] ?? null;
-  if (candidates.length === 0) return sequentialRoleplayGroupTarget(args.storedMessages, args.activeIds);
+  if (candidates.length === 0) return sequentialGroupTarget(args.storedMessages, args.activeIds);
 
   const personaId = readString(args.chat.personaId).trim();
   const persona = personaId ? await args.deps.storage.get<JsonRecord>("personas", personaId).catch(() => null) : null;
   const personaData = isRecord(persona) ? characterDataRecord(persona) : {};
+  const chatMode = readString(args.chat.mode || args.chat.chatMode, "conversation");
+  const chatKind = chatMode === "conversation" ? "conversation group chat" : "individual-mode roleplay group chat";
   const candidateLines = candidates
     .map((candidate) =>
       JSON.stringify({
@@ -1108,8 +1121,7 @@ async function smartRoleplayGroupTarget(args: {
         messages: [
           {
             role: "system",
-            content:
-              'You are a hidden response orchestrator for an individual-mode roleplay group chat. Choose which character should respond next based on the latest message, direct address, narrative momentum, and talkativeness. Usually choose exactly one character. Return only JSON: {"characterIds":["character-id"],"reason":"short"}.',
+            content: `You are a hidden response orchestrator for a ${chatKind}. Choose which character should respond next based on the latest message, direct address, conversation momentum, and talkativeness. Usually choose exactly one character. Return only JSON: {"characterIds":["character-id"],"reason":"short"}.`,
           },
           {
             role: "user",
@@ -1128,12 +1140,11 @@ async function smartRoleplayGroupTarget(args: {
     if (isRecord(error) && readString(error.name) === "AbortError") throw error;
   }
   return (
-    parseSmartGroupSelectionIds(raw, args.activeIds)[0] ??
-    sequentialRoleplayGroupTarget(args.storedMessages, args.activeIds)
+    parseSmartGroupSelectionIds(raw, args.activeIds)[0] ?? sequentialGroupTarget(args.storedMessages, args.activeIds)
   );
 }
 
-async function resolveRoleplayGroupTargetForGeneration(args: {
+async function resolveGroupTargetForGeneration(args: {
   deps: GenerationEngineDeps;
   input: StartGenerationInput;
   chat: JsonRecord;
@@ -1144,11 +1155,20 @@ async function resolveRoleplayGroupTargetForGeneration(args: {
   signal?: AbortSignal;
 }): Promise<string | null> {
   if (args.input.impersonate === true) return null;
-  const activeIds = roleplayIndividualGroupCharacterIds(args.chat);
+  const activeIds = targetedGroupCharacterIds(args.chat);
   if (activeIds.length === 0) return null;
-  const explicit = explicitRoleplayGroupTarget(args.input, args.storedMessages, activeIds);
+  const explicit = explicitGroupTarget(args.input, args.storedMessages, activeIds);
   if (explicit) return explicit;
-  const continuation = continuationRoleplayGroupTarget({
+
+  const candidates = await loadSmartResponderCandidates(args.deps.storage, activeIds);
+  const mentionedIds = mentionedSmartResponderIds({
+    candidates,
+    latestUserInput: args.latestUserInput,
+    mentionedNames: args.mentionedNames,
+  });
+  if (mentionedIds.length > 0) return mentionedIds[0] ?? null;
+
+  const continuation = continuationGroupTarget({
     input: args.input,
     latestUserInput: args.latestUserInput,
     storedMessages: args.storedMessages,
@@ -1161,7 +1181,7 @@ async function resolveRoleplayGroupTargetForGeneration(args: {
   if (order === "smart") {
     return smartRoleplayGroupTarget({ ...args, activeIds });
   }
-  return sequentialRoleplayGroupTarget(args.storedMessages, activeIds);
+  return sequentialGroupTarget(args.storedMessages, activeIds);
 }
 
 function isPassiveGenerationRequest(input: StartGenerationInput, prepared: PreparedUserInput): boolean {
@@ -2146,7 +2166,7 @@ export async function* startGeneration(
   );
   const chatForGeneration = generationTrackerBaseline ? { ...chat, gameState: generationTrackerBaseline } : chat;
   const latestUserInput = preparedUserInput.content || inputUserMessage(input);
-  const resolvedRoleplayGroupTarget = await resolveRoleplayGroupTargetForGeneration({
+  const resolvedGroupTarget = await resolveGroupTargetForGeneration({
     deps,
     input,
     chat: chatForGeneration,
@@ -2157,8 +2177,8 @@ export async function* startGeneration(
     signal,
   });
   throwIfAborted(signal);
-  if (resolvedRoleplayGroupTarget && readString(input.forCharacterId).trim() !== resolvedRoleplayGroupTarget) {
-    input = { ...input, forCharacterId: resolvedRoleplayGroupTarget };
+  if (resolvedGroupTarget && readString(input.forCharacterId).trim() !== resolvedGroupTarget) {
+    input = { ...input, forCharacterId: resolvedGroupTarget };
   }
   const directMessages = requestMessages(input);
   const agentEvents: AgentResult[] = [];

--- a/src/features/modes/conversation/hooks/autonomous/use-autonomous-messaging.ts
+++ b/src/features/modes/conversation/hooks/autonomous/use-autonomous-messaging.ts
@@ -83,6 +83,7 @@ export function useAutonomousMessaging(
         produced = await generate({
           chatId,
           connectionId: null,
+          forCharacterId: characterId,
         });
         if (produced) {
           recordAssistantActivityState(chatId, characterId);

--- a/src/features/modes/conversation/hooks/autonomous/use-background-autonomous.ts
+++ b/src/features/modes/conversation/hooks/autonomous/use-background-autonomous.ts
@@ -137,6 +137,7 @@ export function useBackgroundAutonomousPolling() {
                   {
                     chatId: chat.id,
                     connectionId: null,
+                    forCharacterId: characterId,
                     streaming: useUIStore.getState().enableStreaming,
                     hideAutomatedSummarySourceMessages:
                       useUIStore.getState().summaryPopoverSettings.hideSummarizedMessages,


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #1603

## Why this change

- Conversation chats with multiple characters could route replies as generic assistant turns instead of a concrete character turn. That made @mentions, sequential follow-up replies, and autonomous selected speakers behave inconsistently because prompt assembly did not hard-scope the responding character.

## What changed

- Extended group reply target resolution so conversation-mode chats with multiple active characters can resolve an explicit responding character from `forCharacterId`, @mentions, continuation, sequential order, or smart order.
- Added conversation turn prompt scoping that keeps all attached character cards visible while instructing the model to respond only as the selected character for the current turn.
- Passed the autonomous scheduler's selected character into foreground and background conversation generation.
- Added regression coverage for @mentioned conversation replies, sequential conversation follow-up replies, and prompt/history scoping.

## Refactor impact

Primary owner:

engine generation

Impact areas reviewed:

- Conversation-mode generation routing
- Prompt assembly for multi-character conversation chats
- Roleplay individual group regression coverage
- Foreground and background autonomous conversation generation callers

Boundary notes:

- Product behavior stays in `src/engine/generation`.
- Feature hooks only pass an existing selected `characterId` through the existing generation API.
- No raw Tauri, shared API, Rust storage, schema, dependency, or release metadata changes.

Pressure points touched:

- Runtime generation target selection
- Prompt assembly role/history shaping
- Conversation autonomous generation hooks

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Codex reproduction before fix: targeted Vitest regression rows failed because conversation prompts lacked a hard selected-character turn instruction and saved multi-character conversation replies did not get the expected `characterId`.
- Codex verification after fix: `pnpm exec vitest run src/engine/generation/prompt-assembly.test.ts src/engine/generation/start-generation.test.ts` passed with 121 tests, including the new issue #1603 regression rows.
- Codex baseline: `pnpm typecheck` passed.
- Codex baseline: `pnpm check` passed, including line endings, architecture, frontend typecheck, Rust cargo check, and docs.
- Codex proof gate: `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json` passed.
- Bunny review: passed for the current diff before opening this PR.
- Manual browser/app verification not performed because this is generation contract behavior covered by focused engine tests rather than a visible UI layout bug.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A. This is not a visible UI rendering change; the proof is the before/after generation contract regression suite and baseline checks above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed group conversation character selection to ensure targeted characters respond appropriately while preserving conversation context.
  * Improved autonomous messaging to correctly associate generated responses with their intended characters.

* **Improvements**
  * Unified character targeting logic across conversation and roleplay modes for consistent behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1675?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->