### PR TITLE
Fix game metadata save retry

### DIFF
--- a/src/features/modes/game/components/GameSurface.tsx
+++ b/src/features/modes/game/components/GameSurface.tsx
@@ -56,7 +56,6 @@ import { npcAvatarApi } from "../../../../shared/api/avatar-api";
 import { spriteApi } from "../../../../shared/api/image-generation-api";
 import { spotifyApi } from "../../../../shared/api/integration-utility-api";
 import { gameAssetFileUrlFromPath, userBackgroundUrl } from "../../../../shared/api/local-file-api";
-import { storageApi } from "../../../../shared/api/storage-api";
 import { showConfirmDialog } from "../../../../shared/lib/app-dialogs";
 import { formatTextQuotes } from "../../../../shared/lib/dialogue-quotes";
 import { cn, type AvatarCropValue } from "../../../../shared/lib/utils";
@@ -87,6 +86,10 @@ import { normalizeGameSegmentEdit, serializeGameSegmentEdit, type GameSegmentEdi
 import { useGameSceneAnalysis } from "../hooks/use-game-scene-analysis";
 import { usePartyTurn } from "../hooks/use-party-turn";
 import { parsePartyDialogue } from "../lib/party-dialogue-parser";
+import {
+  flushPendingGameMetadataPatches,
+  persistGameMetadataPatch,
+} from "../lib/game-metadata-persistence";
 import { dispatchSpotifySceneTrackChange } from "../../../../shared/lib/spotify-playback-events";
 import { ActiveWorldInfoButton, ActiveWorldInfoModal } from "../../../runtime/visuals/index";
 import type {
@@ -981,10 +984,6 @@ import type { Chat, Message } from "../../../../engine/contracts/types/chat";
 import type { SessionSummary, Combatant, GameCombatStateSnapshot } from "../../../../engine/contracts/types/game";
 import type { CharacterMap, PersonaInfo } from "../../shared/chat-ui/types";
 
-async function persistGameMetadata(chatId: string, patch: Record<string, unknown>) {
-  return storageApi.patchChatMetadata<Chat>(chatId, patch);
-}
-
 /** Typewriter component for the intro screen — reveals text character-by-character. */
 function IntroTypewriter({ text, onComplete }: { text: string; onComplete?: () => void }) {
   const [visible, setVisible] = useState(0);
@@ -1835,6 +1834,17 @@ export function GameSurface({
     },
     [queryClient],
   );
+  const persistMetadata = useCallback(
+    (chatId: string, patch: Record<string, unknown>) =>
+      persistGameMetadataPatch(chatId, patch, { onPersisted: publishSessionChat }),
+    [publishSessionChat],
+  );
+
+  useEffect(() => {
+    void flushPendingGameMetadataPatches(activeChatId, { onPersisted: publishSessionChat }).catch(() => {
+      /* failure is retained and reported by the persistence helper */
+    });
+  }, [activeChatId, publishSessionChat]);
 
   useEffect(() => {
     const loc = gameSnapshot?.location;
@@ -2338,7 +2348,7 @@ export function GameSurface({
 
       const inventoryPersist =
         updated !== previousInventory
-          ? persistGameMetadata(activeChatId, { gameInventory: updated }).catch(() => null)
+          ? persistMetadata(activeChatId, { gameInventory: updated }).catch(() => null)
           : Promise.resolve(null);
 
       if (updated !== previousInventory) {
@@ -2380,7 +2390,7 @@ export function GameSurface({
         notificationTimerRef.current = setTimeout(() => setInventoryNotifications([]), 4000);
       }
     },
-    [activeChatId, patchVisibleGameState, publishSessionChat],
+    [activeChatId, patchVisibleGameState, persistMetadata, publishSessionChat],
   );
 
   const playDirections = useCallback((directions: DirectionCommand[]) => {
@@ -2975,7 +2985,7 @@ export function GameSurface({
           recentSpotifyTrackHistoryRef.current,
           track.uri,
         );
-        persistGameMetadata(activeChatId, { gameRecentSpotifyTracks: recentSpotifyTrackHistoryRef.current }).catch(
+        persistMetadata(activeChatId, { gameRecentSpotifyTracks: recentSpotifyTrackHistoryRef.current }).catch(
           () => {},
         );
         await queryClient.invalidateQueries({ queryKey: ["spotify", "player"] });
@@ -2986,7 +2996,7 @@ export function GameSurface({
         setSpotifyRetryPending(false);
       }
     },
-    [activeChatId, queryClient, useSpotifyGameMusic],
+    [activeChatId, persistMetadata, queryClient, useSpotifyGameMusic],
   );
 
   const hasCombatResultAfterMessage = useCallback(
@@ -3182,7 +3192,7 @@ export function GameSurface({
           recentMusicHistoryRef.current = appendRecentMusic(recentMusicHistoryRef.current, state.currentMusic);
           patch.gameRecentMusic = recentMusicHistoryRef.current;
         }
-        persistGameMetadata(activeChatId, patch).catch(() => {});
+        persistMetadata(activeChatId, patch).catch(() => {});
       }, 1500);
     });
     return () => {
@@ -3191,7 +3201,7 @@ export function GameSurface({
       if (scenePersistTimer.current) {
         clearTimeout(scenePersistTimer.current);
         const { currentBackground, currentMusic, currentAmbient } = useGameAssetStore.getState();
-        persistGameMetadata(activeChatId, {
+        persistMetadata(activeChatId, {
           gameSceneBackground: currentBackground,
           gameSceneMusic: currentMusic,
           gameSceneAmbient: currentAmbient,
@@ -3199,7 +3209,7 @@ export function GameSurface({
         }).catch(() => {});
       }
     };
-  }, [activeChatId]);
+  }, [activeChatId, persistMetadata]);
 
   // ── Restore in-progress combat state from chat metadata on page load ──
   // Without this, refreshing during a fight drops the user back into prose narration even
@@ -3217,7 +3227,7 @@ export function GameSurface({
     if (!snapshot || !snapshot.party?.length || !snapshot.enemies?.length) return;
     if (chatMeta.gameActiveState !== "combat") {
       // Stale snapshot — combat ended but the metadata write didn't land. Clear it.
-      persistGameMetadata(activeChatId, { gameCombatState: null }).catch(() => {});
+      persistMetadata(activeChatId, { gameCombatState: null }).catch(() => {});
       return;
     }
     // Runtime validation: the snapshot is JSON-deserialized from chat metadata that
@@ -3232,7 +3242,7 @@ export function GameSurface({
         "[game-surface] Discarding combat snapshot — failed Combatant schema validation. " +
           "Likely written by an older client version.",
       );
-      persistGameMetadata(activeChatId, { gameCombatState: null }).catch(() => {});
+      persistMetadata(activeChatId, { gameCombatState: null }).catch(() => {});
       return;
     }
     setCombatParty(rawParty);
@@ -3242,7 +3252,7 @@ export function GameSurface({
     setCombatDialogueCues(Array.isArray(snapshot.dialogueCues) ? snapshot.dialogueCues : []);
     if (snapshot.startMessageId) setCombatStartMessageId(snapshot.startMessageId);
     useGameModeStore.getState().setGameState("combat");
-  }, [activeChatId, chatMeta.gameCombatState, chatMeta.gameActiveState, isMessagesLoading]);
+  }, [activeChatId, chatMeta.gameCombatState, chatMeta.gameActiveState, isMessagesLoading, persistMetadata]);
 
   // ── Persist live combat snapshot to chat metadata (debounced) ──
   // Mirrors the scene-asset persistence above but only fires while combat is active.
@@ -3256,15 +3266,18 @@ export function GameSurface({
   // Shared helper used by combat-end + return-to-pre-combat-turn so both paths reliably
   // wipe the persisted snapshot, even if the exploration-state PATCH is still in flight
   // when the user refreshes.
-  const clearCombatSnapshot = useCallback((chatId: string | null) => {
-    if (!chatId) return;
-    if (combatPersistTimer.current) {
-      clearTimeout(combatPersistTimer.current);
-      combatPersistTimer.current = null;
-    }
-    combatPendingSnapshotRef.current = null;
-    persistGameMetadata(chatId, { gameCombatState: null }).catch(() => {});
-  }, []);
+  const clearCombatSnapshot = useCallback(
+    (chatId: string | null) => {
+      if (!chatId) return;
+      if (combatPersistTimer.current) {
+        clearTimeout(combatPersistTimer.current);
+        combatPersistTimer.current = null;
+      }
+      combatPendingSnapshotRef.current = null;
+      persistMetadata(chatId, { gameCombatState: null }).catch(() => {});
+    },
+    [persistMetadata],
+  );
   useEffect(() => {
     if (combatRestoredChatIdRef.current !== activeChatId) return;
     if (!combatParty || !combatEnemies || gameState !== "combat") return;
@@ -3283,7 +3296,7 @@ export function GameSurface({
       // keepalive flush below or the lifecycle wipes in `clearCombatSnapshot`. A
       // silent failure here means the user keeps fighting believing state is saved,
       // then loses progress on refresh — the operator needs to see this in console.
-      persistGameMetadata(activeChatId, { gameCombatState: snapshot }).catch((err: unknown) =>
+      persistMetadata(activeChatId, { gameCombatState: snapshot }).catch((err: unknown) =>
         console.error("[game-surface] combat snapshot persist failed", err),
       );
       combatPendingSnapshotRef.current = null;
@@ -3301,7 +3314,7 @@ export function GameSurface({
       // which is exactly the scenario this feature is meant to protect.
       const pending = combatPendingSnapshotRef.current;
       if (pending) {
-        persistGameMetadata(pending.chatId, { gameCombatState: pending.snapshot }).catch(() => {});
+        persistMetadata(pending.chatId, { gameCombatState: pending.snapshot }).catch(() => {});
         combatPendingSnapshotRef.current = null;
       }
     };
@@ -3314,6 +3327,7 @@ export function GameSurface({
     combatDialogueCues,
     combatStartMessageId,
     gameState,
+    persistMetadata,
   ]);
 
   // ── Self-heal stale "user" persona name in restored combat state ──
@@ -3361,13 +3375,13 @@ export function GameSurface({
       }
       if (segmentPersistTimer.current) clearTimeout(segmentPersistTimer.current);
       segmentPersistTimer.current = setTimeout(() => {
-        persistGameMetadata(activeChatId, {
+        persistMetadata(activeChatId, {
           gameNarrationIndex: index,
           gameNarrationMessageId: narrationProgressMessageId,
         }).catch(() => {});
       }, 500);
     },
-    [activeChatId, narrationProgressMessageId, segmentStorageKey],
+    [activeChatId, narrationProgressMessageId, persistMetadata, segmentStorageKey],
   );
   useEffect(() => {
     return () => {
@@ -3377,7 +3391,7 @@ export function GameSurface({
         try {
           const saved = parseStoredNarrationProgress(localStorage.getItem(segmentStorageKey));
           if (saved) {
-            persistGameMetadata(activeChatId, {
+            persistMetadata(activeChatId, {
               gameNarrationIndex: saved.index,
               gameNarrationMessageId: saved.messageId,
             }).catch(() => {});
@@ -3387,7 +3401,7 @@ export function GameSurface({
         }
       }
     };
-  }, [activeChatId, segmentStorageKey]);
+  }, [activeChatId, persistMetadata, segmentStorageKey]);
 
   // Read the saved narration index for restore — prefer localStorage (fast, survives
   // browser restarts) for instant restore, fall back to server metadata.
@@ -3521,7 +3535,7 @@ export function GameSurface({
     } catch {
       /* ignore */
     }
-    persistGameMetadata(activeChatId, { gameNarrationIndex: 0, gameNarrationMessageId: msg.id }).catch(() => {});
+    persistMetadata(activeChatId, { gameNarrationIndex: 0, gameNarrationMessageId: msg.id }).catch(() => {});
 
     const tags = parseGmTags(msg.content);
     const mapUpdateCommands = parseMapUpdateCommands(msg.content);
@@ -5424,7 +5438,7 @@ export function GameSurface({
         next.set(`${messageId}:${segmentIndex}`, payload);
         return next;
       });
-      persistGameMetadata(activeChatId, { [key]: payload }).catch(() => {});
+      persistMetadata(activeChatId, { [key]: payload }).catch(() => {});
 
       if (payload.readableContent) {
         upsertReadableJournalEntry({
@@ -5435,7 +5449,7 @@ export function GameSurface({
         });
       }
     },
-    [activeChatId, upsertReadableJournalEntry],
+    [activeChatId, persistMetadata, upsertReadableJournalEntry],
   );
 
   const handleDeleteSegment = useCallback(
@@ -5447,9 +5461,9 @@ export function GameSurface({
         next.add(`${messageId}:${segmentIndex}`);
         return next;
       });
-      persistGameMetadata(activeChatId, { [key]: true }).catch(() => {});
+      persistMetadata(activeChatId, { [key]: true }).catch(() => {});
     },
-    [activeChatId],
+    [activeChatId, persistMetadata],
   );
 
   const handleEditMessage = useCallback(

--- a/src/features/modes/game/lib/game-metadata-persistence.test.ts
+++ b/src/features/modes/game/lib/game-metadata-persistence.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Chat } from "../../../../engine/contracts/types/chat";
+import { storageApi } from "../../../../shared/api/storage-api";
+import {
+  flushPendingGameMetadataPatches,
+  getPendingGameMetadataPatch,
+  persistGameMetadataPatch,
+  resetGameMetadataPersistenceForTest,
+} from "./game-metadata-persistence";
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("../../../../shared/api/storage-api", () => ({
+  storageApi: {
+    patchChatMetadata: vi.fn(),
+  },
+}));
+
+const patchChatMetadataMock = vi.mocked(storageApi.patchChatMetadata);
+
+function chat(metadata: Record<string, unknown> = {}): Chat {
+  return {
+    id: "chat-1",
+    name: "Game",
+    mode: "game",
+    characterIds: [],
+    metadata,
+  } as unknown as Chat;
+}
+
+beforeEach(async () => {
+  vi.useFakeTimers();
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+  await resetGameMetadataPersistenceForTest();
+  patchChatMetadataMock.mockReset();
+});
+
+afterEach(async () => {
+  await resetGameMetadataPersistenceForTest();
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe("game metadata persistence", () => {
+  it("retains a failed patch and retries the same payload on the next flush", async () => {
+    patchChatMetadataMock.mockRejectedValueOnce(new Error("storage offline")).mockResolvedValueOnce(chat());
+
+    await expect(persistGameMetadataPatch("chat-1", { gameSceneBackground: "forest" })).rejects.toThrow(
+      "Failed to persist 1 game metadata patch.",
+    );
+
+    expect(getPendingGameMetadataPatch("chat-1")).toEqual({ gameSceneBackground: "forest" });
+
+    await flushPendingGameMetadataPatches("chat-1");
+
+    expect(patchChatMetadataMock).toHaveBeenCalledTimes(2);
+    expect(patchChatMetadataMock).toHaveBeenNthCalledWith(2, "chat-1", { gameSceneBackground: "forest" });
+    expect(getPendingGameMetadataPatch("chat-1")).toBeNull();
+  });
+
+  it("coalesces multiple pending patches for the same chat without dropping keys", async () => {
+    patchChatMetadataMock.mockRejectedValueOnce(new Error("storage offline")).mockResolvedValueOnce(chat());
+
+    await expect(persistGameMetadataPatch("chat-1", { gameSceneBackground: "forest" })).rejects.toThrow();
+    await persistGameMetadataPatch("chat-1", { gameSceneMusic: "theme" });
+
+    expect(patchChatMetadataMock).toHaveBeenLastCalledWith("chat-1", {
+      gameSceneBackground: "forest",
+      gameSceneMusic: "theme",
+    });
+    expect(getPendingGameMetadataPatch("chat-1")).toBeNull();
+  });
+
+  it("clears durable pending state after a successful retry", async () => {
+    patchChatMetadataMock.mockRejectedValueOnce(new Error("storage offline")).mockResolvedValueOnce(chat());
+
+    await expect(persistGameMetadataPatch("chat-1", { gameNarrationIndex: 2 })).rejects.toThrow();
+    expect(window.localStorage.getItem("marinara:pending-game-metadata-patches:v1")).not.toBeNull();
+
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(patchChatMetadataMock).toHaveBeenCalledTimes(2);
+    expect(window.localStorage.getItem("marinara:pending-game-metadata-patches:v1")).toBeNull();
+  });
+
+  it("ignores invalid stored retry payloads safely", async () => {
+    window.localStorage.setItem(
+      "marinara:pending-game-metadata-patches:v1",
+      JSON.stringify([["chat-1", { chatId: "chat-1", patch: "not-an-object", revision: 1 }]]),
+    );
+
+    await flushPendingGameMetadataPatches("chat-1");
+
+    expect(patchChatMetadataMock).not.toHaveBeenCalled();
+    expect(getPendingGameMetadataPatch("chat-1")).toBeNull();
+  });
+});

--- a/src/features/modes/game/lib/game-metadata-persistence.ts
+++ b/src/features/modes/game/lib/game-metadata-persistence.ts
@@ -1,0 +1,277 @@
+import { toast } from "sonner";
+import type { Chat } from "../../../../engine/contracts/types/chat";
+import { storageApi } from "../../../../shared/api/storage-api";
+
+type GameMetadataPatch = Record<string, unknown>;
+type QueuedGameMetadataPatch = {
+  chatId: string;
+  patch: GameMetadataPatch;
+  revision: number;
+};
+type PersistOptions = {
+  onPersisted?: (chat: Chat) => void;
+  onPersistedOnce?: boolean;
+};
+type PersistedChatHandler = {
+  handler: (chat: Chat) => void;
+  once: boolean;
+};
+
+const PATCH_QUEUE_STORAGE_KEY = "marinara:pending-game-metadata-patches:v1";
+const RETRY_DELAY_MS = 5_000;
+
+const pendingPatches = new Map<string, QueuedGameMetadataPatch>();
+const durablePatches = new Map<string, QueuedGameMetadataPatch>();
+const inFlightPatches = new Map<string, Promise<Chat>>();
+const retryTimers = new Map<string, ReturnType<typeof setTimeout>>();
+const persistedChatHandlers = new Map<string, Map<(chat: Chat) => void, PersistedChatHandler>>();
+const lastFailureToastAt = new Map<string, number>();
+
+let restoredStoredPatches = false;
+let nextPatchRevision = 1;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function cloneQueuedPatch(queued: QueuedGameMetadataPatch): QueuedGameMetadataPatch {
+  return {
+    chatId: queued.chatId,
+    patch: { ...queued.patch },
+    revision: queued.revision,
+  };
+}
+
+function getNextPatchRevision() {
+  const revision = nextPatchRevision;
+  nextPatchRevision += 1;
+  return revision;
+}
+
+function validateStoredPatchEntry(value: unknown): [string, QueuedGameMetadataPatch] | null {
+  if (!Array.isArray(value) || value.length !== 2 || typeof value[0] !== "string" || !isRecord(value[1])) {
+    return null;
+  }
+
+  const queued = value[1];
+  if (typeof queued.chatId !== "string" || !isRecord(queued.patch)) return null;
+
+  return [
+    value[0],
+    {
+      chatId: queued.chatId,
+      patch: queued.patch,
+      revision: typeof queued.revision === "number" ? queued.revision : getNextPatchRevision(),
+    },
+  ];
+}
+
+function persistPendingPatches() {
+  if (typeof window === "undefined") return;
+  try {
+    const entries = Array.from(durablePatches.entries()).filter(([, queued]) => Object.keys(queued.patch).length > 0);
+    if (entries.length === 0) {
+      window.localStorage.removeItem(PATCH_QUEUE_STORAGE_KEY);
+      return;
+    }
+    window.localStorage.setItem(PATCH_QUEUE_STORAGE_KEY, JSON.stringify(entries));
+  } catch {
+    // The in-memory queue still owns the active write path when localStorage is unavailable.
+  }
+}
+
+function restorePendingPatchesFromStorage() {
+  if (restoredStoredPatches || typeof window === "undefined") return;
+  restoredStoredPatches = true;
+
+  let parsed: unknown;
+  try {
+    const raw = window.localStorage.getItem(PATCH_QUEUE_STORAGE_KEY);
+    if (!raw) return;
+    parsed = JSON.parse(raw);
+  } catch {
+    return;
+  }
+
+  if (!Array.isArray(parsed)) return;
+  for (const rawEntry of parsed) {
+    const entry = validateStoredPatchEntry(rawEntry);
+    if (!entry) continue;
+    const [key, queued] = entry;
+    const existing = pendingPatches.get(key);
+    const restored = {
+      chatId: queued.chatId,
+      patch: {
+        ...(existing?.patch ?? {}),
+        ...queued.patch,
+      },
+      revision: getNextPatchRevision(),
+    };
+    pendingPatches.set(key, restored);
+    durablePatches.set(key, cloneQueuedPatch(restored));
+  }
+  persistPendingPatches();
+}
+
+function reportPersistenceFailure(chatId: string, error: unknown) {
+  console.warn("[game-metadata] Failed to persist game metadata; retrying.", { chatId, error });
+  const now = Date.now();
+  const lastToastAt = lastFailureToastAt.get(chatId);
+  if (lastToastAt === undefined || now - lastToastAt > 30_000) {
+    lastFailureToastAt.set(chatId, now);
+    toast.error("Game progress could not be saved. Marinara will retry automatically.");
+  }
+}
+
+function scheduleRetry(chatId: string) {
+  if (retryTimers.has(chatId)) return;
+  retryTimers.set(
+    chatId,
+    setTimeout(() => {
+      retryTimers.delete(chatId);
+      void flushPendingGameMetadataPatches(chatId).catch(() => {
+        /* failure was already reported and re-queued */
+      });
+    }, RETRY_DELAY_MS),
+  );
+}
+
+function retainPersistedHandler(chatId: string, options: PersistOptions) {
+  if (!options.onPersisted) return;
+  const handlers = persistedChatHandlers.get(chatId) ?? new Map<(chat: Chat) => void, PersistedChatHandler>();
+  handlers.set(options.onPersisted, {
+    handler: options.onPersisted,
+    once: options.onPersistedOnce === true,
+  });
+  persistedChatHandlers.set(chatId, handlers);
+}
+
+function requeuePatch(key: string, queued: QueuedGameMetadataPatch) {
+  const existing = pendingPatches.get(key);
+  const next = {
+    chatId: queued.chatId,
+    patch: {
+      ...queued.patch,
+      ...(existing?.patch ?? {}),
+    },
+    revision: getNextPatchRevision(),
+  };
+  pendingPatches.set(key, next);
+  durablePatches.set(key, cloneQueuedPatch(next));
+  persistPendingPatches();
+  scheduleRetry(queued.chatId);
+}
+
+export function getPendingGameMetadataPatch(chatId: string): GameMetadataPatch | null {
+  restorePendingPatchesFromStorage();
+  const queued = pendingPatches.get(chatId) ?? durablePatches.get(chatId);
+  return queued ? { ...queued.patch } : null;
+}
+
+export function persistGameMetadataPatch(chatId: string, patch: GameMetadataPatch, options: PersistOptions = {}) {
+  restorePendingPatchesFromStorage();
+  retainPersistedHandler(chatId, options);
+
+  const existing = pendingPatches.get(chatId) ?? durablePatches.get(chatId);
+  const queued = {
+    chatId,
+    patch: {
+      ...(existing?.patch ?? {}),
+      ...patch,
+    },
+    revision: getNextPatchRevision(),
+  };
+  pendingPatches.set(chatId, queued);
+  durablePatches.set(chatId, cloneQueuedPatch(queued));
+  persistPendingPatches();
+
+  const retryTimer = retryTimers.get(chatId);
+  if (retryTimer) {
+    clearTimeout(retryTimer);
+    retryTimers.delete(chatId);
+  }
+
+  return flushPendingGameMetadataPatches(chatId, options);
+}
+
+export async function flushPendingGameMetadataPatches(chatId?: string, options: PersistOptions = {}) {
+  restorePendingPatchesFromStorage();
+  if (chatId) retainPersistedHandler(chatId, options);
+
+  const errors: unknown[] = [];
+  const entries = Array.from(pendingPatches.entries()).filter(([key]) => !chatId || key === chatId);
+
+  for (const [key] of entries) {
+    const previousInFlight = inFlightPatches.get(key);
+    if (previousInFlight) {
+      await previousInFlight.catch(() => {
+        /* previous failure was already re-queued */
+      });
+    }
+
+    const latestQueued = pendingPatches.get(key);
+    if (!latestQueued || Object.keys(latestQueued.patch).length === 0) continue;
+
+    const queuedSnapshot = cloneQueuedPatch(latestQueued);
+    pendingPatches.delete(key);
+    durablePatches.set(key, cloneQueuedPatch(queuedSnapshot));
+    persistPendingPatches();
+
+    const request = storageApi
+      .patchChatMetadata<Chat>(queuedSnapshot.chatId, queuedSnapshot.patch)
+      .then((chat) => {
+        const durable = durablePatches.get(key);
+        if (durable?.revision === queuedSnapshot.revision) {
+          durablePatches.delete(key);
+          persistPendingPatches();
+        }
+        const handlers = persistedChatHandlers.get(queuedSnapshot.chatId);
+        for (const [handler, entry] of handlers ?? []) {
+          entry.handler(chat);
+          if (entry.once) {
+            handlers?.delete(handler);
+          }
+        }
+        return chat;
+      })
+      .catch((error) => {
+        requeuePatch(key, queuedSnapshot);
+        reportPersistenceFailure(queuedSnapshot.chatId, error);
+        throw error;
+      })
+      .finally(() => {
+        if (inFlightPatches.get(key) === request) {
+          inFlightPatches.delete(key);
+        }
+      });
+
+    inFlightPatches.set(key, request);
+
+    try {
+      await request;
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+
+  if (errors.length > 0) {
+    throw new Error(`Failed to persist ${errors.length} game metadata patch${errors.length === 1 ? "" : "es"}.`);
+  }
+}
+
+export async function resetGameMetadataPersistenceForTest() {
+  for (const timer of retryTimers.values()) clearTimeout(timer);
+  retryTimers.clear();
+  pendingPatches.clear();
+  durablePatches.clear();
+  persistedChatHandlers.clear();
+  lastFailureToastAt.clear();
+  const inFlight = Array.from(inFlightPatches.values());
+  inFlightPatches.clear();
+  await Promise.allSettled(inFlight);
+  restoredStoredPatches = false;
+  nextPatchRevision = 1;
+  if (typeof window !== "undefined") {
+    window.localStorage.removeItem(PATCH_QUEUE_STORAGE_KEY);
+  }
+}

--- a/src/features/modes/game/stores/game-mode.store.test.ts
+++ b/src/features/modes/game/stores/game-mode.store.test.ts
@@ -1,13 +1,31 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
-import type { GameNpc } from "../../../../engine/contracts/types/game";
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { GameNpc, HudWidget } from "../../../../engine/contracts/types/game";
 import { BUILT_IN_MARI_AVATAR } from "../../../../engine/modes/game/assets/npc-avatar-utils";
-import { useGameModeStore } from "./game-mode.store";
+import { storageApi } from "../../../../shared/api/storage-api";
+import { resetGameMetadataPersistenceForTest } from "../lib/game-metadata-persistence";
+import { useSyncGameState } from "../hooks/use-game";
+import {
+  getHudWidgetStateSignature,
+  getPendingHudWidgetPersistenceSignature,
+  resetHudWidgetPersistenceForTest,
+  useGameModeStore,
+} from "./game-mode.store";
 
-vi.mock("../api/game-api", () => ({
-  gameApi: {
-    updateWidgets: vi.fn(),
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
   },
 }));
+
+vi.mock("../../../../shared/api/storage-api", () => ({
+  storageApi: {
+    patchChatMetadata: vi.fn(),
+  },
+}));
+
+const patchChatMetadataMock = vi.mocked(storageApi.patchChatMetadata);
 
 function npc(overrides: Partial<GameNpc>): GameNpc {
   return {
@@ -23,11 +41,46 @@ function npc(overrides: Partial<GameNpc>): GameNpc {
   };
 }
 
-describe("useGameModeStore NPC avatar handling", () => {
-  afterEach(() => {
-    useGameModeStore.getState().reset();
-  });
+function widget(overrides: Partial<HudWidget> = {}): HudWidget {
+  return {
+    id: overrides.id ?? "inventory",
+    type: overrides.type ?? "inventory_grid",
+    label: overrides.label ?? "Inventory",
+    position: overrides.position ?? "hud_right",
+    config: overrides.config ?? { contents: [] },
+  } as HudWidget;
+}
 
+function chat(metadata: Record<string, unknown> = {}) {
+  return {
+    id: "chat-1",
+    name: "Game",
+    mode: "game",
+    characterIds: [],
+    metadata,
+  };
+}
+
+async function resetStoreTestState() {
+  useGameModeStore.getState().reset();
+  resetHudWidgetPersistenceForTest();
+  await resetGameMetadataPersistenceForTest();
+  patchChatMetadataMock.mockReset();
+}
+
+beforeEach(async () => {
+  vi.useFakeTimers();
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+  await resetStoreTestState();
+});
+
+afterEach(async () => {
+  await resetStoreTestState();
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe("useGameModeStore NPC avatar handling", () => {
   it("removes the built-in Mari avatar from non-Mari NPCs when syncing metadata", () => {
     useGameModeStore
       .getState()
@@ -65,5 +118,79 @@ describe("useGameModeStore NPC avatar handling", () => {
 
     const [storedNpc] = useGameModeStore.getState().npcs;
     expect(storedNpc?.avatarUrl).toBeUndefined();
+  });
+});
+
+describe("useGameModeStore widget persistence", () => {
+  it("keeps failed debounced widget persistence pending", async () => {
+    patchChatMetadataMock.mockRejectedValueOnce(new Error("storage offline"));
+    const initialWidget = widget();
+    useGameModeStore.getState().setActiveGame("game-1", "chat-1");
+    useGameModeStore.getState().setHudWidgets([initialWidget]);
+
+    const updatedWidgets = useGameModeStore.getState().applyWidgetUpdate({
+      widgetId: "inventory",
+      changes: { add: "Moon Key" },
+    });
+    const expectedSignature = getHudWidgetStateSignature(updatedWidgets);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(patchChatMetadataMock).toHaveBeenCalledWith("chat-1", { gameWidgetState: updatedWidgets });
+    expect(getPendingHudWidgetPersistenceSignature("chat-1")).toBe(expectedSignature);
+  });
+
+  it("clears failed widget persistence after the retry succeeds", async () => {
+    patchChatMetadataMock.mockRejectedValueOnce(new Error("storage offline")).mockResolvedValueOnce(chat());
+    useGameModeStore.getState().setActiveGame("game-1", "chat-1");
+    useGameModeStore.getState().setHudWidgets([widget()]);
+
+    useGameModeStore.getState().applyWidgetUpdate({
+      widgetId: "inventory",
+      changes: { add: "Moon Key" },
+    });
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(getPendingHudWidgetPersistenceSignature("chat-1")).not.toBeNull();
+
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(patchChatMetadataMock).toHaveBeenCalledTimes(2);
+    expect(getPendingHudWidgetPersistenceSignature("chat-1")).toBeNull();
+  });
+
+  it("does not let stale metadata clobber widgets while a failed save is pending", async () => {
+    patchChatMetadataMock.mockRejectedValueOnce(new Error("storage offline"));
+    useGameModeStore.getState().setActiveGame("game-1", "chat-1");
+    useGameModeStore.getState().setHudWidgets([widget()]);
+
+    const updatedWidgets = useGameModeStore.getState().applyWidgetUpdate({
+      widgetId: "inventory",
+      changes: { add: "Moon Key" },
+    });
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    function Harness() {
+      useSyncGameState("chat-1", {
+        gameId: "game-1",
+        gameWidgetState: [widget({ config: { contents: [] } })],
+      });
+      return null;
+    }
+
+    await act(async () => {
+      root.render(createElement(Harness));
+    });
+
+    expect(useGameModeStore.getState().hudWidgets).toEqual(updatedWidgets);
+
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
   });
 });

--- a/src/features/modes/game/stores/game-mode.store.ts
+++ b/src/features/modes/game/stores/game-mode.store.ts
@@ -2,7 +2,6 @@
 // Store: Game Mode
 // ──────────────────────────────────────────────
 import { create } from "zustand";
-import { gameApi } from "../api/game-api";
 import type {
   GameActiveState,
   GameMap,
@@ -13,6 +12,7 @@ import type {
   WidgetUpdate,
 } from "../../../../engine/contracts/types/game";
 import { sanitizeGameNpcAvatarUrls } from "../../../../engine/modes/game/assets/npc-avatar-utils";
+import { persistGameMetadataPatch } from "../lib/game-metadata-persistence";
 
 interface GameModeStore {
   /** The active game ID (groupId that links all sessions). */
@@ -85,20 +85,28 @@ export function getPendingHudWidgetPersistenceSignature(chatId: string): string 
   return pendingWidgetPersistence?.chatId === chatId ? pendingWidgetPersistence.signature : null;
 }
 
+export function resetHudWidgetPersistenceForTest() {
+  if (widgetPersistTimer) clearTimeout(widgetPersistTimer);
+  widgetPersistTimer = null;
+  pendingWidgetPersistence = null;
+}
+
 function debouncedPersistWidgets(chatId: string, widgets: HudWidget[]) {
   const signature = getHudWidgetStateSignature(widgets);
   pendingWidgetPersistence = { chatId, signature };
   if (widgetPersistTimer) clearTimeout(widgetPersistTimer);
   widgetPersistTimer = setTimeout(() => {
-    gameApi
-      .updateWidgets({ chatId, widgets })
-      .catch(() => {
-        /* best-effort persistence */
+    const clearPending = () => {
+      if (pendingWidgetPersistence?.chatId === chatId && pendingWidgetPersistence.signature === signature) {
+        pendingWidgetPersistence = null;
+      }
+    };
+    persistGameMetadataPatch(chatId, { gameWidgetState: widgets }, { onPersisted: clearPending, onPersistedOnce: true })
+      .then(() => {
+        clearPending();
       })
-      .finally(() => {
-        if (pendingWidgetPersistence?.chatId === chatId && pendingWidgetPersistence.signature === signature) {
-          pendingWidgetPersistence = null;
-        }
+      .catch(() => {
+        /* failure is retained and reported by the persistence helper */
       });
   }, 1000);
 }


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

<!-- Every user-facing PR should reference a feature request or issue report when practical. -->

Closes #1537

## Why this change

<!-- What user problem, bug, refactor goal, or maintenance need does this solve? -->

- Game mode had several automatic metadata writes that updated visible state first and then saved in the background with silent catches. If a metadata write failed, inventory/widgets/scene/combat/segment UI could appear durable but disappear after refresh or chat switch.

## What changed

<!-- List the key changes in this PR. -->

- Added a focused Game metadata persistence helper that coalesces per-chat metadata patches, keeps failed patches retryable in `localStorage`, reports persistence failures with toast/console feedback, and publishes successful saved `sessionChat` responses back into cache.
- Routed GameSurface automatic metadata writes for scene assets, narration progress, segment edits/deletes, combat snapshots, map command persistence, recent tracks, stale combat cleanup, and segment-driven inventory persistence through the retryable helper.
- Updated HUD widget auto-persistence so failed saves keep the pending signature active until a retry succeeds, and stale incoming metadata does not clobber locally pending widgets.
- Added regression coverage for failed retry retention, patch coalescing, durable retry clearing, invalid retry payload handling, widget retry state, and stale widget metadata protection.

## Refactor impact

Primary owner:

<!-- Examples: app shell, catalog, chat mode, roleplay mode, game mode, runtime generation, world-state, shared API, engine generation, Rust storage, imports, remote runtime. -->

Game mode metadata persistence in `src/features/modes/game`.

Impact areas reviewed:

- GameSurface metadata-backed UI state for inventory, widgets, scenes, narration progress, segment edits/deletes, combat snapshots, map command state, and recent tracks.
- Game mode widget store persistence and incoming metadata hydration.

Boundary notes:

<!-- Note engine/shared-api/feature/Rust/remote-runtime boundaries. Say "none" only if you checked. -->

- Kept the fix in `src/features/modes/game`; no schema, engine, Rust, Tauri storage, shared runtime adapter, dependency, or prompt assembly changes.
- The helper continues to use the existing `storageApi.patchChatMetadata` wrapper instead of adding a new storage fallback.

Pressure points touched:

<!-- Mention ModeSurface, GameSurface, shared mode UI, src-tauri/src/lib.rs command registration, or import modules if touched. -->

- `GameSurface`
- Game mode widget store
- Game metadata persistence helper

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app/runtime, step by step. If an AI agent filled this out, verify it yourself before ticking boxes. -->

- Codex proof run:
- `pnpm test -- src/features/modes/game/lib/game-metadata-persistence.test.ts src/features/modes/game/stores/game-mode.store.test.ts`
- `pnpm test -- src/features/modes/game src/features/runtime/world-state`
- `pnpm typecheck`
- `pnpm check:architecture`
- `pnpm check`
- `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json`
- Visual evidence is not applicable: this is a persistence-contract bug proven with forced storage failure tests rather than a visible layout state.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs or release-note changes were made; this PR does not restore old staging/package-workspace/release claims.

## UI evidence

<!-- Add before/after screenshots or recordings for visible UI changes. -->

N/A. The fix is covered by forced metadata persistence failure tests and store retry-state tests.
