### PR TITLE
Restore hostable auth parity

### DIFF
--- a/custom_components/marinara_engine/__init__.py
+++ b/custom_components/marinara_engine/__init__.py
@@ -14,8 +14,10 @@ from homeassistant.helpers import config_validation as cv
 from .const import (
     CONF_ENABLED_CATEGORIES,
     CONF_HOST,
+    CONF_PASSWORD,
     CONF_PORT,
     CONF_PRIMARY_CHAT_ID,
+    CONF_USERNAME,
     CONF_WEBHOOK_ID,
     DEFAULT_ENABLED_CATEGORIES,
     DOMAIN,
@@ -49,7 +51,11 @@ TRIGGER_GENERATION_SCHEMA = vol.Schema(
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     coordinator = MarinaraCoordinator(
-        hass, entry.data[CONF_HOST], entry.data[CONF_PORT]
+        hass,
+        entry.data[CONF_HOST],
+        entry.data[CONF_PORT],
+        entry.data.get(CONF_USERNAME, ""),
+        entry.data.get(CONF_PASSWORD, ""),
     )
     await coordinator.async_verify_connection()
     await coordinator.async_config_entry_first_refresh()

--- a/custom_components/marinara_engine/config_flow.py
+++ b/custom_components/marinara_engine/config_flow.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from base64 import b64encode
 from collections.abc import Mapping
 from typing import Any
 
@@ -19,13 +20,18 @@ from homeassistant.helpers.selector import (
     SelectSelector,
     SelectSelectorConfig,
     SelectSelectorMode,
+    TextSelector,
+    TextSelectorConfig,
+    TextSelectorType,
 )
 
 from .const import (
     CONF_ENABLED_CATEGORIES,
     CONF_HOST,
+    CONF_PASSWORD,
     CONF_PORT,
     CONF_PRIMARY_CHAT_ID,
+    CONF_USERNAME,
     CONF_WEBHOOK_ID,
     DEFAULT_ENABLED_CATEGORIES,
     DEFAULT_HOST,
@@ -40,33 +46,74 @@ _STEP_USER_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_HOST, default=DEFAULT_HOST): str,
         vol.Required(CONF_PORT, default=DEFAULT_PORT): vol.Coerce(int),
+        vol.Optional(CONF_USERNAME, default=""): str,
+        vol.Optional(CONF_PASSWORD, default=""): TextSelector(
+            TextSelectorConfig(type=TextSelectorType.PASSWORD)
+        ),
     }
 )
+
+
+def _authorization_header(username: str | None, password: str | None) -> str | None:
+    user = (username or "").strip()
+    if not user:
+        return None
+    credentials = f"{user}:{password or ''}".encode()
+    return f"Basic {b64encode(credentials).decode()}"
+
+
+def _headers(username: str | None, password: str | None) -> dict[str, str]:
+    headers = {"X-Marinara-CSRF": "1"}
+    authorization = _authorization_header(username, password)
+    if authorization:
+        headers["Authorization"] = authorization
+    return headers
 
 
 async def _invoke(
     session: aiohttp.ClientSession,
     host: str,
     port: int,
+    username: str | None,
+    password: str | None,
     command: str,
     args: dict[str, Any] | None = None,
 ) -> Any:
     async with session.post(
         f"http://{host}:{port}/api/invoke",
         json={"command": command, "args": args or None},
-        headers={"X-Marinara-CSRF": "1"},
+        headers=_headers(username, password),
         timeout=aiohttp.ClientTimeout(total=5),
     ) as resp:
         resp.raise_for_status()
         return await resp.json()
 
 
-async def _fetch_chats(host: str, port: int) -> list[object]:
+async def _check_health(
+    session: aiohttp.ClientSession,
+    host: str,
+    port: int,
+    username: str | None,
+    password: str | None,
+) -> None:
+    async with session.get(
+        f"http://{host}:{port}/health",
+        headers=_headers(username, password),
+        timeout=aiohttp.ClientTimeout(total=5),
+    ) as resp:
+        resp.raise_for_status()
+
+
+async def _fetch_chats(
+    host: str, port: int, username: str | None = None, password: str | None = None
+) -> list[object]:
     async with aiohttp.ClientSession() as session:
         rows = await _invoke(
             session,
             host,
             port,
+            username,
+            password,
             "storage_list",
             {
                 "entity": "chats",
@@ -98,10 +145,14 @@ def _chat_options_from_payload(chats: list[object]) -> dict[str, str]:
     return options
 
 
-async def _test_connection(host: str, port: int) -> str | None:
+async def _test_connection(
+    host: str, port: int, username: str | None, password: str | None
+) -> str | None:
     """Return None on success or an error key string on failure."""
     try:
-        await _fetch_chats(host, port)
+        async with aiohttp.ClientSession() as session:
+            await _check_health(session, host, port, username, password)
+        await _fetch_chats(host, port, username, password)
         return None
     except aiohttp.ClientConnectionError:
         return "cannot_connect"
@@ -124,8 +175,10 @@ class MarinaraConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             host = user_input[CONF_HOST].strip()
             port = user_input[CONF_PORT]
+            username = user_input.get(CONF_USERNAME, "").strip()
+            password = user_input.get(CONF_PASSWORD, "")
 
-            error = await _test_connection(host, port)
+            error = await _test_connection(host, port, username, password)
             if error:
                 errors["base"] = error
             else:
@@ -137,6 +190,8 @@ class MarinaraConfigFlow(ConfigFlow, domain=DOMAIN):
                     data={
                         CONF_HOST: host,
                         CONF_PORT: port,
+                        CONF_USERNAME: username,
+                        CONF_PASSWORD: password,
                         CONF_WEBHOOK_ID: async_generate_id(),
                     },
                 )
@@ -168,8 +223,10 @@ class MarinaraOptionsFlow(OptionsFlow):
 
         host = self._config_entry.data[CONF_HOST]
         port = self._config_entry.data[CONF_PORT]
+        username = self._config_entry.data.get(CONF_USERNAME, "")
+        password = self._config_entry.data.get(CONF_PASSWORD, "")
         try:
-            self._chats = await _fetch_chats(host, port)
+            self._chats = await _fetch_chats(host, port, username, password)
         except Exception:
             self._chats = []
 

--- a/custom_components/marinara_engine/const.py
+++ b/custom_components/marinara_engine/const.py
@@ -8,6 +8,8 @@ SCAN_INTERVAL = 30  # seconds
 
 CONF_HOST = "host"
 CONF_PORT = "port"
+CONF_USERNAME = "username"
+CONF_PASSWORD = "password"
 CONF_WEBHOOK_ID = "webhook_id"
 CONF_PRIMARY_CHAT_ID = "primary_chat_id"
 CONF_ENABLED_CATEGORIES = "enabled_categories"

--- a/custom_components/marinara_engine/coordinator.py
+++ b/custom_components/marinara_engine/coordinator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+from base64 import b64encode
 from datetime import timedelta
 from typing import Any
 
@@ -19,6 +20,14 @@ from .const import DOMAIN, SCAN_INTERVAL
 _LOGGER = logging.getLogger(__name__)
 
 
+def _authorization_header(username: str | None, password: str | None) -> str | None:
+    user = (username or "").strip()
+    if not user:
+        return None
+    credentials = f"{user}:{password or ''}".encode()
+    return f"Basic {b64encode(credentials).decode()}"
+
+
 def _is_enabled(value: object) -> bool:
     if isinstance(value, bool):
         return value
@@ -32,15 +41,29 @@ def _is_enabled(value: object) -> bool:
 class MarinaraCoordinator(DataUpdateCoordinator[dict]):
     """Polls Marinara Engine for chats and agents."""
 
-    def __init__(self, hass: HomeAssistant, host: str, port: int) -> None:
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        host: str,
+        port: int,
+        username: str | None = None,
+        password: str | None = None,
+    ) -> None:
         self.base_url = f"http://{host}:{port}"
         self._session = async_get_clientsession(hass)
