### PR TITLE
Fix game item-use feedback

### DIFF
--- a/src/features/modes/game/components/GameInventory.tsx
+++ b/src/features/modes/game/components/GameInventory.tsx
@@ -25,7 +25,7 @@ interface GameInventoryProps {
   /** Called when the user wants to add a new item */
   onAddItem?: () => Promise<string | null> | string | null;
   /** Called when the user wants to use an item during input phase */
-  onUseItem?: (itemName: string) => void;
+  onUseItem?: (itemName: string) => void | Promise<void>;
   /** Called when the user wants to rename an item */
   onRenameItem?: (currentName: string, nextName: string) => Promise<string | null> | string | null;
   /** Called when the user wants to manually remove one unit of an item */
@@ -60,6 +60,7 @@ export function GameInventory({
   const [renamePending, setRenamePending] = useState(false);
   const [addPending, setAddPending] = useState(false);
   const [amountPending, setAmountPending] = useState<"increment" | "decrement" | "clear" | null>(null);
+  const [usePending, setUsePending] = useState(false);
   const [pageIndex, setPageIndex] = useState(0);
 
   // Mouse: 4px distance threshold so quick clicks still select.
@@ -82,9 +83,16 @@ export function GameInventory({
   );
 
   const handleUse = useCallback(
-    (itemName: string) => {
-      onUseItem?.(itemName);
-      setSelectedItem(null);
+    async (itemName: string) => {
+      if (!onUseItem) return;
+
+      setUsePending(true);
+      try {
+        await onUseItem(itemName);
+        setSelectedItem(null);
+      } finally {
+        setUsePending(false);
+      }
     },
     [onUseItem],
   );
@@ -391,11 +399,12 @@ export function GameInventory({
               )}
               {selectedItem && canInteract && onUseItem && (
                 <button
-                  onClick={() => handleUse(selectedItem)}
-                  className="flex flex-1 items-center justify-center gap-1 rounded border border-amber-500/20 bg-amber-500/10 py-1.5 text-[0.7rem] font-semibold text-amber-400 transition-colors hover:bg-amber-500/15"
+                  onClick={() => void handleUse(selectedItem)}
+                  disabled={usePending}
+                  className="flex flex-1 items-center justify-center gap-1 rounded border border-amber-500/20 bg-amber-500/10 py-1.5 text-[0.7rem] font-semibold text-amber-400 transition-colors hover:bg-amber-500/15 disabled:cursor-wait disabled:opacity-60"
                 >
                   <Wand2 size={12} />
-                  Use
+                  {usePending ? "Using..." : "Use"}
                 </button>
               )}
             </div>

--- a/src/features/modes/game/components/GameSurface.tsx
+++ b/src/features/modes/game/components/GameSurface.tsx
@@ -985,6 +985,21 @@ async function persistGameMetadata(chatId: string, patch: Record<string, unknown
   return storageApi.patchChatMetadata<Chat>(chatId, patch);
 }
 
+type InventoryNotificationKind = "gain" | "loss" | "use-pending" | "use-kept" | "use-consumed" | "error";
+
+interface InventoryNotification {
+  id: string;
+  kind: InventoryNotificationKind;
+  message: string;
+}
+
+interface PendingInventoryUse {
+  id: string;
+  itemName: string;
+  normalizedItemName: string;
+  submittedAfterMessageId: string | null;
+}
+
 /** Typewriter component for the intro screen — reveals text character-by-character. */
 function IntroTypewriter({ text, onComplete }: { text: string; onComplete?: () => void }) {
   const [visible, setVisible] = useState(0);
@@ -1995,7 +2010,9 @@ export function GameSurface({
     },
     [activeChatId, queryClient],
   );
-  const [inventoryNotifications, setInventoryNotifications] = useState<string[]>([]);
+  const [inventoryNotifications, setInventoryNotifications] = useState<InventoryNotification[]>([]);
+  const [pendingInventoryUse, setPendingInventoryUse] = useState<PendingInventoryUse | null>(null);
+  const pendingInventoryUseRef = useRef<PendingInventoryUse | null>(null);
   const [removingPartyMemberId, setRemovingPartyMemberId] = useState<string | null>(null);
   const [pendingMapMove, setPendingMapMove] = useState<{
     position: { x: number; y: number } | string;
@@ -2018,6 +2035,27 @@ export function GameSurface({
   const appliedCombatStatusMessageIdsRef = useRef<Set<string>>(new Set());
   const appliedCombatElementMessageIdsRef = useRef<Set<string>>(new Set());
   const interruptedInteractiveCommandKeysRef = useRef<Set<string>>(new Set());
+  const clearInventoryNotificationTimer = useCallback(() => {
+    if (!notificationTimerRef.current) return;
+    clearTimeout(notificationTimerRef.current);
+    notificationTimerRef.current = null;
+  }, []);
+  const showInventoryNotifications = useCallback(
+    (notifications: InventoryNotification[], durationMs: number | null = 4000) => {
+      setInventoryNotifications(notifications);
+      clearInventoryNotificationTimer();
+      if (durationMs !== null) {
+        notificationTimerRef.current = setTimeout(() => {
+          setInventoryNotifications([]);
+          notificationTimerRef.current = null;
+        }, durationMs);
+      }
+    },
+    [clearInventoryNotificationTimer],
+  );
+  useEffect(() => {
+    pendingInventoryUseRef.current = pendingInventoryUse;
+  }, [pendingInventoryUse]);
   const recruitPartyMember = useRecruitPartyMember();
   const removePartyMember = useRemovePartyMember();
   const availableMaps = useMemo(() => (maps.length > 0 ? maps : currentMap ? [currentMap] : []), [currentMap, maps]);
@@ -2252,6 +2290,8 @@ export function GameSurface({
     // Reset inventory/readables for the new chat
     setInventoryItems((chatMeta.gameInventory as Array<{ name: string; quantity: number }>) ?? []);
     setInventoryNotifications([]);
+    setPendingInventoryUse(null);
+    clearInventoryNotificationTimer();
     setPendingInventorySegmentUpdates([]);
     setActiveReadable(null);
     readableQueueRef.current = [];
@@ -2264,7 +2304,13 @@ export function GameSurface({
     setPrepareSessionWidgetsOpen(false);
     // Allow the auto-tutorial to re-evaluate for the new chat (guard still gates on disabled flag)
     tutorialAutoTriggeredRef.current = false;
-  }, [activeChatId, chatMeta.gameInventory, chatMeta.gameRecentMusic, chatMeta.gameRecentSpotifyTracks]);
+  }, [
+    activeChatId,
+    chatMeta.gameInventory,
+    chatMeta.gameRecentMusic,
+    chatMeta.gameRecentSpotifyTracks,
+    clearInventoryNotificationTimer,
+  ]);
 
   const clearPendingInteractiveCommands = useCallback(() => {
     setActiveChoices(null);
@@ -2287,10 +2333,12 @@ export function GameSurface({
     (updates: InventoryTag[]) => {
       if (updates.length === 0) return;
 
-      const notifications: string[] = [];
+      const notifications: InventoryNotification[] = [];
       const journalEntries: Array<{ item: string; action: "acquired" | "lost" }> = [];
       const previousInventory = inventoryItemsRef.current;
       let updated = previousInventory;
+      const pendingUse = pendingInventoryUseRef.current;
+      let consumedPendingUse = false;
       const currentGameState = useGameStateStore.getState().current;
       const currentPlayerStats = currentGameState?.chatId === activeChatId ? currentGameState.playerStats : null;
       let nextPlayerStats = currentPlayerStats;
@@ -2309,13 +2357,32 @@ export function GameSurface({
                 inventory: addInventoryUnit(nextPlayerStats.inventory, normalizedItemName),
               };
             }
-            notifications.push(`You gained ${normalizedItemName}!`);
+            notifications.push({
+              id: `gain-${normalizedItemName}-${Date.now()}-${notifications.length}`,
+              kind: "gain",
+              message: `You gained ${normalizedItemName}!`,
+            });
             applied = true;
           } else {
             const nextInventory = removeInventoryUnit(updated, normalizedItemName);
             if (nextInventory !== updated) {
               updated = nextInventory;
-              notifications.push(`You lost ${normalizedItemName}!`);
+              const matchesPendingUse =
+                !!pendingUse && normalizedItemName.toLowerCase() === pendingUse.normalizedItemName.toLowerCase();
+              if (matchesPendingUse) {
+                consumedPendingUse = true;
+                notifications.push({
+                  id: `use-consumed-${normalizedItemName}-${Date.now()}-${notifications.length}`,
+                  kind: "use-consumed",
+                  message: `${normalizedItemName} was used and removed from inventory.`,
+                });
+              } else {
+                notifications.push({
+                  id: `loss-${normalizedItemName}-${Date.now()}-${notifications.length}`,
+                  kind: "loss",
+                  message: `You lost ${normalizedItemName}!`,
+                });
+              }
               applied = true;
             }
             if (nextPlayerStats) {
@@ -2375,12 +2442,13 @@ export function GameSurface({
       }
 
       if (notifications.length > 0) {
-        setInventoryNotifications(notifications);
-        if (notificationTimerRef.current) clearTimeout(notificationTimerRef.current);
-        notificationTimerRef.current = setTimeout(() => setInventoryNotifications([]), 4000);
+        showInventoryNotifications(notifications);
+      }
+      if (consumedPendingUse) {
+        setPendingInventoryUse(null);
       }
     },
-    [activeChatId, patchVisibleGameState, publishSessionChat],
+    [activeChatId, patchVisibleGameState, publishSessionChat, showInventoryNotifications],
   );
 
   const playDirections = useCallback((directions: DirectionCommand[]) => {
@@ -5060,9 +5128,13 @@ export function GameSurface({
 
       setInventoryItems(updatedInventory);
 
-      setInventoryNotifications([`You gained ${addedItemName}!`]);
-      if (notificationTimerRef.current) clearTimeout(notificationTimerRef.current);
-      notificationTimerRef.current = setTimeout(() => setInventoryNotifications([]), 4000);
+      showInventoryNotifications([
+        {
+          id: `gain-${addedItemName}-${Date.now()}`,
+          kind: "gain",
+          message: `You gained ${addedItemName}!`,
+        },
+      ]);
       toast.success(`Added ${addedItemName} to inventory.`);
       return addedItemName;
     } catch (error) {
@@ -5073,7 +5145,7 @@ export function GameSurface({
       toast.error(message);
       return null;
     }
-  }, [activeChatId, inventoryItems, patchVisibleGameState, updateChatMetadata]);
+  }, [activeChatId, inventoryItems, patchVisibleGameState, showInventoryNotifications, updateChatMetadata]);
 
   const handleIncrementInventoryItem = useCallback(
     async (itemName: string) => {
@@ -5113,9 +5185,13 @@ export function GameSurface({
 
         setInventoryItems(updatedInventory);
 
-        setInventoryNotifications([`You gained ${normalizedItemName}!`]);
-        if (notificationTimerRef.current) clearTimeout(notificationTimerRef.current);
-        notificationTimerRef.current = setTimeout(() => setInventoryNotifications([]), 4000);
+        showInventoryNotifications([
+          {
+            id: `gain-${normalizedItemName}-${Date.now()}`,
+            kind: "gain",
+            message: `You gained ${normalizedItemName}!`,
+          },
+        ]);
         toast.success(`Added 1 ${normalizedItemName}.`);
       } catch (error) {
         if (patchedGameState && currentPlayerStats) {
@@ -5125,7 +5201,7 @@ export function GameSurface({
         toast.error(message);
       }
     },
-    [activeChatId, inventoryItems, patchVisibleGameState, updateChatMetadata],
+    [activeChatId, inventoryItems, patchVisibleGameState, showInventoryNotifications, updateChatMetadata],
   );
 
   const handleRemoveInventoryItem = useCallback(
@@ -5176,9 +5252,13 @@ export function GameSurface({
           .then((res) => publishSessionChat(res.sessionChat))
           .catch(() => {});
 
-        setInventoryNotifications([`You removed ${itemName}.`]);
-        if (notificationTimerRef.current) clearTimeout(notificationTimerRef.current);
-        notificationTimerRef.current = setTimeout(() => setInventoryNotifications([]), 4000);
+        showInventoryNotifications([
+          {
+            id: `loss-${itemName}-${Date.now()}`,
+            kind: "loss",
+            message: `You removed ${itemName}.`,
+          },
+        ]);
         toast.success(`Removed ${itemName} from inventory.`);
       } catch (error) {
         if (patchedGameState && currentPlayerStats) {
@@ -5188,7 +5268,7 @@ export function GameSurface({
         toast.error(message);
       }
     },
-    [activeChatId, inventoryItems, patchVisibleGameState, publishSessionChat, updateChatMetadata],
+    [activeChatId, inventoryItems, patchVisibleGameState, publishSessionChat, showInventoryNotifications, updateChatMetadata],
   );
 
   const handleClearInventoryItem = useCallback(
@@ -5241,9 +5321,13 @@ export function GameSurface({
           .then((res) => publishSessionChat(res.sessionChat))
           .catch(() => {});
 
-        setInventoryNotifications([`You removed ${itemName}.`]);
-        if (notificationTimerRef.current) clearTimeout(notificationTimerRef.current);
-        notificationTimerRef.current = setTimeout(() => setInventoryNotifications([]), 4000);
+        showInventoryNotifications([
+          {
+            id: `loss-${itemName}-${Date.now()}`,
+            kind: "loss",
+            message: `You removed ${itemName}.`,
+          },
+        ]);
         toast.success(`Removed ${itemName} from inventory.`);
       } catch (error) {
         if (patchedGameState && currentPlayerStats) {
@@ -5253,7 +5337,7 @@ export function GameSurface({
         toast.error(message);
       }
     },
-    [activeChatId, inventoryItems, patchVisibleGameState, publishSessionChat, updateChatMetadata],
+    [activeChatId, inventoryItems, patchVisibleGameState, publishSessionChat, showInventoryNotifications, updateChatMetadata],
   );
 
   const handleUseCombatInventoryItem = useCallback(
@@ -5305,9 +5389,13 @@ export function GameSurface({
           .then((res) => publishSessionChat(res.sessionChat))
           .catch(() => {});
 
-        setInventoryNotifications([`You used ${normalizedItemName}.`]);
-        if (notificationTimerRef.current) clearTimeout(notificationTimerRef.current);
-        notificationTimerRef.current = setTimeout(() => setInventoryNotifications([]), 4000);
+        showInventoryNotifications([
+          {
+            id: `use-consumed-${normalizedItemName}-${Date.now()}`,
+            kind: "use-consumed",
+            message: `You used ${normalizedItemName}.`,
+          },
+        ]);
         toast.success(`Used ${normalizedItemName}.`);
       } catch (error) {
         if (patchedGameState && currentPlayerStats) {
@@ -5317,7 +5405,7 @@ export function GameSurface({
         toast.error(message);
       }
     },
-    [activeChatId, inventoryItems, patchVisibleGameState, publishSessionChat, updateChatMetadata],
+    [activeChatId, inventoryItems, patchVisibleGameState, publishSessionChat, showInventoryNotifications, updateChatMetadata],
   );
 
   const handleRenameInventoryItem = useCallback(
@@ -6854,7 +6942,7 @@ export function GameSurface({
       attachments?: Array<{ type: string; data: string }>,
       options?: { commitPendingMove?: boolean },
     ) => {
-      if (!sessionInteractive) return;
+      if (!sessionInteractive) return false;
       audioManager.unlock();
       // Commit a pending interrupt: persist the truncated GM message before generating
       // so the server-side prompt build doesn't see segments the player never read. We
@@ -6876,7 +6964,7 @@ export function GameSurface({
         } catch {
           if (interruptedCommandKey) interruptedInteractiveCommandKeysRef.current.delete(interruptedCommandKey);
           toast.error("Failed to commit the interrupt. Please try again.");
-          return;
+          return false;
         }
       }
       // Risky mode tells the GM about the interrupt via a one-line system message.
@@ -6892,7 +6980,7 @@ export function GameSurface({
         } catch {
           if (interruptedCommandKey) interruptedInteractiveCommandKeysRef.current.delete(interruptedCommandKey);
           toast.error("Failed to mark the risky interrupt. Please try again.");
-          return;
+          return false;
         }
       }
       if (interruptedCommandKey) {
@@ -6910,7 +6998,7 @@ export function GameSurface({
       if (getGameDirectAddressMode(message) === "party" && !attachments?.length) {
         if (partyTurnInFlightRef.current || partyTurn.isPending) {
           clearCommittedPendingMapMove();
-          return;
+          return false;
         }
         const playerAction = stripGameDirectAddressPrefix(message);
         const requestId = partyTurnRequestIdRef.current + 1;
@@ -6920,7 +7008,7 @@ export function GameSurface({
         setPartyChatMessageId(null);
         try {
           await createMessage.mutateAsync({ role: "user", content: message });
-          if (partyTurnRequestIdRef.current !== requestId) return;
+          if (partyTurnRequestIdRef.current !== requestId) return false;
           setPartyChatInput(playerAction);
           const result = await partyTurn.mutateAsync({
             chatId: activeChatId,
@@ -6928,7 +7016,7 @@ export function GameSurface({
             playerAction,
             connectionId: chat.connectionId ?? undefined,
           });
-          if (partyTurnRequestIdRef.current !== requestId) return;
+          if (partyTurnRequestIdRef.current !== requestId) return false;
           setPartyDialogue(result.lines);
           setPartyChatMessageId(result.messageId);
         } catch (error) {
@@ -6938,16 +7026,18 @@ export function GameSurface({
             setPartyChatInput(null);
             toast.error(error instanceof Error ? error.message : "The party did not respond.");
           }
+          return false;
         } finally {
           if (partyTurnRequestIdRef.current === requestId) {
             partyTurnInFlightRef.current = false;
           }
           clearCommittedPendingMapMove();
         }
-        return;
+        return true;
       }
       sendMessage(message, attachments);
       clearCommittedPendingMapMove();
+      return true;
     },
     [
       activeChatId,
@@ -6965,6 +7055,109 @@ export function GameSurface({
       updateMessage,
     ],
   );
+
+  const handleUseInventoryItem = useCallback(
+    async (itemName: string) => {
+      if (!activeChatId) return;
+
+      const normalizedItemName = normalizeInventoryName(itemName);
+      if (!normalizedItemName) return;
+
+      const inventoryItem = inventoryItems.find(
+        (item) => normalizeInventoryName(item.name).toLowerCase() === normalizedItemName.toLowerCase(),
+      );
+      if (!inventoryItem) {
+        toast.error(`${normalizedItemName} is no longer in your inventory.`);
+        return;
+      }
+
+      const pendingUse: PendingInventoryUse = {
+        id: `use-pending-${normalizedItemName}-${Date.now()}`,
+        itemName: inventoryItem.name,
+        normalizedItemName,
+        submittedAfterMessageId: latestAssistantMsg?.id ?? null,
+      };
+      setPendingInventoryUse(pendingUse);
+      showInventoryNotifications(
+        [
+          {
+            id: pendingUse.id,
+            kind: "use-pending",
+            message: `Using ${inventoryItem.name}... waiting for the GM response.`,
+          },
+        ],
+        null,
+      );
+      setInventoryOpen(false);
+      const submitted = await handleSendGameTurn(`I use my ${normalizedItemName}.`);
+      if (!submitted) {
+        setPendingInventoryUse(null);
+        showInventoryNotifications(
+          [
+            {
+              id: `use-error-${normalizedItemName}-${Date.now()}`,
+              kind: "error",
+              message: `Could not queue ${inventoryItem.name}. It remains in inventory.`,
+            },
+          ],
+          6000,
+        );
+      }
+    },
+    [activeChatId, handleSendGameTurn, inventoryItems, latestAssistantMsg?.id, showInventoryNotifications],
+  );
+
+  useEffect(() => {
+    if (!pendingInventoryUse) return;
+
+    if (generationFailed) {
+      showInventoryNotifications(
+        [
+          {
+            id: `use-error-${pendingInventoryUse.normalizedItemName}-${Date.now()}`,
+            kind: "error",
+            message: `Could not process ${pendingInventoryUse.itemName}. It remains in inventory.`,
+          },
+        ],
+        6000,
+      );
+      setPendingInventoryUse(null);
+      return;
+    }
+
+    if (isStreaming) return;
+    if (!latestAssistantMsg?.id || latestAssistantMsg.id === pendingInventoryUse.submittedAfterMessageId) return;
+
+    const inventoryUpdates = latestAssistantMsg.content ? parseGmTags(latestAssistantMsg.content).inventoryUpdates : [];
+    const responseWillRemoveItem = inventoryUpdates.some(
+      (update) =>
+        update.action === "remove" &&
+        update.items.some(
+          (item) => normalizeInventoryName(item).toLowerCase() === pendingInventoryUse.normalizedItemName.toLowerCase(),
+        ),
+    );
+
+    if (responseWillRemoveItem) return;
+
+    showInventoryNotifications(
+      [
+        {
+          id: `use-kept-${pendingInventoryUse.normalizedItemName}-${Date.now()}`,
+          kind: "use-kept",
+          message: `${pendingInventoryUse.itemName} action was sent. The item remains in inventory.`,
+        },
+      ],
+      6000,
+    );
+    setPendingInventoryUse(null);
+  }, [
+    generationFailed,
+    isStreaming,
+    latestAssistantMsg?.content,
+    latestAssistantMsg?.id,
+    pendingInventoryUse,
+    showInventoryNotifications,
+  ]);
 
   useEffect(() => {
     setPendingMapMove(null);
@@ -8851,10 +9044,7 @@ export function GameSurface({
                 onIncrementItem={handleIncrementInventoryItem}
                 onReorderItem={handleReorderInventoryItem}
                 canInteract={sessionInteractive && narrationDone && !isStreaming}
-                onUseItem={(itemName) => {
-                  setInventoryOpen(false);
-                  sendMessage(`I use my ${itemName}.`);
-                }}
+                onUseItem={handleUseInventoryItem}
               />
 
               {/* Readable document display (Notes / Books) */}
@@ -8875,17 +9065,20 @@ export function GameSurface({
               {/* Inventory notifications */}
               {inventoryNotifications.length > 0 && (
                 <div className="pointer-events-none absolute left-1/2 top-20 z-40 -translate-x-1/2 flex flex-col gap-1">
-                  {inventoryNotifications.map((n, i) => (
+                  {inventoryNotifications.map((notification) => (
                     <div
-                      key={i}
+                      key={notification.id}
                       className={cn(
                         "animate-in fade-in-0 slide-in-from-bottom-2 rounded-lg border px-4 py-2 text-sm font-semibold shadow-lg backdrop-blur-sm",
-                        n.startsWith("You gained")
-                          ? "border-emerald-400/30 bg-emerald-900/80 text-emerald-200"
-                          : "border-red-400/30 bg-red-900/80 text-red-200",
+                        notification.kind === "gain" && "border-emerald-400/30 bg-emerald-900/80 text-emerald-200",
+                        notification.kind === "loss" && "border-red-400/30 bg-red-900/80 text-red-200",
+                        notification.kind === "use-pending" && "border-amber-300/35 bg-amber-950/85 text-amber-100",
+                        notification.kind === "use-kept" && "border-sky-300/30 bg-sky-950/85 text-sky-100",
+                        notification.kind === "use-consumed" && "border-amber-300/35 bg-emerald-950/85 text-emerald-100",
+                        notification.kind === "error" && "border-red-400/35 bg-red-950/85 text-red-100",
                       )}
                     >
-                      {n}
+                      {notification.message}
                     </div>
                   ))}
                 </div>


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #1594

## Why this change

- Non-combat inventory item Use previously closed the inventory and sent a transient player turn, but it did not give durable feedback that the item action was queued or clarify whether the item stayed in inventory when the GM did not emit an inventory remove tag.

## What changed

- Added a dedicated non-combat inventory Use handler in `GameSurface`.
- Routed item-use turns through the normal game turn path instead of calling `sendMessage` inline.
- Added pending item-use state and typed inventory notifications for queued, kept, consumed, gain, loss, and error feedback.
- Kept non-combat inventory consumption driven by GM inventory tags such as `[inventory: action="remove" item="Test"]`.
- Left combat item-use behavior unchanged, aside from rendering its notification through the typed notification path.

## Refactor impact

Primary owner:

- game mode

Impact areas reviewed:

- `GameInventory` Use button async/pending behavior
- `GameSurface` non-combat turn submission
- GM inventory tag application
- Combat inventory item use
- Inventory notification rendering

Boundary notes:

- Feature-lane change only. No `src/engine`, `src/shared/api`, `src-tauri`, schema, dependency, storage, or prompt changes.
- Actual non-combat item consumption remains owned by GM inventory tags; this PR does not consume items immediately on click.

Pressure points touched:

- `GameSurface`

## Validation

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Codex ran `git diff --check`.
- Codex ran `pnpm typecheck`.
- Codex ran `pnpm build`; build passed with the existing Vite large chunk warning.
- Codex ran `pnpm check`, including line endings, architecture, frontend typecheck, Rust check, and docs check.
- Codex ran the local proof gate with `scratch/bugfix-verification.json`.
- Codex used a Playwright browser harness against the real `GameInventory` component to verify pending, kept, and consumed item-use feedback states.
- Codex app-smoked the web shell, but real game-chat item-use e2e was blocked locally because creating a game chat in web-shell mode requires Remote Runtime configuration.
- Human follow-up: verify the same item-use path in a configured Remote Runtime or Tauri game session with a real GM response.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- Local Playwright evidence was captured under `scratch/issue-1594-inventory-harness-after.png`; it is not embedded here because it is a local scratch artifact.
- Real app e2e screenshot evidence still needs a configured Remote Runtime or Tauri session.
