### PR TITLE
Harden refactor storage imports

### DIFF
--- a/src-tauri/src/commands/storage/imports/access.rs
+++ b/src-tauri/src/commands/storage/imports/access.rs
@@ -184,9 +184,9 @@ pub(super) fn resolve_import_folder(body: &Value) -> AppResult<PathBuf> {
     Ok(resolved)
 }
 
-pub(super) fn directory_listing(path: PathBuf, picker_selected: bool) -> AppResult<Value> {
+pub(super) fn directory_listing(path: PathBuf, _picker_selected: bool) -> AppResult<Value> {
     let path = canonical_directory(&path)?;
-    if !picker_selected && !is_home_contained(&path) && !is_allowed_import_root(&path) {
+    if !is_home_contained(&path) && !is_allowed_import_root(&path) {
         return Ok(json!({
             "success": false,
             "error": "Access denied: path outside home directory"
@@ -212,4 +212,26 @@ pub(super) fn directory_listing(path: PathBuf, picker_selected: bool) -> AppResu
         "folderToken": folder_token,
         "folders": folders
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn directory_listing_does_not_treat_picker_selected_as_unrestricted_access() {
+        let path = std::env::current_dir().expect("current dir should be available");
+        if is_home_contained(&path) || is_allowed_import_root(&path) {
+            return;
+        }
+
+        let result = directory_listing(path, true).expect("directory listing should return JSON");
+
+        assert_eq!(result["success"], false);
+        assert_eq!(
+            result["error"],
+            "Access denied: path outside home directory"
+        );
+        assert!(result.get("folderToken").is_none());
+    }
 }

--- a/src-tauri/src/commands/storage/imports/bulk_imports.rs
+++ b/src-tauri/src/commands/storage/imports/bulk_imports.rs
@@ -518,11 +518,14 @@ fn import_st_chat_text(
     let mut character_name = String::new();
     let mut character_ids = Vec::new();
     let mut parsed_rows = Vec::new();
-    for line in text.lines().map(str::trim).filter(|line| !line.is_empty()) {
-        let parsed = match parse_json_text(line) {
-            Ok(value) => value,
-            Err(_) => continue,
-        };
+    for (index, line) in text.lines().enumerate() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let parsed = parse_json_text(line).map_err(|error| {
+            AppError::invalid_input(format!("Invalid chat JSONL at line {}: {error}", index + 1))
+        })?;
         if character_name.is_empty() {
             if let Some(name) = parsed.get("character_name").and_then(Value::as_str) {
                 character_name = name.to_string();
@@ -539,6 +542,24 @@ fn import_st_chat_text(
             }
         }
         parsed_rows.push(parsed);
+    }
+    let has_importable_message = parsed_rows.iter().any(|row| {
+        if row
+            .get("is_system")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+        {
+            return false;
+        }
+        row.get("mes")
+            .or_else(|| row.get("content"))
+            .and_then(Value::as_str)
+            .is_some_and(|content| !content.trim().is_empty())
+    });
+    if !has_importable_message {
+        return Err(AppError::invalid_input(
+            "Chat import JSONL must contain at least one message",
+        ));
     }
     let mut chat = ensure_object(inherited.unwrap_or_else(|| json!({})))?;
     chat.remove("id");
@@ -1049,7 +1070,7 @@ mod tests {
             .duration_since(UNIX_EPOCH)
             .expect("system clock should be after epoch")
             .as_nanos();
-        std::env::temp_dir().join(format!(
+        home_dir().join(".marinara-test-temp").join(format!(
             "marinara-st-bulk-import-{label}-{}-{nonce}",
             std::process::id()
         ))
@@ -1333,6 +1354,31 @@ mod tests {
         assert!(
             messages[0].get("characterId").is_none_or(Value::is_null),
             "ST character_name alone should keep transcript messages unlinked"
+        );
+
+        let _ = fs::remove_dir_all(app_root);
+    }
+
+    #[test]
+    fn import_st_chat_text_rejects_empty_or_invalid_jsonl_without_creating_chat() {
+        let app_root = temp_path("chat-empty-invalid");
+        let state = AppState::from_data_dir(&app_root, Vec::new())
+            .expect("test app state should initialize");
+
+        let empty_error = import_st_chat_text(&state, " \n\n", "Empty".to_string(), None)
+            .expect_err("empty JSONL should be rejected");
+        assert_eq!(empty_error.code, "invalid_input");
+        assert!(
+            state.storage.list("chats").unwrap().is_empty(),
+            "empty JSONL must not create a chat"
+        );
+
+        let invalid_error = import_st_chat_text(&state, "{not-json}", "Invalid".to_string(), None)
+            .expect_err("invalid JSONL should be rejected");
+        assert_eq!(invalid_error.code, "invalid_input");
+        assert!(
+            state.storage.list("chats").unwrap().is_empty(),
+            "invalid JSONL must not create a chat"
         );
 
         let _ = fs::remove_dir_all(app_root);

--- a/src-tauri/src/commands/storage/imports/marinara.rs
+++ b/src-tauri/src/commands/storage/imports/marinara.rs
@@ -1,5 +1,13 @@
 use super::*;
 
+#[path = "marinara_assets.rs"]
+mod marinara_assets;
+#[path = "marinara_rollback.rs"]
+mod marinara_rollback;
+
+use marinara_assets::*;
+use marinara_rollback::*;
+
 const PROFILE_IMPORT_GUIDANCE: &str =
     "Full profile exports must be imported with Import Profile in Settings -> Import. Use Import Profile (JSON/ZIP) instead.";
 
@@ -179,208 +187,6 @@ fn array_from_envelope(data: &Value, envelope: &Map<String, Value>, key: &str) -
         .unwrap_or_default()
 }
 
-fn import_parented_records(
-    state: &AppState,
-    items: Vec<Value>,
-    collection: &str,
-    owner_field: &str,
-    owner_id: &str,
-    parent_field: &str,
-    label: &str,
-) -> AppResult<HashMap<String, String>> {
-    let mut created_ids = Vec::new();
-    let result = (|| -> AppResult<HashMap<String, String>> {
-        let mut id_map = HashMap::new();
-        let mut pending_parents = Vec::new();
-        for item in items {
-            let old_id = item
-                .get("id")
-                .and_then(Value::as_str)
-                .map(ToOwned::to_owned);
-            let old_parent_id = item
-                .get(parent_field)
-                .and_then(Value::as_str)
-                .map(ToOwned::to_owned);
-            let mut record = ensure_object(item)?;
-            record.remove("id");
-            record.remove(owner_field);
-            record.insert(owner_field.to_string(), Value::String(owner_id.to_string()));
-            if old_parent_id.is_some() {
-                record.insert(parent_field.to_string(), Value::Null);
-            }
-            let created = state.storage.create(collection, Value::Object(record))?;
-            let new_id = created_record_id(&created, label)?;
-            created_ids.push(new_id.clone());
-            if let Some(old_id) = old_id {
-                id_map.insert(old_id, new_id.clone());
-            }
-            if let Some(old_parent_id) = old_parent_id {
-                pending_parents.push((new_id, old_parent_id));
-            }
-        }
-        for (record_id, old_parent_id) in pending_parents {
-            if let Some(new_parent_id) = id_map.get(&old_parent_id) {
-                let mut patch = Map::new();
-                patch.insert(
-                    parent_field.to_string(),
-                    Value::String(new_parent_id.clone()),
-                );
-                state
-                    .storage
-                    .patch(collection, &record_id, Value::Object(patch))?;
-            }
-        }
-        Ok(id_map)
-    })();
-
-    result.map_err(|error| rollback_created_records(state, collection, &created_ids, error))
-}
-
-fn rollback_created_records(
-    state: &AppState,
-    collection: &str,
-    record_ids: &[String],
-    error: AppError,
-) -> AppError {
-    let mut rollback_errors = Vec::new();
-    for record_id in record_ids.iter().rev() {
-        if let Err(rollback_error) = state.storage.delete(collection, record_id) {
-            rollback_errors.push(format!("{record_id}: {rollback_error}"));
-        }
-    }
-    if rollback_errors.is_empty() {
-        error
-    } else {
-        AppError::new(
-            "storage_rollback_failed",
-            format!(
-                "{error}; additionally failed to roll back imported {collection} records: {}",
-                rollback_errors.join("; ")
-            ),
-        )
-    }
-}
-
-fn extension_from_filename(filename: &str) -> Option<&'static str> {
-    match Path::new(filename)
-        .extension()
-        .and_then(|value| value.to_str())
-        .unwrap_or("")
-        .to_ascii_lowercase()
-        .as_str()
-    {
-        "jpg" | "jpeg" => Some("jpg"),
-        "webp" => Some("webp"),
-        "gif" => Some("gif"),
-        "avif" => Some("avif"),
-        "png" => Some("png"),
-        "svg" => Some("svg"),
-        _ => None,
-    }
-}
-
-fn import_image_filename(raw: Option<&str>, fallback: &str, ext: &str) -> String {
-    let mut filename = raw
-        .filter(|value| !value.trim().is_empty())
-        .map(safe_filename)
-        .unwrap_or_else(|| format!("{}.{}", safe_filename(fallback), ext));
-    if Path::new(&filename).extension().is_none() {
-        filename.push('.');
-        filename.push_str(ext);
-    }
-    filename
-}
-
-fn restore_sprites(state: &AppState, target_id: &str, sprites: Option<&Value>) -> AppResult<usize> {
-    let Some(items) = sprites.and_then(Value::as_array) else {
-        return Ok(0);
-    };
-    if items.is_empty() || target_id.contains('/') || target_id.contains('\\') {
-        return Ok(0);
-    }
-    let dir = state.data_dir.join("sprites").join(target_id);
-    fs::create_dir_all(&dir)?;
-    let mut imported = 0usize;
-    for (index, sprite) in items.iter().enumerate() {
-        let Some(image) = sprite
-            .get("data")
-            .or_else(|| sprite.get("url"))
-            .and_then(Value::as_str)
-            .filter(|value| value.starts_with("data:image/"))
-        else {
-            continue;
-        };
-        let (mime, bytes) = decode_image_payload(image, "sprite")?;
-        let ext = extension_for_image_mime(&mime)
-            .or_else(|| {
-                sprite
-                    .get("filename")
-                    .and_then(Value::as_str)
-                    .and_then(extension_from_filename)
-            })
-            .unwrap_or("png");
-        let fallback = sprite
-            .get("expression")
-            .and_then(Value::as_str)
-            .filter(|value| !value.trim().is_empty())
-            .map(ToOwned::to_owned)
-            .unwrap_or_else(|| format!("sprite-{}", index + 1));
-        let filename = import_image_filename(
-            sprite.get("filename").and_then(Value::as_str),
-            &fallback,
-            ext,
-        );
-        let target = unique_file_path(&dir.join(filename))?;
-        fs::write(target, bytes)?;
-        imported += 1;
-    }
-    Ok(imported)
-}
-
-fn restore_character_gallery(
-    state: &AppState,
-    character_id: &str,
-    gallery: Option<&Value>,
-) -> AppResult<usize> {
-    let Some(items) = gallery.and_then(Value::as_array) else {
-        return Ok(0);
-    };
-    let mut imported = 0usize;
-    for (index, item) in items.iter().enumerate() {
-        let Some(data_url) = item
-            .get("data")
-            .or_else(|| item.get("url"))
-            .and_then(Value::as_str)
-            .filter(|value| value.starts_with("data:image/"))
-        else {
-            continue;
-        };
-        let (mime, _) = decode_image_payload(data_url, "gallery image")?;
-        let ext = extension_for_image_mime(&mime).unwrap_or("png");
-        let filename = import_image_filename(
-            item.get("filename").and_then(Value::as_str),
-            &format!("gallery-{}", index + 1),
-            ext,
-        );
-        state.storage.create(
-            "character-gallery",
-            json!({
-                "characterId": character_id,
-                "filePath": filename,
-                "filename": filename,
-                "url": data_url,
-                "prompt": item.get("prompt").cloned().unwrap_or_else(|| json!("")),
-                "provider": item.get("provider").cloned().unwrap_or_else(|| json!("")),
-                "model": item.get("model").cloned().unwrap_or_else(|| json!("")),
-                "width": item.get("width").cloned().unwrap_or(Value::Null),
-                "height": item.get("height").cloned().unwrap_or(Value::Null)
-            }),
-        )?;
-        imported += 1;
-    }
-    Ok(imported)
-}
-
 fn import_marinara_character(state: &AppState, data: Value) -> AppResult<Value> {
     if data.get("spec").is_some() && data.get("data").is_some_and(Value::is_object) {
         let mut character_data = data.get("data").cloned().unwrap_or_else(|| json!({}));
@@ -401,26 +207,50 @@ fn import_marinara_character(state: &AppState, data: Value) -> AppResult<Value> 
             }
         }
         apply_import_timestamps(&mut record, &data);
-        let character = state.storage.create("characters", record)?;
-        let character_id = created_record_id(&character, "character")?;
-        let sprites_imported = restore_sprites(state, &character_id, data.get("sprites"))?;
-        let gallery_imported =
-            restore_character_gallery(state, &character_id, data.get("gallery"))?;
         let name = character_data
             .get("name")
             .and_then(Value::as_str)
             .unwrap_or("Imported Character")
             .to_string();
-        return Ok(json!({
-            "success": true,
-            "type": "marinara_character",
-            "id": character_id,
-            "characterId": character_id,
-            "name": name,
-            "character": character,
-            "spritesImported": sprites_imported,
-            "galleryImported": gallery_imported
-        }));
+        let mut created_character_id = None;
+        let result = (|| -> AppResult<Value> {
+            let character = state.storage.create("characters", record)?;
+            let character_id = created_record_id(&character, "character")?;
+            created_character_id = Some(character_id.clone());
+            let sprites_imported = restore_sprites(state, &character_id, data.get("sprites"))?;
+            let gallery_imported =
+                restore_character_gallery(state, &character_id, data.get("gallery"))?;
+            Ok(json!({
+                "success": true,
+                "type": "marinara_character",
+                "id": character_id,
+                "characterId": character_id,
+                "name": name,
+                "character": character,
+                "spritesImported": sprites_imported,
+                "galleryImported": gallery_imported
+            }))
+        })();
+        return result.map_err(|error| {
+            let mut rollback_errors = Vec::new();
+            if let Some(character_id) = created_character_id.as_deref() {
+                rollback_records_by_field_collect(
+                    state,
+                    "character-gallery",
+                    "characterId",
+                    character_id,
+                    &mut rollback_errors,
+                );
+                rollback_managed_child_dir(state, "sprites", character_id, &mut rollback_errors);
+                rollback_created_records_collect(
+                    state,
+                    "characters",
+                    &[character_id.to_string()],
+                    &mut rollback_errors,
+                );
+            }
+            append_marinara_rollback_errors(error, "character import", rollback_errors)
+        });
     }
 
     let looks_like_storage_record = data.get("data").is_some()
@@ -449,28 +279,53 @@ fn import_marinara_character(state: &AppState, data: Value) -> AppResult<Value> 
         }
     }
     apply_import_timestamps(&mut record_value, &data);
-    let record = state.storage.create("characters", record_value)?;
-    let character_id = created_record_id(&record, "character")?;
-    let sprites_imported = restore_sprites(state, &character_id, data.get("sprites"))?;
-    let gallery_imported = restore_character_gallery(state, &character_id, data.get("gallery"))?;
-    let name = data_string_name(&record)
-        .or_else(|| {
-            record
-                .get("name")
-                .and_then(Value::as_str)
-                .map(ToOwned::to_owned)
-        })
-        .unwrap_or_else(|| "Imported Character".to_string());
-    Ok(json!({
-        "success": true,
-        "type": "marinara_character",
-        "id": record.get("id").cloned().unwrap_or(Value::Null),
-        "characterId": record.get("id").cloned().unwrap_or(Value::Null),
-        "name": name,
-        "character": record,
-        "spritesImported": sprites_imported,
-        "galleryImported": gallery_imported
-    }))
+    let mut created_character_id = None;
+    let result = (|| -> AppResult<Value> {
+        let record = state.storage.create("characters", record_value)?;
+        let character_id = created_record_id(&record, "character")?;
+        created_character_id = Some(character_id.clone());
+        let sprites_imported = restore_sprites(state, &character_id, data.get("sprites"))?;
+        let gallery_imported =
+            restore_character_gallery(state, &character_id, data.get("gallery"))?;
+        let name = data_string_name(&record)
+            .or_else(|| {
+                record
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .map(ToOwned::to_owned)
+            })
+            .unwrap_or_else(|| "Imported Character".to_string());
+        Ok(json!({
+            "success": true,
+            "type": "marinara_character",
+            "id": record.get("id").cloned().unwrap_or(Value::Null),
+            "characterId": record.get("id").cloned().unwrap_or(Value::Null),
+            "name": name,
+            "character": record,
+            "spritesImported": sprites_imported,
+            "galleryImported": gallery_imported
+        }))
+    })();
+    result.map_err(|error| {
+        let mut rollback_errors = Vec::new();
+        if let Some(character_id) = created_character_id.as_deref() {
+            rollback_records_by_field_collect(
+                state,
+                "character-gallery",
+                "characterId",
+                character_id,
+                &mut rollback_errors,
+            );
+            rollback_managed_child_dir(state, "sprites", character_id, &mut rollback_errors);
+            rollback_created_records_collect(
+                state,
+                "characters",
+                &[character_id.to_string()],
+                &mut rollback_errors,
+            );
+        }
+        append_marinara_rollback_errors(error, "character import", rollback_errors)
+    })
 }
 
 fn import_marinara_persona(state: &AppState, data: Value) -> AppResult<Value> {
@@ -484,16 +339,33 @@ fn import_marinara_persona(state: &AppState, data: Value) -> AppResult<Value> {
         }
     }
     apply_import_timestamps(&mut record_value, &data);
-    let record = state.storage.create("personas", record_value)?;
-    let persona_id = created_record_id(&record, "persona")?;
-    let sprites_imported = restore_sprites(state, &persona_id, data.get("sprites"))?;
-    Ok(json!({
-        "success": true,
-        "type": "marinara_persona",
-        "id": record.get("id").cloned().unwrap_or(Value::Null),
-        "name": record.get("name").cloned().unwrap_or(Value::Null),
-        "spritesImported": sprites_imported
-    }))
+    let mut created_persona_id = None;
+    let result = (|| -> AppResult<Value> {
+        let record = state.storage.create("personas", record_value)?;
+        let persona_id = created_record_id(&record, "persona")?;
+        created_persona_id = Some(persona_id.clone());
+        let sprites_imported = restore_sprites(state, &persona_id, data.get("sprites"))?;
+        Ok(json!({
+            "success": true,
+            "type": "marinara_persona",
+            "id": record.get("id").cloned().unwrap_or(Value::Null),
+            "name": record.get("name").cloned().unwrap_or(Value::Null),
+            "spritesImported": sprites_imported
+        }))
+    })();
+    result.map_err(|error| {
+        let mut rollback_errors = Vec::new();
+        if let Some(persona_id) = created_persona_id.as_deref() {
+            rollback_managed_child_dir(state, "sprites", persona_id, &mut rollback_errors);
+            rollback_created_records_collect(
+                state,
+                "personas",
+                &[persona_id.to_string()],
+                &mut rollback_errors,
+            );
+        }
+        append_marinara_rollback_errors(error, "persona import", rollback_errors)
+    })
 }
 
 fn import_marinara_lorebook(
@@ -533,48 +405,81 @@ fn import_marinara_lorebook(
         }
     }
     apply_import_timestamps(&mut lorebook, &lorebook_data);
-    let record = state.storage.create("lorebooks", lorebook)?;
-    let lorebook_id = created_record_id(&record, "lorebook")?;
-    let folder_id_map = import_parented_records(
-        state,
-        array_from_envelope(&data, envelope, "folders"),
-        "lorebook-folders",
-        "lorebookId",
-        &lorebook_id,
-        "parentFolderId",
-        "lorebook folder",
-    )?;
+    let mut created_lorebook_id = None;
+    let mut created_folder_ids = Vec::new();
+    let mut created_entry_ids = Vec::new();
+    let result = (|| -> AppResult<Value> {
+        let record = state.storage.create("lorebooks", lorebook)?;
+        let lorebook_id = created_record_id(&record, "lorebook")?;
+        created_lorebook_id = Some(lorebook_id.clone());
+        let folder_id_map = import_parented_records(
+            state,
+            array_from_envelope(&data, envelope, "folders"),
+            "lorebook-folders",
+            "lorebookId",
+            &lorebook_id,
+            "parentFolderId",
+            "lorebook folder",
+        )?;
+        created_folder_ids.extend(folder_id_map.values().cloned());
 
-    let mut exported_entries = array_from_envelope(&data, envelope, "entries");
-    if exported_entries.is_empty() {
-        exported_entries = lorebook_entries(&data);
-    }
-    for (index, entry) in exported_entries.iter().enumerate() {
-        let mut normalized = normalize_imported_lorebook_entry(&lorebook_id, entry, index);
-        if let Some(old_folder_id) = entry.get("folderId").and_then(Value::as_str) {
-            if let Some(object) = normalized.as_object_mut() {
-                object.insert(
-                    "folderId".to_string(),
-                    folder_id_map
-                        .get(old_folder_id)
-                        .map(|id| Value::String(id.clone()))
-                        .unwrap_or(Value::Null),
-                );
-            }
+        let mut exported_entries = array_from_envelope(&data, envelope, "entries");
+        if exported_entries.is_empty() {
+            exported_entries = lorebook_entries(&data);
         }
-        state.storage.create("lorebook-entries", normalized)?;
-    }
+        for (index, entry) in exported_entries.iter().enumerate() {
+            let mut normalized = normalize_imported_lorebook_entry(&lorebook_id, entry, index);
+            if let Some(old_folder_id) = entry.get("folderId").and_then(Value::as_str) {
+                if let Some(object) = normalized.as_object_mut() {
+                    object.insert(
+                        "folderId".to_string(),
+                        folder_id_map
+                            .get(old_folder_id)
+                            .map(|id| Value::String(id.clone()))
+                            .unwrap_or(Value::Null),
+                    );
+                }
+            }
+            let entry_record = state.storage.create("lorebook-entries", normalized)?;
+            created_entry_ids.push(created_record_id(&entry_record, "lorebook entry")?);
+        }
 
-    Ok(json!({
-        "success": true,
-        "type": "marinara_lorebook",
-        "id": lorebook_id,
-        "lorebookId": lorebook_id,
-        "name": record.get("name").cloned().unwrap_or(Value::Null),
-        "entriesImported": exported_entries.len(),
-        "foldersImported": folder_id_map.len(),
-        "lorebook": record
-    }))
+        Ok(json!({
+            "success": true,
+            "type": "marinara_lorebook",
+            "id": lorebook_id,
+            "lorebookId": lorebook_id,
+            "name": record.get("name").cloned().unwrap_or(Value::Null),
+            "entriesImported": exported_entries.len(),
+            "foldersImported": folder_id_map.len(),
+            "lorebook": record
+        }))
+    })();
+
+    result.map_err(|error| {
+        let mut rollback_errors = Vec::new();
+        rollback_created_records_collect(
+            state,
+            "lorebook-entries",
+            &created_entry_ids,
+            &mut rollback_errors,
+        );
+        rollback_created_records_collect(
+            state,
+            "lorebook-folders",
+            &created_folder_ids,
+            &mut rollback_errors,
+        );
+        if let Some(lorebook_id) = created_lorebook_id.as_deref() {
+            rollback_created_records_collect(
+                state,
+                "lorebooks",
+                &[lorebook_id.to_string()],
+                &mut rollback_errors,
+            );
+        }
+        append_marinara_rollback_errors(error, "lorebook import", rollback_errors)
+    })
 }
 
 fn import_marinara_preset(
@@ -590,65 +495,106 @@ fn import_marinara_preset(
     );
     let mut record_value = with_entity_defaults("prompts", preset_data.clone())?;
     apply_import_timestamps(&mut record_value, &preset_data);
-    let record = state.storage.create("prompts", record_value)?;
-    let preset_id = created_record_id(&record, "preset")?;
-    let group_id_map = import_parented_records(
-        state,
-        array_from_envelope(&data, envelope, "groups"),
-        "prompt-groups",
-        "presetId",
-        &preset_id,
-        "parentGroupId",
-        "prompt group",
-    )?;
+    let mut created_preset_id = None;
+    let mut created_group_ids = Vec::new();
+    let mut created_section_ids = Vec::new();
+    let mut created_variable_ids = Vec::new();
+    let result = (|| -> AppResult<Value> {
+        let record = state.storage.create("prompts", record_value)?;
+        let preset_id = created_record_id(&record, "preset")?;
+        created_preset_id = Some(preset_id.clone());
+        let group_id_map = import_parented_records(
+            state,
+            array_from_envelope(&data, envelope, "groups"),
+            "prompt-groups",
+            "presetId",
+            &preset_id,
+            "parentGroupId",
+            "prompt group",
+        )?;
+        created_group_ids.extend(group_id_map.values().cloned());
 
-    let mut sections_imported = 0usize;
-    for section in array_from_envelope(&data, envelope, "sections") {
-        let mut section_record = ensure_object(section)?;
-        section_record.remove("id");
-        section_record.remove("presetId");
-        section_record.insert("presetId".to_string(), Value::String(preset_id.clone()));
-        if section_record.contains_key("groupId") {
-            let group_id = section_record
-                .get("groupId")
-                .and_then(Value::as_str)
-                .and_then(|old_group_id| group_id_map.get(old_group_id))
-                .map(|id| Value::String(id.clone()))
-                .unwrap_or(Value::Null);
-            section_record.insert("groupId".to_string(), group_id);
+        let mut sections_imported = 0usize;
+        for section in array_from_envelope(&data, envelope, "sections") {
+            let mut section_record = ensure_object(section)?;
+            section_record.remove("id");
+            section_record.remove("presetId");
+            section_record.insert("presetId".to_string(), Value::String(preset_id.clone()));
+            if section_record.contains_key("groupId") {
+                let group_id = section_record
+                    .get("groupId")
+                    .and_then(Value::as_str)
+                    .and_then(|old_group_id| group_id_map.get(old_group_id))
+                    .map(|id| Value::String(id.clone()))
+                    .unwrap_or(Value::Null);
+                section_record.insert("groupId".to_string(), group_id);
+            }
+            let section = state
+                .storage
+                .create("prompt-sections", Value::Object(section_record))?;
+            created_section_ids.push(created_record_id(&section, "prompt section")?);
+            sections_imported += 1;
         }
-        state
-            .storage
-            .create("prompt-sections", Value::Object(section_record))?;
-        sections_imported += 1;
-    }
 
-    let mut variables_imported = 0usize;
-    let mut variables = array_from_envelope(&data, envelope, "choiceBlocks");
-    if variables.is_empty() {
-        variables = array_from_envelope(&data, envelope, "variables");
-    }
-    for variable in variables {
-        let mut variable_record = ensure_object(variable)?;
-        variable_record.remove("id");
-        variable_record.remove("presetId");
-        variable_record.insert("presetId".to_string(), Value::String(preset_id.clone()));
-        state
-            .storage
-            .create("prompt-variables", Value::Object(variable_record))?;
-        variables_imported += 1;
-    }
+        let mut variables_imported = 0usize;
+        let mut variables = array_from_envelope(&data, envelope, "choiceBlocks");
+        if variables.is_empty() {
+            variables = array_from_envelope(&data, envelope, "variables");
+        }
+        for variable in variables {
+            let mut variable_record = ensure_object(variable)?;
+            variable_record.remove("id");
+            variable_record.remove("presetId");
+            variable_record.insert("presetId".to_string(), Value::String(preset_id.clone()));
+            let variable = state
+                .storage
+                .create("prompt-variables", Value::Object(variable_record))?;
+            created_variable_ids.push(created_record_id(&variable, "prompt variable")?);
+            variables_imported += 1;
+        }
 
-    Ok(json!({
-        "success": true,
-        "type": "marinara_preset",
-        "id": preset_id,
-        "name": record.get("name").cloned().unwrap_or(Value::Null),
-        "preset": record,
-        "groupsImported": group_id_map.len(),
-        "sectionsImported": sections_imported,
-        "variablesImported": variables_imported
-    }))
+        Ok(json!({
+            "success": true,
+            "type": "marinara_preset",
+            "id": preset_id,
+            "name": record.get("name").cloned().unwrap_or(Value::Null),
+            "preset": record,
+            "groupsImported": group_id_map.len(),
+            "sectionsImported": sections_imported,
+            "variablesImported": variables_imported
+        }))
+    })();
+
+    result.map_err(|error| {
+        let mut rollback_errors = Vec::new();
+        rollback_created_records_collect(
+            state,
+            "prompt-variables",
+            &created_variable_ids,
+            &mut rollback_errors,
+        );
+        rollback_created_records_collect(
+            state,
+            "prompt-sections",
+            &created_section_ids,
+            &mut rollback_errors,
+        );
+        rollback_created_records_collect(
+            state,
+            "prompt-groups",
+            &created_group_ids,
+            &mut rollback_errors,
+        );
+        if let Some(preset_id) = created_preset_id.as_deref() {
+            rollback_created_records_collect(
+                state,
+                "prompts",
+                &[preset_id.to_string()],
+                &mut rollback_errors,
+            );
+        }
+        append_marinara_rollback_errors(error, "preset import", rollback_errors)
+    })
 }
 
 pub(super) fn import_marinara_envelope(state: &AppState, envelope: Value) -> AppResult<Value> {

--- a/src-tauri/src/commands/storage/imports/marinara_assets.rs
+++ b/src-tauri/src/commands/storage/imports/marinara_assets.rs
@@ -1,0 +1,125 @@
+use super::*;
+
+fn extension_from_filename(filename: &str) -> Option<&'static str> {
+    match Path::new(filename)
+        .extension()
+        .and_then(|value| value.to_str())
+        .unwrap_or("")
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "jpg" | "jpeg" => Some("jpg"),
+        "webp" => Some("webp"),
+        "gif" => Some("gif"),
+        "avif" => Some("avif"),
+        "png" => Some("png"),
+        "svg" => Some("svg"),
+        _ => None,
+    }
+}
+
+fn import_image_filename(raw: Option<&str>, fallback: &str, ext: &str) -> String {
+    let mut filename = raw
+        .filter(|value| !value.trim().is_empty())
+        .map(safe_filename)
+        .unwrap_or_else(|| format!("{}.{}", safe_filename(fallback), ext));
+    if Path::new(&filename).extension().is_none() {
+        filename.push('.');
+        filename.push_str(ext);
+    }
+    filename
+}
+
+pub(super) fn restore_sprites(
+    state: &AppState,
+    target_id: &str,
+    sprites: Option<&Value>,
+) -> AppResult<usize> {
+    let Some(items) = sprites.and_then(Value::as_array) else {
+        return Ok(0);
+    };
+    if items.is_empty() || target_id.contains('/') || target_id.contains('\\') {
+        return Ok(0);
+    }
+    let dir = state.data_dir.join("sprites").join(target_id);
+    fs::create_dir_all(&dir)?;
+    let mut imported = 0usize;
+    for (index, sprite) in items.iter().enumerate() {
+        let Some(image) = sprite
+            .get("data")
+            .or_else(|| sprite.get("url"))
+            .and_then(Value::as_str)
+            .filter(|value| value.starts_with("data:image/"))
+        else {
+            continue;
+        };
+        let (mime, bytes) = decode_image_payload(image, "sprite")?;
+        let ext = extension_for_image_mime(&mime)
+            .or_else(|| {
+                sprite
+                    .get("filename")
+                    .and_then(Value::as_str)
+                    .and_then(extension_from_filename)
+            })
+            .unwrap_or("png");
+        let fallback = sprite
+            .get("expression")
+            .and_then(Value::as_str)
+            .filter(|value| !value.trim().is_empty())
+            .map(ToOwned::to_owned)
+            .unwrap_or_else(|| format!("sprite-{}", index + 1));
+        let filename = import_image_filename(
+            sprite.get("filename").and_then(Value::as_str),
+            &fallback,
+            ext,
+        );
+        let target = unique_file_path(&dir.join(filename))?;
+        fs::write(target, bytes)?;
+        imported += 1;
+    }
+    Ok(imported)
+}
+
+pub(super) fn restore_character_gallery(
+    state: &AppState,
+    character_id: &str,
+    gallery: Option<&Value>,
+) -> AppResult<usize> {
+    let Some(items) = gallery.and_then(Value::as_array) else {
+        return Ok(0);
+    };
+    let mut imported = 0usize;
+    for (index, item) in items.iter().enumerate() {
+        let Some(data_url) = item
+            .get("data")
+            .or_else(|| item.get("url"))
+            .and_then(Value::as_str)
+            .filter(|value| value.starts_with("data:image/"))
+        else {
+            continue;
+        };
+        let (mime, _) = decode_image_payload(data_url, "gallery image")?;
+        let ext = extension_for_image_mime(&mime).unwrap_or("png");
+        let filename = import_image_filename(
+            item.get("filename").and_then(Value::as_str),
+            &format!("gallery-{}", index + 1),
+            ext,
+        );
+        state.storage.create(
+            "character-gallery",
+            json!({
+                "characterId": character_id,
+                "filePath": filename,
+                "filename": filename,
+                "url": data_url,
+                "prompt": item.get("prompt").cloned().unwrap_or_else(|| json!("")),
+                "provider": item.get("provider").cloned().unwrap_or_else(|| json!("")),
+                "model": item.get("model").cloned().unwrap_or_else(|| json!("")),
+                "width": item.get("width").cloned().unwrap_or(Value::Null),
+                "height": item.get("height").cloned().unwrap_or(Value::Null)
+            }),
+        )?;
+        imported += 1;
+    }
+    Ok(imported)
+}

--- a/src-tauri/src/commands/storage/imports/marinara_rollback.rs
+++ b/src-tauri/src/commands/storage/imports/marinara_rollback.rs
@@ -1,0 +1,146 @@
+use super::*;
+
+pub(super) fn import_parented_records(
+    state: &AppState,
+    items: Vec<Value>,
+    collection: &str,
+    owner_field: &str,
+    owner_id: &str,
+    parent_field: &str,
+    label: &str,
+) -> AppResult<HashMap<String, String>> {
+    let mut created_ids = Vec::new();
+    let result = (|| -> AppResult<HashMap<String, String>> {
+        let mut id_map = HashMap::new();
+        let mut pending_parents = Vec::new();
+        for item in items {
+            let old_id = item
+                .get("id")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned);
+            let old_parent_id = item
+                .get(parent_field)
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned);
+            let mut record = ensure_object(item)?;
+            record.remove("id");
+            record.remove(owner_field);
+            record.insert(owner_field.to_string(), Value::String(owner_id.to_string()));
+            if old_parent_id.is_some() {
+                record.insert(parent_field.to_string(), Value::Null);
+            }
+            let created = state.storage.create(collection, Value::Object(record))?;
+            let new_id = created_record_id(&created, label)?;
+            created_ids.push(new_id.clone());
+            if let Some(old_id) = old_id {
+                id_map.insert(old_id, new_id.clone());
+            }
+            if let Some(old_parent_id) = old_parent_id {
+                pending_parents.push((new_id, old_parent_id));
+            }
+        }
+        for (record_id, old_parent_id) in pending_parents {
+            if let Some(new_parent_id) = id_map.get(&old_parent_id) {
+                let mut patch = Map::new();
+                patch.insert(
+                    parent_field.to_string(),
+                    Value::String(new_parent_id.clone()),
+                );
+                state
+                    .storage
+                    .patch(collection, &record_id, Value::Object(patch))?;
+            }
+        }
+        Ok(id_map)
+    })();
+
+    result.map_err(|error| rollback_created_records_error(state, collection, &created_ids, error))
+}
+
+fn rollback_created_records_error(
+    state: &AppState,
+    collection: &str,
+    record_ids: &[String],
+    error: AppError,
+) -> AppError {
+    let mut rollback_errors = Vec::new();
+    rollback_created_records_collect(state, collection, record_ids, &mut rollback_errors);
+    append_marinara_rollback_errors(
+        error,
+        &format!("imported {collection} records"),
+        rollback_errors,
+    )
+}
+
+pub(super) fn rollback_created_records_collect(
+    state: &AppState,
+    collection: &str,
+    record_ids: &[String],
+    rollback_errors: &mut Vec<String>,
+) {
+    for record_id in record_ids.iter().rev() {
+        if let Err(rollback_error) = state.storage.delete(collection, record_id) {
+            rollback_errors.push(format!("{record_id}: {rollback_error}"));
+        }
+    }
+}
+
+pub(super) fn rollback_records_by_field_collect(
+    state: &AppState,
+    collection: &str,
+    field: &str,
+    value: &str,
+    rollback_errors: &mut Vec<String>,
+) {
+    let mut filters = Map::new();
+    filters.insert(field.to_string(), Value::String(value.to_string()));
+    if let Err(error) = state.storage.delete_where(collection, &filters) {
+        rollback_errors.push(format!("{collection} where {field}={value}: {error}"));
+    }
+}
+
+pub(super) fn rollback_managed_child_dir(
+    state: &AppState,
+    root: &str,
+    child: &str,
+    rollback_errors: &mut Vec<String>,
+) {
+    if child.trim().is_empty() || child.contains('/') || child.contains('\\') {
+        rollback_errors.push(format!("{root}/{child}: invalid managed child id"));
+        return;
+    }
+    let path = state.data_dir.join(root).join(child);
+    let metadata = match fs::symlink_metadata(&path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return,
+        Err(error) => {
+            rollback_errors.push(format!("{}: {error}", path.display()));
+            return;
+        }
+    };
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        rollback_errors.push(format!("{} is not a managed directory", path.display()));
+        return;
+    }
+    if let Err(error) = fs::remove_dir_all(&path) {
+        rollback_errors.push(format!("{}: {error}", path.display()));
+    }
+}
+
+pub(super) fn append_marinara_rollback_errors(
+    error: AppError,
+    context: &str,
+    rollback_errors: Vec<String>,
+) -> AppError {
+    if rollback_errors.is_empty() {
+        error
+    } else {
+        AppError::new(
+            "storage_rollback_failed",
+            format!(
+                "{error}; additionally failed to roll back {context}: {}",
+                rollback_errors.join("; ")
+            ),
+        )
+    }
+}

--- a/src-tauri/src/commands/storage/imports/marinara_tests.rs
+++ b/src-tauri/src/commands/storage/imports/marinara_tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::state::AppState;
+use std::fs;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 fn test_state(label: &str) -> AppState {
@@ -26,6 +27,21 @@ fn test_string<'a>(record: &'a Value, field: &str) -> &'a str {
         .get(field)
         .and_then(Value::as_str)
         .expect("expected record field to be a string")
+}
+
+fn block_collection_writes(state: &AppState, collection: &str) {
+    let collection_path = state
+        .storage
+        .root()
+        .join("collections")
+        .join(format!("{collection}.json"));
+    if let Some(parent) = collection_path.parent() {
+        fs::create_dir_all(parent).expect("collection parent should be created");
+    }
+    if collection_path.is_file() {
+        fs::remove_file(&collection_path).expect("seeded collection file should be removable");
+    }
+    fs::create_dir(collection_path).expect("collection path should block file writes");
 }
 
 #[test]
@@ -86,6 +102,72 @@ fn parented_record_import_rolls_back_created_records_on_failure() {
         .filter(|group| group.get("presetId").and_then(Value::as_str) == Some(owner_id))
         .collect::<Vec<_>>();
     assert!(remaining.is_empty());
+}
+
+#[test]
+fn generic_marinara_lorebook_import_rolls_back_outer_records_on_entry_failure() {
+    let state = test_state("generic-lorebook-outer-rollback");
+    block_collection_writes(&state, "lorebook-entries");
+
+    let error = import_marinara_envelope(
+        &state,
+        json!({
+            "type": "marinara_lorebook",
+            "version": 1,
+            "data": {
+                "lorebook": { "id": "old-book", "name": "Rollback Lorebook" },
+                "folders": [
+                    { "id": "old-root", "name": "Root", "lorebookId": "old-book" }
+                ],
+                "entries": [
+                    { "id": "old-entry", "name": "Entry", "content": "body", "keys": ["rollback"] }
+                ]
+            }
+        }),
+    )
+    .expect_err("entry storage failure should reject lorebook import");
+
+    assert_eq!(error.code, "io_error");
+    assert!(state.storage.list("lorebooks").unwrap().is_empty());
+    assert!(state.storage.list("lorebook-folders").unwrap().is_empty());
+}
+
+#[test]
+fn generic_marinara_preset_import_rolls_back_outer_records_on_section_failure() {
+    let state = test_state("generic-preset-outer-rollback");
+    block_collection_writes(&state, "prompt-sections");
+
+    let error = import_marinara_envelope(
+        &state,
+        json!({
+            "type": "marinara_preset",
+            "version": 1,
+            "data": {
+                "preset": { "id": "old-preset", "name": "Rollback Preset" },
+                "groups": [
+                    { "id": "old-root", "name": "Root", "presetId": "old-preset" }
+                ],
+                "sections": [
+                    { "id": "old-section", "name": "Section", "content": "hello", "presetId": "old-preset" }
+                ]
+            }
+        }),
+    )
+    .expect_err("section storage failure should reject preset import");
+
+    assert_eq!(error.code, "io_error");
+    assert!(state
+        .storage
+        .list("prompts")
+        .unwrap()
+        .iter()
+        .all(|prompt| prompt.get("name").and_then(Value::as_str) != Some("Rollback Preset")));
+    assert!(state
+        .storage
+        .list("prompt-groups")
+        .unwrap()
+        .iter()
+        .all(|group| group.get("name").and_then(Value::as_str) != Some("Root")));
 }
 
 #[test]

--- a/src-tauri/src/commands/storage/profile.rs
+++ b/src-tauri/src/commands/storage/profile.rs
@@ -155,6 +155,7 @@ fn import_profile_collections(
     data: &Map<String, Value>,
     collections: &Map<String, Value>,
 ) -> AppResult<Value> {
+    validate_native_profile_import(data, collections)?;
     let mut restored_assets = restore_profile_assets(state, data.get("assets"))?;
     let restored_count = restored_assets.restored();
     let result =
@@ -162,6 +163,41 @@ fn import_profile_collections(
             restored_assets.install()
         });
     finish_profile_import_assets(restored_assets, result)
+}
+
+pub(super) fn validate_native_profile_import(
+    data: &Map<String, Value>,
+    collections: &Map<String, Value>,
+) -> AppResult<()> {
+    match data.get("assets") {
+        Some(Value::Array(_)) => {}
+        Some(_) => {
+            return Err(AppError::invalid_input(
+                "Profile export data.assets must be a JSON array",
+            ));
+        }
+        None => {
+            return Err(AppError::invalid_input(
+                "Native profile export is missing data.assets",
+            ));
+        }
+    }
+    for collection in PROFILE_COLLECTIONS {
+        match collections.get(*collection) {
+            Some(Value::Array(_)) => {}
+            Some(_) => {
+                return Err(AppError::invalid_input(format!(
+                    "Profile collection `{collection}` must be a JSON array"
+                )));
+            }
+            None => {
+                return Err(AppError::invalid_input(format!(
+                    "Native profile export is missing collection `{collection}`"
+                )));
+            }
+        }
+    }
+    Ok(())
 }
 
 pub(super) fn import_profile_collections_with_restored_assets<F>(
@@ -374,6 +410,104 @@ mod tests {
             state.storage.list("characters").unwrap()[0]["id"],
             "old-character"
         );
+    }
+
+    #[test]
+    fn native_profile_import_rejects_missing_assets_without_wiping_existing_assets() {
+        let state = test_state("missing-assets-no-wipe");
+        let avatar_dir = state.data_dir.join("avatars");
+        std::fs::create_dir_all(&avatar_dir).expect("avatar dir should be created");
+        std::fs::write(avatar_dir.join("keep.png"), b"keep").expect("avatar fixture should write");
+        let collections = complete_empty_profile_collections();
+
+        let error = import_profile(
+            &state,
+            json!({
+                "type": "marinara_profile",
+                "version": 1,
+                "data": {
+                    "collections": collections
+                }
+            }),
+        )
+        .expect_err("native profile missing data.assets should be rejected");
+
+        assert_eq!(error.code, "invalid_input");
+        assert_eq!(
+            std::fs::read(avatar_dir.join("keep.png")).expect("avatar should remain"),
+            b"keep"
+        );
+    }
+
+    #[test]
+    fn native_profile_import_rejects_missing_collection_without_wiping_existing_rows() {
+        let state = test_state("missing-collection-no-wipe");
+        state
+            .storage
+            .upsert_with_id(
+                "characters",
+                "char-1",
+                json!({ "name": "Keep Me", "data": { "name": "Keep Me" } }),
+            )
+            .expect("seeded character should write");
+        let mut collections = complete_empty_profile_collections();
+        collections.remove("characters");
+
+        let error = import_profile(
+            &state,
+            json!({
+                "type": "marinara_profile",
+                "version": 1,
+                "data": {
+                    "collections": collections,
+                    "assets": []
+                }
+            }),
+        )
+        .expect_err("native profile missing a collection should be rejected");
+
+        assert_eq!(error.code, "invalid_input");
+        assert!(state
+            .storage
+            .get("characters", "char-1")
+            .expect("character lookup should not fail")
+            .is_some());
+    }
+
+    #[test]
+    fn legacy_profile_import_without_files_preserves_existing_assets() {
+        let state = test_state("legacy-missing-files-preserves-assets");
+        let avatar_dir = state.data_dir.join("avatars");
+        std::fs::create_dir_all(&avatar_dir).expect("avatar dir should be created");
+        std::fs::write(avatar_dir.join("keep.png"), b"keep").expect("avatar fixture should write");
+
+        import_profile(
+            &state,
+            json!({
+                "type": "marinara_profile",
+                "version": 1,
+                "data": {
+                    "fileStorage": {
+                        "tables": {
+                            "chats": []
+                        }
+                    }
+                }
+            }),
+        )
+        .expect("legacy profile without files should import partial tables");
+
+        assert_eq!(
+            std::fs::read(avatar_dir.join("keep.png")).expect("avatar should remain"),
+            b"keep"
+        );
+    }
+
+    fn complete_empty_profile_collections() -> Map<String, Value> {
+        PROFILE_COLLECTIONS
+            .iter()
+            .map(|collection| ((*collection).to_string(), json!([])))
+            .collect()
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/profile/assets.rs
+++ b/src-tauri/src/commands/storage/profile/assets.rs
@@ -266,11 +266,20 @@ fn collect_profile_assets(
     inline_bytes: bool,
 ) -> AppResult<()> {
     let dir = root.join(relative);
-    if !dir.exists() {
+    let dir_metadata = match fs::symlink_metadata(&dir) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error.into()),
+    };
+    if dir_metadata.file_type().is_symlink() || !dir_metadata.is_dir() {
         return Ok(());
     }
     for entry in fs::read_dir(&dir)? {
         let path = entry?.path();
+        let metadata = fs::symlink_metadata(&path)?;
+        if metadata.file_type().is_symlink() {
+            continue;
+        }
         let Some(name) = path.file_name().and_then(|value| value.to_str()) else {
             continue;
         };
@@ -278,9 +287,9 @@ fn collect_profile_assets(
             continue;
         }
         let next_relative = relative.join(name);
-        if path.is_dir() {
+        if metadata.is_dir() {
             collect_profile_assets(root, &next_relative, assets, inline_bytes)?;
-        } else if path.is_file() {
+        } else if metadata.is_file() {
             let mut asset = json!({
                 "path": profile_relative_path(&next_relative),
             });
@@ -293,7 +302,7 @@ fn collect_profile_assets(
                     Value::String(general_purpose::STANDARD.encode(fs::read(path)?)),
                 );
             } else {
-                object.insert("size".to_string(), json!(fs::metadata(path)?.len()));
+                object.insert("size".to_string(), json!(metadata.len()));
             }
             assets.push(asset);
         }
@@ -328,6 +337,12 @@ fn restore_profile_json_assets_in_root(
     raw_assets: Option<&Value>,
     allow_legacy_data_field: bool,
 ) -> AppResult<RestoredProfileAssets> {
+    if raw_assets.is_none() {
+        return Ok(RestoredProfileAssets {
+            restored: 0,
+            transaction: None,
+        });
+    }
     let assets = decoded_profile_json_assets(raw_assets, allow_legacy_data_field)?;
     let restored = assets.len();
     let transaction = ProfileAssetTransaction::new(data_dir)?;
@@ -380,6 +395,12 @@ pub(super) fn restore_profile_zip_assets<R: Read + Seek>(
     profile_prefix: &str,
     raw_assets: Option<&Value>,
 ) -> AppResult<RestoredProfileAssets> {
+    if raw_assets.is_none() {
+        return Ok(RestoredProfileAssets {
+            restored: 0,
+            transaction: None,
+        });
+    }
     let assets = decoded_profile_zip_assets(raw_assets, names, profile_prefix)?;
     let restored = assets.len();
     let transaction = ProfileAssetTransaction::new(&state.data_dir)?;

--- a/src-tauri/src/commands/storage/profile/zip_import.rs
+++ b/src-tauri/src/commands/storage/profile/zip_import.rs
@@ -1,7 +1,7 @@
 use super::assets::{normalize_zip_entry_name, restore_profile_zip_assets};
 use super::{
     finish_profile_import_assets, import_profile_collections_with_restored_assets,
-    legacy::import_legacy_profile_tables_with_restored_assets,
+    legacy::import_legacy_profile_tables_with_restored_assets, validate_native_profile_import,
 };
 use crate::state::AppState;
 use marinara_core::{AppError, AppResult};
@@ -35,6 +35,7 @@ pub(super) fn import_profile_zip(state: &AppState, path: &Path) -> AppResult<Val
         .and_then(|value| value.get("files"))
         .or_else(|| data.get("assets"));
     if let Some(collections) = data.get("collections").and_then(Value::as_object) {
+        validate_native_profile_import(data, collections)?;
         let mut restored_assets =
             restore_profile_zip_assets(state, &mut archive, &names, &profile_prefix, files)?;
         let restored_count = restored_assets.restored();


### PR DESCRIPTION
﻿<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

N/A - refactor readiness blocker found during boundary/data-contract review.

## Why this change

Storage/import behavior is a high-risk refactor boundary because profile imports, ST imports, managed assets, and generic Marinara imports can affect existing user data. The review found cases where missing current-profile collections or assets could be treated like empty replacement data, ST import selection trusted client-provided picker state, and nested generic imports could leave partial records behind after a failure.

## What changed

- Reject incomplete current profile imports before replacing existing rows or managed assets.
- Preserve existing managed assets when importing legacy profiles without asset manifests.
- Add rollback coverage for collection replacement plus asset install failures.
- Stop treating client `pickerSelected` as unrestricted directory access for ST bulk import.
- Reject empty or invalid ST chat JSONL before creating chats while preserving upstream Marinara JSONL role and character-id handling.
- Roll back nested Marinara preset/lorebook imports when child entry/group creation fails.
- Split Marinara import asset/rollback helpers out of the large import module.

## Refactor impact

Primary owner:

Rust storage and imports.

Impact areas reviewed:

- Profile import/export safety.
- Managed asset restore behavior.
- SillyTavern bulk import access and chat JSONL handling.
- Generic Marinara preset/lorebook import rollback.

Boundary notes:

- Keeps destructive storage behavior inside `src-tauri`.
- Does not move product behavior into React or `src/shared/api`.
- Uses Rust-side validation and rollback instead of UI-only guards or fake success.

Pressure points touched:

- `src-tauri/src/commands/storage/profile.rs`
- `src-tauri/src/commands/storage/profile/assets.rs`
- `src-tauri/src/commands/storage/imports/bulk_imports.rs`
- `src-tauri/src/commands/storage/imports/marinara.rs`

## Validation

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

Codex-run proof:

- `pnpm check` passed in `scratch/refactor-lane-worktrees/storage`.
- `cargo test --manifest-path src-tauri\Cargo.toml bulk_imports` passed: 10 tests.
- `cargo test --manifest-path src-tauri\Cargo.toml marinara::tests` passed: 7 tests.
- `cargo test --manifest-path src-tauri\Cargo.toml profile` passed: 38 tests.
- `cargo check --manifest-path src-tauri\Cargo.toml` passed.
- `git diff --check upstream/refactor...HEAD` passed.
- Bunny pre-PR review pass: no blocking findings; remaining risk is manual review of real user backup/export data samples outside these unit-level fixtures.

### Manual verification notes

- Human reviewer should inspect whether the stricter current-profile import rejection is acceptable UX for incomplete exports.
- No real user profile archive was imported through the desktop UI in this pass.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs changes included. This is a storage/import safety lane only.

## UI evidence

N/A - storage/import behavior only; no visible UI changes.