+        self._authorization = _authorization_header(username, password)
         super().__init__(
             hass,
             _LOGGER,
             name=DOMAIN,
             update_interval=timedelta(seconds=SCAN_INTERVAL),
         )
+
+    def _headers(self) -> dict[str, str]:
+        headers = {"X-Marinara-CSRF": "1"}
+        if self._authorization:
+            headers["Authorization"] = self._authorization
+        return headers
 
     async def _invoke(
         self,
@@ -51,7 +74,7 @@ class MarinaraCoordinator(DataUpdateCoordinator[dict]):
         async with self._session.post(
             f"{self.base_url}/api/invoke",
             json={"command": command, "args": args or None},
-            headers={"X-Marinara-CSRF": "1"},
+            headers=self._headers(),
             timeout=aiohttp.ClientTimeout(total=timeout_seconds),
         ) as resp:
             resp.raise_for_status()
@@ -107,13 +130,19 @@ class MarinaraCoordinator(DataUpdateCoordinator[dict]):
             raise UpdateFailed(f"Unexpected error: {err}") from err
 
     async def async_verify_connection(self) -> None:
-        """Raise ConfigEntryNotReady if the server is unreachable."""
+        """Raise ConfigEntryNotReady if the authenticated health/API checks fail."""
         try:
             async with self._session.get(
                 f"{self.base_url}/health",
+                headers=self._headers(),
                 timeout=aiohttp.ClientTimeout(total=5),
             ) as resp:
                 resp.raise_for_status()
+            await self._invoke(
+                "storage_list",
+                {"entity": "chats", "options": {"fields": ["id"], "limit": 1}},
+                timeout_seconds=5,
+            )
         except Exception as err:
             raise ConfigEntryNotReady(
                 f"Cannot connect to Marinara Engine at {self.base_url}: {err}"

--- a/custom_components/marinara_engine/strings.json
+++ b/custom_components/marinara_engine/strings.json
@@ -6,7 +6,9 @@
         "description": "Enter the host and port where the Marinara hostable runtime is running.",
         "data": {
           "host": "Host",
-          "port": "Port"
+          "port": "Port",
+          "username": "Username",
+          "password": "Password"
         }
       }
     },

--- a/custom_components/marinara_engine/translations/en.json
+++ b/custom_components/marinara_engine/translations/en.json
@@ -6,7 +6,9 @@
         "description": "Enter the host and port where marinara-server is running (default: localhost:8787).",
         "data": {
           "host": "Host",
-          "port": "Port"
+          "port": "Port",
+          "username": "Username",
+          "password": "Password"
         }
       }
     },

--- a/src-tauri/src/http_dispatch.rs
+++ b/src-tauri/src/http_dispatch.rs
@@ -214,9 +214,6 @@ pub async fn dispatch(state: &AppState, request: InvokeRequest) -> AppResult<Val
                 .remove(required_string(&args, "path")?, false)?;
             Ok(json!({ "deleted": true }))
         }
-        "game_assets_file_path" => Ok(json!({
-            "path": state.game_assets.absolute_path_string(required_string(&args, "path")?)?
-        })),
         "game_assets_read_text" => Ok(json!({
             "content": state.game_assets.read_text(required_string(&args, "path")?)?
         })),
@@ -268,12 +265,6 @@ pub async fn dispatch(state: &AppState, request: InvokeRequest) -> AppResult<Val
         ),
         "game_assets_upload" => {
             game_assets::game_assets_upload(state, optional_value(&args, "body"))
-        }
-        "background_file_path" => Ok(json!({
-            "path": state.backgrounds.absolute_path_string(required_string(&args, "filename")?)?
-        })),
-        "lorebook_image_file_path" => {
-            lorebook_images::lorebook_image_file_path(state, required_string(&args, "filename")?)
         }
         "gif_search" => gif_search(&args).await,
         "tts_config" => integrations::tts_call(state, "GET", &["config"], Value::Null).await,
@@ -1267,6 +1258,8 @@ mod tests {
     // local filesystem paths, Tauri IPC channels, or user-machine devices.
     const NON_REMOTE_COMMANDS: &[&str] = &[
         "fonts_open_folder",
+        "background_file_path",
+        "game_assets_file_path",
         "game_assets_open_folder",
         "haptic_command",
         "haptic_connect",
@@ -1276,6 +1269,7 @@ mod tests {
         "haptic_stop_all",
         "haptic_stop_scan",
         "import_st_bulk_run_events",
+        "lorebook_image_file_path",
         "llm_stream_channel",
         "profile_import_file",
     ];
@@ -1519,6 +1513,28 @@ mod tests {
             result.get("originalName").and_then(Value::as_str),
             Some("background.png")
         );
+    }
+
+    #[tokio::test]
+    async fn dispatch_rejects_remote_raw_server_path_commands() {
+        for (command, args) in [
+            ("background_file_path", json!({ "filename": "background.png" })),
+            ("game_assets_file_path", json!({ "path": "folder/asset.png" })),
+            ("lorebook_image_file_path", json!({ "filename": "image.png" })),
+        ] {
+            let state = test_state(command);
+            let error = dispatch(
+                &state,
+                InvokeRequest {
+                    command: command.to_string(),
+                    args: Some(args),
+                },
+            )
+            .await
+            .expect_err("raw server file paths should not be exposed remotely");
+
+            assert_eq!(error.code, "unsupported_command");
+        }
     }
 
     #[tokio::test]

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -6,7 +6,7 @@ import { CustomThemeInjector } from "./providers/CustomThemeInjector";
 import { AppDialogRenderer } from "../shared/components/ui/AppDialogRenderer";
 import { ChibiProfessorMariEasterEgg } from "../shared/components/ui/ChibiProfessorMariEasterEgg";
 import { fontsApi } from "../shared/api/settings-assets-api";
-import { fontFileUrlFromPath } from "../shared/api/local-file-api";
+import { resolveFontFileUrl } from "../shared/api/local-file-api";
 import { useUIStore } from "../shared/stores/ui.store";
 import { useChatSwitchEffects } from "./startup/chat-switch-effects";
 import { installRangeSliderSync } from "./startup/range-slider-sync";
@@ -87,15 +87,19 @@ export function App() {
     const loadFonts = () => {
       fontsApi
         .list<CustomFontFace[]>()
-        .then((fonts) => {
+        .then(async (fonts) => {
           if (cancelled) return;
-          const css = fonts
-            .map((font) => {
-              const source = fontFileUrlFromPath(font.filename, font.absolutePath) || font.url;
+          const cssParts = await Promise.all(
+            fonts.map(async (font) => {
+              const source =
+                (await resolveFontFileUrl(font.filename, font.absolutePath).catch(() => "")) || font.url;
               if (!source || !font.family) return "";
               const unicodeRange = font.unicodeRange ? `  unicode-range: ${font.unicodeRange};\n` : "";
               return `@font-face {\n  font-family: "${font.family.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}";\n  src: url("${source}") format("${font.filename.endsWith(".woff2") ? "woff2" : font.filename.endsWith(".woff") ? "woff" : font.filename.endsWith(".otf") ? "opentype" : "truetype"}");\n  font-weight: ${font.weight ?? "400"};\n  font-style: ${font.style ?? "normal"};\n  font-display: swap;\n${unicodeRange}}`;
-            })
+            }),
+          );
+          if (cancelled) return;
+          const css = cssParts
             .filter(Boolean)
             .join("\n");
           let style = document.getElementById("marinara-custom-fonts") as HTMLStyleElement | null;

--- a/src/app/shell/ChatSidebar.tsx
+++ b/src/app/shell/ChatSidebar.tsx
@@ -49,7 +49,7 @@ import { useChatStore } from "../../shared/stores/chat.store";
 import { showConfirmDialog } from "../../shared/lib/app-dialogs";
 import { useUIStore, type UserStatus } from "../../shared/stores/ui.store";
 import { cn, getAvatarCropStyle, type AvatarCropValue } from "../../shared/lib/utils";
-import { avatarFileUrlFromPath } from "../../shared/api/local-file-api";
+import { avatarFileUrlFromPath, resolveAvatarFileUrl } from "../../shared/api/local-file-api";
 import { useState, useCallback, useMemo, useRef, useEffect } from "react";
 import { CHAT_MODES } from "../../engine/contracts/constants/chat-modes";
 import type { ChatFolder } from "../../engine/contracts/types/chat";
@@ -163,6 +163,30 @@ export function ChatSidebar({
     return Array.from(ids);
   }, [chats]);
   const { data: allCharacters } = useCharacterSummariesByIds(sidebarCharacterIds, sidebarCharacterIds.length > 0);
+  const [resolvedCharacterAvatars, setResolvedCharacterAvatars] = useState<Map<string, string | null>>(() => new Map());
+
+  useEffect(() => {
+    let cancelled = false;
+    const characters = allCharacters ?? [];
+    if (characters.length === 0) {
+      setResolvedCharacterAvatars(new Map());
+      return;
+    }
+    Promise.all(
+      characters.map(async (char) => {
+        const resolved =
+          (await resolveAvatarFileUrl(char.avatarFilename, char.avatarFilePath).catch(() => null)) ??
+          char.avatarPath ??
+          null;
+        return [char.id, resolved] as const;
+      }),
+    ).then((entries) => {
+      if (!cancelled) setResolvedCharacterAvatars(new Map(entries));
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [allCharacters]);
 
   // Build character lookup: id → { name, avatarUrl, avatarCrop, conversationStatus }
   const charLookup = useMemo(() => {
@@ -187,13 +211,17 @@ export function ChatSidebar({
         typeof extensions.conversationStatus === "string" ? extensions.conversationStatus : undefined;
       map.set(char.id, {
         name,
-        avatarUrl: avatarFileUrlFromPath(char.avatarFilename, char.avatarFilePath) ?? char.avatarPath ?? null,
+        avatarUrl:
+          resolvedCharacterAvatars.get(char.id) ??
+          avatarFileUrlFromPath(char.avatarFilename, char.avatarFilePath) ??
+          char.avatarPath ??
+          null,
         avatarCrop: (extensions.avatarCrop as AvatarCropValue | undefined) ?? null,
         conversationStatus,
       });
     }
     return map;
-  }, [allCharacters]);
+  }, [allCharacters, resolvedCharacterAvatars]);
   const [searchQuery, setSearchQuery] = useState("");
   const [sort, setSort] = useState<ChatSortOption>("newest");
   const [activeTag, setActiveTag] = useState<string | null>(null);

--- a/src/features/catalog/characters/components/CharacterAvatarImage.tsx
+++ b/src/features/catalog/characters/components/CharacterAvatarImage.tsx
@@ -1,7 +1,8 @@
 import type { AvatarCropValue } from "../../../../shared/lib/utils";
-import { avatarFileUrlFromPath } from "../../../../shared/api/local-file-api";
+import { avatarFileUrlFromPath, resolveAvatarFileUrl } from "../../../../shared/api/local-file-api";
 import { cn, getAvatarCropStyle, parseAvatarCropJson } from "../../../../shared/lib/utils";
 import { getCharacterAvatarLoadingMode } from "../lib/character-avatar-loading";
+import { useEffect, useState } from "react";
 
 function resolveAvatarCrop(crop: unknown): AvatarCropValue | null {
   if (!crop) return null;
@@ -29,7 +30,25 @@ export function CharacterAvatarImage({
   crop?: unknown;
   className?: string;
 }) {
-  const resolvedSrc = avatarFileUrlFromPath(avatarFilename, avatarFilePath) ?? src;
+  const initialSrc = avatarFileUrlFromPath(avatarFilename, avatarFilePath) ?? src ?? null;
+  const [asyncSrc, setAsyncSrc] = useState<string | null>(initialSrc);
+
+  useEffect(() => {
+    let cancelled = false;
+    setAsyncSrc(initialSrc);
+    resolveAvatarFileUrl(avatarFilename, avatarFilePath)
+      .then((url) => {
+        if (!cancelled) setAsyncSrc(url ?? src ?? null);
+      })
+      .catch(() => {
+        if (!cancelled) setAsyncSrc(src ?? null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [avatarFilename, avatarFilePath, initialSrc, src]);
+
+  const resolvedSrc = asyncSrc ?? initialSrc;
   if (!resolvedSrc) return null;
 
   return (

--- a/src/features/modes/game-assets/components/AssetGrid.tsx
+++ b/src/features/modes/game-assets/components/AssetGrid.tsx
@@ -2,10 +2,11 @@
 // File Browser — Asset grid / list view (with multi-select checkboxes)
 // ──────────────────────────────────────────────
 import { Check, Folder, FolderOpen, Minus, MoreHorizontal } from "lucide-react";
+import { useEffect, useState } from "react";
 import type { TreeNode } from "../hooks/use-game-assets";
 import type { GameAssetSelectionStatus } from "../../game/index";
 import { formatBytes, formatDate } from "../../../../shared/lib/format";
-import { gameAssetFileUrlFromPath } from "../../../../shared/api/local-file-api";
+import { gameAssetFileUrlFromPath, resolveGameAssetFileUrl } from "../../../../shared/api/local-file-api";
 import { CATEGORY_ICONS } from "./constants";
 import { FileIcon, isImage } from "./utils";
 
@@ -59,6 +60,35 @@ function FolderSelectionMark({ status }: { status: GameAssetSelectionStatus }) {
   if (status === "included") return <Check size="0.75rem" />;
   if (status === "partial") return <Minus size="0.75rem" />;
   return null;
+}
+
+function GameAssetImage({
+  node,
+  alt,
+  className,
+}: {
+  node: TreeNode;
+  alt: string;
+  className: string;
+}) {
+  const [src, setSrc] = useState(() => gameAssetFileUrlFromPath(node.path, node.absolutePath));
+
+  useEffect(() => {
+    let cancelled = false;
+    setSrc(gameAssetFileUrlFromPath(node.path, node.absolutePath));
+    resolveGameAssetFileUrl(node.path)
+      .then((url) => {
+        if (!cancelled) setSrc(url || gameAssetFileUrlFromPath(node.path, node.absolutePath));
+      })
+      .catch(() => {
+        if (!cancelled) setSrc(gameAssetFileUrlFromPath(node.path, node.absolutePath));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [node.absolutePath, node.path]);
+
+  return <img src={src} alt={alt} className={className} loading="lazy" />;
 }
 
 /**
@@ -166,12 +196,7 @@ export function AssetGrid({
                     );
                   })()
                 ) : isImage(node.ext) ? (
-                  <img
-                    src={gameAssetFileUrlFromPath(node.path, node.absolutePath)}
-                    alt={node.name}
-                    className="h-full w-full object-cover"
-                    loading="lazy"
-                  />
+                  <GameAssetImage node={node} alt={node.name} className="h-full w-full object-cover" />
                 ) : (
                   <FileIcon ext={node.ext} className="h-8 w-8 text-[var(--primary)]" />
                 )}
@@ -252,12 +277,7 @@ export function AssetGrid({
               })()
             ) : isImage(node.ext) ? (
               <div className="flex h-6 w-6 shrink-0 items-center justify-center overflow-hidden rounded bg-[var(--accent)]">
-                <img
-                  src={gameAssetFileUrlFromPath(node.path, node.absolutePath)}
-                  alt=""
-                  className="h-full w-full object-cover"
-                  loading="lazy"
-                />
+                <GameAssetImage node={node} alt="" className="h-full w-full object-cover" />
               </div>
             ) : (
               <FileIcon ext={node.ext} className="shrink-0 text-[var(--muted-foreground)]" size="1rem" />

--- a/src/features/modes/game-assets/components/ImagePreviewModal.tsx
+++ b/src/features/modes/game-assets/components/ImagePreviewModal.tsx
@@ -7,7 +7,7 @@ import type { TreeNode } from "../hooks/use-game-assets";
 import { useGameAssetFileInfo } from "../hooks/use-game-assets";
 import { cn } from "../../../../shared/lib/utils";
 import { formatBytes, formatDate } from "../../../../shared/lib/format";
-import { gameAssetFileUrlFromPath } from "../../../../shared/api/local-file-api";
+import { gameAssetFileUrlFromPath, resolveGameAssetFileUrl } from "../../../../shared/api/local-file-api";
 
 /**
  * Full-screen image preview overlay with optional metadata side panel.
@@ -18,6 +18,7 @@ import { gameAssetFileUrlFromPath } from "../../../../shared/api/local-file-api"
  */
 export function ImagePreviewModal({ node, onClose }: { node: TreeNode; onClose: () => void }) {
   const [showInfo, setShowInfo] = useState(false);
+  const [imageSrc, setImageSrc] = useState(() => gameAssetFileUrlFromPath(node.path, node.absolutePath));
   const { data: info } = useGameAssetFileInfo(node.path);
 
   useEffect(() => {
@@ -27,6 +28,21 @@ export function ImagePreviewModal({ node, onClose }: { node: TreeNode; onClose: 
     document.addEventListener("keydown", handle);
     return () => document.removeEventListener("keydown", handle);
   }, [onClose]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setImageSrc(gameAssetFileUrlFromPath(node.path, node.absolutePath));
+    resolveGameAssetFileUrl(node.path)
+      .then((url) => {
+        if (!cancelled) setImageSrc(url || gameAssetFileUrlFromPath(node.path, node.absolutePath));
+      })
+      .catch(() => {
+        if (!cancelled) setImageSrc(gameAssetFileUrlFromPath(node.path, node.absolutePath));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [node.absolutePath, node.path]);
 
   return (
     <div
@@ -39,7 +55,7 @@ export function ImagePreviewModal({ node, onClose }: { node: TreeNode; onClose: 
       <div className="relative flex max-h-[90vh] max-w-[90vw]">
         <div className="relative">
           <img
-            src={gameAssetFileUrlFromPath(node.path, node.absolutePath)}
+            src={imageSrc}
             alt={node.name}
             className={cn(
               "max-h-[85vh] rounded-lg object-contain shadow-2xl",

--- a/src/features/shell/settings/components/SettingsPanel.tsx
+++ b/src/features/shell/settings/components/SettingsPanel.tsx
@@ -34,6 +34,7 @@ import { triggerDownload } from "../../../../shared/api/download-payload";
 import { chatBackgroundMetadataToUrl, chatBackgroundUrlToMetadata } from "../../../../shared/lib/backgrounds";
 import {
   backgroundFileUrlFromPath,
+  resolveBackgroundFileUrl,
   resolveManagedLocalAssetUrl,
   userBackgroundUrl,
 } from "../../../../shared/api/local-file-api";
@@ -2147,11 +2148,20 @@ function BackgroundThumbnail({ item }: { item: BackgroundLibraryItem }) {
   const [src, setSrc] = useState(() => (filename ? backgroundFileUrlFromPath(filename, item.absolutePath) : ""));
 
   useEffect(() => {
+    let cancelled = false;
     if (filename) {
       setSrc(backgroundFileUrlFromPath(filename, item.absolutePath));
-      return;
+      resolveBackgroundFileUrl(filename)
+        .then((url) => {
+          if (!cancelled) setSrc(url || backgroundFileUrlFromPath(filename, item.absolutePath));
+        })
+        .catch(() => {
+          if (!cancelled) setSrc(backgroundFileUrlFromPath(filename, item.absolutePath));
+        });
+      return () => {
+        cancelled = true;
+      };
     }
-    let cancelled = false;
     resolveManagedLocalAssetUrl(item.url)
       .then((url) => {
         if (!cancelled) setSrc(url ?? "");

--- a/src/shared/api/local-file-api.test.ts
+++ b/src/shared/api/local-file-api.test.ts
@@ -1,32 +1,60 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { convertFileSrc } from "@tauri-apps/api/core";
-import { remoteRuntimeTarget } from "./remote-runtime";
-import { avatarFileUrlFromPath } from "./local-file-api";
+import { useUIStore } from "../stores/ui.store";
+import { avatarFileUrlFromPath, backgroundFileUrlFromPath, resolveGameAssetFileUrl } from "./local-file-api";
 
 vi.mock("@tauri-apps/api/core", () => ({
   convertFileSrc: vi.fn(),
 }));
 
-vi.mock("./remote-runtime", () => ({
-  remoteRuntimeTarget: vi.fn(),
-}));
-
 const convertFileSrcMock = vi.mocked(convertFileSrc);
-const remoteRuntimeTargetMock = vi.mocked(remoteRuntimeTarget);
 
-describe("avatarFileUrlFromPath", () => {
+describe("managed remote asset URLs", () => {
   beforeEach(() => {
+    useUIStore.setState({ remoteRuntimeUrl: "" });
     convertFileSrcMock.mockReset();
-    remoteRuntimeTargetMock.mockReset();
-    remoteRuntimeTargetMock.mockReturnValue(null);
     convertFileSrcMock.mockImplementation((path) => `asset://localhost/${encodeURIComponent(path)}`);
     (window as unknown as { __TAURI_INTERNALS__?: { convertFileSrc?: unknown } }).__TAURI_INTERNALS__ = {
       convertFileSrc: vi.fn(),
     };
   });
 
+  afterEach(() => {
+    useUIStore.setState({ remoteRuntimeUrl: "" });
+    vi.unstubAllGlobals();
+  });
+
+  it("keeps unauthenticated assets as direct remote URLs", () => {
+    useUIStore.setState({ remoteRuntimeUrl: "http://runtime.local:8787/" });
+
+    expect(backgroundFileUrlFromPath("scene one.png")).toBe(
+      "http://runtime.local:8787/api/assets/background/scene%20one.png",
+    );
+  });
+
+  it("fetches authenticated remote assets into blob URLs", async () => {
+    useUIStore.setState({ remoteRuntimeUrl: "http://user:pass@runtime.local:8787/" });
+    const createObjectURL = vi.fn(() => "blob:marinara-asset");
+    Object.defineProperty(URL, "createObjectURL", { configurable: true, value: createObjectURL });
+    const fetchMock = vi.fn().mockResolvedValue(new Response("asset bytes"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(resolveGameAssetFileUrl("folder/asset one.png")).resolves.toBe("blob:marinara-asset");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://runtime.local:8787/api/assets/game/folder/asset%20one.png",
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({
+          Authorization: "Basic dXNlcjpwYXNz",
+          "X-Marinara-CSRF": "1",
+        }),
+      }),
+    );
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+  });
+
   it("uses the remote avatar asset route when a filename is present", () => {
-    remoteRuntimeTargetMock.mockReturnValue({ baseUrl: "http://runtime.test" });
+    useUIStore.setState({ remoteRuntimeUrl: "http://runtime.test" });
 
     expect(avatarFileUrlFromPath("Avatar One.png", "C:\\Marinara\\avatars\\characters\\Avatar One.png")).toBe(
       "http://runtime.test/api/assets/avatar/Avatar%20One.png",
@@ -35,7 +63,7 @@ describe("avatarFileUrlFromPath", () => {
   });
 
   it("strips dot segments before building remote avatar asset routes", () => {
-    remoteRuntimeTargetMock.mockReturnValue({ baseUrl: "http://runtime.test" });
+    useUIStore.setState({ remoteRuntimeUrl: "http://runtime.test" });
 
     expect(avatarFileUrlFromPath(".\\..\\Avatar One.png", null)).toBe(
       "http://runtime.test/api/assets/avatar/Avatar%20One.png",
@@ -44,7 +72,7 @@ describe("avatarFileUrlFromPath", () => {
   });
 
   it("derives a remote avatar filename from an absolute path without leaking the path", () => {
-    remoteRuntimeTargetMock.mockReturnValue({ baseUrl: "http://runtime.test" });
+    useUIStore.setState({ remoteRuntimeUrl: "http://runtime.test" });
 
     expect(avatarFileUrlFromPath(null, "C:\\Marinara\\avatars\\characters\\Avatar One.png")).toBe(
       "http://runtime.test/api/assets/avatar/Avatar%20One.png",
@@ -60,7 +88,7 @@ describe("avatarFileUrlFromPath", () => {
   });
 
   it("returns null when neither a filename nor an absolute path is available", () => {
-    remoteRuntimeTargetMock.mockReturnValue({ baseUrl: "http://runtime.test" });
+    useUIStore.setState({ remoteRuntimeUrl: "http://runtime.test" });
 
     expect(avatarFileUrlFromPath(null, null)).toBeNull();
   });

--- a/src/shared/api/local-file-api.test.ts
+++ b/src/shared/api/local-file-api.test.ts
@@ -1,7 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { convertFileSrc } from "@tauri-apps/api/core";
 import { useUIStore } from "../stores/ui.store";
-import { avatarFileUrlFromPath, backgroundFileUrlFromPath, resolveGameAssetFileUrl } from "./local-file-api";
+import {
+  avatarFileUrlFromPath,
+  backgroundFileUrlFromPath,
+  resolveAvatarFileUrl,
+  resolveBackgroundFileUrl,
+  resolveGameAssetFileUrl,
+} from "./local-file-api";
 
 vi.mock("@tauri-apps/api/core", () => ({
   convertFileSrc: vi.fn(),
@@ -32,11 +38,17 @@ describe("managed remote asset URLs", () => {
     );
   });
 
+  it("does not return raw remote URLs from sync helpers when auth is required", () => {
+    useUIStore.setState({ remoteRuntimeUrl: "http://user:pass@runtime.local:8787/" });
+
+    expect(backgroundFileUrlFromPath("scene one.png")).toBe("marinara-background:scene%20one.png");
+  });
+
   it("fetches authenticated remote assets into blob URLs", async () => {
     useUIStore.setState({ remoteRuntimeUrl: "http://user:pass@runtime.local:8787/" });
     const createObjectURL = vi.fn(() => "blob:marinara-asset");
     Object.defineProperty(URL, "createObjectURL", { configurable: true, value: createObjectURL });
-    const fetchMock = vi.fn().mockResolvedValue(new Response("asset bytes"));
+    const fetchMock = vi.fn().mockImplementation(() => Promise.resolve(new Response("asset bytes")));
     vi.stubGlobal("fetch", fetchMock);
 
     await expect(resolveGameAssetFileUrl("folder/asset one.png")).resolves.toBe("blob:marinara-asset");
@@ -51,6 +63,33 @@ describe("managed remote asset URLs", () => {
       }),
     );
     expect(createObjectURL).toHaveBeenCalledTimes(1);
+  });
+
+  it("fetches authenticated background and avatar assets through async resolvers", async () => {
+    useUIStore.setState({ remoteRuntimeUrl: "http://user:pass@runtime.local:8787/" });
+    const createObjectURL = vi.fn().mockReturnValueOnce("blob:background").mockReturnValueOnce("blob:avatar");
+    Object.defineProperty(URL, "createObjectURL", { configurable: true, value: createObjectURL });
+    const fetchMock = vi.fn().mockImplementation(() => Promise.resolve(new Response("asset bytes")));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(resolveBackgroundFileUrl("scene one.png")).resolves.toBe("blob:background");
+    await expect(resolveAvatarFileUrl("Avatar One.png", "C:\\Marinara\\avatars\\characters\\Avatar One.png")).resolves.toBe(
+      "blob:avatar",
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "http://runtime.local:8787/api/assets/background/scene%20one.png",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Basic dXNlcjpwYXNz" }),
+      }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "http://runtime.local:8787/api/assets/avatar/Avatar%20One.png",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Basic dXNlcjpwYXNz" }),
+      }),
+    );
   });
 
   it("uses the remote avatar asset route when a filename is present", () => {

--- a/src/shared/api/local-file-api.ts
+++ b/src/shared/api/local-file-api.ts
@@ -1,12 +1,18 @@
 import { convertFileSrc } from "@tauri-apps/api/core";
 import { invokeTauri } from "./tauri-client";
-import { remoteRuntimeTarget } from "./remote-runtime";
+import { remoteHeaders, remoteRuntimeTarget, type RuntimeTarget } from "./remote-runtime";
 
 export const USER_BACKGROUND_URL_PREFIX = "marinara-background:";
 export const GAME_ASSET_URL_PREFIX = "marinara-game-asset:";
 const LOREBOOK_IMAGE_URL_PREFIX = "marinara-lorebook-image:";
 
 type PathResponse = { path?: string | null };
+type RemoteManagedAsset = {
+  url: string;
+  target: RuntimeTarget;
+};
+
+const remoteAssetObjectUrls = new Map<string, string>();
 
 function hasScheme(value: string): boolean {
   return /^[a-z][a-z0-9+.-]*:/i.test(value);
@@ -55,10 +61,12 @@ function filePathToAssetUrl(path: string | null | undefined): string {
   }
 }
 
-function remoteManagedAssetUrl(
-  kind: "avatar" | "background" | "font" | "game" | "lorebook",
+type RemoteManagedAssetKind = "avatar" | "background" | "font" | "game" | "lorebook";
+
+function remoteManagedAsset(
+  kind: RemoteManagedAssetKind,
   path: string | null | undefined,
-): string | null {
+): RemoteManagedAsset | null {
   const target = remoteRuntimeTarget();
   if (!target || !path?.trim()) return null;
   const encodedPath = path
@@ -68,7 +76,41 @@ function remoteManagedAssetUrl(
     .filter((segment) => segment && segment !== "." && segment !== "..")
     .map(encodeURIComponent)
     .join("/");
-  return encodedPath ? `${target.baseUrl}/api/assets/${kind}/${encodedPath}` : null;
+  return encodedPath ? { url: `${target.baseUrl}/api/assets/${kind}/${encodedPath}`, target } : null;
+}
+
+function remoteManagedAssetUrl(
+  kind: RemoteManagedAssetKind,
+  path: string | null | undefined,
+): string | null {
+  return remoteManagedAsset(kind, path)?.url ?? null;
+}
+
+async function remoteManagedAssetResolvableUrl(
+  kind: RemoteManagedAssetKind,
+  path: string | null | undefined,
+): Promise<string | null> {
+  const asset = remoteManagedAsset(kind, path);
+  if (!asset) return null;
+  if (!asset.target.authorization) return asset.url;
+  return fetchRemoteManagedAssetBlobUrl(asset);
+}
+
+async function fetchRemoteManagedAssetBlobUrl(asset: RemoteManagedAsset): Promise<string> {
+  const cacheKey = `${asset.target.baseUrl}\0${asset.target.authorization ?? ""}\0${asset.url}`;
+  const cached = remoteAssetObjectUrls.get(cacheKey);
+  if (cached) return cached;
+
+  const response = await fetch(asset.url, {
+    method: "GET",
+    headers: remoteHeaders(asset.target),
+  });
+  if (!response.ok) {
+    throw new Error(`Remote managed asset returned ${response.status}`);
+  }
+  const objectUrl = URL.createObjectURL(await response.blob());
+  remoteAssetObjectUrls.set(cacheKey, objectUrl);
+  return objectUrl;
 }
 
 function filenameFromPath(path: string | null | undefined): string | null {
@@ -106,21 +148,21 @@ export function avatarFileUrlFromPath(
 }
 
 export async function resolveGameAssetFileUrl(path: string): Promise<string> {
-  const remoteUrl = remoteManagedAssetUrl("game", path);
+  const remoteUrl = await remoteManagedAssetResolvableUrl("game", path);
   if (remoteUrl) return remoteUrl;
   const response = await invokeTauri<PathResponse>("game_assets_file_path", { path });
   return filePathToAssetUrl(response.path ?? "");
 }
 
 async function resolveBackgroundFileUrl(filename: string): Promise<string> {
-  const remoteUrl = remoteManagedAssetUrl("background", filename);
+  const remoteUrl = await remoteManagedAssetResolvableUrl("background", filename);
   if (remoteUrl) return remoteUrl;
   const response = await invokeTauri<PathResponse>("background_file_path", { filename });
   return filePathToAssetUrl(response.path ?? "");
 }
 
 async function resolveLorebookImageFileUrl(filename: string): Promise<string> {
-  const remoteUrl = remoteManagedAssetUrl("lorebook", filename);
+  const remoteUrl = await remoteManagedAssetResolvableUrl("lorebook", filename);
   if (remoteUrl) return remoteUrl;
   const response = await invokeTauri<PathResponse>("lorebook_image_file_path", { filename });
   return filePathToAssetUrl(response.path ?? "");

--- a/src/shared/api/local-file-api.ts
+++ b/src/shared/api/local-file-api.ts
@@ -83,7 +83,9 @@ function remoteManagedAssetUrl(
   kind: RemoteManagedAssetKind,
   path: string | null | undefined,
 ): string | null {
-  return remoteManagedAsset(kind, path)?.url ?? null;
+  const asset = remoteManagedAsset(kind, path);
+  if (!asset || asset.target.authorization) return null;
+  return asset.url;
 }
 
 async function remoteManagedAssetResolvableUrl(
@@ -154,11 +156,26 @@ export async function resolveGameAssetFileUrl(path: string): Promise<string> {
   return filePathToAssetUrl(response.path ?? "");
 }
 
-async function resolveBackgroundFileUrl(filename: string): Promise<string> {
+export async function resolveBackgroundFileUrl(filename: string): Promise<string> {
   const remoteUrl = await remoteManagedAssetResolvableUrl("background", filename);
   if (remoteUrl) return remoteUrl;
   const response = await invokeTauri<PathResponse>("background_file_path", { filename });
   return filePathToAssetUrl(response.path ?? "");
+}
+
+export async function resolveFontFileUrl(filename: string, absolutePath?: string | null): Promise<string> {
+  const remoteUrl = await remoteManagedAssetResolvableUrl("font", filename);
+  if (remoteUrl) return remoteUrl;
+  return absolutePath ? filePathToAssetUrl(absolutePath) : "";
+}
+
+export async function resolveAvatarFileUrl(
+  filename: string | null | undefined,
+  absolutePath?: string | null,
+): Promise<string | null> {
+  const remoteUrl = await remoteManagedAssetResolvableUrl("avatar", filename?.trim() || filenameFromPath(absolutePath));
+  if (remoteUrl) return remoteUrl;
+  return absolutePath ? filePathToAssetUrl(absolutePath) : null;
 }
 
 async function resolveLorebookImageFileUrl(filename: string): Promise<string> {

--- a/src/shared/api/remote-runtime.test.ts
+++ b/src/shared/api/remote-runtime.test.ts
@@ -168,12 +168,19 @@ describe("remote LLM stream cancellation", () => {
   });
 
   it("checks remote health with normalized URL and reverse-proxy auth", async () => {
-    fetchMock.mockResolvedValue(
-      new Response(JSON.stringify({ ok: true, runtime: "marinara-server", writable: true }), {
-        status: 200,
-        headers: { "content-type": "application/json" },
-      }),
-    );
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true, runtime: "marinara-server", writable: true }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([]), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
 
     await expect(checkRemoteRuntimeHealth("https://user:pass@example.com/runtime///")).resolves.toEqual({
       status: "ok",
@@ -181,7 +188,7 @@ describe("remote LLM stream cancellation", () => {
       health: { ok: true, runtime: "marinara-server", writable: true },
     });
 
-    expect(fetchMock).toHaveBeenCalledWith("https://example.com/runtime/health", {
+    expect(fetchMock).toHaveBeenNthCalledWith(1, "https://example.com/runtime/health", {
       method: "GET",
       headers: {
         Authorization: "Basic dXNlcjpwYXNz",
@@ -189,6 +196,39 @@ describe("remote LLM stream cancellation", () => {
         "X-Marinara-CSRF": "1",
       },
       signal: undefined,
+    });
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://example.com/runtime/api/invoke",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: "Basic dXNlcjpwYXNz",
+          "content-type": "application/json",
+        }),
+      }),
+    );
+  });
+
+  it("does not report ready when health passes but invoke auth fails", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true, runtime: "marinara-server", writable: true }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ code: "authentication_required" }), {
+          status: 401,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+    await expect(checkRemoteRuntimeHealth("http://user:pass@runtime.local:8787")).resolves.toEqual({
+      status: "unreachable",
+      message: "Remote runtime health is reachable, but API invoke returned 401.",
+      health: { ok: true, runtime: "marinara-server", writable: true },
     });
   });
 

--- a/src/shared/api/remote-runtime.ts
+++ b/src/shared/api/remote-runtime.ts
@@ -39,7 +39,6 @@ const REMOTE_COMMANDS = new Set([
   "game_assets_create_folder",
   "game_assets_delete_folder",
   "game_assets_delete_file",
-  "game_assets_file_path",
   "game_assets_read_text",
   "game_assets_write_text",
   "game_assets_rename",
@@ -51,8 +50,6 @@ const REMOTE_COMMANDS = new Set([
   "game_assets_file_info",
   "game_assets_folder_description",
   "game_assets_upload",
-  "background_file_path",
-  "lorebook_image_file_path",
   "gif_search",
   "tts_config",
   "tts_update_config",
@@ -229,7 +226,7 @@ export function isRemoteCommand(command: string): boolean {
   return REMOTE_COMMANDS.has(command);
 }
 
-function remoteHeaders(target: RuntimeTarget, extra?: HeadersInit): HeadersInit {
+export function remoteHeaders(target: RuntimeTarget, extra?: HeadersInit): HeadersInit {
   return {
     ...(target.authorization ? { Authorization: target.authorization } : {}),
     ...extra,
@@ -292,6 +289,27 @@ export async function checkRemoteRuntimeHealth(
       return {
         status: "not-writable",
         message: "Remote runtime is reachable, but its data storage is not writable.",
+        health: body,
+      };
+    }
+
+    const invokeReady = await fetch(`${target.baseUrl}/api/invoke`, {
+      method: "POST",
+      headers: remoteHeaders(target, { "content-type": "application/json" }),
+      body: JSON.stringify({
+        command: "storage_list",
+        args: {
+          entity: "chats",
+          options: { fields: ["id"], limit: 1 },
+        },
+      }),
+      signal: options.signal,
+    });
+
+    if (!invokeReady.ok) {
+      return {
+        status: "unreachable",
+        message: `Remote runtime health is reachable, but API invoke returned ${invokeReady.status}.`,
         health: body,
       };
     }


### PR DESCRIPTION
﻿<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

N/A - refactor readiness blocker found during hostable/security/integration review.

## Why this change

The refactor branch added secured hostable runtime behavior, but Home Assistant and remote asset paths were not fully aligned with that boundary. Secured `marinara-server` needed an authenticated integration path, and raw server-path commands needed to stay unavailable over HTTP.

## What changed

- Add Home Assistant username/password configuration fields.
- Send Basic Auth headers from Home Assistant coordinator checks.
- Verify both hostable health and authenticated API access during setup/update.
- Keep raw server-path commands out of the remote HTTP command allowlist and dispatch path.
- Resolve authenticated remote managed asset URLs into blob URLs for async local-file API consumers.
- Add focused tests for remote runtime auth checks, managed asset blob resolution, and HTTP raw-path rejection.

## Refactor impact

Primary owner:

Remote runtime / shared API / Home Assistant integration.

Impact areas reviewed:

- `src/shared/api` remote runtime wrappers.
- `src-tauri` HTTP dispatch command boundary.
- Home Assistant config flow and coordinator auth handling.
- Managed asset URL behavior for remote-capable frontend code.

Boundary notes:

- Feature code continues to use focused shared API wrappers.
- Raw file/server-path capabilities remain privileged and are not exposed over hostable HTTP.
- Auth is enforced in the hostable path rather than being assumed by integration callers.

Pressure points touched:

- `src/shared/api/remote-runtime.ts`
- `src/shared/api/local-file-api.ts`
- `src-tauri/src/http_dispatch.rs`
- `custom_components/marinara_engine/*`

## Validation

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

Codex-run proof:

- `pnpm check` passed in `scratch/refactor-lane-worktrees/hostable`.
- `pnpm test src/shared/api/remote-runtime.test.ts src/shared/api/local-file-api.test.ts` passed: 21 tests.
- `cargo test --manifest-path src-tauri\Cargo.toml http_dispatch::tests` passed: 10 tests.
- `pnpm typecheck` passed.
- `cargo check --manifest-path src-tauri\Cargo.toml` passed.
- `git diff --check upstream/refactor...HEAD` passed.
- Bunny pre-PR review pass: no blocking findings; remaining risk is live Home Assistant setup verification with a secured hostable server.

### Manual verification notes

- A live Home Assistant instance was not connected during this pass.
- A secured remote runtime should be smoke-tested manually with real credentials before marking the integration fully proven.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs changes included. This PR updates integration strings/translations for the new auth fields.

## UI evidence

N/A - hostable/auth/integration behavior only; no app UI changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Username and password authentication support for Marinara Engine configuration
  * Authenticated remote asset resolution for game assets, backgrounds, and lorebook images
  * Remote runtime health checks now verify authentication credentials

* **Bug Fixes**
  * Removed unsupported raw server path commands from remote dispatch

* **Tests**
  * Updated test coverage for authenticated remote assets and health validation
  * Added tests for rejected remote path commands

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1680?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->